### PR TITLE
Week view: 7-column timeline with task chips, popovers, and all-day section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -243,6 +243,10 @@ const DayPlanner = () => {
     const saved = localStorage.getItem('day-planner-day-view-mode');
     return saved ? JSON.parse(saved) : 'calendar-day';
   });
+  const [weekViewMode, setWeekViewMode] = useState(() => {
+    const saved = localStorage.getItem('day-planner-week-view-mode');
+    return saved ? JSON.parse(saved) : 'strict';
+  });
   const [darkMode, setDarkMode] = useState(() => {
     const saved = localStorage.getItem('day-planner-darkmode');
     return saved ? JSON.parse(saved) : false;
@@ -1042,6 +1046,9 @@ const DayPlanner = () => {
   useEffect(() => {
     localStorage.setItem('day-planner-day-view-mode', JSON.stringify(dayViewMode));
   }, [dayViewMode]);
+  useEffect(() => {
+    localStorage.setItem('day-planner-week-view-mode', JSON.stringify(weekViewMode));
+  }, [weekViewMode]);
 
   // Lock body/html scrolling to prevent scroll chaining (all devices incl. desktop PWA)
   useEffect(() => {
@@ -5288,6 +5295,35 @@ const DayPlanner = () => {
     ];
   }, [selectedDate, dayViewMode, currentTime]);
 
+  // Seven dates for week view — strict (calendar week) or rolling (today + 6 days).
+  // Empty array when not in week mode so it doesn't affect other views.
+  const weekViewDates = useMemo(() => {
+    if (effectiveViewMode !== 'week') return [];
+    const base = new Date(selectedDate);
+    base.setHours(0, 0, 0, 0);
+    const todayStr = dateToString(new Date());
+    const isViewingToday = dateToString(base) === todayStr;
+
+    if (weekViewMode === 'rolling' && isViewingToday) {
+      return Array.from({ length: 7 }, (_, i) => {
+        const d = new Date(base);
+        d.setDate(d.getDate() + i);
+        return d;
+      });
+    }
+
+    // Strict: week containing selectedDate, starting on weekStartDay
+    const dayOfWeek = base.getDay();
+    const diff = (dayOfWeek - weekStartDay + 7) % 7;
+    const weekStart = new Date(base);
+    weekStart.setDate(weekStart.getDate() - diff);
+    return Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(weekStart);
+      d.setDate(d.getDate() + i);
+      return d;
+    });
+  }, [effectiveViewMode, selectedDate, weekViewMode, weekStartDay]);
+
   // Auto-select new tags when they appear (only truly new tags, not previously deselected ones)
   const prevAllTagsRef = useRef(new Set(allTags));
   useEffect(() => {
@@ -5299,12 +5335,13 @@ const DayPlanner = () => {
     prevAllTagsRef.current = new Set(allTags);
   }, [allTags]);
 
-  // Expand recurring task templates into virtual task instances for visible dates
+  // Expand recurring task templates into virtual task instances for visible dates.
+  // In week view, expand over the full week range (which may extend beyond visibleDates).
   const expandedRecurringTasks = useMemo(() => {
     if (recurringTasks.length === 0) return [];
-    const dateStrs = visibleDates.map(d => dateToString(d));
-    const rangeStart = dateStrs[0];
-    const rangeEnd = dateStrs[dateStrs.length - 1];
+    const allDateStrs = [...visibleDates, ...weekViewDates].map(d => dateToString(d)).sort();
+    const rangeStart = allDateStrs[0];
+    const rangeEnd = allDateStrs[allDateStrs.length - 1];
     const today = getTodayStr();
     const instances = [];
     for (const template of recurringTasks) {
@@ -5333,7 +5370,7 @@ const DayPlanner = () => {
       }
     }
     return instances;
-  }, [recurringTasks, visibleDates]);
+  }, [recurringTasks, visibleDates, weekViewDates]);
   expandedRecurringTasksRef.current = expandedRecurringTasks;
 
   // Build today's non-overdue HG sessions for the reminder engine.
@@ -6903,6 +6940,8 @@ const DayPlanner = () => {
     defaultView, setDefaultView,
     dayViewMode, setDayViewMode,
     dayViewColumns,
+    weekViewMode, setWeekViewMode,
+    weekViewDates,
 
     // ── DOM / timer / function refs ───────────────────────────────────────────
     tabBarRef, suppressTabBarRef,

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   AlertCircle, BookOpen, Calendar, Check, CheckSquare,
   ExternalLink, FileText, GripVertical, Inbox, MoreHorizontal,
@@ -8,6 +8,7 @@ import {
 import ViewCycler from './ViewCycler.jsx';
 import DayViewAllDaySection from './DayViewAllDaySection.jsx';
 import AllDayTaskCard from './AllDayTaskCard.jsx';
+import { WEEK_GUTTER_W } from './WeekView.jsx';
 import { isNativeAndroid, nativeUpdateEvent } from '../native.js';
 import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
 import { dateToString, extractWikilinks, formatDeadlineDate, formatShortDate } from '../utils/taskUtils.js';
@@ -27,6 +28,7 @@ const CalendarHeader = () => {
     selectedDate,
     canShowViewCycler, effectiveViewMode,
     use24HourClock, dayViewColumns,
+    weekViewDates,
     mobileDateHeaderRef, mobileAllDaySectionRef,
     autoScrollInterval,
     longPressTimerRef, longPressTriggeredRef,
@@ -90,6 +92,28 @@ const CalendarHeader = () => {
     openRoutinesDashboard,
   } = useFeaturesCtx();
 
+  // Week view: all-day popover state
+  const weekAllDayBtnRefs = useRef({});
+  const [weekAllDayPopover, setWeekAllDayPopover] = useState(null); // { dateStr, tasks, anchor }
+  const weekAllDayPopoverRef = useRef(null);
+
+  useEffect(() => {
+    if (!weekAllDayPopover) return;
+    const onDown = (e) => {
+      const btnEl = weekAllDayBtnRefs.current[weekAllDayPopover.dateStr];
+      if (!weekAllDayPopoverRef.current?.contains(e.target) && !btnEl?.contains(e.target)) {
+        setWeekAllDayPopover(null);
+      }
+    };
+    const onKey = (e) => { if (e.key === 'Escape') setWeekAllDayPopover(null); };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [weekAllDayPopover]);
+
   // Helpers for day-mode date-group header labels
   const formatBoundHour = (h, use24h) => {
     const norm = h % 24;
@@ -104,10 +128,53 @@ const CalendarHeader = () => {
 {/* Date headers row */}
 <div
   ref={(el) => { if (isTablet) mobileDateHeaderRef.current = el; }}
-  className={`border-b ${borderClass} ${cardBg}${effectiveViewMode === 'day' ? '' : ' flex'}`}
+  className={`border-b ${borderClass} ${cardBg} flex`}
   style={effectiveViewMode === 'day' ? { display: 'grid', gridTemplateColumns: `repeat(${dayViewColumns.length}, 1fr)` } : undefined}
 >
-  {effectiveViewMode === 'multi' ? (
+  {effectiveViewMode === 'week' ? (
+    /* Week view: gutter cell + 7 day-header cells */
+    <>
+      <div
+        className={`flex-shrink-0 border-r ${borderClass} flex items-center justify-center`}
+        style={{ width: WEEK_GUTTER_W, minHeight: 'var(--header-row-h)' }}
+      >
+        {canShowViewCycler && <ViewCycler />}
+      </div>
+      {weekViewDates.map((date, idx) => {
+        const dateStr = dateToString(date);
+        const isDateToday = dateStr === dateToString(new Date());
+        return (
+          <div
+            key={dateStr}
+            className={`flex-1 py-1.5 px-1 text-center transition-colors ${idx > 0 ? `border-l ${borderClass}` : ''}
+              ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : ''}`}
+            style={{ minHeight: 'var(--header-row-h)' }}
+          >
+            <div className={`text-xs font-bold flex items-center justify-center gap-1 ${isDateToday ? 'text-blue-600' : textPrimary}`}>
+              <span>{['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][date.getDay()]}</span>
+              <span className={`font-normal ${isDateToday ? 'text-blue-500' : textSecondary}`}>
+                {date.getMonth() + 1}/{date.getDate()}
+              </span>
+              <button
+                onClick={(e) => { e.stopPropagation(); setDailyNotesModalDate(dateStr); }}
+                className={`p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors ${dailyNotes[dateStr]?.text ? '' : 'opacity-40'}`}
+                title="Daily notes"
+              >
+                <NotebookPen size={12} />
+              </button>
+              <button
+                onClick={(e) => { e.stopPropagation(); setFocusLogModalDate(dateStr); }}
+                className={`p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors ${focusLog[dateStr]?.totalMinutes > 0 ? '' : 'opacity-40'}`}
+                title="Focus sessions"
+              >
+                <Target size={12} />
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  ) : effectiveViewMode === 'multi' ? (
     <>
     {/* Top-left cell: hosts ViewCycler on large screens */}
     <div className={`w-16 flex-shrink-0 border-r ${borderClass} flex items-center justify-center`} style={{ minHeight: 'var(--header-row-h)' }}>
@@ -258,6 +325,67 @@ const CalendarHeader = () => {
 
 {/* Day mode all-day chips strip */}
 {effectiveViewMode === 'day' && <DayViewAllDaySection />}
+
+{/* Week view all-day count chips */}
+{effectiveViewMode === 'week' && weekViewDates.some(d => getTasksForDate(d).some(t => t.isAllDay)) && (
+  <div className={`flex border-b ${borderClass} ${cardBg}`}>
+    <div
+      className={`flex-shrink-0 border-r ${borderClass} flex items-center justify-center`}
+      style={{ width: WEEK_GUTTER_W, minHeight: '28px' }}
+    >
+      <span className={`text-[10px] font-semibold ${textSecondary} uppercase tracking-wide`}>All day</span>
+    </div>
+    {weekViewDates.map((date, idx) => {
+      const dateStr = dateToString(date);
+      const allDayTasks = getTasksForDate(date).filter(t => t.isAllDay && (!projectFilter || t.projectId === projectFilter));
+      const isDateToday = dateStr === dateToString(new Date());
+      return (
+        <div
+          key={dateStr}
+          className={`flex-1 flex items-center justify-center py-1 min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}
+            ${isDateToday ? (darkMode ? 'bg-blue-900/10' : 'bg-blue-50/40') : ''}`}
+        >
+          {allDayTasks.length > 0 && (
+            <button
+              ref={el => { weekAllDayBtnRefs.current[dateStr] = el; }}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (weekAllDayPopover?.dateStr === dateStr) {
+                  setWeekAllDayPopover(null);
+                } else {
+                  const rect = e.currentTarget.getBoundingClientRect();
+                  setWeekAllDayPopover({ dateStr, tasks: allDayTasks, anchor: rect });
+                }
+              }}
+              className={`px-1.5 py-0.5 rounded text-[10px] font-semibold transition-colors
+                ${darkMode ? 'bg-blue-700/60 text-blue-200 hover:bg-blue-700' : 'bg-blue-100 text-blue-700 hover:bg-blue-200'}`}
+            >
+              {allDayTasks.length} all day
+            </button>
+          )}
+        </div>
+      );
+    })}
+  </div>
+)}
+{/* Week all-day popover */}
+{weekAllDayPopover && (
+  <div
+    ref={weekAllDayPopoverRef}
+    className={`fixed z-50 shadow-xl rounded-xl border p-2 space-y-1 ${cardBg} ${borderClass}`}
+    style={{
+      left: Math.max(8, Math.min(weekAllDayPopover.anchor.left, window.innerWidth - 296)),
+      top: weekAllDayPopover.anchor.bottom + 4,
+      width: 280,
+    }}
+    onClick={(e) => e.stopPropagation()}
+    onMouseDown={(e) => e.stopPropagation()}
+  >
+    {weekAllDayPopover.tasks.map(task => (
+      <AllDayTaskCard key={task.id} task={task} fillWidth={true} />
+    ))}
+  </div>
+)}
 
 {/* Multi-mode all-day tasks section */}
 {effectiveViewMode === 'multi' && (visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay) || getDeadlineTasksForDate(dateToString(date)).length > 0) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (

--- a/src/components/DesktopHeader.jsx
+++ b/src/components/DesktopHeader.jsx
@@ -12,6 +12,7 @@ const DesktopHeader = () => {
   const {
     visibleDays, visibleDates,
     effectiveViewMode, dayViewColumns,
+    weekViewDates,
     selectedDate,
     darkMode, setDarkMode,
     showMonthView, setShowMonthView,
@@ -112,6 +113,8 @@ const DesktopHeader = () => {
             >
               {effectiveViewMode === 'day'
                 ? formatDateRange([...new Map(dayViewColumns.map(c => [c.dateStr, c.date])).values()])
+                : effectiveViewMode === 'week' && weekViewDates.length > 0
+                ? formatDateRange(weekViewDates)
                 : formatDateRange(visibleDates)}
             </button>
             <button onClick={() => changeDate(1)} className={`p-1.5 rounded-lg ${hoverBg} transition-colors`} aria-label="Next day">

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -30,6 +30,7 @@ const SettingsModal = () => {
     dailyNoteTemplate, setDailyNoteTemplate,
     defaultView, setDefaultView,
     dayViewMode, setDayViewMode,
+    weekViewMode, setWeekViewMode,
     canShowViewCycler,
   } = useDayPlannerCtx();
   const {
@@ -168,6 +169,31 @@ const SettingsModal = () => {
                               }`}
                             >
                               Rolling 24h
+                            </button>
+                          </div>
+                        </div>
+                        <div>
+                          <label className={`block text-xs ${textSecondary} mb-1.5`}>Week view mode</label>
+                          <div className="flex gap-2">
+                            <button
+                              onClick={() => setWeekViewMode('strict')}
+                              className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${
+                                weekViewMode === 'strict'
+                                  ? 'bg-blue-600 text-white'
+                                  : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`
+                              }`}
+                            >
+                              Strict week
+                            </button>
+                            <button
+                              onClick={() => setWeekViewMode('rolling')}
+                              className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${
+                                weekViewMode === 'rolling'
+                                  ? 'bg-blue-600 text-white'
+                                  : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`
+                              }`}
+                            >
+                              Rolling 7 days
                             </button>
                           </div>
                         </div>

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -1,13 +1,299 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { dateToString } from '../utils/taskUtils.js';
+import TimelineTaskCardContent from './TimelineTaskCardContent.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import useWeekViewHourHeight from '../hooks/useWeekViewHourHeight.js';
 
-const WeekView = () => {
-  const { textSecondary } = useDayPlannerCtx();
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function weekColConflictPos(task, colTasks, timeToMinutes) {
+  const tStart = timeToMinutes(task.startTime || '0:00');
+  const tEnd = tStart + (task.duration || 0);
+
+  const peers = colTasks.filter(other => {
+    if (other.id === task.id) return false;
+    const oStart = timeToMinutes(other.startTime || '0:00');
+    const oEnd = oStart + (other.duration || 0);
+    return tStart < oEnd && tEnd > oStart;
+  });
+
+  if (peers.length === 0) return { left: '1px', right: '1px', width: undefined };
+
+  const group = [task, ...peers].sort((a, b) => {
+    const diff = timeToMinutes(a.startTime || '0:00') - timeToMinutes(b.startTime || '0:00');
+    return diff !== 0 ? diff : String(a.id).localeCompare(String(b.id));
+  });
+  const idx = group.findIndex(t => t.id === task.id);
+  const total = group.length;
+  const pct = 100 / total;
+  return { left: `calc(${idx * pct}% + 1px)`, width: `calc(${pct}% - 2px)`, right: undefined };
+}
+
+// ── Task popover ──────────────────────────────────────────────────────────────
+
+const WeekViewTaskPopover = ({ task, anchor, onClose }) => {
+  const { cardBg, borderClass, darkMode, getTaskCalendarStyle } = useDayPlannerCtx();
+  const popoverRef = useRef(null);
+  const POPOVER_W = 300;
+  const POPOVER_H = 220;
+
+  const isImported = task.imported;
+  const isCalendarEvent = isImported && !task.isTaskCalendar;
+  const taskCalStyle = getTaskCalendarStyle(task, darkMode);
+
+  let left = anchor.right + 8;
+  if (left + POPOVER_W > window.innerWidth - 8) left = anchor.left - POPOVER_W - 8;
+  let top = anchor.top;
+  if (top + POPOVER_H > window.innerHeight - 8) top = window.innerHeight - POPOVER_H - 8;
+  top = Math.max(8, top);
+  left = Math.max(8, left);
+
+  useEffect(() => {
+    const onDown = (e) => {
+      if (!popoverRef.current?.contains(e.target)) onClose();
+    };
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [onClose]);
+
   return (
-    <div className="flex flex-1 items-center justify-center" style={{ height: '100%' }}>
-      <span className={`text-sm ${textSecondary}`}>Week view coming soon</span>
+    <div
+      ref={popoverRef}
+      className={`fixed z-50 shadow-2xl rounded-xl border overflow-hidden notes-panel-container
+        ${task.isTaskCalendar ? '' : task.color}
+        ${isCalendarEvent ? '' : ''}
+      `}
+      style={{
+        left,
+        top,
+        width: POPOVER_W,
+        minHeight: POPOVER_H,
+        ...(isCalendarEvent || task.isTaskCalendar ? taskCalStyle : {}),
+      }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <TimelineTaskCardContent
+        task={task}
+        height={POPOVER_H}
+        isNarrowWidth={false}
+        flipNotesPanel={top + POPOVER_H > window.innerHeight / 2}
+      />
     </div>
   );
 };
 
+// ── WeekViewColumn ────────────────────────────────────────────────────────────
+
+const WEEK_GUTTER_W = 64; // px — matches the hour-label column width
+
+const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, activePopoverTaskId, isToday }) => {
+  const {
+    darkMode, borderClass,
+    getTasksForDate, getTaskCalendarStyle,
+    timeToMinutes,
+    setTaskContextMenu,
+  } = useDayPlannerCtx();
+  const { projectFilter } = useFeaturesCtx();
+
+  const colTasks = getTasksForDate(date).filter(t => {
+    if (t.isAllDay || !t.startTime) return false;
+    if (projectFilter && t.projectId !== projectFilter) return false;
+    return true;
+  });
+
+  const now = new Date();
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+  const nowY = isToday ? nowMinutes * hourHeight / 60 : 0;
+  const altRow = darkMode ? 'bg-white/[0.04]' : 'bg-stone-100/50';
+
+  return (
+    <div
+      data-week-col={dateStr}
+      className={`flex-1 flex flex-col min-w-0 relative ${colIdx > 0 ? `border-l ${borderClass}` : ''} ${isToday ? (darkMode ? 'bg-blue-900/10' : 'bg-blue-50/40') : ''}`}
+    >
+      {/* Hour rows */}
+      {Array.from({ length: 24 }, (_, hour) => (
+        <div
+          key={hour}
+          className={`relative${hour === 23 ? ' flex-1' : ''}`}
+          style={hour === 23 ? { minHeight: `${hourHeight}px` } : { height: `${hourHeight}px` }}
+        >
+          <div className={`border-b h-full ${borderClass} ${hour % 2 === 1 ? altRow : ''}`} />
+          <div
+            className="absolute left-0 right-0 pointer-events-none"
+            style={{ top: `${hourHeight / 2}px` }}
+          >
+            <div className={`border-b border-dashed ${borderClass} opacity-30`} />
+          </div>
+        </div>
+      ))}
+
+      {/* Now line — today's column only */}
+      {isToday && (
+        <div
+          className="absolute left-0 right-0 pointer-events-none z-10"
+          style={{ top: `${nowY}px` }}
+        >
+          <div className="flex items-center">
+            <div className="w-2 h-2 bg-red-500 rounded-full -ml-1 flex-shrink-0" />
+            <div className="flex-1 h-0.5 bg-red-500" />
+          </div>
+        </div>
+      )}
+
+      {/* Task chips */}
+      <div className="absolute top-0 left-0 right-0 bottom-0 pointer-events-none">
+        {colTasks.map(task => {
+          const taskStart = timeToMinutes(task.startTime || '0:00');
+          const duration = task.duration || 0;
+          const rawH = duration * hourHeight / 60;
+          const chipH = Math.max(22, rawH);
+          const chipTop = taskStart * hourHeight / 60;
+          const { left, right, width } = weekColConflictPos(task, colTasks, timeToMinutes);
+
+          const isImported = task.imported;
+          const isCalendarEvent = isImported && !task.isTaskCalendar;
+          const taskCalStyle = getTaskCalendarStyle(task, darkMode);
+          const isActive = activePopoverTaskId === task.id;
+
+          return (
+            <div
+              key={task.id}
+              data-task-id={task.id}
+              className={`absolute pointer-events-auto rounded-sm overflow-hidden cursor-pointer
+                ${task.isTaskCalendar ? '' : task.color}
+                ${task.completed ? 'opacity-50' : ''}
+                ${isActive ? 'ring-2 ring-white/70 z-20' : 'z-10'}
+                hover:brightness-90
+              `}
+              style={{
+                top: `${chipTop}px`,
+                height: `${chipH}px`,
+                left,
+                right: width ? undefined : right,
+                width,
+                ...(isCalendarEvent || task.isTaskCalendar ? taskCalStyle : {}),
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                onTaskClick(task, e.currentTarget.getBoundingClientRect());
+              }}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                setTaskContextMenu({
+                  x: e.clientX, y: e.clientY,
+                  taskId: task.id,
+                  isRecurring: typeof task.id === 'string' && task.id.startsWith('recurring-'),
+                  isImported: !!isImported,
+                  isAllDay: false,
+                  dateStr,
+                });
+              }}
+            >
+              <span className="block text-white text-[11px] font-medium leading-tight px-1 py-0.5 truncate">
+                {task.title}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+// ── WeekView ──────────────────────────────────────────────────────────────────
+
+const WeekView = () => {
+  const {
+    calendarRef, stickyHeaderRef,
+    weekViewDates,
+    darkMode, borderClass, textSecondary,
+    use24HourClock,
+    cardBg,
+  } = useDayPlannerCtx();
+
+  const hourHeight = useWeekViewHourHeight(calendarRef, stickyHeaderRef);
+  const [popoverTask, setPopoverTask] = useState(null);
+  const [popoverAnchor, setPopoverAnchor] = useState(null);
+
+  const todayStr = dateToString(new Date());
+
+  const handleTaskClick = (task, anchor) => {
+    if (popoverTask?.id === task.id) {
+      setPopoverTask(null);
+      setPopoverAnchor(null);
+    } else {
+      setPopoverTask(task);
+      setPopoverAnchor(anchor);
+    }
+  };
+
+  const handleClosePopover = () => {
+    setPopoverTask(null);
+    setPopoverAnchor(null);
+  };
+
+  return (
+    <div className="flex" style={{ height: '100%' }}>
+      {/* Hour-label gutter */}
+      <div
+        className={`flex-shrink-0 border-r ${borderClass} flex flex-col`}
+        style={{ width: WEEK_GUTTER_W }}
+      >
+        {Array.from({ length: 24 }, (_, hour) => (
+          <div
+            key={hour}
+            className={`relative flex-shrink-0${hour === 23 ? ' flex-1' : ''}`}
+            style={hour === 23 ? { minHeight: `${hourHeight}px` } : { height: `${hourHeight}px` }}
+          >
+            {hour % 3 === 0 && (
+              <span
+                className={`absolute top-0.5 right-2 text-[10px] leading-none ${textSecondary} select-none`}
+              >
+                {use24HourClock
+                  ? `${String(hour).padStart(2, '0')}:00`
+                  : hour === 0 ? '12 AM' : hour === 12 ? '12 PM' : hour < 12 ? `${hour} AM` : `${hour - 12} PM`
+                }
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Day columns */}
+      {weekViewDates.map((date, colIdx) => {
+        const dateStr = dateToString(date);
+        return (
+          <WeekViewColumn
+            key={dateStr}
+            date={date}
+            dateStr={dateStr}
+            colIdx={colIdx}
+            hourHeight={hourHeight}
+            onTaskClick={handleTaskClick}
+            activePopoverTaskId={popoverTask?.id}
+            isToday={dateStr === todayStr}
+          />
+        );
+      })}
+
+      {/* Task detail popover */}
+      {popoverTask && popoverAnchor && (
+        <WeekViewTaskPopover
+          task={popoverTask}
+          anchor={popoverAnchor}
+          onClose={handleClosePopover}
+        />
+      )}
+    </div>
+  );
+};
+
+export { WEEK_GUTTER_W };
 export default WeekView;

--- a/src/hooks/useWeekViewHourHeight.js
+++ b/src/hooks/useWeekViewHourHeight.js
@@ -1,0 +1,31 @@
+import { useState, useLayoutEffect } from 'react';
+
+export default function useWeekViewHourHeight(calendarRef, stickyHeaderRef) {
+  const [hourHeight, setHourHeight] = useState(33);
+
+  useLayoutEffect(() => {
+    const compute = () => {
+      if (!calendarRef?.current) return;
+      const totalH = calendarRef.current.clientHeight;
+      const stickyH = stickyHeaderRef?.current?.offsetHeight || 0;
+      const usable = Math.max(240, totalH - stickyH);
+      setHourHeight(Math.max(10, Math.floor(usable / 24)));
+    };
+
+    const rafId = requestAnimationFrame(() => {
+      compute();
+      const ro = new ResizeObserver(compute);
+      if (calendarRef?.current) ro.observe(calendarRef.current);
+      if (stickyHeaderRef?.current) ro.observe(stickyHeaderRef.current);
+      roRef = ro;
+    });
+
+    let roRef = null;
+    return () => {
+      cancelAnimationFrame(rafId);
+      roRef?.disconnect();
+    };
+  }, []); // refs are stable objects — no deps needed
+
+  return hourHeight;
+}


### PR DESCRIPTION
## Summary

- Replaces the week view placeholder with a fully functional 7-column timeline showing all 24 hours per column
- Task chips are compressed color blocks (title only, truncated); clicking opens a 300px popover with the full interactive `TimelineTaskCardContent` (action buttons, tags, notes intact)
- Two start-of-week modes: **Strict** (calendar week respecting first-day-of-week setting, default) and **Rolling** (today + next 6 days, gated to today only like rolling-24)
- All-day count chips in a thin strip above the timeline; clicking opens a popover listing that day's all-day tasks
- Now-line in today's column only (same red dot + line as day view)
- Today column has a subtle blue tint for visual distinction
- Week range shown in the desktop date navigator header
- Week view mode setting added to Settings under View defaults

## What changed

**New files:**
- `src/hooks/useWeekViewHourHeight.js` -- like `useDayViewHourHeight` but divides by 24; uses same ResizeObserver + rAF pattern

**`src/components/WeekView.jsx`** -- full rewrite from placeholder:
- `WeekViewColumn` renders 24 hour rows + task chips + now-line; conflict-aware side-by-side positioning within each column
- `WeekViewTaskPopover` opens on task chip click, auto-positions left/right of the chip
- Exports `WEEK_GUTTER_W = 64` so CalendarHeader's sticky header aligns with the timeline gutter

**`src/components/CalendarHeader.jsx`:**
- New `effectiveViewMode === 'week'` branch in the date headers row (gutter cell with ViewCycler + 7 day-header cells)
- Week view all-day count chips strip with click-to-popover listing via `AllDayTaskCard`

**`src/App.jsx`:**
- `weekViewMode` state (strict/rolling), persisted to localStorage
- `weekViewDates` useMemo -- 7 dates for the current week view
- `expandedRecurringTasks` range extended to cover week dates so recurring tasks appear across all 7 columns
- `weekViewMode`, `setWeekViewMode`, `weekViewDates` added to context

**`src/components/DesktopHeader.jsx`:** date navigator shows `formatDateRange(weekViewDates)` in week mode

**`src/components/SettingsModal.jsx`:** "Week view mode" buttons (Strict week / Rolling 7 days) added to View defaults section

## Out of scope (as specified)
- Drag-and-drop (final pre-main-merge PR)
- Habit rings in week view column headers (omitted -- columns too narrow to fit comfortably)
- Routines and projects on the week view timeline (separate PR)

## Test plan
- [x] Switch to week view via ViewCycler or `3` key at >=1600px -- 7 columns render
- [x] Verify today's column has a blue tint and now-line at correct position
- [ ] Click a task chip -- popover appears with full action buttons; click outside closes it; Escape closes it
- [ ] All-day count chip visible when day has all-day tasks; clicking opens popover
- [ ] Date navigator shows week range (e.g. "Apr 13 - 19, 2026")
- [ ] Arrow keys advance by 7 days; Today button jumps to current week
- [ ] Navigate to a week crossing a month boundary -- headers show correct dates
- [ ] Navigate to a week crossing a year boundary -- range shows both years
- [ ] Switch to rolling mode in Settings -- column 1 is today when viewing today; falls back to strict for other dates
- [ ] Resize viewport below 1600px -- falls back to multi; resize back -- week view returns

https://claude.ai/code/session_01Aza9Jaj7BfUg8N3YdKkNLD