### PR TITLE
Declare export compliance in Info.plist (stop the per-upload prompt)

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -96,6 +96,10 @@ module.exports = {
     extendInfo: {
       NSCalendarsUsageDescription: 'dayGLANCE shows your calendar events alongside your tasks.',
       NSCalendarsFullAccessUsageDescription: 'dayGLANCE shows your calendar events alongside your tasks.',
+      // Export compliance: the app uses only standard HTTPS/TLS (exempt encryption),
+      // no proprietary or user-facing crypto. Declaring this in the binary stops
+      // App Store Connect from prompting for encryption docs on every upload.
+      ITSAppUsesNonExemptEncryption: false,
     },
     extraResources: [
       { from: 'electron/native/calendar-helper/build/dayglance-calendar-helper', to: 'calendar-helper/dayglance-calendar-helper' },


### PR DESCRIPTION
Every App Store upload pops the "App Encryption Documentation" dialog until the answer is declared in the binary.

**Fix:** set `ITSAppUsesNonExemptEncryption: false` in the MAS `extendInfo`. dayGLANCE uses only standard HTTPS/TLS (exempt encryption) with no proprietary or user-facing crypto, so `false` is the correct declaration. App Store Connect then stops prompting on every upload.

Scoped to the `mas` target only — the Developer ID build isn't distributed through the App Store, so it doesn't need it.

Note: this affects uploads of builds made *after* this change; it won't retroactively clear the prompt for the build already in App Store Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CscotGcQqLRopjsVdNZsox)_