### PR TITLE
iOS: drain Up Next widget button actions on the same path as Quick Actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1569,6 +1569,18 @@ const DayPlanner = () => {
             }
           }
         }
+        // Up Next widget Done / Focus buttons. openAppWhenRun foregrounds the
+        // app, but perform() may write the action just after scenePhase.active —
+        // so this is drained here on the same 200 ms delay as quick actions,
+        // rather than synchronously, to avoid the poll racing ahead of the write.
+        const widgetAction = nativeGetWidgetPendingAction();
+        if (widgetAction) {
+          if (widgetAction.action === 'completeTask' && widgetAction.taskId) {
+            toggleComplete(widgetAction.taskId);
+          } else if (widgetAction.action === 'startFocus') {
+            setShowFocusMode(true);
+          }
+        }
       }, 200);
       if (window.DayGlanceNative?.getShareExtensionPending) {
         try {
@@ -6396,15 +6408,6 @@ const DayPlanner = () => {
   useEffect(() => {
     if (!isNativeApp()) return;
     const checkPending = () => {
-      // Up Next widget buttons (Done / Focus) write to a separate slot.
-      const widgetPending = nativeGetWidgetPendingAction();
-      if (widgetPending) {
-        if (widgetPending.action === 'completeTask' && widgetPending.taskId) {
-          toggleComplete(widgetPending.taskId);
-        } else if (widgetPending.action === 'startFocus') {
-          setShowFocusMode(true);
-        }
-      }
       const pending = nativeGetPendingAction();
       if (!pending) return;
       if (pending.action === 'voice_input') {


### PR DESCRIPTION
## Problem

After #1007 the Up Next widget **Done** / **Focus** buttons were *still* no-ops.

You were right that they should work like the Quick Action buttons — and the fix is to put them on the **exact same drain path**. #1007 wired up the drain but in the wrong place.

## Root cause

#1007 drained the widget action inside `checkPending`, which polls **synchronously** on `visibilitychange`. But the widget intent's `perform()` (in the widget extension) writes the pending action right around the moment `openAppWhenRun` brings the app to `scenePhase.active`. So the immediate poll almost always runs **before** the write lands and reads nothing.

This is the exact race the Quick Action path already documents and avoids:

```js
// Delay 200 ms: on warm launch, scenePhase.active fires before the system
// calls performActionFor(shortcutItem:) ... polling immediately would always return null.
```

Quick Actions and deep links drain inside the `dayGlanceForeground` handler's 200ms `setTimeout`. The widget action wasn't in there.

## Fix

Move the widget-action drain into that same `dayGlanceForeground` + 200ms block, next to the quick-action and deep-link draining:
- `completeTask` → `toggleComplete(taskId)`
- `startFocus` → open Focus mode

`ContentView.swift` posts `dayGlanceForeground` on **every** `scenePhase == .active` transition, so a widget-triggered foreground (via `openAppWhenRun`, already merged in #1007) reliably reaches this handler. Same path the working Quick Action buttons use.

## Files
- `src/App.jsx` — relocate the widget drain from `checkPending` (immediate `visibilitychange` poll) to the `dayGlanceForeground` 200ms block.

## Verification
iOS web build passes. Needs an on-device pass: tap **Done** → task completes once the app opens; tap **Focus** → Focus mode opens.

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe)_