### PR TITLE
Fix weekly review showing "Due tomorrow" for goals due today

### DIFF
--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -410,7 +410,7 @@ const WeeklyReviewModal = () => {
           ? goals.filter(g => g.status === 'active' && g.targetDate && g.targetDate >= todayStr && g.targetDate <= nextEndStr)
               .map(g => {
                 const progress = calculateGoalProgress(g.id, projects, allTasksCombined);
-                const target = new Date(g.targetDate + 'T12:00:00');
+                const target = new Date(g.targetDate + 'T00:00:00');
                 const todayMidnight = new Date(todayStr + 'T00:00:00');
                 const daysLeft = Math.ceil((target - todayMidnight) / (1000 * 60 * 60 * 24));
                 const childProjects = projects.filter(p => p.goalId === g.id && p.status !== 'archived');


### PR DESCRIPTION
## Summary

- Fixed `daysLeft` calculation in `WeeklyReviewModal.jsx` using `T12:00:00` as the time component, causing `Math.ceil(0.5) = 1` for goals due today → displayed "Due tomorrow"
- Changed to `T00:00:00` so `Math.ceil(0) = 0` → correctly displays "Due today"

## Root Cause

```javascript
// Before — midnight UTC offset caused 0.5-day remainder → "Due tomorrow"
const target = new Date(g.targetDate + 'T12:00:00');

// After — clean zero difference → "Due today"
const target = new Date(g.targetDate + 'T00:00:00');
```