### PR TITLE
Fix task completion status not syncing across devices

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4656,12 +4656,12 @@ const DayPlanner = () => {
           }
           case 'complete': {
             const setter = isInbox ? setUnscheduledTasks : setTasks;
-            setter(prev => prev.map(t => t.id === id ? { ...t, completed: true } : t));
+            setter(prev => prev.map(t => t.id === id ? { ...t, completed: true, lastModified: new Date().toISOString() } : t));
             break;
           }
           case 'uncomplete': {
             const setter = isInbox ? setUnscheduledTasks : setTasks;
-            setter(prev => prev.map(t => t.id === id ? { ...t, completed: false } : t));
+            setter(prev => prev.map(t => t.id === id ? { ...t, completed: false, lastModified: new Date().toISOString() } : t));
             break;
           }
           case 'changePriority': {


### PR DESCRIPTION
## Summary

Completing or uncompleting a task didn't update `lastModified`. The merge logic in `mergeTaskArrays` uses timestamps to determine which version of a task wins — equal timestamps keep local state, so the completion was never treated as a change and never propagated to other devices.

Fix: stamp `lastModified` when completing or uncompleting a task, both for scheduled tasks and inbox tasks.

## Test plan

- [x] Complete an all-day task on desktop, sync — should show as completed on phone
- [x] Uncomplete a task on phone, sync — should show as uncompleted on desktop

https://claude.ai/code/session_013k2rJ448A4YHUkPEta6kL6