### PR TITLE
fix(electron): suppress white screen on startup with ready-to-show

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -81,6 +81,7 @@ function createWindow(): BrowserWindow {
     width: saved.width,
     height: saved.height,
     ...(saved.x != null && saved.y != null ? { x: saved.x, y: saved.y } : {}),
+    show: false,
     minWidth: 800,
     minHeight: 600,
     titleBarStyle: 'hiddenInset',
@@ -110,6 +111,11 @@ function createWindow(): BrowserWindow {
   });
 
   if (saved.maximized) mainWindow.maximize();
+
+  // Show the window only after the renderer has painted its first frame,
+  // preventing the white screen that appears when the window is shown before
+  // React has had a chance to render anything.
+  mainWindow.once('ready-to-show', () => { live(mainWindow)?.show(); });
 
   if (DEV) {
     mainWindow.loadURL(VITE_DEV_SERVER_URL);


### PR DESCRIPTION
## Summary

- Adds `show: false` to the `BrowserWindow` options in `createWindow()`
- Adds a `ready-to-show` listener that calls `show()` once the renderer has completed its first paint
- `maximize()` is intentionally placed before `ready-to-show` so the window appears in the correct saved state without a visible resize step
- The tray window already used this pattern correctly (`show: false` at line 138); this brings the main window in line with it

## What this fixes

On launch, macOS was displaying a blank white window immediately — before React had rendered anything. With this change the window stays hidden until Electron signals the first paint is ready, then appears in one step with full content visible.

This does not address the intermediate "half timeline" render flash, which is a separate React data-loading concern.

## Test plan

- [ ] Cold launch: window appears with full content, no white flash
- [ ] Cold launch with saved maximized state: window appears already maximized, no resize step
- [ ] App hide/show (Cmd+Tab, dock click, tray click) still works normally
- [ ] `activate` event (clicking dock icon when hidden) still shows and focuses the window

https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX)_