### PR TITLE
exhaustive-deps App.jsx batch 3c: voice pipeline + cloud-sync refs (29 → 17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:android": "./node_modules/.bin/vite build --config vite.config.android.js",
     "build:ios": "./node_modules/.bin/vite build --config vite.config.ios.js",
     "preview": "vite preview",
-    "lint": "eslint src --max-warnings 29",
+    "lint": "eslint src --max-warnings 17",
     "test": "vitest run",
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
     "build:calendar-helper": "bash scripts/build-calendar-helper.sh",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1666,6 +1666,10 @@ const DayPlanner = () => {
       window.removeEventListener('focus', handleVisibility);
       delete window.__onHealthPermResult;
     };
+    // Mount-once: binds global foreground/visibility listeners a single time.
+    // Refs and setters are stable; selectedDate is read inside a handler and is
+    // intentionally not a dep so the listeners aren't re-bound on every date change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Auto-refresh page at midnight (00:00:01) to reset the timeline to the new day
@@ -1757,7 +1761,7 @@ const DayPlanner = () => {
       cloudSyncEngineRef.current.upload();
     }, 5000);
     return () => { if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current); };
-  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, allTodayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled, syncKeyReady, multiUserEnabled, users]);
+  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, allTodayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled, syncKeyReady, multiUserEnabled, users, cloudSyncDebounceRef, dataLoaded, suppressCloudUploadRef]);
 
   // ── GLANCEvault DB transport ─────────────────────────────────────────────
   // Row-grained sync that runs ALONGSIDE the file-tier WebDAV engine (it shares
@@ -2146,7 +2150,7 @@ const DayPlanner = () => {
         iCloudSyncRef.current?.();
       }
     });
-  }, []);
+  }, [cloudSyncInProgressRef]);
 
   // Cloud sync: download on app load or when sync is first enabled.
   // One-time check: if existing sync user is still on the legacy 'dayglance'
@@ -2188,7 +2192,7 @@ const DayPlanner = () => {
       // No cloud sync — allow local-modified timestamps immediately
       cloudSyncInitialDoneRef.current = true;
     }
-  }, [dataLoaded, cloudSyncConfig?.enabled, syncKeyReady]);
+  }, [dataLoaded, cloudSyncConfig?.enabled, syncKeyReady, cloudSyncInitialDoneRef]);
 
   // Cloud sync: poll for remote changes every 60 seconds.
   // Respects the engine's download backoff so persistent errors don't hammer
@@ -2201,7 +2205,7 @@ const DayPlanner = () => {
       }
     }, 60 * 1000);
     return () => clearInterval(pollTimer);
-  }, [cloudSyncConfig?.enabled]);
+  }, [cloudSyncConfig?.enabled, cloudSyncDownloadRef]);
 
   // TRMNL auto-sync: push data when tasks/habits change
   // Debounce 10s to batch rapid edits, then throttle to at most once per 2 min.
@@ -3135,6 +3139,9 @@ const DayPlanner = () => {
       }
       voiceAudioChunksRef.current = [];
     }
+    // Keyed on showVoiceInput (open/close). The omitted names are all stable
+    // state setters and *Ref values used to reset the recorder.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showVoiceInput]);
 
   const voiceStartRecording = useCallback(async () => {
@@ -3186,6 +3193,9 @@ const DayPlanner = () => {
       setVoiceParseError(msg);
       setVoiceMicError('error');
     }
+    // Omitted names are all stable state setters and *Ref values; keyed on
+    // voiceCanRecord.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [voiceCanRecord]);
 
   // When the voice modal is opened via the Android launcher shortcut, auto-start recording.
@@ -3194,7 +3204,7 @@ const DayPlanner = () => {
       voiceAutoStartRef.current = false;
       voiceStartRecording();
     }
-  }, [showVoiceInput, voiceStartRecording]);
+  }, [showVoiceInput, voiceStartRecording, voiceAutoStartRef]);
 
   const voiceStopRecording = useCallback(async () => {
     const ref = voiceRecorderRef.current;
@@ -3275,6 +3285,8 @@ const DayPlanner = () => {
       }
       setVoiceIsTranscribing(false);
     }
+    // Omitted names are all stable state setters and *Ref values; keyed on aiConfig.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [aiConfig]);
 
   const enterFocusModeRef = useRef(null);
@@ -5979,7 +5991,7 @@ const DayPlanner = () => {
     if (cloudSyncLastSynced && !cloudSyncInitialDoneRef.current) {
       cloudSyncInitialDoneRef.current = true;
     }
-  }, [cloudSyncLastSynced]);
+  }, [cloudSyncLastSynced, cloudSyncInitialDoneRef]);
 
   // DeadlinePickerPopover extracted to src/components/DeadlinePickerPopover.jsx
 
@@ -6076,7 +6088,7 @@ const DayPlanner = () => {
       setVoiceParsedEdits([]);
     }
     setVoiceIsParsing(false);
-  }, [voiceTranscript, aiConfig, allTags, buildTaskContextForAI, resolveTaskMatch]);
+  }, [voiceTranscript, aiConfig, allTags, buildTaskContextForAI, resolveTaskMatch, setVoiceIsParsing, setVoiceParseError, setVoiceParsedEdits, setVoiceParsedTasks]);
 
   // Apply all parsed changes (new tasks + edit commands)
   const voiceApplyAllChanges = useCallback(() => {
@@ -6473,7 +6485,7 @@ const DayPlanner = () => {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
     };
-  }, [showVoiceInput, voiceIsRecording, voiceIsTranscribing, voiceParsedTasks, voiceParsedEdits, voiceManualMode, voiceCanRecord, voiceHasTranscription, voiceEditingParsed, voiceStartRecording, voiceStopRecording, voiceParseWithAI, voiceApplyAllChanges]);
+  }, [showVoiceInput, voiceIsRecording, voiceIsTranscribing, voiceParsedTasks, voiceParsedEdits, voiceManualMode, voiceCanRecord, voiceHasTranscription, voiceEditingParsed, voiceStartRecording, voiceStopRecording, voiceParseWithAI, voiceApplyAllChanges, setVoiceManualMode]);
 
   // L — toggle Intent Activity Log
   useEffect(() => {


### PR DESCRIPTION
## What

Third App.jsx sub-batch — the voice-input pipeline and the cloud-sync ref effects (12 sites). **29 → 17**; ratchet lowered to 17.

## Changes

**Voice-input pipeline:**
- Added stable deps where the list was short: `voiceAutoStartRef` (auto-start effect), the 4 parse-result setters (`voiceParseWithAI`), `setVoiceManualMode` (keyboard-shortcut effect).
- Annotated the recorder-lifecycle, start-recording, and transcribe callbacks, whose long missing lists are entirely stable state setters and `*Ref` values.

**Cloud-sync ref effects:**
- Added the stable refs (declared at lines 523–529): `cloudSyncInProgressRef`, `cloudSyncInitialDoneRef` (×2), `cloudSyncDownloadRef`, and on the debounced-upload effect `cloudSyncDebounceRef` + `suppressCloudUploadRef` + `dataLoaded` (the upload is gated by `suppressCloudUploadRef`, so the `dataLoaded` flip is safe).
- Annotated the mount-once global foreground/visibility listener binder: refs/setters are stable; `selectedDate` is read inside a handler and left out so the listeners aren't re-bound on every date change.

All added symbols are refs/setters/state declared near the top of the component (well before these effects), so no TDZ.

## One thing to flag (not changed here)

The mount-once listener binder (the `selectedDate` site) reads `selectedDate` inside a foreground handler that can create a task. Because the listener binds once, that read could be **stale** (the launch-time date) if you've navigated to another date before the app foregrounds. I deliberately did **not** "fix" it by adding `selectedDate` (that would re-bind global listeners on every date change — a behavior change that doesn't belong in a lint pass). If the foreground task-creation date matters, it's worth a separate look (a `selectedDateRef` would be the clean fix). Let me know and I'll take it on its own.

## Verification

- `npm run lint`: 0 errors, **17 warnings**, exit 0 (ratchet at 17).
- `npm test`: **411 passed**.
- `npm run build`: clean.

## Remaining (17, all App.jsx)

The `isVisibleForUser` over-trigger sites, a handful of singletons (`mobileActiveTab`, `myFrames`, `swipeSchedulingInboxTaskId`, `setUndoToast`/`t`, backup callbacks, TRMNL), and the two special cases — a `useMemo` with *unnecessary* deps (just remove them) and the unstable `getTasksForDate` → `useCallback` chain (the trickiest, saved for last). One or two more region PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_