### PR TITLE
Phase 10.8 — migrate EmptyBinConfirmModal to useSyncCtx() + useDayPlannerCtx()

### DIFF
--- a/src/components/EmptyBinConfirmModal.jsx
+++ b/src/components/EmptyBinConfirmModal.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { Trash2 } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useSyncCtx } from '../context/SyncContext.jsx';
 
 const EmptyBinConfirmModal = () => {
   const {
-    showEmptyBinConfirm, setShowEmptyBinConfirm,
-    setShowMobileRecycleBin,
     recycleBin,
     cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg,
     confirmEmptyBin,
   } = useDayPlannerCtx();
+  const { showEmptyBinConfirm, setShowEmptyBinConfirm, setShowMobileRecycleBin } = useSyncCtx();
 
   if (!showEmptyBinConfirm) return null;
 


### PR DESCRIPTION
Splits `EmptyBinConfirmModal`: `showEmptyBinConfirm`, `setShowEmptyBinConfirm`, and `setShowMobileRecycleBin` move to `useSyncCtx()`; `recycleBin`, `confirmEmptyBin`, and theme values stay on `useDayPlannerCtx()` since they're core task-management concerns.\n\nBuild and audit both clean.