### PR TITLE
Fix Tasker intents dying at handleIntent action switch

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 139
+        versionCode = 140
         versionName = "3.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/docs/tasker-integration.md
+++ b/docs/tasker-integration.md
@@ -94,8 +94,10 @@ Opens the app and optionally navigates to a specific task or tab.
 
 **Example payload:**
 ```json
-{"tab":"inbox"}
+{"tab":"goals"}
 ```
+
+> **Target must be Activity, not Broadcast Receiver.** Unlike CREATE / COMPLETE / QUERY (which just mutate state or return data and work fine as broadcasts), OPEN needs to bring dayGLANCE to the foreground. Android does not let a background broadcast launch an activity, so if you send OPEN as a **Broadcast Receiver** the tab will change silently underneath but the app won't come forward. In Tasker's Intent action, set **Target: Activity** and **Package: `com.dayglance.app`** for OPEN.
 
 ---
 

--- a/src/intents/useAndroidIntentBridge.js
+++ b/src/intents/useAndroidIntentBridge.js
@@ -1,6 +1,21 @@
 import { useEffect, useRef } from 'react';
+import { ACTIONS } from '@glance-apps/intents';
 import { isNativeAndroid, nativeGetPendingIntent, nativeReportIntentResult } from '../native';
 import { handleIntent } from './handleIntent.js';
+
+/**
+ * The native transport delivers the fully-qualified Android action string
+ * (e.g. "app.dayglance.OPEN") — that's what IntentReceiver / onNewIntent store.
+ * handleIntent, however, switches on the short ACTIONS constants ("open"), so
+ * the raw broadcast action never matches and every intent falls through to
+ * "Unknown action". Map the broadcast action to the intents action here.
+ */
+const BROADCAST_ACTION_MAP = {
+  'app.dayglance.CREATE': ACTIONS.CREATE,
+  'app.dayglance.COMPLETE': ACTIONS.COMPLETE,
+  'app.dayglance.OPEN': ACTIONS.OPEN,
+  'app.dayglance.QUERY': ACTIONS.QUERY,
+};
 
 /**
  * Android intent transport bridge.
@@ -29,14 +44,19 @@ export function useAndroidIntentBridge(context) {
       if (!intent) return;
 
       const { action, payload = {} } = intent;
+      // action is the Android broadcast action (e.g. "app.dayglance.OPEN");
+      // translate it to the short ACTIONS constant handleIntent expects.
+      const mappedAction = BROADCAST_ACTION_MAP[action] ?? action;
       let result;
       try {
-        result = await handleIntent(action, payload, contextRef.current);
+        result = await handleIntent(mappedAction, payload, contextRef.current);
       } catch (err) {
         result = { success: false, error: err?.message ?? String(err) };
       }
 
-      console.log('[intent-bridge]', action, result);
+      // Report back under the ORIGINAL broadcast action so Tasker's RESULT
+      // listener sees %action = "app.dayglance.OPEN" as documented.
+      console.log('[intent-bridge]', action, '→', mappedAction, result);
       nativeReportIntentResult(action, JSON.stringify(result));
     };
 


### PR DESCRIPTION
## The real reason nothing happened

The earlier background-delivery fix (#1097) was necessary but not sufficient. Even with the wake broadcast reaching JS, **no Tasker intent did anything** — because it died at the action switch inside `handleIntent`.

The native transport stores the **fully-qualified Android action string**:
- `IntentReceiver` → `action = intent.action` = `"app.dayglance.OPEN"`
- `MainActivity.onNewIntent` / `storeIntentAction` → same

`useAndroidIntentBridge` passed that straight into `handleIntent`, but `handleIntent` switches on the **short** `ACTIONS` constants (`"open"`, `"create"`, `"complete"`, `"query"` — confirmed by the emitters that build envelopes with `action: 'create'` / `action: 'notify'`). So `"app.dayglance.OPEN"` never matched any case and fell through to:

```js
default:
  return fail(`Unknown action: ${action}`);
```

Every intent — foreground or background — returned `{ success: false, error: "Unknown action: app.dayglance.OPEN" }` and never navigated, created, or completed anything. That's why the app just sat there.

## Fix

- **Map the broadcast action to the `ACTIONS` constant** (`BROADCAST_ACTION_MAP`) before calling `handleIntent`, in `useAndroidIntentBridge`.
- **Report back under the original broadcast action** so Tasker's RESULT listener still sees `%action = "app.dayglance.OPEN"` as documented.
- **Document the OPEN foreground caveat:** OPEN must be sent as an **Activity** intent (Tasker → Target: Activity), not a Broadcast Receiver. Android won't let a background broadcast launch an activity, so a broadcast OPEN flips the tab silently but can't pull the app to the front. CREATE / COMPLETE / QUERY stay as broadcasts.
- **Bump `versionCode` 139 → 140** so the corrected build is distinct from the 139 build (which shipped the still-broken feature).

## Testing notes

Dev dependencies aren't installed in this environment, so the vitest suite couldn't be exercised here. The change is a small, self-contained lookup map plus a docs/version bump. Worth a quick on-device check: with this build, fire `app.dayglance.QUERY` as a broadcast and confirm the RESULT comes back `success:true` with counts; fire `app.dayglance.OPEN {"tab":"goals"}` as an **Activity** intent and confirm the app opens to Goals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDD8mfAwTkK3CjUS4eETUA)_