### PR TITLE
fix: remove DispatchQueue.main.sync deadlock in AudioBridge

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/AudioBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/AudioBridge.swift
@@ -18,65 +18,59 @@ final class AudioBridge {
     /// Activates the record audio session, creates the recorder, and starts capture.
     /// Returns "ok" on success or {"error":"…"} on failure.
     func startRecording() -> String {
-        var result = "ok"
-        DispatchQueue.main.sync {
-            do {
-                let session = AVAudioSession.sharedInstance()
-                try session.setCategory(.record, mode: .default)
-                try session.setActive(true)
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.record, mode: .default)
+            try session.setActive(true)
 
-                let url = FileManager.default.temporaryDirectory
-                    .appendingPathComponent("dayglance_voice.m4a")
-                recordingURL = url
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("dayglance_voice.m4a")
+            recordingURL = url
 
-                let settings: [String: Any] = [
-                    AVFormatIDKey:         Int(kAudioFormatMPEG4AAC),
-                    AVSampleRateKey:       16000.0,
-                    AVEncoderBitRateKey:   32000,
-                    AVNumberOfChannelsKey: 1,
-                ]
+            let settings: [String: Any] = [
+                AVFormatIDKey:         Int(kAudioFormatMPEG4AAC),
+                AVSampleRateKey:       16000.0,
+                AVEncoderBitRateKey:   32000,
+                AVNumberOfChannelsKey: 1,
+            ]
 
-                let rec = try AVAudioRecorder(url: url, settings: settings)
-                rec.prepareToRecord()
+            let rec = try AVAudioRecorder(url: url, settings: settings)
+            rec.prepareToRecord()
 
-                guard rec.record() else {
-                    // record() returns false when permission is denied; iOS shows
-                    // the system dialog automatically on the first attempt.
-                    result = #"{"error":"Could not start recording — grant microphone access in Settings and try again"}"#
-                    return
-                }
-                recorder = rec
-            } catch {
-                result = #"{"error":"\#(esc(error.localizedDescription))"}"#
+            guard rec.record() else {
+                // record() returns false when permission is denied; iOS shows
+                // the system dialog automatically on the first attempt.
+                return #"{"error":"Could not start recording — grant microphone access in Settings and try again"}"#
             }
+            recorder = rec
+            return "ok"
+        } catch {
+            return #"{"error":"\#(esc(error.localizedDescription))"}"#
         }
-        return result
     }
 
     /// Stops the recorder, restores the ambient audio session, and returns the
     /// captured audio as a data:audio/mp4;base64,… string (matching Android).
     /// Returns {"error":"…"} if no recording is active or if file I/O fails.
     func stopRecording() -> String {
-        var result = #"{"error":"no active recording"}"#
-        DispatchQueue.main.sync {
-            guard let rec = recorder, let url = recordingURL else { return }
-            rec.stop()
-            recorder = nil
-            recordingURL = nil
-
-            // Restore ambient session so background audio can resume.
-            try? AVAudioSession.sharedInstance().setCategory(.ambient, mode: .default)
-            try? AVAudioSession.sharedInstance().setActive(true)
-
-            do {
-                let data = try Data(contentsOf: url)
-                try? FileManager.default.removeItem(at: url)
-                result = "data:audio/mp4;base64,\(data.base64EncodedString())"
-            } catch {
-                result = #"{"error":"\#(esc(error.localizedDescription))"}"#
-            }
+        guard let rec = recorder, let url = recordingURL else {
+            return #"{"error":"no active recording"}"#
         }
-        return result
+        rec.stop()
+        recorder = nil
+        recordingURL = nil
+
+        // Restore ambient session so background audio can resume.
+        try? AVAudioSession.sharedInstance().setCategory(.ambient, mode: .default)
+        try? AVAudioSession.sharedInstance().setActive(true)
+
+        do {
+            let data = try Data(contentsOf: url)
+            try? FileManager.default.removeItem(at: url)
+            return "data:audio/mp4;base64,\(data.base64EncodedString())"
+        } catch {
+            return #"{"error":"\#(esc(error.localizedDescription))"}"#
+        }
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

- `WKURLSchemeHandler` callbacks run on the main thread
- `AudioBridge.startRecording` and `stopRecording` were calling `DispatchQueue.main.sync` from within that callback — instant deadlock, freezing the app whenever the mic button was pressed
- `AVAudioSession` and `AVAudioRecorder` don't require main-thread access, so the dispatch was unnecessary and has been removed from both methods

## Test plan

- [ ] Tap mic button — app should not freeze
- [ ] Microphone permission prompt should appear on first use
- [ ] Record a voice input and confirm it's sent to AI for parsing

https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK)_