### PR TITLE
Fix Android storage warning, add lastGLANCE task badge, bump to 2.13.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.13.3-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-2.13.4-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 105
+        versionCode = 106
         versionName = "2.13"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "2.13.3",
+      "version": "2.13.4",
       "hasInstallScript": true,
       "dependencies": {
         "@glance-apps/intents": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "2.13.3",
+  "version": "2.13.4",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1174,11 +1174,15 @@ const DayPlanner = () => {
 
   // Best-effort request for persistent storage on startup.
   // Keeps IndexedDB / Cache Storage alive even when the browser is under quota pressure.
-  useEffect(() => { navigator.storage?.persist?.(); }, []);
+  // No-op in the native shells: WebView storage lives in the app's private data
+  // directory and isn't subject to browser quota eviction.
+  useEffect(() => { if (!isNativeApp()) navigator.storage?.persist?.(); }, []);
 
-  // Refresh persisted status each time the ? modal opens.
+  // Refresh persisted status each time the ? modal opens. Skipped in the native
+  // shells, where the "data may be cleared" warning doesn't apply — leaving
+  // storagePersisted null keeps the banner hidden.
   useEffect(() => {
-    if (showHelpModal) navigator.storage?.persisted?.().then(p => setStoragePersisted(p));
+    if (showHelpModal && !isNativeApp()) navigator.storage?.persisted?.().then(p => setStoragePersisted(p));
   }, [showHelpModal]);
 
   // Lock body/html scrolling to prevent scroll chaining (all devices incl. desktop PWA)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -469,6 +469,13 @@ const DayPlanner = () => {
   const [showShortcutHelp, setShowShortcutHelp] = useState(false);
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [storagePersisted, setStoragePersisted] = useState(null);
+  // True once a persist() request has been declined by the browser. On Chromium
+  // (incl. Android) persist() grants silently based on engagement heuristics and
+  // returns false with no prompt, so we surface guidance instead of looping.
+  const [storagePersistDenied, setStoragePersistDenied] = useState(false);
+  const [storageWarnDismissed, setStorageWarnDismissed] = useState(() => {
+    try { return localStorage.getItem('storageWarnDismissed') === '1'; } catch { return false; }
+  });
 
   const tagFilterBtnRef = useRef(null);
 
@@ -9133,17 +9140,39 @@ const DayPlanner = () => {
                     </button>
                   );
                 })()}
-                {storagePersisted === false && (
+                {storagePersisted === false && !storageWarnDismissed && (
                   <div className={`p-2.5 rounded-lg border ${darkMode ? 'bg-amber-900/20 border-amber-700' : 'bg-amber-50 border-amber-300'}`}>
                     <p className={`text-xs ${darkMode ? 'text-amber-300' : 'text-amber-800'} mb-1.5`}>
                       Your data may be cleared by the browser when storage is low.
                     </p>
-                    <button
-                      onClick={() => navigator.storage?.persist?.().then(granted => setStoragePersisted(granted))}
-                      className={`px-2.5 py-1 text-xs rounded font-medium ${darkMode ? 'bg-amber-700 hover:bg-amber-600 text-white' : 'bg-amber-600 hover:bg-amber-700 text-white'} transition-colors`}
-                    >
-                      Allow persistent storage
-                    </button>
+                    {storagePersistDenied && (
+                      <p className={`text-xs ${darkMode ? 'text-amber-400/90' : 'text-amber-700'} mb-1.5`}>
+                        Your browser declined the request. Browsers usually only grant persistent
+                        storage once dayGLANCE is installed to your home screen. Open the browser
+                        menu and choose “Add to Home screen” / “Install app”, then reopen dayGLANCE
+                        from the home-screen icon.
+                      </p>
+                    )}
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => navigator.storage?.persist?.().then(granted => {
+                          setStoragePersisted(granted);
+                          setStoragePersistDenied(!granted);
+                        })}
+                        className={`px-2.5 py-1 text-xs rounded font-medium ${darkMode ? 'bg-amber-700 hover:bg-amber-600 text-white' : 'bg-amber-600 hover:bg-amber-700 text-white'} transition-colors`}
+                      >
+                        {storagePersistDenied ? 'Try again' : 'Allow persistent storage'}
+                      </button>
+                      <button
+                        onClick={() => {
+                          setStorageWarnDismissed(true);
+                          try { localStorage.setItem('storageWarnDismissed', '1'); } catch { /* ignore */ }
+                        }}
+                        className={`px-2.5 py-1 text-xs rounded font-medium ${darkMode ? 'text-amber-300 hover:bg-amber-900/40' : 'text-amber-700 hover:bg-amber-100'} transition-colors`}
+                      >
+                        Dismiss
+                      </button>
+                    </div>
                   </div>
                 )}
                 <div className={`flex items-center justify-between`}>

--- a/src/components/AllDayTaskCard.jsx
+++ b/src/components/AllDayTaskCard.jsx
@@ -4,8 +4,9 @@ import {
   FileText, Inbox, MoreHorizontal,
   Pencil, RefreshCw, SkipForward, Trash2,
 } from 'lucide-react';
-import { isNativeAndroid, isNativeApp, nativeUpdateEvent } from '../native.js';
+import { isNativeAndroid, isNativeApp, nativeUpdateEvent, SOURCE_APPS } from '../native.js';
 import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
+import LastGlanceBadge from './LastGlanceBadge.jsx';
 import { extractWikilinks } from '../utils/taskUtils.js';
 import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
@@ -191,6 +192,7 @@ const AllDayTaskCard = ({ task, fillWidth = true }) => {
               )}
               <Calendar size={14} className="flex-shrink-0" />
               {task.isRecurring && <RefreshCw size={12} className="flex-shrink-0 opacity-75 hover:opacity-100 cursor-pointer" onClick={(e) => { e.stopPropagation(); setEditingRecurrenceTaskId(task.id); }} />}
+              {task.source_app === SOURCE_APPS.LASTGLANCE && <LastGlanceBadge size={12} className="flex-shrink-0" title="From lastGLANCE" />}
               <div
                 className={`${task.isTaskCalendar ? 'font-bold' : 'font-semibold'} text-sm truncate ${task.completed ? 'line-through' : ''} ${!isImported && !isTablet ? 'cursor-text' : ''} flex-1 min-w-0`}
                 onDoubleClick={!isTablet ? (e) => {

--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -3,7 +3,9 @@ import { BookOpen, Calendar, Check, Loader, Sparkles, X } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
+import { SOURCE_APPS } from '../native.js';
 import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
+import LastGlanceBadge from './LastGlanceBadge.jsx';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
 
@@ -94,6 +96,13 @@ const DesktopNewTaskModal = () => {
               {mobileEditingTask ? 'Edit Task' : newTask.openInInbox ? 'New Inbox Task' : 'New Scheduled Task'}
             </h3>
             <div className="space-y-4">
+              {/* Source attribution — shown when editing a task created via lastGLANCE */}
+              {mobileEditingTask?.source_app === SOURCE_APPS.LASTGLANCE && (
+                <div className={`flex items-center gap-1.5 text-xs ${textSecondary}`}>
+                  <LastGlanceBadge size={14} className="flex-shrink-0" />
+                  <span>Added by lastGLANCE</span>
+                </div>
+              )}
               <div className="relative tag-autocomplete-container">
                 <input
                   ref={newTaskInputRef}

--- a/src/components/LastGlanceBadge.jsx
+++ b/src/components/LastGlanceBadge.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+/**
+ * lastGLANCE source badge.
+ *
+ * A miniature of the lastGLANCE logo mark: a square dot grid with one
+ * highlighted column rendered in the brand green. Used as a small inline
+ * indicator next to task titles so tasks created via lastGLANCE intents are
+ * distinguishable from regular dayGLANCE tasks.
+ *
+ * The faint grid dots use `currentColor` so they adapt to context (white text
+ * on coloured timeline cards, dark text in modals); the highlighted column is
+ * always brand green for recognisability.
+ */
+
+const BRAND_GREEN = '#3DDC84';
+
+// 5×5 grid laid out in a 24×24 viewBox. Column index 1 (left-of-centre, as in
+// the wordmark) is the highlighted brand column.
+const CELL = 3;
+const STEP = 4.5;
+const ORIGIN = 1.5;
+const HIGHLIGHT_COL = 1;
+
+const LastGlanceBadge = ({ size = 12, className = '', title }) => {
+  const cells = [];
+  for (let row = 0; row < 5; row++) {
+    for (let col = 0; col < 5; col++) {
+      const highlighted = col === HIGHLIGHT_COL;
+      cells.push(
+        <rect
+          key={`${row}-${col}`}
+          x={ORIGIN + col * STEP}
+          y={ORIGIN + row * STEP}
+          width={CELL}
+          height={CELL}
+          rx={0.9}
+          fill={highlighted ? BRAND_GREEN : 'currentColor'}
+          opacity={highlighted ? 1 : 0.35}
+        />,
+      );
+    }
+  }
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden={title ? undefined : true}
+      role={title ? 'img' : undefined}
+    >
+      {title && <title>{title}</title>}
+      {cells}
+    </svg>
+  );
+};
+
+export default LastGlanceBadge;

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -3,6 +3,8 @@ import { BookOpen, Calendar, Check, Loader, Sparkles, X } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
+import { SOURCE_APPS } from '../native.js';
+import LastGlanceBadge from './LastGlanceBadge.jsx';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
 
@@ -70,6 +72,13 @@ const MobileNewTaskModal = () => {
                 }
               }}
             >
+              {/* Source attribution — shown when editing a task created via lastGLANCE */}
+              {mobileEditingTask?.source_app === SOURCE_APPS.LASTGLANCE && (
+                <div className={`flex items-center gap-1.5 text-xs ${textSecondary}`}>
+                  <LastGlanceBadge size={14} className="flex-shrink-0" />
+                  <span>Added by lastGLANCE</span>
+                </div>
+              )}
               {/* Title */}
               <div className="relative">
                 <input

--- a/src/components/TimelineTaskCardContent.jsx
+++ b/src/components/TimelineTaskCardContent.jsx
@@ -4,10 +4,11 @@ import {
   FileText, Inbox, MapPin, MoreHorizontal,
   Pencil, RefreshCw, SkipForward, Trash2,
 } from 'lucide-react';
-import { isNativeAndroid, isNativeApp, nativeUpdateEvent } from '../native.js';
+import { isNativeAndroid, isNativeApp, nativeUpdateEvent, SOURCE_APPS } from '../native.js';
 import { renderTitleWithoutTags, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
 import { extractTags, extractWikilinks, stripWikilinks } from '../utils/taskUtils.js';
 import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
+import LastGlanceBadge from './LastGlanceBadge.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
@@ -223,6 +224,7 @@ const TimelineTaskCardContent = ({ task, height, isNarrowWidth, flipNotesPanel }
                 )}
                 {task.isRecurring && <RefreshCw size={12} className="flex-shrink-0 opacity-75 hover:opacity-100 cursor-pointer" onClick={(e) => { e.stopPropagation(); setEditingRecurrenceTaskId(task.id); }} />}
                 {task.importSource === 'obsidian' && <BookOpen size={12} className="flex-shrink-0 opacity-75" title="From Obsidian" />}
+                {task.source_app === SOURCE_APPS.LASTGLANCE && <LastGlanceBadge size={12} className="flex-shrink-0" title="From lastGLANCE" />}
                 <div className="flex-1 min-w-0">
                   {!isTablet && editingTaskId === task.id ? (
                     <div className="relative tag-autocomplete-container">
@@ -309,6 +311,7 @@ const TimelineTaskCardContent = ({ task, height, isNarrowWidth, flipNotesPanel }
                 )}
                 {task.isRecurring && <RefreshCw size={12} className="flex-shrink-0 opacity-75 hover:opacity-100 cursor-pointer" onClick={(e) => { e.stopPropagation(); setEditingRecurrenceTaskId(task.id); }} />}
                 {task.importSource === 'obsidian' && <BookOpen size={12} className="flex-shrink-0 opacity-75" title="From Obsidian" />}
+                {task.source_app === SOURCE_APPS.LASTGLANCE && <LastGlanceBadge size={12} className="flex-shrink-0" title="From lastGLANCE" />}
                 <div className="flex-1 min-w-0">
                   {!isTablet && editingTaskId === task.id ? (
                     <div className="relative tag-autocomplete-container">


### PR DESCRIPTION
## Summary

Three related changes bundled here (all surfaced from the Android storage-warning report):

### 1. Persistent-storage warning on Android
The "Your data may be cleared by the browser when storage is low" banner couldn't be dismissed in the native Android app.

- **Native shells:** WebView storage lives in the app's private data directory and isn't subject to browser quota eviction, so the warning is a false alarm there. Both the startup `persist()` request and the modal's `persisted()` check are now skipped when running in a native shell (`isNativeApp()`), leaving the banner hidden.
- **Browser/PWA:** the warning still applies, but is now dismissible (persisted to `localStorage`), and when the browser declines a `persist()` request it shows install guidance instead of looping. (On Chromium, `persist()` grants silently via engagement heuristics and returns `false` with no prompt, which is why tapping the button appeared to do nothing.)

### 2. lastGLANCE source badge on tasks
Tasks created via lastGLANCE intents carry `source_app === 'app.lastglance'`. A new `LastGlanceBadge` component (a miniature of the lastGLANCE logo mark — a dot grid with a highlighted brand-green column) now distinguishes them:

- Inline next to the title on **timeline cards** and **all-day cards**, alongside the existing recurring/Obsidian indicators.
- As an "Added by lastGLANCE" line in the **task edit modals** (the inline icon's tooltip isn't available on touch).

Faint grid dots use `currentColor` so they adapt to context; the highlighted column is always brand green (`#3DDC84`).

### 3. Version bump to 2.13.4
- `package.json` + lockfile → `2.13.4`
- Android `versionCode` 105 → 106 (`versionName` stays `2.13`, matching the web major.minor)
- README version badge → `2.13.4`

## Notes
- The Android storage fix only takes visible effect once a new Android build ships with the updated web bundle.
- Brand green was derived from the lastGLANCE wordmark; the highlighted-column position and color are single constants in `LastGlanceBadge.jsx` if they need tweaking.

https://claude.ai/code/session_01Bjme3TRwiE74U4orwVrtzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bjme3TRwiE74U4orwVrtzp)_