### PR TITLE
Fix iOS multi-user roster sync (real cause) + desktop-panel Sync button

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -10,7 +10,8 @@ import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
 import { isNativeAndroid, isNativeApp, nativeGetCalendars } from '../native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault } from '../obsidian.js';
 import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from '../intents/useIntentPoller.js';
-import { syncSharedUsers } from '../intents/sharedUsers.js';
+import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUsers.js';
+import { isAvailable as isICloudAvailable } from '../intents/icloudFileTransport.js';
 import { getSyncPassphrase, setSyncPassphrase } from '../utils/crypto.js';
 import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
 import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
@@ -982,7 +983,7 @@ const SettingsModal = () => {
                             <p className={`${textSecondary} text-xs`}>
                               Share dayGLANCE with your household. Tasks can be assigned to specific people; unassigned tasks are visible to everyone.
                             </p>
-                            {cloudSyncConfig?.enabled && (
+                            {(cloudSyncConfig?.enabled || isICloudAvailable()) && (
                               <button
                                 type="button"
                                 disabled={userSyncStatus === 'syncing'}
@@ -991,7 +992,11 @@ const SettingsModal = () => {
                                   try {
                                     const raw = localStorage.getItem(MULTI_USER_CONFIG_KEY);
                                     const uPath = raw ? (JSON.parse(raw).usersPath ?? undefined) : undefined;
-                                    const merged = await syncSharedUsers(cloudSyncConfig, uPath, users);
+                                    // Prefer WebDAV when configured; otherwise fetch the roster
+                                    // from iCloud Drive (same-Apple-ID zero-config sync).
+                                    const merged = cloudSyncConfig?.enabled
+                                      ? await syncSharedUsers(cloudSyncConfig, uPath, users)
+                                      : await syncSharedUsersViaICloud(uPath, users);
                                     if (merged) {
                                       localStorage.setItem('dayglance-users', JSON.stringify(merged));
                                       setUsers(merged);

--- a/src/utils/cloudSyncProviders.js
+++ b/src/utils/cloudSyncProviders.js
@@ -3,20 +3,22 @@
 import { nativeHttpRequest as _nativeHttpRequest } from '../native.js';
 import { webdavFetch as _webdavFetch, createProviders } from '@glance-apps/sync';
 
-// iOS sets window.DayGlanceIOS = true. Its DayGlanceNative is a Proxy that
-// makes every property truthy — explicitly exclude iOS so it falls through
-// to the Vercel proxy path, same as the original webdavFetch logic.
-const isAndroid =
+// The native HTTP bridge exists on BOTH Android and iOS — iOS exposes it via
+// the DayGlanceNative Proxy (dgbridge:// → URLSession). src/sync/adapter.js (the
+// main sync engine) routes WebDAV through it on iOS, which is why main sync works
+// there; webdavFetch must match. Otherwise iOS falls back to /api/webdav-proxy/,
+// which is unreachable from the app's dg:// origin (proxyUrl is relative), so
+// every request throws. Detection mirrors adapter.js exactly.
+const isNativeApp =
   typeof window !== 'undefined' &&
-  !window.DayGlanceIOS &&
   !!window.DayGlanceNative?.httpRequest;
 
 const dayGlanceEngineConfig = {
   appFolderName: 'GLANCE/dayglance',
   syncFilename: 'dayglance-sync.json',
 
-  // Android: pass the real bridge. iOS/web: null → falls through to proxy.
-  nativeHttpRequest: isAndroid ? _nativeHttpRequest : null,
+  // Android + iOS: use the native bridge. Web: null → falls through to proxy.
+  nativeHttpRequest: isNativeApp ? _nativeHttpRequest : null,
 
   // Electron: detect at module load (preload sets this up before renderer).
   electronProxyFetch:
@@ -34,11 +36,11 @@ const dayGlanceEngineConfig = {
   // Crypto config (threaded to encryptData/decryptData inside providers).
   cryptoDBName: 'dayglance-crypto',
   nativeGetSyncKey:
-    isAndroid && window?.DayGlanceNative?.getSyncKey
+    isNativeApp && window?.DayGlanceNative?.getSyncKey
       ? () => window.DayGlanceNative.getSyncKey()
       : null,
   nativeStoreSyncKey:
-    isAndroid && window?.DayGlanceNative?.storeSyncKey
+    isNativeApp && window?.DayGlanceNative?.storeSyncKey
       ? (val) => window.DayGlanceNative.storeSyncKey(val)
       : null,
 };


### PR DESCRIPTION
Follow-up to #988, which fixed the wrong things. This is the actual fix.

## What #988 got wrong

#988 changed `btoa` → UTF-8-safe encoding and added the iCloud button to `MobileSettingsPanel.jsx`. Neither had any effect on device because:
- the **real** "Failed" cause is the WebDAV **transport** on iOS, not auth encoding; and
- the **iPad renders `SettingsModal.jsx`** (the desktop panel), not `MobileSettingsPanel.jsx`.

## Root cause of "Failed"

The main sync engine (`src/sync/adapter.js`) detects native as `!!window.DayGlanceNative?.httpRequest` — **true on iOS** — and routes WebDAV through the native URLSession bridge. That's why main sync works on the iPad.

But `src/utils/cloudSyncProviders.js` (which backs the bare `webdavFetch` used by `syncSharedUsers`) excluded iOS via `!window.DayGlanceIOS`, so it fell back to `/api/webdav-proxy/`. That relative URL resolves against the app's `dg://` custom-scheme origin (`proxyUrl` is empty in the iOS build), where no such resource exists → the fetch rejects → `syncSharedUsers` throws → **"Failed"**.

## Changes

- **`src/utils/cloudSyncProviders.js`**: detect native as `!!window.DayGlanceNative?.httpRequest` (Android **and** iOS), mirroring `adapter.js`, so `webdavFetch` uses the native bridge on iOS instead of the dead proxy. This also fixes CalDAV/ICS WebDAV calls on iOS.
- **`src/components/SettingsModal.jsx`** (the panel iPad actually uses): show the multi-user "Sync now" button when WebDAV is enabled **or** iCloud is available, routing to `syncSharedUsers` / `syncSharedUsersViaICloud` — matching the `MobileSettingsPanel` change from #988.

## Verification

`vite build` passes (2011 modules). On-device confirmation: after `npm run build:ios` + archive, the "Sync now" button should now appear on the iCloud iPad, and the WebDAV iPad should sync the roster instead of showing "Failed".

https://claude.ai/code/session_016xgyZrDrQkTYQFPZ9j11Qi

---
_Generated by [Claude Code](https://claude.ai/code/session_016xgyZrDrQkTYQFPZ9j11Qi)_