### PR TITLE
fix: force iCloud download before reading sync file on iOS

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
@@ -22,11 +22,14 @@ final class ICloudBridge {
     // MARK: - Public API
 
     /// Returns the sync file JSON, "null" if unavailable/not yet downloaded,
+    /// {"downloading":true} if a fresher version is being fetched from iCloud,
     /// or {"error":"…"} if iCloud is not signed in.
     ///
-    /// Uses NSFileCoordinator for the actual read so iCloud refreshes the local
-    /// copy from the cloud before we read it — without this, iOS can serve a
-    /// stale cached version even when the Mac has written a newer one.
+    /// NSFileCoordinator alone does not force iCloud to pull a newer remote
+    /// version when a local copy already exists — it only serialises against
+    /// in-flight operations the local daemon is already aware of. We therefore
+    /// always call startDownloadingUbiquitousItem and only return file bytes
+    /// once the downloading status reports .current.
     func readSync() -> String {
         guard let container = containerURL() else {
             return #"{"error":"iCloud not available"}"#
@@ -48,8 +51,18 @@ final class ICloudBridge {
             return "null"
         }
 
-        // Coordinated read: iCloud will freshen the local copy from the server
-        // before our read block executes, ensuring we get the latest version.
+        // Always ask the daemon to pull the latest version. No-op if already current.
+        try? FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+
+        // If a newer remote version exists, the status will be .downloaded
+        // (older bytes cached) rather than .current. Returning the cached bytes
+        // would serve stale data, so signal the caller to retry instead.
+        let status = (try? fileURL.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey]))?
+            .ubiquitousItemDownloadingStatus
+        if let status, status != .current {
+            return #"{"downloading":true}"#
+        }
+
         var result = "null"
         var coordError: NSError?
         let coordinator = NSFileCoordinator()
@@ -128,6 +141,14 @@ final class ICloudBridge {
         if let lastWrite = lastLocalWriteDate,
            Date().timeIntervalSince(lastWrite) < writeSuppressionInterval {
             return
+        }
+        // Kick off a download for the changed file before notifying JS — otherwise
+        // readSync() will see "file exists, no placeholder" and return cached bytes
+        // from the previous version. The download is async; readSync() gates on
+        // ubiquitousItemDownloadingStatus and will return {"downloading":true}
+        // until the new bytes arrive, prompting JS to retry on its next poll.
+        if let container = containerURL() {
+            try? FileManager.default.startDownloadingUbiquitousItem(at: syncFileURL(in: container))
         }
         // Fire the same notification that scenePhase foreground transitions use,
         // so the JS sync cycle runs immediately without waiting for the 60-second poll.


### PR DESCRIPTION
## Summary

Mac→iOS iCloud sync was returning stale data because `readSync()` had no path that forces iCloud to pull a newer remote version when a local copy already exists.

The three branches of `readSync()`:
1. `.filename.icloud` placeholder present → `startDownloadingUbiquitousItem` + `{"downloading":true}` ✅
2. File missing entirely → `startDownloadingUbiquitousItem` + `null` ✅
3. **File exists locally → coordinated read of whatever bytes are cached** ❌

Branch 3 is the steady state after the first successful download. `NSFileCoordinator` only serialises against in-flight operations the local daemon is already aware of — it does not poll iCloud or freshen the local cache. So once iOS has cached any version of the file, every subsequent `readSync()` returned those same bytes regardless of what the Mac later wrote to the cloud.

This was visible from JS as `JSON.parse(readICloudSync()).downloading === undefined` even after a confirmed Mac-side write — meaning we never hit either of the `{"downloading":true}` branches and just served stale cache.

## Fix

Both halves of the same bug, in `ICloudBridge.swift`:

1. **`readSync()`** now always calls `startDownloadingUbiquitousItem(at:)` and checks `URLResourceKey.ubiquitousItemDownloadingStatusKey`. If a newer remote version is in flight (status `.downloaded`, not `.current`), it returns `{"downloading":true}` and lets the JS poll retry rather than serving stale bytes.
2. **`handleQueryUpdate()`** kicks off the same download before posting `.dayGlanceForeground`, so the JS sync triggered by a remote-change notification actually sees fresh bytes (or trips the downloading gate above) rather than the previously-cached version.

JS side is unchanged — `App.jsx:1425` already handles `remote?.downloading` by skipping the cycle and waiting for the next poll.

## Test plan

- [ ] Build iOS app, install on iPhone/iPad
- [ ] Add a task on Mac
- [ ] Within ~30s, task appears on iOS without backgrounding/foregrounding the app
- [ ] Bring iOS app to foreground after a Mac edit — change appears immediately (or on the next 15s poll if still downloading)
- [ ] Reverse direction (iOS→Mac) still works
- [ ] `cloudSyncStatus === 'downloading'` is briefly visible in the header when a remote pull is in progress

## Out of scope

- The Electron `rename(2)`-vs-in-place-write change from #843. Worth verifying separately with `brctl log -w | grep dayglance-sync` on Mac after a write — if `bird` logs the upload cleanly, #843 is unnecessary.

https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01A49ERfWjJbbmdC2KuzsNcM)_