### PR TITLE
Fix Android wikilink loading (#heading, hidden dirs, not-found UX)

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
@@ -57,6 +57,7 @@ class ObsidianRepository(private val context: Context) {
     private fun indexDirectory(dir: DocumentFile, index: ConcurrentHashMap<String, Uri>) {
         for (file in dir.listFiles()) {
             val name = file.name ?: continue
+            if (name.startsWith('.')) continue // skip hidden files/dirs (.obsidian/, .trash/, etc.)
             if (file.isFile && name.endsWith(".md")) {
                 index[name.removeSuffix(".md").lowercase()] = file.uri
             } else if (file.isDirectory) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1828,11 +1828,13 @@ const DayPlanner = () => {
   const loadWikiNote = useCallback(async (noteName) => {
     const handle = obsidianVaultHandleRef.current;
     if (!handle) return null;
+    // Strip [[Note#Heading]] fragment — we load the whole note file, not just a section
+    const notePath = noteName.split('#')[0].trim();
     if (handle === 'native') {
-      return nativeGetNote(noteName);
+      return nativeGetNote(notePath);
     }
     try {
-      return await readWikiNote(handle, noteName);
+      return await readWikiNote(handle, notePath);
     } catch (err) {
       console.error('Failed to read wiki note:', err);
       return null;
@@ -1842,12 +1844,14 @@ const DayPlanner = () => {
   const saveWikiNote = useCallback(async (noteName, content) => {
     const handle = obsidianVaultHandleRef.current;
     if (!handle) return;
+    // Strip [[Note#Heading]] fragment for write path too
+    const notePath = noteName.split('#')[0].trim();
     if (handle === 'native') {
-      nativeWriteNote(noteName, content);
+      nativeWriteNote(notePath, content);
       return;
     }
     try {
-      await writeWikiNote(handle, noteName, content, obsidianConfig?.newNotesFolder || '');
+      await writeWikiNote(handle, notePath, content, obsidianConfig?.newNotesFolder || '');
     } catch (err) {
       console.error('Failed to write wiki note:', err);
     }

--- a/src/components/NotesSubtasksPanel.jsx
+++ b/src/components/NotesSubtasksPanel.jsx
@@ -88,6 +88,12 @@ const NotesSubtasksPanel = ({
     if (linkedNoteStates[noteName]) return; // already loaded or loading
     setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text: '', lastModified: null, loading: true, error: null } }));
     onLoadWikiNote?.(noteName).then(result => {
+      if (result === null) {
+        // Note not found in vault (or vault not configured) — show a clear message rather
+        // than an empty "create new note" textarea that would silently fail to save.
+        setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text: '', lastModified: null, loading: false, error: 'not_found' } }));
+        return;
+      }
       const text = result?.text ?? '';
       setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text, lastModified: result?.lastModified ?? null, loading: false, error: null } }));
       setLinkedNoteEditing(prev => ({ ...prev, [noteName]: !text }));
@@ -243,7 +249,11 @@ const NotesSubtasksPanel = ({
                     Loading…
                   </div>
                 ) : state.error ? (
-                  <div className={`text-xs opacity-60 italic ${noteMinH}`}>Could not load note: {state.error}</div>
+                  <div className={`text-xs opacity-60 italic ${noteMinH}`}>
+                    {state.error === 'not_found'
+                      ? 'Note not found in vault — check that your vault is configured and the note exists.'
+                      : `Could not load note: ${state.error}`}
+                  </div>
                 ) : isEditingWiki ? (
                   <textarea
                     value={state.text}


### PR DESCRIPTION
## Summary

Three bugs in the Obsidian wikilink note-loading path that cause wikilinks to show as empty on Android (and silently fail on PWA for heading-linked notes).

### Bug 1 — `#heading` fragments in wikilinks (both platforms)

`[[My Note#Section]]` passed `"My Note#Section"` to `getNote`/`readWikiNote`, which then searched for `My Note#Section.md`. That file doesn't exist — the vault file is `My Note.md`. Fix: strip the `#fragment` from the note path in `loadWikiNote` and `saveWikiNote` before handing off to either the native bridge or the File System Access API.

### Bug 2 — Hidden directory scan during vault index build (Android)

`ObsidianRepository.indexDirectory` recursed into `.obsidian/`, `.trash/`, and other hidden folders on every `buildNoteIndex()` call. These directories can be large (plugins, themes, config JSON) and contain no `.md` notes worth indexing. The browser-side `findFileHandleInDir` already skipped hidden dirs with `!name.startsWith('.')` — this aligns the Kotlin side. Reduces vault scan time, which matters because the first `bridge.getNote()` call from JS blocks the JS thread while the scan runs.

### Bug 3 — Misleading empty textarea when note not found (Android / unconfigured)

When `loadWikiNote` returned `null` (vault not configured, or note genuinely absent from vault), `NotesSubtasksPanel` showed an empty "start typing to create it in your vault" textarea. On Android this is actively misleading — the note may just not be in the vault, or the vault may not be set up at all, and any text typed in the textarea would silently fail to save. Now shows a clear **"Note not found in vault — check that your vault is configured and the note exists."** message instead.

## Test plan
- [x] Task with `[[Note Name]]` wikilink → opens correctly on both PWA and Android
- [x] Task with `[[Note Name#Section]]` wikilink → loads `Note Name.md` (not a missing `Note Name#Section.md`)
- [x] Task with wikilink pointing to a note that doesn't exist → shows "Note not found in vault" message, not empty textarea
- [x] Vault not configured on Android → same "Note not found" message, not empty textarea

https://claude.ai/code/session_01GGuxCMcsx2k6gVFWhJZuwY