### PR TITLE
chore: bump version to 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.1.2-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.2.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 114
-        versionName = "3.1"
+        versionCode = 115
+        versionName = "3.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.1.2",
+  "version": "3.2.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- `package.json`: `3.1.2` → `3.2.0`
- `package-lock.json`: updated to match
- `dayglance-android/app/build.gradle.kts`: `versionCode 114 / "3.1"` → `versionCode 115 / "3.2"`
- `README.md`: version badge updated to `3.2.0`

https://claude.ai/code/session_01WQ4LYponzAHgneP8hZr3W8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQ4LYponzAHgneP8hZr3W8)_