### PR TITLE
Port GTD Frames to Day and Week views

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -8,6 +8,7 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import useDayViewHourHeight from '../hooks/useDayViewHourHeight.js';
 import { getHGBarsForDate } from '../hooks/useHyperGlance.js';
 import HyperGlanceBar from './HyperGlanceBar.jsx';
+import { frameColorBg, frameColorBorder } from '../utils/colorUtils.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -70,9 +71,10 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     getTaskCalendarStyle,
     timeToMinutes,
     handleRoutineResizeStart, handleTouchRoutineResizeStart,
+    handleFrameResizeStart, frameResizingRef,
   } = useDayPlannerCtx();
 
-  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion, goalsProjectsEnabled, projects } = useFeaturesCtx();
+  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion, goalsProjectsEnabled, projects, getFrameInstancesForDate, computeAvailableSlots, setFrameContextMenu } = useFeaturesCtx();
 
   const isDateToday = col.dateStr === dateToString(new Date());
   const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
@@ -158,6 +160,58 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             </div>
           </div>
         )}
+
+        {/* GTD Frame background zones — behind tasks */}
+        {(() => {
+          const frameInstances = getFrameInstancesForDate(col.date);
+          if (!frameInstances.length) return null;
+          return (
+            <div className="absolute top-0 left-16 right-0 bottom-0 pointer-events-none">
+              {frameInstances.map(frame => {
+                const fStartMin = timeToMinutes(frame.start);
+                const fEndMin = timeToMinutes(frame.end);
+                if (fEndMin <= colStartMin || fStartMin >= colEndMin) return null;
+                const visStart = Math.max(fStartMin, colStartMin);
+                const visEnd = Math.min(fEndMin, colEndMin);
+                const top = (visStart - colStartMin) * hourHeight / 60;
+                const height = (visEnd - visStart) * hourHeight / 60;
+                if (height <= 0) return null;
+                const bg = frameColorBg(frame.color, darkMode);
+                const border = frameColorBorder(frame.color, darkMode);
+                const availableSlots = computeAvailableSlots(frame, col.date);
+                return (
+                  <div key={frame.frameId}>
+                    <div
+                      data-ctx-menu
+                      className="absolute left-0 right-0 rounded-sm pointer-events-auto select-none"
+                      style={{ top: `${top}px`, height: `${height}px`, background: bg, borderLeft: `3px solid ${border}` }}
+                      onContextMenu={(e) => { e.preventDefault(); setFrameContextMenu({ x: e.clientX, y: e.clientY, frameId: frame.frameId, dateStr: col.dateStr }); }}
+                    >
+                      <span className="absolute top-1 left-1.5 text-[10px] font-medium pointer-events-none select-none" style={{ color: border }}>{frame.label}</span>
+                      <div className="absolute top-0 left-0 right-0 h-2 cursor-n-resize" onMouseDown={(e) => handleFrameResizeStart(frame.frameId, col.dateStr, 'top', e)} />
+                      <div className="absolute bottom-0 left-0 right-0 h-2 cursor-s-resize" onMouseDown={(e) => handleFrameResizeStart(frame.frameId, col.dateStr, 'bottom', e)} />
+                    </div>
+                    {availableSlots.map((slot, si) => {
+                      const sStart = Math.max(timeToMinutes(slot.start), colStartMin);
+                      const sEnd = Math.min(timeToMinutes(slot.end), colEndMin);
+                      if (sEnd <= sStart) return null;
+                      const slotTop = (sStart - colStartMin) * hourHeight / 60;
+                      const slotH = (sEnd - sStart) * hourHeight / 60;
+                      if (slotH < 4) return null;
+                      return (
+                        <div
+                          key={`avail-${frame.frameId}-${si}`}
+                          className="absolute left-1 right-1 rounded pointer-events-none"
+                          style={{ top: `${slotTop}px`, height: `${slotH}px`, border: `1.5px dashed ${border}`, opacity: 0.5 }}
+                        />
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })()}
 
         {/* Task pill overlay — covers the event area only (right of gutter) */}
         <div className="absolute top-0 left-16 right-0 bottom-0 pointer-events-none">

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -8,7 +8,7 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import useWeekViewHourHeight from '../hooks/useWeekViewHourHeight.js';
 import { getHGBarsForDate, isHGSessionReachable } from '../hooks/useHyperGlance.js';
-import { hexToRgba } from '../utils/colorUtils.js';
+import { hexToRgba, frameColorBg, frameColorBorder } from '../utils/colorUtils.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -110,7 +110,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
     timeToMinutes,
     setTaskContextMenu,
   } = useDayPlannerCtx();
-  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, goalsProjectsEnabled, projects } = useFeaturesCtx();
+  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, goalsProjectsEnabled, projects, getFrameInstancesForDate, setFrameContextMenu } = useFeaturesCtx();
 
   const [overflowPopover, setOverflowPopover] = useState(null); // { routines, rect }
   const overflowPopoverRef = useRef(null);
@@ -189,6 +189,25 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
           </div>
         </div>
       )}
+
+      {/* GTD Frame background zones — behind everything */}
+      {getFrameInstancesForDate(date).map(frame => {
+        const fStartMin = timeToMinutes(frame.start);
+        const fEndMin = timeToMinutes(frame.end);
+        const top = fStartMin * hourHeight / 60;
+        const height = Math.max((fEndMin - fStartMin) * hourHeight / 60, 4);
+        const bg = frameColorBg(frame.color, darkMode);
+        const border = frameColorBorder(frame.color, darkMode);
+        return (
+          <div
+            key={frame.frameId}
+            data-ctx-menu
+            className="absolute left-0 right-0 pointer-events-auto select-none"
+            style={{ top: `${top}px`, height: `${height}px`, background: bg, borderLeft: `3px solid ${border}` }}
+            onContextMenu={(e) => { e.preventDefault(); setFrameContextMenu({ x: e.clientX, y: e.clientY, frameId: frame.frameId, dateStr }); }}
+          />
+        );
+      })}
 
       {/* HyperGLANCE project strips — narrow left edge, display only */}
       {hgBars.length > 0 && (

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -915,8 +915,7 @@ export default function useDragDrop({
     const handleMouseMove = (moveEvent) => {
       frameResizingRef.current = true;
       const deltaY = moveEvent.clientY - startY;
-      // Use approximate 80px per hour for desktop
-      const deltaMinutes = Math.round((deltaY / 80) * 60 / 15) * 15;
+      const deltaMinutes = Math.round((deltaY / getHourHeight()) * 60 / 15) * 15;
       let newStart = origStart;
       let newEnd = origEnd;
       if (edge === 'top') {

--- a/src/utils/colorUtils.js
+++ b/src/utils/colorUtils.js
@@ -43,6 +43,38 @@ export const hexToRgba = (hex, alpha) => {
   return `rgba(${r},${g},${b},${alpha})`;
 };
 
+// GTD Frame color maps — Tailwind bg class → rgba for background and border
+const _FB = {
+  light: {
+    'bg-indigo-200': 'rgba(165,180,252,0.18)', 'bg-amber-200': 'rgba(253,230,138,0.18)',
+    'bg-green-200':  'rgba(167,243,208,0.18)', 'bg-blue-200':  'rgba(191,219,254,0.18)',
+    'bg-rose-200':   'rgba(254,205,211,0.18)', 'bg-purple-200':'rgba(221,214,254,0.18)',
+    'bg-teal-200':   'rgba(153,246,228,0.18)', 'bg-orange-200':'rgba(254,215,170,0.18)',
+  },
+  dark: {
+    'bg-indigo-200': 'rgba(165,180,252,0.08)', 'bg-amber-200': 'rgba(253,230,138,0.08)',
+    'bg-green-200':  'rgba(167,243,208,0.08)', 'bg-blue-200':  'rgba(191,219,254,0.08)',
+    'bg-rose-200':   'rgba(254,205,211,0.08)', 'bg-purple-200':'rgba(221,214,254,0.08)',
+    'bg-teal-200':   'rgba(153,246,228,0.08)', 'bg-orange-200':'rgba(254,215,170,0.08)',
+  },
+};
+const _FBorder = {
+  light: {
+    'bg-indigo-200': 'rgba(79,70,229,0.75)',   'bg-amber-200': 'rgba(217,119,6,0.75)',
+    'bg-green-200':  'rgba(22,163,74,0.75)',    'bg-blue-200':  'rgba(37,99,235,0.75)',
+    'bg-rose-200':   'rgba(225,29,72,0.75)',    'bg-purple-200':'rgba(147,51,234,0.75)',
+    'bg-teal-200':   'rgba(13,148,136,0.75)',   'bg-orange-200':'rgba(234,88,12,0.75)',
+  },
+  dark: {
+    'bg-indigo-200': 'rgba(165,180,252,0.4)',   'bg-amber-200': 'rgba(253,230,138,0.4)',
+    'bg-green-200':  'rgba(167,243,208,0.4)',   'bg-blue-200':  'rgba(191,219,254,0.4)',
+    'bg-rose-200':   'rgba(254,205,211,0.4)',   'bg-purple-200':'rgba(221,214,254,0.4)',
+    'bg-teal-200':   'rgba(153,246,228,0.4)',   'bg-orange-200':'rgba(254,215,170,0.4)',
+  },
+};
+export const frameColorBg     = (color, darkMode) => (darkMode ? _FB.dark : _FB.light)[color]       || (darkMode ? 'rgba(165,180,252,0.08)' : 'rgba(165,180,252,0.18)');
+export const frameColorBorder = (color, darkMode) => (darkMode ? _FBorder.dark : _FBorder.light)[color] || (darkMode ? 'rgba(165,180,252,0.4)'  : 'rgba(79,70,229,0.75)');
+
 /** Converts a task's .color field (Tailwind class or native hex) to a hex string. */
 export const taskColorToHex = (color, nativeCalendarColor) => {
   if (nativeCalendarColor) return nativeCalendarColor;


### PR DESCRIPTION
## Summary

- **Day view**: full parity with TimeGrid — colored background zone, frame label, availability slot outlines (dashed), top/bottom resize handles, and right-click context menu (adjust time / manually schedule / skip). Frames are clipped to the visible hour range and positioned using the column's own `hourHeight` offset so nothing bleeds outside the 8-hour window.
- **Week view**: background zone + right-click only — no label, no availability slots, no resize handles. Matches the condensed column aesthetic.
- **`useDragDrop.js` bugfix**: `handleFrameResizeStart` was using a hardcoded `80px/hour`; now calls `getHourHeight()` so resize snapping is accurate in Day view (which uses a much larger `hourHeight`) and any future view.
- **`colorUtils.js`**: frame color maps extracted to `frameColorBg` / `frameColorBorder` helpers to avoid triplicating 32 entries across TimeGrid, DayView, and WeekView.

## Test plan

- [ ] Day view: frame background zone visible, label shown, resize handles drag correctly (check snap accuracy), right-click menu works (adjust / schedule / skip)
- [ ] Day view: frame is clipped when it extends outside the 8-hour window (e.g. a frame starting at 6am is partially hidden)
- [ ] Day view: availability slot dashes appear inside the frame and disappear as tasks fill the frame
- [ ] Week view: colored background appears, no label/slots/handles; right-click menu works
- [ ] TimeGrid: frame resize drag still feels correct (regression check)