### PR TITLE
Fix notification flicker and position instability

### DIFF
--- a/src/components/HyperGlanceModeModal.jsx
+++ b/src/components/HyperGlanceModeModal.jsx
@@ -83,15 +83,20 @@ const HyperGlanceModeModal = () => {
     prevPhaseRef.current = hgTimerPhase;
   }, [hgTimerPhase]);
 
-  // Sync the Android notification center with hyperGLANCE timer state.
+  // Ref so the notification effect can read current seconds without depending on them —
+  // only fire on meaningful transitions, not every tick (which resets the chronometer).
+  const hgTimerSecondsRef = useRef(hgTimerSeconds);
+  useEffect(() => { hgTimerSecondsRef.current = hgTimerSeconds; }, [hgTimerSeconds]);
+
+  // Sync the Android notification on state transitions only (start, pause, resume, phase change).
   useEffect(() => {
     if (!isNativeAndroid()) return;
     if (hgShowSettings) {
       nativeDismissFocusTimerNotification();
       return;
     }
-    nativeShowFocusTimerNotification(hgTimerPhase, hgTimerSeconds, !hgTimerRunning);
-  }, [hgTimerRunning, hgTimerPhase, hgShowSettings, hgTimerSeconds]);
+    nativeShowFocusTimerNotification(hgTimerPhase, hgTimerSecondsRef.current, !hgTimerRunning);
+  }, [hgTimerRunning, hgTimerPhase, hgShowSettings]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Dismiss notification when this modal unmounts (session ended / exited).
   useEffect(() => () => { if (isNativeAndroid()) nativeDismissFocusTimerNotification(); }, []);

--- a/src/hooks/useFocusMode.js
+++ b/src/hooks/useFocusMode.js
@@ -53,18 +53,23 @@ const useFocusMode = () => {
     }
   }, [focusTimerSeconds, showFocusMode, focusTimerRunning, focusShowSettings]);
 
-  // Sync the Android notification center with timer state.
-  // focusTimerSeconds is included in deps so Kotlin always gets a fresh remainingSeconds
-  // to compute setWhen(now + remainingMs) — keeping the native chronometer accurate even
-  // if there's any small JS/native clock drift.
+  // Keep a ref to the current remaining seconds so the notification effect can read
+  // it without depending on it — we only want to fire on meaningful transitions,
+  // not every 1-second tick (which would reset the native chronometer and cause flicker).
+  const focusTimerSecondsRef = useRef(focusTimerSeconds);
+  useEffect(() => { focusTimerSecondsRef.current = focusTimerSeconds; }, [focusTimerSeconds]);
+
+  // Sync the Android notification on state transitions only: start, pause, resume,
+  // phase change, and session end. The native chronometer ticks independently between
+  // these calls — calling notify() every second would reset it and cause flicker.
   useEffect(() => {
     if (!isNativeAndroid()) return;
     if (!showFocusMode || focusShowSettings || focusShowStats) {
       nativeDismissFocusTimerNotification();
       return;
     }
-    nativeShowFocusTimerNotification(focusPhase, focusTimerSeconds, !focusTimerRunning);
-  }, [showFocusMode, focusTimerRunning, focusPhase, focusShowSettings, focusShowStats, focusTimerSeconds]);
+    nativeShowFocusTimerNotification(focusPhase, focusTimerSecondsRef.current, !focusTimerRunning);
+  }, [showFocusMode, focusTimerRunning, focusPhase, focusShowSettings, focusShowStats]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Poll for notification button actions while a focus session is active.
   // visibilitychange doesn't fire when the app is already in the foreground, so polling


### PR DESCRIPTION
Calling nm.notify() every second reset the native chronometer (causing 00:00/-00:01 flicker) and triggered Android's notification re-ranking (causing it to swap places with Up Next).

Fix: revert to transition-only updates — the notification fires on pause/resume/phase-change/start/exit only. A ref captures the current remainingSeconds at each transition so Kotlin can compute the correct setWhen without depending on focusTimerSeconds in the effect deps.

The native chronometer ticks independently between transitions; no per-second JS calls needed or wanted.

https://claude.ai/code/session_012mSZvrqwe4yDTL88pWn7be