### PR TITLE
fix(stream-deck): revert encoder setFeedback, restore setImage for all instances

### DIFF
--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -75,12 +75,8 @@ export class AgendaAction extends SingletonAction {
       const time = task.startTime ? formatTime(task.startTime) : "";
       image = renderKey({ value: title, sub: time, barColor: task.colorHex, strikethrough: task.completed });
     }
-    if (act.controller === "Encoder") {
-      await act.setFeedback({ icon: image });
-    } else {
-      await act.setImage(image);
-      await act.setTitle("");
-    }
+    await act.setImage(image);
+    await act.setTitle("");
   }
 }
 


### PR DESCRIPTION
## Summary

Reverts the `setFeedback({ icon })` change introduced in #599 for encoder instances.

## What broke

`setFeedback({ icon: image })` caused the encoder LCD to go blank and silently swallowed errors during rendering, making the dial press appear to do nothing.

## Why setImage() is correct

`setImage()` was confirmed working for both Keypad and Encoder instances in PRs #597 and #598 — the encoder dial displayed "Blue Task 8:30" correctly in that state. The research suggesting encoders need `setFeedback` was wrong for this SDK version / `$B1` layout combination.

## Touch strip

The touch strip showing a gray bar is a pre-existing, separate issue — it was already gray before #599. Leaving that for a future investigation.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_