### PR TITLE
Fix ResizeObserver feedback loop in all-day section overflow chip

### DIFF
--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -239,7 +239,7 @@ const GroupChips = ({ tasks, deadlineTasks = [], date, dateStr, darkMode, border
       {/* Ghost render for overflow measurement — invisible, no pointer events */}
       <div
         ref={ghostRef}
-        className="absolute inset-0 flex flex-wrap gap-1 opacity-0 pointer-events-none"
+        className="absolute inset-x-0 top-0 flex flex-wrap gap-1 opacity-0 pointer-events-none"
         aria-hidden="true"
       >
         {allItems.map(item => (


### PR DESCRIPTION
## Summary

The DAY view all-day section was flickering continuously in Rolling 24h mode when multiple all-day items (tasks + calendar events) competed for the single column.

**Root cause:** The `GroupChips` ghost div — used for overflow chip measurement — was `absolute inset-0`. That means its height was always equal to the container's height. The measurement loop was:

1. `setLimit(n)` — visible chips change
2. Container height changes (fewer/more chips rendered)
3. Ghost height changes (`inset-0` tracks container)
4. ResizeObserver fires → `measure()` runs
5. `setLimit` may change → back to step 1

**Why Rolling 24h but not Calendar Day?** Rolling 24h re-renders more frequently (live current-time indicator), giving the oscillating loop more chances to pump. Calendar Day is static between interactions so the loop manifests but settles; Rolling 24h keeps it alive.

**Fix:** `absolute inset-0` → `absolute inset-x-0 top-0`. The ghost still stretches to the full container width (required for accurate chip wrapping measurement), but its height is now content-determined — all items, freely wrapped, overflowing downward invisibly. Container height changes from `setLimit` no longer affect the ghost at all, so the ResizeObserver only fires on genuine width changes (e.g. window resize or column layout change).

## Test plan

- [ ] Open DAY view in Rolling 24h mode with 2+ all-day tasks/events — no flickering
- [ ] Overflow still works: with enough items, `+N more` button appears correctly
- [ ] Resize the window — overflow recalculates correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01F6kqLE13m38KDqUso1ndne)_