### PR TITLE
Fix silent completion sound in hyperGLANCE on Android

### DIFF
--- a/src/components/HyperGlanceModeModal.jsx
+++ b/src/components/HyperGlanceModeModal.jsx
@@ -64,7 +64,6 @@ const HyperGlanceModeModal = () => {
   useEffect(() => {
     if (allDone && !hgCompleted && !hgShowSettings) {
       setHgCompleted(true);
-      playFocusSound('complete');
       completeHyperGlanceSession();
     }
   }, [allDone, hgCompleted, hgShowSettings]);
@@ -134,11 +133,20 @@ const HyperGlanceModeModal = () => {
   };
 
   const handleToggleTask = (taskId) => {
+    const taskBeingToggled = projectTasks.find(t => t.id === taskId);
     const inScheduled = tasks.find(t => t.id === taskId);
     if (inScheduled) {
       setTasks(prev => prev.map(t => t.id === taskId ? { ...t, completed: !t.completed, lastModified: new Date().toISOString() } : t));
     } else {
       setUnscheduledTasks(prev => prev.map(t => t.id === taskId ? { ...t, completed: !t.completed, lastModified: new Date().toISOString() } : t));
+    }
+    // Play completion sound synchronously in the gesture handler — Android's AudioContext
+    // is often suspended by the time a useEffect fires, so the sound would be silently dropped.
+    if (!taskBeingToggled?.completed) {
+      const remainingIncomplete = projectTasks.filter(t => !t.completed && t.id !== taskId);
+      if (remainingIncomplete.length === 0) {
+        playFocusSound('complete');
+      }
     }
   };
 
@@ -339,7 +347,7 @@ const HyperGlanceModeModal = () => {
               Exit — I'll come back
             </button>
             <button
-              onClick={() => { setHgExitConfirm(false); setHgCompleted(true); completeHyperGlanceSession(); }}
+              onClick={() => { setHgExitConfirm(false); setHgCompleted(true); playFocusSound('complete'); completeHyperGlanceSession(); }}
               className="w-full py-3 rounded-xl text-white font-semibold transition-opacity hover:opacity-90"
               style={{ backgroundColor: barColor }}
             >


### PR DESCRIPTION
## Problem

The completion chord (`playFocusSound('complete')`) was called from a `useEffect` watching the `allDone` computed value. On Android WebView, the `AudioContext` is frequently suspended between render cycles. The existing `resume()` call in `getAudioCtx()` is not awaited, so by the time the oscillators are scheduled against `ctx.currentTime`, the context still hasn't resumed — the audio is silently dropped.

## Fix

Move `playFocusSound('complete')` out of the effect and into the two gesture handlers where Android's audio is guaranteed to be active:

1. **`handleToggleTask`** — when the user checks off the last incomplete task, play the sound immediately in the click handler (before React re-renders)
2. **"End Session" button** — when the user manually ends the session via the exit-confirm dialog

The `useEffect` still handles `setHgCompleted` + `completeHyperGlanceSession` (pure state updates that don't need to be synchronous with the gesture).

## Test plan

- [x] Check off all tasks one by one — completion chord plays when the last one is ticked
- [x] With tasks remaining, open the exit dialog and tap "End Session" — completion chord plays
- [x] Phase transition sounds (work → break → work) still play normally
- [x] Sounds respect the sound-enabled toggle

https://claude.ai/code/session_014pEpeBnzaNVKcrgGwiqr2M