### PR TITLE
fix: explicit WebView.VisualStateCallback SAM type (compilation fix)

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -401,9 +401,9 @@ class MainActivity : AppCompatActivity() {
         // picture ready to draw — at that point the overlay is no longer needed.
         // The 800 ms postDelayed is a safety net in case the callback doesn't fire
         // (e.g. WebView has no pending draw commands because the DOM hasn't changed).
-        webView.postVisualStateCallback(System.currentTimeMillis()) { _ ->
+        webView.postVisualStateCallback(System.currentTimeMillis(), WebView.VisualStateCallback { _ ->
             resumeOverlay.visibility = View.GONE
-        }
+        })
         webView.postDelayed({ resumeOverlay.visibility = View.GONE }, 800)
     }
 


### PR DESCRIPTION
Fixes compilation error introduced in #797.

Kotlin cannot infer the SAM interface type for `postVisualStateCallback`'s second parameter when using trailing lambda syntax. Must use `WebView.VisualStateCallback { }` explicitly.

```
e: MainActivity.kt:404:69 Type mismatch: inferred type is ([Error type: Cannot infer a lambda parameter type]) -> Unit but WebView.VisualStateCallback was expected
```

No logic change — one-line fix.

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_