### PR TITLE
Fix tablet all-day drag tab color mismatch for native calendar events

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -361,8 +361,8 @@ const CalendarHeader = () => {
                 {isTablet && !isImported && (
                   <div
                     data-drag-handle
-                    className={`relative flex-shrink-0 ${task.color} rounded-l-lg flex items-center pl-px cursor-grab active:opacity-70 text-white/70`}
-                    style={{ marginLeft: '-12px', marginRight: '-8px', marginTop: '3px', width: '20px', height: '24px', touchAction: 'none', zIndex: 10 }}
+                    className={`relative flex-shrink-0 ${task.nativeCalendarColor ? '' : task.color} rounded-l-lg flex items-center pl-px cursor-grab active:opacity-70 text-white/70`}
+                    style={{ marginLeft: '-12px', marginRight: '-8px', marginTop: '3px', width: '20px', height: '24px', touchAction: 'none', zIndex: 10, ...(task.nativeCalendarColor ? { backgroundColor: task.nativeCalendarColor } : {}) }}
                     onTouchStart={(e) => handleMobileTaskTouchStart(e, task, 'allday')}
                     onTouchMove={(e) => handleMobileTaskTouchMove(e)}
                     onTouchEnd={(e) => handleMobileTaskTouchEnd(e, task.id, 'allday')}


### PR DESCRIPTION
## Summary

Follows on from #291. For native calendar events, the task card's color comes from `nativeCalendarColor` applied as an inline `backgroundColor`, not from the `task.color` Tailwind class. The drag tab was only using `task.color`, so it rendered with a visibly different shade.

Fix mirrors `MobileAllDaySection` exactly: omit the color class when `nativeCalendarColor` is present and apply it as an inline `backgroundColor` instead.

> Note: this branch also includes the swipe fix from #291. If #291 merges first, this PR will show only the one-line color change as its diff.

## Test plan

- [ ] Tablet: native calendar event all-day task — drag tab color matches card exactly
- [ ] Tablet: regular (non-native) all-day task — drag tab color unchanged
- [ ] Mobile: `MobileAllDaySection` unaffected

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV