### PR TITLE
Fix Obsidian sync silently doing nothing after page reload

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallba
 import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Moon, Sun, Upload, Inbox, AlertCircle, Calendar, Check, RefreshCw, Palette, Trash2, Undo2, BarChart3, SkipForward, Hash, MoreHorizontal, Save, Menu, BrainCircuit, AlertTriangle, FileText, ExternalLink, CheckSquare, HelpCircle, Sparkles, Link, GripHorizontal, Play, Pause, Trophy, Cloud, Settings, Search, Bell, Target, TrendingUp, Zap, CalendarDays, Ban, Volume2, VolumeX, Pencil, Eye, Filter, Smartphone, CheckCircle, Pin, PinOff, NotebookPen, MapPin, BookOpen, Flag, FolderOpen, Droplets, Footprints, Dumbbell, Apple, Cigarette, Coffee, Flame, Heart, ListChecks, Minus, Wine, Candy, Pill, Activity, CupSoda, Mic, MicOff, Loader, Key, Server, Wifi, WifiOff, LayoutGrid, RotateCcw } from 'lucide-react';
 import { mergeTaskArrays, mergeSyncData } from './mergeSync.js';
 import { isNativeAndroid, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording } from './native.js';
-import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
+import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, tryRestoreVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
 import { loadAIConfig, saveAIConfig, aiComplete, aiJSON, aiTranscribe, supportsTranscription, testConnection, DEFAULT_CONFIG, PROVIDER_MODELS, PROVIDER_LABELS } from './ai.js';
 import { voiceParseSystemPrompt, voiceParseUserPrompt, taskSuggestSystemPrompt, taskSuggestUserPrompt, frameNudgeSystemPrompt, frameNudgeUserPrompt, rescheduleSystemPrompt, rescheduleUserPrompt, aiSubtasksSystemPrompt, aiSubtasksUserPrompt, morningSummarySystemPrompt, morningSummaryUserPrompt, eveningReflectionSystemPrompt, eveningReflectionUserPrompt, weeklySummarySystemPrompt, weeklySummaryUserPrompt, smartScheduleSystemPrompt, smartScheduleUserPrompt } from './ai-prompts.js';
 import { gatherTrmnlData, pushToTrmnl, TRMNL_MARKUP_FULL, TRMNL_MARKUP_HALF_HORIZONTAL, TRMNL_MARKUP_HALF_VERTICAL, TRMNL_MARKUP_QUADRANT } from './trmnl.js';
@@ -1142,7 +1142,7 @@ const DayPlanner = () => {
     if (!obsidianConfig?.enabled) return;
     (async () => {
       try {
-        const handle = await getVaultAccess();
+        const handle = await tryRestoreVaultAccess();
         if (handle) {
           obsidianVaultHandleRef.current = handle;
           performObsidianSync();
@@ -1785,7 +1785,20 @@ const DayPlanner = () => {
 
   // Obsidian vault sync — reads daily notes + imports tasks
   const performObsidianSync = async () => {
-    if (obsidianSyncInProgressRef.current || !obsidianVaultHandleRef.current) return;
+    if (obsidianSyncInProgressRef.current) return;
+    // If the vault handle was lost (e.g. permission expired after page reload),
+    // try to re-acquire it. When called from a button click this will trigger
+    // the browser's requestPermission prompt. When called from a timer/visibility
+    // event without a user gesture it will silently return null and we skip.
+    if (!obsidianVaultHandleRef.current) {
+      try {
+        const handle = await getVaultAccess();
+        if (!handle) return;
+        obsidianVaultHandleRef.current = handle;
+      } catch {
+        return;
+      }
+    }
     obsidianSyncInProgressRef.current = true;
     const syncStart = Date.now();
     setObsidianSyncStatus('syncing');

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -86,9 +86,21 @@ export async function requestVaultAccess() {
 }
 
 /**
+ * Silently restore a previously-granted vault handle from IndexedDB.
+ * Only succeeds if permission is already 'granted' — does NOT call
+ * requestPermission, so it is safe to call on page load without a user gesture.
+ * Returns the handle or null.
+ */
+export async function tryRestoreVaultAccess() {
+  const handle = await loadVaultHandle();
+  if (!handle) return null;
+  const perm = await handle.queryPermission({ mode: 'readwrite' });
+  return perm === 'granted' ? handle : null;
+}
+
+/**
  * Try to restore a previously-granted vault handle from IndexedDB.
- * Re-requests permission if needed (requires a user gesture the first time
- * after a page reload). Returns the handle or null.
+ * Re-requests permission if needed (requires a user gesture). Returns the handle or null.
  */
 export async function getVaultAccess() {
   const handle = await loadVaultHandle();


### PR DESCRIPTION
Root cause: on reload the vault handle permission resets to 'prompt'. The init useEffect called getVaultAccess() → requestPermission() without a user gesture → browser silently rejects → obsidianVaultHandleRef stays null → every subsequent sync call (including manual button clicks) bailed immediately on the !obsidianVaultHandleRef guard.

Fix:
- Add tryRestoreVaultAccess() to obsidian.js — only calls queryPermission, never requestPermission, safe to call on load without a user gesture
- Init useEffect now uses tryRestoreVaultAccess (succeeds silently if permission is still granted, leaves handle null otherwise)
- performObsidianSync attempts getVaultAccess() when handle is null; from a button click this triggers requestPermission and shows the browser prompt; from timers/visibility it returns null and skips silently

https://claude.ai/code/session_017F6BMEcbJ6v8L6Q7jRby92