### PR TITLE
fix: remove logo from tablet header, left-align date navigator

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -430,12 +430,8 @@ const DesktopLayout = () => {
 
       {/* Tablet header strip */}
       {isTablet && (
-        <div className={`${cardBg} border-b ${borderClass} px-4 flex items-center justify-between relative`} style={{ height: '56px' }}>
-          <div className="flex items-center">
-            <img src={darkMode ? '/dayglance-dark.svg' : '/dayglance-light.svg'} alt="dayGLANCE" className="h-10" />
-          </div>
-          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-            <div className="flex items-center gap-1 pointer-events-auto">
+        <div className={`${cardBg} border-b ${borderClass} px-4 flex items-center justify-between`} style={{ height: '56px' }}>
+          <div className="flex items-center gap-1">
               <button onClick={() => changeDate(-1)} className={`p-2 rounded-lg hover:bg-black/5 active:bg-black/10 dark:hover:bg-white/5 dark:active:bg-white/10 transition-colors`} aria-label="Previous day">
                 <ChevronLeft size={20} className={textSecondary} />
               </button>
@@ -459,7 +455,6 @@ const DesktopLayout = () => {
                   Today
                 </button>
               )}
-            </div>
           </div>
           <div className="flex items-center gap-2">
             <button


### PR DESCRIPTION
## Summary

- Removes the dayGLANCE logo from the tablet header strip (`isTablet`, 721–1200px wide)
- Left-aligns the date navigator (prev/next chevrons + date display + Today button) using normal flex flow instead of `position: absolute; inset-0` centering
- Drops the now-unnecessary `relative` class from the outer header div

## Root cause

The previous layout used absolute positioning to center the date navigator between the logo (left) and settings buttons (right). This only works when both sides are equal width. In portrait mode the right-side button cluster (up to 7 icons) is wider than the logo, causing the absolutely positioned nav to visually overlap the buttons.

## Why no new breakpoint

The `isTablet` condition (721–1200px, touch-primary) is already the right boundary for this header. The logo doesn't add navigational value in a compact tool UI at any width in this range, so the fix applies uniformly rather than introducing an `isLandscape` conditional.

## Test plan

- [ ] Tablet portrait — date navigator and settings buttons no longer overlap
- [ ] Tablet landscape — header lays out cleanly with nav left and buttons right
- [ ] Today button appears/disappears correctly when navigating away from today
- [ ] Month view popover still opens on date tap
- [ ] Desktop (non-tablet) — `DesktopHeader` unchanged, unaffected

https://claude.ai/code/session_01Rdu3ayBgtxH4wm8UDk1nD7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rdu3ayBgtxH4wm8UDk1nD7)_