### PR TITLE
Add Goals Due Today to Android widget

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
@@ -45,6 +45,7 @@ class DayGlanceWidgetListFactory(
         const val TYPE_ROUTINE = 4
         const val TYPE_EMPTY = 5
         const val TYPE_GLANCEAHEAD = 6
+        const val TYPE_GOAL = 7
 
         private val TWELVE_HR = DateTimeFormatter.ofPattern("h:mm a")
         private val TWELVE_HR_SHORT = DateTimeFormatter.ofPattern("h:mm")
@@ -80,6 +81,7 @@ class DayGlanceWidgetListFactory(
             val isEmpty: Boolean,
         ) : AgendaItem(TYPE_GLANCEAHEAD)
         object Empty : AgendaItem(TYPE_EMPTY)
+        class Goal(val title: String, val progressPct: Int) : AgendaItem(TYPE_GOAL)
     }
 
     data class HabitData(
@@ -111,7 +113,7 @@ class DayGlanceWidgetListFactory(
     override fun onDestroy() { items.clear() }
 
     override fun getCount(): Int = items.size.coerceAtLeast(1)
-    override fun getViewTypeCount(): Int = 7
+    override fun getViewTypeCount(): Int = 8
     override fun getItemId(position: Int): Long = position.toLong()
     override fun hasStableIds(): Boolean = false
     override fun getLoadingView(): RemoteViews? = null
@@ -139,6 +141,18 @@ class DayGlanceWidgetListFactory(
                 )
             }
             if (habits.isNotEmpty()) items += AgendaItem.Habits(habits)
+        }
+
+        // 1.5 Goals due today — compact rows below habits, above overdue
+        val goalsArray = snapshot.optJSONArray("goals")
+        if (goalsArray != null && goalsArray.length() > 0) {
+            for (i in 0 until goalsArray.length()) {
+                val g = goalsArray.optJSONObject(i) ?: continue
+                items += AgendaItem.Goal(
+                    title = g.optString("title", "Untitled"),
+                    progressPct = g.optInt("progressPct", 0).coerceIn(0, 100),
+                )
+            }
         }
 
         // 2. OVERDUE section — prior-day tasks only (no time, no badge — section header is enough)
@@ -397,6 +411,7 @@ class DayGlanceWidgetListFactory(
         is AgendaItem.FrameHeader -> buildFrameHeaderView(item)
         is AgendaItem.RoutineGroup -> buildRoutineGroupView(item)
         is AgendaItem.GlanceAhead -> buildGlanceAheadView(item)
+        is AgendaItem.Goal -> buildGoalView(item)
         AgendaItem.Empty -> buildEmptyView()
     }
 
@@ -425,6 +440,15 @@ class DayGlanceWidgetListFactory(
             }
         }
         rv.setOnClickFillInIntent(R.id.habits_item_root, android.content.Intent())
+        return rv
+    }
+
+    private fun buildGoalView(item: AgendaItem.Goal): RemoteViews {
+        val rv = RemoteViews(context.packageName, R.layout.widget_item_goal)
+        rv.setTextViewText(R.id.tv_goal_title, item.title)
+        rv.setProgressBar(R.id.pb_goal_progress, 100, item.progressPct, false)
+        rv.setTextViewText(R.id.tv_goal_pct, "${item.progressPct}%")
+        rv.setOnClickFillInIntent(R.id.goal_item_root, android.content.Intent())
         return rv
     }
 

--- a/dayglance-android/app/src/main/res/layout/widget_item_goal.xml
+++ b/dayglance-android/app/src/main/res/layout/widget_item_goal.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Widget list item: a goal due today.
+
+  Structure:
+    [amber bar 3dp] [title — flex] [ProgressBar — 56dp] [X% label]
+
+  One row, same height as a short task row.
+  The amber bar signals "due today" without needing a text badge.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/goal_item_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingTop="5dp"
+    android:paddingBottom="5dp"
+    android:paddingStart="0dp"
+    android:paddingEnd="0dp">
+
+    <!-- Amber color bar — same width/style as task_color_bar -->
+    <View
+        android:id="@+id/goal_color_bar"
+        android:layout_width="3dp"
+        android:layout_height="28dp"
+        android:background="#f59e0b"
+        android:layout_marginEnd="7dp" />
+
+    <!-- Goal title -->
+    <TextView
+        android:id="@+id/tv_goal_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="Goal title"
+        android:textColor="@color/widget_text_primary"
+        android:textSize="13sp"
+        android:maxLines="1"
+        android:ellipsize="end"
+        android:layout_marginEnd="8dp" />
+
+    <!-- Thin horizontal progress bar -->
+    <ProgressBar
+        android:id="@+id/pb_goal_progress"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="56dp"
+        android:layout_height="4dp"
+        android:max="100"
+        android:progress="0"
+        android:layout_marginEnd="6dp" />
+
+    <!-- Percentage label -->
+    <TextView
+        android:id="@+id/tv_goal_pct"
+        android:layout_width="30dp"
+        android:layout_height="wrap_content"
+        android:text="0%"
+        android:textColor="@color/widget_text_secondary"
+        android:textSize="11sp"
+        android:gravity="end" />
+
+</LinearLayout>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import { autoBackupDB, autoBackupProviders, AUTO_BACKUP_RETENTION, AUTO_BACKUP_I
 import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOnlyTask, getLinkUrl, hasOnlySubtasks, renderTitle, highlightMatch, renderTitleWithoutTags, extractShareTitle } from './utils/textFormatting.jsx';
 import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate } from './utils/taskUtils.js';
 import { TASK_COLORS, TAILWIND_TO_HEX, taskColorToHex } from './utils/colorUtils.js';
+import { calculateGoalProgress } from './utils/goalProgress.js';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from './constants/habits.js';
 import { FRAME_COLORS, DAY_LABELS } from './constants/frames.js';
 import { getOccurrencesInRange, getRecurrencePresets } from './utils/recurrenceEngine.js';
@@ -5770,6 +5771,17 @@ const DayPlanner = () => {
       isAllDay: !r.startTime || r.isAllDay || false,
     }));
 
+    // ── Goals due today ───────────────────────────────────────────────────
+    const allTasksCombinedW = [...tasks, ...unscheduledTasks];
+    const goalItems = goalsProjectsEnabled
+      ? goals
+          .filter(g => g.status === 'active' && g.targetDate === todayStr)
+          .map(g => {
+            const progressPct = Math.round(calculateGoalProgress(g.id, projects, allTasksCombinedW) * 100);
+            return { id: g.id, title: g.title, progressPct };
+          })
+      : [];
+
     // ── Steps (from HealthConnect cache if available) ─────────────────────
     let steps = -1;
     try {
@@ -5817,6 +5829,7 @@ const DayPlanner = () => {
       overdue: overdueItems,
       overdueToday: overdueTodayItems,
       habits: habitItems,
+      goals: goalItems,
       allDay: allDayItems,
       deadlines: deadlineItems,
       sections,
@@ -5839,6 +5852,7 @@ const DayPlanner = () => {
     glanceAhead,
     currentTime,
     projects,
+    goals,
     goalsProjectsEnabled,
   ]);
 


### PR DESCRIPTION
## Summary

Goals due today now appear in the home screen widget, positioned right after habit rings — matching the new Glance panel order.

**JS (`App.jsx`)**
- Imports `calculateGoalProgress`
- Computes `goalItems`: active goals where `targetDate === todayStr`, each with `{ id, title, progressPct }`
- Adds `goals` field to the widget snapshot JSON
- Adds `goals` / `goalsProjectsEnabled` to the `useEffect` dependency array

**Layout (`widget_item_goal.xml`)**
- Single-row, same height as a short task row
- 3dp amber left bar (signals "due today" without needing a text badge)
- Title `TextView` (flex, 1-line ellipsize)
- 56dp horizontal `ProgressBar`
- 30dp "X%" `TextView`

**Kotlin (`DayGlanceWidgetListFactory`)**
- `TYPE_GOAL = 7`, `getViewTypeCount` bumped to 8
- `AgendaItem.Goal(title, progressPct)` sealed class
- Parses `goals` array from snapshot after habits (step 1.5), before overdue
- `buildGoalView()` — sets title, `setProgressBar`, percentage label
- `buildView` dispatch case added

## Test plan
- [x] Widget shows goal row(s) between habits and overdue when a goal is due today
- [x] Progress bar reflects `progressPct` (0–100)
- [x] Amber left bar visible
- [x] No goal rows when no goals are due today or goals feature is disabled
- [x] `getViewTypeCount` = 8 (no crash on Samsung/AOSP launchers)

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn