### PR TITLE
fix: move tablet notes panel inside colored task card

### DIFF
--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -621,7 +621,6 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
                 </button>
               </div>
             </div>
-          </div>
           {expandedNotesTaskId === task.id && (
             <NotesSubtasksPanel
               task={task}
@@ -640,6 +639,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
               onSaveWikiNote={task.importSource === 'obsidian' ? saveWikiNote : undefined}
             />
           )}
+          </div>
           </div>{/* end swipe wrapper */}
         </div>
       ))


### PR DESCRIPTION
The previous fix (#266) moved the `NotesSubtasksPanel` inside the swipe wrapper but still outside the `${task.color}` div. The panel's `bg-black/25` was rendering over the sidebar background (white/light) instead of the task card's blue color, producing the gray appearance shown in the screenshot.

Fix: move the panel one level deeper — inside the colored card div, after the `text-white` content div closes. This matches how the desktop variant renders it.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs