### PR TITLE
fix(mobile): list-view spine fade, grid scroll-to-now, refocus toast

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -966,6 +966,7 @@ const DayPlanner = () => {
     selectedDate,
     isMobile, isTablet,
     mobileActiveTab,
+    mobileViewMode,
     viewMode: effectiveViewMode,
   });
 
@@ -8517,8 +8518,8 @@ const DayPlanner = () => {
         </div>
       )}
 
-      {/* Refocus timeline toast — all form factors */}
-      {timelineScrolledAway && effectiveViewMode === 'multi' && (
+      {/* Refocus timeline toast — all form factors except mobile list view */}
+      {timelineScrolledAway && effectiveViewMode === 'multi' && !(isMobile && mobileViewMode === 'list') && (
         <div className="fixed left-1/2 -translate-x-1/2 z-50 pointer-events-auto" style={{ bottom: isMobile ? 'calc(5rem + env(safe-area-inset-bottom, 0px))' : '1.5rem' }}>
           <button
             onClick={() => { setTimelineScrolledAway(false); scrollToCurrentHour(true); }}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -787,20 +787,25 @@ const MobileListView = () => {
     return ys;
   }, [segments, isToday, inProgressItem, visibleItems]);
 
-  // CSS mask: opaque everywhere, fades to transparent at each marker centre (±FADE px).
-  // This makes the spine genuinely transparent at markers rather than being covered.
+  // CSS mask: spine fades to transparent BEFORE each marker's top edge, holds
+  // invisible through the marker, then fades back after the marker's bottom edge.
   const bgSpineMask = useMemo(() => {
     if (spineMarkerYs.length === 0) return undefined;
-    const FADE = 14;
+    const MARKER_R  = 8;  // half of 16px marker height
+    const PRE_FADE  = 12; // fade-out distance ending at marker top edge
+    const POST_FADE = 12; // fade-in distance starting at marker bottom edge
     const stops = ['black 0px'];
     let prev = 0;
     spineMarkerYs.forEach(cy => {
-      const lo = cy - FADE;
-      const hi = cy + FADE;
-      if (lo > prev) stops.push(`black ${lo}px`);
-      stops.push(`transparent ${cy}px`);
-      stops.push(`black ${hi}px`);
-      prev = hi;
+      const fadeOutStart = cy - MARKER_R - PRE_FADE;  // where spine starts fading
+      const fadeOutEnd   = cy - MARKER_R;              // fully transparent by here
+      const fadeInStart  = cy + MARKER_R;              // starts returning after marker
+      const fadeInEnd    = cy + MARKER_R + POST_FADE;  // back to opaque
+      if (fadeOutStart > prev) stops.push(`black ${fadeOutStart}px`);
+      stops.push(`transparent ${fadeOutEnd}px`);
+      stops.push(`transparent ${fadeInStart}px`);
+      stops.push(`black ${fadeInEnd}px`);
+      prev = fadeInEnd;
     });
     stops.push('black 9999px');
     return `linear-gradient(to bottom, ${stops.join(', ')})`;

--- a/src/hooks/useTimelineScroll.js
+++ b/src/hooks/useTimelineScroll.js
@@ -6,6 +6,7 @@ export default function useTimelineScroll({
   selectedDate,
   isMobile, isTablet,
   mobileActiveTab,
+  mobileViewMode,
   viewMode = 'multi',
 }) {
   const [timelineScrolledAway, setTimelineScrolledAway] = useState(false);
@@ -50,12 +51,14 @@ export default function useTimelineScroll({
       if (calendarRef.current) calendarRef.current.scrollTop = 0;
       return;
     }
+    // On mobile, skip scroll-to-now when in list view (no time grid to scroll)
+    if (isMobile && mobileViewMode === 'list') return;
     const isToday = dateToString(selectedDate) === dateToString(new Date());
     if (isToday && calendarRef.current && (!isMobile || mobileActiveTab === 'timeline')) {
       const timerId = setTimeout(() => scrollToCurrentHour(false), 100);
       return () => clearTimeout(timerId);
     }
-  }, [selectedDate, isMobile, mobileActiveTab, scrollToCurrentHour, viewMode]);
+  }, [selectedDate, isMobile, mobileActiveTab, mobileViewMode, scrollToCurrentHour, viewMode]);
 
   // Detect when user scrolls away from current time (all form factors)
   useEffect(() => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Spine fade**: The list-view spine now fades to full transparency *before* touching each marker's edge (12px pre-fade), holds invisible through the 16px marker, then fades back in after — cleaner than the previous behaviour of fading through the marker centre
- **Grid scroll bug**: Switching from LIST → GRID now correctly scrolls the timeline to the current hour; `mobileViewMode` was missing from `useTimelineScroll`'s effect deps so the scroll-to-now never fired on view-mode switch
- **Refocus toast**: The "Refocus timeline" toast no longer lingers when switching to LIST view; added `!(isMobile && mobileViewMode === 'list')` to the toast condition

## Test plan

- [ ] LIST view: spine visually fades away before each task/routine/frame marker dot, with a clean gap, then reappears after
- [ ] Switch timeline from LIST → GRID — timeline should jump to the current hour, not 00:00
- [ ] While on GRID, scroll away from current time so the "Refocus timeline" toast appears, then switch to LIST — toast should disappear immediately

https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF)_