### PR TITLE
Fix iCloud helper Swift compile error

### DIFF
--- a/electron/native/icloud-helper/Sources/main.swift
+++ b/electron/native/icloud-helper/Sources/main.swift
@@ -47,8 +47,12 @@ guard let command = args.first else {
 switch command {
 case "container":
     let identifier = args.count > 1 ? args[1] : nil
-    // NSNull so the JSON serializes as {"url":null} rather than failing on nil.
-    printJSON(["url": resolveContainer(identifier) ?? NSNull()])
+    // Print {"url":"..."} or {"url":null} — NSNull serializes as JSON null.
+    if let path = resolveContainer(identifier) {
+        printJSON(["url": path])
+    } else {
+        printJSON(["url": NSNull()])
+    }
 
 default:
     printJSON(["error": "unknown command: \(command)"])


### PR DESCRIPTION
Follow-up to #1078. The `dayglance-icloud-helper` Swift source didn't compile, which broke `npm run build:electron:mas` at the `build:icloud-helper` step:

```
error: binary operator '??' cannot be applied to operands of type 'String?' and 'NSNull'
    printJSON(["url": resolveContainer(identifier) ?? NSNull()])
```

Swift's `??` requires both operands to share a type, and `String?` vs `NSNull` don't. Replaced it with an explicit `if let` so the success path prints the resolved path and the nil path prints JSON `null` (via `NSNull`). Behavior and the `{"url": ...}` wire format are unchanged.

This is the compile issue that couldn't be caught in #1078 (no Swift toolchain in that environment) — surfaced on the first real macOS build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CscotGcQqLRopjsVdNZsox)_