### PR TITLE
Move persistent storage notice to ? modal (remove from Settings)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -468,7 +468,7 @@ const DayPlanner = () => {
   // Keyboard shortcut cheat sheet
   const [showShortcutHelp, setShowShortcutHelp] = useState(false);
   const [showHelpModal, setShowHelpModal] = useState(false);
-
+  const [storagePersisted, setStoragePersisted] = useState(null);
 
   const tagFilterBtnRef = useRef(null);
 
@@ -1168,6 +1168,11 @@ const DayPlanner = () => {
   // Best-effort request for persistent storage on startup.
   // Keeps IndexedDB / Cache Storage alive even when the browser is under quota pressure.
   useEffect(() => { navigator.storage?.persist?.(); }, []);
+
+  // Refresh persisted status each time the ? modal opens.
+  useEffect(() => {
+    if (showHelpModal) navigator.storage?.persisted?.().then(p => setStoragePersisted(p));
+  }, [showHelpModal]);
 
   // Lock body/html scrolling to prevent scroll chaining (all devices incl. desktop PWA)
   useEffect(() => {
@@ -9128,6 +9133,19 @@ const DayPlanner = () => {
                     </button>
                   );
                 })()}
+                {storagePersisted === false && (
+                  <div className={`p-2.5 rounded-lg border ${darkMode ? 'bg-amber-900/20 border-amber-700' : 'bg-amber-50 border-amber-300'}`}>
+                    <p className={`text-xs ${darkMode ? 'text-amber-300' : 'text-amber-800'} mb-1.5`}>
+                      Your data may be cleared by the browser when storage is low.
+                    </p>
+                    <button
+                      onClick={() => navigator.storage?.persist?.().then(granted => setStoragePersisted(granted))}
+                      className={`px-2.5 py-1 text-xs rounded font-medium ${darkMode ? 'bg-amber-700 hover:bg-amber-600 text-white' : 'bg-amber-600 hover:bg-amber-700 text-white'} transition-colors`}
+                    >
+                      Allow persistent storage
+                    </button>
+                  </div>
+                )}
                 <div className={`flex items-center justify-between`}>
                   <p className={`text-xs ${textSecondary}`}>
                     {typeof __APP_VERSION__ !== 'undefined' ? `v${__APP_VERSION__}` : 'dayGLANCE'}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,12 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import { Activity, Archive, BarChart3, Bell, BookOpen, BrainCircuit, CalendarDays, CheckCircle, CheckSquare, ChevronDown, Clock, Cloud, ExternalLink, Flag, FolderOpen, Globe, HardDrive, Key, LayoutGrid, Loader, Lock, MapPin, Mic, Moon, Newspaper, RefreshCw, Server, Settings, Sparkles, Sun, Target, Thermometer, Upload, Wifi, WifiOff, X, Zap } from 'lucide-react';
+import React, { useState } from 'react';
+import { Activity, Archive, BarChart3, Bell, BookOpen, BrainCircuit, CalendarDays, CheckCircle, CheckSquare, ChevronDown, Clock, Cloud, ExternalLink, Flag, FolderOpen, Globe, Key, LayoutGrid, Loader, Lock, MapPin, Mic, Moon, Newspaper, RefreshCw, Server, Settings, Sparkles, Sun, Target, Thermometer, Upload, Wifi, WifiOff, X, Zap } from 'lucide-react';
 import { getTzLabel, getTzOptions } from '../utils/timezones.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
-import { getStorageUsage, formatBytes } from '../utils/storage.js';
+import { getStorageUsage } from '../utils/storage.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
 import { isNativeAndroid, isNativeApp, nativeGetCalendars } from '../native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault } from '../obsidian.js';
@@ -94,11 +94,6 @@ const SettingsModal = () => {
   // null | 'passphrase-needed' | 'running' | { error: string }
   const [intentSetupPhase, setIntentSetupPhase] = useState(null);
   const [intentPassphraseInput, setIntentPassphraseInput] = useState('');
-
-  const [persisted, setPersisted] = useState(null); // null = checking, true/false = result
-  useEffect(() => {
-    navigator.storage?.persisted?.().then(p => setPersisted(p));
-  }, []);
 
   const [trayHotkey, setTrayHotkey] = useState(() => localStorage.getItem('dg-tray-hotkey') || '');
   const [mainWindowHotkey, setMainWindowHotkey] = useState(() => localStorage.getItem('dg-main-window-hotkey') || '');
@@ -696,34 +691,6 @@ const SettingsModal = () => {
                           <option value={60}>After 60 days</option>
                         </select>
                       </div>
-                    </div>
-
-                    <hr className={borderClass} />
-
-                    {/* Storage */}
-                    <div className="space-y-3">
-                      <div className={`font-medium ${textPrimary} flex items-center gap-2`}>
-                        <HardDrive size={16} className={textSecondary} />
-                        Storage
-                      </div>
-                      <p className={`text-xs ${textSecondary}`}>
-                        {formatBytes(storageUsage.totalBytes)} used{storageWarning ? ' — nearing the ~5 MB localStorage limit' : ''}
-                      </p>
-                      {persisted === false && (
-                        <div className={`p-3 rounded-lg border ${darkMode ? 'bg-amber-900/20 border-amber-700' : 'bg-amber-50 border-amber-300'}`}>
-                          <p className={`text-xs ${darkMode ? 'text-amber-300' : 'text-amber-800'} mb-2`}>
-                            Your data may be cleared by the browser when storage is low. Allow persistent storage to protect it.
-                          </p>
-                          <button
-                            onClick={() => {
-                              navigator.storage?.persist?.().then(granted => setPersisted(granted));
-                            }}
-                            className={`px-3 py-1.5 text-xs rounded-lg font-medium ${darkMode ? 'bg-amber-700 hover:bg-amber-600 text-white' : 'bg-amber-600 hover:bg-amber-700 text-white'} transition-colors`}
-                          >
-                            Allow persistent storage
-                          </button>
-                        </div>
-                      )}
                     </div>
                   </div>
 

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -6,7 +6,6 @@ import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
-import { getStorageUsage } from '../utils/storage.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
 import { isNativeAndroid, isNativeApp, nativeGetCalendars } from '../native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault } from '../obsidian.js';
@@ -73,9 +72,6 @@ const SettingsModal = () => {
 
   const currentProvider = cloudSyncConfig?.provider || 'nextcloud';
   const provider = cloudSyncProviders[currentProvider];
-  const storageUsage = getStorageUsage();
-  const storageWarning = storageUsage.totalBytes > 4 * 1024 * 1024;
-
   const [intentForm, setIntentForm] = useState(() => {
     const raw = localStorage.getItem(INTENT_CONFIG_KEY);
     const saved = raw ? JSON.parse(raw) : {};


### PR DESCRIPTION
## Summary

Fixes the placement introduced in #925. The `?` modal already shows the storage usage button, so the amber notice belongs there — not as a new Storage section in Settings.

- **Removes** the Storage section added to `SettingsModal.jsx` in #925 (reverts `HardDrive` icon, `formatBytes` import, `useEffect`, `persisted` state)
- **Adds** `storagePersisted` state to `App.jsx`, refreshed via `navigator.storage?.persisted?.()` each time the `?` modal opens
- Amber notice + "Allow persistent storage" button appears in the `?` modal immediately below the storage usage line when `persisted === false`; disappears as soon as the browser grants persistence

The startup `navigator.storage?.persist?.()` call from #925 is unchanged.

## Test plan

- [ ] Open Settings — no Storage section, no regression
- [ ] Open `?` modal on a fresh browser profile — amber notice appears below the storage line
- [ ] Click "Allow persistent storage" — notice disappears
- [ ] Re-open `?` modal — notice gone (persisted === true)
- [ ] Browser that already granted persistence (or Electron/Android) — no notice

https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX)_