### PR TITLE
chore: bump to v2.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Your day, at a glance.** A privacy-first day planner with visual time-blocking, deep integrations, and zero lock-in. Use it free at [dayglance.app](https://dayglance.app) or self-host it on your own server. Your data stays on your device — nothing is ever sent to a server unless you choose to sync it yourself.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.7.2-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-2.8.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases) · [**Android APK**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 52
-        versionName = "2.7"
+        versionCode = 53
+        versionName = "2.8"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "dependencies": {
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "2.7.2",
+  "version": "2.8.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -321,7 +321,7 @@ const SettingsModal = () => {
                     <div className="space-y-3">
                       <h4 className={`font-medium ${textPrimary} flex items-center gap-2`}>
                         <Key size={16} className={textSecondary} />
-                        Global Shortcut
+                        Global Shortcuts
                       </h4>
                       <p className={`text-sm ${textSecondary}`}>
                         Open the quick-add popup from anywhere on your Mac.


### PR DESCRIPTION
## Summary

- Fix "Global Shortcut" → "Global Shortcuts" heading in Settings
- Web: `2.7.2` → `2.8.0` (`package.json` + `package-lock.json`)
- Android: `versionCode` 52 → 53, `versionName` `2.7` → `2.8` (`build.gradle.kts`)
- README version badge updated to `2.8.0`

## Test plan

- [ ] Settings modal shows "Global Shortcuts" (plural)
- [ ] `package.json` version reads `2.8.0`
- [ ] Android `versionCode` is 53, `versionName` is `2.8`
- [ ] README badge reflects `2.8.0`

https://claude.ai/code/session_019eFYrHekNtLqUMCy6W4xzq

---
_Generated by [Claude Code](https://claude.ai/code/session_019eFYrHekNtLqUMCy6W4xzq)_