### PR TITLE
iOS: medium+large widgets, working Quick Actions/Spotlight, unified haptics

### DIFF
--- a/dayglance-ios/DayGlance/AppDelegate.swift
+++ b/dayglance-ios/DayGlance/AppDelegate.swift
@@ -63,6 +63,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         completionHandler: @escaping (Bool) -> Void
     ) {
         AppDelegate.pendingShortcutAction = shortcutItem.type
+        AppDelegate.notifyWebViewToDrainPendingActions()
         completionHandler(true)
     }
 
@@ -71,6 +72,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         if url.scheme == "dayglance" {
             AppDelegate.pendingDeepLink = url.absoluteString
+            AppDelegate.notifyWebViewToDrainPendingActions()
         }
         return true
     }
@@ -81,8 +83,21 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         if userActivity.activityType == CSSearchableItemActionType,
            let id = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String {
             AppDelegate.pendingDeepLink = "dayglance://task?id=\(id)"
+            AppDelegate.notifyWebViewToDrainPendingActions()
         }
         return true
+    }
+
+    /// Nudges the web layer to poll for the pending shortcut/deep-link it just
+    /// stored. The WebView translates .dayGlanceForeground into a JS
+    /// `dayglanceForeground` event, whose handler drains the pending action.
+    /// Posting here (rather than relying solely on the scenePhase → active
+    /// transition) closes the cold-launch race where the native callback can
+    /// arrive after the app is already active and the one-shot drain has run.
+    static func notifyWebViewToDrainPendingActions() {
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .dayGlanceForeground, object: nil)
+        }
     }
 }
 

--- a/dayglance-ios/DayGlance/ContentView.swift
+++ b/dayglance-ios/DayGlance/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import EventKit
+import CoreSpotlight
 
 struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
@@ -35,6 +36,22 @@ struct ContentView: View {
                 if current != lastCalendarStatus {
                     lastCalendarStatus = current
                     NotificationCenter.default.post(name: .dayGlanceReloadWebView, object: nil)
+                }
+            }
+            // Spotlight result taps. SwiftUI delivers these reliably on both cold
+            // and warm launch, unlike the AppDelegate continueUserActivity path
+            // which can be skipped under the scene-based lifecycle.
+            .onContinueUserActivity(CSSearchableItemActionType) { activity in
+                if let id = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String {
+                    AppDelegate.pendingDeepLink = "dayglance://task?id=\(id)"
+                    AppDelegate.notifyWebViewToDrainPendingActions()
+                }
+            }
+            // dayglance:// deep links (e.g. from Shortcuts or other apps).
+            .onOpenURL { url in
+                if url.scheme == "dayglance" {
+                    AppDelegate.pendingDeepLink = url.absoluteString
+                    AppDelegate.notifyWebViewToDrainPendingActions()
                 }
             }
     }

--- a/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
@@ -20,6 +20,7 @@ struct ProjectProvider: TimelineProvider {
 
 struct ProjectWidgetView: View {
     var entry: ProjectEntry
+    @Environment(\.widgetFamily) var family
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -74,7 +75,7 @@ struct ProjectWidgetView: View {
                 Divider()
                 let incomplete = tasks.filter { !($0.completed ?? false) }
                 let complete = tasks.filter { $0.completed ?? false }
-                let visible = Array((incomplete + complete).prefix(4))
+                let visible = Array((incomplete + complete).prefix(family == .systemLarge ? 8 : 4))
                 ForEach(visible, id: \.id) { t in
                     HStack(spacing: 6) {
                         Image(systemName: (t.completed ?? false) ? "checkmark.circle.fill" : "circle")
@@ -111,6 +112,6 @@ struct ProjectWidget: Widget {
         }
         .configurationDisplayName("Project")
         .description("Progress on your active project.")
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([.systemMedium, .systemLarge])
     }
 }

--- a/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
@@ -58,7 +58,7 @@ struct UpNextWidgetView: View {
                     HStack {
                         Text(task.title ?? "")
                             .font(.subheadline).fontWeight(.semibold)
-                            .lineLimit(2)
+                            .lineLimit(family == .systemLarge ? 3 : 2)
                         Spacer()
                         if let time = formattedTime(task) {
                             Text(time)
@@ -78,8 +78,16 @@ struct UpNextWidgetView: View {
                             .foregroundColor(.secondary)
                             .lineLimit(1)
                     }
+                    // Notes only on the large family, where there's room.
+                    if family == .systemLarge, let notes = task.notes, !notes.isEmpty {
+                        Text(notes)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(3)
+                            .padding(.top, 2)
+                    }
                     // iOS 17+ interactive buttons
-                    if #available(iOS 17.0, *), family != .systemSmall {
+                    if #available(iOS 17.0, *) {
                         HStack(spacing: 8) {
                             Button(intent: CompleteTaskIntent(taskId: task.id ?? "")) {
                                 Label("Done", systemImage: "checkmark.circle")
@@ -96,9 +104,9 @@ struct UpNextWidgetView: View {
                     }
                 }
             }
-            if family != .systemSmall, let subtasks = task.subtasks, !subtasks.isEmpty {
+            if let subtasks = task.subtasks, !subtasks.isEmpty {
                 Divider().padding(.vertical, 4)
-                ForEach(subtasks.prefix(3), id: \.title) { sub in
+                ForEach(subtasks.prefix(family == .systemLarge ? 6 : 3), id: \.title) { sub in
                     HStack(spacing: 6) {
                         Image(systemName: sub.completed ? "checkmark.circle.fill" : "circle")
                             .font(.caption2)
@@ -148,6 +156,6 @@ struct UpNextWidget: Widget {
         }
         .configurationDisplayName("Up Next")
         .description("Your next scheduled task.")
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([.systemMedium, .systemLarge])
     }
 }

--- a/dayglance-ios/project.yml
+++ b/dayglance-ios/project.yml
@@ -124,9 +124,10 @@ targets:
             UIApplicationShortcutItemTitle: Start Focus
             UIApplicationShortcutItemSubtitle: Focus on next task
             UIApplicationShortcutItemIconType: UIApplicationShortcutIconTypePlay
-          - UIApplicationShortcutItemType: com.dayglance.openToday
-            UIApplicationShortcutItemTitle: Open Today
-            UIApplicationShortcutItemIconType: UIApplicationShortcutIconTypeDate
+          - UIApplicationShortcutItemType: com.dayglance.voiceInput
+            UIApplicationShortcutItemTitle: Voice Input
+            UIApplicationShortcutItemSubtitle: Capture tasks by voice
+            UIApplicationShortcutItemIconType: UIApplicationShortcutIconTypeAudio
 
   DayGlanceWidget:
     type: app-extension

--- a/docs/dayglance-ios-app.md
+++ b/docs/dayglance-ios-app.md
@@ -471,11 +471,11 @@ Ship the three widget kinds at the minimum-viable sizes to give iOS a native-fee
 - App Group shared container (`group.com.dayglance.app`) replaces Android's `SharedDataStore`
 - Three widget kinds matching Android: **Up Next**, **Goal**, **Project**. The fourth Android widget — **dayGLANCE** (mirror of the GLANCE tab) — is intentionally **out of v1 scope**; it's the densest layout and benefits most from being designed alongside the Live Activity work in v1.1.
 - `nativeUpdateWidgetSnapshot(type, json)` bridge call — one call per widget kind
-- SwiftUI views — **Medium** size for all three at launch; Small added where the design is obvious (Up Next, Project)
+- SwiftUI views — **Medium** and **Large** sizes for all three (Up Next, Goal, Project). Small was removed; the dense layouts read poorly at that size. Large shows more (extra subtasks/notes on Up Next, more tasks on Project, per-project progress bars on Goal).
 - `BGAppRefreshTask` for 15-minute background refresh
 - iOS 17+ interactive widget buttons (task complete) on Up Next — App Intents required (small set: complete-task, start-focus)
 
-**Deferred to v1.1**: Large size, StandBy variant, Lock Screen widgets (separate widget family — circular, rectangular, inline), iPad-XL size.
+**Deferred to v1.1**: StandBy variant, Lock Screen widgets (separate widget family — circular, rectangular, inline), iPad-XL size.
 
 ### Phase 11 — iOS launch polish (v1)
 
@@ -483,7 +483,7 @@ Native-feeling touches that make v1 look like an iOS app rather than a port. All
 
 - **Haptics**: `nativeHaptic(type)` bridge call wired to `UIImpactFeedbackGenerator` (light/medium/heavy/success/warning/error). Web layer fires on task complete, snooze, focus-start, etc.
 - **Share Extension**: Receive shared text/URLs → create new inbox task on next app open. Standard `ShareViewController` extension target.
-- **Home Screen Quick Actions**: Long-press app icon menu with up to four actions — "New scheduled task", "New inbox task", "Start Focus on next task", "Open today". Static items in `Info.plist` (`UIApplicationShortcutItems`); handled in scene delegate, routed to the WebView as a deep link (e.g. `dg:///?action=newInboxTask`).
+- **Home Screen Quick Actions**: Long-press app icon menu with four actions — "New Scheduled Task", "New Inbox Task", "Start Focus", "Voice Input". Static items in `Info.plist` (`UIApplicationShortcutItems`); the chosen action type is stashed in the AppDelegate and drained by the web layer (via `getPendingShortcutAction`) on launch/foreground. ("Open Today" was removed — it duplicated the default launch behaviour.)
 - **Spotlight indexing**: CoreSpotlight indexes today's and upcoming tasks (and goals/projects), so users can search from the home screen and tap to open dayGLANCE deep-linked to the item. Index updates on data change via the bridge.
 - **Reminders read (opt-in)**: EventKit already covers Reminders. Add a Settings toggle "Show iOS Reminders as inbox tasks" (off by default). When enabled, reminders surface read-only alongside dayGLANCE inbox tasks — gives Apple-ecosystem users a way to consolidate without forced migration.
 - **Validate free platform features** (no implementation, just confirm they work): Universal Clipboard (copy on Mac, paste on iOS), AirDrop (export sharing), Continuity Camera (image attachments to task notes), Live Text (free OCR on attached images).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback } from 'react';
 import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Moon, Sun, Upload, Inbox, AlertCircle, Calendar, Check, RefreshCw, Palette, Trash2, Undo2, BarChart3, SkipForward, Hash, MoreHorizontal, Save, Menu, BrainCircuit, AlertTriangle, FileText, ExternalLink, CheckSquare, HelpCircle, Sparkles, Link, GripHorizontal, Play, Pause, Trophy, Cloud, Settings, Search, Bell, Target, TrendingUp, Zap, CalendarDays, Ban, Volume2, VolumeX, Pencil, Eye, Filter, Smartphone, CheckCircle, Pin, PinOff, NotebookPen, MapPin, BookOpen, Flag, FolderOpen, Droplets, Footprints, Dumbbell, Apple, Cigarette, Coffee, Flame, Heart, ListChecks, Minus, Wine, Candy, Pill, Activity, CupSoda, Mic, MicOff, Loader, Key, Server, Wifi, WifiOff, LayoutGrid, RotateCcw } from 'lucide-react';
 import { mergeTaskArrays, mergeSyncData } from './mergeSync.js';
-import { isNativeAndroid, isNativeApp, isNativeIOS, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeSetVaultSettings, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording } from './native.js';
+import { isNativeAndroid, isNativeApp, isNativeIOS, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeSetVaultSettings, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording, triggerHaptic } from './native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, tryRestoreVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, listVaultNotes, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
 import { loadAIConfig, saveAIConfig, aiComplete, aiJSON, aiTranscribe, supportsTranscription, testConnection, DEFAULT_CONFIG, PROVIDER_MODELS, PROVIDER_LABELS } from './ai.js';
 import { voiceParseSystemPrompt, voiceParseUserPrompt, taskSuggestSystemPrompt, taskSuggestUserPrompt, frameNudgeSystemPrompt, frameNudgeUserPrompt, rescheduleSystemPrompt, rescheduleUserPrompt, aiSubtasksSystemPrompt, aiSubtasksUserPrompt, morningSummarySystemPrompt, morningSummaryUserPrompt, eveningReflectionSystemPrompt, eveningReflectionUserPrompt, weeklySummarySystemPrompt, weeklySummaryUserPrompt, smartScheduleSystemPrompt, smartScheduleUserPrompt } from './ai-prompts.js';
@@ -1549,6 +1549,9 @@ const DayPlanner = () => {
                 openNewInboxTaskRef.current?.();
               } else if (action === 'startFocus') {
                 setShowFocusMode(true);
+              } else if (action === 'voiceInput') {
+                voiceAutoStartRef.current = true;
+                setShowVoiceInput(true);
               }
             } catch (_) {}
           }
@@ -1560,7 +1563,10 @@ const DayPlanner = () => {
             if (action === 'com.dayglance.newScheduledTask') setShowAddTask(true);
             else if (action === 'com.dayglance.newInboxTask') openNewInboxTaskRef.current?.();
             else if (action === 'com.dayglance.startFocus') setShowFocusMode(true);
-            // com.dayglance.openToday — app is already on today view; nothing extra needed
+            else if (action === 'com.dayglance.voiceInput') {
+              voiceAutoStartRef.current = true;
+              setShowVoiceInput(true);
+            }
           }
         }
       }, 200);
@@ -1703,6 +1709,10 @@ const DayPlanner = () => {
         if (action === 'com.dayglance.newScheduledTask') setShowAddTask(true);
         else if (action === 'com.dayglance.newInboxTask') openNewInboxTaskRef.current?.();
         else if (action === 'com.dayglance.startFocus') setShowFocusMode(true);
+        else if (action === 'com.dayglance.voiceInput') {
+          voiceAutoStartRef.current = true;
+          setShowVoiceInput(true);
+        }
       }
     }
     if (window.DayGlanceNative?.getPendingDeepLink) {
@@ -1717,6 +1727,10 @@ const DayPlanner = () => {
           else if (action === 'newScheduledTask') setShowAddTask(true);
           else if (action === 'newInboxTask') openNewInboxTaskRef.current?.();
           else if (action === 'startFocus') setShowFocusMode(true);
+          else if (action === 'voiceInput') {
+            voiceAutoStartRef.current = true;
+            setShowVoiceInput(true);
+          }
         } catch (_) {}
       }
     }
@@ -3747,7 +3761,7 @@ const DayPlanner = () => {
     setFocusTimerSeconds(focusWorkMinutes * 60);
     setFocusTimerRunning(true);
     playFocusSound('work');
-    try { window.DayGlanceNative?.triggerHaptic('medium'); } catch (_) {}
+    triggerHaptic('medium');
     if (!onboardingProgress.hasUsedFocusMode) {
       setOnboardingProgress(prev => ({ ...prev, hasUsedFocusMode: true }));
     }
@@ -5832,7 +5846,7 @@ const DayPlanner = () => {
           case 'complete': {
             const setter = isInbox ? setUnscheduledTasks : setTasks;
             setter(prev => prev.map(t => t.id === id ? { ...t, completed: true, lastModified: new Date().toISOString(), transitionId: crypto.randomUUID() } : t));
-            try { window.DayGlanceNative?.triggerHaptic('success'); } catch (_) {}
+            triggerHaptic('success');
             break;
           }
           case 'uncomplete': {
@@ -6413,7 +6427,7 @@ const DayPlanner = () => {
       } else if (pending.action === 'focus-stop') {
         exitFocusModeRef.current?.(false);
       } else if (pending.action === 'snooze' && pending.taskId) {
-        try { window.DayGlanceNative?.triggerHaptic('light'); } catch (_) {}
+        triggerHaptic('light');
         // Shift the task's start time forward by the snooze duration (default 15 min)
         const snoozeMin = pending.minutes || 15;
         const parsed = parseRecurringId(pending.taskId);

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -11,6 +11,7 @@ import * as LucideIcons from 'lucide-react';
 import { renderTitle, isLinkOnlyTask, getLinkUrl, hasNotesOrSubtasks, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
 import { dateToString } from '../utils/taskUtils.js';
 import { taskColorToHex } from '../utils/colorUtils.js';
+import { triggerHaptic } from '../native.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { getHGBarsForDate, isHGSessionReachable } from '../hooks/useHyperGlance.js';
@@ -966,7 +967,7 @@ const MobileListView = ({ hideInboxHandle = false }) => {
     ref.active = false;
     ref.ignoreRoutineId = item._kind === 'routine' ? item._routineId : null;
     ref.timer = setTimeout(() => {
-      navigator.vibrate?.(10);
+      triggerHaptic('light');
       ref.active = true;
       dragTouchPos.current = { x: t.clientX, y: t.clientY };
       setListDragItem(item);

--- a/src/hooks/useDragDrop.js
+++ b/src/hooks/useDragDrop.js
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
 import { TASK_COLORS } from '../utils/colorUtils.js';
-import { nativeUpdateEvent } from '../native.js';
+import { nativeUpdateEvent, triggerHaptic } from '../native.js';
 
 // Pure utilities used by position helpers
 const timeToMinutes = (time) => {
@@ -1004,7 +1004,7 @@ export default function useDragDrop({
       if (overTrash !== mobileDragOverTrashRef.current) {
         mobileDragOverTrashRef.current = overTrash;
         setMobileDragOverTrash(overTrash);
-        if (overTrash && navigator.vibrate) navigator.vibrate(30);
+        if (overTrash) triggerHaptic('medium');
       }
       if (overTrash) return; // freeze preview time — don't update while over trash
     }
@@ -1171,7 +1171,7 @@ export default function useDragDrop({
         document.body.style.webkitUserSelect = 'none';
         document.body.style.userSelect = 'none';
         // Haptic feedback
-        if (navigator.vibrate) navigator.vibrate(50);
+        triggerHaptic('heavy');
       }, 500);
     }
   };
@@ -1488,7 +1488,7 @@ export default function useDragDrop({
 
     if (Math.abs(offset) > threshold && !isRightSwipeBlocked) {
       // Trigger action
-      if (navigator.vibrate) navigator.vibrate(40);
+      triggerHaptic('medium');
       const direction = offset > 0 ? 'right' : 'left';
       // Animate off-screen
       el.style.transform = `translateX(${direction === 'right' ? elWidth : -elWidth}px)`;

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -1,6 +1,7 @@
 import { cleanTitle } from '../utils/suggestionParser.js';
 import { dateToString, extractTags, formatDeadlineDate } from '../utils/taskUtils.js';
 import { TASK_COLORS } from '../utils/colorUtils.js';
+import { triggerHaptic } from '../native.js';
 
 // Strip a specific tag (e.g. "#obsidian") from a title string.
 const stripTag = (title, tag) =>
@@ -379,7 +380,7 @@ export default function useTaskActions({
   const toggleComplete = (id, fromInbox = false) => {
     pushUndo();
     playUISound('tick');
-    if (navigator.vibrate) navigator.vibrate(30);
+    triggerHaptic('medium');
     if (typeof id === 'string' && id.startsWith('recurring-')) {
       const { templateId, dateStr } = parseRecurringId(id);
       setRecurringTasks(prev => prev.map(t => {
@@ -644,7 +645,7 @@ export default function useTaskActions({
         setTasks(prev => prev.filter(t => t.id !== id));
       }
       playUISound('swoosh');
-      if (navigator.vibrate) navigator.vibrate([30, 50, 30]);
+      triggerHaptic('success');
       setUndoToast({ message: 'Task deleted', actionable: true });
       if (!onboardingProgress.hasUsedActionButtons) {
         setOnboardingProgress(prev => ({ ...prev, hasUsedActionButtons: true }));

--- a/src/native.js
+++ b/src/native.js
@@ -596,3 +596,44 @@ export const nativeShareFile = (filename, content) => {
     return null;
   }
 };
+
+// ── Haptics ─────────────────────────────────────────────────────────────────
+
+// Web vibration durations (ms) used only for the PWA / desktop fallback.
+const WEB_VIBRATION_PATTERNS = {
+  light: 10,
+  medium: 30,
+  heavy: 50,
+  success: [30, 50, 30],
+  warning: [40, 60, 40],
+  error: [60, 40, 60],
+};
+
+/**
+ * Triggers haptic feedback, routed to the correct mechanism per platform.
+ *
+ * Both the iOS WKWebView and the Android System WebView ignore the web
+ * `navigator.vibrate` API, so feedback must go through the native bridge's
+ * triggerHaptic (UIFeedbackGenerator on iOS, Vibrator on Android). Only the
+ * PWA / desktop web build falls back to navigator.vibrate.
+ *
+ * NOTE: iPads have no Taptic Engine, so UIFeedbackGenerator is a silent no-op
+ * there — haptics on iOS are felt on iPhone only. On Android the device's
+ * system "touch/haptic feedback" setting must be enabled.
+ *
+ * @param type  'light' | 'medium' | 'heavy' | 'success' | 'warning' | 'error'
+ */
+export const triggerHaptic = (type = 'medium') => {
+  const bridge = nativeBridge();
+  if (bridge?.triggerHaptic) {
+    try {
+      bridge.triggerHaptic(type);
+      return;
+    } catch (_) { /* fall through to the web vibration fallback */ }
+  }
+  if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+    try {
+      navigator.vibrate(WEB_VIBRATION_PATTERNS[type] ?? 30);
+    } catch (_) {}
+  }
+};


### PR DESCRIPTION
Final iOS pre-launch fixes across widgets, Quick Actions, Spotlight, and haptics.

## 1. Widgets — drop Small, support Medium + Large (Up Next, Project, Goal)
The earlier blank-widget breakage came from the `let x = …; return VStack {…}` form, which strips SwiftUI's implicit `@ViewBuilder` and collapses the conditional branches. This change deliberately avoids that and mirrors the **Goal** widget, which already shipped Large successfully: every size-dependent value is computed inline *inside* the ViewBuilder closures (e.g. `prefix(family == .systemLarge ? 8 : 4)`), never as a bare statement before a `return`.

| Widget | Medium | Large |
|---|---|---|
| **Up Next** | 1 task: title (2 lines), time, project, tags, Done/Focus buttons (iOS 17+), up to **3 subtasks** | 1 task: title (3 lines), time, project, tags, **+ notes (3 lines)**, Done/Focus buttons, up to **6 subtasks** |
| **Project** | 1 active project: goal name, title, progress bar, completed/total, up to **4 tasks** + "+N more" | Same, up to **8 tasks** + "+N more" |
| **Goal** | 1 goal: title, due badge, progress bar, %/task count, up to **3 projects** | Same, up to **5 projects**, each **with its own progress bar** |

## 2. Quick Actions
- Removed the no-op **"Open Today"**.
- Added **"Voice Input"**, which opens the voice modal and auto-starts recording.
- The other three were already wired in JS; the pending action could be missed on cold launch — see reliability fix below.

## 3. Quick Actions / Spotlight reliability
Under SwiftUI's scene lifecycle, the `NSUserActivity` from a Spotlight tap (and a pending shortcut) could be dropped on cold launch. The AppDelegate now nudges the web layer to drain the pending action the instant it captures it, and `ContentView` uses SwiftUI's `.onContinueUserActivity` / `.onOpenURL`, which deliver reliably on both cold and warm launch. A Spotlight tap navigates to the task's date (and switches to timeline/inbox on mobile).

## 4. Haptics
Most call sites used `navigator.vibrate`, which is a no-op in both the iOS WKWebView and the Android System WebView. Added a unified `triggerHaptic()` helper that routes through the native bridge (`UIFeedbackGenerator` on iOS, `Vibrator` on Android) and only falls back to `navigator.vibrate` on the web/PWA build, then routed every vibrate/haptic call site through it.

Notes for testing:
- **iPads have no Taptic Engine** — `UIFeedbackGenerator` is silent there regardless of code; iOS haptics are felt on iPhone only.
- **Android** has the `VIBRATE` permission already; confirm the device's system touch/haptic-feedback setting is on.

## Verification
The iOS web build (`vite build --config vite.config.ios.js`) passes. The Swift/Xcode targets can't be built in this environment, so the native changes need a device pass: confirm the three widgets render at both sizes, the four Quick Actions, a Spotlight tap, and haptics on an iPhone.

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe)_