### PR TITLE
Fix settings layout, resize modal bug, and add tray Now bar

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -129,7 +129,7 @@ function createTrayWindow(): BrowserWindow {
   // registered its onReminders listener. 800ms is enough for the renderer to
   // finish hydrating; focus state self-corrects within 1s so no re-push needed.
   win.webContents.on('did-finish-load', () => {
-    setTimeout(pushRemindersToTray, 800);
+    setTimeout(() => { pushRemindersToTray(); pushCurrentTaskToTray(); }, 800);
   });
 
   // Hide when the user clicks outside the popup; reload if state changed while it was open
@@ -172,6 +172,7 @@ function createTray(): void {
     tw.show();
     tw.focus();
     pushRemindersToTray();
+    pushCurrentTaskToTray();
   });
 
   // Right-click: native Open / Quit menu
@@ -229,10 +230,23 @@ function pushRemindersToTray() {
   }
 }
 
+// Last-known in-progress task — re-sent to the tray popup after a reload or on show.
+let lastKnownCurrentTask: unknown = null;
+
+function pushCurrentTaskToTray() {
+  live(trayWindow)?.webContents.send('tray:current-task', lastKnownCurrentTask);
+}
+
 // Reminder list: cache + forward to tray popup whenever it changes.
 ipcMain.on('tray:push-reminders', (_event, reminders: unknown) => {
   lastKnownReminders = reminders;
   live(trayWindow)?.webContents.send('tray:reminders', reminders);
+});
+
+// Current task: cache + forward to tray popup whenever it changes.
+ipcMain.on('tray:push-current-task', (_event, task: unknown) => {
+  lastKnownCurrentTask = task;
+  live(trayWindow)?.webContents.send('tray:current-task', task);
 });
 
 // Focus state: update menu bar countdown and forward to tray popup.
@@ -270,6 +284,7 @@ ipcMain.handle('hotkey:register', (_event, accelerator: string) => {
     tw.show();
     tw.focus();
     pushRemindersToTray();
+    pushCurrentTaskToTray();
     tw.webContents.send('tray:focus-quick-add');
   });
   if (ok) registeredHotkey = accelerator;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -71,6 +71,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('tray:reminders', handler);
   },
 
+  // Main window pushes the currently-in-progress task to the tray popup.
+  pushCurrentTask: (task: unknown) => ipcRenderer.send('tray:push-current-task', task),
+
+  // Tray popup receives the currently-in-progress task forwarded from the main window.
+  onCurrentTask: (callback: (task: unknown) => void) => {
+    const handler = (_: Electron.IpcRendererEvent, task: unknown) => callback(task);
+    ipcRenderer.on('tray:current-task', handler);
+    return () => ipcRenderer.removeListener('tray:current-task', handler);
+  },
+
   // Registers (or clears) a system-wide hotkey that shows the tray popup.
   // Pass an empty string to unregister. Returns true if registration succeeded.
   setGlobalHotkey: (accelerator: string) => ipcRenderer.invoke('hotkey:register', accelerator),

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -223,6 +223,24 @@ const SettingsModal = () => {
                             </button>
                           </div>
                         </div>
+                        <div>
+                          <label className={`block text-xs ${textSecondary} mb-1.5`}>Week timeline start</label>
+                          <div className="flex flex-wrap gap-2">
+                            {[0, 4, 5, 6, 7].map(h => (
+                              <button
+                                key={h}
+                                onClick={() => setWeekTimelineStartHour(h)}
+                                className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${
+                                  weekTimelineStartHour === h
+                                    ? 'bg-blue-600 text-white'
+                                    : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`
+                                }`}
+                              >
+                                {h === 0 ? '12am' : `${h}am`}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
                       </div>
                     )}
 
@@ -260,24 +278,6 @@ const SettingsModal = () => {
                         </div>
                       </div>
                       <div>
-                        <label className={`block text-xs ${textSecondary} mb-1.5`}>Week timeline start</label>
-                        <div className="flex flex-wrap gap-2">
-                          {[0, 4, 5, 6, 7].map(h => (
-                            <button
-                              key={h}
-                              onClick={() => setWeekTimelineStartHour(h)}
-                              className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${
-                                weekTimelineStartHour === h
-                                  ? 'bg-blue-600 text-white'
-                                  : `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`
-                              }`}
-                            >
-                              {h === 0 ? '12am' : `${h}am`}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                      <div>
                         <label className={`block text-xs ${textSecondary} mb-1.5`}>First day of week</label>
                         <div className="flex gap-2">
                           <button
@@ -303,6 +303,38 @@ const SettingsModal = () => {
                         </div>
                       </div>
                     </div>
+
+                    {window.electronAPI?.platform === 'darwin' && (<>
+                    <hr className={borderClass} />
+
+                    {/* Global Shortcut — macOS only */}
+                    <div className="space-y-3">
+                      <h4 className={`font-medium ${textPrimary} flex items-center gap-2`}>
+                        <Key size={16} className={textSecondary} />
+                        Global Shortcut
+                      </h4>
+                      <p className={`text-sm ${textSecondary}`}>
+                        Open the quick-add popup from anywhere on your Mac.
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <input
+                          readOnly
+                          placeholder="Click, then press shortcut…"
+                          value={trayHotkey}
+                          onKeyDown={handleHotkeyRecord}
+                          className={`flex-1 px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white placeholder-gray-500' : 'bg-white text-stone-900 placeholder-stone-400'} text-sm cursor-pointer font-mono`}
+                        />
+                        {trayHotkey && (
+                          <button
+                            onClick={clearHotkey}
+                            className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`}
+                          >
+                            Clear
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                    </>)}
 
                     <hr className={borderClass} />
 
@@ -389,38 +421,6 @@ const SettingsModal = () => {
                         <span className={`text-sm ${textPrimary}`}>Show daily tips &amp; quotes in header</span>
                       </label>
                     </div>
-
-                    {window.electronAPI?.platform === 'darwin' && (<>
-                    <hr className={borderClass} />
-
-                    {/* Global Shortcut — macOS only */}
-                    <div className="space-y-3">
-                      <h4 className={`font-medium ${textPrimary} flex items-center gap-2`}>
-                        <Key size={16} className={textSecondary} />
-                        Global Shortcut
-                      </h4>
-                      <p className={`text-sm ${textSecondary}`}>
-                        Open the quick-add popup from anywhere on your Mac.
-                      </p>
-                      <div className="flex items-center gap-2">
-                        <input
-                          readOnly
-                          placeholder="Click, then press shortcut…"
-                          value={trayHotkey}
-                          onKeyDown={handleHotkeyRecord}
-                          className={`flex-1 px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white placeholder-gray-500' : 'bg-white text-stone-900 placeholder-stone-400'} text-sm cursor-pointer font-mono`}
-                        />
-                        {trayHotkey && (
-                          <button
-                            onClick={clearHotkey}
-                            className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`}
-                          >
-                            Clear
-                          </button>
-                        )}
-                      </div>
-                    </div>
-                    </>)}
 
                     </>)}
 

--- a/src/components/TrayApp.jsx
+++ b/src/components/TrayApp.jsx
@@ -3,6 +3,7 @@ import GlanceSidebar from './GlanceSidebar.jsx';
 import TrayHeader from './TrayHeader.jsx';
 import TrayFocus from './TrayFocus.jsx';
 import TrayReminders from './TrayReminders.jsx';
+import TrayNowBar from './TrayNowBar.jsx';
 import TraySpotlight from './TraySpotlight.jsx';
 import TrayVoice from './TrayVoice.jsx';
 
@@ -10,6 +11,7 @@ export default function TrayApp({ bgClass, darkMode }) {
   const [overlay, setOverlay] = useState(null); // 'spotlight' | 'voice' | null
   const [focusState, setFocusState] = useState(null);
   const [reminders, setReminders] = useState([]);
+  const [currentTask, setCurrentTask] = useState(null);
 
   useEffect(() => {
     if (!window.electronAPI?.onFocusState) return;
@@ -25,6 +27,13 @@ export default function TrayApp({ bgClass, darkMode }) {
     });
   }, []);
 
+  useEffect(() => {
+    if (!window.electronAPI?.onCurrentTask) return;
+    return window.electronAPI.onCurrentTask((task) => {
+      setCurrentTask(task ?? null);
+    });
+  }, []);
+
   return (
     <div className={`${bgClass} flex flex-col`} style={{ height: '100vh' }}>
       <TrayHeader
@@ -37,6 +46,7 @@ export default function TrayApp({ bgClass, darkMode }) {
       ) : (
         <>
           <TrayReminders darkMode={darkMode} reminders={reminders} />
+          <TrayNowBar darkMode={darkMode} currentTask={currentTask} />
           {overlay === 'spotlight' && (
             <TraySpotlight darkMode={darkMode} onClose={() => setOverlay(null)} />
           )}

--- a/src/components/TrayNowBar.jsx
+++ b/src/components/TrayNowBar.jsx
@@ -1,0 +1,54 @@
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+
+function fmtTime(t) {
+  if (!t) return '';
+  const [h, m] = t.split(':').map(Number);
+  const suffix = h < 12 ? 'am' : 'pm';
+  const hour = h % 12 || 12;
+  return m === 0 ? `${hour}${suffix}` : `${hour}:${String(m).padStart(2, '0')}${suffix}`;
+}
+
+function fmtEndTime(startTime, duration) {
+  if (!startTime || !duration) return null;
+  const [h, m] = startTime.split(':').map(Number);
+  const totalMin = h * 60 + m + duration;
+  const eh = Math.floor(totalMin / 60) % 24;
+  const em = totalMin % 60;
+  const suffix = eh < 12 ? 'am' : 'pm';
+  const hour = eh % 12 || 12;
+  return em === 0 ? `${hour}${suffix}` : `${hour}:${String(em).padStart(2, '0')}${suffix}`;
+}
+
+export default function TrayNowBar({ darkMode, currentTask }) {
+  const { borderClass, textPrimary, textSecondary } = useDayPlannerCtx();
+
+  if (!currentTask) return null;
+
+  const open = () => window.electronAPI?.openMainAt({ action: 'goto-task', taskId: currentTask.id });
+  const start = fmtTime(currentTask.startTime);
+  const end = fmtEndTime(currentTask.startTime, currentTask.duration);
+  const timeLabel = end ? `${start}–${end}` : start;
+
+  return (
+    <div className={`flex-shrink-0 border-b ${borderClass}`}>
+      <button
+        onClick={open}
+        className={`w-full flex items-center gap-2 px-3 py-2.5 text-left transition-opacity hover:opacity-80 ${
+          darkMode ? 'bg-blue-500/15' : 'bg-blue-50'
+        }`}
+      >
+        <div
+          className="flex-shrink-0 w-2 h-2 rounded-full mt-px"
+          style={{ backgroundColor: currentTask.colorHex || '#3b82f6' }}
+        />
+        <div className="flex-1 min-w-0">
+          <div className={`text-xs font-medium truncate ${textPrimary}`}>{currentTask.title}</div>
+          {timeLabel && <div className={`text-xs ${textSecondary}`}>{timeLabel}</div>}
+        </div>
+        <div className={`text-xs font-medium flex-shrink-0 ${darkMode ? 'text-blue-400' : 'text-blue-600'}`}>
+          Now
+        </div>
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -783,6 +783,8 @@ export default function useDragDrop({
       document.removeEventListener('mouseup', handleMouseUp);
       document.removeEventListener('dragstart', preventDrag);
       setIsResizing(false);
+      frameResizingRef.current = true;
+      setTimeout(() => { frameResizingRef.current = false; }, 0);
       // Sync resize back to the device calendar for native events
       if (task.nativeEventId && !isRecurringTask && task.startTime) {
         const endMin = timeToMinutes(task.startTime) + finalDuration;
@@ -904,6 +906,8 @@ export default function useDragDrop({
       document.removeEventListener('mouseup', handleMouseUp);
       document.removeEventListener('dragstart', preventDrag);
       setIsResizing(false);
+      frameResizingRef.current = true;
+      setTimeout(() => { frameResizingRef.current = false; }, 0);
     };
 
     document.addEventListener('mousemove', handleMouseMove);

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -374,6 +374,28 @@ export default function useElectronBridge({
     });
   }, [showFocusMode, focusShowStats, focusShowSettings, focusPhase, focusTimerSeconds, focusTimerRunning, focusCycleCount]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Push currently-in-progress task to tray popup whenever it changes. Guarded to main window only.
+  useEffect(() => {
+    if (isTrayMode || !window.electronAPI?.pushCurrentTask) return;
+    const nowMin = currentTime.getHours() * 60 + currentTime.getMinutes();
+    const hgSessions = todayHGSessions || [];
+    const scheduled = [
+      ...todayAgenda.filter(t => t._agendaType === 'scheduled' && !t.completed && t.startTime),
+      ...hgSessions,
+    ];
+    const inProgress = scheduled.find(t => {
+      const start = timeToMinutes(t.startTime);
+      return start <= nowMin && start + (t.duration || 0) > nowMin;
+    }) || null;
+    window.electronAPI.pushCurrentTask(inProgress ? {
+      id: inProgress.id,
+      title: inProgress.title,
+      startTime: inProgress.startTime ?? null,
+      duration: inProgress.duration || 0,
+      colorHex: inProgress.colorHex || taskColorToHex(inProgress.color, inProgress.nativeCalendarColor),
+    } : null);
+  }, [currentTime, todayAgenda, todayHGSessions]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Push state snapshot whenever relevant state changes.
   useEffect(() => {
     if (!window.electronAPI) return;


### PR DESCRIPTION
## Summary

- **Settings — Week timeline start**: moved into the View defaults section so it's only visible when `canShowViewCycler` is true (alongside Default view, Day view mode, Week view mode)
- **Settings — Global Shortcut**: moved to between Localization and Sound; the macOS-only guard is kept but the desktop-only (`!isMobile && !isTablet`) guard is removed since the shortcut is irrelevant on mobile regardless
- **Resize → new task modal**: after a task or routine duration resize, `mouseup` was followed by a synthetic click that triggered `openNewTaskAtTime`. Fixed by setting `frameResizingRef.current = true` in both resize `handleMouseUp` handlers (same pattern already used by frame resizes) so the click is suppressed for one tick
- **Tray Now bar**: adds a compact `TrayNowBar` strip below reminders showing the currently in-progress task (title, time range, color dot). Clicking opens the main window focused on the task. Pushed from `useElectronBridge` → `tray:push-current-task` IPC → `main.ts` cache → tray window, with repush on show and `did-finish-load`

## Test plan

- [ ] Open Settings on macOS desktop — confirm "Week timeline start" appears in View defaults when that section is visible, and not in Localization
- [ ] Confirm Global Shortcut appears between Localization and Sound on macOS; absent on non-macOS
- [ ] Drag the resize handle of a task to shorten/lengthen it and release — confirm New Scheduled Task modal does NOT appear
- [ ] Same for a routine resize handle
- [ ] With a task currently in progress, open tray popup — confirm Now bar appears with task name and time range; clicking navigates to main window

https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_