### PR TITLE
fix(electron): robust xattr clearing + fix guard-push hook

### DIFF
--- a/.claude/hooks/guard-push.sh
+++ b/.claude/hooks/guard-push.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Blocks `git push` when the current branch already has a merged PR.
+# Blocks `git push` when the current branch has already been merged into main.
+# Uses a local git check (no GitHub API needed) so it works in restricted envs.
 # Reads a Bash tool call from stdin (JSON with .tool_input.command).
 
 command=$(jq -r '.tool_input.command // ""' 2>/dev/null)
@@ -14,19 +15,15 @@ if [ -z "$branch" ]; then
   exit 0
 fi
 
-# URL-encode the branch name (replace / with %2F)
-branch_encoded="${branch//\//%2F}"
+# Fetch the latest main so the check reflects the true remote state.
+git -C "$CLAUDE_PROJECT_DIR" fetch origin main --quiet 2>/dev/null
 
-# Query GitHub API for any closed PR on this branch
-response=$(curl -s \
-  "https://api.github.com/repos/krelltunez/dayGLANCE/pulls?state=closed&head=krelltunez:${branch_encoded}&per_page=1")
-
-merged_at=$(echo "$response" | jq -r 'if (type == "array") and (length > 0) and (.[0].merged_at != null) then .[0].merged_at else "null" end' 2>/dev/null)
-
-if [ "$merged_at" != "null" ] && [ -n "$merged_at" ]; then
-  pr_number=$(echo "$response" | jq -r '.[0].number' 2>/dev/null)
-  printf '{"continue":false,"stopReason":"Branch '"'"'%s'"'"' already has a merged PR (#%s) — per CLAUDE.md, create a new branch from the correct base (electron-develop or main) before pushing."}\n' \
-    "$branch" "$pr_number"
+# If the branch tip is already an ancestor of origin/main, it was merged in.
+# (Catches regular merges and fast-forward squash merges. Squash merges that
+# leave an orphan commit are not caught, but those are rare in this repo.)
+if git -C "$CLAUDE_PROJECT_DIR" merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+  printf '{"continue":false,"stopReason":"Branch '"'"'%s'"'"' is already merged into main — per CLAUDE.md, create a new branch from the correct base before pushing."}\n' \
+    "$branch"
   exit 0
 fi
 

--- a/scripts/codesign-ad-hoc.cjs
+++ b/scripts/codesign-ad-hoc.cjs
@@ -7,16 +7,24 @@
 // App Store / notarized signing. It satisfies macOS code signature requirements
 // without being trusted by Gatekeeper's CA chain.
 
-const { execFileSync } = require('child_process');
+const { execSync } = require('child_process');
 const path = require('path');
 
 exports.default = async function codesignAdHoc({ appOutDir, packager }) {
   if (packager.platform.name !== 'mac') return;
   const appPath = path.join(appOutDir, `${packager.appInfo.productName}.app`);
-  // Strip extended attributes (resource forks, Finder metadata) — codesign
-  // refuses to sign a bundle that contains them.
+
+  // codesign --deep traverses nested executables (Electron framework, helpers)
+  // and fails with "detritus not allowed" if any file has a resource fork or
+  // extended attribute. Two sources of detritus need clearing:
+  //   1. ._* files — resource fork proxy files macOS creates on non-HFS+ copies
+  //   2. Extended attributes on regular files (com.apple.FinderInfo etc.)
+  // xattr -cr alone misses ._* files; find + delete handles them explicitly.
+  // xargs -0 on non-symlinks avoids xattr choking on symlinks inside frameworks.
+  console.log(`[codesign-ad-hoc] Removing ._* resource fork files from ${appPath}`);
+  execSync(`find ${JSON.stringify(appPath)} -name "._*" -delete`);
   console.log(`[codesign-ad-hoc] Clearing xattrs on ${appPath}`);
-  execFileSync('xattr', ['-cr', appPath], { stdio: 'inherit' });
+  execSync(`find ${JSON.stringify(appPath)} -not -type l -print0 | xargs -0 xattr -c`);
   console.log(`[codesign-ad-hoc] Signing ${appPath}`);
-  execFileSync('codesign', ['--sign', '-', '--deep', '--force', appPath], { stdio: 'inherit' });
+  execSync(`codesign --sign - --deep --force ${JSON.stringify(appPath)}`);
 };


### PR DESCRIPTION
## Summary

Two fixes that didn't make it into #652:

**`scripts/codesign-ad-hoc.cjs`** — the initial `xattr -cr` wasn't enough. `codesign --deep` traverses into nested Electron framework executables and chokes on `._*` resource fork proxy files that `xattr -cr` leaves behind, and on symlinks that `xattr -c` can't handle. New approach:
- `find ... -name "._*" -delete` — explicitly removes resource fork proxy files
- `find ... -not -type l | xargs -0 xattr -c` — clears xattrs on regular files only, skipping symlinks inside the Electron framework

**`.claude/hooks/guard-push.sh`** — the hook that was meant to block pushes to merged branches never fired because `curl` to `api.github.com` exits with code 5 (host unreachable) in this environment. Replaced with a local git check: `git merge-base --is-ancestor HEAD origin/main`. No GitHub API access needed.

## Test plan

- [ ] `npm run build:electron` on macOS completes without the `codesign` detritus error
- [ ] Confirm the guard-push hook blocks a push on a branch whose HEAD is already in `main`

https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP)_