### PR TITLE
Localize cloud-sync error messages via engine error codes

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,4 +1,24 @@
 {
+  "sync": {
+    "errors": {
+      "AUTH_FAILURE": "Authentication failed — check your username and password in sync settings.",
+      "FORBIDDEN": "Sync blocked (403) — your server may be blocking the request.",
+      "LOCKED": "Sync is locked by another device — try again in a moment.",
+      "NETWORK_ERROR": "Network error — check your connection and try again.",
+      "PASSPHRASE_REQUIRED": "Enter your sync passphrase to continue.",
+      "PRECONDITION_FAILED": "Another device updated first — retrying.",
+      "KEY_MISMATCH": "Wrong sync passphrase — it must exactly match the passphrase used on your other devices.",
+      "VERIFIER_UNSUPPORTED": "Your GLANCEvault server needs to be updated to support this app version (key verification).",
+      "ACCOUNT_ID_REQUIRED": "GLANCEvault is missing an account ID — re-enter your GLANCEvault details (URL, device token, and account ID) in Cloud Sync settings.",
+      "APP_ID_MISMATCH": "This sync data belongs to a different app.",
+      "SCHEMA_FORWARD_INCOMPATIBLE": "This sync data is from a newer app version — please update the app.",
+      "ROW_DECRYPT_FAILED": "Some items couldn't be decrypted.",
+      "passphraseNeeded": "Enter your sync passphrase above to enable GLANCEvault.",
+      "vaultUnreachable": "Couldn't reach GLANCEvault — check the vault URL and device token. ({{detail}})",
+      "requestFailed": "request failed",
+      "iCloudUnavailable": "iCloud unavailable: {{error}}"
+    }
+  },
   "common": {
     "cancel": "Cancel",
     "save": "Save",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1,4 +1,25 @@
 {
+  "sync": {
+    "_comment": "STUB — English placeholders awaiting French translation.",
+    "errors": {
+      "AUTH_FAILURE": "Authentication failed — check your username and password in sync settings.",
+      "FORBIDDEN": "Sync blocked (403) — your server may be blocking the request.",
+      "LOCKED": "Sync is locked by another device — try again in a moment.",
+      "NETWORK_ERROR": "Network error — check your connection and try again.",
+      "PASSPHRASE_REQUIRED": "Enter your sync passphrase to continue.",
+      "PRECONDITION_FAILED": "Another device updated first — retrying.",
+      "KEY_MISMATCH": "Wrong sync passphrase — it must exactly match the passphrase used on your other devices.",
+      "VERIFIER_UNSUPPORTED": "Your GLANCEvault server needs to be updated to support this app version (key verification).",
+      "ACCOUNT_ID_REQUIRED": "GLANCEvault is missing an account ID — re-enter your GLANCEvault details (URL, device token, and account ID) in Cloud Sync settings.",
+      "APP_ID_MISMATCH": "This sync data belongs to a different app.",
+      "SCHEMA_FORWARD_INCOMPATIBLE": "This sync data is from a newer app version — please update the app.",
+      "ROW_DECRYPT_FAILED": "Some items couldn't be decrypted.",
+      "passphraseNeeded": "Enter your sync passphrase above to enable GLANCEvault.",
+      "vaultUnreachable": "Couldn't reach GLANCEvault — check the vault URL and device token. ({{detail}})",
+      "requestFailed": "request failed",
+      "iCloudUnavailable": "iCloud unavailable: {{error}}"
+    }
+  },
   "common": {
     "cancel": "Annuler",
     "save": "Enregistrer",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -134,6 +134,7 @@ import HabitModal from './components/HabitModal.jsx';
 import SubscriptionWall from './components/SubscriptionWall.jsx';
 import { useSubscription } from './hooks/useSubscription.js';
 import { useTranslation } from 'react-i18next';
+import { syncErrorText } from './sync/syncErrors.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -554,16 +555,6 @@ const DayPlanner = () => {
   // Count of synced rows the last cycle couldn't decrypt (skipped/quarantined by
   // the engine) — surfaced in Cloud Sync settings so a key mismatch is visible.
   const [vaultSkipped, setVaultSkipped] = useState(0);
-  // Map the engine's typed error codes to a user-facing message. KEY_MISMATCH
-  // (wrong passphrase/salt) and VERIFIER_UNSUPPORTED (server too old for the key
-  // verifier) get clear instructions instead of the raw crypto/HTTP text.
-  const vaultErrorText = (msg, code) => {
-    if (!msg) return null;
-    if (code === 'KEY_MISMATCH') return 'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.';
-    if (code === 'VERIFIER_UNSUPPORTED') return 'Your GLANCEvault server needs to be updated to support this app version (key verification).';
-    if (code === 'ACCOUNT_ID_REQUIRED') return 'GLANCEvault is missing an account ID — re-open Cloud Sync settings and re-enter your GLANCEvault details.';
-    return msg;
-  };
   const engineFolderRef = useRef(null);
   const syncFolder = cloudSyncConfig?.syncFolder ?? 'GLANCE/dayglance';
   const autoBackupProviders = useMemo(() => createAutoBackupProvidersForFolder(syncFolder), [syncFolder]);
@@ -579,7 +570,7 @@ const DayPlanner = () => {
         if (status === 'idle' && (prev === 'uploading' || prev === 'downloading')) return prev;
         return status;
       }),
-      onError:              (msg) => setCloudSyncError(msg),
+      onError:              (msg, code) => setCloudSyncError(syncErrorText(t, msg, code)),
       onLastSyncedChange:   (iso) => setCloudSyncLastSynced(iso),
       onConflict:           (remoteData, remoteModified, etag) =>
         setCloudSyncConflict({ remoteData, remoteModified, etag }),
@@ -1788,7 +1779,7 @@ const DayPlanner = () => {
           setVaultLastSynced(dbEngineRef.current?.getLastSynced?.() || new Date().toISOString());
         }
       },
-      onError: (msg, code) => { setVaultError(vaultErrorText(msg, code)); if (msg) console.warn('[dayglance] vault sync error:', code || '', msg); },
+      onError: (msg, code) => { setVaultError(syncErrorText(t, msg, code)); if (msg) console.warn('[dayglance] vault sync error:', code || '', msg); },
       onRowsSkipped: (count) => {
         setVaultSkipped(count);
         if (count > 0) setUndoToast({ message: `GLANCEvault: ${count} item${count === 1 ? '' : 's'} couldn't be read — see Cloud Sync settings`, actionable: false });
@@ -2074,7 +2065,7 @@ const DayPlanner = () => {
       if (remote?.downloading) return;
       if (remote?.error) {
         console.error('iCloud unavailable:', remote.error);
-        setCloudSyncError(`iCloud unavailable: ${remote.error}`);
+        setCloudSyncError(t('sync.errors.iCloudUnavailable', { error: remote.error }));
         setCloudSyncStatus('error');
         setTimeout(() => setCloudSyncStatus((s) => s === 'error' ? 'idle' : s), 5000);
         return;

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -166,17 +166,19 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
         await resetDbRootKey(); // don't leave a bad key cached after a failed attempt
         setVaultConfig(vaultOriginal || null); // roll back so we don't half-enable
         const msg = err?.message || '';
-        setVaultBootstrapError(
-          err?.code === 'VERIFIER_UNSUPPORTED'
-            ? 'Your GLANCEvault server needs to be updated to support this app version (key verification).'
-            : err?.code === 'ACCOUNT_ID_REQUIRED'
-            ? 'GLANCEvault is missing an account ID — re-enter your GLANCEvault details (URL, device token, and account ID) above.'
-            : (err?.code === 'KEY_MISMATCH' || /decrypt/i.test(msg))
-              ? 'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.'
-              : /passphrase/i.test(msg)
-                ? 'Enter your sync passphrase above to enable GLANCEvault.'
-                : `Couldn't reach GLANCEvault — check the vault URL and device token. (${msg || 'request failed'})`,
-        );
+        const code = err?.code;
+        let key, opts;
+        if (code === 'VERIFIER_UNSUPPORTED' || code === 'ACCOUNT_ID_REQUIRED') {
+          key = `sync.errors.${code}`;
+        } else if (code === 'KEY_MISMATCH' || /decrypt/i.test(msg)) {
+          key = 'sync.errors.KEY_MISMATCH';
+        } else if (/passphrase/i.test(msg)) {
+          key = 'sync.errors.passphraseNeeded';
+        } else {
+          key = 'sync.errors.vaultUnreachable';
+          opts = { detail: msg || t('sync.errors.requestFailed') };
+        }
+        setVaultBootstrapError(t(key, opts));
         return;
       }
       setVaultBootstrapping(false);

--- a/src/sync/syncErrors.js
+++ b/src/sync/syncErrors.js
@@ -1,0 +1,27 @@
+// Localize cloud-sync errors.
+//
+// @glance-apps/sync already delivers BOTH a human-readable English `message`
+// AND a structured `code` (SyncErrorCode) to onError(message, code, isHardStop)
+// on both the file (WebDAV/iCloud) and DB (GLANCEvault) tiers. So localization is
+// a client concern: key the display string off the typed `code`, and fall back
+// to the engine's English `message` for any code we don't (yet) have a key for.
+//
+// Pass the caller's own `t` (from useTranslation) so the string honours the
+// active language at the moment the error is rendered.
+//
+// NOTE: testConnection()/test() return only `{ success, error }` with NO code, so
+// the "Test Connection" result is the one sync surface that stays English until
+// the package grows a code there — handled at that call site, not here.
+
+/**
+ * @param {(key: string, opts?: object) => string} t  i18next translator
+ * @param {string|null} message  engine-provided English message (fallback)
+ * @param {string|null} [code]   SyncErrorCode, if any
+ * @returns {string|null}  localized message, or null when there is no error
+ *                          (a null message is the engine's "clear error" signal)
+ */
+export function syncErrorText(t, message, code) {
+  if (!message) return null;
+  if (code) return t(`sync.errors.${code}`, { defaultValue: message });
+  return message;
+}

--- a/src/sync/syncErrors.test.js
+++ b/src/sync/syncErrors.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { syncErrorText } from './syncErrors.js';
+
+// A fake i18next translator: returns a known string for mapped keys, otherwise
+// honours { defaultValue } the way i18next does.
+const KNOWN = { 'sync.errors.KEY_MISMATCH': 'Wrong sync passphrase.' };
+const t = (key, opts = {}) => KNOWN[key] ?? (opts.defaultValue ?? key);
+
+describe('syncErrorText', () => {
+  it('returns null for a null/empty message (the engine "clear error" signal)', () => {
+    expect(syncErrorText(t, null, 'NETWORK_ERROR')).toBe(null);
+    expect(syncErrorText(t, '', 'NETWORK_ERROR')).toBe(null);
+  });
+
+  it('maps a known code to its localized string', () => {
+    expect(syncErrorText(t, 'raw decrypt error', 'KEY_MISMATCH')).toBe('Wrong sync passphrase.');
+  });
+
+  it('falls back to the engine message when the code has no key', () => {
+    expect(syncErrorText(t, 'Server exploded', 'SOME_FUTURE_CODE')).toBe('Server exploded');
+  });
+
+  it('returns the raw message when there is no code', () => {
+    expect(syncErrorText(t, 'Plain message', null)).toBe('Plain message');
+    expect(syncErrorText(t, 'Plain message', undefined)).toBe('Plain message');
+  });
+});


### PR DESCRIPTION
## Why

We'd assumed localizing sync errors would need a `@glance-apps/sync` change to emit error codes. It turns out **the package already does** — `onError(message, code, isHardStop)` delivers a typed `SyncErrorCode` alongside the English message on **both** the file (WebDAV/iCloud) and DB (GLANCEvault) tiers. So this is a **client-only** change: no package change, no version bump, no cross-repo coordination for the main path.

Today those codes are either mapped to **hardcoded English** (`vaultErrorText` in App.jsx, the bootstrap mapping in the settings form) or thrown away entirely (the file-tier handler used only the message).

## What

- **New helper** `src/sync/syncErrors.js` — `syncErrorText(t, message, code)` keys off the code (`t('sync.errors.<CODE>')`) and falls back to the engine's English `message` for any unmapped/absent code. A `null` message stays the engine's "clear error" signal. Takes the caller's `t` so it honours the active language.
- **Wired the error sites:**
  - File/WebDAV tier `onError` now **uses the code it already received** (was discarded).
  - Vault/DB tier `onError` replaces the hardcoded `vaultErrorText` map.
  - `CloudSyncSettingsForm` bootstrap-error mapping uses `t()` keyed by code (the existing regex fallbacks for **code-less** messages are preserved).
  - iCloud-unavailable uses an interpolated key.
- **Locale keys:** added `sync.errors.*` to `en` (real) and `fr` (English stubs, marked awaiting translation). `de/es/it/pt` fall back to `en` automatically until translated.

## Known exception (documented)

`testConnection()` / `test()` returns `{ success, error }` with **no code**, so the **"Test Connection"** result stays English until the package grows a code there. Not worth a package round-trip on its own; called out in the helper's doc comment.

## Verification

- `vitest run` — **395 passed** (4 new in `syncErrors.test.js`: code mapping, message fallback, null-message clear signal).
- `vite build` — clean.
- Confirmed `t` is in scope at every wired site (App.jsx has a single `useTranslation()`).

## Porting

Same client-only pattern applies to lastGLANCE / the third app via their own locale files — no shared-package work needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_