### PR TITLE
Remove invalid in-app-payments entitlement from MAS build

### DIFF
--- a/electron/entitlements.mas.plist
+++ b/electron/entitlements.mas.plist
@@ -20,9 +20,10 @@
          behind the network.server entitlement. -->
     <key>com.apple.security.network.server</key>
     <true/>
-    <!-- StoreKit in-app purchases -->
-    <key>com.apple.security.in-app-payments</key>
-    <true/>
+    <!-- NOTE: StoreKit in-app purchases need NO sandbox entitlement on macOS.
+         com.apple.security.in-app-payments is the Apple Pay entitlement (not
+         StoreKit) and is rejected by App Store validation on macOS, so it is
+         intentionally omitted. IAP works via the sandbox + store signature alone. -->
     <!-- Read access to the system Calendar via the EventKit helper -->
     <key>com.apple.security.personal-information.calendars</key>
     <true/>


### PR DESCRIPTION
Transporter validation rejected the MAS build:

```
Validation failed (409)
Invalid Code Signing Entitlements. Your application bundle's signature contains
code signing entitlements that are not supported on macOS. Specifically, key
'com.apple.security.in-app-payments' ... is not supported.
```

**Cause:** `com.apple.security.in-app-payments` is the **Apple Pay** entitlement, not StoreKit, and it isn't valid on macOS. It was added to `entitlements.mas.plist` on the mistaken assumption that StoreKit IAP needed it.

**Fix:** removed the key. StoreKit in-app purchases require **no** sandbox entitlement on macOS — they work via the App Sandbox plus the store signature alone (`inAppPurchase` / receipt validation is unaffected). Left a comment documenting why it's intentionally absent so it doesn't get re-added.

Surfaced on the first real Transporter upload. After this, rebuild (`npm run build:electron:mas`) and re-upload the regenerated `.pkg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CscotGcQqLRopjsVdNZsox)_