### PR TITLE
Tockify/webcal sync + GLANCEahead navigation + habit tracker rename + Obsidian folder fix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -881,7 +881,7 @@ const DayPlanner = () => {
     goals, projects, goalsProjectsEnabled,
   });
 
-  const { timelineScrolledAway, setTimelineScrolledAway, scrollToCurrentHour } = useTimelineScroll({
+  const { timelineScrolledAway, setTimelineScrolledAway, scrollToCurrentHour, scrollToHour } = useTimelineScroll({
     calendarRef, timeGridRef,
     selectedDate,
     isMobile, isTablet,
@@ -1852,7 +1852,7 @@ const DayPlanner = () => {
       return;
     }
     try {
-      await writeWikiNote(handle, notePath, content, obsidianConfig?.newNotesFolder || '');
+      await writeWikiNote(handle, notePath, content, obsidianConfig?.newNotesFolder ?? 'dayGLANCE');
     } catch (err) {
       console.error('Failed to write wiki note:', err);
     }
@@ -6809,7 +6809,7 @@ const DayPlanner = () => {
 
     // ── Functions – navigation ────────────────────────────────────────────────
     changeDate, goToToday, goToDate, changeViewedMonth,
-    scrollToCurrentHour,
+    scrollToCurrentHour, scrollToHour,
 
     // ── Functions – task CRUD ─────────────────────────────────────────────────
     addTask, toggleComplete,
@@ -7838,7 +7838,7 @@ const DayPlanner = () => {
                   >
                     <div className="flex items-center gap-2">
                       <Flame size={18} className="text-orange-500" />
-                      <span className={`font-semibold ${textPrimary}`}>Habit Streaks</span>
+                      <span className={`font-semibold ${textPrimary}`}>Habit Tracker</span>
                     </div>
                     {desktopStatsHabitsCollapsed ? <ChevronDown size={16} className={textSecondary} /> : <ChevronUp size={16} className={textSecondary} />}
                   </button>

--- a/src/components/DesktopWelcomeModal.jsx
+++ b/src/components/DesktopWelcomeModal.jsx
@@ -194,7 +194,7 @@ const DesktopWelcomeModal = () => {
                   <span className="w-8 h-8 bg-rose-100 dark:bg-rose-900 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
                     <Target size={16} className="text-rose-500" />
                   </span>
-                  <span><strong className={textPrimary}>Habits</strong> — track daily habits with streaks and visual progress rings</span>
+                  <span><strong className={textPrimary}>Habits</strong> — track daily habits with visual progress rings and history</span>
                 </div>
                 <div className="flex items-start gap-3">
                   <span className="w-8 h-8 bg-amber-100 dark:bg-amber-900 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -63,6 +63,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     moveToRecycleBin,
     setInboxProjectFilter, setInboxPriorityFilter, setHideCompletedInbox,
     setHideProjectTasksInbox, setHideStandaloneTasksInbox,
+    goToDate, scrollToHour,
   } = useDayPlannerCtx();
   const {
     habitLongPressTimer,
@@ -1044,8 +1045,19 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     const committedH = Math.floor(committedMinutes / 60);
     const committedM = committedMinutes % 60;
     const committedStr = committedH > 0 ? `${committedH}h${committedM > 0 ? ` ${committedM}m` : ''}` : committedM > 0 ? `${committedM}m` : null;
+    const handleGlanceAheadClick = () => {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      goToDate(tomorrow);
+      if (firstStartTime) {
+        setTimeout(() => scrollToHour(firstStartTime), 150);
+      }
+    };
     return (
-      <div className={isDesktop ? `rounded-lg border ${borderClass} p-3` : `mt-3 pt-3 border-t ${borderClass}`}>
+      <div
+        className={`${isDesktop ? `rounded-lg border ${borderClass} p-3` : `mt-3 pt-3 border-t ${borderClass}`} cursor-pointer ${isDesktop ? 'hover:opacity-80' : 'active:opacity-70'} transition-opacity`}
+        onClick={handleGlanceAheadClick}
+      >
         <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>
           <span className="flex items-center gap-1.5">
             <span><span className="italic">GLANCE</span><span className="normal-case not-italic">ahead</span></span>

--- a/src/components/MobileBottomSheets.jsx
+++ b/src/components/MobileBottomSheets.jsx
@@ -356,7 +356,7 @@ const MobileBottomSheets = () => {
             >
               <div className="flex items-center gap-2">
                 <Flame size={18} className="text-orange-500" />
-                <span className={`font-semibold ${textPrimary}`}>Habit Streaks</span>
+                <span className={`font-semibold ${textPrimary}`}>Habit Tracker</span>
               </div>
               {dailyStatsHabitsCollapsed ? <ChevronDown size={16} className={textSecondary} /> : <ChevronUp size={16} className={textSecondary} />}
             </button>

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -68,6 +68,7 @@ const MobileGlanceSection = () => {
     moveToRecycleBin,
     updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
     tagFilterBtnRef,
+    goToDate, scrollToHour,
   } = useDayPlannerCtx();
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
   const {
@@ -982,8 +983,17 @@ const MobileGlanceSection = () => {
     const committedH = Math.floor(committedMinutes / 60);
     const committedM = committedMinutes % 60;
     const committedStr = committedH > 0 ? `${committedH}h${committedM > 0 ? ` ${committedM}m` : ''}` : committedM > 0 ? `${committedM}m` : null;
+    const handleGlanceAheadClick = () => {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      setMobileActiveTab('timeline');
+      goToDate(tomorrow);
+      if (firstStartTime) {
+        setTimeout(() => scrollToHour(firstStartTime), 150);
+      }
+    };
     return (
-      <div className={`mt-3 pt-3 border-t ${borderClass}`}>
+      <div className={`mt-3 pt-3 border-t ${borderClass} cursor-pointer active:opacity-70 transition-opacity`} onClick={handleGlanceAheadClick}>
         <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>
           <span className="flex items-center gap-1.5">
             <span><span className="italic">GLANCE</span><span className="normal-case not-italic">ahead</span></span>

--- a/src/components/MobileWelcomeModal.jsx
+++ b/src/components/MobileWelcomeModal.jsx
@@ -102,7 +102,7 @@ const MobileWelcomeModal = () => {
                 <span className="w-8 h-8 bg-rose-100 dark:bg-rose-900 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
                   <Target size={16} className="text-rose-500" />
                 </span>
-                <span><strong className={textPrimary}>Habits</strong> — track daily habits with streaks and visual progress rings</span>
+                <span><strong className={textPrimary}>Habits</strong> — track daily habits with visual progress rings and history</span>
               </div>
               <div className="flex items-start gap-3">
                 <span className="w-8 h-8 bg-amber-100 dark:bg-amber-900 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -389,7 +389,7 @@ const SettingsModal = () => {
                           type="url"
                           placeholder="https://nextcloud.example.com/remote.php/dav/calendars/user/calendar-name/?export"
                           value={syncUrl}
-                          onChange={(e) => setSyncUrl(e.target.value)}
+                          onChange={(e) => setSyncUrl(e.target.value.replace(/^webcal:\/\//i, 'https://'))}
                           className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
                         />
                         <p className={`text-xs ${textSecondary} mt-1`}>
@@ -440,7 +440,7 @@ const SettingsModal = () => {
                           type="url"
                           placeholder="https://nextcloud.example.com/remote.php/dav/calendars/user/tasks/?export"
                           value={taskCalendarUrl}
-                          onChange={(e) => setTaskCalendarUrl(e.target.value)}
+                          onChange={(e) => setTaskCalendarUrl(e.target.value.replace(/^webcal:\/\//i, 'https://'))}
                           className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
                         />
                         <p className={`text-xs ${textSecondary} mt-1`}>

--- a/src/hooks/useTimelineScroll.js
+++ b/src/hooks/useTimelineScroll.js
@@ -28,6 +28,20 @@ export default function useTimelineScroll({
     }
   }, []);
 
+  // Scroll timeline to a specific time string (e.g. "08:00")
+  const scrollToHour = useCallback((timeStr, smooth = false) => {
+    const [h, m] = timeStr.split(':').map(Number);
+    const hourHeight = timeGridRef.current?.children?.[1]?.offsetHeight || 161;
+    const scrollPosition = Math.max(0, (h + m / 60) * hourHeight);
+    if (calendarRef.current) {
+      if (smooth) {
+        calendarRef.current.scrollTo({ top: scrollPosition, behavior: 'smooth' });
+      } else {
+        calendarRef.current.scrollTop = scrollPosition;
+      }
+    }
+  }, []);
+
   useEffect(() => {
     const isToday = dateToString(selectedDate) === dateToString(new Date());
     if (isToday && calendarRef.current && (!isMobile || mobileActiveTab === 'timeline')) {
@@ -89,5 +103,5 @@ export default function useTimelineScroll({
     };
   }, [isMobile, selectedDate, scrollToCurrentHour]);
 
-  return { timelineScrolledAway, setTimelineScrolledAway, scrollToCurrentHour };
+  return { timelineScrolledAway, setTimelineScrolledAway, scrollToCurrentHour, scrollToHour };
 }


### PR DESCRIPTION
## Summary

- **webcal:// support**: Calendar URL inputs now auto-convert `webcal://` → `https://` on paste/type, so Tockify (and other services) subscription links work without manual editing. Applies to both Calendar URL and Task Calendar URL fields.
- **GLANCEahead navigation**: Clicking/tapping the GLANCEahead section navigates to tomorrow's date and scrolls the timeline to the first scheduled task's start time. On mobile, also switches to the timeline tab. Adds a `scrollToHour(timeStr)` helper to `useTimelineScroll`.
- **Habit Tracker rename**: "Habit Streaks" section header renamed to "Habit Tracker" in the daily stats panel (desktop + mobile) and welcome modals.
- **Obsidian new-note folder fix**: Fixed a bug where notes created from dayGLANCE landed in the vault root instead of the configured folder. The issue was `||` treating `undefined` the same as `''` — changed to `??` so only `null`/`undefined` falls back to `'dayGLANCE'`, while an explicit empty string still means vault root.

## Test plan

- [x] Paste a `webcal://` URL into Settings → Calendar URL — should silently rewrite to `https://`
- [x] When GLANCEahead is visible (evening or day done), tap it — should jump to tomorrow's timeline scrolled to the first task time
- [x] Verify "Habit Tracker" label appears in daily stats panel and on mobile
- [x] Create a new note from dayGLANCE with a fresh/old Obsidian config (no `newNotesFolder` key) — should land in `dayGLANCE/` folder, not vault root

https://claude.ai/code/session_01TmkeuP5vAkesjoPbTmjwCS