### PR TITLE
Fix project chip layout, Goals carousel, and dark mode scrollbars

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -1341,7 +1341,7 @@ const DesktopLayout = () => {
                                     <button key={i} className="flex-shrink-0 text-purple-400 active:text-purple-300" onClick={(e) => { e.stopPropagation(); window.DayGlanceObsidian?.openNote(note); }} title={`Open "${note}" in Obsidian`}><NotebookPen size={13} /></button>
                                   ))}
                                 </div>
-                                <div className={`text-sm ${textSecondary} flex items-center gap-1 flex-wrap`}>
+                                <div className={`text-sm ${textSecondary} flex items-center gap-1`}>
                                   <span className="whitespace-nowrap">{timeLabel}{relativeLabel ? ',' : ''}</span>{relativeLabel ? <span className={relativeLabel === 'Overdue' ? 'text-orange-500 font-medium' : relativeLabel === 'In Progress' ? 'text-blue-500 font-medium' : ''}>{relativeLabel}</span> : ''}
                                   {relativeLabel === 'In Progress' && focusModeAvailable && (
                                     <button
@@ -1352,20 +1352,20 @@ const DesktopLayout = () => {
                                       <Target size={16} className="animate-pulse" />
                                     </button>
                                   )}
-                                  {goalsProjectsEnabled && task.projectId && (() => {
-                                    const proj = projects.find(p => p.id === task.projectId);
-                                    if (!proj) return null;
-                                    return (
-                                      <button
-                                        onClick={(e) => { e.stopPropagation(); setProjectFilter(prev => prev === task.projectId ? null : task.projectId); }}
-                                        className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full font-medium transition-colors ${darkMode ? 'bg-blue-900/50 text-blue-300 hover:bg-blue-800/70' : 'bg-blue-100 text-blue-700 hover:bg-blue-200'} ${projectFilter === task.projectId ? 'ring-1 ring-blue-400' : ''}`}
-                                        title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
-                                      >
-                                        {proj.title}
-                                      </button>
-                                    );
-                                  })()}
                                 </div>
+                                {goalsProjectsEnabled && task.projectId && (() => {
+                                  const proj = projects.find(p => p.id === task.projectId);
+                                  if (!proj) return null;
+                                  return (
+                                    <button
+                                      onClick={(e) => { e.stopPropagation(); setProjectFilter(prev => prev === task.projectId ? null : task.projectId); }}
+                                      className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full font-medium transition-colors ${darkMode ? 'bg-blue-900/50 text-blue-300 hover:bg-blue-800/70' : 'bg-blue-100 text-blue-700 hover:bg-blue-200'} ${projectFilter === task.projectId ? 'ring-1 ring-blue-400' : ''}`}
+                                      title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
+                                    >
+                                      {proj.title}
+                                    </button>
+                                  );
+                                })()}
                               </div>
                               {(relativeLabel === 'Overdue' || (task._agendaType === 'allday' && !task.imported)) && !task.completed && (
                                 <div className="flex items-center gap-1 flex-shrink-0 mr-5">
@@ -2565,7 +2565,7 @@ const DesktopLayout = () => {
                                 <button key={i} className="flex-shrink-0 text-purple-400 active:text-purple-300" onClick={(e) => { e.stopPropagation(); window.DayGlanceObsidian?.openNote(note); }} title={`Open "${note}" in Obsidian`}><NotebookPen size={13} /></button>
                               ))}
                             </div>
-                            <div className={`text-sm ${textSecondary} flex items-center gap-1 flex-wrap`}>
+                            <div className={`text-sm ${textSecondary} flex items-center gap-1`}>
                               <span className="whitespace-nowrap">{timeLabel}{relativeLabel ? ',' : ''}</span>{relativeLabel ? <span className={relativeLabel === 'Overdue' ? 'text-orange-500 font-medium' : relativeLabel === 'In Progress' ? 'text-blue-500 font-medium' : ''}>{relativeLabel}</span> : ''}
                               {relativeLabel === 'In Progress' && focusModeAvailable && (
                                 <button
@@ -2576,20 +2576,20 @@ const DesktopLayout = () => {
                                   <Target size={16} className="animate-pulse" />
                                 </button>
                               )}
-                              {goalsProjectsEnabled && task.projectId && (() => {
-                                const proj = projects.find(p => p.id === task.projectId);
-                                if (!proj) return null;
-                                return (
-                                  <button
-                                    onClick={(e) => { e.stopPropagation(); setProjectFilter(prev => prev === task.projectId ? null : task.projectId); }}
-                                    className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full font-medium transition-colors ${darkMode ? 'bg-blue-900/50 text-blue-300 hover:bg-blue-800/70' : 'bg-blue-100 text-blue-700 hover:bg-blue-200'} ${projectFilter === task.projectId ? 'ring-1 ring-blue-400' : ''}`}
-                                    title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
-                                  >
-                                    {proj.title}
-                                  </button>
-                                );
-                              })()}
                             </div>
+                            {goalsProjectsEnabled && task.projectId && (() => {
+                              const proj = projects.find(p => p.id === task.projectId);
+                              if (!proj) return null;
+                              return (
+                                <button
+                                  onClick={(e) => { e.stopPropagation(); setProjectFilter(prev => prev === task.projectId ? null : task.projectId); }}
+                                  className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full font-medium transition-colors ${darkMode ? 'bg-blue-900/50 text-blue-300 hover:bg-blue-800/70' : 'bg-blue-100 text-blue-700 hover:bg-blue-200'} ${projectFilter === task.projectId ? 'ring-1 ring-blue-400' : ''}`}
+                                  title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
+                                >
+                                  {proj.title}
+                                </button>
+                              );
+                            })()}
                           </div>
                           {(relativeLabel === 'Overdue' || (task._agendaType === 'allday' && !task.imported)) && !task.completed && (
                             <div className="flex items-center gap-1 flex-shrink-0 mr-5">

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -875,7 +875,7 @@ const MobileDashboard = ({
       {/* Carousel */}
       <div
         ref={scrollRef}
-        className="flex-1 min-h-0 flex overflow-x-auto overflow-y-hidden"
+        className="goal-carousel flex-1 min-h-0 flex overflow-x-auto overflow-y-hidden"
         style={{
           scrollSnapType: 'x mandatory',
           WebkitOverflowScrolling: 'touch',
@@ -896,7 +896,7 @@ const MobileDashboard = ({
             return (
               <div
                 key={goal.id}
-                className="flex-shrink-0 w-full h-full overflow-y-auto px-4 pb-4"
+                className="flex-shrink-0 w-full h-full overflow-y-auto overflow-x-hidden px-4 pb-4"
                 style={{ scrollSnapAlign: 'start' }}
               >
                 {/* Goal header card */}

--- a/src/index.css
+++ b/src/index.css
@@ -103,8 +103,15 @@ body.using-pointer a:focus-visible {
   outline: none;
 }
 
-/* Hide scrollbar on review carousel */
+/* Hide scrollbar on review carousel and goal dashboard carousel */
 .review-carousel::-webkit-scrollbar { display: none; }
+.goal-carousel::-webkit-scrollbar { display: none; }
+
+/* Dark mode scrollbar — applied when html.dark is active */
+.dark ::-webkit-scrollbar-track { background: #1f2937; }
+.dark ::-webkit-scrollbar-thumb { background: #4b5563; }
+.dark ::-webkit-scrollbar-thumb:hover { background: #6b7280; }
+.dark * { scrollbar-color: #4b5563 #1f2937; }
 
 /* App shell — locks body to visible viewport so only inner panes scroll */
 .app-shell {


### PR DESCRIPTION
## Summary

Follow-up bugfixes after testing the goals/projects feature on device.

## Changes

**`src/components/DesktopLayout.jsx`** — GLANCE panel chip on its own line
- Project chip was rendering inline with the time/label row; moved it to a separate line below (both GLANCE tab instances)

**`src/components/goals/GoalDashboard.jsx`** — carousel scrollbar + swipe
- Added `goal-carousel` CSS class to the carousel container
- Added `overflow-x-hidden` to each page div so that `flex-wrap` project card content can't bleed out and corrupt the scroll-snap page widths (this was breaking swipe-between-pages)

**`src/index.css`** — scrollbar styling
- Added `.goal-carousel::-webkit-scrollbar { display: none }` to hide the horizontal scrollbar in Chrome/Android WebView (the existing `scrollbarWidth: none` only works in Firefox)
- Added `.dark ::-webkit-scrollbar-*` overrides so all scrollbars (timeline, GLANCE tab, Goals tab, etc.) use dark grey tones in dark mode instead of the default bright white/light grey

## Test plan

- [ ] GLANCE panel: project chip appears on its own line below the time label, not inline with it
- [ ] Goals tab: no horizontal scrollbar visible when paging between goals
- [ ] Goals tab: swiping left/right between goal pages works again
- [ ] Dark mode: all vertical scrollbars (timeline, inbox, GLANCE panel, Goals tab) show dark grey styling
- [ ] Light mode: scrollbar styling unchanged

https://claude.ai/code/session_01RuQWp1p2w54BfdK3hvXzwT