### PR TITLE
Focus mode tray popup and menu bar countdown

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -20,6 +20,13 @@ let trayNeedsReload = false;
 let trayReloadTimer: ReturnType<typeof setTimeout> | null = null;
 let registeredHotkey: string | null = null;
 
+// Tray menu bar title: focus countdown takes priority over the reminder dot.
+let trayIndicatorOn = false;
+let trayFocusTitle = '';
+function refreshTrayTitle() {
+  tray?.setTitle(trayFocusTitle || (trayIndicatorOn ? '●' : ''));
+}
+
 // Safe accessor — returns null if the window has been destroyed so callers
 // never have to scatter isDestroyed() checks throughout the file.
 function live(win: BrowserWindow | null): BrowserWindow | null {
@@ -147,7 +154,8 @@ function createTray(): void {
     const { x, y, width: iconW, height: iconH } = bounds;
     const { width: popW } = tw.getBounds();
     tw.setPosition(Math.round(x - popW / 2 + iconW / 2), Math.round(y + iconH));
-    tray?.setTitle('');
+    trayIndicatorOn = false;
+    refreshTrayTitle();
     tw.show();
     tw.focus();
   });
@@ -193,7 +201,21 @@ ipcMain.on('tray:background-action', (_event, payload: unknown) => {
 
 // Reminder indicator: show/clear the dot next to the tray icon.
 ipcMain.on('tray:set-indicator', (_event, on: boolean) => {
-  tray?.setTitle(on ? '●' : '');
+  trayIndicatorOn = on;
+  refreshTrayTitle();
+});
+
+// Focus state: update menu bar countdown and forward to tray popup.
+ipcMain.on('tray:push-focus-state', (_event, state: { active: boolean; secondsRemaining: number }) => {
+  if (state.active) {
+    const m = Math.floor(state.secondsRemaining / 60);
+    const s = state.secondsRemaining % 60;
+    trayFocusTitle = `${m}:${s.toString().padStart(2, '0')}`;
+  } else {
+    trayFocusTitle = '';
+  }
+  refreshTrayTitle();
+  live(trayWindow)?.webContents.send('tray:focus-state', state);
 });
 
 // Global hotkey: show tray popup and focus quick-add input.
@@ -213,7 +235,8 @@ ipcMain.handle('hotkey:register', (_event, accelerator: string) => {
       const { width: popW } = tw.getBounds();
       tw.setPosition(Math.round(x - popW / 2 + iconW / 2), Math.round(y + iconH));
     }
-    tray?.setTitle('');
+    trayIndicatorOn = false;
+    refreshTrayTitle();
     tw.show();
     tw.focus();
     tw.webContents.send('tray:focus-quick-add');

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -205,6 +205,11 @@ ipcMain.on('tray:set-indicator', (_event, on: boolean) => {
   refreshTrayTitle();
 });
 
+// Reminder list: forward to tray popup whenever it changes.
+ipcMain.on('tray:push-reminders', (_event, reminders: unknown) => {
+  live(trayWindow)?.webContents.send('tray:reminders', reminders);
+});
+
 // Focus state: update menu bar countdown and forward to tray popup.
 ipcMain.on('tray:push-focus-state', (_event, state: { active: boolean; secondsRemaining: number }) => {
   if (state.active) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -51,6 +51,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Show or clear the reminder dot (●) next to the tray icon.
   setTrayIndicator: (on: boolean) => ipcRenderer.send('tray:set-indicator', on),
 
+  // Main window pushes live focus state to main process (every second when active).
+  pushFocusState: (state: unknown) => ipcRenderer.send('tray:push-focus-state', state),
+
+  // Tray popup receives live focus state forwarded from the main window.
+  onFocusState: (callback: (state: unknown) => void) => {
+    const handler = (_: Electron.IpcRendererEvent, state: unknown) => callback(state);
+    ipcRenderer.on('tray:focus-state', handler);
+    return () => ipcRenderer.removeListener('tray:focus-state', handler);
+  },
+
   // Registers (or clears) a system-wide hotkey that shows the tray popup.
   // Pass an empty string to unregister. Returns true if registration succeeded.
   setGlobalHotkey: (accelerator: string) => ipcRenderer.invoke('hotkey:register', accelerator),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -61,6 +61,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('tray:focus-state', handler);
   },
 
+  // Main window pushes active reminders to the tray popup whenever they change.
+  pushReminders: (reminders: unknown) => ipcRenderer.send('tray:push-reminders', reminders),
+
+  // Tray popup receives the active reminder list forwarded from the main window.
+  onReminders: (callback: (reminders: unknown) => void) => {
+    const handler = (_: Electron.IpcRendererEvent, reminders: unknown) => callback(reminders);
+    ipcRenderer.on('tray:reminders', handler);
+    return () => ipcRenderer.removeListener('tray:reminders', handler);
+  },
+
   // Registers (or clears) a system-wide hotkey that shows the tray popup.
   // Pass an empty string to unregister. Returns true if registration succeeded.
   setGlobalHotkey: (accelerator: string) => ipcRenderer.invoke('hotkey:register', accelerator),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6247,6 +6247,9 @@ const DayPlanner = () => {
     goalsProjectsEnabled,
     goToDate,
     scrollToHour,
+    activeReminders,
+    snoozeReminder,
+    dismissReminder,
   });
 
   // ── Native Android widget snapshot sync ──────────────────────────────────

--- a/src/components/TrayApp.jsx
+++ b/src/components/TrayApp.jsx
@@ -1,11 +1,20 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import GlanceSidebar from './GlanceSidebar.jsx';
 import TrayHeader from './TrayHeader.jsx';
+import TrayFocus from './TrayFocus.jsx';
 import TraySpotlight from './TraySpotlight.jsx';
 import TrayVoice from './TrayVoice.jsx';
 
 export default function TrayApp({ bgClass, darkMode }) {
   const [overlay, setOverlay] = useState(null); // 'spotlight' | 'voice' | null
+  const [focusState, setFocusState] = useState(null);
+
+  useEffect(() => {
+    if (!window.electronAPI?.onFocusState) return;
+    return window.electronAPI.onFocusState((state) => {
+      setFocusState(state?.active ? state : null);
+    });
+  }, []);
 
   return (
     <div className={`${bgClass} flex flex-col`} style={{ height: '100vh' }}>
@@ -14,16 +23,22 @@ export default function TrayApp({ bgClass, darkMode }) {
         onSearchClick={() => setOverlay('spotlight')}
         onVoiceClick={() => setOverlay('voice')}
       />
-      {overlay === 'spotlight' && (
-        <TraySpotlight darkMode={darkMode} onClose={() => setOverlay(null)} />
-      )}
-      {overlay === 'voice' && (
-        <TrayVoice darkMode={darkMode} onClose={() => setOverlay(null)} autoStart />
-      )}
-      {!overlay && (
-        <div className="flex-1 overflow-y-auto px-3 py-3">
-          <GlanceSidebar variant="tray" />
-        </div>
+      {focusState ? (
+        <TrayFocus darkMode={darkMode} focusState={focusState} />
+      ) : (
+        <>
+          {overlay === 'spotlight' && (
+            <TraySpotlight darkMode={darkMode} onClose={() => setOverlay(null)} />
+          )}
+          {overlay === 'voice' && (
+            <TrayVoice darkMode={darkMode} onClose={() => setOverlay(null)} autoStart />
+          )}
+          {!overlay && (
+            <div className="flex-1 overflow-y-auto px-3 py-3">
+              <GlanceSidebar variant="tray" />
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/TrayApp.jsx
+++ b/src/components/TrayApp.jsx
@@ -2,17 +2,26 @@ import { useState, useEffect } from 'react';
 import GlanceSidebar from './GlanceSidebar.jsx';
 import TrayHeader from './TrayHeader.jsx';
 import TrayFocus from './TrayFocus.jsx';
+import TrayReminders from './TrayReminders.jsx';
 import TraySpotlight from './TraySpotlight.jsx';
 import TrayVoice from './TrayVoice.jsx';
 
 export default function TrayApp({ bgClass, darkMode }) {
   const [overlay, setOverlay] = useState(null); // 'spotlight' | 'voice' | null
   const [focusState, setFocusState] = useState(null);
+  const [reminders, setReminders] = useState([]);
 
   useEffect(() => {
     if (!window.electronAPI?.onFocusState) return;
     return window.electronAPI.onFocusState((state) => {
       setFocusState(state?.active ? state : null);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!window.electronAPI?.onReminders) return;
+    return window.electronAPI.onReminders((r) => {
+      setReminders(Array.isArray(r) ? r : []);
     });
   }, []);
 
@@ -27,6 +36,7 @@ export default function TrayApp({ bgClass, darkMode }) {
         <TrayFocus darkMode={darkMode} focusState={focusState} />
       ) : (
         <>
+          <TrayReminders darkMode={darkMode} reminders={reminders} />
           {overlay === 'spotlight' && (
             <TraySpotlight darkMode={darkMode} onClose={() => setOverlay(null)} />
           )}

--- a/src/components/TrayFocus.jsx
+++ b/src/components/TrayFocus.jsx
@@ -1,0 +1,57 @@
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+
+const PHASE_LABELS = { work: 'Work', shortBreak: 'Short Break', longBreak: 'Long Break' };
+const PHASE_COLORS = {
+  work: 'bg-blue-500/20 text-blue-400',
+  shortBreak: 'bg-green-500/20 text-green-400',
+  longBreak: 'bg-emerald-500/20 text-emerald-400',
+};
+
+function fmt(seconds) {
+  const m = Math.floor(Math.max(0, seconds) / 60);
+  const s = Math.max(0, seconds) % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export default function TrayFocus({ darkMode, focusState }) {
+  const { textPrimary, textSecondary } = useDayPlannerCtx();
+  const { phase, secondsRemaining, cycleCount } = focusState;
+
+  const stop = () => window.electronAPI?.backgroundAction({ action: 'focus-stop' });
+  const skip = () => window.electronAPI?.backgroundAction({ action: 'focus-skip' });
+
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center px-4 pb-6 gap-4">
+      <div className={`px-3 py-1 rounded-full text-xs font-semibold ${PHASE_COLORS[phase] ?? 'bg-blue-500/20 text-blue-400'}`}>
+        {PHASE_LABELS[phase] ?? phase}
+      </div>
+
+      <div className={`text-5xl font-bold tabular-nums tracking-tight ${textPrimary}`}>
+        {fmt(secondsRemaining)}
+      </div>
+
+      {cycleCount > 0 && (
+        <div className={`text-xs ${textSecondary}`}>
+          {cycleCount} cycle{cycleCount !== 1 ? 's' : ''} completed
+        </div>
+      )}
+
+      <div className="flex gap-2 w-full mt-2">
+        <button
+          onClick={stop}
+          className={`flex-1 py-2.5 rounded-lg text-sm font-medium transition-opacity hover:opacity-70 ${
+            darkMode ? 'bg-white/10 text-gray-300' : 'bg-black/5 text-stone-600'
+          }`}
+        >
+          Stop
+        </button>
+        <button
+          onClick={skip}
+          className="flex-1 py-2.5 rounded-lg text-sm font-semibold bg-blue-500 text-white transition-opacity hover:opacity-90"
+        >
+          Skip
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TrayReminders.jsx
+++ b/src/components/TrayReminders.jsx
@@ -1,0 +1,55 @@
+import { Bell, X, Clock } from 'lucide-react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+
+export default function TrayReminders({ darkMode, reminders }) {
+  const { borderClass, textPrimary, textSecondary } = useDayPlannerCtx();
+
+  if (!reminders?.length) return null;
+
+  const dismiss = (id) =>
+    window.electronAPI?.backgroundAction({ action: 'dismiss-reminder', reminderId: id });
+
+  const snooze = (reminder) =>
+    window.electronAPI?.backgroundAction({ action: 'snooze-reminder', reminder });
+
+  return (
+    <div className={`flex-shrink-0 border-b ${borderClass}`}>
+      {reminders.map((r) => (
+        <div
+          key={r.id}
+          className={`flex items-start gap-2 px-3 py-2.5 border-b last:border-b-0 ${borderClass} ${
+            darkMode ? 'bg-yellow-500/10' : 'bg-yellow-50'
+          }`}
+        >
+          <Bell size={13} className="flex-shrink-0 mt-0.5 text-yellow-500" />
+          <div className="flex-1 min-w-0">
+            <div className={`text-xs font-medium truncate ${textPrimary}`}>{r.taskTitle}</div>
+            <div className={`text-xs ${textSecondary}`}>{r.message}</div>
+          </div>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            {!r.isCalendarEvent && r.startTime && (
+              <button
+                onClick={() => snooze(r)}
+                title="Snooze 15 min"
+                className={`p-1 rounded transition-opacity hover:opacity-70 ${
+                  darkMode ? 'text-gray-400' : 'text-stone-400'
+                }`}
+              >
+                <Clock size={13} />
+              </button>
+            )}
+            <button
+              onClick={() => dismiss(r.id)}
+              title="Dismiss"
+              className={`p-1 rounded transition-opacity hover:opacity-70 ${
+                darkMode ? 'text-gray-400' : 'text-stone-400'
+              }`}
+            >
+              <X size={13} />
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -292,6 +292,10 @@ export default function useElectronBridge({
         moveToRecycleBinRef.current?.(payload.taskId, !!payload.isInbox);
       } else if (payload.action === 'clear-deadline' && payload.taskId) {
         clearDeadlineRef.current?.(payload.taskId);
+      } else if (payload.action === 'focus-stop') {
+        exitFocusModeRef.current?.(true);
+      } else if (payload.action === 'focus-skip') {
+        skipFocusPhaseRef.current?.();
       }
     });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -302,6 +306,19 @@ export default function useElectronBridge({
     const stored = localStorage.getItem('dg-tray-hotkey');
     if (stored) window.electronAPI.setGlobalHotkey(stored);
   }, []);
+
+  // Push live focus state to main process every second when active (drives menu
+  // bar countdown and tray popup focus view). Guarded to main window only.
+  useEffect(() => {
+    if (isTrayMode || !window.electronAPI?.pushFocusState) return;
+    window.electronAPI.pushFocusState({
+      active: showFocusMode,
+      phase: focusPhase,
+      secondsRemaining: focusTimerSeconds,
+      running: focusTimerRunning,
+      cycleCount: focusCycleCount,
+    });
+  }, [showFocusMode, focusPhase, focusTimerSeconds, focusTimerRunning, focusCycleCount]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Push state snapshot whenever relevant state changes.
   useEffect(() => {

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -126,6 +126,10 @@ export default function useElectronBridge({
   goalsProjectsEnabled,
   goToDate,
   scrollToHour,
+  // Reminders
+  activeReminders,
+  snoozeReminder,
+  dismissReminder,
 }) {
   const [pushTrigger, setPushTrigger] = useState(0);
 
@@ -153,6 +157,8 @@ export default function useElectronBridge({
   const clearDeadlineRef = useRef(clearDeadline);
   const scrollToHourRef = useRef(scrollToHour);
   const setHabitCountRef = useRef(setHabitCount);
+  const snoozeReminderRef = useRef(snoozeReminder);
+  const dismissReminderRef = useRef(dismissReminder);
   skipFocusPhaseRef.current = skipFocusPhase;
   dismissFocusStatsRef.current = dismissFocusStats;
   focusCompleteTaskRef.current = focusCompleteTask;
@@ -177,6 +183,8 @@ export default function useElectronBridge({
   clearDeadlineRef.current = clearDeadline;
   scrollToHourRef.current = scrollToHour;
   setHabitCountRef.current = setHabitCount;
+  snoozeReminderRef.current = snoozeReminder;
+  dismissReminderRef.current = dismissReminder;
 
   // Subscribe to commands from WebSocket clients once on mount.
   useEffect(() => {
@@ -296,6 +304,10 @@ export default function useElectronBridge({
         exitFocusModeRef.current?.(true);
       } else if (payload.action === 'focus-skip') {
         skipFocusPhaseRef.current?.();
+      } else if (payload.action === 'dismiss-reminder' && payload.reminderId) {
+        dismissReminderRef.current?.(payload.reminderId);
+      } else if (payload.action === 'snooze-reminder' && payload.reminder) {
+        snoozeReminderRef.current?.(payload.reminder);
       }
     });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -306,6 +318,12 @@ export default function useElectronBridge({
     const stored = localStorage.getItem('dg-tray-hotkey');
     if (stored) window.electronAPI.setGlobalHotkey(stored);
   }, []);
+
+  // Push active reminders to tray popup whenever they change. Guarded to main window only.
+  useEffect(() => {
+    if (isTrayMode || !window.electronAPI?.pushReminders) return;
+    window.electronAPI.pushReminders(activeReminders ?? []);
+  }, [activeReminders]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Push live focus state to main process every second when active (drives menu
   // bar countdown and tray popup focus view). Guarded to main window only.


### PR DESCRIPTION
## Summary

- While a focus session is running, the tray popup shows a compact focus view (phase badge, live countdown, Stop + Skip) instead of the task list
- The menu bar title shows the live countdown (`24:32`) next to the icon
- Focus countdown takes priority over the reminder indicator dot; both are managed by a single `refreshTrayTitle()` helper in main.ts

## How it works

Focus state is not persisted to localStorage, so the tray popup can't read it from context after a reload. Instead:

1. `useElectronBridge` pushes `{ active, phase, secondsRemaining, running, cycleCount }` to main.ts every second (fires because `focusTimerSeconds` changes on each tick, guarded by `!isTrayMode`)
2. Main.ts updates `tray.setTitle()` with the formatted countdown and forwards the state to the tray popup renderer via `tray:focus-state` IPC
3. `TrayApp` listens on `onFocusState` and sets local state; when `active`, renders `TrayFocus` in place of the task list
4. Stop/Skip buttons in `TrayFocus` use `backgroundAction({ action: 'focus-stop/skip' })` — already the established pattern for tray→main mutations. The new actions are handled in `useElectronBridge`'s `onBackgroundAction` switch

## Changes

- **`electron/preload.ts`** — adds `pushFocusState` (send) and `onFocusState` (listener)
- **`electron/main.ts`** — adds `trayIndicatorOn`/`trayFocusTitle` state + `refreshTrayTitle()` helper; `tray:set-indicator` and hotkey/click handlers use it; new `tray:push-focus-state` handler updates title and forwards to tray popup
- **`src/hooks/useElectronBridge.js`** — focus state push effect; `focus-stop` and `focus-skip` background action handlers
- **`src/components/TrayFocus.jsx`** — new compact focus view component
- **`src/components/TrayApp.jsx`** — subscribes to `onFocusState`, renders `TrayFocus` when active

## Test plan

- [ ] Start a focus session → menu bar shows `25:00` countdown, updates every second
- [ ] Open tray popup during focus → shows phase badge, timer, Stop and Skip buttons
- [ ] Skip → phase advances in main window, tray updates within 1 second
- [ ] Stop → focus ends, tray returns to task list, menu bar title clears
- [ ] Reminder fires during focus → dot doesn't override the countdown; appears after focus ends
- [ ] No focus session → tray popup shows normal task list as before

https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_