### PR TITLE
Fix scheduled routines losing their times after opening/closing modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2262,6 +2262,7 @@ const DayPlanner = () => {
   }, [aiConfig]);
 
   const enterFocusModeRef = useRef(null);
+  const openRoutinesDashboardRef = useRef(null);
 
   const { longPressTriggeredRef, longPressTimerRef } = useMobileInteractions({
     isMobile, performUndo, performRedo,
@@ -2301,7 +2302,7 @@ const DayPlanner = () => {
     showHabitModal, showFramesModal, frameAdjustModal, showRescheduleModal,
     selectedDate, hoverPreviewTime, hoverPreviewDate,
     setNewTask, setShowAddTask, setHoverPreviewTime, setHoverPreviewDate,
-    routinesEnabled, setRoutinesEnabled, setShowRoutinesDashboard,
+    routinesEnabled, setRoutinesEnabled, openRoutinesDashboardRef,
     focusModeAvailableRef, enterFocusModeRef,
     setDarkMode,
     showMonthView, goToToday, setViewedMonth,
@@ -2897,6 +2898,7 @@ const DayPlanner = () => {
     nativeEnterFocusMode();
   };
   enterFocusModeRef.current = enterFocusMode;
+  openRoutinesDashboardRef.current = openRoutinesDashboard;
 
   const startFocusTimer = () => {
     setFocusShowSettings(false);

--- a/src/components/MobileTabBar.jsx
+++ b/src/components/MobileTabBar.jsx
@@ -14,7 +14,7 @@ const MobileTabBar = () => {
     goToToday,
   } = useDayPlannerCtx();
   const {
-    goalsProjectsEnabled, goals,
+    goalsProjectsEnabled, goals, handleRoutinesDone,
   } = useFeaturesCtx();
 
   const activeGoals = goalsProjectsEnabled ? (goals || []).filter(g => g.status !== 'archived') : [];

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -31,7 +31,7 @@ export default function useKeyboardShortcuts({
   selectedDate, hoverPreviewTime, hoverPreviewDate,
   setNewTask, setShowAddTask, setHoverPreviewTime, setHoverPreviewDate,
   // routines ('r')
-  routinesEnabled, setRoutinesEnabled, setShowRoutinesDashboard,
+  routinesEnabled, setRoutinesEnabled, openRoutinesDashboardRef,
   // focus mode ('f') — passed as a ref to avoid TDZ
   focusModeAvailableRef, enterFocusModeRef,
   // dark mode ('d')
@@ -148,7 +148,7 @@ export default function useKeyboardShortcuts({
         if (isMobile) {
           setMobileActiveTab('routines');
         } else {
-          setShowRoutinesDashboard(true);
+          openRoutinesDashboardRef.current?.();
         }
       }
 

--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -116,7 +116,8 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress })
     if (isSelected) {
       setDashboardSelectedChips(prev => prev.filter(c => c.id !== chip.id));
     } else {
-      setDashboardSelectedChips(prev => [...prev, { id: chip.id, name: chip.name, bucket, startTime: null }]);
+      const existingRoutine = todayRoutines.find(r => r.id === chip.id);
+      setDashboardSelectedChips(prev => [...prev, { id: chip.id, name: chip.name, bucket, startTime: existingRoutine?.startTime || null }]);
     }
   };
 
@@ -130,7 +131,11 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress })
     const newTodayRoutines = dashboardSelectedChips.map(chip => {
       const existing = existingMap[chip.id];
       if (existing) {
-        return { ...existing, name: chip.name, bucket: chip.bucket, startTime: chip.startTime, isAllDay: !chip.startTime, lastModified: now };
+        // chip.startTime reflects any time set in the modal; fall back to the
+        // existing DnD-placed time so that opening and closing the modal without
+        // touching the time picker never unschedules a placed routine.
+        const startTime = chip.startTime !== null ? chip.startTime : (existing.startTime || null);
+        return { ...existing, name: chip.name, bucket: chip.bucket, startTime, isAllDay: !startTime, lastModified: now };
       }
       return { id: chip.id, name: chip.name, bucket: chip.bucket, startTime: chip.startTime || null, duration: 15, isAllDay: !chip.startTime, lastModified: now };
     });


### PR DESCRIPTION
## Summary

Three bugs caused DnD-placed routine times to be discarded when the routines modal was opened and closed.

**Root cause — `useKeyboardShortcuts` bypassed `openRoutinesDashboard`.** The `r` keyboard shortcut called `setShowRoutinesDashboard(true)` directly, skipping `openRoutinesDashboard()` which repopulates `dashboardSelectedChips` from `todayRoutines`. This left chips with `startTime: null` from the first modal use, so any DnD-placed times were discarded when Done was clicked. Fix: thread through an `openRoutinesDashboardRef` (same ref pattern as `enterFocusModeRef`) so the shortcut always opens the modal with fresh scheduled-time data.

**Bug 2 — `toggleRoutineChipSelection` always resets `startTime` to null when re-adding a chip.** If the user deselected a routine chip and then re-selected it inside the modal, the chip was re-added with `startTime: null`. Fix: read `existingRoutine.startTime` from `todayRoutines` when re-adding.

**Bug 3 — `handleRoutinesDone` used `chip.startTime` as the sole source for scheduled time.** Even if `chip.startTime` was null for any reason, it would overwrite a valid DnD placement. Fix: fall back to `existing.startTime` when `chip.startTime` is null.

**Bonus — missing `handleRoutinesDone` import in `MobileTabBar`.** The Inbox tab button referenced `handleRoutinesDone` without importing it from context, causing a ReferenceError when tapping Inbox from the routines tab.

## Files changed

| File | Change |
|------|--------|
| `src/hooks/useRoutines.js` | Fix `toggleRoutineChipSelection` and `handleRoutinesDone` fallback |
| `src/hooks/useKeyboardShortcuts.js` | Use `openRoutinesDashboardRef` for `r` shortcut |
| `src/App.jsx` | Wire up `openRoutinesDashboardRef` |
| `src/components/MobileTabBar.jsx` | Add missing `handleRoutinesDone` from context |

## Test plan

- [x] DnD a routine to the timeline; press `r` to open modal; click Done — routine should remain on timeline at the same time
- [x] DnD a routine to the timeline; click the Routines button in the sidebar; click Done — routine should remain scheduled
- [x] DnD a routine; open modal; deselect the chip then re-select it; click Done — time preserved
- [x] On mobile: tap Inbox tab while on Routines tab — should not throw an error
- [x] Confirm routines with no scheduled time still appear correctly in the all-day area

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs