### PR TITLE
fix: improve transcription error message for custom providers (OpenRouter)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25558,7 +25558,11 @@ const DayPlanner = () => {
                   )}
 
                   {voiceParseError && voiceMicError !== 'error' && (
-                    <p className="text-xs text-amber-500 mt-2">AI parsing error: {voiceParseError}. Added as plain task.</p>
+                    <p className="text-xs text-amber-500 mt-2">
+                      {voiceManualMode
+                        ? voiceParseError
+                        : `AI parsing error: ${voiceParseError}. Added as plain task.`}
+                    </p>
                   )}
                 </>
               ) : (

--- a/src/ai.js
+++ b/src/ai.js
@@ -274,7 +274,10 @@ async function _aiTranscribe(audioBlob, config) {
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
-        throw new Error(err.error?.message || `Transcription API error: ${res.status}`);
+        const hint = provider === 'custom' && res.status >= 500
+          ? ' (your custom endpoint may not support audio transcription — try OpenAI or Gemini directly)'
+          : '';
+        throw new Error(err.error?.message || `Transcription API error: ${res.status}${hint}`);
       }
       const data = await res.json();
       return data.text;


### PR DESCRIPTION
## Summary

- Adds a clear hint to the 500 error when a `custom` provider doesn't support the Whisper transcription endpoint (e.g. OpenRouter): *"your custom endpoint may not support audio transcription — try OpenAI or Gemini directly"*
- Fixes misleading "Added as plain task" UI label: it was shown even for transcription failures where the user was dropped into manual text-input mode (no task was actually added). Now shows the raw error message in that case.

## Root cause

OpenRouter (and similar chat-completion proxies configured as `custom` provider) don't implement the OpenAI Whisper `/audio/transcriptions` endpoint, so they return 500. Voice input works fine with a direct OpenAI key.

## Test plan

- [ ] Configure a custom provider (e.g. OpenRouter). Attempt voice recording. Verify the error message now reads "Transcription API error: 500 (your custom endpoint may not support audio transcription — try OpenAI or Gemini directly)" instead of the generic 500 message
- [ ] Verify the "Added as plain task" text is NOT shown when in manual fallback mode after transcription failure
- [ ] Verify AI parse failures (where transcript was added as plain task) still show "Added as plain task" correctly
- [ ] `npm run build` passes ✅

https://claude.ai/code/session_014Q2Dszu2C3S7wsMwEbTHPm