### PR TITLE
v2.9.3 — bug fixes: past events, wikilinks, AI button, timezone warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Your day, at a glance.** A privacy-first day planner with visual time-blocking, deep integrations, and zero lock-in. Use it free at [dayglance.app](https://dayglance.app) or self-host it on your own server. Your data stays on your device — nothing is ever sent to a server unless you choose to sync it yourself.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.0.1-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-2.9.3-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases) · [**Android APK**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 62
-        versionName = "3.0"
+        versionCode = 63
+        versionName = "2.9.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
@@ -173,10 +173,18 @@ class ObsidianRepository(private val context: Context) {
         val dir = if (folder.isBlank()) root else (root.navigateTo(folder) ?: return "[]")
         val prefix = if (folder.isBlank()) "" else "$folder/"
         val arr = JSONArray()
-        dir.listFiles()
-            .filter { it.isFile && it.name?.endsWith(".md") == true }
-            .sortedByDescending { it.name }
-            .forEach { arr.put(prefix + it.name) }
+        fun collect(d: DocumentFile, pathPrefix: String) {
+            for (file in d.listFiles()) {
+                val name = file.name ?: continue
+                if (name.startsWith('.')) continue
+                if (file.isFile && name.endsWith(".md")) {
+                    arr.put(pathPrefix + name)
+                } else if (file.isDirectory) {
+                    collect(file, "$pathPrefix$name/")
+                }
+            }
+        }
+        collect(dir, prefix)
         return arr.toString()
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.0.1",
+  "version": "2.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.0.1",
+      "version": "2.9.3",
       "dependencies": {
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.0.1",
+  "version": "2.9.3",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -342,6 +342,11 @@ const DayPlanner = () => {
     return saved !== null ? JSON.parse(saved) : 0; // 0=Sunday, 1=Monday
   });
   useEffect(() => { localStorage.setItem('day-planner-week-start-day', JSON.stringify(weekStartDay)); }, [weekStartDay]);
+  const [homeTimezone, setHomeTimezone] = useState(() => {
+    const saved = localStorage.getItem('day-planner-home-timezone');
+    return saved || Intl.DateTimeFormat().resolvedOptions().timeZone;
+  });
+  useEffect(() => { localStorage.setItem('day-planner-home-timezone', homeTimezone); }, [homeTimezone]);
   const [weekTimelineStartHour, setWeekTimelineStartHour] = useState(() => {
     const saved = localStorage.getItem('day-planner-week-timeline-start-hour');
     return saved !== null ? JSON.parse(saved) : 0;
@@ -7571,6 +7576,7 @@ const DayPlanner = () => {
     use24HourClock, setUse24HourClock,
     inboxAutoArchiveDays, setInboxAutoArchiveDays,
     weekStartDay, setWeekStartDay,
+    homeTimezone, setHomeTimezone,
     weekTimelineStartHour, setWeekTimelineStartHour,
     minimizedSections, setMinimizedSections,
     showSettings, setShowSettings,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2268,6 +2268,7 @@ const DayPlanner = () => {
         const handle = await getVaultAccess();
         if (!handle) return;
         obsidianVaultHandleRef.current = handle;
+        listVaultNotes(handle).then(names => setWikilinkCandidates(names)).catch(() => {});
       } catch {
         return;
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5567,41 +5567,37 @@ const DayPlanner = () => {
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
   }, [aiConfig.enabled, aiConfig.features.eveningReflection]);
 
-  // --- AI Task Suggestion (duration + tags debounce) ---
+  // Clear AI suggestion when the form closes or switches to edit mode
   useEffect(() => {
-    // Clear suggestion when form closes or when editing an existing task
     if (!showAddTask || mobileEditingTask) {
       setTaskAISuggestion(null);
       setTaskAISuggestionLoading(false);
-      return;
     }
-    // Strip inline tags/shorthands so we query the clean title words
+  }, [showAddTask, mobileEditingTask]);
+
+  // --- AI Task Suggestion (manually triggered) ---
+  const triggerTaskAISuggestion = useCallback(async () => {
     const cleanedTitle = newTask.title.replace(/#\w+|@\S+|~\S+|%\d+|\^\S*/g, '').trim();
     if (
       cleanedTitle.length < 3 ||
       !aiConfig.enabled ||
       !aiConfig.features?.durationEstimate ||
       (!aiConfig.apiKey && aiConfig.provider !== 'ollama')
-    ) {
-      setTaskAISuggestion(null);
-      return;
-    }
+    ) return;
+    setTaskAISuggestion(null);
     setTaskAISuggestionLoading(true);
-    const timer = setTimeout(async () => {
-      try {
-        const result = await aiJSON(
-          taskSuggestSystemPrompt(),
-          taskSuggestUserPrompt({ title: cleanedTitle, existingTags: allTags }),
-          aiConfig
-        );
-        if (result && typeof result.duration === 'number') {
-          setTaskAISuggestion(result);
-        }
-      } catch {}
-      setTaskAISuggestionLoading(false);
-    }, 650);
-    return () => { clearTimeout(timer); setTaskAISuggestionLoading(false); };
-  }, [newTask.title, showAddTask, mobileEditingTask, aiConfig, allTags]);
+    try {
+      const result = await aiJSON(
+        taskSuggestSystemPrompt(),
+        taskSuggestUserPrompt({ title: cleanedTitle, existingTags: allTags }),
+        aiConfig
+      );
+      if (result && typeof result.duration === 'number') {
+        setTaskAISuggestion(result);
+      }
+    } catch {}
+    setTaskAISuggestionLoading(false);
+  }, [newTask.title, aiConfig, allTags]);
 
   // --- Weekly AI Summary (enhanced weekly review) ---
   const generateWeeklyAISummary = useCallback(async (stats) => {
@@ -7943,6 +7939,7 @@ const DayPlanner = () => {
     voiceCanRecord,
     taskAISuggestion, setTaskAISuggestion,
     taskAISuggestionLoading, setTaskAISuggestionLoading,
+    triggerTaskAISuggestion,
     aiSubtasksLoadingForTask, setAiSubtasksLoadingForTask,
 
     // ── Weekly review / AI summaries ──────────────────────────────────────────

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -61,6 +61,7 @@ const DesktopLayout = () => {
     showMobileDailySummary, setShowMobileDailySummary,
     mobileSettingsView, setMobileSettingsView,
     use24HourClock, setUse24HourClock,
+    homeTimezone,
     minimizedSections, setMinimizedSections,
     showSettings, setShowSettings,
     collapsedSettings, setCollapsedSettings,
@@ -558,8 +559,8 @@ const DesktopLayout = () => {
               aria-label="Settings"
             >
               <Settings size={18} className={textSecondary} />
-              {updateInfo && (
-                <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full border-2 ${darkMode ? 'border-gray-800' : 'border-white'} bg-red-500`} />
+              {(updateInfo || Intl.DateTimeFormat().resolvedOptions().timeZone !== homeTimezone) && (
+                <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full border-2 ${darkMode ? 'border-gray-800' : 'border-white'} ${updateInfo ? 'bg-red-500' : 'bg-amber-500'}`} />
               )}
             </button>
             <button

--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -31,7 +31,7 @@ const DesktopNewTaskModal = () => {
     applySuggestionForNewTask,
     handleNewTaskInputChange, handleNewTaskInputKeyDown,
   } = useDayPlannerCtx();
-  const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, goals, projects, goalsProjectsEnabled } = useFeaturesCtx();
+  const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, triggerTaskAISuggestion, goals, projects, goalsProjectsEnabled } = useFeaturesCtx();
   const { wikilinkCandidates = [] } = useSyncCtx() || {};
 
   // Wikilink autocomplete: detect [[partial at end of title
@@ -133,7 +133,7 @@ const DesktopNewTaskModal = () => {
                     ))}
                   </div>
                 )}
-                {/* AI duration + tag suggestion pill */}
+                {/* AI duration + tag suggestion */}
                 {aiConfig.enabled && aiConfig.features?.durationEstimate && !mobileEditingTask && (
                   taskAISuggestionLoading ? (
                     <div className={`mt-1.5 flex items-center gap-1.5 text-xs ${darkMode ? 'text-purple-400' : 'text-purple-600'}`}>
@@ -169,7 +169,18 @@ const DesktopNewTaskModal = () => {
                         <X size={11} className={textSecondary} />
                       </button>
                     </div>
-                  ) : null
+                  ) : (
+                    <div className="mt-1.5">
+                      <button
+                        type="button"
+                        onClick={triggerTaskAISuggestion}
+                        className={`flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium transition-colors ${darkMode ? 'bg-purple-500/20 hover:bg-purple-500/30 text-purple-400' : 'bg-purple-100 hover:bg-purple-200 text-purple-600'}`}
+                      >
+                        <Sparkles size={9} />
+                        AI
+                      </button>
+                    </div>
+                  )
                 )}
               </div>
               {/* Project assignment (only when Goals & Projects is enabled) */}

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -73,6 +73,7 @@ const MobileGlanceSection = () => {
     tagFilterBtnRef,
     goToDate, scrollToHour,
     glancePage, setGlancePage,
+    mobileViewMode,
   } = useDayPlannerCtx();
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
   const {
@@ -1091,7 +1092,9 @@ const MobileGlanceSection = () => {
       tomorrow.setDate(tomorrow.getDate() + 1);
       setMobileActiveTab('timeline');
       goToDate(tomorrow);
-      if (firstStartTime) {
+      if (mobileViewMode === 'list') {
+        setTimeout(() => calendarRef.current?.scrollTo({ top: 0, behavior: 'smooth' }), 150);
+      } else if (firstStartTime) {
         setTimeout(() => scrollToHour(firstStartTime), 150);
       }
     };

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -3,7 +3,7 @@ import {
   Activity, AlertCircle, AlertTriangle, Archive, BarChart3, Bell, BookOpen, BrainCircuit,
   Calendar, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronLeft, ChevronRight, ChevronUp, Clock, Cloud, ExternalLink,
-  Eye, FileText, Filter, Flag, Flame, FolderOpen, GitBranch, GripVertical, Hash, HelpCircle,
+  Eye, FileText, Filter, Flag, Flame, FolderOpen, GitBranch, Globe, GripVertical, Hash, HelpCircle,
   Inbox, Key, Layers, LayoutGrid, Link, Loader, Menu, Mic, Minus, Moon, MoreHorizontal,
   NotebookPen, Plus, RefreshCw, Save, Search, Settings, SkipForward, Sparkles,
   Sun, Target, Trash2, TrendingUp, Trophy, Undo2, Upload, Volume2, VolumeX,
@@ -41,6 +41,7 @@ import InboxFilterPopover from './InboxFilterPopover.jsx';
 import InboxArchivedBar from './InboxArchivedBar.jsx';
 
 const MobileLayout = () => {
+  const [tzBannerDismissed, setTzBannerDismissed] = useState(false);
   const {
     isPhone, isMobile, isTablet, isLandscape,
     visibleDays, visibleDates,
@@ -76,6 +77,7 @@ const MobileLayout = () => {
     tabletActiveTab, setTabletActiveTab,
     mobileActiveTab, setMobileActiveTab,
     mobileViewMode, setMobileViewMode,
+    homeTimezone,
     mobileWelcomeStep, setMobileWelcomeStep,
     desktopWelcomeStep, setDesktopWelcomeStep,
     showMonthView, setShowMonthView,
@@ -680,6 +682,22 @@ const MobileLayout = () => {
                   ref={calendarRef}
                   className={`${cardBg} border ${borderClass} overflow-y-scroll overflow-x-hidden ${darkMode ? 'dark-scrollbar' : ''} relative h-full`}
                 >
+                  {/* Timezone mismatch strip */}
+                  {!tzBannerDismissed && Intl.DateTimeFormat().resolvedOptions().timeZone !== homeTimezone && (
+                    <div className={`flex items-center gap-2 px-3 py-2 text-xs border-b ${darkMode ? 'bg-amber-900/20 border-amber-800 text-amber-300' : 'bg-amber-50 border-amber-200 text-amber-800'}`}>
+                      <Globe size={12} className="flex-shrink-0" />
+                      <span className="flex-1 min-w-0 truncate">
+                        Device timezone differs from home ({homeTimezone.replace(/_/g, ' ')})
+                      </span>
+                      <button
+                        onClick={() => setTzBannerDismissed(true)}
+                        className="flex-shrink-0 p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10"
+                      >
+                        <X size={12} />
+                      </button>
+                    </div>
+                  )}
+
                   {/* Sticky header group: date header + all-day section */}
                   <div ref={mobileDateHeaderRef} className={`sticky top-0 z-40 ${cardBg}`}>
                   {/* Current task banner */}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -107,7 +107,7 @@ function SpineMarker({ kind, completed, colour, pageBg }) {
       </div>
     );
   }
-  if (kind === 'calendar-event') {
+  if (kind === 'calendar-event' && !completed) {
     return (
       <div style={{ ...base, borderRadius: 2, background: colour }} />
     );
@@ -150,7 +150,7 @@ function Connector({ colour, opacity = 1 }) {
 // ─── TaskCard ─────────────────────────────────────────────────────────────────
 
 const TaskCard = React.memo(({
-  item, accentHex, isCalendarEvent, isInProgress, darkMode, textPrimary, textSecondary,
+  item, accentHex, isCalendarEvent, isInProgress, isPast, darkMode, textPrimary, textSecondary,
   formatTime, minutesToTime, timeToMinutes,
   setExpandedNotesTaskId, postponeTask, moveToInbox, openMobileEditTask,
   dateStr,
@@ -184,7 +184,7 @@ const TaskCard = React.memo(({
       <div style={{ flex: 1, minWidth: 0, padding: '7px 0 7px 8px', display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: 3 }}>
         {/* Title */}
         <div
-          className={`text-sm font-medium leading-snug ${textPrimary} ${item.completed ? 'line-through opacity-50' : ''}`}
+          className={`text-sm font-medium leading-snug ${textPrimary} ${item.completed ? 'line-through opacity-50' : (isCalendarEvent && isPast) ? 'line-through' : ''}`}
           style={{ overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}
         >
           {renderTitle(item.title)}
@@ -1655,7 +1655,7 @@ const MobileListView = () => {
                 marker={
                   <SpineMarker
                     kind={isCalendarEvent ? 'calendar-event' : 'task'}
-                    completed={item.completed}
+                    completed={isCalendarEvent ? isPast : item.completed}
                     colour={accentHex}
                     pageBg={pageBg}
                   />
@@ -1671,6 +1671,7 @@ const MobileListView = () => {
                     accentHex={accentHex}
                     isCalendarEvent={isCalendarEvent}
                     isInProgress={isInProgress}
+                    isPast={isPast}
                     darkMode={darkMode}
                     textPrimary={textPrimary}
                     textSecondary={textSecondary}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -174,7 +174,7 @@ const TaskCard = React.memo(({
     : hasOnlySubtasks(item)      ? CheckSquare
     : isObsidianNoteOnlyTask(item) ? BookOpen
     : FileText;
-  const hasNotes = hasNotesOrSubtasks(item) || isLinkOnlyTask(item);
+  const hasNotes = hasNotesOrSubtasks(item) || isLinkOnlyTask(item) || isObsidianNoteOnlyTask(item);
 
   return (
     <div style={cardStyle}>

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -25,7 +25,7 @@ const MobileNewTaskModal = () => {
     moveToRecycleBin, clearNativeEventOverride,
     handleNewTaskInputChange,
   } = useDayPlannerCtx();
-  const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, goals, projects, goalsProjectsEnabled } = useFeaturesCtx();
+  const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, triggerTaskAISuggestion, goals, projects, goalsProjectsEnabled } = useFeaturesCtx();
   const { wikilinkCandidates = [] } = useSyncCtx() || {};
 
   // Wikilink autocomplete: detect [[partial at end of title
@@ -98,7 +98,7 @@ const MobileNewTaskModal = () => {
                     ))}
                   </div>
                 )}
-                {/* AI duration + tag suggestion pill */}
+                {/* AI duration + tag suggestion */}
                 {aiConfig.enabled && aiConfig.features?.durationEstimate && !mobileEditingTask && (
                   taskAISuggestionLoading ? (
                     <div className={`mt-1.5 flex items-center gap-1.5 text-xs ${darkMode ? 'text-purple-400' : 'text-purple-600'}`}>
@@ -134,7 +134,18 @@ const MobileNewTaskModal = () => {
                         <X size={11} className={textSecondary} />
                       </button>
                     </div>
-                  ) : null
+                  ) : (
+                    <div className="mt-1.5">
+                      <button
+                        type="button"
+                        onClick={triggerTaskAISuggestion}
+                        className={`flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium transition-colors ${darkMode ? 'bg-purple-500/20 hover:bg-purple-500/30 text-purple-400' : 'bg-purple-100 hover:bg-purple-200 text-purple-600'}`}
+                      >
+                        <Sparkles size={9} />
+                        AI
+                      </button>
+                    </div>
+                  )
                 )}
               </div>
 

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -3,11 +3,12 @@ import {
   Activity, Archive, BarChart3, Bell, BookOpen, BrainCircuit,
   CalendarDays, CheckCircle, CheckSquare, ChevronDown, ChevronUp,
   ChevronLeft, ChevronRight, Clock, Cloud, ExternalLink,
-  Footprints, FolderOpen, GripVertical, HelpCircle, Key, LayoutGrid,
+  Footprints, FolderOpen, Globe, GripVertical, HelpCircle, Key, LayoutGrid,
   Loader, Mic, Moon, Pencil, Plus,
   Flag, RefreshCw, Save, Settings, Sparkles, Sun, Target, Trash2,
   Undo2, Upload, Volume2, VolumeX, Wifi, Zap,
 } from 'lucide-react';
+import { getTzLabel, getTzOptions } from '../utils/timezones.js';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from '../constants/habits.js';
 import { isNativeAndroid, isNativeApp, nativeGetCalendars, nativePickVault } from '../native.js';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
@@ -30,6 +31,7 @@ const MobileSettingsPanel = () => {
     use24HourClock, setUse24HourClock,
     inboxAutoArchiveDays, setInboxAutoArchiveDays,
     weekStartDay, setWeekStartDay,
+    homeTimezone, setHomeTimezone,
     collapsedSettings,
     soundEnabled, setSoundEnabled,
     setShowHelpModal,
@@ -122,6 +124,28 @@ const MobileSettingsPanel = () => {
     className={`px-4 py-4 space-y-4 transition-transform duration-200 ${mobileSettingsView !== 'main' ? '-translate-x-full' : 'translate-x-0'}`}
     style={{ display: mobileSettingsView !== 'main' ? 'none' : undefined }}
   >
+    {/* Timezone mismatch warning */}
+    {Intl.DateTimeFormat().resolvedOptions().timeZone !== homeTimezone && (
+      <div className={`p-3 rounded-xl border ${darkMode ? 'bg-amber-900/20 border-amber-800' : 'bg-amber-50 border-amber-200'} flex items-start gap-2`}>
+        <Globe size={14} className={`flex-shrink-0 mt-0.5 ${darkMode ? 'text-amber-400' : 'text-amber-600'}`} />
+        <div className="flex-1 min-w-0">
+          <div className={`text-xs font-semibold ${darkMode ? 'text-amber-300' : 'text-amber-800'}`}>Timezone mismatch</div>
+          <div className={`text-xs mt-0.5 ${darkMode ? 'text-amber-400/80' : 'text-amber-700/80'}`}>
+            Device: <strong>{Intl.DateTimeFormat().resolvedOptions().timeZone.replace(/_/g, ' ')}</strong>
+          </div>
+          <div className={`text-xs ${darkMode ? 'text-amber-400/80' : 'text-amber-700/80'}`}>
+            Home: <strong>{homeTimezone.replace(/_/g, ' ')}</strong>
+          </div>
+          <button
+            onClick={() => setMobileSettingsView('app')}
+            className={`mt-1.5 text-[10px] font-medium underline ${darkMode ? 'text-amber-400' : 'text-amber-700'}`}
+          >
+            Fix in App Settings →
+          </button>
+        </div>
+      </div>
+    )}
+
     {/* Quick toggles */}
     <div className="grid grid-cols-3 gap-3">
       {/* Row 1: 12h/24h | First Day | Sound */}
@@ -365,6 +389,25 @@ const MobileSettingsPanel = () => {
             </div>
           </div>
         )}
+      </div>
+
+      {/* Home timezone */}
+      <hr className={borderClass} />
+      <div className="space-y-2">
+        <div className={`font-medium ${textPrimary} flex items-center gap-2`}>
+          <Globe size={16} className={textSecondary} />
+          Home timezone
+        </div>
+        <p className={`text-xs ${textSecondary}`}>Used to detect when your device is in a different timezone.</p>
+        <select
+          value={homeTimezone}
+          onChange={e => setHomeTimezone(e.target.value)}
+          className={`w-full px-3 py-2 text-sm rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} focus:outline-none focus:ring-2 focus:ring-blue-500`}
+        >
+          {getTzOptions(homeTimezone).map(tz => (
+            <option key={tz} value={tz}>{getTzLabel(tz)}</option>
+          ))}
+        </select>
       </div>
 
       {/* GLANCE default */}

--- a/src/components/ObsidianSyncToast.jsx
+++ b/src/components/ObsidianSyncToast.jsx
@@ -5,7 +5,7 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 
 const ObsidianSyncToast = () => {
   const { obsidianSyncStatus, obsidianSyncError } = useSyncCtx();
-  const { cardBg, borderClass, textPrimary, textSecondary } = useDayPlannerCtx();
+  const { cardBg, borderClass, textPrimary, textSecondary, isMobile } = useDayPlannerCtx();
 
   if (obsidianSyncStatus === 'idle') return null;
 
@@ -28,7 +28,10 @@ const ObsidianSyncToast = () => {
   }
 
   return (
-    <div className="fixed bottom-6 left-6 z-50 animate-in slide-in-from-bottom-2 duration-200">
+    <div
+      className={`fixed z-50 animate-in slide-in-from-bottom-2 duration-200 ${isMobile ? 'left-1/2 -translate-x-1/2' : 'bottom-6 left-6'}`}
+      style={isMobile ? { bottom: 'calc(4.5rem + env(safe-area-inset-bottom, 0px))' } : undefined}
+    >
       <div className={`flex items-center gap-3 ${cardBg} border ${borderClass} rounded-xl shadow-xl px-4 py-3 max-w-xs`}>
         <div className={`w-1.5 self-stretch rounded-full flex-shrink-0 ${accentColor}`} />
         {icon}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Activity, Archive, BarChart3, Bell, BookOpen, BrainCircuit, CalendarDays, CheckCircle, CheckSquare, ChevronDown, Clock, Cloud, ExternalLink, Flag, FolderOpen, Key, LayoutGrid, Loader, MapPin, Mic, Moon, Newspaper, RefreshCw, Server, Settings, Sparkles, Sun, Target, Thermometer, Upload, Wifi, WifiOff, X, Zap } from 'lucide-react';
+import { Activity, Archive, BarChart3, Bell, BookOpen, BrainCircuit, CalendarDays, CheckCircle, CheckSquare, ChevronDown, Clock, Cloud, ExternalLink, Flag, FolderOpen, Globe, Key, LayoutGrid, Loader, MapPin, Mic, Moon, Newspaper, RefreshCw, Server, Settings, Sparkles, Sun, Target, Thermometer, Upload, Wifi, WifiOff, X, Zap } from 'lucide-react';
+import { getTzLabel, getTzOptions } from '../utils/timezones.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -20,6 +21,7 @@ const SettingsModal = () => {
     use24HourClock, setUse24HourClock,
     inboxAutoArchiveDays, setInboxAutoArchiveDays,
     weekStartDay, setWeekStartDay,
+    homeTimezone, setHomeTimezone,
     weekTimelineStartHour, setWeekTimelineStartHour,
     soundEnabled, setSoundEnabled,
     setOnboardingProgress,
@@ -152,6 +154,24 @@ const SettingsModal = () => {
                       >
                         <X size={14} className={darkMode ? 'text-blue-400' : 'text-blue-600'} />
                       </button>
+                    </div>
+                  </div>
+                )}
+
+                {Intl.DateTimeFormat().resolvedOptions().timeZone !== homeTimezone && (
+                  <div className={`mb-4 p-3 rounded-lg border ${darkMode ? 'bg-amber-900/20 border-amber-800' : 'bg-amber-50 border-amber-200'}`}>
+                    <div className="flex items-start gap-2">
+                      <Globe size={14} className={`flex-shrink-0 mt-0.5 ${darkMode ? 'text-amber-400' : 'text-amber-600'}`} />
+                      <div className="flex-1 min-w-0">
+                        <div className={`text-sm font-medium ${darkMode ? 'text-amber-300' : 'text-amber-800'}`}>Timezone mismatch</div>
+                        <div className={`text-xs mt-0.5 ${darkMode ? 'text-amber-400/80' : 'text-amber-700/80'}`}>
+                          Device: <strong>{Intl.DateTimeFormat().resolvedOptions().timeZone.replace(/_/g, ' ')}</strong>
+                          {' · '}Home: <strong>{homeTimezone.replace(/_/g, ' ')}</strong>
+                        </div>
+                        <div className={`text-xs mt-1 ${darkMode ? 'text-amber-400/70' : 'text-amber-600/70'}`}>
+                          Task times may appear offset on this device. Update your home timezone below, or re-enable automatic timezone on your device.
+                        </div>
+                      </div>
                     </div>
                   </div>
                 )}
@@ -333,6 +353,21 @@ const SettingsModal = () => {
                             Monday
                           </button>
                         </div>
+                      </div>
+                      <div>
+                        <label className={`block text-xs ${textSecondary} mb-1.5`}>Home timezone</label>
+                        <select
+                          value={homeTimezone}
+                          onChange={e => setHomeTimezone(e.target.value)}
+                          className={`w-full px-2 py-1.5 text-xs rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                        >
+                          {getTzOptions(homeTimezone).map(tz => (
+                            <option key={tz} value={tz}>{getTzLabel(tz)}</option>
+                          ))}
+                        </select>
+                        <p className={`text-[10px] ${textSecondary} mt-1 opacity-70`}>
+                          Used to detect when your device is in a different timezone.
+                        </p>
                       </div>
                     </div>
 

--- a/src/utils/timezones.js
+++ b/src/utils/timezones.js
@@ -1,0 +1,67 @@
+export const COMMON_TIMEZONES = [
+  'Pacific/Honolulu',
+  'America/Anchorage',
+  'America/Los_Angeles',
+  'America/Denver',
+  'America/Phoenix',
+  'America/Chicago',
+  'America/New_York',
+  'America/Toronto',
+  'America/Halifax',
+  'America/Sao_Paulo',
+  'UTC',
+  'Europe/London',
+  'Europe/Dublin',
+  'Europe/Lisbon',
+  'Europe/Paris',
+  'Europe/Berlin',
+  'Europe/Rome',
+  'Europe/Warsaw',
+  'Europe/Athens',
+  'Europe/Helsinki',
+  'Europe/Istanbul',
+  'Europe/Moscow',
+  'Africa/Cairo',
+  'Africa/Nairobi',
+  'Africa/Johannesburg',
+  'Asia/Dubai',
+  'Asia/Karachi',
+  'Asia/Kolkata',
+  'Asia/Dhaka',
+  'Asia/Bangkok',
+  'Asia/Singapore',
+  'Asia/Shanghai',
+  'Asia/Hong_Kong',
+  'Asia/Seoul',
+  'Asia/Tokyo',
+  'Australia/Perth',
+  'Australia/Adelaide',
+  'Australia/Sydney',
+  'Pacific/Auckland',
+  'Pacific/Fiji',
+];
+
+const TZ_FRIENDLY = {
+  'Pacific/Honolulu':    'Hawaii',
+  'America/Anchorage':   'Alaska',
+  'America/Los_Angeles': 'Pacific',
+  'America/Denver':      'Mountain',
+  'America/Phoenix':     'Arizona (no DST)',
+  'America/Chicago':     'Central',
+  'America/New_York':    'Eastern',
+  'America/Toronto':     'Eastern (Canada)',
+};
+
+export function getTzLabel(tz) {
+  const display = tz.replace(/_/g, ' ');
+  const friendly = TZ_FRIENDLY[tz];
+  return friendly ? `${display} — ${friendly}` : display;
+}
+
+export function getTzOptions(homeTimezone) {
+  const deviceTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const base = [...COMMON_TIMEZONES];
+  if (!base.includes(deviceTz)) base.unshift(deviceTz);
+  if (homeTimezone && !base.includes(homeTimezone)) base.unshift(homeTimezone);
+  return base;
+}


### PR DESCRIPTION
## Summary

Eight focused bug fixes and improvements accumulated since v2.9.2, plus a version rollback from 3.0.1 → 2.9.3 (reserving 3.0.0 for the iOS launch).

### Bug Fixes

- **Past calendar events in LIST view** — Past events now render with strikethrough text and a filled checkmark, matching the visual treatment of completed tasks. Previously they appeared unstyled.

- **Obsidian `[[` wikilink autocomplete (Android)** — `ObsidianRepository.listNotes()` was non-recursive, so notes in subdirectories were never indexed for autocomplete. Now matches the existing recursive `buildNoteIndex()` behavior.

- **Obsidian `[[` wikilink autocomplete (PWA)** — After a browser restart, FSA permissions are re-acquired on first sync, but `wikilinkCandidates` was never repopulated. Now `listVaultNotes()` is called immediately after the vault handle is re-acquired in `performObsidianSync()`.

- **Obsidian icon opacity in LIST view** — The BookOpen icon was rendering at reduced opacity compared to other row icons. Fixed by removing the unintentional opacity modifier.

### Improvements

- **Manual AI suggestion button (New Task modals)** — Replaced the auto-triggered debounce AI suggestion with an explicit `AI` button (purple pill, Sparkles icon) consistent with AI buttons elsewhere in the app. Reduces surprise AI calls while typing.

- **Obsidian sync toast positioning (mobile)** — Toast is now centered horizontally between the Notes and Weekly Review FABs, matching the visual weight of those controls.

- **GLANCEahead scrolls to top in LIST view** — Tapping GLANCEahead while in LIST mode now scrolls the list to the top (earliest event/task) instead of calling `scrollToHour`, which had no effect in LIST mode.

- **Home timezone setting + mismatch warning** — New `homeTimezone` setting (Localization section in both desktop Settings and mobile App Settings). When the device's current timezone differs from the saved home timezone, an amber warning banner appears — a thin dismissible strip on mobile, a badge on the settings button, and a banner inside the settings panel.

### Version

- Rolled back from 3.0.1 → **2.9.3** (`package.json`, `README.md`, Android `build.gradle.kts`)
- Android `versionCode` bumped 62 → **63**
- 3.0.0 is reserved for the iOS launch

## Test Plan

- [ ] LIST view: past calendar events show strikethrough + filled checkmark
- [ ] LIST view: Obsidian BookOpen icon opacity matches other row icons
- [ ] Android: type `[[` in New Task title → vault notes appear in suggestions
- [ ] PWA: close and reopen browser, perform Obsidian sync, type `[[` → suggestions appear
- [ ] New Task modal: no automatic AI suggestion on typing; AI button appears and triggers suggestion on click
- [ ] Mobile: Obsidian sync toast appears centered between Notes and Weekly Review FABs
- [ ] Mobile LIST view: tap GLANCEahead → list scrolls to top
- [ ] Settings (desktop + mobile): Home Timezone select is present in Localization section
- [ ] Travel simulation: change device timezone → amber warning banner appears; tap dismiss → hides until next app load
- [ ] Version shows 2.9.3 in app and no spurious update notification

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_