### PR TITLE
Phase 10.4 — migrate AutoBackupManagerModal to useSyncCtx()

### DIFF
--- a/src/components/AutoBackupManagerModal.jsx
+++ b/src/components/AutoBackupManagerModal.jsx
@@ -1,20 +1,21 @@
 import React, { useState } from 'react';
 import { ChevronDown, ChevronRight, Cloud, Clock, Save, Trash2, Undo2, X } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useSyncCtx } from '../context/SyncContext.jsx';
 import AutoBackupSettingsForm from './AutoBackupSettingsForm.jsx';
 
 const AutoBackupManagerModal = () => {
+  const { cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg } = useDayPlannerCtx();
   const {
     showAutoBackupManager, setShowAutoBackupManager,
     autoBackupRestoreConfirm, setAutoBackupRestoreConfirm,
     autoBackupManagerTab, setAutoBackupManagerTab,
     autoBackupConfig, setAutoBackupConfig,
     autoBackupStatus, autoBackupHistory,
-    cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg,
     loadAutoBackupHistory, performRemoteBackup,
     restoreFromAutoBackup, restoreFromRemoteBackup,
     deleteLocalAutoBackup, deleteRemoteAutoBackup,
-  } = useDayPlannerCtx();
+  } = useSyncCtx();
 
   const [localExpanded, setLocalExpanded] = useState(false);
   const [remoteExpanded, setRemoteExpanded] = useState(false);


### PR DESCRIPTION
Splits `AutoBackupManagerModal`: sync-domain values (`showAutoBackupManager`, `autoBackupConfig`, `autoBackupHistory`, `loadAutoBackupHistory`, restore/delete functions, etc.) now come from `useSyncCtx()`; theme values stay on `useDayPlannerCtx()`.\n\nBuild and audit both clean.