### PR TITLE
Fix four sync correctness bugs (first-sync reload, native imports, missed events, passphrase)

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
@@ -17,7 +17,7 @@ final class ICloudBridge {
 
     // Suppress query callbacks that fire immediately after our own local write.
     private var lastLocalWriteDate: Date?
-    private let writeSuppressionInterval: TimeInterval = 3.0
+    private let writeSuppressionInterval: TimeInterval = 5.0
 
     // MARK: - Public API
 
@@ -29,6 +29,16 @@ final class ICloudBridge {
         }
         let fileURL = syncFileURL(in: container)
 
+        // On older iOS versions, a cloud-only file appears as a hidden .filename.icloud
+        // placeholder whose body is metadata, not JSON. Detect it before fileExists() so
+        // we never accidentally read placeholder bytes as sync data.
+        let placeholderURL = fileURL.deletingLastPathComponent()
+            .appendingPathComponent("." + fileURL.lastPathComponent + ".icloud")
+        if FileManager.default.fileExists(atPath: placeholderURL.path) {
+            try? FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+            return #"{"downloading":true}"#
+        }
+
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             return "null"
         }
@@ -36,8 +46,8 @@ final class ICloudBridge {
         // Trigger download if the file exists in cloud but hasn't been fetched locally yet.
         try? FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
 
-        // If it's still a cloud-only placeholder, signal "downloading" so the caller
-        // doesn't mistake it for "no remote file" and accidentally seed with empty data.
+        // If it's still a cloud-only placeholder per the ubiquitous status API, signal
+        // "downloading" so the caller doesn't seed iCloud with empty/stale data.
         if let values = try? fileURL.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey]),
            let status = values.ubiquitousItemDownloadingStatus,
            status == .notDownloaded {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1379,9 +1379,16 @@ const DayPlanner = () => {
 
   // On Electron/macOS, sync immediately when the main process detects the iCloud
   // file was changed by the iOS app (fs.watch → icloud:changed IPC event).
+  // If a sync is already in progress, schedule a retry so the change isn't lost.
   useEffect(() => {
     if (!isElectronMac()) return;
-    return window.electronAPI.onICloudChanged?.(() => iCloudSyncRef.current?.());
+    return window.electronAPI.onICloudChanged?.(() => {
+      if (cloudSyncInProgressRef.current) {
+        setTimeout(() => iCloudSyncRef.current?.(), 2000);
+      } else {
+        iCloudSyncRef.current?.();
+      }
+    });
   }, []);
 
   // Cloud sync: download on app load or when sync is first enabled.
@@ -4841,7 +4848,10 @@ const DayPlanner = () => {
       const mergedIds = new Set(normalizedTasks.map(t => String(t.id)));
       return [...normalizedTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported))];
     });
-    if (normalizedUnsched) setUnscheduledTasks(normalizedUnsched);
+    if (normalizedUnsched) setUnscheduledTasks(prev => {
+      const mergedIds = new Set(normalizedUnsched.map(t => String(t.id)));
+      return [...normalizedUnsched, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported))];
+    });
     if (data.unscheduledOrderTimestamp) {
       setUnscheduledOrderTimestamp(data.unscheduledOrderTimestamp);
       localStorage.setItem('day-planner-unscheduled-order-ts', data.unscheduledOrderTimestamp);
@@ -4880,6 +4890,7 @@ const DayPlanner = () => {
     setCloudSyncStatus('downloading');
     setCloudSyncError(null);
     let conflictShown = false;
+    let passphraseRequired = false;
     try {
       const remote = await provider.download(cloudSyncConfig);
       if (!remote) {
@@ -4908,10 +4919,6 @@ const DayPlanner = () => {
       if (localChanged) {
         applyRemoteData(mergedData);
         localStorage.setItem('day-planner-cloud-sync-local-modified', new Date().toISOString());
-        // On first sync the setState calls from applyRemoteData don't always
-        // propagate visibly before the user notices the empty screen. A reload
-        // guarantees a clean render from localStorage. Only do this once.
-        if (hasNeverSynced) setTimeout(() => window.location.reload(), 500);
       }
 
       if (remoteChanged || localChanged) {
@@ -4933,7 +4940,11 @@ const DayPlanner = () => {
         // Hold the lock through the upload (skipLockCheck) so no concurrent
         // sync can start between the download and its paired upload.
         await cloudSyncUpload(mergedPayload, { skipLockCheck: true });
-        // cloudSyncUpload sets its own success status
+        // On first sync, reload after the upload completes so the full merged
+        // dataset renders cleanly from localStorage. Reloading before the upload
+        // (the old setTimeout approach) could lose the merged result if the network
+        // round-trip took more than 500ms.
+        if (hasNeverSynced && localChanged) window.location.reload();
         return;
       }
 
@@ -4951,6 +4962,7 @@ const DayPlanner = () => {
       // If the file's encryption salt doesn't match the cached key and no passphrase
       // is in memory, re-show the passphrase modal so the user can re-enter it.
       if (err.code === 'PASSPHRASE_REQUIRED') {
+        passphraseRequired = true;
         setSyncKeyReady(false);
         setCloudSyncStatus('idle');
         return;
@@ -4972,11 +4984,12 @@ const DayPlanner = () => {
       setCloudSyncStatus('error');
       setTimeout(() => setCloudSyncStatus((s) => s === 'error' ? 'idle' : s), 5000);
     } finally {
-      // Don't release the lock or mark initial sync done when the conflict modal is
-      // shown — the dialog button handlers do that explicitly.
+      // conflictShown: leave lock held — dialog button handlers release it and set initialDone.
+      // passphraseRequired: release lock but don't mark initial sync done — user must re-enter passphrase.
+      // Normal path: release lock and mark initial sync done.
       if (!conflictShown) {
         cloudSyncInProgressRef.current = false;
-        cloudSyncInitialDoneRef.current = true;
+        if (!passphraseRequired) cloudSyncInitialDoneRef.current = true;
       }
     }
   };


### PR DESCRIPTION
Follow-up to #757. Four correctness fixes from the sync audit.

## Changes

**M12 — First-sync reload fires before upload completes**
`hasNeverSynced` path used `setTimeout(reload, 500)` then `await cloudSyncUpload`. If the upload took >500ms the page reloaded mid-upload, meaning the merged data never reached the server. The next launch would re-show the conflict dialog. Now awaits the upload before reloading.

**H7 — `setUnscheduledTasks` discards native/imported inbox items**
`applyRemoteData` preserved `_native`/`imported` items in `setTasks` via a `prev` callback but passed a plain array to `setUnscheduledTasks`. Any inbox items imported by the native bridge mid-sync were silently wiped on the next merge. Applied the same prev-merge pattern.

**H5 — `icloud:changed` event dropped when sync lock is held**
If the iOS app wrote while macOS held `cloudSyncInProgressRef` (e.g. mid-upload), the `icloud:changed` IPC event caused `iCloudSync` to return early at the lock check. The remote change was silently lost until the next 15s poll. Now schedules a 2s retry when the lock is held.

**H15 — `PASSPHRASE_REQUIRED` set `cloudSyncInitialDoneRef=true`**
`PASSPHRASE_REQUIRED` returned inside `catch`, which still triggered `finally`. The `finally` block unconditionally set `cloudSyncInitialDoneRef=true`, making subsequent wrong-passphrase errors route through normal backoff as if initial sync had completed. Added a `passphraseRequired` flag to gate `initialDone`.

**C7 (iOS) — placeholder filename not detected on older iOS**
`ICloudBridge.swift` now checks for the hidden `.filename.icloud` placeholder before `fileExists()`, preventing older iOS from returning `true` for a placeholder whose body is iCloud metadata rather than JSON. Also bumps the iOS write-suppression interval from 3s → 5s to match the macOS change from #757.

## Test plan

- [ ] First sync on a new device: verify tasks appear correctly and the conflict dialog doesn't re-appear on next launch
- [ ] Add a task on iOS while macOS is mid-sync: verify the change appears on macOS within ~15s (not just the next 15s poll)
- [ ] Add an inbox item via native bridge, then trigger a sync: verify the item survives
- [ ] Enter a wrong passphrase: verify the passphrase modal re-appears instead of backing off

https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr)_