### PR TITLE
Add npm run reviewer-code script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ios:generate": "bash scripts/gen-ios-project.sh",
     "ios": "npm run build:ios && npm run ios:generate",
     "preview": "vite preview",
+    "reviewer-code": "node scripts/reviewer-code.js",
     "lint": "eslint src --max-warnings 0",
     "test": "vitest run",
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",

--- a/scripts/reviewer-code.js
+++ b/scripts/reviewer-code.js
@@ -1,0 +1,40 @@
+// Prints the current month's reviewer bypass code.
+//
+//   npm run reviewer-code
+//
+// Reuses deriveReviewerCode() from src/config/reviewerAccess.js so the
+// terminal output can never drift from what the app computes. The code
+// rotates on the 1st of each month — paste the output into the Play
+// Console / App Store Connect App Review notes on that day.
+//
+// Pass a YYYY-MM argument to preview a specific month (e.g. next month
+// before a store update): npm run reviewer-code -- 2026-08
+
+import { deriveReviewerCode } from '../src/config/reviewerAccess.js';
+
+const arg = process.argv[2];
+
+if (arg && !/^\d{4}-\d{2}$/.test(arg)) {
+  console.error(`Invalid month "${arg}" — expected YYYY-MM (e.g. 2026-08).`);
+  process.exit(1);
+}
+
+// deriveReviewerCode() reads the current month internally. To preview a
+// different month we temporarily pin the clock via Date.toISOString.
+let code;
+if (arg) {
+  const realToISOString = Date.prototype.toISOString;
+  Date.prototype.toISOString = function () {
+    return `${arg}-01T00:00:00.000Z`;
+  };
+  try {
+    code = await deriveReviewerCode();
+  } finally {
+    Date.prototype.toISOString = realToISOString;
+  }
+} else {
+  code = await deriveReviewerCode();
+}
+
+const period = arg || new Date().toISOString().slice(0, 7);
+console.log(`Reviewer code for ${period}: ${code}`);


### PR DESCRIPTION
Generates the monthly reviewer bypass code from the terminal instead of pasting a console snippet. Reuses deriveReviewerCode() from src/config/reviewerAccess.js so the CLI output can never drift from what the app computes. Supports an optional YYYY-MM arg to preview a future month before a store update.


Claude-Session: https://claude.ai/code/session_01SV3GT6eUgJ28o7EFP4n5LK