### PR TITLE
Bump version to v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Your day, at a glance.** A privacy-first day planner with visual time-blocking, deep integrations, and zero lock-in. Use it free at [dayglance.app](https://dayglance.app) or self-host it on your own server. Your data stays on your device — nothing is ever sent to a server unless you choose to sync it yourself.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.9.2-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.0.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases) · [**Android APK**](https://github.com/krelltunez/dayglance/releases)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "2.9.2",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "2.9.2",
+      "version": "3.0.0",
       "dependencies": {
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "2.9.2",
+  "version": "3.0.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
Completes the v3.0.0 version bump — the Android side (`versionCode 57`, `versionName "3.0"`) was already updated in a previous PR.

## Changes
- `package.json`: `2.9.2` → `3.0.0`
- `package-lock.json`: updated to match
- `README.md`: version badge updated to `3.0.0`

https://claude.ai/code/session_01My6Am5tsriBopdqfYeN1wV

---
_Generated by [Claude Code](https://claude.ai/code/session_01My6Am5tsriBopdqfYeN1wV)_