### PR TITLE
feat: include task count in hG up-next notification

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5942,6 +5942,10 @@ const DayPlanner = () => {
     setUnscheduledTasks(prev => prev.map(t => t.id === id ? { ...t, archived: false } : t));
   };
 
+  // Tracks the last Up Next notification payload to avoid re-posting identical content,
+  // which causes a brief flicker on Android (dismiss + repost instead of update-in-place).
+  const lastUpNextRef = React.useRef(null); // { title, bodyText } | 'cancelled'
+
   // ── Native Android widget snapshot sync ──────────────────────────────────
   // Pushes a rich snapshot of today's agenda to the native widget via NativeBridge.
   // Runs whenever tasks, habits, routines, or frames change so the widget is always
@@ -6345,10 +6349,10 @@ const DayPlanner = () => {
             : `${endH > 12 ? endH - 12 : (endH || 12)}:${endM} ${endH >= 12 ? 'PM' : 'AM'}`;
           bodyText = `${nextHGItem.title} · In progress · ends at ${endStr}`;
         }
-        window.DayGlanceNative?.updateUpNextNotification?.(JSON.stringify({
-          title: 'hyperGLANCE',
-          bodyText,
-        }));
+        if (lastUpNextRef.current?.title !== 'hyperGLANCE' || lastUpNextRef.current?.bodyText !== bodyText) {
+          lastUpNextRef.current = { title: 'hyperGLANCE', bodyText };
+          window.DayGlanceNative?.updateUpNextNotification?.(JSON.stringify({ title: 'hyperGLANCE', bodyText }));
+        }
       } else if (nextTaskItem) {
         const startMin2 = timeToMinutes(nextTaskItem.startTime);
         const endMin2 = startMin2 + nextTaskItem.duration;
@@ -6368,12 +6372,15 @@ const DayPlanner = () => {
             : `${endH > 12 ? endH - 12 : (endH || 12)}:${endM} ${endH >= 12 ? 'PM' : 'AM'}`;
           bodyText = `In progress · ends at ${endStr}`;
         }
-        window.DayGlanceNative?.updateUpNextNotification?.(JSON.stringify({
-          title: nextTaskItem.title,
-          bodyText,
-        }));
+        if (lastUpNextRef.current?.title !== nextTaskItem.title || lastUpNextRef.current?.bodyText !== bodyText) {
+          lastUpNextRef.current = { title: nextTaskItem.title, bodyText };
+          window.DayGlanceNative?.updateUpNextNotification?.(JSON.stringify({ title: nextTaskItem.title, bodyText }));
+        }
       } else {
-        window.DayGlanceNative?.cancelUpNextNotification?.();
+        if (lastUpNextRef.current !== 'cancelled') {
+          lastUpNextRef.current = 'cancelled';
+          window.DayGlanceNative?.cancelUpNextNotification?.();
+        }
       }
     } catch (_) {}
   }, [

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5267,9 +5267,16 @@ const DayPlanner = () => {
         if (!effectiveTime || effectiveTime === '0:0') return [];
         const [startH, startM] = effectiveTime.split(':').map(Number);
         if (!Number.isFinite(startH) || !Number.isFinite(startM)) return [];
-        return [{ id: project.id, title: project.title, date: instance.date, startMinutes: startH * 60 + startM }];
+        const allProjectTasks = [...tasks, ...unscheduledTasks];
+        const alreadyInstantiated = allProjectTasks.some(
+          t => t.projectId === project.id && t.hyperglanceSessionDate === instance.date
+        );
+        const taskCount = allProjectTasks.filter(
+          t => t.projectId === project.id && !t.archived && !t.completed
+        ).length + (alreadyInstantiated ? 0 : (hg.templateTasks?.length || 0));
+        return [{ id: project.id, title: project.title, date: instance.date, startMinutes: startH * 60 + startM, taskCount }];
       });
-  }, [projects, goalsProjectsEnabled]);
+  }, [projects, goalsProjectsEnabled, tasks, unscheduledTasks]);
 
   const {
     activeReminders, setActiveReminders,

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -738,11 +738,11 @@ const MobileSettingsPanel = () => {
               <div className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${reminderSettings.hyperGlance?.enabled !== false ? 'translate-x-5' : 'translate-x-1'}`} />
             </div>
           </div>
-          <span className={`text-sm ${textPrimary}`}>Notify me for sessions</span>
+          <span className={`text-sm ${textPrimary}`}>Notify me at session start</span>
         </label>
         {reminderSettings.hyperGlance?.enabled !== false && (
           <div>
-            <p className={`text-xs ${textSecondary} mb-1.5`}>Up next reminder</p>
+            <p className={`text-xs ${textSecondary} mb-1.5`}>Session reminder</p>
             <div className="flex gap-1.5 flex-wrap">
               {[[0, 'Off'], [5, '5m'], [10, '10m'], [15, '15m'], [30, '30m']].map(([mins, label]) => (
                 <button

--- a/src/components/RemindersSettingsModal.jsx
+++ b/src/components/RemindersSettingsModal.jsx
@@ -250,11 +250,11 @@ const RemindersSettingsModal = () => {
                     <div className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${reminderSettings.hyperGlance?.enabled !== false ? 'translate-x-5' : 'translate-x-1'}`} />
                   </div>
                 </div>
-                <span className={`text-sm ${textPrimary}`}>Notify me for sessions</span>
+                <span className={`text-sm ${textPrimary}`}>Notify me at session start</span>
               </label>
               {reminderSettings.hyperGlance?.enabled !== false && (
                 <div>
-                  <p className={`text-xs ${textSecondary} mb-1.5`}>Up next reminder</p>
+                  <p className={`text-xs ${textSecondary} mb-1.5`}>Session reminder</p>
                   <div className="flex gap-1.5 flex-wrap">
                     {[[0, 'Off'], [5, '5m before'], [10, '10m before'], [15, '15m before'], [30, '30m before']].map(([mins, label]) => (
                       <button

--- a/src/hooks/useReminderEngine.js
+++ b/src/hooks/useReminderEngine.js
@@ -125,7 +125,7 @@ export default function useReminderEngine({
             firedRemindersRef.current.add(upNextKey);
             hgFires.push({
               title: 'hyperGLANCE',
-              body: `${session.title} · Starts in ${upNextMinutes}m`,
+              body: `${session.title}${session.taskCount > 0 ? ` · ${session.taskCount} task${session.taskCount !== 1 ? 's' : ''}` : ''} · Starts in ${upNextMinutes}m`,
               tag: `hg-upnext-${session.id}`,
             });
           }
@@ -318,7 +318,7 @@ export default function useReminderEngine({
               id: `hg-upnext-${session.id}-${session.date}`,
               taskId: `hg-${session.id}`,
               title: 'hyperGLANCE',
-              body: `${session.title} · Starts in ${upNextMinutes}m`,
+              body: `${session.title}${session.taskCount > 0 ? ` · ${session.taskCount} task${session.taskCount !== 1 ? 's' : ''}` : ''} · Starts in ${upNextMinutes}m`,
               type: 'hg-upnext',
               isCalendarEvent: false,
               triggerAtMillis,


### PR DESCRIPTION
## Summary

Adds the project's incomplete task count to the "up next" hyperGLANCE notification body, right after the project title:

> **hyperGLANCE** — Deep Work · 3 tasks · Starts in 10m

Uses the same `alreadyInstantiated` logic as `HyperGlanceBar` to decide whether to count real tasks or fall back to template task count. Applied to both the browser/in-app notification and the native Android AlarmManager body.

## Test plan

- [ ] With a project that has template tasks (not yet instantiated), trigger an up-next notification — confirm template count appears
- [ ] After entering a session (tasks instantiated), verify count reflects actual incomplete tasks
- [ ] Project with no tasks — notification omits the task count segment entirely
- [ ] Singular: "1 task", plural: "3 tasks"

https://claude.ai/code/session_01DD2Ns6xTNrRcGct9ESBYha