### PR TITLE
fix: wikilink suppression, Obsidian spinner freeze, Android resume blank screen

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 67
+        versionCode = 68
         versionName = "2.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/res/values-night/themes.xml
+++ b/dayglance-android/app/src/main/res/values-night/themes.xml
@@ -7,6 +7,7 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <!-- Dark mode: use light icons (white) so they're visible on dark backgrounds -->
         <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowBackground">#1f2937</item>
     </style>
 
     <!-- Splash screen (dark) -->

--- a/dayglance-android/app/src/main/res/values/themes.xml
+++ b/dayglance-android/app/src/main/res/values/themes.xml
@@ -9,6 +9,7 @@
         <item name="colorSecondary">#f97316</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowBackground">#ffffff</item>
     </style>
 
     <!-- Settings activity — with action bar -->

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2294,12 +2294,12 @@ const DayPlanner = () => {
       const currentTasks = obsidianTasksRef.current;
       const currentInbox = obsidianInboxRef.current;
       const result = isNative
-        ? await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve(syncObsidianVaultNative(
+        ? await new Promise(resolve => requestAnimationFrame(() => setTimeout(() => resolve(syncObsidianVaultNative(
             obsidianConfig?.dailyNotesPath || '',
             syncRetentionDays,
             currentTasks,
             currentInbox,
-          )))))
+          )), 0)))
         : await syncObsidianVault(
             obsidianVaultHandleRef.current,
             obsidianConfig?.dailyNotesPath || '',

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -567,7 +567,7 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
 
   const diff = nextItem ? timeToMinutes_pure(nextItem.startTime) - nowMin : null;
   const rawTitle = nextItem?.title || nextItem?.name || nextItem?.label || '';
-  const cleanTitle = rawTitle.replace(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g, '$1').replace(/#\S+/g, '').replace(/\s+/g, ' ').trim();
+  const cleanTitle = rawTitle.replace(/\[\[[^\]]*\]\]/g, '').replace(/#\S+/g, '').replace(/\s+/g, ' ').trim();
   const countdownStr = diff !== null && diff > 0
     ? `${countdownText(diff)} until ${cleanTitle}`
     : 'Nothing planned';


### PR DESCRIPTION
Three fixes in one:

**1. NowRow wikilink suppression**
The previous fix stripped `[[` and `]]` but kept the note name. Changed to remove the entire `[[wikilink]]` token so nothing from it appears in the countdown text.

**2. Obsidian spinner freeze**
Double-rAF runs the blocking sync *inside* a rAF callback — the browser can't commit the frame while the callback is blocked, so the spinner was never actually painted before the sync started. Changed to `rAF → setTimeout(0)`: the rAF fires just before a paint, the setTimeout yields *past* the paint, then the sync blocks. The spinner frame is committed before the JS thread is held.

**3. Android blank screen on resume**
The Activity theme had no `android:windowBackground` set. When Android reclaims the GPU surface during background time, the window background shows through while it's recreated — a white (light) or default-grey (dark) flash. Now set to `#ffffff` (light) / `#1f2937` (dark), matching the app background so any flash is invisible.

**versionCode → 68**

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_