### PR TITLE
fix(sync): address all Critical findings from iCloud/WebDAV re-audit

### DIFF
--- a/api/webdav-proxy.js
+++ b/api/webdav-proxy.js
@@ -110,9 +110,12 @@ export default async function handler(req, res) {
       headers['Depth'] = req.headers['depth'];
     }
 
-    // Forward optimistic-concurrency header so servers can reject stale writes.
+    // Forward optimistic-concurrency headers.
     if (req.headers['if-match']) {
       headers['If-Match'] = req.headers['if-match'];
+    }
+    if (req.headers['if-none-match']) {
+      headers['If-None-Match'] = req.headers['if-none-match'];
     }
 
     const fetchOptions = {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -357,7 +357,7 @@ ipcMain.handle('proxy-fetch', async (_event, method: string, url: string, header
     ...(body != null ? { body } : {}),
   });
   const text = await response.text();
-  return { status: response.status, ok: response.ok, statusText: response.statusText, body: text };
+  return { status: response.status, ok: response.ok, statusText: response.statusText, body: text, headers: { etag: response.headers.get('etag') || null } };
 });
 
 // Dock badge — macOS only

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4344,7 +4344,7 @@ const DayPlanner = () => {
     };
 
     try {
-      const getRes = await fetch(`/api/webdav-proxy/?url=${resourceUrl}`, {
+      const getRes = await fetch(`/api/webdav-proxy/?url=${encodeURIComponent(resourceUrl)}`, {
         method: 'GET',
         headers: authHeaders
       });
@@ -4560,7 +4560,7 @@ const DayPlanner = () => {
       }
 
       // PUT the updated resource back
-      const putRes = await fetch(`/api/webdav-proxy/?url=${resourceUrl}`, {
+      const putRes = await fetch(`/api/webdav-proxy/?url=${encodeURIComponent(resourceUrl)}`, {
         method: 'PUT',
         headers: { ...authHeaders, 'Content-Type': 'text/calendar; charset=utf-8' },
         body: icsContent
@@ -4748,6 +4748,15 @@ const DayPlanner = () => {
       setTimeout(() => setCloudSyncStatus((s) => s === 'success' ? 'idle' : s), 3000);
     } catch (err) {
       console.error('Cloud sync upload error:', err);
+      if (err.message === 'PRECONDITION_FAILED') {
+        // Another device wrote between our download and upload.
+        // Re-throw so the download cycle can retry the full download→merge→upload.
+        // When called from the debounced upload path (not inside a download cycle),
+        // the next download poll will reconcile — just let it pass quietly.
+        if (skipLockCheck) throw err;
+        setCloudSyncStatus('idle');
+        return;
+      }
       cloudSyncErrorCountRef.current += 1;
       const backoffMs = Math.min(30 * Math.pow(2, cloudSyncErrorCountRef.current - 1), 15 * 60) * 1000;
       cloudSyncBackoffUntilRef.current = Date.now() + backoffMs;
@@ -5029,6 +5038,8 @@ const DayPlanner = () => {
       if (err.message === 'PRECONDITION_FAILED') {
         try {
           await doDownloadMergeUpload(null);
+          cloudSyncDownloadErrorCountRef.current = 0;
+          cloudSyncDownloadBackoffUntilRef.current = 0;
         } catch (retryErr) {
           console.error('Cloud sync retry after 412 failed:', retryErr);
         }

--- a/src/utils/cloudSyncProviders.js
+++ b/src/utils/cloudSyncProviders.js
@@ -24,7 +24,7 @@ export const webdavFetch = async (method, targetUrl, authHeaders, body, extraHea
       status: result.status,
       ok: result.ok,
       statusText: result.error || '',
-      headers: { get: () => null }, // Android bridge doesn't return response headers
+      headers: { get: (h) => (h.toLowerCase() === 'etag' ? result.headers?.etag ?? null : null) },
       json: async () => JSON.parse(result.body),
       text: async () => result.body,
     };
@@ -46,13 +46,13 @@ export const webdavFetch = async (method, targetUrl, authHeaders, body, extraHea
       status: result.status,
       ok: result.ok,
       statusText: result.statusText,
-      headers: { get: () => null }, // Electron bridge doesn't return response headers
+      headers: { get: (h) => (h.toLowerCase() === 'etag' ? result.headers?.etag ?? null : null) },
       json: async () => JSON.parse(result.body),
       text: async () => result.body,
     };
   }
   // On web: route through the server-side CORS proxy.
-  return fetch(`/api/webdav-proxy/?url=${targetUrl}`, {
+  return fetch(`/api/webdav-proxy/?url=${encodeURIComponent(targetUrl)}`, {
     method,
     headers: { ...authHeaders, ...extraHeaders },
     ...(body !== undefined && body !== null ? { body } : {}),


### PR DESCRIPTION
C1: URL-encode the target URL in every ?url= proxy query param so
    usernames, UIDs, or server paths containing &, #, +, or ? are
    not truncated before reaching validateProxyUrl.

C2: Return the ETag header from the Electron net.fetch bridge so
    If-Match is included on uploads from the desktop app, restoring
    optimistic-concurrency protection. Android bridge header slot
    is now wired up on the JS side (native side to follow).

C3: Forward If-None-Match through the WebDAV proxy alongside
    If-Match, enabling conditional GETs.

C4: cloudSyncUpload re-throws PRECONDITION_FAILED (without
    incrementing error counters or triggering backoff) so the
    download cycle's existing retry handler can act on it. Debounced
    direct uploads silently yield to the next download poll instead.
    Reset download error counters after a successful 412 retry.

https://claude.ai/code/session_01U9AvrEMjCyvPXxqo4yWu9X