### PR TITLE
Add github build flavor with billing disabled

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -74,6 +74,19 @@ android {
 
     buildFeatures {
         viewBinding = true
+        buildConfig = true
+    }
+
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("play") {
+            dimension = "distribution"
+            buildConfigField("boolean", "BILLING_ENABLED", "true")
+        }
+        create("github") {
+            dimension = "distribution"
+            buildConfigField("boolean", "BILLING_ENABLED", "false")
+        }
     }
 }
 

--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -33,6 +33,7 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.health.connect.client.PermissionController
 import androidx.webkit.WebViewAssetLoader
+import com.dayglance.app.BuildConfig
 import com.dayglance.app.billing.BillingManager
 import com.dayglance.app.billing.SubscriptionBridge
 import com.dayglance.app.bridge.NativeBridge
@@ -134,8 +135,11 @@ class MainActivity : AppCompatActivity() {
         billingManager = BillingManager(this, dataStore)
         subscriptionBridge = SubscriptionBridge(billingManager, dataStore)
 
-        // Fast path: if the cache already confirms an active subscription, don't wait.
-        if (dataStore.subscriptionActive) {
+        // Debug and github flavor builds skip billing entirely.
+        if (BuildConfig.DEBUG || !BuildConfig.BILLING_ENABLED) {
+            billingReady = true
+        } else if (dataStore.subscriptionActive) {
+            // Fast path: cache already confirms active — no need to wait for Play.
             billingReady = true
         } else {
             billingManager.onPurchasesQueried = { billingReady = true }
@@ -326,14 +330,18 @@ class MainActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
-        billingManager.activity = this
-        billingManager.connect()
+        if (BuildConfig.BILLING_ENABLED && !BuildConfig.DEBUG) {
+            billingManager.activity = this
+            billingManager.connect()
+        }
     }
 
     override fun onStop() {
         super.onStop()
-        billingManager.activity = null
-        billingManager.disconnect()
+        if (BuildConfig.BILLING_ENABLED && !BuildConfig.DEBUG) {
+            billingManager.activity = null
+            billingManager.disconnect()
+        }
     }
 
     override fun onResume() {

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
@@ -1,6 +1,7 @@
 package com.dayglance.app.billing
 
 import android.webkit.JavascriptInterface
+import com.dayglance.app.BuildConfig
 import com.dayglance.app.data.SharedDataStore
 
 /**
@@ -29,7 +30,7 @@ class SubscriptionBridge(
      */
     @JavascriptInterface
     fun getStatus(): String {
-        val active = dataStore.subscriptionActive
+        val active = BuildConfig.DEBUG || !BuildConfig.BILLING_ENABLED || dataStore.subscriptionActive
         val productId = (dataStore.subscriptionProductId ?: "")
             .replace("\\", "\\\\").replace("\"", "\\\"")
         return """{"active":$active,"productId":"$productId"}"""


### PR DESCRIPTION
Adds a `github` product flavor with `BILLING_ENABLED=false`, alongside the existing `play` flavor with `BILLING_ENABLED=true`. Also disables billing for debug builds.

## Behavior when billing is disabled (github flavor or debug build)
- `billingReady` is set immediately — splash screen doesn't wait for Play
- Billing client is never connected — no Play Services calls made
- `SubscriptionBridge.getStatus()` always returns `active: true`

## Build variants
- `playRelease` → Play Store upload
- `githubRelease` → GitHub releases (no paywall)
- `playDebug` / `githubDebug` → development (no paywall)

## Why it can't be gamed
`BuildConfig.BILLING_ENABLED` is a compile-time constant. It can't be changed at runtime, only by rebuilding from source — which anyone could do anyway since the code is open source.

https://claude.ai/code/session_01My6Am5tsriBopdqfYeN1wV

---
_Generated by [Claude Code](https://claude.ai/code/session_01My6Am5tsriBopdqfYeN1wV)_