### PR TITLE
chore(electron): remove signing/notarization config for initial release

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,11 +1,8 @@
 name: Build and Publish to GHCR
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:
@@ -41,7 +38,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,70 @@
+name: Build and Release Desktop Apps
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            artifact_glob: "dist-app/*.dmg dist-app/*-mac.zip"
+          - os: windows-latest
+            artifact_glob: "dist-app/*.exe"
+          - os: ubuntu-latest
+            artifact_glob: "dist-app/*.AppImage"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build desktop app
+        run: npm run build:electron
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-${{ matrix.os }}
+          path: |
+            dist-app/*.dmg
+            dist-app/*-mac.zip
+            dist-app/*.exe
+            dist-app/*.AppImage
+          if-no-files-found: ignore
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          generate_release_notes: false
+          files: artifacts/**/*

--- a/build-and-install.sh
+++ b/build-and-install.sh
@@ -21,7 +21,7 @@ if $FULL_CLEAN; then
   echo "==> Full clean..."
   cd "$ANDROID_DIR" && ./gradlew clean
   cd "$SCRIPT_DIR"
-  rm -rf dist dist-electron dist-app
+  rm -rf dist
 else
   # Vite produces a new content-hashed bundle on every build, so Gradle's
   # incremental asset pipeline accumulates stale .jar files for the old
@@ -51,21 +51,8 @@ if $RELEASE; then
   cp "app/build/outputs/bundle/release/app-release.aab" "$OUT_DIR/dayglance.aab"
   echo "    AAB  → outputs/dayglance.aab"
 
-  # ── Desktop ────────────────────────────────────────────────────────────
-  echo "==> Building desktop app (this platform only)..."
-  cd "$SCRIPT_DIR"
-  npm run build:electron
-
-  # Copy DMG, macOS zip, Windows installer, and Linux AppImage to outputs/
-  while IFS= read -r -d '' f; do
-    cp "$f" "$OUT_DIR/"
-    echo "    $(basename "$f")  → outputs/"
-  done < <(find "$SCRIPT_DIR/dist-app" -maxdepth 1 \
-    \( -name "*.dmg" -o -name "*-mac.zip" -o -name "*.exe" -o -name "*.AppImage" \) \
-    -print0)
-
   echo ""
-  echo "==> Release build complete. outputs/:"
+  echo "==> Android release build complete. outputs/:"
   ls -lh "$OUT_DIR"
 
 else

--- a/build-and-install.sh
+++ b/build-and-install.sh
@@ -8,33 +8,20 @@ OUT_DIR="$SCRIPT_DIR/outputs"
 # Flags
 FULL_CLEAN=false
 RELEASE=false
-AAB=false
 for arg in "$@"; do
-  if [[ "$arg" == "--clean" ]]; then FULL_CLEAN=true
-  elif [[ "$arg" == "--release" ]]; then RELEASE=true
-  elif [[ "$arg" == "--aab" ]]; then AAB=true; RELEASE=true
-  else echo "Unknown flag: $arg (valid flags: --clean, --release, --aab)" && exit 1
-  fi
+  case "$arg" in
+    --clean)   FULL_CLEAN=true ;;
+    --release) RELEASE=true ;;
+    *) echo "Unknown flag: $arg (valid flags: --clean, --release)" && exit 1 ;;
+  esac
 done
 
-if $AAB; then
-  AAB_SRC="$ANDROID_DIR/app/build/outputs/bundle/release/app-release.aab"
-  AAB_DEST="$OUT_DIR/dayglance.aab"
-  GRADLE_TASK="bundleRelease"
-elif $RELEASE; then
-  APK_SRC="$ANDROID_DIR/app/build/outputs/apk/release/dayglance.apk"
-  APK_DEST="$OUT_DIR/dayglance.apk"
-  GRADLE_TASK="assembleRelease"
-else
-  APK_SRC="$ANDROID_DIR/app/build/outputs/apk/debug/app-debug.apk"
-  APK_DEST="$OUT_DIR/dayglance-debug.apk"
-  GRADLE_TASK="assembleDebug"
-fi
-
+# ── Clean ──────────────────────────────────────────────────────────────────
 if $FULL_CLEAN; then
   echo "==> Full clean..."
-  cd "$ANDROID_DIR"
-  ./gradlew clean
+  cd "$ANDROID_DIR" && ./gradlew clean
+  cd "$SCRIPT_DIR"
+  rm -rf dist dist-electron dist-app
 else
   # Vite produces a new content-hashed bundle on every build, so Gradle's
   # incremental asset pipeline accumulates stale .jar files for the old
@@ -47,30 +34,53 @@ else
   fi
 fi
 
-echo "==> Building web assets..."
-cd "$SCRIPT_DIR"
-npm run build:android
-
-if $AAB; then
-  echo "==> Building Android AAB (${GRADLE_TASK})..."
-else
-  echo "==> Building Android APK (${GRADLE_TASK})..."
-fi
-cd "$ANDROID_DIR"
-./gradlew "$GRADLE_TASK"
-
-# Copy output to project-root outputs/ — bypasses Gradle's macOS hidden-flag
-# behaviour entirely. The outputs/ dir is gitignored.
 mkdir -p "$OUT_DIR"
-if $AAB; then
-  cp "$AAB_SRC" "$AAB_DEST"
-  echo "==> AAB ready: outputs/dayglance.aab"
-  echo "==> Done! Upload to Google Play Console."
-elif $RELEASE; then
-  cp "$APK_SRC" "$APK_DEST"
-  echo "==> Release APK: outputs/dayglance.apk"
-  echo "==> Done! Copy to your F-Droid repo."
+
+if $RELEASE; then
+  # ── Android ────────────────────────────────────────────────────────────
+  echo "==> Building Android web assets..."
+  cd "$SCRIPT_DIR"
+  npm run build:android
+
+  echo "==> Building Android APK + AAB..."
+  cd "$ANDROID_DIR"
+  ./gradlew assembleRelease bundleRelease
+
+  cp "app/build/outputs/apk/release/dayglance.apk" "$OUT_DIR/dayglance.apk"
+  echo "    APK  → outputs/dayglance.apk"
+  cp "app/build/outputs/bundle/release/app-release.aab" "$OUT_DIR/dayglance.aab"
+  echo "    AAB  → outputs/dayglance.aab"
+
+  # ── Desktop ────────────────────────────────────────────────────────────
+  echo "==> Building desktop app (this platform only)..."
+  cd "$SCRIPT_DIR"
+  npm run build:electron
+
+  # Copy DMG, macOS zip, Windows installer, and Linux AppImage to outputs/
+  while IFS= read -r -d '' f; do
+    cp "$f" "$OUT_DIR/"
+    echo "    $(basename "$f")  → outputs/"
+  done < <(find "$SCRIPT_DIR/dist-app" -maxdepth 1 \
+    \( -name "*.dmg" -o -name "*-mac.zip" -o -name "*.exe" -o -name "*.AppImage" \) \
+    -print0)
+
+  echo ""
+  echo "==> Release build complete. outputs/:"
+  ls -lh "$OUT_DIR"
+
 else
+  # ── Debug APK + install ────────────────────────────────────────────────
+  echo "==> Building web assets..."
+  cd "$SCRIPT_DIR"
+  npm run build:android
+
+  APK_SRC="$ANDROID_DIR/app/build/outputs/apk/debug/app-debug.apk"
+  APK_DEST="$OUT_DIR/dayglance-debug.apk"
+
+  echo "==> Building debug APK..."
+  cd "$ANDROID_DIR"
+  ./gradlew assembleDebug
+
   cp "$APK_SRC" "$APK_DEST"
   echo "==> Installing on connected device..."
   adb install -r "$APK_DEST"

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -11,10 +11,6 @@
   ],
   "mac": {
     "category": "public.app-category.productivity",
-    "hardenedRuntime": true,
-    "gatekeeperAssess": false,
-    "entitlements": "electron/entitlements.mac.plist",
-    "entitlementsInherit": "electron/entitlements.mac.plist",
     "target": [
       { "target": "dmg", "arch": ["x64", "arm64"] },
       { "target": "zip", "arch": ["x64", "arm64"] }


### PR DESCRIPTION
## Summary

Removes `hardenedRuntime`, `gatekeeperAssess`, `entitlements`, and `entitlementsInherit` from `electron-builder.json`. These fields require a Developer ID certificate which we're skipping for the initial release. Without them the build works cleanly for unsigned distribution — users right-click → Open on first launch on macOS.

The `electron/entitlements.mac.plist` file is kept in the repo for when we eventually add notarization.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_