### PR TITLE
fix: suppress stalled chip when project has a scheduled HG session

### DIFF
--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -90,7 +90,8 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
   const completedCount = projectTasks.filter(t => t.completed).length;
   const totalCount = projectTasks.length;
   const progress = calculateProjectProgress(project.id, allTasks);
-  const stalled = !!project.goalId && isProjectStalled(project.id, allTasks, project);
+  const hasHGSession = !!getActiveHGInstance(project, currentTimeMinutes);
+  const stalled = !!project.goalId && !hasHGSession && isProjectStalled(project.id, allTasks, project);
 
   // All project tasks: unscheduled (in array order) then scheduled (by date), completed last
   const projectUnscheduled = unscheduledTasks.filter(t => t.projectId === project.id && !t.archived);


### PR DESCRIPTION
## Summary

A project with an active hyperGLANCE instance is not truly stalled — it has a structured, recurring work session planned. Showing "Stalled" alongside the HG chip is contradictory and misleading.

`getActiveHGInstance` already handles all the schedule logic (recurring vs one-time, completed/skipped/archived filtering) and returns `null` when there's nothing actionable, so reusing it as the gate is the right call.

## Change

`ProjectCard.jsx` — one additional condition on the `stalled` computation:

```js
const hasHGSession = !!getActiveHGInstance(project, currentTimeMinutes);
const stalled = !!project.goalId && !hasHGSession && isProjectStalled(...);
```

## Test plan

- [x] Project with a recurring HG session and no recent task completions: **no** "Stalled" chip
- [x] Same project after completing/skipping the session (so `getActiveHGInstance` returns null): "Stalled" chip reappears if the stall criteria are met
- [x] Project without HG: "Stalled" chip behaviour unchanged

https://claude.ai/code/session_01DD2Ns6xTNrRcGct9ESBYha