### PR TITLE
Stabilize two timing-flaky merge tests

### DIFF
--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -142,17 +142,22 @@ describe('mergeSyncData', () => {
 
   // ── The user's reported scenario ───────────────────────────────
   it('SCENARIO: tasks added on desktop survive when tablet syncs', () => {
+    // Task 1 exists on BOTH sides and must be byte-identical, so compute its
+    // timestamp ONCE. Calling ts(30) separately per side produced two values a
+    // millisecond apart on slow runners, making the tablet's copy look newer and
+    // flipping remoteChanged to true (flaky CI failure).
+    const standupTs = ts(30);
     const desktop = {
       ...emptyData(),
       tasks: [
-        T(1, 'Morning standup', ts(30)),
+        T(1, 'Morning standup', standupTs),
         T(2, 'New from desktop', ts(5)),
       ],
       unscheduledTasks: [T(10, 'Inbox from desktop', ts(4))],
     };
     const tablet = {
       ...emptyData(),
-      tasks: [T(1, 'Morning standup', ts(30))],
+      tasks: [T(1, 'Morning standup', standupTs)],
       unscheduledTasks: [],
     };
 
@@ -2019,7 +2024,10 @@ describe('mergeCalendarConfigByUser', () => {
 
   it('tolerates empty / missing sides', () => {
     expect(mergeCalendarConfigByUser(undefined, undefined)).toEqual({});
-    expect(mergeCalendarConfigByUser({ a: { updatedAt: ts(1) } }, undefined)).toEqual({ a: { updatedAt: ts(1) } });
+    // Compute the timestamp once: the input and the expected output must match
+    // exactly, and two ts(1) calls can differ by a millisecond on slow runners.
+    const cfg = { a: { updatedAt: ts(1) } };
+    expect(mergeCalendarConfigByUser(cfg, undefined)).toEqual(cfg);
   });
 });
 


### PR DESCRIPTION
## Problem

CI on #1061 went red on `mergeSync.test.js > "tasks added on desktop survive when tablet syncs"` — a failure **unrelated to that PR's change** (#1061 only touches `dbEngine.js` + a new test, both green). It's a pre-existing **timing flake** that lives on `main` and can hit any PR.

Two tests call the `ts()` helper (`new Date(Date.now() - n).toISOString()`) more than once to build values that must be byte-identical, so on a slow runner the calls land in different milliseconds:

- **"tasks added on desktop survive when tablet syncs"**: task 1 exists on both the desktop and tablet inputs. Two separate `ts(30)` calls let the tablet's copy look 1ms newer, so the merge set `remoteChanged=true` and `expect(remoteChanged).toBe(false)` failed. (This is the failure that turned #1061 red.)
- **"tolerates empty / missing sides"**: the input and the expected output each built `{ a: { updatedAt: ts(1) } }` independently, so a 1ms skew broke the `toEqual`.

## Fix

Compute each shared timestamp once and reuse it. **No production code changes** — this only removes nondeterminism from the fixtures.

## Verification

- Ran `mergeSync.test.js` repeatedly (5×): 148 passed every time.
- ESLint: 70 warnings, 0 errors.

Merging this to `main` and updating the feature branches (or just re-running their CI) will clear the intermittent red on #1059 / #1060 / #1061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzEgW1hRJa1fxyqTaBfcJZ)_