### PR TITLE
Fix week view HG Zap never showing for short sessions

### DIFF
--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -238,7 +238,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
                 }}
               >
                 <IconComp size={12} style={{ color: barColor, flexShrink: 0 }} />
-                {canEnter && barH > 24 && (
+                {canEnter && (
                   <Zap size={10} style={{ color: barColor }} className="animate-pulse flex-shrink-0" />
                 )}
               </div>


### PR DESCRIPTION
## Summary

The pulsing Zap icon was gated on `canEnter && barH > 24`. `barH` is `Math.max(dur * hourHeight / 60, 18)` — so any session shorter than ~45 min at the default `hourHeight` of ~33px collapses to its 18px minimum and fails the `> 24` guard, silently suppressing the Zap entirely.

The container already has `overflow-hidden`, so removing the size guard is safe: on very short bars the Zap may be partially clipped rather than invisible. For the common case (60 min session), both the project icon and the Zap are fully visible.

## Test plan

- [ ] Schedule a project session for the current time and open week view — pulsing Zap should appear on the HG strip
- [ ] Works for sessions of varying durations (15 min, 30 min, 60 min)