### PR TITLE
Security: restrict WebSocket to loopback and add proxy-fetch SSRF guard

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -185,11 +185,56 @@ function createTray(): void {
   });
 }
 
+// Allowed HTTP methods for the proxy — covers CalDAV/WebDAV needs.
+const PROXY_ALLOWED_METHODS = new Set(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'PROPFIND', 'MKCOL', 'REPORT', 'OPTIONS']);
+
+// Block private/loopback/link-local addresses to prevent SSRF.
+function validateProxyUrl(urlString: string): void {
+  let parsed: URL;
+  try { parsed = new URL(urlString); } catch { throw new Error('Invalid URL'); }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error('Only http and https URLs are allowed');
+  }
+
+  const h = parsed.hostname.toLowerCase();
+
+  if (h === 'localhost' || h === '0.0.0.0') throw new Error('Private/reserved address');
+
+  const ipv4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const [a, b] = [Number(ipv4[1]), Number(ipv4[2])];
+    if (
+      a === 10 ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      a === 127 ||
+      (a === 169 && b === 254) ||
+      a === 0 ||
+      (a === 100 && b >= 64 && b <= 127)
+    ) throw new Error('Private/reserved address');
+  }
+
+  if (
+    h === '::1' || h === '::' ||
+    /^::ffff:/i.test(h) || /^fe80:/i.test(h) ||
+    /^fc/i.test(h)      || /^fd/i.test(h)
+  ) throw new Error('Private/reserved address');
+}
+
 // Proxy outbound HTTP requests from the renderer so they aren't subject to
 // Chromium's CORS restrictions when the app is loaded from file://.
 ipcMain.handle('proxy-fetch', async (_event, method: string, url: string, headers: Record<string, string>, body: string | null) => {
+  const upperMethod = (method ?? '').toUpperCase();
+  if (!PROXY_ALLOWED_METHODS.has(upperMethod)) {
+    return { status: 400, ok: false, statusText: 'Bad Request', body: 'Method not allowed' };
+  }
+  try { validateProxyUrl(url); } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Invalid URL';
+    return { status: 400, ok: false, statusText: 'Bad Request', body: msg };
+  }
   const response = await net.fetch(url, {
-    method,
+    method: upperMethod,
     headers,
     ...(body != null ? { body } : {}),
   });

--- a/electron/ws-server.ts
+++ b/electron/ws-server.ts
@@ -8,11 +8,20 @@ const WS_PORT = 7892;
 // even if it was closed and recreated after startup (possible when the tray
 // keeps the process alive).
 export function createWsServer(getMainWindow: () => BrowserWindow | null): WebSocketServer {
-  const wss = new WebSocketServer({ port: WS_PORT });
+  // Bind to loopback only — never reachable from the network.
+  const wss = new WebSocketServer({ host: '127.0.0.1', port: WS_PORT });
   const clients = new Set<WebSocket>();
   let lastState: string | null = null;
 
-  wss.on('connection', (ws) => {
+  wss.on('connection', (ws, req) => {
+    // Browser-initiated WebSocket connections always include an Origin header;
+    // native clients (e.g. the Stream Deck plugin) do not. Reject browser
+    // connections to prevent any web page from reaching this server.
+    if (req.headers['origin']) {
+      ws.terminate();
+      return;
+    }
+
     clients.add(ws);
     if (lastState) {
       ws.send(lastState);


### PR DESCRIPTION
Fixes two HIGH severity findings from security audit.

## WebSocket server (`electron/ws-server.ts`)

**Before:** `new WebSocketServer({ port: 7892 })` binds to `0.0.0.0` — reachable from any process on the LAN or from a malicious web page via `ws://localhost:7892`.

**After:**
- Bind to `127.0.0.1` so the server is never network-reachable
- Reject any connection that includes an `Origin` header. Browsers always send `Origin` on WebSocket upgrades; native clients (the Stream Deck plugin uses Node.js `ws`) do not — so legitimate connections are unaffected

## proxy-fetch IPC (`electron/main.ts`)

**Before:** The renderer could pass any URL to `net.fetch` — including `file:///etc/passwd`, `http://169.254.169.254/` (cloud IMDS), or private LAN addresses.

**After:**
- `validateProxyUrl()` blocks `file:`, `ftp:`, and all private/loopback/link-local IPv4 (`10.x`, `172.16–31.x`, `192.168.x`, `127.x`, `169.254.x`) and IPv6 (`::1`, `::ffff:`, `fe80:`, `fc/fd` ULA) ranges — identical logic to the existing guards in `vite.config.js` and the Vercel API routes
- HTTP method allowlist (`GET POST PUT DELETE PATCH PROPFIND MKCOL REPORT OPTIONS`) covers all CalDAV/WebDAV needs and nothing else

## Test plan
- [ ] Stream Deck plugin connects and receives state updates normally
- [ ] CalDAV sync (WebDAV calendar) still works
- [ ] AI calls (OpenAI/Anthropic/Gemini) still work through the proxy
- [ ] A request to `file:///etc/passwd` via proxy-fetch returns 400
- [ ] A request to `http://192.168.1.1/` via proxy-fetch returns 400

https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_