### PR TITLE
chore: bump version to 2.13.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.13.2-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-2.13.3-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 104
+        versionCode = 105
         versionName = "2.13"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "2.13.2",
+      "version": "2.13.3",
       "hasInstallScript": true,
       "dependencies": {
         "@glance-apps/intents": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "2.13.2",
+  "version": "2.13.3",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
Version bump for the 2.13.3 hotfix release.

| File | Change |
|---|---|
| `package.json` | `2.13.2` -> `2.13.3` |
| `package-lock.json` | updated |
| `dayglance-android/app/build.gradle.kts` | `versionCode` 104 -> 105 (versionName stays `2.13`) |
| `README.md` | version badge `2.13.2` -> `2.13.3` |

https://claude.ai/code/session_01JJQf7MGBnSZW9faJKmRnA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJQf7MGBnSZW9faJKmRnA5)_