### PR TITLE
Fix completed project cards stacking vertically on desktop dashboard

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -701,7 +701,7 @@ const DesktopDashboard = ({
                   </div>
                 )}
                 {doneProjs.length > 0 && (
-                  <div className="flex flex-col gap-1.5">
+                  <div className="flex flex-wrap gap-4 justify-center">
                     {doneProjs.map(proj => (
                       <ProjectCard
                         key={proj.id}
@@ -753,7 +753,7 @@ const DesktopDashboard = ({
                   </div>
                 )}
                 {doneProjs.length > 0 && (
-                  <div className="flex flex-col gap-1.5">
+                  <div className="flex flex-wrap gap-4">
                     {doneProjs.map(proj => (
                       <ProjectCard
                         key={proj.id}


### PR DESCRIPTION
## Summary

Completed project cards were stacking vertically instead of wrapping horizontally across the dashboard width.

Both `doneProjs` container divs used `flex flex-col gap-1.5`, which forced cards into a single column. Changed to `flex flex-wrap gap-4` to match the active-projects layout above them. The goal-linked section also gets `justify-center` to stay consistent with the active-projects row it sits under.

The compact card itself already had `min-w-[180px] max-w-[240px]` set correctly for wrapping — only the container class was wrong.

## Test plan
- [ ] Completed projects under a goal wrap horizontally (centered), not stacked vertically
- [ ] Completed standalone projects wrap horizontally (left-aligned)
- [ ] Active projects layout unchanged
- [ ] Mobile carousel unaffected (separate code path)
- [ ] `npm run build` passes ✓