### PR TITLE
Intent activity log UI: log panel with inbound and outbound events

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,6 +42,7 @@ import RestoreConfirmModal from './components/RestoreConfirmModal.jsx';
 import AutoBackupManagerModal from './components/AutoBackupManagerModal.jsx';
 import ImportCalendarModal from './components/ImportCalendarModal.jsx';
 import StorageBreakdownModal from './components/StorageBreakdownModal.jsx';
+import IntentActivityLogModal from './components/IntentActivityLogModal.jsx';
 import EmptyBinConfirmModal from './components/EmptyBinConfirmModal.jsx';
 import RecurringDeleteModal from './components/RecurringDeleteModal.jsx';
 import EditRecurrenceModal from './components/EditRecurrenceModal.jsx';
@@ -578,6 +579,7 @@ const DayPlanner = () => {
   const [autoBackupRestoreConfirm, setAutoBackupRestoreConfirm] = useState(null); // { type: 'local'|'remote', id, filename, timestamp }
   const autoBackupInProgressRef = useRef(false);
   const [showStorageBreakdown, setShowStorageBreakdown] = useState(false);
+  const [showIntentActivityLog, setShowIntentActivityLog] = useState(false);
 
   const syncAllRef = useRef(null);
 
@@ -7724,6 +7726,7 @@ const DayPlanner = () => {
     autoBackupHistory, setAutoBackupHistory,
     autoBackupRestoreConfirm, setAutoBackupRestoreConfirm,
     showStorageBreakdown, setShowStorageBreakdown,
+    showIntentActivityLog, setShowIntentActivityLog,
 
     // ── Cloud sync ────────────────────────────────────────────────────────────
     cloudSyncConfig, setCloudSyncConfig,
@@ -8215,6 +8218,7 @@ const DayPlanner = () => {
 
       {/* Storage Breakdown Modal */}
       <StorageBreakdownModal />
+      <IntentActivityLogModal />
 
 
       <RecurringDeleteModal />

--- a/src/components/IntentActivityLogModal.jsx
+++ b/src/components/IntentActivityLogModal.jsx
@@ -1,0 +1,186 @@
+import React, { useState } from 'react';
+import { X, ArrowDownLeft, ArrowUpRight, Trash2 } from 'lucide-react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useSyncCtx } from '../context/SyncContext.jsx';
+import { getActivityLog, clearActivityLog } from '../intents/intentLog.js';
+
+const EVENT_COLORS = {
+  completed:   'bg-green-100 text-green-700',
+  uncompleted: 'bg-yellow-100 text-yellow-700',
+  deleted:     'bg-red-100 text-red-700',
+  rescheduled: 'bg-blue-100 text-blue-700',
+  updated:     'bg-stone-100 text-stone-600',
+  create:      'bg-green-100 text-green-700',
+  complete:    'bg-green-100 text-green-700',
+  open:        'bg-blue-100 text-blue-700',
+  query:       'bg-stone-100 text-stone-600',
+  notify:      'bg-purple-100 text-purple-700',
+  error:       'bg-red-100 text-red-700',
+};
+
+const EVENT_COLORS_DARK = {
+  completed:   'bg-green-900/40 text-green-400',
+  uncompleted: 'bg-yellow-900/40 text-yellow-400',
+  deleted:     'bg-red-900/40 text-red-400',
+  rescheduled: 'bg-blue-900/40 text-blue-400',
+  updated:     'bg-gray-700 text-gray-400',
+  create:      'bg-green-900/40 text-green-400',
+  complete:    'bg-green-900/40 text-green-400',
+  open:        'bg-blue-900/40 text-blue-400',
+  query:       'bg-gray-700 text-gray-400',
+  notify:      'bg-purple-900/40 text-purple-400',
+  error:       'bg-red-900/40 text-red-400',
+};
+
+function badgeClass(entry, darkMode) {
+  const key = entry.status === 'error' ? 'error' : (entry.event ?? entry.action);
+  return darkMode ? (EVENT_COLORS_DARK[key] ?? EVENT_COLORS_DARK.updated) : (EVENT_COLORS[key] ?? EVENT_COLORS.updated);
+}
+
+function badgeLabel(entry) {
+  if (entry.status === 'error') return 'error';
+  if (entry.event) return entry.event;
+  return entry.action;
+}
+
+function shortApp(source_app) {
+  if (!source_app) return null;
+  // 'app.lastglance' → 'lastglance'
+  return source_app.replace(/^app\./, '');
+}
+
+function formatTime(iso) {
+  try {
+    return new Date(iso).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+}
+
+function formatDate(iso) {
+  try {
+    const d = new Date(iso);
+    const today = new Date();
+    if (d.toDateString() === today.toDateString()) return 'Today';
+    const yesterday = new Date(today);
+    yesterday.setDate(today.getDate() - 1);
+    if (d.toDateString() === yesterday.toDateString()) return 'Yesterday';
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  } catch {
+    return '';
+  }
+}
+
+const IntentActivityLogModal = () => {
+  const { cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg } = useDayPlannerCtx();
+  const { showIntentActivityLog, setShowIntentActivityLog } = useSyncCtx();
+  const [entries, setEntries] = useState(() => getActivityLog());
+
+  if (!showIntentActivityLog) return null;
+
+  const handleClear = () => {
+    clearActivityLog();
+    setEntries([]);
+  };
+
+  const dividerBg = darkMode ? 'bg-gray-700' : 'bg-stone-200';
+
+  // Group by date for display
+  let lastDate = null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-[60]"
+      onClick={() => setShowIntentActivityLog(false)}
+      onKeyDown={e => { if (e.key === 'Escape') setShowIntentActivityLog(false); }}
+      tabIndex={-1}
+      ref={el => el && el.focus()}
+    >
+      <div
+        className={`${cardBg} rounded-t-2xl sm:rounded-2xl shadow-xl border ${borderClass} w-full sm:max-w-md mx-0 sm:mx-4 flex flex-col`}
+        style={{ maxHeight: '80vh' }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className={`flex items-center justify-between px-4 pt-4 pb-3 border-b ${borderClass} flex-shrink-0`}>
+          <h3 className={`text-sm font-semibold ${textPrimary}`}>Intent Activity</h3>
+          <div className="flex items-center gap-1">
+            {entries.length > 0 && (
+              <button
+                onClick={handleClear}
+                className={`p-1.5 rounded-lg ${hoverBg} flex items-center gap-1`}
+                title="Clear log"
+              >
+                <Trash2 size={14} className={textSecondary} />
+              </button>
+            )}
+            <button onClick={() => setShowIntentActivityLog(false)} className={`p-1.5 rounded-lg ${hoverBg}`}>
+              <X size={16} className={textSecondary} />
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto flex-1">
+          {entries.length === 0 ? (
+            <div className={`text-sm ${textSecondary} text-center py-10 px-4`}>
+              No activity yet.<br />
+              <span className="text-xs">Events appear here once the intent WebDAV endpoint is configured.</span>
+            </div>
+          ) : (
+            <div className="py-1">
+              {entries.map(entry => {
+                const dateLabel = formatDate(entry.timestamp);
+                const showDateDivider = dateLabel !== lastDate;
+                lastDate = dateLabel;
+                return (
+                  <React.Fragment key={entry.id}>
+                    {showDateDivider && (
+                      <div className={`px-4 py-1.5 flex items-center gap-2`}>
+                        <div className={`flex-1 h-px ${dividerBg}`} />
+                        <span className={`text-xs ${textSecondary} flex-shrink-0`}>{dateLabel}</span>
+                        <div className={`flex-1 h-px ${dividerBg}`} />
+                      </div>
+                    )}
+                    <div className={`px-4 py-2.5 flex items-start gap-2.5`}>
+                      {/* Direction icon */}
+                      <div className="mt-0.5 flex-shrink-0">
+                        {entry.direction === 'in'
+                          ? <ArrowDownLeft size={13} className="text-blue-500" />
+                          : <ArrowUpRight size={13} className="text-purple-500" />
+                        }
+                      </div>
+
+                      {/* Content */}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-1.5 flex-wrap">
+                          <span className={`text-xs font-medium px-1.5 py-0.5 rounded ${badgeClass(entry, darkMode)}`}>
+                            {badgeLabel(entry)}
+                          </span>
+                          {shortApp(entry.source_app) && (
+                            <span className={`text-xs ${textSecondary}`}>{shortApp(entry.source_app)}</span>
+                          )}
+                        </div>
+                        {entry.title && (
+                          <p className={`text-xs ${textPrimary} mt-0.5 truncate`}>{entry.title}</p>
+                        )}
+                        {entry.error && (
+                          <p className="text-xs text-red-500 mt-0.5 truncate">{entry.error}</p>
+                        )}
+                      </div>
+
+                      {/* Time */}
+                      <span className={`text-xs ${textSecondary} flex-shrink-0 mt-0.5`}>{formatTime(entry.timestamp)}</span>
+                    </div>
+                  </React.Fragment>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default IntentActivityLogModal;

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -75,6 +75,7 @@ const MobileSettingsPanel = () => {
     loadAutoBackupHistory,
     deleteLocalAutoBackup, deleteRemoteAutoBackup,
     exportBackup, handleFileUpload, handleBackupFileSelect,
+    setShowIntentActivityLog,
   } = useSyncCtx();
   const {
     routinesEnabled, setRoutinesEnabled,
@@ -282,6 +283,14 @@ const MobileSettingsPanel = () => {
             <ChevronRight size={18} className={textSecondary} />
           </button>
         )}
+        <button
+          onClick={() => setShowIntentActivityLog(true)}
+          className={`w-full ${cardBg} border ${borderClass} rounded-xl p-4 flex items-center gap-3`}
+        >
+          <Activity size={20} className={textSecondary} />
+          <span className={`font-medium ${textPrimary} flex-1 text-left`}>Intent Activity</span>
+          <ChevronRight size={18} className={textSecondary} />
+        </button>
       </div>
     )}
 

--- a/src/intents/intentLog.js
+++ b/src/intents/intentLog.js
@@ -1,0 +1,20 @@
+const LOG_KEY = 'dayglance-intent-activity-log';
+const MAX_ENTRIES = 100;
+
+/**
+ * Append one activity entry to the log. Thread-safe at the JS single-thread
+ * level; trimmed to MAX_ENTRIES on every write.
+ */
+export function logActivity(entry) {
+  const existing = JSON.parse(localStorage.getItem(LOG_KEY) || '[]');
+  const updated = [{ ...entry, id: crypto.randomUUID() }, ...existing].slice(0, MAX_ENTRIES);
+  localStorage.setItem(LOG_KEY, JSON.stringify(updated));
+}
+
+export function getActivityLog() {
+  return JSON.parse(localStorage.getItem(LOG_KEY) || '[]');
+}
+
+export function clearActivityLog() {
+  localStorage.removeItem(LOG_KEY);
+}

--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { parseEnvelope, filenameFor, parseFilename } from '@glance-apps/intents';
 import { webdavFetch } from '../utils/cloudSyncProviders.js';
 import { handleIntent } from './handleIntent.js';
+import { logActivity } from './intentLog.js';
 
 export const INTENT_CONFIG_KEY = 'dayglance-intent-config';
 const CURSOR_KEY = 'dayglance-intent-cursor';
@@ -186,9 +187,29 @@ async function poll(config, context) {
         continue;
       }
 
-      await handleIntent(envelope.action, envelope.payload, context);
+      const result = await handleIntent(envelope.action, envelope.payload, context);
+      logActivity({
+        direction: 'in',
+        action: envelope.action,
+        event: envelope.payload.event ?? null,
+        source_app: envelope.payload.source_app ?? envelope.emitted_by ?? null,
+        title: envelope.payload.title ?? null,
+        timestamp: envelope.emitted_at,
+        status: result.success ? 'ok' : 'error',
+        error: result.success ? null : result.error,
+      });
     } catch (err) {
       console.warn('[intent] Error processing', name, ':', err.message);
+      logActivity({
+        direction: 'in',
+        action: 'unknown',
+        event: null,
+        source_app: null,
+        title: null,
+        timestamp: new Date().toISOString(),
+        status: 'error',
+        error: err.message,
+      });
     }
 
     setCursor(parsed.event_id);

--- a/src/intents/useNotifyEmitter.js
+++ b/src/intents/useNotifyEmitter.js
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { buildEnvelope, eventId as makeEventId, EVENTS, ENTITY_TYPES } from '@glance-apps/intents';
 import { writeEventFile, INTENT_CONFIG_KEY } from './useIntentPoller.js';
+import { logActivity } from './intentLog.js';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -122,8 +123,28 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
             emittedBy: 'app.dayglance',
           });
           await writeEventFile(config, envelope);
+          logActivity({
+            direction: 'out',
+            action: 'notify',
+            event: change.event,
+            source_app: task.source_app,
+            title: task.title,
+            timestamp: now,
+            status: 'ok',
+            error: null,
+          });
         } catch (err) {
           console.warn('[notify] emit failed for task', task.id, ':', err.message);
+          logActivity({
+            direction: 'out',
+            action: 'notify',
+            event: change.event,
+            source_app: task.source_app,
+            title: task.title,
+            timestamp: now,
+            status: 'error',
+            error: err.message,
+          });
         }
       }
     };


### PR DESCRIPTION
## Summary

Adds the intent activity log infrastructure and UI panel so users can see what's crossing the WebDAV transport wire.

### New files
- **`src/intents/intentLog.js`** — `logActivity()`, `getActivityLog()`, `clearActivityLog()`. Persists up to 100 entries in `dayglance-intent-activity-log` localStorage.
- **`src/components/IntentActivityLogModal.jsx`** — Sheet-style modal (slides up from bottom on mobile, centered on desktop). Entries grouped by date; each shows direction arrow (↓ in / ↑ out), event badge with colour-coding, source app suffix, task title, and time. Error entries highlighted in red. Clear button; empty state with setup hint.

### Updated files
- **`useIntentPoller.js`** — calls `logActivity` after each processed inbound event (success or error)
- **`useNotifyEmitter.js`** — calls `logActivity` after each emitted outbound notify (success or error)
- **`App.jsx`** — `showIntentActivityLog` state, modal rendered, both wired through `SyncContext`
- **`MobileSettingsPanel.jsx`** — "Intent Activity" button in the Sync section (will be moved into the integration settings screen in PR #11)

### Event badge colours
| Event | Badge |
|---|---|
| completed | green |
| uncompleted | yellow |
| deleted | red |
| rescheduled | blue |
| updated | muted |
| create / complete | green |
| error | red |

## Test plan

- [ ] `npm test` passes (229 tests)
- [ ] Settings → "Intent Activity" opens the modal
- [ ] Empty state shows setup hint when no log entries exist
- [ ] With config active: events appear after processing/emitting
- [ ] Clear button empties the list and localStorage
- [ ] Dark mode badge colours display correctly

https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm)_