### PR TITLE
Bump versionCode to 77

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 76
+        versionCode = 77
         versionName = "2.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Bumps `versionCode` from 76 → 77.

https://claude.ai/code/session_0125DadvH9RwgRKRGhnxzQsk

---
_Generated by [Claude Code](https://claude.ai/code/session_0125DadvH9RwgRKRGhnxzQsk)_