### PR TITLE
Fix self-loop: check emitted_by on raw JSON before parsing

### DIFF
--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -178,6 +178,15 @@ async function poll(config, context) {
       }
 
       const raw = await fileRes.json();
+
+      // Check emitted_by on the raw object before parsing. Our own notify
+      // envelopes use a different action schema that parseEnvelope rejects as
+      // malformed, so the post-parse check would never be reached for them.
+      if (raw?.emitted_by === 'app.dayglance') {
+        setCursor(parsed.event_id);
+        continue;
+      }
+
       let envelope;
       try {
         if (raw?.encrypted === true) {


### PR DESCRIPTION
## Summary

After #908 (tray cursor fix) and #911 (all-day startTime fix), the intent flow was working — but the activity log was showing spurious `malformed envelope` errors for every outbound `rescheduled`/`notify` event.

**Root cause:** `useIntentPoller` writes a `notify` action envelope to WebDAV (via `useNotifyEmitter`), then polls the same directory and reads it back. The self-loop guard (`emitted_by === 'app.dayglance'`) only ran *after* `parseEnvelope` succeeded. But `parseEnvelope` from `@glance-apps/intents` validates the `action` field against the inbound action set — `notify` is not in that set, so it throws `MalformedEnvelopeError`, and the guard never fired.

**Fix:** Check `raw?.emitted_by === 'app.dayglance'` on the raw JSON *before* attempting to parse. The existing post-parse guard is kept as a safety net for encrypted envelopes (where `emitted_by` is inside the ciphertext and not visible on the raw object).

## Test plan

- [ ] Trigger a reschedule on an intent-created task — activity log should show `rescheduled` (outbound only), no `malformed envelope` error following it
- [ ] Encrypted path: same test with encryption enabled


---
_Generated by [Claude Code](https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne)_