### PR TITLE
Fix rationale screen content overlapping action bar (API 35 edge-to-edge)

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.view.WindowCompat
 import com.dayglance.app.data.SharedDataStore
 import com.dayglance.app.databinding.ActivityPermissionsRationaleBinding
 
@@ -22,6 +23,10 @@ class PermissionsRationaleActivity : AppCompatActivity() {
             null  -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
         }
         super.onCreate(savedInstanceState)
+        // Opt out of edge-to-edge so the action bar and content sit below the status bar.
+        // targetSdk 35 enforces edge-to-edge by default; without this the action bar renders
+        // at y=0 (under the transparent status bar) and content overlaps the header.
+        WindowCompat.setDecorFitsSystemWindows(window, true)
         binding = ActivityPermissionsRationaleBinding.inflate(layoutInflater)
         setContentView(binding.root)
 


### PR DESCRIPTION
## Summary

After removing the redundant title TextView (#856), the scroll content appeared to overlap the "← Health Connect Permissions" action bar.

**Root cause:** `Theme.DayGlance` sets `android:statusBarColor=@android:color/transparent`, and `targetSdk=35` enforces edge-to-edge for all apps regardless of theme settings. This means the window extends behind the status bar — the action bar renders at y=0 (under the transparent status bar) rather than below it, and scroll content starts immediately below the action bar with only `padding=20dp` of clearance.

**Fix:** Call `WindowCompat.setDecorFitsSystemWindows(window, true)` in `PermissionsRationaleActivity.onCreate()`. This explicitly opts this activity out of edge-to-edge, so the system reserves space for the status bar and the action bar sits correctly below it.

## Test plan

- [ ] Open rationale screen — intro paragraph is fully visible below the action bar, not hidden behind it
- [ ] No overlap with status bar
- [ ] Light and dark mode both render correctly

https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS)_