### PR TITLE
fix(tray): icon size, badge count, quick-add IPC race

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -91,8 +91,8 @@ function createTrayWindow(): BrowserWindow {
 
 function createTray(): void {
   const iconPath = DEV
-    ? path.join(process.cwd(), 'public/icon-32x32.png')
-    : path.join(__dirname, '../dist/icon-32x32.png');
+    ? path.join(process.cwd(), 'public/icon-16x16.png')
+    : path.join(__dirname, '../dist/icon-16x16.png');
 
   const icon = nativeImage.createFromPath(iconPath);
   icon.setTemplateImage(true); // auto-adapts to light/dark menu bar (white on dark)

--- a/src/components/TrayHeader.jsx
+++ b/src/components/TrayHeader.jsx
@@ -11,7 +11,7 @@ export default function TrayHeader({ darkMode, onSearchClick, onVoiceClick }) {
   const commit = () => {
     const title = text.trim();
     if (!title) return;
-    setUnscheduledTasks(prev => [...prev, {
+    const newTask = {
       id: crypto.randomUUID(),
       title,
       duration: 30,
@@ -21,11 +21,12 @@ export default function TrayHeader({ darkMode, onSearchClick, onVoiceClick }) {
       notes: '',
       subtasks: [],
       priority: 0,
-    }]);
+    };
+    setUnscheduledTasks(prev => [...prev, newTask]);
     setText('');
-    // Notify the main window to re-read inbox from localStorage so it sees
-    // the new task without needing a restart.
-    window.electronAPI?.backgroundAction({ action: 'refresh-inbox' });
+    // Send the task directly in the payload so the main window doesn't race
+    // against the tray's async localStorage write.
+    window.electronAPI?.backgroundAction({ action: 'add-inbox-task', task: newTask });
   };
 
   const showVoice = aiConfig?.enabled && aiConfig?.features?.voiceTaskInput && voiceCanRecord;

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -257,11 +257,8 @@ export default function useElectronBridge({
       if (!payload?.action) return;
       if (payload.action === 'toggle-complete') {
         toggleCompleteRef.current?.(payload.taskId, false);
-      } else if (payload.action === 'refresh-inbox') {
-        try {
-          const fresh = JSON.parse(localStorage.getItem('day-planner-unscheduled') || '[]');
-          setUnscheduledTasksRef.current?.(fresh);
-        } catch {}
+      } else if (payload.action === 'add-inbox-task' && payload.task) {
+        setUnscheduledTasksRef.current?.(prev => [...(prev || []), payload.task]);
       }
     });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -302,7 +302,7 @@ export default function useElectronBridge({
     const todayRecurring = (expandedRecurringTasks || []).filter(t => t.date === todayStr);
     // Include recurring instances in counts (stable denominator — all tasks regardless of completion/time)
     const todayTasks = [
-      ...tasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay),
+      ...tasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay && !(t.imported && !t.isTaskCalendar)),
       ...todayRecurring.filter(t => t.startTime && !t.isAllDay),
       ...hgSessions,
     ];


### PR DESCRIPTION
## Summary

Three fixes discovered during testing of PR #661.

- **Tray icon** — 32×32 was too wide at 32 logical points; reverted to 16×16 (macOS scales it for Retina automatically)
- **Dock badge** — was counting imported CalDAV/ICS events with start times as incomplete tasks; now excludes `imported && !isTaskCalendar` events, matching the filter used everywhere else in the app
- **Quick-add IPC race** — `refresh-inbox` sent the IPC before React's useEffect had written to localStorage, so the main window always read stale data; now the task object travels directly in the `add-inbox-task` payload, bypassing localStorage timing entirely

## Test plan

- [ ] Tray icon is correctly sized in the menu bar
- [x] Dock badge reflects only incomplete user-created scheduled tasks (not imported calendar events)
- [x] Quick-add a task in the tray → appears in the main window Inbox immediately

https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRxuNGNuxaPqQkV1VepJSP)_