### PR TITLE
PR 1: Goals & Projects — Data & Logic Foundation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,6 +56,7 @@ import useOnboarding from './hooks/useOnboarding.js';
 import useDailyContent from './hooks/useDailyContent.js';
 import useHabits from './hooks/useHabits.js';
 import useRoutines from './hooks/useRoutines.js';
+import useGoalsProjects from './hooks/useGoalsProjects.js';
 import useFocusMode from './hooks/useFocusMode.js';
 import useTrmnlSync from './hooks/useTrmnlSync.js';
 import useObsidian from './hooks/useObsidian.js';
@@ -474,6 +475,14 @@ const DayPlanner = () => {
     handleRoutinesDone,
   } = useRoutines({ currentTime, onboardingProgress, setOnboardingProgress });
   const {
+    goals, setGoals,
+    projects, setProjects,
+    showGoalsDashboard, setShowGoalsDashboard,
+    goalsProjectsEnabled, setGoalsProjectsEnabled,
+    addGoal, updateGoal, deleteGoal,
+    addProject, updateProject, deleteProject,
+  } = useGoalsProjects();
+  const {
     showFocusMode, setShowFocusMode,
     focusPhase, setFocusPhase,
     focusTimerSeconds, setFocusTimerSeconds,
@@ -764,12 +773,13 @@ const DayPlanner = () => {
     setDarkMode, setSyncUrl, setTaskCalendarUrl, setCompletedTaskUids,
     setDailyNotes, setRoutineDefinitions, setTodayRoutines, setRoutinesDate,
     setRemovedTodayRoutineIds, setHabits, setHabitLogs, setHabitsEnabled,
-    setRoutinesEnabled, setDataLoaded,
+    setRoutinesEnabled, setGoals, setProjects, setGoalsProjectsEnabled, setDataLoaded,
     // values for saveData
     tasks, unscheduledTasks, recycleBin, recurringTasks, todayRoutines,
     darkMode, syncUrl, taskCalendarUrl, syncRetentionDays, completedTaskUids,
     routineDefinitions, routinesDate, removedTodayRoutineIds,
     habits, habitLogs, habitsEnabled, routinesEnabled, gtdFrames,
+    goals, projects, goalsProjectsEnabled,
     cloudSyncConfig, cloudSyncInitialDoneRef, suppressTimestampRef,
     setUndoToast,
   });
@@ -781,6 +791,7 @@ const DayPlanner = () => {
     tasks, unscheduledTasks, recycleBin, taskCalendarUrl, syncUrl, syncRetentionDays,
     completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate,
     removedTodayRoutineIds, habits, habitLogs, habitsEnabled, routinesEnabled, gtdFrames,
+    goals, projects, goalsProjectsEnabled,
   });
 
   const { timelineScrolledAway, setTimelineScrolledAway, scrollToCurrentHour } = useTimelineScroll({
@@ -3102,7 +3113,10 @@ const DayPlanner = () => {
         habitsEnabled: JSON.parse(localStorage.getItem('day-planner-habits-enabled') || 'true'),
         routinesEnabled: JSON.parse(localStorage.getItem('day-planner-routines-enabled') || 'true'),
         aiConfig: JSON.parse(localStorage.getItem('day-planner-ai-config') || 'null'),
-        calendarFilter: JSON.parse(localStorage.getItem('day-planner-calendar-filter') || '[]')
+        calendarFilter: JSON.parse(localStorage.getItem('day-planner-calendar-filter') || '[]'),
+        goals: JSON.parse(localStorage.getItem('day-planner-goals') || '[]'),
+        projects: JSON.parse(localStorage.getItem('day-planner-projects') || '[]'),
+        goalsProjectsEnabled: JSON.parse(localStorage.getItem('day-planner-goals-projects-enabled') || 'false'),
       }
     };
 
@@ -3148,7 +3162,10 @@ const DayPlanner = () => {
       habitLogs: JSON.parse(localStorage.getItem('day-planner-habit-logs') || '{}'),
       aiConfig: JSON.parse(localStorage.getItem('day-planner-ai-config') || 'null'),
       obsidianConfig: JSON.parse(localStorage.getItem('day-planner-obsidian-config') || 'null'),
-      calendarFilter: JSON.parse(localStorage.getItem('day-planner-calendar-filter') || '[]')
+      calendarFilter: JSON.parse(localStorage.getItem('day-planner-calendar-filter') || '[]'),
+      goals: JSON.parse(localStorage.getItem('day-planner-goals') || '[]'),
+      projects: JSON.parse(localStorage.getItem('day-planner-projects') || '[]'),
+      goalsProjectsEnabled: JSON.parse(localStorage.getItem('day-planner-goals-projects-enabled') || 'false'),
     }
   });
 
@@ -3318,6 +3335,9 @@ const DayPlanner = () => {
         if (data.aiConfig) localStorage.setItem('day-planner-ai-config', JSON.stringify(data.aiConfig));
         if (data.obsidianConfig) localStorage.setItem('day-planner-obsidian-config', JSON.stringify(data.obsidianConfig));
         if (data.calendarFilter) localStorage.setItem('day-planner-calendar-filter', JSON.stringify(data.calendarFilter));
+        if (data.goals) localStorage.setItem('day-planner-goals', JSON.stringify(data.goals));
+        if (data.projects) localStorage.setItem('day-planner-projects', JSON.stringify(data.projects));
+        if (data.goalsProjectsEnabled !== undefined) localStorage.setItem('day-planner-goals-projects-enabled', JSON.stringify(data.goalsProjectsEnabled));
 
         // Reload app to reflect changes
         // On Android WebView, use href assignment for a full reload; fall back to reload()
@@ -3854,6 +3874,9 @@ const DayPlanner = () => {
         deletedHabitIds: JSON.parse(localStorage.getItem('day-planner-deleted-habit-ids') || '{}'),
         routinesEnabled,
         gtdFrames,
+        goals,
+        projects,
+        goalsProjectsEnabled,
       }
     };
   };
@@ -3995,6 +4018,18 @@ const DayPlanner = () => {
     if (data.gtdFrames) {
       localStorage.setItem('day-planner-gtd-frames', JSON.stringify(data.gtdFrames));
       setGtdFrames(data.gtdFrames);
+    }
+    if (data.goals) {
+      localStorage.setItem('day-planner-goals', JSON.stringify(data.goals));
+      setGoals(data.goals);
+    }
+    if (data.projects) {
+      localStorage.setItem('day-planner-projects', JSON.stringify(data.projects));
+      setProjects(data.projects);
+    }
+    if (data.goalsProjectsEnabled !== undefined) {
+      localStorage.setItem('day-planner-goals-projects-enabled', JSON.stringify(data.goalsProjectsEnabled));
+      setGoalsProjectsEnabled(data.goalsProjectsEnabled);
     }
     // darkMode, reminderSettings, and soundEnabled are device-specific — not synced
 
@@ -6316,6 +6351,14 @@ const DayPlanner = () => {
     frameNudgeLoading, setFrameNudgeLoading,
     frameNudgeError, setFrameNudgeError,
     frameNudgeDismissedKey, setFrameNudgeDismissedKey,
+
+    // ── Goals & Projects ──────────────────────────────────────────────────────
+    goals, setGoals,
+    projects, setProjects,
+    showGoalsDashboard, setShowGoalsDashboard,
+    goalsProjectsEnabled, setGoalsProjectsEnabled,
+    addGoal, updateGoal, deleteGoal,
+    addProject, updateProject, deleteProject,
 
     // ── Reminders ─────────────────────────────────────────────────────────────
     reminderSettings, setReminderSettings,

--- a/src/hooks/useDataPersistence.js
+++ b/src/hooks/useDataPersistence.js
@@ -6,12 +6,13 @@ export default function useDataPersistence({
   setDarkMode, setSyncUrl, setTaskCalendarUrl, setCompletedTaskUids,
   setDailyNotes, setRoutineDefinitions, setTodayRoutines, setRoutinesDate,
   setRemovedTodayRoutineIds, setHabits, setHabitLogs, setHabitsEnabled,
-  setRoutinesEnabled, setDataLoaded,
+  setRoutinesEnabled, setGoals, setProjects, setGoalsProjectsEnabled, setDataLoaded,
   // values for saveData
   tasks, unscheduledTasks, recycleBin, recurringTasks, todayRoutines,
   darkMode, syncUrl, taskCalendarUrl, syncRetentionDays, completedTaskUids,
   routineDefinitions, routinesDate, removedTodayRoutineIds,
   habits, habitLogs, habitsEnabled, routinesEnabled, gtdFrames,
+  goals, projects, goalsProjectsEnabled,
   cloudSyncConfig, cloudSyncInitialDoneRef, suppressTimestampRef,
   setUndoToast,
 }) {
@@ -130,6 +131,14 @@ export default function useDataPersistence({
       if (habitsEnabledData !== null) setHabitsEnabled(JSON.parse(habitsEnabledData));
       const routinesEnabledData = localStorage.getItem('day-planner-routines-enabled');
       if (routinesEnabledData !== null) setRoutinesEnabled(JSON.parse(routinesEnabledData));
+
+      // Load goals and projects
+      const goalsData = localStorage.getItem('day-planner-goals');
+      if (goalsData) setGoals(JSON.parse(goalsData));
+      const projectsData = localStorage.getItem('day-planner-projects');
+      if (projectsData) setProjects(JSON.parse(projectsData));
+      const goalsProjectsEnabledData = localStorage.getItem('day-planner-goals-projects-enabled');
+      if (goalsProjectsEnabledData !== null) setGoalsProjectsEnabled(JSON.parse(goalsProjectsEnabledData));
     } catch (error) {
       console.log('No existing data found, starting fresh');
     }
@@ -186,6 +195,9 @@ export default function useDataPersistence({
     safeSet('day-planner-habits-enabled', JSON.stringify(habitsEnabled));
     safeSet('day-planner-routines-enabled', JSON.stringify(routinesEnabled));
     safeSet('day-planner-gtd-frames', JSON.stringify(gtdFrames));
+    safeSet('day-planner-goals', JSON.stringify(goals));
+    safeSet('day-planner-projects', JSON.stringify(projects));
+    safeSet('day-planner-goals-projects-enabled', JSON.stringify(goalsProjectsEnabled));
     // Only update local-modified after initial cloud sync has run,
     // otherwise the initial loadData() sets it to "now" and overwrites remote
     if (!cloudSyncConfig?.enabled || cloudSyncInitialDoneRef.current) {

--- a/src/hooks/useGoalsProjects.js
+++ b/src/hooks/useGoalsProjects.js
@@ -1,0 +1,94 @@
+/**
+ * Goals & Projects feature state and CRUD operations.
+ *
+ * Follows the same pattern as useHabits and useRoutines:
+ *   - State is initialised lazily from localStorage
+ *   - Enabled flag defaults OFF for new installs; auto-enables if data already
+ *     exists (upgrade migration path)
+ *   - CRUD functions return the new/updated object so callers can chain
+ */
+
+import { useState, useCallback } from 'react';
+
+const useGoalsProjects = () => {
+  const [goals, setGoals] = useState([]);
+  const [projects, setProjects] = useState([]);
+  const [showGoalsDashboard, setShowGoalsDashboard] = useState(false);
+
+  const [goalsProjectsEnabled, setGoalsProjectsEnabled] = useState(() => {
+    const stored = localStorage.getItem('day-planner-goals-projects-enabled');
+    if (stored !== null) return JSON.parse(stored);
+    // Default OFF for new installs; ON if data already exists (upgrade migration)
+    try {
+      const existingGoals = JSON.parse(localStorage.getItem('day-planner-goals') || '[]');
+      const existingProjects = JSON.parse(localStorage.getItem('day-planner-projects') || '[]');
+      if (existingGoals.length > 0 || existingProjects.length > 0) return true;
+    } catch (_) {}
+    return false;
+  });
+
+  // ── Goal CRUD ────────────────────────────────────────────────────────────────
+
+  const addGoal = useCallback((fields) => {
+    const now = new Date().toISOString();
+    const newGoal = {
+      status: 'active',
+      ...fields,
+      id: crypto.randomUUID(),
+      createdAt: now,
+      updatedAt: now,
+    };
+    setGoals(prev => [...prev, newGoal]);
+    return newGoal;
+  }, []);
+
+  const updateGoal = useCallback((id, updates) => {
+    setGoals(prev => prev.map(g =>
+      g.id === id
+        ? { ...g, ...updates, updatedAt: new Date().toISOString() }
+        : g
+    ));
+  }, []);
+
+  const deleteGoal = useCallback((id) => {
+    setGoals(prev => prev.filter(g => g.id !== id));
+  }, []);
+
+  // ── Project CRUD ─────────────────────────────────────────────────────────────
+
+  const addProject = useCallback((fields) => {
+    const now = new Date().toISOString();
+    const newProject = {
+      status: 'active',
+      ...fields,
+      id: crypto.randomUUID(),
+      createdAt: now,
+      updatedAt: now,
+    };
+    setProjects(prev => [...prev, newProject]);
+    return newProject;
+  }, []);
+
+  const updateProject = useCallback((id, updates) => {
+    setProjects(prev => prev.map(p =>
+      p.id === id
+        ? { ...p, ...updates, updatedAt: new Date().toISOString() }
+        : p
+    ));
+  }, []);
+
+  const deleteProject = useCallback((id) => {
+    setProjects(prev => prev.filter(p => p.id !== id));
+  }, []);
+
+  return {
+    goals, setGoals,
+    projects, setProjects,
+    showGoalsDashboard, setShowGoalsDashboard,
+    goalsProjectsEnabled, setGoalsProjectsEnabled,
+    addGoal, updateGoal, deleteGoal,
+    addProject, updateProject, deleteProject,
+  };
+};
+
+export default useGoalsProjects;

--- a/src/hooks/useSaveOnChange.js
+++ b/src/hooks/useSaveOnChange.js
@@ -7,6 +7,7 @@ export default function useSaveOnChange({
   tasks, unscheduledTasks, recycleBin, taskCalendarUrl, syncUrl, syncRetentionDays,
   completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate,
   removedTodayRoutineIds, habits, habitLogs, habitsEnabled, routinesEnabled, gtdFrames,
+  goals, projects, goalsProjectsEnabled,
 }) {
   useEffect(() => {
     if (!dataLoaded) return; // Don't overwrite localStorage before initial load
@@ -23,5 +24,5 @@ export default function useSaveOnChange({
         suppressTimestampRef.current = false;
       });
     }
-  }, [dataLoaded, tasks, unscheduledTasks, recycleBin, taskCalendarUrl, syncUrl, syncRetentionDays, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, removedTodayRoutineIds, habits, habitLogs, habitsEnabled, routinesEnabled, gtdFrames]);
+  }, [dataLoaded, tasks, unscheduledTasks, recycleBin, taskCalendarUrl, syncUrl, syncRetentionDays, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, removedTodayRoutineIds, habits, habitLogs, habitsEnabled, routinesEnabled, gtdFrames, goals, projects, goalsProjectsEnabled]);
 }

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -572,6 +572,75 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
     localChanged = true;
   }
 
+  // Merge goals by ID using updatedAt for conflict resolution (same strategy as frames)
+  const localGoals = localData.goals || [];
+  const remoteGoals = remoteData.goals || [];
+  const localGoalIds = new Set(localGoals.map(g => String(g.id)));
+  const remoteGoalMap = new Map(remoteGoals.map(g => [String(g.id), g]));
+  const mergedGoals = [];
+  for (const localGoal of localGoals) {
+    const id = String(localGoal.id);
+    const remoteGoal = remoteGoalMap.get(id);
+    if (remoteGoal && JSON.stringify(localGoal) !== JSON.stringify(remoteGoal)) {
+      const localTime = new Date(localGoal.updatedAt || 0);
+      const remoteTime = new Date(remoteGoal.updatedAt || 0);
+      if (remoteTime > localTime) {
+        mergedGoals.push(remoteGoal);
+        localChanged = true;
+      } else {
+        mergedGoals.push(localGoal);
+        if (remoteTime < localTime) remoteChanged = true;
+      }
+    } else {
+      mergedGoals.push(localGoal);
+      if (!remoteGoal) remoteChanged = true;
+    }
+  }
+  for (const remoteGoal of remoteGoals) {
+    if (!localGoalIds.has(String(remoteGoal.id))) {
+      mergedGoals.push(remoteGoal);
+      localChanged = true;
+    }
+  }
+
+  // Merge projects by ID using updatedAt for conflict resolution (same strategy as frames)
+  const localProjects = localData.projects || [];
+  const remoteProjects = remoteData.projects || [];
+  const localProjectIds = new Set(localProjects.map(p => String(p.id)));
+  const remoteProjectMap = new Map(remoteProjects.map(p => [String(p.id), p]));
+  const mergedProjects = [];
+  for (const localProject of localProjects) {
+    const id = String(localProject.id);
+    const remoteProject = remoteProjectMap.get(id);
+    if (remoteProject && JSON.stringify(localProject) !== JSON.stringify(remoteProject)) {
+      const localTime = new Date(localProject.updatedAt || 0);
+      const remoteTime = new Date(remoteProject.updatedAt || 0);
+      if (remoteTime > localTime) {
+        mergedProjects.push(remoteProject);
+        localChanged = true;
+      } else {
+        mergedProjects.push(localProject);
+        if (remoteTime < localTime) remoteChanged = true;
+      }
+    } else {
+      mergedProjects.push(localProject);
+      if (!remoteProject) remoteChanged = true;
+    }
+  }
+  for (const remoteProject of remoteProjects) {
+    if (!localProjectIds.has(String(remoteProject.id))) {
+      mergedProjects.push(remoteProject);
+      localChanged = true;
+    }
+  }
+
+  // Check if goalsProjectsEnabled setting differs
+  const localGoalsProjectsEnabled = localData.goalsProjectsEnabled !== undefined ? localData.goalsProjectsEnabled : false;
+  const remoteGoalsProjectsEnabled = remoteData.goalsProjectsEnabled !== undefined ? remoteData.goalsProjectsEnabled : false;
+  if (localGoalsProjectsEnabled !== remoteGoalsProjectsEnabled) {
+    localChanged = true;
+  }
+
   // Detect calendar URL changes so the sync cycle completes even when URLs
   // are the only difference between local and remote.
   const mergedSyncUrl = remoteData.syncUrl || localData.syncUrl || '';
@@ -616,6 +685,9 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
       habitsEnabled: remoteData.habitsEnabled !== undefined ? remoteData.habitsEnabled : localData.habitsEnabled,
       routinesEnabled: remoteData.routinesEnabled !== undefined ? remoteData.routinesEnabled : localData.routinesEnabled,
       gtdFrames: mergedFrames,
+      goals: mergedGoals,
+      projects: mergedProjects,
+      goalsProjectsEnabled: remoteData.goalsProjectsEnabled !== undefined ? remoteData.goalsProjectsEnabled : localData.goalsProjectsEnabled,
       minimizedSections: localData.minimizedSections, // UI pref — keep local
       use24HourClock: localData.use24HourClock // device pref — keep local
     },

--- a/src/utils/goalProgress.js
+++ b/src/utils/goalProgress.js
@@ -1,0 +1,40 @@
+/**
+ * Weighted-average progress for a goal across its child projects.
+ *
+ * Each child project's contribution is weighted by its total task duration,
+ * so a project with more (or longer) tasks has more influence on the goal's
+ * overall progress bar.  Only active and completed projects are included —
+ * archived projects are excluded from both numerator and denominator.
+ */
+
+import { calculateProjectProgress, getProjectTotalDuration } from './projectProgress.js';
+
+/**
+ * Calculates weighted-average progress for a goal.
+ *
+ * @param {string} goalId
+ * @param {Array} projects - all projects
+ * @param {Array} allTasks - combined scheduled + unscheduled tasks
+ * @returns {number} value between 0 and 1 (0 if no child projects with tasks)
+ */
+export function calculateGoalProgress(goalId, projects, allTasks) {
+  const childProjects = projects.filter(
+    p => p.goalId === goalId && p.status !== 'archived'
+  );
+
+  if (childProjects.length === 0) return 0;
+
+  let totalWeight = 0;
+  let weightedSum = 0;
+
+  for (const project of childProjects) {
+    const weight = getProjectTotalDuration(project.id, allTasks);
+    const progress = calculateProjectProgress(project.id, allTasks);
+    totalWeight += weight;
+    weightedSum += progress * weight;
+  }
+
+  if (totalWeight === 0) return 0;
+
+  return weightedSum / totalWeight;
+}

--- a/src/utils/projectProgress.js
+++ b/src/utils/projectProgress.js
@@ -1,0 +1,79 @@
+/**
+ * Duration-weighted progress calculations for a single project.
+ *
+ * All tasks belonging to a project are weighted by their duration so that
+ * a 2-hour task counts more than a 15-minute one.  Tasks with no duration
+ * set fall back to DEFAULT_DURATION so they still contribute meaningfully
+ * without forcing the user to assign a time estimate.
+ */
+
+const DEFAULT_DURATION = 30; // minutes — fallback for tasks with no duration set
+
+/**
+ * Calculates duration-weighted completion progress for a single project.
+ *
+ * @param {string} projectId
+ * @param {Array} allTasks - combined scheduled + unscheduled tasks
+ * @returns {number} value between 0 and 1 (0 if no tasks)
+ */
+export function calculateProjectProgress(projectId, allTasks) {
+  const projectTasks = allTasks.filter(
+    t => t.projectId === projectId && !t.archived
+  );
+
+  if (projectTasks.length === 0) return 0;
+
+  const totalDuration = projectTasks.reduce(
+    (sum, t) => sum + (t.duration || DEFAULT_DURATION), 0
+  );
+
+  if (totalDuration === 0) return 0;
+
+  const completedDuration = projectTasks
+    .filter(t => t.completed)
+    .reduce((sum, t) => sum + (t.duration || DEFAULT_DURATION), 0);
+
+  return completedDuration / totalDuration;
+}
+
+/**
+ * Returns total task duration (minutes) for a project.
+ * Used as the weight when computing goal-level progress.
+ *
+ * @param {string} projectId
+ * @param {Array} allTasks
+ * @returns {number} total minutes (0 if no tasks)
+ */
+export function getProjectTotalDuration(projectId, allTasks) {
+  return allTasks
+    .filter(t => t.projectId === projectId && !t.archived)
+    .reduce((sum, t) => sum + (t.duration || DEFAULT_DURATION), 0);
+}
+
+/**
+ * Returns whether a project is stalled:
+ *   - has at least one incomplete task, AND
+ *   - no task has completedAt within the last 7 days
+ *
+ * @param {string} projectId
+ * @param {Array} allTasks
+ * @returns {boolean}
+ */
+export function isProjectStalled(projectId, allTasks) {
+  const projectTasks = allTasks.filter(
+    t => t.projectId === projectId && !t.archived
+  );
+
+  const hasIncomplete = projectTasks.some(t => !t.completed);
+  if (!hasIncomplete) return false;
+
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  const cutoff = sevenDaysAgo.toISOString().slice(0, 10); // YYYY-MM-DD
+
+  const hasRecentCompletion = projectTasks.some(
+    t => t.completed && t.completedAt && t.completedAt >= cutoff
+  );
+
+  return !hasRecentCompletion;
+}


### PR DESCRIPTION
## Summary

- Adds `useGoalsProjects` hook with full Goal/Project CRUD, `goalsProjectsEnabled` toggle, and `showGoalsDashboard` UI flag — following the exact same pattern as `useHabits` and `useRoutines`
- Adds `src/utils/projectProgress.js`: duration-weighted task completion per project, total duration helper (used for goal weighting), and stalled-project detection (no `completedAt` within 7 days)
- Adds `src/utils/goalProgress.js`: weighted-average progress across child projects, weighted by each project's total task duration
- Wires goals/projects into `useDataPersistence` (localStorage keys: `day-planner-goals`, `day-planner-projects`, `day-planner-goals-projects-enabled`)
- Wires into `useSaveOnChange` so any state change auto-saves
- Wires into `mergeSync.js` with by-ID / `updatedAt` conflict resolution (same strategy as GTD frames); `goalsProjectsEnabled` syncs across devices like `habitsEnabled`/`routinesEnabled`
- Wires into `App.jsx`: `buildSyncPayload`, `applyRemoteData`, `exportBackup`, `buildAutoBackupPayload`, `restoreBackup`, and `DayPlannerContext`

## No UI changes

This is pure foundation. No existing behaviour is altered. Existing tasks gain an optional `projectId` field that is `undefined` on all current tasks — no migration needed.

## Test plan

- [ ] `npm run build` passes (verified before commit)
- [ ] App loads normally with no console errors
- [ ] Backup export JSON includes `goals`, `projects`, `goalsProjectsEnabled` keys
- [ ] Restore from a backup that includes those keys repopulates state correctly
- [ ] WebDAV sync payload includes the new keys (verify in network tab or sync file)

https://claude.ai/code/session_01EBmKak8KgzkeWAhiFh9RBg