### PR TITLE
Limit habits: green check while at/under limit, red X over (no amber)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7547,12 +7547,11 @@ const DayPlanner = () => {
         isComplete = h.target > 0 && count >= h.target;
         ringColorHex = count === 0 ? '#d1d5db' : colorObj.ring;
       } else {
+        // Limit type: green (met) while at or under the limit, red once over —
+        // no amber intermediate state.
         progress = 1;
-        isComplete = false;
-        if (count === 0) ringColorHex = '#22c55e';
-        else if (count <= h.target * 0.5) ringColorHex = '#eab308';
-        else if (count <= h.target) ringColorHex = '#f59e0b';
-        else ringColorHex = '#ef4444';
+        isComplete = count <= h.target;
+        ringColorHex = count <= h.target ? '#22c55e' : '#ef4444';
       }
       return {
         id: h.id,

--- a/src/components/HabitRing.jsx
+++ b/src/components/HabitRing.jsx
@@ -19,19 +19,12 @@ const HabitRing = ({ size = 40, habit, count = 0, onClick, onContextMenu, onMous
     showCheck = count >= target && target > 0;
     showX = false;
   } else {
-    // Limit type: ring is always full, color shifts green → yellow → red
+    // Limit type: ring is always full. Stay green (with a check) while at or
+    // under the limit, then flip to red (with an X) once it's exceeded —
+    // no amber intermediate state.
     progress = 1;
-    if (count === 0) {
-      ringColor = '#22c55e'; // green
-    } else if (count <= target) {
-      // Graduated yellow/amber
-      const ratio = count / target;
-      if (ratio <= 0.5) ringColor = '#eab308'; // yellow
-      else ringColor = '#f59e0b'; // amber
-    } else {
-      ringColor = '#ef4444'; // red
-    }
-    showCheck = false;
+    ringColor = count <= target ? '#22c55e' : '#ef4444';
+    showCheck = count <= target;
     showX = count > target;
   }
 
@@ -121,9 +114,7 @@ const MiniHabitRing = ({ habit, count = 0, darkMode }) => {
     ringColor = count === 0 ? (darkMode ? '#4b5563' : '#d1d5db') : colorObj.ring;
   } else {
     progress = 1;
-    if (count === 0) ringColor = '#22c55e';
-    else if (count <= target) ringColor = '#f59e0b';
-    else ringColor = '#ef4444';
+    ringColor = count <= target ? '#22c55e' : '#ef4444';
   }
 
   return (

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -41,10 +41,8 @@ const HABIT_COLOR_HEX = {
 function habitRingColor(habit, count) {
   const base = HABIT_COLOR_HEX[habit.color] ?? '#3b82f6';
   if (habit.type === 'limit') {
-    if (count === 0) return '#22c55e';
-    if (count <= habit.target * 0.5) return '#eab308';
-    if (count <= habit.target) return '#f59e0b';
-    return '#ef4444';
+    // Green while at or under the limit, red once exceeded — no amber state.
+    return count <= habit.target ? '#22c55e' : '#ef4444';
   }
   return count === 0 ? '#d1d5db' : base;
 }


### PR DESCRIPTION
## What changed

For **Limit**-type habits, the status ring now uses a simple two-state scheme:

- **Green ring + green checkmark** for every count **at or under** the target. For a "2 sugary drinks" limit, that means 0/2, 1/2, and 2/2 all show the green check — you've stayed within budget.
- **Red ring + red X** only once the count **exceeds** the target (3/2 and up).

The previous graduated **yellow → amber** middle band has been removed, so there's no ambiguous intermediate color — a limit is either still met (green) or broken (red).

## Where

The limit color/status is computed in several places; all were updated to the same scheme:

- `src/components/HabitRing.jsx` — main `HabitRing` (now shows the green check badge while under limit) and `MiniHabitRing` (past-day date headers)
- `src/App.jsx` — Android home-screen widget snapshot
- `src/hooks/useElectronBridge.js` — Electron desktop ring color

## Notes

`doMore` habits are unchanged. Streak logic (`useHabits.js`) already counted a limit day as met when `count <= target`, so this brings the visual status in line with how streaks were already scored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_