### PR TITLE
Harden iCloud + WebDAV sync: separate backoffs, lock fixes, atomic writes

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -268,20 +268,36 @@ const ICLOUD_SYNC_PATH = path.join(
 ipcMain.handle('icloud:read', () => {
   if (process.platform !== 'darwin') return null;
   try {
-    if (!fs.existsSync(ICLOUD_SYNC_PATH)) return null;
+    const dir = path.dirname(ICLOUD_SYNC_PATH);
+    const base = path.basename(ICLOUD_SYNC_PATH);
+    // iCloud daemon stores cloud-only files as hidden .filename.icloud placeholders.
+    // Detect this case and tell JS to wait rather than treating it as "no remote file".
+    if (!fs.existsSync(ICLOUD_SYNC_PATH)) {
+      if (fs.existsSync(path.join(dir, '.' + base + '.icloud'))) {
+        return JSON.stringify({ downloading: true });
+      }
+      return null;
+    }
     return fs.readFileSync(ICLOUD_SYNC_PATH, 'utf-8');
   } catch { return null; }
 });
 
 // Track our own writes so the fs.watch callback can ignore them.
 let lastMacOSWriteTime = 0;
-const ICLOUD_WRITE_SUPPRESSION_MS = 3000;
+// 5s suppression: iCloud daemon can take longer than 3s to propagate a write
+// back through fs.watch, causing self-echo sync cycles.
+const ICLOUD_WRITE_SUPPRESSION_MS = 5000;
 
 ipcMain.handle('icloud:write', (_event, json: string) => {
   if (process.platform !== 'darwin') return false;
   try {
-    fs.mkdirSync(path.dirname(ICLOUD_SYNC_PATH), { recursive: true });
-    fs.writeFileSync(ICLOUD_SYNC_PATH, json, { encoding: 'utf-8' });
+    const dir = path.dirname(ICLOUD_SYNC_PATH);
+    fs.mkdirSync(dir, { recursive: true });
+    // Atomic write: write to a temp file then rename so the iCloud daemon never
+    // picks up a partially-written file.
+    const tmp = ICLOUD_SYNC_PATH + '.tmp';
+    fs.writeFileSync(tmp, json, { encoding: 'utf-8' });
+    fs.renameSync(tmp, ICLOUD_SYNC_PATH);
     lastMacOSWriteTime = Date.now();
     return true;
   } catch { return false; }
@@ -289,7 +305,7 @@ ipcMain.handle('icloud:write', (_event, json: string) => {
 
 // Watch the iCloud container directory for changes written by the iOS app.
 // Sends 'icloud:changed' to the renderer so it can run a sync cycle immediately
-// instead of waiting for the 60-second poll.
+// instead of waiting for the 15-second poll.
 function startICloudWatch(win: BrowserWindow): void {
   if (process.platform !== 'darwin') return;
   const dir = path.dirname(ICLOUD_SYNC_PATH);
@@ -298,20 +314,30 @@ function startICloudWatch(win: BrowserWindow): void {
 
   let debounce: ReturnType<typeof setTimeout> | null = null;
 
-  try {
-    fs.watch(dir, (_eventType, filename) => {
-      if (filename !== file) return;
-      if (Date.now() - lastMacOSWriteTime < ICLOUD_WRITE_SUPPRESSION_MS) return;
-      if (debounce) clearTimeout(debounce);
-      debounce = setTimeout(() => {
-        try {
-          if (!fs.existsSync(ICLOUD_SYNC_PATH)) return;
-          const content = fs.readFileSync(ICLOUD_SYNC_PATH, 'utf-8');
-          live(win)?.webContents.send('icloud:changed', content);
-        } catch {}
-      }, 500);
-    });
-  } catch {}
+  // Re-attachable watcher: iCloud daemon can recreate the directory (e.g. on
+  // Sonoma+), which kills the watcher silently. Re-attach on error or close.
+  const attach = () => {
+    try {
+      const watcher = fs.watch(dir, (_eventType, filename) => {
+        if (filename !== file) return;
+        if (Date.now() - lastMacOSWriteTime < ICLOUD_WRITE_SUPPRESSION_MS) return;
+        if (debounce) clearTimeout(debounce);
+        debounce = setTimeout(() => {
+          try {
+            if (!fs.existsSync(ICLOUD_SYNC_PATH)) return;
+            const content = fs.readFileSync(ICLOUD_SYNC_PATH, 'utf-8');
+            live(win)?.webContents.send('icloud:changed', content);
+          } catch {}
+        }, 1000);
+      });
+      watcher.on('error', () => setTimeout(attach, 5000));
+      watcher.on('close', () => setTimeout(attach, 5000));
+    } catch {
+      setTimeout(attach, 5000);
+    }
+  };
+
+  attach();
 }
 
 // Proxy outbound HTTP requests from the renderer so they aren't subject to

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -478,6 +478,8 @@ const DayPlanner = () => {
     cloudSyncDownloadRef,
     cloudSyncErrorCountRef,
     cloudSyncBackoffUntilRef,
+    cloudSyncDownloadErrorCountRef,
+    cloudSyncDownloadBackoffUntilRef,
   } = useCloudSync();
 
   // Ref so interval/timeout callbacks can read the current syncKeyReady without stale closure
@@ -1181,9 +1183,9 @@ const DayPlanner = () => {
       // avoid a double-sync from both the native visibilitychange and our Swift dispatch.
       if (!document.hidden && !window.DayGlanceIOS) {
         setCurrentTime(new Date());
-        if (Date.now() >= cloudSyncBackoffUntilRef.current) {
-          cloudSyncDownloadRef.current?.();
-        }
+        // Reset download backoff when user returns to the app so retries happen promptly.
+        cloudSyncDownloadBackoffUntilRef.current = 0;
+        cloudSyncDownloadRef.current?.();
         syncHealthConnectHabitsRef.current?.();
       }
     };
@@ -1191,11 +1193,10 @@ const DayPlanner = () => {
     // that occurs when scenePhase fires before WKWebView updates visibility state.
     const handleNativeForeground = () => {
       setCurrentTime(new Date());
+      cloudSyncDownloadBackoffUntilRef.current = 0;
       // iCloud runs first (fast local file I/O), then WebDAV (network)
       iCloudSyncRef.current?.();
-      if (Date.now() >= cloudSyncBackoffUntilRef.current) {
-        cloudSyncDownloadRef.current?.();
-      }
+      cloudSyncDownloadRef.current?.();
       syncHealthConnectHabitsRef.current?.();
     };
     document.addEventListener('visibilitychange', handleVisibility);
@@ -1275,10 +1276,23 @@ const DayPlanner = () => {
   const isElectronMac = () =>
     !!(window.electronAPI?.isElectron && window.electronAPI?.platform === 'darwin');
 
+  const iCloudWriteSync = async (onIOS, payloadStr) => {
+    if (onIOS) {
+      try {
+        const r = JSON.parse(window.DayGlanceNative.writeICloudSync(payloadStr));
+        if (!r.ok) console.error('iCloud write failed:', r.error);
+      } catch { console.error('iCloud write failed'); }
+    } else {
+      const ok = await window.electronAPI.writeICloud(payloadStr);
+      if (!ok) console.error('iCloud write failed');
+    }
+  };
+
   const iCloudSync = async () => {
     const onIOS = isNativeIOS();
     const onMac = !onIOS && isElectronMac();
     if (!onIOS && !onMac) return;
+    if (!dataLoaded) return;
     if (cloudSyncInProgressRef.current) return;
 
     // iOS: check iCloud availability once and cache.
@@ -1299,18 +1313,23 @@ const DayPlanner = () => {
         : await window.electronAPI.readICloud();
 
       if (!str || str === 'null') {
-        // No remote file yet — seed it with local data.
-        const payload = JSON.stringify(buildSyncPayload());
-        if (onIOS) window.DayGlanceNative.writeICloudSync(payload);
-        else await window.electronAPI.writeICloud(payload);
+        // No remote file yet — seed it with local data, but only if state is hydrated.
+        // If React state is empty but localStorage has tasks, we'd wipe the cloud file.
+        const localTaskCount = JSON.parse(localStorage.getItem('day-planner-tasks') || '[]').length;
+        const localInboxCount = JSON.parse(localStorage.getItem('day-planner-unscheduled') || '[]').length;
+        const payload = buildSyncPayload();
+        const payloadTaskCount = (payload.data?.tasks?.length || 0) + (payload.data?.unscheduledTasks?.length || 0);
+        if (localTaskCount + localInboxCount > 0 && payloadTaskCount === 0) return;
+        await iCloudWriteSync(onIOS, JSON.stringify(payload));
         return;
       }
 
       // iCloud file exists but is still downloading from the cloud — skip this
-      // cycle and let the 60-second poll retry once it's available locally.
+      // cycle and let the 15-second poll retry once it's available locally.
       let remote;
       try { remote = JSON.parse(str); } catch { return; }
       if (remote?.downloading) return;
+      if (remote?.error) { console.error('iCloud unavailable:', remote.error); return; }
       if (!remote?.data) return;
 
       const localData = buildSyncPayload().data;
@@ -1321,9 +1340,8 @@ const DayPlanner = () => {
         localStorage.setItem('day-planner-cloud-sync-local-modified', new Date().toISOString());
       }
       if (remoteChanged || localChanged) {
-        const payload = JSON.stringify({ version: 2, lastModified: new Date().toISOString(), data: mergedData });
-        if (onIOS) window.DayGlanceNative.writeICloudSync(payload);
-        else await window.electronAPI.writeICloud(payload);
+        const payloadStr = JSON.stringify({ version: 2, lastModified: new Date().toISOString(), data: mergedData });
+        await iCloudWriteSync(onIOS, payloadStr);
       }
     } finally {
       cloudSyncInProgressRef.current = false;
@@ -1383,7 +1401,7 @@ const DayPlanner = () => {
   useEffect(() => {
     if (isTrayMode || !cloudSyncConfig?.enabled) return;
     const pollTimer = setInterval(() => {
-      if (syncKeyReadyRef.current && Date.now() >= cloudSyncBackoffUntilRef.current) {
+      if (syncKeyReadyRef.current && Date.now() >= cloudSyncDownloadBackoffUntilRef.current) {
         cloudSyncDownloadRef.current?.();
       }
     }, 60 * 1000);
@@ -4634,12 +4652,12 @@ const DayPlanner = () => {
     };
   };
 
-  const cloudSyncUpload = async (prebuiltPayload) => {
-    if (!cloudSyncConfig?.enabled || cloudSyncInProgressRef.current) return;
+  const cloudSyncUpload = async (prebuiltPayload, { skipLockCheck = false } = {}) => {
+    if (!cloudSyncConfig?.enabled || (!skipLockCheck && cloudSyncInProgressRef.current)) return;
     const provider = cloudSyncProviders[cloudSyncConfig.provider];
     if (!provider) return;
 
-    cloudSyncInProgressRef.current = true;
+    if (!skipLockCheck) cloudSyncInProgressRef.current = true;
     const syncStart = Date.now();
     setCloudSyncStatus('uploading');
     setCloudSyncError(null);
@@ -4682,7 +4700,7 @@ const DayPlanner = () => {
       setCloudSyncStatus('error');
       setTimeout(() => setCloudSyncStatus((s) => s === 'error' ? 'idle' : s), 5000);
     } finally {
-      cloudSyncInProgressRef.current = false;
+      if (!skipLockCheck) cloudSyncInProgressRef.current = false;
     }
   };
 
@@ -4861,12 +4879,12 @@ const DayPlanner = () => {
     const syncStart = Date.now();
     setCloudSyncStatus('downloading');
     setCloudSyncError(null);
+    let conflictShown = false;
     try {
       const remote = await provider.download(cloudSyncConfig);
       if (!remote) {
-        // No remote file yet — do initial upload
-        cloudSyncInProgressRef.current = false;
-        await cloudSyncUpload();
+        // No remote file yet — do initial upload (hold lock through upload)
+        await cloudSyncUpload(undefined, { skipLockCheck: true });
         return;
       }
 
@@ -4874,11 +4892,12 @@ const DayPlanner = () => {
       const hasNeverSynced = !localStorage.getItem('day-planner-cloud-sync-last-synced');
 
       if (hasNeverSynced && remoteModified) {
-        // First sync on this device — ask user what to do
-        // Keep inProgressRef locked so poll timer doesn't re-trigger
+        // First sync on this device — ask user what to do.
+        // Set conflictShown so the finally block doesn't release the lock;
+        // conflict dialog handlers release it explicitly.
+        conflictShown = true;
         setCloudSyncConflict({ remoteData: remote.data, remoteModified });
         setCloudSyncStatus('idle');
-        // Don't release lock — conflict dialog handlers will release it
         return;
       }
 
@@ -4911,14 +4930,15 @@ const DayPlanner = () => {
           lastModified: new Date().toISOString(),
           data: mergedData,
         };
-        cloudSyncInProgressRef.current = false;
-        await cloudSyncUpload(mergedPayload);
+        // Hold the lock through the upload (skipLockCheck) so no concurrent
+        // sync can start between the download and its paired upload.
+        await cloudSyncUpload(mergedPayload, { skipLockCheck: true });
         // cloudSyncUpload sets its own success status
         return;
       }
 
-      cloudSyncErrorCountRef.current = 0; // reset error backoff on success
-      cloudSyncBackoffUntilRef.current = 0;
+      cloudSyncDownloadErrorCountRef.current = 0;
+      cloudSyncDownloadBackoffUntilRef.current = 0;
       const elapsed = Date.now() - syncStart;
       if (elapsed < 2000) await new Promise(r => setTimeout(r, 2000 - elapsed));
       const now = new Date().toISOString();
@@ -4935,19 +4955,29 @@ const DayPlanner = () => {
         setCloudSyncStatus('idle');
         return;
       }
-      cloudSyncErrorCountRef.current += 1;
-      // Exponential backoff: 30s, 60s, 2m, 4m … capped at 15 min
-      const backoffMs = Math.min(30 * Math.pow(2, cloudSyncErrorCountRef.current - 1), 15 * 60) * 1000;
-      cloudSyncBackoffUntilRef.current = Date.now() + backoffMs;
+      // 423 Locked = another client is writing right now.
+      // Use a short fixed retry rather than escalating backoff — the lock clears quickly.
+      if (err.message?.includes('423')) {
+        cloudSyncDownloadBackoffUntilRef.current = Date.now() + 30_000;
+      } else {
+        cloudSyncDownloadErrorCountRef.current += 1;
+        // Exponential backoff: 30s, 60s, 2m, 4m … capped at 5 min
+        const backoffMs = Math.min(30 * Math.pow(2, cloudSyncDownloadErrorCountRef.current - 1), 5 * 60) * 1000;
+        cloudSyncDownloadBackoffUntilRef.current = Date.now() + backoffMs;
+      }
       const errMsg = err.message === 'FORBIDDEN'
-        ? 'Sync blocked (403) — your server may be blocking Vercel\'s IP addresses.'
+        ? 'Sync blocked (403) — your server may be blocking requests.'
         : err.message;
       setCloudSyncError(errMsg);
       setCloudSyncStatus('error');
       setTimeout(() => setCloudSyncStatus((s) => s === 'error' ? 'idle' : s), 5000);
     } finally {
-      cloudSyncInProgressRef.current = false;
-      cloudSyncInitialDoneRef.current = true;
+      // Don't release the lock or mark initial sync done when the conflict modal is
+      // shown — the dialog button handlers do that explicitly.
+      if (!conflictShown) {
+        cloudSyncInProgressRef.current = false;
+        cloudSyncInitialDoneRef.current = true;
+      }
     }
   };
 

--- a/src/hooks/useCloudSync.js
+++ b/src/hooks/useCloudSync.js
@@ -18,15 +18,19 @@ const useCloudSync = () => {
   // false = passphrase required (encryption enabled, no cached key)
   const [syncKeyReady, setSyncKeyReady] = useState(null);
 
-  const cloudSyncDebounceRef       = useRef(null);
-  const suppressCloudUploadRef     = useRef(false);
-  const suppressTimestampRef       = useRef(false);
-  const suppressClearPendingRef    = useRef(false);
-  const cloudSyncInProgressRef     = useRef(false);
-  const cloudSyncInitialDoneRef    = useRef(false);
-  const cloudSyncDownloadRef       = useRef(null);
-  const cloudSyncErrorCountRef     = useRef(0);
-  const cloudSyncBackoffUntilRef   = useRef(0);
+  const cloudSyncDebounceRef            = useRef(null);
+  const suppressCloudUploadRef          = useRef(false);
+  const suppressTimestampRef            = useRef(false);
+  const suppressClearPendingRef         = useRef(false);
+  const cloudSyncInProgressRef          = useRef(false);
+  const cloudSyncInitialDoneRef         = useRef(false);
+  const cloudSyncDownloadRef            = useRef(null);
+  // Upload-specific backoff (used by cloudSyncUpload)
+  const cloudSyncErrorCountRef          = useRef(0);
+  const cloudSyncBackoffUntilRef        = useRef(0);
+  // Download-specific backoff (separate so upload failures don't block downloads and vice versa)
+  const cloudSyncDownloadErrorCountRef  = useRef(0);
+  const cloudSyncDownloadBackoffUntilRef = useRef(0);
 
   // Persist cloud sync config
   useEffect(() => {
@@ -74,6 +78,8 @@ const useCloudSync = () => {
     cloudSyncDownloadRef,
     cloudSyncErrorCountRef,
     cloudSyncBackoffUntilRef,
+    cloudSyncDownloadErrorCountRef,
+    cloudSyncDownloadBackoffUntilRef,
   };
 };
 


### PR DESCRIPTION
## Summary

Comprehensive hardening of the iCloud and WebDAV sync layer, based on a full review of all sync code. Addresses the Android→macOS sync outage (caused by 423 Locked driving a 15-min backoff) and a range of race conditions, data-loss scenarios, and reliability issues.

### Critical fixes

- **Separate upload/download backoff refs** — upload failures no longer block downloads and vice versa. A WebDAV upload error no longer silences the download poll for 15 minutes.
- **423 Locked → 30s fixed retry, no escalation** — 423 means "another client is writing right now." It should retry in seconds, not escalate to 15 minutes. This was the direct cause of the Android→macOS outage.
- **Cap download backoff at 5 min** (was 15 min); **reset download backoff to zero on app foreground** so the user always gets a fresh attempt when returning to the app.
- **Hold lock through full download→merge→upload cycle** — the previous code released `cloudSyncInProgressRef` before awaiting `cloudSyncUpload`, opening a window where a concurrent iCloud poll or WebDAV tick could interleave. Now uses a `skipLockCheck` flag to hold the lock end-to-end.
- **Fix conflict-modal lock leak** — `finally` block previously released the lock and set `cloudSyncInitialDoneRef=true` even when the conflict dialog was open (because `finally` always runs). A `conflictShown` flag now prevents this; dialog button handlers release the lock explicitly as before.
- **`dataLoaded` guard in `iCloudSync`** — prevents the function from running (and seeding iCloud with empty state) before `loadData()` has hydrated React state.
- **Empty-payload guard on iCloud seed path** — same safety check as WebDAV: abort the seed write if localStorage has tasks but the payload is empty (state not yet hydrated).

### Reliability fixes

- **Atomic macOS iCloud write** — writes to a `.tmp` file then renames, so the iCloud daemon never picks up a partial/corrupt file mid-write.
- **macOS iCloud placeholder detection** — detects `.filename.icloud` cloud-only placeholders and returns `{"downloading":true}` instead of `null`, preventing the "no remote file" seed path from wiping real iCloud data on a fresh install or sign-in before the daemon downloads the file.
- **Surface iCloud write failures** — parses the iOS bridge result (`{"ok":false,"error":"..."}`) and logs macOS write failures instead of silently discarding them.
- **Handle `{"error":"..."}` from iCloud read** — if iCloud is unavailable (signed out, etc.), the error is logged and the sync cycle exits cleanly instead of attempting a merge.
- **`fs.watch` re-attach** — the macOS file watcher now re-attaches on `error` or `close` events. The iCloud daemon can recreate the directory (observed on Sonoma+), which previously killed the watcher silently and degraded sync to poll-only.
- **Write-suppression window: 3s → 5s** — iCloud propagation can take longer than 3s, causing self-echo sync cycles. 5s reduces unnecessary churn.
- **`fs.watch` debounce: 500ms → 1s** — matches the longer suppression window and reduces spurious sync triggers during multi-stage iCloud daemon updates.

## Test plan

- [ ] Make a change on iOS and verify it appears on macOS within ~15s (iCloud real-time path)
- [ ] Make a change on macOS and verify it appears on iOS within ~15s
- [ ] Simulate a 423 by checking Nextcloud logs after a conflict — verify sync resumes within 30s instead of waiting 15 min
- [ ] Open the app on a fresh iOS install (before iCloud finishes propagating) — verify it shows "downloading" state instead of seeding with empty data
- [ ] Verify the conflict modal ("Existing Data Found") still appears correctly on first sync and all three buttons work
- [ ] Verify the "last synced" timestamp updates after successful sync

https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr)_