### PR TITLE
Improve Koofr 403 error message for hosted vs self-hosted context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.2.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "^1.1.2",
+        "@glance-apps/sync": "^1.1.3",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -2267,9 +2267,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.2.tgz",
-      "integrity": "sha512-BlfzcgyVLz+3xdWWa1f+oin0p3fJTmCuCprurRX+CaOpr366eCrTKa4DR0Z3EaoHmXS/qck/WM0qYz0EbjPzCg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.3.tgz",
+      "integrity": "sha512-tvtaGlRFILVwX+6LG29omq2e1SCuegLQsfo3kpZwCSgwivE7TNZLE6Hnh88CZdcnUerdKHFQn0LsWbz/8uqoJA==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "^1.1.2",
+    "@glance-apps/sync": "^1.1.3",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/src/utils/cloudSyncProviders.js
+++ b/src/utils/cloudSyncProviders.js
@@ -24,6 +24,10 @@ const dayGlanceEngineConfig = {
       ? (...args) => window.electronAPI.proxyFetch(...args)
       : null,
 
+  isHostedApp:
+    typeof window !== 'undefined' &&
+    /(^|\.)(?:dayglance|lifeglance|lastglance)\.app$/.test(window.location.hostname),
+
   // Relative URL → proxy runs at the same origin as the app.
   proxyUrl: import.meta.env.VITE_WEBDAV_PROXY_URL ?? '',
 


### PR DESCRIPTION
## Summary

- Bumps `@glance-apps/sync` to 1.1.3, which splits the Koofr 403 error into two context-aware messages
- Adds `isHostedApp` to the dayGLANCE engine config in `cloudSyncProviders.js` — true when running on dayglance.app, lifeglance.app, or lastglance.app
- Hosted-app users now see a message explaining the Koofr IP block and pointing to self-hosting or the Android app; self-hosted users see a generic proxy-blocking message instead

Closes #966

---
_Generated by [Claude Code](https://claude.ai/code/session_0154gs1V7ztwHf6JG5fKenUE)_