### PR TITLE
fix: parse UTC (Z-suffix) ICS timestamps correctly

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3923,6 +3923,18 @@ const DayPlanner = () => {
         parseInt(dtstr.substr(6, 2))
       );
     } else if (dtstr.length >= 15) {
+      // Z suffix means UTC — use Date.UTC so the browser converts to local time.
+      // Without this, Google Calendar events (which are exported in UTC) display
+      // at the UTC hour rather than the user's local hour.
+      if (dtstr.endsWith('Z')) {
+        return new Date(Date.UTC(
+          parseInt(dtstr.substr(0, 4)),
+          parseInt(dtstr.substr(4, 2)) - 1,
+          parseInt(dtstr.substr(6, 2)),
+          parseInt(dtstr.substr(9, 2)),
+          parseInt(dtstr.substr(11, 2))
+        ));
+      }
       return new Date(
         parseInt(dtstr.substr(0, 4)),
         parseInt(dtstr.substr(4, 2)) - 1,


### PR DESCRIPTION
## Summary

`parseDatetime` was using the local-time `Date` constructor for all datetime strings, ignoring the `Z` suffix that marks UTC timestamps. Google Calendar exports timed events in UTC (e.g. `DTSTART:20260529T160000Z`), so a noon EDT event arrives as `T160000Z` and was being displayed as 4 pm — exactly 4 hours ahead for a UTC-4 user.

When `dtstr` ends with `Z`, the fix uses `Date.UTC()` instead, so the browser applies the user's local timezone offset correctly on display. Floating/local datetimes (no `Z` suffix) are unchanged.

## Test plan

- [ ] Add a Google Calendar event at a known local time, sync into dayGLANCE — event should appear at the correct local time
- [ ] All-day events unaffected (8-char date strings take the existing branch)
- [ ] Events from CalDAV sources that use floating (no-Z) datetimes still display correctly

Fixes #923

https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX)_