### PR TITLE
chore: upgrade @glance-apps/intents to 1.1.0 and @glance-apps/sync to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "dayglance",
       "version": "2.10.0",
       "dependencies": {
-        "@glance-apps/intents": "^1.0.1",
-        "@glance-apps/sync": "^1.0.1",
+        "@glance-apps/intents": "^1.1.0",
+        "@glance-apps/sync": "^1.0.2",
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2239,9 +2239,9 @@
       }
     },
     "node_modules/@glance-apps/intents": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.0.1.tgz",
-      "integrity": "sha512-fJzf4MF9nCRW6Tws5kekMsS0vpwW6XkaVhSwtwnmguBNuI5h96ur+CGSc8IF+TMy1uN5UJPLAryoBmHObwoPZw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.1.0.tgz",
+      "integrity": "sha512-L6QKB92bKneCcK2u93pgTe6WM2MT88CpxZryLPdGkzrdV/dEQRPYcuTVzqRUPS4QeAcw+LD5vIg5useuQgUGRQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -2251,9 +2251,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.0.1.tgz",
-      "integrity": "sha512-9E2aENfLhZ1F0SevGMZKbnJiABogkrvTXCJTIVu1b3VTHIrlRWiUSg0j70n0Heq7iBiYD7UpRH+ClnlYpmvsAQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.0.2.tgz",
+      "integrity": "sha512-ibe5sAzhylH4Ix8xWzQbcFartzuSVp21ccUudH6EasjmRTT++S7B3RE+3c0WpntQbNYoOeIh4TVen2Zs9+4Yzg==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "build:electron:release": "vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs --publish never"
   },
   "dependencies": {
-    "@glance-apps/intents": "^1.0.1",
-    "@glance-apps/sync": "^1.0.1",
+    "@glance-apps/intents": "^1.1.0",
+    "@glance-apps/sync": "^1.0.2",
     "lucide-react": "^0.564.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary

- Upgrades `@glance-apps/intents` from `1.0.1` to `1.1.0`, bringing in the Phase 2.5 encrypted envelope API: `buildEncryptedEnvelope`, `parseEncryptedEnvelope`, and typed error classes (`NoKeyError`, `WrongKeyError`, `NotEncryptedError`, `MalformedEnvelopeError`, `InvalidPayloadError`).
- Upgrades `@glance-apps/sync` from `1.0.1` to `1.0.2`, bringing in `getSessionKey()` — a one-line getter that surfaces the in-memory non-extractable `CryptoKey` for use by the intents encryption path.
- No behavior change. All Phase 2.5 wiring (settings toggle, emitter, poller, activity log) lands in the three PRs that follow this one.

## Pre-work context

The `getSessionKey()` addition was the resolution to the CryptoKey exposure investigation: the derived key lives in module-scoped `_sessionKey` in `@glance-apps/sync/src/crypto.js` as a non-extractable `CryptoKey`. Adding a getter surfaces the opaque reference without weakening the non-extractable constraint — callers can pass it to Web Crypto operations but cannot export raw bytes from it.

## Test plan

- [ ] `npm install` completes cleanly
- [ ] `import { buildEncryptedEnvelope, parseEncryptedEnvelope, NoKeyError, WrongKeyError } from '@glance-apps/intents'` resolves
- [ ] `import { getSessionKey, hasEncryptionReady } from '@glance-apps/sync'` resolves
- [ ] Existing intent handling (poller, emitter) continues to work with plaintext envelopes unchanged

https://claude.ai/code/session_01MF6aVQcCiXJnyD9kzReXYv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MF6aVQcCiXJnyD9kzReXYv)_