### PR TITLE
Fix notes panel clipping at bottom of day view columns

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -187,7 +187,12 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                   </div>
                 )}
                 {showTitle && (
-                  <TimelineTaskCardContent task={task} height={height} isNarrowWidth={false} />
+                  <TimelineTaskCardContent
+                    task={task}
+                    height={height}
+                    isNarrowWidth={false}
+                    flipNotesPanel={(8 * hourHeight) - (top + height) < 200}
+                  />
                 )}
                 {clippedBottom && (
                   <div className="absolute bottom-0 left-0 right-0 flex justify-center pointer-events-none">

--- a/src/components/TimelineTaskCardContent.jsx
+++ b/src/components/TimelineTaskCardContent.jsx
@@ -13,7 +13,7 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
-const TimelineTaskCardContent = ({ task, height, isNarrowWidth }) => {
+const TimelineTaskCardContent = ({ task, height, isNarrowWidth, flipNotesPanel }) => {
   const {
     isTablet,
     darkMode,
@@ -397,7 +397,7 @@ const TimelineTaskCardContent = ({ task, height, isNarrowWidth }) => {
       {expandedNotesTaskId === task.id && !isImported && (() => {
         const startMin = timeToMinutes(task.startTime || '0:00');
         const endMin = startMin + (task.duration || 0);
-        const showAbove = endMin >= 22 * 60;
+        const showAbove = flipNotesPanel !== undefined ? flipNotesPanel : endMin >= 22 * 60;
         return (
           <div
             className="notes-panel-container absolute left-0 right-0 z-40"
@@ -430,7 +430,7 @@ const TimelineTaskCardContent = ({ task, height, isNarrowWidth }) => {
       {expandedNotesTaskId === task.id && isImported && (() => {
         const startMin = timeToMinutes(task.startTime || '0:00');
         const endMin = startMin + (task.duration || 0);
-        const showAbove = endMin >= 22 * 60;
+        const showAbove = flipNotesPanel !== undefined ? flipNotesPanel : endMin >= 22 * 60;
         return (
           <div
             className="notes-panel-container absolute left-0 right-0 z-40"


### PR DESCRIPTION
## Summary

- Notes panels on tasks near the bottom of any day view column now open upward instead of being clipped
- Root cause: the existing `showAbove` heuristic in `TimelineTaskCardContent` only flips for `endMin >= 22 * 60`, which doesn't cover tasks near the bottom of the 00:00-08:00 or 08:00-16:00 columns
- Fix: add optional `flipNotesPanel` prop to `TimelineTaskCardContent`; when provided it overrides the time-based heuristic
- `DayView` passes `flipNotesPanel={true}` when the task pill's bottom is within 200px of the column floor (`(8 * hourHeight) - (top + height) < 200`)
- Multi view and all other consumers of `TimelineTaskCardContent` are unaffected -- prop is `undefined` so existing logic is unchanged

## Test plan

- [ ] Open day view, find a task near the bottom of any column -- open notes panel -- verify it opens upward and is fully visible
- [ ] Open notes panel on a task near the top/middle of a column -- verify it still opens downward normally
- [ ] Verify multi view notes panel behaviour is unchanged
- [ ] Verify the 200px threshold feels right at typical screen heights -- adjust if panels still clip or flip prematurely

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh