### PR TITLE
Bump Android versionCode to 130

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 129
+        versionCode = 130
         versionName = "3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## What

Bumps the Android `versionCode` from `129` to `130` in `dayglance-android/app/build.gradle.kts`.

`versionName` stays at `3.5` and no other version metadata changes — this is a build-number increment only, not a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fkz91n9RQnFyqMNCrWwHuM)_