### PR TITLE
Fix routines showing already-completed when added in the morning

### DIFF
--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -1,6 +1,47 @@
 import { useState, useEffect } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
 
+// Local midnight (00:00:00) of the current day, as an ISO instant. This is the
+// moment routine completions "reset" each day, and the timestamp used to stamp
+// day-rollover tombstones. Choosing local midnight (rather than "now") is
+// load-bearing for multi-device sync: the tombstone must be NEWER than a stale
+// completion carried over from a PRIOR day (so it heals the resurrection), yet
+// OLDER than any genuine completion made earlier TODAY on another device (whose
+// timestamp is after midnight, so it still wins the LWW merge).
+export const startOfTodayIso = (now = new Date()) => {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString();
+};
+
+// Build the routine-completion state to load for `todayStr` from the persisted
+// maps. Today's completions are kept verbatim; every routine that carried a
+// prior-day completion or timestamp is reset for the new day — its completion
+// dropped and its timestamp replaced with a `midnightIso` tombstone. That
+// tombstone out-dates a stale remote completion on the day's first sync, so a
+// freshly re-added routine no longer shows up already-completed. This runs on
+// every load, so it fixes the common case (app closed overnight) that the
+// open-across-midnight rollover effect below never reaches.
+export const resetRoutineCompletionsForToday = (
+  storedCompletions = {}, storedTimestamps = {}, todayStr, midnightIso,
+) => {
+  const completions = {};
+  for (const [id, date] of Object.entries(storedCompletions)) {
+    if (date === todayStr) completions[id] = date;
+  }
+  const timestamps = {};
+  for (const id of new Set([...Object.keys(storedCompletions), ...Object.keys(storedTimestamps)])) {
+    // A genuine completion made today keeps its real timestamp so its recency is
+    // preserved for the LWW merge; anything older is reset to a midnight tombstone.
+    if (completions[id] && typeof storedTimestamps[id] === 'string' && storedTimestamps[id] >= midnightIso) {
+      timestamps[id] = storedTimestamps[id];
+    } else {
+      timestamps[id] = midnightIso;
+    }
+  }
+  return { completions, timestamps };
+};
+
 const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, hrOwnerRef }) => {
   // The dashboard's active owner (multi-user) or null in single-user mode.
   const currentOwner = () => hrOwnerRef?.current ?? null;
@@ -10,31 +51,24 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
   const [todayRoutines, setTodayRoutines] = useState([]);
   const [routinesDate, setRoutinesDate] = useState('');
   const [removedTodayRoutineIds, setRemovedTodayRoutineIds] = useState({});
-  const [routineCompletions, setRoutineCompletions] = useState(() => {
+  // Load today's completion state from the persisted maps. Both the completions
+  // and their sibling LWW timestamps are derived together so a routine reset for
+  // the new day gets a midnight tombstone (see resetRoutineCompletionsForToday),
+  // which stops a stale remote completion from resurrecting it on the first sync
+  // — the "added-already-completed" bug. Read once, since the timestamp
+  // initializer needs the raw completions too.
+  const loadRoutineState = () => {
     try {
-      const stored = JSON.parse(localStorage.getItem('day-planner-routine-completions') || '{}');
-      const todayStr = dateToString(new Date());
-      const filtered = {};
-      for (const [id, date] of Object.entries(stored)) {
-        if (date === todayStr) filtered[id] = date;
-      }
-      return filtered;
-    } catch (_) { return {}; }
-  });
+      const storedC = JSON.parse(localStorage.getItem('day-planner-routine-completions') || '{}');
+      const storedTs = JSON.parse(localStorage.getItem('day-planner-routine-completion-timestamps') || '{}');
+      return resetRoutineCompletionsForToday(storedC, storedTs, dateToString(new Date()), startOfTodayIso());
+    } catch (_) { return { completions: {}, timestamps: {} }; }
+  };
+  const [routineCompletions, setRoutineCompletions] = useState(() => loadRoutineState().completions);
   // Per-routine completion timestamps (ISO), the sync LWW key that lets an
-  // un-complete win over a stale complete instead of being resurrected by a
-  // grow-union merge. Kept day-scoped (the ISO date prefix must be today).
-  const [routineCompletionTimestamps, setRoutineCompletionTimestamps] = useState(() => {
-    try {
-      const stored = JSON.parse(localStorage.getItem('day-planner-routine-completion-timestamps') || '{}');
-      const todayStr = dateToString(new Date());
-      const filtered = {};
-      for (const [id, iso] of Object.entries(stored)) {
-        if (typeof iso === 'string' && iso.slice(0, 10) === todayStr) filtered[id] = iso;
-      }
-      return filtered;
-    } catch (_) { return {}; }
-  });
+  // un-complete (or a day-rollover reset) win over a stale complete instead of
+  // being resurrected by a grow-union merge.
+  const [routineCompletionTimestamps, setRoutineCompletionTimestamps] = useState(() => loadRoutineState().timestamps);
   const [showRoutinesDashboard, setShowRoutinesDashboard] = useState(false);
   const [dashboardSelectedChips, setDashboardSelectedChips] = useState([]);
   const [routineAddingToBucket, setRoutineAddingToBucket] = useState(null);
@@ -85,13 +119,16 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
       // Instead, stamp a fresh tombstone (completion absent, timestamp = now)
       // for every id that carried a completion or an old timestamp, so the
       // cleared state out-dates the stale remote completion and heals it.
-      const nowIso = new Date().toISOString();
+      // Stamp the reset at local midnight of the new day — the same instant the
+      // load-time reset uses — so an un-complete made later today on another
+      // device still out-dates this tombstone and wins the merge.
+      const midnightIso = startOfTodayIso();
       const tombstones = {};
       for (const id of new Set([
         ...Object.keys(routineCompletions),
         ...Object.keys(routineCompletionTimestamps),
       ])) {
-        tombstones[id] = nowIso;
+        tombstones[id] = midnightIso;
       }
       setRoutineCompletionTimestamps(tombstones);
       localStorage.removeItem('day-planner-removed-today-routine-ids');

--- a/src/hooks/useRoutines.test.js
+++ b/src/hooks/useRoutines.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { resetRoutineCompletionsForToday, startOfTodayIso } from './useRoutines.js';
+
+const TODAY = '2026-07-03';
+const MIDNIGHT = '2026-07-03T00:00:00.000Z'; // local-midnight stand-in for the tests
+const YESTERDAY = '2026-07-02';
+const YESTERDAY_TS = '2026-07-02T21:00:00.000Z';
+const TODAY_MORNING_TS = '2026-07-03T09:00:00.000Z';
+
+describe('resetRoutineCompletionsForToday', () => {
+  it("drops a prior-day completion and stamps a midnight tombstone (the added-already-completed bug)", () => {
+    const { completions, timestamps } = resetRoutineCompletionsForToday(
+      { chip1: YESTERDAY }, { chip1: YESTERDAY_TS }, TODAY, MIDNIGHT,
+    );
+    // Completion cleared for the new day...
+    expect(completions.chip1).toBeUndefined();
+    // ...but a tombstone timestamp remains, and it out-dates the stale completion.
+    expect(timestamps.chip1).toBe(MIDNIGHT);
+    expect(new Date(timestamps.chip1).getTime()).toBeGreaterThan(new Date(YESTERDAY_TS).getTime());
+  });
+
+  it("keeps a genuine completion made today, with its real timestamp", () => {
+    const { completions, timestamps } = resetRoutineCompletionsForToday(
+      { chip1: TODAY }, { chip1: TODAY_MORNING_TS }, TODAY, MIDNIGHT,
+    );
+    expect(completions.chip1).toBe(TODAY);
+    expect(timestamps.chip1).toBe(TODAY_MORNING_TS);
+  });
+
+  it("tombstone does not clobber a completion made earlier today on another device", () => {
+    // Local device has only yesterday's data (was closed overnight); it emits a
+    // midnight tombstone. A completion made today at 09:00 (on another device)
+    // has a later timestamp, so it must still win the LWW merge.
+    const { timestamps } = resetRoutineCompletionsForToday(
+      { chip1: YESTERDAY }, { chip1: YESTERDAY_TS }, TODAY, MIDNIGHT,
+    );
+    expect(new Date(TODAY_MORNING_TS).getTime()).toBeGreaterThan(new Date(timestamps.chip1).getTime());
+  });
+
+  it("resets a prior-day completion that has no timestamp (legacy data)", () => {
+    const { completions, timestamps } = resetRoutineCompletionsForToday(
+      { chip1: YESTERDAY }, {}, TODAY, MIDNIGHT,
+    );
+    expect(completions.chip1).toBeUndefined();
+    expect(timestamps.chip1).toBe(MIDNIGHT);
+  });
+
+  it("handles empty maps", () => {
+    expect(resetRoutineCompletionsForToday({}, {}, TODAY, MIDNIGHT)).toEqual({ completions: {}, timestamps: {} });
+  });
+});
+
+describe('startOfTodayIso', () => {
+  it('returns local midnight of the given day', () => {
+    const iso = startOfTodayIso(new Date('2026-07-03T14:30:00'));
+    const d = new Date(iso);
+    expect(d.getHours()).toBe(0);
+    expect(d.getMinutes()).toBe(0);
+    expect(d.getSeconds()).toBe(0);
+    expect(d.getMilliseconds()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

Routines added in the morning could appear **already completed** (strikethrough text). Completions are day-scoped and are supposed to reset at local midnight, but they weren't reliably doing so.

## Root cause

The tombstone that clears a prior-day completion was only stamped by the **open-across-midnight** rollover effect in `useRoutines`. When the app is **closed overnight and reopened the next day** (the common case), that effect never fires:

- `useDataPersistence` runs first on load and, seeing `routinesDate` ≠ today, immediately advances `routinesDate` to today.
- So the rollover effect's guard (`routinesDate && routinesDate !== todayStr`) is already false — it no-ops.
- The load-time initializers merely *dropped* yesterday's local completion entries, leaving **no tombstone** behind.

On the day's first sync, the remote vault still held yesterday's completion with a real timestamp. In `mergeRoutineCompletions`, local had no competing timestamp (time 0) while remote did, so the stale completion was **resurrected**. Every UI site renders `routineCompletions[id]` as done by plain truthiness, so the routine showed struck-through.

The earlier fix (tombstones at rollover) was correct in principle but lived in a code path that doesn't run in the overnight-close scenario.

## Fix

Generate the reset tombstone at **load time**, not just at rollover:

- Extract a pure `resetRoutineCompletionsForToday()` that keeps today's completions verbatim and stamps a tombstone for every prior-day routine id, and use it in both completion-state initializers in `useRoutines`.
- Stamp the tombstone at **local midnight** (`startOfTodayIso`), not `now`. This is load-bearing for multi-device sync: the tombstone must be *newer* than a stale prior-day completion (so it heals the resurrection) yet *older* than a genuine completion made later today on another device (so that real completion still wins the LWW merge).
- Align the open-across-midnight rollover effect to stamp the same local-midnight instant for consistency.

## Tests

Adds `src/hooks/useRoutines.test.js` covering the reset helper:
- prior-day completion is dropped and gets a midnight tombstone that out-dates the stale completion (the bug);
- a genuine completion made today is preserved with its real timestamp;
- the midnight tombstone does not clobber a completion made earlier today on another device;
- legacy (no-timestamp) and empty-map cases.

Full suite: 434 tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UQiSTWTpQSoH8cCv9sQGT

---
_Generated by [Claude Code](https://claude.ai/code/session_011UQiSTWTpQSoH8cCv9sQGT)_