### PR TITLE
Fix inbound-create → outbound-delete intent loop

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -540,6 +540,12 @@ const DayPlanner = () => {
   const syncKeyReadyRef = useRef(syncKeyReady);
   useEffect(() => { syncKeyReadyRef.current = syncKeyReady; }, [syncKeyReady]);
 
+  // True while applyEngineData is applying remote/merged data (declared here,
+  // above the intent emitters, so those hooks can read it as their remote-apply
+  // guard — a sync-driven setGoals/setTasks must NOT echo an outbound intent).
+  // Set in applyEngineData; cleared 500ms later (see applyingRemoteDataRef usage).
+  const applyingRemoteDataRef   = useRef(false); // true while applyEngineData is running
+
   // ── Cloud sync engine ────────────────────────────────────────────────────
   // The orchestration (download → validate → merge → apply → upload, with
   // backoff, hard-stops, 412 retry, follow-up queueing, etc.) lives in
@@ -1138,8 +1144,15 @@ const DayPlanner = () => {
       if (tab === 'glance' || tab === 'inbox') setTabletActiveTab(tab === 'glance' ? 'glance' : 'inbox');
     },
   });
-  useNotifyEmitter({ tasks, unscheduledTasks });
-  useGoalNotifyEmitter({ goals });
+  // Guard the intent emitters against sync/remote-apply-driven state changes: a
+  // setGoals/setTasks coming from applyEngineData (or any merge apply) must not
+  // echo an outbound intent, mirroring how the cloud-upload effect bails on
+  // suppressCloudUploadRef. applyingRemoteDataRef covers the whole apply window
+  // (cleared on a 500ms timer, never mid-commit); suppressCloudUploadRef is
+  // included as the same belt the push side uses.
+  const isRemoteApply = () => applyingRemoteDataRef.current || suppressCloudUploadRef.current;
+  useNotifyEmitter({ tasks, unscheduledTasks, isRemoteApply });
+  useGoalNotifyEmitter({ goals, isRemoteApply });
   // Durable outbox background drain: flush queued intents on mount (catches
   // anything held from a previous session), on focus, and on the poll cadence.
   useOutboxFlush();
@@ -1847,7 +1860,9 @@ const DayPlanner = () => {
   // last changed on this device, so mergeSyncData can do last-writer-wins instead
   // of remote-always-wins.
   const configTrackingActiveRef = useRef(false); // false until after initial loadData
-  const applyingRemoteDataRef   = useRef(false); // true while applyEngineData is running
+  // applyingRemoteDataRef is declared earlier (near the cloud-sync refs) so the
+  // intent emitters, which mount above this point, can read it as their
+  // remote-apply guard.
   // Timestamp (ms) when the iCloud mutex was taken, so a foreground resume can
   // tell a genuinely in-flight cycle from one stranded by iOS suspending the app
   // mid-sync (the in-flight promise never settles, so its finally never clears

--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -20,6 +20,34 @@ import {
 
 export const DEFAULT_TASK_COLOR = 'bg-blue-500';
 
+// localStorage key holding the goal tombstone map ({ id → deletedAt ISO }).
+// Kept in sync with useGoalsProjects.deleteGoal, which writes it.
+const DELETED_GOAL_IDS_KEY = 'day-planner-deleted-goal-ids';
+
+/**
+ * Clear a stale tombstone for a goal id, if present.
+ *
+ * An inbound cross-app CREATE is authoritative: it must supersede any local
+ * tombstone left by a prior deletion of the same (deterministic) id, otherwise
+ * the tombstone wins the last-writer-wins sync merge and re-drops the goal we
+ * just created — which the notify emitter then echoes back as a spurious
+ * `deleted`. Removing the tombstone as part of the create lets the merge keep
+ * the goal. No-ops safely when storage is unavailable (skeleton/tests) or the
+ * id was never tombstoned.
+ */
+function clearGoalTombstone(goalId) {
+  if (!goalId || typeof localStorage === 'undefined') return;
+  try {
+    const raw = localStorage.getItem(DELETED_GOAL_IDS_KEY);
+    if (!raw) return;
+    const tombstones = JSON.parse(raw);
+    if (Object.prototype.hasOwnProperty.call(tombstones, String(goalId))) {
+      delete tombstones[String(goalId)];
+      localStorage.setItem(DELETED_GOAL_IDS_KEY, JSON.stringify(tombstones));
+    }
+  } catch (_) { /* malformed/absent storage — nothing to clear */ }
+}
+
 // Derive a deterministic UUID from a seed string so that two devices
 // processing the same intent create tasks with the same ID, letting the sync
 // engine deduplicate them naturally rather than keeping both copies.
@@ -138,6 +166,10 @@ async function handleCreateGoal(payload, context) {
       g => g.source_app === payload.source_app && g.source_entity_id === payload.source_entity_id
     );
     if (existing) {
+      // Still supersede any stale tombstone for the existing goal so a pending
+      // sync merge can't drop it out from under us (same reasoning as the create
+      // path below).
+      clearGoalTombstone(existing.id);
       return ok({ task_id: existing.id, warning: 'Goal already exists' });
     }
   }
@@ -153,6 +185,12 @@ async function handleCreateGoal(payload, context) {
   const goalId = payload.source_app && payload.source_entity_id
     ? await deterministicTaskId(`${payload.source_app}|${payload.source_entity_id}`)
     : crypto.randomUUID();
+
+  // This inbound create supersedes any stale tombstone for this id (a prior
+  // deletion). Clear it BEFORE adding so the next sync merge keeps the new goal
+  // instead of re-dropping it against the tombstone (which the notify emitter
+  // would then echo outbound as a spurious `deleted`).
+  clearGoalTombstone(goalId);
 
   const newGoal = addGoal({
     id: goalId,

--- a/src/intents/handleIntent.test.js
+++ b/src/intents/handleIntent.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { createKey, TABS, QUERY_RETURN_VARS } from '@glance-apps/intents';
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { createKey, TABS, QUERY_RETURN_VARS, ENTITY_TYPES, SOURCE_APPS } from '@glance-apps/intents';
 import { handleIntent } from './handleIntent.js';
 
 // ─── create ────────────────────────────────────────────────────────────────
@@ -692,5 +692,98 @@ describe('handleIntent create execution', () => {
     await handleIntent('create', { title: 'Quick task' }, ctx);
     expect(ctx._inbox[0].color).toBe('bg-blue-500');
     expect(ctx._inbox[0].duration).toBe(30);
+  });
+});
+
+// ─── inbound goal create supersedes a stale tombstone (create/delete-loop fix) ──
+
+describe('handleIntent create goal — clears stale tombstone', () => {
+  const DELETED_GOAL_IDS_KEY = 'day-planner-deleted-goal-ids';
+
+  function memLocalStorage() {
+    const m = new Map();
+    return {
+      getItem: (k) => (m.has(k) ? m.get(k) : null),
+      setItem: (k, v) => m.set(k, String(v)),
+      removeItem: (k) => m.delete(k),
+      clear: () => m.clear(),
+    };
+  }
+
+  const readTombstones = () =>
+    JSON.parse(localStorage.getItem(DELETED_GOAL_IDS_KEY) || '{}');
+
+  const goalPayload = {
+    title: 'Rule of 55',
+    entity_type: ENTITY_TYPES.GOAL,
+    source_app: SOURCE_APPS.LIFEGLANCE,
+    source_entity_id: 'milestone_55',
+  };
+
+  beforeEach(() => {
+    global.localStorage = memLocalStorage();
+  });
+  afterAll(() => { delete global.localStorage; });
+
+  it('create path: clears the goal tombstone so the next merge keeps the goal', async () => {
+    // First create to learn the deterministic id the create path derives.
+    let capturedId = null;
+    const addGoal = (fields) => { capturedId = fields.id; return { id: fields.id }; };
+    await handleIntent('create', goalPayload, { goals: [], addGoal });
+    expect(capturedId).toBeTruthy();
+
+    // Simulate: the goal was later deleted (tombstone recorded) and dropped from
+    // state by a sync merge. lifeGLANCE re-emits the create.
+    localStorage.setItem(DELETED_GOAL_IDS_KEY, JSON.stringify({
+      [capturedId]: '2026-07-01T00:00:00.000Z',
+      'unrelated-goal': '2026-06-01T00:00:00.000Z',
+    }));
+
+    let secondId = null;
+    const addGoal2 = (fields) => { secondId = fields.id; return { id: fields.id }; };
+    const r = await handleIntent('create', goalPayload, { goals: [], addGoal: addGoal2 });
+
+    expect(r.success).toBe(true);
+    expect(secondId).toBe(capturedId);         // same deterministic id
+    const tombstones = readTombstones();
+    expect(tombstones[capturedId]).toBeUndefined();   // superseded
+    expect(tombstones['unrelated-goal']).toBe('2026-06-01T00:00:00.000Z'); // untouched
+  });
+
+  it('idempotency path: clears the tombstone for an already-existing goal', async () => {
+    const existing = {
+      id: 'goal-existing',
+      title: 'True retirement',
+      source_app: SOURCE_APPS.LIFEGLANCE,
+      source_entity_id: 'milestone_tr',
+    };
+    localStorage.setItem(DELETED_GOAL_IDS_KEY, JSON.stringify({
+      'goal-existing': '2026-07-01T00:00:00.000Z',
+    }));
+
+    let addCalled = false;
+    const addGoal = () => { addCalled = true; return { id: 'x' }; };
+    const r = await handleIntent(
+      'create',
+      { ...goalPayload, title: 'True retirement', source_entity_id: 'milestone_tr' },
+      { goals: [existing], addGoal },
+    );
+
+    expect(r.success).toBe(true);
+    expect(r.task_id).toBe('goal-existing');
+    expect(r.warning).toContain('already exists');
+    expect(addCalled).toBe(false);                        // no duplicate created
+    expect(readTombstones()['goal-existing']).toBeUndefined(); // tombstone cleared
+  });
+
+  it('leaves an unrelated tombstone alone when no tombstone exists for the created goal', async () => {
+    localStorage.setItem(DELETED_GOAL_IDS_KEY, JSON.stringify({
+      'some-other-id': '2026-06-01T00:00:00.000Z',
+    }));
+    const addGoal = (fields) => ({ id: fields.id });
+    const r = await handleIntent('create', goalPayload, { goals: [], addGoal });
+
+    expect(r.success).toBe(true);
+    expect(readTombstones()['some-other-id']).toBe('2026-06-01T00:00:00.000Z');
   });
 });

--- a/src/intents/useGoalNotifyEmitter.js
+++ b/src/intents/useGoalNotifyEmitter.js
@@ -43,13 +43,68 @@ function detectGoalChange(prev, next) {
 }
 
 /**
+ * Pure planner: decide what to emit for a prev→next goals snapshot transition,
+ * and what the new baseline snapshot should be. Extracted from the effect so the
+ * remote-apply guard and the deleted/changed diff are unit-testable without a
+ * React renderer.
+ *
+ * Returns { emits, advanceTo }:
+ *   - emits:     array of { goal, change } to enqueue (empty when nothing to send)
+ *   - advanceTo: the snapshot to store as prevRef, or null to leave it unchanged
+ *                (null while a fire() is in flight — it advances the ref itself,
+ *                or when there are emits, which advance after a durable enqueue)
+ *
+ * The isRemoteApply branch is the echo guard: a goals change driven by a
+ * sync/remote apply (applyEngineData's setGoals, or any merge-driven mutation)
+ * must NOT emit an outbound intent — it did not come from the user. It is
+ * consumed into the baseline silently, mirroring how the cloud-upload effect
+ * bails on suppressCloudUploadRef. Without it, a merge that drops a goal (e.g.
+ * re-applying a stale tombstone) looks identical to a user delete and echoes a
+ * spurious `deleted` back to the source app.
+ */
+export function planGoalNotifyEmits(prev, next, { isRemoteApply = false, hasTargets = true, inFlight = false } = {}) {
+  if (prev === null) return { emits: [], advanceTo: next };
+  if (isRemoteApply) return { emits: [], advanceTo: next };
+  if (inFlight) return { emits: [], advanceTo: null };
+  if (!hasTargets) return { emits: [], advanceTo: next };
+
+  const prevMap = new Map(prev.map(g => [g.id, g]));
+  const nextMap = new Map(next.map(g => [g.id, g]));
+
+  const emits = [];
+
+  // Deleted: present in prev but gone from next
+  for (const [id, prevGoal] of prevMap) {
+    if (!shouldEmit(prevGoal)) continue;
+    if (!nextMap.has(id)) {
+      emits.push({ goal: prevGoal, change: { event: EVENTS.DELETED } });
+    }
+  }
+
+  // Changed: present in both prev and next
+  for (const [id, nextGoal] of nextMap) {
+    if (!shouldEmit(nextGoal)) continue;
+    const prevGoal = prevMap.get(id);
+    if (!prevGoal) continue; // new goal — no notify for creation
+    const change = detectGoalChange(prevGoal, nextGoal);
+    if (change) emits.push({ goal: nextGoal, change });
+  }
+
+  if (!emits.length) return { emits: [], advanceTo: next };
+  return { emits, advanceTo: null }; // advanced after durable enqueue
+}
+
+/**
  * Watches goals for changes to goals that carry source_app + source_entity_id,
  * and emits a WebDAV notify event for each state change. No-ops when the intent
  * WebDAV config is absent.
  *
  * Mirrors useNotifyEmitter but for the Goals entity type.
+ *
+ * `isRemoteApply` (optional) is a getter returning true while a sync/remote
+ * apply is mutating goals state, so those changes are never echoed outbound.
  */
-export function useGoalNotifyEmitter({ goals }) {
+export function useGoalNotifyEmitter({ goals, isRemoteApply }) {
   const prevRef = useRef(null);
   const inFlightRef = useRef(false);
   const [, bump] = useReducer(x => x + 1, 0);
@@ -62,38 +117,19 @@ export function useGoalNotifyEmitter({ goals }) {
       return raw ? JSON.parse(raw) : null;
     })();
 
-    const prev = prevRef.current;
-
-    if (prev === null) { prevRef.current = goals; return; }
-    if (inFlightRef.current) return;
-
     const targets = enabledIntentTargets(config);
-    if (targets.length === 0) { prevRef.current = goals; return; }
-
-    const prevMap = new Map(prev.map(g => [g.id, g]));
-    const nextMap = new Map(goals.map(g => [g.id, g]));
     const now = new Date().toISOString();
 
-    const emits = [];
+    const { emits, advanceTo } = planGoalNotifyEmits(prevRef.current, goals, {
+      isRemoteApply: !!isRemoteApply?.(),
+      hasTargets: targets.length > 0,
+      inFlight: inFlightRef.current,
+    });
 
-    // Deleted: present in prev but gone from next
-    for (const [id, prevGoal] of prevMap) {
-      if (!shouldEmit(prevGoal)) continue;
-      if (!nextMap.has(id)) {
-        emits.push({ goal: prevGoal, change: { event: EVENTS.DELETED } });
-      }
+    if (!emits.length) {
+      if (advanceTo !== null) prevRef.current = advanceTo;
+      return;
     }
-
-    // Changed: present in both prev and next
-    for (const [id, nextGoal] of nextMap) {
-      if (!shouldEmit(nextGoal)) continue;
-      const prevGoal = prevMap.get(id);
-      if (!prevGoal) continue; // new goal — no notify for creation
-      const change = detectGoalChange(prevGoal, nextGoal);
-      if (change) emits.push({ goal: nextGoal, change });
-    }
-
-    if (!emits.length) { prevRef.current = goals; return; }
 
     inFlightRef.current = true;
     const fire = async () => {

--- a/src/intents/useGoalNotifyEmitter.test.js
+++ b/src/intents/useGoalNotifyEmitter.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { EVENTS } from '@glance-apps/intents';
+import { planGoalNotifyEmits } from './useGoalNotifyEmitter.js';
+
+// A goal linked to a source app (the only kind that notifies outbound).
+const LINKED_GOAL = {
+  id: 'goal-1',
+  title: 'Run a marathon',
+  status: 'active',
+  source_app: 'app.lifeglance',
+  source_entity_id: 'milestone_7',
+};
+
+describe('planGoalNotifyEmits — remote-apply echo guard', () => {
+  it('emits DELETED when a linked goal is removed by a USER action (not remote)', () => {
+    const { emits, advanceTo } = planGoalNotifyEmits([LINKED_GOAL], [], { isRemoteApply: false });
+    expect(emits).toHaveLength(1);
+    expect(emits[0].goal.id).toBe('goal-1');
+    expect(emits[0].change.event).toBe(EVENTS.DELETED);
+    // Not advanced yet — the snapshot advances only after a durable enqueue.
+    expect(advanceTo).toBeNull();
+  });
+
+  it('does NOT emit when the same removal is driven by a sync/remote apply', () => {
+    // This is the create→delete-loop fix: a merge that re-drops a just-created
+    // goal (setGoals from applyEngineData) must not echo a spurious `deleted`.
+    const { emits, advanceTo } = planGoalNotifyEmits([LINKED_GOAL], [], { isRemoteApply: true });
+    expect(emits).toHaveLength(0);
+    // Remote change is consumed into the baseline silently.
+    expect(advanceTo).toEqual([]);
+  });
+
+  it('does NOT emit for a remote-driven completion/title change', () => {
+    const changed = { ...LINKED_GOAL, status: 'completed' };
+    const { emits, advanceTo } = planGoalNotifyEmits([LINKED_GOAL], [changed], { isRemoteApply: true });
+    expect(emits).toHaveLength(0);
+    expect(advanceTo).toEqual([changed]);
+  });
+
+  it('emits COMPLETED for a user completion (guard does not suppress real actions)', () => {
+    const changed = { ...LINKED_GOAL, status: 'completed' };
+    const { emits } = planGoalNotifyEmits([LINKED_GOAL], [changed], { isRemoteApply: false });
+    expect(emits).toHaveLength(1);
+    expect(emits[0].change.event).toBe(EVENTS.COMPLETED);
+  });
+
+  it('never emits for a brand-new goal (an inbound create must not echo)', () => {
+    const { emits, advanceTo } = planGoalNotifyEmits([], [LINKED_GOAL], { isRemoteApply: false });
+    expect(emits).toHaveLength(0);
+    expect(advanceTo).toEqual([LINKED_GOAL]);
+  });
+
+  it('ignores goals without source linkage', () => {
+    const local = { id: 'g-local', title: 'Personal goal', status: 'active' };
+    const { emits } = planGoalNotifyEmits([local], [], { isRemoteApply: false });
+    expect(emits).toHaveLength(0);
+  });
+
+  it('initial snapshot (prev === null) just seeds the baseline', () => {
+    const { emits, advanceTo } = planGoalNotifyEmits(null, [LINKED_GOAL], { isRemoteApply: false });
+    expect(emits).toHaveLength(0);
+    expect(advanceTo).toEqual([LINKED_GOAL]);
+  });
+
+  it('no enabled targets → consume the change without emitting', () => {
+    const { emits, advanceTo } = planGoalNotifyEmits([LINKED_GOAL], [], { isRemoteApply: false, hasTargets: false });
+    expect(emits).toHaveLength(0);
+    expect(advanceTo).toEqual([]);
+  });
+
+  it('in-flight → hold (no emit, no advance) until the running fire() completes', () => {
+    const { emits, advanceTo } = planGoalNotifyEmits([LINKED_GOAL], [], { isRemoteApply: false, inFlight: true });
+    expect(emits).toHaveLength(0);
+    expect(advanceTo).toBeNull();
+  });
+});

--- a/src/intents/useNotifyEmitter.js
+++ b/src/intents/useNotifyEmitter.js
@@ -87,6 +87,52 @@ export function buildNotifyPayload(task, change, now, meUserSyncId = null) {
 // ─── hook ────────────────────────────────────────────────────────────────────
 
 /**
+ * Pure planner: decide what to emit for a prev→next tasks snapshot transition,
+ * and what the new baseline snapshot should be. Extracted from the effect so the
+ * remote-apply guard and the deleted/changed diff are unit-testable without a
+ * React renderer.
+ *
+ * Returns { emits, advanceTo } — see planGoalNotifyEmits for the contract.
+ *
+ * The isRemoteApply branch is the echo guard: a tasks change driven by a
+ * sync/remote apply (applyEngineData's setTasks/setUnscheduledTasks, or any
+ * merge-driven mutation) must NOT emit an outbound intent — it did not come from
+ * the user. It is consumed into the baseline silently, mirroring how the
+ * cloud-upload effect bails on suppressCloudUploadRef.
+ */
+export function planTaskNotifyEmits(prev, next, { isRemoteApply = false, hasTargets = true, inFlight = false } = {}) {
+  if (prev === null) return { emits: [], advanceTo: next };
+  if (isRemoteApply) return { emits: [], advanceTo: next };
+  if (inFlight) return { emits: [], advanceTo: null };
+  if (!hasTargets) return { emits: [], advanceTo: next };
+
+  const prevMap = new Map(prev.map(t => [t.id, t]));
+  const nextMap = new Map(next.map(t => [t.id, t]));
+
+  const emits = [];
+
+  // Deleted: present in prev but gone from next
+  for (const [id, prevTask] of prevMap) {
+    if (!shouldEmit(prevTask)) continue;
+    if (!nextMap.has(id)) {
+      emits.push({ task: prevTask, change: { event: EVENTS.DELETED } });
+    }
+  }
+
+  // Changed: present in both prev and next
+  for (const [id, nextTask] of nextMap) {
+    if (!shouldEmit(nextTask)) continue;
+    const prevTask = prevMap.get(id);
+    if (!prevTask) continue; // new task — no notify for creation
+    const change = detectChange(prevTask, nextTask);
+    if (change) emits.push({ task: nextTask, change });
+  }
+
+  if (!emits.length) return { emits: [], advanceTo: next };
+  return { emits, advanceTo: null }; // advanced after durable enqueue
+}
+
+/**
  * Watches tasks and unscheduledTasks for changes to tasks that carry
  * source_app + source_entity_id, and emits a WebDAV notify event for each
  * state change. No-ops when the intent WebDAV config is absent.
@@ -94,8 +140,11 @@ export function buildNotifyPayload(task, change, now, meUserSyncId = null) {
  * Covered events: completed, uncompleted, deleted, rescheduled, updated.
  * Recurring templates are excluded — their completion model (completedDates)
  * differs from the boolean model assumed here.
+ *
+ * `isRemoteApply` (optional) is a getter returning true while a sync/remote
+ * apply is mutating task state, so those changes are never echoed outbound.
  */
-export function useNotifyEmitter({ tasks, unscheduledTasks }) {
+export function useNotifyEmitter({ tasks, unscheduledTasks, isRemoteApply }) {
   const prevRef = useRef(null);
   // Guard so a re-render during the async enqueue/flush window can't re-detect
   // and double-enqueue the same change (notify event_ids are freshly generated,
@@ -114,44 +163,23 @@ export function useNotifyEmitter({ tasks, unscheduledTasks }) {
     })();
 
     const allTasks = [...tasks, ...unscheduledTasks];
-    const prev = prevRef.current;
-
-    // Skip the initial snapshot — no previous state to diff against.
-    if (prev === null) { prevRef.current = allTasks; return; }
-    // A fire() is in progress; it will advance the snapshot and bump() us again.
-    if (inFlightRef.current) return;
 
     // Targets enabled for this emit ('webdav' | 'icloud' | 'vault'). When NONE
-    // are enabled there's nowhere to send, so consume the changes (advance the
-    // snapshot) and bail — matching the old early-return-after-advance behavior.
+    // are enabled there's nowhere to send, so the planner consumes the changes
+    // (advances the snapshot) and bails — matching the old behavior.
     const targets = enabledIntentTargets(config);
-    if (targets.length === 0) { prevRef.current = allTasks; return; }
-
-    const prevMap = new Map(prev.map(t => [t.id, t]));
-    const nextMap = new Map(allTasks.map(t => [t.id, t]));
     const now = new Date().toISOString();
 
-    const emits = [];
+    const { emits, advanceTo } = planTaskNotifyEmits(prevRef.current, allTasks, {
+      isRemoteApply: !!isRemoteApply?.(),
+      hasTargets: targets.length > 0,
+      inFlight: inFlightRef.current,
+    });
 
-    // Deleted: present in prev but gone from next
-    for (const [id, prevTask] of prevMap) {
-      if (!shouldEmit(prevTask)) continue;
-      if (!nextMap.has(id)) {
-        emits.push({ task: prevTask, change: { event: EVENTS.DELETED } });
-      }
+    if (!emits.length) {
+      if (advanceTo !== null) prevRef.current = advanceTo;
+      return;
     }
-
-    // Changed: present in both prev and next
-    for (const [id, nextTask] of nextMap) {
-      if (!shouldEmit(nextTask)) continue;
-      const prevTask = prevMap.get(id);
-      if (!prevTask) continue; // new task — no notify for creation
-      const change = detectChange(prevTask, nextTask);
-      if (change) emits.push({ task: nextTask, change });
-    }
-
-    // Nothing notification-worthy changed — advance the snapshot and bail.
-    if (!emits.length) { prevRef.current = allTasks; return; }
 
     inFlightRef.current = true;
     const fire = async () => {

--- a/src/intents/useNotifyEmitter.test.js
+++ b/src/intents/useNotifyEmitter.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { EVENTS } from '@glance-apps/intents';
-import { buildNotifyPayload } from './useNotifyEmitter.js';
+import { buildNotifyPayload, planTaskNotifyEmits } from './useNotifyEmitter.js';
 
 const BASE_TASK = {
   id: 'task-1',
@@ -73,5 +73,69 @@ describe('buildNotifyPayload', () => {
     const change = { event: EVENTS.UPDATED, due: '2026-06-01' };
     const payload = buildNotifyPayload(task, change, NOW, 'user-sync-id-abc');
     expect('completed_by_user_id' in payload).toBe(false);
+  });
+});
+
+describe('planTaskNotifyEmits — remote-apply echo guard', () => {
+  const linked = { ...BASE_TASK }; // carries source_app + source_entity_id
+
+  it('emits DELETED when a linked task is removed by a USER action (not remote)', () => {
+    const { emits, advanceTo } = planTaskNotifyEmits([linked], [], { isRemoteApply: false });
+    expect(emits).toHaveLength(1);
+    expect(emits[0].task.id).toBe('task-1');
+    expect(emits[0].change.event).toBe(EVENTS.DELETED);
+    // Not advanced yet — the snapshot advances only after a durable enqueue.
+    expect(advanceTo).toBeNull();
+  });
+
+  it('does NOT emit when the same removal is driven by a sync/remote apply', () => {
+    const { emits, advanceTo } = planTaskNotifyEmits([linked], [], { isRemoteApply: true });
+    expect(emits).toHaveLength(0);
+    // Remote change is consumed into the baseline silently.
+    expect(advanceTo).toEqual([]);
+  });
+
+  it('does NOT emit for a remote-driven field change either', () => {
+    const changed = { ...linked, title: 'Renamed remotely' };
+    const { emits, advanceTo } = planTaskNotifyEmits([linked], [changed], { isRemoteApply: true });
+    expect(emits).toHaveLength(0);
+    expect(advanceTo).toEqual([changed]);
+  });
+
+  it('emits UPDATED for a user field change (guard does not suppress real actions)', () => {
+    const changed = { ...linked, title: 'Renamed by user' };
+    const { emits } = planTaskNotifyEmits([linked], [changed], { isRemoteApply: false });
+    expect(emits).toHaveLength(1);
+    expect(emits[0].change.event).toBe(EVENTS.UPDATED);
+  });
+
+  it('never emits for a brand-new task (creation is not a notify)', () => {
+    const { emits, advanceTo } = planTaskNotifyEmits([], [linked], { isRemoteApply: false });
+    expect(emits).toHaveLength(0);
+    expect(advanceTo).toEqual([linked]);
+  });
+
+  it('ignores tasks without source linkage', () => {
+    const local = { id: 'local-1', title: 'Local only' };
+    const { emits } = planTaskNotifyEmits([local], [], { isRemoteApply: false });
+    expect(emits).toHaveLength(0);
+  });
+
+  it('initial snapshot (prev === null) just seeds the baseline', () => {
+    const { emits, advanceTo } = planTaskNotifyEmits(null, [linked], { isRemoteApply: false });
+    expect(emits).toHaveLength(0);
+    expect(advanceTo).toEqual([linked]);
+  });
+
+  it('no enabled targets → consume the change without emitting', () => {
+    const { emits, advanceTo } = planTaskNotifyEmits([linked], [], { isRemoteApply: false, hasTargets: false });
+    expect(emits).toHaveLength(0);
+    expect(advanceTo).toEqual([]);
+  });
+
+  it('in-flight → hold (no emit, no advance) until the running fire() completes', () => {
+    const { emits, advanceTo } = planTaskNotifyEmits([linked], [], { isRemoteApply: false, inFlight: true });
+    expect(emits).toHaveLength(0);
+    expect(advanceTo).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

When dayGLANCE received a CREATE intent from lifeGLANCE and created a goal, it immediately echoed a spurious `deleted` intent back to lifeGLANCE, deleting the just-created goal on both sides until retries eventually won the race (per the intent activity log: inbound create → outbound deleted → inbound create → outbound deleted → inbound create sticks).

Two coupled defects caused this; both are fixed here.

### Root cause
1. `handleCreateGoal` re-created a goal over a **live stale tombstone** (`day-planner-deleted-goal-ids`) without clearing it, so the next sync merge re-dropped the goal by last-writer-wins.
2. The intent notify emitters had **no remote-apply guard** — they diff `goals`/`tasks` snapshots and emit on *any* change, including a sync-driven `setGoals`/`setTasks`. So the merge-driven removal was indistinguishable from a user delete and got echoed outbound.

## Changes

**Fix 1 — inbound create supersedes a stale tombstone** (`src/intents/handleIntent.js`)
- New `clearGoalTombstone(goalId)` removes the goal's entry from `day-planner-deleted-goal-ids`.
- `handleCreateGoal` clears it on the **create path** (before `addGoal`, keyed on the deterministic `source_app|source_entity_id` id) and on the **idempotency path** (existing goal's id). An explicit cross-app create is authoritative, so the subsequent sync merge keeps the goal instead of re-dropping it against a stale tombstone. Guarded to no-op safely in skeleton/test mode.

**Fix 2 — emitters no longer echo sync/remote-driven changes** (`src/intents/useGoalNotifyEmitter.js`, `src/intents/useNotifyEmitter.js`, `src/App.jsx`)
- Extracted the emit decision into pure, exported planners `planGoalNotifyEmits` / `planTaskNotifyEmits` carrying an `isRemoteApply` guard. When a change is driven by a sync/remote apply it is consumed into the baseline snapshot and **never emitted**; a genuine user delete/change still emits.
- `App.jsx` passes an `isRemoteApply` getter backed by `applyingRemoteDataRef || suppressCloudUploadRef` — the same remote-apply signal the cloud-upload push side already uses. `applyingRemoteDataRef`'s declaration was hoisted above the emitter hooks so it's in scope.

## Constraints honored
- No changes to the sync merge logic or `@glance-apps/sync`.
- Tombstones for real user deletions remain intact — only an inbound create for that id supersedes its own tombstone.
- Remote/sync-driven changes are never echoed outbound.

## Existing stale tombstones
No one-time cleanup needed. Fix 1 clears each goal's tombstone as its inbound create is processed, so the affected test goals ("rule of 55", "true retirement", etc.) resolve naturally the next time lifeGLANCE re-emits their create. Fix 2 additionally ensures that even a momentary mid-sync drop is recognized as sync-driven and not echoed.

## Testing
- Inbound create for a tombstoned goal clears the tombstone (create + idempotency paths); an unrelated tombstone is left untouched.
- A remote-apply-driven removal/change does **not** emit; a user removal/change **still** emits — for both goals and tasks — plus baseline / no-targets / in-flight edge cases.
- Full suite (466 tests) and production build pass; ESLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8E7tDspr28LNHSFznPxRs)_