### PR TITLE
Fix intent all-day task startTime and activity log refresh

### DIFF
--- a/src/components/IntentActivityLogModal.jsx
+++ b/src/components/IntentActivityLogModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { X, ArrowDownLeft, ArrowUpRight, Trash2 } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
@@ -98,6 +98,10 @@ const IntentActivityLogModal = () => {
   const { cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg } = useDayPlannerCtx();
   const { showIntentActivityLog, setShowIntentActivityLog } = useSyncCtx();
   const [entries, setEntries] = useState(() => getActivityLog());
+
+  useEffect(() => {
+    if (showIntentActivityLog) setEntries(getActivityLog());
+  }, [showIntentActivityLog]);
 
   if (!showIntentActivityLog) return null;
 

--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -51,7 +51,7 @@ function parseDue(due, allDay) {
 
   const dateOnly = !due.includes('T');
   if (dateOnly || allDay) {
-    return { date: due.slice(0, 10), startTime: '00:00', isAllDay: true };
+    return { date: due.slice(0, 10), startTime: null, isAllDay: true };
   }
 
   const d = new Date(due);


### PR DESCRIPTION
## Summary

- **`parseDue` all-day fix**: `parseDue` in `handleIntent.js` was returning `startTime: '00:00'` for all-day tasks (both date-only strings and `all_day: true` payloads). Native dayGLANCE all-day tasks have `startTime: null` — this is what `useTaskActions` sets when creating them. The mismatch was likely causing rendering inconsistencies in the DAY view all-day section (continuous layout flickering reported after testing PR #908).

- **Activity log refresh fix**: `IntentActivityLogModal` initialized `entries` state once on mount via `useState(() => getActivityLog())` and never re-read. Added a `useEffect` that re-reads the log from localStorage each time the modal is opened (`showIntentActivityLog` transitions to `true`). Previously, new entries only appeared after a full page reload.

## Notes

The recurring task path in `handleCreate` is unaffected — it uses `startTime: scheduled && !scheduled.isAllDay ? scheduled.startTime : '00:00'` directly, which correctly keeps `'00:00'` for recurring all-day templates (matching how dayGLANCE stores recurring all-day instances).

## Test plan

- [ ] Trigger a `+ dG` create intent with a date-only due (all-day) — task should appear in the all-day section with no DAY view flickering
- [ ] Open the activity log immediately after the intent fires — entries should appear without a page reload
- [ ] Trigger a timed intent — timed task should still render correctly on the timeline


---
_Generated by [Claude Code](https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne)_