### PR TITLE
Mobile habits: add day-of-week active days picker

### DIFF
--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -1566,6 +1566,43 @@ const MobileSettingsPanel = () => {
                       />
                     </div>
                   </div>
+                  {/* Scheduled days -- hidden for auto-synced habits */}
+                  {editingHabit.source !== 'healthConnect' && (() => {
+                    const DOW_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+                    const days = editingHabit.scheduledDays ?? [0, 1, 2, 3, 4, 5, 6];
+                    return (
+                      <div>
+                        <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Active days</label>
+                        <div className="flex gap-1.5">
+                          {DOW_LABELS.map((label, idx) => {
+                            const active = days.includes(idx);
+                            return (
+                              <button
+                                key={idx}
+                                type="button"
+                                onClick={() => {
+                                  if (active && days.length === 1) return;
+                                  setEditingHabit(prev => ({
+                                    ...prev,
+                                    scheduledDays: active
+                                      ? days.filter(d => d !== idx)
+                                      : [...days, idx].sort((a, b) => a - b),
+                                  }));
+                                }}
+                                className="w-9 h-9 rounded-lg text-sm font-semibold transition-colors flex-shrink-0"
+                                style={active
+                                  ? { backgroundColor: '#fe8b00', color: '#fff' }
+                                  : { backgroundColor: darkMode ? '#374151' : '#f1f0ef', color: darkMode ? '#9ca3af' : '#78716c' }
+                                }
+                              >
+                                {label}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })()}
                   <div>
                     <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Icon</label>
                     <div className="flex flex-wrap gap-2">
@@ -1649,6 +1686,16 @@ const MobileSettingsPanel = () => {
                             )}
                           </div>
                           <div className={`text-xs ${textSecondary}`}>{habit.type === 'doMore' ? 'Goal' : 'Limit'}: {habit.target} {habit.unit}</div>
+                          {(() => {
+                            const days = habit.scheduledDays ?? [0, 1, 2, 3, 4, 5, 6];
+                            if (days.length === 7) return null;
+                            const names = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+                            return (
+                              <div className={`text-xs ${textSecondary} opacity-70`}>
+                                {days.map(d => names[d]).join(', ')}
+                              </div>
+                            );
+                          })()}
                         </div>
                         <div className="flex items-center gap-1">
                           {idx > 0 && (
@@ -1667,7 +1714,7 @@ const MobileSettingsPanel = () => {
               )}
               {activeHabits.length < 8 && (
                 <button
-                  onClick={() => setEditingHabit({ name: '', icon: 'Droplets', color: 'blue', type: 'doMore', target: 8, unit: '' })}
+                  onClick={() => setEditingHabit({ name: '', icon: 'Droplets', color: 'blue', type: 'doMore', target: 8, unit: '', scheduledDays: [0, 1, 2, 3, 4, 5, 6] })}
                   className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border-2 border-dashed border-blue-500/30 text-blue-500 text-sm font-medium hover:bg-blue-500/5 transition-colors"
                 >
                   <Plus size={16} />


### PR DESCRIPTION
## Summary

- Adds the **Active days** S/M/T/W/T/F/S toggle row to the mobile habit edit form (`MobileSettingsPanel`), matching the desktop `HabitModal` implementation exactly
- Initializes `scheduledDays: [0,1,2,3,4,5,6]` when tapping **Add Habit** on mobile (was missing, so new habits had no `scheduledDays` set)
- Shows the active-days summary line below Goal/Limit in the habit list for habits not scheduled every day — same behaviour as desktop

Health Connect auto-synced habits continue to hide the picker on both platforms.

## Test plan

- [ ] Open mobile settings → Habits → Add Habit: confirm the day-of-week row appears with all 7 days highlighted in orange
- [ ] Toggle individual days off/on; verify at least one day is always required
- [ ] Save the habit and confirm the active-days line appears in the list (e.g. "Mon, Wed, Fri")
- [ ] Edit an existing habit that has no `scheduledDays` saved; verify it defaults to all 7 days selected
- [ ] Habits sourced from Health Connect should not show the picker
- [ ] Desktop habit modal behaviour unchanged

https://claude.ai/code/session_011fZ8vLiYfjnAK8cFAom99f