### PR TITLE
Mark task & event reminders as time-sensitive (iOS) / DND-categorised (Android)

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
@@ -84,6 +84,9 @@ class NotificationBridge(private val context: Context) {
             .setContentTitle(title)
             .setContentText(body)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
+            // CATEGORY_REMINDER lets the alert ride through Do Not Disturb when the
+            // user has the Reminders exception enabled — the parallel to iOS Time Sensitive.
+            .setCategory(NotificationCompat.CATEGORY_REMINDER)
             .setContentIntent(tapPendingIntent())
             .setAutoCancel(true)
             .build()
@@ -124,6 +127,9 @@ class NotificationBridge(private val context: Context) {
             .setContentTitle(title)
             .setContentText(body)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
+            // Categorise so the alert can pass through Do Not Disturb (Android's
+            // equivalent of iOS Time Sensitive): events vs task reminders.
+            .setCategory(if (isCalendarEvent) NotificationCompat.CATEGORY_EVENT else NotificationCompat.CATEGORY_REMINDER)
             .setContentIntent(tapPendingIntent())
             .setAutoCancel(true)
 
@@ -314,6 +320,7 @@ class NotificationBridge(private val context: Context) {
                 .setContentTitle(task.optString("title", "Up Next"))
                 .setContentText(task.optString("bodyText", ""))
                 .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setCategory(NotificationCompat.CATEGORY_STATUS)
                 .setOngoing(true)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .setOnlyAlertOnce(true)
@@ -379,6 +386,7 @@ class NotificationBridge(private val context: Context) {
             .setSubText("Focus Mode")
             .setContentTitle(phaseLabel)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_STOPWATCH)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)

--- a/dayglance-android/app/src/main/java/com/dayglance/app/notifications/ReminderReceiver.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/notifications/ReminderReceiver.kt
@@ -75,6 +75,9 @@ class ReminderReceiver : BroadcastReceiver() {
             .setContentTitle(title)
             .setContentText(body)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
+            // Categorise so the alert can pass through Do Not Disturb (Android's
+            // equivalent of iOS Time Sensitive): events vs task reminders.
+            .setCategory(if (isCalendar) NotificationCompat.CATEGORY_EVENT else NotificationCompat.CATEGORY_REMINDER)
             .setContentIntent(tapIntent)
             .setAutoCancel(true)
 

--- a/dayglance-ios/DayGlance/Bridges/NotificationBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/NotificationBridge.swift
@@ -217,6 +217,9 @@ final class NotificationBridge {
         c.title = title
         c.body  = body
         c.sound = .default
+        // Task and event reminders are time-critical: surface them through Focus /
+        // Do Not Disturb (subject to the user's per-app Time Sensitive permission).
+        c.interruptionLevel = .timeSensitive
         return c
     }
 

--- a/dayglance-ios/DayGlance/DayGlance.entitlements
+++ b/dayglance-ios/DayGlance/DayGlance.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<key>com.apple.developer.usernotifications.time-sensitive</key>
+	<true/>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.dayglance</string>

--- a/docs/dayglance-ios-app.md
+++ b/docs/dayglance-ios-app.md
@@ -336,7 +336,7 @@ An iOS Share Extension lets users share text or URLs from any app (Safari, Notes
 - `UNNotificationServiceExtension` not needed — action handling in `UNUserNotificationCenterDelegate`
 - No boot receiver needed (iOS restores notifications automatically)
 
-**Status: ✅ Complete.** All six bridge methods implemented. Snooze + Mark Complete action categories registered at launch via `AppDelegate`. `UNUserNotificationCenterDelegate` wired for foreground banner presentation and action handling.
+**Status: ✅ Complete.** All six bridge methods implemented. Snooze + Mark Complete action categories registered at launch via `AppDelegate`. `UNUserNotificationCenterDelegate` wired for foreground banner presentation and action handling. Reminders are sent at `.timeSensitive` interruption level (with the `com.apple.developer.usernotifications.time-sensitive` entitlement) so they surface through Focus / Do Not Disturb, subject to the user's per-app permission. Android parity: reminder notifications carry `CATEGORY_REMINDER` (or `CATEGORY_EVENT` for calendar events) so they ride through DND under the matching exception.
 
 ### Phase 5 — File access + Obsidian
 


### PR DESCRIPTION
## What

Surfaces task and event reminders through Focus / Do Not Disturb on both platforms, so time-critical reminders aren't silently swallowed.

### iOS
- `NotificationBridge.swift` — reminder content is now sent at `.timeSensitive` interruption level (set in `makeContent`, so it applies to every reminder path: scheduled, task, sync, and snooze reschedule).
- `DayGlance.entitlements` — added `com.apple.developer.usernotifications.time-sensitive`, required for the Time Sensitive interruption level to take effect.
- No availability guard needed — deployment target is iOS 16 (the API is iOS 15+).

### Android (parity)
The Android equivalent of iOS Time Sensitive is the notification **category**, which lets an alert ride through DND when the user has the matching exception enabled (importance was already `IMPORTANCE_HIGH`):
- Reminder notifications now carry `CATEGORY_REMINDER`, or `CATEGORY_EVENT` for calendar events — applied on all three reminder builders, including the background `ReminderReceiver` path that fires when the app is closed.
- Consistency bonus: the persistent "Up Next" notification gets `CATEGORY_STATUS` and the focus-timer notification gets `CATEGORY_STOPWATCH`.

### Docs
- Updated the Phase 4 status note in `docs/dayglance-ios-app.md` to record both changes.

## Why

Both behaviours respect the user's per-app permission/exception — this is the standard, non-intrusive way to ensure reminders reach the user during Focus modes without resorting to Critical Alerts (iOS) or forced DND bypass (Android).

## Testing notes

Behavioural change in native notification delivery — not covered by automated tests. Worth a manual check on device: enable a Focus mode and confirm a fired reminder surfaces (with the per-app Time Sensitive / Reminders exception granted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fkz91n9RQnFyqMNCrWwHuM)_