### PR TITLE
Wikilink tasks: show BookOpen icon; expand Open-in-Obsidian button label

### DIFF
--- a/src/components/NotesSubtasksPanel.jsx
+++ b/src/components/NotesSubtasksPanel.jsx
@@ -179,8 +179,8 @@ const NotesSubtasksPanel = ({
                       title={`Open "${noteName}" in Obsidian`}
                       className="flex items-center gap-1 opacity-70 hover:opacity-100 active:opacity-100 transition-opacity px-1 py-0.5 rounded hover:bg-white/10 active:bg-white/10"
                     >
-                      <ExternalLink size={11} />
-                      <span className="text-[10px]">Open</span>
+                      <ExternalLink size={12} />
+                      <span className="text-xs">Open in Obsidian</span>
                     </button>
                   )}
                 </div>

--- a/src/utils/textFormatting.jsx
+++ b/src/utils/textFormatting.jsx
@@ -182,12 +182,14 @@ export const hasOnlySubtasks = (task) => {
   return (!task.notes || !task.notes.trim()) && task.subtasks && task.subtasks.length > 0;
 };
 
-// Check if task is Obsidian-sourced with only a note (no subtasks, no plain URL)
+// Check if task should show the vault-linked note icon (BookOpen).
+// True for Obsidian-imported tasks OR any task whose title contains [[wikilinks]],
+// as long as it isn't purely a link/URL and has no subtasks.
 export const isObsidianNoteOnlyTask = (task) => {
-  if (task.importSource !== 'obsidian') return false;
   if (task.subtasks && task.subtasks.length > 0) return false;
   if (isLinkOnlyTask(task)) return false;
-  return true;
+  if (task.importSource === 'obsidian') return true;
+  return /\[\[[^\]]+\]\]/.test(task.title || '');
 };
 
 // Strip wikilinks from displayed text; style hashtags


### PR DESCRIPTION
## Changes

**1. BookOpen icon for `[[wikilink]]` tasks**

`isObsidianNoteOnlyTask()` previously required `importSource === 'obsidian'`, so manually-created tasks with `[[wikilinks]]` kept the generic FileText icon. Updated the function to also return `true` when the task title matches `[[...]]`, regardless of import source.

One change in `textFormatting.jsx` covers all 10 icon-decision ternaries across 7 components (MobileLayout, TimeGrid, CalendarHeader, MobileTimeGrid, InboxSidebar, MobileAllDaySection, ProjectCard) — no other files needed.

**2. "Open in Obsidian" button text**

- Label: `"Open"` → `"Open in Obsidian"`  
- Font: `text-[10px]` → `text-xs`  
- Icon: `size={11}` → `size={12}`

## Test plan

- [x] Task with `[[note]]` (no `#obsidian` tag): notes toggle button shows BookOpen icon
- [x] Task with `#obsidian` tag from vault sync: BookOpen icon still shows (no regression)
- [x] Task with subtasks only: still shows CheckSquare (no regression)
- [x] Link-only task: still shows ExternalLink (no regression)
- [x] "Open in Obsidian" button label is readable and full text is visible in the note panel header

https://claude.ai/code/session_011GBxNYmTvdnb2mthg8QU63