### PR TITLE
Fix startup TDZ crash (from #990) + filter AI/frame gating to "my" frames

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -807,18 +807,6 @@ const DayPlanner = () => {
       : prev);
   }, [meUserSyncId, setRoutineDefinitions, setTodayRoutines]);
 
-  // GTD Frames equivalent of the habit/routine claim.
-  const hasUnownedFrames = useMemo(
-    () => multiUserEnabled && gtdFrames.some(f => !f.ownerSyncId),
-    [multiUserEnabled, gtdFrames]
-  );
-  const claimUnownedFrames = useCallback(() => {
-    if (!meUserSyncId) return;
-    const now = new Date().toISOString();
-    setGtdFrames(prev => prev.some(f => !f.ownerSyncId)
-      ? prev.map(f => f.ownerSyncId ? f : { ...f, ownerSyncId: meUserSyncId, lastModified: now })
-      : prev);
-  }, [meUserSyncId, setGtdFrames]);
   // Everyday timeline/widgets show only my placed routines; persistence and
   // cloud sync use the full `allTodayRoutines` so other members' entries are
   // preserved across saves.
@@ -1026,6 +1014,21 @@ const DayPlanner = () => {
     () => gtdFrames.filter(f => ownedBy(f, meUserSyncId)),
     [gtdFrames, ownedBy, meUserSyncId]
   );
+
+  // GTD Frames equivalent of the habit/routine claim. Must live after the
+  // useGTDFrames() destructure above — gtdFrames/setGtdFrames are in the
+  // temporal dead zone before that point.
+  const hasUnownedFrames = useMemo(
+    () => multiUserEnabled && gtdFrames.some(f => !f.ownerSyncId),
+    [multiUserEnabled, gtdFrames]
+  );
+  const claimUnownedFrames = useCallback(() => {
+    if (!meUserSyncId) return;
+    const now = new Date().toISOString();
+    setGtdFrames(prev => prev.some(f => !f.ownerSyncId)
+      ? prev.map(f => f.ownerSyncId ? f : { ...f, ownerSyncId: meUserSyncId, lastModified: now })
+      : prev);
+  }, [meUserSyncId, setGtdFrames]);
 
   const [taskContextMenu, setTaskContextMenu] = useState(null); // { x, y, taskId, isRecurring, isImported, isAllDay, dateStr }
   const [timelineContextMenu, setTimelineContextMenu] = useState(null); // { x, y, dateStr, timeMinutes }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1016,6 +1016,17 @@ const DayPlanner = () => {
     frameAdjustTimeField, setFrameAdjustTimeField,
     frameScheduleModal, setFrameScheduleModal,
   } = useGTDFrames();
+
+  // Frames owned by me — the everyday set used for AI gating (smart-schedule /
+  // reschedule button visibility, empty states, keyboard shortcuts). Mirrors
+  // activeHabits/todayRoutines so the UI reflects my frames only, consistent
+  // with what the AI actually operates on (getFrameInstancesForDate is
+  // already me-filtered).
+  const myFrames = useMemo(
+    () => gtdFrames.filter(f => ownedBy(f, meUserSyncId)),
+    [gtdFrames, ownedBy, meUserSyncId]
+  );
+
   const [taskContextMenu, setTaskContextMenu] = useState(null); // { x, y, taskId, isRecurring, isImported, isAllDay, dateStr }
   const [timelineContextMenu, setTimelineContextMenu] = useState(null); // { x, y, dateStr, timeMinutes }
   const [hgContextMenu, setHgContextMenu] = useState(null); // { x, y, projectId, date, isCompleted }
@@ -3082,7 +3093,7 @@ const DayPlanner = () => {
     aiConfig, setShowVoiceInput,
     habitsEnabled, setHabitsEnabled, setShowHabitModal,
     goalsProjectsEnabled, setGoalsProjectsEnabled, showGoalsDashboard, setShowGoalsDashboard,
-    gtdFrames, setShowRescheduleModal, setRescheduleResults, setRescheduleError,
+    gtdFrames: myFrames, setShowRescheduleModal, setRescheduleResults, setRescheduleError,
     setMobileActiveTab, setMobileSettingsView, setFramesModalTab, setEditingFrame, setShowFramesModal,
     changeDate, setSelectedDate,
     setViewMode, canShowViewCycler,
@@ -6782,7 +6793,7 @@ const DayPlanner = () => {
   const prevFrameNudgeKeyRef = useRef(null);
   useEffect(() => {
     if (isTrayMode || !aiConfig.enabled || !aiConfig.features?.frameNudge) return;
-    if (gtdFrames.filter(f => f.enabled).length === 0) return;
+    if (myFrames.filter(f => f.enabled).length === 0) return;
     if (activeFrameNudgeKey === prevFrameNudgeKeyRef.current) return;
     prevFrameNudgeKeyRef.current = activeFrameNudgeKey;
     // Only auto-fire when inside an active frame (not free time)
@@ -8455,7 +8466,7 @@ const DayPlanner = () => {
     weeklyAIError, setWeeklyAIError,
 
     // ── GTD Frames ────────────────────────────────────────────────────────────
-    gtdFrames, setGtdFrames,
+    gtdFrames, setGtdFrames, myFrames,
     showFramesModal, setShowFramesModal,
     framesModalTab, setFramesModalTab,
     editingFrame, setEditingFrame,

--- a/src/components/FramesModal.jsx
+++ b/src/components/FramesModal.jsx
@@ -20,7 +20,7 @@ const FramesModal = () => {
     setShowFramesModal,
     editingFrame, setEditingFrame,
     framesModalTab, setFramesModalTab,
-    gtdFrames, aiConfig,
+    gtdFrames, myFrames, aiConfig,
     smartScheduleResults, smartScheduleLoading, smartScheduleError,
     smartScheduleAccepted, setSmartScheduleAccepted,
     runSmartSchedule, applySmartSchedule, setSmartScheduleResults, setSmartScheduleError,
@@ -185,7 +185,7 @@ const FramesModal = () => {
               borderClass={borderClass}
               cardBg={cardBg}
               hoverBg={hoverBg}
-              gtdFrames={gtdFrames}
+              gtdFrames={myFrames}
               formatTime={formatTime}
             />
           )}

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -87,7 +87,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     habitOverflowOpen, setHabitOverflowOpen,
     showHabitModal, setShowHabitModal,
     aiConfig,
-    gtdFrames,
+    myFrames,
     showFramesModal, setShowFramesModal,
     framesModalTab, setFramesModalTab,
     editingFrame, setEditingFrame,
@@ -527,7 +527,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
         {morningGlanceText && !morningGlanceLoading && (
           <p className={`text-sm leading-relaxed ${textPrimary}`}>{morningGlanceText}</p>
         )}
-        {morningGlanceText && !morningGlanceLoading && aiConfig?.enabled && aiConfig.features?.smartScheduling && gtdFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
+        {morningGlanceText && !morningGlanceLoading && aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
           <button
             onClick={() => isTray ? openMainAt({ action: 'schedule-inbox' }) : (setShowFramesModal(true), setFramesModalTab('schedule'), setEditingFrame(null))}
             className={`mt-2 flex items-center gap-1.5 text-xs font-medium transition-colors ${darkMode ? 'text-purple-400 hover:text-purple-300' : 'text-purple-600 hover:text-purple-700'}`}
@@ -583,7 +583,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
         )}
         {eveningGlanceError && <p className={`text-xs ${darkMode ? 'text-red-400' : 'text-red-600'}`}>{eveningGlanceError}</p>}
         {eveningGlanceText && !eveningGlanceLoading && <p className={`text-sm leading-relaxed ${textPrimary}`}>{eveningGlanceText}</p>}
-        {eveningGlanceText && !eveningGlanceLoading && incompleteTodayTasks.length > 0 && gtdFrames.filter(f => f.enabled).length > 0 && aiConfig.features?.aiReschedule && (
+        {eveningGlanceText && !eveningGlanceLoading && incompleteTodayTasks.length > 0 && myFrames.filter(f => f.enabled).length > 0 && aiConfig.features?.aiReschedule && (
           <button
             onClick={() => isTray ? openMainAt({ action: 'reschedule' }) : (setShowRescheduleModal(true), setRescheduleResults(null), setRescheduleError(''))}
             className={`mt-2 flex items-center gap-1.5 text-xs font-medium transition-colors ${darkMode ? 'text-orange-400 hover:text-orange-300' : 'text-orange-600 hover:text-orange-700'}`}
@@ -642,7 +642,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
   }}
 />}
   {/* Reschedule Tasks — shown when overdue past-day tasks exist, or incomplete today tasks after 7pm */}
-  {aiConfig?.enabled && aiConfig.features?.aiReschedule && gtdFrames.filter(f => f.enabled).length > 0 && (() => {
+  {aiConfig?.enabled && aiConfig.features?.aiReschedule && myFrames.filter(f => f.enabled).length > 0 && (() => {
     const _todayStr = getTodayStr();
     const _pastOverdue = getOverdueTasks().filter(t => t._overdueType === 'scheduled' ? t.date < _todayStr : true);
     if (!(_pastOverdue.length > 0 || (incompleteTodayTasks.length > 0 && currentTime.getHours() >= 19))) return null;

--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -56,7 +56,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
   const {
     aiConfig,
-    gtdFrames,
+    myFrames,
     showFramesModal, setShowFramesModal,
     framesModalTab, setFramesModalTab,
     editingFrame, setEditingFrame,
@@ -97,7 +97,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
           <Plus size={14} strokeWidth={3} />
           <span className="text-xs font-medium">{t('common.newTask')}</span>
         </button>
-        {aiConfig?.enabled && aiConfig.features?.smartScheduling && gtdFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
+        {aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
           <button
             onClick={() => { setShowFramesModal(true); setFramesModalTab('schedule'); setEditingFrame(null); }}
             className="px-2.5 flex items-center justify-center gap-1 py-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
@@ -400,7 +400,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
       >
         <Plus size={16} strokeWidth={3} />
       </button>
-      {aiConfig?.enabled && aiConfig.features?.smartScheduling && gtdFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
+      {aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
         <button
           onClick={() => { setShowFramesModal(true); setFramesModalTab('schedule'); setEditingFrame(null); }}
           className="p-2 flex items-center justify-center bg-blue-600 text-white rounded-lg active:bg-blue-700 transition-colors"

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -97,7 +97,7 @@ const MobileGlanceSection = () => {
     habitEditingCountId, setHabitEditingCountId,
     habitOverflowOpen, setHabitOverflowOpen,
     aiConfig, aiSubtasksLoadingForTask, generateAISubtasks,
-    gtdFrames,
+    myFrames,
     showFramesModal, setShowFramesModal,
     framesModalTab, setFramesModalTab,
     editingFrame, setEditingFrame,
@@ -436,7 +436,7 @@ const MobileGlanceSection = () => {
         {morningGlanceText && !morningGlanceLoading && (
           <p className={`text-sm leading-relaxed ${textPrimary}`}>{morningGlanceText}</p>
         )}
-        {morningGlanceText && !morningGlanceLoading && aiConfig?.enabled && aiConfig.features?.smartScheduling && gtdFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
+        {morningGlanceText && !morningGlanceLoading && aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
           <button
             onClick={() => { setMobileActiveTab('settings'); setMobileSettingsView('frames'); setFramesModalTab('schedule'); }}
             className={`mt-2 flex items-center gap-1.5 text-xs font-medium transition-colors ${darkMode ? 'text-purple-400 hover:text-purple-300' : 'text-purple-600 hover:text-purple-700'}`}
@@ -491,7 +491,7 @@ const MobileGlanceSection = () => {
         )}
         {eveningGlanceError && <p className={`text-xs ${darkMode ? 'text-red-400' : 'text-red-600'}`}>{eveningGlanceError}</p>}
         {eveningGlanceText && !eveningGlanceLoading && <p className={`text-sm leading-relaxed ${textPrimary}`}>{eveningGlanceText}</p>}
-        {eveningGlanceText && !eveningGlanceLoading && incompleteTodayTasks.length > 0 && gtdFrames.filter(f => f.enabled).length > 0 && aiConfig.features?.aiReschedule && (
+        {eveningGlanceText && !eveningGlanceLoading && incompleteTodayTasks.length > 0 && myFrames.filter(f => f.enabled).length > 0 && aiConfig.features?.aiReschedule && (
           <button
             onClick={() => { setShowRescheduleModal(true); setRescheduleResults(null); setRescheduleError(''); }}
             className={`mt-2 flex items-center gap-1.5 text-xs font-medium transition-colors ${darkMode ? 'text-orange-400 hover:text-orange-300' : 'text-orange-600 hover:text-orange-700'}`}
@@ -548,7 +548,7 @@ const MobileGlanceSection = () => {
     }}
   />}
   {/* Reschedule Tasks — shown when overdue past-day tasks exist, or incomplete today tasks after 7pm */}
-  {aiConfig?.enabled && aiConfig.features?.aiReschedule && gtdFrames.filter(f => f.enabled).length > 0 && (() => {
+  {aiConfig?.enabled && aiConfig.features?.aiReschedule && myFrames.filter(f => f.enabled).length > 0 && (() => {
     const _todayStr = getTodayStr();
     const _pastOverdue = getOverdueTasks().filter(t => t._overdueType === 'scheduled' ? t.date < _todayStr : true);
     if (!(_pastOverdue.length > 0 || (incompleteTodayTasks.length > 0 && currentTime.getHours() >= 19))) return null;

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -401,7 +401,7 @@ const MobileLayout = () => {
     weeklyAISummary, setWeeklyAISummary,
     weeklyAILoading, setWeeklyAILoading,
     weeklyAIError, setWeeklyAIError,
-    gtdFrames, setGtdFrames,
+    setGtdFrames, myFrames,
     showFramesModal, setShowFramesModal,
     framesModalTab, setFramesModalTab,
     editingFrame, setEditingFrame,
@@ -586,7 +586,7 @@ const MobileLayout = () => {
                       <Plus size={14} strokeWidth={3} />
                       <span className="text-xs font-medium">{t('common.newTask')}</span>
                     </button>
-                    {aiConfig?.enabled && aiConfig.features?.smartScheduling && gtdFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
+                    {aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
                       <button
                         onClick={() => { setMobileActiveTab('settings'); setMobileSettingsView('frames'); setFramesModalTab('schedule'); setEditingFrame(null); }}
                         className="flex items-center justify-center gap-1 px-2.5 py-1.5 bg-blue-600 text-white rounded-lg active:bg-blue-700 transition-colors"

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -98,7 +98,7 @@ const MobileSettingsPanel = () => {
     addStepsHabit, addSleepHabit, healthPerms,
     hrViewUserSyncId, setHrViewUserSyncId,
     goalsProjectsEnabled, setGoalsProjectsEnabled,
-    gtdFrames,
+    gtdFrames, myFrames,
     framesModalTab, setFramesModalTab,
     editingFrame, setEditingFrame,
     saveFrame, deleteFrame,
@@ -1942,7 +1942,7 @@ const MobileSettingsPanel = () => {
             <>
               {(() => {
                 const todayStr = getTodayStr();
-                const visibleFrames = gtdFrames.filter(f => !f.singleDate || f.singleDate >= todayStr);
+                const visibleFrames = myFrames.filter(f => !f.singleDate || f.singleDate >= todayStr);
                 return visibleFrames.length === 0 ? (
                   <div className="flex flex-col items-center justify-center py-12 gap-3">
                     <LayoutGrid size={48} className={textSecondary} />
@@ -2012,7 +2012,7 @@ const MobileSettingsPanel = () => {
           borderClass={borderClass}
           cardBg={cardBg}
           hoverBg={hoverBg}
-          gtdFrames={gtdFrames}
+          gtdFrames={myFrames}
           formatTime={formatTime}
         />
       )}


### PR DESCRIPTION
## ⚠️ Critical: fixes a startup crash introduced by #990

#990 placed `hasUnownedFrames`/`claimUnownedFrames` **before** the `useGTDFrames()` destructure, so their `useMemo` dependency array referenced `gtdFrames` while it was still in the temporal dead zone → **`ReferenceError: Cannot access 'No' before initialization`** on first render, crashing the app at startup. `vite build` and the unit tests don't render `<App/>`, so neither caught it.

**Fix:** move both definitions below the `useGTDFrames()` destructure (next to `myFrames`). Audited every multi-user addition for declaration order; the migration's `setGtdFrames` call is inside a `useEffect` (deferred), so it's fine.

Merging this PR resolves the crash on `main`.

---

## Also: filter AI/frame gating to "my" frames (the #990 follow-up)

After #990 the data sent to the AI was already me-scoped (smart-schedule/reschedule/nudge use the owner-filtered `getFrameInstancesForDate`; summaries only send `isVisibleForUser` tasks). This makes the surrounding **UI gating** consistent:

- Add a `myFrames` memo (frames owned by me) and route through it: smart-schedule/reschedule button visibility (GlanceSidebar, InboxSidebar, MobileGlanceSection, MobileLayout), the SmartSchedulePanel empty state (FramesModal + MobileSettingsPanel), the frame-nudge guard, and the keyboard shortcuts.
- Route the mobile settings frames list through `myFrames` (phone counterpart of #990's FramesModal fix).

## Verification

- `vite build` passes; 256/256 unit tests pass.
- Runtime: the TDZ fix can't be covered by the current node-env unit tests (no `jsdom`/RTL); root-caused and ordering-audited instead. Please rebuild to confirm startup.

https://claude.ai/code/session_016xgyZrDrQkTYQFPZ9j11Qi