### PR TITLE
Add Android share sheet support

### DIFF
--- a/dayglance-android/app/src/main/AndroidManifest.xml
+++ b/dayglance-android/app/src/main/AndroidManifest.xml
@@ -70,6 +70,12 @@
                 <action android:name="com.dayglance.app.ACTION_ADD_TASK" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <!-- Share sheet: other apps can share plain text / URLs to dayGLANCE -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />

--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -90,6 +90,7 @@ class MainActivity : AppCompatActivity() {
             ACTION_VOICE_INPUT    -> store.pendingVoiceInput = true
             ACTION_ADD_TASK       -> store.pendingAddTask = true
             ACTION_ADD_INBOX_TASK -> store.pendingAddInboxTask = true
+            Intent.ACTION_SEND    -> storeShareIntent(intent, store)
         }
 
         webView = binding.webView
@@ -351,6 +352,7 @@ class MainActivity : AppCompatActivity() {
             ACTION_VOICE_INPUT    -> store.pendingVoiceInput = true
             ACTION_ADD_TASK       -> store.pendingAddTask = true
             ACTION_ADD_INBOX_TASK -> store.pendingAddInboxTask = true
+            Intent.ACTION_SEND    -> storeShareIntent(intent, store)
             else -> return
         }
         // The WebView is already loaded; trigger the JS check immediately.
@@ -369,6 +371,22 @@ class MainActivity : AppCompatActivity() {
         } else {
             super.onBackPressed()
         }
+    }
+
+    /**
+     * Extracts shared text from an ACTION_SEND intent and stores it for the JS layer.
+     * Combines subject + text when both are present (e.g. shared from a browser: subject
+     * is the page title, text is the URL).
+     */
+    private fun storeShareIntent(intent: Intent, store: com.dayglance.app.data.SharedDataStore) {
+        val text = intent.getStringExtra(Intent.EXTRA_TEXT) ?: return
+        val subject = intent.getStringExtra(Intent.EXTRA_SUBJECT)
+        val combined = if (!subject.isNullOrBlank() && !text.startsWith(subject)) {
+            "$subject $text".trim()
+        } else {
+            text
+        }
+        store.pendingShareText = combined.take(500)
     }
 
     companion object {

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -371,6 +371,12 @@ class NativeBridge(
             dataStore.pendingAddInboxTask = false
             return """{"action":"add_inbox_task"}"""
         }
+        val shareText = dataStore.pendingShareText
+        if (shareText != null) {
+            dataStore.pendingShareText = null
+            val escaped = shareText.replace("\\", "\\\\").replace("\"", "\\\"")
+            return """{"action":"share","text":"$escaped"}"""
+        }
         // Snooze takes priority over complete (it was triggered most recently)
         val snoozeId = dataStore.pendingSnoozeTaskId
         if (snoozeId != null) {

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
@@ -101,6 +101,17 @@ class SharedDataStore(context: Context) {
         get() = prefs.getBoolean(KEY_PENDING_ADD_INBOX_TASK, false)
         set(value) = prefs.edit { putBoolean(KEY_PENDING_ADD_INBOX_TASK, value) }
 
+    /**
+     * Text shared to dayGLANCE via the Android share sheet (ACTION_SEND).
+     * Written by MainActivity; read and cleared by NativeBridge.getPendingAction().
+     */
+    var pendingShareText: String?
+        get() = prefs.getString(KEY_PENDING_SHARE, null)
+        set(value) = prefs.edit {
+            if (value != null) putString(KEY_PENDING_SHARE, value)
+            else remove(KEY_PENDING_SHARE)
+        }
+
     // ── Scheduled reminders (background alarm persistence) ───────────────────
 
     /**
@@ -139,6 +150,7 @@ class SharedDataStore(context: Context) {
         private const val KEY_PENDING_VOICE_INPUT = "pending_voice_input"
         private const val KEY_PENDING_ADD_TASK = "pending_add_task"
         private const val KEY_PENDING_ADD_INBOX_TASK = "pending_add_inbox_task"
+        private const val KEY_PENDING_SHARE = "pending_share_text"
 
         const val DEFAULT_DAILY_NOTE_PATTERN = "yyyy-MM-dd"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12959,6 +12959,18 @@ const DayPlanner = () => {
         setShowAddTask(true);
       } else if (pending.action === 'add_inbox_task') {
         openNewInboxTask();
+      } else if (pending.action === 'share' && pending.text) {
+        setNewTask({
+          title: pending.text,
+          startTime: getNextQuarterHour(),
+          duration: 30,
+          date: dateToString(selectedDate),
+          isAllDay: false,
+          openInInbox: true,
+          deadline: null,
+          priority: 0
+        });
+        setShowAddTask(true);
       } else if (pending.action === 'complete' && pending.taskId) {
         toggleComplete(pending.taskId);
       } else if (pending.action === 'snooze' && pending.taskId) {


### PR DESCRIPTION
Other apps can now share plain text and URLs to dayGLANCE via the Android share sheet. The shared text pre-fills the inbox task dialog.

- AndroidManifest: add ACTION_SEND / text/plain intent-filter to MainActivity
- SharedDataStore: add pendingShareText to persist share across app launch
- MainActivity: extract EXTRA_TEXT + EXTRA_SUBJECT from share intents in both onCreate (cold start) and onNewIntent (already running), combining subject + URL when both present (e.g. browser shares page title + URL)
- NativeBridge: expose pending share via getPendingAction() as {action:"share",text:"..."}
- App.jsx: handle share action in the existing pending-action effect, opening the inbox task dialog with the shared text pre-filled

https://claude.ai/code/session_01LCw6YmcJE2D128iur14Ktw