### PR TITLE
fix: tablet inbox notes panel gray background

### DIFF
--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -622,7 +622,6 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
               </div>
             </div>
           </div>
-          </div>{/* end swipe wrapper */}
           {expandedNotesTaskId === task.id && (
             <NotesSubtasksPanel
               task={task}
@@ -641,6 +640,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
               onSaveWikiNote={task.importSource === 'obsidian' ? saveWikiNote : undefined}
             />
           )}
+          </div>{/* end swipe wrapper */}
         </div>
       ))
     )}


### PR DESCRIPTION
Fixes tablet inbox notes panel appearing with a gray background instead of overlaying the task card color.

The `NotesSubtasksPanel` uses `bg-black/25` (semi-transparent) and relies on being rendered inside/adjacent to the colored task card. The extraction placed it outside the swipe wrapper, so the transparency showed the sidebar background instead of the card color.

Fix: move the panel inside the swipe wrapper div (after the colored card closes, before the swipe wrapper closes), matching the original MobileLayout structure.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs