### PR TITLE
Apply scheduledDays DOW filter to prior-day habit displays

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8423,7 +8423,7 @@ const DayPlanner = () => {
               <button onClick={() => setHabitDayPopup(null)} className={`${textSecondary} hover:${textPrimary} transition-colors`}><X size={18} /></button>
             </div>
             <div className="flex flex-wrap gap-3 justify-center">
-              {activeHabits.map(habit => (
+              {activeHabits.filter(h => (h.scheduledDays ?? [0,1,2,3,4,5,6]).includes(new Date(habitDayPopup + 'T12:00:00').getDay())).map(habit => (
                 <div key={habit.id} className="flex flex-col items-center gap-1">
                   <div className="pointer-events-none">
                     <HabitRing

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -254,7 +254,7 @@ const CalendarHeader = () => {
         </div>
         {habitsEnabled && !isDateToday && dateStr < dateToString(new Date()) && habitLogs[dateStr] && activeHabits.length > 0 && (
           <div className="flex items-center justify-center gap-0.5 mt-0.5 cursor-pointer" onClick={(e) => { e.stopPropagation(); setHabitDayPopup(dateStr); }}>
-            {activeHabits.slice(0, 6).map(habit => (
+            {activeHabits.filter(h => (h.scheduledDays ?? [0,1,2,3,4,5,6]).includes(new Date(dateStr + 'T12:00:00').getDay())).slice(0, 6).map(habit => (
               <MiniHabitRing key={habit.id} habit={habit} count={habitLogs[dateStr]?.[habit.id] || 0} darkMode={darkMode} />
             ))}
           </div>

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -741,7 +741,7 @@ const MobileLayout = () => {
                           </div>
                           {habitsEnabled && !isDateToday && dateStr < dateToString(new Date()) && habitLogs[dateStr] && activeHabits.length > 0 && (
                             <div className="flex items-center justify-center gap-0.5 mt-0.5 cursor-pointer" onClick={(e) => { e.stopPropagation(); setHabitDayPopup(dateStr); }}>
-                              {activeHabits.slice(0, 6).map(habit => (
+                              {activeHabits.filter(h => (h.scheduledDays ?? [0,1,2,3,4,5,6]).includes(new Date(dateStr + 'T12:00:00').getDay())).slice(0, 6).map(habit => (
                                 <MiniHabitRing key={habit.id} habit={habit} count={habitLogs[dateStr]?.[habit.id] || 0} darkMode={darkMode} />
                               ))}
                             </div>


### PR DESCRIPTION
## Summary

Follow-up to #567. Applies the same `scheduledDays` day-of-week filter to the three prior-day habit surfaces that were missed in the original PR:

- **WEEK view column headers** (`CalendarHeader.jsx`) -- mini rings under past date headers now only show habits scheduled for that date's day-of-week
- **Mobile calendar headers** (`MobileLayout.jsx`) -- same
- **Prior-day habit summary popup** (`App.jsx`) -- the full-size popup opened by tapping a mini-rings row now only shows habits that were scheduled for that day

Filter: `activeHabits.filter(h => (h.scheduledDays ?? [0,1,2,3,4,5,6]).includes(new Date(dateStr + 'T12:00:00').getDay()))`

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs