### PR TITLE
fix(stream-deck): idle strip shows Focus/rings, not work/break durations

### DIFF
--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -14,7 +14,7 @@ import {
   MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_TIMER_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP,
   MSG_DAY_FOCUS_SET_DURATION,
 } from "../client";
-import { renderKey, renderFocusSlot, renderFocusSlotKey, renderFocusSetupSlot } from "../render";
+import { renderKey, renderStrip, renderFocusSlot, renderFocusSlotKey, renderFocusSetupSlot } from "../render";
 
 // Three operating modes for the Focus encoder:
 //   idle   — panel closed (active=false)
@@ -155,7 +155,11 @@ export class FocusAction extends SingletonAction {
           ? { value: "Focus", sub: available ? "press to start" : "unavailable", dim: !available, barColor: "#f97316" }
           : { value: `${slotIndex + 1}`, sub: `cycle ${slotIndex + 1}`, dim: true, barColor: "#f97316" };
         await act.setImage(renderKey(idleKeyOpts));
-        await act.setFeedback({ canvas: renderFocusSetupSlot(slotIndex, workMinutes, breakMinutes, this.adjusting) });
+        // Strip mirrors the key: slot 0 = Focus label, slots 1-3 = pending rings
+        const idleStrip = slotIndex === 0
+          ? renderStrip(idleKeyOpts)
+          : renderFocusSlot(slotIndex, "work", 0, 0);
+        await act.setFeedback({ canvas: idleStrip });
       } else if (setup) {
         // Setup screen open: slots 0+1 show work/break; slots 2-3 show pending
         const barColor = this.adjusting === "work" ? "#f97316" : "#22c55e";


### PR DESCRIPTION
## Summary

Corrects the idle touch strip for the Focus encoder slots. Work/break durations only matter once the session start screen is open in the app — showing them in the idle state was premature and confusing.

**Before:** idle strip showed "25m WORK" / "5m break" / pending rings  
**After:** idle strip matches the key buttons — slot 0 shows "Focus / press to start" (or "unavailable"), slots 1–3 show the same pending rings as the key images

The setup-screen strip (work/break duration adjustment) still appears correctly once the knob is pressed to open the session start screen.

## Test plan

- [ ] Rebuild + reinstall plugin
- [ ] Idle: slot 1 strip = "Focus / press to start", slots 2–4 strips = pending rings with numbers
- [ ] Press knob → session start screen opens in app; strip switches to work/break setup view
- [ ] Short-press knob → timer starts; strip switches to 4-slot Pomodoro view

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_