### PR TITLE
Fix two undefined-reference crashes found by lint pass

### DIFF
--- a/src/components/VoiceInputModal.jsx
+++ b/src/components/VoiceInputModal.jsx
@@ -3,7 +3,7 @@ import { BrainCircuit, Check, Loader, Mic, MicOff, Pencil, Plus, X } from 'lucid
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import ClockTimePicker from './ClockTimePicker.jsx';
-import { supportsTranscription } from '../ai.js';
+import { supportsTranscription, PROVIDER_LABELS } from '../ai.js';
 
 const VoiceInputModal = () => {
   const {

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -13,7 +13,7 @@ const WeeklyReviewModal = () => {
     mobileReviewPage, setMobileReviewPage,
     reviewScrollRef,
     tasks: allTasks, recurringTasks: allRecurringTasks, unscheduledTasks: allUnscheduledTasks,
-    selectedDate,
+    selectedDate, setSelectedDate,
     isMobile, isTablet,
     darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg,
     use24HourClock, formatTime, timeToMinutes,


### PR DESCRIPTION
## Why

A pre-release bug-only ESLint pass (`no-undef`) surfaced two latent `ReferenceError`s. The production build doesn't catch them because both references sit in **runtime-only branches** that only evaluate under specific conditions — so they'd ship and white-screen for affected users.

## The two bugs

1. **`VoiceInputModal.jsx` — `PROVIDER_LABELS` not imported.** It's exported from `ai.js` but the file imported only `supportsTranscription`. The reference is in the error-message branch that renders when **a user's configured AI provider doesn't support voice transcription** (e.g. Anthropic/OpenRouter) and they open voice input → crash.
   - Fix: add `PROVIDER_LABELS` to the existing `ai.js` import.

2. **`WeeklyReviewModal.jsx` — `setSelectedDate` not destructured.** The component pulled `selectedDate` from `useDayPlannerCtx()` but not the setter (the context provides it). The reference is in the click handler that runs when a user **clicks an overdue task in the Weekly Review** to jump to its date → crash.
   - Fix: add `setSelectedDate` to the same destructure.

Both are one-line changes. The four other `no-undef` hits from the pass were false positives (`__APP_VERSION__` / `__BUILD_TIMESTAMP__` Vite `define` constants) and are not touched here.

## Verification

- `vite build` — clean.
- `vitest run` — 391 passed.

## Follow-up (not in this PR)

Adopt ESLint properly post-release as its own PR — committed flat config (declaring the Vite-define globals so those false positives vanish), plus a CI job running lint + the vitest suite on PRs (neither runs in CI today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_