### PR TITLE
chore: bump version to 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Your day, at a glance.** A privacy-first day planner with visual time-blocking, deep integrations, and zero lock-in. Use it free at [dayglance.app](https://dayglance.app) or self-host it on your own server. Your data stays on your device — nothing is ever sent to a server unless you choose to sync it yourself.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.0.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.0.1-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases) · [**Android APK**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 60
+        versionCode = 61
         versionName = "3.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- `package.json`: 3.0.0 → 3.0.1 (+ lockfile updated)
- `README.md`: version badge 3.0.0 → 3.0.1
- `dayglance-android/app/build.gradle.kts`: `versionCode` 60 → 61, `versionName` stays `"3.0"` (major.minor per convention)

Patch release covering the iCloud/WebDAV cloud sync re-audit fixes landed in PRs #772 and #773.

https://claude.ai/code/session_01U9AvrEMjCyvPXxqo4yWu9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9AvrEMjCyvPXxqo4yWu9X)_