### PR TITLE
Add iOS Control Center controls for voice/inbox/scheduled task actions

### DIFF
--- a/dayglance-ios/DayGlanceWidget/ControlWidgets.swift
+++ b/dayglance-ios/DayGlanceWidget/ControlWidgets.swift
@@ -1,0 +1,127 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+/// Control Center controls (iOS 18+) that mirror the Home Screen Quick Actions:
+/// add a scheduled task, add an inbox task, and capture a task by voice.
+///
+/// A control button can only trigger an `AppIntent` (unlike home-screen widgets,
+/// which can use a `Link`/`widgetURL`). So each control runs a tiny intent that
+/// stashes a pending action in the shared App Group and opens the app
+/// (`openAppWhenRun`). On foreground the web layer drains it via
+/// `getWidgetPendingAction` → `nativeGetWidgetPendingAction()` — the same App
+/// Group slot the widget bridge already reads (see WidgetBridge.getPendingAction).
+///
+/// Gated to iOS 18 because the Controls (WidgetKit `ControlWidget`) API does not
+/// exist before then; users on iOS 16/17 keep the Home Screen Quick Actions.
+
+// MARK: - Shared store
+
+@available(iOS 18.0, *)
+private enum ControlActionStore {
+    static func write(_ action: String) {
+        // Same suite + key the widget bridge drains; value shape matches the
+        // existing widget intents ({ "action": ... }).
+        UserDefaults(suiteName: "group.com.dayglance.app")?
+            .set(["action": action], forKey: "widgetPendingAction")
+    }
+}
+
+// MARK: - Intents
+
+// iOS 18.4 tightened sandboxing for AppIntents running in the widget process when
+// the main app is not alive. Conforming to ForegroundContinuableIntent (in the app
+// process only) routes the intent through the app, matching how the existing widget
+// intents avoid entitlement errors. See WidgetIntents.swift.
+@available(iOS 18.0, *)
+@available(iOSApplicationExtension, unavailable)
+extension AddScheduledTaskControlIntent: ForegroundContinuableIntent {}
+
+@available(iOS 18.0, *)
+@available(iOSApplicationExtension, unavailable)
+extension AddInboxTaskControlIntent: ForegroundContinuableIntent {}
+
+@available(iOS 18.0, *)
+@available(iOSApplicationExtension, unavailable)
+extension VoiceInputControlIntent: ForegroundContinuableIntent {}
+
+@available(iOS 18.0, *)
+struct AddScheduledTaskControlIntent: AppIntent {
+    static let title: LocalizedStringResource = "Add Scheduled Task"
+    // Task data lives in the web layer, so the app must be foregrounded to act.
+    static var openAppWhenRun: Bool = true
+
+    init() {}
+
+    func perform() async throws -> some IntentResult {
+        ControlActionStore.write("newScheduledTask")
+        return .result()
+    }
+}
+
+@available(iOS 18.0, *)
+struct AddInboxTaskControlIntent: AppIntent {
+    static let title: LocalizedStringResource = "Add Inbox Task"
+    static var openAppWhenRun: Bool = true
+
+    init() {}
+
+    func perform() async throws -> some IntentResult {
+        ControlActionStore.write("newInboxTask")
+        return .result()
+    }
+}
+
+@available(iOS 18.0, *)
+struct VoiceInputControlIntent: AppIntent {
+    static let title: LocalizedStringResource = "Add Task by Voice"
+    static var openAppWhenRun: Bool = true
+
+    init() {}
+
+    func perform() async throws -> some IntentResult {
+        ControlActionStore.write("voiceInput")
+        return .result()
+    }
+}
+
+// MARK: - Controls
+
+@available(iOS 18.0, *)
+struct AddScheduledTaskControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: "com.dayglance.control.scheduledTask") {
+            ControlWidgetButton(action: AddScheduledTaskControlIntent()) {
+                Label("Scheduled Task", systemImage: "calendar.badge.plus")
+            }
+        }
+        .displayName("Scheduled Task")
+        .description("Add a task to today's schedule.")
+    }
+}
+
+@available(iOS 18.0, *)
+struct AddInboxTaskControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: "com.dayglance.control.inboxTask") {
+            ControlWidgetButton(action: AddInboxTaskControlIntent()) {
+                Label("Inbox Task", systemImage: "tray.and.arrow.down.fill")
+            }
+        }
+        .displayName("Inbox Task")
+        .description("Quickly capture a task to your inbox.")
+    }
+}
+
+@available(iOS 18.0, *)
+struct VoiceInputControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: "com.dayglance.control.voiceInput") {
+            ControlWidgetButton(action: VoiceInputControlIntent()) {
+                Label("Voice Task", systemImage: "mic.fill")
+            }
+        }
+        .displayName("Voice Task")
+        .description("Capture a task by voice.")
+    }
+}

--- a/dayglance-ios/DayGlanceWidget/DayGlanceWidgetBundle.swift
+++ b/dayglance-ios/DayGlanceWidget/DayGlanceWidgetBundle.swift
@@ -7,5 +7,12 @@ struct DayGlanceWidgetBundle: WidgetBundle {
         UpNextWidget()
         GoalWidget()
         ProjectWidget()
+        // Control Center controls — iOS 18+ only (the Controls API doesn't exist
+        // before then). Mirror the Home Screen Quick Actions.
+        if #available(iOS 18.0, *) {
+            AddScheduledTaskControl()
+            AddInboxTaskControl()
+            VoiceInputControl()
+        }
     }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallba
 import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Moon, Sun, Upload, Inbox, AlertCircle, Calendar, Check, RefreshCw, Palette, Trash2, Undo2, BarChart3, SkipForward, Hash, MoreHorizontal, Save, Menu, BrainCircuit, AlertTriangle, FileText, ExternalLink, CheckSquare, HelpCircle, Sparkles, Link, GripHorizontal, Play, Pause, Trophy, Cloud, Settings, Search, Bell, Target, TrendingUp, Zap, CalendarDays, Ban, Volume2, VolumeX, Pencil, Eye, Filter, Smartphone, CheckCircle, Pin, PinOff, NotebookPen, MapPin, BookOpen, Flag, FolderOpen, Droplets, Footprints, Dumbbell, Apple, Cigarette, Coffee, Flame, Heart, ListChecks, Minus, Wine, Candy, Pill, Activity, CupSoda, Mic, MicOff, Loader, Key, Server, Wifi, WifiOff, LayoutGrid, RotateCcw } from 'lucide-react';
 import { mergeTaskArrays, mergeSyncData } from './mergeSync.js';
 import { hasNativeCalendar, electronGetCalendars, electronGetEventsByDate, electronRequestCalendarAccess, nativeEventToTask } from './utils/nativeCalendar.js';
-import { isNativeAndroid, isNativeApp, isNativeIOS, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeSetVaultSettings, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording, triggerHaptic } from './native.js';
+import { isNativeAndroid, isNativeApp, isNativeIOS, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeSetVaultSettings, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording, nativeGetWidgetPendingAction, triggerHaptic } from './native.js';
 import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, tryRestoreVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, listVaultNotes, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
 import { loadAIConfig, saveAIConfig, aiComplete, aiJSON, aiTranscribe, supportsTranscription, testConnection, DEFAULT_CONFIG, PROVIDER_MODELS, PROVIDER_LABELS } from './ai.js';
 import { voiceParseSystemPrompt, voiceParseUserPrompt, taskSuggestSystemPrompt, taskSuggestUserPrompt, frameNudgeSystemPrompt, frameNudgeUserPrompt, rescheduleSystemPrompt, rescheduleUserPrompt, aiSubtasksSystemPrompt, aiSubtasksUserPrompt, morningSummarySystemPrompt, morningSummaryUserPrompt, eveningReflectionSystemPrompt, eveningReflectionUserPrompt, weeklySummarySystemPrompt, weeklySummaryUserPrompt, smartScheduleSystemPrompt, smartScheduleUserPrompt } from './ai-prompts.js';
@@ -1634,6 +1634,20 @@ const DayPlanner = () => {
             }
           }
         }
+        // iOS Control Center controls write a pending action to the App Group
+        // (see ControlWidgets.swift); drain it the same way as quick actions.
+        const widgetAction = nativeGetWidgetPendingAction();
+        if (widgetAction?.action) {
+          const wa = widgetAction.action;
+          if (wa === 'newScheduledTask') openNewTaskFormRef.current?.();
+          else if (wa === 'newInboxTask') openNewInboxTaskRef.current?.();
+          else if (wa === 'voiceInput') {
+            voiceAutoStartRef.current = true;
+            setShowVoiceInput(true);
+          }
+          else if (wa === 'startFocus') setShowFocusMode(true);
+          else if (wa === 'completeTask' && widgetAction.taskId) toggleComplete(widgetAction.taskId);
+        }
       }, 200);
       if (window.DayGlanceNative?.getShareExtensionPending) {
         try {
@@ -1878,6 +1892,19 @@ const DayPlanner = () => {
           }
         } catch (_) {}
       }
+    }
+    // iOS Control Center controls (cold launch): drain the App Group pending action.
+    const widgetAction = nativeGetWidgetPendingAction();
+    if (widgetAction?.action) {
+      const wa = widgetAction.action;
+      if (wa === 'newScheduledTask') openNewTaskFormRef.current?.();
+      else if (wa === 'newInboxTask') openNewInboxTaskRef.current?.();
+      else if (wa === 'voiceInput') {
+        voiceAutoStartRef.current = true;
+        setShowVoiceInput(true);
+      }
+      else if (wa === 'startFocus') setShowFocusMode(true);
+      else if (wa === 'completeTask' && widgetAction.taskId) toggleComplete(widgetAction.taskId);
     }
     // Drains pending native actions once after load (keyed on dataLoaded). The
     // setters/voiceAutoStartRef are stable; toggleComplete is read at drain time.


### PR DESCRIPTION
## What changed

Adds three **iOS Control Center controls** (iOS 18+) that mirror the existing Home Screen Quick Actions — the iOS counterpart to the Android Quick Settings tiles:

| Control | Action | SF Symbol | Behaviour |
|---------|--------|-----------|-----------|
| Voice Task | `voiceInput` | `mic.fill` | Opens the voice recording modal |
| Inbox Task | `newInboxTask` | `tray.and.arrow.down.fill` | Opens the add-task modal in inbox mode |
| Scheduled Task | `newScheduledTask` | `calendar.badge.plus` | Opens the add-task modal in scheduled mode |

Users on iOS 18+ can add these to Control Center (or the Lock Screen / Action Button) for one-tap access to the same three quick actions already exposed via long-pressing the app icon.

## How it works

A Control Center button can only trigger an `AppIntent` (unlike home-screen widgets, which can use a `Link`/`widgetURL`). So each control runs a tiny intent that:

1. Writes a pending action (`{ "action": "voiceInput" }`, etc.) to the shared App Group (`group.com.dayglance.app`, key `widgetPendingAction`).
2. Sets `openAppWhenRun = true` to foreground the app.

On foreground, the web layer drains it through the **existing** `getWidgetPendingAction` bridge → `nativeGetWidgetPendingAction()` — the same App Group slot `WidgetBridge.getPendingAction()` already reads and clears. That drain helper existed but was previously unused on the JS side; this wires it into both the warm-foreground and cold-launch drains in `App.jsx`, reusing the exact handlers the Quick Actions already call (`openNewTaskFormRef`, `openNewInboxTaskRef`, `voiceAutoStartRef` + `setShowVoiceInput`; plus `startFocus`/`completeTask` for completeness).

### Files
- **`DayGlanceWidget/ControlWidgets.swift`** (new): three `ControlWidget`s + their `AppIntent`s, all gated `@available(iOS 18.0, *)`.
- **`DayGlanceWidget/DayGlanceWidgetBundle.swift`**: register the controls behind `if #available(iOS 18.0, *)`.
- **`src/App.jsx`**: import and drain `nativeGetWidgetPendingAction()` in the two existing native-action drains.

## Notes & caveats

- **iOS 18+ only.** The WidgetKit Controls API doesn't exist before iOS 18, so the controls are availability-gated and only appear on iOS 18+. Users on iOS 16/17 keep the Home Screen Quick Actions unchanged — this is purely additive, no regression. There is no pre-iOS-18 API for custom Control Center toggles.
- **Build requirement:** because the Controls symbols live in the iOS 18 SDK, this must be built with **Xcode 16+** (iOS 18 SDK). The widget target's deployment target stays at 17.0; `@available` handles the runtime gate.
- This environment has no Xcode/iOS toolchain or `node_modules`, so the Swift and JS changes were not compiled/linted here — they follow the established widget-intent and native-drain patterns in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ay31NsRciuyRh6153t1Gg)_