### PR TITLE
refactor: extract useMobileEdit hook (Step 5.13)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,7 @@ import useTaskActions from './hooks/useTaskActions.js';
 import useRecycleBin from './hooks/useRecycleBin.js';
 import useReminderEngine from './hooks/useReminderEngine.js';
 import useReminders from './hooks/useReminders.js';
+import useMobileEdit from './hooks/useMobileEdit.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -333,8 +334,10 @@ const DayPlanner = () => {
   const [mobileActiveTab, setMobileActiveTab] = useState('dayglance');
   const [mobileWelcomeStep, setMobileWelcomeStep] = useState(0);
   const [desktopWelcomeStep, setDesktopWelcomeStep] = useState(0);
-  const [mobileEditingTask, setMobileEditingTask] = useState(null);
-  const [mobileEditIsInbox, setMobileEditIsInbox] = useState(false);
+  const {
+    mobileEditingTask, setMobileEditingTask,
+    mobileEditIsInbox, setMobileEditIsInbox,
+  } = useMobileEdit();
   const [mobileEditingNativeEvent, setMobileEditingNativeEvent] = useState(null);
   const [nativeCalendarKey, setNativeCalendarKey] = useState(0);
   const [mobileSettingsView, setMobileSettingsView] = useState('main');

--- a/src/hooks/useMobileEdit.js
+++ b/src/hooks/useMobileEdit.js
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+export default function useMobileEdit() {
+  const [mobileEditingTask, setMobileEditingTask] = useState(null);
+  const [mobileEditIsInbox, setMobileEditIsInbox] = useState(false);
+
+  return {
+    mobileEditingTask,
+    setMobileEditingTask,
+    mobileEditIsInbox,
+    setMobileEditIsInbox,
+  };
+}


### PR DESCRIPTION
## Summary

- Creates `src/hooks/useMobileEdit.js` owning the mobile task editing flow state
- Moves `mobileEditingTask` and `mobileEditIsInbox` out of App.jsx into the hook
- All values returned and destructured in App.jsx — no JSX changes required

## Test plan

- [ ] On a mobile viewport, tap a scheduled task to open the mobile edit view
- [ ] Change the task title and save — verify the change persists
- [ ] Tap an inbox task to open mobile edit view — verify `mobileEditIsInbox` is set correctly (inbox-specific fields shown)
- [ ] Cancel/close the edit view — verify both state values reset to `null`/`false`

https://claude.ai/code/session_01VpY46fc3uxDSgqT1Un7mMc