### PR TITLE
perf: add CDN cache headers to reduce Vercel Fast Origin Transfer

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,13 +11,13 @@
     {
       "source": "/sw.js",
       "headers": [
-        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=60, must-revalidate" }
       ]
     },
     {
       "source": "/manifest.webmanifest",
       "headers": [
-        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" },
+        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=300, must-revalidate" },
         { "key": "Content-Type", "value": "application/manifest+json" }
       ]
     },
@@ -25,6 +25,12 @@
       "source": "/assets/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=3600, must-revalidate" }
       ]
     }
   ]


### PR DESCRIPTION
sw.js and manifest.webmanifest had no-store which prevented CDN caching, causing every request from every edge region to hit origin. index.html (served via catch-all rewrite) had no explicit header at all.

- sw.js: s-maxage=60 (CDN caches 1 min), browsers always re-validate
- manifest.webmanifest: s-maxage=300 (CDN caches 5 min), browsers re-validate
- index.html / SPA routes: s-maxage=3600 (CDN caches 1 hr), browsers re-validate
- /assets/(*): unchanged (immutable, already optimal)

Vercel auto-invalidates CDN on every deploy so correctness is unaffected.

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta