### PR TITLE
refactor: extract useTrmnlSync hook (Phase 4, Step 4.4)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,6 +40,7 @@ import useDailyContent from './hooks/useDailyContent.js';
 import useHabits from './hooks/useHabits.js';
 import useRoutines from './hooks/useRoutines.js';
 import useFocusMode from './hooks/useFocusMode.js';
+import useTrmnlSync from './hooks/useTrmnlSync.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -430,27 +431,6 @@ const DayPlanner = () => {
     return saved !== null ? saved : '## Quick Notes\n## Thoughts\n## Accomplished\n## Tasks\n';
   });
 
-  // TRMNL e-ink dashboard state
-  const [trmnlConfig, setTrmnlConfig] = useState(() => {
-    try {
-      const saved = localStorage.getItem('day-planner-trmnl-config');
-      return saved ? JSON.parse(saved) : null;
-    } catch { return null; }
-  });
-  const [trmnlSyncStatus, setTrmnlSyncStatus] = useState('idle'); // 'idle' | 'syncing' | 'success' | 'error'
-  const [trmnlLastSynced, setTrmnlLastSynced] = useState(() =>
-    localStorage.getItem('day-planner-trmnl-last-synced') || null
-  );
-  const trmnlSyncTimerRef = useRef(null);
-  // Seed from persisted last-synced so the 2-min throttle survives page reloads
-  const trmnlLastPushRef = useRef(
-    (() => { const s = localStorage.getItem('day-planner-trmnl-last-synced'); return s ? new Date(s).getTime() : 0; })()
-  ); // timestamp of last push attempt
-  const trmnlBackoffUntilRef = useRef(0); // timestamp: skip auto-sync until this time (429 backoff)
-  const trmnlBackoffCountRef = useRef(0); // consecutive 429s — drives exponential backoff
-  const trmnlSyncInProgressRef = useRef(false); // prevents concurrent pushes
-  const performTrmnlSyncRef = useRef(null);
-  const [trmnlMarkupCopied, setTrmnlMarkupCopied] = useState('');
 
   // Obsidian Integration state
   const [obsidianConfig, setObsidianConfig] = useState(() => {
@@ -601,6 +581,18 @@ const DayPlanner = () => {
     handleFocusTimerEndRef,
     focusModeAvailableRef,
   } = useFocusMode();
+  const {
+    trmnlConfig, setTrmnlConfig,
+    trmnlSyncStatus, setTrmnlSyncStatus,
+    trmnlLastSynced, setTrmnlLastSynced,
+    trmnlMarkupCopied, setTrmnlMarkupCopied,
+    trmnlSyncTimerRef,
+    trmnlLastPushRef,
+    trmnlBackoffUntilRef,
+    trmnlBackoffCountRef,
+    trmnlSyncInProgressRef,
+    performTrmnlSyncRef,
+  } = useTrmnlSync();
   const { undoToast, setUndoToast, pushUndo, performUndo, performRedo } = useUndo({
     tasks, unscheduledTasks, recycleBin, recurringTasks,
     setTasks, setUnscheduledTasks, setRecycleBin, setRecurringTasks,
@@ -1262,15 +1254,6 @@ const DayPlanner = () => {
       localStorage.removeItem('day-planner-cloud-sync-config');
     }
   }, [cloudSyncConfig]);
-
-  // Persist TRMNL config
-  useEffect(() => {
-    if (trmnlConfig) {
-      localStorage.setItem('day-planner-trmnl-config', JSON.stringify(trmnlConfig));
-    } else {
-      localStorage.removeItem('day-planner-trmnl-config');
-    }
-  }, [trmnlConfig]);
 
   // TRMNL auto-sync: push data when tasks/habits change
   // Debounce 10s to batch rapid edits, then throttle to at most once per 2 min.

--- a/src/hooks/useTrmnlSync.js
+++ b/src/hooks/useTrmnlSync.js
@@ -1,0 +1,48 @@
+import { useState, useRef, useEffect } from 'react';
+
+const useTrmnlSync = () => {
+  const [trmnlConfig, setTrmnlConfig] = useState(() => {
+    try {
+      const saved = localStorage.getItem('day-planner-trmnl-config');
+      return saved ? JSON.parse(saved) : null;
+    } catch { return null; }
+  });
+  const [trmnlSyncStatus, setTrmnlSyncStatus] = useState('idle'); // 'idle' | 'syncing' | 'success' | 'error'
+  const [trmnlLastSynced, setTrmnlLastSynced] = useState(() =>
+    localStorage.getItem('day-planner-trmnl-last-synced') || null
+  );
+  const [trmnlMarkupCopied, setTrmnlMarkupCopied] = useState('');
+  // Seed from persisted last-synced so the 2-min throttle survives page reloads
+  const trmnlSyncTimerRef = useRef(null);
+  const trmnlLastPushRef = useRef(
+    (() => { const s = localStorage.getItem('day-planner-trmnl-last-synced'); return s ? new Date(s).getTime() : 0; })()
+  ); // timestamp of last push attempt
+  const trmnlBackoffUntilRef = useRef(0); // timestamp: skip auto-sync until this time (429 backoff)
+  const trmnlBackoffCountRef = useRef(0); // consecutive 429s — drives exponential backoff
+  const trmnlSyncInProgressRef = useRef(false); // prevents concurrent pushes
+  const performTrmnlSyncRef = useRef(null);
+
+  // Persist TRMNL config
+  useEffect(() => {
+    if (trmnlConfig) {
+      localStorage.setItem('day-planner-trmnl-config', JSON.stringify(trmnlConfig));
+    } else {
+      localStorage.removeItem('day-planner-trmnl-config');
+    }
+  }, [trmnlConfig]);
+
+  return {
+    trmnlConfig, setTrmnlConfig,
+    trmnlSyncStatus, setTrmnlSyncStatus,
+    trmnlLastSynced, setTrmnlLastSynced,
+    trmnlMarkupCopied, setTrmnlMarkupCopied,
+    trmnlSyncTimerRef,
+    trmnlLastPushRef,
+    trmnlBackoffUntilRef,
+    trmnlBackoffCountRef,
+    trmnlSyncInProgressRef,
+    performTrmnlSyncRef,
+  };
+};
+
+export default useTrmnlSync;


### PR DESCRIPTION
## Summary

- Creates `src/hooks/useTrmnlSync.js` owning all TRMNL e-ink dashboard state and refs
- The `trmnlConfig` persist effect moves to the hook (only depends on internal state)
- `performTrmnlSync` and the auto-sync effect remain in App.jsx — they depend on tasks, habits, routines, weather, dailyNotes, and other external state

## State/refs moved to hook
- **4 useState:** `trmnlConfig`, `trmnlSyncStatus`, `trmnlLastSynced`, `trmnlMarkupCopied`
- **6 useRef:** `trmnlSyncTimerRef`, `trmnlLastPushRef`, `trmnlBackoffUntilRef`, `trmnlBackoffCountRef`, `trmnlSyncInProgressRef`, `performTrmnlSyncRef`

> `trmnlBackoffCountRef` and `trmnlSyncInProgressRef` are not listed in the plan but are private TRMNL refs included for completeness.

## Stays in App.jsx
- `performTrmnlSync` — reads tasks, unscheduledTasks, habits, habitLogs, weather, dailyNotes, todayRoutines, routinesEnabled, selectedDate
- Auto-sync `useEffect` — depends on all the above external state as deps
- `performTrmnlSyncRef.current = performTrmnlSync` assignment effect

## Test plan
- [ ] Open Settings → TRMNL section
- [ ] Verify config fields (webhook URL, API key) load from localStorage
- [ ] Toggle TRMNL enabled on/off — verify setting persists on reload
- [ ] If webhook configured: trigger a sync manually, verify status indicator updates

https://claude.ai/code/session_014Q2Dszu2C3S7wsMwEbTHPm