### PR TITLE
Fix wikilinks showing in Up Next notification

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 69
+        versionCode = 70
         versionName = "2.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6879,7 +6879,7 @@ const DayPlanner = () => {
       }) || null;
     const nextTaskItem = nextTaskCandidate ? {
       id: nextTaskCandidate.id,
-      title: nextTaskCandidate.title,
+      title: nextTaskCandidate.title.replace(/\[\[[^\]]*\]\]/g, '').replace(/#\S+/g, '').replace(/\s+/g, ' ').trim(),
       colorHex: taskColorToHex(nextTaskCandidate.color, nextTaskCandidate.nativeCalendarColor),
       startTime: nextTaskCandidate.startTime || '',
       duration: nextTaskCandidate.duration || 0,


### PR DESCRIPTION
## Summary

- Task titles with `[[wikilinks]]` or `#hashtags` were being passed raw into the Android Up Next persistent notification title.
- Fixed by stripping wikilinks and hashtags when building `nextTaskItem` in the widget snapshot (covers both the `nextTask` legacy field and the `nextUpNext` path).
- Bump versionCode to 70 for internal testing.

## Test plan
- [ ] Create a task with a `[[wikilink]]` or `#hashtag` in the title and verify the Up Next notification shows the clean title
- [ ] Verify tasks without wikilinks/hashtags are unaffected

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_