### PR TITLE
Fix routines showing as completed when added (rollover tombstones)

### DIFF
--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -77,12 +77,30 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
       setRoutinesDate(todayStr);
       setRemovedTodayRoutineIds({});
       setRoutineCompletions({});
-      setRoutineCompletionTimestamps({});
+      // Don't just drop the completion timestamps — a bare clear leaves no
+      // signal, so any device/vault snapshot still holding yesterday's
+      // completion (with yesterday's timestamp) wins the LWW merge and
+      // resurrects it, making a freshly-added routine show up completed today
+      // (same zombie-resurrection class as the recycle-bin delete fix).
+      // Instead, stamp a fresh tombstone (completion absent, timestamp = now)
+      // for every id that carried a completion or an old timestamp, so the
+      // cleared state out-dates the stale remote completion and heals it.
+      const nowIso = new Date().toISOString();
+      const tombstones = {};
+      for (const id of new Set([
+        ...Object.keys(routineCompletions),
+        ...Object.keys(routineCompletionTimestamps),
+      ])) {
+        tombstones[id] = nowIso;
+      }
+      setRoutineCompletionTimestamps(tombstones);
       localStorage.removeItem('day-planner-removed-today-routine-ids');
-      localStorage.removeItem('day-planner-routine-completions');
-      localStorage.removeItem('day-planner-routine-completion-timestamps');
+      localStorage.setItem('day-planner-routine-completions', '{}');
+      localStorage.setItem('day-planner-routine-completion-timestamps', JSON.stringify(tombstones));
     }
-  }, [currentTime, routinesDate]);
+    // routineCompletions/routineCompletionTimestamps are read only to build the
+    // rollover tombstones; the guard above no-ops every other (toggle-driven) run.
+  }, [currentTime, routinesDate, routineCompletions, routineCompletionTimestamps]);
 
   const toggleRoutineCompletion = (routineId) => {
     const todayStr = dateToString(new Date());

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mergeTaskArrays, mergeRoutineDefinitions, mergeDailyNotes, mergeHabits, mergeHabitLogs, mergeSyncData, mergeCalendarConfigByUser } from './mergeSync.js';
+import { mergeTaskArrays, mergeRoutineDefinitions, mergeDailyNotes, mergeHabits, mergeHabitLogs, mergeRoutineCompletions, mergeSyncData, mergeCalendarConfigByUser } from './mergeSync.js';
 
 // Helpers to create task fixtures with timestamps
 const T = (id, title, lastModified, extra = {}) => ({
@@ -1521,6 +1521,40 @@ describe('mergeHabitLogs', () => {
     const onMac = mergeHabitLogs(mac, ipad, macTs, ipadTs);
     expect(onMac.merged['2026-02-20'].h1).toBe(4);  // Mac keeps it; both now agree
     expect(onMac.localChanged).toBe(false);
+  });
+});
+
+// ─── mergeRoutineCompletions ──────────────────────────────────────────
+
+describe('mergeRoutineCompletions', () => {
+  const Y0 = '2026-06-25T10:00:00.000Z'; // yesterday's completion
+  const N0 = '2026-06-26T06:00:00.000Z'; // this-morning rollover
+
+  it('a fresh rollover tombstone beats a stale remote completion (completed-on-add bug)', () => {
+    // Local rolled over: completion cleared, but a fresh tombstone timestamp was
+    // stamped for the id. Remote still holds yesterday's completion. The newer
+    // local timestamp must win so the completion is NOT resurrected — otherwise a
+    // routine re-added this morning renders already-completed.
+    const { merged, remoteChanged } = mergeRoutineCompletions(
+      {},                 // local: cleared
+      { 5001: '2026-06-25' }, // remote: still completed yesterday
+      { 5001: N0 },       // local tombstone stamped at rollover
+      { 5001: Y0 },       // remote's stale completion timestamp
+    );
+    expect(merged['5001']).toBeUndefined();
+    expect(remoteChanged).toBe(true); // remote heals (drops the completion)
+  });
+
+  it('a bare clear (no tombstone, timestamp dropped) IS resurrected — proves the tombstone matters', () => {
+    // Counter-case: without a fresh local timestamp, remote's completion is
+    // strictly newer and wins, resurrecting it. This is the pre-fix behavior.
+    const { merged } = mergeRoutineCompletions(
+      {},                 // local: cleared, but...
+      { 5001: '2026-06-25' },
+      {},                 // ...no local timestamp (the old bare clear)
+      { 5001: Y0 },
+    );
+    expect(merged['5001']).toBe('2026-06-25'); // resurrected
   });
 });
 

--- a/src/sync/dbMerge.test.js
+++ b/src/sync/dbMerge.test.js
@@ -153,6 +153,46 @@ describe('A1 bundle merge — concurrent different-entry edits are not lost', ()
     }
   });
 
+  it('routineCompletions: a day-rollover clear is not resurrected by a stale remote completion (completed-on-add bug)', () => {
+    // Both devices hold yesterday's completion of routine 5001. Device A rolls
+    // over to the new day: it clears the completion but stamps a FRESH tombstone
+    // timestamp (T2) for that id instead of just dropping the timestamp. Device B
+    // hasn't rolled over yet and still carries the stale completion (T0). After
+    // sync, the completion must NOT come back — otherwise a routine re-added on
+    // the new day shows up already completed (driven by routineCompletions[id]).
+    const base = {
+      ...EMPTY_COLLECTIONS, routinesDate: '2026-06-18',
+      routineCompletions: { 5001: '2026-06-18' },
+      routineCompletionTimestamps: { 5001: T0 },
+    };
+    const { vault, a, b } = newPair(base);
+    // Rollover on A: completion cleared, tombstone timestamp stamped fresh.
+    a.mutate((d) => { delete d.routineCompletions['5001']; d.routineCompletionTimestamps['5001'] = T2; return ['singleton:routineCompletions']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      expect(dev.data.routineCompletions['5001']).toBeUndefined();
+    }
+  });
+
+  it('routineCompletions: a bare clear (no tombstone) WOULD be resurrected — proves the tombstone is load-bearing', () => {
+    // Counter-case to the test above: if the rollover had merely dropped the
+    // timestamp (leaving T0) instead of stamping a fresh one, the remote's
+    // equal-timestamp completion wins by the "present-wins" tie-break and the
+    // completion is resurrected. This documents why the fix stamps the tombstone.
+    const base = {
+      ...EMPTY_COLLECTIONS, routinesDate: '2026-06-18',
+      routineCompletions: { 5001: '2026-06-18' },
+      routineCompletionTimestamps: { 5001: T0 },
+    };
+    const { vault, a, b } = newPair(base);
+    // Bare clear: completion removed but timestamp left untouched (the old bug).
+    a.mutate((d) => { delete d.routineCompletions['5001']; return ['singleton:routineCompletions']; });
+    syncToConvergence(a, b, vault);
+    for (const dev of [a, b]) {
+      expect(dev.data.routineCompletions['5001']).toBe('2026-06-18'); // resurrected
+    }
+  });
+
   it('recurringTasks: a completion is not clobbered by a concurrent series edit (the cross-device bug)', () => {
     const base = {
       ...EMPTY_COLLECTIONS,


### PR DESCRIPTION
## Problem

When routines are added to the timeline in the morning, they show up as **already completed** — the user has to un-complete them. Unlike the earlier flip-flop bug, they don't bounce back and forth; they sit stably-but-wrongly completed until manually un-completed.

## Root cause

Routine completion is rendered entirely from `routineCompletions[id]`, keyed by the routine chip's **stable** id. The completion was being **resurrected from a previous day** via sync.

The day-rollover handler in `useRoutines.js` wiped `routineCompletionTimestamps` to `{}` alongside the completions. The flip-flop fix (5036c5c) resolves completions by per-id last-writer-wins timestamps — but a bare clear leaves **no** local timestamp. Any device or vault snapshot still holding yesterday's completion carries yesterday's timestamp, which is strictly newer than the local "nothing" (time 0), so `mergeRoutineCompletions` resurrects it. `routinesDate` merges independently (max-date wins) and converges to today, so the `App.jsx` `routinesDate === today` apply-guard passes and the resurrected completion is applied.

It no longer flip-flops because the merge now converges deterministically — it stays wrongly-completed until the user un-completes, which stamps a fresh timestamp that finally wins (exactly the workaround the user found).

## Fix

Same lesson as the recycle-bin delete fix (3864af6): **a clear must leave a fresh tombstone, not an absence.** On rollover, stamp a fresh tombstone (completion absent, timestamp = now) for every id that carried a completion or an old timestamp, instead of dropping the timestamp map. The cleared state then out-dates any stale remote completion and heals it on both sync tiers.

The two completion maps are added to the effect deps to keep `exhaustive-deps` clean; the rollover guard no-ops every toggle-driven re-run.

## Tests

- `dbMerge.test.js` (vault tier) and `mergeSync.test.js` (file tier): "fresh rollover tombstone beats stale remote completion", each paired with a counter-case proving the tombstone is load-bearing (a bare clear resurrects).

## Verification

- ESLint: 70 warnings, 0 errors (at the CI ceiling, not over it)
- Full suite: 399 passed
- Production build: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzEgW1hRJa1fxyqTaBfcJZ)_