### PR TITLE
refactor: extract useBackup hook (Step 4.8)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,6 +44,7 @@ import useTrmnlSync from './hooks/useTrmnlSync.js';
 import useObsidian from './hooks/useObsidian.js';
 import useCloudSync from './hooks/useCloudSync.js';
 import useCalendarSync from './hooks/useCalendarSync.js';
+import useBackup from './hooks/useBackup.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -297,9 +298,11 @@ const DayPlanner = () => {
     const saved = localStorage.getItem('day-planner-calendar-url-auth');
     return saved ? JSON.parse(saved) : { username: '', password: '' };
   });
-  const [pendingBackupFile, setPendingBackupFile] = useState(null);
-  const [showRestoreConfirm, setShowRestoreConfirm] = useState(false);
-  const [showBackupMenu, setShowBackupMenu] = useState(false);
+  const {
+    pendingBackupFile, setPendingBackupFile,
+    showRestoreConfirm, setShowRestoreConfirm,
+    showBackupMenu, setShowBackupMenu,
+  } = useBackup();
   const { dailyContent, setDailyContent, contentRotation, setContentRotation, fetchAllDailyContent } = useDailyContent();
   const [dragPreviewTime, setDragPreviewTime] = useState(null);
   const [dragPreviewDate, setDragPreviewDate] = useState(null);

--- a/src/hooks/useBackup.js
+++ b/src/hooks/useBackup.js
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+const useBackup = () => {
+  const [pendingBackupFile, setPendingBackupFile] = useState(null);
+  const [showRestoreConfirm, setShowRestoreConfirm] = useState(false);
+  const [showBackupMenu, setShowBackupMenu] = useState(false);
+
+  return {
+    pendingBackupFile, setPendingBackupFile,
+    showRestoreConfirm, setShowRestoreConfirm,
+    showBackupMenu, setShowBackupMenu,
+  };
+};
+
+export default useBackup;


### PR DESCRIPTION
## Summary

- Extracts backup UI state from `App.jsx` into a dedicated `useBackup` hook
- Moves `pendingBackupFile`, `showRestoreConfirm`, `showBackupMenu` (all useState, no persist effects)
- Backup functions (`restoreFromBackup`, `downloadBackup`, etc.) remain in `App.jsx`

## Test plan

- [ ] Open the backup menu. Verify it opens correctly
- [ ] Verify download backup works
- [ ] Verify restore-from-file flow opens the confirm modal
- [ ] `npm run build` passes ✅

https://claude.ai/code/session_014Q2Dszu2C3S7wsMwEbTHPm