### PR TITLE
Implement handleIntent.open execution: tab routing via navigate callback

### DIFF
--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -256,12 +256,16 @@ function handleComplete(payload) {
   return ok({ _normalized: v.data });
 }
 
-function handleOpen(payload) {
+function handleOpen(payload, context) {
   const v = validate(OpenSchema, payload);
   if (!v.ok) return fail(v.error);
 
   const requested = v.data.tab;
   const tab = Object.values(TABS).includes(requested) ? requested : TABS.GLANCE;
+
+  // navigate(tab) is provided by the transport layer; it handles device-specific
+  // routing (mobileActiveTab vs tabletActiveTab) and the goals-enabled fallback.
+  context.navigate?.(tab);
 
   return ok({ _normalized: { tab } });
 }
@@ -295,7 +299,7 @@ export async function handleIntent(action, payload, context = {}) {
     case ACTIONS.COMPLETE:
       return handleComplete(payload);
     case ACTIONS.OPEN:
-      return handleOpen(payload);
+      return handleOpen(payload, context);
     case ACTIONS.QUERY:
       return handleQuery(payload);
     default:

--- a/src/intents/handleIntent.test.js
+++ b/src/intents/handleIntent.test.js
@@ -194,6 +194,37 @@ describe('handleIntent open', () => {
   });
 });
 
+// ─── open execution ────────────────────────────────────────────────────────
+
+describe('handleIntent open execution', () => {
+  it('calls navigate with the resolved tab', async () => {
+    const calls = [];
+    const ctx = { navigate: tab => calls.push(tab) };
+    await handleIntent('open', { tab: 'inbox' }, ctx);
+    expect(calls).toEqual(['inbox']);
+  });
+
+  it('calls navigate with glance when tab is unrecognised', async () => {
+    const calls = [];
+    const ctx = { navigate: tab => calls.push(tab) };
+    await handleIntent('open', { tab: 'nowhere' }, ctx);
+    expect(calls).toEqual(['glance']);
+  });
+
+  it('calls navigate with glance when tab is omitted', async () => {
+    const calls = [];
+    const ctx = { navigate: tab => calls.push(tab) };
+    await handleIntent('open', {}, ctx);
+    expect(calls).toEqual(['glance']);
+  });
+
+  it('does not throw when navigate is absent (skeleton mode)', async () => {
+    const r = await handleIntent('open', { tab: 'timeline' }, {});
+    expect(r.success).toBe(true);
+    expect(r._normalized.tab).toBe('timeline');
+  });
+});
+
 // ─── query ─────────────────────────────────────────────────────────────────
 
 describe('handleIntent query', () => {


### PR DESCRIPTION
## Summary

- `handleIntent('open', payload, context)` now calls `context.navigate(tab)` when provided
- The `navigate` callback is supplied by the transport layer — the handler stays transport-agnostic and doesn't know about `mobileActiveTab` vs `tabletActiveTab` or the goals-enabled fallback
- Unknown/omitted tab values still silently fall back to `TABS.GLANCE` before `navigate` is called
- No `navigate` in context → skeleton mode, returns `_normalized` as before
- 4 execution tests added; 204 total passing

This is Phase 2 PR #5 from `dayglance-intents-package.md`.

## Design note

The `navigate(tab)` interface is intentionally thin. The transport layer (URL parser, Android bridge, WebDAV poller hook) will provide a `navigate` closure that contains the device-specific logic: mobile routes to `mobileActiveTab`, tablet to `tabletActiveTab`, and the goals tab check lives there too. This keeps the handler pure and testable with a simple spy.

## Test plan

- [x] 204 tests pass (`npm test`)
- [x] `npm run build` clean

https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm)_