### PR TITLE
exhaustive-deps App.jsx final: getTasksForDate cluster (4 → 0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:android": "./node_modules/.bin/vite build --config vite.config.android.js",
     "build:ios": "./node_modules/.bin/vite build --config vite.config.ios.js",
     "preview": "vite preview",
-    "lint": "eslint src --max-warnings 4",
+    "lint": "eslint src --max-warnings 0",
     "test": "vitest run",
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
     "build:calendar-helper": "bash scripts/build-calendar-helper.sh",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7046,7 +7046,9 @@ const DayPlanner = () => {
       committedMinutes,
       isEmpty: allTasks.length === 0 && deadlines.length === 0,
     };
-  }, [tasks, recurringTasks, unscheduledTasks, getOccurrencesInRange, dateToString, isVisibleForUser]);
+    // getOccurrencesInRange and dateToString are module-level imports, not
+    // reactive values, so they are intentionally not listed.
+  }, [tasks, recurringTasks, unscheduledTasks, isVisibleForUser]);
 
   // Group tasks + recurring by date for O(1) lookups (avoids repeated O(n) scans)
   const tasksByDate = useMemo(() => {
@@ -7064,11 +7066,13 @@ const DayPlanner = () => {
     return map;
   }, [tasks, expandedRecurringTasks, isVisibleForUser]);
 
-  // Helper to get tasks for a specific date (must be after filterByTags)
-  const getTasksForDate = (date) => {
+  // Helper to get tasks for a specific date (must be after filterByTags).
+  // Memoized so downstream useCallback/useMemo consumers stay stable; only
+  // re-created when the tag filter or the date-grouped task map changes.
+  const getTasksForDate = useCallback((date) => {
     const dateStr = dateToString(date);
     return filterByTags(tasksByDate[dateStr] || []);
-  };
+  }, [filterByTags, tasksByDate]);
 
   // --- GTD Frames: Instance computation + Available time calculation ---
 
@@ -7198,7 +7202,9 @@ const DayPlanner = () => {
       setFrameNudgeError('Could not get suggestion.');
     }
     setFrameNudgeLoading(false);
-  }, [agendaNowMarker, aiConfig, currentTime, extractTags, getFrameInstancesForDate, getTasksForDate, renderTitleWithoutTags, tasks, unscheduledTasks]);
+    // extractTags and renderTitleWithoutTags are module-level imports, not
+    // reactive values, so they are intentionally not listed.
+  }, [agendaNowMarker, aiConfig, currentTime, getFrameInstancesForDate, getTasksForDate, isVisibleForUser, unscheduledTasks]);
 
   // Auto-trigger frame nudge when entering a new Frame
   const prevFrameNudgeKeyRef = useRef(null);
@@ -7438,7 +7444,9 @@ const DayPlanner = () => {
 
     const remainingMinutes = blockEnd - nowMin;
     return remainingMinutes >= 45;
-  }, [currentTime, tasks, expandedRecurringTasks]);
+    // getTasksForDate already tracks tasks/expandedRecurringTasks (via tasksByDate)
+    // and the active tag filter, so it is the single correct dependency here.
+  }, [currentTime, getTasksForDate]);
   focusModeAvailableRef.current = focusModeAvailable;
 
   // ── Electron desktop bridge ──────────────────────────────────────────────


### PR DESCRIPTION
The last `react-hooks/exhaustive-deps` warnings in `App.jsx`, fixed together because they were entangled around `getTasksForDate`. Drops the lint ratchet to a hard `--max-warnings 0`.

## The knot
`getTasksForDate` was a plain function recreated on every render, so any `useCallback`/`useMemo` that depended on it churned, and consumers worked around that by listing the underlying `tasks`/`expandedRecurringTasks` instead. Stabilizing it untangles all four:

- **Memoize `getTasksForDate`** with `useCallback([filterByTags, tasksByDate])`. `filterByTags` is already a stable `useCallback` and `tasksByDate` a `useMemo`, so the helper now keeps a stable identity and stops invalidating downstream deps (e.g. `computeAvailableSlots`).
- **`focusModeAvailable`** now depends on `getTasksForDate` directly rather than proxying via `tasks`/`expandedRecurringTasks`. The helper already tracks those (through `tasksByDate`) *plus* the active tag filter, so it's the single correct dependency — and slightly more correct, since the old proxy missed tag-filter changes.
- **`generateFrameNudge`** gains the genuinely-missing `isVisibleForUser` (used to filter inbox candidates), and drops three deps that were never reactive: the module imports `extractTags` / `renderTitleWithoutTags` and the unreferenced `tasks`.
- **Tomorrow-summary memo** drops its unnecessary module-import deps `getOccurrencesInRange` / `dateToString`.

## Result
`App.jsx` is fully clean under `react-hooks/exhaustive-deps`. With this merged the codebase passes `eslint src --max-warnings 0`, so the gate is now hard — any new dependency-array mistake fails CI.

This completes the multi-PR ratchet that started at 169 warnings.

## Verification
- `npm run lint` — 0 warnings (at `--max-warnings 0`)
- `npm test` — 411 passing
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_