### PR TITLE
fix(tray): break ws:push-state reload loop

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -129,8 +129,10 @@ ipcMain.on('set-badge-count', (_event, count: number) => {
 });
 
 // Keep tray popup in sync: reload it in the background whenever state changes
-ipcMain.on('ws:push-state', () => {
+ipcMain.on('ws:push-state', (event) => {
   if (!trayWindow) return;
+  // Ignore pushes from the tray window itself to prevent a reload loop
+  if (event.sender === trayWindow.webContents) return;
   if (trayWindow.isVisible()) {
     trayNeedsReload = true; // reload on next blur so the open popup isn't disrupted
   } else {


### PR DESCRIPTION
## Problem

The tray popup's `useElectronBridge` calls `pushState` when it loads. That fires `ws:push-state`, which the new sync handler in `main.ts` picks up and reloads the tray window — which pushes state again — infinite loop. The WebSocket server broadcasts every one of those pushes to connected Stream Deck clients, causing them to receive a flood of rapid state updates ("freaking out").

## Fix

One line: check `event.sender === trayWindow.webContents` at the top of the `ws:push-state` handler and return early if it matches. State pushes from the tray window are irrelevant for sync purposes — only pushes from the main window should trigger a reload.

## Test plan

- [ ] Open main app, make a change — tray popup background-reloads (confirm via DevTools Network or by opening popup immediately after)
- [ ] Stream Deck receives normal state updates, no flooding
- [ ] Open tray popup while app is running — no reload loop, popup is stable

https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP)_