### PR TITLE
fix(layout): remove calendarRef border-top causing 1px panel border drift

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -776,7 +776,7 @@ const DesktopLayout = () => {
           <div className="flex-1 min-w-0 relative">
             <div
               ref={calendarRef}
-              className={`${cardBg} border ${borderClass} ${effectiveViewMode === 'multi' ? `overflow-y-scroll overflow-x-hidden ${darkMode ? 'dark-scrollbar' : ''}` : 'overflow-hidden'} relative`}
+              className={`${cardBg} border-x border-b ${borderClass} ${effectiveViewMode === 'multi' ? `overflow-y-scroll overflow-x-hidden ${darkMode ? 'dark-scrollbar' : ''}` : 'overflow-hidden'} relative`}
               style={{ height: '100%' }}
             >
               {/* Combined sticky header — date headers + all-day section */}


### PR DESCRIPTION
## Summary

One-character class change: `border` to `border-x border-b` on the `calendarRef` div in `DesktopLayout.jsx`.

## Root cause

The `calendarRef` div had `border ${borderClass}` -- a 1px border on all four sides. That `border-top: 1px` places the div's content area 1px below its outer edge. Since the sticky CalendarHeader sits at `top: 0` inside this scroll container, all CalendarHeader rows start at y=1px relative to the content area origin.

Meanwhile, the GLANCE panel's tab bar has no top-border on any ancestor container, so it starts at y=0.

Result:
- GLANCE tab bar outer div: content at y=0, border-b at y=47px
- CalendarHeader date row: content at y=1px, border-b at y=48px

The GLANCE bottom border is 1px higher than the calendar's bottom border -- exactly what was reported.

## Fix

`border-x border-b` keeps the left, right, and bottom borders but removes the top. The toolbar's own `border-b` already provides a visual line at the top of the content area, so no horizontal line is lost. CalendarHeader content now starts at y=0, matching the GLANCE panel.

## Test plan

- [ ] GLANCE/Inbox tab bar bottom border aligns with CalendarHeader date row bottom border (DAY view)
- [ ] GLANCE/Inbox tab bar bottom border aligns with CalendarHeader date row bottom border (MULTI view)
- [ ] No visual regression at the top edge of the calendar area (no missing border line)
- [ ] No regression in multi-view scrolling behavior

https://claude.ai/code/session_01SsH8wR57rDaYEPirgeS6DZ