### PR TITLE
Fix unschedule project task: clear date/startTime and reset lastModified

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2372,10 +2372,14 @@ const DayPlanner = () => {
       // Keep/make this an unscheduled project task
       const inScheduled = tasks.find(t => t.id === taskId);
       if (inScheduled) {
-        // Move from scheduled → unscheduled project task
+        // Move from scheduled → unscheduled project task.
+        // Clear schedule fields and drop lastModified so stampTaskTimestamps
+        // re-stamps it as "just changed", preventing cloud sync from reverting
+        // the move when the remote still has the task in the scheduled list.
+        const { date: _d, startTime: _s, isAllDay: _a, lastModified: _m, ...rest } = inScheduled;
         setTasks(prev => prev.filter(t => t.id !== taskId));
         setUnscheduledTasks(prev => [...prev, {
-          ...inScheduled,
+          ...rest,
           title: cleanTitle(newTask.title),
           duration: newTask.duration,
           color: newTask.color || colors[0].class,


### PR DESCRIPTION
When saving a task with "Unscheduled" checked, the code spread ...inScheduled which still carried date, startTime, isAllDay, and lastModified from the scheduled version. The stale lastModified caused cloud sync to revert the move: both the local (unscheduledTasks) and remote (tasks) versions had equal timestamps, so the merge's >= tie-break kept the scheduled (remote) copy, making the task immediately reappear on the timeline after being unscheduled.

Fix: destructure out date, startTime, isAllDay, and lastModified before spreading inScheduled. Dropping lastModified causes stampTaskTimestamps to treat the task as newly changed and stamp it with the current time, ensuring the next cloud sync merge correctly keeps the unscheduled version.

https://claude.ai/code/session_0187CrhH5Rqy6HAvAQ64BS4d