### PR TITLE
Fix frame utilization rows being clipped on Android

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28852,7 +28852,7 @@ const DayPlanner = () => {
               {/* Swipeable cards */}
               <div
                 ref={reviewScrollRef}
-                className="flex-1 flex overflow-x-auto overflow-y-hidden review-carousel"
+                className="flex-1 min-h-0 flex overflow-x-auto overflow-y-hidden review-carousel"
                 style={{ scrollSnapType: 'x mandatory', WebkitOverflowScrolling: 'touch', scrollbarWidth: 'none', msOverflowStyle: 'none' }}
                 onScroll={(e) => {
                   const page = Math.round(e.target.scrollLeft / e.target.clientWidth);


### PR DESCRIPTION
Add min-h-0 to the weekly review carousel container so that flex-1 correctly constrains its height on Android Chrome. Without it, h-full on the card resolved to the unconstrained height, causing the last frame utilization row to be hidden behind overflow-y-hidden clipping.

https://claude.ai/code/session_01LCw6YmcJE2D128iur14Ktw