### PR TITLE
Restore widget to working state (short color bar) (#213)

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
@@ -443,18 +443,7 @@ class DayGlanceWidgetListFactory(
         val rv = RemoteViews(context.packageName, R.layout.widget_item_task)
         rv.setTextViewText(R.id.tv_task_title, item.title)
         val color = safeParseColor(item.colorHex, "#3b82f6")
-
-        // Toggle between the 28dp bar (no chip) and the 44dp bar (with project chip).
-        // RemoteViews cannot set layout params dynamically, so we use two static Views.
-        if (item.projectName.isNotEmpty()) {
-            rv.setViewVisibility(R.id.task_color_bar, View.GONE)
-            rv.setViewVisibility(R.id.task_color_bar_tall, View.VISIBLE)
-            rv.setInt(R.id.task_color_bar_tall, "setBackgroundColor", color)
-        } else {
-            rv.setViewVisibility(R.id.task_color_bar, View.VISIBLE)
-            rv.setViewVisibility(R.id.task_color_bar_tall, View.GONE)
-            rv.setInt(R.id.task_color_bar, "setBackgroundColor", color)
-        }
+        rv.setInt(R.id.task_color_bar, "setBackgroundColor", color)
 
         // Indent frame-nested tasks and give them the same gray background as the frame header
         val startPad = if (item.indent) dpToPx(14) else 0

--- a/dayglance-android/app/src/main/res/layout/widget_item_task.xml
+++ b/dayglance-android/app/src/main/res/layout/widget_item_task.xml
@@ -7,48 +7,36 @@
             setViewPadding on the root view).
 
   Structure:
-    [color bar] [title + label row]
-                [project chip]       ← hidden when no projectId
-                [time/tag line]
-
-  Two color-bar Views are used because RemoteViews cannot set layout params
-  dynamically. The 28dp bar is for standard 2-line rows (no project chip);
-  the 44dp bar is for 3-line rows (with project chip). Exactly one is VISIBLE
-  at a time; GONE views take no space in LinearLayout.
+    [color bar 3dp] [title + label row]
+                    [project chip]       ← hidden when no projectId
+                    [time/tag line]
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/task_item_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:gravity="center_vertical">
+    android:gravity="center_vertical"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp"
+    android:paddingStart="0dp"
+    android:paddingEnd="0dp">
 
-    <!-- Short color bar — 2-line rows (no project chip), VISIBLE by default -->
-    <View
+    <!-- Color bar -->
+    <TextView
         android:id="@+id/task_color_bar"
         android:layout_width="3dp"
         android:layout_height="28dp"
-        android:layout_marginEnd="7dp"
-        android:background="#3b82f6" />
-
-    <!-- Tall color bar — 3-line rows (with project chip), GONE by default -->
-    <View
-        android:id="@+id/task_color_bar_tall"
-        android:layout_width="3dp"
-        android:layout_height="44dp"
-        android:layout_marginEnd="7dp"
         android:background="#3b82f6"
-        android:visibility="gone" />
+        android:layout_marginEnd="7dp"
+        android:text="" />
 
-    <!-- Text content — drives the row height -->
+    <!-- Text content -->
     <LinearLayout
-        android:id="@+id/task_text_content"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:orientation="vertical"
-        android:paddingTop="4dp"
-        android:paddingBottom="4dp">
+        android:orientation="vertical">
 
         <!-- Title row: task name + badge (ALL DAY / DUE TODAY / OVERDUE) -->
         <LinearLayout


### PR DESCRIPTION
## Summary

Reverts `widget_item_task.xml` and `DayGlanceWidgetListFactory.kt` back to the single 28dp `TextView` color bar that was working before PR #209.

**Root cause of "Loading..." crash:** The two-bar fix in PR #211 used `<View>` (base class) for both color bar elements. `RemoteViews` only supports a limited subset of view subclasses — `View` itself is not in that list, only subclasses like `TextView`, `ImageView`, etc. This caused inflation to throw, which made `getViewAt()` return null → "Loading..." for every item.

**What this restores:** Single `<TextView android:id="@+id/task_color_bar">` at 28dp height, same as the state that was working in PR #208. The color bar will be short again for project tasks (3-line rows), but the widget will function correctly.

A follow-up PR will fix the bar height using `<TextView>` elements instead of `<View>`.

## Test plan

- [ ] Widget renders task rows (no "Loading..." placeholders)
- [ ] Project chip shows correctly on project tasks
- [ ] Color bar shows at 28dp (short — known issue, follow-up coming)

https://claude.ai/code/session_01RuQWp1p2w54BfdK3hvXzwT