### PR TITLE
Fix task reorder drag on iOS (make the grip the drag source)

### DIFF
--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -249,7 +249,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
           {/* Row 1: title + edit/delete */}
           <div className="flex items-center gap-1.5 px-3 pt-2.5 pb-1">
             {dragHandleProps && (
-              <div {...dragHandleProps} className={`flex-shrink-0 cursor-grab active:cursor-grabbing ${textSecondary} opacity-30 hover:opacity-60 transition-opacity touch-none select-none`} title="Drag to reorder">
+              <div {...dragHandleProps} data-drag-handle className={`flex-shrink-0 cursor-grab active:cursor-grabbing ${textSecondary} opacity-30 hover:opacity-60 transition-opacity touch-none select-none`} title="Drag to reorder">
                 <GripVertical size={12} />
               </div>
             )}
@@ -337,7 +337,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
         {/* Header: title + badges + edit + delete */}
         <div className="flex items-start gap-2">
           {dragHandleProps && (
-            <div {...dragHandleProps} className={`flex-shrink-0 mt-0.5 cursor-grab active:cursor-grabbing ${textSecondary} opacity-30 hover:opacity-60 transition-opacity touch-none select-none`} title="Drag to reorder">
+            <div {...dragHandleProps} data-drag-handle className={`flex-shrink-0 mt-0.5 cursor-grab active:cursor-grabbing ${textSecondary} opacity-30 hover:opacity-60 transition-opacity touch-none select-none`} title="Drag to reorder">
               <GripVertical size={14} />
             </div>
           )}
@@ -457,11 +457,8 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
                 <div
                   key={t.id}
                   data-drag-idx={draggable ? incompleteUnscheduledIdx : undefined}
-                  draggable={draggable}
-                  onDragStart={draggable ? e => handleDragStart(e, incompleteUnscheduledIdx) : undefined}
                   onDragOver={draggable ? e => handleDragOver(e, incompleteUnscheduledIdx) : undefined}
                   onDrop={draggable ? e => handleDrop(e, incompleteUnscheduledIdx) : undefined}
-                  onDragEnd={draggable ? handleDragEnd : undefined}
                   className={`flex items-center rounded-lg select-none transition-colors ${hoverBg} ${
                     draggable && dragIdx === incompleteUnscheduledIdx ? 'opacity-40' : ''
                   } ${
@@ -529,9 +526,19 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
                     </div>
                   )}
                   {draggable && (
+                    // Drag SOURCE lives on the grip (not the row): on iOS, touching a
+                    // non-draggable child inside a draggable row puts the gesture into a
+                    // native-drag limbo that starves our touch listeners. Mirroring the
+                    // project-card grip (which works) — grip is the draggable source, the
+                    // row is only the drop target — fixes touch reorder. data-drag-handle
+                    // + select-none apply the documented iOS selection/callout guards.
                     <div
-                      className={`flex-shrink-0 p-1 cursor-grab touch-none ${textSecondary} opacity-30`}
+                      data-drag-handle
+                      draggable
+                      onDragStart={e => handleDragStart(e, incompleteUnscheduledIdx)}
+                      onDragEnd={handleDragEnd}
                       onTouchStart={e => handleGripTouchStart(e, incompleteUnscheduledIdx)}
+                      className={`flex-shrink-0 p-1 cursor-grab active:cursor-grabbing touch-none select-none ${textSecondary} opacity-30`}
                       aria-label="Drag to reorder"
                     >
                       <GripVertical size={12} />


### PR DESCRIPTION
## Problem

After #1060, dragging **project cards** works on iOS but reordering **tasks inside a project card** still doesn't — even though both used the same touch-DnD handlers.

## Root cause

A structural asymmetry between the two grips:

- **Project grip** (works): the grip element *itself* is `draggable` (the drag **source**); drop targets are separate, non-draggable elements.
- **Task reorder** (broken): the whole **row** was `draggable` *and* the drop target, with the grip a non-draggable child carrying only `onTouchStart`.

On iOS WebKit, touching a *non-draggable child inside a draggable ancestor* puts the gesture into a "maybe native-drag the ancestor" limbo that starves the grip's touch listeners, so the JS reorder never starts. That's exactly why the project grip (grip *is* the draggable source, so our `dragstart`-cancel cleanly releases the gesture) works while the task row didn't.

The reporter also noticed text-selection/the long-press magnifier interfering on task rows — consistent with the same area.

## Fix

Mirror the working project pattern:

- Move the HTML5 drag source (`draggable` + `onDragStart` + `onDragEnd`) from the **row** onto the **grip**. The row keeps `onDragOver`/`onDrop` + `data-drag-idx`, so it stays the drop target.
- Add the documented iOS selection/callout guards to the grip: the **`data-drag-handle`** attribute (activates the existing `index.css` rule — `-webkit-user-select`/`-webkit-touch-callout: none` — which, it turns out, wasn't wired to any element) plus `select-none`, matching the project grips. This also addresses the observed long-press text-selection/magnifier interference.
- Add `data-drag-handle` to the two project grips too, for consistency and the same callout protection.

Desktop mouse reorder now initiates from the grip handle rather than anywhere on the row — the grip's intended purpose, and consistent with how project cards already behave.

## Verification

- ESLint: 70 warnings, 0 errors
- Full suite: 411 passed
- Production build: passes

⚠️ **Not yet verified on a physical iPad** — this targets the project/task structural asymmetry and the selection interference the reporter observed. If it still doesn't take, the fallback is disabling HTML5 `draggable` on touch devices entirely (relying solely on the grip's touch handlers); happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzEgW1hRJa1fxyqTaBfcJZ)_