### PR TITLE
fix(stream-deck): resolve streamdeck pack validation errors

### DIFF
--- a/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
+++ b/stream-deck-plugin/com.dayglance.streamdeck.sdPlugin/manifest.json
@@ -29,7 +29,7 @@
     "Actions": [
         {
             "Name": "Agenda",
-            "UUID": "app.dayglance.streamdeck.agenda",
+            "UUID": "com.dayglance.streamdeck.agenda",
             "Icon": "imgs/actions/agenda/icon",
             "Tooltip": "Scrollable agenda strip — shows current and next events.",
             "PropertyInspectorPath": "ui/property-inspector.html",
@@ -42,7 +42,6 @@
                 "TriggerDescription": {
                     "Rotate": "Cycle through tasks / overview",
                     "Push": "Complete current task",
-                    "TouchTap": "Tap left/right to cycle views",
                     "LongTouch": "Complete current task"
                 }
             },
@@ -51,15 +50,11 @@
                     "Image": "imgs/actions/agenda/key",
                     "TitleAlignment": "bottom"
                 }
-            ],
-            "KeyDescription": {
-                "Short": "Cycle to next task",
-                "Long": "Complete current task"
-            }
+            ]
         },
         {
             "Name": "Focus / Pomodoro",
-            "UUID": "app.dayglance.streamdeck.focus",
+            "UUID": "com.dayglance.streamdeck.focus",
             "Icon": "imgs/actions/focus/icon",
             "Tooltip": "Start, stop, or adjust the Pomodoro timer. Stays in sync with dayGLANCE focus mode.",
             "PropertyInspectorPath": "ui/property-inspector.html",
@@ -72,7 +67,6 @@
                 "TriggerDescription": {
                     "Rotate": "Adjust session duration",
                     "Push": "Start / stop session",
-                    "TouchTap": "Switch work / break phase",
                     "LongTouch": "Start / stop session"
                 }
             },
@@ -84,7 +78,7 @@
         },
         {
             "Name": "hyperGLANCE",
-            "UUID": "app.dayglance.streamdeck.hyperglance",
+            "UUID": "com.dayglance.streamdeck.hyperglance",
             "Icon": "imgs/actions/hyperglance/icon",
             "Tooltip": "Control hyperGLANCE project focus sessions. Shows scheduled sessions in idle; pulsing when a session is ready to start.",
             "PropertyInspectorPath": "ui/property-inspector.html",
@@ -97,7 +91,6 @@
                 "TriggerDescription": {
                     "Rotate": "Adjust session duration",
                     "Push": "Start session / skip phase",
-                    "TouchTap": "Start session / skip phase",
                     "LongTouch": "Stop session"
                 }
             },
@@ -109,7 +102,7 @@
         },
         {
             "Name": "Up Next",
-            "UUID": "app.dayglance.streamdeck.up-next",
+            "UUID": "com.dayglance.streamdeck.up-next",
             "Icon": "imgs/actions/up-next/icon",
             "Tooltip": "Shows the current or next scheduled task with a live countdown. Auto-advances when the time passes.",
             "PropertyInspectorPath": "ui/property-inspector.html",
@@ -133,7 +126,7 @@
         },
         {
             "Name": "Goal Progress",
-            "UUID": "app.dayglance.streamdeck.goal-progress",
+            "UUID": "com.dayglance.streamdeck.goal-progress",
             "Icon": "imgs/actions/goal-progress/icon",
             "Tooltip": "Cycles through active goals with arc progress indicator.",
             "PropertyInspectorPath": "ui/property-inspector.html",
@@ -144,8 +137,7 @@
             "Encoder": {
                 "layout": "layouts/goal-progress.json",
                 "TriggerDescription": {
-                    "Rotate": "Cycle through goals / overview",
-                    "TouchTap": "Tap left/right to cycle goals"
+                    "Rotate": "Cycle through goals / overview"
                 }
             },
             "States": [
@@ -157,7 +149,7 @@
         },
         {
             "Name": "Project Progress",
-            "UUID": "app.dayglance.streamdeck.project-progress",
+            "UUID": "com.dayglance.streamdeck.project-progress",
             "Icon": "imgs/actions/project-progress/icon",
             "Tooltip": "Cycles through active projects with arc progress indicator. Goal-linked projects first, then standalone.",
             "PropertyInspectorPath": "ui/property-inspector.html",
@@ -168,8 +160,7 @@
             "Encoder": {
                 "layout": "layouts/project-progress.json",
                 "TriggerDescription": {
-                    "Rotate": "Cycle through projects / overview",
-                    "TouchTap": "Tap left/right to cycle projects"
+                    "Rotate": "Cycle through projects / overview"
                 }
             },
             "States": [
@@ -181,7 +172,7 @@
         },
         {
             "Name": "Quick Glance",
-            "UUID": "app.dayglance.streamdeck.quick-glance",
+            "UUID": "com.dayglance.streamdeck.quick-glance",
             "Icon": "imgs/actions/quick-glance/icon",
             "Tooltip": "Auto-rotates between date, next event, and focus timer every 10s. Pin to lock on a mode.",
             "PropertyInspectorPath": "ui/property-inspector.html",
@@ -194,7 +185,6 @@
                 "TriggerDescription": {
                     "Rotate": "Cycle display mode",
                     "Push": "Pin / unpin current mode",
-                    "TouchTap": "Tap left/right to cycle modes",
                     "LongTouch": "Pin / unpin current mode"
                 }
             },
@@ -207,7 +197,7 @@
         },
         {
             "Name": "Habit",
-            "UUID": "app.dayglance.streamdeck.habit",
+            "UUID": "com.dayglance.streamdeck.habit",
             "Icon": "imgs/actions/habit/icon",
             "Tooltip": "Shows today's count for a selected habit. Press to log one increment.",
             "PropertyInspectorPath": "ui/habit-pi.html",
@@ -223,7 +213,7 @@
         },
         {
             "Name": "Next Routine",
-            "UUID": "app.dayglance.streamdeck.routine",
+            "UUID": "com.dayglance.streamdeck.routine",
             "Icon": "imgs/actions/next-routine/icon",
             "Tooltip": "Shows the next uncompleted routine for today. Press to mark it done.",
             "PropertyInspectorPath": "ui/property-inspector.html",

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -12,7 +12,7 @@ import {
 import { DayGlanceState, onState, send, MSG_DAY_TASK_COMPLETE } from "../client";
 import { renderKey, renderStrip, stripTags, truncate } from "../render";
 
-@action({ UUID: "app.dayglance.streamdeck.agenda" })
+@action({ UUID: "com.dayglance.streamdeck.agenda" })
 export class AgendaAction extends SingletonAction {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;

--- a/stream-deck-plugin/src/actions/focus-mode.ts
+++ b/stream-deck-plugin/src/actions/focus-mode.ts
@@ -21,7 +21,7 @@ import { renderKey, renderStrip, renderFocusSlot, renderFocusSlotKey, renderFocu
 //   setup  — panel open, settings screen showing (active=true, setup=true)
 //   session — timer running or paused (active=true, setup=false)
 
-@action({ UUID: "app.dayglance.streamdeck.focus" })
+@action({ UUID: "com.dayglance.streamdeck.focus" })
 export class FocusAction extends SingletonAction {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;

--- a/stream-deck-plugin/src/actions/goal-progress.ts
+++ b/stream-deck-plugin/src/actions/goal-progress.ts
@@ -12,7 +12,7 @@ import {
 import { DayGlanceState, onState } from "../client";
 import { renderGoalKey, renderGoalStrip } from "../render";
 
-@action({ UUID: "app.dayglance.streamdeck.goal-progress" })
+@action({ UUID: "com.dayglance.streamdeck.goal-progress" })
 export class GoalProgressAction extends SingletonAction {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;

--- a/stream-deck-plugin/src/actions/habit.ts
+++ b/stream-deck-plugin/src/actions/habit.ts
@@ -11,7 +11,7 @@ import { renderKey, truncate } from "../render";
 
 type Settings = { habitId: string | null };
 
-@action({ UUID: "app.dayglance.streamdeck.habit" })
+@action({ UUID: "com.dayglance.streamdeck.habit" })
 export class HabitAction extends SingletonAction<Settings> {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;

--- a/stream-deck-plugin/src/actions/hyperglance.ts
+++ b/stream-deck-plugin/src/actions/hyperglance.ts
@@ -27,7 +27,7 @@ import {
 //   session  — timer running/paused (hg.active, !setup, !completed)
 //   complete — post-session stats screen (hg.active.completed=true)
 
-@action({ UUID: "app.dayglance.streamdeck.hyperglance" })
+@action({ UUID: "com.dayglance.streamdeck.hyperglance" })
 export class HyperGlanceAction extends SingletonAction {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;

--- a/stream-deck-plugin/src/actions/next-task.ts
+++ b/stream-deck-plugin/src/actions/next-task.ts
@@ -11,7 +11,7 @@ import {
 import { DayGlanceState, onState, send, MSG_DAY_TASK_COMPLETE } from "../client";
 import { renderKey, renderStrip, stripTags, truncate } from "../render";
 
-@action({ UUID: "app.dayglance.streamdeck.next-task" })
+@action({ UUID: "com.dayglance.streamdeck.next-task" })
 export class NextTaskAction extends SingletonAction {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;

--- a/stream-deck-plugin/src/actions/project-progress.ts
+++ b/stream-deck-plugin/src/actions/project-progress.ts
@@ -12,7 +12,7 @@ import {
 import { DayGlanceState, onState } from "../client";
 import { renderProjectKey, renderProjectStrip } from "../render";
 
-@action({ UUID: "app.dayglance.streamdeck.project-progress" })
+@action({ UUID: "com.dayglance.streamdeck.project-progress" })
 export class ProjectProgressAction extends SingletonAction {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;

--- a/stream-deck-plugin/src/actions/quick-glance.ts
+++ b/stream-deck-plugin/src/actions/quick-glance.ts
@@ -16,7 +16,7 @@ type DisplayMode = "date" | "next-event" | "focus";
 const MODES: DisplayMode[] = ["date", "next-event", "focus"];
 const AUTO_ROTATE_MS = 10_000;
 
-@action({ UUID: "app.dayglance.streamdeck.quick-glance" })
+@action({ UUID: "com.dayglance.streamdeck.quick-glance" })
 export class QuickGlanceAction extends SingletonAction {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;

--- a/stream-deck-plugin/src/actions/routine.ts
+++ b/stream-deck-plugin/src/actions/routine.ts
@@ -8,7 +8,7 @@ import {
 import { DayGlanceState, onState, send, MSG_DAY_ROUTINE_COMPLETE } from "../client";
 import { renderKey, truncate } from "../render";
 
-@action({ UUID: "app.dayglance.streamdeck.routine" })
+@action({ UUID: "com.dayglance.streamdeck.routine" })
 export class RoutineAction extends SingletonAction {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;

--- a/stream-deck-plugin/src/actions/up-next.ts
+++ b/stream-deck-plugin/src/actions/up-next.ts
@@ -10,7 +10,7 @@ import {
 import { DayGlanceState, Task, onState, send, MSG_DAY_TASK_COMPLETE } from "../client";
 import { renderKey, renderStrip, stripTags, truncate } from "../render";
 
-@action({ UUID: "app.dayglance.streamdeck.up-next" })
+@action({ UUID: "com.dayglance.streamdeck.up-next" })
 export class UpNextAction extends SingletonAction {
   private unsubscribe: (() => void) | null = null;
   private lastState: DayGlanceState | null = null;


### PR DESCRIPTION
Fixes all 7 errors and 9 warnings reported by `streamdeck pack` after the SDK v3 upgrade.

**Errors fixed:**
- `KeyDescription` removed from Agenda action (property dropped in SDK v3)
- `TouchTap` removed from `Encoder.TriggerDescription` in all 6 encoder actions (property dropped in SDK v3)

**Warnings fixed:**
- All 9 action UUIDs renamed from `app.dayglance.streamdeck.*` → `com.dayglance.streamdeck.*` to match the plugin bundle ID prefix as required by the SDK v3 validator
- Matching `@action({ UUID: ... })` decorators updated in all 10 TypeScript source files

## Test plan
- [ ] `npm run build` — clean
- [ ] `streamdeck pack com.dayglance.streamdeck.sdPlugin` — should report 0 errors, 0 warnings

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_