### PR TITLE
Fix project filter: apply to all-day tasks and sync with inbox

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -60,6 +60,8 @@ const CalendarHeader = () => {
     openMobileEditTask,
     postponeTask, postponeDeadlineTask,
     moveToRecycleBin, moveToInbox,
+    goalsProjectsEnabled, projects,
+    projectFilter, setProjectFilter, setInboxProjectFilter,
     getTasksForDate, getDeadlineTasksForDate,
     getTaskCalendarStyle,
     setTaskRef,
@@ -169,7 +171,7 @@ const CalendarHeader = () => {
       ALL DAY
     </div>
     {visibleDates.map((date, idx) => {
-      const dayTasks = getTasksForDate(date).filter(t => t.isAllDay).sort((a, b) => {
+      const dayTasks = getTasksForDate(date).filter(t => t.isAllDay && (!projectFilter || t.projectId === projectFilter)).sort((a, b) => {
         const order = (t) => {
           if (t.importSource === 'file') return 0;             // ICS downloads
           if (t.imported && !t.isTaskCalendar) return 1;       // Imported calendar events
@@ -479,6 +481,19 @@ const CalendarHeader = () => {
                       </button>
                     ) : null}
                   </div>
+                  {goalsProjectsEnabled && task.projectId && (() => {
+                    const proj = projects.find(p => p.id === task.projectId);
+                    if (!proj) return null;
+                    return (
+                      <button
+                        onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); }}
+                        className={`mt-1 inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 hover:bg-white/40 text-white font-medium transition-colors ${projectFilter === task.projectId ? 'ring-1 ring-white/60' : ''}`}
+                        title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
+                      >
+                        {proj.title}
+                      </button>
+                    );
+                  })()}
                 </div>
                 {/* Notes panel for all-day tasks */}
                 {expandedNotesTaskId === task.id && !isImported && (

--- a/src/components/MobileAllDaySection.jsx
+++ b/src/components/MobileAllDaySection.jsx
@@ -23,7 +23,7 @@ const MobileAllDaySection = () => {
     taskContextMenu, setTaskContextMenu,
     mobileDragPreviewTime, mobileDragTaskIdState,
     routinesEnabled, todayRoutines,
-    goalsProjectsEnabled, projects, projectFilter,
+    goalsProjectsEnabled, projects, projectFilter, setProjectFilter, setInboxProjectFilter,
     toggleComplete,
     postponeTask, postponeDeadlineTask,
     handleMobileTaskTouchStart, handleMobileTaskTouchMove, handleMobileTaskTouchEnd,
@@ -44,7 +44,7 @@ const MobileAllDaySection = () => {
       </div>
       <div className="flex-1 min-w-0 p-2 space-y-1.5">
         {visibleDates.map((date) => {
-          const dayTasks = getTasksForDate(date).filter(t => t.isAllDay && !t.isExample).sort((a, b) => {
+          const dayTasks = getTasksForDate(date).filter(t => t.isAllDay && !t.isExample && (!projectFilter || t.projectId === projectFilter)).sort((a, b) => {
             const order = (t) => {
               if (t.importSource === 'file') return 0;             // ICS downloads
               if (t.imported && !t.isTaskCalendar) return 1;       // Imported calendar events
@@ -200,6 +200,19 @@ const MobileAllDaySection = () => {
                         </button>
                       )}
                     </div>
+                    {goalsProjectsEnabled && task.projectId && (() => {
+                      const proj = projects.find(p => p.id === task.projectId);
+                      if (!proj) return null;
+                      return (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); }}
+                          className={`mt-1 inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 active:bg-white/40 text-white font-medium transition-colors ${projectFilter === task.projectId ? 'ring-1 ring-white/60' : ''}`}
+                          title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
+                        >
+                          {proj.title}
+                        </button>
+                      );
+                    })()}
                   </div>
                   </div>
                   </div>{/* end data-swipe-container */}

--- a/src/components/MobileTimeGrid.jsx
+++ b/src/components/MobileTimeGrid.jsx
@@ -18,7 +18,7 @@ const MobileTimeGrid = () => {
     borderClass, textSecondary,
     tasks, setTasks,
     projects,
-    projectFilter, setProjectFilter,
+    projectFilter, setProjectFilter, setInboxProjectFilter,
     taskWidths,
     expandedNotesTaskId, setExpandedNotesTaskId,
     expandedTaskMenu, setExpandedTaskMenu,
@@ -499,7 +499,7 @@ const MobileTimeGrid = () => {
                       return (
                         <div className="flex items-center gap-1 flex-wrap mt-0.5">
                           <button
-                            onClick={(e) => { e.stopPropagation(); setProjectFilter(prev => prev === task.projectId ? null : task.projectId); }}
+                            onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); }}
                             className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 active:bg-white/40 text-white font-medium transition-colors flex-shrink-0 ${projectFilter === task.projectId ? 'ring-1 ring-white/60' : ''}`}
                             title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
                           >
@@ -541,7 +541,7 @@ const MobileTimeGrid = () => {
                       return (
                         <div className="flex items-center gap-1 flex-wrap mt-0.5">
                           <button
-                            onClick={(e) => { e.stopPropagation(); setProjectFilter(prev => prev === task.projectId ? null : task.projectId); }}
+                            onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); }}
                             className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 active:bg-white/40 text-white font-medium transition-colors flex-shrink-0 ${projectFilter === task.projectId ? 'ring-1 ring-white/60' : ''}`}
                             title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
                           >

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -23,7 +23,7 @@ const TimeGrid = () => {
     conflicts,
     goalsProjectsEnabled,
     projects,
-    projectFilter, setProjectFilter,
+    projectFilter, setProjectFilter, setInboxProjectFilter,
     taskWidths,
     expandedNotesTaskId, setExpandedNotesTaskId,
     expandedTaskMenu, setExpandedTaskMenu,
@@ -589,7 +589,7 @@ const TimeGrid = () => {
                                   if (!proj) return null;
                                   return (
                                     <button
-                                      onClick={(e) => { e.stopPropagation(); setProjectFilter(prev => prev === task.projectId ? null : task.projectId); }}
+                                      onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); }}
                                       className={`not-italic inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 hover:bg-white/40 text-white font-medium transition-colors flex-shrink-0`}
                                       title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
                                     >
@@ -678,7 +678,7 @@ const TimeGrid = () => {
                                   if (!proj) return null;
                                   return (
                                     <button
-                                      onClick={(e) => { e.stopPropagation(); setProjectFilter(prev => prev === task.projectId ? null : task.projectId); }}
+                                      onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); }}
                                       className={`not-italic inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 hover:bg-white/40 text-white font-medium transition-colors flex-shrink-0`}
                                       title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
                                     >


### PR DESCRIPTION
## Summary

**All-day tasks ignored by project filter (`CalendarHeader`, `MobileAllDaySection`)**
- `dayTasks` now applies `(!projectFilter || t.projectId === projectFilter)` so all-day tasks are hidden when a project filter is active
- Project chip rendered on all-day task cards (same style as timeline chips) — clicking sets/clears the filter

**Clicking a timeline chip didn't filter the Inbox (`TimeGrid`, `MobileTimeGrid`)**
- `setInboxProjectFilter` was only called by `InboxSidebar`'s chip handler; timeline chips only called `setProjectFilter`, leaving `inboxProjectFilter` stale
- Both `TimeGrid` and `MobileTimeGrid` chip handlers now call both setters together

## Test plan

- [x] Set a project filter by clicking a chip on a timeline task → all-day tasks with other projects disappear; inbox also filters
- [x] Set a project filter by clicking a chip in the inbox → all-day tasks filter correctly
- [x] All-day project tasks now show a project chip; clicking it activates the filter
- [x] Clearing the filter (click active chip again) restores all tasks everywhere

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV