### PR TITLE
Keep ViewCycler cell unaffected by date header drag highlight in DAY mode

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -273,7 +273,7 @@ const CalendarHeader = () => {
           {/* ViewCycler floats in the absolute-left of the first date group so
               column boundaries align: both header and DayView start at x=0. */}
           {idx === 0 && canShowViewCycler && (
-            <div className={`absolute left-0 top-0 w-16 h-full border-r ${borderClass}`}>
+            <div className={`absolute left-0 top-0 w-16 h-full border-r ${borderClass} ${cardBg}`}>
               <ViewCycler />
             </div>
           )}


### PR DESCRIPTION
## Summary

- In DAY mode the ViewCycler ("DAY" + cycle icon) is `absolute`-positioned inside the first date column header `<div>`
- That outer div gets `bg-green-700` + ring when `dragOverAllDay` matches — the green was bleeding through the ViewCycler cell since it had no background of its own
- In MULTI mode the ViewCycler is a sibling element (never inside a highlighted cell), so it was unaffected there
- Fix: add `${cardBg}` to the ViewCycler's wrapper div so it always paints its own background, shielding it from any parent highlight

## Test plan

- [ ] DAY mode: drag a task over the date column header — header turns green with ring, ViewCycler cell stays at its normal background colour
- [ ] DAY mode: drag a task over the ALL DAY chip area — chip area turns green (no ring), date header and ViewCycler cell are unaffected
- [ ] No visual regression in MULTI or WEEK modes

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs