### PR TITLE
fix(day-view): fix hourHeight ref race + scrollTop bleed into day mode

### DIFF
--- a/src/hooks/useDayViewHourHeight.js
+++ b/src/hooks/useDayViewHourHeight.js
@@ -1,9 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useState, useLayoutEffect } from 'react';
 
 export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
   const [hourHeight, setHourHeight] = useState(80);
 
-  useEffect(() => {
+  // useLayoutEffect runs synchronously after DOM mutations, before paint — ensures
+  // stickyHeaderRef.current is already set when we measure. The inline ref callback
+  // on DesktopLayout's sticky div briefly nulls the ref on each render, so we also
+  // defer one rAF to let React re-set it before the first measurement.
+  useLayoutEffect(() => {
     const compute = () => {
       if (!calendarRef?.current) return;
       const totalH = calendarRef.current.clientHeight;
@@ -12,11 +16,21 @@ export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
       setHourHeight(Math.max(20, Math.floor(usable / 8)));
     };
 
-    compute();
-    const ro = new ResizeObserver(compute);
-    if (calendarRef?.current) ro.observe(calendarRef.current);
-    if (stickyHeaderRef?.current) ro.observe(stickyHeaderRef.current);
-    return () => ro.disconnect();
+    // Defer first measurement by one frame so the sticky header ref is populated.
+    const rafId = requestAnimationFrame(() => {
+      compute();
+      const ro = new ResizeObserver(compute);
+      if (calendarRef?.current) ro.observe(calendarRef.current);
+      if (stickyHeaderRef?.current) ro.observe(stickyHeaderRef.current);
+      // Keep a reference so cleanup can disconnect even after the rAF fires.
+      roRef = ro;
+    });
+
+    let roRef = null;
+    return () => {
+      cancelAnimationFrame(rafId);
+      roRef?.disconnect();
+    };
   }, []); // refs are stable objects — no deps needed
 
   return hourHeight;

--- a/src/hooks/useTimelineScroll.js
+++ b/src/hooks/useTimelineScroll.js
@@ -45,7 +45,11 @@ export default function useTimelineScroll({
   }, []);
 
   useEffect(() => {
-    if (viewMode !== 'multi') return;
+    if (viewMode !== 'multi') {
+      // Reset any scroll position left over from multi mode so day/week view starts at top.
+      if (calendarRef.current) calendarRef.current.scrollTop = 0;
+      return;
+    }
     const isToday = dateToString(selectedDate) === dateToString(new Date());
     if (isToday && calendarRef.current && (!isMobile || mobileActiveTab === 'timeline')) {
       setTimeout(() => scrollToCurrentHour(false), 100);


### PR DESCRIPTION
## Summary

Two fixes for the rolling-24 "wrong start hour" symptom. Diagnosed by an Opus 4.7 agent: the column data (`dayViewColumns`) was always correct — the bug was purely visual/layout.

### Fix 1 — `useDayViewHourHeight.js`: ref race on first measurement

The sticky header uses an inline ref callback (`ref={(el) => { stickyHeaderRef.current = el; }}`), which briefly nulls the ref on each render before re-setting it. The old `useEffect` ran during that null window, measuring `stickyH = 0`. This made hour rows too tall (`8 × hourHeight ≈ full calendarRef height`), which, combined with the sticky header sitting on top, hid the first hour row(s) — so the first *visible* label appeared to be near the current clock hour.

Additionally, because `stickyHeaderRef.current` was null when the ResizeObserver was attached, the sticky header's subsequent size changes (e.g. DayViewAllDaySection appearing after tasks load) never triggered a re-measure. The coincidental fix from "delete a task" was: task deletion can cause the all-day strip to appear/disappear, which resizes `calendarRef` (not `stickyHeader`), firing the observer and correcting `hourHeight`.

**Fix:** Switch to `useLayoutEffect` (runs synchronously after DOM commit, before paint) and defer the first `compute()` by one `requestAnimationFrame` — by that point React has re-populated the ref. The ResizeObserver is attached inside the same rAF callback.

### Fix 2 — `useTimelineScroll.js`: stale `scrollTop` bleeds into day mode

Multi mode scrolls `calendarRef` to the current hour via `scrollToCurrentHour`. Nothing reset `scrollTop` when switching to day mode. Day mode uses `overflow-hidden` so the user can't scroll manually, but the persisted `scrollTop` visually shifted DayView's content upward — masking the top hour rows.

**Fix:** When entering any non-multi view mode, immediately reset `calendarRef.current.scrollTop = 0`.

## Test plan

- [ ] Fresh load in rolling-24 day view: first column starts at the correct 8-hour block boundary (0:00, 8:00, or 16:00 depending on current hour) — not at current clock hour
- [ ] Switch to multi view (which auto-scrolls to current hour), then switch back to day view: day view starts at top, no rows clipped
- [ ] Task mutations (add/delete) do not cause column start hours to change
- [ ] Multi view still auto-scrolls to current hour on load and date change (no regression)

https://claude.ai/code/session_0118wJxmC1HHc5x2SMRTQoW9