### PR TITLE
Actually force universal arch on MAS build (--universal flag)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:helpers": "npm run build:calendar-helper && npm run build:icloud-helper",
     "build:electron": "npm run build:helpers && vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs",
     "build:electron:release": "npm run build:helpers && vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs --publish never",
-    "build:electron:mas": "npm run build:helpers && vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && DAYGLANCE_APP_ID=com.dayglance electron-builder --config electron-builder.config.cjs --mac mas --publish never"
+    "build:electron:mas": "npm run build:helpers && vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && DAYGLANCE_APP_ID=com.dayglance electron-builder --config electron-builder.config.cjs --mac mas --universal --publish never"
   },
   "dependencies": {
     "@glance-apps/intents": "1.4.0",


### PR DESCRIPTION
Fixes the gap in #1084. The `mas.target` `arch: 'universal'` added there is a **no-op** for the real build command: `build:electron:mas` passes `--mac mas` on the command line, and a CLI target overrides the config's `target`/`arch`. So electron-builder kept building the host arch (arm64) and the App Store still rejected the bundle for lacking `x86_64`.

**Fix:** add `--universal` to the `electron-builder` invocation in the `build:electron:mas` script. That flag forces the universal arch regardless of the CLI target override. The config `target` line from #1084 stays as documentation / for non-override invocation paths.

This is the change that actually makes the output a `-universal.pkg` instead of `-arm64.pkg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CscotGcQqLRopjsVdNZsox)_