### PR TITLE
fix: remove duplicate typo key 'pomoroCycles' from all locales

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -479,7 +479,6 @@
     "sessionComplete": "Sitzung abgeschlossen!",
     "totalTime": "Gesamtzeit",
     "tasksCompleted": "Abgeschlossene Aufgaben",
-    "pomoroCycles": "Pomodoro-Zyklen",
     "sessionElapsed": "Sitzung: {{minutes}} Min verstrichen",
     "breakLabel": "Pause",
     "pomodoroTimer": "Pomodoro-Timer",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -479,7 +479,6 @@
     "sessionComplete": "Session Complete!",
     "totalTime": "Total time",
     "tasksCompleted": "Tasks completed",
-    "pomoroCycles": "Pomodoro cycles",
     "sessionElapsed": "Session: {{minutes}}m elapsed",
     "breakLabel": "Break",
     "pomodoroTimer": "Pomodoro Timer",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -479,7 +479,6 @@
     "sessionComplete": "¡Sesión completada!",
     "totalTime": "Tiempo total",
     "tasksCompleted": "Tareas completadas",
-    "pomoroCycles": "Ciclos Pomodoro",
     "sessionElapsed": "Sesión: {{minutes}} min transcurridos",
     "breakLabel": "Descanso",
     "pomodoroTimer": "Temporizador Pomodoro",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -479,7 +479,6 @@
     "sessionComplete": "Session terminée !",
     "totalTime": "Durée totale",
     "tasksCompleted": "Tâches terminées",
-    "pomoroCycles": "Cycles Pomodoro",
     "sessionElapsed": "Session : {{minutes}} min écoulées",
     "breakLabel": "Pause",
     "pomodoroTimer": "Minuteur Pomodoro",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -479,7 +479,6 @@
     "sessionComplete": "Sessione completata!",
     "totalTime": "Tempo totale",
     "tasksCompleted": "Attività completate",
-    "pomoroCycles": "Cicli Pomodoro",
     "sessionElapsed": "Sessione: {{minutes}} min trascorsi",
     "breakLabel": "Pausa",
     "pomodoroTimer": "Timer Pomodoro",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -479,7 +479,6 @@
     "sessionComplete": "Sessão concluída!",
     "totalTime": "Tempo total",
     "tasksCompleted": "Tarefas concluídas",
-    "pomoroCycles": "Ciclos Pomodoro",
     "sessionElapsed": "Sessão: {{minutes}} min decorridos",
     "breakLabel": "Pausa",
     "pomodoroTimer": "Temporizador Pomodoro",

--- a/src/components/FocusModeModal.jsx
+++ b/src/components/FocusModeModal.jsx
@@ -225,7 +225,7 @@ const FocusModeModal = () => {
               <span className="text-white font-medium">{focusCompletedTasks.size}</span>
             </div>
             <div className="flex justify-between bg-gray-800 rounded-lg px-4 py-3">
-              <span className="text-gray-400">{t('focus.pomoroCycles')}</span>
+              <span className="text-gray-400">{t('focus.pomodoroCycles')}</span>
               <span className="text-white font-medium">{focusCycleCount}</span>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- `FocusModeModal` was referencing `focus.pomoroCycles` (typo), while `HyperGlanceModeModal` was already using the correct `focus.pomodoroCycles`. Both keys existed as duplicates with identical translations in all 6 locale files.
- The typo was introduced in the i18n extraction commit (#189a11f) — pre-i18n, `FocusModeModal` had the hardcoded string `"Pomodoro cycles"`, same as the correct key.
- Updated `FocusModeModal` to use `pomodoroCycles`, removed the `pomoroCycles` key from all 6 locale files (en, fr, de, es, it, pt).

## Test plan

- [ ] Open Focus Mode, complete at least one Pomodoro cycle — verify "Pomodoro cycles" label appears correctly in the session summary
- [ ] Open hyperGLANCE mode, complete a cycle — verify the same label still appears correctly

https://claude.ai/code/session_01WQ4LYponzAHgneP8hZr3W8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQ4LYponzAHgneP8hZr3W8)_