### PR TITLE
GLANCEhub protocol v1: namespace, versioning, canonical types, userData pin

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -5,6 +5,10 @@ import { createWsServer } from './ws-server.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Pin userData explicitly — the implicit default derives from productName,
+// so a rename or build-config drift would silently orphan existing user data.
+app.setPath('userData', path.join(app.getPath('appData'), 'dayGLANCE'));
+
 const DEV = !app.isPackaged;
 const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL'] ?? 'http://localhost:5173';
 

--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -1,0 +1,54 @@
+// Canonical protocol contract for the dayGLANCE Desktop ↔ client WebSocket API.
+// All message type string constants and wire-format types live here.
+// Clients (Stream Deck plugin, future integrations) import from this file.
+// Do not define these strings anywhere else in the codebase.
+
+export const PROTOCOL_VERSION = 1 as const;
+
+// ── Outbound message type constants (server → clients) ───────────────────
+export const MSG_DAY_STATE = 'day:state' as const;
+
+// ── Inbound command type constants (clients → server) ────────────────────
+export const MSG_DAY_FOCUS_START   = 'day:focus:start'   as const;
+export const MSG_DAY_FOCUS_STOP    = 'day:focus:stop'    as const;
+export const MSG_DAY_FOCUS_SKIP    = 'day:focus:skip'    as const;
+export const MSG_DAY_TASK_COMPLETE = 'day:task:complete' as const;
+
+// ── Shared data types ─────────────────────────────────────────────────────
+export type Task = {
+  id: string;
+  title: string;
+  startTime: string | null;
+  duration: number;
+  colorHex: string;
+  tags: string[];
+};
+
+export type FocusState = {
+  active: boolean;
+  phase: string;
+  secondsRemaining: number;
+  running: boolean;
+  workMinutes: number;
+  breakMinutes: number;
+};
+
+export type DayGlanceState = {
+  currentTask: Task | null;
+  nextTask: Task | null;
+  today: { total: number; completed: number; date: string };
+  focus: FocusState;
+};
+
+// ── Outbound message (server → clients) ──────────────────────────────────
+export type OutboundMessage = {
+  v: typeof PROTOCOL_VERSION;
+  type: typeof MSG_DAY_STATE;
+} & DayGlanceState;
+
+// ── Inbound commands (clients → server) ──────────────────────────────────
+export type InboundCommand =
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_START }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_STOP }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_SKIP }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_TASK_COMPLETE; id: string };

--- a/electron/ws-server.ts
+++ b/electron/ws-server.ts
@@ -1,5 +1,6 @@
 import { WebSocketServer, WebSocket } from 'ws';
 import { BrowserWindow, ipcMain } from 'electron';
+import type { OutboundMessage } from './protocol.js';
 
 const WS_PORT = 7892;
 
@@ -24,7 +25,7 @@ export function createWsServer(win: BrowserWindow): WebSocketServer {
   });
 
   // Broadcast state updates from the renderer to all connected clients
-  ipcMain.on('ws:push-state', (_event, state: unknown) => {
+  ipcMain.on('ws:push-state', (_event, state: OutboundMessage) => {
     const payload = JSON.stringify(state);
     for (const client of clients) {
       if (client.readyState === WebSocket.OPEN) {

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -1,6 +1,14 @@
 import { useEffect, useRef } from 'react';
 import { taskColorToHex } from '../utils/colorUtils.js';
 import { dateToString } from '../utils/taskUtils.js';
+import {
+  PROTOCOL_VERSION,
+  MSG_DAY_STATE,
+  MSG_DAY_FOCUS_START,
+  MSG_DAY_FOCUS_STOP,
+  MSG_DAY_FOCUS_SKIP,
+  MSG_DAY_TASK_COMPLETE,
+} from '../../electron/protocol';
 
 const timeToMinutes = (time) => {
   if (!time) return 0;
@@ -13,13 +21,13 @@ const timeToMinutes = (time) => {
 // commands from connected clients (e.g. Stream Deck plugin) back to the app.
 //
 // Message types pushed to clients:
-//   { type: 'state', currentTask, nextTask, today, focus }
+//   { v: PROTOCOL_VERSION, type: MSG_DAY_STATE, currentTask, nextTask, today, focus }
 //
 // Commands received from clients:
-//   { type: 'focus:start' }
-//   { type: 'focus:stop' }
-//   { type: 'focus:skip' }
-//   { type: 'task:complete', id: string }
+//   { v: PROTOCOL_VERSION, type: MSG_DAY_FOCUS_START }
+//   { v: PROTOCOL_VERSION, type: MSG_DAY_FOCUS_STOP }
+//   { v: PROTOCOL_VERSION, type: MSG_DAY_FOCUS_SKIP }
+//   { v: PROTOCOL_VERSION, type: MSG_DAY_TASK_COMPLETE, id: string }
 export default function useElectronBridge({
   todayAgenda,
   currentTime,
@@ -46,16 +54,16 @@ export default function useElectronBridge({
     const unsubscribe = window.electronAPI.onCommand((cmd) => {
       if (!cmd?.type) return;
       switch (cmd.type) {
-        case 'focus:start':
+        case MSG_DAY_FOCUS_START:
           enterFocusModeRef.current?.();
           break;
-        case 'focus:stop':
+        case MSG_DAY_FOCUS_STOP:
           exitFocusModeRef.current?.();
           break;
-        case 'focus:skip':
+        case MSG_DAY_FOCUS_SKIP:
           skipFocusPhaseRef.current?.();
           break;
-        case 'task:complete':
+        case MSG_DAY_TASK_COMPLETE:
           if (cmd.id) toggleCompleteRef.current?.(cmd.id);
           break;
       }
@@ -92,7 +100,8 @@ export default function useElectronBridge({
     const todayTasks = tasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay);
 
     window.electronAPI.pushState({
-      type: 'state',
+      v: PROTOCOL_VERSION,
+      type: MSG_DAY_STATE,
       currentTask: mapTask(inProgress),
       nextTask: mapTask(nextUpcoming),
       today: {

--- a/stream-deck-plugin/.gitignore
+++ b/stream-deck-plugin/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+com.dayglance.streamdeck.sdPlugin/bin/
+*.js.map

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/focus.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/focus.json
@@ -1,0 +1,28 @@
+{
+  "id": "focus-layout",
+  "items": [
+    {
+      "key": "title",
+      "type": "text",
+      "rect": [16, 8, 200, 24],
+      "alignment": "left",
+      "font": { "size": 14, "weight": 600 }
+    },
+    {
+      "key": "value",
+      "type": "text",
+      "rect": [16, 36, 200, 40],
+      "alignment": "left",
+      "font": { "size": 28, "weight": 700 },
+      "color": "#fe8b00"
+    },
+    {
+      "key": "indicator",
+      "type": "progressBar",
+      "rect": [16, 82, 700, 10],
+      "bar_bg_c": "2C2C2C",
+      "bar_fill_c": "fe8b00",
+      "bar_border_c": "2C2C2C"
+    }
+  ]
+}

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/goal-progress.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/goal-progress.json
@@ -1,0 +1,27 @@
+{
+  "id": "goal-progress-layout",
+  "items": [
+    {
+      "key": "title",
+      "type": "text",
+      "rect": [16, 8, 500, 24],
+      "alignment": "left",
+      "font": { "size": 13, "weight": 600 }
+    },
+    {
+      "key": "value",
+      "type": "text",
+      "rect": [16, 36, 200, 40],
+      "alignment": "left",
+      "font": { "size": 28, "weight": 700 }
+    },
+    {
+      "key": "indicator",
+      "type": "progressBar",
+      "rect": [16, 82, 700, 10],
+      "bar_bg_c": "2C2C2C",
+      "bar_fill_c": "FFFFFF",
+      "bar_border_c": "2C2C2C"
+    }
+  ]
+}

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -1,0 +1,116 @@
+{
+  "Name": "dayGLANCE",
+  "Version": "0.0.1",
+  "Author": "dayGLANCE",
+  "Description": "Agenda, focus, tasks, and goals on your Stream Deck+.",
+  "Category": "dayGLANCE",
+  "CategoryIcon": "imgs/plugin/category-icon",
+  "Icon": "imgs/plugin/icon",
+  "CodePath": "bin/plugin.js",
+  "SDKVersion": 2,
+  "Software": {
+    "MinimumVersion": "6.5"
+  },
+  "OS": [
+    { "Platform": "mac", "MinimumVersion": "12" },
+    { "Platform": "windows", "MinimumVersion": "10" }
+  ],
+  "Nodejs": {
+    "Version": "20",
+    "Debug": "enabled"
+  },
+  "Actions": [
+    {
+      "Name": "Agenda",
+      "UUID": "app.dayglance.streamdeck.agenda",
+      "Icon": "imgs/actions/agenda/icon",
+      "Tooltip": "Scrollable agenda strip — shows current and next events.",
+      "PropertyInspectorPath": "ui/property-inspector.html",
+      "Controllers": ["Encoder", "Keypad"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Rotate": "Scroll agenda forward / back",
+          "Push": "Open event detail"
+        }
+      },
+      "States": [
+        { "Image": "imgs/actions/agenda/key", "TitleAlignment": "bottom" }
+      ]
+    },
+    {
+      "Name": "Focus / Pomodoro",
+      "UUID": "app.dayglance.streamdeck.focus",
+      "Icon": "imgs/actions/focus/icon",
+      "Tooltip": "Start, stop, or adjust the Pomodoro timer. Stays in sync with dayGLANCE focus mode.",
+      "PropertyInspectorPath": "ui/property-inspector.html",
+      "Controllers": ["Encoder", "Keypad"],
+      "Encoder": {
+        "layout": "layouts/focus.json",
+        "TriggerDescription": {
+          "Rotate": "Adjust session duration",
+          "Push": "Start / stop session",
+          "TouchTap": "Switch work / break"
+        }
+      },
+      "States": [
+        { "Image": "imgs/actions/focus/key-idle" },
+        { "Image": "imgs/actions/focus/key-active" }
+      ]
+    },
+    {
+      "Name": "Next Task",
+      "UUID": "app.dayglance.streamdeck.next-task",
+      "Icon": "imgs/actions/next-task/icon",
+      "Tooltip": "Shows your next due task. Press to complete, long-press to snooze.",
+      "PropertyInspectorPath": "ui/property-inspector.html",
+      "Controllers": ["Encoder", "Keypad"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Rotate": "Browse tasks",
+          "Push": "Complete task"
+        }
+      },
+      "States": [
+        { "Image": "imgs/actions/next-task/key", "TitleAlignment": "bottom" }
+      ]
+    },
+    {
+      "Name": "Goal Progress",
+      "UUID": "app.dayglance.streamdeck.goal-progress",
+      "Icon": "imgs/actions/goal-progress/icon",
+      "Tooltip": "Cycles through active goals with arc progress indicator.",
+      "PropertyInspectorPath": "ui/property-inspector.html",
+      "Controllers": ["Encoder", "Keypad"],
+      "Encoder": {
+        "layout": "layouts/goal-progress.json",
+        "TriggerDescription": {
+          "Rotate": "Cycle goals",
+          "Push": "Toggle goal detail"
+        }
+      },
+      "States": [
+        { "Image": "imgs/actions/goal-progress/key", "TitleAlignment": "bottom" }
+      ]
+    },
+    {
+      "Name": "Quick Glance",
+      "UUID": "app.dayglance.streamdeck.quick-glance",
+      "Icon": "imgs/actions/quick-glance/icon",
+      "Tooltip": "Rotates between date, weather, and next event.",
+      "PropertyInspectorPath": "ui/property-inspector.html",
+      "Controllers": ["Encoder", "Keypad"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Rotate": "Cycle display mode",
+          "Push": "Pin current mode"
+        }
+      },
+      "States": [
+        { "Image": "imgs/actions/quick-glance/key", "TitleAlignment": "bottom" }
+      ]
+    }
+  ]
+}

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/ui/property-inspector.html
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/ui/property-inspector.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    :root {
+      --brand: #fe8b00;
+      --bg: #1e1e1e;
+      --surface: #2a2a2a;
+      --border: #3a3a3a;
+      --text: #d4d4d4;
+      --text-dim: #888;
+      --radius: 4px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 13px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 12px;
+    }
+
+    .status-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 0 6px;
+    }
+
+    .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--border);
+      flex-shrink: 0;
+      transition: background 0.2s;
+    }
+
+    .dot.connected    { background: #4caf50; }
+    .dot.disconnected { background: var(--text-dim); }
+    .dot.error        { background: #f44336; }
+
+    .status-label {
+      font-size: 13px;
+      color: var(--text);
+    }
+
+    .hint {
+      font-size: 11px;
+      color: var(--text-dim);
+      margin-top: 2px;
+    }
+
+    .divider {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 12px 0;
+    }
+
+    button {
+      padding: 7px 12px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      font-size: 13px;
+      cursor: pointer;
+      transition: border-color 0.15s, color 0.15s;
+    }
+
+    button:hover  { border-color: var(--brand); color: var(--brand); }
+    button:active { opacity: 0.8; }
+  </style>
+</head>
+<body>
+  <div class="status-row">
+    <div class="dot disconnected" id="dot"></div>
+    <span class="status-label" id="statusLabel">Connecting…</span>
+  </div>
+  <p class="hint">ws://localhost:7892 &nbsp;·&nbsp; open dayGLANCE Desktop to connect</p>
+
+  <hr class="divider" />
+
+  <button id="reconnectBtn">Reconnect</button>
+
+  <script>
+    const WS_URL = "ws://localhost:7892";
+    const RETRY_MS = 4000;
+
+    // Stream Deck ↔ plugin socket
+    let sdWs = null;
+
+    function connectElgatoStreamDeckSocket(port, pluginUUID, registerEvent) {
+      sdWs = new WebSocket(`ws://127.0.0.1:${port}`);
+      sdWs.onopen = () => sdWs.send(JSON.stringify({ event: registerEvent, uuid: pluginUUID }));
+    }
+
+    // dayGLANCE Desktop status probe
+    let dgWs = null;
+    let retryTimer = null;
+
+    function setStatus(state) {
+      const dot   = document.getElementById("dot");
+      const label = document.getElementById("statusLabel");
+      dot.className = "dot " + state;
+      label.textContent = state === "connected" ? "Connected" : "dayGLANCE Desktop not running";
+    }
+
+    function probe() {
+      clearTimeout(retryTimer);
+      if (dgWs) { dgWs.onopen = dgWs.onclose = dgWs.onerror = null; dgWs.close(); }
+
+      dgWs = new WebSocket(WS_URL);
+
+      dgWs.onopen  = () => setStatus("connected");
+      dgWs.onclose = () => { setStatus("disconnected"); retryTimer = setTimeout(probe, RETRY_MS); };
+      dgWs.onerror = () => { /* onclose fires after onerror */ };
+    }
+
+    document.getElementById("reconnectBtn").addEventListener("click", probe);
+
+    probe();
+  </script>
+</body>
+</html>

--- a/stream-deck-plugin/package-lock.json
+++ b/stream-deck-plugin/package-lock.json
@@ -1,0 +1,894 @@
+{
+  "name": "dayglance-streamdeck",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dayglance-streamdeck",
+      "version": "0.0.1",
+      "dependencies": {
+        "@elgato/streamdeck": "^1.0.0",
+        "ws": "^8.0.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "^25.0.0",
+        "@rollup/plugin-node-resolve": "^15.0.0",
+        "@rollup/plugin-typescript": "^11.0.0",
+        "@types/ws": "^8.0.0",
+        "rollup": "^4.0.0",
+        "tslib": "^2.6.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@elgato/schemas": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/@elgato/schemas/-/schemas-0.4.15.tgz",
+      "integrity": "sha512-UpELAqazf52PFer+hqg/hvEhYoPHCH3R0af6P7Ih3Hk6xCCJENn7cA5TIpXAIGEWe6dIteHuo/e/iPGLUP7yXA==",
+      "license": "MIT"
+    },
+    "node_modules/@elgato/streamdeck": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@elgato/streamdeck/-/streamdeck-1.4.1.tgz",
+      "integrity": "sha512-nk3TWfSvLrMWR6AhD6DG/pnJhWR6/xzP9elH/VLaiyZ27Nxb1Hu3rPuRty6xE5AZykwf3Auafok016wZSJZ3TA==",
+      "license": "MIT",
+      "dependencies": {
+        "@elgato/schemas": "^0.4.8",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.5.1"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.8.tgz",
+      "integrity": "sha512-ZEZWTK5n6Qde0to4vS9Mr5x/0UZoqCxPVR9KRUjU4kA2sO7GEUn1fop0DAwpO6z0Nw/kJON9bDmSxdWxO/TT1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "glob": "^8.0.3",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
+      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
+      "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/stream-deck-plugin/package.json
+++ b/stream-deck-plugin/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "dayglance-streamdeck",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rollup -c --bundleConfigAsCjs",
+    "watch": "rollup -cw --bundleConfigAsCjs",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@elgato/streamdeck": "^1.0.0",
+    "ws": "^8.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^25.0.0",
+    "@rollup/plugin-node-resolve": "^15.0.0",
+    "@rollup/plugin-typescript": "^11.0.0",
+    "@types/ws": "^8.0.0",
+    "rollup": "^4.0.0",
+    "tslib": "^2.6.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/stream-deck-plugin/rollup.config.mjs
+++ b/stream-deck-plugin/rollup.config.mjs
@@ -1,0 +1,23 @@
+import commonjs from "@rollup/plugin-commonjs";
+import resolve from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+
+export default {
+  input: "src/plugin.ts",
+  output: {
+    file: "com.dayglance.streamdeck.sdPlugin/bin/plugin.js",
+    format: "cjs",
+    sourcemap: true,
+  },
+  plugins: [
+    resolve({ browser: false }),
+    commonjs(),
+    typescript({
+      tsconfig: "./tsconfig.json",
+      // rootDir must span both src/ and ../../electron/ to allow the cross-package
+      // protocol import without a TypeScript rootDir violation during bundling.
+      rootDir: "../..",
+    }),
+  ],
+  external: [],
+};

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -1,0 +1,31 @@
+import {
+  action,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+} from "@elgato/streamdeck";
+import { DayGlanceState, onState } from "../client";
+
+@action({ UUID: "app.dayglance.streamdeck.agenda" })
+export class AgendaAction extends SingletonAction {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private actionRef: any = null;
+  private unsubscribe: (() => void) | null = null;
+
+  override async onWillAppear(ev: WillAppearEvent): Promise<void> {
+    this.actionRef = ev.action;
+    this.unsubscribe?.();
+    this.unsubscribe = onState((s) => void this.render(s));
+  }
+
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
+    // reserved for future navigation
+  }
+
+  private async render(state: DayGlanceState): Promise<void> {
+    if (!this.actionRef) return;
+    const { completed, total } = state.today;
+    const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
+    await this.actionRef.setTitle(`${completed}/${total}\n${pct}%`);
+  }
+}

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -1,0 +1,68 @@
+import {
+  action,
+  DialRotateEvent,
+  DialUpEvent,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+} from "@elgato/streamdeck";
+import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP } from "../client";
+
+type Settings = { sessionDurationMinutes: number };
+
+@action({ UUID: "app.dayglance.streamdeck.focus" })
+export class FocusAction extends SingletonAction<Settings> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private actionRef: any = null;
+  private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
+
+  override async onWillAppear(ev: WillAppearEvent<Settings>): Promise<void> {
+    this.actionRef = ev.action;
+    this.unsubscribe?.();
+    this.unsubscribe = onState((s) => {
+      this.lastState = s;
+      void this.render(s);
+    });
+  }
+
+  override async onDialRotate(ev: DialRotateEvent<Settings>): Promise<void> {
+    if (this.lastState?.focus.active) return;
+    const settings = await ev.action.getSettings();
+    const newDuration = Math.max(5, (settings.sessionDurationMinutes ?? 25) + ev.payload.ticks);
+    await ev.action.setSettings({ sessionDurationMinutes: newDuration });
+    await ev.action.setTitle(`${newDuration}m`);
+  }
+
+  override async onDialUp(_ev: DialUpEvent<Settings>): Promise<void> {
+    this.toggle();
+  }
+
+  override async onKeyDown(_ev: KeyDownEvent<Settings>): Promise<void> {
+    this.toggle();
+  }
+
+  private toggle(): void {
+    if (!this.lastState?.focus.active) {
+      send({ type: MSG_DAY_FOCUS_START });
+    } else {
+      send({ type: MSG_DAY_FOCUS_STOP });
+    }
+  }
+
+  private async render(state: DayGlanceState): Promise<void> {
+    if (!this.actionRef) return;
+    const { active, phase, secondsRemaining, running } = state.focus;
+    if (!active) {
+      await this.actionRef.setTitle("Focus");
+      await this.actionRef.setState(0);
+    } else {
+      const m = Math.floor(secondsRemaining / 60);
+      const s = secondsRemaining % 60;
+      const label = phase === "work" ? "Work" : "Break";
+      const timer = running ? `${m}:${s.toString().padStart(2, "0")}` : "Paused";
+      await this.actionRef.setTitle(`${label}\n${timer}`);
+      await this.actionRef.setState(1);
+    }
+  }
+}

--- a/stream-deck-plugin/src/actions/goal-progress.ts
+++ b/stream-deck-plugin/src/actions/goal-progress.ts
@@ -1,0 +1,37 @@
+import {
+  action,
+  DialRotateEvent,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+} from "@elgato/streamdeck";
+import { DayGlanceState, onState } from "../client";
+
+@action({ UUID: "app.dayglance.streamdeck.goal-progress" })
+export class GoalProgressAction extends SingletonAction {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private actionRef: any = null;
+  private unsubscribe: (() => void) | null = null;
+
+  override async onWillAppear(ev: WillAppearEvent): Promise<void> {
+    this.actionRef = ev.action;
+    this.unsubscribe?.();
+    this.unsubscribe = onState((s) => void this.render(s));
+  }
+
+  override async onDialRotate(_ev: DialRotateEvent): Promise<void> {
+    // TODO: cycle through goals when goal data is added to state
+  }
+
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
+    // TODO: interact with goal when goal data is added to state
+  }
+
+  private async render(state: DayGlanceState): Promise<void> {
+    if (!this.actionRef) return;
+    // Showing today's task completion until goal data is in the state shape
+    const { completed, total } = state.today;
+    const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
+    await this.actionRef.setTitle(`Today\n${pct}%`);
+  }
+}

--- a/stream-deck-plugin/src/actions/next-task.ts
+++ b/stream-deck-plugin/src/actions/next-task.ts
@@ -1,0 +1,50 @@
+import {
+  action,
+  DialRotateEvent,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+} from "@elgato/streamdeck";
+import { DayGlanceState, onState, send, MSG_DAY_TASK_COMPLETE } from "../client";
+
+@action({ UUID: "app.dayglance.streamdeck.next-task" })
+export class NextTaskAction extends SingletonAction {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private actionRef: any = null;
+  private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
+  private showNext = false; // false = currentTask, true = nextTask
+
+  override async onWillAppear(ev: WillAppearEvent): Promise<void> {
+    this.actionRef = ev.action;
+    this.unsubscribe?.();
+    this.unsubscribe = onState((s) => {
+      this.lastState = s;
+      void this.render(s);
+    });
+  }
+
+  override async onDialRotate(ev: DialRotateEvent): Promise<void> {
+    this.showNext = ev.payload.ticks > 0 ? true : false;
+    if (this.lastState) void this.render(this.lastState);
+  }
+
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
+    const task = this.showNext
+      ? this.lastState?.nextTask
+      : (this.lastState?.currentTask ?? this.lastState?.nextTask);
+    if (task) send({ type: MSG_DAY_TASK_COMPLETE, id: task.id });
+  }
+
+  private async render(state: DayGlanceState): Promise<void> {
+    if (!this.actionRef) return;
+    const task = this.showNext
+      ? state.nextTask
+      : (state.currentTask ?? state.nextTask);
+    await this.actionRef.setTitle(task ? truncate(task.title, 20) : "No tasks");
+  }
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}

--- a/stream-deck-plugin/src/actions/quick-glance.ts
+++ b/stream-deck-plugin/src/actions/quick-glance.ts
@@ -1,0 +1,74 @@
+import {
+  action,
+  DialRotateEvent,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+} from "@elgato/streamdeck";
+import { DayGlanceState, onState } from "../client";
+
+type DisplayMode = "date" | "next-event" | "focus";
+const MODES: DisplayMode[] = ["date", "next-event", "focus"];
+
+@action({ UUID: "app.dayglance.streamdeck.quick-glance" })
+export class QuickGlanceAction extends SingletonAction {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private actionRef: any = null;
+  private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
+  private modeIndex = 0;
+  private pinned = false;
+
+  override async onWillAppear(ev: WillAppearEvent): Promise<void> {
+    this.actionRef = ev.action;
+    this.unsubscribe?.();
+    this.unsubscribe = onState((s) => {
+      this.lastState = s;
+      void this.render(s);
+    });
+  }
+
+  override async onDialRotate(ev: DialRotateEvent): Promise<void> {
+    if (this.pinned) return;
+    this.modeIndex = (this.modeIndex + ev.payload.ticks + MODES.length) % MODES.length;
+    if (this.lastState) void this.render(this.lastState);
+  }
+
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
+    this.pinned = !this.pinned;
+  }
+
+  private async render(state: DayGlanceState): Promise<void> {
+    if (!this.actionRef) return;
+    const mode = MODES[this.modeIndex];
+    let title: string;
+
+    if (mode === "date") {
+      title = formatDate(state.today.date);
+    } else if (mode === "next-event") {
+      const task = state.currentTask ?? state.nextTask;
+      title = task ? truncate(task.title, 20) : "No events";
+    } else {
+      const { active, phase, secondsRemaining } = state.focus;
+      if (!active) {
+        title = "Focus\noff";
+      } else {
+        const m = Math.floor(secondsRemaining / 60);
+        const s = secondsRemaining % 60;
+        title = `${phase}\n${m}:${s.toString().padStart(2, "0")}`;
+      }
+    }
+
+    await this.actionRef.setTitle(title);
+  }
+}
+
+function formatDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}

--- a/stream-deck-plugin/src/client.ts
+++ b/stream-deck-plugin/src/client.ts
@@ -1,0 +1,74 @@
+import WebSocket from "ws";
+import {
+  PROTOCOL_VERSION,
+  MSG_DAY_STATE,
+  MSG_DAY_FOCUS_START,
+  MSG_DAY_FOCUS_STOP,
+  MSG_DAY_FOCUS_SKIP,
+  MSG_DAY_TASK_COMPLETE,
+  type DayGlanceState,
+  type InboundCommand,
+} from "../../electron/protocol";
+
+// Re-export everything action files need — keeps their imports pointing at ../client only
+export type { DayGlanceState, Task, FocusState } from "../../electron/protocol";
+export { MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_TASK_COMPLETE } from "../../electron/protocol";
+
+// CommandPayload is the caller-facing API — send() stamps v internally
+type CommandPayload =
+  | { type: typeof MSG_DAY_FOCUS_START }
+  | { type: typeof MSG_DAY_FOCUS_STOP }
+  | { type: typeof MSG_DAY_FOCUS_SKIP }
+  | { type: typeof MSG_DAY_TASK_COMPLETE; id: string };
+
+type StateListener = (state: DayGlanceState) => void;
+
+const WS_URL = "ws://localhost:7892";
+const RETRY_MS = 3000;
+
+let ws: WebSocket | null = null;
+let retryTimer: ReturnType<typeof setTimeout> | undefined;
+let lastState: DayGlanceState | null = null;
+const listeners = new Set<StateListener>();
+
+function connect(): void {
+  clearTimeout(retryTimer);
+  ws = new WebSocket(WS_URL);
+
+  ws.on("message", (data) => {
+    try {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === MSG_DAY_STATE) {
+        lastState = msg as DayGlanceState;
+        for (const listener of listeners) listener(lastState);
+      }
+    } catch {
+      // drop malformed frames
+    }
+  });
+
+  ws.on("close", () => {
+    retryTimer = setTimeout(connect, RETRY_MS);
+  });
+
+  ws.on("error", () => {
+    // "close" fires after "error" — retry is handled there
+  });
+}
+
+export function send(command: CommandPayload): void {
+  if (ws?.readyState === WebSocket.OPEN) {
+    const wire: InboundCommand = { v: PROTOCOL_VERSION, ...command } as InboundCommand;
+    ws.send(JSON.stringify(wire));
+  }
+}
+
+/** Subscribe to state updates. Returns an unsubscribe function.
+ *  Immediately invokes listener with the last known state if available. */
+export function onState(listener: StateListener): () => void {
+  listeners.add(listener);
+  if (lastState) listener(lastState);
+  return () => listeners.delete(listener);
+}
+
+connect();

--- a/stream-deck-plugin/src/plugin.ts
+++ b/stream-deck-plugin/src/plugin.ts
@@ -1,0 +1,15 @@
+import streamDeck from "@elgato/streamdeck";
+
+import { AgendaAction } from "./actions/agenda";
+import { FocusAction } from "./actions/focus-mode";
+import { GoalProgressAction } from "./actions/goal-progress";
+import { NextTaskAction } from "./actions/next-task";
+import { QuickGlanceAction } from "./actions/quick-glance";
+
+streamDeck.actions.registerAction(new AgendaAction());
+streamDeck.actions.registerAction(new FocusAction());
+streamDeck.actions.registerAction(new GoalProgressAction());
+streamDeck.actions.registerAction(new NextTaskAction());
+streamDeck.actions.registerAction(new QuickGlanceAction());
+
+streamDeck.connect();

--- a/stream-deck-plugin/tsconfig.json
+++ b/stream-deck-plugin/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "com.dayglance.streamdeck.sdPlugin/bin"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Four pre-ship architectural fixes from the GLANCEhub readiness audit. Strictly scoped — no feature changes, no behavior changes.

## Fix 1 — App namespace prefix on all WS message types

| Old | New |
|---|---|
| `state` | `day:state` |
| `focus:start` | `day:focus:start` |
| `focus:stop` | `day:focus:stop` |
| `focus:skip` | `day:focus:skip` |
| `task:complete` | `day:task:complete` |

Updated in: `useElectronBridge.js`, `stream-deck-plugin/src/client.ts`, `stream-deck-plugin/src/actions/focus-mode.ts`, `stream-deck-plugin/src/actions/next-task.ts`.

## Fix 2 — `v: 1` on all wire-protocol messages

Outbound state pushed from the renderer carries `{ v: PROTOCOL_VERSION, ... }`. Inbound commands are stamped by `client.ts send()` before hitting the wire — action callers don't need to include it.

## Fix 3 — `electron/protocol.ts` as the canonical protocol contract

New file owns: `PROTOCOL_VERSION`, all `MSG_DAY_*` string constants, `OutboundMessage`, `InboundCommand`, `DayGlanceState`, `Task`, `FocusState`.

- `ws-server.ts` imports `OutboundMessage` from it
- `useElectronBridge.js` imports all constants from it (Vite resolves the cross-directory `.ts` import natively)
- `stream-deck-plugin/src/client.ts` imports from `../../electron/protocol` and re-exports for action files; `rollup.config.mjs` sets `rootDir: "../.."` so the TypeScript plugin spans both source trees during bundling

**No message type string literal exists outside `protocol.ts`.** Verified with grep.

## Fix 4 — Pin Electron userData path explicitly

```ts
app.setPath('userData', path.join(app.getPath('appData'), 'dayGLANCE'));
```

Resolves to the exact same directory as the implicit default. Prevents silent data-orphan if `productName` ever changes.

## Acceptance criteria

- [x] Both TypeScript projects compile clean (`tsc --noEmit`)
- [x] Stream Deck plugin builds clean (`npm run build` in `stream-deck-plugin/`)
- [x] All WS messages use `day:*` prefixes and carry `v: 1`
- [x] `electron/protocol.ts` is the only file with `day:state` / `day:focus:*` / `day:task:complete` string literals
- [x] userData path resolves identically to the previous implicit default
- [x] No feature, UI, or behavioral changes

https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k

---
_Generated by [Claude Code](https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k)_