### PR TITLE
chore(android): bump versionCode to 81

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 80
+        versionCode = 81
         versionName = "2.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Bumps `versionCode` from 80 → 81 for the corrected v2.9.5 resubmission. `versionName` stays `"2.9"`.

https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n)_