### PR TITLE
feat: macOS title bar NOW strip, dock badge, and menu bar tray

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, ipcMain, net } from 'electron';
+import { app, BrowserWindow, shell, ipcMain, net, Tray, Menu, nativeImage } from 'electron';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createWsServer } from './ws-server.js';
@@ -12,8 +12,12 @@ app.setPath('userData', path.join(app.getPath('appData'), 'dayGLANCE'));
 const DEV = !app.isPackaged;
 const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL'] ?? 'http://localhost:5173';
 
+let mainWindow: BrowserWindow | null = null;
+let tray: Tray | null = null;
+let trayWindow: BrowserWindow | null = null;
+
 function createWindow(): BrowserWindow {
-  const win = new BrowserWindow({
+  mainWindow = new BrowserWindow({
     width: 1280,
     height: 800,
     minWidth: 800,
@@ -28,18 +32,76 @@ function createWindow(): BrowserWindow {
   });
 
   if (DEV) {
-    win.loadURL(VITE_DEV_SERVER_URL);
+    mainWindow.loadURL(VITE_DEV_SERVER_URL);
   } else {
-    win.loadFile(path.join(__dirname, '../dist/index.html'));
+    mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
   }
 
   // Open external links in the system browser
-  win.webContents.setWindowOpenHandler(({ url }) => {
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url);
     return { action: 'deny' };
   });
 
+  return mainWindow;
+}
+
+function createTrayWindow(): BrowserWindow {
+  const win = new BrowserWindow({
+    width: 320,
+    height: 560,
+    show: false,
+    frame: false,
+    resizable: false,
+    skipTaskbar: true,
+    alwaysOnTop: true,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  if (DEV) {
+    win.loadURL(`${VITE_DEV_SERVER_URL}?tray=1`);
+  } else {
+    win.loadFile(path.join(__dirname, '../dist/index.html'), { query: { tray: '1' } });
+  }
+
+  // Hide when the user clicks outside the popup
+  win.on('blur', () => win.hide());
+
   return win;
+}
+
+function createTray(): void {
+  const iconPath = DEV
+    ? path.join(process.cwd(), 'public/icon-16x16.png')
+    : path.join(__dirname, '../dist/icon-16x16.png');
+
+  tray = new Tray(nativeImage.createFromPath(iconPath));
+  tray.setToolTip('dayGLANCE');
+  trayWindow = createTrayWindow();
+
+  // Left-click: toggle the Glance popup
+  tray.on('click', (_event, bounds) => {
+    if (!trayWindow) return;
+    if (trayWindow.isVisible()) { trayWindow.hide(); return; }
+    const { x, y, width: iconW, height: iconH } = bounds;
+    const { width: popW } = trayWindow.getBounds();
+    trayWindow.setPosition(Math.round(x - popW / 2 + iconW / 2), Math.round(y + iconH));
+    trayWindow.show();
+    trayWindow.focus();
+  });
+
+  // Right-click: native Open / Quit menu
+  tray.on('right-click', () => {
+    tray?.popUpContextMenu(Menu.buildFromTemplate([
+      { label: 'Open dayGLANCE', click: () => { mainWindow?.show(); mainWindow?.focus(); } },
+      { type: 'separator' },
+      { label: 'Quit', click: () => app.quit() },
+    ]));
+  });
 }
 
 // Proxy outbound HTTP requests from the renderer so they aren't subject to
@@ -54,15 +116,24 @@ ipcMain.handle('proxy-fetch', async (_event, method: string, url: string, header
   return { status: response.status, ok: response.ok, statusText: response.statusText, body: text };
 });
 
+// Dock badge — macOS only
+ipcMain.on('set-badge-count', (_event, count: number) => {
+  if (process.platform === 'darwin') app.setBadgeCount(count);
+});
+
 app.whenReady().then(() => {
   const win = createWindow();
   createWsServer(win);
+  if (process.platform === 'darwin') createTray();
 
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    if (mainWindow) { mainWindow.show(); mainWindow.focus(); }
+    else createWindow();
   });
 });
 
 app.on('window-all-closed', () => {
+  // On macOS the app stays alive in the tray; the user can reopen from there or the dock.
   if (process.platform !== 'darwin') app.quit();
 });
+

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -15,6 +15,7 @@ const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL'] ?? 'http://localh
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let trayWindow: BrowserWindow | null = null;
+let trayNeedsReload = false;
 
 function createWindow(): BrowserWindow {
   mainWindow = new BrowserWindow({
@@ -68,8 +69,14 @@ function createTrayWindow(): BrowserWindow {
     win.loadFile(path.join(__dirname, '../dist/index.html'), { query: { tray: '1' } });
   }
 
-  // Hide when the user clicks outside the popup
-  win.on('blur', () => win.hide());
+  // Hide when the user clicks outside the popup; reload if state changed while it was open
+  win.on('blur', () => {
+    win.hide();
+    if (trayNeedsReload) {
+      trayNeedsReload = false;
+      win.webContents.reload();
+    }
+  });
 
   return win;
 }
@@ -119,6 +126,16 @@ ipcMain.handle('proxy-fetch', async (_event, method: string, url: string, header
 // Dock badge — macOS only
 ipcMain.on('set-badge-count', (_event, count: number) => {
   if (process.platform === 'darwin') app.setBadgeCount(count);
+});
+
+// Keep tray popup in sync: reload it in the background whenever state changes
+ipcMain.on('ws:push-state', () => {
+  if (!trayWindow) return;
+  if (trayWindow.isVisible()) {
+    trayNeedsReload = true; // reload on next blur so the open popup isn't disrupted
+  } else {
+    trayWindow.webContents.reload();
+  }
 });
 
 app.whenReady().then(() => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -25,4 +25,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // external servers (WebDAV, CalDAV) without hitting Chromium CORS restrictions.
   proxyFetch: (method: string, url: string, headers: Record<string, string>, body: string | null) =>
     ipcRenderer.invoke('proxy-fetch', method, url, headers, body),
+
+  // Sets the macOS dock badge to the number of incomplete tasks today.
+  setBadgeCount: (count: number) => ipcRenderer.send('set-badge-count', count),
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -100,6 +100,7 @@ import FrameNudgeCard from './components/FrameNudgeCard.jsx';
 import DeadlinePickerPopover from './components/DeadlinePickerPopover.jsx';
 import DatePicker from './components/DatePicker.jsx';
 import DesktopLayout from './components/DesktopLayout.jsx';
+import GlanceSidebar from './components/GlanceSidebar.jsx';
 import MobileLayout from './components/MobileLayout.jsx';
 import ShortcutHelpModal from './components/ShortcutHelpModal.jsx';
 import FocusModeModal from './components/FocusModeModal.jsx';
@@ -168,6 +169,8 @@ const TimePicker = ({ value, onChange, use24HourClock, borderClass, darkMode }) 
 // Smart Schedule panel — shows AI scheduling UI
 // FrameNudgeCard extracted to src/components/FrameNudgeCard.jsx
 
+
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
 
 const DayPlanner = () => {
   const _visibleDays = useVisibleDays();
@@ -7618,6 +7621,20 @@ const DayPlanner = () => {
     applyReminderPreset, updateCategoryReminder,
     snoozeReminder, dismissReminder, dismissAllReminders,
   };
+
+  if (isTrayMode) {
+    return (
+      <DayPlannerContext.Provider value={ctx}>
+      <SyncContext.Provider value={syncCtx}>
+      <FeaturesContext.Provider value={featuresCtx}>
+        <div className={`${bgClass} overflow-y-auto`} style={{ height: '100vh', padding: '12px' }}>
+          <GlanceSidebar variant="desktop" />
+        </div>
+      </FeaturesContext.Provider>
+      </SyncContext.Provider>
+      </DayPlannerContext.Provider>
+    );
+  }
 
   return (
     <DayPlannerContext.Provider value={ctx}>

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -337,8 +337,9 @@ const CalendarHeader = () => {
   })()}
 </div>
 
-{/* Now bar - current running task */}
+{/* Now bar - current running task (suppressed on Electron Mac where it shows in the title bar) */}
 {(() => {
+  if (window.electronAPI?.isElectron && window.electronAPI?.platform === 'darwin') return null;
   const todayStr = dateToString(new Date());
   const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
   const runningTask = [...tasks, ...expandedRecurringTasks].find(t =>

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -428,10 +428,34 @@ const DesktopLayout = () => {
 
   return (
       <>
-      {/* macOS traffic-light drag region — sits above the header so content clears the buttons */}
-      {isElectronMac && (
-        <div style={{ height: titlebarH, WebkitAppRegion: 'drag', flexShrink: 0 }} />
-      )}
+      {/* macOS traffic-light drag region — doubles as the NOW bar when a task is running */}
+      {isElectronMac && (() => {
+        const todayStr = dateToString(new Date());
+        const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
+        const runningTask = [...tasks, ...expandedRecurringTasks].find(t =>
+          t.date === todayStr && !t.isAllDay && !t.completed &&
+          !(t.imported && !t.isTaskCalendar) &&
+          nowMin >= timeToMinutes(t.startTime || '0:00') &&
+          nowMin < timeToMinutes(t.startTime || '0:00') + (t.duration || 0)
+        );
+        return (
+          <div
+            style={{ height: titlebarH, WebkitAppRegion: 'drag', flexShrink: 0, paddingLeft: '85px' }}
+            className={`flex items-center gap-2 text-xs font-semibold overflow-hidden ${
+              runningTask
+                ? (darkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-50 text-amber-800')
+                : ''
+            }`}
+          >
+            {runningTask && (
+              <>
+                <span className="w-2 h-2 rounded-full bg-amber-400 animate-pulse flex-shrink-0" />
+                <span className="truncate">Now: {runningTask.title}</span>
+              </>
+            )}
+          </div>
+        );
+      })()}
       {/* Desktop & Tablet Layout */}
       {!isTablet && <DesktopHeader />}
 

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -324,6 +324,9 @@ export default function useElectronBridge({
       ...activeProjects.filter(p => !p.goalId).map(mapProject).sort(sortByProgressAsc),
     ];
 
+    // Dock badge: incomplete scheduled tasks today
+    window.electronAPI.setBadgeCount?.(todayTasks.filter(t => !t.completed).length);
+
     window.electronAPI.pushState({
       v: PROTOCOL_VERSION,
       type: MSG_DAY_STATE,


### PR DESCRIPTION
## Summary

- **Title bar NOW strip** — the 28px `hiddenInset` drag region in `DesktopLayout` now doubles as a live task indicator: when a task is actively running it shows an amber background, a pulsing dot, and the task title. When nothing is running the strip is invisible but still draggable. The equivalent NOW bar in `CalendarHeader` is suppressed on Electron/macOS to avoid duplication.

- **Dock badge** — `useElectronBridge` calls `window.electronAPI.setBadgeCount()` on every state push, keeping the macOS dock icon badge in sync with the count of incomplete tasks scheduled for today. The IPC handler in `electron/main.ts` and the preload bridge in `electron/preload.ts` wire this up end-to-end.

- **Menu bar tray with full Glance panel** — a `Tray` icon is created on macOS at app startup. Left-click toggles a 320×560 frameless, always-on-top popup that loads the full `GlanceSidebar` (no FABs). Right-click shows a native Open / Quit menu. `App.jsx` detects the `?tray=1` URL parameter and renders only the sidebar inside the full provider tree so it has complete data access.

## Files changed

| File | Change |
|---|---|
| `electron/main.ts` | Add `Tray`, tray window, badge IPC handler |
| `electron/preload.ts` | Expose `setBadgeCount` |
| `src/hooks/useElectronBridge.js` | Call `setBadgeCount` on each state push |
| `src/components/DesktopLayout.jsx` | Replace blank drag div with NOW bar IIFE |
| `src/components/CalendarHeader.jsx` | Suppress NOW bar on Electron/macOS |
| `src/App.jsx` | Import `GlanceSidebar`; detect `isTrayMode`; render sidebar-only tree |

## Test plan

- [ ] Launch Electron app on macOS; confirm traffic lights render at top-left and drag region works
- [ ] Start a time-blocked task that covers the current minute — confirm amber strip + pulsing dot appear in the title bar
- [ ] Confirm CalendarHeader no longer shows the duplicate NOW bar on macOS
- [ ] Complete/remove all today tasks → dock badge disappears; add incomplete tasks → badge updates
- [ ] Click menu bar icon → Glance popup appears centered below icon; click again → hides
- [ ] Click outside popup → hides via blur
- [ ] Right-click menu bar icon → Open / Quit items work correctly

https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP)_