### PR TITLE
feat: hyperGLANCE — scheduled project sessions on the timeline

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -101,6 +101,7 @@ import DesktopLayout from './components/DesktopLayout.jsx';
 import MobileLayout from './components/MobileLayout.jsx';
 import ShortcutHelpModal from './components/ShortcutHelpModal.jsx';
 import FocusModeModal from './components/FocusModeModal.jsx';
+import HyperGlanceModeModal from './components/HyperGlanceModeModal.jsx';
 import RoutinesDashboardModal from './components/RoutinesDashboardModal.jsx';
 import FrameAdjustModal from './components/FrameAdjustModal.jsx';
 import FrameScheduleModal from './components/FrameScheduleModal.jsx';
@@ -563,6 +564,21 @@ const DayPlanner = () => {
     exitFocusModeRef,
     focusModeAvailableRef,
   } = useFocusMode();
+
+  // ── HyperGLANCE state ────────────────────────────────────────────────────
+  const [showHyperGlanceMode, setShowHyperGlanceMode] = React.useState(false);
+  const [hyperGlanceProjectId, setHyperGlanceProjectId] = React.useState(null);
+  const [hyperGlanceSessionDate, setHyperGlanceSessionDate] = React.useState(null);
+  const [hgTimerSeconds, setHgTimerSeconds] = React.useState(0);
+  const [hgTimerRunning, setHgTimerRunning] = React.useState(false);
+  const [hgTimerPhase, setHgTimerPhase] = React.useState('work'); // 'work' | 'break'
+  const [hgWorkMinutes, setHgWorkMinutes] = React.useState(25);
+  const [hgBreakMinutes, setHgBreakMinutes] = React.useState(5);
+  const [hgCycleCount, setHgCycleCount] = React.useState(0);
+  const [hgExitConfirm, setHgExitConfirm] = React.useState(false);
+  const [hgShowSettings, setHgShowSettings] = React.useState(true);
+  const hgTimerRef = React.useRef(null);
+
   const {
     trmnlConfig, setTrmnlConfig,
     trmnlSyncStatus, setTrmnlSyncStatus,
@@ -2948,6 +2964,71 @@ const DayPlanner = () => {
     setFocusTimerRunning(true);
   };
   handleFocusTimerEndRef.current = handleFocusTimerEnd;
+
+  // ── HyperGLANCE functions ──────────────────────────────────────────────────
+  const instantiateHGTemplateTasks = (project, sessionDate) => {
+    const templates = project.hyperglance?.templateTasks || [];
+    if (templates.length === 0) return;
+    // Avoid duplicate instantiation for the same session date
+    const alreadyInstantiated = unscheduledTasks.some(
+      t => t.projectId === project.id && t.hyperglanceSessionDate === sessionDate
+    );
+    if (alreadyInstantiated) return;
+    const newTasks = templates.map(tmpl => ({
+      id: `hg-${project.id}-${sessionDate}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      title: tmpl.title,
+      projectId: project.id,
+      hyperglanceSessionDate: sessionDate,
+      completed: false,
+      createdAt: new Date().toISOString(),
+    }));
+    setUnscheduledTasks(prev => [...prev, ...newTasks]);
+  };
+
+  const enterHyperGlanceMode = (projectId, date) => {
+    const project = projects.find(p => p.id === projectId);
+    if (!project) return;
+    instantiateHGTemplateTasks(project, date);
+    setHyperGlanceProjectId(projectId);
+    setHyperGlanceSessionDate(date);
+    setHgTimerSeconds(0);
+    setHgTimerRunning(false);
+    setHgTimerPhase('work');
+    setHgCycleCount(0);
+    setHgExitConfirm(false);
+    setHgShowSettings(true);
+    setShowHyperGlanceMode(true);
+  };
+
+  const exitHyperGlanceMode = () => {
+    // Pause: close the modal but leave the session open (bar stays on timeline)
+    setHgTimerRunning(false);
+    setHgExitConfirm(false);
+    setShowHyperGlanceMode(false);
+  };
+
+  const completeHyperGlanceSession = () => {
+    if (!hyperGlanceProjectId || !hyperGlanceSessionDate) return;
+    setProjects(prev => prev.map(p => {
+      if (p.id !== hyperGlanceProjectId) return p;
+      const hg = p.hyperglance || {};
+      const completions = hg.completions || [];
+      if (completions.some(c => c.date === hyperGlanceSessionDate)) return p;
+      return {
+        ...p,
+        hyperglance: {
+          ...hg,
+          completions: [
+            ...completions,
+            { date: hyperGlanceSessionDate, completedAt: new Date().toISOString() },
+          ],
+        },
+      };
+    }));
+    setHgTimerRunning(false);
+    setHgExitConfirm(false);
+    setShowHyperGlanceMode(false);
+  };
 
   const parseICS = (icsContent) => {
     // Unfold iCal line continuations (RFC 5545: lines starting with space/tab are continuations)
@@ -7095,6 +7176,20 @@ const DayPlanner = () => {
     focusDeleteSubtask, focusUpdateSubtaskTitle, focusUpdateTaskNotes,
     computeFocusBlockTasks,
 
+    // ── HyperGLANCE ───────────────────────────────────────────────────────────
+    showHyperGlanceMode, setShowHyperGlanceMode,
+    hyperGlanceProjectId, setHyperGlanceProjectId,
+    hyperGlanceSessionDate, setHyperGlanceSessionDate,
+    hgTimerSeconds, setHgTimerSeconds,
+    hgTimerRunning, setHgTimerRunning,
+    hgTimerPhase, setHgTimerPhase,
+    hgWorkMinutes, setHgWorkMinutes,
+    hgBreakMinutes, setHgBreakMinutes,
+    hgCycleCount, setHgCycleCount,
+    hgExitConfirm, setHgExitConfirm,
+    hgShowSettings, setHgShowSettings,
+    enterHyperGlanceMode, exitHyperGlanceMode, completeHyperGlanceSession,
+
     // ── Functions – GTD / AI ──────────────────────────────────────────────────
     saveFrame, deleteFrame, skipFrameForDay,
     openFrameAdjust, openFrameSchedule, saveFrameAdjust,
@@ -8118,6 +8213,9 @@ const DayPlanner = () => {
 
       {/* Focus Mode Overlay */}
       {showFocusMode && <FocusModeModal />}
+
+      {/* HyperGLANCE Overlay */}
+      {showHyperGlanceMode && <HyperGlanceModeModal />}
 
       {/* Spotlight Search */}
       {showSpotlight && <SpotlightModal />}

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -4,7 +4,7 @@ import {
   Calendar, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronUp, Clock, Filter, Flag, Hash, Inbox, LayoutGrid, Loader,
   Mic, Minus, Moon, Plus, RefreshCw, Search,
-  Sparkles, Sun, Target, Trash2, X,
+  Sparkles, Sun, Target, Trash2, X, Zap,
 } from 'lucide-react';
 import { renderTitle } from '../utils/textFormatting.jsx';
 import { dateToString, extractTags, extractWikilinks, formatDeadlineDate } from '../utils/taskUtils.js';
@@ -15,6 +15,7 @@ import GettingStartedChecklist from './GettingStartedChecklist.jsx';
 import FrameNudgeCard from './FrameNudgeCard.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { getOverdueHGInstances } from '../hooks/useHyperGlance.js';
 
 const GlanceSidebar = ({ variant = 'desktop' }) => {
   const {
@@ -91,6 +92,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     generateFrameNudge, generateMorningSummary, generateEveningReflection,
     dismissMorningGlance, dismissEveningGlance,
     openRoutinesDashboard,
+    enterHyperGlanceMode,
     getFrameInstancesForDate,
     computeAvailableSlots,
     showVoiceInput, setShowVoiceInput,
@@ -1098,6 +1100,30 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
               </span>
             );
           })}
+        </div>
+      </div>
+    );
+  })()}
+
+  {/* Overdue HyperGLANCE projects */}
+  {goalsProjectsEnabled && (() => {
+    const overdue = getOverdueHGInstances(projects);
+    if (overdue.length === 0) return null;
+    return (
+      <div className={isDesktop ? `rounded-lg border ${borderClass} p-3` : `mt-3 pt-3 border-t ${borderClass}`}>
+        <div className="text-xs font-semibold uppercase tracking-wide mb-2 text-orange-500">Overdue Projects</div>
+        <div className="space-y-1.5">
+          {overdue.map(({ project, instance }) => (
+            <button
+              key={project.id}
+              onClick={() => enterHyperGlanceMode(project.id, instance.date)}
+              className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-left transition-opacity ${isDesktop ? 'hover:opacity-80' : 'active:opacity-70'} ${darkMode ? 'bg-orange-900/20' : 'bg-orange-50'}`}
+            >
+              <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: project.hyperglance?.color || '#e11d48' }}></div>
+              <span className={`text-sm font-medium flex-1 min-w-0 truncate ${darkMode ? 'text-orange-200' : 'text-orange-800'}`}>{project.title}</span>
+              <Zap size={12} className="text-orange-500 flex-shrink-0" />
+            </button>
+          ))}
         </div>
       </div>
     );

--- a/src/components/HyperGlanceBar.jsx
+++ b/src/components/HyperGlanceBar.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import * as Icons from 'lucide-react';
+import { Zap } from 'lucide-react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { isHGSessionReachable } from '../hooks/useHyperGlance.js';
+
+/**
+ * Renders a single hyperGLANCE project bar inside the left half of a
+ * timeline day column. When the session is completed it shrinks to a pill.
+ */
+const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
+  const { minutesToPosition, timeToMinutes, currentTime, darkMode, formatTime, use24HourClock } = useDayPlannerCtx();
+  const { enterHyperGlanceMode } = useFeaturesCtx();
+
+  const hg = project.hyperglance;
+  const [startH, startM] = (hg.scheduledTime || '0:0').split(':').map(Number);
+  const startMinutes = startH * 60 + startM;
+  const durationMin = hg.scheduledDuration || 60;
+  const endMinutes = startMinutes + durationMin;
+
+  const top = Math.round(minutesToPosition(startMinutes));
+  const bottom = Math.round(minutesToPosition(endMinutes));
+  const height = Math.max(bottom - top - 1, isCompleted ? 18 : 24);
+
+  const barColor = hg.color || '#4f46e5';
+  const IconComp = Icons[hg.icon] || Icons.Sparkles;
+  const instance = isCompleted ? null : { date, isOverdue };
+  const canEnter = !isCompleted && isHGSessionReachable({ date, isOverdue: false }, hg, currentTime);
+
+  // Format start time label
+  const timeLabel = (() => {
+    if (!hg.scheduledTime) return '';
+    if (use24HourClock) return hg.scheduledTime;
+    const hour12 = startH === 0 ? 12 : startH > 12 ? startH - 12 : startH;
+    const ampm = startH < 12 ? 'a' : 'p';
+    return startM === 0 ? `${hour12}${ampm}` : `${hour12}:${String(startM).padStart(2, '0')}${ampm}`;
+  })();
+
+  if (isCompleted) {
+    // Render as a small completion pill
+    return (
+      <div
+        className="absolute pointer-events-none"
+        style={{ top: `${top}px`, left: 2, right: 2, height: `${height}px`, zIndex: 6 }}
+      >
+        <div
+          className="h-full rounded-full flex items-center justify-center gap-1 opacity-50"
+          style={{ backgroundColor: barColor }}
+        >
+          <Icons.Check size={9} className="text-white flex-shrink-0" />
+          <span className="text-white text-[9px] font-medium truncate px-1">{project.title}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="absolute"
+      style={{ top: `${top}px`, left: 2, right: 2, height: `${height}px`, zIndex: 6 }}
+    >
+      <div
+        className="h-full rounded-md flex flex-col items-center justify-start overflow-hidden select-none"
+        style={{
+          backgroundColor: `${barColor}18`,
+          borderLeft: `3px solid ${barColor}`,
+          borderTop: `1px solid ${barColor}30`,
+          borderRight: `1px solid ${barColor}30`,
+          borderBottom: `1px solid ${barColor}30`,
+        }}
+      >
+        {/* Icon + time label row */}
+        <div className="flex items-center gap-0.5 pt-1 px-1 w-full">
+          <IconComp size={12} style={{ color: barColor, flexShrink: 0 }} />
+          {height > 30 && timeLabel && (
+            <span className="text-[9px] font-medium opacity-70 ml-0.5 truncate" style={{ color: barColor }}>
+              {timeLabel}
+            </span>
+          )}
+        </div>
+
+        {/* Project title */}
+        {height > 38 && (
+          <span
+            className="text-[10px] font-semibold leading-tight text-center px-1 w-full truncate"
+            style={{ color: barColor }}
+          >
+            {project.title}
+          </span>
+        )}
+
+        {/* Overdue badge */}
+        {isOverdue && height > 50 && (
+          <span className="text-[9px] font-semibold text-orange-500 px-1">overdue</span>
+        )}
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* HG enter button — pulsing when session is live */}
+        {canEnter && height > 50 && (
+          <button
+            onClick={() => enterHyperGlanceMode(project.id, date)}
+            className="mb-1.5 flex items-center gap-0.5 px-2 py-0.5 rounded-full text-white text-[9px] font-bold animate-pulse pointer-events-auto"
+            style={{ backgroundColor: barColor }}
+            title="Enter hyperGLANCE"
+          >
+            <Zap size={8} />
+            HG
+          </button>
+        )}
+
+        {/* Pre-session: show small HG label (not pulsing) */}
+        {!canEnter && !isOverdue && height > 50 && (
+          <span
+            className="mb-1.5 text-[9px] font-bold opacity-40"
+            style={{ color: barColor }}
+          >
+            HG
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HyperGlanceBar;

--- a/src/components/HyperGlanceModeModal.jsx
+++ b/src/components/HyperGlanceModeModal.jsx
@@ -1,0 +1,455 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as Icons from 'lucide-react';
+import { Check, CheckCircle, ChevronDown, ChevronUp, Pause, Play, Plus, SkipForward, Trophy, X, Zap } from 'lucide-react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { useSyncCtx } from '../context/SyncContext.jsx';
+import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
+import { extractWikilinks, stripWikilinks } from '../utils/taskUtils.js';
+
+const HyperGlanceModeModal = () => {
+  const {
+    currentTime, darkMode, isPhone,
+    tasks, setTasks,
+    unscheduledTasks, setUnscheduledTasks,
+    updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
+    aiSubtasksLoadingForTask,
+    generateAISubtasks,
+  } = useDayPlannerCtx();
+
+  const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
+
+  const {
+    projects, updateProject,
+    hyperGlanceProjectId,
+    hyperGlanceSessionDate,
+    hgTimerSeconds, setHgTimerSeconds,
+    hgTimerRunning, setHgTimerRunning,
+    hgTimerPhase, setHgTimerPhase,
+    hgWorkMinutes, setHgWorkMinutes,
+    hgBreakMinutes, setHgBreakMinutes,
+    hgCycleCount, setHgCycleCount,
+    hgExitConfirm, setHgExitConfirm,
+    hgShowSettings, setHgShowSettings,
+    exitHyperGlanceMode,
+    completeHyperGlanceSession,
+    aiConfig,
+  } = useFeaturesCtx();
+
+  const timerRef = useRef(null);
+  const sessionStartRef = useRef(null);
+  const [sessionElapsed, setSessionElapsed] = useState(0);
+  const [expandedTaskId, setExpandedTaskId] = useState(null);
+  const [hgCompleted, setHgCompleted] = useState(false); // session auto-completed
+
+  const project = projects.find(p => p.id === hyperGlanceProjectId);
+  const hg = project?.hyperglance;
+  const barColor = hg?.color || '#4f46e5';
+  const IconComp = Icons[hg?.icon] || Icons.Sparkles;
+
+  // All project tasks (unscheduled + scheduled), not archived, sorted: incomplete first
+  const projectTasks = [...tasks, ...unscheduledTasks]
+    .filter(t => t.projectId === hyperGlanceProjectId && !t.archived)
+    .sort((a, b) => {
+      if (a.completed && !b.completed) return 1;
+      if (!a.completed && b.completed) return -1;
+      return 0;
+    });
+
+  const allDone = projectTasks.length > 0 && projectTasks.every(t => t.completed);
+
+  // Auto-complete when all tasks are checked
+  useEffect(() => {
+    if (allDone && !hgCompleted && !hgShowSettings) {
+      setHgCompleted(true);
+      completeHyperGlanceSession();
+    }
+  }, [allDone, hgCompleted, hgShowSettings]);
+
+  // Timer countdown
+  useEffect(() => {
+    if (hgTimerRunning) {
+      timerRef.current = setInterval(() => {
+        setHgTimerSeconds(prev => {
+          if (prev <= 1) {
+            if (hgTimerPhase === 'work') {
+              setHgTimerPhase('break');
+              setHgCycleCount(c => c + 1);
+              return hgBreakMinutes * 60;
+            } else {
+              setHgTimerPhase('work');
+              return hgWorkMinutes * 60;
+            }
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }
+    return () => { if (timerRef.current) clearInterval(timerRef.current); };
+  }, [hgTimerRunning, hgTimerPhase, hgWorkMinutes, hgBreakMinutes]);
+
+  // Session elapsed clock
+  useEffect(() => {
+    if (hgTimerRunning && !sessionStartRef.current) {
+      sessionStartRef.current = Date.now();
+    }
+    const interval = setInterval(() => {
+      if (sessionStartRef.current) {
+        setSessionElapsed(Math.floor((Date.now() - sessionStartRef.current) / 1000));
+      }
+    }, 10000);
+    return () => clearInterval(interval);
+  }, [hgTimerRunning]);
+
+  const handleStart = () => {
+    setHgShowSettings(false);
+    setHgTimerSeconds(hgWorkMinutes * 60);
+    setHgTimerRunning(true);
+    setHgTimerPhase('work');
+    setHgCycleCount(0);
+    sessionStartRef.current = Date.now();
+  };
+
+  const handleToggleTask = (taskId) => {
+    const inScheduled = tasks.find(t => t.id === taskId);
+    if (inScheduled) {
+      setTasks(prev => prev.map(t => t.id === taskId ? { ...t, completed: !t.completed, updatedAt: new Date().toISOString() } : t));
+    } else {
+      setUnscheduledTasks(prev => prev.map(t => t.id === taskId ? { ...t, completed: !t.completed, updatedAt: new Date().toISOString() } : t));
+    }
+  };
+
+  const formatTimer = (seconds) => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  };
+
+  const formatElapsed = (seconds) => {
+    if (seconds < 60) return `${seconds}s`;
+    return `${Math.floor(seconds / 60)}m`;
+  };
+
+  if (!project) return null;
+
+  // ── Settings / pre-session view ────────────────────────────────────────────
+  if (hgShowSettings) {
+    return (
+      <div className="fixed inset-0 z-[200] bg-gray-950 flex flex-col items-center justify-center">
+        <div className="w-full max-w-md px-6 py-8 flex flex-col gap-6">
+          {/* Header */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-xl flex items-center justify-center" style={{ backgroundColor: `${barColor}30` }}>
+                <IconComp size={20} style={{ color: barColor }} />
+              </div>
+              <div>
+                <div className="text-white font-bold text-lg leading-tight">{project.title}</div>
+                <div className="text-gray-400 text-sm">{hyperGlanceSessionDate}</div>
+              </div>
+            </div>
+            <button onClick={() => exitHyperGlanceMode()} className="text-gray-500 hover:text-gray-300 p-1">
+              <X size={20} />
+            </button>
+          </div>
+
+          {/* Timer settings */}
+          <div className="space-y-3">
+            <div className="text-gray-400 text-xs font-semibold uppercase tracking-wide">Timer (Pomodoro)</div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="bg-gray-800 rounded-xl p-3 flex flex-col gap-1">
+                <span className="text-gray-400 text-xs">Work (min)</span>
+                <input
+                  type="number"
+                  min={1} max={120}
+                  value={hgWorkMinutes}
+                  onChange={e => setHgWorkMinutes(Math.max(1, parseInt(e.target.value) || 25))}
+                  className="bg-transparent text-white text-xl font-bold w-full focus:outline-none"
+                />
+              </div>
+              <div className="bg-gray-800 rounded-xl p-3 flex flex-col gap-1">
+                <span className="text-gray-400 text-xs">Break (min)</span>
+                <input
+                  type="number"
+                  min={1} max={60}
+                  value={hgBreakMinutes}
+                  onChange={e => setHgBreakMinutes(Math.max(1, parseInt(e.target.value) || 5))}
+                  className="bg-transparent text-white text-xl font-bold w-full focus:outline-none"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Task preview */}
+          {projectTasks.length > 0 && (
+            <div className="space-y-2">
+              <div className="text-gray-400 text-xs font-semibold uppercase tracking-wide">
+                Tasks ({projectTasks.filter(t => !t.completed).length} remaining)
+              </div>
+              <div className="space-y-1.5 max-h-48 overflow-y-auto">
+                {projectTasks.map(t => (
+                  <div key={t.id} className={`flex items-center gap-2 text-sm py-1 ${t.completed ? 'opacity-40 line-through text-gray-500' : 'text-gray-200'}`}>
+                    {t.completed ? <CheckCircle size={14} className="text-green-500 flex-shrink-0" /> : <div className="w-3.5 h-3.5 rounded border border-gray-500 flex-shrink-0" />}
+                    {stripWikilinks(t.title)}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {projectTasks.length === 0 && (
+            <p className="text-gray-500 text-sm text-center py-2">
+              No tasks yet — add project tasks in the Goals dashboard.
+            </p>
+          )}
+
+          {/* Start button */}
+          <button
+            onClick={handleStart}
+            className="w-full py-4 rounded-xl text-white font-bold text-lg flex items-center justify-center gap-2 transition-opacity hover:opacity-90"
+            style={{ backgroundColor: barColor }}
+          >
+            <Zap size={20} />
+            Start hyperGLANCE
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Post-completion view ───────────────────────────────────────────────────
+  if (hgCompleted) {
+    const elapsed = sessionElapsed;
+    return (
+      <div className="fixed inset-0 z-[200] bg-gray-950 flex flex-col items-center justify-center">
+        <div className="w-full max-w-sm px-6 py-8 flex flex-col items-center gap-6">
+          <Trophy size={48} className="text-yellow-400" />
+          <h1 className="text-2xl font-bold text-white">Session Complete!</h1>
+          <div className="text-gray-400 text-center text-sm">{project.title}</div>
+
+          <div className="w-full space-y-3">
+            <div className="flex justify-between bg-gray-800 rounded-lg px-4 py-3">
+              <span className="text-gray-400">Tasks completed</span>
+              <span className="text-white font-semibold">{projectTasks.filter(t => t.completed).length} / {projectTasks.length}</span>
+            </div>
+            {elapsed > 0 && (
+              <div className="flex justify-between bg-gray-800 rounded-lg px-4 py-3">
+                <span className="text-gray-400">Session time</span>
+                <span className="text-white font-semibold">{formatElapsed(elapsed)}</span>
+              </div>
+            )}
+          </div>
+
+          <button
+            onClick={() => exitHyperGlanceMode()}
+            className="w-full py-3 rounded-xl text-white font-semibold text-base"
+            style={{ backgroundColor: barColor }}
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Exit confirmation dialog ───────────────────────────────────────────────
+  if (hgExitConfirm) {
+    return (
+      <div className="fixed inset-0 z-[200] bg-gray-950 flex flex-col items-center justify-center">
+        <div className="w-full max-w-sm px-6 py-8 flex flex-col items-center gap-5">
+          <X size={40} className="text-gray-400" />
+          <h2 className="text-xl font-bold text-white text-center">Leave hyperGLANCE?</h2>
+          <p className="text-gray-400 text-sm text-center">
+            Your progress is saved. Choose to pause and return later, or end the session.
+          </p>
+          <div className="w-full flex flex-col gap-3">
+            <button
+              onClick={() => { setHgTimerRunning(false); setHgExitConfirm(false); exitHyperGlanceMode(); }}
+              className="w-full py-3 rounded-xl bg-gray-700 hover:bg-gray-600 text-white font-semibold transition-colors"
+            >
+              Pause — I'll come back
+            </button>
+            <button
+              onClick={() => { setHgExitConfirm(false); completeHyperGlanceSession(); }}
+              className="w-full py-3 rounded-xl text-white font-semibold transition-opacity hover:opacity-90"
+              style={{ backgroundColor: barColor }}
+            >
+              End Session
+            </button>
+            <button
+              onClick={() => setHgExitConfirm(false)}
+              className="text-gray-500 hover:text-gray-300 text-sm text-center py-1"
+            >
+              Cancel — keep going
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Main session view ──────────────────────────────────────────────────────
+  return (
+    <div className="fixed inset-0 z-[200] bg-gray-950 flex flex-col overflow-hidden">
+      {/* Top bar */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800 flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-lg flex items-center justify-center" style={{ backgroundColor: `${barColor}30` }}>
+            <IconComp size={14} style={{ color: barColor }} />
+          </div>
+          <span className="text-white font-semibold text-sm truncate max-w-[160px]">{project.title}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+            hgTimerPhase === 'work' ? 'bg-blue-900 text-blue-300' : 'bg-green-900 text-green-300'
+          }`}>
+            {hgTimerPhase === 'work' ? 'Work' : 'Break'} · Cycle {hgCycleCount + 1}
+          </span>
+          <button onClick={() => setHgExitConfirm(true)} className="text-gray-500 hover:text-gray-300 p-1">
+            <X size={18} />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <div className={`${isPhone ? 'px-4 py-5' : 'px-6 py-6'} max-w-lg mx-auto flex flex-col gap-6`}>
+          {/* Timer */}
+          <div className="flex flex-col items-center gap-4">
+            <div className="text-7xl font-mono text-white font-bold tracking-wider tabular-nums">
+              {formatTimer(hgTimerSeconds)}
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => setHgTimerRunning(prev => !prev)}
+                className="w-12 h-12 rounded-full flex items-center justify-center text-white transition-colors"
+                style={{ backgroundColor: barColor }}
+              >
+                {hgTimerRunning ? <Pause size={20} /> : <Play size={20} />}
+              </button>
+              <button
+                onClick={() => {
+                  setHgTimerPhase(p => p === 'work' ? 'break' : 'work');
+                  setHgTimerSeconds(hgTimerPhase === 'work' ? hgBreakMinutes * 60 : hgWorkMinutes * 60);
+                }}
+                className="w-9 h-9 rounded-full bg-gray-800 hover:bg-gray-700 flex items-center justify-center text-gray-400 transition-colors"
+                title="Skip phase"
+              >
+                <SkipForward size={16} />
+              </button>
+            </div>
+            {/* Cycle dots */}
+            <div className="flex gap-2">
+              {[0, 1, 2, 3].map(i => (
+                <div
+                  key={i}
+                  className={`w-3 h-3 rounded-full transition-all ${
+                    i < (hgCycleCount % 4) ? 'bg-blue-500' :
+                    i === (hgCycleCount % 4) && hgTimerPhase === 'work' ? 'bg-blue-500 animate-pulse' :
+                    'bg-gray-700'
+                  }`}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Tasks */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-gray-400 text-xs font-semibold uppercase tracking-wide">
+                Tasks · {projectTasks.filter(t => !t.completed).length} remaining
+              </span>
+              {sessionElapsed > 0 && (
+                <span className="text-gray-600 text-xs">{formatElapsed(sessionElapsed)} elapsed</span>
+              )}
+            </div>
+
+            {projectTasks.length === 0 && (
+              <p className="text-gray-600 text-sm text-center py-4">
+                No tasks — add them in the Goals dashboard.
+              </p>
+            )}
+
+            {projectTasks.map(task => {
+              const isDone = task.completed;
+              const isExpanded = expandedTaskId === task.id;
+              const hasExtra = (task.notes && task.notes.trim()) || (task.subtasks && task.subtasks.length > 0);
+
+              return (
+                <div
+                  key={task.id}
+                  className={`rounded-xl p-3 transition-opacity ${isDone ? 'opacity-40 bg-gray-900' : 'bg-gray-800'}`}
+                >
+                  <div className="flex items-start gap-3">
+                    <button
+                      onClick={() => handleToggleTask(task.id)}
+                      className={`w-5 h-5 rounded flex-shrink-0 mt-0.5 border-2 flex items-center justify-center transition-colors ${
+                        isDone ? 'border-green-500 bg-green-500' : 'border-gray-500 bg-transparent hover:border-gray-300'
+                      }`}
+                    >
+                      {isDone && <Check size={11} className="text-white" />}
+                    </button>
+                    <span className={`flex-1 text-sm leading-snug min-w-0 ${isDone ? 'text-gray-500 line-through' : 'text-gray-100'}`}>
+                      {stripWikilinks(task.title)}
+                    </span>
+                    {!isDone && (
+                      <button
+                        onClick={() => setExpandedTaskId(isExpanded ? null : task.id)}
+                        className="text-gray-500 hover:text-gray-300 p-0.5 flex-shrink-0"
+                      >
+                        {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Notes & subtasks panel */}
+                  {isExpanded && !isDone && (
+                    <div className="mt-2 pl-8">
+                      <NotesSubtasksPanel
+                        task={task}
+                        isInbox={false}
+                        darkMode={true}
+                        updateTaskNotes={updateTaskNotes}
+                        addSubtask={addSubtask}
+                        toggleSubtask={toggleSubtask}
+                        deleteSubtask={deleteSubtask}
+                        updateSubtaskTitle={updateSubtaskTitle}
+                        compact={false}
+                        noAutoFocus
+                        aiConfig={aiConfig}
+                        aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
+                        onGenerateSubtasks={generateAISubtasks}
+                        wikilinks={!isPhone && extractWikilinks(task.title).length > 0 ? extractWikilinks(task.title) : undefined}
+                        onLoadWikiNote={!isPhone && extractWikilinks(task.title).length > 0 ? loadWikiNote : undefined}
+                        onSaveWikiNote={!isPhone && extractWikilinks(task.title).length > 0 ? saveWikiNote : undefined}
+                        onOpenInObsidian={!isPhone && extractWikilinks(task.title).length > 0 ? openInObsidian : undefined}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex-shrink-0 flex gap-3 px-4 py-4 border-t border-gray-800">
+        <button
+          onClick={() => { setHgTimerRunning(false); exitHyperGlanceMode(); }}
+          className="flex-1 py-3 rounded-xl bg-gray-700 hover:bg-gray-600 text-white font-semibold text-sm transition-colors"
+        >
+          Pause
+        </button>
+        <button
+          onClick={() => setHgExitConfirm(true)}
+          className="flex-1 py-3 rounded-xl text-white font-semibold text-sm transition-opacity hover:opacity-90"
+          style={{ backgroundColor: barColor }}
+        >
+          End Session
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default HyperGlanceModeModal;

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -4,7 +4,7 @@ import {
   Calendar, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronUp, Clock, ExternalLink, FileText, Filter, Flag, Inbox, LayoutGrid,
   Loader, Mic, Minus, Moon, Plus, RefreshCw,
-  Search, Sparkles, Sun, Target, Trash2, X,
+  Search, Sparkles, Sun, Target, Trash2, X, Zap,
 } from 'lucide-react';
 import { renderTitle, renderFormattedText, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
 import { dateToString, extractTags, extractWikilinks, formatDeadlineDate } from '../utils/taskUtils.js';
@@ -17,6 +17,7 @@ import FrameNudgeCard from './FrameNudgeCard.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { getOverdueHGInstances } from '../hooks/useHyperGlance.js';
 
 const MobileGlanceSection = () => {
   const {
@@ -100,6 +101,7 @@ const MobileGlanceSection = () => {
     generateFrameNudge, generateMorningSummary, generateEveningReflection,
     dismissMorningGlance, dismissEveningGlance,
     openRoutinesDashboard,
+    enterHyperGlanceMode,
     getFrameInstancesForDate, computeAvailableSlots,
     showVoiceInput, setShowVoiceInput,
     voiceCanRecord,
@@ -1042,6 +1044,30 @@ const MobileGlanceSection = () => {
               </span>
             );
           })}
+        </div>
+      </div>
+    );
+  })()}
+
+  {/* Overdue HyperGLANCE projects */}
+  {goalsProjectsEnabled && (() => {
+    const overdue = getOverdueHGInstances(projects);
+    if (overdue.length === 0) return null;
+    return (
+      <div className={`mt-3 pt-3 border-t ${borderClass}`}>
+        <div className="text-xs font-semibold uppercase tracking-wide mb-2 text-orange-500">Overdue Projects</div>
+        <div className="space-y-1.5">
+          {overdue.map(({ project, instance }) => (
+            <button
+              key={project.id}
+              onClick={() => enterHyperGlanceMode(project.id, instance.date)}
+              className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-left active:opacity-70 transition-opacity ${darkMode ? 'bg-orange-900/20' : 'bg-orange-50'}`}
+            >
+              <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: project.hyperglance?.color || '#e11d48' }}></div>
+              <span className={`text-sm font-medium flex-1 min-w-0 truncate ${darkMode ? 'text-orange-200' : 'text-orange-800'}`}>{project.title}</span>
+              <Zap size={12} className="text-orange-500 flex-shrink-0" />
+            </button>
+          ))}
         </div>
       </div>
     );

--- a/src/components/MobileTimeGrid.jsx
+++ b/src/components/MobileTimeGrid.jsx
@@ -10,6 +10,8 @@ import { dateToString, extractWikilinks } from '../utils/taskUtils.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { getHGBarsForDate } from '../hooks/useHyperGlance.js';
+import HyperGlanceBar from './HyperGlanceBar.jsx';
 
 const MobileTimeGrid = () => {
   const {
@@ -116,6 +118,8 @@ const MobileTimeGrid = () => {
       const isDateToday = dateStr === dateToString(new Date());
       const dayTasks = getTasksForDate(date).filter(t => !t.isAllDay && !t.isExample && (!projectFilter || t.projectId === projectFilter));
       const frameInstances = getFrameInstancesForDate(date);
+      const hgBars = getHGBarsForDate(projects, dateStr);
+      const hasBars = hgBars.length > 0;
 
       return (
         <div
@@ -261,6 +265,17 @@ const MobileTimeGrid = () => {
             </div>
           )}
 
+          {/* HyperGLANCE project bars (left half of column) */}
+          {hasBars && (
+            <div className="absolute top-0 bottom-0 pointer-events-none" style={{ left: 0, width: '50%' }}>
+              {hgBars.map(bar => (
+                <HyperGlanceBar key={bar.project.id} {...bar} />
+              ))}
+            </div>
+          )}
+
+          {/* Task + routine layer (shifts to right half when HG bars are present) */}
+          <div className="absolute top-0 bottom-0 pointer-events-none" style={hasBars ? { left: '50%', right: 0 } : { left: 0, right: 0 }}>
           {/* Task blocks */}
           {dayTasks.map(task => {
             const { top, height } = calculateTaskPosition(task);
@@ -669,6 +684,7 @@ const MobileTimeGrid = () => {
               );
             });
           })()}
+          </div>{/* end task+routine layer */}
         </div>
       );
     })}

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -12,6 +12,8 @@ import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { getHGBarsForDate } from '../hooks/useHyperGlance.js';
+import HyperGlanceBar from './HyperGlanceBar.jsx';
 
 const TimeGrid = () => {
   const {
@@ -139,6 +141,8 @@ const TimeGrid = () => {
       const isDateToday = dateStr === dateToString(new Date());
       const dayTasks = getTasksForDate(date).filter(t => !t.isAllDay && (!projectFilter || t.projectId === projectFilter));
       const frameInstances = getFrameInstancesForDate(date);
+      const hgBars = getHGBarsForDate(projects, dateStr);
+      const hasBars = hgBars.length > 0;
 
       return (
         <div
@@ -260,6 +264,17 @@ const TimeGrid = () => {
             </div>
           )}
 
+          {/* HyperGLANCE project bars (left half of column) */}
+          {hasBars && (
+            <div className="absolute top-0 bottom-0 pointer-events-none" style={{ left: 0, width: '50%' }}>
+              {hgBars.map(bar => (
+                <HyperGlanceBar key={bar.project.id} {...bar} />
+              ))}
+            </div>
+          )}
+
+          {/* Task + routine layer (shifts to right half when HG bars are present) */}
+          <div className="absolute top-0 bottom-0 pointer-events-none" style={hasBars ? { left: '50%', right: 0 } : { left: 0, right: 0 }}>
           {/* Tasks for this day */}
           {dayTasks.map((task) => {
             const { top, height } = calculateTaskPosition(task);
@@ -927,6 +942,7 @@ const TimeGrid = () => {
               );
             });
           })()}
+          </div>{/* end task+routine layer */}
 
           {/* Hover preview line - shows where a new task would start */}
           {hoverPreviewTime && !draggedTask && !isResizing && hoverPreviewDate && dateToString(hoverPreviewDate) === dateStr && (

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -23,11 +23,19 @@ import {
   LogIn,
   Plus,
   RotateCcw,
+  Trash2,
   X,
+  Zap,
+  // hyperGLANCE icon picker icons
+  BookOpen, GraduationCap, Brain, Calculator, FlaskConical, Pencil,
+  Briefcase, Code2, LineChart, Target, LayoutDashboard, Clipboard,
+  Dumbbell, Heart, Activity, Apple, Moon, Bike,
+  Music, Camera, Palette, Lightbulb, Star, Wand2,
 } from 'lucide-react';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
 import { TASK_COLORS, TAILWIND_TO_HEX } from '../../utils/colorUtils.js';
+import { HG_ICON_GROUPS, HG_COLORS, HG_DAYS } from '../../hooks/useHyperGlance.js';
 import { calculateGoalProgress } from '../../utils/goalProgress.js';
 import { isProjectStalled } from '../../utils/projectProgress.js';
 import GoalCard from './GoalCard.jsx';
@@ -259,6 +267,14 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
   );
 };
 
+// ─── hyperGLANCE icon lookup map ──────────────────────────────────────────────
+const HG_ICON_MAP = {
+  BookOpen, GraduationCap, Brain, Calculator, FlaskConical, Pencil,
+  Briefcase, Code2, LineChart, Target, LayoutDashboard, Clipboard,
+  Dumbbell, Heart, Activity, Apple, Moon, Bike,
+  Music, Camera, Palette, Lightbulb, Star, Wand2,
+};
+
 // ─── Project form (create / edit) ─────────────────────────────────────────────
 
 const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, mobile }) => {
@@ -270,6 +286,33 @@ const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, mobile }
   const [goalId, setGoalId] = useState(initial?.goalId || defaultGoalId || '');
   const [status, setStatus] = useState(initial?.status || 'active');
 
+  // ── hyperGLANCE state ────────────────────────────────────────────────────
+  const initHG = initial?.hyperglance || {};
+  const [hgEnabled, setHgEnabled] = useState(initHG.enabled || false);
+  const [hgIcon, setHgIcon] = useState(initHG.icon || 'BookOpen');
+  const [hgColor, setHgColor] = useState(initHG.color || '#4f46e5');
+  const [hgIsRecurring, setHgIsRecurring] = useState(initHG.isRecurring !== false);
+  const [hgScheduledDays, setHgScheduledDays] = useState(initHG.scheduledDays || []);
+  const [hgScheduledDate, setHgScheduledDate] = useState(initHG.scheduledDate || '');
+  const [hgScheduledTime, setHgScheduledTime] = useState(initHG.scheduledTime || '09:00');
+  const [hgDuration, setHgDuration] = useState(initHG.scheduledDuration || 60);
+  const [hgTemplateTasks, setHgTemplateTasks] = useState(initHG.templateTasks || []);
+  const [hgNewTask, setHgNewTask] = useState('');
+
+  const toggleHGDay = (day) => {
+    setHgScheduledDays(prev =>
+      prev.includes(day) ? prev.filter(d => d !== day) : [...prev, day]
+    );
+  };
+
+  const addHGTemplateTask = () => {
+    if (!hgNewTask.trim()) return;
+    setHgTemplateTasks(prev => [...prev, { id: crypto.randomUUID(), name: hgNewTask.trim(), notes: '' }]);
+    setHgNewTask('');
+  };
+
+  const removeHGTemplateTask = (id) => setHgTemplateTasks(prev => prev.filter(t => t.id !== id));
+
   // "Completed" only available when all project tasks are completed (or none exist)
   const projectTasks = initial
     ? [...tasks, ...unscheduledTasks].filter(t => t.projectId === initial.id && !t.archived)
@@ -279,7 +322,20 @@ const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, mobile }
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!title.trim()) return;
-    onSave({ title: title.trim(), description: description.trim(), goalId: goalId || undefined, status });
+    const hyperglance = hgEnabled ? {
+      enabled: true,
+      icon: hgIcon,
+      color: hgColor,
+      isRecurring: hgIsRecurring,
+      scheduledDays: hgIsRecurring ? hgScheduledDays : [],
+      scheduledDate: hgIsRecurring ? null : (hgScheduledDate || null),
+      scheduledTime: hgScheduledTime,
+      scheduledDuration: Math.max(1, hgDuration),
+      templateTasks: hgTemplateTasks,
+      completions: initHG.completions || [],
+      activeSession: initHG.activeSession || null,
+    } : null;
+    onSave({ title: title.trim(), description: description.trim(), goalId: goalId || undefined, status, hyperglance });
   };
 
   const activeGoals = goals.filter(g => g.status !== 'archived');
@@ -373,6 +429,203 @@ const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, mobile }
           )}
         </div>
       )}
+
+      {/* ── hyperGLANCE section ────────────────────────────────────────── */}
+      <div className={`rounded-xl border ${borderClass} overflow-hidden`}>
+        {/* Toggle row */}
+        <button
+          type="button"
+          onClick={() => setHgEnabled(v => !v)}
+          className={`w-full flex items-center justify-between px-3 py-2.5 ${hoverBg} transition-colors`}
+        >
+          <div className="flex items-center gap-2">
+            <Zap size={15} className={hgEnabled ? 'text-yellow-400' : textSecondary} />
+            <span className={`text-sm font-medium ${hgEnabled ? textPrimary : textSecondary}`}>
+              hyperGLANCE
+            </span>
+            {hgEnabled && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-yellow-400/20 text-yellow-400 font-semibold">ON</span>
+            )}
+          </div>
+          <ChevronDown size={14} className={`${textSecondary} transition-transform ${hgEnabled ? 'rotate-180' : ''}`} />
+        </button>
+
+        {hgEnabled && (
+          <div className={`px-3 pb-4 pt-1 space-y-4 border-t ${borderClass}`}>
+            {/* Icon picker */}
+            <div className="flex flex-col gap-1.5">
+              <label className={`text-xs font-medium ${textSecondary}`}>Icon</label>
+              {HG_ICON_GROUPS.map(({ group, icons }) => (
+                <div key={group}>
+                  <div className={`text-[10px] font-medium ${textSecondary} opacity-60 mb-1`}>{group}</div>
+                  <div className="flex flex-wrap gap-1">
+                    {icons.map(iconName => {
+                      const Ic = HG_ICON_MAP[iconName];
+                      if (!Ic) return null;
+                      return (
+                        <button
+                          key={iconName}
+                          type="button"
+                          onClick={() => setHgIcon(iconName)}
+                          className={`w-8 h-8 rounded-lg flex items-center justify-center transition-colors ${
+                            hgIcon === iconName
+                              ? 'ring-2'
+                              : `${hoverBg} opacity-60 hover:opacity-100`
+                          }`}
+                          style={hgIcon === iconName ? { ringColor: hgColor, backgroundColor: `${hgColor}20` } : {}}
+                          title={iconName}
+                        >
+                          <Ic size={15} style={{ color: hgIcon === iconName ? hgColor : undefined }} className={hgIcon === iconName ? '' : textSecondary} />
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Color picker */}
+            <div className="flex flex-col gap-1.5">
+              <label className={`text-xs font-medium ${textSecondary}`}>Color</label>
+              <div className="flex flex-wrap gap-2">
+                {HG_COLORS.map(c => (
+                  <button
+                    key={c.value}
+                    type="button"
+                    onClick={() => setHgColor(c.value)}
+                    className={`w-7 h-7 rounded-full transition-all ${hgColor === c.value ? 'ring-2 ring-offset-2' : 'opacity-70 hover:opacity-100'}`}
+                    style={{ backgroundColor: c.value, ringColor: c.value }}
+                    title={c.label}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Schedule type */}
+            <div className="flex flex-col gap-1.5">
+              <label className={`text-xs font-medium ${textSecondary}`}>Schedule</label>
+              <div className={`flex rounded-lg border ${borderClass} overflow-hidden`}>
+                {[{ value: true, label: 'Recurring' }, { value: false, label: 'One-off' }].map(opt => (
+                  <button
+                    key={String(opt.value)}
+                    type="button"
+                    onClick={() => setHgIsRecurring(opt.value)}
+                    className={`flex-1 py-1.5 text-xs font-medium transition-colors ${
+                      hgIsRecurring === opt.value ? 'bg-blue-600 text-white' : `${textSecondary} ${hoverBg}`
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Recurring: day picker */}
+            {hgIsRecurring && (
+              <div className="flex flex-col gap-1.5">
+                <label className={`text-xs font-medium ${textSecondary}`}>Days</label>
+                <div className="flex gap-1 flex-wrap">
+                  {HG_DAYS.slice(1).concat(HG_DAYS[0]).map(day => (
+                    <button
+                      key={day}
+                      type="button"
+                      onClick={() => toggleHGDay(day)}
+                      className={`px-2 py-1 rounded-md text-[11px] font-medium transition-colors ${
+                        hgScheduledDays.includes(day)
+                          ? 'text-white'
+                          : `${textSecondary} ${hoverBg} opacity-60`
+                      }`}
+                      style={hgScheduledDays.includes(day) ? { backgroundColor: hgColor } : {}}
+                    >
+                      {day.charAt(0).toUpperCase() + day.slice(1, 3)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* One-off: date picker */}
+            {!hgIsRecurring && (
+              <div className="flex flex-col gap-1.5">
+                <label className={`text-xs font-medium ${textSecondary}`}>Date</label>
+                <input
+                  type="date"
+                  value={hgScheduledDate}
+                  onChange={e => setHgScheduledDate(e.target.value)}
+                  className={`px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                    darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'
+                  }`}
+                />
+              </div>
+            )}
+
+            {/* Time + Duration row */}
+            <div className="flex gap-3">
+              <div className="flex flex-col gap-1.5 flex-1">
+                <label className={`text-xs font-medium ${textSecondary}`}>Start time</label>
+                <input
+                  type="time"
+                  value={hgScheduledTime}
+                  onChange={e => setHgScheduledTime(e.target.value)}
+                  className={`px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                    darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'
+                  }`}
+                />
+              </div>
+              <div className="flex flex-col gap-1.5 w-24">
+                <label className={`text-xs font-medium ${textSecondary}`}>Duration (min)</label>
+                <input
+                  type="number"
+                  min={5}
+                  max={480}
+                  value={hgDuration}
+                  onChange={e => setHgDuration(Math.max(5, parseInt(e.target.value) || 60))}
+                  className={`px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                    darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'
+                  }`}
+                />
+              </div>
+            </div>
+
+            {/* Template tasks */}
+            {hgIsRecurring && (
+              <div className="flex flex-col gap-1.5">
+                <label className={`text-xs font-medium ${textSecondary}`}>
+                  Template tasks <span className="opacity-50 font-normal">(instantiated each session)</span>
+                </label>
+                {hgTemplateTasks.map(t => (
+                  <div key={t.id} className={`flex items-center gap-2 px-2 py-1.5 rounded-lg ${darkMode ? 'bg-gray-700/50' : 'bg-stone-50'}`}>
+                    <span className={`flex-1 text-sm ${textPrimary}`}>{t.name}</span>
+                    <button type="button" onClick={() => removeHGTemplateTask(t.id)} className={`p-0.5 rounded ${hoverBg}`}>
+                      <Trash2 size={13} className="text-red-400" />
+                    </button>
+                  </div>
+                ))}
+                <div className="flex gap-2 mt-1">
+                  <input
+                    type="text"
+                    value={hgNewTask}
+                    onChange={e => setHgNewTask(e.target.value)}
+                    onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addHGTemplateTask(); } }}
+                    placeholder="Add task…"
+                    className={`flex-1 px-2 py-1.5 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                      darkMode ? 'bg-gray-700 text-gray-100 placeholder-gray-500' : 'bg-white text-stone-900 placeholder-stone-400'
+                    }`}
+                  />
+                  <button
+                    type="button"
+                    onClick={addHGTemplateTask}
+                    disabled={!hgNewTask.trim()}
+                    className="px-2 py-1.5 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-40"
+                  >
+                    <Plus size={14} />
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
 
       {/* Actions */}
       <div className="flex gap-2 justify-end">

--- a/src/hooks/useHyperGlance.js
+++ b/src/hooks/useHyperGlance.js
@@ -1,0 +1,126 @@
+import { dateToString } from '../utils/taskUtils.js';
+
+// Days of week in JS Date.getDay() order
+export const HG_DAYS = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+
+// Curated icon groups for hyperGLANCE project icon picker
+export const HG_ICON_GROUPS = [
+  { group: 'Education', icons: ['BookOpen', 'GraduationCap', 'Brain', 'Calculator', 'FlaskConical', 'Pencil'] },
+  { group: 'Work',      icons: ['Briefcase', 'Code2', 'LineChart', 'Target', 'LayoutDashboard', 'Clipboard'] },
+  { group: 'Health',    icons: ['Dumbbell', 'Heart', 'Activity', 'Apple', 'Moon', 'Bike'] },
+  { group: 'Creative',  icons: ['Music', 'Camera', 'Palette', 'Lightbulb', 'Star', 'Wand2'] },
+];
+
+// Preset color palette for project bars
+export const HG_COLORS = [
+  { label: 'Indigo',  value: '#4f46e5' },
+  { label: 'Blue',    value: '#2563eb' },
+  { label: 'Teal',    value: '#0d9488' },
+  { label: 'Green',   value: '#16a34a' },
+  { label: 'Amber',   value: '#d97706' },
+  { label: 'Orange',  value: '#ea580c' },
+  { label: 'Rose',    value: '#e11d48' },
+  { label: 'Purple',  value: '#9333ea' },
+];
+
+/**
+ * Returns the "active instance" for a hyperGLANCE project — the earliest
+ * incomplete scheduled session. Looks back up to 7 days for missed sessions,
+ * then forward up to 365 days for the next future session.
+ *
+ * Returns null if the project has no hyperglance config, is not enabled,
+ * or has no scheduled days.
+ */
+export function getActiveHGInstance(project) {
+  const hg = project.hyperglance;
+  if (!hg?.enabled) return null;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const todayStr = dateToString(today);
+
+  const completedDates = new Set((hg.completions || []).map(c => c.date));
+
+  if (!hg.isRecurring) {
+    // One-off: show if not yet completed
+    if (!hg.scheduledDate) return null;
+    if (completedDates.has(hg.scheduledDate)) return null;
+    return {
+      projectId: project.id,
+      date: hg.scheduledDate,
+      isOverdue: hg.scheduledDate < todayStr,
+    };
+  }
+
+  // Recurring: look back 7 days for missed sessions, then forward for the next
+  const scheduledDays = hg.scheduledDays || [];
+  if (scheduledDays.length === 0) return null;
+
+  for (let i = -7; i <= 365; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() + i);
+    const ds = dateToString(d);
+    const dayName = HG_DAYS[d.getDay()];
+
+    if (scheduledDays.includes(dayName) && !completedDates.has(ds)) {
+      return {
+        projectId: project.id,
+        date: ds,
+        isOverdue: ds < todayStr,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Returns all hyperGLANCE bars that should be shown on a given date string:
+ * - Active (incomplete) instance for that date → full bar
+ * - Completed instance for that date → small pill
+ */
+export function getHGBarsForDate(projects, dateStr) {
+  const bars = [];
+
+  for (const project of projects) {
+    const hg = project.hyperglance;
+    if (!hg?.enabled) continue;
+
+    const active = getActiveHGInstance(project);
+    const completedOnDate = (hg.completions || []).some(c => c.date === dateStr);
+
+    if (active?.date === dateStr) {
+      bars.push({ project, date: dateStr, isCompleted: false, isOverdue: active.isOverdue });
+    } else if (completedOnDate) {
+      bars.push({ project, date: dateStr, isCompleted: true, isOverdue: false });
+    }
+  }
+
+  return bars;
+}
+
+/**
+ * Returns true if current time has reached or passed the scheduled start time
+ * for today's session (enabling the pulsing HG button).
+ */
+export function isHGSessionReachable(instance, hgConfig, currentTime) {
+  if (!instance || instance.isOverdue) return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  if (instance.date !== dateToString(today)) return false;
+
+  const [h, m] = (hgConfig.scheduledTime || '0:0').split(':').map(Number);
+  const startMinutes = h * 60 + m;
+  const nowMinutes = currentTime.getHours() * 60 + currentTime.getMinutes();
+  return nowMinutes >= startMinutes;
+}
+
+/**
+ * Returns all overdue hyperGLANCE instances (missed sessions from past dates).
+ */
+export function getOverdueHGInstances(projects) {
+  return projects
+    .filter(p => p.hyperglance?.enabled)
+    .map(p => ({ project: p, instance: getActiveHGInstance(p) }))
+    .filter(({ instance }) => instance?.isOverdue);
+}


### PR DESCRIPTION
## Summary

- **New `hyperGLANCE` concept**: Projects can now be given a scheduled time/duration and recurrence (specific days of the week, or a one-off date). When scheduled, they appear as vertical bars in the **left half** of the timeline; regular tasks shift to the **right half**.
- **Project Form enhancements** (`GoalDashboard.jsx`): a collapsible hyperGLANCE section in the project form adds icon picker (24 curated Lucide icons in 4 categories), color picker (8 presets), schedule type toggle (recurring day picker or one-off date picker), time + duration inputs, and a template task editor.
- **Timeline split** (`TimeGrid.jsx`, `MobileTimeGrid.jsx`): each day column is now conditionally split — a left-50% layer for HG bars and a right-50% layer for tasks+routines. When no bars are present the column reverts to full-width (no visual change for non-HG days).
- **HyperGlanceBar component**: renders the project bar (icon, time label, title, overdue badge, pulsing "HG" enter button when session is live) or a completion pill for completed sessions.
- **HyperGlanceModeModal component**: full-screen overlay (z-200) with Pomodoro timer (work/break phases, cycle dots, skip), project task list with inline notes/subtasks, session elapsed clock, pause vs. end-session controls (end requires confirmation), and auto-completion when all tasks are checked.
- **GLANCE "Overdue Projects" row** (`GlanceSidebar.jsx`, `MobileGlanceSection.jsx`): missed HG sessions surface as orange-tinted project buttons — tap to jump straight into the session.
- **Session logic** (`useHyperGlance.js`): `getActiveHGInstance` looks back 7 days for missed sessions then forward 365 days for the next scheduled one. `getHGBarsForDate` returns both the active bar and completed pills for a date. Only one bar per project is visible at a time.
- **App.jsx wiring**: `enterHyperGlanceMode`, `exitHyperGlanceMode`, `completeHyperGlanceSession` functions + all HG timer/phase state added to `FeaturesContext`.

## Test plan

- [ ] Create a project, enable hyperGLANCE, pick an icon/color, set a recurring schedule for today
- [ ] Confirm a bar appears in the left half of today's timeline column; tasks appear in the right half
- [ ] At the scheduled time, confirm the pulsing "HG" button appears; tapping it opens the session modal
- [ ] Start the timer; verify work/break phases cycle correctly
- [ ] Check a task in the modal; verify it stays checked
- [ ] Check all tasks → session should auto-complete, bar shrinks to completion pill
- [ ] End a session manually (without completing tasks); confirm exit confirmation dialog works; modal closes and bar remains on timeline (not completed)
- [ ] Miss a session (past date) → confirm "Overdue Projects" row appears in GLANCE with tap-to-enter
- [ ] Verify days without HG projects show full-width task columns (no regression)
- [ ] Verify template tasks are instantiated as unscheduled project tasks when entering a session

https://claude.ai/code/session_013k2rJ448A4YHUkPEta6kL6