### PR TITLE
Bump version to 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.3.1-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.4.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 117
-        versionName = "3.3"
+        versionCode = 118
+        versionName = "3.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.3.1",
+      "version": "3.4.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -613,7 +613,7 @@ const DayPlanner = () => {
 
   // Settings & Reminders modals
   const [showSettings, setShowSettings] = useState(false);
-  const [collapsedSettings, setCollapsedSettings] = useState({ cloudSync: true, calSync: !isNativeApp(), ai: true, obsidian: !isNativeApp(), trmnl: true, multiUser: true });
+  const [collapsedSettings, setCollapsedSettings] = useState({ cloudSync: true, calSync: true, ai: true, obsidian: true, trmnl: true, multiUser: true });
   const [updateInfo, setUpdateInfo] = useState(null);
   const [updateDismissedVersion, setUpdateDismissedVersion] = useState(() => localStorage.getItem('dayglance-update-dismissed') || null);
   const toggleSettingsSection = (key) => setCollapsedSettings(prev => ({ ...prev, [key]: !prev[key] }));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -613,7 +613,7 @@ const DayPlanner = () => {
 
   // Settings & Reminders modals
   const [showSettings, setShowSettings] = useState(false);
-  const [collapsedSettings, setCollapsedSettings] = useState({ cloudSync: true, calSync: true, ai: true, obsidian: true, trmnl: true, multiUser: true });
+  const [collapsedSettings, setCollapsedSettings] = useState({ cloudSync: true, calSync: true, ai: true, obsidian: true, trmnl: true, multiUser: true, intent: true });
   const [updateInfo, setUpdateInfo] = useState(null);
   const [updateDismissedVersion, setUpdateDismissedVersion] = useState(() => localStorage.getItem('dayglance-update-dismissed') || null);
   const toggleSettingsSection = (key) => setCollapsedSettings(prev => ({ ...prev, [key]: !prev[key] }));

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -538,7 +538,7 @@ const CalendarHeader = () => {
 )}
 
 {/* Multi-mode all-day tasks section */}
-{effectiveViewMode === 'multi' && (visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay) || getDeadlineTasksForDate(dateToString(date)).length > 0) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (
+{effectiveViewMode === 'multi' && !(isTablet && !isLandscape && mobileViewMode === 'list') && (visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay) || getDeadlineTasksForDate(dateToString(date)).length > 0) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (
   <div ref={(el) => { if (isTablet) mobileAllDaySectionRef.current = el; }} className={`flex border-b ${borderClass} ${cardBg}`}>
     <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>
       ALL DAY

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -5,6 +5,7 @@ import {
   RefreshCw, Save, Settings, Sun, Trash2,
 } from 'lucide-react';
 import { dateToString, formatDateRange } from '../utils/taskUtils.js';
+import { isNativeApp } from '../native.js';
 import DesktopHeader from './DesktopHeader.jsx';
 import CalendarHeader from './CalendarHeader.jsx';
 import TimeGrid from './TimeGrid.jsx';
@@ -494,7 +495,7 @@ const DesktopLayout = () => {
               )}
           </div>
           <div className="flex items-center gap-2">
-            <button
+            {!isNativeApp() && <button
               onClick={() => {
                 if (isSyncing) return;
                 if (calSyncConfigured) {
@@ -517,7 +518,7 @@ const DesktopLayout = () => {
                   'bg-green-500'
                 }`} />
               )}
-            </button>
+            </button>}
             <button
               onClick={() => {
                 if (cloudSyncConfig?.enabled) {

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -106,6 +106,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     showVoiceInput, setShowVoiceInput,
     voiceCanRecord,
     healthPerms,
+    isVisibleForUser,
   } = useFeaturesCtx();
   const { t } = useTranslation();
 
@@ -262,7 +263,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
       : [];
     const allTasksCombined = [...tasks, ...unscheduledTasks];
     const activeGoalsList = goalsProjectsEnabled
-      ? goals.filter(g => g.status === 'active').map(g => {
+      ? goals.filter(g => g.status === 'active' && isVisibleForUser(g)).map(g => {
           const progressPct = Math.round(calculateGoalProgress(g.id, projects, allTasksCombined) * 100);
           const daysLeft = g.targetDate
             ? Math.ceil((new Date(g.targetDate + 'T00:00:00') - new Date(getTodayStr() + 'T00:00:00')) / 86400000)

--- a/src/components/MobileBottomSheets.jsx
+++ b/src/components/MobileBottomSheets.jsx
@@ -323,7 +323,7 @@ const MobileBottomSheets = () => {
                 {todayCompletedProjects.map(p => (
                   <div key={p.id} className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium ${darkMode ? 'bg-green-900/30 text-green-300' : 'bg-green-50 text-green-700'}`}>
                     <FolderOpen size={14} className="flex-shrink-0" />
-                    <span className="truncate">{t('app.projectComplete')}: {p.title}</span>
+                    <span className="truncate">{t('app.projectComplete', { title: p.title })}</span>
                   </div>
                 ))}
               </div>

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -115,6 +115,7 @@ const MobileGlanceSection = () => {
     showVoiceInput, setShowVoiceInput,
     voiceCanRecord,
     healthPerms,
+    isVisibleForUser,
   } = useFeaturesCtx();
   const { t } = useTranslation();
   const glanceSwipeStartX = useRef(0);
@@ -171,7 +172,7 @@ const MobileGlanceSection = () => {
       : [];
     const allTasksCombined = [...tasks, ...unscheduledTasks];
     const activeGoalsList = goalsProjectsEnabled
-      ? goals.filter(g => g.status === 'active').map(g => {
+      ? goals.filter(g => g.status === 'active' && isVisibleForUser(g)).map(g => {
           const progressPct = Math.round(calculateGoalProgress(g.id, projects, allTasksCombined) * 100);
           const daysLeft = g.targetDate
             ? Math.ceil((new Date(g.targetDate + 'T00:00:00') - new Date(getTodayStr() + 'T00:00:00')) / 86400000)

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -2564,7 +2564,7 @@ const MobileSettingsPanel = () => {
             onClick={() => setMuAddingUser(true)}
             className={`mt-3 w-full ${cardBg} border ${borderClass} rounded-xl p-3 flex items-center justify-center gap-2 ${darkMode ? 'text-blue-400' : 'text-blue-600'} text-sm font-medium`}
           >
-            <Plus size={16} /> {t('common.addPerson')}
+            {t('common.addPerson')}
           </button>
         )}
       </div>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1141,7 +1141,7 @@ const SettingsModal = () => {
                                 type="button"
                                 onClick={() => setAddingUser(true)}
                                 className={`mt-2 text-sm ${darkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'}`}
-                              >+ {t('common.addPerson')}</button>
+                              >{t('common.addPerson')}</button>
                             )}
                           </div>
                           {/* Users path — only shown when GLANCE Integrations WebDAV is configured */}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Bumps web version to 3.4.0 in `package.json` / `package-lock.json`
- Bumps Android `versionCode` to 118 and `versionName` to `3.4` in `build.gradle.kts`
- Updates README version badge to 3.4.0

Also includes the following fixes landed on this branch since 3.3.1:

- Fix duplicate `+` in "Add person" button in multi-user settings
- Collapse all settings sections by default (desktop/tablet and mobile Calendar Sync)
- Fix Glance Intent section also expanded by default (missing key in initial state)
- Fix duplicate ALL DAY section on tablet LIST view
- Fix unresolved `{{title}}` placeholder in daily summary project complete line
- Hide calendar sync button on native Android/iOS in tablet settings cluster

## Test plan

- [ ] Confirm version reads 3.4.0 in app
- [ ] Confirm Android build picks up versionCode 118 / versionName 3.4

https://claude.ai/code/session_01DydVNwUZ8j7TpyB4ikxnAg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DydVNwUZ8j7TpyB4ikxnAg)_