### PR TITLE
Fix paywall subscription disclosure (Play Store + App Store policy)

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 98
+        versionCode = 99
         versionName = "2.12"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
@@ -135,11 +135,18 @@ class BillingManager(
             billingClient.queryProductDetailsAsync(subsParams) { result, detailsList ->
                 if (result.responseCode != BillingClient.BillingResponseCode.OK) return@queryProductDetailsAsync
                 for (details in detailsList) {
-                    val price = details.subscriptionOfferDetails
-                        ?.flatMap { it.pricingPhases.pricingPhaseList }
-                        ?.firstOrNull { it.recurrenceMode == 1 }
-                        ?.formattedPrice ?: continue
-                    if (details.productId == PRODUCT_ANNUAL) dataStore.productPriceAnnual = price
+                    if (details.productId != PRODUCT_ANNUAL) continue
+                    val offerDetails = details.subscriptionOfferDetails ?: continue
+                    val price = offerDetails
+                        .flatMap { it.pricingPhases.pricingPhaseList }
+                        .firstOrNull { it.recurrenceMode == 1 }
+                        ?.formattedPrice
+                    if (price != null) dataStore.productPriceAnnual = price
+                    // A zero-price phase indicates a free trial. Play only surfaces this offer
+                    // when the user is still eligible; absence means the trial has been used.
+                    dataStore.trialEligibleAnnual = offerDetails.any { offer ->
+                        offer.pricingPhases.pricingPhaseList.any { it.priceAmountMicros == 0L }
+                    }
                 }
             }
             billingClient.queryProductDetailsAsync(inappParams) { result, detailsList ->

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
@@ -110,6 +110,18 @@ class SubscriptionBridge(
         """["${BillingManager.PRODUCT_ANNUAL}","${BillingManager.PRODUCT_LIFETIME}"]"""
 
     /**
+     * Returns trial eligibility per subscription product as JSON.
+     * True = user is eligible for the free trial offer.
+     * False = trial already used or not available in this region.
+     * Defaults to true until BillingManager has queried product details at least once.
+     *
+     * Response: `{"dayglance_pro_annual": bool}`
+     */
+    @JavascriptInterface
+    fun getTrialEligibility(): String =
+        """{"dayglance_pro_annual":${dataStore.trialEligibleAnnual}}"""
+
+    /**
      * Consumes the stored lifetime purchase token so it can be bought again.
      * Only available on play builds (BILLING_ENABLED=true). Intended for testing.
      * Result is delivered via window.__billingEvent with status "consumed" or "consume_failed".

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
@@ -206,6 +206,15 @@ class SharedDataStore(context: Context) {
             else remove(KEY_PRODUCT_PRICE_LIFETIME)
         }
 
+    /**
+     * Whether the user is eligible for the free trial on the annual plan.
+     * Set by BillingManager when subscriptionOfferDetails are queried; defaults to true
+     * so the trial copy shows until Play confirms otherwise.
+     */
+    var trialEligibleAnnual: Boolean
+        get() = prefs.getBoolean(KEY_TRIAL_ELIGIBLE_ANNUAL, true)
+        set(value) = prefs.edit { putBoolean(KEY_TRIAL_ELIGIBLE_ANNUAL, value) }
+
     // ── Step count cache ────────────────────────────────────────────────────
 
     /** Cached step count for today, updated by WidgetUpdateWorker. */
@@ -245,6 +254,7 @@ class SharedDataStore(context: Context) {
         private const val KEY_SUBSCRIPTION_TOKEN = "subscription_token"
         private const val KEY_PRODUCT_PRICE_ANNUAL   = "product_price_annual"
         private const val KEY_PRODUCT_PRICE_LIFETIME = "product_price_lifetime"
+        private const val KEY_TRIAL_ELIGIBLE_ANNUAL  = "trial_eligible_annual"
 
         const val DEFAULT_DAILY_NOTE_PATTERN = "yyyy-MM-dd"
         const val DEFAULT_NEW_NOTES_FOLDER = "dayGLANCE"

--- a/src/components/SubscriptionWall.jsx
+++ b/src/components/SubscriptionWall.jsx
@@ -142,11 +142,22 @@ export default function SubscriptionWall({
               : <span className={`text-xs ${sub}`}>Loading…</span>
             }
           </div>
-          <div className={`text-xs mt-0.5 ${sub}`}>{trialEligible ? '14-day free trial · billed yearly · cancel any time' : 'Billed yearly · cancel any time'}</div>
+          <div className={`text-xs mt-0.5 ${sub}`}>
+            {trialEligible
+              ? `14-day free trial, then ${prices?.yearly ?? '$9.99'}/yr`
+              : `Billed yearly · ${prices?.yearly ?? '$9.99'}/yr`}
+          </div>
           {pending === 'yearly' && <Loader className={`w-4 h-4 mt-2 animate-spin ${sub}`} />}
         </button>
 
       </div>
+
+      {/* Subscription disclosure — required by App Store guideline 3.1.2 and Play Subscriptions policy */}
+      <p className={`text-xs text-center mb-3 max-w-xs leading-relaxed ${sub}`}>
+        {trialEligible
+          ? `Your 14-day free trial automatically converts to a ${prices?.yearly ?? '$9.99'}/year subscription that renews annually until canceled. Cancel anytime in your ${isIOSApp ? 'App Store' : 'Google Play'} subscription settings.`
+          : `Your ${prices?.yearly ?? '$9.99'}/year subscription automatically renews annually until canceled. Cancel anytime in your ${isIOSApp ? 'App Store' : 'Google Play'} subscription settings.`}
+      </p>
 
       <p className={`text-xs text-center mb-6 max-w-xs ${sub}`}>
         {isIOSApp ? 'Payment via App Store.' : 'Payment via Google Play.'}

--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -68,7 +68,13 @@ function readPrices() {
   return {};
 }
 
-function readTrialEligibilityIOS() {
+function readTrialEligibility() {
+  if (BILLING) {
+    try {
+      const data = JSON.parse(BILLING.getTrialEligibility());
+      return data?.['dayglance_pro_annual'] !== false;
+    } catch { return true; }
+  }
   if (!IOS) return true;
   try {
     const data = JSON.parse(window.DayGlanceNative.getTrialEligibility());
@@ -114,7 +120,7 @@ function billingErrorMessage(code) {
 export function useSubscription() {
   const [status, setStatus]               = useState(() => readStatus());
   const [prices, setPrices]               = useState(() => readPrices());
-  const [trialEligible, setTrialEligible] = useState(() => readTrialEligibilityIOS());
+  const [trialEligible, setTrialEligible] = useState(() => readTrialEligibility());
   const [isLoading, setIsLoading]         = useState(false);
   const [billingEvent, setBillingEvent]   = useState(null);
   const timeoutRef = useRef(null);
@@ -174,7 +180,7 @@ export function useSubscription() {
       setTimeout(() => {
         setStatus(readStatusIOS());
         setPrices(readPricesIOS());
-        setTrialEligible(readTrialEligibilityIOS());
+        setTrialEligible(readTrialEligibility());
       }, 3000);
     }
 


### PR DESCRIPTION
## Summary

- **Annual card subtitle** shortened to `14-day free trial, then $9.99/yr` (trial eligible) or `Billed yearly · $9.99/yr` (ineligible). Price is dynamic from the billing bridge so it localizes correctly.
- **Disclosure paragraph** added below the pricing cards with auto-renewal terms and platform-specific cancellation instructions ("Google Play subscription settings" on Android, "App Store subscription settings" on iOS/macOS). Covers both Google Play Subscriptions policy and App Store guideline 3.1.2 in one shot.
- **Android trial eligibility detection** wired up end-to-end for the first time (was always `true` on Android before this):
  - `BillingManager.queryProductPrices()` inspects `subscriptionOfferDetails` for a zero-price pricing phase (the free trial) and caches the result in `SharedDataStore.trialEligibleAnnual`.
  - `SubscriptionBridge.getTrialEligibility()` exposes it to JS as `{"dayglance_pro_annual": bool}`.
  - `useSubscription.readTrialEligibility()` (renamed from `readTrialEligibilityIOS`) now checks the Android bridge first, then falls through to the existing iOS/RevenueCat path.

## Behaviour notes

- Default is `true` at all times until Play confirms otherwise, so the trial copy never flickers away on first launch.
- The disclosure paragraph uses `prices?.yearly` with a `$9.99` fallback, so it always renders something sensible even before prices have loaded.
- Lifetime card and all other UI untouched.

## Test plan

- [ ] Android (trial eligible): subtitle shows "14-day free trial, then £/$/€X.XX/yr"; disclosure shows trial copy with "Google Play subscription settings"
- [ ] Android (trial ineligible — use a license tester account that has already subscribed and cancelled): subtitle shows "Billed yearly · £/$/€X.XX/yr"; disclosure shows no-trial copy
- [ ] iOS: subtitle and disclosure render correctly with "App Store subscription settings"; trial eligibility continues to come from RevenueCat
- [ ] No em dashes anywhere in the new copy
- [ ] Lifetime card visually unchanged

https://claude.ai/code/session_018EumhhU3eeiykWJQe1ivqq

---
_Generated by [Claude Code](https://claude.ai/code/session_018EumhhU3eeiykWJQe1ivqq)_