### PR TITLE
GLANCE polish: tappable routine chips, gear icons bottom-right

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -77,7 +77,7 @@ const CalendarHeader = () => {
     focusLog, setFocusLogModalDate,
     habitLogs, activeHabits, habitsEnabled,
     habitDayPopup, setHabitDayPopup,
-    todayRoutines, routinesEnabled,
+    todayRoutines, routinesEnabled, routineCompletions,
     aiConfig, aiSubtasksLoadingForTask, generateAISubtasks,
     goalsProjectsEnabled, projects,
     projectFilter, setProjectFilter,
@@ -766,7 +766,7 @@ const CalendarHeader = () => {
                 onTouchMove: (e) => handleMobileTaskTouchMove(e),
                 onTouchEnd: (e) => handleMobileTaskTouchEnd(e, routine.id, 'allday'),
               } : {})}
-              className={`rounded-full px-3 py-1 text-xs font-medium ${isTablet ? 'cursor-default select-none' : 'cursor-move'} inline-block mr-1 mb-1 ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'}`}
+              className={`rounded-full px-3 py-1 text-xs font-medium ${isTablet ? 'cursor-default select-none' : 'cursor-move'} inline-block mr-1 mb-1 ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${routineCompletions[routine.id] ? 'line-through opacity-75' : ''}`}
               style={isTablet ? { touchAction: 'none', WebkitTouchCallout: 'none', WebkitUserSelect: 'none' } : {}}
             >
               {routine.name}

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -73,7 +73,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     eveningGlanceText, eveningGlanceLoading, eveningGlanceDismissed, eveningGlanceError,
     frameNudgeSuggestion, frameNudgeLoading, frameNudgeError,
     frameNudgeDismissedKey, setFrameNudgeDismissedKey,
-    routinesEnabled, todayRoutines, routineCompletions,
+    routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion,
     habitsEnabled,
     activeHabits, habitStreaks,
     habitLongPressId, setHabitLongPressId,
@@ -212,7 +212,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
       <div className="relative">
         <button
           onClick={() => setShowHabitModal(true)}
-          className={`absolute -top-0.5 -right-0.5 p-1 rounded ${hoverBg} ${textSecondary} transition-colors z-10`}
+          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${textSecondary} transition-colors z-10`}
           title="Manage habits"
         >
           <Settings size={11} />
@@ -1088,24 +1088,32 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     const visibleRoutines = realRoutines.filter(r => !routineCompletions[r.id]);
     if (realRoutines.length > 0 && visibleRoutines.length === 0) return null;
     return (
-      <div className={isDesktop ? `rounded-lg border ${borderClass} p-3 cursor-pointer hover:opacity-80 transition-opacity` : `mt-3 pt-3 border-t ${borderClass} cursor-pointer active:opacity-70 transition-opacity`} onClick={() => openRoutinesDashboard()}>
+      <div className={`relative ${isDesktop ? `rounded-lg border ${borderClass} p-3` : `mt-3 pt-3 border-t ${borderClass}`}`}>
+        <button
+          onClick={() => openRoutinesDashboard()}
+          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${textSecondary} transition-colors z-10`}
+          title="Manage routines"
+        >
+          <Settings size={11} />
+        </button>
         <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Routines</div>
         {visibleRoutines.length === 0 ? (
           <div className="flex items-center gap-2">
             <span className={`text-xs ${textSecondary} italic`}>None scheduled</span>
             <button
-              onClick={(e) => { e.stopPropagation(); openRoutinesDashboard(); }}
+              onClick={() => openRoutinesDashboard()}
               className="text-xs text-teal-500 font-medium hover:text-teal-400 transition-colors"
             >+ Add</button>
           </div>
         ) : (
           <div className={`flex flex-wrap ${isDesktop ? "gap-1" : "gap-1.5"}`}>
-            {[...visibleRoutines].sort((a, b) => {
+            {[...realRoutines].sort((a, b) => {
               if (a.isAllDay && !b.isAllDay) return -1;
               if (!a.isAllDay && b.isAllDay) return 1;
               if (a.startTime && b.startTime) return timeToMinutes(a.startTime) - timeToMinutes(b.startTime);
               return 0;
             }).map(r => {
+              const done = !!routineCompletions[r.id];
               let timeLabel = '';
               if (!r.isAllDay && r.startTime) {
                 if (use24HourClock) {
@@ -1118,9 +1126,13 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                 }
               }
               return (
-                <span key={r.id} className={`rounded-full px-2.5 ${isDesktop ? "py-0.5" : "py-1"} text-xs font-medium ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'}`}>
+                <button
+                  key={r.id}
+                  onClick={() => toggleRoutineCompletion(r.id)}
+                  className={`rounded-full px-2.5 ${isDesktop ? "py-0.5" : "py-1"} text-xs font-medium ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${done ? 'line-through opacity-50' : 'hover:opacity-80'} transition-opacity`}
+                >
                   {timeLabel && <span className="opacity-70 mr-1">{timeLabel}</span>}{r.name}
-                </span>
+                </button>
               );
             })}
           </div>

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -1087,6 +1087,17 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     const realRoutines = todayRoutines.filter(r => !String(r.id).startsWith('example-'));
     const visibleRoutines = realRoutines.filter(r => !routineCompletions[r.id]);
     if (realRoutines.length > 0 && visibleRoutines.length === 0) return null;
+    if (visibleRoutines.length === 0) {
+      return (
+        <div className={isDesktop ? `rounded-lg border ${borderClass} p-3 cursor-pointer hover:opacity-80 transition-opacity` : `mt-3 pt-3 border-t ${borderClass} cursor-pointer active:opacity-70 transition-opacity`} onClick={() => openRoutinesDashboard()}>
+          <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Routines</div>
+          <div className="flex items-center gap-2">
+            <span className={`text-xs ${textSecondary} italic`}>None scheduled</span>
+            <span className="text-xs text-teal-500 font-medium hover:text-teal-400 transition-colors">+ Add</span>
+          </div>
+        </div>
+      );
+    }
     return (
       <div className={`relative ${isDesktop ? `rounded-lg border ${borderClass} p-3` : `mt-3 pt-3 border-t ${borderClass}`}`}>
         <button
@@ -1097,46 +1108,36 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
           <Settings size={11} />
         </button>
         <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Routines</div>
-        {visibleRoutines.length === 0 ? (
-          <div className="flex items-center gap-2">
-            <span className={`text-xs ${textSecondary} italic`}>None scheduled</span>
-            <button
-              onClick={() => openRoutinesDashboard()}
-              className="text-xs text-teal-500 font-medium hover:text-teal-400 transition-colors"
-            >+ Add</button>
-          </div>
-        ) : (
-          <div className={`flex flex-wrap ${isDesktop ? "gap-1" : "gap-1.5"}`}>
-            {[...realRoutines].sort((a, b) => {
-              if (a.isAllDay && !b.isAllDay) return -1;
-              if (!a.isAllDay && b.isAllDay) return 1;
-              if (a.startTime && b.startTime) return timeToMinutes(a.startTime) - timeToMinutes(b.startTime);
-              return 0;
-            }).map(r => {
-              const done = !!routineCompletions[r.id];
-              let timeLabel = '';
-              if (!r.isAllDay && r.startTime) {
-                if (use24HourClock) {
-                  timeLabel = r.startTime;
-                } else {
-                  const [h, m] = r.startTime.split(':').map(Number);
-                  const hour12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
-                  const ampm = h < 12 ? 'a' : 'p';
-                  timeLabel = m === 0 ? `${hour12}${ampm}` : `${hour12}:${String(m).padStart(2, '0')}${ampm}`;
-                }
+        <div className={`flex flex-wrap ${isDesktop ? "gap-1" : "gap-1.5"}`}>
+          {[...realRoutines].sort((a, b) => {
+            if (a.isAllDay && !b.isAllDay) return -1;
+            if (!a.isAllDay && b.isAllDay) return 1;
+            if (a.startTime && b.startTime) return timeToMinutes(a.startTime) - timeToMinutes(b.startTime);
+            return 0;
+          }).map(r => {
+            const done = !!routineCompletions[r.id];
+            let timeLabel = '';
+            if (!r.isAllDay && r.startTime) {
+              if (use24HourClock) {
+                timeLabel = r.startTime;
+              } else {
+                const [h, m] = r.startTime.split(':').map(Number);
+                const hour12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+                const ampm = h < 12 ? 'a' : 'p';
+                timeLabel = m === 0 ? `${hour12}${ampm}` : `${hour12}:${String(m).padStart(2, '0')}${ampm}`;
               }
-              return (
-                <button
-                  key={r.id}
-                  onClick={() => toggleRoutineCompletion(r.id)}
-                  className={`rounded-full px-2.5 ${isDesktop ? "py-0.5" : "py-1"} text-xs font-medium ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${done ? 'line-through opacity-50' : 'hover:opacity-80'} transition-opacity`}
-                >
-                  {timeLabel && <span className="opacity-70 mr-1">{timeLabel}</span>}{r.name}
-                </button>
-              );
-            })}
-          </div>
-        )}
+            }
+            return (
+              <button
+                key={r.id}
+                onClick={() => toggleRoutineCompletion(r.id)}
+                className={`rounded-full px-2.5 ${isDesktop ? "py-0.5" : "py-1"} text-xs font-medium ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${done ? 'line-through opacity-50' : 'hover:opacity-80'} transition-opacity`}
+              >
+                {timeLabel && <span className="opacity-70 mr-1">{timeLabel}</span>}{r.name}
+              </button>
+            );
+          })}
+        </div>
       </div>
     );
   })()}

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -212,7 +212,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
       <div className="relative">
         <button
           onClick={() => setShowHabitModal(true)}
-          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${textSecondary} transition-colors z-10`}
+          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${darkMode ? 'text-gray-700' : 'text-stone-300'} transition-colors z-10`}
           title="Manage habits"
         >
           <Settings size={11} />
@@ -1102,7 +1102,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
       <div className={`relative ${isDesktop ? `rounded-lg border ${borderClass} p-3` : `mt-3 pt-3 border-t ${borderClass}`}`}>
         <button
           onClick={() => openRoutinesDashboard()}
-          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${textSecondary} transition-colors z-10`}
+          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${darkMode ? 'text-gray-700' : 'text-stone-300'} transition-colors z-10`}
           title="Manage routines"
         >
           <Settings size={11} />

--- a/src/components/MobileAllDaySection.jsx
+++ b/src/components/MobileAllDaySection.jsx
@@ -32,7 +32,7 @@ const MobileAllDaySection = () => {
   } = useDayPlannerCtx();
 
   const {
-    routinesEnabled, todayRoutines,
+    routinesEnabled, todayRoutines, routineCompletions,
     openRoutinesDashboard,
   } = useFeaturesCtx();
 
@@ -352,7 +352,7 @@ const MobileAllDaySection = () => {
               {routinesEnabled && dateToString(date) === dateToString(new Date()) && todayRoutines.filter(r => r.isAllDay && !String(r.id).startsWith('example-')).map((routine) => (
                 <div
                   key={`routine-${routine.id}`}
-                  className={`rounded-full px-3 py-1 text-xs font-medium inline-block mr-1 mb-1 select-none ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${mobileDragTaskIdState === routine.id ? 'scale-105 shadow-2xl z-40' : ''}`}
+                  className={`rounded-full px-3 py-1 text-xs font-medium inline-block mr-1 mb-1 select-none ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${mobileDragTaskIdState === routine.id ? 'scale-105 shadow-2xl z-40' : ''} ${routineCompletions[routine.id] ? 'line-through opacity-75' : ''}`}
                   style={{ touchAction: 'none', WebkitTouchCallout: 'none', WebkitUserSelect: 'none' }}
                   onTouchStart={(e) => handleMobileTaskTouchStart(e, { ...routine, isRoutineDrag: true, duration: routine.duration || 15 }, 'allday')}
                   onTouchMove={(e) => handleMobileTaskTouchMove(e)}

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -150,7 +150,7 @@ const MobileGlanceSection = () => {
       <div className="mb-4 relative">
         <button
           onClick={() => { setMobileActiveTab('settings'); setMobileSettingsView('habits'); }}
-          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${textSecondary} transition-colors z-10`}
+          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${darkMode ? 'text-gray-700' : 'text-stone-300'} transition-colors z-10`}
           title="Manage habits"
         >
           <Settings size={11} />
@@ -1046,7 +1046,7 @@ const MobileGlanceSection = () => {
       <div className={`relative mt-3 pt-3 border-t ${borderClass}`}>
         <button
           onClick={openRoutinesSettings}
-          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${textSecondary} transition-colors z-10`}
+          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${darkMode ? 'text-gray-700' : 'text-stone-300'} transition-colors z-10`}
           title="Manage routines"
         >
           <Settings size={11} />

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -1031,6 +1031,17 @@ const MobileGlanceSection = () => {
       setMobileActiveTab('settings');
       setMobileSettingsView('routines');
     };
+    if (visibleRoutines.length === 0) {
+      return (
+        <div className={`mt-3 pt-3 border-t ${borderClass} cursor-pointer active:opacity-70 transition-opacity`} onClick={openRoutinesSettings}>
+          <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Routines</div>
+          <div className="flex items-center gap-2">
+            <span className={`text-xs ${textSecondary} italic`}>None scheduled</span>
+            <span className="text-xs text-teal-500 font-medium">+ Add</span>
+          </div>
+        </div>
+      );
+    }
     return (
       <div className={`relative mt-3 pt-3 border-t ${borderClass}`}>
         <button
@@ -1041,46 +1052,36 @@ const MobileGlanceSection = () => {
           <Settings size={11} />
         </button>
         <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Routines</div>
-        {visibleRoutines.length === 0 ? (
-          <div className="flex items-center gap-2">
-            <span className={`text-xs ${textSecondary} italic`}>None scheduled</span>
-            <button
-              onClick={openRoutinesSettings}
-              className="text-xs text-teal-500 font-medium"
-            >+ Add</button>
-          </div>
-        ) : (
-          <div className="flex flex-wrap gap-1.5">
-            {[...realRoutines].sort((a, b) => {
-              if (a.isAllDay && !b.isAllDay) return -1;
-              if (!a.isAllDay && b.isAllDay) return 1;
-              if (a.startTime && b.startTime) return timeToMinutes(a.startTime) - timeToMinutes(b.startTime);
-              return 0;
-            }).map(r => {
-              const done = !!routineCompletions[r.id];
-              let timeLabel = '';
-              if (!r.isAllDay && r.startTime) {
-                if (use24HourClock) {
-                  timeLabel = r.startTime;
-                } else {
-                  const [h, m] = r.startTime.split(':').map(Number);
-                  const hour12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
-                  const ampm = h < 12 ? 'a' : 'p';
-                  timeLabel = m === 0 ? `${hour12}${ampm}` : `${hour12}:${String(m).padStart(2, '0')}${ampm}`;
-                }
+        <div className="flex flex-wrap gap-1.5">
+          {[...realRoutines].sort((a, b) => {
+            if (a.isAllDay && !b.isAllDay) return -1;
+            if (!a.isAllDay && b.isAllDay) return 1;
+            if (a.startTime && b.startTime) return timeToMinutes(a.startTime) - timeToMinutes(b.startTime);
+            return 0;
+          }).map(r => {
+            const done = !!routineCompletions[r.id];
+            let timeLabel = '';
+            if (!r.isAllDay && r.startTime) {
+              if (use24HourClock) {
+                timeLabel = r.startTime;
+              } else {
+                const [h, m] = r.startTime.split(':').map(Number);
+                const hour12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+                const ampm = h < 12 ? 'a' : 'p';
+                timeLabel = m === 0 ? `${hour12}${ampm}` : `${hour12}:${String(m).padStart(2, '0')}${ampm}`;
               }
-              return (
-                <button
-                  key={r.id}
-                  onClick={() => toggleRoutineCompletion(r.id)}
-                  className={`rounded-full px-2.5 py-1 text-xs font-medium ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${done ? 'line-through opacity-50' : 'active:opacity-70'} transition-opacity`}
-                >
-                  {timeLabel && <span className="opacity-70 mr-1">{timeLabel}</span>}{r.name}
-                </button>
-              );
-            })}
-          </div>
-        )}
+            }
+            return (
+              <button
+                key={r.id}
+                onClick={() => toggleRoutineCompletion(r.id)}
+                className={`rounded-full px-2.5 py-1 text-xs font-medium ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${done ? 'line-through opacity-50' : 'active:opacity-70'} transition-opacity`}
+              >
+                {timeLabel && <span className="opacity-70 mr-1">{timeLabel}</span>}{r.name}
+              </button>
+            );
+          })}
+        </div>
       </div>
     );
   })()}

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -82,7 +82,7 @@ const MobileGlanceSection = () => {
     eveningGlanceText, eveningGlanceLoading, eveningGlanceDismissed, eveningGlanceError,
     frameNudgeSuggestion, frameNudgeLoading, frameNudgeError,
     frameNudgeDismissedKey, setFrameNudgeDismissedKey,
-    routinesEnabled, todayRoutines, routineCompletions,
+    routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion,
     habitsEnabled,
     activeHabits, habitStreaks,
     habitLongPressId, setHabitLongPressId,
@@ -150,7 +150,7 @@ const MobileGlanceSection = () => {
       <div className="mb-4 relative">
         <button
           onClick={() => { setMobileActiveTab('settings'); setMobileSettingsView('habits'); }}
-          className={`absolute -top-0.5 -right-0.5 p-1 rounded ${hoverBg} ${textSecondary} transition-colors z-10`}
+          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${textSecondary} transition-colors z-10`}
           title="Manage habits"
         >
           <Settings size={11} />
@@ -1032,24 +1032,32 @@ const MobileGlanceSection = () => {
       setMobileSettingsView('routines');
     };
     return (
-      <div className={`mt-3 pt-3 border-t ${borderClass} cursor-pointer`} onClick={openRoutinesSettings}>
+      <div className={`relative mt-3 pt-3 border-t ${borderClass}`}>
+        <button
+          onClick={openRoutinesSettings}
+          className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${textSecondary} transition-colors z-10`}
+          title="Manage routines"
+        >
+          <Settings size={11} />
+        </button>
         <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Routines</div>
         {visibleRoutines.length === 0 ? (
           <div className="flex items-center gap-2">
             <span className={`text-xs ${textSecondary} italic`}>None scheduled</span>
             <button
-              onClick={(e) => { e.stopPropagation(); openRoutinesSettings(); }}
+              onClick={openRoutinesSettings}
               className="text-xs text-teal-500 font-medium"
             >+ Add</button>
           </div>
         ) : (
           <div className="flex flex-wrap gap-1.5">
-            {[...visibleRoutines].sort((a, b) => {
+            {[...realRoutines].sort((a, b) => {
               if (a.isAllDay && !b.isAllDay) return -1;
               if (!a.isAllDay && b.isAllDay) return 1;
               if (a.startTime && b.startTime) return timeToMinutes(a.startTime) - timeToMinutes(b.startTime);
               return 0;
             }).map(r => {
+              const done = !!routineCompletions[r.id];
               let timeLabel = '';
               if (!r.isAllDay && r.startTime) {
                 if (use24HourClock) {
@@ -1062,9 +1070,13 @@ const MobileGlanceSection = () => {
                 }
               }
               return (
-                <span key={r.id} className={`rounded-full px-2.5 py-1 text-xs font-medium ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'}`}>
+                <button
+                  key={r.id}
+                  onClick={() => toggleRoutineCompletion(r.id)}
+                  className={`rounded-full px-2.5 py-1 text-xs font-medium ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${done ? 'line-through opacity-50' : 'active:opacity-70'} transition-opacity`}
+                >
                   {timeLabel && <span className="opacity-70 mr-1">{timeLabel}</span>}{r.name}
-                </span>
+                </button>
               );
             })}
           </div>


### PR DESCRIPTION
## Summary

**Routines (non-empty state in GLANCE):**
- Each chip is now a tappable button that calls `toggleRoutineCompletion` — completed chips show line-through + reduced opacity, matching the timeline pill behavior
- All scheduled routines are shown (not just incomplete ones), so you can see progress as you work through them; the section still vanishes when all are done
- Removed the full-card `onClick`; added a corner gear button (bottom-right) to open the routines dashboard on desktop or settings on mobile

**Habits:**
- Corner gear moved from top-right to bottom-right to avoid overlapping the `+N` overflow marker when ≥6 habits are defined

Empty state for routines is unchanged.

## Test plan

- [x] With routines scheduled: tapping a chip marks it complete (strikethrough + faded); tapping again un-completes it
- [x] Section disappears when all chips are marked done
- [x] Gear button opens routines dashboard (desktop) / navigates to Settings → Routines (mobile)
- [x] With ≥6 habits: gear sits at bottom-right, no overlap with +N button

https://claude.ai/code/session_013k2rJ448A4YHUkPEta6kL6