### PR TITLE
fix(mobile/list): inbox handle anchor, task card divider, hG card polish

### DIFF
--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -3,7 +3,7 @@ import React, {
   useMemo, useCallback,
 } from 'react';
 import {
-  Check, ChevronDown, ChevronLeft, ChevronRight, ChevronUp,
+  Check, ChevronDown, ChevronRight, ChevronUp,
   Clock, Edit2, ExternalLink, FileText, Inbox, SkipForward, Zap,
 } from 'lucide-react';
 import * as LucideIcons from 'lucide-react';
@@ -751,14 +751,19 @@ const MobileListView = () => {
     return () => clearTimeout(timer);
   }, [dateStr, isToday, calendarRef]);
 
-  // ── Keep inbox handle anchored to the top of the scroll container ──────────
+  // ── Keep inbox handle anchored to the bottom of the sticky header ──────────
+  // calendarRef's first child is the sticky header group (date row + optional
+  // "Now" banner). Measuring its bottom edge keeps the handle correctly aligned
+  // regardless of whether the banner is visible or not.
   useLayoutEffect(() => {
     const el = calendarRef?.current;
     if (!el) return;
-    const update = () => setInboxHandleTop(el.getBoundingClientRect().top);
+    const stickyHeader = el.firstElementChild;
+    if (!stickyHeader) return;
+    const update = () => setInboxHandleTop(stickyHeader.getBoundingClientRect().bottom);
     update();
     const ro = new ResizeObserver(update);
-    ro.observe(el);
+    ro.observe(stickyHeader);
     window.addEventListener('resize', update);
     return () => { ro.disconnect(); window.removeEventListener('resize', update); };
   }, [calendarRef]);
@@ -1126,7 +1131,6 @@ const MobileListView = () => {
             >
               <span className={textSecondary}>Inbox</span>
             </span>
-            <ChevronLeft size={11} className={textSecondary} style={{ opacity: 0.5 }} />
           </button>
         </div>
       )}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -21,7 +21,7 @@ const TIME_COL_W     = 56;   // w-14
 const CONNECTOR_W    = 16;   // half of spine col — reaches spine centre
 const TASK_H         = 72;
 const ROUTINE_H      = 38;
-const HG_SESSION_H   = 64;
+const HG_SESSION_H   = TASK_H;
 const ALLDAY_H       = 44;
 
 // ─── Spine colour gradient (orange→green→blue, 6 am→noon→6 pm) ───────────────
@@ -183,7 +183,6 @@ const TaskCard = React.memo(({
           style={{
             display: 'grid', gridTemplateColumns: '1fr 1fr', gridTemplateRows: '1fr 1fr',
             flexShrink: 0, alignSelf: 'stretch', width: 72,
-            borderLeft: `1px solid ${accentHex}22`,
           }}
         >
           {/* Notes */}
@@ -284,57 +283,59 @@ const HGSessionCard = React.memo(({
   };
   const barStyle = { width: 4, flexShrink: 0, background: accentHex, borderRadius: '6px 0 0 6px' };
 
-  const hgControl = isCompleted ? (
-    <span className="text-[9px] font-semibold opacity-50" style={{ color: accentHex }}>✓</span>
+  const hgButton = isCompleted ? (
+    <span className="text-[10px] font-semibold opacity-50" style={{ color: accentHex }}>✓</span>
   ) : canEnter ? (
     <button
       onClick={e => { e.stopPropagation(); enterHyperGlanceMode(project.id, date); }}
-      className="flex items-center gap-0.5 px-2 py-0.5 rounded-full text-white text-[9px] font-bold animate-pulse flex-shrink-0"
+      className="flex items-center gap-0.5 px-2 py-1 rounded-full text-white text-[10px] font-bold animate-pulse"
       style={{ background: accentHex }}
     >
-      <Zap size={8} />hyperGLANCE
+      <Zap size={10} />hG
     </button>
   ) : isOverdue ? (
     <button
       onClick={e => { e.stopPropagation(); enterHyperGlanceMode(project.id, date); }}
-      className="flex items-center gap-0.5 px-2 py-0.5 rounded-full text-white text-[9px] font-bold opacity-80 flex-shrink-0"
+      className="flex items-center gap-0.5 px-2 py-1 rounded-full text-white text-[10px] font-bold opacity-80"
       style={{ background: accentHex }}
     >
-      <Zap size={8} />Start
+      <Zap size={10} />Start
     </button>
   ) : (
-    <span className="text-[9px] font-bold opacity-30 flex-shrink-0" style={{ color: accentHex }}>hG</span>
+    <span className="text-[10px] font-bold opacity-30" style={{ color: accentHex }}>hG</span>
   );
 
   return (
     <div style={cardStyle}>
       <div style={barStyle} />
-      <div style={{ flex: 1, minWidth: 0, padding: '7px 6px 7px 10px', display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: 5 }}>
-        {/* Title row */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-          <IconComp size={13} style={{ color: accentHex, flexShrink: 0 }} />
+      {/* Left: icon + title, then time meta */}
+      <div style={{ flex: 1, minWidth: 0, padding: '7px 0 7px 8px', display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: 3 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <IconComp size={16} style={{ color: accentHex, flexShrink: 0 }} />
           <span
             className={`text-sm font-semibold flex-1 min-w-0 truncate ${isCompleted ? 'line-through opacity-60' : ''}`}
             style={{ color: accentHex }}
           >
             {project.title}
           </span>
-          <button
-            onClick={e => { e.stopPropagation(); setPendingEditProjectId(project.id); }}
-            className={`flex items-center justify-center rounded p-1 flex-shrink-0 transition-colors ${darkMode ? 'hover:bg-white/10' : 'hover:bg-black/10'}`}
-            title="Edit project"
-          >
-            <Edit2 size={12} style={{ color: accentHex, opacity: 0.7 }} />
-          </button>
         </div>
-        {/* Time + task count + hG control on one row */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
-          <span className={`text-[10px] leading-none ${textSecondary}`}>
-            {timeStr}
-            {taskLabel && <span className="ml-1.5">· {taskLabel}</span>}
-            {isOverdue && <span className="ml-1.5 text-orange-500 font-semibold">overdue</span>}
-          </span>
-          {hgControl}
+        <div className={`text-[10px] leading-none ${textSecondary}`}>
+          {timeStr}
+          {taskLabel && <span className="ml-1.5">· {taskLabel}</span>}
+          {isOverdue && <span className="ml-1.5 text-orange-500 font-semibold">overdue</span>}
+        </div>
+      </div>
+      {/* Right column: pencil (top) + hG control (bottom) — mirrors task card action grid */}
+      <div style={{ display: 'grid', gridTemplateRows: '1fr 1fr', flexShrink: 0, alignSelf: 'stretch', width: 72 }}>
+        <button
+          onClick={e => { e.stopPropagation(); setPendingEditProjectId(project.id); }}
+          className={`flex items-center justify-center transition-colors ${darkMode ? 'hover:bg-white/10 active:bg-white/20' : 'hover:bg-black/10 active:bg-black/15'}`}
+          title="Edit project"
+        >
+          <Edit2 size={14} style={{ color: accentHex, opacity: 0.7 }} />
+        </button>
+        <div className="flex items-center justify-center">
+          {hgButton}
         </div>
       </div>
     </div>
@@ -344,7 +345,7 @@ HGSessionCard.displayName = 'HGSessionCard';
 
 // ─── Row wrapper (3 columns) ──────────────────────────────────────────────────
 
-function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeight, accentHex, children, isNow, pageBg, onMarkerClick }) {
+function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeight, accentHex, children, isNow, pageBg, onMarkerClick, noConnector }) {
   return (
     <div style={{ display: 'flex', minHeight: cardHeight }}>
       {/* Col 1 — time */}
@@ -376,7 +377,7 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
 
       {/* Col 3 — card area */}
       <div style={{ flex: 1, minWidth: 0, position: 'relative', paddingRight: 8 }}>
-        {accentHex && <Connector colour={accentHex} />}
+        {accentHex && !noConnector && <Connector colour={accentHex} />}
         {children}
       </div>
     </div>
@@ -1032,6 +1033,7 @@ const MobileListView = () => {
                 cardHeight={HG_SESSION_H}
                 accentHex={accentHex}
                 pageBg={pageBg}
+                noConnector
               >
                 <div style={{ opacity: isPast && !item.isCompleted ? 0.5 : 1, marginTop: 4, marginBottom: 4 }}>
                   <HGSessionCard


### PR DESCRIPTION
## Summary

**Inbox handle anchor fix**
Previously measured `calendarRef.top` (the scroll container's top edge), which placed the handle down at the task-card level. Now observes `calendarRef.firstElementChild` — the sticky header group containing the "Now" banner and the date row — and tracks its `.bottom`. The handle stays flush below the date header and correctly adjusts when the "Now" banner appears/disappears. Also removed the collapse chevron from the handle.

**Task cards**
- Removed the faint accent-colour divider line between the text area and the action button grid

**hG session cards**
- Card height now matches tasks (`TASK_H = 72px`)
- Project icon enlarged to `size={16}` to match the visual scale of task spine markers
- Connector line suppressed (`noConnector` prop) so it doesn't cut through the bare Zap spine element
- Layout restructured to mirror task cards: left side = icon + title + time/meta (same padding/spacing); right side = 72px two-row column with **pencil** top (`Edit2 size={14}`) and **hG/Start button** bottom (`Zap size={10}`, `text-[10px]`) — consistent with the task action grid

## Test plan

- [ ] Inbox handle sits immediately below the "Fri, May 1" date header row (not at the task level); adjusts correctly when "Now" banner appears
- [ ] Task cards: no divider line between text and action buttons
- [ ] hG session cards: same height as task cards; larger project icon; no connector line stub; pencil top-right, hG/Start button bottom-right

https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF)_