### PR TITLE
Fix reset test purchase for annual subscriptions

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
@@ -293,18 +293,22 @@ class BillingManager(
     }
 
     fun consumePurchase(token: String, onComplete: (success: Boolean) -> Unit) {
-        if (!billingClient.isReady) { onComplete(false); return }
-        val params = ConsumeParams.newBuilder().setPurchaseToken(token).build()
-        scope.launch {
-            billingClient.consumeAsync(params) { result, _ ->
-                val success = result.responseCode == BillingClient.BillingResponseCode.OK
-                if (success) {
-                    dataStore.subscriptionActive = false
-                    dataStore.subscriptionProductId = null
-                    dataStore.subscriptionToken = null
-                }
-                onComplete(success)
+        // Always clear the local cache so the subscription wall reappears immediately.
+        // For INAPP (lifetime) products also call consumeAsync so Play allows re-purchase.
+        // Subscriptions can't be consumed via the billing API — clearing the cache is enough
+        // to re-test the purchase UI (Play will re-activate on the next subscribe call).
+        dataStore.subscriptionActive = false
+        val productId = dataStore.subscriptionProductId
+        dataStore.subscriptionProductId = null
+        dataStore.subscriptionToken = null
+
+        if (productId in INAPP_PRODUCTS && billingClient.isReady) {
+            val params = ConsumeParams.newBuilder().setPurchaseToken(token).build()
+            scope.launch {
+                billingClient.consumeAsync(params) { _, _ -> onComplete(true) }
             }
+        } else {
+            onComplete(true)
         }
     }
 }

--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -63,8 +63,8 @@ export function useSubscription() {
     window.__billingEvent = (ev) => {
       try {
         const parsed = typeof ev === 'string' ? JSON.parse(ev) : ev;
-        if (parsed.status === 'success') {
-          // Re-read entitlement from cache — handlePurchase has just written it
+        if (parsed.status === 'success' || parsed.status === 'consumed') {
+          // Re-read entitlement from cache — handlePurchase / consumePurchase has just written it
           setStatus(readStatus());
           setPrices(readPrices());
         }


### PR DESCRIPTION
## Summary

The "Reset test purchase" button wasn't working for annual subscriptions because `consumeAsync` is a Play Billing API that only applies to one-time (INAPP) products — calling it on a subscription token does nothing.

Fix: always clear the local SharedPreferences cache first (which makes the subscription wall reappear immediately), then only call `consumeAsync` for lifetime/INAPP products so Play allows re-purchasing.

For annual, clearing the cache is all that's needed to re-test the UI. When the user taps "Subscribe" again, Play re-activates the cancelled subscription.

Also includes the status refresh fix from #802 so the wall reappears without a reload.

https://claude.ai/code/session_0125DadvH9RwgRKRGhnxzQsk

---
_Generated by [Claude Code](https://claude.ai/code/session_0125DadvH9RwgRKRGhnxzQsk)_