### PR TITLE
Fix blank-screen delay on Electron startup (bundle i18n translations)

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,10 +1,10 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import HttpBackend from 'i18next-http-backend';
+import en from '../public/locales/en/translation.json';
+import fr from '../public/locales/fr/translation.json';
 
 i18n
-  .use(HttpBackend)
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
@@ -12,8 +12,9 @@ i18n
     supportedLngs: ['en', 'fr'],
     ns: ['translation'],
     defaultNS: 'translation',
-    backend: {
-      loadPath: '/locales/{{lng}}/{{ns}}.json',
+    resources: {
+      en: { translation: en },
+      fr: { translation: fr },
     },
     interpolation: {
       escapeValue: false,


### PR DESCRIPTION
## Summary

The i18n infrastructure (merged in 3.1.0) used `HttpBackend` to load translation JSON files asynchronously at runtime. In the Electron build this caused a multi-second blank screen on startup while the app waited for the locale files to load before rendering.

Fix: import the translation JSON files directly and pass them as bundled `resources` to `i18n.init()`. Translations are now available synchronously at init time — no HTTP round-trip, no blank screen.

## Test plan

- [ ] Launch the macOS Electron build — confirm UI appears immediately with no blank-screen delay
- [ ] Confirm English and French translations still work correctly
- [ ] Confirm web build is unaffected

https://claude.ai/code/session_0196yak3w87eDGRnciZLkgTL

---
_Generated by [Claude Code](https://claude.ai/code/session_0196yak3w87eDGRnciZLkgTL)_