### PR TITLE
Update @glance-apps/sync to v1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.13.4",
       "dependencies": {
         "@glance-apps/intents": "^1.3.2",
-        "@glance-apps/sync": "^1.1.1",
+        "@glance-apps/sync": "^1.1.2",
         "lucide-react": "^0.564.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2251,9 +2251,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.1.tgz",
-      "integrity": "sha512-hc+dkfJTAOOL8BwNoqYR7vi4FDOMKFUtQdnujCsu83bymtioZxERM1VHO28mu0KXTOefH5tUIiGRLFb1oUQBHw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.2.tgz",
+      "integrity": "sha512-BlfzcgyVLz+3xdWWa1f+oin0p3fJTmCuCprurRX+CaOpr366eCrTKa4DR0Z3EaoHmXS/qck/WM0qYz0EbjPzCg==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.2",
-    "@glance-apps/sync": "^1.1.1",
+    "@glance-apps/sync": "^1.1.2",
     "lucide-react": "^0.564.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary

- Bumps `@glance-apps/sync` from `^1.1.1` to `^1.1.2` in `package.json`
- Updates `package-lock.json` accordingly

## Test plan

- [ ] Verify app builds without errors
- [ ] Confirm sync functionality works as expected after the update

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQSwbyYefDKQyhft2PiLhf)_