### PR TITLE
fix(list-view): apply completed styling to calendar events on past dates

### DIFF
--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -1632,7 +1632,7 @@ const MobileListView = () => {
 
           // task or calendar-event
           const isCalendarEvent = item._kind === 'calendar-event';
-          const isPast = isItemPast(item);
+          const isPast = isItemPast(item) || (isCalendarEvent && dateStr < dateToString(new Date()));
           const isInProgress = item.id === inProgressItem?.id;
           const remainingMin = isInProgress ? Math.max(0, (startMin + (item.duration || 30)) - nowMin) : 0;
           const isDragging = listDragItem?.id === item.id;


### PR DESCRIPTION
## Problem

Calendar events on past dates (any date before today) were not getting the strikethrough + dimmed treatment in the LIST view.

`isItemPast()` short-circuits to `false` when `!isToday`, so even when you navigate to yesterday or earlier, all calendar events appeared as if they were upcoming — no strikethrough, full opacity.

The fix shipped in v2.9.3 only worked for calendar events **earlier today** (events whose end time had already passed). It had no effect when browsing a past date.

## Fix

One-line change in the rendering loop:

```js
// Before
const isPast = isItemPast(item);

// After
const isPast = isItemPast(item) || (isCalendarEvent && dateStr < dateToString(new Date()));
```

Calendar events whose date is strictly before today now get `isPast = true` regardless of which date the user is viewing, giving them the filled checkmark, strikethrough title, and 0.5 opacity — matching the treatment for events that ended earlier today.

Regular tasks on past dates are unaffected (the `isCalendarEvent` guard keeps the existing behavior).

## Test Plan

- [ ] Navigate to yesterday in LIST view — calendar events show strikethrough + dimmed
- [ ] Navigate to today — events earlier today still show as past; future events unaffected
- [ ] Navigate to a future date — no events shown as past
- [ ] Regular tasks on past dates are not struck through or dimmed

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_