### PR TITLE
Fix goal pre-selection in New Project modal; restyle Add button

### DIFF
--- a/src/components/goals/GoalCard.jsx
+++ b/src/components/goals/GoalCard.jsx
@@ -140,7 +140,7 @@ const GoalCard = forwardRef(
             </div>
           ) : (
             <div className="flex items-center justify-between">
-              <div className="flex items-center gap-1.5">
+              <div className="flex items-center gap-2">
                 <span className={`text-xs ${textSecondary}`}>
                   {projects.length} project{projects.length !== 1 ? 's' : ''}
                 </span>
@@ -148,10 +148,9 @@ const GoalCard = forwardRef(
                   <button
                     type="button"
                     onClick={onNewProject}
-                    className={`p-0.5 rounded transition-colors ${textSecondary} hover:text-emerald-500`}
-                    aria-label="Add project"
+                    className={`flex items-center gap-0.5 text-xs ${textSecondary} opacity-60 hover:opacity-100 transition-opacity`}
                   >
-                    <Plus size={11} />
+                    <Plus size={10} /> Add
                   </button>
                 )}
               </div>

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -260,13 +260,13 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
 
 // ─── Project form (create / edit) ─────────────────────────────────────────────
 
-const ProjectForm = ({ initial, goals, onSave, onCancel, mobile }) => {
+const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, mobile }) => {
   const { darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg, tasks, unscheduledTasks } =
     useDayPlannerCtx();
 
   const [title, setTitle] = useState(initial?.title || '');
   const [description, setDescription] = useState(initial?.description || '');
-  const [goalId, setGoalId] = useState(initial?.goalId || '');
+  const [goalId, setGoalId] = useState(initial?.goalId || defaultGoalId || '');
   const [status, setStatus] = useState(initial?.status || 'active');
 
   // "Completed" only available when all project tasks are completed (or none exist)
@@ -1265,17 +1265,16 @@ const MobileDashboard = ({
                       {/* Project count + completion % */}
                       {!isCompleted && nonArchivedProjects.length > 0 && (
                         <div className="flex items-center justify-between mt-1.5">
-                          <div className="flex items-center gap-1.5">
+                          <div className="flex items-center gap-2">
                             <span className={`text-xs ${textSecondary}`}>
                               {nonArchivedProjects.length} project{nonArchivedProjects.length !== 1 ? 's' : ''}
                             </span>
                             <button
                               type="button"
                               onClick={() => onNewProject(goal.id)}
-                              className={`p-0.5 rounded transition-colors ${textSecondary} hover:text-emerald-500`}
-                              aria-label="Add project"
+                              className={`flex items-center gap-0.5 text-xs ${textSecondary} opacity-60 hover:opacity-100 transition-opacity`}
                             >
-                              <Plus size={11} />
+                              <Plus size={10} /> Add
                             </button>
                           </div>
                           <span className={`text-xs font-medium ${goalProgress >= 1 ? 'text-green-500' : textSecondary}`}>


### PR DESCRIPTION
## Summary

Two fixes:

**1. Goal not pre-selected when opening New Project modal**  
`ProjectForm` accepted a `defaultGoalId` prop but never destructured it — the prop was silently dropped. The `goalId` state was always initialised from `initial?.goalId` only. Fixed by adding `defaultGoalId` to the destructured props and using it as a fallback: `useState(initial?.goalId || defaultGoalId || '')`.

**2. Button style** — replaced the icon-only `+` button with a subdued `+ Add` text button (same secondary text color at 60% opacity, full opacity on hover) in both `GoalCard` and the `MobileDashboard` inline goal card.

## Test plan

- [ ] Goal with projects: click `+ Add` → New Project modal opens with that goal pre-selected in the Goal dropdown
- [ ] Goal with no projects: click `Add project` in the empty state → same pre-selection
- [ ] Editing an existing project: goal dropdown still shows the project's existing goal (not overridden by defaultGoalId)
- [ ] `+ Add` button is visible but not distracting alongside the project count

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV