### PR TITLE
Release v3.5.1 (renumber from unreleased 3.5.2)

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 128
+        versionCode = 129
         versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.5.2",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.5.2",
+      "version": "3.5.1",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.5.2",
+  "version": "3.5.1",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Renumber the upcoming release from `3.5.2` down to **`3.5.1`**.

`v3.5.0` is the last actually-released version. During last night's GLANCEvault debugging the version was bumped to `3.5.2` across a couple of unreleased PRs, but **no `3.5.1` or `3.5.2` tag was ever cut** — so the next release is free to take the natural next patch number, `v3.5.1`.

## Changes

- `package.json`: `version` `3.5.2` → `3.5.1`
- `package-lock.json`: root package `version` (both refs) `3.5.2` → `3.5.1`

The unrelated `ajv-keywords@3.5.2` dependency entry in the lockfile is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTke3Bmt7tj9raPa7A5Sp5)_