### PR TITLE
Fix tray focus view staying open after Stop

### DIFF
--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -330,13 +330,13 @@ export default function useElectronBridge({
   useEffect(() => {
     if (isTrayMode || !window.electronAPI?.pushFocusState) return;
     window.electronAPI.pushFocusState({
-      active: showFocusMode,
+      active: showFocusMode && !focusShowStats && !focusShowSettings,
       phase: focusPhase,
       secondsRemaining: focusTimerSeconds,
       running: focusTimerRunning,
       cycleCount: focusCycleCount,
     });
-  }, [showFocusMode, focusPhase, focusTimerSeconds, focusTimerRunning, focusCycleCount]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [showFocusMode, focusShowStats, focusShowSettings, focusPhase, focusTimerSeconds, focusTimerRunning, focusCycleCount]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Push state snapshot whenever relevant state changes.
   useEffect(() => {


### PR DESCRIPTION
## Bug

Pressing Stop in the tray popup froze the timer but left the focus view visible.

## Root cause

`exitFocusMode(true)` keeps `showFocusMode = true` while the post-session stats screen is displayed. The push effect was using `active: showFocusMode`, so it sent `{ active: true, running: false }` — the tray saw an active-but-frozen focus session and never switched back to the task list.

## Fix

Exclude the stats and settings screens from the `active` flag:

```js
active: showFocusMode && !focusShowStats && !focusShowSettings,
```

Both flags are already passed to `useElectronBridge`, so no new plumbing needed. `focusShowStats` and `focusShowSettings` were also added to the effect's dependency array.

## Test plan

- [ ] Start focus session, open tray → focus view shows
- [ ] Press Stop → tray immediately returns to task list
- [ ] Stats screen appears in main window (unaffected)
- [ ] Skip still works normally

https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_