### PR TITLE
fix: don't gate iCloud sync on WebDAV engine's isSyncing() state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1369,9 +1369,11 @@ const DayPlanner = () => {
     const onMac = !onIOS && isElectronMac();
     if (!onIOS && !onMac) return;
     if (!dataLoaded) return;
-    // Serialise with both the iCloud lock (set below) and the WebDAV engine's
-    // internal lock so the two transports don't trample each other.
-    if (cloudSyncInProgressRef.current || cloudSyncEngineRef.current?.isSyncing()) {
+    // iCloud and WebDAV are independent transports — don't gate iCloud on the
+    // WebDAV engine's isSyncing() state. If WebDAV is stuck in a retry loop
+    // (e.g. persistent 412), iCloud sync would be permanently blocked.
+    // cloudSyncInProgressRef is the iCloud-only mutex; it's sufficient here.
+    if (cloudSyncInProgressRef.current) {
       iCloudPendingRef.current = true;
       return;
     }


### PR DESCRIPTION
## Summary

`iCloudSync` was checking `cloudSyncEngineRef.current?.isSyncing()` before running. If the WebDAV engine gets stuck in a persistent retry loop (e.g. repeated 412 PRECONDITION_FAILED from Nextcloud), `isSyncing()` stays true indefinitely — and every iCloud sync attempt on Mac silently bails out. Result: Mac never writes to the iCloud container, iOS reads stale data from hours ago.

iCloud and WebDAV are independent transports writing to different files. `cloudSyncInProgressRef` is the correct iCloud-only mutex. Removed the WebDAV engine dependency.

## Test plan

- [ ] With WebDAV configured but erroring (412), iCloud sync should still run every 15 seconds on Mac
- [ ] Mac changes should appear on iPad within ~15s regardless of WebDAV state
- [ ] No regression when WebDAV is healthy

https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK)_