### PR TITLE
fix: compute inboxFilterActive locally in InboxSidebar

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -416,14 +416,6 @@ const DesktopLayout = () => {
   } = useDayPlannerCtx();
 
 
-  // A filter is "active" (non-default) when any non-priority filter deviates from defaults
-  const inboxFilterActive =
-    hideCompletedInbox ||
-    hideStandaloneTasksInbox ||
-    (goalsProjectsEnabled && !hideProjectTasksInbox) ||
-    inboxTagFilter.length > 0 ||
-    inboxProjectFilter.length > 0;
-
   return (
       <>
       {/* Desktop & Tablet Layout */}

--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -54,13 +54,19 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
     handleDragStart, handleDragEnd,
     handleDragOverInbox, handleDropOnInbox,
     dragOverInbox, setDragOverInbox,
-    inboxFilterActive,
-    setInboxProjectFilter,
+    hideCompletedInbox, hideStandaloneTasksInbox, hideProjectTasksInbox,
+    inboxTagFilter, inboxProjectFilter, setInboxProjectFilter,
     handleMobileTaskTouchStart, handleMobileTaskTouchMove, handleMobileTaskTouchEnd,
   } = useDayPlannerCtx();
 
   const [showInboxFilter, setShowInboxFilter] = useState(false);
   const inboxFilterBtnRef = useRef(null);
+  const inboxFilterActive =
+    hideCompletedInbox ||
+    hideStandaloneTasksInbox ||
+    (goalsProjectsEnabled && !hideProjectTasksInbox) ||
+    inboxTagFilter.length > 0 ||
+    inboxProjectFilter.length > 0;
   const isDesktop = variant === 'desktop';
 
   if (isDesktop) {


### PR DESCRIPTION
Fixes filter icon not highlighting when inbox filter is active.

Same class of bug as #258 — `inboxFilterActive` was computed locally in DesktopLayout, not a context value. InboxSidebar was pulling `undefined` from context so the filter icon always appeared inactive.

Fix: compute `inboxFilterActive` locally in InboxSidebar from the underlying context values (`hideCompletedInbox`, `hideStandaloneTasksInbox`, `hideProjectTasksInbox`, `inboxTagFilter`, `inboxProjectFilter`).

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs