### PR TITLE
Fix week view HG strip width (14px → 25% of column)

### DIFF
--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -176,7 +176,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
 
       {/* HyperGLANCE project strips — narrow left edge, display only */}
       {hgBars.length > 0 && (
-        <div className="absolute top-0 bottom-0 left-0 pointer-events-none" style={{ width: 14 }}>
+        <div className="absolute top-0 bottom-0 left-0 pointer-events-none" style={{ width: '25%' }}>
           {hgBars.map(bar => {
             const hg = bar.project.hyperglance;
             const effectiveTime = hg.scheduledTimeOverrides?.[bar.date] || hg.scheduledTime || '0:0';
@@ -202,9 +202,9 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
                   borderRadius: 3,
                 }}
               >
-                <IconComp size={9} style={{ color: barColor, flexShrink: 0 }} />
+                <IconComp size={12} style={{ color: barColor, flexShrink: 0 }} />
                 {canEnter && barH > 24 && (
-                  <Zap size={8} style={{ color: barColor }} className="animate-pulse flex-shrink-0" />
+                  <Zap size={10} style={{ color: barColor }} className="animate-pulse flex-shrink-0" />
                 )}
               </div>
             );


### PR DESCRIPTION
## Summary

- Week view hyperGLANCE strip was 14px fixed — barely visible at typical column widths
- Changed to 25% of column width so the strip scales with the viewport
- Bumped icon sizes to match: project icon 9→12px, Zap 8→10px

## Test plan

- [ ] Week view: HG strip is clearly visible on each day that has a scheduled session
- [ ] Strip scales proportionally when the window is resized

https://claude.ai/code/session_01KsC9vAoza9DQF9P6eBRsAV