### PR TITLE
Show Pro license status in settings (versionCode 79)

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 78
+        versionCode = 79
         versionName = "2.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7630,6 +7630,7 @@ const DayPlanner = () => {
     showHelpModal, setShowHelpModal,
 
     // ── Billing ───────────────────────────────────────────────────────────────
+    isPro, isAndroidApp, productId: subProductId,
     consumeTestPurchase, canConsumeTestPurchase,
 
     // ── Autocomplete suggestions ──────────────────────────────────────────────

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -25,6 +25,7 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
 const MobileSettingsPanel = () => {
   const {
+    isPro, isAndroidApp, subProductId,
     consumeTestPurchase, canConsumeTestPurchase,
     setTasks, setUnscheduledTasks,
     darkMode, setDarkMode,
@@ -328,6 +329,11 @@ const MobileSettingsPanel = () => {
           <RefreshCw size={16} className={textSecondary} />
           <span className={`text-sm ${textSecondary} flex-1 text-left`}>Reset test purchase</span>
         </button>
+      )}
+      {isAndroidApp && isPro && (
+        <p className={`text-xs ${textSecondary} text-center pt-1`}>
+          {subProductId === 'dayglance_pro_lifetime' ? 'dayGLANCE Pro · Lifetime' : 'dayGLANCE Pro · Annual'}
+        </p>
       )}
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Shows a small `"dayGLANCE Pro · Annual"` or `"dayGLANCE Pro · Lifetime"` label at the bottom of the Settings main view, only visible on Android when the user has an active subscription
- Bumps `versionCode` to 79

https://claude.ai/code/session_0125DadvH9RwgRKRGhnxzQsk

---
_Generated by [Claude Code](https://claude.ai/code/session_0125DadvH9RwgRKRGhnxzQsk)_