### PR TITLE
fix(android): remove webView.onPause() to eliminate UI flash on resume

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 66
+        versionCode = 67
         versionName = "2.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -350,11 +350,6 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    override fun onPause() {
-        super.onPause()
-        webView.onPause()
-    }
-
     override fun onResume() {
         super.onResume()
         webView.onResume()


### PR DESCRIPTION
`webView.onPause()` releases the WebView's rendering surface. When the app resumes, `webView.onResume()` has to recreate it, producing a visible UI → blank → UI flash. Removing the `onPause()` call keeps the surface alive through backgrounding so there's nothing to recreate on resume. `webView.onResume()` is retained to ensure JavaScript timers and animations restart correctly when the app comes back to the foreground.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_