### PR TITLE
Calendar URLs use last-writer-wins merge so clearing a URL propagates cross-device

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1294,6 +1294,10 @@ const DayPlanner = () => {
   // Only track obsidianConfig on non-native apps; native apps auto-populate fields from the vault.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { if (!isNativeApp()) writeConfigTimestamp('day-planner-obsidian-config-updated-at'); }, [obsidianConfig]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { writeConfigTimestamp('day-planner-sync-url-updated-at'); }, [syncUrl]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { writeConfigTimestamp('day-planner-task-calendar-url-updated-at'); }, [taskCalendarUrl]);
 
   // ── iCloud sync ──────────────────────────────────────────────────────────
   // Runs independently alongside any configured WebDAV/Nextcloud sync so that
@@ -4653,7 +4657,9 @@ const DayPlanner = () => {
         unscheduledOrderTimestamp,
         recycleBin: stampTaskTimestamps(recycleBin, 'day-planner-recycle-bin'),
         syncUrl,
+        syncUrlUpdatedAt: localStorage.getItem('day-planner-sync-url-updated-at') || null,
         taskCalendarUrl,
+        taskCalendarUrlUpdatedAt: localStorage.getItem('day-planner-task-calendar-url-updated-at') || null,
         // taskCalendarAuth is intentionally excluded — credentials must not be written
         // to the shared sync file on the WebDAV server.
         completedTaskUids: prunedUids,
@@ -4784,10 +4790,15 @@ const DayPlanner = () => {
     if (normalizedTasks) localStorage.setItem('day-planner-tasks', JSON.stringify(normalizedTasks));
     if (normalizedUnsched) localStorage.setItem('day-planner-unscheduled', JSON.stringify(normalizedUnsched));
     if (data.recycleBin) localStorage.setItem('day-planner-recycle-bin', JSON.stringify(data.recycleBin));
-    // Calendar URLs: only overwrite if remote provides a non-empty value
-    // (prevents a device without URLs from wiping one that has them configured).
-    if (data.syncUrl) localStorage.setItem('day-planner-sync-url', data.syncUrl);
-    if (data.taskCalendarUrl) localStorage.setItem('day-planner-task-calendar-url', data.taskCalendarUrl);
+    // Calendar URLs: apply merged value unconditionally (empty string = intentional clear).
+    if (data.syncUrl !== undefined) {
+      localStorage.setItem('day-planner-sync-url', data.syncUrl);
+      if (data.syncUrlUpdatedAt) localStorage.setItem('day-planner-sync-url-updated-at', data.syncUrlUpdatedAt);
+    }
+    if (data.taskCalendarUrl !== undefined) {
+      localStorage.setItem('day-planner-task-calendar-url', data.taskCalendarUrl);
+      if (data.taskCalendarUrlUpdatedAt) localStorage.setItem('day-planner-task-calendar-url-updated-at', data.taskCalendarUrlUpdatedAt);
+    }
     // taskCalendarAuth is not applied from sync — credentials are device-local only.
     if (data.completedTaskUids) localStorage.setItem('day-planner-task-completed-uids', JSON.stringify(data.completedTaskUids));
     if (data.recurringTasks) localStorage.setItem('day-planner-recurring-tasks', JSON.stringify(data.recurringTasks));
@@ -4900,8 +4911,8 @@ const DayPlanner = () => {
       localStorage.setItem('day-planner-unscheduled-order-ts', data.unscheduledOrderTimestamp);
     }
     if (data.recycleBin) setRecycleBin(data.recycleBin);
-    if (data.syncUrl) setSyncUrl(data.syncUrl);
-    if (data.taskCalendarUrl) setTaskCalendarUrl(data.taskCalendarUrl);
+    if (data.syncUrl !== undefined) setSyncUrl(data.syncUrl);
+    if (data.taskCalendarUrl !== undefined) setTaskCalendarUrl(data.taskCalendarUrl);
     if (data.completedTaskUids) setCompletedTaskUids(new Set(data.completedTaskUids));
     if (data.recurringTasks) setRecurringTasks(data.recurringTasks);
     if (data.routineDefinitions) setRoutineDefinitions(data.routineDefinitions);

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -732,14 +732,26 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
   if (JSON.stringify(mergedObsidianConfig) !== JSON.stringify(localData.obsidianConfig ?? null)) localChanged = true;
   if (JSON.stringify(mergedObsidianConfig) !== JSON.stringify(remoteData.obsidianConfig ?? null)) remoteChanged = true;
 
-  // Detect calendar URL changes so the sync cycle completes even when URLs
-  // are the only difference between local and remote.
-  const mergedSyncUrl = remoteData.syncUrl || localData.syncUrl || '';
-  const mergedTaskCalUrl = remoteData.taskCalendarUrl || localData.taskCalendarUrl || '';
-  if (mergedSyncUrl !== (localData.syncUrl || '')) localChanged = true;
-  if (mergedSyncUrl !== (remoteData.syncUrl || '')) remoteChanged = true;
-  if (mergedTaskCalUrl !== (localData.taskCalendarUrl || '')) localChanged = true;
-  if (mergedTaskCalUrl !== (remoteData.taskCalendarUrl || '')) remoteChanged = true;
+  // Calendar URLs: last-writer-wins so a device that clears a URL propagates the clear.
+  // Falls back to remote-wins for legacy payloads that lack timestamps (empty string
+  // means "not set" in legacy, so we keep the non-empty side as a safe default).
+  const localSyncUrl = localData.syncUrl ?? '';
+  const remoteSyncUrl = remoteData.syncUrl ?? '';
+  const mergedSyncUrl = (localData.syncUrlUpdatedAt || remoteData.syncUrlUpdatedAt)
+    ? pickConfigByTs(localSyncUrl, localData.syncUrlUpdatedAt, remoteSyncUrl, remoteData.syncUrlUpdatedAt, '')
+    : (remoteSyncUrl || localSyncUrl);
+  const mergedSyncUrlUpdatedAt = newerTs(localData.syncUrlUpdatedAt, remoteData.syncUrlUpdatedAt);
+  if (mergedSyncUrl !== localSyncUrl) localChanged = true;
+  if (mergedSyncUrl !== remoteSyncUrl) remoteChanged = true;
+
+  const localTaskCalUrl = localData.taskCalendarUrl ?? '';
+  const remoteTaskCalUrl = remoteData.taskCalendarUrl ?? '';
+  const mergedTaskCalUrl = (localData.taskCalendarUrlUpdatedAt || remoteData.taskCalendarUrlUpdatedAt)
+    ? pickConfigByTs(localTaskCalUrl, localData.taskCalendarUrlUpdatedAt, remoteTaskCalUrl, remoteData.taskCalendarUrlUpdatedAt, '')
+    : (remoteTaskCalUrl || localTaskCalUrl);
+  const mergedTaskCalUrlUpdatedAt = newerTs(localData.taskCalendarUrlUpdatedAt, remoteData.taskCalendarUrlUpdatedAt);
+  if (mergedTaskCalUrl !== localTaskCalUrl) localChanged = true;
+  if (mergedTaskCalUrl !== remoteTaskCalUrl) remoteChanged = true;
 
   // Prune tombstones older than the retention window so they don't grow forever.
   // Pruning happens after merge resolution so stale tombstones still participate
@@ -767,10 +779,10 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
       deletedRoutineChipIds: prunedDeletedChipIds,
       deletedFrameIds: prunedDeletedFrameIds,
       removedTodayRoutineIds: prunedRemovedTodayIds,
-      // Calendar URLs: prefer non-empty value (don't let a device without URLs configured wipe one that has them).
-      // If both are non-empty and differ, prefer remote so a URL change propagates across devices.
-      syncUrl: (remoteData.syncUrl || localData.syncUrl || ''),
-      taskCalendarUrl: (remoteData.taskCalendarUrl || localData.taskCalendarUrl || ''),
+      syncUrl: mergedSyncUrl,
+      syncUrlUpdatedAt: mergedSyncUrlUpdatedAt,
+      taskCalendarUrl: mergedTaskCalUrl,
+      taskCalendarUrlUpdatedAt: mergedTaskCalUrlUpdatedAt,
       routineDefinitions: routineMerge.merged,
       todayRoutines: todayRoutinesMerge.merged,
       routinesDate: mergedRoutinesDate,


### PR DESCRIPTION
## Summary

- **Root cause**: `remoteData.syncUrl || localData.syncUrl` meant a device that cleared its WebDAV/CalDAV URL (empty string) could never win — the other device's non-empty value always took precedence. Removing a configured URL was impossible across devices.
- **Per-field `*UpdatedAt` timestamps** are now written to localStorage whenever `syncUrl` or `taskCalendarUrl` changes (same `writeConfigTimestamp` guard as the boolean fields, so hydration and `applyRemoteData` don't produce spurious timestamps).
- **`pickConfigByTs`** in `mergeSyncData()` resolves URL conflicts by timestamp, enabling the device that last modified the URL to win — including to empty string.
- **`applyRemoteData`** guards changed from `if (data.syncUrl)` to `if (data.syncUrl !== undefined)` so an explicit empty string clears both localStorage and React state instead of being skipped.
- **Legacy compatibility**: payloads without timestamps (old clients) fall back to the previous "prefer non-empty" behaviour, avoiding breakage during a mixed-version rollout.

> Stacks on #759 (sync-config-timestamps) — targets that branch as base.

## Test plan

- [ ] Clear `syncUrl` on Device A; verify Device B picks up the empty URL on next sync (not restored to the old value)
- [ ] Set a new `taskCalendarUrl` on Device B; verify Device A adopts it
- [ ] Confirm legacy payload (no `*UpdatedAt` fields) still works: non-empty URL is preserved when the other side has none

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr)_