### PR TITLE
Fix click-to-edit and hover stuck state in DAY view

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -416,7 +416,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                   <TimelineTaskCardContent
                     task={task}
                     height={height}
-                    isNarrowWidth={false}
+                    isNarrowWidth={true}
                     flipNotesPanel={(8 * hourHeight) - (top + height) < 200}
                   />
                 )}

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
 import { TASK_COLORS } from '../utils/colorUtils.js';
 import { nativeUpdateEvent } from '../native.js';
@@ -252,6 +252,40 @@ export default function useDragDrop({
       autoScrollInterval.current = null;
     }
   };
+
+  // Safeguard: clear drag state on any dragend event at the document level.
+  // The onDragEnd prop only fires on the source element — if it unmounts before
+  // dragend (e.g. a cross-column drop changes the element key), React never
+  // calls the handler and draggedTask stays stuck, blocking hover preview.
+  useEffect(() => {
+    const onDocDragEnd = () => {
+      setDraggedTask(null);
+      setDragSource(null);
+      setDragPreviewTime(null);
+      setDragPreviewDate(null);
+      setDragOverAllDay(null);
+      setDragOverInbox(false);
+      setDragOverRecycleBin(false);
+      if (autoScrollInterval.current) {
+        clearInterval(autoScrollInterval.current);
+        autoScrollInterval.current = null;
+      }
+    };
+    document.addEventListener('dragend', onDocDragEnd);
+    return () => document.removeEventListener('dragend', onDocDragEnd);
+  }, []);
+
+  // On window blur (alt-tab, focus loss), clear resize stuck states. The per-operation
+  // document mouseup listeners won't fire if the mouse button was released outside the
+  // browser window, leaving isResizing or frameResizingRef stuck and blocking hover.
+  useEffect(() => {
+    const onBlur = () => {
+      setIsResizing(false);
+      frameResizingRef.current = false;
+    };
+    window.addEventListener('blur', onBlur);
+    return () => window.removeEventListener('blur', onBlur);
+  }, []);
 
   const updateDragAutoScroll = (e) => {
     if (!calendarRef.current) return;


### PR DESCRIPTION
## Summary

- **DAY view click-to-edit**: `TimelineTaskCardContent` was rendering in wide layout (`isNarrowWidth=false`), placing the Pencil/Edit action button inline next to the title text. The first click intended for the title was landing on the Pencil button and opening the edit modal, preventing the double-click for inline editing from registering. Fixed by switching to `isNarrowWidth={true}`, which moves action buttons into the "..." overflow menu and gives the title a clear click area.

- **Hover preview stuck state**: Two stuck-state scenarios blocked the blue hover bar after interactions:
  1. `draggedTask` non-null after an incomplete drag cycle — the `onDragEnd` prop only fires on the source element, but when a cross-column drop changes the element's React key, the element unmounts before `dragend` fires and `draggedTask` stays stuck. Fixed by adding a document-level `dragend` listener in `useDragDrop` that always clears drag state.
  2. `isResizing` / `frameResizingRef` stuck true — the per-operation `document.mouseup` listeners don't fire if the user releases the mouse outside the browser window. Fixed by adding a `window.blur` listener that clears both values, replacing the manual ALT-TAB workaround the user was using.

## Test plan

- [ ] In DAY view, single-click a task title — should NOT open edit modal
- [ ] In DAY view, double-click a task title — should open inline title editor
- [ ] Click the "..." menu on a task card — should show action buttons including Edit
- [ ] Hover over an empty calendar slot — blue hover bar and time label should appear
- [ ] Drag a task, drop it, then move cursor over empty slot — hover should restore immediately (no ALT-TAB needed)
- [ ] Drag a task to a different time column (rolling-24 mode), drop — hover should restore
- [ ] Start resizing a task, release mouse — hover should restore; releasing outside window should also clear stuck state

https://claude.ai/code/session_01TK6htw63hLKPJwHF742cua