### PR TITLE
Implement handleIntent.complete execution: title search, tiebreak, warning

### DIFF
--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -250,10 +250,64 @@ async function handleCreate(payload, context) {
   return ok({ task_id: taskId });
 }
 
-function handleComplete(payload) {
+function handleComplete(payload, context) {
   const v = validate(CompleteSchema, payload);
   if (!v.ok) return fail(v.error);
-  return ok({ _normalized: v.data });
+
+  const { title: searchTitle, completed_at } = v.data;
+  const { tasks = [], unscheduledTasks = [], setTasks, setUnscheduledTasks } = context;
+
+  // Skeleton mode: no setters provided.
+  if (!setTasks && !setUnscheduledTasks) {
+    return ok({ _normalized: v.data });
+  }
+
+  // Collect all incomplete tasks, tagging each with which list it came from.
+  const candidates = [
+    ...tasks.map(t => ({ ...t, _list: 'tasks' })),
+    ...unscheduledTasks.map(t => ({ ...t, _list: 'unscheduled' })),
+  ].filter(t => !t.completed);
+
+  const norm = s => s.toLowerCase().trim();
+  const needle = norm(searchTitle);
+
+  // Exact match first, then partial.
+  let matches = candidates.filter(t => norm(t.title) === needle);
+  if (!matches.length) {
+    matches = candidates.filter(t => norm(t.title).includes(needle));
+  }
+
+  if (!matches.length) {
+    return fail('no matching task');
+  }
+
+  let warning = '';
+  let target = matches[0];
+
+  if (matches.length > 1) {
+    // Soonest-due tiebreak: scheduled date, then deadline, then no-date (sorts last).
+    const dueOf = t => t.date || t.deadline || null;
+    matches.sort((a, b) => {
+      const da = dueOf(a), db = dueOf(b);
+      if (!da && !db) return 0;
+      if (!da) return 1;
+      if (!db) return -1;
+      return da < db ? -1 : da > db ? 1 : 0;
+    });
+    target = matches[0];
+    warning = `${matches.length} tasks matched "${searchTitle}"; completed soonest-due (${target.date || target.deadline || 'no date'})`;
+  }
+
+  const completedAt = completed_at || new Date().toISOString();
+  const patch = { completed: true, completedAt };
+
+  if (target._list === 'tasks') {
+    setTasks(prev => prev.map(t => t.id === target.id ? { ...t, ...patch } : t));
+  } else {
+    setUnscheduledTasks(prev => prev.map(t => t.id === target.id ? { ...t, ...patch } : t));
+  }
+
+  return ok({ task_id: target.id, warning });
 }
 
 function handleOpen(payload) {
@@ -293,7 +347,7 @@ export async function handleIntent(action, payload, context = {}) {
     case ACTIONS.CREATE:
       return handleCreate(payload, context);
     case ACTIONS.COMPLETE:
-      return handleComplete(payload);
+      return handleComplete(payload, context);
     case ACTIONS.OPEN:
       return handleOpen(payload);
     case ACTIONS.QUERY:

--- a/src/intents/handleIntent.test.js
+++ b/src/intents/handleIntent.test.js
@@ -165,6 +165,98 @@ describe('handleIntent complete', () => {
   });
 });
 
+// ─── complete execution ────────────────────────────────────────────────────
+
+function task(overrides) {
+  return { id: crypto.randomUUID(), title: 'Task', completed: false, duration: 30, color: 'bg-blue-500', ...overrides };
+}
+
+describe('handleIntent complete execution', () => {
+  it('fails when no task matches', async () => {
+    const ctx = makeCapture({ tasks: [task({ title: 'Feed cat' })] });
+    const r = await handleIntent('complete', { title: 'Walk dog' }, ctx);
+    expect(r.success).toBe(false);
+    expect(r.error).toBe('no matching task');
+  });
+
+  it('completes an exact-match scheduled task', async () => {
+    const t = task({ title: 'Feed cat', date: '2026-06-01' });
+    const ctx = makeCapture({ tasks: [t] });
+    const r = await handleIntent('complete', { title: 'Feed cat' }, ctx);
+    expect(r.success).toBe(true);
+    expect(r.task_id).toBe(t.id);
+    expect(ctx._tasks[0].completed).toBe(true);
+    expect(ctx._tasks[0].completedAt).toBeTruthy();
+  });
+
+  it('completes an exact-match inbox task', async () => {
+    const t = task({ title: 'Buy milk', priority: 1 });
+    const ctx = makeCapture({ unscheduledTasks: [t] });
+    const r = await handleIntent('complete', { title: 'Buy milk' }, ctx);
+    expect(r.success).toBe(true);
+    expect(ctx._inbox[0].completed).toBe(true);
+  });
+
+  it('uses the provided completed_at timestamp', async () => {
+    const t = task({ title: 'Feed cat', date: '2026-06-01' });
+    const ctx = makeCapture({ tasks: [t] });
+    await handleIntent('complete', { title: 'Feed cat', completed_at: '2026-06-01T08:00:00Z' }, ctx);
+    expect(ctx._tasks[0].completedAt).toBe('2026-06-01T08:00:00Z');
+  });
+
+  it('falls back to a partial match when no exact match exists', async () => {
+    const t = task({ title: 'Feed cat #home', date: '2026-06-01' });
+    const ctx = makeCapture({ tasks: [t] });
+    const r = await handleIntent('complete', { title: 'Feed cat' }, ctx);
+    expect(r.success).toBe(true);
+    expect(ctx._tasks[0].completed).toBe(true);
+  });
+
+  it('prefers exact match over partial when both exist', async () => {
+    const exact = task({ id: 'exact', title: 'Feed cat', date: '2026-06-02' });
+    const partial = task({ id: 'partial', title: 'Feed cat and dog', date: '2026-06-01' });
+    const ctx = makeCapture({ tasks: [partial, exact] });
+    const r = await handleIntent('complete', { title: 'Feed cat' }, ctx);
+    expect(r.task_id).toBe('exact');
+    expect(r.warning).toBe('');
+  });
+
+  it('completes soonest-due task and sets warning on multiple matches', async () => {
+    const later = task({ id: 'later', title: 'Feed cat', date: '2026-06-10' });
+    const sooner = task({ id: 'sooner', title: 'Feed cat', date: '2026-06-01' });
+    const ctx = makeCapture({ tasks: [later, sooner] });
+    const r = await handleIntent('complete', { title: 'Feed cat' }, ctx);
+    expect(r.task_id).toBe('sooner');
+    expect(r.warning).toContain('2 tasks matched');
+    expect(ctx._tasks.find(t => t.id === 'sooner').completed).toBe(true);
+    expect(ctx._tasks.find(t => t.id === 'later').completed).toBe(false);
+  });
+
+  it('tasks without a date sort after dated tasks in tiebreak', async () => {
+    const nodueInbox = task({ id: 'nodueInbox', title: 'Feed cat', priority: 0 });
+    const dated = task({ id: 'dated', title: 'Feed cat', date: '2026-06-10' });
+    const ctx = makeCapture({ tasks: [dated], unscheduledTasks: [nodueInbox] });
+    const r = await handleIntent('complete', { title: 'Feed cat' }, ctx);
+    expect(r.task_id).toBe('dated');
+  });
+
+  it('skips already-completed tasks in search', async () => {
+    const done = task({ title: 'Feed cat', date: '2026-06-01', completed: true });
+    const todo = task({ id: 'todo', title: 'Feed cat', date: '2026-06-02' });
+    const ctx = makeCapture({ tasks: [done, todo] });
+    const r = await handleIntent('complete', { title: 'Feed cat' }, ctx);
+    expect(r.task_id).toBe('todo');
+    expect(r.warning).toBe('');
+  });
+
+  it('is case-insensitive', async () => {
+    const t = task({ title: 'Feed Cat', date: '2026-06-01' });
+    const ctx = makeCapture({ tasks: [t] });
+    const r = await handleIntent('complete', { title: 'feed cat' }, ctx);
+    expect(r.success).toBe(true);
+  });
+});
+
 // ─── open ──────────────────────────────────────────────────────────────────
 
 describe('handleIntent open', () => {


### PR DESCRIPTION
## Summary

- `handleIntent('complete', payload, context)` now executes when setters are provided
- Searches incomplete tasks across both `tasks` (scheduled) and `unscheduledTasks` (inbox)
- Exact title match preferred over partial; case-insensitive throughout
- Multiple matches: completes soonest-due task and sets `%dg_warning` with match count and winning date
- No match: `success=false`, `error='no matching task'`
- `completed_at` from payload used when provided, otherwise `new Date().toISOString()`
- 10 new execution tests; 210 total passing

This is Phase 2 PR #4 from `dayglance-intents-package.md`.

## Tiebreak logic

Soonest-due ordering: `task.date` (scheduled) → `task.deadline` (inbox with deadline) → no date (sorts last). This means a task due tomorrow beats an inbox task with no deadline, and an inbox task with a deadline beats one with none.

## What's still stubbed

`handleOpen` and `handleQuery` execute in PRs #5 and #6. No transport wiring yet.

## Test plan

- [x] 210 tests pass (`npm test`)
- [x] `npm run build` clean

https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm)_