### PR TITLE
refactor: extract useAppInit hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,6 +63,7 @@ import useMobileEdit from './hooks/useMobileEdit.js';
 import useDragDrop from './hooks/useDragDrop.js';
 import useDataPersistence from './hooks/useDataPersistence.js';
 import useLocalStoragePersist from './hooks/useLocalStoragePersist.js';
+import useAppInit from './hooks/useAppInit.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -783,20 +784,6 @@ const DayPlanner = () => {
     cloudSyncConfig, cloudSyncInitialDoneRef, suppressTimestampRef,
     setUndoToast,
   });
-
-  useEffect(() => {
-    loadData();
-    fetchAllDailyContent();
-
-    // Rotate content every 15 minutes
-    const rotationInterval = setInterval(() => {
-      setContentRotation(prev => (prev + 1) % 4);
-    }, 15 * 60 * 1000);
-
-    return () => {
-      clearInterval(rotationInterval);
-    };
-  }, []);
 
   // Close month view when clicking outside
   useEffect(() => {
@@ -5283,26 +5270,12 @@ const DayPlanner = () => {
   // Getting Started checklist — show until dismissed or all items complete
   const showGettingStarted = dataLoaded && !gettingStartedDismissed && !allGettingStartedComplete;
 
-  // Persist welcome dismissal only when user has real tasks
-  useEffect(() => {
-    if (!showWelcome && !hasZeroRealTasks) {
-      localStorage.setItem('welcomeDismissed', 'true');
-    }
-  }, [showWelcome, hasZeroRealTasks]);
-
-  // Show welcome only on initial load with zero tasks (not when zeroing out during session)
-  useEffect(() => {
-    if (dataLoaded && !hasCheckedInitialWelcome.current) {
-      hasCheckedInitialWelcome.current = true;
-      if (hasZeroRealTasks) {
-        setShowWelcome(true);
-        localStorage.removeItem('welcomeDismissed');
-      } else {
-        setShowWelcome(false);
-      }
-    }
-  }, [dataLoaded, hasZeroRealTasks]);
-
+  useAppInit({
+    loadData, fetchAllDailyContent, setContentRotation,
+    dataLoaded, hasZeroRealTasks,
+    hasCheckedInitialWelcome,
+    showWelcome, setShowWelcome,
+  });
 
   // Compute array of visible dates based on selectedDate and visibleDays
   const visibleDates = useMemo(() => {

--- a/src/hooks/useAppInit.js
+++ b/src/hooks/useAppInit.js
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+
+export default function useAppInit({
+  loadData, fetchAllDailyContent, setContentRotation,
+  dataLoaded, hasZeroRealTasks,
+  hasCheckedInitialWelcome,
+  showWelcome, setShowWelcome,
+}) {
+  // Load data and fetch daily content on mount; rotate content every 15 minutes
+  useEffect(() => {
+    loadData();
+    fetchAllDailyContent();
+
+    // Rotate content every 15 minutes
+    const rotationInterval = setInterval(() => {
+      setContentRotation(prev => (prev + 1) % 4);
+    }, 15 * 60 * 1000);
+
+    return () => {
+      clearInterval(rotationInterval);
+    };
+  }, []);
+
+  // Persist welcome dismissal only when user has real tasks
+  useEffect(() => {
+    if (!showWelcome && !hasZeroRealTasks) {
+      localStorage.setItem('welcomeDismissed', 'true');
+    }
+  }, [showWelcome, hasZeroRealTasks]);
+
+  // Show welcome only on initial load with zero tasks (not when zeroing out during session)
+  useEffect(() => {
+    if (dataLoaded && !hasCheckedInitialWelcome.current) {
+      hasCheckedInitialWelcome.current = true;
+      if (hasZeroRealTasks) {
+        setShowWelcome(true);
+        localStorage.removeItem('welcomeDismissed');
+      } else {
+        setShowWelcome(false);
+      }
+    }
+  }, [dataLoaded, hasZeroRealTasks]);
+}


### PR DESCRIPTION
Extracts three one-time initialization `useEffect` hooks from `App.jsx` into a new `useAppInit` hook.\n\n**Effects moved:**\n- Mount effect: calls `loadData()`, `fetchAllDailyContent()`, starts content rotation interval\n- Welcome dismissal: persists `welcomeDismissed` to localStorage when user has real tasks\n- Welcome check: shows/hides welcome modal on initial load based on `hasZeroRealTasks`\n\nHook is called after `hasZeroRealTasks` (`useMemo` at ~line 5275) to avoid TDZ — all three effects work correctly regardless of call position since `useEffect` deps are resolved at runtime.\n\nPart of Phase 6 refactoring (Step 6.3).