### PR TITLE
fix(sync): stamp lastModified on recurring tasks; UUID for new habit IDs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3072,7 +3072,8 @@ const DayPlanner = () => {
                 exceptions: {
                   ...t.exceptions,
                   [parsed.dateStr]: { ...(t.exceptions?.[parsed.dateStr] || {}), skipped: true },
-                }
+                },
+                lastModified: new Date().toISOString()
               };
             }));
             setTasks(prev => [...prev, {
@@ -3106,6 +3107,7 @@ const DayPlanner = () => {
                 };
                 // Update recurrence pattern on template if changed
                 updated.recurrence = { ...newTask.recurrence, startDate: t.recurrence?.startDate || parsed.dateStr.substring(0, 8) + '01' };
+                updated.lastModified = new Date().toISOString();
                 return updated;
               }
               return t;
@@ -3128,7 +3130,8 @@ const DayPlanner = () => {
         subtasks: existingTask?.subtasks || [],
         recurrence: { ...newTask.recurrence, startDate: taskDate },
         completedDates: existingTask?.completed ? [taskDate] : [],
-        exceptions: {}
+        exceptions: {},
+        lastModified: new Date().toISOString()
       };
       setTasks(prev => prev.filter(t => t.id !== taskId));
       setRecurringTasks(prev => [...prev, template]);
@@ -5993,7 +5996,7 @@ const DayPlanner = () => {
             const baseStart = (exceptions[parsed.dateStr] || t).startTime || '0:00';
             const newStart = minutesToTime(Math.min(timeToMinutes(baseStart) + snoozeMin, 23 * 60 + 45));
             exceptions[parsed.dateStr] = { ...(exceptions[parsed.dateStr] || {}), startTime: newStart };
-            return { ...t, exceptions };
+            return { ...t, exceptions, lastModified: new Date().toISOString() };
           }));
         } else {
           setTasks(prev => prev.map(t => {

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -449,13 +449,13 @@ export default function useDragDrop({
             // Same-date drag: store startTime override in exception
             setRecurringTasks(prev => prev.map(t => {
               if (t.id !== templateId) return t;
-              return { ...t, exceptions: { ...t.exceptions, [origDateStr]: { ...t.exceptions?.[origDateStr], startTime } } };
+              return { ...t, exceptions: { ...t.exceptions, [origDateStr]: { ...t.exceptions?.[origDateStr], startTime } }, lastModified: new Date().toISOString() };
             }));
           } else {
             // Cross-date drag: mark deleted on old date, create regular task on new date
             setRecurringTasks(prev => prev.map(t => {
               if (t.id !== templateId) return t;
-              return { ...t, exceptions: { ...t.exceptions, [origDateStr]: { ...t.exceptions?.[origDateStr], deleted: true } } };
+              return { ...t, exceptions: { ...t.exceptions, [origDateStr]: { ...t.exceptions?.[origDateStr], deleted: true } }, lastModified: new Date().toISOString() };
             }));
             const { id, isRecurring, recurringTemplateId, ...taskData } = draggedTask;
             setTasks(prev => [...prev, { ...taskData, id: crypto.randomUUID(), startTime, date: dropDateStr, isAllDay: false }]);
@@ -768,7 +768,7 @@ export default function useDragDrop({
         const { templateId, dateStr } = recurringInfo;
         setRecurringTasks(prev => prev.map(t => {
           if (t.id !== templateId) return t;
-          return { ...t, exceptions: { ...t.exceptions, [dateStr]: { ...t.exceptions?.[dateStr], duration: newDuration } } };
+          return { ...t, exceptions: { ...t.exceptions, [dateStr]: { ...t.exceptions?.[dateStr], duration: newDuration } }, lastModified: new Date().toISOString() };
         }));
       } else {
         setTasks(prevTasks => prevTasks.map(t =>
@@ -838,7 +838,7 @@ export default function useDragDrop({
         const { templateId, dateStr } = recurringInfo;
         setRecurringTasks(prev => prev.map(t => {
           if (t.id !== templateId) return t;
-          return { ...t, exceptions: { ...t.exceptions, [dateStr]: { ...t.exceptions?.[dateStr], duration: newDuration } } };
+          return { ...t, exceptions: { ...t.exceptions, [dateStr]: { ...t.exceptions?.[dateStr], duration: newDuration } }, lastModified: new Date().toISOString() };
         }));
       } else {
         setTasks(prevTasks => prevTasks.map(t =>

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -133,7 +133,7 @@ const useHabits = ({ playUISound }) => {
   };
 
   const addHabit = (habit) => {
-    setHabits(prev => [...prev, { ...habit, id: Date.now().toString(), createdAt: new Date().toISOString(), archived: false }]);
+    setHabits(prev => [...prev, { ...habit, id: crypto.randomUUID(), createdAt: new Date().toISOString(), archived: false }]);
   };
 
   const updateHabit = (id, updates) => {

--- a/src/hooks/useReminderEngine.js
+++ b/src/hooks/useReminderEngine.js
@@ -369,7 +369,7 @@ export default function useReminderEngine({
         if (t.id !== parsed.templateId) return t;
         const exceptions = { ...(t.exceptions || {}) };
         exceptions[parsed.dateStr] = { ...(exceptions[parsed.dateStr] || {}), startTime: newStartTime };
-        return { ...t, exceptions };
+        return { ...t, exceptions, lastModified: new Date().toISOString() };
       }));
     } else {
       setTasks(prev => prev.map(t =>

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -180,7 +180,8 @@ export default function useTaskActions({
           subtasks: [],
           recurrence: { ...newTask.recurrence, startDate: taskDate },
           completedDates: [],
-          exceptions: {}
+          exceptions: {},
+          lastModified: new Date().toISOString()
         };
         setRecurringTasks(prev => [...prev, template]);
         if (!onboardingProgress.hasCreatedRecurring) {
@@ -307,7 +308,7 @@ export default function useTaskActions({
       const parsed = parseRecurringId(taskId);
       if (parsed) {
         setRecurringTasks(prev => prev.map(t =>
-          t.id === parsed.templateId ? { ...t, color: newColor } : t
+          t.id === parsed.templateId ? { ...t, color: newColor, lastModified: new Date().toISOString() } : t
         ));
       }
       setShowColorPicker(null);
@@ -334,7 +335,7 @@ export default function useTaskActions({
       const parsed = parseRecurringId(taskId);
       if (parsed) {
         setRecurringTasks(prev => prev.map(t =>
-          t.id === parsed.templateId ? { ...t, notes } : t
+          t.id === parsed.templateId ? { ...t, notes, lastModified: new Date().toISOString() } : t
         ));
       }
     } else if (isInbox) {
@@ -357,7 +358,7 @@ export default function useTaskActions({
       const origStart = t.recurrence.startDate;
       const earlierDate = origStart <= dateStr ? origStart : dateStr;
       const newStart = earlierDate.substring(0, 8) + '01';
-      return { ...t, recurrence: { ...newRecurrence, startDate: newStart } };
+      return { ...t, recurrence: { ...newRecurrence, startDate: newStart }, lastModified: new Date().toISOString() };
     }));
   };
 
@@ -369,7 +370,7 @@ export default function useTaskActions({
       delete updated.maxOccurrences;
       if (endDate) updated.endDate = endDate;
       if (maxOccurrences) updated.maxOccurrences = maxOccurrences;
-      return { ...t, recurrence: updated };
+      return { ...t, recurrence: updated, lastModified: new Date().toISOString() };
     }));
   };
 
@@ -388,7 +389,8 @@ export default function useTaskActions({
           ...t,
           completedDates: completed
             ? (t.completedDates || []).filter(d => d !== dateStr)
-            : [...(t.completedDates || []), dateStr]
+            : [...(t.completedDates || []), dateStr],
+          lastModified: new Date().toISOString()
         };
       }));
       if (!onboardingProgress.hasCompletedTask) {
@@ -465,6 +467,7 @@ export default function useTaskActions({
       setRecurringTasks(prev => prev.map(t => t.id !== parsed.templateId ? t : {
         ...t,
         exceptions: { ...t.exceptions, [parsed.dateStr]: { ...(t.exceptions?.[parsed.dateStr] || {}), skipped: true } },
+        lastModified: new Date().toISOString()
       }));
       setTasks(prev => [...prev, {
         id: crypto.randomUUID(), title,
@@ -657,7 +660,7 @@ export default function useTaskActions({
     if (mode === 'this') {
       setRecurringTasks(prev => prev.map(t => {
         if (t.id !== taskId) return t;
-        return { ...t, exceptions: { ...t.exceptions, [dateStr]: { deleted: true } } };
+        return { ...t, exceptions: { ...t.exceptions, [dateStr]: { deleted: true } }, lastModified: new Date().toISOString() };
       }));
     } else if (mode === 'future') {
       const dayBefore = new Date(dateStr + 'T12:00:00');
@@ -665,7 +668,7 @@ export default function useTaskActions({
       const endDate = dateToString(dayBefore);
       setRecurringTasks(prev => prev.map(t => {
         if (t.id !== taskId) return t;
-        return { ...t, recurrence: { ...t.recurrence, endDate } };
+        return { ...t, recurrence: { ...t.recurrence, endDate }, lastModified: new Date().toISOString() };
       }));
     } else if (mode === 'series') {
       recordDeletedTaskTombstone(taskId);

--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -255,6 +255,7 @@ async function handleCreate(payload, context) {
       recurrence: freqToRecurrence(recurring, startDate),
       completedDates: [],
       exceptions: {},
+      lastModified: new Date().toISOString(),
     };
     setRecurringTasks(prev => [...prev, newRecurring]);
   } else if (due) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Two independent sync-correctness fixes, one commit each for independent revertability.

### Fix 1: stamp `lastModified` on recurring task mutations

Recurring task template objects had no `lastModified` field, so the sync merge's last-write-wins tiebreaker had nothing to work with. Completing or editing a recurring task on one device would not reliably propagate to another — `completedDates` changes in particular were never stamped.

Added `lastModified: new Date().toISOString()` at every site that creates or mutates a recurring template:
- **`useTaskActions.js`**: template creation, `changeTaskColor`, `updateTaskNotes`, `updateRecurrencePattern`, `updateRecurrenceEndCondition`, `toggleComplete` (completedDates), `postponeTask` exception, `deleteRecurringInstance` 'this'/'future' modes
- **`handleIntent.js`**: intent-driven template creation
- **`App.jsx`**: regular→recurring conversion, skipped-instance exception, full-instance edit, native snooze
- **`useDragDrop.js`**: same-date drag, cross-date drag, mouse resize, touch resize
- **`useReminderEngine.js`**: reminder snooze

The field name matches `timestampField: 'lastModified'` already configured in `mergeSync.js` — no merge-side changes needed.

### Fix 2: `crypto.randomUUID()` for new habit IDs

Habits were created with `Date.now().toString()` as their ID. Two devices creating a habit, or two creates in the same millisecond, produce colliding IDs causing duplicates or silent drops in merge.

Changed `addHabit` in `useHabits.js` to use `crypto.randomUUID()`. Forward-only — existing habits keep their `Date.now()` IDs to avoid orphaning habit logs (keys are `YYYY-MM-DD:habitId`).

## Test plan

- [ ] Create a recurring task, complete it on one device, verify the template's `lastModified` is updated in localStorage
- [ ] Edit a recurring instance (title, time, color), verify `lastModified` is bumped on the template
- [ ] Drag/resize a recurring instance, verify `lastModified` is bumped
- [ ] Create a new habit, verify its `id` is a UUID (not a 13-digit timestamp)
- [ ] Existing habits retain their original IDs after reload
- [ ] Existing habit logs remain intact
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DX8ADbqCx9Q8D7wFc3ioSL)_