### PR TITLE
Fix wikilinks panel on mobile timeline tasks

### DIFF
--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -825,6 +825,9 @@ const MobileLayout = () => {
                               aiConfig={aiConfig}
                               aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
                               onGenerateSubtasks={generateAISubtasks}
+                              wikilinks={noteTask.importSource === 'obsidian' ? extractWikilinks(noteTask.title) : undefined}
+                              onLoadWikiNote={noteTask.importSource === 'obsidian' ? loadWikiNote : undefined}
+                              onSaveWikiNote={noteTask.importSource === 'obsidian' ? saveWikiNote : undefined}
                             />
                             </div>
                           )}

--- a/src/components/MobileTimeGrid.jsx
+++ b/src/components/MobileTimeGrid.jsx
@@ -314,7 +314,7 @@ const MobileTimeGrid = () => {
                       setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
                     }
                   }}
-                  className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${inMenu ? 'flex items-center gap-2 w-full' : ''} ${hasNotesOrSubtasks(task) ? '' : 'opacity-40'}`}
+                  className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${inMenu ? 'flex items-center gap-2 w-full' : ''} ${hasNotesOrSubtasks(task) || (task.importSource === 'obsidian' && extractWikilinks(task.title).length > 0) ? '' : 'opacity-40'}`}
                 >
                   {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
                   {inMenu && <span className="text-xs">{isLinkOnlyTask(task) ? 'Open Link' : 'Notes'}</span>}


### PR DESCRIPTION
## Summary

Follow-up to #287 — same wikilinks bugs on the mobile timeline that were fixed for the inbox.

- **`MobileTimeGrid.jsx`**: Notes toggle button opacity check was using only `hasNotesOrSubtasks`, missing the obsidian wikilinks condition. Obsidian timeline tasks with `[[wikilinks]]` in the title now show a fully-opaque icon.
- **`MobileLayout.jsx` timeline overlay**: `NotesSubtasksPanel` was rendered without `wikilinks`, `onLoadWikiNote`, or `onSaveWikiNote` props — the panel opened but wiki note content could never load.

## Test plan

- [ ] Obsidian timeline task with `[[wikilink]]` in title — icon is fully opaque on mobile
- [ ] Tap BookOpen on mobile timeline task — overlay opens and wiki note content loads
- [ ] Non-obsidian timeline tasks with no notes still show reduced-opacity icon

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV