### PR TITLE
Fix Stream Deck page-switch repaint

### DIFF
--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -12,11 +12,13 @@ export class AgendaAction extends SingletonAction {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private actionRef: any = null;
   private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.actionRef = ev.action;
     this.unsubscribe?.();
-    this.unsubscribe = onState((s) => void this.render(s));
+    this.unsubscribe = onState((s) => { this.lastState = s; void this.render(s); });
+    if (this.lastState) await this.render(this.lastState);
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -25,6 +25,7 @@ export class FocusAction extends SingletonAction<Settings> {
       this.lastState = s;
       void this.render(s);
     });
+    if (this.lastState) await this.render(this.lastState);
   }
 
   override async onDialRotate(ev: DialRotateEvent<Settings>): Promise<void> {

--- a/stream-deck-plugin/src/actions/goal-progress.ts
+++ b/stream-deck-plugin/src/actions/goal-progress.ts
@@ -13,11 +13,13 @@ export class GoalProgressAction extends SingletonAction {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private actionRef: any = null;
   private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.actionRef = ev.action;
     this.unsubscribe?.();
-    this.unsubscribe = onState((s) => void this.render(s));
+    this.unsubscribe = onState((s) => { this.lastState = s; void this.render(s); });
+    if (this.lastState) await this.render(this.lastState);
   }
 
   override async onDialRotate(_ev: DialRotateEvent): Promise<void> {

--- a/stream-deck-plugin/src/actions/next-task.ts
+++ b/stream-deck-plugin/src/actions/next-task.ts
@@ -23,6 +23,7 @@ export class NextTaskAction extends SingletonAction {
       this.lastState = s;
       void this.render(s);
     });
+    if (this.lastState) await this.render(this.lastState);
   }
 
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {

--- a/stream-deck-plugin/src/actions/quick-glance.ts
+++ b/stream-deck-plugin/src/actions/quick-glance.ts
@@ -27,6 +27,7 @@ export class QuickGlanceAction extends SingletonAction {
       this.lastState = s;
       void this.render(s);
     });
+    if (this.lastState) await this.render(this.lastState);
   }
 
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {

--- a/stream-deck-plugin/src/render.ts
+++ b/stream-deck-plugin/src/render.ts
@@ -13,16 +13,16 @@ interface KeyOpts {
 
 export function renderKey(opts: KeyOpts): string {
   const { value, sub = "", label = "dayGLANCE", barColor = ORANGE, dim = false } = opts;
-  const valueColor = dim ? "rgba(255,255,255,0.4)" : "white";
-  const subColor = dim ? "rgba(255,255,255,0.25)" : "rgba(255,255,255,0.55)";
+  const valueOpacity = dim ? "0.4" : "1";
+  const subOpacity = dim ? "0.25" : "0.55";
   const valueY = sub ? "78" : "88";
 
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}">
   <rect width="${W}" height="${H}" fill="#111"/>
   <rect width="${W}" height="5" fill="${barColor}"/>
-  <text x="72" y="22" font-family="${FONT}" font-size="13" fill="rgba(255,255,255,0.38)" text-anchor="middle" letter-spacing="0.5">${escape(label)}</text>
-  <text x="72" y="${valueY}" font-family="${FONT}" font-size="${fontSize(value)}" fill="${valueColor}" text-anchor="middle" font-weight="700">${escape(value)}</text>
-  ${sub ? `<text x="72" y="108" font-family="${FONT}" font-size="18" fill="${subColor}" text-anchor="middle">${escape(sub)}</text>` : ""}
+  <text x="72" y="22" font-family="${FONT}" font-size="13" fill="white" fill-opacity="0.38" text-anchor="middle" letter-spacing="0.5">${escape(label)}</text>
+  <text x="72" y="${valueY}" font-family="${FONT}" font-size="${fontSize(value)}" fill="white" fill-opacity="${valueOpacity}" text-anchor="middle" font-weight="700">${escape(value)}</text>
+  ${sub ? `<text x="72" y="108" font-family="${FONT}" font-size="18" fill="white" fill-opacity="${subOpacity}" text-anchor="middle">${escape(sub)}</text>` : ""}
 </svg>`;
 
   return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");


### PR DESCRIPTION
## Summary

When switching between Stream Deck pages, `onWillAppear` fires for each returning action. The previous code called `void this.render()` (fire-and-forget) inside the `onState` subscription, which meant the async render raced against the SDK resetting the key image to the manifest default — the custom image lost.

Fix: each action now awaits the render explicitly at the end of `onWillAppear`, ensuring the branded SVG image is set before the event handler returns. Also adds `lastState` caching to `AgendaAction` and `GoalProgressAction` which were missing it.

## Test plan

- [ ] Merge, rebuild plugin (`cd stream-deck-plugin && npm run build`), reinstall
- [ ] Switch away from the dayGLANCE page and back — keys should repopulate immediately without flickering to default

https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k

---
_Generated by [Claude Code](https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k)_