### PR TITLE
Fix Health Connect permission state not updating after grant

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -108,8 +108,12 @@ class MainActivity : AppCompatActivity() {
     private val requestHealthPermissions = registerForActivityResult(
         PermissionController.createRequestPermissionResultContract()
     ) { _ ->
-        // Permissions result is handled transparently: the next getSteps/getSleep
-        // call will succeed if granted, or return zeros if still denied.
+        // Notify JS so the Authorize/Add buttons update immediately without
+        // depending on visibilitychange (which is unreliable when webView.onPause
+        // is intentionally skipped).
+        webView.evaluateJavascript(
+            "window.__onHealthPermResult && window.__onHealthPermResult()", null
+        )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1252,10 +1252,19 @@ const DayPlanner = () => {
     document.addEventListener('visibilitychange', handleVisibility);
     document.addEventListener('dayglanceForeground', handleNativeForeground);
     window.addEventListener('focus', handleVisibility);
+    // Called by MainActivity's ActivityResultLauncher when the HC dialog completes.
+    // Provides a reliable refresh path independent of visibilitychange timing.
+    window.__onHealthPermResult = () => {
+      requestAnimationFrame(() => setTimeout(() => {
+        refreshHealthPermsRef.current?.();
+        syncHealthConnectHabitsRef.current?.();
+      }, 0));
+    };
     return () => {
       document.removeEventListener('visibilitychange', handleVisibility);
       document.removeEventListener('dayglanceForeground', handleNativeForeground);
       window.removeEventListener('focus', handleVisibility);
+      delete window.__onHealthPermResult;
     };
   }, []);
 


### PR DESCRIPTION
## Summary

After granting Health Connect permissions, the Add buttons stayed grayed and tapping Authorize again appeared to do nothing. Two bugs caused this:

1. **`ActivityResultLauncher` callback was a no-op** — when the HC dialog completed (granted or denied), the result was discarded and JS was never notified. `healthPerms` state never updated.

2. **`visibilitychange` is unreliable here** — `webView.onPause()`/`onResume()` are intentionally skipped in `MainActivity` to prevent a blank-frame flash on resume. This means the WebView doesn't change its visibility state when the HC permission Activity is on top, so `visibilitychange` never fires as a fallback signal.

## Fix

When `ActivityResultLauncher` fires, call `evaluateJavascript` to invoke `window.__onHealthPermResult()`, which is registered in `App.jsx` to immediately run `refreshHealthPerms` + `syncHealthConnect`. This is a direct native→JS callback that works regardless of visibility event timing.

## Changes

| File | Change |
|---|---|
| `MainActivity.kt` | `requestHealthPermissions` callback calls `evaluateJavascript("window.__onHealthPermResult && window.__onHealthPermResult()")` |
| `App.jsx` | Registers `window.__onHealthPermResult` in the visibility effect; cleans up on unmount |

## Test plan

- [ ] Tap Authorize (steps not granted) → grant in HC dialog → return → steps Add button immediately becomes active
- [ ] Tap Authorize → deny → return → Add stays grayed
- [ ] Same for sleep, independently
- [ ] Grant steps only → steps Add active, sleep Add still grayed

https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS)_