### PR TITLE
fix(intents): disable Save button while passphrase-needed prompt is s…

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1614,7 +1614,7 @@ const SettingsModal = () => {
                         )}
                         <div className="flex items-center gap-2 flex-wrap">
                           <button
-                            disabled={intentSetupPhase === 'running'}
+                            disabled={intentSetupPhase === 'running' || intentSetupPhase === 'passphrase-needed'}
                             onClick={async () => {
                               const wantsEncryption = intentForm.encryptionEnabled && !!cloudSyncConfig?.encryptionEnabled;
                               const cfg = {


### PR DESCRIPTION
…howing

Previously Save was only disabled during 'running'. While 'passphrase-needed' the handler would re-enter and re-set the same phase, which is harmless but confusing. Match the instruction that the form should be non-interactive during the full inline setup flow.

https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne