### PR TITLE
fix(stream-deck): hG task completion + idle slot label polish

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6015,6 +6015,7 @@ const DayPlanner = () => {
     recordDeletedTaskTombstone,
     scheduleTaskAtNextSlot,
     manuallyScheduleTask,
+    hgCompleteTask,
     focusCompleteTask,
     focusUpdateTaskNotes,
     focusAddSubtask,
@@ -6181,6 +6182,7 @@ const DayPlanner = () => {
     setFocusWorkMinutes,
     setFocusBreakMinutes,
     focusCompleteTask,
+    hgCompleteTask,
     toggleComplete,
     // HyperGLANCE
     showHyperGlanceMode,

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -78,6 +78,7 @@ export default function useElectronBridge({
   setFocusBreakMinutes,
   setFocusLongBreakMinutes,
   focusCompleteTask,
+  hgCompleteTask,
   toggleComplete,
   // HyperGLANCE
   showHyperGlanceMode,
@@ -120,6 +121,7 @@ export default function useElectronBridge({
   const skipFocusPhaseRef = useRef(skipFocusPhase);
   const dismissFocusStatsRef = useRef(dismissFocusStats);
   const focusCompleteTaskRef = useRef(focusCompleteTask);
+  const hgCompleteTaskRef = useRef(hgCompleteTask);
   const toggleCompleteRef = useRef(toggleComplete);
   const incrementHabitRef = useRef(incrementHabit);
   const toggleRoutineCompletionRef = useRef(toggleRoutineCompletion);
@@ -137,6 +139,7 @@ export default function useElectronBridge({
   skipFocusPhaseRef.current = skipFocusPhase;
   dismissFocusStatsRef.current = dismissFocusStats;
   focusCompleteTaskRef.current = focusCompleteTask;
+  hgCompleteTaskRef.current = hgCompleteTask;
   toggleCompleteRef.current = toggleComplete;
   incrementHabitRef.current = incrementHabit;
   toggleRoutineCompletionRef.current = toggleRoutineCompletion;
@@ -209,7 +212,7 @@ export default function useElectronBridge({
           exitHyperGlanceModeRef.current?.();
           break;
         case MSG_DAY_HG_TASK_COMPLETE:
-          if (cmd.id) toggleCompleteRef.current?.(cmd.id);
+          if (cmd.id) hgCompleteTaskRef.current?.(cmd.id);
           break;
       }
     });

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -751,6 +751,11 @@ export default function useTaskActions({
     }
   };
 
+  const hgCompleteTask = (taskId) => {
+    const fromInbox = !tasks.find(t => t.id === taskId);
+    toggleComplete(taskId, fromInbox);
+  };
+
   const focusUpdateTaskNotes = (taskId, notes, isInbox) => {
     updateTaskNotes(taskId, notes, isInbox);
     setFocusBlockTasks(prev => prev.map(t => t.id === taskId ? { ...t, notes } : t));
@@ -818,6 +823,8 @@ export default function useTaskActions({
     // Schedule
     scheduleTaskAtNextSlot,
     manuallyScheduleTask,
+    // HG wrapper
+    hgCompleteTask,
     // Focus wrappers
     focusCompleteTask,
     focusUpdateTaskNotes,

--- a/stream-deck-plugin/src/render.ts
+++ b/stream-deck-plugin/src/render.ts
@@ -399,7 +399,7 @@ export function renderHGIdleKey(session: { title: string; colorHex: string; star
     const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}">
   <rect width="${W}" height="${H}" fill="#111"/>
   <rect width="${W}" height="5" fill="#4f46e5" fill-opacity="0.3"/>
-  <text x="72" y="80" font-family="${FONT}" font-size="28" fill="white" fill-opacity="0.15" text-anchor="middle" font-weight="700">hG</text>
+  <text x="72" y="80" font-family="${FONT}" font-size="16" fill="white" fill-opacity="0.15" text-anchor="middle" font-weight="700">hyper<tspan font-style="italic">GLANCE</tspan></text>
 </svg>`;
     return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
   }
@@ -425,7 +425,7 @@ export function renderHGIdleSlot(session: { title: string; colorHex: string; sta
     const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${SW}" height="${SH}">
   <rect width="${SW}" height="${SH}" fill="#111"/>
   <rect width="${SW}" height="4" fill="#4f46e5" fill-opacity="0.2"/>
-  <text x="12" y="60" font-family="${FONT}" font-size="28" fill="white" fill-opacity="0.1" font-weight="700">hG</text>
+  <text x="12" y="60" font-family="${FONT}" font-size="16" fill="white" fill-opacity="0.1" font-weight="700">hyper<tspan font-style="italic">GLANCE</tspan></text>
 </svg>`;
     return "data:image/svg+xml;base64," + Buffer.from(svg).toString("base64");
   }


### PR DESCRIPTION
## Summary

- **Fix HG task completion**: Long-pressing the dial during an active hyperGLANCE session now correctly completes the next project task regardless of whether it lives in the scheduled `tasks` list or the `unscheduledTasks` inbox. Previously the bare `toggleComplete(id)` call was missing the `fromInbox` flag, so inbox tasks silently failed to toggle. The fix adds an `hgCompleteTask()` wrapper in `useTaskActions` that mirrors the logic in `HyperGlanceModeModal`'s `handleToggleTask`.

- **Idle slot label**: Empty hyperGLANCE encoder slots now show `hyper`*`GLANCE`* (with GLANCE italicised) instead of the terse `hG` placeholder, matching the style of the active-slot header.

## Test plan

- [ ] Start a hyperGLANCE session for a project that has tasks in the **inbox** (unscheduledTasks)
- [ ] Long-press the dial during the work phase → task should mark complete in the app and the next task should appear
- [ ] Repeat with a project whose tasks are **scheduled** (in `tasks`) — same result
- [ ] Open the Stream Deck software and observe empty hyperGLANCE encoder slots — should show `hyperGLANCE` (italic GLANCE) rather than `hG`

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_