### PR TITLE
Fix deadline drag tab opacity mismatch on tablet

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -558,8 +558,7 @@ const CalendarHeader = () => {
                 </>
               )}
               {/* data-swipe-container wraps drag tab + card so they slide together on tablet */}
-              <div {...(isTablet ? { 'data-swipe-container': '', className: 'flex items-start' } : {})}>
-              {/* Protruding drag tab (tablet only, in-flow with negative margin) */}
+              <div {...(isTablet ? { 'data-swipe-container': '', className: `flex items-start ${task.completed ? 'opacity-50' : 'opacity-90'}` } : { className: task.completed ? 'opacity-50' : 'opacity-90' })}>              {/* Protruding drag tab (tablet only, in-flow with negative margin) */}
               {isTablet && (
                 <div
                   data-drag-handle
@@ -603,7 +602,7 @@ const CalendarHeader = () => {
               onTouchStart={(e) => handleMobileTaskTouchStart(e, { ...task, isDeadlineDrag: true }, 'deadline')}
               onTouchMove={(e) => handleMobileTaskTouchMove(e)}
               onTouchEnd={(e) => handleMobileTaskTouchEnd(e, task.id, 'deadline')}
-              className={`${task.color} rounded-lg shadow-sm cursor-move ${task.completed ? 'opacity-50' : 'opacity-90'} relative border-2 border-dashed border-white/60`}
+              className={`${task.color} rounded-lg shadow-sm cursor-move relative border-2 border-dashed border-white/60`}
               style={{ touchAction: 'pan-y' }}
             >
               {task.isExample && (


### PR DESCRIPTION
## Summary

The deadline task card had `opacity-90` / `opacity-50` applied to itself while the drag tab was at full opacity. Both use the same `task.color` class, but the card's dimming made it look slightly lighter — the subtle color difference visible in the screenshot.

Fix: move the opacity from the task card to the `data-swipe-container` wrapper so it covers both the drag tab and the card together. This matches the pattern in `MobileAllDaySection` exactly.

## Test plan

- [x] Tablet: deadline task drag tab and card appear the same colour
- [x] Tablet: completed deadline task — both drag tab and card show at `opacity-50`
- [x] Desktop: deadline task opacity/appearance unchanged (opacity now on wrapper, same visual result)

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV