### PR TITLE
WebDAV uploads use If-Match ETag for optimistic concurrency control

### DIFF
--- a/api/webdav-proxy.js
+++ b/api/webdav-proxy.js
@@ -110,6 +110,10 @@ export default async function handler(req, res) {
       headers['Depth'] = req.headers['depth'];
     }
 
+    // Forward optimistic-concurrency header so servers can reject stale writes.
+    if (req.headers['if-match']) {
+      headers['If-Match'] = req.headers['if-match'];
+    }
 
     const fetchOptions = {
       method: req.method,
@@ -128,6 +132,8 @@ export default async function handler(req, res) {
 
     res.setHeader('Content-Type', response.headers.get('content-type') || 'text/plain');
     res.setHeader('Cache-Control', 'no-store');
+    const etag = response.headers.get('etag');
+    if (etag) res.setHeader('ETag', etag);
     res.status(response.status).send(body);
   } catch (err) {
     res.status(502).json({ error: 'Failed to proxy WebDAV request' });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4706,7 +4706,7 @@ const DayPlanner = () => {
     };
   };
 
-  const cloudSyncUpload = async (prebuiltPayload, { skipLockCheck = false } = {}) => {
+  const cloudSyncUpload = async (prebuiltPayload, { skipLockCheck = false, etag = null } = {}) => {
     if (!cloudSyncConfig?.enabled || (!skipLockCheck && cloudSyncInProgressRef.current)) return;
     const provider = cloudSyncProviders[cloudSyncConfig.provider];
     if (!provider) return;
@@ -4731,7 +4731,7 @@ const DayPlanner = () => {
         return;
       }
 
-      await provider.upload(cloudSyncConfig, payload);
+      await provider.upload(cloudSyncConfig, payload, etag);
       const elapsed = Date.now() - syncStart;
       if (elapsed < 2000) await new Promise(r => setTimeout(r, 2000 - elapsed));
       const now = new Date().toISOString();
@@ -4947,28 +4947,25 @@ const DayPlanner = () => {
     setCloudSyncError(null);
     let conflictShown = false;
     let passphraseRequired = false;
-    try {
-      const remote = await provider.download(cloudSyncConfig);
-      if (!remote) {
-        // No remote file yet — do initial upload (hold lock through upload)
+    // Helper: download, merge, and upload in one pass.
+    // Returns true if we reloaded (caller should return), false otherwise.
+    const doDownloadMergeUpload = async (downloadedEtag) => {
+      const downloaded = await provider.download(cloudSyncConfig);
+      if (!downloaded) {
         await cloudSyncUpload(undefined, { skipLockCheck: true });
-        return;
+        return false;
       }
-
+      const { payload: remote, etag } = downloaded;
       const remoteModified = remote.lastModified;
       const hasNeverSynced = !localStorage.getItem('day-planner-cloud-sync-last-synced');
 
       if (hasNeverSynced && remoteModified) {
-        // First sync on this device — ask user what to do.
-        // Set conflictShown so the finally block doesn't release the lock;
-        // conflict dialog handlers release it explicitly.
         conflictShown = true;
         setCloudSyncConflict({ remoteData: remote.data, remoteModified });
         setCloudSyncStatus('idle');
-        return;
+        return false;
       }
 
-      // Build local snapshot and merge with remote at the task level
       const localData = buildSyncPayload().data;
       const { data: mergedData, localChanged, remoteChanged } = mergeSyncData(localData, remote.data, syncRetentionDays);
 
@@ -4978,31 +4975,22 @@ const DayPlanner = () => {
       }
 
       if (remoteChanged || localChanged) {
-        // Upload merged result so both sides converge.
-        // We upload even when only localChanged (remoteChanged is false) because
-        // applyRemoteData's setState calls trigger useSaveOnChange, which clears
-        // the suppress refs, and a subsequent native-calendar re-sync then fires
-        // the debounce upload — producing a spurious second sync event. Uploading
-        // from here keeps cloudSyncInProgressRef locked through the upload so the
-        // debounce cannot fire.
-        // Pass the merged data directly as a pre-built payload — reading from
-        // React state via buildSyncPayload() would return stale pre-merge data
-        // because applyRemoteData's setState calls haven't been processed yet.
         const mergedPayload = {
           version: 2,
           lastModified: new Date().toISOString(),
           data: mergedData,
         };
-        // Hold the lock through the upload (skipLockCheck) so no concurrent
-        // sync can start between the download and its paired upload.
-        await cloudSyncUpload(mergedPayload, { skipLockCheck: true });
-        // On first sync, reload after the upload completes so the full merged
-        // dataset renders cleanly from localStorage. Reloading before the upload
-        // (the old setTimeout approach) could lose the merged result if the network
-        // round-trip took more than 500ms.
+        // Pass the ETag so the server can reject a stale write (412 Precondition Failed).
+        await cloudSyncUpload(mergedPayload, { skipLockCheck: true, etag: etag || downloadedEtag || null });
         if (hasNeverSynced && localChanged) window.location.reload();
-        return;
+        return hasNeverSynced && localChanged;
       }
+      return false;
+    };
+
+    try {
+      let reloaded = await doDownloadMergeUpload(null);
+      if (reloaded || conflictShown) return;
 
       cloudSyncDownloadErrorCountRef.current = 0;
       cloudSyncDownloadBackoffUntilRef.current = 0;
@@ -5021,6 +5009,16 @@ const DayPlanner = () => {
         passphraseRequired = true;
         setSyncKeyReady(false);
         setCloudSyncStatus('idle');
+        return;
+      }
+      // 412 Precondition Failed: another device wrote between our download and upload.
+      // Re-run the full download→merge→upload cycle once to pick up the new version.
+      if (err.message === 'PRECONDITION_FAILED') {
+        try {
+          await doDownloadMergeUpload(null);
+        } catch (retryErr) {
+          console.error('Cloud sync retry after 412 failed:', retryErr);
+        }
         return;
       }
       // 423 Locked = another client is writing right now.

--- a/src/utils/cloudSyncProviders.js
+++ b/src/utils/cloudSyncProviders.js
@@ -24,6 +24,7 @@ export const webdavFetch = async (method, targetUrl, authHeaders, body, extraHea
       status: result.status,
       ok: result.ok,
       statusText: result.error || '',
+      headers: { get: () => null }, // Android bridge doesn't return response headers
       json: async () => JSON.parse(result.body),
       text: async () => result.body,
     };
@@ -45,6 +46,7 @@ export const webdavFetch = async (method, targetUrl, authHeaders, body, extraHea
       status: result.status,
       ok: result.ok,
       statusText: result.statusText,
+      headers: { get: () => null }, // Electron bridge doesn't return response headers
       json: async () => JSON.parse(result.body),
       text: async () => result.body,
     };
@@ -55,6 +57,15 @@ export const webdavFetch = async (method, targetUrl, authHeaders, body, extraHea
     headers: { ...authHeaders, ...extraHeaders },
     ...(body !== undefined && body !== null ? { body } : {}),
   });
+};
+
+// Parses and decrypts a WebDAV download response.
+// Returns { payload, etag } where etag may be null if the server doesn't supply one.
+const parseDownloadResponse = async (res) => {
+  const parsed = await res.json();
+  const payload = isEncryptedEnvelope(parsed) ? await decryptData(parsed) : parsed;
+  const etag = res.headers.get('etag') || null;
+  return { payload, etag };
 };
 
 // Creates a WebDAV collection and any missing intermediate collections.
@@ -83,15 +94,17 @@ export const cloudSyncProviders = {
     getAuthHeaders: (config) => ({
       'X-WebDAV-Auth': 'Basic ' + toBase64(config.username + ':' + config.appPassword)
     }),
-    async upload(config, data) {
+    async upload(config, data, etag = null) {
       const fileUrl = this.getFileUrl(config);
       const dirUrl = this.getDirUrl(config);
       const authHeaders = this.getAuthHeaders(config);
       const payload = config.encryptionEnabled ? await encryptData(data) : data;
       const body = JSON.stringify(payload);
+      const extraHeaders = { 'Content-Type': 'application/json' };
+      if (etag) extraHeaders['If-Match'] = etag;
 
       const doUpload = () =>
-        webdavFetch('PUT', fileUrl, authHeaders, body, { 'Content-Type': 'application/json' });
+        webdavFetch('PUT', fileUrl, authHeaders, body, extraHeaders);
 
       let res = await doUpload();
       if (res.status === 404 || res.status === 409) {
@@ -99,6 +112,7 @@ export const cloudSyncProviders = {
         res = await doUpload();
       }
       if (res.status === 403) throw new Error('FORBIDDEN');
+      if (res.status === 412) throw new Error('PRECONDITION_FAILED');
       if (!res.ok) throw new Error(`Upload failed: ${res.status} ${res.statusText}`);
       return true;
     },
@@ -111,9 +125,7 @@ export const cloudSyncProviders = {
       if (res.status === 404) return null; // No remote file yet
       if (res.status === 403) throw new Error('FORBIDDEN');
       if (!res.ok) throw new Error(`Download failed: ${res.status} ${res.statusText}`);
-      const parsed = await res.json();
-      if (isEncryptedEnvelope(parsed)) return decryptData(parsed);
-      return parsed;
+      return parseDownloadResponse(res);
     },
     async test(config) {
       const dirUrl = this.getDirUrl(config);
@@ -140,20 +152,23 @@ export const cloudSyncProviders = {
     getAuthHeaders: (config) => ({
       'X-WebDAV-Auth': 'Basic ' + toBase64(config.username + ':' + config.appPassword)
     }),
-    async upload(config, data) {
+    async upload(config, data, etag = null) {
       const fileUrl = this.getFileUrl();
       const dirUrl = this.getDirUrl();
       const authHeaders = this.getAuthHeaders(config);
       const payload = config.encryptionEnabled ? await encryptData(data) : data;
       const body = JSON.stringify(payload);
+      const extraHeaders = { 'Content-Type': 'application/json' };
+      if (etag) extraHeaders['If-Match'] = etag;
       const doUpload = () =>
-        webdavFetch('PUT', fileUrl, authHeaders, body, { 'Content-Type': 'application/json' });
+        webdavFetch('PUT', fileUrl, authHeaders, body, extraHeaders);
       let res = await doUpload();
       if (res.status === 404 || res.status === 409) {
         await mkcolWithParents(dirUrl, authHeaders);
         res = await doUpload();
       }
       if (res.status === 403) throw new Error('FORBIDDEN');
+      if (res.status === 412) throw new Error('PRECONDITION_FAILED');
       if (!res.ok) throw new Error(`Upload failed: ${res.status} ${res.statusText}`);
       return true;
     },
@@ -164,9 +179,7 @@ export const cloudSyncProviders = {
       if (res.status === 404) return null;
       if (res.status === 403) throw new Error('FORBIDDEN');
       if (!res.ok) throw new Error(`Download failed: ${res.status} ${res.statusText}`);
-      const parsed = await res.json();
-      if (isEncryptedEnvelope(parsed)) return decryptData(parsed);
-      return parsed;
+      return parseDownloadResponse(res);
     },
     async test(config) {
       const dirUrl = this.getDirUrl();
@@ -196,20 +209,23 @@ export const cloudSyncProviders = {
     getAuthHeaders: (config) => ({
       'X-WebDAV-Auth': 'Basic ' + toBase64(config.username + ':' + config.appPassword)
     }),
-    async upload(config, data) {
+    async upload(config, data, etag = null) {
       const fileUrl = this.getFileUrl(config);
       const dirUrl = this.getDirUrl(config);
       const authHeaders = this.getAuthHeaders(config);
       const payload = config.encryptionEnabled ? await encryptData(data) : data;
       const body = JSON.stringify(payload);
+      const extraHeaders = { 'Content-Type': 'application/json' };
+      if (etag) extraHeaders['If-Match'] = etag;
       const doUpload = () =>
-        webdavFetch('PUT', fileUrl, authHeaders, body, { 'Content-Type': 'application/json' });
+        webdavFetch('PUT', fileUrl, authHeaders, body, extraHeaders);
       let res = await doUpload();
       if (res.status === 404 || res.status === 409) {
         await mkcolWithParents(dirUrl, authHeaders);
         res = await doUpload();
       }
       if (res.status === 403) throw new Error('FORBIDDEN');
+      if (res.status === 412) throw new Error('PRECONDITION_FAILED');
       if (!res.ok) throw new Error(`Upload failed: ${res.status} ${res.statusText}`);
       return true;
     },
@@ -220,9 +236,7 @@ export const cloudSyncProviders = {
       if (res.status === 404) return null;
       if (res.status === 403) throw new Error('FORBIDDEN');
       if (!res.ok) throw new Error(`Download failed: ${res.status} ${res.statusText}`);
-      const parsed = await res.json();
-      if (isEncryptedEnvelope(parsed)) return decryptData(parsed);
-      return parsed;
+      return parseDownloadResponse(res);
     },
     async test(config) {
       // GET the sync file rather than PROPFIND — Apache mod_dav and other strict


### PR DESCRIPTION
## Summary

- **Root cause**: Two devices racing on the same WebDAV file — both download version N, both merge, then the second PUT silently overwrites the first device's merged result. The first device's changes are lost until the next sync.
- **ETag/If-Match**: `GET` responses now return the server's `ETag` header. Subsequent `PUT` requests include `If-Match: <etag>`. If another device wrote in between, the server returns 412 Precondition Failed instead of silently overwriting.
- **Retry on 412**: On `PRECONDITION_FAILED`, `cloudSyncDownload` re-runs the full download → merge → upload cycle once to incorporate the interleaved write.
- **Proxy changes** (`api/webdav-proxy.js`): forwards `If-Match` request header and `ETag` response header through the CORS proxy.
- **Provider refactor**: `download()` now returns `{ payload, etag }` instead of the raw payload; `upload(config, data, etag)` adds `If-Match` when etag is present; 412 throws `PRECONDITION_FAILED`.
- **Android/Electron**: native bridges don't return response headers, so `etag` is `null` — uploads proceed without `If-Match` (no regression, same as before).

## Test plan

- [ ] Two browsers open simultaneously — make a change in each and let both sync. Confirm second device picks up first device's changes rather than overwriting them
- [ ] Server that doesn't support ETags (returns no `ETag` header) — confirm sync works normally with `etag = null`
- [ ] Simulate 412 (via network intercept or test server) — confirm retry re-downloads and re-uploads cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr)_