### PR TITLE
Mobile GRID/LIST view toggle (step 1)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -248,6 +248,10 @@ const DayPlanner = () => {
     const saved = localStorage.getItem('day-planner-day-view-mode');
     return saved ? JSON.parse(saved) : 'calendar-day';
   });
+  const [mobileViewMode, setMobileViewMode] = useState(() => {
+    const saved = localStorage.getItem('day-planner-mobile-view-mode');
+    return saved ? JSON.parse(saved) : 'grid';
+  });
   const [weekViewMode, setWeekViewMode] = useState(() => {
     const saved = localStorage.getItem('day-planner-week-view-mode');
     return saved ? JSON.parse(saved) : 'strict';
@@ -1061,6 +1065,9 @@ const DayPlanner = () => {
   useEffect(() => {
     localStorage.setItem('day-planner-week-view-mode', JSON.stringify(weekViewMode));
   }, [weekViewMode]);
+  useEffect(() => {
+    localStorage.setItem('day-planner-mobile-view-mode', JSON.stringify(mobileViewMode));
+  }, [mobileViewMode]);
 
   // Lock body/html scrolling to prevent scroll chaining (all devices incl. desktop PWA)
   useEffect(() => {
@@ -7146,6 +7153,7 @@ const DayPlanner = () => {
     // ── Layout / navigation ───────────────────────────────────────────────────
     tabletActiveTab, setTabletActiveTab,
     mobileActiveTab, setMobileActiveTab,
+    mobileViewMode, setMobileViewMode,
     mobileWelcomeStep, setMobileWelcomeStep,
     desktopWelcomeStep, setDesktopWelcomeStep,
     showMonthView, setShowMonthView,

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -32,6 +32,7 @@ import MobileTimeGrid from './MobileTimeGrid.jsx';
 import MobileAllDaySection from './MobileAllDaySection.jsx';
 import MobileBottomSheets from './MobileBottomSheets.jsx';
 import MobileGlanceSection from './MobileGlanceSection.jsx';
+import MobileViewToggle from './MobileViewToggle.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -73,6 +74,7 @@ const MobileLayout = () => {
     hours, firstHour,
     tabletActiveTab, setTabletActiveTab,
     mobileActiveTab, setMobileActiveTab,
+    mobileViewMode, setMobileViewMode,
     mobileWelcomeStep, setMobileWelcomeStep,
     desktopWelcomeStep, setDesktopWelcomeStep,
     showMonthView, setShowMonthView,
@@ -699,9 +701,10 @@ const MobileLayout = () => {
                   })()}
                   <div className={`flex border-b ${borderClass} ${mobileDragPreviewTime === 'all-day' ? 'ring-2 ring-inset ring-blue-500' : ''}`}>
                     <div className={`w-12 flex-shrink-0 border-r ${borderClass} ${mobileDragPreviewTime === 'all-day' ? 'flex items-center justify-center' : ''}`}>
-                      {mobileDragPreviewTime === 'all-day' && (
-                        <span className="text-[9px] font-bold text-blue-500">ALL DAY</span>
-                      )}
+                      {mobileDragPreviewTime === 'all-day'
+                        ? <span className="text-[9px] font-bold text-blue-500">ALL DAY</span>
+                        : <MobileViewToggle />
+                      }
                     </div>
                     {visibleDates.map((date, idx) => {
                       const isDateToday = dateToString(date) === dateToString(new Date());
@@ -754,8 +757,8 @@ const MobileLayout = () => {
                   <MobileAllDaySection />
                   </div>{/* end sticky header group */}
 
-                  {/* Time grid */}
-                  <MobileTimeGrid />
+                  {/* Time grid — hidden in LIST mode; LIST view content added in a later step */}
+                  {mobileViewMode === 'grid' && <MobileTimeGrid />}
                 </div>
 
                 {/* Mobile notes panel overlay for timeline tasks (including deadline tasks) */}

--- a/src/components/MobileViewToggle.jsx
+++ b/src/components/MobileViewToggle.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+
+const ORANGE = '#fe8b00';
+
+const GridIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    <rect x="1"  y="1"  width="7" height="7" rx="1.5" fill={ORANGE} />
+    <rect x="10" y="1"  width="7" height="7" rx="1.5" fill={ORANGE} fillOpacity="0.55" />
+    <rect x="1"  y="10" width="7" height="7" rx="1.5" fill={ORANGE} fillOpacity="0.55" />
+    <rect x="10" y="10" width="7" height="7" rx="1.5" fill={ORANGE} fillOpacity="0.28" />
+  </svg>
+);
+
+const ListIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    {/* Vertical spine */}
+    <rect x="5" y="1" width="2" height="16" rx="1" fill={ORANGE} />
+    {/* Blocks to the right of the spine */}
+    <rect x="9" y="2"  width="8" height="4" rx="1" fill={ORANGE} />
+    <rect x="9" y="8"  width="8" height="4" rx="1" fill={ORANGE} fillOpacity="0.7" />
+    <rect x="9" y="14" width="6" height="3" rx="1" fill={ORANGE} fillOpacity="0.45" />
+    {/* Tiny time labels left of spine */}
+    <rect x="1" y="3.5" width="2.5" height="1" rx="0.5" fill={ORANGE} fillOpacity="0.5" />
+    <rect x="1" y="9.5" width="2.5" height="1" rx="0.5" fill={ORANGE} fillOpacity="0.5" />
+  </svg>
+);
+
+const MobileViewToggle = () => {
+  const { mobileViewMode, setMobileViewMode, textSecondary } = useDayPlannerCtx();
+
+  const toggle = () => setMobileViewMode(prev => prev === 'grid' ? 'list' : 'grid');
+
+  return (
+    <button
+      onClick={toggle}
+      className="flex flex-col items-center justify-center gap-0.5 w-full h-full py-1 hover:bg-black/5 dark:hover:bg-white/5 active:bg-black/10 dark:active:bg-white/10 transition-colors"
+      aria-label={`Switch to ${mobileViewMode === 'grid' ? 'list' : 'grid'} view`}
+      title={`Current view: ${mobileViewMode.toUpperCase()}. Tap to switch.`}
+    >
+      {mobileViewMode === 'grid' ? <GridIcon /> : <ListIcon />}
+      <span className={`text-[9px] font-semibold tracking-widest uppercase ${textSecondary} leading-none`}>
+        {mobileViewMode === 'grid' ? 'GRID' : 'LIST'}
+      </span>
+    </button>
+  );
+};
+
+export default MobileViewToggle;

--- a/src/components/MobileViewToggle.jsx
+++ b/src/components/MobileViewToggle.jsx
@@ -14,15 +14,12 @@ const GridIcon = () => (
 
 const ListIcon = () => (
   <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-    {/* Vertical spine */}
-    <rect x="4" y="1" width="2" height="16" rx="1" fill={ORANGE} />
-    {/* Blocks to the right of the spine — start at x=7 to match GRID's visual width */}
-    <rect x="7" y="2"  width="10" height="4" rx="1" fill={ORANGE} />
-    <rect x="7" y="8"  width="10" height="4" rx="1" fill={ORANGE} fillOpacity="0.7" />
-    <rect x="7" y="14" width="7"  height="3" rx="1" fill={ORANGE} fillOpacity="0.45" />
-    {/* Tiny time labels left of spine */}
-    <rect x="1" y="3.5" width="2" height="1" rx="0.5" fill={ORANGE} fillOpacity="0.5" />
-    <rect x="1" y="9.5" width="2" height="1" rx="0.5" fill={ORANGE} fillOpacity="0.5" />
+    {/* Vertical spine — flush left */}
+    <rect x="1" y="1" width="2" height="16" rx="1" fill={ORANGE} />
+    {/* Blocks to the right */}
+    <rect x="5" y="2"  width="12" height="4" rx="1" fill={ORANGE} />
+    <rect x="5" y="8"  width="12" height="4" rx="1" fill={ORANGE} fillOpacity="0.7" />
+    <rect x="5" y="14" width="9"  height="3" rx="1" fill={ORANGE} fillOpacity="0.45" />
   </svg>
 );
 

--- a/src/components/MobileViewToggle.jsx
+++ b/src/components/MobileViewToggle.jsx
@@ -15,14 +15,14 @@ const GridIcon = () => (
 const ListIcon = () => (
   <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
     {/* Vertical spine */}
-    <rect x="5" y="1" width="2" height="16" rx="1" fill={ORANGE} />
-    {/* Blocks to the right of the spine */}
-    <rect x="9" y="2"  width="8" height="4" rx="1" fill={ORANGE} />
-    <rect x="9" y="8"  width="8" height="4" rx="1" fill={ORANGE} fillOpacity="0.7" />
-    <rect x="9" y="14" width="6" height="3" rx="1" fill={ORANGE} fillOpacity="0.45" />
+    <rect x="4" y="1" width="2" height="16" rx="1" fill={ORANGE} />
+    {/* Blocks to the right of the spine — start at x=7 to match GRID's visual width */}
+    <rect x="7" y="2"  width="10" height="4" rx="1" fill={ORANGE} />
+    <rect x="7" y="8"  width="10" height="4" rx="1" fill={ORANGE} fillOpacity="0.7" />
+    <rect x="7" y="14" width="7"  height="3" rx="1" fill={ORANGE} fillOpacity="0.45" />
     {/* Tiny time labels left of spine */}
-    <rect x="1" y="3.5" width="2.5" height="1" rx="0.5" fill={ORANGE} fillOpacity="0.5" />
-    <rect x="1" y="9.5" width="2.5" height="1" rx="0.5" fill={ORANGE} fillOpacity="0.5" />
+    <rect x="1" y="3.5" width="2" height="1" rx="0.5" fill={ORANGE} fillOpacity="0.5" />
+    <rect x="1" y="9.5" width="2" height="1" rx="0.5" fill={ORANGE} fillOpacity="0.5" />
   </svg>
 );
 


### PR DESCRIPTION
## Summary

- Adds `mobileViewMode` state (`'grid' | 'list'`, default `'grid'`) persisted to `localStorage` under `'day-planner-mobile-view-mode'`
- New `MobileViewToggle` component with two orange SVG icons (GridIcon / ListIcon) + label
- Toggle sits in the existing `w-12` top-left cell of the timeline sticky header — **cell dimensions unchanged**
- In LIST mode `MobileTimeGrid` is unmounted; the sticky header, date column header, and all-day section are fully preserved
- LIST view body is intentionally blank — content follows in later steps

## What's unchanged

- GRID view behaviour is 100% identical
- Date nav header untouched
- Date column header (with NotebookPen / Target icons) untouched
- All-day section untouched
- Desktop MULTI/DAY/WEEK cycler untouched

## Test checklist

- [ ] Toggle appears in top-left square on mobile, not on desktop
- [ ] Tapping cycles GRID → LIST → GRID
- [ ] GRID label shows GridIcon; LIST label shows ListIcon
- [ ] State persists across page reload
- [ ] GRID view is completely unchanged when modeViewMode = 'grid'
- [ ] LIST mode shows blank content area (date header + all-day section still visible)
- [ ] Light and dark mode both look correct
- [ ] ALL DAY drag label still overrides the toggle during drag

https://claude.ai/code/session_01XB9ceEk9TdLd6kJc3awnZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XB9ceEk9TdLd6kJc3awnZP)_