### PR TITLE
fix(electron): use npx tsc instead of ./node_modules/.bin/tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "build:android": "./node_modules/.bin/vite build --config vite.config.android.js",
     "preview": "vite preview",
     "test": "vitest run",
-    "dev:electron": "./node_modules/.bin/tsc -p tsconfig.electron.json && ./node_modules/.bin/tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"./node_modules/.bin/tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"./node_modules/.bin/tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
-    "build:electron": "vite build --config vite.config.electron.js && ./node_modules/.bin/tsc -p tsconfig.electron.json && ./node_modules/.bin/tsc -p tsconfig.electron.preload.json && electron-builder"
+    "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
+    "build:electron": "vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder"
   },
   "dependencies": {
     "lucide-react": "^0.564.0",


### PR DESCRIPTION
`./node_modules/.bin/tsc` fails on the Windows CI runner (`cmd.exe` doesn't understand `./` paths). `npx tsc` is cross-platform and works on macOS, Linux, and Windows. Updated both `build:electron` and `dev:electron` scripts.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_