### PR TITLE
Tray: amber Now bar color and Complete button on Ending now reminders

### DIFF
--- a/src/components/TrayNowBar.jsx
+++ b/src/components/TrayNowBar.jsx
@@ -20,35 +20,25 @@ function fmtEndTime(startTime, duration) {
 }
 
 export default function TrayNowBar({ darkMode, currentTask }) {
-  const { borderClass, textPrimary, textSecondary } = useDayPlannerCtx();
-
   if (!currentTask) return null;
 
   const open = () => window.electronAPI?.openMainAt({ action: 'goto-task', taskId: currentTask.id });
   const start = fmtTime(currentTask.startTime);
   const end = fmtEndTime(currentTask.startTime, currentTask.duration);
   const timeLabel = end ? `${start}–${end}` : start;
+  const label = timeLabel ? `Now: ${currentTask.title}  ·  ${timeLabel}` : `Now: ${currentTask.title}`;
 
   return (
-    <div className={`flex-shrink-0 border-b ${borderClass}`}>
-      <button
-        onClick={open}
-        className={`w-full flex items-center gap-2 px-3 py-2.5 text-left transition-opacity hover:opacity-80 ${
-          darkMode ? 'bg-blue-500/15' : 'bg-blue-50'
-        }`}
-      >
-        <div
-          className="flex-shrink-0 w-2 h-2 rounded-full mt-px"
-          style={{ backgroundColor: currentTask.colorHex || '#3b82f6' }}
-        />
-        <div className="flex-1 min-w-0">
-          <div className={`text-xs font-medium truncate ${textPrimary}`}>{currentTask.title}</div>
-          {timeLabel && <div className={`text-xs ${textSecondary}`}>{timeLabel}</div>}
-        </div>
-        <div className={`text-xs font-medium flex-shrink-0 ${darkMode ? 'text-blue-400' : 'text-blue-600'}`}>
-          Now
-        </div>
-      </button>
-    </div>
+    <button
+      onClick={open}
+      className={`w-full flex-shrink-0 flex items-center gap-2 px-4 py-1.5 text-xs font-semibold text-left transition-opacity hover:opacity-80 ${
+        darkMode
+          ? 'bg-amber-900/40 text-amber-300 border-b border-amber-700/40'
+          : 'bg-amber-50 text-amber-800 border-b border-amber-200'
+      }`}
+    >
+      <span className="w-2 h-2 rounded-full bg-amber-400 animate-pulse flex-shrink-0" />
+      <span className="truncate">{label}</span>
+    </button>
   );
 }

--- a/src/components/TrayReminders.jsx
+++ b/src/components/TrayReminders.jsx
@@ -12,6 +12,11 @@ export default function TrayReminders({ darkMode, reminders }) {
   const snooze = (reminder) =>
     window.electronAPI?.backgroundAction({ action: 'snooze-reminder', reminder });
 
+  const complete = (reminder) => {
+    window.electronAPI?.backgroundAction({ action: 'toggle-complete', taskId: reminder.taskId });
+    dismiss(reminder.id);
+  };
+
   return (
     <div className={`flex-shrink-0 border-b ${borderClass}`}>
       {reminders.map((r) => (
@@ -27,7 +32,16 @@ export default function TrayReminders({ darkMode, reminders }) {
             <div className={`text-xs ${textSecondary}`}>{r.message}</div>
           </div>
           <div className="flex items-center gap-1 flex-shrink-0">
-            {!r.isCalendarEvent && r.startTime && (
+            {r.type === 'end' && !r.isCalendarEvent && (
+              <button
+                onClick={() => complete(r)}
+                title="Mark complete"
+                className="px-2 py-0.5 text-xs rounded bg-blue-600 text-white transition-opacity hover:opacity-80"
+              >
+                Complete
+              </button>
+            )}
+            {r.type !== 'end' && r.type !== 'morning' && !r.isCalendarEvent && r.startTime && (
               <button
                 onClick={() => snooze(r)}
                 title="Snooze 15 min"


### PR DESCRIPTION
## Summary

- **TrayNowBar color**: matches the desktop Now bar — amber background (`bg-amber-900/40` dark / `bg-amber-50` light), pulsing amber dot, `Now: {title} · {time}` format
- **TrayReminders — Ending now**: `type === 'end'` reminders now show a **Complete** button (triggers `toggle-complete` background action + dismisses the reminder) instead of Snooze, matching the desktop `ReminderToasts` behavior. Snooze is also now correctly suppressed for `morning` type reminders.

## Test plan

- [ ] With a task currently in progress, open tray popup — Now bar appears in amber, not blue
- [ ] When an "Ending now" reminder fires in the tray, the action button reads "Complete", not the clock/snooze icon
- [ ] Clicking Complete marks the task done in the main window and dismisses the reminder
- [ ] "Starting now" / "Starts in X" reminders still show the Snooze clock icon

https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_