### PR TITLE
Fix widget tall color bar (TextView) + ProjectForm crash (#214)

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
@@ -443,7 +443,19 @@ class DayGlanceWidgetListFactory(
         val rv = RemoteViews(context.packageName, R.layout.widget_item_task)
         rv.setTextViewText(R.id.tv_task_title, item.title)
         val color = safeParseColor(item.colorHex, "#3b82f6")
-        rv.setInt(R.id.task_color_bar, "setBackgroundColor", color)
+
+        // Show the tall bar (44dp) for 3-line rows that include a project chip,
+        // and the short bar (28dp) for standard 2-line rows. Both are TextViews
+        // so RemoteViews can inflate them — base <View> is not in the supported subset.
+        if (item.projectName.isNotEmpty()) {
+            rv.setViewVisibility(R.id.task_color_bar, View.GONE)
+            rv.setViewVisibility(R.id.task_color_bar_tall, View.VISIBLE)
+            rv.setInt(R.id.task_color_bar_tall, "setBackgroundColor", color)
+        } else {
+            rv.setViewVisibility(R.id.task_color_bar, View.VISIBLE)
+            rv.setViewVisibility(R.id.task_color_bar_tall, View.GONE)
+            rv.setInt(R.id.task_color_bar, "setBackgroundColor", color)
+        }
 
         // Indent frame-nested tasks and give them the same gray background as the frame header
         val startPad = if (item.indent) dpToPx(14) else 0

--- a/dayglance-android/app/src/main/res/layout/widget_item_task.xml
+++ b/dayglance-android/app/src/main/res/layout/widget_item_task.xml
@@ -22,7 +22,7 @@
     android:paddingStart="0dp"
     android:paddingEnd="0dp">
 
-    <!-- Color bar -->
+    <!-- Short color bar — 2-line rows (no project chip), VISIBLE by default -->
     <TextView
         android:id="@+id/task_color_bar"
         android:layout_width="3dp"
@@ -30,6 +30,16 @@
         android:background="#3b82f6"
         android:layout_marginEnd="7dp"
         android:text="" />
+
+    <!-- Tall color bar — 3-line rows (with project chip), GONE by default -->
+    <TextView
+        android:id="@+id/task_color_bar_tall"
+        android:layout_width="3dp"
+        android:layout_height="44dp"
+        android:background="#3b82f6"
+        android:layout_marginEnd="7dp"
+        android:text=""
+        android:visibility="gone" />
 
     <!-- Text content -->
     <LinearLayout

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -1325,7 +1325,7 @@ const GoalDashboard = ({ embedded = false, addGoalTrigger = 0, addProjectTrigger
         )}
         {projectForm && (
           <FormOverlay onClose={() => setProjectForm(null)} mobile cardBg={cardBg}>
-            <ProjectForm initial={projectForm.editing} defaultGoalId={projectForm.defaultGoalId} onSave={handleSaveProject} onCancel={() => setProjectForm(null)} mobile />
+            <ProjectForm initial={projectForm.editing} goals={goals} defaultGoalId={projectForm.defaultGoalId} onSave={handleSaveProject} onCancel={() => setProjectForm(null)} mobile />
           </FormOverlay>
         )}
         {confirmDialog && (


### PR DESCRIPTION
## Summary

- **Widget tall bar**: adds `task_color_bar_tall` (44dp, GONE by default) as a `<TextView>` — not `<View>`. Base `<View>` is not in the RemoteViews supported subset and causes inflation crashes. The Kotlin toggles between the 28dp and 44dp bars based on whether the task has a project name.
- **ProjectForm crash**: the desktop dashboard's `ProjectForm` call at line 1328 was missing `goals={goals}`, causing `goals.filter()` to throw on `undefined` when the edit button was tapped on any project card.

## Test plan

- [ ] Widget: project tasks show the taller 44dp color bar; non-project tasks show 28dp
- [ ] Widget: no "Loading..." — all rows inflate correctly
- [ ] Tapping edit on a project card opens the edit form without crashing

https://claude.ai/code/session_01RuQWp1p2w54BfdK3hvXzwT