### PR TITLE
Fix tray popup dead-ends when main window is closed on macOS

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -15,6 +15,7 @@ const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL'] ?? 'http://localh
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
+let isQuitting = false;
 let trayWindow: BrowserWindow | null = null;
 let trayNeedsReload = false;
 let trayReloadTimer: ReturnType<typeof setTimeout> | null = null;
@@ -76,7 +77,12 @@ function createWindow(): BrowserWindow {
   };
   mainWindow.on('resize', trackBounds);
   mainWindow.on('move', trackBounds);
-  mainWindow.on('close', () => {
+  mainWindow.on('close', (event) => {
+    if (process.platform === 'darwin' && !isQuitting) {
+      event.preventDefault();
+      live(mainWindow)?.hide();
+      return;
+    }
     saveWindowState({ ...normalBounds, maximized: live(mainWindow)?.isMaximized() ?? false });
   });
 
@@ -273,9 +279,11 @@ app.whenReady().then(() => {
 
   app.on('activate', () => {
     const mw = live(mainWindow);
-    if (mw) { mw.show(); mw.focus(); } else createWindow();
+    if (mw) { if (!mw.isVisible()) mw.show(); mw.focus(); } else createWindow();
   });
 });
+
+app.on('before-quit', () => { isQuitting = true; });
 
 app.on('will-quit', () => {
   globalShortcut.unregisterAll();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6250,6 +6250,9 @@ const DayPlanner = () => {
     activeReminders,
     snoozeReminder,
     dismissReminder,
+    setShowRescheduleModal,
+    setRescheduleResults,
+    setRescheduleError,
   });
 
   // ── Native Android widget snapshot sync ──────────────────────────────────

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -473,7 +473,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
         {eveningGlanceText && !eveningGlanceLoading && <p className={`text-sm leading-relaxed ${textPrimary}`}>{eveningGlanceText}</p>}
         {eveningGlanceText && !eveningGlanceLoading && incompleteTodayTasks.length > 0 && gtdFrames.filter(f => f.enabled).length > 0 && aiConfig.features?.aiReschedule && (
           <button
-            onClick={() => { setShowRescheduleModal(true); setRescheduleResults(null); setRescheduleError(''); }}
+            onClick={() => isTray ? openMainAt({ action: 'reschedule' }) : (setShowRescheduleModal(true), setRescheduleResults(null), setRescheduleError(''))}
             className={`mt-2 flex items-center gap-1.5 text-xs font-medium transition-colors ${darkMode ? 'text-orange-400 hover:text-orange-300' : 'text-orange-600 hover:text-orange-700'}`}
           >
             <CalendarDays size={12} />
@@ -536,7 +536,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     if (!(_pastOverdue.length > 0 || (incompleteTodayTasks.length > 0 && currentTime.getHours() >= 19))) return null;
     return (
       <button
-        onClick={() => { setShowRescheduleModal(true); setRescheduleResults(null); setRescheduleError(''); }}
+        onClick={() => isTray ? openMainAt({ action: 'reschedule' }) : (setShowRescheduleModal(true), setRescheduleResults(null), setRescheduleError(''))}
         className={`w-full mb-3 flex items-center justify-center gap-2 py-2.5 px-4 rounded-xl text-sm font-semibold transition-colors ${darkMode ? 'bg-violet-600/20 hover:bg-violet-600/30 text-violet-300 border border-violet-500/30' : 'bg-violet-50 hover:bg-violet-100 text-violet-700 border border-violet-200'}`}
       >
         <Sparkles size={15} />

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -130,6 +130,10 @@ export default function useElectronBridge({
   activeReminders,
   snoozeReminder,
   dismissReminder,
+  // Reschedule modal
+  setShowRescheduleModal,
+  setRescheduleResults,
+  setRescheduleError,
 }) {
   const [pushTrigger, setPushTrigger] = useState(0);
 
@@ -159,6 +163,9 @@ export default function useElectronBridge({
   const setHabitCountRef = useRef(setHabitCount);
   const snoozeReminderRef = useRef(snoozeReminder);
   const dismissReminderRef = useRef(dismissReminder);
+  const setShowRescheduleModalRef = useRef(setShowRescheduleModal);
+  const setRescheduleResultsRef = useRef(setRescheduleResults);
+  const setRescheduleErrorRef = useRef(setRescheduleError);
   skipFocusPhaseRef.current = skipFocusPhase;
   dismissFocusStatsRef.current = dismissFocusStats;
   focusCompleteTaskRef.current = focusCompleteTask;
@@ -185,6 +192,9 @@ export default function useElectronBridge({
   setHabitCountRef.current = setHabitCount;
   snoozeReminderRef.current = snoozeReminder;
   dismissReminderRef.current = dismissReminder;
+  setShowRescheduleModalRef.current = setShowRescheduleModal;
+  setRescheduleResultsRef.current = setRescheduleResults;
+  setRescheduleErrorRef.current = setRescheduleError;
 
   // Subscribe to commands from WebSocket clients once on mount.
   useEffect(() => {
@@ -274,6 +284,10 @@ export default function useElectronBridge({
         enterFocusModeRef.current?.();
       } else if (action === 'hyperglance') {
         if (projectId && date) enterHyperGlanceModeRef.current?.(projectId, date);
+      } else if (action === 'reschedule') {
+        setShowRescheduleModalRef.current?.(true);
+        setRescheduleResultsRef.current?.(null);
+        setRescheduleErrorRef.current?.('');
       }
     });
   }, [goToDate]); // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

- **Main window hide-on-close**: On macOS, closing the main window now hides it instead of destroying it. An `isQuitting` flag (set on `before-quit`) ensures Cmd+Q / File → Quit still exits cleanly. The `activate` event (dock click) now shows the hidden window rather than creating a new one. This fixes the root cause of "clicking anything in the tray that would normally do something results in no action" — previously `live(mainWindow)` returned null and all IPC silently dropped.
- **Reschedule Tasks from tray**: The Reschedule Tasks button in `GlanceSidebar` now routes through `openMainAt({ action: 'reschedule' })` when rendered in the tray popup. The `onTrayNavigate` handler in `useElectronBridge` handles this by showing the main window and opening the modal there. Previously the button called `setShowRescheduleModal(true)` in the tray renderer, which has no modal — it silently did nothing.

## Test plan

- [x] Open the app, then close the main window (red X). The app should remain in the tray.
- [x] Click something in the tray popup (e.g. a task, focus mode, Reschedule Tasks) — the main window should open and respond correctly.
- [x] Clicking the tray icon or using the hotkey should reopen the main window if it was hidden.
- [x] Cmd+Q should quit the app completely (not just hide).
- [x] On macOS, clicking the dock icon when the window is hidden should bring it back.
- [x] Reschedule Tasks button in tray (when overdue tasks exist or it's past 7pm) should open the main window and trigger the smart reschedule modal.

https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_