### PR TITLE
Phase 10.11 — migrate HabitModal to useFeaturesCtx()

### DIFF
--- a/src/components/HabitModal.jsx
+++ b/src/components/HabitModal.jsx
@@ -5,8 +5,10 @@ import {
 } from 'lucide-react';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from '../constants/habits.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
 const HabitModal = () => {
+  const { cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg } = useDayPlannerCtx();
   const {
     setShowHabitModal,
     editingHabit, setEditingHabit,
@@ -14,8 +16,7 @@ const HabitModal = () => {
     activeHabits, habits,
     addHabit, updateHabit, archiveHabit, deleteHabit, reorderHabits,
     addStepsHabit, addSleepHabit,
-    cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg,
-  } = useDayPlannerCtx();
+  } = useFeaturesCtx();
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => { setShowHabitModal(false); setEditingHabit(null); }}>


### PR DESCRIPTION
Splits `HabitModal`: habit state and functions move to `useFeaturesCtx()`; theme values stay on `useDayPlannerCtx()`. Build and audit clean.