### PR TITLE
Hold + bounded-retry vault receive on key-not-ready (no intent loss)

### DIFF
--- a/src/intents/dbIntentsKeyRetry.test.js
+++ b/src/intents/dbIntentsKeyRetry.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { buildEncryptedEnvelope, deriveIntentsRootKey, deriveEnvelopeKey } from '@glance-apps/intents';
+
+// Mock the handler so a decrypted+routed row is observable without app context.
+vi.mock('./handleIntent.js', () => ({ handleIntent: vi.fn(async () => ({ success: true })) }));
+
+import {
+  sendIntentsDb,
+  pollDbIntents,
+  routeIncoming,
+  DB_CURSOR_KEY,
+  DB_RETRY_KEY,
+  MAX_INTENT_RETRIES,
+} from './dbIntentsTransport.js';
+import { handleIntent } from './handleIntent.js';
+import { getActivityLog } from './intentLog.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Vault RECEIVE: key-not-ready folds into the bounded-retry three-way model.
+// A row that fails to decrypt because the key is ABSENT (transient) must be HELD
+// + bounded-retried, NEVER advanced past (lost). A decrypt failure with the key
+// PRESENT (wrong key / bad ciphertext) stays permanent (advance + log).
+//
+// Drives the REAL routeIncoming through the REAL drain (pollDbIntents) against an
+// in-memory GLANCEvault server, with the vault key flipped via the loadKey seam.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CONN = { vaultUrl: 'https://vault.example.com', vaultToken: 'tok-123', accountId: 'acct-1' };
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+// In-memory /intents server: insert-only on eventId, global seq, { rows, hasMore }.
+function createMemoryIntentsServer({ pageSize = 500, now = () => Date.now() } = {}) {
+  const rows = [];
+  const byEventId = new Map();
+  let seq = 0;
+  const vaultFetch = async (method, url, headers, body) => {
+    const u = new URL(url);
+    if (headers?.Authorization !== `Bearer ${CONN.vaultToken}`) {
+      return { status: 401, ok: false, body: JSON.stringify({ error: 'unauthorized' }) };
+    }
+    if (method === 'POST' && u.pathname === '/intents/batch') {
+      const parsed = JSON.parse(body);
+      let written = 0;
+      for (const ev of parsed.events) {
+        if (byEventId.has(ev.eventId)) continue;
+        const row = { eventId: ev.eventId, envelope: ev.envelope, seq: ++seq, expiresAt: new Date(ev.expiresAt).toISOString(), serverMtime: new Date(now()).toISOString() };
+        rows.push(row); byEventId.set(ev.eventId, row); written++;
+      }
+      return { status: 200, ok: true, body: JSON.stringify({ written, maxSeq: seq }) };
+    }
+    if (method === 'GET' && u.pathname === '/intents/list') {
+      const since = Number(u.searchParams.get('since'));
+      const limit = Number(u.searchParams.get('limit')) || pageSize;
+      const nowMs = now();
+      const visible = rows.filter((r) => r.seq > since).filter((r) => new Date(r.expiresAt).getTime() > nowMs).sort((a, b) => a.seq - b.seq);
+      const page = visible.slice(0, limit);
+      return { status: 200, ok: true, body: JSON.stringify({ rows: page, hasMore: visible.length > limit }) };
+    }
+    return { status: 404, ok: false, body: '{}' };
+  };
+  return { vaultFetch, rows };
+}
+
+function validPayload() {
+  return {
+    event_id: 'evt-1', source_app: 'app.lifeglance', source_entity_id: 'se-1',
+    event: 'completed', task_id: 'task-1', title: 'inbound', timestamp: '2026-01-01T00:00:00.000Z', entity_type: 'task',
+  };
+}
+
+async function encryptedRow(rootKey, eventId) {
+  return buildEncryptedEnvelope(
+    { action: 'notify', payload: validPayload(), emittedBy: 'app.lifeglance', eventId },
+    (salt) => deriveEnvelopeKey(rootKey, salt),
+  );
+}
+
+const poll = (server, route) =>
+  pollDbIntents({}, { connection: CONN, vaultFetch: server.vaultFetch, routeIncoming: route });
+
+const cursor = () => localStorage.getItem(DB_CURSOR_KEY);
+const retries = () => JSON.parse(localStorage.getItem(DB_RETRY_KEY) || '{}');
+
+beforeEach(() => { global.localStorage = memLocalStorage(); handleIntent.mockClear(); });
+afterAll(() => { delete global.localStorage; });
+
+describe('vault receive — key-not-ready is transient (bounded retry)', () => {
+  it('(a) key ABSENT does not advance; once the key is present it decrypts, advances, clears counter', async () => {
+    const server = createMemoryIntentsServer();
+    const rootKey = await deriveIntentsRootKey('pw', new Uint8Array(16).fill(7));
+    await sendIntentsDb(await encryptedRow(rootKey, '20260101T000000Z-aaa111'), { connection: CONN, config: { ttlMs: 3600_000 }, vaultFetch: server.vaultFetch });
+
+    let keyPresent = false;
+    const route = (envelope, ctx) => routeIncoming(envelope, ctx, { loadKey: async () => (keyPresent ? rootKey : null) });
+
+    // Poll 1: key absent → HELD. Cursor not advanced; per-seq counter bumped.
+    await poll(server, route);
+    expect(cursor()).toBeNull();
+    expect(retries()['1']).toBe(1);
+    expect(handleIntent).not.toHaveBeenCalled();
+
+    // Key becomes available → decrypts, processes, advances, clears the counter.
+    keyPresent = true;
+    await poll(server, route);
+    expect(cursor()).toBe('1');
+    expect(localStorage.getItem(DB_RETRY_KEY)).toBeNull(); // counter cleared
+    expect(handleIntent).toHaveBeenCalledTimes(1);
+  });
+
+  it('(b) decrypt fails with the key PRESENT (wrong key) is permanent: advances + logs, handler not called', async () => {
+    const server = createMemoryIntentsServer();
+    const keyA = await deriveIntentsRootKey('A', new Uint8Array(16).fill(1));
+    const keyB = await deriveIntentsRootKey('B', new Uint8Array(16).fill(2));
+    await sendIntentsDb(await encryptedRow(keyA, '20260101T000000Z-bad222'), { connection: CONN, config: { ttlMs: 3600_000 }, vaultFetch: server.vaultFetch });
+
+    // Wrong key, but PRESENT → WrongKeyError → permanent.
+    const route = (envelope, ctx) => routeIncoming(envelope, ctx, { loadKey: async () => keyB });
+    await poll(server, route);
+
+    expect(cursor()).toBe('1');                       // advanced past the bad row
+    expect(localStorage.getItem(DB_RETRY_KEY)).toBeNull(); // not held for retry
+    expect(handleIntent).not.toHaveBeenCalled();
+    expect(getActivityLog().some((e) => e.error === 'WrongKeyError')).toBe(true);
+  });
+
+  it('(c) a persistently key-absent row gives up at the bound (advance + loud log), no wedge', async () => {
+    const server = createMemoryIntentsServer();
+    const rootKey = await deriveIntentsRootKey('pw', new Uint8Array(16).fill(9));
+    await sendIntentsDb(await encryptedRow(rootKey, '20260101T000000Z-ccc333'), { connection: CONN, config: { ttlMs: 3600_000 }, vaultFetch: server.vaultFetch });
+
+    const route = (envelope, ctx) => routeIncoming(envelope, ctx, { loadKey: async () => null }); // never available
+
+    // Each poll holds + bumps; below the cap the cursor stays put.
+    for (let i = 1; i < MAX_INTENT_RETRIES; i++) {
+      await poll(server, route);
+      expect(cursor()).toBeNull();
+      expect(retries()['1']).toBe(i);
+    }
+    // The MAX_INTENT_RETRIES-th failure gives up: advance + clear + loud log.
+    await poll(server, route);
+    expect(cursor()).toBe('1');
+    expect(localStorage.getItem(DB_RETRY_KEY)).toBeNull();
+    expect(handleIntent).not.toHaveBeenCalled();
+    expect(getActivityLog().some((e) => String(e.error).startsWith('gave_up_after'))).toBe(true);
+  });
+});

--- a/src/intents/dbIntentsReceive.test.js
+++ b/src/intents/dbIntentsReceive.test.js
@@ -6,7 +6,7 @@ import { buildEnvelope, buildEncryptedEnvelope, deriveIntentsRootKey, deriveEnve
 // rows it accepts; a rejected plaintext row must never reach it.
 vi.mock('./handleIntent.js', () => ({ handleIntent: vi.fn(async () => ({ success: true })) }));
 
-import { routeIncoming } from './dbIntentsTransport.js';
+import { routeIncoming, KeyUnavailableError } from './dbIntentsTransport.js';
 import { handleIntent } from './handleIntent.js';
 import { getActivityLog } from './intentLog.js';
 
@@ -69,15 +69,16 @@ describe('vault receive plaintext rejection', () => {
     expect(handleIntent.mock.calls[0][1].title).toBe('inbound');
   });
 
-  it('(d) an encrypted row with NO vault key cached is held (permanent for this drain, no_root_key)', async () => {
+  it('(d) an encrypted row with NO vault key cached is TRANSIENT: routeIncoming throws (held, not advanced)', async () => {
     const rootKey = await deriveIntentsRootKey('pw', new Uint8Array(16).fill(8));
     const env = await buildEncryptedEnvelope({
       action: 'notify', payload: validPayload(), emittedBy: 'app.lifeglance', eventId: '20260101T000000Z-ccc333',
     }, (salt) => deriveEnvelopeKey(rootKey, salt));
 
-    const outcome = await routeIncoming(env, {}, { loadKey: async () => null });
-    expect(outcome).toBe('permanent');
+    // Key absent → KeyUnavailableError so the drain HOLDS + bounded-retries
+    // (never advances past / loses the row). It is no longer a permanent skip.
+    await expect(routeIncoming(env, {}, { loadKey: async () => null }))
+      .rejects.toBeInstanceOf(KeyUnavailableError);
     expect(handleIntent).not.toHaveBeenCalled();
-    expect(getActivityLog()[0].error).toBe('no_root_key');
   });
 });

--- a/src/intents/dbIntentsTransport.js
+++ b/src/intents/dbIntentsTransport.js
@@ -64,6 +64,20 @@ const MAX_INTENT_RETRIES = 5;
 const PAGE_LIMIT = 500;
 const APP_EMITTER = 'app.dayglance';
 
+// Thrown by routeIncoming when the vault intents key isn't available yet (cached
+// key absent, or a NoKeyError surfaced during parse). This is a TRANSIENT
+// condition — the key becomes available once setup/restore completes — so the
+// drain must HOLD + bounded-retry (same machinery as a handler throw), never
+// advance past the row. Distinct from a genuine decrypt failure with the key
+// PRESENT (wrong key / bad ciphertext), which is permanent.
+export class KeyUnavailableError extends Error {
+  constructor(message = 'vault intents key not available') {
+    super(message);
+    this.name = 'KeyUnavailableError';
+  }
+}
+
+
 // The tray popup holds a read-only snapshot and must never poll — processing an
 // event would consume it before the main window can act (mirrors useIntentPoller).
 const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
@@ -252,12 +266,11 @@ async function routeIncoming(raw, context, opts = {}) {
     if (raw?.encrypted === true) {
       const rootKey = await loadKey();
       if (!rootKey) {
-        console.warn('[db-intent] Skipping encrypted event — intents encryption not set up');
-        logActivity({
-          direction: 'in', action: 'unknown', event: null, source_app: null,
-          title: null, timestamp: new Date().toISOString(), status: 'error', error: 'no_root_key',
-        });
-        return 'permanent';
+        // KEY NOT AVAILABLE — transient (setup not complete yet, or mid-restore).
+        // Throw so the drain HOLDS + bounded-retries via the SAME machinery as a
+        // handler throw; once the key exists the held row decrypts and processes.
+        // Do NOT advance/lose the row here.
+        throw new KeyUnavailableError();
       }
       envelope = await parseEncryptedEnvelope(raw, (salt) => deriveEnvelopeKey(rootKey, salt));
     } else {
@@ -276,13 +289,23 @@ async function routeIncoming(raw, context, opts = {}) {
       return 'permanent';
     }
   } catch (parseErr) {
+    // TRANSIENT — key not available: our own KeyUnavailableError, or a NoKeyError
+    // surfaced by the parser. Re-throw so the drain HOLDS + bounded-retries
+    // (persisted per-seq counter, give up at MAX_INTENT_RETRIES) instead of
+    // advancing past — never lose a row that only failed for lack of a key.
+    if (parseErr instanceof KeyUnavailableError) throw parseErr;
+    if (parseErr instanceof NoKeyError) {
+      console.warn('[db-intent] Holding encrypted event — vault intents key not available (NoKeyError)');
+      throw new KeyUnavailableError('vault intents key not available (NoKeyError)');
+    }
+
+    // PERMANENT — key IS present but the row won't decrypt/validate (wrong key,
+    // corrupt ciphertext, or malformed/protocol mismatch). Advance past + log.
     let errorCode = parseErr.name ?? 'parse_error';
     // MalformedEnvelopeError = decrypted/parsed fine but failed schema validation
     // (protocol mismatch) — amber, not a genuine key/network failure.
     let logStatus = 'error';
-    if (parseErr instanceof NoKeyError) {
-      console.warn('[db-intent] Skipping encrypted event (no key)');
-    } else if (parseErr instanceof WrongKeyError) {
+    if (parseErr instanceof WrongKeyError) {
       console.warn('[db-intent] Skipping encrypted event (wrong key)');
     } else if (parseErr instanceof MalformedEnvelopeError) {
       console.warn('[db-intent] Skipping malformed envelope:', parseErr.message);
@@ -343,12 +366,16 @@ async function routeIncoming(raw, context, opts = {}) {
  * never read .rows just once.
  *
  * Per-row failure handling is three-way:
- *   (1) DECODE / PERMANENT-BAD (unparseable row, decrypt failure, or a SOFT
- *       handler result.success===false) → advance past it; retrying is pointless.
- *   (2) HANDLER THREW (maybe-transient) → do NOT advance; bump a persisted
- *       per-seq counter. At MAX_INTENT_RETRIES consecutive failures the row is
- *       poison: give up, log loudly, advance past it. Below the cap, HOLD —
- *       stop the whole drain (cursor unchanged) so the next poll retries here.
+ *   (1) DECODE / PERMANENT-BAD (unparseable row, a plaintext-on-vault rejection,
+ *       a decrypt failure WITH THE KEY PRESENT — wrong key / bad ciphertext — or
+ *       a SOFT handler result.success===false) → advance past it; retrying is
+ *       pointless.
+ *   (2) TRANSIENT — HANDLER THREW or KEY NOT AVAILABLE (routeIncoming throws
+ *       KeyUnavailableError when the vault intents key is absent). Do NOT advance;
+ *       bump a persisted per-seq counter. At MAX_INTENT_RETRIES consecutive
+ *       failures the row is poison: give up, log loudly, advance past it. Below
+ *       the cap, HOLD — stop the whole drain (cursor unchanged) so the next poll
+ *       retries here (the key may have become available by then).
  *   (3) SUCCESS → advance and clear the seq's counter.
  *
  * Connection is inherited from the vault SYNC config unless injected (tests).


### PR DESCRIPTION
## Confirmation: the issue existed

The vault intents receive drain already had a three-way model for **handler** outcomes (success → advance; handler threw → hold + bounded retry, give up at `MAX_INTENT_RETRIES`; permanent/soft-fail → advance + log). But **decrypt / key-availability failures were handled outside that model**. When the vault key was absent, `routeIncoming` returned `'permanent'`:

```js
if (!rootKey) {
  console.warn('[db-intent] Skipping encrypted event — intents encryption not set up');
  logActivity({ … error: 'no_root_key' });
  return 'permanent';            // ← drain advances the cursor past the row
}
```

and the drain treats `'permanent'` as **advance past the row** — permanently losing an intent that only failed because the key wasn't ready yet (a transient condition that resolves once setup/restore completes). Exactly the data-loss class we've been closing elsewhere.

## The fix

Fold key-not-ready into the existing transient branch — no second retry mechanism:

- `routeIncoming` now **throws `KeyUnavailableError`** when the cached vault key is absent (and re-throws a parser `NoKeyError` as the same). A throw out of `routeIncoming` is precisely what the drain already treats as transient: it bumps the persisted per-seq counter and **holds** (cursor unchanged) so the next poll retries; at `MAX_INTENT_RETRIES` it **gives up loudly and advances** so a permanently-keyless state can't wedge the channel forever.
- A decrypt failure with the key **present** (wrong key / corrupt ciphertext / malformed) stays **permanent** → advance + log. Plaintext-on-vault rejection and the handler outcomes are unchanged.

Resulting uniform model:

| cause | outcome |
|---|---|
| key not available | **transient → hold + bounded retry** (new) |
| decrypt fails, key present (bad row) | permanent → advance + log |
| plaintext row over vault | permanent (reject) → advance + log |
| handler threw | transient → hold + bounded retry |
| handler permanent/soft-fail | advance + log |
| success | advance + clear counter |

## Tests
- **(a)** key absent → cursor not advanced, per-seq counter bumped; once the key is present → decrypts, advances, counter clears.
- **(b)** wrong key present → permanent: advances + logs `WrongKeyError`, handler not called.
- **(c)** persistently key-absent → gives up at `MAX_INTENT_RETRIES` (loud `gave_up_after_*` log + advance), no wedge.
- Updated the prior `no_root_key` test to the new held/throws contract; existing receive + drain tests still pass.
- Full suite **375 passing**; production build clean. No changes to send path, deliverers, outbox, key setup, or `@glance-apps/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014sbrgAjco6WnCBymjqFr4N)_