### PR TITLE
Add project chips to Android widget task rows

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
@@ -62,6 +62,7 @@ class DayGlanceWidgetListFactory(
             val badge: String,   // e.g. "ALL DAY", "DUE TODAY", "OVERDUE"
             val timeStr: String,
             val indent: Boolean = false,
+            val projectName: String = "",
         ) : AgendaItem(TYPE_TASK)
         class FrameHeader(
             val name: String,
@@ -151,6 +152,7 @@ class DayGlanceWidgetListFactory(
                     colorHex = t.optString("colorHex", "#ef4444"),
                     badge = "",
                     timeStr = "",
+                    projectName = t.optString("projectName", ""),
                 )
             }
         }
@@ -166,6 +168,7 @@ class DayGlanceWidgetListFactory(
                     colorHex = t.optString("colorHex", "#3b82f6"),
                     badge = "ALL DAY",
                     timeStr = "",
+                    projectName = t.optString("projectName", ""),
                 )
             }
         }
@@ -180,6 +183,7 @@ class DayGlanceWidgetListFactory(
                     colorHex = t.optString("colorHex", "#f97316"),
                     badge = "DUE TODAY",
                     timeStr = "",
+                    projectName = t.optString("projectName", ""),
                 )
             }
         }
@@ -209,6 +213,7 @@ class DayGlanceWidgetListFactory(
                     colorHex = t.optString("colorHex", "#ef4444"),
                     badge = "OVERDUE",
                     timeStr = buildTimeStr(t),
+                    projectName = t.optString("projectName", ""),
                 )
             }
         }
@@ -237,6 +242,7 @@ class DayGlanceWidgetListFactory(
                                     badge = if (isInProgress(t)) "IN PROGRESS" else "",
                                     timeStr = buildTimeStr(t),
                                     indent = true,
+                                    projectName = t.optString("projectName", ""),
                                 )
                             }
                         }
@@ -251,6 +257,7 @@ class DayGlanceWidgetListFactory(
                                 badge = if (isInProgress(t)) "IN PROGRESS" else "",
                                 timeStr = buildTimeStr(t),
                                 indent = false,
+                                projectName = t.optString("projectName", ""),
                             )
                         }
                     }
@@ -462,6 +469,14 @@ class DayGlanceWidgetListFactory(
             rv.setViewVisibility(R.id.tv_task_badge, View.GONE)
         }
 
+        // Project chip
+        if (item.projectName.isNotEmpty()) {
+            rv.setTextViewText(R.id.tv_task_project, item.projectName)
+            rv.setViewVisibility(R.id.tv_task_project, View.VISIBLE)
+        } else {
+            rv.setViewVisibility(R.id.tv_task_project, View.GONE)
+        }
+
         // Time / tag line
         if (item.timeStr.isNotEmpty()) {
             rv.setTextViewText(R.id.tv_task_time, item.timeStr)
@@ -472,6 +487,7 @@ class DayGlanceWidgetListFactory(
 
         rv.boostTextSizeForOneUi(R.id.tv_task_title, 13f)
         rv.boostTextSizeForOneUi(R.id.tv_task_badge, 11f)
+        rv.boostTextSizeForOneUi(R.id.tv_task_project, 10f)
         rv.boostTextSizeForOneUi(R.id.tv_task_time, 12f)
         rv.setOnClickFillInIntent(R.id.task_item_root, android.content.Intent())
         return rv

--- a/dayglance-android/app/src/main/res/layout/widget_item_task.xml
+++ b/dayglance-android/app/src/main/res/layout/widget_item_task.xml
@@ -8,6 +8,7 @@
 
   Structure:
     [color bar 3dp] [title + label row]
+                    [project chip]       ← hidden when no projectId
                     [time/tag line]
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
@@ -69,6 +70,24 @@
                 android:visibility="gone" />
 
         </LinearLayout>
+
+        <!-- Project chip — hidden when task has no project -->
+        <TextView
+            android:id="@+id/tv_task_project"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=""
+            android:textColor="@color/widget_committed_text"
+            android:textSize="10sp"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
+            android:paddingTop="1dp"
+            android:paddingBottom="1dp"
+            android:layout_marginTop="2dp"
+            android:background="@drawable/widget_committed_pill"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:visibility="gone" />
 
         <!-- Time + tags line -->
         <TextView

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5496,6 +5496,9 @@ const DayPlanner = () => {
 
     // ── Overdue tasks (split: prior-day vs today-past-endtime) ────────────
     const allOverdueTasks = getOverdueTasks();
+    const getProjectName = t => (goalsProjectsEnabled && t.projectId)
+      ? (projects.find(p => p.id === t.projectId)?.title || null)
+      : null;
     // Prior-day tasks → dedicated OVERDUE section in widget (no time, no badge)
     const overdueItems = allOverdueTasks
       .filter(t => t._overdueType === 'scheduled' ? t.date < todayStr : true)
@@ -5504,6 +5507,7 @@ const DayPlanner = () => {
         title: t.title,
         colorHex: taskColorToHex(t.color, t.nativeCalendarColor),
         overdueType: t._overdueType || 'scheduled',
+        projectName: getProjectName(t),
       }));
     // Today's tasks that have passed their end time → shown in SCHEDULED with time
     const overdueTodayItems = allOverdueTasks
@@ -5514,6 +5518,7 @@ const DayPlanner = () => {
         colorHex: taskColorToHex(t.color, t.nativeCalendarColor),
         startTime: t.startTime || '',
         duration: t.duration || 0,
+        projectName: getProjectName(t),
       }));
 
     // ── Habits (up to 5) ──────────────────────────────────────────────────
@@ -5553,6 +5558,7 @@ const DayPlanner = () => {
         id: t.id,
         title: t.title,
         colorHex: taskColorToHex(t.color, t.nativeCalendarColor),
+        projectName: getProjectName(t),
       }));
 
     // ── Deadline tasks (due today) ─────────────────────────────────────────
@@ -5562,6 +5568,7 @@ const DayPlanner = () => {
         id: t.id,
         title: t.title,
         colorHex: taskColorToHex(t.color, t.nativeCalendarColor),
+        projectName: getProjectName(t),
       }));
 
     // ── Frame sections + unframed scheduled tasks ─────────────────────────
@@ -5592,6 +5599,9 @@ const DayPlanner = () => {
       startTime: t.startTime || '',
       duration: t.duration || 0,
       tags: (t.tags || []).slice(0, 3),
+      projectName: (goalsProjectsEnabled && t.projectId)
+        ? (projects.find(p => p.id === t.projectId)?.title || null)
+        : null,
     });
 
     const sections = [];
@@ -5716,6 +5726,8 @@ const DayPlanner = () => {
     unscheduledTasks,
     glanceAhead,
     currentTime,
+    projects,
+    goalsProjectsEnabled,
   ]);
 
   // GTD Frame CRUD operations


### PR DESCRIPTION
## Summary

- Tasks that belong to a project now show a small pill chip with the project name below the task title in the Android home screen widget
- Matches the blue pill styling from the GLANCE panel — uses the existing `widget_committed_pill` drawable and `widget_committed_bg`/`widget_committed_text` color tokens, which already have `values-night` overrides for dark mode
- Chip is hidden when `goalsProjectsEnabled` is false or the task has no project
- Covers all task types: scheduled (framed + unframed), overdue (prior-day + today past end-time), all-day, and deadline tasks

## Changes

**`src/App.jsx`**
- Added `getProjectName(t)` helper in the widget snapshot `useEffect`
- Added `projectName` field to all 5 task serialization paths
- Added `projects` and `goalsProjectsEnabled` to the useEffect dependency array

**`dayglance-android/…/widget_item_task.xml`**
- Added `tv_task_project` TextView between the title row and time row, using `@drawable/widget_committed_pill` background and `@color/widget_committed_text`

**`dayglance-android/…/DayGlanceWidgetListFactory.kt`**
- Added `projectName: String = ""` field to `AgendaItem.Task`
- Extracts `projectName` from JSON at all 7 `AgendaItem.Task(…)` construction sites
- Shows/hides `tv_task_project` chip in `buildTaskView`, with OneUI font size boost applied

## Test plan

- [ ] Place widget on home screen with a task that has a project assigned — confirm chip appears below the task title with the project name
- [ ] Confirm chip is absent for tasks without a project
- [ ] Confirm chip is absent when Goals & Projects is disabled (`goalsProjectsEnabled = false`)
- [ ] Check dark mode — chip background/text should switch to dark blue tones automatically
- [ ] Verify tasks with both a project chip and a time string display both rows correctly

https://claude.ai/code/session_01RuQWp1p2w54BfdK3hvXzwT