### PR TITLE
Add fullscreen + wake lock to hyperGLANCE on mobile web

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2990,6 +2990,17 @@ const DayPlanner = () => {
     setHgExitConfirm(false);
     setHgShowSettings(true);
     setShowHyperGlanceMode(true);
+    // Request fullscreen (web fallback; Android uses native immersive mode below)
+    try { document.documentElement.requestFullscreen?.(); } catch (e) {}
+    // Request wake lock
+    (async () => {
+      try {
+        if (navigator.wakeLock) {
+          wakeLockSentinel.current = await navigator.wakeLock.request('screen');
+        }
+      } catch (e) {}
+    })();
+    // Android: hide system bars
     nativeSetImmersiveMode(true);
   };
 
@@ -2998,6 +3009,10 @@ const DayPlanner = () => {
     setHgTimerRunning(false);
     setHgExitConfirm(false);
     setShowHyperGlanceMode(false);
+    // Exit fullscreen and release wake lock
+    try { if (document.fullscreenElement) document.exitFullscreen?.(); } catch (e) {}
+    try { wakeLockSentinel.current?.release(); wakeLockSentinel.current = null; } catch (e) {}
+    // Android: restore system bars
     nativeSetImmersiveMode(false);
   };
 


### PR DESCRIPTION
## Problem

`enterFocusMode` calls `requestFullscreen()` and requests a wake lock on web, but `enterHyperGlanceMode` only called `nativeSetImmersiveMode` (Android-only). On mobile web/PWA, hyperGLANCE never went fullscreen.

## Fix

Mirror the Focus Mode pattern in both enter and exit:

- **`enterHyperGlanceMode`**: `requestFullscreen()` + wake lock request (web); `nativeSetImmersiveMode(true)` (Android)
- **`exitHyperGlanceMode`**: `exitFullscreen()` + wake lock release (web); `nativeSetImmersiveMode(false)` (Android)

## Test plan

- [x] On mobile web/PWA: start a hyperGLANCE session — browser goes fullscreen (address bar hides)
- [x] Exit/pause the session — fullscreen is released
- [x] On Android native: immersive mode still works as before
- [x] Focus Mode fullscreen behavior unchanged