### PR TITLE
refactor: extract useCloudSync hook (Step 4.6)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,6 +42,7 @@ import useRoutines from './hooks/useRoutines.js';
 import useFocusMode from './hooks/useFocusMode.js';
 import useTrmnlSync from './hooks/useTrmnlSync.js';
 import useObsidian from './hooks/useObsidian.js';
+import useCloudSync from './hooks/useCloudSync.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -400,25 +401,22 @@ const DayPlanner = () => {
   const tagFilterBtnRef = useRef(null);
 
   // Cloud Sync state
-  const [cloudSyncConfig, setCloudSyncConfig] = useState(() => {
-    const saved = localStorage.getItem('day-planner-cloud-sync-config');
-    return saved ? JSON.parse(saved) : null;
-  });
-  const [cloudSyncStatus, setCloudSyncStatus] = useState('idle');
-  const [cloudSyncError, setCloudSyncError] = useState(null);
-  const [cloudSyncLastSynced, setCloudSyncLastSynced] = useState(() =>
-    localStorage.getItem('day-planner-cloud-sync-last-synced') || null
-  );
-  const cloudSyncDebounceRef = useRef(null);
-  const suppressCloudUploadRef = useRef(false);
-  const suppressTimestampRef = useRef(false);
-  const suppressClearPendingRef = useRef(false);
-  const cloudSyncInProgressRef = useRef(false);
-  const cloudSyncInitialDoneRef = useRef(false);
-  const cloudSyncDownloadRef = useRef(null);
-  const cloudSyncErrorCountRef = useRef(0); // consecutive download failures
-  const cloudSyncBackoffUntilRef = useRef(0); // timestamp: skip poll/visibility retries until this time
-  const [cloudSyncConflict, setCloudSyncConflict] = useState(null); // { remoteData, remoteModified }
+  const {
+    cloudSyncConfig, setCloudSyncConfig,
+    cloudSyncStatus, setCloudSyncStatus,
+    cloudSyncError, setCloudSyncError,
+    cloudSyncLastSynced, setCloudSyncLastSynced,
+    cloudSyncConflict, setCloudSyncConflict,
+    cloudSyncDebounceRef,
+    suppressCloudUploadRef,
+    suppressTimestampRef,
+    suppressClearPendingRef,
+    cloudSyncInProgressRef,
+    cloudSyncInitialDoneRef,
+    cloudSyncDownloadRef,
+    cloudSyncErrorCountRef,
+    cloudSyncBackoffUntilRef,
+  } = useCloudSync();
 
   // Daily Notes state — keyed by date string "YYYY-MM-DD" → { text, lastModified }
   const [dailyNotes, setDailyNotes] = useState(() => {
@@ -1239,15 +1237,6 @@ const DayPlanner = () => {
     }, 60 * 1000);
     return () => clearInterval(pollTimer);
   }, [cloudSyncConfig?.enabled]);
-
-  // Persist cloud sync config
-  useEffect(() => {
-    if (cloudSyncConfig) {
-      localStorage.setItem('day-planner-cloud-sync-config', JSON.stringify(cloudSyncConfig));
-    } else {
-      localStorage.removeItem('day-planner-cloud-sync-config');
-    }
-  }, [cloudSyncConfig]);
 
   // TRMNL auto-sync: push data when tasks/habits change
   // Debounce 10s to batch rapid edits, then throttle to at most once per 2 min.

--- a/src/hooks/useCloudSync.js
+++ b/src/hooks/useCloudSync.js
@@ -1,0 +1,51 @@
+import { useState, useRef, useEffect } from 'react';
+
+const useCloudSync = () => {
+  const [cloudSyncConfig, setCloudSyncConfig] = useState(() => {
+    const saved = localStorage.getItem('day-planner-cloud-sync-config');
+    return saved ? JSON.parse(saved) : null;
+  });
+  const [cloudSyncStatus, setCloudSyncStatus] = useState('idle');
+  const [cloudSyncError, setCloudSyncError] = useState(null);
+  const [cloudSyncLastSynced, setCloudSyncLastSynced] = useState(() =>
+    localStorage.getItem('day-planner-cloud-sync-last-synced') || null
+  );
+  const [cloudSyncConflict, setCloudSyncConflict] = useState(null); // { remoteData, remoteModified }
+  const cloudSyncDebounceRef = useRef(null);
+  const suppressCloudUploadRef = useRef(false);
+  const suppressTimestampRef = useRef(false);
+  const suppressClearPendingRef = useRef(false);
+  const cloudSyncInProgressRef = useRef(false);
+  const cloudSyncInitialDoneRef = useRef(false);
+  const cloudSyncDownloadRef = useRef(null);
+  const cloudSyncErrorCountRef = useRef(0); // consecutive download failures
+  const cloudSyncBackoffUntilRef = useRef(0); // timestamp: skip poll/visibility retries until this time
+
+  // Persist cloud sync config
+  useEffect(() => {
+    if (cloudSyncConfig) {
+      localStorage.setItem('day-planner-cloud-sync-config', JSON.stringify(cloudSyncConfig));
+    } else {
+      localStorage.removeItem('day-planner-cloud-sync-config');
+    }
+  }, [cloudSyncConfig]);
+
+  return {
+    cloudSyncConfig, setCloudSyncConfig,
+    cloudSyncStatus, setCloudSyncStatus,
+    cloudSyncError, setCloudSyncError,
+    cloudSyncLastSynced, setCloudSyncLastSynced,
+    cloudSyncConflict, setCloudSyncConflict,
+    cloudSyncDebounceRef,
+    suppressCloudUploadRef,
+    suppressTimestampRef,
+    suppressClearPendingRef,
+    cloudSyncInProgressRef,
+    cloudSyncInitialDoneRef,
+    cloudSyncDownloadRef,
+    cloudSyncErrorCountRef,
+    cloudSyncBackoffUntilRef,
+  };
+};
+
+export default useCloudSync;


### PR DESCRIPTION
## Summary

- Extracts cloud sync state and refs from `App.jsx` into a dedicated `useCloudSync` hook
- Moves `cloudSyncConfig`, `cloudSyncStatus`, `cloudSyncError`, `cloudSyncLastSynced`, `cloudSyncConflict` (useState) into the hook
- Moves all cloud-sync refs: `cloudSyncDebounceRef`, `suppressCloudUploadRef`, `suppressTimestampRef`, `suppressClearPendingRef`, `cloudSyncInProgressRef`, `cloudSyncInitialDoneRef`, `cloudSyncDownloadRef`, `cloudSyncErrorCountRef`, `cloudSyncBackoffUntilRef`
- Moves the `cloudSyncConfig` persist effect into the hook
- All sync functions (`cloudSyncUpload`, `cloudSyncDownload`) and their effects remain in `App.jsx` as they depend on app-level state

## Test plan

- [ ] Open Settings → Cloud Sync. Verify the config form loads correctly
- [ ] If configured, verify sync status indicator updates
- [ ] `npm run build` passes ✅

https://claude.ai/code/session_014Q2Dszu2C3S7wsMwEbTHPm