### PR TITLE
fix: defer Health Connect bridge calls past first paint on app resume

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 72
+        versionCode = 73
         versionName = "2.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1194,7 +1194,10 @@ const DayPlanner = () => {
         // Reset download backoff when user returns to the app so retries happen promptly.
         cloudSyncDownloadBackoffUntilRef.current = 0;
         cloudSyncDownloadRef.current?.();
-        syncHealthConnectHabitsRef.current?.();
+        // Defer the blocking Health Connect bridge calls (up to 7 × N synchronous
+        // @JavascriptInterface calls) to after the next paint so the JS thread isn't
+        // blocked mid-render, which shows as a brief blank screen on app resume.
+        requestAnimationFrame(() => setTimeout(() => syncHealthConnectHabitsRef.current?.(), 0));
       }
     };
     // Native iOS fires a custom event to bypass the document.hidden timing gap
@@ -1205,7 +1208,7 @@ const DayPlanner = () => {
       // iCloud runs first (fast local file I/O), then WebDAV (network)
       iCloudSyncRef.current?.();
       cloudSyncDownloadRef.current?.();
-      syncHealthConnectHabitsRef.current?.();
+      requestAnimationFrame(() => setTimeout(() => syncHealthConnectHabitsRef.current?.(), 0));
     };
     document.addEventListener('visibilitychange', handleVisibility);
     document.addEventListener('dayglanceForeground', handleNativeForeground);


### PR DESCRIPTION
## Summary

- `syncHealthConnectHabits` was firing synchronously in the `visibilitychange` handler on every app resume
- It loops 7 days × N health habits, calling `DayGlanceNative.getSteps()` or `getSleep()` synchronously on each iteration — these are `@JavascriptInterface` bridge calls that block the JS main thread until Android returns
- The WebView shows its cached frame immediately when the app resumes, but the Health Connect loop then blocks the thread for ~100–200ms, preventing the browser from painting — producing the "UI briefly → blank → UI" flash
- Fix: same `requestAnimationFrame(() => setTimeout(..., 0))` deferral already applied to `nativeListNotes` in #794 — Health Connect queries now start only after the browser has painted the current frame

## Test plan

- [ ] Resume app from background — blank screen flash should be gone
- [ ] Steps/sleep habit counts still update correctly after returning to the app
- [ ] No regressions on web (non-native) — the `window.DayGlanceNative` guard still exits early

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_