### PR TITLE
Obsidian wikilink enhancements: timestamp, inline navigation, autocomplete

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback } from 'react';
 import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Moon, Sun, Upload, Inbox, AlertCircle, Calendar, Check, RefreshCw, Palette, Trash2, Undo2, BarChart3, SkipForward, Hash, MoreHorizontal, Save, Menu, BrainCircuit, AlertTriangle, FileText, ExternalLink, CheckSquare, HelpCircle, Sparkles, Link, GripHorizontal, Play, Pause, Trophy, Cloud, Settings, Search, Bell, Target, TrendingUp, Zap, CalendarDays, Ban, Volume2, VolumeX, Pencil, Eye, Filter, Smartphone, CheckCircle, Pin, PinOff, NotebookPen, MapPin, BookOpen, Flag, FolderOpen, Droplets, Footprints, Dumbbell, Apple, Cigarette, Coffee, Flame, Heart, ListChecks, Minus, Wine, Candy, Pill, Activity, CupSoda, Mic, MicOff, Loader, Key, Server, Wifi, WifiOff, LayoutGrid, RotateCcw } from 'lucide-react';
 import { mergeTaskArrays, mergeSyncData } from './mergeSync.js';
-import { isNativeAndroid, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording } from './native.js';
-import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, tryRestoreVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
+import { isNativeAndroid, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording } from './native.js';
+import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, tryRestoreVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, listVaultNotes, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
 import { loadAIConfig, saveAIConfig, aiComplete, aiJSON, aiTranscribe, supportsTranscription, testConnection, DEFAULT_CONFIG, PROVIDER_MODELS, PROVIDER_LABELS } from './ai.js';
 import { voiceParseSystemPrompt, voiceParseUserPrompt, taskSuggestSystemPrompt, taskSuggestUserPrompt, frameNudgeSystemPrompt, frameNudgeUserPrompt, rescheduleSystemPrompt, rescheduleUserPrompt, aiSubtasksSystemPrompt, aiSubtasksUserPrompt, morningSummarySystemPrompt, morningSummaryUserPrompt, eveningReflectionSystemPrompt, eveningReflectionUserPrompt, weeklySummarySystemPrompt, weeklySummaryUserPrompt, smartScheduleSystemPrompt, smartScheduleUserPrompt } from './ai-prompts.js';
 import { gatherTrmnlData, pushToTrmnl, TRMNL_MARKUP_FULL, TRMNL_MARKUP_HALF_HORIZONTAL, TRMNL_MARKUP_HALF_VERTICAL, TRMNL_MARKUP_QUADRANT } from './trmnl.js';
@@ -431,6 +431,10 @@ const DayPlanner = () => {
     obsidianTasksRef,
     obsidianInboxRef,
   } = useObsidian();
+
+  // Wikilink autocomplete candidates — bare note names from the connected vault.
+  // Populated when the vault connects (native or FSA) and used by task-title inputs.
+  const [wikilinkCandidates, setWikilinkCandidates] = useState([]);
 
   // Auto-Backup state
   const [autoBackupConfig, setAutoBackupConfig] = useState(() => {
@@ -1165,6 +1169,11 @@ const DayPlanner = () => {
             setObsidianConfig({ enabled: true, dailyNotesPath: cfg.folder || '', newNotesFolder: cfg.newNotesFolder || 'dayGLANCE' });
           }
           performObsidianSync();
+          // Populate wikilink autocomplete candidates from the vault index
+          try {
+            const notes = nativeListNotes('');
+            if (notes) setWikilinkCandidates(notes.map(p => p.split('/').pop().replace(/\.md$/i, '')).sort((a, b) => a.localeCompare(b)));
+          } catch {}
         }
       } catch (err) {
         console.error('Obsidian: failed to read native vault config', err);
@@ -1178,6 +1187,7 @@ const DayPlanner = () => {
         if (handle) {
           obsidianVaultHandleRef.current = handle;
           performObsidianSync();
+          listVaultNotes(handle).then(names => setWikilinkCandidates(names)).catch(() => {});
         }
       } catch (err) {
         console.error('Obsidian: failed to restore vault access', err);
@@ -1199,6 +1209,11 @@ const DayPlanner = () => {
               setObsidianConfig({ enabled: true, dailyNotesPath: cfg.folder || '', newNotesFolder: cfg.newNotesFolder || 'dayGLANCE' });
             }
             performObsidianSync();
+            // Refresh candidates in case new notes were added while in native settings
+            try {
+              const notes = nativeListNotes('');
+              if (notes) setWikilinkCandidates(notes.map(p => p.split('/').pop().replace(/\.md$/i, '')).sort((a, b) => a.localeCompare(b)));
+            } catch {}
           }
         } catch {}
         return;
@@ -6685,6 +6700,7 @@ const DayPlanner = () => {
     obsidianSyncStatus, setObsidianSyncStatus,
     obsidianSyncError, setObsidianSyncError,
     obsidianLastSynced, setObsidianLastSynced,
+    wikilinkCandidates, setWikilinkCandidates,
 
     // ── TRMNL ─────────────────────────────────────────────────────────────────
     trmnlConfig, setTrmnlConfig,

--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Calendar, Check, Loader, Sparkles, X } from 'lucide-react';
+import { BookOpen, Calendar, Check, Loader, Sparkles, X } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { useSyncCtx } from '../context/SyncContext.jsx';
 import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
@@ -31,6 +32,19 @@ const DesktopNewTaskModal = () => {
     handleNewTaskInputChange, handleNewTaskInputKeyDown,
   } = useDayPlannerCtx();
   const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, goals, projects, goalsProjectsEnabled } = useFeaturesCtx();
+  const { wikilinkCandidates = [] } = useSyncCtx() || {};
+
+  // Wikilink autocomplete: detect [[partial at end of title
+  const wikilinkMatch = newTask.title.match(/\[\[([^\]]*)?$/);
+  const wikilinkQuery = wikilinkMatch ? (wikilinkMatch[1] ?? '') : null;
+  const wikilinkSuggestions = wikilinkQuery !== null && wikilinkCandidates.length > 0
+    ? wikilinkCandidates.filter(c => c.toLowerCase().includes(wikilinkQuery.toLowerCase())).slice(0, 8)
+    : [];
+  const applyWikilinkSuggestion = (noteName) => {
+    const newTitle = newTask.title.replace(/\[\[([^\]]*)?$/, `[[${noteName}]]`);
+    setNewTask(prev => ({ ...prev, title: newTitle }));
+    newTaskInputRef.current?.focus();
+  };
 
   if (!showAddTask || isMobile) return null;
 
@@ -101,6 +115,23 @@ const DesktopNewTaskModal = () => {
                     textPrimary={textPrimary}
                     hoverBg={hoverBg}
                   />
+                )}
+                {/* Wikilink autocomplete dropdown */}
+                {wikilinkSuggestions.length > 0 && (
+                  <div className={`absolute top-full left-0 mt-1 ${cardBg} rounded-lg p-1 z-50 shadow-xl border ${borderClass} min-w-[200px] max-h-48 overflow-y-auto`}>
+                    {wikilinkSuggestions.map(name => (
+                      <button
+                        key={name}
+                        type="button"
+                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); applyWikilinkSuggestion(name); }}
+                        onMouseDown={(e) => e.preventDefault()}
+                        className={`w-full text-left px-2 py-1.5 rounded text-sm flex items-center gap-2 ${textPrimary} ${hoverBg}`}
+                      >
+                        <BookOpen size={12} className="flex-shrink-0 opacity-50" />
+                        <span className="truncate">{name}</span>
+                      </button>
+                    ))}
+                  </div>
                 )}
                 {/* AI duration + tag suggestion pill */}
                 {aiConfig.enabled && aiConfig.features?.durationEstimate && !mobileEditingTask && (

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Calendar, Check, Loader, Sparkles, X } from 'lucide-react';
+import { BookOpen, Calendar, Check, Loader, Sparkles, X } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { useSyncCtx } from '../context/SyncContext.jsx';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
 
@@ -25,6 +26,19 @@ const MobileNewTaskModal = () => {
     handleNewTaskInputChange,
   } = useDayPlannerCtx();
   const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, goals, projects, goalsProjectsEnabled } = useFeaturesCtx();
+  const { wikilinkCandidates = [] } = useSyncCtx() || {};
+
+  // Wikilink autocomplete: detect [[partial at end of title
+  const wikilinkMatch = newTask.title.match(/\[\[([^\]]*)?$/);
+  const wikilinkQuery = wikilinkMatch ? (wikilinkMatch[1] ?? '') : null;
+  const wikilinkSuggestions = wikilinkQuery !== null && wikilinkCandidates.length > 0
+    ? wikilinkCandidates.filter(c => c.toLowerCase().includes(wikilinkQuery.toLowerCase())).slice(0, 6)
+    : [];
+  const applyWikilinkSuggestion = (noteName) => {
+    const newTitle = newTask.title.replace(/\[\[([^\]]*)?$/, `[[${noteName}]]`);
+    setNewTask(prev => ({ ...prev, title: newTitle }));
+    newTaskInputRef.current?.focus();
+  };
 
   return (
     <>
@@ -57,7 +71,7 @@ const MobileNewTaskModal = () => {
               }}
             >
               {/* Title */}
-              <div>
+              <div className="relative">
                 <input
                   ref={newTaskInputRef}
                   type="text"
@@ -67,6 +81,23 @@ const MobileNewTaskModal = () => {
                   autoFocus={!mobileEditingTask && !newTask.title}
                   className={`w-full px-3 py-3 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white'} text-base`}
                 />
+                {/* Wikilink autocomplete dropdown */}
+                {wikilinkSuggestions.length > 0 && (
+                  <div className={`absolute top-full left-0 mt-1 ${cardBg} rounded-lg p-1 z-50 shadow-xl border ${borderClass} w-full max-h-48 overflow-y-auto`}>
+                    {wikilinkSuggestions.map(name => (
+                      <button
+                        key={name}
+                        type="button"
+                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); applyWikilinkSuggestion(name); }}
+                        onMouseDown={(e) => e.preventDefault()}
+                        className={`w-full text-left px-3 py-2 rounded text-sm flex items-center gap-2 ${textPrimary} ${hoverBg}`}
+                      >
+                        <BookOpen size={14} className="flex-shrink-0 opacity-50" />
+                        <span className="truncate">{name}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
                 {/* AI duration + tag suggestion pill */}
                 {aiConfig.enabled && aiConfig.features?.durationEstimate && !mobileEditingTask && (
                   taskAISuggestionLoading ? (

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -12,7 +12,7 @@ import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from '../constants/habits
 import { isNativeAndroid, nativeGetCalendars } from '../native.js';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
-import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault } from '../obsidian.js';
+import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, listVaultNotes } from '../obsidian.js';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
 import AutoBackupSettingsForm from './AutoBackupSettingsForm.jsx';
 import FrameEditor from './FrameEditor.jsx';
@@ -59,6 +59,7 @@ const MobileSettingsPanel = () => {
     cloudSyncStatus, cloudSyncLastSynced,
     obsidianConfig, setObsidianConfig,
     obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
+    wikilinkCandidates, setWikilinkCandidates,
     cloudSyncUpload, cloudSyncTest,
     syncAll, performObsidianSync, performRemoteBackup,
     loadAutoBackupHistory,
@@ -1150,6 +1151,7 @@ const MobileSettingsPanel = () => {
             if (handle) {
               obsidianVaultHandleRef.current = handle;
               setObsidianConfig({ enabled: true, dailyNotesPath: '', vaultName: handle.name });
+              listVaultNotes(handle).then(names => setWikilinkCandidates(names)).catch(() => {});
             }
           }}
           className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 flex items-center gap-2 text-sm"

--- a/src/components/NotesSubtasksPanel.jsx
+++ b/src/components/NotesSubtasksPanel.jsx
@@ -2,6 +2,45 @@ import React, { useState, useEffect, useRef } from 'react';
 import { BookOpen, Loader, Sparkles, X, Check, Plus, ExternalLink } from 'lucide-react';
 import { isOnlyUrl, renderFormattedText } from '../utils/textFormatting.jsx';
 
+/** Format an ISO timestamp as a human-readable relative or absolute string. */
+function formatNoteTimestamp(iso) {
+  if (!iso) return null;
+  const d = new Date(iso);
+  const diffMs = Date.now() - d.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+/**
+ * Render note text with [[wikilink]] patterns as clickable buttons.
+ * Non-wikilink segments are passed through renderFormattedText.
+ */
+function renderNoteContent(text, onWikilinkClick) {
+  if (!text) return null;
+  const segments = text.split(/(\[\[[^\]]+\]\])/g);
+  return segments.map((seg, i) => {
+    const m = seg.match(/^\[\[([^\]]+)\]\]$/);
+    if (m) {
+      return (
+        <button
+          key={i}
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onWikilinkClick(m[1]); }}
+          title={`Open "${m[1]}"`}
+          className="text-purple-300 hover:text-purple-200 underline decoration-dashed underline-offset-2 transition-colors"
+        >
+          [[{m[1]}]]
+        </button>
+      );
+    }
+    return <span key={i} style={{ whiteSpace: 'pre-wrap' }}>{renderFormattedText(seg)}</span>;
+  });
+}
+
 const NotesSubtasksPanel = ({
   task,
   isInbox,
@@ -35,29 +74,41 @@ const NotesSubtasksPanel = ({
   const updateTaskNotesRef = useRef(updateTaskNotes);
 
   // Linked wiki note state (desktop Obsidian tasks only)
-  const [linkedNoteStates, setLinkedNoteStates] = useState({}); // { noteName: { text, loading, error } }
+  const [linkedNoteStates, setLinkedNoteStates] = useState({}); // { noteName: { text, lastModified, loading, error } }
   const [linkedNoteEditing, setLinkedNoteEditing] = useState({}); // { noteName: boolean }
   const linkedNoteTextsRef = useRef({}); // { noteName: currentText } — for save-on-unmount
   const linkedNoteOriginalRef = useRef({}); // { noteName: textAtLoad } — to detect changes
   const onSaveWikiNoteRef = useRef(onSaveWikiNote);
   useEffect(() => { onSaveWikiNoteRef.current = onSaveWikiNote; }, [onSaveWikiNote]);
 
+  // Additional notes navigated to via [[wikilink]] clicks inside note content
+  const [additionalNotes, setAdditionalNotes] = useState([]);
+
+  const loadNote = (noteName) => {
+    if (linkedNoteStates[noteName]) return; // already loaded or loading
+    setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text: '', lastModified: null, loading: true, error: null } }));
+    onLoadWikiNote?.(noteName).then(result => {
+      const text = result?.text ?? '';
+      setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text, lastModified: result?.lastModified ?? null, loading: false, error: null } }));
+      setLinkedNoteEditing(prev => ({ ...prev, [noteName]: !text }));
+      linkedNoteTextsRef.current[noteName] = text;
+      linkedNoteOriginalRef.current[noteName] = text;
+    }).catch(err => {
+      setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text: '', lastModified: null, loading: false, error: err.message } }));
+    });
+  };
+
+  const handleContentWikilinkClick = (noteName) => {
+    if (!additionalNotes.includes(noteName)) {
+      setAdditionalNotes(prev => [...prev, noteName]);
+    }
+    loadNote(noteName);
+  };
+
   // Load wiki notes on mount
   useEffect(() => {
     if (!wikilinks || wikilinks.length === 0 || !onLoadWikiNote) return;
-    wikilinks.forEach(async (noteName) => {
-      setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text: '', loading: true, error: null } }));
-      try {
-        const result = await onLoadWikiNote(noteName);
-        const text = result?.text ?? '';
-        setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text, loading: false, error: null } }));
-        setLinkedNoteEditing(prev => ({ ...prev, [noteName]: !text })); // edit mode only if empty
-        linkedNoteTextsRef.current[noteName] = text;
-        linkedNoteOriginalRef.current[noteName] = text;
-      } catch (err) {
-        setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text: '', loading: false, error: err.message } }));
-      }
-    });
+    wikilinks.forEach(noteName => loadNote(noteName));
   }, []); // load only on mount
 
   // Save unsaved linked note changes on unmount
@@ -164,14 +215,16 @@ const NotesSubtasksPanel = ({
       {/* Notes section — replaced by linked vault note for Obsidian wikilink tasks */}
       {wikilinks && wikilinks.length > 0 && onLoadWikiNote ? (
         <div className="mb-3 space-y-3">
-          {wikilinks.map((noteName) => {
-            const state = linkedNoteStates[noteName] || { text: '', loading: true, error: null };
+          {[...(wikilinks || []), ...additionalNotes].map((noteName) => {
+            const state = linkedNoteStates[noteName] || { text: '', lastModified: null, loading: true, error: null };
             const isEditingWiki = linkedNoteEditing[noteName] ?? false;
+            const ts = formatNoteTimestamp(state.lastModified);
             return (
               <div key={noteName}>
                 <div className="text-xs font-semibold opacity-90 mb-1 flex items-center gap-1.5">
                   <BookOpen size={11} />
                   <span className="flex-1">{noteName}</span>
+                  {ts && <span className="opacity-40 font-normal">{ts}</span>}
                   {onOpenInObsidian && (
                     <button
                       type="button"
@@ -225,9 +278,9 @@ const NotesSubtasksPanel = ({
                 ) : (
                   <div
                     onClick={() => setLinkedNoteEditing(prev => ({ ...prev, [noteName]: true }))}
-                    className={`text-sm whitespace-pre-wrap cursor-text p-2 rounded bg-white/10 hover:bg-white/15 ${noteMinH}`}
+                    className={`text-sm cursor-text p-2 rounded bg-white/10 hover:bg-white/15 ${noteMinH}`}
                   >
-                    {renderFormattedText(state.text)}
+                    {renderNoteContent(state.text, handleContentWikilinkClick)}
                   </div>
                 )}
               </div>

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -405,6 +405,27 @@ export async function writeWikiNote(vaultHandle, noteName, content, newNotesFold
 }
 
 /**
+ * Return a sorted array of all vault note names (bare, without .md extension).
+ * Used to populate the wikilink autocomplete candidates list.
+ * Scans at most 8 levels deep and ignores hidden directories (starting with '.').
+ */
+export async function listVaultNotes(vaultHandle) {
+  const names = [];
+  async function scan(dir, depth) {
+    if (depth > 8) return;
+    for await (const [name, handle] of dir.entries()) {
+      if (handle.kind === 'file' && name.endsWith('.md')) {
+        names.push(name.slice(0, -3));
+      } else if (handle.kind === 'directory' && !name.startsWith('.')) {
+        await scan(handle, depth + 1);
+      }
+    }
+  }
+  await scan(vaultHandle, 0);
+  return names.sort((a, b) => a.localeCompare(b));
+}
+
+/**
  * Strip leading date / date+time / time prefixes from a raw task line body
  * (the text after `- [x] `) to get the bare title, mirroring
  * parseTasksFromMarkdown.  Returns { bareTitle, datePrefix } where datePrefix


### PR DESCRIPTION
Three wikilink UX improvements that build on the existing note panel infrastructure.

## 3 — Last-modified timestamp

The note header now shows how recently the note was last edited ("2h ago", "Apr 5"). The bridge already returned `lastModified` in its JSON; it just wasn't being displayed. The format degrades gracefully: `< 1 min` → "just now", `< 1h` → "Xm ago", `< 24h` → "Xh ago", older → short date.

## 5 — Clickable [[wikilinks]] in note content

In preview mode, `[[noteName]]` patterns inside the note body render as purple underlined buttons. Tapping one loads that note inline below the current panel — no task-title change required. This makes Obsidian-style note graphs navigable within dayGLANCE.

- `renderNoteContent()` in `NotesSubtasksPanel` splits text by `[[...]]` tokens, renders wikilinks as `<button>` elements, and passes remaining segments through the existing `renderFormattedText()` for markdown/URL formatting
- `additionalNotes[]` local state tracks navigated-to notes; `loadNote()` handles async loading with the same state machinery as the initial wikilinks

## 4 — Wikilink autocomplete in task title

When the user types `[[` in the task title input, a compact dropdown of matching vault note names appears. Selecting one inserts `[[noteName]]` at that position.

**Candidate list population:**
- Android: `nativeListNotes('')` from the already-built in-memory index — zero extra SAF cost
- Web FSA: new `listVaultNotes(vaultHandle)` function recursively scans the vault handle (same traversal pattern as `findFileHandleInDir`)
- Populated on vault connect (startup + `visibilitychange`) and when connecting via Settings
- Exposed as `wikilinkCandidates` in `SyncContext`

**Autocomplete UX:**
- Triggers on `[[` at end of title (regex `/\[\[([^\]]*)$/`)
- Case-insensitive substring match, max 8 results on desktop / 6 on mobile
- `onMouseDown` prevents blur-before-click; `applyWikilinkSuggestion` replaces the partial text and refocuses the input
- Works in both `DesktopNewTaskModal` and `MobileNewTaskModal`

## Test plan

- [x] Open a note panel for a `[[wikilink]]` task — timestamp appears in header ("Xh ago" or date)
- [x] Note with `[[other-note]]` in content — visible as purple underlined link in preview; tapping loads it inline below
- [ ] Circular navigation (note A links to note B, note B links to note A) — both load correctly
- [ ] Android: type `[[` in task title — note names from vault index appear in dropdown
- [ ] Web: connect vault, type `[[` in task title — note names from FSA scan appear
- [ ] Selecting a suggestion inserts `[[noteName]]` and returns focus to input
- [ ] No vault connected — `[[` typed, no dropdown appears (empty candidates)
- [ ] Very large vault (1000+ notes) — autocomplete still responds quickly (uses pre-built index)

https://claude.ai/code/session_011GBxNYmTvdnb2mthg8QU63