### PR TITLE
Bump Android versionCode to 58

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 57
+        versionCode = 58
         versionName = "3.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Increments `versionCode` from 57 to 58 for the v3.0 billing release. `versionName` stays at `"3.0"`.

https://claude.ai/code/session_01My6Am5tsriBopdqfYeN1wV

---
_Generated by [Claude Code](https://claude.ai/code/session_01My6Am5tsriBopdqfYeN1wV)_