### PR TITLE
Stream Deck: Habit + Routine buttons; strip tags from task titles

### DIFF
--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -9,10 +9,12 @@ export const PROTOCOL_VERSION = 1 as const;
 export const MSG_DAY_STATE = 'day:state' as const;
 
 // ── Inbound command type constants (clients → server) ────────────────────
-export const MSG_DAY_FOCUS_START   = 'day:focus:start'   as const;
-export const MSG_DAY_FOCUS_STOP    = 'day:focus:stop'    as const;
-export const MSG_DAY_FOCUS_SKIP    = 'day:focus:skip'    as const;
-export const MSG_DAY_TASK_COMPLETE = 'day:task:complete' as const;
+export const MSG_DAY_FOCUS_START      = 'day:focus:start'      as const;
+export const MSG_DAY_FOCUS_STOP       = 'day:focus:stop'       as const;
+export const MSG_DAY_FOCUS_SKIP       = 'day:focus:skip'       as const;
+export const MSG_DAY_TASK_COMPLETE    = 'day:task:complete'    as const;
+export const MSG_DAY_HABIT_INCREMENT  = 'day:habit:increment'  as const;
+export const MSG_DAY_ROUTINE_COMPLETE = 'day:routine:complete' as const;
 
 // ── Shared data types ─────────────────────────────────────────────────────
 export type Task = {
@@ -34,11 +36,32 @@ export type FocusState = {
   breakMinutes: number;
 };
 
+export type Habit = {
+  id: string;
+  name: string;
+  colorHex: string;     // habit's brand color (ring color from HABIT_COLORS)
+  ringColorHex: string; // display color — same as colorHex for doMore, traffic-light for limit
+  count: number;        // today's logged count
+  target: number;       // daily goal or limit
+  unit: string;         // e.g. "glasses", "min"
+  type: 'doMore' | 'limit';
+  complete: boolean;
+};
+
+export type Routine = {
+  id: string;
+  name: string;
+  startTime: string | null;
+  completed: boolean;
+};
+
 export type DayGlanceState = {
   currentTask: Task | null;
   nextTask: Task | null;
   today: { total: number; completed: number; date: string };
   focus: FocusState;
+  habits: Habit[];
+  nextRoutine: Routine | null;
 };
 
 // ── Outbound message (server → clients) ──────────────────────────────────
@@ -52,4 +75,6 @@ export type InboundCommand =
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_START }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_STOP }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_SKIP }
-  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_TASK_COMPLETE; id: string };
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_TASK_COMPLETE; id: string }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_HABIT_INCREMENT; id: string }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_ROUTINE_COMPLETE; id: string };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6122,6 +6122,13 @@ const DayPlanner = () => {
     exitFocusModeRef,
     skipFocusPhase,
     toggleComplete,
+    activeHabits,
+    getTodayHabitCount,
+    habitsEnabled,
+    incrementHabit,
+    todayRoutines,
+    routineCompletions,
+    toggleRoutineCompletion,
   });
 
   // ── Native Android widget snapshot sync ──────────────────────────────────

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -8,6 +8,8 @@ import {
   MSG_DAY_FOCUS_STOP,
   MSG_DAY_FOCUS_SKIP,
   MSG_DAY_TASK_COMPLETE,
+  MSG_DAY_HABIT_INCREMENT,
+  MSG_DAY_ROUTINE_COMPLETE,
 } from '../../electron/protocol';
 
 const timeToMinutes = (time) => {
@@ -16,18 +18,26 @@ const timeToMinutes = (time) => {
   return h * 60 + (m || 0);
 };
 
+// Inline habit color map (mirrors HABIT_COLORS ring values from src/constants/habits.js)
+const HABIT_COLOR_HEX = {
+  blue: '#3b82f6', green: '#22c55e', red: '#ef4444', amber: '#f59e0b',
+  purple: '#a855f7', pink: '#ec4899', cyan: '#06b6d4', orange: '#f97316',
+};
+
+function habitRingColor(habit, count) {
+  const base = HABIT_COLOR_HEX[habit.color] ?? '#3b82f6';
+  if (habit.type === 'limit') {
+    if (count === 0) return '#22c55e';
+    if (count <= habit.target * 0.5) return '#eab308';
+    if (count <= habit.target) return '#f59e0b';
+    return '#ef4444';
+  }
+  return count === 0 ? '#d1d5db' : base;
+}
+
 // Pushes a lightweight state snapshot to the Electron WebSocket server
 // (ws://localhost:7892) whenever app state changes, and routes incoming
 // commands from connected clients (e.g. Stream Deck plugin) back to the app.
-//
-// Message types pushed to clients:
-//   { v: PROTOCOL_VERSION, type: MSG_DAY_STATE, currentTask, nextTask, today, focus }
-//
-// Commands received from clients:
-//   { v: PROTOCOL_VERSION, type: MSG_DAY_FOCUS_START }
-//   { v: PROTOCOL_VERSION, type: MSG_DAY_FOCUS_STOP }
-//   { v: PROTOCOL_VERSION, type: MSG_DAY_FOCUS_SKIP }
-//   { v: PROTOCOL_VERSION, type: MSG_DAY_TASK_COMPLETE, id: string }
 export default function useElectronBridge({
   todayAgenda,
   currentTime,
@@ -43,11 +53,24 @@ export default function useElectronBridge({
   exitFocusModeRef,
   skipFocusPhase,
   toggleComplete,
+  // Habits
+  activeHabits,
+  getTodayHabitCount,
+  habitsEnabled,
+  incrementHabit,
+  // Routines
+  todayRoutines,
+  routineCompletions,
+  toggleRoutineCompletion,
 }) {
   const skipFocusPhaseRef = useRef(skipFocusPhase);
   const toggleCompleteRef = useRef(toggleComplete);
+  const incrementHabitRef = useRef(incrementHabit);
+  const toggleRoutineCompletionRef = useRef(toggleRoutineCompletion);
   skipFocusPhaseRef.current = skipFocusPhase;
   toggleCompleteRef.current = toggleComplete;
+  incrementHabitRef.current = incrementHabit;
+  toggleRoutineCompletionRef.current = toggleRoutineCompletion;
 
   // Subscribe to commands from WebSocket clients once on mount.
   useEffect(() => {
@@ -66,6 +89,12 @@ export default function useElectronBridge({
           break;
         case MSG_DAY_TASK_COMPLETE:
           if (cmd.id) toggleCompleteRef.current?.(cmd.id);
+          break;
+        case MSG_DAY_HABIT_INCREMENT:
+          if (cmd.id) incrementHabitRef.current?.(cmd.id);
+          break;
+        case MSG_DAY_ROUTINE_COMPLETE:
+          if (cmd.id) toggleRoutineCompletionRef.current?.(cmd.id);
           break;
       }
     });
@@ -100,6 +129,29 @@ export default function useElectronBridge({
     const todayStr = dateToString(currentTime);
     const todayTasks = tasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay);
 
+    // ── Habits ────────────────────────────────────────────────────────────
+    const habits = habitsEnabled ? (activeHabits ?? []).map(h => {
+      const count = getTodayHabitCount(h.id);
+      const colorHex = HABIT_COLOR_HEX[h.color] ?? '#3b82f6';
+      const ringColorHex = habitRingColor(h, count);
+      return {
+        id: h.id,
+        name: h.name,
+        colorHex,
+        ringColorHex,
+        count,
+        target: h.target,
+        unit: h.unit ?? '',
+        type: h.type || 'doMore',
+        complete: h.type === 'doMore' ? (h.target > 0 && count >= h.target) : false,
+      };
+    }) : [];
+
+    // ── Next routine (next uncompleted scheduled routine for today) ────────
+    const nextRoutineRaw = (todayRoutines ?? [])
+      .filter(r => r.startTime && !r.isAllDay && !routineCompletions?.[r.id])
+      .sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime))[0] ?? null;
+
     window.electronAPI.pushState({
       v: PROTOCOL_VERSION,
       type: MSG_DAY_STATE,
@@ -119,6 +171,19 @@ export default function useElectronBridge({
         workMinutes: focusWorkMinutes,
         breakMinutes: focusBreakMinutes,
       },
+      habits,
+      nextRoutine: nextRoutineRaw ? {
+        id: nextRoutineRaw.id,
+        name: nextRoutineRaw.name,
+        startTime: nextRoutineRaw.startTime,
+        completed: false,
+      } : null,
     });
-  }, [todayAgenda, currentTime, tasks, focusModeAvailable, showFocusMode, focusPhase, focusTimerSeconds, focusTimerRunning, focusWorkMinutes, focusBreakMinutes]);
+  }, [
+    todayAgenda, currentTime, tasks, focusModeAvailable,
+    showFocusMode, focusPhase, focusTimerSeconds, focusTimerRunning,
+    focusWorkMinutes, focusBreakMinutes,
+    activeHabits, getTodayHabitCount, habitsEnabled,
+    todayRoutines, routineCompletions,
+  ]);
 }

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -111,6 +111,28 @@
       "States": [
         { "Image": "imgs/actions/quick-glance/key", "TitleAlignment": "bottom" }
       ]
+    },
+    {
+      "Name": "Habit",
+      "UUID": "app.dayglance.streamdeck.habit",
+      "Icon": "imgs/actions/agenda/icon",
+      "Tooltip": "Shows today's count for a selected habit. Press to log one increment.",
+      "PropertyInspectorPath": "ui/habit-pi.html",
+      "Controllers": ["Keypad"],
+      "States": [
+        { "Image": "imgs/actions/agenda/key", "TitleAlignment": "bottom" }
+      ]
+    },
+    {
+      "Name": "Next Routine",
+      "UUID": "app.dayglance.streamdeck.routine",
+      "Icon": "imgs/actions/next-task/icon",
+      "Tooltip": "Shows the next uncompleted routine for today. Press to mark it done.",
+      "PropertyInspectorPath": "ui/property-inspector.html",
+      "Controllers": ["Keypad"],
+      "States": [
+        { "Image": "imgs/actions/next-task/key", "TitleAlignment": "bottom" }
+      ]
     }
   ]
 }

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/ui/habit-pi.html
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/ui/habit-pi.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    :root {
+      --brand: #fe8b00;
+      --bg: #1e1e1e;
+      --surface: #2a2a2a;
+      --border: #3a3a3a;
+      --text: #d4d4d4;
+      --text-dim: #888;
+      --radius: 4px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 13px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 12px;
+    }
+
+    .status-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 0 6px;
+    }
+
+    .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--border);
+      flex-shrink: 0;
+      transition: background 0.2s;
+    }
+
+    .dot.connected    { background: #4caf50; }
+    .dot.disconnected { background: var(--text-dim); }
+
+    .status-label { font-size: 13px; color: var(--text); }
+    .hint { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+
+    .divider { border: none; border-top: 1px solid var(--border); margin: 12px 0; }
+
+    label {
+      display: block;
+      font-size: 11px;
+      color: var(--text-dim);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 6px;
+    }
+
+    select {
+      width: 100%;
+      padding: 7px 10px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      font-size: 13px;
+      cursor: pointer;
+      appearance: none;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23888'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 10px center;
+    }
+
+    select:focus { outline: none; border-color: var(--brand); }
+  </style>
+</head>
+<body>
+  <div class="status-row">
+    <div class="dot disconnected" id="dot"></div>
+    <span class="status-label" id="statusLabel">Connecting…</span>
+  </div>
+  <p class="hint">Open dayGLANCE Desktop to connect</p>
+
+  <hr class="divider" />
+
+  <label for="habit-select">Habit</label>
+  <select id="habit-select">
+    <option value="">— Pick a habit —</option>
+  </select>
+
+  <script>
+    const DG_WS_URL = "ws://localhost:7892";
+    const RETRY_MS  = 4000;
+
+    // ── Stream Deck socket (settings) ──────────────────────────────────────
+    let sdWs = null;
+    let sdContext = null;
+    let currentHabitId = null;
+
+    function connectElgatoStreamDeckSocket(port, pluginUUID, registerEvent) {
+      sdContext = pluginUUID;
+      sdWs = new WebSocket("ws://127.0.0.1:" + port);
+      sdWs.onopen = () => {
+        sdWs.send(JSON.stringify({ event: registerEvent, uuid: pluginUUID }));
+        sdWs.send(JSON.stringify({ event: "getSettings", context: pluginUUID }));
+      };
+      sdWs.onmessage = (ev) => {
+        try {
+          const data = JSON.parse(ev.data);
+          if (data.event === "didReceiveSettings") {
+            currentHabitId = data.payload?.settings?.habitId ?? null;
+            syncSelection();
+          }
+        } catch {}
+      };
+    }
+
+    function saveSettings(habitId) {
+      if (sdWs?.readyState === WebSocket.OPEN && sdContext) {
+        sdWs.send(JSON.stringify({
+          event: "setSettings",
+          context: sdContext,
+          payload: { habitId: habitId || null },
+        }));
+      }
+    }
+
+    // ── dayGLANCE Desktop socket (habit list) ──────────────────────────────
+    let dgWs  = null;
+    let retry = null;
+    let knownHabits = [];
+
+    function setStatus(connected) {
+      document.getElementById("dot").className = "dot " + (connected ? "connected" : "disconnected");
+      document.getElementById("statusLabel").textContent = connected
+        ? "Connected" : "dayGLANCE Desktop not running";
+    }
+
+    function probe() {
+      clearTimeout(retry);
+      if (dgWs) { dgWs.onopen = dgWs.onclose = dgWs.onerror = dgWs.onmessage = null; dgWs.close(); }
+
+      dgWs = new WebSocket(DG_WS_URL);
+      dgWs.onopen  = () => setStatus(true);
+      dgWs.onclose = () => { setStatus(false); retry = setTimeout(probe, RETRY_MS); };
+      dgWs.onerror = () => {};
+      dgWs.onmessage = (ev) => {
+        try {
+          const msg = JSON.parse(ev.data);
+          if (msg.type === "day:state" && Array.isArray(msg.habits)) {
+            knownHabits = msg.habits;
+            populateSelect(msg.habits);
+          }
+        } catch {}
+      };
+    }
+
+    function populateSelect(habits) {
+      const sel = document.getElementById("habit-select");
+      // Keep the placeholder, rebuild the rest
+      while (sel.options.length > 1) sel.remove(1);
+      for (const h of habits) {
+        const opt = document.createElement("option");
+        opt.value = h.id;
+        opt.textContent = h.name + (h.unit ? " (" + h.unit + ")" : "");
+        sel.appendChild(opt);
+      }
+      syncSelection();
+    }
+
+    function syncSelection() {
+      const sel = document.getElementById("habit-select");
+      sel.value = currentHabitId ?? "";
+    }
+
+    document.getElementById("habit-select").addEventListener("change", (ev) => {
+      saveSettings(ev.target.value || null);
+    });
+
+    probe();
+  </script>
+</body>
+</html>

--- a/stream-deck-plugin/src/actions/habit.ts
+++ b/stream-deck-plugin/src/actions/habit.ts
@@ -1,0 +1,84 @@
+import {
+  action,
+  DidReceiveSettingsEvent,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+  WillDisappearEvent,
+} from "@elgato/streamdeck";
+import { DayGlanceState, onState, send, MSG_DAY_HABIT_INCREMENT } from "../client";
+import { renderKey, truncate } from "../render";
+
+type Settings = { habitId: string | null };
+
+@action({ UUID: "app.dayglance.streamdeck.habit" })
+export class HabitAction extends SingletonAction<Settings> {
+  private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
+  private visibleCount = 0;
+
+  override async onWillAppear(ev: WillAppearEvent<Settings>): Promise<void> {
+    this.visibleCount++;
+
+    if (!this.unsubscribe) {
+      this.unsubscribe = onState((s) => {
+        this.lastState = s;
+        this.renderAll(s).catch(e => console.error("[dayGLANCE] habit render:", e));
+      });
+    }
+
+    // Render this specific key on appear (onState may have fired before ev.action joined this.actions)
+    const settings = await ev.action.getSettings();
+    if (this.lastState) {
+      await this.renderOne(ev.action, settings.habitId ?? null, this.lastState)
+        .catch(e => console.error("[dayGLANCE] habit render:", e));
+    }
+  }
+
+  override async onWillDisappear(_ev: WillDisappearEvent<Settings>): Promise<void> {
+    this.visibleCount = Math.max(0, this.visibleCount - 1);
+    if (this.visibleCount === 0) {
+      this.unsubscribe?.();
+      this.unsubscribe = null;
+    }
+  }
+
+  override async onDidReceiveSettings(ev: DidReceiveSettingsEvent<Settings>): Promise<void> {
+    if (this.lastState) {
+      await this.renderOne(ev.action, ev.payload.settings.habitId ?? null, this.lastState)
+        .catch(e => console.error("[dayGLANCE] habit render:", e));
+    }
+  }
+
+  override async onKeyDown(ev: KeyDownEvent<Settings>): Promise<void> {
+    const settings = await ev.action.getSettings();
+    if (settings.habitId) send({ type: MSG_DAY_HABIT_INCREMENT, id: settings.habitId });
+  }
+
+  private async renderAll(state: DayGlanceState): Promise<void> {
+    for (const act of this.actions) {
+      const settings = await act.getSettings<Settings>();
+      await this.renderOne(act, settings.habitId ?? null, state);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async renderOne(action: any, habitId: string | null, state: DayGlanceState): Promise<void> {
+    if (!habitId) {
+      await action.setImage(renderKey({ value: "Habit", sub: "select in settings", dim: true }));
+      await action.setTitle("");
+      return;
+    }
+    const habit = state.habits.find((h) => h.id === habitId);
+    if (!habit) {
+      await action.setImage(renderKey({ value: "—", sub: "habit not found", dim: true }));
+      await action.setTitle("");
+      return;
+    }
+    const valueStr = `${habit.count}/${habit.target}`;
+    const sub = truncate(habit.name, 14);
+    const barColor = habit.complete ? "#22c55e" : habit.ringColorHex;
+    await action.setImage(renderKey({ value: valueStr, sub, barColor }));
+    await action.setTitle("");
+  }
+}

--- a/stream-deck-plugin/src/actions/next-task.ts
+++ b/stream-deck-plugin/src/actions/next-task.ts
@@ -6,7 +6,7 @@ import {
   WillAppearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState, send, MSG_DAY_TASK_COMPLETE } from "../client";
-import { renderKey } from "../render";
+import { renderKey, stripTags, truncate } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.next-task" })
 export class NextTaskAction extends SingletonAction {
@@ -45,14 +45,10 @@ export class NextTaskAction extends SingletonAction {
       : (state.currentTask ?? state.nextTask);
     const label = this.showNext ? "next task" : "current task";
     if (task) {
-      await this.actionRef.setImage(renderKey({ value: truncate(task.title, 18), sub: label }));
+      await this.actionRef.setImage(renderKey({ value: truncate(stripTags(task.title), 18), sub: label }));
     } else {
       await this.actionRef.setImage(renderKey({ value: "No tasks", dim: true }));
     }
     await this.actionRef.setTitle("");
   }
-}
-
-function truncate(s: string, max: number): string {
-  return s.length <= max ? s : s.slice(0, max - 1) + "…";
 }

--- a/stream-deck-plugin/src/actions/quick-glance.ts
+++ b/stream-deck-plugin/src/actions/quick-glance.ts
@@ -6,7 +6,7 @@ import {
   WillAppearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState } from "../client";
-import { renderKey } from "../render";
+import { renderKey, stripTags, truncate } from "../render";
 
 type DisplayMode = "date" | "next-event" | "focus";
 const MODES: DisplayMode[] = ["date", "next-event", "focus"];
@@ -50,7 +50,7 @@ export class QuickGlanceAction extends SingletonAction {
     } else if (mode === "next-event") {
       const task = state.currentTask ?? state.nextTask;
       if (task) {
-        await this.actionRef.setImage(renderKey({ value: truncate(task.title, 18), sub: "next up" }));
+        await this.actionRef.setImage(renderKey({ value: truncate(stripTags(task.title), 18), sub: "next up" }));
       } else {
         await this.actionRef.setImage(renderKey({ value: "Clear", sub: "no events", dim: true }));
       }
@@ -79,6 +79,3 @@ function formatDate(iso: string): { weekday: string; month: string; day: string 
   };
 }
 
-function truncate(s: string, max: number): string {
-  return s.length <= max ? s : s.slice(0, max - 1) + "…";
-}

--- a/stream-deck-plugin/src/actions/routine.ts
+++ b/stream-deck-plugin/src/actions/routine.ts
@@ -1,0 +1,44 @@
+import {
+  action,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+} from "@elgato/streamdeck";
+import { DayGlanceState, onState, send, MSG_DAY_ROUTINE_COMPLETE } from "../client";
+import { renderKey, truncate } from "../render";
+
+@action({ UUID: "app.dayglance.streamdeck.routine" })
+export class RoutineAction extends SingletonAction {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private actionRef: any = null;
+  private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
+
+  override async onWillAppear(ev: WillAppearEvent): Promise<void> {
+    this.actionRef = ev.action;
+    this.unsubscribe?.();
+    this.unsubscribe = onState((s) => {
+      this.lastState = s;
+      this.render(s).catch(e => console.error("[dayGLANCE] routine render:", e));
+    });
+    if (this.lastState) await this.render(this.lastState);
+  }
+
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
+    const routine = this.lastState?.nextRoutine;
+    if (routine) send({ type: MSG_DAY_ROUTINE_COMPLETE, id: routine.id });
+  }
+
+  private async render(state: DayGlanceState): Promise<void> {
+    if (!this.actionRef) return;
+    const routine = state.nextRoutine;
+    if (!routine) {
+      await this.actionRef.setImage(renderKey({ value: "✓", sub: "all done", barColor: "#22c55e" }));
+    } else {
+      const name = truncate(routine.name, 14);
+      const sub = routine.startTime ?? "routine";
+      await this.actionRef.setImage(renderKey({ value: name, sub }));
+    }
+    await this.actionRef.setTitle("");
+  }
+}

--- a/stream-deck-plugin/src/client.ts
+++ b/stream-deck-plugin/src/client.ts
@@ -6,20 +6,24 @@ import {
   MSG_DAY_FOCUS_STOP,
   MSG_DAY_FOCUS_SKIP,
   MSG_DAY_TASK_COMPLETE,
+  MSG_DAY_HABIT_INCREMENT,
+  MSG_DAY_ROUTINE_COMPLETE,
   type DayGlanceState,
   type InboundCommand,
 } from "../../electron/protocol";
 
 // Re-export everything action files need — keeps their imports pointing at ../client only
 export type { DayGlanceState, Task, FocusState } from "../../electron/protocol";
-export { MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_TASK_COMPLETE } from "../../electron/protocol";
+export { MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_TASK_COMPLETE, MSG_DAY_HABIT_INCREMENT, MSG_DAY_ROUTINE_COMPLETE } from "../../electron/protocol";
 
 // CommandPayload is the caller-facing API — send() stamps v internally
 type CommandPayload =
   | { type: typeof MSG_DAY_FOCUS_START }
   | { type: typeof MSG_DAY_FOCUS_STOP }
   | { type: typeof MSG_DAY_FOCUS_SKIP }
-  | { type: typeof MSG_DAY_TASK_COMPLETE; id: string };
+  | { type: typeof MSG_DAY_TASK_COMPLETE; id: string }
+  | { type: typeof MSG_DAY_HABIT_INCREMENT; id: string }
+  | { type: typeof MSG_DAY_ROUTINE_COMPLETE; id: string };
 
 type StateListener = (state: DayGlanceState) => void;
 
@@ -45,14 +49,7 @@ function connect(): void {
       const msg = JSON.parse(data.toString());
       if (msg.type === MSG_DAY_STATE) {
         lastState = msg as DayGlanceState;
-        console.log("[dayGLANCE] state received, listeners:", listeners.size, "currentTask:", lastState.currentTask?.title ?? "none");
-        for (const listener of listeners) {
-          try {
-            listener(lastState);
-          } catch (e) {
-            console.error("[dayGLANCE] listener error:", e);
-          }
-        }
+        for (const listener of listeners) listener(lastState);
       }
     } catch {
       // drop malformed frames

--- a/stream-deck-plugin/src/plugin.ts
+++ b/stream-deck-plugin/src/plugin.ts
@@ -3,13 +3,17 @@ import streamDeck from "@elgato/streamdeck";
 import { AgendaAction } from "./actions/agenda";
 import { FocusAction } from "./actions/focus-mode";
 import { GoalProgressAction } from "./actions/goal-progress";
+import { HabitAction } from "./actions/habit";
 import { NextTaskAction } from "./actions/next-task";
 import { QuickGlanceAction } from "./actions/quick-glance";
+import { RoutineAction } from "./actions/routine";
 
 streamDeck.actions.registerAction(new AgendaAction());
 streamDeck.actions.registerAction(new FocusAction());
 streamDeck.actions.registerAction(new GoalProgressAction());
+streamDeck.actions.registerAction(new HabitAction());
 streamDeck.actions.registerAction(new NextTaskAction());
 streamDeck.actions.registerAction(new QuickGlanceAction());
+streamDeck.actions.registerAction(new RoutineAction());
 
 streamDeck.connect();

--- a/stream-deck-plugin/src/render.ts
+++ b/stream-deck-plugin/src/render.ts
@@ -35,6 +35,19 @@ function fontSize(text: string): number {
   return 18;
 }
 
+/** Strips #hashtags and [[wikilinks]] from a task title. */
+export function stripTags(s: string): string {
+  return s
+    .replace(/\[\[[^\]]+\]\]/g, "")
+    .replace(/#\w[\w\d_]*/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}
+
 function escape(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }


### PR DESCRIPTION
## Summary

### New buttons

**Habit** (`app.dayglance.streamdeck.habit`)
- Multi-key: add as many Habit buttons as you like, each showing a different habit
- Pick which habit via the Property Inspector — a dropdown populated live from the WS state (open dayGLANCE Desktop to see habits listed)
- Displays `count / target` as the main value, habit name as sub-label, and the habit's brand color as the bar (turns green when complete)
- Press increments the habit by 1 (same as tapping the ring in the app)

**Next Routine** (`app.dayglance.streamdeck.routine`)
- Shows the next uncompleted scheduled routine for today (sorted by start time)
- Sub-label shows the scheduled time
- Press marks it complete (toggles completion, same as the app)
- Shows a green ✓ / "all done" when all routines are checked off

### Tag stripping
Task titles on the **Next Task** and **Quick Glance** buttons now strip `#hashtags` and `[[wikilinks]]` before display so they don't eat up the limited key space.

### Protocol additions
- `Habit` and `Routine` wire types added to `electron/protocol.ts`
- `MSG_DAY_HABIT_INCREMENT` and `MSG_DAY_ROUTINE_COMPLETE` commands added
- `habits[]` and `nextRoutine` added to `DayGlanceState`

### Bridge additions
- `useElectronBridge` now receives `activeHabits`, `getTodayHabitCount`, `habitsEnabled`, `incrementHabit`, `todayRoutines`, `routineCompletions`, `toggleRoutineCompletion`
- Pushes habits (with computed `ringColorHex` for limit-type habits) and next routine on every state change

## Test plan

- [ ] Rebuild plugin, reinstall, restart Stream Deck
- [ ] Add a Habit button → Property Inspector shows a dropdown of your habits
- [ ] Pick a habit → key shows `count/target` and habit color bar
- [ ] Press key → count increments in app and on key
- [ ] Add a Next Routine button → shows next uncompleted routine by time
- [ ] Press key → routine marked complete in app; key advances to next
- [ ] Task titles on Next Task / Quick Glance keys no longer show `#tags`

https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k

---
_Generated by [Claude Code](https://claude.ai/code/session_018G7Sg2EfsYstsQ48WqW85k)_