### PR TITLE
fix(stream-deck): include hyperGLANCE project sessions in Up Next and Agenda

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6107,11 +6107,26 @@ const DayPlanner = () => {
   // ── Electron desktop bridge ──────────────────────────────────────────────
   // Pushes lightweight state snapshots to the Electron WebSocket server and
   // routes commands from connected clients (Stream Deck, etc.) back into the app.
+  const todayHGSessions = useMemo(() => {
+    if (!goalsProjectsEnabled) return [];
+    const todayStr = getTodayStr();
+    const nowMin = currentTime.getHours() * 60 + currentTime.getMinutes();
+    return getGlanceHGInstances(projects, nowMin)
+      .map(({ project, instance }) => {
+        const hg = project.hyperglance;
+        const effectiveTime = hg.scheduledTimeOverrides?.[instance.date] || hg.scheduledTime || '';
+        const duration = hg.scheduledDurationOverrides?.[instance.date] || hg.scheduledDuration || 60;
+        return { id: project.id, title: project.title, colorHex: hg.color || '#4f46e5', startTime: effectiveTime, duration, isOverdue: instance.isOverdue, date: instance.date };
+      })
+      .filter(s => !s.isOverdue && s.date === todayStr && s.startTime);
+  }, [goalsProjectsEnabled, projects, currentTime]);
+
   useElectronBridge({
     todayAgenda,
     currentTime,
     tasks,
     expandedRecurringTasks,
+    todayHGSessions,
     focusModeAvailable,
     showFocusMode,
     focusPhase,

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -43,6 +43,7 @@ export default function useElectronBridge({
   currentTime,
   tasks,
   expandedRecurringTasks,
+  todayHGSessions,
   focusModeAvailable,
   showFocusMode,
   focusPhase,
@@ -107,7 +108,11 @@ export default function useElectronBridge({
     if (!window.electronAPI) return;
 
     const nowMin = currentTime.getHours() * 60 + currentTime.getMinutes();
-    const scheduled = todayAgenda.filter(t => t._agendaType === 'scheduled' && !t.completed && t.startTime);
+    const hgSessions = (todayHGSessions || []);
+    const scheduled = [
+      ...todayAgenda.filter(t => t._agendaType === 'scheduled' && !t.completed && t.startTime),
+      ...hgSessions,
+    ].sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime));
 
     const inProgress = scheduled.find(t => {
       const start = timeToMinutes(t.startTime);
@@ -123,7 +128,7 @@ export default function useElectronBridge({
       title: t.title,
       startTime: t.startTime ?? null,
       duration: t.duration || 0,
-      colorHex: taskColorToHex(t.color, t.nativeCalendarColor),
+      colorHex: t.colorHex || taskColorToHex(t.color, t.nativeCalendarColor),
       tags: t.tags || [],
       completed: !!t.completed,
       isAllDay: !!t.isAllDay,
@@ -135,6 +140,7 @@ export default function useElectronBridge({
     const todayTasks = [
       ...tasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay),
       ...todayRecurring.filter(t => t.startTime && !t.isAllDay),
+      ...hgSessions,
     ];
     const allDayTasks = [
       ...tasks.filter(t => t.date === todayStr && t.isAllDay),
@@ -198,7 +204,7 @@ export default function useElectronBridge({
       } : null,
     });
   }, [
-    todayAgenda, currentTime, tasks, expandedRecurringTasks, focusModeAvailable,
+    todayAgenda, currentTime, tasks, expandedRecurringTasks, todayHGSessions, focusModeAvailable,
     showFocusMode, focusPhase, focusTimerSeconds, focusTimerRunning,
     focusWorkMinutes, focusBreakMinutes,
     activeHabits, getTodayHabitCount, habitsEnabled,


### PR DESCRIPTION
## Summary

Up Next was skipping hyperGLANCE project sessions because they live in a separate `hyperGlanceItems` array and never touch `todayAgenda`. The `currentTask`/`nextTask` selection only looked at `todayAgenda.scheduled`, so the session was invisible.

**Fix:**
- New `todayHGSessions` `useMemo` in App.jsx: calls `getGlanceHGInstances`, filters to today's non-overdue sessions, maps each to a task-shaped object with `{ id, title, startTime, duration, colorHex }`
- Passed to `useElectronBridge` as a new prop
- In the bridge, HG sessions are merged into the `scheduled` pool (sorted by `startTime`) so they participate in `currentTask`/`nextTask` selection
- Also merged into `todayTasks` so they appear in the Agenda cycling strip and count
- `mapTask` now uses `t.colorHex` directly when present (HG sessions pre-compute it; regular tasks still go through `taskColorToHex`)

## Test plan

- [ ] Rebuild + reinstall plugin
- [ ] Up Next shows the scheduled project session at its start time ("in Xm" or "Xm left")
- [ ] Up Next auto-advances past the session when its time window ends
- [ ] Project session also appears in the Agenda cycling strip
- [ ] Regular tasks and recurring tasks unaffected

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_