### PR TITLE
tweak(goals): widen standalone project cards to 260px

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -882,7 +882,7 @@ const DesktopDashboard = ({
               <div
                 key={proj.id}
                 data-proj-id={proj.id}
-                className={`relative w-[240px] transition-opacity ${dragProjectId === proj.id ? 'opacity-40' : ''} ${
+                className={`relative w-[260px] transition-opacity ${dragProjectId === proj.id ? 'opacity-40' : ''} ${
                   dropInsertBeforeId === proj.id && dragProjectId && dragProjectId !== proj.id
                     ? 'ring-2 ring-blue-500 rounded-xl' : ''
                 }`}

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -224,7 +224,7 @@ const ProjectCard = forwardRef(({ project, onFocusClick, onEditClick, compact, d
           ref={ref}
           className={`flex flex-col rounded-xl border overflow-hidden ${
             darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'
-          } ${isMobile ? 'w-full' : 'min-w-[180px] max-w-[240px] w-full'}`}
+          } ${isMobile ? 'w-full' : 'min-w-[180px] max-w-[260px] w-full'}`}
           style={goalHex ? { borderLeft: `3px solid ${goalHex}88` } : {}}
         >
           {/* Row 1: title + edit/delete */}
@@ -307,7 +307,7 @@ const ProjectCard = forwardRef(({ project, onFocusClick, onEditClick, compact, d
       ref={ref}
       className={`flex flex-col rounded-xl border overflow-hidden ${
         darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'
-      } ${isMobile ? 'w-full' : 'min-w-[180px] max-w-[240px] w-full'}`}
+      } ${isMobile ? 'w-full' : 'min-w-[180px] max-w-[260px] w-full'}`}
     >
       {/* Goal color bar */}
       {goalHex && (


### PR DESCRIPTION
## Summary

- `ProjectCard` `max-w` bumped from 240px → 260px
- Standalone card wrappers in `GoalDashboard` updated from `w-[240px]` → `w-[260px]` to match

https://claude.ai/code/session_019KymrFvPD72EWGrvjgDJWb