### PR TITLE
Split Health Connect permission checks; separate Authorize/Add buttons

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 89
+        versionCode = 90
         versionName = "2.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/HealthBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/HealthBridge.kt
@@ -56,6 +56,14 @@ class HealthBridge(
         if (runBlocking { repository.hasPermissions() }) "granted" else "denied"
 
     @JavascriptInterface
+    fun checkStepsPermission(): String =
+        if (runBlocking { repository.hasStepsPermission() }) "granted" else "denied"
+
+    @JavascriptInterface
+    fun checkSleepPermission(): String =
+        if (runBlocking { repository.hasSleepPermission() }) "granted" else "denied"
+
+    @JavascriptInterface
     fun requestPermission(): String {
         onRequestPermission()
         return "pending"

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -122,6 +122,12 @@ class NativeBridge(
     fun checkHealthPermission(): String = health.checkPermission()
 
     @JavascriptInterface
+    fun checkStepsPermission(): String = health.checkStepsPermission()
+
+    @JavascriptInterface
+    fun checkSleepPermission(): String = health.checkSleepPermission()
+
+    @JavascriptInterface
     fun requestHealthPermission(): String = health.requestPermission()
 
     // ── Calendar ────────────────────────────────────────────────────────────

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/HealthRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/HealthRepository.kt
@@ -37,6 +37,26 @@ class HealthRepository(context: Context) {
         }
     }
 
+    suspend fun hasStepsPermission(): Boolean = withContext(Dispatchers.IO) {
+        val c = client ?: return@withContext false
+        try {
+            HealthPermission.getReadPermission(StepsRecord::class) in
+                c.permissionController.getGrantedPermissions()
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    suspend fun hasSleepPermission(): Boolean = withContext(Dispatchers.IO) {
+        val c = client ?: return@withContext false
+        try {
+            HealthPermission.getReadPermission(SleepSessionRecord::class) in
+                c.permissionController.getGrantedPermissions()
+        } catch (e: Exception) {
+            false
+        }
+    }
+
     suspend fun getSteps(date: LocalDate): Int = withContext(Dispatchers.IO) {
         val c = client ?: return@withContext 0
         val zone = ZoneId.systemDefault()

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -617,7 +617,8 @@ const DayPlanner = () => {
     deleteHabit,
     reorderHabits,
     syncHealthConnectHabitsRef,
-    resolvePendingHealthHabitRef,
+    refreshHealthPermsRef,
+    healthPerms,
     addStepsHabit,
     addSleepHabit,
   } = useHabits({ playUISound });
@@ -1230,7 +1231,7 @@ const DayPlanner = () => {
         // @JavascriptInterface calls) to after the next paint so the JS thread isn't
         // blocked mid-render, which shows as a brief blank screen on app resume.
         requestAnimationFrame(() => setTimeout(() => {
-          resolvePendingHealthHabitRef.current?.();
+          refreshHealthPermsRef.current?.();
           syncHealthConnectHabitsRef.current?.();
         }, 0));
       }
@@ -1244,7 +1245,7 @@ const DayPlanner = () => {
       iCloudSyncRef.current?.();
       cloudSyncDownloadRef.current?.();
       requestAnimationFrame(() => setTimeout(() => {
-        resolvePendingHealthHabitRef.current?.();
+        refreshHealthPermsRef.current?.();
         syncHealthConnectHabitsRef.current?.();
       }, 0));
     };
@@ -7892,7 +7893,7 @@ const DayPlanner = () => {
     // ── Functions – habits ────────────────────────────────────────────────────
     getTodayHabitCount, incrementHabit, setHabitCount,
     addHabit, updateHabit, archiveHabit, deleteHabit, reorderHabits,
-    addStepsHabit, addSleepHabit,
+    addStepsHabit, addSleepHabit, healthPerms,
 
     // ── Functions – focus mode ────────────────────────────────────────────────
     enterFocusMode, exitFocusMode, skipFocusPhase,

--- a/src/components/HabitModal.jsx
+++ b/src/components/HabitModal.jsx
@@ -15,7 +15,7 @@ const HabitModal = () => {
     draggedHabitIdx, setDraggedHabitIdx,
     activeHabits, habits,
     addHabit, updateHabit, archiveHabit, deleteHabit, reorderHabits,
-    addStepsHabit, addSleepHabit,
+    addStepsHabit, addSleepHabit, healthPerms,
   } = useFeaturesCtx();
 
   return (
@@ -304,12 +304,23 @@ const HabitModal = () => {
                     <div className={`text-sm font-semibold ${darkMode ? 'text-green-300' : 'text-green-800'}`}>Track steps automatically</div>
                     <div className={`text-xs ${darkMode ? 'text-green-500' : 'text-green-600'} mt-0.5`}>Pulls from Health Connect — no manual tapping</div>
                   </div>
-                  <button
-                    onClick={addStepsHabit}
-                    className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-500 text-white hover:bg-green-600 active:bg-green-700 transition-colors flex-shrink-0"
-                  >
-                    Add
-                  </button>
+                  <div className="flex gap-1.5 flex-shrink-0">
+                    {!healthPerms?.steps && (
+                      <button
+                        onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
+                        className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-500 text-white hover:bg-green-600 active:bg-green-700 transition-colors"
+                      >
+                        Authorize
+                      </button>
+                    )}
+                    <button
+                      onClick={healthPerms?.steps ? addStepsHabit : undefined}
+                      disabled={!healthPerms?.steps}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.steps ? 'bg-green-500 text-white hover:bg-green-600 active:bg-green-700' : 'bg-green-500/30 text-white/50 cursor-not-allowed'}`}
+                    >
+                      Add
+                    </button>
+                  </div>
                 </div>
               )}
 
@@ -321,12 +332,23 @@ const HabitModal = () => {
                     <div className={`text-sm font-semibold ${darkMode ? 'text-indigo-300' : 'text-indigo-800'}`}>Track sleep automatically</div>
                     <div className={`text-xs ${darkMode ? 'text-indigo-500' : 'text-indigo-600'} mt-0.5`}>Pulls from Health Connect — no manual tapping</div>
                   </div>
-                  <button
-                    onClick={addSleepHabit}
-                    className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700 transition-colors flex-shrink-0"
-                  >
-                    Add
-                  </button>
+                  <div className="flex gap-1.5 flex-shrink-0">
+                    {!healthPerms?.sleep && (
+                      <button
+                        onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
+                        className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700 transition-colors"
+                      >
+                        Authorize
+                      </button>
+                    )}
+                    <button
+                      onClick={healthPerms?.sleep ? addSleepHabit : undefined}
+                      disabled={!healthPerms?.sleep}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.sleep ? 'bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700' : 'bg-indigo-500/30 text-white/50 cursor-not-allowed'}`}
+                    >
+                      Add
+                    </button>
+                  </div>
                 </div>
               )}
 

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -86,7 +86,7 @@ const MobileSettingsPanel = () => {
     editingHabit, setEditingHabit,
     draggedHabitIdx, setDraggedHabitIdx,
     addHabit, updateHabit, archiveHabit, deleteHabit, reorderHabits,
-    addStepsHabit, addSleepHabit,
+    addStepsHabit, addSleepHabit, healthPerms,
     goalsProjectsEnabled, setGoalsProjectsEnabled,
     gtdFrames,
     framesModalTab, setFramesModalTab,
@@ -1896,7 +1896,23 @@ const MobileSettingsPanel = () => {
                     <div className={`text-sm font-semibold ${darkMode ? 'text-green-300' : 'text-green-800'}`}>Track steps automatically</div>
                     <div className={`text-xs ${darkMode ? 'text-green-500' : 'text-green-600'} mt-0.5`}>Pulls from Health Connect — no manual tapping</div>
                   </div>
-                  <button onClick={addStepsHabit} className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-500 text-white hover:bg-green-600 active:bg-green-700 transition-colors flex-shrink-0">Add</button>
+                  <div className="flex gap-1.5 flex-shrink-0">
+                    {!healthPerms?.steps && (
+                      <button
+                        onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
+                        className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-500 text-white hover:bg-green-600 active:bg-green-700 transition-colors"
+                      >
+                        Authorize
+                      </button>
+                    )}
+                    <button
+                      onClick={healthPerms?.steps ? addStepsHabit : undefined}
+                      disabled={!healthPerms?.steps}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.steps ? 'bg-green-500 text-white hover:bg-green-600 active:bg-green-700' : 'bg-green-500/30 text-white/50 cursor-not-allowed'}`}
+                    >
+                      Add
+                    </button>
+                  </div>
                 </div>
               )}
               {window.DayGlanceNative && !activeHabits.some(h => h.source === 'healthConnect' && h.unit === 'min') && activeHabits.length < 8 && (
@@ -1906,7 +1922,23 @@ const MobileSettingsPanel = () => {
                     <div className={`text-sm font-semibold ${darkMode ? 'text-indigo-300' : 'text-indigo-800'}`}>Track sleep automatically</div>
                     <div className={`text-xs ${darkMode ? 'text-indigo-500' : 'text-indigo-600'} mt-0.5`}>Pulls from Health Connect — no manual tapping</div>
                   </div>
-                  <button onClick={addSleepHabit} className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700 transition-colors flex-shrink-0">Add</button>
+                  <div className="flex gap-1.5 flex-shrink-0">
+                    {!healthPerms?.sleep && (
+                      <button
+                        onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
+                        className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700 transition-colors"
+                      >
+                        Authorize
+                      </button>
+                    )}
+                    <button
+                      onClick={healthPerms?.sleep ? addSleepHabit : undefined}
+                      disabled={!healthPerms?.sleep}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.sleep ? 'bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700' : 'bg-indigo-500/30 text-white/50 cursor-not-allowed'}`}
+                    >
+                      Add
+                    </button>
+                  </div>
                 </div>
               )}
               {habits.filter(h => h.archived).length > 0 && (

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -224,41 +224,24 @@ const useHabits = ({ playUISound }) => {
     syncHealthConnectHabitsRef.current?.();
   }, [habits]);
 
-  // Habit config pending permission grant. Stored as a full habit object so the
-  // resolve path doesn't have to reconstruct it.
-  const pendingHealthHabitRef = useRef(null);
+  // Per-type Health Connect permission state: null = not yet checked, true/false = result.
+  const [healthPerms, setHealthPerms] = useState({ steps: null, sleep: null });
 
-  // Called on app foreground / visibility-return. If a health habit is pending
-  // (user tapped Add, got the permission dialog, returned), check whether
-  // permission was granted and add the habit only if it was.
-  const resolvePendingHealthHabit = () => {
-    if (!window.DayGlanceNative || !pendingHealthHabitRef.current) return;
-    let granted = false;
-    try {
-      granted = window.DayGlanceNative.checkHealthPermission() === 'granted';
-    } catch (e) { /* bridge method unavailable — treat as denied */ }
-    const config = pendingHealthHabitRef.current;
-    pendingHealthHabitRef.current = null;
-    if (granted) addHabit(config);
-  };
-  const resolvePendingHealthHabitRef = useRef(null);
-  resolvePendingHealthHabitRef.current = resolvePendingHealthHabit;
-
-  const _addHealthHabit = (config) => {
+  const refreshHealthPerms = () => {
     if (!window.DayGlanceNative) return;
-    let alreadyGranted = false;
     try {
-      alreadyGranted = window.DayGlanceNative.checkHealthPermission() === 'granted';
-    } catch (e) { /* checkHealthPermission unavailable — fall back to old behaviour */ alreadyGranted = true; }
-    if (alreadyGranted) {
-      addHabit(config);
-    } else {
-      pendingHealthHabitRef.current = config;
-      try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {}
-    }
+      const steps = window.DayGlanceNative.checkStepsPermission() === 'granted';
+      const sleep = window.DayGlanceNative.checkSleepPermission() === 'granted';
+      setHealthPerms({ steps, sleep });
+    } catch (e) { /* bridge unavailable — leave state unchanged */ }
   };
+  const refreshHealthPermsRef = useRef(null);
+  refreshHealthPermsRef.current = refreshHealthPerms;
 
-  const addStepsHabit = () => _addHealthHabit({
+  // Check permissions once on mount.
+  useEffect(() => { refreshHealthPerms(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const addStepsHabit = () => addHabit({
     name: 'Steps',
     icon: 'Footprints',
     color: 'green',
@@ -269,7 +252,7 @@ const useHabits = ({ playUISound }) => {
     scheduledDays: [0, 1, 2, 3, 4, 5, 6],
   });
 
-  const addSleepHabit = () => _addHealthHabit({
+  const addSleepHabit = () => addHabit({
     name: 'Sleep',
     icon: 'Moon',
     color: 'indigo',
@@ -304,7 +287,8 @@ const useHabits = ({ playUISound }) => {
     deleteHabit,
     reorderHabits,
     syncHealthConnectHabitsRef,
-    resolvePendingHealthHabitRef,
+    refreshHealthPermsRef,
+    healthPerms,
     addStepsHabit,
     addSleepHabit,
   };


### PR DESCRIPTION
## Summary

- Previously a single `checkHealthPermission()` bridge call checked both steps and sleep together — granting only one type made both appear granted
- Splits into independent `checkStepsPermission()` / `checkSleepPermission()` bridge methods so each data type's grant state is tracked separately
- Redesigns the Add Habit UI: each health type now has an **Authorize** button (visible only while permission is not yet granted) and an **Add** button (grayed/disabled until permission is granted), replacing the old combined tap-to-authorize-then-add flow
- `healthPerms` React state `{ steps, sleep }` is refreshed on mount and on every foreground/visibility-return event, so the buttons update correctly after the user returns from the Health Connect permission dialog

## Changes

| File | Change |
|---|---|
| `HealthRepository.kt` | `hasStepsPermission()` / `hasSleepPermission()` — per-type permission checks |
| `HealthBridge.kt` | `checkStepsPermission()` / `checkSleepPermission()` — synchronous bridge wrappers |
| `NativeBridge.kt` | Exposes both as `@JavascriptInterface` methods |
| `useHabits.js` | Replaces `pendingHealthHabitRef` flow with `healthPerms` state + `refreshHealthPerms()`; `addStepsHabit`/`addSleepHabit` are now plain add-only functions |
| `App.jsx` | Calls `refreshHealthPermsRef` on visibility-return; adds `healthPerms` to `featuresCtx` |
| `HabitModal.jsx` | Authorize + Add buttons per type; Add disabled until permission granted |
| `MobileSettingsPanel.jsx` | Same Authorize + Add pattern |
| `build.gradle.kts` | versionCode 89 → 90 |

## Test plan

- [ ] Steps not granted: Authorize button visible, Add button grayed — tap Authorize → grant steps → return → Add becomes active
- [ ] Steps not granted: tap Authorize → **deny** → return → Add stays grayed
- [ ] Sleep follows the same behaviour independently of steps
- [ ] Grant steps only → steps Add active, sleep Add still grayed (no cross-contamination)
- [ ] Already granted on launch → both Add buttons immediately active, no Authorize shown
- [ ] Existing health habits auto-sync is unaffected

https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS)_