### PR TITLE
Bump Android versionCode to 133

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 132
+        versionCode = 133
         versionName = "3.7"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Bumps Android `versionCode` 132 → 133 for a new build carrying the completion-sync convergence fixes (routines flip-flop, recurring-task completions across devices) and the GLANCEvault settings dot indicators merged in #1047.

`versionName` stays `3.7` (no user-facing version change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3K8rfxQ2tuByi23yCzSet

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3K8rfxQ2tuByi23yCzSet)_