### PR TITLE
fix(tray): stop tray window from pushing state to Stream Deck

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,6 +16,7 @@ let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let trayWindow: BrowserWindow | null = null;
 let trayNeedsReload = false;
+let trayReloadTimer: ReturnType<typeof setTimeout> | null = null;
 
 function createWindow(): BrowserWindow {
   mainWindow = new BrowserWindow({
@@ -136,7 +137,12 @@ ipcMain.on('ws:push-state', (event) => {
   if (trayWindow.isVisible()) {
     trayNeedsReload = true; // reload on next blur so the open popup isn't disrupted
   } else {
-    trayWindow.webContents.reload();
+    // Debounce: coalesce rapid pushes (e.g. hover/interaction) into one reload
+    if (trayReloadTimer) clearTimeout(trayReloadTimer);
+    trayReloadTimer = setTimeout(() => {
+      trayReloadTimer = null;
+      trayWindow?.webContents.reload();
+    }, 500);
   }
 });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -131,7 +131,7 @@ ipcMain.on('set-badge-count', (_event, count: number) => {
 
 // Keep tray popup in sync: reload it in the background whenever state changes
 ipcMain.on('ws:push-state', (event) => {
-  if (!trayWindow) return;
+  if (!trayWindow || trayWindow.isDestroyed()) return;
   // Ignore pushes from the tray window itself to prevent a reload loop
   if (event.sender === trayWindow.webContents) return;
   if (trayWindow.isVisible()) {
@@ -141,7 +141,7 @@ ipcMain.on('ws:push-state', (event) => {
     if (trayReloadTimer) clearTimeout(trayReloadTimer);
     trayReloadTimer = setTimeout(() => {
       trayReloadTimer = null;
-      trayWindow?.webContents.reload();
+      if (trayWindow && !trayWindow.isDestroyed()) trayWindow.webContents.reload();
     }, 500);
   }
 });

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -30,6 +30,8 @@ const timeToMinutes = (time) => {
   return h * 60 + (m || 0);
 };
 
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+
 // Inline habit color map (mirrors HABIT_COLORS ring values from src/constants/habits.js)
 const HABIT_COLOR_HEX = {
   blue: '#3b82f6', green: '#22c55e', red: '#ef4444', amber: '#f59e0b',
@@ -323,6 +325,8 @@ export default function useElectronBridge({
       ...activeProjects.filter(p => p.goalId).map(mapProject).sort(sortByProgressAsc),
       ...activeProjects.filter(p => !p.goalId).map(mapProject).sort(sortByProgressAsc),
     ];
+
+    if (isTrayMode) return;
 
     // Dock badge: incomplete scheduled tasks today
     window.electronAPI.setBadgeCount?.(todayTasks.filter(t => !t.completed).length);


### PR DESCRIPTION
## Problem

Two issues causing Stream Deck flicker during mouse movement / interaction:

**1. Tray window was sending state to the Stream Deck.**
The tray window runs the full React app, so `useElectronBridge` was calling `pushState` on every state change. `ws-server.ts` has no tray guard — it broadcasts every `ws:push-state` to all WebSocket clients. This doubled the Stream Deck update rate (one push from the main window, one from the tray reload).

**2. Every interaction triggered a tray reload.**
Any state change in the main window (including hover, selection, etc.) immediately called `trayWindow.webContents.reload()`. With frequent interaction this caused a near-continuous reload cycle.

## Fix

- **`useElectronBridge.js`**: detect `?tray=1` at module level and return early before any `pushState` or `setBadgeCount` calls. The tray is a read-only view — it has no business pushing state.
- **`electron/main.ts`**: debounce the tray reload by 500ms so rapid pushes from interaction coalesce into a single reload.

## Test plan

- [ ] Interact with the main app (hover, click, drag) — Stream Deck should update at the same rate as before the tray feature, no flicker
- [ ] Open tray popup — shows current data, no reload loop
- [ ] Make a change in main app, close and reopen tray — shows updated data

https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP)_