### PR TITLE
Pass defaultGoalId to ProjectForm in desktop/tablet render

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -1854,6 +1854,7 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
           <ProjectForm
             initial={projectForm.editing}
             goals={goals}
+            defaultGoalId={projectForm.defaultGoalId}
             onSave={handleSaveProject}
             onCancel={() => setProjectForm(null)}
             mobile={isMobile}


### PR DESCRIPTION
## Summary

One-line fix: the desktop/tablet `ProjectForm` render was missing `defaultGoalId={projectForm.defaultGoalId}`. The mobile embedded path already had it (added in #312), but the desktop path didn't, so goal pre-selection never took effect there.

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV