### PR TITLE
Streamline TRMNL setup to use published DayGLANCE recipe

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -499,7 +499,6 @@ const DayPlanner = () => {
     trmnlConfig, setTrmnlConfig,
     trmnlSyncStatus, setTrmnlSyncStatus,
     trmnlLastSynced, setTrmnlLastSynced,
-    trmnlMarkupCopied, setTrmnlMarkupCopied,
     trmnlSyncTimerRef,
     trmnlLastPushRef,
     trmnlBackoffUntilRef,
@@ -6120,7 +6119,6 @@ const DayPlanner = () => {
     trmnlConfig, setTrmnlConfig,
     trmnlSyncStatus, setTrmnlSyncStatus,
     trmnlLastSynced, setTrmnlLastSynced,
-    trmnlMarkupCopied, setTrmnlMarkupCopied,
 
     // ── Routines ──────────────────────────────────────────────────────────────
     routineDefinitions, setRoutineDefinitions,

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -160,7 +160,6 @@ const DesktopLayout = () => {
     trmnlConfig, setTrmnlConfig,
     trmnlSyncStatus, setTrmnlSyncStatus,
     trmnlLastSynced, setTrmnlLastSynced,
-    trmnlMarkupCopied, setTrmnlMarkupCopied,
     routineDefinitions, setRoutineDefinitions,
     todayRoutines, setTodayRoutines,
     routinesDate, setRoutinesDate,

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -168,7 +168,6 @@ const MobileLayout = () => {
     trmnlConfig, setTrmnlConfig,
     trmnlSyncStatus, setTrmnlSyncStatus,
     trmnlLastSynced, setTrmnlLastSynced,
-    trmnlMarkupCopied, setTrmnlMarkupCopied,
     routineDefinitions, setRoutineDefinitions,
     todayRoutines, setTodayRoutines,
     routinesDate, setRoutinesDate,

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -5,7 +5,6 @@ import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { getStorageUsage } from '../utils/storage.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
-import { TRMNL_MARKUP_FULL, TRMNL_MARKUP_HALF_HORIZONTAL, TRMNL_MARKUP_HALF_VERTICAL, TRMNL_MARKUP_QUADRANT } from '../trmnl.js';
 import { isNativeAndroid, nativeGetCalendars } from '../native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault } from '../obsidian.js';
 
@@ -41,7 +40,6 @@ const SettingsModal = () => {
     setTasks, setUnscheduledTasks,
     dailyNoteTemplate, setDailyNoteTemplate,
     trmnlConfig, setTrmnlConfig, trmnlSyncStatus, trmnlLastSynced, performTrmnlSync,
-    trmnlMarkupCopied, setTrmnlMarkupCopied,
   } = useDayPlannerCtx();
 
   const currentProvider = cloudSyncConfig?.provider || 'nextcloud';
@@ -877,7 +875,7 @@ const SettingsModal = () => {
                       </button>
                       {!collapsedSettings.trmnl && (<>
                       <p className={`${textSecondary} text-xs`}>
-                        Push your daily schedule to a <a href="https://trmnl.com" target="_blank" rel="noopener noreferrer" className="underline">TRMNL</a> e-ink display via webhook.
+                        Push your daily schedule to a <a href="https://trmnl.com" target="_blank" rel="noopener noreferrer" className="underline">TRMNL</a> e-ink display via webhook. Install the <strong>DayGLANCE</strong> recipe from the TRMNL Recipe Library to get started.
                       </p>
                       <div>
                         <label className={`block text-sm ${textSecondary} mb-1`}>Webhook URL</label>
@@ -889,7 +887,7 @@ const SettingsModal = () => {
                           className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
                         />
                         <p className={`text-xs ${textSecondary} mt-1`}>
-                          Create a Private Plugin in TRMNL, then copy the Webhook URL
+                          Found in your DayGLANCE recipe settings on TRMNL
                         </p>
                       </div>
                       <div>
@@ -943,38 +941,6 @@ const SettingsModal = () => {
                         </p>
                       )}
 
-                      {/* Markup templates - copy to TRMNL editor */}
-                      {trmnlConfig?.enabled && (
-                        <div className="space-y-2 mt-2">
-                          <p className={`text-xs font-medium ${textSecondary}`}>Markup Templates</p>
-                          <p className={`text-xs ${textSecondary}`}>
-                            Copy a template below and paste it into your TRMNL plugin's Markup Editor.
-                          </p>
-                          {[
-                            ['full', 'Full', TRMNL_MARKUP_FULL],
-                            ['half_h', 'Half Horizontal', TRMNL_MARKUP_HALF_HORIZONTAL],
-                            ['half_v', 'Half Vertical', TRMNL_MARKUP_HALF_VERTICAL],
-                            ['quad', 'Quadrant', TRMNL_MARKUP_QUADRANT],
-                          ].map(([key, label, markup]) => (
-                            <button
-                              key={key}
-                              onClick={() => {
-                                navigator.clipboard.writeText(markup).then(() => {
-                                  setTrmnlMarkupCopied(key);
-                                  setTimeout(() => setTrmnlMarkupCopied(''), 2000);
-                                });
-                              }}
-                              className={`mr-1 mb-1 px-2.5 py-1 text-xs rounded transition-colors ${
-                                trmnlMarkupCopied === key
-                                  ? 'bg-green-600 text-white'
-                                  : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`
-                              }`}
-                            >
-                              {trmnlMarkupCopied === key ? `${label} ✓` : label}
-                            </button>
-                          ))}
-                        </div>
-                      )}
                       </>)}
                     </div>
 

--- a/src/hooks/useTrmnlSync.js
+++ b/src/hooks/useTrmnlSync.js
@@ -11,7 +11,6 @@ const useTrmnlSync = () => {
   const [trmnlLastSynced, setTrmnlLastSynced] = useState(() =>
     localStorage.getItem('day-planner-trmnl-last-synced') || null
   );
-  const [trmnlMarkupCopied, setTrmnlMarkupCopied] = useState('');
   // Seed from persisted last-synced so the 2-min throttle survives page reloads
   const trmnlSyncTimerRef = useRef(null);
   const trmnlLastPushRef = useRef(
@@ -35,7 +34,6 @@ const useTrmnlSync = () => {
     trmnlConfig, setTrmnlConfig,
     trmnlSyncStatus, setTrmnlSyncStatus,
     trmnlLastSynced, setTrmnlLastSynced,
-    trmnlMarkupCopied, setTrmnlMarkupCopied,
     trmnlSyncTimerRef,
     trmnlLastPushRef,
     trmnlBackoffUntilRef,


### PR DESCRIPTION
## Summary

- Removes the markup template copy buttons — the published **DayGLANCE** recipe on TRMNL handles layout automatically
- Updates the section description to direct users to install the DayGLANCE recipe from the TRMNL Recipe Library
- Updates the Webhook URL helper text to say "Found in your DayGLANCE recipe settings on TRMNL"
- Cleans up the `trmnlMarkupCopied` state and all related plumbing across `useTrmnlSync.js`, `App.jsx`, `DesktopLayout.jsx`, and `MobileLayout.jsx`

## Test plan

- [ ] Open Settings → TRMNL Dashboard — confirm the Markup Templates section is gone
- [ ] Verify the description and webhook helper text reflect the recipe-based setup
- [ ] Enable TRMNL with a webhook URL and confirm sync still works normally

https://claude.ai/code/session_01Rwht71ybyCq9HJk9Cz8aoa