### PR TITLE
Fix stale selectedDate in the foreground Share-sheet handler

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -319,6 +319,11 @@ const DayPlanner = () => {
     today.setHours(12, 0, 0, 0);
     return today;
   });
+  // Mirror selectedDate into a ref so handlers that are bound ONCE (e.g. the
+  // foreground Share-sheet listener) read the CURRENT date instead of the value
+  // captured when they were bound at mount.
+  const selectedDateRef = useRef(selectedDate);
+  selectedDateRef.current = selectedDate;
   const [tasks, setTasks] = useState([]);
   const [unscheduledTasks, setUnscheduledTasks] = useState([]);
   const [unscheduledOrderTimestamp, setUnscheduledOrderTimestamp] = useState(null);
@@ -1637,7 +1642,7 @@ const DayPlanner = () => {
                 notes: shareNotes || undefined,
                 startTime: getNextQuarterHour(),
                 duration: 30,
-                date: dateToString(selectedDate),
+                date: dateToString(selectedDateRef.current),
                 isAllDay: false,
                 openInInbox: true,
                 deadline: null,


### PR DESCRIPTION
## The bug

The app binds its foreground/visibility listeners **once** at mount (an effect with an empty dependency array). One of those handlers (`handleNativeForeground`) creates a task from content shared into dayGLANCE and stamped it with `dateToString(selectedDate)`.

Because the handler is created once, it closed over `selectedDate` **as it was at launch**. So this sequence misbehaves:

1. Open the app (selectedDate = today).
2. Navigate to a different date.
3. Share something into dayGLANCE from another app.

→ The shared task is created with the **launch-day** date, not the date you're viewing. (It goes to the inbox via `openInInbox: true`, so it's a minor latent issue rather than an everyday-visible one — but still wrong.)

## The fix

Mirror `selectedDate` into a ref that's updated during render (the same "latest value" ref pattern already used throughout the app, e.g. in `useElectronBridge`), and have the handler read `selectedDateRef.current`. The listener still binds once (no re-registering global listeners on every date change), but now reads the **current** date when it fires.

```js
const selectedDateRef = useRef(selectedDate);
selectedDateRef.current = selectedDate;
...
date: dateToString(selectedDateRef.current),   // was: selectedDate
```

## Scope / interaction

- Behavior fix only. Only `handleNativeForeground` had this staleness; `handleVisibility` doesn't read `selectedDate`, and the other `dateToString(selectedDate)` call sites are in render-scope handlers (recreated each render, already fresh).
- The lint warning count is **unchanged at 29** (that effect still has other intentionally-omitted refs/setters). This does not touch the ratchet.
- Independent of the open lint PR #1069, which annotates the same effect — no textual conflict (this changes the handler body + adds the ref; #1069 touches the deps line). After this lands, #1069's annotation comment no longer needs to mention `selectedDate`.

## Verification

- `npm test`: **411 passed**.
- `npm run build`: clean.
- `eslint`: `selectedDate` no longer flagged on that effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_