### PR TITLE
Show all active projects in inbox filter popover

### DIFF
--- a/src/components/InboxFilterPopover.jsx
+++ b/src/components/InboxFilterPopover.jsx
@@ -60,9 +60,8 @@ const InboxFilterPopover = ({ open, onClose, buttonRef }) => {
 
   const inboxProjects = useMemo(() => {
     if (!goalsProjectsEnabled) return [];
-    const ids = new Set(unscheduledTasks.filter(t => t.projectId).map(t => t.projectId));
-    return projects.filter(p => ids.has(p.id));
-  }, [projects, unscheduledTasks, goalsProjectsEnabled]);
+    return projects.filter(p => p.status !== 'archived' && p.status !== 'completed');
+  }, [projects, goalsProjectsEnabled]);
 
   const isNonDefault =
     hideCompletedInbox ||


### PR DESCRIPTION
## Summary

- Inbox filter popover was only showing projects that already had tasks in the inbox (`unscheduledTasks`). If a project's tasks were all scheduled on the timeline, it wouldn't appear as a filter option at all.
- Fixed to show all active (non-archived, non-completed) projects regardless of whether they have inbox tasks.

## Test plan

- [x] Open the inbox filter popover — all active projects should appear under "Projects"
- [x] Click a project chip on a timeline task — the matching project should be highlighted in the filter popover

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn