### PR TITLE
Fix WebDAV proxy caching stale sync file

### DIFF
--- a/api/webdav-proxy.js
+++ b/api/webdav-proxy.js
@@ -127,6 +127,7 @@ export default async function handler(req, res) {
     const body = await response.text();
 
     res.setHeader('Content-Type', response.headers.get('content-type') || 'text/plain');
+    res.setHeader('Cache-Control', 'no-store');
     res.status(response.status).send(body);
   } catch (err) {
     res.status(502).json({ error: 'Failed to proxy WebDAV request' });


### PR DESCRIPTION
## Summary

Without `Cache-Control: no-store`, the browser caches the WebDAV proxy GET response. When another device uploads changes, the desktop still reads the old cached version on its next download — then overwrites the server with stale data, breaking sync in the phone→desktop direction.

## Test plan

- [x] Make a change on Android, force sync
- [x] Refresh desktop — change should now appear

https://claude.ai/code/session_013k2rJ448A4YHUkPEta6kL6