### PR TITLE
Fix ALL DAY section layout: text alignment, row padding, broken border

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -421,7 +421,7 @@ const CalendarHeader = () => {
       return (
         <div
           key={dateStr}
-          className={`flex-1 min-w-0 p-2 space-y-1 ${idx > 0 ? `border-l ${borderClass}` : ''} ${isDragOverThis || (isTablet && mobileDragPreviewTime === 'all-day') ? (darkMode ? 'bg-green-700/50' : 'bg-green-100') : ''}`}
+          className={`flex-1 min-w-0 p-2 ${idx > 0 ? `border-l ${borderClass}` : ''} ${isDragOverThis || (isTablet && mobileDragPreviewTime === 'all-day') ? (darkMode ? 'bg-green-700/50' : 'bg-green-100') : ''}`}
           onDragOver={(e) => { e.preventDefault(); if (autoScrollInterval.current) { clearInterval(autoScrollInterval.current); autoScrollInterval.current = null; } }}
           onDragEnter={(e) => {
             e.preventDefault();
@@ -465,7 +465,7 @@ const CalendarHeader = () => {
                   setDragPreviewTime(null);
                 }}
                 onDrop={(e) => handleDropOnDateHeader(e, date)}
-                className={`notes-panel-container relative ${task.completed && (!isImported || task.isTaskCalendar) ? 'opacity-50' : ''}`}
+                className={`notes-panel-container relative mb-1 ${task.completed && (!isImported || task.isTaskCalendar) ? 'opacity-50' : ''}`}
                 style={isTablet && !isImported ? { marginLeft: '12px' } : {}}
               >
                 {/* Tablet swipe strips — outside data-swipe-container so they stay behind as content slides */}
@@ -512,7 +512,7 @@ const CalendarHeader = () => {
           {deadlineTasks.map((task) => (
             <div
               key={`deadline-${task.id}`}
-              className="notes-panel-container relative"
+              className="notes-panel-container relative mb-1"
               style={isTablet ? { marginLeft: '12px' } : {}}
             >
               {/* Swipe action strips — outside data-swipe-container so they stay behind as content slides */}

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -193,18 +193,18 @@ const DayViewAllDaySection = () => {
             {idx === 0 ? 'ALL DAY' : ''}
           </div>
           <div
-            className={`flex-1 min-w-0 p-2 space-y-1 ${dragOverAllDay === group.dateStr ? (darkMode ? 'bg-green-700/50 ring-2 ring-inset ring-green-400' : 'bg-green-100 ring-2 ring-inset ring-green-500') : ''}`}
+            className={`flex-1 min-w-0 p-2 ${dragOverAllDay === group.dateStr ? (darkMode ? 'bg-green-700/50 ring-2 ring-inset ring-green-400' : 'bg-green-100 ring-2 ring-inset ring-green-500') : ''}`}
             onDragOver={(e) => e.preventDefault()}
             onDragEnter={(e) => { e.preventDefault(); setDragOverAllDay(group.dateStr); setDragPreviewTime(null); }}
             onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) setDragOverAllDay(null); }}
             onDrop={(e) => handleDropOnDateHeader(e, group.date)}
           >
-            <GroupChips
+            {group.tasks.length > 0 && <GroupChips
               tasks={group.tasks}
               darkMode={darkMode}
               borderClass={borderClass}
               cardBg={cardBg}
-            />
+            />}
             {routinesEnabled && group.dateStr === todayStr && todayRoutines.filter(r => r.isAllDay).map(routine => (
               <span
                 key={`routine-${routine.id}`}


### PR DESCRIPTION
## Summary

- **"ALL DAY" text alignment** — In DAY view, `GroupChips` was always rendered even when there were no all-day tasks. Its internal `p-2` added 16px of dead space above routine pills, pushing them lower than the gutter's "ALL DAY" label. Guarding it with `tasks.length > 0` means the chip area's own `p-2` is the only offset, so the first visible element always lines up with the gutter text — identical between MULTI and DAY.

- **Row padding uniformity** — Both chip areas had `space-y-1`, which adds `margin-top: 4px` to every sibling after the first but no bottom margin on the last item. Replaced with `mb-1` on each individual task/deadline card wrapper so every item gets uniform spacing below it, matching the more balanced look of DAY view.

- **Broken border in DAY view** — The empty `GroupChips` block (with its ghost absolute-positioned div and `p-2` padding) created visual dead space between the gutter border-right and the chip content. Eliminating the empty render fixes the apparent gap/disconnection.

## Files changed

| File | Change |
|------|--------|
| `src/components/DayViewAllDaySection.jsx` | Remove `space-y-1`; guard `GroupChips` render on `tasks.length > 0` |
| `src/components/CalendarHeader.jsx` | Remove `space-y-1` from MULTI chip area; add `mb-1` to task and deadline card wrappers |

## Test plan

- [ ] MULTI view with all-day tasks: cards have uniform spacing, "ALL DAY" text vertically aligned with first card
- [ ] DAY view with only routines (no all-day tasks): routine pills start flush with "ALL DAY" text, no dead space above them
- [ ] DAY view with all-day tasks + routines: GroupChips renders above routine pills, alignment preserved
- [ ] Gutter border-right connects cleanly to chip content in DAY view — no broken/floating border appearance
- [ ] MULTI view: drag-over highlight still works correctly on the chip area

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs