### PR TITLE
fix: VisualStateCallback is abstract — use anonymous object

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -401,8 +401,10 @@ class MainActivity : AppCompatActivity() {
         // picture ready to draw — at that point the overlay is no longer needed.
         // The 800 ms postDelayed is a safety net in case the callback doesn't fire
         // (e.g. WebView has no pending draw commands because the DOM hasn't changed).
-        webView.postVisualStateCallback(System.currentTimeMillis(), WebView.VisualStateCallback { _ ->
-            resumeOverlay.visibility = View.GONE
+        webView.postVisualStateCallback(System.currentTimeMillis(), object : WebView.VisualStateCallback() {
+            override fun onComplete(requestId: Long) {
+                resumeOverlay.visibility = View.GONE
+            }
         })
         webView.postDelayed({ resumeOverlay.visibility = View.GONE }, 800)
     }


### PR DESCRIPTION
Fixes the remaining compilation error after #798.

`WebView.VisualStateCallback` is an abstract class, not a functional interface — a SAM constructor doesn't work. Must use an anonymous object with an explicit `onComplete()` override:

```kotlin
// before (fails)
WebView.VisualStateCallback { _ -> ... }

// after (correct)
object : WebView.VisualStateCallback() {
    override fun onComplete(requestId: Long) { ... }
}
```

No logic change.

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_