### PR TITLE
Up Next widget: pack upcoming tasks under the primary task, not at the bottom

### DIFF
--- a/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
@@ -104,6 +104,10 @@ struct UpNextWidgetView: View {
                     }
                 }
             }
+            // Keep the main row at its natural height — the color bar is a
+            // greedy shape that would otherwise stretch and shove the list below
+            // it to the bottom of the widget.
+            .fixedSize(horizontal: false, vertical: true)
             if let subtasks = task.subtasks, !subtasks.isEmpty {
                 Divider().padding(.vertical, 3)
                 ForEach(subtasks.prefix(family == .systemLarge ? 7 : 4), id: \.title) { sub in
@@ -138,6 +142,8 @@ struct UpNextWidgetView: View {
                     }
                 }
             }
+            // Pack everything to the top; leftover space falls to the bottom.
+            Spacer(minLength: 0)
         }
         .padding()
         .containerBackground(.background, for: .widget)


### PR DESCRIPTION
## Problem

In the multi-task Up Next widget (from #1005), the upcoming tasks rendered pinned to the **bottom** of the widget with a large blank gap above them, instead of filling the space directly beneath the primary task.

### Root cause
The primary task's accent bar is `RoundedRectangle().frame(width: 3)` with **no height set**. A SwiftUI `Shape` with an unconstrained dimension is *greedy* — it expands to fill all available vertical space. That made the entire main row greedy, so it stretched to fill the widget and pushed the upcoming-tasks list to the bottom. (That blue line running all the way down the left edge in the screenshot was the stretched bar.)

The Project widget doesn't have this issue because its bar uses a fixed `height: 36`.

## Fix
- `.fixedSize(horizontal: false, vertical: true)` on the main row so it takes only its natural height (the bar then matches the text block, like the Project widget).
- A trailing `Spacer(minLength: 0)` so content packs at the top and leftover space falls to the bottom.

Result: upcoming tasks list immediately under the primary task; blank space (when there are few tasks) collapses to the bottom.

## Verification
Layout-only SwiftUI change — needs an on-device pass to confirm the spacing looks right on Medium and Large.

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe)_