### PR TITLE
Fix GoalDashboard swipe guard: use closest('.hidden') not offsetParent

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -1062,10 +1062,11 @@ const MobileDashboard = ({
     if (!el) return;
 
     const onStart = (e) => {
-      // Guard: don't capture swipes when this component is hidden (display:none).
-      // On real Android WebView, passive:false listeners remain active on hidden
-      // elements and can interfere with touch handling elsewhere in the app.
-      if (el.offsetParent === null) return;
+      // Guard: don't capture swipes when this component is hidden via Tailwind's
+      // `hidden` class (display:none). On real Android WebView, passive:false
+      // listeners remain active on hidden elements and can interfere with touch
+      // handling elsewhere in the app.
+      if (el.closest('.hidden')) return;
       const t = e.touches[0];
       swipeRef.current = { startX: t.clientX, startY: t.clientY, locked: null };
     };


### PR DESCRIPTION
offsetParent returns null even on visible elements when an ancestor uses position:fixed (typical in mobile layouts), causing the onStart guard to wrongly suppress carousel swipes when the goals tab IS active.

Switch to el.closest('.hidden') which explicitly checks for the Tailwind hidden class set on the GoalDashboard wrapper when another tab is active.

https://claude.ai/code/session_017F6BMEcbJ6v8L6Q7jRby92