### PR TITLE
Fix Kotlin compiler error: use imported SharedDataStore type

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -378,7 +378,7 @@ class MainActivity : AppCompatActivity() {
      * Combines subject + text when both are present (e.g. shared from a browser: subject
      * is the page title, text is the URL).
      */
-    private fun storeShareIntent(intent: Intent, store: com.dayglance.app.data.SharedDataStore) {
+    private fun storeShareIntent(intent: Intent, store: SharedDataStore) {
         val text = intent.getStringExtra(Intent.EXTRA_TEXT) ?: return
         val subject = intent.getStringExtra(Intent.EXTRA_SUBJECT)
         val combined = if (!subject.isNullOrBlank() && !text.startsWith(subject)) {


### PR DESCRIPTION
Use the already-imported SharedDataStore type name instead of the fully qualified com.dayglance.app.data.SharedDataStore in the storeShareIntent function signature, which was triggering an internal Kotlin compiler error.

https://claude.ai/code/session_01LCw6YmcJE2D128iur14Ktw