### PR TITLE
GLANCEvault: fix "Decryption failed" by re-deriving the root key from the entered passphrase (+ Android 122)

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 121
+        versionCode = 122
         versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -3,7 +3,7 @@ import { AlertTriangle } from 'lucide-react';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { setupEncryptionKey, setSyncPassphrase, clearEncryptionKey, getSyncPassphrase } from '../utils/crypto.js';
 import { getVaultConfig, setVaultConfig } from '../sync/vaultConfig.js';
-import { createDbEngine } from '../sync/dbEngine.js';
+import { createDbEngine, resetDbRootKey } from '../sync/dbEngine.js';
 import { useTranslation } from 'react-i18next';
 
 // Cloud sync settings form (extracted to avoid hooks-in-conditional issues)
@@ -110,12 +110,19 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
     if (vaultEnabled && passphrase) setSyncPassphrase(passphrase);
     setVaultConfig(nextVault);
 
+    // Any enable/disable makes the entered passphrase authoritative: drop a cached
+    // DB root key (in-memory + keystore/IndexedDB) so the next derive uses the
+    // current passphrase + the server's account salt. Without this, a key cached
+    // during an earlier attempt (wrong/old passphrase) stays locked in and pulling
+    // another device's rows fails with "Decryption failed".
+    if (vaultChanged) await resetDbRootKey();
+
     // Run the first real sync NOW, while the passphrase is in memory: this caches
     // the DB root key (IndexedDB on web, OS keystore on native) AND uploads/downloads
     // immediately, so data moves on Save instead of waiting for the post-reload
     // cadence. The passphrase itself is never persisted. It also validates the
-    // vault URL/token — on failure we surface the error and roll back instead of
-    // reloading.
+    // vault URL/token AND the passphrase — on failure we surface the error and roll
+    // back instead of reloading.
     if (vaultEnabled && vaultChanged) {
       setVaultBootstrapping(true);
       try {
@@ -129,12 +136,15 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
         if (!result.ok) throw new Error(result.error || 'sync failed');
       } catch (err) {
         setVaultBootstrapping(false);
+        await resetDbRootKey(); // don't leave a bad key cached after a failed attempt
         setVaultConfig(vaultOriginal || null); // roll back so we don't half-enable
         const msg = err?.message || '';
         setVaultBootstrapError(
-          /passphrase/i.test(msg)
-            ? 'Enter your sync passphrase above to enable GLANCEvault.'
-            : `Couldn't reach GLANCEvault — check the vault URL and device token. (${msg || 'request failed'})`,
+          /decrypt/i.test(msg)
+            ? 'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.'
+            : /passphrase/i.test(msg)
+              ? 'Enter your sync passphrase above to enable GLANCEvault.'
+              : `Couldn't reach GLANCEvault — check the vault URL and device token. (${msg || 'request failed'})`,
         );
         return;
       }

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -23,7 +23,7 @@
 //     applyPayload (which sets the suppress flags), so a pulled row never bounces
 //     back out as a file-tier upload or a re-push.
 
-import { createDbSyncEngine } from '@glance-apps/sync';
+import { createDbSyncEngine, clearDbRootKey } from '@glance-apps/sync';
 import { getVaultConfig, isVaultEnabled } from './vaultConfig.js';
 import { getDeviceId } from './deviceId.js';
 import {
@@ -38,6 +38,28 @@ import {
 
 const APP_ID = 'dayglance';
 const CRYPTO_DB_NAME = 'dayglance-db-crypto';
+
+// Where the per-account DB root key is stored: the OS keystore on native shells
+// (mirrors the file tier in adapter.js), IndexedDB elsewhere. Centralized so the
+// engine and resetDbRootKey agree.
+function nativeKeyConfig() {
+  const bridge = typeof window !== 'undefined' ? window.DayGlanceNative : null;
+  const isNativeApp = !!bridge?.httpRequest;
+  return {
+    cryptoDBName: CRYPTO_DB_NAME,
+    nativeGetSyncKey: isNativeApp && bridge?.getSyncKey ? () => bridge.getSyncKey() : null,
+    nativeStoreSyncKey: isNativeApp && bridge?.storeSyncKey ? (val) => bridge.storeSyncKey(val) : null,
+  };
+}
+
+// Drop any cached DB root key (in-memory + keystore/IndexedDB) so the next sync
+// re-derives it from the current session passphrase + the server's account salt.
+// Called when the vault is enabled/disabled so a freshly-entered passphrase is
+// authoritative — otherwise a key cached during an earlier attempt (wrong/old
+// passphrase) stays locked in and decryption of other devices' rows fails.
+export async function resetDbRootKey() {
+  try { await clearDbRootKey(nativeKeyConfig()); } catch { /* ignore */ }
+}
 
 const clone = (x) => (x == null ? x : JSON.parse(JSON.stringify(x)));
 const hashOf = (entity) => JSON.stringify(entity);
@@ -74,10 +96,9 @@ export function createDbEngine(callbacks = {}) {
   // callers (App wiring, save-time bootstrap) don't each have to pass them.
   const nativeBridge = typeof window !== 'undefined' ? window.DayGlanceNative : null;
   const isNativeApp = !!nativeBridge?.httpRequest;
-  const nativeGetSyncKey = callbacks.nativeGetSyncKey
-    ?? (isNativeApp && nativeBridge?.getSyncKey ? () => nativeBridge.getSyncKey() : null);
-  const nativeStoreSyncKey = callbacks.nativeStoreSyncKey
-    ?? (isNativeApp && nativeBridge?.storeSyncKey ? (val) => nativeBridge.storeSyncKey(val) : null);
+  const nativeKeys = nativeKeyConfig();
+  const nativeGetSyncKey = callbacks.nativeGetSyncKey ?? nativeKeys.nativeGetSyncKey;
+  const nativeStoreSyncKey = callbacks.nativeStoreSyncKey ?? nativeKeys.nativeStoreSyncKey;
 
   // The vault client defaults to global fetch, which fails inside the Android
   // WebView (no CORS, restricted network) — the same reason the WebDAV file tier


### PR DESCRIPTION
Follow-up to the GLANCEvault enable fixes. On Android, enabling the vault failed with **"Decryption failed: wrong passphrase or corrupted data"** when pulling another device's rows.

## Cause
The DB engine caches the per-account root key (OS keystore on native, IndexedDB on web) and **never re-derives it once set**. A key cached during an earlier test attempt — derived from a different/old passphrase — stayed "locked in", so the device derived a key that didn't match the one the data was encrypted with, and decryption on pull failed.

## Fix
- Add `resetDbRootKey()` (clears the in-memory key **and** the keystore/IndexedDB copy) and call it on every vault **enable/disable**, so the next derive uses the passphrase you just entered + the server's account salt. The entered passphrase is now authoritative. It's also cleared after a failed attempt so a bad key is never left behind.
- Clearer error: a decryption failure now reads **"Wrong sync passphrase — it must exactly match the passphrase used on your other devices"** instead of the raw crypto message.
- Android `versionCode` 121 → **122** for a new test build.

Note: the cycle pulls before it pushes, so a wrong passphrase fails at the decrypt step **before** any local data is uploaded — the vault isn't polluted with mismatched-key rows; you just re-enter the correct passphrase and retry.

## Testing
- `vite build` clean; full suite **294/294**.

Scope: `src/sync/dbEngine.js`, `src/components/CloudSyncSettingsForm.jsx`, `dayglance-android/app/build.gradle.kts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01939L4RyjfxWxi65QDACQPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01939L4RyjfxWxi65QDACQPK)_