### PR TITLE
fix(stream-deck): long-press task complete updates focus session UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6148,6 +6148,7 @@ const DayPlanner = () => {
     setFocusLongBreakMinutes,
     setFocusWorkMinutes,
     setFocusBreakMinutes,
+    focusCompleteTask,
     toggleComplete,
     activeHabits,
     getTodayHabitCount,

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -67,6 +67,7 @@ export default function useElectronBridge({
   setFocusWorkMinutes,
   setFocusBreakMinutes,
   setFocusLongBreakMinutes,
+  focusCompleteTask,
   toggleComplete,
   // Habits
   activeHabits,
@@ -86,6 +87,7 @@ export default function useElectronBridge({
   goalsProjectsEnabled,
 }) {
   const skipFocusPhaseRef = useRef(skipFocusPhase);
+  const focusCompleteTaskRef = useRef(focusCompleteTask);
   const toggleCompleteRef = useRef(toggleComplete);
   const incrementHabitRef = useRef(incrementHabit);
   const toggleRoutineCompletionRef = useRef(toggleRoutineCompletion);
@@ -93,6 +95,7 @@ export default function useElectronBridge({
   const setFocusBreakMinutesRef = useRef(setFocusBreakMinutes);
   const setFocusLongBreakMinutesRef = useRef(setFocusLongBreakMinutes);
   skipFocusPhaseRef.current = skipFocusPhase;
+  focusCompleteTaskRef.current = focusCompleteTask;
   toggleCompleteRef.current = toggleComplete;
   incrementHabitRef.current = incrementHabit;
   toggleRoutineCompletionRef.current = toggleRoutineCompletion;
@@ -124,7 +127,7 @@ export default function useElectronBridge({
           if (cmd.longBreakMinutes !== undefined) setFocusLongBreakMinutesRef.current?.(Math.max(1, Math.min(60, cmd.longBreakMinutes)));
           break;
         case MSG_DAY_TASK_COMPLETE:
-          if (cmd.id) toggleCompleteRef.current?.(cmd.id);
+          if (cmd.id) focusCompleteTaskRef.current?.(cmd.id);
           break;
         case MSG_DAY_HABIT_INCREMENT:
           if (cmd.id) incrementHabitRef.current?.(cmd.id);

--- a/stream-deck-plugin/src/actions/habit.ts
+++ b/stream-deck-plugin/src/actions/habit.ts
@@ -76,7 +76,9 @@ export class HabitAction extends SingletonAction<Settings> {
       return;
     }
     const valueStr = `${habit.count}/${habit.target}`;
-    const sub = truncate(habit.name, 14);
+    const exceeded = habit.type === 'limit' && habit.count > habit.target;
+    const indicator = habit.complete ? "✓ " : exceeded ? "✗ " : "";
+    const sub = indicator + truncate(habit.name, exceeded || habit.complete ? 12 : 14);
     const barColor = habit.complete ? "#22c55e" : habit.ringColorHex;
     await action.setImage(renderKey({ value: valueStr, sub, barColor }));
     await action.setTitle("");

--- a/stream-deck-plugin/src/actions/routine.ts
+++ b/stream-deck-plugin/src/actions/routine.ts
@@ -48,7 +48,7 @@ export class RoutineAction extends SingletonAction {
   private async renderOne(act: any, state: DayGlanceState): Promise<void> {
     const routine = state.nextRoutine;
     if (!routine) {
-      await act.setImage(renderKey({ value: "✓", sub: "all done", barColor: "#22c55e" }));
+      await act.setImage(renderKey({ value: "✓", sub: "routines done", barColor: "#22c55e" }));
     } else {
       await act.setImage(renderKey({ value: truncate(routine.name, 14), sub: routine.startTime ?? "routine" }));
     }


### PR DESCRIPTION
## Summary

- `MSG_DAY_TASK_COMPLETE` was calling `toggleComplete`, which only marks the task done in the main task list
- The focus session modal tracks in-session completions separately via `focusCompletedTasks` (a `Set`)
- Switched to `focusCompleteTask`, which updates both — so the checkmark appears on the focus screen immediately and the all-done auto-exit fires correctly

## Test plan

- [ ] Start a focus session with at least one task in the focus block
- [ ] Long-press the encoder dial (~400ms) during a work phase
- [ ] Task shows as checked off on the focus session screen immediately
- [ ] If it was the last task, session exits automatically
- [ ] Short-press still skips to the next phase as before

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_