### PR TITLE
Bump version to v2.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.11.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-2.12.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 97
-        versionName = "2.11"
+        versionCode = 98
+        versionName = "2.12"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Summary

- `package.json` was already at `2.12.0`
- Android `versionCode` bumped 97 → 98, `versionName` updated `"2.11"` → `"2.12"`
- README version badge updated `2.11.0` → `2.12.0`

## Test plan

- [ ] Confirm `package.json` reports `2.12.0`
- [ ] Confirm Android build uses `versionCode = 98` and `versionName = "2.12"`
- [ ] Confirm README badge displays `2.12.0`

https://claude.ai/code/session_01NYw9ycsMoTa6Pfv4qE8mJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYw9ycsMoTa6Pfv4qE8mJ6)_