### PR TITLE
Day view navigation tightening

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -722,6 +722,7 @@ const DayPlanner = () => {
 
   const { changeDate, goToToday, goToDate, handleSpotlightSelect } = useNavigation({
     visibleDays,
+    effectiveViewMode,
     setSelectedDate,
     setShowMonthView,
     setShowSpotlight,
@@ -5253,7 +5254,9 @@ const DayPlanner = () => {
     const baseStr = dateToString(base);
     const nextStr = dateToString(nextDay);
 
-    if (dayViewMode === 'rolling-24') {
+    // rolling-24 only makes sense when viewing today; fall back to calendar-day for other dates
+    const isViewingToday = baseStr === dateToString(new Date());
+    if (dayViewMode === 'rolling-24' && isViewingToday) {
       const blockStart = Math.floor(currentTime.getHours() / 8) * 8;
       return [0, 1, 2].map(i => {
         const absStart = blockStart + i * 8;

--- a/src/components/DesktopHeader.jsx
+++ b/src/components/DesktopHeader.jsx
@@ -11,6 +11,7 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 const DesktopHeader = () => {
   const {
     visibleDays, visibleDates,
+    effectiveViewMode, dayViewColumns,
     selectedDate,
     darkMode, setDarkMode,
     showMonthView, setShowMonthView,
@@ -109,7 +110,9 @@ const DesktopHeader = () => {
               }}
               className={`month-view-toggle ${textPrimary} font-semibold text-base px-2 py-1 rounded-lg ${hoverBg} transition-colors cursor-pointer text-center min-w-[13rem]`}
             >
-              {formatDateRange(visibleDates)}
+              {effectiveViewMode === 'day'
+                ? formatDateRange([...new Map(dayViewColumns.map(c => [c.dateStr, c.date])).values()])
+                : formatDateRange(visibleDates)}
             </button>
             <button onClick={() => changeDate(1)} className={`p-1.5 rounded-lg ${hoverBg} transition-colors`} aria-label="Next day">
               <ChevronRight size={20} className={textSecondary} />

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -4,6 +4,7 @@ import { getNextOccurrence } from '../utils/recurrenceEngine.js';
 
 export default function useNavigation({
   visibleDays,
+  effectiveViewMode,
   setSelectedDate,
   setShowMonthView,
   setShowSpotlight,
@@ -15,13 +16,16 @@ export default function useNavigation({
   calendarRef,
 }) {
   const changeDate = useCallback((direction) => {
+    const stride = effectiveViewMode === 'day' ? 1
+      : effectiveViewMode === 'week' ? 7
+      : visibleDays;
     setSelectedDate(prev => {
       const newDate = new Date(prev);
-      newDate.setDate(newDate.getDate() + (direction * visibleDays));
+      newDate.setDate(newDate.getDate() + (direction * stride));
       newDate.setHours(12, 0, 0, 0);
       return newDate;
     });
-  }, [setSelectedDate, visibleDays]);
+  }, [setSelectedDate, visibleDays, effectiveViewMode]);
 
   const goToToday = useCallback(() => {
     const today = new Date();


### PR DESCRIPTION
## Summary

Four related navigation fixes bundled because they all touch the same selectedDate/viewMode decision surface.

**Arrow-key stride** (`useNavigation.js`): day view now advances 1 calendar day per left/right keypress instead of inheriting `visibleDays` (which was 3 at ≥1600px, causing 3-day jumps). Week view is wired to 7 days for when it lands. Multi view keeps its existing `visibleDays` stride unchanged. `effectiveViewMode` is passed into `useNavigation` to drive the decision.

**Rolling-24 gating** (`App.jsx` `dayViewColumns` useMemo): rolling-24 now activates only when `selectedDate === today`. Navigating to any other date falls back to calendar-day layout (00:00-08:00 / 08:00-16:00 / 16:00-24:00). The `dayView.mode` localStorage preference is never cleared -- it is only overridden in display. Returning to today (via arrow key or Today button) automatically restores rolling-24.

**Date navigator display** (`DesktopHeader.jsx`): in day view the header now shows dates derived from `dayViewColumns` (the unique calendar dates actually on screen) rather than `visibleDates`. Calendar-day mode and single-day rolling-24 show a single date (e.g. "Sunday, Apr 19"); rolling-24 spanning midnight shows a two-date range (e.g. "Apr 19 - 20, 2026"). Multi view is unchanged.

**Today button**: no code change needed -- the rolling-24 gating fix makes it work correctly by itself.

## Test plan

- [ ] Day view: press right arrow -- verify it advances exactly 1 day
- [ ] Day view: press left arrow -- verify it goes back exactly 1 day
- [ ] Multi view: press arrow keys -- verify stride is unchanged (advances by visible days)
- [ ] Day view with rolling-24 set: navigate to yesterday -- verify columns show 00:00-08:00 / 08:00-16:00 / 16:00-24:00 (calendar-day fallback)
- [ ] Day view with rolling-24 set: press Today -- verify rolling-24 layout resumes
- [ ] Check localStorage `day-planner-day-view-mode` after navigating to yesterday -- should still be `"rolling-24"`, not changed to `"calendar-day"`
- [ ] Date navigator: in day view calendar-day mode, verify header shows single date
- [ ] Date navigator: in day view rolling-24 mode (same-day), verify header shows single date
- [ ] Date navigator: in multi view, verify header still shows the multi-day range
- [ ] Switch views with selectedDate on a non-today date -- verify selectedDate is preserved

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh