### PR TITLE
Electron: settle Restore Purchases on receipt validation, not a fixed 4s timer

### DIFF
--- a/electron/subscription.ts
+++ b/electron/subscription.ts
@@ -56,6 +56,30 @@ function fireBillingEvent(payload: object): void {
   live()?.webContents.send('subscription:event', payload);
 }
 
+// ── Restore settlement ────────────────────────────────────────────────────────
+// StoreKit delivers restored purchases through 'transactions-updated', but
+// Electron exposes no "restore finished" callback, so a restore that finds no
+// purchases produces no event at all. Settlement is therefore dual-path: a
+// restored transaction settles as soon as its receipt validates (regardless of
+// network speed), and a fallback timer settles the nothing-to-restore case.
+// Whichever runs first wins; the other becomes a no-op.
+
+const RESTORE_FALLBACK_MS = 10_000;
+let restorePending = false;
+let restoreFallback: NodeJS.Timeout | null = null;
+
+function settleRestore(active: boolean, productId: string | null): void {
+  if (!restorePending) return;
+  restorePending = false;
+  if (restoreFallback) { clearTimeout(restoreFallback); restoreFallback = null; }
+  fireBillingEvent({
+    status: 'cancelled', // mirrors Android restore pattern: spinner clears, no "new purchase" UI
+    code: 0,
+    message: active ? 'restore_complete_active' : 'restore_complete',
+    productId: productId ?? '',
+  });
+}
+
 // ── RevenueCat REST API ───────────────────────────────────────────────────────
 
 async function rcFetch(method: string, endpoint: string, body?: object): Promise<unknown> {
@@ -123,13 +147,18 @@ export function registerSubscriptionHandlers(window: BrowserWindow): void {
   inAppPurchase.on('transactions-updated', (async (_event: any, transactions: Electron.Transaction[]) => {
     for (const t of transactions) {
       if (t.transactionState === 'purchased' || t.transactionState === 'restored') {
-        await fetchEntitlementStatus(); // validates receipt with RC; result delivered via subscription:status
+        const s = await fetchEntitlementStatus(); // validates receipt with RC; result delivered via subscription:status
         fireBillingEvent({
           status: 'success',
           code: 0,
           message: 'ok',
           productId: t.payment.productIdentifier,
         });
+        if (t.transactionState === 'restored') {
+          // Explicit Restore Purchases flow: the receipt has validated, so
+          // settle now instead of leaving it to the fallback timer.
+          settleRestore(s.active, s.productId ?? t.payment.productIdentifier);
+        }
         inAppPurchase.finishTransactionByDate(t.transactionDate);
       } else if (t.transactionState === 'failed') {
         const cancelled = t.errorCode === 2; // SKErrorPaymentCancelled
@@ -184,17 +213,16 @@ export function registerSubscriptionHandlers(window: BrowserWindow): void {
     }
     try {
       inAppPurchase.restoreCompletedTransactions();
-      // Give StoreKit time to deliver restored transactions via 'transactions-updated',
-      // then post receipt and fire the terminal event.
-      setTimeout(async () => {
+      // Fast path: a restored transaction settles this via 'transactions-updated'
+      // as soon as its receipt validates. The timer only covers the
+      // nothing-to-restore case, which produces no StoreKit event at all.
+      restorePending = true;
+      if (restoreFallback) clearTimeout(restoreFallback);
+      restoreFallback = setTimeout(async () => {
+        restoreFallback = null;
         const s = await fetchEntitlementStatus();
-        fireBillingEvent({
-          status: 'cancelled', // mirrors Android restore pattern: spinner clears, no "new purchase" UI
-          code: 0,
-          message: s.active ? 'restore_complete_active' : 'restore_complete',
-          productId: s.productId ?? '',
-        });
-      }, 4000);
+        settleRestore(s.active, s.productId);
+      }, RESTORE_FALLBACK_MS);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Restore failed';
       fireBillingEvent({ status: 'error', code: 0, message: msg, productId: '' });


### PR DESCRIPTION
Closes the last code-level MEDIUM from the v4.0.0 pre-release review.

## Problem
`subscription:restore` fired its terminal `restore_complete` event after a flat `setTimeout(4000)`, without waiting for StoreKit. On a slow network the timer won the race: the user was told the restore finished with nothing restored, then the entitlement activated silently a few seconds later. On a fresh install during launch week, that reads as "restore is broken" and generates support mail or duplicate purchases.

## Fix
Dual-path settlement in `electron/subscription.ts`:

- **Fast path**: when a `restored` transaction arrives via `transactions-updated`, the flow settles immediately after its receipt validates with RevenueCat — correct at any network speed.
- **Fallback**: a timer (raised 4s → 10s) covers only the nothing-to-restore case, which is invisible to us because Electron's `inAppPurchase` doesn't expose StoreKit's restore-finished callback — zero restored transactions means zero events.
- Whichever path runs first wins; the other becomes a no-op (`restorePending` guard).

The per-transaction `success` event still fires before settlement, preserving the renderer contract (`useSubscription.js` re-reads entitlement only on `success`; the terminal event just clears the spinner). No renderer changes.

## Verification
- `tsc` main + preload: pass
- Behavior needs a MAS-signed build to exercise end-to-end — worth folding into the same Mac smoke-test pass as #1110: restore with an existing purchase (should settle as soon as validation completes) and restore on an account with no purchases (should settle at ~10s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_