### PR TITLE
fix: preserve _intentKey tasks during applyEngineData cloud sync apply

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5063,11 +5063,11 @@ const DayPlanner = () => {
     // next calendar sync re-imports them.
     if (normalizedTasks) setTasks(prev => {
       const mergedIds = new Set(normalizedTasks.map(t => String(t.id)));
-      return [...normalizedTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported))];
+      return [...normalizedTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
     });
     if (normalizedUnsched) setUnscheduledTasks(prev => {
       const mergedIds = new Set(normalizedUnsched.map(t => String(t.id)));
-      return [...normalizedUnsched, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported))];
+      return [...normalizedUnsched, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
     });
     if (data.unscheduledOrderTimestamp) {
       setUnscheduledOrderTimestamp(data.unscheduledOrderTimestamp);
@@ -5077,7 +5077,10 @@ const DayPlanner = () => {
     if (data.syncUrl !== undefined) setSyncUrl(data.syncUrl);
     if (data.taskCalendarUrl !== undefined) setTaskCalendarUrl(data.taskCalendarUrl);
     if (data.completedTaskUids) setCompletedTaskUids(new Set(data.completedTaskUids));
-    if (data.recurringTasks) setRecurringTasks(data.recurringTasks);
+    if (data.recurringTasks) setRecurringTasks(prev => {
+      const mergedIds = new Set(data.recurringTasks.map(t => String(t.id)));
+      return [...data.recurringTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey)];
+    });
     if (data.routineDefinitions) setRoutineDefinitions(data.routineDefinitions);
     // Only apply today's routine state if the remote data is from today — matching
     // the localStorage guard above. If routinesDate is stale/off, applying it would


### PR DESCRIPTION
## Summary

- Intent-created tasks (`_intentKey` set) were silently dropped by `applyEngineData` during the ~5-second window between task creation and the first cloud upload
- The preserve-from-prev filter only kept `_native` and `imported` tasks; `_intentKey` tasks matched neither, so cloud sync's apply pass would overwrite them with the (not-yet-updated) remote payload
- Task appeared as `ok` in the activity log but was never visible in dayGLANCE

## Changes

**`src/App.jsx` — `applyEngineData`** (lines 5064–5083):

- Extend the `setTasks` and `setUnscheduledTasks` preserve-from-prev filter: `t._native || t.imported` → `t._native || t.imported || t._intentKey`
- Convert `setRecurringTasks(data.recurringTasks)` from a full replacement to a functional updater that preserves any `_intentKey` recurring templates not yet uploaded

## Safety

Deletion in dayGLANCE is tombstone+recycleBin-based, not pure-absence-based:
- **Soft delete** (`moveToRecycleBin`): task moves to `recycleBin` array — it's already out of `prev.tasks` at apply time, so the `_intentKey` filter can't resurrect it
- **Permanent delete** (`confirmEmptyBin`): tombstone written to `deletedTaskIds`; `mergeArrayById` uses explicit `deletedIds`, not the absence of a task from prev

An intent-created task that has been legitimately deleted will not be in `prev` when `applyEngineData` runs.

## Test plan

- [ ] Create a task via intent (e.g. Shortcuts / another GLANCE app)
- [ ] Confirm task appears in dayGLANCE immediately (not dropped by the next cloud sync cycle)
- [ ] Verify activity log shows `ok` and the task is visible in the task list
- [ ] Delete a previously intent-created task, let cloud sync run — confirm it stays deleted

https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne)_