### PR TITLE
Bump Android versionCode to 139

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 138
+        versionCode = 139
         versionName = "3.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Bumps `versionCode` 138 → 139 in `dayglance-android/app/build.gradle.kts` so the Tasker background-intent fix (#1097, already merged) ships in a new Play build.

`versionName` is left at `3.9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDD8mfAwTkK3CjUS4eETUA)_