### PR TITLE
fix: add missing position functions to TimeGrid

### DIFF
--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -59,6 +59,8 @@ const TimeGrid = () => {
     getTasksForDate, getFrameInstancesForDate,
     getTaskCalendarStyle,
     computeAvailableSlots,
+    minutesToPosition, positionToMinutes,
+    calculateTaskPosition, calculateConflictPosition,
     updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
     aiConfig, aiSubtasksLoadingForTask, generateAISubtasks,
     loadWikiNote, saveWikiNote,


### PR DESCRIPTION
Fixes `ReferenceError: minutesToPosition is not defined` crash on load after merging TimeGrid.

4 position calculation functions used throughout TimeGrid for rendering task blocks and frame zones were not destructured from context:
- `minutesToPosition` (7 uses) — converts minutes to pixel Y position
- `positionToMinutes` (1 use) — converts pixel Y position to minutes
- `calculateTaskPosition` (2 uses) — computes task block top/height
- `calculateConflictPosition` (1 use) — computes column layout for overlapping tasks

These were missed by the previous audit because they're provided by the context provider but weren't in the component's destructuring.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs