### PR TITLE
feat(sync): include obsidianConfig in cloud sync payload

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4147,6 +4147,7 @@ const DayPlanner = () => {
         projects,
         deletedProjectIds: JSON.parse(localStorage.getItem('day-planner-deleted-project-ids') || '{}'),
         goalsProjectsEnabled,
+        obsidianConfig: obsidianConfig ?? null,
       }
     };
   };
@@ -4303,6 +4304,29 @@ const DayPlanner = () => {
     }
     if (data.deletedGoalIds) localStorage.setItem('day-planner-deleted-goal-ids', JSON.stringify(data.deletedGoalIds));
     if (data.deletedProjectIds) localStorage.setItem('day-planner-deleted-project-ids', JSON.stringify(data.deletedProjectIds));
+    if (data.obsidianConfig) {
+      // On Android, vault path and pattern are managed by native settings — only apply
+      // the app-level fields so a desktop value doesn't break the native integration.
+      // The startup useEffect always re-seeds path/pattern from native config anyway.
+      if (isNativeAndroid()) {
+        setObsidianConfig(prev => prev ? {
+          ...prev,
+          taskHeading: data.obsidianConfig.taskHeading ?? prev.taskHeading,
+          dailyNoteTemplate: data.obsidianConfig.dailyNoteTemplate ?? prev.dailyNoteTemplate,
+          newNotesFolder: data.obsidianConfig.newNotesFolder ?? prev.newNotesFolder,
+        } : prev);
+        const existing = JSON.parse(localStorage.getItem('day-planner-obsidian-config') || 'null');
+        if (existing) localStorage.setItem('day-planner-obsidian-config', JSON.stringify({
+          ...existing,
+          taskHeading: data.obsidianConfig.taskHeading ?? existing.taskHeading,
+          dailyNoteTemplate: data.obsidianConfig.dailyNoteTemplate ?? existing.dailyNoteTemplate,
+          newNotesFolder: data.obsidianConfig.newNotesFolder ?? existing.newNotesFolder,
+        }));
+      } else {
+        localStorage.setItem('day-planner-obsidian-config', JSON.stringify(data.obsidianConfig));
+        setObsidianConfig(data.obsidianConfig);
+      }
+    }
     // darkMode, reminderSettings, and soundEnabled are device-specific — not synced
 
     // Update React state directly (avoid page reload).

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -749,6 +749,9 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
       projects: mergedProjects,
       deletedProjectIds: prunedDeletedProjectIds,
       goalsProjectsEnabled: remoteData.goalsProjectsEnabled !== undefined ? remoteData.goalsProjectsEnabled : localData.goalsProjectsEnabled,
+      // obsidianConfig: remote wins if present, preserving all app-level settings across devices.
+      // On Android, applyRemoteData only applies the non-native fields.
+      obsidianConfig: remoteData.obsidianConfig ?? localData.obsidianConfig ?? null,
       minimizedSections: localData.minimizedSections, // UI pref — keep local
       use24HourClock: localData.use24HourClock // device pref — keep local
     },


### PR DESCRIPTION
## Summary

`obsidianConfig` is now included in cloud sync so `taskHeading`, `dailyNoteTemplate`, `newNotesFolder`, `dailyNotesPath`, and `dailyNotePattern` stay consistent across desktop, web, and Android.

**Android caveat:** vault path and pattern are managed by native Android settings, so `applyRemoteData` only merges the three app-level fields on Android (`taskHeading`, `dailyNoteTemplate`, `newNotesFolder`). Path and pattern are left to native config as before.

## Changes
- `buildSyncPayload`: adds `obsidianConfig` to the payload
- `applyRemoteData`: full apply on desktop/web; selective merge on Android
- `mergeSync.js`: remote wins if present, else local (same pattern as `habitsEnabled`, `goalsProjectsEnabled`)

## Test plan
- [ ] Change `taskHeading` on desktop — syncs to web and Android
- [ ] Change `dailyNoteTemplate` on web — syncs to desktop
- [ ] On Android, cloud sync does not overwrite the native-configured vault path/pattern

https://claude.ai/code/session_019KymrFvPD72EWGrvjgDJWb