### PR TITLE
fix: WEEK toggle button overlap and merged-branch push guard

### DIFF
--- a/.claude/hooks/guard-push.sh
+++ b/.claude/hooks/guard-push.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Blocks `git push` when the current branch already has a merged PR.
+# Reads a Bash tool call from stdin (JSON with .tool_input.command).
+
+command=$(jq -r '.tool_input.command // ""' 2>/dev/null)
+
+# Only act on git push commands
+if ! echo "$command" | grep -qE '^\s*git\s+push'; then
+  exit 0
+fi
+
+branch=$(git -C "$CLAUDE_PROJECT_DIR" branch --show-current 2>/dev/null)
+if [ -z "$branch" ]; then
+  exit 0
+fi
+
+# URL-encode the branch name (replace / with %2F)
+branch_encoded="${branch//\//%2F}"
+
+# Query GitHub API for any closed PR on this branch
+response=$(curl -s \
+  "https://api.github.com/repos/krelltunez/dayGLANCE/pulls?state=closed&head=krelltunez:${branch_encoded}&per_page=1")
+
+merged_at=$(echo "$response" | jq -r 'if (type == "array") and (length > 0) and (.[0].merged_at != null) then .[0].merged_at else "null" end' 2>/dev/null)
+
+if [ "$merged_at" != "null" ] && [ -n "$merged_at" ]; then
+  pr_number=$(echo "$response" | jq -r '.[0].number' 2>/dev/null)
+  printf '{"continue":false,"stopReason":"Branch '"'"'%s'"'"' already has a merged PR (#%s) — per CLAUDE.md, create a new branch from the correct base (electron-develop or main) before pushing."}\n' \
+    "$branch" "$pr_number"
+  exit 0
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,17 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-push.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -577,23 +577,29 @@ const WeekView = () => {
         className={`flex-shrink-0 border-r ${borderClass} flex flex-col relative`}
         style={{ width: WEEK_GUTTER_W }}
       >
-        {weekTimelineStartHour > 0 && (
-          <button
-            onClick={() => setShowAllHours(v => !v)}
-            className={`absolute top-1 left-0 right-0 z-10 text-[9px] text-center leading-none px-1 transition-colors ${showAllHours ? 'text-blue-500' : textSecondary} hover:text-blue-500`}
-          >
-            {showAllHours ? 'trim' : `▲ ${use24HourClock ? `${String(weekTimelineStartHour).padStart(2,'0')}:00` : weekTimelineStartHour < 12 ? `${weekTimelineStartHour}am` : '12pm'}`}
-          </button>
-        )}
         {Array.from({ length: visibleHours }, (_, i) => {
           const hour = startHour + i;
+          const isToggleRow = weekTimelineStartHour > 0 && hour === weekTimelineStartHour;
+          const toggleLabel = use24HourClock
+            ? `${String(weekTimelineStartHour).padStart(2, '0')}:00`
+            : weekTimelineStartHour === 0 ? '12AM'
+            : weekTimelineStartHour === 12 ? '12PM'
+            : weekTimelineStartHour < 12 ? `${weekTimelineStartHour}AM`
+            : `${weekTimelineStartHour - 12}PM`;
           return (
             <div
               key={hour}
               className="relative flex-shrink-0"
               style={{ height: `${hourHeight}px` }}
             >
-              {hour % 3 === 0 && (
+              {isToggleRow ? (
+                <button
+                  onClick={() => setShowAllHours(v => !v)}
+                  className="absolute top-0.5 right-2 text-[10px] leading-none text-blue-500 hover:text-blue-400 transition-colors select-none"
+                >
+                  {showAllHours ? `▼ ${toggleLabel}` : `▲ ${toggleLabel}`}
+                </button>
+              ) : (hour % 3 === 0 && (
                 <span
                   className={`absolute top-0.5 right-2 text-[10px] leading-none ${textSecondary} select-none`}
                 >
@@ -602,7 +608,7 @@ const WeekView = () => {
                     : hour === 0 ? '12 AM' : hour === 12 ? '12 PM' : hour < 12 ? `${hour} AM` : `${hour - 12} PM`
                   }
                 </span>
-              )}
+              ))}
             </div>
           );
         })}


### PR DESCRIPTION
## Summary

- **WEEK toggle button**: the old absolute-positioned overlay ("trim" / "▲ 7am") sat at `top-1` in the gutter container, exactly where the "12 AM" hour label lives — they collided into "t12AM". Replaced with an inline button inside the correct hour row. When trimmed shows `▲ 7AM` at the start-hour row (which is the first visible row anyway); when expanded shows `▼ 7AM` at that same row scrolled into view. Text is `text-[10px]` to match other hour markers, uppercase AM/PM format.

- **Merged-branch push guard**: adds `.claude/hooks/guard-push.sh` (PreToolUse Bash hook) that queries the GitHub API before any `git push` and blocks with a clear error if the current branch already has a merged PR. Fails open on network/rate-limit errors so legitimate pushes are never blocked by transient failures.

## Test plan

- [ ] WEEK view with start hour set (e.g. 7AM): gutter shows `▲ 7AM` at the top with no overlap with any hour label
- [ ] Click `▲ 7AM` → expands to 24 hours; `▼ 7AM` appears at the 7AM row, 12AM label at top is clean
- [ ] 12-hour mode: label reads "7AM" / "12AM" consistent size with other labels
- [ ] 24-hour mode: label reads "07:00" consistent with other labels
- [ ] Try `git push` on a branch with a merged PR → blocked with message citing PR number

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_