### PR TITLE
fix(intents): stamp stable transitionId to prevent double-logging on sync

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5311,7 +5311,7 @@ const DayPlanner = () => {
           }
           case 'rename': {
             const setter = isInbox ? setUnscheduledTasks : setTasks;
-            setter(prev => prev.map(t => t.id === id ? { ...t, title: edit.newTitle } : t));
+            setter(prev => prev.map(t => t.id === id ? { ...t, title: edit.newTitle, transitionId: crypto.randomUUID() } : t));
             break;
           }
           case 'delete': {
@@ -5320,17 +5320,17 @@ const DayPlanner = () => {
           }
           case 'complete': {
             const setter = isInbox ? setUnscheduledTasks : setTasks;
-            setter(prev => prev.map(t => t.id === id ? { ...t, completed: true, lastModified: new Date().toISOString() } : t));
+            setter(prev => prev.map(t => t.id === id ? { ...t, completed: true, lastModified: new Date().toISOString(), transitionId: crypto.randomUUID() } : t));
             break;
           }
           case 'uncomplete': {
             const setter = isInbox ? setUnscheduledTasks : setTasks;
-            setter(prev => prev.map(t => t.id === id ? { ...t, completed: false, lastModified: new Date().toISOString() } : t));
+            setter(prev => prev.map(t => t.id === id ? { ...t, completed: false, lastModified: new Date().toISOString(), transitionId: crypto.randomUUID() } : t));
             break;
           }
           case 'changePriority': {
             if (isInbox) {
-              setUnscheduledTasks(prev => prev.map(t => t.id === id ? { ...t, priority: edit.priority } : t));
+              setUnscheduledTasks(prev => prev.map(t => t.id === id ? { ...t, priority: edit.priority, transitionId: crypto.randomUUID() } : t));
             }
             break;
           }
@@ -5340,7 +5340,7 @@ const DayPlanner = () => {
               if (t.id !== id) return t;
               const existing = (t.title.match(/#(\p{L}[\p{L}\p{N}_]*)/gu) || []).map(s => s.slice(1).toLowerCase());
               if (existing.includes(edit.tag.toLowerCase())) return t;
-              return { ...t, title: t.title + ` #${edit.tag}` };
+              return { ...t, title: t.title + ` #${edit.tag}`, transitionId: crypto.randomUUID() };
             }));
             break;
           }
@@ -5348,7 +5348,7 @@ const DayPlanner = () => {
             const setter = isInbox ? setUnscheduledTasks : setTasks;
             setter(prev => prev.map(t => {
               if (t.id !== id) return t;
-              return { ...t, title: t.title.replace(new RegExp(`\\s*#${edit.tag}\\b`, 'gi'), '') };
+              return { ...t, title: t.title.replace(new RegExp(`\\s*#${edit.tag}\\b`, 'gi'), ''), transitionId: crypto.randomUUID() };
             }));
             break;
           }
@@ -7371,7 +7371,7 @@ const DayPlanner = () => {
     for (const placement of accepted) {
       setTasks(prev => prev.map(t => {
         if (t.id === placement.taskId || String(t.id) === String(placement.taskId)) {
-          return { ...t, date: placement.date, startTime: placement.time, isAllDay: false };
+          return { ...t, date: placement.date, startTime: placement.time, isAllDay: false, transitionId: crypto.randomUUID() };
         }
         return t;
       }));

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -465,7 +465,7 @@ export default function useDragDrop({
         const prevDraggedTask = draggedTask;
         setTasks(prev => prev.map(t =>
           t.id === draggedTask.id
-            ? { ...t, startTime, date: dropDateStr, isAllDay: false }
+            ? { ...t, startTime, date: dropDateStr, isAllDay: false, transitionId: crypto.randomUUID() }
             : t
         ));
         // If this is a native Android calendar event, write the change back to the device calendar
@@ -509,7 +509,7 @@ export default function useDragDrop({
         // Reschedule an existing scheduled task
         setTasks(prev => prev.map(t =>
           t.id === draggedTask.id
-            ? { ...t, startTime, date: dropDateStr, isAllDay: false }
+            ? { ...t, startTime, date: dropDateStr, isAllDay: false, transitionId: crypto.randomUUID() }
             : t
         ));
       } else if (draggedTask._overdueType === 'deadline') {
@@ -587,7 +587,7 @@ export default function useDragDrop({
       } else {
         setTasks(prev => prev.map(t =>
           t.id === draggedTask.id
-            ? { ...t, startTime: '00:00', date: dropDateStr, isAllDay: true }
+            ? { ...t, startTime: '00:00', date: dropDateStr, isAllDay: true, transitionId: crypto.randomUUID() }
             : t
         ));
       }
@@ -606,7 +606,7 @@ export default function useDragDrop({
         // Reschedule an existing scheduled task to a new all-day slot
         setTasks(prev => prev.map(t =>
           t.id === draggedTask.id
-            ? { ...t, startTime: '00:00', date: dropDateStr, isAllDay: true }
+            ? { ...t, startTime: '00:00', date: dropDateStr, isAllDay: true, transitionId: crypto.randomUUID() }
             : t
         ));
       } else if (draggedTask._overdueType === 'deadline') {
@@ -1379,6 +1379,7 @@ export default function useDragDrop({
           startTime: finalTime,
           isAllDay: droppingToAllDay,
           date: dropDateStr,
+          transitionId: crypto.randomUUID(),
         } : t));
         // Sync native Android calendar events back to the device calendar
         if (task.nativeEventId && !droppingToAllDay && finalTime) {

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -409,7 +409,7 @@ export default function useTaskActions({
 
     if (fromInbox) {
       setUnscheduledTasks(prev => prev.map(task =>
-        task.id === id ? { ...task, completed: !task.completed, completedAt: !task.completed ? dateToString(new Date()) : null } : task
+        task.id === id ? { ...task, completed: !task.completed, completedAt: !task.completed ? dateToString(new Date()) : null, transitionId: crypto.randomUUID() } : task
       ));
     } else {
       const task = tasks.find(t => t.id === id);
@@ -433,7 +433,7 @@ export default function useTaskActions({
         });
       }
       setTasks(prev => prev.map(task =>
-        task.id === id ? { ...task, completed: !task.completed } : task
+        task.id === id ? { ...task, completed: !task.completed, transitionId: crypto.randomUUID() } : task
       ));
     }
     if (taskToToggle && !taskToToggle.completed) {

--- a/src/intents/useNotifyEmitter.js
+++ b/src/intents/useNotifyEmitter.js
@@ -64,6 +64,23 @@ function shouldEmit(task) {
   return !!(task.source_app && task.source_entity_id);
 }
 
+/** Pure payload builder — exported for testing. */
+export function buildNotifyPayload(task, change, now) {
+  return {
+    event_id: task.transitionId ?? makeEventId(),
+    source_app: task.source_app,
+    source_entity_id: task.source_entity_id,
+    event: change.event,
+    task_id: task.id,
+    title: task.title,
+    timestamp: now,
+    entity_type: ENTITY_TYPES.TASK,
+    ...(change.due !== undefined ? { due: change.due } : {}),
+    ...(change.previous_due !== undefined ? { previous_due: change.previous_due } : {}),
+    ...(change.completed_at !== undefined ? { completed_at: change.completed_at } : {}),
+  };
+}
+
 // ─── hook ────────────────────────────────────────────────────────────────────
 
 /**
@@ -72,8 +89,11 @@ function shouldEmit(task) {
  * state change. No-ops when the intent WebDAV config is absent.
  *
  * Covered events: completed, uncompleted, deleted, rescheduled, updated.
- * Recurring templates are excluded — their completion model (completedDates)
- * differs from the boolean model assumed here.
+ * Recurring templates are excluded: recurringTasks is a separate state slice
+ * not passed to this hook, so recurring completions (completedDates) and
+ * recurring-instance deletions (exceptions) never reach the diff loop. This
+ * is intentional: no current consumer relies on dayGLANCE-native recurring
+ * tasks emitting notify events.
  */
 export function useNotifyEmitter({ tasks, unscheduledTasks }) {
   const prevRef = useRef(null);
@@ -144,19 +164,7 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
       }
 
       for (const { task, change } of emits) {
-        const payload = {
-          event_id: makeEventId(),
-          source_app: task.source_app,
-          source_entity_id: task.source_entity_id,
-          event: change.event,
-          task_id: task.id,
-          title: task.title,
-          timestamp: now,
-          entity_type: ENTITY_TYPES.TASK,
-          ...(change.due !== undefined ? { due: change.due } : {}),
-          ...(change.previous_due !== undefined ? { previous_due: change.previous_due } : {}),
-          ...(change.completed_at !== undefined ? { completed_at: change.completed_at } : {}),
-        };
+        const payload = buildNotifyPayload(task, change, now);
 
         try {
           const envelope = deriveKey

--- a/src/intents/useNotifyEmitter.test.js
+++ b/src/intents/useNotifyEmitter.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { EVENTS } from '@glance-apps/intents';
+import { buildNotifyPayload } from './useNotifyEmitter.js';
+
+const BASE_TASK = {
+  id: 'task-1',
+  title: 'Water plants',
+  source_app: 'app.lastglance',
+  source_entity_id: 'chore_42',
+};
+
+const COMPLETED_CHANGE = {
+  event: EVENTS.COMPLETED,
+  completed_at: '2026-05-30T10:00:00.000Z',
+};
+
+const NOW = '2026-05-30T10:00:00.000Z';
+
+describe('buildNotifyPayload', () => {
+  it('uses transitionId as payload event_id when the task carries one', () => {
+    const knownId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const task = { ...BASE_TASK, transitionId: knownId };
+    const payload = buildNotifyPayload(task, COMPLETED_CHANGE, NOW);
+    expect(payload.event_id).toBe(knownId);
+  });
+
+  it('falls back to a generated id (not a transitionId) when the task has none', () => {
+    const task = { ...BASE_TASK }; // no transitionId
+    const payload = buildNotifyPayload(task, COMPLETED_CHANGE, NOW);
+    expect(payload.event_id).toBeTruthy();
+    expect(payload.event_id).not.toBe(undefined);
+    // The fallback value is makeEventId() output — it will not equal any transitionId
+    // on the task because there is none. Confirm it's a non-empty string distinct from
+    // the fixed UUID used in the other test case.
+    expect(typeof payload.event_id).toBe('string');
+    expect(payload.event_id).not.toBe('f47ac10b-58cc-4372-a567-0e02b2c3d479');
+  });
+
+  it('carries source_app, source_entity_id, event, task_id, title, timestamp', () => {
+    const task = { ...BASE_TASK, transitionId: 'some-uuid' };
+    const payload = buildNotifyPayload(task, COMPLETED_CHANGE, NOW);
+    expect(payload.source_app).toBe('app.lastglance');
+    expect(payload.source_entity_id).toBe('chore_42');
+    expect(payload.event).toBe(EVENTS.COMPLETED);
+    expect(payload.task_id).toBe('task-1');
+    expect(payload.title).toBe('Water plants');
+    expect(payload.timestamp).toBe(NOW);
+  });
+
+  it('includes completed_at when provided in the change', () => {
+    const task = { ...BASE_TASK, transitionId: 'some-uuid' };
+    const payload = buildNotifyPayload(task, COMPLETED_CHANGE, NOW);
+    expect(payload.completed_at).toBe('2026-05-30T10:00:00.000Z');
+  });
+
+  it('omits completed_at when not in the change', () => {
+    const task = { ...BASE_TASK, transitionId: 'some-uuid' };
+    const change = { event: EVENTS.UPDATED, due: '2026-06-01' };
+    const payload = buildNotifyPayload(task, change, NOW);
+    expect('completed_at' in payload).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`useNotifyEmitter` is a state-model observer: it fires on any task state transition, whether caused by a local user action or by the sync layer applying a remote change. With `event_id` generated randomly per emission (`makeEventId()`), two dayGLANCE instances on the same account and WebDAV endpoint each emit a distinct notify file when a `source_app` task completion propagates via sync. The consumer receives two `notify/completed` events for one logical completion, with different `event_id`s, and double-logs.

## Fix

Stamp a stable `transitionId` (plain `crypto.randomUUID()`) onto the task object at the moment of each local mutation, before `setTasks`/`setUnscheduledTasks` stores it. The `@glance-apps/sync` layer passes the field through unchanged (winner-take-all, full-object passthrough — no field allowlist). `useNotifyEmitter` now reads `task.transitionId` as `payload.event_id` instead of calling `makeEventId()` at emit time.

Both devices emit for the same logical completion, but both read the same stored `transitionId`, so both payloads carry the same `event_id`. The consumer's existing dedup absorbs the second arrival as a no-op.

The envelope-level `event_id` (which drives the WebDAV filename and the cursor ordering used by the poller) is untouched — it stays random and emission-time-stamped.

## Mutation sites stamped (15)

- `useTaskActions.js`: `toggleComplete` inbox, `toggleComplete` calendar
- `App.jsx`: voice complete, uncomplete, rename, addTag, removeTag, changePriority
- `App.jsx`: AI reschedule acceptance
- `useDragDrop.js`: desktop drag timed slot (x2), desktop drag all-day (x2), mobile long-press drag

Recurring template sites (`completedDates`, `exceptions`) were explicitly **not** stamped: `recurringTasks` is a separate state slice not passed to `useNotifyEmitter`, so those mutations never reach the diff loop. A comment in the hook JSDoc records this for future readers.

`handleIntent.js handleComplete()` (inbound remote action) is not stamped: it preserves whatever `transitionId` the task already carries.

## Fallback

`task.transitionId ?? makeEventId()` — if a task somehow lacks the field at emit time (deleted-via-filter tasks, any future missed path), the random fallback fires and behaviour is identical to the pre-fix status quo for that event.

## Also in this PR

- Extracts `buildNotifyPayload(task, change, now)` as a named pure export so the payload construction is unit-testable without a React harness.
- Adds `src/intents/useNotifyEmitter.test.js` (5 tests): transitionId present → used as payload event_id; transitionId absent → fallback fires; correct fields carried through.

## Tests

234/234 pass (229 pre-existing + 5 new).

https://claude.ai/code/session_01JJQf7MGBnSZW9faJKmRnA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJQf7MGBnSZW9faJKmRnA5)_