### PR TITLE
Bump version to 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.5.2-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.6.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 130
-        versionName = "3.5"
+        versionCode = 131
+        versionName = "3.6"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "dependencies": {
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.5.1",
+  "version": "3.6.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
Minor version bump for the macOS native calendar (EventKit) feature and its follow-up fixes merged since 3.5.1 (#1034–#1038). A new platform capability / user-facing feature warrants a minor bump per semver, so **3.5.1 → 3.6.0**.

## Changes
- **`package.json`** + **`package-lock.json`**: `3.5.1` → `3.6.0` (lockfile updated via `npm install`).
- **Android** (`dayglance-android/app/build.gradle.kts`): `versionCode` `130` → `131`, `versionName` `"3.5"` → `"3.6"` (matches the web major.minor).
- **README** version badge: → `3.6.0` (was a stale `3.5.2` left over from the earlier "renumber from unreleased 3.5.2" → 3.5.1 change).

No dependency versions changed — `npm install` only rewrote the embedded root version in the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_014yBkvwiGLqsSkiF8AKv1MJ)_