### PR TITLE
fix(stream-deck): correct manifest icon paths + disable debug

### DIFF
--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -23,14 +23,14 @@
     ],
     "Nodejs": {
         "Version": "20",
-        "Debug": "enabled"
+        "Debug": "disabled"
     },
     "Actions": [
         {
             "Name": "Agenda",
             "UUID": "app.dayglance.streamdeck.agenda",
             "Icon": "imgs/actions/agenda/icon",
-            "Tooltip": "Scrollable agenda strip \u2014 shows current and next events.",
+            "Tooltip": "Scrollable agenda strip — shows current and next events.",
             "PropertyInspectorPath": "ui/property-inspector.html",
             "Controllers": [
                 "Encoder",
@@ -77,17 +77,14 @@
             },
             "States": [
                 {
-                    "Image": "imgs/actions/focus/key-idle"
-                },
-                {
-                    "Image": "imgs/actions/focus/key-active"
+                    "Image": "imgs/actions/focus/key"
                 }
             ]
         },
         {
             "Name": "hyperGLANCE",
             "UUID": "app.dayglance.streamdeck.hyperglance",
-            "Icon": "imgs/actions/focus/icon",
+            "Icon": "imgs/actions/hyperglance/icon",
             "Tooltip": "Control hyperGLANCE project focus sessions. Shows scheduled sessions in idle; pulsing when a session is ready to start.",
             "PropertyInspectorPath": "ui/property-inspector.html",
             "Controllers": [
@@ -105,17 +102,14 @@
             },
             "States": [
                 {
-                    "Image": "imgs/actions/focus/key-idle"
-                },
-                {
-                    "Image": "imgs/actions/focus/key-active"
+                    "Image": "imgs/actions/hyperglance/key"
                 }
             ]
         },
         {
             "Name": "Up Next",
             "UUID": "app.dayglance.streamdeck.up-next",
-            "Icon": "imgs/actions/next-task/icon",
+            "Icon": "imgs/actions/up-next/icon",
             "Tooltip": "Shows the current or next scheduled task with a live countdown. Auto-advances when the time passes.",
             "PropertyInspectorPath": "ui/property-inspector.html",
             "Controllers": [
@@ -131,7 +125,7 @@
             },
             "States": [
                 {
-                    "Image": "imgs/actions/next-task/key",
+                    "Image": "imgs/actions/up-next/key",
                     "TitleAlignment": "bottom"
                 }
             ]
@@ -163,7 +157,7 @@
         {
             "Name": "Project Progress",
             "UUID": "app.dayglance.streamdeck.project-progress",
-            "Icon": "imgs/actions/goal-progress/icon",
+            "Icon": "imgs/actions/project-progress/icon",
             "Tooltip": "Cycles through active projects with arc progress indicator. Goal-linked projects first, then standalone.",
             "PropertyInspectorPath": "ui/property-inspector.html",
             "Controllers": [
@@ -179,7 +173,7 @@
             },
             "States": [
                 {
-                    "Image": "imgs/actions/goal-progress/key",
+                    "Image": "imgs/actions/project-progress/key",
                     "TitleAlignment": "bottom"
                 }
             ]
@@ -213,7 +207,7 @@
         {
             "Name": "Habit",
             "UUID": "app.dayglance.streamdeck.habit",
-            "Icon": "imgs/actions/agenda/icon",
+            "Icon": "imgs/actions/habit/icon",
             "Tooltip": "Shows today's count for a selected habit. Press to log one increment.",
             "PropertyInspectorPath": "ui/habit-pi.html",
             "Controllers": [
@@ -221,7 +215,7 @@
             ],
             "States": [
                 {
-                    "Image": "imgs/actions/agenda/key",
+                    "Image": "imgs/actions/habit/key",
                     "TitleAlignment": "bottom"
                 }
             ]
@@ -229,7 +223,7 @@
         {
             "Name": "Next Routine",
             "UUID": "app.dayglance.streamdeck.routine",
-            "Icon": "imgs/actions/next-task/icon",
+            "Icon": "imgs/actions/next-routine/icon",
             "Tooltip": "Shows the next uncompleted routine for today. Press to mark it done.",
             "PropertyInspectorPath": "ui/property-inspector.html",
             "Controllers": [
@@ -237,7 +231,7 @@
             ],
             "States": [
                 {
-                    "Image": "imgs/actions/next-task/key",
+                    "Image": "imgs/actions/next-routine/key",
                     "TitleAlignment": "bottom"
                 }
             ]


### PR DESCRIPTION
## Summary

Now that each action has its own dedicated image folder, the manifest needed updating to match. Previously several actions were borrowing icon paths from sibling actions (a temporary placeholder before the artwork existed).

**Icon and state image paths corrected:**
| Action | Was | Now |
|--------|-----|-----|
| hyperGLANCE | `imgs/actions/focus/icon` | `imgs/actions/hyperglance/icon` |
| Up Next | `imgs/actions/next-task/icon` | `imgs/actions/up-next/icon` |
| Project Progress | `imgs/actions/goal-progress/icon` | `imgs/actions/project-progress/icon` |
| Habit | `imgs/actions/agenda/icon` | `imgs/actions/habit/icon` |
| Next Routine | `imgs/actions/next-task/icon` | `imgs/actions/next-routine/icon` |

**Focus / hyperGLANCE state image names** fixed from `key-idle` / `key-active` (non-existent) to `key` (matches the actual files).

**`Nodejs.Debug`** flipped from `enabled` to `disabled` for production.

## Test plan
- [ ] Open Stream Deck software — each action should show its correct icon in the action picker
- [ ] Run `npx @elgato/streamdeck pack com.dayglance.streamdeck.sdPlugin` from `stream-deck-plugin/` — should complete without icon-not-found warnings

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_