### PR TITLE
feat: save and surface rich hyperGLANCE completion stats

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3034,7 +3034,7 @@ const DayPlanner = () => {
     nativeExitFocusMode();
   };
 
-  const completeHyperGlanceSession = () => {
+  const completeHyperGlanceSession = (stats = {}) => {
     if (!hyperGlanceProjectId || !hyperGlanceSessionDate) return;
     const project = projects.find(p => p.id === hyperGlanceProjectId);
     if (!project) return;
@@ -3048,7 +3048,7 @@ const DayPlanner = () => {
         ...hg,
         completions: [
           ...completions,
-          { date: hyperGlanceSessionDate, completedAt: new Date().toISOString() },
+          { date: hyperGlanceSessionDate, completedAt: new Date().toISOString(), ...stats },
         ],
       },
     });

--- a/src/components/HyperGlanceBar.jsx
+++ b/src/components/HyperGlanceBar.jsx
@@ -121,11 +121,12 @@ const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
       return `${h12}:${String(m).padStart(2, '0')}${ampm}`;
     })();
 
-    const allProjectTasks = [...(tasks || []), ...(unscheduledTasks || [])].filter(
-      t => t.projectId === project.id && !t.archived
-    );
-    const completedTaskCount = allProjectTasks.filter(t => t.completed).length;
-    const totalTaskCount = allProjectTasks.length;
+    const formatElapsed = (seconds) => {
+      if (!seconds) return null;
+      const h = Math.floor(seconds / 3600);
+      const m = Math.floor((seconds % 3600) / 60);
+      return h > 0 ? `${h}h ${m}m` : `${m}m`;
+    };
 
     const statsCard = showStats && statsPos && ReactDOM.createPortal(
       <>
@@ -134,8 +135,7 @@ const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
           className="fixed z-[70] rounded-xl shadow-2xl p-3 min-w-[170px] bg-white dark:bg-gray-900 border"
           style={{
             left: Math.min(statsPos.x, window.innerWidth - 190),
-            top: statsPos.y - 8,
-            transform: 'translateY(-100%)',
+            top: Math.min(statsPos.y + 6, window.innerHeight - 120),
             borderColor: `${barColor}50`,
           }}
         >
@@ -148,9 +148,19 @@ const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
               Completed at <span className="font-medium text-gray-900 dark:text-white">{completedTimeLabel}</span>
             </div>
           )}
-          {totalTaskCount > 0 && (
+          {(completion?.tasksTotal > 0) && (
+            <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+              Tasks <span className="font-medium text-gray-900 dark:text-white">{completion.tasksCompleted}/{completion.tasksTotal}</span>
+            </div>
+          )}
+          {completion?.elapsedSeconds > 0 && (
+            <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+              Duration <span className="font-medium text-gray-900 dark:text-white">{formatElapsed(completion.elapsedSeconds)}</span>
+            </div>
+          )}
+          {completion?.cycleCount > 0 && (
             <div className="text-xs text-gray-500 dark:text-gray-400">
-              Tasks <span className="font-medium text-gray-900 dark:text-white">{completedTaskCount}/{totalTaskCount}</span>
+              Cycles <span className="font-medium text-gray-900 dark:text-white">{completion.cycleCount}</span>
             </div>
           )}
         </div>
@@ -177,7 +187,7 @@ const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
               onClick={(e) => {
                 e.stopPropagation();
                 const rect = e.currentTarget.closest('.absolute')?.getBoundingClientRect();
-                setStatsPos(rect ? { x: rect.left, y: rect.top, width: rect.width } : null);
+                setStatsPos(rect ? { x: rect.left, y: rect.bottom, width: rect.width } : null);
                 setShowStats(s => !s);
               }}
               className="flex-shrink-0 ml-0.5 pointer-events-auto opacity-80 hover:opacity-100"

--- a/src/components/HyperGlanceModeModal.jsx
+++ b/src/components/HyperGlanceModeModal.jsx
@@ -66,7 +66,7 @@ const HyperGlanceModeModal = () => {
   useEffect(() => {
     if (allDone && !hgCompleted && !hgShowSettings) {
       setHgCompleted(true);
-      completeHyperGlanceSession();
+      completeHyperGlanceSession(buildSessionStats());
     }
   }, [allDone, hgCompleted, hgShowSettings]);
 
@@ -120,7 +120,7 @@ const HyperGlanceModeModal = () => {
       if (sessionStartRef.current) {
         setSessionElapsed(Math.floor((Date.now() - sessionStartRef.current) / 1000));
       }
-    }, 10000);
+    }, 1000);
     return () => clearInterval(interval);
   }, [hgTimerRunning]);
 
@@ -173,6 +173,13 @@ const HyperGlanceModeModal = () => {
 
   const phaseLabel = hgTimerPhase === 'work' ? 'Work' : hgTimerPhase === 'longBreak' ? 'Long Break' : 'Break';
   const phaseBg = hgTimerPhase === 'work' ? 'bg-blue-900 text-blue-300' : hgTimerPhase === 'longBreak' ? 'bg-purple-900 text-purple-300' : 'bg-green-900 text-green-300';
+
+  const buildSessionStats = () => ({
+    tasksCompleted: projectTasks.filter(t => t.completed).length,
+    tasksTotal: projectTasks.length,
+    elapsedSeconds: sessionElapsed,
+    cycleCount: hgCycleCount,
+  });
 
   const skipPhase = () => {
     if (hgTimerPhase === 'work') {
@@ -360,7 +367,7 @@ const HyperGlanceModeModal = () => {
               Exit — I'll come back
             </button>
             <button
-              onClick={() => { setHgExitConfirm(false); setHgCompleted(true); playFocusSound('complete'); completeHyperGlanceSession(); }}
+              onClick={() => { setHgExitConfirm(false); setHgCompleted(true); playFocusSound('complete'); completeHyperGlanceSession(buildSessionStats()); }}
               className="w-full py-3 rounded-xl text-white font-semibold transition-opacity hover:opacity-90"
               style={{ backgroundColor: barColor }}
             >


### PR DESCRIPTION
## Summary

- `completeHyperGlanceSession` now accepts a `stats` object and persists `{ tasksCompleted, tasksTotal, elapsedSeconds, cycleCount }` into each completion entry alongside the existing `date`/`completedAt` fields
- Both call sites in `HyperGlanceModeModal` (auto-complete on `allDone` and the "End Session" button) now pass `buildSessionStats()` — no data is discarded
- Session elapsed ticker corrected from 10 s to 1 s intervals so `elapsedSeconds` is accurate at the moment of completion
- `HyperGlanceBar` stats popover reads stored completion stats instead of live task counts, and now surfaces **duration** and **cycle count** in addition to the existing completed-at time and task ratio
- Stats card positioning fixed: card now opens below the pill (`rect.bottom + 6`) and is clamped to viewport height, preventing it from being clipped at the top of the screen

## Test plan

- [x] Complete a hyperGLANCE session (check off all tasks) — verify the stats popover on the completed pill shows tasks, duration, and cycles
- [x] Use "End Session" from the exit confirm dialog — same verification
- [x] Confirm existing completions (without stats fields) still render gracefully — only rows with data appear in the popover
- [x] Stats popover opens below the pill when the pill is near the top of the timeline; stays on screen when near the bottom

https://claude.ai/code/session_01DD2Ns6xTNrRcGct9ESBYha