### PR TITLE
Bump @glance-apps/sync to v1.3.2 (ownership-aware routine claim merge)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.1",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "^1.3.1",
+        "@glance-apps/sync": "^1.3.2",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -2267,9 +2267,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.3.1.tgz",
-      "integrity": "sha512-T1Ujd8ZEXzKHlsuvOEEw8Wz1CAqjqwie4uAGKd3YJuJZniwGhOm3wrt2joFk3lZRUN8bFE/8caygA/2ZuyKZrQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.3.2.tgz",
+      "integrity": "sha512-49Wh24nMQaiGOvgmm6dVXCqCeuXhxx/zjNGGy+VnMnyqUyFEUYy6KYr53E3gTluFMvRxjsoY/ofFIh3OP36kVw==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "^1.3.1",
+    "@glance-apps/sync": "^1.3.2",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -837,12 +837,37 @@ describe('mergeSyncData — routine definitions', () => {
     expect(data.deletedRoutineChipIds['2']).toBeDefined();
   });
 
-  // Regression: a chip edited on one device (e.g. claimed — ownerSyncId stamped
-  // with a fresh lastModified) must propagate to the other device that still has
-  // the older copy of the same chip id. Before @glance-apps/sync v1.3.1 the local
-  // chip was kept verbatim on id collision, so claims/renames never synced.
-  it('SCENARIO: routine chip claim propagates via last-write-wins on collision', () => {
-    // Maggie's device still has the unowned chip (older).
+  // Regression: a claimed chip (ownerSyncId stamped) must propagate to a device
+  // that still holds an unclaimed copy of the same id. Before @glance-apps/sync
+  // v1.3.1 the local chip was kept verbatim on collision (claims never synced);
+  // v1.3.2 made a claimed chip override an unclaimed one regardless of timestamp.
+  it('SCENARIO: routine chip claim propagates even when the unclaimed copy is newer', () => {
+    // Maggie's device holds the unclaimed chip with a NEWER lastModified — this is
+    // the case pure last-write-wins (v1.3.1) got wrong, leaving it claimable.
+    const maggie = {
+      ...emptyData(),
+      routineDefinitions: {
+        ...emptyData().routineDefinitions,
+        monday: [{ id: 1, name: 'Workout', lastModified: ts(2) }],
+      },
+    };
+    // Jason claimed it earlier: ownerSyncId stamped, OLDER lastModified.
+    const jason = {
+      ...emptyData(),
+      routineDefinitions: {
+        ...emptyData().routineDefinitions,
+        monday: [{ id: 1, name: 'Workout', ownerSyncId: 'jason', lastModified: ts(60) }],
+      },
+    };
+
+    const { data, localChanged } = mergeSyncData(maggie, jason);
+    expect(data.routineDefinitions.monday).toHaveLength(1);
+    expect(data.routineDefinitions.monday[0].ownerSyncId).toBe('jason');
+    expect(localChanged).toBe(true); // Maggie's device must adopt the claim
+  });
+
+  // The claimed chip also wins when it carries the newer timestamp (the simple case).
+  it('SCENARIO: routine chip claim propagates when the claim is also newer', () => {
     const maggie = {
       ...emptyData(),
       routineDefinitions: {
@@ -850,7 +875,6 @@ describe('mergeSyncData — routine definitions', () => {
         monday: [{ id: 1, name: 'Workout', lastModified: ts(60) }],
       },
     };
-    // Jason claimed it: same id, ownerSyncId stamped, newer lastModified.
     const jason = {
       ...emptyData(),
       routineDefinitions: {
@@ -862,7 +886,29 @@ describe('mergeSyncData — routine definitions', () => {
     const { data, localChanged } = mergeSyncData(maggie, jason);
     expect(data.routineDefinitions.monday).toHaveLength(1);
     expect(data.routineDefinitions.monday[0].ownerSyncId).toBe('jason');
-    expect(localChanged).toBe(true); // Maggie's device must pick up the claim
+    expect(localChanged).toBe(true);
+  });
+
+  // Two members independently claiming the same chip id is a genuine conflict —
+  // resolved by recency (the documented fallback once ownership status matches).
+  it('SCENARIO: competing claims on the same chip resolve by newer lastModified', () => {
+    const maggie = {
+      ...emptyData(),
+      routineDefinitions: {
+        ...emptyData().routineDefinitions,
+        monday: [{ id: 1, name: 'Workout', ownerSyncId: 'maggie', lastModified: ts(2) }],
+      },
+    };
+    const jason = {
+      ...emptyData(),
+      routineDefinitions: {
+        ...emptyData().routineDefinitions,
+        monday: [{ id: 1, name: 'Workout', ownerSyncId: 'jason', lastModified: ts(60) }],
+      },
+    };
+
+    const { data } = mergeSyncData(maggie, jason);
+    expect(data.routineDefinitions.monday[0].ownerSyncId).toBe('maggie'); // newer claim wins
   });
 });
 


### PR DESCRIPTION
Follow-up to #993. Routine claims still didn't propagate to Maggie's iPad because v1.3.1 resolved chip collisions by pure last-write-wins, and her **unclaimed** copy of a chip carried an equal-or-newer `lastModified` than the claim (likely restamped by the per-device migration / dashboard activity) — so the unclaimed copy kept winning.

## Fix

Bump `@glance-apps/sync` `^1.3.1` → `^1.3.2`. v1.3.2 makes `mergeRoutineDefinitions` resolve chip id collisions **ownership-first**:

1. If exactly one side is claimed (has `ownerSyncId`) and the other isn't → the **claimed** side wins, regardless of `lastModified`. (Claiming is a one-way transition, so an unclaimed copy is stale by definition.)
2. Same ownership status on both sides → newer `lastModified` wins (unchanged).

This is symmetric and stable — a claimed chip beats an unclaimed copy on every device, so ownership never flip-flops — and it's deterministic regardless of timestamps. No manual re-claim needed: the cloud already holds the owned chips, so once a device runs this merge they propagate on the next sync.

## Changes
- `package.json` / lockfile: `@glance-apps/sync` → `^1.3.2`.
- `src/mergeSync.test.js`: strengthened routine-claim regression tests —
  - claimed-**older** beats unclaimed-**newer** (the case v1.3.1 got wrong),
  - claimed-newer also wins,
  - competing claims by two members resolve by recency (documented fallback).

## Verification
- **264/264 tests pass**; `vite build` passes.

> Deploy note: this merge runs on the **receiving** device, so Maggie's iPad must run this build for her claimed-vs-unclaimed chips to reconcile. Once it does, the claims flow down from the cloud automatically on the next sync.

https://claude.ai/code/session_016xgyZrDrQkTYQFPZ9j11Qi

---
_Generated by [Claude Code](https://claude.ai/code/session_016xgyZrDrQkTYQFPZ9j11Qi)_