### PR TITLE
fix: use m4a extension for iOS native audio transcription

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -263,7 +263,11 @@ async function _aiTranscribe(audioBlob, config) {
     case 'openai':
     case 'custom': {
       const base = provider === 'custom' ? (config.baseUrl || '') : 'https://api.openai.com/v1';
-      const ext = audioBlob.type?.includes('mp4') ? 'mp4' : 'webm';
+      // m4a is AAC-in-MP4 (what iOS records); Whisper accepts it explicitly.
+      // audio/mp4 blobs from the native bridge are m4a, not generic mp4 video.
+      const ext = audioBlob.type?.includes('m4a') ? 'm4a'
+                : audioBlob.type?.includes('mp4') ? 'm4a'
+                : 'webm';
       const formData = new FormData();
       formData.append('file', audioBlob, `recording.${ext}`);
       formData.append('model', 'whisper-1');

--- a/src/native.js
+++ b/src/native.js
@@ -400,7 +400,7 @@ export const nativeStopRecording = () => {
   const bytes = atob(base64);
   const arr = new Uint8Array(bytes.length);
   for (let i = 0; i < bytes.length; i++) arr[i] = bytes.charCodeAt(i);
-  return new Blob([arr], { type: 'audio/mp4' });
+  return new Blob([arr], { type: 'audio/m4a' });
 };
 
 // ── Focus mode ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- iOS `AudioBridge` records AAC audio in an M4A container (`.m4a`)
- The blob was typed as `audio/mp4` and uploaded to Whisper as `recording.mp4`, which OpenAI rejected with "not a supported file format"
- Changed the MIME type in `native.js` to `audio/m4a` and updated the extension logic in `ai.js` to send `recording.m4a` — which Whisper explicitly supports

## Test plan

- [ ] Tap mic on iOS with OpenAI configured — transcription should succeed
- [ ] Web/desktop recording (webm) should be unaffected

https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK)_