### PR TITLE
Cloud sync settings: passphrase fix, WebDAV toggle, per-device feature toggles

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/CryptoKeyBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/CryptoKeyBridge.kt
@@ -19,6 +19,14 @@ import java.security.KeyStore
  * Keystore key and persist the ciphertext in SharedPreferences. On retrieval,
  * [getSyncKey] unwraps and returns the original base64 blob to JS.
  *
+ * Slots: the app has more than one independent key (the WebDAV file-tier key and
+ * the GLANCEvault DB root key derive differently and must NOT share storage, or
+ * each would clobber the other on this single bridge). [storeSyncKey]/[getSyncKey]
+ * operate on the legacy default slot (the file tier, preserving keys written by
+ * older builds). [storeSyncKeyForSlot]/[getSyncKeyForSlot] namespace the
+ * SharedPreferences entry by `slot` so each tier gets isolated storage. All slots
+ * are wrapped by the same device-bound Keystore key.
+ *
  * The Keystore key never leaves the hardware security module. Even if
  * SharedPreferences were extracted from a device backup, the ciphertext is
  * useless without the device's Keystore key.
@@ -60,18 +68,20 @@ class CryptoKeyBridge(private val context: Context) {
         return keyGen.generateKey()
     }
 
-    /**
-     * Encrypts [b64] (the JS sync key blob) with the Keystore key and persists
-     * the ciphertext. Pass null to clear the stored key (e.g. when encryption
-     * is disabled).
-     *
-     * Called from JS as: `window.DayGlanceNative.storeSyncKey(b64)`
-     */
-    @JavascriptInterface
-    fun storeSyncKey(b64: String?) {
+    // SharedPreferences keys for a slot. The default slot (null/empty) keeps the
+    // original key names so keys written by older builds stay readable; named
+    // slots get a per-slot suffix.
+    private fun ciphertextKey(slot: String?): String =
+        if (slot.isNullOrEmpty()) PREF_CIPHERTEXT else "${PREF_CIPHERTEXT}_$slot"
+    private fun ivKey(slot: String?): String =
+        if (slot.isNullOrEmpty()) PREF_IV else "${PREF_IV}_$slot"
+
+    // Wrap [b64] with the device-bound Keystore key and persist it under [slot],
+    // or clear that slot when [b64] is null.
+    private fun storeForSlot(slot: String?, b64: String?) {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         if (b64 == null) {
-            prefs.edit().remove(PREF_CIPHERTEXT).remove(PREF_IV).apply()
+            prefs.edit().remove(ciphertextKey(slot)).remove(ivKey(slot)).apply()
             return
         }
         val plaintext = Base64.decode(b64, Base64.DEFAULT)
@@ -80,22 +90,17 @@ class CryptoKeyBridge(private val context: Context) {
         cipher.init(Cipher.ENCRYPT_MODE, key)
         val ciphertext = cipher.doFinal(plaintext)
         prefs.edit()
-            .putString(PREF_CIPHERTEXT, Base64.encodeToString(ciphertext, Base64.DEFAULT))
-            .putString(PREF_IV,         Base64.encodeToString(cipher.iv,  Base64.DEFAULT))
+            .putString(ciphertextKey(slot), Base64.encodeToString(ciphertext, Base64.DEFAULT))
+            .putString(ivKey(slot),         Base64.encodeToString(cipher.iv,  Base64.DEFAULT))
             .apply()
     }
 
-    /**
-     * Decrypts and returns the stored sync key blob, or "" if nothing is stored
-     * or decryption fails (e.g. after an app reinstall that cleared the Keystore).
-     *
-     * Called from JS as: `window.DayGlanceNative.getSyncKey()`
-     */
-    @JavascriptInterface
-    fun getSyncKey(): String {
+    // Unwrap and return the blob stored under [slot], or "" when absent or
+    // undecryptable (e.g. the Keystore key was replaced by a reinstall).
+    private fun loadForSlot(slot: String?): String {
         val prefs          = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val ciphertextB64  = prefs.getString(PREF_CIPHERTEXT, null) ?: return ""
-        val ivB64          = prefs.getString(PREF_IV,          null) ?: return ""
+        val ciphertextB64  = prefs.getString(ciphertextKey(slot), null) ?: return ""
+        val ivB64          = prefs.getString(ivKey(slot),          null) ?: return ""
         return try {
             val ciphertext = Base64.decode(ciphertextB64, Base64.DEFAULT)
             val iv         = Base64.decode(ivB64,          Base64.DEFAULT)
@@ -109,4 +114,41 @@ class CryptoKeyBridge(private val context: Context) {
             ""
         }
     }
+
+    /**
+     * Encrypts [b64] (the JS sync key blob) with the Keystore key and persists
+     * the ciphertext in the default slot. Pass null to clear the stored key
+     * (e.g. when encryption is disabled).
+     *
+     * Called from JS as: `window.DayGlanceNative.storeSyncKey(b64)`
+     */
+    @JavascriptInterface
+    fun storeSyncKey(b64: String?) = storeForSlot(null, b64)
+
+    /**
+     * Decrypts and returns the default-slot key blob, or "" if nothing is stored
+     * or decryption fails (e.g. after an app reinstall that cleared the Keystore).
+     *
+     * Called from JS as: `window.DayGlanceNative.getSyncKey()`
+     */
+    @JavascriptInterface
+    fun getSyncKey(): String = loadForSlot(null)
+
+    /**
+     * Like [storeSyncKey] but persists into the named [slot], isolated from the
+     * default slot and from every other slot. Used so the GLANCEvault DB root key
+     * never shares storage with the WebDAV file-tier key.
+     *
+     * Called from JS as: `window.DayGlanceNative.storeSyncKeyForSlot(slot, b64)`
+     */
+    @JavascriptInterface
+    fun storeSyncKeyForSlot(slot: String, b64: String?) = storeForSlot(slot, b64)
+
+    /**
+     * Like [getSyncKey] but reads the named [slot].
+     *
+     * Called from JS as: `window.DayGlanceNative.getSyncKeyForSlot(slot)`
+     */
+    @JavascriptInterface
+    fun getSyncKeyForSlot(slot: String): String = loadForSlot(slot)
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9890,9 +9890,10 @@ const DayPlanner = () => {
       {/* Keyboard Shortcut Cheat Sheet */}
       {showShortcutHelp && <ShortcutHelpModal />}
 
-      {/* Sync passphrase prompt — shown on app load when encryption is enabled
-          but no cached key was found in device storage (e.g. new device). */}
-      {cloudSyncConfig?.encryptionEnabled && syncKeyReady === false && (
+      {/* Sync passphrase prompt — shown on app load when an encrypted transport
+          (WebDAV encryption or GLANCEvault) is active but no cached key was found
+          in device storage (e.g. new device, or first launch after key isolation). */}
+      {(cloudSyncConfig?.encryptionEnabled || isVaultEnabled()) && syncKeyReady === false && (
         <SyncPassphraseModal
           darkMode={darkMode}
           textPrimary={textPrimary}

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -21,6 +21,11 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
     return initial;
   });
   const [encryptionEnabled, setEncryptionEnabled] = useState(cloudSyncConfig?.encryptionEnabled ?? false);
+  // WebDAV on/off, independent of whether the connection fields are filled — lets a
+  // device keep its WebDAV credentials but stop syncing (e.g. moving fully to
+  // GLANCEvault). Existing configured devices start checked; fresh ones start off
+  // and reveal the connection fields when checked (mirrors the encryption/vault toggles).
+  const [webdavEnabled, setWebdavEnabled] = useState(() => cloudSyncConfig?.enabled ?? false);
   const [passphrase, setPassphrase] = useState('');
   const [passphraseConfirm, setPassphraseConfirm] = useState('');
   const [testResult, setTestResult] = useState(null);
@@ -44,6 +49,11 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   const activeProvider = cloudSyncProviders[formData.provider] || provider;
   const requiredFieldsFilled = activeProvider.configFields.every(f => formData[f.key]) && !!formData.syncFolder;
   const webdavConfigured = requiredFieldsFilled;
+  // WebDAV syncs only when the user has it toggled on AND the connection is complete.
+  const webdavActive = webdavEnabled && webdavConfigured;
+  // True when the user is turning a previously-active WebDAV sync off, so Save stays
+  // enabled even if nothing else (vault) is configured.
+  const webdavBeingDisabled = !!cloudSyncConfig?.enabled && !webdavEnabled;
 
   // When enabling encryption, require a passphrase (confirmed) on fresh enable.
   // When already enabled, allow saving without re-entering (passphrase field is optional).
@@ -67,7 +77,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   // on the WebDAV connection) OR the user is turning the vault OFF — so a
   // vault-only device can disable it even though nothing remains configured.
   const vaultBeingDisabled = !!vaultOriginal?.enabled && !vaultEnabled;
-  const canSave = (webdavConfigured || vaultFilled || vaultBeingDisabled) && passphraseValid && !passphraseMismatch && vaultReady;
+  const canSave = (webdavActive || vaultFilled || vaultBeingDisabled || webdavBeingDisabled) && passphraseValid && !passphraseMismatch && vaultReady;
 
   const handleTest = async () => {
     setTesting(true);
@@ -79,9 +89,10 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
 
   const handleSave = async () => {
     setVaultBootstrapError(null);
-    // WebDAV is only marked enabled when its connection is actually configured, so
-    // enabling GLANCEvault alone never writes a bogus enabled WebDAV config.
-    const newConfig = { ...formData, provider: formData.provider, enabled: webdavConfigured, encryptionEnabled };
+    // WebDAV is marked enabled only when the user toggled it on AND the connection is
+    // configured — so enabling GLANCEvault alone never writes a bogus enabled WebDAV
+    // config, and unchecking the toggle disables sync while keeping the credentials.
+    const newConfig = { ...formData, provider: formData.provider, enabled: webdavActive, encryptionEnabled };
 
     if (encryptionEnabled) {
       if (passphraseRequired && passphrase) {
@@ -164,11 +175,6 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
     onClose();
   };
 
-  const handleDisable = () => {
-    setCloudSyncConfig({ ...cloudSyncConfig, enabled: false });
-    onClose();
-  };
-
   // Manual "Sync now" triggers — WebDAV file tier and GLANCEvault DB tier.
   const handleSyncNow = async () => {
     if (!cloudSyncNow) return;
@@ -190,100 +196,118 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
 
   return (
     <div className="space-y-4">
-      {/* ── WebDAV Connection ─────────────────────────────────────────────── */}
-      <h3 className={sectionHeader}>WebDAV Connection</h3>
+      {/* ── WebDAV Sync ───────────────────────────────────────────────────── */}
+      <h3 className={sectionHeader}>WebDAV Sync</h3>
 
-      <div>
-        <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Provider</label>
-        <select
-          value={formData.provider}
-          onChange={(e) => setFormData(prev => ({ ...prev, provider: e.target.value }))}
-          className={`w-full px-3 py-2 border ${borderClass} rounded-lg ${darkMode ? 'bg-gray-700 text-white' : 'bg-stone-100 text-stone-900'}`}
-        >
-          {Object.entries(cloudSyncProviders).map(([key, p]) => (
-            <option key={key} value={key}>{p.name}</option>
-          ))}
-        </select>
-      </div>
-
-      {activeProvider.configFields.map(field => (
-        <div key={field.key}>
-          <label className={`block text-sm font-medium ${textSecondary} mb-1`}>{field.label}</label>
-          <input
-            type={field.type}
-            placeholder={field.placeholder}
-            value={formData[field.key] || ''}
-            onChange={(e) => setFormData(prev => ({ ...prev, [field.key]: e.target.value }))}
-            className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
-          />
-          {field.type === 'password' && (
-            <p className={`text-xs ${textSecondary} mt-0.5`}>{t('settings.aiApiKeyHint')}</p>
-          )}
-        </div>
-      ))}
-
-      <div>
-        <label className={`block text-sm font-medium ${textSecondary} mb-1`}>{t('settings.syncFolder')}</label>
+      <label className="flex items-center gap-3 cursor-pointer select-none">
         <input
-          type="text"
-          placeholder="GLANCE/dayglance"
-          value={formData.syncFolder || ''}
-          onChange={(e) => setFormData(prev => ({ ...prev, syncFolder: e.target.value }))}
-          className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+          type="checkbox"
+          checked={webdavEnabled}
+          onChange={(e) => setWebdavEnabled(e.target.checked)}
+          className="w-5 h-5 rounded flex-shrink-0"
         />
-        <p className={`text-xs ${textSecondary} mt-0.5`}>Path on your WebDAV server where sync files are stored.</p>
-      </div>
+        <span className={`text-sm font-medium ${textPrimary}`}>Sync via WebDAV</span>
+      </label>
+      <p className={`text-xs ${textSecondary} ml-7`}>
+        Sync to any WebDAV server (Nextcloud, ownCloud, etc.). Turn this off to keep your
+        connection details but stop syncing on this device — for example when moving fully to GLANCEvault.
+      </p>
 
-      {activeProvider.helpText && (
-        <p className={`text-xs ${textSecondary}`}>{activeProvider.helpText}</p>
-      )}
+      {webdavEnabled && (
+        <div className="ml-7 space-y-4">
+          <div>
+            <label className={`block text-sm font-medium ${textSecondary} mb-1`}>Provider</label>
+            <select
+              value={formData.provider}
+              onChange={(e) => setFormData(prev => ({ ...prev, provider: e.target.value }))}
+              className={`w-full px-3 py-2 border ${borderClass} rounded-lg ${darkMode ? 'bg-gray-700 text-white' : 'bg-stone-100 text-stone-900'}`}
+            >
+              {Object.entries(cloudSyncProviders).map(([key, p]) => (
+                <option key={key} value={key}>{p.name}</option>
+              ))}
+            </select>
+          </div>
 
-      {/* WebDAV actions: Test Connection + Sync Now, with status below. */}
-      <div className="flex items-center gap-2">
-        <button
-          onClick={handleTest}
-          disabled={testing || !requiredFieldsFilled}
-          className={secondaryBtn}
-        >
-          {testing ? 'Testing...' : 'Test Connection'}
-        </button>
-        <button
-          onClick={handleSyncNow}
-          disabled={syncingNow || !cloudSyncConfig?.enabled}
-          title={!cloudSyncConfig?.enabled ? 'Enable WebDAV sync first' : 'Sync with WebDAV now'}
-          className={secondaryBtn}
-        >
-          {(syncingNow || cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'Syncing...' : 'Sync Now'}
-        </button>
-      </div>
-      {testResult && (
-        <p className={`text-sm ${testResult.success ? 'text-green-500' : 'text-red-500'}`}>
-          {testResult.success ? 'Connection successful!' : testResult.error}
-        </p>
-      )}
-      {cloudSyncStatus === 'error' && cloudSyncError ? (
-        <p className="text-xs text-red-500">{cloudSyncError}</p>
-      ) : cloudSyncLastSynced ? (
-        <p className={`text-xs ${textSecondary}`}>
-          Last synced: {new Date(cloudSyncLastSynced).toLocaleString()}
-        </p>
-      ) : null}
+          {activeProvider.configFields.map(field => (
+            <div key={field.key}>
+              <label className={`block text-sm font-medium ${textSecondary} mb-1`}>{field.label}</label>
+              <input
+                type={field.type}
+                placeholder={field.placeholder}
+                value={formData[field.key] || ''}
+                onChange={(e) => setFormData(prev => ({ ...prev, [field.key]: e.target.value }))}
+                className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+              />
+              {field.type === 'password' && (
+                <p className={`text-xs ${textSecondary} mt-0.5`}>{t('settings.aiApiKeyHint')}</p>
+              )}
+            </div>
+          ))}
 
-      {migrationOldPath && (
-        <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2.5 text-xs text-amber-800 space-y-1">
-          <p className="font-semibold">Optional: move sync folder</p>
-          <p>Your sync file is at the old location. You can move it for cleaner organization — sync will continue to work either way.</p>
-          <p className="font-mono break-all">{migrationOldPath} → GLANCE/dayglance/</p>
-          <p>After moving the file, update your Sync folder setting above to <span className="font-mono">GLANCE/dayglance</span>.</p>
-          <button
-            onClick={() => {
-              localStorage.removeItem('dayglance-sync-migration-old-path');
-              localStorage.setItem('dayglance-sync-migration-checked', '1');
-            }}
-            className="text-amber-700 underline mt-1"
-          >
-            Dismiss
-          </button>
+          <div>
+            <label className={`block text-sm font-medium ${textSecondary} mb-1`}>{t('settings.syncFolder')}</label>
+            <input
+              type="text"
+              placeholder="GLANCE/dayglance"
+              value={formData.syncFolder || ''}
+              onChange={(e) => setFormData(prev => ({ ...prev, syncFolder: e.target.value }))}
+              className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+            />
+            <p className={`text-xs ${textSecondary} mt-0.5`}>Path on your WebDAV server where sync files are stored.</p>
+          </div>
+
+          {activeProvider.helpText && (
+            <p className={`text-xs ${textSecondary}`}>{activeProvider.helpText}</p>
+          )}
+
+          {/* WebDAV actions: Test Connection + Sync Now, with status below. */}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleTest}
+              disabled={testing || !requiredFieldsFilled}
+              className={secondaryBtn}
+            >
+              {testing ? 'Testing...' : 'Test Connection'}
+            </button>
+            <button
+              onClick={handleSyncNow}
+              disabled={syncingNow || !cloudSyncConfig?.enabled}
+              title={!cloudSyncConfig?.enabled ? 'Enable WebDAV sync first' : 'Sync with WebDAV now'}
+              className={secondaryBtn}
+            >
+              {(syncingNow || cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'Syncing...' : 'Sync Now'}
+            </button>
+          </div>
+          {testResult && (
+            <p className={`text-sm ${testResult.success ? 'text-green-500' : 'text-red-500'}`}>
+              {testResult.success ? 'Connection successful!' : testResult.error}
+            </p>
+          )}
+          {cloudSyncStatus === 'error' && cloudSyncError ? (
+            <p className="text-xs text-red-500">{cloudSyncError}</p>
+          ) : cloudSyncLastSynced ? (
+            <p className={`text-xs ${textSecondary}`}>
+              Last synced: {new Date(cloudSyncLastSynced).toLocaleString()}
+            </p>
+          ) : null}
+
+          {migrationOldPath && (
+            <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2.5 text-xs text-amber-800 space-y-1">
+              <p className="font-semibold">Optional: move sync folder</p>
+              <p>Your sync file is at the old location. You can move it for cleaner organization — sync will continue to work either way.</p>
+              <p className="font-mono break-all">{migrationOldPath} → GLANCE/dayglance/</p>
+              <p>After moving the file, update your Sync folder setting above to <span className="font-mono">GLANCE/dayglance</span>.</p>
+              <button
+                onClick={() => {
+                  localStorage.removeItem('dayglance-sync-migration-old-path');
+                  localStorage.setItem('dayglance-sync-migration-checked', '1');
+                }}
+                className="text-amber-700 underline mt-1"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
         </div>
       )}
 
@@ -469,14 +493,6 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
         >
           Cancel
         </button>
-        {cloudSyncConfig?.enabled && (
-          <button
-            onClick={handleDisable}
-            className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
-          >
-            Disable
-          </button>
-        )}
         <button
           onClick={handleSave}
           disabled={!canSave || vaultBootstrapping}

--- a/src/hooks/useCloudSync.js
+++ b/src/hooks/useCloudSync.js
@@ -1,5 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { initSessionKey } from '../utils/crypto.js';
+import { isVaultEnabled } from '../sync/vaultConfig.js';
+import { restoreDbRootKey } from '../sync/dbEngine.js';
 
 const useCloudSync = () => {
   const [cloudSyncConfig, setCloudSyncConfig] = useState(() => {
@@ -64,25 +66,40 @@ const useCloudSync = () => {
     }
   }, [cloudSyncConfig]);
 
-  // On mount: attempt to restore the session encryption key from device storage.
-  // If encryption is enabled but no cached key exists, syncKeyReady stays false
-  // so the app can show the passphrase prompt.
+  // On mount: attempt to restore the cached encryption key(s) from device storage
+  // for whichever transports are active. syncKeyReady becomes false only when an
+  // active transport needs a key that isn't cached, so the app shows the passphrase
+  // prompt. Each tier has its OWN cached key (file tier vs GLANCEvault DB root key),
+  // so we restore exactly the ones in use:
+  //   • File tier  — needed only when WebDAV sync is enabled AND encrypted. A
+  //     vault-only device has encryptionEnabled=true but enabled=false, so it must
+  //     NOT be gated on the file-tier key (which it never writes) — that was the
+  //     cause of the every-launch re-prompt.
+  //   • GLANCEvault — needed whenever the vault is enabled; gated on its DB root key.
   useEffect(() => {
     const config = (() => {
       const saved = localStorage.getItem('day-planner-cloud-sync-config');
       return saved ? JSON.parse(saved) : null;
     })();
 
-    if (config?.encryptionEnabled) {
-      initSessionKey().then((found) => {
-        // found = true  → key restored silently, unlock sync immediately
-        // found = false → passphrase prompt will be shown by App
-        setSyncKeyReady(found);
-      });
-    } else {
-      // Encryption not configured — no passphrase needed.
+    const needFileKey  = !!(config?.enabled && config?.encryptionEnabled);
+    const needVaultKey = isVaultEnabled();
+
+    if (!needFileKey && !needVaultKey) {
+      // No encrypted transport active — no passphrase needed.
       setSyncKeyReady(true);
+      return;
     }
+
+    Promise.all([
+      needFileKey  ? initSessionKey()   : Promise.resolve(true),
+      needVaultKey ? restoreDbRootKey() : Promise.resolve(true),
+    ]).then(([fileOk, vaultOk]) => {
+      // Ready only when every active tier restored its key; otherwise App shows
+      // the passphrase prompt, and the entered passphrase re-derives + caches the
+      // missing key(s) on the next sync.
+      setSyncKeyReady(fileOk && vaultOk);
+    });
   }, []);
 
   return {

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -13,12 +13,14 @@ export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =
 // wrapped this function to patch the roster in; that stopgap is no longer
 // needed — the upstream merge covers every sync path directly.
 
-// Settings kept per-device: the upstream file-tier merge resolves these
-// last-writer-wins, but on a shared (multi-user) account that lets one person's
-// toggle flip the feature for everyone. We override the merged result back to
-// this device's local value so they never propagate. Mirrors the vault tier's
-// DEVICE_LOCAL_BUNDLES (src/sync/dbAdapter.js).
-const DEVICE_LOCAL_KEYS = ['habitsEnabled', 'routinesEnabled', 'goalsProjectsEnabled', 'obsidianConfig'];
+// Settings the upstream file-tier merge resolves last-writer-wins but which we
+// override back to this device's local value so they don't propagate. Mirrors
+// the vault tier (src/sync/dbAdapter.js):
+//  - obsidianConfig is ALWAYS device-local (the vault differs per machine).
+//  - the feature toggles are device-local ONLY when multi-user is on; a
+//    single-user install keeps syncing them LWW across that user's own devices.
+const ALWAYS_LOCAL_KEYS = ['obsidianConfig'];
+const MULTIUSER_LOCAL_KEYS = ['habitsEnabled', 'routinesEnabled', 'goalsProjectsEnabled'];
 export {
   mergeDailyNotes,
   mergeHabits,
@@ -137,8 +139,12 @@ export const mergeSyncData = (local, remote, retentionDays) => {
   if (habitLogsFix.localChanged) result.localChanged = true;
   if (habitLogsFix.remoteChanged) result.remoteChanged = true;
   // Keep device-local settings on this device's own value rather than the
-  // last-writer-wins result, so a household member's toggle never propagates.
-  for (const key of DEVICE_LOCAL_KEYS) {
+  // last-writer-wins result. Feature toggles only when multi-user is on, so a
+  // household member's toggle never propagates; single-user keeps syncing them.
+  const keepLocalKeys = local?.multiUserEnabled
+    ? [...ALWAYS_LOCAL_KEYS, ...MULTIUSER_LOCAL_KEYS]
+    : ALWAYS_LOCAL_KEYS;
+  for (const key of keepLocalKeys) {
     if (local && Object.prototype.hasOwnProperty.call(local, key)) {
       result.data[key] = local[key];
       const tsKey = `${key}UpdatedAt`;

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -12,6 +12,13 @@ export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =
 // leaving the per-device `multiUserEnabled` toggle alone. dayGLANCE previously
 // wrapped this function to patch the roster in; that stopgap is no longer
 // needed — the upstream merge covers every sync path directly.
+
+// Settings kept per-device: the upstream file-tier merge resolves these
+// last-writer-wins, but on a shared (multi-user) account that lets one person's
+// toggle flip the feature for everyone. We override the merged result back to
+// this device's local value so they never propagate. Mirrors the vault tier's
+// DEVICE_LOCAL_BUNDLES (src/sync/dbAdapter.js).
+const DEVICE_LOCAL_KEYS = ['habitsEnabled', 'routinesEnabled', 'goalsProjectsEnabled', 'obsidianConfig'];
 export {
   mergeDailyNotes,
   mergeHabits,
@@ -129,5 +136,14 @@ export const mergeSyncData = (local, remote, retentionDays) => {
   // Make sure a heal (one side's count changing) actually triggers a write/push.
   if (habitLogsFix.localChanged) result.localChanged = true;
   if (habitLogsFix.remoteChanged) result.remoteChanged = true;
+  // Keep device-local settings on this device's own value rather than the
+  // last-writer-wins result, so a household member's toggle never propagates.
+  for (const key of DEVICE_LOCAL_KEYS) {
+    if (local && Object.prototype.hasOwnProperty.call(local, key)) {
+      result.data[key] = local[key];
+      const tsKey = `${key}UpdatedAt`;
+      if (Object.prototype.hasOwnProperty.call(local, tsKey)) result.data[tsKey] = local[tsKey];
+    }
+  }
   return result;
 };

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -1520,27 +1520,36 @@ describe('mergeSyncData — habits integration', () => {
     expect(data.habitLogs['2026-02-20']['1']).toBe(7);
   });
 
-  it('keeps habitsEnabled device-local (remote never overrides)', () => {
+  it('single-user: habitsEnabled still propagates from remote (LWW)', () => {
     const deviceA = { ...base, habits: [], habitLogs: {}, habitsEnabled: true };
     const deviceB = { ...base, habits: [], habitLogs: {}, habitsEnabled: false };
     const { data } = mergeSyncData(deviceA, deviceB);
-    // Device A keeps its own toggle even though B's value would win LWW — so one
-    // household member turning Habits off does not turn it off for everyone.
+    // No multiUserEnabled flag → the toggle syncs across the user's own devices.
+    expect(data.habitsEnabled).toBe(false);
+  });
+
+  it('multi-user: keeps habitsEnabled device-local (remote never overrides)', () => {
+    const deviceA = { ...base, habits: [], habitLogs: {}, habitsEnabled: true, multiUserEnabled: true };
+    const deviceB = { ...base, habits: [], habitLogs: {}, habitsEnabled: false };
+    const { data } = mergeSyncData(deviceA, deviceB);
+    // Device A has multi-user on, so it keeps its own toggle even though B's value
+    // would win LWW — one household member turning Habits off can't hide it for all.
     expect(data.habitsEnabled).toBe(true);
   });
 
-  it('keeps routinesEnabled device-local (remote never overrides)', () => {
-    const deviceA = { ...base, routinesEnabled: true };
-    const deviceB = { ...base, routinesEnabled: false };
+  it('multi-user: keeps routinesEnabled and goalsProjectsEnabled device-local', () => {
+    const deviceA = { ...base, routinesEnabled: true, goalsProjectsEnabled: false, multiUserEnabled: true };
+    const deviceB = { ...base, routinesEnabled: false, goalsProjectsEnabled: true };
     const { data } = mergeSyncData(deviceA, deviceB);
     expect(data.routinesEnabled).toBe(true);
+    expect(data.goalsProjectsEnabled).toBe(false);
   });
 
-  it('keeps goalsProjectsEnabled and obsidianConfig device-local', () => {
-    const deviceA = { ...base, goalsProjectsEnabled: false, obsidianConfig: { taskHeading: '## A' } };
-    const deviceB = { ...base, goalsProjectsEnabled: true, obsidianConfig: { taskHeading: '## B' } };
+  it('keeps obsidianConfig device-local even with multi-user off', () => {
+    const deviceA = { ...base, obsidianConfig: { taskHeading: '## A' } };
+    const deviceB = { ...base, obsidianConfig: { taskHeading: '## B' } };
     const { data } = mergeSyncData(deviceA, deviceB);
-    expect(data.goalsProjectsEnabled).toBe(false);
+    // Obsidian vault differs per machine, so it is always device-local.
     expect(data.obsidianConfig).toEqual({ taskHeading: '## A' });
   });
 

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -1520,23 +1520,31 @@ describe('mergeSyncData — habits integration', () => {
     expect(data.habitLogs['2026-02-20']['1']).toBe(7);
   });
 
-  it('propagates habitsEnabled from remote', () => {
+  it('keeps habitsEnabled device-local (remote never overrides)', () => {
     const deviceA = { ...base, habits: [], habitLogs: {}, habitsEnabled: true };
     const deviceB = { ...base, habits: [], habitLogs: {}, habitsEnabled: false };
-    const { data, localChanged } = mergeSyncData(deviceA, deviceB);
-    expect(data.habitsEnabled).toBe(false);
-    expect(localChanged).toBe(true);
+    const { data } = mergeSyncData(deviceA, deviceB);
+    // Device A keeps its own toggle even though B's value would win LWW — so one
+    // household member turning Habits off does not turn it off for everyone.
+    expect(data.habitsEnabled).toBe(true);
   });
 
-  it('propagates routinesEnabled from remote', () => {
+  it('keeps routinesEnabled device-local (remote never overrides)', () => {
     const deviceA = { ...base, routinesEnabled: true };
     const deviceB = { ...base, routinesEnabled: false };
-    const { data, localChanged } = mergeSyncData(deviceA, deviceB);
-    expect(data.routinesEnabled).toBe(false);
-    expect(localChanged).toBe(true);
+    const { data } = mergeSyncData(deviceA, deviceB);
+    expect(data.routinesEnabled).toBe(true);
   });
 
-  it('defaults routinesEnabled to true when not present', () => {
+  it('keeps goalsProjectsEnabled and obsidianConfig device-local', () => {
+    const deviceA = { ...base, goalsProjectsEnabled: false, obsidianConfig: { taskHeading: '## A' } };
+    const deviceB = { ...base, goalsProjectsEnabled: true, obsidianConfig: { taskHeading: '## B' } };
+    const { data } = mergeSyncData(deviceA, deviceB);
+    expect(data.goalsProjectsEnabled).toBe(false);
+    expect(data.obsidianConfig).toEqual({ taskHeading: '## A' });
+  });
+
+  it('defaults routinesEnabled to undefined when not present on this device', () => {
     const deviceA = { ...base };
     const deviceB = { ...base };
     const { data } = mergeSyncData(deviceA, deviceB);

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -101,10 +101,6 @@ const deepEqual = (a, b) => {
   if (ka.length !== kb.length) return false;
   return ka.every((k) => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]));
 };
-// Last-writer-wins for a single config value via paired updatedAt timestamps;
-// remote wins ties (mirrors merge.js pickConfigByTs:12-17).
-const pickByTs = (localVal, localTs, remoteVal, remoteTs) =>
-  (ts(remoteTs) >= ts(localTs) ? remoteVal : localVal);
 
 // ── kind / mutability / tiebreaker (engine callbacks) ──────────────────────────
 export function entityKind(entity) {
@@ -333,9 +329,13 @@ const TOMBSTONE_BUNDLES = new Set([
 ]);
 // Device-local prefs: the file-tier merge keeps the local value (merge.js:900-901
 // / weather not in merge output), so a pulled value never overwrites it. Listed
-// so the default branch doesn't LWW-clobber them.
+// so the default branch doesn't LWW-clobber them. The feature-enablement toggles
+// (habitsEnabled/routinesEnabled/goalsProjectsEnabled) and obsidianConfig are
+// device-local so one household member toggling a feature — or pointing Obsidian
+// at a different vault — does not flip it for everyone else on the same account.
 const DEVICE_LOCAL_BUNDLES = new Set([
   'minimizedSections', 'use24HourClock', 'weatherZip', 'weatherTempUnit', 'multiUserEnabled',
+  'habitsEnabled', 'routinesEnabled', 'goalsProjectsEnabled', 'obsidianConfig',
 ]);
 
 function mergeBundle(data, key, value, extra) {
@@ -383,20 +383,10 @@ function mergeBundle(data, key, value, extra) {
       // (mirrors merge.js:810-815).
       data[key] = value || data[key] || '';
       return;
-    case 'habitsEnabled':
-    case 'routinesEnabled':
-    case 'goalsProjectsEnabled': {
-      const tsKey = `${key}UpdatedAt`;
-      data[key] = pickByTs(data[key], data[tsKey], value, extra[tsKey]);
-      data[tsKey] = newerIso(data[tsKey], extra[tsKey]);
-      return;
-    }
-    case 'obsidianConfig': {
-      data.obsidianConfig = pickByTs(data.obsidianConfig, data.obsidianConfigUpdatedAt, value, extra.obsidianConfigUpdatedAt);
-      data.obsidianConfigUpdatedAt = newerIso(data.obsidianConfigUpdatedAt, extra.obsidianConfigUpdatedAt);
-      return;
-    }
     default:
+      // habitsEnabled / routinesEnabled / goalsProjectsEnabled / obsidianConfig
+      // fall through here and are kept local (DEVICE_LOCAL_BUNDLES) — see the set
+      // definition for why these are per-device rather than last-writer-wins.
       if (DEVICE_LOCAL_BUNDLES.has(key)) return; // keep local
       // Unknown bundle: fall back to LWW overwrite, but make it visible so a new
       // bundle type isn't silently subjected to a loss window.

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -101,6 +101,10 @@ const deepEqual = (a, b) => {
   if (ka.length !== kb.length) return false;
   return ka.every((k) => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]));
 };
+// Last-writer-wins for a single config value via paired updatedAt timestamps;
+// remote wins ties (mirrors merge.js pickConfigByTs:12-17).
+const pickByTs = (localVal, localTs, remoteVal, remoteTs) =>
+  (ts(remoteTs) >= ts(localTs) ? remoteVal : localVal);
 
 // ── kind / mutability / tiebreaker (engine callbacks) ──────────────────────────
 export function entityKind(entity) {
@@ -282,7 +286,7 @@ export function applyRemoteEntity(data, entity) {
   if (kind === SINGLETON_KIND) {
     const key = entity._key;
     mergeBundle(data, key, entity.value, entity._extra || {});
-    if (DEVICE_LOCAL_BUNDLES.has(key)) return []; // kept local, never re-pushed
+    if (keptLocalBundle(data, key)) return []; // kept local, never re-pushed
     const merged = makeSingletonEntity(data, key);
     const same = deepEqual(merged.value, entity.value) && deepEqual(merged._extra || {}, entity._extra || {});
     return same ? [] : [makeEntityId(SINGLETON_KIND, key)];
@@ -329,14 +333,26 @@ const TOMBSTONE_BUNDLES = new Set([
 ]);
 // Device-local prefs: the file-tier merge keeps the local value (merge.js:900-901
 // / weather not in merge output), so a pulled value never overwrites it. Listed
-// so the default branch doesn't LWW-clobber them. The feature-enablement toggles
-// (habitsEnabled/routinesEnabled/goalsProjectsEnabled) and obsidianConfig are
-// device-local so one household member toggling a feature — or pointing Obsidian
-// at a different vault — does not flip it for everyone else on the same account.
-const DEVICE_LOCAL_BUNDLES = new Set([
+// so the default branch doesn't LWW-clobber them. obsidianConfig is here
+// unconditionally because the Obsidian vault genuinely differs per machine
+// (installed or not, different path).
+const ALWAYS_DEVICE_LOCAL = new Set([
   'minimizedSections', 'use24HourClock', 'weatherZip', 'weatherTempUnit', 'multiUserEnabled',
-  'habitsEnabled', 'routinesEnabled', 'goalsProjectsEnabled', 'obsidianConfig',
+  'obsidianConfig',
 ]);
+// Feature-enablement toggles are device-local ONLY when multi-user is on, so one
+// household member hiding a feature does not hide it for everyone. A single-user
+// install keeps them syncing last-writer-wins across that user's own devices —
+// the gate below reads the LOCAL multiUserEnabled flag (itself device-local, so
+// stable regardless of merge order).
+const MULTIUSER_DEVICE_LOCAL = new Set([
+  'habitsEnabled', 'routinesEnabled', 'goalsProjectsEnabled',
+]);
+// True when `key` must keep the local value rather than accept the pulled one,
+// given this device's multi-user state. Used by both the merge and the re-push
+// guard so they stay in lockstep.
+const keptLocalBundle = (data, key) =>
+  ALWAYS_DEVICE_LOCAL.has(key) || (MULTIUSER_DEVICE_LOCAL.has(key) && !!data.multiUserEnabled);
 
 function mergeBundle(data, key, value, extra) {
   if (TOMBSTONE_BUNDLES.has(key)) {
@@ -383,11 +399,20 @@ function mergeBundle(data, key, value, extra) {
       // (mirrors merge.js:810-815).
       data[key] = value || data[key] || '';
       return;
+    case 'habitsEnabled':
+    case 'routinesEnabled':
+    case 'goalsProjectsEnabled': {
+      // Multi-user: keep local (device-local). Single-user: LWW across own devices.
+      if (data.multiUserEnabled) return;
+      const tsKey = `${key}UpdatedAt`;
+      data[key] = pickByTs(data[key], data[tsKey], value, extra[tsKey]);
+      data[tsKey] = newerIso(data[tsKey], extra[tsKey]);
+      return;
+    }
     default:
-      // habitsEnabled / routinesEnabled / goalsProjectsEnabled / obsidianConfig
-      // fall through here and are kept local (DEVICE_LOCAL_BUNDLES) — see the set
-      // definition for why these are per-device rather than last-writer-wins.
-      if (DEVICE_LOCAL_BUNDLES.has(key)) return; // keep local
+      // obsidianConfig (and the clock/weather/minimized prefs) are kept local —
+      // see ALWAYS_DEVICE_LOCAL for why these are per-device, not last-writer-wins.
+      if (ALWAYS_DEVICE_LOCAL.has(key)) return; // keep local
       // Unknown bundle: fall back to LWW overwrite, but make it visible so a new
       // bundle type isn't silently subjected to a loss window.
       // eslint-disable-next-line no-console

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -23,7 +23,7 @@
 //     applyPayload (which sets the suppress flags), so a pulled row never bounces
 //     back out as a file-tier upload or a re-push.
 
-import { createDbSyncEngine, clearDbRootKey } from '@glance-apps/sync';
+import { createDbSyncEngine, clearDbRootKey, initDbRootKey } from '@glance-apps/sync';
 import { getVaultConfig, isVaultEnabled } from './vaultConfig.js';
 import { getDeviceId } from './deviceId.js';
 import {
@@ -39,16 +39,36 @@ import {
 const APP_ID = 'dayglance';
 const CRYPTO_DB_NAME = 'dayglance-db-crypto';
 
+// Native keystore slot for the DB root key. On native shells the bridge exposes a
+// SINGLE legacy slot (getSyncKey/storeSyncKey) that the WebDAV file tier already
+// uses; storing the DB root key there too makes the two tiers clobber each other,
+// which on Android forces a passphrase re-prompt on every launch. Newer shells add
+// per-slot methods, so we isolate the DB key under its own slot. The IndexedDB
+// path (non-native) is already isolated via the distinct CRYPTO_DB_NAME.
+const VAULT_KEY_SLOT = 'db';
+
 // Where the per-account DB root key is stored: the OS keystore on native shells
 // (mirrors the file tier in adapter.js), IndexedDB elsewhere. Centralized so the
 // engine and resetDbRootKey agree.
 function nativeKeyConfig() {
   const bridge = typeof window !== 'undefined' ? window.DayGlanceNative : null;
   const isNativeApp = !!bridge?.httpRequest;
+  if (!isNativeApp) {
+    return { cryptoDBName: CRYPTO_DB_NAME, nativeGetSyncKey: null, nativeStoreSyncKey: null };
+  }
+  // Prefer the isolated per-slot bridge methods; fall back to the shared legacy
+  // slot on older shells (no isolation there, but no worse than before).
+  if (bridge.getSyncKeyForSlot && bridge.storeSyncKeyForSlot) {
+    return {
+      cryptoDBName: CRYPTO_DB_NAME,
+      nativeGetSyncKey: () => bridge.getSyncKeyForSlot(VAULT_KEY_SLOT),
+      nativeStoreSyncKey: (val) => bridge.storeSyncKeyForSlot(VAULT_KEY_SLOT, val),
+    };
+  }
   return {
     cryptoDBName: CRYPTO_DB_NAME,
-    nativeGetSyncKey: isNativeApp && bridge?.getSyncKey ? () => bridge.getSyncKey() : null,
-    nativeStoreSyncKey: isNativeApp && bridge?.storeSyncKey ? (val) => bridge.storeSyncKey(val) : null,
+    nativeGetSyncKey: bridge.getSyncKey ? () => bridge.getSyncKey() : null,
+    nativeStoreSyncKey: bridge.storeSyncKey ? (val) => bridge.storeSyncKey(val) : null,
   };
 }
 
@@ -59,6 +79,15 @@ function nativeKeyConfig() {
 // passphrase) stays locked in and decryption of other devices' rows fails.
 export async function resetDbRootKey() {
   try { await clearDbRootKey(nativeKeyConfig()); } catch { /* ignore */ }
+}
+
+// Restore the cached DB root key from device storage (keystore/IndexedDB) without
+// the passphrase. Used by the app's load-time readiness gate so a vault-enabled
+// device that already has its key cached unlocks silently instead of prompting.
+// Returns false (not throwing) when no key is cached, so the caller can show the
+// passphrase prompt.
+export async function restoreDbRootKey() {
+  try { return await initDbRootKey(nativeKeyConfig()); } catch { return false; }
 }
 
 const clone = (x) => (x == null ? x : JSON.parse(JSON.stringify(x)));

--- a/src/sync/dbMerge.test.js
+++ b/src/sync/dbMerge.test.js
@@ -143,11 +143,24 @@ describe('A1 bundle merge — concurrent different-entry edits are not lost', ()
     }
   });
 
-  it('*Enabled toggles stay device-local: a remote toggle never overrides local', () => {
+  it('single-user *Enabled pair: last-writer-wins by paired UpdatedAt, deterministic on both', () => {
     const base = { ...EMPTY_COLLECTIONS, habitsEnabled: true, habitsEnabledUpdatedAt: T0 };
     const { vault, a, b } = newPair(base);
-    // Device B turns Habits off with the NEWEST timestamp — under the old LWW it
-    // would flip A too. With device-local toggles each device keeps its own value.
+    // No multiUserEnabled → the toggle syncs LWW across the user's own devices.
+    a.mutate((d) => { d.habitsEnabled = false; d.habitsEnabledUpdatedAt = T1; return ['singleton:habitsEnabled']; });
+    b.mutate((d) => { d.habitsEnabled = true;  d.habitsEnabledUpdatedAt = T2; return ['singleton:habitsEnabled']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      expect(dev.data.habitsEnabled).toBe(true);          // T2 is newest
+      expect(dev.data.habitsEnabledUpdatedAt).toBe(T2);
+    }
+  });
+
+  it('multi-user *Enabled toggle stays device-local: a remote toggle never overrides local', () => {
+    const base = { ...EMPTY_COLLECTIONS, multiUserEnabled: true, habitsEnabled: true, habitsEnabledUpdatedAt: T0 };
+    const { vault, a, b } = newPair(base);
+    // Both devices have multi-user on. B turns Habits off with the NEWEST
+    // timestamp — under LWW it would flip A too; device-local keeps each own.
     a.mutate((d) => { d.habitsEnabled = true;  d.habitsEnabledUpdatedAt = T1; return ['singleton:habitsEnabled']; });
     b.mutate((d) => { d.habitsEnabled = false; d.habitsEnabledUpdatedAt = T2; return ['singleton:habitsEnabled']; });
     syncToConvergence(a, b, vault);

--- a/src/sync/dbMerge.test.js
+++ b/src/sync/dbMerge.test.js
@@ -143,16 +143,16 @@ describe('A1 bundle merge — concurrent different-entry edits are not lost', ()
     }
   });
 
-  it('*Enabled pair: last-writer-wins by paired UpdatedAt, deterministic on both', () => {
+  it('*Enabled toggles stay device-local: a remote toggle never overrides local', () => {
     const base = { ...EMPTY_COLLECTIONS, habitsEnabled: true, habitsEnabledUpdatedAt: T0 };
     const { vault, a, b } = newPair(base);
-    a.mutate((d) => { d.habitsEnabled = false; d.habitsEnabledUpdatedAt = T1; return ['singleton:habitsEnabled']; });
-    b.mutate((d) => { d.habitsEnabled = true; d.habitsEnabledUpdatedAt = T2; return ['singleton:habitsEnabled']; });
+    // Device B turns Habits off with the NEWEST timestamp — under the old LWW it
+    // would flip A too. With device-local toggles each device keeps its own value.
+    a.mutate((d) => { d.habitsEnabled = true;  d.habitsEnabledUpdatedAt = T1; return ['singleton:habitsEnabled']; });
+    b.mutate((d) => { d.habitsEnabled = false; d.habitsEnabledUpdatedAt = T2; return ['singleton:habitsEnabled']; });
     syncToConvergence(a, b, vault);
-    for (const dev of [a, b]) {
-      expect(dev.data.habitsEnabled).toBe(true);          // T2 is newest
-      expect(dev.data.habitsEnabledUpdatedAt).toBe(T2);
-    }
+    expect(a.data.habitsEnabled).toBe(true);   // A keeps its own
+    expect(b.data.habitsEnabled).toBe(false);  // B keeps its own
   });
 });
 


### PR DESCRIPTION
A set of related cloud-sync settings / multi-user fixes.

## 1. Fix GLANCEvault passphrase re-prompt on every launch (Android)

On Android, a GLANCEvault-only device re-prompted for the sync passphrase on **every launch**, and entering it never stuck.

**Root cause:** the WebDAV file tier (`crypto.js`) and the GLANCEvault DB tier (`dbCrypto.js`) both stored their key through the **single** native Android Keystore slot, with different record shapes — so whichever tier wrote last clobbered the other. With the vault enabled, its root key overwrote the file-tier key; on next launch the readiness gate ran the file-tier `initSessionKey()`, failed to parse the DB record, and showed the modal. A vault-only device has no WebDAV file to re-cache the file-tier key, so it recurred forever. (Web/desktop unaffected — they isolate via distinct IndexedDB names.)

**Fix:**
- **Isolate the keys** — `CryptoKeyBridge` namespaces SharedPreferences by slot and adds `get/storeSyncKeyForSlot`; the DB tier uses its own `'db'` slot. Legacy default slot unchanged; older shells fall back to it.
- **Gate readiness per active transport** — `useCloudSync` restores the file-tier key only when WebDAV is enabled+encrypted, and restores the GLANCEvault DB root key whenever the vault is enabled.

Existing vault devices re-prompt once (key migrates to the isolated slot), then unlock silently.

> Requires a new Android build/APK to take effect.

## 2. Add a "Sync via WebDAV" toggle

WebDAV was implicitly enabled whenever its fields were filled, and the only way to turn it off was an easy-to-miss red "Disable" button placed under the GLANCEvault section (which, despite its placement, only disabled WebDAV). A device wanting to keep its WebDAV credentials but move fully to GLANCEvault had no clear control.

Added a **"Sync via WebDAV"** checkbox mirroring the encryption and GLANCEvault toggles: it gates the connection fields and controls whether WebDAV actually syncs (`enabled: webdavEnabled && webdavConfigured`). Unchecking keeps the saved credentials but stops syncing. The redundant "Disable" button is retired, so all three transports read the same way.

## 3. Feature toggles device-local in multi-user; Obsidian config always device-local

`habitsEnabled`, `routinesEnabled`, and `goalsProjectsEnabled` were synced last-writer-wins across the whole account, so on a shared (multi-user) household one person hiding a feature hid it for everyone. But that cross-device leak **only matters on a multi-user account** — a single user with multiple devices *wants* these to sync.

So the isolation is **gated on the local `multiUserEnabled` flag**:
- **Single-user:** toggles sync last-writer-wins across the user's own devices (unchanged), via the paired `*UpdatedAt` timestamps.
- **Multi-user:** toggles are kept device-local so one member's toggle never propagates.

`obsidianConfig` is **unconditionally** device-local — the Obsidian vault genuinely differs per machine (installed or not, different path), so it should never sync regardless of multi-user state.

Both merge tiers implement this: the vault tier (`dbAdapter.js`) splits its device-local set into `ALWAYS_DEVICE_LOCAL` / `MULTIUSER_DEVICE_LOCAL` with a shared `keptLocalBundle()` guard; the WebDAV tier (`mergeSync.js`) overrides the toggles back to local only when multi-user is on, and always overrides `obsidianConfig`.

> **Follow-up (separate PR):** calendar configuration (`syncUrl` / `taskCalendarUrl`, and credentials when encrypted) will move to per-user storage in the multi-user roster, so it syncs across one person's devices without leaking to others. Native macOS (Electron EventKit) calendar support is planned after that.

## Testing

- Full suite passes (299 tests; merge tests cover both the single-user LWW and multi-user device-local paths on both tiers).
- Production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)