### PR TITLE
exhaustive-deps App.jsx batch 3d: isVisibleForUser + singletons (17 → 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:android": "./node_modules/.bin/vite build --config vite.config.android.js",
     "build:ios": "./node_modules/.bin/vite build --config vite.config.ios.js",
     "preview": "vite preview",
-    "lint": "eslint src --max-warnings 17",
+    "lint": "eslint src --max-warnings 4",
     "test": "vitest run",
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
     "build:calendar-helper": "bash scripts/build-calendar-helper.sh",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1258,7 +1258,7 @@ const DayPlanner = () => {
     if (!showAddTask) {
       swipeSchedulingInboxTaskId.current = null;
     }
-  }, [showAddTask]);
+  }, [showAddTask, swipeSchedulingInboxTaskId]);
 
   // Extract partial tag being typed at cursor position
   // Format time for display (respects 12h/24h setting)
@@ -1492,7 +1492,7 @@ const DayPlanner = () => {
       handleRoutinesDone();
       setMobileActiveTab('dayglance');
     }
-  }, [routinesEnabled]);
+  }, [routinesEnabled, mobileActiveTab, handleRoutinesDone, setMobileActiveTab]);
 
   // Android back button: navigate to dayglance tab from other screens
   useEffect(() => {
@@ -1809,6 +1809,10 @@ const DayPlanner = () => {
       registerDbEngine(null);
       dbEngineRef.current = null;
     };
+    // Keyed on dataLoaded (sets up the DB engine once). setUndoToast/t are read
+    // when surfacing an error toast; adding t would tear down the engine on a
+    // mere language change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataLoaded]);
 
   // ── Config field timestamp tracking ──────────────────────────────────────
@@ -1870,6 +1874,9 @@ const DayPlanner = () => {
         } catch (_) {}
       }
     }
+    // Drains pending native actions once after load (keyed on dataLoaded). The
+    // setters/voiceAutoStartRef are stable; toggleComplete is read at drain time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataLoaded]);
 
   // Navigate to a task opened via Spotlight search.
@@ -2185,6 +2192,9 @@ const DayPlanner = () => {
     }
     if (oldFolderPath) localStorage.setItem(NOTICE_KEY, oldFolderPath);
     localStorage.setItem(CHECKED_KEY, '1');
+    // One-time migration notice (guarded by CHECKED_KEY). Reads the other
+    // cloudSyncConfig fields at check time; keyed on enabled + syncFolder.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cloudSyncConfig?.enabled, cloudSyncConfig?.syncFolder]);
 
   // If encryption is enabled, wait until the session key is ready (either
@@ -2238,6 +2248,9 @@ const DayPlanner = () => {
       }
     }, 10 * 1000); // 10-second debounce after last change
     return () => { if (trmnlSyncTimerRef.current) clearTimeout(trmnlSyncTimerRef.current); };
+    // Keyed on the data that feeds a TRMNL push. The throttle constant, the
+    // trmnl*Ref values, and trmnlConfig.webhookUrl are stable or read at sync time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tasks, unscheduledTasks, habits, habitLogs, todayRoutines, routinesEnabled, trmnlConfig?.enabled, dataLoaded]);
 
   // Auto-archive completed inbox tasks older than the configured threshold
@@ -2509,6 +2522,9 @@ const DayPlanner = () => {
     // Then check every 60 seconds
     const timer = setInterval(checkAndBackup, 60 * 1000);
     return () => clearInterval(timer);
+    // Keyed on the backup config; performLocalBackup/performRemoteBackup are
+    // declared later and read inside checkAndBackup at interval time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataLoaded, autoBackupConfig.local.enabled, autoBackupConfig.local.frequency, autoBackupConfig.remote.enabled, autoBackupConfig.remote.frequency]);
 
 
@@ -6046,7 +6062,7 @@ const DayPlanner = () => {
       return { task: best, source: 'inbox' };
     }
     return null;
-  }, [tasks, unscheduledTasks]);
+  }, [tasks, unscheduledTasks, isVisibleForUser]);
   voiceResolveTaskMatchRef.current = resolveTaskMatch;
 
   const voiceParseWithAI = useCallback(async () => {
@@ -6201,6 +6217,9 @@ const DayPlanner = () => {
     }
 
     setShowVoiceInput(false);
+    // Keyed on the parsed voice results; colors and the moveToRecycleBin/pushUndo
+    // helpers + setShowVoiceInput are read when changes are applied.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [voiceParsedTasks, voiceParsedEdits]);
 
   // --- Morning dayGLANCE (AI morning summary) ---
@@ -6627,7 +6646,7 @@ const DayPlanner = () => {
       setSelectedTags(prev => [...prev, ...brandNewTags.filter(t => !prev.includes(t))]);
     }
     prevAllTagsRef.current = new Set(allTags);
-  }, [allTags]);
+  }, [allTags, setSelectedTags]);
 
   // Expand recurring task templates into virtual task instances for visible dates.
   // In week view, expand over the full week range (which may extend beyond visibleDates).
@@ -6693,7 +6712,7 @@ const DayPlanner = () => {
         ).length + (alreadyInstantiated ? 0 : (hg.templateTasks?.length || 0));
         return [{ id: project.id, title: project.title, date: instance.date, startMinutes: startH * 60 + startM, taskCount }];
       });
-  }, [hgVisibleProjects, goalsProjectsEnabled, tasks, unscheduledTasks]);
+  }, [hgVisibleProjects, goalsProjectsEnabled, tasks, unscheduledTasks, isVisibleForUser]);
 
   const {
     activeReminders, setActiveReminders,
@@ -7193,7 +7212,7 @@ const DayPlanner = () => {
     // Skip if the user already dismissed this key
     if (frameNudgeDismissedKey === activeFrameNudgeKey) return;
     generateFrameNudge();
-  }, [activeFrameNudgeKey, activeFrameForNudge, aiConfig, gtdFrames, frameNudgeDismissedKey, generateFrameNudge]);
+  }, [activeFrameNudgeKey, activeFrameForNudge, aiConfig, gtdFrames, frameNudgeDismissedKey, generateFrameNudge, myFrames]);
 
   // Compute available time slots within a frame instance, subtracting existing tasks/events.
   // For today, elapsed time is excluded: each slot's start is clipped to the current time.
@@ -7944,6 +7963,11 @@ const DayPlanner = () => {
     try {
       window.DayGlanceNative.updateWidgetSnapshot(JSON.stringify(snapshot));
     } catch (_) {}
+    // Keyed on the state that composes the widget snapshot. The omitted names are
+    // unstable per-render helpers (computeAvailableSlots/getFrameInstancesForDate/
+    // getOverdueTasks/getTodayHabitCount) plus stable isVisibleForUser and the
+    // use24HourClock value, all read when the snapshot is built.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     dataLoaded,
     todayAgenda,


### PR DESCRIPTION
Resolves the next tranche of `react-hooks/exhaustive-deps` warnings in `App.jsx` and lowers the lint ratchet from `--max-warnings 17` to `--max-warnings 4`.

## Real staleness fix
- **Routines-done effect (1495)** now lists `mobileActiveTab` / `handleRoutinesDone` / `setMobileActiveTab` so it reads current state rather than the first-render closure.

## Stable / correct dependency additions
- `swipeSchedulingInboxTaskId` ref (1261)
- `isVisibleForUser` in `resolveTaskMatch` and the HyperGlance visible-projects memos (6062, 6712)
- `setSelectedTags` setter (6646)
- `myFrames` in the frame-nudge effect (7212)

## Intentional-omission annotations
Declaration-order / stable-ref cases that would needlessly re-bind or hit a TDZ if the named value were added, so they're annotated with `// eslint-disable-next-line react-hooks/exhaustive-deps` and a rationale comment: DB engine setup, native-action drain, cloud migration notice, TRMNL push debounce, auto-backup interval, voice apply, widget snapshot.

## Remaining
The final 4 warnings are the entangled `getTasksForDate` / frame-nudge cluster (7049, 7068, 7201, 7441), deferred to a final dedicated PR.

## Verification
- `npm run lint` — 0 errors, 4 warnings (passes at `--max-warnings 4`)
- `npm test` — 411 passing
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_