### PR TITLE
Harden sync resume, remove ineffective owner migration, and clean up routine ownership

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -777,12 +777,12 @@ const DayPlanner = () => {
       : prev);
   }, [meUserSyncId, setHabits]);
 
-  // Routine equivalent of the habit claim: unowned routine chips (excluding the
-  // seeded example- chips) or unowned placed today-routines mean the dashboard
-  // would surface them for everyone. Stamp them with "me" deterministically.
+  // Routine equivalent of the habit claim: unowned routine chips or unowned
+  // placed today-routines mean the dashboard would surface them under the
+  // viewer's own tab. Stamp them with "me" deterministically.
   const hasUnownedRoutines = useMemo(
     () => multiUserEnabled && (
-      Object.values(routineDefinitions).some(arr => arr.some(c => !c.ownerSyncId && !String(c.id).startsWith('example-')))
+      Object.values(routineDefinitions).some(arr => arr.some(c => !c.ownerSyncId))
       || allTodayRoutines.some(r => !r.ownerSyncId)
     ),
     [multiUserEnabled, routineDefinitions, allTodayRoutines]
@@ -795,7 +795,7 @@ const DayPlanner = () => {
       const next = {};
       for (const [bucket, arr] of Object.entries(prev)) {
         next[bucket] = arr.map(c => {
-          if (c.ownerSyncId || String(c.id).startsWith('example-')) return c;
+          if (c.ownerSyncId) return c;
           any = true;
           return { ...c, ownerSyncId: meUserSyncId, lastModified: now };
         });
@@ -1502,10 +1502,31 @@ const DayPlanner = () => {
   // Catch up on missed reminders and sync when tab becomes visible
   useEffect(() => {
     if (isTrayMode) return;
+    // Release sync guards that a backgrounded app can strand. iOS (and any OS
+    // that suspends a tab) freezes the setTimeout that normally clears the
+    // suppress flags, and can tear down an in-flight sync's network promise so
+    // its finally never runs — leaving suppressCloudUploadRef stuck (uploads
+    // silently blocked, App.jsx:1667) or the iCloud mutex held (sync skipped,
+    // App.jsx:1801) until a manual force-quit. On resume, any prior cycle is
+    // dead, so clear those guards before re-kicking sync. Clearing is safe: the
+    // worst case is one redundant upload of current state, which the merge
+    // engine is idempotent to. The iCloud mutex is only released if it's been
+    // held long enough to be certainly stale (not a cycle that's actually live).
+    const STALE_ICLOUD_LOCK_MS = 30 * 1000;
+    const clearStrandedSyncGuards = () => {
+      suppressCloudUploadRef.current = false;
+      suppressTimestampRef.current = false;
+      suppressClearPendingRef.current = false;
+      if (cloudSyncInProgressRef.current &&
+          Date.now() - iCloudSyncStartedAtRef.current > STALE_ICLOUD_LOCK_MS) {
+        cloudSyncInProgressRef.current = false;
+      }
+    };
     const handleVisibility = () => {
       // iOS uses the dayglanceForeground custom event instead (see below) to
       // avoid a double-sync from both the native visibilitychange and our Swift dispatch.
       if (!document.hidden && !window.DayGlanceIOS) {
+        clearStrandedSyncGuards();
         setCurrentTime(new Date());
         // Direct engine.download() bypasses the poll's backoff check so a
         // user returning to the app gets a prompt retry even mid-backoff.
@@ -1522,6 +1543,7 @@ const DayPlanner = () => {
     // Native iOS fires a custom event to bypass the document.hidden timing gap
     // that occurs when scenePhase fires before WKWebView updates visibility state.
     const handleNativeForeground = () => {
+      clearStrandedSyncGuards();
       setCurrentTime(new Date());
       // iCloud runs first (fast local file I/O), then WebDAV (network).
       // engine.download() bypasses its own backoff for these foreground kicks.
@@ -1678,6 +1700,11 @@ const DayPlanner = () => {
   // of remote-always-wins.
   const configTrackingActiveRef = useRef(false); // false until after initial loadData
   const applyingRemoteDataRef   = useRef(false); // true while applyEngineData is running
+  // Timestamp (ms) when the iCloud mutex was taken, so a foreground resume can
+  // tell a genuinely in-flight cycle from one stranded by iOS suspending the app
+  // mid-sync (the in-flight promise never settles, so its finally never clears
+  // the lock). Used by clearStrandedSyncGuards on resume.
+  const iCloudSyncStartedAtRef  = useRef(0);
 
   useEffect(() => {
     if (dataLoaded) {
@@ -1820,6 +1847,7 @@ const DayPlanner = () => {
     }
 
     cloudSyncInProgressRef.current = true;
+    iCloudSyncStartedAtRef.current = Date.now();
     try {
       const str = onIOS
         ? window.DayGlanceNative.readICloudSync()

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -815,41 +815,13 @@ const DayPlanner = () => {
     [allTodayRoutines, ownedBy, meUserSyncId]
   );
 
-  // One-time migration (per device): when multi-user is enabled, assign existing
-  // unowned habits / routine chips / today-routines to the current user so they
-  // keep showing for "me". Goals and projects are intentionally left untouched.
-  // Anything misattributed (e.g. a pre-existing shared store) is reassignable via
-  // the dashboard switcher.
-  const hrMigratedRef = useRef(false);
-  useEffect(() => {
-    if (hrMigratedRef.current) return;
-    if (!dataLoaded || !multiUserEnabled || !meUserSyncId) return;
-    if (localStorage.getItem('dayglance-hr-owner-migrated')) { hrMigratedRef.current = true; return; }
-    const now = new Date().toISOString();
-    setHabits(prev => prev.some(h => !h.ownerSyncId)
-      ? prev.map(h => h.ownerSyncId ? h : { ...h, ownerSyncId: meUserSyncId, lastModified: now })
-      : prev);
-    setRoutineDefinitions(prev => {
-      let any = false;
-      const next = {};
-      for (const [bucket, arr] of Object.entries(prev)) {
-        next[bucket] = arr.map(c => {
-          if (c.ownerSyncId) return c;
-          any = true;
-          return { ...c, ownerSyncId: meUserSyncId, lastModified: now };
-        });
-      }
-      return any ? next : prev;
-    });
-    setTodayRoutines(prev => prev.some(r => !r.ownerSyncId)
-      ? prev.map(r => r.ownerSyncId ? r : { ...r, ownerSyncId: meUserSyncId, lastModified: now })
-      : prev);
-    setGtdFrames(prev => prev.some(f => !f.ownerSyncId)
-      ? prev.map(f => f.ownerSyncId ? f : { ...f, ownerSyncId: meUserSyncId, lastModified: now })
-      : prev);
-    localStorage.setItem('dayglance-hr-owner-migrated', now);
-    hrMigratedRef.current = true;
-  }, [dataLoaded, multiUserEnabled, meUserSyncId]);
+  // Legacy unowned habits / routine chips / today-routines / frames are
+  // intentionally NOT auto-migrated to the current user. Claiming is explicit
+  // (claimUnownedHabits / claimUnownedRoutines / claimUnownedFrames). A
+  // per-device one-shot migration was removed: it raced cloud sync (a download
+  // reverts the local stamp before the one-shot latch can retry, so it never
+  // actually stamped anything) and, when it did fire, stamped each device's own
+  // user onto shared items — manufacturing competing claims across devices.
 
   const {
     showFocusMode, setShowFocusMode,

--- a/src/components/FramesModal.jsx
+++ b/src/components/FramesModal.jsx
@@ -99,7 +99,7 @@ const FramesModal = () => {
                       {hasUnownedFrames && meUserSyncId && hrViewUserSyncId === meUserSyncId && (
                         <div className={`mt-3 px-3 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-amber-500/10' : 'bg-amber-50'} flex items-center justify-between gap-3`}>
                           <p className={`text-xs ${textSecondary}`}>
-                            Some frames aren't assigned to anyone yet, so they show for every member. Claim them as yours.
+                            Some frames aren't assigned to anyone yet. Claim them as yours so they stay tied to you across devices.
                           </p>
                           <button
                             type="button"

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -1299,7 +1299,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
 
   {/* Routines row */}
   {routinesEnabled && (() => {
-    const realRoutines = todayRoutines.filter(r => !String(r.id).startsWith('example-'));
+    const realRoutines = todayRoutines;
     const visibleRoutines = realRoutines.filter(r => !routineCompletions[r.id]);
     if (realRoutines.length > 0 && visibleRoutines.length === 0) return null;
     if (visibleRoutines.length === 0) {

--- a/src/components/HabitModal.jsx
+++ b/src/components/HabitModal.jsx
@@ -232,7 +232,7 @@ const HabitModal = () => {
               {multiUserEnabled && hasUnownedHabits && meUserSyncId && hrViewUserSyncId === meUserSyncId && (
                 <div className={`mb-3 px-3 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-amber-500/10' : 'bg-amber-50'} flex items-center justify-between gap-3`}>
                   <p className={`text-xs ${textSecondary}`}>
-                    Some habits aren't assigned to anyone yet, so they show for every member. Claim them as yours.
+                    Some habits aren't assigned to anyone yet. Claim them as yours so they stay tied to you across devices.
                   </p>
                   <button
                     type="button"

--- a/src/components/MobileAllDaySection.jsx
+++ b/src/components/MobileAllDaySection.jsx
@@ -39,7 +39,7 @@ const MobileAllDaySection = () => {
   return (
     <>
 {/* All-day tasks - inside sticky header group */}
-{(visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay && !t.isExample) || getDeadlineTasksForDate(dateToString(date)).some(t => !t.isExample)) || (routinesEnabled && todayRoutines.some(r => r.isAllDay && !String(r.id).startsWith('example-')))) && (
+{(visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay && !t.isExample) || getDeadlineTasksForDate(dateToString(date)).some(t => !t.isExample)) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (
   <div ref={mobileAllDaySectionRef} className={`border-b ${borderClass} ${cardBg} ${mobileDragPreviewTime === 'all-day' ? 'ring-2 ring-inset ring-blue-500' : ''}`}>
     <div className="flex">
       <div className={`w-12 flex-shrink-0 px-2 py-2 text-[10px] font-semibold ${textSecondary} border-r ${borderClass} flex items-start justify-center`}>
@@ -349,7 +349,7 @@ const MobileAllDaySection = () => {
                 </div>
               ))}
               {/* Routine pills in all-day (today only) */}
-              {routinesEnabled && dateToString(date) === dateToString(new Date()) && todayRoutines.filter(r => r.isAllDay && !String(r.id).startsWith('example-')).map((routine) => (
+              {routinesEnabled && dateToString(date) === dateToString(new Date()) && todayRoutines.filter(r => r.isAllDay).map((routine) => (
                 <div
                   key={`routine-${routine.id}`}
                   className={`rounded-full px-3 py-1 text-xs font-medium inline-block mr-1 mb-1 select-none ${darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'} ${mobileDragTaskIdState === routine.id ? 'scale-105 shadow-2xl z-40' : ''} ${routineCompletions[routine.id] ? 'line-through opacity-75' : ''}`}

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -1152,7 +1152,7 @@ const MobileGlanceSection = () => {
   })()}
   {/* Routines row */}
   {routinesEnabled && (() => {
-    const realRoutines = todayRoutines.filter(r => !String(r.id).startsWith('example-'));
+    const realRoutines = todayRoutines;
     const visibleRoutines = realRoutines.filter(r => !routineCompletions[r.id]);
     if (realRoutines.length > 0 && visibleRoutines.length === 0) return null;
     const openRoutinesSettings = () => {

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -726,7 +726,7 @@ const MobileListView = ({ hideInboxHandle = false }) => {
 
   const allDayRoutines = useMemo(() =>
     routinesEnabled && isToday
-      ? todayRoutines.filter(r => r.isAllDay && !String(r.id).startsWith('example-'))
+      ? todayRoutines.filter(r => r.isAllDay)
       : [],
     [routinesEnabled, isToday, todayRoutines],
   );
@@ -752,7 +752,7 @@ const MobileListView = ({ hideInboxHandle = false }) => {
 
   const scheduledRoutines = useMemo(() =>
     routinesEnabled && isToday
-      ? todayRoutines.filter(r => r.startTime && !r.isAllDay && !String(r.id).startsWith('example-'))
+      ? todayRoutines.filter(r => r.startTime && !r.isAllDay)
       : [],
     [routinesEnabled, isToday, todayRoutines],
   );

--- a/src/components/MobileRoutinesTab.jsx
+++ b/src/components/MobileRoutinesTab.jsx
@@ -29,7 +29,7 @@ const MobileRoutinesTab = () => {
   const bucketLabel = (b) => b === 'everyday' ? 'Every Day' : b.charAt(0).toUpperCase() + b.slice(1);
   const isHighlighted = (b) => b === todayDayName || b === 'everyday';
 
-  const hasAnyChips = Object.values(routineDefinitions).some(arr => arr.some(c => !String(c.id).startsWith('example-') && managedBy(c, hrViewUserSyncId)));
+  const hasAnyChips = Object.values(routineDefinitions).some(arr => arr.some(c => managedBy(c, hrViewUserSyncId)));
 
   return (
     <>
@@ -50,7 +50,7 @@ const MobileRoutinesTab = () => {
         {multiUserEnabled && hasUnownedRoutines && meUserSyncId && hrViewUserSyncId === meUserSyncId && (
           <div className={`px-3 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-amber-500/10' : 'bg-amber-50'} flex items-center justify-between gap-3`}>
             <p className={`text-xs ${textSecondary}`}>
-              Some routines aren't assigned to anyone yet, so they show for every member. Claim them as yours.
+              Some routines aren't assigned to anyone yet. Claim them as yours so they stay tied to you across devices.
             </p>
             <button
               type="button"
@@ -64,9 +64,9 @@ const MobileRoutinesTab = () => {
         {/* Today's selected routine */}
         <div className={`rounded-lg border-2 border-dashed ${darkMode ? 'border-gray-600' : 'border-stone-300'} p-4`}>
           <div className={`text-xs font-semibold uppercase tracking-wide mb-3 ${textSecondary} text-center`}>Today's Routine</div>
-          {dashboardSelectedChips.filter(c => !String(c.id).startsWith('example-')).length > 0 ? (
+          {dashboardSelectedChips.length > 0 ? (
             <div className="flex flex-wrap gap-1.5 justify-center">
-              {dashboardSelectedChips.filter(c => !String(c.id).startsWith('example-')).map(chip => {
+              {dashboardSelectedChips.map(chip => {
                 const isFocused = routineFocusedChipId === chip.id;
                 return (
                 <div
@@ -128,7 +128,7 @@ const MobileRoutinesTab = () => {
 
         {/* Day buckets */}
         {allBuckets.map(bucket => {
-          const chips = (routineDefinitions[bucket] || []).filter(c => !String(c.id).startsWith('example-') && managedBy(c, hrViewUserSyncId));
+          const chips = (routineDefinitions[bucket] || []).filter(c => managedBy(c, hrViewUserSyncId));
           return (
             <div
               key={bucket}

--- a/src/components/MobileTimeGrid.jsx
+++ b/src/components/MobileTimeGrid.jsx
@@ -606,7 +606,7 @@ const MobileTimeGrid = () => {
 
           {/* Timeline routine pills (today only) */}
           {routinesEnabled && dateStr === dateToString(new Date()) && (() => {
-            const timelineRoutines = todayRoutines.filter(r => !r.isAllDay && r.startTime && !String(r.id).startsWith('example-'));
+            const timelineRoutines = todayRoutines.filter(r => !r.isAllDay && r.startTime);
             if (timelineRoutines.length === 0) return null;
 
             // Compute side-by-side columns for overlapping routine chips

--- a/src/components/RoutinesDashboardModal.jsx
+++ b/src/components/RoutinesDashboardModal.jsx
@@ -71,7 +71,7 @@ const RoutinesDashboardModal = () => {
                 {hasUnownedRoutines && meUserSyncId && hrViewUserSyncId === meUserSyncId && (
                   <div className={`mt-3 px-3 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-amber-500/10' : 'bg-amber-50'} flex items-center justify-between gap-3`}>
                     <p className={`text-xs ${textSecondary}`}>
-                      Some routines aren't assigned to anyone yet, so they show for every member. Claim them as yours.
+                      Some routines aren't assigned to anyone yet. Claim them as yours so they stay tied to you across devices.
                     </p>
                     <button
                       type="button"

--- a/src/trmnl.js
+++ b/src/trmnl.js
@@ -167,7 +167,6 @@ export function gatherTrmnlData({
   const routineItems = routinesEnabled
     ? todayRoutines
         .filter((r) => {
-          if (String(r.id).startsWith('example-')) return false;
           if (r.isAllDay) return true;
           const rStart = toMinutes(r.startTime);
           if (rStart < 0) return true;


### PR DESCRIPTION
## Summary

Follow-up to today's multi-user habit/routine ownership work. This focuses on the parts that were genuinely defective or misleading; it deliberately leaves the merge/claim logic untouched.

The investigation behind this concluded that the cross-device "routine claim won't propagate" symptom was a **runtime-state** problem (a sync guard stranded when iOS suspends the app mid-cycle, only cleared by a manual force-quit), not a merge-logic problem. These changes harden against that recurrence and remove code that was actively contributing to ownership instability.

## Changes

**1. Harden sync against app suspension (`App.jsx`)**
- On foreground/resume, a new `clearStrandedSyncGuards()` releases guards that a backgrounded app can strand: the `suppressCloudUpload` / `suppressTimestamp` / `suppressClearPending` flags (whose only other clearer is a `setTimeout` iOS freezes on suspend — the code already documented this hazard) and a stale iCloud mutex.
- The iCloud mutex is only released if it's been held longer than 30s (certainly stale, not a live cycle), using a timestamp stamped where the lock is taken.
- Clearing is safe: worst case is one redundant upload of current state, which the merge engine is idempotent to.

**2. Remove the per-device owner migration (`App.jsx`)**
The one-shot migration that auto-stamped unowned habits/routine chips/today-routines/frames with the local user is removed because it was:
- **Ineffective** — it stamped local state then latched a one-shot flag, but a cloud-sync download reverts the stamp on load and the latch blocks any retry, so items stayed unowned (which is why explicit Claim was needed at all).
- **Redundant** — `claimUnownedHabits/Routines/Frames` do the same stamping deterministically on user action.
- **Harmful when it did fire** — it stamped each device's own user onto shared items, manufacturing competing claims across devices (ownership flip-flop).

Removal is **non-retroactive**: existing `ownerSyncId` stamps are untouched; it only stops future auto-stamping. A comment is left in place so the pattern isn't reintroduced.

**3. Fix misleading claim-prompt copy (routines, mobile routines, frames, habits)**
"…so they show for every member" was inaccurate under the stricter `managedBy` dashboard rule (an unowned item shows only under the viewer's own tab). Reworded to "Claim them as yours so they stay tied to you across devices."

**4. Remove dead `example-` routine guards (8 files)**
Nothing creates `example-`-prefixed routine chips (unlike task `isExample`, which is left intact); all 12 references were no-op exclusion filters that repeatedly misled debugging.

## Testing
- `npm test` — 264/264 pass (incl. all 136 mergeSync tests)
- `npm run build` — clean

## Explicitly out of scope (flagged, not changed)
- 1.3.2's "a claim beats an unclaimed copy regardless of timestamp" semantic — deliberate, worth a conscious accept.
- `todayRoutines` still uses pure last-write-wins merge rather than the ownership-aware path.

https://claude.ai/code/session_01Mf8GjRhEBN7HCY8agnJC8Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf8GjRhEBN7HCY8agnJC8Z)_