### PR TITLE
Fix tablet UI discrepancies: deadline opacity and timeline overflow

### DIFF
--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -297,7 +297,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
                         e.stopPropagation();
                         setShowDeadlinePicker(showDeadlinePicker === task.id ? null : task.id);
                       }}
-                      className={`hover:bg-white/20 rounded p-1 transition-colors ${task.deadline ? 'bg-white/20' : ''}`}
+                      className={`hover:bg-white/20 rounded p-1 transition-colors ${task.deadline ? 'bg-white/20' : 'opacity-40'}`}
                       title={task.deadline ? `Deadline: ${formatDeadlineDate(task.deadline)}` : 'Set deadline'}
                     >
                       <Calendar size={14} />

--- a/src/components/MobileAllDaySection.jsx
+++ b/src/components/MobileAllDaySection.jsx
@@ -330,7 +330,7 @@ const MobileAllDaySection = () => {
                           e.stopPropagation();
                           setShowDeadlinePicker(showDeadlinePicker === task.id ? null : task.id);
                         }}
-                        className="hover:bg-white/20 rounded p-1 transition-colors bg-white/20 flex-shrink-0"
+                        className={`hover:bg-white/20 rounded p-1 transition-colors flex-shrink-0 ${task.deadline ? 'bg-white/20' : 'opacity-40'}`}
                         title={task.deadline ? `Deadline: ${formatDeadlineDate(task.deadline)}` : 'Set deadline'}
                       >
                         <Calendar size={14} />

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -995,7 +995,7 @@ const MobileLayout = () => {
                                         e.stopPropagation();
                                         setShowDeadlinePicker(showDeadlinePicker === task.id ? null : task.id);
                                       }}
-                                      className={`hover:bg-white/20 rounded p-1 transition-colors ${task.deadline ? 'bg-white/20' : ''}`}
+                                      className={`hover:bg-white/20 rounded p-1 transition-colors ${task.deadline ? 'bg-white/20' : 'opacity-40'}`}
                                       title={task.deadline ? `Deadline: ${formatDeadlineDate(task.deadline)}` : 'Set deadline'}
                                     >
                                       <Calendar size={14} />

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -448,7 +448,7 @@ const TimeGrid = () => {
                     <GripVertical size={14} />
                   </div>
                 )}
-                <div className={`${isTablet ? 'flex-1 min-w-0 rounded-lg shadow-md' : ''} h-full ${isTablet ? (expandedNotesTaskId === task.id ? 'overflow-visible z-30' : 'overflow-hidden') : ''}`}>
+                <div className={`${isTablet ? 'flex-1 min-w-0 rounded-lg shadow-md' : ''} h-full ${isTablet && expandedNotesTaskId === task.id ? 'overflow-visible z-30' : ''}`}>
                 {task.isExample && isTablet && (
                   <span className="absolute -top-2 -right-2 bg-yellow-400 text-yellow-900 text-[10px] font-bold px-1.5 py-0.5 rounded-full shadow-sm z-10">
                     Example


### PR DESCRIPTION
## Summary

- **Deadline button opacity** (`InboxSidebar` desktop, `MobileLayout`, `MobileAllDaySection`): added `opacity-40` when no deadline is set, making all platforms consistent with the tablet inbox which already had this
- **TimeGrid tablet overflow**: removed `overflow-hidden` from the collapsed task card wrapper on tablet — matches desktop behavior and prevents popovers/notes panels from being clipped

## Not changed (intentional)
- All-day task action buttons on tablet match mobile — both show only Notes + Postpone; Edit/Inbox are swipe-only on both
- Double-click to edit in tablet inbox is already implemented (`InboxSidebar.jsx:515`)

https://claude.ai/code/session_01BnpS88f1EPokFZHR2K5cWV