### PR TITLE
feat: Stream Deck+ plugin scaffold

### DIFF
--- a/stream-deck-plugin/.gitignore
+++ b/stream-deck-plugin/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+com.dayglance.streamdeck.sdPlugin/bin/
+*.js.map

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/focus.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/focus.json
@@ -1,0 +1,28 @@
+{
+  "id": "focus-layout",
+  "items": [
+    {
+      "key": "title",
+      "type": "text",
+      "rect": [16, 8, 200, 24],
+      "alignment": "left",
+      "font": { "size": 14, "weight": 600 }
+    },
+    {
+      "key": "value",
+      "type": "text",
+      "rect": [16, 36, 200, 40],
+      "alignment": "left",
+      "font": { "size": 28, "weight": 700 },
+      "color": "#fe8b00"
+    },
+    {
+      "key": "indicator",
+      "type": "progressBar",
+      "rect": [16, 82, 700, 10],
+      "bar_bg_c": "2C2C2C",
+      "bar_fill_c": "fe8b00",
+      "bar_border_c": "2C2C2C"
+    }
+  ]
+}

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/goal-progress.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/goal-progress.json
@@ -1,0 +1,27 @@
+{
+  "id": "goal-progress-layout",
+  "items": [
+    {
+      "key": "title",
+      "type": "text",
+      "rect": [16, 8, 500, 24],
+      "alignment": "left",
+      "font": { "size": 13, "weight": 600 }
+    },
+    {
+      "key": "value",
+      "type": "text",
+      "rect": [16, 36, 200, 40],
+      "alignment": "left",
+      "font": { "size": 28, "weight": 700 }
+    },
+    {
+      "key": "indicator",
+      "type": "progressBar",
+      "rect": [16, 82, 700, 10],
+      "bar_bg_c": "2C2C2C",
+      "bar_fill_c": "FFFFFF",
+      "bar_border_c": "2C2C2C"
+    }
+  ]
+}

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -1,0 +1,111 @@
+{
+  "Name": "dayGLANCE",
+  "Version": "0.0.1",
+  "Author": "dayGLANCE",
+  "Description": "Agenda, focus, tasks, and goals on your Stream Deck+.",
+  "Category": "dayGLANCE",
+  "CategoryIcon": "imgs/plugin/category-icon",
+  "Icon": "imgs/plugin/icon",
+  "CodePath": "bin/plugin.js",
+  "SDKVersion": 2,
+  "Software": {
+    "MinimumVersion": "6.5"
+  },
+  "OS": [
+    { "Platform": "mac", "MinimumVersion": "12" },
+    { "Platform": "windows", "MinimumVersion": "10" }
+  ],
+  "Nodejs": {
+    "Version": "20",
+    "Debug": "enabled"
+  },
+  "Actions": [
+    {
+      "Name": "Agenda",
+      "UUID": "app.dayglance.streamdeck.agenda",
+      "Icon": "imgs/actions/agenda/icon",
+      "Tooltip": "Scrollable agenda strip — shows current and next events.",
+      "Controllers": ["Encoder", "Keypad"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Rotate": "Scroll agenda forward / back",
+          "Push": "Open event detail"
+        }
+      },
+      "States": [
+        { "Image": "imgs/actions/agenda/key", "TitleAlignment": "bottom" }
+      ]
+    },
+    {
+      "Name": "Focus / Pomodoro",
+      "UUID": "app.dayglance.streamdeck.focus",
+      "Icon": "imgs/actions/focus/icon",
+      "Tooltip": "Start, stop, or adjust the Pomodoro timer. Stays in sync with dayGLANCE focus mode.",
+      "Controllers": ["Encoder", "Keypad"],
+      "Encoder": {
+        "layout": "layouts/focus.json",
+        "TriggerDescription": {
+          "Rotate": "Adjust session duration",
+          "Push": "Start / stop session",
+          "TouchTap": "Switch work / break"
+        }
+      },
+      "States": [
+        { "Image": "imgs/actions/focus/key-idle" },
+        { "Image": "imgs/actions/focus/key-active" }
+      ]
+    },
+    {
+      "Name": "Next Task",
+      "UUID": "app.dayglance.streamdeck.next-task",
+      "Icon": "imgs/actions/next-task/icon",
+      "Tooltip": "Shows your next due task. Press to complete, long-press to snooze.",
+      "Controllers": ["Encoder", "Keypad"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Rotate": "Browse tasks",
+          "Push": "Complete task"
+        }
+      },
+      "States": [
+        { "Image": "imgs/actions/next-task/key", "TitleAlignment": "bottom" }
+      ]
+    },
+    {
+      "Name": "Goal Progress",
+      "UUID": "app.dayglance.streamdeck.goal-progress",
+      "Icon": "imgs/actions/goal-progress/icon",
+      "Tooltip": "Cycles through active goals with arc progress indicator.",
+      "Controllers": ["Encoder", "Keypad"],
+      "Encoder": {
+        "layout": "layouts/goal-progress.json",
+        "TriggerDescription": {
+          "Rotate": "Cycle goals",
+          "Push": "Toggle goal detail"
+        }
+      },
+      "States": [
+        { "Image": "imgs/actions/goal-progress/key", "TitleAlignment": "bottom" }
+      ]
+    },
+    {
+      "Name": "Quick Glance",
+      "UUID": "app.dayglance.streamdeck.quick-glance",
+      "Icon": "imgs/actions/quick-glance/icon",
+      "Tooltip": "Rotates between date, weather, and next event.",
+      "Controllers": ["Encoder", "Keypad"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Rotate": "Cycle display mode",
+          "Push": "Pin current mode"
+        }
+      },
+      "States": [
+        { "Image": "imgs/actions/quick-glance/key", "TitleAlignment": "bottom" }
+      ]
+    }
+  ]
+}

--- a/stream-deck-plugin/package.json
+++ b/stream-deck-plugin/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dayglance-streamdeck",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rollup -c --bundleConfigAsCjs",
+    "watch": "rollup -cw --bundleConfigAsCjs",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@elgato/streamdeck": "^1.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^25.0.0",
+    "@rollup/plugin-node-resolve": "^15.0.0",
+    "@rollup/plugin-typescript": "^11.0.0",
+    "rollup": "^4.0.0",
+    "tslib": "^2.6.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/stream-deck-plugin/rollup.config.mjs
+++ b/stream-deck-plugin/rollup.config.mjs
@@ -1,0 +1,18 @@
+import commonjs from "@rollup/plugin-commonjs";
+import resolve from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+
+export default {
+  input: "src/plugin.ts",
+  output: {
+    file: "com.dayglance.streamdeck.sdPlugin/bin/plugin.js",
+    format: "cjs",
+    sourcemap: true,
+  },
+  plugins: [
+    resolve({ browser: false }),
+    commonjs(),
+    typescript({ tsconfig: "./tsconfig.json" }),
+  ],
+  external: [],
+};

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -1,0 +1,35 @@
+import {
+  action,
+  DialRotateEvent,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+} from "@elgato/streamdeck";
+
+type Settings = {
+  instanceUrl: string;
+  apiToken: string;
+};
+
+@action({ UUID: "app.dayglance.streamdeck.agenda" })
+export class AgendaAction extends SingletonAction<Settings> {
+  private scrollOffset = 0;
+
+  override async onWillAppear(ev: WillAppearEvent<Settings>): Promise<void> {
+    await this.refresh(ev.action.getSettings());
+  }
+
+  override async onDialRotate(ev: DialRotateEvent<Settings>): Promise<void> {
+    this.scrollOffset = Math.max(0, this.scrollOffset + ev.payload.ticks);
+    await this.refresh(ev.action.getSettings());
+  }
+
+  override async onKeyDown(ev: KeyDownEvent<Settings>): Promise<void> {
+    this.scrollOffset = Math.max(0, this.scrollOffset + 1);
+    await this.refresh(ev.action.getSettings());
+  }
+
+  private async refresh(_settings: Promise<Settings>): Promise<void> {
+    // TODO: fetch today's events from dayGLANCE backend and render to touch bar
+  }
+}

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -1,0 +1,102 @@
+import {
+  action,
+  DialRotateEvent,
+  DialUpEvent,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+} from "@elgato/streamdeck";
+
+type Settings = {
+  instanceUrl: string;
+  apiToken: string;
+  sessionDurationMinutes: number;
+};
+
+type Phase = "idle" | "work" | "break";
+
+@action({ UUID: "app.dayglance.streamdeck.focus" })
+export class FocusAction extends SingletonAction<Settings> {
+  private phase: Phase = "idle";
+  private remainingSeconds = 0;
+  private sessionCount = 0;
+  private tickInterval: ReturnType<typeof setInterval> | undefined;
+
+  override async onWillAppear(ev: WillAppearEvent<Settings>): Promise<void> {
+    const settings = await ev.action.getSettings();
+    await ev.action.setTitle(this.buildTitle());
+    // TODO: poll dayGLANCE backend for current focus state and sync
+    void settings;
+  }
+
+  override async onDialRotate(ev: DialRotateEvent<Settings>): Promise<void> {
+    if (this.phase !== "idle") return;
+    const settings = await ev.action.getSettings();
+    const delta = ev.payload.ticks;
+    const newDuration = Math.max(5, (settings.sessionDurationMinutes ?? 25) + delta);
+    await ev.action.setSettings({ ...settings, sessionDurationMinutes: newDuration });
+    await ev.action.setTitle(`${newDuration}m`);
+  }
+
+  override async onDialUp(ev: DialUpEvent<Settings>): Promise<void> {
+    await this.toggleSession(ev.action);
+  }
+
+  override async onKeyDown(ev: KeyDownEvent<Settings>): Promise<void> {
+    await this.toggleSession(ev.action);
+  }
+
+  private async toggleSession(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    actionRef: any
+  ): Promise<void> {
+    if (this.phase === "idle") {
+      const settings: Settings = await actionRef.getSettings();
+      this.phase = "work";
+      this.remainingSeconds = (settings.sessionDurationMinutes ?? 25) * 60;
+      this.startTick(actionRef);
+      // TODO: POST to dayGLANCE backend to start focus mode
+    } else {
+      this.stopTick();
+      this.phase = "idle";
+      await actionRef.setState(0);
+      await actionRef.setTitle("Focus");
+      // TODO: POST to dayGLANCE backend to end focus mode
+    }
+  }
+
+  private startTick(actionRef: unknown): void {
+    this.tickInterval = setInterval(async () => {
+      this.remainingSeconds--;
+      if (this.remainingSeconds <= 0) {
+        this.stopTick();
+        if (this.phase === "work") {
+          this.sessionCount++;
+          this.phase = "break";
+          this.remainingSeconds = 5 * 60;
+          this.startTick(actionRef);
+        } else {
+          this.phase = "idle";
+        }
+      }
+      // @ts-expect-error actionRef typed as unknown for simplicity
+      await actionRef.setTitle(this.buildTitle());
+    }, 1000);
+  }
+
+  private stopTick(): void {
+    if (this.tickInterval !== undefined) {
+      clearInterval(this.tickInterval);
+      this.tickInterval = undefined;
+    }
+  }
+
+  private buildTitle(): string {
+    if (this.phase === "idle") return "Focus";
+    const m = Math.floor(this.remainingSeconds / 60);
+    const s = this.remainingSeconds % 60;
+    const tomatoes = "🍅".repeat(this.sessionCount);
+    const label = this.phase === "work" ? "Work" : "Break";
+    return `${label}\n${m}:${s.toString().padStart(2, "0")}\n${tomatoes}`;
+  }
+}

--- a/stream-deck-plugin/src/actions/goal-progress.ts
+++ b/stream-deck-plugin/src/actions/goal-progress.ts
@@ -1,0 +1,37 @@
+import {
+  action,
+  DialRotateEvent,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+} from "@elgato/streamdeck";
+
+type Settings = {
+  instanceUrl: string;
+  apiToken: string;
+};
+
+@action({ UUID: "app.dayglance.streamdeck.goal-progress" })
+export class GoalProgressAction extends SingletonAction<Settings> {
+  private goalIndex = 0;
+
+  override async onWillAppear(ev: WillAppearEvent<Settings>): Promise<void> {
+    await this.refresh(ev.action);
+  }
+
+  override async onDialRotate(ev: DialRotateEvent<Settings>): Promise<void> {
+    this.goalIndex = Math.max(0, this.goalIndex + ev.payload.ticks);
+    await this.refresh(ev.action);
+  }
+
+  override async onKeyDown(ev: KeyDownEvent<Settings>): Promise<void> {
+    await this.refresh(ev.action);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async refresh(actionRef: any): Promise<void> {
+    // TODO: fetch goals from dayGLANCE backend, render goal at this.goalIndex
+    // with arc + progress % on the touch bar layout
+    await actionRef.setTitle("Goals");
+  }
+}

--- a/stream-deck-plugin/src/actions/next-task.ts
+++ b/stream-deck-plugin/src/actions/next-task.ts
@@ -1,0 +1,38 @@
+import {
+  action,
+  DialRotateEvent,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+} from "@elgato/streamdeck";
+
+type Settings = {
+  instanceUrl: string;
+  apiToken: string;
+};
+
+@action({ UUID: "app.dayglance.streamdeck.next-task" })
+export class NextTaskAction extends SingletonAction<Settings> {
+  private taskIndex = 0;
+
+  override async onWillAppear(ev: WillAppearEvent<Settings>): Promise<void> {
+    await this.refresh(ev.action);
+  }
+
+  override async onDialRotate(ev: DialRotateEvent<Settings>): Promise<void> {
+    this.taskIndex = Math.max(0, this.taskIndex + ev.payload.ticks);
+    await this.refresh(ev.action);
+  }
+
+  override async onKeyDown(ev: KeyDownEvent<Settings>): Promise<void> {
+    // TODO: mark current task complete via dayGLANCE backend, then advance
+    this.taskIndex = 0;
+    await this.refresh(ev.action);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async refresh(actionRef: any): Promise<void> {
+    // TODO: fetch tasks from dayGLANCE backend and render task at this.taskIndex
+    await actionRef.setTitle("Next task");
+  }
+}

--- a/stream-deck-plugin/src/actions/quick-glance.ts
+++ b/stream-deck-plugin/src/actions/quick-glance.ts
@@ -1,0 +1,44 @@
+import {
+  action,
+  DialRotateEvent,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+} from "@elgato/streamdeck";
+
+type Settings = {
+  instanceUrl: string;
+  apiToken: string;
+};
+
+type DisplayMode = "date" | "weather" | "next-event";
+
+const MODES: DisplayMode[] = ["date", "weather", "next-event"];
+
+@action({ UUID: "app.dayglance.streamdeck.quick-glance" })
+export class QuickGlanceAction extends SingletonAction<Settings> {
+  private modeIndex = 0;
+  private pinned = false;
+
+  override async onWillAppear(ev: WillAppearEvent<Settings>): Promise<void> {
+    await this.refresh(ev.action);
+  }
+
+  override async onDialRotate(ev: DialRotateEvent<Settings>): Promise<void> {
+    if (this.pinned) return;
+    this.modeIndex = (this.modeIndex + ev.payload.ticks + MODES.length) % MODES.length;
+    await this.refresh(ev.action);
+  }
+
+  override async onKeyDown(ev: KeyDownEvent<Settings>): Promise<void> {
+    this.pinned = !this.pinned;
+    await this.refresh(ev.action);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async refresh(actionRef: any): Promise<void> {
+    const mode = MODES[this.modeIndex];
+    // TODO: fetch data for current mode from dayGLANCE backend
+    await actionRef.setTitle(mode);
+  }
+}

--- a/stream-deck-plugin/src/plugin.ts
+++ b/stream-deck-plugin/src/plugin.ts
@@ -1,0 +1,15 @@
+import streamDeck from "@elgato/streamdeck";
+
+import { AgendaAction } from "./actions/agenda";
+import { FocusAction } from "./actions/focus-mode";
+import { GoalProgressAction } from "./actions/goal-progress";
+import { NextTaskAction } from "./actions/next-task";
+import { QuickGlanceAction } from "./actions/quick-glance";
+
+streamDeck.actions.registerAction(new AgendaAction());
+streamDeck.actions.registerAction(new FocusAction());
+streamDeck.actions.registerAction(new GoalProgressAction());
+streamDeck.actions.registerAction(new NextTaskAction());
+streamDeck.actions.registerAction(new QuickGlanceAction());
+
+streamDeck.connect();

--- a/stream-deck-plugin/tsconfig.json
+++ b/stream-deck-plugin/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "com.dayglance.streamdeck.sdPlugin/bin"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Adds `stream-deck-plugin/` at the repo root — a self-contained TypeScript project targeting the `@elgato/streamdeck` SDK (Node 20, CJS output via rollup)
- Declares all five actions in `manifest.json` with both `Encoder` (dial + touch bar) and `Keypad` (key button) controller support
- Stubs out each action class with the correct event handlers and `// TODO` markers for the dayGLANCE backend calls:
  - **Agenda** — dial scrolls the timeline, key taps cycle events
  - **Focus / Pomodoro** — dial sets duration, push starts/stops; local countdown ticker with work/break phases and session count (🍅); two-way sync hook points ready
  - **Next Task** — dial browses tasks, press completes
  - **Goal Progress** — dial cycles goals
  - **Quick Glance** — dial rotates date / weather / next-event modes, press pins
- Custom touch bar layouts for Focus (brand orange `#fe8b00` progress bar) and Goal Progress

## What's not here yet

Backend API calls (all actions have `// TODO` comments), icon assets, and the property inspector (settings UI). Those come in follow-up PRs off `stream-deck-develop`.

## Branch note

`stream-deck-develop` has been created as the long-lived development branch for this plugin (mirroring how `develop` works for hyperGLANCE). Feature branches for the plugin should be cut from `stream-deck-develop` and synced back to it after merging to `main`.

## Test plan

- [ ] `cd stream-deck-plugin && npm install && npm run build` produces `com.dayglance.streamdeck.sdPlugin/bin/plugin.js`
- [ ] No TypeScript errors (`npm run lint`)
- [ ] Load plugin in Stream Deck software — all five actions appear in the category list
- [ ] Dial rotate / press events fire without errors in Stream Deck logs

https://claude.ai/code/session_01Rdu3ayBgtxH4wm8UDk1nD7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rdu3ayBgtxH4wm8UDk1nD7)_