### PR TITLE
Show sync-paused indicator on habit rings when Health Connect permission revoked

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -104,7 +104,15 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     computeAvailableSlots,
     showVoiceInput, setShowVoiceInput,
     voiceCanRecord,
+    healthPerms,
   } = useFeaturesCtx();
+
+  const isHealthSyncPaused = (habit) => {
+    if (!habit.source) return false;
+    if (habit.unit === 'steps') return healthPerms?.steps === false;
+    if (habit.unit === 'min' || habit.unit === 'minutes') return healthPerms?.sleep === false;
+    return false;
+  };
 
   const isDesktop = variant === 'desktop';
   const isTray = variant === 'tray';
@@ -303,13 +311,15 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                     habit={habit}
                     count={getTodayHabitCount(habit.id)}
                     darkMode={darkMode}
-                    onClick={() => doIncrementHabit(habit.id)}
-                    onContextMenu={(e) => { e.preventDefault(); setHabitLongPressId(prev => prev === habit.id ? null : habit.id); setHabitEditingCountId(null); }}
-                    onMouseDown={() => { if (habitLongPressTimer.current) clearTimeout(habitLongPressTimer.current); habitLongPressTimer.current = setTimeout(() => { setHabitLongPressId(prev => prev === habit.id ? null : habit.id); setHabitEditingCountId(null); }, 500); }}
-                    onMouseUp={() => { if (habitLongPressTimer.current) clearTimeout(habitLongPressTimer.current); }}
-                    onMouseLeave={() => { if (habitLongPressTimer.current) clearTimeout(habitLongPressTimer.current); }}
-                    onTouchStart={() => { if (habitLongPressTimer.current) clearTimeout(habitLongPressTimer.current); habitLongPressTimer.current = setTimeout(() => { setHabitLongPressId(prev => prev === habit.id ? null : habit.id); setHabitEditingCountId(null); }, 500); }}
-                    onTouchEnd={() => { if (habitLongPressTimer.current) clearTimeout(habitLongPressTimer.current); }}
+                    autoSynced={!!habit.source}
+                    syncPaused={isHealthSyncPaused(habit)}
+                    onClick={habit.source ? undefined : () => doIncrementHabit(habit.id)}
+                    onContextMenu={habit.source ? undefined : (e) => { e.preventDefault(); setHabitLongPressId(prev => prev === habit.id ? null : habit.id); setHabitEditingCountId(null); }}
+                    onMouseDown={habit.source ? undefined : () => { if (habitLongPressTimer.current) clearTimeout(habitLongPressTimer.current); habitLongPressTimer.current = setTimeout(() => { setHabitLongPressId(prev => prev === habit.id ? null : habit.id); setHabitEditingCountId(null); }, 500); }}
+                    onMouseUp={habit.source ? undefined : () => { if (habitLongPressTimer.current) clearTimeout(habitLongPressTimer.current); }}
+                    onMouseLeave={habit.source ? undefined : () => { if (habitLongPressTimer.current) clearTimeout(habitLongPressTimer.current); }}
+                    onTouchStart={habit.source ? undefined : () => { if (habitLongPressTimer.current) clearTimeout(habitLongPressTimer.current); habitLongPressTimer.current = setTimeout(() => { setHabitLongPressId(prev => prev === habit.id ? null : habit.id); setHabitEditingCountId(null); }, 500); }}
+                    onTouchEnd={habit.source ? undefined : () => { if (habitLongPressTimer.current) clearTimeout(habitLongPressTimer.current); }}
                   />
                   {habitLongPressId === habit.id && (
                     <>

--- a/src/components/HabitRing.jsx
+++ b/src/components/HabitRing.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Check, RefreshCw, Target, X } from 'lucide-react';
+import { Check, RefreshCw, Target, WifiOff, X } from 'lucide-react';
 import { HABIT_ICONS, HABIT_COLORS } from '../constants/habits.js';
 
-const HabitRing = ({ size = 40, habit, count = 0, onClick, onContextMenu, onMouseDown, onMouseUp, onMouseLeave, onTouchStart, onTouchEnd, darkMode, autoSynced = false }) => {
+const HabitRing = ({ size = 40, habit, count = 0, onClick, onContextMenu, onMouseDown, onMouseUp, onMouseLeave, onTouchStart, onTouchEnd, darkMode, autoSynced = false, syncPaused = false }) => {
   const { type, target, color, icon } = habit;
   const colorObj = HABIT_COLORS.find(c => c.name === color) || HABIT_COLORS[0];
   const IconComponent = HABIT_ICONS[icon] || Target;
@@ -77,10 +77,13 @@ const HabitRing = ({ size = 40, habit, count = 0, onClick, onContextMenu, onMous
             style={{ color: showCheck ? '#22c55e' : showX ? '#ef4444' : (ringColor === (darkMode ? '#4b5563' : '#d1d5db') ? (darkMode ? '#9ca3af' : '#9ca3af') : ringColor) }}
           />
         </div>
-        {/* Auto-sync indicator — small dot in top-right corner */}
+        {/* Auto-sync indicator — green when syncing, orange when permission revoked */}
         {autoSynced && (
-          <div className="absolute -top-0.5 -right-0.5 w-3 h-3 rounded-full bg-green-500 flex items-center justify-center">
-            <RefreshCw size={7} className="text-white" />
+          <div className={`absolute -top-0.5 -right-0.5 w-3 h-3 rounded-full flex items-center justify-center ${syncPaused ? 'bg-orange-400' : 'bg-green-500'}`}>
+            {syncPaused
+              ? <WifiOff size={6} className="text-white" />
+              : <RefreshCw size={7} className="text-white" />
+            }
           </div>
         )}
         {/* Goal-met (doMore) or limit-exceeded badge — bottom-right corner */}

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -113,7 +113,15 @@ const MobileGlanceSection = () => {
     getFrameInstancesForDate, computeAvailableSlots,
     showVoiceInput, setShowVoiceInput,
     voiceCanRecord,
+    healthPerms,
   } = useFeaturesCtx();
+
+  const isHealthSyncPaused = (habit) => {
+    if (!habit.source) return false;
+    if (habit.unit === 'steps') return healthPerms?.steps === false;
+    if (habit.unit === 'min' || habit.unit === 'minutes') return healthPerms?.sleep === false;
+    return false;
+  };
 
   return (
 <div className={`px-4 py-4 mobile-tab-fade-in flex-1 min-h-0 overflow-y-auto`}>
@@ -226,6 +234,7 @@ const MobileGlanceSection = () => {
                     count={getTodayHabitCount(habit.id)}
                     darkMode={darkMode}
                     autoSynced={!!habit.source}
+                    syncPaused={isHealthSyncPaused(habit)}
                     onClick={habit.source ? undefined : () => incrementHabit(habit.id)}
                     onContextMenu={habit.source ? undefined : (e) => { e.preventDefault(); clearTimeout(habitLongPressTimer.current); setHabitLongPressId(habit.id); habitLongPressOpenedAt.current = Date.now(); setHabitEditingCountId(null); }}
                     onMouseDown={habit.source ? undefined : () => { if (habitLongPressTimer.current) clearTimeout(habitLongPressTimer.current); habitLongPressTimer.current = setTimeout(() => { setHabitLongPressId(habit.id); habitLongPressOpenedAt.current = Date.now(); setHabitEditingCountId(null); }, 500); }}


### PR DESCRIPTION
## Summary

When a Health Connect permission is revoked, the habit ring's auto-sync badge now changes from a **green RefreshCw dot** (syncing) to an **orange WifiOff dot** (paused) so the user has a clear visual signal that live data is no longer flowing into that ring.

## Changes

| File | Change |
|---|---|
| `HabitRing.jsx` | New `syncPaused` prop; swaps badge from green/RefreshCw to orange/WifiOff when true |
| `MobileGlanceSection.jsx` | Destructures `healthPerms` from context; computes `syncPaused` per habit and passes it to `HabitRing` |
| `GlanceSidebar.jsx` | Same `healthPerms` + `syncPaused` wiring; also adds the previously-missing `autoSynced` prop and guards all interaction handlers behind `habit.source` (health habits were still tappable on desktop) |

## Logic

`syncPaused` is true when:
- `habit.unit === 'steps'` and `healthPerms.steps === false`
- `habit.unit === 'min'` and `healthPerms.sleep === false`

`=== false` is intentional — `null` ("not yet checked") leaves the badge green so it doesn't flash orange on first load before the permission check runs.

## Test plan

- [ ] Grant steps permission → green RefreshCw badge on steps ring
- [ ] Revoke steps permission → orange WifiOff badge on steps ring; sleep ring unaffected
- [ ] Re-grant → badge returns to green on next foreground
- [ ] Desktop sidebar: health habit rings are no longer tappable/long-pressable

https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS)_