### PR TITLE
Fix unscheduled project task assignments and tablet landscape list view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3365,6 +3365,7 @@ const DayPlanner = () => {
           duration: newTask.duration,
           color: newTask.color || colors[0].class,
           projectId: newTask.projectId,
+          assignedUserSyncIds: mobileEditingTask.assignedUserSyncIds ?? rest.assignedUserSyncIds,
         }]);
       } else {
         // Already unscheduled, just update
@@ -3374,6 +3375,7 @@ const DayPlanner = () => {
           duration: newTask.duration,
           color: newTask.color || colors[0].class,
           projectId: newTask.projectId,
+          assignedUserSyncIds: mobileEditingTask.assignedUserSyncIds ?? t.assignedUserSyncIds,
           transitionId: crypto.randomUUID(),
         } : t));
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -268,6 +268,11 @@ const DayPlanner = () => {
     const saved = localStorage.getItem('day-planner-mobile-view-mode');
     return saved ? JSON.parse(saved) : 'grid';
   });
+  // LIST view is a portrait-only tablet feature; in landscape the tablet always
+  // uses the two-column timeline (and hides the LIST/GRID toggle). This mirrors
+  // how wider Android tablets behave, where landscape drops out of tablet mode
+  // entirely. (On phones, list view is independent of orientation.)
+  const tabletListView = isTablet && !isLandscape && mobileViewMode === 'list';
   const [glancePage, setGlancePage] = useState(() => {
     const saved = localStorage.getItem('day-planner-glance-page');
     return saved !== null ? parseInt(saved, 10) : 0;
@@ -1197,7 +1202,7 @@ const DayPlanner = () => {
     selectedDate,
     isMobile, isTablet,
     mobileActiveTab,
-    mobileViewMode,
+    mobileViewMode, tabletListView,
     viewMode: effectiveViewMode,
   });
 
@@ -7946,7 +7951,7 @@ const DayPlanner = () => {
     // ── Layout / navigation ───────────────────────────────────────────────────
     tabletActiveTab, setTabletActiveTab,
     mobileActiveTab, setMobileActiveTab,
-    mobileViewMode, setMobileViewMode,
+    mobileViewMode, setMobileViewMode, tabletListView,
     listEndOfDayTime, setListEndOfDayTime,
     glancePage, setGlancePage,
     mobileWelcomeStep, setMobileWelcomeStep,
@@ -9341,7 +9346,7 @@ const DayPlanner = () => {
       )}
 
       {/* Refocus timeline toast — all form factors except mobile list view */}
-      {timelineScrolledAway && effectiveViewMode === 'multi' && !((isMobile || isTablet) && mobileViewMode === 'list') && (
+      {timelineScrolledAway && effectiveViewMode === 'multi' && !((isMobile && mobileViewMode === 'list') || tabletListView) && (
         <div className="fixed left-1/2 -translate-x-1/2 z-50 pointer-events-auto" style={{ bottom: isMobile ? 'calc(5rem + env(safe-area-inset-bottom, 0px))' : '1.5rem' }}>
           <button
             onClick={() => { setTimelineScrolledAway(false); scrollToCurrentHour(true); }}

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -25,7 +25,7 @@ import { useTranslation } from 'react-i18next';
 
 const CalendarHeader = () => {
   const {
-    isTablet,
+    isTablet, isLandscape,
     visibleDates,
     selectedDate,
     canShowViewCycler, effectiveViewMode,
@@ -164,7 +164,7 @@ const CalendarHeader = () => {
         className={`flex-shrink-0 border-r ${borderClass} flex items-center justify-center`}
         style={{ width: WEEK_GUTTER_W, minHeight: 'var(--header-row-h)' }}
       >
-        {isTablet ? <MobileViewToggle /> : (canShowViewCycler && <ViewCycler />)}
+        {isTablet && !isLandscape ? <MobileViewToggle /> : (canShowViewCycler && <ViewCycler />)}
       </div>
       {weekViewDates.map((date, idx) => {
         const dateStr = dateToString(date);
@@ -204,7 +204,7 @@ const CalendarHeader = () => {
     <>
     {/* Top-left cell: hosts ViewCycler on large screens */}
     <div className={`w-16 flex-shrink-0 border-r ${borderClass} flex items-center justify-center`} style={{ minHeight: 'var(--header-row-h)' }}>
-      {isTablet ? <MobileViewToggle /> : (canShowViewCycler && <ViewCycler />)}
+      {isTablet && !isLandscape ? <MobileViewToggle /> : (canShowViewCycler && <ViewCycler />)}
     </div>
     {visibleDates.map((date, idx) => {
     const isDateToday = dateToString(date) === dateToString(new Date());
@@ -300,7 +300,7 @@ const CalendarHeader = () => {
               column boundaries align: both header and DayView start at x=0. */}
           {idx === 0 && (isTablet || canShowViewCycler) && (
             <div className={`absolute left-0 top-0 w-16 h-full border-r ${borderClass} ${cardBg}`}>
-              {isTablet ? <MobileViewToggle /> : <ViewCycler />}
+              {isTablet && !isLandscape ? <MobileViewToggle /> : <ViewCycler />}
             </div>
           )}
           {/* Ring overlay rendered after ViewCycler so it paints on top of it —

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -56,7 +56,7 @@ const DesktopLayout = () => {
     hours, firstHour,
     tabletActiveTab, setTabletActiveTab,
     mobileActiveTab, setMobileActiveTab,
-    mobileViewMode,
+    tabletListView,
     mobileWelcomeStep, setMobileWelcomeStep,
     desktopWelcomeStep, setDesktopWelcomeStep,
     showMonthView, setShowMonthView,
@@ -816,8 +816,9 @@ const DesktopLayout = () => {
               <CalendarHeader />
               </div>
 
-              {/* Main calendar grid — switches between multi/day/week views, or list view on tablet */}
-              {isTablet && mobileViewMode === 'list'
+              {/* Main calendar grid — switches between multi/day/week views, or list
+                  view on tablet (portrait only; landscape uses the two-column timeline) */}
+              {tabletListView
                 ? <MobileListView hideInboxHandle />
                 : <>
                     {effectiveViewMode === 'multi' && <TimeGrid />}

--- a/src/hooks/useTimelineScroll.js
+++ b/src/hooks/useTimelineScroll.js
@@ -6,7 +6,7 @@ export default function useTimelineScroll({
   selectedDate,
   isMobile, isTablet,
   mobileActiveTab,
-  mobileViewMode,
+  mobileViewMode, tabletListView,
   viewMode = 'multi',
 }) {
   const [timelineScrolledAway, setTimelineScrolledAway] = useState(false);
@@ -51,14 +51,15 @@ export default function useTimelineScroll({
       if (calendarRef.current) calendarRef.current.scrollTop = 0;
       return;
     }
-    // On mobile, skip scroll-to-now when in list view (no time grid to scroll)
-    if (isMobile && mobileViewMode === 'list') return;
+    // Skip scroll-to-now when in list view (no time grid to scroll) — on phones
+    // whenever list mode is active, and on tablets in portrait list mode.
+    if ((isMobile && mobileViewMode === 'list') || tabletListView) return;
     const isToday = dateToString(selectedDate) === dateToString(new Date());
     if (isToday && calendarRef.current && (!isMobile || mobileActiveTab === 'timeline')) {
       const timerId = setTimeout(() => scrollToCurrentHour(false), 100);
       return () => clearTimeout(timerId);
     }
-  }, [selectedDate, isMobile, mobileActiveTab, mobileViewMode, scrollToCurrentHour, viewMode]);
+  }, [selectedDate, isMobile, mobileActiveTab, mobileViewMode, tabletListView, scrollToCurrentHour, viewMode]);
 
   // Detect when user scrolls away from current time (all form factors)
   useEffect(() => {


### PR DESCRIPTION
## Summary

Two independent fixes batched on this branch.

### 1. Persist user assignments when editing unscheduled project tasks

The save handler for editing tasks (`saveMobileEditTask`, shared by both the desktop and mobile task modals) updated `assignedUserSyncIds` in every branch **except** the one for unscheduled project tasks (`keepUnscheduled && projectId`). As a result, assigning users to an unscheduled project task silently dropped the change on save.

`mobileEditingTask.assignedUserSyncIds` (the value the picker writes to) is now carried through both the stay-unscheduled and move-to-unscheduled paths, matching every other save branch.

### 2. Use the two-column timeline on tablets in landscape instead of list view

On tablets, LIST view rendered in **both** orientations whenever `mobileViewMode === 'list'`. Because iPads stay under the 1200px tablet breakpoint in landscape (unlike wider Android tablets, which drop out of tablet mode and into the desktop two-column path), landscape iPads showed the single list body underneath a two-column date header — a broken hybrid.

LIST is now a **portrait-only** tablet feature, via a derived `tabletListView` flag. In landscape, tablets always use the two-column timeline and the LIST/GRID toggle is hidden, matching desktop and Android behavior. The flag is also threaded into the refocus-timeline toast and `useTimelineScroll` so scroll-to-now behaves correctly.

## Testing

- `npm test` — 256 passed
- `npx vite build` — clean production build

https://claude.ai/code/session_01AfoX2Q2WTgCWS2nXRbwthw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfoX2Q2WTgCWS2nXRbwthw)_