### PR TITLE
chore(android): bump version to 2.14 (versionCode 109)

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 108
-        versionName = "2.13"
+        versionCode = 109
+        versionName = "2.14"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Bumps `versionCode` 108 → 109 and `versionName` 2.13 → 2.14 in `dayglance-android/app/build.gradle.kts`. No other changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DX8ADbqCx9Q8D7wFc3ioSL)_