### PR TITLE
exhaustive-deps batch 2: clear all non-App.jsx warnings (70 → 49)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:android": "./node_modules/.bin/vite build --config vite.config.android.js",
     "build:ios": "./node_modules/.bin/vite build --config vite.config.ios.js",
     "preview": "vite preview",
-    "lint": "eslint src --max-warnings 70",
+    "lint": "eslint src --max-warnings 49",
     "test": "vitest run",
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
     "build:calendar-helper": "bash scripts/build-calendar-helper.sh",

--- a/src/components/DailyNotesModal.jsx
+++ b/src/components/DailyNotesModal.jsx
@@ -61,6 +61,8 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
       }
     })();
     return () => { cancelled = true; };
+    // Mount-once: load this date's note. The modal is remounted per date.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // For non-Obsidian: apply template on mount when note is empty
@@ -69,6 +71,8 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
     if (!defaultText && template) {
       setLocalText(template);
     }
+    // Mount-once: seed the template only on open, not on later prop changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const localTextRef = useRef(localText);
   const onSaveRef = useRef(onSave);

--- a/src/components/DayViewAllDaySection.jsx
+++ b/src/components/DayViewAllDaySection.jsx
@@ -74,7 +74,7 @@ const GroupChips = ({ tasks, deadlineTasks = [], date, dateStr, darkMode, border
     const ro = new ResizeObserver(measure);
     ro.observe(el);
     return () => ro.disconnect();
-  }, [tasks.length, deadlineTasks.length]);
+  }, [tasks.length, deadlineTasks.length, allItems.length]);
 
   useEffect(() => {
     if (!overflowOpen) return;

--- a/src/components/HyperGlanceModeModal.jsx
+++ b/src/components/HyperGlanceModeModal.jsx
@@ -71,6 +71,10 @@ const HyperGlanceModeModal = () => {
       setHgCompleted(true);
       completeHyperGlanceSession(buildSessionStats());
     }
+    // Fires once when the session completes (guarded by !hgCompleted). setHgCompleted
+    // is a stable setter; buildSessionStats is declared below and read at call time,
+    // so it is deliberately not a dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allDone, hgCompleted, hgShowSettings, completeHyperGlanceSession]);
 
   // Play sounds on phase transitions
@@ -83,7 +87,7 @@ const HyperGlanceModeModal = () => {
       playFocusSound(hgTimerPhase === 'work' ? 'work' : 'break');
     }
     prevPhaseRef.current = hgTimerPhase;
-  }, [hgTimerPhase]);
+  }, [hgTimerPhase, playFocusSound]);
 
   // Ref so the notification effect can read current seconds without depending on them —
   // only fire on meaningful transitions, not every tick (which resets the chronometer).
@@ -143,7 +147,7 @@ const HyperGlanceModeModal = () => {
       }, 1000);
     }
     return () => { if (timerRef.current) clearInterval(timerRef.current); };
-  }, [hgTimerRunning, hgTimerPhase, hgWorkMinutes, hgBreakMinutes, hgLongBreakMinutes, hgCycleCount]);
+  }, [hgTimerRunning, hgTimerPhase, hgWorkMinutes, hgBreakMinutes, hgLongBreakMinutes, hgCycleCount, setHgCycleCount, setHgTimerPhase, setHgTimerSeconds]);
 
   // Session elapsed clock
   useEffect(() => {

--- a/src/components/NotesSubtasksPanel.jsx
+++ b/src/components/NotesSubtasksPanel.jsx
@@ -150,14 +150,22 @@ const NotesSubtasksPanel = ({
   useEffect(() => {
     if (!wikilinks || wikilinks.length === 0 || !onLoadWikiNote) return;
     wikilinks.forEach(noteName => loadNote(noteName));
-  }, []); // load only on mount
+    // Load only on mount; wikilinks/loaders are read once when the panel opens.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // Save unsaved linked note changes on unmount
+  // Save unsaved linked note changes on unmount. Intentionally reads the refs'
+  // CURRENT values at unmount to flush the latest edits — the lint suggestion to
+  // snapshot at mount would capture the initial (empty) state instead.
   useEffect(() => {
     return () => {
       if (!onSaveWikiNoteRef.current) return;
-      Object.entries(linkedNoteTextsRef.current).forEach(([noteName, text]) => {
-        if (text !== (linkedNoteOriginalRef.current[noteName] ?? '')) {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const texts = linkedNoteTextsRef.current;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const originals = linkedNoteOriginalRef.current;
+      Object.entries(texts).forEach(([noteName, text]) => {
+        if (text !== (originals[noteName] ?? '')) {
           onSaveWikiNoteRef.current(noteName, text);
         }
       });
@@ -177,6 +185,9 @@ const NotesSubtasksPanel = ({
   useEffect(() => {
     setLocalNotes(task.notes || '');
     setIsEditingNotes(!task.notes);
+    // Keyed on task.id only — re-syncing on task.notes would overwrite the user's
+    // in-progress edits in this panel.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [task.id]);
 
   // Save notes on unmount only (e.g., when ESC is pressed or panel closes)

--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -551,6 +551,10 @@ const WeekView = () => {
     if (!task) return;
     setPopoverTask(task);
     setPopoverAnchor(chipEl.getBoundingClientRect());
+    // Fires when a note chip is expanded; reads the current week's dates/tasks at
+    // that moment. Re-running on weekViewDates/getTasksForDate identity would
+    // reposition the popover on unrelated re-renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedNotesTaskId]);
 
   const handleTaskClick = (task, anchor) => {

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -37,7 +37,7 @@ const WeeklyReviewModal = () => {
   const [framesCollapsed, setFramesCollapsed] = useState(true);
 
   // Reset to page 0 whenever the modal opens so chevrons are never stale
-  useEffect(() => { setMobileReviewPage(0); }, []);
+  useEffect(() => { setMobileReviewPage(0); }, [setMobileReviewPage]);
 
   if (!showWeeklyReview) return null;
 

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -611,6 +611,10 @@ export default function useElectronBridge({
         } : null,
       },
     });
+    // isVisibleForUser is omitted: it is a filter applied at push time and is
+    // recreated each render, so depending on it would re-push the snapshot on
+    // every render. The push is intentionally keyed on the state values below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     todayAgenda, currentTime, tasks, expandedRecurringTasks, todayHGSessions, focusModeAvailable,
     showFocusMode, focusShowSettings, focusShowStats, focusPhase, focusTimerSeconds, focusTimerRunning,

--- a/src/hooks/useFocusMode.js
+++ b/src/hooks/useFocusMode.js
@@ -32,9 +32,12 @@ const useFocusMode = () => {
     localStorage.setItem('day-planner-focus-log', JSON.stringify(focusLog));
   }, [focusLog]);
 
-  // Focus Mode timer tick
+  // Focus Mode timer tick — runs the interval while the timer is active; the
+  // single derived flag re-runs the effect only when active-ness flips (not every
+  // second), matching the previous `focusTimerSeconds > 0` dependency.
+  const focusTimerActive = showFocusMode && focusTimerRunning && focusTimerSeconds > 0;
   useEffect(() => {
-    if (showFocusMode && focusTimerRunning && focusTimerSeconds > 0) {
+    if (focusTimerActive) {
       focusTimerRef.current = setInterval(() => {
         setFocusTimerSeconds(prev => {
           if (prev <= 1) return 0;
@@ -43,7 +46,7 @@ const useFocusMode = () => {
       }, 1000);
       return () => clearInterval(focusTimerRef.current);
     }
-  }, [showFocusMode, focusTimerRunning, focusTimerSeconds > 0]);
+  }, [focusTimerActive]);
 
   // Focus Mode timer end detection (reads from ref to avoid stale closure)
   useEffect(() => {

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -295,5 +295,10 @@ export default function useKeyboardShortcuts({
 
     document.addEventListener('keydown', handleGlobalKeyDown);
     return () => document.removeEventListener('keydown', handleGlobalKeyDown);
-  }, [selectedDate, showAddTask, showShortcutHelp, showFocusMode, showRoutinesDashboard, showHabitModal, showMonthView, showSpotlight, showSettings, showRemindersSettings, showWeeklyReview, showVoiceInput, showFramesModal, frameAdjustModal, showRescheduleModal, showGoalsDashboard, hoverPreviewTime, hoverPreviewDate, isMobile, routinesEnabled, habitsEnabled, goalsProjectsEnabled, aiConfig, gtdFrames, canShowViewCycler]);
+    // Deps list the state the handler branches on (incl. tabletActiveTab, read by
+    // the '/' shortcut). The omitted names are setX setters, *Ref values, and the
+    // action callbacks (changeDate/goToToday/performUndo/performRedo/playUISound),
+    // all stable or read through refs — listing them would needlessly re-bind.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedDate, showAddTask, showShortcutHelp, showFocusMode, showRoutinesDashboard, showHabitModal, showMonthView, showSpotlight, showSettings, showRemindersSettings, showWeeklyReview, showVoiceInput, showFramesModal, frameAdjustModal, showRescheduleModal, showGoalsDashboard, hoverPreviewTime, hoverPreviewDate, isMobile, tabletActiveTab, routinesEnabled, habitsEnabled, goalsProjectsEnabled, aiConfig, gtdFrames, canShowViewCycler]);
 }

--- a/src/hooks/useLocalStoragePersist.js
+++ b/src/hooks/useLocalStoragePersist.js
@@ -65,7 +65,7 @@ export default function useLocalStoragePersist({
     if (!skipOnboardingPersist.current) {
       localStorage.setItem('sectionInfoDismissed', JSON.stringify(sectionInfoDismissed));
     }
-  }, [sectionInfoDismissed]);
+  }, [sectionInfoDismissed, skipOnboardingPersist]);
 
   // Persist dailyNotes to localStorage and trigger cloud sync upload
   useEffect(() => {
@@ -73,6 +73,10 @@ export default function useLocalStoragePersist({
     if (!suppressCloudUploadRef.current && (!cloudSyncConfig?.enabled || cloudSyncInitialDoneRef.current)) {
       localStorage.setItem('day-planner-cloud-sync-local-modified', new Date().toISOString());
     }
+    // Keyed on dailyNotes only: this persists on note change and reads the sync
+    // guards (refs + current enabled flag) as live values. Adding cloudSyncConfig
+    // would re-persist and re-mark dirty on a mere sync-toggle, which is wrong.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dailyNotes]);
 
   // Persist daily note template

--- a/src/hooks/useModalClose.js
+++ b/src/hooks/useModalClose.js
@@ -145,5 +145,8 @@ export default function useModalClose({
 
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
+    // Deps list the open-modal flags the Escape handler branches on. The only
+    // omitted names are the setX state setters, which React guarantees are stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusLogModalDate, taskContextMenu, timelineContextMenu, quickAddFrameModal, frameContextMenu, frameAdjustModal, frameScheduleModal, showFramesModal, showSpotlight, showHelpModal, showShortcutHelp, editingRecurrenceTaskId, showMonthView, showAutoBackupManager, showBackupMenu, showVoiceInput, showSettings, showRemindersSettings, showWeeklyReview, showMobileDailySummary, showAddTask, showRecurrencePicker]);
 }

--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -182,7 +182,7 @@ export function useSubscription() {
     if (!isOnNativePlatform) return;
     window.__billingEvent = handleBillingEvent;
     return () => { delete window.__billingEvent; };
-  }, [handleBillingEvent]);
+  }, [handleBillingEvent, isOnNativePlatform]);
 
   // Electron: subscribe to subscription:event IPC push.
   useEffect(() => {
@@ -249,7 +249,7 @@ export function useSubscription() {
     const onVisible = () => { if (document.visibilityState === 'visible') refresh(); };
     document.addEventListener('visibilitychange', onVisible);
     return () => document.removeEventListener('visibilitychange', onVisible);
-  }, [refresh]);
+  }, [refresh, isOnNativePlatform]);
 
   // ── subscribe ──────────────────────────────────────────────────────────────
   /**


### PR DESCRIPTION
## What

Second triage-and-fix batch of the `react-hooks/exhaustive-deps` backlog, per-site. **Every non-App.jsx file is now clean** — the 49 remaining warnings are all in `App.jsx`, which gets its own dedicated batch. Ratchet lowered to **49**.

## The split (21 sites across 12 files)

**Stable dep additions (no-op — stable refs/setters/derived constants):**
`useSubscription` (×2, `isOnNativePlatform` is a stable derived boolean), `useLocalStoragePersist` (a ref), `WeeklyReviewModal` (`setMobileReviewPage`), `DayViewAllDaySection` (`allItems.length`), `HyperGlanceModeModal` timer effect (3 setters) + phase-sound effect (`playFocusSound`).

**Real fix:**
`useKeyboardShortcuts` — the `/` shortcut reads `tabletActiveTab`, but it was missing from the deps, so the handler captured a **stale tab**. Added it; the remaining omissions (setters/refs/action callbacks) are stable and annotated.

**Refactor:**
`useFocusMode` — collapsed the three-part timer-tick condition into one derived `focusTimerActive` flag, resolving the "complex expression in deps" warning. Behavior-equivalent: the effect re-runs only when active-ness flips, exactly as the old `focusTimerSeconds > 0` dep did.

**Intentional omissions, annotated with a reason (not blindly "fixed"):**
`useLocalStoragePersist` (keyed on `dailyNotes`), `useElectronBridge` (`isVisibleForUser` would re-push every render), `useModalClose` (all-stable setters), `DailyNotesModal` (×2 mount-once), `NotesSubtasksPanel` (mount-once load; unmount-flush that intentionally reads current ref values; `task.id`-keyed sync that must not clobber in-progress edits), `WeekView` (popover keyed on expand), `HyperGlanceModeModal` session-complete effect.

## Caught a runtime hazard mid-batch

An initial attempt added `buildSessionStats` to a `HyperGlanceModeModal` deps array — but that function is declared **below** the effect, so referencing it in the deps (evaluated during render) would be a **TDZ `ReferenceError` at runtime** that the build can't catch. Reverted to an annotation. (Good reminder that adding a dep isn't always free.)

## Verification

- `npm run lint`: 0 errors, **49 warnings**, exit 0 (ratchet at 49).
- `npm test`: **411 passed**.
- `npm run build`: clean.

## Remaining

49, all in `App.jsx`. That's the next (and final) batch — best done as its own focused pass given the file's size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_