### PR TITLE
Fix Tasker intents not firing while app is backgrounded

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -94,16 +94,34 @@ class MainActivity : AppCompatActivity() {
     // Shown at most once per session so we don't nag the user repeatedly
     private var exactAlarmPromptShown = false
 
-    // Receives the internal INTENT_RECEIVED broadcast sent by IntentReceiver and triggers
-    // a visibilitychange event in the WebView so JS picks up the pending intent immediately.
+    // Receives the internal INTENT_RECEIVED broadcast sent by IntentReceiver and asks JS
+    // to pick up the pending intent immediately. Registered for the whole activity
+    // lifetime (onCreate → onDestroy), not just while resumed, so intents fired from
+    // Tasker while the app is backgrounded are still forwarded to the (still-running) WebView.
     private val intentForwardReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
-            webView.post {
-                webView.evaluateJavascript(
-                    "(function(){ document.dispatchEvent(new Event('visibilitychange')); })();",
-                    null
-                )
-            }
+            forwardPendingIntentToJs()
+        }
+    }
+
+    // Tracks whether intentForwardReceiver is currently registered so onDestroy can
+    // unregister exactly once without risking IllegalArgumentException.
+    private var intentForwardReceiverRegistered = false
+
+    /**
+     * Pokes the WebView to drain any pending intent stored by IntentReceiver /
+     * onNewIntent. Calls the dedicated JS hook exposed by useAndroidIntentBridge
+     * (which processes the intent regardless of document.visibilityState); falls
+     * back to a synthetic visibilitychange event if the hook isn't ready yet.
+     */
+    private fun forwardPendingIntentToJs() {
+        webView.post {
+            webView.evaluateJavascript(
+                "(function(){ if (window.__dayglanceCheckPendingIntent) {" +
+                " window.__dayglanceCheckPendingIntent();" +
+                " } else { document.dispatchEvent(new Event('visibilitychange')); } })();",
+                null
+            )
         }
     }
 
@@ -235,6 +253,19 @@ class MainActivity : AppCompatActivity() {
 
         configureWebView()
         requestRuntimePermissions()
+
+        // Register the INTENT_RECEIVED forward receiver for the whole activity lifetime.
+        // It was previously registered in onResume/unregistered in onPause, which meant the
+        // wake broadcast was dropped whenever the app was backgrounded — so Tasker intents
+        // fired against a backgrounded (but running) app never reached JS. ContextCompat
+        // applies the RECEIVER_NOT_EXPORTED flag correctly across all supported API levels.
+        ContextCompat.registerReceiver(
+            this,
+            intentForwardReceiver,
+            IntentFilter(ACTION_INTENT_RECEIVED),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
+        intentForwardReceiverRegistered = true
 
         // WebViewAssetLoader serves assets via https://appassets.androidplatform.net
         // so ES module scripts load without CORS errors (file:// blocks type="module")
@@ -376,7 +407,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onPause() {
-        unregisterReceiver(intentForwardReceiver)
         super.onPause()
         // Show the overlay so the stale cached frame is hidden when the user returns.
         // dataStore.appDarkMode is the app's own dark/light preference (independent of the
@@ -407,13 +437,21 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onDestroy() {
+        if (intentForwardReceiverRegistered) {
+            unregisterReceiver(intentForwardReceiver)
+            intentForwardReceiverRegistered = false
+        }
+        super.onDestroy()
+    }
+
     override fun onResume() {
         super.onResume()
-        registerReceiver(
-            intentForwardReceiver,
-            IntentFilter(ACTION_INTENT_RECEIVED),
-            Context.RECEIVER_NOT_EXPORTED
-        )
+        // Safety net: drain any intent that landed while the WebView bridge wasn't yet
+        // ready to receive the wake broadcast (e.g. during a cold-start registration gap
+        // or after a process restart). Normal background delivery is handled live by
+        // intentForwardReceiver, which now stays registered while backgrounded.
+        forwardPendingIntentToJs()
         // webView.onResume() intentionally omitted — we don't call webView.onPause() either,
         // so the GPU surface stays live. Calling resume without a prior pause triggers a
         // surface invalidation that causes a blank-frame flash on return from background.
@@ -556,13 +594,7 @@ class MainActivity : AppCompatActivity() {
             else -> return
         }
         // The WebView is already loaded; trigger the JS check immediately.
-        webView.post {
-            webView.evaluateJavascript(
-                "(function(){ if(document.visibilityState==='visible')" +
-                "document.dispatchEvent(new Event('visibilitychange')); })();",
-                null
-            )
-        }
+        forwardPendingIntentToJs()
     }
 
     /**

--- a/docs/tasker-integration.md
+++ b/docs/tasker-integration.md
@@ -10,7 +10,7 @@ dayGLANCE exposes four inbound broadcast actions that you can fire from Tasker, 
 
 When the action is processed, dayGLANCE sends an outbound `app.dayglance.RESULT` broadcast that you can receive in Tasker to check the outcome. dayGLANCE also emits `app.dayglance.NOTIFY` broadcasts whenever tasks change state (completed, rescheduled, updated, deleted).
 
-> **Important:** dayGLANCE must be running and in the foreground (or at least not killed) for broadcasts to be processed. For fully unattended automation (e.g. creating tasks while the app is closed), use the WebDAV transport instead.
+> **Important:** dayGLANCE must be running for broadcasts to be processed — but it does **not** need to be in the foreground. Intents fired while the app is backgrounded are handled live, as long as the app has not been swiped away / killed by the system. For fully unattended automation (e.g. creating tasks while the app is closed), use the WebDAV transport instead.
 
 ---
 
@@ -151,7 +151,7 @@ dayGLANCE fires `app.dayglance.NOTIFY` whenever a task with a `source_app` + `so
 
 ## Troubleshooting
 
-- **Nothing happens:** Make sure dayGLANCE is running. Broadcasts sent while the app is closed are not queued.
+- **Nothing happens:** Make sure dayGLANCE is still running (backgrounded is fine, but not swiped-away/killed). Broadcasts sent while the app is closed are not queued.
 - **Task not found (COMPLETE):** Pass `task_id` instead of `title` for reliable matching.
 - **No RESULT received:** Check that Tasker has permission to receive broadcasts from other apps. Ensure your intent filter matches `app.dayglance.RESULT` exactly.
 - **For set-and-forget automation** (creating tasks without the app open): use the WebDAV transport — dayGLANCE polls a WebDAV directory for incoming intent files even when backgrounded.

--- a/src/intents/useAndroidIntentBridge.js
+++ b/src/intents/useAndroidIntentBridge.js
@@ -40,6 +40,14 @@ export function useAndroidIntentBridge(context) {
       nativeReportIntentResult(action, JSON.stringify(result));
     };
 
+    // Expose an unconditional entry point for the native side to invoke directly
+    // (from MainActivity's INTENT_RECEIVED forward receiver and onResume). This
+    // must NOT be gated on document.visibilityState: the WebView is never paused
+    // (webView.onPause() is intentionally skipped so the GPU surface stays live),
+    // so its visibilityState stays 'visible' even while the app is backgrounded —
+    // but we don't want to depend on that invariant to process background intents.
+    window.__dayglanceCheckPendingIntent = checkPending;
+
     const onVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
         checkPending();
@@ -50,6 +58,11 @@ export function useAndroidIntentBridge(context) {
     checkPending();
 
     document.addEventListener('visibilitychange', onVisibilityChange);
-    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      if (window.__dayglanceCheckPendingIntent === checkPending) {
+        delete window.__dayglanceCheckPendingIntent;
+      }
+    };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 }


### PR DESCRIPTION
## Problem

Firing a dayGLANCE intent (CREATE/COMPLETE/OPEN/QUERY) from Tasker did nothing when the app was **backgrounded but still running** — exactly the scenario the intents transport is meant to support.

## Root cause

The transport is designed to process broadcasts live in the background:

1. Tasker → `IntentReceiver` (a manifest receiver, so it runs while backgrounded) stores `pendingIntentJson` and sends an internal `com.dayglance.app.INTENT_RECEIVED` broadcast to "wake" `MainActivity`.
2. `MainActivity.intentForwardReceiver` catches that and pokes the WebView so JS drains the pending intent via `getPendingIntent()` → `handleIntent()` → `reportIntentResult()`.

But `intentForwardReceiver` was registered in `onResume()` and **unregistered in `onPause()`**, so it only existed while the app was in the foreground. When backgrounded, the wake broadcast had no registered receiver and was silently dropped; the intent sat unread in `SharedDataStore`. And because the app deliberately never calls `webView.onPause()/onResume()`, the document's Page Visibility never toggles — so nothing flushed the stranded intent on return either, only the *next* intent that happened to arrive while foreground.

## Fix

- **Register `intentForwardReceiver` for the whole activity lifetime** (`onCreate` → `onDestroy`) via `ContextCompat.registerReceiver`, so it keeps receiving the wake broadcast while backgrounded. `ContextCompat` applies the `RECEIVER_NOT_EXPORTED` flag correctly across all supported API levels (minSdk 26).
- **Forward via a dedicated JS hook** (`window.__dayglanceCheckPendingIntent`) that drains the pending intent unconditionally, instead of dispatching a `visibilitychange` event that the JS handler only honors when `document.visibilityState === 'visible'`. This decouples background processing from the fragile "never pause the WebView" invariant. A synthetic `visibilitychange` remains as a fallback if the hook isn't ready yet.
- **Flush pending intents on `onResume()`** as a safety net for cold-start registration gaps / process restarts.
- **Docs:** the Tasker integration guide now states that backgrounded (but not swiped-away/killed) is fine — the app no longer needs to be in the foreground.

## Files

- `dayglance-android/.../MainActivity.kt` — receiver lifecycle + forwarding helper
- `src/intents/useAndroidIntentBridge.js` — expose `window.__dayglanceCheckPendingIntent`, clean up on unmount
- `docs/tasker-integration.md` — accuracy update

## Testing notes

Vitest could not run in this environment (dev dependencies not installed — `vite`/`vite-plugin-pwa` missing), so the suite was not exercised here. The changes are small and self-contained; the JS edit only adds a global hook and its cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDD8mfAwTkK3CjUS4eETUA)_