### PR TITLE
Day view refinements: rolling-24 mode, date groups, Now bar, settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -224,14 +224,24 @@ const DayPlanner = () => {
   // Override visible days: tablet uses orientation (static panel always present), mobile always 1, desktop uses width-based hook
   const visibleDays = isTablet ? (isLandscape ? 2 : 1) : isMobile ? 1 : _visibleDays;
   const [viewMode, setViewMode] = useState(() => {
-    const saved = localStorage.getItem('day-planner-view-mode');
-    return saved ? JSON.parse(saved) : 'multi';
+    // Initialize from defaultView on every cold load; last-used viewMode is
+    // written to day-planner-view-mode during a session but not read back.
+    const def = localStorage.getItem('day-planner-default-view');
+    return def ? JSON.parse(def) : 'multi';
   });
   // Only expose the cycler (and honour viewMode) when the 3-day breakpoint is active
   const canShowViewCycler = !isTablet && !isMobile && _visibleDays === 3;
   // Below 1600px the cycler is hidden and the stored mode is ignored until the
   // viewport grows back; the app behaves as 'multi' in the meantime.
   const effectiveViewMode = canShowViewCycler ? viewMode : 'multi';
+  const [defaultView, setDefaultView] = useState(() => {
+    const saved = localStorage.getItem('day-planner-default-view');
+    return saved ? JSON.parse(saved) : 'multi';
+  });
+  const [dayViewMode, setDayViewMode] = useState(() => {
+    const saved = localStorage.getItem('day-planner-day-view-mode');
+    return saved ? JSON.parse(saved) : 'calendar-day';
+  });
   const [darkMode, setDarkMode] = useState(() => {
     const saved = localStorage.getItem('day-planner-darkmode');
     return saved ? JSON.parse(saved) : false;
@@ -1011,6 +1021,14 @@ const DayPlanner = () => {
   useEffect(() => {
     localStorage.setItem('day-planner-view-mode', JSON.stringify(viewMode));
   }, [viewMode]);
+
+  useEffect(() => {
+    localStorage.setItem('day-planner-default-view', JSON.stringify(defaultView));
+  }, [defaultView]);
+
+  useEffect(() => {
+    localStorage.setItem('day-planner-day-view-mode', JSON.stringify(dayViewMode));
+  }, [dayViewMode]);
 
   // Lock body/html scrolling to prevent scroll chaining (all devices incl. desktop PWA)
   useEffect(() => {
@@ -5223,6 +5241,38 @@ const DayPlanner = () => {
     });
   }, [selectedDate, visibleDays]);
 
+  // Columns for DayView — three 8-hour windows.
+  // 'calendar-day': fixed 00-08 / 08-16 / 16-24 for selectedDate.
+  // 'rolling-24': leftmost column is the current 8-hour block; columns that
+  // cross midnight carry the next calendar day's date.
+  const dayViewColumns = useMemo(() => {
+    const base = new Date(selectedDate);
+    base.setHours(0, 0, 0, 0);
+    const nextDay = new Date(base);
+    nextDay.setDate(nextDay.getDate() + 1);
+    const baseStr = dateToString(base);
+    const nextStr = dateToString(nextDay);
+
+    if (dayViewMode === 'rolling-24') {
+      const blockStart = Math.floor(currentTime.getHours() / 8) * 8;
+      return [0, 1, 2].map(i => {
+        const absStart = blockStart + i * 8;
+        const crossesMidnight = absStart >= 24;
+        const startHour = absStart % 24;
+        const endHour = startHour + 8;
+        const date = crossesMidnight ? nextDay : base;
+        const dateStr = crossesMidnight ? nextStr : baseStr;
+        return { startHour, endHour, date, dateStr };
+      });
+    }
+    // calendar-day (default)
+    return [
+      { startHour: 0,  endHour: 8,  date: base, dateStr: baseStr },
+      { startHour: 8,  endHour: 16, date: base, dateStr: baseStr },
+      { startHour: 16, endHour: 24, date: base, dateStr: baseStr },
+    ];
+  }, [selectedDate, dayViewMode, currentTime]);
+
   // Auto-select new tags when they appear (only truly new tags, not previously deselected ones)
   const prevAllTagsRef = useRef(new Set(allTags));
   useEffect(() => {
@@ -6835,6 +6885,9 @@ const DayPlanner = () => {
     isPhone, isMobile, isTablet, isLandscape,
     visibleDays, visibleDates,
     viewMode, setViewMode, canShowViewCycler, effectiveViewMode,
+    defaultView, setDefaultView,
+    dayViewMode, setDayViewMode,
+    dayViewColumns,
 
     // ── DOM / timer / function refs ───────────────────────────────────────────
     tabBarRef, suppressTabBarRef,
@@ -8235,7 +8288,7 @@ const DayPlanner = () => {
       )}
 
       {/* Refocus timeline toast — all form factors */}
-      {timelineScrolledAway && (
+      {timelineScrolledAway && effectiveViewMode === 'multi' && (
         <div className="fixed left-1/2 -translate-x-1/2 z-50 pointer-events-auto" style={{ bottom: isMobile ? 'calc(5rem + env(safe-area-inset-bottom, 0px))' : '1.5rem' }}>
           <button
             onClick={() => { setTimelineScrolledAway(false); scrollToCurrentHour(true); }}

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -24,6 +24,7 @@ const CalendarHeader = () => {
     visibleDates,
     selectedDate,
     canShowViewCycler, effectiveViewMode,
+    use24HourClock, dayViewColumns,
     mobileDateHeaderRef, mobileAllDaySectionRef,
     autoScrollInterval,
     longPressTimerRef, longPressTriggeredRef,
@@ -87,26 +88,17 @@ const CalendarHeader = () => {
     openRoutinesDashboard,
   } = useFeaturesCtx();
 
+  // Helpers for day-mode date-group header labels
+  const formatBoundHour = (h, use24h) => {
+    const norm = h % 24;
+    if (use24h) return `${norm.toString().padStart(2, '0')}:00`;
+    if (norm === 0) return '12a';
+    if (norm === 12) return '12p';
+    return norm < 12 ? `${norm}a` : `${norm - 12}p`;
+  };
+
   return (
     <>
-{/* Current task banner */}
-{(() => {
-  const todayStr = dateToString(new Date());
-  const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
-  const runningTask = [...tasks, ...expandedRecurringTasks].find(t =>
-    t.date === todayStr && !t.isAllDay && !t.completed &&
-    !(t.imported && !t.isTaskCalendar) &&
-    nowMin >= timeToMinutes(t.startTime || '0:00') &&
-    nowMin < timeToMinutes(t.startTime || '0:00') + (t.duration || 0)
-  );
-  if (!runningTask) return null;
-  return (
-    <div className={`flex items-center gap-2 px-4 py-1.5 text-xs font-semibold ${darkMode ? 'bg-amber-900/40 text-amber-300 border-b border-amber-700/40' : 'bg-amber-50 text-amber-800 border-b border-amber-200'}`}>
-      <span className="w-2 h-2 rounded-full bg-amber-400 animate-pulse flex-shrink-0" />
-      <span className="truncate">Now: {renderTitle(runningTask.title)}</span>
-    </div>
-  );
-})()}
 {/* Date headers row */}
 <div ref={(el) => { if (isTablet) mobileDateHeaderRef.current = el; }} className={`flex border-b ${borderClass} ${cardBg}`}>
   {/* Top-left cell: matches GLANCE/Inbox tab row height; hosts ViewCycler on large screens */}
@@ -171,15 +163,58 @@ const CalendarHeader = () => {
         )}
       </div>
     );
-  }) : (
-    // Non-multi views: single full-width date header for the selected date
-    <div className={`flex-1 py-2 px-3 text-center ${cardBg}`}>
-      <div className={`font-bold flex items-center justify-center gap-1.5 ${dateToString(selectedDate) === dateToString(new Date()) ? 'text-blue-600' : textPrimary}`}>
-        {formatShortDate(selectedDate)}
-      </div>
-    </div>
-  )}
+  }) : (() => {
+    // Day mode: build date groups from dayViewColumns
+    const dateGroups = [];
+    for (const col of dayViewColumns) {
+      const last = dateGroups[dateGroups.length - 1];
+      if (last && last.dateStr === col.dateStr) {
+        last.count++;
+        last.endHour = col.endHour;
+      } else {
+        dateGroups.push({ dateStr: col.dateStr, date: col.date, startHour: col.startHour, endHour: col.endHour, count: 1 });
+      }
+    }
+    return dateGroups.map((group, idx) => {
+      const isDateToday = group.dateStr === dateToString(new Date());
+      const fullDay = group.startHour === 0 && group.endHour === 24;
+      const timeRange = fullDay ? null : `${formatBoundHour(group.startHour, use24HourClock)} \u2013 ${formatBoundHour(group.endHour, use24HourClock)}`;
+      return (
+        <div
+          key={group.dateStr}
+          className={`py-2 px-3 text-center min-h-[44px] flex flex-col items-center justify-center ${idx > 0 ? `border-l ${borderClass}` : ''} ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg}`}
+          style={{ flex: group.count }}
+        >
+          <div className={`font-bold ${isDateToday ? 'text-blue-600' : textPrimary}`}>
+            {formatShortDate(group.date)}
+          </div>
+          {timeRange && (
+            <div className={`text-[11px] ${textSecondary} leading-tight`}>{timeRange}</div>
+          )}
+        </div>
+      );
+    });
+  })()}
 </div>
+
+{/* Now bar - current running task */}
+{(() => {
+  const todayStr = dateToString(new Date());
+  const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
+  const runningTask = [...tasks, ...expandedRecurringTasks].find(t =>
+    t.date === todayStr && !t.isAllDay && !t.completed &&
+    !(t.imported && !t.isTaskCalendar) &&
+    nowMin >= timeToMinutes(t.startTime || '0:00') &&
+    nowMin < timeToMinutes(t.startTime || '0:00') + (t.duration || 0)
+  );
+  if (!runningTask) return null;
+  return (
+    <div className={`flex items-center gap-2 px-4 py-1.5 text-xs font-semibold ${darkMode ? 'bg-amber-900/40 text-amber-300 border-b border-amber-700/40' : 'bg-amber-50 text-amber-800 border-b border-amber-200'}`}>
+      <span className="w-2 h-2 rounded-full bg-amber-400 animate-pulse flex-shrink-0" />
+      <span className="truncate">Now: {renderTitle(runningTask.title)}</span>
+    </div>
+  );
+})()}
 
 {/* All-day tasks section - inside combined sticky header */}
 {(visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay) || getDeadlineTasksForDate(dateToString(date)).length > 0) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -1,29 +1,20 @@
 import React from 'react';
 import {
-  Check, ChevronDown, ChevronUp, FileText, Inbox,
+  Check, ChevronDown, ChevronUp, Inbox,
   Pencil, RefreshCw, SkipForward, Trash2,
 } from 'lucide-react';
 import { renderTitleWithoutTags } from '../utils/textFormatting.jsx';
-import { dateToString } from '../utils/taskUtils.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import useDayViewHourHeight from '../hooks/useDayViewHourHeight.js';
 
-// ── Column definitions ────────────────────────────────────────────────────────
-
-const COLUMNS = [
-  { startHour: 0,  endHour: 8,  label12: '12a \u2013 8a',  label24: '00 \u2013 08' },
-  { startHour: 8,  endHour: 16, label12: '8a \u2013 4p',   label24: '08 \u2013 16' },
-  { startHour: 16, endHour: 24, label12: '4p \u2013 12a',  label24: '16 \u2013 00' },
-];
-
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function hourLabel(hour, use24h) {
-  if (use24h) return hour.toString().padStart(2, '0');
-  if (hour === 0) return '12a';
-  if (hour === 12) return '12p';
-  return hour < 12 ? `${hour}a` : `${hour - 12}p`;
+  if (use24h) return `${hour.toString().padStart(2, '0')}:00`;
+  if (hour === 0) return '12:00a';
+  if (hour === 12) return '12:00p';
+  return hour < 12 ? `${hour}:00a` : `${hour - 12}:00p`;
 }
 
 function getTaskSlice(task, col, hourHeight, timeToMinutes) {
@@ -47,9 +38,6 @@ function getTaskSlice(task, col, hourHeight, timeToMinutes) {
   };
 }
 
-// Simple conflict layout — returns left/width percentages for a task among its
-// overlapping peers within one column. More sophisticated conflict detection
-// (matching TimeGrid's algorithm) is deferred to a follow-up PR.
 function columnConflictPos(task, colTasks, timeToMinutes) {
   const tStart = timeToMinutes(task.startTime || '0:00');
   const tEnd = tStart + (task.duration || 0);
@@ -76,13 +64,11 @@ function columnConflictPos(task, colTasks, timeToMinutes) {
 
 // ── DayViewColumn ─────────────────────────────────────────────────────────────
 
-const DayViewColumn = ({ col, colIdx, date, dateStr, hourHeight }) => {
+const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const {
     isTablet,
     darkMode, use24HourClock,
-    borderClass, textPrimary, textSecondary,
-    tasks,
-    expandedRecurringTasks,
+    borderClass, textSecondary,
     taskContextMenu, setTaskContextMenu,
     toggleComplete,
     moveToRecycleBin, moveToInbox, postponeTask,
@@ -95,7 +81,7 @@ const DayViewColumn = ({ col, colIdx, date, dateStr, hourHeight }) => {
 
   const { projectFilter } = useFeaturesCtx();
 
-  const allDayTasks = getTasksForDate(date);
+  const allDayTasks = getTasksForDate(col.date);
   const colTasks = allDayTasks.filter(t => {
     if (t.isAllDay || !t.startTime) return false;
     if (projectFilter && t.projectId !== projectFilter) return false;
@@ -104,31 +90,19 @@ const DayViewColumn = ({ col, colIdx, date, dateStr, hourHeight }) => {
     return end > col.startHour * 60 && start < col.endHour * 60;
   });
 
-  const colLabel = use24HourClock ? col.label24 : col.label12;
   const hours = Array.from({ length: 8 }, (_, i) => col.startHour + i);
-
   const altRow = darkMode ? 'bg-white/[0.04]' : 'bg-stone-100/50';
 
   return (
     <div className={`flex-1 flex flex-col min-w-0 ${colIdx > 0 ? `border-l ${borderClass}` : ''}`}>
-      {/* Column header */}
-      <div
-        className={`flex items-center justify-center border-b ${borderClass} flex-shrink-0`}
-        style={{ height: '32px' }}
-      >
-        <span className={`text-xs font-semibold tracking-wide ${textSecondary}`}>
-          {colLabel}
-        </span>
-      </div>
-
       {/* Gutter + grid */}
       <div className="flex flex-1 relative">
         {/* Hour label gutter */}
-        <div className={`flex-shrink-0 border-r ${borderClass}`} style={{ width: '40px' }}>
+        <div className={`flex-shrink-0 border-r ${borderClass}`} style={{ width: '44px' }}>
           {hours.map(hour => (
             <div
               key={hour}
-              className={`px-1 flex items-start justify-end`}
+              className="px-1 flex items-start justify-end"
               style={{ height: `${hourHeight}px` }}
             >
               <span className={`text-[10px] ${textSecondary} mt-0.5 leading-none`}>
@@ -206,7 +180,7 @@ const DayViewColumn = ({ col, colIdx, date, dateStr, hourHeight }) => {
                     isRecurring: !!isRecurring,
                     isImported: !!isImported,
                     isAllDay: false,
-                    dateStr,
+                    dateStr: col.dateStr,
                   });
                 }}
               >
@@ -238,7 +212,8 @@ const DayViewColumn = ({ col, colIdx, date, dateStr, hourHeight }) => {
                         </button>
                       )}
                       <div
-                        className={`text-xs font-semibold leading-tight truncate flex-1 min-w-0 ${task.completed ? 'line-through' : ''}`}
+                        className={`font-semibold leading-tight truncate flex-1 min-w-0 ${task.completed ? 'line-through' : ''}`}
+                        style={{ fontSize: '13px' }}
                         title={task.title}
                       >
                         {renderTitleWithoutTags(task.title)}
@@ -262,9 +237,9 @@ const DayViewColumn = ({ col, colIdx, date, dateStr, hourHeight }) => {
                   </div>
                 )}
 
-                {/* Action buttons (non-imported, non-tablet) */}
+                {/* Action buttons (non-imported, non-tablet) — top-right corner */}
                 {!isImported && !isTablet && height > 55 && showTitle && (
-                  <div className="absolute bottom-0.5 right-0.5 flex gap-0.5">
+                  <div className="absolute top-0.5 right-0.5 flex gap-0.5">
                     <button
                       onClick={(e) => { e.stopPropagation(); postponeTask(task.id); }}
                       className="hover:bg-white/20 rounded p-0.5 transition-colors text-white/80"
@@ -311,22 +286,19 @@ const DayViewColumn = ({ col, colIdx, date, dateStr, hourHeight }) => {
 
 const DayView = () => {
   const {
-    selectedDate,
     calendarRef, stickyHeaderRef,
+    dayViewColumns,
   } = useDayPlannerCtx();
 
   const hourHeight = useDayViewHourHeight(calendarRef, stickyHeaderRef);
-  const dateStr = dateToString(selectedDate);
 
   return (
     <div className="flex" style={{ height: '100%' }}>
-      {COLUMNS.map((col, colIdx) => (
+      {dayViewColumns.map((col, colIdx) => (
         <DayViewColumn
-          key={col.startHour}
+          key={`${col.dateStr}-${col.startHour}`}
           col={col}
           colIdx={colIdx}
-          date={selectedDate}
-          dateStr={dateStr}
           hourHeight={hourHeight}
         />
       ))}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -28,6 +28,9 @@ const SettingsModal = () => {
     dailyContentEnabled, setDailyContentEnabled,
     setTasks, setUnscheduledTasks,
     dailyNoteTemplate, setDailyNoteTemplate,
+    defaultView, setDefaultView,
+    dayViewMode, setDayViewMode,
+    canShowViewCycler,
   } = useDayPlannerCtx();
   const {
     handleFileUpload,
@@ -117,6 +120,61 @@ const SettingsModal = () => {
                 <div className="lg:grid lg:grid-cols-2 lg:gap-6 space-y-6 lg:space-y-0">
                   {/* Left column */}
                   <div className="space-y-6">
+
+                    {/* View Defaults Section (only when the cycler is available) */}
+                    {canShowViewCycler && (
+                      <div className="space-y-3">
+                        <h4 className={`font-medium ${textPrimary} flex items-center gap-2`}>
+                          <LayoutGrid size={16} className={textSecondary} />
+                          View defaults
+                        </h4>
+                        <div>
+                          <label className={`block text-xs ${textSecondary} mb-1.5`}>Default view on load</label>
+                          <div className="flex gap-2">
+                            {['multi', 'day', 'week'].map(v => (
+                              <button
+                                key={v}
+                                onClick={() => setDefaultView(v)}
+                                className={`px-3 py-1.5 text-xs rounded-lg transition-colors capitalize ${
+                                  defaultView === v
+                                    ? 'bg-blue-600 text-white'
+                                    : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`
+                                }`}
+                              >
+                                {v === 'multi' ? 'Multi-day' : v === 'day' ? 'Day' : 'Week'}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                        <div>
+                          <label className={`block text-xs ${textSecondary} mb-1.5`}>Day view mode</label>
+                          <div className="flex gap-2">
+                            <button
+                              onClick={() => setDayViewMode('calendar-day')}
+                              className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${
+                                dayViewMode === 'calendar-day'
+                                  ? 'bg-blue-600 text-white'
+                                  : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`
+                              }`}
+                            >
+                              Calendar day
+                            </button>
+                            <button
+                              onClick={() => setDayViewMode('rolling-24')}
+                              className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${
+                                dayViewMode === 'rolling-24'
+                                  ? 'bg-blue-600 text-white'
+                                  : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`
+                              }`}
+                            >
+                              Rolling 24h
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {canShowViewCycler && <hr className={borderClass} />}
 
                     {/* Localization Section */}
                     <div className="space-y-3">

--- a/src/hooks/useDayViewHourHeight.js
+++ b/src/hooks/useDayViewHourHeight.js
@@ -1,9 +1,5 @@
 import { useState, useEffect } from 'react';
 
-// Column header row is ~32px (py-1.5 + text-xs line-height).
-// Subtracted so 8 hour rows fill exactly the remaining vertical space.
-const COL_HEADER_HEIGHT = 32;
-
 export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
   const [hourHeight, setHourHeight] = useState(80);
 
@@ -12,7 +8,7 @@ export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
       if (!calendarRef?.current) return;
       const totalH = calendarRef.current.clientHeight;
       const stickyH = stickyHeaderRef?.current?.offsetHeight || 0;
-      const usable = Math.max(160, totalH - stickyH - COL_HEADER_HEIGHT);
+      const usable = Math.max(160, totalH - stickyH);
       setHourHeight(Math.max(20, Math.floor((usable - 8) / 8)));
     };
 


### PR DESCRIPTION
## Summary

- **Rolling-24 mode**: New `dayViewMode` setting (`'calendar-day'` | `'rolling-24'`). In rolling-24, the leftmost column is always the current 8-hour block; columns crossing midnight automatically carry the next day's date. Computed as `dayViewColumns` in App.jsx and shared via context.
- **Date-group header in day mode**: CalendarHeader renders proportional date cells for day mode, grouping consecutive same-day columns. Each cell shows the date and a time-range sub-label (e.g. "8a – 12a") unless the group spans the full 24 hours.
- **Now bar repositioned**: The running-task banner (amber "Now:" strip) moves to below the date headers row instead of above it.
- **DayView polish**: Hour labels now include `:00` suffix; action buttons moved to top-right corner; task title font floored at 13px; column header row removed from DayView (lives in CalendarHeader sticky header now).
- **Settings**: New "View defaults" section (gated behind `canShowViewCycler`) with button-group toggles for default view on load and day view mode.
- **Refocus toast**: Now only shown when `effectiveViewMode === 'multi'`.

## Test plan

- [ ] Switch to Day view (key `2` or ViewCycler). Confirm 3 columns render, filling the vertical space, with date header above.
- [ ] Verify hour labels show e.g. "08:00", "16:00" in 24h mode and "8:00a", "4:00p" in 12h mode.
- [ ] Open Settings, find "View defaults" section. Toggle between Calendar day and Rolling 24h; switch to Day view and confirm columns shift correctly at 8h boundaries.
- [ ] Set Rolling 24h after 16:00 -- confirm left column is 16-00 on today, rightmost is 00-08 on tomorrow with tomorrow's date in the header.
- [ ] Toggle default view to "Day"; reload the app and confirm it opens in Day view.
- [ ] Confirm the Now bar (amber strip) appears below the date row when a task is currently running.
- [ ] Confirm "Refocus timeline" button does not appear when in Day view.
- [ ] Confirm task action buttons appear at top-right of task pills, not bottom-right.

https://claude.ai/code/session_0118wJxmC1HHc5x2SMRTQoW9