### PR TITLE
Fix electron-builder v24 notarization collision and Windows env leak

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -46,12 +46,6 @@ jobs:
       - name: Build desktop app (Windows / Linux)
         if: matrix.os != 'macos-latest'
         run: npm run build:electron -- --publish never
-        env:
-          CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.CSC_LINK || '' }}
-          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.CSC_KEY_PASSWORD || '' }}
-          APPLE_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_ID || '' }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_TEAM_ID || '' }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -28,6 +28,7 @@ module.exports = {
     // Developer ID Application cert from Keychain when CSC_LINK is set.
     identity: hasCert ? undefined : null,
     hardenedRuntime: hasCert,
+    notarize: false, // handled by afterSign hook (scripts/notarize.cjs)
     category: 'public.app-category.productivity',
     entitlements: 'electron/entitlements.mac.plist',
     entitlementsInherit: 'electron/entitlements.mac.plist',


### PR DESCRIPTION
## Problems

**1. `Cannot destructure property 'appBundleId'` crash on macOS build**

electron-builder v24 introduced built-in notarization that fires automatically when Apple credentials are present in the environment. It collides with our custom `afterSign` hook (`scripts/notarize.cjs`) and crashes because it can't find its expected config block.

Fix: add `notarize: false` to the `mac` section of `electron-builder.config.cjs` to disable the built-in path entirely.

**2. Windows/Linux step still had Apple signing env vars**

The env block with empty-string Apple vars was re-introduced on the Windows/Linux step during the PR #734 merge. electron-builder treats any set `CSC_LINK` (even `''`) as a Windows cert path and fails. Removed the env block entirely from the non-macOS step.

## After merging

Delete and re-push the tag to trigger a clean build:
```bash
git tag -d v2.9.1 && git push origin --delete v2.9.1
git tag v2.9.1 && git push origin v2.9.1
```

https://claude.ai/code/session_014G3ti6ZgsPuiadwh15g1bM

---
_Generated by [Claude Code](https://claude.ai/code/session_014G3ti6ZgsPuiadwh15g1bM)_