### PR TITLE
fix: ReferenceError crash — subProductId not defined

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -177,7 +177,7 @@ const TimePicker = ({ value, onChange, use24HourClock, borderClass, darkMode }) 
 const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
 
 const DayPlanner = () => {
-  const { isPro, isLoading: subLoading, isAndroidApp, subscribe, restore, prices: subPrices, billingEvent, clearBillingEvent, billingErrorMessage, consumeTestPurchase, canConsumeTestPurchase } = useSubscription();
+  const { isPro, isLoading: subLoading, isAndroidApp, productId: subProductId, subscribe, restore, prices: subPrices, billingEvent, clearBillingEvent, billingErrorMessage, consumeTestPurchase, canConsumeTestPurchase } = useSubscription();
   const _visibleDays = useVisibleDays();
   const { isPhone, isMobile, isTablet } = useDeviceType();
   const isLandscape = useIsLandscape();
@@ -7642,7 +7642,7 @@ const DayPlanner = () => {
     showHelpModal, setShowHelpModal,
 
     // ── Billing ───────────────────────────────────────────────────────────────
-    isPro, isAndroidApp, productId: subProductId,
+    isPro, isAndroidApp, subProductId,
     consumeTestPurchase, canConsumeTestPurchase,
 
     // ── Autocomplete suggestions ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `productId` was never destructured from `useSubscription()` in `App.jsx`, so the context value object contained a bare reference to the non-existent variable `subProductId` — a `ReferenceError` on any render path that reached the Pro badge in `MobileSettingsPanel`.
- Fix: destructure `productId` as `subProductId` directly from `useSubscription()`, then expose it as `subProductId` in the context (the key `MobileSettingsPanel` already expects).

## Root cause

```js
// Before — App.jsx line 180: productId never pulled out of useSubscription()
const { isPro, isLoading: subLoading, isAndroidApp, ... } = useSubscription();

// Before — ctx object line 7645: subProductId used as a value but never defined
productId: subProductId,   // ← ReferenceError
```

```js
// After
const { isPro, isLoading: subLoading, isAndroidApp, productId: subProductId, ... } = useSubscription();
// ctx
subProductId,   // ← correctly exposes the value
```

## Test plan

- [ ] Open Settings on Android with a Pro subscription — Pro badge renders without crash
- [ ] Open Settings on Android without Pro — no crash (badge is hidden, `subProductId` is `null`)
- [ ] 7-tap on Pro badge reveals the reset test purchase button

https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n)_