### PR TITLE
Phase 10.17 — migrate RemindersSettingsModal to useFeaturesCtx()

### DIFF
--- a/src/components/RemindersSettingsModal.jsx
+++ b/src/components/RemindersSettingsModal.jsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import { Bell, BarChart3 } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import ClockTimePicker from './ClockTimePicker.jsx';
 
 const RemindersSettingsModal = () => {
+  const {
+    darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg,
+    isTablet, use24HourClock, formatTime,
+  } = useDayPlannerCtx();
   const {
     showRemindersSettings, setShowRemindersSettings,
     showMorningTimePicker, setShowMorningTimePicker,
     showWeeklyReviewTimePicker, setShowWeeklyReviewTimePicker,
     reminderSettings, setReminderSettings,
     applyReminderPreset, updateCategoryReminder,
-    darkMode,
-    cardBg, borderClass, textPrimary, textSecondary, hoverBg,
-    isTablet,
-    use24HourClock,
-    formatTime,
-  } = useDayPlannerCtx();
+  } = useFeaturesCtx();
 
   return (
     <>


### PR DESCRIPTION
Splits `RemindersSettingsModal`: reminder state/functions and time-picker visibility flags move to `useFeaturesCtx()`; theme and utility values stay on `useDayPlannerCtx()`.\n\nBuild clean. Audit flags one pre-existing `Notification` browser API reference — zero new issues introduced.