### PR TITLE
iOS: make Up Next widget Done/Focus buttons actually work

### DIFF
--- a/dayglance-ios/DayGlanceWidget/WidgetIntents.swift
+++ b/dayglance-ios/DayGlanceWidget/WidgetIntents.swift
@@ -15,6 +15,9 @@ extension StartFocusIntent: ForegroundContinuableIntent {}
 @available(iOS 17.0, *)
 struct CompleteTaskIntent: AppIntent {
     static let title: LocalizedStringResource = "Complete Task"
+    // Task data lives in the web layer, so the app must be foregrounded to apply
+    // the action; the web layer drains it via getWidgetPendingAction on resume.
+    static var openAppWhenRun: Bool = true
 
     @Parameter(title: "Task ID")
     var taskId: String
@@ -35,6 +38,8 @@ struct CompleteTaskIntent: AppIntent {
 @available(iOS 17.0, *)
 struct StartFocusIntent: AppIntent {
     static let title: LocalizedStringResource = "Start Focus"
+    // Opens Focus mode in the app; foreground so the web layer can act on it.
+    static var openAppWhenRun: Bool = true
 
     func perform() async throws -> some IntentResult {
         if let defaults = UserDefaults(suiteName: "group.com.dayglance.app") {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback } from 'react';
 import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Moon, Sun, Upload, Inbox, AlertCircle, Calendar, Check, RefreshCw, Palette, Trash2, Undo2, BarChart3, SkipForward, Hash, MoreHorizontal, Save, Menu, BrainCircuit, AlertTriangle, FileText, ExternalLink, CheckSquare, HelpCircle, Sparkles, Link, GripHorizontal, Play, Pause, Trophy, Cloud, Settings, Search, Bell, Target, TrendingUp, Zap, CalendarDays, Ban, Volume2, VolumeX, Pencil, Eye, Filter, Smartphone, CheckCircle, Pin, PinOff, NotebookPen, MapPin, BookOpen, Flag, FolderOpen, Droplets, Footprints, Dumbbell, Apple, Cigarette, Coffee, Flame, Heart, ListChecks, Minus, Wine, Candy, Pill, Activity, CupSoda, Mic, MicOff, Loader, Key, Server, Wifi, WifiOff, LayoutGrid, RotateCcw } from 'lucide-react';
 import { mergeTaskArrays, mergeSyncData } from './mergeSync.js';
-import { isNativeAndroid, isNativeApp, isNativeIOS, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeSetVaultSettings, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording, triggerHaptic } from './native.js';
+import { isNativeAndroid, isNativeApp, isNativeIOS, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeGetWidgetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeSetVaultSettings, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording, triggerHaptic } from './native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, tryRestoreVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, listVaultNotes, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
 import { loadAIConfig, saveAIConfig, aiComplete, aiJSON, aiTranscribe, supportsTranscription, testConnection, DEFAULT_CONFIG, PROVIDER_MODELS, PROVIDER_LABELS } from './ai.js';
 import { voiceParseSystemPrompt, voiceParseUserPrompt, taskSuggestSystemPrompt, taskSuggestUserPrompt, frameNudgeSystemPrompt, frameNudgeUserPrompt, rescheduleSystemPrompt, rescheduleUserPrompt, aiSubtasksSystemPrompt, aiSubtasksUserPrompt, morningSummarySystemPrompt, morningSummaryUserPrompt, eveningReflectionSystemPrompt, eveningReflectionUserPrompt, weeklySummarySystemPrompt, weeklySummaryUserPrompt, smartScheduleSystemPrompt, smartScheduleUserPrompt } from './ai-prompts.js';
@@ -6396,6 +6396,15 @@ const DayPlanner = () => {
   useEffect(() => {
     if (!isNativeApp()) return;
     const checkPending = () => {
+      // Up Next widget buttons (Done / Focus) write to a separate slot.
+      const widgetPending = nativeGetWidgetPendingAction();
+      if (widgetPending) {
+        if (widgetPending.action === 'completeTask' && widgetPending.taskId) {
+          toggleComplete(widgetPending.taskId);
+        } else if (widgetPending.action === 'startFocus') {
+          setShowFocusMode(true);
+        }
+      }
       const pending = nativeGetPendingAction();
       if (!pending) return;
       if (pending.action === 'voice_input') {

--- a/src/native.js
+++ b/src/native.js
@@ -370,6 +370,23 @@ export const nativeGetPendingAction = () => {
 };
 
 /**
+ * Reads and clears any pending action stored by an Up Next widget button
+ * (iOS AppIntents write to a separate App Group slot from notification actions).
+ * Returns null if nothing is pending, or e.g. { action: 'completeTask', taskId: '...' }
+ * / { action: 'startFocus' }.
+ */
+export const nativeGetWidgetPendingAction = () => {
+  const bridge = nativeBridge();
+  if (!bridge?.getWidgetPendingAction) return null;
+  try {
+    const raw = bridge.getWidgetPendingAction();
+    return raw && raw !== 'null' ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
  * Reads and clears any pending intent stored by IntentReceiver or MainActivity.onNewIntent.
  * Returns null if nothing is pending, or { action: 'app.dayglance.CREATE', payload: {...} }.
  *


### PR DESCRIPTION
## Problem

The **Done** and **Focus** buttons in the Up Next widget were no-ops. They wrote a pending action to the App Group, but two pieces were missing so nothing ever happened:

### 1. The web layer never read the widget action slot
Notification action buttons write to one slot, read by JS via `getPendingAction()`. The widget writes to a *separate* slot exposed natively as `getWidgetPendingAction()` (`WidgetBridge` + `BridgeSchemeHandler`) — but **no JS code ever called it**. The action was written and silently discarded on the next reload.

**Fix:** added `nativeGetWidgetPendingAction()` and drain it in the existing foreground `checkPending` handler:
- `completeTask` → `toggleComplete(taskId)`
- `startFocus` → open Focus mode

(Drained on `visibilitychange` and on mount — the same path notification "complete" already uses.)

### 2. The intents never foregrounded the app
Widget `Button(intent:)` actions run in the **background** by default. Since all task data lives in the web layer, the action could never be applied without bringing the app forward.

**Fix:** set `openAppWhenRun = true` on both `CompleteTaskIntent` and `StartFocusIntent`, so the tap foregrounds the app, which then drains the pending action on resume.

## Files
- `dayglance-ios/DayGlanceWidget/WidgetIntents.swift` — `openAppWhenRun`
- `src/native.js` — `nativeGetWidgetPendingAction()`
- `src/App.jsx` — drain widget action in `checkPending`

## Verification
iOS web build passes. The native foregrounding + intent behavior needs an on-device pass (tap Done → task completes after app opens; tap Focus → Focus mode opens).

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe)_