### PR TITLE
feat(stream-deck): touch tap cycling and long-press complete on agenda strip

### DIFF
--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -31,7 +31,9 @@
         "layout": "layouts/agenda.json",
         "TriggerDescription": {
           "Rotate": "Cycle through tasks / overview",
-          "Push": "Complete current task"
+          "Push": "Complete current task",
+          "TouchTap": "Tap left/right to cycle views",
+          "LongTouch": "Complete current task"
         }
       },
       "States": [

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -4,6 +4,7 @@ import {
   DialUpEvent,
   KeyDownEvent,
   SingletonAction,
+  TouchTapEvent,
   WillAppearEvent,
   WillDisappearEvent,
 } from "@elgato/streamdeck";
@@ -62,6 +63,20 @@ export class AgendaAction extends SingletonAction {
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
     await this.completeCurrentTask();
+  }
+
+  override async onTouchTap(ev: TouchTapEvent): Promise<void> {
+    if (!this.lastState) return;
+    if (ev.payload.hold) {
+      await this.completeCurrentTask();
+      return;
+    }
+    const count = this.lastState.scheduledTasks?.length ?? 0;
+    if (count === 0) return;
+    const total = count + 1;
+    const delta = ev.payload.tapPos[0] < 100 ? -1 : 1;
+    this.viewIndex = ((this.viewIndex + delta) % total + total) % total;
+    await this.renderAll(this.lastState);
   }
 
   private async completeCurrentTask(): Promise<void> {


### PR DESCRIPTION
## Summary

Adds touch strip gesture support to the Agenda encoder action:

- **Tap left half** (`tapPos[0] < 100`) → cycle view backward
- **Tap right half** (`tapPos[0] >= 100`) → cycle view forward
- **Long press** (`hold: true`) → complete the currently shown task (no-op on overview)

Uses `onTouchTap` with the existing `ev.payload.tapPos` and `ev.payload.hold` from the SDK — no hacks required.

Also updates `manifest.json` `TriggerDescription` to document the new interactions.

## Test plan

- [ ] Rebuild plugin, reinstall
- [ ] Tap right side of strip → advances to next task (wraps overview → task 1 → … → overview)
- [ ] Tap left side of strip → goes back one view
- [ ] Long-press strip on a task view → task is marked complete
- [ ] Long-press strip on overview (index 0) → no-op

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_