### PR TITLE
Reframe paywall to lead with free trial + bump to 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.2.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.3.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 115
-        versionName = "3.2"
+        versionCode = 116
+        versionName = "3.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.2.0",
+  "version": "3.3.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/SubscriptionWall.jsx
+++ b/src/components/SubscriptionWall.jsx
@@ -110,10 +110,12 @@ export default function SubscriptionWall({
 
       {/* Headline */}
       <h1 className={`text-xl font-semibold text-center mb-2 ${text}`}>
-        Unlock dayGLANCE Pro
+        {trialEligible ? 'Start your 14-day free trial' : 'Unlock dayGLANCE Pro'}
       </h1>
       <p className={`text-sm text-center mb-7 max-w-xs ${sub}`}>
-        Choose a plan to keep using dayGLANCE. Your data is safe and waiting.
+        {trialEligible
+          ? 'Free for 14 days — nothing charged today. Cancel anytime, keep your data.'
+          : 'Pick a plan to pick up where you left off. Your data is safe and waiting.'}
       </p>
 
       {/* Error message */}
@@ -126,27 +128,7 @@ export default function SubscriptionWall({
       {/* Plan cards */}
       <div className="w-full max-w-xs space-y-3 mb-5">
 
-        {/* Lifetime — best value, shown first */}
-        <button
-          onClick={() => handleSubscribe('lifetime', onSubscribeLifetime)}
-          disabled={!!pending}
-          className={`w-full rounded-xl border px-4 py-4 text-left transition-colors ${card} ${pending === 'lifetime' ? 'opacity-60' : ''}`}
-        >
-          <div className="flex items-baseline justify-between">
-            <div className="flex items-center gap-2">
-              <span className={`font-semibold text-sm ${text}`}>Lifetime</span>
-              <span className="text-xs bg-indigo-600 text-white rounded-full px-2 py-0.5 leading-none">Best value</span>
-            </div>
-            {prices?.lifetime
-              ? <span className={`text-sm font-medium ${text}`}>{prices.lifetime}</span>
-              : <span className={`text-xs ${sub}`}>Loading…</span>
-            }
-          </div>
-          <div className={`text-xs mt-0.5 ${sub}`}>One-time purchase · yours forever</div>
-          {pending === 'lifetime' && <Loader className={`w-4 h-4 mt-2 animate-spin ${sub}`} />}
-        </button>
-
-        {/* Annual subscription */}
+        {/* Annual subscription — shown first; carries the free trial */}
         <button
           onClick={() => handleSubscribe('yearly', onSubscribeYearly)}
           disabled={!!pending}
@@ -165,6 +147,26 @@ export default function SubscriptionWall({
               : `Billed yearly · ${prices?.yearly ?? '$9.99'}/yr`}
           </div>
           {pending === 'yearly' && <Loader className={`w-4 h-4 mt-2 animate-spin ${sub}`} />}
+        </button>
+
+        {/* Lifetime — best value */}
+        <button
+          onClick={() => handleSubscribe('lifetime', onSubscribeLifetime)}
+          disabled={!!pending}
+          className={`w-full rounded-xl border px-4 py-4 text-left transition-colors ${card} ${pending === 'lifetime' ? 'opacity-60' : ''}`}
+        >
+          <div className="flex items-baseline justify-between">
+            <div className="flex items-center gap-2">
+              <span className={`font-semibold text-sm ${text}`}>Lifetime</span>
+              <span className="text-xs bg-indigo-600 text-white rounded-full px-2 py-0.5 leading-none">Best value</span>
+            </div>
+            {prices?.lifetime
+              ? <span className={`text-sm font-medium ${text}`}>{prices.lifetime}</span>
+              : <span className={`text-xs ${sub}`}>Loading…</span>
+            }
+          </div>
+          <div className={`text-xs mt-0.5 ${sub}`}>One-time purchase · yours forever</div>
+          {pending === 'lifetime' && <Loader className={`w-4 h-4 mt-2 animate-spin ${sub}`} />}
         </button>
 
       </div>


### PR DESCRIPTION
## Summary

Softens the launch paywall so trial-eligible users read the free trial first instead of a pay prompt, and bumps the app version to 3.3.0.

### Paywall reframe (`src/components/SubscriptionWall.jsx`)
- **Trial-forward headline/subtext** when `trialEligible`: "Start your 14-day free trial" / "Free for 14 days — nothing charged today. Cancel anytime, keep your data." Non-eligible users keep the existing "Unlock dayGLANCE Pro" copy.
- **Annual card moved above Lifetime** for everyone, so the trial-bearing plan leads.
- Everything below the cards (disclosure, payment line, Restore, Reviewer access) is untouched. No external links or outside-payment steering, keeping clear of App Store guideline 3.1.1 and Play policy.

### Version bump → 3.3.0
- `package.json` + lockfile: 3.2.0 → 3.3.0
- Android (`dayglance-android/app/build.gradle.kts`): `versionCode` 115 → 116, `versionName` 3.2 → 3.3
- README version badge: 3.2.0 → 3.3.0

## Why
The goal is to reduce the psychological pressure of a cold paywall on launch by foregrounding the free trial, without introducing any policy-risky "it's free elsewhere" steering language.

## Testing
- `vite build` passes.

https://claude.ai/code/session_01CEA6sUBtYTvpZ9n5Q97Y5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEA6sUBtYTvpZ9n5Q97Y5J)_