### PR TITLE
Fix LIST view connector blending, Android back button, and add end-of-day line

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -256,6 +256,10 @@ const DayPlanner = () => {
     const saved = localStorage.getItem('day-planner-glance-page');
     return saved !== null ? parseInt(saved, 10) : 0;
   });
+  // null = off (default 30-min trailing buffer). Otherwise a "HH:MM" string.
+  const [listEndOfDayTime, setListEndOfDayTime] = useState(() => {
+    return localStorage.getItem('day-planner-list-end-of-day') || null;
+  });
   const [goalsDashboardFocusId, setGoalsDashboardFocusId] = useState(null);
   const [weekViewMode, setWeekViewMode] = useState(() => {
     const saved = localStorage.getItem('day-planner-week-view-mode');
@@ -1075,8 +1079,21 @@ const DayPlanner = () => {
     localStorage.setItem('day-planner-mobile-view-mode', JSON.stringify(mobileViewMode));
   }, [mobileViewMode]);
   useEffect(() => {
+    if (listEndOfDayTime === null) {
+      localStorage.removeItem('day-planner-list-end-of-day');
+    } else {
+      localStorage.setItem('day-planner-list-end-of-day', listEndOfDayTime);
+    }
+  }, [listEndOfDayTime]);
+  useEffect(() => {
     localStorage.setItem('day-planner-glance-page', String(glancePage));
   }, [glancePage]);
+
+  // Clear any stale history state left from a previous session so Android back
+  // button interception works correctly from the first navigation.
+  useEffect(() => {
+    window.history.replaceState(null, '');
+  }, []);
 
   // Lock body/html scrolling to prevent scroll chaining (all devices incl. desktop PWA)
   useEffect(() => {
@@ -7170,6 +7187,7 @@ const DayPlanner = () => {
     tabletActiveTab, setTabletActiveTab,
     mobileActiveTab, setMobileActiveTab,
     mobileViewMode, setMobileViewMode,
+    listEndOfDayTime, setListEndOfDayTime,
     glancePage, setGlancePage,
     mobileWelcomeStep, setMobileWelcomeStep,
     desktopWelcomeStep, setDesktopWelcomeStep,

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -453,10 +453,13 @@ function Row({ timeLabel, timeColour, spineColour, spineStyle, marker, cardHeigh
 
 // ─── GapRow ───────────────────────────────────────────────────────────────────
 
-function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minutesToTime, dragTargetMin, dragBlocked, darkMode, pageBg }) {
+function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minutesToTime, dragTargetMin, dragBlocked, darkMode, pageBg, eodMarkerMin }) {
   const h = gapHeight(toMin - fromMin);
   const showLabel = (toMin - fromMin) >= 45;
   const isTarget = dragTargetMin !== null && dragTargetMin >= fromMin && dragTargetMin < toMin;
+  const eodFrac = (eodMarkerMin != null && eodMarkerMin > fromMin && eodMarkerMin < toMin)
+    ? (eodMarkerMin - fromMin) / (toMin - fromMin)
+    : null;
 
   return (
     <div
@@ -465,10 +468,15 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
       style={{ display: 'flex', height: h }}
     >
       {/* Time col */}
-      <div style={{ width: TIME_COL_W, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'flex-end', paddingRight: 8 }}>
+      <div style={{ width: TIME_COL_W, flexShrink: 0, position: 'relative', paddingRight: 8 }}>
         {showLabel && (
-          <span className={`text-[9px] leading-none ${textSecondary}`} style={{ opacity: 0.5 }}>
+          <span className={`text-[9px] leading-none ${textSecondary}`} style={{ opacity: 0.5, position: 'absolute', top: '50%', right: 8, transform: 'translateY(-50%)' }}>
             {formatTime(minutesToTime(fromMin))}
+          </span>
+        )}
+        {eodFrac !== null && (
+          <span className={`text-[9px] leading-none ${textSecondary}`} style={{ opacity: 0.4, position: 'absolute', top: `${eodFrac * 100}%`, right: 8, transform: 'translateY(-50%)', whiteSpace: 'nowrap' }}>
+            {formatTime(minutesToTime(eodMarkerMin))}
           </span>
         )}
       </div>
@@ -480,6 +488,13 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
             <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', marginLeft: -1, width: 2, background: pageBg, zIndex: 1, pointerEvents: 'none' }} />
             <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', marginLeft: -1, width: 2, background: dashedGradient(spineColour), zIndex: 2, pointerEvents: 'none' }} />
           </>
+        )}
+        {eodFrac !== null && (
+          <div style={{
+            position: 'absolute', top: `${eodFrac * 100}%`, left: 0, right: 0,
+            height: 1, background: darkMode ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)',
+            transform: 'translateY(-50%)', zIndex: 4, pointerEvents: 'none',
+          }} />
         )}
         {/* Drag preview indicator on spine */}
         {isTarget && (
@@ -496,7 +511,7 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
         )}
       </div>
       {/* Content col */}
-      <div style={{ flex: 1, display: 'flex', alignItems: 'center', paddingLeft: 4 }}>
+      <div style={{ flex: 1, position: 'relative', display: 'flex', alignItems: 'center', paddingLeft: 4 }}>
         {isTarget ? (
           <span
             className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
@@ -513,6 +528,24 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
               {durLabel(toMin - fromMin)} free
             </span>
           )
+        )}
+        {eodFrac !== null && (
+          <div
+            style={{
+              position: 'absolute',
+              top: `${eodFrac * 100}%`,
+              left: 0, right: 8,
+              display: 'flex', alignItems: 'center', gap: 6,
+              transform: 'translateY(-50%)',
+              pointerEvents: 'none',
+            }}
+          >
+            <div style={{ flex: 1, height: 1, background: darkMode ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)' }} />
+            <LucideIcons.Moon size={10} style={{ color: darkMode ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.25)', flexShrink: 0 }} />
+            <span style={{ fontSize: 10, color: darkMode ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.25)', flexShrink: 0, whiteSpace: 'nowrap' }}>
+              Good work · rest up
+            </span>
+          </div>
         )}
       </div>
     </div>
@@ -649,6 +682,7 @@ const MobileListView = () => {
     toggleComplete, postponeTask, moveToInbox, openMobileEditTask,
     setExpandedNotesTaskId,
     pushUndo, playUISound,
+    listEndOfDayTime,
   } = useDayPlannerCtx();
 
   const {
@@ -1125,10 +1159,14 @@ const MobileListView = () => {
     flushMultiRoutine();
 
 
-    // Trailing gap so last item isn't at very bottom
-    segs.push({ type: 'gap', id: 'gap-trail', fromMin: cursor, toMin: cursor + 30 });
+    // Trailing gap: extend to end-of-day time if set, otherwise 30-min buffer
+    const eodMin = listEndOfDayTime ? timeToMinutes(listEndOfDayTime) : null;
+    const trailEnd = eodMin !== null && eodMin > cursor + 30
+      ? eodMin + 30
+      : cursor + 30;
+    segs.push({ type: 'gap', id: 'gap-trail', fromMin: cursor, toMin: trailEnd });
     return segs;
-  }, [visibleItems, isToday, nowMin, timeToMinutes]);
+  }, [visibleItems, isToday, nowMin, timeToMinutes, listEndOfDayTime]);
 
   // Page background colour — used behind markers (checkbox fill) and long-gap dashed overlays
   const pageBg = darkMode ? '#1f2937' : '#ffffff';
@@ -1391,7 +1429,9 @@ const MobileListView = () => {
         )}
 
         {/* Segment list */}
-        {segments.map(seg => {
+        {(() => {
+          const eodMin = listEndOfDayTime ? timeToMinutes(listEndOfDayTime) : null;
+          return segments.map(seg => {
         if (seg.type === 'gap') {
           const midMin = Math.round((seg.fromMin + seg.toMin) / 2);
           return (
@@ -1407,6 +1447,7 @@ const MobileListView = () => {
               dragBlocked={dragBlocked}
               darkMode={darkMode}
               pageBg={pageBg}
+              eodMarkerMin={seg.id === 'gap-trail' ? eodMin : null}
             />
           );
         }
@@ -1435,7 +1476,7 @@ const MobileListView = () => {
                     cardHeight={ROUTINE_H}
                     accentHex="#14b8a6"
                     pageBg={pageBg}
-                    connectorOpacity={rowCompleted ? 0.5 : 1}
+                    noConnector={rowCompleted}
                   >
                     <div style={{ display: 'flex', gap: 4, marginTop: 4, marginBottom: 4, minWidth: 0 }}>
                       {rowItems.map(item => {
@@ -1498,7 +1539,7 @@ const MobileListView = () => {
                   accentHex="#14b8a6"
                   pageBg={pageBg}
                   onMarkerClick={e => { e.stopPropagation(); toggleRoutineCompletion(item._routineId); }}
-                  connectorOpacity={completed ? 0.5 : 1}
+                  noConnector={completed}
                 >
                   <div style={{ opacity: isPast ? 0.45 : 1, marginTop: 4, marginBottom: 4, transition: 'opacity 0.15s' }}>
                     <RoutineChip
@@ -1632,7 +1673,8 @@ const MobileListView = () => {
         }
 
         return null;
-      })}
+      });
+        })()}
       </div>{/* end timed body */}
 
       {/* ── Ghost card (follows touch during list-item drag) ── */}

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -43,6 +43,7 @@ const MobileSettingsPanel = () => {
     formatTime,
     toggleSettingsSection,
     mobileViewMode, setMobileViewMode,
+    listEndOfDayTime, setListEndOfDayTime,
     glancePage, setGlancePage,
   } = useDayPlannerCtx();
   const {
@@ -324,6 +325,30 @@ const MobileSettingsPanel = () => {
             </button>
           ))}
         </div>
+
+        {/* End of day (LIST view only) */}
+        {mobileViewMode === 'list' && (
+          <div className="mt-3 space-y-1.5">
+            <label className={`block text-xs font-medium ${textSecondary}`}>End of day (LIST view)</label>
+            <p className={`text-xs ${textSecondary} opacity-70`}>Extends the timeline spine to this time so you can drag items there</p>
+            <select
+              value={listEndOfDayTime ?? ''}
+              onChange={e => setListEndOfDayTime(e.target.value || null)}
+              className={`w-full py-2 px-3 rounded-lg text-sm border ${darkMode ? 'bg-gray-700 border-gray-600 text-gray-100' : 'bg-white border-stone-300 text-stone-900'}`}
+            >
+              <option value="">Off</option>
+              {Array.from({ length: 13 }, (_, i) => {
+                const totalMin = 18 * 60 + i * 30;
+                const hh = String(Math.floor(totalMin / 60) % 24).padStart(2, '0');
+                const mm = String(totalMin % 60).padStart(2, '0');
+                const val = `${hh}:${mm}`;
+                return (
+                  <option key={val} value={val}>{formatTime(val)}</option>
+                );
+              })}
+            </select>
+          </div>
+        )}
       </div>
 
       {/* GLANCE default */}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug 2 — Completed routine connector**: Instead of fading the connector line to 50% opacity (which clashed because the spine gradient color tinted it differently from the card), we now hide the connector entirely when a routine is completed (`noConnector={completed}`). Applies to both single and multi-routine rows.

- **Bug 3 — Android back button exits app**: The back-button intercept in `App.jsx` guards against pushing a duplicate history entry by checking `window.history.state?.appTab`. On Android/PWA, the previous session's history state persists across relaunches, so this guard fired immediately and no intercept entry was ever pushed — causing the first back press to exit. Fixed by calling `window.history.replaceState(null, '')` on mount to clear any stale session state.

- **Bug 1 — End of day line in LIST view**: Adds a user-configurable "End of day" time under the LIST view settings (6 PM–midnight in 30-min steps, defaults to off). When set:
  - The trailing gap extends to `eodTime + 30 min`, making the full range draggable.
  - A subtle dashed horizontal line is drawn across the spine and content columns at the exact end-of-day time.
  - A Moon icon + "Good work · rest up" label appears at the marker.
  - The time column shows the EOD time at the marker position.

## Test plan

- [ ] Set end-of-day to e.g. 10 PM in LIST view settings; confirm spine extends there and marker renders
- [ ] Drag a task to a time past what was previously the last item — should now reach the EOD marker
- [ ] Complete a routine; confirm the connector line disappears (not just fades)
- [ ] On Android: navigate to a non-dayglance tab, press back — should return to dayglance tab, not exit the app
- [ ] Relaunch the app after the above; confirm back button still works correctly in the new session

https://claude.ai/code/session_011APg9ZXEgEsAKLPhiw2xNZ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011APg9ZXEgEsAKLPhiw2xNZ)_