### PR TITLE
chore: bump Android versionCode to 104

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 103
+        versionCode = 104
         versionName = "2.13"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Bumps `versionCode` from 103 to 104 in `build.gradle.kts`. No other changes.

https://claude.ai/code/session_01JJQf7MGBnSZW9faJKmRnA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJQf7MGBnSZW9faJKmRnA5)_