### PR TITLE
Fix clipped-top cards in DAY view and recurring task user assignment

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3176,6 +3176,7 @@ const DayPlanner = () => {
               completed: false,
               notes: '',
               subtasks: [],
+              assignedUserSyncIds: mobileEditingTask.assignedUserSyncIds,
             }]);
           } else {
             setRecurringTasks(prev => prev.map(t => {
@@ -3191,6 +3192,7 @@ const DayPlanner = () => {
                       duration: newTask.duration,
                       isAllDay: newTask.isAllDay || false,
                       color: newTask.color || colors[0].class,
+                      assignedUserSyncIds: mobileEditingTask.assignedUserSyncIds,
                     }
                   }
                 };
@@ -3220,6 +3222,7 @@ const DayPlanner = () => {
         recurrence: { ...newTask.recurrence, startDate: taskDate },
         completedDates: existingTask?.completed ? [taskDate] : [],
         exceptions: {},
+        assignedUserSyncIds: newTask.assignedUserSyncIds || existingTask?.assignedUserSyncIds,
         lastModified: new Date().toISOString()
       };
       setTasks(prev => prev.filter(t => t.id !== taskId));
@@ -5979,6 +5982,7 @@ const DayPlanner = () => {
           color: exception?.color ?? template.color,
           completed,
           isAllDay: exception?.isAllDay ?? template.isAllDay ?? false,
+          assignedUserSyncIds: exception?.assignedUserSyncIds ?? template.assignedUserSyncIds,
           notes: template.notes || '',
           subtasks: template.subtasks || [],
           date: dateStr,

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -30,7 +30,6 @@ function getTaskSlice(task, col, hourHeight, timeToMinutes) {
     height: Math.max(27, rawH),
     clippedTop: taskStart < colStart,
     clippedBottom: taskEnd > colEnd,
-    showTitle: taskStart >= colStart,
   };
 }
 
@@ -355,7 +354,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             const slice = getTaskSlice(task, col, hourHeight, timeToMinutes);
             if (!slice) return null;
 
-            const { top, height, clippedTop, clippedBottom, showTitle } = slice;
+            const { top, height, clippedTop, clippedBottom } = slice;
             const { left, width } = columnConflictPos(task, colTasks, timeToMinutes);
 
             const isImported = task.imported;
@@ -420,14 +419,12 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                     <ChevronUp size={12} className="text-white/70" />
                   </div>
                 )}
-                {showTitle && (
-                  <TimelineTaskCardContent
-                    task={task}
-                    height={height}
-                    isNarrowWidth={false}
-                    flipNotesPanel={(8 * hourHeight) - (top + height) < 200}
-                  />
-                )}
+                <TimelineTaskCardContent
+                  task={task}
+                  height={height}
+                  isNarrowWidth={false}
+                  flipNotesPanel={(8 * hourHeight) - (top + height) < 200}
+                />
                 {clippedBottom && (
                   <div className="absolute bottom-0 left-0 right-0 flex justify-center pointer-events-none">
                     <ChevronDown size={12} className="text-white/70" />


### PR DESCRIPTION
## Summary

Two independent bug fixes.

### 1. DAY view — title/buttons hidden on top-clipped cards (rolling 24h)

When a task starts before the leftmost column's start hour, `getTaskSlice` positions the card at `top: 0` within the column — meaning the content _is_ visually at the top of the visible area. However, `showTitle: false` was suppressing `TimelineTaskCardContent` entirely, leaving only a `ChevronUp` indicator and blank space.

Fix: remove the `showTitle` guard and always render `TimelineTaskCardContent`. Since `height` is already clamped to the visible slice, the content fits naturally and the title/buttons appear at the top of the visible card. Also removed the now-dead `showTitle` field from `getTaskSlice`'s return value.

### 2. Recurring tasks — user assignment was a no-op

The Edit Chore modal collects `assignedUserSyncIds` from the UI, but it was never written anywhere in the recurring-task save path, and never propagated into expanded instances. Four places fixed:

- **Exception update** (editing a single occurrence): `assignedUserSyncIds` now written into the per-date exception object
- **Date-change one-off task**: carried into the newly created regular task
- **Template creation** (converting regular → recurring): `assignedUserSyncIds` now included on the template
- **Instance expansion** (`expandedRecurringTasks` memo): `exception?.assignedUserSyncIds ?? template.assignedUserSyncIds` now propagated so cards and user-assignment badges reflect the value

## Test plan

- [ ] DAY view, rolling 24h: create a task that straddles the top of the leftmost column — title and action buttons should be visible at the top of the card
- [ ] Multi-user: assign a user to a recurring task instance — the badge should appear on the card and persist after reload
- [ ] Multi-user: assign a user, then convert a regular task to recurring — assignment should carry over to the template
- [ ] Multi-user: assign a user to a recurring instance whose date is changed — the resulting one-off task should carry the assignment

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLRvwwVrDcwnM4kmp4X7Ek)_