### PR TITLE
Bump version to v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Your day, at a glance.** A privacy-first day planner with visual time-blocking, deep integrations, and zero lock-in. Use it free at [dayglance.app](https://dayglance.app) or self-host it on your own server. Your data stays on your device — nothing is ever sent to a server unless you choose to sync it yourself.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-2.1.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases) · [**Android APK**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 26
-        versionName = "2.0"
+        versionCode = 27
+        versionName = "2.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Version bump to **v2.1.0** across all version-tracking files.

| File | Change |
|------|--------|
| `package.json` | `2.0.0` → `2.1.0` |
| `package-lock.json` | Updated via `npm install` |
| `dayglance-android/app/build.gradle.kts` | `versionCode` 26 → 27, `versionName` `"2.0"` → `"2.1"` |
| `README.md` | Version badge updated to `2.1.0` |

## What's in v2.1.0

- Goals/projects stats in daily summary, all-time stats, and weekly review
- ProjectCard notes/subtasks/wikilinks panel
- Drag-and-drop reordering for project cards
- Inbox toggle for showing/hiding project tasks
- AI summaries distinguish inbox vs project tasks
- Obsidian sync bug fixes (tombstoning, projectId/deadline preservation)
- Various UI polish (color picker, status bar, Focus Log ESC, weekly review day abbreviation)
