### PR TITLE
Focus Mode / hyperGLANCE parity fixes (audit)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback } from 'react';
 import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Moon, Sun, Upload, Inbox, AlertCircle, Calendar, Check, RefreshCw, Palette, Trash2, Undo2, BarChart3, SkipForward, Hash, MoreHorizontal, Save, Menu, BrainCircuit, AlertTriangle, FileText, ExternalLink, CheckSquare, HelpCircle, Sparkles, Link, GripHorizontal, Play, Pause, Trophy, Cloud, Settings, Search, Bell, Target, TrendingUp, Zap, CalendarDays, Ban, Volume2, VolumeX, Pencil, Eye, Filter, Smartphone, CheckCircle, Pin, PinOff, NotebookPen, MapPin, BookOpen, Flag, FolderOpen, Droplets, Footprints, Dumbbell, Apple, Cigarette, Coffee, Flame, Heart, ListChecks, Minus, Wine, Candy, Pill, Activity, CupSoda, Mic, MicOff, Loader, Key, Server, Wifi, WifiOff, LayoutGrid, RotateCcw } from 'lucide-react';
 import { mergeTaskArrays, mergeSyncData } from './mergeSync.js';
-import { isNativeAndroid, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeEnterFocusMode, nativeExitFocusMode, nativeSetImmersiveMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording } from './native.js';
+import { isNativeAndroid, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording } from './native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, tryRestoreVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, listVaultNotes, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
 import { loadAIConfig, saveAIConfig, aiComplete, aiJSON, aiTranscribe, supportsTranscription, testConnection, DEFAULT_CONFIG, PROVIDER_MODELS, PROVIDER_LABELS } from './ai.js';
 import { voiceParseSystemPrompt, voiceParseUserPrompt, taskSuggestSystemPrompt, taskSuggestUserPrompt, frameNudgeSystemPrompt, frameNudgeUserPrompt, rescheduleSystemPrompt, rescheduleUserPrompt, aiSubtasksSystemPrompt, aiSubtasksUserPrompt, morningSummarySystemPrompt, morningSummaryUserPrompt, eveningReflectionSystemPrompt, eveningReflectionUserPrompt, weeklySummarySystemPrompt, weeklySummaryUserPrompt, smartScheduleSystemPrompt, smartScheduleUserPrompt } from './ai-prompts.js';
@@ -2923,6 +2923,23 @@ const DayPlanner = () => {
     setShowFocusMode(false);
   };
 
+  const skipFocusPhase = () => {
+    if (focusPhase === 'work') {
+      const newCycle = focusCycleCount + 1;
+      setFocusCycleCount(newCycle);
+      if (newCycle % 4 === 0) {
+        setFocusPhase('longBreak');
+        setFocusTimerSeconds(focusLongBreakMinutes * 60);
+      } else {
+        setFocusPhase('shortBreak');
+        setFocusTimerSeconds(focusBreakMinutes * 60);
+      }
+    } else {
+      setFocusPhase('work');
+      setFocusTimerSeconds(focusWorkMinutes * 60);
+    }
+  };
+
   const handleFocusTimerEnd = () => {
     if (focusPhase === 'work') {
       // Distribute work minutes across active (non-completed) block tasks
@@ -3001,8 +3018,8 @@ const DayPlanner = () => {
         }
       } catch (e) {}
     })();
-    // Android: hide system bars
-    nativeSetImmersiveMode(true);
+    // Android: immersive mode + pause notifications + DND (same as Focus Mode)
+    nativeEnterFocusMode();
   };
 
   const exitHyperGlanceMode = () => {
@@ -3013,8 +3030,8 @@ const DayPlanner = () => {
     // Exit fullscreen and release wake lock
     try { if (document.fullscreenElement) document.exitFullscreen?.(); } catch (e) {}
     try { wakeLockSentinel.current?.release(); wakeLockSentinel.current = null; } catch (e) {}
-    // Android: restore system bars
-    nativeSetImmersiveMode(false);
+    // Android: restore system bars + DND + reschedule notifications
+    nativeExitFocusMode();
   };
 
   const completeHyperGlanceSession = () => {
@@ -7275,7 +7292,7 @@ const DayPlanner = () => {
     addStepsHabit, addSleepHabit,
 
     // ── Functions – focus mode ────────────────────────────────────────────────
-    enterFocusMode, exitFocusMode,
+    enterFocusMode, exitFocusMode, skipFocusPhase,
     startFocusTimer, dismissFocusStats, handleFocusTimerEnd,
     focusCompleteTask, focusToggleSubtask, focusAddSubtask,
     focusDeleteSubtask, focusUpdateSubtaskTitle, focusUpdateTaskNotes,

--- a/src/components/FocusModeModal.jsx
+++ b/src/components/FocusModeModal.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X, Target, Pause, Play, Check, Trophy } from 'lucide-react';
+import { X, Target, Pause, Play, Check, SkipForward, Trophy } from 'lucide-react';
 import { isNativeAndroid, nativeIsDndPermissionGranted, nativeRequestDndPermission } from '../native.js';
 import { stripWikilinks, extractWikilinks } from '../utils/taskUtils.js';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
@@ -11,7 +11,7 @@ const FocusModeModal = () => {
   const { currentTime, isPhone, isTablet, formatTime, minutesToTime, timeToMinutes } = useDayPlannerCtx();
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
   const {
-    exitFocusMode, startFocusTimer, dismissFocusStats,
+    exitFocusMode, startFocusTimer, dismissFocusStats, skipFocusPhase,
     focusShowSettings, focusShowStats,
     focusWorkMinutes, setFocusWorkMinutes,
     focusBreakMinutes, setFocusBreakMinutes,
@@ -115,13 +115,22 @@ const FocusModeModal = () => {
             {String(Math.floor(focusTimerSeconds / 60)).padStart(2, '0')}:{String(focusTimerSeconds % 60).padStart(2, '0')}
           </div>
 
-          {/* Pause/Resume */}
-          <button
-            onClick={() => setFocusTimerRunning(prev => !prev)}
-            className="w-14 h-14 rounded-full bg-gray-800 hover:bg-gray-700 text-white flex items-center justify-center transition-colors"
-          >
-            {focusTimerRunning ? <Pause size={24} /> : <Play size={24} />}
-          </button>
+          {/* Pause/Resume + Skip phase */}
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => setFocusTimerRunning(prev => !prev)}
+              className="w-14 h-14 rounded-full bg-gray-800 hover:bg-gray-700 text-white flex items-center justify-center transition-colors"
+            >
+              {focusTimerRunning ? <Pause size={24} /> : <Play size={24} />}
+            </button>
+            <button
+              onClick={skipFocusPhase}
+              className="w-9 h-9 rounded-full bg-gray-800 hover:bg-gray-700 flex items-center justify-center text-gray-400 transition-colors"
+              title="Skip phase"
+            >
+              <SkipForward size={16} />
+            </button>
+          </div>
 
           {/* Pomodoro cycle dots */}
           <div className="flex gap-3">

--- a/src/components/HyperGlanceModeModal.jsx
+++ b/src/components/HyperGlanceModeModal.jsx
@@ -6,12 +6,14 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
 import { extractWikilinks, stripWikilinks } from '../utils/taskUtils.js';
+import { isNativeAndroid, nativeIsDndPermissionGranted, nativeRequestDndPermission } from '../native.js';
 
 const HyperGlanceModeModal = () => {
   const {
     currentTime, darkMode, isPhone,
     tasks, setTasks,
     unscheduledTasks, setUnscheduledTasks,
+    toggleComplete,
     updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
     aiSubtasksLoadingForTask,
     generateAISubtasks,
@@ -134,13 +136,11 @@ const HyperGlanceModeModal = () => {
 
   const handleToggleTask = (taskId) => {
     const taskBeingToggled = projectTasks.find(t => t.id === taskId);
-    const inScheduled = tasks.find(t => t.id === taskId);
-    if (inScheduled) {
-      setTasks(prev => prev.map(t => t.id === taskId ? { ...t, completed: !t.completed, lastModified: new Date().toISOString() } : t));
-    } else {
-      setUnscheduledTasks(prev => prev.map(t => t.id === taskId ? { ...t, completed: !t.completed, lastModified: new Date().toISOString() } : t));
-    }
-    // Play completion sound synchronously in the gesture handler — Android's AudioContext
+    const fromInbox = !tasks.find(t => t.id === taskId);
+    // toggleComplete handles tick sound, vibration, undo tracking, onboarding progress,
+    // and updating the right list (scheduled vs unscheduled).
+    toggleComplete(taskId, fromInbox);
+    // Play completion chord synchronously in the gesture handler — Android's AudioContext
     // is often suspended by the time a useEffect fires, so the sound would be silently dropped.
     if (!taskBeingToggled?.completed) {
       const remainingIncomplete = projectTasks.filter(t => !t.completed && t.id !== taskId);
@@ -240,6 +240,19 @@ const HyperGlanceModeModal = () => {
             </div>
             <p className="text-gray-600 text-xs">Long break replaces break every 4 cycles.</p>
           </div>
+
+          {/* Android DND permission prompt */}
+          {isNativeAndroid() && !nativeIsDndPermissionGranted() && (
+            <div className="w-full flex items-center justify-between bg-gray-800/60 border border-gray-700 rounded-lg px-4 py-3 text-sm">
+              <span className="text-gray-300">Enable Do Not Disturb during session?</span>
+              <button
+                onClick={nativeRequestDndPermission}
+                className="ml-3 px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-xs font-medium transition-colors flex-shrink-0"
+              >
+                Grant access
+              </button>
+            </div>
+          )}
 
           {/* Task preview */}
           {projectTasks.length > 0 && (

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -742,9 +742,11 @@ export default function useTaskActions({
       next.add(taskId);
       return next;
     });
-    playFocusSound('complete');
+    // Play completion chord only when all tasks are done — consistent with hyperGLANCE.
+    // (toggleComplete above plays the 'tick' sound on every toggle.)
     const allDone = focusBlockTasks.every(t => t.completed || t.id === taskId || focusCompletedTasks.has(t.id));
     if (allDone) {
+      playFocusSound('complete');
       setTimeout(() => exitFocusModeRef.current?.(true), 500);
     }
   };


### PR DESCRIPTION
## Background

Audit of Focus Mode vs hyperGLANCE surfaced five unintentional differences. This PR addresses all of them.

## Changes

### 1. hyperGLANCE task toggle now uses `toggleComplete()`

`handleToggleTask` was toggling `task.completed` inline via `setTasks`/`setUnscheduledTasks`, bypassing `toggleComplete()` — which meant no tick sound, no vibration, no undo tracking, and no onboarding progress update. Now calls `toggleComplete(taskId, fromInbox)`.

### 2. Completion chord consistency

Focus Mode played the chord on every task completion; hyperGLANCE only on the last. Made both consistent: **tick on every task** (via `toggleComplete`), **chord only when all tasks done**. The "all done → auto-exit" behavior in Focus Mode is preserved.

### 3. Skip phase button added to Focus Mode

Mirrored `skipPhase` from hyperGLANCE as `skipFocusPhase` in App.jsx, exposed via `featuresCtx`, and added the `SkipForward` button next to Pause/Resume in `FocusModeModal`.

### 4. hyperGLANCE now uses `nativeEnterFocusMode`/`nativeExitFocusMode` on Android

Previously called only `nativeSetImmersiveMode(true/false)` — missing DND activation and reminder-alarm pausing. Now uses the same native calls as Focus Mode. Removed the now-unused `nativeSetImmersiveMode` import.

### 5. DND permission prompt added to hyperGLANCE settings

Same prompt Focus Mode shows: appears in the settings panel when running on Android without DND permission granted.

## Intentionally not touched

- **#6 from the audit** (Focus Mode lacks exit confirmation dialog) — left as-is per request.

## Test plan

- [x] hyperGLANCE: tap task → hear tick sound + feel vibration
- [x] hyperGLANCE: undo toast appears after task completion
- [x] hyperGLANCE: completion chord only plays when last task is completed
- [x] Focus Mode: completion chord only plays when all tasks done (not on each)
- [x] Focus Mode: skip phase button advances work→break / break→work
- [x] Android hyperGLANCE: DND prompt shows when permission not granted
- [x] Android hyperGLANCE: entering a session activates DND (if permission granted) and pauses reminder alarms
- [x] Android hyperGLANCE: exiting restores DND + reschedules reminders