### PR TITLE
Fix habit-count split-brain (deterministic tie-break) — no package update needed

### DIFF
--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -2,7 +2,7 @@
 // dayGLANCE tasks use `lastModified` for the per-item timestamp, so
 // mergeTaskArrays pins timestampField rather than re-exporting the alias
 // directly (which would default to `updatedAt`).
-import { mergeArrayById } from '@glance-apps/sync';
+import { mergeArrayById, mergeSyncData as upstreamMergeSyncData } from '@glance-apps/sync';
 
 export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =>
   mergeArrayById(local, remote, deletedIds, syncHorizon, { timestampField: 'lastModified' });
@@ -15,8 +15,103 @@ export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =
 export {
   mergeDailyNotes,
   mergeHabits,
-  mergeHabitLogs,
   mergeRoutineDefinitions,
-  mergeSyncData,
   pruneTombstones,
 } from '@glance-apps/sync';
+
+/**
+ * Habit-log merge with a deterministic tie-break.
+ *
+ * The upstream `mergeHabitLogs` resolves an equal per-(day, habit) timestamp by
+ * keeping the LOCAL count (`lTime >= rTime ? local : remote`). That means two
+ * devices that end up with the same timestamp but different counts — e.g. a
+ * count that changed without its timestamp advancing — each keep their own
+ * value forever. The result is a permanent split-brain that no amount of syncing
+ * reconciles (observed: Water 4↔2 and Candy 1↔0 with identical timestamps).
+ *
+ * Fix: on an exact timestamp tie, fall back to `Math.max` — the same rule the
+ * no-timestamp legacy branch already uses — so both devices compute the same
+ * winner and converge. Strict last-writer-wins still applies whenever the
+ * timestamps differ, so genuine decrements made later are preserved.
+ *
+ * Implemented here (not in the package) so the fix ships with the app and no
+ * `@glance-apps/sync` release/bump is required. `mergeSyncData` below routes the
+ * habit-log portion of every full sync through this function.
+ */
+export const mergeHabitLogs = (localLogs, remoteLogs, localTs = {}, remoteTs = {}) => {
+  const allDates = new Set([...Object.keys(localLogs), ...Object.keys(remoteLogs)]);
+  const merged = {};
+  const mergedTimestamps = { ...localTs };
+  let localChanged = false;
+  let remoteChanged = false;
+
+  // Union the timestamp maps, keeping the newer of each key.
+  for (const [k, v] of Object.entries(remoteTs)) {
+    if (!mergedTimestamps[k] || new Date(v) > new Date(mergedTimestamps[k])) {
+      mergedTimestamps[k] = v;
+    }
+  }
+
+  for (const dateKey of allDates) {
+    const local = localLogs[dateKey];
+    const remote = remoteLogs[dateKey];
+
+    if (local && !remote) {
+      merged[dateKey] = local;
+      remoteChanged = true;
+    } else if (!local && remote) {
+      merged[dateKey] = remote;
+      localChanged = true;
+    } else {
+      const allHabitIds = new Set([...Object.keys(local), ...Object.keys(remote)]);
+      const dayMerged = {};
+      for (const habitId of allHabitIds) {
+        const localCount = local[habitId] !== undefined ? local[habitId] : 0;
+        const remoteCount = remote[habitId] !== undefined ? remote[habitId] : 0;
+        const tsKey = `${dateKey}:${habitId}`;
+        const lTime = localTs[tsKey] ? new Date(localTs[tsKey]).getTime() : 0;
+        const rTime = remoteTs[tsKey] ? new Date(remoteTs[tsKey]).getTime() : 0;
+
+        let winner;
+        if (lTime > rTime) {
+          winner = localCount;          // local is strictly newer
+        } else if (rTime > lTime) {
+          winner = remoteCount;         // remote is strictly newer
+        } else {
+          // Equal timestamps (or both missing): deterministic on both devices
+          // so a stuck split-brain reconciles instead of each side keeping its
+          // own value.
+          winner = Math.max(localCount, remoteCount);
+        }
+
+        if (winner !== localCount) localChanged = true;
+        if (winner !== remoteCount) remoteChanged = true;
+        dayMerged[habitId] = winner;
+      }
+      merged[dateKey] = dayMerged;
+    }
+  }
+
+  return { merged, mergedTimestamps, localChanged, remoteChanged };
+};
+
+/**
+ * Full-sync merge. Delegates to the upstream merge, then overrides the
+ * habit-log portion with the deterministic tie-break above so existing stuck
+ * habit counts self-heal across the fleet (no manual re-touch, no package bump).
+ */
+export const mergeSyncData = (local, remote, retentionDays) => {
+  const result = upstreamMergeSyncData(local, remote, retentionDays);
+  const habitLogsFix = mergeHabitLogs(
+    local?.habitLogs || {},
+    remote?.habitLogs || {},
+    local?.habitLogTimestamps || {},
+    remote?.habitLogTimestamps || {},
+  );
+  result.data.habitLogs = habitLogsFix.merged;
+  result.data.habitLogTimestamps = habitLogsFix.mergedTimestamps;
+  // Make sure a heal (one side's count changing) actually triggers a write/push.
+  if (habitLogsFix.localChanged) result.localChanged = true;
+  if (habitLogsFix.remoteChanged) result.remoteChanged = true;
+  return result;
+};

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -1448,6 +1448,34 @@ describe('mergeHabitLogs', () => {
     expect(merged['2026-02-20'].h1).toBe(2);
     expect(merged['2026-02-20'].h2).toBe(4);
   });
+
+  it('uses last-writer-wins when timestamps differ (allows decrements)', () => {
+    const local = { '2026-02-20': { h1: 1 } };
+    const remote = { '2026-02-20': { h1: 5 } };
+    const localTs = { '2026-02-20:h1': ts(1) };   // local is newer
+    const remoteTs = { '2026-02-20:h1': ts(10) };
+    const { merged } = mergeHabitLogs(local, remote, localTs, remoteTs);
+    expect(merged['2026-02-20'].h1).toBe(1);       // newer local decrement wins
+  });
+
+  it('reconciles a split-brain: equal timestamps but different counts converge to max', () => {
+    // Regression: two devices ended up with identical per-(day,habit) timestamps
+    // but different counts. The upstream tie-break kept local on both sides, so
+    // they never reconciled. The deterministic max tie-break converges them.
+    const sameTs = ts(5);
+    const mac = { '2026-02-20': { h1: 4 } };
+    const ipad = { '2026-02-20': { h1: 2 } };
+    const macTs = { '2026-02-20:h1': sameTs };
+    const ipadTs = { '2026-02-20:h1': sameTs };
+
+    const onIpad = mergeHabitLogs(ipad, mac, ipadTs, macTs);
+    expect(onIpad.merged['2026-02-20'].h1).toBe(4); // iPad adopts the higher count
+    expect(onIpad.localChanged).toBe(true);
+
+    const onMac = mergeHabitLogs(mac, ipad, macTs, ipadTs);
+    expect(onMac.merged['2026-02-20'].h1).toBe(4);  // Mac keeps it; both now agree
+    expect(onMac.localChanged).toBe(false);
+  });
 });
 
 // ─── mergeSyncData — habits integration ───────────────────────────────


### PR DESCRIPTION
## The bug (diagnosed from live device data)

A couple of habit **counts** were stale on an iCloud-only device while everything else synced. Pulling the actual values off both devices:

| Habit | Mac | iPad | timestamp |
|---|---|---|---|
| Water | 4 | 2 | **identical** |
| Candy | 1 | 0 | **identical** |

Same per-`(day, habit)` timestamp to the millisecond, different counts — and the clocks were only a minute apart, so it's **not** clock skew.

`@glance-apps/sync`'s `mergeHabitLogs` breaks an equal-timestamp tie by keeping the **local** count (`lTime >= rTime ? local : remote`). So when two devices have the same timestamp but different counts, **each keeps its own value** — a permanent split-brain that never reconciles, no matter how many times it syncs. (The state arises when a count changes without its timestamp advancing; from then on the tie-break locks it in.)

## The fix — entirely in this repo, no package bump

The merge is re-exported from the package through `src/mergeSync.js`, and the app only ever calls `mergeSyncData`. So the tie-break is overridden **locally**:

- New `mergeHabitLogs` in `src/mergeSync.js`: on an exact timestamp tie, fall back to `Math.max` — the same rule the no-timestamp legacy branch already uses — so **both devices compute the same winner and converge**. Strict last-writer-wins still applies when timestamps differ, so genuine later decrements are preserved.
- `mergeSyncData` is wrapped to route the habit-log portion of every full sync through the corrected merge, and to propagate the `localChanged`/`remoteChanged` flags so a heal actually triggers a write/push.

**Existing stuck counts self-heal** on the next sync (converge to the higher value) — no manual re-touch, and no `@glance-apps/sync` release/reinstall.

## Tests
- Added a regression test for the split-brain heal (identical timestamps, different counts → both converge to max).
- Added a test confirming ts-based last-writer-wins still allows a newer decrement.
- Full suite: **138 passing**; iOS web build passes.

## Follow-up (optional, not in this PR)
Two count-write paths in `useHabits.js` (health-sync `:230`, permission-revoke `:290`) mutate `habitLogs` without stamping a timestamp — the precondition that lets counts drift. With this merge fix they now self-heal, but stamping them would prevent the drift in the first place. Happy to do that separately if you want.

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe)_