### PR TITLE
fix(day-view): align ALL DAY gutter label vertically across views

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -240,7 +240,7 @@ const CalendarHeader = () => {
 {/* Multi-mode all-day tasks section */}
 {effectiveViewMode === 'multi' && (visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay) || getDeadlineTasksForDate(dateToString(date)).length > 0) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (
   <div ref={(el) => { if (isTablet) mobileAllDaySectionRef.current = el; }} className={`flex border-b ${borderClass} ${cardBg}`}>
-    <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>
+    <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass} flex items-center`}>
       ALL DAY
     </div>
     {visibleDates.map((date, idx) => {

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -75,11 +75,11 @@ const GroupChips = ({ tasks, darkMode, borderClass, cardBg }) => {
   const overflowTasks = limit !== null ? tasks.slice(limit) : [];
 
   return (
-    <div className="relative p-1.5">
+    <div className="relative p-2">
       {/* Ghost render for overflow measurement — invisible, no pointer events */}
       <div
         ref={ghostRef}
-        className="absolute top-1.5 left-1.5 right-1.5 flex flex-wrap gap-1 opacity-0 pointer-events-none"
+        className="absolute top-2 left-2 right-2 flex flex-wrap gap-1 opacity-0 pointer-events-none"
         aria-hidden="true"
       >
         {tasks.map(t => (
@@ -183,7 +183,7 @@ const DayViewAllDaySection = () => {
           style={{ gridColumn: `span ${group.count}` }}
           className={`flex min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}`}
         >
-          <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>
+          <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass} flex items-center`}>
             {idx === 0 ? 'ALL DAY' : ''}
           </div>
           <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Root cause

The gutter cell classes were already identical between the two views:

```
w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ... border-r ...
```

With no vertical alignment rule, the text starts at `py-2 = 8px` from the top of its cell in both views. However the row heights differed:

- **Multi view** content column: `p-2` padding + AllDayTaskCard (~36px) + `p-2` = **52px**
- **Day view** content column: GroupChips `p-1.5` + chip (~36px) + `p-1.5` = **48px**

A top-pinned label (`py-2`) inside cells of different heights sits at the same absolute pixel offset from the top, but at a visually different relative position within each row. With many tasks the difference widens further because multi view stacks all tasks (growing taller) while day view caps at 2 rows.

## Changes

**`CalendarHeader.jsx`** and **`DayViewAllDaySection.jsx`** -- gutter cell:
- Add `flex items-center` so the label centers vertically within its cell using the same rule in both views.

**`DayViewAllDaySection.jsx`** -- GroupChips outer div:
- Change `p-1.5` to `p-2`, matching the `p-2` on multi view day-column divs.
- The ghost measurement div's absolute inset (`top/left/right`) is updated from `1.5` to `2` to stay flush with the new outer padding.

These two changes together ensure:
1. The centering rule is identical (both use `flex items-center`).
2. The base row height is identical for the same task count, so the centered label lands at exactly the same pixel position in both views.

## Testing

Toggle between multi view and day view with at least one all-day task present. The ALL DAY label should not shift vertically when switching views.

https://claude.ai/code/session_01SsH8wR57rDaYEPirgeS6DZ