### PR TITLE
refactor: extract FrameAdjustModal, FrameScheduleModal, FramesModal (step 9.7)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,6 +77,9 @@ import MobileLayout from './components/MobileLayout.jsx';
 import ShortcutHelpModal from './components/ShortcutHelpModal.jsx';
 import FocusModeModal from './components/FocusModeModal.jsx';
 import RoutinesDashboardModal from './components/RoutinesDashboardModal.jsx';
+import FrameAdjustModal from './components/FrameAdjustModal.jsx';
+import FrameScheduleModal from './components/FrameScheduleModal.jsx';
+import FramesModal from './components/FramesModal.jsx';
 import MobileWelcomeModal from './components/MobileWelcomeModal.jsx';
 import DesktopWelcomeModal from './components/DesktopWelcomeModal.jsx';
 import SpotlightModal from './components/SpotlightModal.jsx';
@@ -10682,110 +10685,10 @@ const DayPlanner = () => {
       })()}
 
       {/* Frame Adjust Time Modal */}
-      {frameAdjustModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[70]" onClick={() => setFrameAdjustModal(null)}>
-          <div className={`${cardBg} rounded-lg shadow-xl p-5 border ${borderClass} w-72`} onClick={(e) => e.stopPropagation()}>
-            <h3 className={`font-semibold ${textPrimary} mb-4`}>Adjust Frame Time</h3>
-            <p className={`text-xs ${textSecondary} mb-3`}>For {frameAdjustModal.dateStr} only</p>
-            <div className="space-y-3">
-              <div>
-                <label className={`text-xs font-medium ${textSecondary} block mb-1`}>Start</label>
-                <button type="button" onClick={() => setFrameAdjustTimeField('start')}
-                  className={`w-full px-3 py-2 rounded-lg border ${borderClass} ${cardBg} ${textPrimary} text-sm text-left`}>
-                  {frameAdjustModal.start}
-                </button>
-              </div>
-              <div>
-                <label className={`text-xs font-medium ${textSecondary} block mb-1`}>End</label>
-                <button type="button" onClick={() => setFrameAdjustTimeField('end')}
-                  className={`w-full px-3 py-2 rounded-lg border ${borderClass} ${cardBg} ${textPrimary} text-sm text-left`}>
-                  {frameAdjustModal.end}
-                </button>
-              </div>
-            </div>
-            {frameAdjustTimeField && (
-              <ClockTimePicker
-                value={frameAdjustTimeField === 'start' ? frameAdjustModal.start : frameAdjustModal.end}
-                onChange={(t) => { setFrameAdjustModal(prev => ({ ...prev, [frameAdjustTimeField]: t })); setFrameAdjustTimeField(null); }}
-                onClose={() => setFrameAdjustTimeField(null)}
-                darkMode={darkMode} isTablet={isTablet} use24HourClock={use24HourClock}
-              />
-            )}
-            <div className="flex gap-2 mt-4">
-              <button onClick={() => setFrameAdjustModal(null)} className={`flex-1 px-3 py-2 rounded-lg text-sm ${textSecondary} ${hoverBg} transition-colors`}>Cancel</button>
-              <button onClick={saveFrameAdjust} className="flex-1 px-3 py-2 rounded-lg text-sm bg-blue-600 text-white hover:bg-blue-700 transition-colors">Save</button>
-            </div>
-          </div>
-        </div>
-      )}
+      {frameAdjustModal && <FrameAdjustModal />}
 
       {/* Frame Manually Schedule Modal */}
-      {frameScheduleModal && (() => {
-        const inboxTasks = unscheduledTasks.filter(t => !t.completed && !t.isExample && (!t.deadline || t.deadline === frameScheduleModal.dateStr)).sort((a, b) => {
-          const aHasDeadline = a.deadline ? 1 : 0;
-          const bHasDeadline = b.deadline ? 1 : 0;
-          if (bHasDeadline !== aHasDeadline) return bHasDeadline - aHasDeadline;
-          return (b.priority || 0) - (a.priority || 0);
-        });
-        const frameInstance = {
-          frameId: frameScheduleModal.frameId,
-          date: frameScheduleModal.dateStr,
-          start: frameScheduleModal.frame.start,
-          end: frameScheduleModal.frame.end,
-          bufferMinutes: frameScheduleModal.frame.bufferMinutes ?? 5,
-        };
-        const availableSlots = computeAvailableSlots(frameInstance, new Date(frameScheduleModal.dateStr + 'T12:00:00'));
-        const totalAvailable = availableSlots.reduce((sum, s) => sum + s.minutes, 0);
-        return (
-          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[70]" onClick={() => setFrameScheduleModal(null)}>
-            <div className={`${cardBg} rounded-lg shadow-xl border ${borderClass} w-80 max-h-[70vh] flex flex-col`} onClick={(e) => e.stopPropagation()}>
-              <div className={`p-4 border-b ${borderClass}`}>
-                <h3 className={`font-semibold ${textPrimary}`}>Manually Schedule</h3>
-                <p className={`text-xs ${textSecondary} mt-1`}>
-                  {frameScheduleModal.frame.label} &middot; {frameScheduleModal.dateStr}
-                </p>
-                <p className="mt-1.5">
-                  <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${darkMode ? 'bg-blue-900/40 text-blue-300' : 'bg-blue-100 text-blue-700'}`}>{totalAvailable}min available</span>
-                </p>
-              </div>
-              <div className="flex-1 overflow-y-auto p-2">
-                {inboxTasks.length === 0 ? (
-                  <div className={`text-center py-8 ${textSecondary} text-sm`}>
-                    <Inbox size={24} className="mx-auto mb-2 opacity-50" />
-                    No inbox tasks to schedule
-                  </div>
-                ) : (
-                  inboxTasks.map(task => {
-                    const fits = availableSlots.some(s => s.minutes >= (task.duration || 30));
-                    return (
-                      <button
-                        key={task.id}
-                        className={`w-full text-left px-3 py-2.5 rounded-lg mb-1 transition-colors flex items-start gap-2 ${!fits ? 'opacity-50 cursor-not-allowed' : hoverBg}`}
-                        onClick={() => fits && manuallyScheduleTask(task.id)}
-                        disabled={!fits}
-                        title={!fits ? `No slot large enough for ${task.duration || 30}min task` : `Schedule in ${frameScheduleModal.frame.label}`}
-                      >
-                        <div className={`w-2 h-2 rounded-full mt-1.5 flex-shrink-0 ${task.color || 'bg-blue-500'}`} />
-                        <div className="flex-1 min-w-0">
-                          <div className={`text-sm ${textPrimary} truncate`}>{stripWikilinks(task.title)}</div>
-                          <div className={`text-xs ${textSecondary} flex items-center gap-2 mt-0.5`}>
-                            <span>{task.duration || 30}min</span>
-                            {task.priority >= 1 && <span className={task.priority >= 2 ? 'text-red-500' : 'text-amber-500'}>P{task.priority}</span>}
-                            {task.deadline && <span className="flex items-center gap-0.5"><Calendar size={10} />{task.deadline}</span>}
-                          </div>
-                        </div>
-                      </button>
-                    );
-                  })
-                )}
-              </div>
-              <div className={`p-3 border-t ${borderClass}`}>
-                <button onClick={() => setFrameScheduleModal(null)} className={`w-full px-3 py-2 rounded-lg text-sm ${textSecondary} ${hoverBg} transition-colors`}>Cancel</button>
-              </div>
-            </div>
-          </div>
-        );
-      })()}
+      {frameScheduleModal && <FrameScheduleModal />}
 
       {/* Weekly Review Modal */}
       {showWeeklyReview && (() => {
@@ -11728,142 +11631,7 @@ const DayPlanner = () => {
       )}
 
       {/* GTD Frames Modal (Desktop/Tablet) */}
-      {showFramesModal && !isMobile && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={() => { setShowFramesModal(false); setEditingFrame(null); }}>
-          <div className="absolute inset-0 bg-black/40" />
-          <div
-            className={`relative ${cardBg} rounded-2xl shadow-xl w-full max-w-lg max-h-[80vh] overflow-y-auto`}
-            onClick={e => e.stopPropagation()}
-          >
-            <div className={`sticky top-0 ${cardBg} z-10 px-6 pt-5 pb-3 border-b ${borderClass}`}>
-              <div className="flex items-center justify-between mb-3">
-                <h2 className={`text-lg font-semibold ${textPrimary}`}>GTD Frames</h2>
-                <button onClick={() => { setShowFramesModal(false); setEditingFrame(null); }} className={`p-1.5 rounded-lg ${hoverBg} transition-colors`}>
-                  <X size={18} className={textSecondary} />
-                </button>
-              </div>
-              {/* Tab switcher — only show when AI scheduling is enabled */}
-              {aiConfig?.enabled && aiConfig.features?.smartScheduling && (
-              <div className={`flex rounded-lg ${darkMode ? 'bg-gray-800' : 'bg-stone-200'} p-0.5`}>
-                <button
-                  onClick={() => setFramesModalTab('frames')}
-                  className={`flex-1 py-2 rounded-md text-sm font-medium transition-colors ${framesModalTab === 'frames' ? (darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900 shadow-sm') : textSecondary}`}
-                >
-                  My Frames
-                </button>
-                <button
-                  onClick={() => setFramesModalTab('schedule')}
-                  className={`flex-1 py-2 rounded-md text-sm font-medium transition-colors ${framesModalTab === 'schedule' ? (darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900 shadow-sm') : textSecondary}`}
-                >
-                  Smart Schedule
-                </button>
-              </div>
-              )}
-            </div>
-
-            <div className="px-6 py-4">
-              {framesModalTab === 'frames' && (
-                <>
-                  {editingFrame ? (
-                    <FrameEditor
-                      frame={editingFrame === 'new' ? null : editingFrame}
-                      onSave={saveFrame}
-                      onDelete={deleteFrame}
-                      onCancel={() => setEditingFrame(null)}
-                      allTags={allTags}
-                      darkMode={darkMode}
-                      textPrimary={textPrimary}
-                      textSecondary={textSecondary}
-                      borderClass={borderClass}
-                      cardBg={cardBg}
-                      hoverBg={hoverBg}
-                      existingFrames={gtdFrames}
-                      use24HourClock={use24HourClock}
-                      isTablet={isTablet}
-                    />
-                  ) : (
-                    <>
-                      {(() => {
-                        const todayStr = getTodayStr();
-                        const visibleFrames = gtdFrames.filter(f => !f.singleDate || f.singleDate >= todayStr);
-                        return visibleFrames.length === 0 ? (
-                        <div className="flex flex-col items-center justify-center py-12 gap-3">
-                          <LayoutGrid size={48} className={textSecondary} />
-                          <h3 className={`text-lg font-semibold ${textPrimary}`}>No Frames Yet</h3>
-                          <p className={`text-sm ${textSecondary} text-center max-w-xs`}>
-                            Frames are time blocks on your calendar where the AI scheduler can place tasks. Create your first frame to get started.
-                          </p>
-                          <button
-                            onClick={() => setEditingFrame('new')}
-                            className="mt-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors flex items-center gap-2"
-                          >
-                            <Plus size={16} />
-                            Create Frame
-                          </button>
-                        </div>
-                      ) : (
-                        <div className="space-y-2">
-                          {visibleFrames.map(frame => (
-                            <div
-                              key={frame.id}
-                              onClick={() => setEditingFrame(frame)}
-                              className={`p-3 rounded-lg border ${borderClass} cursor-pointer ${hoverBg} transition-colors`}
-                            >
-                              <div className="flex items-center gap-2">
-                                <div className={`w-3 h-3 rounded-full ${frame.color}`} />
-                                <span className={`font-medium text-sm ${textPrimary}`}>{frame.label}</span>
-                                {frame.singleDate && <span className={`text-[10px] px-1.5 py-0.5 rounded ${darkMode ? 'bg-purple-900/50 text-purple-300' : 'bg-purple-100 text-purple-700'}`}>one-time</span>}
-                                {!frame.enabled && <span className={`text-[10px] px-1.5 py-0.5 rounded ${darkMode ? 'bg-gray-700' : 'bg-stone-200'} ${textSecondary}`}>Off</span>}
-                              </div>
-                              <div className={`text-xs ${textSecondary} mt-1`}>
-                                {formatTime(frame.start)} – {formatTime(frame.end)} · {frame.singleDate
-                                  ? new Date(frame.singleDate + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-                                  : frame.days.map(d => DAY_LABELS[d]).join(', ')}
-                                {frame.energyLevel !== 'medium' && ` · ${frame.energyLevel} energy`}
-                              </div>
-                            </div>
-                          ))}
-                          <button
-                            onClick={() => setEditingFrame('new')}
-                            className={`w-full p-3 rounded-lg border border-dashed ${borderClass} text-sm ${textSecondary} flex items-center justify-center gap-2 ${hoverBg} transition-colors`}
-                          >
-                            <Plus size={16} />
-                            Add Frame
-                          </button>
-                        </div>
-                      );
-                      })()}
-                    </>
-                  )}
-                </>
-              )}
-
-              {aiConfig?.enabled && aiConfig.features?.smartScheduling && framesModalTab === 'schedule' && (
-                <SmartSchedulePanel
-                  aiConfig={aiConfig}
-                  inboxTasks={unscheduledTasks.filter(t => !t.completed && !t.isExample)}
-                  smartScheduleResults={smartScheduleResults}
-                  smartScheduleLoading={smartScheduleLoading}
-                  smartScheduleError={smartScheduleError}
-                  smartScheduleAccepted={smartScheduleAccepted}
-                  setSmartScheduleAccepted={setSmartScheduleAccepted}
-                  onRun={runSmartSchedule}
-                  onApply={applySmartSchedule}
-                  onCancel={() => { setSmartScheduleResults(null); setSmartScheduleError(''); }}
-                  darkMode={darkMode}
-                  textPrimary={textPrimary}
-                  textSecondary={textSecondary}
-                  borderClass={borderClass}
-                  cardBg={cardBg}
-                  hoverBg={hoverBg}
-                  gtdFrames={gtdFrames}
-                  formatTime={formatTime}
-                />
-              )}
-            </div>
-          </div>
-        </div>
-      )}
+      {showFramesModal && !isMobile && <FramesModal />}
     </div>
     </DayPlannerContext.Provider>
   );

--- a/src/components/FrameAdjustModal.jsx
+++ b/src/components/FrameAdjustModal.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import ClockTimePicker from './ClockTimePicker.jsx';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+
+const FrameAdjustModal = () => {
+  const {
+    frameAdjustModal, setFrameAdjustModal,
+    frameAdjustTimeField, setFrameAdjustTimeField,
+    saveFrameAdjust,
+    darkMode, isTablet, use24HourClock,
+    cardBg, borderClass, textPrimary, textSecondary, hoverBg,
+  } = useDayPlannerCtx();
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[70]" onClick={() => setFrameAdjustModal(null)}>
+      <div className={`${cardBg} rounded-lg shadow-xl p-5 border ${borderClass} w-72`} onClick={(e) => e.stopPropagation()}>
+        <h3 className={`font-semibold ${textPrimary} mb-4`}>Adjust Frame Time</h3>
+        <p className={`text-xs ${textSecondary} mb-3`}>For {frameAdjustModal.dateStr} only</p>
+        <div className="space-y-3">
+          <div>
+            <label className={`text-xs font-medium ${textSecondary} block mb-1`}>Start</label>
+            <button type="button" onClick={() => setFrameAdjustTimeField('start')}
+              className={`w-full px-3 py-2 rounded-lg border ${borderClass} ${cardBg} ${textPrimary} text-sm text-left`}>
+              {frameAdjustModal.start}
+            </button>
+          </div>
+          <div>
+            <label className={`text-xs font-medium ${textSecondary} block mb-1`}>End</label>
+            <button type="button" onClick={() => setFrameAdjustTimeField('end')}
+              className={`w-full px-3 py-2 rounded-lg border ${borderClass} ${cardBg} ${textPrimary} text-sm text-left`}>
+              {frameAdjustModal.end}
+            </button>
+          </div>
+        </div>
+        {frameAdjustTimeField && (
+          <ClockTimePicker
+            value={frameAdjustTimeField === 'start' ? frameAdjustModal.start : frameAdjustModal.end}
+            onChange={(t) => { setFrameAdjustModal(prev => ({ ...prev, [frameAdjustTimeField]: t })); setFrameAdjustTimeField(null); }}
+            onClose={() => setFrameAdjustTimeField(null)}
+            darkMode={darkMode} isTablet={isTablet} use24HourClock={use24HourClock}
+          />
+        )}
+        <div className="flex gap-2 mt-4">
+          <button onClick={() => setFrameAdjustModal(null)} className={`flex-1 px-3 py-2 rounded-lg text-sm ${textSecondary} ${hoverBg} transition-colors`}>Cancel</button>
+          <button onClick={saveFrameAdjust} className="flex-1 px-3 py-2 rounded-lg text-sm bg-blue-600 text-white hover:bg-blue-700 transition-colors">Save</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FrameAdjustModal;

--- a/src/components/FrameScheduleModal.jsx
+++ b/src/components/FrameScheduleModal.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Inbox, Calendar } from 'lucide-react';
+import { stripWikilinks } from '../utils/taskUtils.js';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+
+const FrameScheduleModal = () => {
+  const {
+    frameScheduleModal, setFrameScheduleModal,
+    unscheduledTasks,
+    computeAvailableSlots, manuallyScheduleTask,
+    darkMode,
+    cardBg, borderClass, textPrimary, textSecondary, hoverBg,
+  } = useDayPlannerCtx();
+
+  const inboxTasks = unscheduledTasks.filter(t => !t.completed && !t.isExample && (!t.deadline || t.deadline === frameScheduleModal.dateStr)).sort((a, b) => {
+    const aHasDeadline = a.deadline ? 1 : 0;
+    const bHasDeadline = b.deadline ? 1 : 0;
+    if (bHasDeadline !== aHasDeadline) return bHasDeadline - aHasDeadline;
+    return (b.priority || 0) - (a.priority || 0);
+  });
+  const frameInstance = {
+    frameId: frameScheduleModal.frameId,
+    date: frameScheduleModal.dateStr,
+    start: frameScheduleModal.frame.start,
+    end: frameScheduleModal.frame.end,
+    bufferMinutes: frameScheduleModal.frame.bufferMinutes ?? 5,
+  };
+  const availableSlots = computeAvailableSlots(frameInstance, new Date(frameScheduleModal.dateStr + 'T12:00:00'));
+  const totalAvailable = availableSlots.reduce((sum, s) => sum + s.minutes, 0);
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[70]" onClick={() => setFrameScheduleModal(null)}>
+      <div className={`${cardBg} rounded-lg shadow-xl border ${borderClass} w-80 max-h-[70vh] flex flex-col`} onClick={(e) => e.stopPropagation()}>
+        <div className={`p-4 border-b ${borderClass}`}>
+          <h3 className={`font-semibold ${textPrimary}`}>Manually Schedule</h3>
+          <p className={`text-xs ${textSecondary} mt-1`}>
+            {frameScheduleModal.frame.label} &middot; {frameScheduleModal.dateStr}
+          </p>
+          <p className="mt-1.5">
+            <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${darkMode ? 'bg-blue-900/40 text-blue-300' : 'bg-blue-100 text-blue-700'}`}>{totalAvailable}min available</span>
+          </p>
+        </div>
+        <div className="flex-1 overflow-y-auto p-2">
+          {inboxTasks.length === 0 ? (
+            <div className={`text-center py-8 ${textSecondary} text-sm`}>
+              <Inbox size={24} className="mx-auto mb-2 opacity-50" />
+              No inbox tasks to schedule
+            </div>
+          ) : (
+            inboxTasks.map(task => {
+              const fits = availableSlots.some(s => s.minutes >= (task.duration || 30));
+              return (
+                <button
+                  key={task.id}
+                  className={`w-full text-left px-3 py-2.5 rounded-lg mb-1 transition-colors flex items-start gap-2 ${!fits ? 'opacity-50 cursor-not-allowed' : hoverBg}`}
+                  onClick={() => fits && manuallyScheduleTask(task.id)}
+                  disabled={!fits}
+                  title={!fits ? `No slot large enough for ${task.duration || 30}min task` : `Schedule in ${frameScheduleModal.frame.label}`}
+                >
+                  <div className={`w-2 h-2 rounded-full mt-1.5 flex-shrink-0 ${task.color || 'bg-blue-500'}`} />
+                  <div className="flex-1 min-w-0">
+                    <div className={`text-sm ${textPrimary} truncate`}>{stripWikilinks(task.title)}</div>
+                    <div className={`text-xs ${textSecondary} flex items-center gap-2 mt-0.5`}>
+                      <span>{task.duration || 30}min</span>
+                      {task.priority >= 1 && <span className={task.priority >= 2 ? 'text-red-500' : 'text-amber-500'}>P{task.priority}</span>}
+                      {task.deadline && <span className="flex items-center gap-0.5"><Calendar size={10} />{task.deadline}</span>}
+                    </div>
+                  </div>
+                </button>
+              );
+            })
+          )}
+        </div>
+        <div className={`p-3 border-t ${borderClass}`}>
+          <button onClick={() => setFrameScheduleModal(null)} className={`w-full px-3 py-2 rounded-lg text-sm ${textSecondary} ${hoverBg} transition-colors`}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FrameScheduleModal;

--- a/src/components/FramesModal.jsx
+++ b/src/components/FramesModal.jsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { X, Plus, LayoutGrid } from 'lucide-react';
+import { DAY_LABELS } from '../constants/frames.js';
+import FrameEditor from './FrameEditor.jsx';
+import SmartSchedulePanel from './SmartSchedulePanel.jsx';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+
+const FramesModal = () => {
+  const {
+    setShowFramesModal,
+    editingFrame, setEditingFrame,
+    framesModalTab, setFramesModalTab,
+    gtdFrames, allTags,
+    aiConfig,
+    unscheduledTasks,
+    smartScheduleResults, smartScheduleLoading, smartScheduleError,
+    smartScheduleAccepted, setSmartScheduleAccepted,
+    runSmartSchedule, applySmartSchedule, setSmartScheduleResults, setSmartScheduleError,
+    saveFrame, deleteFrame,
+    getTodayStr, formatTime,
+    darkMode, isTablet, use24HourClock,
+    cardBg, borderClass, textPrimary, textSecondary, hoverBg,
+  } = useDayPlannerCtx();
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={() => { setShowFramesModal(false); setEditingFrame(null); }}>
+      <div className="absolute inset-0 bg-black/40" />
+      <div
+        className={`relative ${cardBg} rounded-2xl shadow-xl w-full max-w-lg max-h-[80vh] overflow-y-auto`}
+        onClick={e => e.stopPropagation()}
+      >
+        <div className={`sticky top-0 ${cardBg} z-10 px-6 pt-5 pb-3 border-b ${borderClass}`}>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className={`text-lg font-semibold ${textPrimary}`}>GTD Frames</h2>
+            <button onClick={() => { setShowFramesModal(false); setEditingFrame(null); }} className={`p-1.5 rounded-lg ${hoverBg} transition-colors`}>
+              <X size={18} className={textSecondary} />
+            </button>
+          </div>
+          {/* Tab switcher — only show when AI scheduling is enabled */}
+          {aiConfig?.enabled && aiConfig.features?.smartScheduling && (
+          <div className={`flex rounded-lg ${darkMode ? 'bg-gray-800' : 'bg-stone-200'} p-0.5`}>
+            <button
+              onClick={() => setFramesModalTab('frames')}
+              className={`flex-1 py-2 rounded-md text-sm font-medium transition-colors ${framesModalTab === 'frames' ? (darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900 shadow-sm') : textSecondary}`}
+            >
+              My Frames
+            </button>
+            <button
+              onClick={() => setFramesModalTab('schedule')}
+              className={`flex-1 py-2 rounded-md text-sm font-medium transition-colors ${framesModalTab === 'schedule' ? (darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900 shadow-sm') : textSecondary}`}
+            >
+              Smart Schedule
+            </button>
+          </div>
+          )}
+        </div>
+
+        <div className="px-6 py-4">
+          {framesModalTab === 'frames' && (
+            <>
+              {editingFrame ? (
+                <FrameEditor
+                  frame={editingFrame === 'new' ? null : editingFrame}
+                  onSave={saveFrame}
+                  onDelete={deleteFrame}
+                  onCancel={() => setEditingFrame(null)}
+                  allTags={allTags}
+                  darkMode={darkMode}
+                  textPrimary={textPrimary}
+                  textSecondary={textSecondary}
+                  borderClass={borderClass}
+                  cardBg={cardBg}
+                  hoverBg={hoverBg}
+                  existingFrames={gtdFrames}
+                  use24HourClock={use24HourClock}
+                  isTablet={isTablet}
+                />
+              ) : (
+                <>
+                  {(() => {
+                    const todayStr = getTodayStr();
+                    const visibleFrames = gtdFrames.filter(f => !f.singleDate || f.singleDate >= todayStr);
+                    return visibleFrames.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center py-12 gap-3">
+                      <LayoutGrid size={48} className={textSecondary} />
+                      <h3 className={`text-lg font-semibold ${textPrimary}`}>No Frames Yet</h3>
+                      <p className={`text-sm ${textSecondary} text-center max-w-xs`}>
+                        Frames are time blocks on your calendar where the AI scheduler can place tasks. Create your first frame to get started.
+                      </p>
+                      <button
+                        onClick={() => setEditingFrame('new')}
+                        className="mt-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors flex items-center gap-2"
+                      >
+                        <Plus size={16} />
+                        Create Frame
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="space-y-2">
+                      {visibleFrames.map(frame => (
+                        <div
+                          key={frame.id}
+                          onClick={() => setEditingFrame(frame)}
+                          className={`p-3 rounded-lg border ${borderClass} cursor-pointer ${hoverBg} transition-colors`}
+                        >
+                          <div className="flex items-center gap-2">
+                            <div className={`w-3 h-3 rounded-full ${frame.color}`} />
+                            <span className={`font-medium text-sm ${textPrimary}`}>{frame.label}</span>
+                            {frame.singleDate && <span className={`text-[10px] px-1.5 py-0.5 rounded ${darkMode ? 'bg-purple-900/50 text-purple-300' : 'bg-purple-100 text-purple-700'}`}>one-time</span>}
+                            {!frame.enabled && <span className={`text-[10px] px-1.5 py-0.5 rounded ${darkMode ? 'bg-gray-700' : 'bg-stone-200'} ${textSecondary}`}>Off</span>}
+                          </div>
+                          <div className={`text-xs ${textSecondary} mt-1`}>
+                            {formatTime(frame.start)} – {formatTime(frame.end)} · {frame.singleDate
+                              ? new Date(frame.singleDate + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+                              : frame.days.map(d => DAY_LABELS[d]).join(', ')}
+                            {frame.energyLevel !== 'medium' && ` · ${frame.energyLevel} energy`}
+                          </div>
+                        </div>
+                      ))}
+                      <button
+                        onClick={() => setEditingFrame('new')}
+                        className={`w-full p-3 rounded-lg border border-dashed ${borderClass} text-sm ${textSecondary} flex items-center justify-center gap-2 ${hoverBg} transition-colors`}
+                      >
+                        <Plus size={16} />
+                        Add Frame
+                      </button>
+                    </div>
+                  );
+                  })()}
+                </>
+              )}
+            </>
+          )}
+
+          {aiConfig?.enabled && aiConfig.features?.smartScheduling && framesModalTab === 'schedule' && (
+            <SmartSchedulePanel
+              aiConfig={aiConfig}
+              inboxTasks={unscheduledTasks.filter(t => !t.completed && !t.isExample)}
+              smartScheduleResults={smartScheduleResults}
+              smartScheduleLoading={smartScheduleLoading}
+              smartScheduleError={smartScheduleError}
+              smartScheduleAccepted={smartScheduleAccepted}
+              setSmartScheduleAccepted={setSmartScheduleAccepted}
+              onRun={runSmartSchedule}
+              onApply={applySmartSchedule}
+              onCancel={() => { setSmartScheduleResults(null); setSmartScheduleError(''); }}
+              darkMode={darkMode}
+              textPrimary={textPrimary}
+              textSecondary={textSecondary}
+              borderClass={borderClass}
+              cardBg={cardBg}
+              hoverBg={hoverBg}
+              gtdFrames={gtdFrames}
+              formatTime={formatTime}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FramesModal;


### PR DESCRIPTION
Extracts three inline frame-related modals from App.jsx:

- `FrameAdjustModal` — adjust frame start/end time for a specific date
- `FrameScheduleModal` — manually schedule inbox tasks into a frame slot
- `FramesModal` — main GTD Frames management modal (desktop/tablet only), includes FrameEditor and SmartSchedulePanel

All three call `useDayPlannerCtx()` internally. App.jsx replacements:
- `{frameAdjustModal && <FrameAdjustModal />}`
- `{frameScheduleModal && <FrameScheduleModal />}`
- `{showFramesModal && !isMobile && <FramesModal />}`

Build passes ✓