### PR TITLE
Tray icon reminder indicator dot

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -138,7 +138,7 @@ function createTray(): void {
   tray.setToolTip('dayGLANCE');
   trayWindow = createTrayWindow();
 
-  // Left-click: toggle the Glance popup
+  // Left-click: toggle the Glance popup; clear any pending reminder indicator.
   tray.on('click', (_event, bounds) => {
     const tw = live(trayWindow);
     if (!tw) return;
@@ -146,6 +146,7 @@ function createTray(): void {
     const { x, y, width: iconW, height: iconH } = bounds;
     const { width: popW } = tw.getBounds();
     tw.setPosition(Math.round(x - popW / 2 + iconW / 2), Math.round(y + iconH));
+    tray?.setTitle('');
     tw.show();
     tw.focus();
   });
@@ -187,6 +188,11 @@ ipcMain.on('tray:open-main', (_event, payload: unknown) => {
 // Tray sends background mutations (e.g. toggle-complete) to the main window without showing it.
 ipcMain.on('tray:background-action', (_event, payload: unknown) => {
   live(mainWindow)?.webContents.send('tray:background-action', payload);
+});
+
+// Reminder indicator: show/clear the dot next to the tray icon.
+ipcMain.on('tray:set-indicator', (_event, on: boolean) => {
+  tray?.setTitle(on ? '●' : '');
 });
 
 // Keep tray popup in sync: reload it in the background whenever state changes

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -47,4 +47,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('tray:background-action', handler);
     return () => ipcRenderer.removeListener('tray:background-action', handler);
   },
+
+  // Show or clear the reminder dot (●) next to the tray icon.
+  setTrayIndicator: (on: boolean) => ipcRenderer.send('tray:set-indicator', on),
 });

--- a/src/hooks/useReminderEngine.js
+++ b/src/hooks/useReminderEngine.js
@@ -151,6 +151,7 @@ export default function useReminderEngine({
 
       if (hgFires.length > 0) {
         playUISound('reminder');
+        if (window.electronAPI?.isElectron) window.electronAPI.setTrayIndicator(true);
         // Android: AlarmManager already fires showTaskNotification (with Snooze) — don't duplicate.
         if (!isNativeAndroid() && reminderSettings.browserNotifications && typeof Notification !== 'undefined' && Notification.permission === 'granted') {
           if (window.electronAPI?.isElectron) {
@@ -220,6 +221,7 @@ export default function useReminderEngine({
 
     if (newReminders.length > 0) {
       playUISound('reminder');
+      if (window.electronAPI?.isElectron) window.electronAPI.setTrayIndicator(true);
       if (reminderSettings.inAppToasts !== false) {
         const newTaskIds = new Set(newReminders.map(r => r.taskId));
         setActiveReminders(prev => [...prev.filter(r => !newTaskIds.has(r.taskId)), ...newReminders]);


### PR DESCRIPTION
## Summary

- When a task, event, or hyperGLANCE session reminder fires on macOS, a `●` appears next to the dayGLANCE icon in the menu bar
- Opening the tray popup (click or hotkey) clears the dot
- The indicator is independent of the `browserNotifications` toggle — it's always on when the tray is present

## Changes

- **`electron/preload.ts`** — exposes `setTrayIndicator(on: boolean)` → `ipcRenderer.send('tray:set-indicator', on)`
- **`electron/main.ts`** — `tray:set-indicator` IPC handler calls `tray.setTitle('●' | '')`; tray click handler also clears the title on open
- **`src/hooks/useReminderEngine.js`** — calls `setTrayIndicator(true)` when task/event reminders fire and when hyperGLANCE session reminders fire (both guarded by `isElectron`)

## Notes on snooze in system notifications

The existing `new Notification()` call in the renderer (Chromium web API) doesn't support action buttons. Electron's main-process `Notification` class does support `actions` (Snooze / Done) on macOS — that's a follow-up once focus mode notifications are also in scope, since they'd share the same IPC plumbing.

## Test plan

- [ ] Let a task reminder fire → `●` appears next to menu bar icon
- [ ] Click the icon → popup opens, `●` disappears
- [ ] hyperGLANCE "up next" and "starting now" reminders also trigger the dot
- [ ] Dot does not appear on non-macOS or non-Electron builds

https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_