### PR TITLE
Day view PR 3: visual language, header alignment, all-day chip row

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -198,7 +198,7 @@ const CalendarHeader = () => {
               <ViewCycler />
             </div>
           )}
-          <div className={`text-center font-bold text-sm ${isDateToday ? 'text-blue-600' : textPrimary}`}>
+          <div className={`text-center font-bold text-sm ${isDateToday ? 'text-blue-600' : textPrimary} ${idx === 0 && canShowViewCycler ? 'pl-16' : ''}`}>
             {formatShortDate(group.date)}
             {timeRange && (
               <span className={`font-normal text-xs ${textSecondary} ml-1.5`}>\u00b7 {timeRange}</span>

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -6,6 +6,7 @@ import {
   Target, Trash2,
 } from 'lucide-react';
 import ViewCycler from './ViewCycler.jsx';
+import DayViewAllDaySection from './DayViewAllDaySection.jsx';
 import { isNativeAndroid, nativeUpdateEvent } from '../native.js';
 import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
 import { dateToString, extractWikilinks, formatDeadlineDate, formatShortDate } from '../utils/taskUtils.js';
@@ -101,11 +102,13 @@ const CalendarHeader = () => {
     <>
 {/* Date headers row */}
 <div ref={(el) => { if (isTablet) mobileDateHeaderRef.current = el; }} className={`flex border-b ${borderClass} ${cardBg}`}>
-  {/* Top-left cell: matches GLANCE/Inbox tab row height; hosts ViewCycler on large screens */}
-  <div className={`w-16 flex-shrink-0 border-r ${borderClass} flex items-center justify-center min-h-[44px]`}>
-    {canShowViewCycler && <ViewCycler />}
-  </div>
-  {effectiveViewMode === 'multi' ? visibleDates.map((date, idx) => {
+  {effectiveViewMode === 'multi' ? (
+    <>
+    {/* Top-left cell: hosts ViewCycler on large screens */}
+    <div className={`w-16 flex-shrink-0 border-r ${borderClass} flex items-center justify-center min-h-[44px]`}>
+      {canShowViewCycler && <ViewCycler />}
+    </div>
+    {visibleDates.map((date, idx) => {
     const isDateToday = dateToString(date) === dateToString(new Date());
     const dateStr = dateToString(date);
     const isDragOverThis = dragOverAllDay === dateStr;
@@ -163,8 +166,11 @@ const CalendarHeader = () => {
         )}
       </div>
     );
-  }) : (() => {
-    // Day mode: build date groups from dayViewColumns
+  })}
+    </>
+  ) : (() => {
+    // Day mode: build date groups from dayViewColumns — start at x=0 so column
+    // boundaries align exactly with DayView's flex-1 columns below.
     const dateGroups = [];
     for (const col of dayViewColumns) {
       const last = dateGroups[dateGroups.length - 1];
@@ -182,15 +188,22 @@ const CalendarHeader = () => {
       return (
         <div
           key={group.dateStr}
-          className={`py-2 px-3 text-center min-h-[44px] flex flex-col items-center justify-center ${idx > 0 ? `border-l ${borderClass}` : ''} ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg}`}
+          className={`relative min-h-[44px] flex items-center justify-center ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg}`}
           style={{ flex: group.count }}
         >
-          <div className={`font-bold ${isDateToday ? 'text-blue-600' : textPrimary}`}>
-            {formatShortDate(group.date)}
-          </div>
-          {timeRange && (
-            <div className={`text-[11px] ${textSecondary} leading-tight`}>{timeRange}</div>
+          {/* ViewCycler floats in the absolute-left of the first date group so
+              column boundaries align: both header and DayView start at x=0. */}
+          {idx === 0 && canShowViewCycler && (
+            <div className={`absolute left-0 top-0 w-16 h-full border-r ${borderClass}`}>
+              <ViewCycler />
+            </div>
           )}
+          <div className={`text-center font-bold text-sm ${isDateToday ? 'text-blue-600' : textPrimary}`}>
+            {formatShortDate(group.date)}
+            {timeRange && (
+              <span className={`font-normal text-xs ${textSecondary} ml-1.5`}>\u00b7 {timeRange}</span>
+            )}
+          </div>
         </div>
       );
     });
@@ -216,8 +229,11 @@ const CalendarHeader = () => {
   );
 })()}
 
-{/* All-day tasks section - inside combined sticky header */}
-{(visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay) || getDeadlineTasksForDate(dateToString(date)).length > 0) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (
+{/* Day mode all-day chips strip */}
+{effectiveViewMode === 'day' && <DayViewAllDaySection />}
+
+{/* Multi-mode all-day tasks section */}
+{effectiveViewMode === 'multi' && (visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay) || getDeadlineTasksForDate(dateToString(date)).length > 0) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (
   <div ref={(el) => { if (isTablet) mobileAllDaySectionRef.current = el; }} className={`flex border-b ${borderClass} ${cardBg}`}>
     <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>
       ALL DAY

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -12,9 +12,8 @@ import useDayViewHourHeight from '../hooks/useDayViewHourHeight.js';
 
 function hourLabel(hour, use24h) {
   if (use24h) return `${hour.toString().padStart(2, '0')}:00`;
-  if (hour === 0) return '12:00a';
-  if (hour === 12) return '12:00p';
-  return hour < 12 ? `${hour}:00a` : `${hour - 12}:00p`;
+  const n = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  return <>{n}<span className="text-[10px] ml-0.5">{hour >= 12 ? 'PM' : 'AM'}</span></>;
 }
 
 function getTaskSlice(task, col, hourHeight, timeToMinutes) {
@@ -97,17 +96,15 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     <div className={`flex-1 flex flex-col min-w-0 ${colIdx > 0 ? `border-l ${borderClass}` : ''}`}>
       {/* Gutter + grid */}
       <div className="flex flex-1 relative">
-        {/* Hour label gutter */}
-        <div className={`flex-shrink-0 border-r ${borderClass}`} style={{ width: '44px' }}>
+        {/* Hour label gutter — matches TimeGrid's w-16 px-3 py-1 text-sm styling */}
+        <div className={`w-16 flex-shrink-0 border-r ${borderClass}`}>
           {hours.map(hour => (
             <div
               key={hour}
-              className="px-1 flex items-start justify-end"
+              className={`px-3 py-1 text-sm ${textSecondary} flex items-start`}
               style={{ height: `${hourHeight}px` }}
             >
-              <span className={`text-[10px] ${textSecondary} mt-0.5 leading-none`}>
-                {hourLabel(hour, use24HourClock)}
-              </span>
+              {hourLabel(hour, use24HourClock)}
             </div>
           ))}
         </div>
@@ -129,7 +126,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
               className="absolute left-0 right-0 pointer-events-none"
               style={{ top: `${(hour - col.startHour) * hourHeight + hourHeight / 2}px` }}
             >
-              <div className={`border-b border-dashed ${borderClass} opacity-40`} />
+              <div className={`border-b border-dashed ${borderClass} opacity-50`} />
             </div>
           ))}
 

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -33,30 +33,31 @@ const GroupChips = ({ tasks, darkMode, textSecondary, borderClass, cardBg, getTa
   const [limit, setLimit] = useState(null); // null = show all
   const [overflowOpen, setOverflowOpen] = useState(false);
 
-  // Measure which chips fit within MAX_ROWS using a ghost (invisible) render
+  // Measure which chips fit within MAX_ROWS. Re-runs on task count change AND
+  // on container width change (ResizeObserver) so wrapping recalculates on resize.
   useLayoutEffect(() => {
     const el = ghostRef.current;
-    if (!el || !tasks.length) { setLimit(null); return; }
-    const chips = Array.from(el.children);
-    if (!chips.length) { setLimit(null); return; }
+    if (!el) return;
 
-    const rowTop = chips[0].offsetTop;
-    const maxBottom = rowTop + MAX_H;
-
-    let lastFit = chips.length;
-    for (let i = 0; i < chips.length; i++) {
-      if (chips[i].offsetTop + chips[i].offsetHeight > maxBottom + 2) {
-        lastFit = i;
-        break;
+    const measure = () => {
+      const chips = Array.from(el.children);
+      if (!chips.length || !tasks.length) { setLimit(null); return; }
+      const rowTop = chips[0].offsetTop;
+      const maxBottom = rowTop + MAX_H;
+      let lastFit = chips.length;
+      for (let i = 0; i < chips.length; i++) {
+        if (chips[i].offsetTop + chips[i].offsetHeight > maxBottom + 2) {
+          lastFit = i;
+          break;
+        }
       }
-    }
+      setLimit(lastFit < chips.length ? Math.max(0, lastFit - 1) : null);
+    };
 
-    if (lastFit < chips.length) {
-      // Reserve one slot for the "+N more" chip
-      setLimit(Math.max(0, lastFit - 1));
-    } else {
-      setLimit(null);
-    }
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
   }, [tasks.length]);
 
   // Click-outside dismisses the overflow popover

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -1,0 +1,193 @@
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { renderTitleWithoutTags } from '../utils/textFormatting.jsx';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+
+// ── TaskChip ──────────────────────────────────────────────────────────────────
+
+const TaskChip = ({ task, onClick, getTaskCalendarStyle, darkMode }) => {
+  const isCalendarEvent = task.imported && !task.isTaskCalendar;
+  const calStyle = (isCalendarEvent || task.isTaskCalendar) ? getTaskCalendarStyle(task, darkMode) : {};
+  return (
+    <button
+      onClick={onClick}
+      className={`${task.isTaskCalendar ? '' : task.color} text-white text-xs font-medium px-2 py-1 rounded-md shadow-sm truncate max-w-[200px] flex-shrink-0 ${task.completed ? 'opacity-50 line-through' : ''}`}
+      style={calStyle}
+      title={task.title}
+    >
+      {renderTitleWithoutTags(task.title)}
+    </button>
+  );
+};
+
+// ── GroupChips — one date group with 2-row height cap + "+N more" popover ────
+
+const CHIP_ROW_H = 28; // px: approximate height of one chip row (text-xs + py-1)
+const ROW_GAP = 4;     // px: gap-1 = 4px
+const MAX_ROWS = 2;
+const MAX_H = CHIP_ROW_H * MAX_ROWS + ROW_GAP * (MAX_ROWS - 1);
+
+const GroupChips = ({ tasks, darkMode, textSecondary, borderClass, cardBg, getTaskCalendarStyle, openMobileEditTask }) => {
+  const ghostRef = useRef(null);
+  const overflowRef = useRef(null);
+  const [limit, setLimit] = useState(null); // null = show all
+  const [overflowOpen, setOverflowOpen] = useState(false);
+
+  // Measure which chips fit within MAX_ROWS using a ghost (invisible) render
+  useLayoutEffect(() => {
+    const el = ghostRef.current;
+    if (!el || !tasks.length) { setLimit(null); return; }
+    const chips = Array.from(el.children);
+    if (!chips.length) { setLimit(null); return; }
+
+    const rowTop = chips[0].offsetTop;
+    const maxBottom = rowTop + MAX_H;
+
+    let lastFit = chips.length;
+    for (let i = 0; i < chips.length; i++) {
+      if (chips[i].offsetTop + chips[i].offsetHeight > maxBottom + 2) {
+        lastFit = i;
+        break;
+      }
+    }
+
+    if (lastFit < chips.length) {
+      // Reserve one slot for the "+N more" chip
+      setLimit(Math.max(0, lastFit - 1));
+    } else {
+      setLimit(null);
+    }
+  }, [tasks.length]);
+
+  // Click-outside dismisses the overflow popover
+  useEffect(() => {
+    if (!overflowOpen) return;
+    const onDown = (e) => {
+      if (!overflowRef.current?.contains(e.target)) setOverflowOpen(false);
+    };
+    const onKey = (e) => { if (e.key === 'Escape') setOverflowOpen(false); };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [overflowOpen]);
+
+  const shown = limit !== null ? tasks.slice(0, limit) : tasks;
+  const overflowTasks = limit !== null ? tasks.slice(limit) : [];
+
+  return (
+    <div className="relative p-1.5">
+      {/* Ghost render for measurement — invisible, no pointer events */}
+      <div
+        ref={ghostRef}
+        className="absolute top-1.5 left-1.5 right-1.5 flex flex-wrap gap-1 opacity-0 pointer-events-none"
+        aria-hidden="true"
+      >
+        {tasks.map(t => (
+          <TaskChip key={t.id} task={t} darkMode={darkMode} getTaskCalendarStyle={getTaskCalendarStyle} />
+        ))}
+      </div>
+
+      {/* Visible chips */}
+      <div className="flex flex-wrap gap-1" style={{ maxHeight: MAX_H + 12 }}>
+        {shown.map(t => (
+          <TaskChip
+            key={t.id}
+            task={t}
+            darkMode={darkMode}
+            getTaskCalendarStyle={getTaskCalendarStyle}
+            onClick={() => openMobileEditTask(t, false)}
+          />
+        ))}
+
+        {/* "+N more" overflow chip + popover */}
+        {overflowTasks.length > 0 && (
+          <div ref={overflowRef} className="relative flex-shrink-0">
+            <button
+              onClick={() => setOverflowOpen(v => !v)}
+              className={`text-xs font-medium px-2 py-1 rounded-md ${darkMode ? 'bg-gray-600 text-gray-200 hover:bg-gray-500' : 'bg-stone-200 text-stone-600 hover:bg-stone-300'} transition-colors`}
+            >
+              +{overflowTasks.length} more
+            </button>
+            {overflowOpen && (
+              <div className={`absolute top-full left-0 mt-1 z-50 rounded-lg shadow-xl border ${borderClass} ${cardBg} p-2 min-w-[160px] max-w-[260px] flex flex-col gap-1`}>
+                {overflowTasks.map(t => (
+                  <TaskChip
+                    key={t.id}
+                    task={t}
+                    darkMode={darkMode}
+                    getTaskCalendarStyle={getTaskCalendarStyle}
+                    onClick={() => { setOverflowOpen(false); openMobileEditTask(t, false); }}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ── DayViewAllDaySection ──────────────────────────────────────────────────────
+
+const allDayOrder = (t) => {
+  if (t.importSource === 'file') return 0;
+  if (t.imported && !t.isTaskCalendar) return 1;
+  if (t.isTaskCalendar) return 2;
+  if (typeof t.id === 'string' && t.id.startsWith('recurring-')) return 4;
+  return 3;
+};
+
+const DayViewAllDaySection = () => {
+  const {
+    darkMode,
+    borderClass, textSecondary, cardBg,
+    dayViewColumns,
+    getTasksForDate, getTaskCalendarStyle,
+    openMobileEditTask,
+  } = useDayPlannerCtx();
+  const { projectFilter } = useFeaturesCtx();
+
+  // Build date groups (same logic as CalendarHeader day-mode header)
+  const dateGroups = [];
+  for (const col of dayViewColumns) {
+    const last = dateGroups[dateGroups.length - 1];
+    if (last && last.dateStr === col.dateStr) {
+      last.count++;
+    } else {
+      dateGroups.push({ dateStr: col.dateStr, date: col.date, count: 1 });
+    }
+  }
+
+  const groupsWithTasks = dateGroups.map(group => ({
+    ...group,
+    tasks: getTasksForDate(group.date)
+      .filter(t => t.isAllDay && (!projectFilter || t.projectId === projectFilter))
+      .sort((a, b) => allDayOrder(a) - allDayOrder(b)),
+  }));
+
+  if (!groupsWithTasks.some(g => g.tasks.length > 0)) return null;
+
+  return (
+    <div className={`flex border-b ${borderClass} ${cardBg}`}>
+      {groupsWithTasks.map(group => (
+        <div key={group.dateStr} style={{ flex: group.count }} className="min-w-0">
+          <GroupChips
+            tasks={group.tasks}
+            darkMode={darkMode}
+            textSecondary={textSecondary}
+            borderClass={borderClass}
+            cardBg={cardBg}
+            getTaskCalendarStyle={getTaskCalendarStyle}
+            openMobileEditTask={openMobileEditTask}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default DayViewAllDaySection;


### PR DESCRIPTION
## Summary

- **Visual language** (`DayView.jsx`): hour labels now match TimeGrid exactly -- bare number with smaller AM/PM superscript in 12h mode, `HH:00` in 24h; gutter is now `w-16` (64px) with `px-3 py-1 text-sm` matching TimeGrid; half-hour dashes raised from `opacity-40` to `opacity-50`.

- **Header alignment** (`CalendarHeader.jsx`): day-mode date row now starts at x=0 instead of x=64, so date group cell boundaries align exactly with DayView's `flex-1` column boundaries below. ViewCycler is absolute-positioned at the left edge of the first date group cell to preserve its visual position. Rolling-24 header renders date and time range on a single line (`"Sat, Apr 18 · 4p – 12a"`), eliminating the stacked two-line format that caused task clipping at the top of each column.

- **All-day chip row** (`DayViewAllDaySection.jsx`, new): day mode shows all-day tasks as colored horizontal chips above the triptych, grouped by date (matching column proportions for rolling-24). Two-row height cap uses a ghost render to measure which chips fit; excess tasks appear behind a per-group "+N more" chip that opens a popover. Popover dismisses on outside click or Escape. Multi-mode all-day section (full task cards with action buttons) is unchanged, now gated behind `effectiveViewMode === 'multi'`.

## Test plan

- [ ] Switch to Day view. Confirm hour labels match multi view exactly: e.g. `12` `PM` (superscript) in 12h mode, `00:00` in 24h mode.
- [ ] Confirm gutter width is the same as multi view (~64px).
- [ ] Confirm half-hour dashed lines match multi view opacity.
- [ ] Switch to rolling-24 mode after 16:00. Confirm today col and tomorrow col header cells align with the column boundaries in the grid below (a vertical ruler should pass cleanly through both).
- [ ] Confirm rolling-24 header shows date and time range on one line, not stacked.
- [ ] Calendar-day mode: confirm single header spanning all three columns, no time range shown.
- [ ] Add all-day tasks to today and tomorrow. Switch to rolling-24 day view. Confirm today's chips appear in the leftmost group and tomorrow's in the right group.
- [ ] Add 10+ all-day tasks to one date. Confirm only 2 rows of chips are visible and "+N more" appears. Click it -- confirm a popover lists the remaining tasks. Click a task in the popover -- confirm it opens the task editor and the popover closes.
- [ ] Press Escape while popover is open -- confirm it dismisses.
- [ ] Click outside the popover -- confirm it dismisses.
- [ ] Multi view: confirm all-day section looks unchanged (full task cards, action buttons, "ALL DAY" label).

https://claude.ai/code/session_0118wJxmC1HHc5x2SMRTQoW9