### PR TITLE
Stamp lastModified on recurring template subtask mutations

### DIFF
--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -81,7 +81,7 @@ export default function useTaskActions({
   const updateRecurringTemplate = (taskId, updater) => {
     const parsed = parseRecurringId(taskId);
     if (parsed) {
-      setRecurringTasks(prev => prev.map(t => t.id === parsed.templateId ? updater(t) : t));
+      setRecurringTasks(prev => prev.map(t => t.id === parsed.templateId ? { ...updater(t), lastModified: new Date().toISOString() } : t));
     }
   };
 


### PR DESCRIPTION
## Summary

- `updateRecurringTemplate` was the only recurring-template write path missing a `lastModified` stamp
- Subtask adds, edits, toggles, and deletes on recurring templates were therefore invisible to the sync merge tiebreaker
- Fixed by stamping `lastModified: new Date().toISOString()` centrally inside the helper (`useTaskActions.js:84`), so all four subtask callers inherit it automatically — no call-site changes needed

## Test plan

- [ ] Add a subtask to a recurring task template; confirm the template's `lastModified` advances
- [ ] Edit, toggle, and delete a subtask on a recurring template; confirm `lastModified` advances on each mutation
- [ ] Verify existing recurring mutations (color, notes, completedDates, reschedule, delete-instance) are unaffected
- [ ] Sync two devices where one edits a recurring template's subtasks; confirm the change wins on the other device

https://claude.ai/code/session_01LqoKTfyq4PU4y8tNPwHDQo

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqoKTfyq4PU4y8tNPwHDQo)_