### PR TITLE
fix(app): move startFocusTimerRef assignment after const declaration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2900,7 +2900,6 @@ const DayPlanner = () => {
     nativeEnterFocusMode();
   };
   enterFocusModeRef.current = enterFocusMode;
-  startFocusTimerRef.current = startFocusTimer;
   openRoutinesDashboardRef.current = openRoutinesDashboard;
 
   const startFocusTimer = () => {
@@ -2914,6 +2913,7 @@ const DayPlanner = () => {
       setOnboardingProgress(prev => ({ ...prev, hasUsedFocusMode: true }));
     }
   };
+  startFocusTimerRef.current = startFocusTimer;
 
   const exitFocusMode = (showStats = true) => {
     setFocusTimerRunning(false);


### PR DESCRIPTION
## Summary

One-line fix for the crash introduced in #624.

`startFocusTimerRef.current = startFocusTimer` was placed *before* `const startFocusTimer = () => {…}`. `const` declarations are not hoisted, so accessing the variable before the line it's declared on throws `ReferenceError: Cannot access 'startFocusTimer' before initialization`, crashing the app on load.

Fix: moved the ref assignment to immediately after the `const startFocusTimer` definition.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_