### PR TITLE
Week view chips: keep tag visible when title truncates

### DIFF
--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
-import { renderTitle } from '../utils/textFormatting.jsx';
+import { splitChipTitleTag } from '../utils/textFormatting.jsx';
 import TimelineTaskCardContent from './TimelineTaskCardContent.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -163,6 +163,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
           const isCalendarEvent = isImported && !task.isTaskCalendar;
           const taskCalStyle = getTaskCalendarStyle(task, darkMode);
           const isActive = activePopoverTaskId === task.id;
+          const [chipText, chipTag] = splitChipTitleTag(task.title);
 
           return (
             <div
@@ -198,9 +199,10 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
                 });
               }}
             >
-              <span className="block text-white text-[11px] font-medium leading-tight px-1 py-0.5 truncate">
-                {renderTitle(task.title)}
-              </span>
+              <div className="flex items-baseline gap-0.5 text-white text-[11px] font-medium leading-tight px-1 py-0.5 min-w-0 overflow-hidden">
+                <span className="truncate min-w-0">{chipText}</span>
+                {chipTag && <span className="shrink-0 italic opacity-75">{chipTag}</span>}
+              </div>
             </div>
           );
         })}

--- a/src/utils/textFormatting.jsx
+++ b/src/utils/textFormatting.jsx
@@ -204,6 +204,15 @@ export const renderTitle = (title) => {
   });
 };
 
+// Split a title into display text and trailing hashtag for week view chip rendering.
+// Returns [text, tag] where tag is null if no trailing hashtag exists.
+export const splitChipTitleTag = (title) => {
+  const stripped = title.replace(/\[\[[^\]]+\]\]/g, '').trim();
+  const match = stripped.match(/^(.*?)\s+(#\p{L}[\p{L}\p{N}_]*)$/su);
+  if (match) return [match[1], match[2]];
+  return [stripped, null];
+};
+
 export const highlightMatch = (text, query) => {
   if (!query) return text;
   const idx = text.toLowerCase().indexOf(query.toLowerCase());


### PR DESCRIPTION
## Summary

- Adds `splitChipTitleTag` to `textFormatting.jsx` -- extracts a trailing hashtag from a task title (after stripping wikilinks), returning `[text, tag]`
- Replaces the single `truncate` span in the week view chip with a flex row: title span gets `truncate min-w-0` so it yields space, tag span gets `shrink-0 italic opacity-75` so it never gets clipped
- Removes the now-unused `renderTitle` import from `WeekView.jsx`

**Before (PR #522):** `renderTitle` styled the tag correctly, but the outer `truncate` span would cut off the trailing hashtag first when the chip was narrow -- because `text-overflow: ellipsis` doesn't know to preserve the last child element.

**After:** "End-of-day review & plan tomorrow..." with "#admin" in italic/dimmed always visible; same for "#learning" etc. Title gets the ellipsis, tag stays.

## Test plan

- [ ] Purple chip "Read chapter 5 of Designing Data-Intensive Applications #learning" -- title truncates, "#learning" remains in italic/dimmed at the end
- [ ] Yellow chip "End-of-day review & plan tomorrow #admin" -- title truncates, "#admin" remains
- [ ] Tasks with no hashtag in title render normally (tag span is absent, title truncates as before)
- [ ] Day view and multi view chip rendering unchanged

https://claude.ai/code/session_01KsC9vAoza9DQF9P6eBRsAV