### PR TITLE
Fix app-wide hover regression: context menu overlay never dismissing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8597,7 +8597,7 @@ const DayPlanner = () => {
           <div
             className={`absolute ${cardBg} rounded-lg shadow-xl border ${borderClass} py-1 min-w-[160px]`}
             style={{ left: `${fmX}px`, top: `${fmY}px` }}
-            onClick={(e) => e.stopPropagation()}
+          >
           >
             <button
               className={`w-full text-left px-3 py-2 text-sm ${textPrimary} ${hoverBg} transition-colors flex items-center gap-2`}
@@ -8658,7 +8658,7 @@ const DayPlanner = () => {
             <div
               className={`absolute ${cardBg} rounded-lg shadow-xl border ${borderClass} py-1 min-w-[180px]`}
               style={{ left: `${clampedX}px`, top: `${clampedY}px` }}
-              onClick={(e) => e.stopPropagation()}
+            >
             >
               {!isImported && (
                 <button
@@ -8780,7 +8780,7 @@ const DayPlanner = () => {
             <div
               className={`absolute ${cardBg} rounded-lg shadow-xl border ${borderClass} py-1 min-w-[200px]`}
               style={{ left: `${tlX}px`, top: `${tlY}px` }}
-              onClick={(e) => e.stopPropagation()}
+            >
             >
               <button
                 className={`w-full text-left px-3 py-2 text-sm ${textPrimary} ${hoverBg} transition-colors flex items-center gap-2`}
@@ -8858,7 +8858,7 @@ const DayPlanner = () => {
             <div
               className={`absolute ${cardBg} rounded-lg shadow-xl border ${borderClass} py-1 min-w-[168px]`}
               style={{ left: `${cmX}px`, top: `${cmY}px` }}
-              onClick={(e) => e.stopPropagation()}
+            >
             >
               {!isCompleted && (
                 <button

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { formatHourLabel } from '../utils/timeFormatting.jsx';
 import { dateToString } from '../utils/taskUtils.js';
@@ -90,19 +90,6 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const colStartMin = col.startHour * 60;
   const colEndMin = col.endHour * 60;
 
-  // DIAGNOSTIC: native listener bypasses React delegation — tells us if DOM events reach colContentRef
-  useEffect(() => {
-    const el = colContentRef.current;
-    if (!el) return;
-    const handler = (e) => console.log('[DAY native mm]', {
-      tag: e.target?.tagName,
-      cls: (e.target?.className || '').toString().slice(0, 100),
-      isSlot: e.target?.classList?.contains('day-col-slot'),
-    });
-    el.addEventListener('mousemove', handler);
-    return () => el.removeEventListener('mousemove', handler);
-  }, []);
-
   // Compute the snapped 15-minute drop/hover time for the current pointer
   // event relative to this column's content area. Day-view columns span
   // col.startHour..col.endHour; this clamps to that range so the preview
@@ -183,12 +170,6 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const isOverEmptySlot = (target) => target && target.classList && target.classList.contains('day-col-slot');
 
   const onColMouseMove = (e) => {
-    console.log('[DAY react mm]', {
-      tag: e.target?.tagName,
-      cls: (e.target?.className || '').toString().slice(0, 100),
-      isSlot: e.target?.classList?.contains('day-col-slot'),
-      dragging: !!draggedTask, resizing: isResizing, frameResizing: frameResizingRef.current,
-    });
     if (draggedTask || isResizing || frameResizingRef.current) {
       if (hoverPreviewTime) { setHoverPreviewTime(null); setHoverPreviewDate(null); }
       return;


### PR DESCRIPTION
## Root cause

All four context menu overlays (frame, task, timeline, HyperGLANCE) share the same structure:

```jsx
<div className="fixed inset-0 z-[70]" onClick={() => setXxxMenu(null)}>
  <div onClick={(e) => e.stopPropagation()}>  ← BUG
    <button onClick={() => doAction()} />
  </div>
</div>
```

The `stopPropagation` on the inner container was intended to keep the overlay alive while interacting with the menu. But it also prevented the outer overlay's `onClick → setXxxMenu(null)` from ever firing when clicking a **menu item**. Result: the state was never cleared after clicking an item, so the transparent `fixed inset-0` overlay stayed on screen permanently — intercepting every subsequent `mousemove`, `mouseenter`, and `:hover` event across the entire app.

This is why cursor changes, CSS `:hover` effects, and the DAY view hover bar **never worked** after any context menu use. The pattern has been present since the views were first built.

## Fix

Remove `onClick={(e) => e.stopPropagation()}` from the inner container div in all four menus. Menu item clicks now propagate to the outer overlay, which clears the state and removes the overlay. Clicking outside the menu (on the backdrop) still works as before.

Also removes diagnostic console.log instrumentation added during investigation (DayView.jsx).

## Test plan

- [ ] Right-click a task → context menu appears → click a menu item → menu closes → hover bar and cursor styles work normally afterward
- [ ] Right-click a frame, timeline slot, and HyperGLANCE bar — same behavior
- [ ] Right-click → click outside menu → menu closes correctly
- [ ] DAY view hover bar appears when moving over empty time slots
- [ ] Cursor shows `pointer` over buttons, `grab` over draggable task cards

https://claude.ai/code/session_01TK6htw63hLKPJwHF742cua