### PR TITLE
fix(obsidian): hide [[ ]] brackets on rendered wikilinks in note content

### DIFF
--- a/src/components/NotesSubtasksPanel.jsx
+++ b/src/components/NotesSubtasksPanel.jsx
@@ -33,7 +33,7 @@ function renderNoteContent(text, onWikilinkClick) {
           title={`Open "${m[1]}"`}
           className="text-purple-300 hover:text-purple-200 underline decoration-dashed underline-offset-2 transition-colors"
         >
-          [[{m[1]}]]
+          {m[1]}
         </button>
       );
     }


### PR DESCRIPTION
## Summary

- Wikilinks in note preview were rendering as `[[Note Name]]` with the bracket characters visible
- The button now displays just the note name as an underlined link — clicking still navigates to the linked note

One-character change in `renderNoteContent()` in `NotesSubtasksPanel.jsx`.

## Test plan

- [ ] Open a task with a linked note that contains `[[Another Note]]` in its content
- [ ] Confirm the preview shows `Another Note` (no brackets) as an underlined/dashed link
- [ ] Confirm clicking the link still opens the linked note inline

https://claude.ai/code/session_011GBxNYmTvdnb2mthg8QU63