### PR TITLE
Add project chips to mobile timeline + make them interactive

### DIFF
--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -419,7 +419,7 @@ const MobileLayout = () => {
     saveMobileEditTask, saveMobileEditNativeEvent,
     pushUndo, performUndo, performRedo,
     confirmEmptyBin, emptyRecycleBin,
-    projectFilter,
+    projectFilter, setProjectFilter,
     goals,
     projects,
     goalsProjectsEnabled,
@@ -2445,9 +2445,13 @@ const MobileLayout = () => {
                               const proj = projects.find(p => p.id === task.projectId);
                               if (!proj) return null;
                               return (
-                                <span className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full font-medium ${darkMode ? 'bg-blue-900/50 text-blue-300' : 'bg-blue-100 text-blue-700'}`}>
+                                <button
+                                  onClick={(e) => { e.stopPropagation(); setProjectFilter(prev => prev === task.projectId ? null : task.projectId); }}
+                                  className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full font-medium transition-colors ${darkMode ? 'bg-blue-900/50 text-blue-300 active:bg-blue-800/70' : 'bg-blue-100 text-blue-700 active:bg-blue-200'} ${projectFilter === task.projectId ? 'ring-1 ring-blue-400' : ''}`}
+                                  title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
+                                >
                                   {proj.title}
-                                </span>
+                                </button>
                               );
                             })()}
                           </div>


### PR DESCRIPTION
## Summary

Project chips were missing entirely from the mobile layout (Android app + mobile-width PWA), and the project filter could not be toggled on mobile. This PR brings mobile to full parity with desktop for project chip functionality.

## Changes

**`src/components/MobileLayout.jsx`**

**Commit 1 — Add chips to agenda task rows**
- Added `projects` and `goalsProjectsEnabled` to context destructuring
- Added project chip below the time/label row for agenda tasks, gated on `goalsProjectsEnabled && task.projectId`
- Changed `whitespace-nowrap` → `flex-wrap` on the time row so the chip wraps cleanly when space is tight

**Commit 2 — Make chips interactive**
- Added `setProjectFilter` to context destructuring
- Upgraded chip from a read-only `<span>` to a `<button>` matching desktop behaviour: tap to filter the timeline by project, tap again to clear; active ring (`ring-1 ring-blue-400`) shown when filter is active; `active:bg` used instead of `hover:bg` for touch

## Gap analysis performed
A full comparison of goals/projects features between `DesktopLayout` and `MobileLayout` was done. The only actionable gap was project chips + filter interactivity. The other differences (Goals & Projects FAB vs dedicated tab, `addGoalTrigger`/`addProjectTrigger`) are intentional architectural choices for each layout.

## Test plan

- [ ] Open the mobile timeline with a task that has a project — confirm chip appears below the time label
- [ ] Tap the chip — confirm the timeline filters to show only tasks from that project (chip gets blue ring)
- [ ] Tap again — confirm filter clears
- [ ] Confirm no chip appears for tasks without a project
- [ ] Confirm no chip appears when Goals & Projects is disabled
- [ ] Check dark mode chip colours

https://claude.ai/code/session_01RuQWp1p2w54BfdK3hvXzwT