### PR TITLE
feat: configurable cloud sync folder with non-breaking default change to GLANCE/dayglance

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -504,7 +504,10 @@ const DayPlanner = () => {
   // sees fresh closures every cycle — the engine itself is constructed once.
   const engineCallbacksRef = useRef({});
   const cloudSyncEngineRef = useRef(null);
-  if (!cloudSyncEngineRef.current) {
+  const engineFolderRef = useRef(null);
+  const syncFolder = cloudSyncConfig?.syncFolder ?? 'GLANCE/dayglance';
+  if (!cloudSyncEngineRef.current || engineFolderRef.current !== syncFolder) {
+    engineFolderRef.current = syncFolder;
     cloudSyncEngineRef.current = createDayGlanceEngine({
       buildPayload:       () => engineCallbacksRef.current.buildPayload?.(),
       buildBackupPayload: () => engineCallbacksRef.current.buildBackupPayload?.(),
@@ -522,7 +525,7 @@ const DayPlanner = () => {
       onPassphraseRequired: () => setSyncKeyReady(false),
       onFirstSyncReload:    () => window.location.reload(),
       getSyncRetentionDays: () => engineCallbacksRef.current.syncRetentionDays ?? 90,
-    });
+    }, { appFolderName: syncFolder });
     // Visibility/focus listeners + 60 s poll call through this ref so they
     // always run the latest engine method without a closure refresh.
     cloudSyncDownloadRef.current = () => cloudSyncEngineRef.current.download();
@@ -1554,42 +1557,34 @@ const DayPlanner = () => {
   }, []);
 
   // Cloud sync: download on app load or when sync is first enabled.
-  // One-time check: detect if user has sync data at the old folder path
-  // ('dayglance/') before we moved to 'GLANCE/dayglance/'. Stores the old
-  // directory URL in localStorage so the settings form can show a notice.
+  // One-time check: if existing sync user is still on the legacy 'dayglance'
+  // folder, store its URL so the settings form can show an optional migration
+  // notice. Sync keeps working either way — this is informational only.
   useEffect(() => {
     const CHECKED_KEY = 'dayglance-sync-migration-checked';
     const NOTICE_KEY = 'dayglance-sync-migration-old-path';
     if (localStorage.getItem(CHECKED_KEY)) return;
     if (!cloudSyncConfig?.enabled) return;
 
-    const provider = cloudSyncConfig.provider || 'nextcloud';
-    const mark = (oldPath) => {
+    if (cloudSyncConfig?.syncFolder !== 'dayglance') {
       localStorage.setItem(CHECKED_KEY, '1');
-      if (oldPath) localStorage.setItem(NOTICE_KEY, oldPath);
-    };
-
-    let oldFileUrl;
-    let authHeaders;
-
-    if (provider === 'nextcloud' && cloudSyncConfig.nextcloudUrl && cloudSyncConfig.username) {
-      const base = cloudSyncConfig.nextcloudUrl.replace(/\/+$/, '');
-      const user = encodeURIComponent(cloudSyncConfig.username);
-      oldFileUrl = `${base}/remote.php/dav/files/${user}/dayglance/dayglance-sync.json`;
-      authHeaders = { 'X-WebDAV-Auth': `Basic ${btoa(`${cloudSyncConfig.username}:${cloudSyncConfig.appPassword}`)}` };
-    } else if (provider === 'generic' && cloudSyncConfig.webdavUrl && cloudSyncConfig.username) {
-      const base = cloudSyncConfig.webdavUrl.replace(/\/+$/, '');
-      oldFileUrl = `${base}/dayglance/dayglance-sync.json`;
-      authHeaders = { 'X-WebDAV-Auth': `Basic ${btoa(`${cloudSyncConfig.username}:${cloudSyncConfig.appPassword}`)}` };
-    } else {
-      mark(null);
       return;
     }
 
-    webdavFetch('HEAD', oldFileUrl, authHeaders)
-      .then(res => mark(res.ok ? oldFileUrl.replace('/dayglance-sync.json', '/') : null))
-      .catch(() => mark(null));
-  }, [cloudSyncConfig?.enabled]);
+    // Build the display URL for the legacy folder so the notice can show it.
+    const provider = cloudSyncConfig.provider || 'nextcloud';
+    let oldFolderPath = null;
+    if (provider === 'nextcloud' && cloudSyncConfig.nextcloudUrl && cloudSyncConfig.username) {
+      const base = cloudSyncConfig.nextcloudUrl.replace(/\/+$/, '');
+      const user = encodeURIComponent(cloudSyncConfig.username);
+      oldFolderPath = `${base}/remote.php/dav/files/${user}/dayglance/`;
+    } else if (provider === 'generic' && cloudSyncConfig.webdavUrl) {
+      const base = cloudSyncConfig.webdavUrl.replace(/\/+$/, '');
+      oldFolderPath = `${base}/dayglance/`;
+    }
+    if (oldFolderPath) localStorage.setItem(NOTICE_KEY, oldFolderPath);
+    localStorage.setItem(CHECKED_KEY, '1');
+  }, [cloudSyncConfig?.enabled, cloudSyncConfig?.syncFolder]);
 
   // If encryption is enabled, wait until the session key is ready (either
   // restored from IndexedDB or provided by the passphrase modal).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1554,6 +1554,43 @@ const DayPlanner = () => {
   }, []);
 
   // Cloud sync: download on app load or when sync is first enabled.
+  // One-time check: detect if user has sync data at the old folder path
+  // ('dayglance/') before we moved to 'GLANCE/dayglance/'. Stores the old
+  // directory URL in localStorage so the settings form can show a notice.
+  useEffect(() => {
+    const CHECKED_KEY = 'dayglance-sync-migration-checked';
+    const NOTICE_KEY = 'dayglance-sync-migration-old-path';
+    if (localStorage.getItem(CHECKED_KEY)) return;
+    if (!cloudSyncConfig?.enabled) return;
+
+    const provider = cloudSyncConfig.provider || 'nextcloud';
+    const mark = (oldPath) => {
+      localStorage.setItem(CHECKED_KEY, '1');
+      if (oldPath) localStorage.setItem(NOTICE_KEY, oldPath);
+    };
+
+    let oldFileUrl;
+    let authHeaders;
+
+    if (provider === 'nextcloud' && cloudSyncConfig.nextcloudUrl && cloudSyncConfig.username) {
+      const base = cloudSyncConfig.nextcloudUrl.replace(/\/+$/, '');
+      const user = encodeURIComponent(cloudSyncConfig.username);
+      oldFileUrl = `${base}/remote.php/dav/files/${user}/dayglance/dayglance-sync.json`;
+      authHeaders = { 'X-WebDAV-Auth': `Basic ${btoa(`${cloudSyncConfig.username}:${cloudSyncConfig.appPassword}`)}` };
+    } else if (provider === 'generic' && cloudSyncConfig.webdavUrl && cloudSyncConfig.username) {
+      const base = cloudSyncConfig.webdavUrl.replace(/\/+$/, '');
+      oldFileUrl = `${base}/dayglance/dayglance-sync.json`;
+      authHeaders = { 'X-WebDAV-Auth': `Basic ${btoa(`${cloudSyncConfig.username}:${cloudSyncConfig.appPassword}`)}` };
+    } else {
+      mark(null);
+      return;
+    }
+
+    webdavFetch('HEAD', oldFileUrl, authHeaders)
+      .then(res => mark(res.ok ? oldFileUrl.replace('/dayglance-sync.json', '/') : null))
+      .catch(() => mark(null));
+  }, [cloudSyncConfig?.enabled]);
+
   // If encryption is enabled, wait until the session key is ready (either
   // restored from IndexedDB or provided by the passphrase modal).
   useEffect(() => {

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -5,7 +5,10 @@ import { setupEncryptionKey, setSyncPassphrase, clearEncryptionKey } from '../ut
 // Cloud sync settings form (extracted to avoid hooks-in-conditional issues)
 const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderClass, hoverBg, cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, provider, currentProvider, onClose, cloudSyncLastSynced, cloudSyncStatus, cloudSyncError, onSyncKeyReady }) => {
   const [formData, setFormData] = useState(() => {
-    const initial = { provider: currentProvider };
+    const initial = {
+      provider: currentProvider,
+      syncFolder: cloudSyncConfig?.syncFolder ?? 'GLANCE/dayglance',
+    };
     // Populate fields from all providers so switching preserves filled values
     Object.values(cloudSyncProviders).forEach(p => {
       p.configFields.forEach(f => { initial[f.key] = cloudSyncConfig?.[f.key] || ''; });
@@ -20,7 +23,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   const [migrationOldPath] = useState(() => localStorage.getItem('dayglance-sync-migration-old-path'));
 
   const activeProvider = cloudSyncProviders[formData.provider] || provider;
-  const requiredFieldsFilled = activeProvider.configFields.every(f => formData[f.key]);
+  const requiredFieldsFilled = activeProvider.configFields.every(f => formData[f.key]) && !!formData.syncFolder;
 
   // When enabling encryption, require a passphrase (confirmed) on fresh enable.
   // When already enabled, allow saving without re-entering (passphrase field is optional).
@@ -95,6 +98,18 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
           )}
         </div>
       ))}
+
+      <div>
+        <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Sync folder</label>
+        <input
+          type="text"
+          placeholder="GLANCE/dayglance"
+          value={formData.syncFolder || ''}
+          onChange={(e) => setFormData(prev => ({ ...prev, syncFolder: e.target.value }))}
+          className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+        />
+        <p className={`text-xs ${textSecondary} mt-0.5`}>Path on your WebDAV server where sync files are stored.</p>
+      </div>
 
       {activeProvider.helpText && (
         <p className={`text-xs ${textSecondary}`}>{activeProvider.helpText}</p>
@@ -183,9 +198,10 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
 
       {migrationOldPath && (
         <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2.5 text-xs text-amber-800 space-y-1">
-          <p className="font-semibold">Action required: sync folder moved</p>
-          <p>Your sync file is at the old location. Move it to restore sync:</p>
+          <p className="font-semibold">Optional: move sync folder</p>
+          <p>Your sync file is at the old location. You can move it for cleaner organization — sync will continue to work either way.</p>
           <p className="font-mono break-all">{migrationOldPath} → GLANCE/dayglance/</p>
+          <p>After moving the file, update your Sync folder setting above to <span className="font-mono">GLANCE/dayglance</span>.</p>
           <button
             onClick={() => {
               localStorage.removeItem('dayglance-sync-migration-old-path');

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -17,6 +17,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   const [passphraseConfirm, setPassphraseConfirm] = useState('');
   const [testResult, setTestResult] = useState(null);
   const [testing, setTesting] = useState(false);
+  const [migrationOldPath] = useState(() => localStorage.getItem('dayglance-sync-migration-old-path'));
 
   const activeProvider = cloudSyncProviders[formData.provider] || provider;
   const requiredFieldsFilled = activeProvider.configFields.every(f => formData[f.key]);
@@ -180,6 +181,22 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
         )}
       </div>
 
+      {migrationOldPath && (
+        <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2.5 text-xs text-amber-800 space-y-1">
+          <p className="font-semibold">Action required: sync folder moved</p>
+          <p>Your sync file is at the old location. Move it to restore sync:</p>
+          <p className="font-mono break-all">{migrationOldPath} → GLANCE/dayglance/</p>
+          <button
+            onClick={() => {
+              localStorage.removeItem('dayglance-sync-migration-old-path');
+              localStorage.setItem('dayglance-sync-migration-checked', '1');
+            }}
+            className="text-amber-700 underline mt-1"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
       {cloudSyncStatus === 'error' && cloudSyncError ? (
         <p className="text-xs text-red-500">{cloudSyncError}</p>
       ) : cloudSyncLastSynced ? (

--- a/src/hooks/useCloudSync.js
+++ b/src/hooks/useCloudSync.js
@@ -4,7 +4,15 @@ import { initSessionKey } from '../utils/crypto.js';
 const useCloudSync = () => {
   const [cloudSyncConfig, setCloudSyncConfig] = useState(() => {
     const saved = localStorage.getItem('day-planner-cloud-sync-config');
-    return saved ? JSON.parse(saved) : null;
+    if (!saved) return null;
+    const config = JSON.parse(saved);
+    // Existing users who never set a sync folder keep the old 'dayglance' path
+    // so their sync does not break. New users get 'GLANCE/dayglance' by default.
+    if (config?.enabled && !config.syncFolder) {
+      config.syncFolder = 'dayglance';
+      localStorage.setItem('day-planner-cloud-sync-config', JSON.stringify(config));
+    }
+    return config;
   });
   const [cloudSyncStatus, setCloudSyncStatus] = useState('idle');
   const [cloudSyncError, setCloudSyncError] = useState(null);

--- a/src/sync/adapter.js
+++ b/src/sync/adapter.js
@@ -24,7 +24,6 @@ const DAYGLANCE_CONFIG = {
   cryptoDBName:         'dayglance-crypto',
   autoBackupDBName:     'dayglance-auto-backups',
   syncFilename:         'dayglance-sync.json',
-  appFolderName:        'dayglance',
   backupFilenamePrefix: 'dayglance-backup-',
   appId:                'dayglance',
   appName:              'dayGLANCE',
@@ -90,8 +89,9 @@ const validateApplyPayload = async (envelope) => {
  * @param {() => void}                            callbacks.onFirstSyncReload
  * @param {() => number}                          callbacks.getSyncRetentionDays
  */
-export const createDayGlanceEngine = (callbacks) => createSyncEngine({
+export const createDayGlanceEngine = (callbacks, { appFolderName = 'GLANCE/dayglance' } = {}) => createSyncEngine({
   ...DAYGLANCE_CONFIG,
+  appFolderName,
   buildPayload:        callbacks.buildPayload,
   buildBackupPayload:  callbacks.buildBackupPayload,
   applyPayload:        callbacks.applyPayload,

--- a/src/utils/cloudSyncProviders.js
+++ b/src/utils/cloudSyncProviders.js
@@ -12,7 +12,7 @@ const isAndroid =
   !!window.DayGlanceNative?.httpRequest;
 
 const dayGlanceEngineConfig = {
-  appFolderName: 'dayglance',
+  appFolderName: 'GLANCE/dayglance',
   syncFilename: 'dayglance-sync.json',
 
   // Android: pass the real bridge. iOS/web: null → falls through to proxy.


### PR DESCRIPTION
## Summary

- New users get `GLANCE/dayglance/` as the default sync folder (alongside intents at `GLANCE/events/` and future lastGLANCE at `GLANCE/lastglance/`)
- Existing users are automatically preserved on their old `dayglance/` path — **no sync breakage**
- Users can change the sync folder at any time via a new "Sync folder" field in cloud sync settings
- An optional amber notice appears in settings for existing users telling them they can move their files for cleaner organization (sync works either way)

## Implementation

- **`src/sync/adapter.js`**: removed hardcoded `appFolderName` from `DAYGLANCE_CONFIG`; `createDayGlanceEngine` now accepts it as a second parameter (default `'GLANCE/dayglance'`)
- **`src/hooks/useCloudSync.js`**: on first load, pins `syncFolder: 'dayglance'` for any existing user who has sync enabled but no `syncFolder` saved — prevents path change from breaking their sync
- **`src/App.jsx`**: threads `cloudSyncConfig.syncFolder` into engine creation; recreates engine when folder changes; migration detection no longer makes a network request — we know the file is at `dayglance/` if that's what's configured
- **`src/components/CloudSyncSettingsForm.jsx`**: adds "Sync folder" text input field; migration notice softened to "optional" framing

## Test plan

- [ ] Fresh install: sync file written to `GLANCE/dayglance/dayglance-sync.json`
- [ ] Existing user (syncFolder = 'dayglance'): sync continues working, amber notice appears in settings on first open
- [ ] Changing Sync folder in settings and saving: engine recreates with new path, next sync uses new folder
- [ ] Dismiss button on notice removes it permanently
- [ ] Build passes

https://claude.ai/code/session_01QtFKeinXaFZQNmaVKXMmCm