### PR TITLE
exhaustive-deps App.jsx batch 3b: Obsidian sync region (38 → 29)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:android": "./node_modules/.bin/vite build --config vite.config.android.js",
     "build:ios": "./node_modules/.bin/vite build --config vite.config.ios.js",
     "preview": "vite preview",
-    "lint": "eslint src --max-warnings 38",
+    "lint": "eslint src --max-warnings 29",
     "test": "vitest run",
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
     "build:calendar-helper": "bash scripts/build-calendar-helper.sh",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2288,6 +2288,10 @@ const DayPlanner = () => {
         console.error('Obsidian: failed to restore vault access', err);
       }
     })();
+    // Keyed on dataLoaded + enabled. performObsidianSync/notifyNativeReady are
+    // declared later in this component and read at call time; vault refs are read
+    // via .current, so they are intentionally not dependencies.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataLoaded, obsidianConfig?.enabled]);
 
   // Obsidian sync: on visibility change (user switches back from Obsidian / native settings)
@@ -2325,6 +2329,9 @@ const DayPlanner = () => {
     };
     document.addEventListener('visibilitychange', handleVisibility);
     return () => document.removeEventListener('visibilitychange', handleVisibility);
+    // performObsidianSync/setObsidianConfig are read at call time (the former is
+    // declared later); keyed on enabled. Vault state is read via refs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [obsidianConfig?.enabled]);
 
   // Obsidian sync: poll every 5 minutes while open
@@ -2334,11 +2341,14 @@ const DayPlanner = () => {
       if (obsidianVaultHandleRef.current) performObsidianSync();
     }, 5 * 60 * 1000);
     return () => clearInterval(timer);
+    // performObsidianSync is declared later and read at call time; the poll is
+    // keyed on enabled, and the vault handle is read via its ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [obsidianConfig?.enabled]);
 
   // Keep always-fresh refs so the interval-triggered performObsidianSync never reads stale state.
-  useEffect(() => { obsidianTasksRef.current = tasks; }, [tasks]);
-  useEffect(() => { obsidianInboxRef.current = unscheduledTasks; }, [unscheduledTasks]);
+  useEffect(() => { obsidianTasksRef.current = tasks; }, [tasks, obsidianTasksRef]);
+  useEffect(() => { obsidianInboxRef.current = unscheduledTasks; }, [unscheduledTasks, obsidianInboxRef]);
 
   // Obsidian writeback: detect completion/scheduling/title changes and write back to vault
   useEffect(() => {
@@ -2439,6 +2449,10 @@ const DayPlanner = () => {
       next[snapshotId] = { completed: task.completed, startTime: task.startTime || null, duration: task.duration || null, title: task.title, date: task.date || null };
     }
     obsidianPrevTaskStateRef.current = next;
+    // Keyed on task changes — writeback fires when tasks change and reads the
+    // current obsidianConfig paths + dedup refs at that moment. Adding the config
+    // paths would re-run a writeback on a mere settings change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tasks, unscheduledTasks, obsidianConfig?.enabled]);
 
   // On iOS, persist Obsidian folder/pattern/newNotesFolder to UserDefaults so
@@ -2942,7 +2956,7 @@ const DayPlanner = () => {
       console.error('Failed to read wiki note:', err);
       return null;
     }
-  }, []);
+  }, [obsidianVaultHandleRef]);
 
   const saveWikiNote = useCallback(async (noteName, content) => {
     const handle = obsidianVaultHandleRef.current;
@@ -2958,7 +2972,7 @@ const DayPlanner = () => {
     } catch (err) {
       console.error('Failed to write wiki note:', err);
     }
-  }, [obsidianConfig?.newNotesFolder]);
+  }, [obsidianConfig?.newNotesFolder, obsidianVaultHandleRef]);
 
   // Opens a vault note in the Obsidian app (Android) or via obsidian:// URI (web/desktop).
   const openInObsidian = useCallback((noteName) => {
@@ -2976,7 +2990,7 @@ const DayPlanner = () => {
         '_blank',
       );
     }
-  }, []);
+  }, [obsidianVaultHandleRef]);
 
   // Signal the native Android side that the app is interactive and the initial
   // Obsidian sync has completed. This releases the splash screen that was held


### PR DESCRIPTION
## What

Second App.jsx sub-batch — the Obsidian sync effects (9 sites). **38 → 29**; ratchet lowered to 29.

## Changes

**Stable ref additions (no-op):** the obsidian refs are declared at lines 605–609, well before these effects, so adding them is safe and stable:
- the `tasks`/`inbox` ref-sync effects (`obsidianTasksRef`, `obsidianInboxRef`),
- the `loadWikiNote` / `saveWikiNote` / `openInObsidian` callbacks (`obsidianVaultHandleRef`).

**Annotated (intentional — and would be a TDZ crash if "fixed"):**
- The vault-restore-on-load, visibility-change, and 5-minute-poll effects call `performObsidianSync`, which is declared at **line 2993, after these effects**. Referencing it in their deps arrays would be a runtime `ReferenceError`. They're keyed on `dataLoaded`/`obsidianConfig.enabled` and read vault state via refs.
- The writeback effect is keyed on task changes and reads the current Obsidian config paths + dedup refs at write time; adding the config paths would re-run a writeback on a mere settings change.

## Verification

- `npm run lint`: 0 errors, **29 warnings**, exit 0 (ratchet at 29).
- `npm test`: **411 passed**.
- `npm run build`: clean.

## Remaining (29, all App.jsx)

Voice-input pipeline (setter-lists), cloud-sync ref effects, the `isVisibleForUser` over-trigger sites, a few singletons (`mobileActiveTab`, `myFrames`, etc.), and two special cases (a `useMemo` with *unnecessary* deps, and an unstable `getTasksForDate` feeding a `useCallback` — the trickiest, likely needs a `useCallback` wrap). Next region PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_