### PR TITLE
Fix hyperGLANCE bugs (audit)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2987,6 +2987,7 @@ const DayPlanner = () => {
     const newTasks = templates.map(tmpl => ({
       id: `hg-${project.id}-${sessionDate}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       title: tmpl.name,
+      ...(tmpl.notes ? { notes: tmpl.notes } : {}),
       projectId: project.id,
       hyperglanceSessionDate: sessionDate,
       completed: false,

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -1067,7 +1067,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
               >
                 <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: barColor }}></div>
                 <span className={`text-sm font-medium min-w-0 truncate ${darkMode ? 'text-gray-200' : 'text-stone-800'}`}>{project.title}</span>
-                {instance.isOverdue && <span className="text-xs font-semibold text-amber-500 flex-shrink-0">Overdue</span>}
+                {instance.isOverdue && <span className="text-xs font-semibold text-amber-500 flex-shrink-0">{new Date(instance.date + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} · Overdue</span>}
                 {timeLabel && <span className={`text-xs flex-shrink-0 ${darkMode ? 'text-gray-400' : 'text-stone-500'}`}>{timeLabel}</span>}
                 <Zap size={12} style={{ color: barColor, flexShrink: 0 }} />
               </button>

--- a/src/components/HyperGlanceBar.jsx
+++ b/src/components/HyperGlanceBar.jsx
@@ -90,11 +90,17 @@ const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
     setHgContextMenu({ x: e.clientX, y: e.clientY, projectId: project.id, date, isCompleted });
   };
 
-  // Task count for future bars: incomplete real tasks + template tasks
+  // Task count for future bars: incomplete real tasks + template tasks.
+  // Only add template count if templates haven't been instantiated yet for this
+  // session date — otherwise they're already included in the real task count.
+  const allProjectTasks = [...(tasks || []), ...(unscheduledTasks || [])];
+  const alreadyInstantiated = allProjectTasks.some(
+    t => t.projectId === project.id && t.hyperglanceSessionDate === date
+  );
   const incompleteTaskCount =
-    [...(tasks || []), ...(unscheduledTasks || [])].filter(
+    allProjectTasks.filter(
       t => t.projectId === project.id && !t.archived && !t.completed
-    ).length + (hg.templateTasks?.length || 0);
+    ).length + (alreadyInstantiated ? 0 : (hg.templateTasks?.length || 0));
 
   const timeLabel = (() => {
     if (!hg.scheduledTime) return '';
@@ -134,8 +140,7 @@ const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
           className="fixed z-[70] rounded-xl shadow-2xl p-3 min-w-[170px] bg-white dark:bg-gray-900 border"
           style={{
             left: Math.min(statsPos.x, window.innerWidth - 190),
-            top: statsPos.y - 8,
-            transform: 'translateY(-100%)',
+            top: Math.min(statsPos.y + 6, window.innerHeight - 120),
             borderColor: `${barColor}50`,
           }}
         >
@@ -177,7 +182,7 @@ const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
               onClick={(e) => {
                 e.stopPropagation();
                 const rect = e.currentTarget.closest('.absolute')?.getBoundingClientRect();
-                setStatsPos(rect ? { x: rect.left, y: rect.top, width: rect.width } : null);
+                setStatsPos(rect ? { x: rect.left, y: rect.bottom, width: rect.width } : null);
                 setShowStats(s => !s);
               }}
               className="flex-shrink-0 ml-0.5 pointer-events-auto opacity-80 hover:opacity-100"

--- a/src/components/HyperGlanceModeModal.jsx
+++ b/src/components/HyperGlanceModeModal.jsx
@@ -68,7 +68,7 @@ const HyperGlanceModeModal = () => {
       setHgCompleted(true);
       completeHyperGlanceSession();
     }
-  }, [allDone, hgCompleted, hgShowSettings]);
+  }, [allDone, hgCompleted, hgShowSettings, completeHyperGlanceSession]);
 
   // Play sounds on phase transitions
   useEffect(() => {
@@ -120,7 +120,7 @@ const HyperGlanceModeModal = () => {
       if (sessionStartRef.current) {
         setSessionElapsed(Math.floor((Date.now() - sessionStartRef.current) / 1000));
       }
-    }, 10000);
+    }, 1000);
     return () => clearInterval(interval);
   }, [hgTimerRunning]);
 

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -1128,7 +1128,7 @@ const MobileGlanceSection = () => {
               >
                 <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: barColor }}></div>
                 <span className={`text-sm font-medium min-w-0 truncate ${darkMode ? 'text-gray-200' : 'text-stone-800'}`}>{project.title}</span>
-                {instance.isOverdue && <span className="text-xs font-semibold text-amber-500 flex-shrink-0">Overdue</span>}
+                {instance.isOverdue && <span className="text-xs font-semibold text-amber-500 flex-shrink-0">{new Date(instance.date + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} · Overdue</span>}
                 {timeLabel && <span className={`text-xs flex-shrink-0 ${darkMode ? 'text-gray-400' : 'text-stone-500'}`}>{timeLabel}</span>}
                 <Zap size={12} style={{ color: barColor, flexShrink: 0 }} />
               </button>

--- a/src/components/MobileTimeGrid.jsx
+++ b/src/components/MobileTimeGrid.jsx
@@ -118,7 +118,7 @@ const MobileTimeGrid = () => {
       const isDateToday = dateStr === dateToString(new Date());
       const dayTasks = getTasksForDate(date).filter(t => !t.isAllDay && !t.isExample && (!projectFilter || t.projectId === projectFilter));
       const frameInstances = getFrameInstancesForDate(date);
-      const hgBars = getHGBarsForDate(projects, dateStr);
+      const hgBars = getHGBarsForDate(projects, dateStr, isDateToday ? new Date().getHours() * 60 + new Date().getMinutes() : undefined);
       const hasBars = hgBars.length > 0;
       const taskOverlapsHG = (task) => {
         if (!task.startTime || !hasBars) return false;

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -141,7 +141,7 @@ const TimeGrid = () => {
       const isDateToday = dateStr === dateToString(new Date());
       const dayTasks = getTasksForDate(date).filter(t => !t.isAllDay && (!projectFilter || t.projectId === projectFilter));
       const frameInstances = getFrameInstancesForDate(date);
-      const hgBars = getHGBarsForDate(projects, dateStr);
+      const hgBars = getHGBarsForDate(projects, dateStr, isDateToday ? new Date().getHours() * 60 + new Date().getMinutes() : undefined);
       const hasBars = hgBars.length > 0;
       // Returns true if a task's time range overlaps with any HG bar's scheduled time range
       const taskOverlapsHG = (task) => {

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -34,7 +34,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
     tasks, setTasks,
     unscheduledTasks, setUnscheduledTasks, reorderUnscheduledTasks,
     openMobileEditTask,
-    getTodayStr,
+    getTodayStr, currentTimeMinutes,
     darkMode, isMobile, use24HourClock,
     cardBg, borderClass, textPrimary, textSecondary, hoverBg,
     expandedNotesTaskId, setExpandedNotesTaskId,
@@ -43,7 +43,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
     mobileActiveTab,
   } = useDayPlannerCtx();
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
-  const { goals, deleteProject, generateAISubtasks, aiSubtasksLoadingForTask, aiConfig, showGoalsDashboard } = useFeaturesCtx();
+  const { goals, deleteProject, generateAISubtasks, aiSubtasksLoadingForTask, aiConfig, showGoalsDashboard, enterHyperGlanceMode } = useFeaturesCtx();
 
   const isScheduled = (t) => !!tasks.find(s => s.id === t.id);
 
@@ -321,8 +321,8 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
           <span className={`text-sm font-semibold ${textPrimary} leading-tight flex-1 min-w-0`}>
             {project.title}
           </span>
-          {project.hyperglance?.enabled && project.status !== 'completed' && (() => {
-              const instance = getActiveHGInstance(project);
+          {project.hyperglance?.enabled && project.status !== 'completed' && !project.archived && (() => {
+              const instance = getActiveHGInstance(project, currentTimeMinutes);
               if (!instance) return null;
               const hg = project.hyperglance;
               const effectiveTime = hg.scheduledTimeOverrides?.[instance.date] || hg.scheduledTime;
@@ -355,13 +355,14 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
               }
               const color = hg.color || '#4f46e5';
               return (
-                <span
+                <button
+                  onClick={() => enterHyperGlanceMode(project.id, instance.date)}
                   className={`flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded-full font-semibold flex-shrink-0${instance.isOverdue ? ' bg-orange-400/20 text-orange-400' : ''}`}
                   style={instance.isOverdue ? {} : { backgroundColor: color + '25', color }}
                 >
                   <Zap size={9} />
                   {dateLabel}{timeStr}
-                </span>
+                </button>
               );
             })()}
           <div className="flex items-center gap-1 flex-shrink-0">

--- a/src/hooks/useHyperGlance.js
+++ b/src/hooks/useHyperGlance.js
@@ -104,14 +104,15 @@ export function getActiveHGInstance(project, nowMinutes) {
  * - Active (incomplete) instance for that date → full bar
  * - Completed instance for that date → small pill
  */
-export function getHGBarsForDate(projects, dateStr) {
+export function getHGBarsForDate(projects, dateStr, nowMinutes) {
   const bars = [];
 
   for (const project of projects) {
+    if (project.archived) continue;
     const hg = project.hyperglance;
     if (!hg?.enabled) continue;
 
-    const active = getActiveHGInstance(project);
+    const active = getActiveHGInstance(project, nowMinutes);
     const completedOnDate = (hg.completions || []).some(c => c.date === dateStr);
 
     if (active?.date === dateStr) {
@@ -143,19 +144,24 @@ export function isHGSessionReachable(instance, hgConfig, currentTime) {
 
 /**
  * Returns all hyperGLANCE instances for the GLANCE panel: today's sessions
- * plus any overdue (missed) sessions, overdue entries sorted first.
+ * plus any overdue (missed) sessions, overdue entries sorted first, then by time.
  */
 export function getGlanceHGInstances(projects, nowMinutes) {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const todayStr = dateToString(today);
   return projects
-    .filter(p => p.hyperglance?.enabled)
+    .filter(p => !p.archived && p.hyperglance?.enabled)
     .map(p => ({ project: p, instance: getActiveHGInstance(p, nowMinutes) }))
     .filter(({ instance }) => instance && (instance.isOverdue || instance.date === todayStr))
     .sort((a, b) => {
       if (a.instance.isOverdue && !b.instance.isOverdue) return -1;
       if (!a.instance.isOverdue && b.instance.isOverdue) return 1;
-      return 0;
+      // Same overdue status — sort chronologically by effective start time
+      const tA = a.project.hyperglance.scheduledTimeOverrides?.[a.instance.date] || a.project.hyperglance.scheduledTime || '0:0';
+      const tB = b.project.hyperglance.scheduledTimeOverrides?.[b.instance.date] || b.project.hyperglance.scheduledTime || '0:0';
+      const [ah, am] = tA.split(':').map(Number);
+      const [bh, bm] = tB.split(':').map(Number);
+      return (ah * 60 + am) - (bh * 60 + bm);
     });
 }


### PR DESCRIPTION
Addresses the bugs identified in the hyperGLANCE audit. No new features.

## Changes

**Overdue detection accuracy**
- `getHGBarsForDate` now accepts and passes `nowMinutes` to `getActiveHGInstance`, so today's past-end sessions show as overdue on the timeline. Previously it was date-granular only; GLANCE was already accurate — now all three surfaces agree.
- `ProjectCard` chip passes `currentTimeMinutes` to `getActiveHGInstance` for the same reason.

**Archived projects**
- `getHGBarsForDate` and `getGlanceHGInstances` now skip `project.archived === true`. Previously only `hg.enabled` was checked.
- `ProjectCard` chip condition also guards `!project.archived`.

**GLANCE sort order**
- `getGlanceHGInstances` now sorts today's sessions chronologically by effective start time (overrides respected). Previously used project creation order.

**GLANCE overdue label**
- Overdue entries in both `GlanceSidebar` and `MobileGlanceSection` now show the missed date: "Mar 12 · Overdue" instead of just "Overdue".

**`incompleteTaskCount` double-counting**
- `HyperGlanceBar` no longer adds `templateTasks.length` when session tasks have already been instantiated for that date — they're already in the real task count.

**Stats popover positioning**
- Popover now positions below the completed pill (`rect.bottom + 6`) clamped to viewport height, instead of above via `translateY(-100%)` which clipped when the pill was near the top of the timeline.

**Template task notes**
- `instantiateHGTemplateTasks` now copies `tmpl.notes` to spawned tasks (was silently dropped).

**ProjectCard chip clickable**
- Changed `<span>` to `<button>` with `onClick → enterHyperGlanceMode`. The chip was the only surface that didn't let you enter the session.

**Modal fixes**
- Auto-complete `useEffect` dep array now includes `completeHyperGlanceSession` (was missing).
- Session elapsed ticker interval changed from 10 000 ms to 1 000 ms — summary screen was showing elapsed time rounded to nearest 10 s.

## Test plan
- [x] Timeline: a session whose end time has passed shows "Overdue" on today's date
- [x] Goals chip: same — shows "Overdue" for a past-end session on the same day
- [x] Archived project: no bar on timeline, no GLANCE row, no Goals chip
- [x] GLANCE: multiple today sessions appear in chronological order
- [x] GLANCE: overdue entry shows "Mar 12 · Overdue" (or equivalent date)
- [x] Goals chip: tapping enters the session
- [x] Bar task count: re-entering a session shows correct count (no doubling)
- [x] Stats popover: tapping Zap on a pill near the top of the timeline shows popover below, not clipped
- [x] Template tasks with notes: entering session creates tasks with notes populated
- [x] Session summary elapsed time ticks every second
