### PR TITLE
DAY hover diagnostics: unconditional mousemove log

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -171,6 +171,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const isOverEmptySlot = (target) => target && target.classList && target.classList.contains('day-col-slot');
 
   const onColMouseMove = (e) => {
+    console.log('[DAY mousemove]', { tag: e.target?.tagName, cls: e.target?.className?.slice?.(0, 80), draggedTask: !!draggedTask, isResizing, frameResizing: frameResizingRef.current, isSlot: isOverEmptySlot(e.target) });
     if (draggedTask || isResizing || frameResizingRef.current) {
       console.log('[DAY hover blocked]', { draggedTask: !!draggedTask, draggedTaskId: draggedTask?.id, isResizing, frameResizing: frameResizingRef.current, target: e.target?.className });
       if (hoverPreviewTime) { setHoverPreviewTime(null); setHoverPreviewDate(null); }


### PR DESCRIPTION
## Purpose

Adds an unconditional `console.log('[DAY mousemove]', ...)` at the very top of `onColMouseMove` in `DayViewColumn`. This fires on every mousemove that reaches the `colContentRef` div and logs:

- `tag` / `cls` — the actual DOM element the cursor is over
- `draggedTask`, `isResizing`, `frameResizing` — gating state values
- `isSlot` — whether `isOverEmptySlot(target)` would pass

## How to use

Open DevTools console, switch to DAY view, move cursor over an empty calendar slot, and check:

1. **Log never appears** → `onColMouseMove` is never called; event doesn't reach `colContentRef`. Structural/attachment issue — check `pointer-events` on ancestors and any covering elements.
2. **Log appears with `isSlot: false`** → handler IS called but the mouse target is not a `day-col-slot` element. Log shows exactly what element (`tag`/`cls`) is being hit instead. Fix is changing the `isOverEmptySlot` predicate.
3. **Log appears with `isSlot: true`** → handler fires and slot check passes; hover state should be setting. Investigate why the bar still doesn't render (`isHoveringThisCol` condition).

## Not a fix — revert after diagnosis

This PR exists only to surface runtime data. Once the root cause is confirmed, remove the logs as part of the actual fix PR.

https://claude.ai/code/session_01TK6htw63hLKPJwHF742cua