### PR TITLE
Fix recurring intent poll null-deref and remove debug log

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5839,7 +5839,6 @@ const DayPlanner = () => {
       if (data.goalsProjectsEnabledUpdatedAt) localStorage.setItem('day-planner-goals-projects-enabled-updated-at', data.goalsProjectsEnabledUpdatedAt);
     }
     if (data.users !== undefined) {
-      console.log('[diag] applyEngineData users:', JSON.stringify(data.users));
       const localUsers = JSON.parse(localStorage.getItem('dayglance-users') || '[]');
       const merged = new Map(localUsers.map(u => [u.syncId ?? u.id, u]));
       for (const u of data.users) {

--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -393,6 +393,13 @@ async function poll(config, context) {
 }
 
 async function _poll(config, context) {
+  // No-op when WebDAV isn't configured. The poller also runs when only iCloud
+  // is available (config can be null), so guard before dereferencing it —
+  // otherwise eventsDir() throws on config.webdavUrl and the catch in runPoll
+  // would swallow it as a recurring "[intent] poll error" while also skipping
+  // the iCloud poll that follows.
+  if (!config?.webdavUrl || !config?.username || !config?.appPassword) return;
+
   const dir = eventsDir(config);
   const headers = authHeaders(config);
 


### PR DESCRIPTION
## What changed

Two console-noise fixes, both unrelated to the actual GLANCEvault intent-delivery investigation (which is ongoing):

### 1. Recurring `[intent] poll error: …webdavUrl`
`useIntentPoller` mounts whenever **either** WebDAV **or** iCloud is available. On a machine with iCloud available but no WebDAV configured, the intent config is `null`, so `_poll()` → `eventsDir(config)` dereferenced `config.webdavUrl` and threw every poll cycle. The error was swallowed by the `runPoll` catch as a recurring warning, and — worse — it short-circuited the **iCloud** poll that runs on the next line.

`_poll()` now returns early when WebDAV isn't fully configured, mirroring the existing guards in `writeEventFile()` and `runIntentGC()`.

### 2. Leftover `[diag] applyEngineData users:` log
Removed a debug `console.log` in `applyEngineData` that printed the full user list on every sync.

## Not included
This does **not** address GLANCEvault (`vault`/db-intents) intents failing to appear — that's a separate path (`useDbIntentPoller`) still under investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_