### PR TITLE
Week view: open notes/subtasks popover from right-click menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8691,11 +8691,7 @@ const DayPlanner = () => {
                 <button
                   className={`w-full text-left px-3 py-2 text-sm ${textPrimary} ${hoverBg} transition-colors flex items-center gap-2`}
                   onClick={() => {
-                    if (supportsInlineNotes === false) {
-                      if (ctxTask) openMobileEditTask(ctxTask, isInbox);
-                    } else {
-                      setExpandedNotesTaskId(prev => prev === taskId ? null : taskId);
-                    }
+                    setExpandedNotesTaskId(prev => prev === taskId ? null : taskId);
                     setTaskContextMenu(null);
                   }}
                 >

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -453,6 +453,8 @@ const WeekView = () => {
     darkMode, borderClass, textSecondary,
     use24HourClock,
     cardBg,
+    expandedNotesTaskId, setExpandedNotesTaskId,
+    getTasksForDate,
   } = useDayPlannerCtx();
 
   const hourHeight = useWeekViewHourHeight(calendarRef, stickyHeaderRef);
@@ -461,10 +463,22 @@ const WeekView = () => {
 
   const todayStr = dateToString(new Date());
 
+  useEffect(() => {
+    if (!expandedNotesTaskId) return;
+    const chipEl = document.querySelector(`[data-task-id="${expandedNotesTaskId}"]`);
+    if (!chipEl) return;
+    const task = weekViewDates.flatMap(d => getTasksForDate(d))
+      .find(t => String(t.id) === String(expandedNotesTaskId));
+    if (!task) return;
+    setPopoverTask(task);
+    setPopoverAnchor(chipEl.getBoundingClientRect());
+  }, [expandedNotesTaskId]);
+
   const handleTaskClick = (task, anchor) => {
     if (popoverTask?.id === task.id) {
       setPopoverTask(null);
       setPopoverAnchor(null);
+      setExpandedNotesTaskId(null);
     } else {
       setPopoverTask(task);
       setPopoverAnchor(anchor);
@@ -474,6 +488,7 @@ const WeekView = () => {
   const handleClosePopover = () => {
     setPopoverTask(null);
     setPopoverAnchor(null);
+    setExpandedNotesTaskId(null);
   };
 
   return (


### PR DESCRIPTION
## Summary

- "Notes / subtasks" in the week view right-click menu now opens the existing `WeekViewTaskPopover` with the notes panel expanded, instead of opening the Edit modal
- `App.jsx`: removed the `supportsInlineNotes` branch — always calls `setExpandedNotesTaskId` to toggle the notes panel
- `WeekView.jsx`: watches `expandedNotesTaskId` via `useEffect` and auto-opens the popover for the matching chip; `handleTaskClick` and `handleClosePopover` both clear `expandedNotesTaskId` on dismiss

## Test plan

- [ ] Right-click a scheduled task in week view → "Notes / subtasks" → popover opens with notes panel visible (not edit modal)
- [ ] Notes and subtasks are editable within the popover
- [ ] Clicking the task chip directly still opens the popover normally (no notes panel forced open)
- [ ] Dismissing the popover (click outside or Escape) closes it cleanly
- [ ] "Notes / subtasks" on a task with no existing notes still opens the popover correctly

https://claude.ai/code/session_01KsC9vAoza9DQF9P6eBRsAV