### PR TITLE
fix: missing context values in GlanceSidebar + tablet notes panel

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -25,6 +25,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     currentTime,
     use24HourClock,
     tasks, setTasks,
+    expandedRecurringTasks,
     unscheduledTasks, setUnscheduledTasks,
     recycleBin, setRecycleBin,
     recurringTasks, setRecurringTasks,
@@ -89,6 +90,8 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     getFrameInstancesForDate,
     computeAvailableSlots,
     moveToRecycleBin,
+    showVoiceInput, setShowVoiceInput,
+    voiceCanRecord,
   } = useDayPlannerCtx();
 
   const isDesktop = variant === 'desktop';

--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -623,6 +623,24 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
             </div>
           </div>
           </div>{/* end swipe wrapper */}
+          {expandedNotesTaskId === task.id && (
+            <NotesSubtasksPanel
+              task={task}
+              isInbox={true}
+              darkMode={darkMode}
+              updateTaskNotes={updateTaskNotes}
+              addSubtask={addSubtask}
+              toggleSubtask={toggleSubtask}
+              deleteSubtask={deleteSubtask}
+              updateSubtaskTitle={updateSubtaskTitle}
+              aiConfig={aiConfig}
+              aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
+              onGenerateSubtasks={generateAISubtasks}
+              wikilinks={task.importSource === 'obsidian' ? extractWikilinks(task.title) : undefined}
+              onLoadWikiNote={task.importSource === 'obsidian' ? loadWikiNote : undefined}
+              onSaveWikiNote={task.importSource === 'obsidian' ? saveWikiNote : undefined}
+            />
+          )}
         </div>
       ))
     )}


### PR DESCRIPTION
Fixes three issues found during Phase 9b testing:

**GlanceSidebar:**
1. **Filter button crash** — `expandedRecurringTasks` was not destructured from context, causing `ReferenceError` when opening the tag filter popover (it counts recurring tasks per tag)
2. **Mic button broken** — `setShowVoiceInput` and `voiceCanRecord` were not destructured from context

**InboxSidebar:**
3. **Notes/subtasks not working on tablet** — The `NotesSubtasksPanel` was present in the desktop variant but was dropped from the tablet variant during extraction. Added it back after the swipe wrapper div, matching the original code.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs