### PR TITLE
Change Auto-synced pill to Not syncing when HC permission revoked

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 92
+        versionCode = 93
         versionName = "2.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -6,7 +6,7 @@ import {
   Footprints, FolderOpen, Globe, GripVertical, HelpCircle, Key, LayoutGrid,
   Loader, Mic, Moon, Pencil, Plus,
   Flag, RefreshCw, Save, Settings, Sparkles, Sun, Target, Trash2,
-  Undo2, Upload, Volume2, VolumeX, Wifi, Zap,
+  Undo2, Upload, Volume2, VolumeX, Wifi, WifiOff, Zap,
 } from 'lucide-react';
 import { getTzLabel, getTzOptions } from '../utils/timezones.js';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from '../constants/habits.js';
@@ -1847,11 +1847,12 @@ const MobileSettingsPanel = () => {
                         <div className="flex-1 min-w-0">
                           <div className={`text-sm font-medium ${textPrimary} truncate flex items-center gap-1.5`}>
                             {habit.name}
-                            {habit.source === 'healthConnect' && (
-                              <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 flex-shrink-0">
-                                <RefreshCw size={9} />Auto-synced
-                              </span>
-                            )}
+                            {habit.source === 'healthConnect' && (() => {
+                              const paused = habit.unit === 'steps' ? healthPerms?.steps === false : healthPerms?.sleep === false;
+                              return paused
+                                ? <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-orange-400/10 text-orange-500 flex-shrink-0"><WifiOff size={9} />Not syncing</span>
+                                : <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 flex-shrink-0"><RefreshCw size={9} />Auto-synced</span>;
+                            })()}
                           </div>
                           <div className={`text-xs ${textSecondary}`}>{habit.type === 'doMore' ? 'Goal' : 'Limit'}: {habit.target} {habit.unit}</div>
                           {(() => {


### PR DESCRIPTION
Matches the amber WifiOff indicator on the habit ring (#862). When `healthPerms` shows a permission is revoked, the green "Auto-synced" pill in the habits settings list switches to an amber "Not syncing" pill so both surfaces tell the same story.

https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS)_