### PR TITLE
Drop stale CalDAV subscription imports on macOS native calendar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3824,8 +3824,12 @@ const DayPlanner = () => {
         };
       });
 
+      // Drop both prior _native events and any read-only subscription imports
+      // (importSource 'sync', non-task, non-file) that may have arrived via cloud
+      // merge — on native-calendar devices the live EventKit/bridge fetch is the
+      // sole source, so those would otherwise show as stale gray duplicates.
       setTasks(prev => [
-        ...prev.filter(t => !t._native),
+        ...prev.filter(t => !t._native && !(t.imported && !t.isTaskCalendar && t.importSource !== 'file')),
         ...fetchedWithOverrides,
       ]);
     };

--- a/src/hooks/useDataPersistence.js
+++ b/src/hooks/useDataPersistence.js
@@ -1,4 +1,15 @@
 import { dateToString } from '../utils/taskUtils.js';
+import { hasNativeCalendar } from '../utils/nativeCalendar.js';
+
+// Read-only CalDAV/ICS-subscription events (importSource 'sync', non-task,
+// non-file) are ephemeral remote data, re-fetched live each session. On devices
+// with a native calendar source (macOS EventKit / mobile bridge) that live fetch
+// is disabled, so any such events lingering in storage — from an earlier build or
+// a cloud merge — must be dropped rather than shown as stale gray duplicates of
+// the native events. ICS file imports ('file') and CalDAV task-calendar to-dos
+// (isTaskCalendar) are first-class user data and are always kept.
+const isSubscriptionImport = (t) =>
+  !t._native && t.imported && !t.isTaskCalendar && t.importSource !== 'file';
 
 export default function useDataPersistence({
   // setters for loadData
@@ -77,8 +88,11 @@ export default function useDataPersistence({
       if (unscheduledData) localStorage.setItem('day-planner-unscheduled', JSON.stringify(parsedUnscheduled));
 
       // Load tasks normally; preserve any _native events already queued by Effect B
-      // if it raced ahead of loadData in React's state update batch.
-      setTasks(prev => [...parsedTasks, ...prev.filter(t => t._native)]);
+      // if it raced ahead of loadData in React's state update batch. On native-
+      // calendar devices, drop any persisted subscription imports so they don't
+      // linger as stale duplicates of the live EventKit/bridge events.
+      const loadedTasks = hasNativeCalendar() ? parsedTasks.filter(t => !isSubscriptionImport(t)) : parsedTasks;
+      setTasks(prev => [...loadedTasks, ...prev.filter(t => t._native)]);
       setUnscheduledTasks(parsedUnscheduled.filter(t => !t.imported));
       if (recycleBinData) {
         setRecycleBin(JSON.parse(recycleBinData));
@@ -174,7 +188,12 @@ export default function useDataPersistence({
       }
     };
 
-    const stampedTasks = stampTaskTimestamps(tasks.filter(t => !t._native), 'day-planner-tasks');
+    // Never persist _native events; on native-calendar devices also drop ephemeral
+    // subscription imports so they don't reappear (stale) on the next reload.
+    const stampedTasks = stampTaskTimestamps(
+      tasks.filter(t => !t._native && !(hasNativeCalendar() && isSubscriptionImport(t))),
+      'day-planner-tasks'
+    );
     const stampedUnscheduled = stampTaskTimestamps(unscheduledTasks, 'day-planner-unscheduled');
     const stampedRecycleBin = stampTaskTimestamps(recycleBin, 'day-planner-recycle-bin');
     const stampedRecurring = stampTaskTimestamps(recurringTasks, 'day-planner-recurring-tasks');


### PR DESCRIPTION
Follow-up to #1034 / #1035. Fixes the gray CalDAV duplicate events that persisted on macOS even with a native calendar present.

## Root cause
The live CalDAV/ICS subscription fetch is correctly gated off on native-calendar devices (`syncWithCalendar` early-returns). But the **local** `saveData` (`useDataPersistence.js`) only excluded `_native` tasks — it still **persisted subscription events** (`importSource: 'sync'`, non-task) to `localStorage`. So any that had been imported by an earlier pre-gate build (or arrived via a cloud merge) got written to `day-planner-tasks` and reloaded every launch as stale gray duplicates of the live EventKit events. The calendar picker couldn't hide them either, since they aren't device calendars — which is exactly the "I remove them and they come back after reload" symptom.

(The picker filter itself does persist correctly via `useLocalStoragePersist.js` — the issue was purely these non-native subscription events.)

## Fix
Treat subscription imports as the ephemeral remote data they are. On devices with a native calendar source (`hasNativeCalendar()`):
- **`useDataPersistence` (load):** drop subscription imports from the loaded set, clearing any already stuck in `localStorage`.
- **`useDataPersistence` (save):** never persist them, so they don't come back.
- **`App.jsx` (native fetch effect):** strip any that slip in via cloud merge when the effect refreshes `_native` events — belt-and-suspenders for the in-session case.

All three are gated on `hasNativeCalendar()`, so **PWA / Windows / Linux keep their offline-cache behavior unchanged**. ICS file imports (`importSource: 'file'`) and CalDAV task-calendar to-dos (`isTaskCalendar`) remain first-class user data on every platform.

The shared predicate:
```js
const isSubscriptionImport = (t) =>
  !t._native && t.imported && !t.isTaskCalendar && t.importSource !== 'file';
```

## Verification
- `vite build` — clean.
- `vitest run` — 322 passed.

## Expected after rebuild
Open the app on macOS: the gray CalDAV "Jason Off Work" duplicate is gone, leaving only the green native EventKit event, and the Device Calendars picker governs what shows (and sticks across reload). Your PWA install keeps using the Calendar URL subscription normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ)_