### PR TITLE
Fix date picker still enabled for daily recurring tasks

### DIFF
--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -237,7 +237,7 @@ const MobileNewTaskModal = () => {
                     <label className={`block text-sm ${textSecondary} mb-1`}>Date</label>
                     {(() => {
                       const isRecurringEdit = mobileEditingTask && typeof mobileEditingTask.id === 'string' && mobileEditingTask.id.startsWith('recurring-');
-                      const dateDisabled = newTask.keepUnscheduled || (isRecurringEdit && newTask.recurrence?.type === 'daily');
+                      const dateDisabled = newTask.keepUnscheduled || (isRecurringEdit && (mobileEditingTask.recurrenceType === 'daily' || newTask.recurrence?.type === 'daily'));
                       return (
                         <button
                           type="button"


### PR DESCRIPTION
## Summary

The date button disable condition in `MobileNewTaskModal` checked `newTask.recurrence?.type === 'daily'`, but `newTask.recurrence` can be null if the template lookup in `openMobileEditTask` fails or hasn't propagated yet.

Now also checks `mobileEditingTask.recurrenceType === 'daily'` (stamped directly on expanded task instances in #367), so either source disables the picker.

## Test plan

- [x] Open edit modal for a daily recurring task on desktop → date picker greyed out, not clickable
- [x] Open edit modal for a weekly/monthly recurring task → date picker still works
- [x] Non-recurring tasks: unchanged

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn