### PR TITLE
Fix rationale screen text rendering and dark mode behaviour

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
@@ -4,8 +4,10 @@ import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
+import com.dayglance.app.data.SharedDataStore
 import com.dayglance.app.databinding.ActivityPermissionsRationaleBinding
 
 class PermissionsRationaleActivity : AppCompatActivity() {
@@ -13,6 +15,12 @@ class PermissionsRationaleActivity : AppCompatActivity() {
     private lateinit var binding: ActivityPermissionsRationaleBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Follow the app's own dark/light setting rather than the system night mode.
+        delegate.localNightMode = when (SharedDataStore(this).appDarkMode) {
+            true  -> AppCompatDelegate.MODE_NIGHT_YES
+            false -> AppCompatDelegate.MODE_NIGHT_NO
+            null  -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+        }
         super.onCreate(savedInstanceState)
         binding = ActivityPermissionsRationaleBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/dayglance-android/app/src/main/res/layout/activity_permissions_rationale.xml
+++ b/dayglance-android/app/src/main/res/layout/activity_permissions_rationale.xml
@@ -13,14 +13,17 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Health Connect Permissions"
-            android:textAppearance="?attr/textAppearanceHeadlineSmall"
+            android:textSize="22sp"
+            android:textStyle="bold"
+            android:textColor="?android:attr/textColorPrimary"
             android:layout_marginBottom="12dp" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="dayGLANCE uses Health Connect to display your daily progress as habit rings on the main day view."
-            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textSize="15sp"
+            android:textColor="?android:attr/textColorPrimary"
             android:layout_marginBottom="28dp" />
 
         <!-- Steps -->
@@ -28,14 +31,17 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Steps"
-            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:textColor="?android:attr/textColorPrimary"
             android:layout_marginBottom="4dp" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Reads your daily step count to fill the steps habit ring, showing progress toward a daily step goal you set yourself."
-            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textSize="15sp"
+            android:textColor="?android:attr/textColorPrimary"
             android:layout_marginBottom="24dp" />
 
         <!-- Sleep -->
@@ -43,14 +49,17 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Sleep"
-            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:textColor="?android:attr/textColorPrimary"
             android:layout_marginBottom="4dp" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Reads your most recent sleep session duration to fill the sleep habit ring, showing progress toward a daily sleep duration goal you set yourself."
-            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textSize="15sp"
+            android:textColor="?android:attr/textColorPrimary"
             android:layout_marginBottom="24dp" />
 
         <!-- How your data is handled -->
@@ -58,43 +67,49 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="How your data is handled"
-            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:textColor="?android:attr/textColorPrimary"
             android:layout_marginBottom="8dp" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="• Health data is read on-device and rendered locally in the app."
-            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textSize="15sp"
+            android:textColor="?android:attr/textColorPrimary"
             android:layout_marginBottom="4dp" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="• It is never used for analytics, shared with third parties, or written back to Health Connect."
-            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textSize="15sp"
+            android:textColor="?android:attr/textColorPrimary"
             android:layout_marginBottom="4dp" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="• dayGLANCE has no developer-operated servers, no account system, and no telemetry."
-            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textSize="15sp"
+            android:textColor="?android:attr/textColorPrimary"
             android:layout_marginBottom="4dp" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="• If you have enabled optional Cloud Sync, habit data is included in the sync payload using zero-knowledge AES-256-GCM encryption. The destination server (which you control) sees only encrypted ciphertext."
-            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textSize="15sp"
+            android:textColor="?android:attr/textColorPrimary"
             android:layout_marginBottom="28dp" />
 
         <!-- Footer -->
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Granting Health Connect permissions is entirely optional. dayGLANCE functions normally without them; the habit rings will simply appear empty. You can revoke these permissions at any time through the Health Connect app or your device\'s system settings."
-            android:textAppearance="?attr/textAppearanceBodySmall"
+            android:text="Granting Health Connect permissions is entirely optional. dayGLANCE functions normally without them. You can revoke these permissions at any time through the Health Connect app or your device\'s system settings."
+            android:textSize="13sp"
             android:textColor="@color/colorMutedText"
             android:layout_marginBottom="28dp" />
 


### PR DESCRIPTION
## Summary

Two bugs in the Health Connect rationale screen introduced in #852, plus the copy edit that didn't make it into the merge.

- **Tiny/black text**: `?attr/textAppearanceHeadlineSmall` / `textAppearanceTitleMedium` / `textAppearanceBodyMedium` are Material 3 type attributes and don't resolve in `Theme.MaterialComponents` (M2). When an attr doesn't resolve, Android falls back to the framework's default text style — tiny size, no colour set. Fixed by replacing every `android:textAppearance` with explicit `android:textSize` + `android:textColor="?android:attr/textColorPrimary"`, which is a framework-level attribute that always resolves correctly in both light and dark.

- **Dark mode ignores app setting**: The `DayNight` theme follows the Android system night mode, but dayGLANCE has its own in-app light/dark toggle stored in `SharedDataStore.appDarkMode`. Fixed by calling `delegate.localNightMode` from that value before `super.onCreate()`, so the rationale screen matches what the user sees in the rest of the app.

- **Copy**: Remove ", the habit rings will simply appear empty" from the footer paragraph.

## Test plan

- [ ] Open rationale screen with app set to **light mode** → screen renders in light mode regardless of system setting
- [ ] Open rationale screen with app set to **dark mode** → screen renders in dark mode regardless of system setting
- [ ] All text is legible at a normal readable size in both modes
- [ ] Footer reads: "Granting Health Connect permissions is entirely optional. dayGLANCE functions normally without them. You can revoke…"

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS)_