### PR TITLE
fix: allow tablet deadline tasks to drag from all-day to timeline

### DIFF
--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -985,8 +985,8 @@ export default function useDragDrop({
       setMobileDragPreviewTime('all-day');
       return;
     }
-    // For all-day source tasks, use absolute position (finger = time)
-    if (mobileDragSourceType.current === 'allday') {
+    // For all-day and deadline source tasks, use absolute position (finger = time)
+    if (mobileDragSourceType.current === 'allday' || mobileDragSourceType.current === 'deadline') {
       if (!timeGridRef.current) return;
       const headerHeight = timeGridRef.current.offsetTop;
       const y = Math.max(0, touch.clientY - calendarRect.top + scrollTop - headerHeight);


### PR DESCRIPTION
## Summary
Fixes tablet deadline tasks not being draggable from the all-day section to the timeline.

## Root cause
In `updateMobileDragPreview()`, when the finger moves below the all-day zone, there are two position computation branches:
- `'allday'` source → absolute position (finger = time)
- `'timeline'` source → delta-based (offset from original position)

Deadline tasks set `mobileDragSourceType` to `'deadline'`, which matched neither branch. It fell through to the timeline delta code which uses `startTime` — but deadline tasks don't have a `startTime`, producing `NaN` and keeping the preview stuck on `'all-day'`.

## Fix
Treat `'deadline'` the same as `'allday'` for absolute position computation, since both originate from the all-day zone.

**Pre-existing bug** — not caused by the Phase 9b refactoring.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs