### PR TITLE
Add Google Play badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 **Your day, at a glance.** A privacy-first day planner with visual time-blocking, deep integrations, and zero lock-in. Use it free at [dayglance.app](https://dayglance.app) or self-host it on your own server. Your data stays on your device — nothing is ever sent to a server unless you choose to sync it yourself.
 
+[<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-2.10.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
-[<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="40">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases) · [**Android APK**](https://github.com/krelltunez/dayglance/releases)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-2.10.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="40">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases) · [**Android APK**](https://github.com/krelltunez/dayglance/releases)
 
@@ -71,7 +72,9 @@ Open [http://localhost:5173](http://localhost:5173). For production: `npm run bu
 
 ## Android App
 
-A native Android app is available as a direct APK download — no Play Store required.
+A native Android app is available on Google Play and as a direct APK download.
+
+[<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="60">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [**Download APK from Releases →**](https://github.com/krelltunez/dayglance/releases)
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds the official Google Play badge (linking to `https://play.google.com/store/apps/details?id=com.dayglance.app`) in two places: the top-level badges row and the Android section
- Updates the Android section intro from "no Play Store required" to "available on Google Play and as a direct APK download" now that the app is live on the store

## Test plan

- [ ] Confirm badge image renders correctly in the GitHub README preview
- [ ] Confirm badge link opens the correct Play Store listing

https://claude.ai/code/session_011jNtmF948fJKeHM1FMBq8A
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011jNtmF948fJKeHM1FMBq8A)_