### PR TITLE
fix: restore localDateStr default parameter lost during taskUtils extraction

### DIFF
--- a/src/utils/taskUtils.js
+++ b/src/utils/taskUtils.js
@@ -8,8 +8,10 @@ export const dateToString = (date) => {
   return `${year}-${month}-${day}`;
 };
 
-// Alias used by top-level useState initialisers (same implementation).
-export const localDateStr = dateToString;
+// Zero-arg variant: localDateStr() returns today's YYYY-MM-DD string.
+// The original App.jsx defined this with a default parameter (d = new Date()),
+// so callers throughout the codebase rely on being able to call it with no args.
+export const localDateStr = (d = new Date()) => dateToString(d);
 
 // Extract #hashtags from a task title (tags must start with a letter).
 export const extractTags = (title) => {


### PR DESCRIPTION
## Root Cause

The original `App.jsx` defined `localDateStr` with a default parameter:
```js
const localDateStr = (d = new Date()) => ...
```

When step 1.5 extracted it to `taskUtils.js`, it was changed to a plain alias:
```js
export const localDateStr = dateToString;
```

This lost the default parameter, so any call to `localDateStr()` with no arguments now passes `undefined` to `dateToString`, throwing:
```
TypeError: Cannot read properties of undefined (reading 'getFullYear')
```

## Affected callers (6 sites)
- `App.jsx:8212` — `dismissMorningGlance` → `localDateStr()`
- `App.jsx:8292` — `dismissEveningGlance` → `localDateStr()`
- `useVoiceAI.js:51,63,74,81` — various date comparison helpers → `localDateStr()`

## Fix

Restore the default parameter in `taskUtils.js` so zero-arg calls work as originally intended:
```js
export const localDateStr = (d = new Date()) => dateToString(d);
```