### PR TITLE
iOS: make Up Next widget Done/Focus buttons work via deep links (like Quick Actions)

### DIFF
--- a/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/UpNextWidget.swift
@@ -86,22 +86,25 @@ struct UpNextWidgetView: View {
                             .lineLimit(3)
                             .padding(.top, 2)
                     }
-                    // iOS 17+ interactive buttons
-                    if #available(iOS 17.0, *) {
-                        HStack(spacing: 8) {
-                            Button(intent: CompleteTaskIntent(taskId: task.id ?? "")) {
-                                Label("Done", systemImage: "checkmark.circle")
-                                    .font(.caption2)
+                    // Action buttons. These open the app via a dayglance:// deep
+                    // link (same mechanism as Quick Actions / Spotlight), which the
+                    // web layer drains on foreground. AppIntent-based buttons that
+                    // try to act in the background never reliably reached the web
+                    // layer, so the task was never completed / focus never started.
+                    HStack(spacing: 8) {
+                        if let id = task.id?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+                           let doneURL = URL(string: "dayglance://completeTask?id=\(id)") {
+                            Link(destination: doneURL) {
+                                actionLabel("Done", systemImage: "checkmark.circle")
                             }
-                            .buttonStyle(.bordered)
-                            Button(intent: StartFocusIntent()) {
-                                Label("Focus", systemImage: "play.circle")
-                                    .font(.caption2)
-                            }
-                            .buttonStyle(.bordered)
                         }
-                        .padding(.top, 1)
+                        if let focusURL = URL(string: "dayglance://startFocus") {
+                            Link(destination: focusURL) {
+                                actionLabel("Focus", systemImage: "play.circle")
+                            }
+                        }
                     }
+                    .padding(.top, 1)
                 }
             }
             // Keep the main row at its natural height — the color bar is a
@@ -152,6 +155,15 @@ struct UpNextWidgetView: View {
     // Notes are only rendered on the Large family, and only when present.
     private func showsNotes(_ task: NextTaskData) -> Bool {
         family == .systemLarge && !(task.notes?.isEmpty ?? true)
+    }
+
+    // A bordered-pill label used for the Done / Focus deep-link buttons.
+    private func actionLabel(_ title: String, systemImage: String) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(.caption2)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(.quaternary, in: Capsule())
     }
 
     private var header: some View {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback } from 'react';
 import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Moon, Sun, Upload, Inbox, AlertCircle, Calendar, Check, RefreshCw, Palette, Trash2, Undo2, BarChart3, SkipForward, Hash, MoreHorizontal, Save, Menu, BrainCircuit, AlertTriangle, FileText, ExternalLink, CheckSquare, HelpCircle, Sparkles, Link, GripHorizontal, Play, Pause, Trophy, Cloud, Settings, Search, Bell, Target, TrendingUp, Zap, CalendarDays, Ban, Volume2, VolumeX, Pencil, Eye, Filter, Smartphone, CheckCircle, Pin, PinOff, NotebookPen, MapPin, BookOpen, Flag, FolderOpen, Droplets, Footprints, Dumbbell, Apple, Cigarette, Coffee, Flame, Heart, ListChecks, Minus, Wine, Candy, Pill, Activity, CupSoda, Mic, MicOff, Loader, Key, Server, Wifi, WifiOff, LayoutGrid, RotateCcw } from 'lucide-react';
 import { mergeTaskArrays, mergeSyncData } from './mergeSync.js';
-import { isNativeAndroid, isNativeApp, isNativeIOS, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeGetWidgetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeSetVaultSettings, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording, triggerHaptic } from './native.js';
+import { isNativeAndroid, isNativeApp, isNativeIOS, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeSetVaultSettings, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording, triggerHaptic } from './native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, tryRestoreVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, listVaultNotes, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
 import { loadAIConfig, saveAIConfig, aiComplete, aiJSON, aiTranscribe, supportsTranscription, testConnection, DEFAULT_CONFIG, PROVIDER_MODELS, PROVIDER_LABELS } from './ai.js';
 import { voiceParseSystemPrompt, voiceParseUserPrompt, taskSuggestSystemPrompt, taskSuggestUserPrompt, frameNudgeSystemPrompt, frameNudgeUserPrompt, rescheduleSystemPrompt, rescheduleUserPrompt, aiSubtasksSystemPrompt, aiSubtasksUserPrompt, morningSummarySystemPrompt, morningSummaryUserPrompt, eveningReflectionSystemPrompt, eveningReflectionUserPrompt, weeklySummarySystemPrompt, weeklySummaryUserPrompt, smartScheduleSystemPrompt, smartScheduleUserPrompt } from './ai-prompts.js';
@@ -1543,6 +1543,8 @@ const DayPlanner = () => {
               const taskId = url.searchParams.get('id');
               if (action === 'task' && taskId) {
                 setSpotlightTaskId(taskId);
+              } else if (action === 'completeTask' && taskId) {
+                toggleComplete(taskId);
               } else if (action === 'newScheduledTask') {
                 openNewTaskFormRef.current?.();
               } else if (action === 'newInboxTask') {
@@ -1567,18 +1569,6 @@ const DayPlanner = () => {
               voiceAutoStartRef.current = true;
               setShowVoiceInput(true);
             }
-          }
-        }
-        // Up Next widget Done / Focus buttons. openAppWhenRun foregrounds the
-        // app, but perform() may write the action just after scenePhase.active —
-        // so this is drained here on the same 200 ms delay as quick actions,
-        // rather than synchronously, to avoid the poll racing ahead of the write.
-        const widgetAction = nativeGetWidgetPendingAction();
-        if (widgetAction) {
-          if (widgetAction.action === 'completeTask' && widgetAction.taskId) {
-            toggleComplete(widgetAction.taskId);
-          } else if (widgetAction.action === 'startFocus') {
-            setShowFocusMode(true);
           }
         }
       }, 200);
@@ -1736,6 +1726,7 @@ const DayPlanner = () => {
           const action = url.pathname.replace(/^\/+/, '') || url.hostname;
           const taskId = url.searchParams.get('id');
           if (action === 'task' && taskId) setSpotlightTaskId(taskId);
+          else if (action === 'completeTask' && taskId) toggleComplete(taskId);
           else if (action === 'newScheduledTask') openNewTaskFormRef.current?.();
           else if (action === 'newInboxTask') openNewInboxTaskRef.current?.();
           else if (action === 'startFocus') setShowFocusMode(true);


### PR DESCRIPTION
## The honest summary

My previous three attempts (#1006 layout was fine; #1007 / #1008) tried to make the buttons work through **AppIntents** — `Button(intent:)` writing to a shared App Group slot, with `openAppWhenRun` to foreground the app, then draining that slot in JS. On device this never reliably reached the web layer, so Done/Focus stayed no-ops. I kept fixing the *draining* side while the real problem was that the AppIntent delivery itself wasn't getting through.

You were right the whole time: **make them work like the Quick Action buttons.**

## This fix

Switch the widget buttons to a `dayglance://` **deep link** — the exact mechanism Quick Actions and Spotlight task-taps already use successfully:

- **Done** → `dayglance://completeTask?id=<id>` → `toggleComplete(id)`
- **Focus** → `dayglance://startFocus` → opens Focus mode

The buttons are now SwiftUI `Link`s (styled as bordered pills). Tapping opens the app via the registered `dayglance` scheme (project.yml:107-110), which flows through the existing, proven drain:
- **Warm:** `onOpenURL` → `pendingDeepLink` → `notifyWebViewToDrainPendingActions` → `getPendingDeepLink()` in the foreground 200ms handler.
- **Cold:** captured in `SceneDelegate.willConnectTo` → drained in the `dataLoaded` effect.

`startFocus` was already handled in both drains; I added the `completeTask` case to both. Removed the now-dead widget pending-action drain and its import.

## Files
- `dayglance-ios/DayGlanceWidget/UpNextWidget.swift` — buttons → `Link` deep links + `actionLabel` pill helper.
- `src/App.jsx` — `completeTask` in both deep-link handlers; remove dead widget-slot drain.

## Why this should finally work
It reuses the identical code path as features you've confirmed working (Quick Actions, Spotlight). No new delivery mechanism, no background execution, no App Group polling race.

The unused AppIntent/`WidgetBridge` plumbing from earlier attempts is left in place to keep this diff focused; it can be removed in a follow-up cleanup.

## Verification
iOS web build passes. On-device: tap **Done** → app opens and the task completes; tap **Focus** → app opens into Focus mode.

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe)_