### PR TITLE
fix(stream-deck): show past calendar events as Done in Agenda tile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,20 +41,11 @@ Use **merge, not rebase** — rebasing rewrites history and breaks branches cut 
 
 The files most likely to need conflict resolution during syncs are `App.jsx`, `GlanceSidebar.jsx`, and `MobileGlanceSection.jsx` (all touched by hyperGLANCE).
 
-## Electron desktop app + Stream Deck plugin — `electron-develop`
+## Electron desktop app + Stream Deck plugin
 
-`electron-develop` is the long-lived integration branch for the Mac/Windows desktop app and the Stream Deck plugin. Both ship together and share `electron/protocol.ts` as the canonical WS protocol contract.
+The Electron main process lives in `electron/` (compiled to `dist-electron/`). The renderer is the existing Vite/React app. The WebSocket server (`electron/ws-server.ts`) runs on `ws://localhost:7892` and is the integration point for the Stream Deck plugin. The plugin lives in `stream-deck-plugin/` and is built separately with Rollup. `electron/protocol.ts` is the canonical WS protocol contract — all message types and wire-format types live there.
 
-- Feature branches are cut from `electron-develop` (not `main`).
-- PRs target `electron-develop` (not `main`).
-- `main` does **not** receive these changes until the desktop app ships.
-
-```bash
-git fetch origin electron-develop
-git checkout -b <feature-branch> origin/electron-develop
-```
-
-The Electron main process lives in `electron/` (compiled to `dist-electron/`). The renderer is the existing Vite/React app. The WebSocket server (`electron/ws-server.ts`) runs on `ws://localhost:7892` and is the integration point for the Stream Deck plugin. The plugin lives in `stream-deck-plugin/` and is built separately with Rollup.
+Feature branches for Electron/Stream Deck work are cut from `main` and PRs target `main`.
 
 ## GitHub Issues
 

--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -37,6 +37,8 @@ export type Task = {
   completed: boolean;
   isAllDay?: boolean;
   isHGSession?: boolean;
+  imported?: boolean;       // true for events imported from external calendar feeds
+  isTaskCalendar?: boolean; // true only for the user's own task calendar (completable)
 };
 
 export type FocusState = {

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -326,7 +326,14 @@ export default function useElectronBridge({
       completed: !!t.completed,
       isAllDay: !!t.isAllDay,
       isHGSession: !!t.isHGSession,
+      imported: !!t.imported,
+      isTaskCalendar: !!t.isTaskCalendar,
     } : null;
+
+    // A read-only calendar event whose time window has passed is effectively done.
+    const isPastCalendarEvent = (t) =>
+      t.imported && !t.isTaskCalendar && !t.isAllDay && t.startTime &&
+      timeToMinutes(t.startTime) + (t.duration || 0) <= nowMin;
 
     const todayStr = dateToString(currentTime);
     const todayRecurring = (expandedRecurringTasks || []).filter(t => t.date === todayStr);
@@ -411,7 +418,7 @@ export default function useElectronBridge({
       ],
       today: {
         total: todayTasks.length + allDayTasks.length,
-        completed: todayTasks.filter(t => t.completed).length + allDayTasks.filter(t => t.completed).length,
+        completed: todayTasks.filter(t => t.completed || isPastCalendarEvent(t)).length + allDayTasks.filter(t => t.completed).length,
         date: todayStr,
       },
       focus: {

--- a/stream-deck-plugin/src/actions/agenda.ts
+++ b/stream-deck-plugin/src/actions/agenda.ts
@@ -100,7 +100,10 @@ export class AgendaAction extends SingletonAction {
   private async completeCurrentTask(): Promise<void> {
     if (!this.lastState || this.viewIndex === 0) return;
     const task = this.lastState.scheduledTasks?.[this.viewIndex - 1];
-    if (task && !task.isHGSession) send({ type: MSG_DAY_TASK_COMPLETE, id: task.id });
+    // Read-only calendar events (imported, not the user's task calendar) can't be completed
+    if (task && !task.isHGSession && !(task.imported && !task.isTaskCalendar)) {
+      send({ type: MSG_DAY_TASK_COMPLETE, id: task.id });
+    }
   }
 
   private async renderAll(state: DayGlanceState): Promise<void> {
@@ -124,11 +127,13 @@ export class AgendaAction extends SingletonAction {
       const task = tasks[this.viewIndex - 1];
       const title = truncate(stripTags(task.title), 12);
       const use24Hour = state.use24Hour ?? false;
-      const sub = task.completed ? "Completed"
+      const calDone = !task.completed && isCalendarEventDone(task);
+      const effectivelyDone = task.completed || calDone;
+      const sub = effectivelyDone ? "Done"
         : task.isAllDay ? "All Day"
         : task.startTime ? statusLabel(task.startTime, task.duration, use24Hour)
         : "";
-      renderOpts = { value: title, sub, barColor: task.colorHex, strikethrough: task.completed };
+      renderOpts = { value: title, sub, barColor: task.colorHex, strikethrough: effectivelyDone };
     }
 
     await act.setImage(renderKey(renderOpts));
@@ -166,4 +171,11 @@ function statusLabel(startTime: string, duration: number, use24Hour: boolean): s
   if (start > now) return formatTime(startTime, use24Hour);
   if (duration > 0 && start + duration > now) return "In Progress";
   return "Overdue";
+}
+
+// Read-only calendar events (imported, not the user's task calendar) are
+// "done" once their time window has passed — they can't be completed manually.
+function isCalendarEventDone(task: { imported?: boolean; isTaskCalendar?: boolean; isAllDay?: boolean; startTime: string | null; duration: number }): boolean {
+  if (!task.imported || task.isTaskCalendar || task.isAllDay || !task.startTime) return false;
+  return toMin(task.startTime) + task.duration <= nowMin();
 }


### PR DESCRIPTION
## Summary

- **Past calendar events now show as "Done"** (not "Overdue") in the Stream Deck Agenda tile. External calendar events can't be completed by the user — once their time window passes they're done by definition.
- **Strikethrough applied** to past calendar events, consistent with how completed tasks are displayed.
- **Counted as completed in X/Y %** — past calendar events now contribute to the `completed` count in the overview tile, so the progress display reflects the actual shape of the day.
- **Complete button no-ops on calendar events** — pressing the button on a read-only calendar event no longer sends a `task:complete` command (which would have been silently ignored anyway, but now it's explicit).
- **CLAUDE.md**: removed the stale `electron-develop` branch instructions; Electron/Stream Deck work now branches from and targets `main`.

## How it works

Added `imported` and `isTaskCalendar` fields to the `Task` protocol type. `useElectronBridge` passes these through and uses them to count past calendar events as completed. The plugin's `agenda.ts` uses a new `isCalendarEventDone()` helper — `imported && !isTaskCalendar && endTime <= now` — to drive the "Done" label, strikethrough, and button guard.

## Test plan

- [ ] Past calendar events (from an external feed) show "Done" + strikethrough in Agenda tile
- [ ] In-progress calendar events still show "In Progress"
- [ ] Future calendar events still show their start time
- [ ] X/Y % in the overview counts past calendar events as completed
- [ ] Pressing the complete button on a calendar event does nothing (no error)
- [ ] Regular tasks still complete normally via the button
- [ ] Task calendar events (isTaskCalendar) are unaffected — still completable

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_