### PR TITLE
exhaustive-deps batch 1: clear 14 warnings across 8 hooks (84 to 70)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:android": "./node_modules/.bin/vite build --config vite.config.android.js",
     "build:ios": "./node_modules/.bin/vite build --config vite.config.ios.js",
     "preview": "vite preview",
-    "lint": "eslint src --max-warnings 84",
+    "lint": "eslint src --max-warnings 70",
     "test": "vitest run",
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
     "build:calendar-helper": "bash scripts/build-calendar-helper.sh",

--- a/src/hooks/useAppInit.js
+++ b/src/hooks/useAppInit.js
@@ -26,6 +26,9 @@ export default function useAppInit({
     return () => {
       clearInterval(rotationInterval);
     };
+    // Mount-once: load data and start the rotation interval exactly once. Re-running
+    // on dependency changes would reload data and reset the interval.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Persist welcome dismissal only when user has real tasks
@@ -48,5 +51,5 @@ export default function useAppInit({
         setShowWelcome(false);
       }
     }
-  }, [dataLoaded, hasZeroRealTasks]);
+  }, [dataLoaded, hasZeroRealTasks, hasCheckedInitialWelcome, setShowWelcome]);
 }

--- a/src/hooks/useDayViewHourHeight.js
+++ b/src/hooks/useDayViewHourHeight.js
@@ -34,20 +34,24 @@ export default function useDayViewHourHeight(calendarRef, stickyHeaderRef) {
       const ro = new ResizeObserver(compute);
       if (calendarRef?.current) {
         ro.observe(calendarRef.current);
-        calendarRef.current.addEventListener('scroll', onScroll, { passive: true });
+        scrollEl = calendarRef.current;
+        scrollEl.addEventListener('scroll', onScroll, { passive: true });
       }
       if (stickyHeaderRef?.current) ro.observe(stickyHeaderRef.current);
-      // Keep a reference so cleanup can disconnect even after the rAF fires.
+      // Keep references so cleanup can disconnect/detach even after the rAF fires —
+      // and so the listener is removed from the SAME node it was attached to, not
+      // whatever calendarRef.current happens to be at cleanup time.
       roRef = ro;
     });
 
     let roRef = null;
+    let scrollEl = null;
     return () => {
       cancelAnimationFrame(rafId);
       roRef?.disconnect();
-      calendarRef?.current?.removeEventListener('scroll', onScroll);
+      scrollEl?.removeEventListener('scroll', onScroll);
     };
-  }, []); // refs are stable objects — no deps needed
+  }, [calendarRef, stickyHeaderRef]); // refs are stable; listed to satisfy exhaustive-deps
 
   return hourHeight;
 }

--- a/src/hooks/useMobileInteractions.js
+++ b/src/hooks/useMobileInteractions.js
@@ -49,7 +49,7 @@ export default function useMobileInteractions({ isMobile, performUndo, performRe
       document.removeEventListener('touchmove', onTouchMove);
       document.removeEventListener('touchend', onTouchEnd);
     };
-  }, [isMobile]);
+  }, [isMobile, performUndo, performRedo]);
 
   return { longPressTriggeredRef, longPressTimerRef };
 }

--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -82,7 +82,7 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
       localStorage.removeItem('day-planner-routine-completions');
       localStorage.removeItem('day-planner-routine-completion-timestamps');
     }
-  }, [currentTime]);
+  }, [currentTime, routinesDate]);
 
   const toggleRoutineCompletion = (routineId) => {
     const todayStr = dateToString(new Date());

--- a/src/hooks/useSaveOnChange.js
+++ b/src/hooks/useSaveOnChange.js
@@ -33,5 +33,10 @@ export default function useSaveOnChange({
         suppressTimestampRef.current = false;
       });
     }
+    // Intentionally keyed on the DATA slices only: this effect should fire when
+    // saved data changes, not when saveData/checkConflicts identities change (they
+    // are called, not dependencies, and would over-trigger). The suppress* refs are
+    // stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataLoaded, tasks, unscheduledTasks, recycleBin, taskCalendarUrl, syncUrl, syncRetentionDays, completedTaskUids, recurringTasks, routineDefinitions, todayRoutines, routinesDate, removedTodayRoutineIds, habits, habitLogs, habitsEnabled, routinesEnabled, gtdFrames, goals, projects, goalsProjectsEnabled]);
 }

--- a/src/hooks/useTaskMeasurement.js
+++ b/src/hooks/useTaskMeasurement.js
@@ -7,23 +7,24 @@ export default function useTaskMeasurement({ tasks, visibleDays, mobileActiveTab
   // Measure task widths using ResizeObserver
   useEffect(() => {
     const observer = new ResizeObserver((entries) => {
-      const newWidths = {};
-      let hasChanges = false;
-
-      for (const entry of entries) {
-        const taskId = entry.target.dataset.taskId;
-        if (taskId) {
-          const width = entry.contentRect.width;
-          if (taskWidths[taskId] !== width) {
-            newWidths[taskId] = width;
-            hasChanges = true;
+      // Compare against live state inside the updater rather than a captured
+      // `taskWidths` — the observer outlives the render it was created in, so a
+      // closed-over copy would be stale. Returning `prev` unchanged when nothing
+      // differs avoids a needless re-render.
+      setTaskWidths(prev => {
+        let next = prev;
+        for (const entry of entries) {
+          const taskId = entry.target.dataset.taskId;
+          if (taskId) {
+            const width = entry.contentRect.width;
+            if (prev[taskId] !== width) {
+              if (next === prev) next = { ...prev };
+              next[taskId] = width;
+            }
           }
         }
-      }
-
-      if (hasChanges) {
-        setTaskWidths(prev => ({ ...prev, ...newWidths }));
-      }
+        return next;
+      });
     });
 
     // Observe all registered task elements

--- a/src/hooks/useTimelineScroll.js
+++ b/src/hooks/useTimelineScroll.js
@@ -29,7 +29,7 @@ export default function useTimelineScroll({
         calendarRef.current.scrollTop = scrollPosition;
       }
     }
-  }, [viewMode]);
+  }, [viewMode, calendarRef, timeGridRef]);
 
   // Scroll timeline to a specific time string (e.g. "08:00")
   const scrollToHour = useCallback((timeStr, smooth = false) => {
@@ -43,7 +43,7 @@ export default function useTimelineScroll({
         calendarRef.current.scrollTop = scrollPosition;
       }
     }
-  }, []);
+  }, [calendarRef, timeGridRef]);
 
   useEffect(() => {
     if (viewMode !== 'multi') {
@@ -59,7 +59,7 @@ export default function useTimelineScroll({
       const timerId = setTimeout(() => scrollToCurrentHour(false), 100);
       return () => clearTimeout(timerId);
     }
-  }, [selectedDate, isMobile, mobileActiveTab, mobileViewMode, tabletListView, scrollToCurrentHour, viewMode]);
+  }, [selectedDate, isMobile, mobileActiveTab, mobileViewMode, tabletListView, scrollToCurrentHour, viewMode, calendarRef]);
 
   // Detect when user scrolls away from current time (all form factors)
   useEffect(() => {
@@ -89,7 +89,7 @@ export default function useTimelineScroll({
     // Delay initial check so the scroll-to-current-hour effect (100ms timeout) runs first
     const initialCheckTimer = setTimeout(onScroll, 200);
     return () => { el.removeEventListener('scroll', onScroll); clearTimeout(initialCheckTimer); };
-  }, [isMobile, isTablet, selectedDate, mobileActiveTab]);
+  }, [isMobile, isTablet, selectedDate, mobileActiveTab, calendarRef, timeGridRef]);
 
   // Auto-refocus timeline every 30 minutes on tablet and desktop
   useEffect(() => {
@@ -113,7 +113,7 @@ export default function useTimelineScroll({
       clearTimeout(timeoutId);
       if (intervalId) clearInterval(intervalId);
     };
-  }, [isMobile, selectedDate, scrollToCurrentHour, viewMode]);
+  }, [isMobile, selectedDate, scrollToCurrentHour, viewMode, calendarRef]);
 
   return { timelineScrolledAway, setTimelineScrolledAway, scrollToCurrentHour, scrollToHour };
 }

--- a/src/hooks/useWeekViewHourHeight.js
+++ b/src/hooks/useWeekViewHourHeight.js
@@ -25,7 +25,7 @@ export default function useWeekViewHourHeight(calendarRef, stickyHeaderRef, visi
       cancelAnimationFrame(rafId);
       roRef?.disconnect();
     };
-  }, [visibleHours]); // refs are stable; visibleHours changes when truncation toggles
+  }, [visibleHours, calendarRef, stickyHeaderRef]); // refs are stable; visibleHours changes when truncation toggles
 
   return hourHeight;
 }


### PR DESCRIPTION
## What

First triage-and-fix batch of the `react-hooks/exhaustive-deps` backlog, done **per-site** (not a blanket `--fix`, which we already saw misbehave). 8 self-contained hook files, 84 to 70 warnings, ratchet lowered to 70.

> **Stacked on #1056.** Base is the `reduce-eslint-warnings` branch (which holds the ratchet). Merge #1056 first; GitHub will auto-retarget this to `main`.

## The triage split (this is the useful part)

The batch confirms the hypothesis from our discussion: most are benign, but the rule **did** surface real issues.

**Real fixes (latent bug / correctness):**
- **`useTaskMeasurement`** — genuine latent bug. Its `ResizeObserver` callback compared widths against a closed-over `taskWidths`, which goes stale after the effect's render (the observer outlives that render). Moved the comparison **inside** the `setTaskWidths` updater so it reads live state, returning `prev` unchanged when nothing differs. Fixes the staleness and the warning.
- **`useDayViewHourHeight`** — the scroll listener was detached from `calendarRef.current` at cleanup time, which can differ from the node it was attached to. Now captures the node and detaches from that exact element.

**Safe no-op dep additions (stable refs / state setters — identities never change):**
- `useTimelineScroll` (5 sites), `useWeekViewHourHeight`, `useDayViewHourHeight`: added `calendarRef` / `timeGridRef` / `stickyHeaderRef`.
- `useAppInit` (welcome effect): added the stable ref + `setShowWelcome`.

**Behavior-preserving additions (cheap re-subscribe, also removes potential staleness):**
- `useMobileInteractions`: added `performUndo`/`performRedo` so the multi-finger gesture handlers can't call stale versions.
- `useRoutines`: added `routinesDate` to the day-rollover effect (the state-set is guarded, so no loop).

**Intentional omissions, annotated with a reason (not blindly "fixed"):**
- `useAppInit` mount-once init; `useSaveOnChange` (keyed on data slices only — `saveData`/`checkConflicts` would over-trigger).

## Verification

- `npm run lint`: 0 errors, 70 warnings, exit 0 (ratchet at 70).
- `npm test`: 395 passed.
- `npm run build`: clean.

## Takeaway for the remaining 70

Ratio in this batch: 1 real bug, 1 correctness fix, ~10 benign, 2 intentional. So the remaining backlog is worth continuing (it finds real things) but is mostly annotation/no-op. The two giant setter-list effects (`useKeyboardShortcuts`, `useModalClose`) were deliberately deferred — they need careful stale-closure analysis of the values they close over, which deserves its own batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_