### PR TITLE
fix: don't inject Content-Type on bodyless WebDAV methods in proxy

### DIFF
--- a/api/webdav-proxy.js
+++ b/api/webdav-proxy.js
@@ -98,9 +98,11 @@ export default async function handler(req, res) {
   try {
     const headers = {};
 
-    // Only set Content-Type for requests that have a body — sending it on GET/HEAD
-    // causes Apache mod_dav to return 404 (unexpected Content-Type on bodyless request).
-    if (req.method !== 'GET' && req.method !== 'HEAD') {
+    // Only set Content-Type for requests that have a body — sending it on
+    // bodyless methods (GET, HEAD, PROPFIND, DELETE, MKCOL) causes Apache
+    // mod_dav to return 4xx errors.
+    const bodylessMethods = new Set(['GET', 'HEAD', 'PROPFIND', 'DELETE', 'MKCOL']);
+    if (!bodylessMethods.has(req.method)) {
       headers['Content-Type'] = req.headers['content-type'] || 'application/octet-stream';
     }
 


### PR DESCRIPTION
## Summary

The WebDAV proxy was unconditionally setting `Content-Type: application/octet-stream` on all non-GET/HEAD requests. PROPFIND, DELETE, and MKCOL have no request body, and Apache mod_dav responds with 403 when it receives an unexpected Content-Type on these methods.

This was causing the intent event poller's PROPFIND directory listing to fail for Apache-backed WebDAV servers (including the Bytemark Docker image), making the intent integration non-functional for a large class of users without any server-side workaround.

The fix extends the existing exclusion (already in place for GET and HEAD) to all bodyless WebDAV methods.

## Test plan

- [ ] Deploy and configure the intent WebDAV endpoint against an Apache-backed server
- [ ] Verify PROPFIND succeeds (no more 403 in console)
- [ ] Verify PUT/MKCOL still work (body-bearing methods unaffected)
- [ ] Verify existing cloud sync still works

https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm)_