### PR TITLE
fix(stream-deck): Agenda key press cycles tasks, long press completes

### DIFF
--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -38,7 +38,11 @@
       },
       "States": [
         { "Image": "imgs/actions/agenda/key", "TitleAlignment": "bottom" }
-      ]
+      ],
+      "KeyDescription": {
+        "Short": "Cycle to next task",
+        "Long": "Complete current task"
+      }
     },
     {
       "Name": "Focus / Pomodoro",

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -3,6 +3,7 @@ import {
   DialRotateEvent,
   DialUpEvent,
   KeyDownEvent,
+  KeyUpEvent,
   SingletonAction,
   TouchTapEvent,
   WillAppearEvent,
@@ -20,6 +21,7 @@ export class AgendaAction extends SingletonAction {
   private visibleCount = 0;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private encoderRefs = new Set<any>();
+  private keyLongPressTimer: ReturnType<typeof setTimeout> | null = null;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.visibleCount++;
@@ -62,7 +64,18 @@ export class AgendaAction extends SingletonAction {
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
-    await this.completeCurrentTask();
+    this.keyLongPressTimer = setTimeout(async () => {
+      this.keyLongPressTimer = null;
+      await this.completeCurrentTask();
+    }, 500);
+  }
+
+  override async onKeyUp(_ev: KeyUpEvent): Promise<void> {
+    if (this.keyLongPressTimer !== null) {
+      clearTimeout(this.keyLongPressTimer);
+      this.keyLongPressTimer = null;
+      await this.cycleView(1);
+    }
   }
 
   override async onTouchTap(ev: TouchTapEvent): Promise<void> {
@@ -71,10 +84,15 @@ export class AgendaAction extends SingletonAction {
       await this.completeCurrentTask();
       return;
     }
+    const delta = ev.payload.tapPos[0] < 100 ? -1 : 1;
+    await this.cycleView(delta);
+  }
+
+  private async cycleView(delta: number): Promise<void> {
+    if (!this.lastState) return;
     const count = this.lastState.scheduledTasks?.length ?? 0;
     if (count === 0) return;
     const total = count + 1;
-    const delta = ev.payload.tapPos[0] < 100 ? -1 : 1;
     this.viewIndex = ((this.viewIndex + delta) % total + total) % total;
     await this.renderAll(this.lastState);
   }


### PR DESCRIPTION
## Summary

Fixes the Agenda keypad button — pressing it was immediately completing the shown task with no way to browse the list.

**New behaviour:**
- **Short press** (< 500ms) → cycles to the next task (wraps back to overview)
- **Long press** (≥ 500ms) → completes the current task (same as the touch strip hold, no-op on overview or HG sessions)

Uses `onKeyDown` to start a 500ms timer and `onKeyUp` to cancel it for short-press detection. Extracted shared cycling logic into `cycleView()` so `onKeyUp` and `onTouchTap` both use it.

## Test plan

- [ ] Rebuild + reinstall plugin
- [ ] Short press on keypad cycles through tasks and back to overview
- [ ] Long press (~0.5s) on a task marks it complete
- [ ] Long press on overview or HG session is a no-op
- [ ] Touch strip tap-left/right still cycles correctly
- [ ] Touch strip hold still completes the task

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_