### PR TITLE
Fix Goals & Projects dashboard drag-and-drop on iOS

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -951,6 +951,52 @@ const DesktopDashboard = ({
     setDropInsertBeforeId(null);
   }, []);
 
+  // ── Touch drag (iOS/iPad) ──────────────────────────────────────────────────
+  // iOS WebKit never fires the HTML5 drag events above for touch, so on iPad
+  // (the desktop layout runs there: isMobile is false at >=721px wide) project
+  // cards could not be dragged at all. Mirror the proven touch pattern used by
+  // MobileDashboard / ProjectCard: track the drag in a ref and resolve the drop
+  // target under the finger via elementFromPoint. Drop targets carry the move
+  // semantics in data-* attributes (data-move-goal: '' = standalone; optional
+  // data-move-before: a project id to insert before), so one handler covers the
+  // reassign pills, the per-group containers, and the within-group card slots.
+  const touchDragRef = useRef({ active: false, projId: null, goalId: undefined, beforeId: null });
+
+  const startDragTouch = useCallback((projId) => (e) => {
+    e.preventDefault(); // grip is touch-none; block scroll/text-selection
+    touchDragRef.current = { active: true, projId, goalId: undefined, beforeId: null };
+    setDragProjectId(projId);
+  }, []);
+
+  const moveDragTouch = useCallback((e) => {
+    const st = touchDragRef.current;
+    if (!st.active) return;
+    e.preventDefault();
+    const touch = e.touches[0];
+    if (!touch) return;
+    const el = document.elementFromPoint(touch.clientX, touch.clientY);
+    const target = el?.closest('[data-move-goal]');
+    if (!target) return;
+    const goalAttr = target.getAttribute('data-move-goal'); // '' = standalone
+    const beforeAttr = target.getAttribute('data-move-before');
+    const goalId = goalAttr === '' ? null : goalAttr;
+    const beforeId = beforeAttr && beforeAttr !== st.projId ? beforeAttr : null;
+    st.goalId = goalId;
+    st.beforeId = beforeId;
+    // Drive the same visual affordances as the mouse path.
+    setDropInsertBeforeId(beforeId);
+    setDropZoneTarget(beforeId ? undefined : goalId);
+  }, []);
+
+  const endDragTouch = useCallback(() => {
+    const st = touchDragRef.current;
+    touchDragRef.current = { active: false, projId: null, goalId: undefined, beforeId: null };
+    if (st.active && st.projId && st.goalId !== undefined) {
+      moveProject(st.projId, st.goalId, st.beforeId || null);
+    }
+    endDrag();
+  }, [moveProject, endDrag]);
+
   // Sort goals: completed/overdue → left, active/upcoming → right (default focus)
   const sortedGoals = useMemo(() => sortGoalsForCarousel(activeGoals), [activeGoals]);
   const [activeGoalIdx, setActiveGoalIdx] = useState(
@@ -1167,6 +1213,7 @@ const DesktopDashboard = ({
                   return (
                     <div
                       key={g.id}
+                      data-move-goal={g.id}
                       onDragOver={e => { e.preventDefault(); setDropZoneTarget(g.id); }}
                       onDragLeave={() => setDropZoneTarget(undefined)}
                       onDrop={e => { e.preventDefault(); moveProject(dragProjectId, g.id); endDrag(); }}
@@ -1183,6 +1230,7 @@ const DesktopDashboard = ({
                   );
                 })}
                 <div
+                  data-move-goal=""
                   onDragOver={e => { e.preventDefault(); setDropZoneTarget(null); }}
                   onDragLeave={() => setDropZoneTarget(undefined)}
                   onDrop={e => { e.preventDefault(); moveProject(dragProjectId, null); endDrag(); }}
@@ -1208,11 +1256,16 @@ const DesktopDashboard = ({
               draggable: true,
               onDragStart: (e) => startDrag(e, proj.id),
               onDragEnd: endDrag,
+              onTouchStart: startDragTouch(proj.id),
+              onTouchMove: moveDragTouch,
+              onTouchEnd: endDragTouch,
             });
             const wrapCard = (proj, cardJsx) => (
               <div
                 key={proj.id}
                 data-proj-id={proj.id}
+                data-move-goal={activeGoal.id}
+                data-move-before={proj.id}
                 className={`relative w-[260px] transition-opacity ${dragProjectId === proj.id ? 'opacity-40' : ''} ${
                   dropInsertBeforeId === proj.id && dragProjectId && dragProjectId !== proj.id
                     ? 'ring-2 ring-blue-500 rounded-xl' : ''
@@ -1239,6 +1292,7 @@ const DesktopDashboard = ({
             return (
               <div
                 className="relative z-10 mb-8"
+                data-move-goal={activeGoal.id}
                 onDragOver={e => { e.preventDefault(); }}
                 onDrop={e => {
                   e.preventDefault();
@@ -1283,6 +1337,7 @@ const DesktopDashboard = ({
       {/* Standalone projects */}
       {(standaloneProjects.length > 0 || dragProjectId) && (
         <div
+          data-move-goal=""
           className={`relative z-10 pt-6 border-t ${borderClass} ${
             dragProjectId && dropZoneTarget === null
               ? darkMode ? 'bg-emerald-900/20 rounded-xl' : 'bg-emerald-50 rounded-xl'
@@ -1315,11 +1370,16 @@ const DesktopDashboard = ({
               draggable: true,
               onDragStart: (e) => startDrag(e, proj.id),
               onDragEnd: endDrag,
+              onTouchStart: startDragTouch(proj.id),
+              onTouchMove: moveDragTouch,
+              onTouchEnd: endDragTouch,
             });
             const wrapCard = (proj, cardJsx) => (
               <div
                 key={proj.id}
                 data-proj-id={proj.id}
+                data-move-goal=""
+                data-move-before={proj.id}
                 className={`relative w-[260px] transition-opacity ${dragProjectId === proj.id ? 'opacity-40' : ''} ${
                   dropInsertBeforeId === proj.id && dragProjectId && dragProjectId !== proj.id
                     ? 'ring-2 ring-blue-500 rounded-xl' : ''

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -954,41 +954,20 @@ const DesktopDashboard = ({
   // ── Touch drag (iOS/iPad) ──────────────────────────────────────────────────
   // iOS WebKit never fires the HTML5 drag events above for touch, so on iPad
   // (the desktop layout runs there: isMobile is false at >=721px wide) project
-  // cards could not be dragged at all. Mirror the proven touch pattern used by
-  // MobileDashboard / ProjectCard: track the drag in a ref and resolve the drop
-  // target under the finger via elementFromPoint. Drop targets carry the move
-  // semantics in data-* attributes (data-move-goal: '' = standalone; optional
-  // data-move-before: a project id to insert before), so one handler covers the
-  // reassign pills, the per-group containers, and the within-group card slots.
+  // cards could not be dragged at all. Mirror the app's proven touch-DnD pattern
+  // (useDragDrop): track the drag in a ref and resolve the drop target under the
+  // finger via elementFromPoint. Two iOS-specific gotchas force document-level
+  // listeners rather than React's onTouch* props: React's synthetic touchmove is
+  // passive (so e.preventDefault() is ignored), and the grip's draggable={true}
+  // would otherwise start a native iOS drag that hijacks the gesture — so we add
+  // touchmove with { passive: false } and cancel dragstart for the drag's life.
+  // Drop targets carry the move semantics in data-* attributes (data-move-goal:
+  // '' = standalone; optional data-move-before: a project id to insert before),
+  // so one handler covers the reassign pills, the per-group containers, and the
+  // within-group card slots.
   const touchDragRef = useRef({ active: false, projId: null, goalId: undefined, beforeId: null });
 
-  const startDragTouch = useCallback((projId) => (e) => {
-    e.preventDefault(); // grip is touch-none; block scroll/text-selection
-    touchDragRef.current = { active: true, projId, goalId: undefined, beforeId: null };
-    setDragProjectId(projId);
-  }, []);
-
-  const moveDragTouch = useCallback((e) => {
-    const st = touchDragRef.current;
-    if (!st.active) return;
-    e.preventDefault();
-    const touch = e.touches[0];
-    if (!touch) return;
-    const el = document.elementFromPoint(touch.clientX, touch.clientY);
-    const target = el?.closest('[data-move-goal]');
-    if (!target) return;
-    const goalAttr = target.getAttribute('data-move-goal'); // '' = standalone
-    const beforeAttr = target.getAttribute('data-move-before');
-    const goalId = goalAttr === '' ? null : goalAttr;
-    const beforeId = beforeAttr && beforeAttr !== st.projId ? beforeAttr : null;
-    st.goalId = goalId;
-    st.beforeId = beforeId;
-    // Drive the same visual affordances as the mouse path.
-    setDropInsertBeforeId(beforeId);
-    setDropZoneTarget(beforeId ? undefined : goalId);
-  }, []);
-
-  const endDragTouch = useCallback(() => {
+  const finishDragTouch = useCallback(() => {
     const st = touchDragRef.current;
     touchDragRef.current = { active: false, projId: null, goalId: undefined, beforeId: null };
     if (st.active && st.projId && st.goalId !== undefined) {
@@ -996,6 +975,44 @@ const DesktopDashboard = ({
     }
     endDrag();
   }, [moveProject, endDrag]);
+
+  const startDragTouch = useCallback((projId) => () => {
+    touchDragRef.current = { active: true, projId, goalId: undefined, beforeId: null };
+    setDragProjectId(projId);
+
+    const onMove = (moveEvent) => {
+      const st = touchDragRef.current;
+      if (!st.active) return;
+      moveEvent.preventDefault(); // honoured: this listener is non-passive
+      const touch = moveEvent.touches[0];
+      if (!touch) return;
+      const el = document.elementFromPoint(touch.clientX, touch.clientY);
+      const target = el?.closest('[data-move-goal]');
+      if (!target) return;
+      const goalAttr = target.getAttribute('data-move-goal'); // '' = standalone
+      const beforeAttr = target.getAttribute('data-move-before');
+      const goalId = goalAttr === '' ? null : goalAttr;
+      const beforeId = beforeAttr && beforeAttr !== st.projId ? beforeAttr : null;
+      st.goalId = goalId;
+      st.beforeId = beforeId;
+      // Drive the same visual affordances as the mouse path.
+      setDropInsertBeforeId(beforeId);
+      setDropZoneTarget(beforeId ? undefined : goalId);
+    };
+    // Block the grip's draggable from starting a native iOS drag mid-gesture.
+    const preventDrag = (de) => de.preventDefault();
+    const onEnd = () => {
+      document.removeEventListener('touchmove', onMove);
+      document.removeEventListener('touchend', onEnd);
+      document.removeEventListener('touchcancel', onEnd);
+      document.removeEventListener('dragstart', preventDrag);
+      finishDragTouch();
+    };
+    document.addEventListener('touchmove', onMove, { passive: false });
+    document.addEventListener('touchend', onEnd);
+    document.addEventListener('touchcancel', onEnd);
+    document.addEventListener('dragstart', preventDrag);
+  }, [finishDragTouch]);
 
   // Sort goals: completed/overdue → left, active/upcoming → right (default focus)
   const sortedGoals = useMemo(() => sortGoalsForCarousel(activeGoals), [activeGoals]);
@@ -1257,8 +1274,6 @@ const DesktopDashboard = ({
               onDragStart: (e) => startDrag(e, proj.id),
               onDragEnd: endDrag,
               onTouchStart: startDragTouch(proj.id),
-              onTouchMove: moveDragTouch,
-              onTouchEnd: endDragTouch,
             });
             const wrapCard = (proj, cardJsx) => (
               <div
@@ -1371,8 +1386,6 @@ const DesktopDashboard = ({
               onDragStart: (e) => startDrag(e, proj.id),
               onDragEnd: endDrag,
               onTouchStart: startDragTouch(proj.id),
-              onTouchMove: moveDragTouch,
-              onTouchEnd: endDragTouch,
             });
             const wrapCard = (proj, cardJsx) => (
               <div

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -146,28 +146,15 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
     setDragOverIdx(null);
   };
 
-  // ── Touch drag-to-reorder (mobile) ─────────────────────────────────────────
-  const handleGripTouchStart = (e, idx) => {
-    touchDragRef.current = { active: true, fromIdx: idx, overIdx: null };
-    setDragIdx(idx);
-  };
-
-  const handleGripTouchMove = (e) => {
-    if (!touchDragRef.current.active) return;
-    e.preventDefault();
-    const touch = e.touches[0];
-    const el = document.elementFromPoint(touch.clientX, touch.clientY);
-    const taskEl = el?.closest('[data-drag-idx]');
-    if (taskEl) {
-      const overIdx = parseInt(taskEl.getAttribute('data-drag-idx'), 10);
-      if (!isNaN(overIdx)) {
-        touchDragRef.current.overIdx = overIdx;
-        setDragOverIdx(overIdx);
-      }
-    }
-  };
-
-  const handleGripTouchEnd = () => {
+  // ── Touch drag-to-reorder (mobile/iOS) ──────────────────────────────────────
+  // iOS WebKit broke this in two ways that Android/desktop don't hit: React's
+  // synthetic onTouchMove is passive, so e.preventDefault() is ignored, and the
+  // parent row's draggable={true} makes a long-press start a native HTML5 drag
+  // that hijacks the gesture. So the grip's touch reorder never landed on iOS.
+  // Mirror the app's proven touch-DnD pattern (useDragDrop): set up the listeners
+  // at the document level with { passive: false } so preventDefault works, and
+  // cancel dragstart for the duration of the drag so the native drag can't fire.
+  const finishGripTouch = () => {
     if (!touchDragRef.current.active) return;
     const { fromIdx, overIdx } = touchDragRef.current;
     touchDragRef.current = { active: false, fromIdx: null, overIdx: null };
@@ -186,6 +173,40 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
     }
     setDragIdx(null);
     setDragOverIdx(null);
+  };
+
+  const handleGripTouchStart = (e, idx) => {
+    touchDragRef.current = { active: true, fromIdx: idx, overIdx: null };
+    setDragIdx(idx);
+
+    const onMove = (moveEvent) => {
+      if (!touchDragRef.current.active) return;
+      moveEvent.preventDefault(); // honoured: this listener is non-passive
+      const touch = moveEvent.touches[0];
+      if (!touch) return;
+      const el = document.elementFromPoint(touch.clientX, touch.clientY);
+      const taskEl = el?.closest('[data-drag-idx]');
+      if (taskEl) {
+        const overIdx = parseInt(taskEl.getAttribute('data-drag-idx'), 10);
+        if (!isNaN(overIdx)) {
+          touchDragRef.current.overIdx = overIdx;
+          setDragOverIdx(overIdx);
+        }
+      }
+    };
+    // Block the parent draggable row from starting a native iOS drag mid-gesture.
+    const preventDrag = (de) => de.preventDefault();
+    const onEnd = () => {
+      document.removeEventListener('touchmove', onMove);
+      document.removeEventListener('touchend', onEnd);
+      document.removeEventListener('touchcancel', onEnd);
+      document.removeEventListener('dragstart', preventDrag);
+      finishGripTouch();
+    };
+    document.addEventListener('touchmove', onMove, { passive: false });
+    document.addEventListener('touchend', onEnd);
+    document.addEventListener('touchcancel', onEnd);
+    document.addEventListener('dragstart', preventDrag);
   };
 
   // ── Quick-add ──────────────────────────────────────────────────────────────
@@ -511,8 +532,6 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
                     <div
                       className={`flex-shrink-0 p-1 cursor-grab touch-none ${textSecondary} opacity-30`}
                       onTouchStart={e => handleGripTouchStart(e, incompleteUnscheduledIdx)}
-                      onTouchMove={handleGripTouchMove}
-                      onTouchEnd={handleGripTouchEnd}
                       aria-label="Drag to reorder"
                     >
                       <GripVertical size={12} />


### PR DESCRIPTION
## Problem

In the Goals & Projects dashboard, drag-and-drop did not work on iOS (worked on web/Android/desktop). The user-visible breakage was **reordering tasks inside a project card**; dragging **project cards** (reorder + reassign to a goal) was broken the same way.

## Root cause

Two iOS-WebKit-specific traps that other platforms don't hit:

1. **React's synthetic `onTouchMove` is passive** → the `e.preventDefault()` inside the touch handler is silently ignored, so the drag can't take over the gesture.
2. The drag origin sits inside a **`draggable={true}`** element → on iOS a long-press starts a *native* HTML5 drag that hijacks the touch sequence, so the JS reorder never completes.

Project-card dragging additionally relied entirely on the HTML5 drag API (`onDragStart`/`onDragOver`/`onDrop`), which iOS WebKit never fires for touch. On iPad the dashboard renders the desktop layout (`isMobile` is false at ≥721px), so this path was reached.

## Fix

Adopt the app's established iOS-safe touch-DnD pattern (see `useDragDrop`'s resize handlers): on `touchstart`, attach `touchmove`/`touchend`/`touchcancel` at the **document level with `{ passive: false }`** so `preventDefault` is honoured, and register a `dragstart` handler that **cancels the native drag** for the life of the gesture. Listeners are torn down on touchend.

- **ProjectCard**: task-row grip reorder now uses document-level listeners.
- **GoalDashboard (DesktopDashboard)**: project-card grip reorder/reassign gets touch support via the same pattern. Drop targets carry their move semantics in `data-move-goal` (`''` = standalone) / `data-move-before` attributes, resolved under the finger with `elementFromPoint`, reusing the existing drag-visual state.

The HTML5 mouse path is untouched, and the `dragstart`-canceller only exists while a touch drag is in flight, so desktop/web/Android behaviour is unchanged.

## Verification

- ESLint: 70 warnings, 0 errors
- Full suite: 395 passed
- Production build: passes

⚠️ **Not yet verified on a physical iPad** — the reasoning is grounded in the existing iOS-safe pattern and the passive-listener / native-drag mechanics, but an on-device check before merge is advisable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzEgW1hRJa1fxyqTaBfcJZ)_