### PR TITLE
Handle app.dayglance.* intents on cold start

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 140
+        versionCode = 141
         versionName = "3.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -173,6 +173,16 @@ class MainActivity : AppCompatActivity() {
             ACTION_ADD_TASK       -> store.pendingAddTask = true
             ACTION_ADD_INBOX_TASK -> store.pendingAddInboxTask = true
             Intent.ACTION_SEND    -> storeShareIntent(intent, store)
+            // Cold start via an app.dayglance.* Activity intent (app was killed):
+            // onNewIntent is NOT called for the launching intent, so without this the
+            // action's payload — the target tab for OPEN, the task for COMPLETE, etc. —
+            // would be dropped and the app would just open to the default tab. Store it
+            // like onNewIntent does; the intent bridge drains it on mount (no JS poke
+            // here — the WebView hasn't loaded yet).
+            "app.dayglance.CREATE",
+            "app.dayglance.COMPLETE",
+            "app.dayglance.OPEN",
+            "app.dayglance.QUERY" -> storeIntentAction(intent, store)
         }
 
         billingManager = BillingManager(this, dataStore)


### PR DESCRIPTION
## Problem

`MainActivity.onCreate` handled the launcher-shortcut actions (voice, add-task, share) but **not** the `app.dayglance.*` intent actions — only `onNewIntent` did. `onNewIntent` isn't called for the intent that *launches* a killed app, so sending one of these as an **Activity** intent to a swiped-away app dropped its payload:

- **OPEN** opened the app but to the **default tab**, ignoring the requested `tab`.
- **COMPLETE / QUERY** as Activity intents did **nothing** on a cold start.

(The broadcast forms were unaffected — `IntentReceiver` stores those even when the app is dead.)

## Fix

Store the action in `onCreate` the same way `onNewIntent` already does (`storeIntentAction`). The intent bridge drains it on mount, so no JS poke is needed here — the WebView hasn't loaded yet. `onCreate` and `onNewIntent` stay mutually exclusive per delivery, so nothing is double-stored.

Net effect: a single **Activity-target COMPLETE** now both launches a killed app *and* completes the task — no separate OPEN "wake" step required, which also sidesteps the single-slot pending-intent limitation (only one action is ever in flight).

- Bumps `versionCode` 140 → 141.

## Testing notes

Native change; couldn't build/sideload here. Worth verifying on-device: fully kill dayGLANCE, then fire `app.dayglance.OPEN {"tab":"goals"}` as an **Activity** intent → app should cold-start **on the Goals tab**. Then kill it again and fire `app.dayglance.COMPLETE {"title":"…"}` as an **Activity** intent → app should launch and the task should be completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDD8mfAwTkK3CjUS4eETUA)_