### PR TITLE
Fix daily summary collapse chevrons crashing on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -632,6 +632,8 @@ const DayPlanner = () => {
 
   // Incomplete tasks modal
   const [showIncompleteTasks, setShowIncompleteTasks] = useState(null); // null | 'today' | 'allTime'
+  const [dailyStatsHabitsCollapsed, setDailyStatsHabitsCollapsed] = useState(true);
+  const [dailyStatsAllTimeCollapsed, setDailyStatsAllTimeCollapsed] = useState(true);
 
   // Spotlight search
   const [showSpotlight, setShowSpotlight] = useState(false);
@@ -6368,6 +6370,8 @@ const DayPlanner = () => {
     editingRecurrenceTaskId, setEditingRecurrenceTaskId,
     showRecurrenceEndDatePicker, setShowRecurrenceEndDatePicker,
     showIncompleteTasks, setShowIncompleteTasks,
+    dailyStatsHabitsCollapsed, setDailyStatsHabitsCollapsed,
+    dailyStatsAllTimeCollapsed, setDailyStatsAllTimeCollapsed,
     showShortcutHelp, setShowShortcutHelp,
     showHelpModal, setShowHelpModal,
 


### PR DESCRIPTION
## Summary

`dailyStatsHabitsCollapsed` / `setDailyStatsHabitsCollapsed` and `dailyStatsAllTimeCollapsed` / `setDailyStatsAllTimeCollapsed` were destructured from context in `MobileBottomSheets.jsx` but never defined in `App.jsx`. Clicking either chevron threw `TypeError: A is not a function` (minified `set…` setter).

Adds both `useState` declarations (default collapsed = `true`) and exposes them in the context object.

## Test plan

- [ ] Mobile daily summary: Habit Streaks chevron expands/collapses without error
- [ ] Mobile daily summary: All-Time Summary chevron expands/collapses without error

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV