### PR TITLE
Tombstone deleted CalDAV tasks so cloud sync stops resurrecting them

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { webdavFetch } from './utils/cloudSyncProviders.js';
 import { autoBackupDB, createAutoBackupProvidersForFolder, AUTO_BACKUP_RETENTION, AUTO_BACKUP_INTERVALS } from './utils/autoBackup.js';
 import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOnlyTask, getLinkUrl, hasOnlySubtasks, renderTitle, highlightMatch, renderTitleWithoutTags, extractShareTitle } from './utils/textFormatting.jsx';
-import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate } from './utils/taskUtils.js';
+import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate, computeTaskCalendarTombstones } from './utils/taskUtils.js';
 import { TASK_COLORS, TAILWIND_TO_HEX, taskColorToHex } from './utils/colorUtils.js';
 import { calculateGoalProgress } from './utils/goalProgress.js';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from './constants/habits.js';
@@ -4689,6 +4689,24 @@ const DayPlanner = () => {
         expandMultiDayEvent(event, { asTaskCalendar: true, freshCompletedUids })
       );
       const taskCalendarItems = filterByDateWindow(allTaskItems, syncRetentionDays);
+
+      // Tombstone non-recurring task-calendar items that vanished from the feed
+      // (deleted/moved on the server). Without a tombstone the cloud merge treats
+      // the still-present remote copy as a "remote-only" item and resurrects it.
+      // Diff against the unwindowed expansion so an item merely aged past the
+      // retention window isn't mistaken for a deletion. computeTaskCalendarTombstones
+      // returns [] for an empty feed (likely a transient glitch, not a real wipe).
+      const tombstoneCutoffStr = syncRetentionDays > 0
+        ? dateToString(new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - syncRetentionDays))
+        : null;
+      const priorTasksSnapshot = JSON.parse(localStorage.getItem('day-planner-tasks') || '[]');
+      const tombstoneIds = computeTaskCalendarTombstones(priorTasksSnapshot, allTaskItems, { cutoffDateStr: tombstoneCutoffStr });
+      if (tombstoneIds.length > 0) {
+        const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}');
+        const nowIso = new Date().toISOString();
+        for (const id of tombstoneIds) tombstones[id] = nowIso;
+        localStorage.setItem('day-planner-deleted-task-ids', JSON.stringify(tombstones));
+      }
 
       // Remove old sync-sourced task calendar items and add the fresh ones
       // Preserves file-imported task calendar items; uses functional form to avoid stale closures

--- a/src/utils/taskUtils.js
+++ b/src/utils/taskUtils.js
@@ -120,3 +120,36 @@ export const formatDeadlineDate = (deadline) => {
   const date = new Date(deadline + 'T12:00:00');
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 };
+
+// Determine which previously-imported CalDAV task-calendar items have disappeared
+// from the latest fetch and should be tombstoned so the deletion propagates via
+// cloud sync (instead of being resurrected from the remote sync file).
+//
+// Scope (v1): non-recurring task-calendar items only. Recurring series are left to
+// the existing wholesale-replace behaviour because normal occurrence advancement
+// (completing an instance rolls the due date forward) would otherwise be mistaken
+// for a deletion and churn tombstones.
+//
+// Safety: returns [] when the fresh feed is empty — an empty-but-valid calendar is
+// far more likely a transient server/auth glitch than a real "everything deleted",
+// and tombstoning on it would wipe the task calendar across all synced devices.
+//
+//   priorTasks      - tasks from the local snapshot before replacement (any shape)
+//   freshTaskItems  - the full (pre-date-window) expansion of the latest fetch
+//   cutoffDateStr   - YYYY-MM-DD retention cutoff; items dated before it are skipped
+//                     (they won't re-import anyway). null = no window (keep all).
+// Returns: array of task ids (strings) to tombstone.
+export const computeTaskCalendarTombstones = (priorTasks, freshTaskItems, { cutoffDateStr = null } = {}) => {
+  if (!Array.isArray(freshTaskItems) || freshTaskItems.length === 0) return [];
+  if (!Array.isArray(priorTasks) || priorTasks.length === 0) return [];
+  const freshIds = new Set(freshTaskItems.map(t => String(t.id)));
+  return priorTasks
+    .filter(t =>
+      t.isTaskCalendar &&
+      t.importSource !== 'file' &&
+      !t.isRecurringSeries &&
+      !freshIds.has(String(t.id)) &&
+      (!cutoffDateStr || (t.date && t.date >= cutoffDateStr))
+    )
+    .map(t => String(t.id));
+};

--- a/src/utils/taskUtils.test.js
+++ b/src/utils/taskUtils.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { computeTaskCalendarTombstones } from './taskUtils.js';
+
+// A synced (non-file) CalDAV task-calendar item as produced by expandMultiDayEvent.
+const tcItem = (id, date, extra = {}) => ({
+  id,
+  date,
+  isTaskCalendar: true,
+  imported: true,
+  importSource: 'sync',
+  ...extra,
+});
+
+describe('computeTaskCalendarTombstones', () => {
+  it('tombstones a non-recurring item that disappeared from the feed', () => {
+    const prior = [tcItem('uid-a-2026-06-10', '2026-06-10'), tcItem('uid-b-2026-06-11', '2026-06-11')];
+    const fresh = [tcItem('uid-a-2026-06-10', '2026-06-10')]; // uid-b deleted on server
+    expect(computeTaskCalendarTombstones(prior, fresh)).toEqual(['uid-b-2026-06-11']);
+  });
+
+  it('returns [] when every prior item is still present', () => {
+    const prior = [tcItem('uid-a-2026-06-10', '2026-06-10')];
+    const fresh = [tcItem('uid-a-2026-06-10', '2026-06-10')];
+    expect(computeTaskCalendarTombstones(prior, fresh)).toEqual([]);
+  });
+
+  it('treats a moved item (new date => new id) as a deletion of the old id', () => {
+    const prior = [tcItem('uid-a-2026-06-10', '2026-06-10')];
+    const fresh = [tcItem('uid-a-2026-06-12', '2026-06-12')]; // same VTODO, moved
+    expect(computeTaskCalendarTombstones(prior, fresh)).toEqual(['uid-a-2026-06-10']);
+  });
+
+  it('skips tombstoning entirely when the fresh feed is empty (transient-glitch guard)', () => {
+    const prior = [tcItem('uid-a-2026-06-10', '2026-06-10'), tcItem('uid-b-2026-06-11', '2026-06-11')];
+    expect(computeTaskCalendarTombstones(prior, [])).toEqual([]);
+  });
+
+  it('never tombstones recurring-series items (v1 scope)', () => {
+    const prior = [tcItem('uid-r-2026-06-10', '2026-06-10', { isRecurringSeries: true })];
+    const fresh = [tcItem('uid-other-2026-06-10', '2026-06-10')]; // recurring occurrence not in fresh
+    expect(computeTaskCalendarTombstones(prior, fresh)).toEqual([]);
+  });
+
+  it('ignores non-task-calendar tasks and file imports', () => {
+    const prior = [
+      { id: 'regular-1', date: '2026-06-10' }, // user task
+      tcItem('file-1', '2026-06-10', { importSource: 'file' }), // ICS file import
+      tcItem('read-only-1', '2026-06-10', { isTaskCalendar: false }), // read-only calendar event
+    ];
+    const fresh = [tcItem('something-else', '2026-06-10')];
+    expect(computeTaskCalendarTombstones(prior, fresh)).toEqual([]);
+  });
+
+  it('only tombstones items within the retention window', () => {
+    const prior = [
+      tcItem('uid-old-2026-01-01', '2026-01-01'), // before cutoff
+      tcItem('uid-new-2026-06-10', '2026-06-10'), // within window
+    ];
+    const fresh = [tcItem('uid-keep-2026-06-09', '2026-06-09')]; // both prior items gone
+    const result = computeTaskCalendarTombstones(prior, fresh, { cutoffDateStr: '2026-05-13' });
+    expect(result).toEqual(['uid-new-2026-06-10']);
+  });
+
+  it('considers all items when no cutoff is given', () => {
+    const prior = [tcItem('uid-old-2020-01-01', '2020-01-01')];
+    const fresh = [tcItem('uid-other', '2026-06-10')];
+    expect(computeTaskCalendarTombstones(prior, fresh, { cutoffDateStr: null })).toEqual(['uid-old-2020-01-01']);
+  });
+
+  it('handles empty/invalid prior input gracefully', () => {
+    expect(computeTaskCalendarTombstones([], [tcItem('a', '2026-06-10')])).toEqual([]);
+    expect(computeTaskCalendarTombstones(null, [tcItem('a', '2026-06-10')])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Non-recurring CalDAV task-calendar items (VTODOs) are uploaded to the cloud sync file as first-class tasks (the ephemeral-import filter intentionally excludes `isTaskCalendar`), but `syncTaskCalendar` drops them from local state via wholesale replacement **without recording a tombstone**.

So when a task is deleted or moved on the CalDAV server:
1. The next `syncTaskCalendar` removes it from local state.
2. But the remote sync file still holds it, and with no tombstone the merge (`mergeArrayById`) treats it as a "remote-only" addition and **resurrects** it — then re-uploads it, so it never clears.

## Fix

`syncTaskCalendar` now diffs the fresh feed against the prior local snapshot and writes a tombstone (`day-planner-deleted-task-ids`) for any **non-recurring** task-calendar item that disappeared. The deletion then propagates through the existing merge/upload path instead of bouncing back. No new sync plumbing — `buildSyncPayload` already reads that key and `mergeSyncData` already honors it.

The diff logic is extracted to a pure, unit-tested helper `computeTaskCalendarTombstones` in `taskUtils.js`.

## Guardrails

- **Non-recurring only (v1).** Recurring series are left on the existing wholesale-replace behavior. Nextcloud doesn't support `RECURRENCE-ID` overrides for VTODOs (nextcloud/tasks#2276), so completion advances the master `DUE`/`DTSTART` in place while keeping the `RRULE` (`syncTaskCompletionToCalDAV`, `App.jsx`). That makes occurrences legitimately churn every cycle, so they must not be tombstoned. RRULE-expanded occurrences carry `isRecurringSeries: true` and are excluded.
- **Window-aware diff.** Diffs against the pre-`filterByDateWindow` expansion, so an item merely aged past the retention window isn't mistaken for a deletion.
- **Empty-feed safety.** An empty-but-valid feed produces no tombstones — treated as a likely transient server/auth glitch rather than a real "everything deleted" (which would otherwise wipe the task calendar across all synced devices).
- **`completedTaskUids` untouched**, so completion history survives a legitimate re-import.

## Testing

- New `src/utils/taskUtils.test.js` — 9 cases covering: deleted item, moved item (new id), all-present no-op, empty-feed guard, recurring exclusion, non-task-calendar/file-import exclusion, retention-window filtering, and empty/invalid input.
- Full suite: 246 tests passing. `vite build` succeeds.

## Scope / follow-ups (not in this PR)

- Recurring VTODO deletions (would need `icalUid`-level diffing so completion advancement isn't read as a delete).
- This is independent of the recurring-**event** phantom fix in #977.

https://claude.ai/code/session_01M1UFnrwA2Wu784geseAgro

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1UFnrwA2Wu784geseAgro)_