### PR TITLE
fix(sync): re-audit fixes + mergeSync test regressions

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/HttpBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/HttpBridge.kt
@@ -67,6 +67,7 @@ class HttpBridge {
             }
 
             val statusCode = connection.responseCode
+            val etag = connection.getHeaderField("ETag") // read before disconnect()
             val responseBody = try {
                 if (statusCode >= 400) {
                     connection.errorStream?.bufferedReader(Charsets.UTF_8)?.readText() ?: ""
@@ -75,8 +76,6 @@ class HttpBridge {
                 }
             } catch (_: Exception) { "" }
             connection.disconnect()
-
-            val etag = connection.getHeaderField("ETag")
             JSONObject().apply {
                 put("status", statusCode)
                 put("ok", statusCode in 200..299)

--- a/dayglance-ios/DayGlance/Bridges/HttpBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/HttpBridge.swift
@@ -55,8 +55,22 @@ final class HttpBridge {
             let bodyStr = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
             let ok = (200...299).contains(status)
             let etag = http?.value(forHTTPHeaderField: "ETag") ?? ""
-            let headersJSON = etag.isEmpty ? "{}" : #"{"etag":"\#(self.esc(etag))"}"#
-            resultJSON = #"{"status":\#(status),"ok":\#(ok ? "true" : "false"),"body":"\#(self.esc(bodyStr))","headers":\#(headersJSON)}"#
+
+            // Use JSONSerialization to build the response object so that control
+            // characters (U+0000–U+001F) in body text or ETag values are escaped
+            // correctly — hand-rolled string interpolation would produce invalid JSON.
+            var payload: [String: Any] = [
+                "status": status,
+                "ok": ok,
+                "body": bodyStr,
+            ]
+            payload["headers"] = etag.isEmpty ? [:] : ["etag": etag] as [String: String]
+            if let jsonData = try? JSONSerialization.data(withJSONObject: payload),
+               let jsonStr = String(data: jsonData, encoding: .utf8) {
+                resultJSON = jsonStr
+            } else {
+                resultJSON = self.errorJSON("Failed to serialize response")
+            }
         }.resume()
 
         sem.wait()
@@ -66,14 +80,12 @@ final class HttpBridge {
     // MARK: - Helpers
 
     private func errorJSON(_ msg: String) -> String {
-        #"{"status":0,"ok":false,"body":"","error":"\#(esc(msg))"}"#
-    }
-
-    private func esc(_ s: String) -> String {
-        s.replacingOccurrences(of: "\\", with: "\\\\")
-         .replacingOccurrences(of: "\"", with: "\\\"")
-         .replacingOccurrences(of: "\n", with: "\\n")
-         .replacingOccurrences(of: "\r", with: "\\r")
-         .replacingOccurrences(of: "\t", with: "\\t")
+        let payload: [String: Any] = ["status": 0, "ok": false, "body": "", "error": msg]
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let str = String(data: data, encoding: .utf8) {
+            return str
+        }
+        // Absolute fallback: msg is already sanitized by the Swift runtime.
+        return #"{"status":0,"ok":false,"body":"","error":"serialization error"}"#
     }
 }

--- a/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
@@ -17,7 +17,7 @@ final class ICloudBridge {
 
     // Suppress query callbacks that fire immediately after our own local write.
     private var lastLocalWriteDate: Date?
-    private let writeSuppressionInterval: TimeInterval = 5.0
+    private let writeSuppressionInterval: TimeInterval = 2.0
 
     // MARK: - Public API
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -283,7 +283,12 @@ ipcMain.handle('icloud:read', () => {
       return null;
     }
     return fs.readFileSync(ICLOUD_SYNC_PATH, 'utf-8');
-  } catch { return null; }
+  } catch (e: unknown) {
+    // Return a structured error so the renderer can distinguish "iCloud not
+    // available / not signed in" from "no remote file yet" (null).
+    const msg = e instanceof Error ? e.message : String(e);
+    return JSON.stringify({ error: msg });
+  }
 });
 
 // Track our own writes so the fs.watch callback can ignore them.
@@ -357,13 +362,18 @@ ipcMain.handle('proxy-fetch', async (_event, method: string, url: string, header
     const msg = e instanceof Error ? e.message : 'Invalid URL';
     return { status: 400, ok: false, statusText: 'Bad Request', body: msg };
   }
-  const response = await net.fetch(url, {
-    method: upperMethod,
-    headers,
-    ...(body != null ? { body } : {}),
-  });
-  const text = await response.text();
-  return { status: response.status, ok: response.ok, statusText: response.statusText, body: text, headers: { etag: response.headers.get('etag') || null } };
+  try {
+    const response = await net.fetch(url, {
+      method: upperMethod,
+      headers,
+      ...(body != null ? { body } : {}),
+    });
+    const text = await response.text();
+    return { status: response.status, ok: response.ok, statusText: response.statusText, body: text, headers: { etag: response.headers.get('etag') || null } };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Network error';
+    return { status: 0, ok: false, statusText: msg, body: '', headers: { etag: null } };
+  }
 });
 
 // Dock badge — macOS only

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1387,7 +1387,11 @@ const DayPlanner = () => {
 
       // Decrypt if the file is an encrypted envelope.
       if (isEncryptedEnvelope(remote)) {
-        try { remote = await decryptData(remote); } catch { return; }
+        try { remote = await decryptData(remote); }
+        catch (decErr) {
+          if (decErr?.code === 'PASSPHRASE_REQUIRED') setSyncKeyReady(false);
+          return;
+        }
       }
       if (!remote?.data) return;
 
@@ -4847,9 +4851,12 @@ const DayPlanner = () => {
     }
 
     // Suppress config timestamp tracking effects during remote data application so
-    // they don't overwrite the remote timestamps with Date.now().
+    // they don't overwrite the remote timestamps with Date.now(). Clear after
+    // 500ms to match the suppressCloudUploadRef window — React post-state-change
+    // effects run after setState flushes, which is after the current microtask
+    // completes, so setTimeout(0) clears too early.
     applyingRemoteDataRef.current = true;
-    setTimeout(() => { applyingRemoteDataRef.current = false; }, 0);
+    setTimeout(() => { applyingRemoteDataRef.current = false; }, 500);
 
     suppressCloudUploadRef.current = true;
     suppressTimestampRef.current = true;
@@ -8333,22 +8340,24 @@ const DayPlanner = () => {
                 onClick={async () => {
                   const localData = buildSyncPayload().data;
                   const { data: mergedData, remoteChanged } = mergeSyncData(localData, cloudSyncConflict.remoteData, syncRetentionDays);
+                  const conflictEtag = cloudSyncConflict.etag;
                   applyRemoteData(mergedData);
                   const now = new Date().toISOString();
                   localStorage.setItem('day-planner-cloud-sync-local-modified', now);
                   setCloudSyncLastSynced(now);
                   localStorage.setItem('day-planner-cloud-sync-last-synced', now);
                   setCloudSyncConflict(null);
-                  cloudSyncInProgressRef.current = false;
                   cloudSyncInitialDoneRef.current = true;
                   if (remoteChanged) {
-                    // Pass merged data directly — React state is stale after applyRemoteData
+                    // Pass merged data directly — React state is stale after applyRemoteData.
+                    // Keep the lock held (skipLockCheck:true) until the upload completes.
                     const mergedPayload = { version: 2, lastModified: now, data: mergedData };
-                    await cloudSyncUpload(mergedPayload, { etag: cloudSyncConflict.etag });
+                    await cloudSyncUpload(mergedPayload, { skipLockCheck: true, etag: conflictEtag });
                   } else {
                     setCloudSyncStatus('success');
                     setTimeout(() => setCloudSyncStatus((s) => s === 'success' ? 'idle' : s), 3000);
                   }
+                  cloudSyncInProgressRef.current = false;
                 }}
                 className={`w-full px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-left transition-colors`}
               >
@@ -8375,13 +8384,15 @@ const DayPlanner = () => {
               </button>
               <button
                 onClick={async () => {
+                  const conflictEtag = cloudSyncConflict.etag;
                   setCloudSyncConflict(null);
-                  cloudSyncInProgressRef.current = false;
                   cloudSyncInitialDoneRef.current = true;
                   const now = new Date().toISOString();
                   localStorage.setItem('day-planner-cloud-sync-last-synced', now);
                   setCloudSyncLastSynced(now);
-                  await cloudSyncUpload(undefined, { etag: cloudSyncConflict.etag });
+                  // Keep the lock held (skipLockCheck:true) until the upload completes.
+                  await cloudSyncUpload(undefined, { skipLockCheck: true, etag: conflictEtag });
+                  cloudSyncInProgressRef.current = false;
                 }}
                 className={`w-full px-4 py-3 ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-100 hover:bg-stone-200'} ${textPrimary} rounded-lg text-left transition-colors`}
               >

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -678,12 +678,15 @@ export const mergeSyncData = (localData, remoteData, retentionDays = 90) => {
   if (mergedHabitsEnabled !== localHabitsEnabled) localChanged = true;
   if (mergedHabitsEnabled !== remoteHabitsEnabled) remoteChanged = true;
 
+  // When neither device has set routinesEnabled, emit undefined so the app
+  // supplies the default — avoids propagating a synthetic true to old clients.
+  const bothRoutinesUnset = localData.routinesEnabled === undefined && remoteData.routinesEnabled === undefined;
   const localRoutinesEnabled = localData.routinesEnabled !== undefined ? localData.routinesEnabled : true;
   const remoteRoutinesEnabled = remoteData.routinesEnabled !== undefined ? remoteData.routinesEnabled : true;
-  const mergedRoutinesEnabled = pickConfigByTs(localRoutinesEnabled, localData.routinesEnabledUpdatedAt, remoteRoutinesEnabled, remoteData.routinesEnabledUpdatedAt, true);
+  const mergedRoutinesEnabled = bothRoutinesUnset ? undefined : pickConfigByTs(localRoutinesEnabled, localData.routinesEnabledUpdatedAt, remoteRoutinesEnabled, remoteData.routinesEnabledUpdatedAt, true);
   const mergedRoutinesEnabledUpdatedAt = newerTs(localData.routinesEnabledUpdatedAt, remoteData.routinesEnabledUpdatedAt);
-  if (mergedRoutinesEnabled !== localRoutinesEnabled) localChanged = true;
-  if (mergedRoutinesEnabled !== remoteRoutinesEnabled) remoteChanged = true;
+  if (!bothRoutinesUnset && mergedRoutinesEnabled !== localRoutinesEnabled) localChanged = true;
+  if (!bothRoutinesUnset && mergedRoutinesEnabled !== remoteRoutinesEnabled) remoteChanged = true;
 
   // Combine goal and project tombstones from both sides
   const localDeletedGoalIds = localData.deletedGoalIds || {};

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -1578,13 +1578,15 @@ describe('mergeSyncData — GTD frames sync', () => {
   });
 
   it('frame tombstones from both devices are combined', () => {
+    const ts1 = new Date(Date.now() - 5 * 86400000).toISOString();
+    const ts2 = new Date(Date.now() - 3 * 86400000).toISOString();
     const deviceA = {
       ...emptyData(),
-      deletedFrameIds: { 'f1': '2026-01-01T00:00:00Z' },
+      deletedFrameIds: { 'f1': ts1 },
     };
     const deviceB = {
       ...emptyData(),
-      deletedFrameIds: { 'f2': '2026-01-02T00:00:00Z' },
+      deletedFrameIds: { 'f2': ts2 },
     };
 
     const { data } = mergeSyncData(deviceA, deviceB);
@@ -1627,17 +1629,19 @@ describe('mergeSyncData — GTD frames sync', () => {
   });
 
   it('newer tombstone timestamp wins when both devices have tombstones for same frame', () => {
+    const older = new Date(Date.now() - 20 * 86400000).toISOString();
+    const newer = new Date(Date.now() - 10 * 86400000).toISOString();
     const deviceA = {
       ...emptyData(),
-      deletedFrameIds: { 'f1': '2026-01-01T00:00:00Z' },
+      deletedFrameIds: { 'f1': older },
     };
     const deviceB = {
       ...emptyData(),
-      deletedFrameIds: { 'f1': '2026-02-01T00:00:00Z' },
+      deletedFrameIds: { 'f1': newer },
     };
 
     const { data } = mergeSyncData(deviceA, deviceB);
-    expect(data.deletedFrameIds['f1']).toBe('2026-02-01T00:00:00Z');
+    expect(data.deletedFrameIds['f1']).toBe(newer);
   });
 
   it('handles undefined gtdFrames gracefully (old remote data)', () => {

--- a/src/utils/autoBackup.js
+++ b/src/utils/autoBackup.js
@@ -1,28 +1,8 @@
 import { encryptData, decryptData, isEncryptedEnvelope, hasEncryptionReady } from './crypto.js';
+import { webdavFetch } from './cloudSyncProviders.js';
 
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
 const toBase64 = (str) => btoa(String.fromCharCode(...new TextEncoder().encode(str)));
-
-// Routes a WebDAV request through the Electron main process on desktop (no CORS
-// restrictions) or through the server-side proxy on web. Translates X-WebDAV-Auth
-// to Authorization when going direct, mirroring what the proxy does.
-const webdavProxyFetch = async (method, url, headers, body = null) => {
-  if (typeof window !== 'undefined' && window.electronAPI?.isElectron) {
-    const fwd = {};
-    for (const [k, v] of Object.entries(headers)) {
-      fwd[k === 'X-WebDAV-Auth' ? 'Authorization' : k] = v;
-    }
-    if (body != null && !fwd['Content-Type']) fwd['Content-Type'] = 'application/octet-stream';
-    const r = await window.electronAPI.proxyFetch(method, url, fwd, body);
-    if (!r) throw new Error('Electron network bridge unavailable');
-    return { status: r.status, ok: r.ok, statusText: r.statusText, text: async () => r.body, json: async () => JSON.parse(r.body) };
-  }
-  return fetch(`/api/webdav-proxy/?url=${url}`, {
-    method,
-    headers,
-    ...(body != null ? { body } : {}),
-  });
-};
 
 // Auto-backup IndexedDB wrapper
 export const autoBackupDB = {
@@ -127,14 +107,14 @@ export const autoBackupProviders = {
       const body = JSON.stringify(payload);
 
       const doUpload = () =>
-        webdavProxyFetch('PUT', fileUrl, { ...authHeaders, 'Content-Type': 'application/json' }, body);
+        webdavFetch('PUT', fileUrl, authHeaders, body, { 'Content-Type': 'application/json' });
 
       let res = await doUpload();
       if (res.status === 404 || res.status === 409) {
         // Create /dayglance/ then /dayglance/backups/
         const parentDir = `${config.nextcloudUrl.replace(/\/+$/, '')}/remote.php/dav/files/${encodeURIComponent(config.username)}/dayglance/`;
-        await webdavProxyFetch('MKCOL', parentDir, authHeaders);
-        await webdavProxyFetch('MKCOL', dirUrl, authHeaders);
+        await webdavFetch('MKCOL', parentDir, authHeaders);
+        await webdavFetch('MKCOL', dirUrl, authHeaders);
         res = await doUpload();
       }
       if (!res.ok) throw new Error(`Upload failed: ${res.status} ${res.statusText}`);
@@ -143,7 +123,7 @@ export const autoBackupProviders = {
     async listBackups(config) {
       const dirUrl = this._getBackupDirUrl(config);
       const authHeaders = this._getAuthHeaders(config);
-      const res = await webdavProxyFetch('PROPFIND', dirUrl, { ...authHeaders, 'Depth': '1' });
+      const res = await webdavFetch('PROPFIND', dirUrl, authHeaders, undefined, { 'Depth': '1' });
       if (res.status === 404) return [];
       if (!res.ok) throw new Error(`List failed: ${res.status}`);
       const xml = await res.text();
@@ -164,7 +144,7 @@ export const autoBackupProviders = {
     async downloadBackup(config, filename) {
       const fileUrl = this._getBackupDirUrl(config) + filename;
       const authHeaders = this._getAuthHeaders(config);
-      const res = await webdavProxyFetch('GET', fileUrl, authHeaders);
+      const res = await webdavFetch('GET', fileUrl, authHeaders);
       if (!res.ok) throw new Error(`Download failed: ${res.status}`);
       const parsed = await res.json();
       if (isEncryptedEnvelope(parsed)) return decryptData(parsed);
@@ -173,13 +153,13 @@ export const autoBackupProviders = {
     async deleteBackup(config, filename) {
       const fileUrl = this._getBackupDirUrl(config) + filename;
       const authHeaders = this._getAuthHeaders(config);
-      const res = await webdavProxyFetch('DELETE', fileUrl, authHeaders);
+      const res = await webdavFetch('DELETE', fileUrl, authHeaders);
       if (!res.ok && res.status !== 404) throw new Error(`Delete failed: ${res.status}`);
     },
     async testConnection(config) {
       const dirUrl = this._getBackupDirUrl(config);
       const authHeaders = this._getAuthHeaders(config);
-      const res = await webdavProxyFetch('PROPFIND', dirUrl, { ...authHeaders, 'Depth': '0' });
+      const res = await webdavFetch('PROPFIND', dirUrl, authHeaders, undefined, { 'Depth': '0' });
       if (res.status === 200 || res.status === 207 || res.status === 404) return { success: true };
       if (res.status === 401) return { success: false, error: 'Invalid credentials.' };
       return { success: false, error: `Unexpected response: ${res.status}` };
@@ -208,10 +188,10 @@ export const autoBackupProviders = {
       const payload = hasEncryptionReady() ? await encryptData(data) : data;
       const body = JSON.stringify(payload);
       const doUpload = () =>
-        webdavProxyFetch('PUT', fileUrl, { ...authHeaders, 'Content-Type': 'application/json' }, body);
+        webdavFetch('PUT', fileUrl, authHeaders, body, { 'Content-Type': 'application/json' });
       let res = await doUpload();
       if (res.status === 404 || res.status === 409) {
-        await webdavProxyFetch('MKCOL', dirUrl, authHeaders);
+        await webdavFetch('MKCOL', dirUrl, authHeaders);
         res = await doUpload();
       }
       if (!res.ok) throw new Error(`Upload failed: ${res.status} ${res.statusText}`);
@@ -220,7 +200,7 @@ export const autoBackupProviders = {
     async listBackups(config) {
       const dirUrl = this._getBackupDirUrl(config);
       const authHeaders = this._getAuthHeaders(config);
-      const res = await webdavProxyFetch('PROPFIND', dirUrl, { ...authHeaders, 'Depth': '1' });
+      const res = await webdavFetch('PROPFIND', dirUrl, authHeaders, undefined, { 'Depth': '1' });
       if (res.status === 404) return [];
       if (!res.ok) throw new Error(`List failed: ${res.status}`);
       const xml = await res.text();
@@ -241,7 +221,7 @@ export const autoBackupProviders = {
     async downloadBackup(config, filename) {
       const fileUrl = this._getBackupDirUrl(config) + filename;
       const authHeaders = this._getAuthHeaders(config);
-      const res = await webdavProxyFetch('GET', fileUrl, authHeaders);
+      const res = await webdavFetch('GET', fileUrl, authHeaders);
       if (!res.ok) throw new Error(`Download failed: ${res.status}`);
       const parsed = await res.json();
       if (isEncryptedEnvelope(parsed)) return decryptData(parsed);
@@ -250,13 +230,13 @@ export const autoBackupProviders = {
     async deleteBackup(config, filename) {
       const fileUrl = this._getBackupDirUrl(config) + filename;
       const authHeaders = this._getAuthHeaders(config);
-      const res = await webdavProxyFetch('DELETE', fileUrl, authHeaders);
+      const res = await webdavFetch('DELETE', fileUrl, authHeaders);
       if (!res.ok && res.status !== 404) throw new Error(`Delete failed: ${res.status}`);
     },
     async testConnection(config) {
       const dirUrl = this._getBackupDirUrl(config);
       const authHeaders = this._getAuthHeaders(config);
-      const res = await webdavProxyFetch('PROPFIND', dirUrl, { ...authHeaders, 'Depth': '0' });
+      const res = await webdavFetch('PROPFIND', dirUrl, authHeaders, undefined, { 'Depth': '0' });
       if (res.status === 200 || res.status === 207 || res.status === 404) return { success: true };
       if (res.status === 401) return { success: false, error: 'Invalid credentials.' };
       return { success: false, error: `Unexpected response: ${res.status}` };


### PR DESCRIPTION
## Summary

Follow-up to PR #772. After a full Opus 4.7 re-audit of all sync code, this PR fixes everything that remained or was newly found — including a critical bug where Android auto-backups silently failed on every run.

### Critical

- **autoBackup.js**: Delete private `webdavProxyFetch` and replace with shared `webdavFetch` from `cloudSyncProviders.js`. Fixes two issues at once: the `?url=` query param was not URL-encoded (breaking URLs with `+`, `&`, `#` etc.), and there was no Android/iOS native bridge path — meaning auto-backups on Android hit a nonexistent `/api/webdav-proxy/` endpoint and silently failed on every attempt.

### High

- **iOS ICloudBridge**: Reduce `writeSuppressionInterval` from 5s → 2s, matching the Electron side. L12 was only half-applied in the previous PR.
- **Conflict modal** ("Merge both" / "Use local"): Hold the sync lock until the upload `await` completes by passing `skipLockCheck: true`. Previously the lock was released before the upload, creating a window where a concurrent download poll could interleave. Also capture ETag before clearing dialog state to avoid stale closure reads.
- **Electron `icloud:read`**: Return `{"error": msg}` on exception instead of `null`, so `iCloudSync` can distinguish "iCloud unavailable / not signed in" from "no remote file yet." The existing `remote?.error` handler in App.jsx surfaces this to the user.

### Medium

- **Electron `proxy-fetch`**: Wrap `net.fetch` in try/catch, returning `{status:0, ok:false, statusText:msg}` on network failure — mirroring the Android and iOS bridge error contract. Previously a DNS failure would throw out of the IPC handler with no structured error.
- **iOS HttpBridge**: Switch from hand-rolled string-interpolated JSON to `JSONSerialization`. The `esc()` helper missed control characters U+0000–U+001F (excluding `\n`, `\r`, `\t`); `JSONSerialization` handles all of them correctly.
- **Android HttpBridge**: Read ETag header before `disconnect()` — reading connection metadata after disconnect is undefined behavior per the Java spec (worked in practice on most JDKs but not guaranteed).
- **`applyingRemoteDataRef`**: Clear after 500ms instead of `setTimeout(0)`. The 0ms timer fired before React's post-setState effects, so `writeConfigTimestamp` could still overwrite synced timestamps with `Date.now()` during the window when remote data was being applied.

### Low

- **iCloudSync decryption**: Now calls `setSyncKeyReady(false)` on `PASSPHRASE_REQUIRED` errors instead of silently returning. Matches the WebDAV path's behavior and re-shows the passphrase prompt.

### Tests

- Fix 3 pre-existing `mergeSync.test.js` failures (also on branch `fix-mergesync-test-regressions`):
  - Two GTD frame tombstone tests used hardcoded Jan/Feb 2026 timestamps now older than the 90-day retention window — updated to `Date.now() - N days` so they never age out.
  - `routinesEnabled` merge emitted `true` when neither device had it set; now emits `undefined` so the app layer supplies the default.

All 156 tests pass.

## Test plan

- [ ] Auto-backup to WebDAV/Nextcloud works on Android (previously failed silently)
- [ ] Auto-backup to WebDAV/Nextcloud works on web and Electron
- [ ] Conflict modal "Merge both" and "Use local" complete their upload before releasing the sync lock
- [ ] On Mac: signing out of iCloud and triggering a sync shows an error in the UI rather than silently treating it as "no remote file"
- [ ] On iOS: edits from another device within 2–3s of a local write are picked up on the next poll (previously suppressed for 5s)
- [ ] Encrypted iCloud sync: wrong passphrase re-shows the passphrase prompt
- [ ] All 156 mergeSync + obsidian tests pass: `npx vitest run`

https://claude.ai/code/session_01U9AvrEMjCyvPXxqo4yWu9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9AvrEMjCyvPXxqo4yWu9X)_