### PR TITLE
Fix three week view quick hits (HG overlap, routine alignment, notes menu)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8627,7 +8627,7 @@ const DayPlanner = () => {
 
       {/* Task Context Menu */}
       {taskContextMenu && (() => {
-        const { x, y, taskId, isRecurring, isImported, isAllDay, dateStr: ctxDateStr } = taskContextMenu;
+        const { x, y, taskId, isRecurring, isImported, isAllDay, dateStr: ctxDateStr, supportsInlineNotes } = taskContextMenu;
         const ctxDate = new Date(ctxDateStr + 'T12:00:00');
         const scheduledMatch = getTasksForDate(ctxDate).find(t => t.id === taskId);
         const inboxMatch = !scheduledMatch && unscheduledTasks.find(t => t.id === taskId);
@@ -8691,7 +8691,11 @@ const DayPlanner = () => {
                 <button
                   className={`w-full text-left px-3 py-2 text-sm ${textPrimary} ${hoverBg} transition-colors flex items-center gap-2`}
                   onClick={() => {
-                    setExpandedNotesTaskId(prev => prev === taskId ? null : taskId);
+                    if (supportsInlineNotes === false) {
+                      if (ctxTask) openMobileEditTask(ctxTask, isInbox);
+                    } else {
+                      setExpandedNotesTaskId(prev => prev === taskId ? null : taskId);
+                    }
                     setTaskContextMenu(null);
                   }}
                 >

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -138,6 +138,22 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
   const hgBars = goalsProjectsEnabled
     ? getHGBarsForDate(projects, dateStr, isToday ? nowMinutes : undefined)
     : [];
+  const hasBars = hgBars.length > 0;
+
+  const taskOverlapsHG = (task) => {
+    if (!task.startTime || !hasBars) return false;
+    const [th, tm] = (task.startTime || '0:0').split(':').map(Number);
+    const tStart = th * 60 + tm;
+    const tEnd = tStart + (task.duration || 30);
+    return hgBars.some(bar => {
+      const hg = bar.project.hyperglance;
+      const effectiveTime = hg.scheduledTimeOverrides?.[bar.date] || hg.scheduledTime || '0:0';
+      const [bh, bm] = effectiveTime.split(':').map(Number);
+      const bStart = bh * 60 + bm;
+      const effectiveDur = bar.isCompleted ? 15 : (hg.scheduledDurationOverrides?.[bar.date] || hg.scheduledDuration || 60);
+      return tStart < bStart + effectiveDur && tEnd > bStart;
+    });
+  };
 
   return (
     <div
@@ -241,9 +257,9 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
               style={{
                 top: `${chipTop}px`,
                 height: `${chipH}px`,
-                left,
-                right: width ? undefined : right,
-                width,
+                ...(hasBars && taskOverlapsHG(task)
+                  ? { left: '25%', right: '1px', width: undefined }
+                  : { left, right: width ? undefined : right, width }),
                 ...(isCalendarEvent || task.isTaskCalendar ? taskCalStyle : {}),
               }}
               onClick={(e) => {
@@ -259,6 +275,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
                   isImported: !!isImported,
                   isAllDay: false,
                   dateStr,
+                  supportsInlineNotes: false,
                 });
               }}
             >
@@ -333,7 +350,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
             });
             items.push(
               <div key={`routine-${r.id}`}
-                className="absolute pointer-events-none flex items-center justify-center"
+                className="absolute pointer-events-none flex items-start pt-0.5"
                 style={{
                   top: `${top}px`, height: `${h}px`, zIndex: 5,
                   left: hasOverlap && col === 1 ? 'calc(50% + 1px)' : '1px',


### PR DESCRIPTION
## Summary

Three small fixes to the week view following the HG bars port:

- **Task-HG overlap**: `WeekViewColumn` now has the same `taskOverlapsHG` logic as day/multi views. Tasks whose time range overlaps a project bar shift to `left: '25%'` (matching the strip width) so bar and chip are side-by-side.

- **Routine pill alignment**: Changed outer container from `items-center justify-center` to `items-start pt-0.5`. The pill now top-aligns with the routine's actual start time instead of centering in an oversized min-height container, which was making 15-min routines appear visually anchored at the bottom of their slot.

- **Notes/subtasks context menu**: Week view chips have no inline notes panel, so the old handler (`setExpandedNotesTaskId`) was a no-op. Passing `supportsInlineNotes: false` in the `setTaskContextMenu` call; the App.jsx handler now falls back to `openMobileEditTask` so the full edit modal opens instead.

## Test plan

- [ ] Week view: task in same time slot as HG bar shifts right of the strip
- [ ] Week view: 15-min routine pill appears at the top of its scheduled position, not anchored at the bottom
- [ ] Week view: right-click → Notes/subtasks opens edit modal with notes section
- [ ] TimeGrid/day view: Notes/subtasks still expands inline (no regression — `supportsInlineNotes` is only set by WeekView)

https://claude.ai/code/session_01KsC9vAoza9DQF9P6eBRsAV