### PR TITLE
Wire GLANCE sidebar click-to-focus for day view

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -158,6 +158,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             return (
               <div
                 key={`${task.id}-${col.startHour}`}
+                data-task-id={task.id}
                 data-ctx-menu
                 className={`absolute pointer-events-auto shadow-md notes-panel-container
                   ${task.isTaskCalendar ? '' : task.color}

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -64,7 +64,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     moveToRecycleBin,
     setInboxProjectFilter, setInboxPriorityFilter, setHideCompletedInbox,
     setHideProjectTasksInbox, setHideStandaloneTasksInbox,
-    goToDate, scrollToHour,
+    goToDate, scrollToHour, effectiveViewMode,
   } = useDayPlannerCtx();
   const {
     habitLongPressTimer,
@@ -553,14 +553,15 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                   className={`flex-1 min-w-0 ${task._overdueType === 'scheduled' ? 'cursor-pointer' : ''}`}
                   onClick={() => {
                     if (task._overdueType !== 'scheduled') return;
-                    if (task.date) setSelectedDate(new Date(task.date + 'T12:00:00'));
+                    if (task.date) goToDate(task.date);
                     setTimeout(() => {
                       const el = document.querySelector(`[data-task-id="${task.id}"]`);
-                      if (el && calendarRef.current) {
-                        const container = calendarRef.current;
-                        const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
-                        const scrollTarget = Math.max(0, elTop - container.clientHeight / 2 + el.offsetHeight / 2);
-                        container.scrollTo({ top: scrollTarget, behavior: 'smooth' });
+                      if (el) {
+                        if (effectiveViewMode === 'multi' && calendarRef.current) {
+                          const container = calendarRef.current;
+                          const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+                          container.scrollTo({ top: Math.max(0, elTop - container.clientHeight / 2 + el.offsetHeight / 2), behavior: 'smooth' });
+                        }
                         el.classList.add('ring-2', 'ring-blue-400');
                         setTimeout(() => el.classList.remove('ring-2', 'ring-blue-400'), 2000);
                       }
@@ -835,11 +836,12 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
           className={`flex gap-2.5 py-2 ${task.completed ? 'opacity-50' : ''} cursor-pointer ${isDesktop ? 'hover:bg-white/5' : 'active:bg-white/5'} rounded-lg transition-colors`}
           onClick={() => {
             const el = document.querySelector(`[data-task-id="${task.id}"]`);
-            if (el && calendarRef.current) {
-              const container = calendarRef.current;
-              const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
-              const scrollTarget = Math.max(0, elTop - container.clientHeight / 2 + el.offsetHeight / 2);
-              container.scrollTo({ top: scrollTarget, behavior: 'smooth' });
+            if (el) {
+              if (effectiveViewMode === 'multi' && calendarRef.current) {
+                const container = calendarRef.current;
+                const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+                container.scrollTo({ top: Math.max(0, elTop - container.clientHeight / 2 + el.offsetHeight / 2), behavior: 'smooth' });
+              }
               el.classList.add('ring-2', 'ring-blue-400');
               setTimeout(() => el.classList.remove('ring-2', 'ring-blue-400'), 2000);
             }


### PR DESCRIPTION
## Summary

- Day view task pills now carry `data-task-id` so the sidebar's `querySelector` can find them (they were the only timeline cards missing this attribute).
- Both sidebar click handlers (overdue tasks and today's agenda tasks) are now view-mode-aware via `effectiveViewMode`:
  - `multi`: navigate to date + scroll timeline to center the task + blue ring (unchanged behavior)
  - `day` / `week`: navigate to date if the task isn't on the current date, then apply blue ring only (day view is fully visible, no scroll needed)
- Overdue handler now calls `goToDate()` instead of `setSelectedDate` directly, using the same navigation primitive as the rest of the app (URL deeplinks, spotlight, arrow keys, etc.).
- `CalendarHeader.jsx` all-day chips already had `data-task-id`, so clicking an all-day task from the sidebar applies the blue ring to its chip in the ALL DAY row automatically.

## Test plan

- [ ] Multi view: click sidebar task (overdue and today's) -- frame + scroll, unchanged
- [ ] Day view, task on current date: click sidebar task -- blue ring on task card, no scroll
- [ ] Day view, task on a different date: click sidebar task -- day view navigates to task's date, blue ring applied
- [ ] Day view, all-day task: click sidebar task -- blue ring on chip in ALL DAY row
- [ ] Rapid clicks between tasks: ring moves cleanly between cards
- [ ] Completed task: ring applies despite strikethrough/opacity styling

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh