### PR TITLE
Remove 60-min minimum on hyperGLANCE session duration

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -295,7 +295,7 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
   const [hgScheduledDays, setHgScheduledDays] = useState(initHG.scheduledDays || []);
   const [hgScheduledDate, setHgScheduledDate] = useState(initHG.scheduledDate || '');
   const [hgScheduledTime, setHgScheduledTime] = useState(initHG.scheduledTime || '09:00');
-  const [hgDuration, setHgDuration] = useState(Math.max(60, initHG.scheduledDuration || 60));
+  const [hgDuration, setHgDuration] = useState(initHG.scheduledDuration || 60);
   const [hgTemplateTasks, setHgTemplateTasks] = useState(initHG.templateTasks || []);
   const [hgNewTask, setHgNewTask] = useState('');
   const [editingTemplateTask, setEditingTemplateTask] = useState(null); // { id, name, notes }
@@ -338,7 +338,7 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
       scheduledDays: hgIsRecurring ? hgScheduledDays : [],
       scheduledDate: hgIsRecurring ? null : (hgScheduledDate || null),
       scheduledTime: hgScheduledTime,
-      scheduledDuration: Math.max(60, Math.round(hgDuration / 15) * 15),
+      scheduledDuration: Math.max(15, Math.round(hgDuration / 15) * 15),
       templateTasks: hgTemplateTasks,
       completions: initHG.completions || [],
       createdAt: initHG.createdAt || new Date().toISOString(),
@@ -606,7 +606,7 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
                 <div className="flex items-center gap-1.5">
                   <button
                     type="button"
-                    onClick={() => setHgDuration(d => Math.max(60, d - 15))}
+                    onClick={() => setHgDuration(d => Math.max(15, d - 15))}
                     className={`w-8 h-8 rounded-lg border ${borderClass} flex items-center justify-center text-base font-bold ${hoverBg} ${textPrimary} transition-colors`}
                   >−</button>
                   <span className={`text-sm font-medium ${textPrimary} w-14 text-center`}>{hgDuration}m</span>


### PR DESCRIPTION
## Summary

- Removes the hard 60-minute minimum from hyperGLANCE session duration
- Default remains 60 minutes for new sessions
- Minimum is now 15 minutes (one stepper step), so the `−` button can decrement all the way down to 15m

## Changes

`GoalDashboard.jsx` — three edits:
1. State initializer: `Math.max(60, initHG.scheduledDuration || 60)` → `initHG.scheduledDuration || 60` (removes floor while keeping 60m default)
2. Save handler: `Math.max(60, ...)` → `Math.max(15, ...)` (floor lowered to one step)
3. Decrement button: `Math.max(60, d - 15)` → `Math.max(15, d - 15)` (button can now go below 60m)

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs