### PR TITLE
fix(tray): polish — icon, now-bar, task color, complete sync, real-time quick-add

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -91,10 +91,12 @@ function createTrayWindow(): BrowserWindow {
 
 function createTray(): void {
   const iconPath = DEV
-    ? path.join(process.cwd(), 'public/icon-16x16.png')
-    : path.join(__dirname, '../dist/icon-16x16.png');
+    ? path.join(process.cwd(), 'public/icon-32x32.png')
+    : path.join(__dirname, '../dist/icon-32x32.png');
 
-  tray = new Tray(nativeImage.createFromPath(iconPath));
+  const icon = nativeImage.createFromPath(iconPath);
+  icon.setTemplateImage(true); // auto-adapts to light/dark menu bar (white on dark)
+  tray = new Tray(icon);
   tray.setToolTip('dayGLANCE');
   trayWindow = createTrayWindow();
 
@@ -142,6 +144,11 @@ ipcMain.on('tray:open-main', (_event, payload: unknown) => {
   live(trayWindow)?.hide();
   const mw = live(mainWindow);
   if (mw) { mw.show(); mw.focus(); mw.webContents.send('tray:navigate', payload); }
+});
+
+// Tray sends background mutations (e.g. toggle-complete) to the main window without showing it.
+ipcMain.on('tray:background-action', (_event, payload: unknown) => {
+  live(mainWindow)?.webContents.send('tray:background-action', payload);
 });
 
 // Keep tray popup in sync: reload it in the background whenever state changes

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -38,4 +38,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('tray:navigate', handler);
     return () => ipcRenderer.removeListener('tray:navigate', handler);
   },
+
+  // Tray sends background mutations (e.g. toggle-complete) that run in the
+  // main window without bringing it to the foreground.
+  backgroundAction: (payload: unknown) => ipcRenderer.send('tray:background-action', payload),
+  onBackgroundAction: (callback: (payload: unknown) => void) => {
+    const handler = (_: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+    ipcRenderer.on('tray:background-action', handler);
+    return () => ipcRenderer.removeListener('tray:background-action', handler);
+  },
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6233,6 +6233,7 @@ const DayPlanner = () => {
     goals,
     projects,
     unscheduledTasks,
+    setUnscheduledTasks,
     goalsProjectsEnabled,
     goToDate,
   });

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -440,8 +440,8 @@ const DesktopLayout = () => {
         );
         return (
           <div
-            style={{ height: titlebarH, WebkitAppRegion: 'drag', flexShrink: 0, paddingLeft: '85px' }}
-            className={`flex items-center gap-2 text-xs font-semibold overflow-hidden ${
+            style={{ height: titlebarH, WebkitAppRegion: 'drag', flexShrink: 0, paddingLeft: '85px', paddingRight: '85px' }}
+            className={`flex items-center justify-center gap-2 text-xs font-semibold overflow-hidden ${
               runningTask
                 ? (darkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-50 text-amber-800')
                 : ''

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -109,6 +109,13 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
 
   const openMainAt = (payload) => window.electronAPI?.openMainAt(payload);
 
+  // In tray mode, call local toggleComplete for immediate visual update AND
+  // send the action to the main window so its state stays in sync.
+  const doToggleComplete = (taskId, isDeadline = false) => {
+    toggleComplete(taskId, isDeadline);
+    if (isTray) window.electronAPI?.backgroundAction({ action: 'toggle-complete', taskId });
+  };
+
   return (
 <div className="space-y-4">
   {/* Search bar + filter — hidden in tray (TrayHeader handles search/voice) */}
@@ -548,7 +555,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                 className={`flex items-center gap-2.5 py-2 px-2 rounded-lg ${darkMode ? 'bg-white/5' : 'bg-white/80'}`}
               >
                 <button
-                  onClick={() => toggleComplete(task.id, task._overdueType === 'deadline')}
+                  onClick={() => doToggleComplete(task.id, task._overdueType === 'deadline')}
                   className={`w-5 h-5 rounded flex-shrink-0 border-2 ${task.completed
                     ? 'border-orange-400 bg-orange-400'
                     : darkMode ? 'border-orange-400/60 bg-white/10' : 'border-orange-400/60 bg-white'
@@ -597,7 +604,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                         <RefreshCw size={14} />
                       </span>
                       <button
-                        onClick={() => toggleComplete(task.id, false)}
+                        onClick={() => doToggleComplete(task.id, false)}
                         className={`p-1.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-stone-100 text-stone-500'} ${isDesktop ? 'hover:scale-95' : 'active:scale-95'} transition-transform`}
                         title="Mark complete"
                       >
@@ -919,7 +926,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                 </button>
               )}
               <button
-                onClick={(e) => { e.stopPropagation(); toggleComplete(task.id, false); }}
+                onClick={(e) => { e.stopPropagation(); doToggleComplete(task.id, false); }}
                 className={`p-1.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-stone-100 text-stone-500'} ${isDesktop ? 'hover:scale-95' : 'active:scale-95'} transition-transform`}
                 title="Mark complete"
               >

--- a/src/components/TrayHeader.jsx
+++ b/src/components/TrayHeader.jsx
@@ -23,6 +23,9 @@ export default function TrayHeader({ darkMode, onSearchClick, onVoiceClick }) {
       priority: 0,
     }]);
     setText('');
+    // Notify the main window to re-read inbox from localStorage so it sees
+    // the new task without needing a restart.
+    window.electronAPI?.backgroundAction({ action: 'refresh-inbox' });
   };
 
   const showVoice = aiConfig?.enabled && aiConfig?.features?.voiceTaskInput && voiceCanRecord;

--- a/src/components/TrayHeader.jsx
+++ b/src/components/TrayHeader.jsx
@@ -15,7 +15,7 @@ export default function TrayHeader({ darkMode, onSearchClick, onVoiceClick }) {
       id: crypto.randomUUID(),
       title,
       duration: 30,
-      color: 'gray',
+      color: 'bg-blue-500',
       completed: false,
       isAllDay: false,
       notes: '',

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -118,6 +118,7 @@ export default function useElectronBridge({
   goals,
   projects,
   unscheduledTasks,
+  setUnscheduledTasks,
   goalsProjectsEnabled,
   goToDate,
 }) {
@@ -141,6 +142,7 @@ export default function useElectronBridge({
   const setHgBreakMinutesRef = useRef(setHgBreakMinutes);
   const setHgLongBreakMinutesRef = useRef(setHgLongBreakMinutes);
   const setHgCompletedRef = useRef(setHgCompleted);
+  const setUnscheduledTasksRef = useRef(setUnscheduledTasks);
   skipFocusPhaseRef.current = skipFocusPhase;
   dismissFocusStatsRef.current = dismissFocusStats;
   focusCompleteTaskRef.current = focusCompleteTask;
@@ -159,6 +161,7 @@ export default function useElectronBridge({
   setHgBreakMinutesRef.current = setHgBreakMinutes;
   setHgLongBreakMinutesRef.current = setHgLongBreakMinutes;
   setHgCompletedRef.current = setHgCompleted;
+  setUnscheduledTasksRef.current = setUnscheduledTasks;
 
   // Subscribe to commands from WebSocket clients once on mount.
   useEffect(() => {
@@ -254,6 +257,11 @@ export default function useElectronBridge({
       if (!payload?.action) return;
       if (payload.action === 'toggle-complete') {
         toggleCompleteRef.current?.(payload.taskId, false);
+      } else if (payload.action === 'refresh-inbox') {
+        try {
+          const fresh = JSON.parse(localStorage.getItem('day-planner-unscheduled') || '[]');
+          setUnscheduledTasksRef.current?.(fresh);
+        } catch {}
       }
     });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -247,6 +247,17 @@ export default function useElectronBridge({
     });
   }, [goToDate]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Handle background mutations from the tray (no window focus change).
+  useEffect(() => {
+    if (isTrayMode || !window.electronAPI?.onBackgroundAction) return;
+    return window.electronAPI.onBackgroundAction((payload) => {
+      if (!payload?.action) return;
+      if (payload.action === 'toggle-complete') {
+        toggleCompleteRef.current?.(payload.taskId, false);
+      }
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Push state snapshot whenever relevant state changes.
   useEffect(() => {
     if (!window.electronAPI) return;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Follow-up fixes to the interactive tray popup (PR #660).

- **Tray icon** — switched to 32×32 and `setTemplateImage(true)` so macOS renders it white on dark menu bars and black on light ones automatically
- **Now-bar centering** — added `paddingRight: 85px` to match the left padding + `justify-center`, so the running task title centers between the traffic lights and the right edge
- **Quick-add task color** — was `'gray'` (not a valid Tailwind class), causing transparent inbox cards; changed to `'bg-blue-500'`
- **Complete action sync** — added `tray:background-action` IPC channel; completing a task in the tray now immediately updates the main window state without bringing it to the foreground
- **Quick-add sync** — tray was writing to localStorage but the main window had no mechanism to pick it up until restart; TrayHeader now sends a `refresh-inbox` background action after adding a task, and the main window re-reads from localStorage immediately

## Test plan

- [ ] Tray icon appears white on dark menu bar, adapts on light menu bar
- [x] With a task running, the "Now: …" text in the title bar is horizontally centered
- [ ] Quick-add a task in the tray → appears in the main window Inbox immediately with a solid blue background (no restart needed)
- [x] Tap the complete checkmark on a tray task → task is marked done in the main window without the window coming to the foreground

https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP)_