### PR TITLE
fix: widget color bar full height + GoalCard completed state (mobile)

### DIFF
--- a/dayglance-android/app/src/main/res/layout/widget_item_task.xml
+++ b/dayglance-android/app/src/main/res/layout/widget_item_task.xml
@@ -10,33 +10,24 @@
     [color bar 3dp] [title + label row]
                     [project chip]       ← hidden when no projectId
                     [time/tag line]
+
+  The color bar uses alignTop/alignBottom on the text content block so it
+  always stretches to the full row height (2 lines without chip, 3 with).
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/task_item_root"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:gravity="center_vertical"
-    android:paddingTop="4dp"
-    android:paddingBottom="4dp"
-    android:paddingStart="0dp"
-    android:paddingEnd="0dp">
+    android:layout_height="wrap_content">
 
-    <!-- Color bar -->
-    <TextView
-        android:id="@+id/task_color_bar"
-        android:layout_width="3dp"
-        android:layout_height="28dp"
-        android:background="#3b82f6"
-        android:layout_marginEnd="7dp"
-        android:text="" />
-
-    <!-- Text content -->
+    <!-- Text content — drives the row height -->
     <LinearLayout
-        android:layout_width="0dp"
+        android:id="@+id/task_text_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:layout_marginStart="10dp"
+        android:orientation="vertical"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp">
 
         <!-- Title row: task name + badge (ALL DAY / DUE TODAY / OVERDUE) -->
         <LinearLayout
@@ -103,4 +94,13 @@
 
     </LinearLayout>
 
-</LinearLayout>
+    <!-- Color bar — aligned to text content so it always spans the full row height -->
+    <View
+        android:id="@+id/task_color_bar"
+        android:layout_width="3dp"
+        android:layout_height="0dp"
+        android:layout_alignTop="@id/task_text_content"
+        android:layout_alignBottom="@id/task_text_content"
+        android:background="#3b82f6" />
+
+</RelativeLayout>

--- a/src/components/goals/GoalCard.jsx
+++ b/src/components/goals/GoalCard.jsx
@@ -55,6 +55,7 @@ const GoalCard = forwardRef(
     // All non-archived projects complete → offer one-click completion
     const nonArchivedProjects = projects.filter(p => p.status !== 'archived');
     const allProjectsDone = nonArchivedProjects.length > 0 && progress >= 1;
+    const isCompleted = goal.status === 'completed';
 
     return (
       <div
@@ -62,7 +63,7 @@ const GoalCard = forwardRef(
         className={`rounded-xl overflow-hidden border-2 w-full ${
           darkMode ? 'border-gray-600' : 'border-stone-200'
         }`}
-        style={{ borderTopColor: 'transparent', borderLeftColor: 'transparent', borderRightColor: 'transparent' }}
+        style={{ opacity: isCompleted ? 0.45 : 1, borderTopColor: 'transparent', borderLeftColor: 'transparent', borderRightColor: 'transparent' }}
       >
         {/* Colored header */}
         <div className={`${goalColor} px-3 py-2.5 flex items-center gap-2`}>
@@ -84,8 +85,10 @@ const GoalCard = forwardRef(
             darkMode ? 'bg-gray-800' : 'bg-white'
           }`}
         >
-          {/* Target date + caution */}
-          {(daysLabel || showCaution) && (
+          {/* Target date + caution, or Completed label */}
+          {isCompleted ? (
+            <p className="text-xs text-emerald-500">Completed</p>
+          ) : (daysLabel || showCaution || allProjectsDone) ? (
             <div className="flex items-center gap-1.5">
               {daysLabel && (
                 <>
@@ -108,7 +111,7 @@ const GoalCard = forwardRef(
                 </button>
               )}
             </div>
-          )}
+          ) : null}
 
           {/* Description */}
           {goal.description && (


### PR DESCRIPTION
## Summary

- **Android widget color bar**: Switched `widget_item_task.xml` root from `LinearLayout` to `RelativeLayout` so the color bar uses `alignTop`/`alignBottom` relative to the text content block. The bar now stretches to the full row height automatically — 2 lines for normal tasks, 3 lines when the project chip is visible.
- **GoalCard (mobile) completed state**: Completed goals now show a green "Completed" label instead of the target-date/caution row, the CircleCheckBig icon is hidden, and the card renders at 45% opacity — matching desktop `GoalDashboard` behaviour. (This fix was in the PR #208 branch but wasn't included in the merge.)

## Test plan

- [ ] Android widget: verify a project task shows the color bar extending the full height of all three rows (title, chip, time)
- [ ] Android widget: verify a non-project task's color bar still looks correct (2 rows)
- [ ] Mobile Goals tab: mark a goal as completed and confirm it shows "Completed" in green at 45% opacity with no date row or circle-check icon

https://claude.ai/code/session_01RuQWp1p2w54BfdK3hvXzwT