### PR TITLE
Add diagnostic log for habit-count split-brain detection

### DIFF
--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -82,6 +82,22 @@ export const mergeHabitLogs = (localLogs, remoteLogs, localTs = {}, remoteTs = {
           // so a stuck split-brain reconciles instead of each side keeping its
           // own value.
           winner = Math.max(localCount, remoteCount);
+
+          // Diagnostic (harmless, behaviour-neutral): an equal *present*
+          // timestamp with diverging counts is the split-brain signature — a
+          // count drifted without its timestamp advancing. We can't yet repro
+          // the seed, so this surfaces the event if it ever recurs on-device,
+          // with enough context to trace which write decoupled them. Both-
+          // missing (legacy entries with no timestamp) is normal and not logged.
+          if (lTime > 0 && localCount !== remoteCount) {
+            try {
+              console.warn(
+                `[habit-sync] split-brain healed at equal timestamp — ${tsKey}: ` +
+                `local=${localCount} remote=${remoteCount} → ${winner} ` +
+                `(ts=${localTs[tsKey] ?? remoteTs[tsKey]})`
+              );
+            } catch (_) { /* console unavailable — ignore */ }
+          }
         }
 
         if (winner !== localCount) localChanged = true;


### PR DESCRIPTION
## What

A behaviour-neutral diagnostic to catch the **habit-count split-brain seed** in the act, as a follow-up to #1012.

#1012 fixed the *symptom*: an equal per-`(day, habit)` timestamp with diverging counts now reconciles deterministically (`max`) instead of each device keeping its own value forever. But we couldn't pin the *seed* — how a count drifts while its timestamp stays put. The obvious save/apply race is mitigated by React 18 auto-batching, so static analysis wasn't conclusive, and I didn't want to ship a blind change to the delicate persistence/suppress machinery.

## How

Adds a single `console.warn` in the tie branch of `mergeHabitLogs` (`src/mergeSync.js`) that fires **only** on the true split-brain signature: an equal **present** timestamp with differing local/remote counts. It logs the date, habit id, both counts, the winner, and the timestamp:

```
[habit-sync] split-brain healed at equal timestamp — 2026-06-16:1771845742626: local=2 remote=6 → 6 (ts=2026-06-17T05:14:03.464Z)
```

- **Silent in normal operation** — only the anomaly triggers it.
- **Legacy entries with no timestamp** (both missing) are intentionally not logged — that's the expected `Math.max` legacy path, not a bug.
- **Zero behaviour change** — it only observes; the merge result is identical.

Next time this fires on-device, the console tells us exactly which entry decoupled its count from its timestamp, so we can fix the actual seed with evidence instead of a guess. Safe to leave in place indefinitely.

## Tests
- Full suite still passes (138). The existing split-brain regression test now also exercises this log path.

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe)_