### PR TITLE
fix: move InboxFilterPopover state/ref into InboxSidebar

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -16,7 +16,6 @@ import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
 import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
 import DeadlinePickerPopover from './DeadlinePickerPopover.jsx';
 import DesktopHeader from './DesktopHeader.jsx';
-import InboxFilterPopover from './InboxFilterPopover.jsx';
 import InboxArchivedBar from './InboxArchivedBar.jsx';
 import GlanceSidebar from './GlanceSidebar.jsx';
 import InboxSidebar from './InboxSidebar.jsx';
@@ -416,8 +415,6 @@ const DesktopLayout = () => {
     archiveInboxTask,
   } = useDayPlannerCtx();
 
-  const [showInboxFilter, setShowInboxFilter] = useState(false);
-  const inboxFilterBtnRef = useRef(null);
 
   // A filter is "active" (non-default) when any non-priority filter deviates from defaults
   const inboxFilterActive =
@@ -2358,11 +2355,6 @@ const DesktopLayout = () => {
           <Trash2 size={26} className="text-white" />
         </div>
       )}
-      <InboxFilterPopover
-        open={showInboxFilter}
-        onClose={() => setShowInboxFilter(false)}
-        buttonRef={inboxFilterBtnRef}
-      />
       </>
 );
 };

--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import {
   AlertCircle, Archive, BookOpen, BrainCircuit,
   Calendar, Check, CheckSquare, ExternalLink,
@@ -9,12 +9,13 @@ import { dateToString, extractWikilinks, formatDeadlineDate } from '../utils/tas
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
 import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
 import DeadlinePickerPopover from './DeadlinePickerPopover.jsx';
+import InboxFilterPopover from './InboxFilterPopover.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 
 const InboxSidebar = ({ variant = 'desktop' }) => {
   const {
     longPressTriggeredRef, longPressTimerRef,
-    inboxFilterBtnRef, editingInputRef,
+    editingInputRef,
     darkMode,
     unscheduledTasks,
     editingTaskId, editingTaskText,
@@ -54,15 +55,17 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
     handleDragOverInbox, handleDropOnInbox,
     dragOverInbox, setDragOverInbox,
     inboxFilterActive,
-    showInboxFilter, setShowInboxFilter,
     setInboxProjectFilter,
     handleMobileTaskTouchStart, handleMobileTaskTouchMove, handleMobileTaskTouchEnd,
   } = useDayPlannerCtx();
 
+  const [showInboxFilter, setShowInboxFilter] = useState(false);
+  const inboxFilterBtnRef = useRef(null);
   const isDesktop = variant === 'desktop';
 
   if (isDesktop) {
     return (
+    <>
   <div
     onDragOver={handleDragOverInbox}
     onDragLeave={(e) => {
@@ -361,11 +364,18 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
     )}
     </div>
   </div>
+  <InboxFilterPopover
+    open={showInboxFilter}
+    onClose={() => setShowInboxFilter(false)}
+    buttonRef={inboxFilterBtnRef}
+  />
+    </>
     );
   }
 
   // Tablet variant
   return (
+    <>
 <div className="p-4" data-inbox-container>
   {/* Inbox header with priority filter */}
   <div className="flex items-center mb-4">
@@ -607,6 +617,12 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
     )}
   </div>
 </div>
+  <InboxFilterPopover
+    open={showInboxFilter}
+    onClose={() => setShowInboxFilter(false)}
+    buttonRef={inboxFilterBtnRef}
+  />
+    </>
   );
 };
 


### PR DESCRIPTION
Fixes `TypeError: Cannot set properties of undefined (setting 'current')` crash in InboxSidebar.

**Root cause:** `showInboxFilter` and `inboxFilterBtnRef` were local state/ref in DesktopLayout (`useState`/`useRef`), not context values. The extraction tried to destructure them from `useDayPlannerCtx()` which returned `undefined`.

**Fix:** Create local `useState`/`useRef` in InboxSidebar and render `InboxFilterPopover` inside InboxSidebar for both variants. Removes the now-unused state, ref, and import from DesktopLayout.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs