### PR TITLE
Tombstone deleted recurring CalDAV task series so sync stops resurrecting them

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { webdavFetch } from './utils/cloudSyncProviders.js';
 import { autoBackupDB, createAutoBackupProvidersForFolder, AUTO_BACKUP_RETENTION, AUTO_BACKUP_INTERVALS } from './utils/autoBackup.js';
 import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOnlyTask, getLinkUrl, hasOnlySubtasks, renderTitle, highlightMatch, renderTitleWithoutTags, extractShareTitle } from './utils/textFormatting.jsx';
-import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate, computeTaskCalendarTombstones } from './utils/taskUtils.js';
+import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate, computeTaskCalendarTombstones, computeRecurringSeriesTombstones } from './utils/taskUtils.js';
 import { TASK_COLORS, TAILWIND_TO_HEX, taskColorToHex } from './utils/colorUtils.js';
 import { calculateGoalProgress } from './utils/goalProgress.js';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from './constants/habits.js';
@@ -4155,6 +4155,15 @@ const DayPlanner = () => {
       }
     }
 
+    // Surface the set of master UIDs present in the raw feed (pre-expansion) so
+    // callers can detect deleted recurring series. A live series can expand to zero
+    // in-window occurrences, so its UID would be missing from expandedEvents — but
+    // it is still here, in `events`, which is the authoritative "exists on server"
+    // signal. Non-enumerable so it doesn't disturb callers that iterate the array.
+    Object.defineProperty(expandedEvents, 'masterUids', {
+      value: new Set(events.map(e => e.uid).filter(Boolean).map(String)),
+      enumerable: false,
+    });
     return expandedEvents;
   };
 
@@ -4733,17 +4742,23 @@ const DayPlanner = () => {
       );
       const taskCalendarItems = filterByDateWindow(allTaskItems, syncRetentionDays);
 
-      // Tombstone non-recurring task-calendar items that vanished from the feed
-      // (deleted/moved on the server). Without a tombstone the cloud merge treats
-      // the still-present remote copy as a "remote-only" item and resurrects it.
-      // Diff against the unwindowed expansion so an item merely aged past the
-      // retention window isn't mistaken for a deletion. computeTaskCalendarTombstones
-      // returns [] for an empty feed (likely a transient glitch, not a real wipe).
+      // Tombstone task-calendar items that vanished from the feed (deleted/moved on
+      // the server). Without a tombstone the cloud merge treats the still-present
+      // remote copy as a "remote-only" item and resurrects it. Both helpers return
+      // [] for an empty feed (likely a transient glitch, not a real wipe).
+      //   - Non-recurring: diff occurrence ids against the unwindowed expansion, so
+      //     an item merely aged past the retention window isn't mistaken for a delete.
+      //   - Recurring: diff at the series level by master UID against the raw feed
+      //     (events.masterUids), so normal occurrence advancement — and live series
+      //     that expand to zero in-window occurrences — aren't mistaken for deletes.
       const tombstoneCutoffStr = syncRetentionDays > 0
         ? dateToString(new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - syncRetentionDays))
         : null;
       const priorTasksSnapshot = JSON.parse(localStorage.getItem('day-planner-tasks') || '[]');
-      const tombstoneIds = computeTaskCalendarTombstones(priorTasksSnapshot, allTaskItems, { cutoffDateStr: tombstoneCutoffStr });
+      const tombstoneIds = [
+        ...computeTaskCalendarTombstones(priorTasksSnapshot, allTaskItems, { cutoffDateStr: tombstoneCutoffStr }),
+        ...computeRecurringSeriesTombstones(priorTasksSnapshot, events.masterUids, { cutoffDateStr: tombstoneCutoffStr }),
+      ];
       if (tombstoneIds.length > 0) {
         const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}');
         const nowIso = new Date().toISOString();

--- a/src/utils/taskUtils.js
+++ b/src/utils/taskUtils.js
@@ -125,10 +125,9 @@ export const formatDeadlineDate = (deadline) => {
 // from the latest fetch and should be tombstoned so the deletion propagates via
 // cloud sync (instead of being resurrected from the remote sync file).
 //
-// Scope (v1): non-recurring task-calendar items only. Recurring series are left to
-// the existing wholesale-replace behaviour because normal occurrence advancement
-// (completing an instance rolls the due date forward) would otherwise be mistaken
-// for a deletion and churn tombstones.
+// Scope: non-recurring task-calendar items only. Recurring series can't be diffed
+// per-occurrence (normal advancement churns occurrence ids) — they are handled by
+// computeRecurringSeriesTombstones below, which keys off master-UID presence.
 //
 // Safety: returns [] when the fresh feed is empty — an empty-but-valid calendar is
 // far more likely a transient server/auth glitch than a real "everything deleted",
@@ -149,6 +148,50 @@ export const computeTaskCalendarTombstones = (priorTasks, freshTaskItems, { cuto
       t.importSource !== 'file' &&
       !t.isRecurringSeries &&
       !freshIds.has(String(t.id)) &&
+      (!cutoffDateStr || (t.date && t.date >= cutoffDateStr))
+    )
+    .map(t => String(t.id));
+};
+
+// Determine which previously-imported *recurring* CalDAV task-calendar series have
+// been deleted on the server and should be tombstoned. Complements
+// computeTaskCalendarTombstones, which deliberately skips recurring items.
+//
+// Why recurring needs a different signal than per-occurrence diffing:
+//   1. Completing an occurrence rolls the master DUE/DTSTART forward (Nextcloud has
+//      no per-instance RECURRENCE-ID overrides for VTODOs), so the expanded
+//      occurrence ids legitimately change every cycle — a per-occurrence diff would
+//      read that normal churn as a deletion.
+//   2. Occurrence expansion is windowed (±1 year), so a *live* series whose next
+//      occurrence is far out — or whose run already ended — can expand to zero
+//      in-window occurrences while its master VTODO still exists on the server.
+// So a series is "deleted" iff its master UID is absent from the raw feed, not iff
+// its occurrences vanished. `presentMasterUids` must therefore be collected from the
+// parsed feed *before* RRULE expansion (every VTODO/VEVENT uid), so a live but
+// out-of-window series is correctly treated as still present and left alone.
+//
+// Safety: returns [] when presentMasterUids is empty/missing — an empty feed is far
+// more likely a transient server/auth glitch than a real wipe (mirrors the
+// non-recurring guard).
+//
+//   priorTasks        - tasks from the local snapshot before replacement
+//   presentMasterUids - Set or array of icalUids present in the raw (pre-expansion) feed
+//   cutoffDateStr     - YYYY-MM-DD retention cutoff; occurrences dated before it are
+//                       skipped (they won't re-import anyway). null = keep all.
+// Returns: array of task ids (strings) — every local occurrence of each deleted series.
+export const computeRecurringSeriesTombstones = (priorTasks, presentMasterUids, { cutoffDateStr = null } = {}) => {
+  const present = presentMasterUids instanceof Set
+    ? presentMasterUids
+    : new Set((presentMasterUids || []).map(String));
+  if (present.size === 0) return [];
+  if (!Array.isArray(priorTasks) || priorTasks.length === 0) return [];
+  return priorTasks
+    .filter(t =>
+      t.isTaskCalendar &&
+      t.importSource !== 'file' &&
+      t.isRecurringSeries &&
+      t.icalUid &&
+      !present.has(String(t.icalUid)) &&
       (!cutoffDateStr || (t.date && t.date >= cutoffDateStr))
     )
     .map(t => String(t.id));

--- a/src/utils/taskUtils.test.js
+++ b/src/utils/taskUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeTaskCalendarTombstones } from './taskUtils.js';
+import { computeTaskCalendarTombstones, computeRecurringSeriesTombstones } from './taskUtils.js';
 
 // A synced (non-file) CalDAV task-calendar item as produced by expandMultiDayEvent.
 const tcItem = (id, date, extra = {}) => ({
@@ -70,5 +70,93 @@ describe('computeTaskCalendarTombstones', () => {
   it('handles empty/invalid prior input gracefully', () => {
     expect(computeTaskCalendarTombstones([], [tcItem('a', '2026-06-10')])).toEqual([]);
     expect(computeTaskCalendarTombstones(null, [tcItem('a', '2026-06-10')])).toEqual([]);
+  });
+});
+
+// A synced recurring-series occurrence (carries the master uid + isRecurringSeries).
+const recItem = (uid, date, extra = {}) => tcItem(`${uid}-${date}`, date, {
+  icalUid: uid,
+  isRecurringSeries: true,
+  ...extra,
+});
+
+describe('computeRecurringSeriesTombstones', () => {
+  it('tombstones every occurrence of a series whose master UID left the feed', () => {
+    const prior = [
+      recItem('uid-r', '2026-06-10'),
+      recItem('uid-r', '2026-06-17'),
+      recItem('uid-r', '2026-06-24'),
+    ];
+    // The master VTODO uid-r is gone from the raw feed (deleted on the server).
+    expect(computeRecurringSeriesTombstones(prior, new Set(['uid-other']))).toEqual([
+      'uid-r-2026-06-10', 'uid-r-2026-06-17', 'uid-r-2026-06-24',
+    ]);
+  });
+
+  it('leaves a series alone while its master UID is still present (normal churn)', () => {
+    // Occurrence dates differ from prior (completion advanced the due date), but the
+    // master UID is still in the feed — must not be mistaken for a deletion.
+    const prior = [recItem('uid-r', '2026-06-10'), recItem('uid-r', '2026-06-17')];
+    expect(computeRecurringSeriesTombstones(prior, new Set(['uid-r']))).toEqual([]);
+  });
+
+  it('does NOT tombstone a live series that expands to zero in-window occurrences', () => {
+    // The key case: the master is still on the server (uid in presentMasterUids,
+    // collected pre-expansion) but produced no occurrences this fetch. The stale
+    // local occurrences must survive, not be tombstoned.
+    const prior = [recItem('uid-far', '2026-06-10')];
+    expect(computeRecurringSeriesTombstones(prior, new Set(['uid-far', 'uid-other']))).toEqual([]);
+  });
+
+  it('skips tombstoning entirely when the feed has no master UIDs (transient-glitch guard)', () => {
+    const prior = [recItem('uid-r', '2026-06-10')];
+    expect(computeRecurringSeriesTombstones(prior, new Set())).toEqual([]);
+    expect(computeRecurringSeriesTombstones(prior, [])).toEqual([]);
+    expect(computeRecurringSeriesTombstones(prior, null)).toEqual([]);
+  });
+
+  it('only tombstones the deleted series when several series coexist', () => {
+    const prior = [
+      recItem('uid-gone', '2026-06-10'),
+      recItem('uid-gone', '2026-06-17'),
+      recItem('uid-live', '2026-06-11'),
+    ];
+    expect(computeRecurringSeriesTombstones(prior, new Set(['uid-live']))).toEqual([
+      'uid-gone-2026-06-10', 'uid-gone-2026-06-17',
+    ]);
+  });
+
+  it('ignores non-recurring, non-task-calendar, and file-imported items', () => {
+    const prior = [
+      tcItem('plain-2026-06-10', '2026-06-10'), // non-recurring task-calendar (handled elsewhere)
+      recItem('uid-file', '2026-06-10', { importSource: 'file' }), // ICS file import
+      { id: 'regular-1', date: '2026-06-10', isRecurringSeries: true }, // not task-calendar
+    ];
+    expect(computeRecurringSeriesTombstones(prior, new Set(['uid-present']))).toEqual([]);
+  });
+
+  it('only tombstones occurrences within the retention window', () => {
+    const prior = [
+      recItem('uid-gone', '2026-01-01'), // before cutoff
+      recItem('uid-gone', '2026-06-10'), // within window
+    ];
+    const result = computeRecurringSeriesTombstones(prior, new Set(['uid-other']), { cutoffDateStr: '2026-05-13' });
+    expect(result).toEqual(['uid-gone-2026-06-10']);
+  });
+
+  it('accepts the present UIDs as a plain array', () => {
+    const prior = [recItem('uid-r', '2026-06-10')];
+    expect(computeRecurringSeriesTombstones(prior, ['uid-other'])).toEqual(['uid-r-2026-06-10']);
+    expect(computeRecurringSeriesTombstones(prior, ['uid-r'])).toEqual([]);
+  });
+
+  it('skips recurring items missing an icalUid (defensive)', () => {
+    const prior = [tcItem('no-uid-2026-06-10', '2026-06-10', { isRecurringSeries: true })];
+    expect(computeRecurringSeriesTombstones(prior, new Set(['uid-other']))).toEqual([]);
+  });
+
+  it('handles empty/invalid prior input gracefully', () => {
+    expect(computeRecurringSeriesTombstones([], new Set(['a']))).toEqual([]);
+    expect(computeRecurringSeriesTombstones(null, new Set(['a']))).toEqual([]);
   });
 });


### PR DESCRIPTION
## Stacked on #978

This builds directly on #978 (non-recurring CalDAV task tombstones) and is based on its branch, so the diff here shows **only** the recurring-series work. GitHub will auto-retarget this PR to `main` once #978 merges. Review/merge #978 first.

## Problem

#978 deliberately scoped out **recurring** VTODO series, because they can't be diffed per occurrence:

1. **Completion advances the master in place.** `syncTaskCompletionToCalDAV` rolls the master `DUE`/`DTSTART` forward and keeps the `RRULE` (Nextcloud has no per-instance `RECURRENCE-ID` overrides for VTODOs). So each sync re-expands from a later anchor and the earlier occurrence `id`s legitimately disappear — a per-occurrence diff would read that normal churn as a deletion.
2. **Bounded expansion window.** RRULE expansion is only ±1 year. A *live* series whose next occurrence is far out — or whose run already ended — can expand to **zero** in-window occurrences while its master VTODO still exists on the server.

So when a recurring series is genuinely deleted on the server, its occurrences are dropped locally but resurrected from the remote sync file — the same bug #978 fixed for non-recurring items.

## Fix

Detect deletion at the **series level, by master UID**, not per occurrence:

- `parseICS` now surfaces `masterUids` — the set of UIDs of every VTODO/VEVENT in the feed, collected **before** RRULE expansion. This is the authoritative "still exists on the server" signal, so a live-but-out-of-window series (case 2) is correctly seen as present.
- New pure helper `computeRecurringSeriesTombstones(priorTasks, presentMasterUids, { cutoffDateStr })` tombstones every local occurrence of any recurring series whose master UID is absent from `masterUids`.
- `syncTaskCalendar` unions these with the existing non-recurring tombstones. No new sync plumbing — the tombstones are `id`-keyed, which `mergeArrayById` already honors and propagates.

## Guardrails (mirroring #978)

- **Series-level signal** — normal occurrence advancement (case 1) never tombstones, because the master UID stays present.
- **Live zero-occurrence series never tombstoned** (case 2) — the master UID comes from the raw feed, not the expansion. Explicitly unit-tested.
- **Empty-feed safety** — no master UIDs in the feed ⇒ no tombstones (transient server/auth glitch, not a real wipe).
- **Window-aware** — occurrences dated before the retention cutoff are skipped.
- **`completedTaskUids` untouched** — completion history survives a legitimate re-import; stale entries for a truly-deleted series age out via the existing retention prune.

## Testing

- `src/utils/taskUtils.test.js` — **10 new cases** for `computeRecurringSeriesTombstones`: deleted series (all occurrences), normal churn (master present), **live zero-in-window series guard**, empty-feed guard, multi-series isolation, non-recurring/file/non-task-calendar exclusion, retention window, array-vs-Set input, missing-uid defensiveness, empty/invalid input.
- Full suite: **256 tests passing** (was 246). `vite build` succeeds.

## How to verify against a real server

The deterministic logic is covered by the unit tests above. For an end-to-end check on Nextcloud:
1. Create a recurring to-do (e.g. weekly) in the task calendar; let it sync to two devices.
2. Delete the master to-do on the server.
3. Sync device A → the series disappears and a tombstone is written.
4. Sync device B → the series is removed there too and does **not** bounce back on the next sync.
   To confirm the guard, repeat with a recurring to-do whose next occurrence is >1 year out (or already ended): deleting nothing, a normal sync must **not** remove it.

## Scope / follow-ups

- This covers recurring **task** (VTODO) deletions. Recurring **event** phantoms are #977, unrelated.
- Remote orphan occurrences outside the local retention window are converged by the existing zombie fence + re-tombstoning on the next calendar sync rather than in a single pass.

https://claude.ai/code/session_01M1UFnrwA2Wu784geseAgro

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1UFnrwA2Wu784geseAgro)_