### PR TITLE
feat(focus-timer): redesign notification layout with timer as hero

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -209,8 +209,8 @@ class NativeBridge(
      * via getFocusPendingAction() polling every ~500 ms.
      */
     @JavascriptInterface
-    fun showFocusTimerNotification(phase: String, remainingSeconds: Int, isPaused: Boolean) =
-        notifications.showFocusTimerNotification(phase, remainingSeconds, isPaused)
+    fun showFocusTimerNotification(phase: String, remainingSeconds: Int, isPaused: Boolean, cycleCount: Int) =
+        notifications.showFocusTimerNotification(phase, remainingSeconds, isPaused, cycleCount)
 
     /** Cancels the focus timer notification. Call when the session ends or is dismissed. */
     @JavascriptInterface

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
@@ -344,31 +344,26 @@ class NotificationBridge(private val context: Context) {
      * @param phase            "work" | "shortBreak" | "longBreak"
      * @param remainingSeconds seconds left in the current phase
      * @param isPaused         true while the timer is paused
+     * @param cycleCount       completed work cycles (0-based; used to show e.g. "1/4")
      */
-    fun showFocusTimerNotification(phase: String, remainingSeconds: Int, isPaused: Boolean) {
-        android.util.Log.d("DayGlanceFocus", "showFocusTimerNotification: phase=$phase remainingSeconds=$remainingSeconds isPaused=$isPaused")
-
+    fun showFocusTimerNotification(phase: String, remainingSeconds: Int, isPaused: Boolean, cycleCount: Int) {
         val phaseLabel = when (phase) {
             "shortBreak" -> "Short Break"
             "longBreak"  -> "Long Break"
-            else         -> "Focus"
+            else         -> "Work"
         }
+        val cycleInRound = (cycleCount % 4) + 1
+        val statusText = "${if (isPaused) "Paused" else "In Progress"} · $phaseLabel · $cycleInRound/4"
 
-        // Use a RemoteViews Chronometer with android:countDown="true" set in XML.
-        // This sets the base directly via SystemClock.elapsedRealtime(), bypassing
-        // NotificationCompat's setChronometerCountDown which is ignored on some OEMs.
         val views = RemoteViews(context.packageName, R.layout.notification_focus_timer)
         if (isPaused) {
             val mm = remainingSeconds / 60
             val ss = remainingSeconds % 60
-            views.setTextViewText(R.id.notif_status, "Paused")
             views.setTextViewText(R.id.notif_paused_time, "%02d:%02d".format(mm, ss))
             views.setViewVisibility(R.id.notif_chronometer, View.GONE)
             views.setViewVisibility(R.id.notif_paused_time, View.VISIBLE)
         } else {
             val base = SystemClock.elapsedRealtime() + remainingSeconds * 1000L
-            android.util.Log.d("DayGlanceFocus", "  elapsedRealtime=${SystemClock.elapsedRealtime()} base=$base remainingMs=${remainingSeconds * 1000L}")
-            views.setTextViewText(R.id.notif_status, "In progress")
             // setBoolean calls Chronometer.setCountDown(true) in the remote process —
             // the XML android:countDown attribute may not survive RemoteViews inflation.
             views.setBoolean(R.id.notif_chronometer, "setCountDown", true)
@@ -376,6 +371,7 @@ class NotificationBridge(private val context: Context) {
             views.setViewVisibility(R.id.notif_chronometer, View.VISIBLE)
             views.setViewVisibility(R.id.notif_paused_time, View.GONE)
         }
+        views.setTextViewText(R.id.notif_status, statusText)
 
         val builder = NotificationCompat.Builder(context, DayGlanceApplication.CHANNEL_FOCUS)
             .setSmallIcon(R.drawable.ic_notification)

--- a/dayglance-android/app/src/main/res/layout/notification_focus_timer.xml
+++ b/dayglance-android/app/src/main/res/layout/notification_focus_timer.xml
@@ -2,20 +2,10 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical"
-    android:orientation="horizontal">
+    android:orientation="vertical"
+    android:gravity="start">
 
-    <TextView
-        android:id="@+id/notif_status"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:singleLine="true"
-        android:textAppearance="@style/TextAppearance.Compat.Notification" />
-
-    <!-- Shown while timer is running: counts down using elapsedRealtime base.
-         setCountDown(true) is also called programmatically via RemoteViews.setBoolean()
-         because the XML attribute may not propagate to the remote process. -->
+    <!-- Primary: countdown timer (large) or static time when paused -->
     <Chronometer
         android:id="@+id/notif_chronometer"
         android:layout_width="wrap_content"
@@ -24,12 +14,19 @@
         android:textAppearance="@style/TextAppearance.Compat.Notification.Title"
         android:visibility="gone" />
 
-    <!-- Shown while timer is paused: static remaining time -->
     <TextView
         android:id="@+id/notif_paused_time"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="@style/TextAppearance.Compat.Notification.Title"
         android:visibility="gone" />
+
+    <!-- Secondary: "In Progress · Work · 1/4" or "Paused · Work · 1/4" -->
+    <TextView
+        android:id="@+id/notif_status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:singleLine="true"
+        android:textAppearance="@style/TextAppearance.Compat.Notification" />
 
 </LinearLayout>

--- a/src/components/HyperGlanceModeModal.jsx
+++ b/src/components/HyperGlanceModeModal.jsx
@@ -95,7 +95,7 @@ const HyperGlanceModeModal = () => {
       nativeDismissFocusTimerNotification();
       return;
     }
-    nativeShowFocusTimerNotification(hgTimerPhase, hgTimerSecondsRef.current, !hgTimerRunning);
+    nativeShowFocusTimerNotification(hgTimerPhase, hgTimerSecondsRef.current, !hgTimerRunning, hgCycleCount);
   }, [hgTimerRunning, hgTimerPhase, hgShowSettings]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Dismiss notification when this modal unmounts (session ended / exited).

--- a/src/hooks/useFocusMode.js
+++ b/src/hooks/useFocusMode.js
@@ -68,7 +68,7 @@ const useFocusMode = () => {
       nativeDismissFocusTimerNotification();
       return;
     }
-    nativeShowFocusTimerNotification(focusPhase, focusTimerSecondsRef.current, !focusTimerRunning);
+    nativeShowFocusTimerNotification(focusPhase, focusTimerSecondsRef.current, !focusTimerRunning, focusCycleCount);
   }, [showFocusMode, focusTimerRunning, focusPhase, focusShowSettings, focusShowStats]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Poll for notification button actions while a focus session is active.

--- a/src/native.js
+++ b/src/native.js
@@ -455,10 +455,10 @@ export const nativeRequestDndPermission = () => {
  * @param remainingSeconds seconds remaining in the current phase
  * @param isPaused         true while the timer is paused
  */
-export const nativeShowFocusTimerNotification = (phase, remainingSeconds, isPaused) => {
+export const nativeShowFocusTimerNotification = (phase, remainingSeconds, isPaused, cycleCount) => {
   const bridge = nativeBridge();
   if (!bridge?.showFocusTimerNotification) return;
-  bridge.showFocusTimerNotification(phase, remainingSeconds, isPaused);
+  bridge.showFocusTimerNotification(phase, remainingSeconds, isPaused, cycleCount);
 };
 
 /** Cancels the focus timer notification. Call when the session ends or is dismissed. */


### PR DESCRIPTION
## Summary

- Timer (countdown chronometer or static MM:SS when paused) is now the primary/hero element
- Secondary line shows `In Progress · Work · 1/4` or `Paused · Short Break · 2/4`
- Passes `cycleCount` from JS through the bridge so the round indicator is accurate
- Removes the debug `Log.d` calls added during investigation

## Test plan

- [ ] Start a focus session — timer counts down from the correct time, status line shows phase and round
- [ ] Pause — static MM:SS shown, status says "Paused · Work · 1/4"
- [ ] Resume — countdown restarts from correct remaining time
- [ ] Phase transition (work → short break) — status line updates
- [ ] Stop — notification dismissed
- [ ] Test with hyperGLANCE as well as regular Focus Mode

https://claude.ai/code/session_012mSZvrqwe4yDTL88pWn7be

---
_Generated by [Claude Code](https://claude.ai/code/session_012mSZvrqwe4yDTL88pWn7be)_