### PR TITLE
fix(day-view): always use fillWidth=false for popover overflow chips

### DIFF
--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -127,7 +127,7 @@ const GroupChips = ({ tasks, darkMode, borderClass, cardBg }) => {
               className={`notes-panel-container relative ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
               onClick={() => setOverflowOpen(false)}
             >
-              <AllDayTaskCard task={t} fillWidth={true} />
+              <AllDayTaskCard task={t} fillWidth={false} />
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Root cause

`AllDayTaskCard` decides between full action buttons and the `...` collapse menu via:

```js
const useFullLayout = !fillWidth || allDayTaskWidth === undefined || allDayTaskWidth >= 200;
```

`taskWidths` (the source of `allDayTaskWidth`) is populated in multi view when `CalendarHeader` measures each all-day chip's wrapper width via `setTaskRef`. On initial cold load, `effectiveViewMode` can briefly resolve as `'multi'` before `canShowViewCycler` finishes its viewport check. During that brief render, day columns can be narrow (<200px), so narrow widths get written into `taskWidths` for every all-day task.

When the user opens the `+N more` popover in day view, the overflow chips were rendered with `fillWidth={true}`, which made each card read those stale narrow measurements and collapse to the `...` menu despite the popover being 400px wide. Navigating through multi view at a settled viewport re-measured wider widths (>=200px), which is why that navigation sequence appeared to fix the problem.

## Fix

One character: `fillWidth={true}` -> `fillWidth={false}` for overflow chips in the popover.

The main-area chips in `GroupChips` and the ghost measurement row already use `fillWidth={false}`, which bypasses `taskWidths` entirely (`!fillWidth` short-circuits to `useFullLayout=true`). The popover chips now do the same.

The popover is a `flex flex-col` container fixed at 400px. Flex children stretch to full width by default (`align-items: stretch`), so adding `w-full` from `fillWidth={false}` makes no visual difference.

The comment in `AllDayTaskCard` (lines 55-57) already documents this intent:
> "Day-view chips (fillWidth=false) always use full layout -- they have a min-width of 200px and must never read stale taskWidths measurements from multi view."

The popover chips should have followed this pattern from the start.

## Testing

- Open day view fresh (or refresh while in day view).
- Open the `+N more` popover.
- Verify chips show full action buttons, not `...`.
- Also verify: open the app in multi view, switch to day view, open the popover. Same result.

https://claude.ai/code/session_01SsH8wR57rDaYEPirgeS6DZ