### PR TITLE
Diagnose hover: capturing document listener + drag mode detection [SUPERSEDED by #550]

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -103,6 +103,40 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     return () => el.removeEventListener('mousemove', handler);
   }, []);
 
+  // DIAGNOSTIC: capturing document listener — fires BEFORE any element handler, regardless of
+  // stopPropagation or covering elements. Also listens for dragover to detect stuck drag mode.
+  useEffect(() => {
+    const colEl = colContentRef.current;
+    const onDocMM = (e) => {
+      if (!colEl) return;
+      const r = colEl.getBoundingClientRect();
+      if (e.clientX < r.left || e.clientX > r.right || e.clientY < r.top || e.clientY > r.bottom) return;
+      const actual = document.elementFromPoint(e.clientX, e.clientY);
+      console.log('[DAY doc-capture mm]', {
+        eventTarget: (e.target?.className || '').toString().slice(0, 80),
+        elementFromPoint: (actual?.className || '').toString().slice(0, 80),
+        sameAsTarget: actual === e.target,
+        insideColContent: colEl.contains(e.target),
+        insideColContentEFP: colEl.contains(actual),
+      });
+    };
+    const onDocDO = (e) => {
+      if (!colEl) return;
+      const r = colEl.getBoundingClientRect();
+      if (e.clientX < r.left || e.clientX > r.right || e.clientY < r.top || e.clientY > r.bottom) return;
+      console.log('[DAY doc-capture DRAGOVER — browser may be stuck in drag mode]', {
+        target: (e.target?.className || '').toString().slice(0, 80),
+        insideColContent: colEl.contains(e.target),
+      });
+    };
+    document.addEventListener('mousemove', onDocMM, { capture: true });
+    document.addEventListener('dragover', onDocDO, { capture: true });
+    return () => {
+      document.removeEventListener('mousemove', onDocMM, { capture: true });
+      document.removeEventListener('dragover', onDocDO, { capture: true });
+    };
+  }, []);
+
   // Compute the snapped 15-minute drop/hover time for the current pointer
   // event relative to this column's content area. Day-view columns span
   // col.startHour..col.endHour; this clamps to that range so the preview


### PR DESCRIPTION
## Summary

Adds two capturing document-level listeners to definitively diagnose why `mousemove` events never reach `colContentRef` during normal hover.

- **`[DAY doc-capture mm]`** — fires at document capture phase (before ANY element handler, before stopPropagation can block it). Logs:
  - `eventTarget`: what `e.target` is (the element the browser assigned the event to)
  - `elementFromPoint`: what `document.elementFromPoint(x,y)` returns at that position
  - `insideColContent`: whether `e.target` is inside `colContentRef`'s DOM subtree
  - `insideColContentEFP`: whether the `elementFromPoint` result is inside `colContentRef`'s DOM subtree

- **`[DAY doc-capture DRAGOVER]`** — if this fires instead of `mm`, the browser is stuck in native HTML5 drag mode, which suppresses all `mousemove` events

## What each result means

| Log output | Diagnosis |
|---|---|
| `[DAY doc-capture mm]` fires, `insideColContent: true` | Event reaches DOM but stopPropagation called in bubbling phase |
| `[DAY doc-capture mm]` fires, `insideColContent: false` | Covering element outside colContentRef intercepts events |
| `[DAY doc-capture DRAGOVER]` fires, no mm | Browser stuck in drag mode — fix dragend handling |
| Nothing fires at all | OS/browser-level event suppression |

https://claude.ai/code/session_01TK6htw63hLKPJwHF742cua