### PR TITLE
Fix critical hyperGLANCE bugs: cloud sync data loss + override-blind canEnter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3036,22 +3036,22 @@ const DayPlanner = () => {
 
   const completeHyperGlanceSession = () => {
     if (!hyperGlanceProjectId || !hyperGlanceSessionDate) return;
-    setProjects(prev => prev.map(p => {
-      if (p.id !== hyperGlanceProjectId) return p;
-      const hg = p.hyperglance || {};
-      const completions = hg.completions || [];
-      if (completions.some(c => c.date === hyperGlanceSessionDate)) return p;
-      return {
-        ...p,
-        hyperglance: {
-          ...hg,
-          completions: [
-            ...completions,
-            { date: hyperGlanceSessionDate, completedAt: new Date().toISOString() },
-          ],
-        },
-      };
-    }));
+    const project = projects.find(p => p.id === hyperGlanceProjectId);
+    if (!project) return;
+    const hg = project.hyperglance || {};
+    const completions = hg.completions || [];
+    if (completions.some(c => c.date === hyperGlanceSessionDate)) return;
+    // Use updateProject so updatedAt is bumped — cloud sync uses updatedAt for
+    // conflict resolution, so a raw setProjects would let stale remote copies win.
+    updateProject(hyperGlanceProjectId, {
+      hyperglance: {
+        ...hg,
+        completions: [
+          ...completions,
+          { date: hyperGlanceSessionDate, completedAt: new Date().toISOString() },
+        ],
+      },
+    });
     setHgTimerRunning(false);
     setHgExitConfirm(false);
     // Don't close the modal here — the modal handles showing the summary screen
@@ -3074,32 +3074,31 @@ const DayPlanner = () => {
   const saveHGAdjust = () => {
     if (!hgAdjustModal) return;
     const { projectId, date, time, duration } = hgAdjustModal;
-    setProjects(prev => prev.map(p => {
-      if (p.id !== projectId) return p;
-      const hg = p.hyperglance || {};
-      return {
-        ...p,
-        hyperglance: {
-          ...hg,
-          scheduledTimeOverrides: { ...(hg.scheduledTimeOverrides || {}), [date]: time },
-          scheduledDurationOverrides: { ...(hg.scheduledDurationOverrides || {}), [date]: duration },
-        },
-      };
-    }));
+    const project = projects.find(p => p.id === projectId);
+    if (!project) return;
+    const hg = project.hyperglance || {};
+    updateProject(projectId, {
+      hyperglance: {
+        ...hg,
+        scheduledTimeOverrides: { ...(hg.scheduledTimeOverrides || {}), [date]: time },
+        scheduledDurationOverrides: { ...(hg.scheduledDurationOverrides || {}), [date]: duration },
+      },
+    });
     setHgAdjustModal(null);
   };
 
   const cancelHGSession = (projectId, date) => {
-    setProjects(prev => prev.map(p => {
-      if (p.id !== projectId) return p;
-      const hg = p.hyperglance || {};
-      if (!hg.isRecurring) {
-        return { ...p, hyperglance: { ...hg, enabled: false } };
-      }
+    const project = projects.find(p => p.id === projectId);
+    if (!project) return;
+    const hg = project.hyperglance || {};
+    if (!hg.isRecurring) {
+      updateProject(projectId, { hyperglance: { ...hg, enabled: false } });
+    } else {
       const skipped = hg.skippedDates || [];
-      if (skipped.includes(date)) return p;
-      return { ...p, hyperglance: { ...hg, skippedDates: [...skipped, date] } };
-    }));
+      if (!skipped.includes(date)) {
+        updateProject(projectId, { hyperglance: { ...hg, skippedDates: [...skipped, date] } });
+      }
+    }
     setHgContextMenu(null);
   };
 

--- a/src/hooks/useHyperGlance.js
+++ b/src/hooks/useHyperGlance.js
@@ -134,7 +134,8 @@ export function isHGSessionReachable(instance, hgConfig, currentTime) {
   today.setHours(0, 0, 0, 0);
   if (instance.date !== dateToString(today)) return false;
 
-  const [h, m] = (hgConfig.scheduledTime || '0:0').split(':').map(Number);
+  const effectiveTime = hgConfig.scheduledTimeOverrides?.[instance.date] || hgConfig.scheduledTime || '0:0';
+  const [h, m] = effectiveTime.split(':').map(Number);
   const startMinutes = h * 60 + m;
   const nowMinutes = currentTime.getHours() * 60 + currentTime.getMinutes();
   return nowMinutes >= startMinutes;


### PR DESCRIPTION
## Bug 1 — Cloud sync data loss on session completion, time adjustments, and cancellations

`completeHyperGlanceSession`, `saveHGAdjust`, and `cancelHGSession` all called `setProjects()` directly instead of going through `updateProject()`. Cloud sync uses `updatedAt` for conflict resolution — without bumping it, any edit made to the same project on another device after a session would silently overwrite the completion, time adjustment, or cancellation when that device syncs.

**Fix:** All three now call `updateProject()`, which stamps `updatedAt: new Date().toISOString()` on every write.

## Bug 2 — "Start hyperGLANCE" button activates at wrong time after Adjust Session Time

`isHGSessionReachable` compared `currentTime` against `hgConfig.scheduledTime` directly, ignoring `scheduledTimeOverrides`. After a user dragged the bar or used "Adjust time" to move today's session, the bar label correctly showed the new time — but the pulse button became active at the original template time.

**Fix:** `isHGSessionReachable` now uses `scheduledTimeOverrides[date]` with `scheduledTime` as fallback, matching the same pattern already used in `getActiveHGInstance`.

## Test plan
- [x] Complete a hyperGLANCE session on device A; edit the project on device B before syncing — completion survives the sync
- [x] Use "Adjust time" to move a session to a later time — "Start hyperGLANCE" button doesn't activate until the adjusted time
- [x] Cancel a recurring session — cancellation persists after sync with another device
