### PR TITLE
Add 'Goal due today' yellow banner to daily summary

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -678,6 +678,7 @@ const DayPlanner = () => {
     allTimeProjectsCompleted,
     todayCompletedGoals,
     todayCompletedProjects,
+    todayDueGoals,
     consecutiveDayStreak,
     todayIncompleteTasks,
     allTimeIncompleteTasks,
@@ -6644,7 +6645,7 @@ const DayPlanner = () => {
     allTimeUnscheduledProjectDoneCount, allTimeUnscheduledProjectDoneMinutes,
     allTimeGoalsCreated, allTimeGoalsCompleted,
     allTimeProjectsCreated, allTimeProjectsCompleted,
-    todayCompletedGoals, todayCompletedProjects,
+    todayCompletedGoals, todayCompletedProjects, todayDueGoals,
     consecutiveDayStreak,
     todayIncompleteTasks, allTimeIncompleteTasks,
 
@@ -7473,8 +7474,14 @@ const DayPlanner = () => {
                         )}
                       </div>
                     </div>
-                    {goalsProjectsEnabled && (todayCompletedGoals.length > 0 || todayCompletedProjects.length > 0) && (
+                    {goalsProjectsEnabled && (todayDueGoals.length > 0 || todayCompletedGoals.length > 0 || todayCompletedProjects.length > 0) && (
                       <div className="space-y-1.5 mb-3">
+                        {todayDueGoals.map(g => (
+                          <div key={g.id} className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium ${darkMode ? 'bg-yellow-900/30 text-yellow-300' : 'bg-yellow-50 text-yellow-700'}`}>
+                            <Target size={14} className="flex-shrink-0" />
+                            <span className="truncate">Goal due today: {g.title}</span>
+                          </div>
+                        ))}
                         {todayCompletedGoals.map(g => (
                           <div key={g.id} className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium ${darkMode ? 'bg-amber-900/30 text-amber-300' : 'bg-amber-50 text-amber-700'}`}>
                             <Flag size={14} className="flex-shrink-0" />

--- a/src/components/MobileBottomSheets.jsx
+++ b/src/components/MobileBottomSheets.jsx
@@ -42,7 +42,7 @@ const MobileBottomSheets = () => {
     allTimeScheduledCount, allTimeCompletedCount,
     totalCompletedMinutes, totalScheduledMinutes,
     consecutiveDayStreak,
-    todayCompletedGoals, todayCompletedProjects,
+    todayCompletedGoals, todayCompletedProjects, todayDueGoals,
     allTimeGoalsCreated, allTimeGoalsCompleted,
     allTimeProjectsCreated, allTimeProjectsCompleted,
     allTimeIncompleteTasks,
@@ -301,8 +301,14 @@ const MobileBottomSheets = () => {
               </div>
             </div>
             {/* Goal / Project completion callouts */}
-            {goalsProjectsEnabled && (todayCompletedGoals.length > 0 || todayCompletedProjects.length > 0) && (
+            {goalsProjectsEnabled && (todayDueGoals.length > 0 || todayCompletedGoals.length > 0 || todayCompletedProjects.length > 0) && (
               <div className="space-y-1.5 mb-3">
+                {todayDueGoals.map(g => (
+                  <div key={g.id} className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium ${darkMode ? 'bg-yellow-900/30 text-yellow-300' : 'bg-yellow-50 text-yellow-700'}`}>
+                    <Target size={14} className="flex-shrink-0" />
+                    <span className="truncate">Goal due today: {g.title}</span>
+                  </div>
+                ))}
                 {todayCompletedGoals.map(g => (
                   <div key={g.id} className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium ${darkMode ? 'bg-amber-900/30 text-amber-300' : 'bg-amber-50 text-amber-700'}`}>
                     <Flag size={14} className="flex-shrink-0" />

--- a/src/hooks/useStats.js
+++ b/src/hooks/useStats.js
@@ -115,6 +115,9 @@ export default function useStats({ tasks, unscheduledTasks, recurringTasks, goal
   const todayCompletedGoals = goals.filter(g => g.status === 'completed' && g.updatedAt?.startsWith(todayStr));
   const todayCompletedProjects = projects.filter(p => p.status === 'completed' && p.updatedAt?.startsWith(todayStr));
 
+  // Incomplete goals due today
+  const todayDueGoals = goals.filter(g => g.targetDate === todayStr && g.status !== 'completed');
+
   // Consecutive day streak — count of consecutive days (going back from today)
   // on which at least one task was completed
   const consecutiveDayStreak = useMemo(() => {
@@ -211,6 +214,7 @@ export default function useStats({ tasks, unscheduledTasks, recurringTasks, goal
     allTimeProjectsCompleted,
     todayCompletedGoals,
     todayCompletedProjects,
+    todayDueGoals,
     consecutiveDayStreak,
     todayIncompleteTasks,
     allTimeIncompleteTasks,


### PR DESCRIPTION
## Summary

Adds a yellow banner in the daily summary for incomplete goals whose `targetDate` is today. Appears above the existing goal/project completion callouts (due-today has higher urgency than already-completed).

- `useStats.js`: computes `todayDueGoals` (incomplete goals with `targetDate === today`)
- `App.jsx` + `MobileBottomSheets.jsx`: renders the banner with a `Target` icon in yellow/amber

## Test plan

- [x] Goal with `targetDate` = today and status ≠ completed → yellow "Goal due today: …" banner appears in daily summary (desktop and mobile)
- [x] Goal completed today → amber "Goal complete: …" banner still shows correctly
- [x] No goals due today → section hidden as before

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV