### PR TITLE
Distinguish completed projects in the Goal widget

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/GoalWidget.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/GoalWidget.kt
@@ -93,7 +93,7 @@ class GoalWidget : AppWidgetProvider() {
             if (goal == null) {
                 showEmpty(views, "Goal not found", "It may have been deleted or completed")
             } else {
-                bindGoalViews(views, goal)
+                bindGoalViews(views, goal, context)
             }
         }
 
@@ -115,7 +115,7 @@ class GoalWidget : AppWidgetProvider() {
         return null
     }
 
-    private fun bindGoalViews(views: RemoteViews, goal: JSONObject) {
+    private fun bindGoalViews(views: RemoteViews, goal: JSONObject, context: Context) {
         views.setViewVisibility(R.id.layout_goal_content, View.VISIBLE)
         views.setViewVisibility(R.id.layout_goal_empty, View.GONE)
 
@@ -156,43 +156,85 @@ class GoalWidget : AppWidgetProvider() {
             if (total > 0) "$pct%  ·  $done/$total" else "$pct%",
         )
 
-        // Project rows
+        // Project rows — active and completed are rendered in separate sections.
         val projects = goal.optJSONArray("projects")
-        val projectCount = projects?.length() ?: 0
+        val allProjects = (0 until (projects?.length() ?: 0)).mapNotNull { projects?.optJSONObject(it) }
+        val activeProjects   = allProjects.filter { it.optString("status") != "completed" }
+        val completedProjects = allProjects.filter { it.optString("status") == "completed" }
 
-        val projectRows = listOf(
+        // Show the top-of-section divider whenever any projects exist.
+        views.setViewVisibility(
+            R.id.tv_goal_projects_divider,
+            if (allProjects.isNotEmpty()) View.VISIBLE else View.GONE,
+        )
+
+        // Rows 1–3: active slots. Rows 4–6: completed slots.
+        // Exception: if ALL projects are completed, fill rows 1–6 (no separator needed).
+        val activeRows = listOf(
             ProjectRow(R.id.row_wp1, R.id.bar_wp1, R.id.tv_wp1_title, R.id.tv_wp1_stats, R.id.pb_wp1),
             ProjectRow(R.id.row_wp2, R.id.bar_wp2, R.id.tv_wp2_title, R.id.tv_wp2_stats, R.id.pb_wp2),
             ProjectRow(R.id.row_wp3, R.id.bar_wp3, R.id.tv_wp3_title, R.id.tv_wp3_stats, R.id.pb_wp3),
+        )
+        val completedRows = listOf(
             ProjectRow(R.id.row_wp4, R.id.bar_wp4, R.id.tv_wp4_title, R.id.tv_wp4_stats, R.id.pb_wp4),
+            ProjectRow(R.id.row_wp5, R.id.bar_wp5, R.id.tv_wp5_title, R.id.tv_wp5_stats, R.id.pb_wp5),
+            ProjectRow(R.id.row_wp6, R.id.bar_wp6, R.id.tv_wp6_title, R.id.tv_wp6_stats, R.id.pb_wp6),
         )
 
-        if (projectCount > 0) {
-            views.setViewVisibility(R.id.tv_goal_projects_divider, View.VISIBLE)
-        } else {
-            views.setViewVisibility(R.id.tv_goal_projects_divider, View.GONE)
+        // Determine slot assignments.
+        val slot1to3: List<Pair<JSONObject, Boolean>>   // (project, isCompleted)
+        val slot4to6: List<Pair<JSONObject, Boolean>>
+        val showSeparator: Boolean
+        val totalOverflow: Int
+
+        when {
+            activeProjects.isEmpty() -> {
+                // All projects are completed — use all 6 slots, no separator.
+                slot1to3 = completedProjects.take(3).map { it to true }
+                slot4to6 = completedProjects.drop(3).take(3).map { it to true }
+                showSeparator = false
+                totalOverflow = maxOf(0, completedProjects.size - 6)
+            }
+            completedProjects.isEmpty() -> {
+                // All projects are active — use slots 1–3 only.
+                slot1to3 = activeProjects.take(3).map { it to false }
+                slot4to6 = emptyList()
+                showSeparator = false
+                totalOverflow = maxOf(0, activeProjects.size - 3)
+            }
+            else -> {
+                // Mixed: active in slots 1–3, completed in slots 4–6, separator between.
+                slot1to3 = activeProjects.take(3).map { it to false }
+                slot4to6 = completedProjects.take(3).map { it to true }
+                showSeparator = true
+                totalOverflow = maxOf(0, activeProjects.size - 3) + maxOf(0, completedProjects.size - 3)
+            }
         }
 
-        for ((idx, row) in projectRows.withIndex()) {
-            val p = projects?.optJSONObject(idx)
-            if (p != null) {
+        views.setViewVisibility(R.id.tv_goal_completed_sep, if (showSeparator) View.VISIBLE else View.GONE)
+
+        for ((idx, row) in activeRows.withIndex()) {
+            val slot = slot1to3.getOrNull(idx)
+            if (slot != null) {
                 views.setViewVisibility(row.rowId, View.VISIBLE)
-                try { views.setInt(row.barId, "setBackgroundColor", Color.parseColor(colorHex)) }
-                catch (_: Throwable) { }
-                views.setTextViewText(row.titleId, p.optString("title", ""))
-                val pTotal = p.optInt("totalTasks", 0)
-                val pDone  = p.optInt("completedTasks", 0)
-                views.setTextViewText(row.statsId, if (pTotal > 0) "$pDone/$pTotal" else "")
-                views.setInt(row.progressId, "setProgress", p.optInt("progressPct", 0))
+                bindProjectRow(views, row, slot.first, colorHex, slot.second, context)
+            } else {
+                views.setViewVisibility(row.rowId, View.GONE)
+            }
+        }
+        for ((idx, row) in completedRows.withIndex()) {
+            val slot = slot4to6.getOrNull(idx)
+            if (slot != null) {
+                views.setViewVisibility(row.rowId, View.VISIBLE)
+                bindProjectRow(views, row, slot.first, colorHex, slot.second, context)
             } else {
                 views.setViewVisibility(row.rowId, View.GONE)
             }
         }
 
         // Overflow
-        val overflow = projectCount - projectRows.size
-        if (overflow > 0) {
-            views.setTextViewText(R.id.tv_goal_widget_more, "+$overflow more project${if (overflow != 1) "s" else ""}")
+        if (totalOverflow > 0) {
+            views.setTextViewText(R.id.tv_goal_widget_more, "+$totalOverflow more project${if (totalOverflow != 1) "s" else ""}")
             views.setViewVisibility(R.id.tv_goal_widget_more, View.VISIBLE)
         } else {
             views.setViewVisibility(R.id.tv_goal_widget_more, View.GONE)
@@ -205,6 +247,36 @@ class GoalWidget : AppWidgetProvider() {
         val rowId: Int, val barId: Int, val titleId: Int,
         val statsId: Int, val progressId: Int,
     )
+
+    private fun bindProjectRow(
+        views: RemoteViews,
+        row: ProjectRow,
+        p: JSONObject,
+        goalColorHex: String,
+        isCompleted: Boolean,
+        context: Context,
+    ) {
+        val barColor = if (isCompleted) 0xFF22C55E.toInt() else
+            try { Color.parseColor(goalColorHex) } catch (_: Throwable) { 0xFF3B82F6.toInt() }
+        try { views.setInt(row.barId, "setBackgroundColor", barColor) } catch (_: Throwable) { }
+
+        views.setTextViewText(row.titleId, p.optString("title", ""))
+
+        if (isCompleted) {
+            // Hide progress bar; show a green "✓ Done" badge.
+            views.setViewVisibility(row.progressId, View.GONE)
+            views.setTextViewText(row.statsId, "✓ Done")
+            views.setTextColor(row.statsId, 0xFF22C55E.toInt())
+        } else {
+            // Active project — blue progress bar, secondary-coloured task count.
+            views.setViewVisibility(row.progressId, View.VISIBLE)
+            val pTotal = p.optInt("totalTasks", 0)
+            val pDone  = p.optInt("completedTasks", 0)
+            views.setTextViewText(row.statsId, if (pTotal > 0) "$pDone/$pTotal" else "")
+            views.setTextColor(row.statsId, context.getColor(R.color.widget_text_secondary))
+            views.setInt(row.progressId, "setProgress", p.optInt("progressPct", 0))
+        }
+    }
 
     /**
      * Shows exactly one of the three threshold ProgressBars based on [pct].

--- a/dayglance-android/app/src/main/res/layout/widget_goal.xml
+++ b/dayglance-android/app/src/main/res/layout/widget_goal.xml
@@ -371,7 +371,18 @@
 
             </LinearLayout>
 
-            <!-- Project row 4 -->
+            <!-- Completed-projects separator — shown only when both active and completed exist -->
+            <TextView
+                android:id="@+id/tv_goal_completed_sep"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/widget_divider"
+                android:layout_marginTop="3dp"
+                android:layout_marginBottom="2dp"
+                android:text=""
+                android:visibility="gone" />
+
+            <!-- Project row 4 (completed slot 1) -->
             <LinearLayout
                 android:id="@+id/row_wp4"
                 android:layout_width="match_parent"
@@ -423,7 +434,111 @@
 
             </LinearLayout>
 
-            <!-- Overflow: "+N more projects" when more than 4 exist -->
+            <!-- Project row 5 (completed slot 2) -->
+            <LinearLayout
+                android:id="@+id/row_wp5"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingTop="3dp"
+                android:paddingBottom="3dp"
+                android:visibility="gone">
+
+                <TextView
+                    android:id="@+id/bar_wp5"
+                    android:layout_width="3dp"
+                    android:layout_height="20dp"
+                    android:layout_marginEnd="7dp"
+                    android:background="#3b82f6"
+                    android:text="" />
+
+                <TextView
+                    android:id="@+id/tv_wp5_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text=""
+                    android:textColor="@color/widget_text_primary"
+                    android:textSize="12sp"
+                    android:maxLines="1"
+                    android:ellipsize="end" />
+
+                <TextView
+                    android:id="@+id/tv_wp5_stats"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:text=""
+                    android:textColor="@color/widget_text_secondary"
+                    android:textSize="11sp" />
+
+                <ProgressBar
+                    android:id="@+id/pb_wp5"
+                    style="@android:style/Widget.ProgressBar.Horizontal"
+                    android:layout_width="48dp"
+                    android:layout_height="4dp"
+                    android:layout_marginStart="6dp"
+                    android:max="100"
+                    android:progress="0"
+                    android:progressTint="@color/widget_brand"
+                    android:progressBackgroundTint="@color/widget_ring_track" />
+
+            </LinearLayout>
+
+            <!-- Project row 6 (completed slot 3) -->
+            <LinearLayout
+                android:id="@+id/row_wp6"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingTop="3dp"
+                android:paddingBottom="3dp"
+                android:visibility="gone">
+
+                <TextView
+                    android:id="@+id/bar_wp6"
+                    android:layout_width="3dp"
+                    android:layout_height="20dp"
+                    android:layout_marginEnd="7dp"
+                    android:background="#3b82f6"
+                    android:text="" />
+
+                <TextView
+                    android:id="@+id/tv_wp6_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text=""
+                    android:textColor="@color/widget_text_primary"
+                    android:textSize="12sp"
+                    android:maxLines="1"
+                    android:ellipsize="end" />
+
+                <TextView
+                    android:id="@+id/tv_wp6_stats"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:text=""
+                    android:textColor="@color/widget_text_secondary"
+                    android:textSize="11sp" />
+
+                <ProgressBar
+                    android:id="@+id/pb_wp6"
+                    style="@android:style/Widget.ProgressBar.Horizontal"
+                    android:layout_width="48dp"
+                    android:layout_height="4dp"
+                    android:layout_marginStart="6dp"
+                    android:max="100"
+                    android:progress="0"
+                    android:progressTint="@color/widget_brand"
+                    android:progressBackgroundTint="@color/widget_ring_track" />
+
+            </LinearLayout>
+
+            <!-- Overflow: "+N more projects" when more than 6 exist -->
             <TextView
                 android:id="@+id/tv_goal_widget_more"
                 android:layout_width="match_parent"


### PR DESCRIPTION
## Summary

- Active and completed projects are now rendered in distinct sections rather than mixed together with identical styling.
- A thin hairline divider separates the two groups (only shown when both exist).
- Completed projects show a green left bar and a green "✓ Done" badge in place of the blue progress bar.

## Layout changes (`widget_goal.xml`)

Added a `tv_goal_completed_sep` hairline divider between the active and completed sections, plus two new project rows (`row_wp5`, `row_wp6`) bringing the total visible project slots from 4 to 6 (3 active + 3 completed).

## Logic changes (`GoalWidget.kt`)

Projects from the snapshot are split on `status == "completed"`. Three rendering modes:

| Situation | Slots 1–3 | Separator | Slots 4–6 |
|---|---|---|---|
| Only active projects | Active (blue bar) | Hidden | Hidden |
| Only completed projects | Completed (green ✓) | Hidden | Completed (green ✓) |
| Mixed | Active (blue bar) | Visible | Completed (green ✓) |

The overflow "+N more projects" label counts the combined hidden rows from both sections.

## Test plan

- [x] Goal with only active projects → slots 1–3, blue bars, no separator
- [x] Goal with only completed projects → up to 6 green ✓ rows, no separator
- [x] Goal with mixed → active at top, hairline, completed at bottom in green
- [x] More than 3 active → overflow label counts correctly
- [x] More than 3 completed → overflow label counts correctly
- [x] Verify dark mode colours (green ✓ Done, secondary text reset)

https://claude.ai/code/session_01SiNcbZtqj3J9ifpSiv8Nfa