### PR TITLE
fix: fix cursor misalignment in passphrase inputs on iOS

### DIFF
--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -87,7 +87,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
             placeholder={field.placeholder}
             value={formData[field.key] || ''}
             onChange={(e) => setFormData(prev => ({ ...prev, [field.key]: e.target.value }))}
-            className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+            className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
           />
           {field.type === 'password' && (
             <p className={`text-xs ${textSecondary} mt-0.5`}>Stored in browser localStorage — keep your device secure.</p>
@@ -137,7 +137,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
                 placeholder={passphraseRequired ? 'Choose a strong passphrase' : 'Re-enter to re-authenticate'}
                 value={passphrase}
                 onChange={(e) => setPassphrase(e.target.value)}
-                className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+                className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
               />
             </div>
 
@@ -149,7 +149,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
                   placeholder="Re-enter your passphrase"
                   value={passphraseConfirm}
                   onChange={(e) => setPassphraseConfirm(e.target.value)}
-                  className={`w-full px-3 py-2 border ${passphraseMismatch ? 'border-red-500' : borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+                  className={`w-full px-3 py-2 border ${passphraseMismatch ? 'border-red-500' : borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
                 />
                 {passphraseMismatch && (
                   <p className="text-xs text-red-500 mt-0.5">Passphrases do not match.</p>


### PR DESCRIPTION
## Summary

- iOS WebKit applies its own inner padding and line-height to `<input>` elements that conflicts with Tailwind's `py-2`, pushing the cursor off-centre
- Added `appearance-none` (strips WebKit default styling), `leading-normal` (explicit line-height), and `text-base` (16px — also prevents iOS auto-zoom on focus) to all three text/password inputs in `CloudSyncSettingsForm`

## Test plan

- [ ] Tap into the WebDAV URL / password fields — cursor should sit centred in the input
- [ ] Tap into the sync passphrase and confirm passphrase fields — same
- [ ] Verify inputs look unchanged on desktop/web

https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK)_