### PR TITLE
fix: forward X-Calendar-Auth as Authorization in calendar proxy

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -71,6 +71,9 @@ server {
         proxy_ssl_server_name on;
         proxy_set_header Host $proxy_host;
         proxy_set_header Accept "text/calendar, text/plain, */*";
+        # Forward X-Calendar-Auth as Authorization to the target CalDAV/iCal server.
+        # This mirrors what webdav-proxy does with X-WebDAV-Auth.
+        proxy_set_header Authorization $http_x_calendar_auth;
         proxy_hide_header Access-Control-Allow-Origin;
 
         # Increase timeouts for slow calendar servers


### PR DESCRIPTION
The calendar-proxy nginx block was missing the header mapping that webdav-proxy already has. Without it, credentials set in dayGLANCE's sync settings were sent to the proxy as X-Calendar-Auth but never forwarded to the target CalDAV server as Authorization — causing Baikal (and other password-protected servers) to return 401 and the app to show a sync error dialog.

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta