### PR TITLE
Add client-side AES-256-GCM encryption for cloud sync and remote backups

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/CryptoKeyBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/CryptoKeyBridge.kt
@@ -1,0 +1,112 @@
+package com.dayglance.app.bridge
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import android.webkit.JavascriptInterface
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import java.security.KeyStore
+
+/**
+ * Stores and retrieves the JS-layer sync encryption key using the Android Keystore.
+ *
+ * The JS side exports its AES-256-GCM key bytes as a base64 JSON blob and hands
+ * them to [storeSyncKey]. We wrap (encrypt) those bytes with a device-bound
+ * Keystore key and persist the ciphertext in SharedPreferences. On retrieval,
+ * [getSyncKey] unwraps and returns the original base64 blob to JS.
+ *
+ * The Keystore key never leaves the hardware security module. Even if
+ * SharedPreferences were extracted from a device backup, the ciphertext is
+ * useless without the device's Keystore key.
+ *
+ * These methods run on a background thread (Android's JavascriptInterface
+ * dispatch) — Keystore operations are synchronous and safe to call there.
+ */
+class CryptoKeyBridge(private val context: Context) {
+
+    companion object {
+        private const val KEYSTORE_PROVIDER  = "AndroidKeyStore"
+        private const val KEY_ALIAS          = "dayglance_sync_key_v1"
+        private const val AES_GCM            = "AES/GCM/NoPadding"
+        private const val GCM_TAG_LENGTH     = 128 // bits
+
+        private const val PREFS_NAME         = "dayglance_crypto"
+        private const val PREF_CIPHERTEXT    = "sync_key_ciphertext"
+        private const val PREF_IV            = "sync_key_iv"
+    }
+
+    private val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER).also { it.load(null) }
+
+    // Returns the existing Keystore key, or generates a fresh one on first call.
+    private fun getOrCreateKey(): SecretKey {
+        if (keyStore.containsAlias(KEY_ALIAS)) {
+            return (keyStore.getEntry(KEY_ALIAS, null) as KeyStore.SecretKeyEntry).secretKey
+        }
+        val keyGen = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE_PROVIDER)
+        keyGen.init(
+            KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(256)
+                .build()
+        )
+        return keyGen.generateKey()
+    }
+
+    /**
+     * Encrypts [b64] (the JS sync key blob) with the Keystore key and persists
+     * the ciphertext. Pass null to clear the stored key (e.g. when encryption
+     * is disabled).
+     *
+     * Called from JS as: `window.DayGlanceNative.storeSyncKey(b64)`
+     */
+    @JavascriptInterface
+    fun storeSyncKey(b64: String?) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        if (b64 == null) {
+            prefs.edit().remove(PREF_CIPHERTEXT).remove(PREF_IV).apply()
+            return
+        }
+        val plaintext = Base64.decode(b64, Base64.DEFAULT)
+        val key       = getOrCreateKey()
+        val cipher    = Cipher.getInstance(AES_GCM)
+        cipher.init(Cipher.ENCRYPT_MODE, key)
+        val ciphertext = cipher.doFinal(plaintext)
+        prefs.edit()
+            .putString(PREF_CIPHERTEXT, Base64.encodeToString(ciphertext, Base64.DEFAULT))
+            .putString(PREF_IV,         Base64.encodeToString(cipher.iv,  Base64.DEFAULT))
+            .apply()
+    }
+
+    /**
+     * Decrypts and returns the stored sync key blob, or "" if nothing is stored
+     * or decryption fails (e.g. after an app reinstall that cleared the Keystore).
+     *
+     * Called from JS as: `window.DayGlanceNative.getSyncKey()`
+     */
+    @JavascriptInterface
+    fun getSyncKey(): String {
+        val prefs          = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val ciphertextB64  = prefs.getString(PREF_CIPHERTEXT, null) ?: return ""
+        val ivB64          = prefs.getString(PREF_IV,          null) ?: return ""
+        return try {
+            val ciphertext = Base64.decode(ciphertextB64, Base64.DEFAULT)
+            val iv         = Base64.decode(ivB64,          Base64.DEFAULT)
+            val key        = getOrCreateKey()
+            val cipher     = Cipher.getInstance(AES_GCM)
+            cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_LENGTH, iv))
+            val plaintext  = cipher.doFinal(ciphertext)
+            Base64.encodeToString(plaintext, Base64.DEFAULT)
+        } catch (_: Exception) {
+            // Keystore key was replaced (reinstall, etc.) — JS will show passphrase prompt.
+            ""
+        }
+    }
+}

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -36,6 +36,7 @@ class NativeBridge(
     private val focus = FocusBridge(context, notifications)
     private val dataStore = SharedDataStore(context)
     private val http = HttpBridge()
+    private val cryptoKey = CryptoKeyBridge(context)
 
     private var mediaRecorder: MediaRecorder? = null
     private var recordingFile: File? = null
@@ -337,6 +338,14 @@ class NativeBridge(
             }
         }
     }
+
+    // ── Sync key (Android Keystore) ───────────────────────────────────────────
+
+    @JavascriptInterface
+    fun storeSyncKey(b64: String?) = cryptoKey.storeSyncKey(b64)
+
+    @JavascriptInterface
+    fun getSyncKey(): String = cryptoKey.getSyncKey()
 
     // ── Settings ─────────────────────────────────────────────────────────────
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4433,6 +4433,13 @@ const DayPlanner = () => {
       setTimeout(() => setCloudSyncStatus((s) => s === 'success' ? 'idle' : s), 3000);
     } catch (err) {
       console.error('Cloud sync download error:', err);
+      // If the file's encryption salt doesn't match the cached key and no passphrase
+      // is in memory, re-show the passphrase modal so the user can re-enter it.
+      if (err.code === 'PASSPHRASE_REQUIRED') {
+        setSyncKeyReady(false);
+        setCloudSyncStatus('idle');
+        return;
+      }
       cloudSyncErrorCountRef.current += 1;
       // Exponential backoff: 30s, 60s, 2m, 4m … capped at 15 min
       const backoffMs = Math.min(30 * Math.pow(2, cloudSyncErrorCountRef.current - 1), 15 * 60) * 1000;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ import GettingStartedChecklist from './components/GettingStartedChecklist.jsx';
 import NotesSubtasksPanel from './components/NotesSubtasksPanel.jsx';
 import DailyNotesModal from './components/DailyNotesModal.jsx';
 import CloudSyncSettingsForm from './components/CloudSyncSettingsForm.jsx';
+import SyncPassphraseModal from './components/SyncPassphraseModal.jsx';
 import AutoBackupSettingsForm from './components/AutoBackupSettingsForm.jsx';
 import SettingsModal from './components/SettingsModal.jsx';
 import RemindersSettingsModal from './components/RemindersSettingsModal.jsx';
@@ -396,6 +397,7 @@ const DayPlanner = () => {
     cloudSyncError, setCloudSyncError,
     cloudSyncLastSynced, setCloudSyncLastSynced,
     cloudSyncConflict, setCloudSyncConflict,
+    syncKeyReady, setSyncKeyReady,
     cloudSyncDebounceRef,
     suppressCloudUploadRef,
     suppressTimestampRef,
@@ -1108,15 +1110,17 @@ const DayPlanner = () => {
     return () => { if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current); };
   }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled]);
 
-  // Cloud sync: download on app load or when sync is first enabled
+  // Cloud sync: download on app load or when sync is first enabled.
+  // If encryption is enabled, wait until the session key is ready (either
+  // restored from IndexedDB or provided by the passphrase modal).
   useEffect(() => {
-    if (dataLoaded && cloudSyncConfig?.enabled) {
+    if (dataLoaded && cloudSyncConfig?.enabled && syncKeyReady) {
       cloudSyncDownload();
     } else if (dataLoaded && !cloudSyncConfig?.enabled) {
       // No cloud sync — allow local-modified timestamps immediately
       cloudSyncInitialDoneRef.current = true;
     }
-  }, [dataLoaded, cloudSyncConfig?.enabled]);
+  }, [dataLoaded, cloudSyncConfig?.enabled, syncKeyReady]);
 
   // Cloud sync: poll for remote changes every 60 seconds
   useEffect(() => {
@@ -6742,6 +6746,7 @@ const DayPlanner = () => {
     cloudSyncError, setCloudSyncError,
     cloudSyncLastSynced, setCloudSyncLastSynced,
     cloudSyncConflict, setCloudSyncConflict,
+    syncKeyReady, setSyncKeyReady,
 
     // ── Obsidian ──────────────────────────────────────────────────────────────
     obsidianConfig, setObsidianConfig,
@@ -8081,6 +8086,18 @@ const DayPlanner = () => {
 
       {/* Keyboard Shortcut Cheat Sheet */}
       {showShortcutHelp && <ShortcutHelpModal />}
+
+      {/* Sync passphrase prompt — shown on app load when encryption is enabled
+          but no cached key was found in device storage (e.g. new device). */}
+      {cloudSyncConfig?.encryptionEnabled && !syncKeyReady && (
+        <SyncPassphraseModal
+          darkMode={darkMode}
+          textPrimary={textPrimary}
+          textSecondary={textSecondary}
+          borderClass={borderClass}
+          onUnlocked={() => setSyncKeyReady(true)}
+        />
+      )}
 
       {/* Frame Context Menu */}
       {frameContextMenu && (() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -409,6 +409,10 @@ const DayPlanner = () => {
     cloudSyncBackoffUntilRef,
   } = useCloudSync();
 
+  // Ref so interval/timeout callbacks can read the current syncKeyReady without stale closure
+  const syncKeyReadyRef = useRef(syncKeyReady);
+  useEffect(() => { syncKeyReadyRef.current = syncKeyReady; }, [syncKeyReady]);
+
   // Daily Notes state — keyed by date string "YYYY-MM-DD" → { text, lastModified }
   const [dailyNotes, setDailyNotes] = useState(() => {
     try {
@@ -1126,7 +1130,7 @@ const DayPlanner = () => {
   useEffect(() => {
     if (!cloudSyncConfig?.enabled) return;
     const pollTimer = setInterval(() => {
-      if (Date.now() >= cloudSyncBackoffUntilRef.current) {
+      if (syncKeyReadyRef.current && Date.now() >= cloudSyncBackoffUntilRef.current) {
         cloudSyncDownloadRef.current?.();
       }
     }, 60 * 1000);

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
+import { setupEncryptionKey, setSyncPassphrase, clearEncryptionKey } from '../utils/crypto.js';
 
 // Cloud sync settings form (extracted to avoid hooks-in-conditional issues)
-const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderClass, hoverBg, cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, provider, currentProvider, onClose, cloudSyncLastSynced }) => {
+const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderClass, hoverBg, cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, provider, currentProvider, onClose, cloudSyncLastSynced, onSyncKeyReady }) => {
   const [formData, setFormData] = useState(() => {
     const initial = { provider: currentProvider };
     // Populate fields from all providers so switching preserves filled values
@@ -11,11 +12,22 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
     });
     return initial;
   });
+  const [encryptionEnabled, setEncryptionEnabled] = useState(cloudSyncConfig?.encryptionEnabled ?? false);
+  const [passphrase, setPassphrase] = useState('');
+  const [passphraseConfirm, setPassphraseConfirm] = useState('');
   const [testResult, setTestResult] = useState(null);
   const [testing, setTesting] = useState(false);
 
   const activeProvider = cloudSyncProviders[formData.provider] || provider;
   const requiredFieldsFilled = activeProvider.configFields.every(f => formData[f.key]);
+
+  // When enabling encryption, require a passphrase (confirmed) on fresh enable.
+  // When already enabled, allow saving without re-entering (passphrase field is optional).
+  const alreadyEncrypted = cloudSyncConfig?.encryptionEnabled;
+  const passphraseRequired = encryptionEnabled && !alreadyEncrypted;
+  const passphraseMismatch = passphraseRequired && passphraseConfirm && passphrase !== passphraseConfirm;
+  const passphraseValid = !passphraseRequired || (passphrase.length > 0 && passphrase === passphraseConfirm);
+  const canSave = requiredFieldsFilled && passphraseValid && !passphraseMismatch;
 
   const handleTest = async () => {
     setTesting(true);
@@ -25,8 +37,25 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
     setTesting(false);
   };
 
-  const handleSave = () => {
-    setCloudSyncConfig({ ...formData, provider: formData.provider, enabled: true });
+  const handleSave = async () => {
+    const newConfig = { ...formData, provider: formData.provider, enabled: true, encryptionEnabled };
+
+    if (encryptionEnabled) {
+      if (passphraseRequired && passphrase) {
+        // First-time setup: generate salt + derive + cache key.
+        await setupEncryptionKey(passphrase);
+      } else if (!alreadyEncrypted && passphrase) {
+        // Re-entering passphrase on existing encrypted setup (new device via settings form).
+        setSyncPassphrase(passphrase);
+      }
+      // If alreadyEncrypted and no passphrase entered, leave session key as-is.
+    } else if (alreadyEncrypted) {
+      // User disabled encryption.
+      await clearEncryptionKey();
+    }
+
+    setCloudSyncConfig(newConfig);
+    onSyncKeyReady?.(encryptionEnabled);
     onClose();
   };
 
@@ -70,6 +99,72 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
         <p className={`text-xs ${textSecondary}`}>{activeProvider.helpText}</p>
       )}
 
+      {/* Encryption section */}
+      <div className={`border-t ${borderClass} pt-4 space-y-3`}>
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={encryptionEnabled}
+            onChange={(e) => {
+              setEncryptionEnabled(e.target.checked);
+              setPassphrase('');
+              setPassphraseConfirm('');
+            }}
+            className="w-4 h-4 rounded"
+          />
+          <span className={`text-sm font-medium ${textPrimary}`}>Enable end-to-end encryption</span>
+        </label>
+
+        {encryptionEnabled && (
+          <div className="ml-7 space-y-3">
+            <p className={`text-xs ${textSecondary}`}>
+              Your data is encrypted on-device before upload. The server never sees your plaintext.
+              Use a <strong>sync passphrase</strong> — not your WebDAV password.
+            </p>
+
+            {alreadyEncrypted && !passphraseRequired && (
+              <p className={`text-xs text-amber-500`}>
+                Encryption is already configured. Leave the passphrase field blank to keep your existing key, or enter it again to re-authenticate on this device.
+              </p>
+            )}
+
+            <div>
+              <label className={`block text-sm ${textSecondary} mb-1`}>
+                Sync passphrase{passphraseRequired ? '' : ' (optional)'}
+              </label>
+              <input
+                type="password"
+                placeholder={passphraseRequired ? 'Choose a strong passphrase' : 'Re-enter to re-authenticate'}
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+                className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+              />
+            </div>
+
+            {passphraseRequired && (
+              <div>
+                <label className={`block text-sm ${textSecondary} mb-1`}>Confirm passphrase</label>
+                <input
+                  type="password"
+                  placeholder="Re-enter your passphrase"
+                  value={passphraseConfirm}
+                  onChange={(e) => setPassphraseConfirm(e.target.value)}
+                  className={`w-full px-3 py-2 border ${passphraseMismatch ? 'border-red-500' : borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+                />
+                {passphraseMismatch && (
+                  <p className="text-xs text-red-500 mt-0.5">Passphrases do not match.</p>
+                )}
+              </div>
+            )}
+
+            <div className={`text-xs ${textSecondary} space-y-1 rounded-lg p-3 ${darkMode ? 'bg-gray-700' : 'bg-amber-50 border border-amber-200'}`}>
+              <p className="font-medium text-amber-600">Important — store your passphrase safely</p>
+              <p>This passphrase cannot be recovered. You will need it to set up sync on new devices. Store it in a password manager.</p>
+            </div>
+          </div>
+        )}
+      </div>
+
       <div className="flex items-center gap-2">
         <button
           onClick={handleTest}
@@ -108,7 +203,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
         )}
         <button
           onClick={handleSave}
-          disabled={!requiredFieldsFilled}
+          disabled={!canSave}
           className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
         >
           {cloudSyncConfig?.enabled ? 'Save' : 'Save & Enable'}

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -57,6 +57,7 @@ const MobileSettingsPanel = () => {
     setAutoBackupRestoreConfirm,
     cloudSyncConfig, setCloudSyncConfig,
     cloudSyncStatus, cloudSyncLastSynced,
+    syncKeyReady, setSyncKeyReady,
     obsidianConfig, setObsidianConfig,
     obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
     wikilinkCandidates, setWikilinkCandidates,
@@ -471,6 +472,7 @@ const MobileSettingsPanel = () => {
           currentProvider={currentProvider}
           onClose={() => setMobileSettingsView('main')}
           cloudSyncLastSynced={cloudSyncLastSynced}
+          onSyncKeyReady={(ready) => setSyncKeyReady(ready)}
         />
         </>)}
       </div>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -31,6 +31,7 @@ const SettingsModal = () => {
   const {
     handleFileUpload,
     cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, cloudSyncLastSynced,
+    syncKeyReady, setSyncKeyReady,
     calSyncConfigured, syncUrl, setSyncUrl,
     showCalendarUrlHint, setShowCalendarUrlHint,
     calendarUrlAuth, setCalendarUrlAuth,
@@ -363,6 +364,7 @@ const SettingsModal = () => {
                         currentProvider={currentProvider}
                         onClose={() => setShowSettings(false)}
                         cloudSyncLastSynced={cloudSyncLastSynced}
+                        onSyncKeyReady={(ready) => setSyncKeyReady(ready)}
                       />
                       </>)}
                     </div>

--- a/src/components/SyncPassphraseModal.jsx
+++ b/src/components/SyncPassphraseModal.jsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { Lock } from 'lucide-react';
+import { setSyncPassphrase } from '../utils/crypto.js';
+
+/**
+ * Shown on app load when cloud sync encryption is enabled but no cached key
+ * was found in device storage (e.g. new device, cleared browser data).
+ *
+ * The user enters their sync passphrase — we store it in session memory and
+ * the derived key is cached to IndexedDB/Android Keystore on the first
+ * successful decryption (inside decryptData in crypto.js).
+ */
+const SyncPassphraseModal = ({ darkMode, textPrimary, textSecondary, borderClass, onUnlocked }) => {
+  const [passphrase, setPassphrase] = useState('');
+  const [error, setError] = useState(null);
+
+  const bgModal  = darkMode ? 'bg-gray-800' : 'bg-white';
+  const bgOverlay = 'bg-black/60';
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!passphrase.trim()) return;
+    setError(null);
+    // Store in session — the key will be derived and cached on first sync.
+    setSyncPassphrase(passphrase.trim());
+    onUnlocked();
+  };
+
+  return (
+    <div className={`fixed inset-0 z-50 flex items-center justify-center ${bgOverlay}`}>
+      <div className={`${bgModal} rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6`}>
+        <div className="flex items-center gap-3 mb-4">
+          <div className={`p-2 rounded-lg ${darkMode ? 'bg-gray-700' : 'bg-blue-50'}`}>
+            <Lock size={20} className="text-blue-500" />
+          </div>
+          <h2 className={`text-lg font-semibold ${textPrimary}`}>Unlock sync</h2>
+        </div>
+
+        <p className={`text-sm ${textSecondary} mb-4`}>
+          Cloud sync is encrypted. Enter your sync passphrase to continue.
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className={`block text-sm ${textSecondary} mb-1`}>Sync passphrase</label>
+            <input
+              type="password"
+              autoFocus
+              value={passphrase}
+              onChange={(e) => setPassphrase(e.target.value)}
+              placeholder="Your sync passphrase"
+              className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-500">{error}</p>}
+
+          <p className={`text-xs ${textSecondary}`}>
+            This is the passphrase you set when you first enabled encryption. It is never stored — only you know it.
+          </p>
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="submit"
+              disabled={!passphrase.trim()}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+            >
+              Unlock
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default SyncPassphraseModal;

--- a/src/hooks/useCloudSync.js
+++ b/src/hooks/useCloudSync.js
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { initSessionKey } from '../utils/crypto.js';
 
 const useCloudSync = () => {
   const [cloudSyncConfig, setCloudSyncConfig] = useState(() => {
@@ -11,15 +12,20 @@ const useCloudSync = () => {
     localStorage.getItem('day-planner-cloud-sync-last-synced') || null
   );
   const [cloudSyncConflict, setCloudSyncConflict] = useState(null); // { remoteData, remoteModified }
-  const cloudSyncDebounceRef = useRef(null);
-  const suppressCloudUploadRef = useRef(false);
-  const suppressTimestampRef = useRef(false);
-  const suppressClearPendingRef = useRef(false);
-  const cloudSyncInProgressRef = useRef(false);
-  const cloudSyncInitialDoneRef = useRef(false);
-  const cloudSyncDownloadRef = useRef(null);
-  const cloudSyncErrorCountRef = useRef(0); // consecutive download failures
-  const cloudSyncBackoffUntilRef = useRef(0); // timestamp: skip poll/visibility retries until this time
+
+  // true once initSessionKey() resolves (either key found or not)
+  // false means "encryption enabled but no cached key — show passphrase prompt"
+  const [syncKeyReady, setSyncKeyReady] = useState(false);
+
+  const cloudSyncDebounceRef       = useRef(null);
+  const suppressCloudUploadRef     = useRef(false);
+  const suppressTimestampRef       = useRef(false);
+  const suppressClearPendingRef    = useRef(false);
+  const cloudSyncInProgressRef     = useRef(false);
+  const cloudSyncInitialDoneRef    = useRef(false);
+  const cloudSyncDownloadRef       = useRef(null);
+  const cloudSyncErrorCountRef     = useRef(0);
+  const cloudSyncBackoffUntilRef   = useRef(0);
 
   // Persist cloud sync config
   useEffect(() => {
@@ -30,12 +36,34 @@ const useCloudSync = () => {
     }
   }, [cloudSyncConfig]);
 
+  // On mount: attempt to restore the session encryption key from device storage.
+  // If encryption is enabled but no cached key exists, syncKeyReady stays false
+  // so the app can show the passphrase prompt.
+  useEffect(() => {
+    const config = (() => {
+      const saved = localStorage.getItem('day-planner-cloud-sync-config');
+      return saved ? JSON.parse(saved) : null;
+    })();
+
+    if (config?.encryptionEnabled) {
+      initSessionKey().then((found) => {
+        // found = true  → key restored silently, unlock sync immediately
+        // found = false → passphrase prompt will be shown by App
+        setSyncKeyReady(found);
+      });
+    } else {
+      // Encryption not configured — no passphrase needed.
+      setSyncKeyReady(true);
+    }
+  }, []);
+
   return {
     cloudSyncConfig, setCloudSyncConfig,
     cloudSyncStatus, setCloudSyncStatus,
     cloudSyncError, setCloudSyncError,
     cloudSyncLastSynced, setCloudSyncLastSynced,
     cloudSyncConflict, setCloudSyncConflict,
+    syncKeyReady, setSyncKeyReady,
     cloudSyncDebounceRef,
     suppressCloudUploadRef,
     suppressTimestampRef,

--- a/src/utils/autoBackup.js
+++ b/src/utils/autoBackup.js
@@ -1,3 +1,5 @@
+import { encryptData, decryptData, isEncryptedEnvelope, hasEncryptionReady } from './crypto.js';
+
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
 const toBase64 = (str) => btoa(unescape(encodeURIComponent(str)));
 
@@ -100,7 +102,8 @@ export const autoBackupProviders = {
       const timestamp = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}-${String(now.getDate()).padStart(2,'0')}T${String(now.getHours()).padStart(2,'0')}-${String(now.getMinutes()).padStart(2,'0')}-${String(now.getSeconds()).padStart(2,'0')}`;
       const filename = `dayglance-backup-${timestamp}.json`;
       const fileUrl = dirUrl + filename;
-      const body = JSON.stringify(data);
+      const payload = hasEncryptionReady() ? await encryptData(data) : data;
+      const body = JSON.stringify(payload);
 
       const doUpload = () =>
         fetch(`/api/webdav-proxy/?url=${fileUrl}`, {
@@ -152,7 +155,9 @@ export const autoBackupProviders = {
         headers: authHeaders
       });
       if (!res.ok) throw new Error(`Download failed: ${res.status}`);
-      return res.json();
+      const parsed = await res.json();
+      if (isEncryptedEnvelope(parsed)) return decryptData(parsed);
+      return parsed;
     },
     async deleteBackup(config, filename) {
       const fileUrl = this._getBackupDirUrl(config) + filename;
@@ -195,7 +200,8 @@ export const autoBackupProviders = {
       const timestamp = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}-${String(now.getDate()).padStart(2,'0')}T${String(now.getHours()).padStart(2,'0')}-${String(now.getMinutes()).padStart(2,'0')}-${String(now.getSeconds()).padStart(2,'0')}`;
       const filename = `dayglance-backup-${timestamp}.json`;
       const fileUrl = dirUrl + filename;
-      const body = JSON.stringify(data);
+      const payload = hasEncryptionReady() ? await encryptData(data) : data;
+      const body = JSON.stringify(payload);
       const doUpload = () =>
         fetch(`/api/webdav-proxy/?url=${fileUrl}`, {
           method: 'PUT',
@@ -242,7 +248,9 @@ export const autoBackupProviders = {
         headers: authHeaders
       });
       if (!res.ok) throw new Error(`Download failed: ${res.status}`);
-      return res.json();
+      const parsed = await res.json();
+      if (isEncryptedEnvelope(parsed)) return decryptData(parsed);
+      return parsed;
     },
     async deleteBackup(config, filename) {
       const fileUrl = this._getBackupDirUrl(config) + filename;

--- a/src/utils/cloudSyncProviders.js
+++ b/src/utils/cloudSyncProviders.js
@@ -1,4 +1,5 @@
 import { nativeHttpRequest } from '../native.js';
+import { encryptData, decryptData, isEncryptedEnvelope } from './crypto.js';
 
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
 const toBase64 = (str) => btoa(unescape(encodeURIComponent(str)));
@@ -63,7 +64,8 @@ export const cloudSyncProviders = {
       const fileUrl = this.getFileUrl(config);
       const dirUrl = this.getDirUrl(config);
       const authHeaders = this.getAuthHeaders(config);
-      const body = JSON.stringify(data);
+      const payload = config.encryptionEnabled ? await encryptData(data) : data;
+      const body = JSON.stringify(payload);
 
       const doUpload = () =>
         webdavFetch('PUT', fileUrl, authHeaders, body, { 'Content-Type': 'application/json' });
@@ -86,7 +88,9 @@ export const cloudSyncProviders = {
       if (res.status === 404) return null; // No remote file yet
       if (res.status === 403) throw new Error('FORBIDDEN');
       if (!res.ok) throw new Error(`Download failed: ${res.status} ${res.statusText}`);
-      return res.json();
+      const parsed = await res.json();
+      if (isEncryptedEnvelope(parsed)) return decryptData(parsed);
+      return parsed;
     },
     async test(config) {
       const dirUrl = this.getDirUrl(config);
@@ -119,7 +123,8 @@ export const cloudSyncProviders = {
       const fileUrl = this.getFileUrl(config);
       const dirUrl = this.getDirUrl(config);
       const authHeaders = this.getAuthHeaders(config);
-      const body = JSON.stringify(data);
+      const payload = config.encryptionEnabled ? await encryptData(data) : data;
+      const body = JSON.stringify(payload);
       const doUpload = () =>
         webdavFetch('PUT', fileUrl, authHeaders, body, { 'Content-Type': 'application/json' });
       let res = await doUpload();
@@ -138,7 +143,9 @@ export const cloudSyncProviders = {
       if (res.status === 404) return null;
       if (res.status === 403) throw new Error('FORBIDDEN');
       if (!res.ok) throw new Error(`Download failed: ${res.status} ${res.statusText}`);
-      return res.json();
+      const parsed = await res.json();
+      if (isEncryptedEnvelope(parsed)) return decryptData(parsed);
+      return parsed;
     },
     async test(config) {
       const dirUrl = this.getDirUrl(config);

--- a/src/utils/cloudSyncProviders.js
+++ b/src/utils/cloudSyncProviders.js
@@ -39,9 +39,11 @@ export const webdavFetch = async (method, targetUrl, authHeaders, body, extraHea
 // Creates a WebDAV collection and any missing intermediate collections.
 // MKCOL returns 409 when the parent directory doesn't exist; in that case
 // we walk up the path, create the parent first, then retry.
+// Some providers (e.g. Koofr) non-standardly return 404 instead of 409 —
+// treat both the same way.
 const mkcolWithParents = async (dirUrl, authHeaders) => {
   const res = await webdavFetch('MKCOL', dirUrl, authHeaders);
-  if (res.status === 409) {
+  if (res.status === 409 || res.status === 404) {
     const parent = dirUrl.replace(/\/+$/, '').replace(/\/[^/]+$/, '/');
     if (parent && parent !== dirUrl) {
       await mkcolWithParents(parent, authHeaders);

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -269,9 +269,18 @@ export async function decryptData(envelope) {
 
   let key = _sessionKey;
 
+  // If the cached key was derived from a different salt (e.g. user re-configured
+  // encryption, generating a new salt), it cannot decrypt this file. Force
+  // re-derivation so the file's embedded salt always dictates which key is used.
+  if (key && _sessionSalt) {
+    const saltMatch = salt.length === _sessionSalt.length &&
+      salt.every((b, i) => b === _sessionSalt[i]);
+    if (!saltMatch) key = null;
+  }
+
   if (!key) {
     if (_sessionPassphrase) {
-      // Cross-device recovery: derive key from passphrase + salt from file.
+      // Cross-device recovery or salt mismatch: derive key from passphrase + salt from file.
       key          = await deriveKey(_sessionPassphrase, salt);
       _sessionKey  = key;
       _sessionSalt = salt;

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -291,7 +291,10 @@ export async function decryptData(envelope) {
         await saveKeyToIndexedDB(key, salt);
       }
     } else {
-      throw new Error('Encryption key not available. Please enter your sync passphrase.');
+      // Signal to the caller that the passphrase must be collected from the user.
+      const err = new Error('Encryption key not available. Please enter your sync passphrase.');
+      err.code = 'PASSPHRASE_REQUIRED';
+      throw err;
     }
   }
 

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -1,0 +1,304 @@
+// Client-side encryption for cloud sync and remote backup files.
+// Uses Web Crypto API exclusively — no external dependencies.
+// Architecture: passphrase → PBKDF2 → AES-256-GCM key → encrypts JSON blob.
+
+// ---------------------------------------------------------------------------
+// Session state (in-memory only, never persisted)
+// ---------------------------------------------------------------------------
+let _sessionPassphrase = null; // string | null
+let _sessionKey = null;        // CryptoKey | null
+let _sessionSalt = null;       // Uint8Array | null — the salt used to derive _sessionKey
+
+export function setSyncPassphrase(p) { _sessionPassphrase = p; }
+export function getSyncPassphrase()  { return _sessionPassphrase; }
+export function hasEncryptionReady() { return _sessionKey !== null; }
+
+// ---------------------------------------------------------------------------
+// IndexedDB key store (browser)
+// ---------------------------------------------------------------------------
+const KEY_DB_NAME    = 'dayglance-crypto';
+const KEY_DB_VERSION = 1;
+const KEY_STORE      = 'keys';
+const SYNC_KEY_ID    = 'sync-key';
+
+async function openKeyDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(KEY_DB_NAME, KEY_DB_VERSION);
+    req.onupgradeneeded = (e) => {
+      const db = e.target.result;
+      if (!db.objectStoreNames.contains(KEY_STORE)) {
+        db.createObjectStore(KEY_STORE, { keyPath: 'id' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror  = () => reject(req.error);
+  });
+}
+
+async function saveKeyToIndexedDB(cryptoKey, salt) {
+  const db     = await openKeyDB();
+  const rawKey = await crypto.subtle.exportKey('raw', cryptoKey);
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(KEY_STORE, 'readwrite');
+    tx.objectStore(KEY_STORE).put({ id: SYNC_KEY_ID, rawKey, salt: Array.from(salt) });
+    tx.oncomplete = () => resolve();
+    tx.onerror    = () => reject(tx.error);
+  });
+}
+
+async function loadKeyFromIndexedDB() {
+  try {
+    const db     = await openKeyDB();
+    const record = await new Promise((resolve, reject) => {
+      const tx  = db.transaction(KEY_STORE, 'readonly');
+      const req = tx.objectStore(KEY_STORE).get(SYNC_KEY_ID);
+      req.onsuccess = () => resolve(req.result);
+      req.onerror   = () => reject(req.error);
+    });
+    if (!record) return null;
+    const key = await crypto.subtle.importKey(
+      'raw', record.rawKey, { name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']
+    );
+    return { key, salt: new Uint8Array(record.salt) };
+  } catch {
+    return null;
+  }
+}
+
+async function clearKeyFromIndexedDB() {
+  try {
+    const db = await openKeyDB();
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(KEY_STORE, 'readwrite');
+      tx.objectStore(KEY_STORE).delete(SYNC_KEY_ID);
+      tx.oncomplete = () => resolve();
+      tx.onerror    = () => reject(tx.error);
+    });
+  } catch { /* ignore */ }
+}
+
+// ---------------------------------------------------------------------------
+// Android Keystore bridge
+// ---------------------------------------------------------------------------
+async function loadKeyFromAndroid() {
+  try {
+    if (!window.DayGlanceNative?.getSyncKey) return null;
+    const b64 = await window.DayGlanceNative.getSyncKey();
+    if (!b64) return null;
+    const record = JSON.parse(atob(b64));
+    const key = await crypto.subtle.importKey(
+      'raw', new Uint8Array(record.rawKey), { name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']
+    );
+    return { key, salt: new Uint8Array(record.salt) };
+  } catch {
+    return null;
+  }
+}
+
+async function saveKeyToAndroid(cryptoKey, salt) {
+  if (!window.DayGlanceNative?.storeSyncKey) return;
+  const rawKey = await crypto.subtle.exportKey('raw', cryptoKey);
+  const record = { rawKey: Array.from(new Uint8Array(rawKey)), salt: Array.from(salt) };
+  window.DayGlanceNative.storeSyncKey(btoa(JSON.stringify(record)));
+}
+
+async function clearKeyFromAndroid() {
+  try {
+    if (window.DayGlanceNative?.storeSyncKey) {
+      window.DayGlanceNative.storeSyncKey(null);
+    }
+  } catch { /* ignore */ }
+}
+
+// ---------------------------------------------------------------------------
+// PBKDF2 key derivation
+// ---------------------------------------------------------------------------
+async function deriveKey(passphrase, salt) {
+  const enc         = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 310_000, hash: 'SHA-256' },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt']
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public lifecycle API
+// ---------------------------------------------------------------------------
+
+/**
+ * Called on app load. Attempts to restore the session key from device storage
+ * (IndexedDB on browser, Android Keystore on native) without requiring the user
+ * to re-enter their passphrase.
+ *
+ * @returns {Promise<boolean>} true if key was restored, false if passphrase required.
+ */
+export async function initSessionKey() {
+  try {
+    let result;
+    if (typeof window !== 'undefined' && window.DayGlanceNative?.getSyncKey) {
+      result = await loadKeyFromAndroid();
+    } else {
+      result = await loadKeyFromIndexedDB();
+    }
+    if (result) {
+      _sessionKey  = result.key;
+      _sessionSalt = result.salt;
+      return true;
+    }
+  } catch { /* storage unavailable */ }
+  return false;
+}
+
+/**
+ * First-time setup on a fresh device: derives a key from the passphrase with a
+ * freshly generated salt and caches it in device storage.
+ * Call this when the user configures encryption for the first time.
+ */
+export async function setupEncryptionKey(passphrase) {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const key  = await deriveKey(passphrase, salt);
+  _sessionPassphrase = passphrase;
+  _sessionKey        = key;
+  _sessionSalt       = salt;
+  if (typeof window !== 'undefined' && window.DayGlanceNative?.storeSyncKey) {
+    await saveKeyToAndroid(key, salt);
+  } else {
+    await saveKeyToIndexedDB(key, salt);
+  }
+}
+
+/**
+ * Clears the cached key from device storage and session memory.
+ * Call this when the user disables encryption.
+ */
+export async function clearEncryptionKey() {
+  _sessionPassphrase = null;
+  _sessionKey        = null;
+  _sessionSalt       = null;
+  if (typeof window !== 'undefined' && window.DayGlanceNative?.storeSyncKey) {
+    await clearKeyFromAndroid();
+  } else {
+    await clearKeyFromIndexedDB();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function packBytes(...arrays) {
+  const total = arrays.reduce((n, a) => n + a.length, 0);
+  const out   = new Uint8Array(total);
+  let   offset = 0;
+  for (const a of arrays) { out.set(a, offset); offset += a.length; }
+  return out;
+}
+
+function toBase64(bytes) {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function fromBase64(b64) {
+  return Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+}
+
+// ---------------------------------------------------------------------------
+// Encrypt / decrypt
+// ---------------------------------------------------------------------------
+
+/**
+ * Encrypts a plain JS object and returns an envelope object ready for JSON.stringify.
+ *
+ * Envelope format:
+ *   { v: 1, enc: "AES-GCM-256", data: "<base64>" }
+ *
+ * The base64 blob encodes:
+ *   [ 16 bytes: PBKDF2 salt ] [ 12 bytes: AES-GCM IV ] [ N bytes: ciphertext ]
+ *
+ * The salt is the one used to derive the cached session key. Storing it in the
+ * file allows any device to re-derive the key from the passphrase alone.
+ */
+export async function encryptData(data) {
+  // First use: lazily set up the key so the caller doesn't need to distinguish
+  // between "first device" and "subsequent upload" scenarios.
+  if (!_sessionKey) {
+    if (_sessionPassphrase) {
+      await setupEncryptionKey(_sessionPassphrase);
+    } else {
+      throw new Error('Encryption key not available. Please enter your sync passphrase.');
+    }
+  }
+
+  const plaintext = new TextEncoder().encode(JSON.stringify(data));
+  const iv        = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, _sessionKey, plaintext);
+
+  const packed = packBytes(_sessionSalt, iv, new Uint8Array(ciphertext));
+  return { v: 1, enc: 'AES-GCM-256', data: toBase64(packed) };
+}
+
+/**
+ * Decrypts an envelope object produced by encryptData.
+ * Throws on wrong passphrase, tampered data, or missing key.
+ *
+ * Cross-device recovery path: if no cached key but _sessionPassphrase is set,
+ * derives the key from the passphrase + salt embedded in the ciphertext, then
+ * caches it in device storage for future sessions.
+ */
+export async function decryptData(envelope) {
+  if (!envelope || !envelope.data) throw new Error('Invalid encrypted envelope');
+  if (envelope.v !== 1) throw new Error(`Unknown encryption version: ${envelope.v}`);
+
+  const packed     = fromBase64(envelope.data);
+  const salt       = packed.slice(0, 16);
+  const iv         = packed.slice(16, 28);
+  const ciphertext = packed.slice(28);
+
+  let key = _sessionKey;
+
+  if (!key) {
+    if (_sessionPassphrase) {
+      // Cross-device recovery: derive key from passphrase + salt from file.
+      key          = await deriveKey(_sessionPassphrase, salt);
+      _sessionKey  = key;
+      _sessionSalt = salt;
+      // Cache so subsequent sessions don't need the passphrase.
+      if (typeof window !== 'undefined' && window.DayGlanceNative?.storeSyncKey) {
+        await saveKeyToAndroid(key, salt);
+      } else {
+        await saveKeyToIndexedDB(key, salt);
+      }
+    } else {
+      throw new Error('Encryption key not available. Please enter your sync passphrase.');
+    }
+  }
+
+  try {
+    const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+    return JSON.parse(new TextDecoder().decode(plaintext));
+  } catch (err) {
+    if (err.name === 'OperationError') {
+      throw new Error('Decryption failed — wrong passphrase or corrupted data.');
+    }
+    throw err;
+  }
+}
+
+/**
+ * Returns true if the value looks like an encrypted envelope produced by
+ * encryptData. Used to decide whether to call decryptData on downloaded files.
+ */
+export function isEncryptedEnvelope(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    value.v === 1 &&
+    value.enc === 'AES-GCM-256' &&
+    typeof value.data === 'string'
+  );
+}

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -200,7 +200,15 @@ function packBytes(...arrays) {
 }
 
 function toBase64(bytes) {
-  return btoa(String.fromCharCode(...bytes));
+  // Chunk to avoid "Maximum call stack size exceeded" for large payloads —
+  // spreading a large Uint8Array as function arguments hits the engine's
+  // argument-count limit (~65 K in V8).
+  let binary = '';
+  const chunk = 8192;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
 }
 
 function fromBase64(b64) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,133 @@ import { readFileSync } from 'fs'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
+// ---------------------------------------------------------------------------
+// Dev-only middleware that replicates the Vercel serverless functions for
+// /api/webdav-proxy/ and /api/calendar-proxy/ so `npm run dev` works
+// identically to the deployed environment.
+// ---------------------------------------------------------------------------
+function devApiProxy() {
+  // Identical validation logic to api/webdav-proxy.js and api/calendar-proxy.js.
+  function validateProxyUrl(urlString) {
+    let parsed;
+    try { parsed = new URL(urlString); } catch { throw new Error('Invalid URL'); }
+
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new Error('Only http and https URLs are allowed');
+    }
+
+    const hostname = parsed.hostname.toLowerCase();
+
+    if (hostname === 'localhost' || hostname === '0.0.0.0') {
+      throw new Error('Private/reserved addresses are not allowed');
+    }
+
+    const ipv4 = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+    if (ipv4) {
+      const [a, b] = [Number(ipv4[1]), Number(ipv4[2])];
+      if (
+        a === 10 ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168) ||
+        a === 127 ||
+        (a === 169 && b === 254) ||
+        a === 0 ||
+        (a === 100 && b >= 64 && b <= 127)
+      ) throw new Error('Private/reserved addresses are not allowed');
+    }
+
+    if (
+      hostname === '::1' || hostname === '::' ||
+      /^::ffff:/i.test(hostname) || /^fe80:/i.test(hostname) ||
+      /^fc/i.test(hostname)      || /^fd/i.test(hostname)
+    ) throw new Error('Private/reserved addresses are not allowed');
+
+    return parsed;
+  }
+
+  function readBody(req) {
+    return new Promise((resolve, reject) => {
+      let data = '';
+      req.on('data', chunk => data += chunk);
+      req.on('end', () => resolve(data));
+      req.on('error', reject);
+    });
+  }
+
+  function sendJson(res, status, obj) {
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(obj));
+  }
+
+  return {
+    name: 'dev-api-proxy',
+    configureServer(server) {
+
+      // ── /api/webdav-proxy/ ──────────────────────────────────────────────
+      server.middlewares.use('/api/webdav-proxy', async (req, res) => {
+        if (req.method === 'OPTIONS') {
+          res.writeHead(204, { 'Access-Control-Max-Age': '86400' });
+          return res.end();
+        }
+
+        const targetUrl = new URL(req.url, 'http://localhost').searchParams.get('url');
+        if (!targetUrl) return sendJson(res, 400, { error: 'Missing url parameter' });
+
+        try { validateProxyUrl(targetUrl); }
+        catch (err) { return sendJson(res, 400, { error: err.message }); }
+
+        const headers = {
+          'Content-Type': req.headers['content-type'] || 'application/octet-stream',
+        };
+        if (req.headers['x-webdav-auth']) headers['Authorization'] = req.headers['x-webdav-auth'];
+        if (req.headers['depth'] !== undefined) headers['Depth'] = req.headers['depth'];
+
+        const body = (req.method !== 'GET' && req.method !== 'HEAD')
+          ? await readBody(req) : undefined;
+
+        try {
+          const response = await fetch(targetUrl, {
+            method: req.method,
+            headers,
+            ...(body ? { body } : {}),
+          });
+          const responseBody = await response.text();
+          res.writeHead(response.status, {
+            'Content-Type': response.headers.get('content-type') || 'text/plain',
+          });
+          res.end(responseBody);
+        } catch {
+          sendJson(res, 502, { error: 'Failed to proxy WebDAV request' });
+        }
+      });
+
+      // ── /api/calendar-proxy/ ────────────────────────────────────────────
+      server.middlewares.use('/api/calendar-proxy', async (req, res) => {
+        const targetUrl = new URL(req.url, 'http://localhost').searchParams.get('url');
+        if (!targetUrl) return sendJson(res, 400, { error: 'Missing url parameter' });
+
+        try { validateProxyUrl(targetUrl); }
+        catch (err) { return sendJson(res, 400, { error: err.message }); }
+
+        const fetchHeaders = { Accept: 'text/calendar, text/plain, */*' };
+        if (req.headers['x-calendar-auth']) fetchHeaders['Authorization'] = req.headers['x-calendar-auth'];
+
+        try {
+          const response = await fetch(targetUrl, { headers: fetchHeaders });
+          const responseBody = await response.text();
+          res.writeHead(response.status, {
+            'Content-Type': response.headers.get('content-type') || 'text/plain',
+            'Cache-Control': 'public, max-age=900, stale-while-revalidate=60',
+          });
+          res.end(responseBody);
+        } catch {
+          sendJson(res, 502, { error: 'Failed to fetch calendar' });
+        }
+      });
+    },
+  };
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   define: {
@@ -15,6 +142,7 @@ export default defineConfig({
     sourcemap: true,
   },
   plugins: [
+    devApiProxy(),
     react(),
     VitePWA({
       strategies: 'injectManifest',


### PR DESCRIPTION
## Summary

- **Zero-knowledge cloud sync encryption**: All sync and remote backup files are encrypted with AES-256-GCM before upload. The server never sees plaintext.
- **PBKDF2-SHA256 key derivation** (310,000 iterations, OWASP recommendation) from a user-supplied passphrase + random 16-byte salt.
- **Encrypted file envelope format**: `{ v: 1, enc: "AES-GCM-256", data: "<base64>" }` where base64 encodes `[16B salt][12B IV][N bytes ciphertext]`.
- **Device key caching**: Derived key is cached in IndexedDB (browser) or Android Keystore Level 1 (hardware-backed, no biometrics) so the passphrase only needs to be entered once per device.
- **Passphrase modal**: Shown on app load when encryption is enabled but no cached key is found (new device, cleared storage). Silently restores key from cache on subsequent loads.
- **Backward compatible**: Existing plaintext sync files continue to work after encryption is enabled — `isEncryptedEnvelope()` check on download handles both formats.
- **Salt-mismatch recovery**: If the cached key's salt doesn't match the file's embedded salt (e.g. after re-configuring encryption), the app re-derives the key from passphrase + file salt and re-caches it. If no passphrase is in memory, the passphrase modal is re-shown.
- **Dev server proxy**: Added Vite plugin to serve `/api/webdav-proxy/` and `/api/calendar-proxy/` locally during `npm run dev`, replicating the production Vercel serverless functions.
- **Koofr compatibility**: Fixed `mkcolWithParents` to treat HTTP 404 the same as 409 (Koofr's non-standard behaviour when a parent directory doesn't exist).
- **Large payload fix**: Chunked `toBase64` to avoid V8 stack overflow on `Uint8Array`s larger than ~65K bytes.
- **Poll timer guard**: 60-second sync poll now checks `syncKeyReadyRef` before firing to prevent download attempts while the passphrase modal is open.

## Files changed

- `src/utils/crypto.js` — new: all Web Crypto API primitives, key derivation, IndexedDB caching
- `src/utils/cloudSyncProviders.js` — encrypt on upload, decrypt on download
- `src/utils/autoBackup.js` — encrypt remote backup uploads, decrypt downloads
- `src/components/CloudSyncSettingsForm.jsx` — encryption toggle, passphrase fields, recovery warning
- `src/components/SyncPassphraseModal.jsx` — new: passphrase prompt on app load
- `src/hooks/useCloudSync.js` — `syncKeyReady` state, `initSessionKey` on mount
- `src/App.jsx` — gate download on `syncKeyReady`, render passphrase modal, poll guard
- `vite.config.js` — dev API proxy plugin
- `dayglance-android/.../CryptoKeyBridge.kt` — new: Android Keystore wrapping
- `dayglance-android/.../NativeBridge.kt` — expose `storeSyncKey`/`getSyncKey` to JS

## Test plan

- [x] Browser A encrypts and uploads to Koofr (WebDAV)
- [x] Browser B (incognito) shows passphrase modal, enters passphrase, decrypts and loads data
- [x] Browser A reload silently restores key from IndexedDB — no passphrase prompt
- [x] Android debug build shows passphrase modal, enters passphrase, decrypts and loads data
- [x] Overnight stability — no spurious errors across browser and Android

https://claude.ai/code/session_01211p6aBHQ6n6ExSX9iQD4k