### PR TITLE
Bump DayGlanceWidget deployment target to iOS 17.0

### DIFF
--- a/dayglance-ios/project.yml
+++ b/dayglance-ios/project.yml
@@ -123,7 +123,7 @@ targets:
   DayGlanceWidget:
     type: app-extension
     platform: iOS
-    deploymentTarget: "16.0"
+    deploymentTarget: "17.0"
     sources:
       - path: DayGlanceWidget
     entitlements:


### PR DESCRIPTION
containerBackground(_:for:), ForegroundContinuableIntent, and the AppIntent types used throughout the widget require iOS 17. The 16.0 target caused build errors on all three widget files.

https://claude.ai/code/session_015KfmSar4UiWSH8J5DqYxQw