### PR TITLE
fix(android-widget): replace &lt;View&gt; with &lt;TextView&gt; in goal row to fix Loading...

### DIFF
--- a/dayglance-android/app/src/main/res/layout/widget_item_goal.xml
+++ b/dayglance-android/app/src/main/res/layout/widget_item_goal.xml
@@ -19,13 +19,14 @@
     android:paddingStart="0dp"
     android:paddingEnd="0dp">
 
-    <!-- Amber color bar — same width/style as task_color_bar -->
-    <View
+    <!-- Amber color bar — must be TextView, not View; <View> is not in the RemoteViews supported subset -->
+    <TextView
         android:id="@+id/goal_color_bar"
         android:layout_width="3dp"
         android:layout_height="28dp"
         android:background="#f59e0b"
-        android:layout_marginEnd="7dp" />
+        android:layout_marginEnd="7dp"
+        android:text="" />
 
     <!-- Goal title -->
     <TextView


### PR DESCRIPTION
## Summary

- `<View>` (base Android view class) is not in the RemoteViews supported view subset
- The amber color bar in `widget_item_goal.xml` used `<View>`, causing layout inflation to fail silently and Android to show "Loading..." permanently for every goal row
- Fixed by replacing `<View>` with `<TextView android:text="">` — the same fix applied to `widget_item_task.xml` in PR #213

## Test plan
- [x] Add an active goal with `targetDate` = today
- [x] Check the home screen widget — the goal row should render with title, progress bar, and percentage
- [x] Confirm no "Loading..." placeholder

https://claude.ai/code/session_019KymrFvPD72EWGrvjgDJWb