### PR TITLE
feat(stream-deck): context-sensitive Focus dial for duration adjustment

### DIFF
--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -12,6 +12,7 @@ export const MSG_DAY_STATE = 'day:state' as const;
 export const MSG_DAY_FOCUS_START      = 'day:focus:start'      as const;
 export const MSG_DAY_FOCUS_STOP       = 'day:focus:stop'       as const;
 export const MSG_DAY_FOCUS_SKIP       = 'day:focus:skip'       as const;
+export const MSG_DAY_FOCUS_SET_DURATION = 'day:focus:set-duration' as const;
 export const MSG_DAY_TASK_COMPLETE    = 'day:task:complete'    as const;
 export const MSG_DAY_HABIT_INCREMENT  = 'day:habit:increment'  as const;
 export const MSG_DAY_ROUTINE_COMPLETE = 'day:routine:complete' as const;
@@ -98,6 +99,7 @@ export type InboundCommand =
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_START }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_STOP }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_SKIP }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_SET_DURATION; workMinutes?: number; breakMinutes?: number }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_TASK_COMPLETE; id: string }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_HABIT_INCREMENT; id: string }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_ROUTINE_COMPLETE; id: string };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6137,6 +6137,8 @@ const DayPlanner = () => {
     enterFocusModeRef,
     exitFocusModeRef,
     skipFocusPhase,
+    setFocusWorkMinutes,
+    setFocusBreakMinutes,
     toggleComplete,
     activeHabits,
     getTodayHabitCount,

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -9,6 +9,7 @@ import {
   MSG_DAY_FOCUS_START,
   MSG_DAY_FOCUS_STOP,
   MSG_DAY_FOCUS_SKIP,
+  MSG_DAY_FOCUS_SET_DURATION,
   MSG_DAY_TASK_COMPLETE,
   MSG_DAY_HABIT_INCREMENT,
   MSG_DAY_ROUTINE_COMPLETE,
@@ -56,6 +57,8 @@ export default function useElectronBridge({
   enterFocusModeRef,
   exitFocusModeRef,
   skipFocusPhase,
+  setFocusWorkMinutes,
+  setFocusBreakMinutes,
   toggleComplete,
   // Habits
   activeHabits,
@@ -78,10 +81,14 @@ export default function useElectronBridge({
   const toggleCompleteRef = useRef(toggleComplete);
   const incrementHabitRef = useRef(incrementHabit);
   const toggleRoutineCompletionRef = useRef(toggleRoutineCompletion);
+  const setFocusWorkMinutesRef = useRef(setFocusWorkMinutes);
+  const setFocusBreakMinutesRef = useRef(setFocusBreakMinutes);
   skipFocusPhaseRef.current = skipFocusPhase;
   toggleCompleteRef.current = toggleComplete;
   incrementHabitRef.current = incrementHabit;
   toggleRoutineCompletionRef.current = toggleRoutineCompletion;
+  setFocusWorkMinutesRef.current = setFocusWorkMinutes;
+  setFocusBreakMinutesRef.current = setFocusBreakMinutes;
 
   // Subscribe to commands from WebSocket clients once on mount.
   useEffect(() => {
@@ -97,6 +104,10 @@ export default function useElectronBridge({
           break;
         case MSG_DAY_FOCUS_SKIP:
           skipFocusPhaseRef.current?.();
+          break;
+        case MSG_DAY_FOCUS_SET_DURATION:
+          if (cmd.workMinutes !== undefined) setFocusWorkMinutesRef.current?.(Math.max(1, Math.min(120, cmd.workMinutes)));
+          if (cmd.breakMinutes !== undefined) setFocusBreakMinutesRef.current?.(Math.max(1, Math.min(60, cmd.breakMinutes)));
           break;
         case MSG_DAY_TASK_COMPLETE:
           if (cmd.id) toggleCompleteRef.current?.(cmd.id);

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -8,20 +8,18 @@ import {
   WillAppearEvent,
   WillDisappearEvent,
 } from "@elgato/streamdeck";
-import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP } from "../client";
+import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_FOCUS_SET_DURATION } from "../client";
 import { renderKey, renderStrip } from "../render";
 
-type Settings = { sessionDurationMinutes: number };
-
 @action({ UUID: "app.dayglance.streamdeck.focus" })
-export class FocusAction extends SingletonAction<Settings> {
+export class FocusAction extends SingletonAction {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;
   private visibleCount = 0;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private encoderRefs = new Set<any>();
 
-  override async onWillAppear(ev: WillAppearEvent<Settings>): Promise<void> {
+  override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.visibleCount++;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if ((ev.payload as any).controller === "Encoder") {
@@ -36,7 +34,7 @@ export class FocusAction extends SingletonAction<Settings> {
     if (this.lastState) await this.renderOne(ev.action, this.lastState);
   }
 
-  override async onWillDisappear(ev: WillDisappearEvent<Settings>): Promise<void> {
+  override async onWillDisappear(ev: WillDisappearEvent): Promise<void> {
     this.encoderRefs.delete(ev.action);
     this.visibleCount = Math.max(0, this.visibleCount - 1);
     if (this.visibleCount === 0) {
@@ -45,39 +43,46 @@ export class FocusAction extends SingletonAction<Settings> {
     }
   }
 
-  override async onDialRotate(ev: DialRotateEvent<Settings>): Promise<void> {
-    if (this.lastState?.focus.active) return;
-    const settings = await ev.action.getSettings();
-    const newDuration = Math.max(5, (settings.sessionDurationMinutes ?? 25) + ev.payload.ticks);
-    await ev.action.setSettings({ sessionDurationMinutes: newDuration });
-    const previewOpts = { value: `${newDuration}m`, sub: "focus", barColor: "#3b82f6" };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    for (const act of this.actions as unknown as any[]) {
-      await act.setImage(renderKey(previewOpts));
-      if (this.encoderRefs.has(act)) {
-        await act.setFeedback({ canvas: renderStrip(previewOpts) });
-      } else {
-        await act.setTitle("");
-      }
+  override async onDialRotate(ev: DialRotateEvent): Promise<void> {
+    if (!this.lastState) return;
+    const { active, phase, workMinutes, breakMinutes } = this.lastState.focus;
+
+    if (!active) {
+      // Before session: adjust work duration
+      const newWork = Math.max(1, Math.min(120, workMinutes + ev.payload.ticks));
+      send({ type: MSG_DAY_FOCUS_SET_DURATION, workMinutes: newWork });
+      await this.renderPreview(`${newWork}m`, "work session", "#f97316");
+    } else if (phase === "work") {
+      // During work: adjust upcoming break duration
+      const newBreak = Math.max(1, Math.min(60, breakMinutes + ev.payload.ticks));
+      send({ type: MSG_DAY_FOCUS_SET_DURATION, breakMinutes: newBreak });
+      await this.renderPreview(`${newBreak}m`, "next break", "#22c55e");
+    } else {
+      // During break: adjust work duration for next session
+      const newWork = Math.max(1, Math.min(120, workMinutes + ev.payload.ticks));
+      send({ type: MSG_DAY_FOCUS_SET_DURATION, workMinutes: newWork });
+      await this.renderPreview(`${newWork}m`, "next session", "#f97316");
     }
   }
 
-  override async onDialUp(_ev: DialUpEvent<Settings>): Promise<void> {
+  override async onDialUp(_ev: DialUpEvent): Promise<void> {
     this.toggle();
   }
 
-  override async onKeyDown(_ev: KeyDownEvent<Settings>): Promise<void> {
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
     this.toggle();
   }
 
-  override async onTouchTap(ev: TouchTapEvent<Settings>): Promise<void> {
+  override async onTouchTap(ev: TouchTapEvent): Promise<void> {
     if (ev.payload.hold) {
       this.toggle();
       return;
     }
-    // Tap: switch work/break phase if a session is active
+    // Tap: skip phase if active, start if not
     if (this.lastState?.focus.active) {
       send({ type: MSG_DAY_FOCUS_SKIP });
+    } else {
+      this.toggle();
     }
   }
 
@@ -90,6 +95,19 @@ export class FocusAction extends SingletonAction<Settings> {
     }
   }
 
+  private async renderPreview(value: string, sub: string, barColor: string): Promise<void> {
+    const opts = { value, sub, barColor };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    for (const act of this.actions as unknown as any[]) {
+      await act.setImage(renderKey(opts));
+      if (this.encoderRefs.has(act)) {
+        await act.setFeedback({ canvas: renderStrip(opts) });
+      } else {
+        await act.setTitle("");
+      }
+    }
+  }
+
   private async renderAll(state: DayGlanceState): Promise<void> {
     for (const act of this.actions) {
       await this.renderOne(act, state);
@@ -99,11 +117,16 @@ export class FocusAction extends SingletonAction<Settings> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async renderOne(act: any, state: DayGlanceState): Promise<void> {
     const isEncoder = this.encoderRefs.has(act);
-    const { available, active, phase, secondsRemaining, running } = state.focus;
+    const { available, active, phase, secondsRemaining, running, workMinutes } = state.focus;
     let renderOpts: Parameters<typeof renderKey>[0];
 
     if (!active) {
-      renderOpts = { value: "Focus", sub: available ? "press to start" : "unavailable", dim: !available };
+      renderOpts = {
+        value: `${workMinutes}m`,
+        sub: available ? "press to start" : "unavailable",
+        dim: !available,
+        barColor: "#f97316",
+      };
     } else {
       const m = Math.floor(secondsRemaining / 60);
       const s = secondsRemaining % 60;

--- a/stream-deck-plugin/src/client.ts
+++ b/stream-deck-plugin/src/client.ts
@@ -5,6 +5,7 @@ import {
   MSG_DAY_FOCUS_START,
   MSG_DAY_FOCUS_STOP,
   MSG_DAY_FOCUS_SKIP,
+  MSG_DAY_FOCUS_SET_DURATION,
   MSG_DAY_TASK_COMPLETE,
   MSG_DAY_HABIT_INCREMENT,
   MSG_DAY_ROUTINE_COMPLETE,
@@ -14,13 +15,14 @@ import {
 
 // Re-export everything action files need — keeps their imports pointing at ../client only
 export type { DayGlanceState, Task, FocusState } from "../../electron/protocol";
-export { MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_TASK_COMPLETE, MSG_DAY_HABIT_INCREMENT, MSG_DAY_ROUTINE_COMPLETE } from "../../electron/protocol";
+export { MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_FOCUS_SET_DURATION, MSG_DAY_TASK_COMPLETE, MSG_DAY_HABIT_INCREMENT, MSG_DAY_ROUTINE_COMPLETE } from "../../electron/protocol";
 
 // CommandPayload is the caller-facing API — send() stamps v internally
 type CommandPayload =
   | { type: typeof MSG_DAY_FOCUS_START }
   | { type: typeof MSG_DAY_FOCUS_STOP }
   | { type: typeof MSG_DAY_FOCUS_SKIP }
+  | { type: typeof MSG_DAY_FOCUS_SET_DURATION; workMinutes?: number; breakMinutes?: number }
   | { type: typeof MSG_DAY_TASK_COMPLETE; id: string }
   | { type: typeof MSG_DAY_HABIT_INCREMENT; id: string }
   | { type: typeof MSG_DAY_ROUTINE_COMPLETE; id: string };


### PR DESCRIPTION
## Summary

Makes the Focus dial genuinely useful at every stage of the Pomodoro flow, and wires up the duration adjustment end-to-end from Stream Deck → app state.

**Dial behaviour (context-sensitive):**
| State | Rotate does | Preview shows |
|---|---|---|
| Idle (not active) | Adjust work duration | `"28m" / "work session"` |
| Active — work phase | Adjust upcoming break | `"7m" / "next break"` |
| Active — break phase | Adjust next work session | `"30m" / "next session"` |

**New protocol command:** `MSG_DAY_FOCUS_SET_DURATION` with optional `workMinutes` and `breakMinutes` fields. Bridge calls `setFocusWorkMinutes` / `setFocusBreakMinutes` directly. Values clamped to sane ranges (work 1–120m, break 1–60m).

**Other improvements:**
- Idle display now shows current work duration (`"25m"`) so you can see and tune it before starting — previously just showed `"Focus"`
- Touch tap when idle now starts focus (was a no-op)
- Removed the stale `Settings` type that was storing a local duration that never reached the app

## Test plan

- [ ] Rebuild + reinstall plugin
- [ ] Idle: rotating dial changes the displayed duration and updates the app's work minutes
- [ ] Idle: display shows current work duration (e.g. `"25m"`)
- [ ] During work: rotating dial shows break duration preview and updates app's break minutes
- [ ] During break: rotating dial shows next session duration and updates app's work minutes
- [ ] Touch tap when idle starts the session
- [ ] Toggle (start/stop) still works via dial push, key press, and touch hold

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_