### PR TITLE
Fix day view dead space: distribute extra pixels evenly across all 8 hour rows

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -122,8 +122,8 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
         {hours.map((hour, i) => (
           <div
             key={hour}
-            className={`relative${i === hours.length - 1 ? ' flex-1' : ''}`}
-            style={i === hours.length - 1 ? { minHeight: `${hourHeight}px` } : { height: `${hourHeight}px` }}
+            className="relative"
+            style={{ height: `${hourHeight}px` }}
           >
             <div className={`flex border-b h-full ${borderClass} ${i % 2 === 1 ? altRow : ''}`}>
               <div

--- a/src/hooks/useDayViewHourHeight.js
+++ b/src/hooks/useDayViewHourHeight.js
@@ -13,7 +13,7 @@ export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
       const totalH = calendarRef.current.clientHeight;
       const stickyH = stickyHeaderRef?.current?.offsetHeight || 0;
       const usable = Math.max(160, totalH - stickyH);
-      setHourHeight(Math.max(20, Math.floor(usable / 8)));
+      setHourHeight(Math.max(20, usable / 8));
     };
 
     // Defer first measurement by one frame so the sticky header ref is populated.


### PR DESCRIPTION
## Summary

Same fix as #535 (week view), applied to day view:

- Remove `Math.floor` from `useDayViewHourHeight` so `hourHeight` is fractional — `8 × hourHeight` equals usable height exactly
- Remove `flex-1` / `minHeight` special-casing on the last hour row in `DayView.jsx`

## Why

`Math.floor(usable / 8)` leaves up to 7px unaccounted for, all absorbed by `flex-1` on the last row. With fractional `hourHeight`, all 8 rows are perfectly equal and no dead space accumulates at the bottom of the view.

## Test plan

- [ ] Open day view — all 8 hour rows should appear visually equal height
- [ ] Resize the window; rows remain equal as height recomputes
- [ ] Tasks, HG bars, and routine chips still align correctly to their hour positions