### PR TITLE
fix(electron): embed provisioning profile for iCloud entitlements

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Decode provisioning profile
+        if: matrix.os == 'macos-latest' && secrets.MAC_PROVISIONING_PROFILE_BASE64 != ''
+        run: |
+          echo "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/dayglance.provisionprofile"
+          echo "MAC_PROVISIONING_PROFILE=$RUNNER_TEMP/dayglance.provisionprofile" >> $GITHUB_ENV
+        env:
+          MAC_PROVISIONING_PROFILE_BASE64: ${{ secrets.MAC_PROVISIONING_PROFILE_BASE64 }}
+
       - name: Build desktop app (macOS — signed + notarized)
         if: matrix.os == 'macos-latest'
         run: npm run build:electron -- --publish never
@@ -42,6 +50,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MAC_PROVISIONING_PROFILE: ${{ env.MAC_PROVISIONING_PROFILE }}
 
       - name: Build desktop app (Windows / Linux)
         if: matrix.os != 'macos-latest'

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -4,11 +4,12 @@
 // branches that don't have the cert.
 //
 // Required env vars for a notarized release build:
-//   CSC_LINK              path to .p12 OR base64-encoded .p12
-//   CSC_KEY_PASSWORD      password for the .p12
-//   APPLE_ID              your Apple ID email
-//   APPLE_APP_SPECIFIC_PASSWORD  app-specific password generated at appleid.apple.com
-//   APPLE_TEAM_ID         10-char Team ID from developer.apple.com/account
+//   CSC_LINK                         path to .p12 OR base64-encoded .p12
+//   CSC_KEY_PASSWORD                 password for the .p12
+//   APPLE_ID                         your Apple ID email
+//   APPLE_APP_SPECIFIC_PASSWORD      app-specific password generated at appleid.apple.com
+//   APPLE_TEAM_ID                    10-char Team ID from developer.apple.com/account
+//   MAC_PROVISIONING_PROFILE         path to .provisionprofile (required for iCloud entitlements)
 
 const hasCert = Boolean(process.env.CSC_LINK);
 
@@ -29,6 +30,8 @@ module.exports = {
     identity: hasCert ? undefined : null,
     hardenedRuntime: hasCert,
     notarize: false, // handled by afterSign hook (scripts/notarize.cjs)
+    // Required for iCloud entitlements on Developer ID builds
+    provisioningProfile: process.env.MAC_PROVISIONING_PROFILE || undefined,
     category: 'public.app-category.productivity',
     entitlements: 'electron/entitlements.mac.plist',
     entitlementsInherit: 'electron/entitlements.mac.plist',


### PR DESCRIPTION
## Problem

The v2.9.3 macOS app fails to launch with `NSPOSIXErrorDomain Code=163 "Launchd job spawn failed"` despite passing Gatekeeper (`spctl --assess` returns `accepted / Notarized Developer ID`).

Root cause: `com.apple.developer.icloud-*` entitlements were added in the iCloud sync feature between v2.9.2 and v2.9.3. These entitlements require an Apple-issued provisioning profile embedded in the app bundle (`Contents/embedded.provisionprofile`) **even for Developer ID / direct distribution**. Without it, Gatekeeper accepts the signature but launchd refuses to spawn the process.

## Fix

- CI: add a "Decode provisioning profile" step that base64-decodes `MAC_PROVISIONING_PROFILE_BASE64` (new repo secret) into a temp file and sets `MAC_PROVISIONING_PROFILE` in the environment
- electron-builder config: pass `provisioningProfile: process.env.MAC_PROVISIONING_PROFILE` so the profile is embedded in the bundle at build time

The `MAC_PROVISIONING_PROFILE_BASE64` secret has already been added to the repo.

## Test Plan

- [ ] Merge and tag a new patch release
- [ ] Confirm CI macOS build logs show the provisioning profile step succeeding
- [ ] Confirm the resulting `.app` launches without error on Apple Silicon
- [ ] `codesign -d --entitlements -` still shows iCloud entitlements
- [ ] `ls Contents/` shows `embedded.provisionprofile`

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_