### PR TITLE
Hide postpone button for daily recurring all-day tasks (MobileAllDaySection)

### DIFF
--- a/src/components/MobileAllDaySection.jsx
+++ b/src/components/MobileAllDaySection.jsx
@@ -175,12 +175,14 @@ const MobileAllDaySection = () => {
                           >
                             {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
                           </button>
+                          {task.recurrenceType !== 'daily' && (
                           <button
                             onClick={(e) => { e.stopPropagation(); postponeTask(task.id); }}
                             className="hover:bg-white/20 rounded p-1 transition-colors flex-shrink-0"
                           >
                             <SkipForward size={14} />
                           </button>
+                          )}
                         </>
                       )}
                       {isImported && !task.isTaskCalendar && task.notes && (


### PR DESCRIPTION
## Summary

`MobileAllDaySection.jsx` was missed in #367. The postpone button is now gated with `task.recurrenceType !== 'daily'` here too.

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn