### PR TITLE
fix: remove stray )} text and add missing X icon

### DIFF
--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -4,7 +4,7 @@ import {
   Calendar, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronUp, Clock, ExternalLink, FileText, Filter, Inbox, LayoutGrid,
   Loader, Mic, Minus, Moon, NotebookPen, Plus, RefreshCw,
-  Search, Sparkles, Sun, Target,
+  Search, Sparkles, Sun, Target, X,
 } from 'lucide-react';
 import { isNativeAndroid } from '../native.js';
 import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -839,7 +839,6 @@ const MobileLayout = () => {
             {mobileActiveTab === 'dayglance' && (
               <MobileGlanceSection />
             )}
-            )}
 
             {mobileActiveTab === 'inbox' && (
               <div className={`px-4 py-4 mobile-tab-fade-in flex-1 min-h-0 overflow-y-auto`}>


### PR DESCRIPTION
Two fixes:

1. **Stray `)}` text rendering** — The dayglance tab extraction (`<MobileGlanceSection />`) left behind an extra `)}` closing at line 842 in MobileLayout. This rendered as visible text at the bottom of timeline/glance tabs and top of inbox/routines/goals/settings tabs.

2. **Missing `X` icon** — Used in the notes panel close button in MobileGlanceSection (5 uses) but not imported from lucide-react. Crashed when opening the notes panel overlay.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs