### PR TITLE
Add @glance-apps/intents dependency; wire constants through DayGlanceNative namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dayglance",
       "version": "2.10.0",
       "dependencies": {
+        "@glance-apps/intents": "^1.0.1",
         "@glance-apps/sync": "^1.0.1",
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",
@@ -2235,6 +2236,18 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@glance-apps/intents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.0.1.tgz",
+      "integrity": "sha512-fJzf4MF9nCRW6Tws5kekMsS0vpwW6XkaVhSwtwnmguBNuI5h96ur+CGSc8IF+TMy1uN5UJPLAryoBmHObwoPZw==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@glance-apps/sync": {
@@ -11115,6 +11128,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:electron:release": "vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs --publish never"
   },
   "dependencies": {
+    "@glance-apps/intents": "^1.0.1",
     "@glance-apps/sync": "^1.0.1",
     "lucide-react": "^0.564.0",
     "react": "^18.2.0",

--- a/src/native.js
+++ b/src/native.js
@@ -6,13 +6,34 @@
  * access to the bridge so the rest of the frontend can gracefully degrade
  * when running as a PWA (no bridge present).
  *
+ * Intent protocol constants from @glance-apps/intents are re-exported here
+ * so all bridge-related concerns live in one namespace.
+ *
  * Usage:
  *   import { isNativeAndroid, nativeBridge } from './native.js';
+ *   import { ACTIONS, ANDROID_ACTIONS, SOURCE_APPS } from './native.js';
  *
  *   if (isNativeAndroid()) {
  *     const steps = await nativeBridge.getSteps('2026-03-08');
  *   }
  */
+
+export {
+  ACTIONS,
+  ANDROID_ACTIONS,
+  ENTITY_TYPES,
+  EVENTS,
+  PRIORITY,
+  PRIORITY_ALIASES,
+  QUERY_RETURN_VARS,
+  RETURN_VARS,
+  RETURN_VAR_TYPES,
+  SCHEMA_VERSION,
+  SOURCE_APPS,
+  TABS,
+  UNIVERSAL_RETURN_VARS,
+  UPDATED_FIELDS,
+} from '@glance-apps/intents';
 
 const DEVICE_ID_KEY = 'dayglance_device_id';
 


### PR DESCRIPTION
## Summary

- Adds `@glance-apps/intents@^1.0.1` as a dependency
- Re-exports all intent protocol constants from `src/native.js` (`ACTIONS`, `ANDROID_ACTIONS`, `EVENTS`, `ENTITY_TYPES`, `PRIORITY`, `TABS`, `RETURN_VARS`, `SOURCE_APPS`, `SCHEMA_VERSION`, `UPDATED_FIELDS`, etc.) so they live alongside the `DayGlanceNative` bridge and are importable from a single namespace
- No behavior change — constants only

This is Phase 2 PR #1 from `dayglance-intents-package.md`. It unblocks the handler skeleton (PR #2) and all subsequent intent PRs, which will import constants from `./native.js` rather than embedding raw strings.

## Test plan

- [ ] `npm run build` passes (verified locally — ✓)
- [ ] `npm test` passes — 156 tests pass (verified locally — ✓)
- [ ] Confirm `import { ACTIONS, SOURCE_APPS } from './native.js'` resolves correctly in a follow-on PR

https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm)_