### PR TITLE
iOS follow-ups: scheduled-task quick action, widget tags/multi-task/strikethrough, tablet picker

### DIFF
--- a/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
@@ -89,6 +89,7 @@ struct ProjectWidgetView: View {
                             .foregroundColor((t.completed ?? false) ? .green : .secondary)
                         Text(t.title ?? "")
                             .font(.caption2)
+                            .strikethrough(t.completed ?? false)
                             .foregroundColor((t.completed ?? false) ? .secondary : .primary)
                             .lineLimit(1)
                     }

--- a/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
@@ -60,7 +60,7 @@ struct UpNextWidgetView: View {
                             .font(.subheadline).fontWeight(.semibold)
                             .lineLimit(family == .systemLarge ? 3 : 2)
                         Spacer()
-                        if let time = timeLabel(task) {
+                        if let time = timeLabel(startTime: task.startTime, duration: task.duration) {
                             Text(time)
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
@@ -117,10 +117,35 @@ struct UpNextWidgetView: View {
                             .lineLimit(1)
                     }
                 }
+            } else if !showsNotes(task), let upcoming = entry.snapshot?.upcomingTasks, !upcoming.isEmpty {
+                // The primary task is simple, so fill the leftover space with the
+                // next upcoming tasks (title + time only — no action buttons).
+                Divider().padding(.vertical, 3)
+                ForEach(upcoming.prefix(family == .systemLarge ? 4 : 2), id: \.id) { up in
+                    HStack(spacing: 8) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(Color(hex: up.colorHex ?? "#3b82f6"))
+                            .frame(width: 3, height: 14)
+                        Text(up.title ?? "")
+                            .font(.caption2)
+                            .lineLimit(1)
+                        Spacer()
+                        if let time = timeLabel(startTime: up.startTime, duration: up.duration) {
+                            Text(time)
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
             }
         }
         .padding()
         .containerBackground(.background, for: .widget)
+    }
+
+    // Notes are only rendered on the Large family, and only when present.
+    private func showsNotes(_ task: NextTaskData) -> Bool {
+        family == .systemLarge && !(task.notes?.isEmpty ?? true)
     }
 
     private var header: some View {
@@ -137,9 +162,9 @@ struct UpNextWidgetView: View {
 
     // Start time plus duration, e.g. "9:00AM · 30m". Falls back to just the
     // start time when no duration is set.
-    private func timeLabel(_ task: NextTaskData) -> String? {
-        guard let time = formattedTime(task) else { return nil }
-        if let d = task.duration, d > 0 { return "\(time) · \(formattedDuration(d))" }
+    private func timeLabel(startTime: String?, duration: Int?) -> String? {
+        guard let time = formattedTime(startTime) else { return nil }
+        if let d = duration, d > 0 { return "\(time) · \(formattedDuration(d))" }
         return time
     }
 
@@ -149,8 +174,8 @@ struct UpNextWidgetView: View {
         return m == 0 ? "\(h)h" : "\(h)h\(m)m"
     }
 
-    private func formattedTime(_ task: NextTaskData) -> String? {
-        guard let st = task.startTime, !st.isEmpty else { return nil }
+    private func formattedTime(_ startTime: String?) -> String? {
+        guard let st = startTime, !st.isEmpty else { return nil }
         let use24 = entry.snapshot?.use24Hour ?? false
         let parts = st.split(separator: ":").compactMap { Int($0) }
         guard parts.count >= 2 else { return st }

--- a/dayglance-ios/DayGlanceWidget/WidgetModels.swift
+++ b/dayglance-ios/DayGlanceWidget/WidgetModels.swift
@@ -9,9 +9,20 @@ struct WidgetSnapshot: Codable {
     var dateLabel: String?
     var use24Hour: Bool?
     var nextTask: NextTaskData?
+    var upcomingTasks: [UpcomingTaskData]?
     var allGoals: [GoalData]?
     var allProjects: [ProjectData]?
     var updatedAt: Double?
+}
+
+// Lightweight task used to fill leftover space in the Up Next widget when the
+// primary task has no subtasks/notes of its own.
+struct UpcomingTaskData: Codable {
+    var id: String?
+    var title: String?
+    var colorHex: String?
+    var startTime: String?
+    var duration: Int?
 }
 
 struct NextTaskData: Codable {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1544,7 +1544,7 @@ const DayPlanner = () => {
               if (action === 'task' && taskId) {
                 setSpotlightTaskId(taskId);
               } else if (action === 'newScheduledTask') {
-                setShowAddTask(true);
+                openNewTaskFormRef.current?.();
               } else if (action === 'newInboxTask') {
                 openNewInboxTaskRef.current?.();
               } else if (action === 'startFocus') {
@@ -1560,7 +1560,7 @@ const DayPlanner = () => {
           const rawAction = window.DayGlanceNative.getPendingShortcutAction();
           if (rawAction && rawAction !== 'null') {
             const action = rawAction.replace(/^"|"$/g, '');
-            if (action === 'com.dayglance.newScheduledTask') setShowAddTask(true);
+            if (action === 'com.dayglance.newScheduledTask') openNewTaskFormRef.current?.();
             else if (action === 'com.dayglance.newInboxTask') openNewInboxTaskRef.current?.();
             else if (action === 'com.dayglance.startFocus') setShowFocusMode(true);
             else if (action === 'com.dayglance.voiceInput') {
@@ -1706,7 +1706,7 @@ const DayPlanner = () => {
       const rawAction = window.DayGlanceNative.getPendingShortcutAction();
       if (rawAction && rawAction !== 'null') {
         const action = rawAction.replace(/^"|"$/g, '');
-        if (action === 'com.dayglance.newScheduledTask') setShowAddTask(true);
+        if (action === 'com.dayglance.newScheduledTask') openNewTaskFormRef.current?.();
         else if (action === 'com.dayglance.newInboxTask') openNewInboxTaskRef.current?.();
         else if (action === 'com.dayglance.startFocus') setShowFocusMode(true);
         else if (action === 'com.dayglance.voiceInput') {
@@ -1724,7 +1724,7 @@ const DayPlanner = () => {
           const action = url.pathname.replace(/^\/+/, '') || url.hostname;
           const taskId = url.searchParams.get('id');
           if (action === 'task' && taskId) setSpotlightTaskId(taskId);
-          else if (action === 'newScheduledTask') setShowAddTask(true);
+          else if (action === 'newScheduledTask') openNewTaskFormRef.current?.();
           else if (action === 'newInboxTask') openNewInboxTaskRef.current?.();
           else if (action === 'startFocus') setShowFocusMode(true);
           else if (action === 'voiceInput') {
@@ -1811,6 +1811,7 @@ const DayPlanner = () => {
   // Uses the same cloudSyncInProgressRef lock to serialise with WebDAV.
   const iCloudSyncRef = useRef(null);
   const openNewInboxTaskRef = useRef(null);
+  const openNewTaskFormRef = useRef(null);
   const iCloudAvailableRef = useRef(null); // null=unchecked, true/false=result
   const iCloudLastWriteAtRef = useRef(0);
 
@@ -7031,6 +7032,7 @@ const DayPlanner = () => {
   // Keep a stable ref so the foreground handler (defined earlier in the component)
   // can call openNewInboxTask without needing it in its closure.
   openNewInboxTaskRef.current = openNewInboxTask;
+  openNewTaskFormRef.current = openNewTaskForm;
 
   // Wire up TDZ-safe refs for useDragDrop (see refs declared before the hook call).
   moveToRecycleBinRef.current = moveToRecycleBin;
@@ -7386,22 +7388,26 @@ const DayPlanner = () => {
     // ── Next Task (for Up Next widget) ───────────────────────────────────
     // The nearest non-completed scheduled task that hasn't ended yet (or is in progress).
     const nowMin = today.getHours() * 60 + today.getMinutes();
-    const nextTaskCandidate = todayAgenda
+    // Scheduled, non-completed tasks that haven't ended yet (in progress or
+    // upcoming), in chronological order. The first is the "Up Next" task; the
+    // rest fill leftover widget space when the primary task is simple.
+    const sortedUpcoming = todayAgenda
       .filter(t => t._agendaType === 'scheduled' && !t.completed && t.startTime)
       .sort((a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime))
-      .find(t => {
+      .filter(t => {
         const start = timeToMinutes(t.startTime);
         const end = start + (t.duration || 0);
         // Include if not yet ended (covers "in progress" and "upcoming")
         return end > nowMin || (t.duration === 0 && start >= nowMin);
-      }) || null;
+      });
+    const nextTaskCandidate = sortedUpcoming[0] || null;
     const nextTaskItem = nextTaskCandidate ? {
       id: nextTaskCandidate.id,
       title: nextTaskCandidate.title.replace(/\[\[[^\]]*\]\]/g, '').replace(/#\S+/g, '').replace(/\s+/g, ' ').trim(),
       colorHex: taskColorToHex(nextTaskCandidate.color, nextTaskCandidate.nativeCalendarColor),
       startTime: nextTaskCandidate.startTime || '',
       duration: nextTaskCandidate.duration || 0,
-      tags: (nextTaskCandidate.tags || []).slice(0, 5),
+      tags: extractTags(nextTaskCandidate.title).slice(0, 5),
       notes: (nextTaskCandidate.notes || '').substring(0, 300),
       subtasks: (nextTaskCandidate.subtasks || []).slice(0, 7).map(s => ({
         title: s.title,
@@ -7409,6 +7415,16 @@ const DayPlanner = () => {
       })),
       projectName: getProjectName(nextTaskCandidate),
     } : null;
+
+    // The tasks after the "Up Next" one — used to fill the widget when the
+    // primary task has no subtasks/notes. Cap at 4 (the Large widget's max).
+    const upcomingTaskItems = sortedUpcoming.slice(1, 5).map(t => ({
+      id: t.id,
+      title: t.title.replace(/\[\[[^\]]*\]\]/g, '').replace(/#\S+/g, '').replace(/\s+/g, ' ').trim(),
+      colorHex: taskColorToHex(t.color, t.nativeCalendarColor),
+      startTime: t.startTime || '',
+      duration: t.duration || 0,
+    }));
 
     // ── All Goals (for Goal widget) ───────────────────────────────────────
     const allGoalsData = goalsProjectsEnabled
@@ -7584,6 +7600,7 @@ const DayPlanner = () => {
       hyperGlance: hyperGlanceItems,
       glanceAhead: glanceAheadData,
       nextTask: nextTaskItem,
+      upcomingTasks: upcomingTaskItems,
       nextUpNext,
       updatedAt: Date.now(),
     };

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -609,7 +609,7 @@ const DesktopLayout = () => {
           </div>
           {/* Tablet month view popup */}
           {showMonthView && (
-            <div className={`month-view-container absolute left-1/2 -translate-x-1/2 top-full mt-1 ${cardBg} rounded-lg shadow-xl border ${borderClass} p-4 z-50 min-w-[300px]`}>
+            <div className={`month-view-container absolute left-4 top-full mt-1 ${cardBg} rounded-lg shadow-xl border ${borderClass} p-4 z-50 min-w-[300px]`}>
               <div className="flex items-center justify-between mb-3">
                 <button type="button" onClick={(e) => { e.stopPropagation(); changeViewedMonth(-1); }} className={`p-2 rounded-lg hover:bg-black/5 active:bg-black/10 dark:hover:bg-white/5 dark:active:bg-white/10 transition-colors`} aria-label="Previous month">
                   <ChevronLeft size={18} className={textSecondary} />


### PR DESCRIPTION
Follow-ups from device testing of the iOS app.

## Fixes
- **Quick action: "New Scheduled Task" opened the Inbox modal** — it called bare `setShowAddTask(true)`, which reused whatever `openInInbox` flag `newTask` last had. It now routes through `openNewTaskForm` (via a new stable ref), so it always opens the scheduled-task form. Applied to every shortcut/deep-link drain path.
- **Up Next widget — tags not showing** — tasks store tags inline in the title (`#tag`), not as a `tags` array, so the snapshot always sent `[]`. Tags are now derived with `extractTags(title)`.
- **Up Next widget — multiple tasks when there's room** — when the primary task has no subtasks (and no notes on Large), the leftover space is filled with the next upcoming tasks (title + time, no buttons). The snapshot gains an `upcomingTasks` array; the widget shows up to **2 (Medium) / 4 (Large)**.
- **Project widget — strikethrough** for completed task titles.
- **Tablet month-view date picker** — now anchors under the date button (left-aligned) instead of centered on the header.

## Deferred (per discussion)
- **"Show iOS Reminders as inbox tasks"** — confirmed **not implemented** (only a native `getReminders` bridge stub exists; no permission prompt, toggle, or JS integration). Deferred for now.

## Verification
The iOS web build (`vite build --config vite.config.ios.js`) passes, covering the quick-action fix and the snapshot/tags/upcoming changes. The Swift widget changes (tags rendering, upcoming-tasks list, strikethrough) need an on-device pass.

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe)_