### PR TITLE
Fix mobile Goals swipe + Android widget color bar height (#211)

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
@@ -443,7 +443,18 @@ class DayGlanceWidgetListFactory(
         val rv = RemoteViews(context.packageName, R.layout.widget_item_task)
         rv.setTextViewText(R.id.tv_task_title, item.title)
         val color = safeParseColor(item.colorHex, "#3b82f6")
-        rv.setInt(R.id.task_color_bar, "setBackgroundColor", color)
+
+        // Toggle between the 28dp bar (no chip) and the 44dp bar (with project chip).
+        // RemoteViews cannot set layout params dynamically, so we use two static Views.
+        if (item.projectName.isNotEmpty()) {
+            rv.setViewVisibility(R.id.task_color_bar, View.GONE)
+            rv.setViewVisibility(R.id.task_color_bar_tall, View.VISIBLE)
+            rv.setInt(R.id.task_color_bar_tall, "setBackgroundColor", color)
+        } else {
+            rv.setViewVisibility(R.id.task_color_bar, View.VISIBLE)
+            rv.setViewVisibility(R.id.task_color_bar_tall, View.GONE)
+            rv.setInt(R.id.task_color_bar, "setBackgroundColor", color)
+        }
 
         // Indent frame-nested tasks and give them the same gray background as the frame header
         val startPad = if (item.indent) dpToPx(14) else 0

--- a/dayglance-android/app/src/main/res/layout/widget_item_task.xml
+++ b/dayglance-android/app/src/main/res/layout/widget_item_task.xml
@@ -7,24 +7,45 @@
             setViewPadding on the root view).
 
   Structure:
-    [color bar 3dp] [title + label row]
-                    [project chip]       ← hidden when no projectId
-                    [time/tag line]
+    [color bar] [title + label row]
+                [project chip]       ← hidden when no projectId
+                [time/tag line]
 
-  The color bar uses alignTop/alignBottom on the text content block so it
-  always stretches to the full row height (2 lines without chip, 3 with).
+  Two color-bar Views are used because RemoteViews cannot set layout params
+  dynamically. The 28dp bar is for standard 2-line rows (no project chip);
+  the 44dp bar is for 3-line rows (with project chip). Exactly one is VISIBLE
+  at a time; GONE views take no space in LinearLayout.
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/task_item_root"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical">
+
+    <!-- Short color bar — 2-line rows (no project chip), VISIBLE by default -->
+    <View
+        android:id="@+id/task_color_bar"
+        android:layout_width="3dp"
+        android:layout_height="28dp"
+        android:layout_marginEnd="7dp"
+        android:background="#3b82f6" />
+
+    <!-- Tall color bar — 3-line rows (with project chip), GONE by default -->
+    <View
+        android:id="@+id/task_color_bar_tall"
+        android:layout_width="3dp"
+        android:layout_height="44dp"
+        android:layout_marginEnd="7dp"
+        android:background="#3b82f6"
+        android:visibility="gone" />
 
     <!-- Text content — drives the row height -->
     <LinearLayout
         android:id="@+id/task_text_content"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="10dp"
+        android:layout_weight="1"
         android:orientation="vertical"
         android:paddingTop="4dp"
         android:paddingBottom="4dp">
@@ -94,13 +115,4 @@
 
     </LinearLayout>
 
-    <!-- Color bar — aligned to text content so it always spans the full row height -->
-    <View
-        android:id="@+id/task_color_bar"
-        android:layout_width="3dp"
-        android:layout_height="0dp"
-        android:layout_alignTop="@id/task_text_content"
-        android:layout_alignBottom="@id/task_text_content"
-        android:background="#3b82f6" />
-
-</RelativeLayout>
+</LinearLayout>

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -912,7 +912,7 @@ const MobileDashboard = ({
               <div
                 key={goal.id}
                 className="flex-shrink-0 w-full h-full overflow-y-auto overflow-x-hidden px-4 pb-4"
-                style={{ scrollSnapAlign: 'start' }}
+                style={{ scrollSnapAlign: 'start', touchAction: 'pan-y' }}
               >
                 {/* Goal header card */}
                 {(() => {
@@ -1042,7 +1042,7 @@ const MobileDashboard = ({
             <div
               key="standalone"
               className="flex-shrink-0 w-full h-full overflow-y-auto overflow-x-hidden px-4 pb-4"
-              style={{ scrollSnapAlign: 'start' }}
+              style={{ scrollSnapAlign: 'start', touchAction: 'pan-y' }}
             >
               <div className="mt-2 mb-4">
                 <span className={`text-xs font-semibold uppercase tracking-wider ${textSecondary}`}>


### PR DESCRIPTION
## Summary

- **Mobile Goals swipe**: Added `touch-action: pan-y` to both carousel page divs in `GoalDashboard`. Without it, the page's vertical scroller competes with horizontal swipe in Android WebView — the gesture gets consumed before it can reach the scroll-snap container.
- **Widget color bar height**: The RelativeLayout approach from PR #209 (`layout_height="0dp"` + `alignTop/alignBottom`) fails to inflate in RemoteViews on some Android versions, causing `getViewAt()` to throw and the widget to display "Loading…" for every item. Reverted `widget_item_task.xml` to a LinearLayout with **two static `View`s** (`task_color_bar` 28dp, `task_color_bar_tall` 44dp). `DayGlanceWidgetListFactory.buildTaskView()` now toggles visibility between them based on whether the task has a project name — GONE views take no space in LinearLayout, so only the visible bar contributes to row height.

## Test plan

- [ ] Mobile Goals tab: swipe left/right between goal carousel pages works on Android
- [ ] Android widget: no "Loading…" placeholders — task rows render correctly
- [ ] Widget project tasks: 44dp tall color bar aligns with the 3-line row (title + chip + time)
- [ ] Widget non-project tasks: 28dp color bar aligns with the standard 2-line row (title + time)
- [ ] Widget task color bar colour matches the task/project colour

https://claude.ai/code/session_01RuQWp1p2w54BfdK3hvXzwT