### PR TITLE
Translate webcal:// to https:// on paste in calendar sync URL fields

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -499,6 +499,7 @@ const SettingsModal = () => {
                           placeholder="https://nextcloud.example.com/remote.php/dav/calendars/user/calendar-name/?export"
                           value={syncUrl}
                           onChange={(e) => setSyncUrl(e.target.value.replace(/^webcal:\/\//i, 'https://'))}
+                          onPaste={(e) => { const text = e.clipboardData.getData('text'); if (/^webcal:\/\//i.test(text)) { e.preventDefault(); setSyncUrl(text.replace(/^webcal:\/\//i, 'https://')); } }}
                           className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
                         />
                         <p className={`text-xs ${textSecondary} mt-1`}>
@@ -550,6 +551,7 @@ const SettingsModal = () => {
                           placeholder="https://nextcloud.example.com/remote.php/dav/calendars/user/tasks/?export"
                           value={taskCalendarUrl}
                           onChange={(e) => setTaskCalendarUrl(e.target.value.replace(/^webcal:\/\//i, 'https://'))}
+                          onPaste={(e) => { const text = e.clipboardData.getData('text'); if (/^webcal:\/\//i.test(text)) { e.preventDefault(); setTaskCalendarUrl(text.replace(/^webcal:\/\//i, 'https://')); } }}
                           className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
                         />
                         <p className={`text-xs ${textSecondary} mt-1`}>


### PR DESCRIPTION
## Summary

- The `onChange` handler already rewrites `webcal://` to `https://` for typed input
- `type="url"` inputs can suppress paste events for non-standard schemes in some browsers, so pasting a `webcal://` URL was silently dropped or had no effect
- Added `onPaste` handlers to both the Calendar URL and Task Calendar URL inputs that intercept the clipboard text before browser validation, replace `webcal://` with `https://`, and write the corrected value to state

## Test plan

- [ ] Copy a `webcal://` URL to clipboard, paste into Calendar URL field — should appear as `https://`
- [ ] Copy a `webcal://` URL to clipboard, paste into Task Calendar URL field — should appear as `https://`
- [ ] Typing `webcal://...` still rewrites on the fly (existing behaviour unchanged)
- [ ] Pasting a normal `https://` URL is unaffected

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs