### PR TITLE
Don't clear keepUnscheduled when changing project in edit modal

### DIFF
--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -151,7 +151,7 @@ const DesktopNewTaskModal = () => {
                       const pid = e.target.value || null;
                       const proj = pid ? projects.find(p => p.id === pid) : null;
                       const parentGoal = proj?.goalId ? goals.find(g => g.id === proj.goalId) : null;
-                      setNewTask({ ...newTask, projectId: pid, keepUnscheduled: false, ...(parentGoal?.color ? { color: parentGoal.color } : {}) });
+                      setNewTask({ ...newTask, projectId: pid, ...(parentGoal?.color ? { color: parentGoal.color } : {}) });
                     }}
                     className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
                   >

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -117,7 +117,7 @@ const MobileNewTaskModal = () => {
                       const pid = e.target.value || null;
                       const proj = pid ? projects.find(p => p.id === pid) : null;
                       const parentGoal = proj?.goalId ? goals.find(g => g.id === proj.goalId) : null;
-                      setNewTask({ ...newTask, projectId: pid, keepUnscheduled: false, ...(parentGoal?.color ? { color: parentGoal.color } : {}) });
+                      setNewTask({ ...newTask, projectId: pid, ...(parentGoal?.color ? { color: parentGoal.color } : {}) });
                     }}
                     className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
                   >


### PR DESCRIPTION
## Summary

- Changing the parent project in the task edit modal was unconditionally setting `keepUnscheduled: false`, silently switching unscheduled tasks to scheduled
- Removed that forced reset in both `DesktopNewTaskModal` and `MobileNewTaskModal` — the existing value is now preserved
- The only way `keepUnscheduled` changes is if the user explicitly checks/unchecks the "Unscheduled" checkbox

## Test plan

- [ ] Open an existing unscheduled project task (one with no date/time on a project card)
- [ ] Change its project to a different project — confirm the Unscheduled checkbox stays checked and the task remains unscheduled after saving
- [ ] Open the same task and manually uncheck Unscheduled — confirm it becomes scheduled as expected
- [ ] Create a new task, select a project, confirm the Unscheduled checkbox defaults correctly (unchecked)

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV