### PR TITLE
tweak(stream-deck): show "Completed" sub-label for done tasks in Agenda

### DIFF
--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -80,8 +80,8 @@ export class AgendaAction extends SingletonAction {
     } else {
       const task = tasks[this.viewIndex - 1];
       const title = truncate(stripTags(task.title), 12);
-      const time = task.startTime ? formatTime(task.startTime) : "";
-      image = renderKey({ value: title, sub: time, barColor: task.colorHex, strikethrough: task.completed });
+      const sub = task.completed ? "Completed" : (task.startTime ? formatTime(task.startTime) : "");
+      image = renderKey({ value: title, sub, barColor: task.colorHex, strikethrough: task.completed });
     }
     await act.setImage(image);
     await act.setTitle("");


### PR DESCRIPTION
Completed tasks now show `"Completed"` in the sub-label instead of the start time.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_