### PR TITLE
Stream Deck: WebSocket client + wire all actions to live state

### DIFF
--- a/stream-deck-plugin/package-lock.json
+++ b/stream-deck-plugin/package-lock.json
@@ -8,12 +8,14 @@
       "name": "dayglance-streamdeck",
       "version": "0.0.1",
       "dependencies": {
-        "@elgato/streamdeck": "^1.0.0"
+        "@elgato/streamdeck": "^1.0.0",
+        "ws": "^8.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
         "@rollup/plugin-typescript": "^11.0.0",
+        "@types/ws": "^8.0.0",
         "rollup": "^4.0.0",
         "tslib": "^2.6.0",
         "typescript": "^5.4.0"
@@ -503,12 +505,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -832,6 +854,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/stream-deck-plugin/package.json
+++ b/stream-deck-plugin/package.json
@@ -9,12 +9,14 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@elgato/streamdeck": "^1.0.0"
+    "@elgato/streamdeck": "^1.0.0",
+    "ws": "^8.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@rollup/plugin-typescript": "^11.0.0",
+    "@types/ws": "^8.0.0",
     "rollup": "^4.0.0",
     "tslib": "^2.6.0",
     "typescript": "^5.4.0"

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -1,30 +1,31 @@
 import {
   action,
-  DialRotateEvent,
   KeyDownEvent,
   SingletonAction,
   WillAppearEvent,
 } from "@elgato/streamdeck";
+import { DayGlanceState, onState } from "../client";
 
 @action({ UUID: "app.dayglance.streamdeck.agenda" })
 export class AgendaAction extends SingletonAction {
-  private scrollOffset = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private actionRef: any = null;
+  private unsubscribe: (() => void) | null = null;
 
-  override async onWillAppear(_ev: WillAppearEvent): Promise<void> {
-    await this.refresh();
-  }
-
-  override async onDialRotate(ev: DialRotateEvent): Promise<void> {
-    this.scrollOffset = Math.max(0, this.scrollOffset + ev.payload.ticks);
-    await this.refresh();
+  override async onWillAppear(ev: WillAppearEvent): Promise<void> {
+    this.actionRef = ev.action;
+    this.unsubscribe?.();
+    this.unsubscribe = onState((s) => void this.render(s));
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
-    this.scrollOffset = Math.max(0, this.scrollOffset + 1);
-    await this.refresh();
+    // reserved for future navigation
   }
 
-  private async refresh(): Promise<void> {
-    // TODO: render today's agenda from WS state
+  private async render(state: DayGlanceState): Promise<void> {
+    if (!this.actionRef) return;
+    const { completed, total } = state.today;
+    const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
+    await this.actionRef.setTitle(`${completed}/${total}\n${pct}%`);
   }
 }

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -6,95 +6,63 @@ import {
   SingletonAction,
   WillAppearEvent,
 } from "@elgato/streamdeck";
+import { DayGlanceState, onState, send } from "../client";
 
-type Settings = {
-  sessionDurationMinutes: number;
-};
-
-type Phase = "idle" | "work" | "break";
+type Settings = { sessionDurationMinutes: number };
 
 @action({ UUID: "app.dayglance.streamdeck.focus" })
 export class FocusAction extends SingletonAction<Settings> {
-  private phase: Phase = "idle";
-  private remainingSeconds = 0;
-  private sessionCount = 0;
-  private tickInterval: ReturnType<typeof setInterval> | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private actionRef: any = null;
+  private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
 
   override async onWillAppear(ev: WillAppearEvent<Settings>): Promise<void> {
-    const settings = await ev.action.getSettings();
-    await ev.action.setTitle(this.buildTitle());
-    // TODO: poll dayGLANCE backend for current focus state and sync
-    void settings;
+    this.actionRef = ev.action;
+    this.unsubscribe?.();
+    this.unsubscribe = onState((s) => {
+      this.lastState = s;
+      void this.render(s);
+    });
   }
 
   override async onDialRotate(ev: DialRotateEvent<Settings>): Promise<void> {
-    if (this.phase !== "idle") return;
+    if (this.lastState?.focus.active) return;
     const settings = await ev.action.getSettings();
-    const delta = ev.payload.ticks;
-    const newDuration = Math.max(5, (settings.sessionDurationMinutes ?? 25) + delta);
-    await ev.action.setSettings({ ...settings, sessionDurationMinutes: newDuration });
+    const newDuration = Math.max(5, (settings.sessionDurationMinutes ?? 25) + ev.payload.ticks);
+    await ev.action.setSettings({ sessionDurationMinutes: newDuration });
     await ev.action.setTitle(`${newDuration}m`);
   }
 
-  override async onDialUp(ev: DialUpEvent<Settings>): Promise<void> {
-    await this.toggleSession(ev.action);
+  override async onDialUp(_ev: DialUpEvent<Settings>): Promise<void> {
+    this.toggle();
   }
 
-  override async onKeyDown(ev: KeyDownEvent<Settings>): Promise<void> {
-    await this.toggleSession(ev.action);
+  override async onKeyDown(_ev: KeyDownEvent<Settings>): Promise<void> {
+    this.toggle();
   }
 
-  private async toggleSession(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    actionRef: any
-  ): Promise<void> {
-    if (this.phase === "idle") {
-      const settings: Settings = await actionRef.getSettings();
-      this.phase = "work";
-      this.remainingSeconds = (settings.sessionDurationMinutes ?? 25) * 60;
-      this.startTick(actionRef);
-      // TODO: POST to dayGLANCE backend to start focus mode
+  private toggle(): void {
+    if (!this.lastState?.focus.active) {
+      send({ type: "focus:start" });
     } else {
-      this.stopTick();
-      this.phase = "idle";
-      await actionRef.setState(0);
-      await actionRef.setTitle("Focus");
-      // TODO: POST to dayGLANCE backend to end focus mode
+      send({ type: "focus:stop" });
     }
   }
 
-  private startTick(actionRef: unknown): void {
-    this.tickInterval = setInterval(async () => {
-      this.remainingSeconds--;
-      if (this.remainingSeconds <= 0) {
-        this.stopTick();
-        if (this.phase === "work") {
-          this.sessionCount++;
-          this.phase = "break";
-          this.remainingSeconds = 5 * 60;
-          this.startTick(actionRef);
-        } else {
-          this.phase = "idle";
-        }
-      }
-      // @ts-expect-error actionRef typed as unknown for simplicity
-      await actionRef.setTitle(this.buildTitle());
-    }, 1000);
-  }
-
-  private stopTick(): void {
-    if (this.tickInterval !== undefined) {
-      clearInterval(this.tickInterval);
-      this.tickInterval = undefined;
+  private async render(state: DayGlanceState): Promise<void> {
+    if (!this.actionRef) return;
+    const { active, phase, secondsRemaining, running } = state.focus;
+    if (!active) {
+      await this.actionRef.setTitle("Focus");
+      await this.actionRef.setState(0);
+    } else {
+      const m = Math.floor(secondsRemaining / 60);
+      const s = secondsRemaining % 60;
+      const label = phase === "work" ? "Work" : "Break";
+      const timer = running ? `${m}:${s.toString().padStart(2, "0")}` : "Paused";
+      await this.actionRef.setTitle(`${label}\n${timer}`);
+      await this.actionRef.setState(1);
     }
-  }
-
-  private buildTitle(): string {
-    if (this.phase === "idle") return "Focus";
-    const m = Math.floor(this.remainingSeconds / 60);
-    const s = this.remainingSeconds % 60;
-    const tomatoes = "🍅".repeat(this.sessionCount);
-    const label = this.phase === "work" ? "Work" : "Break";
-    return `${label}\n${m}:${s.toString().padStart(2, "0")}\n${tomatoes}`;
   }
 }

--- a/stream-deck-plugin/src/actions/goal-progress.ts
+++ b/stream-deck-plugin/src/actions/goal-progress.ts
@@ -5,27 +5,33 @@ import {
   SingletonAction,
   WillAppearEvent,
 } from "@elgato/streamdeck";
+import { DayGlanceState, onState } from "../client";
 
 @action({ UUID: "app.dayglance.streamdeck.goal-progress" })
 export class GoalProgressAction extends SingletonAction {
-  private goalIndex = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private actionRef: any = null;
+  private unsubscribe: (() => void) | null = null;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
-    await this.refresh(ev.action);
+    this.actionRef = ev.action;
+    this.unsubscribe?.();
+    this.unsubscribe = onState((s) => void this.render(s));
   }
 
-  override async onDialRotate(ev: DialRotateEvent): Promise<void> {
-    this.goalIndex = Math.max(0, this.goalIndex + ev.payload.ticks);
-    await this.refresh(ev.action);
+  override async onDialRotate(_ev: DialRotateEvent): Promise<void> {
+    // TODO: cycle through goals when goal data is added to state
   }
 
-  override async onKeyDown(ev: KeyDownEvent): Promise<void> {
-    await this.refresh(ev.action);
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
+    // TODO: interact with goal when goal data is added to state
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async refresh(actionRef: any): Promise<void> {
-    // TODO: render goal at this.goalIndex from WS state (arc + progress %)
-    await actionRef.setTitle("Goals");
+  private async render(state: DayGlanceState): Promise<void> {
+    if (!this.actionRef) return;
+    // Showing today's task completion until goal data is in the state shape
+    const { completed, total } = state.today;
+    const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
+    await this.actionRef.setTitle(`Today\n${pct}%`);
   }
 }

--- a/stream-deck-plugin/src/actions/next-task.ts
+++ b/stream-deck-plugin/src/actions/next-task.ts
@@ -5,29 +5,46 @@ import {
   SingletonAction,
   WillAppearEvent,
 } from "@elgato/streamdeck";
+import { DayGlanceState, onState, send } from "../client";
 
 @action({ UUID: "app.dayglance.streamdeck.next-task" })
 export class NextTaskAction extends SingletonAction {
-  private taskIndex = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private actionRef: any = null;
+  private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
+  private showNext = false; // false = currentTask, true = nextTask
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
-    await this.refresh(ev.action);
+    this.actionRef = ev.action;
+    this.unsubscribe?.();
+    this.unsubscribe = onState((s) => {
+      this.lastState = s;
+      void this.render(s);
+    });
   }
 
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {
-    this.taskIndex = Math.max(0, this.taskIndex + ev.payload.ticks);
-    await this.refresh(ev.action);
+    this.showNext = ev.payload.ticks > 0 ? true : false;
+    if (this.lastState) void this.render(this.lastState);
   }
 
-  override async onKeyDown(ev: KeyDownEvent): Promise<void> {
-    // TODO: send task:complete via WS, then advance
-    this.taskIndex = 0;
-    await this.refresh(ev.action);
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
+    const task = this.showNext
+      ? this.lastState?.nextTask
+      : (this.lastState?.currentTask ?? this.lastState?.nextTask);
+    if (task) send({ type: "task:complete", id: task.id });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async refresh(actionRef: any): Promise<void> {
-    // TODO: render task at this.taskIndex from WS state
-    await actionRef.setTitle("Next task");
+  private async render(state: DayGlanceState): Promise<void> {
+    if (!this.actionRef) return;
+    const task = this.showNext
+      ? state.nextTask
+      : (state.currentTask ?? state.nextTask);
+    await this.actionRef.setTitle(task ? truncate(task.title, 20) : "No tasks");
   }
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
 }

--- a/stream-deck-plugin/src/actions/quick-glance.ts
+++ b/stream-deck-plugin/src/actions/quick-glance.ts
@@ -5,35 +5,70 @@ import {
   SingletonAction,
   WillAppearEvent,
 } from "@elgato/streamdeck";
+import { DayGlanceState, onState } from "../client";
 
-type DisplayMode = "date" | "weather" | "next-event";
-
-const MODES: DisplayMode[] = ["date", "weather", "next-event"];
+type DisplayMode = "date" | "next-event" | "focus";
+const MODES: DisplayMode[] = ["date", "next-event", "focus"];
 
 @action({ UUID: "app.dayglance.streamdeck.quick-glance" })
 export class QuickGlanceAction extends SingletonAction {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private actionRef: any = null;
+  private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
   private modeIndex = 0;
   private pinned = false;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
-    await this.refresh(ev.action);
+    this.actionRef = ev.action;
+    this.unsubscribe?.();
+    this.unsubscribe = onState((s) => {
+      this.lastState = s;
+      void this.render(s);
+    });
   }
 
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {
     if (this.pinned) return;
     this.modeIndex = (this.modeIndex + ev.payload.ticks + MODES.length) % MODES.length;
-    await this.refresh(ev.action);
+    if (this.lastState) void this.render(this.lastState);
   }
 
-  override async onKeyDown(ev: KeyDownEvent): Promise<void> {
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
     this.pinned = !this.pinned;
-    await this.refresh(ev.action);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async refresh(actionRef: any): Promise<void> {
+  private async render(state: DayGlanceState): Promise<void> {
+    if (!this.actionRef) return;
     const mode = MODES[this.modeIndex];
-    // TODO: render mode data from WS state
-    await actionRef.setTitle(mode);
+    let title: string;
+
+    if (mode === "date") {
+      title = formatDate(state.today.date);
+    } else if (mode === "next-event") {
+      const task = state.currentTask ?? state.nextTask;
+      title = task ? truncate(task.title, 20) : "No events";
+    } else {
+      const { active, phase, secondsRemaining } = state.focus;
+      if (!active) {
+        title = "Focus\noff";
+      } else {
+        const m = Math.floor(secondsRemaining / 60);
+        const s = secondsRemaining % 60;
+        title = `${phase}\n${m}:${s.toString().padStart(2, "0")}`;
+      }
+    }
+
+    await this.actionRef.setTitle(title);
   }
+}
+
+function formatDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
 }

--- a/stream-deck-plugin/src/client.ts
+++ b/stream-deck-plugin/src/client.ts
@@ -1,0 +1,83 @@
+import WebSocket from "ws";
+
+export type Task = {
+  id: string;
+  title: string;
+  startTime: string | null;
+  duration: number;
+  colorHex: string;
+  tags: string[];
+};
+
+export type FocusState = {
+  active: boolean;
+  phase: string;
+  secondsRemaining: number;
+  running: boolean;
+  workMinutes: number;
+  breakMinutes: number;
+};
+
+export type DayGlanceState = {
+  currentTask: Task | null;
+  nextTask: Task | null;
+  today: { total: number; completed: number; date: string };
+  focus: FocusState;
+};
+
+export type Command =
+  | { type: "focus:start" }
+  | { type: "focus:stop" }
+  | { type: "focus:skip" }
+  | { type: "task:complete"; id: string };
+
+type StateListener = (state: DayGlanceState) => void;
+
+const WS_URL = "ws://localhost:7892";
+const RETRY_MS = 3000;
+
+let ws: WebSocket | null = null;
+let retryTimer: ReturnType<typeof setTimeout> | undefined;
+let lastState: DayGlanceState | null = null;
+const listeners = new Set<StateListener>();
+
+function connect(): void {
+  clearTimeout(retryTimer);
+  ws = new WebSocket(WS_URL);
+
+  ws.on("message", (data) => {
+    try {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === "state") {
+        lastState = msg as DayGlanceState;
+        for (const listener of listeners) listener(lastState);
+      }
+    } catch {
+      // drop malformed frames
+    }
+  });
+
+  ws.on("close", () => {
+    retryTimer = setTimeout(connect, RETRY_MS);
+  });
+
+  ws.on("error", () => {
+    // "close" fires after "error" — retry is handled there
+  });
+}
+
+export function send(command: Command): void {
+  if (ws?.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(command));
+  }
+}
+
+/** Subscribe to state updates. Returns an unsubscribe function.
+ *  Immediately invokes listener with the last known state if available. */
+export function onState(listener: StateListener): () => void {
+  listeners.add(listener);
+  if (lastState) listener(lastState);
+  return () => listeners.delete(listener);
+}
+
+connect();


### PR DESCRIPTION
## Summary

- Adds `src/client.ts` — singleton WebSocket client connecting to `ws://localhost:7892` (the dayGLANCE Desktop local API). Auto-reconnects every 3s, caches last state so late subscribers get it immediately.
- All 5 actions now subscribe to live state and send commands instead of hitting a backend:

| Action | Behaviour |
|---|---|
| `focus-mode` | Drops local timer; mirrors renderer focus state; press starts/stops; dial adjusts duration when idle |
| `next-task` | Shows current task (or next if none active); dial toggles current↔next; press sends `task:complete` |
| `agenda` | Shows `completed/total · %` for today |
| `quick-glance` | Cycles date / next-event / focus-timer modes; real data for all three |
| `goal-progress` | Shows today's % until goal data lands in the state shape |

- `ws` added as explicit dep; `@types/ws` added to devDeps.

## Test plan

- [ ] Build compiles clean: `npm run build` in `stream-deck-plugin/`
- [ ] Load plugin in Stream Deck with dayGLANCE Desktop running
- [ ] Start focus mode from the Stream Deck — renderer enters focus mode
- [ ] Focus countdown updates on the key every second
- [ ] Stop focus from the Stream Deck — renderer exits focus mode
- [ ] Complete a task from the Stream Deck — task marked done in the app
- [ ] `agenda` key shows correct completed/total count
- [ ] `quick-glance` cycles through date, next-event, and focus-timer modes

https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k

---
_Generated by [Claude Code](https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k)_