### PR TITLE
Add current-time indicator to day view

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { formatHourLabel } from '../utils/timeFormatting.jsx';
+import { dateToString } from '../utils/taskUtils.js';
 import TimelineTaskCardContent from './TimelineTaskCardContent.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -81,6 +82,13 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const hours = Array.from({ length: 8 }, (_, i) => col.startHour + i);
   const altRow = darkMode ? 'bg-white/[0.04]' : 'bg-stone-100/50';
 
+  const now = new Date();
+  const colStartMin = col.startHour * 60;
+  const colEndMin = col.endHour * 60;
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+  const showNowLine = col.dateStr === dateToString(now) && nowMinutes >= colStartMin && nowMinutes < colEndMin;
+  const nowY = showNowLine ? (nowMinutes - colStartMin) * hourHeight / 60 : 0;
+
   return (
     <div className={`flex-1 flex flex-col min-w-0 ${colIdx > 0 ? `border-l ${borderClass}` : ''}`}>
       <div className="flex-1 relative">
@@ -107,6 +115,19 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             </div>
           </div>
         ))}
+
+        {/* Current-time indicator — dot at gutter edge, line across event area */}
+        {showNowLine && (
+          <div
+            className="absolute left-16 right-0 pointer-events-none z-10"
+            style={{ top: `${nowY}px` }}
+          >
+            <div className="flex items-center">
+              <div className="w-2 h-2 bg-red-500 rounded-full -ml-1" />
+              <div className="flex-1 h-0.5 bg-red-500" />
+            </div>
+          </div>
+        )}
 
         {/* Task pill overlay — covers the event area only (right of gutter) */}
         <div className="absolute top-0 left-16 right-0 bottom-0 pointer-events-none">


### PR DESCRIPTION
## Summary

- Day view now renders the same red dot + horizontal line as multi view, in whichever column contains the current clock time
- Visual treatment is identical to TimeGrid: `w-2 h-2 bg-red-500 rounded-full -ml-1` dot at the gutter/event boundary, `flex-1 h-0.5 bg-red-500` line across the event area
- Position math matches task pill placement exactly: `(nowMinutes - colStartMin) * hourHeight / 60`
- No separate update interval -- the component re-renders every 15 s via the existing `currentTime` state that already drives `dayViewColumns` recomputation in context
- No now-line when a non-today date is selected in calendar-day mode
- In rolling-24 mode the now-line always appears in column 1 (the current block), since rolling-24 only renders today
- Exactly-on-boundary times (e.g. 08:00) appear at the top of the next column, consistent with multi view

Change is 21 lines added to `DayView.jsx` only. No other files touched.

## Test plan

- [ ] Open day view -- verify red dot + line appears in the correct column at the correct vertical position
- [ ] Leave it open a few minutes -- verify the line moves down (15 s update cadence)
- [ ] Toggle to multi view and back -- verify the line is in the same relative position
- [ ] Calendar-day mode: navigate to a non-today date -- verify no now-line appears
- [ ] Calendar-day mode: navigate back to today -- verify now-line reappears in the correct column
- [ ] Rolling-24 mode -- verify now-line is always in column 1
- [ ] Compare side-by-side with multi view: dot size, line thickness, and color should be identical

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh