### PR TITLE
Restore right-click context menus in Day and Week views

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -72,6 +72,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     timeToMinutes,
     handleRoutineResizeStart, handleTouchRoutineResizeStart,
     handleFrameResizeStart, frameResizingRef,
+    setTimelineContextMenu,
   } = useDayPlannerCtx();
 
   const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion, goalsProjectsEnabled, projects, getFrameInstancesForDate, computeAvailableSlots, setFrameContextMenu } = useFeaturesCtx();
@@ -133,7 +134,16 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
               >
                 {formatHourLabel(hour, use24HourClock)}
               </div>
-              <div className="flex-1 h-full" />
+              <div
+                className="flex-1 h-full"
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  const rect = e.currentTarget.getBoundingClientRect();
+                  const fraction = Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height));
+                  const minutes = hour * 60 + Math.round(fraction * 60 / 15) * 15;
+                  setTimelineContextMenu({ x: e.clientX, y: e.clientY, dateStr: col.dateStr, timeMinutes: minutes });
+                }}
+              />
             </div>
             {/* Half-hour dashed line — full-width flex matching TimeGrid */}
             <div

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -108,9 +108,9 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
     darkMode, borderClass, cardBg,
     getTasksForDate, getTaskCalendarStyle,
     timeToMinutes,
-    setTaskContextMenu,
+    setTaskContextMenu, setTimelineContextMenu,
   } = useDayPlannerCtx();
-  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, goalsProjectsEnabled, projects, getFrameInstancesForDate, setFrameContextMenu } = useFeaturesCtx();
+  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, goalsProjectsEnabled, projects, getFrameInstancesForDate, setFrameContextMenu, setHgContextMenu } = useFeaturesCtx();
 
   const [overflowPopover, setOverflowPopover] = useState(null); // { routines, rect }
   const overflowPopoverRef = useRef(null);
@@ -166,6 +166,13 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
           key={hour}
           className="relative"
           style={{ height: `${hourHeight}px` }}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            const rect = e.currentTarget.getBoundingClientRect();
+            const fraction = Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height));
+            const minutes = hour * 60 + Math.round(fraction * 60 / 15) * 15;
+            setTimelineContextMenu({ x: e.clientX, y: e.clientY, dateStr, timeMinutes: minutes });
+          }}
         >
           <div className={`border-b h-full ${borderClass} ${hour % 2 === 1 ? altRow : ''}`} />
           <div
@@ -226,7 +233,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
             return (
               <div
                 key={bar.project.id}
-                className="absolute overflow-hidden flex flex-col items-center pt-0.5 gap-0.5"
+                className="absolute overflow-hidden flex flex-col items-center pt-0.5 gap-0.5 pointer-events-auto"
                 style={{
                   top: `${barTop}px`,
                   height: `${barH}px`,
@@ -235,6 +242,11 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
                   backgroundColor: hexToRgba(barColor, 0.09),
                   borderLeft: `3px solid ${barColor}`,
                   borderRadius: 3,
+                }}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setHgContextMenu({ x: e.clientX, y: e.clientY, projectId: bar.project.id, date: bar.date, isCompleted: bar.isCompleted });
                 }}
               >
                 <IconComp size={12} style={{ color: barColor, flexShrink: 0 }} />


### PR DESCRIPTION
## Summary

- **Day view** — adds empty timeline right-click → "Add a Frame (HH:MM – HH:MM)" (same as Multi). Time is computed from the click's vertical fraction within the hour row plus `col.startHour` offset.
- **Week view** — adds empty timeline right-click → same Add a Frame menu. Also adds HG project bar right-click → full context menu (enter hyperGLANCE / edit / adjust time / cancel session). Bars get `pointer-events-auto` and `stopPropagation` so the right-click doesn't fall through to the hour row behind them.

Task right-click and Frame right-click were already working in both views from previous PRs.

## Test plan

- [ ] Day view: right-click on empty timeline area → "Add a Frame" menu appears at correct time
- [ ] Day view: right-click on a task card → task context menu (edit / complete / delete etc.)
- [ ] Day view: right-click on a frame → frame context menu (adjust / schedule / skip)
- [ ] Week view: right-click on empty timeline area → "Add a Frame" menu
- [ ] Week view: right-click on HG project bar → HG context menu (enter / edit / adjust / cancel)
- [ ] Week view: right-click on a task chip → task context menu
- [ ] Week view: right-click on a frame background → frame context menu