### PR TITLE
Filter deadline tasks by projectFilter on timeline

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -186,7 +186,7 @@ const CalendarHeader = () => {
         return order(a) - order(b);
       });
       const dateStr = dateToString(date);
-      const deadlineTasks = getDeadlineTasksForDate(dateStr);
+      const deadlineTasks = getDeadlineTasksForDate(dateStr).filter(t => !projectFilter || t.projectId === projectFilter);
       const isDragOverThis = dragOverAllDay === dateStr;
       return (
         <div

--- a/src/components/MobileAllDaySection.jsx
+++ b/src/components/MobileAllDaySection.jsx
@@ -55,7 +55,7 @@ const MobileAllDaySection = () => {
             return order(a) - order(b);
           });
           const dateStr = dateToString(date);
-          const deadlineTasks = getDeadlineTasksForDate(dateStr).filter(t => !t.isExample);
+          const deadlineTasks = getDeadlineTasksForDate(dateStr).filter(t => !t.isExample && (!projectFilter || t.projectId === projectFilter));
           return (
             <React.Fragment key={dateStr}>
               {dayTasks.map((task) => {


### PR DESCRIPTION
## Summary

- `getDeadlineTasksForDate` has no awareness of `projectFilter`, so inbox tasks with deadlines were still appearing in the all-day row of the timeline even when a project chip filter was active
- Fixed at the render call sites in `CalendarHeader.jsx` and `MobileAllDaySection.jsx` by filtering the result with `!projectFilter || t.projectId === projectFilter`

## Test plan

- [x] Click a project chip on a timeline task to activate the project filter
- [x] Confirm deadline tasks from other projects no longer appear in the all-day row
- [x] Confirm deadline tasks belonging to the selected project still appear

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn