### PR TITLE
Apply scheduledDays DOW filter to DAY mode date header mini rings

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -326,7 +326,7 @@ const CalendarHeader = () => {
           </div>
           {habitsEnabled && !isDateToday && group.dateStr < dateToString(new Date()) && habitLogs[group.dateStr] && activeHabits.length > 0 && (
             <div className="flex items-center justify-center gap-0.5 mt-0.5 cursor-pointer" onClick={(e) => { e.stopPropagation(); setHabitDayPopup(group.dateStr); }}>
-              {activeHabits.slice(0, 6).map(habit => (
+              {activeHabits.filter(h => (h.scheduledDays ?? [0,1,2,3,4,5,6]).includes(new Date(group.dateStr + 'T12:00:00').getDay())).slice(0, 6).map(habit => (
                 <MiniHabitRing key={habit.id} habit={habit} count={habitLogs[group.dateStr]?.[habit.id] || 0} darkMode={darkMode} />
               ))}
             </div>


### PR DESCRIPTION
## Summary

Pre-merge review catch. The DAY mode date-group mini rings in `CalendarHeader.jsx` (added in PR #507, before habit scheduling existed) were missed in the DOW filter pass from PR #568.

All five other habit-ring surfaces already had the filter applied:
- WEEK mode column headers (PR #568)
- Mobile calendar headers (PR #568)
- Prior-day habit summary popup (PR #568)
- Desktop GLANCE sidebar (PR #567)
- Mobile GLANCE section (PR #567)

One-line fix: add `.filter(h => (h.scheduledDays ?? [0,1,2,3,4,5,6]).includes(new Date(group.dateStr + 'T12:00:00').getDay()))` before `.slice(0, 6)`.

https://claude.ai/code/session_0159NEEc5YEmN5BXNwGhuWCs