### PR TITLE
fix: sync tablet inbox project chip filter with desktop

### DIFF
--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -530,7 +530,12 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
                         if (!proj) return null;
                         return (
                           <button
-                            onClick={(e) => { e.stopPropagation(); setProjectFilter(prev => prev === task.projectId ? null : task.projectId); }}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              const active = projectFilter === task.projectId;
+                              setProjectFilter(active ? null : task.projectId);
+                              setInboxProjectFilter(active ? [] : [task.projectId]);
+                            }}
                             className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 hover:bg-white/40 text-white font-medium transition-colors flex-shrink-0 ${projectFilter === task.projectId ? 'ring-1 ring-white/60' : ''}`}
                             title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
                           >


### PR DESCRIPTION
Fixes project chip in tablet inbox only filtering the timeline but not the inbox list.

The tablet variant's project chip `onClick` only called `setProjectFilter`, missing the `setInboxProjectFilter` call that the desktop variant had. Now both variants call both setters so the timeline and inbox filter stay in sync.

This was a pre-existing discrepancy in the original code that became visible during testing.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs