### PR TITLE
Enlarge goal rings; navigate to specific goal on tap

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -256,6 +256,7 @@ const DayPlanner = () => {
     const saved = localStorage.getItem('day-planner-glance-page');
     return saved !== null ? parseInt(saved, 10) : 0;
   });
+  const [goalsDashboardFocusId, setGoalsDashboardFocusId] = useState(null);
   const [weekViewMode, setWeekViewMode] = useState(() => {
     const saved = localStorage.getItem('day-planner-week-view-mode');
     return saved ? JSON.parse(saved) : 'strict';
@@ -7590,6 +7591,7 @@ const DayPlanner = () => {
     goals, setGoals,
     projects, setProjects,
     showGoalsDashboard, setShowGoalsDashboard,
+    goalsDashboardFocusId, setGoalsDashboardFocusId,
     goalsProjectsEnabled, setGoalsProjectsEnabled,
     addGoal, updateGoal, deleteGoal,
     addProject, updateProject, deleteProject, moveProject,

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -97,6 +97,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     openRoutinesDashboard,
     enterHyperGlanceMode,
     showGoalsDashboard, setShowGoalsDashboard,
+    goalsDashboardFocusId, setGoalsDashboardFocusId,
     glancePage, setGlancePage,
     getFrameInstancesForDate,
     computeAvailableSlots,
@@ -387,7 +388,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                   progressPct={g.progressPct}
                   daysLeft={g.daysLeft}
                   darkMode={darkMode}
-                  onClick={() => setShowGoalsDashboard(true)}
+                  onClick={() => { setGoalsDashboardFocusId(g.id); setShowGoalsDashboard(true); }}
                 />
               ))}
               {activeGoalsList.length > 4 && (

--- a/src/components/GoalRing.jsx
+++ b/src/components/GoalRing.jsx
@@ -6,11 +6,11 @@ const GoalRing = ({ goal, progressPct, daysLeft, darkMode, onClick }) => {
     ? goal.color
     : (TAILWIND_TO_HEX[goal.color] || '#3b82f6');
 
-  const size = 36;
+  const size = 44;
   const radius = size * 0.38;
   const circumference = 2 * Math.PI * radius;
   const center = size / 2;
-  const strokeWidth = 3;
+  const strokeWidth = 3.5;
   const dashOffset = circumference * (1 - Math.min(progressPct / 100, 1));
 
   const urgencyColor = daysLeft !== null && daysLeft <= 0 ? '#ef4444'

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -72,6 +72,7 @@ const MobileGlanceSection = () => {
     tagFilterBtnRef,
     goToDate, scrollToHour,
     showGoalsDashboard, setShowGoalsDashboard,
+    goalsDashboardFocusId, setGoalsDashboardFocusId,
     glancePage, setGlancePage,
   } = useDayPlannerCtx();
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
@@ -309,7 +310,7 @@ const MobileGlanceSection = () => {
                   progressPct={g.progressPct}
                   daysLeft={g.daysLeft}
                   darkMode={darkMode}
-                  onClick={() => setShowGoalsDashboard(true)}
+                  onClick={() => { setGoalsDashboardFocusId(g.id); setMobileActiveTab('goals'); }}
                 />
               ))}
               {activeGoalsList.length > 4 && (

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -852,7 +852,7 @@ const DesktopDashboard = ({
   goalCardRefs,
   projectCardRefs,
 }) => {
-  const { darkMode, textPrimary, textSecondary, borderClass, hoverBg } = useDayPlannerCtx();
+  const { darkMode, textPrimary, textSecondary, borderClass, hoverBg, goalsDashboardFocusId, setGoalsDashboardFocusId } = useDayPlannerCtx();
   const { moveProject } = useFeaturesCtx();
 
   const containerRef = useRef(null);
@@ -885,6 +885,13 @@ const DesktopDashboard = ({
   const [activeGoalIdx, setActiveGoalIdx] = useState(
     () => findDefaultActiveIdx(sortedGoals)
   );
+
+  useEffect(() => {
+    if (!goalsDashboardFocusId) return;
+    const idx = sortedGoals.findIndex(g => g.id === goalsDashboardFocusId);
+    if (idx !== -1) setActiveGoalIdx(idx);
+    setGoalsDashboardFocusId(null);
+  }, [goalsDashboardFocusId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Clamp index whenever the goals list changes length
   const safeIdx = sortedGoals.length > 0
@@ -1332,7 +1339,7 @@ const MobileDashboard = ({
   onNewProject,
   isActive = false,
 }) => {
-  const { darkMode, textPrimary, textSecondary, hoverBg, cardBg, borderClass, tasks: scheduledTasks, unscheduledTasks } = useDayPlannerCtx();
+  const { darkMode, textPrimary, textSecondary, hoverBg, cardBg, borderClass, tasks: scheduledTasks, unscheduledTasks, goalsDashboardFocusId, setGoalsDashboardFocusId } = useDayPlannerCtx();
   const { updateGoal, moveProject } = useFeaturesCtx();
 
   const scrollRef = useRef(null);
@@ -1361,6 +1368,16 @@ const MobileDashboard = ({
   const totalPagesRef = useRef(totalPages);
   useEffect(() => { totalPagesRef.current = totalPages; }, [totalPages]);
   useEffect(() => { pageRef.current = page; }, [page]);
+
+  useEffect(() => {
+    if (!goalsDashboardFocusId || !isActive) return;
+    const idx = sortedGoals.findIndex(g => g.id === goalsDashboardFocusId);
+    if (idx !== -1) {
+      setPage(idx);
+      requestAnimationFrame(() => goToPage(idx));
+    }
+    setGoalsDashboardFocusId(null);
+  }, [goalsDashboardFocusId, isActive]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Scroll to the main goal on mount (instant, no animation)
   useLayoutEffect(() => {


### PR DESCRIPTION
Increases GoalRing arc from 36px to 44px (text stays at 9px).

Tapping a goal row now navigates directly to that goal:
- Desktop/tablet: opens Goals dashboard with that goal selected in carousel
- Mobile: switches to Goals tab with that goal scrolled into view

Implemented via goalsDashboardFocusId context state consumed by both DesktopDashboard and MobileGoalDashboard on open/activation.

https://claude.ai/code/session_012mSZvrqwe4yDTL88pWn7be