### PR TITLE
Bump version to 2.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.13.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-2.13.1-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 101
+        versionCode = 102
         versionName = "2.13"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "hasInstallScript": true,
       "dependencies": {
         "@glance-apps/intents": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "2.13.0",
+  "version": "2.13.1",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
Patch release picking up fixes since 2.13.0.

| File | Change |
|---|---|
| `package.json` | `2.13.0` → `2.13.1` |
| `package-lock.json` | updated |
| `build.gradle.kts` | `versionCode` 101 → 102 (versionName stays `"2.13"`) |
| `README.md` | version badge → `2.13.1` |

### What's in 2.13.1

- **#922** Fix Electron startup white screen (`ready-to-show` pattern) — Electron only
- **#924** Fix ICS/CalDAV UTC timestamp parsing — events with `Z`-suffix datetimes (e.g. Google Calendar exports) were displaying at the wrong local time
- **#925** Silent `navigator.storage.persist()` call on startup + persistent storage notice in `?` modal
- **#926** Collapsible error details in intent activity log
- **#927** Move persistent storage notice from Settings to `?` modal; remove dead code from `SettingsModal`

### Android impact

**#924 is the one that matters for Android**: any user syncing Google Calendar or another CalDAV source that exports timed events in UTC (`DTSTART:…Z`) would see them offset by their UTC difference. The rest of the changes are either Electron-only (#922) or have negligible Android impact.

https://claude.ai/code/session_01RbDU21pyDZnQo56SQEjUJX