### PR TITLE
Reduce ESLint warnings 169 to 84 and add a max-warnings ratchet

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,14 @@ export default [
   {
     files: ['src/**/*.{js,jsx}'],
     ...js.configs.recommended,
+    // While exhaustive-deps is only a warning, the existing
+    // `// eslint-disable-next-line react-hooks/exhaustive-deps` intent-markers
+    // report as "unused" (the current plugin flags a different line than where
+    // they sit). Don't flag them as unused for now; re-enable this when the
+    // exhaustive-deps backlog is cleaned up and the directives are repositioned.
+    linterOptions: {
+      reportUnusedDisableDirectives: 'off',
+    },
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
@@ -48,7 +56,9 @@ export default [
       // context values and imports), which would bury the useful warnings above.
       // Re-enable as 'warn' (with the ^_ ignore patterns) after a cleanup pass.
       'no-unused-vars': 'off',
-      'no-empty': 'warn',
+      // Empty catch is a deliberate "best-effort, ignore failure" idiom here, so
+      // allow it; still flag genuinely empty if/for/while blocks.
+      'no-empty': ['warn', { allowEmptyCatch: true }],
       'no-constant-condition': ['warn', { checkLoops: false }],
       'no-useless-escape': 'warn',
       'no-prototype-builtins': 'warn',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:android": "./node_modules/.bin/vite build --config vite.config.android.js",
     "build:ios": "./node_modules/.bin/vite build --config vite.config.ios.js",
     "preview": "vite preview",
-    "lint": "eslint src",
+    "lint": "eslint src --max-warnings 84",
     "test": "vitest run",
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
     "build:calendar-helper": "bash scripts/build-calendar-helper.sh",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5302,6 +5302,7 @@ const DayPlanner = () => {
         // Parse RRULE from master VTODO
         const rruleMatch = icsContent.match(/^RRULE:(.+)$/m);
         if (!rruleMatch) {
+          // No recurrence rule on this VTODO — nothing to expand.
         } else {
           const rruleStr = rruleMatch[1].trim();
           const datePart = date.replace(/-/g, ''); // "YYYYMMDD"

--- a/src/utils/suggestionParser.js
+++ b/src/utils/suggestionParser.js
@@ -49,7 +49,7 @@ export const getPartialDate = (text, cursorPos) => {
     const char = text[startIndex];
     if (char === '@') {
       const partial = text.slice(startIndex + 1, cursorPos);
-      if (partial.length >= 1 && /^[\w\s\/\-,]*$/.test(partial)) {
+      if (partial.length >= 1 && /^[\w\s/\-,]*$/.test(partial)) {
         return { partial, startIndex };
       }
       return null;
@@ -83,7 +83,7 @@ export const getPartialDeadline = (text, cursorPos) => {
     const char = text[startIndex];
     if (char === '$') {
       const partial = text.slice(startIndex + 1, cursorPos);
-      if (partial.length >= 1 && /^[\w\s\/\-,]*$/.test(partial)) {
+      if (partial.length >= 1 && /^[\w\s/\-,]*$/.test(partial)) {
         return { partial, startIndex };
       }
       return null;


### PR DESCRIPTION
## What

Phase 1 of driving the ESLint warning count down. No behavioral risk: the cuts are config choices and two trivial code touches. The remaining **84 warnings are all `react-hooks/exhaustive-deps`**, which is the signal worth keeping.

### Config (`eslint.config.mjs`)
- **`no-empty: allowEmptyCatch`** — empty `catch` is a deliberate "best-effort, ignore failure" idiom used throughout (`catch {}` / `catch (_) {}`). Allowing it is a principled choice, not suppression; genuinely empty `if`/`for`/`while` blocks are still flagged. Clears 59.
- **`reportUnusedDisableDirectives: off`** — the existing `// eslint-disable-next-line react-hooks/exhaustive-deps` intent-markers report as "unused" under the current plugin version (it flags a different line than where the directive sits). Auto-removing author intent-markers during the warn phase is wrong, so this is silenced for now and will be re-enabled when the `exhaustive-deps` backlog is cleaned up and the directives repositioned. Clears 23.

### Code
- `suggestionParser.js`: removed a redundant `\/` escape inside a regex character class (`no-useless-escape`).
- `App.jsx`: added a one-line comment to the intentional empty branch of an inverted guard (`if (!rruleMatch) {} else {...}`).

### Ratchet (`package.json`)
- `lint` now runs `eslint src --max-warnings 84`, so CI **fails if anyone adds a warning**. Lower the ceiling as the backlog is worked down. (Verified: passes at 84, fails at 83.)

## What's left (Phase 3, separate)

The 84 `exhaustive-deps` warnings are real per-site judgment calls (add the missing dep and verify no render loop, or annotate/restructure an intentional omission). Not auto-fixable and not a blanket change. Best done in small reviewable batches, lowering `--max-warnings` each time.

## Verification

- `npm run lint`: 0 errors, 84 warnings, exit 0 (ratchet passes).
- `npm test`: 395 passed.
- `npm run build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_