### PR TITLE
fix: preserve habits/routines enabled state for existing users on upg…

### DIFF
--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -4,7 +4,18 @@ import { dateToString } from '../utils/taskUtils.js';
 const useHabits = ({ playUISound }) => {
   const [habits, setHabits] = useState([]);
   const [habitLogs, setHabitLogs] = useState({});
-  const [habitsEnabled, setHabitsEnabled] = useState(false);
+  const [habitsEnabled, setHabitsEnabled] = useState(() => {
+    // If the user has an explicit stored preference, use it.
+    const stored = localStorage.getItem('day-planner-habits-enabled');
+    if (stored !== null) return JSON.parse(stored);
+    // No stored preference: default OFF for new installs, but ON if the user
+    // already has habit data (upgrade migration — don't silently disable their habits).
+    try {
+      const existing = JSON.parse(localStorage.getItem('day-planner-habits') || '[]');
+      if (existing.length > 0) return true;
+    } catch (_) {}
+    return false;
+  });
   const [showHabitModal, setShowHabitModal] = useState(false);
   const [editingHabit, setEditingHabit] = useState(null); // null = adding new, object = editing
   const [draggedHabitIdx, setDraggedHabitIdx] = useState(null);

--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -14,7 +14,21 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress })
   const [routineDeleteConfirm, setRoutineDeleteConfirm] = useState(null); // { bucket, chipId, chipName }
   const [routineFocusedChipId, setRoutineFocusedChipId] = useState(null); // touch: first tap shows buttons, second executes
   const [routineDurationEditId, setRoutineDurationEditId] = useState(null); // id of routine chip being duration-edited on timeline
-  const [routinesEnabled, setRoutinesEnabled] = useState(false);
+  const [routinesEnabled, setRoutinesEnabled] = useState(() => {
+    // If the user has an explicit stored preference, use it.
+    const stored = localStorage.getItem('day-planner-routines-enabled');
+    if (stored !== null) return JSON.parse(stored);
+    // No stored preference: default OFF for new installs, but ON if the user
+    // already has routine data (upgrade migration — don't silently disable their routines).
+    try {
+      const existing = JSON.parse(localStorage.getItem('day-planner-routine-definitions') || 'null');
+      if (existing) {
+        const hasAny = Object.values(existing).some(arr => arr.length > 0);
+        if (hasAny) return true;
+      }
+    } catch (_) {}
+    return false;
+  });
 
   // Auto-clear today's routines on day rollover
   useEffect(() => {


### PR DESCRIPTION
…rade

The previous 'default to off' change broke existing users: if the localStorage key was absent, the feature would initialize as false and immediately save that, permanently disabling the feature on every reload.

Now uses a lazy initializer that:
1. Reads the stored preference if it exists (normal path)
2. Defaults to true if the user already has data (upgrade migration)
3. Defaults to false only for genuine new installs with no data

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta