### PR TITLE
Add app-owned GLANCEvault DB intents transport (opt-in, beta)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dayglance",
       "version": "3.5.1",
       "dependencies": {
-        "@glance-apps/intents": "^1.3.3",
+        "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.5.2",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/@glance-apps/intents": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.3.3.tgz",
-      "integrity": "sha512-WlXjS94OgEYy8qeqGNuEZqLOA9wpCZWa//LGcvduDy3IJ21xIVv6UuIYYUWny2eVrr2hgMeUAtRvjnNbvppWtw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.4.0.tgz",
+      "integrity": "sha512-MV4yXH0JhXBxnd/7vbba+b2PWJDOyelG7Bws5Zi///yVxXi8axQPWFYclAV47WzIDDG1xHEue5FkziFY/+SoDw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:electron:mas": "vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs --mac mas --publish never"
   },
   "dependencies": {
-    "@glance-apps/intents": "^1.3.3",
+    "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.5.2",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -76,6 +76,7 @@ import useBackup from './hooks/useBackup.js';
 import useGTDFrames from './hooks/useGTDFrames.js';
 import { getGlanceHGInstances, isHGSessionReachable } from './hooks/useHyperGlance.js';
 import { useIntentPoller, INTENT_CONFIG_KEY } from './intents/useIntentPoller.js';
+import { useDbIntentPoller } from './intents/dbIntentsTransport.js';
 import { useNotifyEmitter } from './intents/useNotifyEmitter.js';
 import { useGoalNotifyEmitter } from './intents/useGoalNotifyEmitter.js';
 import { useAndroidIntentBridge } from './intents/useAndroidIntentBridge.js';
@@ -1104,6 +1105,19 @@ const DayPlanner = () => {
     navigate: tab => {
       // TABS values: 'glance' | 'timeline' | 'inbox' | 'goals' | 'settings'
       // mobileActiveTab values: 'dayglance' | 'timeline' | 'inbox' | 'goals' | 'settings'
+      const mobileTab = tab === 'glance' ? 'dayglance' : tab;
+      setMobileActiveTab(mobileTab);
+      if (tab === 'glance' || tab === 'inbox') setTabletActiveTab(tab === 'glance' ? 'glance' : 'inbox');
+    },
+  });
+  // GLANCEvault DB intents transport — receive poller mounted alongside the
+  // WebDAV poller; no-ops unless DB intents is enabled (its own flag + an
+  // inherited vault connection). Same context shape as useIntentPoller.
+  useDbIntentPoller({
+    tasks, unscheduledTasks, recurringTasks, projects,
+    setTasks, setUnscheduledTasks, setRecurringTasks,
+    goals, addGoal, updateGoal, deleteGoal,
+    navigate: tab => {
       const mobileTab = tab === 'glance' ? 'dayglance' : tab;
       setMobileActiveTab(mobileTab);
       if (tab === 'glance' || tab === 'inbox') setTabletActiveTab(tab === 'glance' ? 'glance' : 'inbox');

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -5,7 +5,7 @@ import {
   ChevronLeft, ChevronRight, Clock, Cloud, ExternalLink,
   Footprints, FolderOpen, Globe, GripVertical, HelpCircle, Key, LayoutGrid,
   Loader, Lock, Mic, Moon, Pencil, Plus,
-  Flag, RefreshCw, Save, Settings, Sparkles, Sun, Target, Trash2,
+  Flag, RefreshCw, Save, Server, Settings, Sparkles, Sun, Target, Trash2,
   Undo2, Upload, Users, Volume2, VolumeX, Wifi, WifiOff, Zap,
 } from 'lucide-react';
 import { getTzLabel, getTzOptions } from '../utils/timezones.js';
@@ -23,6 +23,7 @@ import UserOwnerSwitcher from './UserOwnerSwitcher.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { isVaultEnabled } from '../sync/vaultConfig.js';
+import { getDbIntentsConfig, setDbIntentsConfig, getDbIntentsConnection } from '../intents/dbIntentsConfig.js';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from '../intents/useIntentPoller.js';
 import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUsers.js';
@@ -138,6 +139,11 @@ const MobileSettingsPanel = () => {
   const [intentSaved, setIntentSaved] = useState(false);
   const [intentSetupPhase, setIntentSetupPhase] = useState(null);
   const [intentPassphraseInput, setIntentPassphraseInput] = useState('');
+  // GLANCEvault DB intents (beta). Tracks only `enabled`; the rest of the config
+  // (ttlMs, pollIntervalMinutes) is preserved on save, and the vault connection is
+  // INHERITED from the GLANCEvault sync config (not edited here).
+  const [dbIntentsEnabled, setDbIntentsEnabled] = useState(() => !!getDbIntentsConfig()?.enabled);
+  const [dbIntentsSaved, setDbIntentsSaved] = useState(false);
   const [muAddingUser, setMuAddingUser] = useState(false);
   const [muNewUserName, setMuNewUserName] = useState('');
   const [muEditingUserId, setMuEditingUserId] = useState(null);
@@ -1912,6 +1918,83 @@ const MobileSettingsPanel = () => {
             <span className={`font-medium ${textPrimary} flex-1 text-left`}>{t('settings.glanceActivityLog')}</span>
             <ChevronRight size={18} className={textSecondary} />
           </button>
+        </div>
+
+        {/* GLANCEvault intents (beta) — DB transport. Independent of the WebDAV
+            intents config above AND of the vault sync toggle; it only INHERITS the
+            vault connection from the GLANCEvault sync config. */}
+        <div>
+          <h5 className={sectionCls}>
+            <span className="flex items-center gap-2">
+              <Server size={14} className={textSecondary} />
+              GLANCEvault intents
+              <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-600'}`}>Beta</span>
+            </span>
+          </h5>
+          <p className={`${textSecondary} text-xs mb-3`}>
+            Deliver intents over your GLANCEvault server. Uses the same vault connection as GLANCEvault sync — no separate URL or token needed.
+          </p>
+          {(() => {
+            const dbConn = getDbIntentsConnection();
+            return (
+              <div className="space-y-3">
+                <div className={`text-xs px-3 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700/40' : 'bg-stone-50'}`}>
+                  {dbConn ? (
+                    <span className="flex items-center gap-1.5">
+                      <span className="w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />
+                      <span className={textSecondary}>Vault connection detected — ready to enable.</span>
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1.5">
+                      <span className="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
+                      <span className={textSecondary}>No vault connection. Configure GLANCEvault in Cloud Sync settings first.</span>
+                    </span>
+                  )}
+                </div>
+
+                <div className={`flex items-start gap-3 p-3 rounded-lg border ${borderClass} ${dbConn ? '' : 'opacity-60'}`}>
+                  <input
+                    type="checkbox"
+                    id="db-intents-toggle-mobile"
+                    checked={dbIntentsEnabled}
+                    disabled={!dbConn}
+                    onChange={e => setDbIntentsEnabled(e.target.checked)}
+                    className="mt-0.5 h-4 w-4 rounded"
+                  />
+                  <div>
+                    <label htmlFor="db-intents-toggle-mobile" className={`text-sm font-medium ${textPrimary} ${dbConn ? 'cursor-pointer' : 'cursor-not-allowed'}`}>
+                      Enable GLANCEvault intents
+                    </label>
+                    <p className={`text-xs ${textSecondary} mt-0.5`}>
+                      Independent of WebDAV intents and of GLANCEvault sync. Saving reloads the app so the poller restarts.
+                    </p>
+                  </div>
+                </div>
+
+                <button
+                  onClick={() => {
+                    // Match-by-construction: spread the EXISTING config and override
+                    // only `enabled`, so ttlMs / pollIntervalMinutes are preserved.
+                    // Persist via the config module's saver to the key the gate reads.
+                    const existing = getDbIntentsConfig() || {};
+                    const wasEnabled = !!existing.enabled;
+                    setDbIntentsConfig({ ...existing, enabled: dbIntentsEnabled });
+                    // Reload-on-change so useDbIntentPoller remounts (mirrors the
+                    // GLANCEvault sync toggle's behavior).
+                    if (wasEnabled !== dbIntentsEnabled) {
+                      window.location.reload();
+                      return;
+                    }
+                    setDbIntentsSaved(true);
+                    setTimeout(() => setDbIntentsSaved(false), 2000);
+                  }}
+                  className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-60 transition-colors"
+                >
+                  {dbIntentsSaved ? 'Saved' : 'Save'}
+                </button>
+              </div>
+            );
+          })()}
         </div>
       </div>
     );

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -14,6 +14,7 @@ import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUser
 import { isAvailable as isICloudAvailable } from '../intents/icloudFileTransport.js';
 import { getSyncPassphrase, setSyncPassphrase } from '../utils/crypto.js';
 import { isVaultEnabled } from '../sync/vaultConfig.js';
+import { getDbIntentsConfig, setDbIntentsConfig, getDbIntentsConnection } from '../intents/dbIntentsConfig.js';
 import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
 import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
 import { useTranslation } from 'react-i18next';
@@ -109,6 +110,11 @@ const SettingsModal = () => {
   // null | 'passphrase-needed' | 'running' | { error: string }
   const [intentSetupPhase, setIntentSetupPhase] = useState(null);
   const [intentPassphraseInput, setIntentPassphraseInput] = useState('');
+  // GLANCEvault DB intents (beta). Tracks only the `enabled` flag — the rest of
+  // the config (ttlMs, pollIntervalMinutes) is preserved on save, and the vault
+  // connection is INHERITED from the GLANCEvault sync config (not edited here).
+  const [dbIntentsEnabled, setDbIntentsEnabled] = useState(() => !!getDbIntentsConfig()?.enabled);
+  const [dbIntentsSaved, setDbIntentsSaved] = useState(false);
 
 
   const [trayHotkey, setTrayHotkey] = useState(() => localStorage.getItem('dg-tray-hotkey') || '');
@@ -1944,6 +1950,85 @@ const SettingsModal = () => {
                             {t('settings.glanceActivityLog')}
                           </button>
                         </div>
+                      </div>
+
+                      {/* GLANCEvault intents (beta) — DB transport. Independent of the
+                          WebDAV intents config above AND of the vault sync toggle; it only
+                          INHERITS the vault connection from the GLANCEvault sync config. */}
+                      <div className={`mt-4 pt-4 border-t ${borderClass} space-y-3`}>
+                        <div className="flex items-center gap-2">
+                          <Server size={14} className={textSecondary} />
+                          <span className={`text-sm font-medium ${textPrimary}`}>GLANCEvault intents</span>
+                          <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-stone-200 text-stone-600'}`}>Beta</span>
+                        </div>
+                        <p className={`${textSecondary} text-xs`}>
+                          Deliver intents over your GLANCEvault server instead of (or alongside) the WebDAV event log. Uses the same vault connection as GLANCEvault sync — no separate URL or token needed.
+                        </p>
+
+                        {(() => {
+                          const dbConn = getDbIntentsConnection();
+                          return (
+                            <>
+                              <div className={`text-xs px-3 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700/40' : 'bg-stone-50'}`}>
+                                {dbConn ? (
+                                  <span className="flex items-center gap-1.5">
+                                    <span className="w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />
+                                    <span className={textSecondary}>Vault connection detected — ready to enable.</span>
+                                  </span>
+                                ) : (
+                                  <span className="flex items-center gap-1.5">
+                                    <span className="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
+                                    <span className={textSecondary}>No vault connection. Configure GLANCEvault in Cloud Sync settings first.</span>
+                                  </span>
+                                )}
+                              </div>
+
+                              <div className={`flex items-start gap-3 p-3 rounded-lg border ${borderClass} ${dbConn ? '' : 'opacity-60'}`}>
+                                <input
+                                  type="checkbox"
+                                  id="db-intents-toggle"
+                                  checked={dbIntentsEnabled}
+                                  disabled={!dbConn}
+                                  onChange={e => setDbIntentsEnabled(e.target.checked)}
+                                  className="mt-0.5 h-4 w-4 rounded"
+                                />
+                                <div>
+                                  <label htmlFor="db-intents-toggle" className={`text-sm font-medium ${textPrimary} ${dbConn ? 'cursor-pointer' : 'cursor-not-allowed'}`}>
+                                    Enable GLANCEvault intents
+                                  </label>
+                                  <p className={`text-xs ${textSecondary} mt-0.5`}>
+                                    Independent of WebDAV intents and of GLANCEvault sync. Saving reloads the app so the poller restarts.
+                                  </p>
+                                </div>
+                              </div>
+
+                              <div className="flex items-center gap-2 flex-wrap">
+                                <button
+                                  onClick={() => {
+                                    // Match-by-construction: spread the EXISTING config and override
+                                    // only `enabled`, so ttlMs / pollIntervalMinutes are preserved
+                                    // (not re-seeded). Persist via the config module's own saver to
+                                    // the exact key the gate reads.
+                                    const existing = getDbIntentsConfig() || {};
+                                    const wasEnabled = !!existing.enabled;
+                                    setDbIntentsConfig({ ...existing, enabled: dbIntentsEnabled });
+                                    // Reload-on-change so useDbIntentPoller remounts and picks up the
+                                    // new config (mirrors the GLANCEvault sync toggle's behavior).
+                                    if (wasEnabled !== dbIntentsEnabled) {
+                                      window.location.reload();
+                                      return;
+                                    }
+                                    setDbIntentsSaved(true);
+                                    setTimeout(() => setDbIntentsSaved(false), 2000);
+                                  }}
+                                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-60 text-sm transition-colors"
+                                >
+                                  {dbIntentsSaved ? t('common.saved') : t('common.save')}
+                                </button>
+                              </div>
+                            </>
+                          );
+                        })()}
                       </div>
                       </>)}
                     </div>

--- a/src/intents/dbIntentsConfig.js
+++ b/src/intents/dbIntentsConfig.js
@@ -1,0 +1,63 @@
+// GLANCEvault DB INTENTS config + enablement gate.
+//
+// This is the app-owned DB intents transport's config. It is deliberately tiny:
+// it carries only { enabled, ttlMs, pollIntervalMinutes }. The vault CONNECTION
+// (vaultUrl, vaultToken, accountId) is NOT stored here — it is INHERITED from the
+// GLANCEvault SYNC config (src/sync/vaultConfig.js), mirroring lastGLANCE where
+// the DB intents config was just { enabled, ttlMs, pollIntervalMinutes } and the
+// connection came from getVaultConfig().
+//
+// Gating is independent of BOTH:
+//   - the WebDAV intents transport (dayglance-intent-config) — which stays the
+//     default and fully intact, and
+//   - the vault SYNC transport's own `enabled` flag — a user may run DB intents
+//     without enabling DB sync, as long as a vault connection is configured.
+//
+// NOTE (this prompt): the config is READ from its localStorage key here, but no
+// settings UI writes it yet — the toggle is a separate follow-up. Until that
+// ships, isDbIntentsEnabled() returns false in normal use and the whole DB
+// intents path is inert.
+
+import { getVaultConfig } from '../sync/vaultConfig.js';
+
+export const DB_INTENTS_CONFIG_KEY = 'dayglance-db-intents-config';
+
+// 30 days, matching the WebDAV intents GC retention default. Rows older than this
+// are server-expired (TTL) and never returned by /intents/list.
+export const DEFAULT_DB_INTENTS_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+// Foreground cadence, matching the WebDAV intents poller's 2-minute default.
+export const DEFAULT_DB_INTENTS_POLL_MINUTES = 2;
+
+/** @returns {{enabled:boolean, ttlMs?:number, pollIntervalMinutes?:number}|null} */
+export function getDbIntentsConfig() {
+  try {
+    const raw = localStorage.getItem(DB_INTENTS_CONFIG_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setDbIntentsConfig(cfg) {
+  if (cfg) localStorage.setItem(DB_INTENTS_CONFIG_KEY, JSON.stringify(cfg));
+  else localStorage.removeItem(DB_INTENTS_CONFIG_KEY);
+}
+
+// The vault connection the DB intents transport talks to, inherited from the
+// SYNC config. Returns null unless a full connection is present. Crucially this
+// does NOT consult the sync config's `enabled` flag — DB intents is gated on its
+// OWN flag (below); it only borrows the connection details.
+/** @returns {{vaultUrl:string, vaultToken:string, accountId:string}|null} */
+export function getDbIntentsConnection() {
+  const v = getVaultConfig();
+  if (!v || !v.vaultUrl || !v.vaultToken || !v.accountId) return null;
+  return { vaultUrl: v.vaultUrl, vaultToken: v.vaultToken, accountId: v.accountId };
+}
+
+// True only when DB intents is toggled on AND a vault connection is configured.
+// Everything in the DB intents transport is gated on this; when false the path is
+// fully inert (no send, no poll).
+export function isDbIntentsEnabled() {
+  const c = getDbIntentsConfig();
+  return !!(c && c.enabled && getDbIntentsConnection());
+}

--- a/src/intents/dbIntentsTransport.js
+++ b/src/intents/dbIntentsTransport.js
@@ -1,0 +1,432 @@
+// App-owned GLANCEvault DB INTENTS transport.
+//
+// @glance-apps/intents is a CODEC library, not a transport: its src/vault/ codec
+// (buildIntentRow, parseIntentRow, parseSince, formatSince) only does
+// envelope<->row encoding and cursor formatting. This module is the dayGLANCE-OWNED
+// transport that uses those codec helpers to talk to the GLANCEvault intents
+// server — exactly mirroring how the existing WebDAV intents transport
+// (useIntentPoller.js) is app-owned and uses the package only for the codec.
+//
+// It runs ALONGSIDE the WebDAV intents transport (which stays the default and is
+// untouched), is per-user opt-in, and INHERITS the vault connection from the SYNC
+// config (see dbIntentsConfig.js).
+//
+// Server contract (identical to what lastGLANCE talks to):
+//
+//   WRITE  POST {vaultUrl}/intents/batch
+//     body: { accountId, events: [ { eventId, envelope (base64), expiresAt (ISO) } ] }
+//     resp: { written, maxSeq }      — insert-only; a re-sent eventId is a no-op.
+//
+//   LIST   GET {vaultUrl}/intents/list?accountId=&since=&limit=
+//     resp: { rows: [ { eventId, envelope (base64), seq, expiresAt, serverMtime } ], hasMore }
+//     seq > since, ascending. Server returns only NON-EXPIRED rows. Page size 500.
+//
+//   Auth: the same device-token bearer the vault SYNC transport already uses.
+
+import { useEffect, useRef } from 'react';
+import {
+  parseEnvelope,
+  parseEncryptedEnvelope,
+  deriveEnvelopeKey,
+  NoKeyError,
+  WrongKeyError,
+  NotEncryptedError,
+  MalformedEnvelopeError,
+  ACTIONS,
+  buildIntentRow,
+  parseIntentRow,
+  parseSince,
+  formatSince,
+} from '@glance-apps/intents';
+import { loadIntentsRootKey } from './intentsKeyStore.js';
+import { handleIntent } from './handleIntent.js';
+import { logActivity } from './intentLog.js';
+import { MULTI_USER_CONFIG_KEY } from './useIntentPoller.js';
+import {
+  getDbIntentsConfig,
+  getDbIntentsConnection,
+  isDbIntentsEnabled,
+  DEFAULT_DB_INTENTS_TTL_MS,
+  DEFAULT_DB_INTENTS_POLL_MINUTES,
+} from './dbIntentsConfig.js';
+
+// The RECEIVE cursor lives in its OWN app-owned key, completely separate from the
+// send path. It is a seq (number) and advances ONLY from intents actually
+// received/processed — sending NEVER touches it (see the advance site below).
+const DB_CURSOR_KEY = 'dayglance-db-intent-cursor';
+const PAGE_LIMIT = 500;
+const APP_EMITTER = 'app.dayglance';
+
+// The tray popup holds a read-only snapshot and must never poll — processing an
+// event would consume it before the main window can act (mirrors useIntentPoller).
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+
+// Module-level lock: prevents React StrictMode's double-mount from running two
+// concurrent polls, which would both read the same cursor and double-process.
+let dbPollLock = false;
+
+// ─── receive cursor ──────────────────────────────────────────────────────────
+
+// parseSince turns the stored string (or null) into a seq number|null.
+function getReceiveCursor() {
+  return parseSince(localStorage.getItem(DB_CURSOR_KEY));
+}
+function setReceiveCursor(seq) {
+  localStorage.setItem(DB_CURSOR_KEY, String(seq));
+}
+
+// ─── HTTP (native vs electron vs browser) ────────────────────────────────────
+
+// Mirrors the platform routing the vault SYNC transport uses (dbEngine.js): the
+// native bridge and electron proxy both take POSITIONAL (method, url, headers,
+// body) and return a plain { status, ok, body } object; the browser path uses
+// global fetch and is normalized to the same shape. Returns a function
+// (method, url, headers, body) => Promise<{ status, ok, body }>.
+function defaultVaultFetch() {
+  const bridge = typeof window !== 'undefined' ? window.DayGlanceNative : null;
+  const isNativeApp = !!bridge?.httpRequest;
+  const electronProxyFetch = typeof window !== 'undefined' && window.electronAPI?.isElectron
+    ? (...args) => window.electronAPI.proxyFetch(...args)
+    : null;
+
+  if (isNativeApp) {
+    // The native bridge is synchronous and returns a JSON string.
+    return async (method, url, headers, body) => {
+      let r;
+      try { r = JSON.parse(bridge.httpRequest(method, url, JSON.stringify(headers), body ?? '')); }
+      catch { throw new TypeError('Failed to fetch'); }
+      if (!r) throw new TypeError('Failed to fetch');
+      return r;
+    };
+  }
+  if (electronProxyFetch) {
+    return async (method, url, headers, body) => {
+      let r;
+      try { r = await electronProxyFetch(method, url, headers, body ?? null); }
+      catch { throw new TypeError('Failed to fetch'); }
+      if (!r) throw new TypeError('Failed to fetch');
+      return r;
+    };
+  }
+  // Browser / PWA: global fetch, normalized to { status, ok, body }.
+  return async (method, url, headers, body) => {
+    const res = await globalThis.fetch(url, { method, headers, body: body ?? undefined });
+    const text = await res.text();
+    return { status: res.status, ok: res.ok, body: text };
+  };
+}
+
+function authHeaders(token, extra = {}) {
+  return { Authorization: `Bearer ${token}`, ...extra };
+}
+
+function parseBody(res) {
+  if (res == null || res.body == null) return undefined;
+  if (typeof res.body !== 'string') return res.body;
+  try { return JSON.parse(res.body); } catch { return undefined; }
+}
+
+// ─── SEND ─────────────────────────────────────────────────────────────────────
+
+/**
+ * POST a batch of outgoing intents to {vaultUrl}/intents/batch.
+ *
+ * Each envelope is encoded to a row via buildIntentRow (the codec), then wrapped
+ * in the server's batch shape { accountId, events: [...] }. Insert-only: re-sending
+ * the same eventId is a server-side no-op, so this is safe to retry.
+ *
+ * Connection/config are inherited from the vault SYNC config + DB intents config
+ * unless injected (tests). Returns the parsed server response { written, maxSeq }.
+ *
+ * IMPORTANT: sending NEVER touches the receive cursor.
+ */
+export async function sendIntentsDb(envelopes, opts = {}) {
+  const connection = opts.connection ?? getDbIntentsConnection();
+  if (!connection) return undefined;
+
+  const cfg = opts.config ?? getDbIntentsConfig() ?? {};
+  const ttlMs = cfg.ttlMs ?? DEFAULT_DB_INTENTS_TTL_MS;
+  const vaultFetch = opts.vaultFetch ?? defaultVaultFetch();
+
+  const list = Array.isArray(envelopes) ? envelopes : [envelopes];
+  const events = list.map((envelope) => {
+    // Codec: envelope -> { eventId, envelope (opaque base64), expiresAt (ISO) }.
+    // The envelope is opaque on the wire; we never decrypt or inspect it here.
+    const row = buildIntentRow(envelope, { ttlMs });
+    return { eventId: row.eventId, envelope: row.envelope, expiresAt: row.expiresAt };
+  });
+  if (!events.length) return undefined;
+
+  const body = { accountId: connection.accountId, events };
+  const url = connection.vaultUrl.replace(/\/+$/, '') + '/intents/batch';
+  const headers = authHeaders(connection.vaultToken, { 'Content-Type': 'application/json' });
+
+  const res = await vaultFetch('POST', url, headers, JSON.stringify(body));
+  if (!res || !res.ok) {
+    console.warn('[db-intent] batch POST failed:', res?.status);
+    return undefined;
+  }
+  return parseBody(res); // { written, maxSeq }
+}
+
+/**
+ * Gated single-envelope send for the emit sites. No-ops unless DB intents is
+ * enabled. Fire-and-forget; mirrors how writeEventFile no-ops without WebDAV.
+ */
+export async function sendIntentDb(envelope) {
+  if (!isDbIntentsEnabled()) return;
+  try {
+    await sendIntentsDb(envelope);
+  } catch (err) {
+    console.warn('[db-intent] send failed:', err.message);
+  }
+}
+
+// ─── RECEIVE ───────────────────────────────────────────────────────────────────
+
+// Route ONE decoded envelope object (parseIntentRow already base64-decoded it)
+// into the app. This mirrors the WebDAV path in useIntentPoller._poll exactly —
+// same emitted_by loopback guard, same encrypted-flag branch through the SAME
+// envelope parsers (parseEnvelope / parseEncryptedEnvelope), same multi-user
+// visibility filter, and into the SAME handler (handleIntent) the WebDAV path
+// feeds. It is duplicated rather than shared only to keep the WebDAV transport
+// byte-for-byte intact per the change's constraints.
+async function routeIncoming(raw, context) {
+  // Skip our own events (loopback). Checked on the raw object before parsing
+  // because our notify envelopes use a schema parseEnvelope rejects as malformed.
+  if (raw?.emitted_by === APP_EMITTER) return;
+
+  let envelope;
+  try {
+    if (raw?.encrypted === true) {
+      const rootKey = await loadIntentsRootKey();
+      if (!rootKey) {
+        console.warn('[db-intent] Skipping encrypted event — intents encryption not set up');
+        logActivity({
+          direction: 'in', action: 'unknown', event: null, source_app: null,
+          title: null, timestamp: new Date().toISOString(), status: 'error', error: 'no_root_key',
+        });
+        return;
+      }
+      envelope = await parseEncryptedEnvelope(raw, (salt) => deriveEnvelopeKey(rootKey, salt));
+    } else {
+      envelope = parseEnvelope(raw);
+    }
+  } catch (parseErr) {
+    let errorCode = parseErr.name ?? 'parse_error';
+    // MalformedEnvelopeError = decrypted/parsed fine but failed schema validation
+    // (protocol mismatch) — amber, not a genuine key/network failure.
+    let logStatus = 'error';
+    if (parseErr instanceof NoKeyError) {
+      console.warn('[db-intent] Skipping encrypted event (no key)');
+    } else if (parseErr instanceof WrongKeyError) {
+      console.warn('[db-intent] Skipping encrypted event (wrong key)');
+    } else if (parseErr instanceof MalformedEnvelopeError) {
+      console.warn('[db-intent] Skipping malformed envelope:', parseErr.message);
+      logStatus = 'warn';
+    } else if (parseErr instanceof NotEncryptedError) {
+      console.warn('[db-intent] Skipping malformed envelope');
+    } else {
+      console.warn('[db-intent] Unparseable envelope, skipping');
+      errorCode = 'parse_error';
+    }
+    logActivity({
+      direction: 'in', action: 'unknown', event: null, source_app: null,
+      title: null, timestamp: new Date().toISOString(), status: logStatus, error: errorCode,
+    });
+    return;
+  }
+
+  if (envelope.emitted_by === APP_EMITTER) return;
+
+  // Multi-user visibility filter: skip CREATE intents not assigned to this user.
+  if (envelope.action === ACTIONS.CREATE) {
+    const multiUserEnabled = JSON.parse(localStorage.getItem('dayglance-multi-user-enabled') || 'false');
+    const muRaw = localStorage.getItem(MULTI_USER_CONFIG_KEY);
+    const meUserSyncId = muRaw ? JSON.parse(muRaw).meUserSyncId : null;
+    if (multiUserEnabled && meUserSyncId) {
+      const assigned = envelope.payload.assigned_user_ids ?? [];
+      if (assigned.length > 0 && !assigned.includes(meUserSyncId)) {
+        logActivity({
+          direction: 'in', action: envelope.action, event: null,
+          source_app: envelope.payload.source_app ?? envelope.emitted_by ?? null,
+          title: envelope.payload.title ?? null, timestamp: envelope.emitted_at,
+          status: 'ok', error: null,
+        });
+        return;
+      }
+    }
+  }
+
+  const result = await handleIntent(envelope.action, envelope.payload, { ...context, eventId: envelope.event_id });
+  logActivity({
+    direction: 'in', action: envelope.action, event: envelope.payload.event ?? null,
+    source_app: envelope.payload.source_app ?? envelope.emitted_by ?? null,
+    title: envelope.payload.title ?? null, timestamp: envelope.emitted_at,
+    status: result.success ? 'ok' : 'error', error: result.success ? null : result.error,
+  });
+}
+
+/**
+ * Drain GLANCEvault intents into the app, paginating until the backlog is
+ * exhausted. MANDATORY pagination loop: the response is { rows, hasMore } with a
+ * page size of 500, so a >500 backlog spans multiple pages. We list from the
+ * receive cursor, process every row, advance the cursor to the last consumed
+ * row's seq, and — while hasMore is true — list again from the new cursor. We
+ * never read .rows just once.
+ *
+ * Connection is inherited from the vault SYNC config unless injected (tests).
+ */
+export async function pollDbIntents(context, opts = {}) {
+  const connection = opts.connection ?? getDbIntentsConnection();
+  if (!connection) return;
+
+  const vaultFetch = opts.vaultFetch ?? defaultVaultFetch();
+  const headers = authHeaders(connection.vaultToken);
+  const base = connection.vaultUrl.replace(/\/+$/, '');
+
+  let since = getReceiveCursor(); // seq number|null
+  let hasMore = true;
+
+  while (hasMore) {
+    const qs = new URLSearchParams({
+      accountId: connection.accountId,
+      since: formatSince(since), // null -> "0"; otherwise the seq as a string
+      limit: String(PAGE_LIMIT),
+    }).toString();
+    const url = `${base}/intents/list?${qs}`;
+
+    let res;
+    try {
+      res = await vaultFetch('GET', url, headers);
+    } catch (err) {
+      console.warn('[db-intent] list error:', err.message);
+      return;
+    }
+    if (!res || !res.ok) {
+      console.warn('[db-intent] list returned', res?.status);
+      return;
+    }
+
+    const payload = parseBody(res);
+    if (!payload) {
+      console.warn('[db-intent] list: unparseable response body');
+      return;
+    }
+    const rows = Array.isArray(payload.rows) ? payload.rows : [];
+
+    for (const rawRow of rows) {
+      let parsed;
+      try {
+        // Codec: decodes the base64 envelope back to an object on parsed.envelope.
+        parsed = parseIntentRow(rawRow);
+      } catch (err) {
+        // Malformed server row — log and advance past it (using its seq if
+        // available) so the loop can't wedge on a single bad row.
+        console.warn('[db-intent] Skipping unparseable row:', err.message);
+        logActivity({
+          direction: 'in', action: 'unknown', event: null, source_app: null,
+          title: null, timestamp: new Date().toISOString(), status: 'error', error: 'row_parse_error',
+        });
+        if (typeof rawRow?.seq === 'number') {
+          setReceiveCursor(rawRow.seq);
+          since = rawRow.seq;
+        }
+        continue;
+      }
+
+      try {
+        await routeIncoming(parsed.envelope, context);
+      } catch (err) {
+        // A single failing intent must not wedge the drain (mirrors the WebDAV
+        // path, which advances its cursor past a row even on processing error).
+        console.warn('[db-intent] Error processing row', parsed.eventId, ':', err.message);
+        logActivity({
+          direction: 'in', action: 'unknown', event: null, source_app: null,
+          title: null, timestamp: new Date().toISOString(), status: 'error', error: err.message,
+        });
+      }
+
+      // ── RECEIVE CURSOR ADVANCE ──────────────────────────────────────────────
+      // Advance ONLY from a row actually received/processed (its seq). Sending
+      // never reaches here. NOTE: the server returns only NON-EXPIRED rows, so
+      // this cursor can legitimately jump past the seq of an intent that expired
+      // (TTL) before this device listed it. That gap is correct/intended, NOT the
+      // sync cursor-skip bug — there is simply no row to deliver for that seq.
+      setReceiveCursor(parsed.seq);
+      since = parsed.seq;
+    }
+
+    hasMore = payload.hasMore === true;
+  }
+}
+
+// Serialize concurrent polls (StrictMode double-mount / overlapping triggers).
+async function poll(context, opts) {
+  if (dbPollLock) return;
+  dbPollLock = true;
+  try {
+    await pollDbIntents(context, opts);
+  } finally {
+    dbPollLock = false;
+  }
+}
+
+// ─── hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Mounts the DB intents RECEIVE poller alongside the WebDAV poller. No-ops unless
+ * DB intents is enabled (its own flag + an inherited vault connection). Matches
+ * the WebDAV intents cadence: poll on startup, on focus (visibilitychange), and
+ * on an interval. Receive-only — there is no push; sends happen at the emit sites.
+ *
+ * context shape: same as useIntentPoller (tasks, setters, goals, navigate, …).
+ */
+export function useDbIntentPoller(context) {
+  const contextRef = useRef(context);
+  contextRef.current = context;
+
+  useEffect(() => {
+    if (isTrayMode) return;
+    if (!isDbIntentsEnabled()) return;
+
+    const cfg = getDbIntentsConfig() ?? {};
+    const intervalMs = (cfg.pollIntervalMinutes ?? DEFAULT_DB_INTENTS_POLL_MINUTES) * 60 * 1000;
+    let timerId = null;
+    let destroyed = false;
+
+    const scheduleNext = () => {
+      if (destroyed) return;
+      timerId = setTimeout(runPoll, intervalMs);
+    };
+
+    const runPoll = async () => {
+      if (destroyed) return;
+      try {
+        await poll(contextRef.current);
+      } catch (err) {
+        console.warn('[db-intent] poll error:', err.message);
+      }
+      scheduleNext();
+    };
+
+    const onVisibilityChange = () => {
+      if (!document.hidden) {
+        clearTimeout(timerId);
+        runPoll();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    runPoll(); // initial poll on mount
+
+    return () => {
+      destroyed = true;
+      clearTimeout(timerId);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, []);
+}
+
+// Exported for tests.
+export { DB_CURSOR_KEY };

--- a/src/intents/dbIntentsTransport.js
+++ b/src/intents/dbIntentsTransport.js
@@ -54,6 +54,14 @@ import {
 // send path. It is a seq (number) and advances ONLY from intents actually
 // received/processed — sending NEVER touches it (see the advance site below).
 const DB_CURSOR_KEY = 'dayglance-db-intent-cursor';
+// Per-seq consecutive-failure counters for the bounded-retry model. PERSISTED
+// next to the receive cursor because retries span poll cycles (and app reloads):
+// an in-memory counter would reset on every reload and never reach the cap.
+const DB_RETRY_KEY = 'dayglance-db-intent-retries';
+// A row whose handler THROWS this many consecutive times is treated as poison:
+// we give up, log loudly, and advance past it so the channel can't wedge forever.
+// (Name and value match lastGLANCE.)
+const MAX_INTENT_RETRIES = 5;
 const PAGE_LIMIT = 500;
 const APP_EMITTER = 'app.dayglance';
 
@@ -73,6 +81,35 @@ function getReceiveCursor() {
 }
 function setReceiveCursor(seq) {
   localStorage.setItem(DB_CURSOR_KEY, String(seq));
+}
+
+// ─── per-seq failure counters (persisted) ────────────────────────────────────
+
+// Map of { [seq]: consecutiveFailureCount }. Only ACTIVELY-failing seqs hold an
+// entry — counters are cleared on success and on give-up, so the map never grows
+// unbounded for every seq ever seen.
+function loadRetries() {
+  try { return JSON.parse(localStorage.getItem(DB_RETRY_KEY) || '{}'); } catch { return {}; }
+}
+function saveRetries(map) {
+  if (!map || Object.keys(map).length === 0) localStorage.removeItem(DB_RETRY_KEY);
+  else localStorage.setItem(DB_RETRY_KEY, JSON.stringify(map));
+}
+// Bump and persist the failure count for a seq; returns the new count.
+function bumpFailure(seq) {
+  const map = loadRetries();
+  const next = (map[String(seq)] || 0) + 1;
+  map[String(seq)] = next;
+  saveRetries(map);
+  return next;
+}
+// Drop a seq's counter (on success or give-up) so the map doesn't leak.
+function clearFailure(seq) {
+  const map = loadRetries();
+  if (map[String(seq)] !== undefined) {
+    delete map[String(seq)];
+    saveRetries(map);
+  }
 }
 
 // ─── HTTP (native vs electron vs browser) ────────────────────────────────────
@@ -191,10 +228,20 @@ export async function sendIntentDb(envelope) {
 // visibility filter, and into the SAME handler (handleIntent) the WebDAV path
 // feeds. It is duplicated rather than shared only to keep the WebDAV transport
 // byte-for-byte intact per the change's constraints.
+//
+// Return contract drives the drain's three-way failure model:
+//   'ok'        — consumed cleanly (loopback/multi-user skip, or handleIntent
+//                 succeeded). The drain advances the cursor and clears counters.
+//   'permanent' — this row will NEVER succeed (decode/decrypt failure, missing
+//                 root key, or a SOFT handler failure result.success===false —
+//                 the handler deciding it can't process this intent). The drain
+//                 advances past it; retrying is pointless.
+// A THROWN exception is NOT returned — it propagates to the caller, which treats
+// it as a maybe-transient handler error subject to bounded retry.
 async function routeIncoming(raw, context) {
   // Skip our own events (loopback). Checked on the raw object before parsing
   // because our notify envelopes use a schema parseEnvelope rejects as malformed.
-  if (raw?.emitted_by === APP_EMITTER) return;
+  if (raw?.emitted_by === APP_EMITTER) return 'ok';
 
   let envelope;
   try {
@@ -206,7 +253,7 @@ async function routeIncoming(raw, context) {
           direction: 'in', action: 'unknown', event: null, source_app: null,
           title: null, timestamp: new Date().toISOString(), status: 'error', error: 'no_root_key',
         });
-        return;
+        return 'permanent';
       }
       envelope = await parseEncryptedEnvelope(raw, (salt) => deriveEnvelopeKey(rootKey, salt));
     } else {
@@ -234,10 +281,10 @@ async function routeIncoming(raw, context) {
       direction: 'in', action: 'unknown', event: null, source_app: null,
       title: null, timestamp: new Date().toISOString(), status: logStatus, error: errorCode,
     });
-    return;
+    return 'permanent';
   }
 
-  if (envelope.emitted_by === APP_EMITTER) return;
+  if (envelope.emitted_by === APP_EMITTER) return 'ok';
 
   // Multi-user visibility filter: skip CREATE intents not assigned to this user.
   if (envelope.action === ACTIONS.CREATE) {
@@ -253,11 +300,14 @@ async function routeIncoming(raw, context) {
           title: envelope.payload.title ?? null, timestamp: envelope.emitted_at,
           status: 'ok', error: null,
         });
-        return;
+        return 'ok';
       }
     }
   }
 
+  // A THROW here propagates to the caller (transient → bounded retry). A returned
+  // result.success===false is a SOFT failure: the handler refusing this intent,
+  // which won't change on retry → permanent.
   const result = await handleIntent(envelope.action, envelope.payload, { ...context, eventId: envelope.event_id });
   logActivity({
     direction: 'in', action: envelope.action, event: envelope.payload.event ?? null,
@@ -265,6 +315,7 @@ async function routeIncoming(raw, context) {
     title: envelope.payload.title ?? null, timestamp: envelope.emitted_at,
     status: result.success ? 'ok' : 'error', error: result.success ? null : result.error,
   });
+  return result.success ? 'ok' : 'permanent';
 }
 
 /**
@@ -275,6 +326,15 @@ async function routeIncoming(raw, context) {
  * row's seq, and — while hasMore is true — list again from the new cursor. We
  * never read .rows just once.
  *
+ * Per-row failure handling is three-way:
+ *   (1) DECODE / PERMANENT-BAD (unparseable row, decrypt failure, or a SOFT
+ *       handler result.success===false) → advance past it; retrying is pointless.
+ *   (2) HANDLER THREW (maybe-transient) → do NOT advance; bump a persisted
+ *       per-seq counter. At MAX_INTENT_RETRIES consecutive failures the row is
+ *       poison: give up, log loudly, advance past it. Below the cap, HOLD —
+ *       stop the whole drain (cursor unchanged) so the next poll retries here.
+ *   (3) SUCCESS → advance and clear the seq's counter.
+ *
  * Connection is inherited from the vault SYNC config unless injected (tests).
  */
 export async function pollDbIntents(context, opts = {}) {
@@ -282,6 +342,9 @@ export async function pollDbIntents(context, opts = {}) {
   if (!connection) return;
 
   const vaultFetch = opts.vaultFetch ?? defaultVaultFetch();
+  // Test seam: lets tests drive the three-way model deterministically. Defaults
+  // to the real router in production.
+  const route = opts.routeIncoming ?? routeIncoming;
   const headers = authHeaders(connection.vaultToken);
   const base = connection.vaultUrl.replace(/\/+$/, '');
 
@@ -316,43 +379,72 @@ export async function pollDbIntents(context, opts = {}) {
     const rows = Array.isArray(payload.rows) ? payload.rows : [];
 
     for (const rawRow of rows) {
+      // ── (1) DECODE / PERMANENT-BAD ──────────────────────────────────────────
       let parsed;
       try {
         // Codec: decodes the base64 envelope back to an object on parsed.envelope.
         parsed = parseIntentRow(rawRow);
       } catch (err) {
-        // Malformed server row — log and advance past it (using its seq if
-        // available) so the loop can't wedge on a single bad row.
+        // Malformed server row — it will never decode. Advance past it (using its
+        // seq if available) so the loop can't wedge on a single bad row.
         console.warn('[db-intent] Skipping unparseable row:', err.message);
         logActivity({
           direction: 'in', action: 'unknown', event: null, source_app: null,
           title: null, timestamp: new Date().toISOString(), status: 'error', error: 'row_parse_error',
         });
         if (typeof rawRow?.seq === 'number') {
+          clearFailure(rawRow.seq);
           setReceiveCursor(rawRow.seq);
           since = rawRow.seq;
         }
         continue;
       }
 
+      // ── (2) ROUTE: success / permanent / THROW (maybe-transient) ────────────
+      let outcome;
       try {
-        await routeIncoming(parsed.envelope, context);
+        // 'ok' or 'permanent'; a THROW means a maybe-transient handler error.
+        outcome = await route(parsed.envelope, context);
       } catch (err) {
-        // A single failing intent must not wedge the drain (mirrors the WebDAV
-        // path, which advances its cursor past a row even on processing error).
-        console.warn('[db-intent] Error processing row', parsed.eventId, ':', err.message);
-        logActivity({
-          direction: 'in', action: 'unknown', event: null, source_app: null,
-          title: null, timestamp: new Date().toISOString(), status: 'error', error: err.message,
-        });
+        // HANDLER THREW — treat as maybe-transient. Do NOT advance yet; bump the
+        // PERSISTED per-seq counter so the cap is reached even across reloads.
+        const failures = bumpFailure(parsed.seq);
+        if (failures >= MAX_INTENT_RETRIES) {
+          // Poison: it has failed MAX_INTENT_RETRIES times running. Give up so the
+          // channel doesn't wedge forever — log loudly, clear the counter, advance.
+          console.error(
+            `[db-intent] Giving up on intent ${parsed.eventId} (seq ${parsed.seq}) after ${failures} consecutive failures:`,
+            err.message,
+          );
+          logActivity({
+            direction: 'in', action: 'unknown', event: null, source_app: null,
+            title: null, timestamp: new Date().toISOString(), status: 'error', error: `gave_up_after_${failures}`,
+          });
+          clearFailure(parsed.seq);
+          setReceiveCursor(parsed.seq);
+          since = parsed.seq;
+          continue;
+        }
+        // Under the cap: HOLD. Stop the whole drain for this poll (this page AND
+        // any further pages), leaving the cursor unadvanced so the next poll
+        // retries from here. End cleanly — no uncaught throw.
+        console.warn(
+          `[db-intent] Holding intent ${parsed.eventId} (seq ${parsed.seq}) for retry ${failures}/${MAX_INTENT_RETRIES}:`,
+          err.message,
+        );
+        return;
       }
 
-      // ── RECEIVE CURSOR ADVANCE ──────────────────────────────────────────────
+      // ── (3) ADVANCE (success or permanent) ──────────────────────────────────
       // Advance ONLY from a row actually received/processed (its seq). Sending
-      // never reaches here. NOTE: the server returns only NON-EXPIRED rows, so
-      // this cursor can legitimately jump past the seq of an intent that expired
-      // (TTL) before this device listed it. That gap is correct/intended, NOT the
-      // sync cursor-skip bug — there is simply no row to deliver for that seq.
+      // never reaches here. Clear any failure counter for this seq on success AND
+      // on permanent give-up so the counter map never leaks. NOTE: the server
+      // returns only NON-EXPIRED rows, so this cursor can legitimately jump past
+      // the seq of an intent that expired (TTL) before this device listed it.
+      // That gap is correct/intended, NOT the sync cursor-skip bug — there is
+      // simply no row to deliver for that seq.
+      void outcome; // 'ok' and 'permanent' both advance; distinction was logged inside routeIncoming
+      clearFailure(parsed.seq);
       setReceiveCursor(parsed.seq);
       since = parsed.seq;
     }
@@ -429,4 +521,4 @@ export function useDbIntentPoller(context) {
 }
 
 // Exported for tests.
-export { DB_CURSOR_KEY };
+export { DB_CURSOR_KEY, DB_RETRY_KEY, MAX_INTENT_RETRIES };

--- a/src/intents/dbIntentsTransport.test.js
+++ b/src/intents/dbIntentsTransport.test.js
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { buildEnvelope, buildIntentRow, ACTIONS, TABS } from '@glance-apps/intents';
+import { sendIntentsDb, pollDbIntents, DB_CURSOR_KEY } from './dbIntentsTransport.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App-owned GLANCEvault DB intents transport. These exercise the REAL codec
+// (buildIntentRow/parseIntentRow/parseSince/formatSince) against an in-memory
+// GLANCEvault intents server, with the connection injected (no network, no DOM).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+afterAll(() => { delete global.localStorage; });
+
+const CONN = { vaultUrl: 'https://vault.example.com', vaultToken: 'tok-123', accountId: 'acct-1' };
+
+// In-memory GLANCEvault /intents server. Insert-only on eventId, global seq,
+// honours the { rows, hasMore } list contract with a page size and an
+// expiresAt-driven non-expired filter.
+function createMemoryIntentsServer({ pageSize = 500, now = () => Date.now() } = {}) {
+  const rows = []; // { eventId, envelope, seq, expiresAt, serverMtime }
+  const byEventId = new Map();
+  let seq = 0;
+  const calls = { batch: [], list: [] };
+
+  const vaultFetch = async (method, url, headers, body) => {
+    const u = new URL(url);
+    // Auth must be present on every request.
+    if (headers?.Authorization !== `Bearer ${CONN.vaultToken}`) {
+      return { status: 401, ok: false, body: JSON.stringify({ error: 'unauthorized' }) };
+    }
+
+    if (method === 'POST' && u.pathname === '/intents/batch') {
+      const parsed = JSON.parse(body);
+      calls.batch.push(parsed);
+      let written = 0;
+      for (const ev of parsed.events) {
+        if (byEventId.has(ev.eventId)) continue; // insert-only no-op on re-send
+        const row = {
+          eventId: ev.eventId,
+          envelope: ev.envelope,
+          seq: ++seq,
+          expiresAt: new Date(ev.expiresAt).toISOString(), // server canonicalizes to UTC ISO
+          serverMtime: new Date(now()).toISOString(),
+        };
+        rows.push(row);
+        byEventId.set(ev.eventId, row);
+        written++;
+      }
+      return { status: 200, ok: true, body: JSON.stringify({ written, maxSeq: seq }) };
+    }
+
+    if (method === 'GET' && u.pathname === '/intents/list') {
+      const accountId = u.searchParams.get('accountId');
+      const since = Number(u.searchParams.get('since'));
+      const limit = Number(u.searchParams.get('limit')) || pageSize;
+      calls.list.push({ accountId, since, limit });
+      const nowMs = now();
+      const visible = rows
+        .filter((r) => r.seq > since)
+        .filter((r) => new Date(r.expiresAt).getTime() > nowMs) // only non-expired
+        .sort((a, b) => a.seq - b.seq);
+      const page = visible.slice(0, limit);
+      const hasMore = visible.length > limit;
+      return { status: 200, ok: true, body: JSON.stringify({ rows: page, hasMore }) };
+    }
+
+    return { status: 404, ok: false, body: '{}' };
+  };
+
+  return { vaultFetch, calls, rows, get seq() { return seq; } };
+}
+
+// A notify envelope for a foreign task so routeIncoming doesn't loopback-skip it.
+function makeForeignNotify(i) {
+  return buildEnvelope({
+    action: ACTIONS.NOTIFY,
+    payload: {
+      event_id: `evt-${i}`,
+      source_app: 'app.lifeglance',
+      source_entity_id: `ext-${i}`,
+      event: 'completed',
+      task_id: `t-${i}`,
+      title: `task ${i}`,
+      timestamp: new Date().toISOString(),
+      completed_at: new Date().toISOString(),
+    },
+    emittedBy: 'app.lifeglance',
+  });
+}
+
+beforeEach(() => {
+  global.localStorage = memLocalStorage();
+});
+
+describe('DB intents — SEND (batch wrapper + idempotency)', () => {
+  it('wire body is { accountId, events: [...] } and re-sent eventId is idempotent', async () => {
+    const server = createMemoryIntentsServer();
+    const env = buildEnvelope({ action: ACTIONS.OPEN, payload: { tab: TABS.TODAY }, emittedBy: 'app.dayglance' });
+
+    const first = await sendIntentsDb(env, { connection: CONN, config: { ttlMs: 3600_000 }, vaultFetch: server.vaultFetch });
+    const second = await sendIntentsDb(env, { connection: CONN, config: { ttlMs: 3600_000 }, vaultFetch: server.vaultFetch });
+
+    // Wire body shape.
+    expect(server.calls.batch).toHaveLength(2);
+    const body = server.calls.batch[0];
+    expect(Object.keys(body).sort()).toEqual(['accountId', 'events']);
+    expect(body.accountId).toBe(CONN.accountId);
+    expect(Array.isArray(body.events)).toBe(true);
+    expect(Object.keys(body.events[0]).sort()).toEqual(['envelope', 'eventId', 'expiresAt']);
+    expect(typeof body.events[0].envelope).toBe('string'); // opaque base64
+
+    // Same eventId both times.
+    expect(server.calls.batch[1].events[0].eventId).toBe(body.events[0].eventId);
+
+    // Insert-only: first writes 1, the re-send is a server no-op.
+    expect(first.written).toBe(1);
+    expect(second.written).toBe(0);
+    expect(server.rows).toHaveLength(1);
+  });
+
+  it('does not advance the receive cursor', async () => {
+    const server = createMemoryIntentsServer();
+    localStorage.setItem(DB_CURSOR_KEY, '7'); // pre-existing receive cursor
+
+    const env = buildEnvelope({ action: ACTIONS.OPEN, payload: { tab: TABS.TODAY }, emittedBy: 'app.dayglance' });
+    await sendIntentsDb(env, { connection: CONN, config: { ttlMs: 3600_000 }, vaultFetch: server.vaultFetch });
+
+    // Sending must NEVER touch the receive cursor.
+    expect(localStorage.getItem(DB_CURSOR_KEY)).toBe('7');
+  });
+});
+
+describe('DB intents — RECEIVE (pagination loop drains a >500 backlog)', () => {
+  it('drains ~1200 rows across multiple pages, with an expiry gap, and advances the cursor', async () => {
+    // Freeze "now" so expiry is deterministic.
+    const NOW = 1_700_000_000_000;
+    const server = createMemoryIntentsServer({ pageSize: 500, now: () => NOW });
+
+    const TOTAL = 1200;
+    const EXPIRED_INDEX = 600; // one row in the middle is already expired on the server
+
+    // Seed the server directly via batch (insert-only). Most rows live; one is expired.
+    for (let i = 0; i < TOTAL; i++) {
+      const env = makeForeignNotify(i);
+      const expiresAt = i === EXPIRED_INDEX
+        ? new Date(NOW - 1000).toISOString()       // already expired
+        : new Date(NOW + 3600_000).toISOString();  // valid for an hour
+      const row = buildIntentRow(env, { expiresAt: new Date(expiresAt) });
+      await server.vaultFetch(
+        'POST', `${CONN.vaultUrl}/intents/batch`,
+        { Authorization: `Bearer ${CONN.vaultToken}`, 'Content-Type': 'application/json' },
+        JSON.stringify({ accountId: CONN.accountId, events: [{ eventId: row.eventId, envelope: row.envelope, expiresAt: row.expiresAt }] }),
+      );
+    }
+
+    // Server only ever returns non-expired rows → 1199 visible across pages.
+    const VISIBLE = TOTAL - 1;
+
+    // Count how many envelopes reach the handler.
+    let handled = 0;
+    const context = {
+      tasks: [], unscheduledTasks: [], recurringTasks: [],
+      setTasks: () => {}, setUnscheduledTasks: () => {}, setRecurringTasks: () => {},
+      // handleIntent's COMPLETE path looks up by source ids; with empty state it
+      // returns a (failed) result either way — we only care that it was reached.
+    };
+    const handleSpy = vi.fn(async () => { handled++; });
+
+    // Drive the real pagination loop. We assert on cursor + the number of list
+    // pages requested rather than mocking handleIntent: a >500 backlog MUST take
+    // multiple list calls (ceil(1199/500) = 3).
+    await pollDbIntents(context, { connection: CONN, vaultFetch: server.vaultFetch });
+    void handleSpy; void handled;
+
+    // Multiple pages were fetched (3 pages: 500 + 500 + 199), then a final empty
+    // page is NOT requested because hasMore is false on the third.
+    expect(server.calls.list.length).toBe(3);
+    expect(server.calls.list[0].since).toBe(0);
+    expect(server.calls.list[1].since).toBeGreaterThan(0);
+    expect(server.calls.list[2].since).toBeGreaterThan(server.calls.list[1].since);
+
+    // Cursor advanced to the max visible seq (the last non-expired row's seq).
+    // The expired row's seq is legitimately skipped (TTL), so the cursor can sit
+    // PAST it — that is intended, not a cursor-skip bug.
+    const maxSeq = server.seq; // last assigned seq overall
+    expect(Number(localStorage.getItem(DB_CURSOR_KEY))).toBe(maxSeq);
+
+    // A second poll from the advanced cursor returns nothing new (single empty page).
+    server.calls.list.length = 0;
+    await pollDbIntents(context, { connection: CONN, vaultFetch: server.vaultFetch });
+    expect(server.calls.list).toHaveLength(1);
+    expect(server.calls.list[0].since).toBe(maxSeq);
+    void VISIBLE;
+  });
+
+  it('does not call list when no connection is available', async () => {
+    const server = createMemoryIntentsServer();
+    await pollDbIntents({}, { connection: null, vaultFetch: server.vaultFetch });
+    expect(server.calls.list).toHaveLength(0);
+  });
+});

--- a/src/intents/dbIntentsTransport.test.js
+++ b/src/intents/dbIntentsTransport.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import { buildEnvelope, buildIntentRow, ACTIONS, TABS } from '@glance-apps/intents';
-import { sendIntentsDb, pollDbIntents, DB_CURSOR_KEY } from './dbIntentsTransport.js';
+import { sendIntentsDb, pollDbIntents, DB_CURSOR_KEY, DB_RETRY_KEY, MAX_INTENT_RETRIES } from './dbIntentsTransport.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // App-owned GLANCEvault DB intents transport. These exercise the REAL codec
@@ -206,5 +206,143 @@ describe('DB intents — RECEIVE (pagination loop drains a >500 backlog)', () =>
     const server = createMemoryIntentsServer();
     await pollDbIntents({}, { connection: null, vaultFetch: server.vaultFetch });
     expect(server.calls.list).toHaveLength(0);
+  });
+});
+
+// Seed n valid (non-expired) foreign notify rows into the server.
+async function seedRows(server, n, nowFn = () => Date.now()) {
+  for (let i = 0; i < n; i++) {
+    const env = makeForeignNotify(i);
+    const row = buildIntentRow(env, { expiresAt: new Date(nowFn() + 3600_000) });
+    await server.vaultFetch(
+      'POST', `${CONN.vaultUrl}/intents/batch`,
+      { Authorization: `Bearer ${CONN.vaultToken}`, 'Content-Type': 'application/json' },
+      JSON.stringify({ accountId: CONN.accountId, events: [{ eventId: row.eventId, envelope: row.envelope, expiresAt: row.expiresAt }] }),
+    );
+  }
+}
+
+const retries = () => JSON.parse(localStorage.getItem(DB_RETRY_KEY) || '{}');
+const cursor = () => localStorage.getItem(DB_CURSOR_KEY);
+const CTX = {}; // the injected router ignores context
+
+describe('DB intents — RECEIVE bounded-retry model', () => {
+  it('(a) a handler that THROWS once then succeeds is retried, not lost', async () => {
+    const server = createMemoryIntentsServer();
+    await seedRows(server, 1); // one row at seq 1
+
+    let calls = 0;
+    const route = async () => {
+      calls++;
+      if (calls === 1) throw new Error('transient db error');
+      return 'ok';
+    };
+
+    // First poll: handler throws → HOLD. Cursor must NOT advance; counter persisted.
+    await pollDbIntents(CTX, { connection: CONN, vaultFetch: server.vaultFetch, routeIncoming: route });
+    expect(cursor()).toBeNull();
+    expect(retries()).toEqual({ 1: 1 });
+
+    // Second poll: same row redelivered (cursor held), handler now succeeds → advance + clear.
+    await pollDbIntents(CTX, { connection: CONN, vaultFetch: server.vaultFetch, routeIncoming: route });
+    expect(Number(cursor())).toBe(1);
+    expect(retries()).toEqual({}); // counter cleared on success
+    expect(calls).toBe(2); // delivered twice: failed, then succeeded — never dropped
+  });
+
+  it('a HOLD stops the entire drain — no further pages this poll', async () => {
+    const server = createMemoryIntentsServer({ pageSize: 500 });
+    await seedRows(server, 600); // two pages
+
+    const route = async () => { throw new Error('boom'); };
+    await pollDbIntents(CTX, { connection: CONN, vaultFetch: server.vaultFetch, routeIncoming: route });
+
+    // Threw on the very first row → held immediately; page 2 never fetched.
+    expect(server.calls.list).toHaveLength(1);
+    expect(cursor()).toBeNull();          // cursor unadvanced
+    expect(retries()).toEqual({ 1: 1 });  // only the first row's seq is counted
+  });
+
+  it('(b) a row that throws >= MAX_INTENT_RETRIES is given up, logged, and skipped (no wedge)', async () => {
+    const server = createMemoryIntentsServer();
+    await seedRows(server, 2); // seq 1 (poison) then seq 2 (good)
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // seq 1 always throws; seq 2 succeeds. Key off the decoded envelope's task id.
+    const route = async (envelope) => {
+      if (envelope.payload?.task_id === 't-0') throw new Error('always fails');
+      return 'ok';
+    };
+
+    // Polls 1..(MAX-1): each throws on seq 1 → HOLD, cursor stays null, counter climbs.
+    for (let n = 1; n < MAX_INTENT_RETRIES; n++) {
+      await pollDbIntents(CTX, { connection: CONN, vaultFetch: server.vaultFetch, routeIncoming: route });
+      expect(cursor()).toBeNull();
+      expect(retries()).toEqual({ 1: n });
+    }
+
+    // Poll MAX: count reaches MAX_INTENT_RETRIES → give up on seq 1, advance past it,
+    // then seq 2 succeeds → cursor lands at 2. Channel did not wedge.
+    await pollDbIntents(CTX, { connection: CONN, vaultFetch: server.vaultFetch, routeIncoming: route });
+    expect(Number(cursor())).toBe(2);
+    expect(retries()).toEqual({}); // poison counter cleared on give-up; no leak
+
+    // Give-up was logged loudly.
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Giving up on intent'),
+      expect.anything(),
+    );
+
+    // A subsequent poll re-delivers nothing (single empty page from the advanced cursor).
+    server.calls.list.length = 0;
+    await pollDbIntents(CTX, { connection: CONN, vaultFetch: server.vaultFetch, routeIncoming: route });
+    expect(server.calls.list).toHaveLength(1);
+    expect(server.calls.list[0].since).toBe(2);
+
+    errSpy.mockRestore();
+  });
+
+  it('(c) the failure counter persists across a simulated reload', async () => {
+    const server = createMemoryIntentsServer();
+    await seedRows(server, 1);
+
+    const route = async () => { throw new Error('still failing'); };
+
+    // First poll on "session 1": counter → 1, held.
+    await pollDbIntents(CTX, { connection: CONN, vaultFetch: server.vaultFetch, routeIncoming: route });
+    expect(retries()).toEqual({ 1: 1 });
+
+    // Simulate an app reload: brand-new localStorage seeded ONLY from what was
+    // persisted (retry counter; cursor was never advanced so it's absent). If the
+    // counter were in-memory it would reset to 0 here and never reach the cap.
+    const persistedRetry = localStorage.getItem(DB_RETRY_KEY);
+    global.localStorage = memLocalStorage();
+    localStorage.setItem(DB_RETRY_KEY, persistedRetry);
+
+    // First poll on "session 2": same row redelivered, throws again → counter 2,
+    // proving it accumulated across the reload rather than restarting.
+    await pollDbIntents(CTX, { connection: CONN, vaultFetch: server.vaultFetch, routeIncoming: route });
+    expect(retries()).toEqual({ 1: 2 });
+    expect(cursor()).toBeNull();
+  });
+
+  it('(d) a SOFT failure (result.success===false → permanent) advances past, no retry', async () => {
+    const server = createMemoryIntentsServer();
+    await seedRows(server, 1);
+
+    let calls = 0;
+    const route = async () => { calls++; return 'permanent'; }; // handler refuses this intent
+
+    await pollDbIntents(CTX, { connection: CONN, vaultFetch: server.vaultFetch, routeIncoming: route });
+    expect(Number(cursor())).toBe(1);  // advanced past — permanent, not retried
+    expect(retries()).toEqual({});     // no counter created for a permanent failure
+    expect(calls).toBe(1);
+
+    // Not redelivered on the next poll.
+    server.calls.list.length = 0;
+    await pollDbIntents(CTX, { connection: CONN, vaultFetch: server.vaultFetch, routeIncoming: route });
+    expect(server.calls.list).toHaveLength(1);
+    expect(server.calls.list[0].since).toBe(1);
+    expect(calls).toBe(1); // route NOT called again
   });
 });

--- a/src/intents/emitGoalCreate.js
+++ b/src/intents/emitGoalCreate.js
@@ -1,6 +1,8 @@
 import { buildEnvelope, buildEncryptedEnvelope, ENTITY_TYPES, SOURCE_APPS, deriveEnvelopeKey } from '@glance-apps/intents';
 import { loadIntentsRootKey } from './intentsKeyStore.js';
 import { writeEventFile, writeEventFileICloud, INTENT_CONFIG_KEY } from './useIntentPoller.js';
+import { sendIntentDb } from './dbIntentsTransport.js';
+import { isDbIntentsEnabled } from './dbIntentsConfig.js';
 import { logActivity } from './intentLog.js';
 
 /**
@@ -29,7 +31,9 @@ export async function emitGoalCreate(goal) {
   const raw = localStorage.getItem(INTENT_CONFIG_KEY);
   const config = raw ? JSON.parse(raw) : null;
   const hasWebDAV = !!(config?.webdavUrl && config?.username && config?.appPassword);
-  if (!hasWebDAV) return;
+  // The DB intents transport runs alongside WebDAV and may be enabled on its own,
+  // so don't bail when WebDAV is absent if DB intents is active.
+  if (!hasWebDAV && !isDbIntentsEnabled()) return;
 
   const payload = {
     title: goal.title,
@@ -42,7 +46,7 @@ export async function emitGoalCreate(goal) {
   const now = new Date().toISOString();
 
   let deriveKey = null;
-  if (config.encryptionEnabled) {
+  if (config?.encryptionEnabled) {
     const rootKey = await loadIntentsRootKey();
     if (!rootKey) {
       console.warn('[goal-create] intents encryption setup incomplete — skipping emit');
@@ -68,6 +72,7 @@ export async function emitGoalCreate(goal) {
       : buildEnvelope({ action: 'create', payload, emittedBy: SOURCE_APPS.DAYGLANCE, eventId });
     await writeEventFile(config, envelope);
     await writeEventFileICloud(config, envelope);
+    await sendIntentDb(envelope);  // DB intents transport (no-ops unless enabled)
     logActivity({
       direction: 'out',
       action: 'create',

--- a/src/intents/useGoalNotifyEmitter.js
+++ b/src/intents/useGoalNotifyEmitter.js
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react';
 import { buildEnvelope, buildEncryptedEnvelope, eventId as makeEventId, EVENTS, ENTITY_TYPES, deriveEnvelopeKey } from '@glance-apps/intents';
 import { loadIntentsRootKey } from './intentsKeyStore.js';
 import { writeEventFile, writeEventFileICloud, INTENT_CONFIG_KEY } from './useIntentPoller.js';
+import { sendIntentDb } from './dbIntentsTransport.js';
+import { isDbIntentsEnabled } from './dbIntentsConfig.js';
 import { logActivity } from './intentLog.js';
 import * as iCloudTransport from './icloudFileTransport.js';
 
@@ -67,7 +69,9 @@ export function useGoalNotifyEmitter({ goals }) {
 
     const hasWebDAV = !!(config?.webdavUrl && config?.username && config?.appPassword);
     const hasICloud = iCloudTransport.isAvailable();
-    if (!hasWebDAV && !hasICloud) return;
+    // The DB intents transport runs alongside WebDAV/iCloud and may be enabled on
+    // its own, so don't bail when the file tiers are absent if DB intents is active.
+    if (!hasWebDAV && !hasICloud && !isDbIntentsEnabled()) return;
 
     const prevMap = new Map(prev.map(g => [g.id, g]));
     const nextMap = new Map(goals.map(g => [g.id, g]));
@@ -96,7 +100,7 @@ export function useGoalNotifyEmitter({ goals }) {
 
     const fire = async () => {
       let deriveKey = null;
-      if (config.encryptionEnabled) {
+      if (config?.encryptionEnabled) {
         const rootKey = await loadIntentsRootKey();
         if (!rootKey) {
           console.warn('[goal-notify] intents encryption setup incomplete — skipping', emits.length, 'emit(s)');
@@ -136,6 +140,7 @@ export function useGoalNotifyEmitter({ goals }) {
             : buildEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' });
           await writeEventFile(config, envelope);
           await writeEventFileICloud(config, envelope);
+          await sendIntentDb(envelope);  // GLANCEvault DB (no-ops unless enabled)
           logActivity({
             direction: 'out',
             action: 'notify',

--- a/src/intents/useNotifyEmitter.js
+++ b/src/intents/useNotifyEmitter.js
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react';
 import { buildEnvelope, buildEncryptedEnvelope, eventId as makeEventId, EVENTS, ENTITY_TYPES, deriveEnvelopeKey } from '@glance-apps/intents';
 import { loadIntentsRootKey } from './intentsKeyStore.js';
 import { writeEventFile, writeEventFileICloud, INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from './useIntentPoller.js';
+import { sendIntentDb } from './dbIntentsTransport.js';
+import { isDbIntentsEnabled } from './dbIntentsConfig.js';
 import { logActivity } from './intentLog.js';
 import * as iCloudTransport from './icloudFileTransport.js';
 import { isNativeAndroid } from '../native';
@@ -115,7 +117,9 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
     // Skip emit when neither WebDAV nor iCloud is configured
     const hasWebDAV = !!(config?.webdavUrl && config?.username && config?.appPassword);
     const hasICloud = iCloudTransport.isAvailable();
-    if (!hasWebDAV && !hasICloud) return;
+    // The DB intents transport runs alongside WebDAV/iCloud and may be enabled on
+    // its own, so don't bail when the file tiers are absent if DB intents is active.
+    if (!hasWebDAV && !hasICloud && !isDbIntentsEnabled()) return;
 
     const prevMap = new Map(prev.map(t => [t.id, t]));
     const nextMap = new Map(allTasks.map(t => [t.id, t]));
@@ -149,7 +153,7 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
 
       // Resolve encryption posture once for the whole batch.
       let deriveKey = null;
-      if (config.encryptionEnabled) {
+      if (config?.encryptionEnabled) {
         const rootKey = await loadIntentsRootKey();
         if (!rootKey) {
           // Root key not cached — setup incomplete. Block all emits; do not fall back to plaintext.
@@ -178,6 +182,7 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
             : buildEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' });
           await writeEventFile(config, envelope);          // WebDAV (no-ops if not configured)
           await writeEventFileICloud(config, envelope);    // iCloud (no-ops if not available)
+          await sendIntentDb(envelope);                    // GLANCEvault DB (no-ops unless enabled)
           // Android broadcast: only on the plaintext path. Encrypted envelopes can't be
           // used by local listeners (no key), and their ciphertext fields don't survive
           // JSON.stringify cleanly. Tasker users should rely on WebDAV for encrypted setups.


### PR DESCRIPTION
## Summary

Adds a second, app-owned **GLANCEvault DB intents transport** alongside the existing WebDAV intents transport, so dayGLANCE can deliver intents over the GLANCEvault server (matching lastGLANCE's wire contract for interop). It is **per-user opt-in and beta**; WebDAV intents remains the default and is fully intact.

`@glance-apps/intents` is treated as a **codec** (pinned to `1.4.0` exact); the app owns delivery (HTTP, receive cursor, pagination, transport selection). `@glance-apps/sync` is untouched.

## What's included

**1. The transport** (`src/intents/dbIntentsTransport.js`, `dbIntentsConfig.js`)
- **Send**: `buildIntentRow` per envelope → batch wrapper `{ accountId, events: [...] }` → `POST /intents/batch` with the vault device-token bearer auth, via the same native/electron/browser HTTP routing the vault sync transport uses. Insert-only, idempotent on `eventId`.
- **Receive**: mandatory `hasMore` pagination loop (page size 500) that fully drains a >500 backlog; `parseIntentRow` per row, routed by the encrypted flag through the existing envelope parsers into the **same** `handleIntent` the WebDAV path feeds.
- **Receive cursor** in its own app-owned key, advanced only from rows actually processed; advancing past a TTL-expired seq is documented as intended (not the sync cursor-skip bug).
- Config carries only `{ enabled, ttlMs, pollIntervalMinutes }` and **inherits** the vault connection from the GLANCEvault sync config. Gated independently of both WebDAV intents and the vault sync `enabled` flag. `useDbIntentPoller` mounts alongside the WebDAV poller (startup/focus/interval; no push).

**2. Bounded-retry receive model** (replaces skip-on-failure)
- Decode/permanent-bad (unparseable/undecryptable, or a soft `result.success===false`) → advance past.
- Handler **threw** (maybe-transient) → do not advance; bump a **persisted** per-seq counter. At `MAX_INTENT_RETRIES` (=5) consecutive failures the row is poison: log loudly, advance past it. Below the cap, hold the whole drain so the next poll retries. Counters cleared on success and give-up (no leak).

**3. Settings UI toggle (beta)** — in both `SettingsModal` (desktop) and `MobileSettingsPanel` (mobile)
- Enable toggle + connection-status note (green when a vault connection exists; amber pointing to Cloud Sync settings otherwise). No URL/token/accountId inputs — the connection is inherited.
- Match-by-construction save: spread the existing config, override only `enabled`, persist via the config module's saver to the exact key the gate reads. Reload-on-change so the poller remounts (mirrors the vault sync toggle).

## Independence / safety
- WebDAV intents and vault sync behavior are unchanged; DB intents is independent and only inherits the vault connection.
- No changes to `@glance-apps/intents` / `@glance-apps/sync` beyond the `1.4.0` pin.

## Tests & build
- New tests cover: >500-row pagination drain with an expiry gap; send doesn't advance the receive cursor; re-sent `eventId` idempotency + wire body shape; retry-once-then-succeed (not lost); give-up after 5 throws (no wedge); counter persists across a simulated reload; soft-failure advances.
- **Full suite: 315 passing. Build: clean.**

Note: dayGLANCE has no eslint config / lint script (pre-existing gap, same as lastGLANCE) — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S1NT21jpTCZbsiF5bPcG9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1NT21jpTCZbsiF5bPcG9K)_