### PR TITLE
chore(android): bump versionCode to 82

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 81
+        versionCode = 82
         versionName = "2.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
versionCode 81 → 82. versionName stays `"2.9"`.\n\nhttps://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n)_