### PR TITLE
Electron fixes: SSE reconnect storm + observability, tray popup position

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, ipcMain, net, protocol, Tray, Menu, nativeImage, globalShortcut, session } from 'electron';
+import { app, BrowserWindow, shell, ipcMain, net, protocol, Tray, Menu, nativeImage, globalShortcut, session, screen } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
 import dns from 'node:dns';
@@ -216,6 +216,24 @@ function createTrayWindow(): BrowserWindow {
   return win;
 }
 
+// Position the tray popup under the menu-bar icon. When the icon's bounds are
+// unavailable/zero — which happens if the menu-bar item failed to render, e.g. an
+// icon that didn't load — fall back to the TOP-RIGHT of the primary display's work
+// area (under the menu bar, where the tray lives) instead of the (0,0) top-left
+// corner the raw arithmetic would otherwise produce.
+function positionTrayPopup(tw: BrowserWindow, iconBounds?: Electron.Rectangle): void {
+  const { width: popW } = tw.getBounds();
+  if (iconBounds && iconBounds.width > 0) {
+    tw.setPosition(
+      Math.round(iconBounds.x - popW / 2 + iconBounds.width / 2),
+      Math.round(iconBounds.y + iconBounds.height),
+    );
+    return;
+  }
+  const wa = screen.getPrimaryDisplay().workArea;
+  tw.setPosition(Math.round(wa.x + wa.width - popW - 8), Math.round(wa.y + 8));
+}
+
 function createTray(): void {
   // Downsample the high-res app icon to 44×44 px, then tell Electron it's a
   // @2x image so macOS renders it at 22 logical points — the standard menu bar
@@ -223,8 +241,11 @@ function createTray(): void {
   const srcPath = DEV
     ? path.join(process.cwd(), 'public/icon-512.png')
     : path.join(__dirname, '../dist/icon-512.png');
-  const iconBuf = nativeImage.createFromPath(srcPath).resize({ width: 44, height: 44 }).toPNG();
-  const icon = nativeImage.createFromBuffer(iconBuf, { scaleFactor: 2 });
+  const rawIcon = nativeImage.createFromPath(srcPath);
+  if (rawIcon.isEmpty()) console.error('[tray] menu-bar icon failed to load from', srcPath);
+  const iconBuf = rawIcon.resize({ width: 44, height: 44 }).toPNG();
+  let icon = nativeImage.createFromBuffer(iconBuf, { scaleFactor: 2 });
+  if (icon.isEmpty()) icon = rawIcon; // fall back to the un-resized image
   icon.setTemplateImage(true);
   tray = new Tray(icon);
   tray.setToolTip('dayGLANCE');
@@ -235,9 +256,7 @@ function createTray(): void {
     const tw = live(trayWindow);
     if (!tw) return;
     if (tw.isVisible()) { tw.hide(); return; }
-    const { x, y, width: iconW, height: iconH } = bounds;
-    const { width: popW } = tw.getBounds();
-    tw.setPosition(Math.round(x - popW / 2 + iconW / 2), Math.round(y + iconH));
+    positionTrayPopup(tw, bounds);
     trayIndicatorOn = false;
     refreshTrayTitle();
     tw.show();
@@ -465,12 +484,7 @@ ipcMain.handle('hotkey:register', (_event, accelerator: string) => {
     const tw = live(trayWindow);
     if (!tw) return;
     if (tw.isVisible()) { tw.hide(); return; }
-    const bounds = tray?.getBounds();
-    if (bounds) {
-      const { x, y, width: iconW, height: iconH } = bounds;
-      const { width: popW } = tw.getBounds();
-      tw.setPosition(Math.round(x - popW / 2 + iconW / 2), Math.round(y + iconH));
-    }
+    positionTrayPopup(tw, tray?.getBounds());
     trayIndicatorOn = false;
     refreshTrayTitle();
     tw.show();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -562,7 +562,84 @@ if (!gotSingleInstanceLock) {
   });
 }
 
-app.whenReady().then(() => {
+// One-time origin storage migration (file:// → app://dayglance).
+//
+// Browser storage is PARTITIONED BY ORIGIN. Switching the renderer from file:// to
+// app:// gave the app a fresh, empty localStorage bucket, orphaning every existing
+// user's data under the old file:// origin (it booted empty and rehydrated from
+// iCloud — effective local data loss). This copies the old file:// localStorage
+// into the app:// bucket ONCE, before the main window loads, so existing users keep
+// their data after the switch. Conflict rule: file:// wins (the user's original
+// local data is authoritative), applied a single time and then flagged done.
+//
+// IndexedDB is deliberately NOT migrated: it holds only origin-bound, generally
+// non-extractable CryptoKeys (which cannot be moved across origins by any means and
+// are re-derived from the sync passphrase on the next sync) plus minor caches
+// (durable intents outbox, Obsidian dir handle). So after migration a user may see
+// a one-time passphrase prompt to re-cache sync keys — expected, not data loss.
+const STORAGE_MIGRATION_FLAG = '.origin-migrated-file-to-app-v1';
+
+// Read a whole origin's localStorage as a plain object, robustly (index iteration
+// avoids Storage-method name collisions). Runs in the page's main world.
+const READ_LOCALSTORAGE_JS =
+  'JSON.stringify((function(){var o={};for(var i=0;i<localStorage.length;i++){var k=localStorage.key(i);o[k]=localStorage.getItem(k);}return o;})())';
+
+async function migrateFileToAppStorage(): Promise<void> {
+  const flagPath = path.join(app.getPath('userData'), STORAGE_MIGRATION_FLAG);
+  if (fs.existsSync(flagPath)) return;
+
+  const bridgePath = path.join(APP_DIST_DIR, 'storage-bridge.html');
+  if (!fs.existsSync(bridgePath)) return; // build without the bridge — skip safely
+
+  const mkHidden = () => new BrowserWindow({
+    show: false,
+    webPreferences: { contextIsolation: true, nodeIntegration: false },
+  });
+
+  try {
+    // 1) READ the old file:// localStorage from a blank file:// document. All
+    //    file:// documents share one localStorage bucket, so this sees exactly what
+    //    the old file://…/index.html build wrote — without booting the app.
+    const reader = mkHidden();
+    let dump = '{}';
+    try {
+      await reader.loadFile(bridgePath); // file:// origin
+      dump = await reader.webContents.executeJavaScript(READ_LOCALSTORAGE_JS);
+    } finally {
+      if (!reader.isDestroyed()) reader.destroy();
+    }
+
+    let fileData: Record<string, string> = {};
+    try { fileData = JSON.parse(dump) || {}; } catch { fileData = {}; }
+    const keys = Object.keys(fileData);
+    if (keys.length === 0) {
+      // Nothing under file:// (fresh install / already-migrated machine) — flag done.
+      fs.writeFileSync(flagPath, new Date().toISOString());
+      return;
+    }
+
+    // 2) WRITE into the app:// localStorage (file:// wins on conflict; app://-only
+    //    keys are left intact). Same session as the main window, so the writes are
+    //    visible to it immediately.
+    const writer = mkHidden();
+    try {
+      await writer.loadURL(APP_BASE_URL + 'storage-bridge.html'); // app://dayglance origin
+      await writer.webContents.executeJavaScript(
+        `(function(){var d=${JSON.stringify(fileData)};for(var k in d){localStorage.setItem(k,d[k]);}return true;})()`,
+      );
+    } finally {
+      if (!writer.isDestroyed()) writer.destroy();
+    }
+
+    fs.writeFileSync(flagPath, new Date().toISOString());
+    console.info(`[migrate] copied ${keys.length} localStorage keys file:// → app://dayglance`);
+  } catch (err) {
+    // Never block startup, and do NOT flag done on failure — retry next launch.
+    console.error('[migrate] file:// → app:// storage migration failed:', err);
+  }
+}
+
+app.whenReady().then(async () => {
   // A doomed second instance may still reach 'ready' before app.quit() takes
   // effect; bail before creating any windows so it never steals the port/state.
   if (!gotSingleInstanceLock) return;
@@ -625,6 +702,12 @@ app.whenReady().then(() => {
       return new Response('Not found', { status: 404, headers: { 'Content-Type': 'text/plain; charset=utf-8' } });
     }
   });
+
+  // Recover data stranded under the old file:// origin BEFORE the app loads, so it
+  // boots with the migrated localStorage. The protocol handler above must already
+  // be registered (the writer window loads app://). Awaited so createWindow() sees
+  // the migrated data; failures are swallowed inside and never block startup.
+  await migrateFileToAppStorage();
 
   const win = createWindow();
   createWsServer(() => live(mainWindow));

--- a/public/storage-bridge.html
+++ b/public/storage-bridge.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>dayGLANCE storage bridge</title>
+</head>
+<body>
+  <!--
+    Intentionally blank. The Electron main process loads this page under the old
+    file:// origin and the new app://dayglance origin so it can read/write each
+    origin's localStorage (via webContents.executeJavaScript) WITHOUT booting the
+    full app. Used only by the one-time file:// -> app:// storage migration in
+    electron/main.ts. Not referenced by the running app.
+  -->
+</body>
+</html>

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -54,8 +54,29 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
       return undefined;
     }
 
+    // Observability: a live, inspectable snapshot so SSE health can be checked in
+    // a packaged/MAS build with no devtools — run `window.__glanceVaultSse` in the
+    // console (or read it from a diagnostics panel). Counters make a reconnect
+    // STORM (many connects, few events) immediately obvious. Logging is always-on
+    // (not DEV-gated) but low-volume: one line per lifecycle transition, not per
+    // heartbeat.
+    const diag = {
+      state: 'idle',
+      connects: 0,
+      events: 0,
+      drains: 0,
+      lastEventSeq: null,
+      lastEventKind: null,
+      lastError: null,
+      lastConnectedAt: null,
+      transport,
+    };
+    if (typeof window !== 'undefined') window.__glanceVaultSse = diag;
+
     const coalescer = createNudgeCoalescer({
       onDrain: (kind) => {
+        diag.drains += 1;
+        console.info('[vault-sse] drain →', kind);
         if (kind === 'sync') drainSyncRef.current?.();
         else if (kind === 'intents') drainIntentsRef.current?.();
       },
@@ -71,9 +92,17 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
           : null;
       },
       openStream: openWebSseStream,
-      onEvent: coalescer.handleEvent,
-      onStateChange: (state) => {
-        if (import.meta.env?.DEV) console.debug('[vault-sse]', state);
+      onEvent: (evt) => {
+        diag.events += 1;
+        if (evt && typeof evt.seq === 'number') { diag.lastEventSeq = evt.seq; diag.lastEventKind = evt.kind; }
+        coalescer.handleEvent(evt);
+      },
+      onStateChange: (state, detail) => {
+        diag.state = state;
+        if (state === 'connecting') diag.connects += 1;
+        if (state === 'open') diag.lastConnectedAt = new Date().toISOString();
+        if (state === 'error') { diag.lastError = detail?.message || String(detail || 'error'); console.warn('[vault-sse] error:', diag.lastError); }
+        else console.info('[vault-sse]', state, `(connects=${diag.connects} events=${diag.events} drains=${diag.drains})`);
       },
     });
 

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -263,9 +263,11 @@ export function createNudgeCoalescer({
  * @param {boolean} [p.supported]      false → never opens (native/electron/none)
  * @param {number}  [p.backoffBaseMs]
  * @param {number}  [p.backoffMaxMs]
+ * @param {number}  [p.minStableMs]    connection must stay open ≥ this to reset backoff
  * @param {typeof setTimeout}  [p.setTimeoutFn]
  * @param {typeof clearTimeout}[p.clearTimeoutFn]
- * @param {(state:string) => void} [p.onStateChange]
+ * @param {() => number} [p.now]       clock (injectable for tests)
+ * @param {(state:string, detail?:any) => void} [p.onStateChange]
  */
 export function createVaultEventClient({
   getConnection,
@@ -274,8 +276,10 @@ export function createVaultEventClient({
   supported = true,
   backoffBaseMs = 1000,
   backoffMaxMs = 30000,
+  minStableMs = 5000,
   setTimeoutFn = setTimeout,
   clearTimeoutFn = clearTimeout,
+  now = () => Date.now(),
   onStateChange,
 } = {}) {
   let stopped = true;
@@ -294,11 +298,19 @@ export function createVaultEventClient({
       if (!connection) break; // nothing to connect to → let polling cover it
       abortController = makeAbort();
       onStateChange?.('connecting');
+      const startedAt = now();
       try {
         await openStream({
           connection,
           signal: abortController.signal,
-          onOpen: () => { attempt = 0; onStateChange?.('open'); },
+          // NOTE: do NOT reset the backoff here. A connection that OPENS then drops
+          // immediately (server closes fast, proxy timeout, CORS-accepted-then-reset)
+          // would otherwise reset attempt→0 every cycle and reconnect every
+          // backoffBaseMs (~1s) forever — a reconnect STORM that also re-fires the
+          // connected-seq reconcile drain, flickering sync and re-rendering the app.
+          // Backoff is reset below only after a connection proves STABLE (open long
+          // enough). See minStableMs.
+          onOpen: () => onStateChange?.('open'),
           onEvent,
         });
         // Stream ended cleanly (server closed / heartbeat gap) — reconnect soon.
@@ -306,9 +318,13 @@ export function createVaultEventClient({
       } catch (err) {
         // Connect/network/abort error — SSE is additive, so we swallow it and
         // reconnect. Polling keeps delivering in the meantime.
-        if (!stopped) onStateChange?.('error');
+        if (!stopped) onStateChange?.('error', err);
       }
       if (stopped) break;
+      // Reset backoff ONLY for a connection that stayed open long enough to be
+      // healthy; a flapping open/close keeps backing off (up to backoffMaxMs) so a
+      // broken endpoint can't storm.
+      if (now() - startedAt >= minStableMs) attempt = 0;
       const delay = Math.min(backoffMaxMs, backoffBaseMs * 2 ** attempt);
       attempt += 1;
       await new Promise((resolve) => { reconnectTimer = setTimeoutFn(resolve, delay); });

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -275,6 +275,59 @@ describe('createVaultEventClient — lifecycle, reconnect, reconcile', () => {
     client.stop();
   });
 
+  it('FLAP GUARD: a connection that opens then drops fast does NOT reset backoff (no 1s reconnect storm)', async () => {
+    const s = makeControllableStream();
+    const client = createVaultEventClient({
+      supported: true,
+      getConnection: () => ({ vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' }),
+      openStream: s.openStream,
+      onEvent: () => {},
+      backoffBaseMs: 1000,
+      backoffMaxMs: 60000,
+      minStableMs: 5000,
+    });
+    client.start();
+    expect(s.calls).toHaveLength(1);
+
+    // Open→close instantly (duration 0 < minStableMs): backoff must GROW, not reset.
+    s.close();                                   // attempt 0 → delay 1000, attempt→1
+    await Promise.resolve(); await Promise.resolve();
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve(); await Promise.resolve();
+    expect(s.calls).toHaveLength(2);             // reconnected after 1s
+
+    s.close();                                   // still flapping → delay 2000, attempt→2
+    await Promise.resolve(); await Promise.resolve();
+    vi.advanceTimersByTime(1000);                // only 1s of the 2s elapsed
+    await Promise.resolve(); await Promise.resolve();
+    expect(s.calls).toHaveLength(2);             // NOT yet — backoff grew to 2s (no storm)
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve(); await Promise.resolve();
+    expect(s.calls).toHaveLength(3);             // reconnects only after the full 2s
+
+    client.stop();
+  });
+
+  it('a STABLE connection (open past minStableMs) resets backoff so a later drop reconnects fast', async () => {
+    const s = makeControllableStream();
+    const client = createVaultEventClient({
+      supported: true,
+      getConnection: () => ({ vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' }),
+      openStream: s.openStream,
+      onEvent: () => {},
+      backoffBaseMs: 1000,
+      minStableMs: 5000,
+    });
+    client.start();
+    vi.advanceTimersByTime(5000);                // healthy: stayed open 5s
+    s.close();                                   // duration ≥ minStableMs → attempt resets to 0
+    await Promise.resolve(); await Promise.resolve();
+    vi.advanceTimersByTime(1000);                // so it reconnects after just 1s
+    await Promise.resolve(); await Promise.resolve();
+    expect(s.calls).toHaveLength(2);
+    client.stop();
+  });
+
   it('a stream error does NOT throw and does NOT stop the client from recovering', async () => {
     const s = makeControllableStream();
     const client = createVaultEventClient({


### PR DESCRIPTION
Follow-up fixes from live MAS-build testing.

## 1. SSE reconnect storm → "heartbeat" (fix)

A vault SSE connection that **opens then drops quickly** reset the reconnect backoff to base (~1s) on every cycle (`onOpen: () => { attempt = 0 }`), producing a reconnect storm. Each reconnect re-fires the connected-seq reconcile, which could re-trigger drains and re-render the app — the "heartbeat" that made the UI hard to click.

- `createVaultEventClient`: stop resetting backoff in `onOpen`. Track the connection start time and reset backoff **only after a connection stays open ≥ `minStableMs` (5s)**; a flapping open/close now backs off up to `backoffMaxMs` instead of hammering every second. `onStateChange` now also carries the error detail.

## 2. SSE observability (new)

So SSE health is checkable in a packaged/MAS build with no devtools:
- One **always-on** console line per lifecycle transition (`connecting`/`open`/`closed`/`error`/`drain`) with running counters.
- A live snapshot at **`window.__glanceVaultSse`** — `{ state, connects, events, drains, lastEventSeq, lastEventKind, lastError, lastConnectedAt, transport }`. A reconnect storm shows up as many `connects` with few `events`; a healthy stream shows `state:"open"` and rising `events`.

## 3. Tray popup position (fix)

Fixes the tray popup appearing at the **top-left (0,0)** when summoned via the global hotkey: `tray.getBounds()` returns a zero-size rect when the menu-bar item isn't rendering, and the positioning math then lands at the corner.
- `positionTrayPopup()`: shared by the click + hotkey paths; when icon bounds are missing/zero-width, places the popup at the **top-right of the primary display's work area** (under the menu bar) instead of the corner.
- `createTray()`: logs an error if the menu-bar icon fails to load and falls back to the un-resized image.

Note: the tray/icon code was **not** changed by the file:// → app:// switch, so this addresses the visible top-left symptom and adds a `[tray]` diagnostic to pin the icon-load question on the next packaged build.

## Tests
- `src/sync/vaultEventStream.test.js`: a fast open/close does NOT reset backoff (delays grow, no 1s storm); a stable connection (open past `minStableMs`) resets backoff so a later drop reconnects fast. Full suite **504 pass**, lint clean, web + electron builds pass, electron `tsc --noEmit` clean.

## For the tester
- **SSE cross-device instant sync requires the vault to allowlist `Origin: app://dayglance`** (plus `Access-Control-Allow-Headers: authorization`). Until that's set, the desktop SSE fetch is CORS-rejected and the app falls back to polling — which is very likely why changes aren't appearing instantly yet. Check `window.__glanceVaultSse` on macOS: `state:"open"` with rising `events` = SSE working; repeated `error`/`connecting` = CORS/allowlist still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_