### PR TITLE
Phase 6.4: Extract useTaskMeasurement hook from useTaskDerived

### DIFF
--- a/src/hooks/useTaskDerived.js
+++ b/src/hooks/useTaskDerived.js
@@ -1,5 +1,5 @@
-import { useState, useRef, useEffect } from 'react';
 import { getOccurrencesInRange } from '../utils/recurrenceEngine.js';
+import useTaskMeasurement from './useTaskMeasurement.js';
 
 const timeToMinutes = (time) => {
   const [hours, minutes] = time.split(':').map(Number);
@@ -7,55 +7,7 @@ const timeToMinutes = (time) => {
 };
 
 export default function useTaskDerived({ tasks, recurringTasks, visibleDays, mobileActiveTab }) {
-  const [taskWidths, setTaskWidths] = useState({});
-  const taskElementRefs = useRef({});
-
-  // Measure task widths using ResizeObserver
-  useEffect(() => {
-    const observer = new ResizeObserver((entries) => {
-      const newWidths = {};
-      let hasChanges = false;
-
-      for (const entry of entries) {
-        const taskId = entry.target.dataset.taskId;
-        if (taskId) {
-          const width = entry.contentRect.width;
-          if (taskWidths[taskId] !== width) {
-            newWidths[taskId] = width;
-            hasChanges = true;
-          }
-        }
-      }
-
-      if (hasChanges) {
-        setTaskWidths(prev => ({ ...prev, ...newWidths }));
-      }
-    });
-
-    // Observe all registered task elements
-    Object.values(taskElementRefs.current).forEach(el => {
-      if (el) observer.observe(el);
-    });
-
-    return () => observer.disconnect();
-  }, [tasks, visibleDays, mobileActiveTab]); // Re-setup when tasks, visible days, or mobile tab change
-
-  // Ref callback for task elements
-  const setTaskRef = (taskId) => (element) => {
-    if (element) {
-      taskElementRefs.current[taskId] = element;
-      // Measure after layout settles (calc-based widths need a frame to resolve)
-      requestAnimationFrame(() => {
-        if (!element.isConnected) return;
-        const width = element.offsetWidth;
-        if (width > 0 && taskWidths[taskId] !== width) {
-          setTaskWidths(prev => ({ ...prev, [taskId]: width }));
-        }
-      });
-    } else {
-      delete taskElementRefs.current[taskId];
-    }
-  };
+  const { taskWidths, setTaskRef } = useTaskMeasurement({ tasks, visibleDays, mobileActiveTab });
 
   const getConflictingTasks = (task, allTasks) => {
     const start = timeToMinutes(task.startTime);

--- a/src/hooks/useTaskMeasurement.js
+++ b/src/hooks/useTaskMeasurement.js
@@ -1,0 +1,55 @@
+import { useState, useRef, useEffect } from 'react';
+
+export default function useTaskMeasurement({ tasks, visibleDays, mobileActiveTab }) {
+  const [taskWidths, setTaskWidths] = useState({});
+  const taskElementRefs = useRef({});
+
+  // Measure task widths using ResizeObserver
+  useEffect(() => {
+    const observer = new ResizeObserver((entries) => {
+      const newWidths = {};
+      let hasChanges = false;
+
+      for (const entry of entries) {
+        const taskId = entry.target.dataset.taskId;
+        if (taskId) {
+          const width = entry.contentRect.width;
+          if (taskWidths[taskId] !== width) {
+            newWidths[taskId] = width;
+            hasChanges = true;
+          }
+        }
+      }
+
+      if (hasChanges) {
+        setTaskWidths(prev => ({ ...prev, ...newWidths }));
+      }
+    });
+
+    // Observe all registered task elements
+    Object.values(taskElementRefs.current).forEach(el => {
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [tasks, visibleDays, mobileActiveTab]); // Re-setup when tasks, visible days, or mobile tab change
+
+  // Ref callback for task elements
+  const setTaskRef = (taskId) => (element) => {
+    if (element) {
+      taskElementRefs.current[taskId] = element;
+      // Measure after layout settles (calc-based widths need a frame to resolve)
+      requestAnimationFrame(() => {
+        if (!element.isConnected) return;
+        const width = element.offsetWidth;
+        if (width > 0 && taskWidths[taskId] !== width) {
+          setTaskWidths(prev => ({ ...prev, [taskId]: width }));
+        }
+      });
+    } else {
+      delete taskElementRefs.current[taskId];
+    }
+  };
+
+  return { taskWidths, setTaskRef };
+}


### PR DESCRIPTION
Moves taskWidths state, taskElementRefs ref, ResizeObserver effect, and setTaskRef callback into a dedicated useTaskMeasurement hook. useTaskDerived now imports and delegates to it.

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta