### PR TITLE
Revert DAY view regressions from #544; add hover diagnostic logging

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -67,6 +67,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     borderClass, textSecondary,
     expandedNotesTaskId,
     taskContextMenu, setTaskContextMenu,
+    openMobileEditTask,
     getTasksForDate,
     getTaskCalendarStyle,
     timeToMinutes,
@@ -75,7 +76,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     handleFrameResizeStart, frameResizingRef,
     setTimelineContextMenu,
     // Drag + hover + click-to-add
-    draggedTask,
+    draggedTask, dragSource,
     dragPreviewTime, dragPreviewDate,
     hoverPreviewTime, hoverPreviewDate,
     setDragPreviewTime, setDragPreviewDate,
@@ -164,14 +165,14 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     handleDropOnCalendar(e, col.date, t);
   };
 
-  // Show hover preview only when NOT over an explicit pointer-events-auto
-  // overlay element (task card, frame zone, routine pill, HG bar). Those
-  // elements carry the Tailwind `pointer-events-auto` class; wrapper divs
-  // and the bare day-col-slot cell do not.
-  const isOverEmptySlot = (target) => target && !target.closest('.pointer-events-auto');
+  // Only show hover preview when the cursor is over an empty hour-row
+  // cell (day-col-slot). Hovering over task cards, frames, or the gutter
+  // should leave the preview cleared.
+  const isOverEmptySlot = (target) => target && target.classList && target.classList.contains('day-col-slot');
 
   const onColMouseMove = (e) => {
     if (draggedTask || isResizing || frameResizingRef.current) {
+      console.log('[DAY hover blocked]', { draggedTask: !!draggedTask, draggedTaskId: draggedTask?.id, isResizing, frameResizing: frameResizingRef.current, target: e.target?.className });
       if (hoverPreviewTime) { setHoverPreviewTime(null); setHoverPreviewDate(null); }
       return;
     }
@@ -395,6 +396,13 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                     : { left, width }),
                   ...(isCalendarEvent || task.isTaskCalendar ? taskCalStyle : {}),
                 }}
+                onClick={(e) => {
+                  console.log('[DAY card click]', { taskId: task.id, target: e.target?.className, isCalendarEvent });
+                  e.stopPropagation();
+                  if (!isCalendarEvent || task.isTaskCalendar || task.nativeEventId) {
+                    openMobileEditTask(task, false);
+                  }
+                }}
                 onContextMenu={(e) => {
                   e.preventDefault();
                   setTaskContextMenu({
@@ -416,7 +424,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                   <TimelineTaskCardContent
                     task={task}
                     height={height}
-                    isNarrowWidth={true}
+                    isNarrowWidth={false}
                     flipNotesPanel={(8 * hourHeight) - (top + height) < 200}
                   />
                 )}

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -444,7 +444,7 @@ const TimeGrid = () => {
                 onDragEnd={handleDragEnd}
                 onDragOver={(e) => handleDragOver(e, date)}
                 onDrop={(e) => handleDropOnCalendar(e, date)}
-                className={`absolute notes-panel-container ${task.isTaskCalendar || isTablet ? '' : task.color} ${isTablet ? '' : 'rounded-lg shadow-md'} pointer-events-auto ${isImported && !task.isTaskCalendar || isTablet ? 'cursor-default' : 'cursor-grab active:cursor-grabbing'} ${(task.completed && (!isImported || task.isTaskCalendar)) || isPastEvent ? 'opacity-50' : ''} ${isTablet ? '' : expandedNotesTaskId === task.id ? 'overflow-visible z-30' : ''} ${task.isExample ? 'border-2 border-dashed border-white/50' : ''} ${isCurrentTask ? 'current-task-pulse' : ''}`}
+                className={`absolute notes-panel-container ${task.isTaskCalendar || isTablet ? '' : task.color} ${isTablet ? '' : 'rounded-lg shadow-md'} pointer-events-auto ${isImported && !task.isTaskCalendar || isTablet ? 'cursor-default' : 'cursor-move'} ${(task.completed && (!isImported || task.isTaskCalendar)) || isPastEvent ? 'opacity-50' : ''} ${isTablet ? '' : expandedNotesTaskId === task.id ? 'overflow-visible z-30' : ''} ${task.isExample ? 'border-2 border-dashed border-white/50' : ''} ${isCurrentTask ? 'current-task-pulse' : ''}`}
                 style={{
                   top: `${top}px`,
                   height: `${height}px`,
@@ -601,7 +601,7 @@ const TimeGrid = () => {
                   onDragEnd={!isTablet ? handleDragEnd : undefined}
                   onDragOver={(e) => handleDragOver(e, date)}
                   onDrop={(e) => handleDropOnCalendar(e, date)}
-                  className={`absolute pointer-events-auto ${isTablet ? 'cursor-default select-none' : 'cursor-grab active:cursor-grabbing'} flex items-center justify-center ${isPast ? 'opacity-50' : ''}`}
+                  className={`absolute pointer-events-auto ${isTablet ? 'cursor-default select-none' : 'cursor-move'} flex items-center justify-center ${isPast ? 'opacity-50' : ''}`}
                   style={{
                     top: `${top}px`,
                     height: `${Math.max(height, 27)}px`,


### PR DESCRIPTION
## What this does

PR #544 introduced two regressions in `DayView.jsx`:
- `isNarrowWidth={true}` changed task card text color in light mode (narrow layout uses different color assumptions)
- `isOverEmptySlot` was changed from `classList.contains('day-col-slot')` to `.closest('.pointer-events-auto')` — the new check may have had unintended side effects

This PR reverts `DayView.jsx` and `TimeGrid.jsx` to their state before the entire `fix-hover-cursor-interaction` branch. The defensive safeguards in `useDragDrop.js` (document-level `dragend` + `window.blur` listeners) are kept — they are self-contained and don't cause regressions.

## Diagnostic instrumentation added

Two `console.log` calls are added to surface hover state live in the browser:

- `[DAY hover blocked]` — fires in `onColMouseMove` whenever `draggedTask`, `isResizing`, or `frameResizingRef.current` blocks the hover bar, logging which flag is set and the target element's className
- `[DAY card click]` — fires on task card click, confirming that `openMobileEditTask` is being called and from which element

These logs should be used to reproduce the hover and click-to-edit bugs and report actual observed behavior before any further fixes are attempted.

## Test plan

- [ ] Open browser DevTools console, reproduce hover breaking — check `[DAY hover blocked]` output
- [ ] Click a task card — check `[DAY card click]` output, confirm which path fires
- [ ] Text colors in light mode should be unchanged from before #543

https://claude.ai/code/session_01TK6htw63hLKPJwHF742cua