### PR TITLE
Incomplete Tasks modal: make Escape reliably dismiss it

### DIFF
--- a/src/components/IncompleteTasksModal.jsx
+++ b/src/components/IncompleteTasksModal.jsx
@@ -16,13 +16,22 @@ const IncompleteTasksModal = () => {
   } = useDayPlannerCtx();
   const { t } = useTranslation();
 
+  // Dismiss on Escape. Use a document-level listener rather than the overlay's
+  // own focus so it keeps working after focus moves into a button/link inside.
+  React.useEffect(() => {
+    if (!showIncompleteTasks) return undefined;
+    const onKey = (e) => { if (e.key === 'Escape') setShowIncompleteTasks(null); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [showIncompleteTasks, setShowIncompleteTasks]);
+
   if (!showIncompleteTasks) return null;
 
   const isDaily = showIncompleteTasks === 'today';
   const items = isDaily ? todayIncompleteTasks : allTimeIncompleteTasks;
 
   return (
-          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setShowIncompleteTasks(null)} onKeyDown={(e) => { if (e.key === 'Escape') setShowIncompleteTasks(null); }} tabIndex={-1} ref={el => el && el.focus()}>
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setShowIncompleteTasks(null)}>
             <div
               className={`${cardBg} rounded-lg shadow-xl ${borderClass} border max-w-md w-full mx-4 flex flex-col`}
               style={{ maxHeight: '70vh' }}


### PR DESCRIPTION
## Bug
The **Reschedule Incomplete Tasks** modal couldn't be dismissed with Escape.

## Cause
Its Escape handler was on the overlay div's `onKeyDown` and depended on that div holding keyboard focus (`ref={el => el && el.focus()}`). The moment focus moved into any button/link inside the modal, the keydown no longer reached the overlay, so Escape did nothing.

## Fix
Replaced it with a `document`-level `keydown` listener in an effect, mounted only while the modal is open — so Escape works regardless of where focus sits. Also dropped the focus-stealing `ref`/`tabIndex`/inline `onKeyDown` from the overlay. Backdrop-click dismissal is unchanged.

Web build passes.

https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyLexBxY5vz8L6qEeXRmSe)_