### PR TITLE
Week view chips: italicize tags, truncate long titles

### DIFF
--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
+import { renderTitle } from '../utils/textFormatting.jsx';
 import TimelineTaskCardContent from './TimelineTaskCardContent.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -198,7 +199,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
               }}
             >
               <span className="block text-white text-[11px] font-medium leading-tight px-1 py-0.5 truncate">
-                {task.title}
+                {renderTitle(task.title)}
               </span>
             </div>
           );


### PR DESCRIPTION
## Summary

- **Tags italicized**: week view task chips now use `renderTitle()` (the same helper used everywhere else) so `#hashtag` tokens render italic and dimmed, consistent with day/multi views.
- **Long titles truncated**: the outer `<span>` already had `truncate` — this was already working, confirmed no change needed there.

## Test plan
- [ ] Week view chip with a `#tag` in the title shows the tag italic and dimmed
- [ ] Long task titles ellipsize within the chip rather than overflowing

https://claude.ai/code/session_01Aza9Jaj7BfUg8N3YdKkNLD