### PR TITLE
fix(electron): set identity null for ad-hoc macOS signing

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -10,6 +10,7 @@
     "dist-electron/**/*"
   ],
   "mac": {
+    "identity": null,
     "category": "public.app-category.productivity",
     "target": [
       { "target": "dmg", "arch": ["x64", "arm64"] },


### PR DESCRIPTION
Attempt to get the softer Gatekeeper "downloaded from internet, are you sure?" warning instead of the hard "damaged and can't be opened" block on macOS.

Setting `identity: null` explicitly requests ad-hoc signing for all architectures rather than leaving electron-builder to decide per-arch. Worth testing — may not change anything, but low risk either way.

https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU

---
_Generated by [Claude Code](https://claude.ai/code/session_018MvsWfqjsPg2zRc65myHTU)_