### PR TITLE
chore: remove temporary intent debug logging

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4846,12 +4846,6 @@ const DayPlanner = () => {
     });
     const _tasksForSync = tasks.filter(t => !t._native && !(t.imported && !t.isTaskCalendar && t.importSource !== 'file'));
     const _unschedForSync = unscheduledTasks.filter(t => !(t.imported && !t.isTaskCalendar && t.importSource !== 'file'));
-    const _intentTasks = _tasksForSync.filter(t => t._intentKey).map(t => t._intentKey);
-    const _intentUnsched = _unschedForSync.filter(t => t._intentKey).map(t => t._intentKey);
-    const _intentRecurring = recurringTasks.filter(t => t._intentKey).map(t => t._intentKey);
-    if (_intentTasks.length || _intentUnsched.length || _intentRecurring.length) {
-      console.log('[intent:buildSyncPayload] _intentKey in payload — tasks:', _intentTasks, '| unsched:', _intentUnsched, '| recurring:', _intentRecurring);
-    }
     return {
       version: 2,
       lastModified: new Date().toISOString(),
@@ -5071,20 +5065,10 @@ const DayPlanner = () => {
     // next calendar sync re-imports them.
     if (normalizedTasks) setTasks(prev => {
       const mergedIds = new Set(normalizedTasks.map(t => String(t.id)));
-      const intentKeyPrev = prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey);
-      const intentKeyDropped = prev.filter(t => mergedIds.has(String(t.id)) && t._intentKey);
-      if (prev.some(t => t._intentKey) || intentKeyPrev.length) {
-        console.log('[intent:applyEngineData] setTasks — prev _intentKey:', prev.filter(t => t._intentKey).map(t => t._intentKey), '| preserved:', intentKeyPrev.map(t => t._intentKey), '| in normalizedTasks (not dropped):', intentKeyDropped.map(t => t._intentKey));
-      }
       return [...normalizedTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
     });
     if (normalizedUnsched) setUnscheduledTasks(prev => {
       const mergedIds = new Set(normalizedUnsched.map(t => String(t.id)));
-      const intentKeyPrev = prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey);
-      const intentKeyDropped = prev.filter(t => mergedIds.has(String(t.id)) && t._intentKey);
-      if (prev.some(t => t._intentKey) || intentKeyPrev.length) {
-        console.log('[intent:applyEngineData] setUnscheduledTasks — prev _intentKey:', prev.filter(t => t._intentKey).map(t => t._intentKey), '| preserved:', intentKeyPrev.map(t => t._intentKey), '| in normalizedUnsched (not dropped):', intentKeyDropped.map(t => t._intentKey));
-      }
       return [...normalizedUnsched, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
     });
     if (data.unscheduledOrderTimestamp) {
@@ -5097,11 +5081,6 @@ const DayPlanner = () => {
     if (data.completedTaskUids) setCompletedTaskUids(new Set(data.completedTaskUids));
     if (data.recurringTasks) setRecurringTasks(prev => {
       const mergedIds = new Set(data.recurringTasks.map(t => String(t.id)));
-      const intentKeyPrev = prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey);
-      const intentKeyDropped = prev.filter(t => mergedIds.has(String(t.id)) && t._intentKey);
-      if (prev.some(t => t._intentKey) || intentKeyPrev.length) {
-        console.log('[intent:applyEngineData] setRecurringTasks — prev _intentKey:', prev.filter(t => t._intentKey).map(t => t._intentKey), '| preserved:', intentKeyPrev.map(t => t._intentKey), '| in data.recurringTasks (not dropped):', intentKeyDropped.map(t => t._intentKey));
-      }
       return [...data.recurringTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey)];
     });
     if (data.routineDefinitions) setRoutineDefinitions(data.routineDefinitions);

--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -124,13 +124,8 @@ async function handleCreate(payload, context) {
     projects = [],
   } = context;
 
-  console.log('[intent:handleCreate] entered — title:', payload.title, '| due:', payload.due, '| source_entity_id:', payload.source_entity_id);
-
   const v = validate(CreateSchema, payload);
-  if (!v.ok) {
-    console.log('[intent:handleCreate] validation failed:', v.error);
-    return fail(v.error);
-  }
+  if (!v.ok) return fail(v.error);
 
   const raw = v.data;
 
@@ -162,13 +157,10 @@ async function handleCreate(payload, context) {
     source_entity_id: raw.source_entity_id,
   };
 
-  console.log('[intent:handleCreate] normalized — due:', due, '| allDay:', allDay, '| recurring:', recurring, '| setters:', { setTasks: !!setTasks, setUnscheduledTasks: !!setUnscheduledTasks, setRecurringTasks: !!setRecurringTasks });
-
   let intentKey = null;
 
   if (raw.source_app && raw.source_entity_id) {
     intentKey = await createKey(raw.source_app, raw.source_entity_id, due);
-    console.log('[intent:handleCreate] intentKey:', intentKey, '| searching', tasks.length, 'tasks,', unscheduledTasks.length, 'unsched,', recurringTasks.length, 'recurring');
 
     const existing =
       tasks.find(t => t._intentKey === intentKey && !t.completed) ||
@@ -176,7 +168,6 @@ async function handleCreate(payload, context) {
       recurringTasks.find(t => t._intentKey === intentKey);
 
     if (existing) {
-      console.log('[intent:handleCreate] decision: idempotency hit — existing task id:', existing.id);
       if (setTasks || setUnscheduledTasks || setRecurringTasks) {
         // Execute: update the existing task in whichever list it lives in.
         const projectId = resolveProjectId(normalized.project, projects);
@@ -207,7 +198,6 @@ async function handleCreate(payload, context) {
 
   // Skeleton mode: no setters provided, return normalized result only.
   if (!setTasks && !setUnscheduledTasks && !setRecurringTasks) {
-    console.log('[intent:handleCreate] decision: skeleton mode (no setters) — returning normalized only');
     return ok({ warning: '', _normalized: normalized, _intentKey: intentKey });
   }
 
@@ -241,22 +231,17 @@ async function handleCreate(payload, context) {
       completedDates: [],
       exceptions: {},
     };
-    console.log('[intent:handleCreate] decision: recurring — calling setRecurringTasks, id:', taskId, '_intentKey:', intentKey);
     setRecurringTasks(prev => [...prev, newRecurring]);
   } else if (due) {
     const scheduled = parseDue(due, allDay);
     const newTask = { ...baseTask, date: scheduled.date, startTime: scheduled.startTime, isAllDay: scheduled.isAllDay };
-    console.log('[intent:handleCreate] decision: scheduled — calling setTasks, id:', taskId, 'date:', scheduled.date, 'isAllDay:', scheduled.isAllDay, '_intentKey:', intentKey);
     setTasks(prev => [...prev, newTask]);
   } else {
     const newTask = { ...baseTask, priority: priority ?? 0, ...(normalized.deadline ? { deadline: normalized.deadline } : {}) };
-    console.log('[intent:handleCreate] decision: unscheduled — calling setUnscheduledTasks, id:', taskId, '_intentKey:', intentKey);
     setUnscheduledTasks(prev => [...prev, newTask]);
   }
 
-  const result = ok({ task_id: taskId });
-  console.log('[intent:handleCreate] done — task_id:', taskId, '_intentKey:', intentKey);
-  return result;
+  return ok({ task_id: taskId });
 }
 
 function handleComplete(payload, context) {

--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -136,8 +136,6 @@ async function poll(config, context) {
   const dir = eventsDir(config);
   const headers = authHeaders(config);
 
-  console.log('[intent:poll] starting');
-
   let res;
   try {
     res = await webdavFetch('PROPFIND', dir, headers, undefined, { Depth: '1' });
@@ -164,8 +162,6 @@ async function poll(config, context) {
   const cursor = getCursor();
   // event_id is a sortable timestamp string: only process files strictly after cursor
   const pending = cursor ? files.filter(f => f.parsed.event_id > cursor) : files;
-
-  console.log('[intent:poll] cursor:', cursor, '| total files:', files.length, '| pending:', pending.length);
 
   for (const { name, parsed } of pending) {
     try {
@@ -233,9 +229,7 @@ async function poll(config, context) {
         continue;
       }
 
-      console.log('[intent:poll] processing event_id:', parsed.event_id, '| action:', envelope.action, '| emitted_by:', envelope.emitted_by);
       const result = await handleIntent(envelope.action, envelope.payload, context);
-      console.log('[intent:poll] handleIntent returned:', JSON.stringify(result));
       logActivity({
         direction: 'in',
         action: envelope.action,


### PR DESCRIPTION
Removes the `console.log` statements added in PRs #906 and #907 to trace intent task creation.

The root cause (tray popup consuming intent events before the main window) was identified and fixed in PR #908. The tracing is no longer needed.

**Files cleaned up:**
- `src/intents/handleIntent.js` — removed all `[intent:handleCreate]` trace logs (entry, normalization, intentKey, decisions, done)
- `src/intents/useIntentPoller.js` — removed `[intent:poll]` starting/cursor/processing logs
- `src/App.jsx` — removed `[intent:buildSyncPayload]` conditional log block (and its 3 temp variables) and `[intent:applyEngineData]` conditional log blocks from all three functional updaters

The functional logic in all three updaters is unchanged — only the instrumentation is removed.

https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne)_