### PR TITLE
chore: remove dead code in hyperGLANCE components

### DIFF
--- a/src/components/HyperGlanceModeModal.jsx
+++ b/src/components/HyperGlanceModeModal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as Icons from 'lucide-react';
-import { Check, CheckCircle, ChevronDown, ChevronUp, Pause, Play, Plus, SkipForward, Trophy, X, Zap } from 'lucide-react';
+import { Check, CheckCircle, ChevronDown, ChevronUp, Pause, Play, SkipForward, X, Zap } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -337,7 +337,6 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
       scheduledDuration: Math.max(60, Math.round(hgDuration / 15) * 15),
       templateTasks: hgTemplateTasks,
       completions: initHG.completions || [],
-      activeSession: initHG.activeSession || null,
       createdAt: initHG.createdAt || new Date().toISOString(),
     } : null;
     onSave({ title: title.trim(), description: description.trim(), goalId: goalId || undefined, status, hyperglance });


### PR DESCRIPTION
## Summary

- Remove `Trophy` and `Plus` from named imports in `HyperGlanceModeModal.jsx` — neither icon is referenced anywhere in the file
- Remove `activeSession: initHG.activeSession || null` from the hyperglance config object in `GoalDashboard.jsx` — `activeSession` is never read anywhere in the codebase and was a remnant from an earlier draft of the feature

## Test plan

- [x] Open the project edit modal in Goal Dashboard — save a hyperGLANCE project and confirm it saves/loads correctly
- [x] Open hyperGLANCE mode — no visual or functional regression

https://claude.ai/code/session_01DD2Ns6xTNrRcGct9ESBYha