### PR TITLE
Fix tablet Trash FAB hit-detection during touch drag

### DIFF
--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -1116,8 +1116,16 @@ export default function useDragDrop({
         setMobileDragPreviewTime(_initTime);
         setMobileDragPreviewDate(_initDate);
         // Add native non-passive touchmove listener to prevent browser scroll
-        // (React 18 registers touchmove as passive, so e.preventDefault() in onTouchMove is a no-op)
-        const preventScroll = (e) => e.preventDefault();
+        // (React 18 registers touchmove as passive, so e.preventDefault() in onTouchMove is a no-op).
+        // Also update the drag preview here so the trash FAB hit-test stays current even when
+        // the element-level onTouchMove is suppressed (e.g. tablet with touchAction ancestor).
+        const preventScroll = (e) => {
+          e.preventDefault();
+          if (mobileDragActive.current && e.touches[0]) {
+            mobileDragLastTouch.current = { clientX: e.touches[0].clientX, clientY: e.touches[0].clientY };
+            updateMobileDragPreview();
+          }
+        };
         document.addEventListener('touchmove', preventScroll, { passive: false });
         mobileDragPreventScrollRef.current = preventScroll;
         // Suppress iOS text selection / magnifier during drag


### PR DESCRIPTION
## Summary

- On tablet, the element-level `onTouchMove` can be suppressed when an ancestor has `touchAction: 'manipulation'` (the calendar scroll container sets this on tablet). As a result, `updateMobileDragPreview()` was never called during drag, so `mobileDragOverTrashRef.current` stayed `false` and tasks always dropped on the timeline instead of being deleted.
- The `preventScroll` document listener (non-passive, registered at long-press start) fires reliably regardless of the `touchAction` hierarchy. Piggybacking the drag-preview update onto it ensures the trash zone is checked on every `touchmove` even when the React element handler is bypassed.

## Change

One file: `src/hooks/useDragDrop.js`

The `preventScroll` callback (previously a one-liner) now also updates `mobileDragLastTouch` and calls `updateMobileDragPreview()` when a drag is active, giving the trash FAB hit-test a guaranteed path to execute on tablet.

## Test plan

- [ ] Long-press a task drag tab on tablet, drag to the Trash FAB — task should be deleted (red FAB, haptic)
- [ ] Drag a task to the timeline on tablet — should still drop normally
- [ ] Verify mobile drag-to-trash still works (no regression)
- [ ] Verify desktop mouse drag still works (no regression)

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV