### PR TITLE
fix(ci): move provisioning profile check into shell script

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -34,10 +34,12 @@ jobs:
         run: npm ci
 
       - name: Decode provisioning profile
-        if: matrix.os == 'macos-latest' && secrets.MAC_PROVISIONING_PROFILE_BASE64 != ''
+        if: matrix.os == 'macos-latest'
         run: |
-          echo "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/dayglance.provisionprofile"
-          echo "MAC_PROVISIONING_PROFILE=$RUNNER_TEMP/dayglance.provisionprofile" >> $GITHUB_ENV
+          if [ -n "$MAC_PROVISIONING_PROFILE_BASE64" ]; then
+            echo "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/dayglance.provisionprofile"
+            echo "MAC_PROVISIONING_PROFILE=$RUNNER_TEMP/dayglance.provisionprofile" >> $GITHUB_ENV
+          fi
         env:
           MAC_PROVISIONING_PROFILE_BASE64: ${{ secrets.MAC_PROVISIONING_PROFILE_BASE64 }}
 


### PR DESCRIPTION
Fixes the workflow parse error introduced in #777:

```
Unrecognized named-value: 'secrets'. Located at position 32 within expression: matrix.os == 'macos-latest' && secrets.MAC_PROVISIONING_PROFILE_BASE64 != ''
```

The `secrets` context is not available in step `if` conditions. Moved the empty-check into the shell script instead — the decode step always runs on macOS but is a no-op when the secret isn't set.

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_