### PR TITLE
fix: add missing BuildConfig import to BillingManager

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
@@ -13,6 +13,7 @@ import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.PendingPurchasesParams
 import com.android.billingclient.api.QueryPurchasesParams
+import com.dayglance.app.BuildConfig
 import com.dayglance.app.data.SharedDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers


### PR DESCRIPTION
Fixes compilation error on release builds:

```
e: BillingManager.kt:225:21 Unresolved reference: BuildConfig
```

`BuildConfig.DEBUG` was used to gate verbose diagnostic logging but the import was missing. One-line fix.

https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtSGXYVPfG1sJh7M64gS5f)_