### PR TITLE
Fix startup crash: TDZ on swipeSchedulingInboxTaskId in effect deps

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 135
+        versionCode = 136
         versionName = "3.8"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1258,7 +1258,12 @@ const DayPlanner = () => {
     if (!showAddTask) {
       swipeSchedulingInboxTaskId.current = null;
     }
-  }, [showAddTask, swipeSchedulingInboxTaskId]);
+    // swipeSchedulingInboxTaskId is a stable ref from useDragDrop, which is
+    // declared later in this component. Listing it here would evaluate the ref
+    // in its temporal dead zone on first render and crash. The body only reads
+    // it after commit, so keying on showAddTask alone is correct.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showAddTask]);
 
   // Extract partial tag being typed at cursor position
   // Format time for display (respects 12h/24h setting)


### PR DESCRIPTION
## The crash
The app crashed on load with `ReferenceError: Cannot access 'X' before initialization` (minified, surfaced as `'Go'`), taking down the whole Day Planner before it could mount.

## Root cause
The add-task cleanup effect (around line 1257) listed `swipeSchedulingInboxTaskId` in its dependency array:

```js
useEffect(() => {
  if (!showAddTask) {
    swipeSchedulingInboxTaskId.current = null;
  }
}, [showAddTask, swipeSchedulingInboxTaskId]);   // <- ref declared ~1500 lines later
```

That ref is returned by `useDragDrop`, which is deliberately declared much later in the component (around line 2762, after its own dependencies are set up). React evaluates a hook's dependency array **during render, in source order**, so on first render this array referenced the ref while it was still in its temporal dead zone and threw immediately.

The effect *body* only reads the ref after commit, so it was never the problem. Only the dependency-array reference crashed.

## The fix
Key the effect on `showAddTask` alone (the ref is stable, so it never needs to be a dependency) and annotate why the ref is intentionally omitted.

This regression came from the exhaustive-deps batch 3d change, which added the ref to the array to satisfy `react-hooks/exhaustive-deps`. The lint rule cannot tell that the destructured value is a ref, so the correct resolution is an annotation, not inclusion.

## Why CI did not catch it
This is a runtime-only failure that requires the full component to mount. The build compiles it fine and the unit tests do not mount `DayPlanner`, so neither surfaces it. I additionally ran a static scan of every hook dependency array in `App.jsx` for identifiers declared later than the hook (the TDZ pattern); after this fix the scan is clean, so this was the only occurrence.

## Verification
- `npm run lint` — 0 warnings
- `npm test` — 411 passing
- `npm run build` — clean
- Static TDZ scan over all hook dependency arrays — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcyuhXrVGSisdnJm87BByU)_