### PR TITLE
fix: gate ProjectCard notes portal on goals tab visibility

### DIFF
--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -43,6 +43,7 @@ const ProjectCard = forwardRef(({ project, onFocusClick, onEditClick, compact, d
     generateAISubtasks, aiSubtasksLoadingForTask,
     aiConfig,
     longPressTriggeredRef, longPressTimerRef,
+    showGoalsDashboard, mobileActiveTab,
   } = useDayPlannerCtx();
 
   const isScheduled = (t) => !!tasks.find(s => s.id === t.id);
@@ -568,7 +569,9 @@ const ProjectCard = forwardRef(({ project, onFocusClick, onEditClick, compact, d
     </div>
 
     {/* Notes/subtasks panel — portalled to body, centered over viewport */}
-    {expandedTask && createPortal(
+    {/* Only render when goals tab is active — GoalDashboard stays mounted when hidden,
+        so without this guard the portal fires for any project task's notes on other tabs */}
+    {expandedTask && (isMobile ? mobileActiveTab === 'goals' : showGoalsDashboard) && createPortal(
       <div className={`notes-panel-container fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[720px] max-w-[92vw] max-h-[90vh] overflow-y-auto rounded-xl shadow-2xl border ${
         darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'
       }`}>


### PR DESCRIPTION
## Root cause found

`ProjectCard.jsx` uses `createPortal` to render a `NotesSubtasksPanel` into `document.body` whenever `expandedNotesTaskId` matches a project task. Since `GoalDashboard` stays mounted with `display: none` when not active (to avoid expensive remount), the `ProjectCard` components are still alive and responding to state changes — even when viewing the timeline or glance tabs.

When you click the notes button on a task that has a `projectId`:
1. The correct bottom-sheet overlay fires (from MobileLayout/MobileGlanceSection)
2. The `ProjectCard` portal ALSO fires, rendering a second panel centered on the viewport

This explains why:
- Tasks WITH a projectId showed doubled panels
- Tasks WITHOUT a projectId worked fine
- It only happened with seed data (which assigns projectIds)
- It was a pre-existing bug (confirmed on `main`)

## Fix

Guard the portal on tab visibility: `isMobile ? mobileActiveTab === 'goals' : showGoalsDashboard`

https://claude.ai/code/session_01VuJUu1ZkWBmW4SMBtiiEDs