### PR TITLE
Clear health habit rings when Health Connect permission is revoked

### DIFF
--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -184,6 +184,9 @@ const useHabits = ({ playUISound }) => {
       d.setDate(d.getDate() - daysBack);
       const dateStr = dateToString(d);
       for (const habit of healthHabits) {
+        // Skip types whose permission is known revoked (=== false, not null = "not yet checked").
+        if (habit.unit === 'steps' && healthPerms.steps === false) continue;
+        if ((habit.unit === 'min' || habit.unit === 'minutes') && healthPerms.sleep === false) continue;
         try {
           let count = 0;
           if (habit.unit === 'steps') {
@@ -240,6 +243,28 @@ const useHabits = ({ playUISound }) => {
 
   // Check permissions once on mount.
   useEffect(() => { refreshHealthPerms(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // When a permission transitions true → false (revoked), clear today's counts for the
+  // affected habits so the ring empties immediately instead of showing stale data.
+  const prevHealthPermsRef = useRef({ steps: null, sleep: null });
+  useEffect(() => {
+    const prev = prevHealthPermsRef.current;
+    const stepsRevoked = prev.steps === true && healthPerms.steps === false;
+    const sleepRevoked = prev.sleep === true && healthPerms.sleep === false;
+    if (stepsRevoked || sleepRevoked) {
+      const todayStr = dateToString(new Date());
+      setHabitLogs(prev => {
+        const today = { ...(prev[todayStr] || {}) };
+        for (const h of habits) {
+          if (h.archived) continue;
+          if (stepsRevoked && h.unit === 'steps' && h.source === 'healthConnect') delete today[h.id];
+          if (sleepRevoked && (h.unit === 'min' || h.unit === 'minutes') && h.source === 'healthConnect') delete today[h.id];
+        }
+        return { ...prev, [todayStr]: today };
+      });
+    }
+    prevHealthPermsRef.current = healthPerms;
+  }, [healthPerms]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const addStepsHabit = () => addHabit({
     name: 'Steps',


### PR DESCRIPTION
## Summary

When a user revoked a previously-granted Health Connect permission, the app showed no visual change — the habit ring continued displaying the last synced count.

Two bugs caused this:

1. **`syncHealthConnectHabits` ignored revocation.** It kept calling `getSteps`/`getSleep` for revoked types. Even if the bridge returned 0, the `Math.max` merge logic preserved the previous count (it was designed to prevent downgrading cloud-synced values), so the ring never emptied.

2. **No code reacted to the `true → false` transition in `healthPerms`.** There was no signal to proactively clear the stale display.

## Fix

- `syncHealthConnectHabits` now skips habits whose permission is `=== false`. Using strict equality means `null` ("not yet checked") still attempts the read, preserving first-run behaviour.
- A `useEffect` on `healthPerms` detects `true → false` transitions and deletes today's log entries for affected habits. The ring empties immediately on the next render.

Historical log data (past days) is intentionally preserved — only today's count is cleared, since that's the value we can no longer read.

## Test plan

- [ ] Grant steps permission → steps ring fills with today's count
- [ ] Revoke steps permission in Health Connect → return to app → steps ring empties immediately
- [ ] Sleep permission follows same behaviour independently
- [ ] Revoking one type does not affect the other's ring
- [ ] Historical rings (past days) are unaffected by revocation
- [ ] Re-granting permission → ring refills on next sync

https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS)_