### PR TITLE
fix(obsidian): settings parity across all surfaces

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -852,17 +852,17 @@ const SettingsModal = () => {
                           </div>
                           <div>
                             <label className={`block text-sm ${textSecondary} mb-1`}>
-                              New task heading
+                              New notes folder
                             </label>
                             <input
                               type="text"
-                              placeholder="## Tasks"
-                              value={obsidianConfig.taskHeading || ''}
-                              onChange={(e) => setObsidianConfig(prev => ({ ...prev, taskHeading: e.target.value }))}
+                              placeholder="dayGLANCE"
+                              value={obsidianConfig.newNotesFolder ?? 'dayGLANCE'}
+                              onChange={(e) => setObsidianConfig(prev => ({ ...prev, newNotesFolder: e.target.value }))}
                               className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
                             />
                             <p className={`text-xs ${textSecondary} mt-1`}>
-                              Tasks tagged <code>#obsidian</code> are added under this heading in today's daily note
+                              Where new notes created in dayGLANCE are saved. Leave empty for vault root.
                             </p>
                           </div>
                           <div>
@@ -878,6 +878,21 @@ const SettingsModal = () => {
                             />
                             <p className={`text-xs ${textSecondary} mt-1`}>
                               Date pattern for daily note filenames (without .md). e.g. "yyyy-MM-dd", "dd-MM-yyyy", "MMMM dd, yyyy"
+                            </p>
+                          </div>
+                          <div>
+                            <label className={`block text-sm ${textSecondary} mb-1`}>
+                              Task heading
+                            </label>
+                            <input
+                              type="text"
+                              placeholder="## Tasks"
+                              value={obsidianConfig.taskHeading || ''}
+                              onChange={(e) => setObsidianConfig(prev => ({ ...prev, taskHeading: e.target.value }))}
+                              className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
+                            />
+                            <p className={`text-xs ${textSecondary} mt-1`}>
+                              Tasks tagged <code>#obsidian</code> are added under this heading in today's daily note
                             </p>
                           </div>
                           <div>


### PR DESCRIPTION
## Summary

All three Obsidian settings surfaces now show the same 5 fields in the same order with the same labels:

**Daily notes folder → New notes folder → Filename pattern → Task heading → Daily note template**

Changes to `SettingsModal` (desktop):
- Add missing **New notes folder** field
- Reorder: move Task heading after Filename pattern (matching Android order)
- Rename "New task heading" → "Task heading"

`MobileSettingsPanel` (Android + web FSA) was already correct after PR #391 — no changes needed there.

## Test plan
- [ ] Desktop: all 5 fields present in the correct order
- [ ] Desktop: "Task heading" label (not "New task heading")
- [ ] Desktop: New notes folder field saves and persists

https://claude.ai/code/session_019KymrFvPD72EWGrvjgDJWb