### PR TITLE
feat: L shortcut to toggle Intent Activity Log

### DIFF
--- a/src/components/IntentActivityLogModal.jsx
+++ b/src/components/IntentActivityLogModal.jsx
@@ -92,7 +92,7 @@ const IntentActivityLogModal = () => {
     <div
       className="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-[60]"
       onClick={() => setShowIntentActivityLog(false)}
-      onKeyDown={e => { if (e.key === 'Escape') setShowIntentActivityLog(false); }}
+      onKeyDown={e => { if (e.key === 'Escape') { e.stopPropagation(); setShowIntentActivityLog(false); } }}
       tabIndex={-1}
       ref={el => el && el.focus()}
     >

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -303,7 +303,7 @@ const MobileSettingsPanel = () => {
         className={`w-full ${cardBg} border ${borderClass} rounded-xl p-4 flex items-center gap-3`}
       >
         <Activity size={20} className={intentForm.webdavUrl ? 'text-blue-500' : textSecondary} />
-        <span className={`font-medium ${textPrimary} flex-1 text-left`}>Glance Integrations</span>
+        <span className={`font-medium ${textPrimary} flex-1 text-left`}>GLANCE Integrations</span>
         {intentForm.webdavUrl && (
           <span className="w-2 h-2 rounded-full bg-green-500 mr-1" />
         )}
@@ -1554,7 +1554,7 @@ const MobileSettingsPanel = () => {
     </div>
   )}
 
-  {/* Glance Integrations sub-view */}
+  {/* GLANCE Integrations sub-view */}
   {mobileSettingsView === 'intent' && (() => {
     const inputCls = `w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white placeholder:text-gray-400' : 'bg-white text-stone-900 placeholder:text-stone-400'} text-sm`;
     const labelCls = `block text-sm ${textSecondary} mb-1`;
@@ -1602,7 +1602,7 @@ const MobileSettingsPanel = () => {
         </button>
         <h4 className={`font-medium ${textPrimary} flex items-center gap-2`}>
           <Activity size={18} className={intentForm.webdavUrl ? 'text-blue-500' : textSecondary} />
-          Glance Integrations
+          GLANCE Integrations
         </h4>
         <p className={`text-xs ${textSecondary} -mt-3`}>
           Connect dayGLANCE to other Glance-compatible apps via a shared WebDAV event log.

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1410,11 +1410,11 @@ const SettingsModal = () => {
 
                     <hr className={borderClass} />
 
-                    {/* Glance Integrations Section */}
+                    {/* GLANCE Integrations Section */}
                     <div className="space-y-3">
                       <button onClick={() => toggleSettingsSection('intent')} className={`font-medium ${textPrimary} flex items-center gap-2 w-full text-left`}>
                         <Activity size={16} className={textSecondary} />
-                        Glance Integrations
+                        GLANCE Integrations
                         {intentForm.webdavUrl && <span className="mr-1 w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />}
                         <ChevronDown size={16} className={`ml-auto flex-shrink-0 ${textSecondary} transition-transform ${collapsedSettings.intent ? '' : 'rotate-180'}`} />
                       </button>

--- a/src/components/ShortcutHelpModal.jsx
+++ b/src/components/ShortcutHelpModal.jsx
@@ -48,6 +48,7 @@ const ShortcutHelpModal = () => {
                 ['F', 'Focus mode'],
                 ['G', 'Goals & Projects'],
                 ['H', 'Habits'],
+                ['L', 'Intent activity log'],
                 ['D', 'Toggle dark mode'],
                 ['B', 'Backup menu'],
                 [',', 'Side panel: Glance'],


### PR DESCRIPTION
## Summary

- Adds `L` as a global keyboard shortcut to toggle the Intent Activity Log open/closed
- Documents it in ShortcutHelpModal under the App section (between H and D)
- No-ops when focus is in an input, textarea, or contenteditable element

## Test plan

- [ ] Press `L` with no modal open → activity log opens
- [ ] Press `L` again → activity log closes
- [ ] Press `L` while typing in a task input → no action
- [ ] Check `?` shortcut help → `L` appears in the App section

https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm)_