### PR TITLE
refactor: extract useRoutines hook (Phase 4, Step 4.2)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,6 +38,7 @@ import useTagFilter from './hooks/useTagFilter.js';
 import useOnboarding from './hooks/useOnboarding.js';
 import useDailyContent from './hooks/useDailyContent.js';
 import useHabits from './hooks/useHabits.js';
+import useRoutines from './hooks/useRoutines.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -387,19 +388,6 @@ const DayPlanner = () => {
   const mobileDragPreviewTimeRef = useRef(null);
   const mobileDragPreviewDateRef = useRef(null);
 
-  // Routines state
-  const [routineDefinitions, setRoutineDefinitions] = useState({ monday: [], tuesday: [], wednesday: [], thursday: [], friday: [], saturday: [], sunday: [], everyday: [] });
-  const [todayRoutines, setTodayRoutines] = useState([]);
-  const [routinesDate, setRoutinesDate] = useState('');
-  const [removedTodayRoutineIds, setRemovedTodayRoutineIds] = useState({});
-  const [showRoutinesDashboard, setShowRoutinesDashboard] = useState(false);
-  const [dashboardSelectedChips, setDashboardSelectedChips] = useState([]);
-  const [routineAddingToBucket, setRoutineAddingToBucket] = useState(null);
-  const [routineNewChipName, setRoutineNewChipName] = useState('');
-  const [routineTimePickerChipId, setRoutineTimePickerChipId] = useState(null);
-  const [routineDeleteConfirm, setRoutineDeleteConfirm] = useState(null); // { bucket, chipId, chipName }
-  const [routineFocusedChipId, setRoutineFocusedChipId] = useState(null); // touch: first tap shows buttons, second executes
-  const [routineDurationEditId, setRoutineDurationEditId] = useState(null); // id of routine chip being duration-edited on timeline
 
   // Keyboard shortcut cheat sheet
   const [showShortcutHelp, setShowShortcutHelp] = useState(false);
@@ -430,7 +418,6 @@ const DayPlanner = () => {
   const handleFocusTimerEndRef = useRef(null);
   const focusModeAvailableRef = useRef(false);
 
-  const [routinesEnabled, setRoutinesEnabled] = useState(true);
   const tagFilterBtnRef = useRef(null);
 
   // Cloud Sync state
@@ -595,6 +582,26 @@ const DayPlanner = () => {
     addStepsHabit,
     addSleepHabit,
   } = useHabits({ playUISound });
+  const {
+    routineDefinitions, setRoutineDefinitions,
+    todayRoutines, setTodayRoutines,
+    routinesDate, setRoutinesDate,
+    removedTodayRoutineIds, setRemovedTodayRoutineIds,
+    showRoutinesDashboard, setShowRoutinesDashboard,
+    dashboardSelectedChips, setDashboardSelectedChips,
+    routineAddingToBucket, setRoutineAddingToBucket,
+    routineNewChipName, setRoutineNewChipName,
+    routineTimePickerChipId, setRoutineTimePickerChipId,
+    routineDeleteConfirm, setRoutineDeleteConfirm,
+    routineFocusedChipId, setRoutineFocusedChipId,
+    routineDurationEditId, setRoutineDurationEditId,
+    routinesEnabled, setRoutinesEnabled,
+    openRoutinesDashboard,
+    addRoutineChip,
+    deleteRoutineChip,
+    toggleRoutineChipSelection,
+    handleRoutinesDone,
+  } = useRoutines({ currentTime, onboardingProgress, setOnboardingProgress });
   const { undoToast, setUndoToast, pushUndo, performUndo, performRedo } = useUndo({
     tasks, unscheduledTasks, recycleBin, recurringTasks,
     setTasks, setUnscheduledTasks, setRecycleBin, setRecurringTasks,
@@ -1538,17 +1545,6 @@ const DayPlanner = () => {
     const timer = setInterval(checkAndBackup, 60 * 1000);
     return () => clearInterval(timer);
   }, [dataLoaded, autoBackupConfig.local.enabled, autoBackupConfig.local.frequency, autoBackupConfig.remote.enabled, autoBackupConfig.remote.frequency]);
-
-  // Auto-clear today's routines on day rollover
-  useEffect(() => {
-    const todayStr = dateToString(new Date());
-    if (routinesDate && routinesDate !== todayStr) {
-      setTodayRoutines([]);
-      setRoutinesDate(todayStr);
-      setRemovedTodayRoutineIds({});
-      localStorage.removeItem('day-planner-removed-today-routine-ids');
-    }
-  }, [currentTime]);
 
   const loadData = () => {
     try {
@@ -4616,101 +4612,6 @@ const DayPlanner = () => {
   // --- Routines handlers ---
   const getDayName = (date) => {
     return ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'][date.getDay()];
-  };
-
-  const openRoutinesDashboard = () => {
-    // Pre-populate center with chips already placed today
-    setDashboardSelectedChips(todayRoutines.map(r => ({ id: r.id, name: r.name, bucket: r.bucket, startTime: r.startTime || null })));
-    setRoutineAddingToBucket(null);
-    setRoutineNewChipName('');
-    setShowRoutinesDashboard(true);
-  };
-
-  const addRoutineChip = (bucket) => {
-    const name = routineNewChipName.trim();
-    if (!name) return;
-    const chipId = crypto.randomUUID();
-    setRoutineDefinitions(prev => ({
-      ...prev,
-      [bucket]: [...prev[bucket], { id: chipId, name, lastModified: new Date().toISOString() }]
-    }));
-    setRoutineNewChipName('');
-    setRoutineAddingToBucket(null);
-  };
-
-  const deleteRoutineChip = (bucket, chipId) => {
-    setRoutineDefinitions(prev => ({
-      ...prev,
-      [bucket]: prev[bucket].filter(c => c.id !== chipId)
-    }));
-    // Also remove from dashboard selected and today's routines if present
-    setDashboardSelectedChips(prev => prev.filter(c => c.id !== chipId));
-    setTodayRoutines(prev => prev.filter(r => r.id !== chipId));
-    // Record tombstone so deletion syncs across devices
-    const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-routine-chip-ids') || '{}');
-    tombstones[String(chipId)] = new Date().toISOString();
-    // Prune tombstones older than 90 days
-    const cutoff = Date.now() - 90 * 24 * 60 * 60 * 1000;
-    for (const id in tombstones) {
-      if (new Date(tombstones[id]).getTime() < cutoff) delete tombstones[id];
-    }
-    localStorage.setItem('day-planner-deleted-routine-chip-ids', JSON.stringify(tombstones));
-  };
-
-  const toggleRoutineChipSelection = (chip, bucket) => {
-    const isSelected = dashboardSelectedChips.some(c => c.id === chip.id);
-    if (isSelected) {
-      setDashboardSelectedChips(prev => prev.filter(c => c.id !== chip.id));
-    } else {
-      setDashboardSelectedChips(prev => [...prev, { id: chip.id, name: chip.name, bucket, startTime: null }]);
-    }
-  };
-
-  const handleRoutinesDone = () => {
-    const todayStr = dateToString(new Date());
-    // Preserve placement info for chips that were already placed on the timeline
-    const existingMap = {};
-    todayRoutines.forEach(r => { existingMap[r.id] = r; });
-
-    const now = new Date().toISOString();
-    const newTodayRoutines = dashboardSelectedChips.map(chip => {
-      const existing = existingMap[chip.id];
-      if (existing) {
-        return { ...existing, name: chip.name, bucket: chip.bucket, startTime: chip.startTime, isAllDay: !chip.startTime, lastModified: now };
-      }
-      return { id: chip.id, name: chip.name, bucket: chip.bucket, startTime: chip.startTime || null, duration: 15, isAllDay: !chip.startTime, lastModified: now };
-    });
-
-    // Record tombstones for routines that were removed from today's list
-    // so the removal syncs across devices instead of being re-added by merge.
-    const newIds = new Set(newTodayRoutines.map(r => String(r.id)));
-    const removedIds = todayRoutines.filter(r => !newIds.has(String(r.id)));
-    if (removedIds.length > 0) {
-      setRemovedTodayRoutineIds(prev => {
-        const updated = { ...prev };
-        removedIds.forEach(r => { updated[String(r.id)] = now; });
-        return updated;
-      });
-    }
-    // Clear tombstones for routines that were re-added
-    const prevIds = new Set(todayRoutines.map(r => String(r.id)));
-    const readdedIds = newTodayRoutines.filter(r => !prevIds.has(String(r.id)));
-    if (readdedIds.length > 0) {
-      setRemovedTodayRoutineIds(prev => {
-        const updated = { ...prev };
-        readdedIds.forEach(r => { delete updated[String(r.id)]; });
-        return updated;
-      });
-    }
-
-    setTodayRoutines(newTodayRoutines);
-    setRoutinesDate(todayStr);
-    setShowRoutinesDashboard(false);
-    setRoutineTimePickerChipId(null);
-    setRoutineFocusedChipId(null);
-    if (!onboardingProgress.hasSetupRoutines) {
-      setOnboardingProgress(prev => ({ ...prev, hasSetupRoutines: true }));
-    }
   };
 
   // --- Focus Mode handlers ---

--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -1,0 +1,147 @@
+import { useState, useEffect } from 'react';
+import { dateToString } from '../utils/taskUtils.js';
+
+const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress }) => {
+  const [routineDefinitions, setRoutineDefinitions] = useState({ monday: [], tuesday: [], wednesday: [], thursday: [], friday: [], saturday: [], sunday: [], everyday: [] });
+  const [todayRoutines, setTodayRoutines] = useState([]);
+  const [routinesDate, setRoutinesDate] = useState('');
+  const [removedTodayRoutineIds, setRemovedTodayRoutineIds] = useState({});
+  const [showRoutinesDashboard, setShowRoutinesDashboard] = useState(false);
+  const [dashboardSelectedChips, setDashboardSelectedChips] = useState([]);
+  const [routineAddingToBucket, setRoutineAddingToBucket] = useState(null);
+  const [routineNewChipName, setRoutineNewChipName] = useState('');
+  const [routineTimePickerChipId, setRoutineTimePickerChipId] = useState(null);
+  const [routineDeleteConfirm, setRoutineDeleteConfirm] = useState(null); // { bucket, chipId, chipName }
+  const [routineFocusedChipId, setRoutineFocusedChipId] = useState(null); // touch: first tap shows buttons, second executes
+  const [routineDurationEditId, setRoutineDurationEditId] = useState(null); // id of routine chip being duration-edited on timeline
+  const [routinesEnabled, setRoutinesEnabled] = useState(true);
+
+  // Auto-clear today's routines on day rollover
+  useEffect(() => {
+    const todayStr = dateToString(new Date());
+    if (routinesDate && routinesDate !== todayStr) {
+      setTodayRoutines([]);
+      setRoutinesDate(todayStr);
+      setRemovedTodayRoutineIds({});
+      localStorage.removeItem('day-planner-removed-today-routine-ids');
+    }
+  }, [currentTime]);
+
+  const openRoutinesDashboard = () => {
+    // Pre-populate center with chips already placed today
+    setDashboardSelectedChips(todayRoutines.map(r => ({ id: r.id, name: r.name, bucket: r.bucket, startTime: r.startTime || null })));
+    setRoutineAddingToBucket(null);
+    setRoutineNewChipName('');
+    setShowRoutinesDashboard(true);
+  };
+
+  const addRoutineChip = (bucket) => {
+    const name = routineNewChipName.trim();
+    if (!name) return;
+    const chipId = crypto.randomUUID();
+    setRoutineDefinitions(prev => ({
+      ...prev,
+      [bucket]: [...prev[bucket], { id: chipId, name, lastModified: new Date().toISOString() }]
+    }));
+    setRoutineNewChipName('');
+    setRoutineAddingToBucket(null);
+  };
+
+  const deleteRoutineChip = (bucket, chipId) => {
+    setRoutineDefinitions(prev => ({
+      ...prev,
+      [bucket]: prev[bucket].filter(c => c.id !== chipId)
+    }));
+    // Also remove from dashboard selected and today's routines if present
+    setDashboardSelectedChips(prev => prev.filter(c => c.id !== chipId));
+    setTodayRoutines(prev => prev.filter(r => r.id !== chipId));
+    // Record tombstone so deletion syncs across devices
+    const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-routine-chip-ids') || '{}');
+    tombstones[String(chipId)] = new Date().toISOString();
+    // Prune tombstones older than 90 days
+    const cutoff = Date.now() - 90 * 24 * 60 * 60 * 1000;
+    for (const id in tombstones) {
+      if (new Date(tombstones[id]).getTime() < cutoff) delete tombstones[id];
+    }
+    localStorage.setItem('day-planner-deleted-routine-chip-ids', JSON.stringify(tombstones));
+  };
+
+  const toggleRoutineChipSelection = (chip, bucket) => {
+    const isSelected = dashboardSelectedChips.some(c => c.id === chip.id);
+    if (isSelected) {
+      setDashboardSelectedChips(prev => prev.filter(c => c.id !== chip.id));
+    } else {
+      setDashboardSelectedChips(prev => [...prev, { id: chip.id, name: chip.name, bucket, startTime: null }]);
+    }
+  };
+
+  const handleRoutinesDone = () => {
+    const todayStr = dateToString(new Date());
+    // Preserve placement info for chips that were already placed on the timeline
+    const existingMap = {};
+    todayRoutines.forEach(r => { existingMap[r.id] = r; });
+
+    const now = new Date().toISOString();
+    const newTodayRoutines = dashboardSelectedChips.map(chip => {
+      const existing = existingMap[chip.id];
+      if (existing) {
+        return { ...existing, name: chip.name, bucket: chip.bucket, startTime: chip.startTime, isAllDay: !chip.startTime, lastModified: now };
+      }
+      return { id: chip.id, name: chip.name, bucket: chip.bucket, startTime: chip.startTime || null, duration: 15, isAllDay: !chip.startTime, lastModified: now };
+    });
+
+    // Record tombstones for routines that were removed from today's list
+    // so the removal syncs across devices instead of being re-added by merge.
+    const newIds = new Set(newTodayRoutines.map(r => String(r.id)));
+    const removedIds = todayRoutines.filter(r => !newIds.has(String(r.id)));
+    if (removedIds.length > 0) {
+      setRemovedTodayRoutineIds(prev => {
+        const updated = { ...prev };
+        removedIds.forEach(r => { updated[String(r.id)] = now; });
+        return updated;
+      });
+    }
+    // Clear tombstones for routines that were re-added
+    const prevIds = new Set(todayRoutines.map(r => String(r.id)));
+    const readdedIds = newTodayRoutines.filter(r => !prevIds.has(String(r.id)));
+    if (readdedIds.length > 0) {
+      setRemovedTodayRoutineIds(prev => {
+        const updated = { ...prev };
+        readdedIds.forEach(r => { delete updated[String(r.id)]; });
+        return updated;
+      });
+    }
+
+    setTodayRoutines(newTodayRoutines);
+    setRoutinesDate(todayStr);
+    setShowRoutinesDashboard(false);
+    setRoutineTimePickerChipId(null);
+    setRoutineFocusedChipId(null);
+    if (!onboardingProgress.hasSetupRoutines) {
+      setOnboardingProgress(prev => ({ ...prev, hasSetupRoutines: true }));
+    }
+  };
+
+  return {
+    routineDefinitions, setRoutineDefinitions,
+    todayRoutines, setTodayRoutines,
+    routinesDate, setRoutinesDate,
+    removedTodayRoutineIds, setRemovedTodayRoutineIds,
+    showRoutinesDashboard, setShowRoutinesDashboard,
+    dashboardSelectedChips, setDashboardSelectedChips,
+    routineAddingToBucket, setRoutineAddingToBucket,
+    routineNewChipName, setRoutineNewChipName,
+    routineTimePickerChipId, setRoutineTimePickerChipId,
+    routineDeleteConfirm, setRoutineDeleteConfirm,
+    routineFocusedChipId, setRoutineFocusedChipId,
+    routineDurationEditId, setRoutineDurationEditId,
+    routinesEnabled, setRoutinesEnabled,
+    openRoutinesDashboard,
+    addRoutineChip,
+    deleteRoutineChip,
+    toggleRoutineChipSelection,
+    handleRoutinesDone,
+  };
+};
+
+export default useRoutines;


### PR DESCRIPTION
## Summary

- Extracts all routines state, effects, and handlers from `App.jsx` into `src/hooks/useRoutines.js`
- Hook accepts `{ currentTime, onboardingProgress, setOnboardingProgress }` as arguments
- `routinesEnabled` is co-located with routines state as specified in the plan
- The day-rollover `useEffect` (auto-clears today's routines when date changes) moves into the hook, keyed on `currentTime`

## State owned by hook
`routineDefinitions`, `todayRoutines`, `routinesDate`, `removedTodayRoutineIds`, `showRoutinesDashboard`, `dashboardSelectedChips`, `routineAddingToBucket`, `routineNewChipName`, `routineTimePickerChipId`, `routineDeleteConfirm`, `routineFocusedChipId`, `routineDurationEditId`, `routinesEnabled`

## Functions owned by hook
`openRoutinesDashboard`, `addRoutineChip`, `deleteRoutineChip`, `toggleRoutineChipSelection`, `handleRoutinesDone`

## Note
`handleRoutineResizeStart` / `handleTouchRoutineResizeStart` remain in App.jsx as they also depend on `setIsResizing` (external drag/drop state), but they use `setTodayRoutines` from the hook's return value.

## Test plan
- [ ] Open Routines Dashboard (`r` shortcut) — chips display correctly
- [ ] Add a routine chip to a bucket — verify it appears in the bucket list
- [ ] Select chips and press Done — verify they appear in today's list
- [ ] Remove a chip from today's list and re-confirm
- [ ] Toggle routines on/off in Settings — verify the routines tab appears/disappears
- [ ] Verify day-rollover clears routines (or confirm the effect is wired correctly)

https://claude.ai/code/session_014Q2Dszu2C3S7wsMwEbTHPm