### PR TITLE
refactor: useDragDrop step 9 — routine and frame resize handlers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1974,6 +1974,10 @@ const DayPlanner = () => {
     // task resize handlers
     handleResizeStart,
     handleTouchResizeStart,
+    // routine + frame resize handlers
+    handleRoutineResizeStart,
+    handleTouchRoutineResizeStart,
+    handleFrameResizeStart,
   } = useDragDrop({
     calendarRef, timeGridRef,
     setNewTask, setShowAddTask, selectedDate, setExpandedNotesTaskId,
@@ -1981,6 +1985,7 @@ const DayPlanner = () => {
     pushUndo, parseRecurringId, getAdjustedTimeForImportedConflicts, wouldExceedMaxColumns,
     playUISound, setSyncNotification, onboardingProgress, setOnboardingProgress,
     moveToRecycleBinRef, clearDeadlineRef,
+    gtdFrames, setGtdFrames,
   });
 
   const {
@@ -3353,61 +3358,6 @@ const DayPlanner = () => {
     setFocusTimerRunning(true);
   };
   handleFocusTimerEndRef.current = handleFocusTimerEnd;
-
-  const handleRoutineResizeStart = (routine, e) => {
-    e.stopPropagation();
-    e.preventDefault();
-    setIsResizing(true);
-
-    const startY = e.clientY;
-    const startDuration = routine.duration;
-
-    // Prevent the browser from initiating a native drag on the parent draggable element
-    const preventDrag = (de) => de.preventDefault();
-    document.addEventListener('dragstart', preventDrag);
-
-    const handleMouseMove = (moveEvent) => {
-      const deltaY = moveEvent.clientY - startY;
-      const deltaMinutes = Math.round((deltaY / 80) * 60 / 15) * 15;
-      const newDuration = Math.max(15, startDuration + deltaMinutes);
-      setTodayRoutines(prev => prev.map(r => r.id === routine.id ? { ...r, duration: newDuration, lastModified: new Date().toISOString() } : r));
-    };
-
-    const handleMouseUp = () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-      document.removeEventListener('dragstart', preventDrag);
-      setIsResizing(false);
-    };
-
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
-  };
-
-  const handleTouchRoutineResizeStart = (routine, e) => {
-    e.stopPropagation();
-    setIsResizing(true);
-
-    const startY = e.touches[0].clientY;
-    const startDuration = routine.duration;
-
-    const handleTouchMove = (moveEvent) => {
-      moveEvent.preventDefault();
-      const deltaY = moveEvent.touches[0].clientY - startY;
-      const deltaMinutes = Math.round((deltaY / 80) * 60 / 15) * 15;
-      const newDuration = Math.max(15, startDuration + deltaMinutes);
-      setTodayRoutines(prev => prev.map(r => r.id === routine.id ? { ...r, duration: newDuration, lastModified: new Date().toISOString() } : r));
-    };
-
-    const handleTouchEnd = () => {
-      document.removeEventListener('touchmove', handleTouchMove);
-      document.removeEventListener('touchend', handleTouchEnd);
-      setIsResizing(false);
-    };
-
-    document.addEventListener('touchmove', handleTouchMove, { passive: false });
-    document.addEventListener('touchend', handleTouchEnd);
-  };
 
   // --- Mobile swipe + long-press drag handlers ---
   const handleMobileTaskTouchStart = (e, task, taskType) => {
@@ -7204,62 +7154,6 @@ const DayPlanner = () => {
       },
     });
     setFrameContextMenu(null);
-  };
-
-  // Frame resize via drag on top/bottom edge
-  const handleFrameResizeStart = (frameId, dateStr, edge, e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    pushUndo();
-    const frame = gtdFrames.find(f => f.id === frameId);
-    if (!frame) return;
-    const exception = frame.exceptions?.[dateStr];
-    const origStart = timeToMinutes(exception?.start || frame.start);
-    const origEnd = timeToMinutes(exception?.end || frame.end);
-    const startY = e.clientY;
-
-    const handleMouseMove = (moveEvent) => {
-      frameResizingRef.current = true;
-      const deltaY = moveEvent.clientY - startY;
-      // Use approximate 80px per hour for desktop
-      const deltaMinutes = Math.round((deltaY / 80) * 60 / 15) * 15;
-      let newStart = origStart;
-      let newEnd = origEnd;
-      if (edge === 'top') {
-        newStart = Math.max(0, Math.min(origEnd - 15, origStart + deltaMinutes));
-      } else {
-        newEnd = Math.max(newStart + 15, Math.min(1440, origEnd + deltaMinutes));
-      }
-      setGtdFrames(prev => prev.map(f => {
-        if (f.id !== frameId) return f;
-        return {
-          ...f,
-          lastModified: new Date().toISOString(),
-          exceptions: {
-            ...(f.exceptions || {}),
-            [dateStr]: {
-              ...(f.exceptions?.[dateStr] || {}),
-              start: minutesToTime(newStart),
-              end: minutesToTime(newEnd),
-              deleted: false,
-            },
-          },
-        };
-      }));
-    };
-
-    const handleMouseUp = () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-      if (frameResizingRef.current) {
-        playUISound('tick');
-        // Clear after click event has fired so openNewTaskAtTime can check it
-        setTimeout(() => { frameResizingRef.current = false; }, 0);
-      }
-    };
-
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
   };
 
   // Run Smart Schedule: gather context, call AI, present results

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -21,6 +21,7 @@ export default function useDragDrop({
   pushUndo, parseRecurringId, getAdjustedTimeForImportedConflicts, wouldExceedMaxColumns,
   playUISound, setSyncNotification, onboardingProgress, setOnboardingProgress,
   moveToRecycleBinRef, clearDeadlineRef,
+  gtdFrames, setGtdFrames,
 }) {
   const [draggedTask, setDraggedTask] = useState(null);
   const [dragSource, setDragSource] = useState(null);
@@ -770,6 +771,116 @@ export default function useDragDrop({
     document.addEventListener('touchend', handleTouchEnd);
   };
 
+  const handleRoutineResizeStart = (routine, e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setIsResizing(true);
+
+    const startY = e.clientY;
+    const startDuration = routine.duration;
+
+    // Prevent the browser from initiating a native drag on the parent draggable element
+    const preventDrag = (de) => de.preventDefault();
+    document.addEventListener('dragstart', preventDrag);
+
+    const handleMouseMove = (moveEvent) => {
+      const deltaY = moveEvent.clientY - startY;
+      const deltaMinutes = Math.round((deltaY / 80) * 60 / 15) * 15;
+      const newDuration = Math.max(15, startDuration + deltaMinutes);
+      setTodayRoutines(prev => prev.map(r => r.id === routine.id ? { ...r, duration: newDuration, lastModified: new Date().toISOString() } : r));
+    };
+
+    const handleMouseUp = () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      document.removeEventListener('dragstart', preventDrag);
+      setIsResizing(false);
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  };
+
+  const handleTouchRoutineResizeStart = (routine, e) => {
+    e.stopPropagation();
+    setIsResizing(true);
+
+    const startY = e.touches[0].clientY;
+    const startDuration = routine.duration;
+
+    const handleTouchMove = (moveEvent) => {
+      moveEvent.preventDefault();
+      const deltaY = moveEvent.touches[0].clientY - startY;
+      const deltaMinutes = Math.round((deltaY / 80) * 60 / 15) * 15;
+      const newDuration = Math.max(15, startDuration + deltaMinutes);
+      setTodayRoutines(prev => prev.map(r => r.id === routine.id ? { ...r, duration: newDuration, lastModified: new Date().toISOString() } : r));
+    };
+
+    const handleTouchEnd = () => {
+      document.removeEventListener('touchmove', handleTouchMove);
+      document.removeEventListener('touchend', handleTouchEnd);
+      setIsResizing(false);
+    };
+
+    document.addEventListener('touchmove', handleTouchMove, { passive: false });
+    document.addEventListener('touchend', handleTouchEnd);
+  };
+
+  const handleFrameResizeStart = (frameId, dateStr, edge, e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    pushUndo();
+    const frame = gtdFrames.find(f => f.id === frameId);
+    if (!frame) return;
+    const exception = frame.exceptions?.[dateStr];
+    const origStart = timeToMinutes(exception?.start || frame.start);
+    const origEnd = timeToMinutes(exception?.end || frame.end);
+    const startY = e.clientY;
+
+    const handleMouseMove = (moveEvent) => {
+      frameResizingRef.current = true;
+      const deltaY = moveEvent.clientY - startY;
+      // Use approximate 80px per hour for desktop
+      const deltaMinutes = Math.round((deltaY / 80) * 60 / 15) * 15;
+      let newStart = origStart;
+      let newEnd = origEnd;
+      if (edge === 'top') {
+        newStart = Math.max(0, Math.min(origEnd - 15, origStart + deltaMinutes));
+      } else {
+        newEnd = Math.max(newStart + 15, Math.min(1440, origEnd + deltaMinutes));
+      }
+      setGtdFrames(prev => prev.map(f => {
+        if (f.id !== frameId) return f;
+        return {
+          ...f,
+          lastModified: new Date().toISOString(),
+          exceptions: {
+            ...(f.exceptions || {}),
+            [dateStr]: {
+              ...(f.exceptions?.[dateStr] || {}),
+              start: minutesToTime(newStart),
+              end: minutesToTime(newEnd),
+              deleted: false,
+            },
+          },
+        };
+      }));
+    };
+
+    const handleMouseUp = () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      if (frameResizingRef.current) {
+        playUISound('tick');
+        // Clear after click event has fired so openNewTaskAtTime can check it
+        setTimeout(() => { frameResizingRef.current = false; }, 0);
+      }
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  };
+
   return {
     // state
     draggedTask, setDraggedTask,
@@ -814,5 +925,9 @@ export default function useDragDrop({
     // task resize handlers
     handleResizeStart,
     handleTouchResizeStart,
+    // routine + frame resize handlers
+    handleRoutineResizeStart,
+    handleTouchRoutineResizeStart,
+    handleFrameResizeStart,
   };
 }


### PR DESCRIPTION
## Summary
- Moves `handleRoutineResizeStart`, `handleTouchRoutineResizeStart`, and `handleFrameResizeStart` from `App.jsx` into `useDragDrop.js`
- New parameters: `gtdFrames`, `setGtdFrames` (available at line ~616 in App.jsx, well before the hook call — no TDZ issue)
- `setTodayRoutines` was already a parameter from step 6; `minutesToTime`, `timeToMinutes`, `frameResizingRef`, `pushUndo`, `playUISound` were all already in the hook

## Test plan
- [ ] Resize a routine pill (mouse drag on bottom edge) → verify its duration updates in 15-min increments
- [ ] Resize a routine pill (touch) → verify its duration updates
- [ ] Resize a GTD frame block by dragging its top edge → verify start time changes
- [ ] Resize a GTD frame block by dragging its bottom edge → verify end time changes
- [ ] Click on the calendar immediately after resizing a frame → verify a new task opens (frameResizingRef suppression still works)
- [ ] `npm run build` passes (verified locally)