### PR TITLE
Add Trash FAB for tablet touch drag

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -289,6 +289,8 @@ const DesktopLayout = () => {
     mobileDragTaskIdState, setMobileDragTaskIdState,
     mobileDragPreviewTime, setMobileDragPreviewTime,
     mobileDragPreviewDate, setMobileDragPreviewDate,
+    mobileDragOverTrash,
+    trashFabRef,
     timelineScrolledAway, setTimelineScrolledAway,
     isToday, currentTimeMinutes, currentHour, currentTimeTop, showCurrentTimeLine,
     bgClass, cardBg, borderClass, textPrimary, textSecondary, hoverBg,
@@ -779,6 +781,16 @@ const DesktopLayout = () => {
           onDragLeave={() => setDragOverRecycleBin(false)}
           onDrop={handleDropOnRecycleBin}
           className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-50 w-16 h-16 rounded-full shadow-xl flex items-center justify-center transition-all duration-150 pointer-events-auto ${dragOverRecycleBin ? 'bg-red-600 scale-110' : 'bg-red-500'}`}
+        >
+          <Trash2 size={26} className="text-white" />
+        </div>
+      )}
+      {/* Trash FAB — visible during tablet touch drag (same position as mobile so hit-testing coords match) */}
+      {isTablet && mobileDragTaskIdState !== null && (
+        <div
+          ref={trashFabRef}
+          className={`fixed left-4 z-50 w-16 h-16 rounded-full shadow-xl flex items-center justify-center transition-all duration-150 ${mobileDragOverTrash ? 'bg-red-600 scale-110' : 'bg-red-500'}`}
+          style={{ bottom: 'calc(4.5rem + env(safe-area-inset-bottom, 0px))' }}
         >
           <Trash2 size={26} className="text-white" />
         </div>


### PR DESCRIPTION
## Summary

On tablet, long-press dragging uses the mobile touch drag system (`mobileDragTaskIdState`), but `DesktopLayout` only showed the Trash FAB during HTML drag-and-drop (`draggedTask`). So the FAB never appeared during a tablet drag.

Added a second FAB in `DesktopLayout` that's identical to the one in `MobileLayout` — same `left-4` / `bottom: 4.5rem` position, same `ref={trashFabRef}`, same `mobileDragOverTrash` highlight — so the existing hardcoded hit-testing coordinates in `useDragDrop.js` work without any changes. Also destructures `mobileDragOverTrash` and `trashFabRef` from context (they were missing).

## Test plan

- [ ] Tablet: long-press drag a task — Trash FAB appears bottom-left
- [ ] Tablet: drag finger over FAB — FAB pulses red and vibrates
- [ ] Tablet: release over FAB — task moves to recycle bin
- [x] Desktop: existing drag-and-drop Trash FAB unchanged
- [x] Mobile: unaffected

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV