### PR TITLE
fix: write iCloud sync file in-place to preserve bird xattrs

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -304,11 +304,13 @@ ipcMain.handle('icloud:write', (_event, json: string) => {
   try {
     const dir = path.dirname(ICLOUD_SYNC_PATH);
     fs.mkdirSync(dir, { recursive: true });
-    // Atomic write: write to a temp file then rename so the iCloud daemon never
-    // picks up a partially-written file.
-    const tmp = ICLOUD_SYNC_PATH + '.tmp';
-    fs.writeFileSync(tmp, json, { encoding: 'utf-8' });
-    fs.renameSync(tmp, ICLOUD_SYNC_PATH);
+    // Write in-place rather than using a temp-file + rename.
+    // rename(2) replaces the destination inode, stripping the iCloud extended
+    // attributes that bird attached when it last downloaded the file. Without
+    // those xattrs bird does not recognise the file as needing re-upload.
+    // Writing to the existing fd preserves the inode (and all xattrs) so bird
+    // sees a normal modification event and queues the upload.
+    fs.writeFileSync(ICLOUD_SYNC_PATH, json, { encoding: 'utf-8' });
     lastMacOSWriteTime = Date.now();
     return true;
   } catch { return false; }


### PR DESCRIPTION
## Summary

Mac changes were never reaching iOS because the Electron app's "atomic write" was silently breaking iCloud sync at the OS level.

The old write path was:
```
writeFileSync(path + '.tmp', json)
renameSync(path + '.tmp', path)
```

`rename(2)` replaces the destination inode entirely. The iCloud daemon (`bird`) attaches extended attributes to files it has downloaded — these xattrs are how it tracks which files need re-uploading. Replacing the inode strips those xattrs, so `bird` sees the file but has no record of it being an iCloud-managed item, and never queues it for upload. This is why `brctl log -w` showed zero activity for `dayglance-sync.json` even after the file was clearly being written.

The fix writes directly to the existing file path, preserving the inode and all its xattrs. `bird` then receives a normal FSEvents modification notification and uploads the change as expected.

## Test plan

- [ ] Rebuild and run Electron app on Mac
- [ ] Add a task on Mac
- [ ] `brctl log -w | grep dayglance-sync` should now show upload activity within ~15 seconds
- [ ] The task should appear on iPad within ~30 seconds

https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK)_