### PR TITLE
Phase 7 complete: iCloud real-time watch + PrivacyInfo.xcprivacy

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
@@ -11,6 +11,14 @@ final class ICloudBridge {
     private let containerID   = "iCloud.com.dayglance"
     private let syncFileName  = "dayglance-sync.json"
 
+    // MARK: - Remote-change watching
+
+    private var metadataQuery: NSMetadataQuery?
+
+    // Suppress query callbacks that fire immediately after our own local write.
+    private var lastLocalWriteDate: Date?
+    private let writeSuppressionInterval: TimeInterval = 3.0
+
     // MARK: - Public API
 
     /// Returns the sync file JSON, "null" if unavailable/not yet downloaded,
@@ -56,6 +64,7 @@ final class ICloudBridge {
             guard let data = json.data(using: .utf8) else {
                 return #"{"ok":false,"error":"encoding error"}"#
             }
+            lastLocalWriteDate = Date()
             try data.write(to: fileURL, options: .atomic)
             return #"{"ok":true}"#
         } catch {
@@ -64,8 +73,44 @@ final class ICloudBridge {
     }
 
     /// Returns {"available":true} if iCloud is signed in and the container is accessible.
+    /// Also kicks off NSMetadataQuery watching the first time availability is confirmed.
     func isAvailable() -> String {
-        containerURL() != nil ? #"{"available":true}"# : #"{"available":false}"#
+        guard containerURL() != nil else { return #"{"available":false}"# }
+        DispatchQueue.main.async { self.startWatching() }
+        return #"{"available":true}"#
+    }
+
+    // MARK: - NSMetadataQuery watch
+
+    /// Starts an NSMetadataQuery that watches the iCloud sync file for remote changes
+    /// (e.g. the macOS app wrote while the iOS app was open). Must run on main thread.
+    private func startWatching() {
+        guard metadataQuery == nil else { return }
+
+        let q = NSMetadataQuery()
+        q.searchScopes = [NSMetadataQueryUbiquitousDocumentsScope]
+        q.predicate = NSPredicate(format: "%K == %@", NSMetadataItemFSNameKey, syncFileName)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleQueryUpdate),
+            name: .NSMetadataQueryDidUpdate,
+            object: q
+        )
+
+        q.start()
+        metadataQuery = q
+    }
+
+    @objc private func handleQueryUpdate() {
+        // Skip if the change was caused by our own recent write.
+        if let lastWrite = lastLocalWriteDate,
+           Date().timeIntervalSince(lastWrite) < writeSuppressionInterval {
+            return
+        }
+        // Fire the same notification that scenePhase foreground transitions use,
+        // so the JS sync cycle runs immediately without waiting for the 60-second poll.
+        NotificationCenter.default.post(name: .dayGlanceForeground, object: nil)
     }
 
     // MARK: - Helpers

--- a/dayglance-ios/DayGlance/PrivacyInfo.xcprivacy
+++ b/dayglance-ios/DayGlance/PrivacyInfo.xcprivacy
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <!-- File timestamps: used to detect remote iCloud sync file changes -->
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>DDA9.1</string>
+            </array>
+        </dict>
+        <dict>
+            <!-- UserDefaults: used to persist Obsidian vault bookmarks and app settings -->
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>1C8F.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -273,14 +273,46 @@ ipcMain.handle('icloud:read', () => {
   } catch { return null; }
 });
 
+// Track our own writes so the fs.watch callback can ignore them.
+let lastMacOSWriteTime = 0;
+const ICLOUD_WRITE_SUPPRESSION_MS = 3000;
+
 ipcMain.handle('icloud:write', (_event, json: string) => {
   if (process.platform !== 'darwin') return false;
   try {
     fs.mkdirSync(path.dirname(ICLOUD_SYNC_PATH), { recursive: true });
     fs.writeFileSync(ICLOUD_SYNC_PATH, json, { encoding: 'utf-8' });
+    lastMacOSWriteTime = Date.now();
     return true;
   } catch { return false; }
 });
+
+// Watch the iCloud container directory for changes written by the iOS app.
+// Sends 'icloud:changed' to the renderer so it can run a sync cycle immediately
+// instead of waiting for the 60-second poll.
+function startICloudWatch(win: BrowserWindow): void {
+  if (process.platform !== 'darwin') return;
+  const dir = path.dirname(ICLOUD_SYNC_PATH);
+  const file = path.basename(ICLOUD_SYNC_PATH);
+  try { fs.mkdirSync(dir, { recursive: true }); } catch {}
+
+  let debounce: ReturnType<typeof setTimeout> | null = null;
+
+  try {
+    fs.watch(dir, (_eventType, filename) => {
+      if (filename !== file) return;
+      if (Date.now() - lastMacOSWriteTime < ICLOUD_WRITE_SUPPRESSION_MS) return;
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(() => {
+        try {
+          if (!fs.existsSync(ICLOUD_SYNC_PATH)) return;
+          const content = fs.readFileSync(ICLOUD_SYNC_PATH, 'utf-8');
+          live(win)?.webContents.send('icloud:changed', content);
+        } catch {}
+      }, 500);
+    });
+  } catch {}
+}
 
 // Proxy outbound HTTP requests from the renderer so they aren't subject to
 // Chromium's CORS restrictions when the app is loaded from file://.
@@ -459,7 +491,7 @@ app.whenReady().then(() => {
 
   const win = createWindow();
   createWsServer(() => live(mainWindow));
-  if (process.platform === 'darwin') createTray();
+  if (process.platform === 'darwin') { createTray(); startICloudWatch(win); }
 
   app.on('activate', () => {
     const mw = live(mainWindow);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -92,6 +92,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // macOS only; returns null/false on other platforms.
   readICloud: (): Promise<string | null> => ipcRenderer.invoke('icloud:read'),
   writeICloud: (json: string): Promise<boolean> => ipcRenderer.invoke('icloud:write', json),
+  onICloudChanged: (callback: (json: string) => void) => {
+    const handler = (_: Electron.IpcRendererEvent, json: string) => callback(json);
+    ipcRenderer.on('icloud:changed', handler);
+    return () => ipcRenderer.removeListener('icloud:changed', handler);
+  },
 
   // Tray popup listens for the signal to focus the quick-add input.
   onFocusQuickAdd: (callback: () => void) => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1357,6 +1357,13 @@ const DayPlanner = () => {
     return () => document.removeEventListener('visibilitychange', onVisible);
   }, []);
 
+  // On Electron/macOS, sync immediately when the main process detects the iCloud
+  // file was changed by the iOS app (fs.watch → icloud:changed IPC event).
+  useEffect(() => {
+    if (!isElectronMac()) return;
+    return window.electronAPI.onICloudChanged?.(() => iCloudSyncRef.current?.());
+  }, []);
+
   // Cloud sync: download on app load or when sync is first enabled.
   // If encryption is enabled, wait until the session key is ready (either
   // restored from IndexedDB or provided by the passphrase modal).


### PR DESCRIPTION
## Summary

Closes the three remaining Phase 7 gaps:

- **NSMetadataQuery (iOS)**: `ICloudBridge` starts a query on first confirmed availability, watching the iCloud Documents scope for `dayglance-sync.json`. When the macOS app writes and iCloud propagates the change, the query fires `dayGlanceForeground` immediately — no waiting for the 60-second poll. Own writes are suppressed for 3 seconds to avoid echo loops.

- **fs.watch (macOS)**: Electron main process watches the iCloud container directory for file changes written by iOS. Debounces at 500ms, suppresses own writes for 3 seconds, sends `icloud:changed` IPC to the renderer. `App.jsx` listens and triggers a sync immediately.

- **PrivacyInfo.xcprivacy**: Created the required App Store privacy manifest declaring `NSPrivacyAccessedAPICategoryFileTimestamp` (DDA9.1) for iCloud sync file access and `NSPrivacyAccessedAPICategoryUserDefaults` (1C8F.1) for Obsidian vault bookmarks and app settings. Required for iOS 17+ App Store submission.

## Test plan

- [ ] Make a change on macOS — verify it appears on iOS within a few seconds (not 60s)
- [ ] Make a change on iOS — verify it appears on macOS within a few seconds
- [ ] Verify no sync loop (changes don't keep re-applying themselves)
- [ ] Build in Xcode — confirm PrivacyInfo.xcprivacy appears in the target and no privacy manifest warnings

https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr)_