### PR TITLE
Fix iOS iCloud sync overwriting macOS data on first launch

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
@@ -28,11 +28,12 @@ final class ICloudBridge {
         // Trigger download if the file exists in cloud but hasn't been fetched locally yet.
         try? FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
 
-        // If it's still a cloud-only placeholder, return null — next poll will get it.
+        // If it's still a cloud-only placeholder, signal "downloading" so the caller
+        // doesn't mistake it for "no remote file" and accidentally seed with empty data.
         if let values = try? fileURL.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey]),
            let status = values.ubiquitousItemDownloadingStatus,
            status == .notDownloaded {
-            return "null"
+            return #"{"downloading":true}"#
         }
 
         guard let data = try? Data(contentsOf: fileURL),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1306,8 +1306,11 @@ const DayPlanner = () => {
         return;
       }
 
+      // iCloud file exists but is still downloading from the cloud — skip this
+      // cycle and let the 60-second poll retry once it's available locally.
       let remote;
       try { remote = JSON.parse(str); } catch { return; }
+      if (remote?.downloading) return;
       if (!remote?.data) return;
 
       const localData = buildSyncPayload().data;


### PR DESCRIPTION
## Summary

- When the iCloud sync file exists remotely but hasn't been downloaded to the device yet, `ICloudBridge.readSync()` was returning `"null"` — identical to "no file exists at all"
- The JS sync loop treated this as "no remote file" and seeded iCloud with empty local data, **overwriting whatever the macOS app had written**
- Fix: `ICloudBridge` now returns `{"downloading":true}` for cloud-only placeholders; the JS sync loop skips the seed cycle and lets the 60-second poll retry once the file is locally available

## Test plan

- [ ] Open iOS app for the first time (with macOS app having existing tasks in iCloud)
- [ ] Verify tasks from macOS appear on iOS within ~60 seconds (next poll after file downloads)
- [ ] Verify macOS data is not overwritten/lost
- [ ] Verify new users (no existing iCloud file) still get their local data seeded correctly on first launch

https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr)_