### PR TITLE
Fix rationale screen insets on Android 15 (replace deprecated setDecorFitsSystemWindows)

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 93
+        versionCode = 94
         versionName = "2.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
@@ -3,11 +3,13 @@ package com.dayglance.app
 import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
+import android.util.TypedValue
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.core.view.WindowCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.dayglance.app.data.SharedDataStore
 import com.dayglance.app.databinding.ActivityPermissionsRationaleBinding
 
@@ -23,16 +25,26 @@ class PermissionsRationaleActivity : AppCompatActivity() {
             null  -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
         }
         super.onCreate(savedInstanceState)
-        // Opt out of edge-to-edge so the action bar and content sit below the status bar.
-        // targetSdk 35 enforces edge-to-edge by default; without this the action bar renders
-        // at y=0 (under the transparent status bar) and content overlaps the header.
-        WindowCompat.setDecorFitsSystemWindows(window, true)
         binding = ActivityPermissionsRationaleBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         supportActionBar?.apply {
             title = "Health Connect Permissions"
             setDisplayHomeAsUpEnabled(true)
+        }
+
+        // Android 15 (targetSdk 35) enforces edge-to-edge and ignores
+        // WindowCompat.setDecorFitsSystemWindows(). Apply insets manually:
+        // pad the scroll view by statusBar + actionBar heights so content
+        // starts below the action bar on all API levels.
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val tv = TypedValue()
+            val actionBarHeight = if (theme.resolveAttribute(androidx.appcompat.R.attr.actionBarSize, tv, true))
+                TypedValue.complexToDimensionPixelSize(tv.data, resources.displayMetrics)
+            else 0
+            view.setPadding(0, bars.top + actionBarHeight, 0, bars.bottom)
+            insets
         }
 
         binding.btnPrivacyPolicy.setOnClickListener {


### PR DESCRIPTION
## Summary

The previous fix (#860) called `WindowCompat.setDecorFitsSystemWindows(window, true)`, which is silently ignored on Android 15 — Google deprecated this API path and stops honouring it for apps targeting API 35+, where edge-to-edge is enforced unconditionally.

## Fix

Replace the window-level opt-out with a `ViewCompat.setOnApplyWindowInsetsListener` on the ScrollView that computes `statusBarHeight + actionBarHeight` and applies it as `paddingTop`. This works on all API levels because it operates on the view hierarchy rather than the window decoration system.

The action bar height is resolved from the `actionBarSize` theme attribute so it's correct across screen densities and device form factors.

## Test plan

- [ ] Open rationale screen — first paragraph is fully visible below the action bar
- [ ] No overlap with the status bar or the "← Health Connect Permissions" header
- [ ] Light and dark mode both correct

https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorhL6eZzPb8MDj9ETvBqS)_