### PR TITLE
fix: add missing icons to MobileBottomSheets

### DIFF
--- a/src/components/MobileBottomSheets.jsx
+++ b/src/components/MobileBottomSheets.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {
-  CalendarDays, Check, CheckCircle, ChevronDown, ChevronUp,
+  BarChart3, CalendarDays, Check, CheckCircle, ChevronDown, ChevronUp,
   Clock, Filter, Flag, Flame, FolderOpen, Hash, Inbox,
-  MoreHorizontal, Target, TrendingUp, Trophy,
+  MoreHorizontal, Target, Trash2, TrendingUp, Trophy, Undo2,
 } from 'lucide-react';
 import { renderTitle } from '../utils/textFormatting.jsx';
 import { dateToString, extractTags } from '../utils/taskUtils.js';


### PR DESCRIPTION
Fixes `ReferenceError: BarChart3 is not defined` crash when opening the daily summary bottom sheet.

3 missing icon imports:
- `BarChart3` — daily summary stats header
- `Trash2` — recycle bin empty button
- `Undo2` — recycle bin restore button

The earlier pre-merge audit incorrectly reported this file as clean because it only checked context values, not icon imports.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs