### PR TITLE
fix: set color-scheme on root element to match app theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -854,6 +854,7 @@ const DayPlanner = () => {
   useEffect(() => {
     localStorage.setItem('day-planner-darkmode', JSON.stringify(darkMode));
     document.documentElement.classList.toggle('dark', darkMode);
+    document.documentElement.style.colorScheme = darkMode ? 'dark' : 'light';
     document.documentElement.style.backgroundColor = darkMode ? '#1f2937' : '#ffffff';
     const themeColorMeta = document.querySelector('meta[name="theme-color"]');
     if (themeColorMeta) themeColorMeta.setAttribute('content', darkMode ? '#1f2937' : '#ffffff');


### PR DESCRIPTION
Browser-native form controls (checkboxes, text inputs, selects) derive their appearance from the OS color-scheme, not the app's CSS theme class. When the OS is in dark mode but the app is in light mode, inputs rendered with dark styling: checkboxes appeared black when unchecked, and text in inputs was invisible (white text on white background).

Setting document.documentElement.style.colorScheme = 'light' | 'dark' alongside the existing .dark class toggle ensures native form controls always match the app's active theme regardless of OS preference.

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta