### PR TITLE
Android: bump versionCode to 120 for the GLANCEvault enable fix

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 119
+        versionCode = 120
         versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
versionName stays 3.5 (matches the web major.minor, unchanged); only the Play-required versionCode increments for a new build.


Claude-Session: https://claude.ai/code/session_01939L4RyjfxWxi65QDACQPK