### PR TITLE
refactor: useDragDrop step 5 — desktop drag-over handlers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -759,6 +759,10 @@ const DayPlanner = () => {
     handleDragStart,
     handleDragEnd,
     updateDragAutoScroll,
+    // desktop drag-over handlers
+    handleDragOver,
+    handleDragOverInbox,
+    handleDragOverRecycleBin,
   } = useDragDrop({ calendarRef, timeGridRef, setNewTask, setShowAddTask, selectedDate, setExpandedNotesTaskId });
 
   // Show all 24 hours (full day) - scrollable
@@ -3913,62 +3917,6 @@ const DayPlanner = () => {
     setMobileDragPreviewTime(null);
     setMobileDragPreviewDate(null);
     setMobileDragTaskIdState(null);
-  };
-
-  const handleDragOver = (e, targetDate = null) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
-
-    // Clear other drop indicators when back in timeline
-    setDragOverAllDay(null);
-    setDragOverInbox(false);
-    setDragOverRecycleBin(false);
-
-    // Show preview time while dragging
-    if (draggedTask && calendarRef.current) {
-      const time = getTimeFromCursorPosition(e, {
-        maxMinutes: 24 * 60,
-        taskDuration: draggedTask.duration
-      });
-      setDragPreviewTime(time);
-
-      // Track which date column we're dragging over
-      if (targetDate) {
-        setDragPreviewDate(targetDate);
-      }
-
-      updateDragAutoScroll(e);
-    }
-  };
-
-  const handleDragOverInbox = (e) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
-    // Clear timeline preview when over inbox
-    setDragPreviewTime(null);
-    setDragOverAllDay(null);
-    setDragOverRecycleBin(false);
-    setDragOverInbox(true);
-    // Clear auto-scroll when over inbox
-    if (autoScrollInterval.current) {
-      clearInterval(autoScrollInterval.current);
-      autoScrollInterval.current = null;
-    }
-  };
-
-  const handleDragOverRecycleBin = (e) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
-    // Clear timeline preview when over recycle bin
-    setDragPreviewTime(null);
-    setDragOverAllDay(null);
-    setDragOverInbox(false);
-    setDragOverRecycleBin(true);
-    // Clear auto-scroll when over recycle bin
-    if (autoScrollInterval.current) {
-      clearInterval(autoScrollInterval.current);
-      autoScrollInterval.current = null;
-    }
   };
 
   const handleDropOnCalendar = (e, targetDate = null) => {

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -205,6 +205,62 @@ export default function useDragDrop({ calendarRef, timeGridRef, setNewTask, setS
     }
   };
 
+  const handleDragOver = (e, targetDate = null) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+
+    // Clear other drop indicators when back in timeline
+    setDragOverAllDay(null);
+    setDragOverInbox(false);
+    setDragOverRecycleBin(false);
+
+    // Show preview time while dragging
+    if (draggedTask && calendarRef.current) {
+      const time = getTimeFromCursorPosition(e, {
+        maxMinutes: 24 * 60,
+        taskDuration: draggedTask.duration
+      });
+      setDragPreviewTime(time);
+
+      // Track which date column we're dragging over
+      if (targetDate) {
+        setDragPreviewDate(targetDate);
+      }
+
+      updateDragAutoScroll(e);
+    }
+  };
+
+  const handleDragOverInbox = (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    // Clear timeline preview when over inbox
+    setDragPreviewTime(null);
+    setDragOverAllDay(null);
+    setDragOverRecycleBin(false);
+    setDragOverInbox(true);
+    // Clear auto-scroll when over inbox
+    if (autoScrollInterval.current) {
+      clearInterval(autoScrollInterval.current);
+      autoScrollInterval.current = null;
+    }
+  };
+
+  const handleDragOverRecycleBin = (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    // Clear timeline preview when over recycle bin
+    setDragPreviewTime(null);
+    setDragOverAllDay(null);
+    setDragOverInbox(false);
+    setDragOverRecycleBin(true);
+    // Clear auto-scroll when over recycle bin
+    if (autoScrollInterval.current) {
+      clearInterval(autoScrollInterval.current);
+      autoScrollInterval.current = null;
+    }
+  };
+
   return {
     // state
     draggedTask, setDraggedTask,
@@ -236,5 +292,9 @@ export default function useDragDrop({ calendarRef, timeGridRef, setNewTask, setS
     handleDragStart,
     handleDragEnd,
     updateDragAutoScroll,
+    // desktop drag-over handlers
+    handleDragOver,
+    handleDragOverInbox,
+    handleDragOverRecycleBin,
   };
 }


### PR DESCRIPTION
## Summary
- Moves `handleDragOver`, `handleDragOverInbox`, `handleDragOverRecycleBin` from `App.jsx` into `useDragDrop.js`
- No new external parameters needed — all dependencies (`draggedTask`, `calendarRef`, `getTimeFromCursorPosition`, `updateDragAutoScroll`, drag state setters, `autoScrollInterval`) are already internal to the hook

## Test plan
- [ ] Drag a task over the timeline → blue time preview line moves with the cursor
- [ ] Drag over the inbox zone → inbox highlights
- [ ] Drag over the recycle bin → recycle bin highlights
- [ ] `npm run build` passes (verified locally)