### PR TITLE
Port hyperGLANCE project bars to day and week views

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -6,6 +6,8 @@ import TimelineTaskCardContent from './TimelineTaskCardContent.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import useDayViewHourHeight from '../hooks/useDayViewHourHeight.js';
+import { getHGBarsForDate } from '../hooks/useHyperGlance.js';
+import HyperGlanceBar from './HyperGlanceBar.jsx';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -70,7 +72,29 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     handleRoutineResizeStart, handleTouchRoutineResizeStart,
   } = useDayPlannerCtx();
 
-  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion } = useFeaturesCtx();
+  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion, goalsProjectsEnabled, projects } = useFeaturesCtx();
+
+  const isDateToday = col.dateStr === dateToString(new Date());
+  const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
+  const hgBars = goalsProjectsEnabled
+    ? getHGBarsForDate(projects, col.dateStr, isDateToday ? nowMin : undefined)
+    : [];
+  const hasBars = hgBars.length > 0;
+
+  const taskOverlapsHG = (task) => {
+    if (!task.startTime || !hasBars) return false;
+    const [th, tm] = (task.startTime || '0:0').split(':').map(Number);
+    const tStart = th * 60 + tm;
+    const tEnd = tStart + (task.duration || 30);
+    return hgBars.some(bar => {
+      const hg = bar.project.hyperglance;
+      const effectiveTime = hg.scheduledTimeOverrides?.[bar.date] || hg.scheduledTime || '0:0';
+      const [bh, bm] = effectiveTime.split(':').map(Number);
+      const bStart = bh * 60 + bm;
+      const effectiveDur = bar.isCompleted ? 15 : (hg.scheduledDurationOverrides?.[bar.date] || hg.scheduledDuration || 60);
+      return tStart < bStart + effectiveDur && tEnd > bStart;
+    });
+  };
 
   const allDayTasks = getTasksForDate(col.date);
   const colTasks = allDayTasks.filter(t => {
@@ -137,6 +161,37 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
 
         {/* Task pill overlay — covers the event area only (right of gutter) */}
         <div className="absolute top-0 left-16 right-0 bottom-0 pointer-events-none">
+          {/* HyperGLANCE project bars — left 50% of event area */}
+          {hasBars && (
+            <div className="absolute top-0 bottom-0 pointer-events-none" style={{ left: 0, width: '50%' }}>
+              {hgBars.map(bar => {
+                const hg = bar.project.hyperglance;
+                const effectiveTime = hg.scheduledTimeOverrides?.[bar.date] || hg.scheduledTime || '0:0';
+                const [bh, bm] = effectiveTime.split(':').map(Number);
+                const bStartMin = bh * 60 + bm;
+                const effectiveDur = bar.isCompleted ? 15 : (hg.scheduledDurationOverrides?.[bar.date] || hg.scheduledDuration || 60);
+                const bEndMin = bStartMin + effectiveDur;
+                const colStartMin = col.startHour * 60;
+                const colEndMin = col.endHour * 60;
+                if (bEndMin <= colStartMin || bStartMin >= colEndMin) return null;
+                const visStart = Math.max(bStartMin, colStartMin);
+                const visEnd = Math.min(bEndMin, colEndMin);
+                const overrideTop = (visStart - colStartMin) * hourHeight / 60;
+                const overrideFullHeight = Math.max((visEnd - visStart) * hourHeight / 60 - 1, 24);
+                const overridePillHeight = Math.max(15 * hourHeight / 60 - 1, 18);
+                return (
+                  <HyperGlanceBar
+                    key={bar.project.id}
+                    {...bar}
+                    overrideTop={overrideTop}
+                    overrideFullHeight={overrideFullHeight}
+                    overridePillHeight={overridePillHeight}
+                  />
+                );
+              })}
+            </div>
+          )}
+
           {colTasks.map(task => {
             const slice = getTaskSlice(task, col, hourHeight, timeToMinutes);
             if (!slice) return null;
@@ -173,8 +228,9 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                 style={{
                   top: `${top}px`,
                   height: `${height}px`,
-                  left,
-                  width,
+                  ...(hasBars && taskOverlapsHG(task)
+                    ? { left: '50%', right: 0, width: undefined }
+                    : { left, width }),
                   ...(isCalendarEvent || task.isTaskCalendar ? taskCalStyle : {}),
                 }}
                 onClick={() => {

--- a/src/components/HyperGlanceBar.jsx
+++ b/src/components/HyperGlanceBar.jsx
@@ -11,7 +11,7 @@ import { hexToRgba } from '../utils/colorUtils.js';
  * Renders a single hyperGLANCE project bar inside the left half of a
  * timeline day column. When the session is completed it shrinks to a small pill.
  */
-const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
+const HyperGlanceBar = ({ project, date, isCompleted, isOverdue, overrideTop, overrideFullHeight, overridePillHeight }) => {
   const { minutesToPosition, currentTime, use24HourClock, tasks, unscheduledTasks, getHourHeight, playUISound, frameResizingRef, setHoverPreviewTime, setHoverPreviewDate } = useDayPlannerCtx();
   const { enterHyperGlanceMode, setHgContextMenu, setPendingEditProjectId, updateProject } = useFeaturesCtx();
 
@@ -25,12 +25,13 @@ const HyperGlanceBar = ({ project, date, isCompleted, isOverdue }) => {
   const durationMin = hg.scheduledDurationOverrides?.[date] || hg.scheduledDuration || 60;
   const endMinutes = startMinutes + durationMin;
 
-  const top = Math.round(minutesToPosition(startMinutes));
-  const bottom = Math.round(minutesToPosition(endMinutes));
-  const fullHeight = Math.max(bottom - top - 1, 24);
+  const computedTop = Math.round(minutesToPosition(startMinutes));
+  const computedBottom = Math.round(minutesToPosition(endMinutes));
+  const top = overrideTop ?? computedTop;
+  const fullHeight = overrideFullHeight ?? Math.max(computedBottom - computedTop - 1, 24);
 
   // Completed pill: ~15 min tall at the start position
-  const pillHeight = Math.max(Math.round(minutesToPosition(startMinutes + 15) - minutesToPosition(startMinutes)) - 1, 18);
+  const pillHeight = overridePillHeight ?? Math.max(Math.round(minutesToPosition(startMinutes + 15) - minutesToPosition(startMinutes)) - 1, 18);
 
   const barColor = hg.color || '#4f46e5';
   const IconComp = Icons[hg.icon] || Icons.Sparkles;

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -1,10 +1,14 @@
 import React, { useEffect, useRef, useState } from 'react';
+import * as Icons from 'lucide-react';
+import { Zap } from 'lucide-react';
 import { dateToString } from '../utils/taskUtils.js';
 import { splitChipTitleTag } from '../utils/textFormatting.jsx';
 import TimelineTaskCardContent from './TimelineTaskCardContent.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import useWeekViewHourHeight from '../hooks/useWeekViewHourHeight.js';
+import { getHGBarsForDate, isHGSessionReachable } from '../hooks/useHyperGlance.js';
+import { hexToRgba } from '../utils/colorUtils.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -106,7 +110,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
     timeToMinutes,
     setTaskContextMenu,
   } = useDayPlannerCtx();
-  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions } = useFeaturesCtx();
+  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, goalsProjectsEnabled, projects } = useFeaturesCtx();
 
   const [overflowPopover, setOverflowPopover] = useState(null); // { routines, rect }
   const overflowPopoverRef = useRef(null);
@@ -130,6 +134,10 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
   const nowMinutes = now.getHours() * 60 + now.getMinutes();
   const nowY = isToday ? nowMinutes * hourHeight / 60 : 0;
   const altRow = darkMode ? 'bg-white/[0.04]' : 'bg-stone-100/50';
+
+  const hgBars = goalsProjectsEnabled
+    ? getHGBarsForDate(projects, dateStr, isToday ? nowMinutes : undefined)
+    : [];
 
   return (
     <div
@@ -163,6 +171,44 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
             <div className="w-2 h-2 bg-red-500 rounded-full -ml-1 flex-shrink-0" />
             <div className="flex-1 h-0.5 bg-red-500" />
           </div>
+        </div>
+      )}
+
+      {/* HyperGLANCE project strips — narrow left edge, display only */}
+      {hgBars.length > 0 && (
+        <div className="absolute top-0 bottom-0 left-0 pointer-events-none" style={{ width: 14 }}>
+          {hgBars.map(bar => {
+            const hg = bar.project.hyperglance;
+            const effectiveTime = hg.scheduledTimeOverrides?.[bar.date] || hg.scheduledTime || '0:0';
+            const [bh, bm] = effectiveTime.split(':').map(Number);
+            const startMin = bh * 60 + bm;
+            const dur = bar.isCompleted ? 15 : (hg.scheduledDurationOverrides?.[bar.date] || hg.scheduledDuration || 60);
+            const barTop = startMin * hourHeight / 60;
+            const barH = Math.max(dur * hourHeight / 60, 18);
+            const barColor = hg.color || '#4f46e5';
+            const IconComp = Icons[hg.icon] || Icons.Sparkles;
+            const canEnter = !bar.isCompleted && isHGSessionReachable({ date: bar.date, isOverdue: false }, hg, now);
+            return (
+              <div
+                key={bar.project.id}
+                className="absolute overflow-hidden flex flex-col items-center pt-0.5 gap-0.5"
+                style={{
+                  top: `${barTop}px`,
+                  height: `${barH}px`,
+                  left: 1,
+                  right: 1,
+                  backgroundColor: hexToRgba(barColor, 0.09),
+                  borderLeft: `3px solid ${barColor}`,
+                  borderRadius: 3,
+                }}
+              >
+                <IconComp size={9} style={{ color: barColor, flexShrink: 0 }} />
+                {canEnter && barH > 24 && (
+                  <Zap size={8} style={{ color: barColor }} className="animate-pulse flex-shrink-0" />
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- **Day view**: Full parity with multi/TimeGrid. Bars occupy the left 50% of the event area; tasks shift right when their time range overlaps a bar. `HyperGlanceBar` gains optional `overrideTop` / `overrideFullHeight` / `overridePillHeight` props so DayView can supply positions derived from its own `hourHeight` and partial-day column offset (`col.startHour * 60`), bypassing the context's `minutesToPosition` which is calibrated for the full-day TimeGrid.
- **Week view**: Narrow 14px strip on the left edge of each day column showing the project icon and a pulsing Zap when the session is reachable today. Display-only (no click/resize). Bars do not push tasks right, keeping the compressed chip layout intact.

## Test plan

- [ ] Day view: create a project with an HG session scheduled for today — confirm bar appears in the left half of the column, tasks in the same time slot shift to the right half
- [ ] Day view: resize bar top/bottom handles — confirm position updates correctly
- [ ] Day view: completed session renders as a strikethrough pill at the scheduled start
- [ ] Day view: split column config (AM/PM) — bars clip correctly at the column boundary
- [ ] Week view: HG strip appears on the correct day column at the correct time position
- [ ] Week view: Zap icon pulses only when the session is reachable (today, at or after start time)
- [ ] Week view: completed session renders as a narrow pill (15 min height)
- [ ] Both views: no regressions when `goalsProjectsEnabled` is false

https://claude.ai/code/session_01KsC9vAoza9DQF9P6eBRsAV