### PR TITLE
fix(mobile-list): stable drag + restore routine-overlap drop

### DIFF
--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -843,6 +843,15 @@ const MobileListView = () => {
   // Stop auto-scroll if component unmounts mid-drag
   useEffect(() => () => stopAutoScroll(), [stopAutoScroll]);
 
+  // Block native scroll during active list-item drag so the ghost and drop
+  // targets stay stable. Auto-scroll handles reaching off-screen targets.
+  useEffect(() => {
+    const handler = (e) => {
+      if (listDragRef.current.active) e.preventDefault();
+    };
+    document.addEventListener('touchmove', handler, { passive: false });
+    return () => document.removeEventListener('touchmove', handler);
+  }, []);
 
   // ── List-item drag handlers ────────────────────────────────────────────────
   const handleListItemTouchStart = useCallback((e, item) => {
@@ -894,9 +903,13 @@ const MobileListView = () => {
       const frac    = Math.max(0, Math.min(1, (t.clientY - rect.top) / rect.height));
       const rawMin  = fromMin + frac * (toMin - fromMin);
       const durMin  = state.item.duration || 30;
-      const snapped = getSnapMin(rawMin, durMin, state.ignoreRoutineId);
+      const isDraggingRoutine = state.item._kind === 'routine';
+      // Routines can overlap other routines — skip snap-away and conflict check
+      const snapped = isDraggingRoutine
+        ? Math.round(rawMin / 15) * 15
+        : getSnapMin(rawMin, durMin, state.ignoreRoutineId);
       setDragTargetMin(snapped);
-      setDragBlocked(isBlockedByRoutine(snapped, durMin, state.ignoreRoutineId));
+      setDragBlocked(!isDraggingRoutine && isBlockedByRoutine(snapped, durMin, state.ignoreRoutineId));
     } else {
       const itemEl = el?.closest('[data-item-startmin]');
       if (itemEl) {
@@ -904,9 +917,9 @@ const MobileListView = () => {
         setListDragTargetAllDay(false);
         const targetMin = parseInt(itemEl.dataset.itemStartmin, 10);
         const durMin = state.item.duration || 30;
-        const isRoutine = state.item._kind === 'routine';
+        const isDraggingRoutine = state.item._kind === 'routine';
         setDragTargetMin(targetMin);
-        setDragBlocked(isRoutine && isBlockedByRoutine(targetMin, durMin, state.ignoreRoutineId));
+        setDragBlocked(!isDraggingRoutine && isBlockedByRoutine(targetMin, durMin, state.ignoreRoutineId));
       } else {
         // Check all-day drop zone — only for non-allday tasks and routines
         const allDayEl = el?.closest('[data-allday-drop]');


### PR DESCRIPTION
## Summary

Two fixes in one commit:

**1. Stable drag (no more wobble)**
Adds a non-passive `document` touchmove listener that calls `e.preventDefault()` only when `listDragRef.current.active` is true. This stops native scroll from competing with the drag ghost, so the drop-target indicator stays rock-solid as the finger moves. The edge auto-scroll loop (±80px from container edge → up to 14px/frame) still handles reaching off-screen drop targets including the all-day section.

**2. Routine-overlap fix (re-applied)**
The fix from #708 was silently dropped during conflict resolution — `develop` still had the old conditions. Re-applied: routines now skip the `getSnapMin` snap-away and the `isBlockedByRoutine` block check; `!isDraggingRoutine` gates both checks so only tasks/hG sessions are blocked from routine slots.

## Test plan

- [ ] Long-press a list item → drag ghost appears, finger movement does NOT scroll the list
- [ ] Drag finger to within 80px of screen bottom → list auto-scrolls down smoothly
- [ ] Drag finger to within 80px of screen top → list auto-scrolls up, all-day zone becomes reachable
- [ ] Drop at a gap → lands at the correct snapped time, no jitter
- [ ] Drag a routine → green indicator even over a routine-occupied slot; drop merges into side-by-side row
- [ ] Drag a task → red "Blocked" indicator over a routine-occupied slot, snaps away

https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF)_