### PR TITLE
Bump Android versionCode to 108

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 107
+        versionCode = 108
         versionName = "2.13"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Bumps `versionCode` from 107 to 108 in `app/build.gradle.kts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017uEH4JJN6dCFBQMytAx83C)_