### PR TITLE
Add goal-met / limit-exceeded badges to HabitRing

### DIFF
--- a/src/components/HabitRing.jsx
+++ b/src/components/HabitRing.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RefreshCw, Target } from 'lucide-react';
+import { Check, RefreshCw, Target, X } from 'lucide-react';
 import { HABIT_ICONS, HABIT_COLORS } from '../constants/habits.js';
 
 const HabitRing = ({ size = 40, habit, count = 0, onClick, onContextMenu, onMouseDown, onMouseUp, onMouseLeave, onTouchStart, onTouchEnd, darkMode, autoSynced = false }) => {
@@ -81,6 +81,15 @@ const HabitRing = ({ size = 40, habit, count = 0, onClick, onContextMenu, onMous
         {autoSynced && (
           <div className="absolute -top-0.5 -right-0.5 w-3 h-3 rounded-full bg-green-500 flex items-center justify-center">
             <RefreshCw size={7} className="text-white" />
+          </div>
+        )}
+        {/* Goal-met (doMore) or limit-exceeded badge — bottom-right corner */}
+        {(showCheck || showX) && (
+          <div className={`absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 rounded-full flex items-center justify-center ${showCheck ? 'bg-green-500' : 'bg-red-500'}`}>
+            {showCheck
+              ? <Check size={8} className="text-white" strokeWidth={3} />
+              : <X size={8} className="text-white" strokeWidth={3} />
+            }
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- `doMore` habits now show a small green circle-check badge at the bottom-right of the ring when `count >= target`
- `limit` habits now show a small red circle-X badge when `count > target` (limit exceeded)
- Follows the same `absolute -bottom-0.5 -right-0.5 rounded-full` pattern as the existing auto-sync indicator (which sits at top-right, so they don't overlap)
- Both `Check` and `X` are 8px icons inside a 14px rounded-full coloured circle
- Affects all `HabitRing` usages: GLANCE sidebar rings and the Habit Summary modal (prior-day popup)

## Test plan

- [ ] GLANCE sidebar: doMore habit — badge appears when goal is met or exceeded, disappears when below target
- [ ] GLANCE sidebar: limit habit — red X badge appears when limit is exceeded, no badge when at or under limit
- [ ] Habit Summary modal (click a past date): same badges shown for historical counts
- [ ] Auto-synced habits: auto-sync dot (top-right) and goal badge (bottom-right) coexist without overlap
- [ ] No badge when doMore is in progress (below target) or limit is not exceeded

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs