### PR TITLE
feat: Phase 2.5 intents encryption (settings toggle, emitter, poller, activity log)

### DIFF
--- a/src/components/IntentActivityLogModal.jsx
+++ b/src/components/IntentActivityLogModal.jsx
@@ -16,6 +16,7 @@ const EVENT_COLORS = {
   query:       'bg-stone-100 text-stone-600',
   notify:      'bg-purple-100 text-purple-700',
   error:       'bg-red-100 text-red-700',
+  warn:        'bg-amber-100 text-amber-700',
 };
 
 const EVENT_COLORS_DARK = {
@@ -30,17 +31,37 @@ const EVENT_COLORS_DARK = {
   query:       'bg-gray-700 text-gray-400',
   notify:      'bg-purple-900/40 text-purple-400',
   error:       'bg-red-900/40 text-red-400',
+  warn:        'bg-amber-900/40 text-amber-400',
+};
+
+const CRYPTO_ERROR_MESSAGES = {
+  NoKeyError:            'encryption not configured',
+  WrongKeyError:         'decryption failed: wrong key',
+  NotEncryptedError:     'unexpected: envelope not encrypted',
+  MalformedEnvelopeError:'malformed envelope',
+  InvalidPayloadError:   'invalid payload for encryption',
+  no_key:                'key not ready — sent plaintext',
 };
 
 function badgeClass(entry, darkMode) {
-  const key = entry.status === 'error' ? 'error' : (entry.event ?? entry.action);
+  const key = entry.status === 'error' ? 'error' : entry.status === 'warn' ? 'warn' : (entry.event ?? entry.action);
   return darkMode ? (EVENT_COLORS_DARK[key] ?? EVENT_COLORS_DARK.updated) : (EVENT_COLORS[key] ?? EVENT_COLORS.updated);
 }
 
 function badgeLabel(entry) {
   if (entry.status === 'error') return 'error';
+  if (entry.status === 'warn') return 'warn';
   if (entry.event) return entry.event;
   return entry.action;
+}
+
+function errorMessage(entry) {
+  if (!entry.error) return null;
+  return CRYPTO_ERROR_MESSAGES[entry.error] ?? entry.error;
+}
+
+function errorTextClass(entry) {
+  return entry.status === 'warn' ? 'text-amber-500' : 'text-red-500';
 }
 
 function shortApp(source_app) {
@@ -165,7 +186,7 @@ const IntentActivityLogModal = () => {
                           <p className={`text-xs ${textPrimary} mt-0.5 truncate`}>{entry.title}</p>
                         )}
                         {entry.error && (
-                          <p className="text-xs text-red-500 mt-0.5 truncate">{entry.error}</p>
+                          <p className={`text-xs ${errorTextClass(entry)} mt-0.5 truncate`}>{errorMessage(entry)}</p>
                         )}
                       </div>
 

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -84,6 +84,7 @@ const SettingsModal = () => {
       foregroundInterval: saved.foregroundInterval ?? 120000,
       backgroundInterval: saved.backgroundInterval ?? 900000,
       gcRetentionDays: saved.gcRetentionDays ?? 30,
+      encryptionEnabled: saved.encryptionEnabled ?? false,
     };
   });
   const [intentSaved, setIntentSaved] = useState(false);
@@ -1510,10 +1511,34 @@ const SettingsModal = () => {
                           />
                           <p className={`text-xs ${textSecondary} mt-1`}>Event files older than this are deleted automatically.</p>
                         </div>
+                        <div className={`flex items-start gap-3 p-3 rounded-lg border ${borderClass} ${cloudSyncConfig?.encryptionEnabled ? '' : 'opacity-60'}`}>
+                          <input
+                            type="checkbox"
+                            id="intent-encryption-toggle"
+                            checked={intentForm.encryptionEnabled && !!cloudSyncConfig?.encryptionEnabled}
+                            disabled={!cloudSyncConfig?.encryptionEnabled}
+                            onChange={e => setIntentForm(p => ({ ...p, encryptionEnabled: e.target.checked }))}
+                            className="mt-0.5 h-4 w-4 rounded"
+                          />
+                          <div>
+                            <label htmlFor="intent-encryption-toggle" className={`text-sm font-medium ${textPrimary} ${cloudSyncConfig?.encryptionEnabled ? 'cursor-pointer' : 'cursor-not-allowed'}`}>
+                              Encrypt intent events
+                            </label>
+                            {cloudSyncConfig?.encryptionEnabled ? (
+                              <p className={`text-xs ${textSecondary} mt-0.5`}>Uses your cloud sync passphrase. Consumers without the key skip encrypted events gracefully.</p>
+                            ) : (
+                              <p className={`text-xs ${textSecondary} mt-0.5`}>Requires cloud sync encryption to be enabled first.</p>
+                            )}
+                          </div>
+                        </div>
                         <div className="flex items-center gap-2 flex-wrap">
                           <button
                             onClick={() => {
-                              const cfg = { ...intentForm, gcRetentionDays: Number(intentForm.gcRetentionDays) || 30 };
+                              const cfg = {
+                                ...intentForm,
+                                gcRetentionDays: Number(intentForm.gcRetentionDays) || 30,
+                                encryptionEnabled: intentForm.encryptionEnabled && !!cloudSyncConfig?.encryptionEnabled,
+                              };
                               if (cfg.webdavUrl || cfg.username || cfg.appPassword) {
                                 localStorage.setItem(INTENT_CONFIG_KEY, JSON.stringify(cfg));
                               } else {
@@ -1529,7 +1554,7 @@ const SettingsModal = () => {
                           {intentForm.webdavUrl && (
                             <button
                               onClick={() => {
-                                setIntentForm({ webdavUrl: '', username: '', appPassword: '', eventsPath: '/GLANCE/events/', foregroundInterval: 120000, backgroundInterval: 900000, gcRetentionDays: 30 });
+                                setIntentForm({ webdavUrl: '', username: '', appPassword: '', eventsPath: '/GLANCE/events/', foregroundInterval: 120000, backgroundInterval: 900000, gcRetentionDays: 30, encryptionEnabled: false });
                                 localStorage.removeItem(INTENT_CONFIG_KEY);
                               }}
                               className={`px-4 py-2 ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} rounded-lg text-sm transition-colors`}

--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
-import { parseEnvelope, filenameFor, parseFilename } from '@glance-apps/intents';
+import { parseEnvelope, parseEncryptedEnvelope, filenameFor, parseFilename, NoKeyError, WrongKeyError, NotEncryptedError, MalformedEnvelopeError } from '@glance-apps/intents';
+import { getSessionKey } from '@glance-apps/sync';
 import { webdavFetch } from '../utils/cloudSyncProviders.js';
 import { handleIntent } from './handleIntent.js';
 import { logActivity } from './intentLog.js';
@@ -174,9 +175,33 @@ async function poll(config, context) {
       const raw = await fileRes.json();
       let envelope;
       try {
-        envelope = parseEnvelope(raw);
-      } catch {
-        console.warn('[intent] Unparseable envelope, skipping:', name);
+        if (raw?.encrypted === true) {
+          envelope = await parseEncryptedEnvelope(raw, getSessionKey());
+        } else {
+          envelope = parseEnvelope(raw);
+        }
+      } catch (parseErr) {
+        let errorCode = parseErr.name ?? 'parse_error';
+        if (parseErr instanceof NoKeyError) {
+          console.warn('[intent] Skipping encrypted event (no key):', name);
+        } else if (parseErr instanceof WrongKeyError) {
+          console.warn('[intent] Skipping encrypted event (wrong key):', name);
+        } else if (parseErr instanceof NotEncryptedError || parseErr instanceof MalformedEnvelopeError) {
+          console.warn('[intent] Skipping malformed envelope:', name);
+        } else {
+          console.warn('[intent] Unparseable envelope, skipping:', name);
+          errorCode = 'parse_error';
+        }
+        logActivity({
+          direction: 'in',
+          action: 'unknown',
+          event: null,
+          source_app: null,
+          title: null,
+          timestamp: new Date().toISOString(),
+          status: 'error',
+          error: errorCode,
+        });
         setCursor(parsed.event_id);
         continue;
       }

--- a/src/intents/useNotifyEmitter.js
+++ b/src/intents/useNotifyEmitter.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
-import { buildEnvelope, eventId as makeEventId, EVENTS, ENTITY_TYPES } from '@glance-apps/intents';
+import { buildEnvelope, buildEncryptedEnvelope, eventId as makeEventId, EVENTS, ENTITY_TYPES } from '@glance-apps/intents';
+import { hasEncryptionReady, getSessionKey } from '@glance-apps/sync';
 import { writeEventFile, INTENT_CONFIG_KEY } from './useIntentPoller.js';
 import { logActivity } from './intentLog.js';
 
@@ -103,25 +104,45 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
     if (!emits.length) return;
 
     const fire = async () => {
+      const useEncryption = config.encryptionEnabled && hasEncryptionReady();
+      const keyUnavailable = config.encryptionEnabled && !hasEncryptionReady();
+
       for (const { task, change } of emits) {
-        try {
-          const envelope = buildEnvelope({
+        const payload = {
+          event_id: makeEventId(),
+          source_app: task.source_app,
+          source_entity_id: task.source_entity_id,
+          event: change.event,
+          task_id: task.id,
+          title: task.title,
+          timestamp: now,
+          entity_type: ENTITY_TYPES.TASK,
+          ...(change.due !== undefined ? { due: change.due } : {}),
+          ...(change.previous_due !== undefined ? { previous_due: change.previous_due } : {}),
+          ...(change.completed_at !== undefined ? { completed_at: change.completed_at } : {}),
+        };
+
+        if (keyUnavailable) {
+          // Encryption is configured but the session key isn't loaded yet (new device,
+          // passphrase not entered). Fall back to plaintext so events still flow and log
+          // the configuration drift so the user can diagnose it.
+          console.warn('[notify] encryption configured but key not ready; emitting plaintext for task', task.id);
+          logActivity({
+            direction: 'out',
             action: 'notify',
-            payload: {
-              event_id: makeEventId(),
-              source_app: task.source_app,
-              source_entity_id: task.source_entity_id,
-              event: change.event,
-              task_id: task.id,
-              title: task.title,
-              timestamp: now,
-              entity_type: ENTITY_TYPES.TASK,
-              ...(change.due !== undefined ? { due: change.due } : {}),
-              ...(change.previous_due !== undefined ? { previous_due: change.previous_due } : {}),
-              ...(change.completed_at !== undefined ? { completed_at: change.completed_at } : {}),
-            },
-            emittedBy: 'app.dayglance',
+            event: change.event,
+            source_app: task.source_app,
+            title: task.title,
+            timestamp: now,
+            status: 'warn',
+            error: 'no_key',
           });
+        }
+
+        try {
+          const envelope = useEncryption
+            ? await buildEncryptedEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' }, getSessionKey())
+            : buildEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' });
           await writeEventFile(config, envelope);
           logActivity({
             direction: 'out',
@@ -143,7 +164,7 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
             title: task.title,
             timestamp: now,
             status: 'error',
-            error: err.message,
+            error: err.name ?? err.message,
           });
         }
       }


### PR DESCRIPTION
## Summary

Phase 2.5 dayGLANCE encryption support for WebDAV intent envelopes. Consolidates the four PRs (#890–#893) that previously targeted stacked branches. Targets `main` directly; `@glance-apps/intents@1.1.0` and `@glance-apps/sync@1.0.2` are already on main via #889.

**Four commits, one per logical change:**

### 1. Settings toggle (`SettingsModal.jsx`)
- Adds an **Encrypt intent events** checkbox in the GLANCE Integrations panel
- Disabled with explanatory copy when cloud sync encryption is off ("Requires cloud sync encryption to be enabled first")
- When sync encryption is on, copy reads "Uses your cloud sync passphrase"
- Persists as `encryptionEnabled` in `INTENT_CONFIG_KEY` localStorage; gating check at save time prevents the flag being written as `true` when sync encryption is off

### 2. Emitter (`useNotifyEmitter.js`)
- When `config.encryptionEnabled && hasEncryptionReady()`, calls `buildEncryptedEnvelope(args, getSessionKey())` instead of `buildEnvelope`
- **Fallback:** when encryption is configured but the session key isn't loaded yet (new device, passphrase not entered), falls back to plaintext and logs a `warn` entry (`error: 'no_key'`) — events still flow, the activity log surfaces the drift
- Typed error names stored in the `error` field of activity-log entries for distinct rendering

### 3. Poller (`useIntentPoller.js`)
- Inspects `raw.encrypted` on each downloaded envelope before parsing
- If `true`, calls `parseEncryptedEnvelope(raw, getSessionKey())`; plaintext envelopes still go through `parseEnvelope`
- Catches `NoKeyError`, `WrongKeyError`, `NotEncryptedError`, `MalformedEnvelopeError` individually — each logs a distinct activity-log entry and skips the event; never hard-fails

### 4. Activity log (`IntentActivityLogModal.jsx`)
- Maps error class names to human-readable strings: `NoKeyError` → "encryption not configured", `WrongKeyError` → "decryption failed: wrong key", etc.
- Adds `warn` status (amber badge) visually distinct from `error` (red), used for the no-key emitter fallback
- Unknown codes fall through to the raw value

## Test plan
- [ ] Settings: toggle disabled when sync encryption off; enabled when on; persists correctly; Disconnect clears it
- [ ] Emitter: encrypted envelope appears on WebDAV when encryption is on and key is loaded
- [ ] Emitter no-key fallback: amber warn entry in activity log, plaintext file on WebDAV
- [ ] Poller: decrypts encrypted envelope from another app; `create` task appears in dayGLANCE
- [ ] Poller `NoKeyError`: red error entry "encryption not configured" in activity log
- [ ] Poller `WrongKeyError`: red error entry "decryption failed: wrong key" in activity log
- [ ] All 229 existing tests pass (`npm test`)

https://claude.ai/code/session_01MF6aVQcCiXJnyD9kzReXYv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MF6aVQcCiXJnyD9kzReXYv)_