### PR TITLE
Fix tablet drag-to-trash: remove touchAction manipulation from calendar container

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,13 @@ Use a **fresh branch per logical task or PR**. Do not accumulate multiple unrela
 ## Pull Requests
 
 Always create a PR after pushing a branch. Use the GitHub MCP tools (`mcp__github__create_pull_request`) to do this — do not wait for the user to ask. Write a clear title and a summary that describes what changed and why.
+
+## CRITICAL: Always check PR status before pushing
+
+**Before pushing any commit to an existing branch**, use `mcp__github__pull_request_read` to check whether the PR for that branch has already been merged. If it has:
+
+1. Do NOT push to that branch.
+2. Create a new branch from the latest `main`.
+3. Apply the changes to the new branch instead.
+
+This check is mandatory — even mid-task, even for "small fixes", even when you just created the PR moments ago. PRs can be merged at any time.

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -760,7 +760,7 @@ const DesktopLayout = () => {
             <div
               ref={calendarRef}
               className={`${cardBg} border ${borderClass} overflow-y-scroll overflow-x-hidden ${darkMode ? 'dark-scrollbar' : ''} relative`}
-              style={{ height: '100%', touchAction: isTablet ? 'manipulation' : undefined }}
+              style={{ height: '100%' }}
             >
               {/* Combined sticky header — date headers + all-day section */}
               <div ref={(el) => { stickyHeaderRef.current = el; }} className={`sticky top-0 z-20 ${cardBg}`}>


### PR DESCRIPTION
## Summary

- `touchAction: 'manipulation'` on the calendar scroll container was overriding the drag tab's `touchAction: 'none'` in the browser's touch-action cascade. The browser claimed the touch for panning before JS drag handlers could act, so `updateMobileDragPreview()` never ran and the trash FAB was never detected.
- Mobile's scroll container has no `touchAction` set and works correctly. Removing the `manipulation` value from tablet's container aligns the two and fixes drag-to-trash on tablet.
- Also documents in `CLAUDE.md` that PR merge status must be checked before every push to an existing branch.

## Test plan

- [ ] Long-press drag tab on tablet → drag to Trash FAB → task deleted (red FAB, haptic)
- [ ] Long-press drag tab on tablet → drag to timeline → task drops normally
- [ ] Timeline still scrolls normally on tablet
- [ ] Mobile drag-to-trash unaffected

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV