### PR TITLE
v2.4.7 — Routine completion bug fixes + sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Your day, at a glance.** A privacy-first day planner with visual time-blocking, deep integrations, and zero lock-in. Use it free at [dayglance.app](https://dayglance.app) or self-host it on your own server. Your data stays on your device — nothing is ever sent to a server unless you choose to sync it yourself.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.4.6-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-2.4.7-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases) · [**Android APK**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 38
+        versionCode = 39
         versionName = "2.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "2.4.6",
+      "version": "2.4.7",
       "dependencies": {
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "2.4.6",
+  "version": "2.4.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1113,7 +1113,7 @@ const DayPlanner = () => {
       cloudSyncUpload();
     }, 5000);
     return () => { if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current); };
-  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled]);
+  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled]);
 
   // Cloud sync: download on app load or when sync is first enabled.
   // If encryption is enabled, wait until the session key is ready (either
@@ -4142,6 +4142,7 @@ const DayPlanner = () => {
         routineDefinitions,
         todayRoutines: stampTaskTimestamps(todayRoutines, 'day-planner-today-routines'),
         routinesDate,
+        routineCompletions,
         minimizedSections,
         use24HourClock,
         weatherZip,
@@ -4269,6 +4270,7 @@ const DayPlanner = () => {
     if (data.routinesDate === todayStr) {
       if (data.todayRoutines) localStorage.setItem('day-planner-today-routines', JSON.stringify(data.todayRoutines));
       localStorage.setItem('day-planner-routines-date', data.routinesDate);
+      if (data.routineCompletions) localStorage.setItem('day-planner-routine-completions', JSON.stringify(data.routineCompletions));
     }
     // selectedTags and minimizedSections are per-device UI preferences — not synced to state
     if (data.minimizedSections) localStorage.setItem('minimizedSections', JSON.stringify(data.minimizedSections));
@@ -4370,6 +4372,7 @@ const DayPlanner = () => {
     if (data.routineDefinitions) setRoutineDefinitions(data.routineDefinitions);
     if (data.todayRoutines) setTodayRoutines(data.todayRoutines);
     if (data.routinesDate !== undefined) setRoutinesDate(data.routinesDate);
+    if (data.routineCompletions && data.routinesDate === dateToString(new Date())) setRoutineCompletions(data.routineCompletions);
     if (data.use24HourClock !== undefined) setUse24HourClock(data.use24HourClock);
     if (data.weatherZip !== undefined) setWeatherZip(data.weatherZip);
     if (data.weatherTempUnit !== undefined) setWeatherTempUnit(data.weatherTempUnit);

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -82,7 +82,7 @@ const MobileGlanceSection = () => {
     eveningGlanceText, eveningGlanceLoading, eveningGlanceDismissed, eveningGlanceError,
     frameNudgeSuggestion, frameNudgeLoading, frameNudgeError,
     frameNudgeDismissedKey, setFrameNudgeDismissedKey,
-    routinesEnabled, todayRoutines,
+    routinesEnabled, todayRoutines, routineCompletions,
     habitsEnabled,
     activeHabits, habitStreaks,
     habitLongPressId, setHabitLongPressId,
@@ -1004,11 +1004,9 @@ const MobileGlanceSection = () => {
   })()}
   {/* Routines row */}
   {routinesEnabled && todayRoutines.length > 0 && (() => {
-    const nowMin = currentTime.getHours() * 60 + currentTime.getMinutes();
     const visibleRoutines = todayRoutines.filter(r => {
       if (String(r.id).startsWith('example-')) return false;
-      if (!r.startTime || r.isAllDay) return true;
-      return (timeToMinutes(r.startTime) + r.duration + 60) > nowMin;
+      return !routineCompletions[r.id];
     });
     if (visibleRoutines.length === 0) return null;
     return (


### PR DESCRIPTION
## Summary

Bug-fix follow-up to #433.

- **Mobile/Android glance fix**: `MobileGlanceSection.jsx` had its own copy of the time-based routine filter that wasn't updated in #433. Android and mobile use `MobileGlanceSection` for the glance view, so the completion toggle had no visible effect there. Fixed to use `routineCompletions` check, matching `GlanceSidebar`.
- **Routine completions synced**: `routineCompletions` is now included in the cloud sync payload so marking a routine done on one device propagates to others within the usual 5-second debounce. Applied under the same today-only guard as `todayRoutines` so stale completions from a previous day on another device are never applied.
- **Version bump**: web `2.4.6` → `2.4.7`, Android `versionCode` 38 → 39

## Test plan

- [x] Android/mobile: tap a routine pill → disappears from glance panel immediately
- [x] Tap again → reappears in glance panel
- [x] Mark a routine done on one device → syncs to another device within ~5 seconds
- [x] Completion state does not carry over to the next day
- [x] Desktop glance (GlanceSidebar) unaffected

https://claude.ai/code/session_01BTjPRLnry88Eh2cFD5H9yH