### PR TITLE
fix(stream-deck): add top-level UUID to manifest

### DIFF
--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -1,5 +1,6 @@
 {
     "Name": "dayGLANCE",
+    "UUID": "com.dayglance.streamdeck",
     "Version": "0.0.1",
     "Author": "dayGLANCE",
     "Description": "Agenda, focus, tasks, and goals on your Stream Deck+.",


### PR DESCRIPTION
Adds `"UUID": "com.dayglance.streamdeck"` at the top level of `manifest.json`. The Elgato Maker portal requires this field for marketplace submission.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_