### PR TITLE
Add Quick Settings tiles for voice/inbox/scheduled task actions

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 136
+        versionCode = 137
         versionName = "3.8"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/AndroidManifest.xml
+++ b/dayglance-android/app/src/main/AndroidManifest.xml
@@ -128,6 +128,41 @@
             android:exported="false"
             android:parentActivityName=".MainActivity" />
 
+        <!-- Quick Settings tiles — mirror the launcher shortcuts. Each launches
+             MainActivity with the matching action; JS picks it up via SharedDataStore. -->
+        <service
+            android:name=".tiles.VoiceInputTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_shortcut_voice"
+            android:label="@string/tile_voice_label"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".tiles.AddInboxTaskTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_shortcut_add_task"
+            android:label="@string/tile_add_inbox_label"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".tiles.AddScheduledTaskTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_shortcut_add_task"
+            android:label="@string/tile_add_scheduled_label"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
         <!-- Home screen widget: full agenda -->
         <receiver
             android:name=".widget.DayGlanceWidget"

--- a/dayglance-android/app/src/main/java/com/dayglance/app/tiles/AddInboxTaskTileService.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/tiles/AddInboxTaskTileService.kt
@@ -1,0 +1,8 @@
+package com.dayglance.app.tiles
+
+import com.dayglance.app.MainActivity
+
+/** Quick Settings tile: add an inbox task (mirrors the "Inbox Task" launcher shortcut). */
+class AddInboxTaskTileService : TaskTileService() {
+    override val action = MainActivity.ACTION_ADD_INBOX_TASK
+}

--- a/dayglance-android/app/src/main/java/com/dayglance/app/tiles/AddScheduledTaskTileService.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/tiles/AddScheduledTaskTileService.kt
@@ -1,0 +1,8 @@
+package com.dayglance.app.tiles
+
+import com.dayglance.app.MainActivity
+
+/** Quick Settings tile: add a scheduled task (mirrors the "Scheduled Task" launcher shortcut). */
+class AddScheduledTaskTileService : TaskTileService() {
+    override val action = MainActivity.ACTION_ADD_TASK
+}

--- a/dayglance-android/app/src/main/java/com/dayglance/app/tiles/TaskTileService.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/tiles/TaskTileService.kt
@@ -1,0 +1,50 @@
+package com.dayglance.app.tiles
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.os.Build
+import android.service.quicksettings.TileService
+import com.dayglance.app.MainActivity
+
+/**
+ * Base Quick Settings tile that launches MainActivity with a specific action.
+ *
+ * These tiles mirror the static launcher shortcuts (see res/xml/shortcuts.xml):
+ * tapping a tile drops the user straight into voice input, the inbox add-task
+ * modal, or the scheduled add-task modal. The action is delivered to
+ * MainActivity, which stores a pending flag in SharedDataStore that the JS layer
+ * reads on the next visibilitychange — the exact same path the shortcuts use.
+ *
+ * Subclasses supply the action string (one of MainActivity.ACTION_*).
+ */
+abstract class TaskTileService : TileService() {
+
+    /** One of MainActivity.ACTION_VOICE_INPUT / ACTION_ADD_INBOX_TASK / ACTION_ADD_TASK. */
+    protected abstract val action: String
+
+    override fun onClick() {
+        super.onClick()
+
+        val intent = Intent(action).apply {
+            setClassName(packageName, MainActivity::class.java.name)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        }
+
+        // startActivityAndCollapse(Intent) was deprecated in API 34 and now throws
+        // UnsupportedOperationException — it requires a PendingIntent there. Older
+        // platforms only accept the Intent overload.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val pending = PendingIntent.getActivity(
+                this,
+                0,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            // unlockAndRun ensures the activity launches even from the locked QS panel.
+            unlockAndRun { startActivityAndCollapse(pending) }
+        } else {
+            @Suppress("DEPRECATION", "StartActivityAndCollapseDeprecated")
+            unlockAndRun { startActivityAndCollapse(intent) }
+        }
+    }
+}

--- a/dayglance-android/app/src/main/java/com/dayglance/app/tiles/VoiceInputTileService.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/tiles/VoiceInputTileService.kt
@@ -1,0 +1,8 @@
+package com.dayglance.app.tiles
+
+import com.dayglance.app.MainActivity
+
+/** Quick Settings tile: open voice input (mirrors the "Voice Input" launcher shortcut). */
+class VoiceInputTileService : TaskTileService() {
+    override val action = MainActivity.ACTION_VOICE_INPUT
+}

--- a/dayglance-android/app/src/main/res/values/strings.xml
+++ b/dayglance-android/app/src/main/res/values/strings.xml
@@ -11,4 +11,8 @@
     <string name="shortcut_add_task_long">Add a scheduled task</string>
     <string name="shortcut_add_inbox_task_short">Inbox Task</string>
     <string name="shortcut_add_inbox_task_long">Add a task to inbox</string>
+    <!-- Quick Settings tile labels (mirror the launcher shortcuts) -->
+    <string name="tile_voice_label">Voice Task</string>
+    <string name="tile_add_inbox_label">Inbox Task</string>
+    <string name="tile_add_scheduled_label">Scheduled Task</string>
 </resources>


### PR DESCRIPTION
## What changed

Adds three Android **Quick Settings tiles** that mirror the existing launcher shortcuts:

| Tile | Action | Behaviour |
|------|--------|-----------|
| Voice Task | `ACTION_VOICE_INPUT` | Opens the voice recording modal |
| Inbox Task | `ACTION_ADD_INBOX_TASK` | Opens the add-task modal in inbox mode |
| Scheduled Task | `ACTION_ADD_TASK` | Opens the add-task modal in scheduled mode |

Users can drop these into the notification-shade Quick Settings panel for one-tap access — the same three quick actions already exposed via long-pressing the app icon.

## How it works

Each tile reuses the **exact path the launcher shortcuts already use**: the `TileService` launches `MainActivity` with the matching action, `MainActivity` stores a pending flag in `SharedDataStore`, and the JS layer reads it on the next `visibilitychange`. No new JS-side wiring was needed.

- New `tiles/` package with a shared `TaskTileService` base plus three thin subclasses (`VoiceInputTileService`, `AddInboxTaskTileService`, `AddScheduledTaskTileService`).
- `TaskTileService` uses the `PendingIntent` overload of `startActivityAndCollapse` on API 34+ (the `Intent` overload throws there) and falls back to the `Intent` overload on older platforms, wrapping both in `unlockAndRun` so the tiles work from a locked QS panel.
- Three `<service>` entries in `AndroidManifest.xml` with `BIND_QUICK_SETTINGS_TILE` and the `QS_TILE` intent filter, reusing the existing shortcut icons.
- Three tile label strings in `strings.xml`.

## Notes

This environment has no Android SDK, so the change was not compiled here — it's straightforward Kotlin following the established shortcut/bridge patterns in the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ay31NsRciuyRh6153t1Gg)_