### PR TITLE
Fix multi-user inbox leak + routine claim propagation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.1",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "^1.3.0",
+        "@glance-apps/sync": "^1.3.1",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -2267,9 +2267,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.3.0.tgz",
-      "integrity": "sha512-gmitkKIWtWTRXo/h0gLJ4e0G/YQp7bT5M9zvTHvHsQq7dTnLluR5f7saKRmvCf7eKIU6UeeoSvaSrjoIchkpRQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.3.1.tgz",
+      "integrity": "sha512-T1Ujd8ZEXzKHlsuvOEEw8Wz1CAqjqwie4uAGKd3YJuJZniwGhOm3wrt2joFk3lZRUN8bFE/8caygA/2ZuyKZrQ==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "^1.3.0",
+    "@glance-apps/sync": "^1.3.1",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1141,6 +1141,7 @@ const DayPlanner = () => {
     inboxTagFilter,
     inboxProjectFilter,
     goalsProjectsEnabled,
+    isVisibleForUser,
   });
   const { taskWidths, setTaskRef, getConflictingTasks, calculateConflictPosition, wouldExceedMaxColumns } = useTaskDerived({
     tasks,

--- a/src/hooks/useComputedViews.js
+++ b/src/hooks/useComputedViews.js
@@ -14,6 +14,7 @@ export default function useComputedViews({
   inboxTagFilter,
   inboxProjectFilter,
   goalsProjectsEnabled,
+  isVisibleForUser,
 }) {
   // Tasks for the currently selected date
   const todayTasks = useMemo(
@@ -64,6 +65,10 @@ export default function useComputedViews({
   const filteredUnscheduledTasks = useMemo(
     () => unscheduledTasks
       .filter(task => !task.archived)
+      // Multi-user: only show tasks assigned to "me" (or unassigned). Other
+      // surfaces already filter via isVisibleForUser; the inbox list was the
+      // one display path that didn't, so members saw each other's inbox tasks.
+      .filter(task => isVisibleForUser(task))
       .filter(task => {
         if (!goalsProjectsEnabled) return true;
         // If specific projects are selected, show only tasks from those projects
@@ -87,7 +92,8 @@ export default function useComputedViews({
         return (b.priority || 0) - (a.priority || 0);
       }),
     [unscheduledTasks, inboxPriorityFilter, hideCompletedInbox, hideProjectTasksInbox,
-     hideStandaloneTasksInbox, inboxTagFilter, inboxProjectFilter, goalsProjectsEnabled]
+     hideStandaloneTasksInbox, inboxTagFilter, inboxProjectFilter, goalsProjectsEnabled,
+     isVisibleForUser]
   );
 
   // Today's tasks filtered by tag selection

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -836,6 +836,34 @@ describe('mergeSyncData — routine definitions', () => {
     expect(data.deletedRoutineChipIds['1']).toBeDefined();
     expect(data.deletedRoutineChipIds['2']).toBeDefined();
   });
+
+  // Regression: a chip edited on one device (e.g. claimed — ownerSyncId stamped
+  // with a fresh lastModified) must propagate to the other device that still has
+  // the older copy of the same chip id. Before @glance-apps/sync v1.3.1 the local
+  // chip was kept verbatim on id collision, so claims/renames never synced.
+  it('SCENARIO: routine chip claim propagates via last-write-wins on collision', () => {
+    // Maggie's device still has the unowned chip (older).
+    const maggie = {
+      ...emptyData(),
+      routineDefinitions: {
+        ...emptyData().routineDefinitions,
+        monday: [{ id: 1, name: 'Workout', lastModified: ts(60) }],
+      },
+    };
+    // Jason claimed it: same id, ownerSyncId stamped, newer lastModified.
+    const jason = {
+      ...emptyData(),
+      routineDefinitions: {
+        ...emptyData().routineDefinitions,
+        monday: [{ id: 1, name: 'Workout', ownerSyncId: 'jason', lastModified: ts(2) }],
+      },
+    };
+
+    const { data, localChanged } = mergeSyncData(maggie, jason);
+    expect(data.routineDefinitions.monday).toHaveLength(1);
+    expect(data.routineDefinitions.monday[0].ownerSyncId).toBe('jason');
+    expect(localChanged).toBe(true); // Maggie's device must pick up the claim
+  });
 });
 
 // ─── mergeSyncData: todayRoutines sync ──────────────────────────────


### PR DESCRIPTION
Two multi-user fixes found while testing the roster sync on Maggie's iPad.

## Bug 1 — Inbox showed other members' tasks

The inbox list (`filteredUnscheduledTasks` in `useComputedViews`) was the **one** task display surface that never applied `isVisibleForUser`, so every member saw every unscheduled task regardless of assignment — Maggie could see inbox tasks assigned only to Jason.

**Fix:** thread `isVisibleForUser` into `useComputedViews` and apply it alongside the existing inbox filters. Single-user mode is unaffected (`isVisibleForUser` short-circuits to `true`).

## Bug 2 — Routine claims didn't propagate across devices

When Jason claimed routines, Maggie's iPad still showed them as unclaimed. Root cause was in `@glance-apps/sync`'s `mergeRoutineDefinitions`: on a chip id collision it kept the **local** chip verbatim and skipped the remote one — `lastModified` was only consulted for tombstone resurrection. So Jason's `ownerSyncId` stamp (and any rename/reorder/time edit to an existing chip) never reached a device that already had the chip. Habits/Frames were unaffected because they merge via `mergeArrayById`/`mergeHabits`, which already do last-write-wins.

**Fix:** bump `@glance-apps/sync` `^1.3.0` → `^1.3.1`, which resolves colliding routine chips by newer `lastModified` (matching the array/habit merges). Ordering and tombstone behavior are preserved. Adds a regression test covering claim propagation through `mergeSyncData`.

## Changes
- `src/hooks/useComputedViews.js` + `src/App.jsx`: apply `isVisibleForUser` to the inbox list.
- `package.json` / lockfile: `@glance-apps/sync` → `^1.3.1`.
- `src/mergeSync.test.js`: regression test for routine chip claim propagation.

## Verification
- **262/262 tests pass**; `vite build` passes.

> Deploy note: after updating both devices, the corrected merge fixes *propagation* but won't retroactively re-stamp chips that are already unowned on a device. Jason should re-claim (or re-save a routine) once so his chips carry a fresh `lastModified` and win the merge onto Maggie's iPad. After that it's automatic.

https://claude.ai/code/session_016xgyZrDrQkTYQFPZ9j11Qi

---
_Generated by [Claude Code](https://claude.ai/code/session_016xgyZrDrQkTYQFPZ9j11Qi)_