### PR TITLE
Fix ESC key not closing habit day popup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -905,6 +905,14 @@ const DayPlanner = () => {
   }, [expandedTaskMenu, showColorPicker, showDeadlinePicker, expandedNotesTaskId, routineDurationEditId]);
 
 
+  // Close habit day popup on ESC
+  useEffect(() => {
+    if (!habitDayPopup) return;
+    const handleKeyDown = (e) => { if (e.key === 'Escape') { e.preventDefault(); setHabitDayPopup(null); } };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [habitDayPopup]);
+
   // Close notes panel on ESC
   useEffect(() => {
     if (!expandedNotesTaskId) return;


### PR DESCRIPTION
## Summary

Adds a `useEffect` in `App.jsx` that listens for the `Escape` key while the habit day popup is open and closes it — matching the same pattern used for the notes panel and other modal ESC handlers in the codebase.