### PR TITLE
Fix native calendar picker unselects not persisting on macOS

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3784,12 +3784,21 @@ const DayPlanner = () => {
           }
         });
         if (newCals.length === 0) return prev;
-        // Extend any active calendarFilter so newly discovered calendars show as checked.
-        setCalendarFilter(f => {
-          if (f.length === 0) return f;
-          const toAdd = newCals.map(c => c.id).filter(id => !f.includes(id));
-          return toAdd.length > 0 ? [...f, ...toAdd] : f;
-        });
+        // Extend any active calendarFilter so newly discovered calendars show as
+        // checked — but only once the calendar list has actually loaded (prev
+        // non-empty). On Electron the calendars fetch is async, so on startup the
+        // events can resolve first while prev is still empty; every event-calendar
+        // then looks "new" and augmenting the filter would silently re-check
+        // calendars the user had unselected (calendarFilter loads synchronously
+        // from localStorage, before the async calendar list does). Mobile is
+        // unaffected — nativeGetCalendars() is synchronous.
+        if (prev.length > 0) {
+          setCalendarFilter(f => {
+            if (f.length === 0) return f;
+            const toAdd = newCals.map(c => c.id).filter(id => !f.includes(id));
+            return toAdd.length > 0 ? [...f, ...toAdd] : f;
+          });
+        }
         return [...prev, ...newCals];
       });
 


### PR DESCRIPTION
Separate fix from #1036 (per your clarification that the picker not persisting is unrelated to the gray CalDAV events).

## Symptom
On macOS, unchecking a device calendar in the Settings → Device Calendars picker didn't survive a reload — the calendar came back checked and its events reappeared.

## Root cause — an Electron-only startup race
`calendarFilter` loads **synchronously** from localStorage, but on macOS the calendar list (`availableCalendars`) loads via **async** IPC (`electronGetCalendars`). When the events fetch resolves before the calendar list does, `prev` (availableCalendars) is still empty, so the "discover calendars that `getCalendars()` omitted" logic in the fetch effect treats *every* event's calendar as newly discovered and appends it to `calendarFilter` — silently re-checking the calendars you'd just unselected.

Mobile never hits this because `nativeGetCalendars()` is synchronous, so `availableCalendars` is always populated before the events resolve.

## Fix
Only augment `calendarFilter` once the calendar list has actually loaded (`prev.length > 0`). Newly-discovered calendars are still added to `availableCalendars` (so the picker lists them) — they just no longer override an existing user selection during the load race.

```js
if (prev.length > 0) {
  setCalendarFilter(f => { /* append genuinely-new calendars */ });
}
```

## Verification
- `vite build` — clean.

## Expected after rebuild
Uncheck a calendar in the picker → reload → it stays unchecked and its events stay hidden.

Note: this and #1036 both touch the same `applyEvents` effect in `App.jsx` but different lines, so whichever merges second may need a trivial auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ)_