### PR TITLE
fix(obsidian): add filename pattern field to desktop SettingsModal

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -867,6 +867,21 @@ const SettingsModal = () => {
                           </div>
                           <div>
                             <label className={`block text-sm ${textSecondary} mb-1`}>
+                              Filename pattern
+                            </label>
+                            <input
+                              type="text"
+                              placeholder="yyyy-MM-dd"
+                              value={obsidianConfig.dailyNotePattern ?? 'yyyy-MM-dd'}
+                              onChange={(e) => setObsidianConfig(prev => ({ ...prev, dailyNotePattern: e.target.value }))}
+                              className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
+                            />
+                            <p className={`text-xs ${textSecondary} mt-1`}>
+                              Date pattern for daily note filenames (without .md). e.g. "yyyy-MM-dd", "dd-MM-yyyy", "MMMM dd, yyyy"
+                            </p>
+                          </div>
+                          <div>
+                            <label className={`block text-sm ${textSecondary} mb-1`}>
                               Daily note template
                             </label>
                             <textarea


### PR DESCRIPTION
## Summary

- `dailyNotePattern` input was added to `MobileSettingsPanel` in #383 but the desktop `SettingsModal` was missing it
- Adds the "Filename pattern" field between "New task heading" and "Daily note template", matching the mobile layout

## Test plan

- [ ] Open desktop settings → Obsidian section with a vault connected
- [ ] Confirm "Filename pattern" field appears between task heading and daily note template
- [ ] Change pattern, confirm it persists on reload and is used for daily note reads/writes

https://claude.ai/code/session_011GBxNYmTvdnb2mthg8QU63