### PR TITLE
Fix macOS native calendar: show device-calendar picker, hide desktop sync button

### DIFF
--- a/src/components/DesktopHeader.jsx
+++ b/src/components/DesktopHeader.jsx
@@ -4,6 +4,7 @@ import {
   HelpCircle, Moon, RefreshCw, Save, Settings, Sun,
 } from 'lucide-react';
 import { dateToString, formatDateRange } from '../utils/taskUtils.js';
+import { hasNativeCalendar } from '../utils/nativeCalendar.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -174,7 +175,7 @@ const DesktopHeader = () => {
 
         {/* Right: Action buttons */}
         <div className="flex items-center gap-1.5 flex-shrink-0">
-          <button
+          {!hasNativeCalendar() && <button
             onClick={() => {
               if (isSyncing) return;
               if (calSyncConfigured) {
@@ -196,7 +197,7 @@ const DesktopHeader = () => {
                 'bg-green-500'
               }`} />
             )}
-          </button>
+          </button>}
           <button
             onClick={() => {
               if (cloudSyncConfig?.enabled) {

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -7,7 +7,8 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
-import { isNativeAndroid, isNativeApp, nativeGetCalendars } from '../native.js';
+import { isNativeAndroid, nativeGetCalendars } from '../native.js';
+import { hasNativeCalendar, electronCalendarAvailable, electronGetCalendars } from '../utils/nativeCalendar.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault } from '../obsidian.js';
 import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from '../intents/useIntentPoller.js';
 import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUsers.js';
@@ -769,7 +770,7 @@ const SettingsModal = () => {
                         <ChevronDown size={16} className={`ml-auto flex-shrink-0 ${textSecondary} transition-transform ${collapsedSettings.calSync ? '' : 'rotate-180'}`} />
                       </button>
                       {!collapsedSettings.calSync && (<>
-                      {!isNativeApp() && (
+                      {!hasNativeCalendar() && (
                       <div>
                         <label className={`block text-sm ${textSecondary} mb-1`}>
                           {t('settings.calendarUrl')}
@@ -790,7 +791,7 @@ const SettingsModal = () => {
                         </p>
                       </div>
                       )}
-                      {!isNativeApp() && syncUrl && (
+                      {!hasNativeCalendar() && syncUrl && (
                         <div className={`space-y-2 pl-3 border-l-2 ${darkMode ? 'border-gray-600' : 'border-stone-300'}`}>
                           <p className={`text-xs font-medium ${textSecondary}`}>{t('settings.calendarBasicAuth')}</p>
                           <div className="flex gap-2">
@@ -817,7 +818,7 @@ const SettingsModal = () => {
                           </div>
                         </div>
                       )}
-                      {isNativeApp() && (
+                      {hasNativeCalendar() && (
                         <p className={`text-xs ${textSecondary}`}>
                           Calendar events are read from your device accounts. Use the Device Calendars section below to choose which calendars to show.
                         </p>
@@ -932,11 +933,14 @@ const SettingsModal = () => {
                           {t('common.lastSynced')}: {new Date(calSyncLastSynced).toLocaleString()}
                         </p>
                       )}
-                      {isNativeApp() && (
+                      {hasNativeCalendar() && (
                         <div className="space-y-2 pt-1">
                           <div className="flex items-center justify-between">
                             <p className={`text-sm font-medium ${textPrimary}`}>{t('settings.deviceCalendars')}</p>
-                            <button onClick={() => { const cals = nativeGetCalendars(); if (cals.length > 0) setAvailableCalendars(cals); }} className={`text-xs ${textSecondary} underline`}>{t('common.refresh')}</button>
+                            <button onClick={async () => {
+                              const cals = electronCalendarAvailable() ? await electronGetCalendars() : nativeGetCalendars();
+                              if (cals.length > 0) setAvailableCalendars(cals);
+                            }} className={`text-xs ${textSecondary} underline`}>{t('common.refresh')}</button>
                           </div>
                           {availableCalendars.length === 0 ? (
                             <p className={`text-xs ${textSecondary}`}>No calendars loaded — tap Refresh, or rebuild the app if this persists.</p>


### PR DESCRIPTION
Follow-up to #1034. On the macOS desktop build `hasNativeCalendar()` is true, but several calendar UI gates were still keyed on `isNativeApp()` (which is mobile-only), so they didn't fire on macOS.

## Fixes

**1. Device-calendar picker now appears on macOS (issue: "no ability to select which calendars appear").**
`SettingsModal` gated the Calendar-URL field, basic-auth fields, the "read from device accounts" note, and the **Device Calendars** picker on `isNativeApp()`. Switched all four to `hasNativeCalendar()`, so macOS gets the same calendar-selection checklist as iOS/Android. The picker's **Refresh** now uses the Electron accessor (`electronGetCalendars()`) when on macOS.

**3. Desktop calendar-sync button now hidden on macOS (issue: "sync icon still showing in the settings cluster").**
There are two headers: the tablet inline header in `DesktopLayout.jsx` (fixed in #1034) and `DesktopHeader.jsx`, which renders on actual desktop (`!isTablet`). The latter's sync button wasn't gated at all, so it stayed visible on macOS. Now gated on `!hasNativeCalendar()`.

## Note on issue #2 (CalDAV calendars still appearing)
This is mostly addressed by the per-device gate already in #1034, but the behavior is worth confirming — see the PR thread / my message to the reviewer. Short version: the **Calendar URL** subscription is per-device and never persisted, so macOS skips it automatically (no need to clear settings; a PWA install keeps using the same shared setting). If the lingering events are EventKit surfacing the same CalDAV accounts your Mac's Calendar.app subscribes to, they're now hideable via the new picker.

## Verification
- `vite build` — clean.
- `vitest run` calendar tests — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ)_