### PR TITLE
fix(billing): query INAPP purchases directly in consumePurchase

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
@@ -302,14 +302,33 @@ class BillingManager(
             onComplete(true)
             return
         }
-        // Call consumeAsync regardless of product type. For INAPP (lifetime) this is
-        // required to allow re-purchase. For test subscription tokens purchased by a
-        // license tester, consumeAsync also succeeds and lets Play allow a new
-        // subscription — PR #803 skipped this for SUBS but that broke re-testing.
-        // The result code is ignored; local cache is always cleared above.
-        val params = ConsumeParams.newBuilder().setPurchaseToken(token).build()
         scope.launch {
-            billingClient.consumeAsync(params) { _, _ -> onComplete(true) }
+            // Query INAPP purchases directly rather than relying on the token stored in
+            // dataStore. When an annual test subscription is active, queryPurchases() stores
+            // the SUBS token (SUBS has priority), leaving the lifetime INAPP token untouched.
+            // Querying INAPP directly ensures the lifetime token is always consumed.
+            val inappPurchases = queryPurchasesForType(BillingClient.ProductType.INAPP)
+            for (purchase in inappPurchases) {
+                val p = ConsumeParams.newBuilder().setPurchaseToken(purchase.purchaseToken).build()
+                suspendCancellableCoroutine { cont ->
+                    billingClient.consumeAsync(p) { result, _ ->
+                        Log.d(TAG, "consumeAsync INAPP ${purchase.purchaseToken.takeLast(8)}: code=${result.responseCode} msg='${result.debugMessage}'")
+                        cont.resume(Unit)
+                    }
+                }
+            }
+            // Also attempt the originally stored token (may be a SUBS token for an annual
+            // test subscription — consumeAsync can succeed on license-tester SUBS tokens).
+            if (inappPurchases.none { it.purchaseToken == token }) {
+                val p = ConsumeParams.newBuilder().setPurchaseToken(token).build()
+                suspendCancellableCoroutine { cont ->
+                    billingClient.consumeAsync(p) { result, _ ->
+                        Log.d(TAG, "consumeAsync stored token ${token.takeLast(8)}: code=${result.responseCode} msg='${result.debugMessage}'")
+                        cont.resume(Unit)
+                    }
+                }
+            }
+            onComplete(true)
         }
     }
 }


### PR DESCRIPTION
## What was wrong

When a test annual subscription is active, `queryPurchases()` stores the SUBS token (SUBS has priority over INAPP). `consumePurchase` was then calling `consumeAsync` on that annual token and never touching the lifetime INAPP token — leaving the lifetime token permanently owned in Play, producing "you already own this item" on the next purchase attempt.

A secondary bug: `consumeAsync` was fire-and-forget, so `onComplete` (and the `consumed` billing event to JS) fired before Play had actually processed the consume. If the user tapped "buy" immediately, Play's server hadn't reflected the consume yet.

## Fix

- Query INAPP purchases directly inside `consumePurchase` rather than relying on the dataStore token, which may be a SUBS token.
- Use `suspendCancellableCoroutine` to wait for each `consumeAsync` to complete before calling `onComplete` — the wall now appears only after the consume is confirmed.
- Log the result code from each consume so Logcat shows exactly what Play returned.
- Still attempts `consumeAsync` on the originally stored token too (handles the case where it's a license-tester SUBS token that Play will accept).

## Test plan

- [ ] With an active annual test subscription AND a lifetime purchase: press Reset → paywall appears → tap Lifetime → purchase sheet opens normally (no "you already own this item")
- [ ] Lifetime-only account: same flow works as before
- [ ] Check Logcat (`DayGlanceBilling`) for `consumeAsync` result codes after pressing Reset

## Note on annual "you're already subscribed"

Test annual subscriptions for license testers don't appear in Play Store Payments & subscriptions — they're ghost purchases tracked in Play's backend only. They auto-expire after ~30 min (6 × 5-min renewal cycles). The annual button will keep showing "you're already subscribed" until the active test subscription expires; that's a Play limitation, not a code issue.

https://claude.ai/code/session_01RpyARzWtaYqjiR62nhRUjP

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpyARzWtaYqjiR62nhRUjP)_