### PR TITLE
Fix Generic WebDAV test returning 400 on Apache/bare WebDAV servers

### DIFF
--- a/src/utils/cloudSyncProviders.js
+++ b/src/utils/cloudSyncProviders.js
@@ -204,12 +204,16 @@ export const cloudSyncProviders = {
       return parsed;
     },
     async test(config) {
-      const dirUrl = this.getDirUrl(config);
+      // GET the sync file rather than PROPFIND — Apache mod_dav and other strict
+      // servers return 400 for a bodyless PROPFIND (RFC 4918 requires XML body).
+      // 404 = server reachable but no sync file yet (expected on first use).
+      // 200 = file already exists. Both mean credentials and URL are good.
+      const fileUrl = this.getFileUrl(config);
       const authHeaders = this.getAuthHeaders(config);
-      const res = await webdavFetch('PROPFIND', dirUrl, authHeaders, undefined, { 'Depth': '0' });
-      if (res.status === 200 || res.status === 207 || res.status === 404) return { success: true };
+      const res = await webdavFetch('GET', fileUrl, authHeaders);
+      if (res.status === 200 || res.status === 404) return { success: true };
       if (res.status === 401) return { success: false, error: 'Invalid credentials. Check your username and password.' };
-      if (res.status === 403) return { success: false, error: 'Access forbidden (403). If using a self-hosted server, it may be blocking requests from Vercel\'s IP addresses.' };
+      if (res.status === 403) return { success: false, error: 'Access forbidden (403). Check that the WebDAV URL and path are correct.' };
       return { success: false, error: `Unexpected response: ${res.status}${res.statusText ? ' ' + res.statusText : ''}` };
     },
     configFields: [


### PR DESCRIPTION
## Summary

Apache's `mod_dav` (and other strict WebDAV servers like the `bytemark/webdav` Docker image) return **400 Bad Request** for a `PROPFIND` with no body. RFC 4918 requires an XML payload for `PROPFIND`; Nextcloud is lenient about this, but bare WebDAV servers are not.

Switches the Generic WebDAV "Test Connection" check from `PROPFIND` to `GET` on the sync file URL:
- `404` = server reachable, no sync file yet (expected on first use) → success
- `200` = file exists → success  
- `401` = bad credentials → clear error message
- `403` = path inaccessible → clear error message

## Test plan

- [x] With a local WebDAV container (e.g. `bytemark/webdav`), Test Connection should now return success instead of "Unexpected response: 400"
- [x] Wrong credentials should still show the 401 error message

https://claude.ai/code/session_013k2rJ448A4YHUkPEta6kL6