### PR TITLE
Release v3.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="75">](https://play.google.com/store/apps/details?id=com.dayglance.app)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.9.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-3.10.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 141
-        versionName = "3.9"
+        versionCode = 142
+        versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "dependencies": {
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
-  "version": "3.9.0",
+  "version": "3.10.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps the app version to **3.10.0** for the release that includes the new Goals Roadmap view and the Tasker intents fix (both already merged to `main`).

## Changes

- `package.json` and `package-lock.json`: 3.9.0 to 3.10.0 (minor bump for the new Roadmap feature).
- Android (`dayglance-android/app/build.gradle.kts`): `versionCode` 141 to 142, `versionName` "3.9" to "3.10".
- README version badge: 3.9.0 to 3.10.0.

Version-only change; no application code is touched. The lockfile diff is limited to the two root version fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SNd22BDXoqcoXX4HB4zEk

---
_Generated by [Claude Code](https://claude.ai/code/session_017SNd22BDXoqcoXX4HB4zEk)_