### PR TITLE
ci: push rolling latest image on merge to main

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -2,6 +2,8 @@ name: Build and Publish to GHCR
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   workflow_dispatch:
@@ -39,7 +41,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Add branches: [main] to the push trigger and guard the raw latest tag with enable={{is_default_branch}} so it only publishes on main pushes, not on version tags from other branches.

https://claude.ai/code/session_0171nhppsgUbBW1KjJu8m4va