### PR TITLE
Fix four inbox improvements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -336,6 +336,7 @@ const DayPlanner = () => {
   const [inboxProjectFilter, setInboxProjectFilter] = useState(() => {
     try { return JSON.parse(localStorage.getItem('inboxProjectFilter') || '[]'); } catch { return []; }
   });
+  const [inboxArchivedExpanded, setInboxArchivedExpanded] = useState(false);
   const [priorityPromptDismissed, setPriorityPromptDismissed] = useState(() => {
     return localStorage.getItem('priorityPromptDismissed') === 'true';
   });
@@ -650,6 +651,7 @@ const DayPlanner = () => {
     setMobileActiveTab,
     setTabletActiveTab,
     setInboxProjectFilter,
+    setInboxArchivedExpanded,
     calendarRef,
   });
 
@@ -6342,6 +6344,7 @@ const DayPlanner = () => {
     hideStandaloneTasksInbox, setHideStandaloneTasksInbox,
     inboxTagFilter, setInboxTagFilter,
     inboxProjectFilter, setInboxProjectFilter,
+    inboxArchivedExpanded, setInboxArchivedExpanded,
     priorityPromptDismissed, setPriorityPromptDismissed,
     sectionInfoDismissed, setSectionInfoDismissed,
     expandedSectionInfo, setExpandedSectionInfo,

--- a/src/components/InboxArchivedBar.jsx
+++ b/src/components/InboxArchivedBar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Archive, ChevronDown, RotateCcw } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 
@@ -8,9 +8,9 @@ const InboxArchivedBar = () => {
     unscheduledTasks,
     restoreArchivedInboxTask,
     goalsProjectsEnabled, projects,
+    inboxArchivedExpanded: expanded,
+    setInboxArchivedExpanded: setExpanded,
   } = useDayPlannerCtx();
-
-  const [expanded, setExpanded] = useState(false);
 
   const archivedTasks = unscheduledTasks.filter(t => t.archived && !t.imported);
 
@@ -39,6 +39,7 @@ const InboxArchivedBar = () => {
             return (
               <div
                 key={task.id}
+                data-task-id={task.id}
                 className={`flex items-center gap-1.5 px-2 py-1.5 rounded-lg ${hoverBg} min-w-0`}
               >
                 <span className={`text-xs ${textSecondary} flex-1 min-w-0 truncate line-through opacity-60`}>

--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -548,79 +548,81 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
                     </div>
                   </div>
                 </div>
-                <div className="flex items-center gap-1 flex-shrink-0">
-                  <button
-                    onMouseDown={() => {
-                      if (isLinkOnlyTask(task)) {
-                        longPressTriggeredRef.current = false;
-                        longPressTimerRef.current = setTimeout(() => {
-                          longPressTriggeredRef.current = true;
-                          setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
-                        }, 500);
-                      }
-                    }}
-                    onMouseUp={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
-                    onMouseLeave={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (isLinkOnlyTask(task)) {
-                        if (!longPressTriggeredRef.current) {
-                          window.open(getLinkUrl(task), '_blank', 'noopener,noreferrer');
+                <div className="flex flex-col items-end gap-1 flex-shrink-0">
+                  <div className="flex items-center gap-1">
+                    <button
+                      onMouseDown={() => {
+                        if (isLinkOnlyTask(task)) {
+                          longPressTriggeredRef.current = false;
+                          longPressTimerRef.current = setTimeout(() => {
+                            longPressTriggeredRef.current = true;
+                            setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
+                          }, 500);
                         }
-                        longPressTriggeredRef.current = false;
-                      } else {
-                        setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
-                      }
-                    }}
-                    className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${hasNotesOrSubtasks(task) || (task.importSource === 'obsidian' && extractWikilinks(task.title).length > 0) ? '' : 'opacity-40'}`}
-                  >
-                    {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
-                  </button>
-                  <div className="deadline-picker-container relative">
+                      }}
+                      onMouseUp={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
+                      onMouseLeave={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (isLinkOnlyTask(task)) {
+                          if (!longPressTriggeredRef.current) {
+                            window.open(getLinkUrl(task), '_blank', 'noopener,noreferrer');
+                          }
+                          longPressTriggeredRef.current = false;
+                        } else {
+                          setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
+                        }
+                      }}
+                      className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${hasNotesOrSubtasks(task) || (task.importSource === 'obsidian' && extractWikilinks(task.title).length > 0) ? '' : 'opacity-40'}`}
+                    >
+                      {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
+                    </button>
+                    <div className="deadline-picker-container relative">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setShowDeadlinePicker(showDeadlinePicker === task.id ? null : task.id);
+                        }}
+                        className={`hover:bg-white/20 rounded p-1 transition-colors ${task.deadline ? 'bg-white/20' : 'opacity-40'}`}
+                        title={task.deadline ? `Deadline: ${formatDeadlineDate(task.deadline)}` : 'Set deadline'}
+                      >
+                        <Calendar size={14} />
+                      </button>
+                      {showDeadlinePicker === task.id && (
+                        <DeadlinePickerPopover
+                          taskId={task.id}
+                          currentDeadline={task.deadline}
+                          onClose={() => setShowDeadlinePicker(null)}
+                        />
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between w-full">
+                    {task.completed ? (
+                      <button
+                        onClick={(e) => { e.stopPropagation(); archiveInboxTask(task.id); }}
+                        className="flex items-center gap-0.5 hover:bg-white/20 rounded px-1.5 py-1 transition-colors opacity-60 hover:opacity-100"
+                        title="Archive task"
+                      >
+                        <Archive size={11} className="text-white" />
+                      </button>
+                    ) : <span />}
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
-                        setShowDeadlinePicker(showDeadlinePicker === task.id ? null : task.id);
+                        cyclePriority(task.id);
                       }}
-                      className={`hover:bg-white/20 rounded p-1 transition-colors ${task.deadline ? 'bg-white/20' : 'opacity-40'}`}
-                      title={task.deadline ? `Deadline: ${formatDeadlineDate(task.deadline)}` : 'Set deadline'}
+                      className="flex gap-0.5 hover:bg-white/20 rounded px-1.5 py-1 transition-colors"
                     >
-                      <Calendar size={14} />
+                      {[0, 1, 2].map(i => (
+                        <span
+                          key={i}
+                          className={`w-2 h-0.5 rounded-full bg-white ${i < (pendingPriorities[task.id] ?? task.priority ?? 0) ? 'opacity-100' : 'opacity-30'}`}
+                        />
+                      ))}
                     </button>
-                    {showDeadlinePicker === task.id && (
-                      <DeadlinePickerPopover
-                        taskId={task.id}
-                        currentDeadline={task.deadline}
-                        onClose={() => setShowDeadlinePicker(null)}
-                      />
-                    )}
                   </div>
                 </div>
-              </div>
-              <div className="flex items-center justify-between mt-1.5">
-                {task.completed ? (
-                  <button
-                    onClick={(e) => { e.stopPropagation(); archiveInboxTask(task.id); }}
-                    className="flex items-center gap-0.5 hover:bg-white/20 rounded px-1.5 py-1 transition-colors opacity-60 hover:opacity-100"
-                    title="Archive task"
-                  >
-                    <Archive size={11} className="text-white" />
-                  </button>
-                ) : <span />}
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    cyclePriority(task.id);
-                  }}
-                  className="flex gap-0.5 hover:bg-white/20 rounded px-1.5 py-1 transition-colors"
-                >
-                  {[0, 1, 2].map(i => (
-                    <span
-                      key={i}
-                      className={`w-2 h-0.5 rounded-full bg-white ${i < (pendingPriorities[task.id] ?? task.priority ?? 0) ? 'opacity-100' : 'opacity-30'}`}
-                    />
-                  ))}
-                </button>
               </div>
             </div>
           {expandedNotesTaskId === task.id && (

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -960,79 +960,81 @@ const MobileLayout = () => {
                                   </div>
                                 </div>
                               </div>
-                              <div className="flex items-center gap-1 flex-shrink-0">
-                                <button
-                                  onMouseDown={() => {
-                                    if (isLinkOnlyTask(task)) {
-                                      longPressTriggeredRef.current = false;
-                                      longPressTimerRef.current = setTimeout(() => {
-                                        longPressTriggeredRef.current = true;
-                                        setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
-                                      }, 500);
-                                    }
-                                  }}
-                                  onMouseUp={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
-                                  onMouseLeave={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    if (isLinkOnlyTask(task)) {
-                                      if (!longPressTriggeredRef.current) {
-                                        window.open(getLinkUrl(task), '_blank', 'noopener,noreferrer');
+                              <div className="flex flex-col items-end gap-1 flex-shrink-0">
+                                <div className="flex items-center gap-1">
+                                  <button
+                                    onMouseDown={() => {
+                                      if (isLinkOnlyTask(task)) {
+                                        longPressTriggeredRef.current = false;
+                                        longPressTimerRef.current = setTimeout(() => {
+                                          longPressTriggeredRef.current = true;
+                                          setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
+                                        }, 500);
                                       }
-                                      longPressTriggeredRef.current = false;
-                                    } else {
-                                      setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
-                                    }
-                                  }}
-                                  className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${hasNotesOrSubtasks(task) || (task.importSource === 'obsidian' && extractWikilinks(task.title).length > 0) ? '' : 'opacity-40'}`}
-                                >
-                                  {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
-                                </button>
-                                <div className="deadline-picker-container relative">
+                                    }}
+                                    onMouseUp={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
+                                    onMouseLeave={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      if (isLinkOnlyTask(task)) {
+                                        if (!longPressTriggeredRef.current) {
+                                          window.open(getLinkUrl(task), '_blank', 'noopener,noreferrer');
+                                        }
+                                        longPressTriggeredRef.current = false;
+                                      } else {
+                                        setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
+                                      }
+                                    }}
+                                    className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${hasNotesOrSubtasks(task) || (task.importSource === 'obsidian' && extractWikilinks(task.title).length > 0) ? '' : 'opacity-40'}`}
+                                  >
+                                    {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
+                                  </button>
+                                  <div className="deadline-picker-container relative">
+                                    <button
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        setShowDeadlinePicker(showDeadlinePicker === task.id ? null : task.id);
+                                      }}
+                                      className={`hover:bg-white/20 rounded p-1 transition-colors ${task.deadline ? 'bg-white/20' : ''}`}
+                                      title={task.deadline ? `Deadline: ${formatDeadlineDate(task.deadline)}` : 'Set deadline'}
+                                    >
+                                      <Calendar size={14} />
+                                    </button>
+                                    {showDeadlinePicker === task.id && (
+                                      <DeadlinePickerPopover
+                                        taskId={task.id}
+                                        currentDeadline={task.deadline}
+                                        onClose={() => setShowDeadlinePicker(null)}
+                                      />
+                                    )}
+                                  </div>
+                                </div>
+                                <div className="flex items-center justify-between w-full">
+                                  {task.completed ? (
+                                    <button
+                                      onClick={(e) => { e.stopPropagation(); archiveInboxTask(task.id); }}
+                                      className="flex items-center gap-0.5 hover:bg-white/20 rounded px-1.5 py-1 transition-colors opacity-60 hover:opacity-100"
+                                      title="Archive task"
+                                    >
+                                      <Archive size={11} className="text-white" />
+                                    </button>
+                                  ) : <span />}
                                   <button
                                     onClick={(e) => {
                                       e.stopPropagation();
-                                      setShowDeadlinePicker(showDeadlinePicker === task.id ? null : task.id);
+                                      cyclePriority(task.id);
                                     }}
-                                    className={`hover:bg-white/20 rounded p-1 transition-colors ${task.deadline ? 'bg-white/20' : ''}`}
-                                    title={task.deadline ? `Deadline: ${formatDeadlineDate(task.deadline)}` : 'Set deadline'}
+                                    className="flex gap-0.5 hover:bg-white/20 rounded px-1.5 py-1 transition-colors"
                                   >
-                                    <Calendar size={14} />
+                                    {[0, 1, 2].map(i => (
+                                      <span
+                                        key={i}
+                                        className={`w-2 h-0.5 rounded-full bg-white ${i < (pendingPriorities[task.id] ?? task.priority ?? 0) ? 'opacity-100' : 'opacity-30'}`}
+                                      />
+                                    ))}
                                   </button>
-                                  {showDeadlinePicker === task.id && (
-                                    <DeadlinePickerPopover
-                                      taskId={task.id}
-                                      currentDeadline={task.deadline}
-                                      onClose={() => setShowDeadlinePicker(null)}
-                                    />
-                                  )}
                                 </div>
                               </div>
-                            </div>
-                            <div className="flex items-center justify-between mt-1.5">
-                              {task.completed ? (
-                                <button
-                                  onClick={(e) => { e.stopPropagation(); archiveInboxTask(task.id); }}
-                                  className="flex items-center gap-0.5 hover:bg-white/20 rounded px-1.5 py-1 transition-colors opacity-60 hover:opacity-100"
-                                  title="Archive task"
-                                >
-                                  <Archive size={11} className="text-white" />
-                                </button>
-                              ) : <span />}
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  cyclePriority(task.id);
-                                }}
-                                className="flex gap-0.5 hover:bg-white/20 rounded px-1.5 py-1 transition-colors"
-                              >
-                                {[0, 1, 2].map(i => (
-                                  <span
-                                    key={i}
-                                    className={`w-2 h-0.5 rounded-full bg-white ${i < (pendingPriorities[task.id] ?? task.priority ?? 0) ? 'opacity-100' : 'opacity-30'}`}
-                                  />
-                                ))}
-                              </button>
                             </div>
                           </div>
                         </div>

--- a/src/hooks/useComputedViews.js
+++ b/src/hooks/useComputedViews.js
@@ -81,7 +81,11 @@ export default function useComputedViews({
         const taskTags = extractTags(task.title);
         return inboxTagFilter.some(tag => taskTags.includes(tag));
       })
-      .sort((a, b) => (b.priority || 0) - (a.priority || 0)),
+      .sort((a, b) => {
+        // Completed tasks always sink below incomplete ones
+        if (a.completed !== b.completed) return a.completed ? 1 : -1;
+        return (b.priority || 0) - (a.priority || 0);
+      }),
     [unscheduledTasks, inboxPriorityFilter, hideCompletedInbox, hideProjectTasksInbox,
      hideStandaloneTasksInbox, inboxTagFilter, inboxProjectFilter, goalsProjectsEnabled]
   );

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -10,6 +10,7 @@ export default function useNavigation({
   setMobileActiveTab,
   setTabletActiveTab,
   setInboxProjectFilter,
+  setInboxArchivedExpanded,
   calendarRef,
 }) {
   const changeDate = useCallback((direction) => {
@@ -70,10 +71,8 @@ export default function useNavigation({
       } else {
         setTabletActiveTab('inbox');
       }
-      // If the task belongs to a project, pre-apply the project filter so it's visible
-      if (task.projectId) {
-        setInboxProjectFilter([task.projectId]);
-      }
+      // Apply project filter for project tasks; clear it for plain inbox tasks
+      setInboxProjectFilter(task.projectId ? [task.projectId] : []);
       scrollAndHighlight(`[data-task-id="${task.id}"]`);
     } else if (source === 'archived') {
       if (isMobile) {
@@ -81,7 +80,8 @@ export default function useNavigation({
       } else {
         setTabletActiveTab('inbox');
       }
-      scrollAndHighlight(`[data-task-id="${task.id}"]`, 400);
+      setInboxArchivedExpanded(true);
+      scrollAndHighlight(`[data-task-id="${task.id}"]`, 500);
     } else if (source === 'recurring') {
       const date = task.startDate || dateToString(new Date());
       if (isMobile) {
@@ -91,7 +91,7 @@ export default function useNavigation({
     } else if (source === 'deleted') {
       scrollAndHighlight(`[data-task-id="bin-${task.id}"]`);
     }
-  }, [setShowSpotlight, isMobile, setMobileActiveTab, setTabletActiveTab, setInboxProjectFilter, calendarRef, goToDate]);
+  }, [setShowSpotlight, isMobile, setMobileActiveTab, setTabletActiveTab, setInboxProjectFilter, setInboxArchivedExpanded, calendarRef, goToDate]);
 
   return { changeDate, goToToday, goToDate, handleSpotlightSelect };
 }


### PR DESCRIPTION
## Summary

- **Clear project filter on plain inbox navigation**: When clicking a non-project inbox task in search results, the inbox project filter is now cleared so the task is visible
- **Expand archived section on navigation**: Clicking an archived task in search results now expands `InboxArchivedBar` and scrolls/highlights the task (lifted `inboxArchivedExpanded` state to context)
- **Completed tasks sort below incomplete**: Inbox task list now sorts completed tasks to the bottom, with priority ordering within each group
- **Archive/priority buttons placement on tablet & mobile**: Moved archive and priority buttons to appear directly under the notes/deadline buttons (right-side column layout), matching how desktop already worked

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV