### PR TITLE
fix(stream-deck): Focus setup screen, slot logic, and tomato position

### DIFF
--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -1,5 +1,6 @@
 import {
   action,
+  DialDownEvent,
   DialRotateEvent,
   DialUpEvent,
   KeyDownEvent,
@@ -9,7 +10,7 @@ import {
   WillDisappearEvent,
 } from "@elgato/streamdeck";
 import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_FOCUS_SET_DURATION } from "../client";
-import { renderKey, renderStrip, renderFocusSlot, renderFocusSlotKey } from "../render";
+import { renderKey, renderFocusSlot, renderFocusSlotKey, renderFocusSetupSlot } from "../render";
 
 @action({ UUID: "app.dayglance.streamdeck.focus" })
 export class FocusAction extends SingletonAction {
@@ -20,13 +21,15 @@ export class FocusAction extends SingletonAction {
   private encoderRefs = new Set<any>();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private slotIndexMap = new Map<any, number>();
+  private adjusting: "work" | "break" = "work";
+  private dialPressedAt: number | null = null;
+  private readonly LONG_PRESS_MS = 400;
 
   override async onWillAppear(ev: WillAppearEvent): Promise<void> {
     this.visibleCount++;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if ((ev.payload as any).controller === "Encoder") {
       this.encoderRefs.add(ev.action);
-      // Column position (0–3) determines which Pomodoro cycle this slot represents
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const col: number = (ev.payload as any).coordinates?.column ?? 0;
       this.slotIndexMap.set(ev.action, col % 4);
@@ -50,68 +53,62 @@ export class FocusAction extends SingletonAction {
     }
   }
 
-  override async onDialRotate(ev: DialRotateEvent): Promise<void> {
-    if (!this.lastState) return;
-    const { active, phase, workMinutes, breakMinutes } = this.lastState.focus;
-
-    if (!active) {
-      // Before session: adjust work duration
-      const newWork = Math.max(1, Math.min(120, workMinutes + ev.payload.ticks));
-      send({ type: MSG_DAY_FOCUS_SET_DURATION, workMinutes: newWork });
-      await this.renderPreview(`${newWork}m`, "work session", "#f97316");
-    } else if (phase === "work") {
-      // During work: adjust upcoming break duration
-      const newBreak = Math.max(1, Math.min(60, breakMinutes + ev.payload.ticks));
-      send({ type: MSG_DAY_FOCUS_SET_DURATION, breakMinutes: newBreak });
-      await this.renderPreview(`${newBreak}m`, "next break", "#22c55e");
-    } else {
-      // During break: adjust work duration for next session
-      const newWork = Math.max(1, Math.min(120, workMinutes + ev.payload.ticks));
-      send({ type: MSG_DAY_FOCUS_SET_DURATION, workMinutes: newWork });
-      await this.renderPreview(`${newWork}m`, "next session", "#f97316");
-    }
+  override async onDialDown(_ev: DialDownEvent): Promise<void> {
+    this.dialPressedAt = Date.now();
   }
 
   override async onDialUp(_ev: DialUpEvent): Promise<void> {
-    this.toggle();
+    const held = this.dialPressedAt !== null && (Date.now() - this.dialPressedAt) >= this.LONG_PRESS_MS;
+    this.dialPressedAt = null;
+
+    const { active, available } = this.lastState?.focus ?? { active: false, available: false };
+    if (active) {
+      // Any knob press during a session: advance to next phase
+      send({ type: MSG_DAY_FOCUS_SKIP });
+    } else if (held) {
+      // Long press when idle: toggle which duration the dial adjusts
+      this.adjusting = this.adjusting === "work" ? "break" : "work";
+      if (this.lastState) await this.renderAll(this.lastState);
+    } else if (available) {
+      // Short press when idle: start session
+      send({ type: MSG_DAY_FOCUS_START });
+    }
+  }
+
+  override async onDialRotate(ev: DialRotateEvent): Promise<void> {
+    if (!this.lastState) return;
+    const { active, workMinutes, breakMinutes } = this.lastState.focus;
+    if (active) return; // dial does nothing during a session
+
+    if (this.adjusting === "work") {
+      const newWork = Math.max(1, Math.min(120, workMinutes + ev.payload.ticks));
+      send({ type: MSG_DAY_FOCUS_SET_DURATION, workMinutes: newWork });
+    } else {
+      const newBreak = Math.max(1, Math.min(60, breakMinutes + ev.payload.ticks));
+      send({ type: MSG_DAY_FOCUS_SET_DURATION, breakMinutes: newBreak });
+    }
+    // State subscription will re-render once the app echoes the update back
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
-    this.toggle();
-  }
-
-  override async onTouchTap(ev: TouchTapEvent): Promise<void> {
-    if (ev.payload.hold) {
-      this.toggle();
-      return;
-    }
-    // Tap: skip phase if active, start if not
-    if (this.lastState?.focus.active) {
-      send({ type: MSG_DAY_FOCUS_SKIP });
-    } else {
-      this.toggle();
-    }
-  }
-
-  private toggle(): void {
-    const { available, active } = this.lastState?.focus ?? { available: false, active: false };
+    const { active, available } = this.lastState?.focus ?? { active: false, available: false };
     if (active) {
-      send({ type: MSG_DAY_FOCUS_STOP });
+      send({ type: MSG_DAY_FOCUS_SKIP });
     } else if (available) {
       send({ type: MSG_DAY_FOCUS_START });
     }
   }
 
-  private async renderPreview(value: string, sub: string, barColor: string): Promise<void> {
-    const opts = { value, sub, barColor };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    for (const act of this.actions as unknown as any[]) {
-      await act.setImage(renderKey(opts));
-      if (this.encoderRefs.has(act)) {
-        await act.setFeedback({ canvas: renderStrip(opts) });
-      } else {
-        await act.setTitle("");
-      }
+  override async onTouchTap(ev: TouchTapEvent): Promise<void> {
+    if (ev.payload.hold) {
+      if (this.lastState?.focus.active) send({ type: MSG_DAY_FOCUS_STOP });
+      return;
+    }
+    const { active, available } = this.lastState?.focus ?? { active: false, available: false };
+    if (active) {
+      send({ type: MSG_DAY_FOCUS_SKIP });
+    } else if (available) {
+      send({ type: MSG_DAY_FOCUS_START });
     }
   }
 
@@ -124,7 +121,7 @@ export class FocusAction extends SingletonAction {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async renderOne(act: any, state: DayGlanceState): Promise<void> {
     const isEncoder = this.encoderRefs.has(act);
-    const { available, active, phase, secondsRemaining, running, workMinutes, cycleCount } = state.focus;
+    const { available, active, phase, secondsRemaining, running, workMinutes, breakMinutes, cycleCount } = state.focus;
     const cycles = cycleCount ?? 0;
 
     if (isEncoder) {
@@ -133,34 +130,29 @@ export class FocusAction extends SingletonAction {
         await act.setImage(renderFocusSlotKey(slotIndex, phase, secondsRemaining, cycles));
         await act.setFeedback({ canvas: renderFocusSlot(slotIndex, phase, secondsRemaining, cycles) });
       } else {
-        // Idle: slot 0 shows work duration hint; other slots show their pending number
-        const idleOpts = slotIndex === 0
-          ? { value: `${workMinutes}m`, sub: available ? "press to start" : "unavailable", dim: !available, barColor: "#f97316" }
-          : { value: `${slotIndex + 1}`, sub: `cycle ${slotIndex + 1}`, dim: true, barColor: "#f97316" };
-        await act.setImage(renderKey(idleOpts));
-        await act.setFeedback({ canvas: renderStrip(idleOpts) });
+        // Setup screen: slots 0+1 show work/break durations; slots 2-3 show pending rings
+        const barColor = this.adjusting === "work" ? "#f97316" : "#22c55e";
+        const value = this.adjusting === "work" ? `${workMinutes}m` : `${breakMinutes}m`;
+        const sub = this.adjusting === "work" ? "work" : "break";
+        await act.setImage(renderKey({ value, sub, dim: !available, barColor }));
+        await act.setFeedback({ canvas: renderFocusSetupSlot(slotIndex, workMinutes, breakMinutes, this.adjusting) });
       }
       return;
     }
 
-    // Non-encoder key button — standard start/stop view
-    let renderOpts: Parameters<typeof renderKey>[0];
+    // Non-encoder key button
     if (!active) {
-      renderOpts = {
-        value: `${workMinutes}m`,
-        sub: available ? "press to start" : "unavailable",
-        dim: !available,
-        barColor: "#f97316",
-      };
+      const barColor = this.adjusting === "work" ? "#f97316" : "#22c55e";
+      const value = this.adjusting === "work" ? `${workMinutes}m` : `${breakMinutes}m`;
+      await act.setImage(renderKey({ value, sub: available ? "press to start" : "unavailable", dim: !available, barColor }));
     } else {
       const m = Math.floor(secondsRemaining / 60);
       const s = secondsRemaining % 60;
       const time = `${m}:${s.toString().padStart(2, "0")}`;
       const sub = running ? (phase === "work" ? "work" : "break") : "paused";
       const barColor = phase === "work" ? "#f97316" : "#22c55e";
-      renderOpts = { value: time, sub, barColor };
+      await act.setImage(renderKey({ value: time, sub, barColor }));
     }
-    await act.setImage(renderKey(renderOpts));
     await act.setTitle("");
   }
 }

--- a/stream-deck-plugin/src/render.ts
+++ b/stream-deck-plugin/src/render.ts
@@ -75,7 +75,7 @@ function fontSize(text: string): number {
 }
 
 // ── Pomodoro per-slot rendering ───────────────────────────────────────────
-// Each encoder slot (column 0–3) represents one Pomodoro work cycle.
+// Each encoder slot (column 0–3) represents one Pomodoro work+break cycle.
 // Place the Focus action on all 4 encoder slots; each auto-detects its index.
 
 function focusSlotState(
@@ -84,10 +84,18 @@ function focusSlotState(
   cycleCount: number,
 ): "completed" | "activeWork" | "activeBreak" | "pending" {
   const completedInSet = cycleCount % 4;
-  const allDone = cycleCount > 0 && completedInSet === 0 && phase === "longBreak";
-  if (allDone || slotIndex < completedInSet) return "completed";
-  if (slotIndex === completedInSet && phase === "work") return "activeWork";
-  if (slotIndex === completedInSet && (phase === "shortBreak" || phase === "longBreak")) return "activeBreak";
+
+  if (phase === "work") {
+    if (slotIndex < completedInSet) return "completed";
+    if (slotIndex === completedInSet) return "activeWork";
+    return "pending";
+  }
+
+  // Break phase: cycleCount already incremented after work finished.
+  // The break belongs to the cycle whose work just ended (one slot back).
+  const breakSlot = completedInSet === 0 ? 3 : completedInSet - 1;
+  if (slotIndex < breakSlot) return "completed";
+  if (slotIndex === breakSlot) return "activeBreak";
   return "pending";
 }
 
@@ -108,9 +116,9 @@ export function renderFocusSlot(
   let body: string;
   if (state === "completed") {
     body = `<rect width="${SW}" height="${SH}" fill="#180a0a"/>
-  <circle cx="${cx}" cy="60" r="34" fill="#dc2626"/>
-  <rect x="${cx - 3}" y="22" width="5" height="14" fill="#16a34a" rx="2"/>
-  <path d="M${cx - 3} 33 Q${cx - 14} 21 ${cx - 8} 15 Q${cx - 1} 28 ${cx - 3} 33Z" fill="#16a34a"/>`;
+  <circle cx="${cx}" cy="48" r="30" fill="#dc2626"/>
+  <rect x="${cx - 3}" y="14" width="5" height="12" fill="#16a34a" rx="2"/>
+  <path d="M${cx - 3} 23 Q${cx - 14} 12 ${cx - 8} 7 Q${cx - 1} 19 ${cx - 3} 23Z" fill="#16a34a"/>`;
   } else if (state === "activeWork") {
     body = `<rect width="${SW}" height="${SH}" fill="#1c0e00"/>
   <rect width="${SW}" height="5" fill="#f97316"/>
@@ -170,6 +178,52 @@ export function renderFocusSlotKey(
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}">
   <rect width="${W}" height="${H}" fill="${bg}"/>
   ${header}
+  ${body}
+</svg>`;
+  return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
+}
+
+// ── Focus setup-screen rendering ──────────────────────────────────────────
+// Shown on encoder slots when no session is active.
+// Slot 0 = work duration, slot 1 = break duration, slots 2–3 = pending rings.
+
+/** 200×100 touch strip for the pre-session setup state. */
+export function renderFocusSetupSlot(
+  slotIndex: number,
+  workMinutes: number,
+  breakMinutes: number,
+  adjusting: "work" | "break",
+): string {
+  const cx = SW / 2;
+  let body: string;
+
+  if (slotIndex === 0) {
+    const sel = adjusting === "work";
+    body = sel
+      ? `<rect width="${SW}" height="${SH}" fill="#1c0e00"/>
+  <rect width="${SW}" height="5" fill="#f97316"/>
+  <text x="${cx}" y="52" font-family="${FONT}" font-size="38" fill="white" fill-opacity="0.95" text-anchor="middle" font-weight="700">${workMinutes}m</text>
+  <text x="${cx}" y="76" font-family="${FONT}" font-size="13" fill="#f97316" fill-opacity="0.85" text-anchor="middle">WORK</text>`
+      : `<rect width="${SW}" height="${SH}" fill="#0d0d0d"/>
+  <text x="${cx}" y="52" font-family="${FONT}" font-size="38" fill="white" fill-opacity="0.2" text-anchor="middle" font-weight="700">${workMinutes}m</text>
+  <text x="${cx}" y="76" font-family="${FONT}" font-size="13" fill="white" fill-opacity="0.16" text-anchor="middle">work</text>`;
+  } else if (slotIndex === 1) {
+    const sel = adjusting === "break";
+    body = sel
+      ? `<rect width="${SW}" height="${SH}" fill="#0a180c"/>
+  <rect width="${SW}" height="5" fill="#22c55e"/>
+  <text x="${cx}" y="52" font-family="${FONT}" font-size="38" fill="white" fill-opacity="0.95" text-anchor="middle" font-weight="700">${breakMinutes}m</text>
+  <text x="${cx}" y="76" font-family="${FONT}" font-size="13" fill="#22c55e" fill-opacity="0.85" text-anchor="middle">BREAK</text>`
+      : `<rect width="${SW}" height="${SH}" fill="#0d0d0d"/>
+  <text x="${cx}" y="52" font-family="${FONT}" font-size="38" fill="white" fill-opacity="0.2" text-anchor="middle" font-weight="700">${breakMinutes}m</text>
+  <text x="${cx}" y="76" font-family="${FONT}" font-size="13" fill="white" fill-opacity="0.16" text-anchor="middle">break</text>`;
+  } else {
+    body = `<rect width="${SW}" height="${SH}" fill="#111"/>
+  <circle cx="${cx}" cy="52" r="28" fill="none" stroke="#2a2a2a" stroke-width="2"/>
+  <text x="${cx}" y="62" font-family="${FONT}" font-size="30" fill="#2a2a2a" text-anchor="middle" font-weight="700">${slotIndex + 1}</text>`;
+  }
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${SW}" height="${SH}">
   ${body}
 </svg>`;
   return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");


### PR DESCRIPTION
## Summary

Three fixes to the Focus encoder slots:

### 1. Setup screen (idle state)
Slots now show a proper duration-edit screen when no session is active:

| Slot | Idle display |
|---|---|
| 0 | Work duration — orange bg + "WORK" label when selected, dim when not |
| 1 | Break duration — green bg + "BREAK" label when selected, dim when not |
| 2–3 | Pending rings (unchanged) |

**Dial behaviour when idle:**
- Rotate → adjusts the currently selected duration (work or break)
- Long-press knob → toggles selection between WORK and BREAK
- Short-press knob → starts session
- Touch tap → starts session; touch hold → stops session (when active)

**During session:** dial does nothing. Knob press / key press / touch tap all advance to the next phase (skip).

### 2. Break shown in correct slot

`cycleCount` increments when a work phase completes, so during the subsequent break `completedInSet` is already one ahead. Fixed by computing `breakSlot = completedInSet - 1` so the break countdown stays in the same slot as the work that just finished, not the next one.

Before: completing cycle 1 work → break appeared in slot 2 ❌  
After: completing cycle 1 work → break stays in slot 1 ✓

### 3. Tomato centred in strip

Moved circle from `cy=60` to `cy=48` so the tomato sits centred in the 100px strip instead of being clipped at the bottom.

## Test plan

- [ ] Rebuild + reinstall plugin
- [ ] Idle: slot 1 shows orange "25m / WORK", slots 2–4 show pending rings
- [ ] Rotate dial → work duration changes in real time
- [ ] Long-press knob → slot 2 lights up green "5m / BREAK", slot 1 dims
- [ ] Rotate dial → break duration changes
- [ ] Short-press knob → session starts
- [ ] Cycle 1 work finishes → countdown stays in slot 1 (shows break), slot 1 not yet a tomato
- [ ] Cycle 1 break finishes → slot 1 becomes tomato, slot 2 shows work countdown
- [ ] Tomato is visually centred (not clipped at bottom)
- [ ] Touch strip hold stops the session

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_