### PR TITLE
Replace JSON.stringify comparisons with deepEqual to eliminate spurious sync cycles

### DIFF
--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -22,6 +22,24 @@ const newerTs = (a, b) => {
   return new Date(a).getTime() >= new Date(b).getTime() ? a : b;
 };
 
+// Structural deep equality — key-order independent.
+// Used instead of JSON.stringify comparisons to avoid spurious dirty flags
+// when two objects have identical content but different key insertion order.
+const deepEqual = (a, b) => {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== typeof b) return false;
+  if (typeof a !== 'object') return a === b;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every(k => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]));
+};
+
 /**
  * Merges two task arrays by ID, preserving local ordering and appending
  * remote-only tasks at the end.
@@ -273,7 +291,7 @@ export const mergeHabits = (localHabits, remoteHabits, localDeletedIds = {}, rem
         remoteChanged = true;
       } else {
         // Equal — check for field-level differences (e.g. archived on one side)
-        if (JSON.stringify(localHabit) !== JSON.stringify(remoteHabit)) {
+        if (!deepEqual(localHabit, remoteHabit)) {
           merged.push(localHabit); // keep local
           remoteChanged = true;
         } else {
@@ -582,7 +600,7 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
       continue;
     }
     const remoteFrame = remoteFrameMap.get(id);
-    if (remoteFrame && JSON.stringify(localFrame) !== JSON.stringify(remoteFrame)) {
+    if (remoteFrame && !deepEqual(localFrame, remoteFrame)) {
       const localTime = new Date(localFrame.lastModified || 0);
       const remoteTime = new Date(remoteFrame.lastModified || 0);
       if (remoteTime > localTime) {
@@ -656,7 +674,7 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
       continue;
     }
     const remoteGoal = remoteGoalMap.get(id);
-    if (remoteGoal && JSON.stringify(localGoal) !== JSON.stringify(remoteGoal)) {
+    if (remoteGoal && !deepEqual(localGoal, remoteGoal)) {
       const localTime = new Date(localGoal.updatedAt || 0);
       const remoteTime = new Date(remoteGoal.updatedAt || 0);
       if (remoteTime > localTime) {
@@ -694,7 +712,7 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
       continue;
     }
     const remoteProject = remoteProjectMap.get(id);
-    if (remoteProject && JSON.stringify(localProject) !== JSON.stringify(remoteProject)) {
+    if (remoteProject && !deepEqual(localProject, remoteProject)) {
       const localTime = new Date(localProject.updatedAt || 0);
       const remoteTime = new Date(remoteProject.updatedAt || 0);
       if (remoteTime > localTime) {


### PR DESCRIPTION
## Summary

- **Root cause (M3)**: `JSON.stringify(a) !== JSON.stringify(b)` is key-order dependent. Two objects with identical content but different property insertion order produce different strings, causing `localChanged`/`remoteChanged` to be set to `true` on every sync cycle even when nothing actually changed. This produces unnecessary uploads and can mask real changes.
- **Fix**: Added a `deepEqual()` helper that performs structural, key-order-independent deep equality comparison.
- Replaced all four `JSON.stringify` comparisons in `mergeSyncData()`: habits, GTD frames, goals, and projects.

## Test plan

- [ ] Sync habits between two devices — confirm subsequent sync cycles don't report changes when habit data hasn't changed
- [ ] Sync GTD frames — confirm no spurious upload after the initial sync converges
- [ ] Sync goals and projects — same check
- [ ] Modify a habit/frame/goal on one device — confirm the change propagates correctly (deepEqual correctly returns false)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr)_