### PR TITLE
Add project count and completion % to mobile goal card

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -1261,6 +1261,17 @@ const MobileDashboard = ({
                           <GoalProgress progress={goalProgress} color={goalColor} />
                         </div>
                       )}
+                      {/* Project count + completion % */}
+                      {!isCompleted && nonArchivedProjects.length > 0 && (
+                        <div className="flex items-center justify-between mt-1.5">
+                          <span className={`text-xs ${textSecondary}`}>
+                            {nonArchivedProjects.length} project{nonArchivedProjects.length !== 1 ? 's' : ''}
+                          </span>
+                          <span className={`text-xs font-medium ${goalProgress >= 1 ? 'text-green-500' : textSecondary}`}>
+                            {Math.round(goalProgress * 100)}%
+                          </span>
+                        </div>
+                      )}
                     </div>
                   );
                 })()}


### PR DESCRIPTION
## Summary

The mobile Goals tab uses an inline custom goal header card inside `MobileDashboard` that was missing the project count and completion percentage shown on desktop/tablet (which uses the `GoalCard` component).

Added the matching stats row — `N projects` on the left and `X%` on the right — below the progress bar, visible when the goal is active and has at least one project.

## Test plan

- [x] Open the Goals tab on mobile — confirm the goal header card now shows e.g. "2 projects" and "67%" below the progress bar
- [x] Confirm a goal with 0 projects doesn't show the stats row (empty state message instead)
- [x] Confirm a completed goal doesn't show the stats row (consistent with GoalCard behaviour)
- [x] Check dark mode

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV