### PR TITLE
PR 6: Weekly Review AI integration for goals and projects

### DIFF
--- a/src/ai-prompts.js
+++ b/src/ai-prompts.js
@@ -332,6 +332,7 @@ Rules:
 - Mention any notable tag patterns if data is available
 - If habit data is provided, comment on consistency — celebrate streaks, gently note habits that were missed frequently
 - If frame utilization data is provided, highlight underutilized frames (below 30%) or overloaded ones (above 100%) as actionable observations
+- If goals and projects data is provided: mention per-project task completion for projects that had activity this week, call out goal progress % and days remaining to target when relevant, and gently flag any stalled projects (no completions in 7+ days)
 - End with a brief forward-looking note for next week
 - Do NOT use markdown, bullet points, headers, or formatting — plain text only
 - Do NOT use emojis
@@ -343,7 +344,8 @@ export function weeklySummaryUserPrompt(data) {
     recurringCompleted, recurringScheduled, bestDay, bestDayCount,
     incompleteCount, tagBreakdown, inboxCount,
     nextWeekTaskCount = 0, nextWeekTopTasks = [], nextWeekCalendarEvents = [],
-    habitStats = [], frameStats = [] } = data;
+    habitStats = [], frameStats = [],
+    goalStats = [], projectStats = [] } = data;
 
   const lines = [`Week: ${dateRange}.`];
   lines.push(`Tasks completed: ${tasksCompleted} of ${tasksScheduled} (${completionRate}% completion rate).`);
@@ -381,6 +383,31 @@ export function weeklySummaryUserPrompt(data) {
     lines.push(`Frame utilization: ${frameStats.map(f =>
       `${f.label}: ${f.utilizationPct}% (${f.scheduledMin} of ${f.totalCapacityMin} min scheduled)`
     ).join(', ')}.`);
+  }
+
+  if (goalStats.length > 0) {
+    lines.push(`Goals: ${goalStats.map(g => {
+      let s = `"${g.title}" — ${g.progressPct}% complete`;
+      if (g.daysToTarget !== null) {
+        if (g.daysToTarget < 0) s += ` (${Math.abs(g.daysToTarget)} days overdue)`;
+        else if (g.daysToTarget === 0) s += ' (target date: today)';
+        else s += ` (${g.daysToTarget} days to target)`;
+      }
+      return s;
+    }).join('; ')}.`);
+  }
+
+  if (projectStats.length > 0) {
+    const activeProjects = projectStats.filter(p => p.weekTotal > 0);
+    const stalledProjects = projectStats.filter(p => p.stalled);
+    if (activeProjects.length > 0) {
+      lines.push(`Project activity this week: ${activeProjects.map(p =>
+        `"${p.title}" — ${p.weekCompleted}/${p.weekTotal} tasks completed (${p.overallProgressPct}% overall)`
+      ).join('; ')}.`);
+    }
+    if (stalledProjects.length > 0) {
+      lines.push(`Stalled projects (no completions in 7+ days): ${stalledProjects.map(p => `"${p.title}"`).join(', ')}.`);
+    }
   }
 
   lines.push(`\nNext week: ${nextWeekTaskCount} task(s) already scheduled.`);

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -3,6 +3,8 @@ import { AlertCircle, BarChart3, CalendarDays, CheckSquare, ChevronLeft, Chevron
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { dateToString, stripWikilinks } from '../utils/taskUtils.js';
 import { getOccurrencesInRange } from '../utils/recurrenceEngine.js';
+import { calculateProjectProgress, isProjectStalled } from '../utils/projectProgress.js';
+import { calculateGoalProgress } from '../utils/goalProgress.js';
 
 const WeeklyReviewModal = () => {
   const {
@@ -14,6 +16,7 @@ const WeeklyReviewModal = () => {
     generateWeeklyAISummary,
     reviewScrollRef,
     tasks, recurringTasks, unscheduledTasks,
+    goals, projects, goalsProjectsEnabled,
     habitsEnabled, habits, habitLogs,
     gtdFrames,
     selectedDate,
@@ -313,6 +316,47 @@ const WeeklyReviewModal = () => {
           };
         }).filter(Boolean).sort((a, b) => b.totalCapacityMin - a.totalCapacityMin);
 
+        // Goals & Projects stats for AI weekly summary
+        const allTasksCombined = [...tasks, ...unscheduledTasks];
+
+        const goalStats = (goalsProjectsEnabled && goals.length > 0)
+          ? goals
+              .filter(g => g.status !== 'archived')
+              .map(g => {
+                const progress = calculateGoalProgress(g.id, projects, allTasksCombined);
+                let daysToTarget = null;
+                if (g.targetDate) {
+                  const target = new Date(g.targetDate + 'T12:00:00');
+                  const todayMidnight = new Date();
+                  todayMidnight.setHours(0, 0, 0, 0);
+                  daysToTarget = Math.ceil((target - todayMidnight) / (1000 * 60 * 60 * 24));
+                }
+                return { id: g.id, title: g.title, progressPct: Math.round(progress * 100), daysToTarget };
+              })
+          : [];
+
+        const projectStats = (goalsProjectsEnabled && projects.length > 0)
+          ? projects
+              .filter(p => p.status !== 'archived')
+              .map(p => {
+                const projectTasks = allTasksCombined.filter(t => t.projectId === p.id && !t.archived);
+                const weekTasks = projectTasks.filter(t => pastWeekDates.includes(t.date));
+                const weekCompleted = weekTasks.filter(t => t.completed).length;
+                const weekTotal = weekTasks.length;
+                const overallProgress = calculateProjectProgress(p.id, allTasksCombined);
+                const stalled = isProjectStalled(p.id, allTasksCombined, p);
+                return {
+                  id: p.id,
+                  title: p.title,
+                  weekCompleted,
+                  weekTotal,
+                  overallProgressPct: Math.round(overallProgress * 100),
+                  stalled,
+                };
+              })
+              .filter(p => p.weekTotal > 0 || p.stalled)
+          : [];
+
         // Stats for AI weekly summary (used by click-to-reveal prompt)
         const nextWeekTopTasks = nextRegular
           .filter(t => !t.isExample)
@@ -345,6 +389,8 @@ const WeeklyReviewModal = () => {
           nextWeekCalendarEvents,
           habitStats: habitStats.map(h => ({ name: h.name, type: h.type, target: h.target, daysHit: h.daysHit })),
           frameStats: frameStats.map(f => ({ label: f.label, totalCapacityMin: f.totalCapacityMin, scheduledMin: f.scheduledMin, utilizationPct: f.utilizationPct })),
+          goalStats,
+          projectStats,
         };
 
         const StatCard = ({ value, label, icon }) => (


### PR DESCRIPTION
## Summary

- Updates `weeklySummarySystemPrompt` to instruct the AI to reference goals/projects data when provided (per-project completion, goal progress %, days to target, stalled projects)
- Updates `weeklySummaryUserPrompt` to accept and format `goalStats` and `projectStats` fields in the prompt text
- Updates `WeeklyReviewModal.jsx` to import the progress utilities, compute `goalStats` and `projectStats` from context (only when `goalsProjectsEnabled` is true), and pass them into `weeklyAIStats` → `generateWeeklyAISummary`

No new UI. Fully behind the feature flag — when `goalsProjectsEnabled` is false, `goalStats` and `projectStats` are empty arrays and the AI prompt is unchanged from today.

## What the AI can now say

- "You completed 3/5 tasks in 'Cloud Sync' this week (70% overall)"
- "Goal 'Launch v2.0' is 45% complete with 42 days to target"
- "'iOS App' is stalled — no tasks completed in the past 7 days"

## Test plan

- [ ] With `goalsProjectsEnabled = false`: open Weekly Review, trigger AI summary — output is identical to pre-PR behaviour (no goals/projects mention)
- [ ] With `goalsProjectsEnabled = true`, goals and projects that had task activity this week: AI summary mentions per-project completion and goal progress
- [ ] Goal with a `targetDate` in the past: AI summary mentions it as overdue
- [ ] Project with no completions in 7+ days: AI summary flags it as stalled
- [ ] `npm run build` passes ✓