### PR TITLE
nit: rename modal title to 'Intent Activity Log'

### DIFF
--- a/src/components/IntentActivityLogModal.jsx
+++ b/src/components/IntentActivityLogModal.jsx
@@ -103,7 +103,7 @@ const IntentActivityLogModal = () => {
       >
         {/* Header */}
         <div className={`flex items-center justify-between px-4 pt-4 pb-3 border-b ${borderClass} flex-shrink-0`}>
-          <h3 className={`text-sm font-semibold ${textPrimary}`}>Intent Activity</h3>
+          <h3 className={`text-sm font-semibold ${textPrimary}`}>Intent Activity Log</h3>
           <div className="flex items-center gap-1">
             {entries.length > 0 && (
               <button


### PR DESCRIPTION
One-line change: modal header was "Intent Activity", now "Intent Activity Log".

https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm)_