### PR TITLE
Fix wikilinks panel on tablet and mobile inbox

### DIFF
--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -467,7 +467,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
     ) : (
       filteredUnscheduledTasks.filter(t => !t.isExample).map(task => (
         <div key={task.id} className="notes-panel-container">
-          <div className={`relative rounded-lg ${showDeadlinePicker === task.id ? '' : 'overflow-hidden'}`}>
+          <div className={`relative rounded-lg ${(showDeadlinePicker === task.id || expandedNotesTaskId === task.id) ? '' : 'overflow-hidden'}`}>
             {/* Swipe action strips */}
             <div data-swipe-strip="right" style={{ display: 'none' }} className={`absolute inset-0 ${darkMode ? 'bg-green-900/80 text-green-300' : 'bg-green-100 text-green-600'} rounded-lg flex items-center pl-3 text-xs font-medium`}>
               <Calendar size={14} className="mr-1" />Schedule
@@ -570,7 +570,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
                         setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
                       }
                     }}
-                    className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${hasNotesOrSubtasks(task) ? '' : 'opacity-40'}`}
+                    className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${hasNotesOrSubtasks(task) || (task.importSource === 'obsidian' && extractWikilinks(task.title).length > 0) ? '' : 'opacity-40'}`}
                   >
                     {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
                   </button>

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -981,7 +981,7 @@ const MobileLayout = () => {
                                       setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
                                     }
                                   }}
-                                  className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${hasNotesOrSubtasks(task) ? '' : 'opacity-40'}`}
+                                  className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${hasNotesOrSubtasks(task) || (task.importSource === 'obsidian' && extractWikilinks(task.title).length > 0) ? '' : 'opacity-40'}`}
                                 >
                                   {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
                                 </button>
@@ -1072,6 +1072,9 @@ const MobileLayout = () => {
                             aiConfig={aiConfig}
                             aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
                             onGenerateSubtasks={generateAISubtasks}
+                            wikilinks={noteTask.importSource === 'obsidian' ? extractWikilinks(noteTask.title) : undefined}
+                            onLoadWikiNote={noteTask.importSource === 'obsidian' ? loadWikiNote : undefined}
+                            onSaveWikiNote={noteTask.importSource === 'obsidian' ? saveWikiNote : undefined}
                           />
                           </div>
                         </div>


### PR DESCRIPTION
## Summary

- **Tablet — clicking BookOpen did nothing**: The task card's `overflow-hidden` wrapper was clipping the `NotesSubtasksPanel` when it expanded, making the panel invisible. Fixed by removing `overflow-hidden` when the notes panel is open (same pattern already used for the deadline picker popover).
- **Tablet + Mobile — reduced opacity icon**: The notes toggle button opacity check only tested `hasNotesOrSubtasks`, missing the obsidian wikilinks condition that desktop already had. Obsidian inbox tasks with wikilinks in the title (but no standalone notes) now show a fully-opaque icon.
- **Mobile — panel opens but note doesn't appear**: The mobile inbox notes overlay rendered `NotesSubtasksPanel` without `wikilinks`, `onLoadWikiNote`, or `onSaveWikiNote` props, so the wiki note content could never load. Props are now passed consistently with the tablet/desktop variants.

## Test plan

- [ ] Obsidian inbox task with `[[wikilink]]` in title — icon is fully opaque on tablet and mobile
- [ ] Tap BookOpen on tablet (side panel) — notes panel expands and wiki note content loads
- [ ] Tap BookOpen on mobile — overlay opens and wiki note content loads
- [ ] Desktop behavior unchanged
- [ ] Non-obsidian tasks with no notes still show reduced-opacity icon on all breakpoints

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV