### PR TITLE
debug: revert broken Swift instrumentation, add JS-side iCloud logging

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
@@ -32,7 +32,6 @@ final class ICloudBridge {
     /// once the downloading status reports .current.
     func readSync() -> String {
         guard let container = containerURL() else {
-            NSLog("[ICloudDebug] readSync: container unavailable")
             return #"{"error":"iCloud not available"}"#
         }
         let fileURL = syncFileURL(in: container)
@@ -43,14 +42,12 @@ final class ICloudBridge {
             .appendingPathComponent("." + fileURL.lastPathComponent + ".icloud")
         if FileManager.default.fileExists(atPath: placeholderURL.path) {
             try? FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-            NSLog("[ICloudDebug] readSync: placeholder present, returning downloading:true")
             return #"{"downloading":true}"#
         }
 
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             // File doesn't exist locally — request download and signal caller to retry.
             try? FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-            NSLog("[ICloudDebug] readSync: file missing, returning null")
             return "null"
         }
 
@@ -60,24 +57,9 @@ final class ICloudBridge {
         // If a newer remote version exists, the status will be .downloaded
         // (older bytes cached) rather than .current. Returning the cached bytes
         // would serve stale data, so signal the caller to retry instead.
-        let resourceValues = try? fileURL.resourceValues(forKeys: [
-            .ubiquitousItemDownloadingStatusKey,
-            .fileSizeKey,
-            .contentModificationDateKey,
-        ])
-        let status = resourceValues?.ubiquitousItemDownloadingStatus
-        let size = resourceValues?.fileSize ?? -1
-        let mtime = resourceValues?.contentModificationDate
-            .map { ISO8601DateFormatter().string(from: $0) } ?? "?"
-        let statusStr: String
-        switch status {
-        case .current:       statusStr = "current"
-        case .downloaded:    statusStr = "downloaded"
-        case .notDownloaded: statusStr = "notDownloaded"
-        default:             statusStr = "unknown"
-        }
+        let status = (try? fileURL.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey]))?
+            .ubiquitousItemDownloadingStatus
         if let status, status != .current {
-            NSLog("[ICloudDebug] readSync: status=\(statusStr) size=\(size) mtime=\(mtime) → downloading:true")
             return #"{"downloading":true}"#
         }
 
@@ -90,12 +72,8 @@ final class ICloudBridge {
             result = str
         }
         if let err = coordError {
-            NSLog("[ICloudDebug] readSync: coordError=\(err.localizedDescription)")
             return "{\"error\":\"\(esc(err.localizedDescription))\"}"
         }
-        let zzztest = result.contains("ZZZTEST")
-        let bytes = result.utf8.count
-        NSLog("[ICloudDebug] readSync: status=\(statusStr) fileSize=\(size) readBytes=\(bytes) mtime=\(mtime) containsZZZTEST=\(zzztest)")
         return result
     }
 
@@ -158,14 +136,12 @@ final class ICloudBridge {
         metadataQuery = q
     }
 
-    @objc private func handleQueryUpdate(_ note: Notification) {
+    @objc private func handleQueryUpdate() {
         // Skip if the change was caused by our own recent write.
         if let lastWrite = lastLocalWriteDate,
            Date().timeIntervalSince(lastWrite) < writeSuppressionInterval {
-            NSLog("[ICloudDebug] queryUpdate(\(note.name.rawValue)): suppressed (own write)")
             return
         }
-        NSLog("[ICloudDebug] queryUpdate(\(note.name.rawValue)): triggering download + foreground")
         // Kick off a download for the changed file before notifying JS — otherwise
         // readSync() will see "file exists, no placeholder" and return cached bytes
         // from the previous version. The download is async; readSync() gates on

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1410,7 +1410,13 @@ const DayPlanner = () => {
         ? window.DayGlanceNative.readICloudSync()
         : await window.electronAPI.readICloud();
 
+      console.log('[iCloudDebug] read:',
+        'len=' + (str?.length ?? 0),
+        'containsZZZTEST=' + !!(str && str.includes('ZZZTEST')),
+        'preview=' + JSON.stringify((str || '').slice(0, 120)));
+
       if (!str || str === 'null') {
+        console.log('[iCloudDebug] read returned null/empty — seed branch');
         // No remote file yet — seed it with local data, but only if state is hydrated.
         // If React state is empty but localStorage has tasks, we'd wipe the cloud file.
         //
@@ -1431,8 +1437,8 @@ const DayPlanner = () => {
       // iCloud file exists but is still downloading from the cloud — skip this
       // cycle and let the 15-second poll retry once it's available locally.
       let remote;
-      try { remote = JSON.parse(str); } catch { return; }
-      if (remote?.downloading) return;
+      try { remote = JSON.parse(str); } catch { console.log('[iCloudDebug] JSON parse failed'); return; }
+      if (remote?.downloading) { console.log('[iCloudDebug] downloading=true, bailing'); return; }
       if (remote?.error) {
         console.error('iCloud unavailable:', remote.error);
         setCloudSyncError(`iCloud unavailable: ${remote.error}`);
@@ -1457,10 +1463,23 @@ const DayPlanner = () => {
           return;
         }
       }
-      if (!remote?.data) return;
+      if (!remote?.data) { console.log('[iCloudDebug] remote.data missing'); return; }
 
       const localData = buildSyncPayload().data;
+      const remoteTaskCount = (remote.data?.tasks?.length || 0) + (remote.data?.unscheduledTasks?.length || 0);
+      const localTaskCount = (localData?.tasks?.length || 0) + (localData?.unscheduledTasks?.length || 0);
+      console.log('[iCloudDebug] pre-merge:',
+        'remoteLastModified=' + remote.lastModified,
+        'remoteTasks=' + remoteTaskCount,
+        'localTasks=' + localTaskCount);
+
       const { data: mergedData, localChanged, remoteChanged } = mergeSyncData(localData, remote.data, syncRetentionDays);
+
+      const mergedTaskCount = (mergedData?.tasks?.length || 0) + (mergedData?.unscheduledTasks?.length || 0);
+      console.log('[iCloudDebug] post-merge:',
+        'localChanged=' + localChanged,
+        'remoteChanged=' + remoteChanged,
+        'mergedTasks=' + mergedTaskCount);
 
       if (localChanged) {
         applyEngineData(mergedData, { allowEmpty: !!remote.lastModified });


### PR DESCRIPTION
## Summary

PR #846's Swift-side NSLog instrumentation broke the iOS app on launch — the scene-update watchdog timed out before the WebView could render (symptom: blank screen, no JS executes, no log lines emitted). Reverting `ICloudBridge.swift` to the pre-#846 state restores normal launch.

Replace that approach with JS-side `console.log` statements in `App.jsx`'s `iCloudSync` function. These run inside the WebView and surface in Safari's Web Inspector when connected to the live iPad app, so they don't touch Swift at all and can't repeat the launch-hang failure mode.

## Logs added

- Raw read result: length, `ZZZTEST` marker presence, first 120 chars
- Bail reasons: null/empty, downloading, parse failure, missing data
- Pre-merge state: remote `lastModified`, remote vs local task counts
- Post-merge state: `localChanged`, `remoteChanged`, merged task count

## Usage

1. Build/install from this branch on the iPad
2. On Mac, add a task titled `ZZZTEST`
3. Connect iPad to Mac, open Safari → **Develop** → [your iPad] → **dayGLANCE**
4. Watch the JS console for `[iCloudDebug]` lines on the next 15 s poll, or trigger immediately by backgrounding and foregrounding the app

Output answers two questions:
- Did iOS read bytes containing `ZZZTEST`? (= did fresh data reach the read path)
- Did the merge keep the new task or drop it? (= is `mergeSyncData` discarding it)

## Cleanup

Revert this commit once the diagnosis is done.

https://claude.ai/code/session_019ZnhUdFRiT2eS6SAr6SHyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01A49ERfWjJbbmdC2KuzsNcM)_