### PR TITLE
Pass Apple signing secrets to macOS build in CI

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -35,6 +35,12 @@ jobs:
 
       - name: Build desktop app
         run: npm run build:electron -- --publish never
+        env:
+          CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.CSC_KEY_PASSWORD || '' }}
+          APPLE_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_TEAM_ID || '' }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

The macOS runner was building without `CSC_LINK` and friends, so electron-builder fell back to ad-hoc signing — no hardened runtime, no notarization, no staple ticket. Gatekeeper blocked the resulting `.app` on first launch with "cannot be opened".

## Fix

Pass the five Apple signing env vars to the build step, scoped to the macOS matrix leg only (Windows/Linux get empty strings; the notarize and codesign scripts already guard on platform and `CSC_LINK` presence so they're unaffected).

## Required action

Add these five secrets under **Settings → Secrets and variables → Actions** in the repo before re-running the workflow:

| Secret | Value |
|--------|-------|
| `CSC_LINK` | Base64-encoded `.p12`: `base64 -i certificate.p12 \| pbcopy` |
| `CSC_KEY_PASSWORD` | `.p12` export password |
| `APPLE_ID` | Apple ID email |
| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password from appleid.apple.com |
| `APPLE_TEAM_ID` | 10-char Team ID from developer.apple.com/account |

https://claude.ai/code/session_014G3ti6ZgsPuiadwh15g1bM

---
_Generated by [Claude Code](https://claude.ai/code/session_014G3ti6ZgsPuiadwh15g1bM)_