### PR TITLE
Security: Electron process hardening and Content Security Policy

### DIFF
--- a/electron/entitlements.mac.plist
+++ b/electron/entitlements.mac.plist
@@ -4,8 +4,6 @@
   <dict>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
     <key>com.apple.security.network.client</key>
     <true/>
   </dict>

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, ipcMain, net, Tray, Menu, nativeImage, globalShortcut } from 'electron';
+import { app, BrowserWindow, shell, ipcMain, net, Tray, Menu, nativeImage, globalShortcut, session } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -343,6 +343,32 @@ ipcMain.on('ws:push-state', (event) => {
 });
 
 app.whenReady().then(() => {
+  // Content Security Policy — applied to every response the renderer loads.
+  // script-src 'self': only scripts from the app bundle (no inline scripts, no eval).
+  // style-src 'self' 'unsafe-inline': Tailwind generates inline styles at runtime.
+  // connect-src 'self' https:: allows XHR/fetch to any https origin (AI APIs, CalDAV, etc.).
+  // img-src 'self' data: blob:: covers favicons, base64 images, and blob URLs.
+  // object-src / base-uri 'none': closes classic plugin and base-tag injection vectors.
+  const CSP = [
+    "default-src 'self'",
+    "script-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "connect-src 'self' https:",
+    "img-src 'self' data: blob:",
+    "font-src 'self' data:",
+    "object-src 'none'",
+    "base-uri 'none'",
+  ].join('; ');
+
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [CSP],
+      },
+    });
+  });
+
   const win = createWindow();
   createWsServer(() => live(mainWindow));
   if (process.platform === 'darwin') createTray();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -34,6 +34,27 @@ function live(win: BrowserWindow | null): BrowserWindow | null {
   return win && !win.isDestroyed() ? win : null;
 }
 
+// Only open http/https URLs in the system browser — prevents javascript:,
+// file:, custom-protocol, and other potentially dangerous scheme abuse.
+function openExternalSafe(url: string): void {
+  try {
+    const { protocol } = new URL(url);
+    if (protocol === 'https:' || protocol === 'http:') shell.openExternal(url);
+  } catch { /* malformed URL — ignore */ }
+}
+
+// True if the navigation target is the app itself (file:// in production,
+// the Vite dev server in dev). Used to block renderer-initiated navigations
+// to external origins (defense-in-depth against XSS).
+function isSameAppOrigin(url: string): boolean {
+  try {
+    const { protocol, origin } = new URL(url);
+    if (protocol === 'file:') return true;
+    if (DEV && origin === new URL(VITE_DEV_SERVER_URL).origin) return true;
+    return false;
+  } catch { return false; }
+}
+
 // ── Window state persistence ─────────────────────────────────────────────────
 interface WindowState { x?: number; y?: number; width: number; height: number; maximized: boolean; }
 
@@ -94,10 +115,15 @@ function createWindow(): BrowserWindow {
     mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
   }
 
-  // Open external links in the system browser
+  // Open external links in the system browser (https/http only).
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    openExternalSafe(url);
     return { action: 'deny' };
+  });
+
+  // Prevent the renderer from navigating away from the app origin.
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (!isSameAppOrigin(url)) event.preventDefault();
   });
 
   return mainWindow;
@@ -130,6 +156,15 @@ function createTrayWindow(): BrowserWindow {
   // finish hydrating; focus state self-corrects within 1s so no re-push needed.
   win.webContents.on('did-finish-load', () => {
     setTimeout(() => { pushRemindersToTray(); pushCurrentTaskToTray(); }, 800);
+  });
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    openExternalSafe(url);
+    return { action: 'deny' };
+  });
+
+  win.webContents.on('will-navigate', (event, url) => {
+    if (!isSameAppOrigin(url)) event.preventDefault();
   });
 
   // Hide when the user clicks outside the popup; reload if state changed while it was open

--- a/index.html
+++ b/index.html
@@ -6,15 +6,7 @@
   <meta name="description" content="dayGLANCE - A beautiful time-blocking day planner with task management">
   <meta name="theme-color" content="#ffffff">
   <meta name="color-scheme" content="light dark">
-  <script>
-    try {
-      if (JSON.parse(localStorage.getItem('day-planner-darkmode'))) {
-        document.querySelector('meta[name="theme-color"]').setAttribute('content', '#1f2937');
-        document.documentElement.style.backgroundColor = '#1f2937';
-        document.documentElement.classList.add('dark');
-      }
-    } catch(e) {}
-  </script>
+  <script src="/theme-init.js"></script>
 
   <!-- Favicon -->
   <link rel="icon" type="image/x-icon" href="/favicon.ico">

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,7 @@
+try {
+  if (JSON.parse(localStorage.getItem('day-planner-darkmode'))) {
+    document.querySelector('meta[name="theme-color"]').setAttribute('content', '#1f2937');
+    document.documentElement.style.backgroundColor = '#1f2937';
+    document.documentElement.classList.add('dark');
+  }
+} catch(e) {}


### PR DESCRIPTION
Fixes three MEDIUM severity findings from security audit.

## `shell.openExternal` scheme validation (MEDIUM)

`openExternalSafe()` now validates the URL before passing it to the OS — only `https:` and `http:` are allowed. `javascript:`, `file:`, `ms-cxh:`, `tel:`, and other schemes are silently dropped. Applied to both `mainWindow` and `trayWindow` (tray previously had no handler at all).

## `will-navigate` guard (LOW/defence-in-depth)

`isSameAppOrigin()` prevents the renderer from navigating to an external origin. Allows `file://` (production) and the Vite dev server origin (dev). This closes the XSS→renderer-navigation path that `setWindowOpenHandler` alone doesn't cover.

## `allow-unsigned-executable-memory` entitlement removed (MEDIUM)

Removed from `electron/entitlements.mac.plist`. The renderer's JIT only requires `com.apple.security.cs.allow-jit`, which is still present. `allow-unsigned-executable-memory` is a broader entitlement that weakens exploit mitigations unnecessarily.

## Content Security Policy (MEDIUM)

Added via `session.defaultSession.webRequest.onHeadersReceived` in `app.whenReady()`:

```
script-src 'self'           — no inline scripts, no eval
style-src 'self' 'unsafe-inline'  — Tailwind requires inline styles at runtime
connect-src 'self' https:   — AI APIs, CalDAV, WebDAV
img-src 'self' data: blob:
object-src 'none'
base-uri 'none'
```

The dark-mode flash-prevention inline script in `index.html` has been extracted to `public/theme-init.js` so that `script-src 'self'` covers it without needing a hash or `'unsafe-inline'`.

## Test plan
- [ ] App loads and dark mode initialises correctly (theme-init.js)
- [ ] External links (e.g. clicking a URL in a task note) open in the system browser
- [ ] CalDAV / WebDAV calendar sync still works
- [ ] AI features (OpenAI / Anthropic / Gemini) still work
- [ ] Stream Deck plugin receives state updates normally
- [ ] On macOS: app still launches and signs correctly after entitlement change

https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_