### PR TITLE
fix: Today button below date nav at <1080px, original layout at >=1080px

### DIFF
--- a/src/components/DesktopHeader.jsx
+++ b/src/components/DesktopHeader.jsx
@@ -88,9 +88,10 @@ const DesktopHeader = () => {
         </div>
 
         {/* Center: Logo + Date Nav */}
-        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-        <div className="grid grid-cols-[1fr_auto_1fr] items-center pointer-events-auto">
-          <div className="flex justify-end pr-2">
+        {/* Narrow (<1080px): shift up + stack Today below. Wide: original 3-col grid centered. */}
+        <div className="absolute inset-0 flex items-start pt-2 min-[1080px]:items-center min-[1080px]:pt-0 justify-center pointer-events-none">
+        <div className="flex flex-col items-center gap-1 min-[1080px]:grid min-[1080px]:grid-cols-[1fr_auto_1fr] min-[1080px]:gap-0 pointer-events-auto">
+          <div className="hidden min-[1080px]:flex justify-end pr-2">
             <img src={darkMode ? '/dayglance-dark.svg' : '/dayglance-light.svg'} alt="dayGLANCE" className="h-10" />
           </div>
           <div className="flex items-center gap-1 relative">
@@ -156,7 +157,7 @@ const DesktopHeader = () => {
               </div>
             )}
           </div>
-          <div className="flex justify-start pl-5">
+          <div className="flex min-[1080px]:justify-start min-[1080px]:pl-5">
             <button
               onClick={goToToday}
               className={`px-3 py-1 text-xs bg-blue-600 text-white rounded-full hover:bg-blue-700 transition-colors${dateToString(selectedDate) === dateToString(new Date()) ? ' invisible' : ''}`}


### PR DESCRIPTION
At <1080px: center section shifts to top of header, date nav and Today button stack vertically (logo hidden to keep date nav truly centered). At >=1080px: original 3-col grid layout (logo | date nav | Today) unchanged.

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta