### PR TITLE
Show recurring icon in Glance where inbox button would be

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -558,13 +558,21 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                 </div>
                 <div className="flex items-center gap-1 flex-shrink-0">
                   {task.isRecurring ? (
-                    <button
-                      onClick={() => toggleComplete(task.id, false)}
-                      className={`p-1.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-stone-100 text-stone-500'} ${isDesktop ? 'hover:scale-95' : 'active:scale-95'} transition-transform`}
-                      title="Mark complete"
-                    >
-                      <CheckCircle size={14} />
-                    </button>
+                    <>
+                      <span
+                        className={`p-1.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-stone-100 text-stone-500'} opacity-50 cursor-default`}
+                        title="Recurring task"
+                      >
+                        <RefreshCw size={14} />
+                      </span>
+                      <button
+                        onClick={() => toggleComplete(task.id, false)}
+                        className={`p-1.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-stone-100 text-stone-500'} ${isDesktop ? 'hover:scale-95' : 'active:scale-95'} transition-transform`}
+                        title="Mark complete"
+                      >
+                        <CheckCircle size={14} />
+                      </button>
+                    </>
                   ) : (
                   <button
                     onClick={() => {
@@ -850,7 +858,14 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
           </div>
           {(relativeLabel === 'Overdue' || (task._agendaType === 'allday' && !task.imported)) && !task.completed && (
             <div className="flex items-center gap-1 flex-shrink-0 mr-5">
-              {!task.isRecurring && (
+              {task.isRecurring ? (
+                <span
+                  className={`p-1.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-stone-100 text-stone-500'} opacity-50 cursor-default`}
+                  title="Recurring task"
+                >
+                  <RefreshCw size={14} />
+                </span>
+              ) : (
                 <button
                   onClick={(e) => {
                     e.stopPropagation();

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -502,13 +502,21 @@ const MobileGlanceSection = () => {
                 </div>
                 <div className="flex items-center gap-1 flex-shrink-0">
                   {task.isRecurring ? (
-                    <button
-                      onClick={() => toggleComplete(task.id, false)}
-                      className={`p-1.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-stone-100 text-stone-500'} active:scale-95 transition-transform`}
-                      title="Mark complete"
-                    >
-                      <CheckCircle size={14} />
-                    </button>
+                    <>
+                      <span
+                        className={`p-1.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-stone-100 text-stone-500'} opacity-50 cursor-default`}
+                        title="Recurring task"
+                      >
+                        <RefreshCw size={14} />
+                      </span>
+                      <button
+                        onClick={() => toggleComplete(task.id, false)}
+                        className={`p-1.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-stone-100 text-stone-500'} active:scale-95 transition-transform`}
+                        title="Mark complete"
+                      >
+                        <CheckCircle size={14} />
+                      </button>
+                    </>
                   ) : (
                     <button
                       onClick={() => {
@@ -793,7 +801,14 @@ const MobileGlanceSection = () => {
           </div>
           {(relativeLabel === 'Overdue' || (task._agendaType === 'allday' && !task.imported)) && !task.completed && (
             <div className="flex items-center gap-1 flex-shrink-0 mr-5">
-              {!task.isRecurring && (
+              {task.isRecurring ? (
+                <span
+                  className={`p-1.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-stone-100 text-stone-500'} opacity-50 cursor-default`}
+                  title="Recurring task"
+                >
+                  <RefreshCw size={14} />
+                </span>
+              ) : (
                 <button
                   onClick={(e) => {
                     e.stopPropagation();


### PR DESCRIPTION
## Summary

For recurring tasks in the Glance panel, a dimmed `RefreshCw` icon now appears where the inbox button would normally be. This visually explains the absent inbox button rather than leaving a blank gap.

- Same `p-1.5 rounded-lg` pill style as the surrounding buttons
- `opacity-50 cursor-default` — decorative only, no click handler
- Tooltip: "Recurring task"
- Applies to both the overdue/deadline section and the all-day/agenda section
- Covers `GlanceSidebar` (desktop) and `MobileGlanceSection` (mobile/tablet)

## Test plan

- [x] Overdue recurring task in Glance: shows `RefreshCw` icon + complete button (no inbox button)
- [x] All-day recurring task in Glance agenda: shows `RefreshCw` icon where inbox would appear
- [x] Non-recurring tasks: unchanged — still show inbox button as before
- [x] Hovering the icon shows "Recurring task" tooltip; clicking does nothing

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn