### PR TITLE
revert: remove [iCloudDebug] console logging from iCloudSync

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1410,13 +1410,7 @@ const DayPlanner = () => {
         ? window.DayGlanceNative.readICloudSync()
         : await window.electronAPI.readICloud();
 
-      console.log('[iCloudDebug] read:',
-        'len=' + (str?.length ?? 0),
-        'containsZZZTEST=' + !!(str && str.includes('ZZZTEST')),
-        'preview=' + JSON.stringify((str || '').slice(0, 120)));
-
       if (!str || str === 'null') {
-        console.log('[iCloudDebug] read returned null/empty — seed branch');
         // No remote file yet — seed it with local data, but only if state is hydrated.
         // If React state is empty but localStorage has tasks, we'd wipe the cloud file.
         //
@@ -1437,8 +1431,8 @@ const DayPlanner = () => {
       // iCloud file exists but is still downloading from the cloud — skip this
       // cycle and let the 15-second poll retry once it's available locally.
       let remote;
-      try { remote = JSON.parse(str); } catch { console.log('[iCloudDebug] JSON parse failed'); return; }
-      if (remote?.downloading) { console.log('[iCloudDebug] downloading=true, bailing'); return; }
+      try { remote = JSON.parse(str); } catch { return; }
+      if (remote?.downloading) return;
       if (remote?.error) {
         console.error('iCloud unavailable:', remote.error);
         setCloudSyncError(`iCloud unavailable: ${remote.error}`);
@@ -1463,23 +1457,10 @@ const DayPlanner = () => {
           return;
         }
       }
-      if (!remote?.data) { console.log('[iCloudDebug] remote.data missing'); return; }
+      if (!remote?.data) return;
 
       const localData = buildSyncPayload().data;
-      const remoteTaskCount = (remote.data?.tasks?.length || 0) + (remote.data?.unscheduledTasks?.length || 0);
-      const localTaskCount = (localData?.tasks?.length || 0) + (localData?.unscheduledTasks?.length || 0);
-      console.log('[iCloudDebug] pre-merge:',
-        'remoteLastModified=' + remote.lastModified,
-        'remoteTasks=' + remoteTaskCount,
-        'localTasks=' + localTaskCount);
-
       const { data: mergedData, localChanged, remoteChanged } = mergeSyncData(localData, remote.data, syncRetentionDays);
-
-      const mergedTaskCount = (mergedData?.tasks?.length || 0) + (mergedData?.unscheduledTasks?.length || 0);
-      console.log('[iCloudDebug] post-merge:',
-        'localChanged=' + localChanged,
-        'remoteChanged=' + remoteChanged,
-        'mergedTasks=' + mergedTaskCount);
 
       if (localChanged) {
         applyEngineData(mergedData, { allowEmpty: !!remote.lastModified });


### PR DESCRIPTION
## Summary

PR #847 added JS-side `[iCloudDebug]` `console.log` instrumentation to diagnose Mac→iOS iCloud sync. Diagnosis is complete and sync is confirmed working — removing the debug noise.

## Why sync is now working

Three fixes in combination, plus a one-time cleanup:

- **#843** (Mac in-place write) — the rename-based write was giving the file a new inode on every save, dropping bird's tracking xattrs and forcing it to re-register/re-upload from scratch. In-place writes preserve the xattrs so bird can incrementally sync.
- **#844** (force download + status-gate iOS reads) — `startDownloadingUbiquitousItem` plus checking `ubiquitousItemDownloadingStatus == .current` before returning bytes. Without this, iOS returned cached bytes when a newer remote version existed.
- **#845** (5 s write throttle) — prevents fast successive writes from piling up CloudKit conflict versions on the document zone.
- One-time `rm` of `dayglance-sync.json` — bird couldn't recover from the historical conflict chain on its own, but recreates clean storage with a fresh recordID once the file is gone.

## What the logs revealed (and didn't)

The "`localTasks` stuck below `remoteTasks`" pattern in the captured logs was **not** a bug. `applyEngineData` filters imported calendar events out of `data.tasks` on native iOS (calendar events come from the EventKit bridge, not from sync), so the iOS local count is expected to be lower than the Mac's remote count by however many calendar imports the Mac has.

User confirmed end-to-end: deleted `ZZZTEST`, added `YYYTEST` / `XXXTEST` on Mac, both appeared on iOS almost immediately via the NSMetadataQuery → `dayGlanceForeground` → JS sync path.

## Changes

- Remove `[iCloudDebug]` `console.log` calls from `iCloudSync` in `src/App.jsx`
- No functional changes; fixes from #843, #844, #845 remain in place

## Test plan

- [ ] Build iOS and confirm `[iCloudDebug]` lines no longer appear in Safari Web Inspector
- [ ] Confirm Mac→iOS sync still propagates new tasks within a few seconds of write

https://claude.ai/code/session_01A49ERfWjJbbmdC2KuzsNcM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A49ERfWjJbbmdC2KuzsNcM)_