### PR TITLE
feat(stream-deck): hyperGLANCE action with per-slot scheduling and pulse

### DIFF
--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -15,6 +15,13 @@ export const MSG_DAY_FOCUS_STOP           = 'day:focus:stop'           as const;
 export const MSG_DAY_FOCUS_SKIP           = 'day:focus:skip'           as const;
 export const MSG_DAY_FOCUS_SET_DURATION   = 'day:focus:set-duration'   as const;
 export const MSG_DAY_FOCUS_DISMISS_STATS  = 'day:focus:dismiss-stats'  as const;
+export const MSG_DAY_HG_START             = 'day:hg:start'             as const;
+export const MSG_DAY_HG_TIMER_START       = 'day:hg:timer-start'       as const;
+export const MSG_DAY_HG_STOP              = 'day:hg:stop'              as const;
+export const MSG_DAY_HG_SKIP              = 'day:hg:skip'              as const;
+export const MSG_DAY_HG_SET_DURATION      = 'day:hg:set-duration'      as const;
+export const MSG_DAY_HG_COMPLETE          = 'day:hg:complete'          as const;
+export const MSG_DAY_HG_TASK_COMPLETE     = 'day:hg:task-complete'     as const;
 export const MSG_DAY_TASK_COMPLETE    = 'day:task:complete'    as const;
 export const MSG_DAY_HABIT_INCREMENT  = 'day:habit:increment'  as const;
 export const MSG_DAY_ROUTINE_COMPLETE = 'day:routine:complete' as const;
@@ -45,6 +52,36 @@ export type FocusState = {
   longBreakMinutes: number;
   cycleCount: number;      // total completed work cycles since session start
   nextFocusTask: { id: string; title: string } | null;  // first incomplete task in the focus block
+};
+
+export type HGScheduledSession = {
+  projectId: string;
+  title: string;
+  colorHex: string;
+  startTime: string;
+  reachable: boolean;
+  date: string;
+};
+
+export type HGActiveSession = {
+  projectId: string;
+  title: string;
+  colorHex: string;
+  setup: boolean;
+  completed: boolean;
+  phase: string;           // 'work' | 'shortBreak' | 'longBreak'
+  secondsRemaining: number;
+  running: boolean;
+  cycleCount: number;
+  workMinutes: number;
+  breakMinutes: number;
+  longBreakMinutes: number;
+  nextTask: { id: string; title: string } | null;
+};
+
+export type HGState = {
+  scheduled: HGScheduledSession[];  // today's sessions (up to 4), sorted by time
+  active: HGActiveSession | null;
 };
 
 export type Habit = {
@@ -88,6 +125,7 @@ export type DayGlanceState = {
   scheduledTasks: Task[];
   today: { total: number; completed: number; date: string };
   focus: FocusState;
+  hg: HGState;
   habits: Habit[];
   nextRoutine: Routine | null;
   use24Hour: boolean;
@@ -109,6 +147,13 @@ export type InboundCommand =
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_SKIP }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_SET_DURATION; workMinutes?: number; breakMinutes?: number; longBreakMinutes?: number }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_FOCUS_DISMISS_STATS }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_HG_START; projectId: string; date: string }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_HG_TIMER_START }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_HG_STOP }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_HG_SKIP }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_HG_SET_DURATION; workMinutes?: number; breakMinutes?: number; longBreakMinutes?: number }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_HG_COMPLETE }
+  | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_HG_TASK_COMPLETE; id: string }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_TASK_COMPLETE; id: string }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_HABIT_INCREMENT; id: string }
   | { v: typeof PROTOCOL_VERSION; type: typeof MSG_DAY_ROUTINE_COMPLETE; id: string };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,7 +68,7 @@ import useCloudSync from './hooks/useCloudSync.js';
 import useCalendarSync from './hooks/useCalendarSync.js';
 import useBackup from './hooks/useBackup.js';
 import useGTDFrames from './hooks/useGTDFrames.js';
-import { getGlanceHGInstances } from './hooks/useHyperGlance.js';
+import { getGlanceHGInstances, isHGSessionReachable } from './hooks/useHyperGlance.js';
 import useVoiceAI from './hooks/useVoiceAI.js';
 import useNavigation from './hooks/useNavigation.js';
 import useStats from './hooks/useStats.js';
@@ -622,6 +622,7 @@ const DayPlanner = () => {
   const [hgCycleCount, setHgCycleCount] = React.useState(0);
   const [hgExitConfirm, setHgExitConfirm] = React.useState(false);
   const [hgShowSettings, setHgShowSettings] = React.useState(true);
+  const [hgCompleted, setHgCompleted] = React.useState(false);
   const hgTimerRef = React.useRef(null);
 
   const {
@@ -3069,6 +3070,7 @@ const DayPlanner = () => {
     setHgCycleCount(0);
     setHgExitConfirm(false);
     setHgShowSettings(true);
+    setHgCompleted(false);
     setShowHyperGlanceMode(true);
     // Request fullscreen (web fallback; Android uses native immersive mode below)
     try { document.documentElement.requestFullscreen?.(); } catch (e) {}
@@ -3118,6 +3120,33 @@ const DayPlanner = () => {
     setHgExitConfirm(false);
     // Don't close the modal here — the modal handles showing the summary screen
     // and the user dismisses it via the "Done" button (exitHyperGlanceMode).
+  };
+
+  const startHyperGlanceTimer = () => {
+    setHgShowSettings(false);
+    setHgTimerSeconds(hgWorkMinutes * 60);
+    setHgTimerRunning(true);
+    setHgTimerPhase('work');
+    setHgCycleCount(0);
+  };
+
+  const skipHyperGlancePhase = () => {
+    setHgCycleCount(prev => {
+      const newCycle = hgTimerPhase === 'work' ? prev + 1 : prev;
+      if (hgTimerPhase === 'work') {
+        if (newCycle % 4 === 0) {
+          setHgTimerPhase('longBreak');
+          setHgTimerSeconds(hgLongBreakMinutes * 60);
+        } else {
+          setHgTimerPhase('shortBreak');
+          setHgTimerSeconds(hgBreakMinutes * 60);
+        }
+      } else {
+        setHgTimerPhase('work');
+        setHgTimerSeconds(hgWorkMinutes * 60);
+      }
+      return newCycle;
+    });
   };
 
   const openHGAdjust = (projectId, date) => {
@@ -6118,7 +6147,8 @@ const DayPlanner = () => {
         const hg = project.hyperglance;
         const effectiveTime = hg.scheduledTimeOverrides?.[instance.date] || hg.scheduledTime || '';
         const duration = hg.scheduledDurationOverrides?.[instance.date] || hg.scheduledDuration || 60;
-        return { id: project.id, title: project.title, colorHex: hg.color || '#4f46e5', startTime: effectiveTime, duration, isOverdue: instance.isOverdue, date: instance.date, isHGSession: true };
+        const reachable = isHGSessionReachable(instance, hg, currentTime);
+        return { id: project.id, title: project.title, colorHex: hg.color || '#4f46e5', startTime: effectiveTime, duration, isOverdue: instance.isOverdue, date: instance.date, reachable, isHGSession: true };
       })
       .filter(s => !s.isOverdue && s.date === todayStr && s.startTime);
   }, [goalsProjectsEnabled, projects, currentTime]);
@@ -6152,6 +6182,27 @@ const DayPlanner = () => {
     setFocusBreakMinutes,
     focusCompleteTask,
     toggleComplete,
+    // HyperGLANCE
+    showHyperGlanceMode,
+    hyperGlanceProjectId,
+    hyperGlanceSessionDate,
+    hgTimerSeconds,
+    hgTimerRunning,
+    hgTimerPhase,
+    hgWorkMinutes,
+    hgBreakMinutes,
+    hgLongBreakMinutes,
+    hgCycleCount,
+    hgShowSettings,
+    hgCompleted,
+    startHyperGlanceTimer,
+    skipHyperGlancePhase,
+    setHgWorkMinutes,
+    setHgBreakMinutes,
+    setHgLongBreakMinutes,
+    enterHyperGlanceMode,
+    exitHyperGlanceMode,
+    setHgCompleted,
     activeHabits,
     getTodayHabitCount,
     habitsEnabled,
@@ -7524,7 +7575,9 @@ const DayPlanner = () => {
     hgCycleCount, setHgCycleCount,
     hgExitConfirm, setHgExitConfirm,
     hgShowSettings, setHgShowSettings,
+    hgCompleted, setHgCompleted,
     enterHyperGlanceMode, exitHyperGlanceMode, completeHyperGlanceSession,
+    startHyperGlanceTimer, skipHyperGlancePhase,
     hgContextMenu, setHgContextMenu,
     hgAdjustModal, setHgAdjustModal,
     hgAdjustTimeField, setHgAdjustTimeField,

--- a/src/components/HyperGlanceModeModal.jsx
+++ b/src/components/HyperGlanceModeModal.jsx
@@ -36,6 +36,7 @@ const HyperGlanceModeModal = () => {
     hgCycleCount, setHgCycleCount,
     hgExitConfirm, setHgExitConfirm,
     hgShowSettings, setHgShowSettings,
+    hgCompleted, setHgCompleted,
     exitHyperGlanceMode,
     completeHyperGlanceSession,
     aiConfig,
@@ -47,7 +48,6 @@ const HyperGlanceModeModal = () => {
   const [sessionElapsed, setSessionElapsed] = useState(0);
   // Set of expanded task IDs (allows multiple open at once)
   const [expandedTaskIds, setExpandedTaskIds] = useState(new Set());
-  const [hgCompleted, setHgCompleted] = useState(false);
 
   const project = projects.find(p => p.id === hyperGlanceProjectId);
   const hg = project?.hyperglance;

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -15,6 +15,13 @@ import {
   MSG_DAY_HABIT_INCREMENT,
   MSG_DAY_ROUTINE_COMPLETE,
   MSG_DAY_FOCUS_DISMISS_STATS,
+  MSG_DAY_HG_START,
+  MSG_DAY_HG_TIMER_START,
+  MSG_DAY_HG_STOP,
+  MSG_DAY_HG_SKIP,
+  MSG_DAY_HG_SET_DURATION,
+  MSG_DAY_HG_COMPLETE,
+  MSG_DAY_HG_TASK_COMPLETE,
 } from '../../electron/protocol';
 
 const timeToMinutes = (time) => {
@@ -72,6 +79,27 @@ export default function useElectronBridge({
   setFocusLongBreakMinutes,
   focusCompleteTask,
   toggleComplete,
+  // HyperGLANCE
+  showHyperGlanceMode,
+  hyperGlanceProjectId,
+  hyperGlanceSessionDate,
+  hgTimerSeconds,
+  hgTimerRunning,
+  hgTimerPhase,
+  hgWorkMinutes,
+  hgBreakMinutes,
+  hgLongBreakMinutes,
+  hgCycleCount,
+  hgShowSettings,
+  hgCompleted,
+  startHyperGlanceTimer,
+  skipHyperGlancePhase,
+  setHgWorkMinutes,
+  setHgBreakMinutes,
+  setHgLongBreakMinutes,
+  enterHyperGlanceMode,
+  exitHyperGlanceMode,
+  setHgCompleted,
   // Habits
   activeHabits,
   getTodayHabitCount,
@@ -98,6 +126,14 @@ export default function useElectronBridge({
   const setFocusWorkMinutesRef = useRef(setFocusWorkMinutes);
   const setFocusBreakMinutesRef = useRef(setFocusBreakMinutes);
   const setFocusLongBreakMinutesRef = useRef(setFocusLongBreakMinutes);
+  const startHyperGlanceTimerRef = useRef(startHyperGlanceTimer);
+  const skipHyperGlancePhaseRef = useRef(skipHyperGlancePhase);
+  const enterHyperGlanceModeRef = useRef(enterHyperGlanceMode);
+  const exitHyperGlanceModeRef = useRef(exitHyperGlanceMode);
+  const setHgWorkMinutesRef = useRef(setHgWorkMinutes);
+  const setHgBreakMinutesRef = useRef(setHgBreakMinutes);
+  const setHgLongBreakMinutesRef = useRef(setHgLongBreakMinutes);
+  const setHgCompletedRef = useRef(setHgCompleted);
   skipFocusPhaseRef.current = skipFocusPhase;
   dismissFocusStatsRef.current = dismissFocusStats;
   focusCompleteTaskRef.current = focusCompleteTask;
@@ -107,6 +143,14 @@ export default function useElectronBridge({
   setFocusWorkMinutesRef.current = setFocusWorkMinutes;
   setFocusBreakMinutesRef.current = setFocusBreakMinutes;
   setFocusLongBreakMinutesRef.current = setFocusLongBreakMinutes;
+  startHyperGlanceTimerRef.current = startHyperGlanceTimer;
+  skipHyperGlancePhaseRef.current = skipHyperGlancePhase;
+  enterHyperGlanceModeRef.current = enterHyperGlanceMode;
+  exitHyperGlanceModeRef.current = exitHyperGlanceMode;
+  setHgWorkMinutesRef.current = setHgWorkMinutes;
+  setHgBreakMinutesRef.current = setHgBreakMinutes;
+  setHgLongBreakMinutesRef.current = setHgLongBreakMinutes;
+  setHgCompletedRef.current = setHgCompleted;
 
   // Subscribe to commands from WebSocket clients once on mount.
   useEffect(() => {
@@ -142,6 +186,30 @@ export default function useElectronBridge({
           break;
         case MSG_DAY_ROUTINE_COMPLETE:
           if (cmd.id) toggleRoutineCompletionRef.current?.(cmd.id);
+          break;
+        case MSG_DAY_HG_START:
+          if (cmd.projectId && cmd.date) enterHyperGlanceModeRef.current?.(cmd.projectId, cmd.date);
+          break;
+        case MSG_DAY_HG_TIMER_START:
+          startHyperGlanceTimerRef.current?.();
+          break;
+        case MSG_DAY_HG_STOP:
+          exitHyperGlanceModeRef.current?.();
+          break;
+        case MSG_DAY_HG_SKIP:
+          skipHyperGlancePhaseRef.current?.();
+          break;
+        case MSG_DAY_HG_SET_DURATION:
+          if (cmd.workMinutes !== undefined) setHgWorkMinutesRef.current?.(Math.max(1, Math.min(120, cmd.workMinutes)));
+          if (cmd.breakMinutes !== undefined) setHgBreakMinutesRef.current?.(Math.max(1, Math.min(60, cmd.breakMinutes)));
+          if (cmd.longBreakMinutes !== undefined) setHgLongBreakMinutesRef.current?.(Math.max(1, Math.min(60, cmd.longBreakMinutes)));
+          break;
+        case MSG_DAY_HG_COMPLETE:
+          setHgCompletedRef.current?.(true);
+          exitHyperGlanceModeRef.current?.();
+          break;
+        case MSG_DAY_HG_TASK_COMPLETE:
+          if (cmd.id) toggleCompleteRef.current?.(cmd.id);
           break;
       }
     });
@@ -287,12 +355,45 @@ export default function useElectronBridge({
       use24Hour: !!use24HourClock,
       goals: goalsPayload,
       projects: projectsPayload,
+      hg: {
+        scheduled: (todayHGSessions || []).slice(0, 4).map(s => ({
+          projectId: s.id,
+          title: s.title,
+          colorHex: s.colorHex,
+          startTime: s.startTime,
+          reachable: !!s.reachable,
+          date: s.date,
+        })),
+        active: showHyperGlanceMode ? {
+          projectId: hyperGlanceProjectId || '',
+          title: (() => { const p = (projects || []).find(p => p.id === hyperGlanceProjectId); return p?.title || ''; })(),
+          colorHex: (() => { const p = (projects || []).find(p => p.id === hyperGlanceProjectId); return p?.hyperglance?.color || '#4f46e5'; })(),
+          setup: !!hgShowSettings,
+          completed: !!hgCompleted,
+          phase: hgTimerPhase || 'work',
+          secondsRemaining: hgTimerSeconds || 0,
+          running: !!hgTimerRunning,
+          cycleCount: hgCycleCount || 0,
+          workMinutes: hgWorkMinutes || 25,
+          breakMinutes: hgBreakMinutes || 5,
+          longBreakMinutes: hgLongBreakMinutes || 15,
+          nextTask: (() => {
+            if (!hyperGlanceProjectId) return null;
+            const allT = [...(tasks || []), ...(unscheduledTasks || [])];
+            const t = allT.find(t => t.projectId === hyperGlanceProjectId && !t.archived && !t.completed);
+            return t ? { id: t.id, title: t.title } : null;
+          })(),
+        } : null,
+      },
     });
   }, [
     todayAgenda, currentTime, tasks, expandedRecurringTasks, todayHGSessions, focusModeAvailable,
     showFocusMode, focusShowSettings, focusShowStats, focusPhase, focusTimerSeconds, focusTimerRunning,
     focusCycleCount, focusWorkMinutes, focusBreakMinutes, focusLongBreakMinutes,
     focusBlockTasks, focusCompletedTasks,
+    showHyperGlanceMode, hyperGlanceProjectId, hyperGlanceSessionDate,
+    hgTimerSeconds, hgTimerRunning, hgTimerPhase, hgCycleCount,
+    hgWorkMinutes, hgBreakMinutes, hgLongBreakMinutes, hgShowSettings, hgCompleted,
     activeHabits, getTodayHabitCount, habitsEnabled,
     todayRoutines, routineCompletions, use24HourClock,
     goals, projects, unscheduledTasks, goalsProjectsEnabled,

--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -1,165 +1,246 @@
 {
-  "Name": "dayGLANCE",
-  "Version": "0.0.1",
-  "Author": "dayGLANCE",
-  "Description": "Agenda, focus, tasks, and goals on your Stream Deck+.",
-  "Category": "dayGLANCE",
-  "CategoryIcon": "imgs/plugin/category-icon",
-  "Icon": "imgs/plugin/icon",
-  "CodePath": "bin/plugin.js",
-  "SDKVersion": 2,
-  "Software": {
-    "MinimumVersion": "6.5"
-  },
-  "OS": [
-    { "Platform": "mac", "MinimumVersion": "12" },
-    { "Platform": "windows", "MinimumVersion": "10" }
-  ],
-  "Nodejs": {
-    "Version": "20",
-    "Debug": "enabled"
-  },
-  "Actions": [
-    {
-      "Name": "Agenda",
-      "UUID": "app.dayglance.streamdeck.agenda",
-      "Icon": "imgs/actions/agenda/icon",
-      "Tooltip": "Scrollable agenda strip — shows current and next events.",
-      "PropertyInspectorPath": "ui/property-inspector.html",
-      "Controllers": ["Encoder", "Keypad"],
-      "Encoder": {
-        "layout": "layouts/agenda.json",
-        "TriggerDescription": {
-          "Rotate": "Cycle through tasks / overview",
-          "Push": "Complete current task",
-          "TouchTap": "Tap left/right to cycle views",
-          "LongTouch": "Complete current task"
+    "Name": "dayGLANCE",
+    "Version": "0.0.1",
+    "Author": "dayGLANCE",
+    "Description": "Agenda, focus, tasks, and goals on your Stream Deck+.",
+    "Category": "dayGLANCE",
+    "CategoryIcon": "imgs/plugin/category-icon",
+    "Icon": "imgs/plugin/icon",
+    "CodePath": "bin/plugin.js",
+    "SDKVersion": 2,
+    "Software": {
+        "MinimumVersion": "6.5"
+    },
+    "OS": [
+        {
+            "Platform": "mac",
+            "MinimumVersion": "12"
+        },
+        {
+            "Platform": "windows",
+            "MinimumVersion": "10"
         }
-      },
-      "States": [
-        { "Image": "imgs/actions/agenda/key", "TitleAlignment": "bottom" }
-      ],
-      "KeyDescription": {
-        "Short": "Cycle to next task",
-        "Long": "Complete current task"
-      }
+    ],
+    "Nodejs": {
+        "Version": "20",
+        "Debug": "enabled"
     },
-    {
-      "Name": "Focus / Pomodoro",
-      "UUID": "app.dayglance.streamdeck.focus",
-      "Icon": "imgs/actions/focus/icon",
-      "Tooltip": "Start, stop, or adjust the Pomodoro timer. Stays in sync with dayGLANCE focus mode.",
-      "PropertyInspectorPath": "ui/property-inspector.html",
-      "Controllers": ["Encoder", "Keypad"],
-      "Encoder": {
-        "layout": "layouts/focus.json",
-        "TriggerDescription": {
-          "Rotate": "Adjust session duration",
-          "Push": "Start / stop session",
-          "TouchTap": "Switch work / break phase",
-          "LongTouch": "Start / stop session"
+    "Actions": [
+        {
+            "Name": "Agenda",
+            "UUID": "app.dayglance.streamdeck.agenda",
+            "Icon": "imgs/actions/agenda/icon",
+            "Tooltip": "Scrollable agenda strip \u2014 shows current and next events.",
+            "PropertyInspectorPath": "ui/property-inspector.html",
+            "Controllers": [
+                "Encoder",
+                "Keypad"
+            ],
+            "Encoder": {
+                "layout": "layouts/agenda.json",
+                "TriggerDescription": {
+                    "Rotate": "Cycle through tasks / overview",
+                    "Push": "Complete current task",
+                    "TouchTap": "Tap left/right to cycle views",
+                    "LongTouch": "Complete current task"
+                }
+            },
+            "States": [
+                {
+                    "Image": "imgs/actions/agenda/key",
+                    "TitleAlignment": "bottom"
+                }
+            ],
+            "KeyDescription": {
+                "Short": "Cycle to next task",
+                "Long": "Complete current task"
+            }
+        },
+        {
+            "Name": "Focus / Pomodoro",
+            "UUID": "app.dayglance.streamdeck.focus",
+            "Icon": "imgs/actions/focus/icon",
+            "Tooltip": "Start, stop, or adjust the Pomodoro timer. Stays in sync with dayGLANCE focus mode.",
+            "PropertyInspectorPath": "ui/property-inspector.html",
+            "Controllers": [
+                "Encoder",
+                "Keypad"
+            ],
+            "Encoder": {
+                "layout": "layouts/focus.json",
+                "TriggerDescription": {
+                    "Rotate": "Adjust session duration",
+                    "Push": "Start / stop session",
+                    "TouchTap": "Switch work / break phase",
+                    "LongTouch": "Start / stop session"
+                }
+            },
+            "States": [
+                {
+                    "Image": "imgs/actions/focus/key-idle"
+                },
+                {
+                    "Image": "imgs/actions/focus/key-active"
+                }
+            ]
+        },
+        {
+            "Name": "hyperGLANCE",
+            "UUID": "app.dayglance.streamdeck.hyperglance",
+            "Icon": "imgs/actions/focus/icon",
+            "Tooltip": "Control hyperGLANCE project focus sessions. Shows scheduled sessions in idle; pulsing when a session is ready to start.",
+            "PropertyInspectorPath": "ui/property-inspector.html",
+            "Controllers": [
+                "Encoder",
+                "Keypad"
+            ],
+            "Encoder": {
+                "layout": "layouts/focus.json",
+                "TriggerDescription": {
+                    "Rotate": "Adjust session duration",
+                    "Push": "Start session / skip phase",
+                    "TouchTap": "Start session / skip phase",
+                    "LongTouch": "Stop session"
+                }
+            },
+            "States": [
+                {
+                    "Image": "imgs/actions/focus/key-idle"
+                },
+                {
+                    "Image": "imgs/actions/focus/key-active"
+                }
+            ]
+        },
+        {
+            "Name": "Up Next",
+            "UUID": "app.dayglance.streamdeck.up-next",
+            "Icon": "imgs/actions/next-task/icon",
+            "Tooltip": "Shows the current or next scheduled task with a live countdown. Auto-advances when the time passes.",
+            "PropertyInspectorPath": "ui/property-inspector.html",
+            "Controllers": [
+                "Encoder",
+                "Keypad"
+            ],
+            "Encoder": {
+                "layout": "layouts/up-next.json",
+                "TriggerDescription": {
+                    "Push": "Complete current task",
+                    "LongTouch": "Complete current task"
+                }
+            },
+            "States": [
+                {
+                    "Image": "imgs/actions/next-task/key",
+                    "TitleAlignment": "bottom"
+                }
+            ]
+        },
+        {
+            "Name": "Goal Progress",
+            "UUID": "app.dayglance.streamdeck.goal-progress",
+            "Icon": "imgs/actions/goal-progress/icon",
+            "Tooltip": "Cycles through active goals with arc progress indicator.",
+            "PropertyInspectorPath": "ui/property-inspector.html",
+            "Controllers": [
+                "Encoder",
+                "Keypad"
+            ],
+            "Encoder": {
+                "layout": "layouts/goal-progress.json",
+                "TriggerDescription": {
+                    "Rotate": "Cycle through goals / overview",
+                    "TouchTap": "Tap left/right to cycle goals"
+                }
+            },
+            "States": [
+                {
+                    "Image": "imgs/actions/goal-progress/key",
+                    "TitleAlignment": "bottom"
+                }
+            ]
+        },
+        {
+            "Name": "Project Progress",
+            "UUID": "app.dayglance.streamdeck.project-progress",
+            "Icon": "imgs/actions/goal-progress/icon",
+            "Tooltip": "Cycles through active projects with arc progress indicator. Goal-linked projects first, then standalone.",
+            "PropertyInspectorPath": "ui/property-inspector.html",
+            "Controllers": [
+                "Encoder",
+                "Keypad"
+            ],
+            "Encoder": {
+                "layout": "layouts/project-progress.json",
+                "TriggerDescription": {
+                    "Rotate": "Cycle through projects / overview",
+                    "TouchTap": "Tap left/right to cycle projects"
+                }
+            },
+            "States": [
+                {
+                    "Image": "imgs/actions/goal-progress/key",
+                    "TitleAlignment": "bottom"
+                }
+            ]
+        },
+        {
+            "Name": "Quick Glance",
+            "UUID": "app.dayglance.streamdeck.quick-glance",
+            "Icon": "imgs/actions/quick-glance/icon",
+            "Tooltip": "Auto-rotates between date, next event, and focus timer every 10s. Pin to lock on a mode.",
+            "PropertyInspectorPath": "ui/property-inspector.html",
+            "Controllers": [
+                "Encoder",
+                "Keypad"
+            ],
+            "Encoder": {
+                "layout": "layouts/quick-glance.json",
+                "TriggerDescription": {
+                    "Rotate": "Cycle display mode",
+                    "Push": "Pin / unpin current mode",
+                    "TouchTap": "Tap left/right to cycle modes",
+                    "LongTouch": "Pin / unpin current mode"
+                }
+            },
+            "States": [
+                {
+                    "Image": "imgs/actions/quick-glance/key",
+                    "TitleAlignment": "bottom"
+                }
+            ]
+        },
+        {
+            "Name": "Habit",
+            "UUID": "app.dayglance.streamdeck.habit",
+            "Icon": "imgs/actions/agenda/icon",
+            "Tooltip": "Shows today's count for a selected habit. Press to log one increment.",
+            "PropertyInspectorPath": "ui/habit-pi.html",
+            "Controllers": [
+                "Keypad"
+            ],
+            "States": [
+                {
+                    "Image": "imgs/actions/agenda/key",
+                    "TitleAlignment": "bottom"
+                }
+            ]
+        },
+        {
+            "Name": "Next Routine",
+            "UUID": "app.dayglance.streamdeck.routine",
+            "Icon": "imgs/actions/next-task/icon",
+            "Tooltip": "Shows the next uncompleted routine for today. Press to mark it done.",
+            "PropertyInspectorPath": "ui/property-inspector.html",
+            "Controllers": [
+                "Keypad"
+            ],
+            "States": [
+                {
+                    "Image": "imgs/actions/next-task/key",
+                    "TitleAlignment": "bottom"
+                }
+            ]
         }
-      },
-      "States": [
-        { "Image": "imgs/actions/focus/key-idle" },
-        { "Image": "imgs/actions/focus/key-active" }
-      ]
-    },
-    {
-      "Name": "Up Next",
-      "UUID": "app.dayglance.streamdeck.up-next",
-      "Icon": "imgs/actions/next-task/icon",
-      "Tooltip": "Shows the current or next scheduled task with a live countdown. Auto-advances when the time passes.",
-      "PropertyInspectorPath": "ui/property-inspector.html",
-      "Controllers": ["Encoder", "Keypad"],
-      "Encoder": {
-        "layout": "layouts/up-next.json",
-        "TriggerDescription": {
-          "Push": "Complete current task",
-          "LongTouch": "Complete current task"
-        }
-      },
-      "States": [
-        { "Image": "imgs/actions/next-task/key", "TitleAlignment": "bottom" }
-      ]
-    },
-    {
-      "Name": "Goal Progress",
-      "UUID": "app.dayglance.streamdeck.goal-progress",
-      "Icon": "imgs/actions/goal-progress/icon",
-      "Tooltip": "Cycles through active goals with arc progress indicator.",
-      "PropertyInspectorPath": "ui/property-inspector.html",
-      "Controllers": ["Encoder", "Keypad"],
-      "Encoder": {
-        "layout": "layouts/goal-progress.json",
-        "TriggerDescription": {
-          "Rotate": "Cycle through goals / overview",
-          "TouchTap": "Tap left/right to cycle goals"
-        }
-      },
-      "States": [
-        { "Image": "imgs/actions/goal-progress/key", "TitleAlignment": "bottom" }
-      ]
-    },
-    {
-      "Name": "Project Progress",
-      "UUID": "app.dayglance.streamdeck.project-progress",
-      "Icon": "imgs/actions/goal-progress/icon",
-      "Tooltip": "Cycles through active projects with arc progress indicator. Goal-linked projects first, then standalone.",
-      "PropertyInspectorPath": "ui/property-inspector.html",
-      "Controllers": ["Encoder", "Keypad"],
-      "Encoder": {
-        "layout": "layouts/project-progress.json",
-        "TriggerDescription": {
-          "Rotate": "Cycle through projects / overview",
-          "TouchTap": "Tap left/right to cycle projects"
-        }
-      },
-      "States": [
-        { "Image": "imgs/actions/goal-progress/key", "TitleAlignment": "bottom" }
-      ]
-    },
-    {
-      "Name": "Quick Glance",
-      "UUID": "app.dayglance.streamdeck.quick-glance",
-      "Icon": "imgs/actions/quick-glance/icon",
-      "Tooltip": "Auto-rotates between date, next event, and focus timer every 10s. Pin to lock on a mode.",
-      "PropertyInspectorPath": "ui/property-inspector.html",
-      "Controllers": ["Encoder", "Keypad"],
-      "Encoder": {
-        "layout": "layouts/quick-glance.json",
-        "TriggerDescription": {
-          "Rotate": "Cycle display mode",
-          "Push": "Pin / unpin current mode",
-          "TouchTap": "Tap left/right to cycle modes",
-          "LongTouch": "Pin / unpin current mode"
-        }
-      },
-      "States": [
-        { "Image": "imgs/actions/quick-glance/key", "TitleAlignment": "bottom" }
-      ]
-    },
-    {
-      "Name": "Habit",
-      "UUID": "app.dayglance.streamdeck.habit",
-      "Icon": "imgs/actions/agenda/icon",
-      "Tooltip": "Shows today's count for a selected habit. Press to log one increment.",
-      "PropertyInspectorPath": "ui/habit-pi.html",
-      "Controllers": ["Keypad"],
-      "States": [
-        { "Image": "imgs/actions/agenda/key", "TitleAlignment": "bottom" }
-      ]
-    },
-    {
-      "Name": "Next Routine",
-      "UUID": "app.dayglance.streamdeck.routine",
-      "Icon": "imgs/actions/next-task/icon",
-      "Tooltip": "Shows the next uncompleted routine for today. Press to mark it done.",
-      "PropertyInspectorPath": "ui/property-inspector.html",
-      "Controllers": ["Keypad"],
-      "States": [
-        { "Image": "imgs/actions/next-task/key", "TitleAlignment": "bottom" }
-      ]
-    }
-  ]
+    ]
 }

--- a/stream-deck-plugin/src/actions/hyperglance.ts
+++ b/stream-deck-plugin/src/actions/hyperglance.ts
@@ -1,0 +1,254 @@
+import {
+  action,
+  DialDownEvent,
+  DialRotateEvent,
+  DialUpEvent,
+  KeyDownEvent,
+  SingletonAction,
+  TouchTapEvent,
+  WillAppearEvent,
+  WillDisappearEvent,
+} from "@elgato/streamdeck";
+import {
+  DayGlanceState, onState, send,
+  MSG_DAY_HG_START, MSG_DAY_HG_TIMER_START, MSG_DAY_HG_STOP,
+  MSG_DAY_HG_SKIP, MSG_DAY_HG_SET_DURATION, MSG_DAY_HG_COMPLETE,
+  MSG_DAY_HG_TASK_COMPLETE,
+} from "../client";
+import {
+  renderKey, renderHGIdleKey, renderHGIdleSlot,
+  renderFocusSlot, renderFocusSlotKey, renderFocusSetupSlot,
+  truncate,
+} from "../render";
+
+// Four operating modes:
+//   idle     — no active HG session; up to 4 scheduled sessions shown in slots
+//   setup    — session entered, settings screen showing (hg.active.setup=true)
+//   session  — timer running/paused (hg.active, !setup, !completed)
+//   complete — post-session stats screen (hg.active.completed=true)
+
+@action({ UUID: "app.dayglance.streamdeck.hyperglance" })
+export class HyperGlanceAction extends SingletonAction {
+  private unsubscribe: (() => void) | null = null;
+  private lastState: DayGlanceState | null = null;
+  private visibleCount = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private encoderRefs = new Set<any>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private slotIndexMap = new Map<any, number>();
+  private adjusting: "work" | "break" | "longBreak" = "work";
+  private dialPressedAt: number | null = null;
+  private readonly LONG_PRESS_MS = 400;
+  private pulseOn = false;
+  private pulseTimer: ReturnType<typeof setInterval> | null = null;
+
+  override async onWillAppear(ev: WillAppearEvent): Promise<void> {
+    this.visibleCount++;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((ev.payload as any).controller === "Encoder") {
+      this.encoderRefs.add(ev.action);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const col: number = (ev.payload as any).coordinates?.column ?? 0;
+      this.slotIndexMap.set(ev.action, col % 4);
+    }
+    if (!this.unsubscribe) {
+      this.unsubscribe = onState((s) => {
+        this.lastState = s;
+        this.updatePulse(s);
+        this.renderAll(s).catch(e => console.error("[dayGLANCE] hg render:", e));
+      });
+    }
+    if (this.lastState) await this.renderOne(ev.action, this.lastState);
+  }
+
+  override async onWillDisappear(ev: WillDisappearEvent): Promise<void> {
+    this.encoderRefs.delete(ev.action);
+    this.slotIndexMap.delete(ev.action);
+    this.visibleCount = Math.max(0, this.visibleCount - 1);
+    if (this.visibleCount === 0) {
+      this.stopPulse();
+      this.unsubscribe?.();
+      this.unsubscribe = null;
+    }
+  }
+
+  override async onDialDown(_ev: DialDownEvent): Promise<void> {
+    this.dialPressedAt = Date.now();
+  }
+
+  override async onDialUp(ev: DialUpEvent): Promise<void> {
+    const held = this.dialPressedAt !== null && (Date.now() - this.dialPressedAt) >= this.LONG_PRESS_MS;
+    this.dialPressedAt = null;
+
+    const hg = this.lastState?.hg;
+    if (!hg) return;
+
+    if (hg.active?.completed) {
+      send({ type: MSG_DAY_HG_COMPLETE });
+    } else if (hg.active && !hg.active.setup) {
+      // Session in progress
+      if (held) {
+        const nextTask = hg.active.nextTask;
+        if (nextTask) send({ type: MSG_DAY_HG_TASK_COMPLETE, id: nextTask.id });
+      } else {
+        send({ type: MSG_DAY_HG_SKIP });
+      }
+    } else if (hg.active && hg.active.setup) {
+      if (held) {
+        this.adjusting = this.adjusting === "work" ? "break" : this.adjusting === "break" ? "longBreak" : "work";
+        if (this.lastState) await this.renderAll(this.lastState);
+      } else {
+        send({ type: MSG_DAY_HG_TIMER_START });
+      }
+    } else {
+      // Idle — start the session for this slot's project
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const slotIndex = this.slotIndexMap.get((ev as any).action) ?? 0;
+      const session = hg.scheduled[slotIndex];
+      if (session) send({ type: MSG_DAY_HG_START, projectId: session.projectId, date: session.date });
+    }
+  }
+
+  override async onDialRotate(ev: DialRotateEvent): Promise<void> {
+    const hg = this.lastState?.hg;
+    if (!hg?.active?.setup) return;
+    const { workMinutes, breakMinutes, longBreakMinutes } = hg.active;
+    if (this.adjusting === "work") {
+      send({ type: MSG_DAY_HG_SET_DURATION, workMinutes: Math.max(1, Math.min(120, workMinutes + ev.payload.ticks)) });
+    } else if (this.adjusting === "break") {
+      send({ type: MSG_DAY_HG_SET_DURATION, breakMinutes: Math.max(1, Math.min(60, breakMinutes + ev.payload.ticks)) });
+    } else {
+      send({ type: MSG_DAY_HG_SET_DURATION, longBreakMinutes: Math.max(1, Math.min(60, longBreakMinutes + ev.payload.ticks)) });
+    }
+  }
+
+  override async onKeyDown(ev: KeyDownEvent): Promise<void> {
+    const hg = this.lastState?.hg;
+    if (!hg) return;
+    if (hg.active?.completed) {
+      send({ type: MSG_DAY_HG_COMPLETE });
+    } else if (hg.active && !hg.active.setup) {
+      send({ type: MSG_DAY_HG_SKIP });
+    } else if (hg.active?.setup) {
+      send({ type: MSG_DAY_HG_TIMER_START });
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const slotIndex = this.slotIndexMap.get((ev as any).action) ?? 0;
+      const session = hg.scheduled[slotIndex];
+      if (session) send({ type: MSG_DAY_HG_START, projectId: session.projectId, date: session.date });
+    }
+  }
+
+  override async onTouchTap(ev: TouchTapEvent): Promise<void> {
+    if (ev.payload.hold) {
+      if (this.lastState?.hg.active) send({ type: MSG_DAY_HG_STOP });
+      return;
+    }
+    const hg = this.lastState?.hg;
+    if (!hg) return;
+    if (hg.active?.completed) {
+      send({ type: MSG_DAY_HG_COMPLETE });
+    } else if (hg.active && !hg.active.setup) {
+      send({ type: MSG_DAY_HG_SKIP });
+    } else if (hg.active?.setup) {
+      send({ type: MSG_DAY_HG_TIMER_START });
+    } else {
+      const session = hg.scheduled[0];
+      if (session) send({ type: MSG_DAY_HG_START, projectId: session.projectId, date: session.date });
+    }
+  }
+
+  // ── Pulse management ───────────────────────────────────────────────────────
+
+  private updatePulse(state: DayGlanceState): void {
+    const hasReachable = !state.hg.active && state.hg.scheduled.some(s => s.reachable);
+    if (hasReachable && !this.pulseTimer) {
+      this.pulseTimer = setInterval(() => {
+        this.pulseOn = !this.pulseOn;
+        if (this.lastState) {
+          this.renderAll(this.lastState).catch(() => {/* swallow */});
+        }
+      }, 700);
+    } else if (!hasReachable && this.pulseTimer) {
+      this.stopPulse();
+    }
+  }
+
+  private stopPulse(): void {
+    if (this.pulseTimer) {
+      clearInterval(this.pulseTimer);
+      this.pulseTimer = null;
+    }
+    this.pulseOn = false;
+  }
+
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
+  private async renderAll(state: DayGlanceState): Promise<void> {
+    for (const act of this.actions) {
+      await this.renderOne(act, state);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async renderOne(act: any, state: DayGlanceState): Promise<void> {
+    const isEncoder = this.encoderRefs.has(act);
+    const { hg } = state;
+    const active = hg.active;
+
+    if (isEncoder) {
+      const slotIndex = this.slotIndexMap.get(act) ?? 0;
+
+      if (active?.completed) {
+        // Completion screen — show project name with checkmark
+        const barColor = active.colorHex;
+        await act.setImage(renderKey({ value: "✓", sub: truncate(active.title, 14), barColor }));
+        await act.setFeedback({ canvas: renderHGIdleSlot(
+          { title: "Session Complete!", colorHex: barColor, startTime: "press to exit" },
+          false,
+        )});
+
+      } else if (active && !active.setup) {
+        // Active session — reuse focus slot rendering; map HG phase names to focus names
+        const phase = active.phase === "shortBreak" ? "break" : active.phase;
+        await act.setImage(renderFocusSlotKey(slotIndex, phase, active.secondsRemaining, active.cycleCount));
+        await act.setFeedback({ canvas: renderFocusSlot(slotIndex, phase, active.secondsRemaining, active.cycleCount) });
+
+      } else if (active?.setup) {
+        // Setup screen
+        const barColor = this.adjusting === "longBreak" ? "#16a34a" : this.adjusting === "break" ? "#22c55e" : active.colorHex;
+        const value = this.adjusting === "work" ? `${active.workMinutes}m` : this.adjusting === "break" ? `${active.breakMinutes}m` : `${active.longBreakMinutes}m`;
+        const sub = this.adjusting === "work" ? "work" : this.adjusting === "break" ? "break" : "long break";
+        await act.setImage(renderKey({ value, sub, barColor }));
+        await act.setFeedback({ canvas: renderFocusSetupSlot(slotIndex, active.workMinutes, active.breakMinutes, active.longBreakMinutes, this.adjusting) });
+
+      } else {
+        // Idle — show scheduled session for this slot
+        const session = hg.scheduled[slotIndex] ?? null;
+        const reachable = session?.reachable ?? false;
+        await act.setImage(renderHGIdleKey(session, reachable && this.pulseOn));
+        await act.setFeedback({ canvas: renderHGIdleSlot(session, reachable && this.pulseOn) });
+      }
+      return;
+    }
+
+    // Non-encoder key button
+    if (active?.completed) {
+      await act.setImage(renderKey({ value: "✓", sub: truncate(active.title, 14), barColor: active.colorHex }));
+    } else if (active && !active.setup) {
+      const phase = active.phase === "shortBreak" ? "break" : active.phase;
+      const m = Math.floor(active.secondsRemaining / 60);
+      const s = active.secondsRemaining % 60;
+      const barColor = phase === "work" ? active.colorHex : "#22c55e";
+      await act.setImage(renderKey({ value: `${m}:${s.toString().padStart(2, "0")}`, sub: phase === "work" ? "work" : "break", barColor }));
+    } else if (active?.setup) {
+      const barColor = this.adjusting === "longBreak" ? "#16a34a" : this.adjusting === "break" ? "#22c55e" : active.colorHex;
+      const value = this.adjusting === "work" ? `${active.workMinutes}m` : this.adjusting === "break" ? `${active.breakMinutes}m` : `${active.longBreakMinutes}m`;
+      await act.setImage(renderKey({ value, sub: "press to start", barColor }));
+    } else {
+      const session = hg.scheduled[0] ?? null;
+      await act.setImage(renderHGIdleKey(session, session?.reachable && this.pulseOn));
+    }
+    await act.setTitle("");
+  }
+}

--- a/stream-deck-plugin/src/client.ts
+++ b/stream-deck-plugin/src/client.ts
@@ -8,6 +8,13 @@ import {
   MSG_DAY_FOCUS_SKIP,
   MSG_DAY_FOCUS_SET_DURATION,
   MSG_DAY_FOCUS_DISMISS_STATS,
+  MSG_DAY_HG_START,
+  MSG_DAY_HG_TIMER_START,
+  MSG_DAY_HG_STOP,
+  MSG_DAY_HG_SKIP,
+  MSG_DAY_HG_SET_DURATION,
+  MSG_DAY_HG_COMPLETE,
+  MSG_DAY_HG_TASK_COMPLETE,
   MSG_DAY_TASK_COMPLETE,
   MSG_DAY_HABIT_INCREMENT,
   MSG_DAY_ROUTINE_COMPLETE,
@@ -16,8 +23,14 @@ import {
 } from "../../electron/protocol";
 
 // Re-export everything action files need — keeps their imports pointing at ../client only
-export type { DayGlanceState, Task, FocusState } from "../../electron/protocol";
-export { MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_TIMER_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP, MSG_DAY_FOCUS_SET_DURATION, MSG_DAY_FOCUS_DISMISS_STATS, MSG_DAY_TASK_COMPLETE, MSG_DAY_HABIT_INCREMENT, MSG_DAY_ROUTINE_COMPLETE } from "../../electron/protocol";
+export type { DayGlanceState, Task, FocusState, HGState, HGScheduledSession, HGActiveSession } from "../../electron/protocol";
+export {
+  MSG_DAY_FOCUS_START, MSG_DAY_FOCUS_TIMER_START, MSG_DAY_FOCUS_STOP, MSG_DAY_FOCUS_SKIP,
+  MSG_DAY_FOCUS_SET_DURATION, MSG_DAY_FOCUS_DISMISS_STATS,
+  MSG_DAY_HG_START, MSG_DAY_HG_TIMER_START, MSG_DAY_HG_STOP, MSG_DAY_HG_SKIP,
+  MSG_DAY_HG_SET_DURATION, MSG_DAY_HG_COMPLETE, MSG_DAY_HG_TASK_COMPLETE,
+  MSG_DAY_TASK_COMPLETE, MSG_DAY_HABIT_INCREMENT, MSG_DAY_ROUTINE_COMPLETE,
+} from "../../electron/protocol";
 
 // CommandPayload is the caller-facing API — send() stamps v internally
 type CommandPayload =
@@ -27,6 +40,13 @@ type CommandPayload =
   | { type: typeof MSG_DAY_FOCUS_SKIP }
   | { type: typeof MSG_DAY_FOCUS_SET_DURATION; workMinutes?: number; breakMinutes?: number; longBreakMinutes?: number }
   | { type: typeof MSG_DAY_FOCUS_DISMISS_STATS }
+  | { type: typeof MSG_DAY_HG_START; projectId: string; date: string }
+  | { type: typeof MSG_DAY_HG_TIMER_START }
+  | { type: typeof MSG_DAY_HG_STOP }
+  | { type: typeof MSG_DAY_HG_SKIP }
+  | { type: typeof MSG_DAY_HG_SET_DURATION; workMinutes?: number; breakMinutes?: number; longBreakMinutes?: number }
+  | { type: typeof MSG_DAY_HG_COMPLETE }
+  | { type: typeof MSG_DAY_HG_TASK_COMPLETE; id: string }
   | { type: typeof MSG_DAY_TASK_COMPLETE; id: string }
   | { type: typeof MSG_DAY_HABIT_INCREMENT; id: string }
   | { type: typeof MSG_DAY_ROUTINE_COMPLETE; id: string };

--- a/stream-deck-plugin/src/plugin.ts
+++ b/stream-deck-plugin/src/plugin.ts
@@ -8,6 +8,7 @@ import { HabitAction } from "./actions/habit";
 import { UpNextAction } from "./actions/up-next";
 import { QuickGlanceAction } from "./actions/quick-glance";
 import { RoutineAction } from "./actions/routine";
+import { HyperGlanceAction } from "./actions/hyperglance";
 
 streamDeck.actions.registerAction(new AgendaAction());
 streamDeck.actions.registerAction(new FocusAction());
@@ -17,5 +18,6 @@ streamDeck.actions.registerAction(new HabitAction());
 streamDeck.actions.registerAction(new UpNextAction());
 streamDeck.actions.registerAction(new QuickGlanceAction());
 streamDeck.actions.registerAction(new RoutineAction());
+streamDeck.actions.registerAction(new HyperGlanceAction());
 
 streamDeck.connect();

--- a/stream-deck-plugin/src/render.ts
+++ b/stream-deck-plugin/src/render.ts
@@ -390,6 +390,60 @@ export function renderProjectStrip(opts: ProjectOpts): string {
   return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
 }
 
+// ── HyperGLANCE idle-slot rendering ──────────────────────────────────────
+
+/** 144×144 key for a scheduled (idle) hyperGLANCE session slot.
+ *  pulseOn adds a glowing border to indicate the session is reachable. */
+export function renderHGIdleKey(session: { title: string; colorHex: string; startTime: string } | null, pulseOn = false): string {
+  if (!session) {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}">
+  <rect width="${W}" height="${H}" fill="#111"/>
+  <rect width="${W}" height="5" fill="#4f46e5" fill-opacity="0.3"/>
+  <text x="72" y="80" font-family="${FONT}" font-size="28" fill="white" fill-opacity="0.15" text-anchor="middle" font-weight="700">hG</text>
+</svg>`;
+    return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
+  }
+  const { title, colorHex, startTime } = session;
+  const label = truncate(title, 11);
+  const border = pulseOn ? `<rect x="2" y="2" width="140" height="140" rx="3" fill="none" stroke="${escape(colorHex)}" stroke-width="2.5" stroke-opacity="0.9"/>` : "";
+  const textOpacity = pulseOn ? "1" : "0.75";
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}">
+  <rect width="${W}" height="${H}" fill="#111"/>
+  <rect width="${W}" height="5" fill="${escape(colorHex)}"/>
+  ${border}
+  <text x="72" y="22" font-family="${FONT}" font-size="11" fill="${escape(colorHex)}" fill-opacity="0.7" text-anchor="middle" letter-spacing="0.5">hyper<tspan font-style="italic">GLANCE</tspan></text>
+  <text x="72" y="74" font-family="${FONT}" font-size="22" fill="white" fill-opacity="${textOpacity}" text-anchor="middle" font-weight="700">${escape(label)}</text>
+  <text x="72" y="103" font-family="${FONT}" font-size="18" fill="white" fill-opacity="0.5" text-anchor="middle">${escape(startTime)}</text>
+</svg>`;
+  return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
+}
+
+/** 200×100 touch-strip slot for a scheduled (idle) hyperGLANCE session.
+ *  pulseOn brightens the text to indicate the session is reachable. */
+export function renderHGIdleSlot(session: { title: string; colorHex: string; startTime: string } | null, pulseOn = false): string {
+  if (!session) {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${SW}" height="${SH}">
+  <rect width="${SW}" height="${SH}" fill="#111"/>
+  <rect width="${SW}" height="4" fill="#4f46e5" fill-opacity="0.2"/>
+  <text x="12" y="60" font-family="${FONT}" font-size="28" fill="white" fill-opacity="0.1" font-weight="700">hG</text>
+</svg>`;
+    return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
+  }
+  const { title, colorHex, startTime } = session;
+  const label = truncate(title, 14);
+  const titleOpacity = pulseOn ? "1" : "0.8";
+  const timeOpacity = pulseOn ? "0.8" : "0.5";
+  const accentOpacity = pulseOn ? "1" : "0.6";
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${SW}" height="${SH}">
+  <rect width="${SW}" height="${SH}" fill="#111"/>
+  <rect width="${SW}" height="4" fill="${escape(colorHex)}" fill-opacity="${accentOpacity}"/>
+  <rect width="4" height="${SH}" fill="${escape(colorHex)}" fill-opacity="${accentOpacity}"/>
+  <text x="16" y="46" font-family="${FONT}" font-size="22" fill="white" fill-opacity="${titleOpacity}" font-weight="700">${escape(label)}</text>
+  <text x="16" y="74" font-family="${FONT}" font-size="18" fill="white" fill-opacity="${timeOpacity}">${escape(startTime)}</text>
+</svg>`;
+  return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
+}
+
 /** Strips #hashtags and [[wikilinks]] from a task title. */
 export function stripTags(s: string): string {
   return s


### PR DESCRIPTION
## Summary

Adds a new **hyperGLANCE** Stream Deck action (works on both Encoder and Keypad) with the full session lifecycle controllable from hardware — no mouse required.

### Idle state (no active session)
- Each of the 4 encoder slots shows one of today's scheduled hG sessions: project name, start time, and the project's color as the top bar + left accent strip
- Sessions whose start time has been reached **pulse** with a glowing colored border at 700ms intervals — clear visual signal that a session is ready
- Pressing a slot's dial or key starts that specific project's session (`day:hg:start`)
- Empty slots are shown dimly so the layout is always consistent

### Setup screen
- Identical UX to Focus Mode: rotate to adjust work/short-break/long-break minutes; long-press dial cycles which duration is being adjusted; short-press starts the timer

### Active session
- Reuses the existing 4-slot Pomodoro rendering (one cycle per slot)
- Short-press: skip phase; long-press: complete the next project task; touch-tap hold: exit/pause the session

### Completion screen
- Any press or tap sends `day:hg:complete` — dismisses the stats screen without the mouse

### App-side changes
- Lifts `hgCompleted` from local modal state to App.jsx context so the bridge can observe it
- Adds `startHyperGlanceTimer()` and `skipHyperGlancePhase()` to App.jsx (were previously only inside the modal component)
- Adds `reachable: boolean` field to `todayHGSessions`
- New `day:hg:*` protocol commands and `HGState` / `HGActiveSession` / `HGScheduledSession` types in `protocol.ts`

## Test plan

- [ ] Add the **hyperGLANCE** action to a profile with 4 encoder slots
- [ ] Before session start time: slots show project names/times, no pulse
- [ ] After start time: matching slot(s) pulse with colored border
- [ ] Press a pulsing slot's dial → hyperGLANCE session opens for that project
- [ ] Rotate dial → adjusts work minutes; long-press → cycles to break; long-press again → long break; long-press again → back to work
- [ ] Short-press → timer starts; Pomodoro cycles appear across 4 slots
- [ ] Short-press during session → skips phase
- [ ] Long-press during session → completes next project task (checkmark appears in app)
- [ ] All tasks complete → completion screen shows; any press dismisses
- [ ] Touch-tap hold → exits session (bar stays on timeline, no completion saved)

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_