### PR TITLE
Fix hover bar and cursor effects across DAY and MULTI views

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -67,7 +67,6 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     borderClass, textSecondary,
     expandedNotesTaskId,
     taskContextMenu, setTaskContextMenu,
-    openMobileEditTask,
     getTasksForDate,
     getTaskCalendarStyle,
     timeToMinutes,
@@ -76,7 +75,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     handleFrameResizeStart, frameResizingRef,
     setTimelineContextMenu,
     // Drag + hover + click-to-add
-    draggedTask, dragSource,
+    draggedTask,
     dragPreviewTime, dragPreviewDate,
     hoverPreviewTime, hoverPreviewDate,
     setDragPreviewTime, setDragPreviewDate,
@@ -165,10 +164,11 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     handleDropOnCalendar(e, col.date, t);
   };
 
-  // Only show hover preview when the cursor is over an empty hour-row
-  // cell (day-col-slot). Hovering over task cards, frames, or the gutter
-  // should leave the preview cleared.
-  const isOverEmptySlot = (target) => target && target.classList && target.classList.contains('day-col-slot');
+  // Show hover preview only when NOT over an explicit pointer-events-auto
+  // overlay element (task card, frame zone, routine pill, HG bar). Those
+  // elements carry the Tailwind `pointer-events-auto` class; wrapper divs
+  // and the bare day-col-slot cell do not.
+  const isOverEmptySlot = (target) => target && !target.closest('.pointer-events-auto');
 
   const onColMouseMove = (e) => {
     if (draggedTask || isResizing || frameResizingRef.current) {
@@ -394,12 +394,6 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                     ? { left: '50%', right: 0, width: undefined }
                     : { left, width }),
                   ...(isCalendarEvent || task.isTaskCalendar ? taskCalStyle : {}),
-                }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (!isCalendarEvent || task.isTaskCalendar || task.nativeEventId) {
-                    openMobileEditTask(task, false);
-                  }
                 }}
                 onContextMenu={(e) => {
                   e.preventDefault();

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -81,20 +81,6 @@ const TimeGrid = () => {
 <div
   ref={timeGridRef}
   className="relative"
-  onMouseMove={(e) => {
-    // Belt-and-suspenders fallback: catch hover events that bubble up from
-    // calendar-slot cells (including border seams that individual onMouseMove
-    // handlers miss). Defer to element-specific handlers for interactive
-    // overlay elements (task cards, routine pills, frame zones).
-    if (e.target.closest('.pointer-events-auto')) return;
-    const slotEl = e.target.closest('.calendar-slot[data-date]');
-    if (!slotEl) return;
-    const dateStr = slotEl.getAttribute('data-date');
-    const targetDate = visibleDates.find(d => dateToString(d) === dateStr);
-    if (!targetDate) return;
-    handleCalendarMouseMove(e, targetDate, true);
-  }}
-  onMouseLeave={handleCalendarMouseLeave}
   onDragLeave={(e) => {
     // Clear preview when leaving the calendar grid entirely
     if (!e.currentTarget.contains(e.relatedTarget)) {

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -81,6 +81,20 @@ const TimeGrid = () => {
 <div
   ref={timeGridRef}
   className="relative"
+  onMouseMove={(e) => {
+    // Belt-and-suspenders fallback: catch hover events that bubble up from
+    // calendar-slot cells (including border seams that individual onMouseMove
+    // handlers miss). Defer to element-specific handlers for interactive
+    // overlay elements (task cards, routine pills, frame zones).
+    if (e.target.closest('.pointer-events-auto')) return;
+    const slotEl = e.target.closest('.calendar-slot[data-date]');
+    if (!slotEl) return;
+    const dateStr = slotEl.getAttribute('data-date');
+    const targetDate = visibleDates.find(d => dateToString(d) === dateStr);
+    if (!targetDate) return;
+    handleCalendarMouseMove(e, targetDate, true);
+  }}
+  onMouseLeave={handleCalendarMouseLeave}
   onDragLeave={(e) => {
     // Clear preview when leaving the calendar grid entirely
     if (!e.currentTarget.contains(e.relatedTarget)) {
@@ -444,7 +458,7 @@ const TimeGrid = () => {
                 onDragEnd={handleDragEnd}
                 onDragOver={(e) => handleDragOver(e, date)}
                 onDrop={(e) => handleDropOnCalendar(e, date)}
-                className={`absolute notes-panel-container ${task.isTaskCalendar || isTablet ? '' : task.color} ${isTablet ? '' : 'rounded-lg shadow-md'} pointer-events-auto ${isImported && !task.isTaskCalendar || isTablet ? 'cursor-default' : 'cursor-move'} ${(task.completed && (!isImported || task.isTaskCalendar)) || isPastEvent ? 'opacity-50' : ''} ${isTablet ? '' : expandedNotesTaskId === task.id ? 'overflow-visible z-30' : ''} ${task.isExample ? 'border-2 border-dashed border-white/50' : ''} ${isCurrentTask ? 'current-task-pulse' : ''}`}
+                className={`absolute notes-panel-container ${task.isTaskCalendar || isTablet ? '' : task.color} ${isTablet ? '' : 'rounded-lg shadow-md'} pointer-events-auto ${isImported && !task.isTaskCalendar || isTablet ? 'cursor-default' : 'cursor-grab active:cursor-grabbing'} ${(task.completed && (!isImported || task.isTaskCalendar)) || isPastEvent ? 'opacity-50' : ''} ${isTablet ? '' : expandedNotesTaskId === task.id ? 'overflow-visible z-30' : ''} ${task.isExample ? 'border-2 border-dashed border-white/50' : ''} ${isCurrentTask ? 'current-task-pulse' : ''}`}
                 style={{
                   top: `${top}px`,
                   height: `${height}px`,
@@ -601,7 +615,7 @@ const TimeGrid = () => {
                   onDragEnd={!isTablet ? handleDragEnd : undefined}
                   onDragOver={(e) => handleDragOver(e, date)}
                   onDrop={(e) => handleDropOnCalendar(e, date)}
-                  className={`absolute pointer-events-auto ${isTablet ? 'cursor-default select-none' : 'cursor-move'} flex items-center justify-center ${isPast ? 'opacity-50' : ''}`}
+                  className={`absolute pointer-events-auto ${isTablet ? 'cursor-default select-none' : 'cursor-grab active:cursor-grabbing'} flex items-center justify-center ${isPast ? 'opacity-50' : ''}`}
                   style={{
                     top: `${top}px`,
                     height: `${Math.max(height, 27)}px`,


### PR DESCRIPTION
## Summary

Follow-up to PR #542. Fixes two reported regressions in the
interaction layer: hover bar not appearing, and cursor not changing
to grab on draggable elements.

- **DAY hover bar**: the `isOverEmptySlot` guard used a strict
  `classList.contains('day-col-slot')` check. When the cursor rests
  on a wrapper div or 1px hour-border seam, that element is the event
  target and the check fails, clearing the preview. Replaced with
  `!target.closest('.pointer-events-auto')` -- task cards, frame
  zones, routine pills, and HG bars all carry that Tailwind class;
  bare slot cells and wrapper divs do not.

- **MULTI hover bar**: added an outer `onMouseMove` on the
  `timeGridRef` div as a fallback. It resolves the target date from
  the nearest `.calendar-slot[data-date]` ancestor and calls
  `handleCalendarMouseMove` with `skipCalendarSlotCheck`. This catches
  hover events in border seams that the per-slot handler may miss, and
  defers to per-element handlers for any `.pointer-events-auto`
  element.

- **Cursor on MULTI**: task cards and routine pills in TimeGrid were
  using `cursor-move`. Changed to `cursor-grab active:cursor-grabbing`
  to match the cursor style in DAY and WEEK views.

- **DAY click-to-edit removed**: the `onClick -> openMobileEditTask`
  on task cards in DAY was added only for testing before action
  buttons were restored. Removed it.

## Test plan

- [ ] DAY view: hover over empty slots at various Y positions
  including at hour-boundary seams. Blue hover bar should stay
  continuous, not flicker on/off.
- [ ] DAY view: hover over a task card. Blue hover bar should
  disappear. Move off the card. Bar should reappear over the slot.
- [ ] DAY view: clicking a task card no longer opens the edit modal.
  Right-click still shows context menu.
- [ ] MULTI view: hover over empty slots. Blue hover bar appears and
  follows the cursor.
- [ ] MULTI view: hover over a task card. Cursor shows grab hand.
  Moving off the card shows the grab cursor on the empty slot area.
- [ ] WEEK view: drag a chip. Cursor shows grab hand on chips.

https://claude.ai/code/session_01TK6htw63hLKPJwHF742cua