### PR TITLE
Fix routine/recurring completion sync convergence + GLANCEvault settings dots

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -710,6 +710,7 @@ const DayPlanner = () => {
     routineDurationEditId, setRoutineDurationEditId,
     routinesEnabled, setRoutinesEnabled,
     routineCompletions, setRoutineCompletions, toggleRoutineCompletion,
+    routineCompletionTimestamps, setRoutineCompletionTimestamps,
     openRoutinesDashboard,
     addRoutineChip,
     deleteRoutineChip,
@@ -5656,6 +5657,9 @@ const DayPlanner = () => {
         todayRoutines: stampTaskTimestamps(allTodayRoutines, 'day-planner-today-routines'),
         routinesDate,
         routineCompletions,
+        // Sibling LWW timestamps for routine completions (no React state in the
+        // payload closure — read from localStorage, like habitLogTimestamps).
+        routineCompletionTimestamps: JSON.parse(localStorage.getItem('day-planner-routine-completion-timestamps') || '{}'),
         minimizedSections,
         use24HourClock,
         weatherZip,
@@ -5770,6 +5774,7 @@ const DayPlanner = () => {
       if (data.todayRoutines) localStorage.setItem('day-planner-today-routines', JSON.stringify(data.todayRoutines));
       localStorage.setItem('day-planner-routines-date', data.routinesDate);
       if (data.routineCompletions) localStorage.setItem('day-planner-routine-completions', JSON.stringify(data.routineCompletions));
+      if (data.routineCompletionTimestamps) localStorage.setItem('day-planner-routine-completion-timestamps', JSON.stringify(data.routineCompletionTimestamps));
     }
     // selectedTags is a per-device UI preference and is not applied to state here.
     // minimizedSections is synced to localStorage so the same section layout follows the user across devices.
@@ -5928,6 +5933,7 @@ const DayPlanner = () => {
       if (data.todayRoutines) setTodayRoutines(data.todayRoutines);
       setRoutinesDate(data.routinesDate);
       if (data.routineCompletions) setRoutineCompletions(data.routineCompletions);
+      if (data.routineCompletionTimestamps) setRoutineCompletionTimestamps(data.routineCompletionTimestamps);
     }
     if (data.use24HourClock !== undefined) setUse24HourClock(data.use24HourClock);
     if (data.weatherZip !== undefined) setWeatherZip(data.weatherZip);

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -342,8 +342,8 @@ const MobileSettingsPanel = () => {
         className={`w-full ${cardBg} border ${borderClass} rounded-xl p-4 flex items-center gap-3`}
       >
         <div className="relative">
-          <Activity size={20} className={intentForm.webdavUrl ? 'text-blue-500' : textSecondary} />
-          {intentForm.webdavUrl && (
+          <Activity size={20} className={(intentForm.webdavUrl || dbIntentsEnabled) ? 'text-blue-500' : textSecondary} />
+          {(intentForm.webdavUrl || dbIntentsEnabled) && (
             <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full border-2 ${darkMode ? 'border-gray-800' : 'border-white'} bg-green-500`} />
           )}
         </div>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -730,7 +730,7 @@ const SettingsModal = () => {
                       <button onClick={() => toggleSettingsSection('cloudSync')} className={`font-medium ${textPrimary} flex items-center gap-2 w-full text-left`}>
                         <Cloud size={16} className={textSecondary} />
                         {t('settings.cloudSync')}
-                        {cloudSyncConfig?.enabled && <span className="mr-1 w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />}
+                        {(cloudSyncConfig?.enabled || isVaultEnabled()) && <span className="mr-1 w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />}
                         <ChevronDown size={16} className={`ml-auto flex-shrink-0 ${textSecondary} transition-transform ${collapsedSettings.cloudSync ? '' : 'rotate-180'}`} />
                       </button>
                       {!collapsedSettings.cloudSync && (<>
@@ -1697,7 +1697,7 @@ const SettingsModal = () => {
                       <button onClick={() => toggleSettingsSection('intent')} className={`font-medium ${textPrimary} flex items-center gap-2 w-full text-left`}>
                         <Activity size={16} className={textSecondary} />
                         {t('settings.glanceIntegrations')}
-                        {intentForm.webdavUrl && <span className="mr-1 w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />}
+                        {(intentForm.webdavUrl || dbIntentsEnabled) && <span className="mr-1 w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />}
                         <ChevronDown size={16} className={`ml-auto flex-shrink-0 ${textSecondary} transition-transform ${collapsedSettings.intent ? '' : 'rotate-180'}`} />
                       </button>
                       {!collapsedSettings.intent && (<>

--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -21,6 +21,20 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
       return filtered;
     } catch (_) { return {}; }
   });
+  // Per-routine completion timestamps (ISO), the sync LWW key that lets an
+  // un-complete win over a stale complete instead of being resurrected by a
+  // grow-union merge. Kept day-scoped (the ISO date prefix must be today).
+  const [routineCompletionTimestamps, setRoutineCompletionTimestamps] = useState(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem('day-planner-routine-completion-timestamps') || '{}');
+      const todayStr = dateToString(new Date());
+      const filtered = {};
+      for (const [id, iso] of Object.entries(stored)) {
+        if (typeof iso === 'string' && iso.slice(0, 10) === todayStr) filtered[id] = iso;
+      }
+      return filtered;
+    } catch (_) { return {}; }
+  });
   const [showRoutinesDashboard, setShowRoutinesDashboard] = useState(false);
   const [dashboardSelectedChips, setDashboardSelectedChips] = useState([]);
   const [routineAddingToBucket, setRoutineAddingToBucket] = useState(null);
@@ -50,6 +64,11 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
     localStorage.setItem('day-planner-routine-completions', JSON.stringify(routineCompletions));
   }, [routineCompletions]);
 
+  // Persist completion timestamps (the sync LWW key) alongside the completions.
+  useEffect(() => {
+    localStorage.setItem('day-planner-routine-completion-timestamps', JSON.stringify(routineCompletionTimestamps));
+  }, [routineCompletionTimestamps]);
+
   // Auto-clear today's routines on day rollover
   useEffect(() => {
     const todayStr = dateToString(new Date());
@@ -58,8 +77,10 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
       setRoutinesDate(todayStr);
       setRemovedTodayRoutineIds({});
       setRoutineCompletions({});
+      setRoutineCompletionTimestamps({});
       localStorage.removeItem('day-planner-removed-today-routine-ids');
       localStorage.removeItem('day-planner-routine-completions');
+      localStorage.removeItem('day-planner-routine-completion-timestamps');
     }
   }, [currentTime]);
 
@@ -74,6 +95,9 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
       }
       return next;
     });
+    // Stamp the toggle (complete AND un-complete) so sync resolves the latest
+    // state by last-writer-wins instead of grow-unioning the completion back.
+    setRoutineCompletionTimestamps(prev => ({ ...prev, [routineId]: new Date().toISOString() }));
   };
 
   // Pre-populate the dashboard center with the given owner's placed routines.
@@ -203,6 +227,7 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
     routineDurationEditId, setRoutineDurationEditId,
     routinesEnabled, setRoutinesEnabled,
     routineCompletions, setRoutineCompletions,
+    routineCompletionTimestamps, setRoutineCompletionTimestamps,
     toggleRoutineCompletion,
     openRoutinesDashboard,
     addRoutineChip,

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -394,6 +394,10 @@ export default function useTaskActions({
           completedDates: completed
             ? (t.completedDates || []).filter(d => d !== dateStr)
             : [...(t.completedDates || []), dateStr],
+          // Stamp the toggled occurrence so sync resolves this complete/un-complete
+          // by last-writer-wins per date instead of letting a concurrent series
+          // edit clobber it (completedDates is unioned across devices on merge).
+          completedDatesTimestamps: { ...(t.completedDatesTimestamps || {}), [dateStr]: new Date().toISOString() },
           lastModified: new Date().toISOString()
         };
       }));

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -197,6 +197,51 @@ export const mergeRoutineCompletions = (localC = {}, remoteC = {}, localTs = {},
 };
 
 /**
+ * Merge the completion state of two copies of the SAME recurring template.
+ *
+ * A recurring task's per-occurrence completions live in `completedDates` INSIDE
+ * the shared template row, which both sync tiers otherwise resolve by whole-row
+ * last-writer-wins. That silently drops a completion whenever the series is
+ * touched concurrently on another device — most easily a completion on one
+ * device versus an edit to the same series on another, since the (now
+ * series-level) user-assignment write bumps the template's `lastModified`, so its
+ * row — which lacks the completion — wins and reverts it on every device. That is
+ * the "completed on one device, not the others" report.
+ *
+ * Union the dates instead so no completion is lost, and use the optional per-date
+ * `completedDatesTimestamps` map to let a later UN-complete (date removed, newer
+ * stamp) win over an earlier complete — the same presence-by-timestamp model as
+ * routine completions above. Legacy rows with no timestamps fall back to a plain
+ * union (present wins), so nothing regresses on first upgrade.
+ */
+export const mergeCompletedDates = (localDates = [], remoteDates = [], localTs = {}, remoteTs = {}) => {
+  const lSet = new Set(localDates || []);
+  const rSet = new Set(remoteDates || []);
+  const allDates = new Set([...lSet, ...rSet, ...Object.keys(localTs), ...Object.keys(remoteTs)]);
+  const completedDates = [];
+  const completedDatesTimestamps = {};
+  for (const d of allDates) {
+    const lt = localTs[d] ? new Date(localTs[d]).getTime() : 0;
+    const rt = remoteTs[d] ? new Date(remoteTs[d]).getTime() : 0;
+    const newerTs = rt > lt ? remoteTs[d] : (localTs[d] ?? remoteTs[d]);
+    if (newerTs) completedDatesTimestamps[d] = newerTs;
+    let present;
+    if (lt > rt) present = lSet.has(d);
+    else if (rt > lt) present = rSet.has(d);
+    else present = lSet.has(d) || rSet.has(d); // tie / legacy: present wins
+    if (present) completedDates.push(d);
+  }
+  completedDates.sort();
+  return { completedDates, completedDatesTimestamps };
+};
+
+// Order-independent equality of two date lists (used to flag re-push/persist).
+const sameDateSet = (a = [], b = []) => {
+  const sa = new Set(a), sb = new Set(b);
+  return sa.size === sb.size && [...sa].every((x) => sb.has(x));
+};
+
+/**
  * Full-sync merge. Delegates to the upstream merge, then overrides the
  * habit-log portion with the deterministic tie-break above so existing stuck
  * habit counts self-heal across the fleet (no manual re-touch, no package bump).
@@ -226,6 +271,30 @@ export const mergeSyncData = (local, remote, retentionDays) => {
     result.data.routineCompletionTimestamps = rcFix.mergedTimestamps;
     if (rcFix.localChanged) result.localChanged = true;
     if (rcFix.remoteChanged) result.remoteChanged = true;
+  }
+  // Recurring completions ride inside the shared template row, which the upstream
+  // merge resolves by whole-row LWW — re-merge each series' completedDates by date
+  // so a completion is never clobbered by a concurrent edit to the same series
+  // (e.g. a series-level assignment change) on another device.
+  if (local?.recurringTasks || remote?.recurringTasks) {
+    const lById = new Map((local?.recurringTasks || []).map((t) => [String(t.id), t]));
+    const rById = new Map((remote?.recurringTasks || []).map((t) => [String(t.id), t]));
+    result.data.recurringTasks = (result.data.recurringTasks || []).map((t) => {
+      const l = lById.get(String(t.id));
+      const r = rById.get(String(t.id));
+      if (!l || !r) return t; // present on only one side — nothing concurrent to merge
+      const { completedDates, completedDatesTimestamps } = mergeCompletedDates(
+        l.completedDates || [], r.completedDates || [],
+        l.completedDatesTimestamps || {}, r.completedDatesTimestamps || {},
+      );
+      if (!sameDateSet(completedDates, l.completedDates || [])) result.localChanged = true;
+      if (!sameDateSet(completedDates, r.completedDates || [])) result.remoteChanged = true;
+      return {
+        ...t,
+        completedDates,
+        ...(Object.keys(completedDatesTimestamps).length ? { completedDatesTimestamps } : {}),
+      };
+    });
   }
   // Per-user calendar config merges by syncId (the upstream merge doesn't know
   // this key), so resolve it explicitly here from both sides.

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -135,6 +135,68 @@ export const mergeHabitLogs = (localLogs, remoteLogs, localTs = {}, remoteTs = {
 };
 
 /**
+ * Routine-completion merge with per-routine timestamps.
+ *
+ * Routine completions are a `{routineId → 'YYYY-MM-DD'}` map, but the only
+ * top-level signal was the bare date, so the upstream/vault merge could only
+ * grow-union them: a key, once present, never goes away. That breaks the toggle.
+ * UN-completing a routine deletes its key locally (useRoutines.toggleRoutineCompletion),
+ * and a grow-union immediately resurrects it from any device that still has the
+ * completion — so the routine flips between done/undone on every sync round-trip
+ * with no user action (the same zombie-resurrection class fixed for tasks).
+ *
+ * Fix: carry a parallel `{routineId → ISO}` timestamp map, stamped on EVERY
+ * toggle (complete AND un-complete), and resolve each routine by last-writer-wins
+ * on that timestamp — so a later un-complete (key absent, newer ts) beats an
+ * earlier complete. Presence/absence in the completions map is the value; the
+ * timestamp decides the winner. Legacy entries with no timestamp fall back to the
+ * old grow-union (present wins), so nothing regresses on first upgrade.
+ *
+ * Mirrors mergeHabitLogs above (count↔presence, day-key↔routine-id); routed
+ * through mergeSyncData below and the vault adapter (src/sync/dbAdapter.js).
+ */
+export const mergeRoutineCompletions = (localC = {}, remoteC = {}, localTs = {}, remoteTs = {}) => {
+  const ids = new Set([
+    ...Object.keys(localC), ...Object.keys(remoteC),
+    ...Object.keys(localTs), ...Object.keys(remoteTs),
+  ]);
+  const merged = {};
+  const mergedTimestamps = {};
+  let localChanged = false;
+  let remoteChanged = false;
+
+  for (const id of ids) {
+    const lHas = Object.prototype.hasOwnProperty.call(localC, id);
+    const rHas = Object.prototype.hasOwnProperty.call(remoteC, id);
+    const lTime = localTs[id] ? new Date(localTs[id]).getTime() : 0;
+    const rTime = remoteTs[id] ? new Date(remoteTs[id]).getTime() : 0;
+
+    // Keep the newer timestamp per id so the marker (incl. a tombstone) converges.
+    const newerTs = rTime > lTime ? remoteTs[id] : (localTs[id] ?? remoteTs[id]);
+    if (newerTs) mergedTimestamps[id] = newerTs;
+
+    let present, date;
+    if (lTime > rTime) {
+      present = lHas; date = localC[id];          // local strictly newer
+    } else if (rTime > lTime) {
+      present = rHas; date = remoteC[id];         // remote strictly newer
+    } else {
+      // Equal timestamps (or both missing — legacy): present wins, so a
+      // completion is never silently dropped, matching the old grow-union.
+      present = lHas || rHas;
+      date = (lHas && rHas)
+        ? (localC[id] > remoteC[id] ? localC[id] : remoteC[id])
+        : (lHas ? localC[id] : remoteC[id]);
+    }
+    if (present) merged[id] = date;
+    if (present !== lHas) localChanged = true;
+    if (present !== rHas) remoteChanged = true;
+  }
+
+  return { merged, mergedTimestamps, localChanged, remoteChanged };
+};
+
+/**
  * Full-sync merge. Delegates to the upstream merge, then overrides the
  * habit-log portion with the deterministic tie-break above so existing stuck
  * habit counts self-heal across the fleet (no manual re-touch, no package bump).
@@ -152,6 +214,19 @@ export const mergeSyncData = (local, remote, retentionDays) => {
   // Make sure a heal (one side's count changing) actually triggers a write/push.
   if (habitLogsFix.localChanged) result.localChanged = true;
   if (habitLogsFix.remoteChanged) result.remoteChanged = true;
+  // Routine completions: resolve by per-routine timestamp so an un-complete
+  // propagates instead of being resurrected by the grow-union (the flip-flop bug).
+  if (local?.routineCompletions || remote?.routineCompletions ||
+      local?.routineCompletionTimestamps || remote?.routineCompletionTimestamps) {
+    const rcFix = mergeRoutineCompletions(
+      local?.routineCompletions || {}, remote?.routineCompletions || {},
+      local?.routineCompletionTimestamps || {}, remote?.routineCompletionTimestamps || {},
+    );
+    result.data.routineCompletions = rcFix.merged;
+    result.data.routineCompletionTimestamps = rcFix.mergedTimestamps;
+    if (rcFix.localChanged) result.localChanged = true;
+    if (rcFix.remoteChanged) result.remoteChanged = true;
+  }
   // Per-user calendar config merges by syncId (the upstream merge doesn't know
   // this key), so resolve it explicitly here from both sides.
   if (local?.calendarConfigByUser || remote?.calendarConfigByUser) {

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -26,7 +26,7 @@
 // array inside its row, habitLogs stays a keyed map carried whole. No finer
 // per-completion remodeling.
 
-import { mergeHabitLogs, mergeRoutineDefinitions } from '../mergeSync.js';
+import { mergeHabitLogs, mergeRoutineDefinitions, mergeRoutineCompletions } from '../mergeSync.js';
 
 // ── Collection kinds: each array element is one row, keyed by a stable id, with
 // entity-grain last-writer-wins on tsField (the same grain the file-tier merge
@@ -74,6 +74,7 @@ export const SINGLETON_KIND = 'singleton';
 // order-independent. This is COARSER grouping, not finer remodeling (rule 4).
 export const BUNDLE_OWNS = {
   habitLogs:            ['habitLogTimestamps'],
+  routineCompletions:   ['routineCompletionTimestamps'],
   habitsEnabled:        ['habitsEnabledUpdatedAt'],
   routinesEnabled:      ['routinesEnabledUpdatedAt'],
   goalsProjectsEnabled: ['goalsProjectsEnabledUpdatedAt'],
@@ -315,12 +316,6 @@ const MERGE = {
     for (const [k, v] of Object.entries(remote)) out[k] = newerIso(out[k], v);
     return out;
   },
-  // {routineId → 'YYYY-MM-DD'}: union, keep the later date per key.
-  unionLaterDate(local = {}, remote = {}) {
-    const out = { ...local };
-    for (const [k, v] of Object.entries(remote)) out[k] = (out[k] && out[k] > v) ? out[k] : v;
-    return out;
-  },
   // string[]: set-union (grow-only).
   unionArray(local = [], remote = []) {
     return [...new Set([...(local || []), ...(remote || [])])];
@@ -382,9 +377,17 @@ function mergeBundle(data, key, value, extra) {
       data.routineDefinitions = res.merged;
       return;
     }
-    case 'routineCompletions':
-      data.routineCompletions = MERGE.unionLaterDate(data.routineCompletions || {}, value || {});
+    case 'routineCompletions': {
+      // Per-routine LWW on the timestamp sibling (rides in _extra) so an
+      // un-complete propagates instead of being resurrected by a grow-union.
+      const res = mergeRoutineCompletions(
+        data.routineCompletions || {}, value || {},
+        data.routineCompletionTimestamps || {}, extra.routineCompletionTimestamps || {},
+      );
+      data.routineCompletions = res.merged;
+      data.routineCompletionTimestamps = res.mergedTimestamps;
       return;
+    }
     case 'completedTaskUids':
       data.completedTaskUids = MERGE.unionArray(data.completedTaskUids || [], value || []);
       return;

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -26,7 +26,7 @@
 // array inside its row, habitLogs stays a keyed map carried whole. No finer
 // per-completion remodeling.
 
-import { mergeHabitLogs, mergeRoutineDefinitions, mergeRoutineCompletions } from '../mergeSync.js';
+import { mergeHabitLogs, mergeRoutineDefinitions, mergeRoutineCompletions, mergeCompletedDates } from '../mergeSync.js';
 
 // ── Collection kinds: each array element is one row, keyed by a stable id, with
 // entity-grain last-writer-wins on tsField (the same grain the file-tier merge
@@ -114,9 +114,14 @@ export function entityKind(entity) {
 }
 
 // Singletons (bundles) are insert-only: always applied so their merge runs.
-// Collections and per-date dailyNotes use normal entity-grain LWW.
+// recurringTasks are too: their completedDates must UNION across devices (the
+// row is shared by every occurrence), so the row has to be merged on every pull
+// rather than LWW-skipped — otherwise a completion is lost whenever the series is
+// edited concurrently. See applyRemoteRecurring (scalar fields still resolve LWW).
+// Other collections and per-date dailyNotes use normal entity-grain LWW.
 export function isInsertOnly(entity) {
-  return entityKind(entity) === SINGLETON_KIND;
+  const k = entityKind(entity);
+  return k === SINGLETON_KIND || k === 'recurringTasks';
 }
 
 export function getEntityLastModified(entity) {
@@ -252,6 +257,34 @@ export function getLocalEntity(data, entityId) {
   return null;
 }
 
+// Insert-only merge for one recurring template (always runs on pull). Scalar
+// fields (title, time, assignment, recurrence, exceptions…) resolve by whole-row
+// LWW exactly as before — the winner is the newer lastModified — but completedDates
+// UNION across both copies (per-date LWW via completedDatesTimestamps) so a
+// completion made on one device is never dropped by a concurrent series edit on
+// another. Returns the row's entityId to re-push when our merged superset differs
+// from the pulled row, so the vault converges (mirrors the bundle superset re-push).
+function applyRemoteRecurring(data, remote) {
+  if (!Array.isArray(data.recurringTasks)) data.recurringTasks = [];
+  const id = String(remote.id);
+  const idx = data.recurringTasks.findIndex((x) => x != null && String(x.id) === id);
+  if (idx < 0) {
+    data.recurringTasks.push(remote);
+    return [];
+  }
+  const local = data.recurringTasks[idx];
+  const winner = ts(remote.lastModified) >= ts(local.lastModified) ? remote : local;
+  const { completedDates, completedDatesTimestamps } = mergeCompletedDates(
+    local.completedDates || [], remote.completedDates || [],
+    local.completedDatesTimestamps || {}, remote.completedDatesTimestamps || {},
+  );
+  const merged = { ...winner, completedDates };
+  if (Object.keys(completedDatesTimestamps).length) merged.completedDatesTimestamps = completedDatesTimestamps;
+  else delete merged.completedDatesTimestamps;
+  data.recurringTasks[idx] = merged;
+  return deepEqual(merged, remote) ? [] : [makeEntityId('recurringTasks', id)];
+}
+
 function upsertCollection(data, kind, value) {
   const cfg = COLLECTION_KINDS[kind];
   if (!Array.isArray(data[kind])) data[kind] = [];
@@ -275,6 +308,9 @@ function upsertCollection(data, kind, value) {
 // edits there already land on distinct entityIds.
 export function applyRemoteEntity(data, entity) {
   const kind = entityKind(entity);
+  if (kind === 'recurringTasks') {
+    return applyRemoteRecurring(data, entity.value);
+  }
   if (COLLECTION_KINDS[kind]) {
     upsertCollection(data, kind, entity.value);
     return [];

--- a/src/sync/dbAdapter.losslessness.test.js
+++ b/src/sync/dbAdapter.losslessness.test.js
@@ -91,6 +91,7 @@ function buildFixture() {
         recurrence: { type: 'weekly', days: ['mon', 'thu'] },
         startTime: '08:00',
         completedDates: ['2026-06-11', '2026-06-15', '2026-06-18'], // array stays inside the row
+        completedDatesTimestamps: { '2026-06-11': ts(210), '2026-06-15': ts(160), '2026-06-18': ts(40) },
       },
     ],
     recycleBin: [
@@ -216,14 +217,16 @@ describe('dbAdapter losslessness gate', () => {
     expect(logRows[0].entity.value['2026-06-18']).toEqual({ 7101: 4, 7102: 1 });
   });
 
-  it('routes every row by explicit _kind; bundles are insert-only, collections are LWW', () => {
+  it('routes every row by explicit _kind; bundles + recurringTasks are insert-only, other collections are LWW', () => {
     const rows = shredState(buildFixture());
     for (const r of rows) {
       expect(entityKind(r.entity)).toBe(r.kind);
       // Stage 2: singleton bundles are insert-only (always merged on pull) so a
-      // concurrent edit to a different bundle entry is never lost. Per-item
+      // concurrent edit to a different bundle entry is never lost. recurringTasks
+      // are too, so each series' completedDates UNION across devices instead of a
+      // completion being clobbered by a concurrent series edit. Other per-item
       // collections and per-date dailyNotes stay on entity-grain LWW.
-      expect(isInsertOnly(r.entity)).toBe(r.kind === 'singleton');
+      expect(isInsertOnly(r.entity)).toBe(r.kind === 'singleton' || r.kind === 'recurringTasks');
     }
   });
 

--- a/src/sync/dbAdapter.losslessness.test.js
+++ b/src/sync/dbAdapter.losslessness.test.js
@@ -111,6 +111,7 @@ function buildFixture() {
     ],
     routinesDate: '2026-06-18',
     routineCompletions: { 5001: '2026-06-18' },
+    routineCompletionTimestamps: { 5001: ts(40) },
     minimizedSections: { inbox: true, habits: false },
     use24HourClock: true,
     weatherZip: '60601',

--- a/src/sync/dbMerge.test.js
+++ b/src/sync/dbMerge.test.js
@@ -108,14 +108,48 @@ describe('A1 bundle merge — concurrent different-entry edits are not lost', ()
     }
   });
 
-  it('routineCompletions: completing different routines both survive (set-union)', () => {
-    const base = { ...EMPTY_COLLECTIONS, routinesDate: '2026-06-18', routineCompletions: {} };
+  it('routineCompletions: completing different routines both survive', () => {
+    const base = { ...EMPTY_COLLECTIONS, routinesDate: '2026-06-18', routineCompletions: {}, routineCompletionTimestamps: {} };
     const { vault, a, b } = newPair(base);
-    a.mutate((d) => { d.routineCompletions['5001'] = '2026-06-18'; return ['singleton:routineCompletions']; });
-    b.mutate((d) => { d.routineCompletions['5002'] = '2026-06-18'; return ['singleton:routineCompletions']; });
+    a.mutate((d) => { d.routineCompletions['5001'] = '2026-06-18'; d.routineCompletionTimestamps['5001'] = T1; return ['singleton:routineCompletions']; });
+    b.mutate((d) => { d.routineCompletions['5002'] = '2026-06-18'; d.routineCompletionTimestamps['5002'] = T1; return ['singleton:routineCompletions']; });
     syncToConvergence(a, b, vault);
     for (const dev of [a, b]) {
       expect(dev.data.routineCompletions).toEqual({ 5001: '2026-06-18', 5002: '2026-06-18' });
+    }
+  });
+
+  it('routineCompletions: an un-complete propagates instead of being resurrected (flip-flop bug)', () => {
+    // Both devices see routine 5001 completed. Device A un-completes it (deletes
+    // the key, stamps a later timestamp). After sync, BOTH devices must show it
+    // un-completed — a grow-union would resurrect it from B's stale completion.
+    const base = {
+      ...EMPTY_COLLECTIONS, routinesDate: '2026-06-18',
+      routineCompletions: { 5001: '2026-06-18' },
+      routineCompletionTimestamps: { 5001: T0 },
+    };
+    const { vault, a, b } = newPair(base);
+    a.mutate((d) => { delete d.routineCompletions['5001']; d.routineCompletionTimestamps['5001'] = T2; return ['singleton:routineCompletions']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      expect(dev.data.routineCompletions['5001']).toBeUndefined();
+    }
+  });
+
+  it('routineCompletions: a re-complete after an un-complete wins by recency', () => {
+    // A un-completes (T1), then B re-completes the same routine later (T2).
+    // The later complete must win on both devices.
+    const base = {
+      ...EMPTY_COLLECTIONS, routinesDate: '2026-06-18',
+      routineCompletions: { 5001: '2026-06-18' },
+      routineCompletionTimestamps: { 5001: T0 },
+    };
+    const { vault, a, b } = newPair(base);
+    a.mutate((d) => { delete d.routineCompletions['5001']; d.routineCompletionTimestamps['5001'] = T1; return ['singleton:routineCompletions']; });
+    b.mutate((d) => { d.routineCompletions['5001'] = '2026-06-18'; d.routineCompletionTimestamps['5001'] = T2; return ['singleton:routineCompletions']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      expect(dev.data.routineCompletions['5001']).toBe('2026-06-18');
     }
   });
 

--- a/src/sync/dbMerge.test.js
+++ b/src/sync/dbMerge.test.js
@@ -153,6 +153,76 @@ describe('A1 bundle merge — concurrent different-entry edits are not lost', ()
     }
   });
 
+  it('recurringTasks: a completion is not clobbered by a concurrent series edit (the cross-device bug)', () => {
+    const base = {
+      ...EMPTY_COLLECTIONS,
+      recurringTasks: [{
+        id: 3001, title: 'Stretch', duration: 10, lastModified: T0,
+        recurrence: { type: 'daily' },
+        completedDates: ['2026-06-17'], completedDatesTimestamps: { '2026-06-17': T0 },
+      }],
+    };
+    const { vault, a, b } = newPair(base);
+    // Device A completes a NEW occurrence.
+    a.mutate((d) => {
+      const t = d.recurringTasks[0];
+      t.completedDates = [...t.completedDates, '2026-06-18'];
+      t.completedDatesTimestamps = { ...t.completedDatesTimestamps, '2026-06-18': T1 };
+      t.lastModified = T1;
+      return ['recurringTasks:3001'];
+    });
+    // Device B edits the same series LATER (e.g. a series-level assignment change);
+    // its row does not yet have A's completion. Old whole-row LWW would drop it.
+    b.mutate((d) => {
+      const t = d.recurringTasks[0];
+      t.assignedUserSyncIds = ['user-x'];
+      t.lastModified = T2;
+      return ['recurringTasks:3001'];
+    });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      const t = dev.data.recurringTasks.find((x) => x.id === 3001);
+      expect(new Set(t.completedDates)).toEqual(new Set(['2026-06-17', '2026-06-18'])); // completion survived
+      expect(t.assignedUserSyncIds).toEqual(['user-x']);                                 // newer scalar edit survived
+    }
+  });
+
+  it('recurringTasks: completing different occurrences on each device both survive', () => {
+    const base = {
+      ...EMPTY_COLLECTIONS,
+      recurringTasks: [{
+        id: 3001, title: 'Stretch', lastModified: T0, recurrence: { type: 'daily' },
+        completedDates: [], completedDatesTimestamps: {},
+      }],
+    };
+    const { vault, a, b } = newPair(base);
+    a.mutate((d) => { const t = d.recurringTasks[0]; t.completedDates = ['2026-06-18']; t.completedDatesTimestamps = { '2026-06-18': T1 }; t.lastModified = T1; return ['recurringTasks:3001']; });
+    b.mutate((d) => { const t = d.recurringTasks[0]; t.completedDates = ['2026-06-19']; t.completedDatesTimestamps = { '2026-06-19': T2 }; t.lastModified = T2; return ['recurringTasks:3001']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      const t = dev.data.recurringTasks.find((x) => x.id === 3001);
+      expect(new Set(t.completedDates)).toEqual(new Set(['2026-06-18', '2026-06-19']));
+    }
+  });
+
+  it('recurringTasks: an un-complete propagates instead of being resurrected', () => {
+    const base = {
+      ...EMPTY_COLLECTIONS,
+      recurringTasks: [{
+        id: 3001, title: 'Stretch', lastModified: T0, recurrence: { type: 'daily' },
+        completedDates: ['2026-06-18'], completedDatesTimestamps: { '2026-06-18': T0 },
+      }],
+    };
+    const { vault, a, b } = newPair(base);
+    // A un-completes (removes the date, stamps a later timestamp); B is untouched.
+    a.mutate((d) => { const t = d.recurringTasks[0]; t.completedDates = []; t.completedDatesTimestamps = { '2026-06-18': T2 }; t.lastModified = T2; return ['recurringTasks:3001']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      const t = dev.data.recurringTasks.find((x) => x.id === 3001);
+      expect(t.completedDates).toEqual([]);
+    }
+  });
+
   it('completedTaskUids: appends on both devices both survive (set-union)', () => {
     const base = { ...EMPTY_COLLECTIONS, completedTaskUids: ['uid-base::2026-06-17'] };
     const { vault, a, b } = newPair(base);


### PR DESCRIPTION
## Summary

Two sync-convergence bugs (both the same root class — a merge that can't represent a state being *removed*) plus settings-indicator polish for GLANCEvault.

### 1. Routines flipping between complete/incomplete on their own
Routine completions (`{routineId → date}`) were merged with a **grow-only union** on both sync tiers. Un-completing a routine *deletes* its key (`useRoutines.toggleRoutineCompletion`), and a union can't represent that — so any device that still held the completion resurrected it on the next pull, and the bundle re-push bounced it back. The routine ping-ponged with no user action.

**Fix:** added a parallel `routineCompletionTimestamps` map, stamped on **every** toggle (complete *and* un-complete), and resolve each routine by last-writer-wins on that timestamp so a later un-complete beats a stale complete. Mirrors the existing `habitLogs`/`habitLogTimestamps` pattern. Legacy un-timestamped entries fall back to the old union, so nothing regresses on upgrade.

### 2. Recurring-task completions not converging across devices (multi-user)
A recurring task's per-occurrence completions live in `completedDates` **inside the shared template row**, which both tiers merge by **whole-row last-writer-wins**. The new series-level user-assignment writes (`ef34778`/`59a8917`) bump the template's `lastModified`, so a concurrent assignment edit's row (lacking the completion) won and reverted it everywhere — "completed on one device but not the others."

**Fix:** merge `completedDates` by **union** instead of carrying it inside the LWW row, on both tiers, with optional per-date timestamps so an un-complete still propagates. Scalar fields (title, time, **assignment**, recurrence) still resolve by LWW. On the GLANCEvault tier this required making recurring rows insert-only (merged on every pull rather than LWW-skipped) via `applyRemoteRecurring`, with superset re-push so the vault converges.

### 3. Settings green-dot indicators for GLANCEvault
The Cloud Sync and GLANCE Integrations rows lit only for the file-tier (WebDAV) config, so a GLANCEvault-only setup looked unconfigured. Now gated on the vault state too, on **both** mobile and desktop/tablet settings:
- Cloud Sync → `cloudSyncConfig?.enabled || isVaultEnabled()`
- GLANCE Integrations → `intentForm.webdavUrl || dbIntentsEnabled`

## Testing
- **382 tests pass**, including new regression tests: routine un-complete propagation + re-complete recency, recurring cross-device completion-clobber resistance, concurrent different-occurrence completions, and recurring un-complete propagation.
- Production build succeeds.

## Notes
- These are convergence fixes — once all devices are on this build, existing stuck states should self-heal on the next sync; a routine/task currently mid-flip may need one more sync round to settle.
- The recurring fix is scoped to `completedDates`. Per-date `exceptions` on recurring templates still use whole-row LWW (a latent cousin of bug #2, not reported here) — happy to harden it in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3K8rfxQ2tuByi23yCzSet

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3K8rfxQ2tuByi23yCzSet)_