### PR TITLE
Fix Up Next and Project widget rendering

### DIFF
--- a/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
@@ -23,12 +23,13 @@ struct ProjectWidgetView: View {
     @Environment(\.widgetFamily) var family
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        let taskLimit = family == .systemLarge ? 8 : 4
+        return VStack(alignment: .leading, spacing: 0) {
             header
             Divider().padding(.vertical, 4)
             if let projects = entry.snapshot?.allProjects,
                let proj = projects.first(where: { $0.status != "completed" && $0.status != "archived" }) ?? projects.first {
-                projectView(proj: proj)
+                projectView(proj: proj, taskLimit: taskLimit)
             } else {
                 Text("No active projects")
                     .font(.caption)
@@ -46,7 +47,7 @@ struct ProjectWidgetView: View {
             .foregroundColor(.secondary)
     }
 
-    private func projectView(proj: ProjectData) -> some View {
+    private func projectView(proj: ProjectData, taskLimit: Int) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .top) {
                 RoundedRectangle(cornerRadius: 2)
@@ -73,7 +74,6 @@ struct ProjectWidgetView: View {
             }
             if let tasks = proj.tasks, !tasks.isEmpty {
                 Divider()
-                let taskLimit = family == .systemLarge ? 8 : 4
                 let incomplete = tasks.filter { !($0.completed ?? false) }
                 let complete = tasks.filter { $0.completed ?? false }
                 let visible = Array((incomplete + complete).prefix(taskLimit))

--- a/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
@@ -46,11 +46,11 @@ struct UpNextWidgetView: View {
     }
 
     private func taskView(task: NextTaskData) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
+        let subtaskLimit = family == .systemLarge ? 8 : 3
+        return VStack(alignment: .leading, spacing: 0) {
             header
             Divider().padding(.vertical, 4)
             HStack(alignment: .top, spacing: 8) {
-                // Color accent bar
                 RoundedRectangle(cornerRadius: 2)
                     .fill(Color(hex: task.colorHex ?? "#3b82f6"))
                     .frame(width: 3)
@@ -86,8 +86,7 @@ struct UpNextWidgetView: View {
                             .lineLimit(3)
                             .padding(.top, 2)
                     }
-                    // iOS 17+ interactive buttons
-                    if #available(iOS 17.0, *) {
+                    if #available(iOS 17.0, *), family != .systemSmall {
                         HStack(spacing: 8) {
                             Button(intent: CompleteTaskIntent(taskId: task.id ?? "")) {
                                 Label("Done", systemImage: "checkmark.circle")
@@ -104,10 +103,9 @@ struct UpNextWidgetView: View {
                     }
                 }
             }
-            if let subtasks = task.subtasks, !subtasks.isEmpty {
+            if family != .systemSmall, let subtasks = task.subtasks, !subtasks.isEmpty {
                 Divider().padding(.vertical, 4)
-                let limit = family == .systemLarge ? 8 : 3
-                ForEach(subtasks.prefix(limit), id: \.title) { sub in
+                ForEach(subtasks.prefix(subtaskLimit), id: \.title) { sub in
                     HStack(spacing: 6) {
                         Image(systemName: sub.completed ? "checkmark.circle.fill" : "circle")
                             .font(.caption2)


### PR DESCRIPTION
## Summary

Up Next (both sizes) and Project large were rendering as dark backgrounds with gray bars instead of showing content.

Root cause: `let` bindings computed inside `@ViewBuilder` `if let` blocks — e.g. `let limit = family == .systemLarge ? 8 : 3` nested inside `if let subtasks = ...` — cause SwiftUI to silently drop view content in the WidgetKit render context. GoalWidget wasn't affected because its `let` bindings were at the top level of the VStack, not nested inside `if let`.

Fix: compute all family-dependent values (`subtaskLimit`, `taskLimit`) **before** the ViewBuilder closures and pass them as parameters. Also restored the original `family != .systemSmall` button guard (always true for our supported families, but matches the form that was previously working), and removed the incorrect per-task ProgressViews from Project large (they were showing the project's overall progress on each task row, which was wrong).

## Test plan

- [ ] Up Next medium — shows task title, tags (italic), buttons, subtasks
- [ ] Up Next large — shows above + notes (if any) + up to 8 subtasks
- [ ] Project medium — shows project + 4 tasks
- [ ] Project large — shows project + up to 8 tasks
- [ ] Goal medium and large — unaffected

https://claude.ai/code/session_01CBGFyB3jTRTsyLmBspf2R5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBGFyB3jTRTsyLmBspf2R5)_