### PR TITLE
fix: remove Routines FAB from mobile dayglance tab

### DIFF
--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -3129,16 +3129,6 @@ const MobileLayout = () => {
                   <Activity size={22} />
                 </button>
               )}
-              {/* Routines FAB */}
-              {routinesEnabled && (
-                <button
-                  onClick={() => setMobileActiveTab('routines')}
-                  className={`fixed right-4 z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-200 text-stone-600 active:bg-stone-300'}`}
-                  style={{ bottom: `calc(${(recycleBin.filter(t => !t.isExample).length > 0 ? 16.5 : 12.5) + (habitsEnabled ? 4 : 0)}rem + env(safe-area-inset-bottom, 0px))` }}
-                >
-                  <Sparkles size={22} />
-                </button>
-              )}
             </>
           )}
 


### PR DESCRIPTION
Routines is already accessible as a dedicated tab in the mobile nav bar, making the FAB redundant.

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta