### PR TITLE
fix(day-view): remove max-w cap so all-day chips flex-fill their row

### DIFF
--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -83,7 +83,7 @@ const GroupChips = ({ tasks, darkMode, borderClass, cardBg }) => {
         aria-hidden="true"
       >
         {tasks.map(t => (
-          <div key={t.id} className="grow shrink-0 basis-[200px] max-w-[300px]">
+          <div key={t.id} className="grow shrink-0 basis-[200px]">
             <AllDayTaskCard task={t} fillWidth={false} />
           </div>
         ))}
@@ -94,7 +94,7 @@ const GroupChips = ({ tasks, darkMode, borderClass, cardBg }) => {
         {shown.map(t => (
           <div
             key={t.id}
-            className={`notes-panel-container relative grow shrink-0 basis-[200px] max-w-[300px] ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
+            className={`notes-panel-container relative grow shrink-0 basis-[200px] ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
           >
             <AllDayTaskCard task={t} fillWidth={false} />
           </div>


### PR DESCRIPTION
## Root cause

Chip wrappers in `GroupChips` had:

```
grow shrink-0 basis-[200px] max-w-[300px]
```

The `max-w-[300px]` cap prevented chips from growing beyond 300px. In any span wider than 300px where a chip was the only item on its flex line, the chip stopped at 300px and left dead space to the right. The `grow` was doing its job up to the cap, then stopped.

## Fix

Remove `max-w-[300px]` from both wrappers (ghost and visible). The remaining rules are exactly right:

- `basis-[200px]`: 200px minimum width, enough for action buttons
- `shrink-0`: never compress below 200px
- `grow`: fill all remaining row width once wrap lines are decided

Flex wrapping still works the same way: a second chip joins the current line only if its 200px basis fits alongside the first; otherwise it wraps to the next row. After lines are determined, each chip on a line grows to fill the remaining width with no cap.

The ghost render uses the identical wrapper so it continues to mirror the visible layout for the 2-row overflow `limit` calculation.

## Behavior after fix

- A chip alone on a row fills the full available width (no dead space).
- Two chips on a row each grow to half the available width (minus gap).
- The `+N more` pill is `flex-shrink-0` with no `grow`, so chips on the same row as the pill grow to fill the space the pill leaves; the pill keeps its intrinsic size.

https://claude.ai/code/session_01SsH8wR57rDaYEPirgeS6DZ