### PR TITLE
Weekly Review: scope goals/projects to active user + fix standalone-projects heading

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -663,6 +663,7 @@
     "dropToStandalone": "Hier ablegen für eigenständig",
     "noProjectsYet": "Noch keine Projekte",
     "noStandaloneProjects": "Keine eigenständigen Projekte",
+    "standaloneProjects": "Eigenständige Projekte",
     "standalone": "Eigenständig",
     "projects": "Projekte",
     "noArchivedGoals": "Keine archivierten Ziele",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -663,6 +663,7 @@
     "dropToStandalone": "Drop here to make standalone",
     "noProjectsYet": "No projects yet",
     "noStandaloneProjects": "No standalone projects",
+    "standaloneProjects": "Standalone Projects",
     "standalone": "Standalone",
     "projects": "Projects",
     "noArchivedGoals": "No archived goals",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -663,6 +663,7 @@
     "dropToStandalone": "Soltar aquí para hacer independiente",
     "noProjectsYet": "Aún no hay proyectos",
     "noStandaloneProjects": "No hay proyectos independientes",
+    "standaloneProjects": "Proyectos independientes",
     "standalone": "Independiente",
     "projects": "Proyectos",
     "noArchivedGoals": "No hay objetivos archivados",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -663,6 +663,7 @@
     "dropToStandalone": "Déposer ici pour rendre autonome",
     "noProjectsYet": "Aucun projet pour l'instant",
     "noStandaloneProjects": "Aucun projet autonome",
+    "standaloneProjects": "Projets autonomes",
     "standalone": "Autonome",
     "projects": "Projets",
     "noArchivedGoals": "Aucun objectif archivé",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -663,6 +663,7 @@
     "dropToStandalone": "Trascina qui per rendere indipendente",
     "noProjectsYet": "Nessun progetto ancora",
     "noStandaloneProjects": "Nessun progetto indipendente",
+    "standaloneProjects": "Progetti indipendenti",
     "standalone": "Indipendente",
     "projects": "Progetti",
     "noArchivedGoals": "Nessun obiettivo archiviato",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -663,6 +663,7 @@
     "dropToStandalone": "Largar aqui para tornar independente",
     "noProjectsYet": "Ainda sem projetos",
     "noStandaloneProjects": "Sem projetos independentes",
+    "standaloneProjects": "Projetos independentes",
     "standalone": "Independente",
     "projects": "Projetos",
     "noArchivedGoals": "Sem objetivos arquivados",

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -410,7 +410,7 @@ const WeeklyReviewModal = () => {
 
         // Goals due in next 7 days (only goals with targetDate in range)
         const nextWeekDueGoals = goalsProjectsEnabled
-          ? goals.filter(g => g.status === 'active' && g.targetDate && g.targetDate >= todayStr && g.targetDate <= nextEndStr)
+          ? goals.filter(g => g.status === 'active' && ownedBy(g, meUserSyncId) && g.targetDate && g.targetDate >= todayStr && g.targetDate <= nextEndStr)
               .map(g => {
                 const progress = calculateGoalProgress(g.id, projects, allTasksCombined);
                 const target = new Date(g.targetDate + 'T00:00:00');
@@ -429,7 +429,7 @@ const WeeklyReviewModal = () => {
         const sevenDaysAgoStr = dateToString(new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000));
         const fourteenDaysAgoStr = dateToString(new Date(today.getTime() - 14 * 24 * 60 * 60 * 1000));
         const nextWeekProjects = goalsProjectsEnabled
-          ? projects.filter(p => p.status === 'active' && !p.goalId).map(p => {
+          ? projects.filter(p => p.status === 'active' && !p.goalId && ownedBy(p, meUserSyncId)).map(p => {
               const pTasks = allTasksCombined.filter(t => t.projectId === p.id && !t.archived);
               const totalTasks = pTasks.length;
               const completedTasks = pTasks.filter(t => t.completed).length;
@@ -792,7 +792,7 @@ const WeeklyReviewModal = () => {
                   {/* Standalone projects */}
                   {goalsProjectsEnabled && nextWeekProjects.length > 0 && (
                     <div className="mb-4">
-                      <div className={`text-xs font-semibold uppercase ${textSecondary} tracking-wider mb-2`}>{t('goals.noStandaloneProjects')}</div>
+                      <div className={`text-xs font-semibold uppercase ${textSecondary} tracking-wider mb-2`}>{t('goals.standaloneProjects')}</div>
                       <div className="space-y-2">
                         {nextWeekProjects.map(p => {
                           const momentumColor = p.momentum === 'green' ? '#22c55e' : p.momentum === 'amber' ? '#f59e0b' : '#ef4444';


### PR DESCRIPTION
Two Weekly Review (Next 7 Days) bugs, on **mobile and desktop/tablet**.

## 1. Goals & projects leaked across multi-user members
"Goals Due This Week" and the standalone-projects list showed items belonging to *other* members. Both computations (`nextWeekDueGoals`, `nextWeekProjects`) filtered only by `status`, never by owner — even though the **habits** section in the very same modal already scopes with `ownedBy(item, meUserSyncId)`.

Fix: apply the same `ownedBy(...)` filter to both. Consistent with the rest of the app — unowned/legacy items still show; only *other* members' items are excluded. (`WeeklyReviewModal.jsx` already receives `ownedBy` + `meUserSyncId` as props.)

## 2. "NO STANDALONE PROJECTS" heading was the empty-state string
The standalone-projects section used `t('goals.noStandaloneProjects')` ("No standalone projects") as its **heading**, so it read "NO STANDALONE PROJECTS" even while projects were listed right below it. Added a proper `goals.standaloneProjects` ("Standalone Projects") key across **all six locales** (en/de/es/fr/it/pt) and used it. The section only renders when there are projects, so the heading now always matches the content.

## Verification
- All six locale JSON files validate.
- Production web build passes.

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe)_