### PR TITLE
Release 3.7.0: multi-user visibility fixes, recurring assignment, native search, sync polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.6.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.7.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 131
-        versionName = "3.6"
+        versionCode = 132
+        versionName = "3.7"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "dependencies": {
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.6.0",
+  "version": "3.7.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2658,7 +2658,7 @@ const DayPlanner = () => {
 
     // Today's recurring instances past their end time
     const todayRecurring = expandedRecurringTasks.filter(t =>
-      t.date === todayStr && !t.completed && !t.isExample && isOverdueToday(t)
+      t.date === todayStr && !t.completed && !t.isExample && isVisibleForUser(t) && isOverdueToday(t)
     ).map(t => ({ ...t, _overdueType: 'scheduled' }));
 
     // Past uncompleted recurring all-day instances (look back up to 7 days)
@@ -2669,6 +2669,7 @@ const DayPlanner = () => {
       const dateStr = dateToString(d);
       for (const template of recurringTasks) {
         if (template.isExample) continue;
+        if (!isVisibleForUser(template)) continue;
         const isTemplateAllDay = template.isAllDay ?? false;
         if (!isTemplateAllDay) continue;
         const occs = getOccurrencesInRange(template, dateStr, dateStr);
@@ -2892,10 +2893,13 @@ const DayPlanner = () => {
     setTrmnlSyncStatus('syncing');
     try {
       const today = selectedDate ? dateToString(selectedDate) : new Date().toISOString().slice(0, 10);
+      // Multi-user: the TRMNL dashboard belongs to the current user, so scope
+      // tasks to what's visible to "me" before gathering the payload. Imported
+      // calendar events carry no assignment and remain included.
       const mergeVars = gatherTrmnlData({
-        tasks,
-        unscheduledTasks,
-        recurringTasks,
+        tasks: tasks.filter(isVisibleForUser),
+        unscheduledTasks: unscheduledTasks.filter(isVisibleForUser),
+        recurringTasks: recurringTasks.filter(isVisibleForUser),
         selectedDate: today,
         use24HourClock: use24HourClock,
         habits: activeHabits,
@@ -3366,9 +3370,10 @@ const DayPlanner = () => {
   const hasTasksOnDate = (date) => {
     if (!date) return false;
     const dateStr = dateToString(date);
-    if (tasks.some(task => task.date === dateStr)) return true;
+    if (tasks.some(task => task.date === dateStr && isVisibleForUser(task))) return true;
     // Check recurring tasks for this date
     for (const template of recurringTasks) {
+      if (!isVisibleForUser(template)) continue;
       const occs = getOccurrencesInRange(template, dateStr, dateStr);
       if (occs.length > 0) return true;
     }
@@ -3380,7 +3385,7 @@ const DayPlanner = () => {
     const importedDates = new Set();
     const appTaskDates = new Set();
     for (const task of tasks) {
-      if (!task.date) continue;
+      if (!task.date || !isVisibleForUser(task)) continue;
       if (task.imported) importedDates.add(task.date);
       else appTaskDates.add(task.date);
     }
@@ -3391,16 +3396,17 @@ const DayPlanner = () => {
     const rangeEnd = dateToString(new Date(year, month + 1, 0));
     const recurringDates = new Set();
     for (const template of recurringTasks) {
+      if (!isVisibleForUser(template)) continue;
       const occs = getOccurrencesInRange(template, rangeStart, rangeEnd);
       for (const dateStr of occs) recurringDates.add(dateStr);
     }
     // Inbox tasks with deadlines
     const deadlineDates = new Set();
     for (const task of unscheduledTasks) {
-      if (task.deadline) deadlineDates.add(task.deadline);
+      if (task.deadline && isVisibleForUser(task)) deadlineDates.add(task.deadline);
     }
     return { importedDates, appTaskDates, recurringDates, deadlineDates };
-  }, [tasks, recurringTasks, unscheduledTasks, viewedMonth]);
+  }, [tasks, recurringTasks, unscheduledTasks, viewedMonth, isVisibleForUser]);
 
   // Returns which indicator dots to show for a date: { hasNote, hasImported, hasAppTask }
   const getDateIndicators = (date) => {
@@ -6194,8 +6200,8 @@ const DayPlanner = () => {
       const calendarEventsToday = tasks.filter(t => t.date === todayStr && t.imported && !t.isTaskCalendar)
         .map(t => ({ title: t.title, time: t.startTime, isAllDay: t.isAllDay || false, duration: t.duration || 0 }))
         .sort((a, b) => (a.time || '').localeCompare(b.time || ''));
-      // Gather today's recurring tasks
-      const todayRecurring = recurringTasks.flatMap(t => {
+      // Gather today's recurring tasks (series-level assignment → filter templates)
+      const todayRecurring = recurringTasks.filter(isVisibleForUser).flatMap(t => {
         const occs = getOccurrencesInRange(t, todayStr, todayStr);
         return occs.map(() => ({ title: t.title, time: t.startTime, completed: (t.completedDates || []).includes(todayStr) }));
       }).filter(t => !t.completed);
@@ -6936,8 +6942,8 @@ const DayPlanner = () => {
 
     // Gather tomorrow's tasks (regular + recurring)
     const regularTasks = tasks.filter(t => t.date === tomorrowStr && !t.completed && !t.isExample && isVisibleForUser(t));
-    // Expand recurring tasks for tomorrow
-    const recurringInstances = recurringTasks.flatMap(template => {
+    // Expand recurring tasks for tomorrow (series-level assignment → filter templates)
+    const recurringInstances = recurringTasks.filter(isVisibleForUser).flatMap(template => {
       const occs = getOccurrencesInRange(template, tomorrowStr, tomorrowStr);
       return occs.map(dateStr => {
         const completed = (template.completedDates || []).includes(dateStr);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3573,6 +3573,7 @@ const DayPlanner = () => {
             notes: template?.notes || '',
             subtasks: template?.subtasks ? JSON.parse(JSON.stringify(template.subtasks)) : [],
             date: newTask.date || parsed.dateStr,
+            ...(mobileEditingTask.assignedUserSyncIds?.length ? { assignedUserSyncIds: mobileEditingTask.assignedUserSyncIds } : {}),
           };
           setTasks(prev => [...prev, regularTask]);
           recordDeletedTaskTombstone(parsed.templateId);
@@ -3608,32 +3609,51 @@ const DayPlanner = () => {
               assignedUserSyncIds: mobileEditingTask.assignedUserSyncIds,
             }]);
           } else {
+            // User-assignment scope chosen in the Edit Task modal: 'all' (the
+            // whole series, default) or 'this' (only the edited occurrence).
+            const assignScope = mobileEditingTask._assignScope || 'all';
+            const assigned = mobileEditingTask.assignedUserSyncIds;
             setRecurringTasks(prev => prev.map(t => {
-              if (t.id === parsed.templateId) {
-                const updated = {
-                  ...t,
-                  exceptions: {
-                    ...t.exceptions,
-                    [parsed.dateStr]: {
-                      ...(t.exceptions?.[parsed.dateStr] || {}),
-                      title: cleanTitle(newTask.title),
-                      startTime: newTask.isAllDay ? '00:00' : newTask.startTime,
-                      duration: newTask.duration,
-                      isAllDay: newTask.isAllDay || false,
-                      color: newTask.color || colors[0].class,
+              if (t.id !== parsed.templateId) return t;
+              // Title/time/colour edits always live on this date's exception.
+              const instanceException = {
+                ...(t.exceptions?.[parsed.dateStr] || {}),
+                title: cleanTitle(newTask.title),
+                startTime: newTask.isAllDay ? '00:00' : newTask.startTime,
+                duration: newTask.duration,
+                isAllDay: newTask.isAllDay || false,
+                color: newTask.color || colors[0].class,
+              };
+              let exceptions = { ...t.exceptions, [parsed.dateStr]: instanceException };
+              let templateAssigned = t.assignedUserSyncIds;
+              if (assignScope === 'this') {
+                // Assign only this occurrence: store the override on its exception.
+                // An empty array means "everybody" for this date; undefined leaves
+                // it inheriting the series value.
+                if (assigned !== undefined) instanceException.assignedUserSyncIds = assigned;
+              } else {
+                // Assign the whole series: write to the template and strip any
+                // per-instance assignment overrides so the series value wins on
+                // every occurrence.
+                templateAssigned = assigned ?? t.assignedUserSyncIds;
+                exceptions = Object.fromEntries(
+                  Object.entries(exceptions).map(([d, exc]) => {
+                    if (exc && 'assignedUserSyncIds' in exc) {
+                      const { assignedUserSyncIds, ...rest } = exc;
+                      return [d, rest];
                     }
-                  }
-                };
-                // User assignment applies to the whole series, not just this
-                // instance: write it to the template so every occurrence inherits
-                // it. (Empty array clears the assignment; nullish leaves it as-is.)
-                updated.assignedUserSyncIds = mobileEditingTask.assignedUserSyncIds ?? t.assignedUserSyncIds;
-                // Update recurrence pattern on template if changed
-                updated.recurrence = { ...newTask.recurrence, startDate: t.recurrence?.startDate || parsed.dateStr.substring(0, 8) + '01' };
-                updated.lastModified = new Date().toISOString();
-                return updated;
+                    return [d, exc];
+                  })
+                );
               }
-              return t;
+              return {
+                ...t,
+                exceptions,
+                assignedUserSyncIds: templateAssigned,
+                // Update recurrence pattern on template if changed
+                recurrence: { ...newTask.recurrence, startDate: t.recurrence?.startDate || parsed.dateStr.substring(0, 8) + '01' },
+                lastModified: new Date().toISOString(),
+              };
             }));
           }
         }
@@ -6520,9 +6540,9 @@ const DayPlanner = () => {
           color: exception?.color ?? template.color,
           completed,
           isAllDay: exception?.isAllDay ?? template.isAllDay ?? false,
-          // Assignment is series-level: always inherit from the template so every
-          // instance is visible to (and filterable by) the same assigned users.
-          assignedUserSyncIds: template.assignedUserSyncIds,
+          // Assignment is series-level by default (inherited from the template),
+          // but an instance can carry its own override when assigned "this only".
+          assignedUserSyncIds: exception?.assignedUserSyncIds ?? template.assignedUserSyncIds,
           notes: template.notes || '',
           subtasks: template.subtasks || [],
           date: dateStr,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6751,6 +6751,9 @@ const DayPlanner = () => {
     const cutoffStr = dateToString(cutoff);
 
     const matchTask = (task, source, sourceLabel, date) => {
+      // Respect multi-user visibility — don't surface other users' tasks.
+      // (Native calendar events carry no assignment, so they stay visible.)
+      if (!isVisibleForUser(task)) return;
       // Skip scheduled tasks older than 2 years
       if (date && date < cutoffStr) return;
       // Check title
@@ -6841,7 +6844,7 @@ const DayPlanner = () => {
     });
 
     return results.slice(0, 50);
-  }, [showSpotlight, spotlightQuery, tasks, unscheduledTasks, recurringTasks, recycleBin, spotlightNativeTasks]);
+  }, [showSpotlight, spotlightQuery, tasks, unscheduledTasks, recurringTasks, recycleBin, spotlightNativeTasks, isVisibleForUser]);
 
   // Compute today's agenda for dayGLANCE section (excludes past events)
   const todayAgenda = useMemo(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -191,6 +191,12 @@ const TimePicker = ({ value, onChange, use24HourClock, borderClass, darkMode }) 
 
 const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
 
+// How far back/forward the spotlight search fetches native (device) calendar events.
+// The timeline only loads a ±2-day window, so a broader range is fetched on demand
+// when the search opens so device-calendar events elsewhere are still searchable.
+const SPOTLIGHT_NATIVE_PAST_DAYS = 90;
+const SPOTLIGHT_NATIVE_FUTURE_DAYS = 365;
+
 const DayPlanner = () => {
   const { t } = useTranslation();
   const { isPro, isLoading: subLoading, isAndroidApp, isIOSApp, isElectronApp, productId: subProductId, subscribe, restore, prices: subPrices, trialEligible, billingEvent, clearBillingEvent, billingErrorMessage, consumeTestPurchase, canConsumeTestPurchase, isReviewerUnlocked, setReviewerUnlocked } = useSubscription();
@@ -1054,6 +1060,10 @@ const DayPlanner = () => {
   const [spotlightQuery, setSpotlightQuery] = useState('');
   const [spotlightSelectedIndex, setSpotlightSelectedIndex] = useState(0);
   const spotlightInputRef = useRef(null);
+  // Native calendar events the timeline only fetches for a ±2-day window. When the
+  // spotlight search opens we fetch a much wider window so device-calendar events
+  // become searchable (see the effect near the native-calendar fetch below).
+  const [spotlightNativeTasks, setSpotlightNativeTasks] = useState([]);
 
   const { changeDate, goToToday, goToDate, handleSpotlightSelect } = useNavigation({
     visibleDays,
@@ -3889,6 +3899,66 @@ const DayPlanner = () => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedDate, calendarFilter, nativeCalendarKey]);
 
+  // Wider native-calendar fetch for the spotlight search. The timeline effect above
+  // only loads a ±2-day window, so device-calendar events on other dates never reach
+  // the search. When the search opens, fetch a broad window (cached for the session)
+  // and feed it into spotlightResults. macOS (Electron) resolves the whole range in a
+  // single async IPC call; the mobile bridge is synchronous per-day, so we fetch in
+  // chunks with yields between them and publish results progressively to avoid
+  // blocking the main thread while the modal is open.
+  useEffect(() => {
+    if (!showSpotlight || !hasNativeCalendar()) return;
+    const filterSet = calendarFilter.length > 0 ? new Set(calendarFilter) : null;
+    const start = new Date(); start.setDate(start.getDate() - SPOTLIGHT_NATIVE_PAST_DAYS);
+    const end = new Date(); end.setDate(end.getDate() + SPOTLIGHT_NATIVE_FUTURE_DAYS);
+    const dates = [];
+    for (const d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) dates.push(dateToString(d));
+
+    const toTasks = (results) => {
+      const seen = new Set();
+      const flat = results
+        .flatMap((result, i) => Array.isArray(result) ? result.map(e => ({ ...e, _queryDate: dates[i] })) : [])
+        .filter(e => !filterSet || filterSet.has(e.calendarId))
+        .map(e => nativeEventToTask(e))
+        .filter(t => { if (seen.has(t.id)) return false; seen.add(t.id); return true; });
+      // Collapse repeated/recurring occurrences (same title + calendar) to the single
+      // occurrence nearest today, so a daily/weekly event doesn't flood the results.
+      const todayMs = new Date(getTodayStr()).getTime();
+      const byKey = new Map();
+      for (const t of flat) {
+        const key = `${(t.title || '').toLowerCase()}|${t.calendarName || ''}`;
+        const existing = byKey.get(key);
+        if (!existing) { byKey.set(key, t); continue; }
+        const dist = (d) => Math.abs(new Date(d).getTime() - todayMs);
+        if (dist(t.date) < dist(existing.date)) byKey.set(key, t);
+      }
+      return [...byKey.values()];
+    };
+
+    let cancelled = false;
+    if (isNativeApp()) {
+      // Synchronous bridge: walk the window in day-chunks, yielding between chunks.
+      const CHUNK = 30;
+      const acc = new Array(dates.length).fill(null);
+      let i = 0;
+      const step = () => {
+        if (cancelled) return;
+        const endIdx = Math.min(i + CHUNK, dates.length);
+        for (; i < endIdx; i++) acc[i] = nativeGetEvents(dates[i]);
+        setSpotlightNativeTasks(toTasks(acc));
+        if (i < dates.length) setTimeout(step, 0);
+      };
+      step();
+      return () => { cancelled = true; };
+    } else {
+      electronGetEventsByDate(dates).then(results => {
+        if (!cancelled) setSpotlightNativeTasks(toTasks(results));
+      });
+      return () => { cancelled = true; };
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showSpotlight, calendarFilter, nativeCalendarKey]);
+
   const enterFocusMode = () => {
     setShowFocusMode(true);
     setFocusShowSettings(true);
@@ -6706,9 +6776,16 @@ const DayPlanner = () => {
       }
     };
 
-    // Scheduled tasks
+    // Scheduled tasks. Native (device-calendar) events that the timeline merged into
+    // `tasks` for the current ±2-day window are skipped here — they're searched via
+    // the wider spotlightNativeTasks set below so they aren't listed twice.
     for (const task of tasks) {
+      if (task._native) continue;
       matchTask(task, 'scheduled', 'Scheduled', task.date);
+    }
+    // Native calendar events fetched over the wider spotlight window
+    for (const task of spotlightNativeTasks) {
+      matchTask(task, 'event', 'Calendar', task.date);
     }
     // Inbox tasks (archived get their own source/label)
     for (const task of unscheduledTasks) {
@@ -6746,7 +6823,7 @@ const DayPlanner = () => {
     results.forEach(r => { r.group = getGroup(r); });
 
     // Sort: by group, then title match, then source priority, then date
-    const sourcePriority = { scheduled: 0, inbox: 1, recurring: 2, deleted: 3, archived: 4 };
+    const sourcePriority = { scheduled: 0, event: 1, inbox: 2, recurring: 3, deleted: 4, archived: 5 };
     results.sort((a, b) => {
       const gA = groupOrder[a.group] ?? 6;
       const gB = groupOrder[b.group] ?? 6;
@@ -6763,7 +6840,7 @@ const DayPlanner = () => {
     });
 
     return results.slice(0, 50);
-  }, [showSpotlight, spotlightQuery, tasks, unscheduledTasks, recurringTasks, recycleBin]);
+  }, [showSpotlight, spotlightQuery, tasks, unscheduledTasks, recurringTasks, recycleBin, spotlightNativeTasks]);
 
   // Compute today's agenda for dayGLANCE section (excludes past events)
   const todayAgenda = useMemo(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1189,6 +1189,7 @@ const DayPlanner = () => {
     playUISound,
     onboardingProgress,
     setOnboardingProgress,
+    isVisibleForUser,
   });
   const { conflicts, checkConflicts } = useConflictDetection({
     tasks,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3621,10 +3621,13 @@ const DayPlanner = () => {
                       duration: newTask.duration,
                       isAllDay: newTask.isAllDay || false,
                       color: newTask.color || colors[0].class,
-                      assignedUserSyncIds: mobileEditingTask.assignedUserSyncIds,
                     }
                   }
                 };
+                // User assignment applies to the whole series, not just this
+                // instance: write it to the template so every occurrence inherits
+                // it. (Empty array clears the assignment; nullish leaves it as-is.)
+                updated.assignedUserSyncIds = mobileEditingTask.assignedUserSyncIds ?? t.assignedUserSyncIds;
                 // Update recurrence pattern on template if changed
                 updated.recurrence = { ...newTask.recurrence, startDate: t.recurrence?.startDate || parsed.dateStr.substring(0, 8) + '01' };
                 updated.lastModified = new Date().toISOString();
@@ -3651,7 +3654,7 @@ const DayPlanner = () => {
         recurrence: { ...newTask.recurrence, startDate: taskDate },
         completedDates: existingTask?.completed ? [taskDate] : [],
         exceptions: {},
-        assignedUserSyncIds: newTask.assignedUserSyncIds || existingTask?.assignedUserSyncIds,
+        assignedUserSyncIds: mobileEditingTask.assignedUserSyncIds ?? existingTask?.assignedUserSyncIds,
         lastModified: new Date().toISOString()
       };
       setTasks(prev => prev.filter(t => t.id !== taskId));
@@ -6517,7 +6520,9 @@ const DayPlanner = () => {
           color: exception?.color ?? template.color,
           completed,
           isAllDay: exception?.isAllDay ?? template.isAllDay ?? false,
-          assignedUserSyncIds: exception?.assignedUserSyncIds ?? template.assignedUserSyncIds,
+          // Assignment is series-level: always inherit from the template so every
+          // instance is visible to (and filterable by) the same assigned users.
+          assignedUserSyncIds: template.assignedUserSyncIds,
           notes: template.notes || '',
           subtasks: template.subtasks || [],
           date: dateStr,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8764,6 +8764,9 @@ const DayPlanner = () => {
       return { ok: true };
     },
     vaultStatus, vaultError, vaultLastSynced, vaultSkipped,
+    // Reactive enablement flag for the header sync button. A vault enable/disable
+    // always reloads the app (CloudSyncSettingsForm), so a render-time read is current.
+    vaultEnabled: isVaultEnabled(),
     syncAll,
     performObsidianSync, loadWikiNote, saveWikiNote, openInObsidian, nativeClearVault,
     performTrmnlSync,

--- a/src/components/DesktopHeader.jsx
+++ b/src/components/DesktopHeader.jsx
@@ -33,10 +33,22 @@ const DesktopHeader = () => {
     isSyncing,
     setShowBackupMenu,
     cloudSyncConfig, cloudSyncStatus, cloudSyncLastSynced,
+    vaultEnabled, vaultStatus, vaultLastSynced, vaultSyncNow,
     obsidianConfig, obsidianSyncStatus, obsidianSyncError, obsidianLastSynced,
     cloudSyncUpload, syncAll, performObsidianSync,
   } = useSyncCtx();
   const { setShowRemindersSettings, activeReminders } = useFeaturesCtx();
+
+  // Cloud-sync button: only meaningful once WebDAV and/or GLANCEvault is set up.
+  // (Single-device or zero-config iCloud users get no button — Settings still has
+  // the full config.) When only the vault is enabled, the button drives a vault
+  // sync and reflects vault status; WebDAV keeps its existing upload behaviour.
+  const webdavOn = !!cloudSyncConfig?.enabled;
+  const syncConfigured = webdavOn || vaultEnabled;
+  const effSyncStatus = webdavOn ? cloudSyncStatus : vaultStatus;
+  const effSyncLastSynced = webdavOn ? cloudSyncLastSynced : vaultLastSynced;
+  const effSyncing = effSyncStatus === 'uploading' || effSyncStatus === 'downloading';
+  const triggerSync = () => { if (webdavOn) cloudSyncUpload(); if (vaultEnabled) vaultSyncNow?.(); };
 
   return (
       <div className={`${cardBg} border-b ${borderClass} px-4 py-2 flex items-center justify-between relative`} style={{ height: '80px' }}>
@@ -198,28 +210,22 @@ const DesktopHeader = () => {
               }`} />
             )}
           </button>}
+          {syncConfigured && (
           <button
-            onClick={() => {
-              if (cloudSyncConfig?.enabled) {
-                cloudSyncUpload();
-              } else {
-                setShowSettings(true);
-              }
-            }}
+            onClick={triggerSync}
             className={`relative p-2 ${darkMode ? 'bg-gray-700' : 'bg-stone-200'} rounded-lg ${hoverBg}`}
-            title={cloudSyncConfig?.enabled
-              ? (cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading' ? 'Syncing...' : `Cloud sync — last: ${cloudSyncLastSynced ? new Date(cloudSyncLastSynced).toLocaleTimeString() : 'never'}`)
-              : 'Set up cloud sync'}
+            title={effSyncing
+              ? 'Syncing...'
+              : `${webdavOn ? 'Cloud' : 'GLANCEvault'} sync — last: ${effSyncLastSynced ? new Date(effSyncLastSynced).toLocaleTimeString() : 'never'}`}
           >
-            <Cloud size={18} className={`${textSecondary} ${(cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'animate-pulse' : ''}`} />
-            {cloudSyncConfig?.enabled && (
-              <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full border-2 ${darkMode ? 'border-gray-800' : 'border-white'} ${
-                (cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'bg-blue-500 animate-pulse' :
-                cloudSyncStatus === 'error' ? 'bg-red-500' :
-                'bg-green-500'
-              }`} />
-            )}
+            <Cloud size={18} className={`${textSecondary} ${effSyncing ? 'animate-pulse' : ''}`} />
+            <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full border-2 ${darkMode ? 'border-gray-800' : 'border-white'} ${
+              effSyncing ? 'bg-blue-500 animate-pulse' :
+              effSyncStatus === 'error' ? 'bg-red-500' :
+              'bg-green-500'
+            }`} />
           </button>
+          )}
           {obsidianConfig?.enabled && (
             <button
               onClick={() => performObsidianSync()}

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -283,6 +283,7 @@ const DesktopLayout = () => {
     nativeEventToTask, clearNativeEventOverride, parseDatetime, parseICS, filterByDateWindow,
     loadData, saveData,
     cloudSyncDownload, cloudSyncUpload, cloudSyncTest, syncAll,
+    vaultEnabled, vaultStatus, vaultLastSynced, vaultSyncNow,
     performObsidianSync, loadWikiNote, saveWikiNote, openInObsidian,
     performTrmnlSync,
     performLocalBackup, performRemoteBackup,
@@ -294,6 +295,15 @@ const DesktopLayout = () => {
     buildSyncPayload,
     fetchAllDailyContent, fetchWeather,
   } = useSyncCtx();
+
+  // Cloud-sync button: hidden unless WebDAV and/or GLANCEvault is configured.
+  // Vault-only drives a vault sync and reflects vault status; WebDAV is unchanged.
+  const webdavOn = !!cloudSyncConfig?.enabled;
+  const syncConfigured = webdavOn || vaultEnabled;
+  const effSyncStatus = webdavOn ? cloudSyncStatus : vaultStatus;
+  const effSyncLastSynced = webdavOn ? cloudSyncLastSynced : vaultLastSynced;
+  const effSyncing = effSyncStatus === 'uploading' || effSyncStatus === 'downloading';
+  const triggerSync = () => { if (webdavOn) cloudSyncUpload(); if (vaultEnabled) vaultSyncNow?.(); };
 
   const {
     voiceRecorderRef, voiceAudioChunksRef, voiceAutoStartRef,
@@ -521,29 +531,23 @@ const DesktopLayout = () => {
                 }`} />
               )}
             </button>}
+            {syncConfigured && (
             <button
-              onClick={() => {
-                if (cloudSyncConfig?.enabled) {
-                  cloudSyncUpload();
-                } else {
-                  setShowSettings(true);
-                }
-              }}
+              onClick={triggerSync}
               className={`relative p-2 ${darkMode ? 'bg-gray-700' : 'bg-stone-200'} rounded-lg hover:bg-black/5 active:bg-black/10 dark:hover:bg-white/5 dark:active:bg-white/10 transition-colors`}
-              title={cloudSyncConfig?.enabled
-                ? (cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading' ? 'Syncing...' : `Cloud sync — last: ${cloudSyncLastSynced ? new Date(cloudSyncLastSynced).toLocaleTimeString() : 'never'}`)
-                : 'Set up cloud sync'}
+              title={effSyncing
+                ? 'Syncing...'
+                : `${webdavOn ? 'Cloud' : 'GLANCEvault'} sync — last: ${effSyncLastSynced ? new Date(effSyncLastSynced).toLocaleTimeString() : 'never'}`}
               aria-label="Cloud sync"
             >
-              <Cloud size={18} className={`${textSecondary} ${(cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'animate-pulse' : ''}`} />
-              {cloudSyncConfig?.enabled && (
-                <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full border-2 ${darkMode ? 'border-gray-800' : 'border-white'} ${
-                  (cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'bg-blue-500 animate-pulse' :
-                  cloudSyncStatus === 'error' ? 'bg-red-500' :
-                  'bg-green-500'
-                }`} />
-              )}
+              <Cloud size={18} className={`${textSecondary} ${effSyncing ? 'animate-pulse' : ''}`} />
+              <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full border-2 ${darkMode ? 'border-gray-800' : 'border-white'} ${
+                effSyncing ? 'bg-blue-500 animate-pulse' :
+                effSyncStatus === 'error' ? 'bg-red-500' :
+                'bg-green-500'
+              }`} />
             </button>
+            )}
             {obsidianConfig?.enabled && (
               <button
                 onClick={() => performObsidianSync()}

--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -279,6 +279,28 @@ const DesktopNewTaskModal = () => {
                       );
                     })}
                   </div>
+                  {/* Scope of the assignment change — only when editing an existing
+                      recurring task. New recurring tasks always assign the series. */}
+                  {mobileEditingTask && typeof mobileEditingTask.id === 'string' && mobileEditingTask.id.startsWith('recurring-') && (
+                    <div className="mt-2 flex items-center gap-2">
+                      <span className={`text-xs ${textSecondary} opacity-70`}>Apply to</span>
+                      {[{ key: 'all', label: 'All instances' }, { key: 'this', label: 'This instance' }].map(opt => {
+                        const active = (mobileEditingTask._assignScope || 'all') === opt.key;
+                        return (
+                          <button
+                            key={opt.key}
+                            type="button"
+                            onClick={() => setMobileEditingTask(prev => ({ ...prev, _assignScope: opt.key }))}
+                            className={`px-2.5 py-1 rounded-full text-xs border transition-colors ${active
+                              ? `border-blue-500 ${darkMode ? 'bg-blue-500/20 text-blue-300' : 'bg-blue-50 text-blue-700'}`
+                              : `${borderClass} ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-white text-stone-600'}`}`}
+                          >
+                            {opt.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
                 </div>
               )}
               <div className="grid grid-cols-3 gap-3">

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -247,6 +247,28 @@ const MobileNewTaskModal = () => {
                       );
                     })}
                   </div>
+                  {/* Scope of the assignment change — only when editing an existing
+                      recurring task. New recurring tasks always assign the series. */}
+                  {mobileEditingTask && typeof mobileEditingTask.id === 'string' && mobileEditingTask.id.startsWith('recurring-') && (
+                    <div className="mt-2 flex items-center gap-2">
+                      <span className={`text-xs ${textSecondary} opacity-70`}>Apply to</span>
+                      {[{ key: 'all', label: 'All instances' }, { key: 'this', label: 'This instance' }].map(opt => {
+                        const active = (mobileEditingTask._assignScope || 'all') === opt.key;
+                        return (
+                          <button
+                            key={opt.key}
+                            type="button"
+                            onClick={() => setMobileEditingTask(prev => ({ ...prev, _assignScope: opt.key }))}
+                            className={`px-2.5 py-1 rounded-full text-xs border transition-colors ${active
+                              ? `border-blue-500 ${darkMode ? 'bg-blue-500/20 text-blue-300' : 'bg-blue-50 text-blue-700'}`
+                              : `${borderClass} ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-white text-stone-600'}`}`}
+                          >
+                            {opt.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -940,7 +940,8 @@ const MobileSettingsPanel = () => {
         </div>
       )}
 
-      {/* hyperGLANCE Sessions — independent of global enabled toggle */}
+      {/* hyperGLANCE Sessions — only relevant when Goals & Projects is on */}
+      {goalsProjectsEnabled && (
       <div className={`border-t ${borderClass} pt-4`}>
         <div className="flex items-center gap-2 mb-3">
           <Zap size={16} className="text-indigo-500" />
@@ -976,6 +977,7 @@ const MobileSettingsPanel = () => {
           </div>
         )}
       </div>
+      )}
     </div>
   )}
 

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -84,7 +84,7 @@ const MobileSettingsPanel = () => {
     obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
     wikilinkCandidates, setWikilinkCandidates,
     cloudSyncTest, cloudSyncNow,
-    vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced, vaultSkipped,
+    vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced, vaultSkipped, vaultEnabled,
     syncAll, performObsidianSync, performRemoteBackup, nativeClearVault,
     loadAutoBackupHistory,
     deleteLocalAutoBackup, deleteRemoteAutoBackup,
@@ -300,14 +300,23 @@ const MobileSettingsPanel = () => {
         onClick={() => setMobileSettingsView('cloudsync')}
         className={`w-full ${cardBg} border ${borderClass} rounded-xl p-4 flex items-center gap-3`}
       >
-        <div className="relative">
-          <Cloud size={20} className={`${cloudSyncConfig?.enabled ? 'text-blue-500' : textSecondary} ${(cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'animate-pulse' : ''}`} />
-          {cloudSyncConfig?.enabled && (
-            <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full border-2 ${darkMode ? 'border-gray-800' : 'border-white'} ${
-              (cloudSyncStatus === 'uploading' || cloudSyncStatus === 'downloading') ? 'bg-blue-500 animate-pulse' : cloudSyncStatus === 'error' ? 'bg-red-500' : 'bg-green-500'
-            }`} />
-          )}
-        </div>
+        {/* Dot reflects WebDAV OR GLANCEvault; vault-only uses vault status. */}
+        {(() => {
+          const webdavOn = !!cloudSyncConfig?.enabled;
+          const syncOn = webdavOn || vaultEnabled;
+          const st = webdavOn ? cloudSyncStatus : vaultStatus;
+          const syncing = st === 'uploading' || st === 'downloading';
+          return (
+            <div className="relative">
+              <Cloud size={20} className={`${syncOn ? 'text-blue-500' : textSecondary} ${syncing ? 'animate-pulse' : ''}`} />
+              {syncOn && (
+                <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full border-2 ${darkMode ? 'border-gray-800' : 'border-white'} ${
+                  syncing ? 'bg-blue-500 animate-pulse' : st === 'error' ? 'bg-red-500' : 'bg-green-500'
+                }`} />
+              )}
+            </div>
+          );
+        })()}
         <span className={`font-medium ${textPrimary} flex-1 text-left`}>{t('settings.cloudSync')}</span>
         <ChevronRight size={18} className={textSecondary} />
       </button>

--- a/src/components/RemindersSettingsModal.jsx
+++ b/src/components/RemindersSettingsModal.jsx
@@ -15,6 +15,7 @@ const RemindersSettingsModal = () => {
     showWeeklyReviewTimePicker, setShowWeeklyReviewTimePicker,
     reminderSettings, setReminderSettings,
     applyReminderPreset, updateCategoryReminder,
+    goalsProjectsEnabled,
   } = useFeaturesCtx();
 
   return (
@@ -232,7 +233,8 @@ const RemindersSettingsModal = () => {
               )}
             </div>
 
-            {/* hyperGLANCE Sessions */}
+            {/* hyperGLANCE Sessions — only relevant when Goals & Projects is on */}
+            {goalsProjectsEnabled && (
             <div className={`border-t ${borderClass} mt-4 pt-4`}>
               <div className="flex items-center gap-2 mb-3">
                 <Zap size={16} className="text-indigo-500" />
@@ -273,6 +275,7 @@ const RemindersSettingsModal = () => {
                 </div>
               )}
             </div>
+            )}
 
             <button
               onClick={() => setShowRemindersSettings(false)}

--- a/src/components/SpotlightModal.jsx
+++ b/src/components/SpotlightModal.jsx
@@ -64,6 +64,7 @@ const SpotlightModal = () => {
           ) : (() => {
             const sourceBadgeColors = darkMode ? {
               scheduled: 'bg-blue-900/40 text-blue-300',
+              event: 'bg-amber-900/40 text-amber-300',
               inbox: 'bg-green-900/40 text-green-300',
               project: 'bg-green-900/40 text-green-300',
               recurring: 'bg-purple-900/40 text-purple-300',
@@ -71,6 +72,7 @@ const SpotlightModal = () => {
               archived: 'bg-gray-700/60 text-gray-400',
             } : {
               scheduled: 'bg-blue-100 text-blue-700',
+              event: 'bg-amber-100 text-amber-700',
               inbox: 'bg-green-100 text-green-700',
               project: 'bg-green-100 text-green-700',
               recurring: 'bg-purple-100 text-purple-700',

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -24,7 +24,7 @@ const WeeklyReviewModal = () => {
     weeklyAISummary, setWeeklyAISummary,
     weeklyAILoading, weeklyAIError, setWeeklyAIError,
     generateWeeklyAISummary,
-    goals, projects, goalsProjectsEnabled,
+    goals: allGoals, projects: allProjects, goalsProjectsEnabled,
     habitsEnabled, habits, habitLogs,
     gtdFrames,
     aiConfig,
@@ -41,12 +41,14 @@ const WeeklyReviewModal = () => {
 
   if (!showWeeklyReview) return null;
 
-  // Multi-user: the weekly review reflects only the current user's tasks, so
-  // scope every task source here before any stats are computed. Imported
-  // calendar events carry no assignment, so they remain included.
+  // Multi-user: the weekly review reflects only the current user's tasks, goals,
+  // and projects, so scope every source here before any stats are computed.
+  // Imported calendar events carry no assignment, so they remain included.
   const tasks = allTasks.filter(isVisibleForUser);
   const recurringTasks = allRecurringTasks.filter(isVisibleForUser);
   const unscheduledTasks = allUnscheduledTasks.filter(isVisibleForUser);
+  const goals = allGoals.filter(isVisibleForUser);
+  const projects = allProjects.filter(isVisibleForUser);
 
         // Compute rolling 7-day boundaries
         const today = new Date();

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -12,7 +12,7 @@ const WeeklyReviewModal = () => {
   const {
     mobileReviewPage, setMobileReviewPage,
     reviewScrollRef,
-    tasks, recurringTasks, unscheduledTasks,
+    tasks: allTasks, recurringTasks: allRecurringTasks, unscheduledTasks: allUnscheduledTasks,
     selectedDate,
     isMobile, isTablet,
     darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg,
@@ -29,6 +29,7 @@ const WeeklyReviewModal = () => {
     gtdFrames,
     aiConfig,
     ownedBy, meUserSyncId,
+    isVisibleForUser,
   } = useFeaturesCtx();
 
   // Local collapse state for past-week HABITS and FRAME UTILIZATION sections
@@ -39,6 +40,13 @@ const WeeklyReviewModal = () => {
   useEffect(() => { setMobileReviewPage(0); }, []);
 
   if (!showWeeklyReview) return null;
+
+  // Multi-user: the weekly review reflects only the current user's tasks, so
+  // scope every task source here before any stats are computed. Imported
+  // calendar events carry no assignment, so they remain included.
+  const tasks = allTasks.filter(isVisibleForUser);
+  const recurringTasks = allRecurringTasks.filter(isVisibleForUser);
+  const unscheduledTasks = allUnscheduledTasks.filter(isVisibleForUser);
 
         // Compute rolling 7-day boundaries
         const today = new Date();

--- a/src/hooks/useDeadlinePriority.js
+++ b/src/hooks/useDeadlinePriority.js
@@ -8,15 +8,18 @@ export default function useDeadlinePriority({
   playUISound,
   onboardingProgress,
   setOnboardingProgress,
+  isVisibleForUser = () => true,
 }) {
   const [pendingPriorities, setPendingPriorities] = useState({});
   const priorityTimeouts = useRef({});
 
-  // Get inbox tasks with deadlines for a specific date (not overdue)
+  // Get inbox tasks with deadlines for a specific date (not overdue).
+  // Respect multi-user visibility so deadlines assigned to other users don't
+  // surface in the all-day area.
   const getDeadlineTasksForDate = (dateStr) => {
     const todayStr = dateToString(new Date());
     return unscheduledTasks.filter(t =>
-      t.deadline === dateStr && (t.deadline >= todayStr || t.completed)
+      t.deadline === dateStr && (t.deadline >= todayStr || t.completed) && isVisibleForUser(t)
     );
   };
 

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -64,12 +64,14 @@ export default function useNavigation({
       }, delay);
     };
 
-    if (source === 'scheduled') {
+    if (source === 'scheduled' || source === 'event') {
       if (isMobile) {
         setMobileActiveTab('timeline');
       }
       goToDate(task.date);
-      scrollAndHighlight(`[data-task-id="${task.id}"]`);
+      // Native calendar events are fetched per-date, so the card may not exist
+      // until the timeline re-fetches the target day — give it a little longer.
+      scrollAndHighlight(`[data-task-id="${task.id}"]`, source === 'event' ? 600 : 300);
     } else if (source === 'inbox') {
       if (isMobile) {
         setMobileActiveTab('inbox');

--- a/src/hooks/useRecycleBin.js
+++ b/src/hooks/useRecycleBin.js
@@ -15,7 +15,12 @@ export default function useRecycleBin({
     pushUndo();
     const task = recycleBin.find(t => t.id === id);
     if (task) {
-      const { _deletedFrom, ...cleanTask } = task; // Remove metadata
+      // Drop the deletion metadata and re-stamp lastModified to "now" so the
+      // restore wins against the bin entry on other devices (whose deletedAt is
+      // the deletion-time stamp). Without a fresher lastModified the cross-list
+      // reconciliation would just send the task straight back to the bin.
+      const { _deletedFrom, deletedAt, ...rest } = task;
+      const cleanTask = { ...rest, lastModified: new Date().toISOString() };
 
       if (_deletedFrom === 'inbox') {
         setUnscheduledTasks(prev => [...prev, cleanTask]);

--- a/src/hooks/useStats.js
+++ b/src/hooks/useStats.js
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
 import { getOccurrencesInRange } from '../utils/recurrenceEngine.js';
 
-export default function useStats({ tasks: rawTasks, unscheduledTasks: rawUnscheduled, recurringTasks: rawRecurring, goals = [], projects = [], isVisibleForUser = () => true }) {
+export default function useStats({ tasks: rawTasks, unscheduledTasks: rawUnscheduled, recurringTasks: rawRecurring, goals: rawGoals = [], projects: rawProjects = [], isVisibleForUser = () => true }) {
   const todayStr = dateToString(new Date());
 
   // Multi-user: stats reflect only the current user's tasks. Filtering the
@@ -10,6 +10,9 @@ export default function useStats({ tasks: rawTasks, unscheduledTasks: rawUnsched
   const tasks = useMemo(() => rawTasks.filter(isVisibleForUser), [rawTasks, isVisibleForUser]);
   const unscheduledTasks = useMemo(() => rawUnscheduled.filter(isVisibleForUser), [rawUnscheduled, isVisibleForUser]);
   const recurringTasks = useMemo(() => rawRecurring.filter(isVisibleForUser), [rawRecurring, isVisibleForUser]);
+  // Goals & projects use the same broadcast-with-filter visibility model.
+  const goals = useMemo(() => rawGoals.filter(isVisibleForUser), [rawGoals, isVisibleForUser]);
+  const projects = useMemo(() => rawProjects.filter(isVisibleForUser), [rawProjects, isVisibleForUser]);
 
   // All-time stats helpers (exclude imported events, include recurring)
   // Only count tasks up through today — future tasks aren't "incomplete" yet

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -182,6 +182,9 @@ export default function useTaskActions({
           recurrence: { ...newTask.recurrence, startDate: taskDate },
           completedDates: [],
           exceptions: {},
+          // User assignment on recurring tasks is series-level: it lives on the
+          // template so every materialised instance inherits it.
+          ...(newTask.assignedUserSyncIds?.length ? { assignedUserSyncIds: newTask.assignedUserSyncIds } : {}),
           lastModified: new Date().toISOString()
         };
         setRecurringTasks(prev => [...prev, template]);

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -636,10 +636,22 @@ export default function useTaskActions({
       if (expandedNotesTaskId === id) {
         setExpandedNotesTaskId(null);
       }
+      // Stamp the bin entry with a FRESH timestamp that is strictly newer than
+      // the task's own lastModified, used for BOTH deletedAt and lastModified.
+      // This prevents "zombie" resurrection: an old task (lastModified beyond the
+      // sync horizon) would otherwise have its recycle-bin entry pruned as a
+      // presumed zombie during merge, after which the remote active copy — which
+      // carries no tombstone — reconciles straight back into the inbox. A fresh
+      // stamp keeps the bin entry alive past the horizon and lets it win the
+      // active-vs-recycled reconciliation in both the file and vault sync tiers.
+      const deletedStamp = new Date(
+        Math.max(Date.now(), (task.lastModified ? Date.parse(task.lastModified) : 0) + 1000)
+      ).toISOString();
       const taskWithMeta = {
         ...task,
         _deletedFrom: actuallyInInbox ? 'inbox' : 'calendar',
-        deletedAt: new Date().toISOString()
+        deletedAt: deletedStamp,
+        lastModified: deletedStamp,
       };
       setRecycleBin(prev => [...prev, taskWithMeta]);
       if (actuallyInInbox) {

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -494,6 +494,52 @@ describe('mergeSyncData', () => {
     expect(data.recycleBin).toHaveLength(1);
   });
 
+  // ── Zombie-resurrection regression ────────────────────────────
+  // An OLD task (lastModified beyond the retention horizon) that gets deleted
+  // must not resurrect. moveToRecycleBin stamps the bin entry with a FRESH
+  // deletedAt AND lastModified so the entry survives horizon pruning and wins
+  // the active-vs-recycled reconciliation.
+  it('SCENARIO: deleting a stale task (beyond sync horizon) does not resurrect it', () => {
+    const oldLm = ts(200 * 24 * 60); // ~200 days ago, older than the horizon
+    const freshStamp = ts(0);        // moveToRecycleBin's fresh stamp
+    const thisDevice = {
+      ...emptyData(),
+      recycleBin: [{ ...T(1, 'Leaked seed task', freshStamp), deletedAt: freshStamp, _deletedFrom: 'inbox' }],
+    };
+    // The stale cloud / other device still holds it active with its old timestamp,
+    // and publishes a pruned-before fence (~90 days) that engages the sync horizon.
+    const otherDevice = {
+      ...emptyData(),
+      unscheduledTasks: [T(1, 'Leaked seed task', oldLm)],
+      tombstonePrunedBefore: ts(90 * 24 * 60),
+    };
+    const { data } = mergeSyncData(thisDevice, otherDevice, 90);
+    expect(data.unscheduledTasks).toHaveLength(0); // does NOT come back to inbox
+    expect(data.recycleBin).toHaveLength(1);        // stays in the bin
+    expect(data.recycleBin[0].id).toBe(1);
+  });
+
+  it('ROOT CAUSE: a stale-stamped bin entry is horizon-pruned and the task resurrects', () => {
+    // Documents the pre-fix behaviour: when the bin entry kept the task's OWN
+    // stale lastModified, the merge dropped it as a presumed zombie (the remote's
+    // tombstonePrunedBefore fence engages the horizon), leaving the remote active
+    // copy — which carries no tombstone — to reconcile straight back into the inbox.
+    const oldLm = ts(200 * 24 * 60);
+    const thisDevice = {
+      ...emptyData(),
+      recycleBin: [{ ...T(1, 'Leaked seed task', oldLm), deletedAt: ts(0), _deletedFrom: 'inbox' }],
+    };
+    const otherDevice = {
+      ...emptyData(),
+      unscheduledTasks: [T(1, 'Leaked seed task', oldLm)],
+      tombstonePrunedBefore: ts(90 * 24 * 60),
+    };
+    const { data } = mergeSyncData(thisDevice, otherDevice, 90);
+    // The stale bin entry is pruned, so the active copy survives — the bug.
+    expect(data.recycleBin).toHaveLength(0);
+    expect(data.unscheduledTasks).toHaveLength(1);
+  });
+
   it('SCENARIO: task restored from recycle bin stays active when other device syncs', () => {
     // Device A restored the task (bumped lastModified)
     const deviceA = {


### PR DESCRIPTION
## Summary

A batch of multi-user correctness fixes plus several feature and UX improvements, capped with the 3.7.0 version bump.

### Recurring task user assignment
- User assignment on recurring tasks is now series-level, so setting a user on a new recurring task sticks and applies to every instance.
- Added a "This instance" vs "All instances" scope picker in the Edit Task modal (desktop, tablet, and mobile share one save path).

### Native calendar search
- Device calendar events (Android, iOS, macOS) are now searchable in spotlight. The timeline only loads a small window, so the search fetches a wider range on demand (single IPC on macOS, chunked on mobile) and collapses repeated occurrences to the nearest one.

### Multi-user visibility
- Deadline all-day tasks now respect per-user visibility.
- Spotlight search filters out other users' tasks.
- Weekly review stats, and all-time goal and project stats, are scoped to the current user.
- Closed remaining leaks in TRMNL, overdue computation, GLANCEahead, the morning summary, and the mini-calendar indicator dots. Stream Deck, tray, and the reminder engine were already correctly scoped.

### Zombie task deletion fix
- Old completed and leaked seed tasks that reappeared seconds after deletion are fixed. Root cause: the recycle-bin entry kept the task's stale lastModified, so the sync horizon pruned it as a presumed zombie and the untombstoned remote copy reconciled straight back into the inbox. Recycle-bin entries now get a fresh stamp on delete (and restore re-stamps), so deletion sticks across both sync tiers while preserving restore. Added regression tests.

### Cloud sync button
- Hidden on desktop and tablet when neither WebDAV nor GLANCEvault is configured.
- When only GLANCEvault is enabled, the button drives a vault sync and shows the status dot.
- Mobile now shows the status dot for GLANCEvault-only setups.

### Misc
- hyperGLANCE session notification settings are hidden when Goals and Projects is off.

### Version
- package.json and lockfile: 3.6.0 to 3.7.0
- Android: versionCode 131 to 132, versionName 3.6 to 3.7
- README version badge: 3.6.0 to 3.7.0

## Testing
- 377 unit tests pass (2 new for the zombie-task fix).
- Web build compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTSSigsr8wH72ogQY8PK3Y)_