### PR TITLE
refactor: extract useHabits hook (Phase 4, Step 4.1)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ import useWeather from './hooks/useWeather.js';
 import useTagFilter from './hooks/useTagFilter.js';
 import useOnboarding from './hooks/useOnboarding.js';
 import useDailyContent from './hooks/useDailyContent.js';
+import useHabits from './hooks/useHabits.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -429,42 +430,8 @@ const DayPlanner = () => {
   const handleFocusTimerEndRef = useRef(null);
   const focusModeAvailableRef = useRef(false);
 
-  // Habit tracking state
-  const [habits, setHabits] = useState([]);
-  const [habitLogs, setHabitLogs] = useState({});
-  const [habitsEnabled, setHabitsEnabled] = useState(true);
   const [routinesEnabled, setRoutinesEnabled] = useState(true);
-  const [showHabitModal, setShowHabitModal] = useState(false);
-  const [editingHabit, setEditingHabit] = useState(null); // null = adding new, object = editing
-  const [draggedHabitIdx, setDraggedHabitIdx] = useState(null);
-  const [habitOverflowOpen, setHabitOverflowOpen] = useState(false);
-  const [habitLongPressId, setHabitLongPressId] = useState(null); // ID of habit showing long-press popover
-  const [habitEditingCountId, setHabitEditingCountId] = useState(null); // ID of habit with count input open
-  const [habitDayPopup, setHabitDayPopup] = useState(null); // date string for prior-day habit summary popup
-  const habitLongPressTimer = useRef(null);
-  useEffect(() => {
-    if (!habitLongPressId) return;
-    const handler = (e) => {
-      if (e.key === 'Escape') { setHabitLongPressId(null); setHabitEditingCountId(null); }
-    };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [habitLongPressId]);
   const tagFilterBtnRef = useRef(null);
-  const editingHabitRef = useRef(editingHabit);
-  editingHabitRef.current = editingHabit;
-  useEffect(() => {
-    if (!showHabitModal) return;
-    const handler = (e) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        if (editingHabitRef.current) setEditingHabit(null);
-        else { setShowHabitModal(false); setEditingHabit(null); }
-      }
-    };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [showHabitModal]);
 
   // Cloud Sync state
   const [cloudSyncConfig, setCloudSyncConfig] = useState(() => {
@@ -602,6 +569,32 @@ const DayPlanner = () => {
   const firedRemindersRef = useRef(new Set());
   const lastReminderDateRef = useRef((() => { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`; })());
   const { soundEnabled, setSoundEnabled, playUISound, playFocusSound } = useAudio();
+  const {
+    habits, setHabits,
+    habitLogs, setHabitLogs,
+    habitsEnabled, setHabitsEnabled,
+    showHabitModal, setShowHabitModal,
+    editingHabit, setEditingHabit,
+    draggedHabitIdx, setDraggedHabitIdx,
+    habitOverflowOpen, setHabitOverflowOpen,
+    habitLongPressId, setHabitLongPressId,
+    habitEditingCountId, setHabitEditingCountId,
+    habitDayPopup, setHabitDayPopup,
+    habitLongPressTimer,
+    activeHabits,
+    habitStreaks,
+    getTodayHabitCount,
+    incrementHabit,
+    setHabitCount,
+    addHabit,
+    updateHabit,
+    archiveHabit,
+    deleteHabit,
+    reorderHabits,
+    syncHealthConnectHabitsRef,
+    addStepsHabit,
+    addSleepHabit,
+  } = useHabits({ playUISound });
   const { undoToast, setUndoToast, pushUndo, performUndo, performRedo } = useUndo({
     tasks, unscheduledTasks, recycleBin, recurringTasks,
     setTasks, setUnscheduledTasks, setRecycleBin, setRecurringTasks,
@@ -4722,173 +4715,6 @@ const DayPlanner = () => {
 
   // --- Focus Mode handlers ---
 
-  // Habit tracking helpers
-  const activeHabits = useMemo(() => habits.filter(h => !h.archived), [habits]);
-  // Compute habit streaks: { habitId: { current, best } }
-  const habitStreaks = useMemo(() => {
-    const streaks = {};
-    const today = new Date();
-    today.setHours(12, 0, 0, 0);
-    for (const habit of activeHabits) {
-      let current = 0;
-      let best = 0;
-      let streak = 0;
-      let foundGap = false;
-      // Walk backwards from today up to 365 days
-      for (let i = 0; i < 365; i++) {
-        const d = new Date(today);
-        d.setDate(d.getDate() - i);
-        const ds = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-        const count = habitLogs[ds]?.[habit.id] || 0;
-        // Don't count days before the habit was created
-        const createdDate = (habit.createdAt || '').slice(0, 10);
-        if (createdDate && ds < createdDate) break;
-        const met = habit.type === 'doMore' ? count >= habit.target : count <= habit.target;
-        if (met) {
-          streak++;
-          best = Math.max(best, streak);
-        } else {
-          if (!foundGap) current = streak;
-          foundGap = true;
-          streak = 0;
-        }
-      }
-      if (!foundGap) current = streak;
-      best = Math.max(best, streak);
-      streaks[habit.id] = { current, best };
-    }
-    return streaks;
-  }, [activeHabits, habitLogs]);
-  const getTodayHabitCount = (habitId) => {
-    const todayStr = dateToString(new Date());
-    return habitLogs[todayStr]?.[habitId] || 0;
-  };
-  const incrementHabit = (habitId) => {
-    const todayStr = dateToString(new Date());
-    playUISound('click');
-    setHabitLogs(prev => ({
-      ...prev,
-      [todayStr]: {
-        ...prev[todayStr],
-        [habitId]: (prev[todayStr]?.[habitId] || 0) + 1
-      }
-    }));
-  };
-  const setHabitCount = (habitId, count) => {
-    const todayStr = dateToString(new Date());
-    setHabitLogs(prev => ({
-      ...prev,
-      [todayStr]: {
-        ...prev[todayStr],
-        [habitId]: Math.max(0, count)
-      }
-    }));
-  };
-  const addHabit = (habit) => {
-    setHabits(prev => [...prev, { ...habit, id: Date.now().toString(), createdAt: new Date().toISOString(), archived: false }]);
-  };
-  const updateHabit = (id, updates) => {
-    setHabits(prev => prev.map(h => h.id === id ? { ...h, ...updates, lastModified: new Date().toISOString() } : h));
-  };
-  const archiveHabit = (id) => {
-    setHabits(prev => prev.map(h => h.id === id ? { ...h, archived: true, lastModified: new Date().toISOString() } : h));
-  };
-  const deleteHabit = (id) => {
-    setHabits(prev => prev.filter(h => h.id !== id));
-    const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-habit-ids') || '{}');
-    tombstones[String(id)] = new Date().toISOString();
-    localStorage.setItem('day-planner-deleted-habit-ids', JSON.stringify(tombstones));
-  };
-  const reorderHabits = (fromIndex, toIndex) => {
-    setHabits(prev => {
-      const updated = [...prev];
-      const active = updated.filter(h => !h.archived);
-      const [moved] = active.splice(fromIndex, 1);
-      active.splice(toIndex, 0, moved);
-      const archived = updated.filter(h => h.archived);
-      return [...active, ...archived];
-    });
-  };
-
-  // Ref kept current so the visibilitychange handler always calls the latest version
-  const syncHealthConnectHabitsRef = useRef(null);
-
-  // Pull Health Connect data into habits that have source === 'healthConnect'.
-  // Backfills the last 7 days so historical rings are accurate on first setup.
-  const syncHealthConnectHabits = () => {
-    if (!window.DayGlanceNative) return;
-    const healthHabits = habits.filter(h => !h.archived && h.source === 'healthConnect');
-    if (!healthHabits.length) return;
-
-    const today = new Date();
-    const updates = {};
-    for (let daysBack = 0; daysBack < 7; daysBack++) {
-      const d = new Date(today);
-      d.setDate(d.getDate() - daysBack);
-      const dateStr = dateToString(d);
-      for (const habit of healthHabits) {
-        try {
-          let count = 0;
-          if (habit.unit === 'steps') {
-            const result = JSON.parse(window.DayGlanceNative.getSteps(dateStr));
-            count = result.steps ?? 0;
-          } else if (habit.unit === 'min' || habit.unit === 'minutes') {
-            const result = JSON.parse(window.DayGlanceNative.getSleep(dateStr));
-            count = result.durationMinutes ?? 0;
-          }
-          if (!updates[dateStr]) updates[dateStr] = {};
-          updates[dateStr][habit.id] = count;
-        } catch (e) { /* ignore parse errors */ }
-      }
-    }
-    if (Object.keys(updates).length > 0) {
-      setHabitLogs(prev => {
-        const next = { ...prev };
-        for (const [dateStr, entries] of Object.entries(updates)) {
-          next[dateStr] = { ...next[dateStr], ...entries };
-        }
-        return next;
-      });
-    }
-  };
-  // Keep ref current at render time (no stale closure in event listeners)
-  syncHealthConnectHabitsRef.current = syncHealthConnectHabits;
-
-  // Sync on mount and whenever the habits list changes (e.g. steps habit just added)
-  useEffect(() => {
-    syncHealthConnectHabitsRef.current?.();
-  }, [habits]);
-
-  // Create the steps habit pre-configured for Health Connect auto-sync
-  const addStepsHabit = () => {
-    if (!window.DayGlanceNative) return;
-    // Request permission — stub returns "granted", real impl launches HC permission dialog
-    try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {}
-    addHabit({
-      name: 'Steps',
-      icon: 'Footprints',
-      color: 'green',
-      type: 'doMore',
-      target: 10000,
-      unit: 'steps',
-      source: 'healthConnect',
-    });
-  };
-
-  // Create the sleep habit pre-configured for Health Connect auto-sync
-  const addSleepHabit = () => {
-    if (!window.DayGlanceNative) return;
-    try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {}
-    addHabit({
-      name: 'Sleep',
-      icon: 'Moon',
-      color: 'indigo',
-      type: 'doMore',
-      target: 480,
-      unit: 'min',
-      source: 'healthConnect',
-    });
-  };
 
   // ── Native Calendar Events (Android only) ────────────────────────────────
   // Fetches events from the device calendar for a ±2-day window around the

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -1,0 +1,246 @@
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { dateToString } from '../utils/taskUtils.js';
+
+const useHabits = ({ playUISound }) => {
+  const [habits, setHabits] = useState([]);
+  const [habitLogs, setHabitLogs] = useState({});
+  const [habitsEnabled, setHabitsEnabled] = useState(true);
+  const [showHabitModal, setShowHabitModal] = useState(false);
+  const [editingHabit, setEditingHabit] = useState(null); // null = adding new, object = editing
+  const [draggedHabitIdx, setDraggedHabitIdx] = useState(null);
+  const [habitOverflowOpen, setHabitOverflowOpen] = useState(false);
+  const [habitLongPressId, setHabitLongPressId] = useState(null); // ID of habit showing long-press popover
+  const [habitEditingCountId, setHabitEditingCountId] = useState(null); // ID of habit with count input open
+  const [habitDayPopup, setHabitDayPopup] = useState(null); // date string for prior-day habit summary popup
+  const habitLongPressTimer = useRef(null);
+  const editingHabitRef = useRef(editingHabit);
+  editingHabitRef.current = editingHabit;
+
+  useEffect(() => {
+    if (!habitLongPressId) return;
+    const handler = (e) => {
+      if (e.key === 'Escape') { setHabitLongPressId(null); setHabitEditingCountId(null); }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [habitLongPressId]);
+
+  useEffect(() => {
+    if (!showHabitModal) return;
+    const handler = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        if (editingHabitRef.current) setEditingHabit(null);
+        else { setShowHabitModal(false); setEditingHabit(null); }
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [showHabitModal]);
+
+  const activeHabits = useMemo(() => habits.filter(h => !h.archived), [habits]);
+
+  // Compute habit streaks: { habitId: { current, best } }
+  const habitStreaks = useMemo(() => {
+    const streaks = {};
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    for (const habit of activeHabits) {
+      let current = 0;
+      let best = 0;
+      let streak = 0;
+      let foundGap = false;
+      // Walk backwards from today up to 365 days
+      for (let i = 0; i < 365; i++) {
+        const d = new Date(today);
+        d.setDate(d.getDate() - i);
+        const ds = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+        const count = habitLogs[ds]?.[habit.id] || 0;
+        // Don't count days before the habit was created
+        const createdDate = (habit.createdAt || '').slice(0, 10);
+        if (createdDate && ds < createdDate) break;
+        const met = habit.type === 'doMore' ? count >= habit.target : count <= habit.target;
+        if (met) {
+          streak++;
+          best = Math.max(best, streak);
+        } else {
+          if (!foundGap) current = streak;
+          foundGap = true;
+          streak = 0;
+        }
+      }
+      if (!foundGap) current = streak;
+      best = Math.max(best, streak);
+      streaks[habit.id] = { current, best };
+    }
+    return streaks;
+  }, [activeHabits, habitLogs]);
+
+  const getTodayHabitCount = (habitId) => {
+    const todayStr = dateToString(new Date());
+    return habitLogs[todayStr]?.[habitId] || 0;
+  };
+
+  const incrementHabit = (habitId) => {
+    const todayStr = dateToString(new Date());
+    playUISound('click');
+    setHabitLogs(prev => ({
+      ...prev,
+      [todayStr]: {
+        ...prev[todayStr],
+        [habitId]: (prev[todayStr]?.[habitId] || 0) + 1
+      }
+    }));
+  };
+
+  const setHabitCount = (habitId, count) => {
+    const todayStr = dateToString(new Date());
+    setHabitLogs(prev => ({
+      ...prev,
+      [todayStr]: {
+        ...prev[todayStr],
+        [habitId]: Math.max(0, count)
+      }
+    }));
+  };
+
+  const addHabit = (habit) => {
+    setHabits(prev => [...prev, { ...habit, id: Date.now().toString(), createdAt: new Date().toISOString(), archived: false }]);
+  };
+
+  const updateHabit = (id, updates) => {
+    setHabits(prev => prev.map(h => h.id === id ? { ...h, ...updates, lastModified: new Date().toISOString() } : h));
+  };
+
+  const archiveHabit = (id) => {
+    setHabits(prev => prev.map(h => h.id === id ? { ...h, archived: true, lastModified: new Date().toISOString() } : h));
+  };
+
+  const deleteHabit = (id) => {
+    setHabits(prev => prev.filter(h => h.id !== id));
+    const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-habit-ids') || '{}');
+    tombstones[String(id)] = new Date().toISOString();
+    localStorage.setItem('day-planner-deleted-habit-ids', JSON.stringify(tombstones));
+  };
+
+  const reorderHabits = (fromIndex, toIndex) => {
+    setHabits(prev => {
+      const updated = [...prev];
+      const active = updated.filter(h => !h.archived);
+      const [moved] = active.splice(fromIndex, 1);
+      active.splice(toIndex, 0, moved);
+      const archived = updated.filter(h => h.archived);
+      return [...active, ...archived];
+    });
+  };
+
+  // Ref kept current so the visibilitychange handler always calls the latest version
+  const syncHealthConnectHabitsRef = useRef(null);
+
+  // Pull Health Connect data into habits that have source === 'healthConnect'.
+  // Backfills the last 7 days so historical rings are accurate on first setup.
+  const syncHealthConnectHabits = () => {
+    if (!window.DayGlanceNative) return;
+    const healthHabits = habits.filter(h => !h.archived && h.source === 'healthConnect');
+    if (!healthHabits.length) return;
+
+    const today = new Date();
+    const updates = {};
+    for (let daysBack = 0; daysBack < 7; daysBack++) {
+      const d = new Date(today);
+      d.setDate(d.getDate() - daysBack);
+      const dateStr = dateToString(d);
+      for (const habit of healthHabits) {
+        try {
+          let count = 0;
+          if (habit.unit === 'steps') {
+            const result = JSON.parse(window.DayGlanceNative.getSteps(dateStr));
+            count = result.steps ?? 0;
+          } else if (habit.unit === 'min' || habit.unit === 'minutes') {
+            const result = JSON.parse(window.DayGlanceNative.getSleep(dateStr));
+            count = result.durationMinutes ?? 0;
+          }
+          if (!updates[dateStr]) updates[dateStr] = {};
+          updates[dateStr][habit.id] = count;
+        } catch (e) { /* ignore parse errors */ }
+      }
+    }
+    if (Object.keys(updates).length > 0) {
+      setHabitLogs(prev => {
+        const next = { ...prev };
+        for (const [dateStr, entries] of Object.entries(updates)) {
+          next[dateStr] = { ...next[dateStr], ...entries };
+        }
+        return next;
+      });
+    }
+  };
+
+  // Keep ref current at render time (no stale closure in event listeners)
+  syncHealthConnectHabitsRef.current = syncHealthConnectHabits;
+
+  // Sync on mount and whenever the habits list changes (e.g. steps habit just added)
+  useEffect(() => {
+    syncHealthConnectHabitsRef.current?.();
+  }, [habits]);
+
+  // Create the steps habit pre-configured for Health Connect auto-sync
+  const addStepsHabit = () => {
+    if (!window.DayGlanceNative) return;
+    // Request permission — stub returns "granted", real impl launches HC permission dialog
+    try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {}
+    addHabit({
+      name: 'Steps',
+      icon: 'Footprints',
+      color: 'green',
+      type: 'doMore',
+      target: 10000,
+      unit: 'steps',
+      source: 'healthConnect',
+    });
+  };
+
+  // Create the sleep habit pre-configured for Health Connect auto-sync
+  const addSleepHabit = () => {
+    if (!window.DayGlanceNative) return;
+    try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {}
+    addHabit({
+      name: 'Sleep',
+      icon: 'Moon',
+      color: 'indigo',
+      type: 'doMore',
+      target: 480,
+      unit: 'min',
+      source: 'healthConnect',
+    });
+  };
+
+  return {
+    habits, setHabits,
+    habitLogs, setHabitLogs,
+    habitsEnabled, setHabitsEnabled,
+    showHabitModal, setShowHabitModal,
+    editingHabit, setEditingHabit,
+    draggedHabitIdx, setDraggedHabitIdx,
+    habitOverflowOpen, setHabitOverflowOpen,
+    habitLongPressId, setHabitLongPressId,
+    habitEditingCountId, setHabitEditingCountId,
+    habitDayPopup, setHabitDayPopup,
+    habitLongPressTimer,
+    activeHabits,
+    habitStreaks,
+    getTodayHabitCount,
+    incrementHabit,
+    setHabitCount,
+    addHabit,
+    updateHabit,
+    archiveHabit,
+    deleteHabit,
+    reorderHabits,
+    syncHealthConnectHabitsRef,
+    addStepsHabit,
+    addSleepHabit,
+  };
+};
+
+export default useHabits;


### PR DESCRIPTION
## Summary

- Extracts all habit tracking state, effects, computed values, and handlers from `App.jsx` into `src/hooks/useHabits.js`
- Hook accepts `{ playUISound }` (needed by `incrementHabit`) and returns all habit-related state and functions
- `habitLongPressTimer` ref and `syncHealthConnectHabitsRef` are both returned explicitly so consumers can destructure them safely
- `habitDayPopup` / `setHabitDayPopup` included (belongs to this feature domain)

## State owned by hook
`habits`, `habitLogs`, `habitsEnabled`, `showHabitModal`, `editingHabit`, `draggedHabitIdx`, `habitOverflowOpen`, `habitLongPressId`, `habitEditingCountId`, `habitDayPopup`, `habitLongPressTimer` (ref), `editingHabitRef` (ref, internal)

## Functions owned by hook
`activeHabits`, `habitStreaks`, `getTodayHabitCount`, `incrementHabit`, `setHabitCount`, `addHabit`, `updateHabit`, `archiveHabit`, `deleteHabit`, `reorderHabits`, `syncHealthConnectHabitsRef`, `addStepsHabit`, `addSleepHabit`

## Test plan
- [ ] Open habits panel — habit rings display correctly
- [ ] Short-press a habit to log it (count increments)
- [ ] Long-press a habit to see the count popover; press Escape to dismiss
- [ ] Drag a habit to reorder it
- [ ] Open Habit settings modal (`h` shortcut); add, edit, and delete a habit
- [ ] Press Escape inside habit modal with an editing habit — clears edit state; press again — closes modal

https://claude.ai/code/session_014Q2Dszu2C3S7wsMwEbTHPm