### PR TITLE
Add reset test purchase button (versionCode 76)

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 75
+        versionCode = 76
         versionName = "2.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.util.Log
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.ConsumeParams
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
@@ -289,5 +290,21 @@ class BillingManager(
             .setPurchaseToken(purchase.purchaseToken)
             .build()
         billingClient.acknowledgePurchase(params) { /* fire and forget */ }
+    }
+
+    fun consumePurchase(token: String, onComplete: (success: Boolean) -> Unit) {
+        if (!billingClient.isReady) { onComplete(false); return }
+        val params = ConsumeParams.newBuilder().setPurchaseToken(token).build()
+        scope.launch {
+            billingClient.consumeAsync(params) { result, _ ->
+                val success = result.responseCode == BillingClient.BillingResponseCode.OK
+                if (success) {
+                    dataStore.subscriptionActive = false
+                    dataStore.subscriptionProductId = null
+                    dataStore.subscriptionToken = null
+                }
+                onComplete(success)
+            }
+        }
     }
 }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
@@ -108,4 +108,33 @@ class SubscriptionBridge(
     @JavascriptInterface
     fun getProductIds(): String =
         """["${BillingManager.PRODUCT_ANNUAL}","${BillingManager.PRODUCT_LIFETIME}"]"""
+
+    /**
+     * Consumes the stored lifetime purchase token so it can be bought again.
+     * Only available on play builds (BILLING_ENABLED=true). Intended for testing.
+     * Result is delivered via window.__billingEvent with status "consumed" or "consume_failed".
+     */
+    @JavascriptInterface
+    fun consumeTestPurchase() {
+        if (!BuildConfig.BILLING_ENABLED) return
+        val token = dataStore.subscriptionToken ?: run {
+            webView?.post {
+                webView.evaluateJavascript(
+                    """window.__billingEvent && window.__billingEvent({"status":"consume_failed","code":0,"message":"no_token","productId":""});""", null)
+            }
+            return
+        }
+        billingManager.consumePurchase(token) { success ->
+            val json = JSONObject().apply {
+                put("status", if (success) "consumed" else "consume_failed")
+                put("code", 0)
+                put("message", if (success) "test_consume" else "consume_error")
+                put("productId", BillingManager.PRODUCT_LIFETIME)
+            }
+            webView?.post {
+                webView.evaluateJavascript(
+                    "window.__billingEvent && window.__billingEvent($json);", null)
+            }
+        }
+    }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -177,7 +177,7 @@ const TimePicker = ({ value, onChange, use24HourClock, borderClass, darkMode }) 
 const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
 
 const DayPlanner = () => {
-  const { isPro, isLoading: subLoading, isAndroidApp, subscribe, restore, prices: subPrices, billingEvent, clearBillingEvent, billingErrorMessage } = useSubscription();
+  const { isPro, isLoading: subLoading, isAndroidApp, subscribe, restore, prices: subPrices, billingEvent, clearBillingEvent, billingErrorMessage, consumeTestPurchase, canConsumeTestPurchase } = useSubscription();
   const _visibleDays = useVisibleDays();
   const { isPhone, isMobile, isTablet } = useDeviceType();
   const isLandscape = useIsLandscape();
@@ -7628,6 +7628,9 @@ const DayPlanner = () => {
     dailyStatsAllTimeCollapsed, setDailyStatsAllTimeCollapsed,
     showShortcutHelp, setShowShortcutHelp,
     showHelpModal, setShowHelpModal,
+
+    // ── Billing ───────────────────────────────────────────────────────────────
+    consumeTestPurchase, canConsumeTestPurchase,
 
     // ── Autocomplete suggestions ──────────────────────────────────────────────
     suggestions, setSuggestions,

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -25,6 +25,7 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
 const MobileSettingsPanel = () => {
   const {
+    consumeTestPurchase, canConsumeTestPurchase,
     setTasks, setUnscheduledTasks,
     darkMode, setDarkMode,
     mobileSettingsView, setMobileSettingsView,
@@ -318,6 +319,15 @@ const MobileSettingsPanel = () => {
         <span className={`font-medium ${textPrimary} flex-1 text-left`}>Help & Feedback</span>
         <ChevronRight size={18} className={textSecondary} />
       </button>
+      {canConsumeTestPurchase && (
+        <button
+          onClick={consumeTestPurchase}
+          className={`w-full ${cardBg} border ${borderClass} rounded-xl p-3 flex items-center gap-3 opacity-50`}
+        >
+          <RefreshCw size={16} className={textSecondary} />
+          <span className={`text-sm ${textSecondary} flex-1 text-left`}>Reset test purchase</span>
+        </button>
+      )}
     </div>
   </div>
 

--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -134,6 +134,12 @@ export function useSubscription() {
 
   const clearBillingEvent = useCallback(() => setBillingEvent(null), []);
 
+  const consumeTestPurchase = useCallback(() => {
+    if (!BILLING?.consumeTestPurchase) return;
+    setBillingEvent(null);
+    BILLING.consumeTestPurchase();
+  }, []);
+
   useEffect(() => () => { if (timeoutRef.current) clearTimeout(timeoutRef.current); }, []);
 
   return {
@@ -141,10 +147,12 @@ export function useSubscription() {
     productId: status.productId,
     prices,
     isAndroidApp: !!BILLING,
+    canConsumeTestPurchase: typeof BILLING?.consumeTestPurchase === 'function',
     isLoading,
     subscribe,
     restore,
     refresh,
+    consumeTestPurchase,
     billingEvent,
     clearBillingEvent,
     billingErrorMessage,


### PR DESCRIPTION
## Summary

- Adds a "Reset test purchase" button to Settings (play builds only) that consumes the lifetime purchase token via `billingClient.consumeAsync()`, making it buyable again for re-testing
- The button only renders when `window.DayGlanceBilling.consumeTestPurchase` exists, so it's invisible on github/free builds and web
- Bumps `versionCode` to 76

## Test plan

- [ ] Build `playRelease`, buy the lifetime product as a license tester
- [ ] Open Settings — confirm "Reset test purchase" button is visible (dimmed, at the bottom)
- [ ] Tap it — subscription wall should reappear
- [ ] Buy again to confirm the full flow works end-to-end
- [ ] Build `githubRelease` — confirm the button is NOT visible

https://claude.ai/code/session_0125DadvH9RwgRKRGhnxzQsk

---
_Generated by [Claude Code](https://claude.ai/code/session_0125DadvH9RwgRKRGhnxzQsk)_