### PR TITLE
Hide wikilinks in notes panel headers and search results

### DIFF
--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -1017,7 +1017,7 @@ const MobileGlanceSection = () => {
           onClick={(e) => e.stopPropagation()}
         >
           <div className={`flex items-center justify-between p-4 border-b ${borderClass}`}>
-            <div className={`font-medium ${textPrimary} truncate flex-1`}>{agendaTask.title}</div>
+            <div className={`font-medium ${textPrimary} truncate flex-1`}>{renderTitle(agendaTask.title)}</div>
             <button onClick={() => setExpandedNotesTaskId(null)} className={`p-1 rounded-lg ${hoverBg} transition-colors`} aria-label="Close notes">
               <X size={18} className={textSecondary} />
             </button>

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -778,7 +778,7 @@ const MobileLayout = () => {
                         onClick={(e) => e.stopPropagation()}
                       >
                         <div className={`flex items-center justify-between p-4 border-b ${borderClass}`}>
-                          <div className={`font-medium ${textPrimary} truncate flex-1`}>{noteTask.title}</div>
+                          <div className={`font-medium ${textPrimary} truncate flex-1`}>{renderTitle(noteTask.title)}</div>
                           <button onClick={() => setExpandedNotesTaskId(null)} className={`p-1 rounded-lg ${hoverBg} transition-colors`} aria-label="Close notes">
                             <X size={18} className={textSecondary} />
                           </button>
@@ -1057,7 +1057,7 @@ const MobileLayout = () => {
                         onClick={(e) => e.stopPropagation()}
                       >
                         <div className={`flex items-center justify-between p-4 border-b ${borderClass}`}>
-                          <div className={`font-medium ${textPrimary} truncate flex-1`}>{noteTask.title}</div>
+                          <div className={`font-medium ${textPrimary} truncate flex-1`}>{renderTitle(noteTask.title)}</div>
                           <button onClick={() => setExpandedNotesTaskId(null)} className={`p-1 rounded-lg ${hoverBg} transition-colors`} aria-label="Close notes">
                             <X size={18} className={textSecondary} />
                           </button>

--- a/src/components/SpotlightModal.jsx
+++ b/src/components/SpotlightModal.jsx
@@ -102,7 +102,7 @@ const SpotlightModal = () => {
                     <div className="flex-1 min-w-0">
                       <div className={`text-sm font-medium truncate ${textPrimary}`}>
                         {result.match.field === 'title'
-                          ? highlightMatch(result.task.title, spotlightQuery)
+                          ? highlightMatch(result.task.title.replace(/\[\[[^\]]+\]\]/g, ''), spotlightQuery)
                           : renderTitle(result.task.title)}
                       </div>
                       {result.match.field !== 'title' && (


### PR DESCRIPTION
## Summary

- **Notes panel headers** (MobileLayout, MobileGlanceSection): replaced raw `{task.title}` with `renderTitle(task.title)` so `[[wikilinks]]` are stripped from the slide-up panel title bar
- **Search results** (SpotlightModal): strip wikilinks from the task title before passing to `highlightMatch()` when the match field is `'title'`, so highlights work correctly without exposing `[[...]]` syntax

The edit task modal uses a plain `<input>` for editing so the raw text (including wikilinks) is intentionally preserved there — stripping it would destroy the data on save.

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV