### PR TITLE
Fix mobile LIST view inbox drawer to match Inbox tab filters

### DIFF
--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -684,6 +684,7 @@ const MobileListView = ({ hideInboxHandle = false }) => {
     setExpandedNotesTaskId,
     pushUndo, playUISound,
     listEndOfDayTime,
+    filteredUnscheduledTasks,
   } = useDayPlannerCtx();
   const { t } = useTranslation();
 
@@ -808,10 +809,10 @@ const MobileListView = ({ hideInboxHandle = false }) => {
     });
   }, [futureItems, routineCompletions, nowMin, timeToMinutes]);
 
-  // Inbox tasks
+  // Inbox tasks — mirror the same filtered/sorted list shown in the Inbox tab
   const inboxTasks = useMemo(() =>
-    unscheduledTasks.filter(t => !t.isExample && !t.completed),
-    [unscheduledTasks],
+    filteredUnscheduledTasks.filter(t => !t.isExample),
+    [filteredUnscheduledTasks],
   );
 
   // ── Conflict helpers ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- The inbox mini-card drawer in mobile LIST view was computing its own unfiltered task list (all unscheduled, non-example, non-completed tasks), ignoring any active filters.
- Now uses `filteredUnscheduledTasks` from context, so the drawer always shows the same tasks in the same order as the Inbox tab — respecting project visibility, priority, tag, and hide-completed filters.

## Test plan

- [ ] Open the app on mobile in LIST view
- [ ] Tap the inbox handle to expand the drawer — verify it shows the same tasks as the Inbox tab
- [ ] Apply an inbox filter (e.g. hide project tasks, filter by tag, or filter by priority) — verify the drawer updates to match
- [ ] Toggle "hide completed" in inbox filters — verify completed tasks appear/disappear consistently in both places

https://claude.ai/code/session_01XyAvsSMBpiLHCH4DmG54tX

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyAvsSMBpiLHCH4DmG54tX)_