### PR TITLE
Fix EOD picker UI, empty-timeline gap, and midnight edge case

### DIFF
--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -476,7 +476,7 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
         )}
         {eodFrac !== null && (
           <span className={`text-[9px] leading-none ${textSecondary}`} style={{ opacity: 0.4, position: 'absolute', top: `${eodFrac * 100}%`, right: 8, transform: 'translateY(-50%)', whiteSpace: 'nowrap' }}>
-            {formatTime(minutesToTime(eodMarkerMin))}
+            {formatTime(eodMarkerMin === 1440 ? '00:00' : minutesToTime(eodMarkerMin))}
           </span>
         )}
       </div>
@@ -1111,7 +1111,22 @@ const MobileListView = () => {
   const segments = useMemo(() => {
     const segs = [];
     const items = visibleItems;
-    if (items.length === 0) return segs;
+
+    // '00:00' means midnight = end of day, treat as 1440 min
+    const eodMin = listEndOfDayTime
+      ? (listEndOfDayTime === '00:00' ? 1440 : timeToMinutes(listEndOfDayTime))
+      : null;
+
+    if (items.length === 0) {
+      // Empty day: still emit a trailing gap so the EOD marker (and draggable
+      // area) appears even when nothing is scheduled.
+      const cursor = isToday ? nowMin : 0;
+      const trailEnd = eodMin !== null && eodMin > cursor + 30
+        ? (eodMin === 1440 ? eodMin : eodMin + 30)
+        : cursor + 30;
+      segs.push({ type: 'gap', id: 'gap-trail', fromMin: cursor, toMin: trailEnd });
+      return segs;
+    }
 
     let cursor = isToday ? Math.min(nowMin, timeToMinutes(items[0]?.startTime ?? '00:00')) : timeToMinutes(items[0]?.startTime ?? '00:00');
     let pendingMultiRoutine = null;
@@ -1159,10 +1174,10 @@ const MobileListView = () => {
     flushMultiRoutine();
 
 
-    // Trailing gap: extend to end-of-day time if set, otherwise 30-min buffer
-    const eodMin = listEndOfDayTime ? timeToMinutes(listEndOfDayTime) : null;
+    // Trailing gap: extend to end-of-day time if set, otherwise 30-min buffer.
+    // Midnight (1440) gets no trailing buffer — nothing to schedule after midnight.
     const trailEnd = eodMin !== null && eodMin > cursor + 30
-      ? eodMin + 30
+      ? (eodMin === 1440 ? eodMin : eodMin + 30)
       : cursor + 30;
     segs.push({ type: 'gap', id: 'gap-trail', fromMin: cursor, toMin: trailEnd });
     return segs;
@@ -1430,7 +1445,9 @@ const MobileListView = () => {
 
         {/* Segment list */}
         {(() => {
-          const eodMin = listEndOfDayTime ? timeToMinutes(listEndOfDayTime) : null;
+          const eodMin = listEndOfDayTime
+            ? (listEndOfDayTime === '00:00' ? 1440 : timeToMinutes(listEndOfDayTime))
+            : null;
           return segments.map(seg => {
         if (seg.type === 'gap') {
           const midMin = Math.round((seg.fromMin + seg.toMin) / 2);

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -330,23 +330,31 @@ const MobileSettingsPanel = () => {
         {mobileViewMode === 'list' && (
           <div className="mt-3 space-y-1.5">
             <label className={`block text-xs font-medium ${textSecondary}`}>End of day (LIST view)</label>
-            <p className={`text-xs ${textSecondary} opacity-70`}>Extends the timeline spine to this time so you can drag items there</p>
-            <select
-              value={listEndOfDayTime ?? ''}
-              onChange={e => setListEndOfDayTime(e.target.value || null)}
-              className={`w-full py-2 px-3 rounded-lg text-sm border ${darkMode ? 'bg-gray-700 border-gray-600 text-gray-100' : 'bg-white border-stone-300 text-stone-900'}`}
-            >
-              <option value="">Off</option>
-              {Array.from({ length: 13 }, (_, i) => {
+            <p className={`text-xs ${textSecondary} opacity-70`}>Extends the spine to this time so you can drag items there</p>
+            <div className="flex flex-wrap gap-1.5">
+              {[{ label: 'Off', value: null }, ...Array.from({ length: 13 }, (_, i) => {
                 const totalMin = 18 * 60 + i * 30;
                 const hh = String(Math.floor(totalMin / 60) % 24).padStart(2, '0');
                 const mm = String(totalMin % 60).padStart(2, '0');
                 const val = `${hh}:${mm}`;
+                return { label: formatTime(val), value: val };
+              })].map(({ label, value }) => {
+                const active = (listEndOfDayTime ?? null) === value;
                 return (
-                  <option key={val} value={val}>{formatTime(val)}</option>
+                  <button
+                    key={label}
+                    onClick={() => setListEndOfDayTime(value)}
+                    className={`px-2.5 py-1 rounded-full text-xs font-medium border transition-colors ${
+                      active
+                        ? 'bg-blue-600 text-white border-blue-600'
+                        : `${darkMode ? 'bg-gray-700 border-gray-600 text-gray-300' : 'bg-white border-stone-300 text-stone-700'}`
+                    }`}
+                  >
+                    {label}
+                  </button>
                 );
               })}
-            </select>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Follow-up fixes to the end-of-day line feature (landed in #736), found during testing.

- **Picker UI**: Replaced the native `<select>` (which rendered as an ugly OS-level drawer on mobile) with a wrapping grid of pill chip buttons, matching the existing GRID/LIST toggle style.

- **Empty timeline**: The segment builder was early-returning an empty array when no items were scheduled, so the EOD marker never appeared on empty days. It now always emits the trailing gap segment, even with nothing scheduled.

- **Midnight edge case**: `'00:00'` is now treated as 1440 min throughout so it's correctly greater than any realistic cursor value. No trailing 30-min buffer is added after midnight (nothing to schedule there). Also fixed the time label — `minutesToTime(1440)` produces `'24:00'` which `formatTime` would render as "12:00 PM"; it now passes `'00:00'` directly instead.

## Test plan

- [ ] Open LIST view settings; confirm end-of-day picker shows as pill chips, not a native dropdown
- [ ] On an empty day with EOD set, confirm the marker and draggable area appear
- [ ] Set EOD to 12:00 AM; confirm the marker appears at midnight with no trailing buffer, and the time label reads "12:00 AM" (not "12:00 PM")

https://claude.ai/code/session_011APg9ZXEgEsAKLPhiw2xNZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011APg9ZXEgEsAKLPhiw2xNZ)_