### PR TITLE
fix(sync): prevent Android changes being overwritten + fix hours-long sync freeze

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -362,17 +362,27 @@ ipcMain.handle('proxy-fetch', async (_event, method: string, url: string, header
     const msg = e instanceof Error ? e.message : 'Invalid URL';
     return { status: 400, ok: false, statusText: 'Bad Request', body: msg };
   }
+  // 30-second hard timeout — net.fetch has no built-in timeout, so a slow or
+  // unresponsive WebDAV server (e.g. a home server that went offline) would
+  // hold the cloudSyncInProgressRef lock indefinitely, silently blocking every
+  // subsequent 60-second poll until the app is force-quit and restarted.
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30_000);
   try {
     const response = await net.fetch(url, {
       method: upperMethod,
       headers,
+      signal: controller.signal,
       ...(body != null ? { body } : {}),
     });
     const text = await response.text();
     return { status: response.status, ok: response.ok, statusText: response.statusText, body: text, headers: { etag: response.headers.get('etag') || null } };
   } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : 'Network error';
+    const isAbort = e instanceof Error && e.name === 'AbortError';
+    const msg = isAbort ? 'Sync request timed out (server did not respond within 30 s)' : (e instanceof Error ? e.message : 'Network error');
     return { status: 0, ok: false, statusText: msg, body: '', headers: { etag: null } };
+  } finally {
+    clearTimeout(timeoutId);
   }
 });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1266,12 +1266,16 @@ const DayPlanner = () => {
     return () => clearInterval(syncTimer);
   }, [syncUrl, taskCalendarUrl]);
 
-  // Cloud sync: debounced upload on data changes
+  // Cloud sync: debounced download+merge+upload on data changes.
+  // Triggering a full download cycle (not just an upload) ensures that any
+  // concurrent writes from other devices (e.g. Android) are merged in before
+  // we push our local state, preventing Electron from overwriting Android's
+  // changes that arrived since the last 60-second poll.
   useEffect(() => {
     if (isTrayMode || !cloudSyncConfig?.enabled || !dataLoaded || suppressCloudUploadRef.current) return;
     if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current);
     cloudSyncDebounceRef.current = setTimeout(() => {
-      cloudSyncUpload();
+      cloudSyncDownloadRef.current?.();
     }, 5000);
     return () => { if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current); };
   }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled]);
@@ -5055,7 +5059,13 @@ const DayPlanner = () => {
     const provider = cloudSyncProviders[cloudSyncConfig.provider];
     if (!provider) return;
 
-    if (cloudSyncInProgressRef.current) return;
+    if (cloudSyncInProgressRef.current) {
+      // A debounce-triggered download arrived while one was already running.
+      // Set the pending flag so the running cycle schedules a follow-up download
+      // on completion, ensuring the user's queued changes are not dropped.
+      cloudSyncPendingUploadRef.current = true;
+      return;
+    }
     cloudSyncInProgressRef.current = true;
     const syncStart = Date.now();
     setCloudSyncStatus('downloading');
@@ -5168,10 +5178,12 @@ const DayPlanner = () => {
         cloudSyncInProgressRef.current = false;
         if (!passphraseRequired) cloudSyncInitialDoneRef.current = true;
 
-        // If a local change arrived while the download held the lock, upload it now.
+        // If a debounce-triggered download arrived while this one held the lock,
+        // run a fresh download+merge+upload now so the pending local change is
+        // merged with any concurrent remote writes rather than blindly overwritten.
         if (cloudSyncPendingUploadRef.current) {
           cloudSyncPendingUploadRef.current = false;
-          setTimeout(() => cloudSyncUpload(), 0);
+          setTimeout(() => cloudSyncDownloadRef.current?.(), 0);
         }
         // If iCloudSync was skipped because the lock was held, run it now.
         if (iCloudPendingRef.current) {

--- a/src/hooks/useCloudSync.js
+++ b/src/hooks/useCloudSync.js
@@ -31,8 +31,10 @@ const useCloudSync = () => {
   // Download-specific backoff (separate so upload failures don't block downloads and vice versa)
   const cloudSyncDownloadErrorCountRef  = useRef(0);
   const cloudSyncDownloadBackoffUntilRef = useRef(0);
-  // Set to true when a debounced upload fires while a download holds the lock,
-  // so the download cycle can trigger a follow-up upload on completion (H1).
+  // Set to true when a debounce-triggered download fires while another download
+  // holds the lock, so the running cycle schedules a follow-up download on
+  // completion to pick up the pending local change (and any concurrent remote
+  // writes) rather than blindly uploading over them (H1).
   const cloudSyncPendingUploadRef = useRef(false);
   // Set to true when iCloudSync is skipped because WebDAV holds the lock,
   // so the download cycle can re-run iCloud on completion (H2).

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -997,17 +997,20 @@ describe('mergeSyncData — todayRoutines sync', () => {
   });
 
   it('removedTodayRoutineIds merges from both devices', () => {
+    const today = new Date().toISOString().split('T')[0];
+    const ts1 = new Date(Date.now() - 4 * 3600000).toISOString();
+    const ts2 = new Date(Date.now() - 2 * 3600000).toISOString();
     const deviceA = {
       ...emptyData(),
       todayRoutines: [],
-      routinesDate: '2026-02-14',
-      removedTodayRoutineIds: { 'shower': '2026-02-14T10:00:00.000Z' },
+      routinesDate: today,
+      removedTodayRoutineIds: { 'shower': ts1 },
     };
     const deviceB = {
       ...emptyData(),
       todayRoutines: [],
-      routinesDate: '2026-02-14',
-      removedTodayRoutineIds: { 'workout': '2026-02-14T11:00:00.000Z' },
+      routinesDate: today,
+      removedTodayRoutineIds: { 'workout': ts2 },
     };
 
     const { data } = mergeSyncData(deviceA, deviceB);


### PR DESCRIPTION
## Summary

Two separate sync bugs, both on the Electron side:

**Bug 1 — Hours-long sync freeze (the "force-quit to fix it" issue)**

`net.fetch` in Electron has no request timeout. When a WebDAV server becomes unresponsive (home server offline, VPN drop, slow Nextcloud), the awaited fetch hangs forever holding `cloudSyncInProgressRef.current = true`. Every subsequent 60-second poll hits the early-return guard and silently does nothing. Hours can pass until the app is force-quit and restarted, at which point the initial-load download succeeds.

Fix: wrap `net.fetch` in an `AbortController` that fires after 30 seconds. On abort, the catch block returns `status=0 / ok=false` (same contract as other error paths), the download handler enters its error path, sets a backoff, and **releases the lock** — so normal polling resumes within minutes instead of requiring a restart. Android's `HttpBridge.kt` already had 20-second timeouts; Electron was the only platform with none.

**Bug 2 — Android changes overwritten by Electron's debounced upload**

The debounced upload path (`cloudSyncUpload()`) pushed Electron's local state to WebDAV without first downloading recent changes. If Android uploaded a change between Electron's 60-second polls and Electron's user then made any change, Electron's 5-second debounce would fire and silently overwrite Android's data. Android's change only resurfaced ~120 seconds later after Android re-uploaded it on its own poll.

Fix: change the debounced callback to `cloudSyncDownloadRef.current?.()` so every user-triggered sync does download → merge → upload. When the debounced call arrives while a download is already in progress, the pending flag is set so a follow-up **download** (not bare upload) is scheduled on completion.

**Test fix**

`removedTodayRoutineIds merges from both devices` used hardcoded dates from Feb 14 2026, now ≥90 days old and pruned by the retention window before assertions ran. Updated to relative timestamps (same fix as `2e2b686` for frame tombstone tests).

## Test plan

- [ ] All 128 `mergeSync` tests pass
- [ ] With a responsive server: Android change appears in Electron within ~10 seconds of the debounce cycle
- [ ] With an unresponsive server: after 30 seconds Electron logs a timeout error and resumes polling — no restart required
- [ ] Concurrent changes (Electron + Android simultaneously) both survive — neither overwrites the other

https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n