### PR TITLE
feat(stream-deck): Agenda touch strip + strikethrough for completed tasks

### DIFF
--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -24,6 +24,7 @@ export type Task = {
   duration: number;
   colorHex: string;
   tags: string[];
+  completed: boolean;
 };
 
 export type FocusState = {

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -124,6 +124,7 @@ export default function useElectronBridge({
       duration: t.duration || 0,
       colorHex: taskColorToHex(t.color, t.nativeCalendarColor),
       tags: t.tags || [],
+      completed: !!t.completed,
     } : null;
 
     const todayStr = dateToString(currentTime);

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -64,17 +64,23 @@ export class AgendaAction extends SingletonAction {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async renderOne(act: any, state: DayGlanceState): Promise<void> {
     const tasks = state.scheduledTasks ?? [];
+    let image: string;
     if (this.viewIndex === 0 || tasks.length === 0) {
       const { completed, total } = state.today;
       const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
-      await act.setImage(renderKey({ value: `${completed}/${total}`, sub: `${pct}% done` }));
+      image = renderKey({ value: `${completed}/${total}`, sub: `${pct}% done` });
     } else {
       const task = tasks[this.viewIndex - 1];
       const title = truncate(stripTags(task.title), 12);
       const time = task.startTime ? formatTime(task.startTime) : "";
-      await act.setImage(renderKey({ value: title, sub: time, barColor: task.colorHex }));
+      image = renderKey({ value: title, sub: time, barColor: task.colorHex, strikethrough: task.completed });
     }
-    await act.setTitle("");
+    if (act.controller === "Encoder") {
+      await act.setFeedback({ icon: image });
+    } else {
+      await act.setImage(image);
+      await act.setTitle("");
+    }
   }
 }
 

--- a/stream-deck-plugin/src/render.ts
+++ b/stream-deck-plugin/src/render.ts
@@ -9,19 +9,21 @@ interface KeyOpts {
   label?: string;
   barColor?: string;
   dim?: boolean;
+  strikethrough?: boolean;
 }
 
 export function renderKey(opts: KeyOpts): string {
-  const { value, sub = "", label = "dayGLANCE", barColor = ORANGE, dim = false } = opts;
+  const { value, sub = "", label = "dayGLANCE", barColor = ORANGE, dim = false, strikethrough = false } = opts;
   const valueOpacity = dim ? "0.4" : "1";
   const subOpacity = dim ? "0.25" : "0.55";
   const valueY = sub ? "78" : "88";
+  const strikeAttr = strikethrough ? ' text-decoration="line-through"' : "";
 
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}">
   <rect width="${W}" height="${H}" fill="#111"/>
   <rect width="${W}" height="5" fill="${barColor}"/>
   <text x="72" y="22" font-family="${FONT}" font-size="13" fill="white" fill-opacity="0.38" text-anchor="middle" letter-spacing="0.5">day<tspan font-style="italic">GLANCE</tspan></text>
-  <text x="72" y="${valueY}" font-family="${FONT}" font-size="${fontSize(value)}" fill="white" fill-opacity="${valueOpacity}" text-anchor="middle" font-weight="700">${escape(value)}</text>
+  <text x="72" y="${valueY}" font-family="${FONT}" font-size="${fontSize(value)}" fill="white" fill-opacity="${valueOpacity}" text-anchor="middle" font-weight="700"${strikeAttr}>${escape(value)}</text>
   ${sub ? `<text x="72" y="108" font-family="${FONT}" font-size="18" fill="white" fill-opacity="${subOpacity}" text-anchor="middle">${escape(sub)}</text>` : ""}
 </svg>`;
 


### PR DESCRIPTION
## Summary

- **Touch strip fix**: encoder LCD now receives the image correctly
- **Strikethrough**: completed tasks show struck-through titles in the cycle view

## Touch strip root cause

`setImage()` is keypad-only in the Stream Deck SDK. Encoder instances require `setFeedback({ icon: base64Image })` to update their LCD panel. `renderOne()` now branches on `act.controller`:

```ts
if (act.controller === "Encoder") {
  await act.setFeedback({ icon: image });
} else {
  await act.setImage(image);
  await act.setTitle("");
}
```

## Strikethrough

- `completed: boolean` added to `Task` in `protocol.ts`
- `mapTask()` in `useElectronBridge.js` now maps `t.completed`
- `renderKey()` accepts `strikethrough?: boolean` and applies `text-decoration="line-through"` to the SVG value text
- Agenda's `renderOne()` passes `strikethrough: task.completed` for task cards

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_