### PR TITLE
fix(stream-deck): include recurring tasks in Agenda display and counts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6111,6 +6111,7 @@ const DayPlanner = () => {
     todayAgenda,
     currentTime,
     tasks,
+    expandedRecurringTasks,
     focusModeAvailable,
     showFocusMode,
     focusPhase,

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -42,6 +42,7 @@ export default function useElectronBridge({
   todayAgenda,
   currentTime,
   tasks,
+  expandedRecurringTasks,
   focusModeAvailable,
   showFocusMode,
   focusPhase,
@@ -129,8 +130,19 @@ export default function useElectronBridge({
     } : null;
 
     const todayStr = dateToString(currentTime);
-    const todayTasks = tasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay);
-    const allDayTasks = tasks.filter(t => t.date === todayStr && t.isAllDay);
+    const todayRecurring = (expandedRecurringTasks || []).filter(t => t.date === todayStr);
+    // Include recurring instances in counts (stable denominator — all tasks regardless of completion/time)
+    const todayTasks = [
+      ...tasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay),
+      ...todayRecurring.filter(t => t.startTime && !t.isAllDay),
+    ];
+    const allDayTasks = [
+      ...tasks.filter(t => t.date === todayStr && t.isAllDay),
+      ...todayRecurring.filter(t => t.isAllDay),
+    ];
+    // todayAgenda is pre-built with recurring tasks merged and sorted — use it for display
+    const agendaAllDay = todayAgenda.filter(t => t._agendaType === 'allday');
+    const agendaScheduled = todayAgenda.filter(t => t._agendaType === 'scheduled');
 
     // ── Habits ────────────────────────────────────────────────────────────
     const habits = habitsEnabled ? (activeHabits ?? []).map(h => {
@@ -161,10 +173,8 @@ export default function useElectronBridge({
       currentTask: mapTask(inProgress),
       nextTask: mapTask(nextUpcoming),
       scheduledTasks: [
-        ...allDayTasks.map(mapTask),
-        ...[...todayTasks]
-          .sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime))
-          .map(mapTask),
+        ...agendaAllDay.map(mapTask),
+        ...agendaScheduled.map(mapTask),
       ],
       today: {
         total: todayTasks.length + allDayTasks.length,
@@ -189,7 +199,7 @@ export default function useElectronBridge({
       } : null,
     });
   }, [
-    todayAgenda, currentTime, tasks, focusModeAvailable,
+    todayAgenda, currentTime, tasks, expandedRecurringTasks, focusModeAvailable,
     showFocusMode, focusPhase, focusTimerSeconds, focusTimerRunning,
     focusWorkMinutes, focusBreakMinutes,
     activeHabits, getTodayHabitCount, habitsEnabled,


### PR DESCRIPTION
## Summary

The Agenda cycling strip and today's X/Y count were both missing recurring task instances.

**Root cause:** `scheduledTasks` was built by filtering the raw `tasks` array, which only contains stored tasks. Recurring instances live in `expandedRecurringTasks` and never appear there.

**Fix:**
- `scheduledTasks` now pulls from `todayAgenda` (passed to the bridge already), which correctly merges `expandedRecurringTasks` — all-day tasks first, timed tasks sorted by start time
- `expandedRecurringTasks` is now passed as a new prop to `useElectronBridge` and merged into `todayTasks` / `allDayTasks` for counting, keeping the denominator stable as tasks complete

## Test plan

- [ ] Recurring task for today appears in the Agenda cycling strip
- [ ] Recurring task is counted in the X/Y overview (total goes up)
- [ ] Completing a recurring task increments the completed count and shows strikethrough
- [ ] Non-recurring tasks and all-day tasks unaffected

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_