### PR TITLE
Remove unused ubiquity-kvstore-identifier from MAS entitlements

### DIFF
--- a/electron/entitlements.mas.plist
+++ b/electron/entitlements.mas.plist
@@ -39,7 +39,10 @@
     <array>
       <string>CloudDocuments</string>
     </array>
-    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
-    <string>$(TeamIdentifierPrefix)com.dayglance</string>
+    <!-- NOTE: no com.apple.developer.ubiquity-kvstore-identifier here. The desktop
+         app's iCloud sync is entirely file-based (CloudDocuments); it does not use
+         NSUbiquitousKeyValueStore. The entitlement also embedded the literal
+         $(TeamIdentifierPrefix) macro (electron-builder, unlike Xcode, does not
+         expand it), which failed App Store validation against the profile. -->
   </dict>
 </plist>


### PR DESCRIPTION
Next Transporter validation error after #1082:

```
Validation failed (409)
Invalid Code Signing Entitlements. The entitlements in your app bundle signature
do not match the ones contained in the provisioning profile ... the bundle
contains a key value that is not allowed: '$[TeamIdentifierPrefix]com.dayglance'
for the key 'com.apple.developer.ubiquity-kvstore-identifier'
```

**Cause:** the entitlement value used the `$(TeamIdentifierPrefix)` macro, which **Xcode** expands at sign time but **electron-builder does not** — so the literal macro string got embedded and didn't match the provisioning profile.

**Fix:** removed the entitlement entirely rather than hardcoding the Team ID, because the desktop app doesn't use it. Its iCloud sync is entirely **file-based** (`CloudDocuments` — the JSON files the iCloud helper reads/writes); it never uses `NSUbiquitousKeyValueStore`, and Electron doesn't expose that API. `CloudDocuments` sync is governed by the `icloud-container-identifiers` + `icloud-services` keys, which are untouched, so sync is unaffected.

(If the desktop app ever needs key-value iCloud sync, re-add the key with the real Team ID hardcoded — `<TEAMID>.com.dayglance` — not the macro.)

Final MAS entitlement set: `app-sandbox`, `cs.allow-jit`, `network.client`, `network.server`, `personal-information.calendars`, `files.user-selected.read-write`, `icloud-container-identifiers`, `icloud-services`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CscotGcQqLRopjsVdNZsox)_