### PR TITLE
Add Health Connect permission rationale screen

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 87
+        versionCode = 88
         versionName = "2.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -126,6 +126,9 @@ dependencies {
     // Google Play Billing
     implementation(libs.billing.ktx)
 
+    // Chrome Custom Tabs — privacy policy link in PermissionsRationaleActivity
+    implementation(libs.browser)
+
     // Testing
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/dayglance-android/app/src/main/AndroidManifest.xml
+++ b/dayglance-android/app/src/main/AndroidManifest.xml
@@ -82,12 +82,21 @@
                 android:resource="@xml/shortcuts" />
         </activity>
 
-        <!-- Health Connect: required so the system can show our permission rationale.
-             Without this alias the PermissionController dialog will not launch. -->
+        <!-- Health Connect rationale screen — Android 13 / standalone Health Connect APK path -->
+        <activity
+            android:name=".PermissionsRationaleActivity"
+            android:exported="true"
+            android:theme="@style/Theme.DayGlance.Settings">
+            <intent-filter>
+                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+            </intent-filter>
+        </activity>
+
+        <!-- Health Connect rationale screen — Android 14+ / built-in Health Connect path -->
         <activity-alias
             android:name="ViewPermissionUsageActivity"
             android:exported="true"
-            android:targetActivity=".MainActivity"
+            android:targetActivity=".PermissionsRationaleActivity"
             android:permission="android.permission.START_VIEW_PERMISSION_USAGE">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />

--- a/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
@@ -1,0 +1,41 @@
+package com.dayglance.app
+
+import android.graphics.Color
+import android.net.Uri
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.browser.customtabs.CustomTabColorSchemeParams
+import androidx.browser.customtabs.CustomTabsIntent
+import com.dayglance.app.databinding.ActivityPermissionsRationaleBinding
+
+class PermissionsRationaleActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityPermissionsRationaleBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityPermissionsRationaleBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        supportActionBar?.apply {
+            title = "Health Connect Permissions"
+            setDisplayHomeAsUpEnabled(true)
+        }
+
+        binding.btnPrivacyPolicy.setOnClickListener {
+            CustomTabsIntent.Builder()
+                .setDefaultColorSchemeParams(
+                    CustomTabColorSchemeParams.Builder()
+                        .setToolbarColor(Color.parseColor("#3b82f6"))
+                        .build()
+                )
+                .build()
+                .launchUrl(this, Uri.parse("https://dayglance.app/privacy"))
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+}

--- a/dayglance-android/app/src/main/res/layout/activity_permissions_rationale.xml
+++ b/dayglance-android/app/src/main/res/layout/activity_permissions_rationale.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Health Connect Permissions"
+            android:textAppearance="?attr/textAppearanceHeadlineSmall"
+            android:layout_marginBottom="12dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="dayGLANCE uses Health Connect to display your daily progress as habit rings on the main day view."
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:layout_marginBottom="28dp" />
+
+        <!-- Steps -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Steps"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:layout_marginBottom="4dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Reads your daily step count to fill the steps habit ring, showing progress toward a daily step goal you set yourself."
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:layout_marginBottom="24dp" />
+
+        <!-- Sleep -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Sleep"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:layout_marginBottom="4dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Reads your most recent sleep session duration to fill the sleep habit ring, showing progress toward a daily sleep duration goal you set yourself."
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:layout_marginBottom="24dp" />
+
+        <!-- How your data is handled -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="How your data is handled"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:layout_marginBottom="8dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="• Health data is read on-device and rendered locally in the app."
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:layout_marginBottom="4dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="• It is never used for analytics, shared with third parties, or written back to Health Connect."
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:layout_marginBottom="4dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="• dayGLANCE has no developer-operated servers, no account system, and no telemetry."
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:layout_marginBottom="4dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="• If you have enabled optional Cloud Sync, habit data is included in the sync payload using zero-knowledge AES-256-GCM encryption. The destination server (which you control) sees only encrypted ciphertext."
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:layout_marginBottom="28dp" />
+
+        <!-- Footer -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Granting Health Connect permissions is entirely optional. dayGLANCE functions normally without them; the habit rings will simply appear empty. You can revoke these permissions at any time through the Health Connect app or your device\'s system settings."
+            android:textAppearance="?attr/textAppearanceBodySmall"
+            android:textColor="@color/colorMutedText"
+            android:layout_marginBottom="28dp" />
+
+        <Button
+            android:id="@+id/btn_privacy_policy"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Read the full privacy policy →"
+            android:layout_marginBottom="8dp" />
+
+    </LinearLayout>
+</ScrollView>

--- a/dayglance-android/app/src/main/res/values-night/colors.xml
+++ b/dayglance-android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="colorMutedText">#94a3b8</color>
+</resources>

--- a/dayglance-android/app/src/main/res/values/colors.xml
+++ b/dayglance-android/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="colorMutedText">#64748b</color>
+</resources>

--- a/dayglance-android/gradle/libs.versions.toml
+++ b/dayglance-android/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ webkit = "1.11.0"
 splashscreen = "1.0.1"
 documentfile = "1.0.1"
 billing = "7.1.1"
+browser = "1.8.0"
 junit = "4.13.2"
 junitExt = "1.2.1"
 espresso = "3.6.1"
@@ -53,6 +54,9 @@ androidx-documentfile = { group = "androidx.documentfile", name = "documentfile"
 
 # Google Play Billing
 billing-ktx = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "billing" }
+
+# Chrome Custom Tabs (Health Connect permission rationale — privacy policy link)
+browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Creates `PermissionsRationaleActivity` — a standalone AppCompat/XML activity explaining exactly how dayGLANCE uses each Health Connect data type (steps and sleep), with a privacy policy link via Chrome Custom Tabs
- Wires the activity to both Health Connect intent paths: `androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE` (Android 13 / standalone HC APK) and `android.intent.action.VIEW_PERMISSION_USAGE` + `HEALTH_PERMISSIONS` category (Android 14+ / built-in HC)
- Adds `androidx.browser:browser:1.8.0` as the only new dependency (Custom Tabs for the privacy policy button)

## Why

Google Play's Health Connect policy requires a dedicated in-app rationale screen that explains per-data-type usage before granting permission. The previous setup had the `ViewPermissionUsageActivity` alias pointing at `MainActivity` (no rationale content), and was missing the Android 13 intent path entirely. This fixes both gaps.

## Changes

| File | Change |
|---|---|
| `PermissionsRationaleActivity.kt` | New activity — ViewBinding, action bar with back, Custom Tab button |
| `activity_permissions_rationale.xml` | ScrollView layout with title, intro, Steps/Sleep sections, data-handling bullets, footer, primary button |
| `values/colors.xml` | New — `colorMutedText #64748b` (light) |
| `values-night/colors.xml` | New — `colorMutedText #94a3b8` (dark) |
| `AndroidManifest.xml` | Added `<activity>` with `ACTION_SHOW_PERMISSIONS_RATIONALE` filter; retargeted `ViewPermissionUsageActivity` alias from `.MainActivity` → `.PermissionsRationaleActivity` |
| `libs.versions.toml` + `build.gradle.kts` | Added `androidx.browser:browser:1.8.0` |

## Test plan

- [ ] `adb shell am start -a androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE -n com.dayglance.app/.PermissionsRationaleActivity` opens the rationale screen directly
- [ ] `adb shell am start -a android.intent.action.VIEW_PERMISSION_USAGE -c android.intent.category.HEALTH_PERMISSIONS -n com.dayglance.app/com.dayglance.app.ViewPermissionUsageActivity` also opens the rationale screen (via alias)
- [ ] Screen renders all copy correctly in light and dark mode
- [ ] "Read the full privacy policy →" button opens `https://dayglance.app/privacy` in a Chrome Custom Tab (not system browser)
- [ ] System back / action bar back closes the screen and returns to caller
- [ ] Existing Health Connect permission grant flow from JS (`requestPermission()`) is unaffected
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS)_