### PR TITLE
Stream Deck: Agenda button cycles through scheduled tasks

### DIFF
--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -58,6 +58,7 @@ export type Routine = {
 export type DayGlanceState = {
   currentTask: Task | null;
   nextTask: Task | null;
+  scheduledTasks: Task[];
   today: { total: number; completed: number; date: string };
   focus: FocusState;
   habits: Habit[];

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -157,6 +157,9 @@ export default function useElectronBridge({
       type: MSG_DAY_STATE,
       currentTask: mapTask(inProgress),
       nextTask: mapTask(nextUpcoming),
+      scheduledTasks: [...todayTasks]
+        .sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime))
+        .map(mapTask),
       today: {
         total: todayTasks.length,
         completed: todayTasks.filter(t => t.completed).length,

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -31,7 +31,7 @@
         "layout": "$B1",
         "TriggerDescription": {
           "Rotate": "Scroll agenda forward / back",
-          "Push": "Open event detail"
+          "Push": "Cycle through tasks / back to overview"
         }
       },
       "States": [

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -5,7 +5,7 @@ import {
   WillAppearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState } from "../client";
-import { renderKey } from "../render";
+import { renderKey, stripTags, truncate } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.agenda" })
 export class AgendaAction extends SingletonAction {
@@ -13,23 +13,52 @@ export class AgendaAction extends SingletonAction {
   private actionRef: any = null;
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;
+  // 0 = overview (X/Y + Z%), 1..N = task at index (viewIndex - 1)
+  private viewIndex: number = 0;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.actionRef = ev.action;
+    this.viewIndex = 0;
     this.unsubscribe?.();
-    this.unsubscribe = onState((s) => { this.lastState = s; this.render(s).catch(e => console.error("[dayGLANCE] agenda render:", e)); });
+    this.unsubscribe = onState((s) => {
+      this.lastState = s;
+      const count = s.scheduledTasks?.length ?? 0;
+      if (this.viewIndex > count) this.viewIndex = 0;
+      this.render(s).catch(e => console.error("[dayGLANCE] agenda render:", e));
+    });
     if (this.lastState) await this.render(this.lastState);
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
-    // reserved for future navigation
+    if (!this.lastState) return;
+    const count = this.lastState.scheduledTasks?.length ?? 0;
+    if (count === 0) return;
+    this.viewIndex = (this.viewIndex + 1) % (count + 1);
+    await this.render(this.lastState);
   }
 
   private async render(state: DayGlanceState): Promise<void> {
     if (!this.actionRef) return;
-    const { completed, total } = state.today;
-    const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
-    await this.actionRef.setImage(renderKey({ value: `${completed}/${total}`, sub: `${pct}% done` }));
+    const tasks = state.scheduledTasks ?? [];
+    if (this.viewIndex === 0 || tasks.length === 0) {
+      const { completed, total } = state.today;
+      const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
+      await this.actionRef.setImage(renderKey({ value: `${completed}/${total}`, sub: `${pct}% done` }));
+    } else {
+      const task = tasks[this.viewIndex - 1];
+      const title = truncate(stripTags(task.title), 12);
+      const time = task.startTime ? formatTime(task.startTime) : "";
+      await this.actionRef.setImage(renderKey({
+        value: title,
+        sub: time,
+        barColor: task.colorHex,
+      }));
+    }
     await this.actionRef.setTitle("");
   }
+}
+
+function formatTime(t: string): string {
+  const [h, m] = t.split(":");
+  return `${parseInt(h, 10)}:${m}`;
 }


### PR DESCRIPTION
## Summary

- Pressing the Agenda button now cycles through today's scheduled tasks one by one, then wraps back to the overview screen (`X/Y · Z% done`)
- Each task card shows the stripped title (up to 12 chars), start time, and the task's color bar
- `viewIndex` auto-clamps to 0 if the task list shrinks mid-cycle (e.g. a task gets completed from another button)
- Protocol extended: `DayGlanceState` gains `scheduledTasks: Task[]`, populated in `useElectronBridge` sorted by start time

## Files changed

| File | Change |
|---|---|
| `electron/protocol.ts` | Added `scheduledTasks: Task[]` to `DayGlanceState` |
| `src/hooks/useElectronBridge.js` | Populates `scheduledTasks` from today's scheduled tasks, sorted by start time |
| `stream-deck-plugin/src/actions/agenda.ts` | Implements `viewIndex` cycling on `onKeyDown`; renders task card or overview accordingly |
| `stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json` | Updated Push trigger description |

## Test plan

- [ ] Default state: button shows `X/Y · Z% done` overview
- [ ] With scheduled tasks: each press advances to the next task (title + time, colored bar)
- [ ] After the last task: next press wraps back to the overview
- [ ] With no scheduled tasks: button stays on overview, presses are no-ops
- [ ] Complete a task mid-cycle (via another button): `viewIndex` clamps gracefully, no crash

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_