### PR TITLE
iCloud: re-probe availability each cycle so mid-session disable is silent

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1967,7 +1967,6 @@ const DayPlanner = () => {
   const iCloudSyncRef = useRef(null);
   const openNewInboxTaskRef = useRef(null);
   const openNewTaskFormRef = useRef(null);
-  const iCloudAvailableRef = useRef(null); // null=unchecked, true/false=result
   const iCloudLastWriteAtRef = useRef(0);
 
   const isElectronMac = () =>
@@ -2013,15 +2012,18 @@ const DayPlanner = () => {
     // If the file happens to be an encrypted envelope (written by an older build),
     // we attempt to decrypt it once and write it back as plaintext below.
 
-    // iOS: check iCloud availability once and cache.
+    // iOS: re-probe iCloud availability every cycle rather than caching a sticky
+    // result. A sticky cache meant disabling iCloud Drive mid-session left the value
+    // at `true`, so every 15s poll still read the container, got an "iCloud not
+    // available" error, and flashed a transient sync error until the app was
+    // relaunched. Re-probing is cheap (a nil-container check) and self-healing: we
+    // bail silently while iCloud is off and resume automatically when it returns.
     if (onIOS) {
-      if (iCloudAvailableRef.current === null) {
-        try {
-          const r = JSON.parse(window.DayGlanceNative.iCloudAvailable());
-          iCloudAvailableRef.current = r.available === true;
-        } catch { iCloudAvailableRef.current = false; }
-      }
-      if (!iCloudAvailableRef.current) return;
+      let available = false;
+      try {
+        available = JSON.parse(window.DayGlanceNative.iCloudAvailable()).available === true;
+      } catch { available = false; }
+      if (!available) return;
     }
 
     cloudSyncInProgressRef.current = true;


### PR DESCRIPTION
iOS cached the iCloud availability check once per session (iCloudAvailableRef). If a user turned off iCloud Drive for dayGLANCE while the app was running, the cached value stayed true, so every 15s sync poll still read the container, got an "iCloud not available" error, and flashed a transient sync-error banner that recurred until relaunch.

This re-probes availability on each sync cycle instead. The probe is cheap (a nil-container check natively) and self-healing: the app bails silently while iCloud is off and resumes automatically if iCloud Drive is re-enabled — no relaunch needed. No crash or data-loss path was involved; this only removes the misleading recurring error.