### PR TITLE
Fix sidebar click-to-focus navigation: use DOM presence, not date comparison

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -836,15 +836,20 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
           className={`flex gap-2.5 py-2 ${task.completed ? 'opacity-50' : ''} cursor-pointer ${isDesktop ? 'hover:bg-white/5' : 'active:bg-white/5'} rounded-lg transition-colors`}
           onClick={() => {
             const el = document.querySelector(`[data-task-id="${task.id}"]`);
-            if (el) {
-              if (effectiveViewMode === 'multi' && calendarRef.current) {
-                const container = calendarRef.current;
-                const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
-                container.scrollTo({ top: Math.max(0, elTop - container.clientHeight / 2 + el.offsetHeight / 2), behavior: 'smooth' });
+            const needsNav = !el && task.date && effectiveViewMode !== 'multi';
+            if (needsNav) goToDate(task.date);
+            setTimeout(() => {
+              const target = document.querySelector(`[data-task-id="${task.id}"]`);
+              if (target) {
+                if (effectiveViewMode === 'multi' && calendarRef.current) {
+                  const container = calendarRef.current;
+                  const elTop = target.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+                  container.scrollTo({ top: Math.max(0, elTop - container.clientHeight / 2 + target.offsetHeight / 2), behavior: 'smooth' });
+                }
+                target.classList.add('ring-2', 'ring-blue-400');
+                setTimeout(() => target.classList.remove('ring-2', 'ring-blue-400'), 2000);
               }
-              el.classList.add('ring-2', 'ring-blue-400');
-              setTimeout(() => el.classList.remove('ring-2', 'ring-blue-400'), 2000);
-            }
+            }, needsNav ? 200 : 0);
           }}
         >
           <div className={`w-1.5 rounded-full flex-shrink-0 ${colorClass} ${relativeLabel === 'In Progress' ? 'animate-pulse' : ''}`} style={task.isTaskCalendar ? getTaskCalendarStyle(task, darkMode) : task.nativeCalendarColor ? { backgroundColor: task.nativeCalendarColor } : {}}></div>


### PR DESCRIPTION
## Summary

The today's agenda click handler was only applying the blue ring if the element already existed in the DOM. When the user was viewing a different date in day view, the element was not rendered, so clicks silently no-oped.

Root cause: no navigation logic in the today's agenda handler. The condition was effectively "is this element in the DOM right now?" -- which is correct for deciding whether to scroll, but was being used as the only gate, so off-screen tasks were silently ignored.

Fix: check DOM presence first. If the element is absent and we are not in multi view, call `goToDate(task.date)` then re-query after 200ms. The 200ms delay is only incurred when navigation actually happens (element already present = 0ms delay). Multi view behavior is unchanged.

This makes all these cases work correctly:
- Viewing Apr 15, click task for Apr 19 (today): navigates forward
- Viewing Apr 21, click task for Apr 19 (today): navigates backward
- Viewing Apr 19, click task for Apr 19 (already visible): ring only, no delay
- No date comparison logic -- purely DOM presence as the condition

## Test plan

- [ ] Day view Apr 15, click sidebar task for today (Apr 19): navigates forward, ring applied
- [ ] Day view Apr 21, click sidebar task for today (Apr 19): navigates backward, ring applied
- [ ] Day view showing the task's date: click sidebar task -- ring applies immediately, no navigation
- [ ] Multi view: click sidebar task -- scroll + ring, unchanged

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh