### PR TITLE
fix: prevent tray popup from consuming intent events

### DIFF
--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -14,6 +14,11 @@ const DEFAULT_BG_MS = 15 * 60 * 1000;   // 15 minutes
 const DEFAULT_RETENTION_DAYS = 30;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
+// The tray popup holds a read-only state snapshot; it must never poll for
+// intents because processing an event would advance the cursor and consume
+// the event before the main window can act on it.
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+
 // ─── helpers ────────────────────────────────────────────────────────────────
 
 function authHeaders(config) {
@@ -280,6 +285,8 @@ export function useIntentPoller(context) {
   contextRef.current = context;
 
   useEffect(() => {
+    if (isTrayMode) return;
+
     const config = (() => {
       const raw = localStorage.getItem(INTENT_CONFIG_KEY);
       return raw ? JSON.parse(raw) : null;


### PR DESCRIPTION
## Root cause

`useIntentPoller` had no `isTrayMode` guard. The tray popup renders the full `App` component, so it mounted its own poller on the same cadence as the main window. When lastGLANCE fired a `create` intent:

1. The tray polled first (it was already open, no cold-start delay)
2. Processed the event, called `setTasks` — task created in tray's ephemeral React state
3. Advanced the cursor (`setCursor`) and wrote the activity log `ok` entry to localStorage
4. Main window polled next: `pending: 0` — cursor already past the event
5. Task never persisted — `useSaveOnChange` is already suppressed in tray mode

The trace that exposed this: after triggering `→ dG`, the next main-window poll showed `total files: 1 | pending: 0` with no `[intent:handleCreate]` log, while the activity log already had a `create ok` badge. The cursor had jumped between polls without any dispatch log in the main window.

## Fix

Add the same `isTrayMode` early-return to `useIntentPoller`'s `useEffect` that `useSaveOnChange` already uses. One line plus a module-level constant (matching the pattern in `useSaveOnChange.js`).

## Why this is the right boundary

The tray is a read-only snapshot by design. `useSaveOnChange` documents this explicitly:
> "The tray popup must never write to localStorage — it holds a snapshot of state as of the last reload and would overwrite fresher main-window data."

Intent polling is a write operation (cursor, activity log, React state via setters). It belongs only in the main window.

## Test plan

- [ ] Trigger `→ dG` from lastGLANCE with the tray open
- [ ] Confirm `[intent:poll] pending: 1` appears in the main window's console (not 0)
- [ ] Confirm `[intent:handleCreate] decision: scheduled` fires in the main window
- [ ] Confirm the task appears in dayGLANCE on the correct date
- [ ] Confirm the activity log `ok` entry is written once (not twice)

https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne)_