### PR TITLE
debug: focused intent tracing (v2) — silent unless intent-related

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4846,10 +4846,12 @@ const DayPlanner = () => {
     });
     const _tasksForSync = tasks.filter(t => !t._native && !(t.imported && !t.isTaskCalendar && t.importSource !== 'file'));
     const _unschedForSync = unscheduledTasks.filter(t => !(t.imported && !t.isTaskCalendar && t.importSource !== 'file'));
-    console.log('[intent:buildSyncPayload] tasks:', _tasksForSync.length, '| unsched:', _unschedForSync.length, '| recurring:', recurringTasks.length,
-      '| _intentKey in tasks:', _tasksForSync.filter(t => t._intentKey).map(t => t._intentKey),
-      '| _intentKey in unsched:', _unschedForSync.filter(t => t._intentKey).map(t => t._intentKey),
-      '| _intentKey in recurring:', recurringTasks.filter(t => t._intentKey).map(t => t._intentKey));
+    const _intentTasks = _tasksForSync.filter(t => t._intentKey).map(t => t._intentKey);
+    const _intentUnsched = _unschedForSync.filter(t => t._intentKey).map(t => t._intentKey);
+    const _intentRecurring = recurringTasks.filter(t => t._intentKey).map(t => t._intentKey);
+    if (_intentTasks.length || _intentUnsched.length || _intentRecurring.length) {
+      console.log('[intent:buildSyncPayload] _intentKey in payload — tasks:', _intentTasks, '| unsched:', _intentUnsched, '| recurring:', _intentRecurring);
+    }
     return {
       version: 2,
       lastModified: new Date().toISOString(),
@@ -5070,13 +5072,19 @@ const DayPlanner = () => {
     if (normalizedTasks) setTasks(prev => {
       const mergedIds = new Set(normalizedTasks.map(t => String(t.id)));
       const intentKeyPrev = prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey);
-      console.log('[intent:applyEngineData] setTasks updater — prev:', prev.length, '| normalizedTasks:', normalizedTasks.length, '| _intentKey preserved from prev:', intentKeyPrev.length, intentKeyPrev.map(t => t._intentKey));
+      const intentKeyDropped = prev.filter(t => mergedIds.has(String(t.id)) && t._intentKey);
+      if (prev.some(t => t._intentKey) || intentKeyPrev.length) {
+        console.log('[intent:applyEngineData] setTasks — prev _intentKey:', prev.filter(t => t._intentKey).map(t => t._intentKey), '| preserved:', intentKeyPrev.map(t => t._intentKey), '| in normalizedTasks (not dropped):', intentKeyDropped.map(t => t._intentKey));
+      }
       return [...normalizedTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
     });
     if (normalizedUnsched) setUnscheduledTasks(prev => {
       const mergedIds = new Set(normalizedUnsched.map(t => String(t.id)));
       const intentKeyPrev = prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey);
-      console.log('[intent:applyEngineData] setUnscheduledTasks updater — prev:', prev.length, '| normalizedUnsched:', normalizedUnsched.length, '| _intentKey preserved from prev:', intentKeyPrev.length, intentKeyPrev.map(t => t._intentKey));
+      const intentKeyDropped = prev.filter(t => mergedIds.has(String(t.id)) && t._intentKey);
+      if (prev.some(t => t._intentKey) || intentKeyPrev.length) {
+        console.log('[intent:applyEngineData] setUnscheduledTasks — prev _intentKey:', prev.filter(t => t._intentKey).map(t => t._intentKey), '| preserved:', intentKeyPrev.map(t => t._intentKey), '| in normalizedUnsched (not dropped):', intentKeyDropped.map(t => t._intentKey));
+      }
       return [...normalizedUnsched, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
     });
     if (data.unscheduledOrderTimestamp) {
@@ -5090,7 +5098,10 @@ const DayPlanner = () => {
     if (data.recurringTasks) setRecurringTasks(prev => {
       const mergedIds = new Set(data.recurringTasks.map(t => String(t.id)));
       const intentKeyPrev = prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey);
-      console.log('[intent:applyEngineData] setRecurringTasks updater — prev:', prev.length, '| data.recurringTasks:', data.recurringTasks.length, '| _intentKey preserved from prev:', intentKeyPrev.length, intentKeyPrev.map(t => t._intentKey));
+      const intentKeyDropped = prev.filter(t => mergedIds.has(String(t.id)) && t._intentKey);
+      if (prev.some(t => t._intentKey) || intentKeyPrev.length) {
+        console.log('[intent:applyEngineData] setRecurringTasks — prev _intentKey:', prev.filter(t => t._intentKey).map(t => t._intentKey), '| preserved:', intentKeyPrev.map(t => t._intentKey), '| in data.recurringTasks (not dropped):', intentKeyDropped.map(t => t._intentKey));
+      }
       return [...data.recurringTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey)];
     });
     if (data.routineDefinitions) setRoutineDefinitions(data.routineDefinitions);

--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -124,8 +124,13 @@ async function handleCreate(payload, context) {
     projects = [],
   } = context;
 
+  console.log('[intent:handleCreate] entered — title:', payload.title, '| due:', payload.due, '| source_entity_id:', payload.source_entity_id);
+
   const v = validate(CreateSchema, payload);
-  if (!v.ok) return fail(v.error);
+  if (!v.ok) {
+    console.log('[intent:handleCreate] validation failed:', v.error);
+    return fail(v.error);
+  }
 
   const raw = v.data;
 
@@ -157,10 +162,13 @@ async function handleCreate(payload, context) {
     source_entity_id: raw.source_entity_id,
   };
 
+  console.log('[intent:handleCreate] normalized — due:', due, '| allDay:', allDay, '| recurring:', recurring, '| setters:', { setTasks: !!setTasks, setUnscheduledTasks: !!setUnscheduledTasks, setRecurringTasks: !!setRecurringTasks });
+
   let intentKey = null;
 
   if (raw.source_app && raw.source_entity_id) {
     intentKey = await createKey(raw.source_app, raw.source_entity_id, due);
+    console.log('[intent:handleCreate] intentKey:', intentKey, '| searching', tasks.length, 'tasks,', unscheduledTasks.length, 'unsched,', recurringTasks.length, 'recurring');
 
     const existing =
       tasks.find(t => t._intentKey === intentKey && !t.completed) ||
@@ -168,6 +176,7 @@ async function handleCreate(payload, context) {
       recurringTasks.find(t => t._intentKey === intentKey);
 
     if (existing) {
+      console.log('[intent:handleCreate] decision: idempotency hit — existing task id:', existing.id);
       if (setTasks || setUnscheduledTasks || setRecurringTasks) {
         // Execute: update the existing task in whichever list it lives in.
         const projectId = resolveProjectId(normalized.project, projects);
@@ -198,6 +207,7 @@ async function handleCreate(payload, context) {
 
   // Skeleton mode: no setters provided, return normalized result only.
   if (!setTasks && !setUnscheduledTasks && !setRecurringTasks) {
+    console.log('[intent:handleCreate] decision: skeleton mode (no setters) — returning normalized only');
     return ok({ warning: '', _normalized: normalized, _intentKey: intentKey });
   }
 
@@ -231,21 +241,21 @@ async function handleCreate(payload, context) {
       completedDates: [],
       exceptions: {},
     };
-    console.log('[intent:handleCreate] setRecurringTasks — new recurring task:', JSON.stringify(newRecurring));
+    console.log('[intent:handleCreate] decision: recurring — calling setRecurringTasks, id:', taskId, '_intentKey:', intentKey);
     setRecurringTasks(prev => [...prev, newRecurring]);
   } else if (due) {
     const scheduled = parseDue(due, allDay);
     const newTask = { ...baseTask, date: scheduled.date, startTime: scheduled.startTime, isAllDay: scheduled.isAllDay };
-    console.log('[intent:handleCreate] setTasks — new scheduled task:', JSON.stringify(newTask));
+    console.log('[intent:handleCreate] decision: scheduled — calling setTasks, id:', taskId, 'date:', scheduled.date, 'isAllDay:', scheduled.isAllDay, '_intentKey:', intentKey);
     setTasks(prev => [...prev, newTask]);
   } else {
     const newTask = { ...baseTask, priority: priority ?? 0, ...(normalized.deadline ? { deadline: normalized.deadline } : {}) };
-    console.log('[intent:handleCreate] setUnscheduledTasks — new inbox task:', JSON.stringify(newTask));
+    console.log('[intent:handleCreate] decision: unscheduled — calling setUnscheduledTasks, id:', taskId, '_intentKey:', intentKey);
     setUnscheduledTasks(prev => [...prev, newTask]);
   }
 
   const result = ok({ task_id: taskId });
-  console.log('[intent:handleCreate] returning:', JSON.stringify(result));
+  console.log('[intent:handleCreate] done — task_id:', taskId, '_intentKey:', intentKey);
   return result;
 }
 

--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -136,6 +136,8 @@ async function poll(config, context) {
   const dir = eventsDir(config);
   const headers = authHeaders(config);
 
+  console.log('[intent:poll] starting');
+
   let res;
   try {
     res = await webdavFetch('PROPFIND', dir, headers, undefined, { Depth: '1' });
@@ -162,6 +164,8 @@ async function poll(config, context) {
   const cursor = getCursor();
   // event_id is a sortable timestamp string: only process files strictly after cursor
   const pending = cursor ? files.filter(f => f.parsed.event_id > cursor) : files;
+
+  console.log('[intent:poll] cursor:', cursor, '| total files:', files.length, '| pending:', pending.length);
 
   for (const { name, parsed } of pending) {
     try {
@@ -229,7 +233,9 @@ async function poll(config, context) {
         continue;
       }
 
+      console.log('[intent:poll] processing event_id:', parsed.event_id, '| action:', envelope.action, '| emitted_by:', envelope.emitted_by);
       const result = await handleIntent(envelope.action, envelope.payload, context);
+      console.log('[intent:poll] handleIntent returned:', JSON.stringify(result));
       logActivity({
         direction: 'in',
         action: envelope.action,


### PR DESCRIPTION
## Purpose

Replaces PR #906's noisy per-cycle logging with targeted output that stays silent during normal sync and only speaks when an intent event is in flight. **Do not merge to main** — remove all `console.log` calls before shipping.

## What fires and when

**`[intent:poll] starting`** — once per poll cycle (every 2 min foreground / 15 min background / visibility change). Shows cursor and pending count so you can tell immediately whether a new event is in the queue.

**`[intent:poll] processing event_id: … action: …`** — once per envelope that passes the cursor and self-emit filters. This is the gate: if you see the activity log badge but never see this line, the event is being filtered before dispatch.

**`[intent:poll] handleIntent returned: …`** — immediately after dispatch, shows the full result including any warning.

**`[intent:handleCreate] entered`** — fires at the top of handleCreate, logs title/due/source_entity_id from the raw payload.

**`[intent:handleCreate] normalized`** — logs due, allDay, recurring after normalization; confirms whether `due` parsed correctly and whether `recurring` is set.

**`[intent:handleCreate] intentKey`** — logs the computed SHA-256 key and the sizes of all three task lists being searched for idempotency.

**`[intent:handleCreate] decision: …`** — logs which branch was taken: `idempotency hit`, `skeleton mode`, `scheduled`, `unscheduled`, or `recurring`. For new creates, logs the task id and `_intentKey`.

**`[intent:handleCreate] done`** — final confirmation with task_id and _intentKey.

**`[intent:applyEngineData] setTasks/setUnscheduledTasks/setRecurringTasks`** — only fires when `prev` contains `_intentKey` tasks. Shows which keys are preserved from prev vs already present in normalizedTasks.

**`[intent:buildSyncPayload] _intentKey in payload`** — only fires when the upload payload contains `_intentKey` tasks. Confirms the task made it into the upload.

## How to read the trace

After a `→ dG` from lastGLANCE, the next poll cycle produces:
```
[intent:poll] starting
[intent:poll] cursor: 20260525T… | total files: N | pending: 1
[intent:poll] processing event_id: … action: create
[intent:handleCreate] entered — title: Dust Office | due: 2026-05-25 | source_entity_id: 36
[intent:handleCreate] normalized — due: 2026-05-25 | allDay: true | recurring: null | setters: {setTasks: true, …}
[intent:handleCreate] intentKey: abc123… | searching 132 tasks, 205 unsched, 4 recurring
[intent:handleCreate] decision: scheduled — calling setTasks, id: <uuid> date: 2026-05-25 isAllDay: true _intentKey: abc123…
[intent:handleCreate] done — task_id: <uuid> _intentKey: abc123…
[intent:poll] handleIntent returned: {"success":true,"task_id":"<uuid>",…}
```

Then, if applyEngineData fires while the task is in prev:
```
[intent:applyEngineData] setTasks — prev _intentKey: ["abc123…"] | preserved: ["abc123…"] | in normalizedTasks: []
[intent:buildSyncPayload] _intentKey in payload — tasks: ["abc123…"] | unsched: [] | recurring: []
```

https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne)_