### PR TITLE
Fix remaining consumers using stripped ctx values

### DIFF
--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Calendar, Check, Loader, Sparkles, X } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
@@ -16,7 +17,6 @@ const DesktopNewTaskModal = () => {
     selectedDate,
     cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg, colors,
     durationOptions, formatTime,
-    aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading,
     showNewTaskDeadlinePicker, setShowNewTaskDeadlinePicker,
     showRecurrencePicker, setShowRecurrencePicker,
     showDatePicker, setShowDatePicker,
@@ -29,8 +29,8 @@ const DesktopNewTaskModal = () => {
     addTask, saveMobileEditTask, moveToRecycleBin,
     applySuggestionForNewTask,
     handleNewTaskInputChange, handleNewTaskInputKeyDown,
-    goals, projects, goalsProjectsEnabled,
   } = useDayPlannerCtx();
+  const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, goals, projects, goalsProjectsEnabled } = useFeaturesCtx();
 
   if (!showAddTask || isMobile) return null;
 

--- a/src/components/InboxArchivedBar.jsx
+++ b/src/components/InboxArchivedBar.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { Archive, ChevronDown, RotateCcw } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
 const InboxArchivedBar = () => {
   const {
     darkMode, textSecondary, hoverBg, borderClass,
     unscheduledTasks,
     restoreArchivedInboxTask,
-    goalsProjectsEnabled, projects,
     inboxArchivedExpanded: expanded,
     setInboxArchivedExpanded: setExpanded,
   } = useDayPlannerCtx();
+  const { goalsProjectsEnabled, projects } = useFeaturesCtx();
 
   const archivedTasks = unscheduledTasks.filter(t => t.archived && !t.imported);
 

--- a/src/components/InboxFilterPopover.jsx
+++ b/src/components/InboxFilterPopover.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { extractTags } from '../utils/taskUtils.js';
 
 /**
@@ -11,14 +12,14 @@ import { extractTags } from '../utils/taskUtils.js';
 const InboxFilterPopover = ({ open, onClose, buttonRef }) => {
   const {
     darkMode, textPrimary, textSecondary, cardBg, borderClass, hoverBg,
-    goalsProjectsEnabled,
-    projects, unscheduledTasks,
+    unscheduledTasks,
     hideCompletedInbox, setHideCompletedInbox,
     hideProjectTasksInbox, setHideProjectTasksInbox,
     hideStandaloneTasksInbox, setHideStandaloneTasksInbox,
     inboxTagFilter, setInboxTagFilter,
     inboxProjectFilter, setInboxProjectFilter,
   } = useDayPlannerCtx();
+  const { goalsProjectsEnabled, projects } = useFeaturesCtx();
 
   const popoverRef = useRef(null);
 

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Calendar, Check, Loader, Sparkles, X } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
 
@@ -16,15 +17,14 @@ const MobileNewTaskModal = () => {
     selectedDate,
     cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg, colors,
     durationOptions, formatTime,
-    aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading,
     showNewTaskDeadlinePicker, setShowNewTaskDeadlinePicker,
     showRecurrencePicker, setShowRecurrencePicker,
     setShowDatePicker, setShowTimePicker, setShowRecurrenceEndDatePicker,
     addTask, saveMobileEditTask, saveMobileEditNativeEvent,
     moveToRecycleBin, clearNativeEventOverride,
     handleNewTaskInputChange,
-    goals, projects, goalsProjectsEnabled,
   } = useDayPlannerCtx();
+  const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, goals, projects, goalsProjectsEnabled } = useFeaturesCtx();
 
   return (
     <>


### PR DESCRIPTION
## Summary

Fixes four more components that were still pulling stripped values from `useDayPlannerCtx()` after PR #352.

- `DesktopNewTaskModal`: `aiConfig`/`taskAISuggestion`/`goals`/`projects`/`goalsProjectsEnabled` → `useFeaturesCtx`
- `MobileNewTaskModal`: same as above
- `InboxArchivedBar`: `goalsProjectsEnabled`/`projects` → `useFeaturesCtx`
- `InboxFilterPopover`: `goalsProjectsEnabled`/`projects` → `useFeaturesCtx`

## Test plan

- [x] Click edit on a calendar task — modal opens without crashing
- [x] New task modal opens on mobile
- [x] Inbox archived bar shows correctly
- [x] Inbox filter popover project list works

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn