### PR TITLE
fix: add missing Trash2 icon to MobileGlanceSection

### DIFF
--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -4,7 +4,7 @@ import {
   Calendar, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronUp, Clock, ExternalLink, FileText, Filter, Inbox, LayoutGrid,
   Loader, Mic, Minus, Moon, NotebookPen, Plus, RefreshCw,
-  Search, Sparkles, Sun, Target, X,
+  Search, Sparkles, Sun, Target, Trash2, X,
 } from 'lucide-react';
 import { isNativeAndroid } from '../native.js';
 import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';


### PR DESCRIPTION
Full icon re-audit of all 8 Phase 9b components found one last missing icon:

- `Trash2` in MobileGlanceSection — used in the overdue task delete button

All other components are now clean. This completes the icon audit.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs