### PR TITLE
Fix: Obsidian setup invisible on clean Android install

### DIFF
--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -170,7 +170,7 @@ const MobileSettingsPanel = () => {
     </div>
 
     {/* Sync buttons */}
-    {(calSyncConfigured || cloudSyncConfig?.enabled || obsidianConfig?.enabled) && (
+    {(calSyncConfigured || cloudSyncConfig?.enabled || obsidianConfig?.enabled || isNativeAndroid()) && (
       <div className="space-y-2">
         <h3 className={`text-xs font-semibold uppercase tracking-wide ${textSecondary} px-1`}>Sync</h3>
         {calSyncConfigured && (


### PR DESCRIPTION
## Problem

On a fresh Android install with no prior configuration, the Obsidian vault setup button is completely invisible. The "Sync" section in `MobileSettingsPanel` is gated behind:

```js
(calSyncConfigured || cloudSyncConfig?.enabled || obsidianConfig?.enabled)
```

All three are false on a clean install, so the entire section — including the Obsidian entry — is hidden. Users have no visible path to configure their vault.

## Fix

One-line change: add `isNativeAndroid()` to the condition so the Sync section is always shown on Android regardless of configuration state.

## Test plan

- [x] Fresh Android install (or clear app data): Settings shows the Obsidian row
- [x] Tapping Obsidian row → sub-view shows "No vault configured" + "Vault Settings" button
- [x] After configuring vault and returning, "Vault connected" appears and sync runs
- [x] On web (non-Android): Sync section still hidden until a sync service is configured (no regression)

https://claude.ai/code/session_011GBxNYmTvdnb2mthg8QU63