### PR TITLE
Add weather and daily content on/off toggles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -268,6 +268,16 @@ const DayPlanner = () => {
     return saved !== null ? JSON.parse(saved) : false;
   });
   const { weather, setWeather, weatherZip, setWeatherZip, weatherTempUnit, setWeatherTempUnit, fetchWeather } = useWeather();
+  const [weatherEnabled, setWeatherEnabled] = useState(() => {
+    const saved = localStorage.getItem('day-planner-weather-enabled');
+    return saved !== null ? JSON.parse(saved) : true;
+  });
+  const [dailyContentEnabled, setDailyContentEnabled] = useState(() => {
+    const saved = localStorage.getItem('day-planner-daily-content-enabled');
+    return saved !== null ? JSON.parse(saved) : true;
+  });
+  useEffect(() => { localStorage.setItem('day-planner-weather-enabled', JSON.stringify(weatherEnabled)); }, [weatherEnabled]);
+  useEffect(() => { localStorage.setItem('day-planner-daily-content-enabled', JSON.stringify(dailyContentEnabled)); }, [dailyContentEnabled]);
   const [syncUrl, setSyncUrl] = useState('');
   const [showCalendarUrlHint, setShowCalendarUrlHint] = useState(false);
   const [currentTime, setCurrentTime] = useState(new Date());
@@ -6411,10 +6421,12 @@ const DayPlanner = () => {
     weather, setWeather,
     weatherZip, setWeatherZip,
     weatherTempUnit, setWeatherTempUnit,
+    weatherEnabled, setWeatherEnabled,
 
     // ── Daily content (quotes / tips) ─────────────────────────────────────────
     dailyContent, setDailyContent,
     contentRotation, setContentRotation,
+    dailyContentEnabled, setDailyContentEnabled,
 
     // ── Onboarding / welcome ──────────────────────────────────────────────────
     showWelcome, setShowWelcome,

--- a/src/components/DesktopHeader.jsx
+++ b/src/components/DesktopHeader.jsx
@@ -18,8 +18,8 @@ const DesktopHeader = () => {
     setShowSettings,
     updateInfo,
     setShowHelpModal,
-    weather, weatherTempUnit,
-    dailyContent, contentRotation,
+    weather, weatherTempUnit, weatherEnabled,
+    dailyContent, contentRotation, dailyContentEnabled,
     cardBg, borderClass, textPrimary, textSecondary, hoverBg, colors,
     changeDate, goToToday, goToDate, changeViewedMonth,
     getDateIndicators, getMonthDays,
@@ -38,7 +38,7 @@ const DesktopHeader = () => {
       <div className={`${cardBg} border-b ${borderClass} px-4 py-2 flex items-center justify-between relative`} style={{ height: '80px' }}>
         {/* Left: Weather + Daily Content */}
         <div className="flex items-center gap-4 min-w-0">
-          {weather && (
+          {weather && weatherEnabled && (
             <>
               {/* Current weather */}
               <div className={`flex items-center gap-2 px-3 py-1.5 ${darkMode ? 'bg-gray-700' : 'bg-stone-100'} rounded-lg flex-shrink-0`}>
@@ -68,7 +68,7 @@ const DesktopHeader = () => {
           )}
 
           {/* Rotating Daily Content - 1 item at a time (3-col only to avoid header overlap) */}
-          {visibleDays >= 3 && (() => {
+          {dailyContentEnabled && visibleDays >= 3 && (() => {
             const contentItems = [
               { key: 'dadJoke', icon: '😄', label: 'Dad Joke', content: dailyContent.dadJoke },
               { key: 'funFact', icon: '💡', label: 'Fun Fact', content: dailyContent.funFact },

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -22,6 +22,8 @@ const SettingsModal = () => {
     setOnboardingProgress,
     isMobile, isTablet,
     weatherZip, setWeatherZip, fetchWeather, weatherTempUnit, setWeatherTempUnit,
+    weatherEnabled, setWeatherEnabled,
+    dailyContentEnabled, setDailyContentEnabled,
     setTasks, setUnscheduledTasks,
     dailyNoteTemplate, setDailyNoteTemplate,
   } = useDayPlannerCtx();
@@ -242,57 +244,67 @@ const SettingsModal = () => {
                     {!isMobile && !isTablet && (<>
                     <hr className={borderClass} />
 
-                    {/* Weather Location Section — desktop only (weather not shown on mobile/tablet) */}
+                    {/* Weather — desktop only */}
                     <div className="space-y-3">
                       <h4 className={`font-medium ${textPrimary} flex items-center gap-2`}>
-                        <MapPin size={16} className={textSecondary} />
-                        Weather Location
+                        <Cloud size={16} className={textSecondary} />
+                        Weather
                       </h4>
-                      <div>
-                        <label className={`block text-sm ${textSecondary} mb-1`}>
-                          ZIP code or city name
-                        </label>
-                        <input
-                          type="text"
-                          placeholder="e.g. 90210 or Seattle"
-                          value={weatherZip}
-                          onChange={(e) => setWeatherZip(e.target.value)}
-                          onBlur={() => fetchWeather()}
-                          onKeyDown={(e) => { if (e.key === 'Enter') { e.target.blur(); } }}
-                          className={`w-48 px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
-                        />
-                        <p className={`text-xs ${textSecondary} mt-1`}>
-                          Leave empty to hide weather
-                        </p>
-                      </div>
-                      <div>
-                        <label className={`block text-sm ${textSecondary} mb-1`}>
-                          Temperature unit
-                        </label>
-                        <div className="flex gap-2">
-                          <button
-                            onClick={() => { setWeatherTempUnit('fahrenheit'); setTimeout(fetchWeather, 100); }}
-                            className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${
-                              weatherTempUnit === 'fahrenheit'
-                                ? 'bg-blue-600 text-white'
-                                : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`
-                            }`}
-                          >
-                            °F
-                          </button>
-                          <button
-                            onClick={() => { setWeatherTempUnit('celsius'); setTimeout(fetchWeather, 100); }}
-                            className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${
-                              weatherTempUnit === 'celsius'
-                                ? 'bg-blue-600 text-white'
-                                : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`
-                            }`}
-                          >
-                            °C
-                          </button>
+                      <label className="flex items-center gap-3 cursor-pointer">
+                        <div className="relative">
+                          <input type="checkbox" checked={weatherEnabled} onChange={(e) => setWeatherEnabled(e.target.checked)} className="sr-only" />
+                          <div className={`w-10 h-6 rounded-full transition-colors ${weatherEnabled ? 'bg-blue-600' : darkMode ? 'bg-gray-600' : 'bg-stone-300'}`}>
+                            <div className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${weatherEnabled ? 'translate-x-5' : 'translate-x-1'}`} />
+                          </div>
                         </div>
-                      </div>
+                        <span className={`text-sm ${textPrimary}`}>Show weather in header</span>
+                      </label>
+                      {weatherEnabled && (
+                        <>
+                          <div>
+                            <label className={`block text-sm ${textSecondary} mb-1`}>ZIP code or city name</label>
+                            <input
+                              type="text"
+                              placeholder="e.g. 90210 or Seattle"
+                              value={weatherZip}
+                              onChange={(e) => setWeatherZip(e.target.value)}
+                              onBlur={() => fetchWeather()}
+                              onKeyDown={(e) => { if (e.key === 'Enter') { e.target.blur(); } }}
+                              className={`w-48 px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
+                            />
+                          </div>
+                          <div>
+                            <label className={`block text-sm ${textSecondary} mb-1`}>Temperature unit</label>
+                            <div className="flex gap-2">
+                              <button onClick={() => { setWeatherTempUnit('fahrenheit'); setTimeout(fetchWeather, 100); }} className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${weatherTempUnit === 'fahrenheit' ? 'bg-blue-600 text-white' : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`}`}>°F</button>
+                              <button onClick={() => { setWeatherTempUnit('celsius'); setTimeout(fetchWeather, 100); }} className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${weatherTempUnit === 'celsius' ? 'bg-blue-600 text-white' : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`}`}>°C</button>
+                            </div>
+                          </div>
+                        </>
+                      )}
                     </div>
+
+                    <hr className={borderClass} />
+
+                    {/* Daily Content — desktop only */}
+                    <div className="space-y-3">
+                      <h4 className={`font-medium ${textPrimary} flex items-center gap-2`}>
+                        <Sparkles size={16} className={textSecondary} />
+                        Daily Content
+                      </h4>
+                      <label className="flex items-center gap-3 cursor-pointer">
+                        <div className="relative">
+                          <input type="checkbox" checked={dailyContentEnabled} onChange={(e) => setDailyContentEnabled(e.target.checked)} className="sr-only" />
+                          <div className={`w-10 h-6 rounded-full transition-colors ${dailyContentEnabled ? 'bg-blue-600' : darkMode ? 'bg-gray-600' : 'bg-stone-300'}`}>
+                            <div className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${dailyContentEnabled ? 'translate-x-5' : 'translate-x-1'}`} />
+                          </div>
+                        </div>
+                        <span className={`text-sm ${textPrimary}`}>Show daily tips &amp; quotes in header</span>
+                      </label>
+                    </div>
+
+                    <hr className={borderClass} />
+
                     </>)}
 
                     <hr className={borderClass} />


### PR DESCRIPTION
## Summary

Adds explicit toggles to show/hide weather and daily content in the desktop header. Both default to `on` and persist in localStorage.

**App.jsx:**
- `weatherEnabled` / `dailyContentEnabled` state, initialized from `localStorage` (`day-planner-weather-enabled`, `day-planner-daily-content-enabled`), exposed via `DayPlannerContext`

**DesktopHeader:**
- Weather block gated on `weather && weatherEnabled`
- Daily content block gated on `dailyContentEnabled && visibleDays >= 3`

**SettingsModal (desktop-only section):**
- **Weather**: Replaced the bare ZIP input section with a toggle ("Show weather in header") + ZIP/unit inputs revealed when toggled on
- **Daily Content**: New toggle ("Show daily tips & quotes in header")
- Both sit in the existing desktop-only (`!isMobile && !isTablet`) block

## Test plan

- [x] Toggle weather off → weather disappears from header; toggle on → reappears
- [x] Toggle daily content off → rotating content disappears; toggle on → reappears
- [x] Settings persist across page refresh
- [x] ZIP/unit inputs hidden when weather is off, shown when on
- [x] Both default to on for new users

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn