### PR TITLE
Fix all-day section wider than timeline when tasks present

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -187,7 +187,7 @@ const CalendarHeader = () => {
       return (
         <div
           key={dateStr}
-          className={`flex-1 p-2 space-y-1 ${idx > 0 ? `border-l ${borderClass}` : ''} ${isDragOverThis || (isTablet && mobileDragPreviewTime === 'all-day') ? (darkMode ? 'bg-green-700/50' : 'bg-green-100') : ''}`}
+          className={`flex-1 min-w-0 p-2 space-y-1 ${idx > 0 ? `border-l ${borderClass}` : ''} ${isDragOverThis || (isTablet && mobileDragPreviewTime === 'all-day') ? (darkMode ? 'bg-green-700/50' : 'bg-green-100') : ''}`}
           onDragOver={(e) => { e.preventDefault(); if (autoScrollInterval.current) { clearInterval(autoScrollInterval.current); autoScrollInterval.current = null; } }}
           onDragEnter={(e) => {
             e.preventDefault();
@@ -375,7 +375,7 @@ const CalendarHeader = () => {
                     <GripVertical size={14} />
                   </div>
                 )}
-                <div className={isTablet && !isImported ? 'relative flex-1 min-w-0 rounded-lg overflow-hidden' : 'relative'}>
+                <div className={isTablet && !isImported ? 'relative flex-1 min-w-0 rounded-lg overflow-hidden' : 'relative overflow-hidden'}>
                 <div
                 {...(isTablet && !isImported ? {
                   onTouchStart: (e) => handleMobileTaskTouchStart(e, task, 'allday'),


### PR DESCRIPTION
## Summary

- Add `min-w-0` to the all-day date column flex items (`flex-1`) so they cannot grow beyond their flex allocation when task card content is wide
- Add `overflow-hidden` to the desktop regular all-day task inner wrapper, matching the existing tablet behaviour

Without `min-w-0`, a `flex-1` item has `min-width: auto` by default, meaning its minimum size is determined by its content. A long task name (or any content wider than the column's share of space) could push the column — and therefore the entire all-day row — wider than the date header and time grid rows, causing the misalignment visible at certain screen widths.

## Test plan

- [ ] Add an all-day task and/or a deadline task to the current date
- [ ] Resize the window between ~1000px and ~1600px and confirm the all-day section stays the same width as the date header row above and the time grid below
- [ ] Confirm the all-day section alignment holds on both 1-day and 2-day layouts
- [ ] Confirm the DeadlinePickerPopover still appears correctly (not clipped) when clicking the deadline icon on a deadline task
- [ ] Check dark mode as well

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV