### PR TITLE
Add persistent storage request on startup + Settings notice

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1165,6 +1165,10 @@ const DayPlanner = () => {
     window.history.replaceState(null, '');
   }, []);
 
+  // Best-effort request for persistent storage on startup.
+  // Keeps IndexedDB / Cache Storage alive even when the browser is under quota pressure.
+  useEffect(() => { navigator.storage?.persist?.(); }, []);
+
   // Lock body/html scrolling to prevent scroll chaining (all devices incl. desktop PWA)
   useEffect(() => {
     document.documentElement.style.overflow = 'hidden';

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
-import { Activity, Archive, BarChart3, Bell, BookOpen, BrainCircuit, CalendarDays, CheckCircle, CheckSquare, ChevronDown, Clock, Cloud, ExternalLink, Flag, FolderOpen, Globe, Key, LayoutGrid, Loader, Lock, MapPin, Mic, Moon, Newspaper, RefreshCw, Server, Settings, Sparkles, Sun, Target, Thermometer, Upload, Wifi, WifiOff, X, Zap } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { Activity, Archive, BarChart3, Bell, BookOpen, BrainCircuit, CalendarDays, CheckCircle, CheckSquare, ChevronDown, Clock, Cloud, ExternalLink, Flag, FolderOpen, Globe, HardDrive, Key, LayoutGrid, Loader, Lock, MapPin, Mic, Moon, Newspaper, RefreshCw, Server, Settings, Sparkles, Sun, Target, Thermometer, Upload, Wifi, WifiOff, X, Zap } from 'lucide-react';
 import { getTzLabel, getTzOptions } from '../utils/timezones.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
-import { getStorageUsage } from '../utils/storage.js';
+import { getStorageUsage, formatBytes } from '../utils/storage.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
 import { isNativeAndroid, isNativeApp, nativeGetCalendars } from '../native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault } from '../obsidian.js';
@@ -94,6 +94,11 @@ const SettingsModal = () => {
   // null | 'passphrase-needed' | 'running' | { error: string }
   const [intentSetupPhase, setIntentSetupPhase] = useState(null);
   const [intentPassphraseInput, setIntentPassphraseInput] = useState('');
+
+  const [persisted, setPersisted] = useState(null); // null = checking, true/false = result
+  useEffect(() => {
+    navigator.storage?.persisted?.().then(p => setPersisted(p));
+  }, []);
 
   const [trayHotkey, setTrayHotkey] = useState(() => localStorage.getItem('dg-tray-hotkey') || '');
   const [mainWindowHotkey, setMainWindowHotkey] = useState(() => localStorage.getItem('dg-main-window-hotkey') || '');
@@ -691,6 +696,34 @@ const SettingsModal = () => {
                           <option value={60}>After 60 days</option>
                         </select>
                       </div>
+                    </div>
+
+                    <hr className={borderClass} />
+
+                    {/* Storage */}
+                    <div className="space-y-3">
+                      <div className={`font-medium ${textPrimary} flex items-center gap-2`}>
+                        <HardDrive size={16} className={textSecondary} />
+                        Storage
+                      </div>
+                      <p className={`text-xs ${textSecondary}`}>
+                        {formatBytes(storageUsage.totalBytes)} used{storageWarning ? ' — nearing the ~5 MB localStorage limit' : ''}
+                      </p>
+                      {persisted === false && (
+                        <div className={`p-3 rounded-lg border ${darkMode ? 'bg-amber-900/20 border-amber-700' : 'bg-amber-50 border-amber-300'}`}>
+                          <p className={`text-xs ${darkMode ? 'text-amber-300' : 'text-amber-800'} mb-2`}>
+                            Your data may be cleared by the browser when storage is low. Allow persistent storage to protect it.
+                          </p>
+                          <button
+                            onClick={() => {
+                              navigator.storage?.persist?.().then(granted => setPersisted(granted));
+                            }}
+                            className={`px-3 py-1.5 text-xs rounded-lg font-medium ${darkMode ? 'bg-amber-700 hover:bg-amber-600 text-white' : 'bg-amber-600 hover:bg-amber-700 text-white'} transition-colors`}
+                          >
+                            Allow persistent storage
+                          </button>
+                        </div>
+                      )}
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary

- On app startup, silently calls `navigator.storage?.persist?.()` so the browser won't evict IndexedDB / Cache Storage when the device is under storage pressure
- Adds a **Storage** section to the Settings modal left column (after Inbox) showing current localStorage usage
- If `navigator.storage.persisted()` returns `false`, an amber notice appears with an **Allow persistent storage** button that calls `persist()` and updates state — disappearing immediately once granted

## Details

**`src/App.jsx`** — single mount-only `useEffect` that fires `navigator.storage?.persist?.()`. Optional chaining throughout so it's safe on Electron, native Android WebView, and any browser that doesn't support the API.

**`src/components/SettingsModal.jsx`**:
- Added `useEffect` import and `HardDrive` icon
- Added `formatBytes` to the storage util import (was already importing `getStorageUsage`)
- `persisted` state (`null | boolean`) initialized to `null`; `useEffect` on mount resolves it via `navigator.storage?.persisted?.()`
- New Storage section in the left column with usage display and conditional amber notice

## Test plan

- [ ] Open Settings — Storage section appears showing e.g. "142 KB used"
- [ ] On a browser where storage is not yet persistent (fresh Chrome profile), the amber notice and button appear
- [ ] Clicking "Allow persistent storage" grants persistence; notice disappears
- [ ] Re-opening Settings shows no notice (persisted === true)
- [ ] On a browser that already granted persistence (or doesn't support the API), no notice appears at all

https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX)_