### PR TITLE
Bump Android versionCode to 62

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 61
+        versionCode = 62
         versionName = "3.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

- Increments `versionCode` from 61 to 62 in `dayglance-android/app/build.gradle.kts`
- `versionName` ("3.0") is unchanged

## Test plan

- [ ] Verify the app builds successfully with the new version code
- [ ] Confirm Play Store accepts the updated version code on upload

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ak3G9FFg8D9daGGVwTYQbB)_