### PR TITLE
Fix day view bottom gap using Math.ceil for hour height

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -115,8 +115,6 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             </div>
           </div>
         ))}
-        {/* Absorbs the floor-rounding remainder so columns fill the full height */}
-        <div className="flex-1" />
 
         {/* Current-time indicator — dot at gutter edge, line across event area */}
         {showNowLine && (

--- a/src/hooks/useDayViewHourHeight.js
+++ b/src/hooks/useDayViewHourHeight.js
@@ -13,7 +13,7 @@ export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
       const totalH = calendarRef.current.clientHeight;
       const stickyH = stickyHeaderRef?.current?.offsetHeight || 0;
       const usable = Math.max(160, totalH - stickyH);
-      setHourHeight(Math.max(20, Math.floor(usable / 8)));
+      setHourHeight(Math.max(20, Math.ceil(usable / 8)));
     };
 
     // Defer first measurement by one frame so the sticky header ref is populated.


### PR DESCRIPTION
## Summary

- Previous fix (PR #512) added a `flex-1` spacer after the hour rows, but the gap persisted because the spacer was a flex sibling of `relative`-positioned children, which can prevent it from actually expanding to fill space.
- Root fix: change `Math.floor` → `Math.ceil` in `useDayViewHourHeight`. This ensures `hourHeight * 8` always meets or exceeds the available container height (overflowing by 0–7 px, clipped). No gap possible.
- Also removes the now-redundant `flex-1` spacer div.

## Test plan

- [ ] Open day view — no dark strip visible at the bottom of any column
- [ ] Test in all three day-view column arrangements (1, 2, 3 columns at different widths)
- [ ] Resize the window — verify no gap appears during or after resize

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh