### PR TITLE
Hide postpone button for daily recurring tasks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1558,6 +1558,7 @@ const DayPlanner = () => {
           date: dateStr,
           isRecurring: true,
           recurringTemplateId: template.id,
+          recurrenceType: template.recurrence?.type,
           _overdueType: 'scheduled',
         });
       }
@@ -4950,6 +4951,7 @@ const DayPlanner = () => {
           date: dateStr,
           isRecurring: true,
           recurringTemplateId: template.id,
+          recurrenceType: template.recurrence?.type,
           ...(template.isExample ? { isExample: true } : {}),
         });
       }
@@ -8042,7 +8044,8 @@ const DayPlanner = () => {
         // Check if any menu items would be visible; if not, don't show the menu
         const hasEdit = !isImported;
         const hasNotes = isImported ? !!ctxHasNotes : true;
-        const hasMoveTomorrow = !isImported && !isInbox;
+        const isDaily = isRecurring && ctxTask?.recurrenceType === 'daily';
+        const hasMoveTomorrow = !isImported && !isInbox && !isDaily;
         const hasMoveInbox = !isRecurring && !isImported && !isAllDay && !isInbox;
         const hasComplete = !isImported || isTaskCalendar;
         const hasDelete = !isImported;
@@ -8113,7 +8116,7 @@ const DayPlanner = () => {
                   Generate subtasks (AI)
                 </button>
               )}
-              {!isImported && !isInbox && (
+              {!isImported && !isInbox && !isDaily && (
                 <button
                   className={`w-full text-left px-3 py-2 text-sm ${textPrimary} ${hoverBg} transition-colors flex items-center gap-2`}
                   onClick={() => {

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -248,10 +248,20 @@ const CalendarHeader = () => {
 
             const renderAllDayActionButtons = (inMenu = false) => {
               if (isRecurringAllDay) {
-                // Recurring all-day: Notes, Edit + Delete (desktop only)
+                // Recurring all-day: Notes, Postpone (non-daily only), Edit + Delete (desktop only)
                 return (
                   <>
                     {renderAllDayNotesButton(inMenu)}
+                    {task.recurrenceType !== 'daily' && (
+                    <button
+                      onClick={() => postponeTask(task.id)}
+                      className={`hover:bg-white/20 rounded p-1 transition-colors ${inMenu ? 'flex items-center gap-2 w-full' : ''}`}
+                      title="Postpone to tomorrow"
+                    >
+                      <SkipForward size={14} />
+                      {inMenu && <span className="text-xs">Postpone</span>}
+                    </button>
+                    )}
                     {!isTablet && (
                     <button
                       onClick={() => openMobileEditTask(task, false)}

--- a/src/components/MobileTimeGrid.jsx
+++ b/src/components/MobileTimeGrid.jsx
@@ -330,14 +330,16 @@ const MobileTimeGrid = () => {
                   {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
                   {inMenu && <span className="text-xs">{isLinkOnlyTask(task) ? 'Open Link' : 'Notes'}</span>}
                 </button>
-                <button
-                  onClick={(e) => { e.stopPropagation(); postponeTask(task.id); }}
-                  className={`hover:bg-white/20 rounded p-1 transition-colors ${inMenu ? 'flex items-center gap-2 w-full' : ''}`}
-                  title="Postpone to tomorrow"
-                >
-                  <SkipForward size={14} />
-                  {inMenu && <span className="text-xs">Postpone</span>}
-                </button>
+                {task.recurrenceType !== 'daily' && (
+                  <button
+                    onClick={(e) => { e.stopPropagation(); postponeTask(task.id); }}
+                    className={`hover:bg-white/20 rounded p-1 transition-colors ${inMenu ? 'flex items-center gap-2 w-full' : ''}`}
+                    title="Postpone to tomorrow"
+                  >
+                    <SkipForward size={14} />
+                    {inMenu && <span className="text-xs">Postpone</span>}
+                  </button>
+                )}
               </>
             );
 

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -320,10 +320,11 @@ const TimeGrid = () => {
 
             const ActionButtons = ({ inMenu = false }) => {
               if (isRecurringTask) {
-                // Recurring: Notes, Postpone, Edit + Delete (desktop only)
+                // Recurring: Notes, Postpone (non-daily only), Edit + Delete (desktop only)
                 return (
                   <>
                     <NotesButton inMenu={inMenu} />
+                    {task.recurrenceType !== 'daily' && (
                     <button
                       onClick={() => postponeTask(task.id)}
                       className={`hover:bg-white/20 rounded p-1 transition-colors ${inMenu ? 'flex items-center gap-2 w-full' : ''}`}
@@ -332,6 +333,7 @@ const TimeGrid = () => {
                       <SkipForward size={14} />
                       {inMenu && <span className="text-xs">Postpone</span>}
                     </button>
+                    )}
                     {!isTablet && (
                     <button
                       onClick={() => openMobileEditTask(task, false)}

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -449,6 +449,7 @@ export default function useTaskActions({
       if (!parsed) return;
       const template = recurringTasks.find(t => t.id === parsed.templateId);
       if (!template) return;
+      if (template.recurrence?.type === 'daily') return; // daily tasks recur tomorrow anyway
       const exc = template.exceptions?.[parsed.dateStr] || {};
       const title = exc.title || template.title;
       const startTime = exc.startTime !== undefined ? exc.startTime : (template.startTime || '');


### PR DESCRIPTION
## Summary

Postponing a daily recurring task would create a duplicate — the one-off task lands on tomorrow alongside the regular daily occurrence that was already going to appear there.

**Fix:**
- Stamp `recurrenceType` on expanded recurring task instances (both the main expansion loop and the overdue path in `App.jsx`)
- Early return in `postponeTask` when `recurrenceType === 'daily'`
- Hide the postpone button (`SkipForward`) in `TimeGrid`, `MobileTimeGrid`, and `CalendarHeader` when `task.recurrenceType === 'daily'`
- Hide "Move to tomorrow" in the right-click context menu for daily tasks

Also supersedes #366 — the `CalendarHeader` all-day postpone button is included here with the daily guard already applied, so #366 can be closed.

## Test plan

- [x] Daily recurring task: no postpone button visible anywhere (inline, overflow menu, right-click)
- [x] Weekly/monthly/yearly recurring task: postpone button still appears and works
- [x] Non-recurring tasks: unchanged

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn