### PR TITLE
Remove onClick→openMobileEditTask from DAY task cards

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -67,7 +67,6 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     borderClass, textSecondary,
     expandedNotesTaskId,
     taskContextMenu, setTaskContextMenu,
-    openMobileEditTask,
     getTasksForDate,
     getTaskCalendarStyle,
     timeToMinutes,
@@ -171,9 +170,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const isOverEmptySlot = (target) => target && target.classList && target.classList.contains('day-col-slot');
 
   const onColMouseMove = (e) => {
-    console.log('[DAY mousemove]', { tag: e.target?.tagName, cls: e.target?.className?.slice?.(0, 80), draggedTask: !!draggedTask, isResizing, frameResizing: frameResizingRef.current, isSlot: isOverEmptySlot(e.target) });
     if (draggedTask || isResizing || frameResizingRef.current) {
-      console.log('[DAY hover blocked]', { draggedTask: !!draggedTask, draggedTaskId: draggedTask?.id, isResizing, frameResizing: frameResizingRef.current, target: e.target?.className });
       if (hoverPreviewTime) { setHoverPreviewTime(null); setHoverPreviewDate(null); }
       return;
     }
@@ -397,13 +394,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                     : { left, width }),
                   ...(isCalendarEvent || task.isTaskCalendar ? taskCalStyle : {}),
                 }}
-                onClick={(e) => {
-                  console.log('[DAY card click]', { taskId: task.id, target: e.target?.className, isCalendarEvent });
-                  e.stopPropagation();
-                  if (!isCalendarEvent || task.isTaskCalendar || task.nativeEventId) {
-                    openMobileEditTask(task, false);
-                  }
-                }}
+                onClick={(e) => e.stopPropagation()}
                 onContextMenu={(e) => {
                   e.preventDefault();
                   setTaskContextMenu({


### PR DESCRIPTION
## What

Removes the `onClick → openMobileEditTask` handler from task card divs in DAY view, and cleans up the diagnostic `console.log` calls from the hover investigation.

## Why

Diagnostic logging confirmed that every single-click on a task card was calling `openMobileEditTask`, opening the edit modal immediately. This made double-click inline editing impossible (modal opened on the first click, closed on the second). The edit modal is reachable via the Pencil button in the "..." overflow menu — the card `onClick` path was always wrong.

`e.stopPropagation()` is kept so clicks on task cards don't bubble to `onColClick` (which would open the new-task modal).

## What it doesn't touch

- `isNarrowWidth` stays `false`
- `isOverEmptySlot` logic unchanged
- Hover preview logic unchanged
- No layout or color changes

https://claude.ai/code/session_01TK6htw63hLKPJwHF742cua