### PR TITLE
Fix ALL DAY gutter label alignment: remove flex from gutter cells

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -240,7 +240,7 @@ const CalendarHeader = () => {
 {/* Multi-mode all-day tasks section */}
 {effectiveViewMode === 'multi' && (visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay) || getDeadlineTasksForDate(dateToString(date)).length > 0) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (
   <div ref={(el) => { if (isTablet) mobileAllDaySectionRef.current = el; }} className={`flex border-b ${borderClass} ${cardBg}`}>
-    <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass} flex items-start`}>
+    <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>
       ALL DAY
     </div>
     {visibleDates.map((date, idx) => {

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -183,7 +183,7 @@ const DayViewAllDaySection = () => {
           style={{ gridColumn: `span ${group.count}` }}
           className={`flex min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}`}
         >
-          <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass} flex items-start`}>
+          <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>
             {idx === 0 ? 'ALL DAY' : ''}
           </div>
           <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary

Removes `flex` (and `items-start`/`items-center`) from both ALL DAY gutter cells so both views use identical structure: plain block divs with `py-2`.

**Root cause of previous attempts failing:** Making the gutter a flex container introduced a flex container height calculation that differed between the flex outer row (multi view) and the CSS grid outer container (day view), producing a 1px border shift when toggling views.

**This fix:**
- Both views now use the same strategy (Option A): block div + `py-2`
- Label text lands at 8px from section top via normal block-flow padding, independent of row height
- Content areas also start at 8px (both use `p-2`), so label top-aligns with first chip/card in both views
- No flex container overhead means no rounding quirks between flex and grid outer containers

## Test plan

- [ ] Toggle between multi and day view with one all-day task: ALL DAY label should not move vertically
- [ ] Toggle with multiple all-day tasks (taller row in day view): label still at same top position in both views
- [ ] Toggle with deadline tasks or routine pills in multi view (even taller row): label still consistent
- [ ] Triptych (3-column) day view: label at same position as single-column and multi view

https://claude.ai/code/session_01SsH8wR57rDaYEPirgeS6DZ