### PR TITLE
GLANCEvault (Beta) reliability fixes + @glance-apps/sync 1.5.0 surfacing (v3.5.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.5.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.5.1-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 124
+        versionCode = 125
         versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 122
+        versionCode = 123
         versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 123
+        versionCode = 124
         versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.5.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "1.4.0",
+        "@glance-apps/sync": "1.5.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -2267,9 +2267,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.4.0.tgz",
-      "integrity": "sha512-qk5H5ExPrHVH3VLlCBJLG29A5AGK4djwzslr9ENLqmSqvi6ubN52weNY66Jz3CqFKOVF//gwdMH9hOiNd3WSqQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.0.tgz",
+      "integrity": "sha512-Sm1WLT+x/1fxBZ1rkN+/OQif2w3padII1pAppnP6IJQXVmGs5PlPmpjjIP8e5kJnI+Hs0Qo8pyzDP8J+PkWmlA==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.5.1",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "1.4.0",
+    "@glance-apps/sync": "1.5.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -534,6 +534,16 @@ const DayPlanner = () => {
   const [vaultStatus, setVaultStatus] = useState('idle');
   const [vaultError, setVaultError] = useState(null);
   const [vaultLastSynced, setVaultLastSynced] = useState(null);
+  // Count of synced rows the last cycle couldn't decrypt (skipped/quarantined by
+  // the engine) — surfaced in Cloud Sync settings so a key mismatch is visible.
+  const [vaultSkipped, setVaultSkipped] = useState(0);
+  // Map the engine's typed error codes to a user-facing message. KEY_MISMATCH
+  // (wrong passphrase/salt) gets a clear instruction instead of the raw crypto text.
+  const vaultErrorText = (msg, code) => {
+    if (!msg) return null;
+    if (code === 'KEY_MISMATCH') return 'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.';
+    return msg;
+  };
   const engineFolderRef = useRef(null);
   const syncFolder = cloudSyncConfig?.syncFolder ?? 'GLANCE/dayglance';
   const autoBackupProviders = useMemo(() => createAutoBackupProvidersForFolder(syncFolder), [syncFolder]);
@@ -1708,7 +1718,11 @@ const DayPlanner = () => {
           setVaultLastSynced(dbEngineRef.current?.getLastSynced?.() || new Date().toISOString());
         }
       },
-      onError: (msg) => { setVaultError(msg || null); if (msg) console.warn('[dayglance] vault sync error:', msg); },
+      onError: (msg, code) => { setVaultError(vaultErrorText(msg, code)); if (msg) console.warn('[dayglance] vault sync error:', code || '', msg); },
+      onRowsSkipped: (count) => {
+        setVaultSkipped(count);
+        if (count > 0) setUndoToast({ message: `GLANCEvault: ${count} item${count === 1 ? '' : 's'} couldn't be read — see Cloud Sync settings`, actionable: false });
+      },
     });
     if (!engine) return;
     dbEngineRef.current = engine;
@@ -8498,20 +8512,22 @@ const DayPlanner = () => {
     // (e.g. an unreachable vault) and roll back instead of reloading.
     vaultBootstrapSync: async () => {
       let bootErr = null;
+      let bootCode = null;
       const eng = createDbEngine({
         getData:    () => engineCallbacksRef.current.buildPayload?.()?.data,
         commitData: (data) => engineCallbacksRef.current.applyPayload?.(data, { allowEmpty: true }),
         onStatusChange: (s) => setVaultStatus(s),
-        onError:    (msg) => { if (msg) bootErr = msg; },
+        onError:    (msg, code) => { if (msg) { bootErr = msg; bootCode = code; } },
+        onRowsSkipped: (count) => setVaultSkipped(count),
       });
       if (!eng) return { ok: false, error: 'GLANCEvault is not configured.' };
       await eng.dbSyncCycle();
-      if (bootErr) return { ok: false, error: bootErr };
+      if (bootErr) return { ok: false, error: bootErr, code: bootCode };
       setVaultError(null);
       setVaultLastSynced(eng.getLastSynced?.() || new Date().toISOString());
       return { ok: true };
     },
-    vaultStatus, vaultError, vaultLastSynced,
+    vaultStatus, vaultError, vaultLastSynced, vaultSkipped,
     syncAll,
     performObsidianSync, loadWikiNote, saveWikiNote, openInObsidian, nativeClearVault,
     performTrmnlSync,

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -63,8 +63,10 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   const vaultReady = !vaultFilled || (vaultEncryptionReady && passphraseAvailable);
 
   // Save is enabled when EITHER transport is fully set up (vault no longer gated
-  // on the WebDAV connection).
-  const canSave = (webdavConfigured || vaultFilled) && passphraseValid && !passphraseMismatch && vaultReady;
+  // on the WebDAV connection) OR the user is turning the vault OFF — so a
+  // vault-only device can disable it even though nothing remains configured.
+  const vaultBeingDisabled = !!vaultOriginal?.enabled && !vaultEnabled;
+  const canSave = (webdavConfigured || vaultFilled || vaultBeingDisabled) && passphraseValid && !passphraseMismatch && vaultReady;
 
   const handleTest = async () => {
     setTesting(true);
@@ -460,7 +462,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
           disabled={!canSave || vaultBootstrapping}
           className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
         >
-          {vaultBootstrapping ? 'Enabling…' : (cloudSyncConfig?.enabled ? 'Save' : 'Save & Enable')}
+          {vaultBootstrapping ? 'Enabling…' : ((cloudSyncConfig?.enabled || vaultOriginal?.enabled) ? 'Save' : 'Save & Enable')}
         </button>
       </div>
     </div>

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -7,7 +7,7 @@ import { createDbEngine, resetDbRootKey } from '../sync/dbEngine.js';
 import { useTranslation } from 'react-i18next';
 
 // Cloud sync settings form (extracted to avoid hooks-in-conditional issues)
-const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderClass, hoverBg, cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, cloudSyncNow, provider, currentProvider, onClose, cloudSyncLastSynced, cloudSyncStatus, cloudSyncError, vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced, onSyncKeyReady }) => {
+const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderClass, hoverBg, cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, cloudSyncNow, provider, currentProvider, onClose, cloudSyncLastSynced, cloudSyncStatus, cloudSyncError, vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced, vaultSkipped, onSyncKeyReady }) => {
   const { t } = useTranslation();
   const [formData, setFormData] = useState(() => {
     const initial = {
@@ -136,14 +136,14 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
           const boot = createDbEngine({ getData: () => ({}), commitData: () => {} });
           if (boot) await boot.ensureRootKey();
         }
-        if (!result.ok) throw new Error(result.error || 'sync failed');
+        if (!result.ok) { const e = new Error(result.error || 'sync failed'); e.code = result.code; throw e; }
       } catch (err) {
         setVaultBootstrapping(false);
         await resetDbRootKey(); // don't leave a bad key cached after a failed attempt
         setVaultConfig(vaultOriginal || null); // roll back so we don't half-enable
         const msg = err?.message || '';
         setVaultBootstrapError(
-          /decrypt/i.test(msg)
+          (err?.code === 'KEY_MISMATCH' || /decrypt/i.test(msg))
             ? 'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.'
             : /passphrase/i.test(msg)
               ? 'Enter your sync passphrase above to enable GLANCEvault.'
@@ -449,6 +449,11 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
                 Last synced: {new Date(vaultLastSynced).toLocaleString()}
               </p>
             ) : null}
+            {vaultSkipped > 0 && (
+              <p className="text-xs text-amber-500">
+                {vaultSkipped} item{vaultSkipped === 1 ? '' : 's'} couldn’t be read (skipped). This usually means a different sync passphrase was used on another device.
+              </p>
+            )}
           </>
         )}
       </div>

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Eye, EyeOff } from 'lucide-react';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { setupEncryptionKey, setSyncPassphrase, clearEncryptionKey, getSyncPassphrase } from '../utils/crypto.js';
 import { getVaultConfig, setVaultConfig } from '../sync/vaultConfig.js';
@@ -39,6 +39,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   const [vaultAccountId, setVaultAccountId] = useState(() => vaultOriginal?.accountId || '');
   const [vaultBootstrapping, setVaultBootstrapping] = useState(false);
   const [vaultBootstrapError, setVaultBootstrapError] = useState(null);
+  const [showVaultToken, setShowVaultToken] = useState(false);
 
   const activeProvider = cloudSyncProviders[formData.provider] || provider;
   const requiredFieldsFilled = activeProvider.configFields.every(f => formData[f.key]) && !!formData.syncFolder;
@@ -383,13 +384,23 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
             </div>
             <div>
               <label className={`block text-sm ${textSecondary} mb-1`}>Device token</label>
-              <input
-                type="password"
-                placeholder="Device bearer token"
-                value={vaultToken}
-                onChange={(e) => setVaultToken(e.target.value)}
-                className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
-              />
+              <div className="relative">
+                <input
+                  type={showVaultToken ? 'text' : 'password'}
+                  placeholder="Device bearer token"
+                  value={vaultToken}
+                  onChange={(e) => setVaultToken(e.target.value)}
+                  className={`w-full px-3 py-2 pr-10 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowVaultToken(v => !v)}
+                  aria-label={showVaultToken ? 'Hide device token' : 'Show device token'}
+                  className={`absolute inset-y-0 right-0 flex items-center px-3 ${textSecondary}`}
+                >
+                  {showVaultToken ? <EyeOff size={18} /> : <Eye size={18} />}
+                </button>
+              </div>
             </div>
             <div>
               <label className={`block text-sm ${textSecondary} mb-1`}>Account ID</label>

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -79,7 +79,7 @@ const MobileSettingsPanel = () => {
     obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
     wikilinkCandidates, setWikilinkCandidates,
     cloudSyncTest, cloudSyncNow,
-    vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced,
+    vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced, vaultSkipped,
     syncAll, performObsidianSync, performRemoteBackup, nativeClearVault,
     loadAutoBackupHistory,
     deleteLocalAutoBackup, deleteRemoteAutoBackup,
@@ -1321,6 +1321,7 @@ const MobileSettingsPanel = () => {
         vaultStatus={vaultStatus}
         vaultError={vaultError}
         vaultLastSynced={vaultLastSynced}
+        vaultSkipped={vaultSkipped}
         onSyncKeyReady={(ready) => setSyncKeyReady(ready)}
       />
     </div>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -51,7 +51,7 @@ const SettingsModal = () => {
     handleFileUpload,
     cloudSyncConfig, setCloudSyncConfig, cloudSyncTest, cloudSyncLastSynced,
     cloudSyncStatus, cloudSyncError, cloudSyncNow,
-    vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced,
+    vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced, vaultSkipped,
     syncKeyReady, setSyncKeyReady,
     calSyncConfigured, syncUrl, setSyncUrl,
     showCalendarUrlHint, setShowCalendarUrlHint,
@@ -744,6 +744,7 @@ const SettingsModal = () => {
                         vaultStatus={vaultStatus}
                         vaultError={vaultError}
                         vaultLastSynced={vaultLastSynced}
+                        vaultSkipped={vaultSkipped}
                         onSyncKeyReady={(ready) => setSyncKeyReady(ready)}
                       />
                       </>)}

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -202,7 +202,10 @@ export function createDbEngine(callbacks = {}) {
       }
 
       callbacks.onStatusChange?.('downloading');
-      await engine.pullRemoteChanges();   // merge remote into mirror first
+      const pull = await engine.pullRemoteChanges();   // merge remote into mirror first
+      // The engine's onRowsSkipped fires from its own dbSyncCycle, which we
+      // bypass — so surface undecryptable-row skips from the pull result here.
+      if (pull && pull.skipped > 0) callbacks.onRowsSkipped?.(pull.skipped, pull.skippedEntityIds || []);
       reconcileCrossList(mirror, (id) => engine.markDirty(id));
       callbacks.onStatusChange?.('uploading');
       await engine.pushDirtyRows();        // push merged superset + local changes
@@ -211,10 +214,12 @@ export function createDbEngine(callbacks = {}) {
       callbacks.commitData?.(clone(mirror));
       saveSnapshot(snapshotShred(mirror));
       callbacks.onStatusChange?.('success');
+      return { applied: pull?.applied ?? 0, skipped: pull?.skipped ?? 0, skippedEntityIds: pull?.skippedEntityIds ?? [] };
     } catch (err) {
       const code = err && err.code ? err.code : 'NETWORK_ERROR';
       callbacks.onError?.(err?.message || String(err), code);
       callbacks.onStatusChange?.('error');
+      return { applied: 0, skipped: 0, skippedEntityIds: [], error: err?.message, code };
     } finally {
       syncing = false;
     }


### PR DESCRIPTION
A batch of GLANCEvault (Beta) reliability fixes found while testing on real devices, plus wiring up the new `@glance-apps/sync` 1.5.0 safeguards. Patch release **v3.5.1** (no new features).

## 1. Disable the vault when it's the only transport
On a device where GLANCEvault was the *only* thing configured (e.g. mobile, no WebDAV), unchecking **Sync via GLANCEvault** left **Save** greyed out — `canSave` required a configured transport, so the "off" state could never be saved. Save is now also allowed when the vault is being disabled, and the button reads **"Save"** (not "Save & Enable") when something was already enabled. Disabling clears the cached DB root key, so it's also the supported way to reset a device's vault key.

## 2. Show/hide toggle on the Device token field
An eyeball button reveals the vault Device token so you can verify what you pasted/typed.

## 3. @glance-apps/sync 1.5.0 — verifier + quarantine, surfaced in the UI
1.5.0 adds a key **verifier** (a wrong passphrase/salt is caught up front and the device uploads nothing) and per-row **quarantine** (one undecryptable row is skipped, not a hard wedge). dayGLANCE now consumes both:
- `createDbEngine` forwards `onRowsSkipped` (read from the pull result, since our composed pull-then-push cycle bypasses the engine's own `dbSyncCycle`); the cycle resolves to `{ applied, skipped, skippedEntityIds }`.
- The typed `KEY_MISMATCH` code maps to a clear **"Wrong sync passphrase — it must exactly match the passphrase used on your other devices"** message (at enable-time Save and during ongoing sync) instead of the raw crypto text.
- Skipped rows surface as a transient toast plus a durable amber count in the GLANCEvault settings section; `vaultSkipped` is threaded through both settings panels.
- `vaultBootstrapSync` returns the error code so enabling with the wrong passphrase fails Save with the clear message (and uploads nothing).

## 4. Versioning
- App **3.5.0 → 3.5.1** (package.json + lockfile + README badge).
- Android `versionName` stays **3.5** (major.minor); `versionCode` 122 → **125** across this batch.

## Testing
- `vite build` clean; full suite **294/294** (the real-engine sync tests round-trip the new verifier row through the in-memory vault).

Scope: `src/sync/dbEngine.js`, `src/App.jsx`, `src/components/CloudSyncSettingsForm.jsx`, `src/components/SettingsModal.jsx`, `src/components/MobileSettingsPanel.jsx`, `package.json`, `package-lock.json`, `README.md`, `dayglance-android/app/build.gradle.kts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01939L4RyjfxWxi65QDACQPK