### PR TITLE
iOS: make the Project widget pick which project to show

### DIFF
--- a/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
+++ b/dayglance-ios/DayGlanceWidget/ProjectWidget.swift
@@ -1,20 +1,71 @@
 import WidgetKit
 import SwiftUI
+import AppIntents
+
+// MARK: - Configuration
+
+/// A project the user can pick in the widget editor (long-press → Edit Widget).
+struct ProjectEntity: AppEntity {
+    let id: String
+    let title: String
+    let goalTitle: String?
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation { "Project" }
+    static var defaultQuery = ProjectEntityQuery()
+
+    var displayRepresentation: DisplayRepresentation {
+        if let goalTitle, !goalTitle.isEmpty {
+            return DisplayRepresentation(title: "\(title)", subtitle: "\(goalTitle)")
+        }
+        return DisplayRepresentation(title: "\(title)")
+    }
+}
+
+/// Supplies the project list (from the latest snapshot) to the widget editor and
+/// resolves a previously-selected project by id.
+struct ProjectEntityQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [ProjectEntity] {
+        allEntities().filter { identifiers.contains($0.id) }
+    }
+    func suggestedEntities() async throws -> [ProjectEntity] { allEntities() }
+
+    private func allEntities() -> [ProjectEntity] {
+        (loadSnapshot()?.allProjects ?? []).compactMap { p in
+            guard let id = p.id else { return nil }
+            return ProjectEntity(id: id, title: p.title ?? "Untitled", goalTitle: p.goalTitle)
+        }
+    }
+}
+
+/// Per-widget configuration: which project to show. nil = first active project
+/// (the prior behavior), so widgets placed before this change keep working.
+struct SelectProjectIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Select Project"
+    static var description = IntentDescription("Choose which project this widget displays.")
+
+    @Parameter(title: "Project")
+    var project: ProjectEntity?
+}
+
+// MARK: - Timeline
 
 struct ProjectEntry: TimelineEntry {
     let date: Date
     let snapshot: WidgetSnapshot?
+    let selectedProjectId: String?
 }
 
-struct ProjectProvider: TimelineProvider {
-    func placeholder(in context: Context) -> ProjectEntry { ProjectEntry(date: Date(), snapshot: nil) }
-    func getSnapshot(in context: Context, completion: @escaping (ProjectEntry) -> Void) {
-        completion(ProjectEntry(date: Date(), snapshot: loadSnapshot()))
+struct ProjectProvider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> ProjectEntry {
+        ProjectEntry(date: Date(), snapshot: nil, selectedProjectId: nil)
     }
-    func getTimeline(in context: Context, completion: @escaping (Timeline<ProjectEntry>) -> Void) {
-        let entry = ProjectEntry(date: Date(), snapshot: loadSnapshot())
+    func snapshot(for configuration: SelectProjectIntent, in context: Context) async -> ProjectEntry {
+        ProjectEntry(date: Date(), snapshot: loadSnapshot(), selectedProjectId: configuration.project?.id)
+    }
+    func timeline(for configuration: SelectProjectIntent, in context: Context) async -> Timeline<ProjectEntry> {
+        let entry = ProjectEntry(date: Date(), snapshot: loadSnapshot(), selectedProjectId: configuration.project?.id)
         let next = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
-        completion(Timeline(entries: [entry], policy: .after(next)))
+        return Timeline(entries: [entry], policy: .after(next))
     }
 }
 
@@ -22,12 +73,21 @@ struct ProjectWidgetView: View {
     var entry: ProjectEntry
     @Environment(\.widgetFamily) var family
 
+    // The configured project, falling back to the first active (non-completed,
+    // non-archived) project when nothing is selected or the selection is gone.
+    private var selectedProject: ProjectData? {
+        let projects = entry.snapshot?.allProjects ?? []
+        if let id = entry.selectedProjectId, let match = projects.first(where: { $0.id == id }) {
+            return match
+        }
+        return projects.first(where: { $0.status != "completed" && $0.status != "archived" }) ?? projects.first
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
             Divider().padding(.vertical, 4)
-            if let projects = entry.snapshot?.allProjects,
-               let proj = projects.first(where: { $0.status != "completed" && $0.status != "archived" }) ?? projects.first {
+            if let proj = selectedProject {
                 projectView(proj: proj)
             } else {
                 Text("No active projects")
@@ -114,11 +174,11 @@ struct ProjectWidgetView: View {
 struct ProjectWidget: Widget {
     let kind = "ProjectWidget"
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: kind, provider: ProjectProvider()) { entry in
+        AppIntentConfiguration(kind: kind, intent: SelectProjectIntent.self, provider: ProjectProvider()) { entry in
             ProjectWidgetView(entry: entry)
         }
         .configurationDisplayName("Project")
-        .description("Progress on your active project.")
+        .description("Progress on a project. Long-press to choose which one.")
         .supportedFamilies([.systemMedium, .systemLarge])
     }
 }


### PR DESCRIPTION
## What

Makes the **Project** widget configurable — each placed instance can be pointed at a specific project via long-press → **Edit Widget**. Defaults to the current "first active project" behavior when nothing is chosen, so existing widgets are unaffected.

This is PR 2 of 2 (companion to #1010 for the Goal widget). Same approach, independent file — no overlap with #1010.

## How

Converts the widget from `StaticConfiguration` to `AppIntentConfiguration` (iOS 17+). The snapshot **already** ships `allProjects` into the App Group, so the selectable list needs no new data — no JS or snapshot changes.

- **`ProjectEntity` / `ProjectEntityQuery`** — expose projects to the widget editor, read from the latest snapshot. The picker shows each project's **parent goal as a subtitle** to disambiguate same-named projects.
- **`SelectProjectIntent: WidgetConfigurationIntent`** — the per-widget config, `@Parameter var project: ProjectEntity?`.
- **`ProjectProvider`** → `AppIntentTimelineProvider`; the view resolves the selected project by id and **falls back to the first active (non-completed, non-archived) project** — the existing behavior — when nothing is selected.

## Notes
- Same `kind` ("ProjectWidget") kept; unconfigured instances render exactly as before.
- Per-instance config means you can place multiple Project widgets, each on a different project.

## Verification
⚠️ Can't compile Swift / run Xcode here — needs a local build + on-device check: long-press the Project widget → Edit Widget → a "Project" picker should list your projects (with goal subtitles); selecting one pins the widget to it.

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe)_