### PR TITLE
fix(layout): enforce shared header row height via CSS variable

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -110,7 +110,7 @@ const CalendarHeader = () => {
   {effectiveViewMode === 'multi' ? (
     <>
     {/* Top-left cell: hosts ViewCycler on large screens */}
-    <div className={`w-16 flex-shrink-0 border-r ${borderClass} flex items-center justify-center min-h-[44px]`}>
+    <div className={`w-16 flex-shrink-0 border-r ${borderClass} flex items-center justify-center`} style={{ minHeight: 'var(--header-row-h)' }}>
       {canShowViewCycler && <ViewCycler />}
     </div>
     {visibleDates.map((date, idx) => {
@@ -121,6 +121,7 @@ const CalendarHeader = () => {
       <div
         key={dateStr}
         className={`flex-1 py-2 px-3 text-center cursor-pointer hover:bg-opacity-80 transition-colors ${idx > 0 ? `border-l ${borderClass}` : ''} ${isDateToday ? (darkMode ? 'bg-blue-900/30 hover:bg-blue-900/50' : 'bg-blue-50 hover:bg-blue-100') : `${cardBg} ${darkMode ? 'hover:bg-gray-700' : 'hover:bg-stone-100'}`} ${isDragOverThis ? (darkMode ? 'bg-green-700 ring-2 ring-inset ring-green-400' : 'bg-green-200 ring-2 ring-inset ring-green-500') : ''}`}
+        style={{ minHeight: 'var(--header-row-h)' }}
         onClick={() => {
           setNewTask({
             title: '',
@@ -193,8 +194,8 @@ const CalendarHeader = () => {
       return (
         <div
           key={group.dateStr}
-          className={`relative min-h-[46px] flex items-center justify-center ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg} ${idx > 0 ? `border-l ${borderClass}` : ''}`}
-          style={{ gridColumn: `span ${group.count}` }}
+          className={`relative flex items-center justify-center ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg} ${idx > 0 ? `border-l ${borderClass}` : ''}`}
+          style={{ gridColumn: `span ${group.count}`, minHeight: 'var(--header-row-h)' }}
         >
           {/* ViewCycler floats in the absolute-left of the first date group so
               column boundaries align: both header and DayView start at x=0. */}

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -636,13 +636,15 @@ const DesktopLayout = () => {
               <div className={`flex border-b ${borderClass} flex-shrink-0`}>
                 <button
                   onClick={() => setTabletActiveTab('glance')}
-                  className={`flex-1 py-3 text-sm font-semibold text-center transition-colors ${tabletActiveTab === 'glance' ? 'text-blue-500 border-b-2 border-blue-500' : `${textSecondary} border-b-2 border-transparent`}`}
+                  style={{ height: 'var(--header-row-h)' }}
+                  className={`flex-1 flex items-center justify-center text-sm font-semibold transition-colors border-b-2 ${tabletActiveTab === 'glance' ? 'text-blue-500 border-blue-500' : `${textSecondary} border-transparent`}`}
                 >
                   <span className="flex items-center justify-center gap-1.5"><Eye size={16} /> GLANCE</span>
                 </button>
                 <button
                   onClick={() => setTabletActiveTab('inbox')}
-                  className={`flex-1 py-3 text-sm font-semibold text-center transition-colors relative ${tabletActiveTab === 'inbox' ? 'text-blue-500 border-b-2 border-blue-500' : `${textSecondary} border-b-2 border-transparent`}`}
+                  style={{ height: 'var(--header-row-h)' }}
+                  className={`flex-1 flex items-center justify-center text-sm font-semibold transition-colors relative border-b-2 ${tabletActiveTab === 'inbox' ? 'text-blue-500 border-blue-500' : `${textSecondary} border-transparent`}`}
                 >
                   <span className="flex items-center justify-center gap-1.5">
                     <Inbox size={16} /> Inbox
@@ -707,13 +709,15 @@ const DesktopLayout = () => {
             <div className={`flex border-b ${borderClass} flex-shrink-0`}>
               <button
                 onClick={() => setTabletActiveTab('glance')}
-                className={`flex-1 py-3 text-sm font-semibold text-center transition-colors ${tabletActiveTab === 'glance' ? 'text-blue-500 border-b-2 border-blue-500' : `${textSecondary} border-b-2 border-transparent`}`}
+                style={{ height: 'var(--header-row-h)' }}
+                className={`flex-1 flex items-center justify-center text-sm font-semibold transition-colors border-b-2 ${tabletActiveTab === 'glance' ? 'text-blue-500 border-blue-500' : `${textSecondary} border-transparent`}`}
               >
                 <span className="flex items-center justify-center gap-1.5"><Eye size={16} /> GLANCE</span>
               </button>
               <button
                 onClick={() => setTabletActiveTab('inbox')}
-                className={`flex-1 py-3 text-sm font-semibold text-center transition-colors relative ${tabletActiveTab === 'inbox' ? 'text-blue-500 border-b-2 border-blue-500' : `${textSecondary} border-b-2 border-transparent`}`}
+                style={{ height: 'var(--header-row-h)' }}
+                className={`flex-1 flex items-center justify-center text-sm font-semibold transition-colors relative border-b-2 ${tabletActiveTab === 'inbox' ? 'text-blue-500 border-blue-500' : `${textSecondary} border-transparent`}`}
               >
                 <span className="flex items-center justify-center gap-1.5">
                   <Inbox size={16} /> Inbox

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --header-row-h: 46px;
+}
+
 * {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary

- Adds `--header-row-h: 46px` to `:root` in `index.css` as a single source of truth for the calendar/panel header row height
- All three previously-independent header rows now consume this variable — drift between them is structurally impossible

**Consumers:**
| Element | Before | After |
|---|---|---|
| GLANCE/Inbox tab buttons (tablet + desktop) | `py-3 text-center` (content-driven) | `style={{ height: 'var(--header-row-h)' }}` + `flex items-center justify-center` |
| CalendarHeader MULTI ViewCycler cell | `min-h-[44px]` Tailwind class | `style={{ minHeight: 'var(--header-row-h)' }}` |
| CalendarHeader MULTI date cells | no explicit height | `style={{ minHeight: 'var(--header-row-h)' }}` |
| CalendarHeader DAY date cells | `min-h-[46px]` Tailwind class | `style={{ minHeight: 'var(--header-row-h)' }}` merged into existing `style` prop |

## Why this approach

Prior fixes attempted to match three independently-computed heights by tweaking pixel values. This always shifted one while fixing another because each was computed by a different CSS mechanism (`py-3 + text-sm + border-b-2` for GLANCE, content-driven flex for MULTI, `min-h` grid for DAY). A single CSS variable consumed by all three makes a future mismatch require an explicit change to the variable — not an accidental drift.

## Test plan

- [ ] DAY view: bottom border of date header row aligns with GLANCE/Inbox tab bar bottom border
- [ ] MULTI view: bottom border of date header row aligns with GLANCE/Inbox tab bar bottom border
- [ ] Toggle between DAY and MULTI: border stays locked — no movement
- [ ] ALL DAY label position is identical in both views
- [ ] Active/inactive tab underline still renders correctly (border-b-2 on buttons)

https://claude.ai/code/session_01SsH8wR57rDaYEPirgeS6DZ