### PR TITLE
feat(stream-deck): Quick Glance auto-rotation with pin support

### DIFF
--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -123,14 +123,14 @@
       "Name": "Quick Glance",
       "UUID": "app.dayglance.streamdeck.quick-glance",
       "Icon": "imgs/actions/quick-glance/icon",
-      "Tooltip": "Rotates between date, weather, and next event.",
+      "Tooltip": "Auto-rotates between date, next event, and focus timer every 10s. Pin to lock on a mode.",
       "PropertyInspectorPath": "ui/property-inspector.html",
       "Controllers": ["Encoder", "Keypad"],
       "Encoder": {
         "layout": "layouts/quick-glance.json",
         "TriggerDescription": {
           "Rotate": "Cycle display mode",
-          "Push": "Pin current mode",
+          "Push": "Pin / unpin current mode",
           "TouchTap": "Tap left/right to cycle modes",
           "LongTouch": "Pin / unpin current mode"
         }

--- a/stream-deck-plugin/src/actions/quick-glance.ts
+++ b/stream-deck-plugin/src/actions/quick-glance.ts
@@ -3,6 +3,7 @@ import {
   DialRotateEvent,
   DialUpEvent,
   KeyDownEvent,
+  KeyUpEvent,
   SingletonAction,
   TouchTapEvent,
   WillAppearEvent,
@@ -13,6 +14,7 @@ import { renderKey, renderStrip, stripTags, truncate } from "../render";
 
 type DisplayMode = "date" | "next-event" | "focus";
 const MODES: DisplayMode[] = ["date", "next-event", "focus"];
+const AUTO_ROTATE_MS = 10_000;
 
 @action({ UUID: "app.dayglance.streamdeck.quick-glance" })
 export class QuickGlanceAction extends SingletonAction {
@@ -23,6 +25,8 @@ export class QuickGlanceAction extends SingletonAction {
   private encoderRefs = new Set<any>();
   private modeIndex = 0;
   private pinned = false;
+  private autoRotateTimer: ReturnType<typeof setInterval> | null = null;
+  private keyLongPressTimer: ReturnType<typeof setTimeout> | null = null;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.visibleCount++;
@@ -35,6 +39,7 @@ export class QuickGlanceAction extends SingletonAction {
         this.lastState = s;
         this.renderAll(s).catch(e => console.error("[dayGLANCE] quick-glance render:", e));
       });
+      this.startAutoRotate();
     }
     if (this.lastState) await this.renderOne(ev.action, this.lastState);
   }
@@ -45,34 +50,77 @@ export class QuickGlanceAction extends SingletonAction {
     if (this.visibleCount === 0) {
       this.unsubscribe?.();
       this.unsubscribe = null;
+      this.stopAutoRotate();
     }
   }
 
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {
     if (this.pinned) return;
-    const total = MODES.length;
-    this.modeIndex = ((this.modeIndex + ev.payload.ticks) % total + total) % total;
-    if (this.lastState) await this.renderAll(this.lastState);
+    await this.cycleMode(ev.payload.ticks);
   }
 
   override async onDialUp(_ev: DialUpEvent): Promise<void> {
-    this.pinned = !this.pinned;
+    this.togglePin();
+    if (this.lastState) await this.renderAll(this.lastState);
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
-    this.pinned = !this.pinned;
+    this.keyLongPressTimer = setTimeout(async () => {
+      this.keyLongPressTimer = null;
+      this.togglePin();
+      if (this.lastState) await this.renderAll(this.lastState);
+    }, 500);
+  }
+
+  override async onKeyUp(_ev: KeyUpEvent): Promise<void> {
+    if (this.keyLongPressTimer !== null) {
+      clearTimeout(this.keyLongPressTimer);
+      this.keyLongPressTimer = null;
+      if (!this.pinned) await this.cycleMode(1);
+    }
   }
 
   override async onTouchTap(ev: TouchTapEvent): Promise<void> {
     if (ev.payload.hold) {
-      this.pinned = !this.pinned;
+      this.togglePin();
+      if (this.lastState) await this.renderAll(this.lastState);
       return;
     }
     if (this.pinned) return;
-    const total = MODES.length;
     const delta = ev.payload.tapPos[0] < 100 ? -1 : 1;
+    await this.cycleMode(delta);
+  }
+
+  private async cycleMode(delta: number): Promise<void> {
+    const total = MODES.length;
     this.modeIndex = ((this.modeIndex + delta) % total + total) % total;
+    this.startAutoRotate(); // reset the timer on manual cycle
     if (this.lastState) await this.renderAll(this.lastState);
+  }
+
+  private togglePin(): void {
+    this.pinned = !this.pinned;
+    if (this.pinned) {
+      this.stopAutoRotate();
+    } else {
+      this.startAutoRotate();
+    }
+  }
+
+  private startAutoRotate(): void {
+    this.stopAutoRotate();
+    this.autoRotateTimer = setInterval(async () => {
+      if (!this.lastState) return;
+      this.modeIndex = (this.modeIndex + 1) % MODES.length;
+      await this.renderAll(this.lastState).catch(e => console.error("[dayGLANCE] quick-glance auto-rotate:", e));
+    }, AUTO_ROTATE_MS);
+  }
+
+  private stopAutoRotate(): void {
+    if (this.autoRotateTimer !== null) {
+      clearInterval(this.autoRotateTimer);
+      this.autoRotateTimer = null;
+    }
   }
 
   private async renderAll(state: DayGlanceState): Promise<void> {
@@ -89,21 +137,29 @@ export class QuickGlanceAction extends SingletonAction {
 
     if (mode === "date") {
       const { weekday, month, day } = formatDate(state.today.date);
-      renderOpts = { value: `${month} ${day}`, sub: weekday };
+      const sub = this.pinned ? `${weekday} ●` : weekday;
+      renderOpts = { value: `${month} ${day}`, sub };
     } else if (mode === "next-event") {
       const task = state.currentTask ?? state.nextTask;
-      renderOpts = task
-        ? { value: truncate(stripTags(task.title), 12), sub: "next up" }
-        : { value: "Clear", sub: "no events", dim: true };
+      if (task) {
+        const timeLabel = task.startTime ? eventTimeLabel(task.startTime, task.duration, state.use24Hour ?? false) : "";
+        const sub = this.pinned ? `${timeLabel} ●` : timeLabel;
+        renderOpts = { value: truncate(stripTags(task.title), 12), sub };
+      } else {
+        const sub = this.pinned ? "no events ●" : "no events";
+        renderOpts = { value: "Clear", sub, dim: true };
+      }
     } else {
       const { active, phase, secondsRemaining } = state.focus;
       if (!active) {
-        renderOpts = { value: "Focus", sub: "off", dim: true };
+        const sub = this.pinned ? "off ●" : "off";
+        renderOpts = { value: "Focus", sub, dim: true };
       } else {
         const m = Math.floor(secondsRemaining / 60);
         const s = secondsRemaining % 60;
         const barColor = phase === "work" ? "#f97316" : "#22c55e";
-        renderOpts = { value: `${m}:${s.toString().padStart(2, "0")}`, sub: phase, barColor };
+        const sub = this.pinned ? `${phase} ●` : phase;
+        renderOpts = { value: `${m}:${s.toString().padStart(2, "0")}`, sub, barColor };
       }
     }
 
@@ -124,4 +180,32 @@ function formatDate(iso: string): { weekday: string; month: string; day: string 
     month: date.toLocaleDateString("en-US", { month: "short" }),
     day: String(d),
   };
+}
+
+function toMin(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function nowMin(): number {
+  const now = new Date();
+  return now.getHours() * 60 + now.getMinutes();
+}
+
+function formatTime(t: string, use24Hour: boolean): string {
+  const [hStr, mStr] = t.split(":");
+  const h = parseInt(hStr, 10);
+  const m = mStr.padStart(2, "0");
+  if (use24Hour) return `${h.toString().padStart(2, "0")}:${m}`;
+  const displayHour = h === 0 ? 12 : h > 12 ? h - 12 : h;
+  const ampm = h >= 12 ? "PM" : "AM";
+  return `${displayHour}:${m} ${ampm}`;
+}
+
+function eventTimeLabel(startTime: string, duration: number, use24Hour: boolean): string {
+  const start = toMin(startTime);
+  const now = nowMin();
+  if (start > now) return formatTime(startTime, use24Hour);
+  if (duration > 0 && start + duration > now) return "In Progress";
+  return "Overdue";
 }


### PR DESCRIPTION
## Summary

Brings Quick Glance to life with auto-rotation and makes pin actually meaningful.

**Auto-rotation:**
- Cycles date → next event → focus every 10 seconds automatically
- Any manual cycle (dial, tap, key) resets the countdown to a fresh 10s
- Timer starts when the button appears, stops when it disappears

**Pin:**
- Dial push / key long-press / touch hold toggles pin
- When pinned: timer stops, mode is locked, `●` appears in the sub-label
- When unpinned: timer restarts with a fresh 10s window

**Key interaction fix:**
- Short press → cycle mode (consistent with Agenda/Goal Progress)
- Long press (≥500ms) → toggle pin

**`next-event` mode improvement:**
- Now shows the actual formatted start time (`1:00 PM` / `13:00`) respecting the app's 12hr/24hr setting, or `In Progress` / `Overdue` as appropriate — instead of the generic "next up"

**Tooltip:**
- Removed stale "weather" mention

## Test plan

- [ ] Rebuild + reinstall plugin
- [ ] Button auto-advances between the 3 modes every ~10s with no interaction
- [ ] Manual dial rotate / tap / key press cycles and resets the 10s countdown
- [ ] Long-pressing key pins the mode; `●` appears in sub-label
- [ ] Pinning stops auto-rotation; unpinning resumes it
- [ ] Dial push also toggles pin
- [ ] next-event shows start time or "In Progress" / "Overdue" correctly
- [ ] 12hr / 24hr setting respected in next-event time display

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_