### PR TITLE
Fix Focus Mode exit completely broken

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2900,7 +2900,6 @@ const DayPlanner = () => {
         });
       }
     }
-    setFocusProjectId(null);
     if (showStats) {
       setFocusShowStats(true);
     } else {


### PR DESCRIPTION
## Problem

`exitFocusMode()` called `setFocusProjectId(null)` which doesn't exist anywhere in the codebase — a leftover from a removed feature. This threw a `ReferenceError` that killed the function before it could call `setFocusShowStats(true)` or `setShowFocusMode(false)`, making the X button and task-completion exit both appear to do nothing (the timer would stop but the modal never changed state).

## Fix

Remove the dead `setFocusProjectId(null)` call.