### PR TITLE
Fix project chip filter: sync hideProjectTasksInbox/hideStandaloneTasksInbox state

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -57,6 +57,7 @@ const CalendarHeader = () => {
     postponeTask, postponeDeadlineTask,
     moveToRecycleBin, moveToInbox,
     setInboxProjectFilter, setInboxPriorityFilter, setHideCompletedInbox,
+    setHideProjectTasksInbox, setHideStandaloneTasksInbox,
     getTasksForDate, getDeadlineTasksForDate,
     getTaskCalendarStyle,
     setTaskRef,
@@ -489,7 +490,7 @@ const CalendarHeader = () => {
                     if (!proj) return null;
                     return (
                       <button
-                        onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); } }}
+                        onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); setHideProjectTasksInbox(false); setHideStandaloneTasksInbox(true); } else { setHideProjectTasksInbox(true); setHideStandaloneTasksInbox(false); } }}
                         className={`mt-1 inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 hover:bg-white/40 text-white font-medium transition-colors ${projectFilter === task.projectId ? 'ring-1 ring-white/60' : ''}`}
                         title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
                       >

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -62,6 +62,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     selectAllTags, clearTagFilter, toggleTag,
     moveToRecycleBin,
     setInboxProjectFilter, setInboxPriorityFilter, setHideCompletedInbox,
+    setHideProjectTasksInbox, setHideStandaloneTasksInbox,
   } = useDayPlannerCtx();
   const {
     habitLongPressTimer,
@@ -802,7 +803,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
               if (!proj) return null;
               return (
                 <button
-                  onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); } }}
+                  onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); setHideProjectTasksInbox(false); setHideStandaloneTasksInbox(true); } else { setHideProjectTasksInbox(true); setHideStandaloneTasksInbox(false); } }}
                   className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full font-medium transition-colors ${darkMode ? 'bg-blue-900/50 text-blue-300 hover:bg-blue-800/70' : 'bg-blue-100 text-blue-700 hover:bg-blue-200'} ${projectFilter === task.projectId ? 'ring-1 ring-blue-400' : ''}`}
                   title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
                 >

--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -45,7 +45,9 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
     handleDragStart, handleDragEnd,
     handleDragOverInbox, handleDropOnInbox,
     dragOverInbox, setDragOverInbox,
-    hideCompletedInbox, setHideCompletedInbox, hideStandaloneTasksInbox, hideProjectTasksInbox,
+    hideCompletedInbox, setHideCompletedInbox,
+    hideStandaloneTasksInbox, setHideStandaloneTasksInbox,
+    hideProjectTasksInbox, setHideProjectTasksInbox,
     inboxTagFilter, inboxProjectFilter, setInboxProjectFilter,
     handleMobileTaskTouchStart, handleMobileTaskTouchMove, handleMobileTaskTouchEnd,
   } = useDayPlannerCtx();
@@ -247,7 +249,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
                             const active = projectFilter === task.projectId;
                             setProjectFilter(active ? null : task.projectId);
                             setInboxProjectFilter(active ? [] : [task.projectId]);
-                            if (!active) { setInboxPriorityFilter(0); setHideCompletedInbox(false); }
+                            if (!active) { setInboxPriorityFilter(0); setHideCompletedInbox(false); setHideProjectTasksInbox(false); setHideStandaloneTasksInbox(true); } else { setHideProjectTasksInbox(true); setHideStandaloneTasksInbox(false); }
                           }}
                           className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 hover:bg-white/40 text-white font-medium transition-colors flex-shrink-0 ${projectFilter === task.projectId ? 'ring-1 ring-white/60' : ''}`}
                           title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}

--- a/src/components/MobileTimeGrid.jsx
+++ b/src/components/MobileTimeGrid.jsx
@@ -43,6 +43,7 @@ const MobileTimeGrid = () => {
     calculateTaskPosition, calculateConflictPosition,
     getTimeFromCursorPosition,
     setInboxProjectFilter, setInboxPriorityFilter, setHideCompletedInbox,
+    setHideProjectTasksInbox, setHideStandaloneTasksInbox,
   } = useDayPlannerCtx();
   const {
     projects,
@@ -504,7 +505,7 @@ const MobileTimeGrid = () => {
                       return (
                         <div className="flex items-center gap-1 flex-wrap mt-0.5">
                           <button
-                            onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); } }}
+                            onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); setHideProjectTasksInbox(false); setHideStandaloneTasksInbox(true); } else { setHideProjectTasksInbox(true); setHideStandaloneTasksInbox(false); } }}
                             className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 active:bg-white/40 text-white font-medium transition-colors flex-shrink-0 ${projectFilter === task.projectId ? 'ring-1 ring-white/60' : ''}`}
                             title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
                           >
@@ -546,7 +547,7 @@ const MobileTimeGrid = () => {
                       return (
                         <div className="flex items-center gap-1 flex-wrap mt-0.5">
                           <button
-                            onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); } }}
+                            onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); setHideProjectTasksInbox(false); setHideStandaloneTasksInbox(true); } else { setHideProjectTasksInbox(true); setHideStandaloneTasksInbox(false); } }}
                             className={`inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 active:bg-white/40 text-white font-medium transition-colors flex-shrink-0 ${projectFilter === task.projectId ? 'ring-1 ring-white/60' : ''}`}
                             title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
                           >

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -59,6 +59,7 @@ const TimeGrid = () => {
     calculateTaskPosition, calculateConflictPosition,
     updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
     setInboxProjectFilter, setInboxPriorityFilter, setHideCompletedInbox,
+    setHideProjectTasksInbox, setHideStandaloneTasksInbox,
   } = useDayPlannerCtx();
   const { loadWikiNote, saveWikiNote } = useSyncCtx();
   const {
@@ -595,7 +596,7 @@ const TimeGrid = () => {
                                   if (!proj) return null;
                                   return (
                                     <button
-                                      onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); } }}
+                                      onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); setHideProjectTasksInbox(false); setHideStandaloneTasksInbox(true); } else { setHideProjectTasksInbox(true); setHideStandaloneTasksInbox(false); } }}
                                       className={`not-italic inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 hover:bg-white/40 text-white font-medium transition-colors flex-shrink-0 ${projectFilter === task.projectId ? 'ring-1 ring-white/60' : ''}`}
                                       title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
                                     >
@@ -684,7 +685,7 @@ const TimeGrid = () => {
                                   if (!proj) return null;
                                   return (
                                     <button
-                                      onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); } }}
+                                      onClick={(e) => { e.stopPropagation(); const next = projectFilter === task.projectId ? null : task.projectId; setProjectFilter(next); setInboxProjectFilter(next ? [next] : []); if (next) { setInboxPriorityFilter(0); setHideCompletedInbox(false); setHideProjectTasksInbox(false); setHideStandaloneTasksInbox(true); } else { setHideProjectTasksInbox(true); setHideStandaloneTasksInbox(false); } }}
                                       className={`not-italic inline-flex items-center text-[10px] px-1.5 py-0.5 rounded-full bg-white/25 hover:bg-white/40 text-white font-medium transition-colors flex-shrink-0 ${projectFilter === task.projectId ? 'ring-1 ring-white/60' : ''}`}
                                       title={projectFilter === task.projectId ? 'Clear project filter' : `Filter: ${proj.title}`}
                                     >


### PR DESCRIPTION
## Summary

- When clicking a project chip anywhere, the inbox filter panel was visually showing "Standalone ON / Project tasks OFF" even though `inboxProjectFilter` was correctly filtering tasks
- Root cause: `hideProjectTasksInbox` defaults to `true` and was never updated when a chip was activated
- Fix: on chip activation, set `hideProjectTasksInbox=false` and `hideStandaloneTasksInbox=true` so the filter popover correctly reflects the active state; on deactivation, restore both to their defaults

Applies to: TimeGrid, CalendarHeader, MobileTimeGrid, GlanceSidebar, InboxSidebar

## Test plan

- [x] Click a project chip anywhere (timeline, all-day, glance, inbox)
- [x] Open the filter popover — "Project tasks" should be highlighted, "Standalone" should not, and the specific project chip should be highlighted
- [x] Click the chip again to deactivate — filter popover should return to default state (Standalone ON, Project tasks OFF)

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn