### PR TITLE
Match deadline task chip sizing to regular all-day chips in DAY view

### DIFF
--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import {
   AlertCircle, BookOpen, Calendar, Check, CheckSquare,
   ExternalLink, FileText, GripVertical, Inbox,
-  Pencil, Settings, SkipForward, Trash2,
+  Pencil, Settings, SkipForward,
 } from 'lucide-react';
 import AllDayTaskCard from './AllDayTaskCard.jsx';
 import DeadlinePickerPopover from './DeadlinePickerPopover.jsx';
@@ -20,14 +20,24 @@ const MAX_H = CHIP_ROW_H * MAX_ROWS + ROW_GAP * (MAX_ROWS - 1);
 
 // ── GroupChips — horizontal flex-wrap with 2-row cap + "+N more" popover ─────
 
-const GroupChips = ({ tasks, date, dateStr, darkMode, borderClass, cardBg }) => {
+const GroupChips = ({ tasks, deadlineTasks = [], date, dateStr, darkMode, borderClass, cardBg }) => {
   const {
     isTablet,
     handleDragStart, handleDragEnd,
     updateDragAutoScroll,
     setDragOverAllDay, setDragPreviewTime,
     handleDropOnDateHeader,
+    showDeadlinePicker, setShowDeadlinePicker,
+    postponeDeadlineTask, toggleComplete,
+    expandedNotesTaskId, setExpandedNotesTaskId,
+    updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
+    setTaskContextMenu,
+    longPressTimerRef, longPressTriggeredRef, openMobileEditTask,
+    handleMobileTaskTouchStart, handleMobileTaskTouchMove, handleMobileTaskTouchEnd,
   } = useDayPlannerCtx();
+  const { aiConfig, aiSubtasksLoadingForTask, generateAISubtasks } = useFeaturesCtx();
+  const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
+
   const ghostRef = useRef(null);
   const buttonRef = useRef(null);
   const popoverRef = useRef(null);
@@ -35,13 +45,19 @@ const GroupChips = ({ tasks, date, dateStr, darkMode, borderClass, cardBg }) => 
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [popoverPos, setPopoverPos] = useState({ top: 0, left: 0 });
 
+  // Unified item list — tasks first, then deadline tasks
+  const allItems = [
+    ...tasks.map(t => ({ type: 'task', data: t })),
+    ...deadlineTasks.map(t => ({ type: 'deadline', data: t })),
+  ];
+
   useLayoutEffect(() => {
     const el = ghostRef.current;
     if (!el) return;
 
     const measure = () => {
       const chips = Array.from(el.children);
-      if (!chips.length || !tasks.length) { setLimit(null); return; }
+      if (!chips.length || !allItems.length) { setLimit(null); return; }
       const rowTop = chips[0].offsetTop;
       const maxBottom = rowTop + MAX_H;
       let lastFit = chips.length;
@@ -58,7 +74,7 @@ const GroupChips = ({ tasks, date, dateStr, darkMode, borderClass, cardBg }) => 
     const ro = new ResizeObserver(measure);
     ro.observe(el);
     return () => ro.disconnect();
-  }, [tasks.length]);
+  }, [tasks.length, deadlineTasks.length]);
 
   useEffect(() => {
     if (!overflowOpen) return;
@@ -88,8 +104,135 @@ const GroupChips = ({ tasks, date, dateStr, darkMode, borderClass, cardBg }) => 
     setOverflowOpen(v => !v);
   };
 
-  const shown = limit !== null ? tasks.slice(0, limit) : tasks;
-  const overflowTasks = limit !== null ? tasks.slice(limit) : [];
+  const shown = limit !== null ? allItems.slice(0, limit) : allItems;
+  const overflowItems = limit !== null ? allItems.slice(limit) : [];
+
+  // Renders the inner deadline card (shared between visible chips and overflow popover)
+  const renderDeadlineCardInner = (task) => (
+    <>
+      {isTablet && (
+        <>
+          <div data-swipe-strip="right" style={{ display: 'none', left: '8px' }} className={`absolute inset-0 ${darkMode ? 'bg-blue-900/80 text-blue-300' : 'bg-blue-100 text-blue-600'} rounded-lg flex items-center pl-3 text-xs font-medium`}>
+            <Inbox size={14} className="mr-1" />Inbox
+          </div>
+          <div data-swipe-strip="left" style={{ display: 'none', left: '8px' }} className={`absolute inset-0 ${darkMode ? 'bg-amber-900/80 text-amber-300' : 'bg-amber-100 text-amber-600'} rounded-lg flex items-center justify-end pr-3 text-xs font-medium`}>
+            Edit<Settings size={14} className="ml-1" />
+          </div>
+        </>
+      )}
+      <div {...(isTablet ? { 'data-swipe-container': '', className: `flex items-start ${task.completed ? 'opacity-50' : 'opacity-90'}` } : { className: task.completed ? 'opacity-50' : 'opacity-90' })}>
+        {isTablet && (
+          <div
+            data-drag-handle
+            className={`relative flex-shrink-0 ${task.color} rounded-l-lg flex items-center pl-px cursor-grab active:opacity-70 text-white/70`}
+            style={{ marginLeft: '-12px', marginRight: '-8px', marginTop: '3px', width: '20px', height: '24px', touchAction: 'none', zIndex: 10 }}
+            onTouchStart={(e) => handleMobileTaskTouchStart(e, { ...task, isDeadlineDrag: true }, 'deadline')}
+            onTouchMove={(e) => handleMobileTaskTouchMove(e)}
+            onTouchEnd={(e) => handleMobileTaskTouchEnd(e, task.id, 'deadline')}
+            onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); }}
+          >
+            <div className="absolute top-0 left-0 h-full rounded-l-lg border-l-2 border-t-2 border-b-2 border-dashed border-white/60 pointer-events-none" style={{ width: '12px' }} />
+            <div className="absolute top-0 border-t-2 border-dashed border-white/60 pointer-events-none" style={{ left: '12px', width: '2px' }} />
+            <GripVertical size={14} />
+          </div>
+        )}
+        <div className={`relative rounded-lg ${showDeadlinePicker === task.id ? '' : 'overflow-hidden'} ${isTablet ? 'flex-1 min-w-0' : 'w-full'}`}>
+          <div
+            data-task-id={task.id}
+            data-ctx-menu
+            draggable
+            onDragStart={(e) => handleDragStart(task, 'inbox', e)}
+            onDragEnd={handleDragEnd}
+            onDragOver={(e) => { e.preventDefault(); updateDragAutoScroll(e); }}
+            onDragEnter={(e) => { e.preventDefault(); setDragOverAllDay(dateStr); setDragPreviewTime(null); }}
+            onDrop={(e) => handleDropOnDateHeader(e, date)}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              setTaskContextMenu({ x: e.clientX, y: e.clientY, taskId: task.id, isRecurring: false, isImported: false, isAllDay: true, dateStr });
+            }}
+            onTouchStart={(e) => handleMobileTaskTouchStart(e, { ...task, isDeadlineDrag: true }, 'deadline')}
+            onTouchMove={(e) => handleMobileTaskTouchMove(e)}
+            onTouchEnd={(e) => handleMobileTaskTouchEnd(e, task.id, 'deadline')}
+            className={`${task.color} rounded-lg shadow-sm cursor-move relative border-2 border-dashed border-white/60`}
+            style={{ touchAction: 'pan-y' }}
+          >
+            {task.isExample && (
+              <span className="absolute -top-2 -right-2 bg-yellow-400 text-yellow-900 text-[10px] font-bold px-1.5 py-0.5 rounded-full shadow-sm z-10">Example</span>
+            )}
+            <div className="p-2 text-white">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2 flex-1 min-w-0">
+                  <button
+                    onClick={() => toggleComplete(task.id, true)}
+                    className={`rounded flex-shrink-0 ${task.completed ? 'bg-white/40' : 'bg-white/20'} border-2 border-white w-4 h-4 flex items-center justify-center hover:bg-white/30 transition-colors`}
+                  >
+                    {task.completed && <Check size={10} strokeWidth={3} />}
+                  </button>
+                  <AlertCircle size={14} className="flex-shrink-0" />
+                  <div className={`font-semibold text-sm truncate ${task.completed ? 'line-through' : ''}`} title={task.title}>
+                    {renderTitle(task.title)}
+                  </div>
+                </div>
+                <div className="flex items-center gap-0.5 flex-shrink-0">
+                  <button
+                    onMouseDown={() => { if (isLinkOnlyTask(task)) { longPressTriggeredRef.current = false; longPressTimerRef.current = setTimeout(() => { longPressTriggeredRef.current = true; setExpandedNotesTaskId(prev => prev === task.id ? null : task.id); }, 500); } }}
+                    onMouseUp={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
+                    onMouseLeave={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
+                    onClick={(e) => { e.stopPropagation(); if (isLinkOnlyTask(task)) { if (!longPressTriggeredRef.current) window.open(getLinkUrl(task), '_blank', 'noopener,noreferrer'); longPressTriggeredRef.current = false; } else { setExpandedNotesTaskId(prev => prev === task.id ? null : task.id); } }}
+                    className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${hasNotesOrSubtasks(task) || extractWikilinks(task.title).length > 0 ? '' : 'opacity-40'}`}
+                    title={isLinkOnlyTask(task) ? `${getLinkUrl(task)} (hold to edit)` : 'Notes & subtasks'}
+                  >
+                    {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
+                  </button>
+                  <button onClick={(e) => { e.stopPropagation(); postponeDeadlineTask(task.id); }} className="hover:bg-white/20 rounded p-1 transition-colors" title="Postpone to tomorrow">
+                    <SkipForward size={14} />
+                  </button>
+                  <div className="deadline-picker-container relative">
+                    <button
+                      onClick={(e) => { e.stopPropagation(); setShowDeadlinePicker(showDeadlinePicker === task.id ? null : task.id); }}
+                      className="hover:bg-white/20 rounded p-1 transition-colors bg-white/20"
+                      title={`Deadline: ${formatDeadlineDate(task.deadline)}`}
+                    >
+                      <Calendar size={14} />
+                    </button>
+                    {showDeadlinePicker === task.id && (
+                      <DeadlinePickerPopover taskId={task.id} currentDeadline={task.deadline} onClose={() => setShowDeadlinePicker(null)} />
+                    )}
+                  </div>
+                  {!isTablet && (
+                    <button onClick={() => openMobileEditTask(task, true)} className="hover:bg-white/20 rounded p-1 transition-colors" title="Edit">
+                      <Pencil size={14} />
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+            {expandedNotesTaskId === task.id && (
+              <div className="notes-panel-container">
+                <NotesSubtasksPanel
+                  task={task}
+                  isInbox={true}
+                  darkMode={darkMode}
+                  updateTaskNotes={updateTaskNotes}
+                  addSubtask={addSubtask}
+                  toggleSubtask={toggleSubtask}
+                  deleteSubtask={deleteSubtask}
+                  updateSubtaskTitle={updateSubtaskTitle}
+                  aiConfig={aiConfig}
+                  aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
+                  onGenerateSubtasks={generateAISubtasks}
+                  wikilinks={extractWikilinks(task.title).length > 0 ? extractWikilinks(task.title) : undefined}
+                  onLoadWikiNote={extractWikilinks(task.title).length > 0 ? loadWikiNote : undefined}
+                  onSaveWikiNote={extractWikilinks(task.title).length > 0 ? saveWikiNote : undefined}
+                  onOpenInObsidian={extractWikilinks(task.title).length > 0 ? openInObsidian : undefined}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
 
   return (
     <div className="relative">
@@ -99,58 +242,71 @@ const GroupChips = ({ tasks, date, dateStr, darkMode, borderClass, cardBg }) => 
         className="absolute inset-0 flex flex-wrap gap-1 opacity-0 pointer-events-none"
         aria-hidden="true"
       >
-        {tasks.map(t => (
-          <div key={t.id} className="grow shrink-0 basis-[200px] max-w-[400px]">
-            <AllDayTaskCard task={t} fillWidth={false} />
-          </div>
+        {allItems.map(item => (
+          <div
+            key={item.type === 'task' ? item.data.id : `deadline-${item.data.id}`}
+            className="grow shrink-0 basis-[200px] max-w-[400px]"
+          />
         ))}
       </div>
 
       {/* Visible chips */}
       <div className="flex flex-wrap gap-1">
-        {shown.map(t => (
+        {shown.map(item => item.type === 'task' ? (
           <div
-            key={t.id}
-            draggable={(!t.imported || !!t.nativeEventId) && !isTablet}
-            onDragStart={(e) => (!t.imported || !!t.nativeEventId) && handleDragStart(t, 'calendar', e)}
+            key={item.data.id}
+            draggable={(!item.data.imported || !!item.data.nativeEventId) && !isTablet}
+            onDragStart={(e) => (!item.data.imported || !!item.data.nativeEventId) && handleDragStart(item.data, 'calendar', e)}
             onDragEnd={handleDragEnd}
             onDragOver={(e) => { e.preventDefault(); updateDragAutoScroll(e); }}
             onDragEnter={(e) => { e.preventDefault(); setDragOverAllDay(dateStr); setDragPreviewTime(null); }}
             onDrop={(e) => handleDropOnDateHeader(e, date)}
-            className={`notes-panel-container relative grow shrink-0 basis-[200px] max-w-[400px] ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
+            className={`notes-panel-container relative grow shrink-0 basis-[200px] max-w-[400px] ${item.data.completed && (!item.data.imported || item.data.isTaskCalendar) ? 'opacity-50' : ''}`}
           >
-            <AllDayTaskCard task={t} fillWidth={false} />
+            <AllDayTaskCard task={item.data} fillWidth={false} />
+          </div>
+        ) : (
+          <div
+            key={`deadline-${item.data.id}`}
+            className="notes-panel-container relative grow shrink-0 basis-[200px] max-w-[400px]"
+            style={isTablet ? { marginLeft: '12px' } : {}}
+          >
+            {renderDeadlineCardInner(item.data)}
           </div>
         ))}
 
         {/* "+N more" overflow chip */}
-        {overflowTasks.length > 0 && (
+        {overflowItems.length > 0 && (
           <div className="relative flex-shrink-0 self-start">
             <button
               ref={buttonRef}
               onClick={handleTogglePopover}
               className={`text-xs font-medium px-2 py-1 rounded-md ${darkMode ? 'bg-gray-600 text-gray-200 hover:bg-gray-500' : 'bg-stone-200 text-stone-600 hover:bg-stone-300'} transition-colors`}
             >
-              +{overflowTasks.length} more
+              +{overflowItems.length} more
             </button>
           </div>
         )}
       </div>
 
       {/* Overflow popover — fixed to viewport so it doesn't overlap the timeline */}
-      {overflowOpen && overflowTasks.length > 0 && (
+      {overflowOpen && overflowItems.length > 0 && (
         <div
           ref={popoverRef}
           style={{ position: 'fixed', top: popoverPos.top, left: popoverPos.left, width: 400, zIndex: 200 }}
           className={`rounded-lg shadow-xl border ${borderClass} ${cardBg} p-2 flex flex-col gap-1 max-h-[60vh] overflow-y-auto`}
         >
-          {overflowTasks.map(t => (
+          {overflowItems.map(item => (
             <div
-              key={t.id}
-              className={`notes-panel-container relative ${t.completed && (!t.imported || t.isTaskCalendar) ? 'opacity-50' : ''}`}
+              key={item.type === 'task' ? item.data.id : `deadline-${item.data.id}`}
+              className={`notes-panel-container relative ${item.type === 'task' && item.data.completed && (!item.data.imported || item.data.isTaskCalendar) ? 'opacity-50' : ''}`}
               onClick={() => setOverflowOpen(false)}
             >
-              <AllDayTaskCard task={t} fillWidth={false} />
+              {item.type === 'task' ? (
+                <AllDayTaskCard task={item.data} fillWidth={false} />
+              ) : (
+                renderDeadlineCardInner(item.data)
+              )}
             </div>
           ))}
         </div>
@@ -181,19 +337,10 @@ const DayViewAllDaySection = () => {
     mobileDragPreviewTime,
     autoScrollInterval,
     handleMobileTaskTouchStart, handleMobileTaskTouchMove, handleMobileTaskTouchEnd,
-    showDeadlinePicker, setShowDeadlinePicker,
-    postponeDeadlineTask, toggleComplete,
-    expandedNotesTaskId, setExpandedNotesTaskId,
-    updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
-    setTaskContextMenu,
-    longPressTimerRef, longPressTriggeredRef,
-    openMobileEditTask,
   } = useDayPlannerCtx();
   const {
     projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion,
-    aiConfig, aiSubtasksLoadingForTask, generateAISubtasks,
   } = useFeaturesCtx();
-  const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
   const todayStr = dateToString(new Date());
 
   // Build date groups (same logic as CalendarHeader day-mode header)
@@ -236,10 +383,11 @@ const DayViewAllDaySection = () => {
             onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) setDragOverAllDay(null); }}
             onDrop={(e) => handleDropOnDateHeader(e, group.date)}
           >
-            {group.tasks.length > 0 && (
+            {(group.tasks.length > 0 || group.deadlineTasks.length > 0) && (
               <div className="mb-1">
                 <GroupChips
                   tasks={group.tasks}
+                  deadlineTasks={group.deadlineTasks}
                   date={group.date}
                   dateStr={group.dateStr}
                   darkMode={darkMode}
@@ -248,184 +396,6 @@ const DayViewAllDaySection = () => {
                 />
               </div>
             )}
-
-            {/* Deadline tasks from inbox */}
-            {group.deadlineTasks.map((task) => (
-              <div
-                key={`deadline-${task.id}`}
-                className="notes-panel-container relative mb-1"
-                style={isTablet ? { marginLeft: '12px' } : {}}
-              >
-                {/* Tablet swipe strips */}
-                {isTablet && (
-                  <>
-                    <div data-swipe-strip="right" style={{ display: 'none', left: '8px' }} className={`absolute inset-0 ${darkMode ? 'bg-blue-900/80 text-blue-300' : 'bg-blue-100 text-blue-600'} rounded-lg flex items-center pl-3 text-xs font-medium`}>
-                      <Inbox size={14} className="mr-1" />Inbox
-                    </div>
-                    <div data-swipe-strip="left" style={{ display: 'none', left: '8px' }} className={`absolute inset-0 ${darkMode ? 'bg-amber-900/80 text-amber-300' : 'bg-amber-100 text-amber-600'} rounded-lg flex items-center justify-end pr-3 text-xs font-medium`}>
-                      Edit<Settings size={14} className="ml-1" />
-                    </div>
-                  </>
-                )}
-                <div {...(isTablet ? { 'data-swipe-container': '', className: `flex items-start ${task.completed ? 'opacity-50' : 'opacity-90'}` } : { className: task.completed ? 'opacity-50' : 'opacity-90' })}>
-                  {/* Tablet drag tab */}
-                  {isTablet && (
-                    <div
-                      data-drag-handle
-                      className={`relative flex-shrink-0 ${task.color} rounded-l-lg flex items-center pl-px cursor-grab active:opacity-70 text-white/70`}
-                      style={{ marginLeft: '-12px', marginRight: '-8px', marginTop: '3px', width: '20px', height: '24px', touchAction: 'none', zIndex: 10 }}
-                      onTouchStart={(e) => handleMobileTaskTouchStart(e, { ...task, isDeadlineDrag: true }, 'deadline')}
-                      onTouchMove={(e) => handleMobileTaskTouchMove(e)}
-                      onTouchEnd={(e) => handleMobileTaskTouchEnd(e, task.id, 'deadline')}
-                      onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                    >
-                      <div className="absolute top-0 left-0 h-full rounded-l-lg border-l-2 border-t-2 border-b-2 border-dashed border-white/60 pointer-events-none" style={{ width: '12px' }} />
-                      <div className="absolute top-0 border-t-2 border-dashed border-white/60 pointer-events-none" style={{ left: '12px', width: '2px' }} />
-                      <GripVertical size={14} />
-                    </div>
-                  )}
-                  <div className={`relative rounded-lg ${showDeadlinePicker === task.id ? '' : 'overflow-hidden'} ${isTablet ? 'flex-1 min-w-0' : ''}`}>
-                    <div
-                      data-task-id={task.id}
-                      data-ctx-menu
-                      draggable
-                      onDragStart={(e) => handleDragStart(task, 'inbox', e)}
-                      onDragEnd={handleDragEnd}
-                      onDragOver={(e) => { e.preventDefault(); updateDragAutoScroll(e); }}
-                      onDragEnter={(e) => { e.preventDefault(); setDragOverAllDay(group.dateStr); setDragPreviewTime(null); }}
-                      onDrop={(e) => handleDropOnDateHeader(e, group.date)}
-                      onContextMenu={(e) => {
-                        e.preventDefault();
-                        setTaskContextMenu({
-                          x: e.clientX, y: e.clientY,
-                          taskId: task.id,
-                          isRecurring: false,
-                          isImported: false,
-                          isAllDay: true,
-                          dateStr: group.dateStr,
-                        });
-                      }}
-                      onTouchStart={(e) => handleMobileTaskTouchStart(e, { ...task, isDeadlineDrag: true }, 'deadline')}
-                      onTouchMove={(e) => handleMobileTaskTouchMove(e)}
-                      onTouchEnd={(e) => handleMobileTaskTouchEnd(e, task.id, 'deadline')}
-                      className={`${task.color} rounded-lg shadow-sm cursor-move relative border-2 border-dashed border-white/60`}
-                      style={{ touchAction: 'pan-y' }}
-                    >
-                      {task.isExample && (
-                        <span className="absolute -top-2 -right-2 bg-yellow-400 text-yellow-900 text-[10px] font-bold px-1.5 py-0.5 rounded-full shadow-sm z-10">
-                          Example
-                        </span>
-                      )}
-                      <div className="p-2 text-white">
-                        <div className="flex items-center justify-between gap-2">
-                          <div className="flex items-center gap-2 flex-1 min-w-0">
-                            <button
-                              onClick={() => toggleComplete(task.id, true)}
-                              className={`rounded flex-shrink-0 ${task.completed ? 'bg-white/40' : 'bg-white/20'} border-2 border-white w-4 h-4 flex items-center justify-center hover:bg-white/30 transition-colors`}
-                            >
-                              {task.completed && <Check size={10} strokeWidth={3} />}
-                            </button>
-                            <AlertCircle size={14} className="flex-shrink-0" />
-                            <div
-                              className={`font-semibold text-sm truncate ${task.completed ? 'line-through' : ''}`}
-                              title={task.title}
-                            >
-                              {renderTitle(task.title)}
-                            </div>
-                          </div>
-                          <div className="flex items-center gap-0.5 flex-shrink-0">
-                            <button
-                              onMouseDown={() => {
-                                if (isLinkOnlyTask(task)) {
-                                  longPressTriggeredRef.current = false;
-                                  longPressTimerRef.current = setTimeout(() => {
-                                    longPressTriggeredRef.current = true;
-                                    setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
-                                  }, 500);
-                                }
-                              }}
-                              onMouseUp={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
-                              onMouseLeave={() => { if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current); }}
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                if (isLinkOnlyTask(task)) {
-                                  if (!longPressTriggeredRef.current) {
-                                    window.open(getLinkUrl(task), '_blank', 'noopener,noreferrer');
-                                  }
-                                  longPressTriggeredRef.current = false;
-                                } else {
-                                  setExpandedNotesTaskId(prev => prev === task.id ? null : task.id);
-                                }
-                              }}
-                              className={`notes-toggle-button hover:bg-white/20 rounded p-1 transition-colors ${hasNotesOrSubtasks(task) || extractWikilinks(task.title).length > 0 ? '' : 'opacity-40'}`}
-                              title={isLinkOnlyTask(task) ? `${getLinkUrl(task)} (hold to edit)` : 'Notes & subtasks'}
-                            >
-                              {isLinkOnlyTask(task) ? <ExternalLink size={14} /> : hasOnlySubtasks(task) ? <CheckSquare size={14} /> : isObsidianNoteOnlyTask(task) ? <BookOpen size={14} /> : <FileText size={14} />}
-                            </button>
-                            <button
-                              onClick={(e) => { e.stopPropagation(); postponeDeadlineTask(task.id); }}
-                              className="hover:bg-white/20 rounded p-1 transition-colors"
-                              title="Postpone to tomorrow"
-                            >
-                              <SkipForward size={14} />
-                            </button>
-                            <div className="deadline-picker-container relative">
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  setShowDeadlinePicker(showDeadlinePicker === task.id ? null : task.id);
-                                }}
-                                className="hover:bg-white/20 rounded p-1 transition-colors bg-white/20"
-                                title={`Deadline: ${formatDeadlineDate(task.deadline)}`}
-                              >
-                                <Calendar size={14} />
-                              </button>
-                              {showDeadlinePicker === task.id && (
-                                <DeadlinePickerPopover
-                                  taskId={task.id}
-                                  currentDeadline={task.deadline}
-                                  onClose={() => setShowDeadlinePicker(null)}
-                                />
-                              )}
-                            </div>
-                            {!isTablet && (
-                              <button
-                                onClick={() => openMobileEditTask(task, true)}
-                                className="hover:bg-white/20 rounded p-1 transition-colors"
-                                title="Edit"
-                              >
-                                <Pencil size={14} />
-                              </button>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                      {expandedNotesTaskId === task.id && (
-                        <div className="notes-panel-container">
-                          <NotesSubtasksPanel
-                            task={task}
-                            isInbox={true}
-                            darkMode={darkMode}
-                            updateTaskNotes={updateTaskNotes}
-                            addSubtask={addSubtask}
-                            toggleSubtask={toggleSubtask}
-                            deleteSubtask={deleteSubtask}
-                            updateSubtaskTitle={updateSubtaskTitle}
-                            aiConfig={aiConfig}
-                            aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
-                            onGenerateSubtasks={generateAISubtasks}
-                            wikilinks={extractWikilinks(task.title).length > 0 ? extractWikilinks(task.title) : undefined}
-                            onLoadWikiNote={extractWikilinks(task.title).length > 0 ? loadWikiNote : undefined}
-                            onSaveWikiNote={extractWikilinks(task.title).length > 0 ? saveWikiNote : undefined}
-                            onOpenInObsidian={extractWikilinks(task.title).length > 0 ? openInObsidian : undefined}
-                          />
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            ))}
 
             {/* Routine pills (today only) */}
             {routinesEnabled && group.dateStr === todayStr && todayRoutines.filter(r => r.isAllDay).map(routine => (


### PR DESCRIPTION
## Summary

- Deadline tasks were rendered as a separate full-width block below `GroupChips`, so they never participated in the `flex flex-wrap` layout and never got the `grow shrink-0 basis-[200px] max-w-[400px]` sizing that keeps task chips compact
- Folded deadline tasks into `GroupChips` as a unified `allItems` array (tasks first, then deadline tasks); both types now share the same flex-wrap, ghost overflow measurement, 2-row height cap, and "+N more" popover
- `DayViewAllDaySection` simplified: the separate deadline rendering loop is gone, and deadline-specific context values moved into `GroupChips` where they're used
- Ghost placeholder divs use the same `basis-[200px] max-w-[400px]` for all item types so the 2-row cap measures correctly across mixed content

## Test plan

- [ ] DAY view: deadline task chips appear inline with regular all-day chips at the same width (not full-width)
- [ ] DAY view: mix of tasks + deadline tasks wraps correctly at the same row height
- [ ] DAY view: when chips overflow 2 rows, "+N more" covers both task and deadline chips
- [ ] All deadline task actions (postpone, deadline picker, notes, complete, edit) still work
- [ ] Tablet swipe/drag still works on deadline chips
- [ ] Routine pills unaffected

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs