### PR TITLE
Add GLANCEvault "Test Connection" pre-save credential check

### DIFF
--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -4,6 +4,7 @@ import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { setupEncryptionKey, setSyncPassphrase, clearEncryptionKey, getSyncPassphrase } from '../utils/crypto.js';
 import { getVaultConfig, setVaultConfig } from '../sync/vaultConfig.js';
 import { createDbEngine, resetDbRootKey } from '../sync/dbEngine.js';
+import { testVaultConnection } from '../sync/vaultConnectionTest.js';
 import { useTranslation } from 'react-i18next';
 
 // Cloud sync settings form (extracted to avoid hooks-in-conditional issues)
@@ -45,6 +46,10 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   const [vaultBootstrapping, setVaultBootstrapping] = useState(false);
   const [vaultBootstrapError, setVaultBootstrapError] = useState(null);
   const [showVaultToken, setShowVaultToken] = useState(false);
+  // Pre-save vault credential check (mirrors the WebDAV Test Connection UX above,
+  // but the LOGIC is the vault getSalt probe — see testVaultConnection).
+  const [vaultTesting, setVaultTesting] = useState(false);
+  const [vaultTestResult, setVaultTestResult] = useState(null);
 
   const activeProvider = cloudSyncProviders[formData.provider] || provider;
   const requiredFieldsFilled = activeProvider.configFields.every(f => formData[f.key]) && !!formData.syncFolder;
@@ -202,6 +207,24 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
     setVaultSyncing(true);
     try { await vaultSyncNow(); } catch { /* surfaced via vaultError */ }
     finally { setVaultSyncing(false); }
+  };
+
+  // Pre-save TEST only: probe the entered vault credentials with an authenticated
+  // getSalt and surface a typed outcome. Does NOT save, enable, or derive a key —
+  // it just tells the user whether the credentials work, so bad vault credentials
+  // no longer save silently and fail invisibly at first sync.
+  const handleVaultTest = async () => {
+    setVaultTesting(true);
+    setVaultTestResult(null);
+    try {
+      const result = await testVaultConnection({ vaultUrl, vaultToken, accountId: vaultAccountId });
+      setVaultTestResult(result);
+    } catch {
+      // testVaultConnection classifies every failure itself; this is defensive.
+      setVaultTestResult({ ok: false, message: 'Could not reach the vault at this URL.' });
+    } finally {
+      setVaultTesting(false);
+    }
   };
 
   // Shared section-header style (uppercase, like the lastGLANCE layout).
@@ -455,6 +478,24 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
                 className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
               />
             </div>
+            {/* Vault actions: pre-save Test Connection (mirrors the WebDAV button
+                above), with the typed outcome shown below. This verifies the
+                credentials with a getSalt probe; it does not save or enable. */}
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleVaultTest}
+                disabled={vaultTesting || !vaultFilled}
+                className={secondaryBtn}
+              >
+                {vaultTesting ? 'Testing...' : 'Test Connection'}
+              </button>
+            </div>
+            {vaultTestResult && (
+              <p className={`text-sm ${vaultTestResult.ok ? 'text-green-500' : 'text-red-500'}`}>
+                {vaultTestResult.message}
+              </p>
+            )}
             <p className={`text-xs ${textSecondary}`}>Saving a GLANCEvault change reloads the app so the sync engines reconstruct.</p>
             {!vaultEncryptionReady && (
               <p className="text-xs text-amber-500">

--- a/src/intents/vaultIntentsSetup.js
+++ b/src/intents/vaultIntentsSetup.js
@@ -33,7 +33,7 @@ export class VaultIntentsSetupError extends Error {
 // latter to the former — the same shaping src/sync/dbEngine.js does for the sync
 // vault client — so getSalt routes through the exact transport the DB intents
 // path already uses on every platform.
-function adaptFetchForVaultClient(rawFetch) {
+export function adaptFetchForVaultClient(rawFetch) {
   return async (url, { method = 'GET', headers = {}, body } = {}) => {
     const r = await rawFetch(method, url, headers, body ?? null);
     if (!r) throw new TypeError('Failed to fetch');

--- a/src/sync/vaultConnectionTest.js
+++ b/src/sync/vaultConnectionTest.js
@@ -1,0 +1,136 @@
+// GLANCEvault credential pre-save verification (Test Connection).
+//
+// Verifies entered vault credentials BEFORE the user saves/enables, closing the
+// gap where bad vault credentials saved silently and only failed (invisibly) at
+// first sync. The probe is an authenticated GET /salt/:accountId — the exact call
+// the vault intents key setup already uses (setupVaultIntentsEncryption) — issued
+// through the SAME vault client + native-safe fetch path the vault SYNC/intents
+// transports use. It does NOT use a plain global fetch (which fails inside the
+// native WebView), and it does NOT save, activate, or derive any key.
+//
+// This is React-free and fully injectable so it works on every platform and tests
+// can drive each outcome without network/IndexedDB.
+
+import { createVaultClient } from '@glance-apps/sync';
+import { defaultVaultFetch } from '../intents/dbIntentsTransport.js';
+import { adaptFetchForVaultClient } from '../intents/vaultIntentsSetup.js';
+
+// Typed, DISTINCT outcomes. `ok: true` means the credentials are good enough to
+// save — that includes SALT_NOT_ESTABLISHED, which is a FRESH account before its
+// first sync (the vault legitimately has no salt yet). Reporting that as an error
+// would wrongly block first-device setup, so it is ACCEPTABLE, not a failure.
+export const VAULT_TEST_OUTCOMES = {
+  SUCCESS: 'SUCCESS',
+  SALT_NOT_ESTABLISHED: 'SALT_NOT_ESTABLISHED',
+  AUTH_FAILURE: 'AUTH_FAILURE',
+  FORBIDDEN: 'FORBIDDEN',
+  NETWORK: 'NETWORK',
+  SERVER_ERROR: 'SERVER_ERROR',
+  BAD_INPUT: 'BAD_INPUT',
+};
+
+/**
+ * Probe the vault with the entered credentials and classify the result.
+ *
+ * @param {{vaultUrl?:string, vaultToken?:string, accountId?:string}} credentials
+ * @param {object} [opts] - injection seams for tests/wiring:
+ *   vaultClient (default createVaultClient(...) over the native-safe fetch),
+ *   fetchImpl   (positional raw fetch; default defaultVaultFetch())
+ * @returns {Promise<{ok:boolean, code:string, message:string, status?:number}>}
+ *   never rejects — every failure mode is classified into a typed outcome.
+ */
+export async function testVaultConnection(credentials = {}, opts = {}) {
+  const vaultUrl = (credentials.vaultUrl || '').trim();
+  const vaultToken = (credentials.vaultToken || '').trim();
+  const accountId = (credentials.accountId || '').trim();
+
+  if (!vaultUrl || !vaultToken || !accountId) {
+    return {
+      ok: false,
+      code: VAULT_TEST_OUTCOMES.BAD_INPUT,
+      message: 'Enter the vault URL, device token, and account ID first.',
+    };
+  }
+
+  let client;
+  try {
+    // SAME client + native-safe transport the vault intents setup uses, so the
+    // probe rides the working native/electron/browser fetch path (no plain
+    // global fetch that would fail inside the native WebView).
+    client = opts.vaultClient
+      ?? createVaultClient({
+        vaultUrl,
+        vaultToken,
+        fetchImpl: adaptFetchForVaultClient(opts.fetchImpl ?? defaultVaultFetch()),
+      });
+  } catch {
+    // createVaultClient throws synchronously only on a missing url/token (guarded
+    // above) or no fetch implementation — treat as unreachable.
+    return {
+      ok: false,
+      code: VAULT_TEST_OUTCOMES.NETWORK,
+      message: 'Could not reach the vault at this URL.',
+    };
+  }
+
+  try {
+    const salt = await client.getSalt(accountId);
+    if (salt) {
+      return { ok: true, code: VAULT_TEST_OUTCOMES.SUCCESS, message: 'Connected.' };
+    }
+    // getSalt returns null on a 404 OR an empty salt body: the account has no
+    // salt registered yet. This is a brand-new account before its first sync —
+    // ACCEPTABLE, not a failure. Do NOT invent a salt and do NOT block setup.
+    return {
+      ok: true,
+      code: VAULT_TEST_OUTCOMES.SALT_NOT_ESTABLISHED,
+      message: 'Connected — this account will be initialized on first sync.',
+    };
+  } catch (err) {
+    // createVaultClient.getSalt throws a VaultError carrying the HTTP `status` on
+    // any non-OK, non-404 response; the transport throws a plain TypeError
+    // ('Failed to fetch') with NO status on a network/DNS/bad-URL failure.
+    const status = err?.status;
+    if (status === 401) {
+      return {
+        ok: false,
+        code: VAULT_TEST_OUTCOMES.AUTH_FAILURE,
+        message: 'Device token is incorrect.',
+        status,
+      };
+    }
+    if (status === 403) {
+      return {
+        ok: false,
+        code: VAULT_TEST_OUTCOMES.FORBIDDEN,
+        message: 'Account ID not found or not permitted for this token.',
+        status,
+      };
+    }
+    if (typeof status === 'number' && status >= 500) {
+      // 5xx — the server errored. A vault too old to support this app surfaces
+      // here (or only at real sync, via key verification); flag it clearly.
+      return {
+        ok: false,
+        code: VAULT_TEST_OUTCOMES.SERVER_ERROR,
+        message: `The vault returned a server error (${status}). It may be misconfigured or need updating.`,
+        status,
+      };
+    }
+    if (typeof status === 'number') {
+      // Any other unexpected HTTP status from the salt endpoint.
+      return {
+        ok: false,
+        code: VAULT_TEST_OUTCOMES.SERVER_ERROR,
+        message: `The vault rejected the request (status ${status}).`,
+        status,
+      };
+    }
+    // No status → network unreachable, bad URL, DNS failure, CORS, etc.
+    return {
+      ok: false,
+      code: VAULT_TEST_OUTCOMES.NETWORK,
+      message: 'Could not reach the vault at this URL.',
+    };
+  }
+}

--- a/src/sync/vaultConnectionTest.test.js
+++ b/src/sync/vaultConnectionTest.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+import { testVaultConnection, VAULT_TEST_OUTCOMES } from './vaultConnectionTest.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pre-save vault credential check. Exercises the typed-outcome classifier with
+// the vault client injected (opts.vaultClient) — no network — and one end-to-end
+// case that drives the REAL createVaultClient + adaptFetchForVaultClient over an
+// injected POSITIONAL fetch shaped exactly like defaultVaultFetch()'s native
+// bridge result, confirming the probe rides the native-safe transport.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CREDS = { vaultUrl: 'https://vault.example.com', vaultToken: 'tok-123', accountId: 'acct-1' };
+const SALT = new Uint8Array(16).fill(5);
+
+// A VaultError-like throw: createVaultClient.getSalt throws with an HTTP `status`.
+function httpError(status) {
+  const e = new Error(`get salt failed: ${status}`);
+  e.status = status;
+  return e;
+}
+
+describe('testVaultConnection', () => {
+  it('SUCCESS: salt returned → ok, Connected.', async () => {
+    const vaultClient = { getSalt: vi.fn(async () => SALT) };
+    const res = await testVaultConnection(CREDS, { vaultClient });
+
+    expect(vaultClient.getSalt).toHaveBeenCalledWith('acct-1');
+    expect(res.ok).toBe(true);
+    expect(res.code).toBe(VAULT_TEST_OUTCOMES.SUCCESS);
+    expect(res.message).toBe('Connected.');
+  });
+
+  it('SALT-NOT-ESTABLISHED: null salt (fresh account) → ACCEPTABLE, not an error', async () => {
+    const vaultClient = { getSalt: vi.fn(async () => null) }; // 404 / empty salt body
+    const res = await testVaultConnection(CREDS, { vaultClient });
+
+    // The one outcome easy to get wrong: a brand-new account legitimately has no
+    // salt yet. Must be ok:true so it does not block first-device setup.
+    expect(res.ok).toBe(true);
+    expect(res.code).toBe(VAULT_TEST_OUTCOMES.SALT_NOT_ESTABLISHED);
+    expect(res.message).toBe('Connected — this account will be initialized on first sync.');
+  });
+
+  it('AUTH FAILURE: 401 → device token is incorrect', async () => {
+    const vaultClient = { getSalt: vi.fn(async () => { throw httpError(401); }) };
+    const res = await testVaultConnection(CREDS, { vaultClient });
+
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe(VAULT_TEST_OUTCOMES.AUTH_FAILURE);
+    expect(res.message).toBe('Device token is incorrect.');
+  });
+
+  it('FORBIDDEN: 403 → account id not found / not permitted', async () => {
+    const vaultClient = { getSalt: vi.fn(async () => { throw httpError(403); }) };
+    const res = await testVaultConnection(CREDS, { vaultClient });
+
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe(VAULT_TEST_OUTCOMES.FORBIDDEN);
+    expect(res.message).toBe('Account ID not found or not permitted for this token.');
+  });
+
+  it('NETWORK: a thrown TypeError with no status → unreachable', async () => {
+    const vaultClient = { getSalt: vi.fn(async () => { throw new TypeError('Failed to fetch'); }) };
+    const res = await testVaultConnection(CREDS, { vaultClient });
+
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe(VAULT_TEST_OUTCOMES.NETWORK);
+    expect(res.message).toBe('Could not reach the vault at this URL.');
+  });
+
+  it('SERVER_ERROR: 5xx → clear server/needs-updating message', async () => {
+    const vaultClient = { getSalt: vi.fn(async () => { throw httpError(503); }) };
+    const res = await testVaultConnection(CREDS, { vaultClient });
+
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe(VAULT_TEST_OUTCOMES.SERVER_ERROR);
+    expect(res.message).toMatch(/503/);
+  });
+
+  it('BAD_INPUT: missing fields → never hits the network', async () => {
+    const vaultClient = { getSalt: vi.fn() };
+    const res = await testVaultConnection({ vaultUrl: '', vaultToken: '', accountId: '' }, { vaultClient });
+
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe(VAULT_TEST_OUTCOMES.BAD_INPUT);
+    expect(vaultClient.getSalt).not.toHaveBeenCalled();
+  });
+
+  it('native-safe transport: builds the real client over a POSITIONAL fetch and GETs /salt/:accountId', async () => {
+    // Mirrors defaultVaultFetch()'s native/electron contract:
+    //   (method, url, headers, body) -> { status, ok, body } (body a JSON string).
+    // Passing this through adaptFetchForVaultClient + createVaultClient (NO
+    // vaultClient injected) proves the probe reaches the vault via the same
+    // native-safe path vault sync uses — not a plain global fetch.
+    const fetchImpl = vi.fn(async (method, url) => ({
+      status: 200,
+      ok: true,
+      body: JSON.stringify({ salt: 'AAAA' }), // valid base64 → non-null salt
+      _method: method,
+      _url: url,
+    }));
+
+    const res = await testVaultConnection(CREDS, { fetchImpl });
+
+    expect(res.ok).toBe(true);
+    expect(res.code).toBe(VAULT_TEST_OUTCOMES.SUCCESS);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [method, url] = fetchImpl.mock.calls[0];
+    expect(method).toBe('GET');
+    expect(url).toBe('https://vault.example.com/salt/acct-1');
+  });
+
+  it('native-safe transport: a positional fetch that throws → NETWORK', async () => {
+    // defaultVaultFetch throws TypeError('Failed to fetch') when the native bridge
+    // can't complete the request; the probe must classify that as unreachable.
+    const fetchImpl = vi.fn(async () => { throw new TypeError('Failed to fetch'); });
+    const res = await testVaultConnection(CREDS, { fetchImpl });
+
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe(VAULT_TEST_OUTCOMES.NETWORK);
+  });
+});


### PR DESCRIPTION
## What & why

Bad GLANCEvault credentials previously saved silently and only failed **invisibly** at first sync — there was no way to verify a vault URL / device token / account ID before committing to them. This adds an explicit pre-save **Test Connection** button in the vault credential section that verifies the entered credentials with an authenticated `getSalt` probe (the same call vault intents key setup already uses), routed through the **same native-safe vault fetch path** (`defaultVaultFetch` + `adaptFetchForVaultClient`) so it works on native, electron, and the browser — not a plain global fetch that would fail inside the native WebView.

## Typed outcomes

`testVaultConnection` classifies the probe into distinct outcomes with clear user messages:

| Result | Outcome | Message |
|---|---|---|
| Salt returned | SUCCESS | "Connected." |
| Null salt (fresh account before first sync) | **SALT-NOT-ESTABLISHED — acceptable** | "Connected — this account will be initialized on first sync." |
| 401 | AUTH_FAILURE | "Device token is incorrect." |
| 403 | FORBIDDEN | "Account ID not found or not permitted for this token." |
| No status / TypeError | NETWORK | "Could not reach the vault at this URL." |
| 5xx / unexpected status | SERVER_ERROR | clear server / needs-updating message |

The **salt-not-established** case is deliberately treated as acceptable (not a failure) and **no salt is invented**, so a brand-new account is never wrongly blocked from first-device setup.

## UX

The button mirrors the existing WebDAV Test Connection UX (in-progress spinner, green/red result line) but runs the vault `getSalt` logic, not the WebDAV test. It is a **pre-save test only** — it does not save, enable, or derive a key; it just tells the user whether the credentials work.

## Changes

- **`src/sync/vaultConnectionTest.js`** (new) — React-free, injectable `testVaultConnection()` with the typed-outcome classifier.
- **`src/intents/vaultIntentsSetup.js`** — exported `adaptFetchForVaultClient` (non-behavioral) so the probe reuses the exact native-safe adapter.
- **`src/components/CloudSyncSettingsForm.jsx`** — Test Connection button + handler + result display in the vault credential block.
- **`src/sync/vaultConnectionTest.test.js`** (new) — mocks `getSalt` for every outcome, plus two end-to-end cases driving the real `createVaultClient` over an injected positional fetch (shaped like `defaultVaultFetch()`'s native result), asserting `GET …/salt/:accountId` to confirm the probe rides the native-safe transport.

## Verification

- New tests: 9 pass. Full suite: **420 pass**. Lint clean. Production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ekMdzJoWg9xYgCL6BNBTR

---
_Generated by [Claude Code](https://claude.ai/code/session_016ekMdzJoWg9xYgCL6BNBTR)_