### PR TITLE
Habit log decrements propagate cross-device using per-entry timestamps

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4688,6 +4688,7 @@ const DayPlanner = () => {
         dailyNotes,
         habits,
         habitLogs,
+        habitLogTimestamps: JSON.parse(localStorage.getItem('day-planner-habit-log-timestamps') || '{}'),
         habitsEnabled,
         habitsEnabledUpdatedAt: localStorage.getItem('day-planner-habits-enabled-updated-at') || null,
         deletedHabitIds: JSON.parse(localStorage.getItem('day-planner-deleted-habit-ids') || '{}'),
@@ -4837,6 +4838,15 @@ const DayPlanner = () => {
     if (data.habitLogs) {
       localStorage.setItem('day-planner-habit-logs', JSON.stringify(data.habitLogs));
       setHabitLogs(data.habitLogs);
+    }
+    if (data.habitLogTimestamps) {
+      // Merge with local timestamps, keeping the newer of each entry.
+      const localTs = JSON.parse(localStorage.getItem('day-planner-habit-log-timestamps') || '{}');
+      const merged = { ...localTs };
+      for (const [k, v] of Object.entries(data.habitLogTimestamps)) {
+        if (!merged[k] || new Date(v) > new Date(merged[k])) merged[k] = v;
+      }
+      localStorage.setItem('day-planner-habit-log-timestamps', JSON.stringify(merged));
     }
     if (data.habitsEnabled !== undefined) {
       localStorage.setItem('day-planner-habits-enabled', JSON.stringify(data.habitsEnabled));

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -100,6 +100,12 @@ const useHabits = ({ playUISound }) => {
     return habitLogs[todayStr]?.[habitId] || 0;
   };
 
+  const stampHabitLogTs = (dateStr, habitId) => {
+    const ts = JSON.parse(localStorage.getItem('day-planner-habit-log-timestamps') || '{}');
+    ts[`${dateStr}:${habitId}`] = new Date().toISOString();
+    localStorage.setItem('day-planner-habit-log-timestamps', JSON.stringify(ts));
+  };
+
   const incrementHabit = (habitId) => {
     const todayStr = dateToString(new Date());
     playUISound('click');
@@ -110,6 +116,7 @@ const useHabits = ({ playUISound }) => {
         [habitId]: (prev[todayStr]?.[habitId] || 0) + 1
       }
     }));
+    stampHabitLogTs(todayStr, habitId);
   };
 
   const setHabitCount = (habitId, count) => {
@@ -121,6 +128,7 @@ const useHabits = ({ playUISound }) => {
         [habitId]: Math.max(0, count)
       }
     }));
+    stampHabitLogTs(todayStr, habitId);
   };
 
   const addHabit = (habit) => {

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -22,6 +22,24 @@ const newerTs = (a, b) => {
   return new Date(a).getTime() >= new Date(b).getTime() ? a : b;
 };
 
+// Structural deep equality — key-order independent.
+// Used instead of JSON.stringify comparisons to avoid spurious dirty flags
+// when two objects have identical content but different key insertion order.
+const deepEqual = (a, b) => {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== typeof b) return false;
+  if (typeof a !== 'object') return a === b;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every(k => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]));
+};
+
 /**
  * Merges two task arrays by ID, preserving local ordering and appending
  * remote-only tasks at the end.
@@ -273,7 +291,7 @@ export const mergeHabits = (localHabits, remoteHabits, localDeletedIds = {}, rem
         remoteChanged = true;
       } else {
         // Equal — check for field-level differences (e.g. archived on one side)
-        if (JSON.stringify(localHabit) !== JSON.stringify(remoteHabit)) {
+        if (!deepEqual(localHabit, remoteHabit)) {
           merged.push(localHabit); // keep local
           remoteChanged = true;
         } else {
@@ -311,13 +329,23 @@ export const mergeHabits = (localHabits, remoteHabits, localDeletedIds = {}, rem
  *
  * @param {Object} localLogs  - { "YYYY-MM-DD": { habitId: count } }
  * @param {Object} remoteLogs - { "YYYY-MM-DD": { habitId: count } }
- * @returns {{ merged: Object, localChanged: boolean, remoteChanged: boolean }}
+ * @param {Object} [localTs]  - { "YYYY-MM-DD:habitId": ISO } timestamps for local entries
+ * @param {Object} [remoteTs] - { "YYYY-MM-DD:habitId": ISO } timestamps for remote entries
+ * @returns {{ merged: Object, mergedTimestamps: Object, localChanged: boolean, remoteChanged: boolean }}
  */
-export const mergeHabitLogs = (localLogs, remoteLogs) => {
+export const mergeHabitLogs = (localLogs, remoteLogs, localTs = {}, remoteTs = {}) => {
   const allDates = new Set([...Object.keys(localLogs), ...Object.keys(remoteLogs)]);
   const merged = {};
+  const mergedTimestamps = { ...localTs };
   let localChanged = false;
   let remoteChanged = false;
+
+  // Merge remote timestamps in (keep the newer of each key).
+  for (const [k, v] of Object.entries(remoteTs)) {
+    if (!mergedTimestamps[k] || new Date(v) > new Date(mergedTimestamps[k])) {
+      mergedTimestamps[k] = v;
+    }
+  }
 
   for (const dateKey of allDates) {
     const local = localLogs[dateKey];
@@ -330,23 +358,37 @@ export const mergeHabitLogs = (localLogs, remoteLogs) => {
       merged[dateKey] = remote;
       localChanged = true;
     } else {
-      // Both have it — merge per habit, taking the max count
+      // Both have it — per-habit merge using timestamps when available, Math.max for legacy.
       const allHabitIds = new Set([...Object.keys(local), ...Object.keys(remote)]);
       const dayMerged = {};
       for (const habitId of allHabitIds) {
-        const localCount = local[habitId] || 0;
-        const remoteCount = remote[habitId] || 0;
-        dayMerged[habitId] = Math.max(localCount, remoteCount);
-        if (remoteCount > localCount) localChanged = true;
-        if (localCount > remoteCount) remoteChanged = true;
-        if (!local[habitId] && remote[habitId]) localChanged = true;
-        if (local[habitId] && !remote[habitId]) remoteChanged = true;
+        const localCount = local[habitId] !== undefined ? local[habitId] : 0;
+        const remoteCount = remote[habitId] !== undefined ? remote[habitId] : 0;
+        const tsKey = `${dateKey}:${habitId}`;
+        const lTime = localTs[tsKey] ? new Date(localTs[tsKey]).getTime() : 0;
+        const rTime = remoteTs[tsKey] ? new Date(remoteTs[tsKey]).getTime() : 0;
+
+        let winner;
+        if (lTime > 0 || rTime > 0) {
+          // Timestamp-based: last-writer-wins (handles decrements).
+          winner = lTime >= rTime ? localCount : remoteCount;
+          if (lTime > rTime && localCount !== remoteCount) remoteChanged = true;
+          if (rTime > lTime && localCount !== remoteCount) localChanged = true;
+        } else {
+          // Legacy (no timestamps): take the max to be safe.
+          winner = Math.max(localCount, remoteCount);
+          if (remoteCount > localCount) localChanged = true;
+          if (localCount > remoteCount) remoteChanged = true;
+        }
+        dayMerged[habitId] = winner;
+        if (local[habitId] === undefined && remote[habitId] !== undefined) localChanged = true;
+        if (remote[habitId] === undefined && local[habitId] !== undefined) remoteChanged = true;
       }
       merged[dateKey] = dayMerged;
     }
   }
 
-  return { merged, localChanged, remoteChanged };
+  return { merged, mergedTimestamps, localChanged, remoteChanged };
 };
 
 /**
@@ -454,7 +496,12 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
   const localDeletedHabitIds = localData.deletedHabitIds || {};
   const remoteDeletedHabitIds = remoteData.deletedHabitIds || {};
   const habitsMerge = mergeHabits(localData.habits || [], remoteData.habits || [], localDeletedHabitIds, remoteDeletedHabitIds);
-  const habitLogsMerge = mergeHabitLogs(localData.habitLogs || {}, remoteData.habitLogs || {});
+  const habitLogsMerge = mergeHabitLogs(
+    localData.habitLogs || {},
+    remoteData.habitLogs || {},
+    localData.habitLogTimestamps || {},
+    remoteData.habitLogTimestamps || {}
+  );
 
   // Detect routine completion changes: did the merge add completions that one side was missing?
   const localCompletionsFiltered = Object.fromEntries(Object.entries(localCompletions).filter(([, d]) => d === mergedRoutinesDate));
@@ -582,7 +629,7 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
       continue;
     }
     const remoteFrame = remoteFrameMap.get(id);
-    if (remoteFrame && JSON.stringify(localFrame) !== JSON.stringify(remoteFrame)) {
+    if (remoteFrame && !deepEqual(localFrame, remoteFrame)) {
       const localTime = new Date(localFrame.lastModified || 0);
       const remoteTime = new Date(remoteFrame.lastModified || 0);
       if (remoteTime > localTime) {
@@ -656,7 +703,7 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
       continue;
     }
     const remoteGoal = remoteGoalMap.get(id);
-    if (remoteGoal && JSON.stringify(localGoal) !== JSON.stringify(remoteGoal)) {
+    if (remoteGoal && !deepEqual(localGoal, remoteGoal)) {
       const localTime = new Date(localGoal.updatedAt || 0);
       const remoteTime = new Date(remoteGoal.updatedAt || 0);
       if (remoteTime > localTime) {
@@ -694,7 +741,7 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
       continue;
     }
     const remoteProject = remoteProjectMap.get(id);
-    if (remoteProject && JSON.stringify(localProject) !== JSON.stringify(remoteProject)) {
+    if (remoteProject && !deepEqual(localProject, remoteProject)) {
       const localTime = new Date(localProject.updatedAt || 0);
       const remoteTime = new Date(remoteProject.updatedAt || 0);
       if (remoteTime > localTime) {
@@ -779,6 +826,7 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
       habits: habitsMerge.merged,
       deletedHabitIds: prunedDeletedHabitIds,
       habitLogs: habitLogsMerge.merged,
+      habitLogTimestamps: habitLogsMerge.mergedTimestamps,
       habitsEnabled: mergedHabitsEnabled,
       habitsEnabledUpdatedAt: mergedHabitsEnabledUpdatedAt,
       routinesEnabled: mergedRoutinesEnabled,


### PR DESCRIPTION
## Summary

- **Root cause (H12/M15)**: `Math.max(localCount, remoteCount)` in `mergeHabitLogs` meant a decremented count could never win against a device still holding the higher value. Correcting an accidental over-increment or intentionally reducing a count was impossible across devices.
- **Per-entry timestamps**: `stampHabitLogTs()` in `useHabits.js` writes a `"YYYY-MM-DD:habitId" → ISO` entry to localStorage on every `incrementHabit` or `setHabitCount` call.
- **Last-writer-wins in merge**: `mergeHabitLogs` now accepts `localTs`/`remoteTs` maps and uses the timestamp to decide which side wins. The device that most recently set the count wins, even if its value is lower.
- **Legacy safety**: Entries with no timestamps (old payloads) continue using `Math.max` as before — no breaking change during a mixed-version rollout.
- `mergeHabitLogs` returns `mergedTimestamps` (union of both sides, keeping the newer per key); `mergeSyncData` includes it in the returned `data` so timestamps are uploaded and propagated to other devices.
- `applyRemoteData` merges incoming `habitLogTimestamps` into localStorage, keeping the newer entry per key.

## Test plan

- [ ] Set a habit count to 5 on Device A; sync. Then reduce to 2 on Device A and sync again — verify Device B shows 2, not 5
- [ ] Increment on Device A and Device B concurrently; sync — verify the later write wins
- [ ] Old client (no timestamps) syncing with new client — verify Math.max fallback applies; no errors
- [ ] Habit streaks still compute correctly after the count correction propagates

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgW63AFE4LxyHFrxCHYZvr)_