### PR TITLE
Fix project card calendar badge alignment on scheduled tasks

### DIFF
--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -486,8 +486,12 @@ const ProjectCard = forwardRef(({ project, onFocusClick, onEditClick, compact, d
                       <NotebookPen size={10} />
                     </button>
                   ))}
-                  {/* Calendar badge for scheduled tasks */}
-                  {scheduled && <Calendar size={10} className={`${textSecondary} opacity-40 flex-shrink-0`} />}
+                  {/* Calendar badge for scheduled tasks — same p-1 padding as drag handle for consistent alignment */}
+                  {scheduled && (
+                    <div className={`flex-shrink-0 p-1 ${textSecondary} opacity-40`}>
+                      <Calendar size={10} />
+                    </div>
+                  )}
                   {draggable && (
                     <div
                       className={`flex-shrink-0 p-1 cursor-grab touch-none ${textSecondary} opacity-30`}


### PR DESCRIPTION
## Summary

The calendar badge shown on scheduled tasks had no padding, while the drag handle (shown on unscheduled tasks) uses `p-1`. This caused the notes and calendar icons to sit against the right edge without breathing room, visually misaligned compared to unscheduled rows.

Wraps the calendar badge in a `div` with `p-1` to match the drag handle structure.

## Test plan

- [ ] Project card: scheduled task row — notes icon and calendar badge are aligned with the notes icon and drag handle on unscheduled rows

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV