### PR TITLE
fix(android): unfreeze Obsidian sync spinner with double-rAF

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2294,12 +2294,12 @@ const DayPlanner = () => {
       const currentTasks = obsidianTasksRef.current;
       const currentInbox = obsidianInboxRef.current;
       const result = isNative
-        ? await new Promise(resolve => setTimeout(() => resolve(syncObsidianVaultNative(
+        ? await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve(syncObsidianVaultNative(
             obsidianConfig?.dailyNotesPath || '',
             syncRetentionDays,
             currentTasks,
             currentInbox,
-          )), 0))
+          )))))
         : await syncObsidianVault(
             obsidianVaultHandleRef.current,
             obsidianConfig?.dailyNotesPath || '',


### PR DESCRIPTION
## Problem

The spinner in the Obsidian sync toast appears frozen on Android, then starts spinning once the sync completes.

`syncObsidianVaultNative` blocks the JS thread (JavascriptInterface is synchronous). The previous `setTimeout(..., 0)` deferred by one event loop tick, but the `animate-spin` CSS animation hadn't been handed off to the compositor thread yet when the block started — so the spinner was painted but not animating.

## Fix

Replace `setTimeout(..., 0)` with double `requestAnimationFrame`. Two rAF callbacks guarantee two full frames are committed to the compositor before the blocking call runs, by which point the CSS animation is independently established on the compositor thread and continues spinning through the sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_