### PR TITLE
Disable date picker for daily recurring tasks in DesktopNewTaskModal

### DIFF
--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -354,14 +354,20 @@ const DesktopNewTaskModal = () => {
                     </div>
                     <div>
                       <label className={`block text-sm ${textSecondary} mb-1`}>Date</label>
-                      <button
-                        type="button"
-                        onClick={() => !newTask.keepUnscheduled && setShowDatePicker(true)}
-                        disabled={newTask.keepUnscheduled}
-                        className={`w-full px-3 py-2 border ${borderClass} rounded-lg text-left text-sm ${darkMode ? 'bg-gray-700 text-white' : 'bg-white'} ${newTask.keepUnscheduled ? 'opacity-50 cursor-not-allowed' : ''}`}
-                      >
-                        {newTask.date ? new Date(newTask.date + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : 'Select'}
-                      </button>
+                      {(() => {
+                        const isRecurringEdit = mobileEditingTask && typeof mobileEditingTask.id === 'string' && mobileEditingTask.id.startsWith('recurring-');
+                        const dateDisabled = newTask.keepUnscheduled || (isRecurringEdit && (mobileEditingTask.recurrenceType === 'daily' || newTask.recurrence?.type === 'daily'));
+                        return (
+                          <button
+                            type="button"
+                            onClick={() => !dateDisabled && setShowDatePicker(true)}
+                            disabled={dateDisabled}
+                            className={`w-full px-3 py-2 border ${borderClass} rounded-lg text-left text-sm ${darkMode ? 'bg-gray-700 text-white' : 'bg-white'} ${dateDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                          >
+                            {newTask.date ? new Date(newTask.date + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : 'Select'}
+                          </button>
+                        );
+                      })()}
                     </div>
                     <div className="relative">
                       <label className={`block text-sm ${textSecondary} mb-1`}>Recurrence</label>


### PR DESCRIPTION
## Summary

`DesktopNewTaskModal` has its own date button separate from `MobileNewTaskModal`. Same disable logic applied: greys out the date picker when editing a daily recurring task instance.

## Test plan

- [x] Edit a daily recurring task on desktop → date picker greyed out, not clickable
- [x] Edit a weekly/monthly recurring task on desktop → date picker still works

https://claude.ai/code/session_01CkX6NtLSKCZ8uANTdUSAUn