### PR TITLE
Day view PR 4: grid structure, shared hour labels, all-day row fixes

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -201,7 +201,7 @@ const CalendarHeader = () => {
           <div className={`text-center font-bold text-sm ${isDateToday ? 'text-blue-600' : textPrimary} ${idx === 0 && canShowViewCycler ? 'pl-16' : ''}`}>
             {formatShortDate(group.date)}
             {timeRange && (
-              <span className={`font-normal text-xs ${textSecondary} ml-1.5`}>\u00b7 {timeRange}</span>
+              <span className={`font-normal text-xs ${textSecondary} ml-1.5`}>· {timeRange}</span>
             )}
           </div>
         </div>

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -4,17 +4,12 @@ import {
   Pencil, RefreshCw, SkipForward, Trash2,
 } from 'lucide-react';
 import { renderTitleWithoutTags } from '../utils/textFormatting.jsx';
+import { formatHourLabel } from '../utils/timeFormatting.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import useDayViewHourHeight from '../hooks/useDayViewHourHeight.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function hourLabel(hour, use24h) {
-  if (use24h) return `${hour.toString().padStart(2, '0')}:00`;
-  const n = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
-  return <>{n}<span className="text-[10px] ml-0.5">{hour >= 12 ? 'PM' : 'AM'}</span></>;
-}
 
 function getTaskSlice(task, col, hourHeight, timeToMinutes) {
   const taskStart = timeToMinutes(task.startTime || '0:00');
@@ -94,43 +89,34 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
 
   return (
     <div className={`flex-1 flex flex-col min-w-0 ${colIdx > 0 ? `border-l ${borderClass}` : ''}`}>
-      {/* Gutter + grid */}
-      <div className="flex flex-1 relative">
-        {/* Hour label gutter — matches TimeGrid's w-16 px-3 py-1 text-sm styling */}
-        <div className={`w-16 flex-shrink-0 border-r ${borderClass}`}>
-          {hours.map(hour => (
-            <div
-              key={hour}
-              className={`px-3 py-1 text-sm ${textSecondary} flex items-start`}
-              style={{ height: `${hourHeight}px` }}
-            >
-              {hourLabel(hour, use24HourClock)}
+      <div className="flex-1 relative">
+        {/* Hour rows — each is a full-width flex row matching TimeGrid's structure */}
+        {hours.map((hour, i) => (
+          <div key={hour} className="relative">
+            <div className={`flex border-b ${borderClass} ${i % 2 === 1 ? altRow : ''}`}>
+              <div
+                className={`w-16 flex-shrink-0 px-3 py-1 text-sm ${textSecondary} border-r ${borderClass} flex items-start`}
+                style={{ height: `${hourHeight}px` }}
+              >
+                {formatHourLabel(hour, use24HourClock)}
+              </div>
+              <div className="flex-1" style={{ height: `${hourHeight}px` }} />
             </div>
-          ))}
-        </div>
-
-        {/* Time slot rows */}
-        <div className="flex-1 relative">
-          {hours.map((hour, i) => (
+            {/* Half-hour dashed line — full-width flex matching TimeGrid */}
             <div
-              key={hour}
-              className={`border-b ${borderClass} ${i % 2 === 1 ? altRow : ''}`}
-              style={{ height: `${hourHeight}px` }}
-            />
-          ))}
-
-          {/* Half-hour dashed lines */}
-          {hours.map(hour => (
-            <div
-              key={`half-${hour}`}
               className="absolute left-0 right-0 pointer-events-none"
-              style={{ top: `${(hour - col.startHour) * hourHeight + hourHeight / 2}px` }}
+              style={{ top: `${hourHeight / 2}px` }}
             >
-              <div className={`border-b border-dashed ${borderClass} opacity-50`} />
+              <div className={`flex border-b border-dashed ${borderClass} opacity-50`}>
+                <div className="w-16 flex-shrink-0" />
+                <div className="flex-1" />
+              </div>
             </div>
-          ))}
+          </div>
+        ))}
 
-          {/* Task pills */}
+        {/* Task pill overlay — covers the event area only (right of gutter) */}
+        <div className="absolute top-0 left-16 right-0 bottom-0 pointer-events-none">
           {colTasks.map(task => {
             const slice = getTaskSlice(task, col, hourHeight, timeToMinutes);
             if (!slice) return null;
@@ -222,7 +208,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                   {showTitle && height > 42 && (
                     <div className="text-[10px] opacity-80 leading-none mt-0.5 flex-shrink-0">
                       {formatTime(task.startTime)}
-                      {task.duration ? ` \u00b7 ${task.duration}m` : ''}
+                      {task.duration ? ` · ${task.duration}m` : ''}
                     </div>
                   )}
                 </div>

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -1,28 +1,85 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Check, Inbox, Pencil, SkipForward, Trash2 } from 'lucide-react';
 import { renderTitleWithoutTags } from '../utils/textFormatting.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
-// ── TaskChip ──────────────────────────────────────────────────────────────────
+// ── AllDayChip — matches multi-view card style ────────────────────────────────
 
-const TaskChip = ({ task, onClick, getTaskCalendarStyle, darkMode }) => {
-  const isCalendarEvent = task.imported && !task.isTaskCalendar;
-  const calStyle = (isCalendarEvent || task.isTaskCalendar) ? getTaskCalendarStyle(task, darkMode) : {};
+const AllDayChip = ({ task, getTaskCalendarStyle, darkMode, openMobileEditTask }) => {
+  const {
+    isTablet,
+    toggleComplete, postponeTask, moveToInbox, moveToRecycleBin,
+  } = useDayPlannerCtx();
+
+  const isImported = task.imported && !task.isTaskCalendar;
+  const isRecurring = typeof task.id === 'string' && task.id.startsWith('recurring-');
+  const calStyle = (isImported || task.isTaskCalendar) ? getTaskCalendarStyle(task, darkMode) : {};
+
   return (
-    <button
-      onClick={onClick}
-      className={`${task.isTaskCalendar ? '' : task.color} text-white text-xs font-medium px-2 py-1 rounded-md shadow-sm truncate max-w-[200px] flex-shrink-0 ${task.completed ? 'opacity-50 line-through' : ''}`}
+    <div
+      onClick={() => openMobileEditTask(task, false)}
+      className={`${task.isTaskCalendar ? '' : task.color} rounded-lg shadow-sm cursor-pointer flex-shrink-0 ${task.completed && !isImported ? 'opacity-50' : ''}`}
       style={calStyle}
       title={task.title}
     >
-      {renderTitleWithoutTags(task.title)}
-    </button>
+      <div className="px-2 py-1 text-white">
+        <div className="flex items-center gap-1.5 min-w-0">
+          {(!task.imported || task.isTaskCalendar) && (
+            <button
+              onClick={(e) => { e.stopPropagation(); toggleComplete(task.id); }}
+              className={`rounded flex-shrink-0 border-2 border-white w-3.5 h-3.5 flex items-center justify-center transition-colors ${task.completed ? 'bg-white/40' : 'bg-white/20'} hover:bg-white/30`}
+            >
+              {task.completed && <Check size={9} strokeWidth={3} />}
+            </button>
+          )}
+          <span className={`text-xs font-semibold truncate flex-1 min-w-0 max-w-[160px] ${task.completed ? 'line-through' : ''}`}>
+            {renderTitleWithoutTags(task.title)}
+          </span>
+          {!isTablet && !isImported && (
+            <div className="flex items-center gap-0.5 flex-shrink-0">
+              <button
+                onClick={(e) => { e.stopPropagation(); postponeTask(task.id); }}
+                className="hover:bg-white/20 rounded p-0.5 transition-colors text-white/80"
+                title="Postpone"
+              >
+                <SkipForward size={10} />
+              </button>
+              <button
+                onClick={(e) => { e.stopPropagation(); openMobileEditTask(task, false); }}
+                className="hover:bg-white/20 rounded p-0.5 transition-colors text-white/80"
+                title="Edit"
+              >
+                <Pencil size={10} />
+              </button>
+              {isRecurring ? (
+                <button
+                  onClick={(e) => { e.stopPropagation(); moveToRecycleBin(task.id); }}
+                  className="hover:bg-white/20 rounded p-0.5 transition-colors text-white/80"
+                  title="Delete"
+                >
+                  <Trash2 size={10} />
+                </button>
+              ) : (
+                <button
+                  onClick={(e) => { e.stopPropagation(); moveToInbox(task.id); }}
+                  className="hover:bg-white/20 rounded p-0.5 transition-colors text-white/80"
+                  title="To Inbox"
+                >
+                  <Inbox size={10} />
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
   );
 };
 
 // ── GroupChips — one date group with 2-row height cap + "+N more" popover ────
 
-const CHIP_ROW_H = 28; // px: approximate height of one chip row (text-xs + py-1)
+const CHIP_ROW_H = 32; // px: approximate height of one chip row
 const ROW_GAP = 4;     // px: gap-1 = 4px
 const MAX_ROWS = 2;
 const MAX_H = CHIP_ROW_H * MAX_ROWS + ROW_GAP * (MAX_ROWS - 1);
@@ -33,8 +90,6 @@ const GroupChips = ({ tasks, darkMode, textSecondary, borderClass, cardBg, getTa
   const [limit, setLimit] = useState(null); // null = show all
   const [overflowOpen, setOverflowOpen] = useState(false);
 
-  // Measure which chips fit within MAX_ROWS. Re-runs on task count change AND
-  // on container width change (ResizeObserver) so wrapping recalculates on resize.
   useLayoutEffect(() => {
     const el = ghostRef.current;
     if (!el) return;
@@ -87,19 +142,19 @@ const GroupChips = ({ tasks, darkMode, textSecondary, borderClass, cardBg, getTa
         aria-hidden="true"
       >
         {tasks.map(t => (
-          <TaskChip key={t.id} task={t} darkMode={darkMode} getTaskCalendarStyle={getTaskCalendarStyle} />
+          <AllDayChip key={t.id} task={t} darkMode={darkMode} getTaskCalendarStyle={getTaskCalendarStyle} openMobileEditTask={openMobileEditTask} />
         ))}
       </div>
 
       {/* Visible chips */}
-      <div className="flex flex-wrap gap-1" style={{ maxHeight: MAX_H + 12 }}>
+      <div className="flex flex-wrap gap-1">
         {shown.map(t => (
-          <TaskChip
+          <AllDayChip
             key={t.id}
             task={t}
             darkMode={darkMode}
             getTaskCalendarStyle={getTaskCalendarStyle}
-            onClick={() => openMobileEditTask(t, false)}
+            openMobileEditTask={openMobileEditTask}
           />
         ))}
 
@@ -115,12 +170,12 @@ const GroupChips = ({ tasks, darkMode, textSecondary, borderClass, cardBg, getTa
             {overflowOpen && (
               <div className={`absolute top-full left-0 mt-1 z-50 rounded-lg shadow-xl border ${borderClass} ${cardBg} p-2 min-w-[160px] max-w-[260px] flex flex-col gap-1`}>
                 {overflowTasks.map(t => (
-                  <TaskChip
+                  <AllDayChip
                     key={t.id}
                     task={t}
                     darkMode={darkMode}
                     getTaskCalendarStyle={getTaskCalendarStyle}
-                    onClick={() => { setOverflowOpen(false); openMobileEditTask(t, false); }}
+                    openMobileEditTask={() => { setOverflowOpen(false); openMobileEditTask(t, false); }}
                   />
                 ))}
               </div>
@@ -174,19 +229,26 @@ const DayViewAllDaySection = () => {
 
   return (
     <div className={`flex border-b ${borderClass} ${cardBg}`}>
-      {groupsWithTasks.map(group => (
-        <div key={group.dateStr} style={{ flex: group.count }} className="min-w-0">
-          <GroupChips
-            tasks={group.tasks}
-            darkMode={darkMode}
-            textSecondary={textSecondary}
-            borderClass={borderClass}
-            cardBg={cardBg}
-            getTaskCalendarStyle={getTaskCalendarStyle}
-            openMobileEditTask={openMobileEditTask}
-          />
-        </div>
-      ))}
+      {/* ALL DAY gutter label — matches multi-view all-day section */}
+      <div className={`w-16 flex-shrink-0 px-2 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass} flex items-start justify-center`}>
+        ALL DAY
+      </div>
+      {/* Date groups — each spans `count` columns proportionally */}
+      <div className="flex flex-1 min-w-0">
+        {groupsWithTasks.map((group, idx) => (
+          <div key={group.dateStr} style={{ flex: group.count }} className={`min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}`}>
+            <GroupChips
+              tasks={group.tasks}
+              darkMode={darkMode}
+              textSecondary={textSecondary}
+              borderClass={borderClass}
+              cardBg={cardBg}
+              getTaskCalendarStyle={getTaskCalendarStyle}
+              openMobileEditTask={openMobileEditTask}
+            />
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -6,6 +6,7 @@ import {
 } from 'lucide-react';
 import { isNativeAndroid, nativeUpdateEvent } from '../native.js';
 import { renderTitleWithoutTags, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
+import { formatHourLabel } from '../utils/timeFormatting.jsx';
 import { dateToString, extractTags, extractWikilinks, stripWikilinks } from '../utils/taskUtils.js';
 import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
@@ -92,10 +93,7 @@ const TimeGrid = () => {
       {/* Main hour row with solid border */}
       <div className={`flex border-b ${index === 0 ? `border-t` : ''} ${borderClass} ${index % 2 === 1 ? (darkMode ? 'bg-white/[0.04]' : 'bg-stone-100/50') : ''}`}>
         <div className={`w-16 flex-shrink-0 px-3 py-1 text-sm ${textSecondary} border-r ${borderClass}`}>
-          {use24HourClock
-            ? `${hour.toString().padStart(2, '0')}:00`
-            : <>{hour === 0 ? 12 : hour > 12 ? hour - 12 : hour}<span className="text-[10px] ml-0.5">{hour >= 12 ? 'PM' : 'AM'}</span></>
-          }
+          {formatHourLabel(hour, use24HourClock)}
         </div>
         {visibleDates.map((date, idx) => (
           <div

--- a/src/utils/timeFormatting.jsx
+++ b/src/utils/timeFormatting.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export function formatHourLabel(hour, use24h) {
+  const norm = hour % 24;
+  if (use24h) return `${norm.toString().padStart(2, '0')}:00`;
+  const n = norm === 0 ? 12 : norm > 12 ? norm - 12 : norm;
+  return <>{n}<span className="text-[10px] ml-0.5">{norm >= 12 ? 'PM' : 'AM'}</span></>;
+}


### PR DESCRIPTION
## Summary

- **Bug: middot renders as literal text** (`CalendarHeader.jsx`): the `\u00b7` Unicode escape in JSX text content is not processed by the JSX transformer, so it rendered as the seven characters `\u00b7`. Replaced with the actual UTF-8 middot character `·`.

- **Shared hour label utility** (`src/utils/timeFormatting.jsx`, new): `formatHourLabel(hour, use24h)` normalises the hour with `% 24` before formatting, fixing the edge-case where hour 24 would display as "12 PM" instead of "12 AM". Both `TimeGrid` and `DayView` now import this shared function instead of maintaining separate inline implementations.

- **DayView grid structure** (`DayView.jsx`): restructured hour rows to match `TimeGrid` exactly. Previously, `border-b` and alternating-row shading were applied only to the event column, leaving the gutter unstyled. Now each hour is a full-width flex row `[w-16 gutter | flex-1 event]` with the border and shading applied to the whole row. Half-hour dashed lines use the same full-width flex structure positioned at `hourHeight / 2`. Task pills moved to an `absolute top-0 left-16 right-0 bottom-0` overlay so their `left` / `width` percentages remain relative to the event area.

- **DayView all-day row** (`DayViewAllDaySection.jsx`):
  - Replaced tiny `TaskChip` pills (`text-xs px-2 py-1 rounded-md`, no action buttons) with `AllDayChip` cards that match the multi-view all-day style: colored `rounded-lg` card, completion checkbox, title, and postpone / edit / inbox-or-delete action buttons on non-tablet.
  - Removed the fixed `maxHeight` from the visible chip container -- height is now dynamic, eliminating the blank gap below chips when fewer than two rows are needed.
  - Added "ALL DAY" gutter label on the left matching the multi-view all-day section.

## Test plan

- [ ] Switch to Day view (rolling-24). Confirm the time range in the column header renders as e.g. "Sat, Apr 18 · 4p -- 12a" with an actual middot, not the literal string `\u00b7`.
- [ ] Confirm hour labels in Day view match multi view exactly: bare number with small AM/PM superscript in 12h mode, `HH:00` in 24h mode.
- [ ] In Day view, confirm horizontal solid gridlines span the full column width (gutter + event area), not just the event column.
- [ ] Confirm alternating hour-block background shading also spans full column width.
- [ ] Confirm half-hour dashed lines span full column width at the midpoint of each hour row.
- [ ] Add all-day tasks. Confirm they appear as colored cards (not tiny pills) with a completion checkbox and action buttons (postpone, edit, inbox).
- [ ] Confirm the all-day row shows "ALL DAY" on the left.
- [ ] Add exactly 1 all-day task. Confirm the all-day row height shrinks to 1 row (no blank gap below).
- [ ] Add many all-day tasks (10+). Confirm overflow still works: 2 rows visible, "+N more" button, popover.
- [ ] Multi view: confirm all-day section and hour labels are unchanged.

https://claude.ai/code/session_0118wJxmC1HHc5x2SMRTQoW9