### PR TITLE
Step 4: cloudSyncProviders.js shim — extract to @glance-apps/sync 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dayglance",
       "version": "2.9.5",
       "dependencies": {
-        "@glance-apps/sync": "^0.3.0",
+        "@glance-apps/sync": "^0.4.0",
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-0.3.0.tgz",
-      "integrity": "sha512-nJ7ACv2zoBXq7IWkYUkTn9iBKADfEC4BghedXxMHfrlG9vxzG+70wCws8zH3r4OglGplG2Qeq6sSvntflx/DZA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-0.4.0.tgz",
+      "integrity": "sha512-lPqWzjMjcakM9VrYuqZ3Hg/TtmrcTvhOxYleLkVTJ0iesbBmapwIHTMhV8arKvT/hIUd+VGeiOts4RFTvet/bg==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:electron:release": "vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs --publish never"
   },
   "dependencies": {
-    "@glance-apps/sync": "^0.3.0",
+    "@glance-apps/sync": "^0.4.0",
     "lucide-react": "^0.564.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/utils/cloudSyncProviders.js
+++ b/src/utils/cloudSyncProviders.js
@@ -1,276 +1,46 @@
-import { nativeHttpRequest } from '../native.js';
-import { encryptData, decryptData, isEncryptedEnvelope } from './crypto.js';
+// Shim: re-exports providers from @glance-apps/sync with dayGLANCE-pinned config.
+// Callers use the same cloudSyncProviders shape and webdavFetch signature as before.
+import { nativeHttpRequest as _nativeHttpRequest } from '../native.js';
+import { webdavFetch as _webdavFetch, createProviders } from '@glance-apps/sync';
 
-// btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
-const toBase64 = (str) => btoa(String.fromCharCode(...new TextEncoder().encode(str)));
+// iOS sets window.DayGlanceIOS = true. Its DayGlanceNative is a Proxy that
+// makes every property truthy — explicitly exclude iOS so it falls through
+// to the Vercel proxy path, same as the original webdavFetch logic.
+const isAndroid =
+  typeof window !== 'undefined' &&
+  !window.DayGlanceIOS &&
+  !!window.DayGlanceNative?.httpRequest;
 
-// Routes WebDAV requests through the server-side CORS proxy on web, or
-// directly via the Android HTTP bridge on native.
-export const webdavFetch = async (method, targetUrl, authHeaders, body, extraHeaders = {}) => {
-  if (typeof window !== 'undefined' && window.DayGlanceNative?.httpRequest) {
-    // On Android: call the target URL directly with a standard Authorization header.
-    const headers = { ...extraHeaders };
-    if (authHeaders['X-WebDAV-Auth']) {
-      headers['Authorization'] = authHeaders['X-WebDAV-Auth'];
-    } else {
-      Object.assign(headers, authHeaders);
-    }
-    if (body !== undefined && body !== null) {
-      headers['Content-Type'] = extraHeaders['Content-Type'] || 'application/octet-stream';
-    }
-    const result = nativeHttpRequest(method, targetUrl, headers, body ?? '');
-    if (!result) throw new Error('Native HTTP bridge unavailable');
-    return {
-      status: result.status,
-      ok: result.ok,
-      statusText: result.error || '',
-      headers: { get: (h) => (h.toLowerCase() === 'etag' ? result.headers?.etag ?? null : null) },
-      json: async () => {
-        try { return JSON.parse(result.body); }
-        catch { throw new Error(`Server returned non-JSON response (status ${result.status})`); }
-      },
-      text: async () => result.body,
-    };
-  }
-  if (typeof window !== 'undefined' && window.electronAPI?.isElectron) {
-    // On Electron: route through the main process (net.fetch has no CORS restrictions).
-    const headers = { ...extraHeaders };
-    if (authHeaders['X-WebDAV-Auth']) {
-      headers['Authorization'] = authHeaders['X-WebDAV-Auth'];
-    } else {
-      Object.assign(headers, authHeaders);
-    }
-    if (body !== undefined && body !== null) {
-      headers['Content-Type'] = extraHeaders['Content-Type'] || 'application/octet-stream';
-    }
-    const result = await window.electronAPI.proxyFetch(method, targetUrl, headers, body ?? null);
-    if (!result) throw new Error('Electron network bridge unavailable');
-    return {
-      status: result.status,
-      ok: result.ok,
-      statusText: result.statusText,
-      headers: { get: (h) => (h.toLowerCase() === 'etag' ? result.headers?.etag ?? null : null) },
-      json: async () => {
-        try { return JSON.parse(result.body); }
-        catch { throw new Error(`Server returned non-JSON response (status ${result.status})`); }
-      },
-      text: async () => result.body,
-    };
-  }
-  // On web: route through the server-side CORS proxy.
-  return fetch(`/api/webdav-proxy/?url=${encodeURIComponent(targetUrl)}`, {
-    method,
-    headers: { ...authHeaders, ...extraHeaders },
-    ...(body !== undefined && body !== null ? { body } : {}),
-  });
+const dayGlanceEngineConfig = {
+  appFolderName: 'dayglance',
+  syncFilename: 'dayglance-sync.json',
+
+  // Android: pass the real bridge. iOS/web: null → falls through to proxy.
+  nativeHttpRequest: isAndroid ? _nativeHttpRequest : null,
+
+  // Electron: detect at module load (preload sets this up before renderer).
+  electronProxyFetch:
+    typeof window !== 'undefined' && window.electronAPI?.isElectron
+      ? (...args) => window.electronAPI.proxyFetch(...args)
+      : null,
+
+  // Relative URL → proxy runs at the same origin as the app.
+  proxyUrl: import.meta.env.VITE_WEBDAV_PROXY_URL ?? '',
+
+  // Crypto config (threaded to encryptData/decryptData inside providers).
+  cryptoDBName: 'dayglance-crypto',
+  nativeGetSyncKey:
+    isAndroid && window?.DayGlanceNative?.getSyncKey
+      ? () => window.DayGlanceNative.getSyncKey()
+      : null,
+  nativeStoreSyncKey:
+    isAndroid && window?.DayGlanceNative?.storeSyncKey
+      ? (val) => window.DayGlanceNative.storeSyncKey(val)
+      : null,
 };
 
-// Parses and decrypts a WebDAV download response.
-// Returns { payload, etag } where etag may be null if the server doesn't supply one.
-const parseDownloadResponse = async (res) => {
-  const parsed = await res.json();
-  const payload = isEncryptedEnvelope(parsed) ? await decryptData(parsed) : parsed;
-  const etag = res.headers.get('etag') || null;
-  return { payload, etag };
-};
+export const cloudSyncProviders = createProviders(dayGlanceEngineConfig);
 
-// Creates a WebDAV collection and any missing intermediate collections.
-// MKCOL returns 409 when the parent directory doesn't exist; in that case
-// we walk up the path, create the parent first, then retry.
-// Some providers (e.g. Koofr) non-standardly return 404 instead of 409 —
-// treat both the same way.
-const mkcolWithParents = async (dirUrl, authHeaders) => {
-  const res = await webdavFetch('MKCOL', dirUrl, authHeaders);
-  if (res.status === 409 || res.status === 404) {
-    // Derive the parent by stripping the last path segment using URL() so we
-    // never produce malformed strings like "https:/" on root-level inputs.
-    let parent;
-    try {
-      const u = new URL(dirUrl);
-      const stripped = u.pathname.replace(/\/+$/, '').replace(/\/[^/]+$/, '/');
-      if (!stripped || stripped === u.pathname.replace(/\/+$/, '')) return; // already at root
-      u.pathname = stripped;
-      parent = u.toString();
-    } catch { return; }
-    if (parent && parent !== dirUrl) {
-      await mkcolWithParents(parent, authHeaders);
-      await webdavFetch('MKCOL', dirUrl, authHeaders);
-    }
-  }
-};
-
-export const cloudSyncProviders = {
-  nextcloud: {
-    name: 'Nextcloud / WebDAV',
-    getFileUrl: (config) =>
-      `${config.nextcloudUrl.replace(/\/+$/, '')}/remote.php/dav/files/${encodeURIComponent(config.username)}/dayglance/dayglance-sync.json`,
-    getDirUrl: (config) =>
-      `${config.nextcloudUrl.replace(/\/+$/, '')}/remote.php/dav/files/${encodeURIComponent(config.username)}/dayglance/`,
-    getAuthHeaders: (config) => ({
-      'X-WebDAV-Auth': 'Basic ' + toBase64(config.username + ':' + config.appPassword)
-    }),
-    async upload(config, data, etag = null) {
-      const fileUrl = this.getFileUrl(config);
-      const dirUrl = this.getDirUrl(config);
-      const authHeaders = this.getAuthHeaders(config);
-      const payload = config.encryptionEnabled ? await encryptData(data) : data;
-      const body = JSON.stringify(payload);
-      const extraHeaders = { 'Content-Type': 'application/json' };
-      if (etag) extraHeaders['If-Match'] = etag;
-
-      const doUpload = () =>
-        webdavFetch('PUT', fileUrl, authHeaders, body, extraHeaders);
-
-      let res = await doUpload();
-      if (res.status === 404 || res.status === 409) {
-        await mkcolWithParents(dirUrl, authHeaders);
-        res = await doUpload();
-      }
-      if (res.status === 403) throw new Error('FORBIDDEN');
-      if (res.status === 412) throw new Error('PRECONDITION_FAILED');
-      if (!res.ok) throw new Error(`Upload failed: ${res.status} ${res.statusText}`);
-      return true;
-    },
-    async download(config) {
-      const fileUrl = this.getFileUrl(config);
-      const authHeaders = this.getAuthHeaders(config);
-
-      const res = await webdavFetch('GET', fileUrl, authHeaders);
-
-      if (res.status === 404) return null; // No remote file yet
-      if (res.status === 403) throw new Error('FORBIDDEN');
-      if (!res.ok) throw new Error(`Download failed: ${res.status} ${res.statusText}`);
-      return parseDownloadResponse(res);
-    },
-    async test(config) {
-      const dirUrl = this.getDirUrl(config);
-      const authHeaders = this.getAuthHeaders(config);
-
-      const res = await webdavFetch('PROPFIND', dirUrl, authHeaders, undefined, { 'Depth': '0' });
-
-      if (res.status === 200 || res.status === 207 || res.status === 404) return { success: true };
-      if (res.status === 401) return { success: false, error: 'Invalid credentials. Check your username and app password.' };
-      if (res.status === 403) return { success: false, error: 'Access forbidden (403). If using a self-hosted server, it may be blocking requests from Vercel\'s IP addresses.' };
-      return { success: false, error: `Unexpected response: ${res.status}${res.statusText ? ' ' + res.statusText : ''}` };
-    },
-    configFields: [
-      { key: 'nextcloudUrl', label: 'Nextcloud URL', type: 'url', placeholder: 'https://cloud.example.com' },
-      { key: 'username', label: 'Username', type: 'text', placeholder: 'your-username' },
-      { key: 'appPassword', label: 'App Password', type: 'password', placeholder: 'xxxxx-xxxxx-xxxxx-xxxxx-xxxxx' }
-    ],
-    helpText: 'Go to Nextcloud Settings → Security → Devices & sessions → Create new app password'
-  },
-  koofr: {
-    name: 'Koofr',
-    getFileUrl: () => 'https://app.koofr.net/dav/Koofr/dayGLANCE/dayglance-sync.json',
-    getDirUrl: () => 'https://app.koofr.net/dav/Koofr/dayGLANCE/',
-    getAuthHeaders: (config) => ({
-      'X-WebDAV-Auth': 'Basic ' + toBase64(config.username + ':' + config.appPassword)
-    }),
-    async upload(config, data, etag = null) {
-      const fileUrl = this.getFileUrl();
-      const dirUrl = this.getDirUrl();
-      const authHeaders = this.getAuthHeaders(config);
-      const payload = config.encryptionEnabled ? await encryptData(data) : data;
-      const body = JSON.stringify(payload);
-      const extraHeaders = { 'Content-Type': 'application/json' };
-      if (etag) extraHeaders['If-Match'] = etag;
-      const doUpload = () =>
-        webdavFetch('PUT', fileUrl, authHeaders, body, extraHeaders);
-      let res = await doUpload();
-      if (res.status === 404 || res.status === 409) {
-        await mkcolWithParents(dirUrl, authHeaders);
-        res = await doUpload();
-      }
-      if (res.status === 403) throw new Error('FORBIDDEN');
-      if (res.status === 412) throw new Error('PRECONDITION_FAILED');
-      if (!res.ok) throw new Error(`Upload failed: ${res.status} ${res.statusText}`);
-      return true;
-    },
-    async download(config) {
-      const fileUrl = this.getFileUrl();
-      const authHeaders = this.getAuthHeaders(config);
-      const res = await webdavFetch('GET', fileUrl, authHeaders);
-      if (res.status === 404) return null;
-      if (res.status === 403) throw new Error('FORBIDDEN');
-      if (!res.ok) throw new Error(`Download failed: ${res.status} ${res.statusText}`);
-      return parseDownloadResponse(res);
-    },
-    async test(config) {
-      const dirUrl = this.getDirUrl();
-      const authHeaders = this.getAuthHeaders(config);
-      const res = await webdavFetch('PROPFIND', dirUrl, authHeaders, undefined, { 'Depth': '0' });
-      if (res.status === 200 || res.status === 207 || res.status === 404) return { success: true };
-      if (res.status === 401) return { success: false, error: 'Invalid credentials. Use your Koofr email and an app password, not your account password.' };
-      if (res.status === 403) {
-        const onAndroid = typeof window !== 'undefined' && !!window.DayGlanceNative;
-        if (!onAndroid) return { success: false, error: 'Koofr is blocking requests from the web app\'s server. Use the Android app — it connects to Koofr directly.' };
-        return { success: false, error: 'Access forbidden. Check that your app password is correct and has not been revoked.' };
-      }
-      return { success: false, error: `Unexpected response: ${res.status}${res.statusText ? ' ' + res.statusText : ''}` };
-    },
-    configFields: [
-      { key: 'username', label: 'Email', type: 'text', placeholder: 'you@example.com' },
-      { key: 'appPassword', label: 'App Password', type: 'password', placeholder: 'your-app-password' },
-    ],
-    helpText: 'Go to Koofr → Preferences → App passwords → New app password. Use your Koofr email as the username. Note: sync works on the Android app (direct connection); the web app may be blocked by Koofr\'s server-side restrictions.',
-  },
-  webdav: {
-    name: 'Generic WebDAV',
-    getFileUrl: (config) =>
-      `${config.webdavUrl.replace(/\/+$/, '')}/dayglance-sync.json`,
-    getDirUrl: (config) =>
-      `${config.webdavUrl.replace(/\/+$/, '')}/`,
-    getAuthHeaders: (config) => ({
-      'X-WebDAV-Auth': 'Basic ' + toBase64(config.username + ':' + config.appPassword)
-    }),
-    async upload(config, data, etag = null) {
-      const fileUrl = this.getFileUrl(config);
-      const dirUrl = this.getDirUrl(config);
-      const authHeaders = this.getAuthHeaders(config);
-      const payload = config.encryptionEnabled ? await encryptData(data) : data;
-      const body = JSON.stringify(payload);
-      const extraHeaders = { 'Content-Type': 'application/json' };
-      if (etag) extraHeaders['If-Match'] = etag;
-      const doUpload = () =>
-        webdavFetch('PUT', fileUrl, authHeaders, body, extraHeaders);
-      let res = await doUpload();
-      if (res.status === 404 || res.status === 409) {
-        await mkcolWithParents(dirUrl, authHeaders);
-        res = await doUpload();
-      }
-      if (res.status === 403) throw new Error('FORBIDDEN');
-      if (res.status === 412) throw new Error('PRECONDITION_FAILED');
-      if (!res.ok) throw new Error(`Upload failed: ${res.status} ${res.statusText}`);
-      return true;
-    },
-    async download(config) {
-      const fileUrl = this.getFileUrl(config);
-      const authHeaders = this.getAuthHeaders(config);
-      const res = await webdavFetch('GET', fileUrl, authHeaders);
-      if (res.status === 404) return null;
-      if (res.status === 403) throw new Error('FORBIDDEN');
-      if (!res.ok) throw new Error(`Download failed: ${res.status} ${res.statusText}`);
-      return parseDownloadResponse(res);
-    },
-    async test(config) {
-      // GET the sync file rather than PROPFIND — Apache mod_dav and other strict
-      // servers return 400 for a bodyless PROPFIND (RFC 4918 requires XML body).
-      // 404 = server reachable but no sync file yet (expected on first use).
-      // 200 = file already exists. Both mean credentials and URL are good.
-      const fileUrl = this.getFileUrl(config);
-      const authHeaders = this.getAuthHeaders(config);
-      const res = await webdavFetch('GET', fileUrl, authHeaders);
-      if (res.status === 200 || res.status === 404) return { success: true };
-      if (res.status === 401) return { success: false, error: 'Invalid credentials. Check your username and password.' };
-      if (res.status === 403) return { success: false, error: 'Access forbidden (403). Check that the WebDAV URL and path are correct.' };
-      return { success: false, error: `Unexpected response: ${res.status}${res.statusText ? ' ' + res.statusText : ''}` };
-    },
-    configFields: [
-      { key: 'webdavUrl', label: 'WebDAV URL', type: 'url', placeholder: 'https://dav.example.com/dayGLANCE/' },
-      { key: 'username', label: 'Username', type: 'text', placeholder: 'your-username' },
-      { key: 'appPassword', label: 'Password / App Password', type: 'password', placeholder: 'your-password' }
-    ],
-    helpText: 'Enter the full URL of the WebDAV folder where dayGLANCE should store its sync file. pCloud, Seafile, and most self-hosted WebDAV providers are supported.'
-  }
-};
+// webdavFetch is used directly by App.jsx for CalDAV/ICS requests.
+// Unwrap the curried factory so callers get the same (method, url, ...) signature.
+export const webdavFetch = _webdavFetch(dayGlanceEngineConfig);


### PR DESCRIPTION
## Summary

- Replaces `src/utils/cloudSyncProviders.js` (~275 lines of inline implementation) with a 44-line re-export shim from `@glance-apps/sync@0.4.0`
- Bumps `@glance-apps/sync` dependency from `^0.3.0` to `^0.4.0`

## What moved to the package

`src/providers.js` in `glance-sync` with five parameterizations per EXTRACTION_PLAN.md §4.1:

1. **`nativeHttpRequest`** — removed import from `native.js`; Android HTTP bridge injected via `config.nativeHttpRequest`
2. **`electronProxyFetch`** — `window.electronAPI?.isElectron` detection → `config.electronProxyFetch != null`
3. **Paths** — `dayglance/dayglance-sync.json` → `${appFolderName}/${syncFilename}` across all three providers (Nextcloud, Koofr, Generic WebDAV)
4. **Koofr 403 detection** — `!!window.DayGlanceNative` → `engineConfig.nativeHttpRequest != null`
5. **`webdavFetch`** — becomes a curried factory `webdavFetch(config) → async fn`; `createProviders(engineConfig)` bakes transport config at creation time

## Shim design

`dayGlanceEngineConfig` pins all dayGLANCE-specific values. The iOS exclusion guard (`!window.DayGlanceIOS`) is applied before passing `nativeHttpRequest` so iOS correctly falls through to the Vercel proxy — same logic as the original `webdavFetch`.

`webdavFetch` is exported as the **unwrapped plain async function** (factory consumed at module load), so App.jsx's CalDAV/ICS callers (`webdavFetch('GET', url, headers, ...)`) work without any changes.

## Behavior note: Koofr 403 on iOS

The original code checked `!!window.DayGlanceNative` to select the 403 error message, which was truthy on iOS due to the `DayGlanceNative` Proxy. The new code checks `nativeHttpRequest != null`, which is `false` on iOS.

**Result:** iOS users hitting a Koofr 403 now see "Koofr is blocking requests from the web app's server. Use the Android app" instead of "Access forbidden. Check that your app password is correct." The new message is accurate — iOS goes through the Vercel proxy, which Koofr blocks. The original message was a Proxy detection bug.

## Verification

- 156/156 dayGLANCE tests passing
- Vite build clean
- Nextcloud and Generic WebDAV: connection test, upload, and download verified
- `@glance-apps/sync@0.4.0` ships 34 new provider tests (88 total in package)

https://claude.ai/code/session_016RrK45oXimySzpbhAVBtjJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016RrK45oXimySzpbhAVBtjJ)_