### PR TITLE
iCloud sync respects encryption settings (encrypt writes, decrypt reads)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,6 +65,7 @@ import useFocusMode from './hooks/useFocusMode.js';
 import useTrmnlSync from './hooks/useTrmnlSync.js';
 import useObsidian from './hooks/useObsidian.js';
 import useCloudSync from './hooks/useCloudSync.js';
+import { encryptData, decryptData, isEncryptedEnvelope, hasEncryptionReady } from './utils/crypto.js';
 import useCalendarSync from './hooks/useCalendarSync.js';
 import useBackup from './hooks/useBackup.js';
 import useGTDFrames from './hooks/useGTDFrames.js';
@@ -1295,6 +1296,11 @@ const DayPlanner = () => {
     if (!dataLoaded) return;
     if (cloudSyncInProgressRef.current) return;
 
+    // If encryption is configured but the key isn't ready yet (passphrase not entered),
+    // skip — we must not read an encrypted file we can't decrypt, or write plaintext.
+    const encEnabled = cloudSyncConfig?.encryptionEnabled && hasEncryptionReady();
+    if (cloudSyncConfig?.encryptionEnabled && !hasEncryptionReady()) return;
+
     // iOS: check iCloud availability once and cache.
     if (onIOS) {
       if (iCloudAvailableRef.current === null) {
@@ -1320,7 +1326,8 @@ const DayPlanner = () => {
         const payload = buildSyncPayload();
         const payloadTaskCount = (payload.data?.tasks?.length || 0) + (payload.data?.unscheduledTasks?.length || 0);
         if (localTaskCount + localInboxCount > 0 && payloadTaskCount === 0) return;
-        await iCloudWriteSync(onIOS, JSON.stringify(payload));
+        const toWrite = encEnabled ? await encryptData(payload) : payload;
+        await iCloudWriteSync(onIOS, JSON.stringify(toWrite));
         return;
       }
 
@@ -1330,6 +1337,11 @@ const DayPlanner = () => {
       try { remote = JSON.parse(str); } catch { return; }
       if (remote?.downloading) return;
       if (remote?.error) { console.error('iCloud unavailable:', remote.error); return; }
+
+      // Decrypt if the file is an encrypted envelope.
+      if (isEncryptedEnvelope(remote)) {
+        try { remote = await decryptData(remote); } catch { return; }
+      }
       if (!remote?.data) return;
 
       const localData = buildSyncPayload().data;
@@ -1340,8 +1352,9 @@ const DayPlanner = () => {
         localStorage.setItem('day-planner-cloud-sync-local-modified', new Date().toISOString());
       }
       if (remoteChanged || localChanged) {
-        const payloadStr = JSON.stringify({ version: 2, lastModified: new Date().toISOString(), data: mergedData });
-        await iCloudWriteSync(onIOS, payloadStr);
+        const outPayload = { version: 2, lastModified: new Date().toISOString(), data: mergedData };
+        const toWrite = encEnabled ? await encryptData(outPayload) : outPayload;
+        await iCloudWriteSync(onIOS, JSON.stringify(toWrite));
       }
     } finally {
       cloudSyncInProgressRef.current = false;


### PR DESCRIPTION
## Summary

- **Root cause (C1)**: `iCloudSync()` always wrote the sync payload as plaintext JSON to the iCloud container, even when end-to-end encryption was enabled. Anyone with access to the iCloud container (another app, iCloud web, etc.) could read task data in the clear.
- **Passphrase guard**: If encryption is configured but the session key isn't ready (user hasn't entered their passphrase yet), sync is skipped entirely — prevents writing plaintext or crashing on an undecryptable remote file.
- **Encrypt on write**: `encryptData(payload)` is called before `JSON.stringify` when `encryptionEnabled && hasEncryptionReady()`.
- **Decrypt on read**: `isEncryptedEnvelope()` check on the parsed remote value; if true, `decryptData()` unwraps it before the merge.
- Covers both the "seed" path (first write, no remote file) and the "merge" path (existing remote file).

## Test plan

- [ ] Enable encryption, reload — confirm iCloud file on disk is an encrypted envelope (`{"v":1,"enc":"AES-GCM-256","data":"..."}`) not plaintext JSON
- [ ] Open on a second device with the same passphrase — confirm it decrypts and merges correctly
- [ ] Disable encryption — confirm subsequent writes revert to plaintext and existing plaintext files are read without error
- [ ] Open app before entering passphrase — confirm iCloud sync is skipped (not called until key is ready)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr)_