### PR TITLE
fix(ci): prevent electron-builder from auto-publishing to GitHub

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -34,9 +34,7 @@ jobs:
         run: npm ci
 
       - name: Build desktop app
-        run: npm run build:electron
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run build:electron -- --publish never
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes the 403 Forbidden failure in the desktop build CI.

electron-builder detects `GH_TOKEN` in the environment plus a tag and tries to create the GitHub release itself — but the `build` job only has default (read) permissions on `contents`, so it gets a 403.

The `release` job already handles creating the draft release via `softprops/action-gh-release` with `contents: write`. The build jobs just need to compile and package; passing `--publish never` stops electron-builder from trying to do anything with GitHub.

Also removes the unnecessary `GH_TOKEN` env var from the build step.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_