### PR TITLE
Fix setRoutineCompletions ReferenceError on cloud sync download

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -521,7 +521,7 @@ const DayPlanner = () => {
     routineFocusedChipId, setRoutineFocusedChipId,
     routineDurationEditId, setRoutineDurationEditId,
     routinesEnabled, setRoutinesEnabled,
-    routineCompletions, toggleRoutineCompletion,
+    routineCompletions, setRoutineCompletions, toggleRoutineCompletion,
     openRoutinesDashboard,
     addRoutineChip,
     deleteRoutineChip,
@@ -6965,7 +6965,7 @@ const DayPlanner = () => {
     routineFocusedChipId, setRoutineFocusedChipId,
     routineDurationEditId, setRoutineDurationEditId,
     routinesEnabled, setRoutinesEnabled,
-    routineCompletions, toggleRoutineCompletion,
+    routineCompletions, setRoutineCompletions, toggleRoutineCompletion,
 
     // ── Habits ────────────────────────────────────────────────────────────────
     habits, setHabits,

--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -181,7 +181,7 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress })
     routineFocusedChipId, setRoutineFocusedChipId,
     routineDurationEditId, setRoutineDurationEditId,
     routinesEnabled, setRoutinesEnabled,
-    routineCompletions,
+    routineCompletions, setRoutineCompletions,
     toggleRoutineCompletion,
     openRoutinesDashboard,
     addRoutineChip,


### PR DESCRIPTION
## Summary

`setRoutineCompletions` was called in `applyRemoteData` (added in PR #444) but was never exported from `useRoutines`, added to the context value, or destructured in App.jsx — causing a `ReferenceError` on every cloud sync download and breaking routine completion sync entirely.

Fixes all three places: hook return, context value, and destructuring.

## Test plan

- [x] Cloud sync download no longer throws `ReferenceError: setRoutineCompletions is not defined`
- [x] Routine completions sync correctly across devices

https://claude.ai/code/session_013k2rJ448A4YHUkPEta6kL6