### PR TITLE
fix(stream-deck): draw strikethrough as SVG line instead of text-decoration

### DIFF
--- a/stream-deck-plugin/src/render.ts
+++ b/stream-deck-plugin/src/render.ts
@@ -17,13 +17,18 @@ export function renderKey(opts: KeyOpts): string {
   const valueOpacity = dim ? "0.4" : "1";
   const subOpacity = dim ? "0.25" : "0.55";
   const valueY = sub ? "78" : "88";
-  const strikeAttr = strikethrough ? ' text-decoration="line-through"' : "";
+  const fs = fontSize(value);
+  // Approximate half-width: ~0.55× font-size per char for bold sans-serif, capped at key margin
+  const strikeHalfW = Math.min((value.length * fs * 0.55) / 2, 62);
+  const strikeY = parseInt(valueY) - Math.round(fs * 0.33);
+  const strikeW = Math.max(1.5, fs * 0.07);
 
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}">
   <rect width="${W}" height="${H}" fill="#111"/>
   <rect width="${W}" height="5" fill="${barColor}"/>
   <text x="72" y="22" font-family="${FONT}" font-size="13" fill="white" fill-opacity="0.38" text-anchor="middle" letter-spacing="0.5">day<tspan font-style="italic">GLANCE</tspan></text>
-  <text x="72" y="${valueY}" font-family="${FONT}" font-size="${fontSize(value)}" fill="white" fill-opacity="${valueOpacity}" text-anchor="middle" font-weight="700"${strikeAttr}>${escape(value)}</text>
+  <text x="72" y="${valueY}" font-family="${FONT}" font-size="${fs}" fill="white" fill-opacity="${valueOpacity}" text-anchor="middle" font-weight="700">${escape(value)}</text>
+  ${strikethrough ? `<line x1="${72 - strikeHalfW}" y1="${strikeY}" x2="${72 + strikeHalfW}" y2="${strikeY}" stroke="white" stroke-opacity="${valueOpacity}" stroke-width="${strikeW}"/>` : ""}
   ${sub ? `<text x="72" y="108" font-family="${FONT}" font-size="18" fill="white" fill-opacity="${subOpacity}" text-anchor="middle">${escape(sub)}</text>` : ""}
 </svg>`;
 


### PR DESCRIPTION
## Summary

Replaces `text-decoration="line-through"` with an explicit `<line>` SVG element for the strikethrough effect on completed tasks.

## Root cause

The Stream Deck's SVG renderer doesn't honour the `text-decoration` CSS presentation attribute. A manually drawn line is renderer-agnostic.

## Implementation

The line is positioned at `baseline - 0.33 × font-size` (roughly mid cap-height) and its half-width is estimated as `chars × font-size × 0.55 / 2`, capped at 62px to stay within the key margins. Stroke width scales with font size (`max(1.5, font-size × 0.07)`).

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_