### PR TITLE
fix(day-view): revert column container from CSS grid to flex (Bug 1)

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -82,7 +82,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const altRow = darkMode ? 'bg-white/[0.04]' : 'bg-stone-100/50';
 
   return (
-    <div className={`flex flex-col min-w-0 h-full ${colIdx > 0 ? `border-l ${borderClass}` : ''}`}>
+    <div className={`flex-1 flex flex-col min-w-0 ${colIdx > 0 ? `border-l ${borderClass}` : ''}`}>
       <div className="flex-1 relative">
         {/* Hour rows — each is a full-width flex row matching TimeGrid's structure */}
         {hours.map((hour, i) => (
@@ -193,7 +193,7 @@ const DayView = () => {
   const hourHeight = useDayViewHourHeight(calendarRef, stickyHeaderRef);
 
   return (
-    <div style={{ height: '100%', display: 'grid', gridTemplateColumns: `repeat(${dayViewColumns.length}, 1fr)` }}>
+    <div className="flex" style={{ height: '100%' }}>
       {dayViewColumns.map((col, colIdx) => (
         <DayViewColumn
           key={`${col.dateStr}-${col.startHour}`}


### PR DESCRIPTION
## Summary

- **Root cause:** PR #493's Bug 4 fix changed `DayView`'s outer container from `flex` to `display: grid; grid-template-columns: repeat(3, 1fr)` and added `h-full` to `DayViewColumn`. CSS grid with an auto-height row cannot resolve `h-full` on grid items — browsers position them at y=0 of the grid container, which is behind the sticky header (z-20, opaque background). The sticky header visually covered the first hour row, so rolling-24 mode showed 7 rows starting at 5 PM instead of 8 rows starting at 4 PM.

- **Fix:** Revert `DayView` outer container back to `display: flex` and `DayViewColumn` back to `flex-1`. Three equal `flex-1` columns produce identical widths to `repeat(3, 1fr)` grid tracks — no alignment regression. The CSS grid is kept in `CalendarHeader` and `DayViewAllDaySection`, where it's needed for `gridColumn: span N` on multi-column date groups.

## Test plan

- [ ] Rolling-24 mode at any time of day: first column shows the correct start hour (e.g. at 11 PM, first column starts at 4 PM, not 5 PM)
- [ ] All 8 hour rows are visible in each column — none hidden behind the header
- [ ] Column boundaries still align with date header and all-day strip (no regression from Bug 4 fix)

https://claude.ai/code/session_0118wJxmC1HHc5x2SMRTQoW9