### PR TITLE
refactor: useDragDrop step 4 — desktop drag start/end and auto-scroll

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -755,7 +755,11 @@ const DayPlanner = () => {
     openNewTaskAtTime,
     handleCalendarMouseMove,
     handleCalendarMouseLeave,
-  } = useDragDrop({ calendarRef, timeGridRef, setNewTask, setShowAddTask, selectedDate });
+    // desktop drag start/end + auto-scroll
+    handleDragStart,
+    handleDragEnd,
+    updateDragAutoScroll,
+  } = useDragDrop({ calendarRef, timeGridRef, setNewTask, setShowAddTask, selectedDate, setExpandedNotesTaskId });
 
   // Show all 24 hours (full day) - scrollable
   const hours = Array.from({ length: 24 }, (_, i) => i);
@@ -3379,29 +3383,6 @@ const DayPlanner = () => {
     document.addEventListener('touchend', handleTouchEnd);
   };
 
-  const handleDragStart = (task, source, e) => {
-    setDraggedTask(task);
-    setDragSource(source);
-    setDragPreviewTime(null);
-    setExpandedNotesTaskId(null); // Close notes panel when dragging
-    e.dataTransfer.effectAllowed = 'move';
-  };
-
-  const handleDragEnd = () => {
-    setDraggedTask(null);
-    setDragSource(null);
-    setDragPreviewTime(null);
-    setDragPreviewDate(null);
-    setDragOverAllDay(null);
-    setDragOverInbox(false);
-    setDragOverRecycleBin(false);
-    // Clear auto-scroll
-    if (autoScrollInterval.current) {
-      clearInterval(autoScrollInterval.current);
-      autoScrollInterval.current = null;
-    }
-  };
-
   // --- Mobile swipe + long-press drag handlers ---
   const handleMobileTaskTouchStart = (e, task, taskType) => {
     // Skip swipe for imported items that can't be moved; allow drag for native calendar events
@@ -3932,42 +3913,6 @@ const DayPlanner = () => {
     setMobileDragPreviewTime(null);
     setMobileDragPreviewDate(null);
     setMobileDragTaskIdState(null);
-  };
-
-  const updateDragAutoScroll = (e) => {
-    if (!calendarRef.current) return;
-    const calendarRect = calendarRef.current.getBoundingClientRect();
-    // Account for sticky headers (date header + all-day section) when computing scroll-up zone
-    const stickyHeight = stickyHeaderRef.current ? stickyHeaderRef.current.getBoundingClientRect().bottom - calendarRect.top : 0;
-    const scrollZoneSize = 60;
-    const scrollSpeed = 8;
-
-    const cursorY = e.clientY;
-    const effectiveTop = calendarRect.top + stickyHeight;
-    const distanceFromTop = cursorY - effectiveTop;
-    const distanceFromBottom = calendarRect.bottom - cursorY;
-
-    if (autoScrollInterval.current) {
-      clearInterval(autoScrollInterval.current);
-      autoScrollInterval.current = null;
-    }
-
-    if (distanceFromTop < scrollZoneSize && distanceFromTop > 0 && calendarRef.current.scrollTop > 0) {
-      autoScrollInterval.current = setInterval(() => {
-        if (calendarRef.current) {
-          calendarRef.current.scrollTop -= scrollSpeed;
-        }
-      }, 16);
-    } else if (distanceFromBottom < scrollZoneSize && distanceFromBottom > 0) {
-      autoScrollInterval.current = setInterval(() => {
-        if (calendarRef.current) {
-          const maxScroll = calendarRef.current.scrollHeight - calendarRef.current.clientHeight;
-          if (calendarRef.current.scrollTop < maxScroll) {
-            calendarRef.current.scrollTop += scrollSpeed;
-          }
-        }
-      }, 16);
-    }
   };
 
   const handleDragOver = (e, targetDate = null) => {

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -13,7 +13,7 @@ const minutesToTime = (minutes) => {
   return `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}`;
 };
 
-export default function useDragDrop({ calendarRef, timeGridRef, setNewTask, setShowAddTask, selectedDate }) {
+export default function useDragDrop({ calendarRef, timeGridRef, setNewTask, setShowAddTask, selectedDate, setExpandedNotesTaskId }) {
   const [draggedTask, setDraggedTask] = useState(null);
   const [dragSource, setDragSource] = useState(null);
   const [dragPreviewTime, setDragPreviewTime] = useState(null);
@@ -146,6 +146,65 @@ export default function useDragDrop({ calendarRef, timeGridRef, setNewTask, setS
     setHoverPreviewDate(null);
   };
 
+  const handleDragStart = (task, source, e) => {
+    setDraggedTask(task);
+    setDragSource(source);
+    setDragPreviewTime(null);
+    setExpandedNotesTaskId(null); // Close notes panel when dragging
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragEnd = () => {
+    setDraggedTask(null);
+    setDragSource(null);
+    setDragPreviewTime(null);
+    setDragPreviewDate(null);
+    setDragOverAllDay(null);
+    setDragOverInbox(false);
+    setDragOverRecycleBin(false);
+    // Clear auto-scroll
+    if (autoScrollInterval.current) {
+      clearInterval(autoScrollInterval.current);
+      autoScrollInterval.current = null;
+    }
+  };
+
+  const updateDragAutoScroll = (e) => {
+    if (!calendarRef.current) return;
+    const calendarRect = calendarRef.current.getBoundingClientRect();
+    // Account for sticky headers (date header + all-day section) when computing scroll-up zone
+    const stickyHeight = stickyHeaderRef.current ? stickyHeaderRef.current.getBoundingClientRect().bottom - calendarRect.top : 0;
+    const scrollZoneSize = 60;
+    const scrollSpeed = 8;
+
+    const cursorY = e.clientY;
+    const effectiveTop = calendarRect.top + stickyHeight;
+    const distanceFromTop = cursorY - effectiveTop;
+    const distanceFromBottom = calendarRect.bottom - cursorY;
+
+    if (autoScrollInterval.current) {
+      clearInterval(autoScrollInterval.current);
+      autoScrollInterval.current = null;
+    }
+
+    if (distanceFromTop < scrollZoneSize && distanceFromTop > 0 && calendarRef.current.scrollTop > 0) {
+      autoScrollInterval.current = setInterval(() => {
+        if (calendarRef.current) {
+          calendarRef.current.scrollTop -= scrollSpeed;
+        }
+      }, 16);
+    } else if (distanceFromBottom < scrollZoneSize && distanceFromBottom > 0) {
+      autoScrollInterval.current = setInterval(() => {
+        if (calendarRef.current) {
+          const maxScroll = calendarRef.current.scrollHeight - calendarRef.current.clientHeight;
+          if (calendarRef.current.scrollTop < maxScroll) {
+            calendarRef.current.scrollTop += scrollSpeed;
+          }
+        }
+      }, 16);
+    }
+  };
+
   return {
     // state
     draggedTask, setDraggedTask,
@@ -173,5 +232,9 @@ export default function useDragDrop({ calendarRef, timeGridRef, setNewTask, setS
     openNewTaskAtTime,
     handleCalendarMouseMove,
     handleCalendarMouseLeave,
+    // desktop drag start/end + auto-scroll
+    handleDragStart,
+    handleDragEnd,
+    updateDragAutoScroll,
   };
 }


### PR DESCRIPTION
## Summary
- Moves `handleDragStart`, `handleDragEnd`, `updateDragAutoScroll` from `App.jsx` into `useDragDrop.js`
- Adds `setExpandedNotesTaskId` as a new hook parameter (used in `handleDragStart` to close the notes panel on drag)
- All other dependencies (`autoScrollInterval`, `stickyHeaderRef`, `calendarRef`, drag state setters) are already internal to the hook

## Test plan
- [ ] Pick up a task and drag it — verify it lifts (opacity/scale change)
- [ ] Drop it back where it was — task remains unchanged
- [ ] Drag near the top or bottom edge of the calendar — verify auto-scroll triggers
- [ ] `npm run build` passes (verified locally)