### PR TITLE
fix: add base URL hints for known OpenAI-compatible providers in AI s…

### DIFF
--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -826,6 +826,11 @@ const MobileSettingsPanel = () => {
                   onChange={(e) => setAiConfig(prev => ({ ...prev, baseUrl: e.target.value }))}
                   className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
                 />
+                {aiConfig.provider === 'custom' && (
+                  <p className={`text-xs ${textSecondary} mt-1`}>
+                    Common providers: OpenRouter → <code className="font-mono">https://openrouter.ai/api/v1</code> · Groq → <code className="font-mono">https://api.groq.com/openai/v1</code> · Together AI → <code className="font-mono">https://api.together.xyz/v1</code> · LM Studio → <code className="font-mono">http://localhost:1234/v1</code>
+                  </p>
+                )}
               </div>
             )}
 

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -604,6 +604,11 @@ const SettingsModal = () => {
                                 onChange={(e) => setAiConfig(prev => ({ ...prev, baseUrl: e.target.value }))}
                                 className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
                               />
+                              {aiConfig.provider === 'custom' && (
+                                <p className={`text-xs ${textSecondary} mt-1`}>
+                                  Common providers: OpenRouter → <code className="font-mono">https://openrouter.ai/api/v1</code> · Groq → <code className="font-mono">https://api.groq.com/openai/v1</code> · Together AI → <code className="font-mono">https://api.together.xyz/v1</code> · LM Studio → <code className="font-mono">http://localhost:1234/v1</code>
+                                </p>
+                              )}
                             </div>
                           )}
 


### PR DESCRIPTION
…ettings

When "Custom (OpenAI-compatible)" is selected, show example base URLs for OpenRouter, Groq, Together AI, and LM Studio below the input field. Applied to both desktop (SettingsModal) and mobile (MobileSettingsPanel).

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta