### PR TITLE
Enable Obsidian wikilinks and settings on tablet

### DIFF
--- a/src/components/FocusModeModal.jsx
+++ b/src/components/FocusModeModal.jsx
@@ -163,7 +163,7 @@ const FocusModeModal = () => {
                     )}
                   </div>
                   {/* Notes/subtasks panel — full card width */}
-                  {!isDone && ((task.notes && task.notes.trim()) || (task.subtasks && task.subtasks.length > 0) || (!isPhone && !isTablet && task.importSource === 'obsidian' && extractWikilinks(task.title).length > 0)) && (
+                  {!isDone && ((task.notes && task.notes.trim()) || (task.subtasks && task.subtasks.length > 0) || (!isPhone && task.importSource === 'obsidian' && extractWikilinks(task.title).length > 0)) && (
                     <NotesSubtasksPanel
                       task={task}
                       isInbox={false}
@@ -178,9 +178,9 @@ const FocusModeModal = () => {
                       aiConfig={aiConfig}
                       aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
                       onGenerateSubtasks={generateAISubtasks}
-                      wikilinks={!isPhone && !isTablet && task.importSource === 'obsidian' ? extractWikilinks(task.title) : undefined}
-                      onLoadWikiNote={!isPhone && !isTablet && task.importSource === 'obsidian' ? loadWikiNote : undefined}
-                      onSaveWikiNote={!isPhone && !isTablet && task.importSource === 'obsidian' ? saveWikiNote : undefined}
+                      wikilinks={!isPhone && task.importSource === 'obsidian' ? extractWikilinks(task.title) : undefined}
+                      onLoadWikiNote={!isPhone && task.importSource === 'obsidian' ? loadWikiNote : undefined}
+                      onSaveWikiNote={!isPhone && task.importSource === 'obsidian' ? saveWikiNote : undefined}
                     />
                   )}
                 </div>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -758,7 +758,7 @@ const SettingsModal = () => {
                       </>)}
                     </div>
 
-                    {(!isMobile && !isTablet || isNativeAndroid()) && (<>
+                    {(!isMobile || isNativeAndroid()) && (<>
                     <hr className={borderClass} />
 
                     {/* Obsidian Integration Section — desktop + Android native */}


### PR DESCRIPTION
## Summary

- **Focus Mode** (`FocusModeModal.jsx`): removed `!isTablet` from the Obsidian wikilink conditions — tablet now renders linked vault notes in focus mode, same as desktop
- **Settings** (`SettingsModal.jsx`): removed `!isTablet` from the Obsidian integration section gate — tablet web browsers can now configure the Obsidian integration; the existing `isFileSystemAccessSupported()` check already handles Safari gracefully with a warning message

No new code paths — tablet just follows the existing desktop logic for both.

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV