### PR TITLE
Fix DAY view ALL DAY gutter: text position and border height

### DIFF
--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -187,7 +187,7 @@ const DayViewAllDaySection = () => {
         <div
           key={group.dateStr}
           style={{ gridColumn: `span ${group.count}` }}
-          className={`flex items-center min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}`}
+          className={`flex min-w-0 ${idx > 0 ? `border-l ${borderClass}` : ''}`}
         >
           <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>
             {idx === 0 ? 'ALL DAY' : ''}


### PR DESCRIPTION
## Summary

Single-line fix: remove `items-center` from the row flex container in `DayViewAllDaySection.jsx`.

`items-center` was causing two bugs:

1. **"ALL DAY" text jumps** — centering the gutter text vertically within the row means it shifts up and down as chip content grows/shrinks. MULTI view uses the flex default (`stretch`), which pins the text at `py-2` (8px) from the top regardless of row height.

2. **Broken border at top and bottom** — with `items-center`, the gutter div only grows to fit its own text content, not the full row height. So `border-r` is shorter than the row, leaving visible gaps above and below it.

Removing `items-center` restores `stretch` (the flex default): the gutter fills the full row height, `border-r` spans top-to-bottom, and `py-2` keeps the "ALL DAY" text exactly 8px from the top — identical positioning to MULTI view.

## Test plan

- [ ] DAY view with only routines: "ALL DAY" text at same vertical position as in MULTI view
- [ ] DAY view with multiple all-day tasks: "ALL DAY" text stays pinned at the top as row height grows — does not re-center
- [ ] `border-r` on gutter spans the full row height with no gaps at top or bottom

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs