### PR TITLE
fix(sync): revert debounce to cloudSyncUpload to stop mobile sync loop

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1266,16 +1266,14 @@ const DayPlanner = () => {
     return () => clearInterval(syncTimer);
   }, [syncUrl, taskCalendarUrl]);
 
-  // Cloud sync: debounced download+merge+upload on data changes.
-  // Triggering a full download cycle (not just an upload) ensures that any
-  // concurrent writes from other devices (e.g. Android) are merged in before
-  // we push our local state, preventing Electron from overwriting Android's
-  // changes that arrived since the last 60-second poll.
+  // Cloud sync: debounced upload on data changes.
+  // Upload only (no download) to avoid the applyRemoteData → state-change → debounce
+  // re-trigger loop. The 60-second poll handles keeping remote changes in sync.
   useEffect(() => {
     if (isTrayMode || !cloudSyncConfig?.enabled || !dataLoaded || suppressCloudUploadRef.current) return;
     if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current);
     cloudSyncDebounceRef.current = setTimeout(() => {
-      cloudSyncDownloadRef.current?.();
+      cloudSyncUpload();
     }, 5000);
     return () => { if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current); };
   }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled]);


### PR DESCRIPTION
## Summary

- Reverts the debounce trigger from `cloudSyncDownload` back to `cloudSyncUpload` to stop a tight sync loop on mobile.

## Root cause

When the debounce called `cloudSyncDownload`, it would call `applyRemoteData` which updates task state. `useSaveOnChange` clears `suppressCloudUploadRef` via `queueMicrotask` after saving — but by then the debounce effect has already re-fired with suppress=false and queued another download. On desktop the timing is tight enough to work; on mobile (slower render pipeline) it loses the race every time and loops.

Reverting to `cloudSyncUpload` breaks the loop: upload doesn't call `applyRemoteData`, so it doesn't change task state, so the debounce effect doesn't re-fire.

## Trade-off

The narrow (~60s) overwrite window that motivated the `cloudSyncDownload` change is accepted back. The primary fix — the 30-second `net.fetch` timeout that prevented the hours-long sync lock — remains in place and covers the main sync reliability problem.

## Test plan

- [ ] Make a change on mobile → confirm sync fires once (not in a loop)
- [ ] Make a change on Electron → confirm it uploads correctly
- [ ] Android changes still appear in Electron within the 60-second poll window

https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n)_