### PR TITLE
Fix timeline scroll drift in DAY view on task click

### DIFF
--- a/src/hooks/useDayViewHourHeight.js
+++ b/src/hooks/useDayViewHourHeight.js
@@ -21,11 +21,21 @@ export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
       calendarRef.current.scrollTop = 0;
     };
 
+    // Also reset on any scroll event — Chromium's scroll-anchoring and
+    // focus-scroll can set scrollTop on overflow:hidden containers without
+    // triggering a ResizeObserver, causing a visible "drift" on task click.
+    const onScroll = () => {
+      if (calendarRef?.current) calendarRef.current.scrollTop = 0;
+    };
+
     // Defer first measurement by one frame so the sticky header ref is populated.
     const rafId = requestAnimationFrame(() => {
       compute();
       const ro = new ResizeObserver(compute);
-      if (calendarRef?.current) ro.observe(calendarRef.current);
+      if (calendarRef?.current) {
+        ro.observe(calendarRef.current);
+        calendarRef.current.addEventListener('scroll', onScroll, { passive: true });
+      }
       if (stickyHeaderRef?.current) ro.observe(stickyHeaderRef.current);
       // Keep a reference so cleanup can disconnect even after the rAF fires.
       roRef = ro;
@@ -35,6 +45,7 @@ export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
     return () => {
       cancelAnimationFrame(rafId);
       roRef?.disconnect();
+      calendarRef?.current?.removeEventListener('scroll', onScroll);
     };
   }, []); // refs are stable objects — no deps needed
 


### PR DESCRIPTION
## Summary

Clicking a task card in DAY view caused the timeline to visibly drift/scroll slightly.

Root cause: Chromium's scroll-anchoring and focus-scroll behavior can set `scrollTop` on an `overflow:hidden` container without triggering a `ResizeObserver`. The existing `useDayViewHourHeight` hook resets `scrollTop = 0` in its `ResizeObserver` callback, but this doesn't cover the case where the container's measured size doesn't change (which is most task clicks — only the task card's internal state changes).

Fix: add a `scroll` event listener on the calendar container that immediately resets `scrollTop = 0`. Since DAY view is always `overflow:hidden` and should never scroll, any scroll event is drift that should be cancelled.

## Test plan

- [x] In DAY view, click a task card — the timeline should not scroll at all
- [x] In DAY view, expand a task's notes panel — the timeline should not scroll
- [x] In multi-column (WEEK/MULTI) view, normal scrolling should be unaffected (the hook only mounts in DAY view)
- [x] Switching to DAY view from another mode should still reset scroll to 0

https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_