### PR TITLE
chore: bump to 2.10.0 (Android versionCode 86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Your day, at a glance.** A privacy-first day planner with visual time-blocking, deep integrations, and zero lock-in. Use it free at [dayglance.app](https://dayglance.app) or self-host it on your own server. Your data stays on your device — nothing is ever sent to a server unless you choose to sync it yourself.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.9.5-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-2.10.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases) · [**Android APK**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 85
-        versionName = "2.9"
+        versionCode = 86
+        versionName = "2.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "2.9.5",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "2.9.5",
+      "version": "2.10.0",
       "dependencies": {
         "@glance-apps/sync": "^1.0.0",
         "lucide-react": "^0.564.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "2.9.5",
+  "version": "2.10.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- `package.json` / `package-lock.json`: `2.9.5` → `2.10.0`
- `dayglance-android/app/build.gradle.kts`: `versionCode` `85` → `86`, `versionName` `"2.9"` → `"2.10"`
- `README.md`: version badge `2.9.5` → `2.10.0`

First minor release after the `@glance-apps/sync` extraction landed (PR #828).

## Test plan

- [x] `npm install` clean (lockfile updated)
- [ ] CI builds web + Android successfully on the bumped version

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4PdLKTLCMfEkxiRVC9Bxw)_