### PR TITLE
PR 5 — Focus Mode Integration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -501,6 +501,7 @@ const DayPlanner = () => {
     focusTimerRunning, setFocusTimerRunning,
     focusTaskMinutes, setFocusTaskMinutes,
     focusBlockTasks, setFocusBlockTasks,
+    focusProjectId, setFocusProjectId,
     focusLog, setFocusLog,
     focusLogModalDate, setFocusLogModalDate,
     wakeLockSentinel,
@@ -2608,6 +2609,33 @@ const DayPlanner = () => {
   };
   enterFocusModeRef.current = enterFocusMode;
 
+  const enterProjectFocusMode = (project, projectTasks) => {
+    setFocusProjectId(project.id);
+    setShowFocusMode(true);
+    setFocusShowSettings(true);
+    setFocusShowStats(false);
+    setFocusPhase('work');
+    setFocusTimerSeconds(0);
+    setFocusCycleCount(0);
+    setFocusSessionStart(null);
+    setFocusCompletedTasks(new Set());
+    setFocusTimerRunning(false);
+    setFocusTaskMinutes({});
+    setFocusBlockTasks(projectTasks);
+    setFocusWorkMinutes(25);
+    setFocusBreakMinutes(5);
+    setFocusLongBreakMinutes(15);
+    try { document.documentElement.requestFullscreen?.(); } catch (e) {}
+    (async () => {
+      try {
+        if (navigator.wakeLock) {
+          wakeLockSentinel.current = await navigator.wakeLock.request('screen');
+        }
+      } catch (e) {}
+    })();
+    nativeEnterFocusMode();
+  };
+
   const startFocusTimer = () => {
     setFocusShowSettings(false);
     setFocusSessionStart(new Date());
@@ -2651,20 +2679,27 @@ const DayPlanner = () => {
       const sessionMinutes = Math.round((new Date() - focusSessionStart) / 60000);
       if (sessionMinutes > 0) {
         const sessionDateStr = dateToString(new Date(focusSessionStart));
+        const sessionProjectId = focusProjectId;
         setFocusLog(prev => {
           const existing = prev[sessionDateStr] || { totalMinutes: 0, sessions: 0, cyclesCompleted: 0, tasksCompleted: 0 };
-          return {
-            ...prev,
-            [sessionDateStr]: {
-              totalMinutes: existing.totalMinutes + sessionMinutes,
-              sessions: existing.sessions + 1,
-              cyclesCompleted: existing.cyclesCompleted + focusCycleCount,
-              tasksCompleted: existing.tasksCompleted + focusCompletedTasks.size,
-            },
+          const updated = {
+            ...existing,
+            totalMinutes: existing.totalMinutes + sessionMinutes,
+            sessions: existing.sessions + 1,
+            cyclesCompleted: existing.cyclesCompleted + focusCycleCount,
+            tasksCompleted: existing.tasksCompleted + focusCompletedTasks.size,
           };
+          if (sessionProjectId) {
+            updated.projectSessions = [
+              ...(existing.projectSessions || []),
+              { projectId: sessionProjectId, minutes: sessionMinutes },
+            ];
+          }
+          return { ...prev, [sessionDateStr]: updated };
         });
       }
     }
+    setFocusProjectId(null);
     if (showStats) {
       setFocusShowStats(true);
     } else {
@@ -6539,7 +6574,8 @@ const DayPlanner = () => {
     addStepsHabit, addSleepHabit,
 
     // ── Functions – focus mode ────────────────────────────────────────────────
-    enterFocusMode, exitFocusMode, startFocusTimer, dismissFocusStats,
+    enterFocusMode, enterProjectFocusMode, exitFocusMode, startFocusTimer, dismissFocusStats,
+    focusProjectId,
     handleFocusTimerEnd,
     focusCompleteTask, focusToggleSubtask, focusAddSubtask,
     focusDeleteSubtask, focusUpdateSubtaskTitle, focusUpdateTaskNotes,

--- a/src/components/ConfirmDialog.jsx
+++ b/src/components/ConfirmDialog.jsx
@@ -12,7 +12,7 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
  *   onConfirm    — called when the user confirms
  *   onCancel     — called when the user cancels or clicks the backdrop
  */
-const ConfirmDialog = ({ title, message, confirmLabel = 'Delete', onConfirm, onCancel }) => {
+const ConfirmDialog = ({ title, message, confirmLabel = 'Delete', onConfirm, onCancel, hideCancelButton = false }) => {
   const { darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg } =
     useDayPlannerCtx();
 
@@ -33,15 +33,17 @@ const ConfirmDialog = ({ title, message, confirmLabel = 'Delete', onConfirm, onC
           </div>
         </div>
         <div className="flex gap-2 justify-end">
-          <button
-            onClick={onCancel}
-            className={`px-3 py-2 text-base rounded-lg ${hoverBg} ${textSecondary} transition-colors`}
-          >
-            Cancel
-          </button>
+          {!hideCancelButton && (
+            <button
+              onClick={onCancel}
+              className={`px-3 py-2 text-base rounded-lg ${hoverBg} ${textSecondary} transition-colors`}
+            >
+              Cancel
+            </button>
+          )}
           <button
             onClick={onConfirm}
-            className="px-4 py-2 text-base rounded-lg bg-red-600 hover:bg-red-700 text-white font-medium transition-colors"
+            className={`px-4 py-2 text-base rounded-lg font-medium transition-colors ${hideCancelButton ? `${hoverBg} ${textPrimary}` : 'bg-red-600 hover:bg-red-700 text-white'}`}
           >
             {confirmLabel}
           </button>

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -1056,9 +1056,11 @@ const GoalDashboard = ({ embedded = false, addGoalTrigger = 0, addProjectTrigger
   const {
     showGoalsDashboard, setShowGoalsDashboard,
     goals, projects,
+    tasks,
     addGoal, updateGoal, deleteGoal,
     addProject, updateProject,
-    setShowFocusMode,
+    enterProjectFocusMode,
+    getTodayStr,
     showAddTask, setShowAddTask, setShowNewTaskDeadlinePicker,
     isMobile,
     darkMode,
@@ -1069,6 +1071,7 @@ const GoalDashboard = ({ embedded = false, addGoalTrigger = 0, addProjectTrigger
   const [projectForm, setProjectForm] = useState(null);
   const [confirmDialog, setConfirmDialog] = useState(null); // { title, message, onConfirm }
   const [showArchived, setShowArchived] = useState(false);
+  const [focusNoTasksProject, setFocusNoTasksProject] = useState(null);
 
   // Trigger props from header buttons (mobile embedded mode)
   useEffect(() => { if (addGoalTrigger > 0) setGoalForm({ editing: null }); }, [addGoalTrigger]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -1117,10 +1120,18 @@ const GoalDashboard = ({ embedded = false, addGoalTrigger = 0, addProjectTrigger
     setProjectForm(null);
   };
 
-  const handleFocusClick = useCallback(() => {
-    setShowGoalsDashboard(false);
-    setShowFocusMode(true);
-  }, [setShowGoalsDashboard, setShowFocusMode]);
+  const handleFocusClick = useCallback((project) => {
+    const todayStr = getTodayStr();
+    const projectTodayTasks = tasks.filter(
+      t => t.date === todayStr && t.projectId === project.id && !t.completed && !t.isAllDay
+    );
+    if (projectTodayTasks.length > 0) {
+      if (!embedded) setShowGoalsDashboard(false);
+      enterProjectFocusMode(project, projectTodayTasks);
+    } else {
+      setFocusNoTasksProject(project);
+    }
+  }, [tasks, getTodayStr, embedded, setShowGoalsDashboard, enterProjectFocusMode]);
 
   // Escape key — use capture phase so this fires before useModalClose and other handlers.
   // GoalDashboard owns all Escape behavior while it's visible.
@@ -1227,6 +1238,16 @@ const GoalDashboard = ({ embedded = false, addGoalTrigger = 0, addProjectTrigger
         )}
         {confirmDialog && (
           <ConfirmDialog title={confirmDialog.title} message={confirmDialog.message} onConfirm={confirmDialog.onConfirm} onCancel={() => setConfirmDialog(null)} />
+        )}
+        {focusNoTasksProject && (
+          <ConfirmDialog
+            title="No tasks scheduled today"
+            message={`"${focusNoTasksProject.title}" has no incomplete tasks on today's timeline. Schedule a task for today to start a Project Focus session.`}
+            onConfirm={() => setFocusNoTasksProject(null)}
+            onCancel={() => setFocusNoTasksProject(null)}
+            confirmLabel="Got it"
+            hideCancelButton
+          />
         )}
       </>
     );
@@ -1414,6 +1435,16 @@ const GoalDashboard = ({ embedded = false, addGoalTrigger = 0, addProjectTrigger
           message={confirmDialog.message}
           onConfirm={confirmDialog.onConfirm}
           onCancel={() => setConfirmDialog(null)}
+        />
+      )}
+      {focusNoTasksProject && (
+        <ConfirmDialog
+          title="No tasks scheduled today"
+          message={`"${focusNoTasksProject.title}" has no incomplete tasks on today's timeline. Schedule a task for today to start a Project Focus session.`}
+          onConfirm={() => setFocusNoTasksProject(null)}
+          onCancel={() => setFocusNoTasksProject(null)}
+          confirmLabel="Got it"
+          hideCancelButton
         />
       )}
     </>

--- a/src/hooks/useFocusMode.js
+++ b/src/hooks/useFocusMode.js
@@ -15,6 +15,7 @@ const useFocusMode = () => {
   const [focusTimerRunning, setFocusTimerRunning] = useState(false);
   const [focusTaskMinutes, setFocusTaskMinutes] = useState({});
   const [focusBlockTasks, setFocusBlockTasks] = useState([]);
+  const [focusProjectId, setFocusProjectId] = useState(null);
   const [focusLog, setFocusLog] = useState(() => {
     const saved = localStorage.getItem('day-planner-focus-log');
     return saved ? JSON.parse(saved) : {};
@@ -66,6 +67,7 @@ const useFocusMode = () => {
     focusTimerRunning, setFocusTimerRunning,
     focusTaskMinutes, setFocusTaskMinutes,
     focusBlockTasks, setFocusBlockTasks,
+    focusProjectId, setFocusProjectId,
     focusLog, setFocusLog,
     focusLogModalDate, setFocusLogModalDate,
     wakeLockSentinel,


### PR DESCRIPTION
## Summary

- **Project Focus fully wired**: clicking "Project Focus" on a `ProjectCard` now finds all of today's incomplete scheduled tasks for that project and launches Focus Mode with `focusBlockTasks` pre-populated with them
- **No tasks today prompt**: if no tasks are on today's timeline for the project, a `ConfirmDialog` is shown — "No tasks scheduled today — schedule a task for today to start a Project Focus session" — instead of silently opening an empty focus session
- **Focus log tagging**: `exitFocusMode` now appends a `projectSessions` array entry `{ projectId, minutes }` to the daily focus log when the session was started from a project, enabling future per-project analytics
- **`ConfirmDialog` improvement**: added `hideCancelButton` prop for single-action informational dialogs (used by the "no tasks" prompt)

## Changes

| File | Change |
|---|---|
| `src/hooks/useFocusMode.js` | Add `focusProjectId` / `setFocusProjectId` state |
| `src/App.jsx` | Add `enterProjectFocusMode(project, tasks)`, update `exitFocusMode` to log `projectSessions`, expose both via context |
| `src/components/goals/GoalDashboard.jsx` | Wire `handleFocusClick(project)` with task lookup; add `focusNoTasksProject` state + dialog |
| `src/components/ConfirmDialog.jsx` | Add `hideCancelButton` prop |

## Test plan

- [ ] Open Goals dashboard, click "Project Focus" on a project that has tasks scheduled today → Focus Mode opens with only that project's tasks in the block
- [ ] Click "Project Focus" on a project with no tasks today → "No tasks scheduled today" dialog appears; dismissing it keeps you on the dashboard
- [ ] Complete a Project Focus session, check `day-planner-focus-log` in localStorage → daily entry has `projectSessions: [{ projectId, minutes }]`
- [ ] Regular Focus Mode (from timeline) still works and does NOT add `projectSessions` to the log

https://claude.ai/code/session_01EBmKak8KgzkeWAhiFh9RBg