### PR TITLE
Fix Android trial eligibility not refreshing after billing query

### DIFF
--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -184,7 +184,12 @@ export function useSubscription() {
 
   // On mount: background refresh for each platform.
   useEffect(() => {
-    if (BILLING) BILLING.refresh?.();
+    if (BILLING) {
+      BILLING.refresh?.();
+      // Re-read trial eligibility after a delay to match iOS behavior — BillingManager
+      // queries Play async, so the initial read may predate the authoritative result.
+      setTimeout(() => { setTrialEligible(readTrialEligibility()); }, 3000);
+    }
 
     if (IOS) {
       // RevenueCat caches status; re-read after a short delay so it has


### PR DESCRIPTION
## Summary

- `BillingManager` queries Google Play asynchronously on connect, so the initial JS read of `trialEligibleAnnual` in `useSubscription.js` can predate the authoritative result from Play
- If the subscription wall opens before the query completes, the UI shows the optimistic default (`true`) but the actual Play offer may differ — causing a mismatch between the trial CTA and the billing sheet the user sees
- Added a 3-second delayed re-read of trial eligibility on Android mount, matching the existing iOS behavior

## Test plan

- [ ] Open the subscription wall immediately after a cold start on Android — confirm trial messaging updates correctly after ~3s if eligibility changes
- [ ] Verify trial-eligible users still see "14-day free trial" copy
- [ ] Verify ineligible users (e.g. account that used trial via beta) see "Billed yearly" copy after the delay
- [ ] Confirm no regression on iOS trial eligibility display

https://claude.ai/code/session_01Rtcf2ymuYr2cQuEumU7Y8j

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rtcf2ymuYr2cQuEumU7Y8j)_