### PR TITLE
feat(stream-deck): Agenda dial rotates to cycle, press completes task

### DIFF
--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -30,8 +30,8 @@
       "Encoder": {
         "layout": "$B1",
         "TriggerDescription": {
-          "Rotate": "Scroll agenda forward / back",
-          "Push": "Cycle through tasks / back to overview"
+          "Rotate": "Cycle through tasks / overview",
+          "Push": "Complete current task"
         }
       },
       "States": [

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -1,12 +1,13 @@
 import {
   action,
+  DialRotateEvent,
   DialUpEvent,
   KeyDownEvent,
   SingletonAction,
   WillAppearEvent,
   WillDisappearEvent,
 } from "@elgato/streamdeck";
-import { DayGlanceState, onState } from "../client";
+import { DayGlanceState, onState, send, MSG_DAY_TASK_COMPLETE } from "../client";
 import { renderKey, stripTags, truncate } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.agenda" })
@@ -39,20 +40,27 @@ export class AgendaAction extends SingletonAction {
     }
   }
 
-  override async onDialUp(_ev: DialUpEvent): Promise<void> {
-    await this.cycle();
-  }
-
-  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
-    await this.cycle();
-  }
-
-  private async cycle(): Promise<void> {
+  override async onDialRotate(ev: DialRotateEvent): Promise<void> {
     if (!this.lastState) return;
     const count = this.lastState.scheduledTasks?.length ?? 0;
     if (count === 0) return;
-    this.viewIndex = (this.viewIndex + 1) % (count + 1);
+    const total = count + 1;
+    this.viewIndex = ((this.viewIndex + ev.payload.ticks) % total + total) % total;
     await this.renderAll(this.lastState);
+  }
+
+  override async onDialUp(_ev: DialUpEvent): Promise<void> {
+    await this.completeCurrentTask();
+  }
+
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
+    await this.completeCurrentTask();
+  }
+
+  private async completeCurrentTask(): Promise<void> {
+    if (!this.lastState || this.viewIndex === 0) return;
+    const task = this.lastState.scheduledTasks?.[this.viewIndex - 1];
+    if (task) send({ type: MSG_DAY_TASK_COMPLETE, id: task.id });
   }
 
   private async renderAll(state: DayGlanceState): Promise<void> {


### PR DESCRIPTION
## Summary

Swaps the Agenda encoder interactions:

| Control | Before | After |
|---|---|---|
| Rotate | (unimplemented) | Cycle through tasks / overview |
| Press (encoder) | Cycle | Complete current task |
| Press (keypad) | Cycle | Complete current task |

## Details

- `onDialRotate`: advances `viewIndex` by `ev.payload.ticks`, wrapping in both directions with `((idx + ticks) % total + total) % total`
- `onDialUp` / `onKeyDown`: call `completeCurrentTask()`, which sends `MSG_DAY_TASK_COMPLETE` for the task at the current view; no-ops on the overview screen (`viewIndex === 0`)
- Manifest trigger descriptions updated to match

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_