### PR TITLE
Reorder mobile tabs: Goals before Routines

### DIFF
--- a/src/components/MobileTabBar.jsx
+++ b/src/components/MobileTabBar.jsx
@@ -95,21 +95,6 @@ const MobileTabBar = () => {
           </div>
           {showLabels && <span className="text-[10px] font-medium">Inbox</span>}
         </button>
-        {routinesEnabled && (
-        <button
-          onClick={() => {
-            setMobileActiveTab('routines');
-            setMobileSettingsView('main');
-            setDashboardSelectedChips(todayRoutines.map(r => ({ id: r.id, name: r.name, bucket: r.bucket, startTime: r.startTime || null })));
-            setRoutineAddingToBucket(null);
-            setRoutineNewChipName('');
-          }}
-          className={`flex flex-col items-center justify-center ${showLabels ? 'gap-0.5' : ''} flex-1 h-full ${mobileActiveTab === 'routines' ? 'text-blue-500' : textSecondary}`}
-        >
-          <Sparkles size={iconSize} />
-          {showLabels && <span className="text-[10px] font-medium">Routines</span>}
-        </button>
-        )}
         {goalsProjectsEnabled && (
         <button
           onClick={() => {
@@ -128,6 +113,21 @@ const MobileTabBar = () => {
             )}
           </div>
           {showLabels && <span className="text-[10px] font-medium">Goals</span>}
+        </button>
+        )}
+        {routinesEnabled && (
+        <button
+          onClick={() => {
+            setMobileActiveTab('routines');
+            setMobileSettingsView('main');
+            setDashboardSelectedChips(todayRoutines.map(r => ({ id: r.id, name: r.name, bucket: r.bucket, startTime: r.startTime || null })));
+            setRoutineAddingToBucket(null);
+            setRoutineNewChipName('');
+          }}
+          className={`flex flex-col items-center justify-center ${showLabels ? 'gap-0.5' : ''} flex-1 h-full ${mobileActiveTab === 'routines' ? 'text-blue-500' : textSecondary}`}
+        >
+          <Sparkles size={iconSize} />
+          {showLabels && <span className="text-[10px] font-medium">Routines</span>}
         </button>
         )}
         <button


### PR DESCRIPTION
## Summary

Swaps the Goals and Routines tabs so the mobile tab bar order is:

**GLANCE › Timeline › Inbox › Goals › Routines › Settings**

Single change in `MobileTabBar.jsx` — the Goals button block moved before the Routines button block.

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV