### PR TITLE
Port routines to day and week views

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -327,7 +327,7 @@ const CalendarHeader = () => {
 {effectiveViewMode === 'day' && <DayViewAllDaySection />}
 
 {/* Week view all-day count chips */}
-{effectiveViewMode === 'week' && weekViewDates.some(d => getTasksForDate(d).some(t => t.isAllDay)) && (
+{effectiveViewMode === 'week' && (weekViewDates.some(d => getTasksForDate(d).some(t => t.isAllDay)) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (
   <div className={`flex border-b ${borderClass} ${cardBg}`}>
     <div
       className={`flex-shrink-0 border-r ${borderClass} flex items-center justify-center`}
@@ -342,7 +342,7 @@ const CalendarHeader = () => {
       return (
         <div
           key={dateStr}
-          className={`flex-1 flex items-center justify-center py-1 min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}
+          className={`flex-1 flex flex-wrap items-center justify-center gap-1 py-1 min-w-0 overflow-hidden ${idx > 0 ? `border-l ${borderClass}` : ''}
             ${isDateToday ? (darkMode ? 'bg-blue-900/10' : 'bg-blue-50/40') : ''}`}
         >
           {allDayTasks.length > 0 && (
@@ -363,6 +363,14 @@ const CalendarHeader = () => {
               {allDayTasks.length} all day
             </button>
           )}
+          {routinesEnabled && isDateToday && todayRoutines.filter(r => r.isAllDay).map(routine => (
+            <div
+              key={`routine-${routine.id}`}
+              className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${routineCompletions[routine.id] ? 'line-through opacity-75' : ''}`}
+            >
+              {routine.name}
+            </div>
+          ))}
         </div>
       );
     })}

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -58,6 +58,7 @@ function columnConflictPos(task, colTasks, timeToMinutes) {
 
 const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const {
+    isTablet,
     darkMode, use24HourClock,
     borderClass, textSecondary,
     expandedNotesTaskId,
@@ -66,9 +67,10 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     getTasksForDate,
     getTaskCalendarStyle,
     timeToMinutes,
+    handleRoutineResizeStart, handleTouchRoutineResizeStart,
   } = useDayPlannerCtx();
 
-  const { projectFilter } = useFeaturesCtx();
+  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion } = useFeaturesCtx();
 
   const allDayTasks = getTasksForDate(col.date);
   const colTasks = allDayTasks.filter(t => {
@@ -213,6 +215,90 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
               </div>
             );
           })}
+
+          {/* Timeline routine pills (today only) */}
+          {routinesEnabled && col.dateStr === dateToString(new Date()) && (() => {
+            const timedRoutines = todayRoutines.filter(r => !r.isAllDay && r.startTime);
+            if (timedRoutines.length === 0) return null;
+
+            const routineCols = [];
+            const sorted = [...timedRoutines].sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime));
+            sorted.forEach(r => {
+              const rStart = timeToMinutes(r.startTime);
+              let placed = false;
+              for (let c = 0; c < routineCols.length; c++) {
+                const last = routineCols[c][routineCols[c].length - 1];
+                if (timeToMinutes(last.startTime) + last.duration <= rStart) {
+                  routineCols[c].push(r); placed = true; break;
+                }
+              }
+              if (!placed) routineCols.push([r]);
+            });
+
+            const colMap = {};
+            routineCols.forEach((rc, ci) => rc.forEach(r => { colMap[r.id] = ci; }));
+
+            const overlapCount = {};
+            timedRoutines.forEach(r => {
+              const rStart = timeToMinutes(r.startTime);
+              const rEnd = rStart + r.duration;
+              const pts = new Set([rStart]);
+              timedRoutines.forEach(o => { const s = timeToMinutes(o.startTime); if (s > rStart && s < rEnd) pts.add(s); });
+              let max = 0;
+              pts.forEach(t => {
+                let cnt = 0;
+                timedRoutines.forEach(o => { const s = timeToMinutes(o.startTime); if (s <= t && s + o.duration > t) cnt++; });
+                max = Math.max(max, cnt);
+              });
+              overlapCount[r.id] = max;
+            });
+
+            const nowMinutes = new Date().getHours() * 60 + new Date().getMinutes();
+
+            return timedRoutines.map(routine => {
+              const slice = getTaskSlice(routine, col, hourHeight, timeToMinutes);
+              if (!slice) return null;
+              const { top, height } = slice;
+              const rci = colMap[routine.id];
+              const cols = overlapCount[routine.id];
+              const wPct = cols > 1 ? `${100 / cols}%` : '100%';
+              const lPct = cols > 1 ? `${(rci * 100) / cols}%` : '0%';
+              const isPast = timeToMinutes(routine.startTime) + routine.duration <= nowMinutes;
+
+              return (
+                <div
+                  key={`routine-tl-${routine.id}`}
+                  className={`absolute pointer-events-auto flex items-center justify-center ${isPast ? 'opacity-50' : ''}`}
+                  style={{ top: `${top}px`, height: `${Math.max(height, 27)}px`, left: `calc(${lPct} + 4px)`, width: `calc(${wPct} - 8px)` }}
+                >
+                  <div className={`absolute left-0 right-0 top-1/2 -translate-y-1/2 h-1.5 rounded-full ${darkMode ? 'bg-teal-700/80' : 'bg-teal-600/80'}`} />
+                  <div className={`absolute top-0 bottom-0 left-1/2 -translate-x-1/2 w-1.5 rounded-full ${darkMode ? 'bg-teal-700/80' : 'bg-teal-600/80'}`} />
+                  <span
+                    className={`relative rounded-full px-3 py-1 text-xs font-medium cursor-pointer ${darkMode ? 'bg-teal-700 text-teal-100' : 'bg-teal-600 text-white'} ${routineCompletions[routine.id] ? 'line-through opacity-75' : ''}`}
+                    onClick={() => toggleRoutineCompletion(routine.id)}
+                  >{routine.name}</span>
+                  {!isTablet && (
+                    <div
+                      className="absolute bottom-0 left-0 right-0 h-3 cursor-ns-resize flex justify-center items-center"
+                      onMouseDown={(e) => handleRoutineResizeStart(routine, e)}
+                      style={{ marginBottom: '-4px' }}
+                    >
+                      <div className="w-8 h-1 rounded-full bg-white" />
+                    </div>
+                  )}
+                  {isTablet && (
+                    <div
+                      onTouchStart={(e) => handleTouchRoutineResizeStart(routine, e)}
+                      className="absolute bottom-0 left-1/3 right-1/3 h-3 flex items-center justify-center select-none"
+                      style={{ marginBottom: '-4px', touchAction: 'none', WebkitTouchCallout: 'none' }}
+                    >
+                      <div className="w-12 h-1 bg-white rounded-full" />
+                    </div>
+                  )}
+                </div>
+              );
+            });
+          })()}
         </div>
       </div>
     </div>

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import AllDayTaskCard from './AllDayTaskCard.jsx';
+import { dateToString } from '../utils/taskUtils.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
@@ -153,7 +154,8 @@ const DayViewAllDaySection = () => {
     dayViewColumns,
     getTasksForDate,
   } = useDayPlannerCtx();
-  const { projectFilter } = useFeaturesCtx();
+  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion } = useFeaturesCtx();
+  const todayStr = dateToString(new Date());
 
   // Build date groups (same logic as CalendarHeader day-mode header)
   const dateGroups = [];
@@ -173,7 +175,8 @@ const DayViewAllDaySection = () => {
       .sort((a, b) => allDayOrder(a) - allDayOrder(b)),
   }));
 
-  if (!groupsWithTasks.some(g => g.tasks.length > 0)) return null;
+  const hasAllDayRoutines = routinesEnabled && todayRoutines.some(r => r.isAllDay);
+  if (!groupsWithTasks.some(g => g.tasks.length > 0) && !hasAllDayRoutines) return null;
 
   return (
     <div className={`border-b ${borderClass} ${cardBg}`} style={{ display: 'grid', gridTemplateColumns: `repeat(${dayViewColumns.length}, 1fr)` }}>
@@ -193,6 +196,15 @@ const DayViewAllDaySection = () => {
               borderClass={borderClass}
               cardBg={cardBg}
             />
+            {routinesEnabled && group.dateStr === todayStr && todayRoutines.filter(r => r.isAllDay).map(routine => (
+              <span
+                key={`routine-${routine.id}`}
+                className={`rounded-full px-3 py-1 text-xs font-medium inline-block mr-1 mb-1 cursor-pointer ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${routineCompletions[routine.id] ? 'line-through opacity-75' : ''}`}
+                onClick={() => toggleRoutineCompletion(routine.id)}
+              >
+                {routine.name}
+              </span>
+            ))}
           </div>
         </div>
       ))}

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -101,7 +101,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
     timeToMinutes,
     setTaskContextMenu,
   } = useDayPlannerCtx();
-  const { projectFilter } = useFeaturesCtx();
+  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions } = useFeaturesCtx();
 
   const colTasks = getTasksForDate(date).filter(t => {
     if (t.isAllDay || !t.startTime) return false;
@@ -203,6 +203,23 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
                 <span className="truncate min-w-0">{chipText}</span>
                 {chipTag && <span className="shrink-0 italic opacity-75">{chipTag}</span>}
               </div>
+            </div>
+          );
+        })}
+
+        {/* Routine chips — today's column only, display only */}
+        {routinesEnabled && isToday && todayRoutines.filter(r => !r.isAllDay && r.startTime).map(routine => {
+          const top = timeToMinutes(routine.startTime) * hourHeight / 60;
+          const chipH = Math.max(22, routine.duration * hourHeight / 60);
+          return (
+            <div
+              key={`routine-${routine.id}`}
+              className={`absolute pointer-events-none rounded-sm flex items-center justify-center overflow-hidden ${darkMode ? 'bg-teal-700/80' : 'bg-teal-600/80'} ${routineCompletions[routine.id] ? 'opacity-50' : ''}`}
+              style={{ top: `${top}px`, height: `${chipH}px`, left: '1px', right: '1px', zIndex: 5 }}
+            >
+              <span className={`text-white text-[11px] font-medium px-1 text-center leading-tight ${routineCompletions[routine.id] ? 'line-through' : ''}`}>
+                {routine.name}
+              </span>
             </div>
           );
         })}


### PR DESCRIPTION
## Summary

Routines were previously only visible in multi view. This adds them to day and week views.

### Day view -- timed routines (`DayView.jsx`)

Ports the cross-line + teal pill design from `TimeGrid` into `DayViewColumn`. Uses the existing `getTaskSlice` helper for hour-window-aware positioning (day view columns can cover a subset of the day), and the same overlap-column layout algorithm as TimeGrid. Supports completion toggle on click and desktop/tablet resize handles.

### Day view -- all-day routines (`DayViewAllDaySection.jsx`)

Adds teal completion-toggle pills for today's column in `DayViewAllDaySection`, rendered after the existing `GroupChips`. The section's `null` guard is updated so the row stays visible when today has all-day routines even if there are no all-day tasks.

### Week view -- timed routines (`WeekView.jsx`)

Adds display-only teal chips for today's column inside the existing task chips overlay layer. No cross-lines (columns are narrow). No click or resize handlers.

### Week view -- all-day routines (`CalendarHeader.jsx`)

The week all-day row now appears when today has all-day routines even if no all-day tasks exist. Today's column shows compact teal pills (display only) alongside the existing count chip. Cell layout changed from `flex` single-axis to `flex flex-wrap` to accommodate both elements.

## Test plan

- [ ] Day view: open on today -- timed routines appear as teal cross + pill, can click to toggle, can resize
- [ ] Day view: all-day routines appear as teal pills below any all-day task chips; click toggles completion
- [ ] Day view: all-day section visible when today has all-day routines and no all-day tasks
- [ ] Week view: today's column shows teal chips for timed routines (no cross-lines, no interaction)
- [ ] Week view: all-day row appears when today has all-day routines; routine pills visible in today's cell
- [ ] Week view: other day columns show no routines
- [ ] Multi view: unchanged

https://claude.ai/code/session_01KsC9vAoza9DQF9P6eBRsAV