### PR TITLE
Phase 2.7: HKDF-per-envelope intents encryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "dayglance",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@glance-apps/intents": "^1.2.0",
+        "@glance-apps/intents": "^1.3.0",
         "@glance-apps/sync": "^1.1.0",
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",
@@ -2241,9 +2241,9 @@
       }
     },
     "node_modules/@glance-apps/intents": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.2.0.tgz",
-      "integrity": "sha512-TDgw4cMd9i1vbXkJeA217n+7zmUWo0iSdm1rjSUJXpkOXsTVA2O2SBF/RG7ELmp5cD1WW85diwsLJvgPmIkKSA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.3.0.tgz",
+      "integrity": "sha512-rWJDKa1vANFLMLdmqUirJDzANPAMlw93jP/ET4QR/Xrw2YNx0GMusm0C61y0GBzEroQLg4FEenXhsfu00/r2iQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "2.11.0",
+  "version": "2.12.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {
@@ -17,7 +17,7 @@
     "build:electron:release": "vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs --publish never"
   },
   "dependencies": {
-    "@glance-apps/intents": "^1.2.0",
+    "@glance-apps/intents": "^1.3.0",
     "@glance-apps/sync": "^1.1.0",
     "lucide-react": "^0.564.0",
     "react": "^18.2.0",

--- a/src/components/IntentActivityLogModal.jsx
+++ b/src/components/IntentActivityLogModal.jsx
@@ -36,10 +36,12 @@ const EVENT_COLORS_DARK = {
 
 const CRYPTO_ERROR_MESSAGES = {
   NoKeyError:            'encryption not configured',
-  WrongKeyError:         'decryption failed (wrong passphrase — verify same passphrase used in both apps)',
+  WrongKeyError:         'decryption failed (root key mismatch — try re-running intents encryption setup in Settings)',
   NotEncryptedError:     'unexpected: envelope not encrypted',
   MalformedEnvelopeError:'malformed envelope',
   InvalidPayloadError:   'invalid payload for encryption',
+  setup_incomplete:      'intents encryption setup incomplete — open Settings to complete setup',
+  no_root_key:           'encrypted intent received but intents encryption not set up on this device',
   no_key:                'key not ready — sent plaintext',
 };
 

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Activity, Archive, BarChart3, Bell, BookOpen, BrainCircuit, CalendarDays, CheckCircle, CheckSquare, ChevronDown, Clock, Cloud, ExternalLink, Flag, FolderOpen, Globe, Key, LayoutGrid, Loader, MapPin, Mic, Moon, Newspaper, RefreshCw, Server, Settings, Sparkles, Sun, Target, Thermometer, Upload, Wifi, WifiOff, X, Zap } from 'lucide-react';
+import { Activity, Archive, BarChart3, Bell, BookOpen, BrainCircuit, CalendarDays, CheckCircle, CheckSquare, ChevronDown, Clock, Cloud, ExternalLink, Flag, FolderOpen, Globe, Key, LayoutGrid, Loader, Lock, MapPin, Mic, Moon, Newspaper, RefreshCw, Server, Settings, Sparkles, Sun, Target, Thermometer, Upload, Wifi, WifiOff, X, Zap } from 'lucide-react';
 import { getTzLabel, getTzOptions } from '../utils/timezones.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
@@ -11,6 +11,9 @@ import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
 import { isNativeAndroid, isNativeApp, nativeGetCalendars } from '../native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault } from '../obsidian.js';
 import { INTENT_CONFIG_KEY } from '../intents/useIntentPoller.js';
+import { getSyncPassphrase, setSyncPassphrase } from '../utils/crypto.js';
+import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
+import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
 
 const SettingsModal = () => {
   const {
@@ -88,6 +91,9 @@ const SettingsModal = () => {
     };
   });
   const [intentSaved, setIntentSaved] = useState(false);
+  // null | 'passphrase-needed' | 'running' | { error: string }
+  const [intentSetupPhase, setIntentSetupPhase] = useState(null);
+  const [intentPassphraseInput, setIntentPassphraseInput] = useState('');
 
   const [trayHotkey, setTrayHotkey] = useState(() => localStorage.getItem('dg-tray-hotkey') || '');
   const [mainWindowHotkey, setMainWindowHotkey] = useState(() => localStorage.getItem('dg-main-window-hotkey') || '');
@@ -1516,7 +1522,7 @@ const SettingsModal = () => {
                             type="checkbox"
                             id="intent-encryption-toggle"
                             checked={intentForm.encryptionEnabled && !!cloudSyncConfig?.encryptionEnabled}
-                            disabled={!cloudSyncConfig?.encryptionEnabled}
+                            disabled={!cloudSyncConfig?.encryptionEnabled || intentSetupPhase !== null}
                             onChange={e => setIntentForm(p => ({ ...p, encryptionEnabled: e.target.checked }))}
                             className="mt-0.5 h-4 w-4 rounded"
                           />
@@ -1525,20 +1531,126 @@ const SettingsModal = () => {
                               Encrypt intent events
                             </label>
                             {cloudSyncConfig?.encryptionEnabled ? (
-                              <p className={`text-xs ${textSecondary} mt-0.5`}>Uses your cloud sync passphrase. Each event is independently re-keyed; no setup beyond entering the passphrase.</p>
+                              <p className={`text-xs ${textSecondary} mt-0.5`}>Uses your cloud sync passphrase. Set up once; remains active across sessions.</p>
                             ) : (
                               <p className={`text-xs ${textSecondary} mt-0.5`}>Requires cloud sync encryption to be enabled first.</p>
                             )}
                           </div>
                         </div>
+
+                        {/* Intents encryption setup — inline passphrase prompt or error */}
+                        {intentSetupPhase === 'passphrase-needed' && (
+                          <div className={`p-3 rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700/50' : 'bg-stone-50'}`}>
+                            <div className="flex items-center gap-2 mb-2">
+                              <Lock size={13} className="text-blue-500 flex-shrink-0" />
+                              <span className={`text-sm font-medium ${textPrimary}`}>Enter your sync passphrase to complete setup</span>
+                            </div>
+                            <p className={`text-xs ${textSecondary} mb-3`}>
+                              Required once to derive the intents encryption key. After this, no passphrase is needed across sessions.
+                            </p>
+                            <input
+                              type="password"
+                              autoFocus
+                              value={intentPassphraseInput}
+                              onChange={e => setIntentPassphraseInput(e.target.value)}
+                              onKeyDown={e => { if (e.key === 'Escape') { setIntentSetupPhase(null); setIntentPassphraseInput(''); } }}
+                              placeholder="Your sync passphrase"
+                              className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm mb-2`}
+                            />
+                            <div className="flex gap-2">
+                              <button
+                                disabled={!intentPassphraseInput.trim()}
+                                onClick={async () => {
+                                  const passphrase = intentPassphraseInput.trim();
+                                  setSyncPassphrase(passphrase);
+                                  setIntentPassphraseInput('');
+                                  setIntentSetupPhase('running');
+                                  const cfg = {
+                                    ...intentForm,
+                                    gcRetentionDays: Number(intentForm.gcRetentionDays) || 30,
+                                    encryptionEnabled: true,
+                                  };
+                                  try {
+                                    await setupIntentsEncryption(cfg, passphrase);
+                                    if (cfg.webdavUrl || cfg.username || cfg.appPassword) {
+                                      localStorage.setItem(INTENT_CONFIG_KEY, JSON.stringify(cfg));
+                                    }
+                                    setIntentSetupPhase(null);
+                                    setIntentSaved(true);
+                                    setTimeout(() => setIntentSaved(false), 2000);
+                                  } catch (err) {
+                                    setIntentSetupPhase({ error: err.message });
+                                  }
+                                }}
+                                className="px-3 py-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm"
+                              >
+                                Confirm
+                              </button>
+                              <button
+                                onClick={() => { setIntentSetupPhase(null); setIntentPassphraseInput(''); }}
+                                className={`px-3 py-1.5 ${darkMode ? 'bg-gray-600 hover:bg-gray-500' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} rounded-lg text-sm`}
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </div>
+                        )}
+                        {intentSetupPhase === 'running' && (
+                          <div className={`flex items-center gap-2 p-3 rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700/50' : 'bg-stone-50'}`}>
+                            <Loader size={14} className="animate-spin text-blue-500" />
+                            <span className={`text-sm ${textSecondary}`}>Setting up intents encryption…</span>
+                          </div>
+                        )}
+                        {intentSetupPhase?.error && (
+                          <div className={`p-3 rounded-lg border border-red-300 ${darkMode ? 'bg-red-900/20' : 'bg-red-50'}`}>
+                            <p className="text-sm text-red-500">Setup failed: {intentSetupPhase.error}</p>
+                            <button
+                              onClick={() => setIntentSetupPhase(null)}
+                              className="mt-1 text-xs text-red-400 hover:text-red-300 underline"
+                            >
+                              Dismiss
+                            </button>
+                          </div>
+                        )}
                         <div className="flex items-center gap-2 flex-wrap">
                           <button
-                            onClick={() => {
+                            disabled={intentSetupPhase === 'running'}
+                            onClick={async () => {
+                              const wantsEncryption = intentForm.encryptionEnabled && !!cloudSyncConfig?.encryptionEnabled;
                               const cfg = {
                                 ...intentForm,
                                 gcRetentionDays: Number(intentForm.gcRetentionDays) || 30,
-                                encryptionEnabled: intentForm.encryptionEnabled && !!cloudSyncConfig?.encryptionEnabled,
+                                encryptionEnabled: wantsEncryption,
                               };
+
+                              // If encryption is being turned off, clear the cached root key.
+                              if (!wantsEncryption) {
+                                await clearIntentsRootKey();
+                              }
+
+                              // If encryption is on, ensure setup is complete before saving.
+                              if (wantsEncryption) {
+                                const rootKey = await loadIntentsRootKey();
+                                if (!rootKey) {
+                                  const passphrase = getSyncPassphrase();
+                                  if (passphrase) {
+                                    // Passphrase already in session — run setup silently.
+                                    setIntentSetupPhase('running');
+                                    try {
+                                      await setupIntentsEncryption(cfg, passphrase);
+                                    } catch (err) {
+                                      setIntentSetupPhase({ error: err.message });
+                                      return;
+                                    }
+                                    setIntentSetupPhase(null);
+                                  } else {
+                                    // Passphrase not in session — show inline prompt.
+                                    setIntentSetupPhase('passphrase-needed');
+                                    return; // save deferred until passphrase confirmed
+                                  }
+                                }
+                              }
+
                               if (cfg.webdavUrl || cfg.username || cfg.appPassword) {
                                 localStorage.setItem(INTENT_CONFIG_KEY, JSON.stringify(cfg));
                               } else {
@@ -1547,8 +1659,9 @@ const SettingsModal = () => {
                               setIntentSaved(true);
                               setTimeout(() => setIntentSaved(false), 2000);
                             }}
-                            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm transition-colors"
+                            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-60 text-sm transition-colors flex items-center gap-1.5"
                           >
+                            {intentSetupPhase === 'running' && <Loader size={13} className="animate-spin" />}
                             {intentSaved ? 'Saved' : 'Save'}
                           </button>
                           {intentForm.webdavUrl && (
@@ -1556,6 +1669,7 @@ const SettingsModal = () => {
                               onClick={() => {
                                 setIntentForm({ webdavUrl: '', username: '', appPassword: '', eventsPath: '/GLANCE/events/', foregroundInterval: 120000, backgroundInterval: 900000, gcRetentionDays: 30, encryptionEnabled: false });
                                 localStorage.removeItem(INTENT_CONFIG_KEY);
+                                clearIntentsRootKey();
                               }}
                               className={`px-4 py-2 ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} rounded-lg text-sm transition-colors`}
                             >

--- a/src/intents/intentsEncryptionSetup.js
+++ b/src/intents/intentsEncryptionSetup.js
@@ -1,0 +1,67 @@
+import { deriveIntentsRootKey } from '@glance-apps/intents';
+import { webdavFetch } from '../utils/cloudSyncProviders.js';
+import { storeIntentsRootKey } from './intentsKeyStore.js';
+
+const SALT_FILENAME = 'intents-encryption-salt.json';
+
+function eventsDir(config) {
+  const base = (config.webdavUrl ?? '').replace(/\/+$/, '');
+  const path = (config.eventsPath ?? '/GLANCE/events/').replace(/\/+$/, '') + '/';
+  return `${base}${path}`;
+}
+
+function authHeaders(config) {
+  const cred = btoa(`${config.username}:${config.appPassword}`);
+  return { 'X-WebDAV-Auth': `Basic ${cred}` };
+}
+
+async function fetchOrCreateRootSalt(config) {
+  const dir = eventsDir(config);
+  const saltUrl = `${dir}${SALT_FILENAME}`;
+  const headers = authHeaders(config);
+
+  const getRes = await webdavFetch('GET', saltUrl, headers);
+  if (getRes.ok) {
+    const data = await getRes.json();
+    return Uint8Array.from(atob(data.salt), c => c.charCodeAt(0));
+  }
+
+  if (getRes.status !== 404) {
+    throw new Error(`Failed to fetch salt file: HTTP ${getRes.status}`);
+  }
+
+  // Salt file doesn't exist yet — this app is first. Generate and write it.
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const saltB64 = btoa(String.fromCharCode(...salt));
+  const body = JSON.stringify({ version: 1, salt: saltB64, created_at: new Date().toISOString() });
+  const putHeaders = { ...headers, 'Content-Type': 'application/json' };
+
+  let putRes = await webdavFetch('PUT', saltUrl, putHeaders, body);
+  if (putRes.status === 404 || putRes.status === 409) {
+    await webdavFetch('MKCOL', dir, headers);
+    putRes = await webdavFetch('PUT', saltUrl, putHeaders, body);
+  }
+  if (!putRes.ok) {
+    throw new Error(`Failed to write salt file: HTTP ${putRes.status}`);
+  }
+
+  return salt;
+}
+
+/**
+ * Derive and cache the intents root key for the given WebDAV endpoint.
+ * Fetches the shared salt from WebDAV (writing it if this app is first),
+ * derives an HKDF root key, and stores it in IndexedDB.
+ *
+ * Caller must supply the cloud sync passphrase — this is the only time
+ * intents needs it. After this returns, the cached root key is sufficient
+ * for all emit/poll operations.
+ *
+ * @param {object} config - intent WebDAV config (webdavUrl, username, appPassword, eventsPath)
+ * @param {string} passphrase - the cloud sync passphrase
+ */
+export async function setupIntentsEncryption(config, passphrase) {
+  const sharedRootSalt = await fetchOrCreateRootSalt(config);
+  const rootKey = await deriveIntentsRootKey(passphrase, sharedRootSalt);
+  await storeIntentsRootKey(rootKey);
+}

--- a/src/intents/intentsKeyStore.js
+++ b/src/intents/intentsKeyStore.js
@@ -1,0 +1,57 @@
+const DB_NAME = 'dayglance-intents-crypto';
+const DB_VERSION = 1;
+const STORE = 'keys';
+const ROOT_KEY_RECORD = 'root-key';
+
+// Module-level cache: avoids an IDB round-trip on every emit/poll cycle.
+// Cleared synchronously by clearIntentsRootKey().
+let _cachedRootKey = null;
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function storeIntentsRootKey(cryptoKey) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).put(cryptoKey, ROOT_KEY_RECORD);
+    tx.oncomplete = () => { _cachedRootKey = cryptoKey; resolve(); };
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function loadIntentsRootKey() {
+  if (_cachedRootKey !== null) return _cachedRootKey;
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).get(ROOT_KEY_RECORD);
+    req.onsuccess = () => {
+      _cachedRootKey = req.result ?? null;
+      resolve(_cachedRootKey);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function clearIntentsRootKey() {
+  _cachedRootKey = null;
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).delete(ROOT_KEY_RECORD);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}

--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
-import { parseEnvelope, parseEncryptedEnvelope, filenameFor, parseFilename, NoKeyError, WrongKeyError, NotEncryptedError, MalformedEnvelopeError } from '@glance-apps/intents';
-import { deriveKeyForSalt } from '@glance-apps/sync';
+import { parseEnvelope, parseEncryptedEnvelope, filenameFor, parseFilename, deriveEnvelopeKey, NoKeyError, WrongKeyError, NotEncryptedError, MalformedEnvelopeError } from '@glance-apps/intents';
+import { loadIntentsRootKey } from './intentsKeyStore.js';
 import { webdavFetch } from '../utils/cloudSyncProviders.js';
 import { handleIntent } from './handleIntent.js';
 import { logActivity } from './intentLog.js';
@@ -176,7 +176,24 @@ async function poll(config, context) {
       let envelope;
       try {
         if (raw?.encrypted === true) {
-          envelope = await parseEncryptedEnvelope(raw, deriveKeyForSalt);
+          const rootKey = await loadIntentsRootKey();
+          if (!rootKey) {
+            // Encrypted envelope received but intents encryption not set up on this device.
+            console.warn('[intent] Skipping encrypted event — intents encryption not set up:', name);
+            logActivity({
+              direction: 'in',
+              action: 'unknown',
+              event: null,
+              source_app: null,
+              title: null,
+              timestamp: new Date().toISOString(),
+              status: 'error',
+              error: 'no_root_key',
+            });
+            setCursor(parsed.event_id);
+            continue;
+          }
+          envelope = await parseEncryptedEnvelope(raw, (salt) => deriveEnvelopeKey(rootKey, salt));
         } else {
           envelope = parseEnvelope(raw);
         }

--- a/src/intents/useNotifyEmitter.js
+++ b/src/intents/useNotifyEmitter.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
-import { buildEnvelope, buildEncryptedEnvelope, eventId as makeEventId, EVENTS, ENTITY_TYPES } from '@glance-apps/intents';
-import { hasEncryptionReady, deriveKeyForSalt } from '@glance-apps/sync';
+import { buildEnvelope, buildEncryptedEnvelope, eventId as makeEventId, EVENTS, ENTITY_TYPES, deriveEnvelopeKey } from '@glance-apps/intents';
+import { loadIntentsRootKey } from './intentsKeyStore.js';
 import { writeEventFile, INTENT_CONFIG_KEY } from './useIntentPoller.js';
 import { logActivity } from './intentLog.js';
 
@@ -104,8 +104,27 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
     if (!emits.length) return;
 
     const fire = async () => {
-      const useEncryption = config.encryptionEnabled && hasEncryptionReady();
-      const keyUnavailable = config.encryptionEnabled && !hasEncryptionReady();
+      // Resolve encryption posture once for the whole batch.
+      let deriveKey = null;
+      if (config.encryptionEnabled) {
+        const rootKey = await loadIntentsRootKey();
+        if (!rootKey) {
+          // Root key not cached — setup incomplete. Block all emits; do not fall back to plaintext.
+          console.warn('[notify] intents encryption setup incomplete — skipping', emits.length, 'emit(s)');
+          logActivity({
+            direction: 'out',
+            action: 'notify',
+            event: null,
+            source_app: null,
+            title: null,
+            timestamp: now,
+            status: 'error',
+            error: 'setup_incomplete',
+          });
+          return;
+        }
+        deriveKey = (salt) => deriveEnvelopeKey(rootKey, salt);
+      }
 
       for (const { task, change } of emits) {
         const payload = {
@@ -122,26 +141,9 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
           ...(change.completed_at !== undefined ? { completed_at: change.completed_at } : {}),
         };
 
-        if (keyUnavailable) {
-          // Encryption is configured but the session key isn't loaded yet (new device,
-          // passphrase not entered). Fall back to plaintext so events still flow and log
-          // the configuration drift so the user can diagnose it.
-          console.warn('[notify] encryption configured but key not ready; emitting plaintext for task', task.id);
-          logActivity({
-            direction: 'out',
-            action: 'notify',
-            event: change.event,
-            source_app: task.source_app,
-            title: task.title,
-            timestamp: now,
-            status: 'warn',
-            error: 'no_key',
-          });
-        }
-
         try {
-          const envelope = useEncryption
-            ? await buildEncryptedEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' }, deriveKeyForSalt)
+          const envelope = deriveKey
+            ? await buildEncryptedEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' }, deriveKey)
             : buildEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' });
           await writeEventFile(config, envelope);
           logActivity({


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Phase 2.7 replaces PBKDF2-per-envelope (Phase 2.6) with HKDF-per-envelope against an intents-owned long-lived root key. The root key is derived once at intents-encryption setup, cached non-extractably in IndexedDB, and reused via HKDF for every envelope. After setup, the cloud sync passphrase is never needed by intents — restoring the set-and-forget UX that Phase 2.6 broke.

Sync is not modified. This is an intents-only change.

---

## Five commits

**PR #1 — Package upgrade**
- `@glance-apps/intents` → `1.3.0` (brings `deriveIntentsRootKey` and `deriveEnvelopeKey`)
- `dayglance` → `v2.12.0`

**PR #2 — `src/intents/intentsKeyStore.js`**
- New module: raw IndexedDB in a separate `dayglance-intents-crypto` database (never co-mingles with sync's `dayglance-crypto`)
- Three exports: `storeIntentsRootKey`, `loadIntentsRootKey`, `clearIntentsRootKey`
- Module-level cache avoids IDB round-trips on every emit/poll; `clearIntentsRootKey` flushes both cache and IDB

**PR #3 — Setup flow**
- New `src/intents/intentsEncryptionSetup.js`: fetches-or-writes the shared root salt (`intents-encryption-salt.json` in the events directory) and derives + caches the HKDF root key
- `SettingsModal`: save handler is now async; when encryption is toggled on and no root key is cached, either runs setup silently (passphrase in session) or shows an inline passphrase step with loading/error states; toggle-off and Disconnect both call `clearIntentsRootKey()`
- Settings copy updated: "Uses your cloud sync passphrase. Set up once; remains active across sessions."
- The inline setup UI disables the save button and toggle during setup to prevent concurrent submissions

**PR #4 — Emitter and poller**
- `useNotifyEmitter`: loads root key from IDB once per emit batch; builds `deriveKey = (salt) => deriveEnvelopeKey(rootKey, salt)`; if root key absent, logs `setup_incomplete` error and **blocks all emits** — no plaintext fallback (eliminates the silent-plaintext bug from Phase 2.6)
- `useIntentPoller`: when `encrypted: true`, loads root key; if absent, logs `no_root_key` and skips; if present, decrypts via HKDF callback
- Both files drop the `@glance-apps/sync` import entirely — no sync state accessed at emit/poll time

**PR #5 — Activity log copy**
- New error codes: `setup_incomplete` ("intents encryption setup incomplete — open Settings to complete setup") and `no_root_key` ("encrypted intent received but intents encryption not set up on this device")
- `WrongKeyError` copy updated to reflect that it now means genuine root-key mismatch (corrupted shared salt) rather than passphrase mismatch

---

## Pre-work cleanup required before testing

1. Delete all encrypted envelopes from the WebDAV intents directory (`/GLANCE/events/`) — they lack Phase 2.7-compatible key material
2. Turn off the intents encryption toggle in dayGLANCE and save
3. Open DevTools → Application → IndexedDB → delete the `dayglance-intents-crypto` database if present

Sync data, tasks, and app settings are untouched.

## Verification checklist

- [ ] First-time setup: enable intents encryption toggle. If passphrase not in session, confirm inline prompt appears. After entry, confirm `intents-encryption-salt.json` is written to WebDAV and root key appears in `dayglance-intents-crypto` IDB
- [ ] Cross-session UX (the core Phase 2.7 requirement): close and reopen dayGLANCE without entering any passphrase. Trigger a task state change on a linked task. Confirm encrypted notify emitted to WebDAV with no passphrase prompt
- [ ] Toggle-off: disable encryption and save. Confirm `dayglance-intents-crypto` IDB record is cleared
- [ ] Re-enable without passphrase in session: confirm inline passphrase prompt appears
- [ ] Setup-incomplete error: clear IDB manually, leave toggle on, trigger emit. Confirm activity log shows "intents encryption setup incomplete" and no file is written
- [ ] Full cross-app: coordinate with lastGLANCE v0.1.14 for end-to-end encrypted round-trip

## Release coordination

Ships as dayGLANCE v2.12.0 in coordination with lastGLANCE v0.1.14. Do not merge without the counterpart — a Phase 2.6 emitter sending to a Phase 2.7 poller (or vice versa) will produce `WrongKeyError` on every decrypt.

https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne)_