### PR TITLE
debug: console tracing for intent task creation and applyEngineData

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4844,6 +4844,12 @@ const DayPlanner = () => {
       const m = uid.match(/::(\d{4}-\d{2}-\d{2})$/);
       return !m || new Date(m[1]) >= uidCutoff;
     });
+    const _tasksForSync = tasks.filter(t => !t._native && !(t.imported && !t.isTaskCalendar && t.importSource !== 'file'));
+    const _unschedForSync = unscheduledTasks.filter(t => !(t.imported && !t.isTaskCalendar && t.importSource !== 'file'));
+    console.log('[intent:buildSyncPayload] tasks:', _tasksForSync.length, '| unsched:', _unschedForSync.length, '| recurring:', recurringTasks.length,
+      '| _intentKey in tasks:', _tasksForSync.filter(t => t._intentKey).map(t => t._intentKey),
+      '| _intentKey in unsched:', _unschedForSync.filter(t => t._intentKey).map(t => t._intentKey),
+      '| _intentKey in recurring:', recurringTasks.filter(t => t._intentKey).map(t => t._intentKey));
     return {
       version: 2,
       lastModified: new Date().toISOString(),
@@ -5063,10 +5069,14 @@ const DayPlanner = () => {
     // next calendar sync re-imports them.
     if (normalizedTasks) setTasks(prev => {
       const mergedIds = new Set(normalizedTasks.map(t => String(t.id)));
+      const intentKeyPrev = prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey);
+      console.log('[intent:applyEngineData] setTasks updater — prev:', prev.length, '| normalizedTasks:', normalizedTasks.length, '| _intentKey preserved from prev:', intentKeyPrev.length, intentKeyPrev.map(t => t._intentKey));
       return [...normalizedTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
     });
     if (normalizedUnsched) setUnscheduledTasks(prev => {
       const mergedIds = new Set(normalizedUnsched.map(t => String(t.id)));
+      const intentKeyPrev = prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey);
+      console.log('[intent:applyEngineData] setUnscheduledTasks updater — prev:', prev.length, '| normalizedUnsched:', normalizedUnsched.length, '| _intentKey preserved from prev:', intentKeyPrev.length, intentKeyPrev.map(t => t._intentKey));
       return [...normalizedUnsched, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
     });
     if (data.unscheduledOrderTimestamp) {
@@ -5079,6 +5089,8 @@ const DayPlanner = () => {
     if (data.completedTaskUids) setCompletedTaskUids(new Set(data.completedTaskUids));
     if (data.recurringTasks) setRecurringTasks(prev => {
       const mergedIds = new Set(data.recurringTasks.map(t => String(t.id)));
+      const intentKeyPrev = prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey);
+      console.log('[intent:applyEngineData] setRecurringTasks updater — prev:', prev.length, '| data.recurringTasks:', data.recurringTasks.length, '| _intentKey preserved from prev:', intentKeyPrev.length, intentKeyPrev.map(t => t._intentKey));
       return [...data.recurringTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey)];
     });
     if (data.routineDefinitions) setRoutineDefinitions(data.routineDefinitions);

--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -223,31 +223,30 @@ async function handleCreate(payload, context) {
   if (recurring) {
     const scheduled = parseDue(due, allDay);
     const startDate = scheduled?.date ?? new Date().toISOString().slice(0, 10);
-    setRecurringTasks(prev => [...prev, {
+    const newRecurring = {
       ...baseTask,
       startTime: scheduled && !scheduled.isAllDay ? scheduled.startTime : '00:00',
       isAllDay: allDay ?? true,
       recurrence: freqToRecurrence(recurring, startDate),
       completedDates: [],
       exceptions: {},
-    }]);
+    };
+    console.log('[intent:handleCreate] setRecurringTasks — new recurring task:', JSON.stringify(newRecurring));
+    setRecurringTasks(prev => [...prev, newRecurring]);
   } else if (due) {
     const scheduled = parseDue(due, allDay);
-    setTasks(prev => [...prev, {
-      ...baseTask,
-      date: scheduled.date,
-      startTime: scheduled.startTime,
-      isAllDay: scheduled.isAllDay,
-    }]);
+    const newTask = { ...baseTask, date: scheduled.date, startTime: scheduled.startTime, isAllDay: scheduled.isAllDay };
+    console.log('[intent:handleCreate] setTasks — new scheduled task:', JSON.stringify(newTask));
+    setTasks(prev => [...prev, newTask]);
   } else {
-    setUnscheduledTasks(prev => [...prev, {
-      ...baseTask,
-      priority: priority ?? 0,
-      ...(normalized.deadline ? { deadline: normalized.deadline } : {}),
-    }]);
+    const newTask = { ...baseTask, priority: priority ?? 0, ...(normalized.deadline ? { deadline: normalized.deadline } : {}) };
+    console.log('[intent:handleCreate] setUnscheduledTasks — new inbox task:', JSON.stringify(newTask));
+    setUnscheduledTasks(prev => [...prev, newTask]);
   }
 
-  return ok({ task_id: taskId });
+  const result = ok({ task_id: taskId });
+  console.log('[intent:handleCreate] returning:', JSON.stringify(result));
+  return result;
 }
 
 function handleComplete(payload, context) {


### PR DESCRIPTION
## Purpose

Temporary diagnostic build to trace where intent-created tasks disappear. **Do not merge to main** — remove all `console.log` calls before shipping.

## What's logged

**`[intent:handleCreate]`** — fires inside `handleCreate` when a new task is actually created (not the idempotency-update path). Logs:
- Which setter was called (`setTasks` / `setUnscheduledTasks` / `setRecurringTasks`)
- Full task object including `_intentKey`, `date`, `startTime`, `isAllDay`
- The `ok({ task_id })` result being returned

**`[intent:applyEngineData]`** — fires inside each of the three functional updaters in `applyEngineData` (the ones PR #905 modified). Logs:
- `prev.length` — how many tasks were in React state when the updater ran
- `normalizedTasks.length` / `data.recurringTasks.length` — how many tasks came from the cloud merge
- `_intentKey preserved from prev` — count and key list of intent tasks rescued from prev

**`[intent:buildSyncPayload]`** — fires every time the upload payload is built. Logs:
- Task/unsched/recurring counts going into the upload
- Which `_intentKey` values are present in each list

## How to use

Deploy this build, trigger a `→ dG` from lastGLANCE, and capture the console output in time order. The sequence should show:

1. `[intent:handleCreate]` — confirms the handler ran and which list the task went into
2. `[intent:buildSyncPayload]` — confirms whether the task was present when the upload fired
3. `[intent:applyEngineData]` — if this fires after #1, confirms whether the task survived or was dropped

Wherever the `_intentKey` value disappears from the trace, that's the drop site.

https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne)_