### PR TITLE
fix(day-view): restore date header min-h to 46px to realign panel borders

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -193,7 +193,7 @@ const CalendarHeader = () => {
       return (
         <div
           key={group.dateStr}
-          className={`relative min-h-[45px] flex items-center justify-center ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg} ${idx > 0 ? `border-l ${borderClass}` : ''}`}
+          className={`relative min-h-[46px] flex items-center justify-center ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg} ${idx > 0 ? `border-l ${borderClass}` : ''}`}
           style={{ gridColumn: `span ${group.count}` }}
         >
           {/* ViewCycler floats in the absolute-left of the first date group so


### PR DESCRIPTION
## Summary

One-character fix: `min-h-[45px]` → `min-h-[46px]` on the day-mode date header cells in `CalendarHeader.jsx`.

**Root cause:** Commit `c094139` established panel border alignment by:
1. Making the GLANCE/Inbox tab bar always 46px tall (`py-3 text-sm border-b-2`, with `border-transparent` on inactive tabs so height never fluctuates)
2. Setting the day-mode date header `min-h-[46px]` to match

PR #8 bugfix sweep (`327f708`) changed `min-h-[46px]` → `min-h-[45px]` during a flex-to-grid layout refactor. This created a 1px misalignment between the calendar date header bottom border and the GLANCE tab bar bottom border that all subsequent ALL DAY alignment work was layered on top of.

## Test plan

- [ ] Day view: bottom border of date header row aligns with bottom border of GLANCE/Inbox tab bar
- [ ] Multi view: unaffected (this `min-h` only applies to day-mode date header cells)
- [ ] Toggle between day and multi view: border alignment stable

https://claude.ai/code/session_01SsH8wR57rDaYEPirgeS6DZ