### PR TITLE
feat: show action buttons for today's all-day tasks in Glance panel

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -1351,7 +1351,7 @@ const DesktopLayout = () => {
                                   )}
                                 </div>
                               </div>
-                              {relativeLabel === 'Overdue' && !task.completed && (
+                              {(relativeLabel === 'Overdue' || (task._agendaType === 'allday' && !task.imported)) && !task.completed && (
                                 <div className="flex items-center gap-1 flex-shrink-0 mr-5">
                                   {!task.isRecurring && (
                                     <button

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -2419,7 +2419,7 @@ const MobileLayout = () => {
                             )}
                           </div>
                         </div>
-                        {relativeLabel === 'Overdue' && !task.completed && (
+                        {(relativeLabel === 'Overdue' || (task._agendaType === 'allday' && !task.imported)) && !task.completed && (
                           <div className="flex items-center gap-1 flex-shrink-0 mr-5">
                             {!task.isRecurring && (
                               <button


### PR DESCRIPTION
Incomplete all-day tasks now show inbox and complete buttons in the Glance panel, matching the behavior of same-day overdue timed tasks. Imported calendar events are excluded.

https://claude.ai/code/session_01NNb4aMtUNtgVmWJmP3r6Ta