### PR TITLE
Fix universal merge failure on already-universal Swift helpers

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -97,6 +97,11 @@ module.exports = {
     // unless the deployment target is 12.0+. The bundled Swift helpers are already
     // universal (lipo'd in their build scripts), so they slot in cleanly.
     target: [{ target: 'pkg', arch: 'universal' }],
+    // The bundled Swift helpers are already universal (x86_64+arm64), so they're
+    // byte-identical in the x64 and arm64 sub-builds. @electron/universal refuses
+    // to merge identical Mach-O files unless they're declared here — this tells it
+    // to take them as-is instead of trying to lipo two copies of the same fat binary.
+    x64ArchFiles: '**/dayglance-*-helper',
   },
   win: {
     target: [{ target: 'nsis' }],


### PR DESCRIPTION
Follow-up to #1085. With `--universal` actually taking effect, the build now reaches the `@electron/universal` merge step and fails:

```
Detected file "Contents/Resources/calendar-helper/dayglance-calendar-helper" that's
the same in both x64 and arm64 builds and not covered by the x64ArchFiles rule: "undefined"
```

**Cause:** the bundled Swift helpers (`dayglance-calendar-helper`, `dayglance-icloud-helper`) are **already universal** (the build scripts `lipo` them to x86_64+arm64). So they're byte-identical in the x64 and arm64 sub-builds. `@electron/universal` lipos each binary when merging the two arches, but refuses to merge files that are *identical* Mach-O unless they're whitelisted via `x64ArchFiles` (the `"undefined"` in the error is that unset rule).

**Fix:** set `mas.x64ArchFiles: '**/dayglance-*-helper'` so the merger takes the already-fat helpers as-is instead of trying to lipo two copies of the same binary.

After this the universal `.pkg` should build and merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CscotGcQqLRopjsVdNZsox)_