### PR TITLE
Restore one-by-one routine drop-off in GLANCE

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -1109,7 +1109,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
         </button>
         <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Routines</div>
         <div className={`flex flex-wrap ${isDesktop ? "gap-1" : "gap-1.5"}`}>
-          {[...realRoutines].sort((a, b) => {
+          {[...visibleRoutines].sort((a, b) => {
             if (a.isAllDay && !b.isAllDay) return -1;
             if (!a.isAllDay && b.isAllDay) return 1;
             if (a.startTime && b.startTime) return timeToMinutes(a.startTime) - timeToMinutes(b.startTime);

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -1053,7 +1053,7 @@ const MobileGlanceSection = () => {
         </button>
         <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Routines</div>
         <div className="flex flex-wrap gap-1.5">
-          {[...realRoutines].sort((a, b) => {
+          {[...visibleRoutines].sort((a, b) => {
             if (a.isAllDay && !b.isAllDay) return -1;
             if (!a.isAllDay && b.isAllDay) return 1;
             if (a.startTime && b.startTime) return timeToMinutes(a.startTime) - timeToMinutes(b.startTime);


### PR DESCRIPTION
## Summary

Restores the original behavior where completed routines fall off the GLANCE chip list immediately when tapped, rather than staying with strikethrough until all are done.

PR #441 inadvertently changed the chip loop from `visibleRoutines` (incomplete only) to `realRoutines` (all). This reverts that to `visibleRoutines` in both `GlanceSidebar.jsx` (desktop/tablet) and `MobileGlanceSection.jsx` (mobile). The section still disappears entirely when the last routine is marked done.

## Test plan

- [x] Tap a routine chip in GLANCE — it should disappear from the list immediately
- [x] Tap the last remaining chip — the entire section should disappear
- [x] Completed routines still show strikethrough in the timeline all-day area

https://claude.ai/code/session_013k2rJ448A4YHUkPEta6kL6