### PR TITLE
refactor: extract useNavigation hook (Step 5.1)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,6 +47,7 @@ import useCalendarSync from './hooks/useCalendarSync.js';
 import useBackup from './hooks/useBackup.js';
 import useGTDFrames from './hooks/useGTDFrames.js';
 import useVoiceAI from './hooks/useVoiceAI.js';
+import useNavigation from './hooks/useNavigation.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -667,6 +668,17 @@ const DayPlanner = () => {
   const [spotlightQuery, setSpotlightQuery] = useState('');
   const [spotlightSelectedIndex, setSpotlightSelectedIndex] = useState(0);
   const spotlightInputRef = useRef(null);
+
+  const { changeDate, goToToday, goToDate, handleSpotlightSelect } = useNavigation({
+    visibleDays,
+    setSelectedDate,
+    setShowMonthView,
+    setShowSpotlight,
+    isMobile,
+    setMobileActiveTab,
+    setTabletActiveTab,
+    calendarRef,
+  });
 
   // Show all 24 hours (full day) - scrollable
   const hours = Array.from({ length: 24 }, (_, i) => i);
@@ -4073,34 +4085,6 @@ const DayPlanner = () => {
     playUISound('crumple');
   };
 
-  const changeDate = (direction) => {
-    // Move by the number of visible days (1, 2, or 3) in the given direction
-    const newDate = new Date(selectedDate);
-    newDate.setDate(newDate.getDate() + (direction * visibleDays));
-    newDate.setHours(12, 0, 0, 0); // Maintain noon to avoid timezone issues
-    setSelectedDate(newDate);
-  };
-
-  const goToToday = () => {
-    const today = new Date();
-    today.setHours(12, 0, 0, 0); // Set to noon to avoid timezone issues
-    setSelectedDate(today);
-  };
-
-  const goToDate = (date) => {
-    let newDate;
-    if (typeof date === 'string') {
-      // Parse date strings as local time to avoid UTC midnight → previous day shift
-      const [y, m, d] = date.split('-').map(Number);
-      newDate = new Date(y, m - 1, d, 12, 0, 0, 0);
-    } else {
-      newDate = new Date(date);
-      newDate.setHours(12, 0, 0, 0);
-    }
-    setSelectedDate(newDate);
-    setShowMonthView(false);
-  };
-
   const changeViewedMonth = (delta) => {
     setViewedMonth(prev => {
       const newMonth = new Date(prev);
@@ -4108,49 +4092,6 @@ const DayPlanner = () => {
       newMonth.setMonth(newMonth.getMonth() + delta);
       return newMonth;
     });
-  };
-
-  const handleSpotlightSelect = (result) => {
-    setShowSpotlight(false);
-    const { task, source } = result;
-
-    const scrollAndHighlight = (selector, delay = 300) => {
-      setTimeout(() => {
-        const el = document.querySelector(selector);
-        if (el && calendarRef.current) {
-          const container = calendarRef.current;
-          const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
-          const scrollTarget = Math.max(0, elTop - container.clientHeight / 2 + el.offsetHeight / 2);
-          container.scrollTo({ top: scrollTarget, behavior: 'smooth' });
-          el.classList.add('ring-2', 'ring-blue-400');
-          setTimeout(() => el.classList.remove('ring-2', 'ring-blue-400'), 2000);
-        }
-      }, delay);
-    };
-
-    if (source === 'scheduled') {
-      if (isMobile) {
-        setMobileActiveTab('timeline');
-      }
-      goToDate(task.date);
-      scrollAndHighlight(`[data-task-id="${task.id}"]`);
-    } else if (source === 'inbox') {
-      if (isMobile) {
-        setMobileActiveTab('inbox');
-      } else {
-        setTabletActiveTab('inbox');
-      }
-      scrollAndHighlight(`[data-task-id="${task.id}"]`);
-    } else if (source === 'recurring') {
-      const date = task.startDate || dateToString(new Date());
-      if (isMobile) {
-        setMobileActiveTab('timeline');
-      }
-      goToDate(date);
-    } else if (source === 'deleted') {
-      // Recycle bin is accessed via FAB — just highlight if visible
-      scrollAndHighlight(`[data-task-id="bin-${task.id}"]`);
-    }
   };
 
   const getMonthDays = () => {

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -1,0 +1,85 @@
+import { useCallback } from 'react';
+import { dateToString } from '../utils/taskUtils.js';
+
+export default function useNavigation({
+  visibleDays,
+  setSelectedDate,
+  setShowMonthView,
+  setShowSpotlight,
+  isMobile,
+  setMobileActiveTab,
+  setTabletActiveTab,
+  calendarRef,
+}) {
+  const changeDate = useCallback((direction) => {
+    setSelectedDate(prev => {
+      const newDate = new Date(prev);
+      newDate.setDate(newDate.getDate() + (direction * visibleDays));
+      newDate.setHours(12, 0, 0, 0);
+      return newDate;
+    });
+  }, [setSelectedDate, visibleDays]);
+
+  const goToToday = useCallback(() => {
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    setSelectedDate(today);
+  }, [setSelectedDate]);
+
+  const goToDate = useCallback((date) => {
+    let newDate;
+    if (typeof date === 'string') {
+      const [y, m, d] = date.split('-').map(Number);
+      newDate = new Date(y, m - 1, d, 12, 0, 0, 0);
+    } else {
+      newDate = new Date(date);
+      newDate.setHours(12, 0, 0, 0);
+    }
+    setSelectedDate(newDate);
+    setShowMonthView(false);
+  }, [setSelectedDate, setShowMonthView]);
+
+  const handleSpotlightSelect = useCallback((result) => {
+    setShowSpotlight(false);
+    const { task, source } = result;
+
+    const scrollAndHighlight = (selector, delay = 300) => {
+      setTimeout(() => {
+        const el = document.querySelector(selector);
+        if (el && calendarRef.current) {
+          const container = calendarRef.current;
+          const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+          const scrollTarget = Math.max(0, elTop - container.clientHeight / 2 + el.offsetHeight / 2);
+          container.scrollTo({ top: scrollTarget, behavior: 'smooth' });
+          el.classList.add('ring-2', 'ring-blue-400');
+          setTimeout(() => el.classList.remove('ring-2', 'ring-blue-400'), 2000);
+        }
+      }, delay);
+    };
+
+    if (source === 'scheduled') {
+      if (isMobile) {
+        setMobileActiveTab('timeline');
+      }
+      goToDate(task.date);
+      scrollAndHighlight(`[data-task-id="${task.id}"]`);
+    } else if (source === 'inbox') {
+      if (isMobile) {
+        setMobileActiveTab('inbox');
+      } else {
+        setTabletActiveTab('inbox');
+      }
+      scrollAndHighlight(`[data-task-id="${task.id}"]`);
+    } else if (source === 'recurring') {
+      const date = task.startDate || dateToString(new Date());
+      if (isMobile) {
+        setMobileActiveTab('timeline');
+      }
+      goToDate(date);
+    } else if (source === 'deleted') {
+      scrollAndHighlight(`[data-task-id="bin-${task.id}"]`);
+    }
+  }, [setShowSpotlight, isMobile, setMobileActiveTab, setTabletActiveTab, calendarRef, goToDate]);
+
+  return { changeDate, goToToday, goToDate, handleSpotlightSelect };
+}


### PR DESCRIPTION
## Summary

- Extracts `useNavigation` hook to `src/hooks/useNavigation.js`
- Moves `changeDate`, `goToToday`, `goToDate`, and `handleSpotlightSelect` out of `App.jsx`
- `changeDate` rewritten to use functional `setSelectedDate` updater (no `selectedDate` closure needed)
- Hook receives: `visibleDays`, `setSelectedDate`, `setShowMonthView`, `setShowSpotlight`, `isMobile`, `setMobileActiveTab`, `setTabletActiveTab`, `calendarRef`
- `selectedDate` state remains in `App.jsx` per plan guidance

## Test plan

- [ ] Click forward/back date arrows — verify correct date is shown
- [ ] Open spotlight (Cmd/Ctrl+K), click a scheduled task result — verify date jumps to that task's date
- [ ] Open spotlight, click an inbox result — verify inbox tab is activated
- [ ] `npm run build` passes ✓