### PR TITLE
fix: crash when adding a project (t is not defined)

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -316,6 +316,7 @@ const HG_ICON_MAP = {
 export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, mobile }) => {
   const { darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg, tasks, unscheduledTasks, use24HourClock, isMobile, isTablet } =
     useDayPlannerCtx();
+  const { t } = useTranslation();
 
   const [title, setTitle] = useState(initial?.title || '');
   const [description, setDescription] = useState(initial?.description || '');


### PR DESCRIPTION
## Summary

- `ProjectForm` in `GoalDashboard.jsx` used `t('common.titleRequired')` and `t('goals.goalOptional')` for two field labels, but never called `useTranslation()` to obtain `t`
- This caused a `ReferenceError: t is not defined` crash whenever the Add Project form was opened

## Fix

Added `const { t } = useTranslation();` inside `ProjectForm`, right after the existing `useDayPlannerCtx()` call.

## Test plan

- [ ] Open the Goals/Projects dashboard
- [ ] Click "Add Project" — form should open without crashing
- [ ] Confirm the "Title (required)" and "Goal (optional)" labels render correctly
- [ ] Save a new project and confirm it appears in the list

https://claude.ai/code/session_01GDXmTCyKqmEYsJu4htju9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDXmTCyKqmEYsJu4htju9K)_