### PR TITLE
Multi-user owner treatment for habits, routines & GTD frames (+ Claim)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -776,6 +776,36 @@ const DayPlanner = () => {
       ? prev.map(h => h.ownerSyncId ? h : { ...h, ownerSyncId: meUserSyncId, lastModified: now })
       : prev);
   }, [meUserSyncId, setHabits]);
+
+  // Routine equivalent of the habit claim: unowned routine chips (excluding the
+  // seeded example- chips) or unowned placed today-routines mean the dashboard
+  // would surface them for everyone. Stamp them with "me" deterministically.
+  const hasUnownedRoutines = useMemo(
+    () => multiUserEnabled && (
+      Object.values(routineDefinitions).some(arr => arr.some(c => !c.ownerSyncId && !String(c.id).startsWith('example-')))
+      || allTodayRoutines.some(r => !r.ownerSyncId)
+    ),
+    [multiUserEnabled, routineDefinitions, allTodayRoutines]
+  );
+  const claimUnownedRoutines = useCallback(() => {
+    if (!meUserSyncId) return;
+    const now = new Date().toISOString();
+    setRoutineDefinitions(prev => {
+      let any = false;
+      const next = {};
+      for (const [bucket, arr] of Object.entries(prev)) {
+        next[bucket] = arr.map(c => {
+          if (c.ownerSyncId || String(c.id).startsWith('example-')) return c;
+          any = true;
+          return { ...c, ownerSyncId: meUserSyncId, lastModified: now };
+        });
+      }
+      return any ? next : prev;
+    });
+    setTodayRoutines(prev => prev.some(r => !r.ownerSyncId)
+      ? prev.map(r => r.ownerSyncId ? r : { ...r, ownerSyncId: meUserSyncId, lastModified: now })
+      : prev);
+  }, [meUserSyncId, setRoutineDefinitions, setTodayRoutines]);
   // Everyday timeline/widgets show only my placed routines; persistence and
   // cloud sync use the full `allTodayRoutines` so other members' entries are
   // preserved across saves.
@@ -8322,6 +8352,7 @@ const DayPlanner = () => {
     // ── Habits & Routines multi-user ──────────────────────────────────────────
     hrViewUserSyncId, setHrViewUserSyncId,
     ownedBy, managedBy,
+    hasUnownedRoutines, claimUnownedRoutines,
 
     // ── Habits ────────────────────────────────────────────────────────────────
     habits, setHabits,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -738,15 +738,44 @@ const DayPlanner = () => {
     return !item.ownerSyncId || item.ownerSyncId === target;
   }, [multiUserEnabled, meUserSyncId]);
 
+  // Stricter ownership test for the management dashboards (the Habit/Routine
+  // owner switcher). Unlike ownedBy, an UNOWNED item belongs to "me" only — it
+  // must never surface under another member, where it would render and be
+  // deletable by someone who doesn't own it (the cross-owner leak that let
+  // "Maggie" see and delete "Jason"'s habits). ownedBy keeps the looser
+  // "unowned = everyone" rule for the everyday "my" rings/timeline so legacy
+  // unstamped items still show for the primary user.
+  const managedBy = useCallback((item, syncId) => {
+    if (!multiUserEnabled) return true;
+    if (item.ownerSyncId) return item.ownerSyncId === syncId;
+    return syncId === meUserSyncId; // unowned → me's (null === null shows in the default view)
+  }, [multiUserEnabled, meUserSyncId]);
+
   // Everyday "my" habits (rings/glance); management list for the switcher user.
   const activeHabits = useMemo(
     () => allActiveHabits.filter(h => ownedBy(h, meUserSyncId)),
     [allActiveHabits, ownedBy, meUserSyncId]
   );
   const managedHabits = useMemo(
-    () => allActiveHabits.filter(h => ownedBy(h, hrViewUserSyncId)),
-    [allActiveHabits, ownedBy, hrViewUserSyncId]
+    () => allActiveHabits.filter(h => managedBy(h, hrViewUserSyncId)),
+    [allActiveHabits, managedBy, hrViewUserSyncId]
   );
+  // Whether the switcher is pointed at "me" and unowned (legacy/unstamped) habits
+  // are present — gates the "Claim" affordance so the primary user can deterministically
+  // take ownership of habits the one-time migration failed to stamp.
+  const hasUnownedHabits = useMemo(
+    () => multiUserEnabled && habits.some(h => !h.ownerSyncId),
+    [multiUserEnabled, habits]
+  );
+  // Stamp every unowned habit (active + archived) with the current "me" so it
+  // stops surfacing for other members and survives cloud sync as explicitly owned.
+  const claimUnownedHabits = useCallback(() => {
+    if (!meUserSyncId) return;
+    const now = new Date().toISOString();
+    setHabits(prev => prev.some(h => !h.ownerSyncId)
+      ? prev.map(h => h.ownerSyncId ? h : { ...h, ownerSyncId: meUserSyncId, lastModified: now })
+      : prev);
+  }, [meUserSyncId, setHabits]);
   // Everyday timeline/widgets show only my placed routines; persistence and
   // cloud sync use the full `allTodayRoutines` so other members' entries are
   // preserved across saves.
@@ -8292,7 +8321,7 @@ const DayPlanner = () => {
 
     // ── Habits & Routines multi-user ──────────────────────────────────────────
     hrViewUserSyncId, setHrViewUserSyncId,
-    ownedBy,
+    ownedBy, managedBy,
 
     // ── Habits ────────────────────────────────────────────────────────────────
     habits, setHabits,
@@ -8306,6 +8335,7 @@ const DayPlanner = () => {
     habitEditingCountId, setHabitEditingCountId,
     habitDayPopup, setHabitDayPopup,
     activeHabits, managedHabits, habitStreaks,
+    hasUnownedHabits, claimUnownedHabits,
     habitLongPressTimer,
     habitLongPressOpenedAt,
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -806,6 +806,19 @@ const DayPlanner = () => {
       ? prev.map(r => r.ownerSyncId ? r : { ...r, ownerSyncId: meUserSyncId, lastModified: now })
       : prev);
   }, [meUserSyncId, setRoutineDefinitions, setTodayRoutines]);
+
+  // GTD Frames equivalent of the habit/routine claim.
+  const hasUnownedFrames = useMemo(
+    () => multiUserEnabled && gtdFrames.some(f => !f.ownerSyncId),
+    [multiUserEnabled, gtdFrames]
+  );
+  const claimUnownedFrames = useCallback(() => {
+    if (!meUserSyncId) return;
+    const now = new Date().toISOString();
+    setGtdFrames(prev => prev.some(f => !f.ownerSyncId)
+      ? prev.map(f => f.ownerSyncId ? f : { ...f, ownerSyncId: meUserSyncId, lastModified: now })
+      : prev);
+  }, [meUserSyncId, setGtdFrames]);
   // Everyday timeline/widgets show only my placed routines; persistence and
   // cloud sync use the full `allTodayRoutines` so other members' entries are
   // preserved across saves.
@@ -842,6 +855,9 @@ const DayPlanner = () => {
     });
     setTodayRoutines(prev => prev.some(r => !r.ownerSyncId)
       ? prev.map(r => r.ownerSyncId ? r : { ...r, ownerSyncId: meUserSyncId, lastModified: now })
+      : prev);
+    setGtdFrames(prev => prev.some(f => !f.ownerSyncId)
+      ? prev.map(f => f.ownerSyncId ? f : { ...f, ownerSyncId: meUserSyncId, lastModified: now })
       : prev);
     localStorage.setItem('dayglance-hr-owner-migrated', now);
     hrMigratedRef.current = true;
@@ -6641,6 +6657,7 @@ const DayPlanner = () => {
     return gtdFrames
       .filter(f => {
         if (!f.enabled) return false;
+        if (!ownedBy(f, meUserSyncId)) return false; // everyday/timeline shows only my frames
         if (f.singleDate) return f.singleDate === dateStr;
         return f.days.includes(dayOfWeek);
       })
@@ -6662,7 +6679,7 @@ const DayPlanner = () => {
         };
       })
       .filter(Boolean);
-  }, [gtdFrames]);
+  }, [gtdFrames, ownedBy, meUserSyncId]);
 
   // --- Frame Nudge --- (must be after getFrameInstancesForDate and getTasksForDate)
   const activeFrameForNudge = useMemo(() => {
@@ -7549,7 +7566,14 @@ const DayPlanner = () => {
     if (frame.id) {
       setGtdFrames(prev => prev.map(f => f.id === frame.id ? frame : f));
     } else {
-      setGtdFrames(prev => [...prev, { ...frame, id: crypto.randomUUID() }]);
+      // Multi-user: stamp the dashboard's active owner so the frame only shows
+      // for that user. Single-user mode leaves it unowned (ref is null).
+      const owner = hrOwnerRef?.current;
+      setGtdFrames(prev => [...prev, {
+        ...frame,
+        ...(frame.ownerSyncId || owner ? { ownerSyncId: frame.ownerSyncId ?? owner } : {}),
+        id: crypto.randomUUID(),
+      }]);
     }
     setEditingFrame(null);
   };
@@ -8353,6 +8377,7 @@ const DayPlanner = () => {
     hrViewUserSyncId, setHrViewUserSyncId,
     ownedBy, managedBy,
     hasUnownedRoutines, claimUnownedRoutines,
+    hasUnownedFrames, claimUnownedFrames,
 
     // ── Habits ────────────────────────────────────────────────────────────────
     habits, setHabits,

--- a/src/components/FramesModal.jsx
+++ b/src/components/FramesModal.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { DAY_LABELS } from '../constants/frames.js';
 import FrameEditor from './FrameEditor.jsx';
 import SmartSchedulePanel from './SmartSchedulePanel.jsx';
+import UserOwnerSwitcher from './UserOwnerSwitcher.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
@@ -24,6 +25,8 @@ const FramesModal = () => {
     smartScheduleAccepted, setSmartScheduleAccepted,
     runSmartSchedule, applySmartSchedule, setSmartScheduleResults, setSmartScheduleError,
     saveFrame, deleteFrame,
+    multiUserEnabled, users, hrViewUserSyncId, setHrViewUserSyncId,
+    managedBy, meUserSyncId, hasUnownedFrames, claimUnownedFrames,
   } = useFeaturesCtx();
 
   return (
@@ -81,9 +84,37 @@ const FramesModal = () => {
                 />
               ) : (
                 <>
+                  {multiUserEnabled && users.filter(u => !u.deleted).length > 0 && (
+                    <div className="mb-3">
+                      <UserOwnerSwitcher
+                        enabled={multiUserEnabled}
+                        users={users}
+                        value={hrViewUserSyncId}
+                        onChange={setHrViewUserSyncId}
+                        darkMode={darkMode}
+                        borderClass={borderClass}
+                        textSecondary={textSecondary}
+                        label="Frames for"
+                      />
+                      {hasUnownedFrames && meUserSyncId && hrViewUserSyncId === meUserSyncId && (
+                        <div className={`mt-3 px-3 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-amber-500/10' : 'bg-amber-50'} flex items-center justify-between gap-3`}>
+                          <p className={`text-xs ${textSecondary}`}>
+                            Some frames aren't assigned to anyone yet, so they show for every member. Claim them as yours.
+                          </p>
+                          <button
+                            type="button"
+                            onClick={() => claimUnownedFrames()}
+                            className="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-500 text-white hover:bg-amber-600"
+                          >
+                            Claim
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
                   {(() => {
                     const todayStr = getTodayStr();
-                    const visibleFrames = gtdFrames.filter(f => !f.singleDate || f.singleDate >= todayStr);
+                    const visibleFrames = gtdFrames.filter(f => (!f.singleDate || f.singleDate >= todayStr) && managedBy(f, hrViewUserSyncId));
                     return visibleFrames.length === 0 ? (
                     <div className="flex flex-col items-center justify-center py-12 gap-3">
                       <LayoutGrid size={48} className={textSecondary} />

--- a/src/components/HabitModal.jsx
+++ b/src/components/HabitModal.jsx
@@ -21,6 +21,7 @@ const HabitModal = () => {
     addHabit, updateHabit, archiveHabit, deleteHabit, reorderHabits,
     addStepsHabit, addSleepHabit, healthPerms,
     multiUserEnabled, users, hrViewUserSyncId, setHrViewUserSyncId,
+    meUserSyncId, managedBy, hasUnownedHabits, claimUnownedHabits,
   } = useFeaturesCtx();
 
   return (
@@ -228,6 +229,20 @@ const HabitModal = () => {
                 textSecondary={textSecondary}
                 label="Habits for"
               />
+              {multiUserEnabled && hasUnownedHabits && meUserSyncId && hrViewUserSyncId === meUserSyncId && (
+                <div className={`mb-3 px-3 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-amber-500/10' : 'bg-amber-50'} flex items-center justify-between gap-3`}>
+                  <p className={`text-xs ${textSecondary}`}>
+                    Some habits aren't assigned to anyone yet, so they show for every member. Claim them as yours.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => claimUnownedHabits()}
+                    className="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-500 text-white hover:bg-amber-600"
+                  >
+                    Claim
+                  </button>
+                </div>
+              )}
               {activeHabits.length === 0 ? (
                 <div className={`text-center py-8 ${textSecondary}`}>
                   <Activity size={40} className="mx-auto mb-3 opacity-30" />
@@ -377,12 +392,12 @@ const HabitModal = () => {
                 </div>
               )}
 
-              {/* Archived habits */}
-              {habits.filter(h => h.archived).length > 0 && (
+              {/* Archived habits — scoped to the selected owner so they don't leak across members */}
+              {habits.filter(h => h.archived && managedBy(h, hrViewUserSyncId)).length > 0 && (
                 <div className="pt-2">
                   <h4 className={`text-xs font-semibold uppercase tracking-wide ${textSecondary} mb-2`}>{t('habit.archived')}</h4>
                   <div className="space-y-1">
-                    {habits.filter(h => h.archived).map(habit => {
+                    {habits.filter(h => h.archived && managedBy(h, hrViewUserSyncId)).map(habit => {
                       const IconComp = HABIT_ICONS[habit.icon] || Target;
                       const colorObj = HABIT_COLORS.find(c => c.name === habit.color) || HABIT_COLORS[0];
                       return (

--- a/src/components/MobileRoutinesTab.jsx
+++ b/src/components/MobileRoutinesTab.jsx
@@ -16,7 +16,7 @@ const MobileRoutinesTab = () => {
     routineFocusedChipId, setRoutineFocusedChipId,
     addRoutineChip, deleteRoutineChip, toggleRoutineChipSelection,
     multiUserEnabled, users, hrViewUserSyncId, setHrViewUserSyncId,
-    ownedBy, selectTodayChipsForOwner,
+    managedBy, selectTodayChipsForOwner,
   } = useFeaturesCtx();
 
   const today = new Date();
@@ -28,7 +28,7 @@ const MobileRoutinesTab = () => {
   const bucketLabel = (b) => b === 'everyday' ? 'Every Day' : b.charAt(0).toUpperCase() + b.slice(1);
   const isHighlighted = (b) => b === todayDayName || b === 'everyday';
 
-  const hasAnyChips = Object.values(routineDefinitions).some(arr => arr.some(c => !String(c.id).startsWith('example-') && ownedBy(c, hrViewUserSyncId)));
+  const hasAnyChips = Object.values(routineDefinitions).some(arr => arr.some(c => !String(c.id).startsWith('example-') && managedBy(c, hrViewUserSyncId)));
 
   return (
     <>
@@ -113,7 +113,7 @@ const MobileRoutinesTab = () => {
 
         {/* Day buckets */}
         {allBuckets.map(bucket => {
-          const chips = (routineDefinitions[bucket] || []).filter(c => !String(c.id).startsWith('example-') && ownedBy(c, hrViewUserSyncId));
+          const chips = (routineDefinitions[bucket] || []).filter(c => !String(c.id).startsWith('example-') && managedBy(c, hrViewUserSyncId));
           return (
             <div
               key={bucket}

--- a/src/components/MobileRoutinesTab.jsx
+++ b/src/components/MobileRoutinesTab.jsx
@@ -17,6 +17,7 @@ const MobileRoutinesTab = () => {
     addRoutineChip, deleteRoutineChip, toggleRoutineChipSelection,
     multiUserEnabled, users, hrViewUserSyncId, setHrViewUserSyncId,
     managedBy, selectTodayChipsForOwner,
+    meUserSyncId, hasUnownedRoutines, claimUnownedRoutines,
   } = useFeaturesCtx();
 
   const today = new Date();
@@ -45,6 +46,20 @@ const MobileRoutinesTab = () => {
             textSecondary={textSecondary}
             label="Routines for"
           />
+        )}
+        {multiUserEnabled && hasUnownedRoutines && meUserSyncId && hrViewUserSyncId === meUserSyncId && (
+          <div className={`px-3 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-amber-500/10' : 'bg-amber-50'} flex items-center justify-between gap-3`}>
+            <p className={`text-xs ${textSecondary}`}>
+              Some routines aren't assigned to anyone yet, so they show for every member. Claim them as yours.
+            </p>
+            <button
+              type="button"
+              onClick={() => claimUnownedRoutines()}
+              className="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-500 text-white hover:bg-amber-600"
+            >
+              Claim
+            </button>
+          </div>
         )}
         {/* Today's selected routine */}
         <div className={`rounded-lg border-2 border-dashed ${darkMode ? 'border-gray-600' : 'border-stone-300'} p-4`}>

--- a/src/components/RoutinesDashboardModal.jsx
+++ b/src/components/RoutinesDashboardModal.jsx
@@ -22,7 +22,7 @@ const RoutinesDashboardModal = () => {
     dashboardSelectedChips, setDashboardSelectedChips,
     addRoutineChip, deleteRoutineChip, toggleRoutineChipSelection,
     multiUserEnabled, users, hrViewUserSyncId, setHrViewUserSyncId,
-    ownedBy, selectTodayChipsForOwner,
+    managedBy, selectTodayChipsForOwner,
   } = useFeaturesCtx();
 
   return (
@@ -82,7 +82,7 @@ const RoutinesDashboardModal = () => {
               const isHighlighted = (b) => b === todayDayName || b === 'everyday';
 
               const renderBucket = (bucket) => {
-                const chips = (routineDefinitions[bucket] || []).filter(c => ownedBy(c, hrViewUserSyncId));
+                const chips = (routineDefinitions[bucket] || []).filter(c => managedBy(c, hrViewUserSyncId));
                 return (
                   <div
                     key={bucket}
@@ -165,7 +165,7 @@ const RoutinesDashboardModal = () => {
                 );
               };
 
-              const hasAnyChips = Object.values(routineDefinitions).some(arr => arr.some(c => ownedBy(c, hrViewUserSyncId)));
+              const hasAnyChips = Object.values(routineDefinitions).some(arr => arr.some(c => managedBy(c, hrViewUserSyncId)));
 
               return (
                 <div className="grid grid-cols-3 gap-4">

--- a/src/components/RoutinesDashboardModal.jsx
+++ b/src/components/RoutinesDashboardModal.jsx
@@ -23,6 +23,7 @@ const RoutinesDashboardModal = () => {
     addRoutineChip, deleteRoutineChip, toggleRoutineChipSelection,
     multiUserEnabled, users, hrViewUserSyncId, setHrViewUserSyncId,
     managedBy, selectTodayChipsForOwner,
+    meUserSyncId, hasUnownedRoutines, claimUnownedRoutines,
   } = useFeaturesCtx();
 
   return (
@@ -67,6 +68,20 @@ const RoutinesDashboardModal = () => {
                   textSecondary={textSecondary}
                   label="Routines for"
                 />
+                {hasUnownedRoutines && meUserSyncId && hrViewUserSyncId === meUserSyncId && (
+                  <div className={`mt-3 px-3 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-amber-500/10' : 'bg-amber-50'} flex items-center justify-between gap-3`}>
+                    <p className={`text-xs ${textSecondary}`}>
+                      Some routines aren't assigned to anyone yet, so they show for every member. Claim them as yours.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => claimUnownedRoutines()}
+                      className="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-500 text-white hover:bg-amber-600"
+                    >
+                      Claim
+                    </button>
+                  </div>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Problem

Switching the owner in the Habit modal / Routines dashboard / Frames modal to another member (e.g. "Maggie") still showed "Jason"'s items, and deleting them there removed Jason's actual items. GTD Frames had no multi-user treatment at all.

## Root cause

Habits/routines/frames carry an `ownerSyncId`, but `ownedBy()` (`App.jsx:734`) treats an **unowned** item as visible to *everyone* (`!item.ownerSyncId` → true). The management dashboards filtered with `ownedBy(item, hrViewUserSyncId)`, so a member other than the owner saw — and could delete — unstamped items.

The one-time migration meant to back-stamp legacy items to "me" guards on a `localStorage` flag (`dayglance-hr-owner-migrated`); once set it **never reconciles unowned items again**, so anything that stayed/became unowned (e.g. a cloud-sync download of still-unowned copies from another device) remains unowned permanently.

## Changes

**Shared (`App.jsx`)**
- Add `managedBy()` — stricter test for management dashboards where an **unowned item belongs to "me" only**, never leaking to another member. `ownedBy()` keeps the looser "unowned = everyone" rule for everyday surfaces.

**Habits**
- `managedHabits` and `HabitModal` (incl. archived list) use `managedBy`.
- `claimUnownedHabits()` + a "Claim" affordance in `HabitModal`.

**Routines**
- `RoutinesDashboardModal` + `MobileRoutinesTab` use `managedBy`.
- `claimUnownedRoutines()` + "Claim" banner in both routine dashboards.

**GTD Frames (new)**
- `saveFrame` stamps the active owner on newly created frames.
- `getFrameInstancesForDate` (timeline + frame nudge) filters to my frames via `ownedBy(meUserSyncId)`.
- `FramesModal` gains the owner switcher, uses `managedBy`, and shows a "Claim" banner.
- The one-time migration now also stamps unowned frames; `claimUnownedFrames()` provides the deterministic recovery.

## Effect

- Switch to another member → you see only their habits/routines/frames (no leak, nothing destructive).
- As yourself, legacy unowned items still show, each with a "Claim" button to take ownership permanently across all devices.

## Notes / follow-ups

- AI smart-schedule / morning-summary consumers still read the unfiltered `gtdFrames`/habits/routines lists — same scope decision as the existing AI paths. Can be tightened separately if desired.
- `vite build` passes (2011 modules).

https://claude.ai/code/session_016xgyZrDrQkTYQFPZ9j11Qi