### PR TITLE
Stream Deck: add WS + render error logging for real-time update debugging

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6065,6 +6065,45 @@ const DayPlanner = () => {
     setUnscheduledTasks(prev => prev.map(t => t.id === id ? { ...t, archived: false } : t));
   };
 
+  // Focus mode availability: current task or back-to-back block >= 45 min remaining
+  const focusModeAvailable = useMemo(() => {
+    const now = currentTime;
+    const nowMin = now.getHours() * 60 + now.getMinutes();
+    const todayTasks = getTasksForDate(now);
+
+    const timelineTasks = todayTasks
+      .filter(t => !t.isAllDay && !t.completed && t.startTime)
+      .sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime));
+
+    const inProgress = timelineTasks.filter(t => {
+      const start = timeToMinutes(t.startTime);
+      const end = start + t.duration;
+      return start <= nowMin && end > nowMin;
+    });
+
+    if (inProgress.length === 0) return false;
+
+    let blockStart = Math.min(...inProgress.map(t => timeToMinutes(t.startTime)));
+    let blockEnd = Math.max(...inProgress.map(t => timeToMinutes(t.startTime) + t.duration));
+
+    let extended = true;
+    while (extended) {
+      extended = false;
+      for (const t of timelineTasks) {
+        const tStart = timeToMinutes(t.startTime);
+        const tEnd = tStart + t.duration;
+        if (tStart <= blockEnd && tEnd > blockEnd) {
+          blockEnd = tEnd;
+          extended = true;
+        }
+      }
+    }
+
+    const remainingMinutes = blockEnd - nowMin;
+    return remainingMinutes >= 45;
+  }, [currentTime, tasks, expandedRecurringTasks]);
+  focusModeAvailableRef.current = focusModeAvailable;
+
   // ── Electron desktop bridge ──────────────────────────────────────────────
   // Pushes lightweight state snapshots to the Electron WebSocket server and
   // routes commands from connected clients (Stream Deck, etc.) back into the app.
@@ -6851,51 +6890,6 @@ const DayPlanner = () => {
     } catch {}
     setAiSubtasksLoadingForTask(null);
   }, [aiConfig, pushUndo, updateRecurringTemplate]);
-
-  // Focus mode availability: current task or back-to-back block >= 45 min remaining
-  const focusModeAvailable = useMemo(() => {
-    const now = currentTime;
-    const nowMin = now.getHours() * 60 + now.getMinutes();
-    const todayDateStr = dateToString(now);
-    const todayTasks = getTasksForDate(now);
-
-    // Get all non-completed timeline tasks happening now or in the future, sorted by start
-    const timelineTasks = todayTasks
-      .filter(t => !t.isAllDay && !t.completed && t.startTime)
-      .sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime));
-
-    // Find contiguous block that includes the current time
-    // First, find tasks currently in progress
-    const inProgress = timelineTasks.filter(t => {
-      const start = timeToMinutes(t.startTime);
-      const end = start + t.duration;
-      return start <= nowMin && end > nowMin;
-    });
-
-    if (inProgress.length === 0) return false;
-
-    // Find the earliest start and then extend forward through back-to-back tasks
-    let blockStart = Math.min(...inProgress.map(t => timeToMinutes(t.startTime)));
-    let blockEnd = Math.max(...inProgress.map(t => timeToMinutes(t.startTime) + t.duration));
-
-    // Extend block forward with back-to-back or overlapping tasks
-    let extended = true;
-    while (extended) {
-      extended = false;
-      for (const t of timelineTasks) {
-        const tStart = timeToMinutes(t.startTime);
-        const tEnd = tStart + t.duration;
-        if (tStart <= blockEnd && tEnd > blockEnd) {
-          blockEnd = tEnd;
-          extended = true;
-        }
-      }
-    }
-
-    const remainingMinutes = blockEnd - nowMin;
-    return remainingMinutes >= 45;
-  }, [currentTime, tasks, expandedRecurringTasks]);
-  focusModeAvailableRef.current = focusModeAvailable;
 
   // Focus mode: compute the current block tasks (used to snapshot when entering focus mode)
   const computeFocusBlockTasks = () => {

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -17,7 +17,7 @@ export class AgendaAction extends SingletonAction {
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.actionRef = ev.action;
     this.unsubscribe?.();
-    this.unsubscribe = onState((s) => { this.lastState = s; void this.render(s); });
+    this.unsubscribe = onState((s) => { this.lastState = s; this.render(s).catch(e => console.error("[dayGLANCE] agenda render:", e)); });
     if (this.lastState) await this.render(this.lastState);
   }
 

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -23,7 +23,7 @@ export class FocusAction extends SingletonAction<Settings> {
     this.unsubscribe?.();
     this.unsubscribe = onState((s) => {
       this.lastState = s;
-      void this.render(s);
+      this.render(s).catch(e => console.error("[dayGLANCE] focus-mode render:", e));
     });
     if (this.lastState) await this.render(this.lastState);
   }

--- a/stream-deck-plugin/src/actions/goal-progress.ts
+++ b/stream-deck-plugin/src/actions/goal-progress.ts
@@ -18,7 +18,7 @@ export class GoalProgressAction extends SingletonAction {
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.actionRef = ev.action;
     this.unsubscribe?.();
-    this.unsubscribe = onState((s) => { this.lastState = s; void this.render(s); });
+    this.unsubscribe = onState((s) => { this.lastState = s; this.render(s).catch(e => console.error("[dayGLANCE] goal-progress render:", e)); });
     if (this.lastState) await this.render(this.lastState);
   }
 

--- a/stream-deck-plugin/src/actions/next-task.ts
+++ b/stream-deck-plugin/src/actions/next-task.ts
@@ -21,14 +21,14 @@ export class NextTaskAction extends SingletonAction {
     this.unsubscribe?.();
     this.unsubscribe = onState((s) => {
       this.lastState = s;
-      void this.render(s);
+      this.render(s).catch(e => console.error("[dayGLANCE] next-task render:", e));
     });
     if (this.lastState) await this.render(this.lastState);
   }
 
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {
     this.showNext = ev.payload.ticks > 0;
-    if (this.lastState) void this.render(this.lastState);
+    if (this.lastState) this.render(this.lastState).catch(e => console.error("[dayGLANCE] next-task render:", e));
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {

--- a/stream-deck-plugin/src/actions/quick-glance.ts
+++ b/stream-deck-plugin/src/actions/quick-glance.ts
@@ -25,7 +25,7 @@ export class QuickGlanceAction extends SingletonAction {
     this.unsubscribe?.();
     this.unsubscribe = onState((s) => {
       this.lastState = s;
-      void this.render(s);
+      this.render(s).catch(e => console.error("[dayGLANCE] quick-glance render:", e));
     });
     if (this.lastState) await this.render(this.lastState);
   }
@@ -33,7 +33,7 @@ export class QuickGlanceAction extends SingletonAction {
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {
     if (this.pinned) return;
     this.modeIndex = (this.modeIndex + ev.payload.ticks + MODES.length) % MODES.length;
-    if (this.lastState) void this.render(this.lastState);
+    if (this.lastState) this.render(this.lastState).catch(e => console.error("[dayGLANCE] quick-glance render:", e));
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {

--- a/stream-deck-plugin/src/client.ts
+++ b/stream-deck-plugin/src/client.ts
@@ -33,14 +33,26 @@ const listeners = new Set<StateListener>();
 
 function connect(): void {
   clearTimeout(retryTimer);
+  console.log("[dayGLANCE] connecting to", WS_URL);
   ws = new WebSocket(WS_URL);
+
+  ws.on("open", () => {
+    console.log("[dayGLANCE] WS connected");
+  });
 
   ws.on("message", (data) => {
     try {
       const msg = JSON.parse(data.toString());
       if (msg.type === MSG_DAY_STATE) {
         lastState = msg as DayGlanceState;
-        for (const listener of listeners) listener(lastState);
+        console.log("[dayGLANCE] state received, listeners:", listeners.size, "currentTask:", lastState.currentTask?.title ?? "none");
+        for (const listener of listeners) {
+          try {
+            listener(lastState);
+          } catch (e) {
+            console.error("[dayGLANCE] listener error:", e);
+          }
+        }
       }
     } catch {
       // drop malformed frames
@@ -48,6 +60,7 @@ function connect(): void {
   });
 
   ws.on("close", () => {
+    console.log("[dayGLANCE] WS closed, retrying in", RETRY_MS, "ms");
     retryTimer = setTimeout(connect, RETRY_MS);
   });
 


### PR DESCRIPTION
## Summary

- `client.ts` now logs `[dayGLANCE] connecting`, `WS connected`, `WS closed`, and every state receipt with the number of active listeners and current task title
- All `void this.render(s)` calls replaced with `.catch(e => console.error(...))` so any `setImage`/`renderKey` failure is visible in the Stream Deck plugin log instead of silently dropped

## Why

Keys aren't updating in real-time. The WS pipeline is confirmed working (DevTools WebSocket receives correct messages). The bug is inside the plugin process. This logging will tell us:
1. Whether the plugin's WebSocket is connecting at all
2. How many listeners are registered when state arrives (0 = actions never appeared)
3. Whether render is throwing silently

## Test plan

- [ ] Rebuild and reinstall plugin
- [ ] Open Stream Deck plugin debug log (right-click plugin in Stream Deck app → View Plugin Log, or check `~/Library/Logs/ElgatoStreamDeck/`)
- [ ] Should see `[dayGLANCE] connecting to ws://localhost:7892` then `WS connected`
- [ ] Should see `[dayGLANCE] state received, listeners: N` on every state push
- [ ] Any render errors will now appear as `[dayGLANCE] <action> render: <error>`

https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k

---
_Generated by [Claude Code](https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k)_