### PR TITLE
Add handleIntent skeleton: validation, normalization, idempotency checks

### DIFF
--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -1,0 +1,131 @@
+import {
+  ACTIONS,
+  TABS,
+  QUERY_RETURN_VARS,
+  RETURN_VAR_TYPES,
+  CreateSchema,
+  CompleteSchema,
+  OpenSchema,
+  QuerySchema,
+  normalizePriority,
+  normalizeTags,
+  normalizeDue,
+  normalizeRecurring,
+  createKey,
+} from '@glance-apps/intents';
+
+function ok(extra = {}) {
+  return { success: true, task_id: '', error: '', warning: '', ...extra };
+}
+
+function fail(message) {
+  return { success: false, task_id: '', error: message, warning: '' };
+}
+
+function validate(schema, payload) {
+  const result = schema.safeParse(payload);
+  if (!result.success) {
+    return { ok: false, error: result.error.issues[0]?.message ?? 'Invalid payload' };
+  }
+  return { ok: true, data: result.data };
+}
+
+async function handleCreate(payload, tasks) {
+  const v = validate(CreateSchema, payload);
+  if (!v.ok) return fail(v.error);
+
+  const raw = v.data;
+
+  const { title, tags } = normalizeTags({ title: raw.title, tags: raw.tags });
+  const { due, all_day: inferredAllDay } = normalizeDue(raw.due);
+  const priority = normalizePriority(raw.priority);
+
+  let recurring;
+  try {
+    recurring = normalizeRecurring(raw.recurring);
+  } catch (e) {
+    return fail(`Invalid recurring value: ${raw.recurring}`);
+  }
+
+  const normalized = {
+    title,
+    tags,
+    due,
+    all_day: raw.all_day !== undefined ? raw.all_day : inferredAllDay,
+    duration: raw.duration,
+    deadline: raw.deadline,
+    notes: raw.notes,
+    project: raw.project,
+    priority,
+    recurring,
+    source_app: raw.source_app,
+    source_entity_id: raw.source_entity_id,
+  };
+
+  let warning = '';
+  let intentKey = null;
+
+  if (raw.source_app && raw.source_entity_id) {
+    intentKey = await createKey(raw.source_app, raw.source_entity_id, due);
+    const existing = tasks.find(t => t._intentKey === intentKey && !t.completed);
+    if (existing) {
+      warning = `Task already exists; will update (id: ${existing.id})`;
+    }
+  }
+
+  return ok({ warning, _normalized: normalized, _intentKey: intentKey });
+}
+
+function handleComplete(payload) {
+  const v = validate(CompleteSchema, payload);
+  if (!v.ok) return fail(v.error);
+  return ok({ _normalized: v.data });
+}
+
+function handleOpen(payload) {
+  const v = validate(OpenSchema, payload);
+  if (!v.ok) return fail(v.error);
+
+  const requested = v.data.tab;
+  const tab = Object.values(TABS).includes(requested) ? requested : TABS.GLANCE;
+
+  return ok({ _normalized: { tab } });
+}
+
+function handleQuery(payload) {
+  const v = validate(QuerySchema, payload);
+  if (!v.ok) return fail(v.error);
+
+  // Query vars are populated by the executor (PR #6); skeleton returns typed zero-values.
+  const queryVars = Object.fromEntries(
+    Object.values(QUERY_RETURN_VARS).map(k => [k, RETURN_VAR_TYPES[k] === 'string' ? '' : 0])
+  );
+
+  return ok(queryVars);
+}
+
+/**
+ * Core intent handler. Validates, normalizes, and checks idempotency.
+ * Execution is stubbed — filled in by subsequent PRs per action.
+ *
+ * @param {string} action - One of the ACTIONS constants
+ * @param {object} payload - Raw payload from the transport layer
+ * @param {{ tasks?: object[] }} context - Read-only task list for idempotency checks
+ * @returns {Promise<object>} Result: { success, task_id, error, warning, ...queryVars? }
+ */
+export async function handleIntent(action, payload, context = {}) {
+  const { tasks = [] } = context;
+
+  switch (action) {
+    case ACTIONS.CREATE:
+      return handleCreate(payload, tasks);
+    case ACTIONS.COMPLETE:
+      return handleComplete(payload);
+    case ACTIONS.OPEN:
+      return handleOpen(payload);
+    case ACTIONS.QUERY:
+      return handleQuery(payload);
+    default:
+      return fail(`Unknown action: ${action}`);
+  }
+}

--- a/src/intents/handleIntent.test.js
+++ b/src/intents/handleIntent.test.js
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import { createKey, TABS, QUERY_RETURN_VARS } from '@glance-apps/intents';
+import { handleIntent } from './handleIntent.js';
+
+// ─── create ────────────────────────────────────────────────────────────────
+
+describe('handleIntent create', () => {
+  it('succeeds with a minimal valid payload', async () => {
+    const r = await handleIntent('create', { title: 'Buy milk' });
+    expect(r.success).toBe(true);
+    expect(r.error).toBe('');
+    expect(r._normalized.title).toBe('Buy milk');
+  });
+
+  it('fails when title is missing', async () => {
+    const r = await handleIntent('create', {});
+    expect(r.success).toBe(false);
+    expect(r.error).toBeTruthy();
+  });
+
+  it('fails on unknown fields (strict schema)', async () => {
+    const r = await handleIntent('create', { title: 'Test', bogus: true });
+    expect(r.success).toBe(false);
+  });
+
+  it('normalizes priority from string to number', async () => {
+    const r = await handleIntent('create', { title: 'Test', priority: 'HIGH' });
+    expect(r.success).toBe(true);
+    expect(r._normalized.priority).toBe(3);
+  });
+
+  it('normalizes priority from integer', async () => {
+    const r = await handleIntent('create', { title: 'Test', priority: 2 });
+    expect(r._normalized.priority).toBe(2);
+  });
+
+  it('parses inline #tags from title and merges with tags field', async () => {
+    const r = await handleIntent('create', { title: 'Buy milk #groceries', tags: 'errands' });
+    expect(r._normalized.title).toBe('Buy milk');
+    expect(r._normalized.tags).toContain('groceries');
+    expect(r._normalized.tags).toContain('errands');
+  });
+
+  it('deduplicates tags across title and tags field', async () => {
+    const r = await handleIntent('create', { title: 'Task #home', tags: 'home,work' });
+    const count = r._normalized.tags.filter(t => t === 'home').length;
+    expect(count).toBe(1);
+    expect(r._normalized.tags).toContain('work');
+  });
+
+  it('normalizes a date-only due to all_day', async () => {
+    const r = await handleIntent('create', { title: 'Test', due: '2026-05-21' });
+    expect(r._normalized.due).toBe('2026-05-21');
+    expect(r._normalized.all_day).toBe(true);
+  });
+
+  it('normalizes a datetime due to timed task', async () => {
+    const r = await handleIntent('create', { title: 'Test', due: '2026-05-21T10:00:00Z' });
+    expect(r._normalized.all_day).toBe(false);
+  });
+
+  it('explicit all_day overrides the inferred value', async () => {
+    const r = await handleIntent('create', { title: 'Test', due: '2026-05-21', all_day: false });
+    expect(r._normalized.all_day).toBe(false);
+  });
+
+  it('expands recurring shorthand to a FREQ= rule string', async () => {
+    const r = await handleIntent('create', { title: 'Test', recurring: 'daily' });
+    expect(r._normalized.recurring).toBe('FREQ=DAILY');
+  });
+
+  it('passes through raw FREQ= strings unchanged', async () => {
+    const rrule = 'FREQ=WEEKLY;BYDAY=MO,WE,FR';
+    const r = await handleIntent('create', { title: 'Test', recurring: rrule });
+    expect(r._normalized.recurring).toBe(rrule);
+  });
+
+  it('fails on invalid recurring strings', async () => {
+    const r = await handleIntent('create', { title: 'Test', recurring: 'RRULE:FREQ=DAILY' });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('recurring');
+  });
+
+  it('omits intentKey when source_app is absent', async () => {
+    const r = await handleIntent('create', { title: 'Test' });
+    expect(r._intentKey).toBeNull();
+  });
+
+  it('computes intentKey when source_app and source_entity_id are present', async () => {
+    const r = await handleIntent('create', {
+      title: 'Test',
+      source_app: 'app.lastglance',
+      source_entity_id: 'chore_1',
+      due: '2026-06-01',
+    });
+    expect(r._intentKey).toBeTruthy();
+    expect(typeof r._intentKey).toBe('string');
+  });
+
+  it('produces a stable intentKey for the same inputs', async () => {
+    const payload = { title: 'T', source_app: 'app.lastglance', source_entity_id: 'c1', due: '2026-06-01' };
+    const r1 = await handleIntent('create', payload);
+    const r2 = await handleIntent('create', payload);
+    expect(r1._intentKey).toBe(r2._intentKey);
+  });
+
+  it('warns when a matching non-completed task already exists', async () => {
+    const key = await createKey('app.lastglance', 'chore_42', '2026-06-01');
+    const existing = { id: 'tsk_1', _intentKey: key, completed: false };
+
+    const r = await handleIntent('create', {
+      title: 'Existing chore',
+      source_app: 'app.lastglance',
+      source_entity_id: 'chore_42',
+      due: '2026-06-01',
+    }, { tasks: [existing] });
+
+    expect(r.success).toBe(true);
+    expect(r.warning).toContain('tsk_1');
+  });
+
+  it('does not warn when the matching task is already completed', async () => {
+    const key = await createKey('app.lastglance', 'chore_42', '2026-06-01');
+    const existing = { id: 'tsk_1', _intentKey: key, completed: true };
+
+    const r = await handleIntent('create', {
+      title: 'Existing chore',
+      source_app: 'app.lastglance',
+      source_entity_id: 'chore_42',
+      due: '2026-06-01',
+    }, { tasks: [existing] });
+
+    expect(r.warning).toBe('');
+  });
+});
+
+// ─── complete ──────────────────────────────────────────────────────────────
+
+describe('handleIntent complete', () => {
+  it('succeeds with a valid title', async () => {
+    const r = await handleIntent('complete', { title: 'Feed cat' });
+    expect(r.success).toBe(true);
+    expect(r._normalized.title).toBe('Feed cat');
+  });
+
+  it('fails when title is missing', async () => {
+    const r = await handleIntent('complete', {});
+    expect(r.success).toBe(false);
+    expect(r.error).toBeTruthy();
+  });
+
+  it('accepts an optional completed_at timestamp', async () => {
+    const r = await handleIntent('complete', {
+      title: 'Feed cat',
+      completed_at: '2026-05-21T09:00:00Z',
+    });
+    expect(r.success).toBe(true);
+    expect(r._normalized.completed_at).toBe('2026-05-21T09:00:00Z');
+  });
+
+  it('fails on unknown fields', async () => {
+    const r = await handleIntent('complete', { title: 'Feed cat', bogus: true });
+    expect(r.success).toBe(false);
+  });
+});
+
+// ─── open ──────────────────────────────────────────────────────────────────
+
+describe('handleIntent open', () => {
+  it('succeeds with a recognised tab name', async () => {
+    const r = await handleIntent('open', { tab: 'inbox' });
+    expect(r.success).toBe(true);
+    expect(r._normalized.tab).toBe(TABS.INBOX);
+  });
+
+  it('falls back to glance for an unrecognised tab', async () => {
+    const r = await handleIntent('open', { tab: 'does-not-exist' });
+    expect(r.success).toBe(true);
+    expect(r._normalized.tab).toBe(TABS.GLANCE);
+  });
+
+  it('falls back to glance when tab is omitted', async () => {
+    const r = await handleIntent('open', {});
+    expect(r.success).toBe(true);
+    expect(r._normalized.tab).toBe(TABS.GLANCE);
+  });
+
+  it('accepts every valid tab value', async () => {
+    for (const tab of Object.values(TABS)) {
+      const r = await handleIntent('open', { tab });
+      expect(r._normalized.tab).toBe(tab);
+    }
+  });
+});
+
+// ─── query ─────────────────────────────────────────────────────────────────
+
+describe('handleIntent query', () => {
+  it('succeeds with an empty payload', async () => {
+    const r = await handleIntent('query', {});
+    expect(r.success).toBe(true);
+  });
+
+  it('returns all 10 query return variables', async () => {
+    const r = await handleIntent('query', {});
+    for (const key of Object.values(QUERY_RETURN_VARS)) {
+      expect(key in r).toBe(true);
+    }
+  });
+
+  it('returns zero-values for integer vars and empty string for string vars', async () => {
+    const r = await handleIntent('query', {});
+    expect(r['%dg_count_today']).toBe(0);
+    expect(r['%dg_in_progress_title']).toBe('');
+    expect(r['%dg_next_title']).toBe('');
+  });
+
+  it('fails on unknown fields', async () => {
+    const r = await handleIntent('query', { scope: 'all' });
+    expect(r.success).toBe(false);
+  });
+});
+
+// ─── unknown action ────────────────────────────────────────────────────────
+
+describe('handleIntent unknown action', () => {
+  it('returns failure for an unrecognised action', async () => {
+    const r = await handleIntent('destroy_everything', {});
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('Unknown action');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/intents/handleIntent.js` — the transport-agnostic core of the intent protocol
- For all four inbound actions (`create`, `complete`, `open`, `query`): validates via `@glance-apps/intents` Zod schemas, normalizes flexible inputs, checks create idempotency against the task list
- Returns typed result objects without executing any state changes — execution is wired in subsequent PRs per action
- 31 tests covering validation, normalization, all tab fallback cases, all query return variables, idempotency warning, and the unknown-action guard

This is Phase 2 PR #2 from `dayglance-intents-package.md`.

## What's in the skeleton

- **Validation**: strict Zod schemas reject unknown fields and missing required fields; error message surfaces the first issue
- **Normalization**: `normalizeTags` strips inline `#tags` from title and merges/dedupes with the `tags` field; `normalizeDue` infers `all_day` from date format; `normalizePriority` accepts int or string; `normalizeRecurring` expands shorthands (`daily` → `FREQ=DAILY`) and passes through `FREQ=…` strings
- **Idempotency (create)**: computes `createKey(source_app, source_entity_id, due)` and searches for a matching non-completed task with `_intentKey`; sets `warning` if found. No task has `_intentKey` yet — PR #3 adds that when execution is wired.
- **Open tab fallback**: unrecognised or omitted `tab` silently falls back to `glance`
- **Query zero-values**: all 10 `%dg_` return variables are present but zero-valued; PR #6 fills them in

## One thing learned during implementation

`normalizeRecurring` accepts `FREQ=…` strings directly but throws on `RRULE:FREQ=…` (the prefix is not part of the format the package uses). The handler catches the throw and returns a clean validation error. Tests cover this.

## Test plan

- [x] 31 new handler tests — all pass
- [x] All 187 tests pass (`npm test`)
- [x] `npm run build` clean

https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm)_