### PR TITLE
fix(electron): remove process from electron import in preload

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, process } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   isElectron: true,


### PR DESCRIPTION
Fixes the CI build failure on all three platforms.

`process` is a global available in Electron's preload context — it's not a named export from the `electron` package. The incorrect import caused a TypeScript compile error that blocked the entire matrix build.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_