### PR TITLE
Collapsible error details in intent activity log

### DIFF
--- a/src/components/IntentActivityLogModal.jsx
+++ b/src/components/IntentActivityLogModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { X, ArrowDownLeft, ArrowUpRight, Trash2 } from 'lucide-react';
+import { X, ArrowDownLeft, ArrowUpRight, ChevronRight, Trash2 } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { getActivityLog, clearActivityLog } from '../intents/intentLog.js';
@@ -98,10 +98,22 @@ const IntentActivityLogModal = () => {
   const { cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg } = useDayPlannerCtx();
   const { showIntentActivityLog, setShowIntentActivityLog } = useSyncCtx();
   const [entries, setEntries] = useState(() => getActivityLog());
+  const [expandedErrors, setExpandedErrors] = useState(new Set());
 
   useEffect(() => {
-    if (showIntentActivityLog) setEntries(getActivityLog());
+    if (showIntentActivityLog) {
+      setEntries(getActivityLog());
+      setExpandedErrors(new Set());
+    }
   }, [showIntentActivityLog]);
+
+  const toggleError = (id) => {
+    setExpandedErrors(prev => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
 
   if (!showIntentActivityLog) return null;
 
@@ -192,7 +204,23 @@ const IntentActivityLogModal = () => {
                           <p className={`text-xs ${textPrimary} mt-0.5 truncate`}>{entry.title}</p>
                         )}
                         {entry.error && (
-                          <p className={`text-xs ${errorTextClass(entry)} mt-0.5 truncate`}>{errorMessage(entry)}</p>
+                          <div className="mt-0.5">
+                            <button
+                              onClick={() => toggleError(entry.id)}
+                              className={`flex items-center gap-0.5 ${errorTextClass(entry)} hover:opacity-75 transition-opacity text-left w-full`}
+                            >
+                              <ChevronRight
+                                size={11}
+                                className={`flex-shrink-0 transition-transform ${expandedErrors.has(entry.id) ? 'rotate-90' : ''}`}
+                              />
+                              <span className="text-xs">{errorMessage(entry)}</span>
+                            </button>
+                            {expandedErrors.has(entry.id) && (
+                              <pre className={`mt-1.5 text-[10px] font-mono rounded p-2 whitespace-pre-wrap break-all leading-relaxed ${darkMode ? 'bg-gray-900/60 text-gray-300' : 'bg-stone-100 text-stone-700'}`}>
+                                {entry.error}
+                              </pre>
+                            )}
+                          </div>
                         )}
                       </div>
 


### PR DESCRIPTION
## Summary

- Error entries in the intent activity log are now collapsed by default — the human-readable mapped message is shown with a `▶` chevron instead of a truncated line
- Clicking the chevron expands a monospace `pre` block showing the raw `entry.error` string (Zod validation messages, JS exception text, crypto error codes, etc.)
- Expanded state resets whenever the modal is opened, so it never accumulates stale state across sessions
- The `ChevronRight` icon rotates 90° when expanded for a standard accordion feel

## Why

Long Zod or exception strings were previously clipped by `truncate` with no way to see the full text. Making them collapsible keeps the log compact while still exposing the full technical detail on demand.

## Test plan

- [ ] Open activity log with no errors — no visible change
- [ ] Trigger an intent error (e.g. bad payload or encryption not set up) — entry shows badge + mapped message + `▶` chevron, no detail by default
- [ ] Click chevron — expands monospace block with raw error string, chevron rotates to `▼`
- [ ] Click again — collapses
- [ ] Close and re-open modal — all entries back to collapsed state

https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX)_