### PR TITLE
Compile preload with separate CommonJS tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "build:android": "./node_modules/.bin/vite build --config vite.config.android.js",
     "preview": "vite preview",
     "test": "vitest run",
-    "dev:electron": "./node_modules/.bin/tsc -p tsconfig.electron.json && concurrently -n renderer,main,electron -c cyan,yellow,green \"vite\" \"./node_modules/.bin/tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
-    "build:electron": "vite build --config vite.config.electron.js && ./node_modules/.bin/tsc -p tsconfig.electron.json && electron-builder"
+    "dev:electron": "./node_modules/.bin/tsc -p tsconfig.electron.json && ./node_modules/.bin/tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"./node_modules/.bin/tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"./node_modules/.bin/tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
+    "build:electron": "vite build --config vite.config.electron.js && ./node_modules/.bin/tsc -p tsconfig.electron.json && ./node_modules/.bin/tsc -p tsconfig.electron.preload.json && electron-builder"
   },
   "dependencies": {
     "lucide-react": "^0.564.0",

--- a/tsconfig.electron.preload.json
+++ b/tsconfig.electron.preload.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "ignoreDeprecations": "6.0",
     "outDir": "dist-electron",
@@ -10,8 +10,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "types": ["node", "electron", "ws"]
+    "types": ["node", "electron"]
   },
-  "include": ["electron"],
-  "exclude": ["electron/preload.ts"]
+  "include": ["electron/preload.ts"]
 }


### PR DESCRIPTION
Electron preload scripts must be CJS regardless of the main process format. Split the build: tsconfig.electron.json (ES2022) for main+ws-server, tsconfig.electron.preload.json (CommonJS) for preload. Both dev:electron and build:electron now run both compilers.

https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k