### PR TITLE
Fix Windows build failing due to Apple signing secrets leaking

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -33,7 +33,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build desktop app
+      - name: Build desktop app (macOS — signed + notarized)
+        if: matrix.os == 'macos-latest'
+        run: npm run build:electron -- --publish never
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Build desktop app (Windows / Linux)
+        if: matrix.os != 'macos-latest'
         run: npm run build:electron -- --publish never
 
       - name: Upload artifacts


### PR DESCRIPTION
## Problem

Setting `CSC_LINK` to an empty string on the Windows runner is enough to trigger electron-builder's Windows code-signing path — it tries to resolve the value as `WIN_CSC_LINK` and fails with `not a file`.

## Fix

Split the single build step into two conditional steps: the macOS one carries all five Apple signing env vars, the Windows/Linux one runs with a clean environment. The secrets are now never present in any form on non-macOS runners.

https://claude.ai/code/session_014G3ti6ZgsPuiadwh15g1bM

---
_Generated by [Claude Code](https://claude.ai/code/session_014G3ti6ZgsPuiadwh15g1bM)_