### PR TITLE
Fix ReferenceError crash — mobileDragIsRoutine not in scope

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1718,6 +1718,7 @@ const DayPlanner = () => {
     mobileDragPreviewTime, setMobileDragPreviewTime,
     mobileDragPreviewDate, setMobileDragPreviewDate,
     mobileDragTaskIdState, setMobileDragTaskIdState,
+    mobileDragIsRoutine,
     // mobile swipe refs
     swipeTouchStartX,
     swipeTouchStartY,


### PR DESCRIPTION
## Problem

PR #464 added `mobileDragIsRoutine` to the context value object in App.jsx but never destructured it from the `useDragDrop` return — so it was undefined in scope, causing a `ReferenceError` that crashed the app on load.

## Fix

Destructure `mobileDragIsRoutine` from the `useDragDrop` hook return in App.jsx, completing the chain: hook state → return → App.jsx destructure → context value → MobileLayout guard.