### PR TITLE
fix(electron): remove iCloud entitlements from Developer ID build

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -9,7 +9,6 @@
 //   APPLE_ID                         your Apple ID email
 //   APPLE_APP_SPECIFIC_PASSWORD      app-specific password generated at appleid.apple.com
 //   APPLE_TEAM_ID                    10-char Team ID from developer.apple.com/account
-//   MAC_PROVISIONING_PROFILE         path to .provisionprofile (required for iCloud entitlements)
 
 const hasCert = Boolean(process.env.CSC_LINK);
 
@@ -30,8 +29,6 @@ module.exports = {
     identity: hasCert ? undefined : null,
     hardenedRuntime: hasCert,
     notarize: false, // handled by afterSign hook (scripts/notarize.cjs)
-    // Required for iCloud entitlements on Developer ID builds
-    provisioningProfile: process.env.MAC_PROVISIONING_PROFILE || undefined,
     category: 'public.app-category.productivity',
     entitlements: 'electron/entitlements.mac.plist',
     entitlementsInherit: 'electron/entitlements.mac.plist',

--- a/electron/entitlements.mac.plist
+++ b/electron/entitlements.mac.plist
@@ -11,18 +11,9 @@
     <!-- Outbound network access (CalDAV, AI APIs, WebSocket, etc.) -->
     <key>com.apple.security.network.client</key>
     <true/>
-    <!-- iCloud Drive access — shares the dayglance-sync.json container with iOS -->
-    <key>com.apple.developer.icloud-container-identifiers</key>
-    <array>
-      <string>iCloud.com.dayglance</string>
-    </array>
-    <key>com.apple.developer.icloud-services</key>
-    <array>
-      <string>CloudDocuments</string>
-    </array>
-    <key>com.apple.developer.ubiquity-container-identifiers</key>
-    <array>
-      <string>iCloud.com.dayglance</string>
-    </array>
+    <!-- iCloud entitlements are NOT needed for the Developer ID build: the app
+         is unsandboxed and accesses the iCloud container via a plain file path.
+         They will be added to a separate entitlements.mas.plist for the future
+         Mac App Store build, which requires sandboxing. -->
   </dict>
 </plist>


### PR DESCRIPTION
## Problem

v2.9.4 crashes on launch with `EXC_BREAKPOINT (brk 0)` — a V8 CHECK() failure — immediately after the provisioning profile fix in #777 allowed the app to spawn.

Root cause: the iCloud entitlements added in the Phase 7 iCloud sync commit required an embedded provisioning profile (#777). On macOS Tahoe, that provisioning profile interferes with Electron's hardened runtime memory permissions, causing V8 to crash during startup.

## Fix

Remove the three iCloud entitlements from `electron/entitlements.mac.plist` for the Developer ID build:
- `com.apple.developer.icloud-container-identifiers`
- `com.apple.developer.icloud-services`
- `com.apple.developer.ubiquity-container-identifiers`

Also remove `provisioningProfile` from `electron-builder.config.cjs` (no longer needed).

**iCloud sync is unaffected.** The Electron app is unsandboxed (no `com.apple.security.app-sandbox`), so it can freely read/write `~/Library/Mobile Documents/iCloud~com~dayglance/Documents/` via plain `fs` calls without any entitlements. The iCloud daemon syncs the file regardless of whether the writing app holds iCloud entitlements.

These entitlements will be added to a separate `entitlements.mas.plist` when the Mac App Store build is configured.

## Test Plan

- [ ] Merge and tag v2.9.4 (no release was published for 2.9.4 yet)
- [ ] Confirm macOS build launches without crashing
- [ ] Confirm iCloud sync still works (write a task on iOS, verify it appears on Mac and vice versa)

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f