### PR TITLE
Wire drag and hover interactions into day and week views

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { formatHourLabel } from '../utils/timeFormatting.jsx';
 import { dateToString } from '../utils/taskUtils.js';
+import { columnTimeFromEvent } from '../utils/dragUtils.js';
 import TimelineTaskCardContent from './TimelineTaskCardContent.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -70,10 +71,41 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     getTasksForDate,
     getTaskCalendarStyle,
     timeToMinutes,
+    formatTime,
     handleRoutineResizeStart, handleTouchRoutineResizeStart,
     handleFrameResizeStart, frameResizingRef,
     setTimelineContextMenu,
+    // Drag + hover + click-to-add
+    draggedTask, dragSource,
+    dragPreviewTime, dragPreviewDate,
+    hoverPreviewTime, hoverPreviewDate,
+    setDragPreviewTime, setDragPreviewDate,
+    setHoverPreviewTime, setHoverPreviewDate,
+    handleDragStart, handleDragEnd, handleDropOnCalendar,
+    handleResizeStart,
+    isResizing,
+    setNewTask, setShowAddTask,
   } = useDayPlannerCtx();
+
+  const colContentRef = useRef(null);
+  const colStartMin = col.startHour * 60;
+  const colEndMin = col.endHour * 60;
+
+  // Compute the snapped 15-minute drop/hover time for the current pointer
+  // event relative to this column's content area. Day-view columns span
+  // col.startHour..col.endHour; this clamps to that range so the preview
+  // can't escape the column's visible window.
+  const timeFromEvent = (e, { taskDuration = 0 } = {}) => columnTimeFromEvent(e, colContentRef.current, {
+    startMinute: colStartMin,
+    hourHeight,
+    minMinute: colStartMin,
+    maxMinute: colEndMin,
+    taskDuration,
+  });
+
+  const isDraggingOverThisCol = draggedTask && dragPreviewDate && dateToString(dragPreviewDate) === col.dateStr;
+  const isHoveringThisCol = hoverPreviewTime && !draggedTask && !isResizing
+    && hoverPreviewDate && dateToString(hoverPreviewDate) === col.dateStr;
 
   const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion, goalsProjectsEnabled, projects, getFrameInstancesForDate, computeAvailableSlots, setFrameContextMenu } = useFeaturesCtx();
 
@@ -112,15 +144,71 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const altRow = darkMode ? 'bg-white/[0.04]' : 'bg-stone-100/50';
 
   const now = new Date();
-  const colStartMin = col.startHour * 60;
-  const colEndMin = col.endHour * 60;
   const nowMinutes = now.getHours() * 60 + now.getMinutes();
   const showNowLine = col.dateStr === dateToString(now) && nowMinutes >= colStartMin && nowMinutes < colEndMin;
   const nowY = showNowLine ? (nowMinutes - colStartMin) * hourHeight / 60 : 0;
 
+  // Column-level handlers. These fire on the inner content div, so they
+  // also pick up drag events that bubble from task cards in the overlay.
+  const onColDragOver = (e) => {
+    if (!draggedTask) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    const t = timeFromEvent(e, { taskDuration: draggedTask.duration || 0 });
+    setDragPreviewTime(t);
+    setDragPreviewDate(col.date);
+  };
+
+  const onColDrop = (e) => {
+    if (!draggedTask) return;
+    const t = timeFromEvent(e, { taskDuration: draggedTask.duration || 0 });
+    handleDropOnCalendar(e, col.date, t);
+  };
+
+  // Only show hover preview when the cursor is over an empty hour-row
+  // cell (day-col-slot). Hovering over task cards, frames, or the gutter
+  // should leave the preview cleared.
+  const isOverEmptySlot = (target) => target && target.classList && target.classList.contains('day-col-slot');
+
+  const onColMouseMove = (e) => {
+    if (draggedTask || isResizing || frameResizingRef.current) {
+      if (hoverPreviewTime) { setHoverPreviewTime(null); setHoverPreviewDate(null); }
+      return;
+    }
+    if (!isOverEmptySlot(e.target)) {
+      if (hoverPreviewTime) { setHoverPreviewTime(null); setHoverPreviewDate(null); }
+      return;
+    }
+    const t = timeFromEvent(e);
+    setHoverPreviewTime(t);
+    setHoverPreviewDate(col.date);
+  };
+
+  const onColMouseLeave = () => {
+    setHoverPreviewTime(null);
+    setHoverPreviewDate(null);
+  };
+
+  const onColClick = (e) => {
+    if (frameResizingRef.current) return;
+    if (draggedTask) return;
+    if (!isOverEmptySlot(e.target)) return;
+    const t = timeFromEvent(e);
+    setNewTask({ title: '', startTime: t, duration: 30, date: col.dateStr, isAllDay: false });
+    setShowAddTask(true);
+  };
+
   return (
     <div className={`flex-1 flex flex-col min-w-0 ${colIdx > 0 ? `border-l ${borderClass}` : ''} ${showNowLine ? (darkMode ? 'bg-blue-900/10' : 'bg-blue-50/40') : ''}`}>
-      <div className="flex-1 relative flex flex-col">
+      <div
+        ref={colContentRef}
+        className="flex-1 relative flex flex-col"
+        onDragOver={onColDragOver}
+        onDrop={onColDrop}
+        onMouseMove={onColMouseMove}
+        onMouseLeave={onColMouseLeave}
+        onClick={onColClick}
+      >
         {/* Hour rows — each is a full-width flex row matching TimeGrid's structure */}
         {hours.map((hour, i) => (
           <div
@@ -135,7 +223,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                 {formatHourLabel(hour, use24HourClock)}
               </div>
               <div
-                className="flex-1 h-full"
+                className="flex-1 h-full day-col-slot cursor-pointer"
                 onContextMenu={(e) => {
                   e.preventDefault();
                   const rect = e.currentTarget.getBoundingClientRect();
@@ -276,16 +364,26 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             const radiusTop = clippedTop ? '' : 'rounded-t-lg';
             const radiusBot = clippedBottom ? '' : 'rounded-b-lg';
 
+            const taskDraggable = (!isImported || task.isTaskCalendar || !!task.nativeEventId) && !isTablet;
+            // Resize handle shows on the pill slice that contains the
+            // task's real end (not clipped by the column's right edge).
+            // When a task spans multiple columns the handle appears only
+            // on its last visible slice, at the real bottom of the task.
+            const canResize = (!isImported || !!task.nativeEventId) && !isTablet && !clippedBottom;
+
             return (
               <div
                 key={`${task.id}-${col.startHour}`}
                 data-task-id={task.id}
                 data-ctx-menu
+                draggable={taskDraggable}
+                onDragStart={taskDraggable ? (e) => handleDragStart(task, 'calendar', e) : undefined}
+                onDragEnd={taskDraggable ? handleDragEnd : undefined}
                 className={`absolute pointer-events-auto shadow-md notes-panel-container
                   ${task.isTaskCalendar ? '' : task.color}
                   ${radiusTop} ${radiusBot}
                   ${isCompleted && !isCalendarEvent ? 'opacity-50' : ''}
-                  ${isCalendarEvent ? 'cursor-default' : 'cursor-pointer'}
+                  ${isCalendarEvent ? 'cursor-default' : (taskDraggable ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer')}
                   ${expandedNotesTaskId === task.id ? 'overflow-visible z-30' : 'overflow-hidden'}
                   ${isCurrentTask ? 'current-task-pulse' : ''}
                 `}
@@ -297,7 +395,8 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                     : { left, width }),
                   ...(isCalendarEvent || task.isTaskCalendar ? taskCalStyle : {}),
                 }}
-                onClick={() => {
+                onClick={(e) => {
+                  e.stopPropagation();
                   if (!isCalendarEvent || task.isTaskCalendar || task.nativeEventId) {
                     openMobileEditTask(task, false);
                   }
@@ -330,6 +429,17 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                 {clippedBottom && (
                   <div className="absolute bottom-0 left-0 right-0 flex justify-center pointer-events-none">
                     <ChevronDown size={12} className="text-white/70" />
+                  </div>
+                )}
+                {canResize && (
+                  <div
+                    onMouseDown={(e) => handleResizeStart(task, e)}
+                    onClick={(e) => e.stopPropagation()}
+                    onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                    className="absolute bottom-0 left-1/3 right-1/3 h-3 cursor-ns-resize hover:bg-white/20 flex items-center justify-center select-none"
+                    style={{ marginBottom: '-4px' }}
+                  >
+                    <div className="w-12 h-1 bg-white rounded-full" />
                   </div>
                 )}
               </div>
@@ -388,14 +498,17 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
               return (
                 <div
                   key={`routine-tl-${routine.id}`}
-                  className={`absolute pointer-events-auto flex items-center justify-center ${isPast ? 'opacity-50' : ''}`}
+                  draggable={!isTablet}
+                  onDragStart={!isTablet ? (e) => handleDragStart({ ...routine }, 'routine', e) : undefined}
+                  onDragEnd={!isTablet ? handleDragEnd : undefined}
+                  className={`absolute pointer-events-auto flex items-center justify-center ${isPast ? 'opacity-50' : ''} ${!isTablet ? 'cursor-grab active:cursor-grabbing' : ''}`}
                   style={{ top: `${top}px`, height: `${Math.max(height, 27)}px`, left: `calc(${lPct} + 4px)`, width: `calc(${wPct} - 8px)` }}
                 >
                   <div className={`absolute left-0 right-0 top-1/2 -translate-y-1/2 h-1.5 rounded-full ${darkMode ? 'bg-teal-700/80' : 'bg-teal-600/80'}`} />
                   <div className={`absolute top-0 bottom-0 left-1/2 -translate-x-1/2 w-1.5 rounded-full ${darkMode ? 'bg-teal-700/80' : 'bg-teal-600/80'}`} />
                   <span
                     className={`relative rounded-full px-3 py-1 text-xs font-medium cursor-pointer ${darkMode ? 'bg-teal-700 text-teal-100' : 'bg-teal-600 text-white'} ${routineCompletions[routine.id] ? 'line-through opacity-75' : ''}`}
-                    onClick={() => toggleRoutineCompletion(routine.id)}
+                    onClick={(e) => { e.stopPropagation(); toggleRoutineCompletion(routine.id); }}
                   >{routine.name}</span>
                   {!isTablet && (
                     <div
@@ -420,6 +533,52 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             });
           })()}
         </div>
+
+        {/* Blue hover bar on empty slots (matches MULTI view behavior) */}
+        {isHoveringThisCol && (() => {
+          const hoverMin = timeToMinutes(hoverPreviewTime);
+          if (hoverMin < colStartMin || hoverMin > colEndMin) return null;
+          const topPx = (hoverMin - colStartMin) * hourHeight / 60;
+          return (
+            <div
+              className="absolute left-16 right-0 pointer-events-none z-30"
+              style={{ top: `${topPx}px` }}
+            >
+              <div className="absolute left-0 right-12 h-0.5 bg-blue-400/60" />
+              <div className="absolute right-1 bg-blue-500/80 text-white text-xs px-1.5 py-0.5 rounded -translate-y-1/2">
+                {formatTime(hoverPreviewTime)}
+              </div>
+            </div>
+          );
+        })()}
+
+        {/* Drag preview bar during an active drag */}
+        {isDraggingOverThisCol && dragPreviewTime && (() => {
+          const dragMin = timeToMinutes(dragPreviewTime);
+          if (dragMin < colStartMin || dragMin > colEndMin) return null;
+          const topPx = (dragMin - colStartMin) * hourHeight / 60;
+          const todayStr = dateToString(new Date());
+          const tomorrowStr = dateToString(new Date(Date.now() + 24 * 60 * 60 * 1000));
+          // Rolling-24 disambiguation: when multiple columns in this day
+          // view span different dates, label the target date so the user
+          // knows which day the drop will land on.
+          const showDateLabel = col.dateStr === todayStr ? ' (today)'
+            : col.dateStr === tomorrowStr ? ' (tomorrow)'
+            : '';
+          return (
+            <div
+              className="absolute left-16 right-0 pointer-events-none z-20"
+              style={{ top: `${topPx}px` }}
+            >
+              <div className="relative">
+                <div className={`absolute bottom-0.5 right-0 px-1.5 py-0.5 rounded text-[10px] font-bold ${darkMode ? 'bg-blue-500 text-white' : 'bg-blue-600 text-white'}`}>
+                  {formatTime(dragPreviewTime)}{showDateLabel}
+                </div>
+                <div className="h-0.5 bg-blue-500" />
+              </div>
+            </div>
+          );
+        })()}
       </div>
     </div>
   );

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -3,6 +3,7 @@ import * as Icons from 'lucide-react';
 import { Zap } from 'lucide-react';
 import { dateToString } from '../utils/taskUtils.js';
 import { splitChipTitleTag } from '../utils/textFormatting.jsx';
+import { columnTimeFromEvent } from '../utils/dragUtils.js';
 import TimelineTaskCardContent from './TimelineTaskCardContent.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -109,11 +110,48 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
     getTasksForDate, getTaskCalendarStyle,
     timeToMinutes,
     setTaskContextMenu, setTimelineContextMenu,
+    isTablet,
+    draggedTask,
+    dragPreviewTime, dragPreviewDate,
+    setDragPreviewTime, setDragPreviewDate,
+    handleDragStart, handleDragEnd, handleDropOnCalendar,
+    formatTime,
   } = useDayPlannerCtx();
   const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, goalsProjectsEnabled, projects, getFrameInstancesForDate, setFrameContextMenu, setHgContextMenu } = useFeaturesCtx();
 
   const [overflowPopover, setOverflowPopover] = useState(null); // { routines, rect }
   const overflowPopoverRef = useRef(null);
+  const colRef = useRef(null);
+
+  // Compute the snapped drop time for the cursor Y relative to this
+  // week-view column. Week columns always span 00:00..24:00, so startMinute
+  // is 0 and the max is clamped to 23:45 (minus the dragged task's length).
+  const timeFromEvent = (e, { taskDuration = 0 } = {}) => columnTimeFromEvent(e, colRef.current, {
+    startMinute: 0,
+    hourHeight,
+    minMinute: 0,
+    maxMinute: 24 * 60,
+    taskDuration,
+  });
+
+  const onColDragOver = (e) => {
+    if (!draggedTask) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    const t = timeFromEvent(e, { taskDuration: draggedTask.duration || 0 });
+    setDragPreviewTime(t);
+    setDragPreviewDate(date);
+  };
+
+  const onColDrop = (e) => {
+    if (!draggedTask) return;
+    const t = timeFromEvent(e, { taskDuration: draggedTask.duration || 0 });
+    handleDropOnCalendar(e, date, t);
+  };
+
+  const isDraggingOverThisCol = draggedTask && dragPreviewDate && dateToString(dragPreviewDate) === dateStr;
+
+  const dayName = date.toLocaleDateString('en-US', { weekday: 'short' });
 
   useEffect(() => {
     if (!overflowPopover) return;
@@ -157,7 +195,10 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
 
   return (
     <div
+      ref={colRef}
       data-week-col={dateStr}
+      onDragOver={onColDragOver}
+      onDrop={onColDrop}
       className={`flex-1 flex flex-col min-w-0 relative ${colIdx > 0 ? `border-l ${borderClass}` : ''} ${isToday ? (darkMode ? 'bg-blue-900/10' : 'bg-blue-50/40') : ''}`}
     >
       {/* Hour rows */}
@@ -275,12 +316,17 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
           const isActive = activePopoverTaskId === task.id;
           const isRecurring = typeof task.id === 'string' && task.id.startsWith('recurring-');
           const [chipText, chipTag] = splitChipTitleTag(task.title);
+          const chipDraggable = (!isImported || task.isTaskCalendar || !!task.nativeEventId) && !isTablet;
 
           return (
             <div
               key={task.id}
               data-task-id={task.id}
-              className={`absolute pointer-events-auto rounded-sm overflow-hidden cursor-pointer
+              draggable={chipDraggable}
+              onDragStart={chipDraggable ? (e) => handleDragStart(task, 'calendar', e) : undefined}
+              onDragEnd={chipDraggable ? handleDragEnd : undefined}
+              className={`absolute pointer-events-auto rounded-sm overflow-hidden
+                ${chipDraggable ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer'}
                 ${task.isTaskCalendar ? '' : task.color}
                 ${task.completed ? 'opacity-50' : ''}
                 ${isActive ? 'ring-2 ring-white/70 z-20' : 'z-10'}
@@ -416,6 +462,25 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
           return items;
         })()}
       </div>
+
+      {/* Drag preview bar — shows target day + time during an active drag */}
+      {isDraggingOverThisCol && dragPreviewTime && (() => {
+        const dragMin = timeToMinutes(dragPreviewTime);
+        const topPx = dragMin * hourHeight / 60;
+        return (
+          <div
+            className="absolute left-0 right-0 pointer-events-none z-30"
+            style={{ top: `${topPx}px` }}
+          >
+            <div className="relative">
+              <div className={`absolute bottom-0.5 right-0 px-1.5 py-0.5 rounded text-[10px] font-bold whitespace-nowrap ${darkMode ? 'bg-blue-500 text-white' : 'bg-blue-600 text-white'}`}>
+                {dayName} {formatTime(dragPreviewTime)}
+              </div>
+              <div className="h-0.5 bg-blue-500" />
+            </div>
+          </div>
+        );
+      })()}
 
       {/* Overflow routine popover */}
       {overflowPopover && (() => {

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -345,7 +345,7 @@ export default function useDragDrop({
     }
   };
 
-  const handleDropOnCalendar = (e, targetDate = null) => {
+  const handleDropOnCalendar = (e, targetDate = null, overrideTime = null) => {
     e.preventDefault();
     if (!draggedTask) return;
 
@@ -358,13 +358,13 @@ export default function useDragDrop({
         setDraggedTask(null); setDragSource(null); setDragPreviewTime(null); setDragPreviewDate(null);
         return;
       }
-      const startTime = getTimeFromCursorPosition(e, { maxMinutes: 24 * 60, taskDuration: draggedTask.duration });
+      const startTime = overrideTime || getTimeFromCursorPosition(e, { maxMinutes: 24 * 60, taskDuration: draggedTask.duration });
       setTodayRoutines(prev => prev.map(r => r.id === draggedTask.id ? { ...r, startTime, isAllDay: false, lastModified: new Date().toISOString() } : r));
       setDraggedTask(null); setDragSource(null); setDragPreviewTime(null); setDragPreviewDate(null);
       return;
     }
 
-    const requestedStartTime = getTimeFromCursorPosition(e, {
+    const requestedStartTime = overrideTime || getTimeFromCursorPosition(e, {
       maxMinutes: 24 * 60,
       taskDuration: draggedTask.duration
     });

--- a/src/utils/dragUtils.js
+++ b/src/utils/dragUtils.js
@@ -1,0 +1,42 @@
+// Shared utilities for drag / hover / click-to-add interactions in the
+// day, multi, and week views. The multi view has its own time-from-cursor
+// helper that goes through the TimeGrid DOM (because its hour rows have
+// real DOM offsets); the day and week views use these column-local
+// helpers, because their hour heights are derived from a CSS variable
+// and not from measured DOM rows.
+
+// Round a minute value to the nearest 15-minute increment.
+export const snapMinutesToQuarter = (minutes) => Math.round(minutes / 15) * 15;
+
+// Format a minute-of-day count (0..1439) as a "HH:MM" 24-hour string.
+export const minutesToTimeStr = (minutes) => {
+  const clamped = Math.max(0, Math.min(23 * 60 + 59, minutes));
+  const h = Math.floor(clamped / 60);
+  const m = clamped % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+};
+
+// Given a pointer event, the DOM element that represents a column's
+// content area, the column's starting minute (e.g. 08:00 -> 480), and the
+// column's pixel-per-hour height, return the snapped 15-minute time
+// string for the cursor's Y position within that column.
+//
+// minMinute / maxMinute clamp the result to the column's legal range so
+// you can't drop beyond the displayed hours. taskDuration shrinks the max
+// so a dragged task doesn't spill past the column's end.
+export const columnTimeFromEvent = (e, colEl, {
+  startMinute,
+  hourHeight,
+  minMinute = startMinute,
+  maxMinute,
+  taskDuration = 0,
+}) => {
+  if (!colEl || !hourHeight) return minutesToTimeStr(startMinute);
+  const rect = colEl.getBoundingClientRect();
+  const y = e.clientY - rect.top;
+  const raw = startMinute + (y / hourHeight) * 60;
+  const snapped = snapMinutesToQuarter(raw);
+  const hardMax = maxMinute - taskDuration;
+  const clamped = Math.max(minMinute, Math.min(hardMax, snapped));
+  return minutesToTimeStr(clamped);
+};


### PR DESCRIPTION
## Summary

Wires the existing `useDragDrop` infrastructure into day view and
week view. Multi view already retains drag, resize, hover bar, and
click-to-add on develop (matches main exactly), so no restoration
was needed there. Day view now has the full interaction set; week
view gets drag only, per the scope laid out in the task description.

Context: when day view and week view were built, drag was not wired
in because the multi-view cursor-to-time helper in `useDragDrop.js`
depends on `timeGridRef` (the multi-view grid DOM), which those views
don't render. This PR adds a column-local time helper in a new
`src/utils/dragUtils.js` module and lets callers pass a pre-computed
time to `handleDropOnCalendar` via a new `overrideTime` parameter, so
the day and week views can compute the drop time from the cursor Y
against the column they live in.

### What each view supports

| Interaction       | Multi | Day | Week |
| ----------------- | :---: | :-: | :--: |
| Drag a task       | yes   | yes | yes  |
| Duration resize   | yes   | yes | no   |
| Blue hover bar    | yes   | yes | no   |
| Click to add      | yes   | yes | no   |
| Cursor by element | yes   | yes | yes  |

Week view deliberately skips hover bar, click-to-add, and resize,
matching the spec. Compressed chips in week view are drag-or-click
only (native HTML5 drag handles the click-vs-drag threshold, so a
brief click still opens the task detail popover from PR #14).

### Notable details

- Rolling-24 day view labels the drag preview with `(today)` or
  `(tomorrow)` when the column's date matches, so two-date views
  make the target date unambiguous across midnight.
- Week view's drag preview shows the day short name plus the time
  (e.g. "Thu 4:15 PM") so the target column is visible at a glance.
- Resize handles only render on the pill slice that contains a
  task's real end, so a task that spans two day-view columns shows
  the handle once, at the true bottom.
- Routines on the day-view timeline are draggable to match multi.
  Week-view routines stay display-only because of the compressed
  two-column layout plus overflow indicator.
- Cursor classes (`cursor-grab` / `active:cursor-grabbing` on
  draggable chips, `cursor-ns-resize` on resize handles,
  `cursor-pointer` on empty slots and action buttons) are gated on
  element type, not on whether a drag is currently in flight.

### Commits in this PR

1. `Accept overrideTime in handleDropOnCalendar` (infra prep)
2. `Wire drag, resize, hover, and click-to-add into day view`
3. `Wire drag and cross-day drop into week view`

## Test plan

- [ ] Multi view: drag within a day, drag across days, resize, hover
      empty slot, click empty slot. Compare to main; no regression.
- [ ] Day view: drag within a column, drag across columns in rolling-24
      two-date mode (date should update), resize past a column boundary
      (should render with clipped-pill treatment), hover empty slot,
      click empty slot.
- [ ] Week view: drag within a day column, drag across day columns
      (both day and time update), verify preview shows "Thu 4:15 PM",
      click a compressed chip (popover opens, not drag), context menu
      still works.
- [ ] All views: no console errors during drag/hover/click/resize.
      Drag cancel (Escape) returns task to its original position.
      Draggable cursor shows on task cards regardless of whether a
      drag is in flight.

https://claude.ai/code/session_01TK6htw63hLKPJwHF742cua