### PR TITLE
fix(stream-deck): Agenda encoder press now cycles tasks

### DIFF
--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -1,5 +1,6 @@
 import {
   action,
+  DialUpEvent,
   KeyDownEvent,
   SingletonAction,
   WillAppearEvent,
@@ -29,7 +30,15 @@ export class AgendaAction extends SingletonAction {
     if (this.lastState) await this.render(this.lastState);
   }
 
+  override async onDialUp(_ev: DialUpEvent): Promise<void> {
+    await this.cycle();
+  }
+
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
+    await this.cycle();
+  }
+
+  private async cycle(): Promise<void> {
     if (!this.lastState) return;
     const count = this.lastState.scheduledTasks?.length ?? 0;
     if (count === 0) return;


### PR DESCRIPTION
## Summary

- Adds `onDialUp` handler to `AgendaAction` so pressing the encoder knob cycles through tasks
- `onKeyDown` (for regular keypad slots) and `onDialUp` (for encoder slots) now both delegate to a shared `cycle()` method

## Root cause

`onKeyDown` only fires when the action is placed in a Keypad slot. Pressing an encoder knob fires `onDialUp` — which was unhandled, so presses were silently no-ops.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_