### PR TITLE
Add postpone button to recurring all-day tasks (CalendarHeader)

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -248,10 +248,18 @@ const CalendarHeader = () => {
 
             const renderAllDayActionButtons = (inMenu = false) => {
               if (isRecurringAllDay) {
-                // Recurring all-day: Notes, Edit + Delete (desktop only)
+                // Recurring all-day: Notes, Postpone, Edit + Delete (desktop only)
                 return (
                   <>
                     {renderAllDayNotesButton(inMenu)}
+                    <button
+                      onClick={() => postponeTask(task.id)}
+                      className={`hover:bg-white/20 rounded p-1 transition-colors ${inMenu ? 'flex items-center gap-2 w-full' : ''}`}
+                      title="Postpone to tomorrow"
+                    >
+                      <SkipForward size={14} />
+                      {inMenu && <span className="text-xs">Postpone</span>}
+                    </button>
                     {!isTablet && (
                     <button
                       onClick={() => openMobileEditTask(task, false)}


### PR DESCRIPTION
## Summary

`CalendarHeader.jsx` renders action buttons for all-day tasks. The recurring branch was missing the Postpone button — same gap as the timed-task fix already shipped in #363.

One-file change: added the `SkipForward` postpone button to the `isRecurringAllDay` branch in `renderAllDayActionButtons`, no tablet gate (same as non-recurring all-day tasks).

## Test plan

- [x] Recurring all-day task on desktop/tablet: postpone button appears in the task chip
- [x] Clicking it skips the original occurrence and creates a one-off all-day task the next day
- [x] Non-recurring all-day tasks: unchanged

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn