### PR TITLE
Fix intent create dedup race: deterministic task ID from source triple

### DIFF
--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -16,11 +16,11 @@ import {
 
 export const DEFAULT_TASK_COLOR = 'bg-blue-500';
 
-// Derive a deterministic UUID from an intent event_id so that two devices
+// Derive a deterministic UUID from a seed string so that two devices
 // processing the same intent create tasks with the same ID, letting the sync
 // engine deduplicate them naturally rather than keeping both copies.
-async function taskIdFromEventId(eventId) {
-  const data = new TextEncoder().encode(eventId);
+async function deterministicTaskId(seed) {
+  const data = new TextEncoder().encode(seed);
   const hash = new Uint8Array(await crypto.subtle.digest('SHA-256', data));
   hash[6] = (hash[6] & 0x0f) | 0x40; // version 4
   hash[8] = (hash[8] & 0x3f) | 0x80; // variant
@@ -215,10 +215,17 @@ async function handleCreate(payload, context) {
   }
 
   // Execute: create a new task.
-  // Use a deterministic ID derived from the intent event_id so that two devices
-  // processing the same intent produce the same task ID — the sync engine then
-  // merges them as one task rather than keeping both copies.
-  const taskId = eventId ? await taskIdFromEventId(eventId) : crypto.randomUUID();
+  // Use a deterministic ID so two devices creating from the same source produce
+  // the same task ID — the sync engine then merges them as one rather than
+  // keeping both copies.
+  // Priority: intentKey (source_app+entity+due triple) > event_id > random.
+  // intentKey covers the case where two devices independently emit a create for
+  // the same chore; event_id covers unassigned intents received by multiple devices.
+  const taskId = intentKey
+    ? await deterministicTaskId(intentKey)
+    : eventId
+      ? await deterministicTaskId(eventId)
+      : crypto.randomUUID();
   const projectId = resolveProjectId(normalized.project, projects);
   const taskTitle = rebuildTitle(cleanedTitle, tags);
 
@@ -230,7 +237,7 @@ async function handleCreate(payload, context) {
     completed: false,
     notes: normalized.notes ?? '',
     subtasks: [],
-    ...(eventId ? { transitionId: eventId } : {}),
+    ...(intentKey || eventId ? { transitionId: intentKey ?? eventId } : {}),
     ...(projectId !== undefined ? { projectId } : {}),
     ...(normalized.source_app ? { source_app: normalized.source_app } : {}),
     ...(normalized.source_entity_id ? { source_entity_id: normalized.source_entity_id } : {}),


### PR DESCRIPTION
## Summary

- **Root cause**: When two devices both auto-emit a `create` intent for the same chore (identical `source_app + source_entity_id + due` triple but different `event_id`s), the existing `_intentKey` dedup check only prevents duplicates *after* the first device's task has synced back. During the race window both devices create the task independently with different random IDs — the sync engine then keeps both.
- **Fix**: Derive the task ID deterministically from `intentKey` (SHA-256 of the source triple) when present, falling back to `event_id`, then random. Both devices hashing the same triple produce the same task ID, so the sync engine merges them as one task regardless of timing.
- Also renames `taskIdFromEventId` → `deterministicTaskId` since the same helper now handles both seeds.

## Test plan

- [ ] Trigger the lastGLANCE auto-send setting on two devices simultaneously for the same chore — confirm only one task appears in dayGLANCE after sync
- [ ] Confirm unassigned intents received by multiple devices still deduplicate (event_id path)
- [ ] Confirm intents without source triple still create tasks normally (random ID path)

https://claude.ai/code/session_013pRNz9hJ6yeFWzS1QvGgGi

---
_Generated by [Claude Code](https://claude.ai/code/session_013pRNz9hJ6yeFWzS1QvGgGi)_