### PR TITLE
Bump Android versionCode to 143

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 142
+        versionCode = 143
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

Bumps the Android `versionCode` from 142 → 143 in `dayglance-android/app/build.gradle.kts`.

`versionName` is unchanged (stays `3.10`). No other version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8E7tDspr28LNHSFznPxRs)_