### PR TITLE
Fix project card calendar badge width to exactly match drag handle

### DIFF
--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -486,9 +486,9 @@ const ProjectCard = forwardRef(({ project, onFocusClick, onEditClick, compact, d
                       <NotebookPen size={10} />
                     </button>
                   ))}
-                  {/* Calendar badge for scheduled tasks — same p-1 padding as drag handle for consistent alignment */}
+                  {/* Calendar badge for scheduled tasks — w-5 h-5 matches drag handle (p-1 + size-12) footprint exactly */}
                   {scheduled && (
-                    <div className={`flex-shrink-0 p-1 ${textSecondary} opacity-40`}>
+                    <div className={`flex-shrink-0 w-5 h-5 flex items-center justify-center ${textSecondary} opacity-40`}>
                       <Calendar size={10} />
                     </div>
                   )}


### PR DESCRIPTION
## Summary

`p-1` + `GripVertical size={12}` = 20px wide. `p-1` + `Calendar size={10}` = 18px — the 2px difference caused the notes icon to sit 2px further right on scheduled rows vs unscheduled rows.

Replace `p-1` with `w-5 h-5 flex items-center justify-center` so the calendar badge occupies the same 20×20px footprint as the drag handle, and both columns align exactly.

## Test plan

- [ ] Project card: notes icon on a scheduled row aligns exactly with the notes icon on unscheduled rows below it

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV