### PR TITLE
fix: prevent text selection on encryption checkbox label on iOS

### DIFF
--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -101,7 +101,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
 
       {/* Encryption section */}
       <div className={`border-t ${borderClass} pt-4 space-y-3`}>
-        <label className="flex items-center gap-3 cursor-pointer">
+        <label className="flex items-center gap-3 cursor-pointer select-none">
           <input
             type="checkbox"
             checked={encryptionEnabled}
@@ -110,7 +110,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
               setPassphrase('');
               setPassphraseConfirm('');
             }}
-            className="w-4 h-4 rounded"
+            className="w-5 h-5 rounded flex-shrink-0"
           />
           <span className={`text-sm font-medium ${textPrimary}`}>Enable end-to-end encryption</span>
         </label>


### PR DESCRIPTION
## Summary

- On iOS, tapping near the "Enable end-to-end encryption" label was triggering text selection on nearby content rather than toggling the checkbox
- Added `select-none` to the label element to prevent the text selection behaviour
- Bumped checkbox size from `w-4 h-4` to `w-5 h-5` for a more comfortable touch target on iPad/iPhone

## Test plan

- [ ] Tap the encryption checkbox on iOS — should toggle cleanly without text selection
- [ ] Verify behaviour unchanged on desktop/web

https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK)_