### PR TITLE
Remove Vercel Analytics and Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "dayglance",
       "version": "2.3.1",
       "dependencies": {
-        "@vercel/analytics": "^1.6.1",
-        "@vercel/speed-insights": "^1.3.1",
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -2593,78 +2591,6 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
-      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
-      "license": "MPL-2.0",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vercel/speed-insights": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.3.1.tgz",
-      "integrity": "sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@vercel/analytics": "^1.6.1",
-    "@vercel/speed-insights": "^1.3.1",
     "lucide-react": "^0.564.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/android-stub.js
+++ b/src/android-stub.js
@@ -1,5 +1,0 @@
-// Stub for packages excluded from the Android build.
-// Vercel analytics/telemetry have no place in a local, privacy-first native app.
-export const Analytics = () => null;
-export const SpeedInsights = () => null;
-export default {};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { Analytics } from '@vercel/analytics/react'
-import { SpeedInsights } from '@vercel/speed-insights/react'
 import App from './App.jsx'
 import './index.css'
 
@@ -68,8 +66,6 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <ErrorBoundary>
       <App />
-      <Analytics />
-      <SpeedInsights />
     </ErrorBoundary>
   </React.StrictMode>,
 )

--- a/vite.config.android.js
+++ b/vite.config.android.js
@@ -4,14 +4,13 @@
  * Differences from the default web build:
  *   - base: './'     — relative asset paths required for file:// loading
  *   - No VitePWA     — service workers don't run on file:// URLs
- *   - Vercel packages stubbed out — no telemetry in the native app
  *   - outDir targets the Android assets folder directly
  */
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
-import { dirname, resolve } from 'path';
+import { dirname } from 'path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
@@ -22,14 +21,6 @@ export default defineConfig({
   define: {
     __BUILD_TIMESTAMP__: JSON.stringify(new Date().toISOString()),
     __APP_VERSION__: JSON.stringify(pkg.version),
-  },
-
-  resolve: {
-    alias: {
-      // Strip Vercel telemetry — replace with no-op stubs
-      '@vercel/analytics/react': resolve(__dirname, 'src/android-stub.js'),
-      '@vercel/speed-insights/react': resolve(__dirname, 'src/android-stub.js'),
-    },
   },
 
   plugins: [


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes `@vercel/analytics` and `@vercel/speed-insights` npm packages
- Removes `<Analytics />` and `<SpeedInsights />` components from `src/main.jsx`
- Deletes `src/android-stub.js` (existed solely to stub these packages for Android builds)
- Cleans up `vite.config.android.js`: removes the stub aliases and unused `resolve` import

https://claude.ai/code/session_01UsLAAd92Xz1gDgZajHy1ux
EOF
)