### PR TITLE
Sync GLANCEhub protocol v1 to stream-deck-develop

### DIFF
--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -1,0 +1,54 @@
+// Canonical protocol contract for the dayGLANCE Desktop ↔ client WebSocket API.
+// All message type string constants and wire-format types live here.
+// Clients (Stream Deck plugin, future integrations) import from this file.
+// Do not define these strings anywhere else in the codebase.
+
+export const PROTOCOL_VERSION = 1 as const;
+
+// ── Outbound message type constants (server → clients) ───────────────────
+export const MSG_DAY_STATE = 'day:state' as const;
+
+// ── Inbound command type constants (clients → server) ────────────────────
+export const MSG_DAY_FOCUS_START   = 'day:focus:start'   as const;
+export const MSG_DAY_FOCUS_STOP    = 'day:focus:stop'    as const;
+export const MSG_DAY_FOCUS_SKIP    = 'day:focus:skip'    as const;
+export const MSG_DAY_TASK_COMPLETE = 'day:task:complete' as const;
+
+// ── Shared data types ─────────────────────────────────────────────────────
+export type Task = {
+  id: string;
+  title: string;
+  startTime: string | null;
+  duration: number;
+  colorHex: string;
+  tags: string[];
+};
+
+export type FocusState = {
+  active: boolean;
+  phase: string;
+  secondsRemaining: number;
+  running: boolean;
+  workMinutes: number;
+  breakMinutes: number;
+};
+
+export type DayGlanceState = {
+  currentTask: Task | null;
+  nextTask: Task | null;
+  today: { total: number; completed: number; date: string };
+  focus: FocusState;
+};
+
+// ── Outbound message (server → clients) ──────────────────────────────────
+export type OutboundMessage = {
+  v: typeof PROTOCOL_VERSION;
+  type: typeof MSG_DAY_STATE;
+} & DayGlanceState;
+
+// ── Inbound commands (clients → server) ──────────────────────────────────
+export type InboundCommand =
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_START }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_STOP }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_SKIP }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_TASK_COMPLETE; id: string };

--- a/stream-deck-plugin/rollup.config.mjs
+++ b/stream-deck-plugin/rollup.config.mjs
@@ -12,7 +12,12 @@ export default {
   plugins: [
     resolve({ browser: false }),
     commonjs(),
-    typescript({ tsconfig: "./tsconfig.json" }),
+    typescript({
+      tsconfig: "./tsconfig.json",
+      // rootDir must span both src/ and ../../electron/ to allow the cross-package
+      // protocol import without a TypeScript rootDir violation during bundling.
+      rootDir: "../..",
+    }),
   ],
   external: [],
 };

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -6,7 +6,7 @@ import {
   SingletonAction,
   WillAppearEvent,
 } from "@elgato/streamdeck";
-import { DayGlanceState, onState, send } from "../client";
+import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP } from "../client";
 
 type Settings = { sessionDurationMinutes: number };
 
@@ -44,9 +44,9 @@ export class FocusAction extends SingletonAction<Settings> {
 
   private toggle(): void {
     if (!this.lastState?.focus.active) {
-      send({ type: "focus:start" });
+      send({ type: MSG_DAY_FOCUS_START });
     } else {
-      send({ type: "focus:stop" });
+      send({ type: MSG_DAY_FOCUS_STOP });
     }
   }
 

--- a/stream-deck-plugin/src/actions/next-task.ts
+++ b/stream-deck-plugin/src/actions/next-task.ts
@@ -5,7 +5,7 @@ import {
   SingletonAction,
   WillAppearEvent,
 } from "@elgato/streamdeck";
-import { DayGlanceState, onState, send } from "../client";
+import { DayGlanceState, onState, send, MSG_DAY_TASK_COMPLETE } from "../client";
 
 @action({ UUID: "app.dayglance.streamdeck.next-task" })
 export class NextTaskAction extends SingletonAction {
@@ -33,7 +33,7 @@ export class NextTaskAction extends SingletonAction {
     const task = this.showNext
       ? this.lastState?.nextTask
       : (this.lastState?.currentTask ?? this.lastState?.nextTask);
-    if (task) send({ type: "task:complete", id: task.id });
+    if (task) send({ type: MSG_DAY_TASK_COMPLETE, id: task.id });
   }
 
   private async render(state: DayGlanceState): Promise<void> {

--- a/stream-deck-plugin/src/client.ts
+++ b/stream-deck-plugin/src/client.ts
@@ -1,35 +1,25 @@
 import WebSocket from "ws";
+import {
+  PROTOCOL_VERSION,
+  MSG_DAY_STATE,
+  MSG_DAY_FOCUS_START,
+  MSG_DAY_FOCUS_STOP,
+  MSG_DAY_FOCUS_SKIP,
+  MSG_DAY_TASK_COMPLETE,
+  type DayGlanceState,
+  type InboundCommand,
+} from "../../electron/protocol";
 
-export type Task = {
-  id: string;
-  title: string;
-  startTime: string | null;
-  duration: number;
-  colorHex: string;
-  tags: string[];
-};
+// Re-export everything action files need — keeps their imports pointing at ../client only
+export type { DayGlanceState, Task, FocusState } from "../../electron/protocol";
+export { MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_TASK_COMPLETE } from "../../electron/protocol";
 
-export type FocusState = {
-  active: boolean;
-  phase: string;
-  secondsRemaining: number;
-  running: boolean;
-  workMinutes: number;
-  breakMinutes: number;
-};
-
-export type DayGlanceState = {
-  currentTask: Task | null;
-  nextTask: Task | null;
-  today: { total: number; completed: number; date: string };
-  focus: FocusState;
-};
-
-export type Command =
-  | { type: "focus:start" }
-  | { type: "focus:stop" }
-  | { type: "focus:skip" }
-  | { type: "task:complete"; id: string };
+// CommandPayload is the caller-facing API — send() stamps v internally
+type CommandPayload =
+  | { type: typeof MSG_DAY_FOCUS_START }
+  | { type: typeof MSG_DAY_FOCUS_STOP }
+  | { type: typeof MSG_DAY_FOCUS_SKIP }
+  | { type: typeof MSG_DAY_TASK_COMPLETE; id: string };
 
 type StateListener = (state: DayGlanceState) => void;
 
@@ -48,7 +38,7 @@ function connect(): void {
   ws.on("message", (data) => {
     try {
       const msg = JSON.parse(data.toString());
-      if (msg.type === "state") {
+      if (msg.type === MSG_DAY_STATE) {
         lastState = msg as DayGlanceState;
         for (const listener of listeners) listener(lastState);
       }
@@ -66,9 +56,10 @@ function connect(): void {
   });
 }
 
-export function send(command: Command): void {
+export function send(command: CommandPayload): void {
   if (ws?.readyState === WebSocket.OPEN) {
-    ws.send(JSON.stringify(command));
+    const wire: InboundCommand = { v: PROTOCOL_VERSION, ...command } as InboundCommand;
+    ws.send(JSON.stringify(wire));
   }
 }
 


### PR DESCRIPTION
## Summary

- Cherry-picks the GLANCEhub protocol v1 commit from `electron-develop` (merged via #587) into `stream-deck-develop`
- Brings `electron/protocol.ts` (canonical message type constants) into the stream-deck branch
- Updates `stream-deck-plugin/src/client.ts` to import from `protocol.ts` and stamp `v: PROTOCOL_VERSION` on outbound commands; checks `MSG_DAY_STATE` constant on inbound messages
- Updates `focus-mode.ts` and `next-task.ts` to use `MSG_DAY_FOCUS_START`, `MSG_DAY_FOCUS_STOP`, `MSG_DAY_TASK_COMPLETE` constants instead of raw strings
- Updates `rollup.config.mjs` with `rootDir: "../.."` so TypeScript can resolve the cross-directory `../../electron/protocol` import during bundling

Build verified: `npm run build` in `stream-deck-plugin/` passes cleanly.

## Test plan

- [ ] Merge this PR into `stream-deck-develop`
- [ ] `cd stream-deck-plugin && npm run build` — should produce `com.dayglance.streamdeck.sdPlugin/bin/plugin.js` with no errors
- [ ] Install plugin to Stream Deck and run `npm run dev:electron` — PI green dot, focus toggle and task completion work end-to-end

https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k

---
_Generated by [Claude Code](https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k)_