### PR TITLE
Wire current-task-pulse highlight to day view

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -143,6 +143,11 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             const taskCalStyle = getTaskCalendarStyle(task, darkMode);
             const isCompleted = task.completed;
 
+            const _nowMin = new Date().getHours() * 60 + new Date().getMinutes();
+            const _taskStart = timeToMinutes(task.startTime || '0:00');
+            const isCurrentTask = col.dateStr === dateToString(new Date()) && !isCompleted && !isCalendarEvent
+              && _nowMin >= _taskStart && _nowMin < _taskStart + (task.duration || 0);
+
             const radiusTop = clippedTop ? '' : 'rounded-t-lg';
             const radiusBot = clippedBottom ? '' : 'rounded-b-lg';
 
@@ -156,6 +161,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                   ${isCompleted && !isCalendarEvent ? 'opacity-50' : ''}
                   ${isCalendarEvent ? 'cursor-default' : 'cursor-pointer'}
                   ${expandedNotesTaskId === task.id ? 'overflow-visible z-30' : 'overflow-hidden'}
+                  ${isCurrentTask ? 'current-task-pulse' : ''}
                 `}
                 style={{
                   top: `${top}px`,


### PR DESCRIPTION
## Summary

- The in-progress task in day view now shows the same amber pulsing outline (`current-task-pulse`) as multi view
- Logic is identical to `TimeGrid.jsx`: today's date, task not completed, not a calendar event, current minute falls within the task's `[startTime, startTime + duration)` window
- The CSS class and animation are already defined in `index.css` -- no style changes needed
- Only `DayView.jsx` touched; 6 lines added

## Test plan

- [ ] Open day view during a scheduled task -- verify amber pulsing outline appears on that task card
- [ ] Compare to multi view -- outline style, color, and animation should be identical
- [ ] Task completes (time passes end) -- verify outline disappears on next 15 s tick
- [ ] Navigate to a non-today date -- verify no pulse on any task

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh