### PR TITLE
fix: crypto.randomUUID polyfill for LAN HTTP + nginx sw caching + sync startup race

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -19,13 +19,14 @@ server {
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src *; font-src 'self' data:; worker-src 'self' blob:; manifest-src 'self';" always;
 
     # PWA - No cache for service worker and manifest
-    location /sw.js {
+    # Use exact match (=) so these take priority over the regex cache block below.
+    location = /sw.js {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
     }
 
-    location /manifest.webmanifest {
+    location = /manifest.webmanifest {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
@@ -33,7 +34,7 @@ server {
     }
 
     # Dead old service worker - no cache
-    location /service-worker.js {
+    location = /service-worker.js {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1345,13 +1345,13 @@ const DayPlanner = () => {
   // Upload only (no download) to avoid the applyEngineData → state-change → debounce
   // re-trigger loop. The 60-second poll handles keeping remote changes in sync.
   useEffect(() => {
-    if (isTrayMode || !cloudSyncConfig?.enabled || !dataLoaded || suppressCloudUploadRef.current) return;
+    if (isTrayMode || !cloudSyncConfig?.enabled || !dataLoaded || suppressCloudUploadRef.current || !syncKeyReadyRef.current) return;
     if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current);
     cloudSyncDebounceRef.current = setTimeout(() => {
       cloudSyncEngineRef.current.upload();
     }, 5000);
     return () => { if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current); };
-  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled]);
+  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled, syncKeyReady]);
 
   // ── Config field timestamp tracking ──────────────────────────────────────
   // Tracks when habitsEnabled/routinesEnabled/goalsProjectsEnabled/obsidianConfig

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,20 @@ import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
 
+// crypto.randomUUID() requires a secure context (HTTPS or localhost).
+// When accessed over HTTP on a LAN IP the API is absent and every call throws,
+// silently breaking any action that creates a new task/id.
+// crypto.getRandomValues() has no such restriction and is safe to use here.
+if (typeof crypto.randomUUID !== 'function') {
+  crypto.randomUUID = () => {
+    const b = crypto.getRandomValues(new Uint8Array(16));
+    b[6] = (b[6] & 0x0f) | 0x40;
+    b[8] = (b[8] & 0x3f) | 0x80;
+    return [b.slice(0,4),b.slice(4,6),b.slice(6,8),b.slice(8,10),b.slice(10,16)]
+      .map(s => Array.from(s).map(x => x.toString(16).padStart(2,'0')).join('')).join('-');
+  };
+}
+
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props)


### PR DESCRIPTION
## Summary

**1. `crypto.randomUUID` polyfill for HTTP on LAN IPs (fixes #918)**

`crypto.randomUUID()` requires a secure context (HTTPS or localhost) in all modern browsers. Users accessing Docker via a LAN IP over HTTP (e.g. `http://192.168.1.x:7191`) get a non-secure context where the API is absent. Every task-creation action throws a `TypeError` silently — the modal stays open and the button appears to do nothing. Affects Chrome, Firefox, and Safari identically.

`crypto.getRandomValues()` has no secure-context restriction. A small polyfill in `main.jsx` activates only when `randomUUID` is missing and produces a standards-compliant UUID v4. No changes needed to the 20+ call sites across the codebase.

**2. nginx: exact-match locations for service worker and manifest (Docker)**

Prefix `location /sw.js` blocks have lower nginx priority than regex `location ~* \.(js|...)$` blocks. The regex block was silently winning and serving the service worker with `Cache-Control: public, immutable` / 1-year expiry — meaning Docker users would never receive service worker updates after initial install. Changed to exact-match (`= /path`) which has the highest nginx priority.

**3. Cloud sync: gate debounced upload on `syncKeyReady` (fixes #904)**

The debounced upload effect was missing a `syncKeyReady` guard, so it could fire during the brief startup window before `initSessionKey()` resolved, producing a spurious `"Encryption key not available"` console error on every encrypted-sync startup. Added `!syncKeyReadyRef.current` to the early-return and `syncKeyReady` to the dependency array so an upload fires promptly once the key is ready.

## Test plan

- [ ] Access the Docker container via LAN IP over HTTP — task creation should work in all browsers
- [ ] Docker: `curl -I http://localhost/sw.js` returns `Cache-Control: no-cache, no-store, must-revalidate`
- [ ] Docker: `curl -I http://localhost/assets/index-[hash].js` still returns `Cache-Control: public, immutable`
- [ ] Cloud sync with encryption: no `"Encryption key not available"` error in console on startup

https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX