### PR TITLE
feat(mobile/list): "Nothing left for today" empty state

### DIFF
--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -1153,6 +1153,14 @@ const MobileListView = () => {
         mobileDateHeaderRef.current
       )}
 
+      {/* Tap-outside backdrop — dismisses the expanded panel */}
+      {(inboxOpen || inboxPinned) && (
+        <div
+          style={{ position: 'fixed', inset: 0, zIndex: 39 }}
+          onClick={() => { setInboxOpen(false); setInboxPinned(false); }}
+        />
+      )}
+
       {/* Expanded panel — fixed to viewport; top captured at open time */}
       {(inboxOpen || inboxPinned) && (
         <div

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -956,8 +956,17 @@ const MobileListView = () => {
         {/* Empty state */}
         {visibleItems.length === 0 && (
           <div className={`flex flex-col items-center justify-center py-16 ${textSecondary}`}>
-            <p className="text-sm">No items scheduled</p>
-            {isToday && <p className="text-xs mt-1 opacity-60">Tap + to add a task</p>}
+            {isToday && pastItems.length > 0 ? (
+              <>
+                <p className="text-sm font-medium">Nothing left for today</p>
+                <p className="text-xs mt-1 opacity-60">All done — or tap + to add more</p>
+              </>
+            ) : (
+              <>
+                <p className="text-sm">No items scheduled</p>
+                {isToday && <p className="text-xs mt-1 opacity-60">Tap + to add a task</p>}
+              </>
+            )}
           </div>
         )}
 

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -149,7 +149,7 @@ function Connector({ colour }) {
 // ─── TaskCard ─────────────────────────────────────────────────────────────────
 
 const TaskCard = React.memo(({
-  item, accentHex, isCalendarEvent, darkMode, textPrimary, textSecondary,
+  item, accentHex, isCalendarEvent, isInProgress, darkMode, textPrimary, textSecondary,
   formatTime, minutesToTime, timeToMinutes,
   setExpandedNotesTaskId, postponeTask, moveToInbox, openMobileEditTask,
   dateStr,
@@ -172,8 +172,8 @@ const TaskCard = React.memo(({
 
   return (
     <div style={cardStyle}>
-      {/* Left colour bar */}
-      <div style={barStyle} />
+      {/* Left colour bar — pulses when item is currently in progress */}
+      <div style={barStyle} className={isInProgress ? 'animate-pulse' : undefined} />
       {/* Text content */}
       <div style={{ flex: 1, minWidth: 0, padding: '7px 0 7px 8px', display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: 3 }}>
         {/* Title */}
@@ -265,7 +265,7 @@ function RoutineChip({ routine, completed, onToggle, darkMode }) {
 // ─── HGSessionCard ────────────────────────────────────────────────────────────
 
 const HGSessionCard = React.memo(({
-  bar, accentHex, darkMode, textPrimary, textSecondary,
+  bar, accentHex, isInProgress, darkMode, textPrimary, textSecondary,
   formatTime, canEnter, incompleteTaskCount,
   enterHyperGlanceMode, setPendingEditProjectId,
 }) => {
@@ -318,7 +318,7 @@ const HGSessionCard = React.memo(({
 
   return (
     <div style={cardStyle}>
-      <div style={barStyle} />
+      <div style={barStyle} className={isInProgress ? 'animate-pulse' : undefined} />
       {/* Left: icon + title, then time meta */}
       <div style={{ flex: 1, minWidth: 0, padding: '7px 0 7px 8px', display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: 3 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
@@ -1035,10 +1035,13 @@ const MobileListView = () => {
               hg, currentTime,
             );
             const isPast = isItemPast(item);
+            const isInProgress = item.id === inProgressItem?.id;
+            const remainingMin = isInProgress ? Math.max(0, (startMin + (item.duration || 60)) - nowMin) : 0;
             return (
               <Row
                 key={seg.id}
-                timeLabel={formatTime(item.startTime)}
+                timeLabel={isInProgress ? `${remainingMin > 0 ? durLabel(remainingMin) : '<1m'} left` : formatTime(item.startTime)}
+                timeColour={isInProgress ? accentHex : undefined}
                 spineColour={sc}
                 spineStyle="solid"
                 marker={<SpineMarker kind="hg-session" colour={accentHex} completed={item.isCompleted} pageBg={pageBg} />}
@@ -1051,6 +1054,7 @@ const MobileListView = () => {
                   <HGSessionCard
                     bar={item}
                     accentHex={accentHex}
+                    isInProgress={isInProgress}
                     darkMode={darkMode}
                     textPrimary={textPrimary}
                     textSecondary={textSecondary}
@@ -1068,10 +1072,13 @@ const MobileListView = () => {
           // task or calendar-event
           const isCalendarEvent = item._kind === 'calendar-event';
           const isPast = isItemPast(item);
+          const isInProgress = item.id === inProgressItem?.id;
+          const remainingMin = isInProgress ? Math.max(0, (startMin + (item.duration || 30)) - nowMin) : 0;
           return (
             <Row
               key={seg.id}
-              timeLabel={formatTime(item.startTime)}
+              timeLabel={isInProgress ? `${remainingMin > 0 ? durLabel(remainingMin) : '<1m'} left` : formatTime(item.startTime)}
+              timeColour={isInProgress ? accentHex : undefined}
               spineColour={sc}
               spineStyle="solid"
               marker={
@@ -1092,6 +1099,7 @@ const MobileListView = () => {
                   item={item}
                   accentHex={accentHex}
                   isCalendarEvent={isCalendarEvent}
+                  isInProgress={isInProgress}
                   darkMode={darkMode}
                   textPrimary={textPrimary}
                   textSecondary={textSecondary}


### PR DESCRIPTION
When all items are in the past on today's view, the future list is empty and the generic "No items scheduled" message was misleading. Now shows "Nothing left for today / All done — or tap + to add more" in that specific case.

https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF)_