### PR TITLE
feat(stream-deck): populate Agenda touch strip via setFeedback

### DIFF
--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/agenda.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/agenda.json
@@ -1,0 +1,27 @@
+{
+  "id": "agenda-layout",
+  "items": [
+    {
+      "key": "title",
+      "type": "text",
+      "rect": [16, 8, 500, 24],
+      "alignment": "left",
+      "font": { "size": 13, "weight": 600 }
+    },
+    {
+      "key": "value",
+      "type": "text",
+      "rect": [16, 36, 200, 40],
+      "alignment": "left",
+      "font": { "size": 28, "weight": 700 }
+    },
+    {
+      "key": "indicator",
+      "type": "progressBar",
+      "rect": [16, 82, 700, 10],
+      "bar_bg_c": "2C2C2C",
+      "bar_fill_c": "fe8b00",
+      "bar_border_c": "2C2C2C"
+    }
+  ]
+}

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -28,7 +28,7 @@
       "PropertyInspectorPath": "ui/property-inspector.html",
       "Controllers": ["Encoder", "Keypad"],
       "Encoder": {
-        "layout": "$B1",
+        "layout": "layouts/agenda.json",
         "TriggerDescription": {
           "Rotate": "Cycle through tasks / overview",
           "Push": "Complete current task"

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -73,18 +73,32 @@ export class AgendaAction extends SingletonAction {
   private async renderOne(act: any, state: DayGlanceState): Promise<void> {
     const tasks = state.scheduledTasks ?? [];
     let image: string;
+    let feedTitle: string;
+    let feedValue: string;
+    let feedIndicator: number;
+
     if (this.viewIndex === 0 || tasks.length === 0) {
       const { completed, total } = state.today;
       const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
       image = renderKey({ value: `${completed}/${total}`, sub: `${pct}% done` });
+      feedTitle = "Today";
+      feedValue = `${completed}/${total}`;
+      feedIndicator = pct;
     } else {
       const task = tasks[this.viewIndex - 1];
       const title = truncate(stripTags(task.title), 12);
-      const time = task.startTime ? formatTime(task.startTime) : "";
-      image = renderKey({ value: title, sub: time, barColor: task.colorHex, strikethrough: task.completed });
+      const sub = task.completed ? "Completed" : (task.startTime ? formatTime(task.startTime) : "");
+      image = renderKey({ value: title, sub, barColor: task.colorHex, strikethrough: task.completed });
+      feedTitle = title;
+      feedValue = sub;
+      feedIndicator = task.completed ? 100 : 0;
     }
+
     await act.setImage(image);
     await act.setTitle("");
+    if (act.controller === "Encoder") {
+      await act.setFeedback({ title: feedTitle, value: feedValue, indicator: feedIndicator });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Populates the physical hardware touch strip by adding `setFeedback()` for encoder instances alongside the existing `setImage()` (which only drives the Stream Deck desktop software UI).

## Why it was blank

`setImage()` only updates the software simulation. The hardware LCD requires `setFeedback()` with named layout keys. The gray bar was the `indicator` progress item from `$B1` sitting empty — we never populated it.

## What changed

- **`layouts/agenda.json`** — new custom layout with `title` (top label), `value` (main number/text), and `indicator` (progress bar, orange)
- **`manifest.json`** — Agenda encoder now uses `layouts/agenda.json` instead of `$B1`
- **`agenda.ts`** — `renderOne()` calls `setFeedback()` on encoder instances only; keypad path (`setImage` + `setTitle`) is untouched

## Touch strip content

| View | `title` | `value` | `indicator` |
|---|---|---|---|
| Overview | `Today` | `2/3` | `67` (% bar) |
| Incomplete task | task name | `9:30` | `0` |
| Completed task | task name | `Completed` | `100` (full bar) |

Also absorbs the "Completed" sub-label change from #604 — that PR can be closed.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_