### PR TITLE
fix: recursive vault search, linked note replaces Notes section, clea…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -445,42 +445,86 @@ const NotesSubtasksPanel = ({
       className={`mt-2 p-3 rounded-lg ${darkMode ? 'bg-black/50' : 'bg-black/25'} text-white`}
       onClick={(e) => e.stopPropagation()}
     >
-      {/* Notes section */}
-      <div className="mb-3">
-        <div className="text-xs font-semibold opacity-90 mb-1">Notes</div>
-        {isEditingNotes ? (
-          <textarea
-            value={localNotes}
-            onChange={handleNotesChange}
-            onKeyDown={handleNotesKeyDown}
-            onBlur={handleNotesBlur}
-            placeholder="Add notes... (**bold**, *italic*, __underline__, URLs) - Shift+Enter for preview"
-            className={`w-full bg-white/10 text-white text-sm px-2 py-1.5 rounded border border-white/20 outline-none focus:bg-white/20 focus:border-white/40 placeholder:text-white/40 ${compact ? 'resize-none' : 'resize-y'}`}
-            rows={compact ? 3 : 8}
-            autoFocus={!noAutoFocus}
-          />
-        ) : (
-          <div
-            onClick={() => setIsEditingNotes(true)}
-            className="text-sm whitespace-pre-wrap cursor-text min-h-[4.5rem] p-2 rounded bg-white/10 hover:bg-white/15"
-          >
-            {urlOnlyNote ? (
-              <a
-                href={noteUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-blue-300 hover:text-blue-200 font-medium break-all"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <ExternalLink size={14} className="flex-shrink-0" />
-                {noteUrl}
-              </a>
-            ) : (
-              renderFormattedText(localNotes)
-            )}
-          </div>
-        )}
-      </div>
+      {/* Notes section — replaced by linked vault note for Obsidian wikilink tasks */}
+      {wikilinks && wikilinks.length > 0 && onLoadWikiNote ? (
+        <div className="mb-3 space-y-3">
+          {wikilinks.map((noteName) => {
+            const state = linkedNoteStates[noteName] || { text: '', loading: true, error: null };
+            return (
+              <div key={noteName}>
+                <div className="text-xs font-semibold opacity-90 mb-1 flex items-center gap-1.5">
+                  <BookOpen size={11} />
+                  <span>{noteName}</span>
+                </div>
+                {state.loading ? (
+                  <div className="flex items-center gap-1.5 py-2 opacity-60 text-xs">
+                    <Loader size={12} className="animate-spin" />
+                    Loading…
+                  </div>
+                ) : state.error ? (
+                  <div className="text-xs opacity-60 italic">Could not load note: {state.error}</div>
+                ) : (
+                  <textarea
+                    value={state.text}
+                    onChange={(e) => {
+                      const newText = e.target.value;
+                      setLinkedNoteStates(prev => ({ ...prev, [noteName]: { ...prev[noteName], text: newText } }));
+                      linkedNoteTextsRef.current[noteName] = newText;
+                    }}
+                    onBlur={() => {
+                      const text = linkedNoteTextsRef.current[noteName] ?? '';
+                      if (text !== (linkedNoteOriginalRef.current[noteName] ?? '') && onSaveWikiNote) {
+                        onSaveWikiNote(noteName, text);
+                        linkedNoteOriginalRef.current[noteName] = text;
+                      }
+                    }}
+                    placeholder="Empty note — start typing to create it in your vault"
+                    className={`w-full bg-white/10 text-white text-sm px-2 py-1.5 rounded border border-white/20 outline-none focus:bg-white/20 focus:border-white/40 placeholder:text-white/40 resize-y`}
+                    rows={compact ? 4 : 8}
+                    autoFocus={!noAutoFocus && !state.loading}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mb-3">
+          <div className="text-xs font-semibold opacity-90 mb-1">Notes</div>
+          {isEditingNotes ? (
+            <textarea
+              value={localNotes}
+              onChange={handleNotesChange}
+              onKeyDown={handleNotesKeyDown}
+              onBlur={handleNotesBlur}
+              placeholder="Add notes... (**bold**, *italic*, __underline__, URLs) - Shift+Enter for preview"
+              className={`w-full bg-white/10 text-white text-sm px-2 py-1.5 rounded border border-white/20 outline-none focus:bg-white/20 focus:border-white/40 placeholder:text-white/40 ${compact ? 'resize-none' : 'resize-y'}`}
+              rows={compact ? 3 : 8}
+              autoFocus={!noAutoFocus}
+            />
+          ) : (
+            <div
+              onClick={() => setIsEditingNotes(true)}
+              className="text-sm whitespace-pre-wrap cursor-text min-h-[4.5rem] p-2 rounded bg-white/10 hover:bg-white/15"
+            >
+              {urlOnlyNote ? (
+                <a
+                  href={noteUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 text-blue-300 hover:text-blue-200 font-medium break-all"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <ExternalLink size={14} className="flex-shrink-0" />
+                  {noteUrl}
+                </a>
+              ) : (
+                renderFormattedText(localNotes)
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Subtasks section */}
       <div>
@@ -570,49 +614,6 @@ const NotesSubtasksPanel = ({
         </form>
       </div>
 
-      {/* Linked wiki note sections (desktop Obsidian tasks only) */}
-      {wikilinks && wikilinks.length > 0 && onLoadWikiNote && (
-        <div className="mt-3 border-t border-white/20 pt-3 space-y-3">
-          {wikilinks.map((noteName) => {
-            const state = linkedNoteStates[noteName] || { text: '', loading: true, error: null };
-            return (
-              <div key={noteName}>
-                <div className="text-xs font-semibold opacity-90 mb-1 flex items-center gap-1.5">
-                  <BookOpen size={11} />
-                  <span className="font-mono opacity-80">[[{noteName}]]</span>
-                </div>
-                {state.loading ? (
-                  <div className="flex items-center gap-1.5 py-2 opacity-60 text-xs">
-                    <Loader size={12} className="animate-spin" />
-                    Loading…
-                  </div>
-                ) : state.error ? (
-                  <div className="text-xs opacity-60 italic">Could not load note: {state.error}</div>
-                ) : (
-                  <textarea
-                    value={state.text}
-                    onChange={(e) => {
-                      const newText = e.target.value;
-                      setLinkedNoteStates(prev => ({ ...prev, [noteName]: { ...prev[noteName], text: newText } }));
-                      linkedNoteTextsRef.current[noteName] = newText;
-                    }}
-                    onBlur={() => {
-                      const text = linkedNoteTextsRef.current[noteName] ?? '';
-                      if (text !== (linkedNoteOriginalRef.current[noteName] ?? '') && onSaveWikiNote) {
-                        onSaveWikiNote(noteName, text);
-                        linkedNoteOriginalRef.current[noteName] = text;
-                      }
-                    }}
-                    placeholder={`Empty note — start typing to create it in your vault`}
-                    className={`w-full bg-white/10 text-white text-sm px-2 py-1.5 rounded border border-white/20 outline-none focus:bg-white/20 focus:border-white/40 placeholder:text-white/40 resize-y`}
-                    rows={4}
-                  />
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
     </div>
   );
 };

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -183,9 +183,29 @@ export async function readDailyNoteFresh(vaultHandle, dailyNotesPath, dateStr) {
 }
 
 /**
+ * Recursively search a directory for `{fileName}.md`, skipping hidden dirs.
+ * Returns the FileSystemFileHandle or null. Capped at depth 8 to avoid
+ * runaway traversal of unusually deep vaults.
+ */
+async function findFileHandleInDir(dirHandle, mdFileName, depth = 0) {
+  if (depth > 8) return null;
+  for await (const [name, handle] of dirHandle.entries()) {
+    if (handle.kind === 'file' && name === mdFileName) return handle;
+    if (handle.kind === 'directory' && !name.startsWith('.')) {
+      const found = await findFileHandleInDir(handle, mdFileName, depth + 1);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/**
  * Read an arbitrary vault note by wikilink name (e.g. "My Note" or "Folder/My Note").
  * Returns { text, lastModified } or null if the file doesn't exist.
- * Path segments are sanitised to prevent traversal outside the vault root.
+ *
+ * When the name contains path separators (e.g. "Folder/My Note") the exact
+ * path is used. When it is a bare name (e.g. "My Note") the entire vault is
+ * searched recursively — mirroring how Obsidian resolves wikilinks.
  */
 export async function readWikiNote(vaultHandle, noteName) {
   const parts = noteName.split('/').filter(Boolean);
@@ -194,30 +214,33 @@ export async function readWikiNote(vaultHandle, noteName) {
       throw new Error(`Obsidian: unsafe path segment "${part}" in wiki note name`);
     }
   }
-  const fileName = parts[parts.length - 1];
-  const dirParts = parts.slice(0, -1);
-  let dir = vaultHandle;
-  for (const part of dirParts) {
-    try {
-      dir = await dir.getDirectoryHandle(part);
-    } catch (err) {
-      if (err.name === 'NotFoundError') return null;
-      throw err;
+  const mdFileName = `${parts[parts.length - 1]}.md`;
+
+  let fileHandle;
+  if (parts.length > 1) {
+    // Explicit path — navigate directly
+    let dir = vaultHandle;
+    for (const part of parts.slice(0, -1)) {
+      try { dir = await dir.getDirectoryHandle(part); }
+      catch (err) { if (err.name === 'NotFoundError') return null; throw err; }
     }
+    try { fileHandle = await dir.getFileHandle(mdFileName); }
+    catch (err) { if (err.name === 'NotFoundError') return null; throw err; }
+  } else {
+    // Bare name — search whole vault so notes in sub-folders are found
+    fileHandle = await findFileHandleInDir(vaultHandle, mdFileName);
+    if (!fileHandle) return null;
   }
-  try {
-    const fileHandle = await dir.getFileHandle(`${fileName}.md`);
-    const file = await fileHandle.getFile();
-    return { text: await file.text(), lastModified: new Date(file.lastModified).toISOString() };
-  } catch (err) {
-    if (err.name === 'NotFoundError') return null;
-    throw err;
-  }
+
+  const file = await fileHandle.getFile();
+  return { text: await file.text(), lastModified: new Date(file.lastModified).toISOString() };
 }
 
 /**
  * Write (create or overwrite) an arbitrary vault note by wikilink name.
- * Creates intermediate directories as needed.
+ *
+ * For bare names the vault is searched first so edits land in the file's
+ * actual location; if not found the file is created at the vault root.
  */
 export async function writeWikiNote(vaultHandle, noteName, content) {
   const parts = noteName.split('/').filter(Boolean);
@@ -226,13 +249,22 @@ export async function writeWikiNote(vaultHandle, noteName, content) {
       throw new Error(`Obsidian: unsafe path segment "${part}" in wiki note name`);
     }
   }
-  const fileName = parts[parts.length - 1];
-  const dirParts = parts.slice(0, -1);
-  let dir = vaultHandle;
-  for (const part of dirParts) {
-    dir = await dir.getDirectoryHandle(part, { create: true });
+  const mdFileName = `${parts[parts.length - 1]}.md`;
+
+  let fileHandle;
+  if (parts.length > 1) {
+    // Explicit path — create dirs as needed
+    let dir = vaultHandle;
+    for (const part of parts.slice(0, -1)) {
+      dir = await dir.getDirectoryHandle(part, { create: true });
+    }
+    fileHandle = await dir.getFileHandle(mdFileName, { create: true });
+  } else {
+    // Bare name — write to existing location or create at vault root
+    fileHandle = await findFileHandleInDir(vaultHandle, mdFileName)
+      ?? await vaultHandle.getFileHandle(mdFileName, { create: true });
   }
-  const fileHandle = await dir.getFileHandle(`${fileName}.md`, { create: true });
+
   const writable = await fileHandle.createWritable();
   await writable.write(content);
   await writable.close();


### PR DESCRIPTION
…ner header

(1) Bug fix: readWikiNote/writeWikiNote now recursively search the entire
    vault for bare note names (e.g. [[My Note]]), matching how Obsidian
    resolves wikilinks. Previously only the vault root was checked, so
    notes in sub-folders were never found. writeWikiNote also finds the
    existing file location before writing.

(2) The linked vault note now replaces the regular "Notes" section instead
    of appearing below Subtasks — consistent placement at the top of the
    panel and avoids redundancy.

(3) Header shows just the note name (e.g. "My Note") without [[ ]] brackets;
    the BookOpen icon already signals it is a vault note. The textarea
    auto-focuses and sizes consistently with the rest of the panel.

https://claude.ai/code/session_011ZHzmVZcRxdzd8SXp6y7Rr