### PR TITLE
Obsidian on MAS: hold vault access in the main process (security-scoped bookmark)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,6 +6,7 @@ import { createWsServer } from './ws-server.js';
 import { registerSubscriptionHandlers } from './subscription.js';
 import { registerCalendarHandlers } from './calendar.js';
 import { registerICloudHandlers } from './icloud.js';
+import { registerObsidianHandlers } from './obsidian.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -464,6 +465,7 @@ app.whenReady().then(() => {
   registerSubscriptionHandlers(win);
   registerCalendarHandlers();
   registerICloudHandlers(() => live(mainWindow));
+  registerObsidianHandlers();
   if (process.platform === 'darwin') createTray();
 
   app.on('activate', () => {

--- a/electron/obsidian.ts
+++ b/electron/obsidian.ts
@@ -1,0 +1,157 @@
+import { ipcMain, app, dialog, BrowserWindow } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs';
+
+// ── Obsidian vault access (Electron) ─────────────────────────────────────────
+//
+// The renderer's Obsidian integration (src/obsidian.js) is built on the browser
+// File System Access API (showDirectoryPicker + a persisted directory handle).
+// That works in the browser and in the unsandboxed Developer ID build, but under
+// the Mac App Store sandbox a restored handle can't re-establish filesystem
+// access after relaunch — Electron's FS Access layer does not create/resolve
+// macOS security-scoped bookmarks. The symptom is a vault that shows "connected"
+// but fails every write with "…could not be modified due to the state of the
+// underlying filesystem".
+//
+// So on Electron we pick the folder with the NATIVE dialog (securityScopedBookmarks),
+// persist the returned bookmark, and on each launch call
+// app.startAccessingSecurityScopedResource() to regain access. All file I/O then
+// runs here in the main process — the process that actually holds the sandbox
+// grant. The renderer drives it through a thin handle shim
+// (src/obsidianElectronHandle.js) that mirrors the FS Access surface it already uses.
+//
+// Requires the com.apple.security.files.bookmarks.app-scope entitlement (MAS).
+
+interface VaultConfig { path: string; bookmark?: string; }
+
+let vaultBasePath: string | null = null;
+let stopAccessing: (() => void) | null = null;
+
+function configPath(): string {
+  return path.join(app.getPath('userData'), 'obsidian-vault.json');
+}
+
+function loadConfig(): VaultConfig | null {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(configPath(), 'utf-8')) as VaultConfig;
+    return cfg && typeof cfg.path === 'string' ? cfg : null;
+  } catch { return null; }
+}
+
+function saveConfig(cfg: VaultConfig): void {
+  try { fs.writeFileSync(configPath(), JSON.stringify(cfg)); } catch { /* ignore */ }
+}
+
+function clearConfig(): void {
+  try { fs.unlinkSync(configPath()); } catch { /* ignore */ }
+}
+
+// Begin security-scoped access for a bookmark (MAS). Releases any prior access
+// first. No-op when there's no bookmark (unsandboxed Developer ID build — direct
+// filesystem access needs no scope), or when the API is unavailable.
+function beginAccess(bookmark: string | undefined): void {
+  if (stopAccessing) { try { stopAccessing(); } catch { /* ignore */ } stopAccessing = null; }
+  if (bookmark && typeof app.startAccessingSecurityScopedResource === 'function') {
+    try { stopAccessing = app.startAccessingSecurityScopedResource(bookmark) as () => void; }
+    catch { stopAccessing = null; }
+  }
+}
+
+// Resolve a vault-relative path to an absolute one, refusing anything that would
+// escape the vault root (defense-in-depth; the renderer already sanitizes segments).
+function resolveInVault(relativePath: string): string | null {
+  if (!vaultBasePath) return null;
+  const abs = path.resolve(vaultBasePath, relativePath || '.');
+  const rel = path.relative(vaultBasePath, abs);
+  if (rel === '..' || rel.startsWith('..' + path.sep) || path.isAbsolute(rel)) return null;
+  return abs;
+}
+
+export function registerObsidianHandlers(): void {
+  // Native folder picker. Returns { path, name } and persists the security-scoped
+  // bookmark so access survives relaunch. null if the user cancels.
+  ipcMain.handle('obsidian:pick', async (event) => {
+    if (process.platform !== 'darwin') return null;
+    const opts = {
+      properties: ['openDirectory', 'createDirectory'] as Array<'openDirectory' | 'createDirectory'>,
+      securityScopedBookmarks: true,
+      message: 'Select your Obsidian vault folder',
+    };
+    const win = BrowserWindow.fromWebContents(event.sender);
+    const result = win
+      ? await dialog.showOpenDialog(win, opts)
+      : await dialog.showOpenDialog(opts);
+    if (result.canceled || result.filePaths.length === 0) return null;
+    const dir = result.filePaths[0];
+    const bookmark = result.bookmarks?.[0];
+    saveConfig({ path: dir, bookmark });
+    vaultBasePath = dir;
+    beginAccess(bookmark);
+    return { path: dir, name: path.basename(dir) };
+  });
+
+  // Re-open a previously-picked vault on launch. Resolves the stored bookmark and
+  // begins access. Returns { path, name } or null if nothing is configured.
+  ipcMain.handle('obsidian:restore', async () => {
+    if (process.platform !== 'darwin') return null;
+    const cfg = loadConfig();
+    if (!cfg) return null;
+    vaultBasePath = cfg.path;
+    beginAccess(cfg.bookmark);
+    return { path: cfg.path, name: path.basename(cfg.path) };
+  });
+
+  ipcMain.handle('obsidian:disconnect', async () => {
+    if (stopAccessing) { try { stopAccessing(); } catch { /* ignore */ } stopAccessing = null; }
+    vaultBasePath = null;
+    clearConfig();
+    return true;
+  });
+
+  // Stat a vault-relative path → { kind: 'file' | 'directory' } or null if missing.
+  ipcMain.handle('obsidian:stat', async (_e, relativePath: string) => {
+    const abs = resolveInVault(relativePath);
+    if (!abs) return null;
+    try {
+      const st = fs.statSync(abs);
+      return { kind: st.isDirectory() ? 'directory' : 'file' };
+    } catch { return null; }
+  });
+
+  // List a directory → [{ name, kind }]. Empty array if missing/unreadable.
+  ipcMain.handle('obsidian:list-dir', async (_e, relativePath: string) => {
+    const abs = resolveInVault(relativePath);
+    if (!abs) return [];
+    try {
+      return fs.readdirSync(abs, { withFileTypes: true })
+        .map((d) => ({ name: d.name, kind: d.isDirectory() ? 'directory' : 'file' }));
+    } catch { return []; }
+  });
+
+  // Read a file → { text, lastModified } or { notFound: true }.
+  ipcMain.handle('obsidian:read-file', async (_e, relativePath: string) => {
+    const abs = resolveInVault(relativePath);
+    if (!abs) return { notFound: true };
+    try {
+      const text = fs.readFileSync(abs, 'utf-8');
+      return { text, lastModified: fs.statSync(abs).mtimeMs };
+    } catch (err: unknown) {
+      if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { notFound: true };
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      return { error: msg };
+    }
+  });
+
+  // Write a file (creating parent directories). Returns true on success.
+  ipcMain.handle('obsidian:write-file', async (_e, relativePath: string, content: string) => {
+    const abs = resolveInVault(relativePath);
+    if (!abs) return false;
+    try {
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, content, 'utf-8');
+      return true;
+    } catch { return false; }
+  });
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -3,6 +3,11 @@ import { contextBridge, ipcRenderer } from 'electron';
 contextBridge.exposeInMainWorld('electronAPI', {
   isElectron: true,
   platform: process.platform,
+  // True only in the Mac App Store (sandboxed) build. Electron sets process.mas
+  // for the `mas` target. Used to gate sandbox-only behavior (e.g. Obsidian vault
+  // access via the main process) so the unsandboxed Developer ID / dev build keeps
+  // its proven File System Access path unchanged.
+  isMAS: process.mas === true,
 
   // Renderer pushes app state to connected WebSocket clients (e.g. Stream Deck plugin)
   pushState: (state: unknown) => ipcRenderer.send('ws:push-state', state),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -147,4 +147,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('tray:focus-quick-add', handler);
     return () => ipcRenderer.removeListener('tray:focus-quick-add', handler);
   },
+
+  // Obsidian vault (macOS) — folder access held by the main process via a
+  // security-scoped bookmark so it survives relaunch under the App Sandbox. The
+  // renderer drives file I/O through the shim in src/obsidianElectronHandle.js.
+  obsidian: {
+    pick: (): Promise<{ path: string; name: string } | null> => ipcRenderer.invoke('obsidian:pick'),
+    restore: (): Promise<{ path: string; name: string } | null> => ipcRenderer.invoke('obsidian:restore'),
+    disconnect: (): Promise<boolean> => ipcRenderer.invoke('obsidian:disconnect'),
+    stat: (relativePath: string): Promise<{ kind: 'file' | 'directory' } | null> =>
+      ipcRenderer.invoke('obsidian:stat', relativePath),
+    listDir: (relativePath: string): Promise<Array<{ name: string; kind: 'file' | 'directory' }>> =>
+      ipcRenderer.invoke('obsidian:list-dir', relativePath),
+    readFile: (relativePath: string): Promise<{ text?: string; lastModified?: number; notFound?: boolean; error?: string }> =>
+      ipcRenderer.invoke('obsidian:read-file', relativePath),
+    writeFile: (relativePath: string, content: string): Promise<boolean> =>
+      ipcRenderer.invoke('obsidian:write-file', relativePath, content),
+  },
 });

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -14,8 +14,13 @@
 
 import { makeElectronVaultHandle } from './obsidianElectronHandle.js';
 
+// MAS-only: the sandboxed Mac App Store build routes vault access through the main
+// process (native picker + security-scoped bookmark). The unsandboxed Developer ID
+// and dev Electron builds keep the proven File System Access API path unchanged, so
+// this change touches nothing but the MAS build.
 const isElectronObsidian = () =>
-  typeof window !== 'undefined' && !!(window.electronAPI && window.electronAPI.isElectron && window.electronAPI.obsidian);
+  typeof window !== 'undefined' &&
+  !!(window.electronAPI && window.electronAPI.isMAS && window.electronAPI.obsidian);
 
 // ---------------------------------------------------------------------------
 // IndexedDB — persist the vault directory handle across sessions

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -4,7 +4,18 @@
  * Provides one-way task import (Obsidian → DG) and two-way daily notes
  * via the File System Access API. Vault directory handles are persisted
  * in IndexedDB so re-granting permission is a single click.
+ *
+ * On Electron the File System Access handle can't persist across relaunch under
+ * the Mac App Store sandbox, so vault access is delegated to the main process
+ * (native folder picker + security-scoped bookmark). requestVaultAccess/restore/
+ * disconnect route through electronAPI.obsidian and return a handle SHIM
+ * (makeElectronVaultHandle) that the rest of this module drives unchanged.
  */
+
+import { makeElectronVaultHandle } from './obsidianElectronHandle.js';
+
+const isElectronObsidian = () =>
+  typeof window !== 'undefined' && !!(window.electronAPI && window.electronAPI.isElectron && window.electronAPI.obsidian);
 
 // ---------------------------------------------------------------------------
 // IndexedDB — persist the vault directory handle across sessions
@@ -63,6 +74,7 @@ async function removeVaultHandle() {
 // ---------------------------------------------------------------------------
 
 export function isFileSystemAccessSupported() {
+  if (isElectronObsidian()) return true; // native picker + bookmark in the main process
   return typeof window !== 'undefined' && 'showDirectoryPicker' in window;
 }
 
@@ -75,6 +87,11 @@ export function isFileSystemAccessSupported() {
  * Returns the directory handle or null if cancelled.
  */
 export async function requestVaultAccess() {
+  if (isElectronObsidian()) {
+    // Native folder picker in the main process; persists a security-scoped bookmark.
+    const res = await window.electronAPI.obsidian.pick();
+    return res ? makeElectronVaultHandle() : null;
+  }
   try {
     const handle = await window.showDirectoryPicker({ mode: 'readwrite' });
     await saveVaultHandle(handle);
@@ -92,6 +109,11 @@ export async function requestVaultAccess() {
  * Returns the handle or null.
  */
 export async function tryRestoreVaultAccess() {
+  if (isElectronObsidian()) {
+    // Re-open the stored bookmark in the main process; no user gesture needed.
+    const res = await window.electronAPI.obsidian.restore();
+    return res ? makeElectronVaultHandle() : null;
+  }
   const handle = await loadVaultHandle();
   if (!handle) return null;
   const perm = await handle.queryPermission({ mode: 'readwrite' });
@@ -103,6 +125,12 @@ export async function tryRestoreVaultAccess() {
  * Re-requests permission if needed (requires a user gesture). Returns the handle or null.
  */
 export async function getVaultAccess() {
+  if (isElectronObsidian()) {
+    // Bookmark-backed access is re-established by the main process; nothing to
+    // re-prompt for. Returns a handle when a vault is configured, else null.
+    const res = await window.electronAPI.obsidian.restore();
+    return res ? makeElectronVaultHandle() : null;
+  }
   const handle = await loadVaultHandle();
   if (!handle) return null;
 
@@ -122,6 +150,10 @@ export async function getVaultAccess() {
  * Disconnect — remove the stored handle.
  */
 export async function disconnectVault() {
+  if (isElectronObsidian()) {
+    await window.electronAPI.obsidian.disconnect();
+    return;
+  }
   await removeVaultHandle();
 }
 

--- a/src/obsidianElectronHandle.js
+++ b/src/obsidianElectronHandle.js
@@ -1,0 +1,104 @@
+/**
+ * Electron vault handle shim.
+ *
+ * Presents the subset of the File System Access API that src/obsidian.js uses
+ * (getDirectoryHandle, getFileHandle, entries, getFile().text()/.lastModified,
+ * createWritable().write()/.close(), and NotFoundError semantics), backed by the
+ * Electron main process via window.electronAPI.obsidian.*.
+ *
+ * This lets all of obsidian.js's proven markdown/sync logic run unchanged on the
+ * Mac App Store build, where the vault folder is accessed in the main process
+ * through a security-scoped bookmark (the renderer's own FS Access handle can't
+ * persist across relaunch under the sandbox).
+ */
+
+function notFoundError() {
+  const e = new Error('A requested file or directory could not be found.');
+  e.name = 'NotFoundError';
+  return e;
+}
+
+function joinRel(base, name) {
+  return base ? `${base}/${name}` : name;
+}
+
+function makeFileHandle(api, relPath, name) {
+  return {
+    kind: 'file',
+    name,
+    async getFile() {
+      const res = await api.readFile(relPath);
+      if (!res || res.notFound) throw notFoundError();
+      if (res.error) throw new Error(res.error);
+      return {
+        lastModified: res.lastModified,
+        async text() { return res.text; },
+      };
+    },
+    async createWritable() {
+      // FS Access createWritable() truncates/overwrites; obsidian.js always writes
+      // the full file contents in a single write() then close(). Buffer and flush
+      // on close() via one IPC write.
+      let buffer = '';
+      return {
+        async write(chunk) { buffer += typeof chunk === 'string' ? chunk : String(chunk ?? ''); },
+        async close() {
+          const ok = await api.writeFile(relPath, buffer);
+          if (!ok) throw new Error(`Obsidian: failed to write ${relPath || name}`);
+        },
+      };
+    },
+  };
+}
+
+function makeDirHandle(api, relPath, name) {
+  return {
+    kind: 'directory',
+    name,
+    // Access is managed by the main process's security-scoped bookmark, so from
+    // the renderer's perspective permission is always granted.
+    async queryPermission() { return 'granted'; },
+    async requestPermission() { return 'granted'; },
+
+    async getDirectoryHandle(childName, opts = {}) {
+      const childRel = joinRel(relPath, childName);
+      if (!opts.create) {
+        const st = await api.stat(childRel);
+        if (!st || st.kind !== 'directory') throw notFoundError();
+      }
+      // With { create: true } the directory is materialized lazily — the main
+      // process's write-file mkdirs the full parent path on first write.
+      return makeDirHandle(api, childRel, childName);
+    },
+
+    async getFileHandle(childName, opts = {}) {
+      const childRel = joinRel(relPath, childName);
+      if (!opts.create) {
+        const st = await api.stat(childRel);
+        if (!st || st.kind !== 'file') throw notFoundError();
+      }
+      return makeFileHandle(api, childRel, childName);
+    },
+
+    async *entries() {
+      const items = await api.listDir(relPath);
+      for (const it of items) {
+        const childRel = joinRel(relPath, it.name);
+        const handle = it.kind === 'directory'
+          ? makeDirHandle(api, childRel, it.name)
+          : makeFileHandle(api, childRel, it.name);
+        yield [it.name, handle];
+      }
+    },
+  };
+}
+
+/**
+ * Build a vault directory handle rooted at the vault folder, backed by the
+ * Electron main process. Returns null if the Electron Obsidian API is unavailable.
+ */
+export function makeElectronVaultHandle() {
+  const api = typeof window !== 'undefined' && window.electronAPI && window.electronAPI.obsidian;
+  if (!api) return null;
+  return makeDirHandle(api, '', 'vault');
+}


### PR DESCRIPTION
The real fix for Obsidian vault persistence under the Mac App Store sandbox. The entitlement (#1089) alone couldn't work — the **File System Access API (`showDirectoryPicker`) never creates a macOS security-scoped bookmark**, so a restored handle is a ghost after relaunch and every write fails with *"could not be modified due to the state of the underlying filesystem."*

Note: this is a **sandbox-only** gap. The unsandboxed Developer ID / dev build doesn't need bookmarks (plain `fs` works once Chromium persists the permission), which is why Obsidian has worked there for months. Only the sandboxed MAS build breaks.

## Approach
Route vault access through the **main process** — but **only in the MAS build** (`electronAPI.isMAS`, from `process.mas`):

- **`electron/obsidian.ts`** — pick the folder with `dialog.showOpenDialog({ securityScopedBookmarks: true })`, persist the returned bookmark to `userData/obsidian-vault.json`, and on each launch call `app.startAccessingSecurityScopedResource()` to regain access. File I/O (`stat` / `list-dir` / `read-file` / `write-file`) runs here via `fs`, path-guarded to the vault root.
- **`preload.ts`** — expose `electronAPI.isMAS` and `electronAPI.obsidian.*`.
- **`src/obsidianElectronHandle.js`** — a shim implementing exactly the FS Access surface `obsidian.js` uses (`getDirectoryHandle`/`getFileHandle` with `NotFoundError`, async `entries()`, `getFile().text()`/`.lastModified`, `createWritable().write()`/`.close()`), backed by the IPC API. So **none of the ~1100 lines of proven markdown/sync logic in `obsidian.js` changed** — it drives the shim like a real handle.
- **`src/obsidian.js`** — `requestVaultAccess` / `tryRestoreVaultAccess` / `getVaultAccess` / `disconnectVault` route through `electronAPI.obsidian` **only when `isMAS`**; every other build (Developer ID/dev Electron, Android, iOS, web) keeps its existing path untouched.

## Scope / safety
Gated on `isMAS`, so this changes **only the Mac App Store build**. Developer ID/dev Electron, Android, iOS, and web are byte-for-byte unaffected at runtime.

## Depends on
`com.apple.security.files.bookmarks.app-scope` entitlement (already in `main` from #1089).

## Verification needed (on device — couldn't run the sandbox in CI)
1. Build & install the MAS build; open Obsidian settings and **re-connect the vault** (now the **native macOS folder picker** — creates the bookmark; the old FS Access handle has none).
2. **Fully quit and relaunch.**
3. Change a task → confirm it writes to the vault **without re-picking** and with no filesystem error.
4. Sanity: daily-note read/write, wiki-note read/write, wikilink autocomplete (exercises directory listing).

The FS-Access shim is hand-rolled and untested in CI, so there may be a small fixup after real-device testing — paste any error and I'll chase it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)