### PR TITLE
Fix health habit added as auto-synced before permission granted

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/HealthBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/HealthBridge.kt
@@ -52,6 +52,10 @@ class HealthBridge(
     }
 
     @JavascriptInterface
+    fun checkPermission(): String =
+        if (runBlocking { repository.hasPermissions() }) "granted" else "denied"
+
+    @JavascriptInterface
     fun requestPermission(): String {
         onRequestPermission()
         return "pending"

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -119,6 +119,9 @@ class NativeBridge(
     fun getSleep(date: String): String = health.getSleep(date)
 
     @JavascriptInterface
+    fun checkHealthPermission(): String = health.checkPermission()
+
+    @JavascriptInterface
     fun requestHealthPermission(): String = health.requestPermission()
 
     // ── Calendar ────────────────────────────────────────────────────────────

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/HealthRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/HealthRepository.kt
@@ -28,6 +28,15 @@ class HealthRepository(context: Context) {
         HealthPermission.getReadPermission(SleepSessionRecord::class),
     )
 
+    suspend fun hasPermissions(): Boolean = withContext(Dispatchers.IO) {
+        val c = client ?: return@withContext false
+        try {
+            c.permissionController.getGrantedPermissions().containsAll(requiredPermissions)
+        } catch (e: Exception) {
+            false
+        }
+    }
+
     suspend fun getSteps(date: LocalDate): Int = withContext(Dispatchers.IO) {
         val c = client ?: return@withContext 0
         val zone = ZoneId.systemDefault()

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -617,6 +617,7 @@ const DayPlanner = () => {
     deleteHabit,
     reorderHabits,
     syncHealthConnectHabitsRef,
+    resolvePendingHealthHabitRef,
     addStepsHabit,
     addSleepHabit,
   } = useHabits({ playUISound });
@@ -1228,7 +1229,10 @@ const DayPlanner = () => {
         // Defer the blocking Health Connect bridge calls (up to 7 × N synchronous
         // @JavascriptInterface calls) to after the next paint so the JS thread isn't
         // blocked mid-render, which shows as a brief blank screen on app resume.
-        requestAnimationFrame(() => setTimeout(() => syncHealthConnectHabitsRef.current?.(), 0));
+        requestAnimationFrame(() => setTimeout(() => {
+          resolvePendingHealthHabitRef.current?.();
+          syncHealthConnectHabitsRef.current?.();
+        }, 0));
       }
     };
     // Native iOS fires a custom event to bypass the document.hidden timing gap
@@ -1239,7 +1243,10 @@ const DayPlanner = () => {
       // engine.download() bypasses its own backoff for these foreground kicks.
       iCloudSyncRef.current?.();
       cloudSyncDownloadRef.current?.();
-      requestAnimationFrame(() => setTimeout(() => syncHealthConnectHabitsRef.current?.(), 0));
+      requestAnimationFrame(() => setTimeout(() => {
+        resolvePendingHealthHabitRef.current?.();
+        syncHealthConnectHabitsRef.current?.();
+      }, 0));
     };
     document.addEventListener('visibilitychange', handleVisibility);
     document.addEventListener('dayglanceForeground', handleNativeForeground);

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -224,38 +224,61 @@ const useHabits = ({ playUISound }) => {
     syncHealthConnectHabitsRef.current?.();
   }, [habits]);
 
-  // Create the steps habit pre-configured for the platform's health bridge.
-  const addStepsHabit = () => {
+  // Habit config pending permission grant. Stored as a full habit object so the
+  // resolve path doesn't have to reconstruct it.
+  const pendingHealthHabitRef = useRef(null);
+
+  // Called on app foreground / visibility-return. If a health habit is pending
+  // (user tapped Add, got the permission dialog, returned), check whether
+  // permission was granted and add the habit only if it was.
+  const resolvePendingHealthHabit = () => {
+    if (!window.DayGlanceNative || !pendingHealthHabitRef.current) return;
+    let granted = false;
+    try {
+      granted = window.DayGlanceNative.checkHealthPermission() === 'granted';
+    } catch (e) { /* bridge method unavailable — treat as denied */ }
+    const config = pendingHealthHabitRef.current;
+    pendingHealthHabitRef.current = null;
+    if (granted) addHabit(config);
+  };
+  const resolvePendingHealthHabitRef = useRef(null);
+  resolvePendingHealthHabitRef.current = resolvePendingHealthHabit;
+
+  const _addHealthHabit = (config) => {
     if (!window.DayGlanceNative) return;
-    // Request permission — stub returns "granted", real impl launches HC/HK permission dialog
-    try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {}
-    addHabit({
-      name: 'Steps',
-      icon: 'Footprints',
-      color: 'green',
-      type: 'doMore',
-      target: 10000,
-      unit: 'steps',
-      source: window.DayGlanceIOS ? 'healthKit' : 'healthConnect',
-      scheduledDays: [0, 1, 2, 3, 4, 5, 6],
-    });
+    let alreadyGranted = false;
+    try {
+      alreadyGranted = window.DayGlanceNative.checkHealthPermission() === 'granted';
+    } catch (e) { /* checkHealthPermission unavailable — fall back to old behaviour */ alreadyGranted = true; }
+    if (alreadyGranted) {
+      addHabit(config);
+    } else {
+      pendingHealthHabitRef.current = config;
+      try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {}
+    }
   };
 
-  // Create the sleep habit pre-configured for the platform's health bridge.
-  const addSleepHabit = () => {
-    if (!window.DayGlanceNative) return;
-    try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {}
-    addHabit({
-      name: 'Sleep',
-      icon: 'Moon',
-      color: 'indigo',
-      type: 'doMore',
-      target: 480,
-      unit: 'min',
-      source: window.DayGlanceIOS ? 'healthKit' : 'healthConnect',
-      scheduledDays: [0, 1, 2, 3, 4, 5, 6],
-    });
-  };
+  const addStepsHabit = () => _addHealthHabit({
+    name: 'Steps',
+    icon: 'Footprints',
+    color: 'green',
+    type: 'doMore',
+    target: 10000,
+    unit: 'steps',
+    source: window.DayGlanceIOS ? 'healthKit' : 'healthConnect',
+    scheduledDays: [0, 1, 2, 3, 4, 5, 6],
+  });
+
+  const addSleepHabit = () => _addHealthHabit({
+    name: 'Sleep',
+    icon: 'Moon',
+    color: 'indigo',
+    type: 'doMore',
+    target: 480,
+    unit: 'min',
+    source: window.DayGlanceIOS ? 'healthKit' : 'healthConnect',
+    scheduledDays: [0, 1, 2, 3, 4, 5, 6],
+  });
 
   return {
     habits, setHabits,
@@ -281,6 +304,7 @@ const useHabits = ({ playUISound }) => {
     deleteHabit,
     reorderHabits,
     syncHealthConnectHabitsRef,
+    resolvePendingHealthHabitRef,
     addStepsHabit,
     addSleepHabit,
   };


### PR DESCRIPTION
## Summary

- `addStepsHabit` / `addSleepHabit` previously fired `requestHealthPermission()` and `addHabit()` in the same tick, so the habit was always created with `source: 'healthConnect'` regardless of whether the user actually granted permission
- Adds a synchronous `checkHealthPermission()` bridge method so JS can query the real grant state before committing to creating the habit
- If permission is already granted: adds the habit immediately. If not: parks the pending config in a ref, shows the permission dialog, and only adds the habit on the next foreground/visibility-return event if the user granted

## Changes

| File | Change |
|---|---|
| `HealthRepository.kt` | `hasPermissions()` — queries `permissionController.getGrantedPermissions()` |
| `HealthBridge.kt` | `checkPermission(): String` — synchronous wrapper returning `"granted"` or `"denied"` |
| `NativeBridge.kt` | `checkHealthPermission()` — `@JavascriptInterface` exposure |
| `useHabits.js` | `_addHealthHabit()` helper, `pendingHealthHabitRef`, `resolvePendingHealthHabit()`, `resolvePendingHealthHabitRef` |
| `App.jsx` | Destructures `resolvePendingHealthHabitRef`; calls it on visibility-return and `dayglanceForeground` events before `syncHealthConnectHabits` |

## Test plan

- [ ] Tap "Add" on the steps suggestion → permission dialog appears → **deny** → return to app → steps habit is NOT added
- [ ] Tap "Add" on the steps suggestion → permission dialog appears → **grant** → return to app → steps habit IS added and immediately shows auto-synced with today's count
- [ ] Tap "Add" when permission is already granted → habit added immediately with no dialog
- [ ] Same three scenarios for sleep habit
- [ ] Existing auto-sync for already-configured health habits is unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS)_