### PR TITLE
Align DAY all-day chip area behavior with MULTI

### DIFF
--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -156,6 +156,9 @@ const DayViewAllDaySection = () => {
     isTablet,
     handleDragStart, handleDragEnd, handleDropOnDateHeader,
     dragOverAllDay, setDragOverAllDay, setDragPreviewTime,
+    mobileDragPreviewTime,
+    autoScrollInterval,
+    handleMobileTaskTouchStart, handleMobileTaskTouchMove, handleMobileTaskTouchEnd,
   } = useDayPlannerCtx();
   const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion } = useFeaturesCtx();
   const todayStr = dateToString(new Date());
@@ -193,29 +196,39 @@ const DayViewAllDaySection = () => {
             {idx === 0 ? 'ALL DAY' : ''}
           </div>
           <div
-            className={`flex-1 min-w-0 p-2 ${dragOverAllDay === group.dateStr ? (darkMode ? 'bg-green-700/50 ring-2 ring-inset ring-green-400' : 'bg-green-100 ring-2 ring-inset ring-green-500') : ''}`}
-            onDragOver={(e) => e.preventDefault()}
+            className={`flex-1 min-w-0 p-2 ${dragOverAllDay === group.dateStr || (isTablet && mobileDragPreviewTime === 'all-day') ? (darkMode ? 'bg-green-700/50' : 'bg-green-100') : ''}`}
+            onDragOver={(e) => { e.preventDefault(); if (autoScrollInterval.current) { clearInterval(autoScrollInterval.current); autoScrollInterval.current = null; } }}
             onDragEnter={(e) => { e.preventDefault(); setDragOverAllDay(group.dateStr); setDragPreviewTime(null); }}
             onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) setDragOverAllDay(null); }}
             onDrop={(e) => handleDropOnDateHeader(e, group.date)}
           >
-            {group.tasks.length > 0 && <GroupChips
-              tasks={group.tasks}
-              darkMode={darkMode}
-              borderClass={borderClass}
-              cardBg={cardBg}
-            />}
+            {group.tasks.length > 0 && (
+              <div className="mb-1">
+                <GroupChips
+                  tasks={group.tasks}
+                  darkMode={darkMode}
+                  borderClass={borderClass}
+                  cardBg={cardBg}
+                />
+              </div>
+            )}
             {routinesEnabled && group.dateStr === todayStr && todayRoutines.filter(r => r.isAllDay).map(routine => (
-              <span
+              <div
                 key={`routine-${routine.id}`}
                 draggable={!isTablet}
                 onDragStart={!isTablet ? (e) => handleDragStart({ ...routine, duration: routine.duration || 15 }, 'routine', e) : undefined}
                 onDragEnd={!isTablet ? handleDragEnd : undefined}
-                className={`rounded-full px-3 py-1 text-xs font-medium inline-block mr-1 mb-1 ${!isTablet ? 'cursor-move' : 'cursor-pointer'} ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${routineCompletions[routine.id] ? 'line-through opacity-75' : ''}`}
+                {...(isTablet ? {
+                  onTouchStart: (e) => handleMobileTaskTouchStart(e, { ...routine, isRoutineDrag: true, duration: routine.duration || 15 }, 'allday'),
+                  onTouchMove: (e) => handleMobileTaskTouchMove(e),
+                  onTouchEnd: (e) => handleMobileTaskTouchEnd(e, routine.id, 'allday'),
+                } : {})}
+                className={`rounded-full px-3 py-1 text-xs font-medium ${isTablet ? 'cursor-default select-none' : 'cursor-move'} inline-block mr-1 mb-1 ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${routineCompletions[routine.id] ? 'line-through opacity-75' : ''}`}
+                style={isTablet ? { touchAction: 'none', WebkitTouchCallout: 'none', WebkitUserSelect: 'none' } : {}}
                 onClick={() => toggleRoutineCompletion(routine.id)}
               >
                 {routine.name}
-              </span>
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary

Brings the DAY view all-day chip area into parity with MULTI on every behavioral dimension (excluding column-width differences like task card sizing).

| Issue | MULTI | DAY (before) | DAY (after) |
|-------|-------|--------------|-------------|
| Drag-over style | `bg-green-*` only | `bg-green-*` + ring | `bg-green-*` only ✓ |
| Tablet drag preview | checks `mobileDragPreviewTime === 'all-day'` | not checked | checked ✓ |
| onDragOver | clears `autoScrollInterval` | no-op | clears interval ✓ |
| Task→routine gap | last task `mb-1` → 4px gap | GroupChips has no margin | GroupChips wrapped in `mb-1` ✓ |
| Routine pill element | `<div>` | `<span>` | `<div>` ✓ |
| Routine pill tablet cursor | `cursor-default select-none` | `cursor-pointer` | `cursor-default select-none` ✓ |
| Routine pill touch handlers | `onTouchStart/Move/End` with `isRoutineDrag` | missing | added ✓ |
| Routine pill tablet style | `touchAction: none` + webkit | missing | added ✓ |

**One remaining structural gap not fixed here:** MULTI renders deadline inbox tasks in the all-day area; DAY does not. This is a larger feature addition and should be addressed separately.

## Test plan

- [ ] DAY view: drag an event over the all-day area — should show plain green background, no ring
- [ ] DAY view: all-day tasks followed by routine pills — should have 4px gap between them (matching MULTI)
- [ ] Tablet DAY view: long-press a routine pill in the all-day area — should initiate drag with `isRoutineDrag` flag
- [ ] Tablet DAY view: dragging a scheduled event into the all-day area should highlight the drop zone

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs