### PR TITLE
fix: guard against undefined URL in _getBackupDirUrl

### DIFF
--- a/src/utils/autoBackup.js
+++ b/src/utils/autoBackup.js
@@ -87,6 +87,7 @@ export const autoBackupProviders = {
       { key: 'appPassword', label: 'App Password', type: 'password', placeholder: 'xxxxx-xxxxx-xxxxx-xxxxx-xxxxx' }
     ],
     _getBackupDirUrl(config) {
+      if (!config.nextcloudUrl) throw new Error('Nextcloud URL is not configured');
       return `${config.nextcloudUrl.replace(/\/+$/, '')}/remote.php/dav/files/${encodeURIComponent(config.username)}/dayglance/backups/`;
     },
     _getAuthHeaders(config) {


### PR DESCRIPTION
Calling "Enable Automatic Backups" with no Nextcloud URL configured caused a TypeError because _getBackupDirUrl called .replace() on undefined. Now throws a clear error message instead, which surfaces correctly in the UI as a backup failure rather than an uncaught crash.

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta