### PR TITLE
Implement handleIntent.create execution: task creation, idempotency, returns task_id

### DIFF
--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -14,6 +14,8 @@ import {
   createKey,
 } from '@glance-apps/intents';
 
+export const DEFAULT_TASK_COLOR = 'bg-blue-500';
+
 function ok(extra = {}) {
   return { success: true, task_id: '', error: '', warning: '', ...extra };
 }
@@ -30,28 +32,121 @@ function validate(schema, payload) {
   return { ok: true, data: result.data };
 }
 
-async function handleCreate(payload, tasks) {
+/**
+ * Re-embed tags into the title so dayGLANCE's tag-in-title storage model is
+ * satisfied. normalizeTags strips inline #tags from the title; this puts the
+ * full merged+deduped set back.
+ */
+function rebuildTitle(cleanedTitle, tags) {
+  if (!tags?.length) return cleanedTitle;
+  return `${cleanedTitle} ${tags.map(t => `#${t}`).join(' ')}`;
+}
+
+/**
+ * Split a normalized ISO `due` string into the dayGLANCE task scheduling fields.
+ * Date-only strings (YYYY-MM-DD) and explicit all_day=true produce isAllDay tasks.
+ */
+function parseDue(due, allDay) {
+  if (!due) return null;
+
+  const dateOnly = !due.includes('T');
+  if (dateOnly || allDay) {
+    return { date: due.slice(0, 10), startTime: '00:00', isAllDay: true };
+  }
+
+  const d = new Date(due);
+  const date = [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, '0'),
+    String(d.getDate()).padStart(2, '0'),
+  ].join('-');
+  const startTime = [
+    String(d.getHours()).padStart(2, '0'),
+    String(d.getMinutes()).padStart(2, '0'),
+  ].join(':');
+
+  return { date, startTime, isAllDay: false };
+}
+
+/**
+ * Convert a normalizeRecurring-produced `FREQ=…` string to dayGLANCE's
+ * internal recurrence object `{ type, startDate, daysOfWeek?, … }`.
+ */
+function freqToRecurrence(freqStr, startDate) {
+  const DAY_MAP = { MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6, SU: 0 };
+  const parts = Object.fromEntries(
+    freqStr.split(';').map(p => {
+      const eq = p.indexOf('=');
+      return [p.slice(0, eq).toUpperCase(), p.slice(eq + 1).toUpperCase()];
+    })
+  );
+
+  const base = { startDate };
+
+  switch (parts.FREQ) {
+    case 'DAILY':
+      return { ...base, type: 'daily' };
+    case 'WEEKLY': {
+      if (parts.BYDAY) {
+        const daysOfWeek = parts.BYDAY.split(',')
+          .map(d => DAY_MAP[d.trim()])
+          .filter(d => d !== undefined);
+        return { ...base, type: 'weekly', daysOfWeek };
+      }
+      return { ...base, type: 'weekly' };
+    }
+    case 'MONTHLY':
+      return { ...base, type: 'monthly' };
+    case 'YEARLY':
+      return { ...base, type: 'yearly' };
+    default:
+      return { ...base, type: 'daily' };
+  }
+}
+
+/** Match a project name or ID against the projects list. Returns projectId or undefined. */
+function resolveProjectId(nameOrId, projects) {
+  if (!nameOrId || !projects?.length) return undefined;
+  return (
+    projects.find(p => p.id === nameOrId)?.id ??
+    projects.find(p => p.name?.toLowerCase() === nameOrId.toLowerCase())?.id
+  );
+}
+
+async function handleCreate(payload, context) {
+  const {
+    tasks = [],
+    unscheduledTasks = [],
+    recurringTasks = [],
+    setTasks,
+    setUnscheduledTasks,
+    setRecurringTasks,
+    projects = [],
+  } = context;
+
   const v = validate(CreateSchema, payload);
   if (!v.ok) return fail(v.error);
 
   const raw = v.data;
 
-  const { title, tags } = normalizeTags({ title: raw.title, tags: raw.tags });
+  const { title: cleanedTitle, tags } = normalizeTags({ title: raw.title, tags: raw.tags });
   const { due, all_day: inferredAllDay } = normalizeDue(raw.due);
   const priority = normalizePriority(raw.priority);
 
   let recurring;
   try {
     recurring = normalizeRecurring(raw.recurring);
-  } catch (e) {
+  } catch {
     return fail(`Invalid recurring value: ${raw.recurring}`);
   }
 
+  const allDay = raw.all_day !== undefined ? raw.all_day : inferredAllDay;
+
   const normalized = {
-    title,
+    title: cleanedTitle,
     tags,
     due,
-    all_day: raw.all_day !== undefined ? raw.all_day : inferredAllDay,
+    all_day: allDay,
     duration: raw.duration,
     deadline: raw.deadline,
     notes: raw.notes,
@@ -62,18 +157,97 @@ async function handleCreate(payload, tasks) {
     source_entity_id: raw.source_entity_id,
   };
 
-  let warning = '';
   let intentKey = null;
 
   if (raw.source_app && raw.source_entity_id) {
     intentKey = await createKey(raw.source_app, raw.source_entity_id, due);
-    const existing = tasks.find(t => t._intentKey === intentKey && !t.completed);
+
+    const existing =
+      tasks.find(t => t._intentKey === intentKey && !t.completed) ||
+      unscheduledTasks.find(t => t._intentKey === intentKey && !t.completed) ||
+      recurringTasks.find(t => t._intentKey === intentKey);
+
     if (existing) {
-      warning = `Task already exists; will update (id: ${existing.id})`;
+      if (setTasks || setUnscheduledTasks || setRecurringTasks) {
+        // Execute: update the existing task in whichever list it lives in.
+        const projectId = resolveProjectId(normalized.project, projects);
+        const taskTitle = rebuildTitle(cleanedTitle, tags);
+        const updates = {
+          title: taskTitle,
+          notes: normalized.notes ?? existing.notes,
+          priority: priority ?? existing.priority,
+          ...(projectId !== undefined ? { projectId } : {}),
+        };
+
+        if (tasks.find(t => t.id === existing.id)) {
+          setTasks(prev => prev.map(t => t.id === existing.id ? { ...t, ...updates } : t));
+        } else if (unscheduledTasks.find(t => t.id === existing.id)) {
+          setUnscheduledTasks(prev => prev.map(t => t.id === existing.id ? { ...t, ...updates } : t));
+        } else {
+          setRecurringTasks(prev => prev.map(t => t.id === existing.id ? { ...t, ...updates } : t));
+        }
+
+        return ok({ task_id: existing.id, warning: 'Updated existing task' });
+      }
+
+      // Skeleton: no setters — return normalized result with warning.
+      const warning = `Task already exists; will update (id: ${existing.id})`;
+      return ok({ warning, _normalized: normalized, _intentKey: intentKey });
     }
   }
 
-  return ok({ warning, _normalized: normalized, _intentKey: intentKey });
+  // Skeleton mode: no setters provided, return normalized result only.
+  if (!setTasks && !setUnscheduledTasks && !setRecurringTasks) {
+    return ok({ warning: '', _normalized: normalized, _intentKey: intentKey });
+  }
+
+  // Execute: create a new task.
+  const taskId = crypto.randomUUID();
+  const projectId = resolveProjectId(normalized.project, projects);
+  const taskTitle = rebuildTitle(cleanedTitle, tags);
+
+  const baseTask = {
+    id: taskId,
+    title: taskTitle,
+    duration: normalized.duration ?? 30,
+    color: DEFAULT_TASK_COLOR,
+    completed: false,
+    notes: normalized.notes ?? '',
+    subtasks: [],
+    ...(projectId !== undefined ? { projectId } : {}),
+    ...(normalized.source_app ? { source_app: normalized.source_app } : {}),
+    ...(normalized.source_entity_id ? { source_entity_id: normalized.source_entity_id } : {}),
+    ...(intentKey ? { _intentKey: intentKey } : {}),
+  };
+
+  if (recurring) {
+    const scheduled = parseDue(due, allDay);
+    const startDate = scheduled?.date ?? new Date().toISOString().slice(0, 10);
+    setRecurringTasks(prev => [...prev, {
+      ...baseTask,
+      startTime: scheduled && !scheduled.isAllDay ? scheduled.startTime : '00:00',
+      isAllDay: allDay ?? true,
+      recurrence: freqToRecurrence(recurring, startDate),
+      completedDates: [],
+      exceptions: {},
+    }]);
+  } else if (due) {
+    const scheduled = parseDue(due, allDay);
+    setTasks(prev => [...prev, {
+      ...baseTask,
+      date: scheduled.date,
+      startTime: scheduled.startTime,
+      isAllDay: scheduled.isAllDay,
+    }]);
+  } else {
+    setUnscheduledTasks(prev => [...prev, {
+      ...baseTask,
+      priority: priority ?? 0,
+      ...(normalized.deadline ? { deadline: normalized.deadline } : {}),
+    }]);
+  }
+
+  return ok({ task_id: taskId });
 }
 
 function handleComplete(payload) {
@@ -106,19 +280,18 @@ function handleQuery(payload) {
 
 /**
  * Core intent handler. Validates, normalizes, and checks idempotency.
- * Execution is stubbed — filled in by subsequent PRs per action.
+ * Executes state changes when setters are provided in context.
  *
  * @param {string} action - One of the ACTIONS constants
  * @param {object} payload - Raw payload from the transport layer
- * @param {{ tasks?: object[] }} context - Read-only task list for idempotency checks
+ * @param {object} context - { tasks?, unscheduledTasks?, recurringTasks?, projects?,
+ *                             setTasks?, setUnscheduledTasks?, setRecurringTasks? }
  * @returns {Promise<object>} Result: { success, task_id, error, warning, ...queryVars? }
  */
 export async function handleIntent(action, payload, context = {}) {
-  const { tasks = [] } = context;
-
   switch (action) {
     case ACTIONS.CREATE:
-      return handleCreate(payload, tasks);
+      return handleCreate(payload, context);
     case ACTIONS.COMPLETE:
       return handleComplete(payload);
     case ACTIONS.OPEN:

--- a/src/intents/handleIntent.test.js
+++ b/src/intents/handleIntent.test.js
@@ -36,6 +36,7 @@ describe('handleIntent create', () => {
 
   it('parses inline #tags from title and merges with tags field', async () => {
     const r = await handleIntent('create', { title: 'Buy milk #groceries', tags: 'errands' });
+    // _normalized.title is the clean title (tags stripped); tags are in _normalized.tags.
     expect(r._normalized.title).toBe('Buy milk');
     expect(r._normalized.tags).toContain('groceries');
     expect(r._normalized.tags).toContain('errands');
@@ -228,5 +229,145 @@ describe('handleIntent unknown action', () => {
     const r = await handleIntent('destroy_everything', {});
     expect(r.success).toBe(false);
     expect(r.error).toContain('Unknown action');
+  });
+});
+
+// ─── create execution ──────────────────────────────────────────────────────
+
+// Capture context: handler reads tasks/projects from it and writes via setters.
+// Tests read _tasks/_inbox/_recurring to inspect results after the handler runs.
+function makeCapture(initial = {}) {
+  const state = {
+    tasks: [...(initial.tasks ?? [])],
+    unscheduledTasks: [...(initial.unscheduledTasks ?? [])],
+    recurringTasks: [...(initial.recurringTasks ?? [])],
+    projects: initial.projects ?? [],
+  };
+
+  const ctx = {
+    get tasks() { return state.tasks; },
+    get unscheduledTasks() { return state.unscheduledTasks; },
+    get recurringTasks() { return state.recurringTasks; },
+    get projects() { return state.projects; },
+    setTasks: fn => { state.tasks = fn(state.tasks); },
+    setUnscheduledTasks: fn => { state.unscheduledTasks = fn(state.unscheduledTasks); },
+    setRecurringTasks: fn => { state.recurringTasks = fn(state.recurringTasks); },
+    // Aliases for clarity in test assertions.
+    get _tasks() { return state.tasks; },
+    get _inbox() { return state.unscheduledTasks; },
+    get _recurring() { return state.recurringTasks; },
+  };
+  return ctx;
+}
+
+describe('handleIntent create execution', () => {
+  it('returns task_id on success', async () => {
+    const ctx = makeCapture();
+    const r = await handleIntent('create', { title: 'Buy milk' }, ctx);
+    expect(r.success).toBe(true);
+    expect(r.task_id).toBeTruthy();
+  });
+
+  it('creates an inbox task when due is absent', async () => {
+    const ctx = makeCapture();
+    await handleIntent('create', { title: 'Buy milk', priority: 2 }, ctx);
+    expect(ctx._inbox).toHaveLength(1);
+    expect(ctx._tasks).toHaveLength(0);
+    expect(ctx._inbox[0].priority).toBe(2);
+  });
+
+  it('creates a scheduled task when due is a date', async () => {
+    const ctx = makeCapture();
+    await handleIntent('create', { title: 'Dentist', due: '2026-06-10' }, ctx);
+    expect(ctx._tasks).toHaveLength(1);
+    expect(ctx._tasks[0].date).toBe('2026-06-10');
+    expect(ctx._tasks[0].isAllDay).toBe(true);
+  });
+
+  it('creates a timed scheduled task when due includes a time', async () => {
+    const ctx = makeCapture();
+    await handleIntent('create', { title: 'Standup', due: '2026-06-10T09:00:00Z' }, ctx);
+    expect(ctx._tasks).toHaveLength(1);
+    expect(ctx._tasks[0].isAllDay).toBe(false);
+    expect(ctx._tasks[0].startTime).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it('creates a recurring template when recurring is provided', async () => {
+    const ctx = makeCapture();
+    await handleIntent('create', { title: 'Morning run', recurring: 'daily', due: '2026-06-01' }, ctx);
+    expect(ctx._recurring).toHaveLength(1);
+    expect(ctx._recurring[0].recurrence.type).toBe('daily');
+    expect(ctx._tasks).toHaveLength(0);
+  });
+
+  it('stores title with tags embedded', async () => {
+    const ctx = makeCapture();
+    await handleIntent('create', { title: 'Buy milk #grocery', tags: 'errands' }, ctx);
+    const t = ctx._inbox[0];
+    expect(t.title).toContain('#grocery');
+    expect(t.title).toContain('#errands');
+  });
+
+  it('stores source_app, source_entity_id, and _intentKey on the task', async () => {
+    const ctx = makeCapture();
+    await handleIntent('create', {
+      title: 'Chore',
+      source_app: 'app.lastglance',
+      source_entity_id: 'chore_1',
+    }, ctx);
+    const t = ctx._inbox[0];
+    expect(t.source_app).toBe('app.lastglance');
+    expect(t.source_entity_id).toBe('chore_1');
+    expect(t._intentKey).toBeTruthy();
+  });
+
+  it('resolves project by name', async () => {
+    const ctx = makeCapture({ projects: [{ id: 'proj-1', name: 'Home' }] });
+    await handleIntent('create', { title: 'Fix sink', project: 'Home' }, ctx);
+    expect(ctx._inbox[0].projectId).toBe('proj-1');
+  });
+
+  it('resolves project by id', async () => {
+    const ctx = makeCapture({ projects: [{ id: 'proj-1', name: 'Home' }] });
+    await handleIntent('create', { title: 'Fix sink', project: 'proj-1' }, ctx);
+    expect(ctx._inbox[0].projectId).toBe('proj-1');
+  });
+
+  it('omits projectId when project does not match', async () => {
+    const ctx = makeCapture({ projects: [{ id: 'proj-1', name: 'Home' }] });
+    await handleIntent('create', { title: 'Fix sink', project: 'Unknown Project' }, ctx);
+    expect(ctx._inbox[0].projectId).toBeUndefined();
+  });
+
+  it('sets the deadline on inbox tasks', async () => {
+    const ctx = makeCapture();
+    await handleIntent('create', { title: 'Tax return', deadline: '2026-04-15' }, ctx);
+    expect(ctx._inbox[0].deadline).toBe('2026-04-15');
+  });
+
+  it('updates existing task instead of duplicating (idempotency)', async () => {
+    const key = await createKey('app.lastglance', 'chore_42', '2026-06-01');
+    const existing = { id: 'tsk_1', title: 'Old title', notes: '', priority: 0, _intentKey: key, completed: false };
+    const ctx = makeCapture({ tasks: [existing] });
+
+    const r = await handleIntent('create', {
+      title: 'New title',
+      source_app: 'app.lastglance',
+      source_entity_id: 'chore_42',
+      due: '2026-06-01',
+    }, ctx);
+
+    expect(r.success).toBe(true);
+    expect(r.task_id).toBe('tsk_1');
+    expect(r.warning).toContain('Updated');
+    expect(ctx._tasks).toHaveLength(1);
+    expect(ctx._tasks[0].title).toBe('New title');
+  });
+
+  it('uses default color and 30-min duration when not specified', async () => {
+    const ctx = makeCapture();
+    await handleIntent('create', { title: 'Quick task' }, ctx);
+    expect(ctx._inbox[0].color).toBe('bg-blue-500');
+    expect(ctx._inbox[0].duration).toBe(30);
   });
 });


### PR DESCRIPTION
## Summary

- `handleIntent('create', payload, context)` now writes to React state when setters are provided
- Three creation paths mirror `addTask` behaviour: inbox (no `due`), scheduled (`due` present), recurring (`recurring` present)
- Idempotency update path: matching `_intentKey` → update in-place, return existing `task_id` with warning
- Tags re-embedded into the stored title (`#tag` format) since dayGLANCE keeps tags inline in the title string
- Project resolved by name (case-insensitive) or id; no match silently omits `projectId`
- `source_app`, `source_entity_id`, and `_intentKey` stored on every intent-created task for future idempotency lookups
- 13 new execution tests; 200 total passing

This is Phase 2 PR #3 from `dayglance-intents-package.md`.

## What changed in the handler

`handleCreate` now accepts the full context object `{ tasks, unscheduledTasks, recurringTasks, setTasks, setUnscheduledTasks, setRecurringTasks, projects }`. When setters are absent it falls back to the skeleton path (validation + normalization only), so the PR #2 skeleton tests are unchanged.

Two new helper functions (internal):
- `parseDue(due, allDay)` — splits an ISO due string into `{ date, startTime, isAllDay }`
- `freqToRecurrence(freqStr, startDate)` — converts `FREQ=DAILY` / `FREQ=WEEKLY;BYDAY=…` / etc. to dayGLANCE's `{ type, startDate, daysOfWeek? }` recurrence object

## What's still stubbed

`handleComplete`, `handleOpen`, `handleQuery` are still skeleton only — those execute in PRs #4–6. No transport wiring yet (PRs #7–9).

## Test plan

- [x] 200 tests pass (`npm test`)
- [x] `npm run build` clean
- [ ] End-to-end: wire a transport (PR #7) and call `handleIntent('create', …)` from a real event file

https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm)_