### PR TITLE
Cascade archive for goals and projects

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -1485,7 +1485,8 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
   const {
     showGoalsDashboard, setShowGoalsDashboard,
     goals, projects,
-    tasks,
+    tasks, setTasks,
+    unscheduledTasks, setUnscheduledTasks,
     addGoal, updateGoal, deleteGoal,
     addProject, updateProject,
     enterProjectFocusMode,
@@ -1519,6 +1520,20 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
 
   const handleSaveGoal = (fields) => {
     if (goalForm.editing) {
+      const wasArchived = goalForm.editing.status === 'archived';
+      const nowArchived = fields.status === 'archived';
+      if (nowArchived && !wasArchived) {
+        // Cascade: archive completed child projects; detach incomplete ones as standalone
+        projects
+          .filter(p => p.goalId === goalForm.editing.id)
+          .forEach(p => {
+            if (p.status === 'completed') {
+              updateProject(p.id, { status: 'archived' });
+            } else {
+              updateProject(p.id, { goalId: undefined });
+            }
+          });
+      }
       updateGoal(goalForm.editing.id, fields);
     } else {
       addGoal(fields);
@@ -1543,6 +1558,20 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
 
   const handleSaveProject = (fields) => {
     if (projectForm.editing) {
+      const wasArchived = projectForm.editing.status === 'archived';
+      const nowArchived = fields.status === 'archived';
+      if (nowArchived && !wasArchived) {
+        // Cascade: archive completed tasks; detach incomplete tasks from this project
+        const projectId = projectForm.editing.id;
+        setTasks(prev => prev.map(t => {
+          if (t.projectId !== projectId) return t;
+          return t.completed ? { ...t, archived: true } : { ...t, projectId: undefined };
+        }));
+        setUnscheduledTasks(prev => prev.map(t => {
+          if (t.projectId !== projectId) return t;
+          return t.completed ? { ...t, archived: true } : { ...t, projectId: undefined };
+        }));
+      }
       updateProject(projectForm.editing.id, fields);
     } else {
       addProject(fields);


### PR DESCRIPTION
## Summary

Cascade archive behaviour, both triggered only when transitioning from non-archived → archived (re-archiving an already-archived item is a no-op for cascades).

**Archiving a Goal**
- Completed child projects → also archived
- Incomplete child projects → `goalId` removed, become standalone projects

**Archiving a Project**
- Completed tasks (scheduled + unscheduled) → `archived: true`
- Incomplete tasks → `projectId` removed, become regular inbox/timeline tasks

Both cascades run inside `handleSaveGoal` / `handleSaveProject` in `GoalDashboard`, which is the single point where status changes are saved. Added `setTasks` and `setUnscheduledTasks` to the component's context pull.

## Test plan

- [ ] Archive a goal that has a mix of completed and incomplete projects → completed projects appear in the Archived section; incomplete projects reappear as standalone
- [ ] Archive a project that has a mix of completed and incomplete tasks → completed tasks are gone from the project; incomplete tasks appear in the inbox/timeline without a project badge
- [ ] Archiving a goal that was already archived does not re-cascade (safe to call twice)
- [ ] Editing a goal without changing status to archived makes no changes to projects
- [ ] Deleting a goal (not archiving) still just detaches all projects as standalone (existing behaviour unchanged)

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV