### PR TITLE
Fix day view bottom gap: last hour row absorbs rounding remainder

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -94,7 +94,11 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
       <div className="flex-1 relative flex flex-col">
         {/* Hour rows — each is a full-width flex row matching TimeGrid's structure */}
         {hours.map((hour, i) => (
-          <div key={hour} className="relative" style={{ height: `${hourHeight}px` }}>
+          <div
+            key={hour}
+            className={`relative${i === hours.length - 1 ? ' flex-1' : ''}`}
+            style={i === hours.length - 1 ? { minHeight: `${hourHeight}px` } : { height: `${hourHeight}px` }}
+          >
             <div className={`flex border-b h-full ${borderClass} ${i % 2 === 1 ? altRow : ''}`}>
               <div
                 className={`w-16 flex-shrink-0 px-3 py-1 text-sm ${textSecondary} border-r ${borderClass} flex items-start h-full`}

--- a/src/hooks/useDayViewHourHeight.js
+++ b/src/hooks/useDayViewHourHeight.js
@@ -13,7 +13,7 @@ export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
       const totalH = calendarRef.current.clientHeight;
       const stickyH = stickyHeaderRef?.current?.offsetHeight || 0;
       const usable = Math.max(160, totalH - stickyH);
-      setHourHeight(Math.max(20, Math.ceil(usable / 8)));
+      setHourHeight(Math.max(20, Math.floor(usable / 8)));
     };
 
     // Defer first measurement by one frame so the sticky header ref is populated.


### PR DESCRIPTION
## Summary

- `Math.floor(usable / 8) * 8` is always ≤ `usable`, leaving a 0–7 px strip at the bottom of each column.
- The last hour row (hour 7 of 8) now gets `flex-1` + `min-height: hourHeight` instead of a fixed height, so it stretches to fill exactly what's left.
- Hours 0–6 keep their fixed pixel heights — time positions are unchanged.
- No overflow, no clipping, no gap.

## Test plan

- [ ] Open day view — no dark strip at the bottom of any column
- [ ] Resize the window — gap stays gone at all sizes
- [ ] Confirm hour labels and half-hour dashes align correctly

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh