### PR TITLE
fix(android): resolve all Kotlin compiler warnings

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 64
+        versionCode = 65
         versionName = "2.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
@@ -10,6 +10,7 @@ import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.PendingPurchasesParams
 import com.android.billingclient.api.QueryPurchasesParams
 import com.dayglance.app.data.SharedDataStore
 import kotlinx.coroutines.CoroutineScope
@@ -56,7 +57,7 @@ class BillingManager(
 
     private val billingClient: BillingClient = BillingClient.newBuilder(context)
         .setListener(purchasesUpdatedListener)
-        .enablePendingPurchases()
+        .enablePendingPurchases(PendingPurchasesParams.newBuilder().enableOneTimeProducts().build())
         .build()
 
     fun connect() {

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
@@ -105,9 +105,10 @@ class NotificationBridge(private val context: Context) {
      * @param type           Reminder type: before15 | before10 | before5 | start | end | morning
      * @param isCalendarEvent  If true, the Complete action is omitted (read-only calendar events)
      */
+    @Suppress("UNUSED_PARAMETER")
     @JavascriptInterface
     fun showTaskNotification(
-        _reminderId: String,
+        reminderId: String,
         taskId: String,
         title: String,
         body: String,

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/CalendarRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/CalendarRepository.kt
@@ -177,8 +177,6 @@ class CalendarRepository(private val context: Context) {
             )?.use { cursor ->
                 val idIdx      = cursor.getColumnIndex(CalendarContract.Events._ID)
                 val titleIdx   = cursor.getColumnIndex(CalendarContract.Events.TITLE)
-                val _startIdx  = cursor.getColumnIndex(CalendarContract.Events.DTSTART)
-                val _dueIdx    = cursor.getColumnIndex(colDue)
                 val descIdx    = cursor.getColumnIndex(CalendarContract.Events.DESCRIPTION)
                 val locIdx     = cursor.getColumnIndex(CalendarContract.Events.EVENT_LOCATION)
                 val calIdIdx   = cursor.getColumnIndex(CalendarContract.Events.CALENDAR_ID)

--- a/dayglance-android/app/src/main/java/com/dayglance/app/widget/GoalWidget.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/widget/GoalWidget.kt
@@ -87,11 +87,11 @@ class GoalWidget : AppWidgetProvider() {
         val selectedGoalId = prefs.getString(prefKey(appWidgetId), null)
 
         if (selectedGoalId == null) {
-            showEmpty(views, "No goal selected", "Long-press widget to reconfigure")
+            showEmpty(views, "Long-press widget to reconfigure")
         } else {
             val goal = findGoal(snapshot, selectedGoalId)
             if (goal == null) {
-                showEmpty(views, "Goal not found", "It may have been deleted or completed")
+                showEmpty(views, "It may have been deleted or completed")
             } else {
                 bindGoalViews(views, goal, context)
             }
@@ -100,7 +100,7 @@ class GoalWidget : AppWidgetProvider() {
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }
 
-    private fun showEmpty(views: RemoteViews, _title: String, subtitle: String) {
+    private fun showEmpty(views: RemoteViews, subtitle: String) {
         views.setViewVisibility(R.id.layout_goal_content, View.GONE)
         views.setViewVisibility(R.id.layout_goal_empty, View.VISIBLE)
         views.setTextViewText(R.id.tv_goal_empty_sub, subtitle)


### PR DESCRIPTION
Clears all five warnings from the release Kotlin compile tasks.

- **BillingManager**: replace deprecated no-arg `enablePendingPurchases()` with `PendingPurchasesParams.newBuilder().enableOneTimeProducts().build()` (required by billing library 7.x)
- **NotificationBridge**: add `@Suppress("UNUSED_PARAMETER")` on `showTaskNotification` — `reminderId` must stay in the signature for the JS bridge API
- **CalendarRepository**: remove unused `_startIdx` / `_dueIdx` column index variables
- **GoalWidget**: remove unused `_title` parameter from `showEmpty()` and update the two call sites

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_