### PR TITLE
Allow private/LAN IPs in proxies for self-hosted deployments

### DIFF
--- a/api/calendar-proxy.js
+++ b/api/calendar-proxy.js
@@ -10,6 +10,10 @@ function validateProxyUrl(urlString) {
     throw new Error('Only http and https URLs are allowed');
   }
 
+  // SSRF protection only applies on Vercel. Self-hosted Docker deployments need
+  // to reach calendar servers on the local network, so we skip these checks there.
+  if (!process.env.VERCEL) return parsed;
+
   const hostname = parsed.hostname.toLowerCase();
 
   if (hostname === 'localhost' || hostname === '0.0.0.0') {

--- a/api/webdav-proxy.js
+++ b/api/webdav-proxy.js
@@ -18,6 +18,10 @@ function validateProxyUrl(urlString) {
     throw new Error('Only http and https URLs are allowed');
   }
 
+  // SSRF protection only applies on Vercel. Self-hosted Docker deployments need
+  // to reach WebDAV servers on the local network, so we skip these checks there.
+  if (!process.env.VERCEL) return parsed;
+
   const hostname = parsed.hostname.toLowerCase();
 
   if (hostname === 'localhost' || hostname === '0.0.0.0') {

--- a/docker/proxy-server.js
+++ b/docker/proxy-server.js
@@ -24,39 +24,9 @@ function validateProxyUrl(urlString) {
     throw new Error('Only http and https URLs are allowed');
   }
 
-  const hostname = parsed.hostname.toLowerCase();
-
-  if (hostname === 'localhost' || hostname === '0.0.0.0') {
-    throw new Error('Private/reserved addresses are not allowed');
-  }
-
-  const ipv4 = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (ipv4) {
-    const [a, b] = [Number(ipv4[1]), Number(ipv4[2])];
-    if (
-      a === 10 ||
-      (a === 172 && b >= 16 && b <= 31) ||
-      (a === 192 && b === 168) ||
-      a === 127 ||
-      (a === 169 && b === 254) ||
-      a === 0 ||
-      (a === 100 && b >= 64 && b <= 127)
-    ) {
-      throw new Error('Private/reserved addresses are not allowed');
-    }
-  }
-
-  if (
-    hostname === '::1' ||
-    hostname === '::' ||
-    /^::ffff:/i.test(hostname) ||
-    /^fe80:/i.test(hostname) ||
-    /^fc/i.test(hostname) ||
-    /^fd/i.test(hostname)
-  ) {
-    throw new Error('Private/reserved addresses are not allowed');
-  }
-
+  // This server runs only in self-hosted Docker deployments, where users need
+  // to reach WebDAV/calendar servers on their local network. Private IP ranges
+  // are intentionally allowed here; SSRF checks are only enforced on Vercel.
   return parsed;
 }
 


### PR DESCRIPTION
## Summary

- `api/webdav-proxy.js` and `api/calendar-proxy.js`: gate the private IP SSRF checks behind `process.env.VERCEL` so they only block on Vercel deployments
- `docker/proxy-server.js`: remove private IP checks entirely — this server runs only in self-hosted Docker context where LAN access is the whole point

## Why

Self-hosters running dayGLANCE via Docker couldn't connect to WebDAV or calendar servers on their local network (e.g. Nextcloud at `192.168.x.x`) because the proxy was unconditionally rejecting private IP ranges. Vercel sets `VERCEL=1` in all its deployments, making it a reliable gate for SSRF protection that doesn't affect self-hosted users.

## Test plan

- [ ] On Vercel: verify that a request to `?url=http://192.168.1.1/dav` still returns 400 "Private/reserved addresses are not allowed"
- [ ] In Docker: verify that a request to a LAN WebDAV server (e.g. Nextcloud) proxies successfully
- [ ] Public URLs (e.g. `https://example.com/dav`) continue to work in both environments

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLRvwwVrDcwnM4kmp4X7Ek)_