### PR TITLE
fix: mobile timeline notes panel gray background

### DIFF
--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -809,6 +809,7 @@ const MobileLayout = () => {
                               />
                             </div>
                           ) : (
+                            <div className={`${noteTask.color || ''} rounded-lg`}>
                             <NotesSubtasksPanel
                               task={noteTask}
                               isInbox={!!deadlineTask}
@@ -823,6 +824,7 @@ const MobileLayout = () => {
                               aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
                               onGenerateSubtasks={generateAISubtasks}
                             />
+                            </div>
                           )}
                         </div>
                       </div>


### PR DESCRIPTION
Fixes the mobile timeline notes panel bottom-sheet showing a gray background instead of the task's color.

The `NotesSubtasksPanel` uses `bg-black/25` (semi-transparent) designed to overlay a colored task card. In the mobile bottom-sheet overlay, it was rendering over `cardBg` (white/dark gray), producing the gray appearance seen in the screenshot.

Fix: wrap the panel in a `<div>` with `${noteTask.color}` so the semi-transparent background shows the correct color.

Pre-existing issue — the original MobileLayout code had the same problem.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs