### PR TITLE
fix: add missing X icon to MobileBottomSheets

### DIFF
--- a/src/components/MobileBottomSheets.jsx
+++ b/src/components/MobileBottomSheets.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   BarChart3, CalendarDays, Check, CheckCircle, ChevronDown, ChevronUp,
   Clock, Filter, Flag, Flame, FolderOpen, Hash, Inbox,
-  MoreHorizontal, Target, Trash2, TrendingUp, Trophy, Undo2,
+  MoreHorizontal, Target, Trash2, TrendingUp, Trophy, Undo2, X,
 } from 'lucide-react';
 import { renderTitle } from '../utils/textFormatting.jsx';
 import { dateToString, extractTags } from '../utils/taskUtils.js';


### PR DESCRIPTION
Missing `X` icon in MobileBottomSheets — used in close buttons for all three bottom sheets.

The previous icon audit regex (`<[A-Z][a-zA-Z0-9]+`) required 2+ characters after `<`, so it missed the single-character `X` icon. Re-verified all 8 components for `<X ` specifically — MobileBottomSheets was the only one missing it.

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs