### PR TITLE
Build MAS as a universal binary (x86_64 + arm64)

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -92,6 +92,11 @@ module.exports = {
       { from: 'electron/native/calendar-helper/build/dayglance-calendar-helper', to: 'calendar-helper/dayglance-calendar-helper' },
       { from: 'electron/native/icloud-helper/build/dayglance-icloud-helper', to: 'icloud-helper/dayglance-icloud-helper' },
     ],
+    // Universal (x86_64 + arm64) so the App Store accepts the build for every Mac.
+    // Without this it defaults to the host arch only (arm64), which Apple rejects
+    // unless the deployment target is 12.0+. The bundled Swift helpers are already
+    // universal (lipo'd in their build scripts), so they slot in cleanly.
+    target: [{ target: 'pkg', arch: 'universal' }],
   },
   win: {
     target: [{ target: 'nsis' }],


### PR DESCRIPTION
Next Transporter validation error after the entitlement/cert fixes:

```
Invalid bundle. The "dayGLANCE.app" bundle supports arm64 but not Intel-based Mac
computers. Your build must include the x86_64 architecture ...
```

**Cause:** the `mas` block had no explicit `target`, so electron-builder defaulted to the host arch only (`arm64`), which the App Store rejects unless the deployment target is 12.0+.

**Fix:** pin a universal `pkg` target (`arch: 'universal'`) so the package covers **both Intel and Apple Silicon** Macs — chosen over arm64-only-with-min-macOS-12 so no Macs are excluded. The bundled Swift helpers (calendar + iCloud) are already universal binaries (lipo'd in their build scripts), so they merge in cleanly; the app has no native node modules to complicate the merge.

Trade-off: the universal build downloads a second Electron binary and the resulting `.pkg` is roughly 2× the size — acceptable for full Mac coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CscotGcQqLRopjsVdNZsox)_