### PR TITLE
refactor: useDragDrop step 2 — drag/hover state and core refs (Step 5.14.2)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -243,8 +243,7 @@ const DayPlanner = () => {
   const [frameNudgeError, setFrameNudgeError] = useState('');
   const [frameNudgeDismissedKey, setFrameNudgeDismissedKey] = useState(''); // key = todayStr-frameId
   const [aiSubtasksLoadingForTask, setAiSubtasksLoadingForTask] = useState(null); // taskId while loading
-  const [draggedTask, setDraggedTask] = useState(null);
-  const [dragSource, setDragSource] = useState(null);
+
   const [minimizedSections, setMinimizedSections] = useState(() => {
     const saved = localStorage.getItem('minimizedSections');
     return saved ? JSON.parse(saved) : {
@@ -312,14 +311,7 @@ const DayPlanner = () => {
     showBackupMenu, setShowBackupMenu,
   } = useBackup();
   const { dailyContent, setDailyContent, contentRotation, setContentRotation, fetchAllDailyContent } = useDailyContent();
-  const [dragPreviewTime, setDragPreviewTime] = useState(null);
-  const [dragPreviewDate, setDragPreviewDate] = useState(null);
-  const [dragOverAllDay, setDragOverAllDay] = useState(null);
-  const [dragOverInbox, setDragOverInbox] = useState(false);
-  const [dragOverRecycleBin, setDragOverRecycleBin] = useState(false);
-  const [hoverPreviewTime, setHoverPreviewTime] = useState(null);
-  const [hoverPreviewDate, setHoverPreviewDate] = useState(null);
-  const [isResizing, setIsResizing] = useState(false);
+
   const [inboxPriorityFilter, setInboxPriorityFilter] = useState(() => {
     const saved = localStorage.getItem('inboxPriorityFilter');
     return saved ? JSON.parse(saved) : 0;
@@ -357,9 +349,33 @@ const DayPlanner = () => {
   const suppressScrollAwayRef = useRef(false); // suppress scroll-away detection during programmatic scrolls
   const timeGridRef = useRef(null);
   const currentTimeRef = useRef(null);
-  const autoScrollInterval = useRef(null); // For drag auto-scroll
-  const frameResizingRef = useRef(false); // Suppress click-to-add-task after frame resize drag
-  const stickyHeaderRef = useRef(null); // For measuring sticky header height during drag
+
+  // useDragDrop is called here — before any useEffect that references its state —
+  // to avoid TDZ errors in dependency arrays (e.g. hoverPreviewTime at line ~2632).
+  const {
+    // state
+    draggedTask, setDraggedTask,
+    dragSource, setDragSource,
+    dragPreviewTime, setDragPreviewTime,
+    dragPreviewDate, setDragPreviewDate,
+    dragOverAllDay, setDragOverAllDay,
+    dragOverInbox, setDragOverInbox,
+    dragOverRecycleBin, setDragOverRecycleBin,
+    hoverPreviewTime, setHoverPreviewTime,
+    hoverPreviewDate, setHoverPreviewDate,
+    isResizing, setIsResizing,
+    // refs
+    autoScrollInterval,
+    frameResizingRef,
+    stickyHeaderRef,
+    // position helpers
+    getHourHeight,
+    minutesToPosition,
+    positionToMinutes,
+    durationToHeight,
+    calculateTaskPosition,
+  } = useDragDrop({ calendarRef, timeGridRef });
+
   // Mobile swipe gesture refs
   const swipeTouchStartX = useRef(0);
   const swipeTouchStartY = useRef(0);
@@ -7507,14 +7523,6 @@ const DayPlanner = () => {
     exitFocusMode,
     playFocusSound,
   });
-
-  const {
-    getHourHeight,
-    minutesToPosition,
-    positionToMinutes,
-    durationToHeight,
-    calculateTaskPosition,
-  } = useDragDrop({ calendarRef, timeGridRef });
 
   // ── Native Android widget snapshot sync ──────────────────────────────────
   // Pushes a rich snapshot of today's agenda to the native widget via NativeBridge.

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -1,3 +1,5 @@
+import { useState, useRef } from 'react';
+
 // Pure utility used by calculateTaskPosition
 const timeToMinutes = (time) => {
   const [hours, minutes] = time.split(':').map(Number);
@@ -5,6 +7,21 @@ const timeToMinutes = (time) => {
 };
 
 export default function useDragDrop({ calendarRef, timeGridRef }) {
+  const [draggedTask, setDraggedTask] = useState(null);
+  const [dragSource, setDragSource] = useState(null);
+  const [dragPreviewTime, setDragPreviewTime] = useState(null);
+  const [dragPreviewDate, setDragPreviewDate] = useState(null);
+  const [dragOverAllDay, setDragOverAllDay] = useState(null);
+  const [dragOverInbox, setDragOverInbox] = useState(false);
+  const [dragOverRecycleBin, setDragOverRecycleBin] = useState(false);
+  const [hoverPreviewTime, setHoverPreviewTime] = useState(null);
+  const [hoverPreviewDate, setHoverPreviewDate] = useState(null);
+  const [isResizing, setIsResizing] = useState(false);
+
+  const autoScrollInterval = useRef(null); // For drag auto-scroll
+  const frameResizingRef = useRef(false); // Suppress click-to-add-task after frame resize drag
+  const stickyHeaderRef = useRef(null); // For measuring sticky header height during drag
+
   // Measure actual hour row height from DOM (handles sub-pixel borders on high-DPI screens)
   const getHourHeight = () => {
     if (timeGridRef.current && timeGridRef.current.children.length > 2) {
@@ -75,6 +92,22 @@ export default function useDragDrop({ calendarRef, timeGridRef }) {
   };
 
   return {
+    // state
+    draggedTask, setDraggedTask,
+    dragSource, setDragSource,
+    dragPreviewTime, setDragPreviewTime,
+    dragPreviewDate, setDragPreviewDate,
+    dragOverAllDay, setDragOverAllDay,
+    dragOverInbox, setDragOverInbox,
+    dragOverRecycleBin, setDragOverRecycleBin,
+    hoverPreviewTime, setHoverPreviewTime,
+    hoverPreviewDate, setHoverPreviewDate,
+    isResizing, setIsResizing,
+    // refs
+    autoScrollInterval,
+    frameResizingRef,
+    stickyHeaderRef,
+    // position helpers
     getHourHeight,
     minutesToPosition,
     positionToMinutes,


### PR DESCRIPTION
## Summary

- Moves 10 `useState` and 3 `useRef` declarations out of `App.jsx` into `useDragDrop`
- State: `draggedTask`, `dragSource`, `dragPreviewTime`, `dragPreviewDate`, `dragOverAllDay`, `dragOverInbox`, `dragOverRecycleBin`, `hoverPreviewTime`, `hoverPreviewDate`, `isResizing`
- Refs: `autoScrollInterval`, `frameResizingRef`, `stickyHeaderRef`
- All destructured back into `App.jsx` — zero behaviour change

## Test plan

- [ ] `npm run build` passes
- [ ] App loads without errors
- [ ] Hover the mouse over the calendar timeline — the blue preview line still appears

https://claude.ai/code/session_01AdV8AuNyBfqeWf9KThaeBG