### PR TITLE
Per-user calendar config in multi-user (URLs + opt-in encrypted credentials)

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -151,6 +151,8 @@
     "taskCalendarUrl": "Task Calendar URL (iCal/CalDAV)",
     "taskCalendarAuth": "Basic auth / sync completions back (optional)",
     "calDAVBaseUrl": "CalDAV Base URL",
+    "syncCalendarCreds": "Sync calendar credentials across my devices",
+    "syncCalendarCredsNeedsEncryption": "Takes effect once sync encryption is on — until then, credentials stay on this device.",
     "keepPastEvents": "Keep past events",
     "appPassword": "App Password",
     "deviceCalendars": "Device Calendars",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1841,6 +1841,40 @@ const DayPlanner = () => {
   useEffect(() => { writeConfigTimestamp('dayglance-multi-user-enabled-updated-at'); }, [multiUserEnabled]);
   useEffect(() => { localStorage.setItem('day-planner-sync-calendar-creds', String(syncCalendarCreds)); }, [syncCalendarCreds]);
 
+  // One-time per-device cleanup when this device first runs in per-user calendar
+  // mode (multi-user on + a "me" selected). Calendar config and CalDAV-imported
+  // tasks carry no owner, so we can't tell whether the current top-level URL /
+  // sync-tasks are this user's own or leaked in from another user before per-user
+  // config existed. Rather than guess, reset to a clean slate:
+  //   • drop subscription-derived ('sync') tasks — ephemeral; they re-fetch from
+  //     your own URL once you set it, and leaked ones simply don't come back;
+  //   • clear the top-level calendar URLs — re-enter once, and it then syncs to
+  //     your other devices via calendarConfigByUser. (Auth is kept: it's
+  //     device-local and never leaked, so you don't re-type your password.)
+  // Runs exactly once, guarded by a persisted flag.
+  useEffect(() => {
+    if (!dataLoaded || !multiUserEnabled || !meUserSyncId) return;
+    if (localStorage.getItem('day-planner-calendar-per-user-migrated') === 'true') return;
+    // Drop subscription-derived tasks unconditionally — always safe (re-fetchable).
+    const isSyncImport = (t) => t.imported && t.importSource === 'sync';
+    setTasks(prev => prev.filter(t => !isSyncImport(t)));
+    setUnscheduledTasks(prev => prev.filter(t => !isSyncImport(t)));
+    // Only clear the top-level URLs if no clean per-user config exists yet. If
+    // another of this user's devices has already established it (post-migration),
+    // that entry is the source of truth and arrives via the normal sync path —
+    // clearing here would overwrite it with empty.
+    let map = {};
+    try { map = JSON.parse(localStorage.getItem('day-planner-calendar-config-by-user') || '{}'); } catch { map = {}; }
+    if (!map[meUserSyncId]) {
+      localStorage.removeItem('day-planner-sync-url');
+      localStorage.removeItem('day-planner-task-calendar-url');
+      setSyncUrl('');
+      setTaskCalendarUrl('');
+    }
+    localStorage.setItem('day-planner-calendar-per-user-migrated', 'true');
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataLoaded, multiUserEnabled, meUserSyncId]);
+
   // Sync user list with glance-users.json on WebDAV and iCloud, so dayGLANCE
   // and lastGLANCE share the same roster regardless of which app is opened first.
   // Both transports run simultaneously; whichever returns non-null is applied.
@@ -5462,9 +5496,13 @@ const DayPlanner = () => {
     // sync is encrypted — follow this user across their devices without leaking to
     // others. updatedAt only advances on a real content change (content-compare),
     // so it doesn't thrash the per-syncId LWW merge.
+    // Gated on the one-time migration having run, so we never seed the entry from a
+    // top-level URL that might have leaked from another user pre-Phase-2 (the
+    // migration resets that to a clean slate first — see the effect below).
     let calendarConfigByUser = {};
     try { calendarConfigByUser = JSON.parse(localStorage.getItem('day-planner-calendar-config-by-user') || '{}'); } catch { calendarConfigByUser = {}; }
-    if (multiUserEnabled && meUserSyncId) {
+    const calMigrated = localStorage.getItem('day-planner-calendar-per-user-migrated') === 'true';
+    if (multiUserEnabled && meUserSyncId && calMigrated) {
       const encrypted = !!(cloudSyncConfig?.encryptionEnabled || isVaultEnabled());
       const includeAuth = syncCalendarCreds && encrypted && taskCalendarAuth
         && (taskCalendarAuth.username || taskCalendarAuth.appPassword);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -384,6 +384,13 @@ const DayPlanner = () => {
   useEffect(() => { localStorage.setItem('day-planner-weather-enabled', JSON.stringify(weatherEnabled)); }, [weatherEnabled]);
   useEffect(() => { localStorage.setItem('day-planner-daily-content-enabled', JSON.stringify(dailyContentEnabled)); }, [dailyContentEnabled]);
   const [syncUrl, setSyncUrl] = useState('');
+  // When multi-user is on, whether to include CalDAV credentials (not just URLs)
+  // in the per-user calendar config that syncs across this user's devices. Only
+  // takes effect when sync is encrypted. Defaults on; surfaced as a toggle.
+  const [syncCalendarCreds, setSyncCalendarCreds] = useState(() => {
+    const v = localStorage.getItem('day-planner-sync-calendar-creds');
+    return v === null ? true : v === 'true';
+  });
   const [showCalendarUrlHint, setShowCalendarUrlHint] = useState(false);
   const [currentTime, setCurrentTime] = useState(new Date());
   const [showTimePicker, setShowTimePicker] = useState(false);
@@ -1832,6 +1839,7 @@ const DayPlanner = () => {
   useEffect(() => { writeConfigTimestamp('day-planner-goals-projects-enabled-updated-at'); }, [goalsProjectsEnabled]);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { writeConfigTimestamp('dayglance-multi-user-enabled-updated-at'); }, [multiUserEnabled]);
+  useEffect(() => { localStorage.setItem('day-planner-sync-calendar-creds', String(syncCalendarCreds)); }, [syncCalendarCreds]);
 
   // Sync user list with glance-users.json on WebDAV and iCloud, so dayGLANCE
   // and lastGLANCE share the same roster regardless of which app is opened first.
@@ -5440,26 +5448,58 @@ const DayPlanner = () => {
       const m = uid.match(/::(\d{4}-\d{2}-\d{2})$/);
       return !m || new Date(m[1]) >= uidCutoff;
     });
-    const _tasksForSync = tasks.filter(t => !t._native && !(t.imported && !t.isTaskCalendar && t.importSource !== 'file'));
-    const _unschedForSync = unscheduledTasks.filter(t => !(t.imported && !t.isTaskCalendar && t.importSource !== 'file'));
+    // Imported-task sync rule. Always drop read-only CalDAV events; keep
+    // isTaskCalendar to-dos and ICS file imports as first-class data. In
+    // multi-user, additionally drop ALL subscription-derived ('sync') items so a
+    // CalDAV feed never leaks to other users — each device re-fetches from its own
+    // per-user URL (completion still flows back through CalDAV).
+    const keepImported = (t) =>
+      !(t.imported && !t.isTaskCalendar && t.importSource !== 'file')
+      && !(multiUserEnabled && t.imported && t.importSource === 'sync');
+
+    // Per-user calendar config (multi-user only). Write this device's own syncId
+    // entry into the shared map so the URLs — and credentials, when opted in AND
+    // sync is encrypted — follow this user across their devices without leaking to
+    // others. updatedAt only advances on a real content change (content-compare),
+    // so it doesn't thrash the per-syncId LWW merge.
+    let calendarConfigByUser = {};
+    try { calendarConfigByUser = JSON.parse(localStorage.getItem('day-planner-calendar-config-by-user') || '{}'); } catch { calendarConfigByUser = {}; }
+    if (multiUserEnabled && meUserSyncId) {
+      const encrypted = !!(cloudSyncConfig?.encryptionEnabled || isVaultEnabled());
+      const includeAuth = syncCalendarCreds && encrypted && taskCalendarAuth
+        && (taskCalendarAuth.username || taskCalendarAuth.appPassword);
+      const desired = { syncUrl, taskCalendarUrl, ...(includeAuth ? { auth: taskCalendarAuth } : {}) };
+      const cur = calendarConfigByUser[meUserSyncId];
+      const sameContent = !!cur
+        && (cur.syncUrl ?? '') === (desired.syncUrl ?? '')
+        && (cur.taskCalendarUrl ?? '') === (desired.taskCalendarUrl ?? '')
+        && JSON.stringify(cur.auth ?? null) === JSON.stringify(desired.auth ?? null);
+      calendarConfigByUser = {
+        ...calendarConfigByUser,
+        [meUserSyncId]: { ...desired, updatedAt: sameContent ? cur.updatedAt : new Date().toISOString() },
+      };
+      localStorage.setItem('day-planner-calendar-config-by-user', JSON.stringify(calendarConfigByUser));
+    }
     return {
       version: 2,
       lastModified: new Date().toISOString(),
       data: {
         tasks: stampTaskTimestamps(
-          tasks.filter(t => !t._native && !(t.imported && !t.isTaskCalendar && t.importSource !== 'file')),
+          tasks.filter(t => !t._native && keepImported(t)),
           'day-planner-tasks'
         ),
         unscheduledTasks: stampTaskTimestamps(
-          unscheduledTasks.filter(t => !(t.imported && !t.isTaskCalendar && t.importSource !== 'file')),
+          unscheduledTasks.filter(keepImported),
           'day-planner-unscheduled'
         ),
         unscheduledOrderTimestamp,
         recycleBin: stampTaskTimestamps(recycleBin, 'day-planner-recycle-bin'),
         syncUrl,
         taskCalendarUrl,
-        // taskCalendarAuth is intentionally excluded — credentials must not be written
-        // to the shared sync file on the WebDAV server.
+        calendarConfigByUser,
+        // taskCalendarAuth is intentionally excluded from the top level — credentials
+        // ride per-user inside calendarConfigByUser (only when opted in and encrypted),
+        // never as a shared top-level field.
         completedTaskUids: prunedUids,
         recurringTasks: stampTaskTimestamps(recurringTasks, 'day-planner-recurring-tasks'),
         routineDefinitions,
@@ -5529,6 +5569,15 @@ const DayPlanner = () => {
     suppressCloudUploadRef.current = true;
     suppressTimestampRef.current = true;
 
+    // Per-user calendar mode: when multi-user is on and a user is selected, this
+    // device's calendar config comes from calendarConfigByUser[mySyncId], not the
+    // top-level syncUrl/taskCalendarUrl (which are device-local in multi-user).
+    // Read meUserSyncId fresh from localStorage to avoid a stale closure.
+    const meSidForCal = (() => {
+      try { return JSON.parse(localStorage.getItem('dayglance-multi-user-config') || '{}').meUserSyncId || null; } catch { return null; }
+    })();
+    const perUserCalendar = !!(data.multiUserEnabled && meSidForCal);
+
     // Normalize task defaults so localStorage and React state are identical.
     // Without this, stampTaskTimestamps detects spurious differences (e.g.
     // missing notes/subtasks) and re-stamps lastModified, making stale local
@@ -5540,7 +5589,11 @@ const DayPlanner = () => {
     // resurrect deleted events. On native, the OS bridge re-provides them; on PWA, CalDAV
     // sync re-imports them on every fetch. Calendar tasks (isTaskCalendar:true) and ICS file
     // imports (importSource:'file') are first-class user data and are kept as normal.
-    const filterTasks = tasks => tasks.filter(t => !(t.imported && !t.isTaskCalendar && t.importSource !== 'file'));
+    // In multi-user also drop subscription-derived ('sync') items — they ride
+    // per-user via the calendar URL, not the shared payload (mirrors buildSyncPayload).
+    const filterTasks = tasks => tasks.filter(t =>
+      !(t.imported && !t.isTaskCalendar && t.importSource !== 'file')
+      && !(multiUserEnabled && t.imported && t.importSource === 'sync'));
 
     const normalizedTasks = data.tasks ? filterTasks(normalizeTasks(data.tasks)) : null;
     const normalizedUnsched = data.unscheduledTasks ? filterTasks(normalizeTasks(data.unscheduledTasks)) : null;
@@ -5551,9 +5604,12 @@ const DayPlanner = () => {
     if (data.recycleBin) localStorage.setItem('day-planner-recycle-bin', JSON.stringify(data.recycleBin));
     // Calendar URLs: apply whenever remote explicitly includes them (even empty string,
     // which propagates an intentional URL clear). Only skip when the key is absent.
-    if (data.syncUrl !== undefined) localStorage.setItem('day-planner-sync-url', data.syncUrl);
-    if (data.taskCalendarUrl !== undefined) localStorage.setItem('day-planner-task-calendar-url', data.taskCalendarUrl);
-    // taskCalendarAuth is not applied from sync — credentials are device-local only.
+    // In per-user mode the top-level URLs are device-local — config is applied from
+    // calendarConfigByUser[mySyncId] below instead.
+    if (!perUserCalendar && data.syncUrl !== undefined) localStorage.setItem('day-planner-sync-url', data.syncUrl);
+    if (!perUserCalendar && data.taskCalendarUrl !== undefined) localStorage.setItem('day-planner-task-calendar-url', data.taskCalendarUrl);
+    // taskCalendarAuth is not applied from the top level — credentials are device-local
+    // unless they arrive per-user inside calendarConfigByUser (applied below).
     if (data.completedTaskUids) localStorage.setItem('day-planner-task-completed-uids', JSON.stringify(data.completedTaskUids));
     if (data.recurringTasks) localStorage.setItem('day-planner-recurring-tasks', JSON.stringify(data.recurringTasks));
     if (data.routineDefinitions) localStorage.setItem('day-planner-routine-definitions', JSON.stringify(data.routineDefinitions));
@@ -5645,6 +5701,20 @@ const DayPlanner = () => {
       setMultiUserEnabled(data.multiUserEnabled);
       if (data.multiUserEnabledUpdatedAt) localStorage.setItem('dayglance-multi-user-enabled-updated-at', data.multiUserEnabledUpdatedAt);
     }
+    if (data.calendarConfigByUser) {
+      // Store the merged per-user map, then — in per-user mode — apply MY own
+      // entry to this device's live calendar config. Other users' entries are
+      // stored but never read here, which is what keeps calendars isolated.
+      localStorage.setItem('day-planner-calendar-config-by-user', JSON.stringify(data.calendarConfigByUser));
+      if (perUserCalendar) {
+        const mine = data.calendarConfigByUser[meSidForCal];
+        if (mine) {
+          if (mine.syncUrl !== undefined) { localStorage.setItem('day-planner-sync-url', mine.syncUrl); setSyncUrl(mine.syncUrl); }
+          if (mine.taskCalendarUrl !== undefined) { localStorage.setItem('day-planner-task-calendar-url', mine.taskCalendarUrl); setTaskCalendarUrl(mine.taskCalendarUrl); }
+          if (mine.auth) { localStorage.setItem('day-planner-task-calendar-auth', JSON.stringify(mine.auth)); setTaskCalendarAuth(mine.auth); }
+        }
+      }
+    }
     if (data.deletedGoalIds) localStorage.setItem('day-planner-deleted-goal-ids', JSON.stringify(data.deletedGoalIds));
     if (data.deletedProjectIds) localStorage.setItem('day-planner-deleted-project-ids', JSON.stringify(data.deletedProjectIds));
     if (data.obsidianConfig) {
@@ -5693,8 +5763,8 @@ const DayPlanner = () => {
       localStorage.setItem('day-planner-unscheduled-order-ts', data.unscheduledOrderTimestamp);
     }
     if (data.recycleBin) setRecycleBin(data.recycleBin);
-    if (data.syncUrl !== undefined) setSyncUrl(data.syncUrl);
-    if (data.taskCalendarUrl !== undefined) setTaskCalendarUrl(data.taskCalendarUrl);
+    if (!perUserCalendar && data.syncUrl !== undefined) setSyncUrl(data.syncUrl);
+    if (!perUserCalendar && data.taskCalendarUrl !== undefined) setTaskCalendarUrl(data.taskCalendarUrl);
     if (data.completedTaskUids) setCompletedTaskUids(new Set(data.completedTaskUids));
     if (data.recurringTasks) setRecurringTasks(prev => {
       const mergedIds = new Set(data.recurringTasks.map(t => String(t.id)));
@@ -8429,6 +8499,7 @@ const DayPlanner = () => {
     syncUrl, setSyncUrl,
     taskCalendarUrl, setTaskCalendarUrl,
     taskCalendarAuth, setTaskCalendarAuth,
+    syncCalendarCreds, setSyncCalendarCreds,
     syncRetentionDays, setSyncRetentionDays,
     calSyncStatus, setCalSyncStatus,
     calSyncLastSynced, setCalSyncLastSynced,

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -22,6 +22,7 @@ import MobileRoutinesTab from './MobileRoutinesTab.jsx';
 import UserOwnerSwitcher from './UserOwnerSwitcher.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
+import { isVaultEnabled } from '../sync/vaultConfig.js';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from '../intents/useIntentPoller.js';
 import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUsers.js';
@@ -63,6 +64,7 @@ const MobileSettingsPanel = () => {
     syncUrl, setSyncUrl,
     taskCalendarUrl, setTaskCalendarUrl,
     taskCalendarAuth, setTaskCalendarAuth,
+    syncCalendarCreds, setSyncCalendarCreds,
     syncRetentionDays, setSyncRetentionDays,
     calSyncStatus, calSyncLastSynced, calSyncConfigured,
     availableCalendars, setAvailableCalendars,
@@ -617,6 +619,22 @@ const MobileSettingsPanel = () => {
               Username + password fetches protected task calendars. Adding a CalDAV Base URL also syncs completion status back to your server.
             </p>
           </div>
+        )}
+        {multiUserEnabled && meUserSyncId && (
+          <label className="flex items-start gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={syncCalendarCreds}
+              onChange={(e) => setSyncCalendarCreds(e.target.checked)}
+              className="mt-0.5 flex-shrink-0"
+            />
+            <span className={`text-xs ${textSecondary}`}>
+              {t('settings.syncCalendarCreds')}
+              {!(cloudSyncConfig?.encryptionEnabled || isVaultEnabled()) && (
+                <span className="block mt-0.5 italic">{t('settings.syncCalendarCredsNeedsEncryption')}</span>
+              )}
+            </span>
+          </label>
         )}
         <div>
           <label className={`block text-sm ${textSecondary} mb-1`}>{t('settings.keepPastEvents')}</label>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -13,6 +13,7 @@ import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from '../intents/useIntentPo
 import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUsers.js';
 import { isAvailable as isICloudAvailable } from '../intents/icloudFileTransport.js';
 import { getSyncPassphrase, setSyncPassphrase } from '../utils/crypto.js';
+import { isVaultEnabled } from '../sync/vaultConfig.js';
 import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
 import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
 import { useTranslation } from 'react-i18next';
@@ -57,6 +58,7 @@ const SettingsModal = () => {
     showCalendarUrlHint, setShowCalendarUrlHint,
     calendarUrlAuth, setCalendarUrlAuth,
     taskCalendarUrl, setTaskCalendarUrl, taskCalendarAuth, setTaskCalendarAuth,
+    syncCalendarCreds, setSyncCalendarCreds,
     syncRetentionDays, setSyncRetentionDays,
     syncAll, isSyncing, calSyncLastSynced,
     availableCalendars, setAvailableCalendars, calendarFilter, setCalendarFilter,
@@ -872,6 +874,22 @@ const SettingsModal = () => {
                             Username + password fetches protected task calendars. Adding a CalDAV Base URL also syncs completion status back to your server.
                           </p>
                         </div>
+                      )}
+                      {multiUserEnabled && meUserSyncId && (
+                        <label className="flex items-start gap-2 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={syncCalendarCreds}
+                            onChange={(e) => setSyncCalendarCreds(e.target.checked)}
+                            className="mt-0.5 flex-shrink-0"
+                          />
+                          <span className={`text-xs ${textSecondary}`}>
+                            {t('settings.syncCalendarCreds')}
+                            {!(cloudSyncConfig?.encryptionEnabled || isVaultEnabled()) && (
+                              <span className="block mt-0.5 italic">{t('settings.syncCalendarCredsNeedsEncryption')}</span>
+                            )}
+                          </span>
+                        </label>
                       )}
                       <div>
                         <label className={`block text-sm ${textSecondary} mb-1`}>

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -20,7 +20,21 @@ export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =
 //  - the feature toggles are device-local ONLY when multi-user is on; a
 //    single-user install keeps syncing them LWW across that user's own devices.
 const ALWAYS_LOCAL_KEYS = ['obsidianConfig'];
-const MULTIUSER_LOCAL_KEYS = ['habitsEnabled', 'routinesEnabled', 'goalsProjectsEnabled'];
+// syncUrl/taskCalendarUrl are device-local in multi-user because each user's
+// calendar config travels per-user via the calendarConfigByUser map instead.
+const MULTIUSER_LOCAL_KEYS = ['habitsEnabled', 'routinesEnabled', 'goalsProjectsEnabled', 'syncUrl', 'taskCalendarUrl'];
+
+// Per-user calendar config: {syncId → {syncUrl, taskCalendarUrl, auth?, updatedAt}}.
+// Union by syncId, keeping the newer entry per user (LWW). Each device reads only
+// its own syncId's entry, so concurrent edits by different users never collide.
+export const mergeCalendarConfigByUser = (local = {}, remote = {}) => {
+  const out = { ...(local || {}) };
+  for (const [sid, entry] of Object.entries(remote || {})) {
+    const newer = !out[sid] || new Date(entry?.updatedAt || 0) > new Date(out[sid]?.updatedAt || 0);
+    if (newer) out[sid] = entry;
+  }
+  return out;
+};
 export {
   mergeDailyNotes,
   mergeHabits,
@@ -138,6 +152,13 @@ export const mergeSyncData = (local, remote, retentionDays) => {
   // Make sure a heal (one side's count changing) actually triggers a write/push.
   if (habitLogsFix.localChanged) result.localChanged = true;
   if (habitLogsFix.remoteChanged) result.remoteChanged = true;
+  // Per-user calendar config merges by syncId (the upstream merge doesn't know
+  // this key), so resolve it explicitly here from both sides.
+  if (local?.calendarConfigByUser || remote?.calendarConfigByUser) {
+    result.data.calendarConfigByUser = mergeCalendarConfigByUser(
+      local?.calendarConfigByUser, remote?.calendarConfigByUser,
+    );
+  }
   // Keep device-local settings on this device's own value rather than the
   // last-writer-wins result. Feature toggles only when multi-user is on, so a
   // household member's toggle never propagates; single-user keeps syncing them.

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mergeTaskArrays, mergeRoutineDefinitions, mergeDailyNotes, mergeHabits, mergeHabitLogs, mergeSyncData } from './mergeSync.js';
+import { mergeTaskArrays, mergeRoutineDefinitions, mergeDailyNotes, mergeHabits, mergeHabitLogs, mergeSyncData, mergeCalendarConfigByUser } from './mergeSync.js';
 
 // Helpers to create task fixtures with timestamps
 const T = (id, title, lastModified, extra = {}) => ({
@@ -1946,5 +1946,66 @@ describe('mergeSyncData — multi-user roster', () => {
     const remote = { ...base(), multiUserEnabled: true, multiUserEnabledUpdatedAt: ts(5) };
     const { data } = mergeSyncData(local, remote);
     expect(data.multiUserEnabled).toBeUndefined();
+  });
+});
+
+// Per-user calendar config: URLs (and opt-in credentials) travel per-user via the
+// calendarConfigByUser map so they sync across one user's devices without leaking
+// to others. The top-level syncUrl/taskCalendarUrl go device-local in multi-user.
+describe('mergeCalendarConfigByUser', () => {
+  // NOTE: ts(minutesAgo) — a SMALLER argument is more recent.
+  it('unions entries from both sides, keeping the newer per syncId', () => {
+    const a = { jason: { syncUrl: 'https://a', updatedAt: ts(5) } }; // newer — A wins
+    const b = {
+      jason: { syncUrl: 'https://b', updatedAt: ts(60) }, // older
+      kim:   { syncUrl: 'https://k', updatedAt: ts(20) }, // only on B — adopted
+    };
+    const out = mergeCalendarConfigByUser(a, b);
+    expect(out.jason.syncUrl).toBe('https://a');
+    expect(out.kim.syncUrl).toBe('https://k');
+  });
+
+  it('a newer remote entry overrides the local one', () => {
+    const a = { jason: { syncUrl: 'https://old', updatedAt: ts(60) } }; // older
+    const b = { jason: { syncUrl: 'https://new', updatedAt: ts(5) } };  // newer
+    expect(mergeCalendarConfigByUser(a, b).jason.syncUrl).toBe('https://new');
+  });
+
+  it('tolerates empty / missing sides', () => {
+    expect(mergeCalendarConfigByUser(undefined, undefined)).toEqual({});
+    expect(mergeCalendarConfigByUser({ a: { updatedAt: ts(1) } }, undefined)).toEqual({ a: { updatedAt: ts(1) } });
+  });
+});
+
+describe('mergeSyncData — per-user calendar config', () => {
+  const base = () => ({
+    tasks: [], unscheduledTasks: [], recycleBin: [], recurringTasks: [],
+    completedTaskUids: [], deletedTaskIds: {}, routineDefinitions: {},
+    todayRoutines: [], routinesDate: '', deletedRoutineChipIds: {},
+    removedTodayRoutineIds: {}, dailyNotes: {},
+  });
+
+  it('single-user: top-level calendar URLs still merge (prefer non-empty)', () => {
+    const local = { ...base(), syncUrl: '', taskCalendarUrl: '' };
+    const remote = { ...base(), syncUrl: 'https://feed', taskCalendarUrl: 'https://tasks' };
+    const { data } = mergeSyncData(local, remote);
+    expect(data.syncUrl).toBe('https://feed');
+    expect(data.taskCalendarUrl).toBe('https://tasks');
+  });
+
+  it('multi-user: top-level calendar URLs are device-local (remote never overrides)', () => {
+    const local = { ...base(), multiUserEnabled: true, syncUrl: 'https://mine', taskCalendarUrl: '' };
+    const remote = { ...base(), syncUrl: 'https://theirs', taskCalendarUrl: 'https://theirtasks' };
+    const { data } = mergeSyncData(local, remote);
+    expect(data.syncUrl).toBe('https://mine');
+    expect(data.taskCalendarUrl).toBe('');
+  });
+
+  it('merges calendarConfigByUser per syncId across devices', () => {
+    const local = { ...base(), calendarConfigByUser: { jason: { syncUrl: 'https://j', updatedAt: ts(60) } } };
+    const remote = { ...base(), calendarConfigByUser: { kim: { syncUrl: 'https://k', updatedAt: ts(20) } } };
+    const { data } = mergeSyncData(local, remote);
+    expect(data.calendarConfigByUser.jason.syncUrl).toBe('https://j');
+    expect(data.calendarConfigByUser.kim.syncUrl).toBe('https://k');
   });
 });

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -340,13 +340,15 @@ const ALWAYS_DEVICE_LOCAL = new Set([
   'minimizedSections', 'use24HourClock', 'weatherZip', 'weatherTempUnit', 'multiUserEnabled',
   'obsidianConfig',
 ]);
-// Feature-enablement toggles are device-local ONLY when multi-user is on, so one
-// household member hiding a feature does not hide it for everyone. A single-user
-// install keeps them syncing last-writer-wins across that user's own devices —
-// the gate below reads the LOCAL multiUserEnabled flag (itself device-local, so
-// stable regardless of merge order).
+// Feature-enablement toggles and the calendar-subscription URLs are device-local
+// ONLY when multi-user is on. For the toggles, so one household member hiding a
+// feature does not hide it for everyone; for the URLs, because each user's
+// calendar config travels per-user via the calendarConfigByUser map instead (so
+// it never leaks to other users on the same account). A single-user install
+// keeps both syncing across that user's own devices — the gate reads the LOCAL
+// multiUserEnabled flag (itself device-local, so stable regardless of merge order).
 const MULTIUSER_DEVICE_LOCAL = new Set([
-  'habitsEnabled', 'routinesEnabled', 'goalsProjectsEnabled',
+  'habitsEnabled', 'routinesEnabled', 'goalsProjectsEnabled', 'syncUrl', 'taskCalendarUrl',
 ]);
 // True when `key` must keep the local value rather than accept the pulled one,
 // given this device's multi-user state. Used by both the merge and the re-push
@@ -395,10 +397,26 @@ function mergeBundle(data, key, value, extra) {
       return;
     case 'syncUrl':
     case 'taskCalendarUrl':
+      // Multi-user: keep local — the per-user calendarConfigByUser map carries
+      // each user's URL instead, so it never leaks across users on one account.
+      if (data.multiUserEnabled) return;
       // prefer a non-empty value; don't let an unconfigured device clear a URL
       // (mirrors merge.js:810-815).
       data[key] = value || data[key] || '';
       return;
+    case 'calendarConfigByUser': {
+      // {syncId → {syncUrl, taskCalendarUrl, auth?, updatedAt}}: union by syncId,
+      // keep the newer entry per user (LWW). Each device reads only its own
+      // syncId's entry, so concurrent edits by different users never collide.
+      const local = data.calendarConfigByUser || {};
+      const remote = value || {};
+      const out = { ...local };
+      for (const [sid, entry] of Object.entries(remote)) {
+        if (!out[sid] || ts(entry?.updatedAt) > ts(out[sid]?.updatedAt)) out[sid] = entry;
+      }
+      data.calendarConfigByUser = out;
+      return;
+    }
     case 'habitsEnabled':
     case 'routinesEnabled':
     case 'goalsProjectsEnabled': {

--- a/src/sync/dbMerge.test.js
+++ b/src/sync/dbMerge.test.js
@@ -167,6 +167,32 @@ describe('A1 bundle merge — concurrent different-entry edits are not lost', ()
     expect(a.data.habitsEnabled).toBe(true);   // A keeps its own
     expect(b.data.habitsEnabled).toBe(false);  // B keeps its own
   });
+
+  it('multi-user: calendar URLs are device-local but calendarConfigByUser merges per syncId', () => {
+    const base = { ...EMPTY_COLLECTIONS, multiUserEnabled: true, syncUrl: '', taskCalendarUrl: '', calendarConfigByUser: {} };
+    const { vault, a, b } = newPair(base);
+    // Each device is a different user editing its own per-user entry; both survive.
+    // The top-level syncUrl stays device-local (a different value on each device).
+    a.mutate((d) => {
+      d.syncUrl = 'https://a-local';
+      d.calendarConfigByUser = { ...d.calendarConfigByUser, jason: { syncUrl: 'https://jason', updatedAt: T1 } };
+      return ['singleton:syncUrl', 'singleton:calendarConfigByUser'];
+    });
+    b.mutate((d) => {
+      d.syncUrl = 'https://b-local';
+      d.calendarConfigByUser = { ...d.calendarConfigByUser, kim: { syncUrl: 'https://kim', updatedAt: T1 } };
+      return ['singleton:syncUrl', 'singleton:calendarConfigByUser'];
+    });
+    syncToConvergence(a, b, vault);
+    // Both users' per-user entries converge on both devices...
+    for (const dev of [a, b]) {
+      expect(dev.data.calendarConfigByUser.jason.syncUrl).toBe('https://jason');
+      expect(dev.data.calendarConfigByUser.kim.syncUrl).toBe('https://kim');
+    }
+    // ...while the top-level URL stays whatever each device set locally.
+    expect(a.data.syncUrl).toBe('https://a-local');
+    expect(b.data.syncUrl).toBe('https://b-local');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

On a shared (multi-user) sync account, calendar configuration leaked between users:

1. **URLs synced top-level** (`syncUrl` / `taskCalendarUrl`, "prefer non-empty"), so one person's calendar feed propagated to everyone's device — and each device then *fetched* that feed.
2. **CalDAV to-do items synced as first-class tasks** (`isTaskCalendar` items were kept in the payload), so one user's task calendar showed up for everyone.

Meanwhile a single user with several devices had to **re-enter identical CalDAV credentials** on each one (auth was never synced).

This is the Phase 2 follow-up discussed on #1029.

## Approach: calendar config follows the *user*, not the *file*

A new synced map **`calendarConfigByUser: { [syncId]: { syncUrl, taskCalendarUrl, auth?, updatedAt } }`**, merged **per-`syncId` last-writer-wins** at both merge tiers:
- File tier — `mergeCalendarConfigByUser()` in `mergeSync.js` (the upstream merge doesn't know this key, so it's resolved explicitly).
- Vault tier — a `mergeBundle` case in `dbAdapter.js`.

> Deliberately **not** nested inside the user roster entry: the roster's wire format (`sharedUsers.js`) is a cross-app contract shared with *lastGLANCE* and strips unknown fields, so a nested `calendarConfig` would be dropped on that channel and pollute their schema.

**Isolation comes from the read side:** each device writes only *its own* `syncId` entry (in `buildSyncPayload`, content-compared so `updatedAt` only advances on a real change) and reads only *its own* `syncId` entry on apply (`applyEngineData`). Other users' entries are stored but never read — so your wife's app never *uses* your feed.

## Behavior

| | Single-user | Multi-user |
|---|---|---|
| Top-level `syncUrl` / `taskCalendarUrl` | sync top-level LWW (**unchanged**) | **device-local** (added to `MULTIUSER_DEVICE_LOCAL` / `MULTIUSER_LOCAL_KEYS`) |
| `calendarConfigByUser` | unused (empty map) | per-`syncId` LWW; each device reads its own entry |
| Subscription (`importSource:'sync'`) tasks | kept as today | **excluded** from shared payload; each device re-fetches from its own URL (completion still flows back via CalDAV) |
| No "me" selected | n/a | config stays purely device-local (safe fallback) |

## Credentials

URLs always travel per-user. The CalDAV **auth** travels only when the new **"Sync calendar credentials"** toggle is on **AND** sync is encrypted (`cloudSyncConfig.encryptionEnabled || isVaultEnabled()`). Defaults on (per discussion on #1029), visible in both the **desktop** (`SettingsModal`) and **mobile** (`MobileSettingsPanel`) calendar sections, with a hint shown when encryption is off. New i18n strings added to `en` (other locales fall back to `en`).

> Trust model: with encryption on, credentials sit in the shared sync file at rest, decryptable by anyone with the account passphrase (same trust model as all synced data). The toggle lets roommates/coworkers keep creds device-local. CalDAV app-passwords are scoped/revocable.

## One-time migration (cleanup of already-leaked data)

Going forward nothing leaks, but a device that *already* pulled another user's URL/tasks keeps that stale data locally. Calendar config and CalDAV-imported tasks carry **no owner**, so we can't classify what leaked — instead we reset to a clean slate once. On the first render where a device runs in per-user mode (guarded by a persisted flag):

- **Drop all `importSource:'sync'` tasks** — ephemeral, so legit ones re-fetch from your own URL and leaked ones simply don't return. (Deterministic, no provenance needed.)
- **Clear the top-level URLs** so a possibly-leaked value is never adopted as "mine" — re-enter once, syncs onward via the map. Auth is kept (device-local, never leaked → no password re-entry).
- The URL clear is **skipped if `calendarConfigByUser` already has this user's entry** (another device established it post-migration), to avoid overwriting clean config with empty.
- `buildSyncPayload` only writes the per-user entry once the migration flag is set, so it never seeds from a pre-migration top-level URL.

Cost: each user re-selects their calendar once when the mode activates (per *user*, then it syncs to their devices).

## Testing

- `mergeCalendarConfigByUser`: per-`syncId` union + LWW, empty-side tolerance.
- `mergeSyncData`: single-user URLs still merge; multi-user URLs device-local; map merges per-`syncId`.
- Vault: two-user convergence (both per-user entries survive; top-level URL stays device-local).
- Full suite passes (306 tests); production build clean. (Migration is an App.jsx effect — covered by reasoning + build, consistent with the rest of App.jsx.)

## Follow-up

Native macOS (Electron EventKit) calendar support — planned next as its own branch/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)