### PR TITLE
feat(electron): macOS drag strip + remove logo from desktop header

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,7 +1,8 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, process } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   isElectron: true,
+  platform: process.platform,
 
   // Renderer pushes app state to connected WebSocket clients (e.g. Stream Deck plugin)
   pushState: (state: unknown) => ipcRenderer.send('ws:push-state', state),

--- a/src/components/DesktopHeader.jsx
+++ b/src/components/DesktopHeader.jsx
@@ -93,13 +93,9 @@ const DesktopHeader = () => {
           })()}
         </div>
 
-        {/* Center: Logo + Date Nav */}
-        {/* Narrow (<1080px): shift up + stack Today below. Wide: original 3-col grid centered. */}
-        <div className="absolute inset-0 flex items-start pt-2 min-[1080px]:items-center min-[1080px]:pt-0 justify-center max-[950px]:pr-36 pointer-events-none">
-        <div className="flex flex-col items-center gap-1 min-[1080px]:grid min-[1080px]:grid-cols-[1fr_auto_1fr] min-[1080px]:gap-0 pointer-events-auto">
-          <div className="hidden min-[1080px]:flex justify-end pr-2">
-            <img src={darkMode ? '/dayglance-dark.svg' : '/dayglance-light.svg'} alt="dayGLANCE" className="h-10" />
-          </div>
+        {/* Center: Date Nav */}
+        <div className="absolute inset-0 flex items-center justify-center max-[950px]:pr-36 pointer-events-none">
+        <div className="pointer-events-auto">
           <div className="flex items-center gap-1 relative">
             <button onClick={() => changeDate(-1)} className={`p-1.5 rounded-lg ${hoverBg} transition-colors`} aria-label="Previous day">
               <ChevronLeft size={20} className={textSecondary} />
@@ -119,6 +115,12 @@ const DesktopHeader = () => {
             </button>
             <button onClick={() => changeDate(1)} className={`p-1.5 rounded-lg ${hoverBg} transition-colors`} aria-label="Next day">
               <ChevronRight size={20} className={textSecondary} />
+            </button>
+            <button
+              onClick={goToToday}
+              className={`ml-1 px-3 py-1 text-xs bg-blue-600 text-white rounded-full hover:bg-blue-700 transition-colors${dateToString(selectedDate) === dateToString(new Date()) ? ' invisible' : ''}`}
+            >
+              Today
             </button>
             {/* Month View Popup */}
             {showMonthView && (
@@ -166,14 +168,6 @@ const DesktopHeader = () => {
                 </div>
               </div>
             )}
-          </div>
-          <div className="flex min-[1080px]:justify-start min-[1080px]:pl-5">
-            <button
-              onClick={goToToday}
-              className={`px-3 py-1 text-xs bg-blue-600 text-white rounded-full hover:bg-blue-700 transition-colors${dateToString(selectedDate) === dateToString(new Date()) ? ' invisible' : ''}`}
-            >
-              Today
-            </button>
           </div>
         </div>
         </div>

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -423,8 +423,15 @@ const DesktopLayout = () => {
   } = useFeaturesCtx();
 
 
+  const isElectronMac = window.electronAPI?.isElectron && window.electronAPI?.platform === 'darwin';
+  const titlebarH = isElectronMac ? 28 : 0;
+
   return (
       <>
+      {/* macOS traffic-light drag region — sits above the header so content clears the buttons */}
+      {isElectronMac && (
+        <div style={{ height: titlebarH, WebkitAppRegion: 'drag', flexShrink: 0 }} />
+      )}
       {/* Desktop & Tablet Layout */}
       {!isTablet && <DesktopHeader />}
 
@@ -617,7 +624,7 @@ const DesktopLayout = () => {
       )}
 
       {/* Content area: side panel + calendar */}
-      <div className="flex" style={{ height: isTablet ? 'calc(100vh - 56px - env(safe-area-inset-top, 0px))' : 'calc(100vh - 80px - env(safe-area-inset-top, 0px))' }}>
+      <div className="flex" style={{ height: isTablet ? 'calc(100vh - 56px - env(safe-area-inset-top, 0px))' : `calc(100vh - ${80 + titlebarH}px - env(safe-area-inset-top, 0px))` }}>
 
         <div className="contents">
 


### PR DESCRIPTION
## Summary

- **macOS drag strip**: adds a 28px transparent `WebkitAppRegion: drag` region at the very top of the window. Traffic light buttons now sit inside this zone rather than overlapping the weather widget, and the window can be dragged normally. Platform is exposed via `process.platform` in preload so the strip only renders on `darwin` — Windows keeps its native title bar and is unaffected. The content area height calculation is adjusted by the same 28px so nothing is clipped.

- **Logo removed from desktop header**: the dayGLANCE logo has been removed from the center of the header. In a native desktop app it's redundant — the dock icon and window switcher already identify the app. The date navigation now sits cleanly centered on its own, with the Today button moved inline next to the arrows rather than in a separate grid column.

## Test plan

- [ ] macOS: window can be dragged by clicking anywhere in the 28px strip at the top
- [ ] macOS: weather widget is no longer overlapped by the traffic light buttons
- [ ] macOS: traffic lights (red/yellow/green) still appear and function correctly
- [ ] Windows: no visible change — native title bar works as before
- [ ] Header center shows `‹ [date range] › Today` with Today hidden when on today's date
- [ ] Month picker still opens on date click

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_