### PR TITLE
feat(stream-deck): Focus 3-state flow — idle / setup screen / session

### DIFF
--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -9,9 +9,10 @@ export const PROTOCOL_VERSION = 1 as const;
 export const MSG_DAY_STATE = 'day:state' as const;
 
 // ── Inbound command type constants (clients → server) ────────────────────
-export const MSG_DAY_FOCUS_START      = 'day:focus:start'      as const;
-export const MSG_DAY_FOCUS_STOP       = 'day:focus:stop'       as const;
-export const MSG_DAY_FOCUS_SKIP       = 'day:focus:skip'       as const;
+export const MSG_DAY_FOCUS_START        = 'day:focus:start'        as const;
+export const MSG_DAY_FOCUS_TIMER_START  = 'day:focus:timer-start'  as const;
+export const MSG_DAY_FOCUS_STOP         = 'day:focus:stop'         as const;
+export const MSG_DAY_FOCUS_SKIP         = 'day:focus:skip'         as const;
 export const MSG_DAY_FOCUS_SET_DURATION = 'day:focus:set-duration' as const;
 export const MSG_DAY_TASK_COMPLETE    = 'day:task:complete'    as const;
 export const MSG_DAY_HABIT_INCREMENT  = 'day:habit:increment'  as const;
@@ -33,12 +34,13 @@ export type Task = {
 export type FocusState = {
   available: boolean;
   active: boolean;
+  setup: boolean;       // true while the settings screen is open (before timer starts)
   phase: string;
   secondsRemaining: number;
   running: boolean;
   workMinutes: number;
   breakMinutes: number;
-  cycleCount: number;  // total completed work cycles since session start
+  cycleCount: number;   // total completed work cycles since session start
 };
 
 export type Habit = {
@@ -98,6 +100,7 @@ export type OutboundMessage = {
 // ── Inbound commands (clients → server) ──────────────────────────────────
 export type InboundCommand =
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_START }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_TIMER_START }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_STOP }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_SKIP }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_SET_DURATION; workMinutes?: number; breakMinutes?: number }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2263,6 +2263,7 @@ const DayPlanner = () => {
   }, [aiConfig]);
 
   const enterFocusModeRef = useRef(null);
+  const startFocusTimerRef = useRef(null);
   const openRoutinesDashboardRef = useRef(null);
 
   const { longPressTriggeredRef, longPressTimerRef } = useMobileInteractions({
@@ -2899,6 +2900,7 @@ const DayPlanner = () => {
     nativeEnterFocusMode();
   };
   enterFocusModeRef.current = enterFocusMode;
+  startFocusTimerRef.current = startFocusTimer;
   openRoutinesDashboardRef.current = openRoutinesDashboard;
 
   const startFocusTimer = () => {
@@ -6135,8 +6137,10 @@ const DayPlanner = () => {
     focusCycleCount,
     focusWorkMinutes,
     focusBreakMinutes,
+    focusShowSettings,
     enterFocusModeRef,
     exitFocusModeRef,
+    startFocusTimerRef,
     skipFocusPhase,
     setFocusWorkMinutes,
     setFocusBreakMinutes,

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -7,6 +7,7 @@ import {
   PROTOCOL_VERSION,
   MSG_DAY_STATE,
   MSG_DAY_FOCUS_START,
+  MSG_DAY_FOCUS_TIMER_START,
   MSG_DAY_FOCUS_STOP,
   MSG_DAY_FOCUS_SKIP,
   MSG_DAY_FOCUS_SET_DURATION,
@@ -55,8 +56,10 @@ export default function useElectronBridge({
   focusCycleCount,
   focusWorkMinutes,
   focusBreakMinutes,
+  focusShowSettings,
   enterFocusModeRef,
   exitFocusModeRef,
+  startFocusTimerRef,
   skipFocusPhase,
   setFocusWorkMinutes,
   setFocusBreakMinutes,
@@ -99,6 +102,9 @@ export default function useElectronBridge({
       switch (cmd.type) {
         case MSG_DAY_FOCUS_START:
           enterFocusModeRef.current?.();
+          break;
+        case MSG_DAY_FOCUS_TIMER_START:
+          startFocusTimerRef.current?.();
           break;
         case MSG_DAY_FOCUS_STOP:
           exitFocusModeRef.current?.();
@@ -239,6 +245,7 @@ export default function useElectronBridge({
       focus: {
         available: focusModeAvailable,
         active: showFocusMode,
+        setup: !!focusShowSettings,
         phase: focusPhase,
         secondsRemaining: focusTimerSeconds,
         running: focusTimerRunning,
@@ -259,7 +266,7 @@ export default function useElectronBridge({
     });
   }, [
     todayAgenda, currentTime, tasks, expandedRecurringTasks, todayHGSessions, focusModeAvailable,
-    showFocusMode, focusPhase, focusTimerSeconds, focusTimerRunning,
+    showFocusMode, focusShowSettings, focusPhase, focusTimerSeconds, focusTimerRunning,
     focusCycleCount, focusWorkMinutes, focusBreakMinutes,
     activeHabits, getTodayHabitCount, habitsEnabled,
     todayRoutines, routineCompletions, use24HourClock,

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -9,8 +9,17 @@ import {
   WillAppearEvent,
   WillDisappearEvent,
 } from "@elgato/streamdeck";
-import { DayGlanceState, onState, send, MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_FOCUS_SET_DURATION } from "../client";
+import {
+  DayGlanceState, onState, send,
+  MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_TIMER_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP,
+  MSG_DAY_FOCUS_SET_DURATION,
+} from "../client";
 import { renderKey, renderFocusSlot, renderFocusSlotKey, renderFocusSetupSlot } from "../render";
+
+// Three operating modes for the Focus encoder:
+//   idle   — panel closed (active=false)
+//   setup  — panel open, settings screen showing (active=true, setup=true)
+//   session — timer running or paused (active=true, setup=false)
 
 @action({ UUID: "app.dayglance.streamdeck.focus" })
 export class FocusAction extends SingletonAction {
@@ -61,24 +70,32 @@ export class FocusAction extends SingletonAction {
     const held = this.dialPressedAt !== null && (Date.now() - this.dialPressedAt) >= this.LONG_PRESS_MS;
     this.dialPressedAt = null;
 
-    const { active, available } = this.lastState?.focus ?? { active: false, available: false };
-    if (active) {
-      // Any knob press during a session: advance to next phase
-      send({ type: MSG_DAY_FOCUS_SKIP });
-    } else if (held) {
-      // Long press when idle: toggle which duration the dial adjusts
-      this.adjusting = this.adjusting === "work" ? "break" : "work";
-      if (this.lastState) await this.renderAll(this.lastState);
-    } else if (available) {
-      // Short press when idle: start session
+    const focus = this.lastState?.focus;
+    if (!focus) return;
+
+    if (!focus.active) {
+      // Idle: open the session start screen in the app
       send({ type: MSG_DAY_FOCUS_START });
+    } else if (focus.setup) {
+      if (held) {
+        // Long press on setup screen: toggle work/break dial selection
+        this.adjusting = this.adjusting === "work" ? "break" : "work";
+        if (this.lastState) await this.renderAll(this.lastState);
+      } else {
+        // Short press on setup screen: start the timer
+        send({ type: MSG_DAY_FOCUS_TIMER_START });
+      }
+    } else {
+      // Session in progress: advance to next phase
+      send({ type: MSG_DAY_FOCUS_SKIP });
     }
   }
 
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {
     if (!this.lastState) return;
-    const { active, workMinutes, breakMinutes } = this.lastState.focus;
-    if (active) return; // dial does nothing during a session
+    const { active, setup, workMinutes, breakMinutes } = this.lastState.focus;
+    // Dial only adjusts durations while the setup screen is showing
+    if (!active || !setup) return;
 
     if (this.adjusting === "work") {
       const newWork = Math.max(1, Math.min(120, workMinutes + ev.payload.ticks));
@@ -87,15 +104,17 @@ export class FocusAction extends SingletonAction {
       const newBreak = Math.max(1, Math.min(60, breakMinutes + ev.payload.ticks));
       send({ type: MSG_DAY_FOCUS_SET_DURATION, breakMinutes: newBreak });
     }
-    // State subscription will re-render once the app echoes the update back
   }
 
   override async onKeyDown(_ev: KeyDownEvent): Promise<void> {
-    const { active, available } = this.lastState?.focus ?? { active: false, available: false };
-    if (active) {
-      send({ type: MSG_DAY_FOCUS_SKIP });
-    } else if (available) {
+    const focus = this.lastState?.focus;
+    if (!focus) return;
+    if (!focus.active) {
       send({ type: MSG_DAY_FOCUS_START });
+    } else if (focus.setup) {
+      send({ type: MSG_DAY_FOCUS_TIMER_START });
+    } else {
+      send({ type: MSG_DAY_FOCUS_SKIP });
     }
   }
 
@@ -104,11 +123,14 @@ export class FocusAction extends SingletonAction {
       if (this.lastState?.focus.active) send({ type: MSG_DAY_FOCUS_STOP });
       return;
     }
-    const { active, available } = this.lastState?.focus ?? { active: false, available: false };
-    if (active) {
-      send({ type: MSG_DAY_FOCUS_SKIP });
-    } else if (available) {
+    const focus = this.lastState?.focus;
+    if (!focus) return;
+    if (!focus.active) {
       send({ type: MSG_DAY_FOCUS_START });
+    } else if (focus.setup) {
+      send({ type: MSG_DAY_FOCUS_TIMER_START });
+    } else {
+      send({ type: MSG_DAY_FOCUS_SKIP });
     }
   }
 
@@ -121,30 +143,41 @@ export class FocusAction extends SingletonAction {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async renderOne(act: any, state: DayGlanceState): Promise<void> {
     const isEncoder = this.encoderRefs.has(act);
-    const { available, active, phase, secondsRemaining, running, workMinutes, breakMinutes, cycleCount } = state.focus;
+    const { available, active, setup, phase, secondsRemaining, running, workMinutes, breakMinutes, cycleCount } = state.focus;
     const cycles = cycleCount ?? 0;
 
     if (isEncoder) {
       const slotIndex = this.slotIndexMap.get(act) ?? 0;
-      if (active) {
-        await act.setImage(renderFocusSlotKey(slotIndex, phase, secondsRemaining, cycles));
-        await act.setFeedback({ canvas: renderFocusSlot(slotIndex, phase, secondsRemaining, cycles) });
-      } else {
-        // Setup screen: slots 0+1 show work/break durations; slots 2-3 show pending rings
+
+      if (!active) {
+        // Idle: slot 0 = standard Focus display; slots 1-3 = pending rings
+        const idleKeyOpts = slotIndex === 0
+          ? { value: "Focus", sub: available ? "press to start" : "unavailable", dim: !available, barColor: "#f97316" }
+          : { value: `${slotIndex + 1}`, sub: `cycle ${slotIndex + 1}`, dim: true, barColor: "#f97316" };
+        await act.setImage(renderKey(idleKeyOpts));
+        await act.setFeedback({ canvas: renderFocusSetupSlot(slotIndex, workMinutes, breakMinutes, this.adjusting) });
+      } else if (setup) {
+        // Setup screen open: slots 0+1 show work/break; slots 2-3 show pending
         const barColor = this.adjusting === "work" ? "#f97316" : "#22c55e";
         const value = this.adjusting === "work" ? `${workMinutes}m` : `${breakMinutes}m`;
         const sub = this.adjusting === "work" ? "work" : "break";
-        await act.setImage(renderKey({ value, sub, dim: !available, barColor }));
+        await act.setImage(renderKey({ value, sub, barColor }));
         await act.setFeedback({ canvas: renderFocusSetupSlot(slotIndex, workMinutes, breakMinutes, this.adjusting) });
+      } else {
+        // Session active: per-slot Pomodoro view
+        await act.setImage(renderFocusSlotKey(slotIndex, phase, secondsRemaining, cycles));
+        await act.setFeedback({ canvas: renderFocusSlot(slotIndex, phase, secondsRemaining, cycles) });
       }
       return;
     }
 
     // Non-encoder key button
     if (!active) {
+      await act.setImage(renderKey({ value: "Focus", sub: available ? "press to start" : "unavailable", dim: !available, barColor: "#f97316" }));
+    } else if (setup) {
       const barColor = this.adjusting === "work" ? "#f97316" : "#22c55e";
       const value = this.adjusting === "work" ? `${workMinutes}m` : `${breakMinutes}m`;
-      await act.setImage(renderKey({ value, sub: available ? "press to start" : "unavailable", dim: !available, barColor }));
+      await act.setImage(renderKey({ value, sub: "press to start", barColor }));
     } else {
       const m = Math.floor(secondsRemaining / 60);
       const s = secondsRemaining % 60;

--- a/stream-deck-plugin/src/client.ts
+++ b/stream-deck-plugin/src/client.ts
@@ -3,6 +3,7 @@ import {
   PROTOCOL_VERSION,
   MSG_DAY_STATE,
   MSG_DAY_FOCUS_START,
+  MSG_DAY_FOCUS_TIMER_START,
   MSG_DAY_FOCUS_STOP,
   MSG_DAY_FOCUS_SKIP,
   MSG_DAY_FOCUS_SET_DURATION,
@@ -15,11 +16,12 @@ import {
 
 // Re-export everything action files need — keeps their imports pointing at ../client only
 export type { DayGlanceState, Task, FocusState } from "../../electron/protocol";
-export { MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_FOCUS_SET_DURATION, MSG_DAY_TASK_COMPLETE, MSG_DAY_HABIT_INCREMENT, MSG_DAY_ROUTINE_COMPLETE } from "../../electron/protocol";
+export { MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_TIMER_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_FOCUS_SET_DURATION, MSG_DAY_TASK_COMPLETE, MSG_DAY_HABIT_INCREMENT, MSG_DAY_ROUTINE_COMPLETE } from "../../electron/protocol";
 
 // CommandPayload is the caller-facing API — send() stamps v internally
 type CommandPayload =
   | { type: typeof MSG_DAY_FOCUS_START }
+  | { type: typeof MSG_DAY_FOCUS_TIMER_START }
   | { type: typeof MSG_DAY_FOCUS_STOP }
   | { type: typeof MSG_DAY_FOCUS_SKIP }
   | { type: typeof MSG_DAY_FOCUS_SET_DURATION; workMinutes?: number; breakMinutes?: number }


### PR DESCRIPTION
## Summary

Implements the correct 3-state dial flow for the Focus encoder, plus fixes the break slot position and tomato centering.

### Three states

**Idle** (`active=false`) — panel not open:
- Slot 0: "Focus / press to start" (or "unavailable")
- Slots 1–3: dim pending rings with cycle number
- Any press → opens the session start screen in the app

**Setup** (`active=true, setup=true`) — session start screen open, timer not started:
- Slot 0: work duration (orange highlight when selected)
- Slot 1: break duration (green highlight when selected)
- Slots 2–3: pending rings
- Rotate dial → adjusts selected duration (live in app + on deck)
- Long-press knob → toggles dial between WORK and BREAK
- Short-press knob / touch tap → starts timer (`MSG_DAY_FOCUS_TIMER_START`)
- Touch hold → closes the panel

**Session** (`active=true, setup=false`) — timer running or paused:
- 4-slot Pomodoro view; each slot shows its cycle state
- Dial does nothing
- Knob press / key / touch tap → advance to next phase (skip)

### Bug fixes
- **Break in correct slot**: break now stays in the same slot as the work cycle that just finished (cycleCount already incremented, so break belongs to `completedInSet - 1`)
- **Tomato centred**: moved from `cy=60` to `cy=48`, no longer clipped at the bottom of the strip

### Protocol additions
- `MSG_DAY_FOCUS_TIMER_START` — new command, calls `startFocusTimer()` in the app
- `FocusState.setup: boolean` — true while `focusShowSettings` is active (settings screen showing before timer starts)

### App wiring
- `startFocusTimerRef` added to App.jsx, assigned from `startFocusTimer`, passed to bridge
- `focusShowSettings` passed to bridge and pushed in state snapshot as `focus.setup`

## Test plan

- [ ] Rebuild + reinstall plugin; re-open app
- [ ] **Idle**: slot 1 = "Focus / press to start", slots 2–4 = dim rings
- [ ] Press knob → session start screen opens in app
- [ ] **Setup**: slot 1 = orange "25m / WORK", slot 2 = dim "5m / break", slots 3–4 = pending
- [ ] Rotate dial → work minutes change in app and on deck
- [ ] Long-press knob → slot 1 dims, slot 2 lights up green "5m / BREAK"
- [ ] Rotate dial → break minutes change
- [ ] Short-press knob → timer starts, deck switches to 4-slot Pomodoro view
- [ ] Cycle 1 work finishes → slot 1 shows break countdown (not slot 2)
- [ ] Cycle 1 break finishes → slot 1 becomes tomato (centred, not clipped)
- [ ] Touch hold → stops session at any point

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_