### PR TITLE
Replace monthly plan with annual subscription + lifetime one-time purchase

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
@@ -19,11 +19,11 @@ import kotlinx.coroutines.launch
 /**
  * Manages the Google Play Billing client lifecycle for dayGLANCE subscriptions.
  *
- * Product IDs must be created in the Google Play Console under
- * Monetize → Subscriptions before they will resolve here.
+ * Annual plan → Play Console: Monetize → Subscriptions (product type SUBS).
+ * Lifetime plan → Play Console: Monetize → In-app products (product type INAPP).
  *
  * Call [connect] from Activity.onStart() and [disconnect] from Activity.onStop().
- * Set [activity] before calling [launchSubscriptionFlow].
+ * Set [activity] before calling [launchPurchaseFlow].
  */
 class BillingManager(
     private val context: Context,
@@ -32,9 +32,11 @@ class BillingManager(
 
     companion object {
         // These IDs must match what you create in the Play Console exactly.
-        const val PRODUCT_MONTHLY = "dayglance_pro_monthly"
-        const val PRODUCT_ANNUAL  = "dayglance_pro_annual"
-        val ALL_PRODUCTS = listOf(PRODUCT_MONTHLY, PRODUCT_ANNUAL)
+        const val PRODUCT_ANNUAL   = "dayglance_pro_annual"
+        const val PRODUCT_LIFETIME = "dayglance_pro_lifetime"
+        val SUBSCRIPTION_PRODUCTS = listOf(PRODUCT_ANNUAL)
+        val INAPP_PRODUCTS        = listOf(PRODUCT_LIFETIME)
+        val ALL_PRODUCTS          = SUBSCRIPTION_PRODUCTS + INAPP_PRODUCTS
     }
 
     var activity: Activity? = null
@@ -67,38 +69,48 @@ class BillingManager(
     }
 
     /**
-     * Fetches the base (non-trial) price for each subscription product from Play
-     * and caches it in SharedPreferences so the subscription wall can display it.
+     * Fetches prices for all products and caches them in SharedPreferences.
      *
-     * Filters for the INFINITE_RECURRING pricing phase (recurrenceMode == 1),
-     * which is the regular recurring charge — not the free-trial phase.
+     * Annual (SUBS): filters for the INFINITE_RECURRING phase (recurrenceMode 1).
+     * Lifetime (INAPP): reads oneTimePurchaseOfferDetails.formattedPrice directly.
      */
     fun queryProductPrices() {
         if (!billingClient.isReady) return
-        val params = QueryProductDetailsParams.newBuilder()
-            .setProductList(
-                ALL_PRODUCTS.map { id ->
-                    QueryProductDetailsParams.Product.newBuilder()
-                        .setProductId(id)
-                        .setProductType(BillingClient.ProductType.SUBS)
-                        .build()
-                }
-            )
+
+        val subsParams = QueryProductDetailsParams.newBuilder()
+            .setProductList(SUBSCRIPTION_PRODUCTS.map { id ->
+                QueryProductDetailsParams.Product.newBuilder()
+                    .setProductId(id)
+                    .setProductType(BillingClient.ProductType.SUBS)
+                    .build()
+            })
+            .build()
+
+        val inappParams = QueryProductDetailsParams.newBuilder()
+            .setProductList(INAPP_PRODUCTS.map { id ->
+                QueryProductDetailsParams.Product.newBuilder()
+                    .setProductId(id)
+                    .setProductType(BillingClient.ProductType.INAPP)
+                    .build()
+            })
             .build()
 
         scope.launch {
-            billingClient.queryProductDetailsAsync(params) { result, detailsList ->
+            billingClient.queryProductDetailsAsync(subsParams) { result, detailsList ->
                 if (result.responseCode != BillingClient.BillingResponseCode.OK) return@queryProductDetailsAsync
                 for (details in detailsList) {
-                    // Find the base recurring price phase (recurrenceMode 1 = INFINITE_RECURRING).
                     val price = details.subscriptionOfferDetails
                         ?.flatMap { it.pricingPhases.pricingPhaseList }
                         ?.firstOrNull { it.recurrenceMode == 1 }
                         ?.formattedPrice ?: continue
-                    when (details.productId) {
-                        PRODUCT_MONTHLY -> dataStore.productPriceMonthly = price
-                        PRODUCT_ANNUAL  -> dataStore.productPriceAnnual  = price
-                    }
+                    if (details.productId == PRODUCT_ANNUAL) dataStore.productPriceAnnual = price
+                }
+            }
+            billingClient.queryProductDetailsAsync(inappParams) { result, detailsList ->
+                if (result.responseCode != BillingClient.BillingResponseCode.OK) return@queryProductDetailsAsync
+                for (details in detailsList) {
+                    val price = details.oneTimePurchaseOfferDetails?.formattedPrice ?: continue
+                    if (details.productId == PRODUCT_LIFETIME) dataStore.productPriceLifetime = price
                 }
             }
         }
@@ -110,14 +122,28 @@ class BillingManager(
 
     fun queryPurchases() {
         if (!billingClient.isReady) return
-        billingClient.queryPurchasesAsync(
-            QueryPurchasesParams.newBuilder()
-                .setProductType(BillingClient.ProductType.SUBS)
-                .build()
-        ) { _, purchases ->
-            val active = purchases.firstOrNull {
-                it.purchaseState == Purchase.PurchaseState.PURCHASED
+        scope.launch {
+            var activePurchase: Purchase? = null
+
+            billingClient.queryPurchasesAsync(
+                QueryPurchasesParams.newBuilder()
+                    .setProductType(BillingClient.ProductType.SUBS)
+                    .build()
+            ) { _, purchases ->
+                activePurchase = purchases.firstOrNull { it.purchaseState == Purchase.PurchaseState.PURCHASED }
             }
+
+            if (activePurchase == null) {
+                billingClient.queryPurchasesAsync(
+                    QueryPurchasesParams.newBuilder()
+                        .setProductType(BillingClient.ProductType.INAPP)
+                        .build()
+                ) { _, purchases ->
+                    activePurchase = purchases.firstOrNull { it.purchaseState == Purchase.PurchaseState.PURCHASED }
+                }
+            }
+
+            val active = activePurchase
             if (active != null) {
                 if (!active.isAcknowledged) acknowledgePurchase(active)
                 dataStore.subscriptionActive = true
@@ -132,42 +158,44 @@ class BillingManager(
     }
 
     /**
-     * Launches the Google Play subscription purchase sheet for [productId].
-     * Must be called from a thread where [activity] is available; the billing
-     * flow itself is dispatched to the main thread.
+     * Launches the Google Play purchase sheet for [productId].
+     * Routes to SUBS or INAPP depending on the product. Must be called with
+     * [activity] set; the billing flow is dispatched to the main thread.
      */
-    fun launchSubscriptionFlow(productId: String) {
+    fun launchPurchaseFlow(productId: String) {
         val act = activity ?: return
         if (!billingClient.isReady) return
 
+        val productType = if (productId in INAPP_PRODUCTS) BillingClient.ProductType.INAPP
+                          else BillingClient.ProductType.SUBS
+
         val params = QueryProductDetailsParams.newBuilder()
-            .setProductList(
-                listOf(
-                    QueryProductDetailsParams.Product.newBuilder()
-                        .setProductId(productId)
-                        .setProductType(BillingClient.ProductType.SUBS)
-                        .build()
-                )
-            )
+            .setProductList(listOf(
+                QueryProductDetailsParams.Product.newBuilder()
+                    .setProductId(productId)
+                    .setProductType(productType)
+                    .build()
+            ))
             .build()
 
         scope.launch {
             billingClient.queryProductDetailsAsync(params) { result, detailsList ->
                 if (result.responseCode != BillingClient.BillingResponseCode.OK) return@queryProductDetailsAsync
                 val details = detailsList.firstOrNull() ?: return@queryProductDetailsAsync
-                // Use the first available offer (base plan or cheapest trial offer).
-                val offerToken = details.subscriptionOfferDetails?.firstOrNull()?.offerToken
-                    ?: return@queryProductDetailsAsync
+
+                val productDetailsParams = BillingFlowParams.ProductDetailsParams.newBuilder()
+                    .setProductDetails(details)
+                    .apply {
+                        if (productType == BillingClient.ProductType.SUBS) {
+                            val offerToken = details.subscriptionOfferDetails?.firstOrNull()?.offerToken
+                                ?: return@queryProductDetailsAsync
+                            setOfferToken(offerToken)
+                        }
+                    }
+                    .build()
 
                 val flowParams = BillingFlowParams.newBuilder()
-                    .setProductDetailsParamsList(
-                        listOf(
-                            BillingFlowParams.ProductDetailsParams.newBuilder()
-                                .setProductDetails(details)
-                                .setOfferToken(offerToken)
-                                .build()
-                        )
-                    )
+                    .setProductDetailsParamsList(listOf(productDetailsParams))
                     .build()
 
                 act.runOnUiThread {

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
@@ -25,7 +25,7 @@ class SubscriptionBridge(
      * Returns the cached subscription status as JSON.
      * Reads from SharedPreferences — always fast and safe to call on the JS thread.
      *
-     * Response: `{"active": bool, "productId": "dayglance_pro_monthly" | "dayglance_pro_annual" | ""}`
+     * Response: `{"active": bool, "productId": "dayglance_pro_annual" | "dayglance_pro_lifetime" | ""}`
      */
     @JavascriptInterface
     fun getStatus(): String {
@@ -46,11 +46,11 @@ class SubscriptionBridge(
     }
 
     /**
-     * Launches the Google Play subscription purchase sheet for the given product ID.
+     * Launches the Google Play purchase sheet for the given product ID.
      *
      * Valid product IDs:
-     *   - "dayglance_pro_monthly"
-     *   - "dayglance_pro_annual"
+     *   - "dayglance_pro_annual"   (subscription)
+     *   - "dayglance_pro_lifetime" (one-time purchase)
      *
      * The purchase result is delivered asynchronously. JS should listen for
      * visibilitychange and re-call getStatus() when the app comes back to the foreground.
@@ -58,8 +58,8 @@ class SubscriptionBridge(
     @JavascriptInterface
     fun purchase(productId: String) {
         val safeId = if (productId in BillingManager.ALL_PRODUCTS) productId
-                     else BillingManager.PRODUCT_MONTHLY
-        billingManager.launchSubscriptionFlow(safeId)
+                     else BillingManager.PRODUCT_ANNUAL
+        billingManager.launchPurchaseFlow(safeId)
     }
 
     /**
@@ -67,22 +67,22 @@ class SubscriptionBridge(
      * Values are null-safe empty strings until the billing client has connected
      * and queried product details at least once.
      *
-     * Response: `{"monthly": "£2.99", "annual": "£19.99"}`
+     * Response: `{"annual": "£19.99", "lifetime": "£49.99"}`
      */
     @JavascriptInterface
     fun getProductPrices(): String {
-        val monthly = (dataStore.productPriceMonthly ?: "")
+        val annual   = (dataStore.productPriceAnnual   ?: "")
             .replace("\\", "\\\\").replace("\"", "\\\"")
-        val annual = (dataStore.productPriceAnnual ?: "")
+        val lifetime = (dataStore.productPriceLifetime ?: "")
             .replace("\\", "\\\\").replace("\"", "\\\"")
-        return """{"monthly":"$monthly","annual":"$annual"}"""
+        return """{"annual":"$annual","lifetime":"$lifetime"}"""
     }
 
     /**
-     * Convenience: returns "dayglance_pro_monthly" and "dayglance_pro_annual" as a
-     * JSON array so JS knows exactly which product IDs to pass to purchase().
+     * Convenience: returns product IDs as a JSON array so JS knows exactly
+     * which IDs to pass to purchase().
      */
     @JavascriptInterface
     fun getProductIds(): String =
-        """["${BillingManager.PRODUCT_MONTHLY}","${BillingManager.PRODUCT_ANNUAL}"]"""
+        """["${BillingManager.PRODUCT_ANNUAL}","${BillingManager.PRODUCT_LIFETIME}"]"""
 }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
@@ -190,20 +190,20 @@ class SharedDataStore(context: Context) {
             else remove(KEY_SUBSCRIPTION_TOKEN)
         }
 
-    /** Localized price string for the monthly plan, e.g. "£2.99". Null until first Play query. */
-    var productPriceMonthly: String?
-        get() = prefs.getString(KEY_PRODUCT_PRICE_MONTHLY, null)
-        set(value) = prefs.edit {
-            if (value != null) putString(KEY_PRODUCT_PRICE_MONTHLY, value)
-            else remove(KEY_PRODUCT_PRICE_MONTHLY)
-        }
-
     /** Localized price string for the annual plan, e.g. "£19.99". Null until first Play query. */
     var productPriceAnnual: String?
         get() = prefs.getString(KEY_PRODUCT_PRICE_ANNUAL, null)
         set(value) = prefs.edit {
             if (value != null) putString(KEY_PRODUCT_PRICE_ANNUAL, value)
             else remove(KEY_PRODUCT_PRICE_ANNUAL)
+        }
+
+    /** Localized price string for the lifetime plan, e.g. "£49.99". Null until first Play query. */
+    var productPriceLifetime: String?
+        get() = prefs.getString(KEY_PRODUCT_PRICE_LIFETIME, null)
+        set(value) = prefs.edit {
+            if (value != null) putString(KEY_PRODUCT_PRICE_LIFETIME, value)
+            else remove(KEY_PRODUCT_PRICE_LIFETIME)
         }
 
     // ── Step count cache ────────────────────────────────────────────────────
@@ -243,8 +243,8 @@ class SharedDataStore(context: Context) {
         private const val KEY_SUBSCRIPTION_ACTIVE = "subscription_active"
         private const val KEY_SUBSCRIPTION_PRODUCT_ID = "subscription_product_id"
         private const val KEY_SUBSCRIPTION_TOKEN = "subscription_token"
-        private const val KEY_PRODUCT_PRICE_MONTHLY = "product_price_monthly"
-        private const val KEY_PRODUCT_PRICE_ANNUAL = "product_price_annual"
+        private const val KEY_PRODUCT_PRICE_ANNUAL   = "product_price_annual"
+        private const val KEY_PRODUCT_PRICE_LIFETIME = "product_price_lifetime"
 
         const val DEFAULT_DAILY_NOTE_PATTERN = "yyyy-MM-dd"
         const val DEFAULT_NEW_NOTES_FOLDER = "dayGLANCE"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9161,8 +9161,8 @@ const DayPlanner = () => {
         <SubscriptionWall
           isLoading={subLoading}
           prices={subPrices}
-          onSubscribeMonthly={() => subscribe('dayglance_pro_monthly')}
           onSubscribeAnnual={() => subscribe('dayglance_pro_annual')}
+          onSubscribeLifetime={() => subscribe('dayglance_pro_lifetime')}
           onRestore={restore}
         />
       )}

--- a/src/components/SubscriptionWall.jsx
+++ b/src/components/SubscriptionWall.jsx
@@ -11,7 +11,7 @@ import { Loader } from 'lucide-react';
  * The "Founder pricing" badge is intentional during launch. Remove it (or change
  * the copy) when you raise prices.
  */
-export default function SubscriptionWall({ onSubscribeMonthly, onSubscribeAnnual, onRestore, isLoading, prices }) {
+export default function SubscriptionWall({ onSubscribeAnnual, onSubscribeLifetime, onRestore, isLoading, prices }) {
   const dark = (() => {
     try { return JSON.parse(localStorage.getItem('day-planner-darkmode') || 'false'); }
     catch { return false; }
@@ -21,8 +21,8 @@ export default function SubscriptionWall({ onSubscribeMonthly, onSubscribeAnnual
 
   const handleSubscribe = (productId, label) => {
     setPending(label);
-    if (label === 'monthly') onSubscribeMonthly?.();
-    if (label === 'annual')  onSubscribeAnnual?.();
+    if (label === 'annual')   onSubscribeAnnual?.();
+    if (label === 'lifetime') onSubscribeLifetime?.();
   };
 
   const handleRestore = () => {
@@ -75,31 +75,12 @@ export default function SubscriptionWall({ onSubscribeMonthly, onSubscribeAnnual
       <div className="w-full max-w-xs space-y-3 mb-5">
 
         <button
-          onClick={() => handleSubscribe('dayglance_pro_monthly', 'monthly')}
-          disabled={!!pending}
-          className={`w-full rounded-xl border px-4 py-4 text-left transition-colors ${card} ${pending === 'monthly' ? 'opacity-60' : ''}`}
-        >
-          <div className="flex items-baseline justify-between">
-            <span className={`font-semibold text-sm ${text}`}>Monthly</span>
-            {prices?.monthly
-              ? <span className={`text-sm font-medium ${text}`}>{prices.monthly}<span className={`text-xs ${sub}`}>/mo</span></span>
-              : <span className={`text-xs ${sub}`}>See price in Play</span>
-            }
-          </div>
-          <div className={`text-xs mt-0.5 ${sub}`}>Billed monthly · cancel any time</div>
-          {pending === 'monthly' && <Loader className={`w-4 h-4 mt-2 animate-spin ${sub}`} />}
-        </button>
-
-        <button
           onClick={() => handleSubscribe('dayglance_pro_annual', 'annual')}
           disabled={!!pending}
           className={`w-full rounded-xl border px-4 py-4 text-left transition-colors ${card} ${pending === 'annual' ? 'opacity-60' : ''}`}
         >
           <div className="flex items-baseline justify-between">
-            <div className="flex items-center gap-2">
-              <span className={`font-semibold text-sm ${text}`}>Annual</span>
-              <span className="text-xs bg-indigo-600 text-white rounded-full px-2 py-0.5 leading-none">Best value</span>
-            </div>
+            <span className={`font-semibold text-sm ${text}`}>Annual</span>
             {prices?.annual
               ? <span className={`text-sm font-medium ${text}`}>{prices.annual}<span className={`text-xs ${sub}`}>/yr</span></span>
               : <span className={`text-xs ${sub}`}>See price in Play</span>
@@ -109,10 +90,29 @@ export default function SubscriptionWall({ onSubscribeMonthly, onSubscribeAnnual
           {pending === 'annual' && <Loader className={`w-4 h-4 mt-2 animate-spin ${sub}`} />}
         </button>
 
+        <button
+          onClick={() => handleSubscribe('dayglance_pro_lifetime', 'lifetime')}
+          disabled={!!pending}
+          className={`w-full rounded-xl border px-4 py-4 text-left transition-colors ${card} ${pending === 'lifetime' ? 'opacity-60' : ''}`}
+        >
+          <div className="flex items-baseline justify-between">
+            <div className="flex items-center gap-2">
+              <span className={`font-semibold text-sm ${text}`}>Lifetime</span>
+              <span className="text-xs bg-indigo-600 text-white rounded-full px-2 py-0.5 leading-none">Best value</span>
+            </div>
+            {prices?.lifetime
+              ? <span className={`text-sm font-medium ${text}`}>{prices.lifetime}</span>
+              : <span className={`text-xs ${sub}`}>See price in Play</span>
+            }
+          </div>
+          <div className={`text-xs mt-0.5 ${sub}`}>One-time purchase · yours forever</div>
+          {pending === 'lifetime' && <Loader className={`w-4 h-4 mt-2 animate-spin ${sub}`} />}
+        </button>
+
       </div>
 
       <p className={`text-xs text-center mb-6 max-w-xs ${sub}`}>
-        14-day free trial included. Payment via Google Play. Cancel any time.
+        Annual plan includes a 14-day free trial. Payment via Google Play.
       </p>
 
       <button

--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -9,14 +9,14 @@ function readStatus() {
 }
 
 function readPrices() {
-  if (!BILLING) return { monthly: null, annual: null };
+  if (!BILLING) return { annual: null, lifetime: null };
   try {
     const p = JSON.parse(BILLING.getProductPrices());
     return {
-      monthly: p.monthly || null,
-      annual:  p.annual  || null,
+      annual:   p.annual   || null,
+      lifetime: p.lifetime || null,
     };
-  } catch { return { monthly: null, annual: null }; }
+  } catch { return { annual: null, lifetime: null }; }
 }
 
 /**
@@ -72,10 +72,10 @@ export function useSubscription() {
   }, [refresh]);
 
   /**
-   * Opens the Google Play subscription / free-trial sheet.
-   * productId: 'dayglance_pro_monthly' | 'dayglance_pro_annual'
+   * Opens the Google Play purchase sheet.
+   * productId: 'dayglance_pro_annual' | 'dayglance_pro_lifetime'
    */
-  const subscribe = useCallback((productId = 'dayglance_pro_monthly') => {
+  const subscribe = useCallback((productId = 'dayglance_pro_annual') => {
     if (!BILLING) return;
     BILLING.purchase?.(productId);
 


### PR DESCRIPTION
Corrects the billing plan structure. The two plans are:
- **Annual** (`dayglance_pro_annual`) — recurring yearly subscription (SUBS)
- **Lifetime** (`dayglance_pro_lifetime`) — one-time purchase (INAPP)

No monthly plan.

## Changes

**Android**
- `BillingManager`: removed `PRODUCT_MONTHLY`, kept `PRODUCT_ANNUAL` (yearly sub), added `PRODUCT_LIFETIME` (INAPP); split into `SUBSCRIPTION_PRODUCTS` + `INAPP_PRODUCTS`; `queryProductPrices()` queries each type separately; `queryPurchases()` checks SUBS then INAPP; `launchSubscriptionFlow()` renamed to `launchPurchaseFlow()` and routes to correct product type
- `SharedDataStore`: removed `productPriceMonthly`, kept `productPriceAnnual`, added `productPriceLifetime`
- `SubscriptionBridge`: `getProductPrices()` returns `{"annual", "lifetime"}`; `getProductIds()` updated; fallback in `purchase()` is now `PRODUCT_ANNUAL`

**Web**
- `useSubscription.js`: `readPrices()` returns `{ annual, lifetime }`; default product ID updated to annual
- `SubscriptionWall.jsx`: shows Annual card (billed yearly) and Lifetime card (one-time); footnote clarifies free trial is on annual plan only
- `App.jsx`: props updated to `onSubscribeAnnual` + `onSubscribeLifetime`

## Play Console setup
- `dayglance_pro_annual` → Monetize → **Subscriptions** (auto-renewing)
- `dayglance_pro_lifetime` → Monetize → **In-app products** (one-time)

Supersedes #743.

https://claude.ai/code/session_01My6Am5tsriBopdqfYeN1wV

---
_Generated by [Claude Code](https://claude.ai/code/session_01My6Am5tsriBopdqfYeN1wV)_