### PR TITLE
Add iCloud Drive as supplemental transport for intents and multi-user…

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/ICloudBridge.swift
@@ -155,6 +155,144 @@ final class ICloudBridge {
         NotificationCenter.default.post(name: .dayGlanceForeground, object: nil)
     }
 
+    // MARK: - File operations (intents + multi-user)
+
+    /// Lists filenames (not full paths) in a directory relative to Documents/.
+    /// Returns a JSON array, [] if the directory doesn't exist, or {"error":"iCloud not available"}.
+    func listFiles(relativePath: String) -> String {
+        guard let container = containerURL() else {
+            return #"{"error":"iCloud not available"}"#
+        }
+        let docsDir = container.appendingPathComponent("Documents")
+        let dirURL = docsDir.appendingPathComponent(relativePath)
+
+        guard FileManager.default.fileExists(atPath: dirURL.path) else {
+            return "[]"
+        }
+
+        let entries: [String]
+        do {
+            entries = try FileManager.default.contentsOfDirectory(atPath: dirURL.path)
+        } catch {
+            return "[]"
+        }
+
+        // Trigger download for any .icloud placeholder files (non-blocking).
+        for entry in entries where entry.hasPrefix(".") && entry.hasSuffix(".icloud") {
+            let inner = String(entry.dropFirst().dropLast(".icloud".count))
+            let realURL = dirURL.appendingPathComponent(inner)
+            try? FileManager.default.startDownloadingUbiquitousItem(at: realURL)
+        }
+
+        let names = entries.filter { !$0.hasPrefix(".") }
+        let json = names.map { "\"\(esc($0))\"" }.joined(separator: ",")
+        return "[\(json)]"
+    }
+
+    /// Reads a file relative to Documents/. Returns content, "null", {"downloading":true}, or {"error":"..."}.
+    func readFile(relativePath: String) -> String {
+        guard let container = containerURL() else {
+            return #"{"error":"iCloud not available"}"#
+        }
+        let docsDir = container.appendingPathComponent("Documents")
+        let fileURL = docsDir.appendingPathComponent(relativePath)
+
+        let placeholderURL = fileURL.deletingLastPathComponent()
+            .appendingPathComponent("." + fileURL.lastPathComponent + ".icloud")
+        if FileManager.default.fileExists(atPath: placeholderURL.path) {
+            try? FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+            return #"{"downloading":true}"#
+        }
+
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            try? FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+            return "null"
+        }
+
+        try? FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+
+        let status = (try? fileURL.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey]))?
+            .ubiquitousItemDownloadingStatus
+        if let status, status != .current {
+            return #"{"downloading":true}"#
+        }
+
+        var result = "null"
+        var coordError: NSError?
+        let coordinator = NSFileCoordinator()
+        coordinator.coordinate(readingItemAt: fileURL, options: [], error: &coordError) { url in
+            guard let data = try? Data(contentsOf: url),
+                  let str  = String(data: data, encoding: .utf8) else { return }
+            result = str
+        }
+        if let err = coordError {
+            return "{\"error\":\"\(esc(err.localizedDescription))\"}"
+        }
+        return result
+    }
+
+    /// Writes content to a file relative to Documents/, creating parent directories.
+    /// Returns {"ok":true} or {"ok":false,"error":"..."}.
+    func writeFile(relativePath: String, content: String) -> String {
+        guard let container = containerURL() else {
+            return #"{"ok":false,"error":"iCloud not available"}"#
+        }
+        let docsDir = container.appendingPathComponent("Documents")
+        let fileURL = docsDir.appendingPathComponent(relativePath)
+
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            guard let data = content.data(using: .utf8) else {
+                return #"{"ok":false,"error":"encoding error"}"#
+            }
+            // Write in-place (not atomic) to preserve iCloud xattrs so the daemon queues the upload.
+            try data.write(to: fileURL, options: [])
+            return #"{"ok":true}"#
+        } catch {
+            return "{\"ok\":false,\"error\":\"\(esc(error.localizedDescription))\"}"
+        }
+    }
+
+    /// Deletes a file relative to Documents/. Idempotent — returns {"ok":true} if not found.
+    func deleteFile(relativePath: String) -> String {
+        guard let container = containerURL() else {
+            return #"{"ok":false,"error":"iCloud not available"}"#
+        }
+        let docsDir = container.appendingPathComponent("Documents")
+        let fileURL = docsDir.appendingPathComponent(relativePath)
+
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return #"{"ok":true}"#
+        }
+
+        do {
+            try FileManager.default.removeItem(at: fileURL)
+            return #"{"ok":true}"#
+        } catch {
+            return "{\"ok\":false,\"error\":\"\(esc(error.localizedDescription))\"}"
+        }
+    }
+
+    /// Creates a directory (with intermediates) relative to Documents/.
+    /// Returns {"ok":true} or {"ok":false,"error":"..."}.
+    func makeDir(relativePath: String) -> String {
+        guard let container = containerURL() else {
+            return #"{"ok":false,"error":"iCloud not available"}"#
+        }
+        let docsDir = container.appendingPathComponent("Documents")
+        let dirURL = docsDir.appendingPathComponent(relativePath)
+
+        do {
+            try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+            return #"{"ok":true}"#
+        } catch {
+            return "{\"ok\":false,\"error\":\"\(esc(error.localizedDescription))\"}"
+        }
+    }
+
     // MARK: - Helpers
 
     private func containerURL() -> URL? {

--- a/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
+++ b/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
@@ -141,6 +141,27 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
         case "iCloudAvailable":
             return ICloudBridge.shared.isAvailable()
 
+        // Phase 7b — iCloud file operations (intents + multi-user)
+        case "iCloudListFiles":
+            guard let path = args.first as? String else { return "[]" }
+            return ICloudBridge.shared.listFiles(relativePath: path)
+        case "iCloudReadFile":
+            guard let path = args.first as? String else { return "null" }
+            return ICloudBridge.shared.readFile(relativePath: path)
+        case "iCloudWriteFile":
+            guard args.count >= 2,
+                  let path    = args[0] as? String,
+                  let content = args[1] as? String else {
+                return #"{"ok":false,"error":"missing args"}"#
+            }
+            return ICloudBridge.shared.writeFile(relativePath: path, content: content)
+        case "iCloudDeleteFile":
+            guard let path = args.first as? String else { return #"{"ok":false,"error":"missing args"}"# }
+            return ICloudBridge.shared.deleteFile(relativePath: path)
+        case "iCloudMakeDir":
+            guard let path = args.first as? String else { return #"{"ok":false,"error":"missing args"}"# }
+            return ICloudBridge.shared.makeDir(relativePath: path)
+
         // Phase 8 — Audio recording
         case "startRecording":
             return AudioBridge.shared.startRecording()

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -323,6 +323,73 @@ ipcMain.handle('icloud:write', (_event, json: string) => {
   } catch { return false; }
 });
 
+// iCloud file operations — intents and multi-user sync (supplemental to WebDAV).
+// All paths are relative to Documents/ inside the iCloud container.
+function iCloudDocumentsDir(): string {
+  return path.join(
+    app.getPath('home'),
+    `Library/Mobile Documents/${ICLOUD_CONTAINER_ID}/Documents`
+  );
+}
+
+ipcMain.handle('icloud:list-files', (_event, relativePath: string) => {
+  if (process.platform !== 'darwin') return [];
+  try {
+    const dirPath = path.join(iCloudDocumentsDir(), relativePath);
+    if (!fs.existsSync(dirPath)) return [];
+    return fs.readdirSync(dirPath)
+      .filter(name => !name.startsWith('.') && name.endsWith('.json'));
+  } catch { return []; }
+});
+
+ipcMain.handle('icloud:read-file', (_event, relativePath: string) => {
+  if (process.platform !== 'darwin') return null;
+  try {
+    const filePath = path.join(iCloudDocumentsDir(), relativePath);
+    const dir = path.dirname(filePath);
+    const base = path.basename(filePath);
+    if (!fs.existsSync(filePath)) {
+      if (fs.existsSync(path.join(dir, '.' + base + '.icloud'))) {
+        return JSON.stringify({ downloading: true });
+      }
+      return null;
+    }
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch { return null; }
+});
+
+ipcMain.handle('icloud:write-file', (_event, relativePath: string, content: string) => {
+  if (process.platform !== 'darwin') return false;
+  try {
+    const filePath = path.join(iCloudDocumentsDir(), relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    // Write in-place (not rename) to preserve iCloud xattrs so bird queues the upload.
+    fs.writeFileSync(filePath, content, { encoding: 'utf-8' });
+    return true;
+  } catch { return false; }
+});
+
+ipcMain.handle('icloud:delete-file', (_event, relativePath: string) => {
+  if (process.platform !== 'darwin') return true;
+  try {
+    const filePath = path.join(iCloudDocumentsDir(), relativePath);
+    fs.unlinkSync(filePath);
+    return true;
+  } catch (e: unknown) {
+    if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'ENOENT') return true;
+    return false;
+  }
+});
+
+ipcMain.handle('icloud:make-dir', (_event, relativePath: string) => {
+  if (process.platform !== 'darwin') return false;
+  try {
+    const dirPath = path.join(iCloudDocumentsDir(), relativePath);
+    fs.mkdirSync(dirPath, { recursive: true });
+    return true;
+  } catch { return false; }
+});
+
 // Watch the iCloud container directory for changes written by the iOS app.
 // Sends 'icloud:changed' to the renderer so it can run a sync cycle immediately
 // instead of waiting for the 15-second poll.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -117,6 +117,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('icloud:changed', handler);
   },
 
+  // iCloud file operations — intents and multi-user sync (supplemental to WebDAV)
+  listICloudFiles: (relativePath: string): Promise<string[]> =>
+    ipcRenderer.invoke('icloud:list-files', relativePath),
+  readICloudFile: (relativePath: string): Promise<string | null> =>
+    ipcRenderer.invoke('icloud:read-file', relativePath),
+  writeICloudFile: (relativePath: string, content: string): Promise<boolean> =>
+    ipcRenderer.invoke('icloud:write-file', relativePath, content),
+  deleteICloudFile: (relativePath: string): Promise<boolean> =>
+    ipcRenderer.invoke('icloud:delete-file', relativePath),
+  makeICloudDir: (relativePath: string): Promise<boolean> =>
+    ipcRenderer.invoke('icloud:make-dir', relativePath),
+
   // Tray popup listens for the signal to focus the quick-add input.
   onFocusQuickAdd: (callback: () => void) => {
     const handler = () => callback();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,7 +74,7 @@ import useGTDFrames from './hooks/useGTDFrames.js';
 import { getGlanceHGInstances, isHGSessionReachable } from './hooks/useHyperGlance.js';
 import { useIntentPoller, INTENT_CONFIG_KEY } from './intents/useIntentPoller.js';
 import { useNotifyEmitter } from './intents/useNotifyEmitter.js';
-import { syncSharedUsers } from './intents/sharedUsers.js';
+import { syncSharedUsers, syncSharedUsersViaICloud } from './intents/sharedUsers.js';
 import useVoiceAI from './hooks/useVoiceAI.js';
 import useNavigation from './hooks/useNavigation.js';
 import useStats from './hooks/useStats.js';
@@ -1421,17 +1421,18 @@ const DayPlanner = () => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { writeConfigTimestamp('dayglance-multi-user-enabled-updated-at'); }, [multiUserEnabled]);
 
-  // Sync user list with glance-users.json on WebDAV using cloud sync credentials,
-  // so dayGLANCE and lastGLANCE share the same roster regardless of which app is
-  // opened first. Re-runs when users change or cloud sync config changes.
+  // Sync user list with glance-users.json on WebDAV and iCloud, so dayGLANCE
+  // and lastGLANCE share the same roster regardless of which app is opened first.
+  // Both transports run simultaneously; whichever returns non-null is applied.
+  // Re-runs when users change or cloud sync config changes.
   useEffect(() => {
-    if (!cloudSyncConfig?.enabled) return;
     if (!multiUserEnabled) return;
     const usersPath = (() => {
       const raw = localStorage.getItem('dayglance-multi-user-config');
       return raw ? (JSON.parse(raw).usersPath ?? undefined) : undefined;
     })();
-    syncSharedUsers(cloudSyncConfig, usersPath, users).then(merged => {
+
+    const applyMerged = (merged) => {
       if (!merged) return;
       const localById = new Map(users.map(u => [u.syncId ?? u.id, u]));
       const hasNew = merged.some(u => {
@@ -1442,7 +1443,17 @@ const DayPlanner = () => {
         localStorage.setItem('dayglance-users', JSON.stringify(merged));
         setUsers(merged);
       }
-    }).catch(err => console.warn('[shared-users] sync error:', err.message));
+    };
+
+    if (cloudSyncConfig?.enabled) {
+      syncSharedUsers(cloudSyncConfig, usersPath, users)
+        .then(applyMerged)
+        .catch(err => console.warn('[shared-users] WebDAV sync error:', err.message));
+    }
+
+    syncSharedUsersViaICloud(usersPath, users)
+      .then(applyMerged)
+      .catch(err => console.warn('[shared-users] iCloud sync error:', err.message));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [users, multiUserEnabled, cloudSyncConfig?.enabled, cloudSyncConfig?.nextcloudUrl, cloudSyncConfig?.webdavUrl, cloudSyncLastSynced]);
 

--- a/src/intents/icloudFileTransport.js
+++ b/src/intents/icloudFileTransport.js
@@ -1,0 +1,137 @@
+/**
+ * Platform adapter for iCloud Drive file operations.
+ *
+ * Provides a uniform async API over two native bridges:
+ *   - iOS WKWebView:   window.DayGlanceNative.iCloudListFiles(path) etc. (synchronous bridge calls)
+ *   - macOS Electron:  window.electronAPI.listICloudFiles(path) etc. (IPC → Promises)
+ *
+ * Android and web are unsupported — isAvailable() returns false and all ops
+ * return safe defaults so callers can guard with a single availability check.
+ *
+ * All relativePath params are relative to the Documents/ folder inside the
+ * iCloud container (e.g. "GLANCE/events/", "GLANCE/users/glance-users.json").
+ * Leading "/" is tolerated but stripped by callers before passing here.
+ */
+
+const isIOS = typeof window !== 'undefined' && !!window.DayGlanceIOS;
+const isMacOS =
+  typeof window !== 'undefined' &&
+  !!window.electronAPI &&
+  typeof window.electronAPI.listICloudFiles === 'function';
+
+/**
+ * Returns true if iCloud file ops are available on this platform.
+ * iOS and macOS only; Android/web return false.
+ */
+export function isAvailable() {
+  return isIOS || isMacOS;
+}
+
+/**
+ * Lists filenames (not full paths) in the given directory.
+ * Returns an array of filename strings, or [] if the directory doesn't exist.
+ */
+export async function listFiles(relativePath) {
+  if (isIOS) {
+    try {
+      const raw = window.DayGlanceNative.iCloudListFiles(relativePath);
+      const parsed = JSON.parse(raw);
+      // Error object from Swift — treat as empty
+      if (!Array.isArray(parsed)) return [];
+      return parsed;
+    } catch {
+      return [];
+    }
+  }
+  if (isMacOS) {
+    try {
+      return await window.electronAPI.listICloudFiles(relativePath);
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+/**
+ * Reads a file. Returns the content string, null if not found, or the raw
+ * JSON string {"downloading":true} if the file is being downloaded from iCloud.
+ * Throws on hard errors.
+ */
+export async function readFile(relativePath) {
+  if (isIOS) {
+    const raw = window.DayGlanceNative.iCloudReadFile(relativePath);
+    return raw === undefined ? null : raw;
+  }
+  if (isMacOS) {
+    return window.electronAPI.readICloudFile(relativePath);
+  }
+  return null;
+}
+
+/**
+ * Writes content to the file, creating parent directories as needed.
+ * Returns true on success.
+ */
+export async function writeFile(relativePath, content) {
+  if (isIOS) {
+    try {
+      const raw = window.DayGlanceNative.iCloudWriteFile(relativePath, content);
+      return JSON.parse(raw)?.ok === true;
+    } catch {
+      return false;
+    }
+  }
+  if (isMacOS) {
+    try {
+      return await window.electronAPI.writeICloudFile(relativePath, content);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Deletes the file. Idempotent — returns true even if the file didn't exist.
+ */
+export async function deleteFile(relativePath) {
+  if (isIOS) {
+    try {
+      const raw = window.DayGlanceNative.iCloudDeleteFile(relativePath);
+      return JSON.parse(raw)?.ok === true;
+    } catch {
+      return false;
+    }
+  }
+  if (isMacOS) {
+    try {
+      return await window.electronAPI.deleteICloudFile(relativePath);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Creates a directory (with intermediates). Returns true on success.
+ */
+export async function makeDir(relativePath) {
+  if (isIOS) {
+    try {
+      const raw = window.DayGlanceNative.iCloudMakeDir(relativePath);
+      return JSON.parse(raw)?.ok === true;
+    } catch {
+      return false;
+    }
+  }
+  if (isMacOS) {
+    try {
+      return await window.electronAPI.makeICloudDir(relativePath);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}

--- a/src/intents/sharedUsers.js
+++ b/src/intents/sharedUsers.js
@@ -1,4 +1,5 @@
 import { webdavFetch } from '../utils/cloudSyncProviders.js';
+import * as icloudFileTransport from './icloudFileTransport.js';
 
 const USERS_FILENAME = 'glance-users.json';
 const DEFAULT_USERS_PATH = '/GLANCE/users/';
@@ -125,6 +126,68 @@ export async function syncSharedUsers(cloudSyncConfig, usersPath, localUsers) {
   }
   if (!putRes.ok) {
     console.warn('[shared-users] PUT failed:', putRes.status);
+  }
+
+  return merged;
+}
+
+/**
+ * Sync the local user list with glance-users.json on iCloud Drive, using the
+ * same directory structure as WebDAV: GLANCE/users/glance-users.json under
+ * the Documents/ folder of the iCloud container.
+ *
+ * Returns the merged user array, or null if iCloud is not available or the
+ * file is still downloading (caller should retry on next sync cycle).
+ */
+export async function syncSharedUsersViaICloud(usersPath, localUsers) {
+  if (!icloudFileTransport.isAvailable()) return null;
+
+  // Build relative path: strip leading / from usersPath, append filename.
+  const dirPath = (usersPath ?? DEFAULT_USERS_PATH).replace(/^\//, '').replace(/\/*$/, '') + '/';
+  const filePath = dirPath + USERS_FILENAME;
+
+  let remoteRaw;
+  try {
+    remoteRaw = await icloudFileTransport.readFile(filePath);
+  } catch (err) {
+    console.warn('[shared-users/icloud] readFile error:', err.message);
+    return null;
+  }
+
+  // Still downloading — caller should retry
+  if (remoteRaw && typeof remoteRaw === 'string') {
+    try {
+      const parsed = JSON.parse(remoteRaw);
+      if (parsed?.downloading === true) return null;
+    } catch { /* not JSON — treat as content */ }
+  }
+
+  let merged;
+  if (remoteRaw === null || remoteRaw === 'null') {
+    // File doesn't exist yet — this app is first
+    merged = localUsers;
+  } else {
+    let remoteWire = [];
+    try {
+      const data = JSON.parse(remoteRaw);
+      remoteWire = Array.isArray(data.users) ? data.users : [];
+    } catch {
+      remoteWire = [];
+    }
+    merged = mergeUsers(localUsers, remoteWire);
+  }
+
+  const wireUsers = merged.map(toWireFormat);
+  const body = JSON.stringify({ version: 1, users: wireUsers, updated_at: new Date().toISOString() });
+
+  let ok = await icloudFileTransport.writeFile(filePath, body);
+  if (!ok) {
+    // Directory may not exist — create it and retry
+    await icloudFileTransport.makeDir(dirPath);
+    ok = await icloudFileTransport.writeFile(filePath, body);
+  }
+  if (!ok) {
+    console.warn('[shared-users/icloud] writeFile failed');
   }
 
   return merged;

--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -4,6 +4,7 @@ import { loadIntentsRootKey } from './intentsKeyStore.js';
 import { webdavFetch } from '../utils/cloudSyncProviders.js';
 import { handleIntent } from './handleIntent.js';
 import { logActivity } from './intentLog.js';
+import * as iCloudTransport from './icloudFileTransport.js';
 
 export const INTENT_CONFIG_KEY = 'dayglance-intent-config';
 export const MULTI_USER_CONFIG_KEY = 'dayglance-multi-user-config';
@@ -23,6 +24,9 @@ const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.l
 // Module-level lock: prevents React StrictMode's double-mount from running two
 // concurrent poll() calls, which would both see cursor=null and duplicate tasks.
 let pollLock = false;
+
+// Separate lock for iCloud polls so they don't run concurrently.
+let iCloudPollLock = false;
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -138,6 +142,231 @@ export async function runIntentGC(config) {
   }
 
   localStorage.setItem(GC_LAST_RUN_KEY, new Date().toISOString());
+}
+
+// ─── iCloud: write one event file ───────────────────────────────────────────
+
+/**
+ * Write a single envelope as a JSON file to iCloud Drive.
+ * No-ops if iCloud is unavailable. Creates the events directory on first use.
+ */
+export async function writeEventFileICloud(config, envelope) {
+  if (!iCloudTransport.isAvailable()) return;
+  const eventsRelPath = ((config?.eventsPath ?? DEFAULT_EVENTS_PATH).replace(/^\//, '').replace(/\/*$/, '')) + '/';
+  const filename = filenameFor(envelope);
+  const filePath = eventsRelPath + filename;
+  const body = JSON.stringify(envelope);
+  const ok = await iCloudTransport.writeFile(filePath, body);
+  if (!ok) {
+    // Directory may not exist yet — create it and retry
+    await iCloudTransport.makeDir(eventsRelPath);
+    await iCloudTransport.writeFile(filePath, body);
+  }
+}
+
+// ─── iCloud: garbage-collect old event files ─────────────────────────────────
+
+/**
+ * Delete iCloud event files older than config.gcRetentionDays.
+ * Best-effort; no-ops if iCloud is unavailable.
+ */
+export async function runIntentGCICloud(config) {
+  if (!iCloudTransport.isAvailable()) return;
+  const eventsRelPath = ((config?.eventsPath ?? DEFAULT_EVENTS_PATH).replace(/^\//, '').replace(/\/*$/, '')) + '/';
+  const retentionMs = (config?.gcRetentionDays ?? DEFAULT_RETENTION_DAYS) * ONE_DAY_MS;
+  const cutoff = Date.now() - retentionMs;
+
+  let names;
+  try {
+    names = await iCloudTransport.listFiles(eventsRelPath);
+  } catch (err) {
+    console.warn('[intent-gc/icloud] listFiles error:', err.message);
+    return;
+  }
+
+  const files = names
+    .filter(name => name.endsWith('.json'))
+    .map(name => ({ name, parsed: parseFilename(name) }))
+    .filter(f => f.parsed !== null);
+
+  let deleted = 0;
+  for (const { name, parsed } of files) {
+    const fileDate = parseFilenameDate(parsed.timestamp);
+    if (isNaN(fileDate) || fileDate.getTime() > cutoff) continue;
+    try {
+      await iCloudTransport.deleteFile(eventsRelPath + name);
+      deleted++;
+    } catch (err) {
+      console.warn('[intent-gc/icloud] deleteFile error:', name, err.message);
+    }
+  }
+
+  if (deleted > 0) {
+    console.log(`[intent-gc/icloud] Deleted ${deleted} expired event file(s)`);
+  }
+}
+
+// ─── iCloud: poll once ──────────────────────────────────────────────────────
+
+async function pollICloud(config, context) {
+  if (iCloudPollLock) return;
+  iCloudPollLock = true;
+  try {
+    await _pollICloud(config, context);
+  } finally {
+    iCloudPollLock = false;
+  }
+}
+
+async function _pollICloud(config, context) {
+  const eventsRelPath = ((config?.eventsPath ?? DEFAULT_EVENTS_PATH).replace(/^\//, '').replace(/\/*$/, '')) + '/';
+
+  let names;
+  try {
+    names = await iCloudTransport.listFiles(eventsRelPath);
+  } catch (err) {
+    console.warn('[intent/icloud] listFiles error:', err.message);
+    return;
+  }
+
+  const files = names
+    .filter(name => name.endsWith('.json'))
+    .map(name => ({ name, parsed: parseFilename(name) }))
+    .filter(f => f.parsed !== null)
+    .sort((a, b) => a.parsed.event_id.localeCompare(b.parsed.event_id));
+
+  const cursor = getCursor();
+  const pending = cursor ? files.filter(f => f.parsed.event_id > cursor) : files;
+
+  for (const { name, parsed } of pending) {
+    try {
+      const rawStr = await iCloudTransport.readFile(eventsRelPath + name);
+      if (rawStr === null || rawStr === 'null') {
+        setCursor(parsed.event_id);
+        continue;
+      }
+
+      // Still downloading from iCloud — skip for now; next poll will retry
+      let raw;
+      try {
+        raw = JSON.parse(rawStr);
+      } catch {
+        setCursor(parsed.event_id);
+        continue;
+      }
+
+      if (raw?.downloading === true) {
+        // Don't advance cursor — retry on next poll
+        continue;
+      }
+
+      // iCloud transport should never carry encrypted envelopes — skip with warning
+      if (raw?.encrypted === true) {
+        console.warn('[intent/icloud] Skipping encrypted envelope on iCloud transport (misconfigured sender):', name);
+        logActivity({
+          direction: 'in',
+          action: 'unknown',
+          event: null,
+          source_app: null,
+          title: null,
+          timestamp: new Date().toISOString(),
+          status: 'warn',
+          error: 'encrypted_on_icloud',
+        });
+        setCursor(parsed.event_id);
+        continue;
+      }
+
+      if (raw?.emitted_by === 'app.dayglance') {
+        setCursor(parsed.event_id);
+        continue;
+      }
+
+      let envelope;
+      try {
+        envelope = parseEnvelope(raw);
+      } catch (parseErr) {
+        let errorCode = parseErr.name ?? 'parse_error';
+        let logStatus = 'error';
+        if (parseErr instanceof MalformedEnvelopeError) {
+          console.warn('[intent/icloud] Skipping malformed envelope:', name, parseErr.message);
+          logStatus = 'warn';
+        } else if (parseErr instanceof NotEncryptedError) {
+          console.warn('[intent/icloud] Skipping malformed envelope:', name);
+        } else {
+          console.warn('[intent/icloud] Unparseable envelope, skipping:', name);
+          errorCode = 'parse_error';
+        }
+        logActivity({
+          direction: 'in',
+          action: 'unknown',
+          event: null,
+          source_app: null,
+          title: null,
+          timestamp: new Date().toISOString(),
+          status: logStatus,
+          error: errorCode,
+        });
+        setCursor(parsed.event_id);
+        continue;
+      }
+
+      if (envelope.emitted_by === 'app.dayglance') {
+        setCursor(parsed.event_id);
+        continue;
+      }
+
+      // Multi-user visibility filter
+      if (envelope.action === ACTIONS.CREATE) {
+        const multiUserEnabled = JSON.parse(localStorage.getItem('dayglance-multi-user-enabled') || 'false');
+        const muRaw = localStorage.getItem(MULTI_USER_CONFIG_KEY);
+        const meUserSyncId = muRaw ? JSON.parse(muRaw).meUserSyncId : null;
+        if (multiUserEnabled && meUserSyncId) {
+          const assigned = envelope.payload.assigned_user_ids ?? [];
+          if (assigned.length > 0 && !assigned.includes(meUserSyncId)) {
+            logActivity({
+              direction: 'in',
+              action: envelope.action,
+              event: null,
+              source_app: envelope.payload.source_app ?? envelope.emitted_by ?? null,
+              title: envelope.payload.title ?? null,
+              timestamp: envelope.emitted_at,
+              status: 'ok',
+              error: null,
+            });
+            setCursor(parsed.event_id);
+            continue;
+          }
+        }
+      }
+
+      const result = await handleIntent(envelope.action, envelope.payload, { ...context, eventId: envelope.event_id });
+      logActivity({
+        direction: 'in',
+        action: envelope.action,
+        event: envelope.payload.event ?? null,
+        source_app: envelope.payload.source_app ?? envelope.emitted_by ?? null,
+        title: envelope.payload.title ?? null,
+        timestamp: envelope.emitted_at,
+        status: result.success ? 'ok' : 'error',
+        error: result.success ? null : result.error,
+      });
+    } catch (err) {
+      console.warn('[intent/icloud] Error processing', name, ':', err.message);
+      logActivity({
+        direction: 'in',
+        action: 'unknown',
+        event: null,
+        source_app: null,
+        title: null,
+        timestamp: new Date().toISOString(),
+        status: 'error',
+        error: err.message,
+      });
+    }
+
+    setCursor(parsed.event_id);
+  }
 }
 
 // ─── poll once ──────────────────────────────────────────────────────────────
@@ -341,10 +570,12 @@ export function useIntentPoller(context) {
       return raw ? JSON.parse(raw) : null;
     })();
 
-    if (!config?.webdavUrl || !config?.username || !config?.appPassword) return;
+    const hasWebDAV = !!(config?.webdavUrl && config?.username && config?.appPassword);
+    const hasICloud = iCloudTransport.isAvailable();
+    if (!hasWebDAV && !hasICloud) return;
 
-    const fgMs = config.foregroundInterval ?? DEFAULT_FG_MS;
-    const bgMs = config.backgroundInterval ?? DEFAULT_BG_MS;
+    const fgMs = config?.foregroundInterval ?? DEFAULT_FG_MS;
+    const bgMs = config?.backgroundInterval ?? DEFAULT_BG_MS;
     let pollTimerId = null;
     let gcTimerId = null;
     let destroyed = false;
@@ -359,7 +590,10 @@ export function useIntentPoller(context) {
     const runPoll = async () => {
       if (destroyed) return;
       try {
-        await poll(config, contextRef.current);
+        await poll(config, contextRef.current);           // WebDAV (no-ops if not configured)
+        if (iCloudTransport.isAvailable()) {
+          await pollICloud(config, contextRef.current);   // iCloud (sequential, sees advanced cursor)
+        }
       } catch (err) {
         console.warn('[intent] poll error:', err.message);
       }
@@ -385,6 +619,7 @@ export function useIntentPoller(context) {
       if (destroyed) return;
       try {
         await runIntentGC(config);
+        await runIntentGCICloud(config);
       } catch (err) {
         console.warn('[intent-gc] error:', err.message);
       }

--- a/src/intents/useNotifyEmitter.js
+++ b/src/intents/useNotifyEmitter.js
@@ -1,8 +1,9 @@
 import { useEffect, useRef } from 'react';
 import { buildEnvelope, buildEncryptedEnvelope, eventId as makeEventId, EVENTS, ENTITY_TYPES, deriveEnvelopeKey } from '@glance-apps/intents';
 import { loadIntentsRootKey } from './intentsKeyStore.js';
-import { writeEventFile, INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from './useIntentPoller.js';
+import { writeEventFile, writeEventFileICloud, INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from './useIntentPoller.js';
 import { logActivity } from './intentLog.js';
+import * as iCloudTransport from './icloudFileTransport.js';
 
 // The tray holds a read-only state snapshot. Any task-state changes in tray
 // mode (e.g. from an iCloud sync download) were already handled by the main
@@ -110,8 +111,10 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
 
     // Skip the initial snapshot — no previous state to diff against
     if (prev === null) return;
-    // Skip emit when config is absent
-    if (!config?.webdavUrl || !config?.username || !config?.appPassword) return;
+    // Skip emit when neither WebDAV nor iCloud is configured
+    const hasWebDAV = !!(config?.webdavUrl && config?.username && config?.appPassword);
+    const hasICloud = iCloudTransport.isAvailable();
+    if (!hasWebDAV && !hasICloud) return;
 
     const prevMap = new Map(prev.map(t => [t.id, t]));
     const nextMap = new Map(allTasks.map(t => [t.id, t]));
@@ -172,7 +175,8 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
           const envelope = deriveKey
             ? await buildEncryptedEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' }, deriveKey)
             : buildEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' });
-          await writeEventFile(config, envelope);
+          await writeEventFile(config, envelope);          // WebDAV (no-ops if not configured)
+          await writeEventFileICloud(config, envelope);    // iCloud (no-ops if not available)
           logActivity({
             direction: 'out',
             action: 'notify',


### PR DESCRIPTION
… sync

Implements iCloud file I/O alongside the existing WebDAV transport so iOS and macOS users get zero-config intents polling and shared-user sync via iCloud Drive. Android continues to use WebDAV only.

- ICloudBridge.swift: add listFiles/readFile/writeFile/deleteFile/makeDir methods operating on paths relative to Documents/ in the iCloud container
- BridgeSchemeHandler.swift: add Phase 7b dispatch cases for the five new iCloud file operation bridge methods
- electron/main.ts: add iCloudDocumentsDir() helper and five new IPC handlers (icloud:list-files, read-file, write-file, delete-file, make-dir) using in-place writes to preserve iCloud xattrs
- electron/preload.ts: expose the five new IPC handlers via contextBridge
- src/intents/icloudFileTransport.js: new platform adapter that dispatches to the iOS synchronous bridge or the macOS Electron IPC layer
- src/intents/sharedUsers.js: add syncSharedUsersViaICloud() mirroring the WebDAV merge/write logic using icloudFileTransport
- src/intents/useIntentPoller.js: add _pollICloud/pollICloud, writeEventFileICloud, runIntentGCICloud; update runPoll/runGC to run iCloud ops sequentially after WebDAV; relax the early-return guard to allow iCloud-only operation
- src/intents/useNotifyEmitter.js: emit to iCloud after WebDAV emit; relax the early-return guard to allow iCloud-only emit
- src/App.jsx: call syncSharedUsersViaICloud alongside syncSharedUsers so both transports sync the user roster

https://claude.ai/code/session_01MFnu2Wu8MGFkfgVeUgHX7F