### PR TITLE
Week view all-day popover: pass fillWidth={false} to AllDayTaskCard

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -382,7 +382,7 @@ const CalendarHeader = () => {
     onMouseDown={(e) => e.stopPropagation()}
   >
     {weekAllDayPopover.tasks.map(task => (
-      <AllDayTaskCard key={task.id} task={task} fillWidth={true} />
+      <AllDayTaskCard key={task.id} task={task} fillWidth={false} />
     ))}
   </div>
 )}


### PR DESCRIPTION
## Summary

- One character change: `fillWidth={true}` to `fillWidth={false}` in the week all-day popover render path (`CalendarHeader.jsx` line 385)

## Why

`AllDayTaskCard` uses `fillWidth` to decide whether to consult `taskWidths` for layout. When `fillWidth={true}`, it looks up a width measurement that may have been recorded during a prior multi-view render at a narrower column size. That stale value causes the chip to think it's too narrow for action buttons and renders the `...` collapse menu instead.

Passing `fillWidth={false}` skips the `taskWidths` lookup entirely and renders the chip at its natural intrinsic width inside the popover, where action buttons always fit.

This is the same fix applied to day view in PR #498. The week view all-day popover was missed at that time.

## Test plan

- [ ] Open week view fresh. Click an all-day count chip. Popover chips show full action buttons immediately.
- [ ] Navigate multi view -> week view. Click an all-day count chip. Popover chips still show full action buttons (not `...`).
- [ ] Day view and multi view all-day rendering unchanged.

https://claude.ai/code/session_01KsC9vAoza9DQF9P6eBRsAV