### PR TITLE
Restore date header content in day view

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -194,7 +194,7 @@ const CalendarHeader = () => {
       return (
         <div
           key={group.dateStr}
-          className={`relative flex items-center justify-center ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg} ${idx > 0 ? `border-l ${borderClass}` : ''}`}
+          className={`relative flex flex-col items-center justify-center py-2 ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : cardBg} ${idx > 0 ? `border-l ${borderClass}` : ''}`}
           style={{ gridColumn: `span ${group.count}`, minHeight: 'var(--header-row-h)' }}
         >
           {/* ViewCycler floats in the absolute-left of the first date group so
@@ -204,12 +204,33 @@ const CalendarHeader = () => {
               <ViewCycler />
             </div>
           )}
-          <div className={`text-center font-bold text-sm ${isDateToday ? 'text-blue-600' : textPrimary} ${idx === 0 && canShowViewCycler ? 'pl-16' : ''}`}>
+          <div className={`font-bold text-sm flex items-center justify-center gap-1.5 ${isDateToday ? 'text-blue-600' : textPrimary} ${idx === 0 && canShowViewCycler ? 'pl-16' : ''}`}>
             {formatShortDate(group.date)}
             {timeRange && (
-              <span className={`font-normal text-xs ${textSecondary} ml-1.5`}>· {timeRange}</span>
+              <span className={`font-normal text-xs ${textSecondary}`}>· {timeRange}</span>
             )}
+            <button
+              onClick={(e) => { e.stopPropagation(); setDailyNotesModalDate(group.dateStr); }}
+              className={`p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors ${dailyNotes[group.dateStr]?.text ? '' : 'opacity-50'}`}
+              title="Daily notes"
+            >
+              <NotebookPen size={14} />
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); setFocusLogModalDate(group.dateStr); }}
+              className={`p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors ${focusLog[group.dateStr]?.totalMinutes > 0 ? '' : 'opacity-50'}`}
+              title="Focus sessions"
+            >
+              <Target size={14} />
+            </button>
           </div>
+          {habitsEnabled && !isDateToday && group.dateStr < dateToString(new Date()) && habitLogs[group.dateStr] && activeHabits.length > 0 && (
+            <div className="flex items-center justify-center gap-0.5 mt-0.5 cursor-pointer" onClick={(e) => { e.stopPropagation(); setHabitDayPopup(group.dateStr); }}>
+              {activeHabits.slice(0, 6).map(habit => (
+                <MiniHabitRing key={habit.id} habit={habit} count={habitLogs[group.dateStr]?.[habit.id] || 0} darkMode={darkMode} />
+              ))}
+            </div>
+          )}
         </div>
       );
     });


### PR DESCRIPTION
## Summary

- Day view date-group headers now show the same supplementary content as multi view: daily note icon (NotebookPen), focus log icon (Target), and habit rings (MiniHabitRing) for past days
- All click handlers wire up identically to multi view -- NotebookPen opens DailyNotesModal, Target opens FocusLogModal, habit ring row opens HabitDayPopup
- In rolling-24 mode spanning two dates, each date-group header shows its own icons and rings for its respective date
- Layout changed from single-row `flex items-center justify-center` to `flex flex-col items-center justify-center py-2` so habit rings can appear beneath the date/time-range line without overlap

The change is confined to the day-view branch of `CalendarHeader.jsx` (lines 194-234). Multi view rendering is untouched.

## Test plan

- [ ] Switch to day view -- verify NotebookPen and Target icons appear in each date-group header
- [ ] Click NotebookPen -- verify daily notes modal opens for the correct date
- [ ] Click Target -- verify focus log modal opens for the correct date
- [ ] On a past date with habit data, verify MiniHabitRing row appears; click it to confirm HabitDayPopup opens
- [ ] Enable rolling-24 mode spanning two dates -- verify each date-group header shows its own icons/rings
- [ ] Switch back to multi view -- verify no visual regression in multi view headers

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh