### PR TITLE
Tighten GoalCard layout: merge percentage and project count onto one line

### DIFF
--- a/src/components/goals/GoalCard.jsx
+++ b/src/components/goals/GoalCard.jsx
@@ -120,7 +120,7 @@ const GoalCard = forwardRef(
           {/* Progress */}
           <GoalProgress progress={progress} color={goalColor} />
 
-          {/* Project count or empty state */}
+          {/* Project count + percentage, or empty state */}
           {projects.length === 0 ? (
             <div className="flex flex-col items-center gap-1.5 py-2">
               <FolderOpen size={18} className={`${textSecondary} opacity-50`} />
@@ -136,9 +136,14 @@ const GoalCard = forwardRef(
               )}
             </div>
           ) : (
-            <span className={`text-xs ${textSecondary}`}>
-              {projects.length} project{projects.length !== 1 ? 's' : ''}
-            </span>
+            <div className="flex items-center justify-between">
+              <span className={`text-xs ${textSecondary}`}>
+                {projects.length} project{projects.length !== 1 ? 's' : ''}
+              </span>
+              <span className={`text-xs font-medium ${progress >= 1 ? 'text-green-500' : textSecondary}`}>
+                {Math.round(progress * 100)}%
+              </span>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/goals/GoalProgress.jsx
+++ b/src/components/goals/GoalProgress.jsx
@@ -10,26 +10,15 @@ const GoalProgress = ({ progress, color }) => {
   const pct = Math.round((progress || 0) * 100);
 
   return (
-    <div className="w-full">
+    <div
+      className={`w-full h-2 rounded-full overflow-hidden ${
+        darkMode ? 'bg-gray-700' : 'bg-stone-200'
+      }`}
+    >
       <div
-        className={`w-full h-2 rounded-full overflow-hidden ${
-          darkMode ? 'bg-gray-700' : 'bg-stone-200'
-        }`}
-      >
-        <div
-          className={`h-full rounded-full transition-all duration-500 ${color || 'bg-blue-500'}`}
-          style={{ width: `${pct}%` }}
-        />
-      </div>
-      <div className="flex justify-end mt-0.5">
-        <span
-          className={`text-xs font-medium ${
-            pct === 100 ? 'text-green-500' : textSecondary
-          }`}
-        >
-          {pct}%
-        </span>
-      </div>
+        className={`h-full rounded-full transition-all duration-500 ${color || 'bg-blue-500'}`}
+        style={{ width: `${pct}%` }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Removes the blank gap between the progress bar and the project count in the active GoalCard.

Previously `GoalProgress` rendered the `100%` label on its own line below the bar, then `GoalCard` rendered `4 projects` on a separate line below that — two lines of content with a `gap-2` between them, creating visible empty space.

**After:** the percentage is removed from `GoalProgress` entirely and placed inline with the project count in `GoalCard` — project count left-aligned, percentage right-aligned on the same row.

- `GoalProgress.jsx`: simplified to just the bar (no label row)
- `GoalCard.jsx`: project-count row becomes a flex `justify-between` with count on left, `{pct}%` on right; empty-state branch is unchanged

## Test plan
- [ ] GoalCard with projects: progress bar, then `4 projects · 100%` on same line — no gap
- [ ] GoalCard with no projects: empty state layout unchanged
- [ ] `npm run build` passes ✓