### PR TITLE
fix(day-view): cap all-day chip max-width at 400px

### DIFF
--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -83,7 +83,7 @@ const GroupChips = ({ tasks, darkMode, borderClass, cardBg }) => {
         aria-hidden="true"
       >
         {tasks.map(t => (
-          <div key={t.id} className="grow shrink-0 basis-[200px]">
+          <div key={t.id} className="grow shrink-0 basis-[200px] max-w-[400px]">
             <AllDayTaskCard task={t} fillWidth={false} />
           </div>
         ))}
@@ -94,7 +94,7 @@ const GroupChips = ({ tasks, darkMode, borderClass, cardBg }) => {
         {shown.map(t => (
           <div
             key={t.id}
-            className={`notes-panel-container relative grow shrink-0 basis-[200px] ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
+            className={`notes-panel-container relative grow shrink-0 basis-[200px] max-w-[400px] ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
           >
             <AllDayTaskCard task={t} fillWidth={false} />
           </div>


### PR DESCRIPTION
## Summary

PR #500 removed the 300px cap to fix dead space in narrow spans. That fix was correct, but exposed the opposite problem: a single chip in a wide span (full triptych ~1400px, two-column span ~1000px) now stretches to fill the entire available width, which is visually heavy.

Add `max-w-[400px]` to both chip wrappers (ghost and visible).

Within the 200-400px band chips still flex-fill their row edge-to-edge. Above 400px the chip caps and remaining space is dead space to the right, the same treatment already accepted for overflow rows.

Both wrappers get the same value so the ghost continues to mirror the visible layout for the overflow `limit` calculation.

## Validation

- Single chip in wide triptych: caps at 400px, dead space to the right.
- Two chips in ~430px single-column: each ~210px, fills row edge-to-edge (below cap).
- Three chips in two-column span: each ~300-330px, fills row edge-to-edge (below cap).
- Five chips in two-column span: each ~200px (at minimum), fills row edge-to-edge.

https://claude.ai/code/session_01SsH8wR57rDaYEPirgeS6DZ