### PR TITLE
Move calendar/location under the title on desktop/tablet event cards

### DIFF
--- a/src/components/TimelineTaskCardContent.jsx
+++ b/src/components/TimelineTaskCardContent.jsx
@@ -163,7 +163,7 @@ const TimelineTaskCardContent = ({ task, height, isNarrowWidth, flipNotesPanel }
       <div className="px-2 py-1 flex-1 min-w-0 h-full flex flex-col">
         {isImported && !isCalendarEvent ? null : isCalendarEvent ? (
           /* IMPORTED EVENT LAYOUT: Always show time on right with truncated title */
-          <div className="flex flex-col h-full justify-between gap-0.5">
+          <div className="flex flex-col h-full justify-start gap-0.5">
             <div className="flex items-center justify-between gap-2">
               <div
                 className="font-semibold text-sm leading-tight truncate flex-1 min-w-0"


### PR DESCRIPTION
## Symptom
On desktop and tablet (incl. iPad), imported calendar-event cards render the calendar name and location at the very **bottom** of the card instead of directly under the title. Mobile was fixed for this a while ago.

## Cause
The imported-event layout in `TimelineTaskCardContent.jsx` used `flex flex-col h-full justify-between`, which spreads its two rows (title+time, and calendar/location) to the top and bottom of a full-height card — so on any reasonably tall event the details sink to the bottom.

The mobile equivalent (`MobileTimeGrid.jsx`) already uses `justify-start`, so the detail row sits right under the title.

## Fix
One-line: `justify-between` → `justify-start`, matching mobile. Events now read top-down — title, then `calendar · location` immediately beneath it. (No change to the all-day card, which doesn't show this row.)

## Verification
- `vite build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ)_