### PR TITLE
fix: add missing Hash icon and toggleTag to GlanceSidebar

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   AlertCircle, AlertTriangle, BookOpen, BrainCircuit,
   Calendar, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
-  ChevronUp, Clock, Filter, Inbox, LayoutGrid, Loader,
+  ChevronUp, Clock, Filter, Hash, Inbox, LayoutGrid, Loader,
   Mic, Minus, Moon, NotebookPen, Plus, RefreshCw, Search,
   Sparkles, Sun, Target, Trash2, X,
 } from 'lucide-react';
@@ -86,7 +86,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     getTodayStr, getOverdueTasks,
     getTaskCalendarStyle,
     timeToMinutes,
-    selectAllTags, clearTagFilter,
+    selectAllTags, clearTagFilter, toggleTag,
     getFrameInstancesForDate,
     computeAvailableSlots,
     moveToRecycleBin,


### PR DESCRIPTION
Fixes crash when opening the tag filter popover in GlanceSidebar.

- `Hash` icon: used to render tag icons in the filter list but missing from lucide-react import
- `toggleTag`: called on tag click but not destructured from context

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs