### PR TITLE
Persist Obsidian vault access across relaunches (app-scope bookmarks)

### DIFF
--- a/electron/entitlements.mas.plist
+++ b/electron/entitlements.mas.plist
@@ -30,6 +30,14 @@
     <!-- Obsidian vault: user picks folder via open panel -->
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
+    <!-- Persist that folder access across relaunches. The Obsidian integration uses
+         the File System Access API (showDirectoryPicker) and stores the directory
+         handle in IndexedDB; on the next launch Chromium needs an app-scoped
+         security-scoped bookmark to re-establish sandbox access to that folder.
+         Without this, a restored handle reports "granted" but writes fail with
+         "could not be modified due to the state of the underlying filesystem". -->
+    <key>com.apple.security.files.bookmarks.app-scope</key>
+    <true/>
     <!-- iCloud CloudDocuments sync -->
     <key>com.apple.developer.icloud-container-identifiers</key>
     <array>


### PR DESCRIPTION
On-device testing found the Obsidian integration works within a session but **breaks after relaunch** in the MAS build: the vault shows "connected" but syncing fails with
```
An attempt was made to write to a file or directory which could not be modified
due to the state of the underlying filesystem.
```

## Cause
The integration uses the **File System Access API** (`showDirectoryPicker`) and persists the `FileSystemDirectoryHandle` in IndexedDB. On relaunch the handle restores and `queryPermission` returns `granted` (so the UI thinks it's connected), but the **macOS sandbox dropped its access to that folder on quit**. Re-establishing access requires a **security-scoped bookmark**, which Chromium creates for persisted FS Access handles only if the app holds `com.apple.security.files.bookmarks.app-scope`. We had `files.user-selected.read-write` (grants access when you pick) but not the bookmark entitlement (persists it).

## Fix
Add `com.apple.security.files.bookmarks.app-scope` to the MAS entitlements. It's a standard sandbox entitlement (not a developer one), so it won't trip App Store validation like the earlier iCloud/IAP entitlement issues did.

## Verification needed (on device)
Bookmarks are created **at pick time**, so the already-saved handle won't have one. After installing the rebuilt entitled app:
1. **Re-connect the vault once** (re-pick the folder) so a bookmark is created under the new entitlement.
2. Fully **quit and relaunch**.
3. Change a task and confirm it writes to the vault **without re-picking**.

If it still fails after that, the fallback is heavier: move vault picking/IO to the main process via Electron's `dialog.showOpenDialog({ securityScopedBookmarks: true })` + `app.startAccessingSecurityScopedResource`, rather than the renderer's FS Access API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CscotGcQqLRopjsVdNZsox)_