### PR TITLE
ci: add ARM64 platform to Docker multi-arch build

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Add linux/arm64 to the platforms list in the publish-ghcr workflow so that the GHCR image ships a multi-arch manifest covering both amd64 and arm64. Both node:20-alpine and nginx:alpine already provide ARM64 variants, so no Dockerfile changes are required.

https://claude.ai/code/session_01QZDTVdJbwpDSmWNgCDmMpM