### PR TITLE
Fix iCloud task resurrection: don't re-stamp unchanged tasks on passive normalization

### DIFF
--- a/src/hooks/useDataPersistence.js
+++ b/src/hooks/useDataPersistence.js
@@ -35,7 +35,17 @@ export default function useDataPersistence({
     if (suppressTimestampRef.current) return currentTasks;
     let prev;
     try { prev = JSON.parse(localStorage.getItem(storageKey) || '[]'); } catch { prev = []; }
-    return stampTimestamps(currentTasks, prev, new Date().toISOString());
+    // Opt-in diagnostic: set localStorage 'dayglance-debug-stamp' = '1' to log
+    // which fields trip a re-stamp. Use it to catch a phantom re-stamp (a default
+    // or unexpected field, not a real edit) if task resurrection ever recurs.
+    let onRestamp;
+    try {
+      if (localStorage.getItem('dayglance-debug-stamp') === '1') {
+        onRestamp = ({ id, changedKeys }) =>
+          console.warn(`[stamp] re-stamped ${storageKey} ${id} — changed:`, changedKeys);
+      }
+    } catch { /* ignore */ }
+    return stampTimestamps(currentTasks, prev, new Date().toISOString(), onRestamp);
   };
 
   const loadData = () => {

--- a/src/hooks/useDataPersistence.js
+++ b/src/hooks/useDataPersistence.js
@@ -1,5 +1,6 @@
 import { dateToString } from '../utils/taskUtils.js';
 import { hasNativeCalendar } from '../utils/nativeCalendar.js';
+import { stampTimestamps } from '../utils/stampTimestamps.js';
 
 // Read-only CalDAV/ICS-subscription events (importSource 'sync', non-task,
 // non-file) are ephemeral remote data, re-fetched live each session. On devices
@@ -32,28 +33,9 @@ export default function useDataPersistence({
   // Stamp lastModified on tasks that changed since last save
   const stampTaskTimestamps = (currentTasks, storageKey) => {
     if (suppressTimestampRef.current) return currentTasks;
-    const now = new Date().toISOString();
     let prev;
     try { prev = JSON.parse(localStorage.getItem(storageKey) || '[]'); } catch { prev = []; }
-    const prevMap = new Map(prev.map(t => [String(t.id), t]));
-    return currentTasks.map(t => {
-      const id = String(t.id);
-      const prevTask = prevMap.get(id);
-      if (prevTask && prevTask.lastModified) {
-        const { lastModified: _a, ...prevRest } = prevTask;
-        const { lastModified: _b, ...currRest } = t;
-        if (JSON.stringify(prevRest) === JSON.stringify(currRest)) {
-          return { ...t, lastModified: prevTask.lastModified };
-        }
-      }
-      // If the task is new to localStorage but already carries a lastModified
-      // (e.g. a fresh Obsidian import stamped with epoch, or a task arriving
-      // via cloud sync), preserve it so cloud merge doesn't treat a passive
-      // re-import as a newer edit than real user changes on other devices.
-      if (!prevTask && t.lastModified) return t;
-      // Task is new or changed — stamp it now so other devices see the update
-      return { ...t, lastModified: now };
-    });
+    return stampTimestamps(currentTasks, prev, new Date().toISOString());
   };
 
   const loadData = () => {

--- a/src/utils/stampTimestamps.js
+++ b/src/utils/stampTimestamps.js
@@ -1,0 +1,52 @@
+// Pure timestamp-stamping for synced task arrays, extracted from
+// useDataPersistence so it can be unit-tested in isolation.
+//
+// PURPOSE: a safety net that assigns `lastModified` to tasks that changed but
+// weren't stamped at their mutation site, so other devices see the update.
+//
+// HAZARD it must avoid: re-stamping a task the user did NOT change. The file-tier
+// cloud sync resolves tasks by last-write-wins on `lastModified`. If a stale
+// device re-stamps an unchanged (e.g. still-incomplete) task with a fresh "now",
+// that fabricated timestamp beats a real completion made elsewhere and the task
+// RESURRECTS. So the change-detection must not fire on passive normalization
+// (default fields that load/merge add to in-memory state but that may be absent
+// from the stored copy it is compared against).
+
+// Fields that are defaulted into in-memory tasks (see loadData / applyEngineData)
+// but may be missing from the stored copy. Normalizing them on BOTH sides of the
+// comparison keeps a passive default-add from registering as a user edit.
+function normalizedForCompare(task) {
+  const { lastModified: _omit, ...rest } = task;
+  return JSON.stringify({
+    ...rest,
+    notes: rest.notes ?? '',
+    subtasks: rest.subtasks ?? [],
+  });
+}
+
+/**
+ * Return `currentTasks` with `lastModified` assigned:
+ *  - unchanged from its stored copy (ignoring default normalization) → keep the
+ *    stored `lastModified` (do NOT fabricate a newer one);
+ *  - new to storage but already carrying a `lastModified` (e.g. arrived via cloud
+ *    merge or an import) → keep it, so a passive re-import isn't treated as a
+ *    newer edit than real changes elsewhere;
+ *  - otherwise (genuinely new or changed) → stamp `now`.
+ *
+ * @param {object[]} currentTasks  in-memory task array
+ * @param {object[]} prevTasks     the stored copy to diff against
+ * @param {string}   now           ISO timestamp to stamp changed/new tasks with
+ */
+export function stampTimestamps(currentTasks, prevTasks, now) {
+  const prevMap = new Map((prevTasks || []).map((t) => [String(t.id), t]));
+  return currentTasks.map((t) => {
+    const prevTask = prevMap.get(String(t.id));
+    if (prevTask && prevTask.lastModified) {
+      if (normalizedForCompare(prevTask) === normalizedForCompare(t)) {
+        return { ...t, lastModified: prevTask.lastModified };
+      }
+    }
+    if (!prevTask && t.lastModified) return t;
+    return { ...t, lastModified: now };
+  });
+}

--- a/src/utils/stampTimestamps.js
+++ b/src/utils/stampTimestamps.js
@@ -12,16 +12,29 @@
 // (default fields that load/merge add to in-memory state but that may be absent
 // from the stored copy it is compared against).
 
-// Fields that are defaulted into in-memory tasks (see loadData / applyEngineData)
-// but may be missing from the stored copy. Normalizing them on BOTH sides of the
-// comparison keeps a passive default-add from registering as a user edit.
-function normalizedForCompare(task) {
+// Strip `lastModified` and default the fields that are normalized into in-memory
+// tasks (see loadData / applyEngineData) but may be missing from the stored copy,
+// so a passive default-add doesn't register as a user edit.
+function normalizeField(task) {
   const { lastModified: _omit, ...rest } = task;
-  return JSON.stringify({
-    ...rest,
-    notes: rest.notes ?? '',
-    subtasks: rest.subtasks ?? [],
-  });
+  return { ...rest, notes: rest.notes ?? '', subtasks: rest.subtasks ?? [] };
+}
+
+function normalizedForCompare(task) {
+  return JSON.stringify(normalizeField(task));
+}
+
+// Keys whose (normalized) values differ between the stored and in-memory copy.
+// Used only by the optional diagnostic below.
+function diffKeys(prev, curr) {
+  const p = normalizeField(prev);
+  const c = normalizeField(curr);
+  const keys = new Set([...Object.keys(p), ...Object.keys(c)]);
+  const changed = [];
+  for (const k of keys) {
+    if (JSON.stringify(p[k]) !== JSON.stringify(c[k])) changed.push(k);
+  }
+  return changed;
 }
 
 /**
@@ -36,14 +49,23 @@ function normalizedForCompare(task) {
  * @param {object[]} currentTasks  in-memory task array
  * @param {object[]} prevTasks     the stored copy to diff against
  * @param {string}   now           ISO timestamp to stamp changed/new tasks with
+ * @param {(info: {id: any, changedKeys: string[]}) => void} [onRestamp]
+ *   Optional diagnostic, called when an EXISTING task (one that had a stored
+ *   `lastModified`) is re-stamped because its content differs. `changedKeys` is
+ *   the list of fields that actually differ — a real edit reports meaningful
+ *   fields; a phantom re-stamp (the resurrection bug) reports an unexpected or
+ *   default-only field. Off in production; wired behind a debug flag by the hook.
  */
-export function stampTimestamps(currentTasks, prevTasks, now) {
+export function stampTimestamps(currentTasks, prevTasks, now, onRestamp) {
   const prevMap = new Map((prevTasks || []).map((t) => [String(t.id), t]));
   return currentTasks.map((t) => {
     const prevTask = prevMap.get(String(t.id));
     if (prevTask && prevTask.lastModified) {
       if (normalizedForCompare(prevTask) === normalizedForCompare(t)) {
         return { ...t, lastModified: prevTask.lastModified };
+      }
+      if (onRestamp) {
+        try { onRestamp({ id: t.id, changedKeys: diffKeys(prevTask, t) }); } catch { /* diagnostic must never throw */ }
       }
     }
     if (!prevTask && t.lastModified) return t;

--- a/src/utils/stampTimestamps.test.js
+++ b/src/utils/stampTimestamps.test.js
@@ -40,6 +40,28 @@ describe('stampTimestamps', () => {
     expect(out[0].lastModified).toBe(stored[0].lastModified); // NOT ISO(0)
   });
 
+  describe('onRestamp diagnostic', () => {
+    it('reports the changed fields when an existing task is re-stamped', () => {
+      const prev = [{ id: 1, title: 'A', completed: false, lastModified: ISO(100) }];
+      const curr = [{ id: 1, title: 'A', completed: true, lastModified: ISO(100) }];
+      const calls = [];
+      stampTimestamps(curr, prev, 'NOW', (info) => calls.push(info));
+      expect(calls).toEqual([{ id: 1, changedKeys: ['completed'] }]);
+    });
+
+    it('does NOT fire for unchanged tasks, default-only diffs, or new tasks', () => {
+      const calls = [];
+      const onRestamp = (info) => calls.push(info);
+      // unchanged
+      stampTimestamps([{ id: 1, title: 'A', lastModified: ISO(100) }], [{ id: 1, title: 'A', lastModified: ISO(100) }], 'NOW', onRestamp);
+      // default-only diff (the resurrection vector — must stay silent)
+      stampTimestamps([{ id: 2, title: 'B', notes: '', subtasks: [], lastModified: ISO(100) }], [{ id: 2, title: 'B', lastModified: ISO(100) }], 'NOW', onRestamp);
+      // new task
+      stampTimestamps([{ id: 3, title: 'C' }], [], 'NOW', onRestamp);
+      expect(calls).toEqual([]);
+    });
+  });
+
   it('a completion made elsewhere survives a stale device sync (end-to-end)', () => {
     // Device B (online) completed the task 30 min ago, bumping its lastModified.
     const remoteCompleted = [{ id: 1, title: 'Pay rent', completed: true, completedAt: '2026-06-26', lastModified: ISO(30) }];

--- a/src/utils/stampTimestamps.test.js
+++ b/src/utils/stampTimestamps.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { stampTimestamps } from './stampTimestamps.js';
+import { mergeTaskArrays } from '../mergeSync.js';
+
+const ISO = (minutesAgo) => new Date(Date.now() - minutesAgo * 60000).toISOString();
+
+describe('stampTimestamps', () => {
+  it('stamps a genuinely new task (no prior, no lastModified)', () => {
+    const out = stampTimestamps([{ id: 1, title: 'New' }], [], 'NOW');
+    expect(out[0].lastModified).toBe('NOW');
+  });
+
+  it('preserves lastModified for an unchanged task', () => {
+    const prev = [{ id: 1, title: 'A', completed: false, lastModified: ISO(100) }];
+    const curr = [{ id: 1, title: 'A', completed: false, lastModified: ISO(100) }];
+    expect(stampTimestamps(curr, prev, 'NOW')[0].lastModified).toBe(prev[0].lastModified);
+  });
+
+  it('stamps a genuinely changed task (user edited the title)', () => {
+    const prev = [{ id: 1, title: 'A', lastModified: ISO(100) }];
+    const curr = [{ id: 1, title: 'A edited', lastModified: ISO(100) }];
+    expect(stampTimestamps(curr, prev, 'NOW')[0].lastModified).toBe('NOW');
+  });
+
+  it('preserves an incoming lastModified for a task new to storage (no re-stamp)', () => {
+    const curr = [{ id: 1, title: 'FromCloud', lastModified: ISO(50) }];
+    expect(stampTimestamps(curr, [], 'NOW')[0].lastModified).toBe(curr[0].lastModified);
+  });
+
+  // ── Regression: the iCloud zombie-resurrection root cause ──────────────────
+  // A stale device holds a still-incomplete task. The stored copy lacks default
+  // fields (notes/subtasks) that load/merge default into in-memory state. The
+  // ONLY difference is that passive normalization — the user did not touch the
+  // task. The stamper must NOT bump lastModified, otherwise the fabricated "now"
+  // beats a real completion made on another device and the task resurrects.
+  it('does NOT re-stamp when the only diff is passive default normalization', () => {
+    const stored = [{ id: 1, title: 'Pay rent', completed: false, lastModified: ISO(100) }];
+    const inMemory = [{ id: 1, title: 'Pay rent', completed: false, notes: '', subtasks: [], lastModified: ISO(100) }];
+    const out = stampTimestamps(inMemory, stored, ISO(0));
+    expect(out[0].lastModified).toBe(stored[0].lastModified); // NOT ISO(0)
+  });
+
+  it('a completion made elsewhere survives a stale device sync (end-to-end)', () => {
+    // Device B (online) completed the task 30 min ago, bumping its lastModified.
+    const remoteCompleted = [{ id: 1, title: 'Pay rent', completed: true, completedAt: '2026-06-26', lastModified: ISO(30) }];
+
+    // Stale device A: stored copy is old/incomplete; in-memory copy is the same
+    // task with default fields normalized in (no real user edit).
+    const storedStale = [{ id: 1, title: 'Pay rent', completed: false, lastModified: ISO(100) }];
+    const inMemoryStale = [{ id: 1, title: 'Pay rent', completed: false, notes: '', subtasks: [], lastModified: ISO(100) }];
+
+    // Device A builds its sync payload (stamps), then merges the remote in.
+    const stampedLocal = stampTimestamps(inMemoryStale, storedStale, ISO(0));
+    const { merged } = mergeTaskArrays(stampedLocal, remoteCompleted, {});
+
+    // The completion must win — the stale incomplete copy must not resurrect it.
+    expect(merged).toHaveLength(1);
+    expect(merged[0].completed).toBe(true);
+  });
+});


### PR DESCRIPTION
## The bug

A device that syncs via **iCloud** (in addition to GLANCEvault) brought back already-completed tasks after being off for a while. GLANCEvault-only devices were unaffected.

## Root cause

The file-tier sync (iCloud/WebDAV) resolves each task by **last-write-wins on `lastModified`**, and that timestamp is re-derived at save time by `stampTaskTimestamps`, which diffs in-memory state against the stored copy and stamps `now` if they differ.

That diff was a **raw whole-object compare**. Default fields that `loadData` / `applyEngineData` normalize *into memory* (e.g. `notes: ''`, `subtasks: []`) but that are absent from the stored copy registered as a "change" — so an **unchanged** task got re-stamped with a fresh `now`. On a device that had been off, that fabricated timestamp **beats a real completion made elsewhere**, the still-incomplete copy wins the merge, and the task **resurrects**. The device then pushes that back out, which is how it spread.

**Why GLANCEvault was fine:** it dirty-tracks individual changed rows rather than re-stamping and rebroadcasting the whole dataset, so a stale device never fabricates "newest" timestamps for tasks it didn't touch.

## The fix

- Extracted the stamping logic into a pure, unit-testable function, `src/utils/stampTimestamps.js`; `useDataPersistence` now delegates to it (behavior-preserving refactor).
- The change-comparison now **normalizes the default-bearing fields (`notes`/`subtasks`) on both sides**, so a passive default-add no longer counts as a user edit. An untouched task keeps its stored `lastModified` and can't out-compete a real completion. (Clearing a real note/subtask still differs and still stamps, so genuine edits propagate.)

## Tests (test-first)

`src/utils/stampTimestamps.test.js` — 6 tests, including:
- `does NOT re-stamp when the only diff is passive default normalization`
- an **end-to-end** case: a completion made on another device survives a stale device's stamp+merge.

Both regression tests **fail without the fix** and pass with it (verified by temporarily reverting the normalization). Full suite: **401 passed**; lint and build clean.

## Note

The exact default field that tripped this on the affected device is environment-specific (likely a value defaulted in via a remote `applyEngineData` merge). Hardening the comparison fixes the whole class rather than one field. If a different default field is implicated on your data, the pure function + harness make it a one-line extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_