### PR TITLE
Fix midnight EOD marker not rendering

### DIFF
--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -457,7 +457,7 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
   const h = gapHeight(toMin - fromMin);
   const showLabel = (toMin - fromMin) >= 45;
   const isTarget = dragTargetMin !== null && dragTargetMin >= fromMin && dragTargetMin < toMin;
-  const eodFrac = (eodMarkerMin != null && eodMarkerMin > fromMin && eodMarkerMin < toMin)
+  const eodFrac = (eodMarkerMin != null && eodMarkerMin > fromMin && eodMarkerMin <= toMin)
     ? (eodMarkerMin - fromMin) / (toMin - fromMin)
     : null;
 


### PR DESCRIPTION
## Summary

One-line fix found during testing: when the end-of-day time is set to 12:00 AM (midnight), the EOD marker was not rendering even though the spine correctly extended to that point.

**Root cause**: `eodFrac` was computed with a strict `eodMarkerMin < toMin` check. For midnight, `eodMin === 1440` and `trailEnd === 1440`, so `eodMarkerMin === toMin` — failing the check and returning `null`, suppressing the marker entirely.

**Fix**: Change `< toMin` to `<= toMin`. The marker renders at `frac = 1.0`, flush at the bottom of the trailing gap, which is correct for midnight.

## Test plan

- [ ] Set end-of-day to 12:00 AM; confirm "Good work · rest up" marker and time label appear at the bottom of the timeline

https://claude.ai/code/session_011APg9ZXEgEsAKLPhiw2xNZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011APg9ZXEgEsAKLPhiw2xNZ)_