### PR TITLE
refactor: useDragDrop step 6 — desktop drop on calendar and date header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -726,45 +726,6 @@ const DayPlanner = () => {
   } = useNewTaskInput({ allTags, showAddTask });
   voiceAllTagsRef.current = allTags;
 
-  // useDragDrop is placed here — after useNewTaskInput (so setNewTask is available) and
-  // before any useEffect that references its state — to avoid TDZ errors in dep arrays.
-  const {
-    // state
-    draggedTask, setDraggedTask,
-    dragSource, setDragSource,
-    dragPreviewTime, setDragPreviewTime,
-    dragPreviewDate, setDragPreviewDate,
-    dragOverAllDay, setDragOverAllDay,
-    dragOverInbox, setDragOverInbox,
-    dragOverRecycleBin, setDragOverRecycleBin,
-    hoverPreviewTime, setHoverPreviewTime,
-    hoverPreviewDate, setHoverPreviewDate,
-    isResizing, setIsResizing,
-    // refs
-    autoScrollInterval,
-    frameResizingRef,
-    stickyHeaderRef,
-    // position helpers
-    getHourHeight,
-    minutesToPosition,
-    positionToMinutes,
-    durationToHeight,
-    calculateTaskPosition,
-    // cursor + calendar hover/click handlers
-    getTimeFromCursorPosition,
-    openNewTaskAtTime,
-    handleCalendarMouseMove,
-    handleCalendarMouseLeave,
-    // desktop drag start/end + auto-scroll
-    handleDragStart,
-    handleDragEnd,
-    updateDragAutoScroll,
-    // desktop drag-over handlers
-    handleDragOver,
-    handleDragOverInbox,
-    handleDragOverRecycleBin,
-  } = useDragDrop({ calendarRef, timeGridRef, setNewTask, setShowAddTask, selectedDate, setExpandedNotesTaskId });
-
   // Show all 24 hours (full day) - scrollable
   const hours = Array.from({ length: 24 }, (_, i) => i);
   const firstHour = 0; // Always start at midnight for positioning
@@ -1960,6 +1921,54 @@ const DayPlanner = () => {
     const templateId = /^\d+$/.test(rawTemplateId) ? Number(rawTemplateId) : rawTemplateId;
     return { templateId, dateStr };
   };
+
+  // useDragDrop is placed here — after all its dependencies are defined and before any
+  // useEffect that references its state (hoverPreviewTime at ~line 2671) to avoid TDZ errors.
+  const {
+    // state
+    draggedTask, setDraggedTask,
+    dragSource, setDragSource,
+    dragPreviewTime, setDragPreviewTime,
+    dragPreviewDate, setDragPreviewDate,
+    dragOverAllDay, setDragOverAllDay,
+    dragOverInbox, setDragOverInbox,
+    dragOverRecycleBin, setDragOverRecycleBin,
+    hoverPreviewTime, setHoverPreviewTime,
+    hoverPreviewDate, setHoverPreviewDate,
+    isResizing, setIsResizing,
+    // refs
+    autoScrollInterval,
+    frameResizingRef,
+    stickyHeaderRef,
+    // position helpers
+    getHourHeight,
+    minutesToPosition,
+    positionToMinutes,
+    durationToHeight,
+    calculateTaskPosition,
+    // cursor + calendar hover/click handlers
+    getTimeFromCursorPosition,
+    openNewTaskAtTime,
+    handleCalendarMouseMove,
+    handleCalendarMouseLeave,
+    // desktop drag start/end + auto-scroll
+    handleDragStart,
+    handleDragEnd,
+    updateDragAutoScroll,
+    // desktop drag-over handlers
+    handleDragOver,
+    handleDragOverInbox,
+    handleDragOverRecycleBin,
+    // desktop drop on calendar + date header
+    handleDropOnCalendar,
+    handleDropOnDateHeader,
+  } = useDragDrop({
+    calendarRef, timeGridRef,
+    setNewTask, setShowAddTask, selectedDate, setExpandedNotesTaskId,
+    tasks, setTasks, setUnscheduledTasks, setRecurringTasks, setRecycleBin, setTodayRoutines,
+    pushUndo, parseRecurringId, getAdjustedTimeForImportedConflicts, wouldExceedMaxColumns,
+    playUISound, setSyncNotification, onboardingProgress, setOnboardingProgress,
+  });
 
   const {
     editingTaskId, setEditingTaskId,
@@ -3919,169 +3928,6 @@ const DayPlanner = () => {
     setMobileDragTaskIdState(null);
   };
 
-  const handleDropOnCalendar = (e, targetDate = null) => {
-    e.preventDefault();
-    if (!draggedTask) return;
-
-    // Routine chip drop — place on timeline (today only)
-    if (dragSource === 'routine') {
-      const dropDate = targetDate || dragPreviewDate || selectedDate;
-      const dropDateStr = dateToString(dropDate);
-      const todayStr = dateToString(new Date());
-      if (dropDateStr !== todayStr) {
-        setDraggedTask(null); setDragSource(null); setDragPreviewTime(null); setDragPreviewDate(null);
-        return;
-      }
-      const startTime = getTimeFromCursorPosition(e, { maxMinutes: 24 * 60, taskDuration: draggedTask.duration });
-      setTodayRoutines(prev => prev.map(r => r.id === draggedTask.id ? { ...r, startTime, isAllDay: false, lastModified: new Date().toISOString() } : r));
-      setDraggedTask(null); setDragSource(null); setDragPreviewTime(null); setDragPreviewDate(null);
-      return;
-    }
-
-    const requestedStartTime = getTimeFromCursorPosition(e, {
-      maxMinutes: 24 * 60,
-      taskDuration: draggedTask.duration
-    });
-
-    // Use the target date from the column, falling back to dragPreviewDate or selectedDate
-    const dropDate = targetDate || dragPreviewDate || selectedDate;
-    const dropDateStr = dateToString(dropDate);
-
-    // Check for conflicts with imported calendar events and adjust if needed
-    const { conflicted, adjustedStartTime, conflictingEvent } = getAdjustedTimeForImportedConflicts(
-      draggedTask.id,
-      requestedStartTime,
-      draggedTask.duration,
-      dropDateStr
-    );
-
-    const startTime = adjustedStartTime;
-
-    // Prevent drops that would create 4+ side-by-side tasks
-    if (wouldExceedMaxColumns(draggedTask, startTime, dropDateStr)) {
-      setDraggedTask(null);
-      setDragSource(null);
-      setDragPreviewTime(null);
-      setDragPreviewDate(null);
-      return;
-    }
-
-    pushUndo();
-    if (dragSource === 'inbox') {
-      setUnscheduledTasks(prev => prev.filter(t => t.id !== draggedTask.id));
-      const { priority, deadline, ...taskWithoutPriorityAndDeadline } = draggedTask;
-      setTasks(prev => [...prev, {
-        ...taskWithoutPriorityAndDeadline,
-        startTime,
-        date: dropDateStr,
-        isAllDay: false
-      }]);
-      // Track for onboarding
-      if (!onboardingProgress.hasDraggedToTimeline) {
-        setOnboardingProgress(prev => ({ ...prev, hasDraggedToTimeline: true }));
-      }
-    } else if (dragSource === 'calendar') {
-      if (draggedTask.isRecurring) {
-        const parsed = parseRecurringId(draggedTask.id);
-        if (parsed) {
-          const { templateId, dateStr: origDateStr } = parsed;
-          if (origDateStr === dropDateStr) {
-            // Same-date drag: store startTime override in exception
-            setRecurringTasks(prev => prev.map(t => {
-              if (t.id !== templateId) return t;
-              return { ...t, exceptions: { ...t.exceptions, [origDateStr]: { ...t.exceptions?.[origDateStr], startTime } } };
-            }));
-          } else {
-            // Cross-date drag: mark deleted on old date, create regular task on new date
-            setRecurringTasks(prev => prev.map(t => {
-              if (t.id !== templateId) return t;
-              return { ...t, exceptions: { ...t.exceptions, [origDateStr]: { ...t.exceptions?.[origDateStr], deleted: true } } };
-            }));
-            const { id, isRecurring, recurringTemplateId, ...taskData } = draggedTask;
-            setTasks(prev => [...prev, { ...taskData, id: crypto.randomUUID(), startTime, date: dropDateStr, isAllDay: false }]);
-          }
-        }
-      } else {
-        const prevDraggedTask = draggedTask;
-        setTasks(prev => prev.map(t =>
-          t.id === draggedTask.id
-            ? { ...t, startTime, date: dropDateStr, isAllDay: false }
-            : t
-        ));
-        // If this is a native Android calendar event, write the change back to the device calendar
-        if (draggedTask.nativeEventId) {
-          const endMin = timeToMinutes(startTime) + (draggedTask.duration || 60);
-          const newStart = `${dropDateStr}T${startTime}:00`;
-          const newEnd = `${dropDateStr}T${String(Math.floor(endMin / 60)).padStart(2, '0')}:${String(endMin % 60).padStart(2, '0')}:00`;
-          nativeUpdateEvent({
-            id: draggedTask.nativeEventId, title: draggedTask.title,
-            start: newStart, end: newEnd, allDay: false,
-            notes: draggedTask.notes || '', location: draggedTask.location || '',
-          }).then(result => {
-            if (!result?.success) {
-              setTasks(prev => prev.map(t => t.id === prevDraggedTask.id ? { ...prevDraggedTask } : t));
-            } else {
-              // Keep any localStorage time-override in sync with the new position so
-              // a subsequent calendar re-fetch doesn't revert to the stale override value.
-              const overrides = JSON.parse(localStorage.getItem('day-planner-native-time-overrides') || '{}');
-              const key = String(draggedTask.nativeEventId);
-              if (overrides[key]) {
-                overrides[key] = { startTime, duration: draggedTask.duration || 60, date: dropDateStr };
-                localStorage.setItem('day-planner-native-time-overrides', JSON.stringify(overrides));
-              }
-            }
-          });
-        }
-      }
-    } else if (dragSource === 'recycleBin') {
-      // Remove metadata and add to calendar
-      const { _deletedFrom, ...cleanTask } = draggedTask;
-      setRecycleBin(prev => prev.filter(t => t.id !== draggedTask.id));
-      setTasks(prev => [...prev, {
-        ...cleanTask,
-        startTime,
-        date: dropDateStr,
-        isAllDay: false
-      }]);
-    } else if (dragSource === 'overdue') {
-      // Handle overdue tasks - they can be scheduled or deadline tasks
-      if (draggedTask._overdueType === 'scheduled') {
-        // Reschedule an existing scheduled task
-        setTasks(prev => prev.map(t =>
-          t.id === draggedTask.id
-            ? { ...t, startTime, date: dropDateStr, isAllDay: false }
-            : t
-        ));
-      } else if (draggedTask._overdueType === 'deadline') {
-        // Schedule an overdue inbox task - remove from inbox, add to calendar
-        setUnscheduledTasks(prev => prev.filter(t => t.id !== draggedTask.id));
-        const { priority, deadline, _overdueType, ...taskWithoutMeta } = draggedTask;
-        setTasks(prev => [...prev, {
-          ...taskWithoutMeta,
-          startTime,
-          date: dropDateStr,
-          isAllDay: false
-        }]);
-      }
-    }
-
-    // Show notification if task was rescheduled to avoid calendar conflict
-    if (conflicted && conflictingEvent) {
-      playUISound('error');
-      setSyncNotification({
-        type: 'info',
-        title: 'Task Rescheduled',
-        message: `Task moved to ${startTime} to avoid conflict with "${conflictingEvent.title}"`
-      });
-    }
-
-    playUISound('drop');
-    setDraggedTask(null);
-    setDragSource(null);
-    setDragPreviewTime(null);
-    setDragPreviewDate(null);
-  };
-
   const handleDropOnInbox = (e) => {
     e.preventDefault();
     if (!draggedTask) return;
@@ -4192,93 +4038,6 @@ const DayPlanner = () => {
     setDragSource(null);
     setDragPreviewTime(null);
     setDragOverRecycleBin(false);
-  };
-
-  const handleDropOnDateHeader = (e, targetDate) => {
-    e.preventDefault();
-    if (!draggedTask) return;
-
-    // Routine chip drop — return to all-day (today only)
-    if (dragSource === 'routine') {
-      const dropDateStr = dateToString(targetDate);
-      const todayStr = dateToString(new Date());
-      if (dropDateStr !== todayStr) {
-        setDraggedTask(null); setDragSource(null); setDragPreviewTime(null); setDragPreviewDate(null); setDragOverAllDay(null);
-        return;
-      }
-      setTodayRoutines(prev => prev.map(r => r.id === draggedTask.id ? { ...r, startTime: null, isAllDay: true, lastModified: new Date().toISOString() } : r));
-      setDraggedTask(null); setDragSource(null); setDragPreviewTime(null); setDragPreviewDate(null); setDragOverAllDay(null);
-      return;
-    }
-
-    const dropDateStr = dateToString(targetDate);
-
-    pushUndo();
-    if (dragSource === 'inbox') {
-      setUnscheduledTasks(prev => prev.filter(t => t.id !== draggedTask.id));
-      const { priority, deadline, ...taskWithoutPriorityAndDeadline } = draggedTask;
-      setTasks(prev => [...prev, {
-        ...taskWithoutPriorityAndDeadline,
-        startTime: '00:00',
-        date: dropDateStr,
-        isAllDay: true
-      }]);
-    } else if (dragSource === 'calendar') {
-      if (draggedTask.isRecurring) {
-        const parsed = parseRecurringId(draggedTask.id);
-        if (parsed) {
-          const { templateId, dateStr: origDateStr } = parsed;
-          // Detach: mark deleted on original date, create regular all-day task
-          setRecurringTasks(prev => prev.map(t => {
-            if (t.id !== templateId) return t;
-            return { ...t, exceptions: { ...t.exceptions, [origDateStr]: { ...t.exceptions?.[origDateStr], deleted: true } } };
-          }));
-          const { id, isRecurring, recurringTemplateId, ...taskData } = draggedTask;
-          setTasks(prev => [...prev, { ...taskData, id: crypto.randomUUID(), startTime: '00:00', date: dropDateStr, isAllDay: true }]);
-        }
-      } else {
-        setTasks(prev => prev.map(t =>
-          t.id === draggedTask.id
-            ? { ...t, startTime: '00:00', date: dropDateStr, isAllDay: true }
-            : t
-        ));
-      }
-    } else if (dragSource === 'recycleBin') {
-      const { _deletedFrom, ...cleanTask } = draggedTask;
-      setRecycleBin(prev => prev.filter(t => t.id !== draggedTask.id));
-      setTasks(prev => [...prev, {
-        ...cleanTask,
-        startTime: '00:00',
-        date: dropDateStr,
-        isAllDay: true
-      }]);
-    } else if (dragSource === 'overdue') {
-      // Handle overdue tasks - they can be scheduled or deadline tasks
-      if (draggedTask._overdueType === 'scheduled') {
-        // Reschedule an existing scheduled task to a new all-day slot
-        setTasks(prev => prev.map(t =>
-          t.id === draggedTask.id
-            ? { ...t, startTime: '00:00', date: dropDateStr, isAllDay: true }
-            : t
-        ));
-      } else if (draggedTask._overdueType === 'deadline') {
-        // Schedule an overdue inbox task - remove from inbox, add to calendar
-        setUnscheduledTasks(prev => prev.filter(t => t.id !== draggedTask.id));
-        const { priority, deadline, _overdueType, ...taskWithoutMeta } = draggedTask;
-        setTasks(prev => [...prev, {
-          ...taskWithoutMeta,
-          startTime: '00:00',
-          date: dropDateStr,
-          isAllDay: true
-        }]);
-      }
-    }
-
-    setDraggedTask(null);
-    setDragSource(null);
-    setDragPreviewTime(null);
-    setDragPreviewDate(null);
-    setDragOverAllDay(null);
   };
 
   const handleResizeStart = (task, e) => {

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
+import { nativeUpdateEvent } from '../native.js';
 
 // Pure utilities used by position helpers
 const timeToMinutes = (time) => {
@@ -13,7 +14,13 @@ const minutesToTime = (minutes) => {
   return `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}`;
 };
 
-export default function useDragDrop({ calendarRef, timeGridRef, setNewTask, setShowAddTask, selectedDate, setExpandedNotesTaskId }) {
+export default function useDragDrop({
+  calendarRef, timeGridRef,
+  setNewTask, setShowAddTask, selectedDate, setExpandedNotesTaskId,
+  tasks, setTasks, setUnscheduledTasks, setRecurringTasks, setRecycleBin, setTodayRoutines,
+  pushUndo, parseRecurringId, getAdjustedTimeForImportedConflicts, wouldExceedMaxColumns,
+  playUISound, setSyncNotification, onboardingProgress, setOnboardingProgress,
+}) {
   const [draggedTask, setDraggedTask] = useState(null);
   const [dragSource, setDragSource] = useState(null);
   const [dragPreviewTime, setDragPreviewTime] = useState(null);
@@ -261,6 +268,256 @@ export default function useDragDrop({ calendarRef, timeGridRef, setNewTask, setS
     }
   };
 
+  const handleDropOnCalendar = (e, targetDate = null) => {
+    e.preventDefault();
+    if (!draggedTask) return;
+
+    // Routine chip drop — place on timeline (today only)
+    if (dragSource === 'routine') {
+      const dropDate = targetDate || dragPreviewDate || selectedDate;
+      const dropDateStr = dateToString(dropDate);
+      const todayStr = dateToString(new Date());
+      if (dropDateStr !== todayStr) {
+        setDraggedTask(null); setDragSource(null); setDragPreviewTime(null); setDragPreviewDate(null);
+        return;
+      }
+      const startTime = getTimeFromCursorPosition(e, { maxMinutes: 24 * 60, taskDuration: draggedTask.duration });
+      setTodayRoutines(prev => prev.map(r => r.id === draggedTask.id ? { ...r, startTime, isAllDay: false, lastModified: new Date().toISOString() } : r));
+      setDraggedTask(null); setDragSource(null); setDragPreviewTime(null); setDragPreviewDate(null);
+      return;
+    }
+
+    const requestedStartTime = getTimeFromCursorPosition(e, {
+      maxMinutes: 24 * 60,
+      taskDuration: draggedTask.duration
+    });
+
+    // Use the target date from the column, falling back to dragPreviewDate or selectedDate
+    const dropDate = targetDate || dragPreviewDate || selectedDate;
+    const dropDateStr = dateToString(dropDate);
+
+    // Check for conflicts with imported calendar events and adjust if needed
+    const { conflicted, adjustedStartTime, conflictingEvent } = getAdjustedTimeForImportedConflicts(
+      draggedTask.id,
+      requestedStartTime,
+      draggedTask.duration,
+      dropDateStr
+    );
+
+    const startTime = adjustedStartTime;
+
+    // Prevent drops that would create 4+ side-by-side tasks
+    if (wouldExceedMaxColumns(draggedTask, startTime, dropDateStr)) {
+      setDraggedTask(null);
+      setDragSource(null);
+      setDragPreviewTime(null);
+      setDragPreviewDate(null);
+      return;
+    }
+
+    pushUndo();
+    if (dragSource === 'inbox') {
+      setUnscheduledTasks(prev => prev.filter(t => t.id !== draggedTask.id));
+      const { priority, deadline, ...taskWithoutPriorityAndDeadline } = draggedTask;
+      setTasks(prev => [...prev, {
+        ...taskWithoutPriorityAndDeadline,
+        startTime,
+        date: dropDateStr,
+        isAllDay: false
+      }]);
+      // Track for onboarding
+      if (!onboardingProgress.hasDraggedToTimeline) {
+        setOnboardingProgress(prev => ({ ...prev, hasDraggedToTimeline: true }));
+      }
+    } else if (dragSource === 'calendar') {
+      if (draggedTask.isRecurring) {
+        const parsed = parseRecurringId(draggedTask.id);
+        if (parsed) {
+          const { templateId, dateStr: origDateStr } = parsed;
+          if (origDateStr === dropDateStr) {
+            // Same-date drag: store startTime override in exception
+            setRecurringTasks(prev => prev.map(t => {
+              if (t.id !== templateId) return t;
+              return { ...t, exceptions: { ...t.exceptions, [origDateStr]: { ...t.exceptions?.[origDateStr], startTime } } };
+            }));
+          } else {
+            // Cross-date drag: mark deleted on old date, create regular task on new date
+            setRecurringTasks(prev => prev.map(t => {
+              if (t.id !== templateId) return t;
+              return { ...t, exceptions: { ...t.exceptions, [origDateStr]: { ...t.exceptions?.[origDateStr], deleted: true } } };
+            }));
+            const { id, isRecurring, recurringTemplateId, ...taskData } = draggedTask;
+            setTasks(prev => [...prev, { ...taskData, id: crypto.randomUUID(), startTime, date: dropDateStr, isAllDay: false }]);
+          }
+        }
+      } else {
+        const prevDraggedTask = draggedTask;
+        setTasks(prev => prev.map(t =>
+          t.id === draggedTask.id
+            ? { ...t, startTime, date: dropDateStr, isAllDay: false }
+            : t
+        ));
+        // If this is a native Android calendar event, write the change back to the device calendar
+        if (draggedTask.nativeEventId) {
+          const endMin = timeToMinutes(startTime) + (draggedTask.duration || 60);
+          const newStart = `${dropDateStr}T${startTime}:00`;
+          const newEnd = `${dropDateStr}T${String(Math.floor(endMin / 60)).padStart(2, '0')}:${String(endMin % 60).padStart(2, '0')}:00`;
+          nativeUpdateEvent({
+            id: draggedTask.nativeEventId, title: draggedTask.title,
+            start: newStart, end: newEnd, allDay: false,
+            notes: draggedTask.notes || '', location: draggedTask.location || '',
+          }).then(result => {
+            if (!result?.success) {
+              setTasks(prev => prev.map(t => t.id === prevDraggedTask.id ? { ...prevDraggedTask } : t));
+            } else {
+              // Keep any localStorage time-override in sync with the new position so
+              // a subsequent calendar re-fetch doesn't revert to the stale override value.
+              const overrides = JSON.parse(localStorage.getItem('day-planner-native-time-overrides') || '{}');
+              const key = String(draggedTask.nativeEventId);
+              if (overrides[key]) {
+                overrides[key] = { startTime, duration: draggedTask.duration || 60, date: dropDateStr };
+                localStorage.setItem('day-planner-native-time-overrides', JSON.stringify(overrides));
+              }
+            }
+          });
+        }
+      }
+    } else if (dragSource === 'recycleBin') {
+      // Remove metadata and add to calendar
+      const { _deletedFrom, ...cleanTask } = draggedTask;
+      setRecycleBin(prev => prev.filter(t => t.id !== draggedTask.id));
+      setTasks(prev => [...prev, {
+        ...cleanTask,
+        startTime,
+        date: dropDateStr,
+        isAllDay: false
+      }]);
+    } else if (dragSource === 'overdue') {
+      // Handle overdue tasks - they can be scheduled or deadline tasks
+      if (draggedTask._overdueType === 'scheduled') {
+        // Reschedule an existing scheduled task
+        setTasks(prev => prev.map(t =>
+          t.id === draggedTask.id
+            ? { ...t, startTime, date: dropDateStr, isAllDay: false }
+            : t
+        ));
+      } else if (draggedTask._overdueType === 'deadline') {
+        // Schedule an overdue inbox task - remove from inbox, add to calendar
+        setUnscheduledTasks(prev => prev.filter(t => t.id !== draggedTask.id));
+        const { priority, deadline, _overdueType, ...taskWithoutMeta } = draggedTask;
+        setTasks(prev => [...prev, {
+          ...taskWithoutMeta,
+          startTime,
+          date: dropDateStr,
+          isAllDay: false
+        }]);
+      }
+    }
+
+    // Show notification if task was rescheduled to avoid calendar conflict
+    if (conflicted && conflictingEvent) {
+      playUISound('error');
+      setSyncNotification({
+        type: 'info',
+        title: 'Task Rescheduled',
+        message: `Task moved to ${startTime} to avoid conflict with "${conflictingEvent.title}"`
+      });
+    }
+
+    playUISound('drop');
+    setDraggedTask(null);
+    setDragSource(null);
+    setDragPreviewTime(null);
+    setDragPreviewDate(null);
+  };
+
+  const handleDropOnDateHeader = (e, targetDate) => {
+    e.preventDefault();
+    if (!draggedTask) return;
+
+    // Routine chip drop — return to all-day (today only)
+    if (dragSource === 'routine') {
+      const dropDateStr = dateToString(targetDate);
+      const todayStr = dateToString(new Date());
+      if (dropDateStr !== todayStr) {
+        setDraggedTask(null); setDragSource(null); setDragPreviewTime(null); setDragPreviewDate(null); setDragOverAllDay(null);
+        return;
+      }
+      setTodayRoutines(prev => prev.map(r => r.id === draggedTask.id ? { ...r, startTime: null, isAllDay: true, lastModified: new Date().toISOString() } : r));
+      setDraggedTask(null); setDragSource(null); setDragPreviewTime(null); setDragPreviewDate(null); setDragOverAllDay(null);
+      return;
+    }
+
+    const dropDateStr = dateToString(targetDate);
+
+    pushUndo();
+    if (dragSource === 'inbox') {
+      setUnscheduledTasks(prev => prev.filter(t => t.id !== draggedTask.id));
+      const { priority, deadline, ...taskWithoutPriorityAndDeadline } = draggedTask;
+      setTasks(prev => [...prev, {
+        ...taskWithoutPriorityAndDeadline,
+        startTime: '00:00',
+        date: dropDateStr,
+        isAllDay: true
+      }]);
+    } else if (dragSource === 'calendar') {
+      if (draggedTask.isRecurring) {
+        const parsed = parseRecurringId(draggedTask.id);
+        if (parsed) {
+          const { templateId, dateStr: origDateStr } = parsed;
+          // Detach: mark deleted on original date, create regular all-day task
+          setRecurringTasks(prev => prev.map(t => {
+            if (t.id !== templateId) return t;
+            return { ...t, exceptions: { ...t.exceptions, [origDateStr]: { ...t.exceptions?.[origDateStr], deleted: true } } };
+          }));
+          const { id, isRecurring, recurringTemplateId, ...taskData } = draggedTask;
+          setTasks(prev => [...prev, { ...taskData, id: crypto.randomUUID(), startTime: '00:00', date: dropDateStr, isAllDay: true }]);
+        }
+      } else {
+        setTasks(prev => prev.map(t =>
+          t.id === draggedTask.id
+            ? { ...t, startTime: '00:00', date: dropDateStr, isAllDay: true }
+            : t
+        ));
+      }
+    } else if (dragSource === 'recycleBin') {
+      const { _deletedFrom, ...cleanTask } = draggedTask;
+      setRecycleBin(prev => prev.filter(t => t.id !== draggedTask.id));
+      setTasks(prev => [...prev, {
+        ...cleanTask,
+        startTime: '00:00',
+        date: dropDateStr,
+        isAllDay: true
+      }]);
+    } else if (dragSource === 'overdue') {
+      // Handle overdue tasks - they can be scheduled or deadline tasks
+      if (draggedTask._overdueType === 'scheduled') {
+        // Reschedule an existing scheduled task to a new all-day slot
+        setTasks(prev => prev.map(t =>
+          t.id === draggedTask.id
+            ? { ...t, startTime: '00:00', date: dropDateStr, isAllDay: true }
+            : t
+        ));
+      } else if (draggedTask._overdueType === 'deadline') {
+        // Schedule an overdue inbox task - remove from inbox, add to calendar
+        setUnscheduledTasks(prev => prev.filter(t => t.id !== draggedTask.id));
+        const { priority, deadline, _overdueType, ...taskWithoutMeta } = draggedTask;
+        setTasks(prev => [...prev, {
+          ...taskWithoutMeta,
+          startTime: '00:00',
+          date: dropDateStr,
+          isAllDay: true
+        }]);
+      }
+    }
+
+    setDraggedTask(null);
+    setDragSource(null);
+    setDragPreviewTime(null);
+    setDragPreviewDate(null);
+    setDragOverAllDay(null);
+  };
+
   return {
     // state
     draggedTask, setDraggedTask,
@@ -296,5 +553,8 @@ export default function useDragDrop({ calendarRef, timeGridRef, setNewTask, setS
     handleDragOver,
     handleDragOverInbox,
     handleDragOverRecycleBin,
+    // desktop drop on calendar + date header
+    handleDropOnCalendar,
+    handleDropOnDateHeader,
   };
 }


### PR DESCRIPTION
## Summary
- Moves `handleDropOnCalendar` and `handleDropOnDateHeader` from `App.jsx` into `useDragDrop.js`
- Adds 14 new parameters: `tasks`, `setTasks`, `setUnscheduledTasks`, `setRecurringTasks`, `setRecycleBin`, `setTodayRoutines`, `pushUndo`, `parseRecurringId`, `getAdjustedTimeForImportedConflicts`, `wouldExceedMaxColumns`, `playUISound`, `setSyncNotification`, `onboardingProgress`, `setOnboardingProgress`
- Imports `nativeUpdateEvent` from `../native.js` (used when dropping a native Android calendar event)
- Relocates the `useDragDrop` call in `App.jsx` to just after `parseRecurringId` (~line 1924) — all new dependencies are defined by that point, and the call still precedes the TDZ-sensitive `useEffect` at ~line 2671

## Test plan
- [ ] Drag a task to a new time → verify it moves correctly
- [ ] Drag a task to a different date column → verify it moves to that date
- [ ] Drag a task to the all-day header → verify it becomes an all-day task
- [ ] Drag an inbox task to the timeline → verify it schedules
- [ ] `npm run build` passes (verified locally)