### PR TITLE
Fix intent create dedup: idempotent task append

### DIFF
--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -257,14 +257,14 @@ async function handleCreate(payload, context) {
       exceptions: {},
       lastModified: new Date().toISOString(),
     };
-    setRecurringTasks(prev => [...prev, newRecurring]);
+    setRecurringTasks(prev => prev.some(t => t.id === taskId) ? prev : [...prev, newRecurring]);
   } else if (due) {
     const scheduled = parseDue(due, allDay);
     const newTask = { ...baseTask, date: scheduled.date, startTime: scheduled.startTime, isAllDay: scheduled.isAllDay };
-    setTasks(prev => [...prev, newTask]);
+    setTasks(prev => prev.some(t => t.id === taskId) ? prev : [...prev, newTask]);
   } else {
     const newTask = { ...baseTask, priority: priority ?? 0, ...(normalized.deadline ? { deadline: normalized.deadline } : {}) };
-    setUnscheduledTasks(prev => [...prev, newTask]);
+    setUnscheduledTasks(prev => prev.some(t => t.id === taskId) ? prev : [...prev, newTask]);
   }
 
   return ok({ task_id: taskId });


### PR DESCRIPTION
## Summary

The deterministic task ID fix (PR #941) correctly computed the same ID for both intents from the same chore, but the `setTasks` / `setUnscheduledTasks` / `setRecurringTasks` calls unconditionally appended the new task.

When two intents are processed in the same polling loop iteration, React state updates from the first aren't visible to the second — both pass the `_intentKey` check (stale `context.tasks`), both compute the same `taskId`, and both call `prev => [...prev, newTask]`, resulting in two tasks with the same ID.

**Fix**: guard each setter with `prev.some(t => t.id === taskId) ? prev : [...prev, newTask]`. React runs queued functional updaters sequentially against the latest state, so the second setter sees the task already present and no-ops.

## Test plan

- [ ] Two lastGLANCE instances auto-send the same chore — confirm only one task appears in dayGLANCE after sync
- [ ] Single intent still creates the task normally

https://claude.ai/code/session_013pRNz9hJ6yeFWzS1QvGgGi

---
_Generated by [Claude Code](https://claude.ai/code/session_013pRNz9hJ6yeFWzS1QvGgGi)_