### PR TITLE
Day view all-day row: horizontal chip layout with 2-row cap and overflow

### DIFF
--- a/src/components/AllDayTaskCard.jsx
+++ b/src/components/AllDayTaskCard.jsx
@@ -13,7 +13,7 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
-const AllDayTaskCard = ({ task }) => {
+const AllDayTaskCard = ({ task, fillWidth = true }) => {
   const {
     isTablet,
     darkMode,
@@ -161,7 +161,7 @@ const AllDayTaskCard = ({ task }) => {
   };
 
   return (
-    <div className={isTablet && !isImported ? 'relative flex-1 min-w-0 rounded-lg overflow-hidden' : 'relative overflow-hidden'}>
+    <div className={isTablet && !isImported ? 'relative flex-1 min-w-0 rounded-lg overflow-hidden' : `relative overflow-hidden${fillWidth ? '' : ' w-fit'}`}>
       <div
         {...(isTablet && !isImported ? {
           onTouchStart: (e) => handleMobileTaskTouchStart(e, task, 'allday'),
@@ -178,7 +178,7 @@ const AllDayTaskCard = ({ task }) => {
         )}
         <div className="p-2 text-white">
           <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2 flex-1 min-w-0">
+            <div className={`flex items-center gap-2 min-w-0${fillWidth ? ' flex-1' : ''}`}>
               {(!isImported || task.isTaskCalendar) && (
                 <button
                   onClick={() => toggleComplete(task.id)}
@@ -190,7 +190,7 @@ const AllDayTaskCard = ({ task }) => {
               <Calendar size={14} className="flex-shrink-0" />
               {task.isRecurring && <RefreshCw size={12} className="flex-shrink-0 opacity-75 hover:opacity-100 cursor-pointer" onClick={(e) => { e.stopPropagation(); setEditingRecurrenceTaskId(task.id); }} />}
               <div
-                className={`${task.isTaskCalendar ? 'font-bold' : 'font-semibold'} text-sm truncate ${task.completed ? 'line-through' : ''} ${!isImported && !isTablet ? 'cursor-text' : ''} flex-1 min-w-0`}
+                className={`${task.isTaskCalendar ? 'font-bold' : 'font-semibold'} text-sm truncate ${task.completed ? 'line-through' : ''} ${!isImported && !isTablet ? 'cursor-text' : ''} ${fillWidth ? 'flex-1 min-w-0' : 'max-w-[160px]'}`}
                 onDoubleClick={!isTablet ? (e) => {
                   if (!isImported) {
                     e.stopPropagation();

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -1,7 +1,117 @@
-import React from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import AllDayTaskCard from './AllDayTaskCard.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+
+const CHIP_ROW_H = 40; // approximate AllDayTaskCard height in px
+const ROW_GAP = 4;     // gap-1 = 4px
+const MAX_ROWS = 2;
+const MAX_H = CHIP_ROW_H * MAX_ROWS + ROW_GAP * (MAX_ROWS - 1);
+
+// ── GroupChips — horizontal flex-wrap with 2-row cap + "+N more" popover ─────
+
+const GroupChips = ({ tasks, darkMode, borderClass, cardBg }) => {
+  const ghostRef = useRef(null);
+  const overflowRef = useRef(null);
+  const [limit, setLimit] = useState(null);
+  const [overflowOpen, setOverflowOpen] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = ghostRef.current;
+    if (!el) return;
+
+    const measure = () => {
+      const chips = Array.from(el.children);
+      if (!chips.length || !tasks.length) { setLimit(null); return; }
+      const rowTop = chips[0].offsetTop;
+      const maxBottom = rowTop + MAX_H;
+      let lastFit = chips.length;
+      for (let i = 0; i < chips.length; i++) {
+        if (chips[i].offsetTop + chips[i].offsetHeight > maxBottom + 2) {
+          lastFit = i;
+          break;
+        }
+      }
+      setLimit(lastFit < chips.length ? Math.max(0, lastFit - 1) : null);
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [tasks.length]);
+
+  useEffect(() => {
+    if (!overflowOpen) return;
+    const onDown = (e) => {
+      if (!overflowRef.current?.contains(e.target)) setOverflowOpen(false);
+    };
+    const onKey = (e) => { if (e.key === 'Escape') setOverflowOpen(false); };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [overflowOpen]);
+
+  const shown = limit !== null ? tasks.slice(0, limit) : tasks;
+  const overflowTasks = limit !== null ? tasks.slice(limit) : [];
+
+  return (
+    <div className="relative p-1.5">
+      {/* Ghost render for overflow measurement — invisible, no pointer events */}
+      <div
+        ref={ghostRef}
+        className="absolute top-1.5 left-1.5 right-1.5 flex flex-wrap gap-1 opacity-0 pointer-events-none"
+        aria-hidden="true"
+      >
+        {tasks.map(t => (
+          <AllDayTaskCard key={t.id} task={t} fillWidth={false} />
+        ))}
+      </div>
+
+      {/* Visible chips */}
+      <div className="flex flex-wrap gap-1">
+        {shown.map(t => (
+          <div
+            key={t.id}
+            className={`notes-panel-container relative flex-shrink-0 ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
+          >
+            <AllDayTaskCard task={t} fillWidth={false} />
+          </div>
+        ))}
+
+        {/* "+N more" overflow chip + popover */}
+        {overflowTasks.length > 0 && (
+          <div ref={overflowRef} className="relative flex-shrink-0 self-start">
+            <button
+              onClick={() => setOverflowOpen(v => !v)}
+              className={`text-xs font-medium px-2 py-1 rounded-md ${darkMode ? 'bg-gray-600 text-gray-200 hover:bg-gray-500' : 'bg-stone-200 text-stone-600 hover:bg-stone-300'} transition-colors`}
+            >
+              +{overflowTasks.length} more
+            </button>
+            {overflowOpen && (
+              <div className={`absolute top-full left-0 mt-1 z-50 rounded-lg shadow-xl border ${borderClass} ${cardBg} p-2 min-w-[200px] max-w-[300px] flex flex-col gap-1`}>
+                {overflowTasks.map(t => (
+                  <div
+                    key={t.id}
+                    className={`notes-panel-container relative ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
+                    onClick={() => setOverflowOpen(false)}
+                  >
+                    <AllDayTaskCard task={t} fillWidth={true} />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ── DayViewAllDaySection ──────────────────────────────────────────────────────
 
 const allDayOrder = (t) => {
   if (t.importSource === 'file') return 0;
@@ -16,7 +126,7 @@ const DayViewAllDaySection = () => {
     darkMode,
     borderClass, textSecondary, cardBg,
     dayViewColumns,
-    getTasksForDate, getTaskCalendarStyle,
+    getTasksForDate,
   } = useDayPlannerCtx();
   const { projectFilter } = useFeaturesCtx();
 
@@ -42,8 +152,8 @@ const DayViewAllDaySection = () => {
 
   return (
     <div className={`flex border-b ${borderClass} ${cardBg}`}>
-      {/* ALL DAY gutter label — matches multi-view all-day section */}
-      <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>
+      {/* ALL DAY gutter label */}
+      <div className={`w-16 flex-shrink-0 px-2 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass} flex items-start justify-center`}>
         ALL DAY
       </div>
       {/* Date groups — each spans `count` columns proportionally */}
@@ -52,16 +162,14 @@ const DayViewAllDaySection = () => {
           <div
             key={group.dateStr}
             style={{ flex: group.count }}
-            className={`min-w-0 p-2 space-y-1 ${idx > 0 ? `border-l ${borderClass}` : ''}`}
+            className={`min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}`}
           >
-            {group.tasks.map(task => (
-              <div
-                key={task.id}
-                className={`notes-panel-container relative ${task.completed && (!task.imported || task.isTaskCalendar) ? 'opacity-50' : ''}`}
-              >
-                <AllDayTaskCard task={task} />
-              </div>
-            ))}
+            <GroupChips
+              tasks={group.tasks}
+              darkMode={darkMode}
+              borderClass={borderClass}
+              cardBg={cardBg}
+            />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary

- `AllDayTaskCard`: add `fillWidth` prop (default `true`, preserving multi view behaviour). When `fillWidth={false}`, the outer wrapper becomes `w-fit` and the title gets `max-w-[160px]` instead of `flex-1 min-w-0`, so chips size to their content rather than filling the row.
- `DayViewAllDaySection`: replace the vertical `space-y-1` stack adopted from multi view in PR #5 with a horizontal flex-wrap `GroupChips` layout matching the original PR #3 design spec. The shared `AllDayTaskCard` component is retained; only the layout container changes.

## Layout behaviour

- Chips stack horizontally and wrap as needed.
- ResizeObserver measures a hidden ghost render of all chips to find the overflow cutoff point.
- Hard cap: 2 rows. Beyond 2 rows, visible chips stop and a "+N more" button appears.
- "+N more" opens a popover listing the remaining chips (full-width `AllDayTaskCard`, same interactions). Popover dismisses on outside click or Escape.
- Rolling-24 two-date view: each date group gets its own independent `GroupChips` instance with its own 2-row cap and popover.

## What stays the same

- `AllDayTaskCard` component is shared between multi view (CalendarHeader) and day view (DayViewAllDaySection) -- no change there.
- Multi view uses `fillWidth={true}` (the default) so its layout is unaffected.

## Test plan

- [ ] Day view single date: all-day chips appear horizontally, wrap after filling a row, cap at 2 rows, "+N more" appears and opens correct popover
- [ ] Day view rolling-24 (triptych): Saturday chips stay in Saturday column, Sunday chips in Sunday column, each with independent overflow
- [ ] Multi view: all-day chip layout unchanged (vertical stacking, full-width chips)
- [ ] Popover dismisses on outside click and Escape key
- [ ] Chips in popover are interactive (complete, postpone, edit, etc.)
- [ ] Dark mode styling correct for "+N more" button and popover

https://claude.ai/code/session_0118wJxmC1HHc5x2SMRTQoW9