### PR TITLE
macOS native calendar (Electron/EventKit) read-only support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 dist-electron
 dist-app
+electron/native/calendar-helper/build/
 outputs
 dayglance-android/app/src/main/assets/web
 *.local

--- a/docs/macos-native-calendar-plan.md
+++ b/docs/macos-native-calendar-plan.md
@@ -1,8 +1,48 @@
 # macOS Native Calendar (Electron / EventKit) — Implementation Plan
 
-Status: **planned, not started.** This doc captures full context so the work can
-resume cold in a future session. Follows the calendar work in PRs #1029 (toggles)
-and #1030 (per-user calendar config).
+Status: **code complete (read-only MVP); pending signed-build validation on a Mac.**
+Steps 1–4 of the sequencing below are implemented (chosen designs: Option A async
+cache, Option 1 Swift helper). What remains is compiling/signing the helper and
+manually verifying a notarized build on macOS — neither possible in the CI/Linux
+dev container. Follows the calendar work in PRs #1029 (toggles) and #1030
+(per-user calendar config).
+
+## What landed
+
+- **Swift EventKit helper** — `electron/native/calendar-helper/Sources/main.swift`.
+  Subcommands `request-access`, `auth-status`, `calendars`, `events --start --end`
+  (the events command returns a per-day `{ "YYYY-MM-DD": [event,…] }` map so
+  multi-day all-day events appear under every day they span, mirroring the mobile
+  per-day `getEvents(date)`). Output JSON is byte-for-byte the iOS contract.
+- **Build script** — `scripts/build-calendar-helper.sh` compiles a universal
+  (arm64 + x64) binary; no-ops on non-macOS hosts. Wired into the `build:electron*`
+  npm scripts and gitignored under `electron/native/calendar-helper/build/`.
+- **Main-process IPC** — `electron/calendar.ts` (`registerCalendarHandlers`,
+  registered from `main.ts`): `calendar:request-access`, `calendar:get-calendars`,
+  `calendar:get-events` spawn the helper via `execFile` and return safe empty
+  defaults off-macOS or when the helper is absent.
+- **Preload bridge** — `electron/preload.ts` exposes `requestCalendarAccess`,
+  `getCalendars`, `getCalendarEvents(startDate, endDate)`.
+- **Capability + extraction** — `src/utils/nativeCalendar.js` now owns
+  `nativeEventToTask` (moved out of `App.jsx`) plus `hasNativeCalendar()`,
+  `electronCalendarAvailable()`, and the Electron accessors.
+- **App wiring** — `App.jsx` gates the calendar-fetch effects and the
+  `syncWithCalendar` / `syncAll` / `calSyncConfigured` early-returns on
+  `hasNativeCalendar()`; the fetch effect branches to an async Electron pre-fetch
+  that feeds the unchanged merge path.
+- **Packaging** — `electron-builder.config.cjs` adds `mac`/`mas` `extendInfo`
+  (NSCalendars[FullAccess]UsageDescription) and `extraResources` for the helper;
+  both entitlement plists add `com.apple.security.personal-information.calendars`.
+- **Test** — `src/utils/nativeCalendar.test.js` covers the `nativeEventToTask`
+  mapping against the Electron/mobile event shape.
+
+## Remaining (needs a Mac)
+
+- Run `npm run build:calendar-helper` then `build:electron:release` (or `:mas`) on
+  macOS; confirm the helper is signed inside `Contents/Resources/calendar-helper`
+  and the notarized build passes Gatekeeper.
+- Manual validation per the **Testing / validation** section below.
+- Permission-denied UX polish (step 4 stretch) and write-back (step 5) remain.
 
 ## Goal
 

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -37,6 +37,17 @@ module.exports = {
     category: 'public.app-category.productivity',
     entitlements: 'electron/entitlements.mac.plist',
     entitlementsInherit: 'electron/entitlements.mac.plist',
+    // Calendar (EventKit) permission strings shown in the system prompt. macOS 14+
+    // uses the FullAccess variant; older releases use NSCalendarsUsageDescription.
+    extendInfo: {
+      NSCalendarsUsageDescription: 'dayGLANCE shows your calendar events alongside your tasks.',
+      NSCalendarsFullAccessUsageDescription: 'dayGLANCE shows your calendar events alongside your tasks.',
+    },
+    // Bundle the signed EventKit helper (built by scripts/build-calendar-helper.sh)
+    // into Contents/Resources/calendar-helper. electron-builder signs nested binaries.
+    extraResources: [
+      { from: 'electron/native/calendar-helper/build/dayglance-calendar-helper', to: 'calendar-helper/dayglance-calendar-helper' },
+    ],
     target: [
       { target: 'dmg', arch: ['x64', 'arm64'] },
       { target: 'zip', arch: ['x64', 'arm64'] },
@@ -47,6 +58,13 @@ module.exports = {
     entitlements: 'electron/entitlements.mas.plist',
     entitlementsInherit: 'electron/entitlements.mas.plist',
     category: 'public.app-category.productivity',
+    extendInfo: {
+      NSCalendarsUsageDescription: 'dayGLANCE shows your calendar events alongside your tasks.',
+      NSCalendarsFullAccessUsageDescription: 'dayGLANCE shows your calendar events alongside your tasks.',
+    },
+    extraResources: [
+      { from: 'electron/native/calendar-helper/build/dayglance-calendar-helper', to: 'calendar-helper/dayglance-calendar-helper' },
+    ],
   },
   win: {
     target: [{ target: 'nsis' }],

--- a/electron/calendar.ts
+++ b/electron/calendar.ts
@@ -1,0 +1,86 @@
+import { ipcMain, app } from 'electron';
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// ── macOS native calendar (EventKit) ───────────────────────────────────────────
+//
+// Read-only access to the system Calendar via a signed Swift helper binary
+// (electron/native/calendar-helper). The helper emits JSON identical to the
+// mobile DayGlanceNative bridge so the renderer reuses nativeEventToTask unchanged.
+//
+// All handlers no-op (empty/false) on non-macOS platforms and when the helper
+// binary is missing, so Windows/Linux Electron and dev builds without the helper
+// degrade gracefully to URL/CalDAV subscriptions.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const HELPER_NAME = 'dayglance-calendar-helper';
+
+// Resolves the helper path: bundled under Contents/Resources/calendar-helper in
+// packaged builds (electron-builder extraResources), or the local build output in dev.
+function helperPath(): string | null {
+  const candidates = app.isPackaged
+    ? [path.join(process.resourcesPath, 'calendar-helper', HELPER_NAME)]
+    : [path.join(__dirname, '..', 'electron', 'native', 'calendar-helper', 'build', HELPER_NAME)];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function calendarSupported(): boolean {
+  return process.platform === 'darwin' && helperPath() !== null;
+}
+
+// Spawns the helper with the given args and resolves its parsed JSON stdout.
+// Rejects are swallowed by callers into safe empty defaults.
+function runHelper(args: string[]): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const bin = helperPath();
+    if (!bin) { reject(new Error('calendar helper not found')); return; }
+    execFile(bin, args, { timeout: 15_000, maxBuffer: 16 * 1024 * 1024 }, (err, stdout) => {
+      if (err) { reject(err); return; }
+      try {
+        resolve(JSON.parse(stdout.toString().trim() || 'null'));
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}
+
+export function registerCalendarHandlers(): void {
+  ipcMain.handle('calendar:request-access', async () => {
+    if (!calendarSupported()) return { granted: false };
+    try {
+      const res = await runHelper(['request-access']) as { granted?: boolean } | null;
+      return { granted: !!res?.granted };
+    } catch {
+      return { granted: false };
+    }
+  });
+
+  ipcMain.handle('calendar:get-calendars', async () => {
+    if (!calendarSupported()) return [];
+    try {
+      const res = await runHelper(['calendars']);
+      return Array.isArray(res) ? res : [];
+    } catch {
+      return [];
+    }
+  });
+
+  // Returns a per-day map { "YYYY-MM-DD": Event[] } inclusive of [startDate, endDate].
+  ipcMain.handle('calendar:get-events', async (_event, startDate: string, endDate: string) => {
+    if (!calendarSupported()) return {};
+    if (typeof startDate !== 'string' || typeof endDate !== 'string') return {};
+    try {
+      const res = await runHelper(['events', '--start', startDate, '--end', endDate]);
+      return (res && typeof res === 'object' && !Array.isArray(res)) ? res : {};
+    } catch {
+      return {};
+    }
+  });
+}

--- a/electron/entitlements.mac.plist
+++ b/electron/entitlements.mac.plist
@@ -11,6 +11,9 @@
     <!-- Outbound network access (CalDAV, AI APIs, WebSocket, etc.) -->
     <key>com.apple.security.network.client</key>
     <true/>
+    <!-- Read access to the system Calendar via the EventKit helper -->
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
     <!-- iCloud entitlements are NOT needed for the Developer ID build: the app
          is unsandboxed and accesses the iCloud container via a plain file path.
          They will be added to a separate entitlements.mas.plist for the future

--- a/electron/entitlements.mas.plist
+++ b/electron/entitlements.mas.plist
@@ -17,6 +17,9 @@
     <!-- StoreKit in-app purchases -->
     <key>com.apple.security.in-app-payments</key>
     <true/>
+    <!-- Read access to the system Calendar via the EventKit helper -->
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
     <!-- Obsidian vault: user picks folder via open panel -->
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { createWsServer } from './ws-server.js';
 import { registerSubscriptionHandlers } from './subscription.js';
+import { registerCalendarHandlers } from './calendar.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -620,6 +621,7 @@ app.whenReady().then(() => {
   const win = createWindow();
   createWsServer(() => live(mainWindow));
   registerSubscriptionHandlers(win);
+  registerCalendarHandlers();
   if (process.platform === 'darwin') { createTray(); startICloudWatch(win); }
 
   app.on('activate', () => {

--- a/electron/native/calendar-helper/Sources/main.swift
+++ b/electron/native/calendar-helper/Sources/main.swift
@@ -1,0 +1,177 @@
+import Foundation
+import EventKit
+
+// dayglance-calendar-helper
+//
+// A tiny read-only EventKit CLI spawned by the Electron main process to give the
+// macOS desktop build access to the system Calendar. It emits JSON on stdout in
+// the exact same shape as the iOS/Android DayGlanceNative bridge so the renderer's
+// nativeEventToTask mapping is unchanged.
+//
+// Subcommands:
+//   request-access            → {"granted":bool}
+//   auth-status               → {"status":"notDetermined|denied|fullAccess|..."}
+//   calendars                 → [{id,name,accountName,color}]
+//   events --start YYYY-MM-DD --end YYYY-MM-DD
+//                             → {"YYYY-MM-DD":[event,...], ...} (one bucket per day,
+//                                inclusive of start/end; each event overlaps that day)
+//
+// Event JSON: {id,title,start,end,allDay,notes,location,calendarId,calendarName,color}
+// (start/end are "yyyy-MM-dd" for all-day events, "yyyy-MM-dd'T'HH:mm:ss" otherwise.)
+
+let store = EKEventStore()
+
+// MARK: - Authorization
+
+func isAuthorized() -> Bool {
+    if #available(macOS 14.0, *) {
+        return EKEventStore.authorizationStatus(for: .event) == .fullAccess
+    } else {
+        return EKEventStore.authorizationStatus(for: .event) == .authorized
+    }
+}
+
+// Requests access synchronously (the only EventKit call that is async). Event
+// queries are synchronous once authorized. Returns true when events can be read.
+func ensureAccess() -> Bool {
+    if isAuthorized() { return true }
+    let sem = DispatchSemaphore(value: 0)
+    var granted = false
+    if #available(macOS 14.0, *) {
+        store.requestFullAccessToEvents { ok, _ in granted = ok; sem.signal() }
+    } else {
+        store.requestAccess(to: .event) { ok, _ in granted = ok; sem.signal() }
+    }
+    sem.wait()
+    return granted || isAuthorized()
+}
+
+func authStatusString() -> String {
+    let status = EKEventStore.authorizationStatus(for: .event)
+    if #available(macOS 14.0, *) {
+        switch status {
+        case .notDetermined: return "notDetermined"
+        case .restricted:    return "restricted"
+        case .denied:        return "denied"
+        case .fullAccess:    return "fullAccess"
+        case .writeOnly:     return "writeOnly"
+        @unknown default:    return "unknown"
+        }
+    } else {
+        switch status {
+        case .notDetermined: return "notDetermined"
+        case .restricted:    return "restricted"
+        case .denied:        return "denied"
+        case .authorized:    return "authorized"
+        @unknown default:    return "unknown"
+        }
+    }
+}
+
+// MARK: - Formatting helpers
+
+func makeFormatter(_ format: String) -> DateFormatter {
+    let f = DateFormatter()
+    f.dateFormat = format
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.timeZone = .current
+    return f
+}
+
+let isoDate = makeFormatter("yyyy-MM-dd")
+let isoDateTime = makeFormatter("yyyy-MM-dd'T'HH:mm:ss")
+
+func hexColor(_ cgColor: CGColor?) -> String {
+    guard let cg = cgColor, let comps = cg.components, comps.count >= 3 else { return "#000000" }
+    let clamp = { (v: CGFloat) -> Int in max(0, min(255, Int(v * 255))) }
+    return String(format: "#%02x%02x%02x", clamp(comps[0]), clamp(comps[1]), clamp(comps[2]))
+}
+
+func printJSON(_ obj: Any) {
+    if let data = try? JSONSerialization.data(withJSONObject: obj, options: []),
+       let s = String(data: data, encoding: .utf8) {
+        print(s)
+    } else {
+        print("null")
+    }
+}
+
+func eventDict(_ e: EKEvent) -> [String: Any] {
+    let allDay = e.isAllDay
+    return [
+        "id": e.eventIdentifier ?? "",
+        "title": e.title ?? "",
+        "start": allDay ? isoDate.string(from: e.startDate) : isoDateTime.string(from: e.startDate),
+        "end": allDay ? isoDate.string(from: e.endDate) : isoDateTime.string(from: e.endDate),
+        "allDay": allDay,
+        "notes": e.notes ?? "",
+        "location": e.location ?? "",
+        "calendarId": e.calendar?.calendarIdentifier ?? "",
+        "calendarName": e.calendar?.title ?? "",
+        "color": hexColor(e.calendar?.cgColor),
+    ]
+}
+
+// MARK: - Argument parsing
+
+func optionValue(_ name: String, in args: [String]) -> String? {
+    guard let idx = args.firstIndex(of: name), idx + 1 < args.count else { return nil }
+    return args[idx + 1]
+}
+
+// MARK: - Main
+
+let args = Array(CommandLine.arguments.dropFirst())
+guard let command = args.first else {
+    printJSON(["error": "no command"])
+    exit(1)
+}
+
+switch command {
+case "request-access":
+    printJSON(["granted": ensureAccess()])
+
+case "auth-status":
+    printJSON(["status": authStatusString()])
+
+case "calendars":
+    guard ensureAccess() else { printJSON([] as [Any]); break }
+    let cals = store.calendars(for: .event).map { cal -> [String: Any] in
+        [
+            "id": cal.calendarIdentifier,
+            "name": cal.title,
+            "accountName": cal.source?.title ?? "",
+            "color": hexColor(cal.cgColor),
+        ]
+    }
+    printJSON(cals)
+
+case "events":
+    guard let startStr = optionValue("--start", in: args),
+          let endStr = optionValue("--end", in: args),
+          let startDay = isoDate.date(from: startStr),
+          let endDay = isoDate.date(from: endStr) else {
+        printJSON([String: Any]())
+        break
+    }
+    guard ensureAccess() else { printJSON([String: Any]()); break }
+
+    let calendar = Calendar.current
+    var result: [String: [[String: Any]]] = [:]
+    var dayStart = calendar.startOfDay(for: startDay)
+    let lastDayStart = calendar.startOfDay(for: endDay)
+
+    // One overlap predicate per day so multi-day all-day events appear under every
+    // day they span — mirroring the mobile bridge's per-day getEvents(date).
+    while dayStart <= lastDayStart {
+        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart)!
+        let predicate = store.predicateForEvents(withStart: dayStart, end: dayEnd, calendars: nil)
+        result[isoDate.string(from: dayStart)] = store.events(matching: predicate).map { eventDict($0) }
+        dayStart = dayEnd
+    }
+    printJSON(result)
+
+default:
+    printJSON(["error": "unknown command: \(command)"])
+    exit(1)
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -129,6 +129,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
   makeICloudDir: (relativePath: string): Promise<boolean> =>
     ipcRenderer.invoke('icloud:make-dir', relativePath),
 
+  // Native calendar (macOS / EventKit) — read-only access to the system Calendar
+  // via a signed Swift helper spawned by the main process. Mirrors the mobile
+  // bridge's JSON contract so the renderer reuses nativeEventToTask unchanged.
+  // All return empty/false on non-macOS platforms.
+  requestCalendarAccess: (): Promise<{ granted: boolean }> =>
+    ipcRenderer.invoke('calendar:request-access'),
+  getCalendars: (): Promise<Array<{ id: string; name: string; accountName: string; color: string }>> =>
+    ipcRenderer.invoke('calendar:get-calendars'),
+  // Returns a per-day map { "YYYY-MM-DD": Event[] } covering [startDate, endDate] inclusive.
+  getCalendarEvents: (startDate: string, endDate: string): Promise<Record<string, unknown[]>> =>
+    ipcRenderer.invoke('calendar:get-events', startDate, endDate),
+
   // Tray popup listens for the signal to focus the quick-add input.
   onFocusQuickAdd: (callback: () => void) => {
     const handler = () => callback();

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "preview": "vite preview",
     "test": "vitest run",
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
-    "build:electron": "vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs",
-    "build:electron:release": "vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs --publish never",
-    "build:electron:mas": "vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs --mac mas --publish never"
+    "build:calendar-helper": "bash scripts/build-calendar-helper.sh",
+    "build:electron": "npm run build:calendar-helper && vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs",
+    "build:electron:release": "npm run build:calendar-helper && vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs --publish never",
+    "build:electron:mas": "npm run build:calendar-helper && vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs --mac mas --publish never"
   },
   "dependencies": {
     "@glance-apps/intents": "1.4.0",

--- a/scripts/build-calendar-helper.sh
+++ b/scripts/build-calendar-helper.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Compiles the macOS EventKit calendar helper to a universal (x64 + arm64) binary
+# that electron-builder bundles into the app via `mac.extraResources`.
+#
+# Output: electron/native/calendar-helper/build/dayglance-calendar-helper
+#
+# No-op (exit 0) on non-macOS hosts or when `swiftc` is unavailable, so the rest
+# of the build pipeline still runs on Linux/Windows/CI — the helper is macOS-only
+# and is only required when producing a macOS (dmg/zip/mas) build.
+
+set -euo pipefail
+
+HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../electron/native/calendar-helper" && pwd)"
+SRC="$HELPER_DIR/Sources/main.swift"
+OUT_DIR="$HELPER_DIR/build"
+OUT="$OUT_DIR/dayglance-calendar-helper"
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "build-calendar-helper: skipping (not macOS)"
+  exit 0
+fi
+
+if ! command -v swiftc >/dev/null 2>&1; then
+  echo "build-calendar-helper: skipping (swiftc not found — install Xcode command line tools)"
+  exit 0
+fi
+
+mkdir -p "$OUT_DIR"
+
+echo "build-calendar-helper: compiling universal binary → $OUT"
+swiftc -O \
+  -framework EventKit -framework Foundation \
+  -target arm64-apple-macos11.0 \
+  -o "$OUT_DIR/dayglance-calendar-helper-arm64" \
+  "$SRC"
+
+swiftc -O \
+  -framework EventKit -framework Foundation \
+  -target x86_64-apple-macos11.0 \
+  -o "$OUT_DIR/dayglance-calendar-helper-x64" \
+  "$SRC"
+
+lipo -create \
+  "$OUT_DIR/dayglance-calendar-helper-arm64" \
+  "$OUT_DIR/dayglance-calendar-helper-x64" \
+  -output "$OUT"
+
+rm -f "$OUT_DIR/dayglance-calendar-helper-arm64" "$OUT_DIR/dayglance-calendar-helper-x64"
+chmod +x "$OUT"
+
+echo "build-calendar-helper: done"
+lipo -info "$OUT" || true

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback } from 'react';
 import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Moon, Sun, Upload, Inbox, AlertCircle, Calendar, Check, RefreshCw, Palette, Trash2, Undo2, BarChart3, SkipForward, Hash, MoreHorizontal, Save, Menu, BrainCircuit, AlertTriangle, FileText, ExternalLink, CheckSquare, HelpCircle, Sparkles, Link, GripHorizontal, Play, Pause, Trophy, Cloud, Settings, Search, Bell, Target, TrendingUp, Zap, CalendarDays, Ban, Volume2, VolumeX, Pencil, Eye, Filter, Smartphone, CheckCircle, Pin, PinOff, NotebookPen, MapPin, BookOpen, Flag, FolderOpen, Droplets, Footprints, Dumbbell, Apple, Cigarette, Coffee, Flame, Heart, ListChecks, Minus, Wine, Candy, Pill, Activity, CupSoda, Mic, MicOff, Loader, Key, Server, Wifi, WifiOff, LayoutGrid, RotateCcw } from 'lucide-react';
 import { mergeTaskArrays, mergeSyncData } from './mergeSync.js';
+import { hasNativeCalendar, electronGetCalendars, electronGetEventsByDate, electronRequestCalendarAccess, nativeEventToTask } from './utils/nativeCalendar.js';
 import { isNativeAndroid, isNativeApp, isNativeIOS, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeSetVaultSettings, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording, triggerHaptic } from './native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, tryRestoreVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, listVaultNotes, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
 import { loadAIConfig, saveAIConfig, aiComplete, aiJSON, aiTranscribe, supportsTranscription, testConnection, DEFAULT_CONFIG, PROVIDER_MODELS, PROVIDER_LABELS } from './ai.js';
@@ -428,8 +429,9 @@ const DayPlanner = () => {
   const [calendarFilter, setCalendarFilter] = useState(() => {
     try { return JSON.parse(localStorage.getItem('day-planner-calendar-filter') || '[]'); } catch { return []; }
   });
-  // On native apps, calendar events come from the native bridge — only task calendar URL matters for sync
-  const calSyncConfigured = isNativeApp() ? !!taskCalendarUrl : !!(syncUrl || taskCalendarUrl);
+  // When a native calendar source is present (mobile bridge or macOS EventKit),
+  // calendar events come from there — only the task calendar URL matters for sync.
+  const calSyncConfigured = hasNativeCalendar() ? !!taskCalendarUrl : !!(syncUrl || taskCalendarUrl);
   const [calendarUrlAuth, setCalendarUrlAuth] = useState(() => {
     const saved = localStorage.getItem('day-planner-calendar-url-auth');
     return saved ? JSON.parse(saved) : { username: '', password: '' };
@@ -1727,7 +1729,7 @@ const DayPlanner = () => {
 
   useEffect(() => {
     if (isTrayMode) return;
-    const hasSyncTarget = isNativeApp() ? !!taskCalendarUrl : !!(syncUrl || taskCalendarUrl);
+    const hasSyncTarget = hasNativeCalendar() ? !!taskCalendarUrl : !!(syncUrl || taskCalendarUrl);
     if (!hasSyncTarget) return;
 
     syncAllRef.current({ silent: true });
@@ -3724,79 +3726,34 @@ const DayPlanner = () => {
   // --- Focus Mode handlers ---
 
 
-  // ── Native Calendar Events (Android only) ────────────────────────────────
+  // ── Native Calendar Events (mobile bridge + macOS Electron) ──────────────
   // Fetches events from the device calendar for a ±2-day window around the
   // selected date and merges them into `tasks` as _native-flagged entries.
   // _native tasks are excluded from saveData so they're never persisted.
-
-  const nativeEventToTask = (event) => {
-    const isAllDay = event.allDay;
-    const startStr = event.start; // "YYYY-MM-DDThh:mm:ss" or "YYYY-MM-DD"
-    const endStr   = event.end;
-
-    // Android formats all-day event timestamps (stored as UTC midnight) as local time
-    // strings without a timezone suffix. In UTC- timezones this shifts the date one day
-    // back (e.g. UTC midnight March 15 → local "2026-03-14T19:00:00"). Parse via Date
-    // so JS treats the string as local time, then read the UTC date from toISOString()
-    // to recover the correct calendar date regardless of device timezone.
-    const allDayDateStr = (str) => {
-      if (!str || str.length === 10) return str; // already "YYYY-MM-DD"
-      return new Date(str).toISOString().substring(0, 10);
-    };
-
-    const startDate = isAllDay ? allDayDateStr(startStr) : startStr.substring(0, 10);
-    // CalendarRepository already subtracts 1 day from Android's exclusive dtend before
-    // sending, so the end arrives as the inclusive last day in "YYYY-MM-DD" format.
-    const endDate = endStr ? endStr.substring(0, 10) : startDate;
-    const isMultiDay = isAllDay && endDate > startDate;
-    // For multi-day all-day events use the queried date so each day they span appears
-    // correctly. Clamp _queryDate to [startDate, endDate]: Android can return an event
-    // one day early/late due to UTC-offset arithmetic, so out-of-range query dates are
-    // snapped to the nearest valid boundary instead of displaying the event off by a day.
-    let date;
-    if (isMultiDay && event._queryDate) {
-      const qd = event._queryDate;
-      date = qd < startDate ? startDate : qd > endDate ? endDate : qd;
-    } else {
-      date = startDate;
-    }
-    const startTime = isAllDay ? null : startStr.substring(11, 16); // "HH:MM"
-    let duration = 60;
-    if (!isAllDay && endStr && endStr.length >= 16) {
-      const endTime = endStr.substring(11, 16);
-      duration = Math.max(15, timeToMinutes(endTime) - timeToMinutes(startTime));
-    }
-    return {
-      // Multi-day all-day events get a per-day ID so each day's copy survives dedup
-      id:                   isMultiDay ? `native-cal-${event.id}-${date}` : `native-cal-${event.id}`,
-      nativeEventId:        event.id,
-      nativeCalendarColor:  event.color || '',
-      title:                event.title || '',
-      date,
-      startTime:            startTime || null,
-      duration,
-      isAllDay,
-      imported:             true,
-      isTaskCalendar:       String(event.id).startsWith('task-'),
-      notes:                event.notes || '',
-      location:             event.location || '',
-      calendarName:         event.calendarName || '',
-      completed:            false,
-      _native:              true,
-    };
-  };
+  // nativeEventToTask now lives in src/utils/nativeCalendar.js.
 
   // Fetch available device calendars once on load
   useEffect(() => {
-    if (!isNativeApp()) return;
-    const cals = nativeGetCalendars();
-    if (cals.length > 0) setAvailableCalendars(cals);
+    if (!hasNativeCalendar()) return;
+    if (isNativeApp()) {
+      const cals = nativeGetCalendars();
+      if (cals.length > 0) setAvailableCalendars(cals);
+    } else {
+      // Electron (macOS): request access first so the calendar list isn't empty
+      // on the very first launch before permission has been granted.
+      let cancelled = false;
+      (async () => {
+        await electronRequestCalendarAccess();
+        const cals = await electronGetCalendars();
+        if (!cancelled && cals.length > 0) setAvailableCalendars(cals);
+      })();
+      return () => { cancelled = true; };
+    }
   }, []);
 
 
   useEffect(() => {
-    if (!isNativeApp()) return;
-
+    if (!hasNativeCalendar()) return;
 
     const dates = [];
     for (let offset = -2; offset <= 2; offset++) {
@@ -3805,75 +3762,88 @@ const DayPlanner = () => {
       dates.push(dateToString(d));
     }
 
-    // nativeGetEvents uses synchronous XHR under the hood (iOS bridge). Calling it
-    // inside Promise.then() blocks the XHR on WKWebView, so we fetch synchronously.
-    const results = dates.map(d => nativeGetEvents(d));
+    // `results` is a per-day array aligned to `dates` — each entry is that day's
+    // event list (or null). The mobile and Electron transports both produce this
+    // shape so the merge below is identical across platforms.
+    const applyEvents = (results) => {
+      // Tag each event with the date it was queried for so multi-day all-day events
+      // can be shown on every day they span, not just their start date.
+      const allEvents = results.flatMap((result, i) =>
+        Array.isArray(result) ? result.map(e => ({ ...e, _queryDate: dates[i] })) : []
+      );
 
-    // Tag each event with the date it was queried for so multi-day all-day events
-    // can be shown on every day they span, not just their start date.
-    const allEvents = results.flatMap((result, i) =>
-      Array.isArray(result) ? result.map(e => ({ ...e, _queryDate: dates[i] })) : []
-    );
-
-
-    // Discover calendars that appear in events but weren't returned by getCalendars()
-    // (e.g. task-only calendars that some providers omit from the calendars list).
-    setAvailableCalendars(prev => {
-      const knownIds = new Set(prev.map(c => c.id));
-      const newCals = [];
-      allEvents.forEach(e => {
-        if (e.calendarId && !knownIds.has(e.calendarId)) {
-          knownIds.add(e.calendarId);
-          newCals.push({ id: e.calendarId, name: e.calendarName || 'Unknown Calendar', accountName: '', color: e.color || '#6b7280' });
-        }
-      });
-      if (newCals.length === 0) return prev;
-      // Extend any active calendarFilter so newly discovered calendars show as checked.
-      setCalendarFilter(f => {
-        if (f.length === 0) return f;
-        const toAdd = newCals.map(c => c.id).filter(id => !f.includes(id));
-        return toAdd.length > 0 ? [...f, ...toAdd] : f;
-      });
-      return [...prev, ...newCals];
-    });
-
-    const filterSet = calendarFilter.length > 0 ? new Set(calendarFilter) : null;
-
-
-    // Deduplicate by task id: CalendarContract can return the same all-day event
-    // in adjacent day windows (especially in UTC+ timezones). Keep first occurrence.
-    const seen = new Set();
-    const fetched = allEvents
-      .filter(e => !filterSet || filterSet.has(e.calendarId))
-      .map(e => nativeEventToTask(e))
-      .filter(t => {
-        if (seen.has(t.id)) return false;
-        seen.add(t.id);
-        return true;
+      // Discover calendars that appear in events but weren't returned by getCalendars()
+      // (e.g. task-only calendars that some providers omit from the calendars list).
+      setAvailableCalendars(prev => {
+        const knownIds = new Set(prev.map(c => c.id));
+        const newCals = [];
+        allEvents.forEach(e => {
+          if (e.calendarId && !knownIds.has(e.calendarId)) {
+            knownIds.add(e.calendarId);
+            newCals.push({ id: e.calendarId, name: e.calendarName || 'Unknown Calendar', accountName: '', color: e.color || '#6b7280' });
+          }
+        });
+        if (newCals.length === 0) return prev;
+        // Extend any active calendarFilter so newly discovered calendars show as checked.
+        setCalendarFilter(f => {
+          if (f.length === 0) return f;
+          const toAdd = newCals.map(c => c.id).filter(id => !f.includes(id));
+          return toAdd.length > 0 ? [...f, ...toAdd] : f;
+        });
+        return [...prev, ...newCals];
       });
 
+      const filterSet = calendarFilter.length > 0 ? new Set(calendarFilter) : null;
 
-    // Apply any stored time overrides (from dragging all-day events to the timeline)
-    // so the scheduled position survives date navigation and native calendar re-fetches.
-    const overrides = JSON.parse(localStorage.getItem('day-planner-native-time-overrides') || '{}');
-    const fetchedWithOverrides = fetched.map(t => {
-      const override = t.nativeEventId && overrides[String(t.nativeEventId)];
-      if (!override) return t;
-      return {
-        ...t,
-        ...(override.date !== undefined ? { date: override.date } : {}),
-        ...(override.startTime !== undefined ? { startTime: override.startTime, isAllDay: false } : {}),
-        ...(override.duration !== undefined ? { duration: override.duration } : {}),
-        ...(override.title !== undefined ? { title: override.title } : {}),
-        ...(override.notes !== undefined ? { notes: override.notes } : {}),
-        ...(override.color !== undefined ? { color: override.color } : {}),
-      };
-    });
+      // Deduplicate by task id: CalendarContract can return the same all-day event
+      // in adjacent day windows (especially in UTC+ timezones). Keep first occurrence.
+      const seen = new Set();
+      const fetched = allEvents
+        .filter(e => !filterSet || filterSet.has(e.calendarId))
+        .map(e => nativeEventToTask(e))
+        .filter(t => {
+          if (seen.has(t.id)) return false;
+          seen.add(t.id);
+          return true;
+        });
 
-    setTasks(prev => [
-      ...prev.filter(t => !t._native),
-      ...fetchedWithOverrides,
-    ]);
+      // Apply any stored time overrides (from dragging all-day events to the timeline)
+      // so the scheduled position survives date navigation and native calendar re-fetches.
+      const overrides = JSON.parse(localStorage.getItem('day-planner-native-time-overrides') || '{}');
+      const fetchedWithOverrides = fetched.map(t => {
+        const override = t.nativeEventId && overrides[String(t.nativeEventId)];
+        if (!override) return t;
+        return {
+          ...t,
+          ...(override.date !== undefined ? { date: override.date } : {}),
+          ...(override.startTime !== undefined ? { startTime: override.startTime, isAllDay: false } : {}),
+          ...(override.duration !== undefined ? { duration: override.duration } : {}),
+          ...(override.title !== undefined ? { title: override.title } : {}),
+          ...(override.notes !== undefined ? { notes: override.notes } : {}),
+          ...(override.color !== undefined ? { color: override.color } : {}),
+        };
+      });
+
+      setTasks(prev => [
+        ...prev.filter(t => !t._native),
+        ...fetchedWithOverrides,
+      ]);
+    };
+
+    if (isNativeApp()) {
+      // nativeGetEvents uses synchronous XHR under the hood (iOS bridge). Calling it
+      // inside Promise.then() blocks the XHR on WKWebView, so we fetch synchronously.
+      applyEvents(dates.map(d => nativeGetEvents(d)));
+    } else {
+      // Electron (macOS): async IPC pre-fetch over the same window (Option A), then
+      // feed the identical merge path. Guard against out-of-order resolves on rapid
+      // date navigation.
+      let cancelled = false;
+      electronGetEventsByDate(dates).then(results => {
+        if (!cancelled) applyEvents(results);
+      });
+      return () => { cancelled = true; };
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedDate, calendarFilter, nativeCalendarKey]);
 
@@ -5002,9 +4972,10 @@ const DayPlanner = () => {
 
   // Returns { success: boolean, count?: number, error?: string }
   const syncWithCalendar = async () => {
-    // On native apps, calendar events come from the native bridge (EventKit/CalendarBridge).
-    // CalDAV iCal sync would duplicate those events, so skip it entirely.
-    if (isNativeApp()) return { success: false, error: 'no-url' };
+    // When a native calendar source is present (mobile bridge or macOS EventKit),
+    // calendar events come from there. CalDAV iCal sync would duplicate those
+    // events, so skip it entirely.
+    if (hasNativeCalendar()) return { success: false, error: 'no-url' };
     if (!syncUrl) {
       return { success: false, error: 'no-url' };
     }
@@ -5451,7 +5422,7 @@ const DayPlanner = () => {
 
   // Combined sync function that shows a single notification
   const syncAll = async ({ silent = false } = {}) => {
-    const hasSyncTarget = isNativeApp() ? !!taskCalendarUrl : !!(syncUrl || taskCalendarUrl);
+    const hasSyncTarget = hasNativeCalendar() ? !!taskCalendarUrl : !!(syncUrl || taskCalendarUrl);
     if (!hasSyncTarget) {
       if (!silent) setSyncNotification({ type: 'info', message: 'Please enter a task calendar URL in sync settings' });
       return;

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -7,7 +7,7 @@ import {
 import { dateToString, extractWikilinks, formatDateRange } from '../utils/taskUtils.js';
 import { renderTitle } from '../utils/textFormatting.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
-import { isNativeApp } from '../native.js';
+import { hasNativeCalendar } from '../utils/nativeCalendar.js';
 import DesktopHeader from './DesktopHeader.jsx';
 import CalendarHeader from './CalendarHeader.jsx';
 import TimeGrid from './TimeGrid.jsx';
@@ -497,7 +497,7 @@ const DesktopLayout = () => {
               )}
           </div>
           <div className="flex items-center gap-2">
-            {!isNativeApp() && <button
+            {!hasNativeCalendar() && <button
               onClick={() => {
                 if (isSyncing) return;
                 if (calSyncConfigured) {

--- a/src/utils/nativeCalendar.js
+++ b/src/utils/nativeCalendar.js
@@ -1,0 +1,156 @@
+/**
+ * Native (device-local) calendar integration.
+ *
+ * Two transports share one event-JSON contract so the rest of the app stays
+ * platform-agnostic:
+ *
+ *   - Mobile bridge (Android/iOS): synchronous accessors on window.DayGlanceNative
+ *     (see src/native.js — nativeGetCalendars / nativeGetEvents).
+ *   - macOS Electron desktop: asynchronous IPC on window.electronAPI, backed by a
+ *     signed Swift EventKit helper spawned by the main process.
+ *
+ * Event JSON contract (identical across every platform — verified against the
+ * iOS CalendarBridge):
+ *   getCalendars()  → [{ id, name, accountName, color }]
+ *   getEvents(date) → [{ id, title, start, end, allDay, notes, location,
+ *                        calendarId, calendarName, color }]
+ *
+ * Native events are tagged `_native: true` by nativeEventToTask and are never
+ * persisted or synced, so they sidestep the multi-user calendar-leak concern
+ * entirely (consistent with the per-user calendar config work).
+ */
+import { isNativeApp } from '../native.js';
+
+const timeToMinutes = (time) => {
+  if (!time) return 0;
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + (m || 0);
+};
+
+/**
+ * True when the Electron renderer exposes the macOS calendar IPC bridge.
+ * Gated on the darwin platform so Windows/Linux Electron builds keep relying
+ * on URL/CalDAV subscriptions.
+ */
+export const electronCalendarAvailable = () =>
+  typeof window !== 'undefined' &&
+  !!window.electronAPI?.getCalendarEvents &&
+  window.electronAPI?.platform === 'darwin';
+
+/**
+ * True when device-local calendar events are available from any native source —
+ * the mobile bridge (Android/iOS) or the macOS Electron EventKit helper.
+ * The URL/CalDAV read-sync path is skipped whenever this is true.
+ */
+export const hasNativeCalendar = () => isNativeApp() || electronCalendarAvailable();
+
+/**
+ * Requests macOS calendar access. Triggers the system permission dialog the
+ * first time it runs; subsequent calls resolve immediately. Returns true when
+ * events can be read. No-op (false) when the Electron bridge is absent.
+ */
+export const electronRequestCalendarAccess = async () => {
+  if (!window.electronAPI?.requestCalendarAccess) return false;
+  try {
+    const res = await window.electronAPI.requestCalendarAccess();
+    return !!res?.granted;
+  } catch {
+    return false;
+  }
+};
+
+/** Fetches the device calendar list from the Electron helper. */
+export const electronGetCalendars = async () => {
+  if (!window.electronAPI?.getCalendars) return [];
+  try {
+    return (await window.electronAPI.getCalendars()) ?? [];
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Fetches events for each date in `dates` from the Electron helper and returns a
+ * per-date array aligned to the input — the same shape the mobile path produces
+ * via `dates.map(nativeGetEvents)` — so the App-side merge logic is identical
+ * across platforms. The helper queries each day with the same overlap predicate
+ * as the mobile bridge, so multi-day all-day events appear under every day they
+ * span. Entries are `null` when a day has no result (e.g. access denied).
+ */
+export const electronGetEventsByDate = async (dates) => {
+  if (!dates?.length || !window.electronAPI?.getCalendarEvents) {
+    return (dates ?? []).map(() => null);
+  }
+  try {
+    const map = await window.electronAPI.getCalendarEvents(dates[0], dates[dates.length - 1]);
+    return dates.map((d) => (Array.isArray(map?.[d]) ? map[d] : null));
+  } catch {
+    return dates.map(() => null);
+  }
+};
+
+/**
+ * Maps a native calendar event (mobile bridge or Electron helper — identical
+ * shape) to a `_native`-flagged task. `_native` tasks are excluded from saveData
+ * so they're never persisted or synced.
+ *
+ * @param event  Native event JSON, optionally tagged with `_queryDate` (the day
+ *               it was fetched for) so multi-day all-day events land on the
+ *               correct day.
+ */
+export const nativeEventToTask = (event) => {
+  const isAllDay = event.allDay;
+  const startStr = event.start; // "YYYY-MM-DDThh:mm:ss" or "YYYY-MM-DD"
+  const endStr = event.end;
+
+  // Android formats all-day event timestamps (stored as UTC midnight) as local time
+  // strings without a timezone suffix. In UTC- timezones this shifts the date one day
+  // back (e.g. UTC midnight March 15 → local "2026-03-14T19:00:00"). Parse via Date
+  // so JS treats the string as local time, then read the UTC date from toISOString()
+  // to recover the correct calendar date regardless of device timezone.
+  const allDayDateStr = (str) => {
+    if (!str || str.length === 10) return str; // already "YYYY-MM-DD"
+    return new Date(str).toISOString().substring(0, 10);
+  };
+
+  const startDate = isAllDay ? allDayDateStr(startStr) : startStr.substring(0, 10);
+  // CalendarRepository already subtracts 1 day from Android's exclusive dtend before
+  // sending, so the end arrives as the inclusive last day in "YYYY-MM-DD" format.
+  const endDate = endStr ? endStr.substring(0, 10) : startDate;
+  const isMultiDay = isAllDay && endDate > startDate;
+  // For multi-day all-day events use the queried date so each day they span appears
+  // correctly. Clamp _queryDate to [startDate, endDate]: Android can return an event
+  // one day early/late due to UTC-offset arithmetic, so out-of-range query dates are
+  // snapped to the nearest valid boundary instead of displaying the event off by a day.
+  let date;
+  if (isMultiDay && event._queryDate) {
+    const qd = event._queryDate;
+    date = qd < startDate ? startDate : qd > endDate ? endDate : qd;
+  } else {
+    date = startDate;
+  }
+  const startTime = isAllDay ? null : startStr.substring(11, 16); // "HH:MM"
+  let duration = 60;
+  if (!isAllDay && endStr && endStr.length >= 16) {
+    const endTime = endStr.substring(11, 16);
+    duration = Math.max(15, timeToMinutes(endTime) - timeToMinutes(startTime));
+  }
+  return {
+    // Multi-day all-day events get a per-day ID so each day's copy survives dedup
+    id:                   isMultiDay ? `native-cal-${event.id}-${date}` : `native-cal-${event.id}`,
+    nativeEventId:        event.id,
+    nativeCalendarColor:  event.color || '',
+    title:                event.title || '',
+    date,
+    startTime:            startTime || null,
+    duration,
+    isAllDay,
+    imported:             true,
+    isTaskCalendar:       String(event.id).startsWith('task-'),
+    notes:                event.notes || '',
+    location:             event.location || '',
+    calendarName:         event.calendarName || '',
+    completed:            false,
+    _native:              true,
+  };
+};

--- a/src/utils/nativeCalendar.test.js
+++ b/src/utils/nativeCalendar.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { nativeEventToTask } from './nativeCalendar.js';
+
+// The Electron EventKit helper emits the exact same JSON shape as the mobile
+// DayGlanceNative bridge, so these fixtures double as the Electron contract.
+const ev = (extra = {}) => ({
+  id: 'ABC-123',
+  title: 'Standup',
+  start: '2026-06-22T09:00:00',
+  end: '2026-06-22T09:30:00',
+  allDay: false,
+  notes: '',
+  location: '',
+  calendarId: 'cal-work',
+  calendarName: 'Work',
+  color: '#3b82f6',
+  ...extra,
+});
+
+describe('nativeEventToTask', () => {
+  it('maps a timed event with derived duration and _native flag', () => {
+    const task = nativeEventToTask(ev());
+    expect(task).toMatchObject({
+      id: 'native-cal-ABC-123',
+      nativeEventId: 'ABC-123',
+      title: 'Standup',
+      date: '2026-06-22',
+      startTime: '09:00',
+      duration: 30,
+      isAllDay: false,
+      imported: true,
+      isTaskCalendar: false,
+      completed: false,
+      _native: true,
+      nativeCalendarColor: '#3b82f6',
+      calendarName: 'Work',
+    });
+  });
+
+  it('clamps a too-short duration to a 15-minute minimum', () => {
+    const task = nativeEventToTask(ev({ start: '2026-06-22T09:00:00', end: '2026-06-22T09:05:00' }));
+    expect(task.duration).toBe(15);
+  });
+
+  it('falls back to a 60-minute duration when no end time is present', () => {
+    const task = nativeEventToTask(ev({ end: '' }));
+    expect(task.duration).toBe(60);
+  });
+
+  it('maps a single-day all-day event with no startTime', () => {
+    const task = nativeEventToTask({
+      ...ev(),
+      allDay: true,
+      start: '2026-06-22',
+      end: '2026-06-22',
+    });
+    expect(task).toMatchObject({
+      id: 'native-cal-ABC-123',
+      date: '2026-06-22',
+      startTime: null,
+      isAllDay: true,
+    });
+  });
+
+  it('gives multi-day all-day events a per-day id and uses the queried date', () => {
+    const base = {
+      ...ev(),
+      id: 'TRIP',
+      allDay: true,
+      start: '2026-06-20',
+      end: '2026-06-23',
+    };
+    const day1 = nativeEventToTask({ ...base, _queryDate: '2026-06-21' });
+    const day2 = nativeEventToTask({ ...base, _queryDate: '2026-06-22' });
+    expect(day1.id).toBe('native-cal-TRIP-2026-06-21');
+    expect(day1.date).toBe('2026-06-21');
+    expect(day2.id).toBe('native-cal-TRIP-2026-06-22');
+    expect(day2.date).toBe('2026-06-22');
+    // Distinct ids so each spanned day survives id-based dedup
+    expect(day1.id).not.toBe(day2.id);
+  });
+
+  it('clamps an out-of-range queried date to the event span', () => {
+    const base = { ...ev(), id: 'TRIP', allDay: true, start: '2026-06-20', end: '2026-06-22' };
+    const before = nativeEventToTask({ ...base, _queryDate: '2026-06-18' });
+    const after = nativeEventToTask({ ...base, _queryDate: '2026-06-25' });
+    expect(before.date).toBe('2026-06-20');
+    expect(after.date).toBe('2026-06-22');
+  });
+
+  it('flags task-list calendars via the task- id prefix', () => {
+    const task = nativeEventToTask(ev({ id: 'task-42' }));
+    expect(task.isTaskCalendar).toBe(true);
+    expect(task.id).toBe('native-cal-task-42');
+  });
+});


### PR DESCRIPTION
Implements steps 1–4 of `docs/macos-native-calendar-plan.md`: read-only access to the macOS system Calendar in the Electron desktop build via a signed Swift EventKit helper. Events surface as `_native` device-local tasks the same way they do on iOS/Android, and because `_native` events are never synced this sidesteps the multi-user calendar-leak concern on macOS. Follows the calendar work in #1029 / #1030.

The plan's design choices are honored: **Option A** (async pre-fetch feeding the existing merge path) and **Option 1** (Swift helper binary).

## What's included

**Native layer (Swift helper)**
- `electron/native/calendar-helper/Sources/main.swift` — a tiny EventKit CLI: `request-access`, `auth-status`, `calendars`, `events --start --end`. The events command returns a per-day `{ "YYYY-MM-DD": [event…] }` map using the same per-day overlap predicate as the iOS bridge, so multi-day all-day events appear under every day they span. Output JSON matches the iOS `CalendarBridge` contract exactly, so `nativeEventToTask` is unchanged.
- `scripts/build-calendar-helper.sh` — builds a universal (arm64 + x64) binary; no-ops cleanly off macOS. Wired into the `build:electron*` scripts and gitignored.

**IPC**
- `electron/calendar.ts` (`registerCalendarHandlers`, registered in `main.ts`) spawns the helper via `execFile` and returns safe empty defaults off-macOS or when the helper is absent.
- `electron/preload.ts` exposes `requestCalendarAccess` / `getCalendars` / `getCalendarEvents`.

**App side**
- `src/utils/nativeCalendar.js` — extracts `nativeEventToTask` out of `App.jsx` (the opportunistic extraction CLAUDE.md flagged) and adds `hasNativeCalendar()` + the Electron accessors.
- `App.jsx` — gates the calendar-fetch effects and `syncWithCalendar` / `syncAll` / `calSyncConfigured` on `hasNativeCalendar()`; the fetch effect branches to an async Electron pre-fetch that feeds the unchanged merge path (mobile stays synchronous).
- `DesktopLayout.jsx` — hides the manual calendar-sync header button on macOS native (switched the gate from `!isNativeApp()` to `!hasNativeCalendar()`), matching how it's hidden on iOS/Android.

**Packaging**
- `electron-builder.config.cjs` — `mac`/`mas` `extendInfo` (NSCalendars[FullAccess]UsageDescription) and `extraResources` for the helper.
- Both entitlement plists add `com.apple.security.personal-information.calendars`.

**Test**
- `src/utils/nativeCalendar.test.js` — covers the `nativeEventToTask` mapping against the shared event shape (timed, all-day, multi-day per-day ids, out-of-range clamp, task- prefix).

## Verification (in CI/Linux dev container)
- `vitest run` — 322 passed (incl. 7 new).
- `tsc` on both electron tsconfigs — clean.
- `vite build` — clean.

## Still needs a Mac (cannot run in this environment)
- `npm run build:calendar-helper` then `build:electron:release` (or `:mas`); confirm the helper is signed inside `Contents/Resources/calendar-helper` and the notarized build passes Gatekeeper.
- Manual validation: grant permission, verify the −2..+2 window populates, the calendar filter works, and `_native` events stay out of the sync payload.

## Reviewer notes
1. **Behavior change:** on macOS, `hasNativeCalendar()` gating means an existing CalDAV **URL** subscription's read path is superseded by EventKit once the helper is present — this is the plan's stated intent but worth a conscious sign-off.
2. **Signing/notarization** of the nested helper is the plan's known risk area; `extraResources` + entitlements are set up so electron-builder signs it, but only a real signed build confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ)_