### PR TITLE
Move habits management to Settings, remove Glance FAB

### DIFF
--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -336,8 +336,7 @@ const MobileLayout = () => {
     routinesEnabled, setRoutinesEnabled,
     habits, setHabits,
     habitLogs, setHabitLogs,
-    habitsEnabled, setHabitsEnabled,
-    showHabitModal, setShowHabitModal,
+    habitsEnabled,
     editingHabit, setEditingHabit,
     draggedHabitIdx, setDraggedHabitIdx,
     habitOverflowOpen, setHabitOverflowOpen,
@@ -1187,16 +1186,6 @@ const MobileLayout = () => {
                       {recycleBin.filter(t => !t.isExample).length > 9 ? '9+' : recycleBin.filter(t => !t.isExample).length}
                     </span>
                   </div>
-                </button>
-              )}
-              {/* Habit management FAB */}
-              {habitsEnabled && (
-                <button
-                  onClick={() => setShowHabitModal(true)}
-                  className={`fixed right-4 z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-200 text-stone-600 active:bg-stone-300'}`}
-                  style={{ bottom: `calc(${recycleBin.filter(t => !t.isExample).length > 0 ? '16.5rem' : '12.5rem'} + env(safe-area-inset-bottom, 0px))` }}
-                >
-                  <Activity size={22} />
                 </button>
               )}
             </>

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import {
   Activity, BarChart3, Bell, BookOpen, BrainCircuit,
-  CalendarDays, CheckCircle, CheckSquare, ChevronDown,
+  CalendarDays, CheckCircle, CheckSquare, ChevronDown, ChevronUp,
   ChevronLeft, ChevronRight, Clock, Cloud, ExternalLink,
-  FolderOpen, HelpCircle, Key, LayoutGrid, Loader, Mic, Moon, Plus,
+  Footprints, FolderOpen, GripVertical, HelpCircle, Key, LayoutGrid,
+  Loader, Mic, Moon, Pencil, Plus,
   RefreshCw, Save, Settings, Sparkles, Sun, Target, Trash2,
   Undo2, Upload, Volume2, VolumeX, Wifi, Zap,
 } from 'lucide-react';
+import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from '../constants/habits.js';
 import { isNativeAndroid, nativeGetCalendars } from '../native.js';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
@@ -65,6 +67,11 @@ const MobileSettingsPanel = () => {
   const {
     routinesEnabled, setRoutinesEnabled,
     habitsEnabled, setHabitsEnabled,
+    activeHabits, habits,
+    editingHabit, setEditingHabit,
+    draggedHabitIdx, setDraggedHabitIdx,
+    addHabit, updateHabit, archiveHabit, deleteHabit, reorderHabits,
+    addStepsHabit, addSleepHabit,
     goalsProjectsEnabled, setGoalsProjectsEnabled,
     gtdFrames,
     framesModalTab, setFramesModalTab,
@@ -115,11 +122,11 @@ const MobileSettingsPanel = () => {
         <span className={`text-xs font-medium ${textPrimary}`}>{use24HourClock ? '24h' : '12h'}</span>
       </button>
       <button
-        onClick={() => { if (!habitsEnabled) setOnboardingProgress(prev => ({ ...prev, hasEnabledOptionalFeature: true })); setHabitsEnabled(!habitsEnabled); }}
+        onClick={() => setMobileSettingsView('habits')}
         className={`${cardBg} border ${borderClass} rounded-xl p-4 flex flex-col items-center gap-2`}
       >
-        {habitsEnabled ? <Activity size={24} className="text-green-500" /> : <Activity size={24} className={textSecondary} />}
-        <span className={`text-xs font-medium ${textPrimary}`}>Habits {habitsEnabled ? 'On' : 'Off'}</span>
+        <Activity size={24} className={mobileSettingsView === 'habits' ? 'text-green-500' : habitsEnabled ? 'text-green-500' : textSecondary} />
+        <span className={`text-xs font-medium ${textPrimary}`}>Habits</span>
       </button>
       <button
         onClick={() => { if (!routinesEnabled) setOnboardingProgress(prev => ({ ...prev, hasEnabledOptionalFeature: true })); setRoutinesEnabled(!routinesEnabled); }}
@@ -1256,6 +1263,240 @@ const MobileSettingsPanel = () => {
           gtdFrames={gtdFrames}
           formatTime={formatTime}
         />
+      )}
+    </div>
+  )}
+
+  {/* Habits sub-view */}
+  {mobileSettingsView === 'habits' && (
+    <div className="px-4 py-4 space-y-4">
+      <button
+        onClick={() => { setMobileSettingsView('main'); setEditingHabit(null); }}
+        className={`flex items-center gap-2 ${textSecondary} mb-2`}
+      >
+        <ChevronLeft size={18} />
+        <span className="text-sm font-medium">Settings</span>
+      </button>
+
+      {/* Enable/disable toggle */}
+      <div className={`flex items-center justify-between p-4 rounded-xl border ${borderClass} ${cardBg}`}>
+        <div className="flex items-center gap-3">
+          <Activity size={20} className={habitsEnabled ? 'text-green-500' : textSecondary} />
+          <span className={`text-sm font-medium ${textPrimary}`}>Habits</span>
+        </div>
+        <button
+          onClick={() => { if (!habitsEnabled) setOnboardingProgress(prev => ({ ...prev, hasEnabledOptionalFeature: true })); setHabitsEnabled(!habitsEnabled); }}
+          className={`w-11 h-6 rounded-full transition-colors ${habitsEnabled ? 'bg-green-500' : (darkMode ? 'bg-gray-600' : 'bg-stone-300')}`}
+        >
+          <div className={`w-5 h-5 rounded-full bg-white shadow transition-transform mx-0.5 ${habitsEnabled ? 'translate-x-5' : 'translate-x-0'}`} />
+        </button>
+      </div>
+
+      {habitsEnabled && (
+        <>
+          {editingHabit ? (
+            /* Edit/Add form */
+            (() => {
+              const isNew = !editingHabit.id;
+              return (
+                <div className="space-y-4">
+                  <div>
+                    <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Name</label>
+                    <input
+                      type="text"
+                      placeholder="e.g., Drink water"
+                      value={editingHabit.name || ''}
+                      onChange={(e) => setEditingHabit(prev => ({ ...prev, name: e.target.value }))}
+                      className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
+                      autoFocus
+                    />
+                  </div>
+                  <div>
+                    <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Type</label>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setEditingHabit(prev => ({ ...prev, type: 'doMore' }))}
+                        className={`flex-1 px-3 py-2 text-sm rounded-lg transition-colors ${editingHabit.type === 'doMore' ? 'bg-blue-600 text-white' : (darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-100 text-stone-700')}`}
+                      >Do More</button>
+                      <button
+                        onClick={() => setEditingHabit(prev => ({ ...prev, type: 'limit' }))}
+                        className={`flex-1 px-3 py-2 text-sm rounded-lg transition-colors ${editingHabit.type === 'limit' ? 'bg-red-600 text-white' : (darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-100 text-stone-700')}`}
+                      >Limit</button>
+                    </div>
+                    <p className={`text-xs ${textSecondary} mt-1`}>{editingHabit.type === 'doMore' ? 'Track progress toward a daily goal' : 'Track consumption against a daily ceiling'}</p>
+                  </div>
+                  <div className="flex gap-3">
+                    <div className="flex-1">
+                      <label className={`block text-sm font-medium ${textSecondary} mb-1`}>{editingHabit.type === 'doMore' ? 'Daily Goal' : 'Daily Limit'}</label>
+                      <input
+                        type="number"
+                        min="1"
+                        value={editingHabit.target || ''}
+                        onChange={(e) => setEditingHabit(prev => ({ ...prev, target: parseInt(e.target.value) || 0 }))}
+                        className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Unit</label>
+                      <input
+                        type="text"
+                        placeholder="e.g., glasses"
+                        value={editingHabit.unit || ''}
+                        onChange={(e) => setEditingHabit(prev => ({ ...prev, unit: e.target.value }))}
+                        className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Icon</label>
+                    <div className="flex flex-wrap gap-2">
+                      {HABIT_ICON_NAMES.map(name => {
+                        const Icon = HABIT_ICONS[name];
+                        return (
+                          <button
+                            key={name}
+                            onClick={() => setEditingHabit(prev => ({ ...prev, icon: name }))}
+                            className={`w-9 h-9 rounded-lg flex items-center justify-center transition-colors ${editingHabit.icon === name ? 'bg-blue-600 text-white' : (darkMode ? 'bg-gray-700 text-gray-400 hover:bg-gray-600' : 'bg-stone-100 text-stone-600 hover:bg-stone-200')}`}
+                          >
+                            <Icon size={18} />
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                  <div>
+                    <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Color</label>
+                    <div className="flex flex-wrap gap-2">
+                      {HABIT_COLORS.map(c => (
+                        <button
+                          key={c.name}
+                          onClick={() => setEditingHabit(prev => ({ ...prev, color: c.name }))}
+                          className={`w-9 h-9 rounded-full ${c.bg} transition-all ${editingHabit.color === c.name ? 'ring-2 ring-offset-2 ring-blue-500' : 'opacity-70 hover:opacity-100'}`}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex gap-2 pt-2">
+                    <button
+                      onClick={() => setEditingHabit(null)}
+                      className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium ${darkMode ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-stone-100 text-stone-700 hover:bg-stone-200'} transition-colors`}
+                    >Cancel</button>
+                    <button
+                      onClick={() => {
+                        if (!editingHabit.name?.trim()) return;
+                        if (isNew) { addHabit(editingHabit); } else { updateHabit(editingHabit.id, editingHabit); }
+                        setEditingHabit(null);
+                      }}
+                      disabled={!editingHabit.name?.trim() || !editingHabit.target}
+                      className="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >{isNew ? 'Add Habit' : 'Save'}</button>
+                  </div>
+                </div>
+              );
+            })()
+          ) : (
+            /* Habit list */
+            <>
+              {activeHabits.length === 0 ? (
+                <div className={`text-center py-8 ${textSecondary}`}>
+                  <Activity size={40} className="mx-auto mb-3 opacity-30" />
+                  <p className="text-sm">No habits yet</p>
+                  <p className="text-xs mt-1">Add a habit to start tracking</p>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {activeHabits.map((habit, idx) => {
+                    const IconComp = HABIT_ICONS[habit.icon] || Target;
+                    const colorObj = HABIT_COLORS.find(c => c.name === habit.color) || HABIT_COLORS[0];
+                    return (
+                      <div
+                        key={habit.id}
+                        draggable
+                        onDragStart={(e) => { setDraggedHabitIdx(idx); e.dataTransfer.effectAllowed = 'move'; }}
+                        onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; }}
+                        onDrop={(e) => { e.preventDefault(); if (draggedHabitIdx !== null && draggedHabitIdx !== idx) reorderHabits(draggedHabitIdx, idx); setDraggedHabitIdx(null); }}
+                        onDragEnd={() => setDraggedHabitIdx(null)}
+                        className={`flex items-center gap-3 px-3 py-2.5 rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-800' : 'bg-white'} ${draggedHabitIdx === idx ? 'opacity-40' : ''} transition-opacity`}
+                      >
+                        <div className={`cursor-grab active:cursor-grabbing ${textSecondary}`}><GripVertical size={16} /></div>
+                        <IconComp size={20} style={{ color: colorObj.ring }} className="flex-shrink-0" />
+                        <div className="flex-1 min-w-0">
+                          <div className={`text-sm font-medium ${textPrimary} truncate flex items-center gap-1.5`}>
+                            {habit.name}
+                            {habit.source === 'healthConnect' && (
+                              <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 flex-shrink-0">
+                                <RefreshCw size={9} />Auto-synced
+                              </span>
+                            )}
+                          </div>
+                          <div className={`text-xs ${textSecondary}`}>{habit.type === 'doMore' ? 'Goal' : 'Limit'}: {habit.target} {habit.unit}</div>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          {idx > 0 && (
+                            <button onClick={() => reorderHabits(idx, idx - 1)} className={`p-1 rounded ${hoverBg}`}><ChevronUp size={14} className={textSecondary} /></button>
+                          )}
+                          {idx < activeHabits.length - 1 && (
+                            <button onClick={() => reorderHabits(idx, idx + 1)} className={`p-1 rounded ${hoverBg}`}><ChevronDown size={14} className={textSecondary} /></button>
+                          )}
+                          <button onClick={() => setEditingHabit({ ...habit })} className={`p-1 rounded ${hoverBg}`}><Pencil size={14} className={textSecondary} /></button>
+                          <button onClick={() => archiveHabit(habit.id)} className={`p-1 rounded ${hoverBg}`}><Trash2 size={14} className="text-red-500" /></button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+              {activeHabits.length < 8 && (
+                <button
+                  onClick={() => setEditingHabit({ name: '', icon: 'Droplets', color: 'blue', type: 'doMore', target: 8, unit: '' })}
+                  className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border-2 border-dashed border-blue-500/30 text-blue-500 text-sm font-medium hover:bg-blue-500/5 transition-colors"
+                >
+                  <Plus size={16} />
+                  Add Habit
+                </button>
+              )}
+              {window.DayGlanceNative && !activeHabits.some(h => h.source === 'healthConnect' && h.unit === 'steps') && activeHabits.length < 8 && (
+                <div className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${darkMode ? 'border-green-800 bg-green-950/40' : 'border-green-200 bg-green-50'}`}>
+                  <Footprints size={22} className="text-green-500 flex-shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <div className={`text-sm font-semibold ${darkMode ? 'text-green-300' : 'text-green-800'}`}>Track steps automatically</div>
+                    <div className={`text-xs ${darkMode ? 'text-green-500' : 'text-green-600'} mt-0.5`}>Pulls from Health Connect — no manual tapping</div>
+                  </div>
+                  <button onClick={addStepsHabit} className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-500 text-white hover:bg-green-600 active:bg-green-700 transition-colors flex-shrink-0">Add</button>
+                </div>
+              )}
+              {window.DayGlanceNative && !activeHabits.some(h => h.source === 'healthConnect' && h.unit === 'min') && activeHabits.length < 8 && (
+                <div className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${darkMode ? 'border-indigo-800 bg-indigo-950/40' : 'border-indigo-200 bg-indigo-50'}`}>
+                  <Moon size={22} className="text-indigo-500 flex-shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <div className={`text-sm font-semibold ${darkMode ? 'text-indigo-300' : 'text-indigo-800'}`}>Track sleep automatically</div>
+                    <div className={`text-xs ${darkMode ? 'text-indigo-500' : 'text-indigo-600'} mt-0.5`}>Pulls from Health Connect — no manual tapping</div>
+                  </div>
+                  <button onClick={addSleepHabit} className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700 transition-colors flex-shrink-0">Add</button>
+                </div>
+              )}
+              {habits.filter(h => h.archived).length > 0 && (
+                <div className="pt-2">
+                  <h4 className={`text-xs font-semibold uppercase tracking-wide ${textSecondary} mb-2`}>Archived</h4>
+                  <div className="space-y-1">
+                    {habits.filter(h => h.archived).map(habit => {
+                      const IconComp = HABIT_ICONS[habit.icon] || Target;
+                      const colorObj = HABIT_COLORS.find(c => c.name === habit.color) || HABIT_COLORS[0];
+                      return (
+                        <div key={habit.id} className={`flex items-center gap-3 px-3 py-2 rounded-lg ${darkMode ? 'bg-gray-800/50' : 'bg-stone-50'} opacity-60`}>
+                          <IconComp size={16} style={{ color: colorObj.ring }} />
+                          <span className={`text-sm flex-1 ${textPrimary}`}>{habit.name}</span>
+                          <button onClick={() => updateHabit(habit.id, { archived: false })} className="text-xs text-blue-500 font-medium px-2 py-1 rounded hover:bg-blue-500/10">Restore</button>
+                          <button onClick={() => deleteHabit(habit.id)} className="text-xs text-red-500 font-medium px-2 py-1 rounded hover:bg-red-500/10">Delete</button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </>
       )}
     </div>
   )}


### PR DESCRIPTION
## Summary

Habits is a "set it and forget it" feature — the FAB on the Glance tab added unnecessary clutter. Habits now lives in Settings alongside Frames.

**MobileSettingsPanel:**
- Habits button in the settings grid now navigates to a `'habits'` sub-view (same pattern as Frames) instead of directly toggling on/off
- Sub-view includes:
  - Enable/disable toggle at the top
  - Full habit management UI: list with drag-to-reorder, add/edit form (name, type, goal/limit, unit, icon, color picker), Health Connect steps/sleep suggestions (Android), archived habits section

**MobileLayout:**
- Removed the Habit management FAB from the Glance tab
- Cleaned up now-unused `showHabitModal` / `setHabitsEnabled` destructures

## Test plan

- [x] Settings → Habits button navigates to habits sub-view
- [x] Enable/disable toggle in sub-view works
- [x] Add, edit, reorder, archive habits from the sub-view
- [x] Back button returns to main settings (clears any in-progress edit)
- [x] No FAB visible on Glance tab
- [x] Habit rings on Glance tab still work normally

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn