### PR TITLE
Fix mobile color picker wrapping to second line

### DIFF
--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -155,13 +155,13 @@ const MobileNewTaskModal = () => {
               {/* Color row */}
               <div>
                 <label className={`block text-sm ${textSecondary} mb-2`}>Color</label>
-                <div className="flex gap-2 flex-wrap">
+                <div className="grid grid-cols-9 gap-2">
                   {colors.map((color) => (
                     <button
                       type="button"
                       key={color.class}
                       onClick={() => setNewTask({ ...newTask, color: color.class })}
-                      className={`${color.class} w-8 h-8 rounded-full transition-transform ${(newTask.color || colors[0].class) === color.class ? 'ring-2 ring-offset-2 ring-blue-500 scale-110' : ''}`}
+                      className={`${color.class} w-full aspect-square rounded-full transition-transform ${(newTask.color || colors[0].class) === color.class ? 'ring-2 ring-offset-2 ring-blue-500 scale-110' : ''}`}
                       title={color.name}
                     />
                   ))}


### PR DESCRIPTION
9 color swatches in a flex row with gap-2 and w-8 exceed the modal width on narrow phones, causing the last color (yellow) to wrap. Switch to grid-cols-9 with aspect-square so all swatches stay on one row and scale proportionally to the available width.

https://claude.ai/code/session_0187CrhH5Rqy6HAvAQ64BS4d