### PR TITLE
Add hyperGLANCE sessions to Android home screen widget

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidgetListFactory.kt
@@ -46,6 +46,7 @@ class DayGlanceWidgetListFactory(
         const val TYPE_EMPTY = 5
         const val TYPE_GLANCEAHEAD = 6
         const val TYPE_GOAL = 7
+        const val TYPE_HYPERGLANCE = 8
 
         private val TWELVE_HR = DateTimeFormatter.ofPattern("h:mm a")
         private val TWELVE_HR_SHORT = DateTimeFormatter.ofPattern("h:mm")
@@ -87,6 +88,13 @@ class DayGlanceWidgetListFactory(
             val totalTasks: Int,
             val completedTasks: Int,
         ) : AgendaItem(TYPE_GOAL)
+        class HyperGLANCE(
+            val title: String,
+            val colorHex: String,
+            val startTime: String,
+            val duration: Int,
+            val isOverdue: Boolean,
+        ) : AgendaItem(TYPE_HYPERGLANCE)
     }
 
     data class HabitData(
@@ -118,7 +126,7 @@ class DayGlanceWidgetListFactory(
     override fun onDestroy() { items.clear() }
 
     override fun getCount(): Int = items.size.coerceAtLeast(1)
-    override fun getViewTypeCount(): Int = 8
+    override fun getViewTypeCount(): Int = 9
     override fun getItemId(position: Int): Long = position.toLong()
     override fun hasStableIds(): Boolean = false
     override fun getLoadingView(): RemoteViews? = null
@@ -159,6 +167,22 @@ class DayGlanceWidgetListFactory(
                     progressPct = g.optInt("progressPct", 0).coerceIn(0, 100),
                     totalTasks = g.optInt("totalTasks", 0),
                     completedTasks = g.optInt("completedTasks", 0),
+                )
+            }
+        }
+
+        // 1.75 hyperGLANCE sessions — today's + overdue project sessions
+        val hyperGlanceArray = snapshot.optJSONArray("hyperGlance")
+        if (hyperGlanceArray != null && hyperGlanceArray.length() > 0) {
+            items += AgendaItem.Section("hyperGLANCE")
+            for (i in 0 until hyperGlanceArray.length()) {
+                val hg = hyperGlanceArray.optJSONObject(i) ?: continue
+                items += AgendaItem.HyperGLANCE(
+                    title = hg.optString("title", "Untitled"),
+                    colorHex = hg.optString("colorHex", "#4f46e5"),
+                    startTime = hg.optString("startTime", ""),
+                    duration = hg.optInt("duration", 60),
+                    isOverdue = hg.optBoolean("isOverdue", false),
                 )
             }
         }
@@ -420,6 +444,7 @@ class DayGlanceWidgetListFactory(
         is AgendaItem.RoutineGroup -> buildRoutineGroupView(item)
         is AgendaItem.GlanceAhead -> buildGlanceAheadView(item)
         is AgendaItem.Goal -> buildGoalView(item)
+        is AgendaItem.HyperGLANCE -> buildHyperGLANCEView(item)
         AgendaItem.Empty -> buildEmptyView()
     }
 
@@ -480,6 +505,41 @@ class DayGlanceWidgetListFactory(
         rv.boostTextSizeForOneUi(R.id.tv_goal_badge, 11f)
         rv.boostTextSizeForOneUi(R.id.tv_goal_stats, 11f)
         rv.setOnClickFillInIntent(R.id.goal_item_root, android.content.Intent())
+        return rv
+    }
+
+    private fun buildHyperGLANCEView(item: AgendaItem.HyperGLANCE): RemoteViews {
+        val rv = RemoteViews(context.packageName, R.layout.widget_item_hyperglance)
+        rv.setTextViewText(R.id.tv_hg_title, item.title)
+        val color = safeParseColor(item.colorHex, "#4f46e5")
+        rv.setInt(R.id.hg_color_bar, "setBackgroundColor", color)
+
+        // Time range
+        if (item.startTime.isNotEmpty() && item.duration > 0) {
+            try {
+                val parts = item.startTime.split(":").map { it.toInt() }
+                val startMin = parts[0] * 60 + (parts.getOrNull(1) ?: 0)
+                val endMin = startMin + item.duration
+                val s = LocalTime.of(parts[0], parts.getOrNull(1) ?: 0)
+                val e = LocalTime.of(endMin / 60 % 24, endMin % 60)
+                val fmt = if (use24Hour) TWENTY_FOUR_HR else TWELVE_HR
+                val fmtShort = if (use24Hour) TWENTY_FOUR_HR else TWELVE_HR_SHORT
+                rv.setTextViewText(R.id.tv_hg_time, "${s.format(fmtShort)} – ${e.format(fmt)}")
+                rv.setViewVisibility(R.id.tv_hg_time, View.VISIBLE)
+            } catch (_: Throwable) {
+                rv.setViewVisibility(R.id.tv_hg_time, View.GONE)
+            }
+        } else {
+            rv.setViewVisibility(R.id.tv_hg_time, View.GONE)
+        }
+
+        // Overdue badge
+        rv.setViewVisibility(R.id.tv_hg_badge, if (item.isOverdue) View.VISIBLE else View.GONE)
+
+        rv.boostTextSizeForOneUi(R.id.tv_hg_title, 13f)
+        rv.boostTextSizeForOneUi(R.id.tv_hg_time, 11f)
+        rv.boostTextSizeForOneUi(R.id.tv_hg_badge, 11f)
+        rv.setOnClickFillInIntent(R.id.hg_item_root, android.content.Intent())
         return rv
     }
 

--- a/dayglance-android/app/src/main/res/layout/widget_item_hyperglance.xml
+++ b/dayglance-android/app/src/main/res/layout/widget_item_hyperglance.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Widget list item: a hyperGLANCE session (today's or overdue).
+
+  Structure:
+    [project color bar 3dp] [Project Title — flex]      [OVERDUE badge (amber, if overdue)]
+                            [start – end time range]
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/hg_item_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp"
+    android:paddingStart="0dp"
+    android:paddingEnd="0dp">
+
+    <!-- Project color bar — must be TextView, not View; <View> is not in the RemoteViews supported subset -->
+    <TextView
+        android:id="@+id/hg_color_bar"
+        android:layout_width="3dp"
+        android:layout_height="36dp"
+        android:background="#4f46e5"
+        android:layout_marginEnd="7dp"
+        android:text="" />
+
+    <!-- Text content: title + time range -->
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tv_hg_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Project title"
+            android:textColor="@color/widget_text_primary"
+            android:textSize="13sp"
+            android:textStyle="bold"
+            android:maxLines="1"
+            android:ellipsize="end" />
+
+        <TextView
+            android:id="@+id/tv_hg_time"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="9:00 – 10:00"
+            android:textColor="@color/widget_text_secondary"
+            android:textSize="11sp"
+            android:visibility="gone" />
+
+    </LinearLayout>
+
+    <!-- Overdue badge — amber, hidden when not overdue -->
+    <TextView
+        android:id="@+id/tv_hg_badge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="OVERDUE"
+        android:textColor="#f59e0b"
+        android:textSize="11sp"
+        android:textStyle="bold"
+        android:letterSpacing="0.06"
+        android:layout_marginStart="4dp"
+        android:visibility="gone" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary

- Adds a new `widget_item_hyperglance.xml` layout: project color bar (3dp, project color) + bold title + time range + amber OVERDUE badge
- `DayGlanceWidgetListFactory`: adds `TYPE_HYPERGLANCE = 8`, `AgendaItem.HyperGLANCE` data class, bumps `getViewTypeCount` to 9, parses `snapshot.hyperGlance` array in `buildItems()` (inserted between Goals and Overdue sections, with a "hyperGLANCE" section header), routes to new `buildHyperGLANCEView()` in `buildView()`
- `buildHyperGLANCEView()` renders the color bar at the project hex color, shows start–end time range (respects 12/24hr preference), and shows the amber OVERDUE badge when `isOverdue = true`

This is the Kotlin-side complement to the JS snapshot change already on `develop` (commit `d7a01d0`).

## Test plan

- [x] Build and install the Android app on a device/emulator
- [x] Add a hyperGLANCE project with today's session and confirm it appears in the widget under a "hyperGLANCE" section header with the correct color bar and time range
- [x] Advance the clock past a session's end time and confirm the OVERDUE badge appears in amber
- [x] Confirm projects without hyperGLANCE enabled do not appear
- [x] Verify 12hr and 24hr time format both display correctly

https://claude.ai/code/session_01Uzyci86aSuheAuSPXrHaRY