### PR TITLE
refactor: extract useObsidian hook (Step 4.5)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,6 +41,7 @@ import useHabits from './hooks/useHabits.js';
 import useRoutines from './hooks/useRoutines.js';
 import useFocusMode from './hooks/useFocusMode.js';
 import useTrmnlSync from './hooks/useTrmnlSync.js';
+import useObsidian from './hooks/useObsidian.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -433,23 +434,16 @@ const DayPlanner = () => {
 
 
   // Obsidian Integration state
-  const [obsidianConfig, setObsidianConfig] = useState(() => {
-    try {
-      const saved = localStorage.getItem('day-planner-obsidian-config');
-      return saved ? JSON.parse(saved) : null;
-    } catch { return null; }
-  });
-  const [obsidianSyncStatus, setObsidianSyncStatus] = useState('idle'); // 'idle' | 'syncing' | 'success' | 'error'
-  const [obsidianLastSynced, setObsidianLastSynced] = useState(() =>
-    localStorage.getItem('day-planner-obsidian-last-synced') || null
-  );
-  const obsidianVaultHandleRef = useRef(null);
-  const obsidianSyncInProgressRef = useRef(false);
-  const obsidianPrevTaskStateRef = useRef({}); // tracks {id: {completed, startTime, title}} for change detection
-  // Always-fresh refs so performObsidianSync (called from a long-lived interval)
-  // never reads stale task state from a closed-over render.
-  const obsidianTasksRef = useRef([]);
-  const obsidianInboxRef = useRef([]);
+  const {
+    obsidianConfig, setObsidianConfig,
+    obsidianSyncStatus, setObsidianSyncStatus,
+    obsidianLastSynced, setObsidianLastSynced,
+    obsidianVaultHandleRef,
+    obsidianSyncInProgressRef,
+    obsidianPrevTaskStateRef,
+    obsidianTasksRef,
+    obsidianInboxRef,
+  } = useObsidian();
 
   // Auto-Backup state
   const [autoBackupConfig, setAutoBackupConfig] = useState(() => {
@@ -1282,15 +1276,6 @@ const DayPlanner = () => {
     }, 10 * 1000); // 10-second debounce after last change
     return () => { if (trmnlSyncTimerRef.current) clearTimeout(trmnlSyncTimerRef.current); };
   }, [tasks, unscheduledTasks, habits, habitLogs, todayRoutines, routinesEnabled, trmnlConfig?.enabled, dataLoaded]);
-
-  // Persist Obsidian config
-  useEffect(() => {
-    if (obsidianConfig) {
-      localStorage.setItem('day-planner-obsidian-config', JSON.stringify(obsidianConfig));
-    } else {
-      localStorage.removeItem('day-planner-obsidian-config');
-    }
-  }, [obsidianConfig]);
 
   // Obsidian sync: restore vault handle on mount and do initial sync
   useEffect(() => {

--- a/src/hooks/useObsidian.js
+++ b/src/hooks/useObsidian.js
@@ -1,0 +1,43 @@
+import { useState, useRef, useEffect } from 'react';
+
+const useObsidian = () => {
+  const [obsidianConfig, setObsidianConfig] = useState(() => {
+    try {
+      const saved = localStorage.getItem('day-planner-obsidian-config');
+      return saved ? JSON.parse(saved) : null;
+    } catch { return null; }
+  });
+  const [obsidianSyncStatus, setObsidianSyncStatus] = useState('idle'); // 'idle' | 'syncing' | 'success' | 'error'
+  const [obsidianLastSynced, setObsidianLastSynced] = useState(() =>
+    localStorage.getItem('day-planner-obsidian-last-synced') || null
+  );
+  const obsidianVaultHandleRef = useRef(null);
+  const obsidianSyncInProgressRef = useRef(false);
+  const obsidianPrevTaskStateRef = useRef({}); // tracks {id: {completed, startTime, title}} for change detection
+  // Always-fresh refs so performObsidianSync (called from a long-lived interval)
+  // never reads stale task state from a closed-over render.
+  const obsidianTasksRef = useRef([]);
+  const obsidianInboxRef = useRef([]);
+
+  // Persist Obsidian config
+  useEffect(() => {
+    if (obsidianConfig) {
+      localStorage.setItem('day-planner-obsidian-config', JSON.stringify(obsidianConfig));
+    } else {
+      localStorage.removeItem('day-planner-obsidian-config');
+    }
+  }, [obsidianConfig]);
+
+  return {
+    obsidianConfig, setObsidianConfig,
+    obsidianSyncStatus, setObsidianSyncStatus,
+    obsidianLastSynced, setObsidianLastSynced,
+    obsidianVaultHandleRef,
+    obsidianSyncInProgressRef,
+    obsidianPrevTaskStateRef,
+    obsidianTasksRef,
+    obsidianInboxRef,
+  };
+};
+
+export default useObsidian;


### PR DESCRIPTION
## Summary

- Extracts Obsidian integration state and refs from `App.jsx` into a dedicated `useObsidian` hook
- Moves `obsidianConfig`, `obsidianSyncStatus`, `obsidianLastSynced` (useState) and `obsidianVaultHandleRef`, `obsidianSyncInProgressRef`, `obsidianPrevTaskStateRef`, `obsidianTasksRef`, `obsidianInboxRef` (useRef) into the hook
- Moves the `obsidianConfig` persist effect into the hook
- All sync effects and functions (`performObsidianSync`, `loadWikiNote`, `saveWikiNote`) remain in `App.jsx` as they depend on app-level state

## Test plan

- [ ] Open Settings → Obsidian. Verify config fields load correctly
- [ ] Toggle enabled, reload — verify setting persists
- [ ] UI should render without errors (full sync requires a real vault)
- [ ] `npm run build` passes ✅

https://claude.ai/code/session_014Q2Dszu2C3S7wsMwEbTHPm