### PR TITLE
Phase 10.7 — migrate ImportCalendarModal to useSyncCtx()

### DIFF
--- a/src/components/ImportCalendarModal.jsx
+++ b/src/components/ImportCalendarModal.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { Upload } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useSyncCtx } from '../context/SyncContext.jsx';
 
 const ImportCalendarModal = () => {
+  const { colors, cardBg, borderClass, textPrimary, textSecondary, darkMode } = useDayPlannerCtx();
   const {
     showImportModal, setShowImportModal,
     pendingImportFile, setPendingImportFile,
     importColor, setImportColor,
-    colors,
-    cardBg, borderClass, textPrimary, textSecondary, darkMode,
     processImportFile,
-  } = useDayPlannerCtx();
+  } = useSyncCtx();
 
   if (!showImportModal) return null;
 


### PR DESCRIPTION
Moves `showImportModal`, `pendingImportFile`, `importColor`, and `processImportFile` to `useSyncCtx()`; `colors` and theme values stay on `useDayPlannerCtx()`. Build and audit clean.