### PR TITLE
Refresh subscription status after test purchase consume

### DIFF
--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -63,8 +63,8 @@ export function useSubscription() {
     window.__billingEvent = (ev) => {
       try {
         const parsed = typeof ev === 'string' ? JSON.parse(ev) : ev;
-        if (parsed.status === 'success') {
-          // Re-read entitlement from cache — handlePurchase has just written it
+        if (parsed.status === 'success' || parsed.status === 'consumed') {
+          // Re-read entitlement from cache — handlePurchase / consumePurchase has just written it
           setStatus(readStatus());
           setPrices(readPrices());
         }


### PR DESCRIPTION
## Summary

After tapping "Reset test purchase", the subscription wall now reappears immediately without needing to reload the app. The `window.__billingEvent` handler already refreshed status on `"success"` — this extends it to also refresh on `"consumed"`.

https://claude.ai/code/session_0125DadvH9RwgRKRGhnxzQsk

---
_Generated by [Claude Code](https://claude.ai/code/session_0125DadvH9RwgRKRGhnxzQsk)_