### PR TITLE
fix: hG stats popover placement + template task notes

### DIFF
--- a/src/components/HyperGlanceBar.jsx
+++ b/src/components/HyperGlanceBar.jsx
@@ -140,8 +140,10 @@ const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
         <div
           className="fixed z-[70] rounded-xl shadow-2xl p-3 min-w-[170px] bg-white dark:bg-gray-900 border"
           style={{
-            left: Math.min(statsPos.x, window.innerWidth - 190),
-            top: Math.min(statsPos.y + 6, window.innerHeight - 120),
+            left: Math.min(Math.max(statsPos.x, 8), window.innerWidth - 190),
+            top: (statsPos.y + 6 + 130 > window.innerHeight)
+              ? Math.max(statsPos.y - 130 - 6, 8)
+              : statsPos.y + 6,
             borderColor: `${barColor}50`,
           }}
         >

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -300,6 +300,7 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
   const [hgDuration, setHgDuration] = useState(Math.max(60, initHG.scheduledDuration || 60));
   const [hgTemplateTasks, setHgTemplateTasks] = useState(initHG.templateTasks || []);
   const [hgNewTask, setHgNewTask] = useState('');
+  const [editingTemplateTask, setEditingTemplateTask] = useState(null); // { id, name, notes }
   const [showHgDatePicker, setShowHgDatePicker] = useState(false);
   const [showHgTimePicker, setShowHgTimePicker] = useState(false);
 
@@ -316,6 +317,11 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
   };
 
   const removeHGTemplateTask = (id) => setHgTemplateTasks(prev => prev.filter(t => t.id !== id));
+  const saveEditingTemplateTask = () => {
+    if (!editingTemplateTask) return;
+    setHgTemplateTasks(prev => prev.map(t => t.id === editingTemplateTask.id ? { ...t, name: editingTemplateTask.name, notes: editingTemplateTask.notes } : t));
+    setEditingTemplateTask(null);
+  };
 
   // "Completed" only available when all project tasks are completed (or none exist)
   const projectTasks = initial
@@ -624,6 +630,10 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
                 {hgTemplateTasks.map(t => (
                   <div key={t.id} className={`flex items-center gap-2 px-2 py-1.5 rounded-lg ${darkMode ? 'bg-gray-700/50' : 'bg-stone-50'}`}>
                     <span className={`flex-1 text-sm ${textPrimary}`}>{t.name}</span>
+                    {t.notes && <span className={`text-xs ${textSecondary} truncate max-w-[120px]`} title={t.notes}>{t.notes}</span>}
+                    <button type="button" onClick={() => setEditingTemplateTask({ id: t.id, name: t.name, notes: t.notes || '' })} className={`p-0.5 rounded ${hoverBg}`}>
+                      <Pencil size={13} className={textSecondary} />
+                    </button>
                     <button type="button" onClick={() => removeHGTemplateTask(t.id)} className={`p-0.5 rounded ${hoverBg}`}>
                       <Trash2 size={13} className="text-red-400" />
                     </button>
@@ -654,6 +664,41 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
           </div>
         )}
       </div>
+
+      {/* Template task edit modal */}
+      {editingTemplateTask && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[80]" onClick={() => setEditingTemplateTask(null)}>
+          <div className={`${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'} border rounded-xl shadow-2xl p-4 w-80 mx-4`} onClick={e => e.stopPropagation()}>
+            <h4 className={`text-sm font-semibold ${textPrimary} mb-3`}>Edit template task</h4>
+            <div className="space-y-3">
+              <div>
+                <label className={`text-xs font-medium ${textSecondary} mb-1 block`}>Name</label>
+                <input
+                  type="text"
+                  value={editingTemplateTask.name}
+                  onChange={e => setEditingTemplateTask(prev => ({ ...prev, name: e.target.value }))}
+                  className={`w-full px-2 py-1.5 text-sm rounded-lg border ${darkMode ? 'bg-gray-700 border-gray-600 text-gray-100' : 'bg-white border-stone-300 text-stone-900'} focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                  autoFocus
+                />
+              </div>
+              <div>
+                <label className={`text-xs font-medium ${textSecondary} mb-1 block`}>Note <span className="font-normal opacity-60">(carried into each session)</span></label>
+                <textarea
+                  value={editingTemplateTask.notes}
+                  onChange={e => setEditingTemplateTask(prev => ({ ...prev, notes: e.target.value }))}
+                  rows={3}
+                  placeholder="Optional note…"
+                  className={`w-full px-2 py-1.5 text-sm rounded-lg border resize-none ${darkMode ? 'bg-gray-700 border-gray-600 text-gray-100 placeholder-gray-500' : 'bg-white border-stone-300 text-stone-900 placeholder-stone-400'} focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                />
+              </div>
+            </div>
+            <div className="flex gap-2 justify-end mt-4">
+              <button type="button" onClick={() => setEditingTemplateTask(null)} className={`px-3 py-1.5 text-sm rounded-lg ${hoverBg} ${textSecondary} transition-colors`}>Cancel</button>
+              <button type="button" onClick={saveEditingTemplateTask} disabled={!editingTemplateTask.name.trim()} className="px-3 py-1.5 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium disabled:opacity-50">Save</button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Actions */}
       <div className="flex gap-2 justify-end">


### PR DESCRIPTION
## Summary

- **Stats popover placement**: replaced the `Math.min` clamp (which caused the card to appear *above* the pill when near the bottom edge) with a proper flip strategy — opens below by default, flips above if within 130px of the bottom. Also adds a left-edge floor so the card doesn't go off-screen on mobile.
- **Template task notes**: pencil icon on each template task chip opens a small edit modal with name + notes fields. The note is stored on the template definition and carried into every spawned task at session start. A truncated preview is shown inline on the chip.

## Test plan

- [x] Tap the Zap icon on a completed hG pill near the bottom of the screen — popover should appear above the pill
- [x] Tap it near the top — popover should appear below
- [x] Verify left-edge clamping on narrow mobile screens
- [x] Open a project's hG settings, add a template task, click the pencil icon, add a note, save
- [x] Start a session — confirm the spawned task carries the note

https://claude.ai/code/session_01DD2Ns6xTNrRcGct9ESBYha