### PR TITLE
fix: trigger cloud sync download on window focus

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1212,9 +1212,11 @@ const DayPlanner = () => {
     };
     document.addEventListener('visibilitychange', handleVisibility);
     document.addEventListener('dayglanceForeground', handleNativeForeground);
+    window.addEventListener('focus', handleVisibility);
     return () => {
       document.removeEventListener('visibilitychange', handleVisibility);
       document.removeEventListener('dayglanceForeground', handleNativeForeground);
+      window.removeEventListener('focus', handleVisibility);
     };
   }, []);
 


### PR DESCRIPTION
## Summary

- Adds `window.addEventListener('focus', handleVisibility)` alongside the existing `visibilitychange` listener.

## Why this is needed

`visibilitychange` only fires when `document.hidden` changes — when a tab is hidden or a window is minimised. On Electron and desktop browsers, switching between app windows without minimising keeps `document.hidden = false` the whole time, so the handler never fires. The only automatic sync trigger was the 60-second poll.

With the `focus` listener, returning to the Electron window immediately triggers a cloud sync download — same as switching back to a mobile app. The `cloudSyncInProgressRef` lock prevents double-downloads if both `focus` and `visibilitychange` fire together.

## Test plan

- [ ] Make a change on Android → switch to Electron window → change appears without CMD-R or waiting 60s
- [ ] No double-sync or errors when both `focus` and `visibilitychange` fire (e.g. restoring a minimised Electron window)

https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV6ae6xQZQyQwsc6c3Nv7n)_