### PR TITLE
Fix MAS build skipping code signing

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -22,6 +22,10 @@
 //     set BUILD_NUMBER only if you need to upload twice under the same version.
 
 const hasCert = Boolean(process.env.CSC_LINK);
+// MAS builds sign from the keychain (no CSC_LINK), so they must never inherit the
+// dev ad-hoc `identity: null` below — that would skip signing entirely. The mas
+// script is the only thing that sets DAYGLANCE_APP_ID, so it's a reliable signal.
+const isMasBuild = process.env.DAYGLANCE_APP_ID === 'com.dayglance';
 
 /** @type {import('electron-builder').Configuration} */
 module.exports = {
@@ -43,9 +47,10 @@ module.exports = {
   },
   files: ['dist/**/*', 'dist-electron/**/*'],
   mac: {
-    // null → ad-hoc (dev); undefined → electron-builder auto-selects the
-    // Developer ID Application cert from Keychain when CSC_LINK is set.
-    identity: hasCert ? undefined : null,
+    // null → ad-hoc (dev); undefined → electron-builder auto-selects the signing
+    // cert from the Keychain (Developer ID when CSC_LINK is set; the Apple
+    // Distribution cert for MAS, which the mas block inherits).
+    identity: hasCert || isMasBuild ? undefined : null,
     hardenedRuntime: hasCert,
     notarize: false, // handled by afterSign hook (scripts/notarize.cjs)
     category: 'public.app-category.productivity',


### PR DESCRIPTION
Follow-up to #1078 / #1080. On the first real MAS build, electron-builder reported:

```
• skipped macOS code signing  reason=identity explicitly is set to null
```

…producing an unsigned `.app` the App Store would reject.

**Cause:** the `mac` block sets `identity: null` (ad-hoc signing for dev) when `CSC_LINK` is unset, and the `mas` block **inherits** `mac`. The keychain-based MAS build doesn't set `CSC_LINK` (its certs come from the keychain, not a `.p12`), so it inherited `null` and skipped signing.

**Fix:** detect the MAS build via `DAYGLANCE_APP_ID` (only the `build:electron:mas` script sets it) and use `identity: undefined` for it, so electron-builder auto-selects the **Apple Distribution** cert from the keychain. Unchanged:
- dev build (no cert) → `null` → ad-hoc
- Developer ID release (`CSC_LINK` set) → `undefined` → Developer ID cert

Verified the config resolves `mac.identity` to `undefined` when `DAYGLANCE_APP_ID=com.dayglance` and `null` otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CscotGcQqLRopjsVdNZsox)_