### PR TITLE
Add '+' button to goal card for adding projects

### DIFF
--- a/src/components/goals/GoalCard.jsx
+++ b/src/components/goals/GoalCard.jsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import { AlertTriangle, Calendar, CircleCheckBig, Edit2, FolderOpen, Layers } from 'lucide-react';
+import { AlertTriangle, Calendar, CircleCheckBig, Edit2, FolderOpen, Layers, Plus } from 'lucide-react';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { calculateGoalProgress } from '../../utils/goalProgress.js';
 import { isProjectStalled } from '../../utils/projectProgress.js';
@@ -140,9 +140,21 @@ const GoalCard = forwardRef(
             </div>
           ) : (
             <div className="flex items-center justify-between">
-              <span className={`text-xs ${textSecondary}`}>
-                {projects.length} project{projects.length !== 1 ? 's' : ''}
-              </span>
+              <div className="flex items-center gap-1.5">
+                <span className={`text-xs ${textSecondary}`}>
+                  {projects.length} project{projects.length !== 1 ? 's' : ''}
+                </span>
+                {onNewProject && (
+                  <button
+                    type="button"
+                    onClick={onNewProject}
+                    className={`p-0.5 rounded transition-colors ${textSecondary} hover:text-emerald-500`}
+                    aria-label="Add project"
+                  >
+                    <Plus size={11} />
+                  </button>
+                )}
+              </div>
               <span className={`text-xs font-medium ${progress >= 1 ? 'text-green-500' : textSecondary}`}>
                 {Math.round(progress * 100)}%
               </span>

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -21,6 +21,7 @@ import {
   GripVertical,
   Layers,
   LogIn,
+  Plus,
   RotateCcw,
   X,
 } from 'lucide-react';
@@ -1264,9 +1265,19 @@ const MobileDashboard = ({
                       {/* Project count + completion % */}
                       {!isCompleted && nonArchivedProjects.length > 0 && (
                         <div className="flex items-center justify-between mt-1.5">
-                          <span className={`text-xs ${textSecondary}`}>
-                            {nonArchivedProjects.length} project{nonArchivedProjects.length !== 1 ? 's' : ''}
-                          </span>
+                          <div className="flex items-center gap-1.5">
+                            <span className={`text-xs ${textSecondary}`}>
+                              {nonArchivedProjects.length} project{nonArchivedProjects.length !== 1 ? 's' : ''}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => onNewProject(goal.id)}
+                              className={`p-0.5 rounded transition-colors ${textSecondary} hover:text-emerald-500`}
+                              aria-label="Add project"
+                            >
+                              <Plus size={11} />
+                            </button>
+                          </div>
                           <span className={`text-xs font-medium ${goalProgress >= 1 ? 'text-green-500' : textSecondary}`}>
                             {Math.round(goalProgress * 100)}%
                           </span>


### PR DESCRIPTION
## Summary

- **GoalCard** (desktop/tablet): added a small `+` button inline with the project count label. Clicking it opens the New Project modal with that goal pre-selected.
- **MobileDashboard inline goal card**: same `+` button added next to the project count we added in #310.
- **Empty-state "Add project" buttons**: both the GoalCard empty state and the mobile inline card empty state already correctly pass the goal id to `onNewProject`, so no change needed there.

The `+` uses the same `onNewProject(goalId)` call path as the empty-state button, so the New Project form opens with the goal pre-selected in both cases.

## Test plan

- [ ] On desktop: open Goals dashboard → goal with projects → confirm `+` appears next to "N projects", clicking it opens New Project modal with the correct goal pre-selected
- [ ] On desktop: goal with no projects → confirm "Add project" in the empty state opens New Project modal with the correct goal pre-selected
- [ ] On mobile: Goals tab → goal with projects → confirm `+` appears next to project count, clicking it opens New Project modal with goal pre-selected
- [ ] On mobile: goal with no projects → confirm "Add project" in the empty state opens New Project modal with goal pre-selected

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV