### PR TITLE
fix(stream-deck): restore completed tasks in Agenda cycling strip

### DIFF
--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -140,9 +140,6 @@ export default function useElectronBridge({
       ...tasks.filter(t => t.date === todayStr && t.isAllDay),
       ...todayRecurring.filter(t => t.isAllDay),
     ];
-    // todayAgenda is pre-built with recurring tasks merged and sorted — use it for display
-    const agendaAllDay = todayAgenda.filter(t => t._agendaType === 'allday');
-    const agendaScheduled = todayAgenda.filter(t => t._agendaType === 'scheduled');
 
     // ── Habits ────────────────────────────────────────────────────────────
     const habits = habitsEnabled ? (activeHabits ?? []).map(h => {
@@ -173,8 +170,10 @@ export default function useElectronBridge({
       currentTask: mapTask(inProgress),
       nextTask: mapTask(nextUpcoming),
       scheduledTasks: [
-        ...agendaAllDay.map(mapTask),
-        ...agendaScheduled.map(mapTask),
+        ...allDayTasks.map(mapTask),
+        ...[...todayTasks]
+          .sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime))
+          .map(mapTask),
       ],
       today: {
         total: todayTasks.length + allDayTasks.length,


### PR DESCRIPTION
## Summary

Using `todayAgenda` for `scheduledTasks` (introduced in #612) broke completed task visibility. `todayAgenda` filters out past-completed tasks by design (so the app UI doesn't show stale items) — but the Stream Deck Agenda strip should keep showing them with strikethrough.

**Fix:** revert `scheduledTasks` back to being built from `todayTasks` + `allDayTasks`, which already include recurring instances (via `expandedRecurringTasks` added in #612) and preserve completed tasks regardless of their time.

## Test plan

- [ ] Completed tasks still appear in the Agenda cycling strip with strikethrough + "Completed"
- [ ] Recurring task instances still appear (from #612)
- [ ] All-day tasks still appear first in the list

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_