### PR TITLE
Allow Stream Deck property inspector through the WS Origin guard

### DIFF
--- a/electron/ws-server.ts
+++ b/electron/ws-server.ts
@@ -14,10 +14,16 @@ export function createWsServer(getMainWindow: () => BrowserWindow | null): WebSo
   let lastState: string | null = null;
 
   wss.on('connection', (ws, req) => {
-    // Browser-initiated WebSocket connections always include an Origin header;
-    // native clients (e.g. the Stream Deck plugin) do not. Reject browser
-    // connections to prevent any web page from reaching this server.
-    if (req.headers['origin']) {
+    // Allow connections from non-browser clients (no Origin header — e.g. the
+    // Stream Deck plugin runtime), file:// pages (Origin: null — the Stream
+    // Deck property inspector is loaded this way), and loopback origins.
+    // Reject anything else so a random web page can't reach this server.
+    const origin = req.headers['origin'];
+    const allowed =
+      !origin ||
+      origin === 'null' ||
+      /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+    if (!allowed) {
       ws.terminate();
       return;
     }


### PR DESCRIPTION
## Summary

The CSRF guard added in #679 rejects any WebSocket connection that carries an `Origin` header. That correctly blocks random web pages but also blocks the Stream Deck property inspector — it's a `file://`-loaded webview that sends `Origin: null` on connect.

Symptoms (with desktop running and plugin functional):
- PI status row reads "dayGLANCE Desktop not running" with the disconnected dot
- Habit action's dropdown stays empty (it's populated from the PI's own WS subscription)
- Tile presses still hit the desktop fine, because the Node-based plugin runtime doesn't send an Origin header and was never blocked

This was latent — surfaced only when an Electron rebuild pulled the guard into a build that previously didn't have it.

## Change

Replace the strict "any Origin → reject" with an allow-list:

- No Origin header (Node clients) ✓
- `Origin: null` (`file://` pages, including the PI) ✓
- `http(s)://localhost:*` or `http(s)://127.0.0.1:*` (loopback) ✓
- Anything else ✗

Browsers set Origin themselves and JS can't override it, so this still rejects pages from `https://evil.com` etc.

## Test plan

- [ ] Rebuild Electron, relaunch dayGLANCE Desktop
- [ ] Open the Stream Deck app, edit a dayGLANCE action's property inspector — status row reads "Connected" with the green dot
- [ ] Edit a Habit action — habit dropdown populates with active habits
- [ ] Tile presses (Agenda complete, Habit increment, hyperGLANCE start, etc.) still trigger the right desktop action
- [ ] No regression for the original CSRF intent: a quick `curl --include -H "Origin: https://evil.com" --no-buffer ws://localhost:7892` style smoke test still gets rejected

https://claude.ai/code/session_01Wdu1idwESbvHV6yGU8zoK8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdu1idwESbvHV6yGU8zoK8)_