### PR TITLE
refactor: extract useGTDFrames hook (Step 4.9)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,6 +45,7 @@ import useObsidian from './hooks/useObsidian.js';
 import useCloudSync from './hooks/useCloudSync.js';
 import useCalendarSync from './hooks/useCalendarSync.js';
 import useBackup from './hooks/useBackup.js';
+import useGTDFrames from './hooks/useGTDFrames.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -616,31 +617,28 @@ const DayPlanner = () => {
   const voiceCanRecord = typeof MediaRecorder !== 'undefined' && typeof navigator !== 'undefined' && !!navigator.mediaDevices;
 
   // GTD Frames state
-  const [gtdFrames, setGtdFrames] = useState(() => {
-    try {
-      const saved = localStorage.getItem('day-planner-gtd-frames');
-      return saved ? JSON.parse(saved) : [];
-    } catch { return []; }
-  });
-  const [showFramesModal, setShowFramesModal] = useState(false);
-  const [framesModalTab, setFramesModalTab] = useState('frames'); // 'frames' | 'schedule'
-  const [editingFrame, setEditingFrame] = useState(null); // frame object being edited, or 'new' for create
-  const [smartScheduleResults, setSmartScheduleResults] = useState(null); // AI scheduling results
-  const [smartScheduleLoading, setSmartScheduleLoading] = useState(false);
-  const [smartScheduleError, setSmartScheduleError] = useState('');
-  const [smartScheduleAccepted, setSmartScheduleAccepted] = useState({}); // { taskId: true/false }
-  const [showRescheduleModal, setShowRescheduleModal] = useState(false);
-  const [rescheduleResults, setRescheduleResults] = useState(null);
-  const [rescheduleLoading, setRescheduleLoading] = useState(false);
-  const [rescheduleError, setRescheduleError] = useState('');
-  const [rescheduleAccepted, setRescheduleAccepted] = useState({});
-  const [frameContextMenu, setFrameContextMenu] = useState(null); // { x, y, frameId, dateStr }
+  const {
+    gtdFrames, setGtdFrames,
+    showFramesModal, setShowFramesModal,
+    framesModalTab, setFramesModalTab,
+    editingFrame, setEditingFrame,
+    smartScheduleResults, setSmartScheduleResults,
+    smartScheduleLoading, setSmartScheduleLoading,
+    smartScheduleError, setSmartScheduleError,
+    smartScheduleAccepted, setSmartScheduleAccepted,
+    showRescheduleModal, setShowRescheduleModal,
+    rescheduleResults, setRescheduleResults,
+    rescheduleLoading, setRescheduleLoading,
+    rescheduleError, setRescheduleError,
+    rescheduleAccepted, setRescheduleAccepted,
+    frameContextMenu, setFrameContextMenu,
+    quickAddFrameModal, setQuickAddFrameModal,
+    frameAdjustModal, setFrameAdjustModal,
+    frameAdjustTimeField, setFrameAdjustTimeField,
+    frameScheduleModal, setFrameScheduleModal,
+  } = useGTDFrames();
   const [taskContextMenu, setTaskContextMenu] = useState(null); // { x, y, taskId, isRecurring, isImported, isAllDay, dateStr }
   const [timelineContextMenu, setTimelineContextMenu] = useState(null); // { x, y, dateStr, timeMinutes }
-  const [quickAddFrameModal, setQuickAddFrameModal] = useState(null); // { dateStr, startMinutes, endMinutes }
-  const [frameAdjustModal, setFrameAdjustModal] = useState(null); // { frameId, dateStr, start, end }
-  const [frameAdjustTimeField, setFrameAdjustTimeField] = useState(null); // 'start' | 'end' | null
-  const [frameScheduleModal, setFrameScheduleModal] = useState(null); // { frameId, dateStr, frame }
 
   // Incomplete tasks modal
   const [showIncompleteTasks, setShowIncompleteTasks] = useState(null); // null | 'today' | 'allTime'

--- a/src/hooks/useGTDFrames.js
+++ b/src/hooks/useGTDFrames.js
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+const useGTDFrames = () => {
+  const [gtdFrames, setGtdFrames] = useState(() => {
+    try {
+      const saved = localStorage.getItem('day-planner-gtd-frames');
+      return saved ? JSON.parse(saved) : [];
+    } catch { return []; }
+  });
+  const [showFramesModal, setShowFramesModal] = useState(false);
+  const [framesModalTab, setFramesModalTab] = useState('frames'); // 'frames' | 'schedule'
+  const [editingFrame, setEditingFrame] = useState(null); // frame object being edited, or 'new' for create
+  const [smartScheduleResults, setSmartScheduleResults] = useState(null); // AI scheduling results
+  const [smartScheduleLoading, setSmartScheduleLoading] = useState(false);
+  const [smartScheduleError, setSmartScheduleError] = useState('');
+  const [smartScheduleAccepted, setSmartScheduleAccepted] = useState({}); // { taskId: true/false }
+  const [showRescheduleModal, setShowRescheduleModal] = useState(false);
+  const [rescheduleResults, setRescheduleResults] = useState(null);
+  const [rescheduleLoading, setRescheduleLoading] = useState(false);
+  const [rescheduleError, setRescheduleError] = useState('');
+  const [rescheduleAccepted, setRescheduleAccepted] = useState({});
+  const [frameContextMenu, setFrameContextMenu] = useState(null); // { x, y, frameId, dateStr }
+  const [quickAddFrameModal, setQuickAddFrameModal] = useState(null); // { dateStr, startMinutes, endMinutes }
+  const [frameAdjustModal, setFrameAdjustModal] = useState(null); // { frameId, dateStr, start, end }
+  const [frameAdjustTimeField, setFrameAdjustTimeField] = useState(null); // 'start' | 'end' | null
+  const [frameScheduleModal, setFrameScheduleModal] = useState(null); // { frameId, dateStr, frame }
+
+  return {
+    gtdFrames, setGtdFrames,
+    showFramesModal, setShowFramesModal,
+    framesModalTab, setFramesModalTab,
+    editingFrame, setEditingFrame,
+    smartScheduleResults, setSmartScheduleResults,
+    smartScheduleLoading, setSmartScheduleLoading,
+    smartScheduleError, setSmartScheduleError,
+    smartScheduleAccepted, setSmartScheduleAccepted,
+    showRescheduleModal, setShowRescheduleModal,
+    rescheduleResults, setRescheduleResults,
+    rescheduleLoading, setRescheduleLoading,
+    rescheduleError, setRescheduleError,
+    rescheduleAccepted, setRescheduleAccepted,
+    frameContextMenu, setFrameContextMenu,
+    quickAddFrameModal, setQuickAddFrameModal,
+    frameAdjustModal, setFrameAdjustModal,
+    frameAdjustTimeField, setFrameAdjustTimeField,
+    frameScheduleModal, setFrameScheduleModal,
+  };
+};
+
+export default useGTDFrames;


### PR DESCRIPTION
## Summary

- Extracts GTD frames state from `App.jsx` into a dedicated `useGTDFrames` hook
- Moves `gtdFrames` (frame definitions) plus all frames modal state: `showFramesModal`, `framesModalTab`, `editingFrame`, `smartScheduleResults/Loading/Error/Accepted`, `showRescheduleModal`, `rescheduleResults/Loading/Error/Accepted`, `frameContextMenu`, `quickAddFrameModal`, `frameAdjustModal`, `frameAdjustTimeField`, `frameScheduleModal`
- `taskContextMenu` and `timelineContextMenu` intentionally left in App.jsx — they are task/timeline specific, not frame-specific
- `gtdFrames` is accessible in App.jsx scope via hook destructuring, so `cloudSyncUpload` continues to reference it without any additional wiring (resolves the ⚠️ noted in the plan)

## Test plan

- [ ] Open GTD Frames modal. Verify it renders
- [ ] Create a frame, edit it, delete it
- [ ] Verify frames appear on the timeline correctly
- [ ] `npm run build` passes ✅

https://claude.ai/code/session_014Q2Dszu2C3S7wsMwEbTHPm