### PR TITLE
Fix status bar icons invisible on launch; fix shortcut modal on mobile

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -53,6 +53,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var nativeBridge: NativeBridge
     private lateinit var obsidianBridge: ObsidianBridge
     private lateinit var healthRepository: HealthRepository
+    private lateinit var dataStore: com.dayglance.app.data.SharedDataStore
 
     // Shown at most once per session so we don't nag the user repeatedly
     private var exactAlarmPromptShown = false
@@ -85,7 +86,8 @@ class MainActivity : AppCompatActivity() {
 
         // Store shortcut intent so JS can pick it up via getPendingAction()
         // after the WebView finishes loading.
-        val store = SharedDataStore(this)
+        dataStore = SharedDataStore(this)
+        val store = dataStore
         when (intent?.action) {
             ACTION_VOICE_INPUT    -> store.pendingVoiceInput = true
             ACTION_ADD_TASK       -> store.pendingAddTask = true
@@ -153,6 +155,12 @@ class MainActivity : AppCompatActivity() {
                 request: WebResourceRequest
             ) = assetLoader.shouldInterceptRequest(request.url)
 
+            override fun onPageFinished(view: WebView, url: String) {
+                super.onPageFinished(view, url)
+                // Re-apply status bar appearance after the WebView's first paint,
+                // which can reset the icon colour on Android 15 edge-to-edge mode.
+                applyStatusBarAppearance()
+            }
         }
         webView.webChromeClient = object : WebChromeClient() {
             override fun onPermissionRequest(request: PermissionRequest) {
@@ -298,12 +306,21 @@ class MainActivity : AppCompatActivity() {
      * wins over any resets by Android 15's edge-to-edge enforcement or the
      * WebView's first paint.
      *
+     * Prefers the app's own dark-mode preference (stored by NativeBridge when JS
+     * calls setStatusBarAppearance) over the system night-mode flag.  The app
+     * setting can differ from the system setting, and using the system flag
+     * causes white-on-white status bar icons when the device is in dark mode but
+     * the app is in light mode.  Falls back to the system flag on first launch
+     * before JS has had a chance to write the preference.
+     *
      * Uses the direct WindowInsetsController API on API 30+ (more reliable on
      * API 35 than the compat wrapper), with the compat path as fallback.
      */
     private fun applyStatusBarAppearance() {
-        val isNightMode = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+        val systemNightMode = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
             Configuration.UI_MODE_NIGHT_YES
+        // Prefer the app's saved preference; fall back to system night mode on first launch.
+        val isNightMode = dataStore.appDarkMode ?: systemNightMode
         // Disable automatic contrast enforcement so our flag isn't overridden.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             window.isStatusBarContrastEnforced = false

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -315,6 +315,9 @@ class NativeBridge(
      */
     @JavascriptInterface
     fun setStatusBarAppearance(isDark: Boolean) {
+        // Persist so MainActivity.applyStatusBarAppearance() can use the app
+        // preference instead of the system night-mode on future onResume/onPageFinished calls.
+        dataStore.appDarkMode = isDark
         (context as? android.app.Activity)?.runOnUiThread {
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
                 (context as android.app.Activity).window.isStatusBarContrastEnforced = false

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
@@ -42,6 +42,22 @@ class SharedDataStore(context: Context) {
             ?: DEFAULT_DAILY_NOTE_PATTERN
         set(value) = prefs.edit { putString(KEY_DAILY_NOTE_PATTERN, value) }
 
+    // ── App appearance preference ───────────────────────────────────────────
+
+    /**
+     * The app's own dark-mode flag, independent of the Android system night-mode
+     * setting. Written by NativeBridge.setStatusBarAppearance() whenever JS
+     * updates the dark-mode state. Null until the first time JS writes it.
+     *
+     * Used by MainActivity.applyStatusBarAppearance() to restore the correct
+     * status-bar icon colour on cold starts and after WebView first-paint resets.
+     */
+    var appDarkMode: Boolean?
+        get() = if (prefs.contains(KEY_APP_DARK_MODE)) prefs.getBoolean(KEY_APP_DARK_MODE, false) else null
+        set(value) = prefs.edit {
+            if (value != null) putBoolean(KEY_APP_DARK_MODE, value) else remove(KEY_APP_DARK_MODE)
+        }
+
     // ── Widget snapshot ─────────────────────────────────────────────────────
 
     /** JSON snapshot of today's agenda written by the app for the widget to read. */
@@ -151,6 +167,7 @@ class SharedDataStore(context: Context) {
         private const val KEY_PENDING_ADD_TASK = "pending_add_task"
         private const val KEY_PENDING_ADD_INBOX_TASK = "pending_add_inbox_task"
         private const val KEY_PENDING_SHARE = "pending_share_text"
+        private const val KEY_APP_DARK_MODE = "app_dark_mode"
 
         const val DEFAULT_DAILY_NOTE_PATTERN = "yyyy-MM-dd"
     }

--- a/src/components/ShortcutHelpModal.jsx
+++ b/src/components/ShortcutHelpModal.jsx
@@ -11,7 +11,7 @@ const ShortcutHelpModal = () => {
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setShowShortcutHelp(false)}>
       <div
-        className={`${cardBg} rounded-lg shadow-xl p-6 ${borderClass} border max-w-lg w-full mx-4`}
+        className={`${cardBg} rounded-lg shadow-xl p-6 ${borderClass} border max-w-lg w-full mx-4 overflow-y-auto max-h-[85vh]`}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-4">
@@ -20,7 +20,7 @@ const ShortcutHelpModal = () => {
             <X size={20} />
           </button>
         </div>
-        <div className="grid grid-cols-2 gap-x-8 gap-y-0.5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-0.5">
           <div>
             <h3 className={`text-xs font-semibold uppercase ${textSecondary} mb-2`}>Navigation</h3>
             {[


### PR DESCRIPTION
## Summary

### Bug #1 — Status bar icons invisible on Pixel (and any device where system ≠ app dark mode)

`applyStatusBarAppearance()` in `MainActivity` was reading the Android **system** night-mode flag to decide whether to show light or dark status bar icons. This is wrong when the app's own dark-mode preference diverges from the system setting — the common case being a device in system dark mode with the app in light mode, which put white icons on a white background.

Three-part fix:
- **`SharedDataStore`** — new `appDarkMode: Boolean?` property persists the app's preference across process boundaries
- **`NativeBridge.setStatusBarAppearance()`** — saves `isDark` to `SharedDataStore` every time JS updates the dark-mode state, so future native calls have the right value without waiting for JS
- **`MainActivity.applyStatusBarAppearance()`** — prefers `dataStore.appDarkMode` over the system night-mode flag; falls back to system only on first launch before JS has written the preference
- **`MainActivity` WebViewClient** — adds the missing `onPageFinished` override that the comment claimed was already there. Android 15 edge-to-edge enforcement can reset status bar icon colours after the WebView's first paint; `onPageFinished` re-applies the correct value before the user sees the screen

### Bug #2 — Keyboard shortcut modal too large on phones

The modal used a fixed 2-column grid with no mobile breakpoint and no scroll constraint. Fixed:
- `grid-cols-1 sm:grid-cols-2` — single column below the `sm` (640px) breakpoint
- `overflow-y-auto max-h-[85vh]` — scrollable and capped at 85% viewport height on all screen sizes

## Test plan

- [ ] On a Pixel (or any device where system dark mode ≠ app dark mode): cold-launch the app in light mode and confirm status bar icons are dark and visible without needing to toggle dark mode
- [ ] Toggle dark mode on/off and confirm icons track correctly
- [ ] Open the keyboard shortcuts modal on a phone — confirm it fits on screen, is single-column, and scrolls if needed

https://claude.ai/code/session_0187CrhH5Rqy6HAvAQ64BS4d