### PR TITLE
Make Android Obsidian vault sync non-blocking

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 68
+        versionCode = 69
         versionName = "2.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -154,7 +154,7 @@ class MainActivity : AppCompatActivity() {
             else android.graphics.Color.WHITE
         )
         healthRepository = HealthRepository(this)
-        obsidianBridge = ObsidianBridge(this)
+        obsidianBridge = ObsidianBridge(this, webView)
         nativeBridge = NativeBridge(
             context = this,
             healthRepository = healthRepository,

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/ObsidianBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/ObsidianBridge.kt
@@ -16,7 +16,7 @@ import com.dayglance.app.data.ObsidianRepository
  * All methods run synchronously on the JavascriptInterface background thread —
  * SAF I/O is acceptable here since it's typically fast for local storage.
  */
-class ObsidianBridge(private val context: Context) {
+class ObsidianBridge(private val context: Context, private val webView: android.webkit.WebView? = null) {
 
     private val repository = ObsidianRepository(context)
 
@@ -54,6 +54,42 @@ class ObsidianBridge(private val context: Context) {
     @JavascriptInterface
     fun getAllDailyNotes(folder: String, cutoff: String): String =
         repository.getAllDailyNotes(folder, cutoff)
+
+    /**
+     * Non-blocking version of getAllDailyNotes. Returns immediately and dispatches the
+     * result (or error) back to JS via window.__obsidianDispatch(callbackId, json, error).
+     *
+     * [callbackId] must be alphanumeric + underscore, max 32 chars — validated before use.
+     */
+    @JavascriptInterface
+    fun getAllDailyNotesAsync(folder: String, cutoff: String, callbackId: String) {
+        // Validate callbackId to prevent JS injection via the interpolated eval string.
+        if (callbackId.length > 32 || !callbackId.matches(Regex("[a-z0-9_]+"))) {
+            return
+        }
+        Thread {
+            try {
+                val json = repository.getAllDailyNotes(folder, cutoff)
+                // Escape backslashes and backticks that could break the JS template literal.
+                // The result is a JSON string so only ` and \ need escaping before eval.
+                val safe = json.replace("\\", "\\\\").replace("`", "\\`")
+                webView?.post {
+                    webView.evaluateJavascript(
+                        "window.__obsidianDispatch('$callbackId',`$safe`,null)",
+                        null
+                    )
+                }
+            } catch (e: Exception) {
+                val msg = (e.message ?: "error").replace("'", "\\'")
+                webView?.post {
+                    webView.evaluateJavascript(
+                        "window.__obsidianDispatch('$callbackId',null,'$msg')",
+                        null
+                    )
+                }
+            }
+        }.start()
+    }
 
     /**
      * Parses GFM task items from the note at [path] (relative to vault root).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2284,22 +2284,17 @@ const DayPlanner = () => {
 
     try {
       const isNative = obsidianVaultHandleRef.current === 'native';
-      // syncObsidianVaultNative is synchronous (JavascriptInterface blocks the JS
-      // thread until all SAF file reads complete).  Wrap it in a one-frame
-      // setTimeout so React finishes its current render — and the UI stays
-      // responsive — before the blocking I/O runs.  This prevents the brief
-      // white/blank flash users see when the app is opened with Obsidian enabled.
       // Use refs so interval-triggered syncs always see the latest task state,
       // not the stale closure from when the interval was set up.
       const currentTasks = obsidianTasksRef.current;
       const currentInbox = obsidianInboxRef.current;
       const result = isNative
-        ? await new Promise(resolve => requestAnimationFrame(() => setTimeout(() => resolve(syncObsidianVaultNative(
+        ? await syncObsidianVaultNative(
             obsidianConfig?.dailyNotesPath || '',
             syncRetentionDays,
             currentTasks,
             currentInbox,
-          )), 0)))
+          )
         : await syncObsidianVault(
             obsidianVaultHandleRef.current,
             obsidianConfig?.dailyNotesPath || '',

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -1113,7 +1113,18 @@ export function writeTaskStateNative(date, obsidianRawTitle, completed, startTim
  * @param {Array}  existingInbox  Current DG inbox tasks
  * @returns {{ dailyNotes, scheduledTasks, inboxTasks }}
  */
-export function syncObsidianVaultNative(folder, retentionDays, existingTasks, existingInbox) {
+// Set up the async callback dispatcher once
+if (typeof window !== 'undefined' && !window.__obsidianDispatch) {
+  window.__obsidianDispatch = (id, result, error) => {
+    const cb = window.__obsidianCbs?.[id];
+    if (cb) {
+      delete window.__obsidianCbs[id];
+      cb(result, error);
+    }
+  };
+}
+
+export async function syncObsidianVaultNative(folder, retentionDays, existingTasks, existingInbox) {
   const bridge = typeof window !== 'undefined' ? window.DayGlanceObsidian : null;
   if (!bridge) throw new Error('Obsidian bridge unavailable');
 
@@ -1150,11 +1161,26 @@ export function syncObsidianVaultNative(folder, retentionDays, existingTasks, ex
   const allScheduled = [];
   const allInbox = [];
 
-  // Prefer the batch getAllDailyNotes method (single native round trip) over the
-  // old listNotes + per-note getDailyNote loop (N round trips that each block the
-  // JS thread and cause the app to freeze during sync).
+  // Prefer the batch getAllDailyNotesAsync method (non-blocking: SAF I/O runs on a
+  // background thread and callbacks back via JS) over the synchronous alternatives.
   let noteEntries; // [{ date, text }]
-  if (bridge.getAllDailyNotes) {
+  if (bridge.getAllDailyNotesAsync) {
+    // Non-blocking path: runs SAF I/O on a background thread, callbacks via JS
+    if (!window.__obsidianCbs) window.__obsidianCbs = {};
+    const json = await new Promise((resolve, reject) => {
+      const id = Math.random().toString(36).slice(2, 18).replace(/[^a-z0-9]/g, 'x');
+      window.__obsidianCbs[id] = (result, error) => {
+        if (error) reject(new Error(error));
+        else resolve(result);
+      };
+      bridge.getAllDailyNotesAsync(folder, cutoffStr, id);
+    });
+    try {
+      noteEntries = JSON.parse(json);
+    } catch (err) {
+      throw new Error(`Failed to parse daily notes from vault: ${err.message}`);
+    }
+  } else if (bridge.getAllDailyNotes) {
     try {
       noteEntries = JSON.parse(bridge.getAllDailyNotes(folder, cutoffStr));
     } catch (err) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`ObsidianBridge.kt`**: Added `webView` parameter (nullable, defaults to `null`) to the constructor, and a new `getAllDailyNotesAsync` method that returns immediately, runs `repository.getAllDailyNotes` on a background `Thread`, and posts the result (or error) back to JS via `webView.evaluateJavascript("window.__obsidianDispatch(...)")`. The `callbackId` is validated as alphanumeric+underscore, max 32 chars, before interpolation.
- **`MainActivity.kt`**: Passes `webView` to the `ObsidianBridge` constructor so the async method can dispatch callbacks.
- **`obsidian.js`**: Adds a module-level `window.__obsidianDispatch` setup, makes `syncObsidianVaultNative` async, and uses the new `getAllDailyNotesAsync` path (with a Promise/callback pattern) when available. Synchronous `getAllDailyNotes` and `listNotes` fallback paths are preserved for older app builds.
- **`App.jsx`**: Removes the `requestAnimationFrame`/`setTimeout` workaround that was needed to yield the JS thread before the blocking sync — it's no longer needed now that the native call is truly async.

## Test plan

- [ ] On a device with the updated APK, open the app with Obsidian configured — verify tasks sync correctly and CSS animations (spinner, transitions) run smoothly during sync
- [ ] Verify the sync still works on an older APK build (falls back to synchronous `getAllDailyNotes`)
- [ ] Verify the sync works when `getAllDailyNotes` is the only available method (no `Async` variant)
- [ ] Verify that an invalid `callbackId` is rejected silently (no crash, no JS injection)
- [ ] Verify error path: if the vault is misconfigured, the Promise rejects and the app surfaces an error rather than hanging

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_