### PR TITLE
feat: extract URL from shared task title into notes for link action b…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import { checkForUpdate } from './versionCheck.js';
 import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { cloudSyncProviders } from './utils/cloudSyncProviders.js';
 import { autoBackupDB, autoBackupProviders, AUTO_BACKUP_RETENTION, AUTO_BACKUP_INTERVALS } from './utils/autoBackup.js';
-import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOnlyTask, getLinkUrl, hasOnlySubtasks, renderTitle, highlightMatch, renderTitleWithoutTags } from './utils/textFormatting.jsx';
+import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOnlyTask, getLinkUrl, hasOnlySubtasks, renderTitle, highlightMatch, renderTitleWithoutTags, extractShareTitle } from './utils/textFormatting.jsx';
 import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate } from './utils/taskUtils.js';
 import { TASK_COLORS, TAILWIND_TO_HEX, taskColorToHex } from './utils/colorUtils.js';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from './constants/habits.js';
@@ -4621,8 +4621,10 @@ const DayPlanner = () => {
       } else if (pending.action === 'add_inbox_task') {
         openNewInboxTask();
       } else if (pending.action === 'share' && pending.text) {
+        const { title: shareTitle, notes: shareNotes } = extractShareTitle(pending.text);
         setNewTask({
-          title: pending.text,
+          title: shareTitle,
+          notes: shareNotes || undefined,
           startTime: getNextQuarterHour(),
           duration: 30,
           date: dateToString(selectedDate),

--- a/src/utils/textFormatting.jsx
+++ b/src/utils/textFormatting.jsx
@@ -141,6 +141,42 @@ export const getLinkUrl = (task) => {
   return task.notes?.trim() || null;
 };
 
+// Given shared text (from Android share sheet or web share target), extract a human-readable
+// title and move any URL to notes so the link action button appears on the task.
+//
+// Handles two forms:
+//   "Page Title https://example.com/path"  →  title="Page Title", notes="https://..."
+//   "https://example.com/path"             →  title="example.com", notes="https://..."
+//
+// Returns { title, notes } — notes may be empty string if no URL was found.
+export const extractShareTitle = (text) => {
+  if (!text) return { title: text || '', notes: '' };
+  const trimmed = text.trim();
+
+  // Single URL regex (non-global, for full-string match)
+  const urlRe = /https?:\/\/[^\s<>"{}|\\^`[\]]+/;
+
+  // Case 1: entire string is a URL — derive title from hostname
+  if (isOnlyUrl(trimmed)) {
+    let hostname = trimmed;
+    try { hostname = new URL(trimmed).hostname.replace(/^www\./, ''); } catch (_) {}
+    return { title: hostname, notes: trimmed };
+  }
+
+  // Case 2: string ends with a URL preceded by non-URL text
+  const trailingUrl = /^([\s\S]+?)\s+(https?:\/\/[^\s<>"{}|\\^`[\]]+)$/.exec(trimmed);
+  if (trailingUrl) {
+    const beforeUrl = trailingUrl[1].trim();
+    const url = trailingUrl[2];
+    // Only split if the part before the URL isn't itself a URL
+    if (beforeUrl && !urlRe.test(beforeUrl)) {
+      return { title: beforeUrl, notes: url };
+    }
+  }
+
+  return { title: trimmed, notes: '' };
+};
+
 // Check if task has only subtasks (no notes)
 export const hasOnlySubtasks = (task) => {
   return (!task.notes || !task.notes.trim()) && task.subtasks && task.subtasks.length > 0;


### PR DESCRIPTION
…utton

When a URL is shared to dayGLANCE (Android share sheet or web), the task title often contains either a bare URL or "Page Title URL". Now:
- "Today's Headlines https://cnn.com/..." → title="Today's Headlines", notes=URL
- "https://cnn.com" → title="cnn.com", notes=URL

This causes the link action button (ExternalLink icon) to appear on the task, so tapping it opens the URL directly rather than showing it in the task name.

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta