### PR TITLE
Unify Obsidian vault path across all Electron builds

### DIFF
--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -14,13 +14,20 @@
 
 import { makeElectronVaultHandle } from './obsidianElectronHandle.js';
 
-// MAS-only: the sandboxed Mac App Store build routes vault access through the main
-// process (native picker + security-scoped bookmark). The unsandboxed Developer ID
-// and dev Electron builds keep the proven File System Access API path unchanged, so
-// this change touches nothing but the MAS build.
+// All Electron builds route vault access through the main process (native picker +
+// security-scoped bookmark). Required under the MAS sandbox (a renderer FS Access
+// handle can't persist there); the unsandboxed Developer ID / dev builds simply get
+// an empty bookmark and read/write the path directly. Unifying on one path — now
+// that it's verified on MAS — means dev exercises the same code that ships, so shim
+// bugs surface on the desk instead of only in the sandbox. Web and native (iOS/
+// Android) have no electronAPI and keep their existing paths.
+//
+// Migration note: an existing Developer ID user's vault lives as an FS Access handle
+// in IndexedDB (no extractable filesystem path), so there's no auto-migration — they
+// reconnect the vault once via the native picker. Sync just no-ops until then.
 const isElectronObsidian = () =>
   typeof window !== 'undefined' &&
-  !!(window.electronAPI && window.electronAPI.isMAS && window.electronAPI.obsidian);
+  !!(window.electronAPI && window.electronAPI.isElectron && window.electronAPI.obsidian);
 
 // ---------------------------------------------------------------------------
 // IndexedDB — persist the vault directory handle across sessions


### PR DESCRIPTION
Follow-up to the MAS Obsidian work (#1092 / #1093), now that the main-process vault path is **verified working on MAS** (persists across relaunch; daily notes + vault search confirmed on device).

**Change:** gate the main-process vault path on `electronAPI.isElectron` instead of `isMAS`, so **all** Electron builds (MAS, Developer ID, dev) use the same path.

**Why:**
- One code path to maintain instead of two.
- The **dev build now exercises the exact code that ships** — shim bugs surface on the desk, not only in the sandbox. (Would have caught the `not async iterable` bug locally without a MAS build.)
- On the unsandboxed Developer ID / dev build, `dialog.showOpenDialog({ securityScopedBookmarks: true })` just returns an empty bookmark and files are read/written by path directly — so it works there too.
- Web and native (iOS/Android) are unaffected (no `electronAPI`).

**One-time migration cost:** an existing Developer ID user's vault is an FS Access handle in IndexedDB with no extractable filesystem path, so there's no auto-migration — they **reconnect the vault once** via the native picker. Until then sync no-ops (no error, degrades gracefully). With the tiny Developer ID user base this is negligible.

`isMAS` stays exported from preload (still a useful general flag), just no longer gates Obsidian.

## Verify
Run the **dev build** (`npm run dev:electron`): Obsidian should now use the **native** folder picker, and connect → sync → quit → relaunch → write should all work exactly as on MAS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CscotGcQqLRopjsVdNZsox)_