### PR TITLE
fix(billing): restore consumeAsync for subscription test tokens

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
@@ -294,21 +294,22 @@ class BillingManager(
 
     fun consumePurchase(token: String, onComplete: (success: Boolean) -> Unit) {
         // Always clear the local cache so the subscription wall reappears immediately.
-        // For INAPP (lifetime) products also call consumeAsync so Play allows re-purchase.
-        // Subscriptions can't be consumed via the billing API — clearing the cache is enough
-        // to re-test the purchase UI (Play will re-activate on the next subscribe call).
         dataStore.subscriptionActive = false
-        val productId = dataStore.subscriptionProductId
         dataStore.subscriptionProductId = null
         dataStore.subscriptionToken = null
 
-        if (productId in INAPP_PRODUCTS && billingClient.isReady) {
-            val params = ConsumeParams.newBuilder().setPurchaseToken(token).build()
-            scope.launch {
-                billingClient.consumeAsync(params) { _, _ -> onComplete(true) }
-            }
-        } else {
+        if (!billingClient.isReady) {
             onComplete(true)
+            return
+        }
+        // Call consumeAsync regardless of product type. For INAPP (lifetime) this is
+        // required to allow re-purchase. For test subscription tokens purchased by a
+        // license tester, consumeAsync also succeeds and lets Play allow a new
+        // subscription — PR #803 skipped this for SUBS but that broke re-testing.
+        // The result code is ignored; local cache is always cleared above.
+        val params = ConsumeParams.newBuilder().setPurchaseToken(token).build()
+        scope.launch {
+            billingClient.consumeAsync(params) { _, _ -> onComplete(true) }
         }
     }
 }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
@@ -124,12 +124,14 @@ class SubscriptionBridge(
             }
             return
         }
+        // Capture productId before consumePurchase clears it from the data store.
+        val productId = dataStore.subscriptionProductId ?: ""
         billingManager.consumePurchase(token) { success ->
             val json = JSONObject().apply {
                 put("status", if (success) "consumed" else "consume_failed")
                 put("code", 0)
                 put("message", if (success) "test_consume" else "consume_error")
-                put("productId", BillingManager.PRODUCT_LIFETIME)
+                put("productId", productId)
             }
             webView?.post {
                 webView.evaluateJavascript(


### PR DESCRIPTION
## Summary

- PR #803 skipped `consumeAsync` for subscription products (annual) on the grounds that the API only officially supports INAPP products. In practice, license-tester subscription tokens **are** consumable via `consumeAsync` — skipping it left the Play-side token in an owned state, so re-purchasing produced `ITEM_ALREADY_OWNED` (error 7).
- `consumePurchase` now calls `consumeAsync` for all product types. The result code is ignored since the local cache is always cleared regardless (so the subscription wall reappears even if Play rejects the consume on production tokens).
- Also fixes a minor bug in `SubscriptionBridge`: the `consumed` billing event was hardcoding `PRODUCT_LIFETIME` as the `productId` regardless of what was actually purchased.

## Test plan

- [ ] With an annual test subscription purchased on a license-tester account: tap Pro badge 7× → press **Reset test purchase** → subscription wall should reappear → tap a plan → Play purchase sheet opens and completes without "you already own this item"
- [ ] Same flow with the lifetime INAPP product — should still work as before
- [ ] Check Logcat for `consumeAsync` result code after pressing the button (OK = 0 expected for license tester, non-OK is tolerated and local cache is still cleared)

https://claude.ai/code/session_01RpyARzWtaYqjiR62nhRUjP

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpyARzWtaYqjiR62nhRUjP)_