### PR TITLE
Fix: tasksCompleted always 0 in focus log

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -506,6 +506,7 @@ const DayPlanner = () => {
     wakeLockSentinel,
     focusTimerRef,
     handleFocusTimerEndRef,
+    exitFocusModeRef,
     focusModeAvailableRef,
   } = useFocusMode();
   const {
@@ -2676,6 +2677,7 @@ const DayPlanner = () => {
       setShowFocusMode(false);
     }
   };
+  exitFocusModeRef.current = exitFocusMode;
 
   const dismissFocusStats = () => {
     try { if (document.fullscreenElement) document.exitFullscreen?.(); } catch (e) {}
@@ -5403,7 +5405,7 @@ const DayPlanner = () => {
     frameScheduleModal, setFrameScheduleModal,
     focusBlockTasks, setFocusBlockTasks,
     focusCompletedTasks, setFocusCompletedTasks,
-    exitFocusMode,
+    exitFocusModeRef,
     playFocusSound,
     getObsidianTaskMeta: obsidianConfig?.enabled && obsidianVaultHandleRef.current
       ? (rawTitle) => {

--- a/src/hooks/useFocusMode.js
+++ b/src/hooks/useFocusMode.js
@@ -23,6 +23,7 @@ const useFocusMode = () => {
   const wakeLockSentinel = useRef(null);
   const focusTimerRef = useRef(null);
   const handleFocusTimerEndRef = useRef(null);
+  const exitFocusModeRef = useRef(null);
   const focusModeAvailableRef = useRef(false);
 
   // Persist focusLog to localStorage
@@ -71,6 +72,7 @@ const useFocusMode = () => {
     wakeLockSentinel,
     focusTimerRef,
     handleFocusTimerEndRef,
+    exitFocusModeRef,
     focusModeAvailableRef,
   };
 };

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -66,7 +66,7 @@ export default function useTaskActions({
   frameScheduleModal, setFrameScheduleModal,
   focusBlockTasks, setFocusBlockTasks,
   focusCompletedTasks, setFocusCompletedTasks,
-  exitFocusMode,
+  exitFocusModeRef,
   playFocusSound,
   // Obsidian integration.
   // getObsidianTaskMeta(rawTitle) → { id, importSource, obsidianRawTitle, obsidianFileDate }
@@ -716,7 +716,7 @@ export default function useTaskActions({
     playFocusSound('complete');
     const allDone = focusBlockTasks.every(t => t.completed || t.id === taskId || focusCompletedTasks.has(t.id));
     if (allDone) {
-      setTimeout(() => exitFocusMode(true), 500);
+      setTimeout(() => exitFocusModeRef.current?.(true), 500);
     }
   };
 


### PR DESCRIPTION
## Problem

After a Project Focus session where all tasks were completed via the **Complete** button, the focus log always recorded `tasksCompleted: 0`.

## Root cause

`focusCompleteTask` in `useTaskActions.js` calls `exitFocusMode(true)` inside a 500ms `setTimeout`. The `exitFocusMode` captured in that closure was from the render *before* `setFocusCompletedTasks` triggered a re-render — so `focusCompletedTasks.size` was always the pre-completion value (0).

## Fix

Add `exitFocusModeRef` to `useFocusMode.js`, following the identical pattern already used for `handleFocusTimerEndRef`. App.jsx assigns `exitFocusModeRef.current = exitFocusMode` on every render, so the ref always points to the freshest closure. `useTaskActions` now receives the ref and calls `exitFocusModeRef.current?.(true)` — guaranteed to read the latest `focusCompletedTasks`.

## Files changed

| File | Change |
|---|---|
| `src/hooks/useFocusMode.js` | Add `exitFocusModeRef = useRef(null)`, return it |
| `src/App.jsx` | Assign `exitFocusModeRef.current = exitFocusMode` each render; pass ref to `useTaskActions` |
| `src/hooks/useTaskActions.js` | Accept `exitFocusModeRef`; call `.current?.(true)` in auto-exit |

https://claude.ai/code/session_01EBmKak8KgzkeWAhiFh9RBg