### PR TITLE
fix(day-view): PR #8 bugfix sweep — task drift, column alignment, time format, chip wrapping

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -94,15 +94,19 @@ const CalendarHeader = () => {
   const formatBoundHour = (h, use24h) => {
     const norm = h % 24;
     if (use24h) return `${norm.toString().padStart(2, '0')}:00`;
-    if (norm === 0) return '12a';
-    if (norm === 12) return '12p';
-    return norm < 12 ? `${norm}a` : `${norm - 12}p`;
+    if (norm === 0) return '12 AM';
+    if (norm === 12) return '12 PM';
+    return norm < 12 ? `${norm} AM` : `${norm - 12} PM`;
   };
 
   return (
     <>
 {/* Date headers row */}
-<div ref={(el) => { if (isTablet) mobileDateHeaderRef.current = el; }} className={`flex border-b ${borderClass} ${cardBg}`}>
+<div
+  ref={(el) => { if (isTablet) mobileDateHeaderRef.current = el; }}
+  className={`border-b ${borderClass} ${cardBg}${effectiveViewMode === 'day' ? '' : ' flex'}`}
+  style={effectiveViewMode === 'day' ? { display: 'grid', gridTemplateColumns: `repeat(${dayViewColumns.length}, 1fr)` } : undefined}
+>
   {effectiveViewMode === 'multi' ? (
     <>
     {/* Top-left cell: hosts ViewCycler on large screens */}
@@ -189,8 +193,8 @@ const CalendarHeader = () => {
       return (
         <div
           key={group.dateStr}
-          className={`relative min-h-[46px] flex items-center justify-center ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg}`}
-          style={{ flex: group.count }}
+          className={`relative min-h-[45px] flex items-center justify-center ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg} ${idx > 0 ? `border-l ${borderClass}` : ''}`}
+          style={{ gridColumn: `span ${group.count}` }}
         >
           {/* ViewCycler floats in the absolute-left of the first date group so
               column boundaries align: both header and DayView start at x=0. */}

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -82,19 +82,18 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const altRow = darkMode ? 'bg-white/[0.04]' : 'bg-stone-100/50';
 
   return (
-    <div className={`flex-1 flex flex-col min-w-0 ${colIdx > 0 ? `border-l ${borderClass}` : ''}`}>
+    <div className={`flex flex-col min-w-0 h-full ${colIdx > 0 ? `border-l ${borderClass}` : ''}`}>
       <div className="flex-1 relative">
         {/* Hour rows — each is a full-width flex row matching TimeGrid's structure */}
         {hours.map((hour, i) => (
-          <div key={hour} className="relative">
-            <div className={`flex border-b ${borderClass} ${i % 2 === 1 ? altRow : ''}`}>
+          <div key={hour} className="relative" style={{ height: `${hourHeight}px` }}>
+            <div className={`flex border-b h-full ${borderClass} ${i % 2 === 1 ? altRow : ''}`}>
               <div
-                className={`w-16 flex-shrink-0 px-3 py-1 text-sm ${textSecondary} border-r ${borderClass} flex items-start`}
-                style={{ height: `${hourHeight}px` }}
+                className={`w-16 flex-shrink-0 px-3 py-1 text-sm ${textSecondary} border-r ${borderClass} flex items-start h-full`}
               >
                 {formatHourLabel(hour, use24HourClock)}
               </div>
-              <div className="flex-1" style={{ height: `${hourHeight}px` }} />
+              <div className="flex-1 h-full" />
             </div>
             {/* Half-hour dashed line — full-width flex matching TimeGrid */}
             <div
@@ -194,7 +193,7 @@ const DayView = () => {
   const hourHeight = useDayViewHourHeight(calendarRef, stickyHeaderRef);
 
   return (
-    <div className="flex" style={{ height: '100%' }}>
+    <div style={{ height: '100%', display: 'grid', gridTemplateColumns: `repeat(${dayViewColumns.length}, 1fr)` }}>
       {dayViewColumns.map((col, colIdx) => (
         <DayViewColumn
           key={`${col.dateStr}-${col.startHour}`}

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -67,7 +67,7 @@ const GroupChips = ({ tasks, darkMode, borderClass, cardBg }) => {
         aria-hidden="true"
       >
         {tasks.map(t => (
-          <div key={t.id} className="flex-1 min-w-[200px] max-w-[300px]">
+          <div key={t.id} className="grow shrink-0 basis-[200px] max-w-[300px]">
             <AllDayTaskCard task={t} fillWidth={false} />
           </div>
         ))}
@@ -78,7 +78,7 @@ const GroupChips = ({ tasks, darkMode, borderClass, cardBg }) => {
         {shown.map(t => (
           <div
             key={t.id}
-            className={`notes-panel-container relative flex-1 min-w-[200px] max-w-[300px] ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
+            className={`notes-panel-container relative grow shrink-0 basis-[200px] max-w-[300px] ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
           >
             <AllDayTaskCard task={t} fillWidth={false} />
           </div>
@@ -153,15 +153,11 @@ const DayViewAllDaySection = () => {
   if (!groupsWithTasks.some(g => g.tasks.length > 0)) return null;
 
   return (
-    <div className={`flex border-b ${borderClass} ${cardBg}`}>
-      {/*
-        Each date group mirrors DayViewColumn exactly: a w-16 gutter + flex-1 chips area.
-        This keeps group boundaries pixel-aligned with column boundaries in the timeline.
-      */}
+    <div className={`border-b ${borderClass} ${cardBg}`} style={{ display: 'grid', gridTemplateColumns: `repeat(${dayViewColumns.length}, 1fr)` }}>
       {groupsWithTasks.map((group, idx) => (
         <div
           key={group.dateStr}
-          style={{ flex: group.count }}
+          style={{ gridColumn: `span ${group.count}` }}
           className={`flex min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}`}
         >
           <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>

--- a/src/hooks/useDayViewHourHeight.js
+++ b/src/hooks/useDayViewHourHeight.js
@@ -9,7 +9,7 @@ export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
       const totalH = calendarRef.current.clientHeight;
       const stickyH = stickyHeaderRef?.current?.offsetHeight || 0;
       const usable = Math.max(160, totalH - stickyH);
-      setHourHeight(Math.max(20, Math.floor((usable - 8) / 8)));
+      setHourHeight(Math.max(20, Math.floor(usable / 8)));
     };
 
     compute();


### PR DESCRIPTION
## Summary

Five bugs fixed across four files — all independent, no architectural changes.

- **Bug 2 — Task vertical drift** (`useDayViewHourHeight.js`, `DayView.jsx`): Each hour row's `border-b: 1px` was adding to layout height (outer div had no explicit height), so row N was 1px taller than `hourHeight`. Task positions (computed as `N * hourHeight`) drifted by N px at hour N, reaching 7px drift at the 7th hour. Fix: set `height: ${hourHeight}px` on the wrapper div (border inside box-sizing); use `h-full` on inner flex children. Also removed the unexplained `-8` offset in `useDayViewHourHeight` that was making `hourHeight` 1px short.

- **Bug 3 — Time range format** (`CalendarHeader.jsx`): `formatBoundHour` returned compact `"4p"` / `"12a"` style instead of the full `"4 PM"` / `"12 AM"` used elsewhere in the app.

- **Bug 4 — Column track misalignment** (`CalendarHeader.jsx`, `DayView.jsx`, `DayViewAllDaySection.jsx`): Date header, all-day strip, and timeline were separate flex containers. Flex proportional widths can round independently at non-divisible container widths, causing 0–1px misalignment between rows. Fixed by changing all three to `display: grid; grid-template-columns: repeat(N, 1fr)` — identical `1fr` tracks in matching containers produce identical widths.

- **Bug 5 — Date header border misaligned** (`CalendarHeader.jsx`): PR #7 set `min-h-[46px]` but overcorrected. The right panel (`calendarRef`) has `border` with `height: 100%` box-sizing, placing a 1px top border before the date header. Content starts at y=1, so `min-h-[45px]` lands the `border-b` at y=46, aligning with the GLANCE tab bar border at y=46.

- **Bug 6 — All-day chips ignore min-width wrapping** (`DayViewAllDaySection.jsx`): `flex-1` = `flex: 1 1 0%` sets flex-basis to 0. The wrapping algorithm places all items on one line (total basis ≈ 0px), then grows them — bypassing the `min-width: 200px` constraint. Changed to `grow shrink-0 basis-[200px]` (`flex: 1 0 200px`) so the wrapping check correctly uses 200px per chip.

## Test plan

- [ ] Day view: tasks at hour boundaries (e.g. 9 AM, 1 PM) align precisely with hour gridlines — no drift
- [ ] Rolling-24 mode: time range in header shows "4 PM – 12 AM" not "4p – 12a"
- [ ] Rolling-24 / calendar-day: date header column boundaries align with all-day strip and timeline column boundaries pixel-for-pixel
- [ ] Date header `border-b` aligns with GLANCE tab bar `border-b` (not above, not below)
- [ ] All-day section with 3+ chips on a date: chips wrap to a second row instead of squishing below 200px width

https://claude.ai/code/session_0118wJxmC1HHc5x2SMRTQoW9