### PR TITLE
Fix iOS widgets showing empty

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7146,7 +7146,7 @@ const DayPlanner = () => {
   // every 15 minutes when the app is closed.
   useEffect(() => {
     if (!dataLoaded) return;
-    if (!isNativeAndroid() || !window.DayGlanceNative?.updateWidgetSnapshot) return;
+    if ((!isNativeAndroid() && !isNativeIOS()) || !window.DayGlanceNative?.updateWidgetSnapshot) return;
 
     const today = new Date();
     const todayStr = getTodayStr();


### PR DESCRIPTION
## Summary

- The `updateWidgetSnapshot` effect in `App.jsx` had an `isNativeAndroid()` guard that caused it to bail out on iOS, so the JS layer never wrote data to the shared App Group container that the iOS widget extension reads from.
- Changed the guard to allow both Android and iOS: `(!isNativeAndroid() && !isNativeIOS())`.

## Test plan

- [ ] Build and run the iOS app
- [ ] Add one or more widgets (Up Next, Goal, Project) to the home screen
- [ ] Open the app — widgets should populate within seconds
- [ ] Verify widget data updates when tasks/goals change in the app

https://claude.ai/code/session_01CBGFyB3jTRTsyLmBspf2R5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBGFyB3jTRTsyLmBspf2R5)_