### PR TITLE
Add goals/projects stats to daily summary, all-time stats, and weekly…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback } from 'react';
-import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Moon, Sun, Upload, Inbox, AlertCircle, Calendar, Check, RefreshCw, Palette, Trash2, Undo2, BarChart3, SkipForward, Hash, MoreHorizontal, Save, Menu, BrainCircuit, AlertTriangle, FileText, ExternalLink, CheckSquare, HelpCircle, Sparkles, Link, GripHorizontal, Play, Pause, Trophy, Cloud, Settings, Search, Bell, Target, TrendingUp, Zap, CalendarDays, Ban, Volume2, VolumeX, Pencil, Eye, Filter, Smartphone, CheckCircle, Pin, PinOff, NotebookPen, MapPin, BookOpen, FolderOpen, Droplets, Footprints, Dumbbell, Apple, Cigarette, Coffee, Flame, Heart, ListChecks, Minus, Wine, Candy, Pill, Activity, CupSoda, Mic, MicOff, Loader, Key, Server, Wifi, WifiOff, LayoutGrid, RotateCcw } from 'lucide-react';
+import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Moon, Sun, Upload, Inbox, AlertCircle, Calendar, Check, RefreshCw, Palette, Trash2, Undo2, BarChart3, SkipForward, Hash, MoreHorizontal, Save, Menu, BrainCircuit, AlertTriangle, FileText, ExternalLink, CheckSquare, HelpCircle, Sparkles, Link, GripHorizontal, Play, Pause, Trophy, Cloud, Settings, Search, Bell, Target, TrendingUp, Zap, CalendarDays, Ban, Volume2, VolumeX, Pencil, Eye, Filter, Smartphone, CheckCircle, Pin, PinOff, NotebookPen, MapPin, BookOpen, Flag, FolderOpen, Droplets, Footprints, Dumbbell, Apple, Cigarette, Coffee, Flame, Heart, ListChecks, Minus, Wine, Candy, Pill, Activity, CupSoda, Mic, MicOff, Loader, Key, Server, Wifi, WifiOff, LayoutGrid, RotateCcw } from 'lucide-react';
 import { mergeTaskArrays, mergeSyncData } from './mergeSync.js';
 import { isNativeAndroid, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording } from './native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
@@ -274,6 +274,8 @@ const DayPlanner = () => {
   const [viewedMonth, setViewedMonth] = useState(() => new Date());
   const [mobileReviewPage, setMobileReviewPage] = useState(0);
   const [showMobileDailySummary, setShowMobileDailySummary] = useState(false);
+  const [desktopStatsHabitsCollapsed, setDesktopStatsHabitsCollapsed] = useState(true);
+  const [desktopStatsAllTimeCollapsed, setDesktopStatsAllTimeCollapsed] = useState(true);
   const reviewScrollRef = useRef(null);
   const [syncNotification, setSyncNotification] = useState(null); // { type: 'success' | 'error' | 'info', message: string }
   const [isSyncing, setIsSyncing] = useState(false);
@@ -643,13 +645,25 @@ const DayPlanner = () => {
     actualTodayPlannedMinutes,
     actualTodayFocusMinutes,
     allTimeFocusMinutes,
+    allTimeProjectFocusMinutes,
     inboxCompletedTodayCount,
     inboxCompletedTodayMinutes,
     allTimeInboxCompletedCount,
     allTimeInboxCompletedMinutes,
+    projectTasksCompletedTodayCount,
+    projectTasksCompletedTodayMinutes,
+    allTimeUnscheduledProjectDoneCount,
+    allTimeUnscheduledProjectDoneMinutes,
+    allTimeGoalsCreated,
+    allTimeGoalsCompleted,
+    allTimeProjectsCreated,
+    allTimeProjectsCompleted,
+    todayCompletedGoals,
+    todayCompletedProjects,
+    consecutiveDayStreak,
     todayIncompleteTasks,
     allTimeIncompleteTasks,
-  } = useStats({ tasks, unscheduledTasks, recurringTasks });
+  } = useStats({ tasks, unscheduledTasks, recurringTasks, goals, projects });
 
   const {
     todayTasks,
@@ -6558,9 +6572,15 @@ const DayPlanner = () => {
     totalCompletedMinutes, totalScheduledMinutes,
     actualTodayNonImportedTasks, actualTodayCompletedTasks,
     actualTodayCompletedMinutes, actualTodayPlannedMinutes, actualTodayFocusMinutes,
-    allTimeFocusMinutes,
+    allTimeFocusMinutes, allTimeProjectFocusMinutes,
     inboxCompletedTodayCount, inboxCompletedTodayMinutes,
     allTimeInboxCompletedCount, allTimeInboxCompletedMinutes,
+    projectTasksCompletedTodayCount, projectTasksCompletedTodayMinutes,
+    allTimeUnscheduledProjectDoneCount, allTimeUnscheduledProjectDoneMinutes,
+    allTimeGoalsCreated, allTimeGoalsCompleted,
+    allTimeProjectsCreated, allTimeProjectsCompleted,
+    todayCompletedGoals, todayCompletedProjects,
+    consecutiveDayStreak,
     todayIncompleteTasks, allTimeIncompleteTasks,
 
     // ── Functions – audio / UI ────────────────────────────────────────────────
@@ -7374,8 +7394,33 @@ const DayPlanner = () => {
                         {inboxCompletedTodayCount > 0 && (
                           <div className={`text-sm ${textSecondary}`}>+ {inboxCompletedTodayCount} inbox {inboxCompletedTodayCount === 1 ? 'task' : 'tasks'} done</div>
                         )}
+                        {goalsProjectsEnabled && projectTasksCompletedTodayCount > 0 && (
+                          <div className={`text-sm ${textSecondary}`}>+ {projectTasksCompletedTodayCount} project {projectTasksCompletedTodayCount === 1 ? 'task' : 'tasks'} done</div>
+                        )}
+                        {consecutiveDayStreak > 1 && (
+                          <div className="flex items-center gap-1 text-sm text-orange-500 font-medium mt-0.5">
+                            <Flame size={13} />
+                            {consecutiveDayStreak} day streak
+                          </div>
+                        )}
                       </div>
                     </div>
+                    {goalsProjectsEnabled && (todayCompletedGoals.length > 0 || todayCompletedProjects.length > 0) && (
+                      <div className="space-y-1.5 mb-3">
+                        {todayCompletedGoals.map(g => (
+                          <div key={g.id} className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium ${darkMode ? 'bg-amber-900/30 text-amber-300' : 'bg-amber-50 text-amber-700'}`}>
+                            <Flag size={14} className="flex-shrink-0" />
+                            <span className="truncate">Goal complete: {g.title}</span>
+                          </div>
+                        ))}
+                        {todayCompletedProjects.map(p => (
+                          <div key={p.id} className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium ${darkMode ? 'bg-green-900/30 text-green-300' : 'bg-green-50 text-green-700'}`}>
+                            <FolderOpen size={14} className="flex-shrink-0" />
+                            <span className="truncate">Project complete: {p.title}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
                     <div className={`space-y-3 ${textSecondary}`}>
                       <div className="flex items-center justify-between text-sm">
                         <div className="flex items-center gap-2"><Clock size={14} className="text-orange-400" /> Time spent</div>
@@ -7396,14 +7441,21 @@ const DayPlanner = () => {
                 );
               })()}
 
-              {/* Habit Streaks */}
+              {/* Habit Streaks — collapsible, default collapsed */}
               {habitsEnabled && activeHabits.length > 0 && (
                 <div className={`mt-4 pt-4 border-t ${borderClass}`}>
-                  <div className="flex items-center gap-2 mb-3">
-                    <Flame size={18} className="text-orange-500" />
-                    <span className={`font-semibold ${textPrimary}`}>Habit Streaks</span>
-                  </div>
-                  <div className="space-y-2">
+                  <button
+                    className="flex items-center justify-between w-full mb-0"
+                    onClick={() => setDesktopStatsHabitsCollapsed(c => !c)}
+                  >
+                    <div className="flex items-center gap-2">
+                      <Flame size={18} className="text-orange-500" />
+                      <span className={`font-semibold ${textPrimary}`}>Habit Streaks</span>
+                    </div>
+                    {desktopStatsHabitsCollapsed ? <ChevronDown size={16} className={textSecondary} /> : <ChevronUp size={16} className={textSecondary} />}
+                  </button>
+                  {!desktopStatsHabitsCollapsed && (
+                  <div className="space-y-2 mt-3">
                     {(() => {
                       const overflow = activeHabits.length > 5;
                       const visible = overflow ? activeHabits.slice(0, 5) : activeHabits;
@@ -7439,16 +7491,36 @@ const DayPlanner = () => {
                       );
                     })()}
                   </div>
+                  )}
                 </div>
               )}
 
-              {/* All-Time Summary */}
+              {/* All-Time Summary — collapsible, default collapsed */}
               <div className={`mt-4 pt-4 border-t ${borderClass}`}>
-                <div className="flex items-center gap-2 mb-3">
-                  <TrendingUp size={18} className={textSecondary} />
-                  <span className={`font-semibold ${textPrimary}`}>All-Time Summary</span>
-                </div>
-                <div className={`space-y-2 text-sm ${textSecondary}`}>
+                <button
+                  className="flex items-center justify-between w-full mb-0"
+                  onClick={() => setDesktopStatsAllTimeCollapsed(c => !c)}
+                >
+                  <div className="flex items-center gap-2">
+                    <TrendingUp size={18} className={textSecondary} />
+                    <span className={`font-semibold ${textPrimary}`}>All-Time Summary</span>
+                  </div>
+                  {desktopStatsAllTimeCollapsed ? <ChevronDown size={16} className={textSecondary} /> : <ChevronUp size={16} className={textSecondary} />}
+                </button>
+                {!desktopStatsAllTimeCollapsed && (
+                <div className={`space-y-2 text-sm ${textSecondary} mt-3`}>
+                  {goalsProjectsEnabled && allTimeGoalsCreated > 0 && (
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2"><Flag size={14} className="text-amber-400" /> Goals</div>
+                      <span className={`font-medium ${textPrimary}`}>{allTimeGoalsCompleted}/{allTimeGoalsCreated} completed</span>
+                    </div>
+                  )}
+                  {goalsProjectsEnabled && allTimeProjectsCreated > 0 && (
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2"><FolderOpen size={14} className="text-blue-400" /> Projects</div>
+                      <span className={`font-medium ${textPrimary}`}>{allTimeProjectsCompleted}/{allTimeProjectsCreated} completed</span>
+                    </div>
+                  )}
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2"><CalendarDays size={14} className="text-blue-400" /> Tasks scheduled</div>
                     <span className={`font-medium ${textPrimary}`}>{allTimeScheduledCount}</span>
@@ -7473,19 +7545,33 @@ const DayPlanner = () => {
                       <span className={`font-medium ${textPrimary}`}>{allTimeInboxCompletedCount}</span>
                     </div>
                   )}
+                  {goalsProjectsEnabled && allTimeUnscheduledProjectDoneCount > 0 && (
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2"><FolderOpen size={14} className="text-green-400" /> Unscheduled done</div>
+                      <span className={`font-medium ${textPrimary}`}>{allTimeUnscheduledProjectDoneCount}</span>
+                    </div>
+                  )}
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2"><Clock size={14} className="text-orange-400" /> Time spent</div>
-                    <span className={`font-medium ${textPrimary}`}>{Math.floor((totalCompletedMinutes + allTimeInboxCompletedMinutes) / 60)}h {(totalCompletedMinutes + allTimeInboxCompletedMinutes) % 60}m</span>
+                    <span className={`font-medium ${textPrimary}`}>{Math.floor((totalCompletedMinutes + allTimeInboxCompletedMinutes + allTimeUnscheduledProjectDoneMinutes) / 60)}h {(totalCompletedMinutes + allTimeInboxCompletedMinutes + allTimeUnscheduledProjectDoneMinutes) % 60}m</span>
                   </div>
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2"><Clock size={14} className="text-blue-400" /> Time planned</div>
                     <span className={`font-medium ${textPrimary}`}>{Math.floor(totalScheduledMinutes / 60)}h {totalScheduledMinutes % 60}m</span>
                   </div>
                   {allTimeFocusMinutes > 0 && (
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2"><Target size={14} className="text-purple-400" /> Focus time</div>
-                      <span className={`font-medium ${textPrimary}`}>{Math.floor(allTimeFocusMinutes / 60)}h {Math.round(allTimeFocusMinutes % 60)}m</span>
-                    </div>
+                    <>
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2"><Target size={14} className="text-purple-400" /> Focus time</div>
+                        <span className={`font-medium ${textPrimary}`}>{Math.floor(allTimeFocusMinutes / 60)}h {Math.round(allTimeFocusMinutes % 60)}m</span>
+                      </div>
+                      {goalsProjectsEnabled && allTimeProjectFocusMinutes > 0 && (
+                        <div className="flex items-center justify-between pl-5">
+                          <div className="flex items-center gap-2"><FolderOpen size={12} className="text-purple-300" /> From projects</div>
+                          <span className={`text-xs font-medium ${textSecondary}`}>{Math.floor(allTimeProjectFocusMinutes / 60)}h {Math.round(allTimeProjectFocusMinutes % 60)}m</span>
+                        </div>
+                      )}
+                    </>
                   )}
                   {allTimeScheduledCount > 0 && (
                     <div className="flex items-center justify-between pt-1">
@@ -7494,6 +7580,7 @@ const DayPlanner = () => {
                     </div>
                   )}
                 </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -331,9 +331,15 @@ const MobileLayout = () => {
     totalCompletedMinutes, totalScheduledMinutes,
     actualTodayNonImportedTasks, actualTodayCompletedTasks,
     actualTodayCompletedMinutes, actualTodayPlannedMinutes, actualTodayFocusMinutes,
-    allTimeFocusMinutes,
+    allTimeFocusMinutes, allTimeProjectFocusMinutes,
     inboxCompletedTodayCount, inboxCompletedTodayMinutes,
     allTimeInboxCompletedCount, allTimeInboxCompletedMinutes,
+    projectTasksCompletedTodayCount, projectTasksCompletedTodayMinutes,
+    allTimeUnscheduledProjectDoneCount, allTimeUnscheduledProjectDoneMinutes,
+    allTimeGoalsCreated, allTimeGoalsCompleted,
+    allTimeProjectsCreated, allTimeProjectsCompleted,
+    todayCompletedGoals, todayCompletedProjects,
+    consecutiveDayStreak,
     todayIncompleteTasks, allTimeIncompleteTasks,
     playUISound, playFocusSound,
     formatTime,
@@ -428,6 +434,8 @@ const MobileLayout = () => {
 
   const [addGoalTrigger, setAddGoalTrigger] = useState(0);
   const [addProjectTrigger, setAddProjectTrigger] = useState(0);
+  const [dailyStatsHabitsCollapsed, setDailyStatsHabitsCollapsed] = useState(true);
+  const [dailyStatsAllTimeCollapsed, setDailyStatsAllTimeCollapsed] = useState(true);
 
   return (
         <>
@@ -3338,8 +3346,34 @@ const MobileLayout = () => {
                           {inboxCompletedTodayCount > 0 && (
                             <div className={`text-sm ${textSecondary}`}>+ {inboxCompletedTodayCount} inbox {inboxCompletedTodayCount === 1 ? 'task' : 'tasks'} done</div>
                           )}
+                          {goalsProjectsEnabled && projectTasksCompletedTodayCount > 0 && (
+                            <div className={`text-sm ${textSecondary}`}>+ {projectTasksCompletedTodayCount} project {projectTasksCompletedTodayCount === 1 ? 'task' : 'tasks'} done</div>
+                          )}
+                          {consecutiveDayStreak > 1 && (
+                            <div className="flex items-center gap-1 text-sm text-orange-500 font-medium mt-0.5">
+                              <Flame size={13} />
+                              {consecutiveDayStreak} day streak
+                            </div>
+                          )}
                         </div>
                       </div>
+                      {/* Goal / Project completion callouts */}
+                      {goalsProjectsEnabled && (todayCompletedGoals.length > 0 || todayCompletedProjects.length > 0) && (
+                        <div className="space-y-1.5 mb-3">
+                          {todayCompletedGoals.map(g => (
+                            <div key={g.id} className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium ${darkMode ? 'bg-amber-900/30 text-amber-300' : 'bg-amber-50 text-amber-700'}`}>
+                              <Flag size={14} className="flex-shrink-0" />
+                              <span className="truncate">Goal complete: {g.title}</span>
+                            </div>
+                          ))}
+                          {todayCompletedProjects.map(p => (
+                            <div key={p.id} className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium ${darkMode ? 'bg-green-900/30 text-green-300' : 'bg-green-50 text-green-700'}`}>
+                              <FolderOpen size={14} className="flex-shrink-0" />
+                              <span className="truncate">Project complete: {p.title}</span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
                       {/* Stat rows */}
                       <div className={`space-y-3 ${textSecondary}`}>
                         <div className="flex items-center justify-between text-sm">
@@ -3361,104 +3395,146 @@ const MobileLayout = () => {
                     );
                   })()}
 
-                  {/* Habit Streaks — always shown */}
+                  {/* Habit Streaks — collapsible, default collapsed */}
                   {habitsEnabled && activeHabits.length > 0 && (
                     <div className={`mt-4 pt-4 border-t ${borderClass}`}>
-                      <div className="flex items-center gap-2 mb-3">
-                        <Flame size={18} className="text-orange-500" />
-                        <span className={`font-semibold ${textPrimary}`}>Habit Streaks</span>
-                      </div>
-                      <div className="space-y-2">
-                        {(() => {
-                          const overflow = activeHabits.length > 5;
-                          const visible = overflow ? activeHabits.slice(0, 5) : activeHabits;
-                          const remaining = activeHabits.length - 5;
-                          return (
-                            <>
-                              {visible.map(habit => {
-                                const s = habitStreaks[habit.id] || { current: 0, best: 0 };
-                                const IconComp = HABIT_ICONS[habit.icon] || Target;
-                                const colorObj = HABIT_COLORS.find(c => c.name === habit.color) || HABIT_COLORS[0];
-                                return (
-                                  <div key={habit.id} className="flex items-center gap-2">
-                                    <IconComp size={16} style={{ color: colorObj.ring }} className="flex-shrink-0" />
-                                    <span className={`text-sm flex-1 min-w-0 truncate ${textPrimary}`}>{habit.name}</span>
-                                    <div className="flex items-center gap-3 flex-shrink-0">
-                                      <span className={`text-sm font-semibold ${s.current > 0 ? 'text-orange-500' : textSecondary}`}>
-                                        {s.current}d
-                                      </span>
-                                      <span className={`text-xs ${textSecondary}`}>
-                                        best {s.best}d
-                                      </span>
+                      <button
+                        className="flex items-center justify-between w-full mb-0"
+                        onClick={() => setDailyStatsHabitsCollapsed(c => !c)}
+                      >
+                        <div className="flex items-center gap-2">
+                          <Flame size={18} className="text-orange-500" />
+                          <span className={`font-semibold ${textPrimary}`}>Habit Streaks</span>
+                        </div>
+                        {dailyStatsHabitsCollapsed ? <ChevronDown size={16} className={textSecondary} /> : <ChevronUp size={16} className={textSecondary} />}
+                      </button>
+                      {!dailyStatsHabitsCollapsed && (
+                        <div className="space-y-2 mt-3">
+                          {(() => {
+                            const overflow = activeHabits.length > 5;
+                            const visible = overflow ? activeHabits.slice(0, 5) : activeHabits;
+                            const remaining = activeHabits.length - 5;
+                            return (
+                              <>
+                                {visible.map(habit => {
+                                  const s = habitStreaks[habit.id] || { current: 0, best: 0 };
+                                  const IconComp = HABIT_ICONS[habit.icon] || Target;
+                                  const colorObj = HABIT_COLORS.find(c => c.name === habit.color) || HABIT_COLORS[0];
+                                  return (
+                                    <div key={habit.id} className="flex items-center gap-2">
+                                      <IconComp size={16} style={{ color: colorObj.ring }} className="flex-shrink-0" />
+                                      <span className={`text-sm flex-1 min-w-0 truncate ${textPrimary}`}>{habit.name}</span>
+                                      <div className="flex items-center gap-3 flex-shrink-0">
+                                        <span className={`text-sm font-semibold ${s.current > 0 ? 'text-orange-500' : textSecondary}`}>
+                                          {s.current}d
+                                        </span>
+                                        <span className={`text-xs ${textSecondary}`}>
+                                          best {s.best}d
+                                        </span>
+                                      </div>
                                     </div>
+                                  );
+                                })}
+                                {overflow && (
+                                  <div className={`flex items-center gap-2 text-sm ${textSecondary}`}>
+                                    <MoreHorizontal size={16} className="flex-shrink-0" />
+                                    <span>+{remaining} more habits</span>
                                   </div>
-                                );
-                              })}
-                              {overflow && (
-                                <div className={`flex items-center gap-2 text-sm ${textSecondary}`}>
-                                  <MoreHorizontal size={16} className="flex-shrink-0" />
-                                  <span>+{remaining} more habits</span>
-                                </div>
-                              )}
-                            </>
-                          );
-                        })()}
-                      </div>
+                                )}
+                              </>
+                            );
+                          })()}
+                        </div>
+                      )}
                     </div>
                   )}
 
-                  {/* All-Time Summary — always shown */}
+                  {/* All-Time Summary — collapsible, default collapsed */}
                   <div className={`mt-4 pt-4 border-t ${borderClass}`}>
-                    <div className="flex items-center gap-2 mb-3">
-                      <TrendingUp size={18} className={textSecondary} />
-                      <span className={`font-semibold ${textPrimary}`}>All-Time Summary</span>
-                    </div>
-                    <div className={`space-y-2 text-sm ${textSecondary}`}>
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2"><CalendarDays size={14} className="text-blue-400" /> Tasks scheduled</div>
-                        <span className={`font-medium ${textPrimary}`}>{allTimeScheduledCount}</span>
+                    <button
+                      className="flex items-center justify-between w-full mb-0"
+                      onClick={() => setDailyStatsAllTimeCollapsed(c => !c)}
+                    >
+                      <div className="flex items-center gap-2">
+                        <TrendingUp size={18} className={textSecondary} />
+                        <span className={`font-semibold ${textPrimary}`}>All-Time Summary</span>
                       </div>
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2"><CheckCircle size={14} className="text-green-400" /> Tasks completed</div>
-                        <span className={`font-medium ${textPrimary}`}>
-                          {allTimeCompletedCount}
-                          {allTimeIncompleteTasks.length > 0 && (
-                            <button
-                              onClick={() => { setShowIncompleteTasks('allTime'); setShowMobileDailySummary(false); }}
-                              className="ml-1 text-blue-500 active:text-blue-400"
-                            >
-                              ({allTimeIncompleteTasks.length} incomplete)
-                            </button>
-                          )}
-                        </span>
-                      </div>
-                      {allTimeInboxCompletedCount > 0 && (
+                      {dailyStatsAllTimeCollapsed ? <ChevronDown size={16} className={textSecondary} /> : <ChevronUp size={16} className={textSecondary} />}
+                    </button>
+                    {!dailyStatsAllTimeCollapsed && (
+                      <div className={`space-y-2 text-sm ${textSecondary} mt-3`}>
+                        {goalsProjectsEnabled && allTimeGoalsCreated > 0 && (
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-2"><Flag size={14} className="text-amber-400" /> Goals</div>
+                            <span className={`font-medium ${textPrimary}`}>{allTimeGoalsCompleted}/{allTimeGoalsCreated} completed</span>
+                          </div>
+                        )}
+                        {goalsProjectsEnabled && allTimeProjectsCreated > 0 && (
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-2"><FolderOpen size={14} className="text-blue-400" /> Projects</div>
+                            <span className={`font-medium ${textPrimary}`}>{allTimeProjectsCompleted}/{allTimeProjectsCreated} completed</span>
+                          </div>
+                        )}
                         <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-2"><Inbox size={14} className="text-amber-400" /> Inbox done</div>
-                          <span className={`font-medium ${textPrimary}`}>{allTimeInboxCompletedCount}</span>
+                          <div className="flex items-center gap-2"><CalendarDays size={14} className="text-blue-400" /> Tasks scheduled</div>
+                          <span className={`font-medium ${textPrimary}`}>{allTimeScheduledCount}</span>
                         </div>
-                      )}
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2"><Clock size={14} className="text-orange-400" /> Time spent</div>
-                        <span className={`font-medium ${textPrimary}`}>{Math.floor((totalCompletedMinutes + allTimeInboxCompletedMinutes) / 60)}h {(totalCompletedMinutes + allTimeInboxCompletedMinutes) % 60}m</span>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2"><Clock size={14} className="text-blue-400" /> Time planned</div>
-                        <span className={`font-medium ${textPrimary}`}>{Math.floor(totalScheduledMinutes / 60)}h {totalScheduledMinutes % 60}m</span>
-                      </div>
-                      {allTimeFocusMinutes > 0 && (
                         <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-2"><Target size={14} className="text-purple-400" /> Focus time</div>
-                          <span className={`font-medium ${textPrimary}`}>{Math.floor(allTimeFocusMinutes / 60)}h {Math.round(allTimeFocusMinutes % 60)}m</span>
+                          <div className="flex items-center gap-2"><CheckCircle size={14} className="text-green-400" /> Tasks completed</div>
+                          <span className={`font-medium ${textPrimary}`}>
+                            {allTimeCompletedCount}
+                            {allTimeIncompleteTasks.length > 0 && (
+                              <button
+                                onClick={() => { setShowIncompleteTasks('allTime'); setShowMobileDailySummary(false); }}
+                                className="ml-1 text-blue-500 active:text-blue-400"
+                              >
+                                ({allTimeIncompleteTasks.length} incomplete)
+                              </button>
+                            )}
+                          </span>
                         </div>
-                      )}
-                      {allTimeScheduledCount > 0 && (
-                        <div className="flex items-center justify-between pt-1">
-                          <div className="flex items-center gap-2"><Trophy size={14} className="text-amber-400" /> <span className={`font-semibold ${textPrimary}`}>Completion rate</span></div>
-                          <span className={`font-semibold ${textPrimary}`}>{Math.round((allTimeCompletedCount / allTimeScheduledCount) * 100)}%</span>
+                        {allTimeInboxCompletedCount > 0 && (
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-2"><Inbox size={14} className="text-amber-400" /> Inbox done</div>
+                            <span className={`font-medium ${textPrimary}`}>{allTimeInboxCompletedCount}</span>
+                          </div>
+                        )}
+                        {goalsProjectsEnabled && allTimeUnscheduledProjectDoneCount > 0 && (
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-2"><FolderOpen size={14} className="text-green-400" /> Unscheduled done</div>
+                            <span className={`font-medium ${textPrimary}`}>{allTimeUnscheduledProjectDoneCount}</span>
+                          </div>
+                        )}
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-2"><Clock size={14} className="text-orange-400" /> Time spent</div>
+                          <span className={`font-medium ${textPrimary}`}>{Math.floor((totalCompletedMinutes + allTimeInboxCompletedMinutes + allTimeUnscheduledProjectDoneMinutes) / 60)}h {(totalCompletedMinutes + allTimeInboxCompletedMinutes + allTimeUnscheduledProjectDoneMinutes) % 60}m</span>
                         </div>
-                      )}
-                    </div>
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-2"><Clock size={14} className="text-blue-400" /> Time planned</div>
+                          <span className={`font-medium ${textPrimary}`}>{Math.floor(totalScheduledMinutes / 60)}h {totalScheduledMinutes % 60}m</span>
+                        </div>
+                        {allTimeFocusMinutes > 0 && (
+                          <>
+                            <div className="flex items-center justify-between">
+                              <div className="flex items-center gap-2"><Target size={14} className="text-purple-400" /> Focus time</div>
+                              <span className={`font-medium ${textPrimary}`}>{Math.floor(allTimeFocusMinutes / 60)}h {Math.round(allTimeFocusMinutes % 60)}m</span>
+                            </div>
+                            {goalsProjectsEnabled && allTimeProjectFocusMinutes > 0 && (
+                              <div className="flex items-center justify-between pl-5">
+                                <div className="flex items-center gap-2"><FolderOpen size={12} className="text-purple-300" /> From projects</div>
+                                <span className={`text-xs font-medium ${textSecondary}`}>{Math.floor(allTimeProjectFocusMinutes / 60)}h {Math.round(allTimeProjectFocusMinutes % 60)}m</span>
+                              </div>
+                            )}
+                          </>
+                        )}
+                        {allTimeScheduledCount > 0 && (
+                          <div className="flex items-center justify-between pt-1">
+                            <div className="flex items-center gap-2"><Trophy size={14} className="text-amber-400" /> <span className={`font-semibold ${textPrimary}`}>Completion rate</span></div>
+                            <span className={`font-semibold ${textPrimary}`}>{Math.round((allTimeCompletedCount / allTimeScheduledCount) * 100)}%</span>
+                          </div>
+                        )}
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { AlertCircle, BarChart3, CalendarDays, CheckSquare, ChevronLeft, ChevronRight, Clock, Loader, RefreshCw, Sparkles, Target, Trophy, X, Zap } from 'lucide-react';
+import React, { useState } from 'react';
+import { AlertCircle, BarChart3, CalendarDays, CheckSquare, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Clock, Flag, Flame, FolderOpen, Loader, RefreshCw, Sparkles, Target, TrendingUp, Trophy, X, Zap } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { dateToString, stripWikilinks } from '../utils/taskUtils.js';
 import { getOccurrencesInRange } from '../utils/recurrenceEngine.js';
@@ -27,6 +27,10 @@ const WeeklyReviewModal = () => {
     formatTime, timeToMinutes,
     aiConfig,
   } = useDayPlannerCtx();
+
+  // Local collapse state for past-week HABITS and FRAME UTILIZATION sections
+  const [habitsCollapsed, setHabitsCollapsed] = useState(true);
+  const [framesCollapsed, setFramesCollapsed] = useState(true);
 
   if (!showWeeklyReview) return null;
 
@@ -119,7 +123,8 @@ const WeeklyReviewModal = () => {
             return sum + getOccurrencesInRange(t, pastStartStr, pastEndStr)
               .filter(ds => !isFutureToday(ds, t.exceptions?.[ds]?.startTime || t.startTime)).length * (t.duration || 0);
           }, 0);
-        const pastFocusMinutes = pastRegularCompleted.filter(t => t.tags && t.tags.includes('focus')).reduce((sum, t) => sum + (t.duration || 0), 0);
+        const pastFocusMinutes = pastRegularCompleted.reduce((sum, t) => sum + (t.focusMinutes || 0), 0)
+          + unscheduledTasks.filter(t => t.completed && t.completedAt && t.completedAt >= pastStartStr && t.completedAt <= pastEndStr + 'T99').reduce((sum, t) => sum + (t.focusMinutes || 0), 0);
 
         // Best day
         const dayCompletions = {};
@@ -316,6 +321,34 @@ const WeeklyReviewModal = () => {
           };
         }).filter(Boolean).sort((a, b) => b.totalCapacityMin - a.totalCapacityMin);
 
+        // Goals & Projects completed this past week
+        const pastCompletedGoals = goalsProjectsEnabled
+          ? goals.filter(g => g.status === 'completed' && g.updatedAt && g.updatedAt >= pastStartStr && g.updatedAt <= pastEndStr + 'T99')
+          : [];
+        const pastCompletedProjects = goalsProjectsEnabled
+          ? projects.filter(p => p.status === 'completed' && p.updatedAt && p.updatedAt >= pastStartStr && p.updatedAt <= pastEndStr + 'T99')
+          : [];
+        const pastUnscheduledProjectDone = goalsProjectsEnabled
+          ? unscheduledTasks.filter(t => t.projectId && t.completed && t.completedAt && t.completedAt >= pastStartStr && t.completedAt <= pastEndStr + 'T99')
+          : [];
+
+        // Consecutive day streak (reuse same logic as useStats)
+        const weeklyStreak = (() => {
+          let streak = 0;
+          const d0 = new Date(today);
+          for (let i = 0; i < 365; i++) {
+            const d = new Date(d0);
+            d.setDate(d.getDate() - i);
+            const ds = dateToString(d);
+            const hadCompletion =
+              tasks.some(t => !t.imported && t.completed && t.date === ds) ||
+              recurringTasks.some(t => (t.completedDates || []).includes(ds)) ||
+              unscheduledTasks.some(t => t.completed && t.completedAt?.startsWith(ds));
+            if (hadCompletion) { streak++; } else { break; }
+          }
+          return streak;
+        })();
+
         // Goals & Projects stats for AI weekly summary
         const allTasksCombined = [...tasks, ...unscheduledTasks];
 
@@ -368,6 +401,50 @@ const WeeklyReviewModal = () => {
           .sort((a, b) => (a.date || '').localeCompare(b.date || '') || (a.startTime || '').localeCompare(b.startTime || ''))
           .slice(0, 5)
           .map(t => ({ title: t.title, date: t.date, time: t.startTime, isAllDay: t.isAllDay || false }));
+
+        // Goals due in next 7 days (only goals with targetDate in range)
+        const nextWeekDueGoals = goalsProjectsEnabled
+          ? goals.filter(g => g.status === 'active' && g.targetDate && g.targetDate >= nextStartStr && g.targetDate <= nextEndStr)
+              .map(g => {
+                const progress = calculateGoalProgress(g.id, projects, allTasksCombined);
+                const target = new Date(g.targetDate + 'T12:00:00');
+                const todayMidnight = new Date(todayStr + 'T00:00:00');
+                const daysLeft = Math.ceil((target - todayMidnight) / (1000 * 60 * 60 * 24));
+                const childProjects = projects.filter(p => p.goalId === g.id && p.status !== 'archived');
+                const totalTasks = allTasksCombined.filter(t => childProjects.some(p => p.id === t.projectId) && !t.archived).length;
+                const completedTasks = allTasksCombined.filter(t => childProjects.some(p => p.id === t.projectId) && !t.archived && t.completed).length;
+                return { id: g.id, title: g.title, progressPct: Math.round(progress * 100), daysLeft, totalTasks, completedTasks };
+              })
+          : [];
+
+        // Active projects — with momentum indicator
+        // Momentum: green = completion in last 7 days, amber = no completion 7-14 days, red = no activity 14+ days
+        const sevenDaysAgoStr = dateToString(new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000));
+        const fourteenDaysAgoStr = dateToString(new Date(today.getTime() - 14 * 24 * 60 * 60 * 1000));
+        const nextWeekProjects = goalsProjectsEnabled
+          ? projects.filter(p => p.status === 'active').map(p => {
+              const pTasks = allTasksCombined.filter(t => t.projectId === p.id && !t.archived);
+              const totalTasks = pTasks.length;
+              const completedTasks = pTasks.filter(t => t.completed).length;
+              const progressPct = totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0;
+              const lastCompletion = pTasks
+                .filter(t => t.completed && t.completedAt)
+                .map(t => t.completedAt.slice(0, 10))
+                .sort()
+                .pop() || null;
+              let momentum; // 'green' | 'amber' | 'red'
+              if (!lastCompletion) {
+                momentum = 'red';
+              } else if (lastCompletion >= sevenDaysAgoStr) {
+                momentum = 'green';
+              } else if (lastCompletion >= fourteenDaysAgoStr) {
+                momentum = 'amber';
+              } else {
+                momentum = 'red';
+              }
+              return { id: p.id, title: p.title, totalTasks, completedTasks, progressPct, momentum };
+            }).filter(p => p.totalTasks > 0)
+          : [];
 
         const weeklyAIStats = {
           dateRange: `${pastStartStr} to ${pastEndStr}`,
@@ -485,64 +562,99 @@ const WeeklyReviewModal = () => {
                         <StatCard value={formatMinutes(pastTimeSpent)} label="Time spent" icon={<Clock size={16} className="text-orange-400" />} />
                         <StatCard value={formatMinutes(pastFocusMinutes)} label="Focus time" icon={<Target size={16} className="text-purple-400" />} />
                       </div>
-                      <div className="grid grid-cols-2 gap-3 mb-4">
+                      <div className="grid grid-cols-2 gap-3 mb-3">
                         <StatCard value={`${pastRecurringCompleted}/${pastRecurringScheduled}`} label="Recurring" icon={<RefreshCw size={14} className="text-blue-400" />} />
                         {bestDayName && (
                           <StatCard value={bestDayName} label={`Best day (${bestDayCount})`} icon={<Trophy size={16} className="text-yellow-400" />} />
                         )}
                       </div>
+                      {goalsProjectsEnabled && (pastCompletedGoals.length > 0 || pastCompletedProjects.length > 0 || pastUnscheduledProjectDone.length > 0) && (
+                        <div className="grid grid-cols-2 gap-3 mb-3">
+                          {pastCompletedGoals.length > 0 && (
+                            <StatCard value={pastCompletedGoals.length} label={pastCompletedGoals.length === 1 ? 'Goal completed' : 'Goals completed'} icon={<Flag size={16} className="text-amber-400" />} />
+                          )}
+                          {pastCompletedProjects.length > 0 && (
+                            <StatCard value={pastCompletedProjects.length} label={pastCompletedProjects.length === 1 ? 'Project completed' : 'Projects completed'} icon={<FolderOpen size={16} className="text-blue-400" />} />
+                          )}
+                          {pastUnscheduledProjectDone.length > 0 && (
+                            <StatCard value={pastUnscheduledProjectDone.length} label="Project tasks done" icon={<TrendingUp size={16} className="text-green-400" />} />
+                          )}
+                        </div>
+                      )}
+                      {weeklyStreak >= 2 && (
+                        <div className={`flex items-center gap-2 rounded-lg px-3 py-2 mb-3 text-sm font-medium ${darkMode ? 'bg-orange-900/30 text-orange-300' : 'bg-orange-50 text-orange-700'}`}>
+                          <Flame size={15} className="flex-shrink-0" />
+                          {weeklyStreak} day streak — keep it going!
+                        </div>
+                      )}
                     </>
                   )}
 
-                  {/* Habits */}
+                  {/* Habits — collapsible, default collapsed */}
                   {habitsEnabled && habitStats.length > 0 && (
-                    <div className="mb-4">
-                      <div className={`text-xs font-semibold uppercase ${textSecondary} tracking-wider mb-2`}>Habits</div>
-                      <div className="space-y-2">
-                        {habitStats.map(h => (
-                          <div key={h.id} className="flex items-center gap-2">
-                            <span className={`text-xs ${textPrimary} w-20 truncate flex-shrink-0`}>{h.name}</span>
-                            <div className="flex gap-1 flex-1">
-                              {h.days.map((hit, i) => (
-                                <div
-                                  key={i}
-                                  className="w-4 h-4 rounded-full flex-shrink-0"
-                                  style={{ backgroundColor: hit ? h.hexColor : (darkMode ? '#374151' : '#e7e5e4') }}
-                                  title={new Date(pastWeekDates[i] + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
-                                />
-                              ))}
+                    <div className="mb-3">
+                      <button
+                        className={`flex items-center justify-between w-full py-1.5 text-xs font-semibold uppercase ${textSecondary} tracking-wider`}
+                        onClick={() => setHabitsCollapsed(c => !c)}
+                      >
+                        <span>Habits</span>
+                        {habitsCollapsed ? <ChevronDown size={14} /> : <ChevronUp size={14} />}
+                      </button>
+                      {!habitsCollapsed && (
+                        <div className="space-y-2 mt-1">
+                          {habitStats.map(h => (
+                            <div key={h.id} className="flex items-center gap-2">
+                              <span className={`text-xs ${textPrimary} w-20 truncate flex-shrink-0`}>{h.name}</span>
+                              <div className="flex gap-1 flex-1">
+                                {h.days.map((hit, i) => (
+                                  <div
+                                    key={i}
+                                    className="w-4 h-4 rounded-full flex-shrink-0"
+                                    style={{ backgroundColor: hit ? h.hexColor : (darkMode ? '#374151' : '#e7e5e4') }}
+                                    title={new Date(pastWeekDates[i] + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+                                  />
+                                ))}
+                              </div>
+                              <span className={`text-xs ${textSecondary} flex-shrink-0`}>{h.daysHit}/7</span>
                             </div>
-                            <span className={`text-xs ${textSecondary} flex-shrink-0`}>{h.daysHit}/7</span>
-                          </div>
-                        ))}
-                      </div>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   )}
 
-                  {/* Frame Utilization */}
+                  {/* Frame Utilization — collapsible, default collapsed */}
                   {frameStats.length > 0 && (
-                    <div className="mb-4">
-                      <div className={`text-xs font-semibold uppercase ${textSecondary} tracking-wider mb-2`}>Frame Utilization</div>
-                      <div className="space-y-2">
-                        {frameStats.map(f => {
-                          const pct = Math.min(f.utilizationPct, 100);
-                          const barColor = f.utilizationPct >= 70 ? '#22c55e' : f.utilizationPct >= 30 ? '#3b82f6' : (darkMode ? '#4b5563' : '#d6d3d1');
-                          return (
-                            <div key={f.frameId}>
-                              <div className="flex justify-between items-center mb-1">
-                                <span className={`text-xs ${textPrimary} truncate flex-1 mr-2`}>{f.label}</span>
-                                <span className={`text-xs ${textSecondary} flex-shrink-0`}>{f.utilizationPct}% &middot; {formatMinutes(f.scheduledMin)}</span>
+                    <div className="mb-3">
+                      <button
+                        className={`flex items-center justify-between w-full py-1.5 text-xs font-semibold uppercase ${textSecondary} tracking-wider`}
+                        onClick={() => setFramesCollapsed(c => !c)}
+                      >
+                        <span>Frame Utilization</span>
+                        {framesCollapsed ? <ChevronDown size={14} /> : <ChevronUp size={14} />}
+                      </button>
+                      {!framesCollapsed && (
+                        <div className="space-y-2 mt-1">
+                          {frameStats.map(f => {
+                            const pct = Math.min(f.utilizationPct, 100);
+                            const barColor = f.utilizationPct >= 70 ? '#22c55e' : f.utilizationPct >= 30 ? '#3b82f6' : (darkMode ? '#4b5563' : '#d6d3d1');
+                            return (
+                              <div key={f.frameId}>
+                                <div className="flex justify-between items-center mb-1">
+                                  <span className={`text-xs ${textPrimary} truncate flex-1 mr-2`}>{f.label}</span>
+                                  <span className={`text-xs ${textSecondary} flex-shrink-0`}>{f.utilizationPct}% &middot; {formatMinutes(f.scheduledMin)}</span>
+                                </div>
+                                <div className={`h-1.5 rounded-full w-full ${darkMode ? 'bg-gray-700' : 'bg-stone-200'}`}>
+                                  <div
+                                    className="h-full rounded-full transition-all"
+                                    style={{ width: `${pct}%`, backgroundColor: barColor }}
+                                  />
+                                </div>
                               </div>
-                              <div className={`h-1.5 rounded-full w-full ${darkMode ? 'bg-gray-700' : 'bg-stone-200'}`}>
-                                <div
-                                  className="h-full rounded-full transition-all"
-                                  style={{ width: `${pct}%`, backgroundColor: barColor }}
-                                />
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
+                            );
+                          })}
+                        </div>
+                      )}
                     </div>
                   )}
 
@@ -630,6 +742,70 @@ const WeeklyReviewModal = () => {
                       <StatCard value={formatMinutes(nextFrameAvailableMinutes)} label="Frame availability" icon={<CalendarDays size={16} className="text-green-400" />} />
                     )}
                   </div>
+
+                  {/* Goals due this week */}
+                  {goalsProjectsEnabled && nextWeekDueGoals.length > 0 && (
+                    <div className="mb-4">
+                      <div className={`text-xs font-semibold uppercase ${textSecondary} tracking-wider mb-2`}>Goals Due This Week</div>
+                      <div className="space-y-2">
+                        {nextWeekDueGoals.map(g => (
+                          <div key={g.id} className={`rounded-lg border p-3 ${darkMode ? 'border-gray-600 bg-gray-700/40' : 'border-stone-200 bg-stone-50'}`}>
+                            <div className="flex items-start justify-between gap-2 mb-2">
+                              <div className="flex items-center gap-1.5 min-w-0">
+                                <Flag size={13} className="text-amber-400 flex-shrink-0" />
+                                <span className={`text-sm font-medium ${textPrimary} truncate`}>{g.title}</span>
+                              </div>
+                              <span className={`text-xs flex-shrink-0 font-medium px-1.5 py-0.5 rounded ${g.progressPct >= 80 ? (darkMode ? 'bg-green-900/40 text-green-300' : 'bg-green-100 text-green-700') : (darkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-100 text-amber-700')}`}>
+                                {g.daysLeft === 0 ? 'Due today' : g.daysLeft === 1 ? 'Due tomorrow' : `${g.daysLeft}d left`}
+                              </span>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <div className={`flex-1 h-1.5 rounded-full ${darkMode ? 'bg-gray-600' : 'bg-stone-200'}`}>
+                                <div
+                                  className="h-full rounded-full"
+                                  style={{ width: `${g.progressPct}%`, backgroundColor: g.progressPct >= 80 ? '#22c55e' : g.progressPct >= 40 ? '#f59e0b' : '#ef4444' }}
+                                />
+                              </div>
+                              <span className={`text-xs ${textSecondary} flex-shrink-0`}>{g.progressPct}%</span>
+                              {g.totalTasks > 0 && (
+                                <span className={`text-xs ${textSecondary} flex-shrink-0`}>{g.completedTasks}/{g.totalTasks}</span>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Active projects */}
+                  {goalsProjectsEnabled && nextWeekProjects.length > 0 && (
+                    <div className="mb-4">
+                      <div className={`text-xs font-semibold uppercase ${textSecondary} tracking-wider mb-2`}>Active Projects</div>
+                      <div className="space-y-2">
+                        {nextWeekProjects.map(p => {
+                          const momentumColor = p.momentum === 'green' ? '#22c55e' : p.momentum === 'amber' ? '#f59e0b' : '#ef4444';
+                          const momentumLabel = p.momentum === 'green' ? 'Active' : p.momentum === 'amber' ? 'Slowing' : 'Stalled';
+                          return (
+                            <div key={p.id} className="flex items-center gap-2">
+                              <div
+                                className="w-2 h-2 rounded-full flex-shrink-0"
+                                style={{ backgroundColor: momentumColor }}
+                                title={momentumLabel}
+                              />
+                              <span className={`text-sm ${textPrimary} flex-1 min-w-0 truncate`}>{p.title}</span>
+                              <div className={`flex-shrink-0 w-16 h-1.5 rounded-full ${darkMode ? 'bg-gray-600' : 'bg-stone-200'}`}>
+                                <div
+                                  className="h-full rounded-full"
+                                  style={{ width: `${p.progressPct}%`, backgroundColor: momentumColor }}
+                                />
+                              </div>
+                              <span className={`text-xs ${textSecondary} flex-shrink-0 w-10 text-right`}>{p.completedTasks}/{p.totalTasks}</span>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
 
                   {/* Open days nudge */}
                   {openDays.length > 0 && (

--- a/src/hooks/useStats.js
+++ b/src/hooks/useStats.js
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
 import { getOccurrencesInRange } from '../utils/recurrenceEngine.js';
 
-export default function useStats({ tasks, unscheduledTasks, recurringTasks }) {
+export default function useStats({ tasks, unscheduledTasks, recurringTasks, goals = [], projects = [] }) {
   const todayStr = dateToString(new Date());
 
   // All-time stats helpers (exclude imported events, include recurring)
@@ -73,17 +73,70 @@ export default function useStats({ tasks, unscheduledTasks, recurringTasks }) {
   const actualTodayCompletedMinutes = actualTodayCompletedTasks.reduce((sum, task) => sum + (task.duration || 0), 0);
   const actualTodayPlannedMinutes = actualTodayNonImportedTasks.reduce((sum, task) => sum + (task.duration || 0), 0);
   const actualTodayFocusMinutes = actualTodayNonImportedTasks.reduce((sum, t) => sum + (t.focusMinutes || 0), 0);
-  const allTimeFocusMinutes = nonImportedTasks.reduce((sum, t) => sum + (t.focusMinutes || 0), 0)
-    + deadlineInboxTasks.reduce((sum, t) => sum + (t.focusMinutes || 0), 0);
 
-  // Inbox completion stats (tasks completed today from inbox, for "extra credit")
-  // Exclude deadline tasks — they count as scheduled since they appear on the timeline
-  const inboxCompletedToday = unscheduledTasks.filter(t => t.completed && !t.deadline && t.completedAt && t.completedAt.startsWith(todayStr));
+  // Project task focus (unscheduled tasks with a projectId)
+  const allTimeProjectFocusMinutes = useMemo(
+    () => unscheduledTasks.filter(t => t.projectId).reduce((sum, t) => sum + (t.focusMinutes || 0), 0),
+    [unscheduledTasks]
+  );
+
+  const allTimeFocusMinutes = nonImportedTasks.reduce((sum, t) => sum + (t.focusMinutes || 0), 0)
+    + deadlineInboxTasks.reduce((sum, t) => sum + (t.focusMinutes || 0), 0)
+    + allTimeProjectFocusMinutes;
+
+  // Inbox completion stats — pure inbox only (no projectId, no deadline)
+  const inboxCompletedToday = unscheduledTasks.filter(t => t.completed && !t.deadline && !t.projectId && t.completedAt && t.completedAt.startsWith(todayStr));
   const inboxCompletedTodayCount = inboxCompletedToday.length;
   const inboxCompletedTodayMinutes = inboxCompletedToday.reduce((sum, t) => sum + (t.duration || 0), 0);
-  const allTimeInboxCompleted = unscheduledTasks.filter(t => t.completed && !t.deadline);
+  const allTimeInboxCompleted = unscheduledTasks.filter(t => t.completed && !t.deadline && !t.projectId);
   const allTimeInboxCompletedCount = allTimeInboxCompleted.length;
   const allTimeInboxCompletedMinutes = allTimeInboxCompleted.reduce((sum, t) => sum + (t.duration || 0), 0);
+
+  // Project task completions today (unscheduled project tasks, won't count toward ring)
+  const projectTasksCompletedToday = unscheduledTasks.filter(t => t.projectId && t.completed && t.completedAt && t.completedAt.startsWith(todayStr));
+  const projectTasksCompletedTodayCount = projectTasksCompletedToday.length;
+  const projectTasksCompletedTodayMinutes = projectTasksCompletedToday.reduce((sum, t) => sum + (t.duration || 0), 0);
+
+  // All-time unscheduled project task completions
+  const allTimeUnscheduledProjectDone = useMemo(
+    () => unscheduledTasks.filter(t => t.completed && t.projectId),
+    [unscheduledTasks]
+  );
+  const allTimeUnscheduledProjectDoneCount = allTimeUnscheduledProjectDone.length;
+  const allTimeUnscheduledProjectDoneMinutes = allTimeUnscheduledProjectDone.reduce((sum, t) => sum + (t.duration || 0), 0);
+
+  // Goals & Projects all-time counts
+  const allTimeGoalsCreated = goals.filter(g => g.status !== 'archived').length;
+  const allTimeGoalsCompleted = goals.filter(g => g.status === 'completed').length;
+  const allTimeProjectsCreated = projects.filter(p => p.status !== 'archived').length;
+  const allTimeProjectsCompleted = projects.filter(p => p.status === 'completed').length;
+
+  // Goals & Projects completed today
+  const todayCompletedGoals = goals.filter(g => g.status === 'completed' && g.updatedAt?.startsWith(todayStr));
+  const todayCompletedProjects = projects.filter(p => p.status === 'completed' && p.updatedAt?.startsWith(todayStr));
+
+  // Consecutive day streak — count of consecutive days (going back from today)
+  // on which at least one task was completed
+  const consecutiveDayStreak = useMemo(() => {
+    let streak = 0;
+    const todayDate = new Date();
+    todayDate.setHours(0, 0, 0, 0);
+    for (let i = 0; i < 365; i++) {
+      const d = new Date(todayDate);
+      d.setDate(d.getDate() - i);
+      const dateStr = dateToString(d);
+      const hadCompletion =
+        tasks.some(t => !t.imported && t.completed && t.date === dateStr) ||
+        recurringTasks.some(t => (t.completedDates || []).includes(dateStr)) ||
+        unscheduledTasks.some(t => t.completed && t.completedAt?.startsWith(dateStr));
+      if (hadCompletion) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }, [tasks, recurringTasks, unscheduledTasks]);
 
   // Incomplete task lists for modal
   // Don't flag tasks as incomplete if they haven't ended yet (still in progress or upcoming)
@@ -143,10 +196,22 @@ export default function useStats({ tasks, unscheduledTasks, recurringTasks }) {
     actualTodayPlannedMinutes,
     actualTodayFocusMinutes,
     allTimeFocusMinutes,
+    allTimeProjectFocusMinutes,
     inboxCompletedTodayCount,
     inboxCompletedTodayMinutes,
     allTimeInboxCompletedCount,
     allTimeInboxCompletedMinutes,
+    projectTasksCompletedTodayCount,
+    projectTasksCompletedTodayMinutes,
+    allTimeUnscheduledProjectDoneCount,
+    allTimeUnscheduledProjectDoneMinutes,
+    allTimeGoalsCreated,
+    allTimeGoalsCompleted,
+    allTimeProjectsCreated,
+    allTimeProjectsCompleted,
+    todayCompletedGoals,
+    todayCompletedProjects,
+    consecutiveDayStreak,
     todayIncompleteTasks,
     allTimeIncompleteTasks,
   };


### PR DESCRIPTION
… review

- useStats: add todayCompletedGoals/Projects, projectTasksCompletedToday, consecutiveDayStreak, allTime goals/projects counts, split inbox vs project unscheduled done, roll project focus into allTimeFocusMinutes
- Daily stats: goal/project completion callouts, project tasks done line, streak indicator; Habit Streaks + All-Time Summary now collapsible (default collapsed)
- All-time stats: goals/projects created/completed, Unscheduled done (project tasks), focus time with project breakdown
- Weekly review past 7 days: goals/projects/project-tasks tiles, streak callout, unified focus via focusMinutes (not tags), Habits and Frame Utilization now collapsible (default collapsed)
- Weekly review next 7 days: read-only goal cards for goals due within 7 days (targetDate required), active projects list with momentum indicator (green/amber/red based on recent completions)
- Desktop daily summary: parity with mobile for all new features

https://claude.ai/code/session_0187CrhH5Rqy6HAvAQ64BS4d