### PR TITLE
Bump version to 3.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.7.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.8.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 133
-        versionName = "3.7"
+        versionCode = 134
+        versionName = "3.8"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "dependencies": {
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.7.0",
+  "version": "3.8.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## What

Release version bump from 3.7.0 to 3.8.0.

- `package.json` + `package-lock.json`: 3.7.0 to 3.8.0
- README version badge: 3.7.0 to 3.8.0
- Android (`dayglance-android/app/build.gradle.kts`): `versionCode` 133 to 134, `versionName` "3.7" to "3.8" (matches the web version's major.minor)

## Why 3.8.0 (minor)

The work landed since 3.7.0 is backward-compatible and user-facing: intent delivery-status observability, cloud-sync error localization, and the Limit-habit color behavior change, plus bug fixes (the intent poll null-deref and the two undefined-reference crashes). That maps to a minor bump under semver.

## Verification

- Lockfile change is limited to the two version fields; no dependency churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_