### PR TITLE
fix: hyperGLANCE misc fixes + GLANCE section polish

### DIFF
--- a/src/components/HyperGlanceBar.jsx
+++ b/src/components/HyperGlanceBar.jsx
@@ -225,9 +225,9 @@ const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
         style={{
           backgroundColor: hexToRgba(barColor, 0.09),
           borderLeft: `3px solid ${barColor}`,
-          borderTop: `1px solid ${barColor}30`,
-          borderRight: `1px solid ${barColor}30`,
-          borderBottom: `1px solid ${barColor}30`,
+          borderTop: `1px solid ${hexToRgba(barColor, 0.19)}`,
+          borderRight: `1px solid ${hexToRgba(barColor, 0.19)}`,
+          borderBottom: `1px solid ${hexToRgba(barColor, 0.19)}`,
         }}
       >
         {/* Resize handles */}


### PR DESCRIPTION
## Summary

- **Android WebView color compat**: replaced all 8-digit hex (`#RRGGBBAA` / `${color}XX`) with `rgba()` across HyperGlanceBar, HyperGlanceModeModal, GoalDashboard, ProjectCard — including 3 border colors in HyperGlanceBar that were missed in the original sweep
- **Up Next persistent notification**: fixed flicker (native updater now reads unified `nextUpNext` field from snapshot, covering both tasks and HG sessions), added task count to body, removed competing direct `updateUpNextNotification` JS calls that were overwriting the correct notification
- **Duplicate Android session reminders**: removed redundant `nativeShowNotification` JS call — AlarmManager already fires `showTaskNotification` (with Snooze) so both were showing
- **Session-start notification replaces session reminder**: both use the same `tag` so the start notification replaces the "Starts in Xm" one in-place
- **GLANCE HG section states**: in-progress shows green "In progress" label + pulsing pill; overdue shows amber badge + pulsing pill (click enters session); future sessions show time only, click navigates to Goals dashboard (desktop) or Goals tab (mobile)
- **12hr time format**: `11a` / `2:30p` shorthand → `11:00 AM` / `2:30 PM` across all HG components (HyperGlanceBar, HGAdjustModal, ProjectCard, GoalDashboard, GlanceSidebar, MobileGlanceSection)
- **Overdue same-day label**: shows "Today · Overdue" instead of the date when the session is from today
- **syncReminders body diff**: alarms now reschedule when body text changes (not just trigger time), fixing stale task count after project edits

## Test plan

- [x] Up Next persistent notification shows task count for HG sessions and doesn't flicker
- [x] Session reminder fires once (with Snooze 15m); session-start notification replaces it
- [x] No duplicate notifications on Android when session time arrives
- [x] GLANCE: in-progress HG session shows green "In progress" + pulsing pill
- [x] GLANCE: overdue session shows amber badge + pulsing pill; tapping enters session
- [x] GLANCE: future session shows time only; tapping opens Goals dashboard (desktop) / Goals tab (mobile)
- [x] GLANCE: same-day overdue shows "Today · Overdue" not the date
- [x] 12hr time format shows `11:00 AM` style everywhere (HyperGlanceBar, project card, Goals dashboard, Adjust modal)
- [x] HG bar borders render correctly on Android (no transparent/missing borders)

https://claude.ai/code/session_01DD2Ns6xTNrRcGct9ESBYha