### PR TITLE
Android: add splash screen held until WebView first-paint

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -104,6 +104,9 @@ dependencies {
     // so ES module scripts load without CORS errors on file:// URLs
     implementation(libs.androidx.webkit)
 
+    // Splash screen
+    implementation(libs.androidx.core.splashscreen)
+
     // DocumentFile — Storage Access Framework wrapper for Obsidian vault file I/O
     implementation(libs.androidx.documentfile)
 

--- a/dayglance-android/app/src/main/AndroidManifest.xml
+++ b/dayglance-android/app/src/main/AndroidManifest.xml
@@ -50,7 +50,8 @@
             android:screenOrientation="portrait"
             android:configChanges="screenSize|keyboardHidden"
             android:windowSoftInputMode="adjustNothing"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:theme="@style/Theme.DayGlance.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -55,6 +56,9 @@ class MainActivity : AppCompatActivity() {
     private lateinit var healthRepository: HealthRepository
     private lateinit var dataStore: com.dayglance.app.data.SharedDataStore
 
+    // Splash screen: held until the WebView finishes its first page load
+    @Volatile private var webViewReady = false
+
     // Shown at most once per session so we don't nag the user repeatedly
     private var exactAlarmPromptShown = false
 
@@ -80,7 +84,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
+        splashScreen.setKeepOnScreenCondition { !webViewReady }
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -157,6 +163,8 @@ class MainActivity : AppCompatActivity() {
 
             override fun onPageFinished(view: WebView, url: String) {
                 super.onPageFinished(view, url)
+                // Release the splash screen now that the WebView has rendered.
+                webViewReady = true
                 // Re-apply status bar appearance after the WebView's first paint,
                 // which can reset the icon colour on Android 15 edge-to-edge mode.
                 applyStatusBarAppearance()

--- a/dayglance-android/app/src/main/res/values-night/themes.xml
+++ b/dayglance-android/app/src/main/res/values-night/themes.xml
@@ -8,4 +8,11 @@
         <!-- Dark mode: use light icons (white) so they're visible on dark backgrounds -->
         <item name="android:windowLightStatusBar">false</item>
     </style>
+
+    <!-- Splash screen (dark) -->
+    <style name="Theme.DayGlance.Starting" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">#0f172a</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="postSplashScreenTheme">@style/Theme.DayGlance</item>
+    </style>
 </resources>

--- a/dayglance-android/app/src/main/res/values/themes.xml
+++ b/dayglance-android/app/src/main/res/values/themes.xml
@@ -16,4 +16,11 @@
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
     </style>
+
+    <!-- Splash screen — shown while WebView loads; transitions to Theme.DayGlance -->
+    <style name="Theme.DayGlance.Starting" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">#0f172a</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="postSplashScreenTheme">@style/Theme.DayGlance</item>
+    </style>
 </resources>

--- a/dayglance-android/gradle/libs.versions.toml
+++ b/dayglance-android/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ room = "2.6.1"
 coroutines = "1.8.1"
 lifecycleViewmodel = "2.8.2"
 webkit = "1.11.0"
+splashscreen = "1.0.1"
 documentfile = "1.0.1"
 junit = "4.13.2"
 junitExt = "1.2.1"
@@ -42,6 +43,9 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 
 # WebKit (WebViewAssetLoader — serves assets via https://appassets.androidplatform.net)
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }
+
+# Splash screen
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 
 # DocumentFile (Storage Access Framework — Obsidian vault file I/O)
 androidx-documentfile = { group = "androidx.documentfile", name = "documentfile", version.ref = "documentfile" }


### PR DESCRIPTION
## Summary

- Adds `androidx.core:core-splashscreen 1.0.1` dependency
- Defines `Theme.DayGlance.Starting` (dark `#0f172a` background + app icon) in both `values/` and `values-night/themes.xml`
- Applies `Theme.DayGlance.Starting` to `MainActivity` in the manifest; `postSplashScreenTheme` restores `Theme.DayGlance` after dismissal
- Installs the splash screen in `onCreate` before `super.onCreate()` and holds it via `setKeepOnScreenCondition { !webViewReady }`
- Sets `webViewReady = true` in `onPageFinished` so the splash is shown for exactly as long as the WebView takes to load (vault indexing, asset loading, etc.)

## Test plan

- [x] Fresh install: splash screen (dark background + app icon) appears on launch and dismisses when the UI is ready
- [x] Normal launch (app already installed, vault indexed): splash visible briefly, then UI appears
- [x] Slow load (large vault, cold start): splash stays visible until WebView finishes rendering — no blank white/black flash
- [x] Dark mode and light mode: same dark splash background in both (intentional — matches the app's loading state)
- [x] Back-tap from recents (activity recreated): splash shows again, releases correctly

https://claude.ai/code/session_011GBxNYmTvdnb2mthg8QU63