### PR TITLE
Update About panel copyright and add support/web contact lines

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -36,6 +36,10 @@ module.exports = {
   // global appId — there is no per-target override — hence the env switch.
   appId: process.env.DAYGLANCE_APP_ID || 'com.dayglance.app',
   productName: 'dayGLANCE',
+  // NSHumanReadableCopyright in the bundle's Info.plist. Keeps the packaged
+  // metadata consistent with the runtime About panel (set via
+  // app.setAboutPanelOptions in electron/main.ts).
+  copyright: 'Copyright © 2026 GLANCE Apps',
   // CFBundleVersion (the *build* number) — must strictly increase on every App
   // Store upload, independent of the marketing version (CFBundleShortVersionString,
   // which stays `version` from package.json, e.g. 3.8.1). Auto-derived from the

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -433,6 +433,16 @@ ipcMain.on('ws:push-state', (event) => {
   }
 });
 
+// Native macOS "About dayGLANCE" panel. macOS builds it from the bundle's
+// Info.plist, but setAboutPanelOptions lets us override the copyright and add
+// contact/website lines via the credits field (rendered below the copyright).
+// applicationName/version are left to Info.plist so they stay in sync with the
+// build (CFBundleShortVersionString + CFBundleVersion).
+app.setAboutPanelOptions({
+  copyright: 'Copyright © 2026 GLANCE Apps',
+  credits: 'Support: support@glance-apps.com\nWeb: https://www.glance-apps.com/',
+});
+
 app.whenReady().then(() => {
   // Content Security Policy — applied to every response the renderer loads.
   // script-src 'self': only scripts from the app bundle (no inline scripts, no eval).


### PR DESCRIPTION
## What changed

The macOS "About dayGLANCE" panel is the **native** panel — there was no custom About code in the Electron main process. This PR customizes the fields macOS renders:

- **Copyright** → `Copyright © 2026 GLANCE Apps` (was an auto-generated default)
- **Credits** (rendered directly below the copyright in the native panel) → two new lines:
  - `Support: support@glance-apps.com`
  - `Web: https://www.glance-apps.com/`

## How

- `electron/main.ts`: added `app.setAboutPanelOptions({ copyright, credits })` so the runtime panel shows the new copyright and contact lines. The application name and version strings are left to `Info.plist` so they stay in sync with the build (`CFBundleShortVersionString` + `CFBundleVersion`).
- `electron-builder.config.cjs`: set the `copyright` field so the packaged bundle's `Info.plist` (`NSHumanReadableCopyright`) matches the runtime panel.

## Notes

- These fields (`copyright`, `credits`) are effective on macOS, which is where the About panel in question is shown.
- A fully custom About window (cross-platform, styled, clickable links) is a possible follow-up — noted for down the road.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UQiSTWTpQSoH8cCv9sQGT

---
_Generated by [Claude Code](https://claude.ai/code/session_011UQiSTWTpQSoH8cCv9sQGT)_