### PR TITLE
fix(day-view): stop 30-min timer from scrolling calendarRef in day mode

### DIFF
--- a/src/hooks/useTimelineScroll.js
+++ b/src/hooks/useTimelineScroll.js
@@ -28,7 +28,7 @@ export default function useTimelineScroll({
         calendarRef.current.scrollTop = scrollPosition;
       }
     }
-  }, []);
+  }, [viewMode]);
 
   // Scroll timeline to a specific time string (e.g. "08:00")
   const scrollToHour = useCallback((timeStr, smooth = false) => {
@@ -108,7 +108,7 @@ export default function useTimelineScroll({
       clearTimeout(timeoutId);
       if (intervalId) clearInterval(intervalId);
     };
-  }, [isMobile, selectedDate, scrollToCurrentHour]);
+  }, [isMobile, selectedDate, scrollToCurrentHour, viewMode]);
 
   return { timelineScrolledAway, setTimelineScrolledAway, scrollToCurrentHour, scrollToHour };
 }


### PR DESCRIPTION
## Root cause

`scrollToCurrentHour` was created with `deps: []`, so it captured a stale `viewMode='multi'` in its closure from mount time. The `if (viewMode !== 'multi') return` guard was present but never fired after the user switched to day view because the closure never updated.

The 30-minute auto-refocus effect also lacked `viewMode` in its deps array, so it was never torn down when leaving multi view.

**Sequence of events triggering the bug:**
1. App mounts in multi view (default). `scrollToCurrentHour` closes over `viewMode='multi'`.
2. User switches to day view. `viewMode` changes but `scrollToCurrentHour` is not recreated (deps: []).
3. At every :00/:30 boundary, the 30-min timer fires and calls `scrollToCurrentHour(true)`.
4. The guard `if (viewMode !== 'multi') return` uses the stale `'multi'` value and passes.
5. `calendarRef.scrollTo({ top: 7 * 161 })` is called. The day-view container is `overflow:hidden`, so the browser clamps `scrollTop` to `stickyHeaderHeight` (~one `hourHeight`).
6. The first hour row (12 AM) is shifted above the top of the viewport and hidden behind the sticky header. Column 1 shows 1 AM through 7 AM instead of 12 AM through 7 AM.

This explains every piece of timing evidence: correct at 7:29, broken at 7:30 with no user action; survives a view switch but not the next :30 boundary; a data change that re-triggers the date-change effect (which resets `scrollTop = 0`) temporarily fixes it until the timer fires again.

## Fix

Two deps additions in `useTimelineScroll.js`:

- `scrollToCurrentHour` useCallback: `deps: []` -> `deps: [viewMode]`
  Recreates the callback with a fresh closure whenever `viewMode` changes.
- 30-minute timer effect: `deps: [isMobile, selectedDate, scrollToCurrentHour]` -> adds `viewMode`
  Tears down and does not recreate the timer when switching away from multi view.

The cascade works automatically: switching to day view recreates `scrollToCurrentHour` with `viewMode='day'`, which triggers the 30-min effect to re-run (its `scrollToCurrentHour` dep changed), which sees `viewMode !== 'multi'` and returns early, and cleanup clears the pending timer.

## Testing

- Open day view. Note column 1 starts at 12 AM.
- Wait through a :00 or :30 boundary. Column layout must be unchanged.
- Refresh the browser. Same result.
- Switch to multi view then back to day view. Same result.
- Repeat across several 30-minute boundaries.

https://claude.ai/code/session_01SsH8wR57rDaYEPirgeS6DZ