### PR TITLE
fix: add missing Mic icon import to GlanceSidebar

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -3,7 +3,7 @@ import {
   AlertCircle, AlertTriangle, BookOpen, BrainCircuit,
   Calendar, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronUp, Clock, Filter, Inbox, LayoutGrid, Loader,
-  Minus, Moon, NotebookPen, Plus, RefreshCw, Search,
+  Mic, Minus, Moon, NotebookPen, Plus, RefreshCw, Search,
   Sparkles, Sun, Target, Trash2, X,
 } from 'lucide-react';
 import { isNativeAndroid } from '../native.js';


### PR DESCRIPTION
Fixes `ReferenceError: Mic is not defined` crash in GlanceSidebar — the `Mic` icon was used at line 189 but missing from the lucide-react import.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs