### PR TITLE
Fix Obsidian shim: support direct async iteration of the vault handle

### DIFF
--- a/src/obsidianElectronHandle.js
+++ b/src/obsidianElectronHandle.js
@@ -90,6 +90,22 @@ function makeDirHandle(api, relPath, name) {
         yield [it.name, handle];
       }
     },
+
+    async *keys() {
+      const items = await api.listDir(relPath);
+      for (const it of items) yield it.name;
+    },
+
+    async *values() {
+      for await (const [, handle] of this.entries()) yield handle;
+    },
+
+    // FS Access directory handles are themselves async-iterable (equivalent to
+    // entries()); obsidian.js's sync path iterates the handle directly, so the
+    // shim must support it too — this was the missing piece.
+    [Symbol.asyncIterator]() {
+      return this.entries();
+    },
   };
 }
 


### PR DESCRIPTION
Follow-up to #1092. On-device, Obsidian sync failed on the MAS build:
```
TypeError: i is not async iterable
```

**Cause:** the sync path (`obsidian.js:924`) iterates a directory handle **directly**:
```js
for await (const [name, handle] of dirHandle)
```
which relies on the FS Access handle being async-iterable via `[Symbol.asyncIterator]`. The Electron handle shim (`obsidianElectronHandle.js`) only implemented `entries()`, so direct iteration threw. Paths using `.entries()` (lines 443/545) worked — which is why setup got far enough to look connected.

**Fix:** add `[Symbol.asyncIterator]` (delegates to `entries()`), plus `keys()` and `values()` for full FS Access parity.

Runtime-verified all four iteration styles (direct `for await…of`, `entries()`, `keys()`, `values()`) against a mock IPC API — not just typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CscotGcQqLRopjsVdNZsox)_