### PR TITLE
fix: add isTrayMode guards to useNotifyEmitter and iCloud sync effects

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1522,7 +1522,7 @@ const DayPlanner = () => {
 
   // Run once on startup after data is loaded.
   useEffect(() => {
-    if (!dataLoaded || (!isNativeIOS() && !isElectronMac())) return;
+    if (isTrayMode || !dataLoaded || (!isNativeIOS() && !isElectronMac())) return;
     iCloudSyncRef.current?.();
   }, [dataLoaded]);
 
@@ -1531,14 +1531,14 @@ const DayPlanner = () => {
   // promptly even when the real-time watchers (NSMetadataQuery / fs.watch)
   // don't fire, which is common for iCloud-daemon-managed files.
   useEffect(() => {
-    if (!isNativeIOS() && !isElectronMac()) return;
+    if (isTrayMode || (!isNativeIOS() && !isElectronMac())) return;
     const timer = setInterval(() => iCloudSyncRef.current?.(), 15 * 1000);
     return () => clearInterval(timer);
   }, []);
 
   // On Electron/macOS, also sync when the window comes back to the foreground.
   useEffect(() => {
-    if (!isElectronMac()) return;
+    if (isTrayMode || !isElectronMac()) return;
     const onVisible = () => {
       if (document.visibilityState === 'visible') iCloudSyncRef.current?.();
     };
@@ -1550,7 +1550,7 @@ const DayPlanner = () => {
   // file was changed by the iOS app (fs.watch → icloud:changed IPC event).
   // If a sync is already in progress, schedule a retry so the change isn't lost.
   useEffect(() => {
-    if (!isElectronMac()) return;
+    if (isTrayMode || !isElectronMac()) return;
     return window.electronAPI.onICloudChanged?.(() => {
       if (cloudSyncInProgressRef.current) {
         setTimeout(() => iCloudSyncRef.current?.(), 2000);

--- a/src/intents/useNotifyEmitter.js
+++ b/src/intents/useNotifyEmitter.js
@@ -4,6 +4,11 @@ import { loadIntentsRootKey } from './intentsKeyStore.js';
 import { writeEventFile, INTENT_CONFIG_KEY } from './useIntentPoller.js';
 import { logActivity } from './intentLog.js';
 
+// The tray holds a read-only state snapshot. Any task-state changes in tray
+// mode (e.g. from an iCloud sync download) were already handled by the main
+// window. Emitting here would produce duplicate WebDAV notify events.
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+
 // ─── helpers ────────────────────────────────────────────────────────────────
 
 /** Reconstruct an ISO due string from dayGLANCE's split date/time fields. */
@@ -64,6 +69,8 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
   const prevRef = useRef(null);
 
   useEffect(() => {
+    if (isTrayMode) return;
+
     const config = (() => {
       const raw = localStorage.getItem(INTENT_CONFIG_KEY);
       return raw ? JSON.parse(raw) : null;


### PR DESCRIPTION
Follow-up to #908. Audit of all hooks for the "tray fires but effects are ephemeral" pattern — the same root cause as the intent poller cursor race.

## Gaps found and fixed

**`useNotifyEmitter` (src/intents/useNotifyEmitter.js)**

No tray guard. It runs a deps-less `useEffect` on every render. The 15s `currentTime` tick re-renders the tray, so the emitter diffs task state every 15 seconds. On Electron Mac, the iCloud sync effects (also fixed below) could call `applyEngineData` in tray mode, updating task state → emitter detects changes → writes duplicate WebDAV notify events for tasks the main window already emitted.

**iCloud sync effects in App.jsx (4 effects)**

No tray guard on:
- Startup effect (fires when `dataLoaded` becomes true)
- 15s poll
- Visibility handler (tab comes to foreground)
- `icloud:changed` IPC listener (fs.watch event from main process)

On Electron Mac all four fire in tray mode, doing unnecessary network reads/writes and acting as the trigger for the spurious notify emitter path above.

## Audit: everything else is already guarded

`useSaveOnChange`, `useReminderEngine`, `useWeather`, `useAppInit`, `useElectronBridge` — all have tray guards. All App.jsx sync loops — cloud sync (WebDAV engine), calendar sync, TRMNL, Obsidian, auto-backup, inbox archive, update check — all already guarded. `useCalendarSync`, `useTrmnlSync`, `useObsidian`, `useHabits`, `useReminders`, `useLocalStoragePersist` — state-management-only hooks with no polling loops of their own (actual sync timers live in App.jsx and are already guarded).

https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne)_