### PR TITLE
fix(mobile): restore routine pills in all-day section

### DIFF
--- a/src/components/MobileAllDaySection.jsx
+++ b/src/components/MobileAllDaySection.jsx
@@ -8,6 +8,7 @@ import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySub
 import { dateToString, extractWikilinks, formatDeadlineDate } from '../utils/taskUtils.js';
 import DeadlinePickerPopover from './DeadlinePickerPopover.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
 const MobileAllDaySection = () => {
   const {
@@ -21,7 +22,6 @@ const MobileAllDaySection = () => {
     showDeadlinePicker, setShowDeadlinePicker,
     taskContextMenu, setTaskContextMenu,
     mobileDragPreviewTime, mobileDragTaskIdState,
-    routinesEnabled, todayRoutines,
     goalsProjectsEnabled, projects, projectFilter, setProjectFilter, setInboxProjectFilter,
     toggleComplete,
     postponeTask, postponeDeadlineTask,
@@ -29,8 +29,12 @@ const MobileAllDaySection = () => {
     formatTime, timeToMinutes,
     getTasksForDate, getDeadlineTasksForDate,
     getTaskCalendarStyle,
-    openRoutinesDashboard,
   } = useDayPlannerCtx();
+
+  const {
+    routinesEnabled, todayRoutines,
+    openRoutinesDashboard,
+  } = useFeaturesCtx();
 
   return (
     <>


### PR DESCRIPTION
## Summary

`MobileAllDaySection` was reading `routinesEnabled`, `todayRoutines`, and `openRoutinesDashboard` from `useDayPlannerCtx()`, but Phase 11.4 moved these to `FeaturesContext`. All three came back as `undefined`, so `routinesEnabled` was always falsy — silently suppressing every routine pill in the all-day section and making them impossible to drag to a time slot.

Fix: add `useFeaturesCtx` import and read the three values from the correct context, matching the pattern already used by `MobileTimeGrid` after the same migration.

## Test plan
- [x] Select one or more routines (with no start time) for today
- [x] All-day section shows the routine pills
- [x] Pills can be dragged onto a time slot

https://claude.ai/code/session_019KymrFvPD72EWGrvjgDJWb