### PR TITLE
Fix blank screen flash when resuming Android app from background

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 70
+        versionCode = 71
         versionName = "2.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -352,7 +352,9 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        webView.onResume()
+        // webView.onResume() intentionally omitted — we don't call webView.onPause() either,
+        // so the GPU surface stays live. Calling resume without a prior pause triggers a
+        // surface invalidation that causes a blank-frame flash on return from background.
         // Re-enable so back button works after returning from background or SettingsActivity.
         // The callback disables itself when the WebView has no back history; without this
         // reset it stays disabled for the rest of the session (Android 13+ behaviour).

--- a/dayglance-android/app/src/main/res/values-night/themes.xml
+++ b/dayglance-android/app/src/main/res/values-night/themes.xml
@@ -7,7 +7,7 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <!-- Dark mode: use light icons (white) so they're visible on dark backgrounds -->
         <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowBackground">#1f2937</item>
+        <item name="android:windowBackground">#0f172a</item>
     </style>
 
     <!-- Splash screen (dark) -->


### PR DESCRIPTION
## Summary

- **Remove `webView.onResume()`** — since we don't call `webView.onPause()` (removed in a prior PR to prevent the UI→blank→UI pattern), calling `onResume()` without a prior pause triggers an unnecessary GPU surface invalidation. This is what causes the brief blank frame when the app returns from the background.
- **Fix dark `windowBackground` color mismatch** — `values-night/themes.xml` had `#1f2937` but `webView.setBackgroundColor` uses `#0f172a`. When the window redraws before the WebView's first frame, the mismatched color was visible as a flash. Now both are `#0f172a`.
- Bump versionCode to 71.

## Test plan
- [ ] Put app in background, return — verify no blank flash in dark mode
- [ ] Put app in background, return — verify no blank flash in light mode
- [ ] Verify back-button navigation still works after returning from background

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_