### PR TITLE
refactor: create DayPlannerContext

### DIFF
--- a/src/context/DayPlannerContext.jsx
+++ b/src/context/DayPlannerContext.jsx
@@ -1,0 +1,3 @@
+import { createContext, useContext } from 'react';
+export const DayPlannerContext = createContext(null);
+export const useDayPlannerCtx = () => useContext(DayPlannerContext);


### PR DESCRIPTION
Creates the context definition file that Step 7.3 will populate.

## Changes
- New `src/context/DayPlannerContext.jsx` — exports `DayPlannerContext` (the context object) and `useDayPlannerCtx` (the consumer hook)
- No behavior change — the context is not yet imported or used anywhere

## Next
Step 7.3 will build the `useMemo` context value in App.jsx and wrap the return in `<DayPlannerContext.Provider>`.