### PR TITLE
fix(electron): logo paths and traffic light alignment

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -19,6 +19,7 @@ function createWindow(): BrowserWindow {
     minWidth: 800,
     minHeight: 600,
     titleBarStyle: 'hiddenInset',
+    trafficLightPosition: { x: 12, y: 8 },
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,

--- a/src/components/DesktopWelcomeModal.jsx
+++ b/src/components/DesktopWelcomeModal.jsx
@@ -38,7 +38,7 @@ const DesktopWelcomeModal = () => {
           {desktopWelcomeStep === 0 && (
             <div className="text-center">
               <img
-                src={darkMode ? '/dayglance-dark.svg' : '/dayglance-light.svg'}
+                src={darkMode ? './dayglance-dark.svg' : './dayglance-light.svg'}
                 alt="dayGLANCE"
                 className="h-24 mx-auto mb-6"
               />
@@ -208,7 +208,7 @@ const DesktopWelcomeModal = () => {
           {desktopWelcomeStep === 7 && (
             <div className="text-center">
               <img
-                src={darkMode ? '/dayglance-dark.svg' : '/dayglance-light.svg'}
+                src={darkMode ? './dayglance-dark.svg' : './dayglance-light.svg'}
                 alt="dayGLANCE"
                 className="h-20 mx-auto mb-6"
               />

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -661,7 +661,7 @@ const MobileLayout = () => {
               <div className={`${cardBg} border-b ${borderClass} sticky top-0 z-30`}>
                 <div className="flex items-center justify-center px-4 py-3">
                   <img
-                    src={darkMode ? '/dayglance-dark.svg' : '/dayglance-light.svg'}
+                    src={darkMode ? './dayglance-dark.svg' : './dayglance-light.svg'}
                     alt="dayGLANCE"
                     className="h-8"
                   />

--- a/src/components/MobileWelcomeModal.jsx
+++ b/src/components/MobileWelcomeModal.jsx
@@ -31,7 +31,7 @@ const MobileWelcomeModal = () => {
         {mobileWelcomeStep === 0 && (
           <div className="text-center">
             <img
-              src={darkMode ? '/dayglance-dark.svg' : '/dayglance-light.svg'}
+              src={darkMode ? './dayglance-dark.svg' : './dayglance-light.svg'}
               alt="dayGLANCE"
               className="h-24 mx-auto mb-6"
             />
@@ -130,7 +130,7 @@ const MobileWelcomeModal = () => {
         {mobileWelcomeStep === 6 && (
           <div className="text-center">
             <img
-              src={darkMode ? '/dayglance-dark.svg' : '/dayglance-light.svg'}
+              src={darkMode ? './dayglance-dark.svg' : './dayglance-light.svg'}
               alt="dayGLANCE"
               className="h-20 mx-auto mb-6"
             />

--- a/src/components/RoutinesDashboardModal.jsx
+++ b/src/components/RoutinesDashboardModal.jsx
@@ -37,7 +37,7 @@ const RoutinesDashboardModal = () => {
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
                 <img
-                  src={darkMode ? '/dayglance-dark.svg' : '/dayglance-light.svg'}
+                  src={darkMode ? './dayglance-dark.svg' : './dayglance-light.svg'}
                   alt="dayGLANCE"
                   className="h-[4.5rem]"
                 />


### PR DESCRIPTION
Two Electron desktop app polish fixes:

**Logo missing in welcome/routines modals**
Logo SVGs were referenced as `/dayglance-dark.svg` (absolute paths). The Electron build uses `base: './'` so assets load via `file://` — absolute paths resolve to the filesystem root instead of the app bundle. Changed all six references to `./dayglance-dark.svg` / `./dayglance-light.svg` which resolve correctly relative to `dist/index.html` in both Electron and browser.

**Traffic lights misaligned in drag strip**
Added `trafficLightPosition: { x: 12, y: 8 }` to `BrowserWindow`. The drag strip is 28px tall and the traffic light buttons are 12px — `(28-12)/2 = 8` centers them vertically.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_