### PR TITLE
feat(stream-deck): upgrade to SDK v2 / manifest SDKVersion 3

### DIFF
--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -8,9 +8,9 @@
     "CategoryIcon": "imgs/plugin/category-icon",
     "Icon": "imgs/plugin/icon",
     "CodePath": "bin/plugin.js",
-    "SDKVersion": 2,
+    "SDKVersion": 3,
     "Software": {
-        "MinimumVersion": "6.5"
+        "MinimumVersion": "6.9"
     },
     "OS": [
         {

--- a/stream-deck-plugin/package-lock.json
+++ b/stream-deck-plugin/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dayglance-streamdeck",
       "version": "0.0.1",
       "dependencies": {
-        "@elgato/streamdeck": "^1.0.0",
+        "@elgato/streamdeck": "^2.1.0",
         "ws": "^8.0.0"
       },
       "devDependencies": {
@@ -28,16 +28,26 @@
       "license": "MIT"
     },
     "node_modules/@elgato/streamdeck": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@elgato/streamdeck/-/streamdeck-1.4.1.tgz",
-      "integrity": "sha512-nk3TWfSvLrMWR6AhD6DG/pnJhWR6/xzP9elH/VLaiyZ27Nxb1Hu3rPuRty6xE5AZykwf3Auafok016wZSJZ3TA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@elgato/streamdeck/-/streamdeck-2.1.0.tgz",
+      "integrity": "sha512-d6wgSe93NbKAW0yT6/rabGCYUWic6nAoQoSLAXVadqTIUVmt+5Tfu7OaIGKnGER6AOn6dOpX6havRLFFFcUmOw==",
       "license": "MIT",
       "dependencies": {
-        "@elgato/schemas": "^0.4.8",
-        "ws": "^8.18.0"
+        "@elgato/schemas": "^0.4.14",
+        "@elgato/utils": "^0.4.4",
+        "ws": "^8.19.0"
       },
       "engines": {
         "node": ">=20.5.1"
+      }
+    },
+    "node_modules/@elgato/utils": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@elgato/utils/-/utils-0.4.5.tgz",
+      "integrity": "sha512-kBoqM8LEhhVLv7lNftYqaecNna3T/L85QQWU56yR1iFCvqlyyD22WmBljRcQkw5ZNvib55Br3cnrsxX3ajp+dQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.25.24"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -888,6 +898,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/stream-deck-plugin/package.json
+++ b/stream-deck-plugin/package.json
@@ -9,7 +9,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@elgato/streamdeck": "^1.0.0",
+    "@elgato/streamdeck": "^2.1.0",
     "ws": "^8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Upgrades the Stream Deck plugin to satisfy the Elgato marketplace compatibility requirements.

- **`@elgato/streamdeck` 1.4.1 → 2.1.0** — the npm package that corresponds to SDK v3 protocol. New transitive deps: `@elgato/utils` and `zod`.
- **`manifest.json` SDKVersion 2 → 3** — required by the Elgato Maker portal
- **`manifest.json` Software.MinimumVersion 6.5 → 6.9** — required by the Elgato Maker portal

**Breaking change impact:** In SDK v2 the event types (`DialDownEvent`, `WillAppearEvent`, etc.) moved from named value exports to `export type *`. Since our action files only use them as TypeScript type annotations, no source code changes were needed — the build is clean.

## Test plan
- [ ] `npm run build` in `stream-deck-plugin/` — should complete with no errors
- [ ] Rebuild the `.streamDeckPlugin` zip and re-upload to the Elgato Maker portal — Compatibility and SDK Compatibility should no longer show red

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_