### PR TITLE
feat(stream-deck): Focus dial duration + 4-section Pomodoro touch strip

### DIFF
--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -12,6 +12,7 @@ export const MSG_DAY_STATE = 'day:state' as const;
 export const MSG_DAY_FOCUS_START      = 'day:focus:start'      as const;
 export const MSG_DAY_FOCUS_STOP       = 'day:focus:stop'       as const;
 export const MSG_DAY_FOCUS_SKIP       = 'day:focus:skip'       as const;
+export const MSG_DAY_FOCUS_SET_DURATION = 'day:focus:set-duration' as const;
 export const MSG_DAY_TASK_COMPLETE    = 'day:task:complete'    as const;
 export const MSG_DAY_HABIT_INCREMENT  = 'day:habit:increment'  as const;
 export const MSG_DAY_ROUTINE_COMPLETE = 'day:routine:complete' as const;
@@ -98,6 +99,7 @@ export type InboundCommand =
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_START }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_STOP }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_SKIP }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_SET_DURATION; workMinutes?: number; breakMinutes?: number }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_TASK_COMPLETE; id: string }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_HABIT_INCREMENT; id: string }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_ROUTINE_COMPLETE; id: string };

--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -38,6 +38,7 @@ export type FocusState = {
   running: boolean;
   workMinutes: number;
   breakMinutes: number;
+  cycleCount: number;  // total completed work cycles since session start
 };
 
 export type Habit = {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6137,6 +6137,8 @@ const DayPlanner = () => {
     enterFocusModeRef,
     exitFocusModeRef,
     skipFocusPhase,
+    setFocusWorkMinutes,
+    setFocusBreakMinutes,
     toggleComplete,
     activeHabits,
     getTodayHabitCount,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6132,6 +6132,7 @@ const DayPlanner = () => {
     focusPhase,
     focusTimerSeconds,
     focusTimerRunning,
+    focusCycleCount,
     focusWorkMinutes,
     focusBreakMinutes,
     enterFocusModeRef,

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -9,6 +9,7 @@ import {
   MSG_DAY_FOCUS_START,
   MSG_DAY_FOCUS_STOP,
   MSG_DAY_FOCUS_SKIP,
+  MSG_DAY_FOCUS_SET_DURATION,
   MSG_DAY_TASK_COMPLETE,
   MSG_DAY_HABIT_INCREMENT,
   MSG_DAY_ROUTINE_COMPLETE,
@@ -56,6 +57,8 @@ export default function useElectronBridge({
   enterFocusModeRef,
   exitFocusModeRef,
   skipFocusPhase,
+  setFocusWorkMinutes,
+  setFocusBreakMinutes,
   toggleComplete,
   // Habits
   activeHabits,
@@ -78,10 +81,14 @@ export default function useElectronBridge({
   const toggleCompleteRef = useRef(toggleComplete);
   const incrementHabitRef = useRef(incrementHabit);
   const toggleRoutineCompletionRef = useRef(toggleRoutineCompletion);
+  const setFocusWorkMinutesRef = useRef(setFocusWorkMinutes);
+  const setFocusBreakMinutesRef = useRef(setFocusBreakMinutes);
   skipFocusPhaseRef.current = skipFocusPhase;
   toggleCompleteRef.current = toggleComplete;
   incrementHabitRef.current = incrementHabit;
   toggleRoutineCompletionRef.current = toggleRoutineCompletion;
+  setFocusWorkMinutesRef.current = setFocusWorkMinutes;
+  setFocusBreakMinutesRef.current = setFocusBreakMinutes;
 
   // Subscribe to commands from WebSocket clients once on mount.
   useEffect(() => {
@@ -97,6 +104,10 @@ export default function useElectronBridge({
           break;
         case MSG_DAY_FOCUS_SKIP:
           skipFocusPhaseRef.current?.();
+          break;
+        case MSG_DAY_FOCUS_SET_DURATION:
+          if (cmd.workMinutes !== undefined) setFocusWorkMinutesRef.current?.(Math.max(1, Math.min(120, cmd.workMinutes)));
+          if (cmd.breakMinutes !== undefined) setFocusBreakMinutesRef.current?.(Math.max(1, Math.min(60, cmd.breakMinutes)));
           break;
         case MSG_DAY_TASK_COMPLETE:
           if (cmd.id) toggleCompleteRef.current?.(cmd.id);

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -52,6 +52,7 @@ export default function useElectronBridge({
   focusPhase,
   focusTimerSeconds,
   focusTimerRunning,
+  focusCycleCount,
   focusWorkMinutes,
   focusBreakMinutes,
   enterFocusModeRef,
@@ -243,6 +244,7 @@ export default function useElectronBridge({
         running: focusTimerRunning,
         workMinutes: focusWorkMinutes,
         breakMinutes: focusBreakMinutes,
+        cycleCount: focusCycleCount || 0,
       },
       habits,
       nextRoutine: nextRoutineRaw ? {
@@ -258,7 +260,7 @@ export default function useElectronBridge({
   }, [
     todayAgenda, currentTime, tasks, expandedRecurringTasks, todayHGSessions, focusModeAvailable,
     showFocusMode, focusPhase, focusTimerSeconds, focusTimerRunning,
-    focusWorkMinutes, focusBreakMinutes,
+    focusCycleCount, focusWorkMinutes, focusBreakMinutes,
     activeHabits, getTodayHabitCount, habitsEnabled,
     todayRoutines, routineCompletions, use24HourClock,
     goals, projects, unscheduledTasks, goalsProjectsEnabled,

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -9,7 +9,7 @@ import {
   WillDisappearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_FOCUS_SET_DURATION } from "../client";
-import { renderKey, renderStrip } from "../render";
+import { renderKey, renderStrip, renderFocusStrip } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.focus" })
 export class FocusAction extends SingletonAction {
@@ -117,7 +117,7 @@ export class FocusAction extends SingletonAction {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async renderOne(act: any, state: DayGlanceState): Promise<void> {
     const isEncoder = this.encoderRefs.has(act);
-    const { available, active, phase, secondsRemaining, running, workMinutes } = state.focus;
+    const { available, active, phase, secondsRemaining, running, workMinutes, cycleCount } = state.focus;
     let renderOpts: Parameters<typeof renderKey>[0];
 
     if (!active) {
@@ -138,7 +138,11 @@ export class FocusAction extends SingletonAction {
 
     await act.setImage(renderKey(renderOpts));
     if (isEncoder) {
-      await act.setFeedback({ canvas: renderStrip(renderOpts) });
+      if (active) {
+        await act.setFeedback({ canvas: renderFocusStrip(phase, secondsRemaining, cycleCount ?? 0) });
+      } else {
+        await act.setFeedback({ canvas: renderStrip(renderOpts) });
+      }
     } else {
       await act.setTitle("");
     }

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -8,20 +8,18 @@ import {
   WillAppearEvent,
   WillDisappearEvent,
 } from "@elgato/streamdeck";
-import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP } from "../client";
+import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_FOCUS_SET_DURATION } from "../client";
 import { renderKey, renderStrip } from "../render";
 
-type Settings = { sessionDurationMinutes: number };
-
 @action({ UUID: "app.dayglance.streamdeck.focus" })
-export class FocusAction extends SingletonAction<Settings> {
+export class FocusAction extends SingletonAction {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;
   private visibleCount = 0;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private encoderRefs = new Set<any>();
 
-  override async onWillAppear(ev: WillAppearEvent<Settings>): Promise<void> {
+  override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.visibleCount++;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if ((ev.payload as any).controller === "Encoder") {
@@ -36,7 +34,7 @@ export class FocusAction extends SingletonAction<Settings> {
     if (this.lastState) await this.renderOne(ev.action, this.lastState);
   }
 
-  override async onWillDisappear(ev: WillDisappearEvent<Settings>): Promise<void> {
+  override async onWillDisappear(ev: WillDisappearEvent): Promise<void> {
     this.encoderRefs.delete(ev.action);
     this.visibleCount = Math.max(0, this.visibleCount - 1);
     if (this.visibleCount === 0) {
@@ -45,39 +43,46 @@ export class FocusAction extends SingletonAction<Settings> {
     }
   }
 
-  override async onDialRotate(ev: DialRotateEvent<Settings>): Promise<void> {
-    if (this.lastState?.focus.active) return;
-    const settings = await ev.action.getSettings();
-    const newDuration = Math.max(5, (settings.sessionDurationMinutes ?? 25) + ev.payload.ticks);
-    await ev.action.setSettings({ sessionDurationMinutes: newDuration });
-    const previewOpts = { value: `${newDuration}m`, sub: "focus", barColor: "#3b82f6" };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    for (const act of this.actions as unknown as any[]) {
-      await act.setImage(renderKey(previewOpts));
-      if (this.encoderRefs.has(act)) {
-        await act.setFeedback({ canvas: renderStrip(previewOpts) });
-      } else {
-        await act.setTitle("");
-      }
+  override async onDialRotate(ev: DialRotateEvent): Promise<void> {
+    if (!this.lastState) return;
+    const { active, phase, workMinutes, breakMinutes } = this.lastState.focus;
+
+    if (!active) {
+      // Before session: adjust work duration
+      const newWork = Math.max(1, Math.min(120, workMinutes + ev.payload.ticks));
+      send({ type: MSG_DAY_FOCUS_SET_DURATION, workMinutes: newWork });
+      await this.renderPreview(`${newWork}m`, "work session", "#f97316");
+    } else if (phase === "work") {
+      // During work: adjust upcoming break duration
+      const newBreak = Math.max(1, Math.min(60, breakMinutes + ev.payload.ticks));
+      send({ type: MSG_DAY_FOCUS_SET_DURATION, breakMinutes: newBreak });
+      await this.renderPreview(`${newBreak}m`, "next break", "#22c55e");
+    } else {
+      // During break: adjust work duration for next session
+      const newWork = Math.max(1, Math.min(120, workMinutes + ev.payload.ticks));
+      send({ type: MSG_DAY_FOCUS_SET_DURATION, workMinutes: newWork });
+      await this.renderPreview(`${newWork}m`, "next session", "#f97316");
     }
   }
 
-  override async onDialUp(_ev: DialUpEvent<Settings>): Promise<void> {
+  override async onDialUp(_ev: DialUpEvent): Promise<void> {
     this.toggle();
   }
 
-  override async onKeyDown(_ev: KeyDownEvent<Settings>): Promise<void> {
+  override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
     this.toggle();
   }
 
-  override async onTouchTap(ev: TouchTapEvent<Settings>): Promise<void> {
+  override async onTouchTap(ev: TouchTapEvent): Promise<void> {
     if (ev.payload.hold) {
       this.toggle();
       return;
     }
-    // Tap: switch work/break phase if a session is active
+    // Tap: skip phase if active, start if not
     if (this.lastState?.focus.active) {
       send({ type: MSG_DAY_FOCUS_SKIP });
+    } else {
+      this.toggle();
     }
   }
 
@@ -90,6 +95,19 @@ export class FocusAction extends SingletonAction<Settings> {
     }
   }
 
+  private async renderPreview(value: string, sub: string, barColor: string): Promise<void> {
+    const opts = { value, sub, barColor };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    for (const act of this.actions as unknown as any[]) {
+      await act.setImage(renderKey(opts));
+      if (this.encoderRefs.has(act)) {
+        await act.setFeedback({ canvas: renderStrip(opts) });
+      } else {
+        await act.setTitle("");
+      }
+    }
+  }
+
   private async renderAll(state: DayGlanceState): Promise<void> {
     for (const act of this.actions) {
       await this.renderOne(act, state);
@@ -99,11 +117,16 @@ export class FocusAction extends SingletonAction<Settings> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async renderOne(act: any, state: DayGlanceState): Promise<void> {
     const isEncoder = this.encoderRefs.has(act);
-    const { available, active, phase, secondsRemaining, running } = state.focus;
+    const { available, active, phase, secondsRemaining, running, workMinutes } = state.focus;
     let renderOpts: Parameters<typeof renderKey>[0];
 
     if (!active) {
-      renderOpts = { value: "Focus", sub: available ? "press to start" : "unavailable", dim: !available };
+      renderOpts = {
+        value: `${workMinutes}m`,
+        sub: available ? "press to start" : "unavailable",
+        dim: !available,
+        barColor: "#f97316",
+      };
     } else {
       const m = Math.floor(secondsRemaining / 60);
       const s = secondsRemaining % 60;

--- a/stream-deck-plugin/src/client.ts
+++ b/stream-deck-plugin/src/client.ts
@@ -5,6 +5,7 @@ import {
   MSG_DAY_FOCUS_START,
   MSG_DAY_FOCUS_STOP,
   MSG_DAY_FOCUS_SKIP,
+  MSG_DAY_FOCUS_SET_DURATION,
   MSG_DAY_TASK_COMPLETE,
   MSG_DAY_HABIT_INCREMENT,
   MSG_DAY_ROUTINE_COMPLETE,
@@ -14,13 +15,14 @@ import {
 
 // Re-export everything action files need — keeps their imports pointing at ../client only
 export type { DayGlanceState, Task, FocusState } from "../../electron/protocol";
-export { MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_TASK_COMPLETE, MSG_DAY_HABIT_INCREMENT, MSG_DAY_ROUTINE_COMPLETE } from "../../electron/protocol";
+export { MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_FOCUS_SET_DURATION, MSG_DAY_TASK_COMPLETE, MSG_DAY_HABIT_INCREMENT, MSG_DAY_ROUTINE_COMPLETE } from "../../electron/protocol";
 
 // CommandPayload is the caller-facing API — send() stamps v internally
 type CommandPayload =
   | { type: typeof MSG_DAY_FOCUS_START }
   | { type: typeof MSG_DAY_FOCUS_STOP }
   | { type: typeof MSG_DAY_FOCUS_SKIP }
+  | { type: typeof MSG_DAY_FOCUS_SET_DURATION; workMinutes?: number; breakMinutes?: number }
   | { type: typeof MSG_DAY_TASK_COMPLETE; id: string }
   | { type: typeof MSG_DAY_HABIT_INCREMENT; id: string }
   | { type: typeof MSG_DAY_ROUTINE_COMPLETE; id: string };

--- a/stream-deck-plugin/src/render.ts
+++ b/stream-deck-plugin/src/render.ts
@@ -74,6 +74,74 @@ function fontSize(text: string): number {
   return 18;
 }
 
+// ── Pomodoro 4-section strip ──────────────────────────────────────────────
+
+/**
+ * Renders the 200×100 touch strip as 4 equal sections (50px each), one per
+ * Pomodoro work cycle. Completed cycles show a tomato; the current phase
+ * (work or break) shows a live countdown; pending cycles show a dim number.
+ */
+export function renderFocusStrip(
+  phase: string,
+  secondsRemaining: number,
+  cycleCount: number,
+): string {
+  // How many work cycles are done within the current set of 4
+  const completedInSet = cycleCount % 4;
+  // All 4 done = long-break after completing cycle 4 (or 8, 12…)
+  const allDone = cycleCount > 0 && completedInSet === 0 && phase === "longBreak";
+
+  const m = Math.floor(secondsRemaining / 60);
+  const s = secondsRemaining % 60;
+  const timeStr = `${m}:${s.toString().padStart(2, "0")}`;
+
+  let cells = "";
+  for (let i = 0; i < 4; i++) {
+    const cx = i * 50 + 25;
+    const lx = i * 50;
+
+    if (allDone || i < completedInSet) {
+      // ── Completed — tomato ──
+      cells += `
+  <rect x="${lx}" y="0" width="50" height="100" fill="#180a0a"/>
+  <circle cx="${cx}" cy="56" r="20" fill="#dc2626"/>
+  <rect x="${cx - 2}" y="31" width="4" height="10" fill="#16a34a" rx="2"/>
+  <path d="M${cx - 2} 37 Q${cx - 9} 29 ${cx - 5} 25 Q${cx - 1} 33 ${cx - 2} 37Z" fill="#16a34a"/>`;
+    } else if (i === completedInSet && phase === "work") {
+      // ── Active work cycle ──
+      cells += `
+  <rect x="${lx}" y="0" width="50" height="100" fill="#1c0e00"/>
+  <rect x="${lx}" y="0" width="50" height="4" fill="#f97316"/>
+  <text x="${cx}" y="53" font-family="${FONT}" font-size="15" fill="white" fill-opacity="0.95" text-anchor="middle" font-weight="700">${timeStr}</text>
+  <text x="${cx}" y="70" font-family="${FONT}" font-size="10" fill="white" fill-opacity="0.4" text-anchor="middle">work</text>`;
+    } else if (i === completedInSet && (phase === "shortBreak" || phase === "longBreak")) {
+      // ── Active break (shown in the upcoming slot) ──
+      cells += `
+  <rect x="${lx}" y="0" width="50" height="100" fill="#0a180c"/>
+  <rect x="${lx}" y="0" width="50" height="4" fill="#22c55e"/>
+  <text x="${cx}" y="53" font-family="${FONT}" font-size="15" fill="white" fill-opacity="0.95" text-anchor="middle" font-weight="700">${timeStr}</text>
+  <text x="${cx}" y="70" font-family="${FONT}" font-size="10" fill="white" fill-opacity="0.4" text-anchor="middle">break</text>`;
+    } else {
+      // ── Pending ──
+      cells += `
+  <rect x="${lx}" y="0" width="50" height="100" fill="#111"/>
+  <circle cx="${cx}" cy="52" r="18" fill="none" stroke="#252525" stroke-width="2"/>
+  <text x="${cx}" y="58" font-family="${FONT}" font-size="16" fill="#2a2a2a" text-anchor="middle" font-weight="700">${i + 1}</text>`;
+    }
+  }
+
+  // Thin dividers between sections
+  const dividers = [50, 100, 150].map(dx =>
+    `<line x1="${dx}" y1="0" x2="${dx}" y2="100" stroke="#222" stroke-width="1"/>`
+  ).join("\n  ");
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${SW}" height="${SH}">
+  ${cells}
+  ${dividers}
+</svg>`;
+  return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
+}
+
 // ── Goal arc rendering ────────────────────────────────────────────────────
 
 interface GoalOpts {


### PR DESCRIPTION
## Summary

Two Focus button improvements, both on this branch:

### Context-sensitive dial (was PR #620)

| State | Rotate does | Preview shows |
|---|---|---|
| Idle (not active) | Adjust work duration | `"28m" / "work session"` |
| Active — work phase | Adjust upcoming break | `"7m" / "next break"` |
| Active — break phase | Adjust next work session | `"30m" / "next session"` |

New protocol command `MSG_DAY_FOCUS_SET_DURATION` with optional `workMinutes` / `breakMinutes`. Bridge calls `setFocusWorkMinutes` / `setFocusBreakMinutes` directly, clamped to sane ranges (work 1–120m, break 1–60m). Idle display now shows current work duration so you can tune it before starting. Touch tap when idle now starts focus.

### 4-section Pomodoro touch strip

Renders the Stream Deck+ touch strip as 4 equal 50px sections, one per cycle in the current set of 4:

| Section state | Appearance |
|---|---|
| Completed cycle | Tomato icon (red circle + green stem) on dark red bg |
| Active — work phase | Dark orange bg, orange top bar, live countdown, "work" label |
| Active — break phase | Dark green bg, green top bar, live countdown, "break" label |
| Pending cycle | Dim ring with cycle number (1–4) |

After all 4 cycles complete (long break), all sections show tomatoes. `cycleCount` added to `FocusState` in the protocol and wired through bridge → App.jsx.

## Test plan

- [ ] Rebuild + reinstall plugin
- [ ] **Idle**: rotating dial changes displayed duration and updates app's work minutes
- [ ] **Idle**: display shows current work duration (e.g. `"25m"`); touch tap starts session
- [ ] **During work**: rotating dial shows break duration preview and updates app's break minutes
- [ ] **During break**: rotating dial shows next session duration and updates app's work minutes
- [ ] **Strip — session start**: section 1 shows live countdown, sections 2–4 show dim rings
- [ ] **Strip — after cycle 1**: section 1 becomes tomato, section 2 shows active phase
- [ ] **Strip — after 4 cycles**: all sections show tomatoes during long break
- [ ] **Strip — session stopped**: returns to idle view (work duration + "press to start")

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU