### PR TITLE
Fix recurring task postpone and instance date change

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2408,28 +2408,57 @@ const DayPlanner = () => {
           recordDeletedTaskTombstone(parsed.templateId);
           setRecurringTasks(prev => prev.filter(t => t.id !== parsed.templateId));
         } else {
-          setRecurringTasks(prev => prev.map(t => {
-            if (t.id === parsed.templateId) {
-              const updated = {
+          const dateChanged = newTask.date && newTask.date !== parsed.dateStr;
+          const isDaily = newTask.recurrence?.type === 'daily';
+          if (dateChanged && !isDaily) {
+            // Date changed for a non-daily recurring instance:
+            // skip the original occurrence and create a one-off task on the new date
+            setRecurringTasks(prev => prev.map(t => {
+              if (t.id !== parsed.templateId) return t;
+              return {
                 ...t,
                 exceptions: {
                   ...t.exceptions,
-                  [parsed.dateStr]: {
-                    ...(t.exceptions?.[parsed.dateStr] || {}),
-                    title: cleanTitle(newTask.title),
-                    startTime: newTask.isAllDay ? '00:00' : newTask.startTime,
-                    duration: newTask.duration,
-                    isAllDay: newTask.isAllDay || false,
-                    color: newTask.color || colors[0].class,
-                  }
+                  [parsed.dateStr]: { ...(t.exceptions?.[parsed.dateStr] || {}), skipped: true },
                 }
               };
-              // Update recurrence pattern on template if changed
-              updated.recurrence = { ...newTask.recurrence, startDate: t.recurrence?.startDate || parsed.dateStr.substring(0, 8) + '01' };
-              return updated;
-            }
-            return t;
-          }));
+            }));
+            setTasks(prev => [...prev, {
+              id: crypto.randomUUID(),
+              title: cleanTitle(newTask.title),
+              startTime: newTask.isAllDay ? '00:00' : newTask.startTime,
+              duration: newTask.duration,
+              color: newTask.color || colors[0].class,
+              isAllDay: newTask.isAllDay || false,
+              date: newTask.date,
+              completed: false,
+              notes: '',
+              subtasks: [],
+            }]);
+          } else {
+            setRecurringTasks(prev => prev.map(t => {
+              if (t.id === parsed.templateId) {
+                const updated = {
+                  ...t,
+                  exceptions: {
+                    ...t.exceptions,
+                    [parsed.dateStr]: {
+                      ...(t.exceptions?.[parsed.dateStr] || {}),
+                      title: cleanTitle(newTask.title),
+                      startTime: newTask.isAllDay ? '00:00' : newTask.startTime,
+                      duration: newTask.duration,
+                      isAllDay: newTask.isAllDay || false,
+                      color: newTask.color || colors[0].class,
+                    }
+                  }
+                };
+                // Update recurrence pattern on template if changed
+                updated.recurrence = { ...newTask.recurrence, startDate: t.recurrence?.startDate || parsed.dateStr.substring(0, 8) + '01' };
+                return updated;
+              }
+              return t;
+            }));
+          }
         }
       }
     } else if (newTask.recurrence) {

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -235,14 +235,20 @@ const MobileNewTaskModal = () => {
                 <div className="grid grid-cols-2 gap-3">
                   <div>
                     <label className={`block text-sm ${textSecondary} mb-1`}>Date</label>
-                    <button
-                      type="button"
-                      onClick={() => !newTask.keepUnscheduled && setShowDatePicker(true)}
-                      disabled={newTask.keepUnscheduled}
-                      className={`w-full px-3 py-2 border ${borderClass} rounded-lg text-left text-sm ${darkMode ? 'bg-gray-700 text-white' : 'bg-white'} ${newTask.keepUnscheduled ? 'opacity-50 cursor-not-allowed' : ''}`}
-                    >
-                      {newTask.date ? new Date(newTask.date + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : 'Select'}
-                    </button>
+                    {(() => {
+                      const isRecurringEdit = mobileEditingTask && typeof mobileEditingTask.id === 'string' && mobileEditingTask.id.startsWith('recurring-');
+                      const dateDisabled = newTask.keepUnscheduled || (isRecurringEdit && newTask.recurrence?.type === 'daily');
+                      return (
+                        <button
+                          type="button"
+                          onClick={() => !dateDisabled && setShowDatePicker(true)}
+                          disabled={dateDisabled}
+                          className={`w-full px-3 py-2 border ${borderClass} rounded-lg text-left text-sm ${darkMode ? 'bg-gray-700 text-white' : 'bg-white'} ${dateDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                        >
+                          {newTask.date ? new Date(newTask.date + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : 'Select'}
+                        </button>
+                      );
+                    })()}
                   </div>
                   <div>
                     <label className={`block text-sm ${textSecondary} mb-1`}>Time</label>

--- a/src/components/MobileTimeGrid.jsx
+++ b/src/components/MobileTimeGrid.jsx
@@ -330,15 +330,14 @@ const MobileTimeGrid = () => {
                   {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
                   {inMenu && <span className="text-xs">{isLinkOnlyTask(task) ? 'Open Link' : 'Notes'}</span>}
                 </button>
-                {!(typeof task.id === 'string' && task.id.startsWith('recurring-')) && (
-                  <button
-                    onClick={(e) => { e.stopPropagation(); postponeTask(task.id); }}
-                    className={`hover:bg-white/20 rounded p-1 transition-colors ${inMenu ? 'flex items-center gap-2 w-full' : ''}`}
-                  >
-                    <SkipForward size={14} />
-                    {inMenu && <span className="text-xs">Postpone</span>}
-                  </button>
-                )}
+                <button
+                  onClick={(e) => { e.stopPropagation(); postponeTask(task.id); }}
+                  className={`hover:bg-white/20 rounded p-1 transition-colors ${inMenu ? 'flex items-center gap-2 w-full' : ''}`}
+                  title="Postpone to tomorrow"
+                >
+                  <SkipForward size={14} />
+                  {inMenu && <span className="text-xs">Postpone</span>}
+                </button>
               </>
             );
 

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -320,10 +320,18 @@ const TimeGrid = () => {
 
             const ActionButtons = ({ inMenu = false }) => {
               if (isRecurringTask) {
-                // Recurring: Notes (tablet+desktop), Edit + Delete (desktop only)
+                // Recurring: Notes, Postpone, Edit + Delete (desktop only)
                 return (
                   <>
                     <NotesButton inMenu={inMenu} />
+                    <button
+                      onClick={() => postponeTask(task.id)}
+                      className={`hover:bg-white/20 rounded p-1 transition-colors ${inMenu ? 'flex items-center gap-2 w-full' : ''}`}
+                      title="Postpone to tomorrow"
+                    >
+                      <SkipForward size={14} />
+                      {inMenu && <span className="text-xs">Postpone</span>}
+                    </button>
                     {!isTablet && (
                     <button
                       onClick={() => openMobileEditTask(task, false)}

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -444,7 +444,35 @@ export default function useTaskActions({
   // ── Task move ────────────────────────────────────────────────────────────
 
   const postponeTask = (id) => {
-    if (typeof id === 'string' && id.startsWith('recurring-')) return;
+    if (typeof id === 'string' && id.startsWith('recurring-')) {
+      const parsed = parseRecurringId(id);
+      if (!parsed) return;
+      const template = recurringTasks.find(t => t.id === parsed.templateId);
+      if (!template) return;
+      const exc = template.exceptions?.[parsed.dateStr] || {};
+      const title = exc.title || template.title;
+      const startTime = exc.startTime !== undefined ? exc.startTime : (template.startTime || '');
+      const duration = exc.duration !== undefined ? exc.duration : (template.duration ?? 30);
+      const color = exc.color || template.color;
+      const isAllDay = exc.isAllDay !== undefined ? exc.isAllDay : (template.isAllDay ?? false);
+      if (!startTime && !isAllDay) return;
+      const nextDay = new Date(parsed.dateStr + 'T12:00:00');
+      nextDay.setDate(nextDay.getDate() + 1);
+      const nextDateStr = dateToString(nextDay);
+      pushUndo();
+      setRecurringTasks(prev => prev.map(t => t.id !== parsed.templateId ? t : {
+        ...t,
+        exceptions: { ...t.exceptions, [parsed.dateStr]: { ...(t.exceptions?.[parsed.dateStr] || {}), skipped: true } },
+      }));
+      setTasks(prev => [...prev, {
+        id: crypto.randomUUID(), title,
+        startTime: isAllDay ? '00:00' : startTime, duration, color,
+        isAllDay, date: nextDateStr, completed: false, notes: '', subtasks: [],
+      }]);
+      setUndoToast({ message: 'Task postponed to tomorrow', actionable: true });
+      playUISound('slide');
+      return;
+    }
     const task = tasks.find(t => t.id === id);
     if (!task || !task.startTime || !task.date) return;
 

--- a/src/utils/recurrenceEngine.js
+++ b/src/utils/recurrenceEngine.js
@@ -22,7 +22,7 @@ export const getOccurrencesInRange = (template, rangeStartStr, rangeEndStr) => {
     if (count >= maxOcc) return false;
     if (endDate && d > endDate) return false;
     const ds = dateToString(d);
-    if (template.exceptions && template.exceptions[ds]?.deleted) { count++; return true; }
+    if (template.exceptions && (template.exceptions[ds]?.deleted || template.exceptions[ds]?.skipped)) { count++; return true; }
     if (d >= rangeStart && d <= rangeEnd) results.push(ds);
     count++;
     return true;


### PR DESCRIPTION
## Summary

- **Postpone button on all devices**: Recurring tasks now show the postpone button on desktop and tablet (previously only mobile had it, and even mobile had it gated out). Postponing a recurring instance marks the original occurrence as `skipped` and creates a one-off task on the next day.
- **Date change for non-daily instances**: Editing a recurring task instance and changing the date now works — the original occurrence is marked `skipped` and a standalone one-off task is created on the new date. Daily recurrences are excluded (changing the date of a daily instance makes no sense, so the date picker is disabled in that case).
- **recurrenceEngine**: Extended the `skipped` flag check (alongside `deleted`) so skipped occurrences are suppressed when computing recurrence ranges.

## Files changed

- `src/utils/recurrenceEngine.js` — suppress `skipped` occurrences
- `src/hooks/useTaskActions.js` — implement postpone for recurring instances
- `src/App.jsx` — handle date change in `saveMobileEditTask` for non-daily recurring instances
- `src/components/TimeGrid.jsx` — add postpone button to recurring task action buttons
- `src/components/MobileTimeGrid.jsx` — remove recurring-task guard on postpone button
- `src/components/MobileNewTaskModal.jsx` — disable date picker when editing a daily recurring instance

## Test plan

- [x] Recurring weekly task: postpone button appears on desktop/tablet, clicking it skips today's occurrence and adds a one-off task tomorrow
- [x] Recurring daily task: postpone button works the same way
- [x] Edit recurring weekly/monthly/yearly task instance, change the date → original occurrence disappears, new one-off task appears on the chosen date
- [x] Edit recurring daily task instance → date picker is disabled (greyed out)
- [x] Existing recurrence exception edits (title, time, color) still work when date is unchanged

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn