### PR TITLE
docs: mark Phases 7 and 8 complete

### DIFF
--- a/docs/dayglance-ios-app.md
+++ b/docs/dayglance-ios-app.md
@@ -370,11 +370,15 @@ An iOS Share Extension lets users share text or URLs from any app (Safari, Notes
 - Add `NSPrivacyAccessedAPICategoryFileTimestamp` to `PrivacyInfo.xcprivacy`
 - Enable iCloud capability in App Store Connect for both macOS and iOS app records
 
+**Status: ✅ Complete.** Container ID is `iCloud.com.dayglance`. iOS side implemented in `ICloudBridge.swift` (NSFileCoordinator-coordinated reads, `startDownloadingUbiquitousItem` + `ubiquitousItemDownloadingStatus` gating to avoid stale-cache reads, NSMetadataQuery watch firing `dayGlanceForeground` to wake the JS sync loop). macOS side in `electron/icloud-sync.ts` writes in-place to preserve bird's xattrs (rename-based writes lose tracking and force re-upload from scratch). JS layer adds a 5 s write throttle to prevent CloudKit conflict storms on rapid successive saves. Mac→iOS and iOS→Mac propagation verified within seconds via NSMetadataQuery. Bug fixes: #838, #839, #843, #844, #845, #847, #848.
+
 ### Phase 8 — Audio recording
 
 - `AudioBridge.swift`: `AVAudioRecorder` capturing to `.m4a` (AAC, 16kHz, 32kbps)
 - Returns same `data:audio/mp4;base64,...` string as Android
 - `NSMicrophoneUsageDescription` in Info.plist
+
+**Status: ✅ Complete.**
 
 ### Phase 9 — Subscriptions (StoreKit 2)
 


### PR DESCRIPTION
## Summary

Mark Phases 7 and 8 of the iOS implementation plan complete in `docs/dayglance-ios-app.md`.

- **Phase 7 — iCloud sync (macOS ↔ iOS)**: verified end-to-end. iOS reads via `NSFileCoordinator` + `startDownloadingUbiquitousItem` + `ubiquitousItemDownloadingStatus` gate. macOS writes in-place to preserve bird xattrs. JS adds a 5 s write throttle to prevent CloudKit conflict storms. NSMetadataQuery on iOS fires `dayGlanceForeground` to wake the JS sync loop on remote changes. Linked the chain of bug-fix PRs that took it from broken to working: #838, #839, #843, #844, #845, #847, #848.
- **Phase 8 — Audio recording**: confirmed shipped (already implemented in `AudioBridge.swift`).

## Test plan

- [ ] Render the docs page and confirm both phases show the green-check status line

https://claude.ai/code/session_01A49ERfWjJbbmdC2KuzsNcM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A49ERfWjJbbmdC2KuzsNcM)_