### PR TITLE
Phase 8: audio recording bridge (AVAudioRecorder)

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/AudioBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/AudioBridge.swift
@@ -1,0 +1,88 @@
+import Foundation
+import AVFoundation
+
+/// Records voice input via AVAudioRecorder and returns it as a base64 MP4 data URL,
+/// matching the Android MediaRecorder bridge contract exactly.
+///
+/// Called synchronously from the JS bridge on a WKURLSchemeHandler background thread.
+/// All AVAudioSession / AVAudioRecorder interactions are marshalled to the main thread.
+final class AudioBridge {
+
+    static let shared = AudioBridge()
+
+    private var recorder: AVAudioRecorder?
+    private var recordingURL: URL?
+
+    // MARK: - Public API
+
+    /// Activates the record audio session, creates the recorder, and starts capture.
+    /// Returns "ok" on success or {"error":"…"} on failure.
+    func startRecording() -> String {
+        var result = "ok"
+        DispatchQueue.main.sync {
+            do {
+                let session = AVAudioSession.sharedInstance()
+                try session.setCategory(.record, mode: .default)
+                try session.setActive(true)
+
+                let url = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("dayglance_voice.m4a")
+                recordingURL = url
+
+                let settings: [String: Any] = [
+                    AVFormatIDKey:         Int(kAudioFormatMPEG4AAC),
+                    AVSampleRateKey:       16000.0,
+                    AVEncoderBitRateKey:   32000,
+                    AVNumberOfChannelsKey: 1,
+                ]
+
+                let rec = try AVAudioRecorder(url: url, settings: settings)
+                rec.prepareToRecord()
+
+                guard rec.record() else {
+                    // record() returns false when permission is denied; iOS shows
+                    // the system dialog automatically on the first attempt.
+                    result = #"{"error":"Could not start recording — grant microphone access in Settings and try again"}"#
+                    return
+                }
+                recorder = rec
+            } catch {
+                result = #"{"error":"\#(esc(error.localizedDescription))"}"#
+            }
+        }
+        return result
+    }
+
+    /// Stops the recorder, restores the ambient audio session, and returns the
+    /// captured audio as a data:audio/mp4;base64,… string (matching Android).
+    /// Returns {"error":"…"} if no recording is active or if file I/O fails.
+    func stopRecording() -> String {
+        var result = #"{"error":"no active recording"}"#
+        DispatchQueue.main.sync {
+            guard let rec = recorder, let url = recordingURL else { return }
+            rec.stop()
+            recorder = nil
+            recordingURL = nil
+
+            // Restore ambient session so background audio can resume.
+            try? AVAudioSession.sharedInstance().setCategory(.ambient, mode: .default)
+            try? AVAudioSession.sharedInstance().setActive(true)
+
+            do {
+                let data = try Data(contentsOf: url)
+                try? FileManager.default.removeItem(at: url)
+                result = "data:audio/mp4;base64,\(data.base64EncodedString())"
+            } catch {
+                result = #"{"error":"\#(esc(error.localizedDescription))"}"#
+            }
+        }
+        return result
+    }
+
+    // MARK: - Helpers
+
+    private func esc(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+         .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
+++ b/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
@@ -141,6 +141,12 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
         case "iCloudAvailable":
             return ICloudBridge.shared.isAvailable()
 
+        // Phase 8 — Audio recording
+        case "startRecording":
+            return AudioBridge.shared.startRecording()
+        case "stopRecording":
+            return AudioBridge.shared.stopRecording()
+
         default:
             return "null"
         }

--- a/dayglance-ios/project.yml
+++ b/dayglance-ios/project.yml
@@ -75,5 +75,6 @@ targets:
         NSCalendarsUsageDescription: "dayGLANCE reads your calendars to show upcoming events on the home screen."
         NSCalendarsFullAccessUsageDescription: "dayGLANCE reads your calendars to show upcoming events on the home screen and can create calendar events from your tasks."
         NSCalendarsWriteOnlyAccessUsageDescription: "dayGLANCE can create calendar events from your tasks."
+        NSMicrophoneUsageDescription: "dayGLANCE uses the microphone to record voice input for AI task parsing."
         NSAppTransportSecurity:
           NSAllowsArbitraryLoads: true


### PR DESCRIPTION
## Summary

Implements Phase 8 of the iOS plan — audio recording via `AVAudioRecorder`, matching the Android `MediaRecorder` bridge contract exactly so no JS changes are needed.

**`AudioBridge.swift`** (new):
- `startRecording()` — switches `AVAudioSession` to `.record`, initialises `AVAudioRecorder` at 16kHz / AAC / 32kbps into a temp `.m4a` file, starts capture. Returns `"ok"` or `{"error":"…"}`. iOS shows the microphone permission dialog automatically on first call.
- `stopRecording()` — stops the recorder, restores `.ambient` session so background audio can resume, reads the temp file, returns `data:audio/mp4;base64,…` (same format as Android). Deletes temp file.

**`BridgeSchemeHandler.swift`**: routes `startRecording` / `stopRecording` to `AudioBridge`.

**`project.yml`**: adds `NSMicrophoneUsageDescription` (required for App Store).

No JS changes needed — `nativeStartRecording()` / `nativeStopRecording()` in `native.js` already handle the iOS bridge via the `DayGlanceNative` Proxy.

## Test plan

- [ ] Tap the voice input button — iOS microphone permission dialog appears on first use
- [ ] Grant permission — recording starts
- [ ] Stop recording — audio is transcribed correctly by the AI
- [ ] Deny permission — error message shown, no crash
- [ ] Background music pauses during recording and resumes after stopping

https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr)_