### PR TITLE
Fix week view dead space: distribute extra pixels evenly across all 24 hour rows

### DIFF
--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -164,8 +164,8 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
       {Array.from({ length: 24 }, (_, hour) => (
         <div
           key={hour}
-          className={`relative${hour === 23 ? ' flex-1' : ''}`}
-          style={hour === 23 ? { minHeight: `${hourHeight}px` } : { height: `${hourHeight}px` }}
+          className="relative"
+          style={{ height: `${hourHeight}px` }}
         >
           <div className={`border-b h-full ${borderClass} ${hour % 2 === 1 ? altRow : ''}`} />
           <div
@@ -455,8 +455,8 @@ const WeekView = () => {
         {Array.from({ length: 24 }, (_, hour) => (
           <div
             key={hour}
-            className={`relative flex-shrink-0${hour === 23 ? ' flex-1' : ''}`}
-            style={hour === 23 ? { minHeight: `${hourHeight}px` } : { height: `${hourHeight}px` }}
+            className="relative flex-shrink-0"
+            style={{ height: `${hourHeight}px` }}
           >
             {hour % 3 === 0 && (
               <span

--- a/src/hooks/useWeekViewHourHeight.js
+++ b/src/hooks/useWeekViewHourHeight.js
@@ -9,7 +9,7 @@ export default function useWeekViewHourHeight(calendarRef, stickyHeaderRef) {
       const totalH = calendarRef.current.clientHeight;
       const stickyH = stickyHeaderRef?.current?.offsetHeight || 0;
       const usable = Math.max(240, totalH - stickyH);
-      setHourHeight(Math.max(10, Math.floor(usable / 24)));
+      setHourHeight(Math.max(10, usable / 24));
     };
 
     const rafId = requestAnimationFrame(() => {


### PR DESCRIPTION
## Summary

- Remove `Math.floor` from `useWeekViewHourHeight` so `hourHeight` is fractional — `24 × hourHeight` equals the usable height exactly, leaving no remainder
- Remove the `flex-1` / `minHeight` special-casing on hour 23 in `WeekView.jsx` (both the gutter and column loops), since there are no extra pixels for the last row to absorb

## Why

With `Math.floor`, up to 23px went unaccounted for and was silently swallowed by `flex-1` on the last row, making the 23:00 slot disproportionately tall — especially noticeable when a task was scheduled there. Fractional pixel heights are rendered correctly by CSS and fully eliminate the dead space.

## Test plan

- [ ] Open week view — all 24 hour rows should appear visually equal height with no oversized last row
- [ ] Resize the window; rows should remain equal as the height recomputes
- [ ] Tasks and routine chips should still align to their correct hour positions