### PR TITLE
fix: wire nativeHttpRequest to iOS in sync adapter

### DIFF
--- a/src/sync/adapter.js
+++ b/src/sync/adapter.js
@@ -10,9 +10,8 @@
 import { createSyncEngine, mergeSyncData } from '@glance-apps/sync';
 import { nativeHttpRequest } from '../native.js';
 
-const isAndroid =
+const isNativeApp =
   typeof window !== 'undefined' &&
-  !window.DayGlanceIOS &&
   !!window.DayGlanceNative?.httpRequest;
 
 const electronProxyFetch =
@@ -30,16 +29,16 @@ const DAYGLANCE_CONFIG = {
   appId:                'dayglance',
   appName:              'dayGLANCE',
 
-  nativeHttpRequest: isAndroid ? nativeHttpRequest : null,
+  nativeHttpRequest: isNativeApp ? nativeHttpRequest : null,
   electronProxyFetch,
   proxyUrl: import.meta.env.VITE_WEBDAV_PROXY_URL ?? '',
 
   nativeGetSyncKey:
-    isAndroid && window?.DayGlanceNative?.getSyncKey
+    isNativeApp && window?.DayGlanceNative?.getSyncKey
       ? () => window.DayGlanceNative.getSyncKey()
       : null,
   nativeStoreSyncKey:
-    isAndroid && window?.DayGlanceNative?.storeSyncKey
+    isNativeApp && window?.DayGlanceNative?.storeSyncKey
       ? (val) => window.DayGlanceNative.storeSyncKey(val)
       : null,
 };


### PR DESCRIPTION
## Summary

- `adapter.js` was gating `nativeHttpRequest` behind an `isAndroid` check that explicitly excluded iOS (`!window.DayGlanceIOS`)
- On iOS the engine fell back to plain `fetch()` from the `dayglance://` custom scheme, which WKWebView blocks — producing "Load Failed" when entering WebDAV credentials
- Renamed `isAndroid` → `isNativeApp` and dropped the iOS exclusion so both Android and iOS use the native HTTP bridge for WebDAV sync

## Test plan

- [ ] Enter WebDAV credentials on iOS — should connect successfully instead of "Load Failed"
- [ ] Verify sync works end-to-end on iOS (initial pull, push after a change)
- [ ] Verify WebDAV sync still works on Android (no regression)
- [ ] Verify WebDAV sync still works on web/PWA (falls back to direct fetch as before)

https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK)_