### PR TITLE
Fix weekly review: include goals due today in next 7 days

### DIFF
--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -407,7 +407,7 @@ const WeeklyReviewModal = () => {
 
         // Goals due in next 7 days (only goals with targetDate in range)
         const nextWeekDueGoals = goalsProjectsEnabled
-          ? goals.filter(g => g.status === 'active' && g.targetDate && g.targetDate >= nextStartStr && g.targetDate <= nextEndStr)
+          ? goals.filter(g => g.status === 'active' && g.targetDate && g.targetDate >= todayStr && g.targetDate <= nextEndStr)
               .map(g => {
                 const progress = calculateGoalProgress(g.id, projects, allTasksCombined);
                 const target = new Date(g.targetDate + 'T12:00:00');


### PR DESCRIPTION
## Summary

`nextStartStr` is tomorrow (`today + 1`), so goals with `targetDate === today` were excluded from the "next 7 days" goal list. Change the lower bound of the filter from `nextStartStr` to `todayStr` so goals due today are included.

## Test plan

- [x] Goal with `targetDate` = today appears in Weekly Review → Next 7 Days goal list
- [x] Goal with `targetDate` = tomorrow still appears
- [x] Goal with `targetDate` > 7 days away does not appear

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV