### PR TITLE
Phase 10.1 — create SyncContext and useSyncCtx hook

### DIFF
--- a/src/context/SyncContext.jsx
+++ b/src/context/SyncContext.jsx
@@ -1,0 +1,3 @@
+import { createContext, useContext } from 'react';
+export const SyncContext = createContext(null);
+export const useSyncCtx = () => useContext(SyncContext);


### PR DESCRIPTION
Creates `src/context/SyncContext.jsx` — a minimal context + hook pair (`SyncContext`, `useSyncCtx`) that will back the sync-domain provider added in step 10.2.\n\nNo consumers yet; build and audit both pass clean.