### PR TITLE
fix: pin builder stage to amd64 to avoid QEMU crash on arm64 npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Build stage
-FROM node:20-alpine AS builder
+# Build stage - pinned to amd64 because the output is static files (arch-independent)
+FROM --platform=linux/amd64 node:20-alpine AS builder
 
 WORKDIR /app
 LABEL org.opencontainers.image.source=https://github.com/krelltunez/dayglance


### PR DESCRIPTION
Static build output (dist/) is arch-independent, so there's no need to run npm install/build under QEMU emulation. The nginx production stage remains unpinned to produce native amd64 and arm64 images.

https://claude.ai/code/session_01GZ9NMeUsBpkJk4pxiwE1Fp