### PR TITLE
Fix context wiring for glancePage and goalsDashboardFocusId

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -66,6 +66,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     setInboxProjectFilter, setInboxPriorityFilter, setHideCompletedInbox,
     setHideProjectTasksInbox, setHideStandaloneTasksInbox,
     goToDate, scrollToHour, effectiveViewMode,
+    glancePage, setGlancePage,
   } = useDayPlannerCtx();
   const {
     habitLongPressTimer,
@@ -98,7 +99,6 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     enterHyperGlanceMode,
     showGoalsDashboard, setShowGoalsDashboard,
     goalsDashboardFocusId, setGoalsDashboardFocusId,
-    glancePage, setGlancePage,
     getFrameInstancesForDate,
     computeAvailableSlots,
     showVoiceInput, setShowVoiceInput,
@@ -372,14 +372,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
 
         {/* Goals page */}
         {hasGoals && (!showCarousel || effectivePage === 1) && (
-          <div className="relative pr-5">
-            <button
-              onClick={() => setShowGoalsDashboard(true)}
-              className={`absolute top-0 right-0 p-1 rounded ${hoverBg} ${darkMode ? 'text-gray-700' : 'text-stone-300'} transition-colors z-10`}
-              title="Manage goals"
-            >
-              <Settings size={11} />
-            </button>
+          <div>
             <div className="flex flex-col gap-2">
               {activeGoalsList.slice(0, 4).map(g => (
                 <GoalRing

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -71,8 +71,6 @@ const MobileGlanceSection = () => {
     updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
     tagFilterBtnRef,
     goToDate, scrollToHour,
-    showGoalsDashboard, setShowGoalsDashboard,
-    goalsDashboardFocusId, setGoalsDashboardFocusId,
     glancePage, setGlancePage,
   } = useDayPlannerCtx();
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
@@ -102,6 +100,8 @@ const MobileGlanceSection = () => {
     editingFrame, setEditingFrame,
     goals, goalsProjectsEnabled, projects,
     projectFilter, setProjectFilter,
+    showGoalsDashboard, setShowGoalsDashboard,
+    goalsDashboardFocusId, setGoalsDashboardFocusId,
     focusModeAvailable, enterFocusMode,
     getTodayHabitCount, incrementHabit, setHabitCount,
     generateFrameNudge, generateMorningSummary, generateEveningReflection,
@@ -294,14 +294,7 @@ const MobileGlanceSection = () => {
 
         {/* Goals page */}
         {hasGoals && (!showCarousel || effectivePage === 1) && (
-          <div className="relative pr-5">
-            <button
-              onClick={() => setShowGoalsDashboard(true)}
-              className={`absolute top-0 right-0 p-1 rounded ${hoverBg} ${darkMode ? 'text-gray-700' : 'text-stone-300'} transition-colors z-10`}
-              title="Manage goals"
-            >
-              <Settings size={11} />
-            </button>
+          <div>
             <div className="flex flex-col gap-2">
               {activeGoalsList.slice(0, 4).map(g => (
                 <GoalRing

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -852,8 +852,8 @@ const DesktopDashboard = ({
   goalCardRefs,
   projectCardRefs,
 }) => {
-  const { darkMode, textPrimary, textSecondary, borderClass, hoverBg, goalsDashboardFocusId, setGoalsDashboardFocusId } = useDayPlannerCtx();
-  const { moveProject } = useFeaturesCtx();
+  const { darkMode, textPrimary, textSecondary, borderClass, hoverBg } = useDayPlannerCtx();
+  const { moveProject, goalsDashboardFocusId, setGoalsDashboardFocusId } = useFeaturesCtx();
 
   const containerRef = useRef(null);
   const [svgLines, setSvgLines] = useState([]);
@@ -1339,8 +1339,8 @@ const MobileDashboard = ({
   onNewProject,
   isActive = false,
 }) => {
-  const { darkMode, textPrimary, textSecondary, hoverBg, cardBg, borderClass, tasks: scheduledTasks, unscheduledTasks, goalsDashboardFocusId, setGoalsDashboardFocusId } = useDayPlannerCtx();
-  const { updateGoal, moveProject } = useFeaturesCtx();
+  const { darkMode, textPrimary, textSecondary, hoverBg, cardBg, borderClass, tasks: scheduledTasks, unscheduledTasks } = useDayPlannerCtx();
+  const { updateGoal, moveProject, goalsDashboardFocusId, setGoalsDashboardFocusId } = useFeaturesCtx();
 
   const scrollRef = useRef(null);
   const swipeRef = useRef(null); // { startX, startY, locked }


### PR DESCRIPTION
glancePage/setGlancePage live in DayPlannerCtx (ctx) but were being read from useFeaturesCtx in GlanceSidebar — moved to the correct context.

showGoalsDashboard/setShowGoalsDashboard and goalsDashboardFocusId/ setGoalsDashboardFocusId live in FeaturesCtx but were being read from useDayPlannerCtx in MobileGlanceSection and GoalDashboard sub-components — moved to useFeaturesCtx in all three files.

Also removes the redundant settings gear icon from the goals carousel page.

https://claude.ai/code/session_012mSZvrqwe4yDTL88pWn7be