### PR TITLE
fix(stream-deck): Agenda syncs all visible instances on press

### DIFF
--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -4,30 +4,39 @@ import {
   KeyDownEvent,
   SingletonAction,
   WillAppearEvent,
+  WillDisappearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState } from "../client";
 import { renderKey, stripTags, truncate } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.agenda" })
 export class AgendaAction extends SingletonAction {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private actionRef: any = null;
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;
   // 0 = overview (X/Y + Z%), 1..N = task at index (viewIndex - 1)
   private viewIndex: number = 0;
+  private visibleCount = 0;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
-    this.actionRef = ev.action;
-    this.viewIndex = 0;
-    this.unsubscribe?.();
-    this.unsubscribe = onState((s) => {
-      this.lastState = s;
-      const count = s.scheduledTasks?.length ?? 0;
-      if (this.viewIndex > count) this.viewIndex = 0;
-      this.render(s).catch(e => console.error("[dayGLANCE] agenda render:", e));
-    });
-    if (this.lastState) await this.render(this.lastState);
+    this.visibleCount++;
+    if (!this.unsubscribe) {
+      this.viewIndex = 0;
+      this.unsubscribe = onState((s) => {
+        this.lastState = s;
+        const count = s.scheduledTasks?.length ?? 0;
+        if (this.viewIndex > count) this.viewIndex = 0;
+        this.renderAll(s).catch(e => console.error("[dayGLANCE] agenda render:", e));
+      });
+    }
+    if (this.lastState) await this.renderOne(ev.action, this.lastState);
+  }
+
+  override async onWillDisappear(_ev: WillDisappearEvent): Promise<void> {
+    this.visibleCount = Math.max(0, this.visibleCount - 1);
+    if (this.visibleCount === 0) {
+      this.unsubscribe?.();
+      this.unsubscribe = null;
+    }
   }
 
   override async onDialUp(_ev: DialUpEvent): Promise<void> {
@@ -43,27 +52,29 @@ export class AgendaAction extends SingletonAction {
     const count = this.lastState.scheduledTasks?.length ?? 0;
     if (count === 0) return;
     this.viewIndex = (this.viewIndex + 1) % (count + 1);
-    await this.render(this.lastState);
+    await this.renderAll(this.lastState);
   }
 
-  private async render(state: DayGlanceState): Promise<void> {
-    if (!this.actionRef) return;
+  private async renderAll(state: DayGlanceState): Promise<void> {
+    for (const act of this.actions) {
+      await this.renderOne(act, state);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async renderOne(act: any, state: DayGlanceState): Promise<void> {
     const tasks = state.scheduledTasks ?? [];
     if (this.viewIndex === 0 || tasks.length === 0) {
       const { completed, total } = state.today;
       const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
-      await this.actionRef.setImage(renderKey({ value: `${completed}/${total}`, sub: `${pct}% done` }));
+      await act.setImage(renderKey({ value: `${completed}/${total}`, sub: `${pct}% done` }));
     } else {
       const task = tasks[this.viewIndex - 1];
       const title = truncate(stripTags(task.title), 12);
       const time = task.startTime ? formatTime(task.startTime) : "";
-      await this.actionRef.setImage(renderKey({
-        value: title,
-        sub: time,
-        barColor: task.colorHex,
-      }));
+      await act.setImage(renderKey({ value: title, sub: time, barColor: task.colorHex }));
     }
-    await this.actionRef.setTitle("");
+    await act.setTitle("");
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixes Agenda keypad button staying stale when the encoder dial is pressed (and vice versa)
- Adopts the same `this.actions` / `visibleCount` pattern as `HabitAction`

## Root cause

`AgendaAction` stored a single `actionRef` — whichever instance appeared last. When both a Keypad and Encoder slot are on the deck simultaneously, `onWillAppear` fires twice and the second call overwrites the ref. `renderAll` then only updates one instance; the other is frozen.

## Fix

- Replace `actionRef` with `renderAll()` iterating `this.actions` (the SDK-maintained set of all visible instances)
- `visibleCount` gates subscription lifecycle — subscribe on first appear, unsubscribe when last instance disappears
- `viewIndex` resets to 0 only when the subscription is first created (first instance appears), not on every subsequent appear

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_