### PR TITLE
debug: temporary cloud sync merge diagnostics

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3996,6 +3996,18 @@ const DayPlanner = () => {
       const localData = buildSyncPayload().data;
       const { data: mergedData, localChanged, remoteChanged } = mergeSyncData(localData, remote.data, syncRetentionDays);
 
+      // TEMP DIAG — remove before release
+      console.log('[CloudSync] merge result:', {
+        localChanged,
+        remoteChanged,
+        localTaskCount: localData.tasks?.length,
+        remoteTaskCount: remote.data?.tasks?.length,
+        mergedTaskCount: mergedData.tasks?.length,
+        localUnschedCount: localData.unscheduledTasks?.length,
+        remoteUnschedCount: remote.data?.unscheduledTasks?.length,
+        mergedUnschedCount: mergedData.unscheduledTasks?.length,
+      });
+
       if (localChanged) {
         applyRemoteData(mergedData);
         localStorage.setItem('day-planner-cloud-sync-local-modified', new Date().toISOString());


### PR DESCRIPTION
## Purpose

Temporary diagnostic logging to identify why Vercel PWA is not receiving changes from Android/Docker during cloud sync.

## What this adds

A `[CloudSync] merge result:` console.log on every sync cycle showing:
- `localChanged` — whether `applyRemoteData` will be called (false = Vercel ignores remote changes)
- `remoteChanged` — whether an upload will follow
- Task counts on local, remote, and merged sides

## How to test

1. Use the Vercel **preview deployment** for this PR (not production)
2. Open DevTools → Console
3. Add a task on Android
4. Wait 60 seconds
5. Look for `[CloudSync] merge result:` entries — share the output

**Do not merge** — remove logging before any production merge.
