### PR TITLE
Fix phantom recurring calendar events from moved/cancelled instances

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3842,6 +3842,7 @@ const DayPlanner = () => {
       }
     }
     const events = [];
+    const overrides = []; // VEVENT RECURRENCE-ID single-instance exceptions (moved/cancelled)
     let currentEvent = null;
     let currentType = null; // 'event' or 'todo'
 
@@ -3860,11 +3861,17 @@ const DayPlanner = () => {
           currentEvent.dtstart = currentEvent.due;
           currentEvent.isAllDay = currentEvent.dueIsAllDay;
         }
-        // Skip RECURRENCE-ID overrides — these are individual-instance exceptions
-        // (e.g. a single completed occurrence of a recurring VTODO). The master RRULE
-        // expansion already generates dates for each occurrence, and completion state
-        // is tracked locally via completedTaskUids.
-        if (currentEvent.summary && currentEvent.dtstart && !currentEvent.isRecurrenceOverride) {
+        // RECURRENCE-ID overrides modify (move/cancel) a single occurrence of a
+        // recurring series. For VTODOs we keep the long-standing behaviour of
+        // dropping them — completion is tracked locally via completedTaskUids.
+        // For VEVENTs we must NOT drop them blindly: moving or cancelling one
+        // instance does not add an EXDATE to the master, so ignoring the override
+        // leaves a phantom occurrence at the original slot. Collect VEVENT overrides
+        // so expansion can suppress the master occurrence and re-place (or cancel) it.
+        const isCancelled = currentType === 'event' && currentEvent.status === 'CANCELLED';
+        if (currentType === 'event' && currentEvent.isRecurrenceOverride && currentEvent.recurrenceId && currentEvent.uid) {
+          overrides.push(currentEvent);
+        } else if (currentEvent.summary && currentEvent.dtstart && !currentEvent.isRecurrenceOverride && !isCancelled) {
           events.push(currentEvent);
         }
         currentEvent = null;
@@ -3914,6 +3921,13 @@ const DayPlanner = () => {
           }
         } else if (line.startsWith('RECURRENCE-ID')) {
           currentEvent.isRecurrenceOverride = true;
+          // Capture the value (the original occurrence this override replaces),
+          // handling parameters like RECURRENCE-ID;TZID=...:20260101T090000.
+          const colonIdx = line.indexOf(':');
+          if (colonIdx !== -1) currentEvent.recurrenceId = line.substring(colonIdx + 1).trim();
+        } else if (line.startsWith('STATUS')) {
+          const colonIdx = line.indexOf(':');
+          if (colonIdx !== -1) currentEvent.status = line.substring(colonIdx + 1).trim().toUpperCase();
         } else if (line.startsWith('RRULE:')) {
           currentEvent.rrule = line.substring(6);
         } else if (line.startsWith('EXDATE')) {
@@ -3933,10 +3947,31 @@ const DayPlanner = () => {
     const curYear = new Date().getFullYear();
     const expandedEvents = [];
 
+    // Index VEVENT RECURRENCE-ID overrides by their series UID. Each override
+    // suppresses the master's generated occurrence at the original slot (an
+    // implicit EXDATE) and — unless STATUS:CANCELLED — is re-emitted at its new
+    // DTSTART. Matching is date-level to mirror the EXDATE handling below.
+    const overrideDatesByUid = {};
+    const overrideEventsByUid = {};
+    for (const ov of overrides) {
+      if (!overrideDatesByUid[ov.uid]) overrideDatesByUid[ov.uid] = [];
+      overrideDatesByUid[ov.uid].push(ov.recurrenceId.substring(0, 8));
+      if (ov.status !== 'CANCELLED' && ov.summary && ov.dtstart) {
+        if (!overrideEventsByUid[ov.uid]) overrideEventsByUid[ov.uid] = [];
+        overrideEventsByUid[ov.uid].push(ov);
+      }
+    }
+
     for (const event of events) {
       if (!event.rrule) {
         expandedEvents.push(event);
         continue;
+      }
+
+      // Fold this series' RECURRENCE-ID override dates into its EXDATE set so the
+      // master never emits a phantom occurrence at a moved or cancelled slot.
+      if (event.uid && overrideDatesByUid[event.uid]) {
+        event.exdates = [...(event.exdates || []), ...overrideDatesByUid[event.uid]];
       }
 
       const rule = {};
@@ -4109,6 +4144,14 @@ const DayPlanner = () => {
       } else {
         // Unsupported frequency — keep the original event
         expandedEvents.push(event);
+      }
+    }
+
+    // Append the moved/modified single instances at their new DTSTART. Cancelled
+    // overrides were excluded above and intentionally produce no event.
+    for (const uid of Object.keys(overrideEventsByUid)) {
+      for (const ov of overrideEventsByUid[uid]) {
+        expandedEvents.push({ ...ov, rrule: undefined });
       }
     }
 


### PR DESCRIPTION
## Problem

CalDAV recurring **events** (VEVENTs) left ghost occurrences at their original slot after a single instance was moved or cancelled:

- `parseICS` discarded **every** `RECURRENCE-ID` override (the component a calendar server emits to move/modify one occurrence of a series).
- Moving an instance does **not** add an `EXDATE` to the master RRULE, so with the override dropped nothing suppressed the original-slot occurrence → phantom at the old time/date, and the moved instance never appeared at its new slot.
- Cancellations delivered as a `RECURRENCE-ID` + `STATUS:CANCELLED` override (common with iCloud/Exchange/CalDAV iTIP `CANCEL`) were likewise dropped, and `parseICS` never read `STATUS` at all → cancelled occurrence still showed.

This is purely local to the ICS parser / RRULE expansion — independent of cloud sync.

## Fix

`parseICS` now handles VEVENT single-instance overrides correctly:

- `RECURRENCE-ID` overrides are collected separately (value captured, not just a boolean flag), and `STATUS` is now parsed.
- Each override's `RECURRENCE-ID` date is folded into the master series' `EXDATE` set, so the master no longer emits a phantom occurrence at a moved/cancelled slot.
- Moved/modified instances are re-emitted at their new `DTSTART`, unless `STATUS:CANCELLED` (in which case they produce no event).
- Standalone events marked `STATUS:CANCELLED` are skipped.
- VTODO override handling is **unchanged**, so task-calendar completion sync (which relies on dropping VTODO `RECURRENCE-ID` overrides) is unaffected.

## Scenarios covered

- Moved instance → no phantom at old slot, event shows at new slot.
- Cancelled instance (override + `STATUS:CANCELLED`) → occurrence suppressed, nothing re-emitted.
- Whole event/series cancelled (`STATUS:CANCELLED`, no `RECURRENCE-ID`) → skipped.
- VTODO overrides → dropped as before (task-calendar path untouched).

## Testing

- `vitest run` — 237 tests passing.
- `vite build` — succeeds.
- `parseICS` is an un-exported closure in `App.jsx` with no automated coverage; scenarios above were validated by manual trace. Follow-up candidate: extract the ICS parser to `src/utils/icsParser.js` and add recurrence unit tests (flagged in CLAUDE.md).

## Known follow-ups (not in this PR)

- `EXDATE` timezone edge: UTC `EXDATE` values are truncated to their UTC date and compared against locally-computed occurrence dates, so an evening event in a negative-UTC-offset zone can fail to match. Same symptom family, distinct timezone-conversion change.
- Separate CalDAV **task** (VTODO) resurrection bug via cloud sync — being scoped separately.

https://claude.ai/code/session_01M1UFnrwA2Wu784geseAgro

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1UFnrwA2Wu784geseAgro)_