### PR TITLE
GLANCEvault: native HTTP on mobile + sync on Save (+ Android versionCode 121)

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 120
+        versionCode = 121
         versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8490,6 +8490,27 @@ const DayPlanner = () => {
       await eng.dbSyncCycle();
       setVaultLastSynced(eng.getLastSynced?.() || new Date().toISOString());
     },
+    // Called from the settings form right after enabling the vault, while the
+    // passphrase is in memory. Builds a transient engine with the REAL data
+    // callbacks and runs one full cycle — caching the root key AND doing the
+    // first sync — so data moves immediately on Save instead of waiting for the
+    // post-reload cadence. Returns { ok, error } so the form can surface failures
+    // (e.g. an unreachable vault) and roll back instead of reloading.
+    vaultBootstrapSync: async () => {
+      let bootErr = null;
+      const eng = createDbEngine({
+        getData:    () => engineCallbacksRef.current.buildPayload?.()?.data,
+        commitData: (data) => engineCallbacksRef.current.applyPayload?.(data, { allowEmpty: true }),
+        onStatusChange: (s) => setVaultStatus(s),
+        onError:    (msg) => { if (msg) bootErr = msg; },
+      });
+      if (!eng) return { ok: false, error: 'GLANCEvault is not configured.' };
+      await eng.dbSyncCycle();
+      if (bootErr) return { ok: false, error: bootErr };
+      setVaultError(null);
+      setVaultLastSynced(eng.getLastSynced?.() || new Date().toISOString());
+      return { ok: true };
+    },
     vaultStatus, vaultError, vaultLastSynced,
     syncAll,
     performObsidianSync, loadWikiNote, saveWikiNote, openInObsidian, nativeClearVault,

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -7,7 +7,7 @@ import { createDbEngine } from '../sync/dbEngine.js';
 import { useTranslation } from 'react-i18next';
 
 // Cloud sync settings form (extracted to avoid hooks-in-conditional issues)
-const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderClass, hoverBg, cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, cloudSyncNow, provider, currentProvider, onClose, cloudSyncLastSynced, cloudSyncStatus, cloudSyncError, vaultSyncNow, vaultStatus, vaultError, vaultLastSynced, onSyncKeyReady }) => {
+const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderClass, hoverBg, cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, cloudSyncNow, provider, currentProvider, onClose, cloudSyncLastSynced, cloudSyncStatus, cloudSyncError, vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced, onSyncKeyReady }) => {
   const { t } = useTranslation();
   const [formData, setFormData] = useState(() => {
     const initial = {
@@ -110,22 +110,31 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
     if (vaultEnabled && passphrase) setSyncPassphrase(passphrase);
     setVaultConfig(nextVault);
 
-    // Bootstrap the DB root key NOW, while the passphrase is in memory, so it is
-    // cached (IndexedDB on web, OS keystore on native) and survives the reload —
-    // the passphrase itself is never persisted. This also validates the vault
-    // URL/token; on failure we surface the error and don't reload.
+    // Run the first real sync NOW, while the passphrase is in memory: this caches
+    // the DB root key (IndexedDB on web, OS keystore on native) AND uploads/downloads
+    // immediately, so data moves on Save instead of waiting for the post-reload
+    // cadence. The passphrase itself is never persisted. It also validates the
+    // vault URL/token — on failure we surface the error and roll back instead of
+    // reloading.
     if (vaultEnabled && vaultChanged) {
       setVaultBootstrapping(true);
       try {
-        const boot = createDbEngine({ getData: () => ({}), commitData: () => {} });
-        if (boot) await boot.ensureRootKey();
+        let result = { ok: true };
+        if (vaultBootstrapSync) {
+          result = await vaultBootstrapSync();
+        } else {
+          const boot = createDbEngine({ getData: () => ({}), commitData: () => {} });
+          if (boot) await boot.ensureRootKey();
+        }
+        if (!result.ok) throw new Error(result.error || 'sync failed');
       } catch (err) {
         setVaultBootstrapping(false);
         setVaultConfig(vaultOriginal || null); // roll back so we don't half-enable
+        const msg = err?.message || '';
         setVaultBootstrapError(
-          err?.code === 'PASSPHRASE_REQUIRED'
+          /passphrase/i.test(msg)
             ? 'Enter your sync passphrase above to enable GLANCEvault.'
-            : `Couldn't reach GLANCEvault — check the vault URL and device token. (${err?.message || 'request failed'})`,
+            : `Couldn't reach GLANCEvault — check the vault URL and device token. (${msg || 'request failed'})`,
         );
         return;
       }

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -79,7 +79,7 @@ const MobileSettingsPanel = () => {
     obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
     wikilinkCandidates, setWikilinkCandidates,
     cloudSyncTest, cloudSyncNow,
-    vaultSyncNow, vaultStatus, vaultError, vaultLastSynced,
+    vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced,
     syncAll, performObsidianSync, performRemoteBackup, nativeClearVault,
     loadAutoBackupHistory,
     deleteLocalAutoBackup, deleteRemoteAutoBackup,
@@ -1317,6 +1317,7 @@ const MobileSettingsPanel = () => {
         cloudSyncError={cloudSyncError}
         cloudSyncNow={cloudSyncNow}
         vaultSyncNow={vaultSyncNow}
+        vaultBootstrapSync={vaultBootstrapSync}
         vaultStatus={vaultStatus}
         vaultError={vaultError}
         vaultLastSynced={vaultLastSynced}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -51,7 +51,7 @@ const SettingsModal = () => {
     handleFileUpload,
     cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, cloudSyncLastSynced,
     cloudSyncStatus, cloudSyncError, cloudSyncNow,
-    vaultSyncNow, vaultStatus, vaultError, vaultLastSynced,
+    vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced,
     syncKeyReady, setSyncKeyReady,
     calSyncConfigured, syncUrl, setSyncUrl,
     showCalendarUrlHint, setShowCalendarUrlHint,
@@ -740,6 +740,7 @@ const SettingsModal = () => {
                         cloudSyncError={cloudSyncError}
                         cloudSyncNow={cloudSyncNow}
                         vaultSyncNow={vaultSyncNow}
+                        vaultBootstrapSync={vaultBootstrapSync}
                         vaultStatus={vaultStatus}
                         vaultError={vaultError}
                         vaultLastSynced={vaultLastSynced}

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -79,6 +79,32 @@ export function createDbEngine(callbacks = {}) {
   const nativeStoreSyncKey = callbacks.nativeStoreSyncKey
     ?? (isNativeApp && nativeBridge?.storeSyncKey ? (val) => nativeBridge.storeSyncKey(val) : null);
 
+  // The vault client defaults to global fetch, which fails inside the Android
+  // WebView (no CORS, restricted network) — the same reason the WebDAV file tier
+  // routes through the native HTTP bridge (adapter.js / providers.js). Supply a
+  // fetchImpl that bridges to it on native, the electron proxy on desktop
+  // electron, and otherwise falls through to global fetch.
+  const electronProxyFetch = typeof window !== 'undefined' && window.electronAPI?.isElectron
+    ? (...args) => window.electronAPI.proxyFetch(...args)
+    : null;
+  const fetchImpl = callbacks.fetchImpl
+    ?? (isNativeApp
+      ? async (url, { method = 'GET', headers = {}, body } = {}) => {
+        let r;
+        try { r = JSON.parse(nativeBridge.httpRequest(method, url, JSON.stringify(headers), body ?? '')); }
+        catch { throw new TypeError('Failed to fetch'); }
+        if (!r) throw new TypeError('Failed to fetch');
+        return {
+          status: r.status,
+          ok: r.ok,
+          statusText: r.statusText,
+          headers: { get: (h) => (h.toLowerCase() === 'etag' ? (r.headers?.etag ?? null) : null) },
+          json: async () => JSON.parse(r.body),
+          text: async () => r.body,
+        };
+      }
+      : (electronProxyFetch || undefined));
+
   const loadSnapshot = () => {
     try { return JSON.parse(localStorage.getItem(SNAPSHOT_KEY) || '{}'); } catch { return {}; }
   };
@@ -100,6 +126,7 @@ export function createDbEngine(callbacks = {}) {
     accountId: cfg.accountId,
     deviceId: callbacks.deviceId || getDeviceId(),
     vaultClient: callbacks.vaultClient,
+    fetchImpl,
     nativeGetSyncKey,
     nativeStoreSyncKey,
     getLocalEntity: (entityId) => adapterGetLocalEntity(mirror, entityId),


### PR DESCRIPTION
Follow-up fixes on top of the merged GLANCEvault-enable work (#1017), found while testing on real devices.

## 1. Mobile "Failed to fetch"
The DB vault client used the browser's global `fetch`, which fails inside the Android WebView (no CORS, restricted network) — the WebDAV file tier already routes through the native HTTP bridge, but the DB tier did not.

`createDbEngine` now supplies a `fetchImpl` that bridges to `window.DayGlanceNative.httpRequest` on native (and the electron proxy on desktop electron), wrapping its `{ status, ok, body, headers }` result into the `Response` shape the vault client expects — mirroring the package's own `providers.js`. Web falls through to global `fetch`.

## 2. Sync on Save (desktop)
Previously Save only bootstrapped the root key and left the first sync to the post-reload cadence, so data didn't move until you reopened settings and pressed **Sync Now**.

Save now runs the first real sync immediately: App exposes `vaultBootstrapSync`, which builds a transient engine with the **real** data callbacks and runs one full `dbSyncCycle` (caches the root key **and** uploads/downloads) while the passphrase is in memory, then reloads. It returns `{ ok, error }`, so an unreachable vault surfaces an error and rolls back instead of reloading. Threaded through `SettingsModal` + `MobileSettingsPanel`.

## Android
- `versionCode` 120 → **121** (versionName stays `3.5`) so a new build can be installed for testing.

## Testing
- `vite build` clean; full suite **294/294**.

Scope: `src/sync/dbEngine.js`, `src/App.jsx`, `src/components/CloudSyncSettingsForm.jsx`, `src/components/SettingsModal.jsx`, `src/components/MobileSettingsPanel.jsx`, `dayglance-android/app/build.gradle.kts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01939L4RyjfxWxi65QDACQPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01939L4RyjfxWxi65QDACQPK)_