### PR TITLE
fix: add missing setSelectedDate to GlanceSidebar

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -24,6 +24,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     darkMode,
     currentTime,
     use24HourClock,
+    selectedDate, setSelectedDate,
     tasks, setTasks,
     expandedRecurringTasks,
     unscheduledTasks, setUnscheduledTasks,


### PR DESCRIPTION
Adds missing `setSelectedDate` to GlanceSidebar context destructuring. Used at line 492 when clicking an overdue scheduled task to navigate the calendar to that task's date. Would crash with `ReferenceError` on that click.

Caught by systematic audit (late-arriving result from parallel agent).

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs