### PR TITLE
Goals/projects stats in daily summary, all-time stats, and weekly review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,7 @@ Use a **fresh branch per logical task or PR**. Do not accumulate multiple unrela
   ```
 - Branch names should be short and descriptive (e.g. `fix-project-card-completed-at`, `weekly-review-goals-tiles`).
 - Once a PR is merged, do not continue committing to that branch. Start fresh from `main` for the next task.
+
+## Pull Requests
+
+Always create a PR after pushing a branch. Use the GitHub MCP tools (`mcp__github__create_pull_request`) to do this — do not wait for the user to ask. Write a clear title and a summary that describes what changed and why.


### PR DESCRIPTION
## Summary

- **Daily summary** (mobile + desktop): goal/project completion callouts, "+ N project tasks done" line, consecutive-day streak indicator; Habit Streaks and All-Time Summary now collapsible (default collapsed)
- **All-time stats**: goals/projects created vs completed, "Project queue done" count (unscheduled project tasks only), focus time with project breakdown
- **Weekly review — Past 7 days**: goals/projects/project-queue stat tiles, streak callout, Habits and Frame Utilization now collapsible; day names abbreviated to prevent tile overflow
- **Weekly review — Next 7 days**: goal cards for goals with a `targetDate` due this week (progress bar + days left); Standalone Projects list (goal-linked projects excluded) with momentum dot + completion-based progress bar
- **Bug fix**: `ProjectCard` was not stamping `completedAt` when toggling project tasks complete, causing all project queue stats to show zero
- **CLAUDE.md**: documents fresh-branch-per-task workflow and auto-PR preference

## Test plan

- [ ] Open Daily Summary — verify goal/project completion banners appear when applicable, streak shows, Habit Streaks and All-Time Summary are collapsed by default
- [ ] All-Time stats — verify Goals, Projects, Project queue done lines appear when data exists
- [ ] Complete a project task in ProjectCard — verify it appears in "Project queue done" stats immediately
- [ ] Open Weekly Review → Past 7 Days — verify stat tiles render when data exists; Habits/Frames collapsed by default
- [ ] Open Weekly Review → Next 7 Days — verify goal cards only show goals with a `targetDate` in range; Standalone Projects excludes goal-linked projects; progress bars use completion-based colors
