### PR TITLE
Habit day-of-week scheduling

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -203,8 +203,10 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
   </div>
 
   {/* Habit rings row — pinned to top */}
-  {habitsEnabled && (
-    activeHabits.length === 0 ? (
+  {habitsEnabled && (() => {
+    const todayDow = new Date().getDay();
+    const todayHabits = activeHabits.filter(h => (h.scheduledDays ?? [0, 1, 2, 3, 4, 5, 6]).includes(todayDow));
+    if (activeHabits.length === 0) return (
       <div className={`rounded-lg border ${borderClass} p-3 cursor-pointer hover:opacity-80 transition-opacity`} onClick={() => setShowHabitModal(true)}>
         <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Habits</div>
         <div className="flex items-center gap-2">
@@ -212,7 +214,9 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
           <span className="text-xs text-teal-500 font-medium">+ Add</span>
         </div>
       </div>
-    ) : (
+    );
+    if (todayHabits.length === 0) return null;
+    return (
       <div className="relative">
         <button
           onClick={() => setShowHabitModal(true)}
@@ -222,7 +226,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
           <Settings size={11} />
         </button>
         <div className="flex items-start gap-1 justify-center">
-        {activeHabits.slice(0, 5).map((habit, habitIdx) => (
+        {todayHabits.slice(0, 5).map((habit, habitIdx) => (
           <div key={habit.id} className="relative">
             <HabitRing
               size={44}
@@ -240,7 +244,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
             {habitLongPressId === habit.id && (
               <>
                 <div className="fixed inset-0 z-40" onClick={() => { setHabitLongPressId(null); setHabitEditingCountId(null); }} />
-                <div className={`absolute top-full mt-1 z-50 ${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'} border rounded-xl shadow-xl p-3 min-w-[140px] ${habitIdx === 0 ? 'left-0' : habitIdx === Math.min(activeHabits.length, 5) - 1 ? 'right-0' : 'left-1/2 -translate-x-1/2'}`}>
+                <div className={`absolute top-full mt-1 z-50 ${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'} border rounded-xl shadow-xl p-3 min-w-[140px] ${habitIdx === 0 ? 'left-0' : habitIdx === Math.min(todayHabits.length, 5) - 1 ? 'right-0' : 'left-1/2 -translate-x-1/2'}`}>
                   <div className={`text-xs font-semibold mb-2 text-center ${darkMode ? 'text-gray-300' : 'text-stone-700'}`}>{habit.name}</div>
                   <div className="flex items-center justify-center gap-3">
                     <button onClick={() => { setHabitCount(habit.id, getTodayHabitCount(habit.id) - 1); }} className={`w-8 h-8 rounded-full flex items-center justify-center ${darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-100 text-stone-600 active:bg-stone-200'}`}><Minus size={16} /></button>
@@ -266,19 +270,19 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
             )}
           </div>
         ))}
-        {activeHabits.length > 5 && (
+        {todayHabits.length > 5 && (
           <div className="relative">
             <button
               onClick={() => setHabitOverflowOpen(prev => !prev)}
               className={`w-[52px] h-[44px] flex items-center justify-center rounded-lg text-xs font-bold ${darkMode ? 'bg-gray-700 text-gray-400 active:bg-gray-600' : 'bg-stone-100 text-stone-500 active:bg-stone-200'} transition-colors`}
             >
-              +{activeHabits.length - 5}
+              +{todayHabits.length - 5}
             </button>
             {habitOverflowOpen && (
               <>
                 <div className="fixed inset-0 z-40" onClick={() => setHabitOverflowOpen(false)} />
                 <div className={`absolute top-full right-0 mt-1 z-50 ${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'} border rounded-xl shadow-xl p-2 min-w-[180px]`}>
-                  {activeHabits.slice(5).map(habit => {
+                  {todayHabits.slice(5).map(habit => {
                     const count = getTodayHabitCount(habit.id);
                     const IconComp = HABIT_ICONS[habit.icon] || Target;
                     const colorObj = HABIT_COLORS.find(c => c.name === habit.color) || HABIT_COLORS[0];
@@ -301,8 +305,8 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
         )}
         </div>
       </div>
-    )
-  )}
+    );
+  })()}
 
   {/* Goals due today */}
   {goalsProjectsEnabled && (() => {

--- a/src/components/HabitModal.jsx
+++ b/src/components/HabitModal.jsx
@@ -105,6 +105,44 @@ const HabitModal = () => {
                     </div>
                   </div>
 
+                  {/* Scheduled days -- hidden for auto-synced habits */}
+                  {editingHabit.source !== 'healthConnect' && (() => {
+                    const DOW_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+                    const days = editingHabit.scheduledDays ?? [0, 1, 2, 3, 4, 5, 6];
+                    return (
+                      <div>
+                        <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Active days</label>
+                        <div className="flex gap-1.5">
+                          {DOW_LABELS.map((label, idx) => {
+                            const active = days.includes(idx);
+                            return (
+                              <button
+                                key={idx}
+                                type="button"
+                                onClick={() => {
+                                  if (active && days.length === 1) return; // keep at least one
+                                  setEditingHabit(prev => ({
+                                    ...prev,
+                                    scheduledDays: active
+                                      ? days.filter(d => d !== idx)
+                                      : [...days, idx].sort((a, b) => a - b),
+                                  }));
+                                }}
+                                className="w-9 h-9 rounded-lg text-sm font-semibold transition-colors flex-shrink-0"
+                                style={active
+                                  ? { backgroundColor: '#fe8b00', color: '#fff' }
+                                  : { backgroundColor: darkMode ? '#374151' : '#f1f0ef', color: darkMode ? '#9ca3af' : '#78716c' }
+                                }
+                              >
+                                {label}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })()}
+
                   {/* Icon picker */}
                   <div>
                     <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Icon</label>
@@ -212,6 +250,16 @@ const HabitModal = () => {
                           <div className={`text-xs ${textSecondary}`}>
                             {habit.type === 'doMore' ? 'Goal' : 'Limit'}: {habit.target} {habit.unit}
                           </div>
+                          {(() => {
+                            const days = habit.scheduledDays ?? [0, 1, 2, 3, 4, 5, 6];
+                            if (days.length === 7) return null;
+                            const names = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+                            return (
+                              <div className={`text-xs ${textSecondary} opacity-70`}>
+                                {days.map(d => names[d]).join(', ')}
+                              </div>
+                            );
+                          })()}
                         </div>
                         <div className="flex items-center gap-1">
                           {idx > 0 && (
@@ -240,7 +288,7 @@ const HabitModal = () => {
               {/* Add button */}
               {activeHabits.length < 8 && (
                 <button
-                  onClick={() => setEditingHabit({ name: '', icon: 'Droplets', color: 'blue', type: 'doMore', target: 8, unit: '' })}
+                  onClick={() => setEditingHabit({ name: '', icon: 'Droplets', color: 'blue', type: 'doMore', target: 8, unit: '', scheduledDays: [0, 1, 2, 3, 4, 5, 6] })}
                   className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border-2 border-dashed border-blue-500/30 text-blue-500 text-sm font-medium hover:bg-blue-500/5 transition-colors"
                 >
                   <Plus size={16} />

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -141,8 +141,10 @@ const MobileGlanceSection = () => {
     )}
   </div>
   {/* Habit rings row — pinned to top */}
-  {habitsEnabled && (
-    activeHabits.length === 0 ? (
+  {habitsEnabled && (() => {
+    const todayDow = new Date().getDay();
+    const todayHabits = activeHabits.filter(h => (h.scheduledDays ?? [0, 1, 2, 3, 4, 5, 6]).includes(todayDow));
+    if (activeHabits.length === 0) return (
       <div className={`mb-4 rounded-lg border ${borderClass} p-3 cursor-pointer active:opacity-70 transition-opacity`} onClick={() => { setMobileActiveTab('settings'); setMobileSettingsView('habits'); }}>
         <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Habits</div>
         <div className="flex items-center gap-2">
@@ -150,7 +152,9 @@ const MobileGlanceSection = () => {
           <span className="text-xs text-teal-500 font-medium">+ Add</span>
         </div>
       </div>
-    ) : (
+    );
+    if (todayHabits.length === 0) return null;
+    return (
       <div className="mb-4 relative">
         <button
           onClick={() => { setMobileActiveTab('settings'); setMobileSettingsView('habits'); }}
@@ -160,7 +164,7 @@ const MobileGlanceSection = () => {
           <Settings size={11} />
         </button>
         <div className="flex items-start gap-1 justify-center">
-        {activeHabits.slice(0, 5).map((habit, habitIdx) => (
+        {todayHabits.slice(0, 5).map((habit, habitIdx) => (
           <div key={habit.id} className="relative">
             <HabitRing
               size={44}
@@ -179,7 +183,7 @@ const MobileGlanceSection = () => {
             {habitLongPressId === habit.id && (
               <>
                 <div className="fixed inset-0 z-40" onClick={() => { if (habitLongPressOpenedAt.current && Date.now() - habitLongPressOpenedAt.current < 300) return; setHabitLongPressId(null); setHabitEditingCountId(null); }} />
-                <div className={`absolute top-full mt-1 z-50 ${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'} border rounded-xl shadow-xl p-3 min-w-[140px] ${habitIdx === 0 ? 'left-0' : habitIdx === Math.min(activeHabits.length, 5) - 1 ? 'right-0' : 'left-1/2 -translate-x-1/2'}`}>
+                <div className={`absolute top-full mt-1 z-50 ${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'} border rounded-xl shadow-xl p-3 min-w-[140px] ${habitIdx === 0 ? 'left-0' : habitIdx === Math.min(todayHabits.length, 5) - 1 ? 'right-0' : 'left-1/2 -translate-x-1/2'}`}>
                   <div className={`text-xs font-semibold mb-2 text-center ${darkMode ? 'text-gray-300' : 'text-stone-700'}`}>{habit.name}</div>
                   <div className="flex items-center justify-center gap-3">
                     <button onClick={() => { setHabitCount(habit.id, getTodayHabitCount(habit.id) - 1); }} className={`w-8 h-8 rounded-full flex items-center justify-center ${darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-100 text-stone-600 active:bg-stone-200'}`}><Minus size={16} /></button>
@@ -205,19 +209,19 @@ const MobileGlanceSection = () => {
             )}
           </div>
         ))}
-        {activeHabits.length > 5 && (
+        {todayHabits.length > 5 && (
           <div className="relative">
             <button
               onClick={() => setHabitOverflowOpen(prev => !prev)}
               className={`w-[52px] h-[44px] flex items-center justify-center rounded-lg text-xs font-bold ${darkMode ? 'bg-gray-700 text-gray-400 active:bg-gray-600' : 'bg-stone-100 text-stone-500 active:bg-stone-200'} transition-colors`}
             >
-              +{activeHabits.length - 5}
+              +{todayHabits.length - 5}
             </button>
             {habitOverflowOpen && (
               <>
                 <div className="fixed inset-0 z-40" onClick={() => setHabitOverflowOpen(false)} />
                 <div className={`absolute top-full right-0 mt-1 z-50 ${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'} border rounded-xl shadow-xl p-2 min-w-[180px]`}>
-                  {activeHabits.slice(5).map(habit => {
+                  {todayHabits.slice(5).map(habit => {
                     const count = getTodayHabitCount(habit.id);
                     const IconComp = HABIT_ICONS[habit.icon] || Target;
                     const colorObj = HABIT_COLORS.find(c => c.name === habit.color) || HABIT_COLORS[0];
@@ -240,8 +244,8 @@ const MobileGlanceSection = () => {
         )}
         </div>
       </div>
-    )
-  )}
+    );
+  })()}
 
   {/* Goals due today */}
   {goalsProjectsEnabled && (() => {

--- a/src/hooks/useDataPersistence.js
+++ b/src/hooks/useDataPersistence.js
@@ -126,7 +126,13 @@ export default function useDataPersistence({
 
       // Load habit tracking data
       const habitsData = localStorage.getItem('day-planner-habits');
-      if (habitsData) setHabits(JSON.parse(habitsData));
+      if (habitsData) {
+        const parsedHabits = JSON.parse(habitsData).map(h =>
+          h.scheduledDays ? h : { ...h, scheduledDays: [0, 1, 2, 3, 4, 5, 6] }
+        );
+        localStorage.setItem('day-planner-habits', JSON.stringify(parsedHabits));
+        setHabits(parsedHabits);
+      }
       const habitLogsData = localStorage.getItem('day-planner-habit-logs');
       if (habitLogsData) setHabitLogs(JSON.parse(habitLogsData));
       const habitsEnabledData = localStorage.getItem('day-planner-habits-enabled');

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -50,7 +50,11 @@ const useHabits = ({ playUISound }) => {
     return () => document.removeEventListener('keydown', handler);
   }, [showHabitModal]);
 
-  const activeHabits = useMemo(() => habits.filter(h => !h.archived), [habits]);
+  const activeHabits = useMemo(() =>
+    habits.filter(h => !h.archived).map(h =>
+      h.scheduledDays ? h : { ...h, scheduledDays: [0, 1, 2, 3, 4, 5, 6] }
+    ),
+  [habits]);
 
   // Compute habit streaks: { habitId: { current, best } }
   const habitStreaks = useMemo(() => {
@@ -58,6 +62,7 @@ const useHabits = ({ playUISound }) => {
     const today = new Date();
     today.setHours(12, 0, 0, 0);
     for (const habit of activeHabits) {
+      const scheduledDays = habit.scheduledDays ?? [0, 1, 2, 3, 4, 5, 6];
       let current = 0;
       let best = 0;
       let streak = 0;
@@ -66,6 +71,8 @@ const useHabits = ({ playUISound }) => {
       for (let i = 0; i < 365; i++) {
         const d = new Date(today);
         d.setDate(d.getDate() - i);
+        // Skip days not in the habit's schedule -- they neither extend nor break
+        if (!scheduledDays.includes(d.getDay())) continue;
         const ds = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
         const count = habitLogs[ds]?.[habit.id] || 0;
         // Don't count days before the habit was created
@@ -209,6 +216,7 @@ const useHabits = ({ playUISound }) => {
       target: 10000,
       unit: 'steps',
       source: 'healthConnect',
+      scheduledDays: [0, 1, 2, 3, 4, 5, 6],
     });
   };
 
@@ -224,6 +232,7 @@ const useHabits = ({ playUISound }) => {
       target: 480,
       unit: 'min',
       source: 'healthConnect',
+      scheduledDays: [0, 1, 2, 3, 4, 5, 6],
     });
   };
 


### PR DESCRIPTION
## Summary

- Adds `scheduledDays: number[]` (0-6, Sun-Sat) to the habit model. No new enum field. Fully backwards compatible.
- Read-time migration: any loaded habit missing `scheduledDays` gets `[0,1,2,3,4,5,6]` -- existing habits and streaks are preserved.
- GLANCE panel (desktop + mobile) filters rings to only habits scheduled for today's day-of-week. Habits not scheduled today disappear entirely -- no placeholder, no greyed state. If zero habits are scheduled today the whole row hides.
- Manage Habits list shows a subtle `Mon, Wed, Fri`-style subtitle beneath each habit when its schedule is not daily.
- Edit/Add form: a 7-button `S M T W T F S` toggle row appears below the goal/limit input. Orange (`#fe8b00`) for active days, muted for inactive. At least one day must stay selected (pressing the last active button is a no-op). Row is hidden for Health Connect auto-synced habits (Steps, Sleep).
- Streak logic skips non-scheduled days: the walk-back loop uses `continue` for out-of-schedule days, so they neither extend nor break a streak.

## Files changed

| File | Change |
|---|---|
| `src/hooks/useDataPersistence.js` | Normalize `scheduledDays` on load from localStorage |
| `src/hooks/useHabits.js` | Normalize in `activeHabits` memo; skip non-scheduled days in streak loop; add `scheduledDays` to `addStepsHabit`/`addSleepHabit` defaults |
| `src/components/HabitModal.jsx` | Day-toggle row in edit form; schedule subtitle in list; updated "Add Habit" default |
| `src/components/GlanceSidebar.jsx` | Filter rings by `todayDow` using IIFE pattern |
| `src/components/MobileGlanceSection.jsx` | Same filter as sidebar |

## Testing checklist

- [ ] New habit: toggle opens with all 7 days on; orange highlight matches `#fe8b00`; cannot deselect last day
- [ ] Habit set to Mon/Wed/Fri: rings hidden on Tue/Thu/Sat/Sun; appear on scheduled days
- [ ] Health Connect habit (Steps/Sleep): day toggle not shown in edit form
- [ ] Manage Habits: "Mon, Wed, Fri" subtitle shows for non-daily habit; no subtitle for daily habit
- [ ] Streak: day off a habit's schedule does not reset a streak built on scheduled days
- [ ] Existing habits loaded from localStorage without `scheduledDays`: migrated to `[0..6]`, no visual change
- [ ] Restore from backup: habits without `scheduledDays` get migrated; streaks preserved
- [ ] 6+ habits scheduled today: overflow `+N` button still shows correct count

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs