### PR TITLE
Show scheduled tasks above unscheduled in ProjectCard

### DIFF
--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -103,10 +103,10 @@ const ProjectCard = forwardRef(({ project, onFocusClick, onEditClick, compact },
   const projectScheduled = tasks.filter(t => t.projectId === project.id && !t.archived)
     .sort((a, b) => (a.date || '').localeCompare(b.date || ''));
   const allProjectDisplayTasks = [
-    ...projectUnscheduled.filter(t => !t.completed),
     ...projectScheduled.filter(t => !t.completed),
-    ...projectUnscheduled.filter(t => t.completed),
+    ...projectUnscheduled.filter(t => !t.completed),
     ...projectScheduled.filter(t => t.completed),
+    ...projectUnscheduled.filter(t => t.completed),
   ];
   const VISIBLE_COUNT = 3;
   const hasMore = allProjectDisplayTasks.length > VISIBLE_COUNT;


### PR DESCRIPTION
## Summary

- Reorders tasks in ProjectCard so scheduled (dated) tasks appear above unscheduled tasks
- Order is now: scheduled incomplete → unscheduled incomplete → scheduled completed → unscheduled completed
- One-line change in `allProjectDisplayTasks`

## Changes

**`src/components/projects/ProjectCard.jsx`**
- Swapped `projectScheduled` and `projectUnscheduled` in the `allProjectDisplayTasks` array for both the incomplete and completed groups

## Test plan

- [ ] Open the Goals Dashboard and expand a project that has both scheduled and unscheduled tasks — confirm scheduled tasks appear first
- [ ] Confirm completed tasks still appear below all incomplete tasks
- [ ] Confirm drag-to-reorder still works on unscheduled tasks

https://claude.ai/code/session_01RuQWp1p2w54BfdK3hvXzwT