### PR TITLE
Fix iOS passphrase prompt on every launch (GLANCEvault DB root key)

### DIFF
--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -47,13 +47,23 @@ const CRYPTO_DB_NAME = 'dayglance-db-crypto';
 // path (non-native) is already isolated via the distinct CRYPTO_DB_NAME.
 const VAULT_KEY_SLOT = 'db';
 
-// Where the per-account DB root key is stored: the OS keystore on native shells
-// (mirrors the file tier in adapter.js), IndexedDB elsewhere. Centralized so the
-// engine and resetDbRootKey agree.
-function nativeKeyConfig() {
+// Where the per-account DB root key is stored: the Android OS keystore on the
+// Android shell (mirrors the file tier in crypto.js), IndexedDB everywhere else
+// (web AND iOS). Centralized so the engine and resetDbRootKey agree.
+//
+// iOS gotcha (the every-launch passphrase re-prompt): iOS exposes
+// window.DayGlanceNative as a Proxy whose every property reads truthy, so the
+// old `!!bridge?.httpRequest` native-app check returned true on iOS and routed
+// it through the bridge's (non-functional, proxy-faked) keystore methods. The
+// DB root key was therefore never actually persisted, so restoreDbRootKey()
+// returned false on every launch and the passphrase modal reappeared. Only
+// Android — which sets no DayGlanceIOS marker and exposes a REAL getSyncKey —
+// should use the native keystore; iOS uses IndexedDB (which persists across
+// launches), exactly as src/utils/crypto.js does for the file tier.
+export function nativeKeyConfig() {
   const bridge = typeof window !== 'undefined' ? window.DayGlanceNative : null;
-  const isNativeApp = !!bridge?.httpRequest;
-  if (!isNativeApp) {
+  const isAndroid = !!bridge && !window.DayGlanceIOS && !!bridge.getSyncKey;
+  if (!isAndroid) {
     return { cryptoDBName: CRYPTO_DB_NAME, nativeGetSyncKey: null, nativeStoreSyncKey: null };
   }
   // Prefer the isolated per-slot bridge methods; fall back to the shared legacy

--- a/src/sync/dbEngine.nativeKey.test.js
+++ b/src/sync/dbEngine.nativeKey.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { nativeKeyConfig } from './dbEngine.js';
+
+// Regression for the iOS-only "passphrase prompt on every launch" bug.
+//
+// The GLANCEvault DB root key must persist across launches so a vault-enabled
+// device unlocks silently. It lives in the Android OS keystore on the Android
+// shell and in IndexedDB everywhere else (web AND iOS). The bug: iOS exposes
+// window.DayGlanceNative as a Proxy whose every property reads truthy, so the
+// old `!!bridge.httpRequest` native-app check matched on iOS and routed the key
+// through the proxy's non-functional keystore methods — it was never persisted,
+// so the passphrase modal reappeared on every launch. Only Android (real
+// getSyncKey, no DayGlanceIOS marker) may use the native keystore.
+
+describe('nativeKeyConfig — native keystore only on Android, IndexedDB on iOS/web', () => {
+  const origWindow = Object.prototype.hasOwnProperty.call(global, 'window') ? global.window : undefined;
+  const hadWindow = Object.prototype.hasOwnProperty.call(global, 'window');
+  afterEach(() => {
+    if (hadWindow) global.window = origWindow;
+    else delete global.window;
+  });
+
+  it('web (no native bridge): uses IndexedDB, no native key methods', () => {
+    global.window = {};
+    const cfg = nativeKeyConfig();
+    expect(cfg.cryptoDBName).toBe('dayglance-db-crypto');
+    expect(cfg.nativeGetSyncKey).toBeNull();
+    expect(cfg.nativeStoreSyncKey).toBeNull();
+  });
+
+  it('iOS (all-truthy Proxy bridge + DayGlanceIOS marker): uses IndexedDB, NOT the proxy keystore', () => {
+    // iOS proxies every property lookup to a truthy function — exactly the trap
+    // the old `!!bridge.httpRequest` check fell into.
+    const proxy = new Proxy({}, { get: () => () => 'truthy' });
+    global.window = { DayGlanceNative: proxy, DayGlanceIOS: {} };
+    const cfg = nativeKeyConfig();
+    expect(cfg.cryptoDBName).toBe('dayglance-db-crypto');
+    expect(cfg.nativeGetSyncKey).toBeNull();
+    expect(cfg.nativeStoreSyncKey).toBeNull();
+  });
+
+  it('Android (real getSyncKey, no DayGlanceIOS): uses the native keystore', () => {
+    global.window = { DayGlanceNative: { getSyncKey: () => 'k', storeSyncKey: () => {} } };
+    const cfg = nativeKeyConfig();
+    expect(typeof cfg.nativeGetSyncKey).toBe('function');
+    expect(typeof cfg.nativeStoreSyncKey).toBe('function');
+  });
+
+  it('Android with per-slot methods: isolates the DB key under its own slot', () => {
+    const calls = [];
+    global.window = { DayGlanceNative: {
+      getSyncKey: () => 'legacy',
+      storeSyncKey: () => {},
+      getSyncKeyForSlot: (slot) => { calls.push(['get', slot]); return 'k'; },
+      storeSyncKeyForSlot: (slot, v) => { calls.push(['store', slot, v]); },
+    } };
+    const cfg = nativeKeyConfig();
+    cfg.nativeGetSyncKey();
+    cfg.nativeStoreSyncKey('val');
+    expect(calls).toEqual([['get', 'db'], ['store', 'db', 'val']]);
+  });
+});


### PR DESCRIPTION
## Problem

On iOS, a GLANCEvault-enabled device re-prompted for the sync passphrase at **every** startup. Web/Android/desktop did not.

## Root cause

`dbEngine.js` `nativeKeyConfig()` decides where the GLANCEvault DB root key is cached so `restoreDbRootKey()` can unlock silently on launch.

iOS exposes `window.DayGlanceNative` as a **Proxy whose every property reads truthy**. The old native-app check, `!!bridge?.httpRequest`, therefore matched on iOS and routed the key through the bridge's keystore methods — which on iOS are proxy-faked no-ops. The DB root key was never actually persisted, so `restoreDbRootKey()` returned `false` on every launch, `syncKeyReady` became `false`, and the passphrase modal reappeared (`App.jsx`: `isVaultEnabled() && syncKeyReady === false`).

`src/utils/crypto.js` already documents and avoids this exact iOS proxy trap for the file tier by excluding iOS (`!window.DayGlanceIOS`); `dbEngine.js` didn't.

## Fix

Apply the same detection: only **Android** — no `DayGlanceIOS` marker **and** a real `getSyncKey` — uses the native keystore. iOS and web both use the isolated **IndexedDB** store, which persists across launches (matching how the file-tier and intents keys already behave on iOS). After entering the passphrase once, the cached key is restored silently thereafter.

## Tests

`nativeKeyConfig` is now exported and covered by a new regression test (`dbEngine.nativeKey.test.js`): the native keystore is used only on Android, while an all-truthy iOS proxy bridge (and web) falls back to IndexedDB.

## Verification

- ESLint: 70 warnings, 0 errors
- Full suite: 399 passed (395 + 4 new)
- Production build: passes

⚠️ **Not yet verified on a physical iPad** — the fix follows the documented iOS proxy handling in `crypto.js`, but an on-device confirmation that the passphrase is remembered across launches is advisable before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzEgW1hRJa1fxyqTaBfcJZ)_