### PR TITLE
fix(mobile/list): Zap connector line + inbox handle position

### DIFF
--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -93,7 +93,17 @@ function SpineMarker({ kind, completed, colour, pageBg }) {
   }
   if (kind === 'hg-session') {
     return (
-      <Zap size={14} strokeWidth={2.5} style={{ color: colour, opacity: completed ? 0.4 : 1, flexShrink: 0 }} />
+      <div style={{ ...base, overflow: 'visible' }}>
+        {/* Line extending right from icon centre to Col2/Col3 boundary */}
+        <div style={{
+          position: 'absolute', left: '50%', top: '50%', marginTop: -1,
+          width: CONNECTOR_W, height: 2, background: colour,
+          opacity: completed ? 0.4 : 1, zIndex: 1,
+        }} />
+        <Zap size={18} strokeWidth={2.5}
+          style={{ color: colour, opacity: completed ? 0.4 : 1, position: 'relative', zIndex: 2 }}
+        />
+      </div>
     );
   }
   if (kind === 'calendar-event') {
@@ -761,10 +771,13 @@ const MobileListView = () => {
     if (!el) return;
     const stickyHeader = el.firstElementChild;
     if (!stickyHeader) return;
-    const update = () => setInboxHandleTop(stickyHeader.getBoundingClientRect().bottom);
+    // Use container top + header offsetHeight — avoids sticky-positioning quirks
+    // in getBoundingClientRect() that caused incorrect viewport-relative values.
+    const update = () => setInboxHandleTop(el.getBoundingClientRect().top + stickyHeader.offsetHeight);
     update();
     const ro = new ResizeObserver(update);
     ro.observe(stickyHeader);
+    ro.observe(el);
     window.addEventListener('resize', update);
     return () => { ro.disconnect(); window.removeEventListener('resize', update); };
   }, [calendarRef]);


### PR DESCRIPTION
## Summary

- **Zap spine marker**: Increased from `size=14` to `size=18` (~25% bigger). Added a 2px horizontal line embedded in the `SpineMarker` element that extends `CONNECTOR_W` (16px) rightward from the icon centre to the Col2/Col3 boundary. The `Connector` component in Col3 (already suppressed via `noConnector` on hG session rows) is replaced by this embedded line — so the connection is now drawn as part of the spine marker itself, treating it the same as all other spine elements.

- **Inbox handle position**: Replaced `stickyHeader.getBoundingClientRect().bottom` with `el.getBoundingClientRect().top + stickyHeader.offsetHeight`. The previous approach was unreliable for sticky-positioned elements (reporting ~2× the expected viewport position). The new formula is scroll-invariant: scroll container's viewport top + header's intrinsic height. Also added the scroll container itself to the `ResizeObserver` watch list so any change to the container's position (e.g. tab bar resize) triggers a re-measure.

## Test plan

- [ ] hG session spine marker: Zap icon is visibly larger; horizontal line connects cleanly to the card's left connector
- [ ] Inbox collapsed handle: appears flush with the bottom of the "Fri, May 1" date header row, not overlapping task action buttons
- [ ] Inbox expanded panel: opens at the same anchored position
- [ ] Rotating device / resizing viewport: inbox handle re-anchors correctly

https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF)_