### PR TITLE
Wire routine DnD in DAY and WEEK views

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -81,7 +81,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     setDragPreviewTime, setDragPreviewDate,
     setHoverPreviewTime, setHoverPreviewDate,
     handleDragStart, handleDragEnd, handleDropOnCalendar,
-    handleResizeStart,
+    handleResizeStart, handleTouchResizeStart,
     isResizing,
     setNewTask, setShowAddTask,
   } = useDayPlannerCtx();
@@ -428,10 +428,11 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                 {canResize && (
                   <div
                     onMouseDown={(e) => handleResizeStart(task, e)}
+                    onTouchStart={(e) => handleTouchResizeStart(task, e)}
                     onClick={(e) => e.stopPropagation()}
                     onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); }}
                     className="absolute bottom-0 left-1/3 right-1/3 h-3 cursor-ns-resize hover:bg-white/20 flex items-center justify-center select-none"
-                    style={{ marginBottom: '-4px' }}
+                    style={{ marginBottom: '-4px', touchAction: 'none' }}
                   >
                     <div className="w-12 h-1 bg-white rounded-full" />
                   </div>

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -495,6 +495,8 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                   draggable={!isTablet}
                   onDragStart={!isTablet ? (e) => handleDragStart({ ...routine }, 'routine', e) : undefined}
                   onDragEnd={!isTablet ? handleDragEnd : undefined}
+                  onDragOver={!isTablet ? onColDragOver : undefined}
+                  onDrop={!isTablet ? onColDrop : undefined}
                   className={`absolute pointer-events-auto flex items-center justify-center ${isPast ? 'opacity-50' : ''} ${!isTablet ? 'cursor-grab active:cursor-grabbing' : ''}`}
                   style={{ top: `${top}px`, height: `${Math.max(height, 27)}px`, left: `calc(${lPct} + 4px)`, width: `calc(${wPct} - 8px)` }}
                 >

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -155,6 +155,7 @@ const DayViewAllDaySection = () => {
     getTasksForDate,
     isTablet,
     handleDragStart, handleDragEnd, handleDropOnDateHeader,
+    dragOverAllDay, setDragOverAllDay, setDragPreviewTime,
   } = useDayPlannerCtx();
   const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion } = useFeaturesCtx();
   const todayStr = dateToString(new Date());
@@ -192,8 +193,10 @@ const DayViewAllDaySection = () => {
             {idx === 0 ? 'ALL DAY' : ''}
           </div>
           <div
-            className="flex-1 min-w-0 py-1"
+            className={`flex-1 min-w-0 py-1 ${dragOverAllDay === group.dateStr ? (darkMode ? 'bg-green-700/50' : 'bg-green-100') : ''}`}
             onDragOver={(e) => e.preventDefault()}
+            onDragEnter={(e) => { e.preventDefault(); setDragOverAllDay(group.dateStr); setDragPreviewTime(null); }}
+            onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) setDragOverAllDay(null); }}
             onDrop={(e) => handleDropOnDateHeader(e, group.date)}
           >
             <GroupChips

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -153,6 +153,8 @@ const DayViewAllDaySection = () => {
     borderClass, textSecondary, cardBg,
     dayViewColumns,
     getTasksForDate,
+    isTablet,
+    handleDragStart, handleDragEnd, handleDropOnDateHeader,
   } = useDayPlannerCtx();
   const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion } = useFeaturesCtx();
   const todayStr = dateToString(new Date());
@@ -189,7 +191,11 @@ const DayViewAllDaySection = () => {
           <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>
             {idx === 0 ? 'ALL DAY' : ''}
           </div>
-          <div className="flex-1 min-w-0">
+          <div
+            className="flex-1 min-w-0 py-1"
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => handleDropOnDateHeader(e, group.date)}
+          >
             <GroupChips
               tasks={group.tasks}
               darkMode={darkMode}
@@ -199,7 +205,10 @@ const DayViewAllDaySection = () => {
             {routinesEnabled && group.dateStr === todayStr && todayRoutines.filter(r => r.isAllDay).map(routine => (
               <span
                 key={`routine-${routine.id}`}
-                className={`rounded-full px-3 py-1 text-xs font-medium inline-block mr-1 mb-1 cursor-pointer ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${routineCompletions[routine.id] ? 'line-through opacity-75' : ''}`}
+                draggable={!isTablet}
+                onDragStart={!isTablet ? (e) => handleDragStart({ ...routine, duration: routine.duration || 15 }, 'routine', e) : undefined}
+                onDragEnd={!isTablet ? handleDragEnd : undefined}
+                className={`rounded-full px-3 py-1 text-xs font-medium inline-block mr-1 mb-1 ${!isTablet ? 'cursor-move' : 'cursor-pointer'} ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${routineCompletions[routine.id] ? 'line-through opacity-75' : ''}`}
                 onClick={() => toggleRoutineCompletion(routine.id)}
               >
                 {routine.name}

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -432,7 +432,10 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
             });
             items.push(
               <div key={`routine-${r.id}`}
-                className="absolute pointer-events-none flex items-start pt-0.5"
+                draggable={!isTablet}
+                onDragStart={!isTablet ? (e) => handleDragStart({ ...r }, 'routine', e) : undefined}
+                onDragEnd={!isTablet ? handleDragEnd : undefined}
+                className={`absolute pointer-events-auto flex items-start pt-0.5 ${!isTablet ? 'cursor-grab active:cursor-grabbing' : ''}`}
                 style={{
                   top: `${top}px`, height: `${h}px`, zIndex: 5,
                   left: hasOverlap && col === 1 ? 'calc(50% + 1px)' : '1px',


### PR DESCRIPTION
## Summary

- **DAY**: routine pill DnD was partially wired (drag start/end existed) but missing `onDragOver`/`onDrop` on the pill itself — drops landing on the pill rather than empty column space were unreliable. Added both, pointing at the existing `onColDragOver`/`onColDrop` locals. Behaviour is now identical to MULTI.
- **WEEK**: routine pills were `pointer-events-none` (display only). Made them draggable using the same `handleDragStart('routine')` call as MULTI and DAY. Drops are handled by the column-level `onColDragOver`/`onColDrop` already wired on the column root div. `handleDropOnCalendar` already enforces today-only placement for routine drags, so dropping on another day column is silently ignored.

## What didn't change

- The `dragSource === 'routine'` logic in `handleDropOnCalendar` is untouched — it already handles all three views correctly.
- WEEK routines remain display-only in terms of completion toggle (no `toggleRoutineCompletion` in WeekView); only DnD repositioning is added, consistent with "basic DnD like tasks."
- Overflow indicator pills (`+N`) in WEEK remain click-only (unchanged).

## Files changed

| File | Change |
|------|--------|
| `src/components/DayView.jsx` | Add `onDragOver`/`onDrop` to routine pill |
| `src/components/WeekView.jsx` | Make individual routine items draggable; remove `pointer-events-none` |

## Test plan

- [ ] **DAY**: drag a routine pill to a different time slot — it should reposition correctly with a preview bar
- [ ] **DAY**: drag a routine pill and drop it directly on top of another routine pill — should still work (was broken before)
- [ ] **WEEK**: drag a routine pill in today's column to a different time — repositions
- [ ] **WEEK**: drag a routine to a different day column — drops are silently ignored (routine stays put)
- [ ] **MULTI**: verify no regression in existing routine DnD

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs