### PR TITLE
Day view all-day row: fix column alignment, gutter label, and chip layout bugs

### DIFF
--- a/src/components/AllDayTaskCard.jsx
+++ b/src/components/AllDayTaskCard.jsx
@@ -163,7 +163,7 @@ const AllDayTaskCard = ({ task, fillWidth = true }) => {
   };
 
   return (
-    <div className={isTablet && !isImported ? 'relative flex-1 min-w-0 rounded-lg overflow-hidden' : `relative overflow-hidden${fillWidth ? '' : ' min-w-[200px] max-w-[300px]'}`}>
+    <div className={isTablet && !isImported ? 'relative flex-1 min-w-0 rounded-lg overflow-hidden' : `relative overflow-hidden${fillWidth ? '' : ' w-full'}`}>
       <div
         {...(isTablet && !isImported ? {
           onTouchStart: (e) => handleMobileTaskTouchStart(e, task, 'allday'),

--- a/src/components/AllDayTaskCard.jsx
+++ b/src/components/AllDayTaskCard.jsx
@@ -52,7 +52,9 @@ const AllDayTaskCard = ({ task, fillWidth = true }) => {
   const taskCalendarStyle = getTaskCalendarStyle(task, darkMode);
   const isRecurringAllDay = typeof task.id === 'string' && task.id.startsWith('recurring-');
   const allDayTaskWidth = taskWidths[task.id];
-  const useFullLayout = allDayTaskWidth === undefined || allDayTaskWidth >= 200;
+  // Day-view chips (fillWidth=false) always use full layout — they have a min-width of 200px
+  // and must never read stale taskWidths measurements from multi view.
+  const useFullLayout = !fillWidth || allDayTaskWidth === undefined || allDayTaskWidth >= 200;
 
   const NotesButton = ({ inMenu = false }) => (
     <button
@@ -161,7 +163,7 @@ const AllDayTaskCard = ({ task, fillWidth = true }) => {
   };
 
   return (
-    <div className={isTablet && !isImported ? 'relative flex-1 min-w-0 rounded-lg overflow-hidden' : `relative overflow-hidden${fillWidth ? '' : ' w-fit'}`}>
+    <div className={isTablet && !isImported ? 'relative flex-1 min-w-0 rounded-lg overflow-hidden' : `relative overflow-hidden${fillWidth ? '' : ' min-w-[200px] max-w-[300px]'}`}>
       <div
         {...(isTablet && !isImported ? {
           onTouchStart: (e) => handleMobileTaskTouchStart(e, task, 'allday'),

--- a/src/components/AllDayTaskCard.jsx
+++ b/src/components/AllDayTaskCard.jsx
@@ -180,7 +180,7 @@ const AllDayTaskCard = ({ task, fillWidth = true }) => {
         )}
         <div className="p-2 text-white">
           <div className="flex items-center justify-between gap-2">
-            <div className={`flex items-center gap-2 min-w-0${fillWidth ? ' flex-1' : ''}`}>
+            <div className="flex items-center gap-2 min-w-0 flex-1">
               {(!isImported || task.isTaskCalendar) && (
                 <button
                   onClick={() => toggleComplete(task.id)}
@@ -192,7 +192,7 @@ const AllDayTaskCard = ({ task, fillWidth = true }) => {
               <Calendar size={14} className="flex-shrink-0" />
               {task.isRecurring && <RefreshCw size={12} className="flex-shrink-0 opacity-75 hover:opacity-100 cursor-pointer" onClick={(e) => { e.stopPropagation(); setEditingRecurrenceTaskId(task.id); }} />}
               <div
-                className={`${task.isTaskCalendar ? 'font-bold' : 'font-semibold'} text-sm truncate ${task.completed ? 'line-through' : ''} ${!isImported && !isTablet ? 'cursor-text' : ''} ${fillWidth ? 'flex-1 min-w-0' : 'max-w-[160px]'}`}
+                className={`${task.isTaskCalendar ? 'font-bold' : 'font-semibold'} text-sm truncate ${task.completed ? 'line-through' : ''} ${!isImported && !isTablet ? 'cursor-text' : ''} flex-1 min-w-0`}
                 onDoubleClick={!isTablet ? (e) => {
                   if (!isImported) {
                     e.stopPropagation();

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -189,7 +189,7 @@ const CalendarHeader = () => {
       return (
         <div
           key={group.dateStr}
-          className={`relative min-h-[44px] flex items-center justify-center ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg}`}
+          className={`relative min-h-[46px] flex items-center justify-center ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg}`}
           style={{ flex: group.count }}
         >
           {/* ViewCycler floats in the absolute-left of the first date group so

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -67,7 +67,9 @@ const GroupChips = ({ tasks, darkMode, borderClass, cardBg }) => {
         aria-hidden="true"
       >
         {tasks.map(t => (
-          <AllDayTaskCard key={t.id} task={t} fillWidth={false} />
+          <div key={t.id} className="flex-1 min-w-[200px] max-w-[300px]">
+            <AllDayTaskCard task={t} fillWidth={false} />
+          </div>
         ))}
       </div>
 
@@ -76,7 +78,7 @@ const GroupChips = ({ tasks, darkMode, borderClass, cardBg }) => {
         {shown.map(t => (
           <div
             key={t.id}
-            className={`notes-panel-container relative flex-shrink-0 ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
+            className={`notes-panel-container relative flex-1 min-w-[200px] max-w-[300px] ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
           >
             <AllDayTaskCard task={t} fillWidth={false} />
           </div>

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -152,18 +152,20 @@ const DayViewAllDaySection = () => {
 
   return (
     <div className={`flex border-b ${borderClass} ${cardBg}`}>
-      {/* ALL DAY gutter label */}
-      <div className={`w-16 flex-shrink-0 px-2 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass} flex items-start justify-center`}>
-        ALL DAY
-      </div>
-      {/* Date groups — each spans `count` columns proportionally */}
-      <div className="flex flex-1 min-w-0">
-        {groupsWithTasks.map((group, idx) => (
-          <div
-            key={group.dateStr}
-            style={{ flex: group.count }}
-            className={`min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}`}
-          >
+      {/*
+        Each date group mirrors DayViewColumn exactly: a w-16 gutter + flex-1 chips area.
+        This keeps group boundaries pixel-aligned with column boundaries in the timeline.
+      */}
+      {groupsWithTasks.map((group, idx) => (
+        <div
+          key={group.dateStr}
+          style={{ flex: group.count }}
+          className={`flex min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}`}
+        >
+          <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>
+            {idx === 0 ? 'ALL DAY' : ''}
+          </div>
+          <div className="flex-1 min-w-0">
             <GroupChips
               tasks={group.tasks}
               darkMode={darkMode}
@@ -171,8 +173,8 @@ const DayViewAllDaySection = () => {
               cardBg={cardBg}
             />
           </div>
-        ))}
-      </div>
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -636,13 +636,13 @@ const DesktopLayout = () => {
               <div className={`flex border-b ${borderClass} flex-shrink-0`}>
                 <button
                   onClick={() => setTabletActiveTab('glance')}
-                  className={`flex-1 py-3 text-sm font-semibold text-center transition-colors ${tabletActiveTab === 'glance' ? 'text-blue-500 border-b-2 border-blue-500' : textSecondary}`}
+                  className={`flex-1 py-3 text-sm font-semibold text-center transition-colors ${tabletActiveTab === 'glance' ? 'text-blue-500 border-b-2 border-blue-500' : `${textSecondary} border-b-2 border-transparent`}`}
                 >
                   <span className="flex items-center justify-center gap-1.5"><Eye size={16} /> GLANCE</span>
                 </button>
                 <button
                   onClick={() => setTabletActiveTab('inbox')}
-                  className={`flex-1 py-3 text-sm font-semibold text-center transition-colors relative ${tabletActiveTab === 'inbox' ? 'text-blue-500 border-b-2 border-blue-500' : textSecondary}`}
+                  className={`flex-1 py-3 text-sm font-semibold text-center transition-colors relative ${tabletActiveTab === 'inbox' ? 'text-blue-500 border-b-2 border-blue-500' : `${textSecondary} border-b-2 border-transparent`}`}
                 >
                   <span className="flex items-center justify-center gap-1.5">
                     <Inbox size={16} /> Inbox
@@ -707,13 +707,13 @@ const DesktopLayout = () => {
             <div className={`flex border-b ${borderClass} flex-shrink-0`}>
               <button
                 onClick={() => setTabletActiveTab('glance')}
-                className={`flex-1 py-3 text-sm font-semibold text-center transition-colors ${tabletActiveTab === 'glance' ? 'text-blue-500 border-b-2 border-blue-500' : textSecondary}`}
+                className={`flex-1 py-3 text-sm font-semibold text-center transition-colors ${tabletActiveTab === 'glance' ? 'text-blue-500 border-b-2 border-blue-500' : `${textSecondary} border-b-2 border-transparent`}`}
               >
                 <span className="flex items-center justify-center gap-1.5"><Eye size={16} /> GLANCE</span>
               </button>
               <button
                 onClick={() => setTabletActiveTab('inbox')}
-                className={`flex-1 py-3 text-sm font-semibold text-center transition-colors relative ${tabletActiveTab === 'inbox' ? 'text-blue-500 border-b-2 border-blue-500' : textSecondary}`}
+                className={`flex-1 py-3 text-sm font-semibold text-center transition-colors relative ${tabletActiveTab === 'inbox' ? 'text-blue-500 border-b-2 border-blue-500' : `${textSecondary} border-b-2 border-transparent`}`}
               >
                 <span className="flex items-center justify-center gap-1.5">
                   <Inbox size={16} /> Inbox


### PR DESCRIPTION
## Summary

Five fixes across four files:

**Bug 1 (ALL DAY gutter label):** Changed from `px-2 py-2 flex items-start justify-center` to `px-3 py-2`, matching multi view exactly.

**Bug 2 (date header border vs GLANCE tab row):** The active tab's `border-b-2` was adding 2px to the tab bar's height (46px) while the day-mode date header had `min-h-[44px]` (44px), causing a 2px vertical misalignment. Fixed by:
- Adding `border-b-2 border-transparent` to inactive GLANCE/Inbox buttons in both tablet and desktop tab bars, so the tab bar height is always 46px regardless of which tab is active.
- Raising the day-mode date header `min-h` from `44px` to `46px` to match.

**Bug 3 (all-day spans vs column alignment):** Restructured `DayViewAllDaySection` so each date group contains its own `w-16` gutter + `flex-1` chips area, mirroring `DayViewColumn` exactly. Group boundaries are now pixel-aligned with timeline column boundaries.

**Bug 4 (first-load shows `...` menu):** When `fillWidth=false`, `useFullLayout` is now forced to `true` regardless of `taskWidths`, eliminating the stale-measurement regression on first load.

**Chip flex-grow:** Chip wrappers use `flex-1 min-w-[200px] max-w-[300px]` so chips grow to fill available row width between their min and max bounds. `AllDayTaskCard` uses `w-full` when `fillWidth=false`; the min/max constraints now live on the wrapper in `DayViewAllDaySection`. Ghost measurement wrappers match visible chip wrappers.

## Test plan

- [ ] Day view single date: "ALL DAY" label lines up with hour labels below it
- [ ] Day view: GLANCE tab row bottom border and date header bottom border are on the same horizontal line
- [ ] Day view rolling-24 triptych: vertical divider between date groups aligns with the column divider in the timeline below
- [ ] Day view: chips show full action buttons on first load, not the `...` menu
- [ ] Day view: chips grow to fill available row width, capped at 300px; a single chip fills the row up to 300px wide
- [ ] Day view: chips respect 2-row cap; "+N more" popover works
- [ ] Multi view: all-day chip layout unchanged (vertical stacking, full-width chips)
- [ ] Left panel GLANCE/Inbox tab bar height is stable (no 2px jump when switching tabs)

https://claude.ai/code/session_0118wJxmC1HHc5x2SMRTQoW9