### PR TITLE
Replay last WS state to new clients on connect

### DIFF
--- a/electron/ws-server.ts
+++ b/electron/ws-server.ts
@@ -7,9 +7,11 @@ const WS_PORT = 7892;
 export function createWsServer(win: BrowserWindow): WebSocketServer {
   const wss = new WebSocketServer({ port: WS_PORT });
   const clients = new Set<WebSocket>();
+  let lastState: string | null = null;
 
   wss.on('connection', (ws) => {
     clients.add(ws);
+    if (lastState) ws.send(lastState);
 
     ws.on('message', (raw) => {
       try {
@@ -27,6 +29,7 @@ export function createWsServer(win: BrowserWindow): WebSocketServer {
   // Broadcast state updates from the renderer to all connected clients
   ipcMain.on('ws:push-state', (_event, state: OutboundMessage) => {
     const payload = JSON.stringify(state);
+    lastState = payload;
     for (const client of clients) {
       if (client.readyState === WebSocket.OPEN) {
         client.send(payload);


### PR DESCRIPTION
## Summary

- The WS server now caches the last `day:state` payload and immediately sends it to any new client that connects
- Without this, a Stream Deck plugin connecting after the Electron app has loaded receives no state until the next user-triggered change — keys stay on their manifest default titles indefinitely

## Test plan

- [ ] `npm run dev:electron`, wait for app to load
- [ ] Install/reload the Stream Deck plugin
- [ ] Keys should update within ~3 seconds (WS retry interval) without needing to interact with the app

https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k

---
_Generated by [Claude Code](https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k)_