### PR TITLE
Fix TRMNL rate limiting — persist throttle across page reloads

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2959,7 +2959,10 @@ const DayPlanner = () => {
     localStorage.getItem('day-planner-trmnl-last-synced') || null
   );
   const trmnlSyncTimerRef = useRef(null);
-  const trmnlLastPushRef = useRef(0); // timestamp of last push attempt
+  // Seed from persisted last-synced so the 2-min throttle survives page reloads
+  const trmnlLastPushRef = useRef(
+    (() => { const s = localStorage.getItem('day-planner-trmnl-last-synced'); return s ? new Date(s).getTime() : 0; })()
+  ); // timestamp of last push attempt
   const trmnlBackoffUntilRef = useRef(0); // timestamp: skip auto-sync until this time (429 backoff)
   const trmnlBackoffCountRef = useRef(0); // consecutive 429s — drives exponential backoff
   const trmnlSyncInProgressRef = useRef(false); // prevents concurrent pushes


### PR DESCRIPTION
trmnlLastPushRef was initialized to 0 on every mount, so the 2-minute cooldown was forgotten on each page reload and a fresh sync fired immediately. Seed the ref from the persisted last-synced timestamp so the throttle is honoured even after a refresh.

https://claude.ai/code/session_01UUAx1sSBB39tBN9fXphmAq