### PR TITLE
fix: add missing tab navigation setters to MobileGlanceSection

### DIFF
--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -25,6 +25,8 @@ const MobileGlanceSection = () => {
     darkMode,
     currentTime, use24HourClock,
     selectedDate, setSelectedDate,
+    mobileActiveTab, setMobileActiveTab,
+    mobileSettingsView, setMobileSettingsView,
     tasks, setTasks,
     unscheduledTasks, setUnscheduledTasks,
     recycleBin, setRecycleBin,


### PR DESCRIPTION
Fixes `ReferenceError: setMobileActiveTab is not defined` when clicking navigation buttons in MobileGlanceSection.

Two missing context destructures:
- `setMobileActiveTab` (4 uses) — navigate to timeline, settings, routines tabs
- `setMobileSettingsView` (2 uses) — open specific settings panels

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs