### PR TITLE
Fix per-user calendar seeding adopting a leaked URL during migration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1683,6 +1683,34 @@ const DayPlanner = () => {
   // On native apps, only the task calendar matters — calendar events come from the native bridge.
   // The immediate sync on mount ensures stale events are cleared whenever the app opens,
   // not just after 15 minutes (which is longer than most PWA sessions).
+  // Maintain this device's own per-user calendar entry (multi-user, post-migration).
+  // Done in an EFFECT rather than in buildSyncPayload so it only ever reads FLUSHED
+  // state: a payload built mid-migration (from the engine's render-time closure)
+  // must never seed the pre-clear, possibly-leaked URL into our own syncId entry.
+  // Declared before the migration and sync-trigger effects so that on the migration
+  // commit it runs first and skips (flag not yet set), then re-runs next render with
+  // the cleared URL. Content-compared so updatedAt only advances on a real change
+  // (and not during remote apply, when the applied value already matches).
+  useEffect(() => {
+    if (!multiUserEnabled || !meUserSyncId) return;
+    if (localStorage.getItem('day-planner-calendar-per-user-migrated') !== 'true') return;
+    const encrypted = !!(cloudSyncConfig?.encryptionEnabled || isVaultEnabled());
+    const includeAuth = syncCalendarCreds && encrypted && taskCalendarAuth
+      && (taskCalendarAuth.username || taskCalendarAuth.appPassword);
+    const desired = { syncUrl, taskCalendarUrl, ...(includeAuth ? { auth: taskCalendarAuth } : {}) };
+    let map = {};
+    try { map = JSON.parse(localStorage.getItem('day-planner-calendar-config-by-user') || '{}'); } catch { map = {}; }
+    const cur = map[meUserSyncId];
+    const sameContent = !!cur
+      && (cur.syncUrl ?? '') === (desired.syncUrl ?? '')
+      && (cur.taskCalendarUrl ?? '') === (desired.taskCalendarUrl ?? '')
+      && JSON.stringify(cur.auth ?? null) === JSON.stringify(desired.auth ?? null);
+    if (sameContent) return;
+    map[meUserSyncId] = { ...desired, updatedAt: new Date().toISOString() };
+    localStorage.setItem('day-planner-calendar-config-by-user', JSON.stringify(map));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [multiUserEnabled, meUserSyncId, syncUrl, taskCalendarUrl, taskCalendarAuth, syncCalendarCreds, cloudSyncConfig?.encryptionEnabled]);
+
   useEffect(() => {
     if (isTrayMode) return;
     const hasSyncTarget = isNativeApp() ? !!taskCalendarUrl : !!(syncUrl || taskCalendarUrl);
@@ -5491,33 +5519,13 @@ const DayPlanner = () => {
       !(t.imported && !t.isTaskCalendar && t.importSource !== 'file')
       && !(multiUserEnabled && t.imported && t.importSource === 'sync');
 
-    // Per-user calendar config (multi-user only). Write this device's own syncId
-    // entry into the shared map so the URLs — and credentials, when opted in AND
-    // sync is encrypted — follow this user across their devices without leaking to
-    // others. updatedAt only advances on a real content change (content-compare),
-    // so it doesn't thrash the per-syncId LWW merge.
-    // Gated on the one-time migration having run, so we never seed the entry from a
-    // top-level URL that might have leaked from another user pre-Phase-2 (the
-    // migration resets that to a clean slate first — see the effect below).
+    // Per-user calendar config (multi-user). Read-only here: the device's own
+    // entry is maintained by an effect (see "maintain per-user calendar entry"),
+    // NOT seeded here. buildSyncPayload runs from the engine's render-time closure
+    // and could otherwise fire mid-migration with a stale syncUrl while the
+    // migrated flag is already set, writing a leaked URL into this device's entry.
     let calendarConfigByUser = {};
     try { calendarConfigByUser = JSON.parse(localStorage.getItem('day-planner-calendar-config-by-user') || '{}'); } catch { calendarConfigByUser = {}; }
-    const calMigrated = localStorage.getItem('day-planner-calendar-per-user-migrated') === 'true';
-    if (multiUserEnabled && meUserSyncId && calMigrated) {
-      const encrypted = !!(cloudSyncConfig?.encryptionEnabled || isVaultEnabled());
-      const includeAuth = syncCalendarCreds && encrypted && taskCalendarAuth
-        && (taskCalendarAuth.username || taskCalendarAuth.appPassword);
-      const desired = { syncUrl, taskCalendarUrl, ...(includeAuth ? { auth: taskCalendarAuth } : {}) };
-      const cur = calendarConfigByUser[meUserSyncId];
-      const sameContent = !!cur
-        && (cur.syncUrl ?? '') === (desired.syncUrl ?? '')
-        && (cur.taskCalendarUrl ?? '') === (desired.taskCalendarUrl ?? '')
-        && JSON.stringify(cur.auth ?? null) === JSON.stringify(desired.auth ?? null);
-      calendarConfigByUser = {
-        ...calendarConfigByUser,
-        [meUserSyncId]: { ...desired, updatedAt: sameContent ? cur.updatedAt : new Date().toISOString() },
-      };
-      localStorage.setItem('day-planner-calendar-config-by-user', JSON.stringify(calendarConfigByUser));
-    }
     return {
       version: 2,
       lastModified: new Date().toISOString(),


### PR DESCRIPTION
## Bug

After #1030, two household devices (one with Jason as "Me", one with Maggie) **both adopted Jason's calendar URL** into their *own* per-user entry and showed his events — the exact cross-user leak the per-user work was meant to prevent.

## Root cause

`buildSyncPayload` seeded the device's own `calendarConfigByUser[mySyncId]` entry **as a side-effect, reading `syncUrl` from its render-time closure**. The engine re-derefs `buildPayload` every render (`App.jsx:5844`), and the one-time migration sets its `migrated` flag **synchronously** (localStorage) but clears `syncUrl` via **React state**, which lags a render.

So when a sync fires *during the migration commit* (the initial/interval sync calls `buildPayload` synchronously), it runs with **`migrated: true` + the still-leaked `syncUrl`**, writing the leaked URL into this device's own `syncId` entry. `applyEngineData` then reads it back via the per-user path, and the feedback loop **stabilizes on the leaked URL** — on every device that had it cached. (Repro: both Electron/macOS, "Me" set before installing the build, so the migration ran on first launch right into this window.)

## Fix

Move per-user-entry maintenance **out of `buildSyncPayload` into a dedicated effect** that only ever observes *flushed* state. It's declared **before** the migration and sync-trigger effects, so on the migration commit it runs first and skips (flag not yet set), then re-runs the next render with the **cleared** `syncUrl`, seeding an empty entry. `buildSyncPayload` is now a **pure read** of the map. Content-compared so `updatedAt` only advances on a real change (and not during remote apply).

## Healing already-affected devices

A device already in the bad state won't self-heal (its entry now equals the adopted URL, so the content-compare sees no change). **Clearing the calendar URL once** on the affected device (Maggie's) writes an empty entry that propagates and sticks. Jason's entry is legitimately his, so it stays.

## Testing

- Full suite passes (306). Build clean.
- The defect is an effect/closure timing issue in `App.jsx` (no component-test harness here); fix verified by tracing the migration-commit render sequence + build. Worth a real two-device run on the test setup to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkgJVJ935C45hHNYPc9MZ5)_