### PR TITLE
Fix Greek (non-Latin) tags and routine delete on narrow tablets

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4661,7 +4661,7 @@ const DayPlanner = () => {
             const setter = isInbox ? setUnscheduledTasks : setTasks;
             setter(prev => prev.map(t => {
               if (t.id !== id) return t;
-              const existing = (t.title.match(/#(\w+)/g) || []).map(s => s.slice(1).toLowerCase());
+              const existing = (t.title.match(/#(\p{L}[\p{L}\p{N}_]*)/gu) || []).map(s => s.slice(1).toLowerCase());
               if (existing.includes(edit.tag.toLowerCase())) return t;
               return { ...t, title: t.title + ` #${edit.tag}` };
             }));

--- a/src/components/MobileRoutinesTab.jsx
+++ b/src/components/MobileRoutinesTab.jsx
@@ -4,7 +4,7 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
 const MobileRoutinesTab = () => {
-  const { isPhone, isTablet, darkMode, textSecondary, hoverBg, colors, formatTime, getDayName } = useDayPlannerCtx();
+  const { isPhone, isMobile, isTablet, darkMode, textSecondary, hoverBg, colors, formatTime, getDayName } = useDayPlannerCtx();
   const {
     routineDefinitions,
     dashboardSelectedChips, setDashboardSelectedChips,
@@ -42,7 +42,7 @@ const MobileRoutinesTab = () => {
                   key={chip.id}
                   className={`group relative rounded-full px-3 py-1.5 text-xs font-medium cursor-pointer ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'}`}
                   onClick={() => {
-                    if (isPhone || isTablet) {
+                    if (isMobile || isTablet) {
                       if (isFocused) {
                         setRoutineTimePickerChipId(chip.id);
                         setRoutineFocusedChipId(null);
@@ -76,7 +76,7 @@ const MobileRoutinesTab = () => {
                   <button
                     onClick={(e) => { e.stopPropagation(); setDashboardSelectedChips(prev => prev.filter(c => c.id !== chip.id)); setRoutineFocusedChipId(null); }}
                     className={`absolute -top-1.5 -right-1.5 transition-opacity ${darkMode ? 'bg-gray-500 text-white' : 'bg-stone-400 text-white'} rounded-full w-4 h-4 flex items-center justify-center ${
-                      (isPhone || isTablet) ? (isFocused ? 'opacity-100' : 'opacity-0 pointer-events-none') : 'opacity-0 group-hover:opacity-100'
+                      (isMobile || isTablet) ? (isFocused ? 'opacity-100' : 'opacity-0 pointer-events-none') : 'opacity-0 group-hover:opacity-100'
                     }`}
                   >
                     <Undo2 size={10} />
@@ -141,7 +141,7 @@ const MobileRoutinesTab = () => {
                     <div
                       key={chip.id}
                       onClick={() => {
-                        if (isPhone || isTablet) {
+                        if (isMobile || isTablet) {
                           if (isFocused) {
                             toggleRoutineChipSelection(chip, bucket);
                             setRoutineFocusedChipId(null);
@@ -162,7 +162,7 @@ const MobileRoutinesTab = () => {
                       <button
                         onClick={(e) => { e.stopPropagation(); setRoutineDeleteConfirm({ bucket, chipId: chip.id, chipName: chip.name }); setRoutineFocusedChipId(null); }}
                         className={`absolute -top-1.5 -right-1.5 transition-opacity bg-red-500 text-white rounded-full w-4 h-4 flex items-center justify-center ${
-                          (isPhone || isTablet) ? (isFocused ? 'opacity-100' : 'opacity-0 pointer-events-none') : 'opacity-0 group-hover:opacity-100'
+                          (isMobile || isTablet) ? (isFocused ? 'opacity-100' : 'opacity-0 pointer-events-none') : 'opacity-0 group-hover:opacity-100'
                         }`}
                       >
                         <X size={10} />

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -253,7 +253,7 @@ const WeeklyReviewModal = () => {
         // Tag breakdown for AI summary
         const tagStats = {};
         pastRegular.forEach(t => {
-          const taskTags = (t.title.match(/#(\w+)/g) || []).map(tag => tag.slice(1));
+          const taskTags = (t.title.match(/#(\p{L}[\p{L}\p{N}_]*)/gu) || []).map(tag => tag.slice(1));
           taskTags.forEach(tag => {
             if (!tagStats[tag]) tagStats[tag] = { total: 0, completed: 0 };
             tagStats[tag].total++;

--- a/src/utils/taskUtils.js
+++ b/src/utils/taskUtils.js
@@ -15,7 +15,7 @@ export const localDateStr = (d = new Date()) => dateToString(d);
 
 // Extract #hashtags from a task title (tags must start with a letter).
 export const extractTags = (title) => {
-  const matches = title.match(/#([a-zA-Z]\w*)/g);
+  const matches = title.match(/#(\p{L}[\p{L}\p{N}_]*)/gu);
   return matches ? matches.map(tag => tag.slice(1).toLowerCase()) : [];
 };
 

--- a/src/utils/textFormatting.jsx
+++ b/src/utils/textFormatting.jsx
@@ -195,9 +195,9 @@ export const isObsidianNoteOnlyTask = (task) => {
 // Strip wikilinks from displayed text; style hashtags
 export const renderTitle = (title) => {
   const stripped = title.replace(/\[\[[^\]]+\]\]/g, '');
-  const parts = stripped.split(/(#[a-zA-Z]\w*)/g);
+  const parts = stripped.split(/(#\p{L}[\p{L}\p{N}_]*)/gu);
   return parts.map((part, i) => {
-    if (part.match(/^#[a-zA-Z]\w*$/)) {
+    if (part.match(/^#\p{L}[\p{L}\p{N}_]*$/u)) {
       return <span key={i} className="text-xs italic opacity-75">{part}</span>;
     }
     return part;
@@ -228,5 +228,5 @@ export const highlightMatch = (text, query) => {
 
 // Remove wikilinks AND hashtags (used for AI context only)
 export const renderTitleWithoutTags = (title) => {
-  return title.replace(/\[\[[^\]]+\]\]/g, '').replace(/#[a-zA-Z]\w*/g, '').replace(/\s+/g, ' ').trim();
+  return title.replace(/\[\[[^\]]+\]\]/g, '').replace(/#\p{L}[\p{L}\p{N}_]*/gu, '').replace(/\s+/g, ' ').trim();
 };


### PR DESCRIPTION
Tags: [a-zA-Z] and \w only match Latin characters, so Greek hashtags like #αθήνα were never recognised. Replaced all tag regexes with Unicode property escapes (\p{L} for letter start, [\p{L}\p{N}_]* for rest) and the u flag across extractTags, renderTitle, renderTitleWithoutTags, voice addTag, and WeeklyReview tag stats.

Routine delete: the two-tap focus mechanism (tap to reveal X, tap X to delete) requires isPhone||isTablet. An 8.4" budget tablet in portrait sits at ~640px CSS width — isPhone=false (shortSide≥600) and isTablet=false (w<721) — so the X was rendered opacity-0 with only group-hover, which never fires on touch. Landscape works because w flips above 721, making isTablet=true. Fix: use isMobile||isTablet; isMobile is true whenever w<721, covering the portrait case.

https://claude.ai/code/session_01GGuxCMcsx2k6gVFWhJZuwY