### PR TITLE
GLANCEvault SSE push (instant drain) + Electron app:// origin

### DIFF
--- a/electron/appProtocol.test.ts
+++ b/electron/appProtocol.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { resolveAppRequest, contentTypeFor, APP_ORIGIN, APP_BASE_URL } from './appProtocol.js';
+
+// Pure request→file mapping for the custom app:// protocol handler. No electron,
+// no real fs — `isFile` is injected. The REAL end-to-end validation (that
+// Chromium loads these under the app:// origin in a packaged/MAS build) is a
+// device test; see the deliverable's TestFlight checklist.
+
+const DIST = '/app/dist';
+const existing = new Set([
+  path.join(DIST, 'index.html'),
+  path.join(DIST, 'assets/index-abc123.js'),
+  path.join(DIST, 'assets/index-abc123.css'),
+  path.join(DIST, 'theme-init.js'),
+  path.join(DIST, 'favicon.ico'),
+]);
+const isFile = (p: string) => existing.has(p);
+const resolve = (url: string) => resolveAppRequest(DIST, url, isFile);
+
+describe('app:// origin constants', () => {
+  it('produces the exact origin app://dayglance (no trailing slash) to allowlist in vault CORS', () => {
+    expect(APP_ORIGIN).toBe('app://dayglance');
+    expect(APP_BASE_URL).toBe('app://dayglance/');
+  });
+});
+
+describe('resolveAppRequest — asset serving', () => {
+  it('serves index.html for the root', () => {
+    const r = resolve('app://dayglance/');
+    expect(r.status).toBe(200);
+    expect(r.filePath).toBe(path.join(DIST, 'index.html'));
+    expect(r.contentType).toContain('text/html');
+  });
+
+  it('serves a hashed JS asset with the JS content type', () => {
+    const r = resolve('app://dayglance/assets/index-abc123.js');
+    expect(r.status).toBe(200);
+    expect(r.filePath).toBe(path.join(DIST, 'assets/index-abc123.js'));
+    expect(r.contentType).toContain('text/javascript');
+  });
+
+  it('serves the CSS asset with the CSS content type', () => {
+    const r = resolve('app://dayglance/assets/index-abc123.css');
+    expect(r.status).toBe(200);
+    expect(r.contentType).toContain('text/css');
+  });
+
+  it('serves a public-dir asset (theme-init.js) referenced absolutely', () => {
+    const r = resolve('app://dayglance/theme-init.js');
+    expect(r.status).toBe(200);
+    expect(r.filePath).toBe(path.join(DIST, 'theme-init.js'));
+  });
+
+  it('ignores the query string (tray loads ?tray=1) and still serves index.html', () => {
+    const r = resolve('app://dayglance/?tray=1');
+    expect(r.status).toBe(200);
+    expect(r.filePath).toBe(path.join(DIST, 'index.html'));
+  });
+});
+
+describe('resolveAppRequest — SPA fallback vs real 404', () => {
+  it('falls back to index.html for an extensionless client route', () => {
+    const r = resolve('app://dayglance/goals/some-id');
+    expect(r.status).toBe(200);
+    expect(r.filePath).toBe(path.join(DIST, 'index.html'));
+    expect(r.fallback).toBe(true);
+  });
+
+  it('returns a real 404 for a MISSING asset (has an extension) — never HTML', () => {
+    const r = resolve('app://dayglance/assets/renamed-old.js');
+    expect(r.status).toBe(404);
+    expect(r.filePath).toBeUndefined();
+  });
+});
+
+describe('resolveAppRequest — traversal containment', () => {
+  it('never resolves a file outside dist (URL parsing clamps .. to root; guard is belt-and-braces)', () => {
+    // The WHATWG URL parser resolves %2e%2e (..) away, clamping the pathname to
+    // the origin root, so this can never escape dist. Whatever it resolves to must
+    // stay inside dist — and it must NOT point at the real /etc/passwd.
+    const r = resolve('app://dayglance/%2e%2e/%2e%2e/etc/passwd');
+    if (r.filePath) expect(r.filePath.startsWith(DIST)).toBe(true);
+    expect(r.filePath).not.toBe('/etc/passwd');
+  });
+});
+
+describe('contentTypeFor', () => {
+  it('maps common extensions', () => {
+    expect(contentTypeFor('/x/app.js')).toContain('text/javascript');
+    expect(contentTypeFor('/x/app.css')).toContain('text/css');
+    expect(contentTypeFor('/x/i.png')).toBe('image/png');
+    expect(contentTypeFor('/x/f.woff2')).toBe('font/woff2');
+    expect(contentTypeFor('/x/unknown.xyz')).toBe('application/octet-stream');
+  });
+});

--- a/electron/appProtocol.ts
+++ b/electron/appProtocol.ts
@@ -1,0 +1,118 @@
+// Custom app:// protocol for the packaged Electron renderer.
+//
+// The production renderer used to load via file:// (loadFile), which gives the
+// document an opaque `null` origin — unallowlistable for CORS and a poor security
+// posture for the Mac App Store build. We instead serve the built dist/ from a
+// registered standard+secure scheme so the renderer runs under a REAL, specific,
+// stable origin that the vault (and future GLANCEvault Pro / lastGLANCE /
+// lifeGLANCE desktop builds) can allowlist.
+//
+// EXACT ORIGIN produced: `app://dayglance` (scheme `app`, host `dayglance`). A
+// direct renderer fetch to the vault therefore sends `Origin: app://dayglance` —
+// that is the precise string to add to the vault's CORS allow-list. It is NOT
+// `null` and NOT `app://dayglance/` (an origin has no trailing slash).
+//
+// This module holds ONLY the pure request→file mapping so it is unit-testable in
+// vitest without importing electron. main.ts wires it into protocol.handle and
+// supplies the real fs existence check + file reads.
+
+import path from 'node:path';
+
+export const APP_SCHEME = 'app';
+export const APP_HOST = 'dayglance';
+/** The renderer's origin (no trailing slash). Allowlist THIS in vault CORS. */
+export const APP_ORIGIN = `${APP_SCHEME}://${APP_HOST}`;
+/** The URL the main/tray windows load. */
+export const APP_BASE_URL = `${APP_SCHEME}://${APP_HOST}/`;
+
+// Minimal content-type table for the asset kinds a Vite build emits. A wrong or
+// missing type on the entry module script means Chromium refuses to execute it,
+// so js/css/html must be exact.
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+  '.map': 'application/json; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webmanifest': 'application/manifest+json',
+};
+
+export function contentTypeFor(filePath: string): string {
+  return CONTENT_TYPES[path.extname(filePath).toLowerCase()] || 'application/octet-stream';
+}
+
+export interface AppRequestResolution {
+  status: 200 | 403 | 404;
+  filePath?: string;
+  contentType?: string;
+  /** True when SPA fallback served index.html for a non-file (client route). */
+  fallback?: boolean;
+}
+
+/**
+ * Map an app:// request URL to a file under distDir.
+ *
+ *  - `/` (or empty) → index.html.
+ *  - An existing file → served with its content type.
+ *  - A NON-existent path WITHOUT a file extension → SPA fallback to index.html,
+ *    so client-side routes resolve. (A missing path WITH an extension — e.g. a
+ *    renamed `/assets/x.js` — is a real 404, never HTML, so a broken asset fails
+ *    loudly instead of silently returning the index doc.)
+ *  - Path traversal outside distDir → 403.
+ *
+ * `isFile` is injected (fs.statSync in prod, a fake set in tests) so this stays
+ * pure and testable. The query string is ignored for file resolution — the tray
+ * loads `app://dayglance/?tray=1`, and index.html is served while the renderer
+ * still reads the query off its document URL.
+ */
+export function resolveAppRequest(
+  distDir: string,
+  requestUrl: string,
+  isFile: (p: string) => boolean,
+): AppRequestResolution {
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(new URL(requestUrl).pathname);
+  } catch {
+    return { status: 404 };
+  }
+
+  const distRoot = path.resolve(distDir);
+  const indexPath = path.join(distRoot, 'index.html');
+
+  if (pathname === '/' || pathname === '') {
+    return { status: 200, filePath: indexPath, contentType: 'text/html; charset=utf-8' };
+  }
+
+  const rel = pathname.replace(/^\/+/, '');
+  const full = path.resolve(distRoot, rel);
+
+  // Traversal guard: the resolved path must stay inside distDir.
+  if (full !== distRoot && !full.startsWith(distRoot + path.sep)) {
+    return { status: 403 };
+  }
+
+  if (isFile(full)) {
+    return { status: 200, filePath: full, contentType: contentTypeFor(full) };
+  }
+
+  // No real file: a route (no extension) falls back to index.html; a missing
+  // asset (has an extension) is a genuine 404.
+  if (!path.extname(rel)) {
+    return { status: 200, filePath: indexPath, contentType: 'text/html; charset=utf-8', fallback: true };
+  }
+  return { status: 404 };
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, ipcMain, net, Tray, Menu, nativeImage, globalShortcut, session } from 'electron';
+import { app, BrowserWindow, shell, ipcMain, net, protocol, Tray, Menu, nativeImage, globalShortcut, session } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
 import dns from 'node:dns';
@@ -9,8 +9,23 @@ import { registerSubscriptionHandlers } from './subscription.js';
 import { registerCalendarHandlers } from './calendar.js';
 import { registerICloudHandlers } from './icloud.js';
 import { registerObsidianHandlers } from './obsidian.js';
+import { APP_SCHEME, APP_HOST, APP_BASE_URL, resolveAppRequest } from './appProtocol.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Register the custom app:// scheme as a proper web origin BEFORE app ready.
+// standard+secure gives it a real, allowlistable origin (app://dayglance) with a
+// secure context (streaming fetch, CSP, service-worker-grade trust) instead of
+// the opaque null origin file:// produced. supportFetchAPI/corsEnabled/stream let
+// the renderer fetch (incl. text/event-stream SSE) and let the handler stream
+// large asset bodies. Must run at module load — registerSchemesAsPrivileged is a
+// no-op once the app is ready.
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: APP_SCHEME,
+    privileges: { standard: true, secure: true, supportFetchAPI: true, corsEnabled: true, stream: true },
+  },
+]);
 
 // Pin userData explicitly to the productName-derived path. Electron's default
 // derives from app.getName() (never the bundle ID), and this pin has shipped in
@@ -52,23 +67,20 @@ function openExternalSafe(url: string): void {
   } catch { /* malformed URL — ignore */ }
 }
 
-// The app's own bundled entry point — the ONLY file:// document navigations are
-// allowed to reach. Computed exactly as createWindow()/createTrayWindow() do via
-// loadFile() so the two stay in lock-step.
-const APP_INDEX_PATH = path.join(__dirname, '../dist/index.html');
+// The app's own built renderer directory — the root the app:// handler serves
+// from, and the only files renderer navigations may reach.
+const APP_DIST_DIR = path.join(__dirname, '../dist');
 
-// True if the navigation target is the app itself: the Vite dev server in dev,
-// or the app's own dist/index.html (any query/hash — the tray uses ?tray=1) in
-// production. Used to block renderer-initiated navigations to external origins
-// AND to arbitrary local files (defense-in-depth against XSS).
+// True if the navigation target is the app itself: the Vite dev server in dev, or
+// the app's own custom-scheme origin (app://dayglance, any path/query/hash — the
+// tray uses ?tray=1) in production. Used to block renderer-initiated navigations
+// to external origins (defense-in-depth against XSS). Production no longer loads
+// via file://, so that branch is gone; the app:// origin is the trusted one.
 function isSameAppOrigin(url: string): boolean {
   try {
     const parsed = new URL(url);
     if (DEV && parsed.origin === new URL(VITE_DEV_SERVER_URL).origin) return true;
-    if (parsed.protocol === 'file:') {
-      // Compare resolved filesystem paths; fileURLToPath drops query/hash.
-      return path.resolve(fileURLToPath(parsed)) === path.resolve(APP_INDEX_PATH);
-    }
+    if (parsed.protocol === `${APP_SCHEME}:` && parsed.host === APP_HOST) return true;
     return false;
   } catch { return false; }
 }
@@ -136,7 +148,7 @@ function createWindow(): BrowserWindow {
   if (DEV) {
     mainWindow.loadURL(VITE_DEV_SERVER_URL);
   } else {
-    mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
+    mainWindow.loadURL(APP_BASE_URL);
   }
 
   // Open external links in the system browser (https/http only).
@@ -172,7 +184,7 @@ function createTrayWindow(): BrowserWindow {
   if (DEV) {
     win.loadURL(`${VITE_DEV_SERVER_URL}?tray=1`);
   } else {
-    win.loadFile(path.join(__dirname, '../dist/index.html'), { query: { tray: '1' } });
+    win.loadURL(`${APP_BASE_URL}?tray=1`);
   }
 
   // After every (re)load, re-push cached reminders once React has mounted and
@@ -311,8 +323,13 @@ async function validateProxyUrl(urlString: string): Promise<void> {
   }
 }
 
-// Proxy outbound HTTP requests from the renderer so they aren't subject to
-// Chromium's CORS restrictions when the app is loaded from file://.
+// Proxy outbound HTTP requests from the renderer (via IPC, origin-independent) so
+// WebDAV/CalDAV/vault sync reach servers that don't send CORS headers for the
+// renderer origin. Invoked through ipcRenderer.invoke('proxy-fetch'), so it is
+// unaffected by the file:// → app:// origin switch — it never reads the origin.
+// (Vault SSE does NOT use this path: the proxy buffers the whole body via
+// response.text() below, which can't stream text/event-stream; SSE uses a direct
+// renderer fetch from the app:// origin instead.)
 ipcMain.handle('proxy-fetch', async (_event, method: string, url: string, headers: Record<string, string>, body: string | null) => {
   const upperMethod = (method ?? '').toUpperCase();
   if (!PROXY_ALLOWED_METHODS.has(upperMethod)) {
@@ -538,8 +555,13 @@ app.whenReady().then(() => {
 
   // Content Security Policy — applied to every response the renderer loads.
   // script-src 'self': only scripts from the app bundle (no inline scripts, no eval).
+  //   Under app://, 'self' is the app://dayglance origin (was the null file:// origin).
   // style-src 'self' 'unsafe-inline': Tailwind generates inline styles at runtime.
-  // connect-src 'self' https:: allows XHR/fetch to any https origin (AI APIs, CalDAV, etc.).
+  // connect-src 'self' https:: allows XHR/fetch/SSE to any https origin — the vault
+  //   (/sync, /intents, /events SSE, /salt, /blobs) on its direct renderer fetch,
+  //   plus AI APIs and CalDAV. (WebDAV/CalDAV/vault sync still go via the IPC proxy,
+  //   which is not subject to CSP; only vault SSE needs the direct-fetch allowance.)
+  //   Note: an http (non-TLS) vault would be blocked here — the vault must be https.
   // img-src 'self' data: blob:: covers favicons, base64 images, and blob URLs.
   // object-src / base-uri 'none': closes classic plugin and base-tag injection vectors.
   const CSP = [
@@ -560,6 +582,34 @@ app.whenReady().then(() => {
         'Content-Security-Policy': [CSP],
       },
     });
+  });
+
+  // Serve the built renderer from the custom app:// origin. Maps app://dayglance/…
+  // requests to files in dist/ (with SPA fallback to index.html for client
+  // routes), replacing the old file:// load. Custom-scheme responses do not pass
+  // through onHeadersReceived, so the CSP is set on the document response here too
+  // (belt-and-braces alongside the <meta> CSP baked into index.html). The IPC
+  // proxy (proxy-fetch) is untouched by this — it never depended on the origin.
+  protocol.handle(APP_SCHEME, async (request) => {
+    const isFile = (p: string): boolean => {
+      try { return fs.statSync(p).isFile(); } catch { return false; }
+    };
+    const resolved = resolveAppRequest(APP_DIST_DIR, request.url, isFile);
+    if (resolved.status !== 200 || !resolved.filePath) {
+      return new Response(resolved.status === 403 ? 'Forbidden' : 'Not found', {
+        status: resolved.status,
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      });
+    }
+    try {
+      const data = await fs.promises.readFile(resolved.filePath);
+      const headers: Record<string, string> = { 'Content-Type': resolved.contentType || 'application/octet-stream' };
+      // Only the HTML document needs the CSP header; assets inherit nothing from it.
+      if (resolved.contentType?.startsWith('text/html')) headers['Content-Security-Policy'] = CSP;
+      return new Response(data, { status: 200, headers });
+    } catch {
+      return new Response('Not found', { status: 404, headers: { 'Content-Type': 'text/plain; charset=utf-8' } });
+    }
   });
 
   const win = createWindow();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,7 +78,8 @@ import useBackup from './hooks/useBackup.js';
 import useGTDFrames from './hooks/useGTDFrames.js';
 import { getGlanceHGInstances, isHGSessionReachable } from './hooks/useHyperGlance.js';
 import { useIntentPoller, INTENT_CONFIG_KEY } from './intents/useIntentPoller.js';
-import { useDbIntentPoller } from './intents/dbIntentsTransport.js';
+import { useDbIntentPoller, drainDbIntents } from './intents/dbIntentsTransport.js';
+import { useVaultEventStream } from './hooks/useVaultEventStream.js';
 import { useNotifyEmitter } from './intents/useNotifyEmitter.js';
 import { useGoalNotifyEmitter } from './intents/useGoalNotifyEmitter.js';
 import { useOutboxFlush } from './intents/useOutboxFlush.js';
@@ -1134,7 +1135,7 @@ const DayPlanner = () => {
   // GLANCEvault DB intents transport — receive poller mounted alongside the
   // WebDAV poller; no-ops unless DB intents is enabled (its own flag + an
   // inherited vault connection). Same context shape as useIntentPoller.
-  useDbIntentPoller({
+  const dbIntentContext = {
     tasks, unscheduledTasks, recurringTasks, projects,
     setTasks, setUnscheduledTasks, setRecurringTasks,
     goals, addGoal, updateGoal, deleteGoal,
@@ -1143,6 +1144,22 @@ const DayPlanner = () => {
       setMobileActiveTab(mobileTab);
       if (tab === 'glance' || tab === 'inbox') setTabletActiveTab(tab === 'glance' ? 'glance' : 'inbox');
     },
+  };
+  useDbIntentPoller(dbIntentContext);
+  // Fresh handle on the intents drain context for the SSE push client (below),
+  // which triggers the SAME drain outside the poll cadence.
+  const dbIntentContextRef = useRef(dbIntentContext);
+  dbIntentContextRef.current = dbIntentContext;
+
+  // GLANCEvault SSE push — instant drain on a server nudge, ADDED on top of the
+  // permanent poll backstops (never replacing them). Opens only when vault sync
+  // is enabled and the app is active; web-only (fetch-stream), degrades to
+  // polling on native/electron. Nudges trigger the EXISTING drains: dbSyncCycle
+  // for sync, drainDbIntents for intents. See useVaultEventStream / vaultEventStream.
+  useVaultEventStream({
+    dataLoaded,
+    drainSync: useCallback(() => dbEngineRef.current?.dbSyncCycle?.(), []),
+    drainIntents: useCallback(() => drainDbIntents(dbIntentContextRef.current), []),
   });
   // Guard the intent emitters against sync/remote-apply-driven state changes: a
   // setGoals/setTasks coming from applyEngineData (or any merge apply) must not

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -44,9 +44,10 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
 
     const transport = detectSseTransport();
     if (transport !== 'web') {
-      // Native WebView / Electron / SSR: the vault HTTP path is fully buffered and
-      // cannot stream frames, so SSE is unavailable — degrade cleanly to polling
-      // (which is already running). Nothing to open, nothing to clean up.
+      // Native WebView / SSR: the vault HTTP path is fully buffered and cannot
+      // stream frames, so SSE is unavailable — degrade cleanly to polling (which
+      // is already running). Nothing to open, nothing to clean up. (Electron is
+      // NOT here — it reports 'web' and streams directly from the app:// origin.)
       if (import.meta.env?.DEV) {
         console.info('[vault-sse] streaming unavailable on', transport, '— polling backstop only');
       }

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -1,0 +1,100 @@
+// React lifecycle wrapper for the GLANCEvault SSE push client.
+//
+// Opens the authenticated /events stream when the vault is enabled AND the app is
+// active, turns nudges into instant drains of the EXISTING sync/intents drains
+// (debounced), reconnects with backoff on any drop, reconciles via the initial
+// {seq, kind:'connected'} on (re)connect, and tears the connection down cleanly
+// on background / unmount / vault-disabled. The pure transport lives in
+// ../sync/vaultEventStream.js; this file only wires it to React + the app.
+//
+// CORE INVARIANT: this is purely ADDITIVE. It never starts, stops, or slows the
+// existing poll cadences (the DB sync 5-min interval + focus in App.jsx, and the
+// DB intents 2-min interval + focus in useDbIntentPoller). Those keep running as
+// the correctness backstop, so a missed nudge or an SSE-down window is always
+// caught by the next poll. If SSE is unavailable (native/electron/none) or throws,
+// the app degrades to exactly today's polling behavior.
+
+import { useEffect, useRef } from 'react';
+import { isVaultEnabled, getVaultConfig } from '../sync/vaultConfig.js';
+import {
+  createNudgeCoalescer,
+  createVaultEventClient,
+  detectSseTransport,
+  openWebSseStream,
+} from '../sync/vaultEventStream.js';
+
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+
+/**
+ * @param {object} p
+ * @param {boolean}  p.dataLoaded    gate: don't connect before initial load
+ * @param {() => (void|Promise<any>)} p.drainSync     triggers the EXISTING vault sync drain (dbSyncCycle)
+ * @param {() => (void|Promise<any>)} p.drainIntents  triggers the EXISTING vault intents drain (drainDbIntents)
+ */
+export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
+  // Keep the drain callbacks fresh without re-running the effect (which would tear
+  // down and re-open the connection on every render).
+  const drainSyncRef = useRef(drainSync);
+  drainSyncRef.current = drainSync;
+  const drainIntentsRef = useRef(drainIntents);
+  drainIntentsRef.current = drainIntents;
+
+  useEffect(() => {
+    if (isTrayMode || !dataLoaded || !isVaultEnabled()) return undefined;
+
+    const transport = detectSseTransport();
+    if (transport !== 'web') {
+      // Native WebView / Electron / SSR: the vault HTTP path is fully buffered and
+      // cannot stream frames, so SSE is unavailable — degrade cleanly to polling
+      // (which is already running). Nothing to open, nothing to clean up.
+      if (import.meta.env?.DEV) {
+        console.info('[vault-sse] streaming unavailable on', transport, '— polling backstop only');
+      }
+      return undefined;
+    }
+
+    const coalescer = createNudgeCoalescer({
+      onDrain: (kind) => {
+        if (kind === 'sync') drainSyncRef.current?.();
+        else if (kind === 'intents') drainIntentsRef.current?.();
+      },
+      onDrainError: (msg, err) => console.warn('[vault-sse]', msg, err?.message || err),
+    });
+
+    const client = createVaultEventClient({
+      supported: true,
+      getConnection: () => {
+        const c = getVaultConfig();
+        return c && c.vaultUrl && c.vaultToken && c.accountId
+          ? { vaultUrl: c.vaultUrl, vaultToken: c.vaultToken, accountId: c.accountId }
+          : null;
+      },
+      openStream: openWebSseStream,
+      onEvent: coalescer.handleEvent,
+      onStateChange: (state) => {
+        if (import.meta.env?.DEV) console.debug('[vault-sse]', state);
+      },
+    });
+
+    // Drop SSE on background, reopen on foreground. The (re)connect delivers a
+    // fresh {seq, kind:'connected'} that reconciles anything missed while hidden;
+    // polling/foreground-drain covers the gap regardless.
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') client.start();
+      else client.stop();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+
+    if (document.visibilityState !== 'hidden') client.start();
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      client.stop();
+      coalescer.cancel();
+    };
+    // Keyed on dataLoaded only: a vault enable/disable reloads the app (see
+    // CloudSyncSettingsForm), so the isVaultEnabled() read at mount stays current,
+    // mirroring the DB sync engine effect in App.jsx.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataLoaded]);
+}

--- a/src/intents/dbIntentsTransport.js
+++ b/src/intents/dbIntentsTransport.js
@@ -507,6 +507,19 @@ async function poll(context, opts) {
   }
 }
 
+/**
+ * Locked drain for callers OUTSIDE the poll cadence (e.g. the SSE push client's
+ * nudge → instant drain). Shares the SAME module-level dbPollLock as the interval
+ * poller, so an SSE-triggered drain and a cadence poll can never run concurrently
+ * and double-process a row. This is the EXISTING drain — it advances the same
+ * receive cursor; it does not reimplement any intents logic. No-ops when DB
+ * intents isn't enabled.
+ */
+export async function drainDbIntents(context, opts) {
+  if (!isDbIntentsEnabled()) return;
+  await poll(context, opts);
+}
+
 // ─── hook ──────────────────────────────────────────────────────────────────────
 
 /**

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -17,17 +17,24 @@
 // the SAME existing drain the poll triggers; the drain re-reads its own cursor
 // and no-ops when there is nothing new.
 //
-// WEB vs NATIVE consumption:
+// WEB vs NATIVE vs ELECTRON consumption:
 //   • WEB (browser/PWA): EventSource cannot set an Authorization header, and the
 //     vault authenticates with a device-token Bearer — so we use a fetch-based
 //     streaming reader (response.body.getReader()) that sets the Bearer header.
 //     See openWebSseStream.
-//   • NATIVE (Android/iOS WebView) and ELECTRON: the vault HTTP path is the
-//     synchronous, fully-BUFFERED bridge (window.DayGlanceNative.httpRequest /
-//     electronAPI.proxyFetch) — it returns the whole body as one string and
-//     cannot deliver incremental frames, so streaming SSE is structurally
-//     impossible there. detectSseTransport() reports this and the client simply
-//     does not open — the device degrades cleanly to exactly today's polling.
+//   • ELECTRON: the renderer is Chromium and, since it now loads from the custom
+//     app://dayglance origin (not file://), its direct fetch() streams
+//     text/event-stream natively exactly like the web path — so Electron uses the
+//     SAME openWebSseStream (direct fetch), NOT the IPC proxy (which buffers the
+//     whole body and cannot stream). The direct fetch presents Origin:
+//     app://dayglance to the vault, which must allowlist that exact origin in its
+//     CORS config; until it does, the SSE fetch is CORS-rejected and the client
+//     falls back to polling (SSE is additive, polling is the backstop).
+//   • NATIVE (Android/iOS WebView): the vault HTTP path is the synchronous,
+//     fully-BUFFERED bridge (window.DayGlanceNative.httpRequest) — it returns the
+//     whole body as one string and cannot deliver incremental frames, so
+//     streaming SSE is structurally impossible. detectSseTransport() reports this
+//     and the client does not open — the device degrades cleanly to polling.
 
 // ─── SSE frame parsing ────────────────────────────────────────────────────────
 
@@ -81,10 +88,12 @@ export function drainSseBuffer(buffer, onEvent) {
 
 /**
  * Which SSE consumption path this runtime supports:
- *   'web'                  — fetch streaming with a Bearer header (works).
- *   'native-unsupported'   — Android/iOS WebView: buffered synchronous bridge.
- *   'electron-unsupported' — Electron proxy: buffered IPC.
- *   'none'                 — no window / no streaming fetch (e.g. tests, SSR).
+ *   'web'                — fetch streaming with a Bearer header (works). Covers
+ *                          browsers/PWA AND Electron: Electron's renderer is
+ *                          Chromium loading from app://dayglance, so its direct
+ *                          fetch streams text/event-stream just like a browser.
+ *   'native-unsupported' — Android/iOS WebView: buffered synchronous bridge.
+ *   'none'               — no window / no streaming fetch (e.g. tests, SSR).
  * Only 'web' opens a stream; every other value degrades cleanly to polling.
  */
 export function detectSseTransport() {
@@ -92,8 +101,9 @@ export function detectSseTransport() {
   // The native WebView bridge (window.DayGlanceNative.httpRequest) is synchronous
   // and returns the whole body as one string — it cannot stream frames.
   if (window.DayGlanceNative?.httpRequest) return 'native-unsupported';
-  // Electron's proxyFetch is buffered IPC — also no streaming.
-  if (window.electronAPI?.isElectron) return 'electron-unsupported';
+  // Electron is intentionally NOT special-cased here: its renderer fetch streams
+  // like any Chromium fetch. The buffering IPC proxy is only for request/response
+  // vault/WebDAV/CalDAV calls; SSE uses the direct fetch below (openWebSseStream).
   if (typeof fetch === 'function' && typeof ReadableStream !== 'undefined') return 'web';
   return 'none';
 }

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -1,0 +1,325 @@
+// GLANCEvault SSE push client (Phase 9, client step 1).
+//
+// The glance-vault server emits authenticated per-account Server-Sent Events at
+// GET {vaultUrl}/events: an initial {seq, kind:'connected'} on connect, then
+// {seq, kind:'sync'|'intents'} nudges when the account's seq advances, plus ~25s
+// heartbeat comments. A nudge carries ONLY the latest account seq — no payload.
+//
+// This module is the PURE, transport-level core (no React). It exists to let
+// dayGLANCE drain INSTANTLY on a nudge instead of waiting for the poll, while the
+// existing polling stays untouched as the correctness backstop. See
+// useVaultEventStream.js for the React lifecycle wrapper and App wiring.
+//
+// CORE INVARIANT: push is an optimization; POLLING IS THE CORRECTNESS BACKSTOP.
+// Nothing here ever stops, slows, or references polling. A nudge only ADDS an
+// instant drain on top; if any of this throws or the stream drops, polling (a
+// separate effect) keeps delivering. Everything is idempotent — a nudge triggers
+// the SAME existing drain the poll triggers; the drain re-reads its own cursor
+// and no-ops when there is nothing new.
+//
+// WEB vs NATIVE consumption:
+//   • WEB (browser/PWA): EventSource cannot set an Authorization header, and the
+//     vault authenticates with a device-token Bearer — so we use a fetch-based
+//     streaming reader (response.body.getReader()) that sets the Bearer header.
+//     See openWebSseStream.
+//   • NATIVE (Android/iOS WebView) and ELECTRON: the vault HTTP path is the
+//     synchronous, fully-BUFFERED bridge (window.DayGlanceNative.httpRequest /
+//     electronAPI.proxyFetch) — it returns the whole body as one string and
+//     cannot deliver incremental frames, so streaming SSE is structurally
+//     impossible there. detectSseTransport() reports this and the client simply
+//     does not open — the device degrades cleanly to exactly today's polling.
+
+// ─── SSE frame parsing ────────────────────────────────────────────────────────
+
+/**
+ * Parse ONE SSE event block (the text between blank-line boundaries) into the
+ * nudge object {seq, kind}, or null if the block carries no usable data.
+ *
+ * Ignores comment lines (leading ':', used for heartbeats) and non-data fields
+ * (event:, id:, retry:). Concatenates multiple data: lines per the SSE spec, then
+ * JSON-parses. Returns null on a heartbeat-only block or unparseable data so the
+ * caller can skip it.
+ */
+export function parseSseFrame(block) {
+  if (!block) return null;
+  const dataLines = [];
+  for (const rawLine of block.split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    if (!line || line.startsWith(':')) continue; // blank or comment (heartbeat)
+    const colon = line.indexOf(':');
+    const field = colon === -1 ? line : line.slice(0, colon);
+    let value = colon === -1 ? '' : line.slice(colon + 1);
+    if (value.startsWith(' ')) value = value.slice(1); // SSE strips one leading space
+    if (field === 'data') dataLines.push(value);
+  }
+  if (dataLines.length === 0) return null;
+  try {
+    return JSON.parse(dataLines.join('\n'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Feed a growing SSE text buffer, emitting each COMPLETE event (delimited by a
+ * blank line) via onEvent and returning the unconsumed remainder to carry into
+ * the next chunk. Normalizes CRLF/CR to LF first.
+ */
+export function drainSseBuffer(buffer, onEvent) {
+  let buf = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  let idx;
+  while ((idx = buf.indexOf('\n\n')) !== -1) {
+    const block = buf.slice(0, idx);
+    buf = buf.slice(idx + 2);
+    const evt = parseSseFrame(block);
+    if (evt) onEvent(evt);
+  }
+  return buf;
+}
+
+// ─── transport detection ──────────────────────────────────────────────────────
+
+/**
+ * Which SSE consumption path this runtime supports:
+ *   'web'                  — fetch streaming with a Bearer header (works).
+ *   'native-unsupported'   — Android/iOS WebView: buffered synchronous bridge.
+ *   'electron-unsupported' — Electron proxy: buffered IPC.
+ *   'none'                 — no window / no streaming fetch (e.g. tests, SSR).
+ * Only 'web' opens a stream; every other value degrades cleanly to polling.
+ */
+export function detectSseTransport() {
+  if (typeof window === 'undefined') return 'none';
+  // The native WebView bridge (window.DayGlanceNative.httpRequest) is synchronous
+  // and returns the whole body as one string — it cannot stream frames.
+  if (window.DayGlanceNative?.httpRequest) return 'native-unsupported';
+  // Electron's proxyFetch is buffered IPC — also no streaming.
+  if (window.electronAPI?.isElectron) return 'electron-unsupported';
+  if (typeof fetch === 'function' && typeof ReadableStream !== 'undefined') return 'web';
+  return 'none';
+}
+
+// ─── web streaming reader ─────────────────────────────────────────────────────
+
+/**
+ * Open the vault /events SSE stream over a fetch streaming body (WEB path) and
+ * pump parsed {seq, kind} nudges to onEvent until the stream ends or the signal
+ * aborts. Authenticates with the same device-token Bearer the other vault calls
+ * use and scopes to accountId (query param, mirroring the sync/intents endpoints).
+ *
+ * Resolves when the server closes the stream (a clean disconnect the caller will
+ * reconnect from). Rejects on connect failure / network error / abort — the
+ * caller treats both the same way: keep polling, reconnect with backoff.
+ *
+ * @param {object}   p
+ * @param {{vaultUrl:string, vaultToken:string, accountId:string}} p.connection
+ * @param {AbortSignal} [p.signal]
+ * @param {() => void}  [p.onOpen]   called once the response is confirmed OK
+ * @param {(evt:object) => void} p.onEvent
+ * @param {typeof fetch} [p.fetchImpl] injectable for tests
+ */
+export async function openWebSseStream({ connection, signal, onOpen, onEvent, fetchImpl }) {
+  const doFetch = fetchImpl || globalThis.fetch;
+  const base = connection.vaultUrl.replace(/\/+$/, '');
+  const url = `${base}/events?accountId=${encodeURIComponent(connection.accountId)}`;
+  const res = await doFetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${connection.vaultToken}`,
+      Accept: 'text/event-stream',
+    },
+    signal,
+  });
+  if (!res || !res.ok || !res.body) {
+    throw new Error(`vault SSE connect failed: ${res ? res.status : 'no response'}`);
+  }
+  onOpen?.();
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      buffer = drainSseBuffer(buffer, onEvent);
+    }
+  } finally {
+    try { reader.releaseLock(); } catch { /* ignore */ }
+  }
+}
+
+// ─── nudge coalescer (seq cursor + debounce) ──────────────────────────────────
+
+/**
+ * Turns a stream of nudge events into debounced drain calls, with a seq cursor so
+ * stale/duplicate nudges are ignored.
+ *
+ * The account seq is a single unified monotonic counter on the server (a sync
+ * write and an intent landing both advance it), so ONE cursor across kinds is
+ * correct: an event is "behind" (worth acting on) only when its seq exceeds the
+ * highest we've already reacted to. A nudge whose seq is <= the cursor is a
+ * duplicate/stale signal and is ignored.
+ *
+ * On acting, we schedule the drain implied by kind: 'sync' -> sync drain,
+ * 'intents' -> intents drain, anything else (incl. the 'connected' reconcile) ->
+ * BOTH, since we can't tell which side advanced. Rapid nudges within debounceMs
+ * coalesce into a single drain per kind.
+ *
+ * onDrain(kind) is called with 'sync' or 'intents' (never 'both' — 'both' fans
+ * out to one 'sync' + one 'intents' call). It is invoked inside a try/catch so a
+ * throwing drain can never break the debounce timer or the SSE loop.
+ *
+ * @param {object} p
+ * @param {(kind:'sync'|'intents') => void} p.onDrain
+ * @param {number} [p.debounceMs]
+ * @param {typeof setTimeout}  [p.setTimeoutFn]
+ * @param {typeof clearTimeout}[p.clearTimeoutFn]
+ * @param {(msg:string, err:any) => void} [p.onDrainError]
+ */
+export function createNudgeCoalescer({
+  onDrain,
+  debounceMs = 400,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  onDrainError,
+} = {}) {
+  let lastSeq = -Infinity;
+  let timer = null;
+  let pending = new Set();
+
+  const runDrain = (kind) => {
+    try {
+      onDrain?.(kind);
+    } catch (err) {
+      onDrainError?.(`vault-sse drain (${kind}) failed`, err);
+    }
+  };
+
+  const flush = () => {
+    timer = null;
+    const kinds = pending;
+    pending = new Set();
+    // Deterministic order: sync before intents.
+    if (kinds.has('sync')) runDrain('sync');
+    if (kinds.has('intents')) runDrain('intents');
+  };
+
+  const schedule = (kind) => {
+    if (kind === 'both') { pending.add('sync'); pending.add('intents'); }
+    else pending.add(kind);
+    if (timer) clearTimeoutFn(timer);
+    timer = setTimeoutFn(flush, debounceMs);
+  };
+
+  /**
+   * Feed one nudge event. Returns true if it was acted on (seq advanced), false
+   * if ignored (not behind / malformed).
+   */
+  const handleEvent = (evt) => {
+    if (!evt || typeof evt.seq !== 'number' || Number.isNaN(evt.seq)) return false;
+    if (evt.seq <= lastSeq) return false; // not behind — coalesced/stale, ignore
+    lastSeq = evt.seq;
+    if (evt.kind === 'sync') schedule('sync');
+    else if (evt.kind === 'intents') schedule('intents');
+    else schedule('both'); // 'connected' reconcile or unknown kind → drain both
+    return true;
+  };
+
+  return {
+    handleEvent,
+    getCursor: () => lastSeq,
+    // Flush any pending debounce immediately (used on teardown if desired).
+    cancel: () => { if (timer) { clearTimeoutFn(timer); timer = null; } pending = new Set(); },
+  };
+}
+
+// ─── connection client (reconnect + backoff) ──────────────────────────────────
+
+/**
+ * Manages the SSE connection lifecycle: connect, pump events through onEvent,
+ * and on any drop reconnect with capped exponential backoff. It NEVER touches
+ * polling — polling is a separate effect and remains the backstop for every gap
+ * this client leaves (backoff waits, background, permanent failure).
+ *
+ * start() opens the stream (no-op when unsupported or no connection). stop()
+ * aborts the current stream and cancels any pending reconnect. Both are
+ * idempotent and safe to interleave (e.g. visibility toggles).
+ *
+ * @param {object} p
+ * @param {() => ({vaultUrl:string,vaultToken:string,accountId:string}|null)} p.getConnection
+ * @param {(args:{connection:object,signal:AbortSignal,onOpen:()=>void,onEvent:(e:object)=>void}) => Promise<void>} p.openStream
+ * @param {(evt:object) => void} p.onEvent
+ * @param {boolean} [p.supported]      false → never opens (native/electron/none)
+ * @param {number}  [p.backoffBaseMs]
+ * @param {number}  [p.backoffMaxMs]
+ * @param {typeof setTimeout}  [p.setTimeoutFn]
+ * @param {typeof clearTimeout}[p.clearTimeoutFn]
+ * @param {(state:string) => void} [p.onStateChange]
+ */
+export function createVaultEventClient({
+  getConnection,
+  openStream,
+  onEvent,
+  supported = true,
+  backoffBaseMs = 1000,
+  backoffMaxMs = 30000,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  onStateChange,
+} = {}) {
+  let stopped = true;
+  let looping = false;
+  let attempt = 0;
+  let abortController = null;
+  let reconnectTimer = null;
+
+  const makeAbort = () => (typeof AbortController !== 'undefined' ? new AbortController() : { signal: undefined, abort() {} });
+
+  const loop = async () => {
+    if (looping) return;
+    looping = true;
+    while (!stopped) {
+      const connection = supported ? getConnection?.() : null;
+      if (!connection) break; // nothing to connect to → let polling cover it
+      abortController = makeAbort();
+      onStateChange?.('connecting');
+      try {
+        await openStream({
+          connection,
+          signal: abortController.signal,
+          onOpen: () => { attempt = 0; onStateChange?.('open'); },
+          onEvent,
+        });
+        // Stream ended cleanly (server closed / heartbeat gap) — reconnect soon.
+        onStateChange?.('closed');
+      } catch (err) {
+        // Connect/network/abort error — SSE is additive, so we swallow it and
+        // reconnect. Polling keeps delivering in the meantime.
+        if (!stopped) onStateChange?.('error');
+      }
+      if (stopped) break;
+      const delay = Math.min(backoffMaxMs, backoffBaseMs * 2 ** attempt);
+      attempt += 1;
+      await new Promise((resolve) => { reconnectTimer = setTimeoutFn(resolve, delay); });
+      reconnectTimer = null;
+    }
+    looping = false;
+  };
+
+  return {
+    start() {
+      if (!supported) { onStateChange?.('unsupported'); return; }
+      stopped = false;
+      if (!looping) { attempt = 0; loop(); }
+    },
+    stop() {
+      stopped = true;
+      if (abortController) { try { abortController.abort(); } catch { /* ignore */ } abortController = null; }
+      if (reconnectTimer) { clearTimeoutFn(reconnectTimer); reconnectTimer = null; }
+      onStateChange?.('stopped');
+    },
+    isRunning: () => !stopped,
+    isSupported: () => supported,
+  };
+}

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -1,0 +1,391 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  parseSseFrame,
+  drainSseBuffer,
+  detectSseTransport,
+  openWebSseStream,
+  createNudgeCoalescer,
+  createVaultEventClient,
+} from './vaultEventStream.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GLANCEvault SSE push client — pure transport core.
+//
+// CORE INVARIANT under test: push is additive; polling is the correctness
+// backstop. These tests exercise the parser, the seq-cursor coalescer, and the
+// reconnect client with everything injected (no network, no DOM, fake timers).
+//
+// What is FAKED vs on-device:
+//   • FAKED here: the SSE byte stream (openStream is injected), the drain
+//     callbacks (spies standing in for the real dbSyncCycle / drainDbIntents),
+//     and timers. This proves the seq/debounce/reconnect/reconcile LOGIC.
+//   • ON-DEVICE (not covered here): the real fetch streaming body on web
+//     (response.body.getReader) and the fact that the native/electron buffered
+//     bridge cannot stream — detectSseTransport() encodes that decision and is
+//     unit-tested below by faking window.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('parseSseFrame', () => {
+  it('parses a data: line as JSON into {seq, kind}', () => {
+    expect(parseSseFrame('data: {"seq":5,"kind":"sync"}')).toEqual({ seq: 5, kind: 'sync' });
+  });
+
+  it('ignores heartbeat/comment lines (leading colon) → null', () => {
+    expect(parseSseFrame(': keep-alive')).toBeNull();
+  });
+
+  it('ignores event:/id: fields and reads only data:', () => {
+    const block = 'event: intents\nid: 9\ndata: {"seq":9,"kind":"intents"}';
+    expect(parseSseFrame(block)).toEqual({ seq: 9, kind: 'intents' });
+  });
+
+  it('concatenates multiple data: lines before JSON.parse', () => {
+    const block = 'data: {"seq":3,\ndata: "kind":"connected"}';
+    expect(parseSseFrame(block)).toEqual({ seq: 3, kind: 'connected' });
+  });
+
+  it('returns null for a block with no data', () => {
+    expect(parseSseFrame('event: ping')).toBeNull();
+  });
+
+  it('returns null for unparseable data', () => {
+    expect(parseSseFrame('data: not-json')).toBeNull();
+  });
+});
+
+describe('drainSseBuffer', () => {
+  it('emits complete frames and returns the partial remainder', () => {
+    const events = [];
+    const rest = drainSseBuffer(
+      'data: {"seq":1,"kind":"sync"}\n\ndata: {"seq":2,"kind":"intents"}\n\ndata: {"seq":3',
+      (e) => events.push(e),
+    );
+    expect(events).toEqual([{ seq: 1, kind: 'sync' }, { seq: 2, kind: 'intents' }]);
+    expect(rest).toBe('data: {"seq":3'); // partial frame carried forward
+  });
+
+  it('normalizes CRLF frame boundaries', () => {
+    const events = [];
+    drainSseBuffer('data: {"seq":7,"kind":"sync"}\r\n\r\n', (e) => events.push(e));
+    expect(events).toEqual([{ seq: 7, kind: 'sync' }]);
+  });
+
+  it('skips heartbeat frames', () => {
+    const events = [];
+    const rest = drainSseBuffer(': hb\n\ndata: {"seq":4,"kind":"sync"}\n\n', (e) => events.push(e));
+    expect(events).toEqual([{ seq: 4, kind: 'sync' }]);
+    expect(rest).toBe('');
+  });
+});
+
+describe('detectSseTransport', () => {
+  const orig = { window: global.window };
+  afterEach(() => { global.window = orig.window; });
+
+  it('returns web when fetch + ReadableStream exist and no native/electron bridge', () => {
+    global.window = { fetch: () => {}, ReadableStream: function () {} };
+    // fetch/ReadableStream are read off globalThis, not window — emulate presence.
+    global.fetch = () => {};
+    global.ReadableStream = global.ReadableStream || function () {};
+    expect(detectSseTransport()).toBe('web');
+  });
+
+  it('returns native-unsupported when the native bridge is present', () => {
+    global.window = { DayGlanceNative: { httpRequest: () => {} } };
+    expect(detectSseTransport()).toBe('native-unsupported');
+  });
+
+  it('returns electron-unsupported when electron proxy is present', () => {
+    global.window = { electronAPI: { isElectron: true } };
+    expect(detectSseTransport()).toBe('electron-unsupported');
+  });
+});
+
+describe('createNudgeCoalescer — seq cursor + debounce', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('drains on a seq-ahead nudge and IGNORES one that is not behind', () => {
+    const onDrain = vi.fn();
+    const c = createNudgeCoalescer({ onDrain, debounceMs: 100 });
+
+    expect(c.handleEvent({ seq: 5, kind: 'sync' })).toBe(true); // ahead → act
+    expect(c.handleEvent({ seq: 5, kind: 'sync' })).toBe(false); // equal → ignore
+    expect(c.handleEvent({ seq: 4, kind: 'sync' })).toBe(false); // behind → ignore
+
+    vi.advanceTimersByTime(100);
+    expect(onDrain).toHaveBeenCalledTimes(1);
+    expect(onDrain).toHaveBeenCalledWith('sync');
+  });
+
+  it('coalesces a rapid burst of nudges into a single drain', () => {
+    const onDrain = vi.fn();
+    const c = createNudgeCoalescer({ onDrain, debounceMs: 100 });
+
+    c.handleEvent({ seq: 1, kind: 'sync' });
+    c.handleEvent({ seq: 2, kind: 'sync' });
+    c.handleEvent({ seq: 3, kind: 'sync' });
+    vi.advanceTimersByTime(50); // still within debounce
+    c.handleEvent({ seq: 4, kind: 'sync' });
+    vi.advanceTimersByTime(100);
+
+    expect(onDrain).toHaveBeenCalledTimes(1); // one drain for the whole burst
+    expect(c.getCursor()).toBe(4);
+  });
+
+  it("routes kind to the matching drain; a 'sync' nudge does not drain intents", () => {
+    const onDrain = vi.fn();
+    const c = createNudgeCoalescer({ onDrain, debounceMs: 100 });
+    c.handleEvent({ seq: 10, kind: 'sync' });
+    vi.advanceTimersByTime(100);
+    expect(onDrain).toHaveBeenCalledTimes(1);
+    expect(onDrain).toHaveBeenCalledWith('sync');
+    expect(onDrain).not.toHaveBeenCalledWith('intents');
+  });
+
+  it("drains BOTH on a 'connected' reconcile and on unknown kinds", () => {
+    const onDrain = vi.fn();
+    const c = createNudgeCoalescer({ onDrain, debounceMs: 100 });
+    c.handleEvent({ seq: 20, kind: 'connected' });
+    vi.advanceTimersByTime(100);
+    expect(onDrain.mock.calls.map((a) => a[0])).toEqual(['sync', 'intents']);
+  });
+
+  it('a throwing drain does not break the coalescer (invariant: SSE is additive)', () => {
+    const onDrain = vi.fn(() => { throw new Error('boom'); });
+    const onDrainError = vi.fn();
+    const c = createNudgeCoalescer({ onDrain, onDrainError, debounceMs: 50 });
+    c.handleEvent({ seq: 1, kind: 'sync' });
+    expect(() => vi.advanceTimersByTime(50)).not.toThrow();
+    expect(onDrainError).toHaveBeenCalled();
+    // A later nudge still acts — the coalescer self-heals.
+    c.handleEvent({ seq: 2, kind: 'intents' });
+    vi.advanceTimersByTime(50);
+    expect(onDrain).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── reconnect client ─────────────────────────────────────────────────────────
+
+// A controllable fake stream: resolves/rejects on command and exposes hooks to
+// push events / simulate the server closing the connection.
+function makeControllableStream() {
+  const calls = [];
+  let current = null;
+  const openStream = ({ connection, signal, onOpen, onEvent }) =>
+    new Promise((resolve, reject) => {
+      const handle = { connection, signal, onOpen, onEvent, resolve, reject };
+      calls.push(handle);
+      current = handle;
+      onOpen?.(); // confirm connection open (resets backoff)
+    });
+  return {
+    openStream,
+    calls,
+    push: (evt) => current?.onEvent(evt),
+    close: () => current?.resolve(),   // server closed the stream cleanly
+    fail: (err) => current?.reject(err || new Error('network')),
+  };
+}
+
+describe('createVaultEventClient — lifecycle, reconnect, reconcile', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('does NOT open when unsupported (native/electron) — degrades to polling', () => {
+    const s = makeControllableStream();
+    const client = createVaultEventClient({
+      supported: false,
+      getConnection: () => ({ vaultUrl: 'u', vaultToken: 't', accountId: 'a' }),
+      openStream: s.openStream,
+      onEvent: () => {},
+    });
+    client.start();
+    expect(s.calls).toHaveLength(0); // never opened → polling is the only path
+    expect(client.isRunning()).toBe(false);
+  });
+
+  it('does NOT open when there is no vault connection (vault disabled)', () => {
+    const s = makeControllableStream();
+    const client = createVaultEventClient({
+      supported: true,
+      getConnection: () => null, // vault disabled / not configured
+      openStream: s.openStream,
+      onEvent: () => {},
+    });
+    client.start();
+    expect(s.calls).toHaveLength(0);
+  });
+
+  it('opens once when supported and connected, forwarding nudges to onEvent', async () => {
+    const s = makeControllableStream();
+    const events = [];
+    const client = createVaultEventClient({
+      supported: true,
+      getConnection: () => ({ vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' }),
+      openStream: s.openStream,
+      onEvent: (e) => events.push(e),
+    });
+    client.start();
+    expect(s.calls).toHaveLength(1);
+    s.push({ seq: 1, kind: 'sync' });
+    expect(events).toEqual([{ seq: 1, kind: 'sync' }]);
+    client.stop();
+  });
+
+  it('reconnects with backoff after a drop and RECONCILES via the connected seq', async () => {
+    const s = makeControllableStream();
+    // Drive the coalescer through the client so we observe the real reconcile path.
+    const onDrain = vi.fn();
+    const coalescer = createNudgeCoalescer({ onDrain, debounceMs: 10 });
+    const client = createVaultEventClient({
+      supported: true,
+      getConnection: () => ({ vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' }),
+      openStream: s.openStream,
+      onEvent: coalescer.handleEvent,
+      backoffBaseMs: 1000,
+      backoffMaxMs: 30000,
+    });
+
+    client.start();
+    // First connect: server reports current account seq 5 → reconcile drains both.
+    s.calls[0].onEvent({ seq: 5, kind: 'connected' });
+    vi.advanceTimersByTime(10);
+    expect(onDrain).toHaveBeenCalledTimes(2); // sync + intents
+    onDrain.mockClear();
+
+    // Connection drops.
+    s.fail(new Error('network gone'));
+    await Promise.resolve(); await Promise.resolve();
+
+    // While disconnected the account advanced to 7 (a change we missed). Backoff
+    // elapses and the client reconnects.
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve(); await Promise.resolve();
+    expect(s.calls.length).toBeGreaterThanOrEqual(2);
+    const reconnected = s.calls[s.calls.length - 1];
+    reconnected.onEvent({ seq: 7, kind: 'connected' }); // catches the missed change
+    vi.advanceTimersByTime(10);
+    expect(onDrain).toHaveBeenCalledTimes(2); // reconcile drain on reconnect
+
+    client.stop();
+  });
+
+  it('a stream error does NOT throw and does NOT stop the client from recovering', async () => {
+    const s = makeControllableStream();
+    const client = createVaultEventClient({
+      supported: true,
+      getConnection: () => ({ vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' }),
+      openStream: s.openStream,
+      onEvent: () => {},
+      backoffBaseMs: 500,
+    });
+    client.start();
+    expect(() => s.fail(new Error('boom'))).not.toThrow();
+    await Promise.resolve(); await Promise.resolve();
+    // It schedules a reconnect rather than dying.
+    vi.advanceTimersByTime(500);
+    await Promise.resolve(); await Promise.resolve();
+    expect(s.calls.length).toBeGreaterThanOrEqual(2);
+    client.stop();
+    expect(client.isRunning()).toBe(false);
+  });
+
+  it('BACKSTOP: while SSE is permanently down, an independent poll still drains', async () => {
+    // The poll cadence is a SEPARATE effect the client never references. Model it
+    // as its own timer-driven drain and prove SSE churn cannot stop it.
+    const drain = vi.fn();
+    let pollTimer = null;
+    const schedulePoll = () => { pollTimer = setTimeout(() => { drain('poll'); schedulePoll(); }, 1000); };
+    schedulePoll();
+
+    const s = {
+      openStream: () => Promise.reject(new Error('SSE unreachable')), // never connects
+    };
+    const client = createVaultEventClient({
+      supported: true,
+      getConnection: () => ({ vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' }),
+      openStream: s.openStream,
+      onEvent: () => {},
+      backoffBaseMs: 1000,
+    });
+    client.start();
+
+    // Let time pass: SSE keeps failing + backing off, poll keeps delivering.
+    for (let n = 0; n < 5; n++) {
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve(); await Promise.resolve();
+    }
+    expect(drain).toHaveBeenCalled(); // polling delivered despite SSE being down
+    expect(drain.mock.calls.every((c) => c[0] === 'poll')).toBe(true);
+
+    clearTimeout(pollTimer);
+    client.stop();
+  });
+
+  it('stop() aborts the current stream and prevents further reconnects', async () => {
+    const s = makeControllableStream();
+    const client = createVaultEventClient({
+      supported: true,
+      getConnection: () => ({ vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' }),
+      openStream: s.openStream,
+      onEvent: () => {},
+      backoffBaseMs: 500,
+    });
+    client.start();
+    const openedBefore = s.calls.length;
+    client.stop();
+    s.fail(new Error('drop after stop'));
+    await Promise.resolve(); await Promise.resolve();
+    vi.advanceTimersByTime(10000);
+    await Promise.resolve(); await Promise.resolve();
+    expect(s.calls.length).toBe(openedBefore); // no reconnect after stop
+  });
+});
+
+// ─── web streaming reader ─────────────────────────────────────────────────────
+
+describe('openWebSseStream — web fetch-stream path', () => {
+  it('sets the Bearer header + accountId, and pumps parsed frames', async () => {
+    const chunks = [
+      'data: {"seq":1,"kind":"connected"}\n\n',
+      ': heartbeat\n\n',
+      'data: {"seq":2,"kind":"sync"}\n\n',
+    ];
+    let i = 0;
+    const reader = {
+      read: async () => (i < chunks.length
+        ? { done: false, value: new TextEncoder().encode(chunks[i++]) }
+        : { done: true, value: undefined }),
+      releaseLock: () => {},
+    };
+    let capturedUrl, capturedInit;
+    const fetchImpl = async (url, init) => {
+      capturedUrl = url; capturedInit = init;
+      return { ok: true, status: 200, body: { getReader: () => reader } };
+    };
+    const events = [];
+    const onOpen = vi.fn();
+    await openWebSseStream({
+      connection: { vaultUrl: 'https://vault.example.com/', vaultToken: 'tok-9', accountId: 'acct-42' },
+      onOpen,
+      onEvent: (e) => events.push(e),
+      fetchImpl,
+    });
+
+    expect(capturedUrl).toBe('https://vault.example.com/events?accountId=acct-42');
+    expect(capturedInit.headers.Authorization).toBe('Bearer tok-9');
+    expect(capturedInit.headers.Accept).toBe('text/event-stream');
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([{ seq: 1, kind: 'connected' }, { seq: 2, kind: 'sync' }]);
+  });
+
+  it('throws on a non-OK response so the client reconnects (never a silent hang)', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 401, body: null });
+    await expect(openWebSseStream({
+      connection: { vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' },
+      onEvent: () => {},
+      fetchImpl,
+    })).rejects.toThrow();
+  });
+});

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -95,9 +95,13 @@ describe('detectSseTransport', () => {
     expect(detectSseTransport()).toBe('native-unsupported');
   });
 
-  it('returns electron-unsupported when electron proxy is present', () => {
+  it('returns web on Electron — Chromium renderer on app:// streams via direct fetch (no proxy)', () => {
     global.window = { electronAPI: { isElectron: true } };
-    expect(detectSseTransport()).toBe('electron-unsupported');
+    global.fetch = global.fetch || (() => {});
+    global.ReadableStream = global.ReadableStream || function () {};
+    // Electron is deliberately NOT short-circuited: it uses the same direct
+    // streaming fetch as web, so SSE push works on the desktop app.
+    expect(detectSseTransport()).toBe('web');
   });
 });
 

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -13,5 +13,5 @@
     "types": ["node", "electron", "ws"]
   },
   "include": ["electron"],
-  "exclude": ["electron/preload.ts"]
+  "exclude": ["electron/preload.ts", "electron/**/*.test.ts"]
 }

--- a/vite.config.electron.js
+++ b/vite.config.electron.js
@@ -33,9 +33,13 @@ function electronCspMetaPlugin() {
   };
 }
 
-// Electron renderer build — no PWA, no dev proxy, base must be './' for file:// loading
+// Electron renderer build — no PWA, no dev proxy. base is '/' (absolute from the
+// origin root): the renderer now loads from the custom app://dayglance origin
+// (not file://), so assets resolve as app://dayglance/assets/… regardless of the
+// document's path — robust for the app:// protocol handler + any client route.
+// (Was './' when the app loaded via file://, where only relative paths worked.)
 export default defineConfig({
-  base: './',
+  base: '/',
   define: {
     __BUILD_TIMESTAMP__: JSON.stringify(new Date().toISOString()),
     __APP_VERSION__: JSON.stringify(pkg.version),


### PR DESCRIPTION
## Summary

Adds client-side GLANCEvault SSE push consumption so dayGLANCE drains **instantly** on a server nudge instead of waiting for the poll — while **keeping polling as the permanent correctness backstop** — and makes it work on the desktop app by moving the Electron renderer from `file://` onto a real, allowlistable `app://dayglance` origin.

Three separable commits:

1. **SSE push consumption** — consume the vault's authenticated per-account SSE stream at `GET /events`; a nudge triggers the **existing** sync/intents drains (debounced), with reconnect + connected-seq reconcile.
2. **Electron `file://` → custom `app://` origin** — production hygiene for the imminent Mac App Store launch and a specific origin (vs the `null` file:// origin) that the vault can allowlist.
3. **Enable SSE on Electron** — remove the Electron short-circuit; the Chromium renderer on `app://` streams directly like web.

## Core invariant

Push is an optimization; **polling is the correctness backstop**. Nothing is delivered only by push — the existing DB sync (5-min) and DB intents (2-min) poll cadences are left untouched; a nudge only ADDS an instant drain on top. If SSE is unavailable, throws, or is CORS-rejected, the app degrades to exactly today's polling behavior.

## What changed

**Part 1 — SSE client**
- `src/sync/vaultEventStream.js`: pure transport core — SSE frame parser (ignores heartbeats/comments), seq-cursor coalescer (ignore-when-not-behind + debounce), reconnect client with capped exponential backoff and connected-seq reconcile, web fetch-stream reader (Bearer auth, `accountId` scope).
- `src/hooks/useVaultEventStream.js`: React lifecycle — opens only when the vault is enabled + app active, drops on background, reconnects on foreground, cleans up on unmount; triggers the EXISTING drains (`dbSyncCycle` / `drainDbIntents`).
- `src/intents/dbIntentsTransport.js`: export `drainDbIntents()`, a locked wrapper sharing the poller's lock so SSE-triggered and cadence drains never race.
- `src/App.jsx`: wire `useVaultEventStream` to the existing sync/intents drains.

**Part 2 — Electron `app://` origin**
- `electron/appProtocol.ts`: pure, unit-tested request→file resolver + scheme/host/origin constants. Maps `app://dayglance/<path>` → `dist/<path>`, SPA fallback to `index.html` for client routes, real 404 for a missing asset, traversal guard. Exact origin: **`app://dayglance`**.
- `electron/main.ts`: register the scheme privileged (standard, secure, supportFetchAPI, corsEnabled, stream) before app-ready; `protocol.handle` serving `dist/` with CSP on the HTML response; load `app://dayglance/` (main) / `?tray=1` (tray) in production (dev still uses the Vite dev server); `isSameAppOrigin` trusts the `app://` origin; refreshed stale `file://` comments.
- `vite.config.electron.js`: `base './' → '/'` so assets resolve from the origin root.
- `tsconfig.electron.json`: exclude `*.test.ts` from the shipped main-process build.

**Part 3 — enable SSE on Electron**
- `detectSseTransport()`: drop the `electron-unsupported` branch — Electron falls through to `'web'` and uses the same direct streaming fetch. Native WebView still degrades to polling (its bridge is buffered).

The IPC proxy (`window.electronAPI.proxyFetch` → `ipcMain 'proxy-fetch'`) is invoked over IPC and reads no origin, so WebDAV/CalDAV/vault-sync via the proxy are unaffected by the origin switch. SSE never uses the proxy (it buffers via `response.text()` and can't stream).

## Web vs native vs Electron

| Platform | SSE transport |
|---|---|
| Web (browser/PWA) | Direct streaming `fetch()` with Bearer header |
| Electron (macOS/desktop) | Same direct streaming fetch, from the `app://dayglance` origin |
| Native WebView (Android/iOS) | No stream (buffered bridge) → polling backstop |

## Action required (vault side)

Direct SSE fetch from Electron presents `Origin: app://dayglance`. **Add that exact origin to glance-vault's CORS allowlist** (plus `Access-Control-Allow-Headers: authorization` for the Bearer preflight on `/events`). Until then, the desktop SSE fetch is CORS-rejected and cleanly falls back to polling.

## Tests

- `src/sync/vaultEventStream.test.js` (26): nudge seq-ahead drains / not-behind ignored; rapid nudges coalesce; kind routing; connected reconcile; SSE-down → polling backstop; reconnect reconciles via connected seq; SSE throw doesn't break recovery; opens only when supported; frame parser ignores heartbeats; web reader sets Bearer + accountId; **Electron now asserts `'web'`**.
- `electron/appProtocol.test.ts` (10): asset serving + content types, root→index, query ignored, SPA fallback vs real 404, traversal containment, exact origin string.
- Faked in tests: the SSE byte stream, drain callbacks, timers, and the protocol resolver's fs. Full suite **502 pass**, `eslint src` clean, web + electron builds pass, electron `tsc --noEmit` clean.

## Real validation (packaged / TestFlight MAS build)

Unit tests can't exercise Chromium-under-sandbox. On a signed MAS/TestFlight build verify: app loads from `app://dayglance/` (no white screen), `theme-init.js` pre-paint, tray `?tray=1`, both reload paths, **vault sync/WebDAV/CalDAV via the proxy still work**, SSE direct-fetch streaming with `app://dayglance` allowlisted (and clean polling fallback without it), and MAS sandbox secure-context behavior of the custom scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_