### PR TITLE
Surface intent delivery status: queued → delivered, and held-for-key

### DIFF
--- a/src/components/IntentActivityLogModal.jsx
+++ b/src/components/IntentActivityLogModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { X, ArrowDownLeft, ArrowUpRight, ChevronRight, Trash2 } from 'lucide-react';
+import { X, ArrowDownLeft, ArrowUpRight, ChevronRight, Trash2, Check, Clock, KeyRound } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { getActivityLog, clearActivityLog } from '../intents/intentLog.js';
@@ -64,6 +64,28 @@ function errorMessage(entry) {
 
 function errorTextClass(entry) {
   return entry.status === 'warn' ? 'text-amber-500' : 'text-red-500';
+}
+
+// Outbound delivery lifecycle chip: queued (in the outbox) → delivered (landed
+// on the vault/WebDAV) — or held while the intents encryption key isn't ready.
+// Inbound entries have no delivery field and render nothing here.
+const DELIVERY_CHIPS = {
+  queued:    { Icon: Clock,    label: 'queued',          cls: 'text-stone-400' },
+  held:      { Icon: KeyRound, label: 'waiting for key', cls: 'text-amber-500' },
+  delivered: { Icon: Check,    label: 'delivered',       cls: 'text-green-500' },
+};
+
+function DeliveryChip({ entry }) {
+  if (entry.direction !== 'out' || !entry.delivery) return null;
+  const chip = DELIVERY_CHIPS[entry.delivery];
+  if (!chip) return null;
+  const { Icon, label, cls } = chip;
+  return (
+    <span className={`inline-flex items-center gap-0.5 text-[11px] ${cls}`} title={label}>
+      <Icon size={11} className="flex-shrink-0" />
+      {label}
+    </span>
+  );
 }
 
 function shortApp(source_app) {
@@ -199,6 +221,7 @@ const IntentActivityLogModal = () => {
                           {shortApp(entry.source_app) && (
                             <span className={`text-xs ${textSecondary}`}>{shortApp(entry.source_app)}</span>
                           )}
+                          <DeliveryChip entry={entry} />
                         </div>
                         {entry.title && (
                           <p className={`text-xs ${textPrimary} mt-0.5 truncate`}>{entry.title}</p>

--- a/src/intents/deliverers.js
+++ b/src/intents/deliverers.js
@@ -37,6 +37,7 @@ import {
   DEFAULT_DB_INTENTS_TTL_MS,
 } from './dbIntentsConfig.js';
 import * as iCloudTransport from './icloudFileTransport.js';
+import { HELD_NO_KEY_REASON } from './outbox.js';
 
 export const DELIVERED = 'delivered';
 export const TRANSIENT = 'transient';
@@ -120,7 +121,10 @@ export async function vaultDeliverer(intent, opts = {}) {
   const rootKey = await (opts.loadKey ?? loadVaultIntentsRootKey)();
   if (!rootKey) {
     // Key not set up yet (or mid-restore). Send nothing, build nothing, hold.
-    return TRANSIENT;
+    // Tag the reason so flush()/the activity log can show a visible "waiting for
+    // the intents key" state instead of a silent stall (this was undiagnosable
+    // before: the outbox held quietly while the log still read "queued").
+    return { status: TRANSIENT, reason: HELD_NO_KEY_REASON };
   }
 
   // ── ALWAYS-ENCRYPTED envelope (no plaintext branch, ever) ──

--- a/src/intents/deliverers.test.js
+++ b/src/intents/deliverers.test.js
@@ -8,6 +8,7 @@ import {
   TRANSIENT,
   PERMANENT,
 } from './deliverers.js';
+import { HELD_NO_KEY_REASON } from './outbox.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Intents deliverers (stage 2a). These exercise the REAL deliverers and the REAL
@@ -101,13 +102,14 @@ describe('vault deliverer', () => {
     expect(Buffer.from(sent.events[0].envelope, 'base64').toString('utf8')).not.toContain('SECRET-TITLE');
   });
 
-  // (b) NO cached key → 'transient', sends nothing, builds nothing.
-  it('(b) with no cached key returns transient and sends nothing', async () => {
+  // (b) NO cached key → held (transient) tagged with the key-not-ready reason,
+  //     sends nothing, builds nothing.
+  it('(b) with no cached key returns transient (held: key not ready) and sends nothing', async () => {
     const vaultFetch = vi.fn();
     const result = await vaultDeliverer(makeIntent(), {
       connection: CONN, vaultFetch, loadKey: async () => null,
     });
-    expect(result).toBe(TRANSIENT);
+    expect(result).toEqual({ status: TRANSIENT, reason: HELD_NO_KEY_REASON });
     expect(vaultFetch).not.toHaveBeenCalled();
   });
 

--- a/src/intents/deliveryStatus.test.js
+++ b/src/intents/deliveryStatus.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { enqueue, flush, DELIVERED, TRANSIENT, HELD_NO_KEY_REASON } from './outbox.js';
+import {
+  logActivity,
+  getActivityLog,
+  clearActivityLog,
+  setDeliveryStatus,
+  reconcileOutboxActivity,
+} from './intentLog.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Outbound delivery-status observability: flush() reports which event_ids were
+// delivered / held-for-key this pass, and the activity log folds those outcomes
+// into the matching 'queued' entries (queued → delivered, queued → held).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+function createMemoryStore() {
+  const m = new Map();
+  const clone = (v) => JSON.parse(JSON.stringify(v));
+  return {
+    async getAll() { return [...m.values()].map(clone); },
+    async get(id) { return m.has(id) ? clone(m.get(id)) : undefined; },
+    async put(entry) { m.set(entry.id, clone(entry)); },
+    async delete(id) { m.delete(id); },
+  };
+}
+
+const makeIntent = (eventId) => ({
+  event_id: eventId,
+  action: 'notify',
+  emitted_by: 'app.dayglance',
+  payload: { event: 'completed', title: 'Task ' + eventId },
+});
+
+const heldNoKey = () => async () => ({ status: TRANSIENT, reason: HELD_NO_KEY_REASON });
+const delivers = () => async () => DELIVERED;
+
+afterAll(() => { delete global.localStorage; });
+
+beforeEach(() => {
+  global.localStorage = memLocalStorage();
+});
+
+describe('flush() delivery reporting', () => {
+  it('reports deliveredIds when a target delivers', async () => {
+    const store = createMemoryStore();
+    await enqueue(makeIntent('evt-1'), ['vault'], { store });
+
+    const r = await flush({ vault: delivers() }, { store });
+
+    expect(r.delivered).toBe(1);
+    expect(r.deliveredIds).toEqual(['evt-1']);
+    expect(r.heldNoKeyIds).toEqual([]);
+  });
+
+  it('reports heldNoKeyIds when the deliverer holds for a missing key', async () => {
+    const store = createMemoryStore();
+    await enqueue(makeIntent('evt-2'), ['vault'], { store });
+
+    const r = await flush({ vault: heldNoKey() }, { store });
+
+    expect(r.delivered).toBe(0);
+    expect(r.deliveredIds).toEqual([]);
+    expect(r.heldNoKeyIds).toEqual(['evt-2']);
+  });
+});
+
+describe('setDeliveryStatus', () => {
+  beforeEach(() => {
+    clearActivityLog();
+    logActivity({ direction: 'out', action: 'notify', event_id: 'evt-x', delivery: 'queued', status: 'ok' });
+  });
+
+  it('advances queued → delivered', () => {
+    expect(setDeliveryStatus('evt-x', 'delivered')).toBe(true);
+    expect(getActivityLog()[0].delivery).toBe('delivered');
+  });
+
+  it('advances queued → held', () => {
+    expect(setDeliveryStatus('evt-x', 'held')).toBe(true);
+    expect(getActivityLog()[0].delivery).toBe('held');
+  });
+
+  it('is forward-only: never downgrades delivered → held', () => {
+    setDeliveryStatus('evt-x', 'delivered');
+    expect(setDeliveryStatus('evt-x', 'held')).toBe(false);
+    expect(getActivityLog()[0].delivery).toBe('delivered');
+  });
+
+  it('no-ops (returns false) when no entry matches the event_id', () => {
+    expect(setDeliveryStatus('missing', 'delivered')).toBe(false);
+  });
+
+  it('only matches OUTBOUND entries', () => {
+    clearActivityLog();
+    logActivity({ direction: 'in', action: 'notify', event_id: 'evt-in', delivery: 'queued', status: 'ok' });
+    expect(setDeliveryStatus('evt-in', 'delivered')).toBe(false);
+  });
+});
+
+describe('reconcileOutboxActivity', () => {
+  it('folds a flush result into the matching queued entries', () => {
+    clearActivityLog();
+    logActivity({ direction: 'out', action: 'notify', event_id: 'd-1', delivery: 'queued', status: 'ok' });
+    logActivity({ direction: 'out', action: 'notify', event_id: 'h-1', delivery: 'queued', status: 'ok' });
+
+    reconcileOutboxActivity({ deliveredIds: ['d-1'], heldNoKeyIds: ['h-1'] });
+
+    const byId = Object.fromEntries(getActivityLog().map(e => [e.event_id, e.delivery]));
+    expect(byId['d-1']).toBe('delivered');
+    expect(byId['h-1']).toBe('held');
+  });
+
+  it('tolerates a missing/empty result without throwing', () => {
+    expect(() => reconcileOutboxActivity(undefined)).not.toThrow();
+    expect(() => reconcileOutboxActivity({})).not.toThrow();
+  });
+});

--- a/src/intents/emitGoalCreate.js
+++ b/src/intents/emitGoalCreate.js
@@ -64,6 +64,7 @@ export async function emitGoalCreate(goal) {
       direction: 'out', action: 'create', event: null,
       source_app: SOURCE_APPS.DAYGLANCE, title: goal.title, timestamp: now,
       status: 'ok', error: null,
+      event_id: eventId, delivery: 'queued',
     }),
     onError: (err) => {
       console.warn('[goal-create] enqueue failed for goal', goal.id, ':', err.message);

--- a/src/intents/intentLog.js
+++ b/src/intents/intentLog.js
@@ -18,3 +18,60 @@ export function getActivityLog() {
 export function clearActivityLog() {
   localStorage.removeItem(LOG_KEY);
 }
+
+// ─── delivery reconciliation ─────────────────────────────────────────────────
+//
+// Outbound entries are logged at ENQUEUE time with delivery:'queued'. The actual
+// vault/WebDAV POST happens later, in the outbox flush. These helpers let the
+// flush callers fold that later outcome back into the matching log entry so the
+// UI can show queued → delivered (or queued → held, waiting for the intents key)
+// instead of a permanently optimistic "sent".
+
+// Forward-only ordering: a higher index means a later delivery state. We never
+// move an entry backwards (e.g. a stray held signal must not un-deliver a row).
+const DELIVERY_ORDER = { queued: 0, held: 1, delivered: 2 };
+
+/**
+ * Set the delivery state of the most recent OUTBOUND log entry for `eventId`.
+ * No-op (returns false) if there is no matching entry, or if the change would
+ * move the state backwards or leave it unchanged — so repeated flushes don't
+ * rewrite the log or spam it. Only mutates the matched entry.
+ *
+ * @param {string} eventId
+ * @param {'queued'|'held'|'delivered'} delivery
+ * @returns {boolean} true iff an entry was updated
+ */
+export function setDeliveryStatus(eventId, delivery) {
+  if (!eventId) return false;
+  const entries = getActivityLog();
+  const idx = entries.findIndex(e => e.direction === 'out' && e.event_id === eventId);
+  if (idx === -1) return false;
+
+  const entry = entries[idx];
+  const current = entry.delivery ?? 'queued';
+  if ((DELIVERY_ORDER[delivery] ?? 0) <= (DELIVERY_ORDER[current] ?? 0)) return false;
+
+  // 'held' is rendered from the delivery state itself (a known, single reason),
+  // so it deliberately does NOT touch `error` — that field stays reserved for
+  // genuine failures and their red treatment.
+  entries[idx] = { ...entry, delivery };
+  localStorage.setItem(LOG_KEY, JSON.stringify(entries));
+  return true;
+}
+
+/**
+ * Fold a flush() result into the activity log: mark delivered ids 'delivered',
+ * and ids held for a missing key 'held'. Safe to call after every flush; the
+ * forward-only / no-op-on-unchanged guard in setDeliveryStatus keeps it cheap.
+ *
+ * @param {{deliveredIds?: string[], heldNoKeyIds?: string[]}} [result]
+ */
+export function reconcileOutboxActivity(result) {
+  if (!result) return;
+  for (const id of result.deliveredIds ?? []) {
+    setDeliveryStatus(id, 'delivered');
+  }
+  for (const id of result.heldNoKeyIds ?? []) {
+    setDeliveryStatus(id, 'held');
+  }
+}

--- a/src/intents/outbox.js
+++ b/src/intents/outbox.js
@@ -47,6 +47,13 @@ export const DELIVERED = 'delivered';
 export const TRANSIENT = 'transient';
 export const PERMANENT = 'permanent';
 
+// A deliverer may return { status: TRANSIENT, reason: HELD_NO_KEY_REASON } to
+// signal that it held the intent specifically because its encryption key isn't
+// set up yet (vs. a network/server transient). flush() surfaces these ids so the
+// activity log can show a "waiting for the intents key" state instead of a
+// silent stall. Purely observational — it does not change retry behaviour.
+export const HELD_NO_KEY_REASON = 'intents_key_not_ready';
+
 // Per-target delivery statuses stored on an entry.
 const PENDING = 'pending';
 const GIVEN_UP = 'given-up';
@@ -260,7 +267,10 @@ export async function flush(deliverers, opts) {
   if (_flushLock) return { attempted: 0, delivered: 0, gaveUp: 0, removed: 0, skipped: true };
   _flushLock = true;
 
-  const stats = { attempted: 0, delivered: 0, gaveUp: 0, removed: 0, skipped: false };
+  // `delivered`/`gaveUp`/etc. are counts (back-compat). `deliveredIds` and
+  // `heldNoKeyIds` carry the event_ids that transitioned this flush so callers
+  // can reconcile the activity log (queued → delivered, or queued → held).
+  const stats = { attempted: 0, delivered: 0, gaveUp: 0, removed: 0, skipped: false, deliveredIds: [], heldNoKeyIds: [] };
   try {
     const entries = await store.getAll();
     for (const entry of entries) {
@@ -272,19 +282,27 @@ export async function flush(deliverers, opts) {
         if (typeof deliver !== 'function') continue; // not attempted this flush
 
         stats.attempted++;
-        let result;
+        let raw;
         try {
-          result = await deliver(entry.intent);
+          raw = await deliver(entry.intent);
         } catch {
-          result = TRANSIENT; // a thrown send is a maybe-transient failure
+          raw = TRANSIENT; // a thrown send is a maybe-transient failure
         }
-        result = normalizeResult(result);
+        const result = normalizeResult(raw);
 
         if (result === DELIVERED) {
           entry.targets[target] = DELIVERED;
           stats.delivered++;
+          if (!stats.deliveredIds.includes(entry.id)) stats.deliveredIds.push(entry.id);
           changed = true;
           continue;
+        }
+
+        // Held specifically because the encryption key isn't ready — record it so
+        // the activity log can show "waiting for the intents key" rather than a
+        // silent stall. (Only while the target is still pending/transient.)
+        if (result === TRANSIENT && raw && typeof raw === 'object' && raw.reason === HELD_NO_KEY_REASON) {
+          if (!stats.heldNoKeyIds.includes(entry.id)) stats.heldNoKeyIds.push(entry.id);
         }
 
         // Both transient and permanent count an attempt against the target.

--- a/src/intents/outboxEmit.js
+++ b/src/intents/outboxEmit.js
@@ -10,6 +10,7 @@
 
 import { enqueue as defaultEnqueue, flush as defaultFlush } from './outbox.js';
 import { deliverers as defaultDeliverers } from './deliverers.js';
+import { reconcileOutboxActivity } from './intentLog.js';
 
 /**
  * @param {Array<{intent:object, onOk?:Function, onError?:(err:Error)=>void}>} items
@@ -35,6 +36,8 @@ export async function enqueueAndFlush(items, targets, deps = {}) {
   }
 
   // Trigger delivery; the outbox's in-flight lock serializes overlapping flushes.
-  await flush(deliverers);
+  const result = await flush(deliverers);
+  // Fold delivery outcomes back into the just-logged 'queued' entries.
+  reconcileOutboxActivity(result);
   return allEnqueued;
 }

--- a/src/intents/useGoalNotifyEmitter.js
+++ b/src/intents/useGoalNotifyEmitter.js
@@ -125,6 +125,7 @@ export function useGoalNotifyEmitter({ goals }) {
               direction: 'out', action: 'notify', event: change.event,
               source_app: goal.source_app, title: goal.title, timestamp: now,
               status: 'ok', error: null,
+              event_id: payload.event_id, delivery: 'queued',
             }),
             onError: (err) => {
               console.warn('[goal-notify] enqueue failed for goal', goal.id, ':', err.message);

--- a/src/intents/useNotifyEmitter.js
+++ b/src/intents/useNotifyEmitter.js
@@ -179,6 +179,7 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
                 direction: 'out', action: 'notify', event: change.event,
                 source_app: task.source_app, title: task.title, timestamp: now,
                 status: 'ok', error: null,
+                event_id: payload.event_id, delivery: 'queued',
               });
               // Android broadcast for local Tasker listeners — a LOCAL notification,
               // independent of the durable outbox. Only on a plaintext WebDAV posture

--- a/src/intents/useOutboxFlush.js
+++ b/src/intents/useOutboxFlush.js
@@ -11,6 +11,7 @@
 import { useEffect } from 'react';
 import { flush } from './outbox.js';
 import { deliverers } from './deliverers.js';
+import { reconcileOutboxActivity } from './intentLog.js';
 
 const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
 
@@ -19,7 +20,10 @@ const FLUSH_INTERVAL_MS = 2 * 60 * 1000;
 
 async function drain() {
   try {
-    await flush(deliverers);
+    const result = await flush(deliverers);
+    // Reflect delivered / held-for-key outcomes back into the activity log,
+    // including intents carried over (held) from a previous session.
+    reconcileOutboxActivity(result);
   } catch (err) {
     console.warn('[outbox] flush error:', err?.message);
   }


### PR DESCRIPTION
## Why

Debugging a "GLANCEvault intents not arriving" issue surfaced a real observability gap: outbound intents are logged **once, at enqueue time**, as effectively "sent" — and never updated. The actual vault/WebDAV POST happens later in the outbox flush, and if it silently **holds** (e.g. the GLANCEvault *intents* encryption key isn't cached yet, so `vaultDeliverer` sends nothing and returns `transient`), the activity log still reads "sent." That made a stuck-in-outbox intent indistinguishable from a delivered one.

This adds the two states that were invisible.

## What

**(a) queued → delivered.** `flush()` now reports the `event_id`s whose targets delivered this pass (`deliveredIds`), and the activity log folds that outcome back into the matching entry. The log reads `queued → delivered` instead of a permanently optimistic "sent."

> ⚠️ "Delivered" means the row **landed on the vault/WebDAV relay** — *not* that the peer app ingested it. GLANCEvault is a zero-knowledge, insert-only relay with no end-to-end receipt, so "the other app received it" is intentionally **not** claimed. (True peer-receipt would need a separate ack channel — out of scope here.)

**(b) waiting-for-key.** `vaultDeliverer` now returns `{ status: transient, reason: intents_key_not_ready }` when the intents key is absent. `flush()` reports these (`heldNoKeyIds`) and the log shows a **"waiting for key"** chip instead of a silent stall — exactly the signal that would have made the original issue self-diagnosable.

## Changes

- **`outbox.js`** — `flush()` return gains `deliveredIds` / `heldNoKeyIds` (existing counts unchanged for back-compat); new `HELD_NO_KEY_REASON` constant.
- **`deliverers.js`** — `vaultDeliverer` tags the missing-key hold with the reason.
- **`intentLog.js`** — `setDeliveryStatus` (forward-only; no-op when unchanged, so repeated flushes don't rewrite/spam the log) + `reconcileOutboxActivity`. Outbound entries now carry `event_id` + `delivery`.
- **`outboxEmit.js` / `useOutboxFlush.js`** — reconcile after every flush, so both emit-time flushes and the background drain (including intents held over from a previous session) update the log.
- **`IntentActivityLogModal.jsx`** — delivery chip on outbound entries: `queued` / `waiting for key` / `delivered`.
- **Tests** — new `deliveryStatus.test.js` (9 tests: flush reporting, forward-only status transitions, reconcile); `deliverers.test.js` updated for the richer no-key return.

## Verification

- `vitest run` — **391 passed** (incl. 9 new).
- `vite build` — clean.

## Note on the sender app

This is the dayGLANCE side. lastGLANCE mirrors this transport, so the same change would need porting there for its activity log to show delivered/held too — but the core misleading-"sent" behavior is fixed here for any intents dayGLANCE itself emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_