### PR TITLE
Bump version to 2.4.8

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 39
-        versionName = "2.4"
+        versionCode = 40
+        versionName = "2.4.8"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "dependencies": {
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "2.4.7",
+  "version": "2.4.8",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Marks the v2.4.8 release following the habits/routines GLANCE polish (PR #441) and sync bugfixes (PR #440).

Changes included in this release:
- Tappable routine chips in GLANCE (strikethrough on completion)
- Gear icons repositioned to bottom-right corner (habits + routines)
- `routineCompletions` sync fix in `mergeSync.js`
- `applyRemoteData` date guard preventing premature routine clear
- All-day routine pills show strikethrough when completed (desktop + mobile)

v2.5.0 is reserved for the hyperGLANCE launch.

https://claude.ai/code/session_013k2rJ448A4YHUkPEta6kL6