### PR TITLE
fix: strip tags from timeline task title when rendered separately below

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -9,7 +9,7 @@ import {
   SkipForward, Sparkles, Sun, Target, Trash2, Upload, X,
 } from 'lucide-react';
 import { isNativeAndroid, nativeUpdateEvent } from '../native.js';
-import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks } from '../utils/textFormatting.jsx';
+import { renderTitle, renderTitleWithoutTags, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks } from '../utils/textFormatting.jsx';
 import { dateToString, extractTags, extractWikilinks, formatDate, formatDateRange, formatDeadlineDate, formatShortDate, stripWikilinks } from '../utils/taskUtils.js';
 import { HABIT_COLORS, HABIT_ICONS } from '../constants/habits.js';
 import { HabitRing, MiniHabitRing } from './HabitRing.jsx';
@@ -4228,7 +4228,7 @@ const DesktopLayout = () => {
                                                 } : undefined}
                                                 title={task.title}
                                               >
-                                                {stripWikilinks(task.title)}
+                                                {renderTitleWithoutTags(task.title)}
                                               </div>
                                               {isNativeAndroid() && extractWikilinks(task.title).map((note, i) => (
                                                 <button key={i} className="flex-shrink-0 text-purple-200 active:text-purple-100" onClick={(e) => { e.stopPropagation(); window.DayGlanceObsidian?.openNote(note); }} title={`Open "${note}" in Obsidian`}><NotebookPen size={14} /></button>
@@ -4302,7 +4302,7 @@ const DesktopLayout = () => {
                                                 } : undefined}
                                                 title={!isImported && !isTablet ? "Double-click to edit" : undefined}
                                               >
-                                                {stripWikilinks(task.title)}
+                                                {renderTitleWithoutTags(task.title)}
                                               </div>
                                               {isNativeAndroid() && extractWikilinks(task.title).map((note, i) => (
                                                 <button key={i} className="flex-shrink-0 text-purple-200 active:text-purple-100" onClick={(e) => { e.stopPropagation(); window.DayGlanceObsidian?.openNote(note); }} title={`Open "${note}" in Obsidian`}><NotebookPen size={14} /></button>


### PR DESCRIPTION
In DesktopLayout timeline task blocks, stripWikilinks(task.title) was used to render the title, which strips [[wikilinks]] but leaves #hashtags intact. Since the tag line below (extractTags) already renders tags styled on their own line, the tags appeared twice: raw inline with the title and again styled below it.

Replace stripWikilinks with renderTitleWithoutTags in both narrow and wide task layout variants so the title displays clean text while tags appear only in the dedicated tag line.

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta