### PR TITLE
Fix routine completions not syncing across devices

### DIFF
--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -441,8 +441,14 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
   const habitsMerge = mergeHabits(localData.habits || [], remoteData.habits || [], localDeletedHabitIds, remoteDeletedHabitIds);
   const habitLogsMerge = mergeHabitLogs(localData.habitLogs || {}, remoteData.habitLogs || {});
 
-  let localChanged = tasksMerge.localChanged || unschedMerge.localChanged || binMerge.localChanged || recurMerge.localChanged || routineMerge.localChanged || todayRoutinesMerge.localChanged || dailyNotesMerge.localChanged || habitsMerge.localChanged || habitLogsMerge.localChanged;
-  let remoteChanged = tasksMerge.remoteChanged || unschedMerge.remoteChanged || binMerge.remoteChanged || recurMerge.remoteChanged || routineMerge.remoteChanged || todayRoutinesMerge.remoteChanged || dailyNotesMerge.remoteChanged || habitsMerge.remoteChanged || habitLogsMerge.remoteChanged;
+  // Detect routine completion changes: did the merge add completions that one side was missing?
+  const localCompletionsFiltered = Object.fromEntries(Object.entries(localCompletions).filter(([, d]) => d === mergedRoutinesDate));
+  const remoteCompletionsFiltered = Object.fromEntries(Object.entries(remoteCompletions).filter(([, d]) => d === mergedRoutinesDate));
+  const completionsLocalChanged = Object.keys(mergedCompletions).some(id => !(id in localCompletionsFiltered));
+  const completionsRemoteChanged = Object.keys(mergedCompletions).some(id => !(id in remoteCompletionsFiltered));
+
+  let localChanged = tasksMerge.localChanged || unschedMerge.localChanged || binMerge.localChanged || recurMerge.localChanged || routineMerge.localChanged || todayRoutinesMerge.localChanged || dailyNotesMerge.localChanged || habitsMerge.localChanged || habitLogsMerge.localChanged || completionsLocalChanged;
+  let remoteChanged = tasksMerge.remoteChanged || unschedMerge.remoteChanged || binMerge.remoteChanged || recurMerge.remoteChanged || routineMerge.remoteChanged || todayRoutinesMerge.remoteChanged || dailyNotesMerge.remoteChanged || habitsMerge.remoteChanged || habitLogsMerge.remoteChanged || completionsRemoteChanged;
 
   // Reconcile cross-list conflicts: task active on one device, in recycle bin on other
   const recycledMap = new Map(binMerge.merged.map(t => [String(t.id), t]));


### PR DESCRIPTION
## Summary

`routineCompletions` was correctly union-merged in `mergeSyncData`, but the result was never applied on the receiving device when **only completions changed** — because `localChanged`/`remoteChanged` didn't account for them.

Adds two flags to the merge:
- `completionsLocalChanged` — true when the merged union contains entries the local side was missing → triggers `applyRemoteData` → `setRoutineCompletions` on the receiving device
- `completionsRemoteChanged` — true when the merged union contains entries the remote side was missing → triggers a direct upload from `cloudSyncDownload`, even if the debounced upload effect was suppressed at the time of the toggle

## Fixes

- Routine chip completions (GLANCE) not propagating to phone after desktop marks them done
- All-day routine pill completions (`CalendarHeader` / `MobileAllDaySection`) not syncing — they also use `toggleRoutineCompletion`

## Test plan

- [x] Mark a routine complete on desktop via GLANCE chip; within ~60s the phone should show it as strikethrough
- [x] Mark a routine complete via the all-day pill on desktop; phone should sync the same strikethrough
- [x] Mark a routine complete on phone; desktop should reflect it on next sync

https://claude.ai/code/session_013k2rJ448A4YHUkPEta6kL6