### PR TITLE
Bug fixes, hyperGLANCE improvements, and keyboard shortcut enhancements

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -20,6 +20,7 @@ let trayWindow: BrowserWindow | null = null;
 let trayNeedsReload = false;
 let trayReloadTimer: ReturnType<typeof setTimeout> | null = null;
 let registeredHotkey: string | null = null;
+let registeredMainWindowHotkey: string | null = null;
 
 // Tray menu bar title: focus countdown takes priority over the reminder dot.
 let trayIndicatorOn = false;
@@ -368,6 +369,24 @@ ipcMain.handle('hotkey:register', (_event, accelerator: string) => {
     tw.webContents.send('tray:focus-quick-add');
   });
   if (ok) registeredHotkey = accelerator;
+  return ok;
+});
+
+// Global hotkey: show and focus the main app window.
+ipcMain.handle('hotkey:register-main-window', (_event, accelerator: string) => {
+  if (registeredMainWindowHotkey) {
+    try { globalShortcut.unregister(registeredMainWindowHotkey); } catch { /* ignore */ }
+    registeredMainWindowHotkey = null;
+  }
+  if (!accelerator) return true;
+  const ok = globalShortcut.register(accelerator, () => {
+    const mw = live(mainWindow);
+    if (!mw) return;
+    if (mw.isMinimized()) mw.restore();
+    mw.show();
+    mw.focus();
+  });
+  if (ok) registeredMainWindowHotkey = accelerator;
   return ok;
 });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -85,6 +85,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Pass an empty string to unregister. Returns true if registration succeeded.
   setGlobalHotkey: (accelerator: string) => ipcRenderer.invoke('hotkey:register', accelerator),
 
+  // Registers (or clears) a system-wide hotkey that shows the main app window.
+  setMainWindowHotkey: (accelerator: string) => ipcRenderer.invoke('hotkey:register-main-window', accelerator),
+
   // Tray popup listens for the signal to focus the quick-add input.
   onFocusQuickAdd: (callback: () => void) => {
     const handler = () => callback();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2327,7 +2327,7 @@ const DayPlanner = () => {
     setShowMonthView,
     setShowMobileTagFilter,
     setShowBackupMenu,
-    isMobile, setTabletActiveTab,
+    isMobile, tabletActiveTab, setTabletActiveTab,
     aiConfig, setShowVoiceInput,
     habitsEnabled, setHabitsEnabled, setShowHabitModal,
     goalsProjectsEnabled, setGoalsProjectsEnabled, showGoalsDashboard, setShowGoalsDashboard,

--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -53,6 +53,7 @@ const DatePicker = ({ value, onChange, onClose }) => {
         >
           <div className="flex items-center justify-between mb-4">
             <button
+              type="button"
               onClick={() => changeMonth(-1)}
               className={`p-2 rounded ${hoverBg}`}
             >
@@ -62,6 +63,7 @@ const DatePicker = ({ value, onChange, onClose }) => {
               {monthNames[viewDate.getMonth()]} {viewDate.getFullYear()}
             </h3>
             <button
+              type="button"
               onClick={() => changeMonth(1)}
               className={`p-2 rounded ${hoverBg}`}
             >
@@ -88,6 +90,7 @@ const DatePicker = ({ value, onChange, onClose }) => {
 
               return (
                 <button
+                  type="button"
                   key={index}
                   onClick={() => {
                     onChange(dayStr);
@@ -111,6 +114,7 @@ const DatePicker = ({ value, onChange, onClose }) => {
 
           <div className="flex gap-2 mt-4">
             <button
+              type="button"
               onClick={() => {
                 onChange(dateToString(new Date()));
                 onClose();
@@ -120,6 +124,7 @@ const DatePicker = ({ value, onChange, onClose }) => {
               Today
             </button>
             <button
+              type="button"
               onClick={onClose}
               className={`flex-1 px-4 py-2 rounded-lg ${darkMode ? 'bg-gray-700' : 'bg-stone-200'} ${textPrimary} ${hoverBg}`}
             >

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -65,8 +65,9 @@ const SettingsModal = () => {
   const storageWarning = storageUsage.totalBytes > 4 * 1024 * 1024;
 
   const [trayHotkey, setTrayHotkey] = useState(() => localStorage.getItem('dg-tray-hotkey') || '');
+  const [mainWindowHotkey, setMainWindowHotkey] = useState(() => localStorage.getItem('dg-main-window-hotkey') || '');
 
-  const handleHotkeyRecord = (e) => {
+  const makeHotkeyRecorder = (storageKey, stateSetter, apiMethod) => (e) => {
     e.preventDefault();
     const ignored = new Set(['Meta', 'Shift', 'Alt', 'Control']);
     if (ignored.has(e.key)) return;
@@ -77,16 +78,25 @@ const SettingsModal = () => {
     if (e.shiftKey) mods.push('Shift');
     const key = e.key === ' ' ? 'Space' : e.key.length === 1 ? e.key.toUpperCase() : e.key;
     const accelerator = [...mods, key].join('+');
-    setTrayHotkey(accelerator);
-    localStorage.setItem('dg-tray-hotkey', accelerator);
-    window.electronAPI?.setGlobalHotkey?.(accelerator);
+    stateSetter(accelerator);
+    localStorage.setItem(storageKey, accelerator);
+    apiMethod?.(accelerator);
     e.target.blur();
   };
+
+  const handleHotkeyRecord = makeHotkeyRecorder('dg-tray-hotkey', setTrayHotkey, (acc) => window.electronAPI?.setGlobalHotkey?.(acc));
+  const handleMainWindowHotkeyRecord = makeHotkeyRecorder('dg-main-window-hotkey', setMainWindowHotkey, (acc) => window.electronAPI?.setMainWindowHotkey?.(acc));
 
   const clearHotkey = () => {
     setTrayHotkey('');
     localStorage.removeItem('dg-tray-hotkey');
     window.electronAPI?.setGlobalHotkey?.('');
+  };
+
+  const clearMainWindowHotkey = () => {
+    setMainWindowHotkey('');
+    localStorage.removeItem('dg-main-window-hotkey');
+    window.electronAPI?.setMainWindowHotkey?.('');
   };
 
   return (
@@ -327,6 +337,26 @@ const SettingsModal = () => {
                         {trayHotkey && (
                           <button
                             onClick={clearHotkey}
+                            className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`}
+                          >
+                            Clear
+                          </button>
+                        )}
+                      </div>
+                      <p className={`text-sm ${textSecondary} mt-3`}>
+                        Show the main app window from anywhere on your Mac.
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <input
+                          readOnly
+                          placeholder="Click, then press shortcut…"
+                          value={mainWindowHotkey}
+                          onKeyDown={handleMainWindowHotkeyRecord}
+                          className={`flex-1 px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white placeholder-gray-500' : 'bg-white text-stone-900 placeholder-stone-400'} text-sm cursor-pointer font-mono`}
+                        />
+                        {mainWindowHotkey && (
+                          <button
+                            onClick={clearMainWindowHotkey}
                             className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'} ${hoverBg}`}
                           >
                             Clear

--- a/src/components/ShortcutHelpModal.jsx
+++ b/src/components/ShortcutHelpModal.jsx
@@ -6,6 +6,7 @@ const ShortcutHelpModal = () => {
   const {
     setShowShortcutHelp,
     cardBg, borderClass, textPrimary, textSecondary, darkMode,
+    canShowViewCycler,
   } = useDayPlannerCtx();
 
   return (
@@ -27,6 +28,11 @@ const ShortcutHelpModal = () => {
               ['T', 'Go to today'],
               ['\u2190 / \u2192', 'Previous / next day'],
               ['M', 'Toggle month view'],
+              ...(canShowViewCycler ? [
+                ['1', 'View: Day'],
+                ['2', 'View: 3-day'],
+                ['3', 'View: Week'],
+              ] : []),
             ].map(([key, desc]) => (
               <div key={key} className={`flex items-center gap-3 py-1 ${textSecondary}`}>
                 <kbd className={`px-1.5 py-0.5 rounded text-xs font-mono min-w-[2rem] text-center ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-700'}`}>{key}</kbd>

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -36,6 +36,7 @@ import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
 import { TASK_COLORS, TAILWIND_TO_HEX, hexToRgba } from '../../utils/colorUtils.js';
 import { HG_ICON_GROUPS, HG_COLORS, HG_DAYS } from '../../hooks/useHyperGlance.js';
+import { dateToString } from '../../utils/taskUtils.js';
 import { calculateGoalProgress } from '../../utils/goalProgress.js';
 import { isProjectStalled } from '../../utils/projectProgress.js';
 import GoalCard from './GoalCard.jsx';
@@ -63,6 +64,14 @@ const sortByOrder = (projs) =>
 const toLightBg = (bgClass, dark) => {
   const hex = toHex(bgClass);
   return dark ? hexToRgba(hex, 0.13) : hexToRgba(hex, 0.09);
+};
+
+const nextQuarterHour = () => {
+  const now = new Date();
+  const m = now.getMinutes();
+  const next = Math.ceil((m + 1) / 15) * 15;
+  const h = (now.getHours() + Math.floor(next / 60)) % 24;
+  return `${String(h).padStart(2, '0')}:${String(next % 60).padStart(2, '0')}`;
 };
 
 // ─── Goal sorting helpers ─────────────────────────────────────────────────────
@@ -293,8 +302,8 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
   const [hgColor, setHgColor] = useState(initHG.color || '#4f46e5');
   const [hgIsRecurring, setHgIsRecurring] = useState(initHG.isRecurring !== false);
   const [hgScheduledDays, setHgScheduledDays] = useState(initHG.scheduledDays || []);
-  const [hgScheduledDate, setHgScheduledDate] = useState(initHG.scheduledDate || '');
-  const [hgScheduledTime, setHgScheduledTime] = useState(initHG.scheduledTime || '09:00');
+  const [hgScheduledDate, setHgScheduledDate] = useState(initHG.scheduledDate || dateToString(new Date()));
+  const [hgScheduledTime, setHgScheduledTime] = useState(initHG.scheduledTime || nextQuarterHour());
   const [hgDuration, setHgDuration] = useState(initHG.scheduledDuration || 60);
   const [hgTemplateTasks, setHgTemplateTasks] = useState(initHG.templateTasks || []);
   const [hgNewTask, setHgNewTask] = useState('');

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -939,6 +939,21 @@ const DesktopDashboard = ({
     return () => ro.disconnect();
   }, [recalc]);
 
+  // ── Arrow-key carousel navigation ────────────────────────────────────────────
+  useEffect(() => {
+    if (sortedGoals.length <= 1) return;
+    const handler = (e) => {
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+      const tag = document.activeElement?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || document.activeElement?.isContentEditable) return;
+      e.preventDefault();
+      if (e.key === 'ArrowLeft')  setActiveGoalIdx(i => Math.max(0, i - 1));
+      if (e.key === 'ArrowRight') setActiveGoalIdx(i => Math.min(sortedGoals.length - 1, i + 1));
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [sortedGoals.length]);
+
   // ── Render ───────────────────────────────────────────────────────────────────
   return (
     <div ref={containerRef} className="relative min-h-[200px]">

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -348,11 +348,13 @@ export default function useElectronBridge({
     });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Re-register the stored global hotkey after the main window (re)loads.
+  // Re-register the stored global hotkeys after the main window (re)loads.
   useEffect(() => {
     if (isTrayMode || !window.electronAPI?.setGlobalHotkey) return;
     const stored = localStorage.getItem('dg-tray-hotkey');
     if (stored) window.electronAPI.setGlobalHotkey(stored);
+    const storedMain = localStorage.getItem('dg-main-window-hotkey');
+    if (storedMain) window.electronAPI.setMainWindowHotkey?.(storedMain);
   }, []);
 
   // Push active reminders to tray popup whenever they change. Guarded to main window only.

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -45,7 +45,7 @@ export default function useKeyboardShortcuts({
   // backup menu ('b')
   setShowBackupMenu,
   // panel tabs (',', '.')
-  isMobile, setTabletActiveTab,
+  isMobile, tabletActiveTab, setTabletActiveTab,
   // voice input ('v')
   aiConfig, setShowVoiceInput,
   // habits ('h')
@@ -182,8 +182,8 @@ export default function useKeyboardShortcuts({
         setShowMonthView(prev => !prev);
       }
 
-      // '/' to toggle tag filter
-      if (e.key === '/' && noModifiers) {
+      // '/' to toggle tag filter — only when GLANCE is active
+      if (e.key === '/' && noModifiers && (isMobile || tabletActiveTab === 'glance')) {
         e.preventDefault();
         setShowMobileTagFilter(prev => !prev);
       }
@@ -198,12 +198,14 @@ export default function useKeyboardShortcuts({
       if (e.key === ',' && noModifiers && !isMobile) {
         e.preventDefault();
         setTabletActiveTab('glance');
+        setShowMobileTagFilter(false);
       }
 
       // '.' to switch side panel to Inbox
       if (e.key === '.' && noModifiers && !isMobile) {
         e.preventDefault();
         setTabletActiveTab('inbox');
+        setShowMobileTagFilter(false);
       }
 
       // 'v' for voice task input


### PR DESCRIPTION
## Summary

- **fix(DatePicker):** Add `type="button"` to all buttons — without this, clicking any button inside a `<form>` (e.g. the hyperGLANCE one-off date picker in GoalDashboard) triggered a form submit and closed the modal instead of navigating months
- **fix(keyboard):** Prevent tag filter popover from flashing at top-left when switching to GLANCE via keyboard — `/` now only fires when GLANCE is active, and `,`/`.` close the filter when switching tabs
- **feat(GoalDashboard):** Arrow keys navigate the goal carousel on desktop (skipped when focus is in a text input)
- **feat(hyperGLANCE):** Default time field to next 15-minute increment; default one-off date to today
- **feat(electron):** Global shortcut to show/focus the main app window, configurable in Settings alongside the existing tray popup shortcut
- **feat(ShortcutHelpModal):** Show `1`/`2`/`3` view shortcuts under Navigation, conditionally when `canShowViewCycler` is true (≥1600px)

## Test plan

- [x] Open GoalDashboard → set up a hyperGLANCE one-off session → confirm date defaults to today and time defaults to next quarter-hour → confirm month navigation chevrons work without closing the modal
- [x] Press `.` (Inbox) → `/` (no-op) → `,` (GLANCE) → confirm tag filter does **not** flash at top-left
- [x] Press `/` while in Inbox → confirm filter does **not** open; press `,` to switch to GLANCE → press `/` → confirm filter opens correctly
- [x] Open Goals dashboard with 2+ goals → confirm `←`/`→` navigate the carousel; confirm they do nothing while typing in an input
- [x] In Electron: set a main window hotkey in Settings → hide the app → press the shortcut → confirm window appears
- [x] At ≥1600px (3-day view active): open shortcut help (`?`) → confirm `1`/`2`/`3` appear under Navigation; at <1600px confirm they are absent

https://claude.ai/code/session_019eFYrHekNtLqUMCy6W4xzq

---
_Generated by [Claude Code](https://claude.ai/code/session_019eFYrHekNtLqUMCy6W4xzq)_