### PR TITLE
fix(mobile/list): connector gaps + inbox handle below header

### DIFF
--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -97,8 +97,8 @@ function SpineMarker({ kind, completed, colour, pageBg }) {
       <div style={{ ...base, overflow: 'visible' }}>
         {/* Line from icon right edge to Col2/Col3 boundary — avoids drawing through hollow icon */}
         <div style={{
-          position: 'absolute', left: '100%', top: '50%', marginTop: -1,
-          width: 8, height: 2, background: colour,
+          position: 'absolute', left: 'calc(100% - 4px)', top: '50%', marginTop: -1,
+          width: 12, height: 2, background: colour,
           opacity: completed ? 0.4 : 1, zIndex: 1,
         }} />
         <Zap size={20} strokeWidth={2.5}
@@ -493,14 +493,14 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
       <div style={{ width: SPINE_COL_W, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <div style={{ width: 16, height: 16, flexShrink: 0, position: 'relative', zIndex: 2, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'visible' }}>
           <div style={{
-            position: 'absolute', left: '100%', top: '50%', marginTop: -1,
-            width: 8, height: 2, background: '#ef4444', zIndex: 1,
+            position: 'absolute', left: 'calc(100% - 4px)', top: '50%', marginTop: -1,
+            width: 12, height: 2, background: '#ef4444', zIndex: 1,
           }} />
           <Clock size={20} strokeWidth={2} color="#ef4444" style={{ position: 'relative', zIndex: 2 }} />
         </div>
       </div>
-      {/* Countdown pill */}
-      <div style={{ flex: 1, minWidth: 0, paddingLeft: 4, paddingRight: 8 }}>
+      {/* Countdown pill — no left padding so pill border meets the connector line */}
+      <div style={{ flex: 1, minWidth: 0, paddingRight: 8 }}>
         <span
           className="text-xs font-medium px-2 py-0.5 rounded-full"
           style={{
@@ -1110,15 +1110,13 @@ const MobileListView = () => {
       {!inboxOpen && !inboxPinned && mobileDateHeaderRef?.current && ReactDOM.createPortal(
         <button
           onClick={() => {
-            // Capture panel top at the moment of opening — sticky header is
-            // guaranteed to be in its correct viewport position right now.
             inboxPanelTop.current = mobileDateHeaderRef.current?.getBoundingClientRect().bottom ?? 0;
             setInboxOpen(true);
           }}
-          className={`absolute right-0 inset-y-0 flex flex-col items-center justify-center gap-1 px-1.5 transition-colors z-50
-            ${darkMode ? 'bg-gray-700/90 hover:bg-gray-600 active:bg-gray-600' : 'bg-white/90 hover:bg-stone-50 active:bg-stone-100'}
-            border-l ${borderClass}`}
-          style={{ width: 32 }}
+          className={`absolute right-0 flex flex-col items-center justify-center gap-1 py-3 px-1.5 transition-colors z-50
+            ${darkMode ? 'bg-gray-700 hover:bg-gray-600 active:bg-gray-600' : 'bg-white hover:bg-stone-50 active:bg-stone-100'}
+            border-l border-b ${borderClass} rounded-bl-xl shadow-md`}
+          style={{ top: '100%', width: 32 }}
           title="Open inbox"
         >
           <Inbox size={14} className={textSecondary} />


### PR DESCRIPTION
## Summary

**Left-side gap (Zap + Clock):** Lucide icon strokes don't fill the full SVG bounding box, leaving a 2–3px gap between the visible icon edge and the connector line. Line moved to `left: 'calc(100% - 4px)'` with `width: 12` so it overlaps 4px into the icon container — the z-index 2 icon hides the overlap and the line appears flush with the visible stroke.

**Right-side gap (NowRow pill only):** `paddingLeft: 4` on the NowRow Col3 wrapper pushed the pill 4px right of where the connector ends. Removed the padding so the pill border starts exactly where the line terminates.

**Inbox handle:** Kept the portal into `mobileDateHeaderRef` for zero-drift anchoring, but changed from `inset-y-0` (filling the header) to `top: '100%'` so the button sits just below the date header row rather than overlapping it. Added `rounded-bl-xl` + bottom border to make it read as attached to the underside of the header.

## Test plan
- [ ] Zap spine marker: connector meets visible icon edge with no gap
- [ ] Clock (Now) marker: connector meets visible icon edge with no gap
- [ ] Now pill: pill left border meets connector with no gap
- [ ] Inbox handle: appears directly below "Fri, May 1" row, not blocking task buttons

https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF)_