### PR TITLE
Fix sidebar click-to-focus regression in multi view

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -553,19 +553,19 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                   className={`flex-1 min-w-0 ${task._overdueType === 'scheduled' ? 'cursor-pointer' : ''}`}
                   onClick={() => {
                     if (task._overdueType !== 'scheduled') return;
-                    if (task.date) goToDate(task.date);
-                    setTimeout(() => {
-                      const el = document.querySelector(`[data-task-id="${task.id}"]`);
-                      if (el) {
-                        if (effectiveViewMode === 'multi' && calendarRef.current) {
-                          const container = calendarRef.current;
-                          const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
-                          container.scrollTo({ top: Math.max(0, elTop - container.clientHeight / 2 + el.offsetHeight / 2), behavior: 'smooth' });
-                        }
-                        el.classList.add('ring-2', 'ring-blue-400');
-                        setTimeout(() => el.classList.remove('ring-2', 'ring-blue-400'), 2000);
+                    const el = document.querySelector(`[data-task-id="${task.id}"]`);
+                    const applyRing = () => {
+                      const target = document.querySelector(`[data-task-id="${task.id}"]`);
+                      if (!target) return;
+                      if (effectiveViewMode === 'multi' && calendarRef.current) {
+                        const container = calendarRef.current;
+                        const elTop = target.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+                        container.scrollTo({ top: Math.max(0, elTop - container.clientHeight / 2 + target.offsetHeight / 2), behavior: 'smooth' });
                       }
-                    }, 200);
+                      target.classList.add('ring-2', 'ring-blue-400');
+                      setTimeout(() => target.classList.remove('ring-2', 'ring-blue-400'), 2000);
+                    };
+                    if (el) { applyRing(); } else if (task.date) { goToDate(task.date); setTimeout(applyRing, 200); }
                   }}
                 >
                   <div className={`text-sm font-medium truncate ${task.completed ? 'line-through opacity-50' : textPrimary}`}>
@@ -836,20 +836,18 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
           className={`flex gap-2.5 py-2 ${task.completed ? 'opacity-50' : ''} cursor-pointer ${isDesktop ? 'hover:bg-white/5' : 'active:bg-white/5'} rounded-lg transition-colors`}
           onClick={() => {
             const el = document.querySelector(`[data-task-id="${task.id}"]`);
-            const needsNav = !el && task.date && effectiveViewMode !== 'multi';
-            if (needsNav) goToDate(task.date);
-            setTimeout(() => {
+            const applyRing = () => {
               const target = document.querySelector(`[data-task-id="${task.id}"]`);
-              if (target) {
-                if (effectiveViewMode === 'multi' && calendarRef.current) {
-                  const container = calendarRef.current;
-                  const elTop = target.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
-                  container.scrollTo({ top: Math.max(0, elTop - container.clientHeight / 2 + target.offsetHeight / 2), behavior: 'smooth' });
-                }
-                target.classList.add('ring-2', 'ring-blue-400');
-                setTimeout(() => target.classList.remove('ring-2', 'ring-blue-400'), 2000);
+              if (!target) return;
+              if (effectiveViewMode === 'multi' && calendarRef.current) {
+                const container = calendarRef.current;
+                const elTop = target.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+                container.scrollTo({ top: Math.max(0, elTop - container.clientHeight / 2 + target.offsetHeight / 2), behavior: 'smooth' });
               }
-            }, needsNav ? 200 : 0);
+              target.classList.add('ring-2', 'ring-blue-400');
+              setTimeout(() => target.classList.remove('ring-2', 'ring-blue-400'), 2000);
+            };
+            if (el) { applyRing(); } else if (task.date) { goToDate(task.date); setTimeout(applyRing, 200); }
           }}
         >
           <div className={`w-1.5 rounded-full flex-shrink-0 ${colorClass} ${relativeLabel === 'In Progress' ? 'animate-pulse' : ''}`} style={task.isTaskCalendar ? getTaskCalendarStyle(task, darkMode) : task.nativeCalendarColor ? { backgroundColor: task.nativeCalendarColor } : {}}></div>


### PR DESCRIPTION
## Summary

PR #517 introduced a `setTimeout(fn, 0)` on the non-navigation path of the today's agenda click handler. This deferred the scroll measurement past React's layout flush, breaking ring+scroll in multi view when the element was already in the DOM.

Both handlers now share the same clean pattern with no `setTimeout` on the happy path:

```
element in DOM  → applyRing() synchronously (scroll if multi, ring always)
element not DOM → goToDate(task.date), setTimeout(applyRing, 200)
```

No view-mode or date conditionals on the navigation decision -- DOM presence is the only condition that matters.

## Test plan

- [ ] Multi view, task visible: click sidebar task -- ring + scroll immediately
- [ ] Multi view, task on a different date: click sidebar task -- navigate, ring + scroll after 200ms
- [ ] Day view, task on current date: click sidebar task -- ring, no scroll
- [ ] Day view, task on different date (past, future, or today from a non-today view): navigate, ring after 200ms

https://claude.ai/code/session_015P6K763NYimvgRFEZ8WyHh