### PR TITLE
fix(stream-deck): render agenda touch strip via pixmap layout item

### DIFF
--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/agenda.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/agenda.json
@@ -1,27 +1,7 @@
 {
+  "$schema": "https://schemas.elgato.com/streamdeck/plugins/layout.json",
   "id": "agenda-layout",
   "items": [
-    {
-      "key": "title",
-      "type": "text",
-      "rect": [16, 8, 500, 24],
-      "alignment": "left",
-      "font": { "size": 13, "weight": 600 }
-    },
-    {
-      "key": "value",
-      "type": "text",
-      "rect": [16, 36, 200, 40],
-      "alignment": "left",
-      "font": { "size": 28, "weight": 700 }
-    },
-    {
-      "key": "indicator",
-      "type": "progressBar",
-      "rect": [16, 82, 700, 10],
-      "bar_bg_c": "2C2C2C",
-      "bar_fill_c": "fe8b00",
-      "bar_border_c": "2C2C2C"
-    }
+    { "key": "canvas", "type": "pixmap", "rect": [0, 0, 200, 100] }
   ]
 }

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -8,7 +8,7 @@ import {
   WillDisappearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState, send, MSG_DAY_TASK_COMPLETE } from "../client";
-import { renderKey, stripTags, truncate } from "../render";
+import { renderKey, renderStrip, stripTags, truncate } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.agenda" })
 export class AgendaAction extends SingletonAction {
@@ -17,9 +17,15 @@ export class AgendaAction extends SingletonAction {
   // 0 = overview (X/Y + Z%), 1..N = task at index (viewIndex - 1)
   private viewIndex: number = 0;
   private visibleCount = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private encoderRefs = new Set<any>();
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.visibleCount++;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((ev.payload as any).controller === "Encoder") {
+      this.encoderRefs.add(ev.action);
+    }
     if (!this.unsubscribe) {
       this.viewIndex = 0;
       this.unsubscribe = onState((s) => {
@@ -32,7 +38,8 @@ export class AgendaAction extends SingletonAction {
     if (this.lastState) await this.renderOne(ev.action, this.lastState);
   }
 
-  override async onWillDisappear(_ev: WillDisappearEvent): Promise<void> {
+  override async onWillDisappear(ev: WillDisappearEvent): Promise<void> {
+    this.encoderRefs.delete(ev.action);
     this.visibleCount = Math.max(0, this.visibleCount - 1);
     if (this.visibleCount === 0) {
       this.unsubscribe?.();
@@ -72,32 +79,26 @@ export class AgendaAction extends SingletonAction {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async renderOne(act: any, state: DayGlanceState): Promise<void> {
     const tasks = state.scheduledTasks ?? [];
-    let image: string;
-    let feedTitle: string;
-    let feedValue: string;
-    let feedIndicator: number;
+    const isEncoder = this.encoderRefs.has(act);
+
+    let renderOpts: Parameters<typeof renderKey>[0];
 
     if (this.viewIndex === 0 || tasks.length === 0) {
       const { completed, total } = state.today;
       const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
-      image = renderKey({ value: `${completed}/${total}`, sub: `${pct}% done` });
-      feedTitle = "Today";
-      feedValue = `${completed}/${total}`;
-      feedIndicator = pct;
+      renderOpts = { value: `${completed}/${total}`, sub: `${pct}% done` };
     } else {
       const task = tasks[this.viewIndex - 1];
       const title = truncate(stripTags(task.title), 12);
       const sub = task.completed ? "Completed" : (task.startTime ? formatTime(task.startTime) : "");
-      image = renderKey({ value: title, sub, barColor: task.colorHex, strikethrough: task.completed });
-      feedTitle = title;
-      feedValue = sub;
-      feedIndicator = task.completed ? 100 : 0;
+      renderOpts = { value: title, sub, barColor: task.colorHex, strikethrough: task.completed };
     }
 
-    await act.setImage(image);
-    await act.setTitle("");
-    if (act.controller === "Encoder") {
-      await act.setFeedback({ title: feedTitle, value: feedValue, indicator: feedIndicator });
+    await act.setImage(renderKey(renderOpts));
+    if (isEncoder) {
+      await act.setFeedback({ canvas: renderStrip(renderOpts) });
+    } else {
+      await act.setTitle("");
     }
   }
 }

--- a/stream-deck-plugin/src/render.ts
+++ b/stream-deck-plugin/src/render.ts
@@ -2,6 +2,8 @@ const FONT = "-apple-system, 'Helvetica Neue', Arial, sans-serif";
 const ORANGE = "#f97316";
 const W = 144;
 const H = 144;
+const SW = 200;
+const SH = 100;
 
 interface KeyOpts {
   value: string;
@@ -33,6 +35,36 @@ export function renderKey(opts: KeyOpts): string {
 </svg>`;
 
   return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
+}
+
+/** Renders a 200×100 landscape SVG for the Stream Deck+ touch strip pixmap item. */
+export function renderStrip(opts: KeyOpts): string {
+  const { value, sub = "", barColor = ORANGE, dim = false, strikethrough = false } = opts;
+  const valueOpacity = dim ? "0.4" : "1";
+  const subOpacity = dim ? "0.25" : "0.55";
+  const fs = stripFontSize(value);
+  const valueY = sub ? "52" : "60";
+  const strikeTextW = Math.min(value.length * fs * 0.6, 180);
+  const strikeY = parseInt(valueY) - Math.round(fs * 0.33);
+  const strikeW = Math.max(3, fs * 0.1);
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${SW}" height="${SH}">
+  <rect width="${SW}" height="${SH}" fill="#111"/>
+  <rect width="${SW}" height="4" fill="${barColor}"/>
+  <text x="${SW - 8}" y="18" font-family="${FONT}" font-size="11" fill="white" fill-opacity="0.3" text-anchor="end">day<tspan font-style="italic">GLANCE</tspan></text>
+  <text x="12" y="${valueY}" font-family="${FONT}" font-size="${fs}" fill="white" fill-opacity="${valueOpacity}" font-weight="700">${escape(value)}</text>
+  ${strikethrough ? `<line x1="12" y1="${strikeY}" x2="${12 + strikeTextW}" y2="${strikeY}" stroke="white" stroke-opacity="${valueOpacity}" stroke-width="${strikeW}"/>` : ""}
+  ${sub ? `<text x="12" y="80" font-family="${FONT}" font-size="18" fill="white" fill-opacity="${subOpacity}">${escape(sub)}</text>` : ""}
+</svg>`;
+
+  return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
+}
+
+function stripFontSize(text: string): number {
+  if (text.length <= 4) return 42;
+  if (text.length <= 7) return 34;
+  if (text.length <= 12) return 28;
+  return 22;
 }
 
 function fontSize(text: string): number {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`agenda.json`**: Replace the text + progressBar layout items with a single full-coverage `pixmap` item (`key: "canvas"`, `rect: [0, 0, 200, 100]`). The old `key: "title"` text item was bound to `setTitle()`, so our `setTitle("")` call was overwriting it with blank and triggering the "Agenda" fallback label.
- **`render.ts`**: Add `renderStrip()` — a 200×100 landscape SVG sized for the touch strip, sharing the same `KeyOpts` interface as `renderKey()` (value, sub, barColor, strikethrough, dim all work).
- **`agenda.ts`**: Track encoder action instances in a `Set` populated from `ev.payload.controller` during `onWillAppear` (the only reliable source — `act.controller` doesn't exist on SDK action instances). For encoders: call `setFeedback({ canvas: renderStrip(...) })` and skip `setTitle("")`. For keypad slots: keep `setTitle("")` to clear the label.

Supersedes #606.

## Test plan

- [ ] Rebuild plugin, reinstall
- [ ] Encoder slot: touch strip should show the current view (overview or task name + time/status) with orange color bar at top
- [ ] Dial rotate: touch strip updates to show each task, then wraps back to overview
- [ ] Completed task: touch strip shows strikethrough + "Completed"
- [ ] Keypad slot: button image still works as before

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_