### PR TITLE
fix(obsidian): add missing settings fields to Android mobile panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1166,7 +1166,7 @@ const DayPlanner = () => {
         if (cfg?.configured) {
           obsidianVaultHandleRef.current = 'native';
           if (!obsidianConfig?.enabled) {
-            setObsidianConfig({ enabled: true, dailyNotesPath: cfg.folder || '', newNotesFolder: cfg.newNotesFolder || 'dayGLANCE' });
+            setObsidianConfig({ enabled: true, dailyNotesPath: cfg.folder || '', newNotesFolder: cfg.newNotesFolder || 'dayGLANCE', dailyNotePattern: cfg.pattern || 'yyyy-MM-dd' });
           }
           performObsidianSync();
           // Populate wikilink autocomplete candidates from the vault index
@@ -1206,7 +1206,7 @@ const DayPlanner = () => {
           if (cfg?.configured) {
             obsidianVaultHandleRef.current = 'native';
             if (!obsidianConfig?.enabled) {
-              setObsidianConfig({ enabled: true, dailyNotesPath: cfg.folder || '', newNotesFolder: cfg.newNotesFolder || 'dayGLANCE' });
+              setObsidianConfig({ enabled: true, dailyNotesPath: cfg.folder || '', newNotesFolder: cfg.newNotesFolder || 'dayGLANCE', dailyNotePattern: cfg.pattern || 'yyyy-MM-dd' });
             }
             performObsidianSync();
             // Refresh candidates in case new notes were added while in native settings

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -1083,6 +1083,48 @@ const MobileSettingsPanel = () => {
               </>
             )}
           </div>
+          {/* Daily notes folder */}
+          {obsidianConfig?.enabled && (
+            <div>
+              <label className={`block text-sm ${textSecondary} mb-1`}>Daily notes folder</label>
+              <input
+                type="text"
+                placeholder="(vault root)"
+                value={obsidianConfig.dailyNotesPath || ''}
+                onChange={(e) => setObsidianConfig(prev => ({ ...prev, dailyNotesPath: e.target.value }))}
+                className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
+              />
+              <p className={`text-xs ${textSecondary} mt-1`}>Leave empty for vault root. Common: "Daily Notes" or "journals"</p>
+            </div>
+          )}
+          {/* New notes folder */}
+          {obsidianConfig?.enabled && (
+            <div>
+              <label className={`block text-sm ${textSecondary} mb-1`}>New notes folder</label>
+              <input
+                type="text"
+                placeholder="dayGLANCE"
+                value={obsidianConfig.newNotesFolder ?? 'dayGLANCE'}
+                onChange={(e) => setObsidianConfig(prev => ({ ...prev, newNotesFolder: e.target.value }))}
+                className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
+              />
+              <p className={`text-xs ${textSecondary} mt-1`}>Where new notes created in dayGLANCE are saved. Leave empty for vault root.</p>
+            </div>
+          )}
+          {/* Filename pattern */}
+          {obsidianConfig?.enabled && (
+            <div>
+              <label className={`block text-sm ${textSecondary} mb-1`}>Filename pattern</label>
+              <input
+                type="text"
+                placeholder="yyyy-MM-dd"
+                value={obsidianConfig.dailyNotePattern ?? 'yyyy-MM-dd'}
+                onChange={(e) => setObsidianConfig(prev => ({ ...prev, dailyNotePattern: e.target.value }))}
+                className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
+              />
+              <p className={`text-xs ${textSecondary} mt-1`}>Date pattern for daily note filenames (without .md). e.g. "yyyy-MM-dd", "dd-MM-yyyy", "MMMM dd, yyyy"</p>
+            </div>
+          )}
           {/* Task heading — same as web */}
           {obsidianConfig?.enabled && (
             <div>


### PR DESCRIPTION
## Summary

Three fields were present on desktop (`SettingsModal`) and in the web FSA branch of `MobileSettingsPanel`, but absent from the Android branch:

| Field | Key | Was missing from |
|---|---|---|
| Daily notes folder | `dailyNotesPath` | Android mobile panel |
| New notes folder | `newNotesFolder` | Android mobile panel (PR #381 added it to FSA only) |
| Filename pattern | `dailyNotePattern` | Android mobile panel |

Android mobile now shows the same 5 fields as desktop: Daily notes folder → New notes folder → Filename pattern → Task heading → Daily note template.

Also fixed: both `setObsidianConfig()` calls in `App.jsx` that initialise config from `nativeGetVaultConfig()` were silently dropping `cfg.pattern`, so the filename pattern set in the native SettingsActivity was never carried into `obsidianConfig` on first setup.

## Test plan
- [x] Android: Obsidian settings section shows all 5 fields (Daily notes folder, New notes folder, Filename pattern, Task heading, Daily note template)
- [x] Android: configuring a non-default filename pattern in the native SettingsActivity → disconnect + reconnect vault → Filename pattern field pre-populated correctly
- [x] Editing any field persists across app restart

https://claude.ai/code/session_019KymrFvPD72EWGrvjgDJWb