### PR TITLE
Week view follow-up: header sizing, vertical centering, today-column tint in all views

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -146,11 +146,11 @@ const CalendarHeader = () => {
         return (
           <div
             key={dateStr}
-            className={`flex-1 py-1.5 px-1 text-center transition-colors ${idx > 0 ? `border-l ${borderClass}` : ''}
+            className={`flex-1 flex items-center justify-center py-1.5 px-1 text-center transition-colors ${idx > 0 ? `border-l ${borderClass}` : ''}
               ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : ''}`}
             style={{ minHeight: 'var(--header-row-h)' }}
           >
-            <div className={`text-xs font-bold flex items-center justify-center gap-1 ${isDateToday ? 'text-blue-600' : textPrimary}`}>
+            <div className={`font-bold text-sm flex items-center justify-center gap-1.5 ${isDateToday ? 'text-blue-600' : textPrimary}`}>
               <span>{['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][date.getDay()]}</span>
               <span className={`font-normal ${isDateToday ? 'text-blue-500' : textSecondary}`}>
                 {date.getMonth() + 1}/{date.getDate()}
@@ -160,14 +160,14 @@ const CalendarHeader = () => {
                 className={`p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors ${dailyNotes[dateStr]?.text ? '' : 'opacity-40'}`}
                 title="Daily notes"
               >
-                <NotebookPen size={12} />
+                <NotebookPen size={14} />
               </button>
               <button
                 onClick={(e) => { e.stopPropagation(); setFocusLogModalDate(dateStr); }}
                 className={`p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors ${focusLog[dateStr]?.totalMinutes > 0 ? '' : 'opacity-40'}`}
                 title="Focus sessions"
               >
-                <Target size={12} />
+                <Target size={14} />
               </button>
             </div>
           </div>

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -89,8 +89,10 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const showNowLine = col.dateStr === dateToString(now) && nowMinutes >= colStartMin && nowMinutes < colEndMin;
   const nowY = showNowLine ? (nowMinutes - colStartMin) * hourHeight / 60 : 0;
 
+  const isToday = col.dateStr === dateToString(new Date());
+
   return (
-    <div className={`flex-1 flex flex-col min-w-0 ${colIdx > 0 ? `border-l ${borderClass}` : ''}`}>
+    <div className={`flex-1 flex flex-col min-w-0 ${colIdx > 0 ? `border-l ${borderClass}` : ''} ${isToday ? (darkMode ? 'bg-blue-900/10' : 'bg-blue-50/40') : ''}`}>
       <div className="flex-1 relative flex flex-col">
         {/* Hour rows — each is a full-width flex row matching TimeGrid's structure */}
         {hours.map((hour, i) => (

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -100,7 +100,7 @@ const TimeGrid = () => {
           <div
             key={dateToString(date)}
             data-ctx-menu
-            className={`flex-1 relative h-40 calendar-slot ${idx > 0 ? `border-l ${borderClass}` : ''}`}
+            className={`flex-1 relative h-40 calendar-slot ${idx > 0 ? `border-l ${borderClass}` : ''} ${dateToString(date) === dateToString(new Date()) ? (darkMode ? 'bg-blue-900/10' : 'bg-blue-50/40') : ''}`}
             data-date={dateToString(date)}
             onDragOver={(e) => handleDragOver(e, date)}
             onDrop={(e) => handleDropOnCalendar(e, date)}


### PR DESCRIPTION
## Summary

Two follow-up fixes after the week view PR merged.

- **Week date header**: text was `text-xs`; bumped to `text-sm font-bold` to match day/multi view headers. Outer cell now has `flex items-center justify-center` for proper vertical centering. Icon size 12 -> 14, gap-1 -> gap-1.5.
- **Today-column blue tint in multi and day views**: the subtle `bg-blue-900/10` (dark) / `bg-blue-50/40` (light) tint introduced in week view is now applied to the today column in multi view (each per-date hour cell in `TimeGrid.jsx`) and day view (`DayViewColumn` wrapper). Consistent across all three views.

## Test plan
- [ ] Week view date headers match the size and vertical alignment of multi/day view headers
- [ ] Today's column has a subtle blue tint in multi view, day view, and week view

https://claude.ai/code/session_01Aza9Jaj7BfUg8N3YdKkNLD