### PR TITLE
Fix GoalDashboard swipe breaking on real Android devices

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -1062,6 +1062,10 @@ const MobileDashboard = ({
     if (!el) return;
 
     const onStart = (e) => {
+      // Guard: don't capture swipes when this component is hidden (display:none).
+      // On real Android WebView, passive:false listeners remain active on hidden
+      // elements and can interfere with touch handling elsewhere in the app.
+      if (el.offsetParent === null) return;
       const t = e.touches[0];
       swipeRef.current = { startX: t.clientX, startY: t.clientY, locked: null };
     };


### PR DESCRIPTION
## Summary

- Guards GoalDashboard's carousel touch handlers so they don't fire when the component is mounted-but-hidden (`display:none`)
- On real Android WebView, `passive:false` touchmove listeners stay active on hidden elements and can block swipe gestures in other tabs
- Fix: check `el.offsetParent === null` in `onStart` — since `onMove`/`onEnd` already bail early when `swipeRef` is null, this single guard is sufficient

## Root cause

After keeping GoalDashboard always mounted (to avoid tab-switch freezes), its `{ passive: false }` touchmove listener on `scrollRef.current` remained registered even when the Goals tab was hidden. On real Android devices (S26 confirmed), this caused the WebView to treat touch sequences as non-passive, breaking swipe navigation in other tabs. The emulator didn't reproduce this because Chrome DevTools mobile simulation handles passive listeners differently.

https://claude.ai/code/session_017F6BMEcbJ6v8L6Q7jRby92