### PR TITLE
Add .js extension to ws-server import for ESM compatibility

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, shell } from 'electron';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createWsServer } from './ws-server';
+import { createWsServer } from './ws-server.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
Node ESM resolver requires explicit file extensions on relative imports; bare './ws-server' works in CJS but fails after the ES2022 module switch.

https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k