### PR TITLE
Stream Deck: branded SVG key renderer + WS state replay fix

### DIFF
--- a/electron/ws-server.ts
+++ b/electron/ws-server.ts
@@ -7,9 +7,11 @@ const WS_PORT = 7892;
 export function createWsServer(win: BrowserWindow): WebSocketServer {
   const wss = new WebSocketServer({ port: WS_PORT });
   const clients = new Set<WebSocket>();
+  let lastState: string | null = null;
 
   wss.on('connection', (ws) => {
     clients.add(ws);
+    if (lastState) ws.send(lastState);
 
     ws.on('message', (raw) => {
       try {
@@ -27,6 +29,7 @@ export function createWsServer(win: BrowserWindow): WebSocketServer {
   // Broadcast state updates from the renderer to all connected clients
   ipcMain.on('ws:push-state', (_event, state: OutboundMessage) => {
     const payload = JSON.stringify(state);
+    lastState = payload;
     for (const client of clients) {
       if (client.readyState === WebSocket.OPEN) {
         client.send(payload);

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -5,6 +5,7 @@ import {
   WillAppearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState } from "../client";
+import { renderKey } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.agenda" })
 export class AgendaAction extends SingletonAction {
@@ -26,6 +27,7 @@ export class AgendaAction extends SingletonAction {
     if (!this.actionRef) return;
     const { completed, total } = state.today;
     const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
-    await this.actionRef.setTitle(`${completed}/${total}\n${pct}%`);
+    await this.actionRef.setImage(renderKey({ value: `${completed}/${total}`, sub: `${pct}% done` }));
+    await this.actionRef.setTitle("");
   }
 }

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -7,6 +7,7 @@ import {
   WillAppearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP } from "../client";
+import { renderKey } from "../render";
 
 type Settings = { sessionDurationMinutes: number };
 
@@ -31,7 +32,8 @@ export class FocusAction extends SingletonAction<Settings> {
     const settings = await ev.action.getSettings();
     const newDuration = Math.max(5, (settings.sessionDurationMinutes ?? 25) + ev.payload.ticks);
     await ev.action.setSettings({ sessionDurationMinutes: newDuration });
-    await ev.action.setTitle(`${newDuration}m`);
+    await this.actionRef.setImage(renderKey({ value: `${newDuration}m`, sub: "focus", barColor: "#3b82f6" }));
+    await this.actionRef.setTitle("");
   }
 
   override async onDialUp(_ev: DialUpEvent<Settings>): Promise<void> {
@@ -54,15 +56,15 @@ export class FocusAction extends SingletonAction<Settings> {
     if (!this.actionRef) return;
     const { active, phase, secondsRemaining, running } = state.focus;
     if (!active) {
-      await this.actionRef.setTitle("Focus");
-      await this.actionRef.setState(0);
+      await this.actionRef.setImage(renderKey({ value: "Focus", sub: "press to start", dim: true }));
     } else {
       const m = Math.floor(secondsRemaining / 60);
       const s = secondsRemaining % 60;
-      const label = phase === "work" ? "Work" : "Break";
-      const timer = running ? `${m}:${s.toString().padStart(2, "0")}` : "Paused";
-      await this.actionRef.setTitle(`${label}\n${timer}`);
-      await this.actionRef.setState(1);
+      const time = `${m}:${s.toString().padStart(2, "0")}`;
+      const sub = running ? (phase === "work" ? "work" : "break") : "paused";
+      const barColor = phase === "work" ? "#f97316" : "#22c55e";
+      await this.actionRef.setImage(renderKey({ value: time, sub, barColor }));
     }
+    await this.actionRef.setTitle("");
   }
 }

--- a/stream-deck-plugin/src/actions/goal-progress.ts
+++ b/stream-deck-plugin/src/actions/goal-progress.ts
@@ -6,6 +6,7 @@ import {
   WillAppearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState } from "../client";
+import { renderKey } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.goal-progress" })
 export class GoalProgressAction extends SingletonAction {
@@ -29,9 +30,9 @@ export class GoalProgressAction extends SingletonAction {
 
   private async render(state: DayGlanceState): Promise<void> {
     if (!this.actionRef) return;
-    // Showing today's task completion until goal data is in the state shape
     const { completed, total } = state.today;
     const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
-    await this.actionRef.setTitle(`Today\n${pct}%`);
+    await this.actionRef.setImage(renderKey({ value: `${pct}%`, sub: "Today" }));
+    await this.actionRef.setTitle("");
   }
 }

--- a/stream-deck-plugin/src/actions/next-task.ts
+++ b/stream-deck-plugin/src/actions/next-task.ts
@@ -6,6 +6,7 @@ import {
   WillAppearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState, send, MSG_DAY_TASK_COMPLETE } from "../client";
+import { renderKey } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.next-task" })
 export class NextTaskAction extends SingletonAction {
@@ -13,7 +14,7 @@ export class NextTaskAction extends SingletonAction {
   private actionRef: any = null;
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;
-  private showNext = false; // false = currentTask, true = nextTask
+  private showNext = false;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.actionRef = ev.action;
@@ -25,7 +26,7 @@ export class NextTaskAction extends SingletonAction {
   }
 
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {
-    this.showNext = ev.payload.ticks > 0 ? true : false;
+    this.showNext = ev.payload.ticks > 0;
     if (this.lastState) void this.render(this.lastState);
   }
 
@@ -41,7 +42,13 @@ export class NextTaskAction extends SingletonAction {
     const task = this.showNext
       ? state.nextTask
       : (state.currentTask ?? state.nextTask);
-    await this.actionRef.setTitle(task ? truncate(task.title, 20) : "No tasks");
+    const label = this.showNext ? "next task" : "current task";
+    if (task) {
+      await this.actionRef.setImage(renderKey({ value: truncate(task.title, 18), sub: label }));
+    } else {
+      await this.actionRef.setImage(renderKey({ value: "No tasks", dim: true }));
+    }
+    await this.actionRef.setTitle("");
   }
 }
 

--- a/stream-deck-plugin/src/actions/quick-glance.ts
+++ b/stream-deck-plugin/src/actions/quick-glance.ts
@@ -6,6 +6,7 @@ import {
   WillAppearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState } from "../client";
+import { renderKey } from "../render";
 
 type DisplayMode = "date" | "next-event" | "focus";
 const MODES: DisplayMode[] = ["date", "next-event", "focus"];
@@ -41,32 +42,40 @@ export class QuickGlanceAction extends SingletonAction {
   private async render(state: DayGlanceState): Promise<void> {
     if (!this.actionRef) return;
     const mode = MODES[this.modeIndex];
-    let title: string;
 
     if (mode === "date") {
-      title = formatDate(state.today.date);
+      const { weekday, month, day } = formatDate(state.today.date);
+      await this.actionRef.setImage(renderKey({ value: `${month} ${day}`, sub: weekday }));
     } else if (mode === "next-event") {
       const task = state.currentTask ?? state.nextTask;
-      title = task ? truncate(task.title, 20) : "No events";
+      if (task) {
+        await this.actionRef.setImage(renderKey({ value: truncate(task.title, 18), sub: "next up" }));
+      } else {
+        await this.actionRef.setImage(renderKey({ value: "Clear", sub: "no events", dim: true }));
+      }
     } else {
       const { active, phase, secondsRemaining } = state.focus;
       if (!active) {
-        title = "Focus\noff";
+        await this.actionRef.setImage(renderKey({ value: "Focus", sub: "off", dim: true }));
       } else {
         const m = Math.floor(secondsRemaining / 60);
         const s = secondsRemaining % 60;
-        title = `${phase}\n${m}:${s.toString().padStart(2, "0")}`;
+        const barColor = phase === "work" ? "#f97316" : "#22c55e";
+        await this.actionRef.setImage(renderKey({ value: `${m}:${s.toString().padStart(2, "0")}`, sub: phase, barColor }));
       }
     }
-
-    await this.actionRef.setTitle(title);
+    await this.actionRef.setTitle("");
   }
 }
 
-function formatDate(iso: string): string {
+function formatDate(iso: string): { weekday: string; month: string; day: string } {
   const [y, m, d] = iso.split("-").map(Number);
   const date = new Date(y, m - 1, d);
-  return date.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+  return {
+    weekday: date.toLocaleDateString("en-US", { weekday: "long" }),
+    month: date.toLocaleDateString("en-US", { month: "short" }),
+    day: String(d),
+  };
 }
 
 function truncate(s: string, max: number): string {

--- a/stream-deck-plugin/src/render.ts
+++ b/stream-deck-plugin/src/render.ts
@@ -1,0 +1,40 @@
+const FONT = "-apple-system, 'Helvetica Neue', Arial, sans-serif";
+const ORANGE = "#f97316";
+const W = 144;
+const H = 144;
+
+interface KeyOpts {
+  value: string;
+  sub?: string;
+  label?: string;
+  barColor?: string;
+  dim?: boolean;
+}
+
+export function renderKey(opts: KeyOpts): string {
+  const { value, sub = "", label = "dayGLANCE", barColor = ORANGE, dim = false } = opts;
+  const valueColor = dim ? "rgba(255,255,255,0.4)" : "white";
+  const subColor = dim ? "rgba(255,255,255,0.25)" : "rgba(255,255,255,0.55)";
+  const valueY = sub ? "78" : "88";
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}">
+  <rect width="${W}" height="${H}" fill="#111"/>
+  <rect width="${W}" height="5" fill="${barColor}"/>
+  <text x="72" y="22" font-family="${FONT}" font-size="13" fill="rgba(255,255,255,0.38)" text-anchor="middle" letter-spacing="0.5">${escape(label)}</text>
+  <text x="72" y="${valueY}" font-family="${FONT}" font-size="${fontSize(value)}" fill="${valueColor}" text-anchor="middle" font-weight="700">${escape(value)}</text>
+  ${sub ? `<text x="72" y="108" font-family="${FONT}" font-size="18" fill="${subColor}" text-anchor="middle">${escape(sub)}</text>` : ""}
+</svg>`;
+
+  return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
+}
+
+function fontSize(text: string): number {
+  if (text.length <= 4) return 44;
+  if (text.length <= 7) return 34;
+  if (text.length <= 12) return 24;
+  return 18;
+}
+
+function escape(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}


### PR DESCRIPTION
## Summary

- Adds `stream-deck-plugin/src/render.ts` — generates inline SVG key images with an orange brand bar, muted "dayGLANCE" label, bold value, and subtitle
- Updates all 5 actions (Agenda, Focus, Next Task, Goal Progress, Quick Glance) to use `setImage()` with the SVG renderer instead of plain `setTitle()`
- Focus bar turns green during breaks, blue while adjusting duration
- Dim mode for empty states ("No tasks", "Focus off")
- Also includes the WS state replay fix (new clients receive last known state on connect) which was missing from `electron-develop`

## Test plan

- [ ] Build plugin (`cd stream-deck-plugin && npm run build`), reinstall, restart Electron
- [ ] Each key shows orange bar + "dayGLANCE" label
- [ ] Next Task key shows actual task title + "current task" / "next task" subtitle
- [ ] Focus key shows countdown when session is active, orange bar for work / green for break
- [ ] Keys populate immediately on connect without needing to interact with the app

https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k

---
_Generated by [Claude Code](https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k)_