### PR TITLE
Fix subscription wall UI + bump versionCode to 59

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 58
+        versionCode = 59
         versionName = "3.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/components/SubscriptionWall.jsx
+++ b/src/components/SubscriptionWall.jsx
@@ -54,7 +54,6 @@ export default function SubscriptionWall({ onSubscribeAnnual, onSubscribeLifetim
           className={`h-10 ${dark ? '' : 'invert'}`}
           onError={e => { e.target.style.display = 'none'; }}
         />
-        <span className={`text-2xl font-bold tracking-tight ${text}`}>dayGLANCE</span>
       </div>
 
       {/* Founder badge */}
@@ -65,10 +64,10 @@ export default function SubscriptionWall({ onSubscribeAnnual, onSubscribeLifetim
 
       {/* Headline */}
       <h1 className={`text-xl font-semibold text-center mb-2 ${text}`}>
-        Your free trial has ended
+        Unlock dayGLANCE Pro
       </h1>
       <p className={`text-sm text-center mb-7 max-w-xs ${sub}`}>
-        Subscribe to keep using dayGLANCE. Your data is safe and waiting.
+        Choose a plan to keep using dayGLANCE. Your data is safe and waiting.
       </p>
 
       {/* Plan cards */}


### PR DESCRIPTION
Two UI fixes found during debug testing, plus a versionCode bump for the next build.

## Changes
- `SubscriptionWall.jsx`: removed duplicate "dayGLANCE" text label that appeared below the logo image; changed headline from "Your free trial has ended" to "Unlock dayGLANCE Pro" (neutral copy that works for new and returning users alike)
- `build.gradle.kts`: `versionCode` 58 → 59

https://claude.ai/code/session_01My6Am5tsriBopdqfYeN1wV

---
_Generated by [Claude Code](https://claude.ai/code/session_01My6Am5tsriBopdqfYeN1wV)_