### PR TITLE
fix: solid-colour overlay hides stale WebView frame on app resume

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 73
+        versionCode = 74
         versionName = "2.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -13,6 +13,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
+import android.view.View
 import android.webkit.PermissionRequest
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
@@ -82,6 +83,10 @@ class MainActivity : AppCompatActivity() {
     @Volatile private var webViewReady = false
     @Volatile private var appReady = false
     @Volatile private var billingReady = false
+
+    // Solid-colour overlay that covers the WebView while it repaints on resume,
+    // preventing the stale-frame flash (UI → blank → UI) the user would otherwise see.
+    private lateinit var resumeOverlay: View
 
     // Shown at most once per session so we don't nag the user repeatedly
     private var exactAlarmPromptShown = false
@@ -153,6 +158,20 @@ class MainActivity : AppCompatActivity() {
             if (isDark) android.graphics.Color.parseColor("#0f172a")
             else android.graphics.Color.WHITE
         )
+
+        // Resume overlay: sits above the WebView in the FrameLayout. Shown in onPause()
+        // to hide the stale cached frame; hidden via postVisualStateCallback() once the
+        // WebView has committed a fresh frame. Colour matches both dark (#0f172a) and
+        // light (#ffffff) mode so the transition is seamless in either appearance setting.
+        resumeOverlay = View(this).apply {
+            setBackgroundColor(
+                if (isDark) android.graphics.Color.parseColor("#0f172a")
+                else android.graphics.Color.WHITE
+            )
+            visibility = View.GONE
+        }
+        binding.root.addView(resumeOverlay)
+
         healthRepository = HealthRepository(this)
         obsidianBridge = ObsidianBridge(this, webView)
         nativeBridge = NativeBridge(
@@ -334,6 +353,21 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onPause() {
+        super.onPause()
+        // Show the overlay so the stale cached frame is hidden when the user returns.
+        // dataStore.appDarkMode is the app's own dark/light preference (independent of the
+        // Android system night-mode flag), so the overlay colour is correct in both modes.
+        val isDarkMode = dataStore.appDarkMode
+            ?: ((resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+                android.content.res.Configuration.UI_MODE_NIGHT_YES)
+        resumeOverlay.setBackgroundColor(
+            if (isDarkMode) android.graphics.Color.parseColor("#0f172a")
+            else android.graphics.Color.WHITE
+        )
+        resumeOverlay.visibility = View.VISIBLE
+    }
+
     override fun onStart() {
         super.onStart()
         if (BuildConfig.BILLING_ENABLED && !BuildConfig.DEBUG) {
@@ -361,6 +395,16 @@ class MainActivity : AppCompatActivity() {
         backCallback.isEnabled = true
         applyStatusBarAppearance()
         maybePromptExactAlarmPermission()
+
+        // Hide the resume overlay once the WebView has committed a fresh frame.
+        // postVisualStateCallback fires on the main thread when the WebView has a valid
+        // picture ready to draw — at that point the overlay is no longer needed.
+        // The 800 ms postDelayed is a safety net in case the callback doesn't fire
+        // (e.g. WebView has no pending draw commands because the DOM hasn't changed).
+        webView.postVisualStateCallback(System.currentTimeMillis()) { _ ->
+            resumeOverlay.visibility = View.GONE
+        }
+        webView.postDelayed({ resumeOverlay.visibility = View.GONE }, 800)
     }
 
     /**


### PR DESCRIPTION
## Summary

After #794 and #796 reduced the blank-screen flash to ~100ms, a residual "UI briefly → blank → UI" pattern remained. The WebView shows its cached frame for one frame immediately on resume, then JS visibility handlers run and block the main thread, then the WebView repaints — producing a brief flash of stale content followed by blank.

This PR adds a solid-colour `View` that sits above the WebView in the `FrameLayout`. It is shown in `onPause()` (covering the WebView as the user leaves) and hidden via `postVisualStateCallback()` once the WebView has committed a fresh frame on resume. The user sees: dark/white background → fresh UI, with no stale-frame flash at all.

**Light and dark mode both handled:** the overlay colour is read from `SharedDataStore.appDarkMode` (the app's own preference, independent of the Android system night-mode flag) — `#0f172a` in dark mode, `#ffffff` in light mode. Falls back to the system night-mode flag if `appDarkMode` hasn't been written yet (first launch).

An 800 ms `postDelayed` acts as a safety net in case `postVisualStateCallback` doesn't fire (e.g. no pending draw commands).

## versionCode

74 — intended to ship before the billing fix (PR #795, currently at 74). If merging after #795, bump #795 to 75 first.

## Test plan

- [ ] Dark mode: resume app from background — no flash, content appears cleanly
- [ ] Light mode: same — overlay is white, no flash
- [ ] Cold start / first launch — no overlay shown (overlay starts `GONE`, only shown in `onPause`)
- [ ] Background app, wait 30+ seconds, return — content appears without flash
- [ ] Open Settings activity and return — no flash (Settings triggers onPause/onResume too)

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_