### PR TITLE
Fix multi-user roster never syncing across devices (bump @glance-apps/sync to v1.3.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.1",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "^1.1.3",
+        "@glance-apps/sync": "^1.3.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -2267,9 +2267,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.3.tgz",
-      "integrity": "sha512-tvtaGlRFILVwX+6LG29omq2e1SCuegLQsfo3kpZwCSgwivE7TNZLE6Hnh88CZdcnUerdKHFQn0LsWbz/8uqoJA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.3.0.tgz",
+      "integrity": "sha512-gmitkKIWtWTRXo/h0gLJ4e0G/YQp7bT5M9zvTHvHsQq7dTnLluR5f7saKRmvCf7eKIU6UeeoSvaSrjoIchkpRQ==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "^1.1.3",
+    "@glance-apps/sync": "^1.3.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -2,58 +2,21 @@
 // dayGLANCE tasks use `lastModified` for the per-item timestamp, so
 // mergeTaskArrays pins timestampField rather than re-exporting the alias
 // directly (which would default to `updatedAt`).
-import { mergeArrayById, mergeSyncData as _mergeSyncData } from '@glance-apps/sync';
+import { mergeArrayById } from '@glance-apps/sync';
 
 export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =>
   mergeArrayById(local, remote, deletedIds, syncHorizon, { timestampField: 'lastModified' });
 
+// mergeSyncData (since @glance-apps/sync v1.3.0) merges the multi-user roster
+// (`users`, last-write-wins per user keyed by `syncId`) while deliberately
+// leaving the per-device `multiUserEnabled` toggle alone. dayGLANCE previously
+// wrapped this function to patch the roster in; that stopgap is no longer
+// needed — the upstream merge covers every sync path directly.
 export {
   mergeDailyNotes,
   mergeHabits,
   mergeHabitLogs,
   mergeRoutineDefinitions,
+  mergeSyncData,
   pruneTombstones,
 } from '@glance-apps/sync';
-
-// @glance-apps/sync's mergeSyncData intentionally omits the multi-user roster
-// (`users`) from its merged output. Because every sync round-trip merges then
-// writes the result back, the roster gets *stripped* on every device — so it
-// never propagates even though tasks do (tasks bridge, users don't). Wrap the
-// upstream merge to re-merge the roster: last-write-wins per user by `updatedAt`,
-// keyed by the stable `syncId` so existing identities (and task assignments) are
-// preserved. localChanged / remoteChanged are updated so the sync engine still
-// applies/writes when only the roster (and not tasks) changed.
-//
-// NOTE: the `multiUserEnabled` toggle is deliberately NOT merged here — it's a
-// per-device preference. The roster (the list of people) is shared; whether a
-// given device filters its view by person is a local choice.
-const rosterKey = (u) => u.syncId ?? u.id;
-const rosterSig = (u) => `${u.updatedAt || ''}|${u.deleted ? 1 : 0}|${u.name || ''}`;
-
-const sameRoster = (a, b) => {
-  if (a.length !== b.length) return false;
-  const m = new Map(b.map(u => [rosterKey(u), rosterSig(u)]));
-  return a.every(u => m.get(rosterKey(u)) === rosterSig(u));
-};
-
-export const mergeSyncData = (localData = {}, remoteData = {}, retentionDays = 90) => {
-  const result = _mergeSyncData(localData, remoteData, retentionDays);
-
-  // Multi-user roster: last-write-wins per user (keyed by syncId, falling back to id).
-  const localUsers = Array.isArray(localData.users) ? localData.users : [];
-  const remoteUsers = Array.isArray(remoteData.users) ? remoteData.users : [];
-  if (localUsers.length || remoteUsers.length) {
-    const byId = new Map(localUsers.map(u => [rosterKey(u), u]));
-    for (const u of remoteUsers) {
-      const k = rosterKey(u);
-      const existing = byId.get(k);
-      if (!existing || (u.updatedAt || '') > (existing.updatedAt || '')) byId.set(k, u);
-    }
-    const mergedUsers = [...byId.values()];
-    result.data.users = mergedUsers;
-    if (!sameRoster(mergedUsers, localUsers)) result.localChanged = true;
-    if (!sameRoster(mergedUsers, remoteUsers)) result.remoteChanged = true;
-  }
-
-  return result;
-};

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -16,13 +16,17 @@ export {
 } from '@glance-apps/sync';
 
 // @glance-apps/sync's mergeSyncData intentionally omits the multi-user roster
-// (`users`) and the `multiUserEnabled` flag from its merged output. Because every
-// sync round-trip merges then writes the result back, those fields get *stripped*
-// on every device — so the roster never propagates even though tasks do. Wrap the
-// upstream merge to re-merge them: last-write-wins per user by `updatedAt`, and the
-// enabled flag by its `multiUserEnabledUpdatedAt` timestamp. localChanged /
-// remoteChanged are updated so the sync engine still applies/writes when only the
-// roster (and not tasks) changed.
+// (`users`) from its merged output. Because every sync round-trip merges then
+// writes the result back, the roster gets *stripped* on every device — so it
+// never propagates even though tasks do (tasks bridge, users don't). Wrap the
+// upstream merge to re-merge the roster: last-write-wins per user by `updatedAt`,
+// keyed by the stable `syncId` so existing identities (and task assignments) are
+// preserved. localChanged / remoteChanged are updated so the sync engine still
+// applies/writes when only the roster (and not tasks) changed.
+//
+// NOTE: the `multiUserEnabled` toggle is deliberately NOT merged here — it's a
+// per-device preference. The roster (the list of people) is shared; whether a
+// given device filters its view by person is a local choice.
 const rosterKey = (u) => u.syncId ?? u.id;
 const rosterSig = (u) => `${u.updatedAt || ''}|${u.deleted ? 1 : 0}|${u.name || ''}`;
 
@@ -49,17 +53,6 @@ export const mergeSyncData = (localData = {}, remoteData = {}, retentionDays = 9
     result.data.users = mergedUsers;
     if (!sameRoster(mergedUsers, localUsers)) result.localChanged = true;
     if (!sameRoster(mergedUsers, remoteUsers)) result.remoteChanged = true;
-  }
-
-  // multiUserEnabled flag: last-write-wins by its own timestamp.
-  const lt = localData.multiUserEnabledUpdatedAt || '';
-  const rt = remoteData.multiUserEnabledUpdatedAt || '';
-  if (lt || rt) {
-    const remoteWins = rt > lt;
-    result.data.multiUserEnabled = remoteWins ? remoteData.multiUserEnabled : localData.multiUserEnabled;
-    result.data.multiUserEnabledUpdatedAt = remoteWins ? rt : lt;
-    if (result.data.multiUserEnabled !== localData.multiUserEnabled) result.localChanged = true;
-    if (result.data.multiUserEnabled !== remoteData.multiUserEnabled) result.remoteChanged = true;
   }
 
   return result;

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -2,7 +2,7 @@
 // dayGLANCE tasks use `lastModified` for the per-item timestamp, so
 // mergeTaskArrays pins timestampField rather than re-exporting the alias
 // directly (which would default to `updatedAt`).
-import { mergeArrayById } from '@glance-apps/sync';
+import { mergeArrayById, mergeSyncData as _mergeSyncData } from '@glance-apps/sync';
 
 export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =>
   mergeArrayById(local, remote, deletedIds, syncHorizon, { timestampField: 'lastModified' });
@@ -12,6 +12,55 @@ export {
   mergeHabits,
   mergeHabitLogs,
   mergeRoutineDefinitions,
-  mergeSyncData,
   pruneTombstones,
 } from '@glance-apps/sync';
+
+// @glance-apps/sync's mergeSyncData intentionally omits the multi-user roster
+// (`users`) and the `multiUserEnabled` flag from its merged output. Because every
+// sync round-trip merges then writes the result back, those fields get *stripped*
+// on every device — so the roster never propagates even though tasks do. Wrap the
+// upstream merge to re-merge them: last-write-wins per user by `updatedAt`, and the
+// enabled flag by its `multiUserEnabledUpdatedAt` timestamp. localChanged /
+// remoteChanged are updated so the sync engine still applies/writes when only the
+// roster (and not tasks) changed.
+const rosterKey = (u) => u.syncId ?? u.id;
+const rosterSig = (u) => `${u.updatedAt || ''}|${u.deleted ? 1 : 0}|${u.name || ''}`;
+
+const sameRoster = (a, b) => {
+  if (a.length !== b.length) return false;
+  const m = new Map(b.map(u => [rosterKey(u), rosterSig(u)]));
+  return a.every(u => m.get(rosterKey(u)) === rosterSig(u));
+};
+
+export const mergeSyncData = (localData = {}, remoteData = {}, retentionDays = 90) => {
+  const result = _mergeSyncData(localData, remoteData, retentionDays);
+
+  // Multi-user roster: last-write-wins per user (keyed by syncId, falling back to id).
+  const localUsers = Array.isArray(localData.users) ? localData.users : [];
+  const remoteUsers = Array.isArray(remoteData.users) ? remoteData.users : [];
+  if (localUsers.length || remoteUsers.length) {
+    const byId = new Map(localUsers.map(u => [rosterKey(u), u]));
+    for (const u of remoteUsers) {
+      const k = rosterKey(u);
+      const existing = byId.get(k);
+      if (!existing || (u.updatedAt || '') > (existing.updatedAt || '')) byId.set(k, u);
+    }
+    const mergedUsers = [...byId.values()];
+    result.data.users = mergedUsers;
+    if (!sameRoster(mergedUsers, localUsers)) result.localChanged = true;
+    if (!sameRoster(mergedUsers, remoteUsers)) result.remoteChanged = true;
+  }
+
+  // multiUserEnabled flag: last-write-wins by its own timestamp.
+  const lt = localData.multiUserEnabledUpdatedAt || '';
+  const rt = remoteData.multiUserEnabledUpdatedAt || '';
+  if (lt || rt) {
+    const remoteWins = rt > lt;
+    result.data.multiUserEnabled = remoteWins ? remoteData.multiUserEnabled : localData.multiUserEnabled;
+    result.data.multiUserEnabledUpdatedAt = remoteWins ? rt : lt;
+    if (result.data.multiUserEnabled !== localData.multiUserEnabled) result.localChanged = true;
+    if (result.data.multiUserEnabled !== remoteData.multiUserEnabled) result.remoteChanged = true;
+  }
+
+  return result;
+};

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -1779,3 +1779,54 @@ describe('mergeSyncData — calendar URL change detection', () => {
     expect(localChanged).toBe(true);
   });
 });
+
+// ─── mergeSyncData — multi-user roster preservation ──────────────────
+// Regression: upstream mergeSyncData drops `users`/`multiUserEnabled`, so the
+// roster never propagated across devices even though tasks did. The local shim
+// re-merges them.
+describe('mergeSyncData — multi-user roster', () => {
+  const base = () => ({
+    tasks: [], unscheduledTasks: [], recycleBin: [], recurringTasks: [],
+    completedTaskUids: [], deletedTaskIds: {},
+    routineDefinitions: {}, todayRoutines: [], routinesDate: '',
+  });
+  const U = (id, name, updatedAt, extra = {}) => ({ id, syncId: id, name, updatedAt, ...extra });
+
+  it('preserves users present on only one side', () => {
+    const local = { ...base(), users: [] };
+    const remote = { ...base(), users: [U('a', 'Jason', ts(10)), U('b', 'Maggie', ts(10))] };
+    const { data, localChanged } = mergeSyncData(local, remote);
+    expect(data.users.map(u => u.name).sort()).toEqual(['Jason', 'Maggie']);
+    expect(localChanged).toBe(true); // local must pick up the roster
+  });
+
+  it('flags remoteChanged so a device seeds users the remote lacks', () => {
+    const local = { ...base(), users: [U('a', 'Jason', ts(10))] };
+    const remote = { ...base(), users: [] };
+    const { data, remoteChanged } = mergeSyncData(local, remote);
+    expect(data.users).toHaveLength(1);
+    expect(remoteChanged).toBe(true);
+  });
+
+  it('last-write-wins per user by updatedAt and keeps stable syncIds', () => {
+    const local = { ...base(), users: [U('a', 'Jason', ts(60))] };
+    const remote = { ...base(), users: [U('a', 'Jason Renamed', ts(5))] };
+    const { data } = mergeSyncData(local, remote);
+    expect(data.users).toHaveLength(1);
+    expect(data.users[0].syncId).toBe('a');
+    expect(data.users[0].name).toBe('Jason Renamed');
+  });
+
+  it('does not touch users when neither side has any', () => {
+    const { data } = mergeSyncData(base(), base());
+    expect(data.users).toBeUndefined();
+  });
+
+  it('syncs multiUserEnabled by its timestamp', () => {
+    const local = { ...base(), multiUserEnabled: false, multiUserEnabledUpdatedAt: ts(60) };
+    const remote = { ...base(), multiUserEnabled: true, multiUserEnabledUpdatedAt: ts(5) };
+    const { data, localChanged } = mergeSyncData(local, remote);
+    expect(data.multiUserEnabled).toBe(true);
+    expect(localChanged).toBe(true);
+  });
+});

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -1781,9 +1781,9 @@ describe('mergeSyncData — calendar URL change detection', () => {
 });
 
 // ─── mergeSyncData — multi-user roster preservation ──────────────────
-// Regression: upstream mergeSyncData drops `users`/`multiUserEnabled`, so the
-// roster never propagated across devices even though tasks did. The local shim
-// re-merges them.
+// Regression coverage for the roster sync that @glance-apps/sync v1.3.0 added:
+// `users` propagate across devices (last-write-wins per user, keyed by syncId)
+// while the per-device `multiUserEnabled` toggle stays local.
 describe('mergeSyncData — multi-user roster', () => {
   const base = () => ({
     tasks: [], unscheduledTasks: [], recycleBin: [], recurringTasks: [],
@@ -1817,9 +1817,9 @@ describe('mergeSyncData — multi-user roster', () => {
     expect(data.users[0].name).toBe('Jason Renamed');
   });
 
-  it('does not touch users when neither side has any', () => {
+  it('produces an empty roster when neither side has any', () => {
     const { data } = mergeSyncData(base(), base());
-    expect(data.users).toBeUndefined();
+    expect(data.users).toEqual([]);
   });
 
   it('does NOT merge the multiUserEnabled toggle (it is per-device)', () => {

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -1822,11 +1822,10 @@ describe('mergeSyncData — multi-user roster', () => {
     expect(data.users).toBeUndefined();
   });
 
-  it('syncs multiUserEnabled by its timestamp', () => {
+  it('does NOT merge the multiUserEnabled toggle (it is per-device)', () => {
     const local = { ...base(), multiUserEnabled: false, multiUserEnabledUpdatedAt: ts(60) };
     const remote = { ...base(), multiUserEnabled: true, multiUserEnabledUpdatedAt: ts(5) };
-    const { data, localChanged } = mergeSyncData(local, remote);
-    expect(data.multiUserEnabled).toBe(true);
-    expect(localChanged).toBe(true);
+    const { data } = mergeSyncData(local, remote);
+    expect(data.multiUserEnabled).toBeUndefined();
   });
 });

--- a/src/sync/adapter.js
+++ b/src/sync/adapter.js
@@ -7,7 +7,8 @@
 // buildBackupPayload, applyPayload) plus all event callbacks come from App.jsx
 // — they close over React state that this module deliberately does not see.
 
-import { createSyncEngine, mergeSyncData } from '@glance-apps/sync';
+import { createSyncEngine } from '@glance-apps/sync';
+import { mergeSyncData } from '../mergeSync.js';
 import { nativeHttpRequest } from '../native.js';
 
 const isNativeApp =


### PR DESCRIPTION
## The cause

Your MacBook bridges everything correctly — the issue was in the merge. `@glance-apps/sync`'s `mergeSyncData` (≤ v1.2.x) **omitted `users` from its merged output**. Since every sync **merges, then writes the merged result back**, the roster got *stripped on every round-trip* on every backend. That's exactly why:

- **Tasks** merge and survive → bridge across WebDAV + iCloud via the Mac. ✅
- **Users** are built into the payload but stripped by the merge → never propagate; "People" stays empty on devices that didn't originate them. ❌

This is also why "Sync Now" said "Saved" with no users: nothing was wrong with the transport — the roster simply never made it into the synced file.

## Fix

`@glance-apps/sync` **v1.3.0** now merges the roster upstream, so the fix is a dependency bump rather than app-side patching:

- **Roster (`users`):** last-write-wins per user by `updatedAt`, keyed by stable `syncId` — existing users keep their identities and **task assignments stay intact** (no duplicate "Jason"/"Maggie"). A roster signature drives `localChanged`/`remoteChanged` so roster edits propagate even when nothing else changed.
- **`multiUserEnabled` toggle is intentionally NOT synced** — it's a per-device preference. The shared list of people syncs; whether a given device filters its view by person is a local choice. (An "off" device shows everything — normal single-user view.)

Because every merge path (iCloud sync, the WebDAV engine in `src/sync/adapter.js`, and conflict resolution in App.jsx) already routes through `mergeSyncData` from `src/mergeSync.js`, bumping the package covers them all. `src/mergeSync.js` now re-exports the upstream `mergeSyncData` directly — the earlier app-side wrapper (a stopgap committed in this PR while the package fix was in flight) is removed since it was behavior-identical.

## Changes

- Bump `@glance-apps/sync` `^1.1.3` → `^1.3.0` (`package.json` + lockfile).
- `src/mergeSync.js`: drop the roster-merge wrapper; re-export `mergeSyncData` from the package.
- `src/mergeSync.test.js`: regression coverage retained (roster propagation, LWW per `syncId`, toggle-stays-local). v1.3.0 always emits an empty `users` array when neither side has a roster, so that one assertion now expects `[]` instead of `undefined`.

## Effect

Once this is on the Mac **and** the iPad: the Mac writes the roster into both the WebDAV and iCloud sync files (just like tasks), and every other device picks it up automatically — with original `syncId`s. No manual "add users", no duplicate identities, no surprise toggling.

## Verification

- **261/261 tests pass** (`src/mergeSync.test.js`: 133).
- `vite build` passes.

> Note: rebuild/deploy to **both** the MacBook (Electron) and the iPad (iOS), and let the Mac sync once, for the roster to flow between them.

https://claude.ai/code/session_016xgyZrDrQkTYQFPZ9j11Qi