### PR TITLE
fix: DAY scroll truncation, DAY hover over frames, WEEK timeline truncation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -320,6 +320,11 @@ const DayPlanner = () => {
     return saved !== null ? JSON.parse(saved) : 0; // 0=Sunday, 1=Monday
   });
   useEffect(() => { localStorage.setItem('day-planner-week-start-day', JSON.stringify(weekStartDay)); }, [weekStartDay]);
+  const [weekTimelineStartHour, setWeekTimelineStartHour] = useState(() => {
+    const saved = localStorage.getItem('day-planner-week-timeline-start-hour');
+    return saved !== null ? JSON.parse(saved) : 0;
+  });
+  useEffect(() => { localStorage.setItem('day-planner-week-timeline-start-hour', JSON.stringify(weekTimelineStartHour)); }, [weekTimelineStartHour]);
   const { weather, setWeather, weatherZip, setWeatherZip, weatherTempUnit, setWeatherTempUnit, fetchWeather } = useWeather();
   const [weatherEnabled, setWeatherEnabled] = useState(() => {
     const saved = localStorage.getItem('day-planner-weather-enabled');
@@ -7117,6 +7122,7 @@ const DayPlanner = () => {
     use24HourClock, setUse24HourClock,
     inboxAutoArchiveDays, setInboxAutoArchiveDays,
     weekStartDay, setWeekStartDay,
+    weekTimelineStartHour, setWeekTimelineStartHour,
     minimizedSections, setMinimizedSections,
     showSettings, setShowSettings,
     collapsedSettings, setCollapsedSettings,

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -164,17 +164,25 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     handleDropOnCalendar(e, col.date, t);
   };
 
-  // Only show hover preview when the cursor is over an empty hour-row
-  // cell (day-col-slot). Hovering over task cards, frames, or the gutter
-  // should leave the preview cleared.
-  const isOverEmptySlot = (target) => target && target.classList && target.classList.contains('day-col-slot');
+  // Block hover/click only when the cursor is directly over a task card.
+  // Frames need pointer-events for context menus and resize handles, so
+  // checking for the exact day-col-slot class is too strict — it kills hover
+  // over any frame area. Walk up from e.target instead.
+  const isOverTaskCard = (target) => {
+    let el = target;
+    while (el && el !== colContentRef.current) {
+      if (el.dataset?.taskId) return true;
+      el = el.parentElement;
+    }
+    return false;
+  };
 
   const onColMouseMove = (e) => {
     if (draggedTask || isResizing || frameResizingRef.current) {
       if (hoverPreviewTime) { setHoverPreviewTime(null); setHoverPreviewDate(null); }
       return;
     }
-    if (!isOverEmptySlot(e.target)) {
+    if (isOverTaskCard(e.target)) {
       if (hoverPreviewTime) { setHoverPreviewTime(null); setHoverPreviewDate(null); }
       return;
     }
@@ -191,7 +199,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const onColClick = (e) => {
     if (frameResizingRef.current) return;
     if (draggedTask) return;
-    if (!isOverEmptySlot(e.target)) return;
+    if (isOverTaskCard(e.target)) return;
     const t = timeFromEvent(e);
     setNewTask({ title: '', startTime: t, duration: 30, date: col.dateStr, isAllDay: false });
     setShowAddTask(true);

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -20,6 +20,7 @@ const SettingsModal = () => {
     use24HourClock, setUse24HourClock,
     inboxAutoArchiveDays, setInboxAutoArchiveDays,
     weekStartDay, setWeekStartDay,
+    weekTimelineStartHour, setWeekTimelineStartHour,
     soundEnabled, setSoundEnabled,
     setOnboardingProgress,
     isMobile, isTablet,
@@ -231,6 +232,24 @@ const SettingsModal = () => {
                           >
                             24-hour
                           </button>
+                        </div>
+                      </div>
+                      <div>
+                        <label className={`block text-xs ${textSecondary} mb-1.5`}>Week timeline start</label>
+                        <div className="flex flex-wrap gap-2">
+                          {[0, 4, 5, 6, 7].map(h => (
+                            <button
+                              key={h}
+                              onClick={() => setWeekTimelineStartHour(h)}
+                              className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${
+                                weekTimelineStartHour === h
+                                  ? 'bg-blue-600 text-white'
+                                  : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`
+                              }`}
+                            >
+                              {h === 0 ? '12am' : `${h}am`}
+                            </button>
+                          ))}
                         </div>
                       </div>
                       <div>

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -104,7 +104,7 @@ const fmtDur = (min) => {
   return min < 60 ? `${min}m` : m ? `${h}h${m}m` : `${h}h`;
 };
 
-const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, activePopoverTaskId, isToday }) => {
+const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, startHour, onTaskClick, activePopoverTaskId, isToday }) => {
   const {
     darkMode, borderClass, cardBg,
     getTasksForDate, getTaskCalendarStyle,
@@ -126,10 +126,11 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
   // Compute the snapped drop time for the cursor Y relative to this
   // week-view column. Week columns always span 00:00..24:00, so startMinute
   // is 0 and the max is clamped to 23:45 (minus the dragged task's length).
+  const startMinute = startHour * 60;
   const timeFromEvent = (e, { taskDuration = 0 } = {}) => columnTimeFromEvent(e, colRef.current, {
-    startMinute: 0,
+    startMinute,
     hourHeight,
-    minMinute: 0,
+    minMinute: startMinute,
     maxMinute: 24 * 60,
     taskDuration,
   });
@@ -170,7 +171,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
 
   const now = new Date();
   const nowMinutes = now.getHours() * 60 + now.getMinutes();
-  const nowY = isToday ? nowMinutes * hourHeight / 60 : 0;
+  const nowY = isToday ? (nowMinutes - startMinute) * hourHeight / 60 : 0;
   const altRow = darkMode ? 'bg-white/[0.04]' : 'bg-stone-100/50';
 
   const hgBars = goalsProjectsEnabled
@@ -201,29 +202,32 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
       onDrop={onColDrop}
       className={`flex-1 flex flex-col min-w-0 relative ${colIdx > 0 ? `border-l ${borderClass}` : ''} ${isToday ? (darkMode ? 'bg-blue-900/10' : 'bg-blue-50/40') : ''}`}
     >
-      {/* Hour rows */}
-      {Array.from({ length: 24 }, (_, hour) => (
-        <div
-          key={hour}
-          className="relative"
-          style={{ height: `${hourHeight}px` }}
-          onContextMenu={(e) => {
-            e.preventDefault();
-            const rect = e.currentTarget.getBoundingClientRect();
-            const fraction = Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height));
-            const minutes = hour * 60 + Math.round(fraction * 60 / 15) * 15;
-            setTimelineContextMenu({ x: e.clientX, y: e.clientY, dateStr, timeMinutes: minutes });
-          }}
-        >
-          <div className={`border-b h-full ${borderClass} ${hour % 2 === 1 ? altRow : ''}`} />
+      {/* Hour rows — only render visible hours */}
+      {Array.from({ length: 24 - startHour }, (_, i) => {
+        const hour = startHour + i;
+        return (
           <div
-            className="absolute left-0 right-0 pointer-events-none"
-            style={{ top: `${hourHeight / 2}px` }}
+            key={hour}
+            className="relative"
+            style={{ height: `${hourHeight}px` }}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              const rect = e.currentTarget.getBoundingClientRect();
+              const fraction = Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height));
+              const minutes = hour * 60 + Math.round(fraction * 60 / 15) * 15;
+              setTimelineContextMenu({ x: e.clientX, y: e.clientY, dateStr, timeMinutes: minutes });
+            }}
           >
-            <div className={`border-b border-dashed ${borderClass} opacity-30`} />
+            <div className={`border-b h-full ${borderClass} ${hour % 2 === 1 ? altRow : ''}`} />
+            <div
+              className="absolute left-0 right-0 pointer-events-none"
+              style={{ top: `${hourHeight / 2}px` }}
+            >
+              <div className={`border-b border-dashed ${borderClass} opacity-30`} />
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
 
       {/* Now line — today's column only */}
       {isToday && (
@@ -242,7 +246,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
       {getFrameInstancesForDate(date).map(frame => {
         const fStartMin = timeToMinutes(frame.start);
         const fEndMin = timeToMinutes(frame.end);
-        const top = fStartMin * hourHeight / 60;
+        const top = (fStartMin - startMinute) * hourHeight / 60;
         const height = Math.max((fEndMin - fStartMin) * hourHeight / 60, 4);
         const bg = frameColorBg(frame.color, darkMode);
         const border = frameColorBorder(frame.color, darkMode);
@@ -266,7 +270,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
             const [bh, bm] = effectiveTime.split(':').map(Number);
             const startMin = bh * 60 + bm;
             const dur = bar.isCompleted ? 15 : (hg.scheduledDurationOverrides?.[bar.date] || hg.scheduledDuration || 60);
-            const barTop = startMin * hourHeight / 60;
+            const barTop = (startMin - startMinute) * hourHeight / 60;
             const barH = Math.max(dur * hourHeight / 60, 18);
             const barColor = hg.color || '#4f46e5';
             const IconComp = Icons[hg.icon] || Icons.Sparkles;
@@ -307,7 +311,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
           const duration = task.duration || 0;
           const rawH = duration * hourHeight / 60;
           const chipH = Math.max(22, rawH);
-          const chipTop = taskStart * hourHeight / 60;
+          const chipTop = (taskStart - startMinute) * hourHeight / 60;
           const { left, right, width } = weekColConflictPos(task, colTasks, timeToMinutes);
 
           const isImported = task.imported;
@@ -418,10 +422,10 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
           const items = [];
 
           assignments.filter(({ r, col }) => col < 2 && !hiddenCol1.has(r.id)).forEach(({ r, col }) => {
-            const rawTop = timeToMinutes(r.startTime) * hourHeight / 60;
+            const rawTop = (timeToMinutes(r.startTime) - startMinute) * hourHeight / 60;
             const h = Math.max(22, r.duration * hourHeight / 60);
             // Clamp top so the chip never straddles the next hour line
-            const nextHourPx = (Math.floor(timeToMinutes(r.startTime) / 60) + 1) * hourHeight;
+            const nextHourPx = (Math.floor(timeToMinutes(r.startTime) / 60) + 1 - startHour) * hourHeight;
             const top = Math.min(rawTop, nextHourPx - h);
             const hasVisiblePartner = assignments.some(({ r: pr, col: pc }) =>
               pc === (1 - col) && !hiddenCol1.has(pr.id) && rangesOverlap(r, pr)
@@ -453,7 +457,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
             items.push(
               <div key={`overflow-${i}`}
                 className="absolute pointer-events-auto flex items-center justify-center cursor-pointer"
-                style={{ top: `${Math.min(sp.s * hourHeight / 60, (Math.floor(sp.s / 60) + 1) * hourHeight - Math.max(22, (sp.e - sp.s) * hourHeight / 60))}px`, height: `${Math.max(22, (sp.e - sp.s) * hourHeight / 60)}px`, left: 'calc(50% + 1px)', right: '1px', zIndex: 6 }}
+                style={{ top: `${Math.min((sp.s - startMinute) * hourHeight / 60, (Math.floor(sp.s / 60) + 1 - startHour) * hourHeight - Math.max(22, (sp.e - sp.s) * hourHeight / 60))}px`, height: `${Math.max(22, (sp.e - sp.s) * hourHeight / 60)}px`, left: 'calc(50% + 1px)', right: '1px', zIndex: 6 }}
                 onClick={(e) => { e.stopPropagation(); setOverflowPopover({ routines: sp.routines, rect: e.currentTarget.getBoundingClientRect() }); }}>
                 <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${darkMode ? 'bg-teal-700/60 text-teal-200' : 'bg-teal-500/60 text-white'}`}>
                   +{sp.routines.length}
@@ -469,7 +473,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, onTaskClick, active
       {/* Drag preview bar — shows target day + time during an active drag */}
       {isDraggingOverThisCol && dragPreviewTime && (() => {
         const dragMin = timeToMinutes(dragPreviewTime);
-        const topPx = dragMin * hourHeight / 60;
+        const topPx = (dragMin - startMinute) * hourHeight / 60;
         return (
           <div
             className="absolute left-0 right-0 pointer-events-none z-30"
@@ -525,9 +529,14 @@ const WeekView = () => {
     cardBg,
     expandedNotesTaskId, setExpandedNotesTaskId,
     getTasksForDate,
+    weekTimelineStartHour,
   } = useDayPlannerCtx();
 
-  const hourHeight = useWeekViewHourHeight(calendarRef, stickyHeaderRef);
+  const [showAllHours, setShowAllHours] = useState(false);
+  const startHour = showAllHours ? 0 : weekTimelineStartHour;
+  const visibleHours = 24 - startHour;
+
+  const hourHeight = useWeekViewHourHeight(calendarRef, stickyHeaderRef, visibleHours);
   const [popoverTask, setPopoverTask] = useState(null);
   const [popoverAnchor, setPopoverAnchor] = useState(null);
 
@@ -565,27 +574,38 @@ const WeekView = () => {
     <div className="flex" style={{ height: '100%' }}>
       {/* Hour-label gutter */}
       <div
-        className={`flex-shrink-0 border-r ${borderClass} flex flex-col`}
+        className={`flex-shrink-0 border-r ${borderClass} flex flex-col relative`}
         style={{ width: WEEK_GUTTER_W }}
       >
-        {Array.from({ length: 24 }, (_, hour) => (
-          <div
-            key={hour}
-            className="relative flex-shrink-0"
-            style={{ height: `${hourHeight}px` }}
+        {weekTimelineStartHour > 0 && (
+          <button
+            onClick={() => setShowAllHours(v => !v)}
+            className={`absolute top-1 left-0 right-0 z-10 text-[9px] text-center leading-none px-1 transition-colors ${showAllHours ? 'text-blue-500' : textSecondary} hover:text-blue-500`}
           >
-            {hour % 3 === 0 && (
-              <span
-                className={`absolute top-0.5 right-2 text-[10px] leading-none ${textSecondary} select-none`}
-              >
-                {use24HourClock
-                  ? `${String(hour).padStart(2, '0')}:00`
-                  : hour === 0 ? '12 AM' : hour === 12 ? '12 PM' : hour < 12 ? `${hour} AM` : `${hour - 12} PM`
-                }
-              </span>
-            )}
-          </div>
-        ))}
+            {showAllHours ? 'trim' : `▲ ${use24HourClock ? `${String(weekTimelineStartHour).padStart(2,'0')}:00` : weekTimelineStartHour < 12 ? `${weekTimelineStartHour}am` : '12pm'}`}
+          </button>
+        )}
+        {Array.from({ length: visibleHours }, (_, i) => {
+          const hour = startHour + i;
+          return (
+            <div
+              key={hour}
+              className="relative flex-shrink-0"
+              style={{ height: `${hourHeight}px` }}
+            >
+              {hour % 3 === 0 && (
+                <span
+                  className={`absolute top-0.5 right-2 text-[10px] leading-none ${textSecondary} select-none`}
+                >
+                  {use24HourClock
+                    ? `${String(hour).padStart(2, '0')}:00`
+                    : hour === 0 ? '12 AM' : hour === 12 ? '12 PM' : hour < 12 ? `${hour} AM` : `${hour - 12} PM`
+                  }
+                </span>
+              )}
+            </div>
+          );
+        })}
       </div>
 
       {/* Day columns */}
@@ -598,6 +618,7 @@ const WeekView = () => {
             dateStr={dateStr}
             colIdx={colIdx}
             hourHeight={hourHeight}
+            startHour={startHour}
             onTaskClick={handleTaskClick}
             activePopoverTaskId={popoverTask?.id}
             isToday={dateStr === todayStr}

--- a/src/hooks/useDayViewHourHeight.js
+++ b/src/hooks/useDayViewHourHeight.js
@@ -14,6 +14,11 @@ export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
       const stickyH = stickyHeaderRef?.current?.offsetHeight || 0;
       const usable = Math.max(160, totalH - stickyH);
       setHourHeight(Math.max(20, usable / 8));
+      // DAY view is overflow:hidden and must never scroll. Any scroll drift
+      // (browser restoration, scroll anchoring, stale timers) gets reset here
+      // on every measurement, including ResizeObserver callbacks that fire
+      // when the tab is restored after prolonged background time.
+      calendarRef.current.scrollTop = 0;
     };
 
     // Defer first measurement by one frame so the sticky header ref is populated.

--- a/src/hooks/useTimelineScroll.js
+++ b/src/hooks/useTimelineScroll.js
@@ -52,7 +52,8 @@ export default function useTimelineScroll({
     }
     const isToday = dateToString(selectedDate) === dateToString(new Date());
     if (isToday && calendarRef.current && (!isMobile || mobileActiveTab === 'timeline')) {
-      setTimeout(() => scrollToCurrentHour(false), 100);
+      const timerId = setTimeout(() => scrollToCurrentHour(false), 100);
+      return () => clearTimeout(timerId);
     }
   }, [selectedDate, isMobile, mobileActiveTab, scrollToCurrentHour, viewMode]);
 

--- a/src/hooks/useWeekViewHourHeight.js
+++ b/src/hooks/useWeekViewHourHeight.js
@@ -1,6 +1,6 @@
 import { useState, useLayoutEffect } from 'react';
 
-export default function useWeekViewHourHeight(calendarRef, stickyHeaderRef) {
+export default function useWeekViewHourHeight(calendarRef, stickyHeaderRef, visibleHours = 24) {
   const [hourHeight, setHourHeight] = useState(33);
 
   useLayoutEffect(() => {
@@ -9,7 +9,7 @@ export default function useWeekViewHourHeight(calendarRef, stickyHeaderRef) {
       const totalH = calendarRef.current.clientHeight;
       const stickyH = stickyHeaderRef?.current?.offsetHeight || 0;
       const usable = Math.max(240, totalH - stickyH);
-      setHourHeight(Math.max(10, usable / 24));
+      setHourHeight(Math.max(10, usable / visibleHours));
     };
 
     const rafId = requestAnimationFrame(() => {
@@ -25,7 +25,7 @@ export default function useWeekViewHourHeight(calendarRef, stickyHeaderRef) {
       cancelAnimationFrame(rafId);
       roRef?.disconnect();
     };
-  }, []); // refs are stable objects — no deps needed
+  }, [visibleHours]); // refs are stable; visibleHours changes when truncation toggles
 
   return hourHeight;
 }


### PR DESCRIPTION
## Summary

**Bug 1 — DAY view top truncation (two-layer fix)**

- `useTimelineScroll`: the 100ms `scrollToCurrentHour` timeout had no cleanup — switching from MULTI to DAY quickly let the stale timer fire and set `scrollTop` to the current-hour position on the `overflow:hidden` container, clipping the first visible hour. Fixed with `return () => clearTimeout(timerId)`.
- `useDayViewHourHeight`: added `calendarRef.current.scrollTop = 0` inside `compute()`. This hook already fires on every ResizeObserver callback, including when a backgrounded tab is restored after hours. Any scroll drift from browser scroll restoration, scroll anchoring, or any other source is corrected the moment the container is remeasured.

**Bug 2 — No hover line / click-to-add over frames in DAY view**

`isOverEmptySlot` required `e.target` to literally be the `.day-col-slot` div. Frame backgrounds have `pointer-events-auto` for context menus and resize handles, so they always intercepted the mouse — `e.target` was never the slot div. Replaced with `isOverTaskCard()` which walks up from `e.target` checking for `data-task-id`, blocking hover only over actual task cards. Frames, routines, and HG bars now allow hover and click-to-add.

**Bug 3 — WEEK timeline truncation**

New `weekTimelineStartHour` setting (Settings → Time Format, presets: 12am / 4am / 5am / 6am / 7am). When set, the WEEK view renders only hours from that time to midnight, giving each visible hour more vertical space. A small `▲ Xam` button in the gutter lets you temporarily expand to all 24 hours when needed. `useWeekViewHourHeight` now divides usable height by visible hours rather than hardcoded 24.

## Test plan

- [ ] DAY view: switch quickly from MULTI → DAY — first hour should never be clipped
- [ ] DAY view: leave app for 30+ min, return — first hour should still be fully visible
- [ ] DAY view: hover over frame background — blue line appears, click opens add-task
- [ ] DAY view: hover over task card — no blue line
- [ ] WEEK view: set timeline start to 6am in Settings — hours 12am–5:59am hidden, more space per hour
- [ ] WEEK view: click `▲ 6am` toggle in gutter — all 24 hours shown
- [ ] WEEK view: task chips, frames, HG bars, routines all positioned correctly at the new offset

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_