### PR TITLE
feat: decrypt incoming encrypted intent envelopes in poller (Phase 2.5 PR #15)

### DIFF
--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
-import { parseEnvelope, filenameFor, parseFilename } from '@glance-apps/intents';
+import { parseEnvelope, parseEncryptedEnvelope, filenameFor, parseFilename, NoKeyError, WrongKeyError, NotEncryptedError, MalformedEnvelopeError } from '@glance-apps/intents';
+import { getSessionKey } from '@glance-apps/sync';
 import { webdavFetch } from '../utils/cloudSyncProviders.js';
 import { handleIntent } from './handleIntent.js';
 import { logActivity } from './intentLog.js';
@@ -174,9 +175,33 @@ async function poll(config, context) {
       const raw = await fileRes.json();
       let envelope;
       try {
-        envelope = parseEnvelope(raw);
-      } catch {
-        console.warn('[intent] Unparseable envelope, skipping:', name);
+        if (raw?.encrypted === true) {
+          envelope = await parseEncryptedEnvelope(raw, getSessionKey());
+        } else {
+          envelope = parseEnvelope(raw);
+        }
+      } catch (parseErr) {
+        let errorCode = parseErr.name ?? 'parse_error';
+        if (parseErr instanceof NoKeyError) {
+          console.warn('[intent] Skipping encrypted event (no key):', name);
+        } else if (parseErr instanceof WrongKeyError) {
+          console.warn('[intent] Skipping encrypted event (wrong key):', name);
+        } else if (parseErr instanceof NotEncryptedError || parseErr instanceof MalformedEnvelopeError) {
+          console.warn('[intent] Skipping malformed envelope:', name);
+        } else {
+          console.warn('[intent] Unparseable envelope, skipping:', name);
+          errorCode = 'parse_error';
+        }
+        logActivity({
+          direction: 'in',
+          action: 'unknown',
+          event: null,
+          source_app: null,
+          title: null,
+          timestamp: new Date().toISOString(),
+          status: 'error',
+          error: errorCode,
+        });
         setCursor(parsed.event_id);
         continue;
       }


### PR DESCRIPTION
## Summary

- `useIntentPoller` now inspects `raw.encrypted` on each downloaded envelope before parsing.
- If `raw.encrypted === true`, calls `parseEncryptedEnvelope(raw, getSessionKey())` from `@glance-apps/intents@1.1.0`.
- If plaintext, calls `parseEnvelope(raw)` as before — no regression.
- All four typed errors from the encrypted path are caught and handled individually:
  - `NoKeyError` → skip + log `error: 'NoKeyError'` ("encryption not configured")
  - `WrongKeyError` → skip + log `error: 'WrongKeyError'` ("wrong key")
  - `NotEncryptedError` → skip + log warning (defensive; shouldn't fire in normal operation)
  - `MalformedEnvelopeError` → skip + log warning (defensive)
- Each log entry uses the error class name as the `error` field value so PR #16 can render them distinctly.
- Never hard-fails. Cursor advances past unprocessable events.

## Note on `isEncryptedEnvelope`

`isEncryptedEnvelope` is exported from `@glance-apps/sync` (not `@glance-apps/intents`) and wasn't available here. The detection falls back to `raw?.encrypted === true`, which is safe and aligns with the envelope schema (`encrypted: z.literal(true)`).

## Test plan

- [ ] Plaintext envelopes parse and execute as before
- [ ] Encrypted envelope with correct key: parses, `handleIntent` runs normally
- [ ] Encrypted envelope with no session key: event skipped, `NoKeyError` logged to activity log
- [ ] Encrypted envelope with wrong key: event skipped, `WrongKeyError` logged
- [ ] Non-JSON or malformed file: caught by outer try/catch, logged as generic error

## Stack

Depends on #891 (emitter). Next: activity log (#16).

https://claude.ai/code/session_01MF6aVQcCiXJnyD9kzReXYv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MF6aVQcCiXJnyD9kzReXYv)_