### PR TITLE
Phase 10.3 — migrate BackupMenuModal to useSyncCtx()

### DIFF
--- a/src/components/BackupMenuModal.jsx
+++ b/src/components/BackupMenuModal.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { Clock, Save, Upload } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useSyncCtx } from '../context/SyncContext.jsx';
 
 const BackupMenuModal = () => {
+  const { cardBg, borderClass, textPrimary, textSecondary, darkMode } = useDayPlannerCtx();
   const {
     showBackupMenu, setShowBackupMenu,
-    cardBg, borderClass, textPrimary, textSecondary, darkMode,
     autoBackupConfig, setAutoBackupManagerTab, setShowAutoBackupManager,
     exportBackup, handleBackupFileSelect,
-  } = useDayPlannerCtx();
+  } = useSyncCtx();
 
   if (!showBackupMenu) return null;
 


### PR DESCRIPTION
Splits `BackupMenuModal`'s context consumption: sync-domain values (`showBackupMenu`, `autoBackupConfig`, `exportBackup`, etc.) now come from `useSyncCtx()`; theme values (`cardBg`, `borderClass`, etc.) stay on `useDayPlannerCtx()`.\n\nBuild and audit both clean.