### PR TITLE
Hide trash FAB when dragging a routine on mobile

### DIFF
--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -159,6 +159,7 @@ const MobileLayout = () => {
     hoverPreviewDate, setHoverPreviewDate,
     isResizing, setIsResizing,
     mobileDragTaskIdState, setMobileDragTaskIdState,
+    mobileDragIsRoutine,
     mobileDragPreviewTime, setMobileDragPreviewTime,
     mobileDragPreviewDate, setMobileDragPreviewDate,
     mobileDragOverTrash,
@@ -1183,8 +1184,8 @@ const MobileLayout = () => {
             </>
           )}
 
-          {/* Trash FAB — visible during mobile long-press drag */}
-          {mobileDragTaskIdState !== null && (
+          {/* Trash FAB — visible during mobile long-press drag, hidden for routines */}
+          {mobileDragTaskIdState !== null && !mobileDragIsRoutine && (
             <div
               ref={trashFabRef}
               className={`fixed left-4 z-50 w-16 h-16 rounded-full shadow-xl flex items-center justify-center transition-all duration-150 ${mobileDragOverTrash ? 'bg-red-600 scale-110' : 'bg-red-500'}`}

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -60,6 +60,7 @@ export default function useDragDrop({
   const [mobileDragPreviewTime, setMobileDragPreviewTime] = useState(null);
   const [mobileDragPreviewDate, setMobileDragPreviewDate] = useState(null);
   const [mobileDragTaskIdState, setMobileDragTaskIdState] = useState(null);
+  const [mobileDragIsRoutine, setMobileDragIsRoutine] = useState(false);
   const [mobileDragOverTrash, setMobileDragOverTrash] = useState(false);
 
   const autoScrollInterval = useRef(null); // For drag auto-scroll
@@ -1101,6 +1102,7 @@ export default function useDragDrop({
       mobileDragTimer.current = setTimeout(() => {
         mobileDragActive.current = true;
         setMobileDragTaskIdState(task.id);
+        setMobileDragIsRoutine(!!task.isRoutineDrag);
         // Capture initial scroll position and finger position for delta-based drag
         if (calendarRef.current) {
           mobileDragStartScrollTop.current = calendarRef.current.scrollTop;
@@ -1238,6 +1240,7 @@ export default function useDragDrop({
       setMobileDragPreviewTime(null);
       setMobileDragPreviewDate(null);
       setMobileDragTaskIdState(null);
+      setMobileDragIsRoutine(false);
       setMobileDragOverTrash(false);
       return;
     }
@@ -1388,6 +1391,7 @@ export default function useDragDrop({
     setMobileDragPreviewTime(null);
     setMobileDragPreviewDate(null);
     setMobileDragTaskIdState(null);
+    setMobileDragIsRoutine(false);
     setMobileDragOverTrash(false);
   };
 
@@ -1583,6 +1587,7 @@ export default function useDragDrop({
     mobileDragPreviewTime, setMobileDragPreviewTime,
     mobileDragPreviewDate, setMobileDragPreviewDate,
     mobileDragTaskIdState, setMobileDragTaskIdState,
+    mobileDragIsRoutine,
     mobileDragOverTrash,
     trashFabRef,
     // mobile swipe refs


### PR DESCRIPTION
## Summary

- Adds `mobileDragIsRoutine` state to `useDragDrop` that is set to `true` when the long-press drag begins on a routine chip (`task.isRoutineDrag === true`)
- The trash FAB in `MobileLayout` is now suppressed when `mobileDragIsRoutine` is true, matching the existing desktop behaviour (`dragSource !== 'routine'` guard in `DesktopLayout`)
- State is reset to `false` in both drag-end cleanup paths (trash drop and normal drop)

## Test plan

- [x] Long-press drag a routine chip on mobile — trash FAB should **not** appear
- [x] Long-press drag a regular timeline task — trash FAB should still appear as before
- [x] Long-press drag an all-day task — trash FAB should still appear as before
- [x] Drag a routine to completion without the trash FAB interfering

https://claude.ai/code/session_014pEpeBnzaNVKcrgGwiqr2M