### PR TITLE
Fix gap at bottom of day view columns

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -91,7 +91,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
 
   return (
     <div className={`flex-1 flex flex-col min-w-0 ${colIdx > 0 ? `border-l ${borderClass}` : ''}`}>
-      <div className="flex-1 relative">
+      <div className="flex-1 relative flex flex-col">
         {/* Hour rows — each is a full-width flex row matching TimeGrid's structure */}
         {hours.map((hour, i) => (
           <div key={hour} className="relative" style={{ height: `${hourHeight}px` }}>
@@ -115,6 +115,8 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             </div>
           </div>
         ))}
+        {/* Absorbs the floor-rounding remainder so columns fill the full height */}
+        <div className="flex-1" />
 
         {/* Current-time indicator — dot at gutter edge, line across event area */}
         {showNowLine && (


### PR DESCRIPTION
## Summary

`Math.floor(usable / 8)` in `useDayViewHourHeight` leaves `usable % 8` pixels (0-7 px) of empty space below the last hour row in each day view column. This shows as a thin dark strip at the bottom of the screen.

Fix: add `flex flex-col` to the column's inner container and append a `flex-1` spacer after the hour rows map. The spacer absorbs the floor-rounding remainder, so columns always fill to the bottom edge. The now-line and task overlay are both absolute-positioned and are entirely unaffected by the flex change.

## Test plan

- [ ] Open day view -- verify no dark gap strip visible at the bottom of any column
- [ ] Toggle the Now bar (have a running task, let it end) -- verify columns fill correctly in both states
- [ ] Switch between rolling-24 and calendar-day modes -- verify no gap in either

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh