### PR TITLE
Fix: date/time pickers behind task edit modal

### DIFF
--- a/src/components/ClockTimePicker.jsx
+++ b/src/components/ClockTimePicker.jsx
@@ -159,7 +159,7 @@ const ClockTimePicker = ({ value, onChange, onClose, darkMode, isTablet, use24Ho
   };
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-[60]" onClick={onClose}>
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-[90]" onClick={onClose}>
       <div className={`${cardBg} rounded-3xl shadow-2xl ${isTablet ? 'p-7' : 'p-5'}`} onClick={e => e.stopPropagation()}>
         <div className="flex items-center justify-between mb-4">
           <h3 className={`${isTablet ? 'text-base' : 'text-sm'} font-semibold tracking-wide uppercase ${textSecondary}`}>Select Time</h3>

--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -46,7 +46,7 @@ const DatePicker = ({ value, onChange, onClose }) => {
     const today = dateToString(new Date());
 
     return (
-      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[60]" onClick={onClose} onKeyDown={(e) => { if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); onClose(); } }} tabIndex={-1} ref={(el) => el && el.focus()}>
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[90]" onClick={onClose} onKeyDown={(e) => { if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); onClose(); } }} tabIndex={-1} ref={(el) => el && el.focus()}>
         <div
           className={`${cardBg} rounded-lg shadow-xl p-6 ${borderClass} border max-w-sm w-full mx-4`}
           onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Problem

When editing a task from the Goals Dashboard and opening the date or time picker, the picker modal appeared **behind** the task edit form.

## Root cause

`DatePicker` and `ClockTimePicker` both used `z-[60]`. The task edit modal uses `z-[80]`. Since 60 < 80, the pickers were rendered underneath.

## Fix

Raise both picker modals from `z-[60]` → `z-[90]`, above the task edit modal and all other app layers except `DeadlinePickerPopover`'s fixed mode (`z-[9999]`).

## Files changed

- `src/components/DatePicker.jsx` — backdrop `z-[60]` → `z-[90]`
- `src/components/ClockTimePicker.jsx` — backdrop `z-[60]` → `z-[90]`

https://claude.ai/code/session_01EBmKak8KgzkeWAhiFh9RBg