### PR TITLE
feat: distinct activity-log entries for encryption error classes (Phase 2.5 PR #16)

### DIFF
--- a/src/components/IntentActivityLogModal.jsx
+++ b/src/components/IntentActivityLogModal.jsx
@@ -16,6 +16,7 @@ const EVENT_COLORS = {
   query:       'bg-stone-100 text-stone-600',
   notify:      'bg-purple-100 text-purple-700',
   error:       'bg-red-100 text-red-700',
+  warn:        'bg-amber-100 text-amber-700',
 };
 
 const EVENT_COLORS_DARK = {
@@ -30,17 +31,37 @@ const EVENT_COLORS_DARK = {
   query:       'bg-gray-700 text-gray-400',
   notify:      'bg-purple-900/40 text-purple-400',
   error:       'bg-red-900/40 text-red-400',
+  warn:        'bg-amber-900/40 text-amber-400',
+};
+
+const CRYPTO_ERROR_MESSAGES = {
+  NoKeyError:            'encryption not configured',
+  WrongKeyError:         'decryption failed: wrong key',
+  NotEncryptedError:     'unexpected: envelope not encrypted',
+  MalformedEnvelopeError:'malformed envelope',
+  InvalidPayloadError:   'invalid payload for encryption',
+  no_key:                'key not ready — sent plaintext',
 };
 
 function badgeClass(entry, darkMode) {
-  const key = entry.status === 'error' ? 'error' : (entry.event ?? entry.action);
+  const key = entry.status === 'error' ? 'error' : entry.status === 'warn' ? 'warn' : (entry.event ?? entry.action);
   return darkMode ? (EVENT_COLORS_DARK[key] ?? EVENT_COLORS_DARK.updated) : (EVENT_COLORS[key] ?? EVENT_COLORS.updated);
 }
 
 function badgeLabel(entry) {
   if (entry.status === 'error') return 'error';
+  if (entry.status === 'warn') return 'warn';
   if (entry.event) return entry.event;
   return entry.action;
+}
+
+function errorMessage(entry) {
+  if (!entry.error) return null;
+  return CRYPTO_ERROR_MESSAGES[entry.error] ?? entry.error;
+}
+
+function errorTextClass(entry) {
+  return entry.status === 'warn' ? 'text-amber-500' : 'text-red-500';
 }
 
 function shortApp(source_app) {
@@ -165,7 +186,7 @@ const IntentActivityLogModal = () => {
                           <p className={`text-xs ${textPrimary} mt-0.5 truncate`}>{entry.title}</p>
                         )}
                         {entry.error && (
-                          <p className="text-xs text-red-500 mt-0.5 truncate">{entry.error}</p>
+                          <p className={`text-xs ${errorTextClass(entry)} mt-0.5 truncate`}>{errorMessage(entry)}</p>
                         )}
                       </div>
 


### PR DESCRIPTION
## Summary

- `IntentActivityLogModal` now maps known crypto error codes to human-readable text via a `CRYPTO_ERROR_MESSAGES` lookup table:
  - `NoKeyError` → "encryption not configured"
  - `WrongKeyError` → "decryption failed: wrong key"
  - `NotEncryptedError` → "unexpected: envelope not encrypted"
  - `MalformedEnvelopeError` → "malformed envelope"
  - `InvalidPayloadError` → "invalid payload for encryption"
  - `no_key` (emitter fallback from PR #14) → "key not ready — sent plaintext"
  - Unknown codes fall through to the raw value (safe for future additions)
- Adds a `warn` status badge (amber) visually distinct from `error` (red), so users can distinguish configuration drift (amber: emitter fell back to plaintext because the session key wasn't loaded yet) from actual decryption failures (red: wrong key, malformed envelope).
- Existing `error` rendering is unchanged except the text is now mapped through `errorMessage()`.

## Spec reference

> `NoKeyError` → "encryption not configured." `WrongKeyError` → "decryption failed (wrong key)." `NotEncryptedError` and `MalformedEnvelopeError` are defensive-only (shouldn't happen in normal operation) and surface as warnings if they do fire.

## Test plan

- [ ] Normal events (ok status) render unchanged
- [ ] `error` entries with crypto error class names render the mapped text in red
- [ ] `warn` entries (from emitter no-key fallback) render with amber badge and mapped text
- [ ] Unknown error codes fall through to raw value — no blank displays
- [ ] Clearing the log still works

## Stack

Final PR in the Phase 2.5 dayGLANCE stack. Depends on #892 (poller). Full stack: #889 → #890 → #891 → #892 → this PR.

https://claude.ai/code/session_01MF6aVQcCiXJnyD9kzReXYv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MF6aVQcCiXJnyD9kzReXYv)_