### PR TITLE
fix(stream-deck): show "Overdue" for past incomplete tasks in Agenda

### DIFF
--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -105,7 +105,9 @@ export class AgendaAction extends SingletonAction {
     } else {
       const task = tasks[this.viewIndex - 1];
       const title = truncate(stripTags(task.title), 12);
-      const sub = task.completed ? "Completed" : (task.startTime ? formatTime(task.startTime) : "");
+      const sub = task.completed ? "Completed"
+        : task.startTime ? (isOverdue(task.startTime) ? "Overdue" : formatTime(task.startTime))
+        : "";
       renderOpts = { value: title, sub, barColor: task.colorHex, strikethrough: task.completed };
     }
 
@@ -121,4 +123,10 @@ export class AgendaAction extends SingletonAction {
 function formatTime(t: string): string {
   const [h, m] = t.split(":");
   return `${parseInt(h, 10)}:${m}`;
+}
+
+function isOverdue(startTime: string): boolean {
+  const [h, m] = startTime.split(":").map(Number);
+  const now = new Date();
+  return h * 60 + m < now.getHours() * 60 + now.getMinutes();
 }


### PR DESCRIPTION
## Summary

When a task has a `startTime` that is already in the past and it has not been completed, the Agenda button now displays `"Overdue"` instead of the start time. Completed tasks continue to show `"Completed"`.

Logic: `startTime` (as minutes since midnight) < current time → overdue. Applies to both the keypad button image and the encoder touch strip.

## Test plan

- [ ] Task with a past start time, not completed → shows "Overdue"
- [ ] Task with a future start time → shows the formatted time as before
- [ ] Completed task → still shows "Completed" with strikethrough
- [ ] Task with no startTime → no sub-label, unchanged

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_