### PR TITLE
fix(electron): strip xattrs before ad-hoc signing

### DIFF
--- a/scripts/codesign-ad-hoc.cjs
+++ b/scripts/codesign-ad-hoc.cjs
@@ -13,6 +13,10 @@ const path = require('path');
 exports.default = async function codesignAdHoc({ appOutDir, packager }) {
   if (packager.platform.name !== 'mac') return;
   const appPath = path.join(appOutDir, `${packager.appInfo.productName}.app`);
+  // Strip extended attributes (resource forks, Finder metadata) — codesign
+  // refuses to sign a bundle that contains them.
+  console.log(`[codesign-ad-hoc] Clearing xattrs on ${appPath}`);
+  execFileSync('xattr', ['-cr', appPath], { stdio: 'inherit' });
   console.log(`[codesign-ad-hoc] Signing ${appPath}`);
   execFileSync('codesign', ['--sign', '-', '--deep', '--force', appPath], { stdio: 'inherit' });
 };


### PR DESCRIPTION
## Summary

- `codesign --sign -` fails with "resource fork, Finder information, or similar detritus not allowed" when files inside the `.app` bundle have extended attributes (Finder metadata, resource forks, etc.)
- Add `xattr -cr <app>` before the `codesign` call in the `afterPack` hook to strip them

## Test plan

- [ ] Run `npm run build:electron` on macOS — build should complete without the `codesign` error
- [ ] Install the DMG and verify macOS shows the softer "unidentified developer" prompt rather than "damaged and can't be opened"
- [ ] Confirm right-click → Open dismisses the prompt without needing a Terminal command

https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP)_