### PR TITLE
Improve search results: project badge, project navigation, archived handler

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -649,6 +649,7 @@ const DayPlanner = () => {
     isMobile,
     setMobileActiveTab,
     setTabletActiveTab,
+    setInboxProjectFilter,
     calendarRef,
   });
 

--- a/src/components/SpotlightModal.jsx
+++ b/src/components/SpotlightModal.jsx
@@ -63,12 +63,14 @@ const SpotlightModal = () => {
             const sourceBadgeColors = darkMode ? {
               scheduled: 'bg-blue-900/40 text-blue-300',
               inbox: 'bg-green-900/40 text-green-300',
+              project: 'bg-green-900/40 text-green-300',
               recurring: 'bg-purple-900/40 text-purple-300',
               deleted: 'bg-red-900/40 text-red-300',
               archived: 'bg-gray-700/60 text-gray-400',
             } : {
               scheduled: 'bg-blue-100 text-blue-700',
               inbox: 'bg-green-100 text-green-700',
+              project: 'bg-green-100 text-green-700',
               recurring: 'bg-purple-100 text-purple-700',
               deleted: 'bg-red-100 text-red-700',
               archived: 'bg-stone-200 text-stone-500',
@@ -115,9 +117,16 @@ const SpotlightModal = () => {
                       <span className={`text-xs ${textSecondary} flex-shrink-0`}>{result.date}</span>
                     )}
                     {/* Source badge */}
-                    <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full flex-shrink-0 ${sourceBadgeColors[result.source]}`}>
-                      {result.sourceLabel}
-                    </span>
+                    {(() => {
+                      const isProjectTask = result.source === 'inbox' && result.task.projectId;
+                      const badgeKey = isProjectTask ? 'project' : result.source;
+                      const label = isProjectTask ? 'Project' : result.sourceLabel;
+                      return (
+                        <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full flex-shrink-0 ${sourceBadgeColors[badgeKey]}`}>
+                          {label}
+                        </span>
+                      );
+                    })()}
                   </div>
                 </div>
               );

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -9,6 +9,7 @@ export default function useNavigation({
   isMobile,
   setMobileActiveTab,
   setTabletActiveTab,
+  setInboxProjectFilter,
   calendarRef,
 }) {
   const changeDate = useCallback((direction) => {
@@ -69,7 +70,18 @@ export default function useNavigation({
       } else {
         setTabletActiveTab('inbox');
       }
+      // If the task belongs to a project, pre-apply the project filter so it's visible
+      if (task.projectId) {
+        setInboxProjectFilter([task.projectId]);
+      }
       scrollAndHighlight(`[data-task-id="${task.id}"]`);
+    } else if (source === 'archived') {
+      if (isMobile) {
+        setMobileActiveTab('inbox');
+      } else {
+        setTabletActiveTab('inbox');
+      }
+      scrollAndHighlight(`[data-task-id="${task.id}"]`, 400);
     } else if (source === 'recurring') {
       const date = task.startDate || dateToString(new Date());
       if (isMobile) {
@@ -79,7 +91,7 @@ export default function useNavigation({
     } else if (source === 'deleted') {
       scrollAndHighlight(`[data-task-id="bin-${task.id}"]`);
     }
-  }, [setShowSpotlight, isMobile, setMobileActiveTab, setTabletActiveTab, calendarRef, goToDate]);
+  }, [setShowSpotlight, isMobile, setMobileActiveTab, setTabletActiveTab, setInboxProjectFilter, calendarRef, goToDate]);
 
   return { changeDate, goToToday, goToDate, handleSpotlightSelect };
 }


### PR DESCRIPTION
## Summary

Three targeted improvements to spotlight search results.

**1. Project badge**
Unscheduled tasks that belong to a project now show `Project` instead of `Inbox` in the source badge. Same green styling as `Inbox` — just a more accurate label. Scheduled project tasks are unchanged (their date/timeline location already conveys where they live).

**2. Smarter click navigation for project tasks**
Clicking a project-tagged inbox task now:
- Switches to the Inbox tab (desktop/tablet/mobile)
- Auto-applies `inboxProjectFilter` to that project, so the task is immediately visible rather than buried in the full inbox list
- Scrolls to and highlights the specific task

**3. Archived task click handler (bug fix)**
`source === 'archived'` previously had no handler — clicking did nothing. Now switches to the Inbox tab and scrolls to + highlights the task. Slight extra delay (400 ms vs 300 ms) to give the archived section time to render.

## Files changed
- `src/components/SpotlightModal.jsx` — project badge display
- `src/hooks/useNavigation.js` — project task routing + archived handler
- `src/App.jsx` — pass `setInboxProjectFilter` to `useNavigation`

## Test plan
- [x] Search for a task that belongs to a project → badge shows `Project` not `Inbox`
- [x] Click that result → Inbox tab opens, project filter is applied, task is highlighted
- [x] Search for a plain inbox task → badge still shows `Inbox`, click navigates to inbox normally (no filter applied)
- [x] Search for an archived task → click navigates to Inbox and highlights it
- [x] Scheduled tasks, recurring, and deleted results are unaffected

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV