### PR TITLE
fix: throttle iCloud writes to prevent CloudKit conflict storm

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1348,11 +1348,21 @@ const DayPlanner = () => {
   // Uses the same cloudSyncInProgressRef lock to serialise with WebDAV.
   const iCloudSyncRef = useRef(null);
   const iCloudAvailableRef = useRef(null); // null=unchecked, true/false=result
+  const iCloudLastWriteAtRef = useRef(0);
 
   const isElectronMac = () =>
     !!(window.electronAPI?.isElectron && window.electronAPI?.platform === 'darwin');
 
+  // Bird's full round-trip (local write → CloudKit upload → server-truth sync-down)
+  // takes ~5-10 s on a healthy link. Writing faster than that piles new conflict
+  // versions onto the CloudKit document zone, because each upload races bird's
+  // pending sync-down ACK. Skip writes inside this window — the 15 s poll
+  // re-runs the merge and writes any genuinely-deferred changes on the next tick.
+  const ICLOUD_WRITE_THROTTLE_MS = 5000;
+
   const iCloudWriteSync = async (onIOS, payloadStr) => {
+    if (Date.now() - iCloudLastWriteAtRef.current < ICLOUD_WRITE_THROTTLE_MS) return;
+    iCloudLastWriteAtRef.current = Date.now();
     if (onIOS) {
       try {
         const r = JSON.parse(window.DayGlanceNative.writeICloudSync(payloadStr));


### PR DESCRIPTION
## Summary

`brctl log -w` confirmed that bird **is** uploading `dayglance-sync.json` correctly after #843 (the earlier "radio silence" reading was a false negative from `grep`-filtering against `<private>`-redacted log lines). The remaining symptom — fresh Mac edits not appearing on iOS even with #844 in place — turned out to be a CloudKit conflict storm.

Sequence from the bird log:

1. Renderer writes `dayglance-sync.json` (15 s poll or `icloud:changed` event).
2. fs.watch fires, the 2 s `ICLOUD_WRITE_SUPPRESSION_MS` suppresses our own self-echo. ✅
3. Bird uploads. Round-trip + sync-down ACK lands ~5-10 s later.
4. That ACK rewrites the file on disk → fs.watch fires *outside* the 2 s window → renderer sends another `icloud:changed`.
5. Renderer reads, merges, finds a delta (timestamps, ordering, anything non-idempotent), writes again.
6. Each new write races bird's still-in-flight previous ACK → CloudKit creates another conflict version.

Visible in the FP snapshot mutation lines as `nsattr:<… conflict ul:uploading … conflicts:<sver: cver:CgN4eG8=, sver: cver:CgN6MDg=, sver: cver:CgN6Zzc=, …(many more)…>>`. Once the chain is long enough, the version CloudKit serves to iOS isn't necessarily the newest local one — which is exactly what made iOS look stale even after the #844 download fix landed.

## Fix

Leading-edge throttle on `iCloudWriteSync`: at most one write per 5 s. First write goes through immediately; subsequent calls inside the window are dropped. The existing 15 s poll re-runs the merge on the next tick, so any genuinely-deferred change still lands ~15 s later.

5 s is chosen to comfortably exceed bird's typical round-trip so an inbound `icloud:changed` triggered by our own ACK can't immediately schedule another write.

## Recovery

Existing files already in conflict state will recover on their own as writes slow down — bird eventually collapses the chain. To clear it instantly on a single Mac:

```
rm ~/Library/Mobile\ Documents/iCloud~com~dayglance/Documents/dayglance-sync.json
```

The next sync cycle re-seeds from local state, and the iCloud zone gets a clean record.

## Test plan

- [ ] Build Electron app
- [ ] Add several tasks in rapid succession on Mac
- [ ] `brctl log -w` shows at most one upload per ~5 s, no growing `conflicts:<…>` list on the FP snapshot lines
- [ ] iPad sees those tasks within ~15-30 s
- [ ] iOS edits still propagate to Mac promptly (the throttle doesn't apply to reads, just writes)

## Out of scope

- The merge function's idempotence. `mergeSyncData` returning `localChanged || remoteChanged === true` for what should be a no-op round-trip is a separate latent issue — the throttle doesn't fix it, but it does prevent it from manifesting as a conflict cascade. Worth a follow-up if we see related issues.

https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01A49ERfWjJbbmdC2KuzsNcM)_