### PR TITLE
Obsidian: configurable new-notes folder (default "dayGLANCE")

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
@@ -226,6 +226,7 @@ class ObsidianRepository(private val context: Context) {
         put("configured", dataStore.vaultPath != null)
         put("folder", dataStore.dailyNoteFolder)
         put("pattern", dataStore.dailyNotePattern)
+        put("newNotesFolder", dataStore.newNotesFolder)
     }.toString()
 
     /**
@@ -351,13 +352,18 @@ class ObsidianRepository(private val context: Context) {
                 ?: dir.createFile("text/markdown", fileName)
                 ?: return false
         } else {
-            // Use the index to find the existing file; create at vault root if absent
+            // Use the index to find the existing file; if not found create in newNotesFolder
             val existingUri = findNoteUri(noteName)
             val existingFile = existingUri?.let { DocumentFile.fromSingleUri(context, it) }
             existingFile?.takeIf { it.exists() }
-                ?: (root.createFile("text/markdown", fileName) ?: return false).also { created ->
-                    // Keep the index up-to-date so the new file is found on next getNote()
-                    noteUriIndex[noteName.lowercase()] = created.uri
+                ?: run {
+                    val folder = dataStore.newNotesFolder
+                    val dir = if (folder.isBlank()) root
+                              else (root.navigateOrCreate(folder) ?: return false)
+                    (dir.createFile("text/markdown", fileName) ?: return false).also { created ->
+                        // Keep the index up-to-date so the new file is found on next getNote()
+                        noteUriIndex[noteName.lowercase()] = created.uri
+                    }
                 }
         }
 

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
@@ -42,6 +42,16 @@ class SharedDataStore(context: Context) {
             ?: DEFAULT_DAILY_NOTE_PATTERN
         set(value) = prefs.edit { putString(KEY_DAILY_NOTE_PATTERN, value) }
 
+    /**
+     * Folder inside the vault where new notes created by dayGLANCE are stored.
+     * e.g. "dayGLANCE" or "Inbox/dayGLANCE". Empty string means vault root.
+     * Only affects note creation — existing notes are always edited in-place.
+     */
+    var newNotesFolder: String
+        get() = prefs.getString(KEY_NEW_NOTES_FOLDER, DEFAULT_NEW_NOTES_FOLDER)
+            ?: DEFAULT_NEW_NOTES_FOLDER
+        set(value) = prefs.edit { putString(KEY_NEW_NOTES_FOLDER, value) }
+
     // ── App appearance preference ───────────────────────────────────────────
 
     /**
@@ -157,6 +167,7 @@ class SharedDataStore(context: Context) {
         private const val KEY_VAULT_PATH = "obsidian_vault_path"
         private const val KEY_DAILY_NOTE_FOLDER = "obsidian_daily_note_folder"
         private const val KEY_DAILY_NOTE_PATTERN = "obsidian_daily_note_pattern"
+        private const val KEY_NEW_NOTES_FOLDER = "obsidian_new_notes_folder"
         private const val KEY_WIDGET_SNAPSHOT = "widget_snapshot"
         private const val KEY_WIDGET_SNAPSHOT_TS = "widget_snapshot_ts"
         private const val KEY_SCHEDULED_REMINDERS = "scheduled_reminders"
@@ -170,5 +181,6 @@ class SharedDataStore(context: Context) {
         private const val KEY_APP_DARK_MODE = "app_dark_mode"
 
         const val DEFAULT_DAILY_NOTE_PATTERN = "yyyy-MM-dd"
+        const val DEFAULT_NEW_NOTES_FOLDER = "dayGLANCE"
     }
 }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/settings/SettingsActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/settings/SettingsActivity.kt
@@ -54,9 +54,11 @@ class SettingsActivity : AppCompatActivity() {
         // Populate daily note fields from stored prefs
         val folderField = findViewById<TextInputEditText>(R.id.et_daily_note_folder)
         val patternField = findViewById<TextInputEditText>(R.id.et_daily_note_pattern)
+        val newNotesFolderField = findViewById<TextInputEditText>(R.id.et_new_notes_folder)
 
         folderField.setText(dataStore.dailyNoteFolder)
         patternField.setText(dataStore.dailyNotePattern)
+        newNotesFolderField.setText(dataStore.newNotesFolder)
 
         findViewById<Button>(R.id.btn_select_vault)?.setOnClickListener {
             vaultPicker.launch(null)
@@ -68,6 +70,9 @@ class SettingsActivity : AppCompatActivity() {
                 .takeIf { !it.isNullOrBlank() }
                 ?: SharedDataStore.DEFAULT_DAILY_NOTE_PATTERN
             dataStore.dailyNotePattern = pattern
+            dataStore.newNotesFolder = newNotesFolderField.text?.toString()?.trim()
+                .takeIf { !it.isNullOrBlank() }
+                ?: SharedDataStore.DEFAULT_NEW_NOTES_FOLDER
             Toast.makeText(this, "Settings saved", Toast.LENGTH_SHORT).show()
         }
     }

--- a/dayglance-android/app/src/main/res/layout/activity_settings.xml
+++ b/dayglance-android/app/src/main/res/layout/activity_settings.xml
@@ -91,6 +91,36 @@
                 android:imeOptions="actionDone" />
         </com.google.android.material.textfield.TextInputLayout>
 
+        <!-- ── New notes folder ── -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="New Notes Folder"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:layout_marginBottom="4dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Folder where notes created in dayGLANCE are saved. Existing notes are always updated in-place regardless of this setting."
+            android:textAppearance="?attr/textAppearanceBodySmall"
+            android:layout_marginBottom="8dp" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="New notes folder (e.g. dayGLANCE)"
+            android:layout_marginBottom="16dp"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_new_notes_folder"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:imeOptions="actionDone" />
+        </com.google.android.material.textfield.TextInputLayout>
+
         <Button
             android:id="@+id/btn_save_daily_note_settings"
             android:layout_width="wrap_content"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1162,7 +1162,7 @@ const DayPlanner = () => {
         if (cfg?.configured) {
           obsidianVaultHandleRef.current = 'native';
           if (!obsidianConfig?.enabled) {
-            setObsidianConfig({ enabled: true, dailyNotesPath: cfg.folder || '' });
+            setObsidianConfig({ enabled: true, dailyNotesPath: cfg.folder || '', newNotesFolder: cfg.newNotesFolder || 'dayGLANCE' });
           }
           performObsidianSync();
         }
@@ -1196,7 +1196,7 @@ const DayPlanner = () => {
           if (cfg?.configured) {
             obsidianVaultHandleRef.current = 'native';
             if (!obsidianConfig?.enabled) {
-              setObsidianConfig({ enabled: true, dailyNotesPath: cfg.folder || '' });
+              setObsidianConfig({ enabled: true, dailyNotesPath: cfg.folder || '', newNotesFolder: cfg.newNotesFolder || 'dayGLANCE' });
             }
             performObsidianSync();
           }
@@ -1817,11 +1817,11 @@ const DayPlanner = () => {
       return;
     }
     try {
-      await writeWikiNote(handle, noteName, content);
+      await writeWikiNote(handle, noteName, content, obsidianConfig?.newNotesFolder || '');
     } catch (err) {
       console.error('Failed to write wiki note:', err);
     }
-  }, []);
+  }, [obsidianConfig?.newNotesFolder]);
 
   // Opens a vault note in the Obsidian app (Android) or via obsidian:// URI (web/desktop).
   const openInObsidian = useCallback((noteName) => {

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -1089,6 +1089,17 @@ const MobileSettingsPanel = () => {
             <p className={`text-xs ${textSecondary} mt-1`}>Leave empty for vault root. Common: "Daily Notes" or "journals"</p>
           </div>
           <div>
+            <label className={`block text-sm ${textSecondary} mb-1`}>New notes folder</label>
+            <input
+              type="text"
+              placeholder="dayGLANCE"
+              value={obsidianConfig.newNotesFolder ?? 'dayGLANCE'}
+              onChange={(e) => setObsidianConfig(prev => ({ ...prev, newNotesFolder: e.target.value }))}
+              className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
+            />
+            <p className={`text-xs ${textSecondary} mt-1`}>Where new notes created in dayGLANCE are saved. Leave empty for vault root.</p>
+          </div>
+          <div>
             <label className={`block text-sm ${textSecondary} mb-1`}>Daily note template</label>
             <textarea
               value={dailyNoteTemplate}

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -362,9 +362,12 @@ export async function readWikiNote(vaultHandle, noteName) {
  * Write (create or overwrite) an arbitrary vault note by wikilink name.
  *
  * For bare names the vault is searched first so edits land in the file's
- * actual location; if not found the file is created at the vault root.
+ * actual location; if not found the file is created in [newNotesFolder]
+ * (relative to vault root) or at vault root when newNotesFolder is blank.
+ *
+ * @param newNotesFolder  Optional folder for newly created notes, e.g. "dayGLANCE"
  */
-export async function writeWikiNote(vaultHandle, noteName, content) {
+export async function writeWikiNote(vaultHandle, noteName, content, newNotesFolder = '') {
   const parts = noteName.split('/').filter(Boolean);
   for (const part of parts) {
     if (part === '..' || part === '.') {
@@ -382,9 +385,18 @@ export async function writeWikiNote(vaultHandle, noteName, content) {
     }
     fileHandle = await dir.getFileHandle(mdFileName, { create: true });
   } else {
-    // Bare name — write to existing location or create at vault root
+    // Bare name — write to existing location, or create in newNotesFolder (or vault root)
     fileHandle = await findFileHandleInDir(vaultHandle, mdFileName)
-      ?? await vaultHandle.getFileHandle(mdFileName, { create: true });
+      ?? await (async () => {
+        if (newNotesFolder) {
+          let dir = vaultHandle;
+          for (const segment of newNotesFolder.split('/').filter(Boolean)) {
+            dir = await dir.getDirectoryHandle(segment, { create: true });
+          }
+          return dir.getFileHandle(mdFileName, { create: true });
+        }
+        return vaultHandle.getFileHandle(mdFileName, { create: true });
+      })();
   }
 
   const writable = await fileHandle.createWritable();


### PR DESCRIPTION
## Summary

Notes created in dayGLANCE now land in a dedicated folder inside your vault instead of Obsidian's default Inbox folder. The folder defaults to `dayGLANCE` and is configurable.

**Existing notes are always edited in-place** — this setting only applies when a brand-new note is being created for the first time.

### Android
- `SharedDataStore`: new `newNotesFolder` property (prefs key `obsidian_new_notes_folder`, default `"dayGLANCE"`)
- `ObsidianRepository.writeNote()`: bare-name creation navigates to (or creates) `newNotesFolder`; `getVaultConfig()` now includes `newNotesFolder` in the JSON
- `activity_settings.xml`: "New Notes Folder" field below the filename-pattern field
- `SettingsActivity`: reads and saves the new field

### Web (File System Access API)
- `obsidian.js writeWikiNote()`: new optional `newNotesFolder` parameter; new bare-name files are created in that folder (recursively created if absent), falling back to vault root when blank
- `MobileSettingsPanel`: "New notes folder" input added to the Obsidian settings section

### App.jsx
- `saveWikiNote` passes `obsidianConfig.newNotesFolder` to `writeWikiNote`
- Both `nativeGetVaultConfig()` startup paths propagate `cfg.newNotesFolder` into `obsidianConfig` state

## Test plan

- [ ] Android: create a task with a new `[[wikilink]]`, open note panel, type some text, close — confirm file appears in `<vault>/dayGLANCE/<note>.md`
- [ ] Android: change "New Notes Folder" to `"Inbox"` in Settings, create another new wikilink note — confirm it lands in `<vault>/Inbox/`
- [ ] Android: clear the field (empty) — confirm new notes are created at vault root
- [ ] Android: edit an existing note — confirm it updates in-place, NOT moved to the new-notes folder
- [ ] Web: connect vault, set new notes folder to `"dayGLANCE"`, create a new wikilink note — confirm it appears in the right folder
- [ ] Web: leave field empty — new notes created at vault root as before

https://claude.ai/code/session_011GBxNYmTvdnb2mthg8QU63