### PR TITLE
Fix blank screen on normal refresh (CMD-R)

### DIFF
--- a/public/registerSW.js
+++ b/public/registerSW.js
@@ -1,0 +1,10 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js', { scope: '/' });
+    // When a new SW takes control (skipWaiting + clients.claim), reload so the
+    // page loads fresh assets from the new precache instead of running stale JS.
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      window.location.reload();
+    });
+  });
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -151,7 +151,7 @@ export default defineConfig({
       registerType: 'autoUpdate',
       injectManifest: {
         globPatterns: ['**/*.{js,css,html,png,ico,svg}'],
-        globIgnores: ['**/dayglance-dark.svg', '**/dayglance-light.svg'],
+        globIgnores: ['**/dayglance-dark.svg', '**/dayglance-light.svg', '**/service-worker.js'],
       },
       manifest: {
         name: 'dayGLANCE',


### PR DESCRIPTION
vite-plugin-pwa generates a bare registerSW.js when no virtual:pwa-register import exists — it registers the SW but never reloads the page when a new SW takes control via skipWaiting + clients.claim. This left a window where old JS ran under a new SW whose precache had already dropped the old asset hashes, causing CMD-R to blank out while SHIFT-CMD-R (which bypasses the SW) worked.

Fix: provide a custom public/registerSW.js that adds a controllerchange listener so the page reloads automatically whenever a new SW takes over. The plugin skips generating its own copy when the file already exists in public/.

Also exclude service-worker.js (dead self-unregistering SW) from the Workbox precache glob — there's no value caching a file whose only job is to unregister itself, and its no-cache nginx headers signal it was never meant to be cached.

https://claude.ai/code/session_01GGuxCMcsx2k6gVFWhJZuwY