### PR TITLE
Improve iOS widgets: italic tags, task count fix, large sizes

### DIFF
--- a/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
@@ -20,6 +20,7 @@ struct ProjectProvider: TimelineProvider {
 
 struct ProjectWidgetView: View {
     var entry: ProjectEntry
+    @Environment(\.widgetFamily) var family
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -72,9 +73,10 @@ struct ProjectWidgetView: View {
             }
             if let tasks = proj.tasks, !tasks.isEmpty {
                 Divider()
+                let taskLimit = family == .systemLarge ? 8 : 4
                 let incomplete = tasks.filter { !($0.completed ?? false) }
                 let complete = tasks.filter { $0.completed ?? false }
-                let visible = Array((incomplete + complete).prefix(5))
+                let visible = Array((incomplete + complete).prefix(taskLimit))
                 ForEach(visible, id: \.id) { t in
                     HStack(spacing: 6) {
                         Image(systemName: (t.completed ?? false) ? "checkmark.circle.fill" : "circle")
@@ -111,6 +113,6 @@ struct ProjectWidget: Widget {
         }
         .configurationDisplayName("Project")
         .description("Progress on your active project.")
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([.systemMedium, .systemLarge])
     }
 }

--- a/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
@@ -59,7 +59,7 @@ struct UpNextWidgetView: View {
                     HStack {
                         Text(task.title ?? "")
                             .font(.subheadline).fontWeight(.semibold)
-                            .lineLimit(2)
+                            .lineLimit(family == .systemLarge ? 3 : 2)
                         Spacer()
                         if let time = formattedTime(task) {
                             Text(time)
@@ -75,11 +75,19 @@ struct UpNextWidgetView: View {
                     if let tags = task.tags, !tags.isEmpty {
                         Text(tags.map { "#\($0)" }.joined(separator: " "))
                             .font(.caption2)
+                            .italic()
                             .foregroundColor(.secondary)
                             .lineLimit(1)
                     }
+                    if family == .systemLarge, let notes = task.notes, !notes.isEmpty {
+                        Text(notes)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(3)
+                            .padding(.top, 2)
+                    }
                     // iOS 17+ interactive buttons
-                    if #available(iOS 17.0, *), family != .systemSmall {
+                    if #available(iOS 17.0, *) {
                         HStack(spacing: 8) {
                             Button(intent: CompleteTaskIntent(taskId: task.id ?? "")) {
                                 Label("Done", systemImage: "checkmark.circle")
@@ -96,9 +104,10 @@ struct UpNextWidgetView: View {
                     }
                 }
             }
-            if family != .systemSmall, let subtasks = task.subtasks, !subtasks.isEmpty {
+            if let subtasks = task.subtasks, !subtasks.isEmpty {
                 Divider().padding(.vertical, 4)
-                ForEach(subtasks.prefix(3), id: \.title) { sub in
+                let limit = family == .systemLarge ? 8 : 3
+                ForEach(subtasks.prefix(limit), id: \.title) { sub in
                     HStack(spacing: 6) {
                         Image(systemName: sub.completed ? "checkmark.circle.fill" : "circle")
                             .font(.caption2)
@@ -148,6 +157,6 @@ struct UpNextWidget: Widget {
         }
         .configurationDisplayName("Up Next")
         .description("Your next scheduled task.")
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([.systemMedium, .systemLarge])
     }
 }


### PR DESCRIPTION
## Summary

- **Up Next**: tags now render in italic
- **Up Next**: subtasks now show on medium too (were accidentally gated to non-small only, which was the same); large shows up to 8 subtasks and the task notes (up to 3 lines); interactive Done/Focus buttons show on all families
- **Project**: task list on medium capped at 4 (was 5, which overflows)
- **Project**: large shows up to 8 tasks
- **Both widgets**: removed `systemSmall` (not useful), added `systemLarge`

## Test plan

- [ ] Add Up Next (medium) — verify tags appear in italic below project name
- [ ] Add Up Next (large) — verify notes appear, subtasks up to 8, buttons visible
- [ ] Add Project (medium) — verify task list stops at 4
- [ ] Add Project (large) — verify task list goes up to 8
- [ ] Confirm small size no longer appears as an option in the widget picker

https://claude.ai/code/session_01CBGFyB3jTRTsyLmBspf2R5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBGFyB3jTRTsyLmBspf2R5)_