### PR TITLE
Add View default setting under App Settings for mobile

### DIFF
--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -42,6 +42,7 @@ const MobileSettingsPanel = () => {
     cardBg, borderClass, textPrimary, textSecondary, hoverBg, colors,
     formatTime,
     toggleSettingsSection,
+    mobileViewMode, setMobileViewMode,
   } = useDayPlannerCtx();
   const {
     obsidianVaultHandleRef,
@@ -299,6 +300,32 @@ const MobileSettingsPanel = () => {
         <ChevronLeft size={18} />
         <span className="text-sm font-medium">Settings</span>
       </button>
+
+      {/* View default */}
+      <div className="space-y-2">
+        <div className={`font-medium ${textPrimary} flex items-center gap-2`}>
+          <LayoutGrid size={16} className={textSecondary} />
+          View default
+        </div>
+        <p className={`text-xs ${textSecondary}`}>Default view for the Timeline tab</p>
+        <div className="flex gap-2">
+          {['grid', 'list'].map(mode => (
+            <button
+              key={mode}
+              onClick={() => setMobileViewMode(mode)}
+              className={`flex-1 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                mobileViewMode === mode
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : `${darkMode ? 'bg-gray-700 border-gray-600' : 'bg-white border-stone-300'} ${textPrimary}`
+              }`}
+            >
+              {mode === 'grid' ? 'GRID' : 'LIST'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <hr className={borderClass} />
 
       {/* Calendar Sync */}
       <div className="space-y-3">


### PR DESCRIPTION
Adds a GRID / LIST toggle in the App Settings sub-view so users can explicitly set their preferred default view for the Timeline tab. The setting maps directly to the existing mobileViewMode state which already persists to localStorage.

https://claude.ai/code/session_012mSZvrqwe4yDTL88pWn7be