### PR TITLE
fix(goals): hide due-today alert for completed/archived goals

### DIFF
--- a/src/hooks/useStats.js
+++ b/src/hooks/useStats.js
@@ -116,7 +116,7 @@ export default function useStats({ tasks, unscheduledTasks, recurringTasks, goal
   const todayCompletedProjects = projects.filter(p => p.status === 'completed' && p.updatedAt?.startsWith(todayStr));
 
   // Incomplete goals due today
-  const todayDueGoals = goals.filter(g => g.targetDate === todayStr && g.status !== 'completed');
+  const todayDueGoals = goals.filter(g => g.targetDate === todayStr && g.status === 'active');
 
   // Consecutive day streak — count of consecutive days (going back from today)
   // on which at least one task was completed


### PR DESCRIPTION
## Summary

`useStats.js` was filtering `todayDueGoals` with `status !== 'completed'`, which still included archived goals. Changed to `status === 'active'` to match the existing behaviour in `GlanceSidebar` and `MobileGlanceSection`, which already filter correctly.

## Test plan
- [ ] Goal completed today — due-today alert no longer shows in daily summary / mobile bottom sheet
- [ ] Goal archived — same
- [ ] Active goal due today — alert still shows

https://claude.ai/code/session_019KymrFvPD72EWGrvjgDJWb