### PR TITLE
Fix trash FAB always visible during routine drag

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6927,6 +6927,7 @@ const DayPlanner = () => {
     hoverPreviewDate, setHoverPreviewDate,
     isResizing, setIsResizing,
     mobileDragTaskIdState, setMobileDragTaskIdState,
+    mobileDragIsRoutine,
     mobileDragPreviewTime, setMobileDragPreviewTime,
     mobileDragPreviewDate, setMobileDragPreviewDate,
     timelineScrolledAway, setTimelineScrolledAway,


### PR DESCRIPTION
## Problem

The previous commit added `mobileDragIsRoutine` to the context value object in App.jsx but never destructured it from the `useDragDrop` return — so it was `undefined` in scope, causing a `ReferenceError` that crashed the app on load.

Additionally, `mobileDragIsRoutine` wasn't tracked as state in `useDragDrop` at all, so even with the destructure fixed the value would always be `undefined`.

## Fix

- Add `mobileDragIsRoutine` state to `useDragDrop`, set to `!!task.isRoutineDrag` on drag start, cleared in both teardown paths
- Return it from the hook and destructure it in App.jsx
- Destructure it in `MobileLayout` and guard the trash FAB: `mobileDragTaskIdState !== null && !mobileDragIsRoutine`