### PR TITLE
Fix focus timer notification: countdown direction, button actions, hy…

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -199,27 +199,33 @@ class NativeBridge(
     /**
      * Posts or updates the persistent focus timer notification.
      *
-     * When running: [isPaused] = false, [endEpochMillis] = System.currentTimeMillis() + remainingMs.
-     * Android displays a live native countdown (setChronometerCountDown) — no JS ticking needed.
+     * [remainingSeconds] is passed as an Int (avoiding JS→Java Long precision issues).
+     * Kotlin computes endEpochMillis = System.currentTimeMillis() + remainingSeconds * 1000L
+     * and uses the native chronometer (setChronometerCountDown) for a live countdown.
      *
-     * When paused: [isPaused] = true, [pausedRemainingSeconds] = seconds left at pause time.
-     * Android displays a static "MM:SS remaining · Paused" string.
+     * When paused: shows static "MM:SS remaining · Paused" text.
      *
-     * Action buttons (Pause/Resume, Stop) write a pendingFocusAction to SharedPreferences and
-     * bring the app to the foreground. JS reads it via getPendingAction() on the next
-     * visibilitychange event.
+     * Action buttons write a pendingFocusAction to SharedPreferences. JS reads it
+     * via getFocusPendingAction() polling every ~500 ms.
      */
     @JavascriptInterface
-    fun showFocusTimerNotification(
-        phase: String,
-        endEpochMillis: Long,
-        isPaused: Boolean,
-        pausedRemainingSeconds: Int,
-    ) = notifications.showFocusTimerNotification(phase, endEpochMillis, isPaused, pausedRemainingSeconds)
+    fun showFocusTimerNotification(phase: String, remainingSeconds: Int, isPaused: Boolean) =
+        notifications.showFocusTimerNotification(phase, remainingSeconds, isPaused)
 
     /** Cancels the focus timer notification. Call when the session ends or is dismissed. */
     @JavascriptInterface
     fun dismissFocusTimerNotification() = notifications.dismissFocusTimerNotification()
+
+    /**
+     * Returns and clears any pending focus timer action from a notification button tap.
+     * Returns "focus-pause" | "focus-resume" | "focus-stop", or "" if none pending.
+     *
+     * Called by JS at ~500 ms intervals while a focus session is active so that
+     * notification button taps are picked up even when the app is already in the
+     * foreground (visibilitychange doesn't fire in that case).
+     */
+    @JavascriptInterface
+    fun getFocusPendingAction(): String = notifications.getFocusPendingAction()
 
     // ── Widget snapshot ──────────────────────────────────────────────────────
 

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
@@ -324,37 +324,29 @@ class NotificationBridge(private val context: Context) {
 
     /**
      * Posts or updates the persistent focus timer notification shown in the
-     * notification drawer while a Pomodoro session is active.
+     * notification drawer while a Pomodoro / hyperGLANCE session is active.
      *
-     * When running ([isPaused] = false): uses Android's native chronometer
-     * (setWhen + setChronometerCountDown) so the countdown ticks without any
-     * JS involvement.
+     * Uses Android's native chronometer (setWhen + setChronometerCountDown) so
+     * the countdown ticks independently of the JS layer — the WebView timer
+     * can be throttled when backgrounded, but this notification keeps ticking.
      *
-     * When paused ([isPaused] = true): shows a static "MM:SS remaining · Paused"
-     * content text derived from [pausedRemainingSeconds].
+     * [remainingSeconds] is used to compute setWhen(now + remainingMs), avoiding
+     * any JS→Java Long precision issues with epoch-millisecond values.
      *
-     * Action buttons write a pendingFocusAction to SharedDataStore and bring the
-     * app to the foreground. JS reads the action on the next visibilitychange
-     * and updates timer state, which triggers another call here to refresh
-     * the notification.
+     * When paused: shows static "MM:SS remaining · Paused" text.
      *
-     * @param phase                 "work" | "shortBreak" | "longBreak"
-     * @param endEpochMillis        System.currentTimeMillis() when the phase ends
-     *                              (ignored when isPaused = true)
-     * @param isPaused              true while the timer is paused
-     * @param pausedRemainingSeconds seconds remaining at the moment of pause
-     *                              (ignored when isPaused = false)
+     * Action buttons (Pause/Resume, Stop) write a pendingFocusAction and bring
+     * the app to the foreground. JS reads it via getFocusPendingAction() polling.
+     *
+     * @param phase            "work" | "shortBreak" | "longBreak"
+     * @param remainingSeconds seconds left in the current phase
+     * @param isPaused         true while the timer is paused
      */
-    fun showFocusTimerNotification(
-        phase: String,
-        endEpochMillis: Long,
-        isPaused: Boolean,
-        pausedRemainingSeconds: Int,
-    ) {
+    fun showFocusTimerNotification(phase: String, remainingSeconds: Int, isPaused: Boolean) {
         val phaseLabel = when (phase) {
             "shortBreak" -> "Short Break"
-            "longBreak" -> "Long Break"
-            else -> "Focus"
+            "longBreak"  -> "Long Break"
+            else         -> "Focus"
         }
 
         val builder = NotificationCompat.Builder(context, DayGlanceApplication.CHANNEL_FOCUS)
@@ -368,18 +360,21 @@ class NotificationBridge(private val context: Context) {
             .setContentIntent(tapPendingIntent())
 
         if (isPaused) {
-            val mm = pausedRemainingSeconds / 60
-            val ss = pausedRemainingSeconds % 60
-            builder.setContentText("%02d:%02d remaining · Paused".format(mm, ss))
-            builder.addAction(0, "Resume", focusActionPendingIntent(
-                NotificationActionReceiver.ACTION_FOCUS_RESUME, FOCUS_RESUME_REQUEST))
+            val mm = remainingSeconds / 60
+            val ss = remainingSeconds % 60
+            builder
+                .setContentText("%02d:%02d remaining · Paused".format(mm, ss))
+                .addAction(0, "Resume", focusActionPendingIntent(
+                    NotificationActionReceiver.ACTION_FOCUS_RESUME, FOCUS_RESUME_REQUEST))
         } else {
-            builder.setWhen(endEpochMillis)
-            builder.setUsesChronometer(true)
-            builder.setChronometerCountDown(true)
-            builder.setContentText("In progress")
-            builder.addAction(0, "Pause", focusActionPendingIntent(
-                NotificationActionReceiver.ACTION_FOCUS_PAUSE, FOCUS_PAUSE_REQUEST))
+            val endAtMillis = System.currentTimeMillis() + remainingSeconds * 1000L
+            builder
+                .setWhen(endAtMillis)
+                .setUsesChronometer(true)
+                .setChronometerCountDown(true)
+                .setContentText("In progress")
+                .addAction(0, "Pause", focusActionPendingIntent(
+                    NotificationActionReceiver.ACTION_FOCUS_PAUSE, FOCUS_PAUSE_REQUEST))
         }
 
         builder.addAction(0, "Stop", focusActionPendingIntent(
@@ -395,6 +390,20 @@ class NotificationBridge(private val context: Context) {
             val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             nm.cancel(NOTIF_ID_FOCUS_TIMER)
         } catch (_: Throwable) { }
+    }
+
+    /**
+     * Returns and clears any pending focus action written by a notification
+     * button tap ("focus-pause" | "focus-resume" | "focus-stop"), or "" if none.
+     *
+     * Called by JS polling every ~500 ms while a focus session is active so that
+     * notification button taps are picked up even when the app is already in the
+     * foreground (visibilitychange doesn't fire in that case).
+     */
+    fun getFocusPendingAction(): String {
+        val action = dataStore.pendingFocusAction ?: return ""
+        dataStore.pendingFocusAction = null
+        return action
     }
 
     private fun focusActionPendingIntent(action: String, requestCode: Int): PendingIntent {

--- a/src/components/HyperGlanceModeModal.jsx
+++ b/src/components/HyperGlanceModeModal.jsx
@@ -7,7 +7,7 @@ import { useSyncCtx } from '../context/SyncContext.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
 import { extractWikilinks, stripWikilinks } from '../utils/taskUtils.js';
 import { hexToRgba } from '../utils/colorUtils.js';
-import { isNativeAndroid, nativeIsDndPermissionGranted, nativeRequestDndPermission } from '../native.js';
+import { isNativeAndroid, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeShowFocusTimerNotification, nativeDismissFocusTimerNotification, nativeGetFocusPendingAction } from '../native.js';
 
 const HyperGlanceModeModal = () => {
   const {
@@ -82,6 +82,32 @@ const HyperGlanceModeModal = () => {
     }
     prevPhaseRef.current = hgTimerPhase;
   }, [hgTimerPhase]);
+
+  // Sync the Android notification center with hyperGLANCE timer state.
+  useEffect(() => {
+    if (!isNativeAndroid()) return;
+    if (hgShowSettings) {
+      nativeDismissFocusTimerNotification();
+      return;
+    }
+    nativeShowFocusTimerNotification(hgTimerPhase, hgTimerSeconds, !hgTimerRunning);
+  }, [hgTimerRunning, hgTimerPhase, hgShowSettings, hgTimerSeconds]);
+
+  // Dismiss notification when this modal unmounts (session ended / exited).
+  useEffect(() => () => { if (isNativeAndroid()) nativeDismissFocusTimerNotification(); }, []);
+
+  // Poll for notification button taps (Pause / Resume / Stop) while session is active.
+  useEffect(() => {
+    if (!isNativeAndroid() || hgShowSettings) return;
+    const interval = setInterval(() => {
+      const action = nativeGetFocusPendingAction();
+      if (!action) return;
+      if (action === 'focus-pause') setHgTimerRunning(false);
+      else if (action === 'focus-resume') setHgTimerRunning(true);
+      else if (action === 'focus-stop') exitHyperGlanceMode();
+    }, 500);
+    return () => clearInterval(interval);
+  }, [hgShowSettings]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Timer countdown — supports work / shortBreak / longBreak phases
   useEffect(() => {

--- a/src/hooks/useFocusMode.js
+++ b/src/hooks/useFocusMode.js
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { isNativeAndroid, nativeShowFocusTimerNotification, nativeDismissFocusTimerNotification } from '../native.js';
+import { isNativeAndroid, nativeShowFocusTimerNotification, nativeDismissFocusTimerNotification, nativeGetFocusPendingAction } from '../native.js';
 
 const useFocusMode = () => {
   const [showFocusMode, setShowFocusMode] = useState(false);
@@ -53,27 +53,33 @@ const useFocusMode = () => {
     }
   }, [focusTimerSeconds, showFocusMode, focusTimerRunning, focusShowSettings]);
 
-  // Keep a ref to the current remaining seconds so the notification effect can
-  // read it without needing to depend on it (we don't want to re-fire every tick).
-  const focusTimerSecondsRef = useRef(focusTimerSeconds);
-  useEffect(() => { focusTimerSecondsRef.current = focusTimerSeconds; }, [focusTimerSeconds]);
-
-  // Sync the Android notification center with the timer state on every meaningful
-  // transition: start, pause, resume, phase change, and session end.
-  // The countdown itself is rendered natively (setChronometerCountDown) — no per-second JS calls.
+  // Sync the Android notification center with timer state.
+  // focusTimerSeconds is included in deps so Kotlin always gets a fresh remainingSeconds
+  // to compute setWhen(now + remainingMs) — keeping the native chronometer accurate even
+  // if there's any small JS/native clock drift.
   useEffect(() => {
     if (!isNativeAndroid()) return;
     if (!showFocusMode || focusShowSettings || focusShowStats) {
       nativeDismissFocusTimerNotification();
       return;
     }
-    const remaining = focusTimerSecondsRef.current;
-    if (focusTimerRunning) {
-      nativeShowFocusTimerNotification(focusPhase, Date.now() + remaining * 1000, false, 0);
-    } else {
-      nativeShowFocusTimerNotification(focusPhase, 0, true, remaining);
-    }
-  }, [showFocusMode, focusTimerRunning, focusPhase, focusShowSettings, focusShowStats]);
+    nativeShowFocusTimerNotification(focusPhase, focusTimerSeconds, !focusTimerRunning);
+  }, [showFocusMode, focusTimerRunning, focusPhase, focusShowSettings, focusShowStats, focusTimerSeconds]);
+
+  // Poll for notification button actions while a focus session is active.
+  // visibilitychange doesn't fire when the app is already in the foreground, so polling
+  // is needed to pick up Pause / Resume / Stop taps promptly.
+  useEffect(() => {
+    if (!isNativeAndroid() || !showFocusMode || focusShowSettings || focusShowStats) return;
+    const interval = setInterval(() => {
+      const action = nativeGetFocusPendingAction();
+      if (!action) return;
+      if (action === 'focus-pause') setFocusTimerRunning(false);
+      else if (action === 'focus-resume') setFocusTimerRunning(true);
+      else if (action === 'focus-stop') exitFocusModeRef.current?.(false);
+    }, 500);
+    return () => clearInterval(interval);
+  }, [showFocusMode, focusShowSettings, focusShowStats]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     showFocusMode, setShowFocusMode,

--- a/src/native.js
+++ b/src/native.js
@@ -447,18 +447,18 @@ export const nativeRequestDndPermission = () => {
 
 /**
  * Posts or updates the persistent focus timer notification in the Android
- * notification drawer. The countdown is handled natively (setChronometerCountDown)
- * so this only needs to be called on state transitions, not every tick.
+ * notification drawer. Kotlin computes endEpochMillis from [remainingSeconds]
+ * to avoid JS→Java Long precision issues. The countdown is handled natively
+ * (setChronometerCountDown) so it ticks even when the WebView is backgrounded.
  *
- * @param phase                 "work" | "shortBreak" | "longBreak"
- * @param endEpochMillis        Date.now() + remainingMs (ignored when isPaused)
- * @param isPaused              true while the timer is paused
- * @param pausedRemainingSeconds seconds left at pause time (ignored when running)
+ * @param phase            "work" | "shortBreak" | "longBreak"
+ * @param remainingSeconds seconds remaining in the current phase
+ * @param isPaused         true while the timer is paused
  */
-export const nativeShowFocusTimerNotification = (phase, endEpochMillis, isPaused, pausedRemainingSeconds) => {
+export const nativeShowFocusTimerNotification = (phase, remainingSeconds, isPaused) => {
   const bridge = nativeBridge();
   if (!bridge?.showFocusTimerNotification) return;
-  bridge.showFocusTimerNotification(phase, endEpochMillis, isPaused, pausedRemainingSeconds);
+  bridge.showFocusTimerNotification(phase, remainingSeconds, isPaused);
 };
 
 /** Cancels the focus timer notification. Call when the session ends or is dismissed. */
@@ -466,6 +466,21 @@ export const nativeDismissFocusTimerNotification = () => {
   const bridge = nativeBridge();
   if (!bridge?.dismissFocusTimerNotification) return;
   bridge.dismissFocusTimerNotification();
+};
+
+/**
+ * Returns and clears any pending focus action from a notification button tap:
+ * "focus-pause" | "focus-resume" | "focus-stop", or null if none pending.
+ *
+ * Poll this at ~500 ms while a focus session is active. Notification button
+ * taps won't trigger visibilitychange when the app is already in the foreground,
+ * so polling is the only way to pick them up promptly.
+ */
+export const nativeGetFocusPendingAction = () => {
+  const bridge = nativeBridge();
+  if (!bridge?.getFocusPendingAction) return null;
+  const raw = bridge.getFocusPendingAction();
+  return raw || null;
 };
 
 export const nativeShareFile = (filename, content) => {


### PR DESCRIPTION
…perGLANCE

Three bugs fixed, one feature added:

Countdown direction: The previous impl passed endEpochMillis as a Long from JS, which can lose precision crossing the JS→Java bridge. Now JS passes remainingSeconds (Int) and Kotlin computes System.currentTimeMillis() + remainingSeconds * 1000L locally — no precision risk, chronometer counts down correctly.

Pause/Stop buttons: visibilitychange doesn't fire when the app is already in the foreground. Added getFocusPendingAction() bridge method (reads only the focus-specific pendingFocusAction key) and a 500 ms polling interval in useFocusMode.js and HyperGlanceModeModal.jsx so button taps are picked up promptly regardless of foreground/background state.

focusTimerSeconds in notification deps: Kotlin gets a fresh remainingSeconds on every tick, keeping the native chronometer's setWhen accurate.

hyperGLANCE: Added identical notification sync + polling effects to HyperGlanceModeModal.jsx, plus a cleanup effect that dismisses the notification when the modal unmounts.

https://claude.ai/code/session_012mSZvrqwe4yDTL88pWn7be