### PR TITLE
Remove redundant title from rationale screen

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
@@ -38,7 +38,7 @@ class PermissionsRationaleActivity : AppCompatActivity() {
                         .build()
                 )
                 .build()
-                .launchUrl(this, Uri.parse("https://dayglance.app/privacy"))
+                .launchUrl(this, Uri.parse("https://docs.dayglance.app/en/privacy-policy"))
         }
     }
 

--- a/dayglance-android/app/src/main/res/layout/activity_permissions_rationale.xml
+++ b/dayglance-android/app/src/main/res/layout/activity_permissions_rationale.xml
@@ -12,15 +12,6 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Health Connect Permissions"
-            android:textSize="22sp"
-            android:textStyle="bold"
-            android:textColor="?android:attr/textColorPrimary"
-            android:layout_marginBottom="12dp" />
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
             android:text="dayGLANCE uses Health Connect to display your daily progress as habit rings on the main day view."
             android:textSize="15sp"
             android:textColor="?android:attr/textColorPrimary"


### PR DESCRIPTION
The action bar already displays "Health Connect Permissions", so the large `TextView` at the top of the scroll view was redundant and was overlapping the status bar. Removed.

https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS)_