### PR TITLE
fix(mobile-list): vertically center text in AllDayTaskPill

### DIFF
--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -587,7 +587,7 @@ function AllDayTaskPill({ item, accentHex, textPrimary, toggleComplete }) {
       <div style={{ width: 4, flexShrink: 0, background: accentHex }} />
       <span
         className={`text-[11px] font-medium truncate ${textPrimary} ${item.completed ? 'line-through opacity-50' : ''}`}
-        style={{ padding: '0 8px 0 5px', lineHeight: '26px', maxWidth: 164 }}
+        style={{ padding: '0 8px 0 5px', maxWidth: 164, display: 'flex', alignItems: 'center' }}
       >
         {item.title}
       </span>


### PR DESCRIPTION
## Summary

Switches the pill's text span from `lineHeight: '26px'` to `display: flex; alignItems: center` so the label is properly vertically centered regardless of font rendering.

https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJ3AJu5f1hxAA4EFJkW1xF)_