### PR TITLE
fix(tray): eliminate all tray-popup side effects (Stream Deck + reminder regressions)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -207,7 +207,7 @@ ipcMain.on('ws:push-state', (event) => {
 
 app.whenReady().then(() => {
   const win = createWindow();
-  createWsServer(win);
+  createWsServer(() => live(mainWindow));
   if (process.platform === 'darwin') createTray();
 
   app.on('activate', () => {

--- a/electron/ws-server.ts
+++ b/electron/ws-server.ts
@@ -4,7 +4,10 @@ import type { OutboundMessage } from './protocol.js';
 
 const WS_PORT = 7892;
 
-export function createWsServer(win: BrowserWindow): WebSocketServer {
+// Accepts a getter so commands are always routed to the current main window,
+// even if it was closed and recreated after startup (possible when the tray
+// keeps the process alive).
+export function createWsServer(getMainWindow: () => BrowserWindow | null): WebSocketServer {
   const wss = new WebSocketServer({ port: WS_PORT });
   const clients = new Set<WebSocket>();
   let lastState: string | null = null;
@@ -15,13 +18,13 @@ export function createWsServer(win: BrowserWindow): WebSocketServer {
       ws.send(lastState);
     } else {
       // Renderer hasn't pushed yet — ask it to send current state now.
-      win.webContents.send('ws:request-state');
+      getMainWindow()?.webContents.send('ws:request-state');
     }
 
     ws.on('message', (raw) => {
       try {
         const msg = JSON.parse(raw.toString());
-        win.webContents.send('ws:command', msg);
+        getMainWindow()?.webContents.send('ws:command', msg);
       } catch {
         // drop malformed frames
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -863,6 +863,7 @@ const DayPlanner = () => {
 
   // Check for app updates on mount and every 6 hours
   useEffect(() => {
+    if (isTrayMode) return;
     const currentVersion = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0';
     const doCheck = async () => {
       const result = await checkForUpdate(currentVersion);
@@ -1137,6 +1138,7 @@ const DayPlanner = () => {
 
   // Catch up on missed reminders and sync when tab becomes visible
   useEffect(() => {
+    if (isTrayMode) return;
     const handleVisibility = () => {
       if (!document.hidden) {
         setCurrentTime(new Date());
@@ -1152,6 +1154,7 @@ const DayPlanner = () => {
 
   // Auto-refresh page at midnight (00:00:01) to reset the timeline to the new day
   useEffect(() => {
+    if (isTrayMode) return;
     const calculateMsUntilMidnight = () => {
       const now = new Date();
       const midnight = new Date(now);
@@ -1186,6 +1189,7 @@ const DayPlanner = () => {
   // Auto-sync calendars every 15 minutes when URLs are configured.
   // On Android, only the task calendar matters — calendar events come from the native bridge.
   useEffect(() => {
+    if (isTrayMode) return;
     const hasSyncTarget = isNativeAndroid() ? !!taskCalendarUrl : !!(syncUrl || taskCalendarUrl);
     if (!hasSyncTarget) return;
 
@@ -1198,7 +1202,7 @@ const DayPlanner = () => {
 
   // Cloud sync: debounced upload on data changes
   useEffect(() => {
-    if (!cloudSyncConfig?.enabled || !dataLoaded || suppressCloudUploadRef.current) return;
+    if (isTrayMode || !cloudSyncConfig?.enabled || !dataLoaded || suppressCloudUploadRef.current) return;
     if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current);
     cloudSyncDebounceRef.current = setTimeout(() => {
       cloudSyncUpload();
@@ -1210,6 +1214,7 @@ const DayPlanner = () => {
   // If encryption is enabled, wait until the session key is ready (either
   // restored from IndexedDB or provided by the passphrase modal).
   useEffect(() => {
+    if (isTrayMode) return;
     if (dataLoaded && cloudSyncConfig?.enabled && syncKeyReady) {
       cloudSyncDownload();
     } else if (dataLoaded && !cloudSyncConfig?.enabled) {
@@ -1220,7 +1225,7 @@ const DayPlanner = () => {
 
   // Cloud sync: poll for remote changes every 60 seconds
   useEffect(() => {
-    if (!cloudSyncConfig?.enabled) return;
+    if (isTrayMode || !cloudSyncConfig?.enabled) return;
     const pollTimer = setInterval(() => {
       if (syncKeyReadyRef.current && Date.now() >= cloudSyncBackoffUntilRef.current) {
         cloudSyncDownloadRef.current?.();
@@ -1237,7 +1242,7 @@ const DayPlanner = () => {
     performTrmnlSyncRef.current = performTrmnlSync;
   });
   useEffect(() => {
-    if (!trmnlConfig?.enabled || !trmnlConfig?.webhookUrl || !dataLoaded) return;
+    if (isTrayMode || !trmnlConfig?.enabled || !trmnlConfig?.webhookUrl || !dataLoaded) return;
     if (trmnlSyncTimerRef.current) clearTimeout(trmnlSyncTimerRef.current);
     trmnlSyncTimerRef.current = setTimeout(() => {
       const now = Date.now();
@@ -1259,7 +1264,7 @@ const DayPlanner = () => {
 
   // Auto-archive completed inbox tasks older than the configured threshold
   useEffect(() => {
-    if (!dataLoaded || inboxAutoArchiveDays === 0) return;
+    if (isTrayMode || !dataLoaded || inboxAutoArchiveDays === 0) return;
     const cutoff = Date.now() - inboxAutoArchiveDays * 86400000;
     setUnscheduledTasks(prev => {
       const hasChanges = prev.some(t => t.completed && !t.archived && t.completedAt && new Date(t.completedAt).getTime() < cutoff);
@@ -1274,7 +1279,7 @@ const DayPlanner = () => {
 
   // Obsidian sync: restore vault handle on mount and do initial sync
   useEffect(() => {
-    if (!dataLoaded) return;
+    if (isTrayMode || !dataLoaded) return;
     if (isNativeAndroid()) {
       // Android: vault is configured natively — detect and auto-enable
       try {
@@ -1318,6 +1323,7 @@ const DayPlanner = () => {
 
   // Obsidian sync: on visibility change (user switches back from Obsidian / native settings)
   useEffect(() => {
+    if (isTrayMode) return;
     const handleVisibility = () => {
       if (document.visibilityState !== 'visible') return;
       if (isNativeAndroid()) {
@@ -1349,7 +1355,7 @@ const DayPlanner = () => {
 
   // Obsidian sync: poll every 5 minutes while open
   useEffect(() => {
-    if (!obsidianConfig?.enabled) return;
+    if (isTrayMode || !obsidianConfig?.enabled) return;
     const timer = setInterval(() => {
       if (obsidianVaultHandleRef.current) performObsidianSync();
     }, 5 * 60 * 1000);
@@ -1362,7 +1368,7 @@ const DayPlanner = () => {
 
   // Obsidian writeback: detect completion/scheduling/title changes and write back to vault
   useEffect(() => {
-    if (!obsidianConfig?.enabled || !obsidianVaultHandleRef.current) return;
+    if (isTrayMode || !obsidianConfig?.enabled || !obsidianVaultHandleRef.current) return;
     // Skip writeback while a sync is replacing the task arrays
     if (obsidianSyncInProgressRef.current) return;
 
@@ -1464,7 +1470,7 @@ const DayPlanner = () => {
 
   // Auto-backup timer
   useEffect(() => {
-    if (!dataLoaded) return;
+    if (isTrayMode || !dataLoaded) return;
     const localEnabled = autoBackupConfig.local.enabled;
     const remoteEnabled = autoBackupConfig.remote.enabled;
     if (!localEnabled && !remoteEnabled) return;
@@ -5919,7 +5925,7 @@ const DayPlanner = () => {
   // Auto-trigger frame nudge when entering a new Frame
   const prevFrameNudgeKeyRef = useRef(null);
   useEffect(() => {
-    if (!aiConfig.enabled || !aiConfig.features?.frameNudge) return;
+    if (isTrayMode || !aiConfig.enabled || !aiConfig.features?.frameNudge) return;
     if (gtdFrames.filter(f => f.enabled).length === 0) return;
     if (activeFrameNudgeKey === prevFrameNudgeKeyRef.current) return;
     prevFrameNudgeKeyRef.current = activeFrameNudgeKey;

--- a/src/hooks/useAppInit.js
+++ b/src/hooks/useAppInit.js
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { isNativeAndroid } from '../native.js';
 
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+
 export default function useAppInit({
   loadData, fetchAllDailyContent, setContentRotation,
   dailyContentEnabled,
@@ -11,6 +13,7 @@ export default function useAppInit({
   // Load data and fetch daily content on mount; rotate content every 15 minutes
   useEffect(() => {
     loadData();
+    if (isTrayMode) return;
     if (dailyContentEnabled && !isNativeAndroid()) {
       fetchAllDailyContent();
     }
@@ -27,6 +30,7 @@ export default function useAppInit({
 
   // Persist welcome dismissal only when user has real tasks
   useEffect(() => {
+    if (isTrayMode) return;
     if (!showWelcome && !hasZeroRealTasks) {
       localStorage.setItem('welcomeDismissed', 'true');
     }
@@ -34,6 +38,7 @@ export default function useAppInit({
 
   // Show welcome only on initial load with zero tasks (not when zeroing out during session)
   useEffect(() => {
+    if (isTrayMode) return;
     if (dataLoaded && !hasCheckedInitialWelcome.current) {
       hasCheckedInitialWelcome.current = true;
       if (hasZeroRealTasks) {

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -332,7 +332,7 @@ export default function useElectronBridge({
     const todayRecurring = (expandedRecurringTasks || []).filter(t => t.date === todayStr);
     // Include recurring instances in counts (stable denominator — all tasks regardless of completion/time)
     const todayTasks = [
-      ...tasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay && !(t.imported && !t.isTaskCalendar)),
+      ...tasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay),
       ...todayRecurring.filter(t => t.startTime && !t.isAllDay),
       ...hgSessions,
     ];
@@ -394,8 +394,9 @@ export default function useElectronBridge({
 
     if (isTrayMode) return;
 
-    // Dock badge: incomplete scheduled tasks today
-    window.electronAPI.setBadgeCount?.(todayTasks.filter(t => !t.completed).length);
+    // Dock badge: incomplete scheduled tasks today, excluding imported calendar events
+    // (imported events can't be "completed" by the user and shouldn't inflate the badge)
+    window.electronAPI.setBadgeCount?.(todayTasks.filter(t => !t.completed && !(t.imported && !t.isTaskCalendar)).length);
 
     window.electronAPI.pushState({
       v: PROTOCOL_VERSION,

--- a/src/hooks/useReminderEngine.js
+++ b/src/hooks/useReminderEngine.js
@@ -272,7 +272,7 @@ export default function useReminderEngine({
   // or HG sessions change. On device reboot, ReminderReceiver.BOOT_COMPLETED
   // re-registers from the persisted list stored by nativeSyncReminders.
   useEffect(() => {
-    if (!isNativeAndroid()) return;
+    if (isTrayMode || !isNativeAndroid()) return;
 
     const todayStr = dateToString(new Date());
     const todayMidnight = new Date();

--- a/src/hooks/useReminderEngine.js
+++ b/src/hooks/useReminderEngine.js
@@ -2,6 +2,10 @@ import { useState, useRef, useEffect } from 'react';
 import { dateToString, stripWikilinks } from '../utils/taskUtils.js';
 import { isNativeAndroid, nativeShowNotification, nativeShowTaskNotification, nativeSyncReminders } from '../native.js';
 
+// The tray popup runs the same App tree — skip the reminder engine there so
+// sounds and notifications don't fire twice (once per renderer process).
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+
 // Pure local helpers
 const timeToMinutes = (time) => {
   const [hours, minutes] = time.split(':').map(Number);
@@ -64,6 +68,7 @@ export default function useReminderEngine({
 
   // Reminder notification engine
   useEffect(() => {
+    if (isTrayMode) return;
     // Weekly review notification (independent of main reminder toggle)
     const wr = reminderSettings.weeklyReview;
     if (wr?.enabled) {
@@ -249,7 +254,7 @@ export default function useReminderEngine({
 
   // Auto-dismiss reminders based on type
   useEffect(() => {
-    if (activeReminders.length === 0) return;
+    if (isTrayMode || activeReminders.length === 0) return;
     const dismissMs = { before15: 870000, before10: 570000, before5: 270000, start: 600000, end: 300000 };
     const timer = setInterval(() => {
       const now = Date.now();

--- a/src/hooks/useSaveOnChange.js
+++ b/src/hooks/useSaveOnChange.js
@@ -1,5 +1,9 @@
 import { useEffect } from 'react';
 
+// The tray popup must never write to localStorage — it holds a snapshot of
+// state as of the last reload and would overwrite fresher main-window data.
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+
 export default function useSaveOnChange({
   saveData, checkConflicts,
   dataLoaded,
@@ -10,7 +14,7 @@ export default function useSaveOnChange({
   goals, projects, goalsProjectsEnabled,
 }) {
   useEffect(() => {
-    if (!dataLoaded) return; // Don't overwrite localStorage before initial load
+    if (isTrayMode || !dataLoaded) return;
     saveData();
     checkConflicts();
     // After the first save pass following applyRemoteData, clear the suppress flags

--- a/src/hooks/useWeather.js
+++ b/src/hooks/useWeather.js
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+
 const getWeatherCondition = (code) => {
   if (code === 0) return 'Clear';
   if ([1, 2, 3].includes(code)) return 'Partly Cloudy';
@@ -151,6 +153,7 @@ const useWeather = () => {
 
   // Fetch on mount and refresh every hour
   useEffect(() => {
+    if (isTrayMode) return;
     fetchWeather();
     const weatherInterval = setInterval(() => {
       fetchWeather();


### PR DESCRIPTION
## Summary

- **Stream Deck buttons unresponsive** — `ws-server.ts` captured the main `BrowserWindow` at startup. Once the tray kept the process alive and the main window was closed/reopened, the reference went stale (destroyed object); `webContents.send('ws:command', …)` silently failed. Fixed by switching to a `getMainWindow` getter so commands always target the current live window.

- **Calendar events missing from Stream Deck Agenda** — A prior badge-count fix filtered imported calendar events out of `todayTasks` in `useElectronBridge.js`. That same array fed `scheduledTasks` sent to the Deck. Fixed by keeping `todayTasks` inclusive and scoping the import filter to the badge count call only.

- **15–20 reminder sounds per event** — Both the main window and the tray run the full React tree, each with their own `firedRemindersRef = useRef(new Set())`. The tray reloads every ~15 s (driven by `currentTime` ticking → state push → 500 ms debounce), resetting the ref and re-firing reminders within the 2-minute window. Fixed with `if (isTrayMode) return;` in `useReminderEngine.js`.

- **Full tray side-effect audit** — The tray was silently running every background effect the main window runs. Added `isTrayMode` guards across all affected files:

| File | Effects suppressed |
|---|---|
| `useSaveOnChange.js` | localStorage writes from stale tray snapshot (data corruption risk) |
| `App.jsx` | Cloud sync upload/download/poll, calendar auto-sync, TRMNL push, inbox auto-archive, Obsidian restore/poll/writeback, auto-backup, update check, midnight reload, visibilitychange handler, frame nudge AI calls |
| `useWeather.js` | Weather fetch + 60-min refresh interval |
| `useAppInit.js` | Daily content fetch, 15-min rotation interval, welcome-screen localStorage writes |
| `useReminderEngine.js` | `nativeSyncReminders` Android block |

## Test plan

- [x] Stream Deck: press Habit, Routine, and Agenda task buttons — actions should apply in the main window
- [x] Stream Deck Agenda: calendar/imported events appear alongside tasks
- [ ] Single task reminder fires exactly once (one sound, one notification)
- [x] Tray popup displays correctly and reflects main-window state after mutations
- [x] Cloud sync, Obsidian, and TRMNL still work normally from the main window

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_