### PR TITLE
Clean up Android compiler warnings

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -21,6 +21,7 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -143,6 +144,17 @@ class MainActivity : AppCompatActivity() {
             v.setPadding(0, 0, 0, navBottom)
             insets
         }
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (webView.canGoBack()) {
+                    webView.goBack()
+                } else {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        })
 
         configureWebView()
         requestRuntimePermissions()
@@ -351,7 +363,10 @@ class MainActivity : AppCompatActivity() {
         // Prefer the app's saved preference; fall back to system night mode on first launch.
         val isNightMode = dataStore.appDarkMode ?: systemNightMode
         // Disable automatic contrast enforcement so our flag isn't overridden.
+        // isStatusBarContrastEnforced is deprecated in API 35 (ignored in edge-to-edge mode),
+        // but there is no replacement — suppress the warning rather than remove the call.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            @Suppress("DEPRECATION")
             window.isStatusBarContrastEnforced = false
         }
         // isAppearanceLightStatusBars = true  → dark (black) icons → light mode
@@ -408,14 +423,6 @@ class MainActivity : AppCompatActivity() {
                 "document.dispatchEvent(new Event('visibilitychange')); })();",
                 null
             )
-        }
-    }
-
-    override fun onBackPressed() {
-        if (webView.canGoBack()) {
-            webView.goBack()
-        } else {
-            super.onBackPressed()
         }
     }
 

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -372,20 +372,24 @@ class NativeBridge(
         // Persist so MainActivity.applyStatusBarAppearance() can use the app
         // preference instead of the system night-mode on future onResume/onPageFinished calls.
         dataStore.appDarkMode = isDark
-        (context as? android.app.Activity)?.runOnUiThread {
+        val activity = context as? android.app.Activity ?: return
+        activity.runOnUiThread {
+            // isStatusBarContrastEnforced is deprecated in API 35 (ignored in edge-to-edge
+            // mode), but there is no replacement — suppress rather than remove the call.
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-                (context as android.app.Activity).window.isStatusBarContrastEnforced = false
+                @Suppress("DEPRECATION")
+                activity.window.isStatusBarContrastEnforced = false
             }
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
                 val appearance = if (!isDark) android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS else 0
-                (context as android.app.Activity).window.insetsController?.setSystemBarsAppearance(
+                activity.window.insetsController?.setSystemBarsAppearance(
                     appearance,
                     android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
                 )
             } else {
                 androidx.core.view.WindowCompat.getInsetsController(
-                    (context as android.app.Activity).window,
-                    (context as android.app.Activity).window.decorView,
+                    activity.window,
+                    activity.window.decorView,
                 ).isAppearanceLightStatusBars = !isDark
             }
         }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
@@ -107,7 +107,7 @@ class NotificationBridge(private val context: Context) {
      */
     @JavascriptInterface
     fun showTaskNotification(
-        reminderId: String,
+        _reminderId: String,
         taskId: String,
         title: String,
         body: String,

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/CalendarRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/CalendarRepository.kt
@@ -177,8 +177,8 @@ class CalendarRepository(private val context: Context) {
             )?.use { cursor ->
                 val idIdx      = cursor.getColumnIndex(CalendarContract.Events._ID)
                 val titleIdx   = cursor.getColumnIndex(CalendarContract.Events.TITLE)
-                val startIdx   = cursor.getColumnIndex(CalendarContract.Events.DTSTART)
-                val dueIdx     = cursor.getColumnIndex(colDue)
+                val _startIdx  = cursor.getColumnIndex(CalendarContract.Events.DTSTART)
+                val _dueIdx    = cursor.getColumnIndex(colDue)
                 val descIdx    = cursor.getColumnIndex(CalendarContract.Events.DESCRIPTION)
                 val locIdx     = cursor.getColumnIndex(CalendarContract.Events.EVENT_LOCATION)
                 val calIdIdx   = cursor.getColumnIndex(CalendarContract.Events.CALENDAR_ID)

--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidget.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/DayGlanceWidget.kt
@@ -101,6 +101,7 @@ class DayGlanceWidget : AppWidgetProvider() {
         // ── Scrollable agenda list ─────────────────────────────────────────
         try {
             val serviceIntent = Intent(context, DayGlanceWidgetListService::class.java)
+            @Suppress("DEPRECATION")
             views.setRemoteAdapter(R.id.lv_agenda, serviceIntent)
             views.setEmptyView(R.id.lv_agenda, android.R.id.empty)
 
@@ -139,6 +140,7 @@ class DayGlanceWidget : AppWidgetProvider() {
 
         // Notify the list service that data may have changed so it calls onDataSetChanged
         try {
+            @Suppress("DEPRECATION")
             appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.lv_agenda)
         } catch (_: Throwable) { }
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/GoalWidget.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/GoalWidget.kt
@@ -100,7 +100,7 @@ class GoalWidget : AppWidgetProvider() {
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }
 
-    private fun showEmpty(views: RemoteViews, title: String, subtitle: String) {
+    private fun showEmpty(views: RemoteViews, _title: String, subtitle: String) {
         views.setViewVisibility(R.id.layout_goal_content, View.GONE)
         views.setViewVisibility(R.id.layout_goal_empty, View.VISIBLE)
         views.setTextViewText(R.id.tv_goal_empty_sub, subtitle)

--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/GoalWidgetConfigureActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/GoalWidgetConfigureActivity.kt
@@ -121,7 +121,6 @@ class GoalWidgetConfigureActivity : AppCompatActivity() {
         val row = LinearLayout(this).apply {
             orientation = LinearLayout.HORIZONTAL
             val dp8 = dp(8)
-            val dp12 = dp(12)
             setPadding(0, dp8, 0, dp8)
             isClickable = true
             isFocusable = true


### PR DESCRIPTION
Closes #726.

## Unused parameters / variables
- `NotificationBridge.kt`: prefix `reminderId` → `_reminderId` (only `taskId` is used in the body)
- `CalendarRepository.kt`: prefix `startIdx` / `dueIdx` → `_startIdx` / `_dueIdx` (column indices fetched but never read from the cursor)
- `GoalWidgetConfigureActivity.kt`: remove unused `dp12` local variable
- `GoalWidget.kt`: prefix `title` → `_title` in `showEmpty()`

## Deprecated API migrations
- `MainActivity.kt`: replace deprecated `onBackPressed()` override with `OnBackPressedCallback` registered in `onCreate()`
- `MainActivity.kt` + `NativeBridge.kt`: suppress `isStatusBarContrastEnforced` deprecation with a comment — deprecated in API 35 and silently ignored in edge-to-edge mode, but there is no replacement API
- `DayGlanceWidget.kt`: suppress `setRemoteAdapter()` and `notifyAppWidgetViewDataChanged()` — both deprecated in API 31; no clean service-based alternative exists at current target SDK

## Unnecessary casts
- `NativeBridge.kt`: extract a `val activity` local at the top of `setStatusBarAppearance()` so the four `(context as android.app.Activity)` casts inside `runOnUiThread` are eliminated

https://claude.ai/code/session_014G3ti6ZgsPuiadwh15g1bM

---
_Generated by [Claude Code](https://claude.ai/code/session_014G3ti6ZgsPuiadwh15g1bM)_