### PR TITLE
fix(codesign): use xattr -cr to clear all xattrs including on symlinks

### DIFF
--- a/scripts/codesign-ad-hoc.cjs
+++ b/scripts/codesign-ad-hoc.cjs
@@ -18,13 +18,13 @@ exports.default = async function codesignAdHoc({ appOutDir, packager }) {
   // and fails with "detritus not allowed" if any file has a resource fork or
   // extended attribute. Two sources of detritus need clearing:
   //   1. ._* files — resource fork proxy files macOS creates on non-HFS+ copies
-  //   2. Extended attributes on regular files (com.apple.FinderInfo etc.)
-  // xattr -cr alone misses ._* files; find + delete handles them explicitly.
-  // xargs -0 on non-symlinks avoids xattr choking on symlinks inside frameworks.
+  //   2. Extended attributes on all files including symlinks (com.apple.FinderInfo etc.)
+  // xattr -cr handles all file types including symlinks inside Electron frameworks
+  // (e.g. Versions/Current) that the previous find -not -type l approach skipped.
   console.log(`[codesign-ad-hoc] Removing ._* resource fork files from ${appPath}`);
   execSync(`find ${JSON.stringify(appPath)} -name "._*" -delete`);
   console.log(`[codesign-ad-hoc] Clearing xattrs on ${appPath}`);
-  execSync(`find ${JSON.stringify(appPath)} -not -type l -print0 | xargs -0 xattr -c`);
+  execSync(`xattr -cr ${JSON.stringify(appPath)}`);
   console.log(`[codesign-ad-hoc] Signing ${appPath}`);
   execSync(`codesign --sign - --deep --force ${JSON.stringify(appPath)}`);
 };


### PR DESCRIPTION
## Problem

Build failing with:
```
dayGLANCE.app: resource fork, Finder information, or similar detritus not allowed
```

The previous cleanup used `find -not -type l | xargs -0 xattr -c`, which explicitly excluded symlinks. Electron app bundles contain symlinks like `Versions/Current` inside `Electron Framework.framework` that can carry extended attributes. `codesign --deep` traverses those symlinks and fails when it finds uncleared xattrs on them.

## Fix

Replace with `xattr -cr <appPath>`, which handles recursion natively and processes **all** file types including symlinks. The `._*` file removal step is unchanged.

## Test plan

- [ ] `npm run dist` (or equivalent) completes without codesign error
- [ ] Built `.app` launches correctly with right-click → Open

https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP)_