### PR TITLE
Add URL query param deeplinks (?view, ?date) and PWA url_handlers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -224,8 +224,9 @@ const DayPlanner = () => {
   // Override visible days: tablet uses orientation (static panel always present), mobile always 1, desktop uses width-based hook
   const visibleDays = isTablet ? (isLandscape ? 2 : 1) : isMobile ? 1 : _visibleDays;
   const [viewMode, setViewMode] = useState(() => {
-    // Initialize from defaultView on every cold load; last-used viewMode is
-    // written to day-planner-view-mode during a session but not read back.
+    // URL ?view= param takes priority over defaultView on cold load.
+    const urlView = new URLSearchParams(window.location.search).get('view');
+    if (urlView && ['multi', 'day', 'week'].includes(urlView)) return urlView;
     const def = localStorage.getItem('day-planner-default-view');
     return def ? JSON.parse(def) : 'multi';
   });
@@ -247,6 +248,17 @@ const DayPlanner = () => {
     return saved ? JSON.parse(saved) : false;
   });
   const [selectedDate, setSelectedDate] = useState(() => {
+    const urlDate = new URLSearchParams(window.location.search).get('date');
+    if (urlDate) {
+      const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(urlDate);
+      if (m) {
+        const parsed = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 12, 0, 0, 0);
+        const currentYear = new Date().getFullYear();
+        if (!isNaN(parsed.getTime()) && parsed.getFullYear() >= currentYear - 100 && parsed.getFullYear() <= currentYear + 100) {
+          return parsed;
+        }
+      }
+    }
     const today = new Date();
     today.setHours(12, 0, 0, 0);
     return today;

--- a/vite.config.js
+++ b/vite.config.js
@@ -189,6 +189,9 @@ export default defineConfig({
             purpose: 'maskable',
           },
         ],
+        url_handlers: [
+          { origin: 'https://dayglance.app' },
+        ],
       },
     }),
   ],


### PR DESCRIPTION
## Summary

- `?view=multi|day|week` on cold load sets `viewMode`, overriding the `defaultView` setting. Invalid values are silently ignored and fall back to the default.
- `?date=YYYY-MM-DD` on cold load sets `selectedDate`. Malformed strings, unparseable values, and dates more than 100 years away from today are ignored; the app falls back to today. Strict ISO format only.
- URL params are read once at mount (useState initialiser). The URL is never written during navigation in this PR.
- `url_handlers` added to the PWA manifest so installed Chromium-based PWAs can handle `dayglance.app` URLs at the OS level (progressive enhancement; no-op in unsupported browsers).

## Behaviour notes

- `?view=day` on a viewport narrower than 1600px: `viewMode` is set to `'day'` but `effectiveViewMode` falls back to `'multi'` (same as the existing defaultView behaviour at narrow widths). Resizing above 1600px surfaces day view without a reload.
- `?view=day&date=<today>` with `dayView.mode = 'rolling-24'`: renders rolling-24 as normal.
- `?view=day&date=<non-today>` with `dayView.mode = 'rolling-24'`: renders calendar-day for that date (rolling-24 only applies to today, per PR #11).

## Test plan

- [ ] `/?view=day` loads in day view (>=1600px viewport) on today
- [ ] `/?view=day&date=2026-04-20` loads day view on April 20
- [ ] `/?view=multi&date=2026-06-15` loads multi view on June 15
- [ ] `/?view=invalid` falls back to defaultView setting
- [ ] `/?date=not-a-date` falls back to today, no crash
- [ ] No params: existing behaviour unchanged
- [ ] Navigate after URL load: arrow keys, Today, view cycler all work normally

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh