### PR TITLE
Cross-device auto-sync badges for health habits

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -114,6 +114,12 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     return false;
   };
 
+  const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+  const isRecentAutoSync = (habit) => {
+    const ts = habit.lastAutoSync?.timestamp;
+    return !!ts && Date.now() - new Date(ts).getTime() < SEVEN_DAYS_MS;
+  };
+
   const isDesktop = variant === 'desktop';
   const isTray = variant === 'tray';
   const interactionClass = isDesktop || isTray ? 'hover:opacity-80' : 'active:opacity-70';
@@ -311,7 +317,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                     habit={habit}
                     count={getTodayHabitCount(habit.id)}
                     darkMode={darkMode}
-                    autoSynced={!!habit.source}
+                    autoSynced={isRecentAutoSync(habit)}
                     syncPaused={isHealthSyncPaused(habit)}
                     onClick={habit.source ? undefined : () => doIncrementHabit(habit.id)}
                     onContextMenu={habit.source ? undefined : (e) => { e.preventDefault(); setHabitLongPressId(prev => prev === habit.id ? null : habit.id); setHabitEditingCountId(null); }}

--- a/src/components/HabitModal.jsx
+++ b/src/components/HabitModal.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import {
   X, Activity, Target, GripVertical, RefreshCw,
-  Pencil, Trash2, ChevronUp, ChevronDown, Plus, Footprints, Moon,
+  Pencil, Trash2, ChevronUp, ChevronDown, Plus, Footprints, Moon, WifiOff,
 } from 'lucide-react';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from '../constants/habits.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { getDeviceId } from '../native.js';
 
 const HabitModal = () => {
   const { cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg } = useDayPlannerCtx();
@@ -241,11 +242,21 @@ const HabitModal = () => {
                         <div className="flex-1 min-w-0">
                           <div className={`text-sm font-medium ${textPrimary} truncate flex items-center gap-1.5`}>
                             {habit.name}
-                            {habit.source === 'healthConnect' && (
-                              <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 flex-shrink-0">
-                                <RefreshCw size={9} />Auto-synced
-                              </span>
-                            )}
+                            {(() => {
+                              const { lastAutoSync } = habit;
+                              const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+                              const isRecent = lastAutoSync?.timestamp &&
+                                Date.now() - new Date(lastAutoSync.timestamp).getTime() < SEVEN_DAYS_MS;
+                              if (!isRecent) return null;
+                              const isThisDevice = lastAutoSync.deviceId === getDeviceId();
+                              if (isThisDevice) {
+                                const paused = habit.unit === 'steps' ? healthPerms?.steps === false : healthPerms?.sleep === false;
+                                if (paused) return <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-orange-400/10 text-orange-500 flex-shrink-0"><WifiOff size={9} />Not syncing</span>;
+                                return <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 flex-shrink-0"><RefreshCw size={9} />Auto-synced on this device</span>;
+                              }
+                              const platform = lastAutoSync.platform ?? 'another device';
+                              return <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 flex-shrink-0"><RefreshCw size={9} />Auto-synced on {platform}</span>;
+                            })()}
                           </div>
                           <div className={`text-xs ${textSecondary}`}>
                             {habit.type === 'doMore' ? 'Goal' : 'Limit'}: {habit.target} {habit.unit}

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -123,6 +123,12 @@ const MobileGlanceSection = () => {
     return false;
   };
 
+  const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+  const isRecentAutoSync = (habit) => {
+    const ts = habit.lastAutoSync?.timestamp;
+    return !!ts && Date.now() - new Date(ts).getTime() < SEVEN_DAYS_MS;
+  };
+
   return (
 <div className={`px-4 py-4 mobile-tab-fade-in flex-1 min-h-0 overflow-y-auto`}>
   <div className="flex items-center gap-2 mb-4">
@@ -233,7 +239,7 @@ const MobileGlanceSection = () => {
                     habit={habit}
                     count={getTodayHabitCount(habit.id)}
                     darkMode={darkMode}
-                    autoSynced={!!habit.source}
+                    autoSynced={isRecentAutoSync(habit)}
                     syncPaused={isHealthSyncPaused(habit)}
                     onClick={habit.source ? undefined : () => incrementHabit(habit.id)}
                     onContextMenu={habit.source ? undefined : (e) => { e.preventDefault(); clearTimeout(habitLongPressTimer.current); setHabitLongPressId(habit.id); habitLongPressOpenedAt.current = Date.now(); setHabitEditingCountId(null); }}

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -10,7 +10,7 @@ import {
 } from 'lucide-react';
 import { getTzLabel, getTzOptions } from '../utils/timezones.js';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from '../constants/habits.js';
-import { isNativeAndroid, isNativeApp, nativeGetCalendars, nativePickVault } from '../native.js';
+import { getDeviceId, isNativeAndroid, isNativeApp, nativeGetCalendars, nativePickVault } from '../native.js';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, listVaultNotes } from '../obsidian.js';
@@ -1849,11 +1849,20 @@ const MobileSettingsPanel = () => {
                         <div className="flex-1 min-w-0">
                           <div className={`text-sm font-medium ${textPrimary} truncate flex items-center gap-1.5`}>
                             {habit.name}
-                            {habit.source === 'healthConnect' && (() => {
-                              const paused = habit.unit === 'steps' ? healthPerms?.steps === false : healthPerms?.sleep === false;
-                              return paused
-                                ? <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-orange-400/10 text-orange-500 flex-shrink-0"><WifiOff size={9} />Not syncing</span>
-                                : <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 flex-shrink-0"><RefreshCw size={9} />Auto-synced</span>;
+                            {(() => {
+                              const { lastAutoSync } = habit;
+                              const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+                              const isRecent = lastAutoSync?.timestamp &&
+                                Date.now() - new Date(lastAutoSync.timestamp).getTime() < SEVEN_DAYS_MS;
+                              if (!isRecent) return null;
+                              const isThisDevice = lastAutoSync.deviceId === getDeviceId();
+                              if (isThisDevice) {
+                                const paused = habit.unit === 'steps' ? healthPerms?.steps === false : healthPerms?.sleep === false;
+                                if (paused) return <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-orange-400/10 text-orange-500 flex-shrink-0"><WifiOff size={9} />Not syncing</span>;
+                                return <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 flex-shrink-0"><RefreshCw size={9} />Auto-synced on this device</span>;
+                              }
+                              const platform = lastAutoSync.platform ?? 'another device';
+                              return <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 flex-shrink-0"><RefreshCw size={9} />Auto-synced on {platform}</span>;
                             })()}
                           </div>
                           <div className={`text-xs ${textSecondary}`}>{habit.type === 'doMore' ? 'Goal' : 'Limit'}: {habit.target} {habit.unit}</div>

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
+import { getDeviceId, isNativeIOS } from '../native.js';
 
 const useHabits = ({ playUISound }) => {
   const [habits, setHabits] = useState([]);
@@ -172,13 +173,14 @@ const useHabits = ({ playUISound }) => {
   // Backfills the last 7 days so historical rings are accurate on first setup.
   const syncHealthConnectHabits = () => {
     if (!window.DayGlanceNative) return;
-    const isIOS = !!window.DayGlanceIOS;
-    const platformSource = isIOS ? 'healthKit' : 'healthConnect';
+    const platformSource = isNativeIOS() ? 'healthKit' : 'healthConnect';
     const healthHabits = habits.filter(h => !h.archived && h.source === platformSource);
     if (!healthHabits.length) return;
 
     const today = new Date();
     const updates = {};
+    // Track habits that successfully read today's data — they get the lastAutoSync marker.
+    const syncedTodayIds = new Set();
     for (let daysBack = 0; daysBack < 7; daysBack++) {
       const d = new Date(today);
       d.setDate(d.getDate() - daysBack);
@@ -198,6 +200,7 @@ const useHabits = ({ playUISound }) => {
           }
           if (!updates[dateStr]) updates[dateStr] = {};
           updates[dateStr][habit.id] = count;
+          if (daysBack === 0) syncedTodayIds.add(habit.id);
         } catch (e) { /* ignore parse errors */ }
       }
     }
@@ -216,6 +219,15 @@ const useHabits = ({ playUISound }) => {
         }
         return next;
       });
+    }
+    if (syncedTodayIds.size > 0) {
+      const deviceId = getDeviceId();
+      const platform = isNativeIOS() ? 'iOS' : 'Android';
+      const timestamp = new Date().toISOString();
+      setHabits(prev => prev.map(h => {
+        if (!syncedTodayIds.has(h.id)) return h;
+        return { ...h, lastAutoSync: { deviceId, platform, timestamp }, lastModified: timestamp };
+      }));
     }
   };
 

--- a/src/native.js
+++ b/src/native.js
@@ -14,6 +14,22 @@
  *   }
  */
 
+const DEVICE_ID_KEY = 'dayglance_device_id';
+
+/**
+ * Returns a stable per-installation device ID, generating and persisting one
+ * on first call. Used to identify which device last auto-synced a habit so
+ * other devices can display the correct cross-device badge label.
+ */
+export const getDeviceId = () => {
+  let id = localStorage.getItem(DEVICE_ID_KEY);
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem(DEVICE_ID_KEY, id);
+  }
+  return id;
+};
+
 /**
  * Returns true when running inside the DayGlance Android WebView.
  */


### PR DESCRIPTION
## Summary

- **`lastAutoSync` marker**: when a device auto-syncs a health habit (Steps or Sleep via HealthKit/Health Connect), `syncHealthConnectHabits` now stamps `lastAutoSync: { deviceId, platform, timestamp }` on the habit object and bumps `lastModified`, so the marker propagates through the existing `mergeHabits` sync merge to all devices.
- **`getDeviceId()` in `native.js`**: generates a `crypto.randomUUID()` on first launch and persists it under `dayglance_device_id` in localStorage — single source of truth for device identity, available for future cross-device features.
- **GLANCE tab badge**: `autoSynced` now shows whenever `lastAutoSync.timestamp` is within 7 days, regardless of which device did the sync. Replaces the previous `!!habit.source` check, which was device-local and invisible on cross-device installs.
- **Habits settings badge**: three states — "Auto-synced on this device" (`lastAutoSync.deviceId === local`), "Auto-synced on [Android|iOS]" (`deviceId` differs, platform from marker), or no badge if marker is absent/stale. The existing "Not syncing" amber pill is preserved when local permission is revoked and this device was the last sync source.
- Platform field derived from `isNativeIOS()` / `isNativeAndroid()` bridge detection, not `navigator.userAgent`.
- 7-day recency window handles stale markers left behind when a user stops using a device.

## Test plan

- [ ] On Android with Health Connect: add Steps habit, confirm green badge appears on GLANCE tab and "Auto-synced on this device" in settings
- [ ] Open the same account on iOS (or another Android device): confirm GLANCE tab shows green badge, settings shows "Auto-synced on Android"
- [ ] Revoke Health Connect permission on Android: GLANCE tab badge disappears (syncPaused orange shows instead), settings shows "Not syncing"
- [ ] Let 7+ days pass with no sync (or manually set a stale timestamp in localStorage for testing): both badges disappear
- [ ] Confirm `dayglance_device_id` is written to localStorage on first launch and stable across reloads

https://claude.ai/code/session_0141G7BnPSj3naNhWoHG9QBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0141G7BnPSj3naNhWoHG9QBy)_