### PR TITLE
Declare non-exempt encryption in Info.plist to skip App Store Connect…

### DIFF
--- a/dayglance-ios/DayGlance/Info.plist
+++ b/dayglance-ios/DayGlance/Info.plist
@@ -57,5 +57,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
… prompt

Adds ITSAppUsesNonExemptEncryption=true so Apple's processing pipeline no longer blocks TestFlight builds waiting for manual export compliance answers. The app uses standard encryption (HTTPS, RevenueCat, HMAC-SHA256).

https://claude.ai/code/session_018RsGGgMdbMxsA3GFGoS5Y4