### PR TITLE
Fix iOS build: drop ForegroundContinuableIntent from Control Center intents

### DIFF
--- a/dayglance-ios/DayGlanceWidget/ControlWidgets.swift
+++ b/dayglance-ios/DayGlanceWidget/ControlWidgets.swift
@@ -29,21 +29,13 @@ private enum ControlActionStore {
 
 // MARK: - Intents
 
-// iOS 18.4 tightened sandboxing for AppIntents running in the widget process when
-// the main app is not alive. Conforming to ForegroundContinuableIntent (in the app
-// process only) routes the intent through the app, matching how the existing widget
-// intents avoid entitlement errors. See WidgetIntents.swift.
-@available(iOS 18.0, *)
-@available(iOSApplicationExtension, unavailable)
-extension AddScheduledTaskControlIntent: ForegroundContinuableIntent {}
-
-@available(iOS 18.0, *)
-@available(iOSApplicationExtension, unavailable)
-extension AddInboxTaskControlIntent: ForegroundContinuableIntent {}
-
-@available(iOS 18.0, *)
-@available(iOSApplicationExtension, unavailable)
-extension VoiceInputControlIntent: ForegroundContinuableIntent {}
+// These intents only stash a pending action in the shared App Group and foreground
+// the app (openAppWhenRun); they run no app-process-only code, so — unlike the
+// home-screen widget intents in WidgetIntents.swift — they don't need
+// ForegroundContinuableIntent. The widget extension holds the App Group entitlement,
+// so the UserDefaults write succeeds in-process. (Conforming an iOS 18-only intent to
+// ForegroundContinuableIntent with @available(iOSApplicationExtension, unavailable)
+// also fails to compile in the extension target, which is what this avoids.)
 
 @available(iOS 18.0, *)
 struct AddScheduledTaskControlIntent: AppIntent {


### PR DESCRIPTION
## Problem

The Control Center controls added in #1076 broke the `DayGlanceWidget` build with three errors:

```
'AddScheduledTaskControlIntent' is only available in iOS 18.0 or newer
'AddInboxTaskControlIntent' is only available in iOS 18.0 or newer
'VoiceInputControlIntent' is only available in iOS 18.0 or newer
```

## Cause

Each intent had a `ForegroundContinuableIntent` conformance declared as:

```swift
@available(iOS 18.0, *)
@available(iOSApplicationExtension, unavailable)
extension AddScheduledTaskControlIntent: ForegroundContinuableIntent {}
```

In the widget **app-extension** target, the `@available(iOSApplicationExtension, unavailable)` path doesn't honor the `iOS 18.0` availability floor for the referenced iOS 18-only intent type, so the compiler flags the type reference against the widget target's iOS 17.0 deployment floor.

This mirrored the pattern in `WidgetIntents.swift`, but that pattern was written for iOS 17-available intents — it doesn't hold up for iOS 18-only types in the extension target.

## Fix

Remove the three `ForegroundContinuableIntent` extensions. They aren't needed:

- The control intents only stash a pending action in the shared App Group (`group.com.dayglance.app`) — the widget extension already holds that entitlement, so the `UserDefaults` write succeeds in-process.
- They foreground the app via `openAppWhenRun = true`; nothing in `perform()` needs to run in the main-app process, so there's no foreground continuation to perform.

Behavior is unchanged — the controls still write the pending action and open the app, and the JS layer drains it via `getWidgetPendingAction` exactly as before. Net `-15 / +7` lines (three extensions removed, comment updated to explain why the conformance is intentionally omitted).

## Notes

This environment has no Xcode toolchain, so the fix wasn't compiled here — but it directly removes the flagged declarations, which were the only references producing the three errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ay31NsRciuyRh6153t1Gg)_