### PR TITLE
fix(goals): apply w-[260px] to goal-assigned project card wrappers

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -775,7 +775,7 @@ const DesktopDashboard = ({
               <div
                 key={proj.id}
                 data-proj-id={proj.id}
-                className={`relative transition-opacity ${dragProjectId === proj.id ? 'opacity-40' : ''} ${
+                className={`relative w-[260px] transition-opacity ${dragProjectId === proj.id ? 'opacity-40' : ''} ${
                   dropInsertBeforeId === proj.id && dragProjectId && dragProjectId !== proj.id
                     ? 'ring-2 ring-blue-500 rounded-xl' : ''
                 }`}


### PR DESCRIPTION
## Summary

PR #395 fixed standalone project card widths but missed the goal-assigned `wrapCard` wrapper. This adds `w-[260px]` there too so all project cards on the dashboard are uniform width.

https://claude.ai/code/session_019KymrFvPD72EWGrvjgDJWb