### PR TITLE
Add CLAUDE.md with git workflow preferences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,7 @@ Use a **fresh branch per logical task or PR**. Do not accumulate multiple unrela
   ```
 - Branch names should be short and descriptive (e.g. `fix-project-card-completed-at`, `weekly-review-goals-tiles`).
 - Once a PR is merged, do not continue committing to that branch. Start fresh from `main` for the next task.
+
+## Pull Requests
+
+Always create a PR after pushing a branch. Use the GitHub MCP tools (`mcp__github__create_pull_request`) to do this — do not wait for the user to ask. Write a clear title and a summary that describes what changed and why.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` to document two persistent preferences:
  - **Fresh branch per task** — always branch off latest `main`, never accumulate unrelated changes on a long-running branch
  - **Auto-create PRs** — always open a PR after pushing, without waiting to be asked

## Test plan

- [ ] Merge and verify CLAUDE.md is on main
