### PR TITLE
Fix no-op buttons in tray sidebar (Routines, Habits, Schedule, AI refresh)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6257,6 +6257,7 @@ const DayPlanner = () => {
     setShowFramesModal,
     setFramesModalTab,
     setEditingFrame,
+    setShowHabitModal,
   });
 
   // ── Native Android widget snapshot sync ──────────────────────────────────

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4985,13 +4985,13 @@ const DayPlanner = () => {
   }, [voiceParsedTasks, voiceParsedEdits]);
 
   // --- Morning dayGLANCE (AI morning summary) ---
-  const generateMorningSummary = useCallback(async () => {
+  const generateMorningSummary = useCallback(async (force = false) => {
     if (!aiConfig.enabled || (!aiConfig.apiKey && aiConfig.provider !== 'ollama') || !aiConfig.features.morningSummary) return;
     const todayStr = dateToString(new Date());
-    // Check cache
+    // Check cache (skip when force-regenerating via the refresh button)
     try {
       const cached = localStorage.getItem('day-planner-morning-glance');
-      if (cached) {
+      if (cached && !force) {
         const { date, text } = JSON.parse(cached);
         if (date === todayStr) { setMorningGlanceText(text); return; }
       }
@@ -5083,12 +5083,12 @@ const DayPlanner = () => {
   }, [aiConfig.enabled, aiConfig.features.morningSummary]);
 
   // --- Evening Reflection ---
-  const generateEveningReflection = useCallback(async () => {
+  const generateEveningReflection = useCallback(async (force = false) => {
     if (!aiConfig.enabled || (!aiConfig.apiKey && aiConfig.provider !== 'ollama') || !aiConfig.features.eveningReflection) return;
     const todayStr = dateToString(new Date());
     try {
       const cached = localStorage.getItem('day-planner-evening-glance');
-      if (cached) {
+      if (cached && !force) {
         const { date, text } = JSON.parse(cached);
         if (date === todayStr) { setEveningGlanceText(text); return; }
       }
@@ -6253,6 +6253,10 @@ const DayPlanner = () => {
     setShowRescheduleModal,
     setRescheduleResults,
     setRescheduleError,
+    openRoutinesDashboardRef,
+    setShowFramesModal,
+    setFramesModalTab,
+    setEditingFrame,
   });
 
   // ── Native Android widget snapshot sync ──────────────────────────────────

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -237,7 +237,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     const todayDow = new Date().getDay();
     const todayHabits = activeHabits.filter(h => (h.scheduledDays ?? [0, 1, 2, 3, 4, 5, 6]).includes(todayDow));
     if (activeHabits.length === 0) return (
-      <div className={`rounded-lg border ${borderClass} p-3 cursor-pointer hover:opacity-80 transition-opacity`} onClick={() => setShowHabitModal(true)}>
+      <div className={`rounded-lg border ${borderClass} p-3 cursor-pointer hover:opacity-80 transition-opacity`} onClick={() => isTray ? openMainAt({ action: 'habits' }) : setShowHabitModal(true)}>
         <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Habits</div>
         <div className="flex items-center gap-2">
           <span className={`text-xs ${textSecondary} italic`}>None added</span>
@@ -249,7 +249,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     return (
       <div className="relative">
         <button
-          onClick={() => setShowHabitModal(true)}
+          onClick={() => isTray ? openMainAt({ action: 'habits' }) : setShowHabitModal(true)}
           className={`absolute -bottom-0.5 -right-0.5 p-1 rounded ${hoverBg} ${darkMode ? 'text-gray-700' : 'text-stone-300'} transition-colors z-10`}
           title="Manage habits"
         >

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -387,7 +387,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
         </div>
         <div className="flex items-center gap-1 flex-shrink-0">
           <button
-            onClick={generateMorningSummary}
+            onClick={() => generateMorningSummary(true)}
             className={`p-1 rounded transition-colors ${darkMode ? 'hover:bg-white/10' : 'hover:bg-black/5'}`}
             title="Regenerate"
           >
@@ -417,7 +417,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
         )}
         {morningGlanceText && !morningGlanceLoading && aiConfig?.enabled && aiConfig.features?.smartScheduling && gtdFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
           <button
-            onClick={() => { setShowFramesModal(true); setFramesModalTab('schedule'); setEditingFrame(null); }}
+            onClick={() => isTray ? openMainAt({ action: 'schedule-inbox' }) : (setShowFramesModal(true), setFramesModalTab('schedule'), setEditingFrame(null))}
             className={`mt-2 flex items-center gap-1.5 text-xs font-medium transition-colors ${darkMode ? 'text-purple-400 hover:text-purple-300' : 'text-purple-600 hover:text-purple-700'}`}
           >
             <BrainCircuit size={12} />
@@ -454,7 +454,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
           <span className={`text-xs font-semibold uppercase tracking-wider ${darkMode ? 'text-indigo-300' : 'text-indigo-700'}`}>Evening Reflection</span>
         </div>
         <div className="flex items-center gap-1 flex-shrink-0">
-          <button onClick={generateEveningReflection} className={`p-1 rounded transition-colors ${darkMode ? 'hover:bg-white/10' : 'hover:bg-black/5'}`} title="Regenerate">
+          <button onClick={() => generateEveningReflection(true)} className={`p-1 rounded transition-colors ${darkMode ? 'hover:bg-white/10' : 'hover:bg-black/5'}`} title="Regenerate">
             <RefreshCw size={12} className={`${eveningGlanceLoading ? 'animate-spin' : ''} ${textSecondary}`} />
           </button>
           <button onClick={dismissEveningGlance} className={`p-1 rounded transition-colors ${darkMode ? 'hover:bg-white/10' : 'hover:bg-black/5'}`} title="Dismiss for today">
@@ -1192,7 +1192,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     if (realRoutines.length > 0 && visibleRoutines.length === 0) return null;
     if (visibleRoutines.length === 0) {
       return (
-        <div className={isDesktop ? `rounded-lg border ${borderClass} p-3 cursor-pointer hover:opacity-80 transition-opacity` : `mt-3 pt-3 border-t ${borderClass} cursor-pointer active:opacity-70 transition-opacity`} onClick={() => openRoutinesDashboard()}>
+        <div className={isDesktop ? `rounded-lg border ${borderClass} p-3 cursor-pointer hover:opacity-80 transition-opacity` : `mt-3 pt-3 border-t ${borderClass} cursor-pointer active:opacity-70 transition-opacity`} onClick={() => isTray ? openMainAt({ action: 'routines' }) : openRoutinesDashboard()}>
           <div className={`text-xs font-semibold uppercase tracking-wide mb-2 ${textSecondary}`}>Routines</div>
           <div className="flex items-center gap-2">
             <span className={`text-xs ${textSecondary} italic`}>None scheduled</span>
@@ -1205,7 +1205,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
       <div className={`${isDesktop ? `rounded-lg border ${borderClass} p-3` : `mt-3 pt-3 border-t ${borderClass}`}`}>
         <div className="flex items-center justify-between mb-2">
           <div className={`text-xs font-semibold uppercase tracking-wide ${textSecondary}`}>Routines</div>
-          <button onClick={() => openRoutinesDashboard()} className="text-xs text-teal-500 font-medium hover:text-teal-400 transition-colors">+ Add</button>
+          <button onClick={() => isTray ? openMainAt({ action: 'routines' }) : openRoutinesDashboard()} className="text-xs text-teal-500 font-medium hover:text-teal-400 transition-colors">+ Add</button>
         </div>
         <div className={`flex flex-wrap ${isDesktop ? "gap-1" : "gap-1.5"}`}>
           {[...visibleRoutines].sort((a, b) => {

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -296,7 +296,7 @@ const MobileGlanceSection = () => {
         </div>
         <div className="flex items-center gap-1 flex-shrink-0">
           <button
-            onClick={generateMorningSummary}
+            onClick={() => generateMorningSummary(true)}
             className={`p-1 rounded transition-colors ${darkMode ? 'hover:bg-white/10' : 'hover:bg-black/5'}`}
             title="Regenerate"
           >
@@ -362,7 +362,7 @@ const MobileGlanceSection = () => {
           <span className={`text-xs font-semibold uppercase tracking-wider ${darkMode ? 'text-indigo-300' : 'text-indigo-700'}`}>Evening Reflection</span>
         </div>
         <div className="flex items-center gap-1 flex-shrink-0">
-          <button onClick={generateEveningReflection} className={`p-1 rounded transition-colors ${darkMode ? 'hover:bg-white/10' : 'hover:bg-black/5'}`} title="Regenerate">
+          <button onClick={() => generateEveningReflection(true)} className={`p-1 rounded transition-colors ${darkMode ? 'hover:bg-white/10' : 'hover:bg-black/5'}`} title="Regenerate">
             <RefreshCw size={12} className={`${eveningGlanceLoading ? 'animate-spin' : ''} ${textSecondary}`} />
           </button>
           <button onClick={dismissEveningGlance} className={`p-1 rounded transition-colors ${darkMode ? 'hover:bg-white/10' : 'hover:bg-black/5'}`} title="Dismiss for today">

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -134,6 +134,11 @@ export default function useElectronBridge({
   setShowRescheduleModal,
   setRescheduleResults,
   setRescheduleError,
+  // Routines / frames modal (opened from tray navigate)
+  openRoutinesDashboardRef,
+  setShowFramesModal,
+  setFramesModalTab,
+  setEditingFrame,
 }) {
   const [pushTrigger, setPushTrigger] = useState(0);
 
@@ -166,6 +171,9 @@ export default function useElectronBridge({
   const setShowRescheduleModalRef = useRef(setShowRescheduleModal);
   const setRescheduleResultsRef = useRef(setRescheduleResults);
   const setRescheduleErrorRef = useRef(setRescheduleError);
+  const setShowFramesModalRef = useRef(setShowFramesModal);
+  const setFramesModalTabRef = useRef(setFramesModalTab);
+  const setEditingFrameRef = useRef(setEditingFrame);
   skipFocusPhaseRef.current = skipFocusPhase;
   dismissFocusStatsRef.current = dismissFocusStats;
   focusCompleteTaskRef.current = focusCompleteTask;
@@ -195,6 +203,9 @@ export default function useElectronBridge({
   setShowRescheduleModalRef.current = setShowRescheduleModal;
   setRescheduleResultsRef.current = setRescheduleResults;
   setRescheduleErrorRef.current = setRescheduleError;
+  setShowFramesModalRef.current = setShowFramesModal;
+  setFramesModalTabRef.current = setFramesModalTab;
+  setEditingFrameRef.current = setEditingFrame;
 
   // Subscribe to commands from WebSocket clients once on mount.
   useEffect(() => {
@@ -288,6 +299,12 @@ export default function useElectronBridge({
         setShowRescheduleModalRef.current?.(true);
         setRescheduleResultsRef.current?.(null);
         setRescheduleErrorRef.current?.('');
+      } else if (action === 'routines') {
+        openRoutinesDashboardRef?.current?.();
+      } else if (action === 'schedule-inbox') {
+        setShowFramesModalRef.current?.(true);
+        setFramesModalTabRef.current?.('schedule');
+        setEditingFrameRef.current?.(null);
       }
     });
   }, [goToDate]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -134,11 +134,12 @@ export default function useElectronBridge({
   setShowRescheduleModal,
   setRescheduleResults,
   setRescheduleError,
-  // Routines / frames modal (opened from tray navigate)
+  // Routines / frames / habit modal (opened from tray navigate)
   openRoutinesDashboardRef,
   setShowFramesModal,
   setFramesModalTab,
   setEditingFrame,
+  setShowHabitModal,
 }) {
   const [pushTrigger, setPushTrigger] = useState(0);
 
@@ -174,6 +175,7 @@ export default function useElectronBridge({
   const setShowFramesModalRef = useRef(setShowFramesModal);
   const setFramesModalTabRef = useRef(setFramesModalTab);
   const setEditingFrameRef = useRef(setEditingFrame);
+  const setShowHabitModalRef = useRef(setShowHabitModal);
   skipFocusPhaseRef.current = skipFocusPhase;
   dismissFocusStatsRef.current = dismissFocusStats;
   focusCompleteTaskRef.current = focusCompleteTask;
@@ -206,6 +208,7 @@ export default function useElectronBridge({
   setShowFramesModalRef.current = setShowFramesModal;
   setFramesModalTabRef.current = setFramesModalTab;
   setEditingFrameRef.current = setEditingFrame;
+  setShowHabitModalRef.current = setShowHabitModal;
 
   // Subscribe to commands from WebSocket clients once on mount.
   useEffect(() => {
@@ -301,6 +304,8 @@ export default function useElectronBridge({
         setRescheduleErrorRef.current?.('');
       } else if (action === 'routines') {
         openRoutinesDashboardRef?.current?.();
+      } else if (action === 'habits') {
+        setShowHabitModalRef.current?.(true);
       } else if (action === 'schedule-inbox') {
         setShowFramesModalRef.current?.(true);
         setFramesModalTabRef.current?.('schedule');


### PR DESCRIPTION
## Summary

Four categories of no-op buttons in the tray popup's GlanceSidebar:

**1. Routines "+ Add"**
Called `openRoutinesDashboard()` directly, which only works in the main window renderer. In tray mode it now routes through `openMainAt({ action: 'routines' })`, which brings the main window to focus and opens the Routines modal. Applies to both the "None scheduled" row click and the `+ Add` button when routines exist.

**2. Habits "+ Add" / ⚙ gear**
Called `setShowHabitModal(true)` — `HabitModal` only renders in App.jsx's main render path, never in the tray. Routes through `openMainAt({ action: 'habits' })` in tray mode.

**3. "Schedule inbox items?" (Morning Briefing)**
Called `setShowFramesModal/setFramesModalTab/setEditingFrame` directly — state setters that belong to the main window's renderer, not the tray's. Routes through `openMainAt({ action: 'schedule-inbox' })` in tray mode; handled in `onTrayNavigate` by opening the FramesModal on the schedule tab.

**4. Morning/Evening refresh buttons (all platforms)**
`generateMorningSummary` and `generateEveningReflection` both had an early-return cache check: if today's text was already in localStorage, they set state to the cached value and returned without making an API call. This made the "Regenerate" button silently a no-op any time there was already a summary for today — in the main window too, not just the tray. Added `force = false` parameter; refresh buttons pass `force = true` to bypass the cache. Also fixes the same no-op on mobile (`MobileGlanceSection`).

## Test plan

- [ ] Tray: Routines section shows no routines → click row or "+ Add" → main window opens to Routines modal
- [ ] Tray: Habits section shows no habits → click row or "+ Add" → main window opens to Habit modal
- [ ] Tray: Habits section with habits → click ⚙ gear → main window opens to Habit modal
- [ ] Tray: Morning Briefing shows → click "Schedule inbox items?" → main window opens to Frames/Schedule modal
- [ ] Main window + tray: click refresh (↺) on Morning Briefing when summary already exists → spinner appears and new text is generated
- [ ] Main window + tray: click refresh on Evening Reflection when text already exists → regenerates
- [ ] Initial "Click here to see AI briefing" still uses cache (no `force`) — doesn't re-generate unnecessarily

https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd