### PR TITLE
Trim week view dead space — render only up to last scheduled hour

### DIFF
--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -103,7 +103,7 @@ const fmtDur = (min) => {
   return min < 60 ? `${min}m` : m ? `${h}h${m}m` : `${h}h`;
 };
 
-const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, activePopoverTaskId, isToday }) => {
+const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, endHour, onTaskClick, activePopoverTaskId, isToday }) => {
   const {
     darkMode, borderClass, cardBg,
     getTasksForDate, getTaskCalendarStyle,
@@ -161,11 +161,11 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
       className={`flex-1 flex flex-col min-w-0 relative ${colIdx > 0 ? `border-l ${borderClass}` : ''} ${isToday ? (darkMode ? 'bg-blue-900/10' : 'bg-blue-50/40') : ''}`}
     >
       {/* Hour rows */}
-      {Array.from({ length: 24 }, (_, hour) => (
+      {Array.from({ length: endHour }, (_, hour) => (
         <div
           key={hour}
-          className={`relative${hour === 23 ? ' flex-1' : ''}`}
-          style={hour === 23 ? { minHeight: `${hourHeight}px` } : { height: `${hourHeight}px` }}
+          className={`relative${hour === endHour - 1 ? ' flex-1' : ''}`}
+          style={hour === endHour - 1 ? { minHeight: `${hourHeight}px` } : { height: `${hourHeight}px` }}
         >
           <div className={`border-b h-full ${borderClass} ${hour % 2 === 1 ? altRow : ''}`} />
           <div
@@ -419,9 +419,29 @@ const WeekView = () => {
     darkMode, borderClass, textSecondary,
     use24HourClock,
     cardBg,
+    getTasksForDate, timeToMinutes,
   } = useDayPlannerCtx();
+  const { projectFilter, routinesEnabled, todayRoutines } = useFeaturesCtx();
 
-  const hourHeight = useWeekViewHourHeight(calendarRef, stickyHeaderRef);
+  // Trim rendered hours to the latest scheduled content + 1 buffer, min 21 (9 PM)
+  const endHour = (() => {
+    let maxMin = 21 * 60;
+    weekViewDates.forEach(date => {
+      getTasksForDate(date).forEach(t => {
+        if (t.isAllDay || !t.startTime) return;
+        if (projectFilter && t.projectId !== projectFilter) return;
+        maxMin = Math.max(maxMin, timeToMinutes(t.startTime) + (t.duration || 0));
+      });
+    });
+    if (routinesEnabled) {
+      todayRoutines.filter(r => r.startTime && !r.isAllDay).forEach(r => {
+        maxMin = Math.max(maxMin, timeToMinutes(r.startTime) + r.duration);
+      });
+    }
+    return Math.min(24, Math.ceil(maxMin / 60));
+  })();
+
+  const hourHeight = useWeekViewHourHeight(calendarRef, stickyHeaderRef, endHour);
   const [popoverTask, setPopoverTask] = useState(null);
   const [popoverAnchor, setPopoverAnchor] = useState(null);
 
@@ -449,11 +469,11 @@ const WeekView = () => {
         className={`flex-shrink-0 border-r ${borderClass} flex flex-col`}
         style={{ width: WEEK_GUTTER_W }}
       >
-        {Array.from({ length: 24 }, (_, hour) => (
+        {Array.from({ length: endHour }, (_, hour) => (
           <div
             key={hour}
-            className={`relative flex-shrink-0${hour === 23 ? ' flex-1' : ''}`}
-            style={hour === 23 ? { minHeight: `${hourHeight}px` } : { height: `${hourHeight}px` }}
+            className={`relative flex-shrink-0${hour === endHour - 1 ? ' flex-1' : ''}`}
+            style={hour === endHour - 1 ? { minHeight: `${hourHeight}px` } : { height: `${hourHeight}px` }}
           >
             {hour % 3 === 0 && (
               <span
@@ -479,6 +499,7 @@ const WeekView = () => {
             dateStr={dateStr}
             colIdx={colIdx}
             hourHeight={hourHeight}
+            endHour={endHour}
             onTaskClick={handleTaskClick}
             activePopoverTaskId={popoverTask?.id}
             isToday={dateStr === todayStr}

--- a/src/hooks/useWeekViewHourHeight.js
+++ b/src/hooks/useWeekViewHourHeight.js
@@ -1,6 +1,6 @@
 import { useState, useLayoutEffect } from 'react';
 
-export default function useWeekViewHourHeight(calendarRef, stickyHeaderRef) {
+export default function useWeekViewHourHeight(calendarRef, stickyHeaderRef, endHour = 24) {
   const [hourHeight, setHourHeight] = useState(33);
 
   useLayoutEffect(() => {
@@ -9,7 +9,7 @@ export default function useWeekViewHourHeight(calendarRef, stickyHeaderRef) {
       const totalH = calendarRef.current.clientHeight;
       const stickyH = stickyHeaderRef?.current?.offsetHeight || 0;
       const usable = Math.max(240, totalH - stickyH);
-      setHourHeight(Math.max(10, Math.floor(usable / 24)));
+      setHourHeight(Math.max(10, Math.floor(usable / endHour)));
     };
 
     const rafId = requestAnimationFrame(() => {
@@ -25,7 +25,7 @@ export default function useWeekViewHourHeight(calendarRef, stickyHeaderRef) {
       cancelAnimationFrame(rafId);
       roRef?.disconnect();
     };
-  }, []); // refs are stable objects — no deps needed
+  }, [endHour]); // re-compute when visible hour range changes
 
   return hourHeight;
 }


### PR DESCRIPTION
## Summary

The week view always rendered all 24 hours, and the last row used `flex-1` to absorb layout rounding — making it disproportionately tall and leaving a large empty region whenever nothing was scheduled in the final hours.

**Fix:** `WeekView` now computes `endHour = min(24, ceil(latestEndMinute / 60))`, minimum 21 (9 PM), by scanning tasks across all visible dates and today's routines. Only `endHour` rows are rendered. `useWeekViewHourHeight` divides by `endHour` instead of `24` so each row is proportionally taller.

Example with the screenshot data (latest item: Meal prep at 22:45 + 15m = ends 23:00): `endHour = 23` — the empty 23:00 hour row is gone and `hourHeight` grows from `⌊H/24⌋` to `⌊H/23⌋`.

Empty weeks (no tasks) still show a minimum of 21 hours (through 9 PM).

## Test plan

- [ ] Week with items ending at 22:45 — bottom of view ends at ~23:00 line, no empty row below
- [ ] Week with items ending at 21:30 — shows through 22:00, not 24:00
- [ ] Empty week — shows through 21:00 (9 PM minimum)
- [ ] Week with a midnight task (23:xx) — shows full 24 hours
- [ ] Resize window — hourHeight recomputes proportionally

https://claude.ai/code/session_01KsC9vAoza9DQF9P6eBRsAV