### PR TITLE
Fix bare wikilink not finding notes created after last sync

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
@@ -65,10 +65,22 @@ class ObsidianRepository(private val context: Context) {
         }
     }
 
-    /** Returns the URI for a note by bare name, building the index first if needed. */
+    /**
+     * Returns the URI for a note by bare name.
+     *
+     * Checks the in-memory index first (O(1)). On a cache miss — which happens
+     * when a note was added to the vault after the last sync — rebuilds the index
+     * and tries once more. This keeps the common case fast while still finding
+     * notes that were created outside of a sync cycle.
+     */
     private fun findNoteUri(noteName: String): Uri? {
         if (!noteIndexBuilt) buildNoteIndex()
         return noteUriIndex[noteName.lowercase()]
+            ?: run {
+                // Cache miss: note may have been added since last build — rescan and retry
+                buildNoteIndex()
+                noteUriIndex[noteName.lowercase()]
+            }
     }
 
     // ── Internal helpers ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Bare-name wikilinks (e.g. `[[My Note]]`) opened an empty panel when the note was created in Obsidian *after* the last dayGLANCE vault sync.

`findNoteUri()` checked the in-memory index, which is built during `getAllDailyNotes()` at sync time. Notes added after that sync weren't in the index, so `getNote()` returned `""` even though the file existed in the vault. Explicit-path wikilinks (e.g. `[[Folder/Note]]`) were unaffected because they navigate SAF directly without touching the index.

## Fix

On a cache miss, rebuild the index once and retry. One line of logic change.

- **Common case** (note was in vault at sync time): O(1) index hit — no change in behaviour or performance.
- **Cache miss** (note added after sync): one vault rescan, then found. Same cost as the old recursive scan, but only paid when actually needed.
- **Genuinely new note** (doesn't exist yet): rescan confirms absence, `getNote` returns `""`, panel opens in create mode — correct behaviour.

## Test plan

- [x] Create a note in Obsidian, then (without syncing dayGLANCE) create a task with `[[NoteName]]` — panel should load the note content
- [x] Notes present at sync time still load instantly (index hit, no rescan)
- [x] Explicit-path wikilinks `[[Folder/Note]]` continue to work (unaffected code path)
- [x] Non-existent bare wikilink opens in create/edit mode as before

https://claude.ai/code/session_011GBxNYmTvdnb2mthg8QU63