### PR TITLE
fix: add missing imports to CalendarHeader

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -5,9 +5,9 @@ import {
   NotebookPen, Pencil, RefreshCw, Settings, SkipForward,
   Target, Trash2,
 } from 'lucide-react';
-import { isNativeAndroid } from '../native.js';
+import { isNativeAndroid, nativeUpdateEvent } from '../native.js';
 import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
-import { dateToString, extractWikilinks, formatShortDate } from '../utils/taskUtils.js';
+import { dateToString, extractWikilinks, formatDeadlineDate, formatShortDate } from '../utils/taskUtils.js';
 import { HABIT_COLORS, HABIT_ICONS } from '../constants/habits.js';
 import { MiniHabitRing } from './HabitRing.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';


### PR DESCRIPTION
Fixes `ReferenceError: formatDeadlineDate is not defined` crash on load after merging CalendarHeader (#251).

Two missing imports:
- `formatDeadlineDate` — used in all-day deadline task tooltips
- `nativeUpdateEvent` — used for native Android calendar event updates

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs