### PR TITLE
fix: copy build outputs to project-root outputs/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+outputs
 dayglance-android/app/src/main/assets/web
 *.local
 

--- a/build-and-install.sh
+++ b/build-and-install.sh
@@ -3,6 +3,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ANDROID_DIR="$SCRIPT_DIR/dayglance-android"
+OUT_DIR="$SCRIPT_DIR/outputs"
 
 # Flags
 FULL_CLEAN=false
@@ -17,13 +18,16 @@ for arg in "$@"; do
 done
 
 if $AAB; then
-  AAB_PATH="$ANDROID_DIR/app/build/outputs/bundle/release/app-release.aab"
+  AAB_SRC="$ANDROID_DIR/app/build/outputs/bundle/release/app-release.aab"
+  AAB_DEST="$OUT_DIR/dayglance.aab"
   GRADLE_TASK="bundleRelease"
 elif $RELEASE; then
-  APK_PATH="$ANDROID_DIR/app/build/outputs/apk/release/dayglance.apk"
+  APK_SRC="$ANDROID_DIR/app/build/outputs/apk/release/dayglance.apk"
+  APK_DEST="$OUT_DIR/dayglance.apk"
   GRADLE_TASK="assembleRelease"
 else
-  APK_PATH="$ANDROID_DIR/app/build/outputs/apk/debug/app-debug.apk"
+  APK_SRC="$ANDROID_DIR/app/build/outputs/apk/debug/app-debug.apk"
+  APK_DEST="$OUT_DIR/dayglance-debug.apk"
   GRADLE_TASK="assembleDebug"
 fi
 
@@ -55,20 +59,20 @@ fi
 cd "$ANDROID_DIR"
 ./gradlew "$GRADLE_TASK"
 
-# Gradle on macOS hides build outputs via two mechanisms: the HFS+ hidden
-# flag (chflags) and the com.apple.FinderInfo xattr (xattr). Both must be
-# cleared — chflags alone is not sufficient.
-chflags -R nohidden "$ANDROID_DIR/app/build/outputs" 2>/dev/null || true
-xattr -cr "$ANDROID_DIR/app/build/outputs" 2>/dev/null || true
-
+# Copy output to project-root outputs/ — bypasses Gradle's macOS hidden-flag
+# behaviour entirely. The outputs/ dir is gitignored.
+mkdir -p "$OUT_DIR"
 if $AAB; then
-  echo "==> AAB ready: $AAB_PATH"
-  echo "==> Done! Upload app-release.aab to Google Play Console."
+  cp "$AAB_SRC" "$AAB_DEST"
+  echo "==> AAB ready: outputs/dayglance.aab"
+  echo "==> Done! Upload to Google Play Console."
 elif $RELEASE; then
-  echo "==> Release APK: $APK_PATH"
-  echo "==> Done! Copy dayglance.apk to your F-Droid repo."
+  cp "$APK_SRC" "$APK_DEST"
+  echo "==> Release APK: outputs/dayglance.apk"
+  echo "==> Done! Copy to your F-Droid repo."
 else
+  cp "$APK_SRC" "$APK_DEST"
   echo "==> Installing on connected device..."
-  adb install -r "$APK_PATH"
+  adb install -r "$APK_DEST"
   echo "==> Done! App installed."
 fi


### PR DESCRIPTION
## Summary

Chasing the macOS hidden-flag behaviour on Gradle's build outputs proved unreliable (`chflags` and `xattr -cr` both had no effect). The pragmatic fix: copy the finished APK/AAB into an `outputs/` directory at the project root immediately after the Gradle task completes. `outputs/` is a plain directory with no reason for macOS to hide it.

- `./build-and-install.sh` → `outputs/dayglance-debug.apk`
- `./build-and-install.sh --release` → `outputs/dayglance.apk`
- `./build-and-install.sh --aab` → `outputs/dayglance.aab`

`outputs/` added to `.gitignore`.

## Test plan

- [ ] `./build-and-install.sh --release` — `outputs/dayglance.apk` appears in Finder and can be dragged to release page
- [ ] `./build-and-install.sh --aab` — `outputs/dayglance.aab` appears
- [ ] `./build-and-install.sh` (debug) — installs via ADB as before

https://claude.ai/code/session_01Rdu3ayBgtxH4wm8UDk1nD7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rdu3ayBgtxH4wm8UDk1nD7)_