### PR TITLE
refactor: extract useConflictDetection hook (Step 5.6)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -52,6 +52,7 @@ import useStats from './hooks/useStats.js';
 import useComputedViews from './hooks/useComputedViews.js';
 import useTaskDerived from './hooks/useTaskDerived.js';
 import useDeadlinePriority from './hooks/useDeadlinePriority.js';
+import useConflictDetection from './hooks/useConflictDetection.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -237,7 +238,6 @@ const DayPlanner = () => {
   const [aiSubtasksLoadingForTask, setAiSubtasksLoadingForTask] = useState(null); // taskId while loading
   const [draggedTask, setDraggedTask] = useState(null);
   const [dragSource, setDragSource] = useState(null);
-  const [conflicts, setConflicts] = useState([]);
   const [minimizedSections, setMinimizedSections] = useState(() => {
     const saved = localStorage.getItem('minimizedSections');
     return saved ? JSON.parse(saved) : {
@@ -728,6 +728,12 @@ const DayPlanner = () => {
     onboardingProgress,
     setOnboardingProgress,
   });
+  const { conflicts, checkConflicts } = useConflictDetection({
+    tasks,
+    recurringTasks,
+    selectedDate,
+    dataLoaded,
+  });
   voiceAllTagsRef.current = allTags;
 
   // Show all 24 hours (full day) - scrollable
@@ -1163,11 +1169,6 @@ const DayPlanner = () => {
       });
     }
   }, [dataLoaded, tasks, unscheduledTasks, recycleBin, taskCalendarUrl, syncUrl, syncRetentionDays, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, removedTodayRoutineIds, habits, habitLogs, habitsEnabled, routinesEnabled, gtdFrames]);
-
-  // Re-check conflicts when date or tasks change
-  useEffect(() => {
-    if (dataLoaded) checkConflicts();
-  }, [selectedDate, tasks, dataLoaded]);
 
   // Cloud sync: debounced upload on data changes
   useEffect(() => {
@@ -1811,47 +1812,6 @@ const DayPlanner = () => {
     const hours = Math.floor(minutes / 60);
     const mins = minutes % 60;
     return `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}`;
-  };
-
-  const checkConflicts = () => {
-    const dateStr = dateToString(selectedDate);
-    // Exclude all-day tasks and imported events (not task calendar) from conflict detection
-    // Include recurring task instances for this date
-    const recurringForDate = [];
-    for (const template of recurringTasks) {
-      if (template.isAllDay) continue;
-      const occs = getOccurrencesInRange(template, dateStr, dateStr);
-      for (const ds of occs) {
-        const exception = template.exceptions?.[ds];
-        if (exception?.deleted) continue;
-        recurringForDate.push({
-          id: `recurring-${template.id}-${ds}`,
-          startTime: exception?.startTime ?? template.startTime,
-          duration: exception?.duration ?? template.duration,
-          isAllDay: false,
-        });
-      }
-    }
-    const todayTasks = [...tasks.filter(t => t.date === dateStr && !t.isAllDay && (!t.imported || t.isTaskCalendar)), ...recurringForDate];
-    const newConflicts = [];
-
-    for (let i = 0; i < todayTasks.length; i++) {
-      for (let j = i + 1; j < todayTasks.length; j++) {
-        const task1 = todayTasks[i];
-        const task2 = todayTasks[j];
-        const start1 = timeToMinutes(task1.startTime);
-        const end1 = start1 + task1.duration;
-        const start2 = timeToMinutes(task2.startTime);
-        const end2 = start2 + task2.duration;
-
-        if ((start1 < end2 && end1 > start2)) {
-          if (!newConflicts.find(c => c.includes(task1.id) && c.includes(task2.id))) {
-            newConflicts.push([task1.id, task2.id, Math.min(start1, start2)]);
-          }
-        }
-      }
-    }
-    setConflicts(newConflicts);
   };
 
   // Check if a task placement would conflict with imported calendar events or reminders

--- a/src/hooks/useConflictDetection.js
+++ b/src/hooks/useConflictDetection.js
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+import { dateToString } from '../utils/taskUtils.js';
+import { getOccurrencesInRange } from '../utils/recurrenceEngine.js';
+
+const timeToMinutes = (time) => {
+  const [hours, minutes] = time.split(':').map(Number);
+  return hours * 60 + minutes;
+};
+
+export default function useConflictDetection({ tasks, recurringTasks, selectedDate, dataLoaded }) {
+  const [conflicts, setConflicts] = useState([]);
+
+  const checkConflicts = () => {
+    const dateStr = dateToString(selectedDate);
+    // Exclude all-day tasks and imported events (not task calendar) from conflict detection
+    // Include recurring task instances for this date
+    const recurringForDate = [];
+    for (const template of recurringTasks) {
+      if (template.isAllDay) continue;
+      const occs = getOccurrencesInRange(template, dateStr, dateStr);
+      for (const ds of occs) {
+        const exception = template.exceptions?.[ds];
+        if (exception?.deleted) continue;
+        recurringForDate.push({
+          id: `recurring-${template.id}-${ds}`,
+          startTime: exception?.startTime ?? template.startTime,
+          duration: exception?.duration ?? template.duration,
+          isAllDay: false,
+        });
+      }
+    }
+    const todayTasks = [...tasks.filter(t => t.date === dateStr && !t.isAllDay && (!t.imported || t.isTaskCalendar)), ...recurringForDate];
+    const newConflicts = [];
+
+    for (let i = 0; i < todayTasks.length; i++) {
+      for (let j = i + 1; j < todayTasks.length; j++) {
+        const task1 = todayTasks[i];
+        const task2 = todayTasks[j];
+        const start1 = timeToMinutes(task1.startTime);
+        const end1 = start1 + task1.duration;
+        const start2 = timeToMinutes(task2.startTime);
+        const end2 = start2 + task2.duration;
+
+        if ((start1 < end2 && end1 > start2)) {
+          if (!newConflicts.find(c => c.includes(task1.id) && c.includes(task2.id))) {
+            newConflicts.push([task1.id, task2.id, Math.min(start1, start2)]);
+          }
+        }
+      }
+    }
+    setConflicts(newConflicts);
+  };
+
+  // Re-check conflicts when date or tasks change
+  useEffect(() => {
+    if (dataLoaded) checkConflicts();
+  }, [selectedDate, tasks, dataLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { conflicts, checkConflicts };
+}


### PR DESCRIPTION
## Summary

- Extracts time-conflict detection logic from `App.jsx` into `src/hooks/useConflictDetection.js`
- Moves `conflicts` state into the hook
- Moves `checkConflicts` function (pairwise overlap scan for the selected date, including recurring instances) into the hook
- Moves the re-check `useEffect` (`[selectedDate, tasks, dataLoaded]`) into the hook
- `checkConflicts` is still returned so the saveData effect in App.jsx can trigger it on any data save
- Hook accepts `{ tasks, recurringTasks, selectedDate, dataLoaded }` and returns `{ conflicts, checkConflicts }`

## Test plan

- [ ] Create two tasks at the same time on the timeline — verify the conflict warning indicator appears
- [ ] Resolve the overlap (move one task) — verify the warning disappears
- [ ] Navigate to a different date — verify conflicts are re-evaluated for the new date
- [ ] Create overlapping recurring task instances — verify they are also detected