### PR TITLE
GLANCEvault DB-tier sync (opt-in, alongside WebDAV) + v3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.4.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.5.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 118
-        versionName = "3.4"
+        versionCode = 119
+        versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/docs/glancevault-stage1.md
+++ b/docs/glancevault-stage1.md
@@ -1,0 +1,294 @@
+# dayGLANCE → GLANCEvault DB-tier cutover — STAGE 1 of 2
+
+**Scope:** build the entity-to-row adapter and prove losslessness.
+**Non-destructive:** no live transport switch, no file-tier changes, no writes to a
+real server, no App.jsx wiring. Stage 2 will add transport selection,
+push-on-write, the deferred buffer, and the live cutover.
+
+Artifacts added this stage:
+
+| File | Role |
+|---|---|
+| `src/sync/dbAdapter.js` | Entity↔row shred/reassemble, `_kind` discriminator, `isInsertOnly`, `getEntityLastModified` |
+| `src/sync/dbAdapter.losslessness.test.js` | Roundtrip gate + discrimination proof (9 tests) |
+| `package.json` / `package-lock.json` | Pin `@glance-apps/sync@1.3.2` exact |
+
+The mapping is read directly from the canonical merge in
+`node_modules/@glance-apps/sync/src/merge.js` (`mergeSyncData`, the authoritative
+list of every synced field and its grain) and the payload builder
+`buildSyncPayload` (`src/App.jsx:5379-5439`).
+
+---
+
+## 1. Dependency-version report
+
+- **dayGLANCE before:** `@glance-apps/sync": "^1.3.2"` (caret) — `package.json:21`.
+- **Installed / locked:** `1.3.2` — `package-lock.json:2270-2271`
+  (`node_modules/@glance-apps/sync/package.json` version `1.3.2`).
+- **Action:** pinned to **`1.3.2` exact** (no caret) in `package.json:21` and the
+  lockfile root spec mirror `package-lock.json:12`. Matches lastGLANCE's pin.
+- No other version change was made. dayGLANCE already ships the same
+  `createDbSyncEngine` / `dbCrypto` / `vaultClient` modules the reference uses;
+  nothing in `@glance-apps/sync` was modified.
+
+> The DB engine surface dayGLANCE will consume in stage 2 is identical to the
+> reference: `createDbSyncEngine({ getLocalEntity, applyRemoteEntity,
+> applyRemoteDelete, isInsertOnly, getEntityLastModified, … })` with a single
+> combined `dbSyncCycle()` (`dbEngine.js:63,311`), an engine-owned high-water mark
+> (`getHighWaterMark`, `dbEngine.js:126`), and per-entity AES-GCM where the entity
+> is `JSON.stringify`-ed before encryption (`dbCrypto.js:274`) — so an in-envelope
+> `_kind` stays sealed in the ciphertext.
+
+---
+
+## 2. Entity-to-row mapping table
+
+Two row classes:
+
+- **Collection** — each array element (or date-map entry) is one row, keyed by a
+  stable id, entity-grain last-writer-wins. These are the entities the file-tier
+  merge already resolves per-item.
+- **Singleton / bundle** — one row carrying a whole structure in its current
+  shape. These are the bundles and scalar/config values that have no per-item id;
+  splitting them into finer rows is explicitly out of scope (rule 4).
+
+### 2a. Collections (per-item rows)
+
+| Entity | `entityId` source | LWW tiebreaker | Mutability | id evidence | timestamp evidence |
+|---|---|---|---|---|---|
+| `tasks` | `id` | `lastModified` | mutable-upsert | `merge.js:449-450` (`idField:'id'`) | `merge.js:449` (`timestampField:'lastModified'`); stamped `useDataPersistence.js:44` |
+| `unscheduledTasks` | `id` | `lastModified` | mutable-upsert | `merge.js:451` | `merge.js:449`; `useDataPersistence.js:178` |
+| `recurringTasks` | `id` | `lastModified` | mutable-upsert | `merge.js:453` | `merge.js:449`; `useDataPersistence.js:180` |
+| `recycleBin` | `id` | `lastModified` | mutable-upsert | `merge.js:452` | `merge.js:449`; `useDataPersistence.js:179` |
+| `todayRoutines` | `id` | `lastModified` | mutable-upsert | `merge.js:493` | `useDataPersistence.js:181` |
+| `habits` | `id` | `lastModified` → `createdAt` | mutable-upsert | `merge.js:282` (`h.id`) | `merge.js:299` (`lastModified \|\| createdAt`) |
+| `goals` | `id` | `updatedAt` | mutable-upsert | `merge.js:722` (`g.id`) | `merge.js:733` (`updatedAt`) |
+| `projects` | `id` | `updatedAt` | mutable-upsert | `merge.js:760` (`p.id`) | `merge.js:771` (`updatedAt`) |
+| `gtdFrames` | `id` | `lastModified` | mutable-upsert | `merge.js:641` (`f.id`) | `merge.js:657` (`lastModified`) |
+| `users` | `syncId` → `id` | `updatedAt` | mutable-upsert | `merge.js:843` (`u.syncId ?? u.id`) | `merge.js:847` (`updatedAt`) |
+| `dailyNotes` (per date key) | date string `YYYY-MM-DD` | `lastModified` | mutable-upsert | `merge.js:218` (date key) | `merge.js:237` (`lastModified`); tombstone via `{deleted:true}` `merge.js:209-211` |
+
+`dailyNotes` is map-shaped, not an array, but is a collection: the merge resolves
+it per date, so each date is its own row (`entityId = dailyNotes:<date>`).
+
+### 2b. Singletons / bundles (one row each, current shape preserved)
+
+Carried whole, keyed `singleton:<key>`. Routed back on reassemble by `_key`.
+
+| Bundle / scalar | Shape | Merge grain (kept as-is) | Evidence |
+|---|---|---|---|
+| `routineDefinitions` | bucket → chip[] | per-chip by `id`, claim-aware | `merge.js:132,466` |
+| `habitLogs` | `{date: {habitId: count}}` | per-(date,habitId) | `merge.js:351,522` |
+| `habitLogTimestamps` | `{date:habitId → ISO}` | per-key newer-wins | `merge.js:354-363` |
+| `routineCompletions` | `{routineId → date}` | date-gated union | `merge.js:505-513` |
+| `completedTaskUids` | `string[]` | union, retention-pruned | `merge.js:607-614` |
+| `deletedTaskIds` | `{id → ISO}` | tombstone union | `merge.js:432-439` |
+| `deletedRoutineChipIds` | `{id → ISO}` | tombstone union | `merge.js:456-463` |
+| `deletedFrameIds` | `{id → ISO}` | tombstone union | `merge.js:619-626` |
+| `removedTodayRoutineIds` | `{id → ISO}` | tombstone union | `merge.js:472-479` |
+| `deletedHabitIds` | `{id → ISO}` | tombstone union | `merge.js:519,835` |
+| `deletedGoalIds` | `{id → ISO}` | tombstone union | `merge.js:702-709` |
+| `deletedProjectIds` | `{id → ISO}` | tombstone union | `merge.js:710-717` |
+| `obsidianConfig` (+`…UpdatedAt`) | object | per-field-ts LWW | `merge.js:804,898` |
+| `habitsEnabled` (+`…UpdatedAt`) | bool | per-field-ts LWW | `merge.js:684-688` |
+| `routinesEnabled` (+`…UpdatedAt`) | bool | per-field-ts LWW | `merge.js:694-699` |
+| `goalsProjectsEnabled` (+`…UpdatedAt`) | bool | per-field-ts LWW | `merge.js:796-801` |
+| `multiUserEnabled` (+`…UpdatedAt`) | bool | per-device, not merged | `merge.js:840` (kept local); emitted `App.jsx:5431-5432` |
+| `unscheduledOrderTimestamp` | ISO | newer-wins | `merge.js:569-571` |
+| `syncUrl`, `taskCalendarUrl` | string | prefer-non-empty | `merge.js:810-815` |
+| `routinesDate` | `YYYY-MM-DD` | date compare | `merge.js:488-501` |
+| `minimizedSections` | object | kept local (device pref) | `merge.js:900` |
+| `use24HourClock` | bool | kept local (device pref) | `merge.js:901` |
+| `weatherZip`, `weatherTempUnit` | string | not merged; emitted in payload | `App.jsx:5405-5406` |
+| `tombstonePrunedBefore` | ISO | max of both fences | `merge.js:824-829` |
+
+### 2c. Entities I added beyond the brief's list
+
+The brief named: tasks, unscheduledTasks, recurringTasks, recycleBin,
+todayRoutines, routineDefinitions, habits, habitLogs, goals, projects, gtdFrames,
+dailyNotes, users, scalar/config. Sweeping `buildSyncPayload` and `mergeSyncData`
+surfaced these **additional** synced members that must also round-trip and are
+covered above:
+
+- `habitLogTimestamps`, `routineCompletions`, `completedTaskUids`
+- `routinesDate`, `unscheduledOrderTimestamp`
+- Seven tombstone maps: `deletedTaskIds`, `deletedRoutineChipIds`,
+  `deletedFrameIds`, `removedTodayRoutineIds`, `deletedHabitIds`,
+  `deletedGoalIds`, `deletedProjectIds`
+- The four `*Enabled` flags + their `*UpdatedAt` siblings; `obsidianConfig` +
+  `obsidianConfigUpdatedAt`; `multiUserEnabled` + `multiUserEnabledUpdatedAt`
+- Device prefs `minimizedSections`, `use24HourClock`, `weatherZip`,
+  `weatherTempUnit`; `syncUrl`, `taskCalendarUrl`; `tombstonePrunedBefore`
+
+The shred iterates **every** remaining `.data` key as a singleton, so any key
+added later is carried automatically rather than silently dropped.
+
+> Not synced (correctly excluded from rows): `taskCalendarAuth` (credentials,
+> `App.jsx:5395`), `_native` / CalDAV-imported tasks (ephemeral, filtered at
+> `App.jsx:5377-5378`), and device-only `darkMode`/`reminderSettings`/`soundEnabled`
+> (`App.jsx:5608`).
+
+---
+
+## 3. Entity discrimination decision — **explicit in-envelope `_kind`**
+
+**Chosen approach: explicit `_kind`, not structural sniffing.**
+
+The reference derives kind by structural field-name sniffing (`entityKind`,
+`dbEngine.ts:29-56`) because lastGLANCE had four well-separated types. That does
+**not** survive in dayGLANCE:
+
+- `tasks`, `unscheduledTasks`, `recurringTasks`, `recycleBin`, and `todayRoutines`
+  are the **same task shape**. App.jsx stamps all five through the *one*
+  `stampTaskTimestamps` function (`useDataPersistence.js:177-181`); they share
+  `{ id, title, duration, color, completed, lastModified, notes, subtasks }`.
+- `recurringTasks` (carries `completedDates`) and `recycleBin` (carries
+  `deletedAt`) are *sometimes* separable by a marker field, but **scheduled
+  `tasks` vs inbox `unscheduledTasks` vs `todayRoutines` have no distinguishing
+  field at all.** A `date`/`startTime` presence test is exactly the fragile sniff
+  the brief warns against (an inbox task can be promoted, a routine can carry a
+  time).
+
+A structural sniff would therefore misroute on apply. The test
+`structural sniff CANNOT separate tasks / unscheduledTasks / todayRoutines`
+proves all three collapse to one ambiguous bucket.
+
+**Decision:** carry a `_kind` field inside the entity object. Because
+`encryptEntity` does `JSON.stringify(entity)` before AES-GCM
+(`dbCrypto.js:274`), `_kind` is sealed in the per-entity ciphertext — the vault
+row is still `{ entityId, seq, ciphertext, deleted? }` and the server sees only
+opaque bytes. **Zero-knowledge is preserved.**
+
+The wire entity also **wraps** the original under `value` (`{ _kind, _key?, value
+}`) so the user payload is never polluted and round-trips byte-for-byte. The
+`entityId` is composite `${kind}:${id}`, so two different kinds sharing a numeric
+id never collide on one row.
+
+**Proof of zero collisions (all types):** the gate shreds a full payload with
+every type present and asserts `new Set(entityIds).size === entityIds.length`,
+that `reassembleState` routes 100% of rows (it throws on any unroutable `_kind`),
+and that the five task-shaped kinds are each distinctly represented. All pass.
+
+---
+
+## 4. FK / out-of-order delivery — **no deferred buffer needed**
+
+The reference parks FK-dependent rows (`deferredChores`) because lastGLANCE's
+Dexie tier is **relational**: a chore needs a resolved numeric `category_id` to
+*insert*, so a chore arriving before its category cannot be stored and must be
+parked (`dbEngine.ts:164-214`).
+
+dayGLANCE has **no hard local FK dependency**, because its data model is a flat
+document, not a normalized relational DB. Every synced structure is a plain
+array/map in localStorage / React state. Cross-entity references are
+**denormalized opaque id fields carried on the same object**:
+
+- `task.projectId → project.id` (`App.jsx:3263,3899`)
+- `project.goalId → goal.id` (`App.jsx:3902`)
+- `goal.frameId → gtdFrame.id`
+
+A task whose `projectId` points at a not-yet-arrived project still inserts fine —
+it sits in the `tasks` array and simply renders ungrouped until the project lands,
+**exactly the transient state the app already tolerates mid-sync today**. There is
+no insert-time resolution step that could drop the row, so nothing needs parking.
+
+**FK-dependent entities requiring a deferred buffer in stage 2: NONE.**
+
+The losslessness gate does not mask this: there is no FK-resolution path in shred
+or reassemble that could silently drop a child, and the same-id cross-list case
+(the one place row identity is subtle) is explicitly tested and preserved.
+
+> Stage-2 note (not an FK buffer): the file-tier merge reconciles a task that
+> exists in both `tasks` and `unscheduledTasks` by `lastModified`
+> (`merge.js:556-601`). Row-grain keeps both copies as distinct rows; stage 2's
+> pull path must re-apply that cross-list reconciliation. Flagged here so it is
+> not forgotten — it is a merge-semantics concern, not a foreign-key one.
+
+---
+
+## 5. stampTaskTimestamps / dirtiness
+
+`stampTaskTimestamps` (`useDataPersistence.js:22-46`) stamps `lastModified` on
+**task-shaped collections only** — `tasks`, `unscheduledTasks`, `recycleBin`,
+`recurringTasks`, `todayRoutines` (`useDataPersistence.js:177-181`,
+`App.jsx:5383-5400`). It diffs each item against its localStorage copy (ignoring
+`lastModified`) and re-stamps `now` only when the rest changed; it is a no-op when
+`suppressTimestampRef` is set (during remote apply).
+
+**The adapter does not read or alter `stampTaskTimestamps`.** It reads each
+entity's **own** timestamp via `getEntityLastModified`, using the per-kind
+`tsField` from the mapping table (`lastModified` for task-shaped + habits +
+frames, `updatedAt` for goals/projects/users, `createdAt` fallback for habits).
+For those five task-shaped kinds, `stampTaskTimestamps` is precisely what *sets*
+the `lastModified` the adapter then reads — so the dirtiness signal is consistent
+with today's behavior, unchanged.
+
+**Entities with a clear dirtiness signal (own timestamp):** all collections in
+§2a.
+
+**Entities whose dirtiness signal is unclear (flagged):** several bundles have
+**no intrinsic timestamp**, so at the singleton-row grain there is no per-entity
+`lastModified` for the engine's LWW:
+
+- `habitLogs`, `habitLogTimestamps`, `routineCompletions`, `completedTaskUids`,
+  and all seven tombstone maps — no top-level timestamp.
+- The `*Enabled` flags and `obsidianConfig` *do* travel with a sibling
+  `*UpdatedAt` singleton, but as **separate rows** the engine cannot pair them for
+  LWW without help.
+
+This is a **known stage-2 concern, not a losslessness blocker** (losslessness
+needs no timestamp — only faithful shred/reassemble, which passes). Stage 2 must
+decide how these bundles signal dirtiness and resolve LWW — e.g. fold each
+`*Enabled`+`*UpdatedAt` into one row, and stamp bundle rows on write. The brief's
+own rule 4 keeps the finer remodel that would give completions real per-item
+timestamps out of scope here. `getEntityLastModified` currently returns the
+bundle's value when it is itself an ISO string (e.g. `tombstonePrunedBefore`) and
+`undefined` otherwise; `dbAdapter.js` documents this inline.
+
+---
+
+## 6. Losslessness roundtrip — **PASS**
+
+`src/sync/dbAdapter.losslessness.test.js` builds a representative full `.data`
+payload covering **every** entity type and edge case (nested subtasks, a
+`recurringTasks.completedDates` array, a deleted `dailyNotes` tombstone entry, a
+same-id task in both `tasks` and `unscheduledTasks`, claimed routine chips, keyed
+`habitLogs`/`habitLogTimestamps` maps, a habit with no `lastModified`, all
+tombstone maps, all scalar config), then:
+
+1. `shredState(data)` → rows
+2. runs each row's entity through `JSON.parse(JSON.stringify(...))` — the exact
+   serialization `encryptEntity`/`decryptEntity` perform on the wire
+3. `reassembleState(rows)` → rebuilt `.data`
+4. deep-diffs original vs rebuilt, key-order independent, treating
+   `undefined ≡ absent`
+
+**Result: PASS — 9/9 tests, full suite 275/275.**
+
+```
+✓ round-trips a full payload value-identically (modulo key order)
+✓ produces a unique entityId for every row (zero collisions)
+✓ keeps a cross-list same-id task as two distinct rows
+✓ keeps recurringTasks.completedDates as an array inside the row (rule 4)
+✓ keeps habitLogs as a single keyed-map row (rule 4)
+✓ routes every row by explicit _kind, and marks no kind insert-only in stage 1
+✓ surfaces the per-kind LWW tiebreaker for collection rows
+✓ structural sniff CANNOT separate tasks / unscheduledTasks / todayRoutines
+✓ explicit _kind resolves ALL kinds with zero collisions
+```
+
+No field, entity, or nested structure failed to round-trip.
+
+> The fixture is a faithful, hand-built representative derived from the real
+> shapes in `mergeSync.test.js` and `buildSyncPayload`. If you want the gate run
+> against a **real exported dev-state payload**, drop its `.data` into the test in
+> place of `buildFixture()` and re-run `npx vitest run
+> src/sync/dbAdapter.losslessness.test.js` — the adapter is payload-shape-driven,
+> so no code change is needed.
+
+---
+
+## 7. Verdict
+
+**Is dayGLANCE's data model losslessly representable as rows under current
+semantics? — YES.**

--- a/docs/glancevault-stage2.md
+++ b/docs/glancevault-stage2.md
@@ -119,4 +119,54 @@ different-kind move (newest wins), and the priority tie-break.
 
 ## Part B — live wiring
 
-_(documented below as each piece lands)_
+Mirrors the lastGLANCE reference. Additive and reversible: the DB engine runs
+**alongside** the file-tier WebDAV engine, sharing only the local data and sync
+passphrase, and is **fully inert when the vault is disabled** (`createDbEngine`
+returns null, the cadence effect early-returns, `schedulePush` is a no-op). The
+file-tier payload is retained untouched — nothing is deleted, and the default
+transport is unchanged.
+
+| Piece | File | One-line summary |
+|---|---|---|
+| **B1** vault config + gate | `vaultConfig.js`, `deviceId.js`, `dbEngine.js` | `dayglance-vault-config` key + `isVaultEnabled`; stable `dayglance-device-id`; `createDbEngine` constructs the real `createDbSyncEngine` alongside WebDAV, returns null when off, HWM-0 seeds the full snapshot. |
+| **B2** dirty tracking + safe apply | `dbEngine.js` | Dirty set computed by diffing the current shred against a persisted snapshot (dayGLANCE's equivalent of per-write `markDirty`, since it has no data-layer); remote applies mutate a per-cycle mirror committed once via `applyPayload`, which sets the suppress flags so a pulled row never bounces back as a WebDAV upload or a re-push. |
+| **B3** push-on-write | `dirtyTracker.js`, `useSaveOnChange.js` | Debounced **3 s, vault-only** push after each local write; never fans out to WebDAV (the file tier keeps its cadence model, spec 6.5); off-safe. |
+| **B4** transport UI | `CloudSyncSettingsForm.jsx` | Independent GLANCEvault toggle (URL/token/account), saved to its own key, **reload on change**; orthogonal to the WebDAV provider. |
+| **B5** WebDAV retained | — | File-tier engine, payload, and merge are completely unchanged; the DB engine never touches the WebDAV file. |
+
+### Cycle ordering note
+
+dayGLANCE composes its cycle **pull-then-push** (the engine's built-in
+`dbSyncCycle` is push-then-pull). The engine advances its high-water mark on
+push (`dbEngine.js:225`), so a device that pushed before pulling would skip rows
+written below its new cursor and never see them — observed directly as a failing
+end-to-end test. Pulling first means the HWM only ever advances past rows the
+device has actually seen, and bundle merges push the merged superset in the same
+cycle. Built from the engine's exposed `pullRemoteChanges` / `pushDirtyRows` /
+`updateDeviceCursor`; the package is not modified.
+
+### Backgrounded-write-reaches-vault check (the lastGLANCE bug)
+
+`dbEngineWiring.test.js` proves the B3 behavior with fake timers: a burst of
+writes collapses into **one** debounced `dbSyncCycle` ~3 s after the last write,
+it is **vault-only** (the file engine is never called), and it is a no-op once
+the engine is detached (vault disabled). So a write on a backgrounded device
+reaches the vault without waiting for an app reopen — the bug the lastGLANCE
+push-on-write fix addressed. **Confirmed.**
+
+### Part B validation
+
+- End-to-end through the **real** `createDbSyncEngine` + real AES-GCM (in-memory
+  vault + native key store, no network/indexedDB): a task syncs A→B; concurrent
+  bundle edits converge by set-union; a cross-list move lands under exactly one
+  kind. Gate returns null when disabled; deviceId stable; push-on-write debounce
+  vault-only + off-safe.
+- Full suite **293/293**; production `vite build` passes.
+
+---
+
+## Verdict
+
+dayGLANCE's data model is **losslessly representable AND correctly mergeable** as
+rows under current semantics. No unavoidable loss window. The GLANCEvault DB
+transport is wired opt-in alongside WebDAV, non-destructive and reversible.

--- a/docs/glancevault-stage2.md
+++ b/docs/glancevault-stage2.md
@@ -1,0 +1,122 @@
+# dayGLANCE → GLANCEvault DB-tier cutover — STAGE 2 of 2
+
+Stage 1 proved **representability** (shred/reassemble is lossless on one device).
+Stage 2 proves **merge correctness** across two devices, then wires the live
+transport. Part A is the gate; Part B is the wiring.
+
+Artifacts:
+
+| File | Role |
+|---|---|
+| `src/sync/dbAdapter.js` | Per-row apply/merge added on top of stage-1 shred/reassemble |
+| `src/sync/dbVaultSim.js` | In-memory two-device GLANCEvault simulator (test support) |
+| `src/sync/dbMerge.test.js` | A1 bundle-merge + A2 cross-list tests |
+
+---
+
+## Part A — multi-device merge correctness (the gate)
+
+### The harness
+
+`dbVaultSim.js` runs two devices against one in-memory vault. It faithfully
+mirrors `createDbSyncEngine`'s push/pull contract (`dbEngine.js`): push encrypts
+each dirty entity (here: JSON clone) and upserts by `entityId`; pull lists rows
+since the cursor and applies each with entity-grain LWW, insert-only
+always-apply, and delete-by-absence — driving the **same** adapter callbacks the
+real engine calls (`getLocalEntity` / `applyRemoteEntity` / `applyRemoteDelete` /
+`isInsertOnly` / `getEntityLastModified`). Two documented, behavior-preserving
+divergences: the pull cursor advances only on pull (a strictly more conservative
+cursor — re-applying a seen row is idempotent), and `reconcileCrossList` runs at
+end-of-pull (the live engine hooks this to the apply-notify).
+
+### The core hazard Part A exists to surface
+
+GLANCEvault stores **one row per `entityId`**, upserted last-write-wins, and the
+engine **pushes before it pulls**. So when two devices edit the *same bundle row*
+between syncs, the second push **clobbers** the first at the vault before the
+first device's value is ever read. A merge in the apply step alone cannot recover
+it — the value is already gone from the vault.
+
+**Fix (the enabling mechanism):** when a bundle's per-key/union merge leaves a
+device's local copy *richer* than the row it just pulled, the device **re-pushes
+the merged superset** (`applyRemoteEntity` returns the entityIds to re-dirty).
+Because the originating device never *reduces* its local bundle (union grows;
+recency keeps newest), the unique contribution is never lost locally and gets
+re-published on the next push. This mirrors the file-tier's `remoteChanged →
+"remote needs this"` flag and **terminates**: once the vault holds the full
+superset, the merge changes nothing and no re-push is emitted. Convergence
+requires the originating device to complete one more sync after a concurrent
+clobber — the same liveness property the file tier already has.
+
+A1 includes an explicit demonstration that a **naive whole-bundle LWW loses an
+edit**, to prove the per-bundle merge + re-push is necessary, not decorative.
+
+### Bundle-merge strategy table
+
+| Bundle | Shape | Strategy | Concurrent **different-entry** edits safe? |
+|---|---|---|---|
+| `habitLogs` (+`habitLogTimestamps`) | `{date:{habitId:count}}` | per-(date,habitId) recency via paired timestamps (`mergeHabitLogs`) | ✅ yes |
+| `routineDefinitions` | `{bucket:[chip]}` | per-chip, claim-aware (`mergeRoutineDefinitions`); chip tombstones converge separately | ✅ yes |
+| `routineCompletions` | `{routineId:date}` | union, keep later date per key | ✅ yes |
+| `completedTaskUids` | `string[]` | set-union | ✅ yes |
+| `deletedTaskIds` | `{id:ISO}` | set-union, keep newer ISO | ✅ yes |
+| `deletedRoutineChipIds` | `{id:ISO}` | set-union, keep newer ISO | ✅ yes |
+| `deletedFrameIds` | `{id:ISO}` | set-union, keep newer ISO | ✅ yes |
+| `removedTodayRoutineIds` | `{id:ISO}` | set-union, keep newer ISO | ✅ yes |
+| `deletedHabitIds` | `{id:ISO}` | set-union, keep newer ISO | ✅ yes |
+| `deletedGoalIds` | `{id:ISO}` | set-union, keep newer ISO | ✅ yes |
+| `deletedProjectIds` | `{id:ISO}` | set-union, keep newer ISO | ✅ yes |
+| `habitsEnabled` (+`…UpdatedAt`) | bool+ISO | paired LWW by `UpdatedAt` | n/a — single value (intended LWW) |
+| `routinesEnabled` (+`…UpdatedAt`) | bool+ISO | paired LWW by `UpdatedAt` | n/a — single value |
+| `goalsProjectsEnabled` (+`…UpdatedAt`) | bool+ISO | paired LWW by `UpdatedAt` | n/a — single value |
+| `obsidianConfig` (+`…UpdatedAt`) | obj+ISO | paired LWW by `UpdatedAt` | n/a — single value |
+| `unscheduledOrderTimestamp` | ISO | newer-wins | n/a — single value |
+| `tombstonePrunedBefore` | ISO | max (newer-wins) | n/a — single value |
+| `routinesDate` | date | later-date-wins | n/a — single value |
+| `syncUrl`, `taskCalendarUrl` | string | prefer non-empty (don't let an unconfigured device clear a URL) | n/a — single value |
+| `minimizedSections`, `use24HourClock`, `weatherZip`, `weatherTempUnit`, `multiUserEnabled` | scalar | **device-local** — kept local, never overwritten or re-pushed (matches `merge.js:900-901`) | n/a — by design |
+
+The "n/a" rows are single-valued settings: there are no independent entries to
+lose, so newest-writer-wins is the intended and correct behavior, not a
+multi-entry loss window. The device-local prefs are deliberately not converged,
+exactly as the file-tier merge keeps them local today.
+
+### Cross-list move (A2)
+
+A task keeps its `id` while moving between the five task kinds, so it maps to a
+different `${kind}:${id}` over its life. Moves are **tombstone-on-old +
+insert-on-new** (the move marks both entityIds dirty; `getLocalEntity` returns
+null for the vacated one → soft-delete; the new one upserts). The delete
+suppresses the stale copy on the other device.
+
+For the nasty interleaving — both devices move the same task to **different**
+kinds concurrently — `reconcileCrossList` keeps exactly one copy with a
+**deterministic** rule, so every device agrees:
+
+> **Winner = newest `lastModified`. Tie → `CROSS_LIST_PRIORITY`
+> (`recycleBin` > `recurringTasks` > `tasks` > `unscheduledTasks` >
+> `todayRoutines`).**
+
+recycleBin sorts first so an explicit delete wins a same-instant tie (mirrors
+`merge.js:540-543`, where a recycle entry wins on a non-older timestamp). Each
+removed copy is soft-deleted on the next push, so the **vault** converges too,
+not just local state. Tests cover the simple move, the concurrent
+different-kind move (newest wins), and the priority tie-break.
+
+### Gate result
+
+- **A1 (bundle merge): PASS** — concurrent different-entry edits to every bundle
+  are preserved; naive-LWW loss demonstrated and avoided.
+- **A2 (cross-list move): PASS** — moved tasks end under exactly one kind;
+  concurrent different-kind moves resolve to a deterministic winner.
+- **A3 (regression): PASS** — full suite **286/286** (275 existing + stage-1
+  losslessness 9 + 11 new).
+- **Unavoidable loss windows: NONE.** With the re-push mechanism, every
+  multi-entry bundle converges; the only LWW is single-valued settings, which is
+  intended. **Gate is GREEN — proceed to Part B.**
+
+---
+
+## Part B — live wiring
+
+_(documented below as each piece lands)_

--- a/docs/glancevault-stage2.md
+++ b/docs/glancevault-stage2.md
@@ -134,16 +134,33 @@ transport is unchanged.
 | **B4** transport UI | `CloudSyncSettingsForm.jsx` | Independent GLANCEvault toggle (URL/token/account), saved to its own key, **reload on change**; orthogonal to the WebDAV provider. |
 | **B5** WebDAV retained | — | File-tier engine, payload, and merge are completely unchanged; the DB engine never touches the WebDAV file. |
 
-### Cycle ordering note
+### Cycle ordering note (updated for @glance-apps/sync 1.4.0)
 
-dayGLANCE composes its cycle **pull-then-push** (the engine's built-in
-`dbSyncCycle` is push-then-pull). The engine advances its high-water mark on
-push (`dbEngine.js:225`), so a device that pushed before pulling would skip rows
-written below its new cursor and never see them — observed directly as a failing
-end-to-end test. Pulling first means the HWM only ever advances past rows the
-device has actually seen, and bundle merges push the merged superset in the same
-cycle. Built from the engine's exposed `pullRemoteChanges` / `pushDirtyRows` /
-`updateDeviceCursor`; the package is not modified.
+dayGLANCE composes its cycle from the engine's exposed `pullRemoteChanges` /
+`pushDirtyRows` / `updateDeviceCursor` (rather than the built-in `dbSyncCycle`)
+because it needs to seed the dirty set into the mirror **before** the steps and
+commit the merged mirror back to React/localStorage **only on success** — the
+engine's own `dbSyncCycle` swallows errors, which would let a failed cycle commit
+a partial mirror. This wrapper is the React-state bridge and is required
+regardless of the package version.
+
+The wrapper runs **pull-then-push**. Originally (on 1.3.2) this was a
+**correctness mitigation**: the engine advanced a single shared high-water mark
+on push, so a device that pushed before pulling could skip a remote row whose seq
+sat below its freshly-pushed rows and never see it.
+
+**1.4.0 closes that race in the package** (split cursor: `getHighWaterMark` is
+pull-only, `getPushAck` tracks push idempotency — a push never moves the pull
+cursor). So pull-then-push is **no longer a data-loss mitigation** and the order
+is no longer load-bearing for correctness.
+
+**Decision: keep pull-then-push.** Rationale — we compose the cycle anyway (for
+the seed/commit-on-success bridge above), so the order is a free choice, and
+pulling first gives a marginal freshness win: a bundle superset and any
+cross-list reconcile flush in the **same** cycle instead of the next one.
+Reverting to the engine's `dbSyncCycle` would also reintroduce its
+commit-on-failure hazard. The `getHighWaterMark`-unchanged-after-push behavior is
+proven directly by the interleave test in `dbEngineWiring.test.js`.
 
 ### Backgrounded-write-reaches-vault check (the lastGLANCE bug)
 
@@ -161,7 +178,11 @@ push-on-write fix addressed. **Confirmed.**
   bundle edits converge by set-union; a cross-list move lands under exactly one
   kind. Gate returns null when disabled; deviceId stable; push-on-write debounce
   vault-only + off-safe.
-- Full suite **293/293**; production `vite build` passes.
+- **Interleave test (1.4.0 cursor fix):** with A's pull cursor at N, B writes a
+  row at seq N+1, then A pushes rows at seqs > N+1; A's pull cursor stays at N
+  (only the push-ack advances) and A's next pull still lists B's row at N+1. The
+  residual race is closed.
+- Full suite **294/294**; production `vite build` passes on `@glance-apps/sync@1.4.0`.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.4.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "^1.3.2",
+        "@glance-apps/sync": "1.3.2",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.4.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "1.3.2",
+        "@glance-apps/sync": "1.4.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -2267,9 +2267,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.3.2.tgz",
-      "integrity": "sha512-49Wh24nMQaiGOvgmm6dVXCqCeuXhxx/zjNGGy+VnMnyqUyFEUYy6KYr53E3gTluFMvRxjsoY/ofFIh3OP36kVw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.4.0.tgz",
+      "integrity": "sha512-qk5H5ExPrHVH3VLlCBJLG29A5AGK4djwzslr9ENLqmSqvi6ubN52weNY66Jz3CqFKOVF//gwdMH9hOiNd3WSqQ==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "1.3.2",
+    "@glance-apps/sync": "1.4.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "^1.3.2",
+    "@glance-apps/sync": "1.3.2",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -529,6 +529,11 @@ const DayPlanner = () => {
   const cloudSyncEngineRef = useRef(null);
   // GLANCEvault row-grained DB transport (opt-in, runs ALONGSIDE the file tier).
   const dbEngineRef = useRef(null);
+  // GLANCEvault status surfaced in the Cloud Sync settings (independent of the
+  // WebDAV file-tier status).
+  const [vaultStatus, setVaultStatus] = useState('idle');
+  const [vaultError, setVaultError] = useState(null);
+  const [vaultLastSynced, setVaultLastSynced] = useState(null);
   const engineFolderRef = useRef(null);
   const syncFolder = cloudSyncConfig?.syncFolder ?? 'GLANCE/dayglance';
   const autoBackupProviders = useMemo(() => createAutoBackupProvidersForFolder(syncFolder), [syncFolder]);
@@ -1696,11 +1701,19 @@ const DayPlanner = () => {
     const engine = createDbEngine({
       getData:    () => engineCallbacksRef.current.buildPayload?.()?.data,
       commitData: (data) => engineCallbacksRef.current.applyPayload?.(data, { allowEmpty: true }),
-      onError:    (msg) => { if (msg) console.warn('[dayglance] vault sync error:', msg); },
+      onStatusChange: (s) => {
+        setVaultStatus(s);
+        if (s === 'success') {
+          setVaultError(null);
+          setVaultLastSynced(dbEngineRef.current?.getLastSynced?.() || new Date().toISOString());
+        }
+      },
+      onError: (msg) => { setVaultError(msg || null); if (msg) console.warn('[dayglance] vault sync error:', msg); },
     });
     if (!engine) return;
     dbEngineRef.current = engine;
     registerDbEngine(engine);
+    setVaultLastSynced(engine.getLastSynced?.() || null);
     const runCycle = () => engine.dbSyncCycle().catch(() => { /* surfaced via onError */ });
     runCycle(); // initial
     const onVisible = () => { if (document.visibilityState === 'visible') runCycle(); };
@@ -8468,6 +8481,16 @@ const DayPlanner = () => {
     cloudSyncDownload: () => cloudSyncEngineRef.current.download(),
     cloudSyncUpload:   (prebuilt, opts) => cloudSyncEngineRef.current.upload({ prebuiltPayload: prebuilt, ...opts }),
     cloudSyncTest:     (cfg) => cloudSyncEngineRef.current.test(cfg),
+    // Manual "Sync now" for the WebDAV file tier (full merge cycle).
+    cloudSyncNow:      () => cloudSyncEngineRef.current.sync(),
+    // Manual "Sync now" for the GLANCEvault DB tier + its surfaced status.
+    vaultSyncNow: async () => {
+      const eng = dbEngineRef.current;
+      if (!eng) return;
+      await eng.dbSyncCycle();
+      setVaultLastSynced(eng.getLastSynced?.() || new Date().toISOString());
+    },
+    vaultStatus, vaultError, vaultLastSynced,
     syncAll,
     performObsidianSync, loadWikiNote, saveWikiNote, openInObsidian, nativeClearVault,
     performTrmnlSync,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,6 +67,9 @@ import useTrmnlSync from './hooks/useTrmnlSync.js';
 import useObsidian from './hooks/useObsidian.js';
 import useCloudSync from './hooks/useCloudSync.js';
 import { createDayGlanceEngine } from './sync/adapter.js';
+import { createDbEngine } from './sync/dbEngine.js';
+import { registerDbEngine } from './sync/dirtyTracker.js';
+import { isVaultEnabled } from './sync/vaultConfig.js';
 import { encryptData, decryptData, isEncryptedEnvelope, hasEncryptionReady } from './utils/crypto.js';
 import useCalendarSync from './hooks/useCalendarSync.js';
 import useBackup from './hooks/useBackup.js';
@@ -524,6 +527,8 @@ const DayPlanner = () => {
   // sees fresh closures every cycle — the engine itself is constructed once.
   const engineCallbacksRef = useRef({});
   const cloudSyncEngineRef = useRef(null);
+  // GLANCEvault row-grained DB transport (opt-in, runs ALONGSIDE the file tier).
+  const dbEngineRef = useRef(null);
   const engineFolderRef = useRef(null);
   const syncFolder = cloudSyncConfig?.syncFolder ?? 'GLANCE/dayglance';
   const autoBackupProviders = useMemo(() => createAutoBackupProvidersForFolder(syncFolder), [syncFolder]);
@@ -1677,6 +1682,37 @@ const DayPlanner = () => {
     }, 5000);
     return () => { if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current); };
   }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, allTodayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled, syncKeyReady, multiUserEnabled, users]);
+
+  // ── GLANCEvault DB transport ─────────────────────────────────────────────
+  // Row-grained sync that runs ALONGSIDE the file-tier WebDAV engine (it shares
+  // the local data and sync passphrase but never touches the WebDAV file). Fully
+  // inert when the vault is disabled — createDbEngine returns null and nothing
+  // below runs, so file-only devices behave exactly as before. Push-on-write is
+  // handled by the 3 s debounce in dirtyTracker (wired from useSaveOnChange);
+  // this effect adds the cadence backstop (initial + focus + 5-min interval).
+  // See docs/glancevault-stage2.md.
+  useEffect(() => {
+    if (isTrayMode || !dataLoaded || !isVaultEnabled()) return;
+    const engine = createDbEngine({
+      getData:    () => engineCallbacksRef.current.buildPayload?.()?.data,
+      commitData: (data) => engineCallbacksRef.current.applyPayload?.(data, { allowEmpty: true }),
+      onError:    (msg) => { if (msg) console.warn('[dayglance] vault sync error:', msg); },
+    });
+    if (!engine) return;
+    dbEngineRef.current = engine;
+    registerDbEngine(engine);
+    const runCycle = () => engine.dbSyncCycle().catch(() => { /* surfaced via onError */ });
+    runCycle(); // initial
+    const onVisible = () => { if (document.visibilityState === 'visible') runCycle(); };
+    document.addEventListener('visibilitychange', onVisible);
+    const interval = setInterval(runCycle, 5 * 60 * 1000);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      clearInterval(interval);
+      registerDbEngine(null);
+      dbEngineRef.current = null;
+    };
+  }, [dataLoaded]);
 
   // ── Config field timestamp tracking ──────────────────────────────────────
   // Tracks when habitsEnabled/routinesEnabled/goalsProjectsEnabled/obsidianConfig

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { setupEncryptionKey, setSyncPassphrase, clearEncryptionKey } from '../utils/crypto.js';
 import { getVaultConfig, setVaultConfig } from '../sync/vaultConfig.js';
 import { useTranslation } from 'react-i18next';
 
 // Cloud sync settings form (extracted to avoid hooks-in-conditional issues)
-const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderClass, hoverBg, cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, provider, currentProvider, onClose, cloudSyncLastSynced, cloudSyncStatus, cloudSyncError, onSyncKeyReady }) => {
+const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderClass, hoverBg, cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, cloudSyncNow, provider, currentProvider, onClose, cloudSyncLastSynced, cloudSyncStatus, cloudSyncError, vaultSyncNow, vaultStatus, vaultError, vaultLastSynced, onSyncKeyReady }) => {
   const { t } = useTranslation();
   const [formData, setFormData] = useState(() => {
     const initial = {
@@ -23,6 +24,8 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   const [passphraseConfirm, setPassphraseConfirm] = useState('');
   const [testResult, setTestResult] = useState(null);
   const [testing, setTesting] = useState(false);
+  const [syncingNow, setSyncingNow] = useState(false);
+  const [vaultSyncing, setVaultSyncing] = useState(false);
   const [migrationOldPath] = useState(() => localStorage.getItem('dayglance-sync-migration-old-path'));
 
   // GLANCEvault (DB transport) — independent of the WebDAV provider above. Runs
@@ -92,8 +95,30 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
     onClose();
   };
 
+  // Manual "Sync now" triggers — WebDAV file tier and GLANCEvault DB tier.
+  const handleSyncNow = async () => {
+    if (!cloudSyncNow) return;
+    setSyncingNow(true);
+    try { await cloudSyncNow(); } catch { /* surfaced via cloudSyncError */ }
+    finally { setSyncingNow(false); }
+  };
+  const handleVaultSyncNow = async () => {
+    if (!vaultSyncNow) return;
+    setVaultSyncing(true);
+    try { await vaultSyncNow(); } catch { /* surfaced via vaultError */ }
+    finally { setVaultSyncing(false); }
+  };
+
+  // Shared section-header style (uppercase, like the lastGLANCE layout).
+  const sectionHeader = `text-xs font-semibold uppercase tracking-wide ${textSecondary}`;
+  const secondaryBtn = `px-4 py-2 ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} rounded-lg transition-colors disabled:opacity-50`;
+  const vaultPersistedEnabled = !!vaultOriginal?.enabled;
+
   return (
     <div className="space-y-4">
+      {/* ── WebDAV Connection ─────────────────────────────────────────────── */}
+      <h3 className={sectionHeader}>WebDAV Connection</h3>
+
       <div>
         <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Provider</label>
         <select
@@ -137,6 +162,55 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
 
       {activeProvider.helpText && (
         <p className={`text-xs ${textSecondary}`}>{activeProvider.helpText}</p>
+      )}
+
+      {/* WebDAV actions: Test Connection + Sync Now, with status below. */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleTest}
+          disabled={testing || !requiredFieldsFilled}
+          className={secondaryBtn}
+        >
+          {testing ? 'Testing...' : 'Test Connection'}
+        </button>
+        <button
+          onClick={handleSyncNow}
+          disabled={syncingNow || !cloudSyncConfig?.enabled}
+          title={!cloudSyncConfig?.enabled ? 'Enable WebDAV sync first' : 'Sync with WebDAV now'}
+          className={secondaryBtn}
+        >
+          {(syncingNow || cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'Syncing...' : 'Sync Now'}
+        </button>
+      </div>
+      {testResult && (
+        <p className={`text-sm ${testResult.success ? 'text-green-500' : 'text-red-500'}`}>
+          {testResult.success ? 'Connection successful!' : testResult.error}
+        </p>
+      )}
+      {cloudSyncStatus === 'error' && cloudSyncError ? (
+        <p className="text-xs text-red-500">{cloudSyncError}</p>
+      ) : cloudSyncLastSynced ? (
+        <p className={`text-xs ${textSecondary}`}>
+          Last synced: {new Date(cloudSyncLastSynced).toLocaleString()}
+        </p>
+      ) : null}
+
+      {migrationOldPath && (
+        <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2.5 text-xs text-amber-800 space-y-1">
+          <p className="font-semibold">Optional: move sync folder</p>
+          <p>Your sync file is at the old location. You can move it for cleaner organization — sync will continue to work either way.</p>
+          <p className="font-mono break-all">{migrationOldPath} → GLANCE/dayglance/</p>
+          <p>After moving the file, update your Sync folder setting above to <span className="font-mono">GLANCE/dayglance</span>.</p>
+          <button
+            onClick={() => {
+              localStorage.removeItem('dayglance-sync-migration-old-path');
+              localStorage.setItem('dayglance-sync-migration-checked', '1');
+            }}
+            className="text-amber-700 underline mt-1"
+          >
+            Dismiss
+          </button>
+        </div>
       )}
 
       {/* Encryption section */}
@@ -205,8 +279,14 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
         )}
       </div>
 
-      {/* GLANCEvault (DB transport) — independent toggle, runs alongside WebDAV */}
+      {/* ── GLANCEvault (Beta) ────────────────────────────────────────────── */}
       <div className={`border-t ${borderClass} pt-4 space-y-3`}>
+        <h3 className={sectionHeader}>GLANCEvault (Beta)</h3>
+        <p className="text-xs text-amber-500 flex items-start gap-1.5">
+          <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+          <span>Experimental. Requires a self-hosted GLANCEvault server. Not recommended for most users.</span>
+        </p>
+
         <label className="flex items-center gap-3 cursor-pointer select-none">
           <input
             type="checkbox"
@@ -214,7 +294,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
             onChange={(e) => setVaultEnabled(e.target.checked)}
             className="w-5 h-5 rounded flex-shrink-0"
           />
-          <span className={`text-sm font-medium ${textPrimary}`}>GLANCEvault (database sync)</span>
+          <span className={`text-sm font-medium ${textPrimary}`}>Sync via GLANCEvault</span>
         </label>
         <p className={`text-xs ${textSecondary} ml-7`}>
           Row-grained database sync. Runs alongside your existing WebDAV sync. Your WebDAV data is never modified.
@@ -255,47 +335,30 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
             <p className={`text-xs ${textSecondary}`}>Saving a GLANCEvault change reloads the app so the sync engines reconstruct.</p>
           </div>
         )}
-      </div>
 
-      <div className="flex items-center gap-2">
-        <button
-          onClick={handleTest}
-          disabled={testing || !requiredFieldsFilled}
-          className={`px-4 py-2 ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} rounded-lg transition-colors disabled:opacity-50`}
-        >
-          {testing ? 'Testing...' : 'Test Connection'}
-        </button>
-        {testResult && (
-          <span className={`text-sm ${testResult.success ? 'text-green-500' : 'text-red-500'}`}>
-            {testResult.success ? 'Connection successful!' : testResult.error}
-          </span>
+        {/* GLANCEvault actions: Sync Now, with status below. Enabled once the
+            saved config is active (and the engine therefore exists). */}
+        {vaultPersistedEnabled && (
+          <>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleVaultSyncNow}
+                disabled={vaultSyncing}
+                className={secondaryBtn}
+              >
+                {(vaultSyncing || vaultStatus === 'uploading' || vaultStatus === 'downloading') ? 'Syncing...' : 'Sync Now'}
+              </button>
+            </div>
+            {vaultError ? (
+              <p className="text-xs text-red-500">{vaultError}</p>
+            ) : vaultLastSynced ? (
+              <p className={`text-xs ${textSecondary}`}>
+                Last synced: {new Date(vaultLastSynced).toLocaleString()}
+              </p>
+            ) : null}
+          </>
         )}
       </div>
-
-      {migrationOldPath && (
-        <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2.5 text-xs text-amber-800 space-y-1">
-          <p className="font-semibold">Optional: move sync folder</p>
-          <p>Your sync file is at the old location. You can move it for cleaner organization — sync will continue to work either way.</p>
-          <p className="font-mono break-all">{migrationOldPath} → GLANCE/dayglance/</p>
-          <p>After moving the file, update your Sync folder setting above to <span className="font-mono">GLANCE/dayglance</span>.</p>
-          <button
-            onClick={() => {
-              localStorage.removeItem('dayglance-sync-migration-old-path');
-              localStorage.setItem('dayglance-sync-migration-checked', '1');
-            }}
-            className="text-amber-700 underline mt-1"
-          >
-            Dismiss
-          </button>
-        </div>
-      )}
-      {cloudSyncStatus === 'error' && cloudSyncError ? (
-        <p className="text-xs text-red-500">{cloudSyncError}</p>
-      ) : cloudSyncLastSynced ? (
-        <p className={`text-xs ${textSecondary}`}>
-          Last synced: {new Date(cloudSyncLastSynced).toLocaleString()}
-        </p>
-      ) : null}
 
       <div className="flex justify-end gap-2 pt-2">
         <button

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { setupEncryptionKey, setSyncPassphrase, clearEncryptionKey } from '../utils/crypto.js';
+import { getVaultConfig, setVaultConfig } from '../sync/vaultConfig.js';
 import { useTranslation } from 'react-i18next';
 
 // Cloud sync settings form (extracted to avoid hooks-in-conditional issues)
@@ -23,6 +24,15 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   const [testResult, setTestResult] = useState(null);
   const [testing, setTesting] = useState(false);
   const [migrationOldPath] = useState(() => localStorage.getItem('dayglance-sync-migration-old-path'));
+
+  // GLANCEvault (DB transport) — independent of the WebDAV provider above. Runs
+  // ALONGSIDE WebDAV; your WebDAV data is never modified. Saved to its own
+  // localStorage key; toggling it requires a reload so the engines reconstruct.
+  const [vaultOriginal] = useState(() => getVaultConfig());
+  const [vaultEnabled, setVaultEnabled] = useState(() => !!vaultOriginal?.enabled);
+  const [vaultUrl, setVaultUrl] = useState(() => vaultOriginal?.vaultUrl || '');
+  const [vaultToken, setVaultToken] = useState(() => vaultOriginal?.vaultToken || '');
+  const [vaultAccountId, setVaultAccountId] = useState(() => vaultOriginal?.accountId || '');
 
   const activeProvider = cloudSyncProviders[formData.provider] || provider;
   const requiredFieldsFilled = activeProvider.configFields.every(f => formData[f.key]) && !!formData.syncFolder;
@@ -62,6 +72,18 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
 
     setCloudSyncConfig(newConfig);
     onSyncKeyReady?.(encryptionEnabled);
+
+    // GLANCEvault is saved/cleared independently of the file engine. Only stored
+    // when the toggle is on; cleared (reverting to file-only) when off.
+    const nextVault = vaultEnabled
+      ? { enabled: true, vaultUrl: vaultUrl.trim(), vaultToken: vaultToken.trim(), accountId: vaultAccountId.trim() }
+      : null;
+    const vaultChanged = JSON.stringify(nextVault) !== JSON.stringify(vaultOriginal || null);
+    setVaultConfig(nextVault);
+
+    // A vault change requires a reload so the DB engine is (re)constructed with
+    // the new transport config on next mount (mirrors lastGLANCE).
+    if (vaultChanged) { window.location.reload(); return; }
     onClose();
   };
 
@@ -179,6 +201,58 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
               <p className="font-medium text-amber-600">Important — store your passphrase safely</p>
               <p>This passphrase cannot be recovered. You will need it to set up sync on new devices. Store it in a password manager.</p>
             </div>
+          </div>
+        )}
+      </div>
+
+      {/* GLANCEvault (DB transport) — independent toggle, runs alongside WebDAV */}
+      <div className={`border-t ${borderClass} pt-4 space-y-3`}>
+        <label className="flex items-center gap-3 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={vaultEnabled}
+            onChange={(e) => setVaultEnabled(e.target.checked)}
+            className="w-5 h-5 rounded flex-shrink-0"
+          />
+          <span className={`text-sm font-medium ${textPrimary}`}>GLANCEvault (database sync)</span>
+        </label>
+        <p className={`text-xs ${textSecondary} ml-7`}>
+          Row-grained database sync. Runs alongside your existing WebDAV sync. Your WebDAV data is never modified.
+          Uses the same encryption passphrase as above.
+        </p>
+        {vaultEnabled && (
+          <div className="ml-7 space-y-3">
+            <div>
+              <label className={`block text-sm ${textSecondary} mb-1`}>Vault URL</label>
+              <input
+                type="text"
+                placeholder="https://vault.glance-apps.com"
+                value={vaultUrl}
+                onChange={(e) => setVaultUrl(e.target.value)}
+                className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+              />
+            </div>
+            <div>
+              <label className={`block text-sm ${textSecondary} mb-1`}>Device token</label>
+              <input
+                type="password"
+                placeholder="Device bearer token"
+                value={vaultToken}
+                onChange={(e) => setVaultToken(e.target.value)}
+                className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+              />
+            </div>
+            <div>
+              <label className={`block text-sm ${textSecondary} mb-1`}>Account ID</label>
+              <input
+                type="text"
+                placeholder="Household account id"
+                value={vaultAccountId}
+                onChange={(e) => setVaultAccountId(e.target.value)}
+                className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+              />
+            </div>
+            <p className={`text-xs ${textSecondary}`}>Saving a GLANCEvault change reloads the app so the sync engines reconstruct.</p>
           </div>
         )}
       </div>

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -78,7 +78,8 @@ const MobileSettingsPanel = () => {
     obsidianConfig, setObsidianConfig,
     obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
     wikilinkCandidates, setWikilinkCandidates,
-    cloudSyncUpload, cloudSyncTest,
+    cloudSyncUpload, cloudSyncTest, cloudSyncNow,
+    vaultSyncNow, vaultStatus, vaultError, vaultLastSynced,
     syncAll, performObsidianSync, performRemoteBackup, nativeClearVault,
     loadAutoBackupHistory,
     deleteLocalAutoBackup, deleteRemoteAutoBackup,
@@ -719,6 +720,13 @@ const MobileSettingsPanel = () => {
           currentProvider={currentProvider}
           onClose={() => setMobileSettingsView('main')}
           cloudSyncLastSynced={cloudSyncLastSynced}
+          cloudSyncStatus={cloudSyncStatus}
+          cloudSyncError={cloudSyncError}
+          cloudSyncNow={cloudSyncNow}
+          vaultSyncNow={vaultSyncNow}
+          vaultStatus={vaultStatus}
+          vaultError={vaultError}
+          vaultLastSynced={vaultLastSynced}
           onSyncKeyReady={(ready) => setSyncKeyReady(ready)}
         />
         </>)}

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -78,7 +78,7 @@ const MobileSettingsPanel = () => {
     obsidianConfig, setObsidianConfig,
     obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
     wikilinkCandidates, setWikilinkCandidates,
-    cloudSyncUpload, cloudSyncTest, cloudSyncNow,
+    cloudSyncTest, cloudSyncNow,
     vaultSyncNow, vaultStatus, vaultError, vaultLastSynced,
     syncAll, performObsidianSync, performRemoteBackup, nativeClearVault,
     loadAutoBackupHistory,
@@ -283,28 +283,21 @@ const MobileSettingsPanel = () => {
           <span className={`font-medium ${textPrimary}`}>{t('settings.syncCalendars')}</span>
         </button>
       )}
-      {cloudSyncConfig?.enabled && (
-        <button
-          onClick={() => cloudSyncUpload()}
-          className={`w-full ${cardBg} border ${borderClass} rounded-xl p-4 flex items-center gap-3`}
-        >
-          <div className="relative">
-            <Cloud size={20} className={`${textSecondary} ${(cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'animate-pulse' : ''}`} />
+      <button
+        onClick={() => setMobileSettingsView('cloudsync')}
+        className={`w-full ${cardBg} border ${borderClass} rounded-xl p-4 flex items-center gap-3`}
+      >
+        <div className="relative">
+          <Cloud size={20} className={`${cloudSyncConfig?.enabled ? 'text-blue-500' : textSecondary} ${(cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'animate-pulse' : ''}`} />
+          {cloudSyncConfig?.enabled && (
             <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full border-2 ${darkMode ? 'border-gray-800' : 'border-white'} ${
               (cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'bg-blue-500 animate-pulse' : cloudSyncStatus === 'error' ? 'bg-red-500' : 'bg-green-500'
             }`} />
-          </div>
-          <div className="flex-1 text-left">
-            <span className={`font-medium ${textPrimary}`}>Cloud Sync</span>
-            {cloudSyncStatus === 'error' && cloudSyncError && (
-              <p className="text-xs text-red-500 mt-0.5 leading-tight">{cloudSyncError}</p>
-            )}
-            {cloudSyncStatus === 'success' && cloudSyncLastSynced && (
-              <p className={`text-xs ${textSecondary} mt-0.5`}>{t('common.lastSynced')} {new Date(cloudSyncLastSynced).toLocaleTimeString()}</p>
-            )}
-          </div>
-        </button>
-      )}
+          )}
+        </div>
+        <span className={`font-medium ${textPrimary} flex-1 text-left`}>{t('settings.cloudSync')}</span>
+        <ChevronRight size={18} className={textSecondary} />
+      </button>
       {isNativeApp() && (
         <button
           onClick={() => setMobileSettingsView('obsidian')}
@@ -407,8 +400,6 @@ const MobileSettingsPanel = () => {
 
   {/* App Settings sub-view */}
   {mobileSettingsView === 'app' && (() => {
-    const currentProvider = cloudSyncConfig?.provider || 'nextcloud';
-    const provider = cloudSyncProviders[currentProvider];
     return (
     <div className="px-4 py-4 space-y-4">
       <button
@@ -692,43 +683,6 @@ const MobileSettingsPanel = () => {
             </>)}
           </div>
         )}
-        </>)}
-      </div>
-
-      <hr className={borderClass} />
-
-      {/* Cloud Sync */}
-      <div className="space-y-3">
-        <button onClick={() => toggleSettingsSection('cloudSync')} className={`font-medium ${textPrimary} flex items-center gap-2 w-full text-left`}>
-          <Cloud size={16} className={textSecondary} />
-          {t('settings.cloudSync')}
-          {cloudSyncConfig?.enabled && <span className="mr-1 w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />}
-          <ChevronDown size={16} className={`ml-auto flex-shrink-0 ${textSecondary} transition-transform ${collapsedSettings.cloudSync ? '' : 'rotate-180'}`} />
-        </button>
-        {!collapsedSettings.cloudSync && (<>
-        <p className={`${textSecondary} text-xs`}>{t('settings.cloudSyncDesc')}</p>
-        <CloudSyncSettingsForm
-          darkMode={darkMode}
-          textPrimary={textPrimary}
-          textSecondary={textSecondary}
-          borderClass={borderClass}
-          hoverBg={hoverBg}
-          cloudSyncConfig={cloudSyncConfig}
-          setCloudSyncConfig={setCloudSyncConfig}
-          cloudSyncTest={cloudSyncTest}
-          provider={provider}
-          currentProvider={currentProvider}
-          onClose={() => setMobileSettingsView('main')}
-          cloudSyncLastSynced={cloudSyncLastSynced}
-          cloudSyncStatus={cloudSyncStatus}
-          cloudSyncError={cloudSyncError}
-          cloudSyncNow={cloudSyncNow}
-          vaultSyncNow={vaultSyncNow}
-          vaultStatus={vaultStatus}
-          vaultError={vaultError}
-          vaultLastSynced={vaultLastSynced}
-          onSyncKeyReady={(ready) => setSyncKeyReady(ready)}
-        />
         </>)}
       </div>
 
@@ -1328,6 +1282,50 @@ const MobileSettingsPanel = () => {
   )}
 
   {/* Obsidian sub-view */}
+  {/* Cloud Sync sub-view */}
+  {mobileSettingsView === 'cloudsync' && (() => {
+    const currentProvider = cloudSyncConfig?.provider || 'nextcloud';
+    const provider = cloudSyncProviders[currentProvider];
+    return (
+    <div className="px-4 py-4 space-y-4">
+      <button
+        onClick={() => setMobileSettingsView('main')}
+        className={`flex items-center gap-2 ${textSecondary} mb-2`}
+      >
+        <ChevronLeft size={18} />
+        <span className="text-sm font-medium">{t('common.settings')}</span>
+      </button>
+      <h4 className={`font-medium ${textPrimary} flex items-center gap-2`}>
+        <Cloud size={18} className={cloudSyncConfig?.enabled ? 'text-blue-500' : textSecondary} />
+        {t('settings.cloudSync')}
+      </h4>
+      <p className={`text-xs ${textSecondary}`}>{t('settings.cloudSyncDesc')}</p>
+      <CloudSyncSettingsForm
+        darkMode={darkMode}
+        textPrimary={textPrimary}
+        textSecondary={textSecondary}
+        borderClass={borderClass}
+        hoverBg={hoverBg}
+        cloudSyncConfig={cloudSyncConfig}
+        setCloudSyncConfig={setCloudSyncConfig}
+        cloudSyncTest={cloudSyncTest}
+        provider={provider}
+        currentProvider={currentProvider}
+        onClose={() => setMobileSettingsView('main')}
+        cloudSyncLastSynced={cloudSyncLastSynced}
+        cloudSyncStatus={cloudSyncStatus}
+        cloudSyncError={cloudSyncError}
+        cloudSyncNow={cloudSyncNow}
+        vaultSyncNow={vaultSyncNow}
+        vaultStatus={vaultStatus}
+        vaultError={vaultError}
+        vaultLastSynced={vaultLastSynced}
+        onSyncKeyReady={(ready) => setSyncKeyReady(ready)}
+      />
+    </div>
+    );
+  })()}
+
   {mobileSettingsView === 'obsidian' && (
     <div className="px-4 py-4 space-y-4">
       <button

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -50,7 +50,8 @@ const SettingsModal = () => {
   const {
     handleFileUpload,
     cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, cloudSyncLastSynced,
-    cloudSyncStatus, cloudSyncError,
+    cloudSyncStatus, cloudSyncError, cloudSyncNow,
+    vaultSyncNow, vaultStatus, vaultError, vaultLastSynced,
     syncKeyReady, setSyncKeyReady,
     calSyncConfigured, syncUrl, setSyncUrl,
     showCalendarUrlHint, setShowCalendarUrlHint,
@@ -737,6 +738,11 @@ const SettingsModal = () => {
                         cloudSyncLastSynced={cloudSyncLastSynced}
                         cloudSyncStatus={cloudSyncStatus}
                         cloudSyncError={cloudSyncError}
+                        cloudSyncNow={cloudSyncNow}
+                        vaultSyncNow={vaultSyncNow}
+                        vaultStatus={vaultStatus}
+                        vaultError={vaultError}
+                        vaultLastSynced={vaultLastSynced}
                         onSyncKeyReady={(ready) => setSyncKeyReady(ready)}
                       />
                       </>)}

--- a/src/hooks/useSaveOnChange.js
+++ b/src/hooks/useSaveOnChange.js
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { schedulePush as scheduleVaultPush } from '../sync/dirtyTracker.js';
 
 // The tray popup must never write to localStorage — it holds a snapshot of
 // state as of the last reload and would overwrite fresher main-window data.
@@ -17,6 +18,10 @@ export default function useSaveOnChange({
     if (isTrayMode || !dataLoaded) return;
     saveData();
     checkConflicts();
+    // Push-on-write to the GLANCEvault DB transport (debounced 3 s, vault-only).
+    // Off-safe no-op when the vault is disabled; skipped while applying remote
+    // data (suppressCloudUpload) so a pulled change never bounces back as a push.
+    if (!suppressCloudUploadRef.current) scheduleVaultPush();
     // After the first save pass following applyEngineData, clear the suppress flags
     // so subsequent user actions (e.g. completing a task) get properly stamped and uploaded.
     if (suppressClearPendingRef.current) {

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -1,88 +1,123 @@
-// dayGLANCE → GLANCEvault entity-to-row adapter (cutover STAGE 1 of 2).
+// dayGLANCE → GLANCEvault entity-to-row adapter.
 //
-// NON-DESTRUCTIVE. This module is pure shred/reassemble logic. It performs no
-// network I/O, touches no transport, writes nothing to a real server, and is
-// not yet wired into App.jsx. It exists so stage 1 can prove that dayGLANCE's
-// full sync payload is losslessly representable as the row-grained rows the
-// GLANCEvault DB engine (createDbSyncEngine, @glance-apps/sync@1.3.2) exchanges.
+// Stage 1 (representability): pure shred/reassemble — proven lossless on one
+// device. Stage 2 (merge correctness): per-row APPLY logic that merges one
+// pulled row into a device's live state without losing concurrent edits made on
+// another device. App-side only; @glance-apps/sync is never modified.
 //
-// It mirrors lastGLANCE's src/sync/dbEngine.ts mapping (getLocalEntity /
-// applyRemoteEntity / isInsertOnly / getEntityLastModified) with ONE deliberate
-// divergence, forced by dayGLANCE's data model:
+// The GLANCEvault DB engine (createDbSyncEngine, dbEngine.js) is data-shape
+// agnostic. It calls these app-side callbacks:
+//   getLocalEntity(entityId)        -> wrapped entity | null   (shred one)
+//   applyRemoteEntity(entityId, e)  -> merge one pulled row
+//   applyRemoteDelete(entityId)     -> remove one row
+//   isInsertOnly(entity)            -> always-apply (merge) vs LWW
+//   getEntityLastModified(entity)   -> entity-grain LWW tiebreaker
+// On pull the engine applies a row only when the local copy is absent, the kind
+// is insert-only, or the remote's lastModified wins (dbEngine.js:262-280).
 //
-//   The reference derives entity kind by STRUCTURAL SNIFFING of field names
-//   (entityKind), because lastGLANCE had only 4 well-separated types. dayGLANCE
-//   has a dozen-plus types and five of them — tasks, unscheduledTasks,
-//   recurringTasks, recycleBin, todayRoutines — are the IDENTICAL task shape
-//   (App.jsx stamps all five through the same stampTaskTimestamps path,
-//   useDataPersistence.js:177-181). No structural sniff can tell a scheduled
-//   task from an inbox task from a today-routine: they carry the same fields.
-//   So this adapter carries an EXPLICIT `_kind` discriminator INSIDE the
-//   encrypted envelope and routes on it. encryptEntity (dbCrypto.js:274)
-//   JSON-stringifies the whole entity before AES-GCM, so `_kind` is sealed in
-//   the per-entity ciphertext — the server still sees only opaque bytes, so the
-//   transport stays zero-knowledge. See docs/glancevault-stage1.md for the full
-//   discrimination decision and proof.
+// DISCRIMINATION: explicit in-envelope `_kind`, not structural sniffing —
+// dayGLANCE's five task-shaped collections (tasks / unscheduledTasks /
+// recurringTasks / recycleBin / todayRoutines) are field-for-field identical and
+// cannot be told apart structurally. encryptEntity JSON-stringifies the whole
+// entity before AES-GCM (dbCrypto.js:274), so `_kind` rides inside the per-entity
+// ciphertext and the server still sees only opaque bytes (zero-knowledge).
 //
-// SCOPING (rule 4 of the stage-1 brief): this is a faithful TRANSPORT shred,
-// NOT a data-model change. Bundled structures keep their current shape —
-// recurringTasks.completedDates stays an array inside its row, habitLogs stays
-// a keyed map carried whole in a single row. Finer per-completion remodeling is
-// a separate future enhancement and is intentionally NOT done here.
+// SCOPING (rule 4): bundles keep their current shape — completedDates stays an
+// array inside its row, habitLogs stays a keyed map carried whole. No finer
+// per-completion remodeling.
 
-// ── Collection kinds: each ARRAY element becomes one row, keyed by a stable id.
-// idField  — the row's stable entityId source (the same id the file-tier merge
-//            keys on in @glance-apps/sync merge.js).
-// tsField  — the entity-grain last-writer-wins tiebreaker the merge compares.
-//            Evidence (file:line) is tabulated in docs/glancevault-stage1.md.
+import { mergeHabitLogs, mergeRoutineDefinitions } from '../mergeSync.js';
+
+// ── Collection kinds: each array element is one row, keyed by a stable id, with
+// entity-grain last-writer-wins on tsField (the same grain the file-tier merge
+// in @glance-apps/sync merge.js resolves). Evidence: docs/glancevault-stage1.md.
 export const COLLECTION_KINDS = {
-  // Task-shaped lists. All five share { id, title, duration, color, completed,
-  // lastModified, ... }; only `_kind` distinguishes them on the wire.
   tasks:            { idField: 'id',     tsField: 'lastModified' },
   unscheduledTasks: { idField: 'id',     tsField: 'lastModified' },
-  recurringTasks:   { idField: 'id',     tsField: 'lastModified' }, // completedDates[] stays inside the row
+  recurringTasks:   { idField: 'id',     tsField: 'lastModified' }, // completedDates[] stays inside
   recycleBin:       { idField: 'id',     tsField: 'lastModified' },
   todayRoutines:    { idField: 'id',     tsField: 'lastModified' },
-  // Non-task collections.
-  habits:           { idField: 'id',     tsField: 'lastModified' }, // falls back to createdAt (merge.js:299)
+  habits:           { idField: 'id',     tsField: 'lastModified' }, // falls back to createdAt
   goals:            { idField: 'id',     tsField: 'updatedAt'    },
   projects:         { idField: 'id',     tsField: 'updatedAt'    },
   gtdFrames:        { idField: 'id',     tsField: 'lastModified' },
-  users:            { idField: 'syncId', tsField: 'updatedAt'    }, // falls back to id (merge.js:843)
+  users:            { idField: 'syncId', tsField: 'updatedAt'    }, // falls back to id
 };
 
+// The five task-shaped kinds. A task keeps its `id` while moving between these
+// lists, so cross-list reconciliation operates over exactly this set.
+export const TASK_KINDS = ['tasks', 'unscheduledTasks', 'recurringTasks', 'recycleBin', 'todayRoutines'];
+
+// Deterministic tie-break order when the same id is live under multiple kinds
+// with equal lastModified: earlier in the list wins. recycleBin first so an
+// explicit delete beats a same-instant live edit (mirrors merge.js:540-543,
+// where a recycle entry wins on a non-older timestamp).
+export const CROSS_LIST_PRIORITY = ['recycleBin', 'recurringTasks', 'tasks', 'unscheduledTasks', 'todayRoutines'];
+
 // dailyNotes is a MAP keyed by 'YYYY-MM-DD' → { text, lastModified, deleted? }.
-// The merge resolves it per-date (merge.js:217), so each date is its own row.
+// Each date is its own LWW row (merge.js:217). NOT insert-only: concurrent edits
+// to different dates are different entityIds, so neither is lost; same-date edits
+// resolve by lastModified, exactly as today.
 export const DATE_MAP_KIND = 'dailyNotes';
 
-// Wire `_kind` value for every other top-level payload key — the bundles and
-// scalar/config values that have no per-item id and must NOT be split into
-// finer rows (rule 4). Each becomes exactly one singleton row.
+// Every other top-level payload key → one singleton row carrying the whole
+// structure in its current shape. Singletons are INSERT-ONLY (always applied) so
+// the per-bundle merge below runs on every pull — a plain LWW upsert of a whole
+// bundle row would silently drop the other device's concurrent edit to a
+// different entry (the spec-5.3 risk Part A exists to close).
 export const SINGLETON_KIND = 'singleton';
 
-// Entity kinds that are insert-only (immutable, never collide on merge). In the
-// reference these are completionEvents. dayGLANCE has NONE in stage 1: completion
-// remodeling is explicitly out of scope (rule 4), so every kind mutable-upserts
-// at its grain.
-const INSERT_ONLY_KINDS = new Set();
+// Bundle pairings. A few bundles only merge correctly together: habitLogs needs
+// its per-(date,habitId) timestamps, and each *Enabled / config flag needs its
+// *UpdatedAt sibling for last-writer-wins. The owner row carries the siblings in
+// `_extra`, so a single insert-only apply has everything it needs and stays
+// order-independent. This is COARSER grouping, not finer remodeling (rule 4).
+export const BUNDLE_OWNS = {
+  habitLogs:            ['habitLogTimestamps'],
+  habitsEnabled:        ['habitsEnabledUpdatedAt'],
+  routinesEnabled:      ['routinesEnabledUpdatedAt'],
+  goalsProjectsEnabled: ['goalsProjectsEnabledUpdatedAt'],
+  obsidianConfig:       ['obsidianConfigUpdatedAt'],
+  multiUserEnabled:     ['multiUserEnabledUpdatedAt'],
+};
+const OWNED_KEYS = new Set(Object.values(BUNDLE_OWNS).flat());
 
-// ── Read the discriminator the engine routes on (replaces the reference's
-// structural entityKind sniff). The kind is an explicit field, never inferred.
+// ── small helpers ────────────────────────────────────────────────────────────
+const ts = (v) => {
+  if (v == null) return 0;
+  const t = new Date(v).getTime();
+  return Number.isNaN(t) ? 0 : t;
+};
+const newerIso = (a, b) => (ts(a) >= ts(b) ? a : b);
+// Key-order-independent deep equality, used to detect when a bundle merge left
+// our local copy richer than the row we just pulled (→ re-push the superset).
+const deepEqual = (a, b) => {
+  if (a === b) return true;
+  if (a == null || b == null || typeof a !== typeof b) return a === b;
+  if (typeof a !== 'object') return a === b;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a)) return a.length === b.length && a.every((v, i) => deepEqual(v, b[i]));
+  const ka = Object.keys(a), kb = Object.keys(b);
+  if (ka.length !== kb.length) return false;
+  return ka.every((k) => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]));
+};
+// Last-writer-wins for a single config value via paired updatedAt timestamps;
+// remote wins ties (mirrors merge.js pickConfigByTs:12-17).
+const pickByTs = (localVal, localTs, remoteVal, remoteTs) =>
+  (ts(remoteTs) >= ts(localTs) ? remoteVal : localVal);
+
+// ── kind / mutability / tiebreaker (engine callbacks) ──────────────────────────
 export function entityKind(entity) {
   if (!entity || typeof entity !== 'object') return null;
   return typeof entity._kind === 'string' ? entity._kind : null;
 }
 
-// ── isInsertOnly: engine callback. Stage 1 has no insert-only per-item type.
+// Singletons (bundles) are insert-only: always applied so their merge runs.
+// Collections and per-date dailyNotes use normal entity-grain LWW.
 export function isInsertOnly(entity) {
-  return INSERT_ONLY_KINDS.has(entityKind(entity));
+  return entityKind(entity) === SINGLETON_KIND;
 }
 
-// ── getEntityLastModified: engine callback. Entity-grain LWW tiebreaker.
-// Reads the per-kind tsField from the wrapped value. Singletons/date-map rows
-// surface a best-effort timestamp where the bundle carries one, else undefined
-// (flagged in the stampTaskTimestamps / dirtiness report — some bundles have no
-// timestamp; that is a known stage-2 concern, not a losslessness blocker).
 export function getEntityLastModified(entity) {
   const kind = entityKind(entity);
   if (!kind) return undefined;
@@ -91,61 +126,61 @@ export function getEntityLastModified(entity) {
     return value && typeof value === 'object' ? value.lastModified : undefined;
   }
   if (kind === SINGLETON_KIND) {
-    // Bundles rarely carry their own timestamp. The *enabled flags travel with a
-    // sibling *UpdatedAt singleton; obsidianConfig likewise. Surface a string
-    // value when the bundle itself is an ISO stamp (e.g. tombstonePrunedBefore),
-    // otherwise undefined — the engine treats undefined as epoch-0.
+    // Insert-only, so the engine ignores this; surface an ISO bundle value
+    // (e.g. tombstonePrunedBefore) for completeness, else undefined.
     return typeof value === 'string' ? value : undefined;
   }
   const cfg = COLLECTION_KINDS[kind];
   if (!cfg || !value || typeof value !== 'object') return undefined;
-  return value[cfg.tsField]
-    ?? value.lastModified
-    ?? value.updatedAt
-    ?? value.createdAt;
+  return value[cfg.tsField] ?? value.lastModified ?? value.updatedAt ?? value.createdAt;
 }
 
-// ── entityId scheme. The kind is ALWAYS part of the id so two different kinds
-// that share a numeric id never collide on one vault row. This matters for
-// dayGLANCE specifically: a task mid cross-list move exists in BOTH `tasks` and
-// `unscheduledTasks` with the SAME id (the file-tier merge reconciles that —
-// merge.js:556-601). Keyed by `${kind}:${id}` those become two distinct rows,
-// which is exactly what losslessness requires (both copies survive the
-// roundtrip). Stage 2 must apply the same cross-list reconciliation on pull.
+// ── entityId scheme: kind is always part of the id so two kinds that share a
+// numeric id never collide on one vault row (a cross-list-moving task is the
+// case that matters — see TASK_KINDS / reconcileCrossList).
 export function makeEntityId(kind, id) {
   return `${kind}:${id}`;
 }
+function splitEntityId(entityId) {
+  const s = String(entityId);
+  const i = s.indexOf(':');
+  return i < 0 ? [s, ''] : [s.slice(0, i), s.slice(i + 1)];
+}
 
-// Build one wire row. `entity` is the plaintext object handed to encryptEntity;
-// it wraps the original value so the user payload is never polluted with adapter
-// fields and round-trips byte-for-byte. `_kind`/`_key` live alongside `value`,
-// all sealed inside the per-entity ciphertext.
 function makeRow(kind, entityId, value, extra = {}) {
   return { entityId, kind, entity: { _kind: kind, ...extra, value } };
 }
 
-/**
- * SHRED: full payload `.data` → array of rows.
- *
- * @param {object} data - the `.data` object from buildSyncPayload (App.jsx:5382)
- * @returns {Array<{ entityId: string, kind: string, entity: object }>}
- */
+// Build the wrapped entity for one singleton, pulling its owned siblings into
+// `_extra`. Returns null when the bundle is genuinely absent.
+function makeSingletonEntity(data, key) {
+  if (!(key in data) && !BUNDLE_OWNS[key]) return null;
+  const entity = { _kind: SINGLETON_KIND, _key: key, value: data[key] };
+  const owned = BUNDLE_OWNS[key];
+  if (owned) {
+    const extra = {};
+    for (const k of owned) extra[k] = data[k];
+    entity._extra = extra;
+  }
+  return entity;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SHRED: full payload `.data` → rows
+// ─────────────────────────────────────────────────────────────────────────────
 export function shredState(data) {
   if (!data || typeof data !== 'object') return [];
   const rows = [];
   const handled = new Set([DATE_MAP_KIND]);
 
-  // Per-item collection rows.
   for (const [kind, cfg] of Object.entries(COLLECTION_KINDS)) {
     handled.add(kind);
-    const arr = Array.isArray(data[kind]) ? data[kind] : [];
-    for (const item of arr) {
+    for (const item of (Array.isArray(data[kind]) ? data[kind] : [])) {
       const id = item == null ? undefined : (item[cfg.idField] ?? item.id);
       rows.push(makeRow(kind, makeEntityId(kind, id), item));
     }
   }
 
-  // dailyNotes: one row per date key.
   const notes = data[DATE_MAP_KIND];
   if (notes && typeof notes === 'object') {
     for (const dateKey of Object.keys(notes)) {
@@ -153,30 +188,21 @@ export function shredState(data) {
     }
   }
 
-  // Everything else (bundles + scalar/config) → one singleton row each, carried
-  // in its CURRENT shape. Iterating every remaining key guarantees no field is
-  // dropped even if the payload gains a key the registry above doesn't name.
+  // Remaining keys → one singleton row each. Owned siblings ride inside their
+  // owner's `_extra`, so skip emitting them standalone.
   for (const key of Object.keys(data)) {
-    if (handled.has(key)) continue;
-    rows.push(makeRow(SINGLETON_KIND, makeEntityId(SINGLETON_KIND, key), data[key], { _key: key }));
+    if (handled.has(key) || OWNED_KEYS.has(key)) continue;
+    rows.push({ entityId: makeEntityId(SINGLETON_KIND, key), kind: SINGLETON_KIND, entity: makeSingletonEntity(data, key) });
   }
 
   return rows;
 }
 
-/**
- * REASSEMBLE: rows → full payload `.data`.
- *
- * Reconstructs the canonical skeleton (every collection key present, even when
- * empty — buildSyncPayload always emits all of them) and routes each row by its
- * explicit `_kind`. Order within a collection follows row order.
- *
- * @param {Array<{ entity: object }>} rows
- * @returns {object} the rebuilt `.data`
- */
+// ─────────────────────────────────────────────────────────────────────────────
+// REASSEMBLE: rows → full payload `.data` (single-device, lossless)
+// ─────────────────────────────────────────────────────────────────────────────
 export function reassembleState(rows) {
   const data = {};
-  // Canonical skeleton: every collection is always present in buildSyncPayload.
   for (const kind of Object.keys(COLLECTION_KINDS)) data[kind] = [];
   data[DATE_MAP_KIND] = {};
 
@@ -185,6 +211,7 @@ export function reassembleState(rows) {
     const kind = entityKind(entity);
     if (kind === SINGLETON_KIND) {
       data[entity._key] = entity.value;
+      if (entity._extra) Object.assign(data, entity._extra);
     } else if (kind === DATE_MAP_KIND) {
       data[DATE_MAP_KIND][entity._key] = entity.value;
     } else if (COLLECTION_KINDS[kind]) {
@@ -193,6 +220,217 @@ export function reassembleState(rows) {
       throw new Error(`reassembleState: unroutable row _kind=${JSON.stringify(kind)}`);
     }
   }
-
   return data;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PER-ROW APPLY / MERGE (stage 2)
+//
+// These mutate `data` in place — the same contract as the reference's Dexie
+// appliers (write directly, never through the dirty-tracked path, so a pulled
+// row never bounces back as a push).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Shred one entity by id (engine getLocalEntity). Returns null on absence, which
+// the engine treats as a soft-delete on push.
+export function getLocalEntity(data, entityId) {
+  const [kind, id] = splitEntityId(entityId);
+  if (COLLECTION_KINDS[kind]) {
+    const cfg = COLLECTION_KINDS[kind];
+    const item = (data[kind] || []).find((x) => x != null && String(x[cfg.idField] ?? x.id) === id);
+    return item ? { _kind: kind, value: item } : null;
+  }
+  if (kind === DATE_MAP_KIND) {
+    const v = (data[DATE_MAP_KIND] || {})[id];
+    return v ? { _kind: DATE_MAP_KIND, _key: id, value: v } : null;
+  }
+  if (kind === SINGLETON_KIND) {
+    if (OWNED_KEYS.has(id)) return null;
+    return makeSingletonEntity(data, id);
+  }
+  return null;
+}
+
+function upsertCollection(data, kind, value) {
+  const cfg = COLLECTION_KINDS[kind];
+  if (!Array.isArray(data[kind])) data[kind] = [];
+  const idOf = (x) => String(x[cfg.idField] ?? x.id);
+  const id = idOf(value);
+  const idx = data[kind].findIndex((x) => x != null && idOf(x) === id);
+  if (idx >= 0) data[kind][idx] = value;
+  else data[kind].push(value);
+}
+
+// Apply one pulled row, merging it into `data`. Returns an array of entityIds
+// the device should re-mark dirty (re-push). This is non-empty only for a bundle
+// whose per-key/union merge left our local copy richer than the row we pulled:
+// because the vault stores ONE row per entityId (upsert, last-write-wins), a
+// device that pushes before pulling clobbers the other device's concurrent
+// bundle edit at the vault. Re-pushing the merged superset is what lets union /
+// key-recency bundles still converge at the vault (mirrors the file-tier
+// `remoteChanged` → "remote needs this" flag in merge.js). It terminates: once
+// the vault holds the full superset, the merge changes nothing and no re-push
+// is emitted. Collections and per-date dailyNotes never need this — independent
+// edits there already land on distinct entityIds.
+export function applyRemoteEntity(data, entity) {
+  const kind = entityKind(entity);
+  if (COLLECTION_KINDS[kind]) {
+    upsertCollection(data, kind, entity.value);
+    return [];
+  }
+  if (kind === DATE_MAP_KIND) {
+    if (!data[DATE_MAP_KIND] || typeof data[DATE_MAP_KIND] !== 'object') data[DATE_MAP_KIND] = {};
+    data[DATE_MAP_KIND][entity._key] = entity.value;
+    return [];
+  }
+  if (kind === SINGLETON_KIND) {
+    const key = entity._key;
+    mergeBundle(data, key, entity.value, entity._extra || {});
+    if (DEVICE_LOCAL_BUNDLES.has(key)) return []; // kept local, never re-pushed
+    const merged = makeSingletonEntity(data, key);
+    const same = deepEqual(merged.value, entity.value) && deepEqual(merged._extra || {}, entity._extra || {});
+    return same ? [] : [makeEntityId(SINGLETON_KIND, key)];
+  }
+  return [];
+}
+
+export function applyRemoteDelete(data, entityId) {
+  const [kind, id] = splitEntityId(entityId);
+  if (COLLECTION_KINDS[kind]) {
+    const cfg = COLLECTION_KINDS[kind];
+    data[kind] = (data[kind] || []).filter((x) => x == null || String(x[cfg.idField] ?? x.id) !== id);
+  } else if (kind === DATE_MAP_KIND) {
+    if (data[DATE_MAP_KIND]) delete data[DATE_MAP_KIND][id];
+  }
+  // singletons are never row-deleted
+}
+
+// ── Per-bundle merge: the spec-5.3 fix. Each bundle merges by its own strategy
+// so concurrent edits to DIFFERENT entries are never lost. See the strategy
+// table in docs/glancevault-stage2.md.
+const MERGE = {
+  // {key → ISO}: keep the newer timestamp per key (grow-only set-union).
+  unionNewerIso(local = {}, remote = {}) {
+    const out = { ...local };
+    for (const [k, v] of Object.entries(remote)) out[k] = newerIso(out[k], v);
+    return out;
+  },
+  // {routineId → 'YYYY-MM-DD'}: union, keep the later date per key.
+  unionLaterDate(local = {}, remote = {}) {
+    const out = { ...local };
+    for (const [k, v] of Object.entries(remote)) out[k] = (out[k] && out[k] > v) ? out[k] : v;
+    return out;
+  },
+  // string[]: set-union (grow-only).
+  unionArray(local = [], remote = []) {
+    return [...new Set([...(local || []), ...(remote || [])])];
+  },
+};
+
+const TOMBSTONE_BUNDLES = new Set([
+  'deletedTaskIds', 'deletedRoutineChipIds', 'deletedFrameIds', 'removedTodayRoutineIds',
+  'deletedHabitIds', 'deletedGoalIds', 'deletedProjectIds',
+]);
+// Device-local prefs: the file-tier merge keeps the local value (merge.js:900-901
+// / weather not in merge output), so a pulled value never overwrites it. Listed
+// so the default branch doesn't LWW-clobber them.
+const DEVICE_LOCAL_BUNDLES = new Set([
+  'minimizedSections', 'use24HourClock', 'weatherZip', 'weatherTempUnit', 'multiUserEnabled',
+]);
+
+function mergeBundle(data, key, value, extra) {
+  if (TOMBSTONE_BUNDLES.has(key)) {
+    data[key] = MERGE.unionNewerIso(data[key] || {}, value || {});
+    return;
+  }
+  switch (key) {
+    case 'habitLogs': {
+      // per-(date,habitId) recency merge; timestamps ride in _extra so the merge
+      // is self-contained and order-independent.
+      const res = mergeHabitLogs(
+        data.habitLogs || {}, value || {},
+        data.habitLogTimestamps || {}, extra.habitLogTimestamps || {},
+      );
+      data.habitLogs = res.merged;
+      data.habitLogTimestamps = res.mergedTimestamps;
+      return;
+    }
+    case 'routineDefinitions': {
+      // per-chip merge, claim-aware, respecting chip tombstones (which converge
+      // separately as their own union bundle).
+      const res = mergeRoutineDefinitions(
+        data.routineDefinitions || {}, value || {}, data.deletedRoutineChipIds || {},
+      );
+      data.routineDefinitions = res.merged;
+      return;
+    }
+    case 'routineCompletions':
+      data.routineCompletions = MERGE.unionLaterDate(data.routineCompletions || {}, value || {});
+      return;
+    case 'completedTaskUids':
+      data.completedTaskUids = MERGE.unionArray(data.completedTaskUids || [], value || []);
+      return;
+    case 'routinesDate':
+      data.routinesDate = (data.routinesDate && data.routinesDate > value) ? data.routinesDate : value;
+      return;
+    case 'unscheduledOrderTimestamp':
+    case 'tombstonePrunedBefore':
+      data[key] = newerIso(data[key], value);
+      return;
+    case 'syncUrl':
+    case 'taskCalendarUrl':
+      // prefer a non-empty value; don't let an unconfigured device clear a URL
+      // (mirrors merge.js:810-815).
+      data[key] = value || data[key] || '';
+      return;
+    case 'habitsEnabled':
+    case 'routinesEnabled':
+    case 'goalsProjectsEnabled': {
+      const tsKey = `${key}UpdatedAt`;
+      data[key] = pickByTs(data[key], data[tsKey], value, extra[tsKey]);
+      data[tsKey] = newerIso(data[tsKey], extra[tsKey]);
+      return;
+    }
+    case 'obsidianConfig': {
+      data.obsidianConfig = pickByTs(data.obsidianConfig, data.obsidianConfigUpdatedAt, value, extra.obsidianConfigUpdatedAt);
+      data.obsidianConfigUpdatedAt = newerIso(data.obsidianConfigUpdatedAt, extra.obsidianConfigUpdatedAt);
+      return;
+    }
+    default:
+      if (DEVICE_LOCAL_BUNDLES.has(key)) return; // keep local
+      // Unknown bundle: fall back to LWW overwrite, but make it visible so a new
+      // bundle type isn't silently subjected to a loss window.
+      // eslint-disable-next-line no-console
+      console.warn(`[dbAdapter] bundle '${key}' has no merge strategy — LWW overwrite (possible loss window)`);
+      data[key] = value;
+  }
+}
+
+// ── Cross-list reconciliation (spec 5.2). A task can be live under more than one
+// kind after concurrent moves on two devices. Keep exactly one copy — newest
+// lastModified, ties broken by CROSS_LIST_PRIORITY — and report each removed
+// copy via onLoser so the caller can soft-delete its stale ${kind}:${id} row,
+// converging the vault. Deterministic, so every device picks the same winner.
+export function reconcileCrossList(data, onLoser) {
+  const byId = new Map();
+  for (const kind of TASK_KINDS) {
+    for (const item of (data[kind] || [])) {
+      if (item == null) continue;
+      const id = String(item.id);
+      if (!byId.has(id)) byId.set(id, []);
+      byId.get(id).push({ kind, item });
+    }
+  }
+  for (const [id, entries] of byId) {
+    if (entries.length < 2) continue;
+    entries.sort((a, b) => {
+      const d = ts(b.item.lastModified) - ts(a.item.lastModified);
+      if (d !== 0) return d;
+      return CROSS_LIST_PRIORITY.indexOf(a.kind) - CROSS_LIST_PRIORITY.indexOf(b.kind);
+    });
+    for (const loser of entries.slice(1)) {
+      data[loser.kind] = (data[loser.kind] || []).filter((x) => String(x.id) !== id);
+      if (onLoser) onLoser(makeEntityId(loser.kind, id));
+    }
+  }
 }

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -1,0 +1,198 @@
+// dayGLANCE → GLANCEvault entity-to-row adapter (cutover STAGE 1 of 2).
+//
+// NON-DESTRUCTIVE. This module is pure shred/reassemble logic. It performs no
+// network I/O, touches no transport, writes nothing to a real server, and is
+// not yet wired into App.jsx. It exists so stage 1 can prove that dayGLANCE's
+// full sync payload is losslessly representable as the row-grained rows the
+// GLANCEvault DB engine (createDbSyncEngine, @glance-apps/sync@1.3.2) exchanges.
+//
+// It mirrors lastGLANCE's src/sync/dbEngine.ts mapping (getLocalEntity /
+// applyRemoteEntity / isInsertOnly / getEntityLastModified) with ONE deliberate
+// divergence, forced by dayGLANCE's data model:
+//
+//   The reference derives entity kind by STRUCTURAL SNIFFING of field names
+//   (entityKind), because lastGLANCE had only 4 well-separated types. dayGLANCE
+//   has a dozen-plus types and five of them — tasks, unscheduledTasks,
+//   recurringTasks, recycleBin, todayRoutines — are the IDENTICAL task shape
+//   (App.jsx stamps all five through the same stampTaskTimestamps path,
+//   useDataPersistence.js:177-181). No structural sniff can tell a scheduled
+//   task from an inbox task from a today-routine: they carry the same fields.
+//   So this adapter carries an EXPLICIT `_kind` discriminator INSIDE the
+//   encrypted envelope and routes on it. encryptEntity (dbCrypto.js:274)
+//   JSON-stringifies the whole entity before AES-GCM, so `_kind` is sealed in
+//   the per-entity ciphertext — the server still sees only opaque bytes, so the
+//   transport stays zero-knowledge. See docs/glancevault-stage1.md for the full
+//   discrimination decision and proof.
+//
+// SCOPING (rule 4 of the stage-1 brief): this is a faithful TRANSPORT shred,
+// NOT a data-model change. Bundled structures keep their current shape —
+// recurringTasks.completedDates stays an array inside its row, habitLogs stays
+// a keyed map carried whole in a single row. Finer per-completion remodeling is
+// a separate future enhancement and is intentionally NOT done here.
+
+// ── Collection kinds: each ARRAY element becomes one row, keyed by a stable id.
+// idField  — the row's stable entityId source (the same id the file-tier merge
+//            keys on in @glance-apps/sync merge.js).
+// tsField  — the entity-grain last-writer-wins tiebreaker the merge compares.
+//            Evidence (file:line) is tabulated in docs/glancevault-stage1.md.
+export const COLLECTION_KINDS = {
+  // Task-shaped lists. All five share { id, title, duration, color, completed,
+  // lastModified, ... }; only `_kind` distinguishes them on the wire.
+  tasks:            { idField: 'id',     tsField: 'lastModified' },
+  unscheduledTasks: { idField: 'id',     tsField: 'lastModified' },
+  recurringTasks:   { idField: 'id',     tsField: 'lastModified' }, // completedDates[] stays inside the row
+  recycleBin:       { idField: 'id',     tsField: 'lastModified' },
+  todayRoutines:    { idField: 'id',     tsField: 'lastModified' },
+  // Non-task collections.
+  habits:           { idField: 'id',     tsField: 'lastModified' }, // falls back to createdAt (merge.js:299)
+  goals:            { idField: 'id',     tsField: 'updatedAt'    },
+  projects:         { idField: 'id',     tsField: 'updatedAt'    },
+  gtdFrames:        { idField: 'id',     tsField: 'lastModified' },
+  users:            { idField: 'syncId', tsField: 'updatedAt'    }, // falls back to id (merge.js:843)
+};
+
+// dailyNotes is a MAP keyed by 'YYYY-MM-DD' → { text, lastModified, deleted? }.
+// The merge resolves it per-date (merge.js:217), so each date is its own row.
+export const DATE_MAP_KIND = 'dailyNotes';
+
+// Wire `_kind` value for every other top-level payload key — the bundles and
+// scalar/config values that have no per-item id and must NOT be split into
+// finer rows (rule 4). Each becomes exactly one singleton row.
+export const SINGLETON_KIND = 'singleton';
+
+// Entity kinds that are insert-only (immutable, never collide on merge). In the
+// reference these are completionEvents. dayGLANCE has NONE in stage 1: completion
+// remodeling is explicitly out of scope (rule 4), so every kind mutable-upserts
+// at its grain.
+const INSERT_ONLY_KINDS = new Set();
+
+// ── Read the discriminator the engine routes on (replaces the reference's
+// structural entityKind sniff). The kind is an explicit field, never inferred.
+export function entityKind(entity) {
+  if (!entity || typeof entity !== 'object') return null;
+  return typeof entity._kind === 'string' ? entity._kind : null;
+}
+
+// ── isInsertOnly: engine callback. Stage 1 has no insert-only per-item type.
+export function isInsertOnly(entity) {
+  return INSERT_ONLY_KINDS.has(entityKind(entity));
+}
+
+// ── getEntityLastModified: engine callback. Entity-grain LWW tiebreaker.
+// Reads the per-kind tsField from the wrapped value. Singletons/date-map rows
+// surface a best-effort timestamp where the bundle carries one, else undefined
+// (flagged in the stampTaskTimestamps / dirtiness report — some bundles have no
+// timestamp; that is a known stage-2 concern, not a losslessness blocker).
+export function getEntityLastModified(entity) {
+  const kind = entityKind(entity);
+  if (!kind) return undefined;
+  const value = entity.value;
+  if (kind === DATE_MAP_KIND) {
+    return value && typeof value === 'object' ? value.lastModified : undefined;
+  }
+  if (kind === SINGLETON_KIND) {
+    // Bundles rarely carry their own timestamp. The *enabled flags travel with a
+    // sibling *UpdatedAt singleton; obsidianConfig likewise. Surface a string
+    // value when the bundle itself is an ISO stamp (e.g. tombstonePrunedBefore),
+    // otherwise undefined — the engine treats undefined as epoch-0.
+    return typeof value === 'string' ? value : undefined;
+  }
+  const cfg = COLLECTION_KINDS[kind];
+  if (!cfg || !value || typeof value !== 'object') return undefined;
+  return value[cfg.tsField]
+    ?? value.lastModified
+    ?? value.updatedAt
+    ?? value.createdAt;
+}
+
+// ── entityId scheme. The kind is ALWAYS part of the id so two different kinds
+// that share a numeric id never collide on one vault row. This matters for
+// dayGLANCE specifically: a task mid cross-list move exists in BOTH `tasks` and
+// `unscheduledTasks` with the SAME id (the file-tier merge reconciles that —
+// merge.js:556-601). Keyed by `${kind}:${id}` those become two distinct rows,
+// which is exactly what losslessness requires (both copies survive the
+// roundtrip). Stage 2 must apply the same cross-list reconciliation on pull.
+export function makeEntityId(kind, id) {
+  return `${kind}:${id}`;
+}
+
+// Build one wire row. `entity` is the plaintext object handed to encryptEntity;
+// it wraps the original value so the user payload is never polluted with adapter
+// fields and round-trips byte-for-byte. `_kind`/`_key` live alongside `value`,
+// all sealed inside the per-entity ciphertext.
+function makeRow(kind, entityId, value, extra = {}) {
+  return { entityId, kind, entity: { _kind: kind, ...extra, value } };
+}
+
+/**
+ * SHRED: full payload `.data` → array of rows.
+ *
+ * @param {object} data - the `.data` object from buildSyncPayload (App.jsx:5382)
+ * @returns {Array<{ entityId: string, kind: string, entity: object }>}
+ */
+export function shredState(data) {
+  if (!data || typeof data !== 'object') return [];
+  const rows = [];
+  const handled = new Set([DATE_MAP_KIND]);
+
+  // Per-item collection rows.
+  for (const [kind, cfg] of Object.entries(COLLECTION_KINDS)) {
+    handled.add(kind);
+    const arr = Array.isArray(data[kind]) ? data[kind] : [];
+    for (const item of arr) {
+      const id = item == null ? undefined : (item[cfg.idField] ?? item.id);
+      rows.push(makeRow(kind, makeEntityId(kind, id), item));
+    }
+  }
+
+  // dailyNotes: one row per date key.
+  const notes = data[DATE_MAP_KIND];
+  if (notes && typeof notes === 'object') {
+    for (const dateKey of Object.keys(notes)) {
+      rows.push(makeRow(DATE_MAP_KIND, makeEntityId(DATE_MAP_KIND, dateKey), notes[dateKey], { _key: dateKey }));
+    }
+  }
+
+  // Everything else (bundles + scalar/config) → one singleton row each, carried
+  // in its CURRENT shape. Iterating every remaining key guarantees no field is
+  // dropped even if the payload gains a key the registry above doesn't name.
+  for (const key of Object.keys(data)) {
+    if (handled.has(key)) continue;
+    rows.push(makeRow(SINGLETON_KIND, makeEntityId(SINGLETON_KIND, key), data[key], { _key: key }));
+  }
+
+  return rows;
+}
+
+/**
+ * REASSEMBLE: rows → full payload `.data`.
+ *
+ * Reconstructs the canonical skeleton (every collection key present, even when
+ * empty — buildSyncPayload always emits all of them) and routes each row by its
+ * explicit `_kind`. Order within a collection follows row order.
+ *
+ * @param {Array<{ entity: object }>} rows
+ * @returns {object} the rebuilt `.data`
+ */
+export function reassembleState(rows) {
+  const data = {};
+  // Canonical skeleton: every collection is always present in buildSyncPayload.
+  for (const kind of Object.keys(COLLECTION_KINDS)) data[kind] = [];
+  data[DATE_MAP_KIND] = {};
+
+  for (const row of rows || []) {
+    const entity = row && row.entity;
+    const kind = entityKind(entity);
+    if (kind === SINGLETON_KIND) {
+      data[entity._key] = entity.value;
+    } else if (kind === DATE_MAP_KIND) {
+      data[DATE_MAP_KIND][entity._key] = entity.value;
+    } else if (COLLECTION_KINDS[kind]) {
+      data[kind].push(entity.value);
+    } else {
+      throw new Error(`reassembleState: unroutable row _kind=${JSON.stringify(kind)}`);
+    }
+  }
+
+  return data;
+}

--- a/src/sync/dbAdapter.losslessness.test.js
+++ b/src/sync/dbAdapter.losslessness.test.js
@@ -215,11 +215,14 @@ describe('dbAdapter losslessness gate', () => {
     expect(logRows[0].entity.value['2026-06-18']).toEqual({ 7101: 4, 7102: 1 });
   });
 
-  it('routes every row by explicit _kind, and marks no kind insert-only in stage 1', () => {
+  it('routes every row by explicit _kind; bundles are insert-only, collections are LWW', () => {
     const rows = shredState(buildFixture());
     for (const r of rows) {
       expect(entityKind(r.entity)).toBe(r.kind);
-      expect(isInsertOnly(r.entity)).toBe(false);
+      // Stage 2: singleton bundles are insert-only (always merged on pull) so a
+      // concurrent edit to a different bundle entry is never lost. Per-item
+      // collections and per-date dailyNotes stay on entity-grain LWW.
+      expect(isInsertOnly(r.entity)).toBe(r.kind === 'singleton');
     }
   });
 

--- a/src/sync/dbAdapter.losslessness.test.js
+++ b/src/sync/dbAdapter.losslessness.test.js
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shredState,
+  reassembleState,
+  entityKind,
+  isInsertOnly,
+  getEntityLastModified,
+  COLLECTION_KINDS,
+  makeEntityId,
+} from './dbAdapter.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// STAGE 1 LOSSLESSNESS GATE
+//
+// Takes a representative full dayGLANCE sync payload `.data` (every synced
+// entity type, in the shape buildSyncPayload emits at App.jsx:5382), shreds it
+// to rows via the adapter, simulates the wire (per-entity JSON serialization,
+// exactly what encryptEntity/decryptEntity do — dbCrypto.js:274/300), reassembles
+// from those rows, and deep-diffs against the original. Must be value-identical
+// modulo key ordering.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Key-order-independent deep equality that treats `undefined` and an absent key
+// as the same (JSON drops undefined; the merge engine never distinguishes them).
+function deepEqualUnordered(a, b, path = '$') {
+  if (a === b) return { equal: true };
+  if (typeof a !== typeof b) return { equal: false, path, a, b };
+  if (a === null || b === null) return { equal: false, path, a, b };
+  if (typeof a !== 'object') return a === b ? { equal: true } : { equal: false, path, a, b };
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return { equal: false, path, a, b };
+    if (a.length !== b.length) return { equal: false, path: `${path}.length`, a: a.length, b: b.length };
+    for (let i = 0; i < a.length; i++) {
+      const r = deepEqualUnordered(a[i], b[i], `${path}[${i}]`);
+      if (!r.equal) return r;
+    }
+    return { equal: true };
+  }
+
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const k of keys) {
+    const av = a[k];
+    const bv = b[k];
+    if (av === undefined && bv === undefined) continue; // undefined ≡ absent
+    const r = deepEqualUnordered(av, bv, `${path}.${k}`);
+    if (!r.equal) return r;
+  }
+  return { equal: true };
+}
+
+const ts = (minsAgo) => new Date(Date.now() - minsAgo * 60000).toISOString();
+
+// A task-shaped item (the shared shape of tasks/unscheduledTasks/recurringTasks/
+// recycleBin/todayRoutines). Mirrors the T() fixture in mergeSync.test.js plus
+// the app-only fields buildSyncPayload preserves (subtasks, notes, projectId…).
+const task = (id, title, lastModified, extra = {}) => ({
+  id, title, duration: 30, color: 'bg-blue-500', completed: false,
+  notes: '', subtasks: [], lastModified, ...extra,
+});
+
+// A realistic full payload `.data`. Every synced key present, with edge cases:
+// nested subtasks, a recurringTask.completedDates array, a deleted dailyNote
+// tombstone, a same-id task in both `tasks` and `unscheduledTasks` (cross-list
+// move state), claimed routine chips, and the keyed habitLogs/timestamps maps.
+function buildFixture() {
+  return {
+    tasks: [
+      task(1001, 'Standup', ts(120), { date: '2026-06-18', startTime: '09:00' }),
+      task(1002, 'Write report', ts(30), {
+        date: '2026-06-18', startTime: '14:00', projectId: 7001, deadline: '2026-06-20',
+        notes: 'draft + review', subtasks: [
+          { id: 'st1', title: 'outline', completed: true },
+          { id: 'st2', title: 'prose', completed: false },
+        ],
+      }),
+      // Same id 1003 also appears in unscheduledTasks below — a cross-list move
+      // state the file-tier merge reconciles (merge.js:556). Both copies must
+      // survive the roundtrip as distinct rows.
+      task(1003, 'Ambiguous list item', ts(15), { date: '2026-06-18' }),
+    ],
+    unscheduledTasks: [
+      task(2001, 'Buy milk', ts(40), { projectId: 7001 }),
+      task(1003, 'Ambiguous list item', ts(10)),
+    ],
+    unscheduledOrderTimestamp: ts(10),
+    recurringTasks: [
+      {
+        id: 3001, title: 'Water plants', duration: 10, color: 'bg-green-500',
+        completed: false, lastModified: ts(200),
+        recurrence: { type: 'weekly', days: ['mon', 'thu'] },
+        startTime: '08:00',
+        completedDates: ['2026-06-11', '2026-06-15', '2026-06-18'], // array stays inside the row
+      },
+    ],
+    recycleBin: [
+      { ...task(4001, 'Deleted thing', ts(500)), deletedAt: ts(60), _deletedFrom: 'calendar' },
+    ],
+    syncUrl: 'https://dav.example.com/cal/',
+    taskCalendarUrl: 'https://dav.example.com/tasks/',
+    completedTaskUids: ['uid-abc::2026-06-17', 'uid-def::2026-06-18'],
+    routineDefinitions: {
+      monday: [
+        { id: 5001, name: 'Workout', lastModified: ts(300) },
+        { id: 5002, name: 'Journal', ownerSyncId: 'user-jason', lastModified: ts(120) },
+      ],
+      thursday: [{ id: 5003, name: 'Review', lastModified: ts(90) }],
+    },
+    todayRoutines: [
+      task(5001, 'Workout', ts(50), { isRoutine: true }),
+    ],
+    routinesDate: '2026-06-18',
+    routineCompletions: { 5001: '2026-06-18' },
+    minimizedSections: { inbox: true, habits: false },
+    use24HourClock: true,
+    weatherZip: '60601',
+    weatherTempUnit: 'F',
+    deletedTaskIds: { 9001: ts(1000), 9002: ts(2000) },
+    deletedRoutineChipIds: { 5099: ts(800) },
+    deletedFrameIds: { 6099: ts(700) },
+    removedTodayRoutineIds: { 5003: ts(600) },
+    dailyNotes: {
+      '2026-06-17': { text: 'shipped v3.4', lastModified: ts(400) },
+      '2026-06-16': { text: '', lastModified: ts(900), deleted: true }, // tombstone entry
+    },
+    habits: [
+      { id: 7101, name: 'Water', icon: '💧', createdAt: ts(5000), lastModified: ts(300), archived: false },
+      { id: 7102, name: 'Read', createdAt: ts(6000), archived: true }, // no lastModified → createdAt fallback
+    ],
+    habitLogs: {
+      '2026-06-18': { 7101: 4, 7102: 1 },
+      '2026-06-17': { 7101: 6 },
+    },
+    habitLogTimestamps: {
+      '2026-06-18:7101': ts(20), '2026-06-18:7102': ts(25), '2026-06-17:7101': ts(1500),
+    },
+    habitsEnabled: true,
+    habitsEnabledUpdatedAt: ts(5000),
+    deletedHabitIds: { 7199: ts(900) },
+    routinesEnabled: true,
+    routinesEnabledUpdatedAt: ts(5000),
+    gtdFrames: [
+      { id: 8001, title: 'Health', lastModified: ts(700), color: 'bg-red-500' },
+      { id: 8002, title: 'Work', lastModified: ts(650) },
+    ],
+    goals: [
+      { id: 9101, title: 'Run a marathon', updatedAt: ts(800), frameId: 8001, progress: 0.3 },
+    ],
+    deletedGoalIds: { 9199: ts(950) },
+    projects: [
+      { id: 7001, title: 'Q3 launch', updatedAt: ts(60), goalId: 9101, hyperglance: { enabled: false } },
+    ],
+    deletedProjectIds: { 7099: ts(990) },
+    goalsProjectsEnabled: true,
+    goalsProjectsEnabledUpdatedAt: ts(5000),
+    obsidianConfig: { taskHeading: '## Tasks', dailyNoteTemplate: 'tpl', newNotesFolder: 'Notes' },
+    obsidianConfigUpdatedAt: ts(5000),
+    multiUserEnabled: true,
+    multiUserEnabledUpdatedAt: ts(5000),
+    users: [
+      { id: 'u1', syncId: 'u1', name: 'Jason', updatedAt: ts(5000), color: 'bg-blue-500' },
+      { id: 'u2', syncId: 'u2', name: 'Maggie', updatedAt: ts(4000) },
+    ],
+    tombstonePrunedBefore: ts(129600), // 90 days
+  };
+}
+
+// Simulate the GLANCEvault wire: each entity is JSON-serialized into the
+// ciphertext on push and JSON-parsed on pull (dbCrypto.js encryptEntity/
+// decryptEntity). Running the rows through JSON proves nested structures and
+// keyed maps survive serialization, not just object-reference passthrough.
+function throughWire(rows) {
+  return rows.map(r => ({ ...r, entity: JSON.parse(JSON.stringify(r.entity)) }));
+}
+
+describe('dbAdapter losslessness gate', () => {
+  it('round-trips a full payload value-identically (modulo key order)', () => {
+    const original = buildFixture();
+    const rows = shredState(original);
+    const wired = throughWire(rows);
+    const rebuilt = reassembleState(wired);
+
+    const diff = deepEqualUnordered(original, rebuilt);
+    if (!diff.equal) {
+      // Surface the exact non-round-tripping field for the report.
+      // eslint-disable-next-line no-console
+      console.error('LOSSLESSNESS FAIL at', diff.path, 'original=', diff.a, 'rebuilt=', diff.b);
+    }
+    expect(diff).toEqual({ equal: true });
+  });
+
+  it('produces a unique entityId for every row (zero collisions)', () => {
+    const rows = shredState(buildFixture());
+    const ids = rows.map(r => r.entityId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('keeps a cross-list same-id task as two distinct rows', () => {
+    const rows = shredState(buildFixture());
+    expect(rows.some(r => r.entityId === makeEntityId('tasks', 1003))).toBe(true);
+    expect(rows.some(r => r.entityId === makeEntityId('unscheduledTasks', 1003))).toBe(true);
+  });
+
+  it('keeps recurringTasks.completedDates as an array inside the row (rule 4)', () => {
+    const rows = shredState(buildFixture());
+    const row = rows.find(r => r.entityId === makeEntityId('recurringTasks', 3001));
+    expect(Array.isArray(row.entity.value.completedDates)).toBe(true);
+    expect(row.entity.value.completedDates).toEqual(['2026-06-11', '2026-06-15', '2026-06-18']);
+  });
+
+  it('keeps habitLogs as a single keyed-map row (rule 4, not per-completion rows)', () => {
+    const rows = shredState(buildFixture());
+    const logRows = rows.filter(r => r.entity._kind === 'singleton' && r.entity._key === 'habitLogs');
+    expect(logRows).toHaveLength(1);
+    expect(logRows[0].entity.value['2026-06-18']).toEqual({ 7101: 4, 7102: 1 });
+  });
+
+  it('routes every row by explicit _kind, and marks no kind insert-only in stage 1', () => {
+    const rows = shredState(buildFixture());
+    for (const r of rows) {
+      expect(entityKind(r.entity)).toBe(r.kind);
+      expect(isInsertOnly(r.entity)).toBe(false);
+    }
+  });
+
+  it('surfaces the per-kind LWW tiebreaker for collection rows', () => {
+    const rows = shredState(buildFixture());
+    const taskRow = rows.find(r => r.entityId === makeEntityId('tasks', 1001));
+    expect(getEntityLastModified(taskRow.entity)).toBe(taskRow.entity.value.lastModified);
+    const goalRow = rows.find(r => r.entityId === makeEntityId('goals', 9101));
+    expect(getEntityLastModified(goalRow.entity)).toBe(goalRow.entity.value.updatedAt);
+    const userRow = rows.find(r => r.entityId === makeEntityId('users', 'u1'));
+    expect(getEntityLastModified(userRow.entity)).toBe(userRow.entity.value.updatedAt);
+    // habit with no lastModified falls back to createdAt.
+    const habitRow = rows.find(r => r.entityId === makeEntityId('habits', 7102));
+    expect(getEntityLastModified(habitRow.entity)).toBe(habitRow.entity.value.createdAt);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DISCRIMINATION PROOF
+//
+// Demonstrates WHY an explicit `_kind` is required: a reference-style structural
+// sniff (field-name inspection) cannot separate dayGLANCE's five task-shaped
+// collections, but `_kind` resolves all of them with zero collisions.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('discrimination: structural sniff vs explicit _kind', () => {
+  // A best-effort structural sniff in the spirit of the reference's entityKind.
+  // It can only see field names, so the five task-shaped kinds are invisible to it.
+  function structuralSniff(item) {
+    if (!item || typeof item !== 'object') return null;
+    if ('completedDates' in item) return 'recurringTasks'; // distinguishable
+    if ('deletedAt' in item) return 'recycleBin';          // distinguishable
+    if ('goalId' in item) return 'projects';
+    if ('frameId' in item && 'progress' in item) return 'goals';
+    if ('syncId' in item && 'name' in item) return 'users';
+    // tasks / unscheduledTasks / todayRoutines share { id,title,duration,color,
+    // completed,lastModified } — no field tells them apart.
+    if ('title' in item && 'duration' in item) return 'task-shaped (AMBIGUOUS)';
+    return null;
+  }
+
+  it('structural sniff CANNOT separate tasks / unscheduledTasks / todayRoutines', () => {
+    const fx = buildFixture();
+    const scheduled = fx.tasks[0];
+    const inbox = fx.unscheduledTasks[0];
+    const todayRoutine = fx.todayRoutines[0];
+    // All three collapse to the same ambiguous bucket — a fragile sniff would
+    // misroute them on apply.
+    expect(structuralSniff(scheduled)).toBe('task-shaped (AMBIGUOUS)');
+    expect(structuralSniff(inbox)).toBe('task-shaped (AMBIGUOUS)');
+    expect(structuralSniff(todayRoutine)).toBe('task-shaped (AMBIGUOUS)');
+  });
+
+  it('explicit _kind resolves ALL kinds with zero collisions', () => {
+    const rows = shredState(buildFixture());
+    const kinds = new Set(rows.map(r => entityKind(r.entity)));
+    // Every collection kind that has data, plus dailyNotes + singleton, is present
+    // and unambiguous; reassemble routes 100% of rows (asserted by the gate test
+    // above succeeding). Here we assert the five task-shaped kinds are all
+    // distinctly represented despite identical structure.
+    for (const k of ['tasks', 'unscheduledTasks', 'recurringTasks', 'recycleBin', 'todayRoutines']) {
+      expect(kinds.has(k)).toBe(true);
+    }
+    // No row is ever the ambiguous bucket the structural sniff produced.
+    expect([...kinds].every(k => k === 'singleton' || k === 'dailyNotes' || k in COLLECTION_KINDS)).toBe(true);
+  });
+});

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -108,14 +108,23 @@ export function createDbEngine(callbacks = {}) {
   // In-flight guard so a debounced push never overlaps a cadence-triggered cycle.
   let syncing = false;
 
-  // dayGLANCE composes its own cycle as PULL-then-PUSH (the engine's built-in
-  // dbSyncCycle is push-then-pull). Pull-first matters here: the engine advances
-  // its high-water mark on push (dbEngine.js:225), so a device that pushes before
-  // pulling would skip rows written below its new cursor and never see them.
-  // Pulling first means we always read up to the current head, merge it into the
-  // mirror, then push the merged superset — so the HWM only ever advances past
-  // rows we have actually seen. It also lets bundle merges push the merged value
-  // in the same cycle rather than waiting for a re-push next cycle.
+  // dayGLANCE wraps the engine's push/pull steps in its own cycle so it can
+  // (1) seed the dirty set by diffing app state into the mirror, (2) commit the
+  // merged mirror back to React/localStorage ONLY on success, and (3) run
+  // cross-list reconcile + snapshot. This wrapper is required regardless of the
+  // package version — it is the bridge between the engine and dayGLANCE's
+  // non-Dexie state, not a transport workaround.
+  //
+  // Cycle ORDER is pull-then-push. As of @glance-apps/sync 1.4.0 this is NOT a
+  // correctness requirement and NOT a data-loss mitigation: the engine split the
+  // cursor so a push never advances the pull cursor (getHighWaterMark is
+  // pull-only; getPushAck tracks push idempotency), making push-then-pull and
+  // pull-then-push equally safe. We keep pull-first only for marginal freshness —
+  // merging remote before the push lets a bundle superset and any cross-list
+  // reconcile flush in the SAME cycle instead of the next one. It is free, since
+  // we compose the cycle from pullRemoteChanges/pushDirtyRows anyway to get
+  // commit-only-on-success (the engine's own dbSyncCycle swallows errors, which
+  // would let a failed cycle commit a partial mirror).
   const dbSyncCycle = async () => {
     if (typeof callbacks.getData !== 'function') return;
     if (syncing) return;

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -1,0 +1,159 @@
+// dayGLANCE GLANCEvault DB engine wrapper (mirrors lastGLANCE
+// src/sync/dbEngine.ts createDbEngine). Constructs @glance-apps/sync's
+// createDbSyncEngine with dayGLANCE's entity↔row adapter, returning null when the
+// vault is disabled so the whole DB path is inert. Additive and reversible: it
+// shares the local data and sync passphrase with the file tier but never touches
+// the WebDAV sync file.
+//
+// Two dayGLANCE-specific concerns the reference handles differently:
+//
+//  1. Dirty tracking. lastGLANCE calls markDirty at each Dexie write site
+//     (queries.ts). dayGLANCE has no such data layer — it holds state in React +
+//     localStorage and commits via one save path. So instead of annotating
+//     hundreds of call sites, this wrapper computes the dirty set by DIFFING the
+//     current shred against a persisted snapshot at cycle time. That captures
+//     exactly the entities that changed (and, by absence, the ones deleted →
+//     soft-delete), which is what markDirty-at-write-sites would have produced.
+//     dirtyTracker.schedulePush still gives prompt push-on-write; this diff is
+//     what decides *which* rows move.
+//
+//  2. Apply target. Remote applies mutate a per-cycle data MIRROR, never the
+//     React/localStorage state directly, and the merged mirror is handed to
+//     commitData once per cycle. commitData writes through the app's existing
+//     applyPayload (which sets the suppress flags), so a pulled row never bounces
+//     back out as a file-tier upload or a re-push.
+
+import { createDbSyncEngine } from '@glance-apps/sync';
+import { getVaultConfig, isVaultEnabled } from './vaultConfig.js';
+import { getDeviceId } from './deviceId.js';
+import {
+  shredState,
+  getLocalEntity as adapterGetLocalEntity,
+  applyRemoteEntity as adapterApplyRemoteEntity,
+  applyRemoteDelete as adapterApplyRemoteDelete,
+  isInsertOnly,
+  getEntityLastModified,
+  reconcileCrossList,
+} from './dbAdapter.js';
+
+const APP_ID = 'dayglance';
+const CRYPTO_DB_NAME = 'dayglance-db-crypto';
+
+const clone = (x) => (x == null ? x : JSON.parse(JSON.stringify(x)));
+const hashOf = (entity) => JSON.stringify(entity);
+
+// entityId → entity-hash for the whole current state. Used to diff for dirtiness.
+function snapshotShred(data) {
+  const map = {};
+  for (const row of shredState(data)) map[row.entityId] = hashOf(row.entity);
+  return map;
+}
+
+/**
+ * Build the dayGLANCE DB sync engine, or null when the vault is disabled.
+ *
+ * @param {object} callbacks
+ * @param {() => object}        callbacks.getData      - current payload `.data` (e.g. buildSyncPayload().data)
+ * @param {(data:object)=>void} callbacks.commitData   - write merged `.data` back (e.g. applyPayload)
+ * @param {(s:string)=>void}   [callbacks.onStatusChange]
+ * @param {(m:string,c:string)=>void} [callbacks.onError]
+ * @param {string}             [callbacks.storageKeyPrefix] - override (tests / multi-instance)
+ * @param {object}             [callbacks.vaultClient]      - injected client (tests)
+ * @param {Function}           [callbacks.nativeGetSyncKey]
+ * @param {Function}           [callbacks.nativeStoreSyncKey]
+ * @param {string}             [callbacks.deviceId]
+ */
+export function createDbEngine(callbacks = {}) {
+  if (!callbacks.vaultClient && !isVaultEnabled()) return null;
+  const cfg = getVaultConfig() || {};
+  const storageKeyPrefix = callbacks.storageKeyPrefix || 'dayglance-vault';
+  const SNAPSHOT_KEY = `${storageKeyPrefix}-db-sync-snapshot`;
+
+  const loadSnapshot = () => {
+    try { return JSON.parse(localStorage.getItem(SNAPSHOT_KEY) || '{}'); } catch { return {}; }
+  };
+  const saveSnapshot = (map) => {
+    try { localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(map)); } catch { /* ignore */ }
+  };
+
+  // Per-cycle data mirror the adapter callbacks operate on. Seeded from getData
+  // at the start of each cycle and committed at the end.
+  let mirror = {};
+
+  const engine = createDbSyncEngine({
+    storageKeyPrefix,
+    appId: APP_ID,
+    vaultApp: APP_ID,
+    cryptoDBName: CRYPTO_DB_NAME,
+    vaultUrl: cfg.vaultUrl,
+    vaultToken: cfg.vaultToken,
+    accountId: cfg.accountId,
+    deviceId: callbacks.deviceId || getDeviceId(),
+    vaultClient: callbacks.vaultClient,
+    nativeGetSyncKey: callbacks.nativeGetSyncKey || null,
+    nativeStoreSyncKey: callbacks.nativeStoreSyncKey || null,
+    getLocalEntity: (entityId) => adapterGetLocalEntity(mirror, entityId),
+    applyRemoteEntity: (entityId, entity) => {
+      // Bundle merges may leave us richer than the clobbered vault row; re-push
+      // the superset so it converges at the vault (see dbAdapter / stage-2 doc).
+      for (const id of adapterApplyRemoteEntity(mirror, entity)) engine.markDirty(id);
+    },
+    applyRemoteDelete: (entityId) => adapterApplyRemoteDelete(mirror, entityId),
+    isInsertOnly,
+    getEntityLastModified,
+    onStatusChange: callbacks.onStatusChange,
+    onError: callbacks.onError,
+  });
+
+  // In-flight guard so a debounced push never overlaps a cadence-triggered cycle.
+  let syncing = false;
+
+  // dayGLANCE composes its own cycle as PULL-then-PUSH (the engine's built-in
+  // dbSyncCycle is push-then-pull). Pull-first matters here: the engine advances
+  // its high-water mark on push (dbEngine.js:225), so a device that pushes before
+  // pulling would skip rows written below its new cursor and never see them.
+  // Pulling first means we always read up to the current head, merge it into the
+  // mirror, then push the merged superset — so the HWM only ever advances past
+  // rows we have actually seen. It also lets bundle merges push the merged value
+  // in the same cycle rather than waiting for a re-push next cycle.
+  const dbSyncCycle = async () => {
+    if (typeof callbacks.getData !== 'function') return;
+    if (syncing) return;
+    syncing = true;
+    callbacks.onError?.(null, null);
+    try {
+      mirror = clone(callbacks.getData()) || {};
+
+      // Seed the dirty set: full snapshot on first-ever sync, else the diff.
+      if (engine.getHighWaterMark() === 0) {
+        for (const row of shredState(mirror)) engine.markDirty(row.entityId);
+      } else {
+        const prev = loadSnapshot();
+        const cur = snapshotShred(mirror);
+        for (const [id, h] of Object.entries(cur)) if (prev[id] !== h) engine.markDirty(id);
+        for (const id of Object.keys(prev)) if (!(id in cur)) engine.markDirty(id); // deletes
+      }
+
+      callbacks.onStatusChange?.('downloading');
+      await engine.pullRemoteChanges();   // merge remote into mirror first
+      reconcileCrossList(mirror, (id) => engine.markDirty(id));
+      callbacks.onStatusChange?.('uploading');
+      await engine.pushDirtyRows();        // push merged superset + local changes
+      await engine.updateDeviceCursor();
+
+      callbacks.commitData?.(clone(mirror));
+      saveSnapshot(snapshotShred(mirror));
+      callbacks.onStatusChange?.('success');
+    } catch (err) {
+      const code = err && err.code ? err.code : 'NETWORK_ERROR';
+      callbacks.onError?.(err?.message || String(err), code);
+      callbacks.onStatusChange?.('error');
+    } finally {
+      syncing = false;
+    }
+  };
+
+  return { ...engine, dbSyncCycle, sync: dbSyncCycle };
+}
+
+export { APP_ID, CRYPTO_DB_NAME };

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, beforeAll, afterEach, afterAll, vi } from 'vitest';
-import { setSyncPassphrase } from '@glance-apps/sync';
+import { setSyncPassphrase, createDbSyncEngine } from '@glance-apps/sync';
 import { createDbEngine } from './dbEngine.js';
 import { getVaultConfig, setVaultConfig, isVaultEnabled } from './vaultConfig.js';
 import { getDeviceId } from './deviceId.js';
@@ -197,5 +197,80 @@ describe('Part B — end-to-end two-device sync via the REAL engine', () => {
       expect(inTasks).toBe(true);
       expect(inUnsched).toBe(false);
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1.4.0 cursor fix — targeted interleave test.
+//
+// Proves the residual race the package fix closed: a PUSH must not advance the
+// PULL cursor (getHighWaterMark) past a remote row the device has not yet read.
+// Under 1.3.2 the engine advanced a single shared HWM on push, so a remote row
+// whose seq sat below the device's freshly-pushed rows was skipped forever
+// (unrecoverable for insert-only rows). 1.4.0 split the cursor: getHighWaterMark
+// is pull-only, getPushAck tracks push idempotency.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('1.4.0 — push does not advance the pull cursor past an unread remote row', () => {
+  beforeEach(() => {
+    global.localStorage = memLocalStorage();
+    setSyncPassphrase('correct horse battery staple');
+  });
+
+  // A raw createDbSyncEngine over a flat entityId→entity map (no app adapter),
+  // so we can drive push/pull steps and inspect the cursors directly.
+  function makeRawEngine(name, vault) {
+    let nativeKey = null;
+    const data = {};
+    const engine = createDbSyncEngine({
+      storageKeyPrefix: `raw-${name}`,
+      appId: 'dayglance',
+      vaultApp: 'dayglance',
+      cryptoDBName: `raw-${name}-crypto`,
+      accountId: 'acct-raw',
+      vaultClient: vault,
+      deviceId: `raw-${name}`,
+      nativeGetSyncKey: () => nativeKey,
+      nativeStoreSyncKey: (v) => { nativeKey = v; },
+      getLocalEntity: (id) => (id in data ? data[id] : null),
+      applyRemoteEntity: (id, e) => { data[id] = e; },
+      applyRemoteDelete: (id) => { delete data[id]; },
+      isInsertOnly: () => false,
+      getEntityLastModified: (e) => e && e.lastModified,
+    });
+    return { engine, data };
+  }
+
+  it('A push (seqs > N+1) leaves the pull cursor at N, so the next pull still lists B@N+1', async () => {
+    const vault = createMemoryVault();
+    const A = makeRawEngine('A', vault);
+    const B = makeRawEngine('B', vault);
+
+    // Baseline: A writes a1 (seq 1) and pulls, so A's pull cursor sits at N = 1.
+    A.data['a1'] = { id: 'a1', lastModified: '2026-06-18T10:00:00.000Z' };
+    A.engine.markDirty('a1');
+    await A.engine.pushDirtyRows();      // a1 → seq 1
+    await A.engine.pullRemoteChanges();  // A pull cursor advances to 1
+    const N = A.engine.getHighWaterMark();
+    expect(N).toBe(1);
+
+    // B writes b1 at seq N+1 = 2 (A has NOT read it yet).
+    B.data['b1'] = { id: 'b1', lastModified: '2026-06-18T10:05:00.000Z' };
+    B.engine.markDirty('b1');
+    await B.engine.pushDirtyRows();      // b1 → seq 2 (= N+1)
+
+    // A pushes a new row, which the server assigns a seq ABOVE N+1 (seq 3).
+    A.data['a2'] = { id: 'a2', lastModified: '2026-06-18T10:10:00.000Z' };
+    A.engine.markDirty('a2');
+    await A.engine.pushDirtyRows();      // a2 → seq 3 (> N+1)
+
+    // The fix: A's push consumed nothing, so the PULL cursor is unchanged (still
+    // N); only the push-ack marker advanced.
+    expect(A.engine.getHighWaterMark()).toBe(N);
+    expect(A.engine.getPushAck()).toBeGreaterThanOrEqual(3);
+
+    // Therefore A's NEXT pull resumes from N and still lists B's row at N+1.
+    await A.engine.pullRemoteChanges();
+    expect(A.data['b1']).toBeTruthy();
+    expect(A.data['b1'].id).toBe('b1');
   });
 });

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, beforeAll, afterEach, afterAll, vi } from 'vitest';
+import { setSyncPassphrase } from '@glance-apps/sync';
+import { createDbEngine } from './dbEngine.js';
+import { getVaultConfig, setVaultConfig, isVaultEnabled } from './vaultConfig.js';
+import { getDeviceId } from './deviceId.js';
+import { registerDbEngine, markDirty, schedulePush } from './dirtyTracker.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// STAGE 2 PART B — live wiring. These exercise the REAL @glance-apps/sync
+// createDbSyncEngine (real per-entity AES-GCM) via an injected in-memory vault
+// client and an in-memory native key store (so no network and no indexedDB).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+// In-memory GLANCEvault: one row per entityId (upsert, last-write-wins), global
+// seq. Mirrors the real vaultClient surface the engine calls.
+function createMemoryVault() {
+  const salts = new Map();
+  const log = new Map();
+  let seq = 0;
+  return {
+    async getSalt(accountId) { return salts.get(accountId) || null; },
+    async putSalt(accountId, fresh) { if (!salts.has(accountId)) salts.set(accountId, fresh); return salts.get(accountId); },
+    async batch(app, { rows }) {
+      for (const r of rows) log.set(r.entityId, { entityId: r.entityId, seq: ++seq, envelope: r.envelope, deleted: false });
+      return { maxSeq: seq };
+    },
+    async deleteRow(app, entityId) { log.set(entityId, { entityId, seq: ++seq, envelope: null, deleted: true }); return { seq }; },
+    async list(app, { since }) {
+      const rows = [...log.values()].filter((r) => r.seq > since).sort((a, b) => a.seq - b.seq);
+      return { rows, hasMore: false };
+    },
+    async device() { return { updated: true }; },
+  };
+}
+
+// Hermetic teardown: never let fake timers or the localStorage shim leak into
+// other test files sharing this worker.
+afterEach(() => { vi.useRealTimers(); });
+afterAll(() => { delete global.localStorage; });
+
+const EMPTY = {
+  tasks: [], unscheduledTasks: [], recurringTasks: [], recycleBin: [], todayRoutines: [],
+  habits: [], goals: [], projects: [], gtdFrames: [], users: [], dailyNotes: {},
+  completedTaskUids: [], deletedTaskIds: {},
+};
+const clone = (x) => JSON.parse(JSON.stringify(x));
+const task = (id, lastModified, extra = {}) => ({
+  id, title: `task ${id}`, duration: 30, color: 'bg-blue-500', completed: false,
+  notes: '', subtasks: [], lastModified, ...extra,
+});
+
+// A device: its own data object + native key store + storageKeyPrefix, sharing
+// one vault. getData/commitData are the app's buildSyncPayload().data /
+// applyPayload analogs.
+function makeDevice(name, vault, initial) {
+  let data = clone(initial);
+  let nativeKey = null;
+  const engine = createDbEngine({
+    vaultClient: vault,
+    storageKeyPrefix: `dev-${name}`,
+    deviceId: `device-${name}`,
+    nativeGetSyncKey: () => nativeKey,
+    nativeStoreSyncKey: (v) => { nativeKey = v; },
+    getData: () => clone(data),
+    commitData: (d) => { data = d; },
+  });
+  return { engine, get data() { return data; } };
+}
+
+async function runRounds(a, b, rounds = 6) {
+  for (let i = 0; i < rounds; i++) {
+    await a.engine.dbSyncCycle();
+    await b.engine.dbSyncCycle();
+  }
+}
+
+describe('Part B — vaultConfig gate', () => {
+  beforeEach(() => { global.localStorage = memLocalStorage(); });
+
+  it('isVaultEnabled is false until fully configured + enabled', () => {
+    expect(isVaultEnabled()).toBe(false);
+    setVaultConfig({ enabled: true, vaultUrl: 'https://v', vaultToken: 't', accountId: 'acct' });
+    expect(isVaultEnabled()).toBe(true);
+    expect(getVaultConfig().accountId).toBe('acct');
+    setVaultConfig(null);
+    expect(isVaultEnabled()).toBe(false);
+  });
+
+  it('createDbEngine returns null when the vault is disabled (DB path inert)', () => {
+    expect(createDbEngine({ getData: () => ({}), commitData: () => {} })).toBeNull();
+  });
+});
+
+describe('Part B — deviceId is stable', () => {
+  beforeEach(() => { global.localStorage = memLocalStorage(); });
+  it('returns the same id across calls and persists it', () => {
+    const a = getDeviceId();
+    expect(a).toBeTruthy();
+    expect(getDeviceId()).toBe(a);
+    expect(global.localStorage.getItem('dayglance-device-id')).toBe(a);
+  });
+});
+
+describe('Part B — dirtyTracker push-on-write (vault-only, debounced)', () => {
+  beforeEach(() => { vi.useFakeTimers(); registerDbEngine(null); });
+
+  it('schedules ONE debounced vault cycle ~3s after a burst of writes, off-safe', async () => {
+    const dbSyncCycle = vi.fn().mockResolvedValue();
+    registerDbEngine({ dbSyncCycle, markDirty: vi.fn() });
+
+    markDirty('tasks:1');
+    markDirty('tasks:2');
+    schedulePush(); // a third write resets the timer
+    expect(dbSyncCycle).not.toHaveBeenCalled(); // debounced, not yet
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(dbSyncCycle).toHaveBeenCalledTimes(1); // burst collapsed into one cycle
+
+    registerDbEngine(null); // detach
+    markDirty('tasks:3');
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(dbSyncCycle).toHaveBeenCalledTimes(1); // no-op when vault is off
+    vi.useRealTimers();
+  });
+});
+
+describe('Part B — end-to-end two-device sync via the REAL engine', () => {
+  beforeAll(() => { /* passphrase shared by both devices, like the file tier */ });
+
+  beforeEach(() => {
+    global.localStorage = memLocalStorage();
+    setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 'tok', accountId: 'acct1' });
+    setSyncPassphrase('correct horse battery staple');
+  });
+
+  it('a task created on device A reaches device B', async () => {
+    const vault = createMemoryVault();
+    const A = makeDevice('A', vault, { ...EMPTY, tasks: [task(1, '2026-06-18T10:00:00.000Z')] });
+    const B = makeDevice('B', vault, { ...EMPTY });
+
+    await runRounds(A, B);
+
+    expect(B.data.tasks.map((t) => t.id)).toContain(1);
+    expect(B.data.tasks.find((t) => t.id === 1).title).toBe('task 1');
+  });
+
+  it('concurrent bundle edits on both devices converge (set-union) through real crypto', async () => {
+    const vault = createMemoryVault();
+    const base = { ...EMPTY, completedTaskUids: ['uid-base::2026-06-17'] };
+    const A = makeDevice('A', vault, base);
+    const B = makeDevice('B', vault, base);
+    // baseline seed
+    await runRounds(A, B, 2);
+
+    // each device appends a different uid offline
+    A.engine /* mutate via commit path */;
+    // simulate local edits by mutating the device data through getData/commitData:
+    // easiest is to push directly into the live data object.
+    A.data.completedTaskUids.push('uid-a::2026-06-18');
+    B.data.completedTaskUids.push('uid-b::2026-06-18');
+
+    await runRounds(A, B);
+
+    for (const dev of [A, B]) {
+      expect(new Set(dev.data.completedTaskUids)).toEqual(
+        new Set(['uid-base::2026-06-17', 'uid-a::2026-06-18', 'uid-b::2026-06-18']),
+      );
+    }
+  });
+
+  it('a cross-list move (unscheduled → scheduled) ends under exactly one kind on both devices', async () => {
+    const vault = createMemoryVault();
+    const start = { ...EMPTY, unscheduledTasks: [task(1003, '2026-06-18T10:00:00.000Z')] };
+    const A = makeDevice('A', vault, start);
+    const B = makeDevice('B', vault, start);
+    await runRounds(A, B, 2); // share baseline
+
+    // device A promotes 1003 to the schedule
+    A.data.unscheduledTasks = A.data.unscheduledTasks.filter((t) => t.id !== 1003);
+    A.data.tasks.push(task(1003, '2026-06-18T11:00:00.000Z', { date: '2026-06-18' }));
+
+    await runRounds(A, B);
+
+    for (const dev of [A, B]) {
+      const inTasks = dev.data.tasks.some((t) => t.id === 1003);
+      const inUnsched = dev.data.unscheduledTasks.some((t) => t.id === 1003);
+      expect(inTasks).toBe(true);
+      expect(inUnsched).toBe(false);
+    }
+  });
+});

--- a/src/sync/dbMerge.test.js
+++ b/src/sync/dbMerge.test.js
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import { createVault, createDevice, syncToConvergence } from './dbVaultSim.js';
+import { shredState, makeEntityId } from './dbAdapter.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// STAGE 2 PART A — MULTI-DEVICE MERGE CORRECTNESS (the gate)
+//
+// Two devices share one in-memory vault. Each edits a DIFFERENT entry of the
+// same structure between syncs; after syncing both ways, no edit may be lost.
+// A plain entity-grain LWW upsert of a whole bundle row fails this — that is the
+// point of the per-bundle merge in dbAdapter.js.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const T0 = '2026-06-18T10:00:00.000Z';
+const T1 = '2026-06-18T11:00:00.000Z';
+const T2 = '2026-06-18T12:00:00.000Z';
+
+const EMPTY_COLLECTIONS = {
+  tasks: [], unscheduledTasks: [], recurringTasks: [], recycleBin: [], todayRoutines: [],
+  habits: [], goals: [], projects: [], gtdFrames: [], users: [], dailyNotes: {},
+};
+
+// Mark a device's entire current state dirty and converge, so the vault and both
+// devices share a baseline (mirrors the HWM-0 full-snapshot seed).
+function seedAndConverge(devA, devB, vault) {
+  for (const row of shredState(devA.data)) devA.markDirty(row.entityId);
+  syncToConvergence(devA, devB, vault);
+}
+
+function newPair(baseData) {
+  const vault = createVault();
+  const a = createDevice('A', baseData);
+  const b = createDevice('B', baseData);
+  seedAndConverge(a, b, vault);
+  return { vault, a, b };
+}
+
+// A naive whole-bundle LWW (newer-writer overwrites the entire bundle) — used
+// only to DEMONSTRATE the silent-loss this stage closes.
+function naiveLWW(localBundle, localTs, remoteBundle, remoteTs) {
+  return new Date(remoteTs) >= new Date(localTs) ? remoteBundle : localBundle;
+}
+
+describe('A1 bundle merge — concurrent different-entry edits are not lost', () => {
+  it('DEMONSTRATION: naive whole-bundle LWW DOES lose an edit (why per-bundle merge is needed)', () => {
+    // device 1 increments habit h1; device 2 increments h2; device 2 writes last.
+    const dev1 = { h1: 5, h2: 1 };
+    const dev2 = { h1: 4, h2: 3 };
+    const merged = naiveLWW(dev1, T1, dev2, T2);
+    expect(merged.h1).toBe(4); // device 1's increment to 5 is LOST
+  });
+
+  it('habitLogs: different habits on the same day both survive', () => {
+    const base = {
+      ...EMPTY_COLLECTIONS,
+      habitLogs: { '2026-06-18': { h1: 4, h2: 1 } },
+      habitLogTimestamps: { '2026-06-18:h1': T0, '2026-06-18:h2': T0 },
+    };
+    const { vault, a, b } = newPair(base);
+
+    a.mutate((d) => {
+      d.habitLogs['2026-06-18'].h1 = 5;
+      d.habitLogTimestamps['2026-06-18:h1'] = T1;
+      return [makeEntityId('singleton', 'habitLogs')];
+    });
+    b.mutate((d) => {
+      d.habitLogs['2026-06-18'].h2 = 3;
+      d.habitLogTimestamps['2026-06-18:h2'] = T2;
+      return [makeEntityId('singleton', 'habitLogs')];
+    });
+    syncToConvergence(a, b, vault);
+
+    for (const dev of [a, b]) {
+      expect(dev.data.habitLogs['2026-06-18']).toEqual({ h1: 5, h2: 3 });
+    }
+  });
+
+  it('habitLogs: edits on different days both survive', () => {
+    const base = {
+      ...EMPTY_COLLECTIONS,
+      habitLogs: { '2026-06-18': { h1: 1 } },
+      habitLogTimestamps: { '2026-06-18:h1': T0 },
+    };
+    const { vault, a, b } = newPair(base);
+    a.mutate((d) => { d.habitLogs['2026-06-18'].h1 = 2; d.habitLogTimestamps['2026-06-18:h1'] = T1; return ['singleton:habitLogs']; });
+    b.mutate((d) => { d.habitLogs['2026-06-19'] = { h1: 1 }; d.habitLogTimestamps['2026-06-19:h1'] = T2; return ['singleton:habitLogs']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      expect(dev.data.habitLogs['2026-06-18'].h1).toBe(2);
+      expect(dev.data.habitLogs['2026-06-19'].h1).toBe(1);
+    }
+  });
+
+  it('routineDefinitions: a renamed chip and a new chip both survive', () => {
+    const base = {
+      ...EMPTY_COLLECTIONS,
+      routineDefinitions: { monday: [{ id: 5001, name: 'Workout', lastModified: T0 }] },
+      deletedRoutineChipIds: {},
+    };
+    const { vault, a, b } = newPair(base);
+    a.mutate((d) => { d.routineDefinitions.monday[0] = { id: 5001, name: 'Workout v2', lastModified: T1 }; return ['singleton:routineDefinitions']; });
+    b.mutate((d) => { d.routineDefinitions.monday.push({ id: 5003, name: 'Review', lastModified: T2 }); return ['singleton:routineDefinitions']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      const monday = dev.data.routineDefinitions.monday;
+      expect(monday.find((c) => c.id === 5001).name).toBe('Workout v2');
+      expect(monday.find((c) => c.id === 5003)).toBeTruthy();
+    }
+  });
+
+  it('routineCompletions: completing different routines both survive (set-union)', () => {
+    const base = { ...EMPTY_COLLECTIONS, routinesDate: '2026-06-18', routineCompletions: {} };
+    const { vault, a, b } = newPair(base);
+    a.mutate((d) => { d.routineCompletions['5001'] = '2026-06-18'; return ['singleton:routineCompletions']; });
+    b.mutate((d) => { d.routineCompletions['5002'] = '2026-06-18'; return ['singleton:routineCompletions']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      expect(dev.data.routineCompletions).toEqual({ 5001: '2026-06-18', 5002: '2026-06-18' });
+    }
+  });
+
+  it('completedTaskUids: appends on both devices both survive (set-union)', () => {
+    const base = { ...EMPTY_COLLECTIONS, completedTaskUids: ['uid-base::2026-06-17'] };
+    const { vault, a, b } = newPair(base);
+    a.mutate((d) => { d.completedTaskUids.push('uid-a::2026-06-18'); return ['singleton:completedTaskUids']; });
+    b.mutate((d) => { d.completedTaskUids.push('uid-b::2026-06-18'); return ['singleton:completedTaskUids']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      expect(new Set(dev.data.completedTaskUids)).toEqual(
+        new Set(['uid-base::2026-06-17', 'uid-a::2026-06-18', 'uid-b::2026-06-18']),
+      );
+    }
+  });
+
+  it('tombstone maps: deleting different ids on each device both survive (set-union)', () => {
+    const base = { ...EMPTY_COLLECTIONS, deletedTaskIds: {} };
+    const { vault, a, b } = newPair(base);
+    a.mutate((d) => { d.deletedTaskIds['9001'] = T1; return ['singleton:deletedTaskIds']; });
+    b.mutate((d) => { d.deletedTaskIds['9002'] = T2; return ['singleton:deletedTaskIds']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      expect(Object.keys(dev.data.deletedTaskIds).sort()).toEqual(['9001', '9002']);
+    }
+  });
+
+  it('*Enabled pair: last-writer-wins by paired UpdatedAt, deterministic on both', () => {
+    const base = { ...EMPTY_COLLECTIONS, habitsEnabled: true, habitsEnabledUpdatedAt: T0 };
+    const { vault, a, b } = newPair(base);
+    a.mutate((d) => { d.habitsEnabled = false; d.habitsEnabledUpdatedAt = T1; return ['singleton:habitsEnabled']; });
+    b.mutate((d) => { d.habitsEnabled = true; d.habitsEnabledUpdatedAt = T2; return ['singleton:habitsEnabled']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      expect(dev.data.habitsEnabled).toBe(true);          // T2 is newest
+      expect(dev.data.habitsEnabledUpdatedAt).toBe(T2);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A2 — CROSS-LIST MOVE (a task keeps its id while moving between kinds)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const task = (id, lastModified, extra = {}) => ({
+  id, title: `task ${id}`, duration: 30, color: 'bg-blue-500', completed: false,
+  notes: '', subtasks: [], lastModified, ...extra,
+});
+
+// count how many task-kinds a given id is live under
+function kindsHolding(data, id) {
+  return ['tasks', 'unscheduledTasks', 'recurringTasks', 'recycleBin', 'todayRoutines']
+    .filter((k) => (data[k] || []).some((t) => String(t.id) === String(id)));
+}
+
+describe('A2 cross-list move — a moved task ends up under exactly one kind', () => {
+  it('one device moves unscheduled → scheduled; the other still has it unscheduled', () => {
+    const base = { ...EMPTY_COLLECTIONS, unscheduledTasks: [task(1003, T0)] };
+    const { vault, a, b } = newPair(base);
+
+    // device A promotes 1003 to the schedule: tombstone-on-old + insert-on-new.
+    a.mutate((d) => {
+      d.unscheduledTasks = d.unscheduledTasks.filter((t) => t.id !== 1003);
+      d.tasks.push(task(1003, T1, { date: '2026-06-18', startTime: '09:00' }));
+      return [makeEntityId('unscheduledTasks', 1003), makeEntityId('tasks', 1003)];
+    });
+    syncToConvergence(a, b, vault);
+
+    for (const dev of [a, b]) {
+      expect(kindsHolding(dev.data, 1003)).toEqual(['tasks']); // exactly one, not lost, not duplicated
+    }
+  });
+
+  it('both devices move the same task to DIFFERENT kinds: deterministic winner, no duplicate', () => {
+    const base = { ...EMPTY_COLLECTIONS, unscheduledTasks: [task(1003, T0)] };
+    const { vault, a, b } = newPair(base);
+
+    // A → scheduled at T1; B → recycleBin at T2 (T2 newer, so recycleBin wins).
+    a.mutate((d) => {
+      d.unscheduledTasks = d.unscheduledTasks.filter((t) => t.id !== 1003);
+      d.tasks.push(task(1003, T1, { date: '2026-06-18' }));
+      return [makeEntityId('unscheduledTasks', 1003), makeEntityId('tasks', 1003)];
+    });
+    b.mutate((d) => {
+      d.unscheduledTasks = d.unscheduledTasks.filter((t) => t.id !== 1003);
+      d.recycleBin.push(task(1003, T2, { deletedAt: T2, _deletedFrom: 'inbox' }));
+      return [makeEntityId('unscheduledTasks', 1003), makeEntityId('recycleBin', 1003)];
+    });
+    syncToConvergence(a, b, vault);
+
+    for (const dev of [a, b]) {
+      expect(kindsHolding(dev.data, 1003)).toEqual(['recycleBin']); // newest lastModified wins, agreed on both
+    }
+  });
+
+  it('tie on lastModified resolves by CROSS_LIST_PRIORITY (recycleBin beats tasks)', () => {
+    const base = { ...EMPTY_COLLECTIONS, unscheduledTasks: [task(1003, T0)] };
+    const { vault, a, b } = newPair(base);
+    a.mutate((d) => {
+      d.unscheduledTasks = d.unscheduledTasks.filter((t) => t.id !== 1003);
+      d.tasks.push(task(1003, T1, { date: '2026-06-18' }));
+      return ['unscheduledTasks:1003', 'tasks:1003'];
+    });
+    b.mutate((d) => {
+      d.unscheduledTasks = d.unscheduledTasks.filter((t) => t.id !== 1003);
+      d.recycleBin.push(task(1003, T1, { deletedAt: T1 })); // same lastModified as A's
+      return ['unscheduledTasks:1003', 'recycleBin:1003'];
+    });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      expect(kindsHolding(dev.data, 1003)).toEqual(['recycleBin']);
+    }
+  });
+});

--- a/src/sync/dbVaultSim.js
+++ b/src/sync/dbVaultSim.js
@@ -1,0 +1,143 @@
+// In-memory two-device GLANCEvault simulator — TEST SUPPORT ONLY, never wired
+// into the app. It exists to prove merge correctness across two devices sharing
+// one vault, which a single-device losslessness test cannot see.
+//
+// It faithfully mirrors the push/pull contract of @glance-apps/sync's
+// createDbSyncEngine (dbEngine.js) and drives the SAME app-side adapter
+// callbacks the real engine calls (getLocalEntity / applyRemoteEntity /
+// applyRemoteDelete / isInsertOnly / getEntityLastModified). Transport + crypto
+// are stubbed: a row carries the plaintext entity through a JSON clone, which is
+// exactly the serialization encryptEntity/decryptEntity perform (dbCrypto.js:274,
+// 300) — so nested structures and keyed maps are exercised through the wire.
+//
+// Two deliberate, documented divergences from dbEngine.js, both behavior-
+// preserving:
+//   1. The pull cursor advances only on PULL (to the max seq seen), not on push.
+//      dbEngine.js advances the HWM on push too (dbEngine.js:225); replicating
+//      that here would let a device skip another device's rows that were written
+//      between its own push and the next list. Because re-applying an
+//      already-seen row is idempotent under LWW (skipped) and under the
+//      insert-only bundle merges (union/recency no-ops), pulling from the lower
+//      cursor is safe and simply avoids the skip — a strictly more conservative
+//      cursor.
+//   2. After each pull we run reconcileCrossList (the spec-5.2 cross-list
+//      dedupe). In the live engine this hooks the end-of-cycle apply notify.
+
+import {
+  getLocalEntity,
+  applyRemoteEntity,
+  applyRemoteDelete,
+  isInsertOnly,
+  getEntityLastModified,
+  reconcileCrossList,
+} from './dbAdapter.js';
+
+const clone = (x) => (x === undefined ? undefined : JSON.parse(JSON.stringify(x)));
+const tsNum = (v) => {
+  if (v == null) return 0;
+  const t = new Date(v).getTime();
+  return Number.isNaN(t) ? 0 : t;
+};
+
+// ── Vault: a single append-only log keyed by entityId with a global seq. Mirrors
+// the GLANCEvault row shape { entityId, seq, ciphertext|deleted } — here the
+// plaintext entity stands in for ciphertext.
+export function createVault() {
+  const rows = new Map(); // entityId -> { entityId, seq, entity|null, deleted }
+  let seq = 0;
+  return {
+    upsert(entityId, entity) {
+      rows.set(entityId, { entityId, seq: ++seq, entity: clone(entity), deleted: false });
+    },
+    remove(entityId) {
+      rows.set(entityId, { entityId, seq: ++seq, entity: null, deleted: true });
+    },
+    list(since) {
+      return [...rows.values()].filter((r) => r.seq > since).sort((a, b) => a.seq - b.seq);
+    },
+    snapshot() {
+      return [...rows.values()].map((r) => ({ ...r, entity: clone(r.entity) }));
+    },
+  };
+}
+
+// ── Device: holds its own `.data`, a dirty set, and a pull cursor. `mutate` runs
+// a local edit and records every entityId it touched as dirty (the markDirty/
+// markDeleted wiring Part B installs at real write sites).
+export function createDevice(name, initialData) {
+  const data = clone(initialData) || {};
+  const dirty = new Set();
+  let cursor = 0;
+
+  const markDirty = (entityId) => dirty.add(String(entityId));
+
+  const push = (vault) => {
+    for (const entityId of dirty) {
+      const entity = getLocalEntity(data, entityId);
+      if (entity == null) vault.remove(entityId);
+      else vault.upsert(entityId, entity);
+    }
+    dirty.clear();
+  };
+
+  const pull = (vault) => {
+    let maxSeq = cursor;
+    for (const r of vault.list(cursor)) {
+      if (r.seq > maxSeq) maxSeq = r.seq;
+      if (r.deleted) {
+        applyRemoteDelete(data, r.entityId);
+        continue;
+      }
+      const remote = clone(r.entity);
+      const local = getLocalEntity(data, r.entityId);
+      if (local == null || isInsertOnly(remote)) {
+        // Bundle merges may leave us richer than the clobbered vault row; re-push
+        // the superset so it converges at the vault, not just locally.
+        for (const id of applyRemoteEntity(data, remote)) markDirty(id);
+      } else if (tsNum(getEntityLastModified(remote)) > tsNum(getEntityLastModified(local))) {
+        applyRemoteEntity(data, remote);
+      }
+      // else: local newer/equal — keep local (mirrors dbEngine.js:272-279)
+    }
+    cursor = maxSeq;
+    // Cross-list dedupe; a removed stale copy is soft-deleted on next push so the
+    // vault converges too.
+    reconcileCrossList(data, (loserId) => markDirty(loserId));
+  };
+
+  return {
+    name,
+    data,
+    markDirty,
+    // Run a local edit; `fn(data)` returns the list of touched entityIds.
+    mutate(fn) {
+      const touched = fn(data) || [];
+      for (const id of touched) markDirty(id);
+    },
+    push,
+    pull,
+    // One full cycle: push then pull (the engine's order, dbEngine.js:319-321).
+    sync(vault) {
+      push(vault);
+      pull(vault);
+    },
+  };
+}
+
+// Drive both devices to a fixed point: alternate full cycles until neither has
+// pending dirty rows and a final cross-pull yields no change. Returns the number
+// of rounds. Bounded so a non-converging bug fails loudly instead of hanging.
+export function syncToConvergence(devA, devB, vault, maxRounds = 8) {
+  for (let round = 1; round <= maxRounds; round++) {
+    devA.sync(vault);
+    devB.sync(vault);
+    devA.sync(vault);
+    devB.sync(vault);
+    // Converged when a further pass changes nothing on either device.
+    const before = JSON.stringify([devA.data, devB.data]);
+    devA.sync(vault);
+    devB.sync(vault);
+    if (JSON.stringify([devA.data, devB.data]) === before) return round;
+  }
+  throw new Error('syncToConvergence: did not converge within maxRounds');
+}

--- a/src/sync/dbVaultSim.js
+++ b/src/sync/dbVaultSim.js
@@ -10,18 +10,15 @@
 // exactly the serialization encryptEntity/decryptEntity perform (dbCrypto.js:274,
 // 300) — so nested structures and keyed maps are exercised through the wire.
 //
-// Two deliberate, documented divergences from dbEngine.js, both behavior-
-// preserving:
-//   1. The pull cursor advances only on PULL (to the max seq seen), not on push.
-//      dbEngine.js advances the HWM on push too (dbEngine.js:225); replicating
-//      that here would let a device skip another device's rows that were written
-//      between its own push and the next list. Because re-applying an
-//      already-seen row is idempotent under LWW (skipped) and under the
-//      insert-only bundle merges (union/recency no-ops), pulling from the lower
-//      cursor is safe and simply avoids the skip — a strictly more conservative
-//      cursor.
-//   2. After each pull we run reconcileCrossList (the spec-5.2 cross-list
-//      dedupe). In the live engine this hooks the end-of-cycle apply notify.
+// Cursor model: the pull cursor advances only on PULL (to the max seq seen),
+// never on push. As of @glance-apps/sync 1.4.0 this is exactly what the real
+// engine does — it split the cursor into a pull cursor (getHighWaterMark,
+// pull-only) and a separate push-ack marker (getPushAck), so a push never moves
+// the pull cursor. (Under 1.3.2 the engine advanced the shared HWM on push,
+// which could skip an unread remote row; the package fix closed that, and
+// dbEngineWiring.test.js asserts it directly.) The one simulator-only convenience
+// is that reconcileCrossList runs at the end of each pull; in the live engine
+// dayGLANCE's createDbEngine wrapper runs it at end-of-cycle.
 
 import {
   getLocalEntity,

--- a/src/sync/deviceId.js
+++ b/src/sync/deviceId.js
@@ -1,0 +1,21 @@
+// Stable per-device id that scopes the GLANCEvault cursor server-side (mirrors
+// lastGLANCE src/sync/deviceId.ts). The engine owns the high-water mark; this is
+// the only piece the app persists for the DB transport.
+
+const DEVICE_ID_KEY = 'dayglance-device-id';
+
+export function getDeviceId() {
+  let id = null;
+  try {
+    id = localStorage.getItem(DEVICE_ID_KEY);
+  } catch { /* storage unavailable */ }
+  if (!id) {
+    id = (typeof crypto !== 'undefined' && crypto.randomUUID)
+      ? crypto.randomUUID()
+      : `dev-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    try { localStorage.setItem(DEVICE_ID_KEY, id); } catch { /* ignore */ }
+  }
+  return id;
+}
+
+export { DEVICE_ID_KEY };

--- a/src/sync/dirtyTracker.js
+++ b/src/sync/dirtyTracker.js
@@ -1,0 +1,64 @@
+// Push-on-write bridge for the GLANCEvault DB transport (mirrors lastGLANCE
+// src/sync/dirtyTracker.ts, including the post-48h-test debounce fix).
+//
+// It schedules a debounced vault sync after local writes so a change uploads
+// promptly instead of waiting for a cadence trigger (load / focus / interval) —
+// the bug the lastGLANCE fix addressed, where edits on a backgrounded device sat
+// unsynced until the app was reopened.
+//
+// VAULT-ONLY by design (spec 6.5): this never pushes to WebDAV. The file tier
+// keeps its cadence model, which is deliberate given its full-payload upload
+// cost. dayGLANCE does not fan push-on-write out to WebDAV.
+//
+// Off-safe: every function is a no-op when no DB engine is registered (vault
+// disabled), so it is safe to call unconditionally from the app's write path.
+
+// Wait this long after the last write before pushing, so a burst of writes
+// collapses into one sync.
+const PUSH_DEBOUNCE_MS = 3000;
+
+let dbEngine = null;
+let pushTimer = null;
+
+function cancelScheduledPush() {
+  if (pushTimer != null) {
+    clearTimeout(pushTimer);
+    pushTimer = null;
+  }
+}
+
+// Debounced vault sync. Each call resets the timer; the cycle runs once writes
+// settle. dbSyncCycle has its own in-flight guard, so this never overlaps a
+// cadence-triggered cycle.
+export function schedulePush() {
+  if (!dbEngine) return;
+  cancelScheduledPush();
+  pushTimer = setTimeout(() => {
+    pushTimer = null;
+    dbEngine?.dbSyncCycle().catch(() => { /* surfaced via the engine onError */ });
+  }, PUSH_DEBOUNCE_MS);
+}
+
+// Wire the active DB engine on startup / config change, or null to detach it
+// (vault disabled). Detaching also cancels any pending push.
+export function registerDbEngine(engine) {
+  cancelScheduledPush();
+  dbEngine = engine;
+}
+
+// Mark an entity changed and schedule a debounced push. dayGLANCE computes the
+// actual dirty set by diffing at cycle time (see dbEngine.createDbEngine), so the
+// engine.markDirty call is a best-effort hint; the debounced schedule is the part
+// that matters for prompt upload. Safe (no-op) when the vault is off.
+export function markDirty(entityId) {
+  if (!dbEngine) return;
+  if (entityId != null && typeof dbEngine.markDirty === 'function') dbEngine.markDirty(String(entityId));
+  schedulePush();
+}
+
+// Deletions resolve by absence (getLocalEntity returns null → soft-delete). The
+// engine exposes no dedicated delete call, so this reuses the dirty path; kept as
+// a named helper to document intent at delete sites.
+export function markDeleted(entityId) {
+  markDirty(entityId);
+}

--- a/src/sync/vaultConfig.js
+++ b/src/sync/vaultConfig.js
@@ -1,0 +1,30 @@
+// GLANCEvault connection config + enablement gate (mirrors lastGLANCE
+// src/sync/vaultConfig.ts). Its own localStorage key, completely independent of
+// the file-tier (WebDAV) config — the DB transport runs ALONGSIDE WebDAV and is
+// opt-in. Clearing this config reverts to file-only instantly.
+
+const VAULT_CONFIG_KEY = 'dayglance-vault-config';
+
+/** @returns {{enabled:boolean, vaultUrl:string, vaultToken:string, accountId:string}|null} */
+export function getVaultConfig() {
+  try {
+    const saved = localStorage.getItem(VAULT_CONFIG_KEY);
+    return saved ? JSON.parse(saved) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setVaultConfig(cfg) {
+  if (cfg) localStorage.setItem(VAULT_CONFIG_KEY, JSON.stringify(cfg));
+  else localStorage.removeItem(VAULT_CONFIG_KEY);
+}
+
+// True only when the vault is fully configured AND toggled on. Everything in the
+// DB transport is gated on this; when false the DB path is fully inert.
+export function isVaultEnabled() {
+  const c = getVaultConfig();
+  return !!(c && c.enabled && c.vaultUrl && c.vaultToken && c.accountId);
+}
+
+export { VAULT_CONFIG_KEY };


### PR DESCRIPTION
## Summary

Adds the **GLANCEvault** row-grained database sync transport as an **opt-in** tier that runs **alongside** the existing WebDAV file-tier sync — additive, reversible, and non-destructive (the WebDAV engine, payload, and merge are untouched; the DB engine never writes the WebDAV file). When the vault is disabled, `createDbEngine` returns `null` and the entire DB path is inert, so file-only devices behave exactly as before.

Delivered in two stages with proofs, then wired into the app and the settings UI, and finally upgraded to `@glance-apps/sync@1.4.0`. Bumps the app to **v3.5.0**.

## Stage 1 — entity↔row adapter + losslessness (representability)
- `src/sync/dbAdapter.js`: shred full sync payload → rows and reassemble, lossless on one device.
- **Explicit in-envelope `_kind` discriminator** instead of structural sniffing — dayGLANCE's five task-shaped collections (`tasks`/`unscheduledTasks`/`recurringTasks`/`recycleBin`/`todayRoutines`) are field-for-field identical and can't be told apart structurally. `_kind` is JSON-serialized inside the per-entity AES-GCM ciphertext, so the server still sees only opaque bytes (zero-knowledge).
- Bundles keep their current shape (rule 4: `completedDates` stays an array, `habitLogs` stays a keyed map). Composite `${kind}:${id}` entityIds so a cross-list-moving task never collides.
- **Losslessness gate: PASS** (`dbAdapter.losslessness.test.js`). Full mapping/decision writeup in `docs/glancevault-stage1.md`.

## Stage 2 — multi-device merge correctness + live wiring
**Part A (gate):** two-device in-memory vault simulator (`dbVaultSim.js`) driving the real adapter callbacks.
- **A1 bundle merge:** concurrent edits to *different* entries of the same bundle are never lost. The vault upserts one row per entityId (last-write-wins), so a single bundle row would clobber a concurrent edit; the fix is to **re-push the merged superset** when a bundle merge leaves us richer than the row we pulled (the file-tier `remoteChanged` mechanism). Per-bundle strategies: per-key recency (habitLogs), claim-aware per-chip (routineDefinitions), set-union (completedTaskUids + tombstone maps), paired-LWW (`*Enabled`/config).
- **A2 cross-list move:** a moved task ends under exactly one kind; concurrent moves to different kinds resolve to a deterministic winner (newest `lastModified`, tie → `recycleBin > recurringTasks > tasks > unscheduledTasks > todayRoutines`).
- **No unavoidable loss windows.** Strategy table + verdict in `docs/glancevault-stage2.md`.

**Part B (wiring):** `vaultConfig.js` + `isVaultEnabled` gate, stable `deviceId`, `createDbEngine` (constructs the real `createDbSyncEngine` alongside WebDAV, HWM-0 full-snapshot seed, dirty set by diffing a persisted snapshot, remote applies mutate a per-cycle mirror committed once via `applyPayload`), `dirtyTracker` debounced **3 s vault-only** push-on-write, and the App.jsx cadence wiring. End-to-end verified through the **real** engine + AES-GCM.

## Settings UI
- Cloud Sync settings split into **WebDAV Connection** and **GLANCEvault (Beta)** sections, each with a **Sync Now** button and status surfaced inline (Test Connection stays with WebDAV).
- **Mobile:** Cloud Sync now always appears under SYNC and opens a **dedicated settings page** (moved out of App Settings); green configured-dot carried over; row status messages removed (they live on the page now).

## @glance-apps/sync 1.4.0
- Pinned **1.4.0** exact; 1.4.0 splits the DB cursor (pull-only `getHighWaterMark` vs `getPushAck`) so a push never advances the pull cursor.
- The pull-then-push wrapper is **no longer a data-loss mitigation**; kept only for marginal freshness (the wrapper itself is the required React-state bridge with commit-on-success). Rationale documented.
- New **interleave test** proves the residual race is closed: with A's pull cursor at N, B writes at N+1, A pushes at seqs > N+1 → A's pull cursor stays N and its next pull still lists B's row at N+1.

## Versioning
- `package.json` 3.4.0 → **3.5.0** (lockfile synced); Android `versionCode` 118 → 119, `versionName` 3.4 → 3.5; README badge → 3.5.0.

## Testing
- Full suite **294/294**; production `vite build` passes on `@glance-apps/sync@1.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01939L4RyjfxWxi65QDACQPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01939L4RyjfxWxi65QDACQPK)_