### PR TITLE
Add recurrence icon to recurring task chips in week view

### DIFF
--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -273,6 +273,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
           const isCalendarEvent = isImported && !task.isTaskCalendar;
           const taskCalStyle = getTaskCalendarStyle(task, darkMode);
           const isActive = activePopoverTaskId === task.id;
+          const isRecurring = typeof task.id === 'string' && task.id.startsWith('recurring-');
           const [chipText, chipTag] = splitChipTitleTag(task.title);
 
           return (
@@ -310,7 +311,8 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
                 });
               }}
             >
-              <div className="flex items-baseline gap-0.5 text-white text-[11px] font-medium leading-tight px-1 py-0.5 min-w-0 overflow-hidden">
+              <div className="flex items-center gap-0.5 text-white text-[11px] font-medium leading-tight px-1 py-0.5 min-w-0 overflow-hidden">
+                {isRecurring && <Icons.RefreshCw size={8} className="shrink-0 opacity-70" />}
                 <span className="truncate min-w-0">{chipText}</span>
                 {chipTag && <span className="shrink-0 italic opacity-75">{chipTag}</span>}
               </div>


### PR DESCRIPTION
## Summary

Adds an 8px `RefreshCw` icon (70% opacity) at the leading edge of any recurring task chip in week view. Uses the same `task.id.startsWith('recurring-')` check as `TimelineTaskCardContent` and the right-click menu. Icon is `shrink-0` so it never crowds out the title on narrow chips.

## Test plan

- [ ] Recurring tasks show the ↻ icon at the left of the chip label
- [ ] Non-recurring tasks are unchanged
- [ ] On very narrow chips the icon is present but the title truncates gracefully