### PR TITLE
fix(sync): delay follow-up download 250ms to let React state propagate

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5183,7 +5183,7 @@ const DayPlanner = () => {
         // merged with any concurrent remote writes rather than blindly overwritten.
         if (cloudSyncPendingUploadRef.current) {
           cloudSyncPendingUploadRef.current = false;
-          setTimeout(() => cloudSyncDownloadRef.current?.(), 0);
+          setTimeout(() => cloudSyncDownloadRef.current?.(), 250);
         }
         // If iCloudSync was skipped because the lock was held, run it now.
         if (iCloudPendingRef.current) {


### PR DESCRIPTION
## Summary

- Changes `setTimeout(fn, 0)` → `setTimeout(fn, 250)` for the follow-up download triggered by `cloudSyncPendingUploadRef` in the `finally` block of `cloudSyncDownload`.

## Why

The `setTimeout(fn, 0)` fired on the very next event loop tick — before React had flushed the state changes from the `applyRemoteData` call that preceded it. On that follow-up download, `buildSyncPayload()` called `stampTaskTimestamps` which compared stale React state (pre-`applyRemoteData`) against the already-updated localStorage. When it found a mismatch it re-stamped the task with `Date.now()`, making the stale local version appear *newer* than the remote version — causing the merge to keep the wrong (pre-reschedule) version and upload it.

250ms is enough for React to commit state but still well within the `suppressTimestampRef` window, so the fix doesn't introduce a new suppress-timing gap.

## Related

Should be merged after or alongside PR #813 (debounce loop fix).

https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n)_