### PR TITLE
Multi-user task visibility across all surfaces

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -997,7 +997,7 @@ const DayPlanner = () => {
     consecutiveDayStreak,
     todayIncompleteTasks,
     allTimeIncompleteTasks,
-  } = useStats({ tasks, unscheduledTasks, recurringTasks, goals, projects });
+  } = useStats({ tasks, unscheduledTasks, recurringTasks, goals, projects, isVisibleForUser });
 
   // WebDAV intent transport — both hooks no-op until configured via intent settings (PR #11).
   useIntentPoller({
@@ -6209,7 +6209,7 @@ const DayPlanner = () => {
         if (!effectiveTime || effectiveTime === '0:0') return [];
         const [startH, startM] = effectiveTime.split(':').map(Number);
         if (!Number.isFinite(startH) || !Number.isFinite(startM)) return [];
-        const allProjectTasks = [...tasks, ...unscheduledTasks];
+        const allProjectTasks = [...tasks, ...unscheduledTasks].filter(isVisibleForUser);
         const alreadyInstantiated = allProjectTasks.some(
           t => t.projectId === project.id && t.hyperglanceSessionDate === instance.date
         );
@@ -6231,6 +6231,7 @@ const DayPlanner = () => {
     tasks,
     expandedRecurringTasks,
     hgSessions: hgSessionsForReminders,
+    isVisibleForUser,
     playUISound,
     pushUndo,
     setTasks,
@@ -6957,6 +6958,7 @@ const DayPlanner = () => {
     currentTime,
     tasks,
     expandedRecurringTasks,
+    isVisibleForUser,
     todayHGSessions,
     focusModeAvailable,
     showFocusMode,
@@ -7217,13 +7219,16 @@ const DayPlanner = () => {
     }));
 
     // ── Goals due today ───────────────────────────────────────────────────
-    const allTasksCombinedW = [...tasks, ...unscheduledTasks];
+    // Multi-user: widgets show only the current user's goals/projects/tasks.
+    const allTasksCombinedW = [...tasks, ...unscheduledTasks].filter(isVisibleForUser);
+    const visibleProjectsW = projects.filter(isVisibleForUser);
+    const visibleGoalsW = goals.filter(isVisibleForUser);
     const goalItems = goalsProjectsEnabled
-      ? goals
+      ? visibleGoalsW
           .filter(g => g.status === 'active' && g.targetDate === todayStr)
           .map(g => {
-            const progressPct = Math.round(calculateGoalProgress(g.id, projects, allTasksCombinedW) * 100);
-            const childProjects = projects.filter(p => p.goalId === g.id && p.status !== 'archived');
+            const progressPct = Math.round(calculateGoalProgress(g.id, visibleProjectsW, allTasksCombinedW) * 100);
+            const childProjects = visibleProjectsW.filter(p => p.goalId === g.id && p.status !== 'archived');
             const totalTasks = allTasksCombinedW.filter(t => childProjects.some(p => p.id === t.projectId) && !t.archived).length;
             const completedTasks = allTasksCombinedW.filter(t => childProjects.some(p => p.id === t.projectId) && !t.archived && t.completed).length;
             return { id: g.id, title: g.title, progressPct, totalTasks, completedTasks };
@@ -7259,14 +7264,14 @@ const DayPlanner = () => {
 
     // ── All Goals (for Goal widget) ───────────────────────────────────────
     const allGoalsData = goalsProjectsEnabled
-      ? goals
+      ? visibleGoalsW
           .filter(g => g.status === 'active')
           .map(g => {
-            const childProjects = projects.filter(p => p.goalId === g.id && p.status !== 'archived');
+            const childProjects = visibleProjectsW.filter(p => p.goalId === g.id && p.status !== 'archived');
             const goalTasks = allTasksCombinedW.filter(
               t => childProjects.some(p => p.id === t.projectId) && !t.archived
             );
-            const pct = Math.round(calculateGoalProgress(g.id, projects, allTasksCombinedW) * 100);
+            const pct = Math.round(calculateGoalProgress(g.id, visibleProjectsW, allTasksCombinedW) * 100);
             const goalColorHex = TAILWIND_TO_HEX[g.color] || '#3b82f6';
             let daysUntilDue = null;
             if (g.targetDate) {
@@ -7302,7 +7307,7 @@ const DayPlanner = () => {
 
     // ── All Projects (for Project widget) ─────────────────────────────────
     const allProjectsData = goalsProjectsEnabled
-      ? projects
+      ? visibleProjectsW
           .filter(p => p.status !== 'archived')
           .map(p => {
             const ptasks = allTasksCombinedW.filter(t => t.projectId === p.id && !t.archived);
@@ -7372,7 +7377,7 @@ const DayPlanner = () => {
           const hg = project.hyperglance;
           const effectiveTime = hg.scheduledTimeOverrides?.[instance.date] || hg.scheduledTime || '';
           const duration = hg.scheduledDurationOverrides?.[instance.date] || hg.scheduledDuration || 60;
-          const allProjectTasks = [...tasks, ...unscheduledTasks];
+          const allProjectTasks = [...tasks, ...unscheduledTasks].filter(isVisibleForUser);
           const alreadyInstantiated = allProjectTasks.some(
             t => t.projectId === project.id && t.hyperglanceSessionDate === instance.date
           );
@@ -7461,7 +7466,7 @@ const DayPlanner = () => {
   useEffect(() => {
     if (!window.DayGlanceNative?.indexSpotlight) return;
     if (!dataLoaded) return;
-    const allTasks = [...tasks, ...unscheduledTasks].filter(t => !t.archived && !t.completed);
+    const allTasks = [...tasks, ...unscheduledTasks].filter(t => !t.archived && !t.completed && isVisibleForUser(t));
     const items = allTasks.map(t => ({
       id: t.id,
       title: t.title.replace(/\[\[[^\]]*\]\]/g, '').replace(/#\S+/g, '').replace(/\s+/g, ' ').trim(),
@@ -7471,7 +7476,7 @@ const DayPlanner = () => {
     try {
       window.DayGlanceNative.indexSpotlight(JSON.stringify(items));
     } catch (_) {}
-  }, [dataLoaded, tasks, unscheduledTasks]);
+  }, [dataLoaded, tasks, unscheduledTasks, isVisibleForUser]);
 
   // GTD Frame CRUD operations
   const saveFrame = (frame) => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -699,6 +699,11 @@ const DayPlanner = () => {
     return assigned.length === 0 || assigned.includes(meUserSyncId);
   }, [multiUserEnabled, meUserSyncId]);
 
+  // Projects visible to the current user — used to filter hyperGLANCE sessions
+  // (a project's sessions only show for its assigned users, or everyone if
+  // unassigned). Shared so every timeline/glance surface filters identically.
+  const hgVisibleProjects = useMemo(() => projects.filter(isVisibleForUser), [projects, isVisibleForUser]);
+
   // Habits & Routines use a single-owner model (not the broadcast-with-filter
   // model used by tasks/goals/projects). Everyday rings and the timeline always
   // show the current user's ("me") items; the management dashboards have a
@@ -6196,7 +6201,7 @@ const DayPlanner = () => {
     if (!goalsProjectsEnabled) return [];
     const todayStr = dateToString(new Date());
     const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
-    return getGlanceHGInstances(projects, nowMin)
+    return getGlanceHGInstances(hgVisibleProjects, nowMin)
       .filter(({ instance }) => !instance.isOverdue && instance.date === todayStr)
       .flatMap(({ project, instance }) => {
         const hg = project.hyperglance;
@@ -6213,7 +6218,7 @@ const DayPlanner = () => {
         ).length + (alreadyInstantiated ? 0 : (hg.templateTasks?.length || 0));
         return [{ id: project.id, title: project.title, date: instance.date, startMinutes: startH * 60 + startM, taskCount }];
       });
-  }, [projects, goalsProjectsEnabled, tasks, unscheduledTasks]);
+  }, [hgVisibleProjects, goalsProjectsEnabled, tasks, unscheduledTasks]);
 
   const {
     activeReminders, setActiveReminders,
@@ -6936,7 +6941,7 @@ const DayPlanner = () => {
     if (!goalsProjectsEnabled) return [];
     const todayStr = getTodayStr();
     const nowMin = currentTime.getHours() * 60 + currentTime.getMinutes();
-    return getGlanceHGInstances(projects, nowMin)
+    return getGlanceHGInstances(hgVisibleProjects, nowMin)
       .map(({ project, instance }) => {
         const hg = project.hyperglance;
         const effectiveTime = hg.scheduledTimeOverrides?.[instance.date] || hg.scheduledTime || '';
@@ -6945,7 +6950,7 @@ const DayPlanner = () => {
         return { id: project.id, title: project.title, colorHex: hg.color || '#4f46e5', startTime: effectiveTime, duration, isOverdue: instance.isOverdue, date: instance.date, reachable, isHGSession: true };
       })
       .filter(s => !s.isOverdue && s.date === todayStr && s.startTime);
-  }, [goalsProjectsEnabled, projects, currentTime]);
+  }, [goalsProjectsEnabled, hgVisibleProjects, currentTime]);
 
   useElectronBridge({
     todayAgenda,
@@ -7363,7 +7368,7 @@ const DayPlanner = () => {
 
     // ── hyperGLANCE sessions (today + overdue) ────────────────────────────
     const hyperGlanceItems = goalsProjectsEnabled
-      ? getGlanceHGInstances(projects, nowMinW).map(({ project, instance }) => {
+      ? getGlanceHGInstances(hgVisibleProjects, nowMinW).map(({ project, instance }) => {
           const hg = project.hyperglance;
           const effectiveTime = hg.scheduledTimeOverrides?.[instance.date] || hg.scheduledTime || '';
           const duration = hg.scheduledDurationOverrides?.[instance.date] || hg.scheduledDuration || 60;
@@ -7446,6 +7451,7 @@ const DayPlanner = () => {
     glanceAhead,
     currentTime,
     projects,
+    hgVisibleProjects,
     goals,
     goalsProjectsEnabled,
   ]);
@@ -8377,6 +8383,7 @@ const DayPlanner = () => {
     // ── Goals & Projects ──────────────────────────────────────────────────────
     goals, setGoals,
     projects, setProjects,
+    hgVisibleProjects,
     showGoalsDashboard, setShowGoalsDashboard,
     goalsDashboardFocusId, setGoalsDashboardFocusId,
     goalsProjectsEnabled, setGoalsProjectsEnabled,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -601,6 +601,11 @@ const DayPlanner = () => {
 
   const syncAllRef = useRef(null);
 
+  // Multi-user: owner stamped onto newly created habits/routines. Updated each
+  // render (below, once multi-user state exists) to the habits/routines
+  // dashboard's active user. null = single-user mode → items are left unowned.
+  const hrOwnerRef = useRef(null);
+
   // Settings & Reminders modals
   const [showSettings, setShowSettings] = useState(false);
   const [collapsedSettings, setCollapsedSettings] = useState({ cloudSync: true, calSync: !isNativeApp(), ai: true, obsidian: !isNativeApp(), trmnl: true, multiUser: true });
@@ -628,7 +633,7 @@ const DayPlanner = () => {
     habitDayPopup, setHabitDayPopup,
     habitLongPressTimer,
     habitLongPressOpenedAt,
-    activeHabits,
+    activeHabits: allActiveHabits,
     habitStreaks,
     getTodayHabitCount,
     incrementHabit,
@@ -643,10 +648,10 @@ const DayPlanner = () => {
     healthPerms,
     addStepsHabit,
     addSleepHabit,
-  } = useHabits({ playUISound });
+  } = useHabits({ playUISound, hrOwnerRef });
   const {
     routineDefinitions, setRoutineDefinitions,
-    todayRoutines, setTodayRoutines,
+    todayRoutines: allTodayRoutines, setTodayRoutines,
     routinesDate, setRoutinesDate,
     removedTodayRoutineIds, setRemovedTodayRoutineIds,
     showRoutinesDashboard, setShowRoutinesDashboard,
@@ -664,7 +669,8 @@ const DayPlanner = () => {
     deleteRoutineChip,
     toggleRoutineChipSelection,
     handleRoutinesDone,
-  } = useRoutines({ currentTime, onboardingProgress, setOnboardingProgress });
+    selectTodayChipsForOwner,
+  } = useRoutines({ currentTime, onboardingProgress, setOnboardingProgress, hrOwnerRef });
   const {
     goals, setGoals,
     projects, setProjects,
@@ -692,6 +698,85 @@ const DayPlanner = () => {
     const assigned = task.assignedUserSyncIds ?? [];
     return assigned.length === 0 || assigned.includes(meUserSyncId);
   }, [multiUserEnabled, meUserSyncId]);
+
+  // Habits & Routines use a single-owner model (not the broadcast-with-filter
+  // model used by tasks/goals/projects). Everyday rings and the timeline always
+  // show the current user's ("me") items; the management dashboards have a
+  // switcher (hrViewUserSyncId, default = me) to view/edit any member's items.
+  const [hrViewUserSyncId, setHrViewUserSyncId] = useState(meUserSyncId);
+  // Keep the switcher pointed at a valid, existing user; fall back to "me".
+  useEffect(() => {
+    setHrViewUserSyncId(prev => {
+      if (!multiUserEnabled) return meUserSyncId;
+      const stillExists = prev && users.some(u => !u.deleted && (u.syncId ?? u.id) === prev);
+      return stillExists ? prev : meUserSyncId;
+    });
+  }, [multiUserEnabled, meUserSyncId, users]);
+
+  // Owner stamped onto items created from the dashboards (the active/switcher
+  // user). null in single-user mode so nothing is stamped.
+  useEffect(() => {
+    hrOwnerRef.current = multiUserEnabled ? (hrViewUserSyncId || meUserSyncId || null) : null;
+  });
+
+  // True when `item` belongs to `syncId` (or is unowned — unowned items show to
+  // whoever is viewing, matching tasks' empty-assignment "everybody" default).
+  const ownedBy = useCallback((item, syncId) => {
+    if (!multiUserEnabled) return true;
+    const target = syncId || meUserSyncId;
+    if (!target) return true;
+    return !item.ownerSyncId || item.ownerSyncId === target;
+  }, [multiUserEnabled, meUserSyncId]);
+
+  // Everyday "my" habits (rings/glance); management list for the switcher user.
+  const activeHabits = useMemo(
+    () => allActiveHabits.filter(h => ownedBy(h, meUserSyncId)),
+    [allActiveHabits, ownedBy, meUserSyncId]
+  );
+  const managedHabits = useMemo(
+    () => allActiveHabits.filter(h => ownedBy(h, hrViewUserSyncId)),
+    [allActiveHabits, ownedBy, hrViewUserSyncId]
+  );
+  // Everyday timeline/widgets show only my placed routines; persistence and
+  // cloud sync use the full `allTodayRoutines` so other members' entries are
+  // preserved across saves.
+  const todayRoutines = useMemo(
+    () => allTodayRoutines.filter(r => ownedBy(r, meUserSyncId)),
+    [allTodayRoutines, ownedBy, meUserSyncId]
+  );
+
+  // One-time migration (per device): when multi-user is enabled, assign existing
+  // unowned habits / routine chips / today-routines to the current user so they
+  // keep showing for "me". Goals and projects are intentionally left untouched.
+  // Anything misattributed (e.g. a pre-existing shared store) is reassignable via
+  // the dashboard switcher.
+  const hrMigratedRef = useRef(false);
+  useEffect(() => {
+    if (hrMigratedRef.current) return;
+    if (!dataLoaded || !multiUserEnabled || !meUserSyncId) return;
+    if (localStorage.getItem('dayglance-hr-owner-migrated')) { hrMigratedRef.current = true; return; }
+    const now = new Date().toISOString();
+    setHabits(prev => prev.some(h => !h.ownerSyncId)
+      ? prev.map(h => h.ownerSyncId ? h : { ...h, ownerSyncId: meUserSyncId, lastModified: now })
+      : prev);
+    setRoutineDefinitions(prev => {
+      let any = false;
+      const next = {};
+      for (const [bucket, arr] of Object.entries(prev)) {
+        next[bucket] = arr.map(c => {
+          if (c.ownerSyncId) return c;
+          any = true;
+          return { ...c, ownerSyncId: meUserSyncId, lastModified: now };
+        });
+      }
+      return any ? next : prev;
+    });
+    setTodayRoutines(prev => prev.some(r => !r.ownerSyncId)
+      ? prev.map(r => r.ownerSyncId ? r : { ...r, ownerSyncId: meUserSyncId, lastModified: now })
+      : prev);
+    localStorage.setItem('dayglance-hr-owner-migrated', now);
+    hrMigratedRef.current = true;
+  }, [dataLoaded, multiUserEnabled, meUserSyncId]);
 
   const {
     showFocusMode, setShowFocusMode,
@@ -1082,7 +1167,7 @@ const DayPlanner = () => {
     setRoutinesEnabled, setGoals, setProjects, setGoalsProjectsEnabled, setDataLoaded,
     setUnscheduledOrderTimestamp,
     // values for saveData
-    tasks, unscheduledTasks, recycleBin, recurringTasks, todayRoutines,
+    tasks, unscheduledTasks, recycleBin, recurringTasks, todayRoutines: allTodayRoutines,
     darkMode, syncUrl, taskCalendarUrl, syncRetentionDays, completedTaskUids,
     routineDefinitions, routinesDate, removedTodayRoutineIds,
     habits, habitLogs, habitsEnabled, routinesEnabled, gtdFrames,
@@ -1097,7 +1182,7 @@ const DayPlanner = () => {
     dataLoaded,
     suppressClearPendingRef, suppressCloudUploadRef, suppressTimestampRef,
     tasks, unscheduledTasks, recycleBin, taskCalendarUrl, syncUrl, syncRetentionDays,
-    completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate,
+    completedTaskUids, recurringTasks, routineDefinitions, todayRoutines: allTodayRoutines, routinesDate,
     removedTodayRoutineIds, habits, habitLogs, habitsEnabled, routinesEnabled, gtdFrames,
     goals, projects, goalsProjectsEnabled,
   });
@@ -1485,7 +1570,7 @@ const DayPlanner = () => {
       cloudSyncEngineRef.current.upload();
     }, 5000);
     return () => { if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current); };
-  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled, syncKeyReady, multiUserEnabled, users]);
+  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, allTodayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled, syncKeyReady, multiUserEnabled, users]);
 
   // ── Config field timestamp tracking ──────────────────────────────────────
   // Tracks when habitsEnabled/routinesEnabled/goalsProjectsEnabled/obsidianConfig
@@ -2490,7 +2575,7 @@ const DayPlanner = () => {
         recurringTasks,
         selectedDate: today,
         use24HourClock: use24HourClock,
-        habits,
+        habits: activeHabits,
         habitLogs,
         weatherSummary: weather ? `${weather.temp}°${weatherTempUnit === 'celsius' ? 'C' : 'F'} ${weather.description || ''}`.trim() : '',
         dailyNotes,
@@ -5156,7 +5241,7 @@ const DayPlanner = () => {
         completedTaskUids: prunedUids,
         recurringTasks: stampTaskTimestamps(recurringTasks, 'day-planner-recurring-tasks'),
         routineDefinitions,
-        todayRoutines: stampTaskTimestamps(todayRoutines, 'day-planner-today-routines'),
+        todayRoutines: stampTaskTimestamps(allTodayRoutines, 'day-planner-today-routines'),
         routinesDate,
         routineCompletions,
         minimizedSections,
@@ -8185,6 +8270,11 @@ const DayPlanner = () => {
     routineDurationEditId, setRoutineDurationEditId,
     routinesEnabled, setRoutinesEnabled,
     routineCompletions, setRoutineCompletions, toggleRoutineCompletion,
+    selectTodayChipsForOwner,
+
+    // ── Habits & Routines multi-user ──────────────────────────────────────────
+    hrViewUserSyncId, setHrViewUserSyncId,
+    ownedBy,
 
     // ── Habits ────────────────────────────────────────────────────────────────
     habits, setHabits,
@@ -8197,7 +8287,7 @@ const DayPlanner = () => {
     habitLongPressId, setHabitLongPressId,
     habitEditingCountId, setHabitEditingCountId,
     habitDayPopup, setHabitDayPopup,
-    activeHabits, habitStreaks,
+    activeHabits, managedHabits, habitStreaks,
     habitLongPressTimer,
     habitLongPressOpenedAt,
 

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -105,12 +105,12 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
   const isHoveringThisCol = hoverPreviewTime && !draggedTask && !isResizing
     && hoverPreviewDate && dateToString(hoverPreviewDate) === col.dateStr;
 
-  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion, goalsProjectsEnabled, projects, getFrameInstancesForDate, computeAvailableSlots, setFrameContextMenu } = useFeaturesCtx();
+  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion, goalsProjectsEnabled, projects, hgVisibleProjects, getFrameInstancesForDate, computeAvailableSlots, setFrameContextMenu } = useFeaturesCtx();
 
   const isDateToday = col.dateStr === dateToString(new Date());
   const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
   const hgBars = goalsProjectsEnabled
-    ? getHGBarsForDate(projects, col.dateStr, isDateToday ? nowMin : undefined)
+    ? getHGBarsForDate(hgVisibleProjects, col.dateStr, isDateToday ? nowMin : undefined)
     : [];
   const hasBars = hgBars.length > 0;
 

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -91,7 +91,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     showFramesModal, setShowFramesModal,
     framesModalTab, setFramesModalTab,
     editingFrame, setEditingFrame,
-    goals, goalsProjectsEnabled, projects, projectFilter, setProjectFilter,
+    goals, goalsProjectsEnabled, projects, hgVisibleProjects, projectFilter, setProjectFilter,
     focusModeAvailable,
     enterFocusMode,
     getTodayHabitCount, incrementHabit, setHabitCount,
@@ -1200,7 +1200,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
   {/* hyperGLANCE sessions — today + overdue */}
   {goalsProjectsEnabled && (() => {
     const nowMinutes = currentTime.getHours() * 60 + currentTime.getMinutes();
-    const hgItems = getGlanceHGInstances(projects, nowMinutes);
+    const hgItems = getGlanceHGInstances(hgVisibleProjects, nowMinutes);
     if (hgItems.length === 0) return null;
     return (
       <div className={isDesktop ? `rounded-lg border ${borderClass} p-3` : `mt-3 pt-3 border-t ${borderClass}`}>

--- a/src/components/HabitModal.jsx
+++ b/src/components/HabitModal.jsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from '../constants/habits.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import UserOwnerSwitcher from './UserOwnerSwitcher.jsx';
 import { getDeviceId } from '../native.js';
 
 const HabitModal = () => {
@@ -16,9 +17,10 @@ const HabitModal = () => {
     setShowHabitModal,
     editingHabit, setEditingHabit,
     draggedHabitIdx, setDraggedHabitIdx,
-    activeHabits, habits,
+    managedHabits: activeHabits, habits,
     addHabit, updateHabit, archiveHabit, deleteHabit, reorderHabits,
     addStepsHabit, addSleepHabit, healthPerms,
+    multiUserEnabled, users, hrViewUserSyncId, setHrViewUserSyncId,
   } = useFeaturesCtx();
 
   return (
@@ -216,6 +218,16 @@ const HabitModal = () => {
           ) : (
             /* Habit list view */
             <>
+              <UserOwnerSwitcher
+                enabled={multiUserEnabled}
+                users={users}
+                value={hrViewUserSyncId}
+                onChange={setHrViewUserSyncId}
+                darkMode={darkMode}
+                borderClass={borderClass}
+                textSecondary={textSecondary}
+                label="Habits for"
+              />
               {activeHabits.length === 0 ? (
                 <div className={`text-center py-8 ${textSecondary}`}>
                   <Activity size={40} className="mx-auto mb-3 opacity-30" />

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -101,7 +101,7 @@ const MobileGlanceSection = () => {
     showFramesModal, setShowFramesModal,
     framesModalTab, setFramesModalTab,
     editingFrame, setEditingFrame,
-    goals, goalsProjectsEnabled, projects,
+    goals, goalsProjectsEnabled, projects, hgVisibleProjects,
     projectFilter, setProjectFilter,
     showGoalsDashboard, setShowGoalsDashboard,
     goalsDashboardFocusId, setGoalsDashboardFocusId,
@@ -1216,7 +1216,7 @@ const MobileGlanceSection = () => {
   {/* hyperGLANCE sessions — today + overdue */}
   {goalsProjectsEnabled && (() => {
     const nowMinutes = currentTime.getHours() * 60 + currentTime.getMinutes();
-    const hgItems = getGlanceHGInstances(projects, nowMinutes);
+    const hgItems = getGlanceHGInstances(hgVisibleProjects, nowMinutes);
     if (hgItems.length === 0) return null;
     return (
       <div className={`mt-3 pt-3 border-t ${borderClass}`}>

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -690,7 +690,7 @@ const MobileListView = ({ hideInboxHandle = false }) => {
 
   const {
     routinesEnabled, todayRoutines, setTodayRoutines, routineCompletions, toggleRoutineCompletion,
-    projects, enterHyperGlanceMode, setPendingEditProjectId, updateProject,
+    projects, hgVisibleProjects, enterHyperGlanceMode, setPendingEditProjectId, updateProject,
   } = useFeaturesCtx();
 
   // ── State ──────────────────────────────────────────────────────────────────
@@ -759,8 +759,8 @@ const MobileListView = ({ hideInboxHandle = false }) => {
 
   const hgBars = useMemo(() => {
     const nowMin = isToday ? currentTime.getHours() * 60 + currentTime.getMinutes() : undefined;
-    return getHGBarsForDate(projects || [], dateStr, nowMin);
-  }, [projects, dateStr, isToday, currentTime]);
+    return getHGBarsForDate(hgVisibleProjects || [], dateStr, nowMin);
+  }, [hgVisibleProjects, dateStr, isToday, currentTime]);
 
   // Combine and sort all scheduled items
   const allItems = useMemo(() => {

--- a/src/components/MobileRoutinesTab.jsx
+++ b/src/components/MobileRoutinesTab.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Clock, Plus, Sparkles, Trash2, Undo2, X } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import UserOwnerSwitcher from './UserOwnerSwitcher.jsx';
 
 const MobileRoutinesTab = () => {
   const { isPhone, isMobile, isTablet, darkMode, textSecondary, hoverBg, colors, formatTime, getDayName, cardBg, borderClass, textPrimary } = useDayPlannerCtx();
@@ -14,6 +15,8 @@ const MobileRoutinesTab = () => {
     routineDeleteConfirm, setRoutineDeleteConfirm,
     routineFocusedChipId, setRoutineFocusedChipId,
     addRoutineChip, deleteRoutineChip, toggleRoutineChipSelection,
+    multiUserEnabled, users, hrViewUserSyncId, setHrViewUserSyncId,
+    ownedBy, selectTodayChipsForOwner,
   } = useFeaturesCtx();
 
   const today = new Date();
@@ -25,12 +28,24 @@ const MobileRoutinesTab = () => {
   const bucketLabel = (b) => b === 'everyday' ? 'Every Day' : b.charAt(0).toUpperCase() + b.slice(1);
   const isHighlighted = (b) => b === todayDayName || b === 'everyday';
 
-  const hasAnyChips = Object.values(routineDefinitions).some(arr => arr.some(c => !String(c.id).startsWith('example-')));
+  const hasAnyChips = Object.values(routineDefinitions).some(arr => arr.some(c => !String(c.id).startsWith('example-') && ownedBy(c, hrViewUserSyncId)));
 
   return (
     <>
     <div className={`px-4 py-4 mobile-tab-fade-in`}>
       <div className="space-y-3">
+        {multiUserEnabled && users.filter(u => !u.deleted).length > 0 && (
+          <UserOwnerSwitcher
+            enabled={multiUserEnabled}
+            users={users}
+            value={hrViewUserSyncId}
+            onChange={(id) => { setHrViewUserSyncId(id); selectTodayChipsForOwner(id); }}
+            darkMode={darkMode}
+            borderClass={borderClass}
+            textSecondary={textSecondary}
+            label="Routines for"
+          />
+        )}
         {/* Today's selected routine */}
         <div className={`rounded-lg border-2 border-dashed ${darkMode ? 'border-gray-600' : 'border-stone-300'} p-4`}>
           <div className={`text-xs font-semibold uppercase tracking-wide mb-3 ${textSecondary} text-center`}>Today's Routine</div>
@@ -98,7 +113,7 @@ const MobileRoutinesTab = () => {
 
         {/* Day buckets */}
         {allBuckets.map(bucket => {
-          const chips = (routineDefinitions[bucket] || []).filter(c => !String(c.id).startsWith('example-'));
+          const chips = (routineDefinitions[bucket] || []).filter(c => !String(c.id).startsWith('example-') && ownedBy(c, hrViewUserSyncId));
           return (
             <div
               key={bucket}

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -19,6 +19,7 @@ import AutoBackupSettingsForm from './AutoBackupSettingsForm.jsx';
 import FrameEditor from './FrameEditor.jsx';
 import SmartSchedulePanel from './SmartSchedulePanel.jsx';
 import MobileRoutinesTab from './MobileRoutinesTab.jsx';
+import UserOwnerSwitcher from './UserOwnerSwitcher.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -89,11 +90,12 @@ const MobileSettingsPanel = () => {
     setRoutineAddingToBucket, setRoutineNewChipName,
     handleRoutinesDone,
     habitsEnabled, setHabitsEnabled,
-    activeHabits, habits,
+    managedHabits: activeHabits, habits,
     editingHabit, setEditingHabit,
     draggedHabitIdx, setDraggedHabitIdx,
     addHabit, updateHabit, archiveHabit, deleteHabit, reorderHabits,
     addStepsHabit, addSleepHabit, healthPerms,
+    hrViewUserSyncId, setHrViewUserSyncId,
     goalsProjectsEnabled, setGoalsProjectsEnabled,
     gtdFrames,
     framesModalTab, setFramesModalTab,
@@ -2183,6 +2185,18 @@ const MobileSettingsPanel = () => {
           ) : (
             /* Habit list */
             <>
+              <div className="mb-3">
+                <UserOwnerSwitcher
+                  enabled={multiUserEnabled}
+                  users={users}
+                  value={hrViewUserSyncId}
+                  onChange={setHrViewUserSyncId}
+                  darkMode={darkMode}
+                  borderClass={borderClass}
+                  textSecondary={textSecondary}
+                  label="Habits for"
+                />
+              </div>
               {activeHabits.length === 0 ? (
                 <div className={`text-center py-8 ${textSecondary}`}>
                   <Activity size={40} className="mx-auto mb-3 opacity-30" />

--- a/src/components/MobileTimeGrid.jsx
+++ b/src/components/MobileTimeGrid.jsx
@@ -52,6 +52,7 @@ const MobileTimeGrid = () => {
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
   const {
     projects,
+    hgVisibleProjects,
     projectFilter, setProjectFilter,
     routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion,
     goalsProjectsEnabled,
@@ -118,7 +119,7 @@ const MobileTimeGrid = () => {
       const isDateToday = dateStr === dateToString(new Date());
       const dayTasks = getTasksForDate(date).filter(t => !t.isAllDay && !t.isExample && (!projectFilter || t.projectId === projectFilter));
       const frameInstances = getFrameInstancesForDate(date);
-      const hgBars = getHGBarsForDate(projects, dateStr, isDateToday ? new Date().getHours() * 60 + new Date().getMinutes() : undefined);
+      const hgBars = getHGBarsForDate(hgVisibleProjects, dateStr, isDateToday ? new Date().getHours() * 60 + new Date().getMinutes() : undefined);
       const hasBars = hgBars.length > 0;
       const taskOverlapsHG = (task) => {
         if (!task.startTime || !hasBars) return false;

--- a/src/components/RoutinesDashboardModal.jsx
+++ b/src/components/RoutinesDashboardModal.jsx
@@ -3,6 +3,7 @@ import { X, Plus, Clock, Undo2, Sparkles, Trash2 } from 'lucide-react';
 import ClockTimePicker from './ClockTimePicker.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import UserOwnerSwitcher from './UserOwnerSwitcher.jsx';
 
 const RoutinesDashboardModal = () => {
   const {
@@ -20,6 +21,8 @@ const RoutinesDashboardModal = () => {
     routineDefinitions,
     dashboardSelectedChips, setDashboardSelectedChips,
     addRoutineChip, deleteRoutineChip, toggleRoutineChipSelection,
+    multiUserEnabled, users, hrViewUserSyncId, setHrViewUserSyncId,
+    ownedBy, selectTodayChipsForOwner,
   } = useFeaturesCtx();
 
   return (
@@ -52,6 +55,20 @@ const RoutinesDashboardModal = () => {
                 <X size={20} className={textSecondary} />
               </button>
             </div>
+            {multiUserEnabled && users.filter(u => !u.deleted).length > 0 && (
+              <div className="mt-4">
+                <UserOwnerSwitcher
+                  enabled={multiUserEnabled}
+                  users={users}
+                  value={hrViewUserSyncId}
+                  onChange={(id) => { setHrViewUserSyncId(id); selectTodayChipsForOwner(id); }}
+                  darkMode={darkMode}
+                  borderClass={borderClass}
+                  textSecondary={textSecondary}
+                  label="Routines for"
+                />
+              </div>
+            )}
           </div>
 
           {/* Body */}
@@ -65,7 +82,7 @@ const RoutinesDashboardModal = () => {
               const isHighlighted = (b) => b === todayDayName || b === 'everyday';
 
               const renderBucket = (bucket) => {
-                const chips = routineDefinitions[bucket] || [];
+                const chips = (routineDefinitions[bucket] || []).filter(c => ownedBy(c, hrViewUserSyncId));
                 return (
                   <div
                     key={bucket}
@@ -148,7 +165,7 @@ const RoutinesDashboardModal = () => {
                 );
               };
 
-              const hasAnyChips = Object.values(routineDefinitions).some(arr => arr.length > 0);
+              const hasAnyChips = Object.values(routineDefinitions).some(arr => arr.some(c => ownedBy(c, hrViewUserSyncId)));
 
               return (
                 <div className="grid grid-cols-3 gap-4">

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -71,6 +71,7 @@ const TimeGrid = () => {
   const {
     goalsProjectsEnabled,
     projects,
+    hgVisibleProjects,
     projectFilter, setProjectFilter,
     routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion,
     getFrameInstancesForDate,
@@ -142,7 +143,7 @@ const TimeGrid = () => {
       const isDateToday = dateStr === dateToString(new Date());
       const dayTasks = getTasksForDate(date).filter(t => !t.isAllDay && (!projectFilter || t.projectId === projectFilter));
       const frameInstances = getFrameInstancesForDate(date);
-      const hgBars = getHGBarsForDate(projects, dateStr, isDateToday ? new Date().getHours() * 60 + new Date().getMinutes() : undefined);
+      const hgBars = getHGBarsForDate(hgVisibleProjects, dateStr, isDateToday ? new Date().getHours() * 60 + new Date().getMinutes() : undefined);
       const hasBars = hgBars.length > 0;
       // Returns true if a task's time range overlaps with any HG bar's scheduled time range
       const taskOverlapsHG = (task) => {

--- a/src/components/UserAssignmentPicker.jsx
+++ b/src/components/UserAssignmentPicker.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+/**
+ * Multi-select user assignment picker (broadcast-with-filter model).
+ *
+ * Mirrors the inline picker used in the task modals: an empty selection means
+ * "everybody can see it", while explicit selections restrict visibility to
+ * those users. Returns null when multi-user is disabled or there are no users,
+ * so callers can drop it in unconditionally.
+ */
+export default function UserAssignmentPicker({
+  enabled,
+  users = [],
+  value = [],
+  onChange,
+  darkMode,
+  borderClass = '',
+  textSecondary = '',
+  label = 'Assigned to',
+}) {
+  const activeUsers = users.filter(u => !u.deleted);
+  if (!enabled || activeUsers.length === 0) return null;
+
+  const assigned = value ?? [];
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className={`text-xs font-medium ${textSecondary}`}>
+        {label} <span className="opacity-70">(empty = everybody)</span>
+      </label>
+      <div className="flex flex-wrap gap-2">
+        {activeUsers.map(u => {
+          const key = u.syncId ?? u.id;
+          const isSelected = assigned.includes(key);
+          const toggle = () => {
+            const next = isSelected
+              ? assigned.filter(id => id !== key)
+              : [...assigned, key];
+            onChange(next);
+          };
+          return (
+            <button
+              key={u.id}
+              type="button"
+              onClick={toggle}
+              className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-sm border transition-colors ${isSelected
+                ? `border-blue-500 ${darkMode ? 'bg-blue-500/20 text-blue-300' : 'bg-blue-50 text-blue-700'}`
+                : `${borderClass} ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-white text-stone-600'}`}`}
+            >
+              <span
+                style={{ width: 18, height: 18, fontSize: 10 }}
+                className="rounded-full bg-gray-500 text-white flex items-center justify-center font-semibold leading-none flex-shrink-0"
+              >
+                {u.name[0].toUpperCase()}
+              </span>
+              {u.name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/UserOwnerSwitcher.jsx
+++ b/src/components/UserOwnerSwitcher.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+/**
+ * Single-user "viewing as" switcher for the Habits / Routines dashboards.
+ *
+ * Habits and routines use a single-owner model, so each dashboard shows one
+ * user's items at a time. This control picks which member's items are being
+ * viewed / edited (defaulting to "me"). Returns null when multi-user is
+ * disabled or there are no users, so callers can drop it in unconditionally.
+ */
+export default function UserOwnerSwitcher({
+  enabled,
+  users = [],
+  value,
+  onChange,
+  darkMode,
+  borderClass = '',
+  textSecondary = '',
+  label = 'Viewing',
+}) {
+  const activeUsers = users.filter(u => !u.deleted);
+  if (!enabled || activeUsers.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className={`text-xs font-medium ${textSecondary}`}>{label}</label>
+      <div className="flex flex-wrap gap-2">
+        {activeUsers.map(u => {
+          const key = u.syncId ?? u.id;
+          const isSelected = value === key;
+          return (
+            <button
+              key={u.id}
+              type="button"
+              onClick={() => onChange(key)}
+              className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-sm border transition-colors ${isSelected
+                ? `border-blue-500 ${darkMode ? 'bg-blue-500/20 text-blue-300' : 'bg-blue-50 text-blue-700'}`
+                : `${borderClass} ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-white text-stone-600'}`}`}
+            >
+              <span
+                style={{ width: 18, height: 18, fontSize: 10 }}
+                className="rounded-full bg-gray-500 text-white flex items-center justify-center font-semibold leading-none flex-shrink-0"
+              >
+                {u.name[0].toUpperCase()}
+              </span>
+              {u.name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -117,7 +117,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, startHour, onTaskCl
     handleDragStart, handleDragEnd, handleDropOnCalendar,
     formatTime,
   } = useDayPlannerCtx();
-  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, goalsProjectsEnabled, projects, getFrameInstancesForDate, setFrameContextMenu, setHgContextMenu } = useFeaturesCtx();
+  const { projectFilter, routinesEnabled, todayRoutines, routineCompletions, goalsProjectsEnabled, projects, hgVisibleProjects, getFrameInstancesForDate, setFrameContextMenu, setHgContextMenu } = useFeaturesCtx();
 
   const [overflowPopover, setOverflowPopover] = useState(null); // { routines, rect }
   const overflowPopoverRef = useRef(null);
@@ -175,7 +175,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, startHour, onTaskCl
   const altRow = darkMode ? 'bg-white/[0.04]' : 'bg-stone-100/50';
 
   const hgBars = goalsProjectsEnabled
-    ? getHGBarsForDate(projects, dateStr, isToday ? nowMinutes : undefined)
+    ? getHGBarsForDate(hgVisibleProjects, dateStr, isToday ? nowMinutes : undefined)
     : [];
   const hasBars = hgBars.length > 0;
 

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -28,6 +28,7 @@ const WeeklyReviewModal = () => {
     habitsEnabled, habits, habitLogs,
     gtdFrames,
     aiConfig,
+    ownedBy, meUserSyncId,
   } = useFeaturesCtx();
 
   // Local collapse state for past-week HABITS and FRAME UTILIZATION sections
@@ -270,7 +271,7 @@ const WeeklyReviewModal = () => {
           purple: '#a855f7', pink: '#ec4899', cyan: '#06b6d4', orange: '#f97316',
         };
         const habitStats = (habitsEnabled && habits.length > 0)
-          ? habits.filter(h => h.enabled !== false).map(h => {
+          ? habits.filter(h => h.enabled !== false && ownedBy(h, meUserSyncId)).map(h => {
               const days = pastWeekDates.map(ds => {
                 const count = (habitLogs?.[ds]?.[h.id]) ?? 0;
                 return h.type === 'limit' ? count <= h.target : count >= h.target;

--- a/src/components/goals/GoalCard.jsx
+++ b/src/components/goals/GoalCard.jsx
@@ -29,9 +29,10 @@ const GoalCard = forwardRef(
       darkMode,
       borderClass, textPrimary, textSecondary, hoverBg,
     } = useDayPlannerCtx();
-    const { updateGoal } = useFeaturesCtx();
+    const { updateGoal, isVisibleForUser } = useFeaturesCtx();
 
-    const allTasks = [...tasks, ...unscheduledTasks];
+    // Multi-user: progress and stalled state reflect only the current user's tasks.
+    const allTasks = [...tasks, ...unscheduledTasks].filter(isVisibleForUser);
     const progress = calculateGoalProgress(goal.id, projects, allTasks);
     const goalColor = goal.color || 'bg-blue-500';
 

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -830,7 +830,7 @@ export const FormOverlay = ({ children, onClose, mobile, cardBg }) => {
 
 const GoalMiniCard = ({ goal, onClick }) => {
   const { darkMode, textPrimary, textSecondary, tasks, unscheduledTasks } = useDayPlannerCtx();
-  const { projects, updateGoal } = useFeaturesCtx();
+  const { projects, updateGoal, isVisibleForUser } = useFeaturesCtx();
   const { t } = useTranslation();
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -850,7 +850,7 @@ const GoalMiniCard = ({ goal, onClick }) => {
     if (diff < 0) isOverdue = true;
   }
 
-  const allTasks = useMemo(() => [...tasks, ...unscheduledTasks], [tasks, unscheduledTasks]);
+  const allTasks = useMemo(() => [...tasks, ...unscheduledTasks].filter(isVisibleForUser), [tasks, unscheduledTasks, isVisibleForUser]);
   const childProjects = useMemo(() => projects.filter(p => p.goalId === goal.id && p.status !== 'archived'), [projects, goal.id]);
   const hasStalledProject = useMemo(() => childProjects.some(p => isProjectStalled(p.id, allTasks, p)), [childProjects, allTasks]);
   const showCaution = isOverdue || hasStalledProject;
@@ -1404,7 +1404,7 @@ const MobileDashboard = ({
   isActive = false,
 }) => {
   const { darkMode, textPrimary, textSecondary, hoverBg, cardBg, borderClass, tasks: scheduledTasks, unscheduledTasks } = useDayPlannerCtx();
-  const { updateGoal, moveProject, goalsDashboardFocusId, setGoalsDashboardFocusId } = useFeaturesCtx();
+  const { updateGoal, moveProject, goalsDashboardFocusId, setGoalsDashboardFocusId, isVisibleForUser } = useFeaturesCtx();
   const { t } = useTranslation();
 
   const scrollRef = useRef(null);
@@ -1626,7 +1626,7 @@ const MobileDashboard = ({
               >
                 {/* Goal header card */}
                 {(() => {
-                  const allTasks = [...scheduledTasks, ...unscheduledTasks];
+                  const allTasks = [...scheduledTasks, ...unscheduledTasks].filter(isVisibleForUser);
                   const goalProgress = calculateGoalProgress(goal.id, activeProjects, allTasks);
                   const nonArchivedProjects = activeProjects.filter(p => p.goalId === goal.id);
                   const isCompleted = goal.status === 'completed';

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -45,6 +45,7 @@ import { useTranslation } from 'react-i18next';
 import GoalProgress from './GoalProgress.jsx';
 import ProjectCard from '../projects/ProjectCard.jsx';
 import ConfirmDialog from '../ConfirmDialog.jsx';
+import UserAssignmentPicker from '../UserAssignmentPicker.jsx';
 import DatePicker from '../DatePicker.jsx';
 import ClockTimePicker from '../ClockTimePicker.jsx';
 import { emitGoalCreate } from '../../intents/emitGoalCreate.js';
@@ -117,6 +118,7 @@ function findDefaultActiveIdx(sortedGoals) {
 const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mobile, showLifeGlanceCheckbox = false }) => {
   const { darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg, isMobile } =
     useDayPlannerCtx();
+  const { multiUserEnabled, users } = useFeaturesCtx();
   const { t } = useTranslation();
 
   const [title, setTitle] = useState(initial?.title || '');
@@ -124,6 +126,7 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
   const [targetDate, setTargetDate] = useState(initial?.targetDate || '');
   const [color, setColor] = useState(initial?.color || TASK_COLORS[0].class);
   const [status, setStatus] = useState(initial?.status || 'active');
+  const [assignedUserSyncIds, setAssignedUserSyncIds] = useState(initial?.assignedUserSyncIds || []);
   const [trackInLifeGlance, setTrackInLifeGlance] = useState(false);
 
   // "Completed" only available when all child projects are completed (or none exist)
@@ -133,7 +136,7 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!title.trim()) return;
-    onSave({ title: title.trim(), description: description.trim(), targetDate: targetDate || undefined, color, status, trackInLifeGlance: showLifeGlanceCheckbox && !initial && trackInLifeGlance });
+    onSave({ title: title.trim(), description: description.trim(), targetDate: targetDate || undefined, color, status, assignedUserSyncIds, trackInLifeGlance: showLifeGlanceCheckbox && !initial && trackInLifeGlance });
   };
 
   return (
@@ -209,6 +212,17 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
       <div
         className="h-1.5 rounded-full w-full"
         style={{ background: toHex(color) }}
+      />
+
+      {/* Assigned users — multi-user only */}
+      <UserAssignmentPicker
+        enabled={multiUserEnabled}
+        users={users}
+        value={assignedUserSyncIds}
+        onChange={setAssignedUserSyncIds}
+        darkMode={darkMode}
+        borderClass={borderClass}
+        textSecondary={textSecondary}
       />
 
       {/* Status — edit only */}
@@ -316,12 +330,14 @@ const HG_ICON_MAP = {
 export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, mobile }) => {
   const { darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg, tasks, unscheduledTasks, use24HourClock, isMobile, isTablet } =
     useDayPlannerCtx();
+  const { multiUserEnabled, users } = useFeaturesCtx();
   const { t } = useTranslation();
 
   const [title, setTitle] = useState(initial?.title || '');
   const [description, setDescription] = useState(initial?.description || '');
   const [goalId, setGoalId] = useState(initial?.goalId || defaultGoalId || '');
   const [status, setStatus] = useState(initial?.status || 'active');
+  const [assignedUserSyncIds, setAssignedUserSyncIds] = useState(initial?.assignedUserSyncIds || []);
 
   // ── hyperGLANCE state ────────────────────────────────────────────────────
   const initHG = initial?.hyperglance || {};
@@ -380,7 +396,7 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
       completions: initHG.completions || [],
       createdAt: initHG.createdAt || new Date().toISOString(),
     } : null;
-    onSave({ title: title.trim(), description: description.trim(), goalId: goalId || undefined, status, hyperglance });
+    onSave({ title: title.trim(), description: description.trim(), goalId: goalId || undefined, status, assignedUserSyncIds, hyperglance });
   };
 
   const activeGoals = goals.filter(g => g.status !== 'archived');
@@ -439,6 +455,17 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
           ))}
         </select>
       </div>
+
+      {/* Assigned users — multi-user only */}
+      <UserAssignmentPicker
+        enabled={multiUserEnabled}
+        users={users}
+        value={assignedUserSyncIds}
+        onChange={setAssignedUserSyncIds}
+        darkMode={darkMode}
+        borderClass={borderClass}
+        textSecondary={textSecondary}
+      />
 
       {/* Status — edit only */}
       {initial && (
@@ -1908,6 +1935,7 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
     goals, projects, setProjects,
     addGoal, updateGoal, deleteGoal,
     addProject, updateProject,
+    isVisibleForUser,
   } = useFeaturesCtx();
   const { t } = useTranslation();
 
@@ -1931,10 +1959,16 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
   const goalCardRefs = useRef({});
   const projectCardRefs = useRef({});
 
-  const activeGoals = useMemo(() => goals.filter(g => g.status !== 'archived'), [goals]);
-  const activeProjects = useMemo(() => projects.filter(p => p.status !== 'archived'), [projects]);
-  const archivedGoals = useMemo(() => goals.filter(g => g.status === 'archived'), [goals]);
-  const archivedProjects = useMemo(() => projects.filter(p => p.status === 'archived'), [projects]);
+  // Multi-user: filter goals and projects independently by assignment (empty =
+  // everybody). Goals are NOT hidden just because their visible children are
+  // filtered out, so shared family goals stay put regardless of who owns the
+  // child projects.
+  const visibleGoals = useMemo(() => goals.filter(isVisibleForUser), [goals, isVisibleForUser]);
+  const visibleProjects = useMemo(() => projects.filter(isVisibleForUser), [projects, isVisibleForUser]);
+  const activeGoals = useMemo(() => visibleGoals.filter(g => g.status !== 'archived'), [visibleGoals]);
+  const activeProjects = useMemo(() => visibleProjects.filter(p => p.status !== 'archived'), [visibleProjects]);
+  const archivedGoals = useMemo(() => visibleGoals.filter(g => g.status === 'archived'), [visibleGoals]);
+  const archivedProjects = useMemo(() => visibleProjects.filter(p => p.status === 'archived'), [visibleProjects]);
   const archivedCount = archivedGoals.length + archivedProjects.length;
 
   const handleSaveGoal = (fields) => {

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -43,7 +43,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
     mobileActiveTab,
   } = useDayPlannerCtx();
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
-  const { goals, deleteProject, generateAISubtasks, aiSubtasksLoadingForTask, aiConfig, showGoalsDashboard, enterHyperGlanceMode } = useFeaturesCtx();
+  const { goals, deleteProject, generateAISubtasks, aiSubtasksLoadingForTask, aiConfig, showGoalsDashboard, enterHyperGlanceMode, isVisibleForUser } = useFeaturesCtx();
 
   const isScheduled = (t) => !!tasks.find(s => s.id === t.id);
 
@@ -85,7 +85,8 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
   const parentGoal = project.goalId ? goals.find(g => g.id === project.goalId) : null;
   const goalHex = parentGoal ? toHex(parentGoal.color || 'bg-blue-500') : null;
 
-  const allTasks = [...tasks, ...unscheduledTasks];
+  // Multi-user: only count/show the current user's tasks within the project.
+  const allTasks = [...tasks, ...unscheduledTasks].filter(isVisibleForUser);
   const projectTasks = allTasks.filter(t => t.projectId === project.id && !t.archived);
   const completedCount = projectTasks.filter(t => t.completed).length;
   const totalCount = projectTasks.length;
@@ -94,8 +95,8 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
   const stalled = !!project.goalId && !hasHGSession && isProjectStalled(project.id, allTasks, project);
 
   // All project tasks: unscheduled (in array order) then scheduled (by date), completed last
-  const projectUnscheduled = unscheduledTasks.filter(t => t.projectId === project.id && !t.archived);
-  const projectScheduled = tasks.filter(t => t.projectId === project.id && !t.archived)
+  const projectUnscheduled = unscheduledTasks.filter(t => t.projectId === project.id && !t.archived && isVisibleForUser(t));
+  const projectScheduled = tasks.filter(t => t.projectId === project.id && !t.archived && isVisibleForUser(t))
     .sort((a, b) => (a.date || '').localeCompare(b.date || ''));
   const allProjectDisplayTasks = [
     ...projectScheduled.filter(t => !t.completed),

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -57,6 +57,7 @@ export default function useElectronBridge({
   currentTime,
   tasks,
   expandedRecurringTasks,
+  isVisibleForUser = () => true,
   todayHGSessions,
   focusModeAvailable,
   showFocusMode,
@@ -438,28 +439,30 @@ export default function useElectronBridge({
       timeToMinutes(t.startTime) + (t.duration || 0) <= nowMin;
 
     const todayStr = dateToString(currentTime);
-    const todayRecurring = (expandedRecurringTasks || []).filter(t => t.date === todayStr);
+    // Multi-user: only surface the current user's tasks on tray/Stream Deck/menu bar.
+    const vTasks = (tasks || []).filter(isVisibleForUser);
+    const todayRecurring = (expandedRecurringTasks || []).filter(t => t.date === todayStr && isVisibleForUser(t));
 
     const tomorrowDate = new Date(currentTime);
     tomorrowDate.setDate(tomorrowDate.getDate() + 1);
     const tomorrowStr = dateToString(tomorrowDate);
-    const tomorrowRecurring = (expandedRecurringTasks || []).filter(t => t.date === tomorrowStr);
+    const tomorrowRecurring = (expandedRecurringTasks || []).filter(t => t.date === tomorrowStr && isVisibleForUser(t));
     const tomorrowAllDay = [
-      ...tasks.filter(t => t.date === tomorrowStr && !!t.isAllDay),
+      ...vTasks.filter(t => t.date === tomorrowStr && !!t.isAllDay),
       ...tomorrowRecurring.filter(t => !!t.isAllDay),
     ];
     const tomorrowTimed = [
-      ...tasks.filter(t => t.date === tomorrowStr && t.startTime && !t.isAllDay),
+      ...vTasks.filter(t => t.date === tomorrowStr && t.startTime && !t.isAllDay),
       ...tomorrowRecurring.filter(t => t.startTime && !t.isAllDay),
     ].sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime));
     // Include recurring instances in counts (stable denominator — all tasks regardless of completion/time)
     const todayTasks = [
-      ...tasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay),
+      ...vTasks.filter(t => t.date === todayStr && t.startTime && !t.isAllDay),
       ...todayRecurring.filter(t => t.startTime && !t.isAllDay),
       ...hgSessions,
     ];
     const allDayTasks = [
-      ...tasks.filter(t => t.date === todayStr && t.isAllDay),
+      ...vTasks.filter(t => t.date === todayStr && t.isAllDay),
       ...todayRecurring.filter(t => t.isAllDay),
     ];
 
@@ -487,10 +490,10 @@ export default function useElectronBridge({
       .sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime))[0] ?? null;
 
     // ── Goals ─────────────────────────────────────────────────────────────
-    const allTasksForGoals = [...tasks, ...(unscheduledTasks || [])];
+    const allTasksForGoals = [...vTasks, ...(unscheduledTasks || []).filter(isVisibleForUser)];
     const todayMs = new Date(dateToString(currentTime) + 'T00:00:00').getTime();
     const goalsPayload = goalsProjectsEnabled ? (goals || [])
-      .filter(g => g.status === 'active')
+      .filter(g => g.status === 'active' && isVisibleForUser(g))
       .map(g => {
         const progress = Math.round(calculateGoalProgress(g.id, projects || [], allTasksForGoals) * 100);
         const colorHex = TAILWIND_TO_HEX[g.color] || '#3b82f6';
@@ -520,7 +523,7 @@ export default function useElectronBridge({
       };
     };
     const sortByProgressAsc = (a, b) => a.progress - b.progress;
-    const activeProjects = goalsProjectsEnabled ? (projects || []).filter(p => p.status === 'active') : [];
+    const activeProjects = goalsProjectsEnabled ? (projects || []).filter(p => p.status === 'active' && isVisibleForUser(p)) : [];
     const projectsPayload = [
       ...activeProjects.filter(p => p.goalId).map(mapProject).sort(sortByProgressAsc),
       ...activeProjects.filter(p => !p.goalId).map(mapProject).sort(sortByProgressAsc),

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useMemo } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
 import { getDeviceId, isNativeIOS } from '../native.js';
 
-const useHabits = ({ playUISound }) => {
+const useHabits = ({ playUISound, hrOwnerRef }) => {
   const [habits, setHabits] = useState([]);
   const [habitLogs, setHabitLogs] = useState({});
   const [habitsEnabled, setHabitsEnabled] = useState(() => {
@@ -133,7 +133,16 @@ const useHabits = ({ playUISound }) => {
   };
 
   const addHabit = (habit) => {
-    setHabits(prev => [...prev, { ...habit, id: crypto.randomUUID(), createdAt: new Date().toISOString(), archived: false }]);
+    // Multi-user: stamp the dashboard's active owner so the habit only shows for
+    // that user. Single-user mode leaves it unowned (ref is null).
+    const owner = hrOwnerRef?.current;
+    setHabits(prev => [...prev, {
+      ...habit,
+      ...(habit.ownerSyncId || owner ? { ownerSyncId: habit.ownerSyncId ?? owner } : {}),
+      id: crypto.randomUUID(),
+      createdAt: new Date().toISOString(),
+      archived: false,
+    }]);
   };
 
   const updateHabit = (id, updates) => {
@@ -152,13 +161,26 @@ const useHabits = ({ playUISound }) => {
   };
 
   const reorderHabits = (fromIndex, toIndex) => {
+    // In multi-user mode the indices come from the owner-filtered list shown in
+    // the dashboard, so reorder only within that owner's active habits and leave
+    // other members' positions untouched.
+    const owner = hrOwnerRef?.current ?? null;
     setHabits(prev => {
       const updated = [...prev];
-      const active = updated.filter(h => !h.archived);
-      const [moved] = active.splice(fromIndex, 1);
-      active.splice(toIndex, 0, moved);
       const archived = updated.filter(h => h.archived);
-      return [...active, ...archived];
+      const active = updated.filter(h => !h.archived);
+      if (!owner) {
+        const [moved] = active.splice(fromIndex, 1);
+        active.splice(toIndex, 0, moved);
+        return [...active, ...archived];
+      }
+      const isOwners = (h) => !h.ownerSyncId || h.ownerSyncId === owner;
+      const ownerActive = active.filter(isOwners);
+      const [moved] = ownerActive.splice(fromIndex, 1);
+      ownerActive.splice(toIndex, 0, moved);
+      let oi = 0;
+      const rebuiltActive = active.map(h => isOwners(h) ? ownerActive[oi++] : h);
+      return [...rebuiltActive, ...archived];
     });
   };
 

--- a/src/hooks/useReminderEngine.js
+++ b/src/hooks/useReminderEngine.js
@@ -50,6 +50,7 @@ export default function useReminderEngine({
   tasks,
   expandedRecurringTasks,
   hgSessions = [],
+  isVisibleForUser = () => true,
   playUISound,
   pushUndo,
   setTasks,
@@ -180,8 +181,8 @@ export default function useReminderEngine({
     }
 
     // Gather all today's tasks
-    const todayRegular = tasks.filter(t => t.date === todayStr);
-    const todayRecurring = expandedRecurringTasks.filter(t => t.date === todayStr);
+    const todayRegular = tasks.filter(t => t.date === todayStr && isVisibleForUser(t));
+    const todayRecurring = expandedRecurringTasks.filter(t => t.date === todayStr && isVisibleForUser(t));
     const allTodayTasks = [...todayRegular, ...todayRecurring];
 
     const newReminders = [];
@@ -252,7 +253,7 @@ export default function useReminderEngine({
         }
       }
     }
-  }, [currentTime, reminderSettings, tasks, expandedRecurringTasks, hgSessions]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [currentTime, reminderSettings, tasks, expandedRecurringTasks, hgSessions, isVisibleForUser]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-dismiss reminders based on type
   useEffect(() => {
@@ -284,8 +285,8 @@ export default function useReminderEngine({
 
     // ── Task reminders (only when globally enabled) ────────────────────────
     if (reminderSettings.enabled) {
-      const todayRegular = tasks.filter(t => t.date === todayStr && !t.completed);
-      const todayRecurring = expandedRecurringTasks.filter(t => t.date === todayStr);
+      const todayRegular = tasks.filter(t => t.date === todayStr && !t.completed && isVisibleForUser(t));
+      const todayRecurring = expandedRecurringTasks.filter(t => t.date === todayStr && isVisibleForUser(t));
       const allTodayTasks = [...todayRegular, ...todayRecurring];
 
       const messageMap = {
@@ -355,7 +356,7 @@ export default function useReminderEngine({
     }
 
     nativeSyncReminders(futureReminders);
-  }, [tasks, expandedRecurringTasks, reminderSettings, hgSessions]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [tasks, expandedRecurringTasks, reminderSettings, hgSessions, isVisibleForUser]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Reminder snooze: push task start time forward 15 minutes
   const snoozeReminder = (reminder) => {

--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -1,7 +1,11 @@
 import { useState, useEffect } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
 
-const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress }) => {
+const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, hrOwnerRef }) => {
+  // The dashboard's active owner (multi-user) or null in single-user mode.
+  const currentOwner = () => hrOwnerRef?.current ?? null;
+  // True when a routine chip / today-routine belongs to `owner` (or is unowned).
+  const ownedByOwner = (item, owner) => !owner || !item.ownerSyncId || item.ownerSyncId === owner;
   const [routineDefinitions, setRoutineDefinitions] = useState({ monday: [], tuesday: [], wednesday: [], thursday: [], friday: [], saturday: [], sunday: [], everyday: [] });
   const [todayRoutines, setTodayRoutines] = useState([]);
   const [routinesDate, setRoutinesDate] = useState('');
@@ -72,9 +76,18 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress })
     });
   };
 
+  // Pre-populate the dashboard center with the given owner's placed routines.
+  const selectTodayChipsForOwner = (owner) => {
+    setDashboardSelectedChips(
+      todayRoutines
+        .filter(r => ownedByOwner(r, owner))
+        .map(r => ({ id: r.id, name: r.name, bucket: r.bucket, startTime: r.startTime || null }))
+    );
+  };
+
   const openRoutinesDashboard = () => {
-    // Pre-populate center with chips already placed today
-    setDashboardSelectedChips(todayRoutines.map(r => ({ id: r.id, name: r.name, bucket: r.bucket, startTime: r.startTime || null })));
+    // Pre-populate center with the active owner's chips already placed today
+    selectTodayChipsForOwner(currentOwner());
     setRoutineAddingToBucket(null);
     setRoutineNewChipName('');
     setShowRoutinesDashboard(true);
@@ -84,9 +97,10 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress })
     const name = routineNewChipName.trim();
     if (!name) return;
     const chipId = crypto.randomUUID();
+    const owner = currentOwner();
     setRoutineDefinitions(prev => ({
       ...prev,
-      [bucket]: [...prev[bucket], { id: chipId, name, lastModified: new Date().toISOString() }]
+      [bucket]: [...prev[bucket], { id: chipId, name, ...(owner ? { ownerSyncId: owner } : {}), lastModified: new Date().toISOString() }]
     }));
     setRoutineNewChipName('');
     setRoutineAddingToBucket(null);
@@ -123,6 +137,7 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress })
 
   const handleRoutinesDone = () => {
     const todayStr = dateToString(new Date());
+    const owner = currentOwner();
     // Preserve placement info for chips that were already placed on the timeline
     const existingMap = {};
     todayRoutines.forEach(r => { existingMap[r.id] = r; });
@@ -135,15 +150,15 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress })
         // existing DnD-placed time so that opening and closing the modal without
         // touching the time picker never unschedules a placed routine.
         const startTime = chip.startTime !== null ? chip.startTime : (existing.startTime || null);
-        return { ...existing, name: chip.name, bucket: chip.bucket, startTime, isAllDay: !startTime, lastModified: now };
+        return { ...existing, name: chip.name, bucket: chip.bucket, startTime, isAllDay: !startTime, ...(owner ? { ownerSyncId: existing.ownerSyncId ?? owner } : {}), lastModified: now };
       }
-      return { id: chip.id, name: chip.name, bucket: chip.bucket, startTime: chip.startTime || null, duration: 15, isAllDay: !chip.startTime, lastModified: now };
+      return { id: chip.id, name: chip.name, bucket: chip.bucket, startTime: chip.startTime || null, duration: 15, isAllDay: !chip.startTime, ...(owner ? { ownerSyncId: owner } : {}), lastModified: now };
     });
 
-    // Record tombstones for routines that were removed from today's list
-    // so the removal syncs across devices instead of being re-added by merge.
+    // Record tombstones for the active owner's routines that were removed from
+    // today's list so the removal syncs. Other members' entries are left alone.
     const newIds = new Set(newTodayRoutines.map(r => String(r.id)));
-    const removedIds = todayRoutines.filter(r => !newIds.has(String(r.id)));
+    const removedIds = todayRoutines.filter(r => ownedByOwner(r, owner) && !newIds.has(String(r.id)));
     if (removedIds.length > 0) {
       setRemovedTodayRoutineIds(prev => {
         const updated = { ...prev };
@@ -162,7 +177,8 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress })
       });
     }
 
-    setTodayRoutines(newTodayRoutines);
+    // Replace only the active owner's today routines; keep other members'.
+    setTodayRoutines(prev => [...prev.filter(r => !ownedByOwner(r, owner)), ...newTodayRoutines]);
     setRoutinesDate(todayStr);
     setShowRoutinesDashboard(false);
     setRoutineTimePickerChipId(null);
@@ -193,6 +209,7 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress })
     deleteRoutineChip,
     toggleRoutineChipSelection,
     handleRoutinesDone,
+    selectTodayChipsForOwner,
   };
 };
 

--- a/src/hooks/useStats.js
+++ b/src/hooks/useStats.js
@@ -2,8 +2,14 @@ import { useMemo } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
 import { getOccurrencesInRange } from '../utils/recurrenceEngine.js';
 
-export default function useStats({ tasks, unscheduledTasks, recurringTasks, goals = [], projects = [] }) {
+export default function useStats({ tasks: rawTasks, unscheduledTasks: rawUnscheduled, recurringTasks: rawRecurring, goals = [], projects = [], isVisibleForUser = () => true }) {
   const todayStr = dateToString(new Date());
+
+  // Multi-user: stats reflect only the current user's tasks. Filtering the
+  // inputs here keeps every downstream computation user-scoped.
+  const tasks = useMemo(() => rawTasks.filter(isVisibleForUser), [rawTasks, isVisibleForUser]);
+  const unscheduledTasks = useMemo(() => rawUnscheduled.filter(isVisibleForUser), [rawUnscheduled, isVisibleForUser]);
+  const recurringTasks = useMemo(() => rawRecurring.filter(isVisibleForUser), [rawRecurring, isVisibleForUser]);
 
   // All-time stats helpers (exclude imported events, include recurring)
   // Only count tasks up through today — future tasks aren't "incomplete" yet


### PR DESCRIPTION
## Summary

Makes multi-user task visibility coherent end-to-end. The guiding principle is now: **a task you can't see never appears on any surface, and a shared (unassigned) project shows only your own tasks/counts/progress.** Everything is gated by `isVisibleForUser`, which returns `true` when multi-user is disabled — so single-user behavior is unchanged.

This branch builds on earlier passes (Goals/Projects, Habits/Routines, hyperGLANCE + weekly-AI) and closes the remaining leaks found in an audit.

## What changed

- **Reminders / notifications** (`useReminderEngine`): in-app, browser, native, and scheduled OS background alarms now skip tasks not visible to the current user.
- **iOS Spotlight indexing**: no longer indexes other members' task titles/notes.
- **Electron bridge** (tray / Stream Deck / menu bar): today/tomorrow lists, counts, and goal/project progress are user-scoped.
- **Android widget snapshot**: goal/project widgets iterate only visible goals/projects and count only visible tasks.
- **hyperGLANCE**: session task counts exclude other members' tasks.
- **Productivity stats** (`useStats`, incl. weekly review numbers): reflect only the current user's tasks.
- **Project cards & goal/project progress**: lists, totals, and progress % count only visible tasks.

## Deliberate non-changes

- **Project completion gate** still considers *all* tasks (not just yours), so one member can't mark a shared project done while another's tasks are still open.
- **Daily notes** remain shared per-day (not per-user).

## Testing

- `vite build` — green
- `vitest run` — 256 passed

https://claude.ai/code/session_01SdzQiWY66TomVnRBoPwiWC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdzQiWY66TomVnRBoPwiWC)_