### PR TITLE
fix: notes panel color for inbox and dayglance overlays

### DIFF
--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -1067,6 +1067,7 @@ const MobileGlanceSection = () => {
                 </div>
               </div>
             ) : (
+              <div className={`${agendaTask.color || ''} rounded-lg`}>
               <NotesSubtasksPanel
                 task={agendaTask}
                 isInbox={isInbox}
@@ -1081,6 +1082,7 @@ const MobileGlanceSection = () => {
                 aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
                 onGenerateSubtasks={generateAISubtasks}
               />
+              </div>
             )}
           </div>
         </div>

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -1059,6 +1059,7 @@ const MobileLayout = () => {
                           </button>
                         </div>
                         <div className="p-4">
+                          <div className={`${noteTask.color || ''} rounded-lg`}>
                           <NotesSubtasksPanel
                             task={noteTask}
                             isInbox={true}
@@ -1073,6 +1074,7 @@ const MobileLayout = () => {
                             aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
                             onGenerateSubtasks={generateAISubtasks}
                           />
+                          </div>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
Same fix as #271 but for the remaining two mobile notes panel overlays:

- **MobileLayout** — inbox tab notes panel bottom-sheet
- **MobileGlanceSection** — dayglance tab notes panel bottom-sheet

Both render `NotesSubtasksPanel` (which uses `bg-black/25`) over a `cardBg` background, producing a gray appearance. Fixed by wrapping in the task's color class.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs