### PR TITLE
Improve drag-grip touch ergonomics for tasks and projects

### DIFF
--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -247,9 +247,9 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
           style={goalHex ? { borderLeft: `3px solid ${goalHex}88` } : {}}
         >
           {/* Row 1: title + edit/delete */}
-          <div className="flex items-center gap-1.5 px-3 pt-2.5 pb-1">
+          <div className="flex items-center gap-1.5 px-3 pt-2.5 pb-1 dnd-no-select">
             {dragHandleProps && (
-              <div {...dragHandleProps} data-drag-handle className={`flex-shrink-0 cursor-grab active:cursor-grabbing ${textSecondary} opacity-30 hover:opacity-60 transition-opacity touch-none select-none`} title="Drag to reorder">
+              <div {...dragHandleProps} data-drag-handle className={`flex-shrink-0 p-1.5 -m-1 cursor-grab active:cursor-grabbing ${textSecondary} opacity-30 hover:opacity-60 transition-opacity touch-none select-none`} title="Drag to reorder">
                 <GripVertical size={12} />
               </div>
             )}
@@ -335,9 +335,9 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
       {/* Card body */}
       <div className="flex flex-col gap-2 p-3">
         {/* Header: title + badges + edit + delete */}
-        <div className="flex items-start gap-2">
+        <div className="flex items-start gap-2 dnd-no-select">
           {dragHandleProps && (
-            <div {...dragHandleProps} data-drag-handle className={`flex-shrink-0 mt-0.5 cursor-grab active:cursor-grabbing ${textSecondary} opacity-30 hover:opacity-60 transition-opacity touch-none select-none`} title="Drag to reorder">
+            <div {...dragHandleProps} data-drag-handle className={`flex-shrink-0 mt-0.5 p-1.5 -m-1 cursor-grab active:cursor-grabbing ${textSecondary} opacity-30 hover:opacity-60 transition-opacity touch-none select-none`} title="Drag to reorder">
               <GripVertical size={14} />
             </div>
           )}
@@ -459,7 +459,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
                   data-drag-idx={draggable ? incompleteUnscheduledIdx : undefined}
                   onDragOver={draggable ? e => handleDragOver(e, incompleteUnscheduledIdx) : undefined}
                   onDrop={draggable ? e => handleDrop(e, incompleteUnscheduledIdx) : undefined}
-                  className={`flex items-center rounded-lg select-none transition-colors ${hoverBg} ${
+                  className={`flex items-center rounded-lg select-none dnd-no-select transition-colors ${hoverBg} ${
                     draggable && dragIdx === incompleteUnscheduledIdx ? 'opacity-40' : ''
                   } ${
                     draggable && dragOverIdx === incompleteUnscheduledIdx && dragIdx !== incompleteUnscheduledIdx
@@ -538,7 +538,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
                       onDragStart={e => handleDragStart(e, incompleteUnscheduledIdx)}
                       onDragEnd={handleDragEnd}
                       onTouchStart={e => handleGripTouchStart(e, incompleteUnscheduledIdx)}
-                      className={`flex-shrink-0 p-1 cursor-grab active:cursor-grabbing touch-none select-none ${textSecondary} opacity-30`}
+                      className={`flex-shrink-0 p-2 -my-1 cursor-grab active:cursor-grabbing touch-none select-none ${textSecondary} opacity-30`}
                       aria-label="Drag to reorder"
                     >
                       <GripVertical size={12} />

--- a/src/index.css
+++ b/src/index.css
@@ -171,6 +171,29 @@ body.using-pointer a:focus-visible {
   }
 }
 
+/* Drag surfaces (task rows, project-card headers): on touch devices disable
+   text selection AND the iOS long-press callout/magnifier across the WHOLE
+   surface — not just the tiny grip — so a touch that slightly misses the
+   handle never selects nearby text. select-none alone only sets user-select;
+   iOS also needs -webkit-touch-callout: none to suppress the magnifier.
+   Scoped to coarse pointers so desktop selection is untouched; on Android this
+   only reinforces the no-selection behaviour it already had (the drag JS is
+   unchanged on every platform). Real text-entry fields keep selection. */
+@media (pointer: coarse) {
+  .dnd-no-select,
+  .dnd-no-select * {
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+  .dnd-no-select input,
+  .dnd-no-select textarea,
+  .dnd-no-select [contenteditable="true"] {
+    -webkit-user-select: text;
+    user-select: text;
+  }
+}
+
 /* Current task ring pulse animation */
 @keyframes current-task-ring {
   0%   { box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.7); }


### PR DESCRIPTION
## Problem

Task/project drag works on iOS now, but the grips are tiny — a touch that slightly misses one lands on the adjacent title text and fires the iOS long-press **selection magnifier** instead of starting a drag. `select-none` alone didn't stop it because it only sets `user-select`; iOS also needs `-webkit-touch-callout: none`.

## Changes

1. **`.dnd-no-select` helper** (`index.css`): disables text selection **and** the iOS callout/magnifier across the **whole drag surface** — the task row and the project-card header — not just the tiny grip, so a near-miss never selects text. Scoped to `@media (pointer: coarse)` so desktop selection is untouched, with `input`/`textarea`/`contenteditable` explicitly kept selectable. Applied to the task row and both project-card header rows.
2. **Larger grip tap targets**: task grip `p-1` → `p-2` (with `-my-1` so the row height doesn't grow); project grips gain `p-1.5 -m-1`. Bigger touch target, negligible visual shift.

## Android impact: none to drag behaviour

You asked specifically about this. The drag **JS is completely unchanged** on every platform — this commit only adjusts CSS and grip padding. The new CSS is selection/callout suppression, which Android already did effectively (the task row already carried `select-none`, and `-webkit-touch-callout` is a no-op in Android Chrome/WebView). The larger grip is strictly an improvement. So Android's already-good behaviour is preserved. Desktop is unaffected by the CSS (coarse-pointer scoped) and just gets the bigger handle.

## Verification

- ESLint: 70 warnings, 0 errors
- Full suite: 411 passed
- Production build: passes

⚠️ **Not verified on a physical iPad.** The grip-size bump in particular is a visual tweak I couldn't eyeball — if the handles end up too big/small or slightly misaligned in the dense task rows, it's a one-line padding adjustment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzEgW1hRJa1fxyqTaBfcJZ)_