### PR TITLE
Fix notes panel not opening in tablet LIST view

### DIFF
--- a/dayglance-ios/DayGlanceWidget/GoalWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/GoalWidget.swift
@@ -20,6 +20,7 @@ struct GoalProvider: TimelineProvider {
 
 struct GoalWidgetView: View {
     var entry: GoalEntry
+    @Environment(\.widgetFamily) var family
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -75,18 +76,25 @@ struct GoalWidgetView: View {
             }
             if let projects = goal.projects, !projects.isEmpty {
                 Divider()
-                ForEach(projects.prefix(3), id: \.id) { proj in
-                    HStack {
-                        Text(proj.title ?? "")
-                            .font(.caption2)
-                            .lineLimit(1)
-                        Spacer()
-                        if proj.status == "completed" || (proj.progressPct ?? 0) == 100 {
-                            Text("✓").font(.caption2).foregroundColor(.green)
-                        } else {
-                            Text("\(proj.completedTasks ?? 0)/\(proj.totalTasks ?? 0)")
+                let projectLimit = family == .systemLarge ? 5 : 3
+                ForEach(projects.prefix(projectLimit), id: \.id) { proj in
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack {
+                            Text(proj.title ?? "")
                                 .font(.caption2)
-                                .foregroundColor(.secondary)
+                                .lineLimit(1)
+                            Spacer()
+                            if proj.status == "completed" || (proj.progressPct ?? 0) == 100 {
+                                Text("✓").font(.caption2).foregroundColor(.green)
+                            } else {
+                                Text("\(proj.completedTasks ?? 0)/\(proj.totalTasks ?? 0)")
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        if family == .systemLarge {
+                            ProgressView(value: Double(proj.progressPct ?? 0) / 100.0)
+                                .tint(progressColor(pct: proj.progressPct ?? 0))
                         }
                     }
                 }
@@ -120,6 +128,6 @@ struct GoalWidget: Widget {
         }
         .configurationDisplayName("Goal")
         .description("Progress on your active goal.")
-        .supportedFamilies([.systemMedium])
+        .supportedFamilies([.systemMedium, .systemLarge])
     }
 }

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -2,9 +2,11 @@ import React, { useState, useRef } from 'react';
 import {
   Bell, BookOpen, ChevronLeft, ChevronRight, Cloud,
   Eye, GitBranch, HelpCircle, Inbox, Moon, NotebookPen,
-  RefreshCw, Save, Settings, Sun, Trash2,
+  RefreshCw, Save, Settings, Sun, Trash2, X,
 } from 'lucide-react';
-import { dateToString, formatDateRange } from '../utils/taskUtils.js';
+import { dateToString, extractWikilinks, formatDateRange } from '../utils/taskUtils.js';
+import { renderTitle } from '../utils/textFormatting.jsx';
+import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
 import { isNativeApp } from '../native.js';
 import DesktopHeader from './DesktopHeader.jsx';
 import CalendarHeader from './CalendarHeader.jsx';
@@ -281,7 +283,7 @@ const DesktopLayout = () => {
     nativeEventToTask, clearNativeEventOverride, parseDatetime, parseICS, filterByDateWindow,
     loadData, saveData,
     cloudSyncDownload, cloudSyncUpload, cloudSyncTest, syncAll,
-    performObsidianSync, loadWikiNote, saveWikiNote,
+    performObsidianSync, loadWikiNote, saveWikiNote, openInObsidian,
     performTrmnlSync,
     performLocalBackup, performRemoteBackup,
     buildAutoBackupPayload, loadAutoBackupHistory,
@@ -831,6 +833,54 @@ const DesktopLayout = () => {
           </div>
         </div>
       </div>
+
+      {/* Notes panel overlay for tablet LIST view */}
+      {tabletListView && expandedNotesTaskId && (() => {
+        const scheduledTask = visibleDates.reduce((found, date) => {
+          if (found) return found;
+          return getTasksForDate(date).find(t => t.id === expandedNotesTaskId);
+        }, null);
+        const deadlineTask = !scheduledTask ? unscheduledTasks.find(t => t.id === expandedNotesTaskId && t.deadline) : null;
+        const noteTask = scheduledTask || deadlineTask;
+        if (!noteTask) return null;
+        return (
+          <div className="notes-panel-container fixed inset-0 z-50 flex flex-col justify-end" onClick={() => setExpandedNotesTaskId(null)}>
+            <div className="bg-black/30 absolute inset-0" />
+            <div
+              className={`relative ${cardBg} rounded-t-2xl shadow-xl max-h-[60vh] overflow-y-auto`}
+              style={{ paddingBottom: 'calc(1rem + env(safe-area-inset-bottom, 0px))' }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className={`flex items-center justify-between p-4 border-b ${borderClass}`}>
+                <div className={`font-medium ${textPrimary} truncate flex-1`}>{renderTitle(noteTask.title)}</div>
+                <button onClick={() => setExpandedNotesTaskId(null)} className={`p-1 rounded-lg ${hoverBg} transition-colors`} aria-label="Close notes">
+                  <X size={18} className={textSecondary} />
+                </button>
+              </div>
+              <div className="p-4">
+                <NotesSubtasksPanel
+                  task={noteTask}
+                  isInbox={!!deadlineTask}
+                  darkMode={darkMode}
+                  updateTaskNotes={updateTaskNotes}
+                  addSubtask={addSubtask}
+                  toggleSubtask={toggleSubtask}
+                  deleteSubtask={deleteSubtask}
+                  updateSubtaskTitle={updateSubtaskTitle}
+                  noAutoFocus
+                  aiConfig={aiConfig}
+                  aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
+                  onGenerateSubtasks={generateAISubtasks}
+                  wikilinks={extractWikilinks(noteTask.title).length > 0 ? extractWikilinks(noteTask.title) : undefined}
+                  onLoadWikiNote={extractWikilinks(noteTask.title).length > 0 ? loadWikiNote : undefined}
+                  onSaveWikiNote={extractWikilinks(noteTask.title).length > 0 ? saveWikiNote : undefined}
+                  onOpenInObsidian={extractWikilinks(noteTask.title).length > 0 ? openInObsidian : undefined}
+                />
+              </div>
+            </div>
+          </div>
+        );
+      })()}
 
       {/* Trash FAB — visible during desktop drag */}
       {draggedTask && dragSource !== 'routine' && (


### PR DESCRIPTION
## Summary

On tablets in portrait LIST view, `MobileListView` is rendered by `DesktopLayout` (not `MobileLayout`), so the `expandedNotesTaskId` bottom-sheet panel that lives in `MobileLayout` was never in the tree — tapping the notes button set the state but nothing rendered.

Fix: added the same notes panel overlay to `DesktopLayout`, gated on `tabletListView && expandedNotesTaskId`. Identical logic and UI to the mobile version.

## Test plan

- [ ] On a tablet in portrait orientation, switch to LIST view
- [ ] Tap the notes button on a task — panel should slide up from the bottom
- [ ] Confirm notes and subtasks are editable
- [ ] Confirm tapping the backdrop or X closes the panel
- [ ] Confirm landscape / phone / desktop are unaffected

https://claude.ai/code/session_01CBGFyB3jTRTsyLmBspf2R5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBGFyB3jTRTsyLmBspf2R5)_