### PR TITLE
fix: clear xattr hidden flag on macOS build outputs

### DIFF
--- a/build-and-install.sh
+++ b/build-and-install.sh
@@ -55,9 +55,11 @@ fi
 cd "$ANDROID_DIR"
 ./gradlew "$GRADLE_TASK"
 
-# Gradle on macOS hides build outputs — start from outputs/ so chflags -R
-# can recurse into the hidden apk/release/ or bundle/release/ subdirectory.
+# Gradle on macOS hides build outputs via two mechanisms: the HFS+ hidden
+# flag (chflags) and the com.apple.FinderInfo xattr (xattr). Both must be
+# cleared — chflags alone is not sufficient.
 chflags -R nohidden "$ANDROID_DIR/app/build/outputs" 2>/dev/null || true
+xattr -cr "$ANDROID_DIR/app/build/outputs" 2>/dev/null || true
 
 if $AAB; then
   echo "==> AAB ready: $AAB_PATH"


### PR DESCRIPTION
## Summary

`chflags -R nohidden` only undoes the HFS+ hidden flag. Gradle also sets the `com.apple.FinderInfo` extended attribute to hide output directories in Finder. Adding `xattr -cr` clears both, so the `apk/release/` folder is visible after a build.

## Test plan

- [ ] Run `./build-and-install.sh --release` — `dayglance-android/app/build/outputs/apk/release/` is visible in Finder after the build completes

https://claude.ai/code/session_01Rdu3ayBgtxH4wm8UDk1nD7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rdu3ayBgtxH4wm8UDk1nD7)_