### PR TITLE
fix(list-view): strip wikilinks from NowRow countdown title

### DIFF
--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -567,7 +567,7 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
 
   const diff = nextItem ? timeToMinutes_pure(nextItem.startTime) - nowMin : null;
   const rawTitle = nextItem?.title || nextItem?.name || nextItem?.label || '';
-  const cleanTitle = rawTitle.replace(/#\S+/g, '').replace(/\s+/g, ' ').trim();
+  const cleanTitle = rawTitle.replace(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g, '$1').replace(/#\S+/g, '').replace(/\s+/g, ' ').trim();
   const countdownStr = diff !== null && diff > 0
     ? `${countdownText(diff)} until ${cleanTitle}`
     : 'Nothing planned';


### PR DESCRIPTION
The "X min until [task title]" countdown in the NowRow was showing raw `[[wikilink]]` syntax when the next task title contained one. The regex now strips them — `[[Note]]` becomes `Note`, `[[Note|alias]]` becomes `Note` — matching the existing hashtag suppression on the same line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_