### PR TITLE
Fix multi-user roster sync: UTF-8-safe auth + iCloud "Sync now" button

### DIFF
--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -24,7 +24,8 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from '../intents/useIntentPoller.js';
-import { syncSharedUsers } from '../intents/sharedUsers.js';
+import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUsers.js';
+import { isAvailable as isICloudAvailable } from '../intents/icloudFileTransport.js';
 import { getSyncPassphrase, setSyncPassphrase } from '../utils/crypto.js';
 import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
 import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
@@ -2412,7 +2413,7 @@ const MobileSettingsPanel = () => {
       </div>
       <div className="flex items-center justify-between gap-3">
         <p className={`text-xs ${textSecondary}`}>Share dayGLANCE with your household. Tasks can be assigned to specific people; unassigned tasks are visible to everyone.</p>
-        {cloudSyncConfig?.enabled && (
+        {(cloudSyncConfig?.enabled || isICloudAvailable()) && (
           <button
             type="button"
             disabled={muSyncStatus === 'syncing'}
@@ -2421,7 +2422,11 @@ const MobileSettingsPanel = () => {
               try {
                 const raw = localStorage.getItem(MULTI_USER_CONFIG_KEY);
                 const uPath = raw ? (JSON.parse(raw).usersPath ?? undefined) : undefined;
-                const merged = await syncSharedUsers(cloudSyncConfig, uPath, users);
+                // Prefer WebDAV when configured; otherwise fetch the roster from
+                // iCloud Drive (zero-config sync across same-Apple-ID devices).
+                const merged = cloudSyncConfig?.enabled
+                  ? await syncSharedUsers(cloudSyncConfig, uPath, users)
+                  : await syncSharedUsersViaICloud(uPath, users);
                 if (merged) {
                   localStorage.setItem('dayglance-users', JSON.stringify(merged));
                   setUsers(merged);

--- a/src/intents/sharedUsers.js
+++ b/src/intents/sharedUsers.js
@@ -30,8 +30,12 @@ function usersDir(baseUrl, usersPath) {
   return `${baseUrl}${path}`;
 }
 
+// Encode credentials as Base64 for Basic auth. btoa() alone throws
+// InvalidCharacterError on codepoints > 255 (accented chars, CJK, emoji), so
+// UTF-8-encode first — matching toBase64() used everywhere else in the app.
 function authHeaders(username, appPassword) {
-  const cred = btoa(`${username}:${appPassword}`);
+  const raw = `${username}:${appPassword}`;
+  const cred = btoa(String.fromCharCode(...new TextEncoder().encode(raw)));
   return { 'X-WebDAV-Auth': `Basic ${cred}` };
 }
 


### PR DESCRIPTION
## Problem

Two issues surfaced while testing multi-user on iOS:

1. **"Sync now" reports "Failed" on a WebDAV device** even though the main WebDAV sync works fine on the same device.
2. **No "Sync now" button appears on iCloud-only devices** (no WebDAV configured).

## Root causes

**1. Raw `btoa()` in the roster auth header.** `src/intents/sharedUsers.js` was the only WebDAV code path in the app that built its Basic-auth header with raw `btoa()`:

```js
const cred = btoa(`${username}:${appPassword}`);
```

`btoa()` throws `InvalidCharacterError` on any character above U+00FF (accented letters, CJK, emoji). Every other WebDAV path — the main sync engine, CalDAV, auto-backup — uses a UTF-8-safe encoder (`btoa(String.fromCharCode(...new TextEncoder().encode(str)))`). So when a credential contains a non-ASCII character, the roster sync throws and surfaces as "Failed", while everything else keeps working — exactly the reported symptom.

**2. Button gated behind WebDAV only.** The multi-user "Sync now" button was rendered only when `cloudSyncConfig?.enabled`, so it never appeared on iCloud-only devices — even though the roster can be fetched from iCloud Drive (and already auto-syncs in the background via `syncSharedUsersViaICloud`).

## Changes

- `src/intents/sharedUsers.js`: `authHeaders()` now UTF-8-encodes credentials before Base64, matching the rest of the app.
- `src/components/MobileSettingsPanel.jsx`: show the "Sync now" button when WebDAV is enabled **or** iCloud is available, and route the click to `syncSharedUsers` (WebDAV when configured) or `syncSharedUsersViaICloud` (iCloud otherwise).

## Notes

- The iCloud roster sync already ran automatically in the background, so the missing button was a manual-trigger/feedback gap, not broken sync.
- `vite build` passes.

https://claude.ai/code/session_016xgyZrDrQkTYQFPZ9j11Qi

---
_Generated by [Claude Code](https://claude.ai/code/session_016xgyZrDrQkTYQFPZ9j11Qi)_