### PR TITLE
exhaustive-deps App.jsx batch 3a: AI-summaries region + setter wins (49 → 38)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:android": "./node_modules/.bin/vite build --config vite.config.android.js",
     "build:ios": "./node_modules/.bin/vite build --config vite.config.ios.js",
     "preview": "vite preview",
-    "lint": "eslint src --max-warnings 49",
+    "lint": "eslint src --max-warnings 38",
     "test": "vitest run",
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
     "build:calendar-helper": "bash scripts/build-calendar-helper.sh",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1364,7 +1364,7 @@ const DayPlanner = () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('touchstart', handleClickOutside);
     };
-  }, [expandedTaskMenu, showColorPicker, showDeadlinePicker, expandedNotesTaskId, routineDurationEditId]);
+  }, [expandedTaskMenu, showColorPicker, showDeadlinePicker, expandedNotesTaskId, routineDurationEditId, setRoutineDurationEditId]);
 
 
   // Close habit day popup on ESC
@@ -1373,7 +1373,7 @@ const DayPlanner = () => {
     const handleKeyDown = (e) => { if (e.key === 'Escape') { e.preventDefault(); setHabitDayPopup(null); } };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [habitDayPopup]);
+  }, [habitDayPopup, setHabitDayPopup]);
 
   // Close notes panel on ESC
   useEffect(() => {
@@ -1515,7 +1515,7 @@ const DayPlanner = () => {
     if (!onboardingProgress.hasSetupSync && (syncUrl.trim() || taskCalendarUrl.trim())) {
       setOnboardingProgress(prev => ({ ...prev, hasSetupSync: true }));
     }
-  }, [syncUrl, taskCalendarUrl, onboardingProgress.hasSetupSync]);
+  }, [syncUrl, taskCalendarUrl, onboardingProgress.hasSetupSync, setOnboardingProgress]);
 
   useEffect(() => {
     // Tick every 15s for responsive reminders; firedRemindersRef prevents duplicates
@@ -1700,7 +1700,7 @@ const DayPlanner = () => {
       const filtered = prev.filter(f => !f.singleDate || f.singleDate >= cutoff);
       return filtered.length === prev.length ? prev : filtered;
     });
-  }, []); // Run once on app start
+  }, [setGtdFrames]); // Run once on app start (setGtdFrames is stable)
 
   // Auto-sync calendars on mount and then every 15 minutes when URLs are configured.
   // On native apps, only the task calendar matters — calendar events come from the native bridge.
@@ -6242,12 +6242,16 @@ const DayPlanner = () => {
       setMorningGlanceError(err.message);
     }
     setMorningGlanceLoading(false);
+    // Curated deps: the inputs that should regenerate the briefing. getOverdueTasks
+    // is an unstable helper read at call time (listing it would defeat this
+    // callback's memoization); the setters and isVisibleForUser are stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [aiConfig, tasks, recurringTasks, unscheduledTasks]);
 
   const dismissMorningGlance = useCallback(() => {
     setMorningGlanceDismissed(true);
     localStorage.setItem('day-planner-mg-dismissed', localDateStr());
-  }, []);
+  }, [setMorningGlanceDismissed]);
 
   // Reset morning briefing state on day rollover (tab regains focus the next day).
   // We no longer auto-generate — the user clicks "see your daily briefing" to trigger it.
@@ -6268,7 +6272,7 @@ const DayPlanner = () => {
     };
     document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
-  }, [aiConfig.enabled, aiConfig.features.morningSummary]);
+  }, [aiConfig.enabled, aiConfig.features.morningSummary, setMorningGlanceDismissed, setMorningGlanceText]);
 
   // --- Evening Reflection ---
   const generateEveningReflection = useCallback(async (force = false) => {
@@ -6323,12 +6327,16 @@ const DayPlanner = () => {
       setEveningGlanceError(err.message);
     }
     setEveningGlanceLoading(false);
+    // Curated deps (see generateMorningSummary): getOverdueTasks/isVisibleForUser
+    // are read at call time; the setters are stable. Listing the unstable helper
+    // would defeat this callback's memoization.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [aiConfig, tasks, unscheduledTasks]);
 
   const dismissEveningGlance = useCallback(() => {
     setEveningGlanceDismissed(true);
     localStorage.setItem('day-planner-eg-dismissed', localDateStr());
-  }, []);
+  }, [setEveningGlanceDismissed]);
 
   // Reset evening reflection on day rollover
   useEffect(() => {
@@ -6345,7 +6353,7 @@ const DayPlanner = () => {
     };
     document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
-  }, [aiConfig.enabled, aiConfig.features.eveningReflection]);
+  }, [aiConfig.enabled, aiConfig.features.eveningReflection, setEveningGlanceDismissed, setEveningGlanceText]);
 
   // Clear AI suggestion when the form closes or switches to edit mode
   useEffect(() => {
@@ -6391,7 +6399,7 @@ const DayPlanner = () => {
       setWeeklyAIError(err.message);
     }
     setWeeklyAILoading(false);
-  }, [aiConfig]);
+  }, [aiConfig, setWeeklyAIError, setWeeklyAILoading, setWeeklyAISummary]);
 
   // Voice input keyboard shortcuts (SPACE to hold-record, T for typing, ENTER to parse/accept)
   const voiceHasTranscription = aiConfig.enabled && supportsTranscription(aiConfig);


### PR DESCRIPTION
## What

First sub-batch of the App.jsx `react-hooks/exhaustive-deps` backlog, done **by region** (App.jsx is ~10.5k lines, so all-at-once would be unreviewable and risky). Clears the AI morning/evening/weekly summary effects plus a few trivial single-setter adds. **49 → 38**; ratchet lowered to 38.

## Changes

**Stable setter additions (no-op):** morning rollover, `dismissMorningGlance`, evening rollover, `dismissEveningGlance`, `generateWeeklyAISummary`, plus standalone `setRoutineDurationEditId`, `setHabitDayPopup`, `setOnboardingProgress`, `setGtdFrames`. All are hook-destructured setters (declared ~lines 490–1024), so they're stable and always in scope.

**Annotated (intentional curated deps):** `generateMorningSummary` / `generateEveningReflection` — `getOverdueTasks` is an unstable per-render helper read at call time; listing it would defeat the callback's memoization. The setters and `isVisibleForUser` are stable.

## TDZ guard

The same hazard from batch 2 applies in App.jsx: a symbol referenced in a deps array must be **declared earlier** in this giant component, or it's a runtime `ReferenceError`. Every addition here is a hook-destructured setter from the top of the component, so all are safely in scope.

## Verification

- `npm run lint`: 0 errors, **38 warnings**, exit 0 (ratchet at 38).
- `npm test`: **411 passed**.
- `npm run build`: clean.

## Remaining (38, all App.jsx)

Grouped for the next sub-batches: Obsidian-sync effects (refs + `performObsidianSync`), the voice-input pipeline (setter-lists), cloud-sync ref effects, `isVisibleForUser` over-trigger sites, and two special cases (a `useMemo` with *unnecessary* deps and an unstable `getTasksForDate` feeding a `useCallback`). Each needs its own per-site read for declaration order and churn, so they'll come as further region PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_