### PR TITLE
GLANCEvault: @glance-apps/sync 1.5.2 (accountId validation) + clearer error messages (v3.5.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.5.1-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.5.2-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 126
+        versionCode = 127
         versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 125
+        versionCode = 126
         versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 127
+        versionCode = 128
         versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.5.2",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "1.5.1",
+        "@glance-apps/sync": "1.5.2",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -2267,9 +2267,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.1.tgz",
-      "integrity": "sha512-I51Ldfb9wy2wGb/uM71A+K87/bsh91OrmpYQ0FeP/Rci8wy88d8WYLr4Q7RIaaBH3Zt2iOFsB1iovFgyBlZG4A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.2.tgz",
+      "integrity": "sha512-S+O/bsGxtkDzcVBPhI8DlTiy89cfOwe9XGFaZoD3G1m2kZzOW9RnKNqHYuPSP2+Auy0RFPBQla+45nhm6WuN+A==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "dayglance",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "1.5.0",
+        "@glance-apps/sync": "1.5.1",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -2267,9 +2267,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.0.tgz",
-      "integrity": "sha512-Sm1WLT+x/1fxBZ1rkN+/OQif2w3padII1pAppnP6IJQXVmGs5PlPmpjjIP8e5kJnI+Hs0Qo8pyzDP8J+PkWmlA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.1.tgz",
+      "integrity": "sha512-I51Ldfb9wy2wGb/uM71A+K87/bsh91OrmpYQ0FeP/Rci8wy88d8WYLr4Q7RIaaBH3Zt2iOFsB1iovFgyBlZG4A==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "1.5.1",
+    "@glance-apps/sync": "1.5.2",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.5.1",
+  "version": "3.5.2",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "1.5.0",
+    "@glance-apps/sync": "1.5.1",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -544,6 +544,7 @@ const DayPlanner = () => {
     if (!msg) return null;
     if (code === 'KEY_MISMATCH') return 'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.';
     if (code === 'VERIFIER_UNSUPPORTED') return 'Your GLANCEvault server needs to be updated to support this app version (key verification).';
+    if (code === 'ACCOUNT_ID_REQUIRED') return 'GLANCEvault is missing an account ID — re-open Cloud Sync settings and re-enter your GLANCEvault details.';
     return msg;
   };
   const engineFolderRef = useRef(null);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -538,10 +538,12 @@ const DayPlanner = () => {
   // the engine) — surfaced in Cloud Sync settings so a key mismatch is visible.
   const [vaultSkipped, setVaultSkipped] = useState(0);
   // Map the engine's typed error codes to a user-facing message. KEY_MISMATCH
-  // (wrong passphrase/salt) gets a clear instruction instead of the raw crypto text.
+  // (wrong passphrase/salt) and VERIFIER_UNSUPPORTED (server too old for the key
+  // verifier) get clear instructions instead of the raw crypto/HTTP text.
   const vaultErrorText = (msg, code) => {
     if (!msg) return null;
     if (code === 'KEY_MISMATCH') return 'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.';
+    if (code === 'VERIFIER_UNSUPPORTED') return 'Your GLANCEvault server needs to be updated to support this app version (key verification).';
     return msg;
   };
   const engineFolderRef = useRef(null);

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -143,11 +143,13 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
         setVaultConfig(vaultOriginal || null); // roll back so we don't half-enable
         const msg = err?.message || '';
         setVaultBootstrapError(
-          (err?.code === 'KEY_MISMATCH' || /decrypt/i.test(msg))
-            ? 'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.'
-            : /passphrase/i.test(msg)
-              ? 'Enter your sync passphrase above to enable GLANCEvault.'
-              : `Couldn't reach GLANCEvault — check the vault URL and device token. (${msg || 'request failed'})`,
+          err?.code === 'VERIFIER_UNSUPPORTED'
+            ? 'Your GLANCEvault server needs to be updated to support this app version (key verification).'
+            : (err?.code === 'KEY_MISMATCH' || /decrypt/i.test(msg))
+              ? 'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.'
+              : /passphrase/i.test(msg)
+                ? 'Enter your sync passphrase above to enable GLANCEvault.'
+                : `Couldn't reach GLANCEvault — check the vault URL and device token. (${msg || 'request failed'})`,
         );
         return;
       }

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -145,6 +145,8 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
         setVaultBootstrapError(
           err?.code === 'VERIFIER_UNSUPPORTED'
             ? 'Your GLANCEvault server needs to be updated to support this app version (key verification).'
+            : err?.code === 'ACCOUNT_ID_REQUIRED'
+            ? 'GLANCEvault is missing an account ID — re-enter your GLANCEvault details (URL, device token, and account ID) above.'
             : (err?.code === 'KEY_MISMATCH' || /decrypt/i.test(msg))
               ? 'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.'
               : /passphrase/i.test(msg)

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -126,6 +126,28 @@ export function createDbEngine(callbacks = {}) {
       }
       : (electronProxyFetch || undefined));
 
+  // Diagnostic: wrap the transport so every vault request logs its method, full
+  // URL (which carries accountId + entityId) and HTTP status on failure. Turns a
+  // bare "get row failed: 400" into the exact request that produced it, so we can
+  // see at a glance whether accountId is populated and which entityId/route the
+  // server rejected — instead of guessing across repos. Quiet on success.
+  const rawFetch = fetchImpl || ((...a) => globalThis.fetch(...a));
+  const loggingFetch = async (url, opts = {}) => {
+    let res;
+    try {
+      res = await rawFetch(url, opts);
+    } catch (e) {
+      console.warn('[dayglance vault]', opts.method || 'GET', String(url), '→ network error:', e?.message || e);
+      throw e;
+    }
+    if (!res || res.ok === false) console.warn('[dayglance vault]', opts.method || 'GET', String(url), '→', res?.status);
+    return res;
+  };
+
+  // Surface the accountId the engine is actually constructed with (settles the
+  // "empty accountId?" question directly).
+  console.info('[dayglance vault] engine accountId:', JSON.stringify(cfg.accountId ?? null), 'vaultUrl:', cfg.vaultUrl || '(none)');
+
   const loadSnapshot = () => {
     try { return JSON.parse(localStorage.getItem(SNAPSHOT_KEY) || '{}'); } catch { return {}; }
   };
@@ -145,9 +167,9 @@ export function createDbEngine(callbacks = {}) {
     vaultUrl: cfg.vaultUrl,
     vaultToken: cfg.vaultToken,
     accountId: cfg.accountId,
+    fetchImpl: loggingFetch,
     deviceId: callbacks.deviceId || getDeviceId(),
     vaultClient: callbacks.vaultClient,
-    fetchImpl,
     nativeGetSyncKey,
     nativeStoreSyncKey,
     getLocalEntity: (entityId) => adapterGetLocalEntity(mirror, entityId),

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -144,10 +144,6 @@ export function createDbEngine(callbacks = {}) {
     return res;
   };
 
-  // Surface the accountId the engine is actually constructed with (settles the
-  // "empty accountId?" question directly).
-  console.info('[dayglance vault] engine accountId:', JSON.stringify(cfg.accountId ?? null), 'vaultUrl:', cfg.vaultUrl || '(none)');
-
   const loadSnapshot = () => {
     try { return JSON.parse(localStorage.getItem(SNAPSHOT_KEY) || '{}'); } catch { return {}; }
   };


### PR DESCRIPTION
Closes out the GLANCEvault key-verifier / "get row failed: 400" story by pulling in `@glance-apps/sync` **1.5.2** and mapping its new typed errors to clear, actionable messages.

## Root cause (fixed in 1.5.2, engine-side)
The `400 {"error":"accountId is required"}` we chased across repos came from a **whitespace-only `accountId`** passing the engine's old falsy check and going out on the wire as `?accountId=`. 1.5.2:
- Validates `accountId` on **every** row-scoped vault call (read/write/verifier GET).
- The verifier GET now correctly carries `accountId`.
- Constructs reject empty/whitespace `accountId`.
- Throws a typed, **retryable** `ACCOUNT_ID_REQUIRED` instead of letting a bad request hit the server.

No dayGLANCE API change was required — this is an engine fix — but we surface the new error nicely.

## Changes
- **Pin `@glance-apps/sync` → 1.5.2** exact; lockfile synced.
- **Map `ACCOUNT_ID_REQUIRED`** to a clear message on both surfaces — ongoing sync (`App.vaultErrorText`) and enable-time bootstrap (`CloudSyncSettingsForm`).
- **Still maps `VERIFIER_UNSUPPORTED`** (server too old for the key verifier) and `KEY_MISMATCH` (wrong passphrase).
- **Removed** the temporary `[dayglance vault] engine accountId` `console.info` diagnostic (the engine validates `accountId` itself now); the failure-only `loggingFetch` stays.
- **Release v3.5.2** — `package.json` + lockfile + README badge.
- **Android** `versionName` stays `3.5`; `versionCode` → **128**.

## Testing
- `vite build` clean; full suite **294/294**.

Scope: `src/App.jsx`, `src/components/CloudSyncSettingsForm.jsx`, `src/sync/dbEngine.js`, `package.json`, `package-lock.json`, `dayglance-android/app/build.gradle.kts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01939L4RyjfxWxi65QDACQPK