### PR TITLE
Mobile LIST view — spine layout, cards, inbox drawer

### DIFF
--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -33,6 +33,7 @@ import MobileAllDaySection from './MobileAllDaySection.jsx';
 import MobileBottomSheets from './MobileBottomSheets.jsx';
 import MobileGlanceSection from './MobileGlanceSection.jsx';
 import MobileViewToggle from './MobileViewToggle.jsx';
+import MobileListView from './MobileListView.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -754,11 +755,11 @@ const MobileLayout = () => {
                     })}
                   </div>
 
-                  <MobileAllDaySection />
+                  {mobileViewMode === 'grid' && <MobileAllDaySection />}
                   </div>{/* end sticky header group */}
 
-                  {/* Time grid — hidden in LIST mode; LIST view content added in a later step */}
                   {mobileViewMode === 'grid' && <MobileTimeGrid />}
+                  {mobileViewMode === 'list' && <MobileListView />}
                 </div>
 
                 {/* Mobile notes panel overlay for timeline tasks (including deadline tasks) */}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -336,7 +336,7 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
         {/* -1/+1 overreach ensures flush join with adjacent rows — no pixel gaps */}
         <div
           style={{
-            position: 'absolute', top: -1, bottom: -1,
+            position: 'absolute', top: 0, bottom: 0,
             left: '50%', transform: 'translateX(-50%)',
             width: 2, zIndex: 0,
             background: spineStyle === 'dashed'
@@ -380,7 +380,7 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
       </div>
       {/* Spine col */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ position: 'absolute', top: -1, bottom: -1, left: '50%', transform: 'translateX(-50%)', width: 2, background: dashedGradient(spineColour + '88') }} />
+        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: dashedGradient(spineColour + '88') }} />
         {/* Drag preview indicator on spine */}
         {isTarget && (
           <div
@@ -447,7 +447,7 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
       </div>
       {/* Spine col */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ position: 'absolute', top: -1, bottom: -1, left: '50%', transform: 'translateX(-50%)', width: 2, zIndex: 0, background: '#ef444440' }} />
+        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, zIndex: 0, background: '#ef444440' }} />
         {/* Red clock marker */}
         <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2, position: 'relative' }}>
           <Clock size={9} color="#fff" />
@@ -806,7 +806,7 @@ const MobileListView = () => {
         <div style={{ display: 'flex', height: 16 }}>
           <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
           <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
-            <div style={{ position: 'absolute', top: -1, bottom: -1, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
           </div>
           <div style={{ flex: 1 }} />
         </div>
@@ -831,7 +831,7 @@ const MobileListView = () => {
         <div style={{ display: 'flex', height: 12 }}>
           <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
           <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
-            <div style={{ position: 'absolute', top: -1, bottom: -1, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
           </div>
           <div style={{ flex: 1 }} />
         </div>

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -331,18 +331,20 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
         {isNow && <Clock size={11} style={{ color: timeColour, marginLeft: 'auto', marginTop: 2 }} />}
       </div>
 
-      {/* Col 2 — spine (background line drawn by container; halo + marker here) */}
+      {/* Col 2 — spine */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-        {/* Gradient halo: fades the background spine into the marker */}
-        {pageBg && (
-          <div style={{
-            position: 'absolute',
-            top: '50%', transform: 'translateY(-50%)',
-            left: '50%', marginLeft: -1,
-            width: 2, height: 56, zIndex: 1, pointerEvents: 'none',
-            background: `linear-gradient(to bottom, transparent, ${pageBg} 40%, ${pageBg} 60%, transparent)`,
-          }} />
-        )}
+        {/* Top half: spine colour fades to transparent as it reaches the marker */}
+        <div style={{
+          position: 'absolute', top: 0, bottom: '50%',
+          left: '50%', marginLeft: -1, width: 2, zIndex: 1, pointerEvents: 'none',
+          background: `linear-gradient(to bottom, ${spineColour}, ${spineColour} 60%, transparent)`,
+        }} />
+        {/* Bottom half: fades from transparent back to spine colour */}
+        <div style={{
+          position: 'absolute', top: '50%', bottom: 0,
+          left: '50%', marginLeft: -1, width: 2, zIndex: 1, pointerEvents: 'none',
+          background: `linear-gradient(to bottom, transparent, ${spineColour} 40%, ${spineColour})`,
+        }} />
         {marker}
       </div>
 
@@ -377,8 +379,14 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
           </span>
         )}
       </div>
-      {/* Spine col (line drawn by container; only drag indicator here) */}
-      <div style={{ width: SPINE_COL_W, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {/* Spine col */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        {/* Solid spine segment through free time */}
+        <div style={{
+          position: 'absolute', top: 0, bottom: 0,
+          left: '50%', marginLeft: -1, width: 2, zIndex: 1, pointerEvents: 'none',
+          background: spineColour,
+        }} />
         {/* Drag preview indicator on spine */}
         {isTarget && (
           <div
@@ -443,17 +451,18 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
       <div style={{ width: TIME_COL_W, flexShrink: 0, paddingRight: 8, textAlign: 'right', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
         <span className="text-[11px] font-bold" style={{ color: '#ef4444' }}>{nowLabel}</span>
       </div>
-      {/* Spine col (line drawn by container; halo + marker here) */}
+      {/* Spine col */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        {pageBg && (
-          <div style={{
-            position: 'absolute',
-            top: '50%', transform: 'translateY(-50%)',
-            left: '50%', marginLeft: -1,
-            width: 2, height: 56, zIndex: 1, pointerEvents: 'none',
-            background: `linear-gradient(to bottom, transparent, ${pageBg} 40%, ${pageBg} 60%, transparent)`,
-          }} />
-        )}
+        <div style={{
+          position: 'absolute', top: 0, bottom: '50%',
+          left: '50%', marginLeft: -1, width: 2, zIndex: 1, pointerEvents: 'none',
+          background: 'linear-gradient(to bottom, #ef4444, #ef4444 60%, transparent)',
+        }} />
+        <div style={{
+          position: 'absolute', top: '50%', bottom: 0,
+          left: '50%', marginLeft: -1, width: 2, zIndex: 1, pointerEvents: 'none',
+          background: 'linear-gradient(to bottom, transparent, #ef4444 40%, #ef4444)',
+        }} />
         {/* Red clock marker */}
         <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2, position: 'relative' }}>
           <Clock size={9} color="#fff" />
@@ -832,6 +841,7 @@ const MobileListView = () => {
               left: TIME_COL_W + SPINE_COL_W / 2 - 1,
               width: 2,
               background: bgSpineGradient,
+              opacity: 0.12,
             }}
           />
         )}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -331,20 +331,8 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
         {isNow && <Clock size={11} style={{ color: timeColour, marginLeft: 'auto', marginTop: 2 }} />}
       </div>
 
-      {/* Col 2 — spine */}
-      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-        {/* Top half: spine colour fades to transparent as it reaches the marker */}
-        <div style={{
-          position: 'absolute', top: 0, bottom: '50%',
-          left: '50%', marginLeft: -1, width: 2, zIndex: 1, pointerEvents: 'none',
-          background: `linear-gradient(to bottom, ${spineColour}, ${spineColour} 60%, transparent)`,
-        }} />
-        {/* Bottom half: fades from transparent back to spine colour */}
-        <div style={{
-          position: 'absolute', top: '50%', bottom: 0,
-          left: '50%', marginLeft: -1, width: 2, zIndex: 1, pointerEvents: 'none',
-          background: `linear-gradient(to bottom, transparent, ${spineColour} 40%, ${spineColour})`,
-        }} />
+      {/* Col 2 — spine: background spine handles the line; just render the marker here */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
         {marker}
       </div>
 
@@ -360,7 +348,7 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
 
 // ─── GapRow ───────────────────────────────────────────────────────────────────
 
-function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minutesToTime, dragTargetMin, dragBlocked, darkMode }) {
+function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minutesToTime, dragTargetMin, dragBlocked, darkMode, pageBg }) {
   const h = gapHeight(toMin - fromMin);
   const showLabel = (toMin - fromMin) >= 45;
   const isTarget = dragTargetMin !== null && dragTargetMin >= fromMin && dragTargetMin < toMin;
@@ -381,12 +369,13 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
       </div>
       {/* Spine col */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        {/* Solid spine segment through free time */}
-        <div style={{
-          position: 'absolute', top: 0, bottom: 0,
-          left: '50%', marginLeft: -1, width: 2, zIndex: 1, pointerEvents: 'none',
-          background: spineColour,
-        }} />
+        {/* Long gaps (≥30 min): cover solid spine then overlay dashes to show free time */}
+        {(toMin - fromMin) >= 30 && pageBg && (
+          <>
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', marginLeft: -1, width: 2, background: pageBg, zIndex: 1, pointerEvents: 'none' }} />
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', marginLeft: -1, width: 2, background: dashedGradient(spineColour), zIndex: 2, pointerEvents: 'none' }} />
+          </>
+        )}
         {/* Drag preview indicator on spine */}
         {isTarget && (
           <div
@@ -451,20 +440,9 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
       <div style={{ width: TIME_COL_W, flexShrink: 0, paddingRight: 8, textAlign: 'right', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
         <span className="text-[11px] font-bold" style={{ color: '#ef4444' }}>{nowLabel}</span>
       </div>
-      {/* Spine col */}
-      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{
-          position: 'absolute', top: 0, bottom: '50%',
-          left: '50%', marginLeft: -1, width: 2, zIndex: 1, pointerEvents: 'none',
-          background: 'linear-gradient(to bottom, #ef4444, #ef4444 60%, transparent)',
-        }} />
-        <div style={{
-          position: 'absolute', top: '50%', bottom: 0,
-          left: '50%', marginLeft: -1, width: 2, zIndex: 1, pointerEvents: 'none',
-          background: 'linear-gradient(to bottom, transparent, #ef4444 40%, #ef4444)',
-        }} />
-        {/* Red clock marker */}
-        <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2, position: 'relative' }}>
+      {/* Spine col: background spine handles the line; just render the marker */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative', zIndex: 2 }}>
           <Clock size={9} color="#fff" />
         </div>
       </div>
@@ -765,7 +743,7 @@ const MobileListView = () => {
     return segs;
   }, [visibleItems, isToday, nowMin, timeToMinutes]);
 
-  // Page background colour — used as opaque fill behind spine markers so they cover the line
+  // Page background colour — used behind markers (checkbox fill) and long-gap dashed overlays
   const pageBg = darkMode ? '#1f2937' : '#ffffff';
 
   // Single continuous background spine gradient covering the visible time range
@@ -782,6 +760,51 @@ const MobileListView = () => {
     });
     return `linear-gradient(to bottom, ${stops.join(', ')})`;
   }, [segments, isToday, nowMin]);
+
+  // Compute the y-offset (px from timed-body top) of each spine marker so we can
+  // build a CSS mask that genuinely fades the spine to transparent at those positions.
+  const spineMarkerYs = useMemo(() => {
+    let y = 0;
+    const ys = [];
+    if (isToday && !inProgressItem) {
+      y += 16;           // height-16 padding div
+      ys.push(y + 20);  // NowRow minHeight=40, marker at vertical centre
+      y += 40;
+      if (visibleItems.length > 0) y += 12; // height-12 padding div
+    }
+    segments.forEach(seg => {
+      if (seg.type === 'gap') {
+        y += gapHeight(seg.toMin - seg.fromMin);
+      } else {
+        const cardH = seg.item._kind === 'routine' ? ROUTINE_H
+                    : seg.item._kind === 'frame'   ? FRAME_H
+                    : TASK_H;
+        const rowH = cardH + 8; // 4px marginTop + 4px marginBottom on card wrapper
+        ys.push(y + rowH / 2);
+        y += rowH;
+      }
+    });
+    return ys;
+  }, [segments, isToday, inProgressItem, visibleItems]);
+
+  // CSS mask: opaque everywhere, fades to transparent at each marker centre (±FADE px).
+  // This makes the spine genuinely transparent at markers rather than being covered.
+  const bgSpineMask = useMemo(() => {
+    if (spineMarkerYs.length === 0) return undefined;
+    const FADE = 14;
+    const stops = ['black 0px'];
+    let prev = 0;
+    spineMarkerYs.forEach(cy => {
+      const lo = cy - FADE;
+      const hi = cy + FADE;
+      if (lo > prev) stops.push(`black ${lo}px`);
+      stops.push(`transparent ${cy}px`);
+      stops.push(`black ${hi}px`);
+      prev = hi;
+    });
+    stops.push('black 9999px');
+    return `linear-gradient(to bottom, ${stops.join(', ')})`;
+  }, [spineMarkerYs]);
 
   // ── Render helpers ─────────────────────────────────────────────────────────
   const getAccentHex = (item) => {
@@ -841,7 +864,7 @@ const MobileListView = () => {
               left: TIME_COL_W + SPINE_COL_W / 2 - 1,
               width: 2,
               background: bgSpineGradient,
-              opacity: 0.12,
+              ...(bgSpineMask ? { WebkitMaskImage: bgSpineMask, maskImage: bgSpineMask } : {}),
             }}
           />
         )}
@@ -891,6 +914,7 @@ const MobileListView = () => {
               dragTargetMin={dragTargetMin}
               dragBlocked={dragBlocked}
               darkMode={darkMode}
+              pageBg={pageBg}
             />
           );
         }

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -79,7 +79,7 @@ function countdownText(diffMin) {
 
 // ─── SpineMarker ─────────────────────────────────────────────────────────────
 
-function SpineMarker({ kind, completed, colour, pageBg }) {
+function SpineMarker({ kind, completed, colour }) {
   const base = {
     width: 16, height: 16, flexShrink: 0, position: 'relative', zIndex: 2,
     display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -92,7 +92,7 @@ function SpineMarker({ kind, completed, colour, pageBg }) {
   }
   if (kind === 'frame') {
     return (
-      <div style={{ ...base, borderRadius: '50%', border: `2px solid ${colour}`, background: pageBg }} />
+      <div style={{ ...base, borderRadius: '50%', border: `2px solid ${colour}`, background: 'transparent' }} />
     );
   }
   if (kind === 'calendar-event') {
@@ -100,14 +100,14 @@ function SpineMarker({ kind, completed, colour, pageBg }) {
       <div style={{ ...base, borderRadius: 2, background: colour }} />
     );
   }
-  // task
+  // task / calendar-task
   return (
     <div
       style={{
         ...base,
         borderRadius: 4,
         border: `2px solid ${colour}`,
-        background: completed ? colour : pageBg,
+        background: completed ? colour : 'transparent',
       }}
     >
       {completed && <Check size={9} strokeWidth={3} color="#fff" />}
@@ -309,7 +309,7 @@ function FrameCard({ frame, darkMode, textPrimary, textSecondary, openFrameAdjus
 
 // ─── Row wrapper (3 columns) ──────────────────────────────────────────────────
 
-function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeight, accentHex, children, isNow, pageBg }) {
+function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeight, accentHex, children, isNow }) {
   return (
     <div style={{ display: 'flex', minHeight: cardHeight }}>
       {/* Col 1 — time */}
@@ -331,24 +331,36 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
         {isNow && <Clock size={11} style={{ color: timeColour, marginLeft: 'auto', marginTop: 2 }} />}
       </div>
 
-      {/* Col 2 — spine (background line drawn by container; halo + marker here) */}
+      {/* Col 2 — spine */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-        {/* Gradient halo: fades the background spine into the marker */}
-        {pageBg && (
-          <div style={{
-            position: 'absolute',
-            top: '50%', transform: 'translateY(-50%)',
-            left: '50%', marginLeft: -1,
-            width: 2, height: 56, zIndex: 1, pointerEvents: 'none',
-            background: `linear-gradient(to bottom, transparent, ${pageBg} 40%, ${pageBg} 60%, transparent)`,
-          }} />
-        )}
+        {/* Top spine segment — fades to transparent near the marker */}
+        <div
+          style={{
+            position: 'absolute', top: 0, bottom: 'calc(50% + 9px)',
+            left: '50%', transform: 'translateX(-50%)',
+            width: 2,
+            background: spineStyle === 'dashed'
+              ? dashedGradient(spineColour + '88')
+              : `linear-gradient(to bottom, ${spineColour}, ${spineColour} calc(100% - 10px), transparent)`,
+          }}
+        />
+        {/* Bottom spine segment — fades in from transparent below the marker */}
+        <div
+          style={{
+            position: 'absolute', top: 'calc(50% + 9px)', bottom: 0,
+            left: '50%', transform: 'translateX(-50%)',
+            width: 2,
+            background: spineStyle === 'dashed'
+              ? dashedGradient(spineColour + '88')
+              : `linear-gradient(to bottom, transparent, ${spineColour} 10px, ${spineColour})`,
+          }}
+        />
+        {/* Marker */}
         {marker}
       </div>
 
-      {/* Col 3 — no padding; card provides its own internal padding so top:50% on
-          the connector always matches the spine marker's vertical centre */}
-      <div style={{ flex: 1, minWidth: 0, position: 'relative', paddingRight: 8 }}>
+      {/* Col 3 — content */}
+      <div style={{ flex: 1, minWidth: 0, position: 'relative', paddingTop: 4, paddingBottom: 4, paddingRight: 8 }}>
         {accentHex && <Connector colour={accentHex} />}
         {children}
       </div>
@@ -377,8 +389,9 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
           </span>
         )}
       </div>
-      {/* Spine col (line drawn by container; only drag indicator here) */}
-      <div style={{ width: SPINE_COL_W, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {/* Spine col */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: dashedGradient(spineColour + '88') }} />
         {/* Drag preview indicator on spine */}
         {isTarget && (
           <div
@@ -419,7 +432,7 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
 
 // ─── NowRow ───────────────────────────────────────────────────────────────────
 
-function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24HourClock, pageBg }) {
+function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24HourClock }) {
   const nowLabel = (() => {
     const h = Math.floor(nowMin / 60);
     const m = nowMin % 60;
@@ -443,17 +456,10 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
       <div style={{ width: TIME_COL_W, flexShrink: 0, paddingRight: 8, textAlign: 'right', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
         <span className="text-[11px] font-bold" style={{ color: '#ef4444' }}>{nowLabel}</span>
       </div>
-      {/* Spine col (line drawn by container; halo + marker here) */}
+      {/* Spine col */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        {pageBg && (
-          <div style={{
-            position: 'absolute',
-            top: '50%', transform: 'translateY(-50%)',
-            left: '50%', marginLeft: -1,
-            width: 2, height: 56, zIndex: 1, pointerEvents: 'none',
-            background: `linear-gradient(to bottom, transparent, ${pageBg} 40%, ${pageBg} 60%, transparent)`,
-          }} />
-        )}
+        <div style={{ position: 'absolute', top: 0, bottom: 'calc(50% + 9px)', left: '50%', transform: 'translateX(-50%)', width: 2, background: 'linear-gradient(to bottom, #ef444466, transparent)' }} />
+        <div style={{ position: 'absolute', top: 'calc(50% + 9px)', bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: 'linear-gradient(to bottom, transparent, #ef444466)' }} />
         {/* Red clock marker */}
         <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2, position: 'relative' }}>
           <Clock size={9} color="#fff" />
@@ -756,24 +762,6 @@ const MobileListView = () => {
     return segs;
   }, [visibleItems, isToday, nowMin, timeToMinutes]);
 
-  // Page background colour — used as opaque fill behind spine markers so they cover the line
-  const pageBg = darkMode ? '#1f2937' : '#ffffff';
-
-  // Single continuous background spine gradient covering the visible time range
-  const bgSpineGradient = useMemo(() => {
-    const startMin = isToday
-      ? Math.min(nowMin, segments[0]?.fromMin ?? segments[0]?.startMin ?? nowMin)
-      : (segments[0]?.fromMin ?? segments[0]?.startMin ?? 0);
-    const lastSeg = segments[segments.length - 1];
-    const endMin = lastSeg?.toMin ?? lastSeg?.endMin ?? (startMin + 120);
-    const range = Math.max(endMin - startMin, 1);
-    const stops = [0, 0.25, 0.5, 0.75, 1].map(t => {
-      const min = startMin + t * range;
-      return `${spineColorAt(min)} ${(t * 100).toFixed(0)}%`;
-    });
-    return `linear-gradient(to bottom, ${stops.join(', ')})`;
-  }, [segments, isToday, nowMin]);
-
   // ── Render helpers ─────────────────────────────────────────────────────────
   const getAccentHex = (item) => {
     if (item._kind === 'calendar-event') {
@@ -822,51 +810,52 @@ const MobileListView = () => {
         </button>
       )}
 
-      {/* ── Timed body — single continuous background spine ── */}
-      <div style={{ position: 'relative' }}>
-        {/* One unbroken spine line behind all rows */}
-        {(visibleItems.length > 0 || (isToday && !inProgressItem)) && (
-          <div
-            style={{
-              position: 'absolute', top: 0, bottom: 0, zIndex: 0, pointerEvents: 'none',
-              left: TIME_COL_W + SPINE_COL_W / 2 - 1,
-              width: 2,
-              background: bgSpineGradient,
-            }}
+      {/* ── Spine spacer (padding above "now") ── */}
+      {isToday && !inProgressItem && (
+        <div style={{ display: 'flex', height: 16 }}>
+          <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
+          <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
+          </div>
+          <div style={{ flex: 1 }} />
+        </div>
+      )}
+
+      {/* ── Now row — hidden when something is currently in progress ── */}
+      {isToday && !inProgressItem && (
+        <div ref={nowRowRef}>
+          <NowRow
+            nowMin={nowMin}
+            nextItem={nextItem}
+            formatTime={formatTime}
+            textSecondary={textSecondary}
+            darkMode={darkMode}
+            use24HourClock={use24HourClock}
           />
-        )}
+        </div>
+      )}
 
-        {/* Padding above "now" */}
-        {isToday && !inProgressItem && <div style={{ height: 16 }} />}
-
-        {/* Now row */}
-        {isToday && !inProgressItem && (
-          <div ref={nowRowRef}>
-            <NowRow
-              nowMin={nowMin}
-              nextItem={nextItem}
-              formatTime={formatTime}
-              textSecondary={textSecondary}
-              darkMode={darkMode}
-              use24HourClock={use24HourClock}
-              pageBg={pageBg}
-            />
+      {/* ── Spine spacer (padding below "now") ── */}
+      {isToday && !inProgressItem && visibleItems.length > 0 && (
+        <div style={{ display: 'flex', height: 12 }}>
+          <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
+          <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
           </div>
-        )}
+          <div style={{ flex: 1 }} />
+        </div>
+      )}
 
-        {/* Padding below "now" */}
-        {isToday && !inProgressItem && visibleItems.length > 0 && <div style={{ height: 12 }} />}
+      {/* ── Empty state ── */}
+      {visibleItems.length === 0 && (
+        <div className={`flex flex-col items-center justify-center py-16 ${textSecondary}`}>
+          <p className="text-sm">No items scheduled</p>
+          {isToday && <p className="text-xs mt-1 opacity-60">Tap + to add a task</p>}
+        </div>
+      )}
 
-        {/* Empty state */}
-        {visibleItems.length === 0 && (
-          <div className={`flex flex-col items-center justify-center py-16 ${textSecondary}`}>
-            <p className="text-sm">No items scheduled</p>
-            {isToday && <p className="text-xs mt-1 opacity-60">Tap + to add a task</p>}
-          </div>
-        )}
-
-        {/* Segment list */}
-        {segments.map(seg => {
+      {/* ── Segment list ── */}
+      {segments.map(seg => {
         if (seg.type === 'gap') {
           const midMin = Math.round((seg.fromMin + seg.toMin) / 2);
           return (
@@ -898,19 +887,16 @@ const MobileListView = () => {
                 timeLabel={formatTime(item.startTime)}
                 spineColour={sc}
                 spineStyle="solid"
-                marker={<SpineMarker kind="routine" colour="#14b8a6" completed={completed} pageBg={pageBg} />}
+                marker={<SpineMarker kind="routine" colour="#14b8a6" completed={completed} />}
                 cardHeight={ROUTINE_H}
                 accentHex="#14b8a6"
-                pageBg={pageBg}
               >
-                <div style={{ marginTop: 4, marginBottom: 4 }}>
-                  <RoutineChip
-                    routine={item}
-                    completed={completed}
-                    onToggle={toggleRoutineCompletion}
-                    darkMode={darkMode}
-                  />
-                </div>
+                <RoutineChip
+                  routine={item}
+                  completed={completed}
+                  onToggle={toggleRoutineCompletion}
+                  darkMode={darkMode}
+                />
               </Row>
             );
           }
@@ -922,21 +908,18 @@ const MobileListView = () => {
                 timeLabel={formatTime(item.startTime)}
                 spineColour={sc}
                 spineStyle="solid"
-                marker={<SpineMarker kind="frame" colour={accentHex} pageBg={pageBg} />}
+                marker={<SpineMarker kind="frame" colour={accentHex} />}
                 cardHeight={FRAME_H}
                 accentHex={accentHex}
-                pageBg={pageBg}
               >
-                <div style={{ marginTop: 4, marginBottom: 4 }}>
-                  <FrameCard
-                    frame={item}
-                    darkMode={darkMode}
-                    textPrimary={textPrimary}
-                    textSecondary={textSecondary}
-                    openFrameAdjust={openFrameAdjust}
-                    dateStr={dateStr}
-                  />
-                </div>
+                <FrameCard
+                  frame={item}
+                  darkMode={darkMode}
+                  textPrimary={textPrimary}
+                  textSecondary={textSecondary}
+                  openFrameAdjust={openFrameAdjust}
+                  dateStr={dateStr}
+                />
               </Row>
             );
           }
@@ -955,14 +938,12 @@ const MobileListView = () => {
                   kind={isCalendarEvent ? 'calendar-event' : 'task'}
                   completed={item.completed}
                   colour={accentHex}
-                  pageBg={pageBg}
                 />
               }
               cardHeight={TASK_H}
               accentHex={accentHex}
-              pageBg={pageBg}
             >
-              <div style={{ opacity: isPast ? 0.5 : 1, marginTop: 4, marginBottom: 4 }}>
+              <div style={{ opacity: isPast ? 0.5 : 1 }}>
                 <TaskCard
                   item={item}
                   accentHex={accentHex}
@@ -987,7 +968,6 @@ const MobileListView = () => {
 
         return null;
       })}
-      </div>{/* end timed body */}
 
       {/* ── Inbox drawer ── */}
       {/* Collapsed handle — fixed to viewport */}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -332,26 +332,26 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
 
       {/* Col 2 — spine */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-        {/* Top spine segment — stops just above the marker */}
+        {/* Top spine segment — fades to transparent near the marker */}
         <div
           style={{
             position: 'absolute', top: 0, bottom: 'calc(50% + 9px)',
             left: '50%', transform: 'translateX(-50%)',
             width: 2,
-            ...(spineStyle === 'dashed'
-              ? { background: dashedGradient(spineColour + '88') }
-              : { background: spineColour }),
+            background: spineStyle === 'dashed'
+              ? dashedGradient(spineColour + '88')
+              : `linear-gradient(to bottom, ${spineColour}, ${spineColour} calc(100% - 10px), transparent)`,
           }}
         />
-        {/* Bottom spine segment — resumes just below the marker */}
+        {/* Bottom spine segment — fades in from transparent below the marker */}
         <div
           style={{
             position: 'absolute', top: 'calc(50% + 9px)', bottom: 0,
             left: '50%', transform: 'translateX(-50%)',
             width: 2,
-            ...(spineStyle === 'dashed'
-              ? { background: dashedGradient(spineColour + '88') }
-              : { background: spineColour }),
+            background: spineStyle === 'dashed'
+              ? dashedGradient(spineColour + '88')
+              : `linear-gradient(to bottom, transparent, ${spineColour} 10px, ${spineColour})`,
           }}
         />
         {/* Marker */}
@@ -450,13 +450,13 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
   return (
     <div style={{ display: 'flex', minHeight: 40, alignItems: 'center' }}>
       {/* Time col */}
-      <div style={{ width: TIME_COL_W, flexShrink: 0, paddingRight: 8, textAlign: 'right', display: 'flex', flexDirection: 'column', alignItems: 'flex-end', justifyContent: 'center', gap: 2 }}>
+      <div style={{ width: TIME_COL_W, flexShrink: 0, paddingRight: 8, textAlign: 'right', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
         <span className="text-[11px] font-bold" style={{ color: '#ef4444' }}>{nowLabel}</span>
-        <Clock size={11} style={{ color: '#ef4444' }} />
       </div>
       {/* Spine col */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: '#ef4444', opacity: 0.4 }} />
+        <div style={{ position: 'absolute', top: 0, bottom: 'calc(50% + 9px)', left: '50%', transform: 'translateX(-50%)', width: 2, background: 'linear-gradient(to bottom, #ef444466, transparent)' }} />
+        <div style={{ position: 'absolute', top: 'calc(50% + 9px)', bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: 'linear-gradient(to bottom, transparent, #ef444466)' }} />
         {/* Red clock marker */}
         <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2, position: 'relative' }}>
           <Clock size={9} color="#fff" />
@@ -595,15 +595,25 @@ const MobileListView = () => {
   const futureItems = useMemo(() => allItems.filter(i => !isItemPast(i)), [allItems, isItemPast]);
   const visibleItems = showPast ? allItems : futureItems;
 
-  // Next non-completed item after now
+  // Item currently in progress (overlaps nowMin)
+  const inProgressItem = useMemo(() => {
+    if (!isToday) return null;
+    return allItems.find(item => {
+      const s = timeToMinutes(item.startTime);
+      return nowMin >= s && nowMin < s + (item.duration || 30);
+    });
+  }, [allItems, isToday, nowMin, timeToMinutes]);
+
+  // Next non-completed item starting after now
   const nextItem = useMemo(() => {
     return futureItems.find(i => {
-      if (i._kind === 'routine')       return !routineCompletions[i._routineId];
-      if (i._kind === 'frame')         return true;
+      if (timeToMinutes(i.startTime) <= nowMin) return false; // skip in-progress
+      if (i._kind === 'routine')        return !routineCompletions[i._routineId];
+      if (i._kind === 'frame')          return true;
       if (i._kind === 'calendar-event') return true;
       return !i.completed;
     });
-  }, [futureItems, routineCompletions]);
+  }, [futureItems, routineCompletions, nowMin, timeToMinutes]);
 
   // Inbox tasks
   const inboxTasks = useMemo(() =>
@@ -798,7 +808,7 @@ const MobileListView = () => {
       )}
 
       {/* ── Spine spacer (padding above "now") ── */}
-      {isToday && (
+      {isToday && !inProgressItem && (
         <div style={{ display: 'flex', height: 16 }}>
           <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
           <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
@@ -808,8 +818,8 @@ const MobileListView = () => {
         </div>
       )}
 
-      {/* ── Now row ── */}
-      {isToday && (
+      {/* ── Now row — hidden when something is currently in progress ── */}
+      {isToday && !inProgressItem && (
         <div ref={nowRowRef}>
           <NowRow
             nowMin={nowMin}
@@ -823,7 +833,7 @@ const MobileListView = () => {
       )}
 
       {/* ── Spine spacer (padding below "now") ── */}
-      {isToday && visibleItems.length > 0 && (
+      {isToday && !inProgressItem && visibleItems.length > 0 && (
         <div style={{ display: 'flex', height: 12 }}>
           <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
           <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -117,7 +117,7 @@ function SpineMarker({ kind, completed, colour }) {
 
 // ─── Connector (horizontal line from spine to card) ───────────────────────────
 
-function Connector({ colour, cardHeight }) {
+function Connector({ colour }) {
   return (
     <div
       style={{
@@ -125,7 +125,8 @@ function Connector({ colour, cardHeight }) {
         right: '100%',
         width: CONNECTOR_W,
         height: 2,
-        top: Math.round(cardHeight / 2) - 1,
+        top: '50%',
+        marginTop: -1,
         background: colour,
         pointerEvents: 'none',
       }}
@@ -360,7 +361,7 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
 
       {/* Col 3 — content */}
       <div style={{ flex: 1, minWidth: 0, position: 'relative', paddingTop: 4, paddingBottom: 4, paddingRight: 8 }}>
-        {accentHex && <Connector colour={accentHex} cardHeight={cardHeight} />}
+        {accentHex && <Connector colour={accentHex} />}
         {children}
       </div>
     </div>
@@ -443,8 +444,10 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
   })();
 
   const diff = nextItem ? timeToMinutes_pure(nextItem.startTime) - nowMin : null;
+  const rawTitle = nextItem?.title || nextItem?.name || nextItem?.label || '';
+  const cleanTitle = rawTitle.replace(/#\S+/g, '').replace(/\s+/g, ' ').trim();
   const countdownStr = diff !== null && diff > 0
-    ? `${countdownText(diff)} until ${nextItem.title || nextItem.name || nextItem.label}`
+    ? `${countdownText(diff)} until ${cleanTitle}`
     : 'Nothing planned';
 
   return (

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -333,10 +333,10 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
 
       {/* Col 2 — spine */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-        {/* Full-height line; marker (zIndex 2, opaque bg) sits on top of it */}
+        {/* -1/+1 overreach ensures flush join with adjacent rows — no pixel gaps */}
         <div
           style={{
-            position: 'absolute', top: 0, bottom: 0,
+            position: 'absolute', top: -1, bottom: -1,
             left: '50%', transform: 'translateX(-50%)',
             width: 2, zIndex: 0,
             background: spineStyle === 'dashed'
@@ -347,8 +347,9 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
         {marker}
       </div>
 
-      {/* Col 3 — content */}
-      <div style={{ flex: 1, minWidth: 0, position: 'relative', paddingTop: 4, paddingBottom: 4, paddingRight: 8 }}>
+      {/* Col 3 — no padding; card provides its own internal padding so top:50% on
+          the connector always matches the spine marker's vertical centre */}
+      <div style={{ flex: 1, minWidth: 0, position: 'relative', paddingRight: 8 }}>
         {accentHex && <Connector colour={accentHex} />}
         {children}
       </div>
@@ -379,7 +380,7 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
       </div>
       {/* Spine col */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: dashedGradient(spineColour + '88') }} />
+        <div style={{ position: 'absolute', top: -1, bottom: -1, left: '50%', transform: 'translateX(-50%)', width: 2, background: dashedGradient(spineColour + '88') }} />
         {/* Drag preview indicator on spine */}
         {isTarget && (
           <div
@@ -446,7 +447,7 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
       </div>
       {/* Spine col */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, zIndex: 0, background: '#ef444440' }} />
+        <div style={{ position: 'absolute', top: -1, bottom: -1, left: '50%', transform: 'translateX(-50%)', width: 2, zIndex: 0, background: '#ef444440' }} />
         {/* Red clock marker */}
         <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2, position: 'relative' }}>
           <Clock size={9} color="#fff" />
@@ -805,7 +806,7 @@ const MobileListView = () => {
         <div style={{ display: 'flex', height: 16 }}>
           <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
           <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
-            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
+            <div style={{ position: 'absolute', top: -1, bottom: -1, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
           </div>
           <div style={{ flex: 1 }} />
         </div>
@@ -830,7 +831,7 @@ const MobileListView = () => {
         <div style={{ display: 'flex', height: 12 }}>
           <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
           <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
-            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
+            <div style={{ position: 'absolute', top: -1, bottom: -1, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
           </div>
           <div style={{ flex: 1 }} />
         </div>
@@ -881,12 +882,14 @@ const MobileListView = () => {
                 cardHeight={ROUTINE_H}
                 accentHex="#14b8a6"
               >
-                <RoutineChip
-                  routine={item}
-                  completed={completed}
-                  onToggle={toggleRoutineCompletion}
-                  darkMode={darkMode}
-                />
+                <div style={{ marginTop: 4, marginBottom: 4 }}>
+                  <RoutineChip
+                    routine={item}
+                    completed={completed}
+                    onToggle={toggleRoutineCompletion}
+                    darkMode={darkMode}
+                  />
+                </div>
               </Row>
             );
           }
@@ -902,14 +905,16 @@ const MobileListView = () => {
                 cardHeight={FRAME_H}
                 accentHex={accentHex}
               >
-                <FrameCard
-                  frame={item}
-                  darkMode={darkMode}
-                  textPrimary={textPrimary}
-                  textSecondary={textSecondary}
-                  openFrameAdjust={openFrameAdjust}
-                  dateStr={dateStr}
-                />
+                <div style={{ marginTop: 4, marginBottom: 4 }}>
+                  <FrameCard
+                    frame={item}
+                    darkMode={darkMode}
+                    textPrimary={textPrimary}
+                    textSecondary={textSecondary}
+                    openFrameAdjust={openFrameAdjust}
+                    dateStr={dateStr}
+                  />
+                </div>
               </Row>
             );
           }
@@ -934,7 +939,7 @@ const MobileListView = () => {
               cardHeight={TASK_H}
               accentHex={accentHex}
             >
-              <div style={{ opacity: isPast ? 0.5 : 1 }}>
+              <div style={{ opacity: isPast ? 0.5 : 1, marginTop: 4, marginBottom: 4 }}>
                 <TaskCard
                   item={item}
                   accentHex={accentHex}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -1,0 +1,1056 @@
+import React, {
+  useState, useRef, useEffect, useLayoutEffect,
+  useMemo, useCallback,
+} from 'react';
+import {
+  Check, ChevronDown, ChevronUp, Clock, Edit2, ExternalLink,
+  FileText, Inbox, SkipForward,
+} from 'lucide-react';
+import * as LucideIcons from 'lucide-react';
+import { renderTitle, isLinkOnlyTask, getLinkUrl, hasNotesOrSubtasks } from '../utils/textFormatting.jsx';
+import { dateToString } from '../utils/taskUtils.js';
+import { taskColorToHex, frameColorBg, frameColorBorder } from '../utils/colorUtils.js';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SPINE_COL_W = 32;   // w-8
+const TIME_COL_W  = 56;   // w-14
+const CONNECTOR_W = 16;   // half of spine col — reaches spine centre
+const TASK_H      = 72;
+const ROUTINE_H   = 38;
+const FRAME_H     = 68;
+const ALLDAY_H    = 44;
+
+// ─── Spine colour gradient (orange→green→blue, 6 am→noon→6 pm) ───────────────
+
+function lerpColour(a, b, t) {
+  return [0, 1, 2].map(i => Math.round(a[i] + (b[i] - a[i]) * t));
+}
+const C_ORANGE = [254, 139,   0];
+const C_GREEN  = [ 34, 197,  94];
+const C_BLUE   = [ 59, 130, 246];
+
+function spineColorAt(timeMin) {
+  let rgb;
+  if      (timeMin <= 360)  rgb = C_ORANGE;
+  else if (timeMin <= 720)  rgb = lerpColour(C_ORANGE, C_GREEN,  (timeMin - 360) / 360);
+  else if (timeMin <= 1080) rgb = lerpColour(C_GREEN,  C_BLUE,   (timeMin - 720) / 360);
+  else                      rgb = C_BLUE;
+  return `rgb(${rgb[0]},${rgb[1]},${rgb[2]})`;
+}
+
+function dashedGradient(colour) {
+  return `repeating-linear-gradient(to bottom,${colour} 0px,${colour} 4px,transparent 4px,transparent 9px)`;
+}
+
+// ─── Gap height (px) based on free-time duration ─────────────────────────────
+
+function gapHeight(gapMin) {
+  if (gapMin <  15) return 12;
+  if (gapMin <  30) return 20;
+  if (gapMin <  60) return 32;
+  if (gapMin < 120) return 48;
+  if (gapMin < 240) return 64;
+  return 80;
+}
+
+// ─── Duration label ───────────────────────────────────────────────────────────
+
+function durLabel(min) {
+  if (!min) return '';
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h)      return `${h}h`;
+  return `${m}m`;
+}
+
+// ─── Format countdown text ────────────────────────────────────────────────────
+
+function countdownText(diffMin) {
+  const h = Math.floor(diffMin / 60);
+  const m = diffMin % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h)      return `${h}h`;
+  return `${m}m`;
+}
+
+// ─── SpineMarker ─────────────────────────────────────────────────────────────
+
+function SpineMarker({ kind, completed, colour }) {
+  const base = {
+    width: 16, height: 16, flexShrink: 0, position: 'relative', zIndex: 2,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+  };
+
+  if (kind === 'routine') {
+    return (
+      <div style={{ ...base, borderRadius: '50%', background: colour, opacity: completed ? 0.5 : 1 }} />
+    );
+  }
+  if (kind === 'frame') {
+    return (
+      <div style={{ ...base, borderRadius: '50%', border: `2px solid ${colour}`, background: 'transparent' }} />
+    );
+  }
+  if (kind === 'calendar-event') {
+    return (
+      <div style={{ ...base, borderRadius: 2, background: colour }} />
+    );
+  }
+  // task / calendar-task
+  return (
+    <div
+      style={{
+        ...base,
+        borderRadius: 4,
+        border: `2px solid ${colour}`,
+        background: completed ? colour : 'transparent',
+      }}
+    >
+      {completed && <Check size={9} strokeWidth={3} color="#fff" />}
+    </div>
+  );
+}
+
+// ─── Connector (horizontal line from spine to card) ───────────────────────────
+
+function Connector({ colour, cardHeight }) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        right: '100%',
+        width: CONNECTOR_W,
+        height: 2,
+        top: Math.round(cardHeight / 2) - 1,
+        background: colour,
+        pointerEvents: 'none',
+      }}
+    />
+  );
+}
+
+// ─── TaskCard ─────────────────────────────────────────────────────────────────
+
+const TaskCard = React.memo(({
+  item, accentHex, isCalendarEvent, darkMode, textPrimary, textSecondary,
+  formatTime, minutesToTime, timeToMinutes,
+  toggleComplete, setExpandedNotesTaskId, postponeTask, moveToInbox, openMobileEditTask,
+  dateStr,
+}) => {
+  const endMin = timeToMinutes(item.startTime) + (item.duration || 30);
+  const timeStr = `${formatTime(item.startTime)}–${formatTime(minutesToTime(endMin))} · ${durLabel(item.duration)}`;
+
+  const cardBg   = `${accentHex}30`;
+  const barStyle = { width: 4, flexShrink: 0, background: accentHex, borderRadius: '6px 0 0 6px' };
+  const cardStyle = {
+    display: 'flex', borderRadius: 6, overflow: 'hidden',
+    border: `1px solid ${accentHex}44`,
+    background: cardBg,
+    minHeight: TASK_H,
+  };
+
+  const noteIcon = isLinkOnlyTask(item) ? ExternalLink : FileText;
+  const NoteIcon = noteIcon;
+  const hasNotes = hasNotesOrSubtasks(item) || isLinkOnlyTask(item);
+
+  return (
+    <div style={cardStyle}>
+      {/* Left colour bar */}
+      <div style={barStyle} />
+      {/* Content */}
+      <div style={{ flex: 1, minWidth: 0, padding: '6px 6px 6px 8px', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+        {/* Top row: completion + title + action grid */}
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6 }}>
+          {/* Completion circle (tasks only, not pure calendar events) */}
+          {!isCalendarEvent && (
+            <button
+              onClick={e => { e.stopPropagation(); toggleComplete(item.id); }}
+              style={{
+                flexShrink: 0, marginTop: 2,
+                width: 16, height: 16, borderRadius: '50%',
+                border: `2px solid ${accentHex}`,
+                background: item.completed ? accentHex : 'transparent',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+              }}
+            >
+              {item.completed && <Check size={8} strokeWidth={3} color="#fff" />}
+            </button>
+          )}
+          {/* Title */}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
+              className={`text-sm font-medium leading-snug ${textPrimary} ${item.completed ? 'line-through opacity-50' : ''}`}
+              style={{ overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}
+            >
+              {renderTitle(item.title)}
+            </div>
+          </div>
+          {/* 2×2 action grid (tasks only) */}
+          {!isCalendarEvent && (
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2, flexShrink: 0 }}>
+              {/* Notes */}
+              <button
+                onClick={e => {
+                  e.stopPropagation();
+                  if (isLinkOnlyTask(item)) window.open(getLinkUrl(item), '_blank', 'noopener,noreferrer');
+                  else setExpandedNotesTaskId(prev => prev === item.id ? null : item.id);
+                }}
+                className={`flex items-center justify-center rounded p-1 transition-colors ${darkMode ? 'hover:bg-white/10 active:bg-white/20' : 'hover:bg-black/10 active:bg-black/15'}`}
+                style={{ opacity: hasNotes ? 0.85 : 0.35 }}
+                title="Notes / links"
+              >
+                <NoteIcon size={12} style={{ color: accentHex }} />
+              </button>
+              {/* Postpone */}
+              <button
+                onClick={e => { e.stopPropagation(); postponeTask(item.id); }}
+                className={`flex items-center justify-center rounded p-1 transition-colors ${darkMode ? 'hover:bg-white/10 active:bg-white/20' : 'hover:bg-black/10 active:bg-black/15'}`}
+                style={{ opacity: 0.7 }}
+                title="Postpone"
+              >
+                <SkipForward size={12} style={{ color: accentHex }} />
+              </button>
+              {/* Move to inbox */}
+              <button
+                onClick={e => { e.stopPropagation(); moveToInbox(item.id, dateStr); }}
+                className={`flex items-center justify-center rounded p-1 transition-colors ${darkMode ? 'hover:bg-white/10 active:bg-white/20' : 'hover:bg-black/10 active:bg-black/15'}`}
+                style={{ opacity: 0.7 }}
+                title="Move to inbox"
+              >
+                <Inbox size={12} style={{ color: accentHex }} />
+              </button>
+              {/* Edit */}
+              <button
+                onClick={e => { e.stopPropagation(); openMobileEditTask(item, false); }}
+                className={`flex items-center justify-center rounded p-1 transition-colors ${darkMode ? 'hover:bg-white/10 active:bg-white/20' : 'hover:bg-black/10 active:bg-black/15'}`}
+                style={{ opacity: 0.7 }}
+                title="Edit"
+              >
+                <Edit2 size={12} style={{ color: accentHex }} />
+              </button>
+            </div>
+          )}
+        </div>
+        {/* Time meta */}
+        <div className={`text-[10px] leading-none ${textSecondary}`} style={{ marginTop: 4 }}>
+          {timeStr}
+        </div>
+      </div>
+    </div>
+  );
+});
+TaskCard.displayName = 'TaskCard';
+
+// ─── RoutineChip ──────────────────────────────────────────────────────────────
+
+function RoutineChip({ routine, completed, onToggle, darkMode }) {
+  return (
+    <button
+      onClick={e => { e.stopPropagation(); onToggle(routine.id); }}
+      className={`flex items-center gap-1.5 px-3 rounded-full text-xs font-medium transition-colors
+        ${darkMode ? 'bg-teal-700 text-teal-100 active:bg-teal-600' : 'bg-teal-600 text-white active:bg-teal-700'}
+        ${completed ? 'opacity-50 line-through' : ''}`}
+      style={{ height: ROUTINE_H, maxWidth: '100%' }}
+    >
+      <span className="truncate">{routine.name}</span>
+      {routine.duration ? (
+        <span className="opacity-60 flex-shrink-0 text-[10px]">{durLabel(routine.duration)}</span>
+      ) : null}
+    </button>
+  );
+}
+
+// ─── FrameCard (hyperGLANCE session) ─────────────────────────────────────────
+
+function FrameCard({ frame, darkMode, textPrimary, textSecondary, openFrameAdjust, dateStr }) {
+  const bg     = frameColorBg(frame.color, darkMode);
+  const border = frameColorBorder(frame.color, darkMode);
+  const ProjIcon = frame.icon ? LucideIcons[frame.icon] : null;
+
+  const cardStyle = {
+    display: 'flex', borderRadius: 6, overflow: 'hidden',
+    border: `1px solid ${border}`,
+    background: bg,
+    minHeight: FRAME_H,
+  };
+  const barStyle = { width: 4, flexShrink: 0, background: border, borderRadius: '6px 0 0 6px' };
+
+  return (
+    <div style={cardStyle}>
+      <div style={barStyle} />
+      <div style={{ flex: 1, minWidth: 0, padding: '8px 8px 8px 10px', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className={`text-sm font-semibold leading-snug ${textPrimary} flex items-center gap-1.5`}>
+              {ProjIcon && <ProjIcon size={13} style={{ color: border, flexShrink: 0 }} />}
+              <span className="truncate">{frame.label}</span>
+            </div>
+          </div>
+          {/* Edit pencil */}
+          <button
+            onClick={e => { e.stopPropagation(); openFrameAdjust(frame.frameId, dateStr); }}
+            className={`flex items-center justify-center rounded p-1 flex-shrink-0 transition-colors ${darkMode ? 'hover:bg-white/10' : 'hover:bg-black/10'}`}
+            title="Adjust session"
+          >
+            <Edit2 size={13} style={{ color: border, opacity: 0.8 }} />
+          </button>
+        </div>
+        <div className={`text-[10px] leading-none ${textSecondary}`}>
+          {frame.start}–{frame.end}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Row wrapper (3 columns) ──────────────────────────────────────────────────
+
+function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeight, accentHex, children, isNow }) {
+  return (
+    <div style={{ display: 'flex', minHeight: cardHeight }}>
+      {/* Col 1 — time */}
+      <div
+        style={{
+          width: TIME_COL_W, flexShrink: 0,
+          display: 'flex', flexDirection: 'column', justifyContent: 'center',
+          paddingRight: 8, textAlign: 'right',
+        }}
+      >
+        {timeLabel && (
+          <span
+            className="text-[10px] font-semibold leading-none"
+            style={{ color: timeColour || spineColour }}
+          >
+            {timeLabel}
+          </span>
+        )}
+        {isNow && <Clock size={11} style={{ color: timeColour, marginLeft: 'auto', marginTop: 2 }} />}
+      </div>
+
+      {/* Col 2 — spine */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+        {/* Spine line segment */}
+        <div
+          style={{
+            position: 'absolute', top: 0, bottom: 0,
+            left: '50%', transform: 'translateX(-50%)',
+            width: 2,
+            ...(spineStyle === 'dashed'
+              ? { background: dashedGradient(spineColour + '88') }
+              : { background: spineColour }),
+          }}
+        />
+        {/* Marker */}
+        {marker}
+      </div>
+
+      {/* Col 3 — content */}
+      <div style={{ flex: 1, minWidth: 0, position: 'relative', paddingTop: 4, paddingBottom: 4, paddingRight: 8 }}>
+        {accentHex && <Connector colour={accentHex} cardHeight={cardHeight} />}
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─── GapRow ───────────────────────────────────────────────────────────────────
+
+function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minutesToTime, dragTargetMin, dragBlocked, darkMode }) {
+  const h = gapHeight(toMin - fromMin);
+  const showLabel = (toMin - fromMin) >= 45;
+  const isTarget = dragTargetMin !== null && dragTargetMin >= fromMin && dragTargetMin < toMin;
+
+  return (
+    <div
+      data-gap-from={fromMin}
+      data-gap-to={toMin}
+      style={{ display: 'flex', height: h }}
+    >
+      {/* Time col */}
+      <div style={{ width: TIME_COL_W, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'flex-end', paddingRight: 8 }}>
+        {showLabel && (
+          <span className={`text-[9px] leading-none ${textSecondary}`} style={{ opacity: 0.5 }}>
+            {formatTime(minutesToTime(fromMin))}
+          </span>
+        )}
+      </div>
+      {/* Spine col */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: dashedGradient(spineColour + '88') }} />
+        {/* Drag preview indicator on spine */}
+        {isTarget && (
+          <div
+            style={{
+              position: 'absolute', top: '50%', transform: 'translateY(-50%)',
+              left: '50%', marginLeft: -8,
+              width: 16, height: 16, borderRadius: '50%',
+              background: dragBlocked ? '#ef4444' : '#22c55e',
+              border: '2px solid white',
+              zIndex: 3,
+            }}
+          />
+        )}
+      </div>
+      {/* Content col */}
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', paddingLeft: 4 }}>
+        {isTarget ? (
+          <span
+            className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
+            style={{
+              background: dragBlocked ? (darkMode ? '#7f1d1d' : '#fee2e2') : (darkMode ? '#14532d' : '#dcfce7'),
+              color: dragBlocked ? (darkMode ? '#fca5a5' : '#991b1b') : (darkMode ? '#86efac' : '#166534'),
+            }}
+          >
+            {dragBlocked ? 'Blocked' : formatTime(minutesToTime(dragTargetMin))}
+          </span>
+        ) : (
+          showLabel && (toMin - fromMin) >= 60 && (
+            <span className={`text-[10px] ${textSecondary}`} style={{ opacity: 0.35 }}>
+              {durLabel(toMin - fromMin)} free
+            </span>
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── NowRow ───────────────────────────────────────────────────────────────────
+
+function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24HourClock }) {
+  const nowLabel = (() => {
+    const h = Math.floor(nowMin / 60);
+    const m = nowMin % 60;
+    const pad = v => String(v).padStart(2, '0');
+    if (use24HourClock) return `${pad(h)}:${pad(m)}`;
+    const period = h >= 12 ? 'p' : 'a';
+    const h12 = h % 12 || 12;
+    return `${h12}:${pad(m)}${period}`;
+  })();
+
+  const diff = nextItem ? timeToMinutes_pure(nextItem.startTime) - nowMin : null;
+  const countdownStr = diff !== null && diff > 0
+    ? `${countdownText(diff)} until ${nextItem.title || nextItem.name || nextItem.label}`
+    : 'Nothing planned';
+
+  return (
+    <div style={{ display: 'flex', minHeight: 40, alignItems: 'center' }}>
+      {/* Time col */}
+      <div style={{ width: TIME_COL_W, flexShrink: 0, paddingRight: 8, textAlign: 'right', display: 'flex', flexDirection: 'column', alignItems: 'flex-end', justifyContent: 'center', gap: 2 }}>
+        <span className="text-[11px] font-bold" style={{ color: '#ef4444' }}>{nowLabel}</span>
+        <Clock size={11} style={{ color: '#ef4444' }} />
+      </div>
+      {/* Spine col */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: '#ef4444', opacity: 0.4 }} />
+        {/* Red clock marker */}
+        <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2, position: 'relative' }}>
+          <Clock size={9} color="#fff" />
+        </div>
+      </div>
+      {/* Countdown */}
+      <div style={{ flex: 1, minWidth: 0, paddingLeft: 4, paddingRight: 8 }}>
+        <span
+          className="text-xs font-medium"
+          style={{ color: darkMode ? '#fca5a5' : '#991b1b' }}
+        >
+          {countdownStr}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// Pure helper (no hook) so NowRow can call it
+function timeToMinutes_pure(t) {
+  if (!t) return 0;
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + (m || 0);
+}
+
+// ─── AllDayCard ───────────────────────────────────────────────────────────────
+
+function AllDayCard({ item, accentHex, darkMode, textPrimary, toggleComplete }) {
+  return (
+    <div
+      style={{
+        display: 'flex', borderRadius: 6, overflow: 'hidden', minHeight: ALLDAY_H,
+        border: `1px solid ${accentHex}44`, background: `${accentHex}28`,
+      }}
+    >
+      <div style={{ width: 4, flexShrink: 0, background: accentHex, borderRadius: '6px 0 0 6px' }} />
+      <div style={{ flex: 1, minWidth: 0, padding: '6px 8px', display: 'flex', alignItems: 'center', gap: 6 }}>
+        <button
+          onClick={e => { e.stopPropagation(); toggleComplete(item.id); }}
+          style={{
+            flexShrink: 0, width: 16, height: 16, borderRadius: '50%',
+            border: `2px solid ${accentHex}`,
+            background: item.completed ? accentHex : 'transparent',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}
+        >
+          {item.completed && <Check size={8} strokeWidth={3} color="#fff" />}
+        </button>
+        <span className={`text-sm font-medium truncate ${textPrimary} ${item.completed ? 'line-through opacity-50' : ''}`}>
+          {renderTitle(item.title)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ─── MobileListView ───────────────────────────────────────────────────────────
+
+const MobileListView = () => {
+  const {
+    selectedDate, currentTime,
+    tasks, setTasks, unscheduledTasks, setUnscheduledTasks,
+    expandedRecurringTasks,
+    calendarRef, use24HourClock,
+    darkMode, cardBg, borderClass, textPrimary, textSecondary,
+    formatTime, timeToMinutes, minutesToTime,
+    getTasksForDate, getTaskCalendarStyle,
+    toggleComplete, postponeTask, moveToInbox, openMobileEditTask,
+    setExpandedNotesTaskId,
+    pushUndo, playUISound,
+  } = useDayPlannerCtx();
+
+  const {
+    routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion,
+    getFrameInstancesForDate, openFrameAdjust,
+  } = useFeaturesCtx();
+
+  // ── State ──────────────────────────────────────────────────────────────────
+  const [showPast, setShowPast]       = useState(false);
+  const [inboxOpen, setInboxOpen]     = useState(false);
+  const [inboxPinned, setInboxPinned] = useState(false);
+  const [dragTargetMin, setDragTargetMin] = useState(null);
+  const [dragBlocked, setDragBlocked] = useState(false);
+  const [activeDragTask, setActiveDragTask] = useState(null);
+  const [inboxHandleTop, setInboxHandleTop] = useState(160);
+
+  const nowRowRef  = useRef(null);
+  const dragRef    = useRef({ active: false, task: null, startX: 0, startY: 0 });
+
+  // ── Derived ────────────────────────────────────────────────────────────────
+  const dateStr = dateToString(selectedDate);
+  const isToday = dateStr === dateToString(new Date());
+  const nowMin  = currentTime.getHours() * 60 + currentTime.getMinutes();
+
+  const allDayItems = useMemo(() =>
+    getTasksForDate(selectedDate).filter(t => t.isAllDay && !t.isExample),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedDate, tasks, expandedRecurringTasks],
+  );
+
+  const scheduledTasks = useMemo(() =>
+    getTasksForDate(selectedDate).filter(t => !t.isAllDay && !t.isExample),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedDate, tasks, expandedRecurringTasks],
+  );
+
+  const scheduledRoutines = useMemo(() =>
+    routinesEnabled && isToday
+      ? todayRoutines.filter(r => r.startTime && !r.isAllDay && !String(r.id).startsWith('example-'))
+      : [],
+    [routinesEnabled, isToday, todayRoutines],
+  );
+
+  const frameInstances = useMemo(() => {
+    try { return getFrameInstancesForDate(selectedDate) || []; }
+    catch { return []; }
+  }, [getFrameInstancesForDate, selectedDate]);
+
+  // Combine and sort all scheduled items
+  const allItems = useMemo(() => {
+    const items = [
+      ...scheduledTasks.map(t => ({ ...t, _kind: t.imported && !t.isTaskCalendar ? 'calendar-event' : 'task' })),
+      ...scheduledRoutines.map(r => ({ ...r, _kind: 'routine', _routineId: r.id, id: `routine-${r.id}`, title: r.name, startTime: r.startTime })),
+      ...frameInstances.map(f => ({ ...f, _kind: 'frame', id: `frame-${f.frameId}`, startTime: f.start })),
+    ];
+    return items.sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime));
+  }, [scheduledTasks, scheduledRoutines, frameInstances, timeToMinutes]);
+
+  const isItemPast = useCallback((item) => {
+    if (!isToday) return false;
+    const endMin = timeToMinutes(item.startTime) + (item.duration || 30);
+    return endMin <= nowMin;
+  }, [isToday, nowMin, timeToMinutes]);
+
+  const pastItems   = useMemo(() => allItems.filter(isItemPast),   [allItems, isItemPast]);
+  const futureItems = useMemo(() => allItems.filter(i => !isItemPast(i)), [allItems, isItemPast]);
+  const visibleItems = showPast ? allItems : futureItems;
+
+  // Next non-completed item after now
+  const nextItem = useMemo(() => {
+    return futureItems.find(i => {
+      if (i._kind === 'routine')       return !routineCompletions[i._routineId];
+      if (i._kind === 'frame')         return true;
+      if (i._kind === 'calendar-event') return true;
+      return !i.completed;
+    });
+  }, [futureItems, routineCompletions]);
+
+  // Inbox tasks
+  const inboxTasks = useMemo(() =>
+    unscheduledTasks.filter(t => !t.isExample && !t.completed),
+    [unscheduledTasks],
+  );
+
+  // ── Conflict helpers ───────────────────────────────────────────────────────
+  const isBlockedByRoutine = useCallback((startMin, durMin) => {
+    const endMin = startMin + durMin;
+    return scheduledRoutines.some(r => {
+      const s = timeToMinutes(r.startTime);
+      const e = s + (r.duration || 30);
+      return startMin < e && endMin > s;
+    });
+  }, [scheduledRoutines, timeToMinutes]);
+
+  const getSnapMin = useCallback((rawMin, durMin) => {
+    const base = Math.round(rawMin / 15) * 15;
+    for (let d = 0; d <= 24 * 60; d += 15) {
+      const fwd = base + d;
+      if (fwd >= 0 && fwd + durMin <= 24 * 60 && !isBlockedByRoutine(fwd, durMin)) return fwd;
+      if (d > 0) {
+        const bck = base - d;
+        if (bck >= 0 && !isBlockedByRoutine(bck, durMin)) return bck;
+      }
+    }
+    return base;
+  }, [isBlockedByRoutine]);
+
+  // ── Drag handlers ──────────────────────────────────────────────────────────
+  const handleInboxTouchStart = useCallback((e, task) => {
+    const t = e.touches[0];
+    dragRef.current = { active: false, task, startX: t.clientX, startY: t.clientY };
+  }, []);
+
+  const handleInboxTouchMove = useCallback((e) => {
+    const state = dragRef.current;
+    if (!state.task) return;
+    const t = e.touches[0];
+    const dx = t.clientX - state.startX;
+    const dy = t.clientY - state.startY;
+
+    if (!state.active && Math.sqrt(dx * dx + dy * dy) > 8) {
+      state.active = true;
+      setActiveDragTask(state.task);
+      setInboxPinned(true);
+    }
+    if (!state.active) return;
+    e.preventDefault();
+
+    // Find which gap segment the finger is over
+    const el = document.elementFromPoint(t.clientX, t.clientY);
+    const gapEl = el?.closest('[data-gap-from]');
+    if (gapEl) {
+      const rect = gapEl.getBoundingClientRect();
+      const fromMin = parseInt(gapEl.dataset.gapFrom, 10);
+      const toMin   = parseInt(gapEl.dataset.gapTo, 10);
+      const frac    = Math.max(0, Math.min(1, (t.clientY - rect.top) / rect.height));
+      const rawMin  = fromMin + frac * (toMin - fromMin);
+      const durMin  = state.task.duration || 30;
+      const snapped = getSnapMin(rawMin, durMin);
+      setDragTargetMin(snapped);
+      setDragBlocked(isBlockedByRoutine(snapped, durMin));
+    } else {
+      setDragTargetMin(null);
+      setDragBlocked(false);
+    }
+  }, [getSnapMin, isBlockedByRoutine]);
+
+  const handleInboxTouchEnd = useCallback(() => {
+    const state = dragRef.current;
+    if (state.active && dragTargetMin !== null && !dragBlocked) {
+      pushUndo();
+      setTasks(prev => [...prev, {
+        ...state.task,
+        date: dateStr,
+        startTime: minutesToTime(dragTargetMin),
+        duration: state.task.duration || 30,
+        color: state.task.color || 'bg-blue-500',
+        isAllDay: false,
+      }]);
+      setUnscheduledTasks(prev => prev.filter(t => t.id !== state.task.id));
+      playUISound('pop');
+    }
+    dragRef.current = { active: false, task: null };
+    setActiveDragTask(null);
+    setInboxPinned(false);
+    setDragTargetMin(null);
+    setDragBlocked(false);
+    if (!inboxOpen) setInboxOpen(false);
+  }, [dragTargetMin, dragBlocked, minutesToTime, dateStr, pushUndo,
+      setTasks, setUnscheduledTasks, playUISound, inboxOpen]);
+
+  // ── Scroll to "now" on mount / date change ─────────────────────────────────
+  useEffect(() => {
+    if (!isToday || !nowRowRef.current || !calendarRef?.current) return;
+    const timer = setTimeout(() => {
+      const container = calendarRef.current;
+      const nowEl     = nowRowRef.current;
+      if (!container || !nowEl) return;
+      const cRect  = container.getBoundingClientRect();
+      const nRect  = nowEl.getBoundingClientRect();
+      const target = container.scrollTop + (nRect.top - cRect.top) - 32;
+      container.scrollTo({ top: Math.max(0, target), behavior: 'auto' });
+    }, 60);
+    return () => clearTimeout(timer);
+  }, [dateStr, isToday, calendarRef]);
+
+  // ── Position inbox handle below sticky header ──────────────────────────────
+  useLayoutEffect(() => {
+    if (!calendarRef?.current) return;
+    const rect = calendarRef.current.getBoundingClientRect();
+    setInboxHandleTop(rect.top + 24);
+  }, [calendarRef]);
+
+  // ── Segment builder ────────────────────────────────────────────────────────
+  const segments = useMemo(() => {
+    const segs = [];
+    const items = visibleItems;
+    if (items.length === 0) return segs;
+
+    // Start time of first item (or nowMin for today)
+    let cursor = isToday ? Math.min(nowMin, timeToMinutes(items[0]?.startTime ?? '00:00')) : timeToMinutes(items[0]?.startTime ?? '00:00');
+
+    items.forEach((item, idx) => {
+      const startMin = timeToMinutes(item.startTime);
+      const durMin   = item.duration || 30;
+      const endMin   = startMin + durMin;
+
+      // Gap before this item
+      const gapMin = startMin - cursor;
+      if (gapMin >= 5) {
+        segs.push({ type: 'gap', id: `gap-${idx}`, fromMin: cursor, toMin: startMin });
+      }
+
+      segs.push({ type: 'item', id: item.id, item, startMin, endMin });
+      cursor = Math.max(cursor, endMin);
+    });
+
+    // Trailing gap so last item isn't at very bottom
+    segs.push({ type: 'gap', id: 'gap-trail', fromMin: cursor, toMin: cursor + 30 });
+    return segs;
+  }, [visibleItems, isToday, nowMin, timeToMinutes]);
+
+  // ── Render helpers ─────────────────────────────────────────────────────────
+  const getAccentHex = (item) => {
+    if (item._kind === 'calendar-event') {
+      const s = getTaskCalendarStyle(item, darkMode);
+      return s?.backgroundColor || '#6b7280';
+    }
+    if (item._kind === 'routine') return darkMode ? '#14b8a6' : '#0d9488';
+    if (item._kind === 'frame')   return frameColorBorder(item.color, darkMode);
+    return taskColorToHex(item.color) || '#3b82f6';
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return (
+    <>
+      {/* ── All-day section ── */}
+      {allDayItems.length > 0 && (
+        <div className={`border-b ${borderClass} px-2 py-2 flex flex-col gap-1.5`}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
+            <div style={{ width: TIME_COL_W, flexShrink: 0, textAlign: 'right', paddingRight: 8 }}>
+              <span className={`text-[9px] font-bold uppercase tracking-widest ${textSecondary}`}>All day</span>
+            </div>
+            <div style={{ flex: 1 }} />
+          </div>
+          {allDayItems.map(item => {
+            const hex = taskColorToHex(item.color) || '#3b82f6';
+            return (
+              <div key={item.id} style={{ display: 'flex' }}>
+                <div style={{ width: TIME_COL_W + SPINE_COL_W, flexShrink: 0 }} />
+                <div style={{ flex: 1, minWidth: 0, paddingRight: 8 }}>
+                  <AllDayCard item={item} accentHex={hex} darkMode={darkMode} textPrimary={textPrimary} toggleComplete={toggleComplete} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* ── Expand-past row ── */}
+      {isToday && pastItems.length > 0 && (
+        <button
+          onClick={() => setShowPast(v => !v)}
+          className={`w-full flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium ${textSecondary} border-b ${borderClass} ${darkMode ? 'hover:bg-white/5 active:bg-white/10' : 'hover:bg-black/5 active:bg-black/8'} transition-colors`}
+        >
+          {showPast ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+          {showPast ? 'Hide earlier items' : `↑ ${pastItems.length} earlier item${pastItems.length !== 1 ? 's' : ''}`}
+        </button>
+      )}
+
+      {/* ── Spine spacer (padding above "now") ── */}
+      {isToday && (
+        <div style={{ display: 'flex', height: 16 }}>
+          <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
+          <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
+          </div>
+          <div style={{ flex: 1 }} />
+        </div>
+      )}
+
+      {/* ── Now row ── */}
+      {isToday && (
+        <div ref={nowRowRef}>
+          <NowRow
+            nowMin={nowMin}
+            nextItem={nextItem}
+            formatTime={formatTime}
+            textSecondary={textSecondary}
+            darkMode={darkMode}
+            use24HourClock={use24HourClock}
+          />
+        </div>
+      )}
+
+      {/* ── Spine spacer (padding below "now") ── */}
+      {isToday && visibleItems.length > 0 && (
+        <div style={{ display: 'flex', height: 12 }}>
+          <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
+          <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
+          </div>
+          <div style={{ flex: 1 }} />
+        </div>
+      )}
+
+      {/* ── Empty state ── */}
+      {visibleItems.length === 0 && (
+        <div className={`flex flex-col items-center justify-center py-16 ${textSecondary}`}>
+          <p className="text-sm">No items scheduled</p>
+          {isToday && <p className="text-xs mt-1 opacity-60">Tap + to add a task</p>}
+        </div>
+      )}
+
+      {/* ── Segment list ── */}
+      {segments.map(seg => {
+        if (seg.type === 'gap') {
+          const midMin = Math.round((seg.fromMin + seg.toMin) / 2);
+          return (
+            <GapRow
+              key={seg.id}
+              fromMin={seg.fromMin}
+              toMin={seg.toMin}
+              spineColour={spineColorAt(midMin)}
+              textSecondary={textSecondary}
+              formatTime={formatTime}
+              minutesToTime={minutesToTime}
+              dragTargetMin={dragTargetMin}
+              dragBlocked={dragBlocked}
+              darkMode={darkMode}
+            />
+          );
+        }
+
+        if (seg.type === 'item') {
+          const { item, startMin } = seg;
+          const accentHex = getAccentHex(item);
+          const sc = spineColorAt(startMin);
+
+          if (item._kind === 'routine') {
+            const completed = !!routineCompletions[item._routineId];
+            return (
+              <Row
+                key={seg.id}
+                timeLabel={formatTime(item.startTime)}
+                spineColour={sc}
+                spineStyle="solid"
+                marker={<SpineMarker kind="routine" colour="#14b8a6" completed={completed} />}
+                cardHeight={ROUTINE_H}
+                accentHex="#14b8a6"
+              >
+                <RoutineChip
+                  routine={item}
+                  completed={completed}
+                  onToggle={toggleRoutineCompletion}
+                  darkMode={darkMode}
+                />
+              </Row>
+            );
+          }
+
+          if (item._kind === 'frame') {
+            return (
+              <Row
+                key={seg.id}
+                timeLabel={formatTime(item.startTime)}
+                spineColour={sc}
+                spineStyle="solid"
+                marker={<SpineMarker kind="frame" colour={accentHex} />}
+                cardHeight={FRAME_H}
+                accentHex={accentHex}
+              >
+                <FrameCard
+                  frame={item}
+                  darkMode={darkMode}
+                  textPrimary={textPrimary}
+                  textSecondary={textSecondary}
+                  openFrameAdjust={openFrameAdjust}
+                  dateStr={dateStr}
+                />
+              </Row>
+            );
+          }
+
+          // task or calendar-event
+          const isCalendarEvent = item._kind === 'calendar-event';
+          const isPast = isItemPast(item);
+          return (
+            <Row
+              key={seg.id}
+              timeLabel={formatTime(item.startTime)}
+              spineColour={sc}
+              spineStyle="solid"
+              marker={
+                <SpineMarker
+                  kind={isCalendarEvent ? 'calendar-event' : 'task'}
+                  completed={item.completed}
+                  colour={accentHex}
+                />
+              }
+              cardHeight={TASK_H}
+              accentHex={accentHex}
+            >
+              <div style={{ opacity: isPast ? 0.5 : 1 }}>
+                <TaskCard
+                  item={item}
+                  accentHex={accentHex}
+                  isCalendarEvent={isCalendarEvent}
+                  darkMode={darkMode}
+                  textPrimary={textPrimary}
+                  textSecondary={textSecondary}
+                  formatTime={formatTime}
+                  minutesToTime={minutesToTime}
+                  timeToMinutes={timeToMinutes}
+                  toggleComplete={toggleComplete}
+                  setExpandedNotesTaskId={setExpandedNotesTaskId}
+                  postponeTask={postponeTask}
+                  moveToInbox={moveToInbox}
+                  openMobileEditTask={openMobileEditTask}
+                  dateStr={dateStr}
+                />
+              </div>
+            </Row>
+          );
+        }
+
+        return null;
+      })}
+
+      {/* ── Inbox drawer ── */}
+      {/* Collapsed handle — fixed to viewport */}
+      {!inboxOpen && (
+        <div
+          style={{
+            position: 'fixed',
+            right: 0,
+            top: inboxHandleTop,
+            zIndex: 40,
+          }}
+        >
+          <button
+            onClick={() => setInboxOpen(true)}
+            className={`flex flex-col items-center justify-center gap-1 rounded-l-xl shadow-lg py-3 px-1.5 transition-colors
+              ${darkMode ? 'bg-gray-700 hover:bg-gray-600 active:bg-gray-600' : 'bg-white hover:bg-stone-50 active:bg-stone-100'}
+              border ${borderClass}`}
+            style={{ width: 32 }}
+            title="Open inbox"
+          >
+            <Inbox size={14} className={textSecondary} />
+            <span
+              className="font-semibold"
+              style={{
+                writingMode: 'vertical-rl',
+                textOrientation: 'mixed',
+                fontSize: 9,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+              }}
+            >
+              <span className={textSecondary}>Inbox</span>
+            </span>
+          </button>
+        </div>
+      )}
+
+      {/* Expanded panel — fixed to viewport */}
+      {(inboxOpen || inboxPinned) && (
+        <div
+          style={{
+            position: 'fixed',
+            right: 0,
+            top: inboxHandleTop,
+            bottom: 'calc(3.5rem + env(safe-area-inset-bottom, 0px))',
+            width: 160,
+            zIndex: 40,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+          className={`shadow-xl border-l ${borderClass} rounded-tl-xl overflow-hidden ${darkMode ? 'bg-gray-800' : 'bg-white'}`}
+        >
+          {/* Panel header */}
+          <div className={`flex items-center justify-between px-3 py-2 border-b ${borderClass} flex-shrink-0`}>
+            <div className="flex items-center gap-1.5">
+              <Inbox size={13} className={textSecondary} />
+              <span className={`text-xs font-semibold ${textSecondary}`}>Inbox</span>
+            </div>
+            <button
+              onClick={() => { setInboxOpen(false); setInboxPinned(false); }}
+              className={`p-0.5 rounded transition-colors ${darkMode ? 'hover:bg-white/10' : 'hover:bg-black/10'}`}
+            >
+              <ChevronDown size={14} className={textSecondary} />
+            </button>
+          </div>
+
+          {/* Task list — vertical scroll */}
+          <div className="flex-1 overflow-y-auto py-2 px-2 space-y-1.5">
+            {inboxTasks.length === 0 ? (
+              <p className={`text-[10px] ${textSecondary} text-center py-4`}>Empty</p>
+            ) : (
+              inboxTasks.map(task => {
+                const hex = taskColorToHex(task.color) || '#3b82f6';
+                const isDragging = activeDragTask?.id === task.id;
+                return (
+                  <div
+                    key={task.id}
+                    style={{
+                      borderRadius: 6,
+                      border: `1px solid ${hex}44`,
+                      borderLeft: `3px solid ${hex}`,
+                      background: `${hex}25`,
+                      padding: '6px 8px',
+                      touchAction: 'none',
+                      opacity: isDragging ? 0.3 : 1,
+                      transition: 'opacity 0.12s',
+                      cursor: 'grab',
+                    }}
+                    onTouchStart={e => handleInboxTouchStart(e, task)}
+                    onTouchMove={handleInboxTouchMove}
+                    onTouchEnd={handleInboxTouchEnd}
+                  >
+                    <div className={`text-[11px] font-medium leading-snug ${textPrimary} overflow-hidden`}
+                      style={{ display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
+                      {renderTitle(task.title)}
+                    </div>
+                    <div className={`text-[9px] mt-0.5 ${textSecondary}`}>{durLabel(task.duration)}</div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default MobileListView;

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -339,8 +339,8 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
             position: 'absolute',
             top: '50%', transform: 'translateY(-50%)',
             left: '50%', marginLeft: -1,
-            width: 2, height: 28, zIndex: 1, pointerEvents: 'none',
-            background: `linear-gradient(to bottom, transparent, ${pageBg} 30%, ${pageBg} 70%, transparent)`,
+            width: 2, height: 56, zIndex: 1, pointerEvents: 'none',
+            background: `linear-gradient(to bottom, transparent, ${pageBg} 40%, ${pageBg} 60%, transparent)`,
           }} />
         )}
         {marker}
@@ -450,8 +450,8 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
             position: 'absolute',
             top: '50%', transform: 'translateY(-50%)',
             left: '50%', marginLeft: -1,
-            width: 2, height: 28, zIndex: 1, pointerEvents: 'none',
-            background: `linear-gradient(to bottom, transparent, ${pageBg} 30%, ${pageBg} 70%, transparent)`,
+            width: 2, height: 56, zIndex: 1, pointerEvents: 'none',
+            background: `linear-gradient(to bottom, transparent, ${pageBg} 40%, ${pageBg} 60%, transparent)`,
           }} />
         )}
         {/* Red clock marker */}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -309,7 +309,7 @@ function FrameCard({ frame, darkMode, textPrimary, textSecondary, openFrameAdjus
 
 // ─── Row wrapper (3 columns) ──────────────────────────────────────────────────
 
-function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeight, accentHex, children, isNow }) {
+function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeight, accentHex, children, isNow, pageBg }) {
   return (
     <div style={{ display: 'flex', minHeight: cardHeight }}>
       {/* Col 1 — time */}
@@ -331,8 +331,18 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
         {isNow && <Clock size={11} style={{ color: timeColour, marginLeft: 'auto', marginTop: 2 }} />}
       </div>
 
-      {/* Col 2 — spine (line drawn by container; only marker here) */}
-      <div style={{ width: SPINE_COL_W, flexShrink: 0, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+      {/* Col 2 — spine (background line drawn by container; halo + marker here) */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+        {/* Gradient halo: fades the background spine into the marker */}
+        {pageBg && (
+          <div style={{
+            position: 'absolute',
+            top: '50%', transform: 'translateY(-50%)',
+            left: '50%', marginLeft: -1,
+            width: 2, height: 28, zIndex: 1, pointerEvents: 'none',
+            background: `linear-gradient(to bottom, transparent, ${pageBg} 30%, ${pageBg} 70%, transparent)`,
+          }} />
+        )}
         {marker}
       </div>
 
@@ -409,7 +419,7 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
 
 // ─── NowRow ───────────────────────────────────────────────────────────────────
 
-function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24HourClock }) {
+function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24HourClock, pageBg }) {
   const nowLabel = (() => {
     const h = Math.floor(nowMin / 60);
     const m = nowMin % 60;
@@ -433,8 +443,17 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
       <div style={{ width: TIME_COL_W, flexShrink: 0, paddingRight: 8, textAlign: 'right', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
         <span className="text-[11px] font-bold" style={{ color: '#ef4444' }}>{nowLabel}</span>
       </div>
-      {/* Spine col (line drawn by container) */}
-      <div style={{ width: SPINE_COL_W, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {/* Spine col (line drawn by container; halo + marker here) */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        {pageBg && (
+          <div style={{
+            position: 'absolute',
+            top: '50%', transform: 'translateY(-50%)',
+            left: '50%', marginLeft: -1,
+            width: 2, height: 28, zIndex: 1, pointerEvents: 'none',
+            background: `linear-gradient(to bottom, transparent, ${pageBg} 30%, ${pageBg} 70%, transparent)`,
+          }} />
+        )}
         {/* Red clock marker */}
         <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2, position: 'relative' }}>
           <Clock size={9} color="#fff" />
@@ -830,6 +849,7 @@ const MobileListView = () => {
               textSecondary={textSecondary}
               darkMode={darkMode}
               use24HourClock={use24HourClock}
+              pageBg={pageBg}
             />
           </div>
         )}
@@ -881,6 +901,7 @@ const MobileListView = () => {
                 marker={<SpineMarker kind="routine" colour="#14b8a6" completed={completed} pageBg={pageBg} />}
                 cardHeight={ROUTINE_H}
                 accentHex="#14b8a6"
+                pageBg={pageBg}
               >
                 <div style={{ marginTop: 4, marginBottom: 4 }}>
                   <RoutineChip
@@ -904,6 +925,7 @@ const MobileListView = () => {
                 marker={<SpineMarker kind="frame" colour={accentHex} pageBg={pageBg} />}
                 cardHeight={FRAME_H}
                 accentHex={accentHex}
+                pageBg={pageBg}
               >
                 <div style={{ marginTop: 4, marginBottom: 4 }}>
                   <FrameCard
@@ -938,6 +960,7 @@ const MobileListView = () => {
               }
               cardHeight={TASK_H}
               accentHex={accentHex}
+              pageBg={pageBg}
             >
               <div style={{ opacity: isPast ? 0.5 : 1, marginTop: 4, marginBottom: 4 }}>
                 <TaskCard

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -331,19 +331,8 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
         {isNow && <Clock size={11} style={{ color: timeColour, marginLeft: 'auto', marginTop: 2 }} />}
       </div>
 
-      {/* Col 2 — spine */}
-      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-        {/* -1/+1 overreach ensures flush join with adjacent rows — no pixel gaps */}
-        <div
-          style={{
-            position: 'absolute', top: 0, bottom: 0,
-            left: '50%', transform: 'translateX(-50%)',
-            width: 2, zIndex: 0,
-            background: spineStyle === 'dashed'
-              ? dashedGradient(spineColour + '88')
-              : spineColour,
-          }}
-        />
+      {/* Col 2 — spine (line drawn by container; only marker here) */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
         {marker}
       </div>
 
@@ -378,9 +367,8 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
           </span>
         )}
       </div>
-      {/* Spine col */}
-      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: dashedGradient(spineColour + '88') }} />
+      {/* Spine col (line drawn by container; only drag indicator here) */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         {/* Drag preview indicator on spine */}
         {isTarget && (
           <div
@@ -445,9 +433,8 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
       <div style={{ width: TIME_COL_W, flexShrink: 0, paddingRight: 8, textAlign: 'right', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
         <span className="text-[11px] font-bold" style={{ color: '#ef4444' }}>{nowLabel}</span>
       </div>
-      {/* Spine col */}
-      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, zIndex: 0, background: '#ef444440' }} />
+      {/* Spine col (line drawn by container) */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         {/* Red clock marker */}
         <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2, position: 'relative' }}>
           <Clock size={9} color="#fff" />
@@ -753,6 +740,21 @@ const MobileListView = () => {
   // Page background colour — used as opaque fill behind spine markers so they cover the line
   const pageBg = darkMode ? '#1f2937' : '#ffffff';
 
+  // Single continuous background spine gradient covering the visible time range
+  const bgSpineGradient = useMemo(() => {
+    const startMin = isToday
+      ? Math.min(nowMin, segments[0]?.fromMin ?? segments[0]?.startMin ?? nowMin)
+      : (segments[0]?.fromMin ?? segments[0]?.startMin ?? 0);
+    const lastSeg = segments[segments.length - 1];
+    const endMin = lastSeg?.toMin ?? lastSeg?.endMin ?? (startMin + 120);
+    const range = Math.max(endMin - startMin, 1);
+    const stops = [0, 0.25, 0.5, 0.75, 1].map(t => {
+      const min = startMin + t * range;
+      return `${spineColorAt(min)} ${(t * 100).toFixed(0)}%`;
+    });
+    return `linear-gradient(to bottom, ${stops.join(', ')})`;
+  }, [segments, isToday, nowMin]);
+
   // ── Render helpers ─────────────────────────────────────────────────────────
   const getAccentHex = (item) => {
     if (item._kind === 'calendar-event') {
@@ -801,52 +803,50 @@ const MobileListView = () => {
         </button>
       )}
 
-      {/* ── Spine spacer (padding above "now") ── */}
-      {isToday && !inProgressItem && (
-        <div style={{ display: 'flex', height: 16 }}>
-          <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
-          <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
-            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
-          </div>
-          <div style={{ flex: 1 }} />
-        </div>
-      )}
-
-      {/* ── Now row — hidden when something is currently in progress ── */}
-      {isToday && !inProgressItem && (
-        <div ref={nowRowRef}>
-          <NowRow
-            nowMin={nowMin}
-            nextItem={nextItem}
-            formatTime={formatTime}
-            textSecondary={textSecondary}
-            darkMode={darkMode}
-            use24HourClock={use24HourClock}
+      {/* ── Timed body — single continuous background spine ── */}
+      <div style={{ position: 'relative' }}>
+        {/* One unbroken spine line behind all rows */}
+        {(visibleItems.length > 0 || (isToday && !inProgressItem)) && (
+          <div
+            style={{
+              position: 'absolute', top: 0, bottom: 0, zIndex: 0, pointerEvents: 'none',
+              left: TIME_COL_W + SPINE_COL_W / 2 - 1,
+              width: 2,
+              background: bgSpineGradient,
+            }}
           />
-        </div>
-      )}
+        )}
 
-      {/* ── Spine spacer (padding below "now") ── */}
-      {isToday && !inProgressItem && visibleItems.length > 0 && (
-        <div style={{ display: 'flex', height: 12 }}>
-          <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
-          <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
-            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
+        {/* Padding above "now" */}
+        {isToday && !inProgressItem && <div style={{ height: 16 }} />}
+
+        {/* Now row */}
+        {isToday && !inProgressItem && (
+          <div ref={nowRowRef}>
+            <NowRow
+              nowMin={nowMin}
+              nextItem={nextItem}
+              formatTime={formatTime}
+              textSecondary={textSecondary}
+              darkMode={darkMode}
+              use24HourClock={use24HourClock}
+            />
           </div>
-          <div style={{ flex: 1 }} />
-        </div>
-      )}
+        )}
 
-      {/* ── Empty state ── */}
-      {visibleItems.length === 0 && (
-        <div className={`flex flex-col items-center justify-center py-16 ${textSecondary}`}>
-          <p className="text-sm">No items scheduled</p>
-          {isToday && <p className="text-xs mt-1 opacity-60">Tap + to add a task</p>}
-        </div>
-      )}
+        {/* Padding below "now" */}
+        {isToday && !inProgressItem && visibleItems.length > 0 && <div style={{ height: 12 }} />}
 
-      {/* ── Segment list ── */}
-      {segments.map(seg => {
+        {/* Empty state */}
+        {visibleItems.length === 0 && (
+          <div className={`flex flex-col items-center justify-center py-16 ${textSecondary}`}>
+            <p className="text-sm">No items scheduled</p>
+            {isToday && <p className="text-xs mt-1 opacity-60">Tap + to add a task</p>}
+          </div>
+        )}
+
+        {/* Segment list */}
+        {segments.map(seg => {
         if (seg.type === 'gap') {
           const midMin = Math.round((seg.fromMin + seg.toMin) / 2);
           return (
@@ -964,6 +964,7 @@ const MobileListView = () => {
 
         return null;
       })}
+      </div>{/* end timed body */}
 
       {/* ── Inbox drawer ── */}
       {/* Collapsed handle — fixed to viewport */}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -79,7 +79,7 @@ function countdownText(diffMin) {
 
 // ─── SpineMarker ─────────────────────────────────────────────────────────────
 
-function SpineMarker({ kind, completed, colour }) {
+function SpineMarker({ kind, completed, colour, pageBg }) {
   const base = {
     width: 16, height: 16, flexShrink: 0, position: 'relative', zIndex: 2,
     display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -92,7 +92,7 @@ function SpineMarker({ kind, completed, colour }) {
   }
   if (kind === 'frame') {
     return (
-      <div style={{ ...base, borderRadius: '50%', border: `2px solid ${colour}`, background: 'transparent' }} />
+      <div style={{ ...base, borderRadius: '50%', border: `2px solid ${colour}`, background: pageBg }} />
     );
   }
   if (kind === 'calendar-event') {
@@ -100,14 +100,14 @@ function SpineMarker({ kind, completed, colour }) {
       <div style={{ ...base, borderRadius: 2, background: colour }} />
     );
   }
-  // task / calendar-task
+  // task
   return (
     <div
       style={{
         ...base,
         borderRadius: 4,
         border: `2px solid ${colour}`,
-        background: completed ? colour : 'transparent',
+        background: completed ? colour : pageBg,
       }}
     >
       {completed && <Check size={9} strokeWidth={3} color="#fff" />}
@@ -333,29 +333,17 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
 
       {/* Col 2 — spine */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-        {/* Top spine segment — fades to transparent near the marker */}
+        {/* Full-height line; marker (zIndex 2, opaque bg) sits on top of it */}
         <div
           style={{
-            position: 'absolute', top: 0, bottom: 'calc(50% + 9px)',
+            position: 'absolute', top: 0, bottom: 0,
             left: '50%', transform: 'translateX(-50%)',
-            width: 2,
+            width: 2, zIndex: 0,
             background: spineStyle === 'dashed'
               ? dashedGradient(spineColour + '88')
-              : `linear-gradient(to bottom, ${spineColour}, ${spineColour} calc(100% - 10px), transparent)`,
+              : spineColour,
           }}
         />
-        {/* Bottom spine segment — fades in from transparent below the marker */}
-        <div
-          style={{
-            position: 'absolute', top: 'calc(50% + 9px)', bottom: 0,
-            left: '50%', transform: 'translateX(-50%)',
-            width: 2,
-            background: spineStyle === 'dashed'
-              ? dashedGradient(spineColour + '88')
-              : `linear-gradient(to bottom, transparent, ${spineColour} 10px, ${spineColour})`,
-          }}
-        />
-        {/* Marker */}
         {marker}
       </div>
 
@@ -458,8 +446,7 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
       </div>
       {/* Spine col */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ position: 'absolute', top: 0, bottom: 'calc(50% + 9px)', left: '50%', transform: 'translateX(-50%)', width: 2, background: 'linear-gradient(to bottom, #ef444466, transparent)' }} />
-        <div style={{ position: 'absolute', top: 'calc(50% + 9px)', bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: 'linear-gradient(to bottom, transparent, #ef444466)' }} />
+        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, zIndex: 0, background: '#ef444440' }} />
         {/* Red clock marker */}
         <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2, position: 'relative' }}>
           <Clock size={9} color="#fff" />
@@ -762,6 +749,9 @@ const MobileListView = () => {
     return segs;
   }, [visibleItems, isToday, nowMin, timeToMinutes]);
 
+  // Page background colour — used as opaque fill behind spine markers so they cover the line
+  const pageBg = darkMode ? '#1f2937' : '#ffffff';
+
   // ── Render helpers ─────────────────────────────────────────────────────────
   const getAccentHex = (item) => {
     if (item._kind === 'calendar-event') {
@@ -887,7 +877,7 @@ const MobileListView = () => {
                 timeLabel={formatTime(item.startTime)}
                 spineColour={sc}
                 spineStyle="solid"
-                marker={<SpineMarker kind="routine" colour="#14b8a6" completed={completed} />}
+                marker={<SpineMarker kind="routine" colour="#14b8a6" completed={completed} pageBg={pageBg} />}
                 cardHeight={ROUTINE_H}
                 accentHex="#14b8a6"
               >
@@ -908,7 +898,7 @@ const MobileListView = () => {
                 timeLabel={formatTime(item.startTime)}
                 spineColour={sc}
                 spineStyle="solid"
-                marker={<SpineMarker kind="frame" colour={accentHex} />}
+                marker={<SpineMarker kind="frame" colour={accentHex} pageBg={pageBg} />}
                 cardHeight={FRAME_H}
                 accentHex={accentHex}
               >
@@ -938,6 +928,7 @@ const MobileListView = () => {
                   kind={isCalendarEvent ? 'calendar-event' : 'task'}
                   completed={item.completed}
                   colour={accentHex}
+                  pageBg={pageBg}
                 />
               }
               cardHeight={TASK_H}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -79,7 +79,7 @@ function countdownText(diffMin) {
 
 // ─── SpineMarker ─────────────────────────────────────────────────────────────
 
-function SpineMarker({ kind, completed, colour }) {
+function SpineMarker({ kind, completed, colour, pageBg }) {
   const base = {
     width: 16, height: 16, flexShrink: 0, position: 'relative', zIndex: 2,
     display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -92,7 +92,7 @@ function SpineMarker({ kind, completed, colour }) {
   }
   if (kind === 'frame') {
     return (
-      <div style={{ ...base, borderRadius: '50%', border: `2px solid ${colour}`, background: 'transparent' }} />
+      <div style={{ ...base, borderRadius: '50%', border: `2px solid ${colour}`, background: pageBg }} />
     );
   }
   if (kind === 'calendar-event') {
@@ -100,14 +100,14 @@ function SpineMarker({ kind, completed, colour }) {
       <div style={{ ...base, borderRadius: 2, background: colour }} />
     );
   }
-  // task / calendar-task
+  // task
   return (
     <div
       style={{
         ...base,
         borderRadius: 4,
         border: `2px solid ${colour}`,
-        background: completed ? colour : 'transparent',
+        background: completed ? colour : pageBg,
       }}
     >
       {completed && <Check size={9} strokeWidth={3} color="#fff" />}
@@ -309,7 +309,7 @@ function FrameCard({ frame, darkMode, textPrimary, textSecondary, openFrameAdjus
 
 // ─── Row wrapper (3 columns) ──────────────────────────────────────────────────
 
-function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeight, accentHex, children, isNow }) {
+function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeight, accentHex, children, isNow, pageBg }) {
   return (
     <div style={{ display: 'flex', minHeight: cardHeight }}>
       {/* Col 1 — time */}
@@ -331,36 +331,24 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
         {isNow && <Clock size={11} style={{ color: timeColour, marginLeft: 'auto', marginTop: 2 }} />}
       </div>
 
-      {/* Col 2 — spine */}
+      {/* Col 2 — spine (background line drawn by container; halo + marker here) */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-        {/* Top spine segment — fades to transparent near the marker */}
-        <div
-          style={{
-            position: 'absolute', top: 0, bottom: 'calc(50% + 9px)',
-            left: '50%', transform: 'translateX(-50%)',
-            width: 2,
-            background: spineStyle === 'dashed'
-              ? dashedGradient(spineColour + '88')
-              : `linear-gradient(to bottom, ${spineColour}, ${spineColour} calc(100% - 10px), transparent)`,
-          }}
-        />
-        {/* Bottom spine segment — fades in from transparent below the marker */}
-        <div
-          style={{
-            position: 'absolute', top: 'calc(50% + 9px)', bottom: 0,
-            left: '50%', transform: 'translateX(-50%)',
-            width: 2,
-            background: spineStyle === 'dashed'
-              ? dashedGradient(spineColour + '88')
-              : `linear-gradient(to bottom, transparent, ${spineColour} 10px, ${spineColour})`,
-          }}
-        />
-        {/* Marker */}
+        {/* Gradient halo: fades the background spine into the marker */}
+        {pageBg && (
+          <div style={{
+            position: 'absolute',
+            top: '50%', transform: 'translateY(-50%)',
+            left: '50%', marginLeft: -1,
+            width: 2, height: 56, zIndex: 1, pointerEvents: 'none',
+            background: `linear-gradient(to bottom, transparent, ${pageBg} 40%, ${pageBg} 60%, transparent)`,
+          }} />
+        )}
         {marker}
       </div>
 
-      {/* Col 3 — content */}
-      <div style={{ flex: 1, minWidth: 0, position: 'relative', paddingTop: 4, paddingBottom: 4, paddingRight: 8 }}>
+      {/* Col 3 — no padding; card provides its own internal padding so top:50% on
+          the connector always matches the spine marker's vertical centre */}
+      <div style={{ flex: 1, minWidth: 0, position: 'relative', paddingRight: 8 }}>
         {accentHex && <Connector colour={accentHex} />}
         {children}
       </div>
@@ -389,9 +377,8 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
           </span>
         )}
       </div>
-      {/* Spine col */}
-      <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: dashedGradient(spineColour + '88') }} />
+      {/* Spine col (line drawn by container; only drag indicator here) */}
+      <div style={{ width: SPINE_COL_W, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         {/* Drag preview indicator on spine */}
         {isTarget && (
           <div
@@ -432,7 +419,7 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
 
 // ─── NowRow ───────────────────────────────────────────────────────────────────
 
-function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24HourClock }) {
+function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24HourClock, pageBg }) {
   const nowLabel = (() => {
     const h = Math.floor(nowMin / 60);
     const m = nowMin % 60;
@@ -456,10 +443,17 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
       <div style={{ width: TIME_COL_W, flexShrink: 0, paddingRight: 8, textAlign: 'right', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
         <span className="text-[11px] font-bold" style={{ color: '#ef4444' }}>{nowLabel}</span>
       </div>
-      {/* Spine col */}
+      {/* Spine col (line drawn by container; halo + marker here) */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ position: 'absolute', top: 0, bottom: 'calc(50% + 9px)', left: '50%', transform: 'translateX(-50%)', width: 2, background: 'linear-gradient(to bottom, #ef444466, transparent)' }} />
-        <div style={{ position: 'absolute', top: 'calc(50% + 9px)', bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: 'linear-gradient(to bottom, transparent, #ef444466)' }} />
+        {pageBg && (
+          <div style={{
+            position: 'absolute',
+            top: '50%', transform: 'translateY(-50%)',
+            left: '50%', marginLeft: -1,
+            width: 2, height: 56, zIndex: 1, pointerEvents: 'none',
+            background: `linear-gradient(to bottom, transparent, ${pageBg} 40%, ${pageBg} 60%, transparent)`,
+          }} />
+        )}
         {/* Red clock marker */}
         <div style={{ width: 16, height: 16, borderRadius: '50%', background: '#ef4444', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2, position: 'relative' }}>
           <Clock size={9} color="#fff" />
@@ -762,6 +756,24 @@ const MobileListView = () => {
     return segs;
   }, [visibleItems, isToday, nowMin, timeToMinutes]);
 
+  // Page background colour — used as opaque fill behind spine markers so they cover the line
+  const pageBg = darkMode ? '#1f2937' : '#ffffff';
+
+  // Single continuous background spine gradient covering the visible time range
+  const bgSpineGradient = useMemo(() => {
+    const startMin = isToday
+      ? Math.min(nowMin, segments[0]?.fromMin ?? segments[0]?.startMin ?? nowMin)
+      : (segments[0]?.fromMin ?? segments[0]?.startMin ?? 0);
+    const lastSeg = segments[segments.length - 1];
+    const endMin = lastSeg?.toMin ?? lastSeg?.endMin ?? (startMin + 120);
+    const range = Math.max(endMin - startMin, 1);
+    const stops = [0, 0.25, 0.5, 0.75, 1].map(t => {
+      const min = startMin + t * range;
+      return `${spineColorAt(min)} ${(t * 100).toFixed(0)}%`;
+    });
+    return `linear-gradient(to bottom, ${stops.join(', ')})`;
+  }, [segments, isToday, nowMin]);
+
   // ── Render helpers ─────────────────────────────────────────────────────────
   const getAccentHex = (item) => {
     if (item._kind === 'calendar-event') {
@@ -810,52 +822,51 @@ const MobileListView = () => {
         </button>
       )}
 
-      {/* ── Spine spacer (padding above "now") ── */}
-      {isToday && !inProgressItem && (
-        <div style={{ display: 'flex', height: 16 }}>
-          <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
-          <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
-            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
-          </div>
-          <div style={{ flex: 1 }} />
-        </div>
-      )}
-
-      {/* ── Now row — hidden when something is currently in progress ── */}
-      {isToday && !inProgressItem && (
-        <div ref={nowRowRef}>
-          <NowRow
-            nowMin={nowMin}
-            nextItem={nextItem}
-            formatTime={formatTime}
-            textSecondary={textSecondary}
-            darkMode={darkMode}
-            use24HourClock={use24HourClock}
+      {/* ── Timed body — single continuous background spine ── */}
+      <div style={{ position: 'relative' }}>
+        {/* One unbroken spine line behind all rows */}
+        {(visibleItems.length > 0 || (isToday && !inProgressItem)) && (
+          <div
+            style={{
+              position: 'absolute', top: 0, bottom: 0, zIndex: 0, pointerEvents: 'none',
+              left: TIME_COL_W + SPINE_COL_W / 2 - 1,
+              width: 2,
+              background: bgSpineGradient,
+            }}
           />
-        </div>
-      )}
+        )}
 
-      {/* ── Spine spacer (padding below "now") ── */}
-      {isToday && !inProgressItem && visibleItems.length > 0 && (
-        <div style={{ display: 'flex', height: 12 }}>
-          <div style={{ width: TIME_COL_W, flexShrink: 0 }} />
-          <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative' }}>
-            <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', transform: 'translateX(-50%)', width: 2, background: spineColorAt(nowMin) }} />
+        {/* Padding above "now" */}
+        {isToday && !inProgressItem && <div style={{ height: 16 }} />}
+
+        {/* Now row */}
+        {isToday && !inProgressItem && (
+          <div ref={nowRowRef}>
+            <NowRow
+              nowMin={nowMin}
+              nextItem={nextItem}
+              formatTime={formatTime}
+              textSecondary={textSecondary}
+              darkMode={darkMode}
+              use24HourClock={use24HourClock}
+              pageBg={pageBg}
+            />
           </div>
-          <div style={{ flex: 1 }} />
-        </div>
-      )}
+        )}
 
-      {/* ── Empty state ── */}
-      {visibleItems.length === 0 && (
-        <div className={`flex flex-col items-center justify-center py-16 ${textSecondary}`}>
-          <p className="text-sm">No items scheduled</p>
-          {isToday && <p className="text-xs mt-1 opacity-60">Tap + to add a task</p>}
-        </div>
-      )}
+        {/* Padding below "now" */}
+        {isToday && !inProgressItem && visibleItems.length > 0 && <div style={{ height: 12 }} />}
 
-      {/* ── Segment list ── */}
-      {segments.map(seg => {
+        {/* Empty state */}
+        {visibleItems.length === 0 && (
+          <div className={`flex flex-col items-center justify-center py-16 ${textSecondary}`}>
+            <p className="text-sm">No items scheduled</p>
+            {isToday && <p className="text-xs mt-1 opacity-60">Tap + to add a task</p>}
+          </div>
+        )}
+
+        {/* Segment list */}
+        {segments.map(seg => {
         if (seg.type === 'gap') {
           const midMin = Math.round((seg.fromMin + seg.toMin) / 2);
           return (
@@ -887,16 +898,19 @@ const MobileListView = () => {
                 timeLabel={formatTime(item.startTime)}
                 spineColour={sc}
                 spineStyle="solid"
-                marker={<SpineMarker kind="routine" colour="#14b8a6" completed={completed} />}
+                marker={<SpineMarker kind="routine" colour="#14b8a6" completed={completed} pageBg={pageBg} />}
                 cardHeight={ROUTINE_H}
                 accentHex="#14b8a6"
+                pageBg={pageBg}
               >
-                <RoutineChip
-                  routine={item}
-                  completed={completed}
-                  onToggle={toggleRoutineCompletion}
-                  darkMode={darkMode}
-                />
+                <div style={{ marginTop: 4, marginBottom: 4 }}>
+                  <RoutineChip
+                    routine={item}
+                    completed={completed}
+                    onToggle={toggleRoutineCompletion}
+                    darkMode={darkMode}
+                  />
+                </div>
               </Row>
             );
           }
@@ -908,18 +922,21 @@ const MobileListView = () => {
                 timeLabel={formatTime(item.startTime)}
                 spineColour={sc}
                 spineStyle="solid"
-                marker={<SpineMarker kind="frame" colour={accentHex} />}
+                marker={<SpineMarker kind="frame" colour={accentHex} pageBg={pageBg} />}
                 cardHeight={FRAME_H}
                 accentHex={accentHex}
+                pageBg={pageBg}
               >
-                <FrameCard
-                  frame={item}
-                  darkMode={darkMode}
-                  textPrimary={textPrimary}
-                  textSecondary={textSecondary}
-                  openFrameAdjust={openFrameAdjust}
-                  dateStr={dateStr}
-                />
+                <div style={{ marginTop: 4, marginBottom: 4 }}>
+                  <FrameCard
+                    frame={item}
+                    darkMode={darkMode}
+                    textPrimary={textPrimary}
+                    textSecondary={textSecondary}
+                    openFrameAdjust={openFrameAdjust}
+                    dateStr={dateStr}
+                  />
+                </div>
               </Row>
             );
           }
@@ -938,12 +955,14 @@ const MobileListView = () => {
                   kind={isCalendarEvent ? 'calendar-event' : 'task'}
                   completed={item.completed}
                   colour={accentHex}
+                  pageBg={pageBg}
                 />
               }
               cardHeight={TASK_H}
               accentHex={accentHex}
+              pageBg={pageBg}
             >
-              <div style={{ opacity: isPast ? 0.5 : 1 }}>
+              <div style={{ opacity: isPast ? 0.5 : 1, marginTop: 4, marginBottom: 4 }}>
                 <TaskCard
                   item={item}
                   accentHex={accentHex}
@@ -968,6 +987,7 @@ const MobileListView = () => {
 
         return null;
       })}
+      </div>{/* end timed body */}
 
       {/* ── Inbox drawer ── */}
       {/* Collapsed handle — fixed to viewport */}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -162,8 +162,8 @@ const TaskCard = React.memo(({
       {/* Left colour bar */}
       <div style={barStyle} />
       {/* Content */}
-      <div style={{ flex: 1, minWidth: 0, padding: '6px 6px 6px 8px', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-        {/* Top row: completion + title + action grid */}
+      <div style={{ flex: 1, minWidth: 0, padding: '6px 6px 6px 8px', display: 'flex', flexDirection: 'column' }}>
+        {/* Top row: completion + title/time + action grid */}
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6 }}>
           {/* Completion circle (tasks only, not pure calendar events) */}
           {!isCalendarEvent && (
@@ -180,13 +180,16 @@ const TaskCard = React.memo(({
               {item.completed && <Check size={8} strokeWidth={3} color="#fff" />}
             </button>
           )}
-          {/* Title */}
+          {/* Title + time meta */}
           <div style={{ flex: 1, minWidth: 0 }}>
             <div
               className={`text-sm font-medium leading-snug ${textPrimary} ${item.completed ? 'line-through opacity-50' : ''}`}
               style={{ overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}
             >
               {renderTitle(item.title)}
+            </div>
+            <div className={`text-[10px] leading-none ${textSecondary}`} style={{ marginTop: 3 }}>
+              {timeStr}
             </div>
           </div>
           {/* 2×2 action grid (tasks only) */}
@@ -234,10 +237,6 @@ const TaskCard = React.memo(({
               </button>
             </div>
           )}
-        </div>
-        {/* Time meta */}
-        <div className={`text-[10px] leading-none ${textSecondary}`} style={{ marginTop: 4 }}>
-          {timeStr}
         </div>
       </div>
     </div>
@@ -333,10 +332,21 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
 
       {/* Col 2 — spine */}
       <div style={{ width: SPINE_COL_W, flexShrink: 0, position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-        {/* Spine line segment */}
+        {/* Top spine segment — stops just above the marker */}
         <div
           style={{
-            position: 'absolute', top: 0, bottom: 0,
+            position: 'absolute', top: 0, bottom: 'calc(50% + 9px)',
+            left: '50%', transform: 'translateX(-50%)',
+            width: 2,
+            ...(spineStyle === 'dashed'
+              ? { background: dashedGradient(spineColour + '88') }
+              : { background: spineColour }),
+          }}
+        />
+        {/* Bottom spine segment — resumes just below the marker */}
+        <div
+          style={{
+            position: 'absolute', top: 'calc(50% + 9px)', bottom: 0,
             left: '50%', transform: 'translateX(-50%)',
             width: 2,
             ...(spineStyle === 'dashed'


### PR DESCRIPTION
## Summary

- New `MobileListView` component (~550 lines) rendering the LIST view body when `mobileViewMode === 'list'`
- `MobileAllDaySection` is now gated to GRID mode only; all-day items appear at the top of the LIST body instead
- 3-column spine layout: `56px time col` | `32px spine col` | `flex-1 content col`

## What's in the LIST view

**Spine**
- Continuous spine line with per-segment colour: orange (≤6am) → green (noon) → blue (≥6pm)
- Dashed spine in gap rows; solid in item rows
- 16×16 per-item marker: rounded-square checkbox (task), filled circle (routine), ring (frame), solid square (calendar event)
- Horizontal connector line from spine marker to left edge of each card

**Item types**
- **Tasks & calendar events** — colour-accented card (30% opacity tint, full-opacity left bar), 2-line title, 2×2 action grid (Notes / Postpone / Inbox / Edit), time + duration meta below
- **Routines** — teal rounded-full chip, name + duration, tap to toggle completion
- **hyperGLANCE sessions (frames)** — colour-bordered card with project icon, label, time range, edit button
- **All-day items** — compact cards in a bordered section above the spine

**Time & flow**
- "Now" row with red clock marker + countdown to next item ("Xh Xm until {title}" or "Nothing planned")
- Expand/collapse past items chip (today only, only shown if past items exist)
- Gap rows sized by free-time duration; show "Xh free" label for gaps ≥ 60 min
- Auto-scroll to "now" row on mount / date change

**Inbox drawer**
- Fixed-position collapsed handle (32px, right edge) — stays visible regardless of scroll
- Expands to 160px panel with vertical scroll list of unscheduled tasks
- Touch drag-to-schedule: `elementFromPoint → closest([data-gap-from])` gap detection, 15-min snap, routine-block avoidance, green/red preview indicator

## What's unchanged
- GRID view behaviour is 100% identical
- Date nav header, date column header (NotebookPen / Target icons), all-day section in GRID mode — all untouched
- Toggle button cell dimensions unchanged

## Test checklist

- [ ] Switching to LIST mode shows the spine layout (not a blank screen)
- [ ] Tasks appear with correct accent colour, 2-line title, 2×2 action buttons
- [ ] Routines appear as teal chips; tapping toggles completion
- [ ] hyperGLANCE sessions appear as framed cards with edit button
- [ ] All-day items appear at the top of the LIST body (not in the sticky all-day section)
- [ ] All-day sticky section is hidden in LIST mode
- [ ] "Now" row appears on today with correct time and countdown
- [ ] Past items are collapsed behind an expand chip (today only)
- [ ] Gap rows show "Xh free" for gaps ≥ 60 min
- [ ] Inbox handle visible at right edge; tap to expand
- [ ] Drag task from inbox onto a gap row → task scheduled at snapped time
- [ ] Drag over a routine block shows "Blocked" in red
- [ ] GRID view is completely unchanged when toggled back
- [ ] Light and dark mode both render correctly

https://claude.ai/code/session_01XB9ceEk9TdLd6kJc3awnZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XB9ceEk9TdLd6kJc3awnZP)_