### PR TITLE
Reduce iCloud poll interval from 60s to 15s

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1339,11 +1339,13 @@ const DayPlanner = () => {
     iCloudSyncRef.current?.();
   }, [dataLoaded]);
 
-  // Poll every 60 seconds — iCloud daemon handles actual network sync;
-  // we just read/write the local container file.
+  // Poll every 15 seconds — iCloud daemon handles actual network sync;
+  // we just read/write the local container file. 15s ensures changes appear
+  // promptly even when the real-time watchers (NSMetadataQuery / fs.watch)
+  // don't fire, which is common for iCloud-daemon-managed files.
   useEffect(() => {
     if (!isNativeIOS() && !isElectronMac()) return;
-    const timer = setInterval(() => iCloudSyncRef.current?.(), 60 * 1000);
+    const timer = setInterval(() => iCloudSyncRef.current?.(), 15 * 1000);
     return () => clearInterval(timer);
   }, []);
 


### PR DESCRIPTION
## Summary

The real-time watchers added in Phase 7 (NSMetadataQuery on iOS, fs.watch on macOS) are unreliable for files managed by the iCloud daemon — changes were taking up to 5 minutes to appear instead of ~60 seconds. The poll is the primary delivery mechanism in practice.

Reducing from 60s → 15s means changes appear within ~15 seconds of iCloud finishing propagation on either device, which feels acceptably responsive.

## Test plan

- [ ] Make a change on macOS — appears on iOS within ~15–30s
- [ ] Make a change on iOS — appears on macOS within ~15–30s
- [ ] No noticeable performance impact from the more frequent poll (it's a fast local file read)

https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr)_