### PR TITLE
feat(stream-deck): replace Next Task with Up Next action

### DIFF
--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -25,6 +25,7 @@ export type Task = {
   colorHex: string;
   tags: string[];
   completed: boolean;
+  isAllDay?: boolean;
 };
 
 export type FocusState = {

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -167,8 +167,8 @@ export default function useElectronBridge({
           .map(mapTask),
       ],
       today: {
-        total: todayTasks.length,
-        completed: todayTasks.filter(t => t.completed).length,
+        total: todayTasks.length + allDayTasks.length,
+        completed: todayTasks.filter(t => t.completed).length + allDayTasks.filter(t => t.completed).length,
         date: todayStr,
       },
       focus: {

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -120,15 +120,17 @@ export default function useElectronBridge({
     const mapTask = (t) => t ? {
       id: t.id,
       title: t.title,
-      startTime: t.startTime,
+      startTime: t.startTime ?? null,
       duration: t.duration || 0,
       colorHex: taskColorToHex(t.color, t.nativeCalendarColor),
       tags: t.tags || [],
       completed: !!t.completed,
+      isAllDay: !!t.isAllDay,
     } : null;
 
     const todayStr = dateToString(currentTime);
     const todayTasks = tasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay);
+    const allDayTasks = tasks.filter(t => t.date === todayStr && t.isAllDay);
 
     // ── Habits ────────────────────────────────────────────────────────────
     const habits = habitsEnabled ? (activeHabits ?? []).map(h => {
@@ -158,9 +160,12 @@ export default function useElectronBridge({
       type: MSG_DAY_STATE,
       currentTask: mapTask(inProgress),
       nextTask: mapTask(nextUpcoming),
-      scheduledTasks: [...todayTasks]
-        .sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime))
-        .map(mapTask),
+      scheduledTasks: [
+        ...allDayTasks.map(mapTask),
+        ...[...todayTasks]
+          .sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime))
+          .map(mapTask),
+      ],
       today: {
         total: todayTasks.length,
         completed: todayTasks.filter(t => t.completed).length,

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/up-next.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/layouts/up-next.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.elgato.com/streamdeck/plugins/layout.json",
+  "id": "up-next-layout",
+  "items": [
+    { "key": "canvas", "type": "pixmap", "rect": [0, 0, 200, 100] }
+  ]
+}

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -62,19 +62,17 @@
       ]
     },
     {
-      "Name": "Next Task",
-      "UUID": "app.dayglance.streamdeck.next-task",
+      "Name": "Up Next",
+      "UUID": "app.dayglance.streamdeck.up-next",
       "Icon": "imgs/actions/next-task/icon",
-      "Tooltip": "Shows your next due task. Press to complete, long-press to snooze.",
+      "Tooltip": "Shows the current or next scheduled task with a live countdown. Auto-advances when the time passes.",
       "PropertyInspectorPath": "ui/property-inspector.html",
       "Controllers": ["Encoder", "Keypad"],
       "Encoder": {
-        "layout": "layouts/next-task.json",
+        "layout": "layouts/up-next.json",
         "TriggerDescription": {
-          "Rotate": "Browse current / next task",
-          "Push": "Complete task",
-          "TouchTap": "Tap left/right to browse tasks",
-          "LongTouch": "Complete task"
+          "Push": "Complete current task",
+          "LongTouch": "Complete current task"
         }
       },
       "States": [

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -106,7 +106,8 @@ export class AgendaAction extends SingletonAction {
       const task = tasks[this.viewIndex - 1];
       const title = truncate(stripTags(task.title), 12);
       const sub = task.completed ? "Completed"
-        : task.startTime ? (isOverdue(task.startTime) ? "Overdue" : formatTime(task.startTime))
+        : task.isAllDay ? "All Day"
+        : task.startTime ? statusLabel(task.startTime, task.duration)
         : "";
       renderOpts = { value: title, sub, barColor: task.colorHex, strikethrough: task.completed };
     }
@@ -125,8 +126,20 @@ function formatTime(t: string): string {
   return `${parseInt(h, 10)}:${m}`;
 }
 
-function isOverdue(startTime: string): boolean {
-  const [h, m] = startTime.split(":").map(Number);
+function nowMin(): number {
   const now = new Date();
-  return h * 60 + m < now.getHours() * 60 + now.getMinutes();
+  return now.getHours() * 60 + now.getMinutes();
+}
+
+function toMin(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function statusLabel(startTime: string, duration: number): string {
+  const start = toMin(startTime);
+  const now = nowMin();
+  if (start > now) return formatTime(startTime);
+  if (duration > 0 && start + duration > now) return "In Progress";
+  return "Overdue";
 }

--- a/stream-deck-plugin/src/actions/up-next.ts
+++ b/stream-deck-plugin/src/actions/up-next.ts
@@ -1,0 +1,144 @@
+import {
+  action,
+  DialUpEvent,
+  KeyDownEvent,
+  SingletonAction,
+  TouchTapEvent,
+  WillAppearEvent,
+  WillDisappearEvent,
+} from "@elgato/streamdeck";
+import { DayGlanceState, Task, onState, send, MSG_DAY_TASK_COMPLETE } from "../client";
+import { renderKey, renderStrip, stripTags, truncate } from "../render";
+
+@action({ UUID: "app.dayglance.streamdeck.up-next" })
+export class UpNextAction extends SingletonAction {
+  private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
+  private visibleCount = 0;
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private encoderRefs = new Set<any>();
+
+  override async onWillAppear(ev: WillAppearEvent): Promise<void> {
+    this.visibleCount++;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((ev.payload as any).controller === "Encoder") {
+      this.encoderRefs.add(ev.action);
+    }
+    if (!this.unsubscribe) {
+      this.unsubscribe = onState((s) => {
+        this.lastState = s;
+        this.renderAll(s).catch(e => console.error("[dayGLANCE] up-next render:", e));
+      });
+      // Refresh countdown every minute between state pushes
+      this.refreshTimer = setInterval(() => {
+        if (this.lastState) {
+          this.renderAll(this.lastState).catch(e => console.error("[dayGLANCE] up-next refresh:", e));
+        }
+      }, 60_000);
+    }
+    if (this.lastState) await this.renderOne(ev.action, this.lastState);
+  }
+
+  override async onWillDisappear(ev: WillDisappearEvent): Promise<void> {
+    this.encoderRefs.delete(ev.action);
+    this.visibleCount = Math.max(0, this.visibleCount - 1);
+    if (this.visibleCount === 0) {
+      this.unsubscribe?.();
+      this.unsubscribe = null;
+      if (this.refreshTimer !== null) {
+        clearInterval(this.refreshTimer);
+        this.refreshTimer = null;
+      }
+    }
+  }
+
+  override async onDialUp(_ev: DialUpEvent): Promise<void> {
+    await this.completeIfInProgress();
+  }
+
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
+    await this.completeIfInProgress();
+  }
+
+  override async onTouchTap(ev: TouchTapEvent): Promise<void> {
+    if (ev.payload.hold) await this.completeIfInProgress();
+  }
+
+  private async completeIfInProgress(): Promise<void> {
+    const task = this.lastState?.currentTask;
+    if (task) send({ type: MSG_DAY_TASK_COMPLETE, id: task.id });
+  }
+
+  private async renderAll(state: DayGlanceState): Promise<void> {
+    for (const act of this.actions) {
+      await this.renderOne(act, state);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async renderOne(act: any, state: DayGlanceState): Promise<void> {
+    const isEncoder = this.encoderRefs.has(act);
+    const renderOpts = buildRenderOpts(state);
+    await act.setImage(renderKey(renderOpts));
+    if (isEncoder) {
+      await act.setFeedback({ canvas: renderStrip(renderOpts) });
+    } else {
+      await act.setTitle("");
+    }
+  }
+}
+
+function buildRenderOpts(state: DayGlanceState): Parameters<typeof renderKey>[0] {
+  const nowMin = nowMinutes();
+
+  if (state.currentTask) {
+    const task = state.currentTask;
+    const endMin = timeToMin(task.startTime!) + task.duration;
+    const remaining = Math.max(0, endMin - nowMin);
+    return {
+      value: truncate(stripTags(task.title), 12),
+      sub: formatRemaining(remaining),
+      barColor: task.colorHex,
+    };
+  }
+
+  if (state.nextTask) {
+    const task = state.nextTask;
+    const startMin = timeToMin(task.startTime!);
+    const until = Math.max(0, startMin - nowMin);
+    return {
+      value: truncate(stripTags(task.title), 12),
+      sub: formatCountdown(until),
+      barColor: task.colorHex,
+    };
+  }
+
+  return { value: "All clear", sub: "nothing up next", dim: true };
+}
+
+function nowMinutes(): number {
+  const now = new Date();
+  return now.getHours() * 60 + now.getMinutes();
+}
+
+function timeToMin(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function formatCountdown(minutes: number): string {
+  if (minutes === 0) return "starting now";
+  if (minutes < 60) return `in ${minutes}m`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `in ${h}h ${m}m` : `in ${h}h`;
+}
+
+function formatRemaining(minutes: number): string {
+  if (minutes === 0) return "ending now";
+  if (minutes < 60) return `${minutes}m left`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h}h ${m}m left` : `${h}h left`;
+}

--- a/stream-deck-plugin/src/plugin.ts
+++ b/stream-deck-plugin/src/plugin.ts
@@ -4,7 +4,7 @@ import { AgendaAction } from "./actions/agenda";
 import { FocusAction } from "./actions/focus-mode";
 import { GoalProgressAction } from "./actions/goal-progress";
 import { HabitAction } from "./actions/habit";
-import { NextTaskAction } from "./actions/next-task";
+import { UpNextAction } from "./actions/up-next";
 import { QuickGlanceAction } from "./actions/quick-glance";
 import { RoutineAction } from "./actions/routine";
 
@@ -12,7 +12,7 @@ streamDeck.actions.registerAction(new AgendaAction());
 streamDeck.actions.registerAction(new FocusAction());
 streamDeck.actions.registerAction(new GoalProgressAction());
 streamDeck.actions.registerAction(new HabitAction());
-streamDeck.actions.registerAction(new NextTaskAction());
+streamDeck.actions.registerAction(new UpNextAction());
 streamDeck.actions.registerAction(new QuickGlanceAction());
 streamDeck.actions.registerAction(new RoutineAction());
 


### PR DESCRIPTION
## Summary

Replaces the "Next Task" action (browse current/next toggle) with a new **"Up Next"** action modelled on Android's Up Next notification — a single auto-advancing display with a live countdown.

### Display logic

| State | Value | Sub-label |
|---|---|---|
| Task in progress (`currentTask`) | Task title | `"12m left"` / `"1h 5m left"` |
| Task upcoming (`nextTask`) | Task title | `"in 45m"` / `"in 2h"` |
| Nothing scheduled | `"All clear"` | `"nothing up next"` (dimmed) |

The countdown refreshes every 60 seconds via `setInterval` between server state pushes. Auto-advance to the next task happens naturally when the server sends a new state (currentTask changes as tasks become in-progress or complete).

### Interactions

- **Press / dial push / long-press strip**: complete the current in-progress task (no-op when showing an upcoming task)
- **No dial cycling** — the display is intentionally automatic

### What changed

- New `up-next.ts` + `layouts/up-next.json`; UUID `app.dayglance.streamdeck.up-next`
- `plugin.ts`: registers `UpNextAction` instead of `NextTaskAction`
- `manifest.json`: replaces "Next Task" entry with "Up Next"
- `next-task.ts` left on disk but deregistered (safe to delete in a follow-up)

## Test plan

- [ ] Rebuild plugin, reinstall
- [ ] During a task's scheduled time: button shows task name + "Xm left", counts down each minute
- [ ] Before next task starts: button shows task name + "in Xm"
- [ ] Press during in-progress task → task marked complete, display switches to next
- [ ] Press when showing upcoming task → no-op
- [ ] Nothing scheduled → "All clear" dimmed

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_