### PR TITLE
Durable, always-encrypted GLANCEvault intents (outbox + deliverers + key setup)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,6 +80,7 @@ import { useIntentPoller, INTENT_CONFIG_KEY } from './intents/useIntentPoller.js
 import { useDbIntentPoller } from './intents/dbIntentsTransport.js';
 import { useNotifyEmitter } from './intents/useNotifyEmitter.js';
 import { useGoalNotifyEmitter } from './intents/useGoalNotifyEmitter.js';
+import { useOutboxFlush } from './intents/useOutboxFlush.js';
 import { useAndroidIntentBridge } from './intents/useAndroidIntentBridge.js';
 import { useUrlActionHandler } from './intents/useUrlActionHandler.js';
 import { syncSharedUsers, syncSharedUsersViaICloud } from './intents/sharedUsers.js';
@@ -1127,6 +1128,9 @@ const DayPlanner = () => {
   });
   useNotifyEmitter({ tasks, unscheduledTasks });
   useGoalNotifyEmitter({ goals });
+  // Durable outbox background drain: flush queued intents on mount (catches
+  // anything held from a previous session), on focus, and on the poll cadence.
+  useOutboxFlush();
 
   // Android intent transport: picks up pending intents on visibilitychange and calls handleIntent.
   useAndroidIntentBridge({

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -30,6 +30,7 @@ import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUser
 import { isAvailable as isICloudAvailable } from '../intents/icloudFileTransport.js';
 import { getSyncPassphrase, setSyncPassphrase } from '../utils/crypto.js';
 import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
+import { ensureVaultIntentsKey, setupVaultIntentsEncryption } from '../intents/vaultIntentsSetup.js';
 import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
 import { useTranslation } from 'react-i18next';
 
@@ -144,6 +145,9 @@ const MobileSettingsPanel = () => {
   // INHERITED from the GLANCEvault sync config (not edited here).
   const [dbIntentsEnabled, setDbIntentsEnabled] = useState(() => !!getDbIntentsConfig()?.enabled);
   const [dbIntentsSaved, setDbIntentsSaved] = useState(false);
+  // Vault intents key-setup phase: null | 'passphrase-needed' | 'running' | { error }.
+  const [dbIntentsSetupPhase, setDbIntentsSetupPhase] = useState(null);
+  const [dbIntentsPassphraseInput, setDbIntentsPassphraseInput] = useState('');
   const [muAddingUser, setMuAddingUser] = useState(false);
   const [muNewUserName, setMuNewUserName] = useState('');
   const [muEditingUserId, setMuEditingUserId] = useState(null);
@@ -1971,13 +1975,98 @@ const MobileSettingsPanel = () => {
                   </div>
                 </div>
 
+                {/* Vault intents are ALWAYS encrypted. Enabling derives + caches the
+                    vault intents key BEFORE the reload; prompt only when the passphrase
+                    is actually unavailable. */}
+                {dbIntentsSetupPhase === 'passphrase-needed' && (
+                  <div className={`p-3 rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700/50' : 'bg-stone-50'}`}>
+                    <p className={`text-sm ${textPrimary} mb-2`}>
+                      GLANCEvault intents are always encrypted. Enter your sync passphrase to set up the encryption key.
+                    </p>
+                    <input
+                      type="password"
+                      autoFocus
+                      value={dbIntentsPassphraseInput}
+                      onChange={e => setDbIntentsPassphraseInput(e.target.value)}
+                      onKeyDown={e => { if (e.key === 'Escape') { setDbIntentsSetupPhase(null); setDbIntentsPassphraseInput(''); setDbIntentsEnabled(false); } }}
+                      placeholder="Your sync passphrase"
+                      className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm mb-2`}
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        disabled={!dbIntentsPassphraseInput.trim()}
+                        onClick={async () => {
+                          const passphrase = dbIntentsPassphraseInput.trim();
+                          setSyncPassphrase(passphrase);
+                          setDbIntentsPassphraseInput('');
+                          setDbIntentsSetupPhase('running');
+                          try {
+                            await setupVaultIntentsEncryption(passphrase);
+                          } catch (err) {
+                            setDbIntentsSetupPhase({ error: err.message });
+                            return;
+                          }
+                          const existing = getDbIntentsConfig() || {};
+                          setDbIntentsConfig({ ...existing, enabled: true });
+                          window.location.reload();
+                        }}
+                        className="px-3 py-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm"
+                      >
+                        Confirm
+                      </button>
+                      <button
+                        onClick={() => { setDbIntentsSetupPhase(null); setDbIntentsPassphraseInput(''); setDbIntentsEnabled(false); }}
+                        className={`px-3 py-1.5 ${darkMode ? 'bg-gray-600 hover:bg-gray-500' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} rounded-lg text-sm`}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                    <p className="text-xs text-amber-500 mt-2">
+                      Encryption setup is required — GLANCEvault intents won't be enabled until the key is set up.
+                    </p>
+                  </div>
+                )}
+                {dbIntentsSetupPhase === 'running' && (
+                  <div className={`flex items-center gap-2 p-3 rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700/50' : 'bg-stone-50'}`}>
+                    <Loader size={14} className="animate-spin text-blue-500" />
+                    <span className={`text-sm ${textSecondary}`}>Setting up vault intents encryption…</span>
+                  </div>
+                )}
+                {dbIntentsSetupPhase?.error && (
+                  <div className={`p-3 rounded-lg border border-red-300 ${darkMode ? 'bg-red-900/20' : 'bg-red-50'}`}>
+                    <p className="text-sm text-red-500">Setup failed: {dbIntentsSetupPhase.error}</p>
+                    <button
+                      onClick={() => { setDbIntentsSetupPhase(null); setDbIntentsEnabled(false); }}
+                      className="mt-1 text-xs text-red-400 hover:text-red-300 underline"
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                )}
+
                 <button
-                  onClick={() => {
+                  disabled={dbIntentsSetupPhase === 'running' || dbIntentsSetupPhase === 'passphrase-needed'}
+                  onClick={async () => {
                     // Match-by-construction: spread the EXISTING config and override
                     // only `enabled`, so ttlMs / pollIntervalMinutes are preserved.
                     // Persist via the config module's saver to the key the gate reads.
                     const existing = getDbIntentsConfig() || {};
                     const wasEnabled = !!existing.enabled;
+                    // Vault intents are always encrypted — derive + cache the vault
+                    // intents key BEFORE the reload (the passphrase is gone after).
+                    if (dbIntentsEnabled) {
+                      let res;
+                      try {
+                        res = await ensureVaultIntentsKey();
+                      } catch (err) {
+                        setDbIntentsSetupPhase({ error: err.message });
+                        return; // do NOT enable without a key
+                      }
+                      if (res.needsPassphrase) {
+                        setDbIntentsSetupPhase('passphrase-needed');
+                        return; // prompt; its confirm finishes save + reload
+                      }
+                    }
                     setDbIntentsConfig({ ...existing, enabled: dbIntentsEnabled });
                     // Reload-on-change so useDbIntentPoller remounts (mirrors the
                     // GLANCEvault sync toggle's behavior).

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -31,6 +31,7 @@ import { isAvailable as isICloudAvailable } from '../intents/icloudFileTransport
 import { getSyncPassphrase, setSyncPassphrase } from '../utils/crypto.js';
 import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
 import { ensureVaultIntentsKey, setupVaultIntentsEncryption } from '../intents/vaultIntentsSetup.js';
+import { flushOutboxNow } from '../intents/useOutboxFlush.js';
 import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
 import { useTranslation } from 'react-i18next';
 
@@ -2069,11 +2070,14 @@ const MobileSettingsPanel = () => {
                     }
                     setDbIntentsConfig({ ...existing, enabled: dbIntentsEnabled });
                     // Reload-on-change so useDbIntentPoller remounts (mirrors the
-                    // GLANCEvault sync toggle's behavior).
+                    // GLANCEvault sync toggle's behavior). The post-reload
+                    // useOutboxFlush mount drain flushes held intents now the key exists.
                     if (wasEnabled !== dbIntentsEnabled) {
                       window.location.reload();
                       return;
                     }
+                    // No reload (already enabled): key may have just been set up — flush now.
+                    await flushOutboxNow();
                     setDbIntentsSaved(true);
                     setTimeout(() => setDbIntentsSaved(false), 2000);
                   }}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -17,6 +17,7 @@ import { getSyncPassphrase, setSyncPassphrase } from '../utils/crypto.js';
 import { isVaultEnabled } from '../sync/vaultConfig.js';
 import { getDbIntentsConfig, setDbIntentsConfig, getDbIntentsConnection } from '../intents/dbIntentsConfig.js';
 import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
+import { ensureVaultIntentsKey, setupVaultIntentsEncryption } from '../intents/vaultIntentsSetup.js';
 import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
 import { useTranslation } from 'react-i18next';
 
@@ -116,6 +117,9 @@ const SettingsModal = () => {
   // connection is INHERITED from the GLANCEvault sync config (not edited here).
   const [dbIntentsEnabled, setDbIntentsEnabled] = useState(() => !!getDbIntentsConfig()?.enabled);
   const [dbIntentsSaved, setDbIntentsSaved] = useState(false);
+  // Vault intents key-setup phase: null | 'passphrase-needed' | 'running' | { error }.
+  const [dbIntentsSetupPhase, setDbIntentsSetupPhase] = useState(null);
+  const [dbIntentsPassphraseInput, setDbIntentsPassphraseInput] = useState('');
 
 
   const [trayHotkey, setTrayHotkey] = useState(() => localStorage.getItem('dg-tray-hotkey') || '');
@@ -2006,15 +2010,102 @@ const SettingsModal = () => {
                                 </div>
                               </div>
 
+                              {/* Vault intents are ALWAYS encrypted. Enabling derives + caches the
+                                  vault intents key BEFORE the reload (the passphrase is gone after).
+                                  Prompt only when the passphrase is actually unavailable. */}
+                              {dbIntentsSetupPhase === 'passphrase-needed' && (
+                                <div className={`p-3 rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700/50' : 'bg-stone-50'}`}>
+                                  <p className={`text-sm ${textPrimary} mb-2`}>
+                                    GLANCEvault intents are always encrypted. Enter your sync passphrase to set up the encryption key.
+                                  </p>
+                                  <input
+                                    type="password"
+                                    autoFocus
+                                    value={dbIntentsPassphraseInput}
+                                    onChange={e => setDbIntentsPassphraseInput(e.target.value)}
+                                    onKeyDown={e => { if (e.key === 'Escape') { setDbIntentsSetupPhase(null); setDbIntentsPassphraseInput(''); setDbIntentsEnabled(false); } }}
+                                    placeholder="Your sync passphrase"
+                                    className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm mb-2`}
+                                  />
+                                  <div className="flex gap-2">
+                                    <button
+                                      disabled={!dbIntentsPassphraseInput.trim()}
+                                      onClick={async () => {
+                                        const passphrase = dbIntentsPassphraseInput.trim();
+                                        setSyncPassphrase(passphrase);
+                                        setDbIntentsPassphraseInput('');
+                                        setDbIntentsSetupPhase('running');
+                                        try {
+                                          await setupVaultIntentsEncryption(passphrase);
+                                        } catch (err) {
+                                          setDbIntentsSetupPhase({ error: err.message });
+                                          return;
+                                        }
+                                        // Key cached — now persist the toggle and reload the poller.
+                                        const existing = getDbIntentsConfig() || {};
+                                        setDbIntentsConfig({ ...existing, enabled: true });
+                                        window.location.reload();
+                                      }}
+                                      className="px-3 py-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm"
+                                    >
+                                      {t('common.confirm')}
+                                    </button>
+                                    <button
+                                      onClick={() => { setDbIntentsSetupPhase(null); setDbIntentsPassphraseInput(''); setDbIntentsEnabled(false); }}
+                                      className={`px-3 py-1.5 ${darkMode ? 'bg-gray-600 hover:bg-gray-500' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} rounded-lg text-sm`}
+                                    >
+                                      {t('common.cancel')}
+                                    </button>
+                                  </div>
+                                  <p className="text-xs text-amber-500 mt-2">
+                                    Encryption setup is required — GLANCEvault intents won't be enabled until the key is set up.
+                                  </p>
+                                </div>
+                              )}
+                              {dbIntentsSetupPhase === 'running' && (
+                                <div className={`flex items-center gap-2 p-3 rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700/50' : 'bg-stone-50'}`}>
+                                  <Loader size={14} className="animate-spin text-blue-500" />
+                                  <span className={`text-sm ${textSecondary}`}>Setting up vault intents encryption…</span>
+                                </div>
+                              )}
+                              {dbIntentsSetupPhase?.error && (
+                                <div className={`p-3 rounded-lg border border-red-300 ${darkMode ? 'bg-red-900/20' : 'bg-red-50'}`}>
+                                  <p className="text-sm text-red-500">Setup failed: {dbIntentsSetupPhase.error}</p>
+                                  <button
+                                    onClick={() => { setDbIntentsSetupPhase(null); setDbIntentsEnabled(false); }}
+                                    className="mt-1 text-xs text-red-400 hover:text-red-300 underline"
+                                  >
+                                    Dismiss
+                                  </button>
+                                </div>
+                              )}
+
                               <div className="flex items-center gap-2 flex-wrap">
                                 <button
-                                  onClick={() => {
+                                  disabled={dbIntentsSetupPhase === 'running' || dbIntentsSetupPhase === 'passphrase-needed'}
+                                  onClick={async () => {
                                     // Match-by-construction: spread the EXISTING config and override
                                     // only `enabled`, so ttlMs / pollIntervalMinutes are preserved
                                     // (not re-seeded). Persist via the config module's own saver to
                                     // the exact key the gate reads.
                                     const existing = getDbIntentsConfig() || {};
                                     const wasEnabled = !!existing.enabled;
+                                    // Vault intents are always encrypted — make sure the vault intents
+                                    // key is derived + cached BEFORE the reload (the passphrase is gone
+                                    // after). Only when enabling (or on with no key cached yet).
+                                    if (dbIntentsEnabled) {
+                                      let res;
+                                      try {
+                                        res = await ensureVaultIntentsKey();
+                                      } catch (err) {
+                                        setDbIntentsSetupPhase({ error: err.message });
+                                        return; // do NOT enable without a key
+                                      }
+                                      if (res.needsPassphrase) {
+                                        setDbIntentsSetupPhase('passphrase-needed');
+                                        return; // prompt; its confirm finishes save + reload
+                                      }
+                                    }
                                     setDbIntentsConfig({ ...existing, enabled: dbIntentsEnabled });
                                     // Reload-on-change so useDbIntentPoller remounts and picks up the
                                     // new config (mirrors the GLANCEvault sync toggle's behavior).

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -18,6 +18,7 @@ import { isVaultEnabled } from '../sync/vaultConfig.js';
 import { getDbIntentsConfig, setDbIntentsConfig, getDbIntentsConnection } from '../intents/dbIntentsConfig.js';
 import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
 import { ensureVaultIntentsKey, setupVaultIntentsEncryption } from '../intents/vaultIntentsSetup.js';
+import { flushOutboxNow } from '../intents/useOutboxFlush.js';
 import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
 import { useTranslation } from 'react-i18next';
 
@@ -2108,11 +2109,16 @@ const SettingsModal = () => {
                                     }
                                     setDbIntentsConfig({ ...existing, enabled: dbIntentsEnabled });
                                     // Reload-on-change so useDbIntentPoller remounts and picks up the
-                                    // new config (mirrors the GLANCEvault sync toggle's behavior).
+                                    // new config (mirrors the GLANCEvault sync toggle's behavior). The
+                                    // post-reload useOutboxFlush mount drain flushes any held intents
+                                    // now that the vault key exists.
                                     if (wasEnabled !== dbIntentsEnabled) {
                                       window.location.reload();
                                       return;
                                     }
+                                    // No reload (already enabled): the key may have just been set up,
+                                    // so flush held intents now.
+                                    await flushOutboxNow();
                                     setDbIntentsSaved(true);
                                     setTimeout(() => setDbIntentsSaved(false), 2000);
                                   }}

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -50,6 +50,7 @@ import DatePicker from '../DatePicker.jsx';
 import ClockTimePicker from '../ClockTimePicker.jsx';
 import { emitGoalCreate } from '../../intents/emitGoalCreate.js';
 import { INTENT_CONFIG_KEY } from '../../intents/useIntentPoller.js';
+import { enabledIntentTargets } from '../../intents/emitTargets.js';
 
 // ─── Tiny helpers ─────────────────────────────────────────────────────────────
 
@@ -1944,11 +1945,17 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
   const [confirmDialog, setConfirmDialog] = useState(null); // { title, message, onConfirm }
   const [showArchived, setShowArchived] = useState(false);
 
-  const hasWebDAVIntents = useMemo(() => {
-    const raw = localStorage.getItem(INTENT_CONFIG_KEY);
-    if (!raw) return false;
-    const cfg = JSON.parse(raw);
-    return !!(cfg?.webdavUrl && cfg?.username && cfg?.appPassword);
+  // Show the "Track in lifeGLANCE" checkbox whenever ANY intents transport is
+  // enabled — WebDAV, iCloud, OR GLANCEvault — not just WebDAV. emitGoalCreate
+  // delivers over whichever targets are enabled, so the share UI must follow the
+  // same enablement, otherwise a vault-only user can't share goals.
+  const hasIntentsTarget = useMemo(() => {
+    let cfg = null;
+    try {
+      const raw = localStorage.getItem(INTENT_CONFIG_KEY);
+      cfg = raw ? JSON.parse(raw) : null;
+    } catch { cfg = null; }
+    return enabledIntentTargets(cfg).length > 0;
   }, []);
 
   // Trigger props from header buttons (mobile embedded mode)
@@ -2134,7 +2141,7 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
         </div>
         {goalForm && (
           <FormOverlay onClose={() => setGoalForm(null)} mobile cardBg={cardBg}>
-            <GoalForm initial={goalForm.editing} onSave={handleSaveGoal} onDelete={goalForm.editing ? () => handleDeleteGoal(goalForm.editing.id) : undefined} onCancel={() => setGoalForm(null)} mobile showLifeGlanceCheckbox={hasWebDAVIntents} />
+            <GoalForm initial={goalForm.editing} onSave={handleSaveGoal} onDelete={goalForm.editing ? () => handleDeleteGoal(goalForm.editing.id) : undefined} onCancel={() => setGoalForm(null)} mobile showLifeGlanceCheckbox={hasIntentsTarget} />
           </FormOverlay>
         )}
         {projectForm && (
@@ -2307,7 +2314,7 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
             onCancel={() => setGoalForm(null)}
             onDelete={goalForm.editing ? () => handleDeleteGoal(goalForm.editing.id) : undefined}
             mobile={isMobile}
-            showLifeGlanceCheckbox={hasWebDAVIntents}
+            showLifeGlanceCheckbox={hasIntentsTarget}
           />
         </FormOverlay>
       )}

--- a/src/intents/dbIntentsReceive.test.js
+++ b/src/intents/dbIntentsReceive.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { buildEnvelope, buildEncryptedEnvelope, deriveIntentsRootKey, deriveEnvelopeKey } from '@glance-apps/intents';
+
+// Mock the intent handler so we can prove a row was (or was NOT) routed without
+// standing up the full app context. routeIncoming calls handleIntent only for
+// rows it accepts; a rejected plaintext row must never reach it.
+vi.mock('./handleIntent.js', () => ({ handleIntent: vi.fn(async () => ({ success: true })) }));
+
+import { routeIncoming } from './dbIntentsTransport.js';
+import { handleIntent } from './handleIntent.js';
+import { getActivityLog } from './intentLog.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Vault RECEIVE: zero-knowledge plaintext rejection. routeIncoming is handed the
+// DECODED envelope object (parseIntentRow already base64-decoded it). A plaintext
+// row over the vault is a contract violation → rejected (permanent), logged, and
+// NEVER routed; an encrypted row decrypts with the vault key and routes normally.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+beforeEach(() => { global.localStorage = memLocalStorage(); handleIntent.mockClear(); });
+afterAll(() => { delete global.localStorage; });
+
+// FOREIGN emitted_by so the loopback guard (emitted_by === 'app.dayglance')
+// doesn't short-circuit before the encrypted/plaintext decision.
+function validPayload() {
+  return {
+    event_id: 'evt-1', source_app: 'app.lifeglance', source_entity_id: 'se-1',
+    event: 'completed', task_id: 'task-1', title: 'inbound', timestamp: '2026-01-01T00:00:00.000Z', entity_type: 'task',
+  };
+}
+
+describe('vault receive plaintext rejection', () => {
+  it('(d) rejects a plaintext row: permanent, logged, never routed', async () => {
+    // A plaintext envelope (encrypted flag absent) — what buildEnvelope produces.
+    const env = buildEnvelope({
+      action: 'notify', payload: validPayload(), emittedBy: 'app.lifeglance', eventId: '20260101T000000Z-aaa111',
+    });
+    expect(env.encrypted).toBeUndefined(); // confirm it really is plaintext
+
+    const outcome = await routeIncoming(env, {});
+    expect(outcome).toBe('permanent');         // advanced past, not wedged
+    expect(handleIntent).not.toHaveBeenCalled(); // never routed
+    expect(getActivityLog()[0].error).toBe('plaintext_rejected'); // logged loudly
+  });
+
+  it('(d) processes an encrypted row normally (decrypts with the vault key, routes)', async () => {
+    const rootKey = await deriveIntentsRootKey('pw', new Uint8Array(16).fill(9));
+    const deriveKey = (salt) => deriveEnvelopeKey(rootKey, salt);
+    const env = await buildEncryptedEnvelope({
+      action: 'notify', payload: validPayload(), emittedBy: 'app.lifeglance', eventId: '20260101T000000Z-bbb222',
+    }, deriveKey);
+    expect(env.encrypted).toBe(true);
+
+    // Inject the vault-slot key loader so decryption uses the same key.
+    const outcome = await routeIncoming(env, {}, { loadKey: async () => rootKey });
+    expect(outcome).toBe('ok');
+    expect(handleIntent).toHaveBeenCalledTimes(1);
+    // Routed with the DECRYPTED action + payload.
+    expect(handleIntent.mock.calls[0][0]).toBe('notify');
+    expect(handleIntent.mock.calls[0][1].title).toBe('inbound');
+  });
+
+  it('(d) an encrypted row with NO vault key cached is held (permanent for this drain, no_root_key)', async () => {
+    const rootKey = await deriveIntentsRootKey('pw', new Uint8Array(16).fill(8));
+    const env = await buildEncryptedEnvelope({
+      action: 'notify', payload: validPayload(), emittedBy: 'app.lifeglance', eventId: '20260101T000000Z-ccc333',
+    }, (salt) => deriveEnvelopeKey(rootKey, salt));
+
+    const outcome = await routeIncoming(env, {}, { loadKey: async () => null });
+    expect(outcome).toBe('permanent');
+    expect(handleIntent).not.toHaveBeenCalled();
+    expect(getActivityLog()[0].error).toBe('no_root_key');
+  });
+});

--- a/src/intents/dbIntentsTransport.js
+++ b/src/intents/dbIntentsTransport.js
@@ -25,7 +25,6 @@
 
 import { useEffect, useRef } from 'react';
 import {
-  parseEnvelope,
   parseEncryptedEnvelope,
   deriveEnvelopeKey,
   NoKeyError,
@@ -38,7 +37,7 @@ import {
   parseSince,
   formatSince,
 } from '@glance-apps/intents';
-import { loadIntentsRootKey } from './intentsKeyStore.js';
+import { loadVaultIntentsRootKey } from './intentsKeyStore.js';
 import { handleIntent } from './handleIntent.js';
 import { logActivity } from './intentLog.js';
 import { MULTI_USER_CONFIG_KEY } from './useIntentPoller.js';
@@ -119,7 +118,7 @@ function clearFailure(seq) {
 // body) and return a plain { status, ok, body } object; the browser path uses
 // global fetch and is normalized to the same shape. Returns a function
 // (method, url, headers, body) => Promise<{ status, ok, body }>.
-function defaultVaultFetch() {
+export function defaultVaultFetch() {
   const bridge = typeof window !== 'undefined' ? window.DayGlanceNative : null;
   const isNativeApp = !!bridge?.httpRequest;
   const electronProxyFetch = typeof window !== 'undefined' && window.electronAPI?.isElectron
@@ -238,15 +237,20 @@ export async function sendIntentDb(envelope) {
 //                 advances past it; retrying is pointless.
 // A THROWN exception is NOT returned — it propagates to the caller, which treats
 // it as a maybe-transient handler error subject to bounded retry.
-async function routeIncoming(raw, context) {
+async function routeIncoming(raw, context, opts = {}) {
   // Skip our own events (loopback). Checked on the raw object before parsing
   // because our notify envelopes use a schema parseEnvelope rejects as malformed.
   if (raw?.emitted_by === APP_EMITTER) return 'ok';
 
+  // Vault rows are decrypted with the VAULT intents key slot (distinct from the
+  // WebDAV intents key) — the vault encrypts with that key, so it decrypts with
+  // it too. Injectable for tests; defaults to the real vault-slot loader.
+  const loadKey = opts.loadKey ?? loadVaultIntentsRootKey;
+
   let envelope;
   try {
     if (raw?.encrypted === true) {
-      const rootKey = await loadIntentsRootKey();
+      const rootKey = await loadKey();
       if (!rootKey) {
         console.warn('[db-intent] Skipping encrypted event — intents encryption not set up');
         logActivity({
@@ -257,7 +261,19 @@ async function routeIncoming(raw, context) {
       }
       envelope = await parseEncryptedEnvelope(raw, (salt) => deriveEnvelopeKey(rootKey, salt));
     } else {
-      envelope = parseEnvelope(raw);
+      // ZERO-KNOWLEDGE ENFORCEMENT: the vault must ONLY ever carry ciphertext.
+      // A row that is not encrypted is a contract violation — REJECT it. Never
+      // parse or route it. Treat as permanent-bad so the drain advances past it
+      // (no wedge), exactly like an undecodable row.
+      console.error(
+        '[db-intent] REJECTING plaintext row on vault (zero-knowledge violation); eventId:',
+        raw?.event_id ?? null,
+      );
+      logActivity({
+        direction: 'in', action: 'unknown', event: null, source_app: null,
+        title: null, timestamp: new Date().toISOString(), status: 'error', error: 'plaintext_rejected',
+      });
+      return 'permanent';
     }
   } catch (parseErr) {
     let errorCode = parseErr.name ?? 'parse_error';
@@ -521,4 +537,4 @@ export function useDbIntentPoller(context) {
 }
 
 // Exported for tests.
-export { DB_CURSOR_KEY, DB_RETRY_KEY, MAX_INTENT_RETRIES };
+export { DB_CURSOR_KEY, DB_RETRY_KEY, MAX_INTENT_RETRIES, routeIncoming };

--- a/src/intents/deliverers.js
+++ b/src/intents/deliverers.js
@@ -1,0 +1,231 @@
+// Intents DELIVERERS (stage 2a).
+//
+// A deliverer is the function the durable outbox calls at flush time for one
+// transport: `async (intent) => 'delivered' | 'transient' | 'permanent'`. The
+// outbox stores and hands over the RAW intent (action + payload + emit metadata,
+// keyed by event_id); the deliverer is where the envelope is BUILT and, where
+// the transport requires it, ENCRYPTED. So encryption happens at flush, and a
+// plaintext envelope is never persisted.
+//
+// RESULT CONTRACT (never throw to signal an expected failure):
+//   'delivered' — landed on the remote (2xx). The outbox drops the target.
+//   'transient' — maybe-temporary: no key yet, no connection, network error, 5xx,
+//                 429/408. The outbox holds the intent and retries.
+//   'permanent' — will never succeed as-is: a 4xx rejecting the row, or a target
+//                 that is misconfigured in a way retrying can't fix. The outbox
+//                 gives that target up.
+// An unexpected throw is also treated as transient by the outbox (never dropped),
+// but deliverers should RETURN the result for expected failures, not throw.
+//
+// This stage builds the deliverers only; wiring them to the outbox and the
+// emit-site enqueue is stage 2b. It does NOT derive or cache the vault intents
+// key and never prompts for a passphrase — the vault deliverer only LOADS an
+// already-cached vault key and returns 'transient' if it is absent.
+
+import {
+  buildEnvelope,
+  buildEncryptedEnvelope,
+  deriveEnvelopeKey,
+  buildIntentRow,
+} from '@glance-apps/intents';
+import { loadIntentsRootKey, loadVaultIntentsRootKey } from './intentsKeyStore.js';
+import { writeEventFile, writeEventFileICloud, INTENT_CONFIG_KEY } from './useIntentPoller.js';
+import { defaultVaultFetch } from './dbIntentsTransport.js';
+import {
+  getDbIntentsConnection,
+  getDbIntentsConfig,
+  DEFAULT_DB_INTENTS_TTL_MS,
+} from './dbIntentsConfig.js';
+import * as iCloudTransport from './icloudFileTransport.js';
+
+export const DELIVERED = 'delivered';
+export const TRANSIENT = 'transient';
+export const PERMANENT = 'permanent';
+
+// ─── shared helpers ──────────────────────────────────────────────────────────
+
+// Map a raw outbox intent to the param object the envelope builders expect. The
+// event_id is ALWAYS carried through as eventId so the built envelope's id (and
+// therefore the vault row's eventId and the WebDAV filename) is stable across
+// retries — the vault server is insert-only/idempotent on eventId, so a re-sent
+// already-delivered row is a server-side no-op.
+function toEnvelopeParams(intent) {
+  const eventId = intent.event_id ?? intent.eventId;
+  return {
+    action: intent.action,
+    payload: intent.payload,
+    emittedBy: intent.emitted_by ?? intent.emittedBy,
+    ...(eventId ? { eventId } : {}),
+  };
+}
+
+// The WebDAV intents config (shared by the WebDAV and iCloud file tiers). Read
+// from localStorage exactly like the existing emit sites do.
+function readIntentConfig() {
+  try {
+    const raw = localStorage.getItem(INTENT_CONFIG_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+// Map an HTTP-ish status to a deliverer result. 5xx / 429 / 408 are transient
+// (retry); other 4xx mean the server rejected the row itself → permanent.
+function mapHttpStatus(status) {
+  if (status >= 200 && status < 300) return DELIVERED;
+  if (status >= 500 || status === 429 || status === 408) return TRANSIENT;
+  if (status >= 400) return PERMANENT;
+  return TRANSIENT;
+}
+
+// ─── file-tier envelope (WebDAV + iCloud share the same encryption policy) ────
+//
+// Keeps the EXISTING file-tier confidentiality policy unchanged: encrypt iff the
+// WebDAV intents config has encryptionEnabled, otherwise plaintext. When
+// encryption is on but the WebDAV intents key isn't cached yet (setup
+// incomplete / mid-restore), we signal HOLD so the deliverer returns 'transient'
+// — never a silent plaintext fallback.
+//
+// Returns { hold: true } to defer, or { envelope } to send.
+async function buildFileTierEnvelope(intent, config, opts) {
+  if (config?.encryptionEnabled) {
+    const rootKey = await (opts.loadWebdavKey ?? loadIntentsRootKey)();
+    if (!rootKey) return { hold: true };
+    const deriveKey = (salt) => deriveEnvelopeKey(rootKey, salt);
+    return { envelope: await buildEncryptedEnvelope(toEnvelopeParams(intent), deriveKey) };
+  }
+  return { envelope: buildEnvelope(toEnvelopeParams(intent)) };
+}
+
+// ─── 1. VAULT deliverer — ALWAYS ENCRYPTED ───────────────────────────────────
+
+/**
+ * Deliver one intent to GLANCEvault. The vault is zero-knowledge: this path is
+ * ALWAYS encrypted and has NO plaintext branch. It loads the cached VAULT intents
+ * key (its own slot, distinct from the WebDAV key); if that key is absent it
+ * sends NOTHING, builds NO envelope, and returns 'transient' so the outbox holds
+ * the intent until stage 2b's setup has derived and cached the key.
+ *
+ * @param {object} intent  - raw outbox intent (action, payload, emit metadata, event_id)
+ * @param {object} [opts]  - injection seams for tests (loadKey, connection, config, vaultFetch)
+ * @returns {Promise<'delivered'|'transient'|'permanent'>}
+ */
+export async function vaultDeliverer(intent, opts = {}) {
+  const connection = opts.connection ?? getDbIntentsConnection();
+  // No vault connection configured yet — hold (may appear); never drop.
+  if (!connection) return TRANSIENT;
+
+  // ── load the ALREADY-CACHED vault intents key (its OWN slot) ──
+  const rootKey = await (opts.loadKey ?? loadVaultIntentsRootKey)();
+  if (!rootKey) {
+    // Key not set up yet (or mid-restore). Send nothing, build nothing, hold.
+    return TRANSIENT;
+  }
+
+  // ── ALWAYS-ENCRYPTED envelope (no plaintext branch, ever) ──
+  let envelope;
+  try {
+    const deriveKey = (salt) => deriveEnvelopeKey(rootKey, salt);
+    envelope = await buildEncryptedEnvelope(toEnvelopeParams(intent), deriveKey);
+  } catch (err) {
+    // Unexpected crypto/build failure — hold rather than drop.
+    console.warn('[deliver/vault] envelope build failed:', err?.message);
+    return TRANSIENT;
+  }
+
+  // ── encode the row and POST /intents/batch (insert-only, idempotent) ──
+  const cfg = opts.config ?? getDbIntentsConfig() ?? {};
+  const ttlMs = cfg.ttlMs ?? DEFAULT_DB_INTENTS_TTL_MS;
+  const row = buildIntentRow(envelope, { ttlMs });
+  const body = {
+    accountId: connection.accountId,
+    events: [{ eventId: row.eventId, envelope: row.envelope, expiresAt: row.expiresAt }],
+  };
+  const url = connection.vaultUrl.replace(/\/+$/, '') + '/intents/batch';
+  const headers = { Authorization: `Bearer ${connection.vaultToken}`, 'Content-Type': 'application/json' };
+  const vaultFetch = opts.vaultFetch ?? defaultVaultFetch();
+
+  let res;
+  try {
+    res = await vaultFetch('POST', url, headers, JSON.stringify(body));
+  } catch (err) {
+    // Network error — transient.
+    console.warn('[deliver/vault] POST network error:', err?.message);
+    return TRANSIENT;
+  }
+  if (!res) return TRANSIENT;
+  return mapHttpStatus(res.status);
+}
+
+// ─── 2. WEBDAV deliverer — existing encryption policy, durable wrapper ────────
+
+/**
+ * Deliver one intent to the WebDAV file tier, preserving WebDAV's EXISTING
+ * confidentiality policy (encrypted iff WebDAV encryptionEnabled, else plaintext).
+ * This fix changes durability, not WebDAV confidentiality.
+ *
+ * @param {object} intent
+ * @param {object} [opts] - test seams (config, loadWebdavKey, writeEventFile)
+ * @returns {Promise<'delivered'|'transient'|'permanent'>}
+ */
+export async function webdavDeliverer(intent, opts = {}) {
+  const config = opts.config ?? readIntentConfig();
+  // Not configured for WebDAV — retrying won't write a file. Permanent for this
+  // target (the other transports still run independently in the outbox).
+  if (!config?.webdavUrl || !config?.username || !config?.appPassword) return PERMANENT;
+
+  const built = await buildFileTierEnvelope(intent, config, opts);
+  if (built.hold) return TRANSIENT; // encryption on, key not ready yet
+
+  const put = opts.writeEventFile ?? writeEventFile;
+  let res;
+  try {
+    res = await put(config, built.envelope);
+  } catch (err) {
+    console.warn('[deliver/webdav] PUT network error:', err?.message);
+    return TRANSIENT;
+  }
+  if (res === undefined) return PERMANENT; // config vanished — won't self-heal
+  return mapHttpStatus(res.status);
+}
+
+// ─── 3. ICLOUD deliverer — mirrors WebDAV over the iCloud write path ──────────
+
+/**
+ * Deliver one intent to the iCloud file tier, same encryption policy as WebDAV.
+ * iCloud has no HTTP status: a write either succeeds or doesn't, and both
+ * "unavailable" and "write failed" are retryable → 'transient'.
+ *
+ * @param {object} intent
+ * @param {object} [opts] - test seams (config, loadWebdavKey, isAvailable, writeEventFileICloud)
+ * @returns {Promise<'delivered'|'transient'|'permanent'>}
+ */
+export async function icloudDeliverer(intent, opts = {}) {
+  const isAvailable = opts.isAvailable ?? iCloudTransport.isAvailable;
+  // iCloud not available on this platform/session — may become available; hold.
+  if (!isAvailable()) return TRANSIENT;
+
+  const config = opts.config ?? readIntentConfig();
+  const built = await buildFileTierEnvelope(intent, config, opts);
+  if (built.hold) return TRANSIENT; // encryption on, key not ready yet
+
+  const write = opts.writeEventFileICloud ?? writeEventFileICloud;
+  let ok;
+  try {
+    ok = await write(config, built.envelope);
+  } catch (err) {
+    console.warn('[deliver/icloud] write error:', err?.message);
+    return TRANSIENT;
+  }
+  return ok ? DELIVERED : TRANSIENT;
+}
+
+// Convenience map keyed by the outbox's transport names. Each value is directly
+// usable as an outbox deliverer (the second opts arg defaults), so stage 2b can
+// pass this straight to flush().
+export const deliverers = {
+  webdav: webdavDeliverer,
+  icloud: icloudDeliverer,
+  vault: vaultDeliverer,
+};

--- a/src/intents/deliverers.test.js
+++ b/src/intents/deliverers.test.js
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { deriveIntentsRootKey } from '@glance-apps/intents';
+import {
+  vaultDeliverer,
+  webdavDeliverer,
+  icloudDeliverer,
+  DELIVERED,
+  TRANSIENT,
+  PERMANENT,
+} from './deliverers.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Intents deliverers (stage 2a). These exercise the REAL deliverers and the REAL
+// @glance-apps/intents codec (deriveIntentsRootKey / buildEncryptedEnvelope /
+// buildIntentRow) with all transport I/O injected — no network, no IndexedDB.
+//
+// The vault deliverer is ALWAYS encrypted: with a key it builds ciphertext and
+// POSTs; with no key it returns 'transient' and sends/builds nothing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+beforeEach(() => { global.localStorage = memLocalStorage(); });
+afterAll(() => { delete global.localStorage; });
+
+const CONN = { vaultUrl: 'https://vault.example.com', vaultToken: 'tok-123', accountId: 'acct-1' };
+
+// A schema-valid notify payload (buildEnvelope validates the plaintext payload).
+function validPayload(title = 'SECRET-TITLE') {
+  return {
+    event_id: 'evt-1',
+    source_app: 'app.testglance',
+    source_entity_id: 'se-1',
+    event: 'completed',
+    task_id: 'task-1',
+    title,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    entity_type: 'task',
+  };
+}
+
+// A raw outbox intent (NOT an envelope): action + payload + emit metadata, keyed
+// by event_id. emitted_by is a FOREIGN app so nothing is treated as loopback.
+function makeIntent(eventId = '20260101T000000Z-aaa111', title = 'SECRET-TITLE') {
+  return {
+    event_id: eventId,
+    action: 'notify',
+    emitted_by: 'app.testglance',
+    payload: validPayload(title),
+  };
+}
+
+function decodeRowEnvelope(b64) {
+  return JSON.parse(Buffer.from(b64, 'base64').toString('utf8'));
+}
+
+async function aRootKey(seed = 1) {
+  return deriveIntentsRootKey('pw', new Uint8Array(16).fill(seed));
+}
+
+// ─── 1. VAULT deliverer ───────────────────────────────────────────────────────
+
+describe('vault deliverer', () => {
+  // (a) WITH a cached key → builds an ENCRYPTED envelope and POSTs.
+  it('(a) with a cached key builds ciphertext and POSTs /intents/batch', async () => {
+    const captured = [];
+    const vaultFetch = vi.fn(async (method, url, headers, body) => {
+      captured.push({ method, url, headers, body });
+      return { status: 200, ok: true, body: JSON.stringify({ written: 1, maxSeq: 7 }) };
+    });
+    const rootKey = await aRootKey();
+
+    const result = await vaultDeliverer(makeIntent(), {
+      connection: CONN, config: { ttlMs: 1000 }, vaultFetch, loadKey: async () => rootKey,
+    });
+
+    expect(result).toBe(DELIVERED);
+    expect(vaultFetch).toHaveBeenCalledTimes(1);
+    expect(captured[0].method).toBe('POST');
+    expect(captured[0].url).toBe('https://vault.example.com/intents/batch');
+    expect(captured[0].headers.Authorization).toBe('Bearer tok-123');
+
+    const sent = JSON.parse(captured[0].body);
+    expect(sent.accountId).toBe('acct-1');
+    expect(sent.events).toHaveLength(1);
+
+    // The row envelope must be CIPHERTEXT, not plaintext.
+    const env = decodeRowEnvelope(sent.events[0].envelope);
+    expect(env.encrypted).toBe(true);
+    expect(env.payload_ciphertext).toBeDefined();
+    expect(env).not.toHaveProperty('payload');     // no plaintext payload
+    expect(env).not.toHaveProperty('action');      // encrypted envelope hides action too
+    // And the secret never appears anywhere in the wire bytes.
+    expect(Buffer.from(sent.events[0].envelope, 'base64').toString('utf8')).not.toContain('SECRET-TITLE');
+  });
+
+  // (b) NO cached key → 'transient', sends nothing, builds nothing.
+  it('(b) with no cached key returns transient and sends nothing', async () => {
+    const vaultFetch = vi.fn();
+    const result = await vaultDeliverer(makeIntent(), {
+      connection: CONN, vaultFetch, loadKey: async () => null,
+    });
+    expect(result).toBe(TRANSIENT);
+    expect(vaultFetch).not.toHaveBeenCalled();
+  });
+
+  it('(b2) with no vault connection returns transient and sends nothing', async () => {
+    const vaultFetch = vi.fn();
+    const result = await vaultDeliverer(makeIntent(), {
+      connection: null, vaultFetch, loadKey: async () => 'should-not-be-loaded',
+    });
+    expect(result).toBe(TRANSIENT);
+    expect(vaultFetch).not.toHaveBeenCalled();
+  });
+
+  // (c) NEVER produces a plaintext envelope under any condition — including when
+  //     the WebDAV-style encryptionEnabled flag is false/absent (vault ignores it).
+  it('(c) always encrypts even when encryptionEnabled is false; never plaintext', async () => {
+    const captured = [];
+    const vaultFetch = async (m, u, h, body) => { captured.push(body); return { status: 200, ok: true, body: '{}' }; };
+    const rootKey = await aRootKey(2);
+
+    // encryptionEnabled deliberately false — vault must STILL encrypt.
+    const result = await vaultDeliverer(makeIntent(), {
+      connection: CONN, config: { ttlMs: 1000, encryptionEnabled: false }, vaultFetch, loadKey: async () => rootKey,
+    });
+    expect(result).toBe(DELIVERED);
+    const env = decodeRowEnvelope(JSON.parse(captured[0]).events[0].envelope);
+    expect(env.encrypted).toBe(true);
+    expect(env).not.toHaveProperty('payload');
+  });
+
+  // Outcome mapping for the vault POST.
+  it('maps 5xx → transient, 4xx → permanent, network throw → transient', async () => {
+    const rootKey = await aRootKey(3);
+    const run = (fetchImpl) => vaultDeliverer(makeIntent(), {
+      connection: CONN, config: { ttlMs: 1000 }, vaultFetch: fetchImpl, loadKey: async () => rootKey,
+    });
+
+    expect(await run(async () => ({ status: 503, ok: false, body: '' }))).toBe(TRANSIENT);
+    expect(await run(async () => ({ status: 429, ok: false, body: '' }))).toBe(TRANSIENT);
+    expect(await run(async () => ({ status: 400, ok: false, body: '' }))).toBe(PERMANENT);
+    expect(await run(async () => { throw new TypeError('Failed to fetch'); })).toBe(TRANSIENT);
+  });
+});
+
+// ─── 2. WEBDAV deliverer ───────────────────────────────────────────────────────
+
+describe('webdav deliverer', () => {
+  const WEBDAV = { webdavUrl: 'https://dav.example.com', username: 'u', appPassword: 'p' };
+
+  it('(e) success → delivered; 5xx → transient; 4xx → permanent; throw → transient', async () => {
+    const run = (writeImpl, config = WEBDAV) =>
+      webdavDeliverer(makeIntent(), { config, writeEventFile: writeImpl });
+
+    expect(await run(async () => ({ ok: true, status: 201 }))).toBe(DELIVERED);
+    expect(await run(async () => ({ ok: false, status: 502 }))).toBe(TRANSIENT);
+    expect(await run(async () => ({ ok: false, status: 400 }))).toBe(PERMANENT);
+    expect(await run(async () => { throw new TypeError('Failed to fetch'); })).toBe(TRANSIENT);
+  });
+
+  it('(e) not configured → permanent (won\'t self-heal on retry)', async () => {
+    const write = vi.fn();
+    const result = await webdavDeliverer(makeIntent(), { config: null, writeEventFile: write });
+    expect(result).toBe(PERMANENT);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('preserves WebDAV policy: plaintext when encryptionEnabled is false', async () => {
+    let sentEnvelope;
+    const write = async (config, envelope) => { sentEnvelope = envelope; return { ok: true, status: 201 }; };
+    const result = await webdavDeliverer(makeIntent(), { config: { ...WEBDAV, encryptionEnabled: false }, writeEventFile: write });
+    expect(result).toBe(DELIVERED);
+    expect(sentEnvelope.encrypted).toBeUndefined();   // plaintext, per existing WebDAV policy
+    expect(sentEnvelope.payload).toBeDefined();
+  });
+
+  it('preserves WebDAV policy: encrypted when encryptionEnabled and key present', async () => {
+    let sentEnvelope;
+    const write = async (config, envelope) => { sentEnvelope = envelope; return { ok: true, status: 201 }; };
+    const rootKey = await aRootKey(4);
+    const result = await webdavDeliverer(makeIntent(), {
+      config: { ...WEBDAV, encryptionEnabled: true }, loadWebdavKey: async () => rootKey, writeEventFile: write,
+    });
+    expect(result).toBe(DELIVERED);
+    expect(sentEnvelope.encrypted).toBe(true);
+    expect(sentEnvelope).not.toHaveProperty('payload');
+  });
+
+  it('encryption on but key not ready → transient, writes nothing', async () => {
+    const write = vi.fn();
+    const result = await webdavDeliverer(makeIntent(), {
+      config: { ...WEBDAV, encryptionEnabled: true }, loadWebdavKey: async () => null, writeEventFile: write,
+    });
+    expect(result).toBe(TRANSIENT);
+    expect(write).not.toHaveBeenCalled();
+  });
+});
+
+// ─── 3. ICLOUD deliverer ───────────────────────────────────────────────────────
+
+describe('icloud deliverer', () => {
+  it('(e) write true → delivered; write false → transient; unavailable → transient; throw → transient', async () => {
+    const base = { config: { encryptionEnabled: false }, isAvailable: () => true };
+
+    expect(await icloudDeliverer(makeIntent(), { ...base, writeEventFileICloud: async () => true })).toBe(DELIVERED);
+    expect(await icloudDeliverer(makeIntent(), { ...base, writeEventFileICloud: async () => false })).toBe(TRANSIENT);
+    expect(await icloudDeliverer(makeIntent(), { ...base, isAvailable: () => false, writeEventFileICloud: vi.fn() })).toBe(TRANSIENT);
+    expect(await icloudDeliverer(makeIntent(), { ...base, writeEventFileICloud: async () => { throw new Error('fs'); } })).toBe(TRANSIENT);
+  });
+
+  it('does not write when iCloud is unavailable', async () => {
+    const write = vi.fn();
+    const result = await icloudDeliverer(makeIntent(), { config: {}, isAvailable: () => false, writeEventFileICloud: write });
+    expect(result).toBe(TRANSIENT);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('encryption on but key not ready → transient, writes nothing', async () => {
+    const write = vi.fn();
+    const result = await icloudDeliverer(makeIntent(), {
+      config: { encryptionEnabled: true }, isAvailable: () => true, loadWebdavKey: async () => null, writeEventFileICloud: write,
+    });
+    expect(result).toBe(TRANSIENT);
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/src/intents/emitGoalCreate.js
+++ b/src/intents/emitGoalCreate.js
@@ -1,19 +1,21 @@
-import { buildEnvelope, buildEncryptedEnvelope, ENTITY_TYPES, SOURCE_APPS, deriveEnvelopeKey } from '@glance-apps/intents';
-import { loadIntentsRootKey } from './intentsKeyStore.js';
-import { writeEventFile, writeEventFileICloud, INTENT_CONFIG_KEY } from './useIntentPoller.js';
-import { sendIntentDb } from './dbIntentsTransport.js';
-import { isDbIntentsEnabled } from './dbIntentsConfig.js';
+import { ENTITY_TYPES, SOURCE_APPS } from '@glance-apps/intents';
+import { INTENT_CONFIG_KEY } from './useIntentPoller.js';
+import { enabledIntentTargets } from './emitTargets.js';
+import { enqueueAndFlush } from './outboxEmit.js';
 import { logActivity } from './intentLog.js';
 
 /**
  * Emit an outbound `create` intent for a dayGLANCE Goal so lifeGLANCE can
  * pick it up and create a mirrored milestone.
  *
- * Fire-and-forget: the caller does not need to await this.
- * No-ops silently if the WebDAV intents config is absent.
+ * Fire-and-forget: the caller does not need to await this. The intent is queued
+ * in the durable outbox (so it survives failures/restarts) and a flush is
+ * triggered; encryption happens at flush inside the per-target deliverer.
+ * No-ops silently if no transport target is enabled.
  */
 // Produces a stable event_id in the required `20260607T014953Z-xxxxxx` format,
-// derived deterministically from the goal so retries emit the same filename.
+// derived deterministically from the goal so retries reuse the same id (it is
+// the outbox entry id AND the server idempotency key).
 async function stableEventId(goal) {
   const ts = new Date(goal.createdAt)
     .toISOString()
@@ -30,10 +32,11 @@ async function stableEventId(goal) {
 export async function emitGoalCreate(goal) {
   const raw = localStorage.getItem(INTENT_CONFIG_KEY);
   const config = raw ? JSON.parse(raw) : null;
-  const hasWebDAV = !!(config?.webdavUrl && config?.username && config?.appPassword);
-  // The DB intents transport runs alongside WebDAV and may be enabled on its own,
-  // so don't bail when WebDAV is absent if DB intents is active.
-  if (!hasWebDAV && !isDbIntentsEnabled()) return;
+
+  // Targets enabled for this emit ('webdav' | 'icloud' | 'vault'). Nothing
+  // enabled → nowhere to send; no-op.
+  const targets = enabledIntentTargets(config);
+  if (targets.length === 0) return;
 
   const payload = {
     title: goal.title,
@@ -45,55 +48,30 @@ export async function emitGoalCreate(goal) {
 
   const now = new Date().toISOString();
 
-  let deriveKey = null;
-  if (config?.encryptionEnabled) {
-    const rootKey = await loadIntentsRootKey();
-    if (!rootKey) {
-      console.warn('[goal-create] intents encryption setup incomplete — skipping emit');
-      logActivity({
-        direction: 'out',
-        action: 'create',
-        event: null,
-        source_app: SOURCE_APPS.DAYGLANCE,
-        title: goal.title,
-        timestamp: now,
-        status: 'error',
-        error: 'setup_incomplete',
-      });
-      return;
-    }
-    deriveKey = (salt) => deriveEnvelopeKey(rootKey, salt);
-  }
+  const eventId = await stableEventId(goal);
+  // RAW intent — encryption happens at flush in the per-target deliverer. The
+  // deterministic eventId is the outbox id AND the server idempotency key.
+  const intent = {
+    event_id: eventId,
+    action: 'create',
+    emitted_by: SOURCE_APPS.DAYGLANCE,
+    payload,
+  };
 
-  try {
-    const eventId = await stableEventId(goal);
-    const envelope = deriveKey
-      ? await buildEncryptedEnvelope({ action: 'create', payload, emittedBy: SOURCE_APPS.DAYGLANCE, eventId }, deriveKey)
-      : buildEnvelope({ action: 'create', payload, emittedBy: SOURCE_APPS.DAYGLANCE, eventId });
-    await writeEventFile(config, envelope);
-    await writeEventFileICloud(config, envelope);
-    await sendIntentDb(envelope);  // DB intents transport (no-ops unless enabled)
-    logActivity({
-      direction: 'out',
-      action: 'create',
-      event: null,
-      source_app: SOURCE_APPS.DAYGLANCE,
-      title: goal.title,
-      timestamp: now,
-      status: 'ok',
-      error: null,
-    });
-  } catch (err) {
-    console.warn('[goal-create] emit failed for goal', goal.id, ':', err.message);
-    logActivity({
-      direction: 'out',
-      action: 'create',
-      event: null,
-      source_app: SOURCE_APPS.DAYGLANCE,
-      title: goal.title,
-      timestamp: now,
-      status: 'error',
-      error: err.name ?? err.message,
-    });
-  }
+  await enqueueAndFlush([{
+    intent,
+    onOk: () => logActivity({
+      direction: 'out', action: 'create', event: null,
+      source_app: SOURCE_APPS.DAYGLANCE, title: goal.title, timestamp: now,
+      status: 'ok', error: null,
+    }),
+    onError: (err) => {
+      console.warn('[goal-create] enqueue failed for goal', goal.id, ':', err.message);
+      logActivity({
+        direction: 'out', action: 'create', event: null,
+        source_app: SOURCE_APPS.DAYGLANCE, title: goal.title, timestamp: now,
+        status: 'error', error: err.name ?? err.message,
+      });
+    },
+  }], targets);
 }

--- a/src/intents/emitGoalCreate.test.js
+++ b/src/intents/emitGoalCreate.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { SOURCE_APPS } from '@glance-apps/intents';
+
+// Capture what the emit site hands to the outbox bridge.
+vi.mock('./outboxEmit.js', () => ({ enqueueAndFlush: vi.fn(async () => true) }));
+
+import { emitGoalCreate } from './emitGoalCreate.js';
+import { enqueueAndFlush } from './outboxEmit.js';
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+beforeEach(() => {
+  global.localStorage = memLocalStorage();
+  enqueueAndFlush.mockClear();
+  // WebDAV intents configured + GLANCEvault intents enabled (vault connection present).
+  localStorage.setItem('dayglance-intent-config', JSON.stringify({ webdavUrl: 'https://dav', username: 'u', appPassword: 'p' }));
+  localStorage.setItem('dayglance-db-intents-config', JSON.stringify({ enabled: true }));
+  localStorage.setItem('dayglance-vault-config', JSON.stringify({ enabled: true, vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' }));
+});
+afterAll(() => { delete global.localStorage; });
+
+describe('emitGoalCreate → outbox (stage 2b-ii)', () => {
+  it('(a) enqueues a RAW intent (not an envelope) with a stable event_id and the enabled targets', async () => {
+    const goal = { id: 'goal-1', title: 'My Goal', targetDate: '2026-08-01', createdAt: '2026-06-07T01:49:53.123Z' };
+    await emitGoalCreate(goal);
+
+    expect(enqueueAndFlush).toHaveBeenCalledTimes(1);
+    const [items, targets] = enqueueAndFlush.mock.calls[0];
+    const intent = items[0].intent;
+
+    // RAW intent shape.
+    expect(intent.action).toBe('create');
+    expect(intent.emitted_by).toBe(SOURCE_APPS.DAYGLANCE);
+    expect(intent.payload).toBeDefined();
+    expect(intent.payload.title).toBe('My Goal');
+    expect(intent.payload.source_entity_id).toBe('goal-1');
+
+    // Stable event_id in the required compact format, used as the outbox id.
+    expect(intent.event_id).toMatch(/^\d{8}T\d{6}Z-[0-9a-f]{6}$/);
+
+    // NOT an envelope — no envelope/ciphertext fields are present.
+    expect(intent).not.toHaveProperty('encrypted');
+    expect(intent).not.toHaveProperty('payload_ciphertext');
+    expect(intent).not.toHaveProperty('salt');
+    expect(intent).not.toHaveProperty('iv');
+    expect(intent).not.toHaveProperty('schema_version');
+
+    // Enabled targets: WebDAV + vault (iCloud unavailable in this environment).
+    expect(targets).toEqual(['webdav', 'vault']);
+  });
+
+  it('emits the SAME stable event_id on a repeat emit (idempotency key is deterministic)', async () => {
+    const goal = { id: 'goal-1', title: 'My Goal', createdAt: '2026-06-07T01:49:53.123Z' };
+    await emitGoalCreate(goal);
+    await emitGoalCreate(goal);
+    const id1 = enqueueAndFlush.mock.calls[0][0][0].intent.event_id;
+    const id2 = enqueueAndFlush.mock.calls[1][0][0].intent.event_id;
+    expect(id1).toBe(id2);
+  });
+
+  it('no-ops when no transport target is enabled', async () => {
+    localStorage.clear();
+    await emitGoalCreate({ id: 'g', title: 'x', createdAt: '2026-06-07T01:49:53.123Z' });
+    expect(enqueueAndFlush).not.toHaveBeenCalled();
+  });
+});

--- a/src/intents/emitIntegration.test.js
+++ b/src/intents/emitIntegration.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from 'vitest';
+import { deriveIntentsRootKey } from '@glance-apps/intents';
+import { enqueue, flush, pendingCount, list, PENDING, DELIVERED, GIVEN_UP } from './outbox.js';
+import { enqueueAndFlush } from './outboxEmit.js';
+import { vaultDeliverer } from './deliverers.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// emit -> outbox -> flush(deliverers) integration (stage 2b-ii). Uses the REAL
+// outbox and an injected in-memory store (the repo has no fake-indexeddb), plus
+// real / fake deliverers. Covers delivery + removal, the held-vault-no-loss case,
+// the snapshot-advance gate, and a real-vault-deliverer encrypted-row roundtrip.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function createMemoryStore() {
+  const m = new Map();
+  const clone = (v) => JSON.parse(JSON.stringify(v));
+  return {
+    async getAll() { return [...m.values()].map(clone); },
+    async get(id) { return m.has(id) ? clone(m.get(id)) : undefined; },
+    async put(e) { m.set(e.id, clone(e)); },
+    async delete(id) { m.delete(id); },
+  };
+}
+
+// A raw intent exactly as the emit sites build it.
+function rawNotify(eventId = '20260101T000000Z-aaa111', title = 'SECRET-TITLE') {
+  return {
+    event_id: eventId,
+    action: 'notify',
+    emitted_by: 'app.dayglance',
+    payload: {
+      event_id: eventId, source_app: 'app.testglance', source_entity_id: 'se-1',
+      event: 'completed', task_id: 'task-1', title, timestamp: '2026-01-01T00:00:00.000Z', entity_type: 'task',
+    },
+  };
+}
+
+// (b) after enqueue, a flush delivers via the deliverers and the entry is removed.
+describe('(b) enqueue → flush delivers and removes on success', () => {
+  it('removes the entry once the (only) target delivers', async () => {
+    const store = createMemoryStore();
+    await enqueue(rawNotify(), ['webdav'], { store });
+    expect(await pendingCount({ store })).toBe(1);
+
+    const webdav = vi.fn(async () => DELIVERED);
+    await flush({ webdav }, { store });
+
+    expect(webdav).toHaveBeenCalledTimes(1);
+    expect(await list({ store })).toHaveLength(0);
+  });
+});
+
+// (c) vault enabled but key absent → vault target stays pending (transient) and
+//     is retried, while webdav delivers — no loss.
+describe('(c) held vault target does not lose the intent', () => {
+  it('keeps the entry with webdav delivered + vault pending, then removes when vault delivers', async () => {
+    const store = createMemoryStore();
+    await enqueue(rawNotify(), ['webdav', 'vault'], { store });
+
+    // First flush: webdav delivers; vault has no key yet → transient.
+    await flush({ webdav: async () => DELIVERED, vault: async () => 'transient' }, { store });
+
+    let [entry] = await list({ store });
+    expect(entry.targets.webdav).toBe(DELIVERED);
+    expect(entry.targets.vault).toBe(PENDING);   // held, not lost
+    expect(await pendingCount({ store })).toBe(1);
+
+    // Later flush (key now present): vault delivers; webdav must NOT be re-sent.
+    const webdav2 = vi.fn(async () => DELIVERED);
+    await flush({ webdav: webdav2, vault: async () => DELIVERED }, { store });
+    expect(webdav2).not.toHaveBeenCalled();
+    expect(await list({ store })).toHaveLength(0);
+  });
+});
+
+// (d) the snapshot does not advance on a failed enqueue.
+describe('(d) snapshot-advance gate (enqueueAndFlush return value)', () => {
+  it('returns false when an enqueue fails (caller must NOT advance the snapshot)', async () => {
+    const flushSpy = vi.fn(async () => {});
+    const enqueueSpy = vi.fn(async () => { throw new Error('IDB write failed'); });
+    const onError = vi.fn();
+
+    const allEnqueued = await enqueueAndFlush(
+      [{ intent: rawNotify(), onError }],
+      ['vault'],
+      { enqueue: enqueueSpy, flush: flushSpy, deliverers: {} },
+    );
+
+    expect(allEnqueued).toBe(false);   // → the hook leaves prevRef unadvanced
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns true when every enqueue succeeds (caller advances the snapshot)', async () => {
+    const allEnqueued = await enqueueAndFlush(
+      [{ intent: rawNotify('e1'), onOk: vi.fn() }, { intent: rawNotify('e2'), onOk: vi.fn() }],
+      ['webdav'],
+      { enqueue: vi.fn(async () => {}), flush: vi.fn(async () => {}), deliverers: {} },
+    );
+    expect(allEnqueued).toBe(true);
+  });
+});
+
+// (e) end-to-end through the REAL vault deliverer: emit-shaped raw intent →
+//     enqueue → flush → vault deliverer builds an ENCRYPTED row and POSTs it.
+describe('(e) end-to-end: real vault deliverer builds an encrypted row', () => {
+  it('flushes a queued intent through vaultDeliverer producing ciphertext', async () => {
+    const store = createMemoryStore();
+    const CONN = { vaultUrl: 'https://vault.example.com', vaultToken: 'tok-123', accountId: 'acct-1' };
+    const rootKey = await deriveIntentsRootKey('pw', new Uint8Array(16).fill(5));
+
+    const captured = [];
+    const vaultFetch = async (method, url, headers, body) => {
+      captured.push({ url, body });
+      return { status: 200, ok: true, body: JSON.stringify({ written: 1, maxSeq: 1 }) };
+    };
+
+    // Wrap the REAL vault deliverer, injecting the connection/key/fetch that the
+    // production deliverer would read from config + IndexedDB.
+    const deliverers = {
+      vault: (intent) => vaultDeliverer(intent, { connection: CONN, config: { ttlMs: 1000 }, loadKey: async () => rootKey, vaultFetch }),
+    };
+
+    await enqueue(rawNotify('20260101T000000Z-enc999', 'SECRET-TITLE'), ['vault'], { store });
+    await flush(deliverers, { store });
+
+    // Delivered → entry removed.
+    expect(await list({ store })).toHaveLength(0);
+
+    // The POSTed row is ciphertext — no plaintext leak.
+    expect(captured).toHaveLength(1);
+    expect(captured[0].url).toBe('https://vault.example.com/intents/batch');
+    const sent = JSON.parse(captured[0].body);
+    const env = JSON.parse(Buffer.from(sent.events[0].envelope, 'base64').toString('utf8'));
+    expect(env.encrypted).toBe(true);
+    expect(env.payload_ciphertext).toBeDefined();
+    expect(env).not.toHaveProperty('payload');
+    expect(Buffer.from(sent.events[0].envelope, 'base64').toString('utf8')).not.toContain('SECRET-TITLE');
+  });
+});
+
+// Defensive: GIVEN_UP is exported and distinct (sanity that imports resolved).
+it('outbox status constants are present', () => {
+  expect(PENDING).toBe('pending');
+  expect(DELIVERED).toBe('delivered');
+  expect(GIVEN_UP).toBe('given-up');
+});

--- a/src/intents/emitTargets.js
+++ b/src/intents/emitTargets.js
@@ -1,0 +1,19 @@
+// Which outbound transports are enabled for an emitted intent, in the outbox's
+// transport-name vocabulary ('webdav' | 'icloud' | 'vault'). Shared by the three
+// emit sites so they enqueue with a consistent target set. Only ENABLED targets
+// are included — the outbox then drives each one through its deliverer.
+
+import * as iCloudTransport from './icloudFileTransport.js';
+import { isDbIntentsEnabled } from './dbIntentsConfig.js';
+
+/**
+ * @param {object|null} config - the WebDAV intents config (INTENT_CONFIG_KEY)
+ * @returns {Array<'webdav'|'icloud'|'vault'>}
+ */
+export function enabledIntentTargets(config) {
+  const targets = [];
+  if (config?.webdavUrl && config?.username && config?.appPassword) targets.push('webdav');
+  if (iCloudTransport.isAvailable()) targets.push('icloud');
+  if (isDbIntentsEnabled()) targets.push('vault');
+  return targets;
+}

--- a/src/intents/emitTargets.test.js
+++ b/src/intents/emitTargets.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { enabledIntentTargets } from './emitTargets.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// enabledIntentTargets decides which transports an emit goes to AND gates the
+// "Track in lifeGLANCE" share UI. iCloud is unavailable in this environment, so
+// these cover the WebDAV/vault matrix — crucially the vault-only case, which
+// must yield a target even with no WebDAV config (the bug this guards against).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+beforeEach(() => { global.localStorage = memLocalStorage(); });
+afterAll(() => { delete global.localStorage; });
+
+const WEBDAV = { webdavUrl: 'https://dav', username: 'u', appPassword: 'p' };
+
+function enableVault() {
+  localStorage.setItem('dayglance-db-intents-config', JSON.stringify({ enabled: true }));
+  localStorage.setItem('dayglance-vault-config', JSON.stringify({ enabled: true, vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' }));
+}
+
+describe('enabledIntentTargets', () => {
+  it('returns ["webdav"] when only WebDAV is configured', () => {
+    expect(enabledIntentTargets(WEBDAV)).toEqual(['webdav']);
+  });
+
+  it('returns ["vault"] when ONLY GLANCEvault intents is enabled (no WebDAV)', () => {
+    enableVault();
+    expect(enabledIntentTargets(null)).toEqual(['vault']);
+  });
+
+  it('returns both when WebDAV is configured and vault is enabled', () => {
+    enableVault();
+    expect(enabledIntentTargets(WEBDAV)).toEqual(['webdav', 'vault']);
+  });
+
+  it('returns [] when nothing is enabled', () => {
+    expect(enabledIntentTargets(null)).toEqual([]);
+    expect(enabledIntentTargets({})).toEqual([]);
+  });
+
+  it('does not count WebDAV when the config is incomplete', () => {
+    expect(enabledIntentTargets({ webdavUrl: 'https://dav' })).toEqual([]);
+  });
+});

--- a/src/intents/intentsKeyStore.js
+++ b/src/intents/intentsKeyStore.js
@@ -1,11 +1,21 @@
 const DB_NAME = 'dayglance-intents-crypto';
 const DB_VERSION = 1;
 const STORE = 'keys';
-const ROOT_KEY_RECORD = 'root-key';
 
-// Module-level cache: avoids an IDB round-trip on every emit/poll cycle.
-// Cleared synchronously by clearIntentsRootKey().
+// Two DISTINCT key slots share this store but NEVER collide:
+//   - ROOT_KEY_RECORD       — the WebDAV intents root key (derived from the
+//                             WebDAV-stored salt). Untouched by the vault path.
+//   - VAULT_ROOT_KEY_RECORD — the GLANCEvault intents root key (derived from the
+//                             vault server's /salt/:accountId salt). A different
+//                             key from a different salt; it MUST live under its
+//                             own record so the two can't clobber each other.
+const ROOT_KEY_RECORD = 'root-key';
+const VAULT_ROOT_KEY_RECORD = 'vault-root-key';
+
+// Module-level caches: avoid an IDB round-trip on every emit/poll cycle. Each
+// slot has its own cache, cleared synchronously by its clear* function.
 let _cachedRootKey = null;
+let _cachedVaultRootKey = null;
 
 function openDB() {
   return new Promise((resolve, reject) => {
@@ -20,6 +30,8 @@ function openDB() {
     req.onerror = () => reject(req.error);
   });
 }
+
+// ─── WebDAV intents key slot (unchanged) ─────────────────────────────────────
 
 export async function storeIntentsRootKey(cryptoKey) {
   const db = await openDB();
@@ -51,6 +63,48 @@ export async function clearIntentsRootKey() {
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE, 'readwrite');
     tx.objectStore(STORE).delete(ROOT_KEY_RECORD);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+// ─── GLANCEvault intents key slot (distinct record, distinct cache) ──────────
+//
+// Mirrors the WebDAV slot's lifecycle exactly but against VAULT_ROOT_KEY_RECORD.
+// Like the WebDAV key, the derived CryptoKey is cached in IndexedDB so it
+// survives a reload WITHOUT re-deriving from the passphrase — the deliverer just
+// loads it. (The one-time derivation that populates this slot is stage 2b.)
+
+export async function storeVaultIntentsRootKey(cryptoKey) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).put(cryptoKey, VAULT_ROOT_KEY_RECORD);
+    tx.oncomplete = () => { _cachedVaultRootKey = cryptoKey; resolve(); };
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function loadVaultIntentsRootKey() {
+  if (_cachedVaultRootKey !== null) return _cachedVaultRootKey;
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).get(VAULT_ROOT_KEY_RECORD);
+    req.onsuccess = () => {
+      _cachedVaultRootKey = req.result ?? null;
+      resolve(_cachedVaultRootKey);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function clearVaultIntentsRootKey() {
+  _cachedVaultRootKey = null;
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).delete(VAULT_ROOT_KEY_RECORD);
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });

--- a/src/intents/outbox.js
+++ b/src/intents/outbox.js
@@ -1,0 +1,349 @@
+// Durable outbound INTENTS OUTBOX (stage 1: standalone core, not yet wired).
+//
+// WHY THIS EXISTS
+// Intents are currently built in memory and fired fire-and-forget: any failure
+// (no encryption key yet, a failed POST/PUT, no connection, an app restart
+// mid-send) drops them silently, and the emit-site change-snapshot advances
+// before the async send resolves — so the change is forgotten and the intent is
+// lost forever. This outbox makes the OUTBOUND side durable: an intent is
+// persisted BEFORE any transmit is attempted, retried across flushes and app
+// restarts, and only ever leaves the outbox once every target is delivered (or
+// genuinely given up).
+//
+// ENCRYPTION BOUNDARY (hard requirement)
+// The outbox persists the RAW intent (action + payload + emit metadata), NEVER a
+// built envelope. Envelope construction AND encryption happen inside the injected
+// deliverer at flush time — the outbox never builds, sees, or stores an envelope.
+// This keeps "encrypt at flush" and "never persist a plaintext envelope to disk"
+// structural rather than a convention that could drift.
+//
+// SELF-CONTAINED
+// This module imports NOTHING from the emit sites, the live transports, or
+// @glance-apps/intents / @glance-apps/sync. It depends only on a persistent store
+// (IndexedDB by default, injectable for tests) and a set of injected deliverer
+// functions. It is local-only and never crosses an app boundary, so it needs no
+// shared protocol package. Stage 2 wires it into the emit sites and transports.
+
+// ─── delivery result contract ───────────────────────────────────────────────
+//
+// A deliverer is `(intent) => DeliveryResult | Promise<DeliveryResult>`, where a
+// result is one of these constants (or an object carrying `.status`). The
+// deliverer is the ONLY place an envelope is built and encrypted; it reports back
+// only how the attempt went:
+//
+//   DELIVERED  — the row/file landed on the remote. Mark that target delivered.
+//   TRANSIENT  — a maybe-temporary failure: no network, a 5xx, the vault
+//                ENCRYPTION KEY NOT READY (sync not unlocked yet), etc. Leave the
+//                target pending and retry on a later flush. This is the bucket
+//                that guarantees we never lose an intent just because the key or
+//                connection wasn't ready at send time.
+//   PERMANENT  — this target will NEVER accept this intent (e.g. a malformed
+//                payload the server rejects with 4xx). Give the target up now.
+//
+// A deliverer that THROWS is treated as TRANSIENT — a thrown POST is exactly the
+// "maybe-temporary" case, and defaulting to retry (never drop) is the safe bias.
+// Any unrecognized return value is also treated as TRANSIENT for the same reason.
+export const DELIVERED = 'delivered';
+export const TRANSIENT = 'transient';
+export const PERMANENT = 'permanent';
+
+// Per-target delivery statuses stored on an entry.
+const PENDING = 'pending';
+const GIVEN_UP = 'given-up';
+
+// Give-up bound. Deliberately MUCH higher than the receive-side
+// MAX_INTENT_RETRIES (5): losing OUTBOUND data is worse than re-attempting, so we
+// retry generously and only ever give up on a target that is genuinely
+// undeliverable. A target hitting this many consecutive transient failures is
+// abandoned (logged loudly) so the outbox can't grow unbounded on a dead target.
+export const MAX_OUTBOX_ATTEMPTS = 50;
+
+// ─── IndexedDB-backed default store ──────────────────────────────────────────
+//
+// Mirrors the storage shape of intentsKeyStore.js (a dedicated DB, a single
+// object store). Opened lazily so importing this module never requires a DOM /
+// IndexedDB — tests inject their own store and never reach this path.
+const DB_NAME = 'dayglance-intents-outbox';
+const DB_VERSION = 1;
+const STORE = 'entries';
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        // keyPath 'id' === the intent's event_id, so a re-enqueue of the same
+        // intent targets the same record (idempotency at the storage layer too).
+        db.createObjectStore(STORE, { keyPath: 'id' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function txStore(db, mode) {
+  return db.transaction(STORE, mode).objectStore(STORE);
+}
+
+/**
+ * The persistent store interface the outbox depends on. Any object implementing
+ * these four async methods can be injected (tests pass an in-memory fake):
+ *
+ *   getAll(): Promise<Entry[]>          — all entries (fresh copies)
+ *   get(id):  Promise<Entry|undefined>  — one entry by id (a fresh copy)
+ *   put(entry): Promise<void>           — insert or overwrite by entry.id
+ *   delete(id): Promise<void>           — remove by id
+ *
+ * IndexedDB inherently structured-clones on read, so callers safely own and may
+ * mutate whatever getAll/get returns; in-memory fakes must clone to match.
+ */
+export function createIndexedDbStore() {
+  return {
+    async getAll() {
+      const db = await openDB();
+      return new Promise((resolve, reject) => {
+        const req = txStore(db, 'readonly').getAll();
+        req.onsuccess = () => resolve(req.result ?? []);
+        req.onerror = () => reject(req.error);
+      });
+    },
+    async get(id) {
+      const db = await openDB();
+      return new Promise((resolve, reject) => {
+        const req = txStore(db, 'readonly').get(id);
+        req.onsuccess = () => resolve(req.result ?? undefined);
+        req.onerror = () => reject(req.error);
+      });
+    },
+    async put(entry) {
+      const db = await openDB();
+      return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE, 'readwrite');
+        tx.objectStore(STORE).put(entry);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      });
+    },
+    async delete(id) {
+      const db = await openDB();
+      return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE, 'readwrite');
+        tx.objectStore(STORE).delete(id);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      });
+    },
+  };
+}
+
+// Lazily-created singleton default store, so module import is side-effect-free.
+let _defaultStore = null;
+function defaultStore() {
+  if (!_defaultStore) _defaultStore = createIndexedDbStore();
+  return _defaultStore;
+}
+function resolveStore(opts) {
+  return opts?.store ?? defaultStore();
+}
+
+// ─── entry helpers ───────────────────────────────────────────────────────────
+//
+// Entry shape:
+//   {
+//     id:        string,                       // === intent.event_id (idempotency key)
+//     intent:    object,                       // RAW intent — NEVER an envelope
+//     createdAt: number,                       // ms epoch
+//     targets:   { [name]: 'pending'|'delivered'|'given-up' },  // per-transport status
+//     attempts:  { [name]: number },           // per-transport failure counter
+//   }
+//
+// `attempts` is keyed PER TARGET (not a single entry-wide number) because the
+// give-up rule is per-target — "stop retrying THAT target" — so each target's
+// failures must be counted independently. An entry that delivered to webdav but
+// keeps transient-failing on vault must count only the vault attempts toward the
+// vault give-up bound.
+
+function normalizeResult(result) {
+  const status = typeof result === 'object' && result !== null ? result.status : result;
+  if (status === DELIVERED || status === PERMANENT || status === TRANSIENT) return status;
+  // Unknown / undefined (e.g. a deliverer that forgot to return) → retry, never
+  // drop. The give-up bound still bounds this at MAX_OUTBOX_ATTEMPTS.
+  return TRANSIENT;
+}
+
+// True once no target is still 'pending' — every target is delivered or given-up,
+// so the entry is as done as it will ever get and can be removed.
+function isEntryDone(entry) {
+  return Object.values(entry.targets).every((s) => s !== PENDING);
+}
+
+function hasPending(entry) {
+  return Object.values(entry.targets).some((s) => s === PENDING);
+}
+
+// Accept targets as an array of transport names (['webdav','vault']) or as a
+// map/object whose keys are the transport names ({ webdav: ..., vault: ... }).
+function targetNames(targets) {
+  if (Array.isArray(targets)) return [...new Set(targets)];
+  if (targets && typeof targets === 'object') return Object.keys(targets);
+  return [];
+}
+
+// ─── API ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Persist a new outbound intent with every target marked 'pending'. Durable
+ * before this resolves (the store write has completed).
+ *
+ * IDEMPOTENT: keyed on intent.event_id. If an entry with that id already exists,
+ * this is a no-op and the existing entry is returned unchanged — re-emitting the
+ * same intent (retry, double-render) never resets in-flight delivery state.
+ *
+ * @param {object} intent  - RAW intent; must carry event_id (the idempotency key)
+ * @param {string[]|object} targets - enabled transports, e.g. ['webdav','vault']
+ * @param {{store?:object}} [opts]
+ * @returns {Promise<object>} the stored (or pre-existing) entry
+ */
+export async function enqueue(intent, targets, opts) {
+  const store = resolveStore(opts);
+  const id = intent?.event_id;
+  if (!id) throw new Error('[outbox] intent.event_id is required as the outbox id');
+
+  const names = targetNames(targets);
+  if (names.length === 0) throw new Error('[outbox] at least one target is required');
+
+  const existing = await store.get(id);
+  if (existing) return existing; // idempotent no-op — do NOT clobber in-flight state
+
+  const entry = {
+    id,
+    intent,
+    createdAt: Date.now(),
+    targets: Object.fromEntries(names.map((n) => [n, PENDING])),
+    attempts: Object.fromEntries(names.map((n) => [n, 0])),
+  };
+  await store.put(entry);
+  return entry;
+}
+
+// Module-level lock: prevents two overlapping flushes (e.g. a cadence tick racing
+// a unlock-triggered flush) from both delivering the same pending target. Mirrors
+// the receive drain's dbPollLock. Coarse on purpose — a skipped concurrent flush
+// just runs on the next trigger; nothing is lost.
+let _flushLock = false;
+
+/**
+ * Attempt delivery of every pending target of every entry.
+ *
+ * For each entry, for each STILL-'pending' target, calls deliverers[target](intent):
+ *   - DELIVERED  → mark target 'delivered'.
+ *   - TRANSIENT  → leave 'pending', increment that target's attempt counter; if it
+ *                  reaches MAX_OUTBOX_ATTEMPTS, give the target up (logged loudly).
+ *   - PERMANENT  → give the target up immediately (logged loudly).
+ *   - (throws)   → treated as TRANSIENT.
+ * A target with no deliverer supplied this flush is left untouched (not a failure,
+ * not counted) — it simply wasn't attempted.
+ *
+ * When an entry has no pending target left (all delivered or given-up), it is
+ * removed. An ALREADY-'delivered' target is never re-delivered (idempotent).
+ *
+ * Overlapping calls are guarded: a flush already in progress makes this a no-op.
+ *
+ * @param {Record<string, (intent:object)=>any>} deliverers - transportName → deliverer
+ * @param {{store?:object}} [opts]
+ * @returns {Promise<{attempted:number, delivered:number, gaveUp:number, removed:number, skipped:boolean}>}
+ */
+export async function flush(deliverers, opts) {
+  const store = resolveStore(opts);
+  if (_flushLock) return { attempted: 0, delivered: 0, gaveUp: 0, removed: 0, skipped: true };
+  _flushLock = true;
+
+  const stats = { attempted: 0, delivered: 0, gaveUp: 0, removed: 0, skipped: false };
+  try {
+    const entries = await store.getAll();
+    for (const entry of entries) {
+      let changed = false;
+
+      for (const target of Object.keys(entry.targets)) {
+        if (entry.targets[target] !== PENDING) continue; // delivered or given-up
+        const deliver = deliverers?.[target];
+        if (typeof deliver !== 'function') continue; // not attempted this flush
+
+        stats.attempted++;
+        let result;
+        try {
+          result = await deliver(entry.intent);
+        } catch {
+          result = TRANSIENT; // a thrown send is a maybe-transient failure
+        }
+        result = normalizeResult(result);
+
+        if (result === DELIVERED) {
+          entry.targets[target] = DELIVERED;
+          stats.delivered++;
+          changed = true;
+          continue;
+        }
+
+        // Both transient and permanent count an attempt against the target.
+        entry.attempts[target] = (entry.attempts[target] ?? 0) + 1;
+        changed = true;
+
+        if (result === PERMANENT) {
+          entry.targets[target] = GIVEN_UP;
+          stats.gaveUp++;
+          console.error(
+            `[outbox] GIVING UP on intent ${entry.id} target '${target}': permanent failure (no retry).`,
+          );
+          continue;
+        }
+
+        // TRANSIENT: stay pending unless we've hit the bound.
+        if (entry.attempts[target] >= MAX_OUTBOX_ATTEMPTS) {
+          entry.targets[target] = GIVEN_UP;
+          stats.gaveUp++;
+          console.error(
+            `[outbox] GIVING UP on intent ${entry.id} target '${target}': ` +
+            `${entry.attempts[target]} consecutive transient failures (bound ${MAX_OUTBOX_ATTEMPTS}).`,
+          );
+        }
+      }
+
+      if (isEntryDone(entry)) {
+        await store.delete(entry.id);
+        stats.removed++;
+      } else if (changed) {
+        await store.put(entry);
+      }
+    }
+    return stats;
+  } finally {
+    _flushLock = false;
+  }
+}
+
+/**
+ * Number of entries still holding at least one pending target. For diagnostics
+ * and tests; an entry whose targets are all delivered/given-up is not counted
+ * (it is removed at flush time anyway).
+ * @param {{store?:object}} [opts]
+ * @returns {Promise<number>}
+ */
+export async function pendingCount(opts) {
+  const entries = await resolveStore(opts).getAll();
+  return entries.filter(hasPending).length;
+}
+
+/**
+ * All current outbox entries (fresh copies). For diagnostics and tests.
+ * @param {{store?:object}} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function list(opts) {
+  return resolveStore(opts).getAll();
+}
+
+// Exported for tests.
+export { PENDING, GIVEN_UP };

--- a/src/intents/outbox.test.js
+++ b/src/intents/outbox.test.js
@@ -1,0 +1,302 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  enqueue,
+  flush,
+  pendingCount,
+  list,
+  DELIVERED,
+  TRANSIENT,
+  PERMANENT,
+  MAX_OUTBOX_ATTEMPTS,
+  PENDING,
+  GIVEN_UP,
+} from './outbox.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Durable outbound intents outbox. These exercise the REAL outbox core against
+// an in-memory fake store and fake deliverers (no network, no IndexedDB, no DOM),
+// mirroring how dbIntentsTransport.test.js injects an in-memory server.
+//
+// The fake store deep-clones on read and write to match IndexedDB's
+// structured-clone semantics — so a value handed back by getAll/get is the
+// caller's to own and mutate, and a put captures a snapshot (no aliasing).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function createMemoryStore() {
+  const m = new Map(); // id -> serialized entry
+  const clone = (v) => JSON.parse(JSON.stringify(v));
+  return {
+    async getAll() { return [...m.values()].map(clone); },
+    async get(id) { return m.has(id) ? clone(m.get(id)) : undefined; },
+    async put(entry) { m.set(entry.id, clone(entry)); },
+    async delete(id) { m.delete(id); },
+    // test-only peek
+    _size: () => m.size,
+  };
+}
+
+// A RAW intent (action + payload + emit metadata) — NEVER an envelope. event_id
+// is the outbox id / idempotency key.
+function makeIntent(eventId, overrides = {}) {
+  return {
+    event_id: eventId,
+    action: 'notify',
+    emitted_by: 'app.dayglance',
+    payload: { event: 'completed', title: 'Task ' + eventId, source_app: 'app.testGLANCE' },
+    ...overrides,
+  };
+}
+
+// Deliverer factories. Each returns a vi.fn so call counts are assertable.
+const ok = () => vi.fn(async () => DELIVERED);
+const transient = () => vi.fn(async () => TRANSIENT);
+const permanent = () => vi.fn(async () => PERMANENT);
+const throwing = () => vi.fn(async () => { throw new Error('network down'); });
+
+let store;
+beforeEach(() => {
+  store = createMemoryStore();
+  vi.restoreAllMocks();
+});
+
+// (a) enqueue persists durably; a simulated reload re-reads pending entries.
+describe('enqueue durability', () => {
+  it('persists an entry that survives a simulated reload', async () => {
+    const intent = makeIntent('evt-a');
+    await enqueue(intent, ['webdav', 'vault'], { store });
+
+    // "Reload": a brand-new run reads from the same underlying store. We model
+    // that by reading through the same store object (its Map is the persistence).
+    const entries = await list({ store });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe('evt-a');
+    expect(entries[0].intent).toEqual(intent);          // RAW intent persisted
+    expect(entries[0].intent.payload).toBeDefined();    // not an opaque envelope
+    expect(entries[0].targets).toEqual({ webdav: PENDING, vault: PENDING });
+    expect(entries[0].attempts).toEqual({ webdav: 0, vault: 0 });
+    expect(typeof entries[0].createdAt).toBe('number');
+    expect(await pendingCount({ store })).toBe(1);
+  });
+
+  it('stores the raw intent, never a built envelope', async () => {
+    await enqueue(makeIntent('evt-raw'), ['vault'], { store });
+    const [entry] = await list({ store });
+    // The persisted shape is the raw intent: it has action/payload, and NO
+    // ciphertext/envelope fields. Encryption happens only at flush in the deliverer.
+    expect(entry.intent.action).toBe('notify');
+    expect(entry.intent).not.toHaveProperty('ciphertext');
+    expect(entry.intent).not.toHaveProperty('envelope');
+    expect(entry.intent).not.toHaveProperty('encrypted');
+  });
+});
+
+// (b) a transient-failing target stays pending and is retried; succeeds later
+//     and is then removed.
+describe('transient retry then success', () => {
+  it('keeps the target pending across flushes, then delivers and removes', async () => {
+    await enqueue(makeIntent('evt-b'), ['vault'], { store });
+
+    const failing = transient();
+    const r1 = await flush({ vault: failing }, { store });
+    expect(r1.delivered).toBe(0);
+    expect(failing).toHaveBeenCalledTimes(1);
+
+    let [entry] = await list({ store });
+    expect(entry.targets.vault).toBe(PENDING);
+    expect(entry.attempts.vault).toBe(1);
+    expect(await pendingCount({ store })).toBe(1); // still there, still pending
+
+    // Second flush still transient — attempts keeps climbing, stays pending.
+    await flush({ vault: failing }, { store });
+    [entry] = await list({ store });
+    expect(entry.attempts.vault).toBe(2);
+    expect(entry.targets.vault).toBe(PENDING);
+
+    // Later flush: the key/connection is ready now, delivery succeeds → removed.
+    const succeeding = ok();
+    const r3 = await flush({ vault: succeeding }, { store });
+    expect(r3.delivered).toBe(1);
+    expect(r3.removed).toBe(1);
+    expect(await list({ store })).toHaveLength(0);
+    expect(await pendingCount({ store })).toBe(0);
+  });
+
+  it('treats a thrown deliverer (failed POST) as transient, not a drop', async () => {
+    await enqueue(makeIntent('evt-throw'), ['vault'], { store });
+    const t = throwing();
+    await flush({ vault: t }, { store });
+    const [entry] = await list({ store });
+    expect(entry.targets.vault).toBe(PENDING); // retained for retry
+    expect(entry.attempts.vault).toBe(1);
+  });
+
+  it('treats "key not ready" (a transient signal from the deliverer) as retryable', async () => {
+    // The deliverer is where encryption happens; if the vault key isn't loaded it
+    // returns TRANSIENT and the outbox simply holds the intent for a later flush.
+    await enqueue(makeIntent('evt-nokey'), ['vault'], { store });
+    const keyNotReady = vi.fn(async () => ({ status: TRANSIENT, reason: 'key-not-ready' }));
+    await flush({ vault: keyNotReady }, { store });
+    expect(await pendingCount({ store })).toBe(1);
+    const [entry] = await list({ store });
+    expect(entry.targets.vault).toBe(PENDING);
+  });
+});
+
+// (c) multi-target: webdav delivered + vault pending -> entry stays, only vault
+//     retried; webdav NOT re-delivered; vault later delivers -> removed.
+describe('multi-target partial delivery', () => {
+  it('does not re-deliver an already-delivered target and removes once all done', async () => {
+    await enqueue(makeIntent('evt-c'), ['webdav', 'vault'], { store });
+
+    const webdav1 = ok();
+    const vault1 = transient();
+    const r1 = await flush({ webdav: webdav1, vault: vault1 }, { store });
+    expect(r1.delivered).toBe(1);   // webdav only
+    expect(webdav1).toHaveBeenCalledTimes(1);
+    expect(vault1).toHaveBeenCalledTimes(1);
+
+    let [entry] = await list({ store });
+    expect(entry.targets.webdav).toBe(DELIVERED);
+    expect(entry.targets.vault).toBe(PENDING);
+    expect(await pendingCount({ store })).toBe(1); // still pending on vault
+
+    // Next flush: webdav deliverer is still provided, but must NOT be called
+    // again (already delivered). Only vault is retried — and now succeeds.
+    const webdav2 = ok();
+    const vault2 = ok();
+    const r2 = await flush({ webdav: webdav2, vault: vault2 }, { store });
+    expect(webdav2).not.toHaveBeenCalled();        // idempotent: already delivered
+    expect(vault2).toHaveBeenCalledTimes(1);
+    expect(r2.removed).toBe(1);
+    expect(await list({ store })).toHaveLength(0);
+  });
+});
+
+// (d) duplicate enqueue (same event_id) is a no-op.
+describe('idempotent enqueue', () => {
+  it('does not create a second entry or reset in-flight state', async () => {
+    await enqueue(makeIntent('evt-d'), ['webdav', 'vault'], { store });
+
+    // Deliver webdav so the entry has in-flight state worth protecting.
+    await flush({ webdav: ok(), vault: transient() }, { store });
+    let [entry] = await list({ store });
+    expect(entry.targets.webdav).toBe(DELIVERED);
+    expect(entry.attempts.vault).toBe(1);
+
+    // Re-enqueue the SAME event_id (a retry / double render). No-op: must not
+    // add a row, must not reset webdav back to pending or zero the counters.
+    const before = await list({ store });
+    await enqueue(makeIntent('evt-d', { payload: { event: 'updated' } }), ['webdav', 'vault'], { store });
+    const after = await list({ store });
+
+    expect(after).toHaveLength(1);
+    expect(after).toEqual(before);                 // entirely unchanged
+    expect(after[0].targets.webdav).toBe(DELIVERED);
+    expect(after[0].attempts.vault).toBe(1);
+  });
+});
+
+// (e) a target that fails MAX_OUTBOX_ATTEMPTS times, or returns permanent-fail,
+//     is given up with a loud log and stops retrying; entry removed when all
+//     targets are delivered-or-given-up.
+describe('give-up bound', () => {
+  it('gives up a target after MAX_OUTBOX_ATTEMPTS transient failures', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await enqueue(makeIntent('evt-e1'), ['vault'], { store });
+
+    const failing = transient();
+    // Flush MAX_OUTBOX_ATTEMPTS - 1 times: still pending, not yet given up.
+    for (let i = 0; i < MAX_OUTBOX_ATTEMPTS - 1; i++) {
+      await flush({ vault: failing }, { store });
+    }
+    let [entry] = await list({ store });
+    expect(entry.targets.vault).toBe(PENDING);
+    expect(entry.attempts.vault).toBe(MAX_OUTBOX_ATTEMPTS - 1);
+    expect(errSpy).not.toHaveBeenCalled();
+
+    // One more failure hits the bound: target given up, entry removed (sole target).
+    const r = await flush({ vault: failing }, { store });
+    expect(r.gaveUp).toBe(1);
+    expect(r.removed).toBe(1);
+    expect(await list({ store })).toHaveLength(0);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(errSpy.mock.calls[0][0]).toContain('evt-e1');  // loud: event_id
+    expect(errSpy.mock.calls[0][0]).toContain('vault');   // loud: transport
+  });
+
+  it('gives up immediately on a permanent-fail result', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await enqueue(makeIntent('evt-e2'), ['vault'], { store });
+
+    const r = await flush({ vault: permanent() }, { store });
+    expect(r.gaveUp).toBe(1);
+    expect(r.removed).toBe(1);
+    expect(await list({ store })).toHaveLength(0);
+    expect(errSpy.mock.calls[0][0]).toContain('evt-e2');
+    expect(errSpy.mock.calls[0][0]).toContain('vault');
+  });
+
+  it('removes an entry when one target delivered and the other is given up', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    await enqueue(makeIntent('evt-e3'), ['webdav', 'vault'], { store });
+
+    // webdav delivers; vault permanently fails → both terminal → entry removed.
+    const r = await flush({ webdav: ok(), vault: permanent() }, { store });
+    expect(r.delivered).toBe(1);
+    expect(r.gaveUp).toBe(1);
+    expect(r.removed).toBe(1);
+    expect(await list({ store })).toHaveLength(0);
+  });
+
+  it('keeps retrying other targets after one is given up', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    await enqueue(makeIntent('evt-e4'), ['webdav', 'vault'], { store });
+
+    // vault permanently fails (given up); webdav transient (still pending).
+    await flush({ webdav: transient(), vault: permanent() }, { store });
+    let [entry] = await list({ store });
+    expect(entry.targets.vault).toBe(GIVEN_UP);
+    expect(entry.targets.webdav).toBe(PENDING);
+    expect(await pendingCount({ store })).toBe(1); // entry survives for webdav
+
+    // A later flush: vault deliverer must NOT be retried; webdav delivers → done.
+    const vaultAgain = ok();
+    const r = await flush({ webdav: ok(), vault: vaultAgain }, { store });
+    expect(vaultAgain).not.toHaveBeenCalled();     // given-up target is not retried
+    expect(r.removed).toBe(1);
+    expect(await list({ store })).toHaveLength(0);
+  });
+});
+
+// (f) overlapping flush calls don't double-deliver or corrupt state.
+describe('concurrent flush guard', () => {
+  it('a flush already in progress makes a concurrent flush a no-op', async () => {
+    await enqueue(makeIntent('evt-f1'), ['vault'], { store });
+    await enqueue(makeIntent('evt-f2'), ['vault'], { store });
+
+    // A deliverer that blocks until we release it, so two flushes truly overlap.
+    let release;
+    const gate = new Promise((res) => { release = res; });
+    const slow = vi.fn(async () => { await gate; return DELIVERED; });
+
+    const first = flush({ vault: slow }, { store });
+    // Second flush starts while the first holds the lock → should skip entirely.
+    const second = await flush({ vault: slow }, { store });
+    expect(second.skipped).toBe(true);
+    expect(second.delivered).toBe(0);
+
+    release();
+    const firstResult = await first;
+    expect(firstResult.delivered).toBe(2);         // first flush did all the work
+    expect(slow).toHaveBeenCalledTimes(2);         // exactly once per entry, no double
+    expect(await list({ store })).toHaveLength(0);
+  });
+
+  it('releases the lock so a later flush runs normally', async () => {
+    await enqueue(makeIntent('evt-f3'), ['vault'], { store });
+    await flush({ vault: transient() }, { store });   // completes, releases lock
+    const r = await flush({ vault: ok() }, { store }); // not skipped
+    expect(r.skipped).toBe(false);
+    expect(r.removed).toBe(1);
+  });
+});

--- a/src/intents/outboxEmit.js
+++ b/src/intents/outboxEmit.js
@@ -1,0 +1,40 @@
+// Shared emit→outbox bridge used by all three emit sites.
+//
+// Enqueues each built RAW intent durably, then triggers a flush. Returns whether
+// EVERY intent was durably enqueued — the caller (the notify hooks) advances its
+// change-snapshot ONLY when this is true, so a failed enqueue never consumes a
+// change (it gets re-detected and re-enqueued next time). Encryption is NOT done
+// here: it happens at flush, inside each per-target deliverer.
+//
+// Dependencies are injectable so the emit sites are testable without IndexedDB.
+
+import { enqueue as defaultEnqueue, flush as defaultFlush } from './outbox.js';
+import { deliverers as defaultDeliverers } from './deliverers.js';
+
+/**
+ * @param {Array<{intent:object, onOk?:Function, onError?:(err:Error)=>void}>} items
+ * @param {Array<'webdav'|'icloud'|'vault'>} targets
+ * @param {object} [deps] - { enqueue, flush, deliverers } (defaults to the real ones)
+ * @returns {Promise<boolean>} true iff every intent was durably enqueued
+ */
+export async function enqueueAndFlush(items, targets, deps = {}) {
+  const enqueue = deps.enqueue ?? defaultEnqueue;
+  const flush = deps.flush ?? defaultFlush;
+  const deliverers = deps.deliverers ?? defaultDeliverers;
+
+  let allEnqueued = true;
+  for (const item of items) {
+    try {
+      await enqueue(item.intent, targets);   // durable before return
+      item.onOk?.();
+    } catch (err) {
+      // A failed ENQUEUE (rare) must NOT advance the caller's snapshot.
+      allEnqueued = false;
+      item.onError?.(err);
+    }
+  }
+
+  // Trigger delivery; the outbox's in-flight lock serializes overlapping flushes.
+  await flush(deliverers);
+  return allEnqueued;
+}

--- a/src/intents/useGoalNotifyEmitter.js
+++ b/src/intents/useGoalNotifyEmitter.js
@@ -1,11 +1,9 @@
-import { useEffect, useRef } from 'react';
-import { buildEnvelope, buildEncryptedEnvelope, eventId as makeEventId, EVENTS, ENTITY_TYPES, deriveEnvelopeKey } from '@glance-apps/intents';
-import { loadIntentsRootKey } from './intentsKeyStore.js';
-import { writeEventFile, writeEventFileICloud, INTENT_CONFIG_KEY } from './useIntentPoller.js';
-import { sendIntentDb } from './dbIntentsTransport.js';
-import { isDbIntentsEnabled } from './dbIntentsConfig.js';
+import { useEffect, useRef, useReducer } from 'react';
+import { eventId as makeEventId, EVENTS, ENTITY_TYPES } from '@glance-apps/intents';
+import { INTENT_CONFIG_KEY } from './useIntentPoller.js';
+import { enabledIntentTargets } from './emitTargets.js';
+import { enqueueAndFlush } from './outboxEmit.js';
 import { logActivity } from './intentLog.js';
-import * as iCloudTransport from './icloudFileTransport.js';
 
 const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
 
@@ -53,6 +51,8 @@ function detectGoalChange(prev, next) {
  */
 export function useGoalNotifyEmitter({ goals }) {
   const prevRef = useRef(null);
+  const inFlightRef = useRef(false);
+  const [, bump] = useReducer(x => x + 1, 0);
 
   useEffect(() => {
     if (isTrayMode) return;
@@ -63,15 +63,12 @@ export function useGoalNotifyEmitter({ goals }) {
     })();
 
     const prev = prevRef.current;
-    prevRef.current = goals;
 
-    if (prev === null) return;
+    if (prev === null) { prevRef.current = goals; return; }
+    if (inFlightRef.current) return;
 
-    const hasWebDAV = !!(config?.webdavUrl && config?.username && config?.appPassword);
-    const hasICloud = iCloudTransport.isAvailable();
-    // The DB intents transport runs alongside WebDAV/iCloud and may be enabled on
-    // its own, so don't bail when the file tiers are absent if DB intents is active.
-    if (!hasWebDAV && !hasICloud && !isDbIntentsEnabled()) return;
+    const targets = enabledIntentTargets(config);
+    if (targets.length === 0) { prevRef.current = goals; return; }
 
     const prevMap = new Map(prev.map(g => [g.id, g]));
     const nextMap = new Map(goals.map(g => [g.id, g]));
@@ -96,74 +93,56 @@ export function useGoalNotifyEmitter({ goals }) {
       if (change) emits.push({ goal: nextGoal, change });
     }
 
-    if (!emits.length) return;
+    if (!emits.length) { prevRef.current = goals; return; }
 
+    inFlightRef.current = true;
     const fire = async () => {
-      let deriveKey = null;
-      if (config?.encryptionEnabled) {
-        const rootKey = await loadIntentsRootKey();
-        if (!rootKey) {
-          console.warn('[goal-notify] intents encryption setup incomplete — skipping', emits.length, 'emit(s)');
-          logActivity({
-            direction: 'out',
-            action: 'notify',
-            event: null,
-            source_app: null,
-            title: null,
-            timestamp: now,
-            status: 'error',
-            error: 'setup_incomplete',
-          });
-          return;
-        }
-        deriveKey = (salt) => deriveEnvelopeKey(rootKey, salt);
-      }
-
-      for (const { goal, change } of emits) {
-        const payload = {
-          event_id: makeEventId(),
-          source_app: goal.source_app,
-          source_entity_id: goal.source_entity_id,
-          event: change.event,
-          task_id: goal.id,
-          title: goal.title,
-          timestamp: now,
-          entity_type: ENTITY_TYPES.GOAL,
-          ...(change.due !== undefined ? { due: change.due } : {}),
-          ...(change.previous_due !== undefined ? { previous_due: change.previous_due } : {}),
-          ...(change.event === EVENTS.COMPLETED ? { completed_at: now } : {}),
-        };
-
-        try {
-          const envelope = deriveKey
-            ? await buildEncryptedEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' }, deriveKey)
-            : buildEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' });
-          await writeEventFile(config, envelope);
-          await writeEventFileICloud(config, envelope);
-          await sendIntentDb(envelope);  // GLANCEvault DB (no-ops unless enabled)
-          logActivity({
-            direction: 'out',
-            action: 'notify',
-            event: change.event,
+      try {
+        const items = emits.map(({ goal, change }) => {
+          const payload = {
+            event_id: makeEventId(),
             source_app: goal.source_app,
+            source_entity_id: goal.source_entity_id,
+            event: change.event,
+            task_id: goal.id,
             title: goal.title,
             timestamp: now,
-            status: 'ok',
-            error: null,
-          });
-        } catch (err) {
-          console.warn('[goal-notify] emit failed for goal', goal.id, ':', err.message);
-          logActivity({
-            direction: 'out',
+            entity_type: ENTITY_TYPES.GOAL,
+            ...(change.due !== undefined ? { due: change.due } : {}),
+            ...(change.previous_due !== undefined ? { previous_due: change.previous_due } : {}),
+            ...(change.event === EVENTS.COMPLETED ? { completed_at: now } : {}),
+          };
+          // RAW intent — encryption happens at flush in the per-target deliverer.
+          const intent = {
+            event_id: payload.event_id,
             action: 'notify',
-            event: change.event,
-            source_app: goal.source_app,
-            title: goal.title,
-            timestamp: now,
-            status: 'error',
-            error: err.name ?? err.message,
-          });
-        }
+            emitted_by: 'app.dayglance',
+            payload,
+          };
+          return {
+            intent,
+            onOk: () => logActivity({
+              direction: 'out', action: 'notify', event: change.event,
+              source_app: goal.source_app, title: goal.title, timestamp: now,
+              status: 'ok', error: null,
+            }),
+            onError: (err) => {
+              console.warn('[goal-notify] enqueue failed for goal', goal.id, ':', err.message);
+              logActivity({
+                direction: 'out', action: 'notify', event: change.event,
+                source_app: goal.source_app, title: goal.title, timestamp: now,
+                status: 'error', error: err.name ?? err.message,
+              });
+            },
+          };
+        });
+
+        // Advance the snapshot ONLY after durable enqueue.
+        const allEnqueued = await enqueueAndFlush(items, targets);
+        if (allEnqueued) prevRef.current = goals;
+      } finally {
+        inFlightRef.current = false;
+        bump();
       }
     };
 

--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -63,9 +63,14 @@ function parseFilenameDate(ts) {
 /**
  * PUT a single envelope as a JSON file into the intent events directory.
  * Creates the directory (MKCOL) on first use. Silently no-ops if config is absent.
+ *
+ * Returns the final webdavFetch response ({ status, ok, ... }), or undefined when
+ * config is absent, so the durable-outbox deliverer can map HTTP outcomes to
+ * delivered/transient/permanent. The existing fire-and-forget emit-site callers
+ * ignore the return value, so this is backward-compatible.
  */
 export async function writeEventFile(config, envelope) {
-  if (!config?.webdavUrl || !config?.username || !config?.appPassword) return;
+  if (!config?.webdavUrl || !config?.username || !config?.appPassword) return undefined;
 
   const dir = eventsDir(config);
   const filename = filenameFor(envelope);
@@ -81,6 +86,7 @@ export async function writeEventFile(config, envelope) {
   if (!res.ok) {
     console.error('[intent] writeEventFile failed:', res.status, filename);
   }
+  return res;
 }
 
 // ─── public: garbage-collect old event files ────────────────────────────────
@@ -149,19 +155,24 @@ export async function runIntentGC(config) {
 /**
  * Write a single envelope as a JSON file to iCloud Drive.
  * No-ops if iCloud is unavailable. Creates the events directory on first use.
+ *
+ * Returns true when the file was written, false when iCloud is unavailable or
+ * the write failed (both retryable), so the durable-outbox deliverer can map the
+ * outcome. Existing fire-and-forget callers ignore the return value.
  */
 export async function writeEventFileICloud(config, envelope) {
-  if (!iCloudTransport.isAvailable()) return;
+  if (!iCloudTransport.isAvailable()) return false;
   const eventsRelPath = ((config?.eventsPath ?? DEFAULT_EVENTS_PATH).replace(/^\//, '').replace(/\/*$/, '')) + '/';
   const filename = filenameFor(envelope);
   const filePath = eventsRelPath + filename;
   const body = JSON.stringify(envelope);
-  const ok = await iCloudTransport.writeFile(filePath, body);
+  let ok = await iCloudTransport.writeFile(filePath, body);
   if (!ok) {
     // Directory may not exist yet — create it and retry
     await iCloudTransport.makeDir(eventsRelPath);
-    await iCloudTransport.writeFile(filePath, body);
+    ok = await iCloudTransport.writeFile(filePath, body);
   }
+  return ok;
 }
 
 // ─── iCloud: garbage-collect old event files ─────────────────────────────────

--- a/src/intents/useNotifyEmitter.js
+++ b/src/intents/useNotifyEmitter.js
@@ -1,11 +1,9 @@
-import { useEffect, useRef } from 'react';
-import { buildEnvelope, buildEncryptedEnvelope, eventId as makeEventId, EVENTS, ENTITY_TYPES, deriveEnvelopeKey } from '@glance-apps/intents';
-import { loadIntentsRootKey } from './intentsKeyStore.js';
-import { writeEventFile, writeEventFileICloud, INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from './useIntentPoller.js';
-import { sendIntentDb } from './dbIntentsTransport.js';
-import { isDbIntentsEnabled } from './dbIntentsConfig.js';
+import { useEffect, useRef, useReducer } from 'react';
+import { eventId as makeEventId, EVENTS, ENTITY_TYPES } from '@glance-apps/intents';
+import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from './useIntentPoller.js';
+import { enabledIntentTargets } from './emitTargets.js';
+import { enqueueAndFlush } from './outboxEmit.js';
 import { logActivity } from './intentLog.js';
-import * as iCloudTransport from './icloudFileTransport.js';
 import { isNativeAndroid } from '../native';
 
 // The tray holds a read-only state snapshot. Any task-state changes in tray
@@ -99,6 +97,13 @@ export function buildNotifyPayload(task, change, now, meUserSyncId = null) {
  */
 export function useNotifyEmitter({ tasks, unscheduledTasks }) {
   const prevRef = useRef(null);
+  // Guard so a re-render during the async enqueue/flush window can't re-detect
+  // and double-enqueue the same change (notify event_ids are freshly generated,
+  // so a re-detection would not be deduped by the outbox).
+  const inFlightRef = useRef(false);
+  // After a fire() completes (and advances the snapshot), force one more effect
+  // run so any change that arrived DURING the in-flight window is picked up.
+  const [, bump] = useReducer(x => x + 1, 0);
 
   useEffect(() => {
     if (isTrayMode) return;
@@ -110,16 +115,17 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
 
     const allTasks = [...tasks, ...unscheduledTasks];
     const prev = prevRef.current;
-    prevRef.current = allTasks;
 
-    // Skip the initial snapshot — no previous state to diff against
-    if (prev === null) return;
-    // Skip emit when neither WebDAV nor iCloud is configured
-    const hasWebDAV = !!(config?.webdavUrl && config?.username && config?.appPassword);
-    const hasICloud = iCloudTransport.isAvailable();
-    // The DB intents transport runs alongside WebDAV/iCloud and may be enabled on
-    // its own, so don't bail when the file tiers are absent if DB intents is active.
-    if (!hasWebDAV && !hasICloud && !isDbIntentsEnabled()) return;
+    // Skip the initial snapshot — no previous state to diff against.
+    if (prev === null) { prevRef.current = allTasks; return; }
+    // A fire() is in progress; it will advance the snapshot and bump() us again.
+    if (inFlightRef.current) return;
+
+    // Targets enabled for this emit ('webdav' | 'icloud' | 'vault'). When NONE
+    // are enabled there's nowhere to send, so consume the changes (advance the
+    // snapshot) and bail — matching the old early-return-after-advance behavior.
+    const targets = enabledIntentTargets(config);
+    if (targets.length === 0) { prevRef.current = allTasks; return; }
 
     const prevMap = new Map(prev.map(t => [t.id, t]));
     const nextMap = new Map(allTasks.map(t => [t.id, t]));
@@ -144,76 +150,60 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
       if (change) emits.push({ task: nextTask, change });
     }
 
-    if (!emits.length) return;
+    // Nothing notification-worthy changed — advance the snapshot and bail.
+    if (!emits.length) { prevRef.current = allTasks; return; }
 
+    inFlightRef.current = true;
     const fire = async () => {
-      // Resolve this device's user sync_id for completion attribution.
-      const muRaw = localStorage.getItem(MULTI_USER_CONFIG_KEY);
-      const meUserSyncId = muRaw ? (JSON.parse(muRaw).meUserSyncId || null) : null;
+      try {
+        // Resolve this device's user sync_id for completion attribution.
+        const muRaw = localStorage.getItem(MULTI_USER_CONFIG_KEY);
+        const meUserSyncId = muRaw ? (JSON.parse(muRaw).meUserSyncId || null) : null;
 
-      // Resolve encryption posture once for the whole batch.
-      let deriveKey = null;
-      if (config?.encryptionEnabled) {
-        const rootKey = await loadIntentsRootKey();
-        if (!rootKey) {
-          // Root key not cached — setup incomplete. Block all emits; do not fall back to plaintext.
-          console.warn('[notify] intents encryption setup incomplete — skipping', emits.length, 'emit(s)');
-          logActivity({
-            direction: 'out',
+        // Build a RAW intent per change (NOT an envelope — encryption happens at
+        // flush in the per-target deliverer). The payload's event_id, stable per
+        // change, is the outbox id AND the server idempotency key, and flows
+        // unchanged through every retry.
+        const items = emits.map(({ task, change }) => {
+          const payload = buildNotifyPayload(task, change, now, meUserSyncId);
+          const intent = {
+            event_id: payload.event_id,
             action: 'notify',
-            event: null,
-            source_app: null,
-            title: null,
-            timestamp: now,
-            status: 'error',
-            error: 'setup_incomplete',
-          });
-          return;
-        }
-        deriveKey = (salt) => deriveEnvelopeKey(rootKey, salt);
-      }
+            emitted_by: 'app.dayglance',
+            payload,
+          };
+          return {
+            intent,
+            onOk: () => {
+              logActivity({
+                direction: 'out', action: 'notify', event: change.event,
+                source_app: task.source_app, title: task.title, timestamp: now,
+                status: 'ok', error: null,
+              });
+              // Android broadcast for local Tasker listeners — a LOCAL notification,
+              // independent of the durable outbox. Only on a plaintext WebDAV posture
+              // (encrypted payloads are unusable by keyless local listeners).
+              if (isNativeAndroid() && !config?.encryptionEnabled) {
+                try { window.DayGlanceNative?.sendNotifyBroadcast?.(JSON.stringify(payload)); } catch (_) {}
+              }
+            },
+            onError: (err) => {
+              console.warn('[notify] enqueue failed for task', task.id, ':', err.message);
+              logActivity({
+                direction: 'out', action: 'notify', event: change.event,
+                source_app: task.source_app, title: task.title, timestamp: now,
+                status: 'error', error: err.name ?? err.message,
+              });
+            },
+          };
+        });
 
-      for (const { task, change } of emits) {
-        const payload = buildNotifyPayload(task, change, now, meUserSyncId);
-
-        try {
-          const envelope = deriveKey
-            ? await buildEncryptedEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' }, deriveKey)
-            : buildEnvelope({ action: 'notify', payload, emittedBy: 'app.dayglance' });
-          await writeEventFile(config, envelope);          // WebDAV (no-ops if not configured)
-          await writeEventFileICloud(config, envelope);    // iCloud (no-ops if not available)
-          await sendIntentDb(envelope);                    // GLANCEvault DB (no-ops unless enabled)
-          // Android broadcast: only on the plaintext path. Encrypted envelopes can't be
-          // used by local listeners (no key), and their ciphertext fields don't survive
-          // JSON.stringify cleanly. Tasker users should rely on WebDAV for encrypted setups.
-          if (isNativeAndroid() && !deriveKey) {
-            try {
-              window.DayGlanceNative?.sendNotifyBroadcast?.(JSON.stringify(payload));
-            } catch (_) {}
-          }
-          logActivity({
-            direction: 'out',
-            action: 'notify',
-            event: change.event,
-            source_app: task.source_app,
-            title: task.title,
-            timestamp: now,
-            status: 'ok',
-            error: null,
-          });
-        } catch (err) {
-          console.warn('[notify] emit failed for task', task.id, ':', err.message);
-          logActivity({
-            direction: 'out',
-            action: 'notify',
-            event: change.event,
-            source_app: task.source_app,
-            title: task.title,
-            timestamp: now,
-            status: 'error',
-            error: err.name ?? err.message,
-          });
-        }
+        // Advance the change-snapshot ONLY after the intents are durably queued.
+        const allEnqueued = await enqueueAndFlush(items, targets);
+        if (allEnqueued) prevRef.current = allTasks;
+      } finally {
+        inFlightRef.current = false;
+        bump(); // re-run the effect to catch any change from the in-flight window
       }
     };
 

--- a/src/intents/useOutboxFlush.js
+++ b/src/intents/useOutboxFlush.js
@@ -1,0 +1,68 @@
+// Drives the durable outbox: periodically (and on mount / focus) flushes any
+// queued outbound intents through their deliverers. This is the "background
+// drain" half of the outbox — the emit sites also flush immediately on enqueue,
+// but this hook guarantees anything persisted from a PREVIOUS session (or held
+// because a transport/key wasn't ready) eventually goes out.
+//
+// Cadence mirrors the WebDAV intents poller's foreground interval + focus
+// trigger. flush() has its own in-flight lock, so overlapping triggers (mount +
+// focus + interval, or a racing emit-time flush) collapse to one drain.
+
+import { useEffect } from 'react';
+import { flush } from './outbox.js';
+import { deliverers } from './deliverers.js';
+
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+
+// Match the WebDAV poller's foreground cadence (2 minutes).
+const FLUSH_INTERVAL_MS = 2 * 60 * 1000;
+
+async function drain() {
+  try {
+    await flush(deliverers);
+  } catch (err) {
+    console.warn('[outbox] flush error:', err?.message);
+  }
+}
+
+/**
+ * Mounts the outbox background drain. No-ops in tray mode (the tray must never
+ * consume/send intents — it mirrors the read-only snapshot poller guard).
+ */
+export function useOutboxFlush() {
+  useEffect(() => {
+    if (isTrayMode) return;
+
+    let timerId = null;
+    let destroyed = false;
+
+    const scheduleNext = () => {
+      if (destroyed) return;
+      timerId = setTimeout(runDrain, FLUSH_INTERVAL_MS);
+    };
+    const runDrain = async () => {
+      if (destroyed) return;
+      await drain();
+      scheduleNext();
+    };
+    const onVisibilityChange = () => {
+      if (!document.hidden) {
+        clearTimeout(timerId);
+        runDrain();
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    runDrain(); // mount drain — clears anything held from a previous session
+
+    return () => {
+      destroyed = true;
+      clearTimeout(timerId);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, []);
+}
+
+// Exported so callers (e.g. the vault-intents enable flow) can request an
+// immediate drain after a key becomes available, without mounting the hook.
+export { drain as flushOutboxNow };

--- a/src/intents/vaultIntentsSetup.js
+++ b/src/intents/vaultIntentsSetup.js
@@ -1,0 +1,119 @@
+// GLANCEvault INTENTS key setup (stage 2b-i).
+//
+// Creates the cached VAULT intents root key that the vault deliverer (stage 2a)
+// reads via loadVaultIntentsRootKey. The key is derived ONCE — from the sync
+// passphrase and the vault's server-stored salt — and cached in its own slot so
+// it survives reloads without the passphrase (exactly like the WebDAV intents
+// key). This mirrors setupIntentsEncryption (the WebDAV path) byte-for-byte; the
+// ONLY difference is the salt source: the vault's /salt/:accountId value instead
+// of the WebDAV salt file. Same passphrase + same salt ⇒ identical key across
+// GLANCE apps.
+//
+// This module is React-free and fully injectable so the enable-toggle handler
+// can call it before reload, and tests can drive it without network/IndexedDB.
+
+import { deriveIntentsRootKey } from '@glance-apps/intents';
+import { createVaultClient } from '@glance-apps/sync';
+import { getSyncPassphrase } from '../utils/crypto.js';
+import { getDbIntentsConnection } from './dbIntentsConfig.js';
+import { defaultVaultFetch } from './dbIntentsTransport.js';
+import { loadVaultIntentsRootKey, storeVaultIntentsRootKey } from './intentsKeyStore.js';
+
+export class VaultIntentsSetupError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.name = 'VaultIntentsSetupError';
+    this.code = code;
+  }
+}
+
+// createVaultClient's fetchImpl uses the (url, init) -> Response-like signature,
+// but defaultVaultFetch (the native/electron-safe fetch the DB transport uses)
+// is POSITIONAL: (method, url, headers, body) -> { status, ok, body }. Adapt the
+// latter to the former — the same shaping src/sync/dbEngine.js does for the sync
+// vault client — so getSalt routes through the exact transport the DB intents
+// path already uses on every platform.
+function adaptFetchForVaultClient(rawFetch) {
+  return async (url, { method = 'GET', headers = {}, body } = {}) => {
+    const r = await rawFetch(method, url, headers, body ?? null);
+    if (!r) throw new TypeError('Failed to fetch');
+    return {
+      status: r.status,
+      ok: r.ok,
+      json: async () => (typeof r.body === 'string' ? JSON.parse(r.body) : r.body),
+      text: async () => (typeof r.body === 'string' ? r.body : JSON.stringify(r.body ?? '')),
+    };
+  };
+}
+
+/**
+ * Derive and cache the vault intents root key from the passphrase + the vault's
+ * server-stored salt. Must be called while the passphrase is in memory (before
+ * the enable-toggle reload).
+ *
+ * @param {string} passphrase - the sync passphrase
+ * @param {object} [opts] - injection seams for tests/wiring:
+ *   connection  (default getDbIntentsConnection()),
+ *   fetchImpl   (positional raw fetch; default defaultVaultFetch()),
+ *   vaultClient (default createVaultClient(...) over the adapted fetch),
+ *   storeKey    (default storeVaultIntentsRootKey)
+ * @returns {Promise<CryptoKey>} the derived (and now cached) root key
+ * @throws {VaultIntentsSetupError} NO_CONNECTION / NO_VAULT_SALT
+ */
+export async function setupVaultIntentsEncryption(passphrase, opts = {}) {
+  const connection = opts.connection ?? getDbIntentsConnection();
+  if (!connection) {
+    throw new VaultIntentsSetupError('No GLANCEvault connection configured.', 'NO_CONNECTION');
+  }
+  const { vaultUrl, vaultToken, accountId } = connection;
+
+  const client = opts.vaultClient
+    ?? createVaultClient({
+      vaultUrl,
+      vaultToken,
+      fetchImpl: adaptFetchForVaultClient(opts.fetchImpl ?? defaultVaultFetch()),
+    });
+
+  // The vault's account salt is SERVER-OWNED and created by sync. If it's absent,
+  // sync hasn't established it yet — surface that rather than inventing a salt: a
+  // fabricated salt would derive a key that diverges from every other device and
+  // never decrypt sibling apps' rows.
+  const salt = await client.getSalt(accountId);
+  if (!salt) {
+    throw new VaultIntentsSetupError(
+      'GLANCEvault has no encryption salt yet. Run GLANCEvault sync once to establish it, then enable vault intents.',
+      'NO_VAULT_SALT',
+    );
+  }
+
+  // EXACT same derivation as the WebDAV intents path (setupIntentsEncryption),
+  // only the salt differs. Cache into the vault slot (distinct from WebDAV).
+  const rootKey = await deriveIntentsRootKey(passphrase, salt);
+  await (opts.storeKey ?? storeVaultIntentsRootKey)(rootKey);
+  return rootKey;
+}
+
+/**
+ * Ensure a vault intents key is cached, deriving it now if the passphrase is
+ * available. Distinguishes "passphrase missing" (the caller must prompt) from
+ * "already set up" and from real errors.
+ *
+ * @param {object} [opts] - loadKey (default loadVaultIntentsRootKey),
+ *   getSyncPassphrase (default getSyncPassphrase), plus all setup opts.
+ * @returns {Promise<{ok:true, alreadySetUp?:true} | {ok:false, needsPassphrase:true}>}
+ * @throws {VaultIntentsSetupError} on a real setup error (no connection / no salt)
+ */
+export async function ensureVaultIntentsKey(opts = {}) {
+  // 1. Already cached? Nothing to do.
+  const existing = await (opts.loadKey ?? loadVaultIntentsRootKey)();
+  if (existing) return { ok: true, alreadySetUp: true };
+
+  // 2. Passphrase available? (DISTINCT from "connection present" — the connection
+  //    can be configured while the passphrase is null after a reload.)
+  const passphrase = (opts.getSyncPassphrase ?? getSyncPassphrase)();
+  if (!passphrase) return { ok: false, needsPassphrase: true };
+
+  // 3-4. Derive + cache now, while the passphrase is in memory.
+  await setupVaultIntentsEncryption(passphrase, opts);
+  return { ok: true };
+}

--- a/src/intents/vaultIntentsSetup.test.js
+++ b/src/intents/vaultIntentsSetup.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from 'vitest';
+import { deriveEnvelopeKey } from '@glance-apps/intents';
+import {
+  ensureVaultIntentsKey,
+  setupVaultIntentsEncryption,
+  VaultIntentsSetupError,
+} from './vaultIntentsSetup.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Vault intents KEY SETUP (stage 2b-i). Exercises the REAL derivation
+// (deriveIntentsRootKey via setupVaultIntentsEncryption) with the vault client,
+// store slot, and passphrase source injected — no network, no IndexedDB.
+//
+// The store slot is modelled by an in-memory { storeKey, loadKey } pair (the
+// repo has no fake-indexeddb; existing tests inject stores the same way), so
+// "a key is now loadable from the vault slot" is asserted via that pair.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CONN = { vaultUrl: 'https://vault.example.com', vaultToken: 'tok-123', accountId: 'acct-1' };
+const SALT = new Uint8Array(16).fill(5);
+
+// An in-memory vault key slot mirroring storeVaultIntentsRootKey / loadVaultIntentsRootKey.
+function memSlot(initial = null) {
+  let key = initial;
+  return {
+    storeKey: vi.fn(async (k) => { key = k; }),
+    loadKey: vi.fn(async () => key),
+    peek: () => key,
+  };
+}
+
+const okVaultClient = (salt = SALT) => ({ getSalt: vi.fn(async () => salt) });
+
+describe('ensureVaultIntentsKey', () => {
+  it('with a passphrase available, derives and caches a vault key loadable from the slot', async () => {
+    const slot = memSlot();
+    const vaultClient = okVaultClient();
+
+    const res = await ensureVaultIntentsKey({
+      loadKey: slot.loadKey,
+      storeKey: slot.storeKey,
+      getSyncPassphrase: () => 'correct horse battery staple',
+      connection: CONN,
+      vaultClient,
+    });
+
+    expect(res).toEqual({ ok: true });
+    expect(vaultClient.getSalt).toHaveBeenCalledWith('acct-1');
+    expect(slot.storeKey).toHaveBeenCalledTimes(1);
+
+    // A key is now loadable from the vault slot...
+    const cached = await slot.loadKey();
+    expect(cached).not.toBeNull();
+    // ...and it is a usable HKDF root key (deriveEnvelopeKey accepts it).
+    const envKey = await deriveEnvelopeKey(cached, new Uint8Array(16).fill(1));
+    expect(envKey).toBeDefined();
+    expect(envKey.type).toBe('secret'); // a real AES-GCM CryptoKey
+  });
+
+  it('with NO passphrase, returns needsPassphrase and caches nothing (prompt path)', async () => {
+    const slot = memSlot();
+    const vaultClient = okVaultClient();
+
+    const res = await ensureVaultIntentsKey({
+      loadKey: slot.loadKey,
+      storeKey: slot.storeKey,
+      getSyncPassphrase: () => null,   // passphrase gone (e.g. after reload)
+      connection: CONN,                // connection present, but that is NOT sufficient
+      vaultClient,
+    });
+
+    expect(res).toEqual({ ok: false, needsPassphrase: true });
+    expect(slot.storeKey).not.toHaveBeenCalled();      // nothing cached
+    expect(vaultClient.getSalt).not.toHaveBeenCalled(); // no derivation attempted
+    expect(slot.peek()).toBeNull();
+  });
+
+  it('cancel path: not deriving leaves vault intents key absent', async () => {
+    // Models the UI cancel: the user declines the passphrase prompt, so
+    // setupVaultIntentsEncryption is never called and the slot stays empty.
+    const slot = memSlot();
+    const res = await ensureVaultIntentsKey({
+      loadKey: slot.loadKey,
+      storeKey: slot.storeKey,
+      getSyncPassphrase: () => null,
+      connection: CONN,
+      vaultClient: okVaultClient(),
+    });
+    expect(res.needsPassphrase).toBe(true);
+    // The handler would now leave the toggle OFF; no key was ever cached.
+    expect(await slot.loadKey()).toBeNull();
+  });
+
+  it('already set up: returns alreadySetUp without re-deriving or prompting', async () => {
+    const slot = memSlot('already-cached-key');
+    const getPass = vi.fn(() => { throw new Error('should not read passphrase'); });
+    const vaultClient = okVaultClient();
+
+    const res = await ensureVaultIntentsKey({
+      loadKey: slot.loadKey,
+      storeKey: slot.storeKey,
+      getSyncPassphrase: getPass,
+      connection: CONN,
+      vaultClient,
+    });
+
+    expect(res).toEqual({ ok: true, alreadySetUp: true });
+    expect(getPass).not.toHaveBeenCalled();
+    expect(vaultClient.getSalt).not.toHaveBeenCalled();
+    expect(slot.storeKey).not.toHaveBeenCalled();
+  });
+
+  it('surfaces NO_VAULT_SALT when the server has no salt (does not invent one)', async () => {
+    const slot = memSlot();
+    const vaultClient = { getSalt: vi.fn(async () => null) }; // 404 / no salt yet
+
+    await expect(ensureVaultIntentsKey({
+      loadKey: slot.loadKey,
+      storeKey: slot.storeKey,
+      getSyncPassphrase: () => 'pw',
+      connection: CONN,
+      vaultClient,
+    })).rejects.toMatchObject({ code: 'NO_VAULT_SALT' });
+
+    expect(slot.storeKey).not.toHaveBeenCalled(); // never cache a fabricated key
+  });
+});
+
+describe('setupVaultIntentsEncryption', () => {
+  it('throws NO_CONNECTION when no vault connection is configured', async () => {
+    await expect(setupVaultIntentsEncryption('pw', { connection: null }))
+      .rejects.toBeInstanceOf(VaultIntentsSetupError);
+    await expect(setupVaultIntentsEncryption('pw', { connection: null }))
+      .rejects.toMatchObject({ code: 'NO_CONNECTION' });
+  });
+
+  it('derives from the vault salt and caches into the provided slot', async () => {
+    const slot = memSlot();
+    const key = await setupVaultIntentsEncryption('pw', {
+      connection: CONN,
+      vaultClient: okVaultClient(),
+      storeKey: slot.storeKey,
+    });
+    expect(key).toBeDefined();
+    expect(slot.peek()).toBe(key);
+  });
+});


### PR DESCRIPTION
## Why

Outbound intents were built in memory and fired fire-and-forget: any failure (no encryption key yet, a failed POST/PUT, no connection, an app restart mid-send) dropped them silently, and the emit-site change-snapshot advanced before the async send resolved — so the change was forgotten. Separately, the GLANCEvault DB intents transport could send and receive **plaintext**, violating the zero-knowledge requirement that the vault store only ciphertext.

This PR makes the outbound path **durable** (no intent is ever lost) and the vault path **always encrypted** end-to-end, then wires it into the emit sites.

## What changed (by stage)

**Stage 1 — durable outbox core** (`src/intents/outbox.js`)
- IndexedDB-backed, store injectable for tests. Persists the **raw intent** (never a built envelope), keyed by `event_id` (idempotent enqueue).
- `flush(deliverers)`: per still-pending target → `delivered` / `transient` (retry; covers "key not ready") / `permanent` (give up). Removes an entry once no target is pending. In-flight lock guards overlapping flushes.
- Give-up bound `MAX_OUTBOX_ATTEMPTS = 50`, per-target; given-up logged loudly.

**Stage 2a — deliverers + receive-side fix** (`src/intents/deliverers.js`)
- **Vault deliverer: always encrypted, no plaintext branch.** Loads the cached vault key from its own slot; absent → `transient` (sends/builds nothing). Present → `buildEncryptedEnvelope` → `buildIntentRow` → POST `/intents/batch` via the native/electron-safe fetch. 2xx→delivered, network/5xx/429/408→transient, other 4xx→permanent.
- **WebDAV / iCloud deliverers** keep the existing encryption policy (encrypted iff WebDAV `encryptionEnabled`); only durability changes.
- **Receive-side zero-knowledge enforcement:** a non-encrypted row arriving over the vault is now rejected (logged with eventId, advanced past — no wedge, never routed). The encrypted branch decrypts with the vault key slot. WebDAV receive unchanged.

**Stage 2b-i — vault key setup** (`src/intents/vaultIntentsSetup.js`)
- On enabling GLANCEvault intents, derives the vault intents key **before** the save/reload (the passphrase is gone after reload) and caches it in its own slot. Same `deriveIntentsRootKey(passphrase, salt)` as the WebDAV path, only the salt is the vault's server-stored `/salt/:accountId` (so the key is byte-identical across GLANCE apps).
- Distinguishes "passphrase missing" (prompts, reusing the existing intents passphrase prompt; cancel leaves the toggle off) from "connection present". `getSalt === null` → typed `NO_VAULT_SALT`, nothing cached (salt is sync-owned; never fabricated).

**Stage 2b-ii — final integration**
- The three emit sites (`useNotifyEmitter`, `useGoalNotifyEmitter`, `emitGoalCreate`) now build a raw intent with a stable `event_id` + enabled targets and `enqueue` → `flush`. Direct `writeEventFile`/`writeEventFileICloud`/`sendIntentDb` calls removed — transports are reached only through deliverers.
- **Snapshot timing fix:** the notify hooks advance the change-snapshot only after the intents are durably enqueued; a failed enqueue does not advance it.
- **Flush triggers:** on enqueue, on app mount + focus + poll cadence (`useOutboxFlush`), and after vault key setup.

**Follow-up fix**
- The "Track in lifeGLANCE" goal-share checkbox was gated on WebDAV intents only, so it was hidden for a vault-only user. Now gated on `enabledIntentTargets(...).length > 0` (any enabled transport).

## Testing
- New unit/integration tests across all stages: outbox lifecycle, deliverer outcomes + always-encrypted vault, receive plaintext rejection, key-setup paths, emit→outbox→flush integration (incl. a real-deliverer encrypted-row roundtrip), and the target-enablement matrix.
- Full suite **372 passing**; production build clean.
- No changes to `@glance-apps/intents` or `@glance-apps/sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014sbrgAjco6WnCBymjqFr4N)_