### PR TITLE
feat(tray): interactive tray — quick-add, search, voice, and open-in-app navigation

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -18,6 +18,12 @@ let trayWindow: BrowserWindow | null = null;
 let trayNeedsReload = false;
 let trayReloadTimer: ReturnType<typeof setTimeout> | null = null;
 
+// Safe accessor — returns null if the window has been destroyed so callers
+// never have to scatter isDestroyed() checks throughout the file.
+function live(win: BrowserWindow | null): BrowserWindow | null {
+  return win && !win.isDestroyed() ? win : null;
+}
+
 function createWindow(): BrowserWindow {
   mainWindow = new BrowserWindow({
     width: 1280,
@@ -72,6 +78,7 @@ function createTrayWindow(): BrowserWindow {
 
   // Hide when the user clicks outside the popup; reload if state changed while it was open
   win.on('blur', () => {
+    if (win.isDestroyed()) return;
     win.hide();
     if (trayNeedsReload) {
       trayNeedsReload = false;
@@ -93,19 +100,20 @@ function createTray(): void {
 
   // Left-click: toggle the Glance popup
   tray.on('click', (_event, bounds) => {
-    if (!trayWindow) return;
-    if (trayWindow.isVisible()) { trayWindow.hide(); return; }
+    const tw = live(trayWindow);
+    if (!tw) return;
+    if (tw.isVisible()) { tw.hide(); return; }
     const { x, y, width: iconW, height: iconH } = bounds;
-    const { width: popW } = trayWindow.getBounds();
-    trayWindow.setPosition(Math.round(x - popW / 2 + iconW / 2), Math.round(y + iconH));
-    trayWindow.show();
-    trayWindow.focus();
+    const { width: popW } = tw.getBounds();
+    tw.setPosition(Math.round(x - popW / 2 + iconW / 2), Math.round(y + iconH));
+    tw.show();
+    tw.focus();
   });
 
   // Right-click: native Open / Quit menu
   tray.on('right-click', () => {
     tray?.popUpContextMenu(Menu.buildFromTemplate([
-      { label: 'Open dayGLANCE', click: () => { mainWindow?.show(); mainWindow?.focus(); } },
+      { label: 'Open dayGLANCE', click: () => { live(mainWindow)?.show(); live(mainWindow)?.focus(); } },
       { type: 'separator' },
       { label: 'Quit', click: () => app.quit() },
     ]));
@@ -131,25 +139,23 @@ ipcMain.on('set-badge-count', (_event, count: number) => {
 
 // Tray popup requests the main window to show and navigate to a specific location.
 ipcMain.on('tray:open-main', (_event, payload: unknown) => {
-  trayWindow?.hide();
-  mainWindow?.show();
-  mainWindow?.focus();
-  mainWindow?.webContents.send('tray:navigate', payload);
+  live(trayWindow)?.hide();
+  const mw = live(mainWindow);
+  if (mw) { mw.show(); mw.focus(); mw.webContents.send('tray:navigate', payload); }
 });
 
 // Keep tray popup in sync: reload it in the background whenever state changes
 ipcMain.on('ws:push-state', (event) => {
-  if (!trayWindow || trayWindow.isDestroyed()) return;
-  // Ignore pushes from the tray window itself to prevent a reload loop
-  if (event.sender === trayWindow.webContents) return;
-  if (trayWindow.isVisible()) {
-    trayNeedsReload = true; // reload on next blur so the open popup isn't disrupted
+  const tw = live(trayWindow);
+  if (!tw) return;
+  if (event.sender === tw.webContents) return;
+  if (tw.isVisible()) {
+    trayNeedsReload = true;
   } else {
-    // Debounce: coalesce rapid pushes (e.g. hover/interaction) into one reload
     if (trayReloadTimer) clearTimeout(trayReloadTimer);
     trayReloadTimer = setTimeout(() => {
       trayReloadTimer = null;
-      if (trayWindow && !trayWindow.isDestroyed()) trayWindow.webContents.reload();
+      live(trayWindow)?.webContents.reload();
     }, 500);
   }
 });
@@ -160,8 +166,8 @@ app.whenReady().then(() => {
   if (process.platform === 'darwin') createTray();
 
   app.on('activate', () => {
-    if (mainWindow) { mainWindow.show(); mainWindow.focus(); }
-    else createWindow();
+    const mw = live(mainWindow);
+    if (mw) { mw.show(); mw.focus(); } else createWindow();
   });
 });
 
@@ -169,4 +175,3 @@ app.on('window-all-closed', () => {
   // On macOS the app stays alive in the tray; the user can reopen from there or the dock.
   if (process.platform !== 'darwin') app.quit();
 });
-

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -129,6 +129,14 @@ ipcMain.on('set-badge-count', (_event, count: number) => {
   if (process.platform === 'darwin') app.setBadgeCount(count);
 });
 
+// Tray popup requests the main window to show and navigate to a specific location.
+ipcMain.on('tray:open-main', (_event, payload: unknown) => {
+  trayWindow?.hide();
+  mainWindow?.show();
+  mainWindow?.focus();
+  mainWindow?.webContents.send('tray:navigate', payload);
+});
+
 // Keep tray popup in sync: reload it in the background whenever state changes
 ipcMain.on('ws:push-state', (event) => {
   if (!trayWindow || trayWindow.isDestroyed()) return;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -28,4 +28,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Sets the macOS dock badge to the number of incomplete tasks today.
   setBadgeCount: (count: number) => ipcRenderer.send('set-badge-count', count),
+
+  // Tray popup tells the main process to show the main window and navigate to a location.
+  openMainAt: (payload: unknown) => ipcRenderer.send('tray:open-main', payload),
+
+  // Main window listens for navigation requests forwarded from the tray popup.
+  onTrayNavigate: (callback: (payload: unknown) => void) => {
+    const handler = (_: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+    ipcRenderer.on('tray:navigate', handler);
+    return () => ipcRenderer.removeListener('tray:navigate', handler);
+  },
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -101,6 +101,7 @@ import DeadlinePickerPopover from './components/DeadlinePickerPopover.jsx';
 import DatePicker from './components/DatePicker.jsx';
 import DesktopLayout from './components/DesktopLayout.jsx';
 import GlanceSidebar from './components/GlanceSidebar.jsx';
+import TrayApp from './components/TrayApp.jsx';
 import MobileLayout from './components/MobileLayout.jsx';
 import ShortcutHelpModal from './components/ShortcutHelpModal.jsx';
 import FocusModeModal from './components/FocusModeModal.jsx';
@@ -6233,6 +6234,7 @@ const DayPlanner = () => {
     projects,
     unscheduledTasks,
     goalsProjectsEnabled,
+    goToDate,
   });
 
   // ── Native Android widget snapshot sync ──────────────────────────────────
@@ -7627,9 +7629,7 @@ const DayPlanner = () => {
       <DayPlannerContext.Provider value={ctx}>
       <SyncContext.Provider value={syncCtx}>
       <FeaturesContext.Provider value={featuresCtx}>
-        <div className={`${bgClass} overflow-y-auto`} style={{ height: '100vh', padding: '12px' }}>
-          <GlanceSidebar variant="desktop" />
-        </div>
+        <TrayApp bgClass={bgClass} darkMode={darkMode} />
       </FeaturesContext.Provider>
       </SyncContext.Provider>
       </DayPlannerContext.Provider>

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -103,13 +103,16 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
   } = useFeaturesCtx();
 
   const isDesktop = variant === 'desktop';
-  const interactionClass = isDesktop ? 'hover:opacity-80' : 'active:opacity-70';
-  const keyPrefix = isDesktop ? 'desktop' : 'tablet';
+  const isTray = variant === 'tray';
+  const interactionClass = isDesktop || isTray ? 'hover:opacity-80' : 'active:opacity-70';
+  const keyPrefix = isDesktop ? 'desktop' : isTray ? 'tray' : 'tablet';
+
+  const openMainAt = (payload) => window.electronAPI?.openMainAt(payload);
 
   return (
 <div className="space-y-4">
-  {/* Search bar + filter */}
-  <div className="flex items-center gap-2">
+  {/* Search bar + filter — hidden in tray (TrayHeader handles search/voice) */}
+  {!isTray && <div className="flex items-center gap-2">
     <button
       onClick={() => { setShowSpotlight(true); playUISound('spotlight'); }}
       className={`flex-1 flex items-center gap-2 px-3 py-2.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-black/5 text-stone-400'} transition-colors ${interactionClass}`}
@@ -200,7 +203,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
         <Mic size={16} />
       </button>
     )}
-  </div>
+  </div>}
 
   {/* Habit rings row — pinned to top */}
   {habitsEnabled && (() => {
@@ -569,6 +572,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                       target.classList.add('ring-2', 'ring-blue-400');
                       setTimeout(() => target.classList.remove('ring-2', 'ring-blue-400'), 2000);
                     };
+                    if (isTray) { openMainAt({ action: 'goto-task', taskId: task.id, date: task.date }); return; }
                     if (el) { applyRing(); } else if (task.date) { goToDate(task.date); setTimeout(applyRing, 200); }
                   }}
                 >
@@ -851,6 +855,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
               target.classList.add('ring-2', 'ring-blue-400');
               setTimeout(() => target.classList.remove('ring-2', 'ring-blue-400'), 2000);
             };
+            if (isTray) { openMainAt({ action: 'goto-task', taskId: task.id, date: task.date }); return; }
             if (el) { applyRing(); } else if (task.date) { goToDate(task.date); setTimeout(applyRing, 200); }
           }}
         >
@@ -865,7 +870,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
               <span className="whitespace-nowrap">{timeLabel}{relativeLabel ? ',' : ''}</span>{relativeLabel ? <span className={relativeLabel === 'Overdue' ? 'text-orange-500 font-medium' : relativeLabel === 'In Progress' ? 'text-blue-500 font-medium' : ''}>{relativeLabel}</span> : ''}
               {relativeLabel === 'In Progress' && focusModeAvailable && (
                 <button
-                  onClick={(e) => { e.stopPropagation(); enterFocusMode(); }}
+                  onClick={(e) => { e.stopPropagation(); isTray ? openMainAt({ action: 'focus-mode' }) : enterFocusMode(); }}
                   className="ml-1 p-1.5 rounded text-purple-500 ${isDesktop ? 'hover:text-purple-400 hover:bg-purple-500/20' : 'active:text-purple-400 active:bg-purple-500/20'} transition-colors"
                   title="Enter Focus Mode"
                 >
@@ -1074,7 +1079,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
             return (
               <button
                 key={project.id}
-                onClick={() => isFuture ? setShowGoalsDashboard(true) : enterHyperGlanceMode(project.id, instance.date)}
+                onClick={() => isTray ? openMainAt({ action: 'hyperglance', projectId: project.id, date: instance.date }) : isFuture ? setShowGoalsDashboard(true) : enterHyperGlanceMode(project.id, instance.date)}
                 className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-left transition-opacity ${isDesktop ? 'hover:opacity-80' : 'active:opacity-70'} ${darkMode ? 'bg-white/5' : 'bg-stone-50'}`}
               >
                 <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: barColor }}></div>
@@ -1103,10 +1108,9 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     const handleGlanceAheadClick = () => {
       const tomorrow = new Date();
       tomorrow.setDate(tomorrow.getDate() + 1);
+      if (isTray) { openMainAt({ action: 'goto-date', date: tomorrow.toISOString() }); return; }
       goToDate(tomorrow);
-      if (firstStartTime) {
-        setTimeout(() => scrollToHour(firstStartTime), 150);
-      }
+      if (firstStartTime) setTimeout(() => scrollToHour(firstStartTime), 150);
     };
     return (
       <div

--- a/src/components/TrayApp.jsx
+++ b/src/components/TrayApp.jsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import GlanceSidebar from './GlanceSidebar.jsx';
+import TrayHeader from './TrayHeader.jsx';
+import TraySpotlight from './TraySpotlight.jsx';
+import TrayVoice from './TrayVoice.jsx';
+
+export default function TrayApp({ bgClass, darkMode }) {
+  const [overlay, setOverlay] = useState(null); // 'spotlight' | 'voice' | null
+
+  return (
+    <div className={`${bgClass} flex flex-col`} style={{ height: '100vh' }}>
+      <TrayHeader
+        darkMode={darkMode}
+        onSearchClick={() => setOverlay('spotlight')}
+        onVoiceClick={() => setOverlay('voice')}
+      />
+      {overlay === 'spotlight' && (
+        <TraySpotlight darkMode={darkMode} onClose={() => setOverlay(null)} />
+      )}
+      {overlay === 'voice' && (
+        <TrayVoice darkMode={darkMode} onClose={() => setOverlay(null)} />
+      )}
+      {!overlay && (
+        <div className="flex-1 overflow-y-auto px-3 pb-3">
+          <GlanceSidebar variant="tray" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TrayHeader.jsx
+++ b/src/components/TrayHeader.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Search, Mic } from 'lucide-react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+
+export default function TrayHeader({ darkMode, onSearchClick, onVoiceClick }) {
+  const { setUnscheduledTasks, borderClass } = useDayPlannerCtx();
+  const { aiConfig, voiceCanRecord } = useFeaturesCtx();
+  const [text, setText] = useState('');
+
+  const commit = () => {
+    const title = text.trim();
+    if (!title) return;
+    setUnscheduledTasks(prev => [...prev, {
+      id: crypto.randomUUID(),
+      title,
+      duration: 30,
+      color: 'gray',
+      completed: false,
+      isAllDay: false,
+      notes: '',
+      subtasks: [],
+      priority: 0,
+    }]);
+    setText('');
+  };
+
+  const showVoice = aiConfig?.enabled && aiConfig?.features?.voiceTaskInput && voiceCanRecord;
+
+  return (
+    <div className={`flex-shrink-0 px-3 pt-3 pb-2 border-b ${borderClass}`}>
+      <div className="flex items-center gap-1.5">
+        <input
+          className={`flex-1 text-sm px-3 py-2 rounded-lg outline-none ${
+            darkMode
+              ? 'bg-white/10 text-white placeholder-gray-500'
+              : 'bg-black/5 text-stone-900 placeholder-stone-400'
+          }`}
+          placeholder="Add to inbox…"
+          value={text}
+          onChange={e => setText(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') commit(); if (e.key === 'Escape') setText(''); }}
+        />
+        <button
+          onClick={onSearchClick}
+          className={`flex-shrink-0 p-2 rounded-lg transition-opacity hover:opacity-70 ${
+            darkMode ? 'bg-white/10 text-gray-400' : 'bg-black/5 text-stone-500'
+          }`}
+          title="Search tasks"
+        >
+          <Search size={16} />
+        </button>
+        {showVoice && (
+          <button
+            onClick={onVoiceClick}
+            className={`flex-shrink-0 p-2 rounded-lg transition-opacity hover:opacity-70 ${
+              darkMode ? 'bg-white/10 text-purple-400' : 'bg-black/5 text-purple-600'
+            }`}
+            title="Voice input"
+          >
+            <Mic size={16} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TraySpotlight.jsx
+++ b/src/components/TraySpotlight.jsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from 'react';
+import { Search, X } from 'lucide-react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+
+export default function TraySpotlight({ darkMode, onClose }) {
+  const {
+    showSpotlight, setShowSpotlight,
+    spotlightQuery, setSpotlightQuery,
+    spotlightResults,
+    spotlightSelectedIndex, setSpotlightSelectedIndex,
+    textPrimary, textSecondary, borderClass,
+  } = useDayPlannerCtx();
+
+  const inputRef = useRef(null);
+
+  // Enable spotlight result computation (normally gated on showSpotlight).
+  useEffect(() => {
+    setShowSpotlight(true);
+    setSpotlightQuery('');
+    setSpotlightSelectedIndex(0);
+    inputRef.current?.focus();
+    return () => { setShowSpotlight(false); setSpotlightQuery(''); };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSelect = (result) => {
+    window.electronAPI?.openMainAt({
+      action: 'goto-task',
+      taskId: result.task.id,
+      date: result.date ?? result.task.date,
+    });
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Escape') { onClose(); return; }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSpotlightSelectedIndex(i => Math.min(i + 1, spotlightResults.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSpotlightSelectedIndex(i => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter' && spotlightResults[spotlightSelectedIndex]) {
+      handleSelect(spotlightResults[spotlightSelectedIndex]);
+    }
+  };
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden px-3 pb-3">
+      {/* Search input */}
+      <div className={`flex items-center gap-2 py-2.5 border-b ${borderClass}`}>
+        <Search size={15} className={`flex-shrink-0 ${textSecondary}`} />
+        <input
+          ref={inputRef}
+          className={`flex-1 text-sm bg-transparent outline-none ${textPrimary}`}
+          placeholder="Search tasks…"
+          value={spotlightQuery}
+          onChange={e => { setSpotlightQuery(e.target.value); setSpotlightSelectedIndex(0); }}
+          onKeyDown={handleKeyDown}
+        />
+        <button onClick={onClose} className={`flex-shrink-0 ${textSecondary} hover:opacity-70 transition-opacity`}>
+          <X size={15} />
+        </button>
+      </div>
+
+      {/* Results */}
+      <div className="flex-1 overflow-y-auto mt-2 space-y-0.5">
+        {!spotlightQuery.trim() && (
+          <p className={`text-sm ${textSecondary} text-center py-10`}>Type to search…</p>
+        )}
+        {spotlightQuery.trim() && spotlightResults.length === 0 && (
+          <p className={`text-sm ${textSecondary} text-center py-10`}>No results</p>
+        )}
+        {spotlightResults.map((result, i) => {
+          const { task, sourceLabel, match, date } = result;
+          const isSelected = i === spotlightSelectedIndex;
+          return (
+            <button
+              key={`${task.id}-${i}`}
+              className={`w-full text-left px-2 py-2 rounded-lg flex items-center gap-2 transition-colors ${
+                isSelected
+                  ? darkMode ? 'bg-white/15' : 'bg-black/10'
+                  : darkMode ? 'hover:bg-white/8' : 'hover:bg-black/5'
+              }`}
+              onMouseEnter={() => setSpotlightSelectedIndex(i)}
+              onClick={() => handleSelect(result)}
+            >
+              <div className={`w-2 h-2 rounded-full flex-shrink-0 bg-${task.color || 'gray'}-400`} />
+              <div className="min-w-0 flex-1">
+                <div className={`text-sm font-medium truncate ${textPrimary}`}>{task.title}</div>
+                <div className={`text-xs ${textSecondary} flex items-center gap-1`}>
+                  {date && <span>{date}</span>}
+                  {sourceLabel && <span className="opacity-60">· {sourceLabel}</span>}
+                  {match.field !== 'title' && <span className="opacity-60">· in {match.field}</span>}
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TrayVoice.jsx
+++ b/src/components/TrayVoice.jsx
@@ -1,0 +1,173 @@
+import { Mic, MicOff, X, Loader, RotateCcw } from 'lucide-react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+
+export default function TrayVoice({ darkMode, onClose }) {
+  const { textPrimary, textSecondary, borderClass, cardBg } = useDayPlannerCtx();
+  const {
+    aiConfig,
+    voiceCanRecord, voiceMicError,
+    voiceIsRecording, voiceIsTranscribing, voiceIsParsing,
+    voiceTranscript, setVoiceTranscript,
+    voiceParsedTasks, setVoiceParsedTasks,
+    voiceParsedEdits,
+    voiceParseError,
+    voiceManualMode, setVoiceManualMode,
+    voiceStartRecording, voiceStopRecording,
+    voiceParseWithAI, voiceApplyAllChanges,
+    voiceHasTranscription,
+  } = useFeaturesCtx();
+
+  const hasParsed = voiceParsedTasks !== null && (voiceParsedTasks?.length > 0 || voiceParsedEdits?.length > 0);
+  const isProcessing = voiceIsTranscribing || voiceIsParsing;
+  const canParse = aiConfig?.enabled && (voiceHasTranscription || voiceTranscript?.trim());
+
+  const handleApply = () => {
+    voiceApplyAllChanges();
+    onClose();
+  };
+
+  const handleBack = () => {
+    setVoiceParsedTasks(null);
+  };
+
+  // ── Preview phase ────────────────────────────────────────────────────────
+  if (hasParsed) {
+    return (
+      <div className="flex-1 flex flex-col overflow-hidden px-3 pb-3">
+        <div className={`flex items-center justify-between py-2.5 border-b ${borderClass} mb-3`}>
+          <span className={`text-sm font-semibold ${textPrimary}`}>
+            {(voiceParsedTasks?.length ?? 0) + (voiceParsedEdits?.length ?? 0)} change{(voiceParsedTasks?.length ?? 0) + (voiceParsedEdits?.length ?? 0) !== 1 ? 's' : ''} to apply
+          </span>
+          <button onClick={onClose} className={`${textSecondary} hover:opacity-70`}><X size={15} /></button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto space-y-1.5 mb-3">
+          {(voiceParsedTasks || []).map((t, i) => (
+            <div key={i} className={`${cardBg} rounded-lg px-3 py-2`}>
+              <div className={`text-sm font-medium ${textPrimary} truncate`}>{t.title}</div>
+              {(t.date || t.startTime) && (
+                <div className={`text-xs ${textSecondary} mt-0.5`}>
+                  {t.date && <span>{t.date}</span>}
+                  {t.startTime && <span> at {t.startTime}</span>}
+                </div>
+              )}
+            </div>
+          ))}
+          {(voiceParsedEdits || []).map((edit, i) => (
+            <div key={`edit-${i}`} className={`${cardBg} rounded-lg px-3 py-2`}>
+              <div className={`text-xs font-medium text-blue-400 mb-0.5 uppercase tracking-wide`}>{edit.action}</div>
+              <div className={`text-sm ${textPrimary} truncate`}>{edit.taskTitle ?? edit.id}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex gap-2 flex-shrink-0">
+          <button
+            onClick={handleBack}
+            className={`flex-1 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-70 ${
+              darkMode ? 'bg-white/10 text-gray-300' : 'bg-black/5 text-stone-600'
+            }`}
+          >
+            Back
+          </button>
+          <button
+            onClick={handleApply}
+            className="flex-1 py-2 rounded-lg text-sm font-semibold bg-blue-500 text-white transition-opacity hover:opacity-90"
+          >
+            Add all
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Input phase ──────────────────────────────────────────────────────────
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden px-3 pb-3">
+      <div className={`flex items-center justify-between py-2.5 border-b ${borderClass} mb-3`}>
+        <span className={`text-sm font-semibold ${textPrimary}`}>Voice input</span>
+        <button onClick={onClose} className={`${textSecondary} hover:opacity-70`}><X size={15} /></button>
+      </div>
+
+      {/* Mic button */}
+      {voiceCanRecord && !voiceManualMode && (
+        <div className="flex justify-center mb-3">
+          <button
+            onClick={voiceIsRecording ? voiceStopRecording : voiceStartRecording}
+            disabled={isProcessing}
+            className={`w-16 h-16 rounded-full flex items-center justify-center transition-all ${
+              voiceIsRecording
+                ? 'bg-red-500 animate-pulse shadow-lg shadow-red-500/40'
+                : isProcessing
+                  ? darkMode ? 'bg-white/10 text-gray-500' : 'bg-black/5 text-stone-400'
+                  : 'bg-blue-500 hover:bg-blue-600 shadow-lg shadow-blue-500/30'
+            }`}
+          >
+            {isProcessing
+              ? <Loader size={22} className="text-white animate-spin" />
+              : voiceIsRecording
+                ? <MicOff size={22} className="text-white" />
+                : <Mic size={22} className="text-white" />
+            }
+          </button>
+          {!voiceIsRecording && !isProcessing && (
+            <button
+              onClick={() => setVoiceManualMode(true)}
+              className={`ml-3 self-center text-xs ${textSecondary} hover:opacity-70 underline underline-offset-2`}
+            >
+              type instead
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Status */}
+      {(voiceIsRecording || isProcessing) && (
+        <p className={`text-xs text-center ${textSecondary} mb-2`}>
+          {voiceIsRecording ? 'Recording… tap to stop' : voiceIsTranscribing ? 'Transcribing…' : 'Parsing…'}
+        </p>
+      )}
+
+      {/* Transcript / manual textarea */}
+      {(voiceHasTranscription || voiceManualMode || !voiceCanRecord) && !isProcessing && (
+        <textarea
+          className={`flex-1 text-sm px-3 py-2 rounded-lg outline-none resize-none ${
+            darkMode ? 'bg-white/10 text-white placeholder-gray-500' : 'bg-black/5 text-stone-900 placeholder-stone-400'
+          }`}
+          placeholder="Describe tasks to add or changes to make…"
+          value={voiceTranscript || ''}
+          onChange={e => setVoiceTranscript(e.target.value)}
+          rows={4}
+        />
+      )}
+
+      {/* Error */}
+      {voiceParseError && (
+        <p className="text-xs text-red-400 mt-1">{voiceParseError}</p>
+      )}
+      {voiceMicError && (
+        <p className="text-xs text-red-400 mt-1">{voiceMicError}</p>
+      )}
+
+      {/* Parse / reset */}
+      {!isProcessing && canParse && (
+        <button
+          onClick={voiceParseWithAI}
+          className="mt-3 flex-shrink-0 py-2 rounded-lg text-sm font-semibold bg-blue-500 text-white transition-opacity hover:opacity-90"
+        >
+          Parse with AI
+        </button>
+      )}
+
+      {voiceManualMode && voiceCanRecord && (
+        <button
+          onClick={() => { setVoiceManualMode(false); setVoiceTranscript(''); }}
+          className={`mt-2 flex-shrink-0 flex items-center justify-center gap-1 text-xs ${textSecondary} hover:opacity-70`}
+        >
+          <RotateCcw size={12} /> use mic instead
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -119,6 +119,7 @@ export default function useElectronBridge({
   projects,
   unscheduledTasks,
   goalsProjectsEnabled,
+  goToDate,
 }) {
   const [pushTrigger, setPushTrigger] = useState(0);
 
@@ -229,6 +230,22 @@ export default function useElectronBridge({
     if (!window.electronAPI?.onRequestState) return;
     return window.electronAPI.onRequestState(() => setPushTrigger(n => n + 1));
   }, []);
+
+  // Handle navigation requests forwarded from the tray popup (main window only).
+  useEffect(() => {
+    if (isTrayMode || !window.electronAPI?.onTrayNavigate) return;
+    return window.electronAPI.onTrayNavigate((payload) => {
+      if (!payload?.action) return;
+      const { action, date, projectId } = payload;
+      if (action === 'goto-task' || action === 'goto-date') {
+        if (date) goToDate(date);
+      } else if (action === 'focus-mode') {
+        enterFocusModeRef.current?.();
+      } else if (action === 'hyperglance') {
+        if (projectId && date) enterHyperGlanceModeRef.current?.(projectId, date);
+      }
+    });
+  }, [goToDate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Push state snapshot whenever relevant state changes.
   useEffect(() => {


### PR DESCRIPTION
## Summary

Makes the menu bar tray popup a first-class interaction surface rather than a read-only view.

### IPC: "open in app" foundation
Every tray action that requires navigation now routes through a clean IPC channel: `openMainAt(payload)` → main process hides the popup and brings the main window to front → `tray:navigate` forwarded to the renderer → `useElectronBridge` dispatches to `goToDate` / `enterFocusMode` / `enterHyperGlanceMode`.

### TrayHeader (always visible at top)
- **Quick-add input** — type a task name, press Enter → added directly to inbox without opening the app
- **Search button** → opens TraySpotlight
- **Voice button** → opens TrayVoice (shown only when AI + mic are available)

### TraySpotlight (in-tray search)
Uses the existing spotlight context (query, results, keyboard navigation). Selecting a result calls `openMainAt` to bring the main window to that task. No modal backdrop — fills the tray window naturally. Keyboard: ↑↓ to navigate, Enter to open, Esc to close.

### TrayVoice (in-tray voice/text input)
Simplified voice panel: large mic button (animated while recording) + "type instead" toggle + textarea for manual input + AI Parse + preview list of parsed tasks/edits + "Add all" button. Tasks are added directly to inbox; the main window doesn't need to be open.

### GlanceSidebar `variant="tray"`
- Hides the search/filter/voice bar (now in TrayHeader)
- Task clicks → `openMainAt` (open app, navigate to that task)  
- GLANCEahead → `openMainAt` to tomorrow
- Focus Mode button → `openMainAt` to focus mode
- HyperGLANCE sessions → `openMainAt`

## Test plan

- [ ] Type in quick-add input, press Enter → task appears in inbox, input clears
- [ ] Click Search → TraySpotlight appears; type a query; click result → main window opens at that task
- [ ] Click Mic (if AI enabled) → TrayVoice appears; record/type; parse → preview; Add all → tasks in inbox, tray closes panel
- [ ] Click an agenda task → main window comes to front, calendar navigates to that date
- [ ] Click GLANCEahead card → main window opens on tomorrow
- [ ] Click Focus Mode on in-progress task → main window opens in focus mode
- [ ] Habits, routines, overdue task action buttons still work as before

https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP)_