### PR TITLE
Bump Android versionCode to 43

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 42
+        versionCode = 43
         versionName = "2.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

Increments Android `versionCode` from `42` to `43`. `versionName` stays `"2.4"`.

The versionCode 42 APK was built from `develop` instead of `main`, so it included unreleased hyperGLANCE code. Play Store won't accept a replacement with the same versionCode, so this bump allows resubmission of the correct v2.4.10 build.

https://claude.ai/code/session_013k2rJ448A4YHUkPEta6kL6