### PR TITLE
Sync iOS status bar colour with the app's dark mode

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/StatusBarBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/StatusBarBridge.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+/// Drives the status bar content colour from the web layer's theme.
+///
+/// dayGLANCE owns its own dark/light source of truth — an in-app toggle that is
+/// independent of the system appearance — so the native side can't infer the
+/// status bar colour from the system trait collection; the web layer has to tell
+/// it (mirroring the Android `setStatusBarAppearance` bridge call).
+///
+/// With `UIViewControllerBasedStatusBarAppearance` = NO and `UIStatusBarStyle` =
+/// default (adaptive on iOS 13+), the status bar content colour resolves from the
+/// key window's user interface style. Overriding that style therefore flips the
+/// status bar text: dark theme → light (white) text, light theme → dark text.
+final class StatusBarBridge {
+
+    static let shared = StatusBarBridge()
+
+    private init() {}
+
+    func setAppearance(isDark: Bool) {
+        // URL-scheme handler callbacks may run off the main thread; UIKit window
+        // mutation must happen on the main queue.
+        DispatchQueue.main.async {
+            let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+            let window = scenes.flatMap { $0.windows }.first { $0.isKeyWindow }
+                ?? scenes.first?.windows.first
+            window?.overrideUserInterfaceStyle = isDark ? .dark : .light
+        }
+    }
+}

--- a/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
+++ b/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
@@ -211,6 +211,12 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
             HapticBridge.shared.trigger(type)
             return "null"
 
+        // Phase 11 — Status bar appearance (sync with web layer's dark mode)
+        case "setStatusBarAppearance":
+            guard let isDark = args.first as? Bool else { return "null" }
+            StatusBarBridge.shared.setAppearance(isDark: isDark)
+            return "null"
+
         // Phase 11 — Spotlight
         case "indexSpotlight":
             guard let json = args.first as? String else { return "null" }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1369,9 +1369,9 @@ const DayPlanner = () => {
     const themeColorMeta = document.querySelector('meta[name="theme-color"]');
     if (themeColorMeta) themeColorMeta.setAttribute('content', darkMode ? '#1f2937' : '#ffffff');
     // Sync status-bar icon colour with the app's own theme.  The app has its own
-    // dark-mode toggle independent of the Android OS setting, so the Kotlin side
-    // can't reliably read resources.configuration.uiMode — it has to be told.
-    if (isNativeAndroid()) window.DayGlanceNative?.setStatusBarAppearance?.(darkMode);
+    // dark-mode toggle independent of the OS appearance setting, so the native
+    // side can't reliably read the system uiMode/trait — it has to be told.
+    if (isNativeApp()) window.DayGlanceNative?.setStatusBarAppearance?.(darkMode);
   }, [darkMode]);
 
   useEffect(() => {


### PR DESCRIPTION
## What

The iOS status bar text no longer follows the app's own dark-mode toggle. Because dayGLANCE's dark mode is independent of the system appearance, the status bar could end up showing dark text on the app's dark background — effectively invisible. This wires the status bar to the web layer's theme, matching how Android already handles it.

## How

The Android side already has a `setStatusBarAppearance(isDark)` bridge that the web layer calls on every `darkMode` change (`App.jsx`). This PR:

- **`src/App.jsx`** — extends that call's guard from `isNativeAndroid()` to `isNativeApp()` so iOS receives the same signal. (`isNativeApp` was already imported; the call is a no-op on web/PWA.)
- **`StatusBarBridge.swift`** (new) — flips the key window's `overrideUserInterfaceStyle` to `.dark` / `.light`. With `UIViewControllerBasedStatusBarAppearance = NO` and the adaptive `UIStatusBarStyle = default` (both already set in `project.yml`), the status bar content colour resolves from that style: dark theme → light (white) text, light theme → dark text. Runs on the main queue since URL-scheme handler callbacks may be off-main.
- **`BridgeSchemeHandler.swift`** — dispatches the `setStatusBarAppearance` method (boolean arg) to the new bridge.

No `project.yml` / Info.plist changes needed — the existing adaptive `UIStatusBarStyleDefault` is exactly what this leverages. The new Swift file is picked up automatically by XcodeGen (the target globs the `DayGlance` source dir).

## Notes

- This was the one genuine "final touch" gap from an iOS audit; it's the item the iOS planning doc had carried over as Phase 1 → Phase 12 polish.
- Behavioural/native change — not covered by automated tests. Worth a quick on-device check: toggle in-app dark mode while the **system** is in light mode and confirm the status bar text flips to white (and back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fkz91n9RQnFyqMNCrWwHuM)_