### PR TITLE
Security: non-extractable AES session key and disable production source maps

### DIFF
--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -57,7 +57,7 @@ async function loadKeyFromIndexedDB() {
     });
     if (!record) return null;
     const key = await crypto.subtle.importKey(
-      'raw', record.rawKey, { name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']
+      'raw', record.rawKey, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']
     );
     return { key, salt: new Uint8Array(record.salt) };
   } catch {
@@ -87,7 +87,7 @@ async function loadKeyFromAndroid() {
     if (!b64) return null;
     const record = JSON.parse(atob(b64));
     const key = await crypto.subtle.importKey(
-      'raw', new Uint8Array(record.rawKey), { name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']
+      'raw', new Uint8Array(record.rawKey), { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']
     );
     return { key, salt: new Uint8Array(record.salt) };
   } catch {
@@ -162,15 +162,19 @@ export async function initSessionKey() {
  */
 export async function setupEncryptionKey(passphrase) {
   const salt = crypto.getRandomValues(new Uint8Array(16));
-  const key  = await deriveKey(passphrase, salt);
+  const key  = await deriveKey(passphrase, salt);  // extractable: true (needed to export for storage)
   _sessionPassphrase = passphrase;
-  _sessionKey        = key;
   _sessionSalt       = salt;
   if (typeof window !== 'undefined' && window.DayGlanceNative?.storeSyncKey) {
     await saveKeyToAndroid(key, salt);
   } else {
     await saveKeyToIndexedDB(key, salt);
   }
+  // Re-import as non-extractable so the live in-memory key cannot be exported via the Web Crypto API.
+  const rawKey = await crypto.subtle.exportKey('raw', key);
+  _sessionKey = await crypto.subtle.importKey(
+    'raw', rawKey, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']
+  );
 }
 
 /**

--- a/vite.config.electron.js
+++ b/vite.config.electron.js
@@ -13,7 +13,7 @@ export default defineConfig({
     __IS_ELECTRON__: 'true',
   },
   build: {
-    sourcemap: true,
+    sourcemap: false,
     outDir: 'dist',
     emptyOutDir: true,
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -140,7 +140,7 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
   build: {
-    sourcemap: true,
+    sourcemap: false,
   },
   plugins: [
     devApiProxy(),


### PR DESCRIPTION
Fixes two LOW severity findings from security audit.

## AES key extractability (`src/utils/crypto.js`)

The in-memory AES-256-GCM session key was imported with `extractable: true`, meaning any script in the same origin could call `crypto.subtle.exportKey()` on it. This closes that window:

- `loadKeyFromIndexedDB` and `loadKeyFromAndroid` now import with `extractable: false` — keys loaded from storage only need to encrypt/decrypt, never to be re-exported
- `setupEncryptionKey` continues to derive with `extractable: true` (required to export raw bytes for storage), but immediately re-imports the key as `extractable: false` so `_sessionKey` in memory is never exportable

The stored format (raw bytes in IndexedDB / Android Keystore) is unchanged — no migration needed.

## Production source maps (`vite.config.js`, `vite.config.electron.js`)

`sourcemap: true` → `false` in both build configs. Dev server source maps are unaffected (this only applies to `npm run build` output). Prevents full original source, AI prompt strings, and business logic from being readable inside the distributed app bundle.

## Test plan
- [ ] Cloud sync encrypt/decrypt still works after this change
- [ ] Encryption key survives an app reload (restored from IndexedDB)
- [ ] Production build (`npm run build`) produces no `.map` files

https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd

---
_Generated by [Claude Code](https://claude.ai/code/session_017DBvYefvAUojvNQLykvGsd)_