### PR TITLE
fix(stream-deck): apply encoder pattern to all remaining actions

### DIFF
--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/focus.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/focus.json
@@ -1,28 +1,7 @@
 {
+  "$schema": "https://schemas.elgato.com/streamdeck/plugins/layout.json",
   "id": "focus-layout",
   "items": [
-    {
-      "key": "title",
-      "type": "text",
-      "rect": [16, 8, 200, 24],
-      "alignment": "left",
-      "font": { "size": 14, "weight": 600 }
-    },
-    {
-      "key": "value",
-      "type": "text",
-      "rect": [16, 36, 200, 40],
-      "alignment": "left",
-      "font": { "size": 28, "weight": 700 },
-      "color": "#fe8b00"
-    },
-    {
-      "key": "indicator",
-      "type": "progressBar",
-      "rect": [16, 82, 700, 10],
-      "bar_bg_c": "2C2C2C",
-      "bar_fill_c": "fe8b00",
-      "bar_border_c": "2C2C2C"
-    }
+    { "key": "canvas", "type": "pixmap", "rect": [0, 0, 200, 100] }
   ]
 }

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/next-task.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/next-task.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.elgato.com/streamdeck/plugins/layout.json",
-  "id": "goal-progress-layout",
+  "id": "next-task-layout",
   "items": [
     { "key": "canvas", "type": "pixmap", "rect": [0, 0, 200, 100] }
   ]

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/quick-glance.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/quick-glance.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.elgato.com/streamdeck/plugins/layout.json",
-  "id": "goal-progress-layout",
+  "id": "quick-glance-layout",
   "items": [
     { "key": "canvas", "type": "pixmap", "rect": [0, 0, 200, 100] }
   ]

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -52,7 +52,8 @@
         "TriggerDescription": {
           "Rotate": "Adjust session duration",
           "Push": "Start / stop session",
-          "TouchTap": "Switch work / break"
+          "TouchTap": "Switch work / break phase",
+          "LongTouch": "Start / stop session"
         }
       },
       "States": [
@@ -68,10 +69,12 @@
       "PropertyInspectorPath": "ui/property-inspector.html",
       "Controllers": ["Encoder", "Keypad"],
       "Encoder": {
-        "layout": "$B1",
+        "layout": "layouts/next-task.json",
         "TriggerDescription": {
-          "Rotate": "Browse tasks",
-          "Push": "Complete task"
+          "Rotate": "Browse current / next task",
+          "Push": "Complete task",
+          "TouchTap": "Tap left/right to browse tasks",
+          "LongTouch": "Complete task"
         }
       },
       "States": [
@@ -104,10 +107,12 @@
       "PropertyInspectorPath": "ui/property-inspector.html",
       "Controllers": ["Encoder", "Keypad"],
       "Encoder": {
-        "layout": "$B1",
+        "layout": "layouts/quick-glance.json",
         "TriggerDescription": {
           "Rotate": "Cycle display mode",
-          "Push": "Pin current mode"
+          "Push": "Pin current mode",
+          "TouchTap": "Tap left/right to cycle modes",
+          "LongTouch": "Pin / unpin current mode"
         }
       },
       "States": [

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -4,28 +4,45 @@ import {
   DialUpEvent,
   KeyDownEvent,
   SingletonAction,
+  TouchTapEvent,
   WillAppearEvent,
+  WillDisappearEvent,
 } from "@elgato/streamdeck";
-import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP } from "../client";
-import { renderKey } from "../render";
+import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP } from "../client";
+import { renderKey, renderStrip } from "../render";
 
 type Settings = { sessionDurationMinutes: number };
 
 @action({ UUID: "app.dayglance.streamdeck.focus" })
 export class FocusAction extends SingletonAction<Settings> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private actionRef: any = null;
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;
+  private visibleCount = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private encoderRefs = new Set<any>();
 
   override async onWillAppear(ev: WillAppearEvent<Settings>): Promise<void> {
-    this.actionRef = ev.action;
-    this.unsubscribe?.();
-    this.unsubscribe = onState((s) => {
-      this.lastState = s;
-      this.render(s).catch(e => console.error("[dayGLANCE] focus-mode render:", e));
-    });
-    if (this.lastState) await this.render(this.lastState);
+    this.visibleCount++;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((ev.payload as any).controller === "Encoder") {
+      this.encoderRefs.add(ev.action);
+    }
+    if (!this.unsubscribe) {
+      this.unsubscribe = onState((s) => {
+        this.lastState = s;
+        this.renderAll(s).catch(e => console.error("[dayGLANCE] focus render:", e));
+      });
+    }
+    if (this.lastState) await this.renderOne(ev.action, this.lastState);
+  }
+
+  override async onWillDisappear(ev: WillDisappearEvent<Settings>): Promise<void> {
+    this.encoderRefs.delete(ev.action);
+    this.visibleCount = Math.max(0, this.visibleCount - 1);
+    if (this.visibleCount === 0) {
+      this.unsubscribe?.();
+      this.unsubscribe = null;
+    }
   }
 
   override async onDialRotate(ev: DialRotateEvent<Settings>): Promise<void> {
@@ -33,8 +50,16 @@ export class FocusAction extends SingletonAction<Settings> {
     const settings = await ev.action.getSettings();
     const newDuration = Math.max(5, (settings.sessionDurationMinutes ?? 25) + ev.payload.ticks);
     await ev.action.setSettings({ sessionDurationMinutes: newDuration });
-    await this.actionRef.setImage(renderKey({ value: `${newDuration}m`, sub: "focus", barColor: "#3b82f6" }));
-    await this.actionRef.setTitle("");
+    const previewOpts = { value: `${newDuration}m`, sub: "focus", barColor: "#3b82f6" };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    for (const act of this.actions as unknown as any[]) {
+      await act.setImage(renderKey(previewOpts));
+      if (this.encoderRefs.has(act)) {
+        await act.setFeedback({ canvas: renderStrip(previewOpts) });
+      } else {
+        await act.setTitle("");
+      }
+    }
   }
 
   override async onDialUp(_ev: DialUpEvent<Settings>): Promise<void> {
@@ -45,29 +70,54 @@ export class FocusAction extends SingletonAction<Settings> {
     this.toggle();
   }
 
-  private toggle(): void {
-    const { available, active } = this.lastState?.focus ?? { available: false, active: false };
-    if (!available && !active) return;
-    if (!active) {
-      send({ type: MSG_DAY_FOCUS_START });
-    } else {
-      send({ type: MSG_DAY_FOCUS_STOP });
+  override async onTouchTap(ev: TouchTapEvent<Settings>): Promise<void> {
+    if (ev.payload.hold) {
+      this.toggle();
+      return;
+    }
+    // Tap: switch work/break phase if a session is active
+    if (this.lastState?.focus.active) {
+      send({ type: MSG_DAY_FOCUS_SKIP });
     }
   }
 
-  private async render(state: DayGlanceState): Promise<void> {
-    if (!this.actionRef) return;
+  private toggle(): void {
+    const { available, active } = this.lastState?.focus ?? { available: false, active: false };
+    if (active) {
+      send({ type: MSG_DAY_FOCUS_STOP });
+    } else if (available) {
+      send({ type: MSG_DAY_FOCUS_START });
+    }
+  }
+
+  private async renderAll(state: DayGlanceState): Promise<void> {
+    for (const act of this.actions) {
+      await this.renderOne(act, state);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async renderOne(act: any, state: DayGlanceState): Promise<void> {
+    const isEncoder = this.encoderRefs.has(act);
     const { available, active, phase, secondsRemaining, running } = state.focus;
+    let renderOpts: Parameters<typeof renderKey>[0];
+
     if (!active) {
-      await this.actionRef.setImage(renderKey({ value: "Focus", sub: available ? "press to start" : "unavailable", dim: !available }));
+      renderOpts = { value: "Focus", sub: available ? "press to start" : "unavailable", dim: !available };
     } else {
       const m = Math.floor(secondsRemaining / 60);
       const s = secondsRemaining % 60;
       const time = `${m}:${s.toString().padStart(2, "0")}`;
       const sub = running ? (phase === "work" ? "work" : "break") : "paused";
       const barColor = phase === "work" ? "#f97316" : "#22c55e";
-      await this.actionRef.setImage(renderKey({ value: time, sub, barColor }));
+      renderOpts = { value: time, sub, barColor };
     }
-    await this.actionRef.setTitle("");
+
+    await act.setImage(renderKey(renderOpts));
+    if (isEncoder) {
+      await act.setFeedback({ canvas: renderStrip(renderOpts) });
+    } else {
+      await act.setTitle("");
+    }
   }
 }

--- a/stream-deck-plugin/src/actions/goal-progress.ts
+++ b/stream-deck-plugin/src/actions/goal-progress.ts
@@ -1,40 +1,76 @@
 import {
   action,
   DialRotateEvent,
+  DialUpEvent,
   KeyDownEvent,
   SingletonAction,
   WillAppearEvent,
+  WillDisappearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState } from "../client";
-import { renderKey } from "../render";
+import { renderKey, renderStrip } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.goal-progress" })
 export class GoalProgressAction extends SingletonAction {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private actionRef: any = null;
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;
+  private visibleCount = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private encoderRefs = new Set<any>();
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
-    this.actionRef = ev.action;
-    this.unsubscribe?.();
-    this.unsubscribe = onState((s) => { this.lastState = s; this.render(s).catch(e => console.error("[dayGLANCE] goal-progress render:", e)); });
-    if (this.lastState) await this.render(this.lastState);
+    this.visibleCount++;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((ev.payload as any).controller === "Encoder") {
+      this.encoderRefs.add(ev.action);
+    }
+    if (!this.unsubscribe) {
+      this.unsubscribe = onState((s) => {
+        this.lastState = s;
+        this.renderAll(s).catch(e => console.error("[dayGLANCE] goal-progress render:", e));
+      });
+    }
+    if (this.lastState) await this.renderOne(ev.action, this.lastState);
+  }
+
+  override async onWillDisappear(ev: WillDisappearEvent): Promise<void> {
+    this.encoderRefs.delete(ev.action);
+    this.visibleCount = Math.max(0, this.visibleCount - 1);
+    if (this.visibleCount === 0) {
+      this.unsubscribe?.();
+      this.unsubscribe = null;
+    }
   }
 
   override async onDialRotate(_ev: DialRotateEvent): Promise<void> {
     // TODO: cycle through goals when goal data is added to state
   }
 
+  override async onDialUp(_ev: DialUpEvent): Promise<void> {
+    // TODO: interact with goal when goal data is added to state
+  }
+
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
     // TODO: interact with goal when goal data is added to state
   }
 
-  private async render(state: DayGlanceState): Promise<void> {
-    if (!this.actionRef) return;
+  private async renderAll(state: DayGlanceState): Promise<void> {
+    for (const act of this.actions) {
+      await this.renderOne(act, state);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async renderOne(act: any, state: DayGlanceState): Promise<void> {
+    const isEncoder = this.encoderRefs.has(act);
     const { completed, total } = state.today;
     const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
-    await this.actionRef.setImage(renderKey({ value: `${pct}%`, sub: "Today" }));
-    await this.actionRef.setTitle("");
+    const renderOpts = { value: `${pct}%`, sub: "Today" };
+    await act.setImage(renderKey(renderOpts));
+    if (isEncoder) {
+      await act.setFeedback({ canvas: renderStrip(renderOpts) });
+    } else {
+      await act.setTitle("");
+    }
   }
 }

--- a/stream-deck-plugin/src/actions/next-task.ts
+++ b/stream-deck-plugin/src/actions/next-task.ts
@@ -1,54 +1,99 @@
 import {
   action,
   DialRotateEvent,
+  DialUpEvent,
   KeyDownEvent,
   SingletonAction,
+  TouchTapEvent,
   WillAppearEvent,
+  WillDisappearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState, send, MSG_DAY_TASK_COMPLETE } from "../client";
-import { renderKey, stripTags, truncate } from "../render";
+import { renderKey, renderStrip, stripTags, truncate } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.next-task" })
 export class NextTaskAction extends SingletonAction {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private actionRef: any = null;
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;
+  private visibleCount = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private encoderRefs = new Set<any>();
   private showNext = false;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
-    this.actionRef = ev.action;
-    this.unsubscribe?.();
-    this.unsubscribe = onState((s) => {
-      this.lastState = s;
-      this.render(s).catch(e => console.error("[dayGLANCE] next-task render:", e));
-    });
-    if (this.lastState) await this.render(this.lastState);
+    this.visibleCount++;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((ev.payload as any).controller === "Encoder") {
+      this.encoderRefs.add(ev.action);
+    }
+    if (!this.unsubscribe) {
+      this.unsubscribe = onState((s) => {
+        this.lastState = s;
+        this.renderAll(s).catch(e => console.error("[dayGLANCE] next-task render:", e));
+      });
+    }
+    if (this.lastState) await this.renderOne(ev.action, this.lastState);
+  }
+
+  override async onWillDisappear(ev: WillDisappearEvent): Promise<void> {
+    this.encoderRefs.delete(ev.action);
+    this.visibleCount = Math.max(0, this.visibleCount - 1);
+    if (this.visibleCount === 0) {
+      this.unsubscribe?.();
+      this.unsubscribe = null;
+    }
   }
 
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {
     this.showNext = ev.payload.ticks > 0;
-    if (this.lastState) this.render(this.lastState).catch(e => console.error("[dayGLANCE] next-task render:", e));
+    if (this.lastState) await this.renderAll(this.lastState);
+  }
+
+  override async onDialUp(_ev: DialUpEvent): Promise<void> {
+    await this.completeCurrentTask();
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
+    await this.completeCurrentTask();
+  }
+
+  override async onTouchTap(ev: TouchTapEvent): Promise<void> {
+    if (ev.payload.hold) {
+      await this.completeCurrentTask();
+      return;
+    }
+    this.showNext = ev.payload.tapPos[0] >= 100;
+    if (this.lastState) await this.renderAll(this.lastState);
+  }
+
+  private async completeCurrentTask(): Promise<void> {
     const task = this.showNext
       ? this.lastState?.nextTask
       : (this.lastState?.currentTask ?? this.lastState?.nextTask);
     if (task) send({ type: MSG_DAY_TASK_COMPLETE, id: task.id });
   }
 
-  private async render(state: DayGlanceState): Promise<void> {
-    if (!this.actionRef) return;
+  private async renderAll(state: DayGlanceState): Promise<void> {
+    for (const act of this.actions) {
+      await this.renderOne(act, state);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async renderOne(act: any, state: DayGlanceState): Promise<void> {
+    const isEncoder = this.encoderRefs.has(act);
     const task = this.showNext
       ? state.nextTask
       : (state.currentTask ?? state.nextTask);
     const label = this.showNext ? "next task" : "current task";
-    if (task) {
-      await this.actionRef.setImage(renderKey({ value: truncate(stripTags(task.title), 18), sub: label }));
+    const renderOpts = task
+      ? { value: truncate(stripTags(task.title), 12), sub: label }
+      : { value: "No tasks", dim: true as const };
+    await act.setImage(renderKey(renderOpts));
+    if (isEncoder) {
+      await act.setFeedback({ canvas: renderStrip(renderOpts) });
     } else {
-      await this.actionRef.setImage(renderKey({ value: "No tasks", dim: true }));
+      await act.setTitle("");
     }
-    await this.actionRef.setTitle("");
   }
 }

--- a/stream-deck-plugin/src/actions/quick-glance.ts
+++ b/stream-deck-plugin/src/actions/quick-glance.ts
@@ -1,71 +1,118 @@
 import {
   action,
   DialRotateEvent,
+  DialUpEvent,
   KeyDownEvent,
   SingletonAction,
+  TouchTapEvent,
   WillAppearEvent,
+  WillDisappearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState } from "../client";
-import { renderKey, stripTags, truncate } from "../render";
+import { renderKey, renderStrip, stripTags, truncate } from "../render";
 
 type DisplayMode = "date" | "next-event" | "focus";
 const MODES: DisplayMode[] = ["date", "next-event", "focus"];
 
 @action({ UUID: "app.dayglance.streamdeck.quick-glance" })
 export class QuickGlanceAction extends SingletonAction {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private actionRef: any = null;
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;
+  private visibleCount = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private encoderRefs = new Set<any>();
   private modeIndex = 0;
   private pinned = false;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
-    this.actionRef = ev.action;
-    this.unsubscribe?.();
-    this.unsubscribe = onState((s) => {
-      this.lastState = s;
-      this.render(s).catch(e => console.error("[dayGLANCE] quick-glance render:", e));
-    });
-    if (this.lastState) await this.render(this.lastState);
+    this.visibleCount++;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((ev.payload as any).controller === "Encoder") {
+      this.encoderRefs.add(ev.action);
+    }
+    if (!this.unsubscribe) {
+      this.unsubscribe = onState((s) => {
+        this.lastState = s;
+        this.renderAll(s).catch(e => console.error("[dayGLANCE] quick-glance render:", e));
+      });
+    }
+    if (this.lastState) await this.renderOne(ev.action, this.lastState);
+  }
+
+  override async onWillDisappear(ev: WillDisappearEvent): Promise<void> {
+    this.encoderRefs.delete(ev.action);
+    this.visibleCount = Math.max(0, this.visibleCount - 1);
+    if (this.visibleCount === 0) {
+      this.unsubscribe?.();
+      this.unsubscribe = null;
+    }
   }
 
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {
     if (this.pinned) return;
-    this.modeIndex = (this.modeIndex + ev.payload.ticks + MODES.length) % MODES.length;
-    if (this.lastState) this.render(this.lastState).catch(e => console.error("[dayGLANCE] quick-glance render:", e));
+    const total = MODES.length;
+    this.modeIndex = ((this.modeIndex + ev.payload.ticks) % total + total) % total;
+    if (this.lastState) await this.renderAll(this.lastState);
+  }
+
+  override async onDialUp(_ev: DialUpEvent): Promise<void> {
+    this.pinned = !this.pinned;
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
     this.pinned = !this.pinned;
   }
 
-  private async render(state: DayGlanceState): Promise<void> {
-    if (!this.actionRef) return;
+  override async onTouchTap(ev: TouchTapEvent): Promise<void> {
+    if (ev.payload.hold) {
+      this.pinned = !this.pinned;
+      return;
+    }
+    if (this.pinned) return;
+    const total = MODES.length;
+    const delta = ev.payload.tapPos[0] < 100 ? -1 : 1;
+    this.modeIndex = ((this.modeIndex + delta) % total + total) % total;
+    if (this.lastState) await this.renderAll(this.lastState);
+  }
+
+  private async renderAll(state: DayGlanceState): Promise<void> {
+    for (const act of this.actions) {
+      await this.renderOne(act, state);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async renderOne(act: any, state: DayGlanceState): Promise<void> {
+    const isEncoder = this.encoderRefs.has(act);
     const mode = MODES[this.modeIndex];
+    let renderOpts: Parameters<typeof renderKey>[0];
 
     if (mode === "date") {
       const { weekday, month, day } = formatDate(state.today.date);
-      await this.actionRef.setImage(renderKey({ value: `${month} ${day}`, sub: weekday }));
+      renderOpts = { value: `${month} ${day}`, sub: weekday };
     } else if (mode === "next-event") {
       const task = state.currentTask ?? state.nextTask;
-      if (task) {
-        await this.actionRef.setImage(renderKey({ value: truncate(stripTags(task.title), 18), sub: "next up" }));
-      } else {
-        await this.actionRef.setImage(renderKey({ value: "Clear", sub: "no events", dim: true }));
-      }
+      renderOpts = task
+        ? { value: truncate(stripTags(task.title), 12), sub: "next up" }
+        : { value: "Clear", sub: "no events", dim: true };
     } else {
       const { active, phase, secondsRemaining } = state.focus;
       if (!active) {
-        await this.actionRef.setImage(renderKey({ value: "Focus", sub: "off", dim: true }));
+        renderOpts = { value: "Focus", sub: "off", dim: true };
       } else {
         const m = Math.floor(secondsRemaining / 60);
         const s = secondsRemaining % 60;
         const barColor = phase === "work" ? "#f97316" : "#22c55e";
-        await this.actionRef.setImage(renderKey({ value: `${m}:${s.toString().padStart(2, "0")}`, sub: phase, barColor }));
+        renderOpts = { value: `${m}:${s.toString().padStart(2, "0")}`, sub: phase, barColor };
       }
     }
-    await this.actionRef.setTitle("");
+
+    await act.setImage(renderKey(renderOpts));
+    if (isEncoder) {
+      await act.setFeedback({ canvas: renderStrip(renderOpts) });
+    } else {
+      await act.setTitle("");
+    }
   }
 }
 
@@ -78,4 +125,3 @@ function formatDate(iso: string): { weekday: string; month: string; day: string 
     day: String(d),
   };
 }
-

--- a/stream-deck-plugin/src/actions/routine.ts
+++ b/stream-deck-plugin/src/actions/routine.ts
@@ -3,25 +3,34 @@ import {
   KeyDownEvent,
   SingletonAction,
   WillAppearEvent,
+  WillDisappearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState, send, MSG_DAY_ROUTINE_COMPLETE } from "../client";
 import { renderKey, truncate } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.routine" })
 export class RoutineAction extends SingletonAction {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private actionRef: any = null;
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;
+  private visibleCount = 0;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
-    this.actionRef = ev.action;
-    this.unsubscribe?.();
-    this.unsubscribe = onState((s) => {
-      this.lastState = s;
-      this.render(s).catch(e => console.error("[dayGLANCE] routine render:", e));
-    });
-    if (this.lastState) await this.render(this.lastState);
+    this.visibleCount++;
+    if (!this.unsubscribe) {
+      this.unsubscribe = onState((s) => {
+        this.lastState = s;
+        this.renderAll(s).catch(e => console.error("[dayGLANCE] routine render:", e));
+      });
+    }
+    if (this.lastState) await this.renderOne(ev.action, this.lastState);
+  }
+
+  override async onWillDisappear(_ev: WillDisappearEvent): Promise<void> {
+    this.visibleCount = Math.max(0, this.visibleCount - 1);
+    if (this.visibleCount === 0) {
+      this.unsubscribe?.();
+      this.unsubscribe = null;
+    }
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
@@ -29,16 +38,20 @@ export class RoutineAction extends SingletonAction {
     if (routine) send({ type: MSG_DAY_ROUTINE_COMPLETE, id: routine.id });
   }
 
-  private async render(state: DayGlanceState): Promise<void> {
-    if (!this.actionRef) return;
+  private async renderAll(state: DayGlanceState): Promise<void> {
+    for (const act of this.actions) {
+      await this.renderOne(act, state);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async renderOne(act: any, state: DayGlanceState): Promise<void> {
     const routine = state.nextRoutine;
     if (!routine) {
-      await this.actionRef.setImage(renderKey({ value: "✓", sub: "all done", barColor: "#22c55e" }));
+      await act.setImage(renderKey({ value: "✓", sub: "all done", barColor: "#22c55e" }));
     } else {
-      const name = truncate(routine.name, 14);
-      const sub = routine.startTime ?? "routine";
-      await this.actionRef.setImage(renderKey({ value: name, sub }));
+      await act.setImage(renderKey({ value: truncate(routine.name, 14), sub: routine.startTime ?? "routine" }));
     }
-    await this.actionRef.setTitle("");
+    await act.setTitle("");
   }
 }


### PR DESCRIPTION
## Summary

Applies the fixes established for Agenda (PRs #605–#608) uniformly across all other Stream Deck actions.

### Pattern fixes (all encoder actions: Focus, Goal Progress, Next Task, Quick Glance)

| Before | After |
|---|---|
| Single `actionRef` overwritten on second `onWillAppear` | `encoderRefs` Set + `visibleCount` + `this.actions` iteration |
| No `onWillDisappear` — subscription leaked on re-appear | `onWillDisappear` tears down ref and subscription when last slot hides |
| `setTitle("")` called on encoder → clears `key: "title"` layout item → action name appears as fallback | `setTitle("")` only on keypad; encoders get `setFeedback({ canvas: renderStrip(...) })` |
| Touch strip blank (text/progressBar layout items) | `pixmap` item covering full 200×100 |

### Layout fixes

- `focus.json`, `goal-progress.json`: replaced text + progressBar items with single `pixmap` `"canvas"` item
- Added `next-task.json`, `quick-glance.json` (same pixmap pattern); manifest updated from `"$B1"` to point at these files

### New touch interactions

- **Focus**: `onDialUp` = start/stop; `onTouchTap` tap = skip work/break phase, long-press = start/stop
- **Next Task**: `onDialUp` = complete shown task; `onTouchTap` tap left/right = browse current↔next, long-press = complete
- **Quick Glance**: `onDialUp` = toggle pin; `onTouchTap` tap left/right = cycle modes, long-press = toggle pin

### Routine (Keypad-only)

Switched from `actionRef` to `this.actions` + `visibleCount`; added `onWillDisappear` for proper subscription cleanup.

### Habit (Keypad-only)

No changes needed — already used the correct pattern.

## Test plan

- [ ] Rebuild plugin, reinstall
- [ ] **Focus encoder**: touch strip shows timer / "press to start"; tap strip = skip phase; long-press = toggle; dial rotate adjusts duration when idle
- [ ] **Next Task encoder**: touch strip shows current task; tap right → next task; tap left → current; long-press = complete
- [ ] **Quick Glance encoder**: touch strip cycles date/next-event/focus; long-press pins mode; dial rotate also cycles
- [ ] **Goal Progress encoder**: touch strip shows today % complete
- [ ] All keypad slots still render button image correctly

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_