### PR TITLE
chore: bump version to 2.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.10.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-2.11.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 96
-        versionName = "2.10"
+        versionCode = 97
+        versionName = "2.11"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "hasInstallScript": true,
       "dependencies": {
         "@glance-apps/intents": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "2.10.0",
+  "version": "2.11.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- `package.json`: `2.10.0` → `2.11.0`
- `dayglance-android/app/build.gradle.kts`: `versionCode` 96 → 97, `versionName` `"2.10"` → `"2.11"`
- `README.md`: version badge `2.10.0` → `2.11.0`

## Test plan

- [ ] Verify Android build picks up versionCode 97 / versionName 2.11
- [ ] Verify web app reports 2.11.0 (if surfaced in UI)

https://claude.ai/code/session_01VKAzZBpxuKvgVHSSGw26wK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKAzZBpxuKvgVHSSGw26wK)_