### PR TITLE
feat(android-widget): enhance goal row with section header, badge, and task count

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
@@ -81,7 +81,12 @@ class DayGlanceWidgetListFactory(
             val isEmpty: Boolean,
         ) : AgendaItem(TYPE_GLANCEAHEAD)
         object Empty : AgendaItem(TYPE_EMPTY)
-        class Goal(val title: String, val progressPct: Int) : AgendaItem(TYPE_GOAL)
+        class Goal(
+            val title: String,
+            val progressPct: Int,
+            val totalTasks: Int,
+            val completedTasks: Int,
+        ) : AgendaItem(TYPE_GOAL)
     }
 
     data class HabitData(
@@ -143,14 +148,17 @@ class DayGlanceWidgetListFactory(
             if (habits.isNotEmpty()) items += AgendaItem.Habits(habits)
         }
 
-        // 1.5 Goals due today — compact rows below habits, above overdue
+        // 1.5 Goals due today — section header + rows below habits, above overdue
         val goalsArray = snapshot.optJSONArray("goals")
         if (goalsArray != null && goalsArray.length() > 0) {
+            items += AgendaItem.Section("GOALS")
             for (i in 0 until goalsArray.length()) {
                 val g = goalsArray.optJSONObject(i) ?: continue
                 items += AgendaItem.Goal(
                     title = g.optString("title", "Untitled"),
                     progressPct = g.optInt("progressPct", 0).coerceIn(0, 100),
+                    totalTasks = g.optInt("totalTasks", 0),
+                    completedTasks = g.optInt("completedTasks", 0),
                 )
             }
         }
@@ -447,7 +455,14 @@ class DayGlanceWidgetListFactory(
         val rv = RemoteViews(context.packageName, R.layout.widget_item_goal)
         rv.setTextViewText(R.id.tv_goal_title, item.title)
         rv.setProgressBar(R.id.pb_goal_progress, 100, item.progressPct, false)
-        rv.setTextViewText(R.id.tv_goal_pct, "${item.progressPct}%")
+        val statsStr = if (item.totalTasks > 0)
+            "${item.progressPct}% · ${item.completedTasks}/${item.totalTasks} tasks"
+        else
+            "${item.progressPct}%"
+        rv.setTextViewText(R.id.tv_goal_stats, statsStr)
+        rv.boostTextSizeForOneUi(R.id.tv_goal_title, 13f)
+        rv.boostTextSizeForOneUi(R.id.tv_goal_badge, 11f)
+        rv.boostTextSizeForOneUi(R.id.tv_goal_stats, 11f)
         rv.setOnClickFillInIntent(R.id.goal_item_root, android.content.Intent())
         return rv
     }

--- a/dayglance-android/app/src/main/res/layout/widget_item_goal.xml
+++ b/dayglance-android/app/src/main/res/layout/widget_item_goal.xml
@@ -3,10 +3,11 @@
   Widget list item: a goal due today.
 
   Structure:
-    [amber bar 3dp] [title — flex] [ProgressBar — 56dp] [X% label]
+    [amber bar 3dp] [title — flex]           [DUE TODAY badge]
+                    [progress bar — flex] [X% · Y/Z tasks]
 
-  One row, same height as a short task row.
-  The amber bar signals "due today" without needing a text badge.
+  Two-line row matching the task row style.
+  The amber bar signals "goal" at a glance.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/goal_item_root"
@@ -14,8 +15,8 @@
     android:layout_height="wrap_content"
     android:orientation="horizontal"
     android:gravity="center_vertical"
-    android:paddingTop="5dp"
-    android:paddingBottom="5dp"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp"
     android:paddingStart="0dp"
     android:paddingEnd="0dp">
 
@@ -23,42 +24,77 @@
     <TextView
         android:id="@+id/goal_color_bar"
         android:layout_width="3dp"
-        android:layout_height="28dp"
+        android:layout_height="44dp"
         android:background="#f59e0b"
         android:layout_marginEnd="7dp"
         android:text="" />
 
-    <!-- Goal title -->
-    <TextView
-        android:id="@+id/tv_goal_title"
+    <!-- Text content: 2-line vertical stack -->
+    <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:text="Goal title"
-        android:textColor="@color/widget_text_primary"
-        android:textSize="13sp"
-        android:maxLines="1"
-        android:ellipsize="end"
-        android:layout_marginEnd="8dp" />
+        android:orientation="vertical">
 
-    <!-- Thin horizontal progress bar -->
-    <ProgressBar
-        android:id="@+id/pb_goal_progress"
-        style="@android:style/Widget.ProgressBar.Horizontal"
-        android:layout_width="56dp"
-        android:layout_height="8dp"
-        android:max="100"
-        android:progress="0"
-        android:layout_marginEnd="6dp" />
+        <!-- Line 1: title + DUE TODAY badge -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
 
-    <!-- Percentage label -->
-    <TextView
-        android:id="@+id/tv_goal_pct"
-        android:layout_width="30dp"
-        android:layout_height="wrap_content"
-        android:text="0%"
-        android:textColor="@color/widget_text_secondary"
-        android:textSize="11sp"
-        android:gravity="end" />
+            <TextView
+                android:id="@+id/tv_goal_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Goal title"
+                android:textColor="@color/widget_text_primary"
+                android:textSize="13sp"
+                android:maxLines="1"
+                android:ellipsize="end" />
+
+            <TextView
+                android:id="@+id/tv_goal_badge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="DUE TODAY"
+                android:textColor="@color/widget_text_secondary"
+                android:textSize="11sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.06"
+                android:layout_marginStart="4dp" />
+
+        </LinearLayout>
+
+        <!-- Line 2: progress bar + "X% · Y/Z tasks" -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginTop="3dp">
+
+            <ProgressBar
+                android:id="@+id/pb_goal_progress"
+                style="@android:style/Widget.ProgressBar.Horizontal"
+                android:layout_width="0dp"
+                android:layout_height="6dp"
+                android:layout_weight="1"
+                android:max="100"
+                android:progress="0"
+                android:layout_marginEnd="6dp" />
+
+            <TextView
+                android:id="@+id/tv_goal_stats"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="0%"
+                android:textColor="@color/widget_text_secondary"
+                android:textSize="11sp" />
+
+        </LinearLayout>
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5852,7 +5852,10 @@ const DayPlanner = () => {
           .filter(g => g.status === 'active' && g.targetDate === todayStr)
           .map(g => {
             const progressPct = Math.round(calculateGoalProgress(g.id, projects, allTasksCombinedW) * 100);
-            return { id: g.id, title: g.title, progressPct };
+            const childProjects = projects.filter(p => p.goalId === g.id && p.status !== 'archived');
+            const totalTasks = allTasksCombinedW.filter(t => childProjects.some(p => p.id === t.projectId) && !t.archived).length;
+            const completedTasks = allTasksCombinedW.filter(t => childProjects.some(p => p.id === t.projectId) && !t.archived && t.completed).length;
+            return { id: g.id, title: g.title, progressPct, totalTasks, completedTasks };
           })
       : [];
 


### PR DESCRIPTION
## Summary

Goal rows were easy to miss with just a progress bar. This update makes them consistent with the rest of the widget's visual language:

- **"GOALS" section header** — same pill style as OVERDUE / ALL DAY / SCHEDULED, so goals have a clear anchor in the list
- **2-line goal row:**
  - Line 1: goal title (flex) + `DUE TODAY` badge (11sp bold uppercase, matching task badge style)
  - Line 2: full-width progress bar + `67% · 4/6 tasks` stats label
- **Color bar height** bumped from 28dp → 44dp to match 2-line row height
- **App.jsx** now includes `totalTasks` + `completedTasks` in the widget snapshot

The result looks like:
```
● GOALS
▌ Launch website          DUE TODAY
▌ ████████░░  67% · 4/6 tasks
```

## Test plan
- [x] Add an active goal with `targetDate` = today that has child projects/tasks
- [x] Widget shows a "GOALS" section header above the goal row
- [x] Goal row shows title + "DUE TODAY" badge on line 1
- [x] Line 2 shows progress bar + "X% · Y/Z tasks"
- [x] Goal with no child tasks shows just "X%" (no task count)

https://claude.ai/code/session_019KymrFvPD72EWGrvjgDJWb