### PR TITLE
iOS: Quick Actions scene delegate + widget polish, Goals badge, Spotlight & tablet fixes

### DIFF
--- a/dayglance-ios/DayGlance/AppDelegate.swift
+++ b/dayglance-ios/DayGlance/AppDelegate.swift
@@ -49,6 +49,23 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         scheduleWidgetRefresh()
     }
 
+    // MARK: - Scene configuration
+
+    // SwiftUI's App lifecycle is scene-based. Routing scene creation through a
+    // UISceneConfiguration with our SceneDelegate is the only reliable way to
+    // receive Home Screen Quick Actions (and cold-launch Spotlight / deep links)
+    // in this kind of app. We do not manage a window in the delegate, so SwiftUI
+    // continues to provide and render the scene's content unchanged.
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let config = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
+        config.delegateClass = SceneDelegate.self
+        return config
+    }
+
     private func scheduleWidgetRefresh() {
         let request = BGAppRefreshTaskRequest(identifier: "com.dayglance.widgetrefresh")
         request.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60)

--- a/dayglance-ios/DayGlance/SceneDelegate.swift
+++ b/dayglance-ios/DayGlance/SceneDelegate.swift
@@ -1,0 +1,63 @@
+import UIKit
+import CoreSpotlight
+
+/// SwiftUI's `App` lifecycle is scene-based, so the system delivers Home Screen
+/// Quick Actions to a `UIWindowSceneDelegate` — NOT to the app delegate's
+/// `application(_:performActionFor:)`, and NOT via `launchOptions[.shortcutItem]`.
+/// Without this scene delegate those callbacks never fire, which is why tapping
+/// a Quick Action only opened the app and did nothing else.
+///
+/// We attach this delegate through `AppDelegate.application(_:configurationForConnecting:options:)`.
+/// Importantly we do NOT create or manage a `UIWindow` here — SwiftUI still owns
+/// the scene's content, so the UI renders exactly as before. We only listen for
+/// the launch events and stash them where the web layer drains them.
+final class SceneDelegate: NSObject, UIWindowSceneDelegate {
+
+    // Cold launch: the app was not running. The triggering shortcut / activity /
+    // URL arrives in the connection options. The web layer drains these once its
+    // data has loaded (the `dataLoaded` effect in App.jsx), so there's no need to
+    // nudge it here — the WebView isn't even up yet.
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        if let shortcut = connectionOptions.shortcutItem {
+            AppDelegate.pendingShortcutAction = shortcut.type
+        }
+        connectionOptions.userActivities.forEach(captureUserActivity)
+        if let url = connectionOptions.urlContexts.first?.url {
+            captureURL(url)
+        }
+    }
+
+    // Warm launch: the app was already running in the background. Stash the action
+    // and nudge the web layer to drain it immediately.
+    func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+        AppDelegate.pendingShortcutAction = shortcutItem.type
+        AppDelegate.notifyWebViewToDrainPendingActions()
+        completionHandler(true)
+    }
+
+    // Warm launch: Spotlight result tap / Handoff.
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        captureUserActivity(userActivity)
+        AppDelegate.notifyWebViewToDrainPendingActions()
+    }
+
+    // Warm launch: dayglance:// deep link.
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else { return }
+        captureURL(url)
+        AppDelegate.notifyWebViewToDrainPendingActions()
+    }
+
+    // MARK: - Helpers
+
+    private func captureUserActivity(_ activity: NSUserActivity) {
+        guard activity.activityType == CSSearchableItemActionType,
+              let id = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String else { return }
+        AppDelegate.pendingDeepLink = "dayglance://task?id=\(id)"
+    }
+
+    private func captureURL(_ url: URL) {
+        guard url.scheme == "dayglance" else { return }
+        AppDelegate.pendingDeepLink = url.absoluteString
+    }
+}

--- a/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
@@ -41,9 +41,15 @@ struct ProjectWidgetView: View {
     }
 
     private var header: some View {
-        Text("PROJECT")
-            .font(.caption2).fontWeight(.bold)
-            .foregroundColor(.secondary)
+        HStack {
+            Text("PROJECT")
+                .font(.caption2).fontWeight(.bold)
+                .foregroundColor(.secondary)
+            Spacer()
+            Text(entry.snapshot?.dateLabel ?? "")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
     }
 
     private func projectView(proj: ProjectData) -> some View {

--- a/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
@@ -48,7 +48,7 @@ struct UpNextWidgetView: View {
     private func taskView(task: NextTaskData) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             header
-            Divider().padding(.vertical, 4)
+            Divider().padding(.vertical, 3)
             HStack(alignment: .top, spacing: 8) {
                 RoundedRectangle(cornerRadius: 2)
                     .fill(Color(hex: task.colorHex ?? "#3b82f6"))
@@ -60,7 +60,7 @@ struct UpNextWidgetView: View {
                             .font(.subheadline).fontWeight(.semibold)
                             .lineLimit(family == .systemLarge ? 3 : 2)
                         Spacer()
-                        if let time = formattedTime(task) {
+                        if let time = timeLabel(task) {
                             Text(time)
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
@@ -100,13 +100,13 @@ struct UpNextWidgetView: View {
                             }
                             .buttonStyle(.bordered)
                         }
-                        .padding(.top, 2)
+                        .padding(.top, 1)
                     }
                 }
             }
             if let subtasks = task.subtasks, !subtasks.isEmpty {
-                Divider().padding(.vertical, 4)
-                ForEach(subtasks.prefix(family == .systemLarge ? 6 : 3), id: \.title) { sub in
+                Divider().padding(.vertical, 3)
+                ForEach(subtasks.prefix(family == .systemLarge ? 7 : 4), id: \.title) { sub in
                     HStack(spacing: 6) {
                         Image(systemName: sub.completed ? "checkmark.circle.fill" : "circle")
                             .font(.caption2)
@@ -133,6 +133,20 @@ struct UpNextWidgetView: View {
                 .font(.caption2)
                 .foregroundColor(.secondary)
         }
+    }
+
+    // Start time plus duration, e.g. "9:00AM · 30m". Falls back to just the
+    // start time when no duration is set.
+    private func timeLabel(_ task: NextTaskData) -> String? {
+        guard let time = formattedTime(task) else { return nil }
+        if let d = task.duration, d > 0 { return "\(time) · \(formattedDuration(d))" }
+        return time
+    }
+
+    private func formattedDuration(_ minutes: Int) -> String {
+        if minutes < 60 { return "\(minutes)m" }
+        let h = minutes / 60, m = minutes % 60
+        return m == 0 ? "\(h)h" : "\(h)h\(m)m"
     }
 
     private func formattedTime(_ task: NextTaskData) -> String? {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7610,11 +7610,16 @@ const DayPlanner = () => {
   ]);
 
   // Phase 11 — Spotlight indexing: keep Spotlight in sync with non-archived,
-  // non-completed tasks so they're searchable from iOS Spotlight.
+  // non-completed tasks so they're searchable from iOS Spotlight. Past-dated
+  // tasks and events are excluded — only today/future and undated (inbox)
+  // items are worth surfacing. Date strings are 'YYYY-MM-DD', so a lexical
+  // compare against today is correct.
   useEffect(() => {
     if (!window.DayGlanceNative?.indexSpotlight) return;
     if (!dataLoaded) return;
-    const allTasks = [...tasks, ...unscheduledTasks].filter(t => !t.archived && !t.completed && isVisibleForUser(t));
+    const todayStr = dateToString(new Date());
+    const allTasks = [...tasks, ...unscheduledTasks].filter(t =>
+      !t.archived && !t.completed && isVisibleForUser(t) && (!t.date || t.date >= todayStr));
     const items = allTasks.map(t => ({
       id: t.id,
       title: t.title.replace(/\[\[[^\]]*\]\]/g, '').replace(/#\S+/g, '').replace(/\s+/g, ' ').trim(),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7403,7 +7403,7 @@ const DayPlanner = () => {
       duration: nextTaskCandidate.duration || 0,
       tags: (nextTaskCandidate.tags || []).slice(0, 5),
       notes: (nextTaskCandidate.notes || '').substring(0, 300),
-      subtasks: (nextTaskCandidate.subtasks || []).slice(0, 5).map(s => ({
+      subtasks: (nextTaskCandidate.subtasks || []).slice(0, 7).map(s => ({
         title: s.title,
         completed: s.completed || false,
       })),

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -470,7 +470,7 @@ const DesktopLayout = () => {
 
       {/* Tablet header strip */}
       {isTablet && (
-        <div className={`${cardBg} border-b ${borderClass} px-4 flex items-center justify-between`} style={{ height: '56px' }}>
+        <div className={`${cardBg} border-b ${borderClass} px-4 flex items-center justify-between relative`} style={{ height: '56px' }}>
           <div className="flex items-center gap-1">
               <button onClick={() => changeDate(-1)} className={`p-2 rounded-lg hover:bg-black/5 active:bg-black/10 dark:hover:bg-white/5 dark:active:bg-white/10 transition-colors`} aria-label="Previous day">
                 <ChevronLeft size={20} className={textSecondary} />

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -598,6 +598,12 @@ function NowRow({ nowMin, nextItem, formatTime, textSecondary, darkMode, use24Ho
             color: darkMode ? '#fca5a5' : '#991b1b',
             border: '2px solid #ef4444',
             background: darkMode ? '#ef444415' : '#fef2f2',
+            display: 'inline-block',
+            maxWidth: '100%',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            verticalAlign: 'middle',
           }}
         >
           {countdownStr}

--- a/src/components/MobileTabBar.jsx
+++ b/src/components/MobileTabBar.jsx
@@ -16,10 +16,14 @@ const MobileTabBar = () => {
   } = useDayPlannerCtx();
   const { t } = useTranslation();
   const {
-    goalsProjectsEnabled, goals, handleRoutinesDone,
+    goalsProjectsEnabled, goals, handleRoutinesDone, isVisibleForUser,
   } = useFeaturesCtx();
 
-  const activeGoals = goalsProjectsEnabled ? (goals || []).filter(g => g.status !== 'archived') : [];
+  // Count only the active user's goals (matches the per-user visibility used
+  // for goals elsewhere); in single-user mode isVisibleForUser is always true.
+  const activeGoals = goalsProjectsEnabled
+    ? (goals || []).filter(g => g.status !== 'archived' && isVisibleForUser(g))
+    : [];
   const goalsCount = activeGoals.length;
   const today = new Date(); today.setHours(0, 0, 0, 0);
   const hasOverdueGoal = activeGoals.some(g => g.targetDate && new Date(g.targetDate + 'T00:00:00') < today && g.status !== 'completed');


### PR DESCRIPTION
Follow-up polish on top of #1003 (now merged).

## Quick Actions — the real fix
Quick Actions still did nothing after #1003 because **SwiftUI's `App` lifecycle is scene-based**: the system never calls the app delegate's `application(_:performActionFor:)` and leaves `launchOptions[.shortcutItem]` nil. Home Screen shortcuts are delivered to a `UIWindowSceneDelegate`, which the app didn't have — so a tap only opened the app.

Added `SceneDelegate.swift`, wired via `application(_:configurationForConnecting:options:)`, which captures the triggering shortcut on **cold launch** (`scene(willConnectTo:)`) and **warm launch** (`windowScene(performActionFor:)`) and nudges the web layer to drain it. It also handles cold/warm Spotlight activities and `dayglance://` deep links, so those no longer depend on app-delegate callbacks a scene-based app skips. The delegate does **not** create or manage a `UIWindow`, so SwiftUI keeps owning and rendering the scene content unchanged.

## Widgets
- **Project widget** — day/date label in the top-right, matching Up Next and Goal (reuses the snapshot's `dateLabel`).
- **Up Next — duration** — shows duration next to the start time, e.g. `9:00AM · 30m` (`1h`, `1h30m` for longer); falls back to just the time when none is set.
- **Up Next — extra subtask row** — tightened the title/notes/buttons block and bumped the subtask count by one (Medium 3→4, Large 6→7); raised the snapshot subtask cap from 5→7 so the Large widget has the data.

All size-dependent values stay inline inside ViewBuilder closures — no structural change, no blank-widget risk.

## App fixes
- **Goals tab badge — per user** — the bottom-tab Goals count now counts only the **active user's** goals (`isVisibleForUser`). Unchanged in single-user mode.
- **List view "now" marker** — the red countdown pill truncates with an ellipsis instead of wrapping for long titles.
- **Spotlight — exclude past items** — indexing skips past-dated tasks/events; only today/future and undated (inbox) items are surfaced.
- **Tablet date picker** — the tablet header was missing `position: relative`, so the month-view popup rendered off-screen; tapping the date now opens the picker on tablet.

## Verification
The iOS web build (`vite build --config vite.config.ios.js`) passes; the app-layer fixes are exercised by it. The Swift targets can't be built here, so please verify on device — **first confirm the app still renders normally after the SceneDelegate change** (the canonical no-window pattern keeps SwiftUI in charge of the UI), then the four Quick Actions, a Spotlight tap, and the widget changes.

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe