### PR TITLE
feat(android): hold splash screen until initial Obsidian sync completes

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -9,6 +9,8 @@ import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.provider.Settings
 import android.webkit.PermissionRequest
 import android.webkit.ValueCallback
@@ -56,8 +58,13 @@ class MainActivity : AppCompatActivity() {
     private lateinit var healthRepository: HealthRepository
     private lateinit var dataStore: com.dayglance.app.data.SharedDataStore
 
-    // Splash screen: held until the WebView finishes its first page load
+    // Splash screen: held until both conditions are true:
+    //   1. WebView has finished its first page load (webViewReady)
+    //   2. JS has signalled the app is interactive — i.e. the initial Obsidian
+    //      sync (which blocks the JS thread) has completed (appReady).
+    //      A fallback timer sets appReady after 10 s in case JS never calls back.
     @Volatile private var webViewReady = false
+    @Volatile private var appReady = false
 
     // Shown at most once per session so we don't nag the user repeatedly
     private var exactAlarmPromptShown = false
@@ -86,7 +93,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
-        splashScreen.setKeepOnScreenCondition { !webViewReady }
+        splashScreen.setKeepOnScreenCondition { !webViewReady || !appReady }
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -112,6 +119,9 @@ class MainActivity : AppCompatActivity() {
                 runOnUiThread {
                     requestHealthPermissions.launch(healthRepository.requiredPermissions)
                 }
+            },
+            onAppReady = {
+                runOnUiThread { appReady = true }
             }
         )
 
@@ -163,11 +173,14 @@ class MainActivity : AppCompatActivity() {
 
             override fun onPageFinished(view: WebView, url: String) {
                 super.onPageFinished(view, url)
-                // Release the splash screen now that the WebView has rendered.
+                // Release the first half of the splash condition.
                 webViewReady = true
                 // Re-apply status bar appearance after the WebView's first paint,
                 // which can reset the icon colour on Android 15 edge-to-edge mode.
                 applyStatusBarAppearance()
+                // Safety fallback: if JS never calls notifyAppReady() (e.g. Obsidian
+                // not configured, or a JS error), dismiss the splash after 10 seconds.
+                Handler(Looper.getMainLooper()).postDelayed({ appReady = true }, 10_000)
             }
         }
         webView.webChromeClient = object : WebChromeClient() {

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -26,6 +26,7 @@ class NativeBridge(
     private val context: Context,
     healthRepository: HealthRepository,
     onRequestHealthPermission: () -> Unit,
+    private val onAppReady: (() -> Unit)? = null,
 ) {
 
     private val health = HealthBridge(healthRepository, onRequestHealthPermission)
@@ -391,5 +392,15 @@ class NativeBridge(
         dataStore.pendingCompleteTaskId = null
         val escaped = completeId.replace("\\", "\\\\").replace("\"", "\\\"")
         return """{"action":"complete","taskId":"$escaped"}"""
+    }
+
+    /**
+     * Called by JS once the app is interactive and the initial Obsidian sync
+     * (if configured) has completed. Signals the native side to dismiss the
+     * splash screen, which has been held to hide the blocking sync freeze.
+     */
+    @JavascriptInterface
+    fun notifyAppReady() {
+        onAppReady?.invoke()
     }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1169,15 +1169,20 @@ const DayPlanner = () => {
           if (!obsidianConfig?.enabled) {
             setObsidianConfig({ enabled: true, dailyNotesPath: cfg.folder || '', newNotesFolder: cfg.newNotesFolder || 'dayGLANCE', dailyNotePattern: cfg.pattern || 'yyyy-MM-dd' });
           }
+          // notifyNativeReady() is called in performObsidianSync's finally block
           performObsidianSync();
           // Populate wikilink autocomplete candidates from the vault index
           try {
             const notes = nativeListNotes('');
             if (notes) setWikilinkCandidates(notes.map(p => p.split('/').pop().replace(/\.md$/i, '')).sort((a, b) => a.localeCompare(b)));
           } catch {}
+        } else {
+          // No Obsidian configured — release the splash immediately
+          notifyNativeReady();
         }
       } catch (err) {
         console.error('Obsidian: failed to read native vault config', err);
+        notifyNativeReady();
       }
       return;
     }
@@ -1858,6 +1863,17 @@ const DayPlanner = () => {
     }
   }, []);
 
+  // Signal the native Android side that the app is interactive and the initial
+  // Obsidian sync has completed. This releases the splash screen that was held
+  // to hide the blocking sync freeze. Only fires once per session.
+  const nativeReadyNotifiedRef = useRef(false);
+  const notifyNativeReady = useCallback(() => {
+    if (!isNativeAndroid()) return;
+    if (nativeReadyNotifiedRef.current) return;
+    nativeReadyNotifiedRef.current = true;
+    try { window.DayGlanceNative?.notifyAppReady?.(); } catch {}
+  }, []);
+
   // Obsidian vault sync — reads daily notes + imports tasks
   const performObsidianSync = async () => {
     if (obsidianSyncInProgressRef.current) return;
@@ -1966,6 +1982,7 @@ const DayPlanner = () => {
       setTimeout(() => setObsidianSyncStatus(s => s === 'error' ? 'idle' : s), 5000);
     } finally {
       obsidianSyncInProgressRef.current = false;
+      notifyNativeReady();
     }
   };
 

--- a/src/components/ObsidianSyncToast.jsx
+++ b/src/components/ObsidianSyncToast.jsx
@@ -1,64 +1,21 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React from 'react';
 import { CheckCircle, AlertCircle, Loader } from 'lucide-react';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
-
-// Minimum time (ms) to show the "syncing" state.
-// On cold open, syncObsidianVaultNative blocks the JS thread so React batches
-// the 'syncing' + 'success' state updates into a single render — the 'syncing'
-// state is never rendered. We detect this (syncingStartRef is null when we see
-// 'success') and force-show the syncing message for the full minimum duration.
-const MIN_SYNCING_MS = 1500;
 
 const ObsidianSyncToast = () => {
   const { obsidianSyncStatus, obsidianSyncError } = useSyncCtx();
   const { cardBg, borderClass, textPrimary, textSecondary } = useDayPlannerCtx();
 
-  const [displayStatus, setDisplayStatus] = useState('idle');
-  const syncingStartRef = useRef(null);
-  const timerRef = useRef(null);
+  if (obsidianSyncStatus === 'idle') return null;
 
-  useEffect(() => {
-    clearTimeout(timerRef.current);
-
-    if (obsidianSyncStatus === 'syncing') {
-      syncingStartRef.current = Date.now();
-      setDisplayStatus('syncing');
-    } else if (obsidianSyncStatus === 'success' || obsidianSyncStatus === 'error') {
-      if (syncingStartRef.current == null) {
-        // React batched 'syncing'+'success' — the 'syncing' render was skipped.
-        // Force-show the syncing message for the full minimum duration first.
-        syncingStartRef.current = Date.now();
-        setDisplayStatus('syncing');
-        timerRef.current = setTimeout(() => setDisplayStatus(obsidianSyncStatus), MIN_SYNCING_MS);
-      } else {
-        const elapsed = Date.now() - syncingStartRef.current;
-        const remaining = Math.max(0, MIN_SYNCING_MS - elapsed);
-        if (remaining > 0) {
-          timerRef.current = setTimeout(() => setDisplayStatus(obsidianSyncStatus), remaining);
-        } else {
-          setDisplayStatus(obsidianSyncStatus);
-        }
-      }
-    } else {
-      // idle — reset for next sync
-      syncingStartRef.current = null;
-      setDisplayStatus('idle');
-    }
-  }, [obsidianSyncStatus]);
-
-  // Cleanup timer on unmount
-  useEffect(() => () => clearTimeout(timerRef.current), []);
-
-  if (displayStatus === 'idle') return null;
-
-  const isSyncing = displayStatus === 'syncing';
-  const isSuccess = displayStatus === 'success';
+  const isSyncing = obsidianSyncStatus === 'syncing';
+  const isSuccess = obsidianSyncStatus === 'success';
 
   let icon, message, accentColor;
   if (isSyncing) {
     icon = <Loader size={16} className="text-blue-500 animate-spin flex-shrink-0" />;
-    message = 'Building Obsidian vault index…';
+    message = 'Syncing Obsidian vault…';
     accentColor = 'bg-blue-500';
   } else if (isSuccess) {
     icon = <CheckCircle size={16} className="text-green-500 flex-shrink-0" />;
@@ -75,12 +32,7 @@ const ObsidianSyncToast = () => {
       <div className={`flex items-center gap-3 ${cardBg} border ${borderClass} rounded-xl shadow-xl px-4 py-3 max-w-xs`}>
         <div className={`w-1.5 self-stretch rounded-full flex-shrink-0 ${accentColor}`} />
         {icon}
-        <div className="flex-1 min-w-0">
-          <p className={`text-sm font-medium ${textPrimary}`}>{message}</p>
-          {isSyncing && (
-            <p className={`text-xs ${textSecondary} mt-0.5`}>The app may be slow for a moment</p>
-          )}
-        </div>
+        <p className={`text-sm font-medium ${textPrimary}`}>{message}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Problem

`syncObsidianVaultNative` blocks the JS thread on cold open. The app appeared interactive but was actually frozen, and no UI feedback was possible during the block because React couldn't render.

## Solution

Hold the AndroidX splash screen until the JS app signals it's ready via a new `DayGlanceNative.notifyAppReady()` bridge method. The sync happens behind the splash — the user sees a clean load rather than a frozen app.

## Changes

**Native (Kotlin):**
- `MainActivity`: adds `appReady` flag; splash condition is now `!webViewReady || !appReady`; 10s fallback timer in `onPageFinished` so the splash always eventually dismisses even if JS never calls back
- `NativeBridge`: adds `onAppReady` callback param + `@JavascriptInterface fun notifyAppReady()`

**JS:**
- `App.jsx`: adds `notifyNativeReady()` helper (fires once per session via ref); called from `performObsidianSync`'s `finally` block, or immediately on startup if Obsidian is not configured / throws
- `ObsidianSyncToast`: reverts the MIN_SYNCING_MS batching workaround from PRs #394/#396 — cold open is now covered by the splash; the toast remains for warm (visibility change) syncs

## Test plan
- [ ] Cold open with Obsidian configured — splash stays visible during sync, dismisses cleanly when done
- [ ] Cold open without Obsidian configured — splash dismisses promptly (no 10s wait)
- [ ] App-switch back to dayGLANCE triggers warm sync — toast appears briefly
- [ ] If JS errors before calling notifyAppReady, splash dismisses after 10s fallback

https://claude.ai/code/session_019KymrFvPD72EWGrvjgDJWb