### PR TITLE
fix: final audit — 2 remaining missing identifiers

### DIFF
--- a/src/components/MobileBottomSheets.jsx
+++ b/src/components/MobileBottomSheets.jsx
@@ -15,6 +15,7 @@ const MobileBottomSheets = () => {
     darkMode,
     cardBg, borderClass, textPrimary, textSecondary, hoverBg,
     tasks,
+    expandedRecurringTasks,
     unscheduledTasks,
     recycleBin, setRecycleBin,
     completedTaskUids,

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -7,7 +7,7 @@ import {
   Search, Sparkles, Sun, Target, Trash2, X,
 } from 'lucide-react';
 import { isNativeAndroid } from '../native.js';
-import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
+import { renderTitle, renderFormattedText, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
 import { dateToString, extractTags, extractWikilinks, formatDeadlineDate } from '../utils/taskUtils.js';
 import { HABIT_COLORS, HABIT_ICONS } from '../constants/habits.js';
 import { HabitRing } from './HabitRing.jsx';


### PR DESCRIPTION
## Final comprehensive audit

Ran a complete audit covering all categories of missing identifiers we've encountered throughout this session:

- Icons (including single-char `X`)
- `set*` context setters
- Position/calculation functions
- All common context values (70+ checked)
- Utility function imports

### Found 2 remaining issues:

| Component | Missing | Used for |
|-----------|---------|----------|
| MobileBottomSheets | `expandedRecurringTasks` | Daily summary tag count computation |
| MobileGlanceSection | `renderFormattedText` | Imported event description in notes overlay |

### Remaining audit output (false positives only):
- `<X` icon: flagged in 3 files but already imported in all — the audit regex struggles with single-char identifiers
- `tasks` in InboxSidebar: only appears inside string literals, not as a variable

**All 8 Phase 9b components now pass the full audit.**

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs