### PR TITLE
Fix ALL DAY gutter label top-alignment between day and multi view

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -240,7 +240,7 @@ const CalendarHeader = () => {
 {/* Multi-mode all-day tasks section */}
 {effectiveViewMode === 'multi' && (visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay) || getDeadlineTasksForDate(dateToString(date)).length > 0) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (
   <div ref={(el) => { if (isTablet) mobileAllDaySectionRef.current = el; }} className={`flex border-b ${borderClass} ${cardBg}`}>
-    <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass} flex items-center`}>
+    <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass} flex items-start`}>
       ALL DAY
     </div>
     {visibleDates.map((date, idx) => {

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -183,7 +183,7 @@ const DayViewAllDaySection = () => {
           style={{ gridColumn: `span ${group.count}` }}
           className={`flex min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}`}
         >
-          <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass} flex items-center`}>
+          <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass} flex items-start`}>
             {idx === 0 ? 'ALL DAY' : ''}
           </div>
           <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary

- Switches the ALL DAY gutter label from `flex items-center` to `flex items-start` in both `CalendarHeader.jsx` (multi view) and `DayViewAllDaySection.jsx` (day view)
- `items-center` caused the label to shift depending on total row height, which differs between views when deadline tasks or routine pills are present in the multi-view section
- `items-start` anchors the label text to the same 8px top offset (`py-2`) as the first chip/card in the content area, giving consistent alignment regardless of row height

## Test plan

- [ ] Multi view with all-day tasks only: label aligns with first chip top edge
- [ ] Multi view with deadline tasks or routine pills (taller row): label still aligns at same top position, not vertically centered in the taller row
- [ ] Day view with all-day tasks: label aligns with first chip top edge, matches multi view position
- [ ] Triptych (3-column) day view: same alignment holds across all columns

https://claude.ai/code/session_01SsH8wR57rDaYEPirgeS6DZ