### PR TITLE
Fix exports ReferenceError by switching Electron TS output to ES2022 …

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,9 @@
 import { app, BrowserWindow, shell } from 'electron';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { createWsServer } from './ws-server';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const DEV = !app.isPackaged;
 const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL'] ?? 'http://localhost:5173';

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
+    "module": "ES2022",
     "moduleResolution": "node",
     "ignoreDeprecations": "6.0",
     "outDir": "dist-electron",


### PR DESCRIPTION
…modules

package.json has "type":"module" so Node treats all .js files as ESM, but tsconfig.electron.json was emitting CommonJS (exports/require), causing the crash. Changed module output to ES2022 and replaced the CJS-only __dirname global with the ESM equivalent via import.meta.url.

https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k