### PR TITLE
Bump Android versionCode to 112

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 111
+        versionCode = 112
         versionName = "3.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Required because versionCode 111 was already uploaded to Google Play.

https://claude.ai/code/session_0196yak3w87eDGRnciZLkgTL