### PR TITLE
Fix SSE self-nudge loop at the root (stable tombstone horizon), remove drain throttle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { voiceParseSystemPrompt, voiceParseUserPrompt, taskSuggestSystemPrompt, 
 import { gatherTrmnlData, pushToTrmnl, TRMNL_MARKUP_FULL, TRMNL_MARKUP_HALF_HORIZONTAL, TRMNL_MARKUP_HALF_VERTICAL, TRMNL_MARKUP_QUADRANT } from './trmnl.js';
 import { checkForUpdate } from './versionCheck.js';
 import { getStorageUsage, formatBytes } from './utils/storage.js';
+import { tombstoneHorizon } from './utils/tombstoneHorizon.js';
 import { stripHealthSourcedLogs } from './utils/healthLogFilter.js';
 import { webdavFetch } from './utils/cloudSyncProviders.js';
 import { autoBackupDB, createAutoBackupProvidersForFolder, AUTO_BACKUP_RETENTION, AUTO_BACKUP_INTERVALS } from './utils/autoBackup.js';
@@ -5819,9 +5820,12 @@ const DayPlanner = () => {
         multiUserEnabled,
         multiUserEnabledUpdatedAt: localStorage.getItem('dayglance-multi-user-enabled-updated-at') || null,
         users,
-        tombstonePrunedBefore: syncRetentionDays > 0
-          ? new Date(Date.now() - syncRetentionDays * 86400000).toISOString()
-          : null,
+        // Floored to the UTC day so this row is STABLE across sync cycles. A
+        // fresh Date.now() here changed the value every cycle, so the snapshot-
+        // diff re-pushed it every cycle → account seq advance → SSE self-nudge
+        // loop. See utils/tombstoneHorizon.js. (Pruning uses a fresh cutoff in
+        // the merge, so a day-granular fence changes nothing that gets pruned.)
+        tombstonePrunedBefore: tombstoneHorizon(syncRetentionDays),
       }
     };
   };

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -74,12 +74,9 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
     if (typeof window !== 'undefined') window.__glanceVaultSse = diag;
 
     const coalescer = createNudgeCoalescer({
-      // THROTTLE: never drain more than once every 5s, no matter how fast nudges
-      // arrive. A nudge for our OWN write echoes back from the server, and if a
-      // drain pushes again (or a backlog of intents keeps landing) that would loop
-      // and hammer the UI. The throttle caps it; polling remains the backstop and
-      // an idle account still drains near-instantly (debounce only).
-      minIntervalMs: 5000,
+      // Debounce-only (no throttle). The self-nudge loop is fixed at the root — a
+      // no-content sync cycle no longer pushes/nudges (utils/tombstoneHorizon.js) —
+      // so drains fire near-instantly on real changes, restoring SSE's low latency.
       onDrain: (kind) => {
         diag.drains += 1;
         console.info('[vault-sse] drain →', kind);

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -74,6 +74,12 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
     if (typeof window !== 'undefined') window.__glanceVaultSse = diag;
 
     const coalescer = createNudgeCoalescer({
+      // THROTTLE: never drain more than once every 5s, no matter how fast nudges
+      // arrive. A nudge for our OWN write echoes back from the server, and if a
+      // drain pushes again (or a backlog of intents keeps landing) that would loop
+      // and hammer the UI. The throttle caps it; polling remains the backstop and
+      // an idle account still drains near-instantly (debounce only).
+      minIntervalMs: 5000,
       onDrain: (kind) => {
         diag.drains += 1;
         console.info('[vault-sse] drain →', kind);

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -178,6 +178,57 @@ describe('Part B — end-to-end two-device sync via the REAL engine', () => {
     }
   });
 
+  it('CONVERGES with stable content — repeated cycles stop pushing (no self-nudge loop)', async () => {
+    // The heart of the loop fix: with no content change, the dirty set must drain
+    // to empty and STAY empty, so the device stops writing to the vault (no batch →
+    // no account-seq advance → no nudge). Real content changes still push.
+    const vault = createMemoryVault();
+    const batchSpy = vi.spyOn(vault, 'batch');
+    const A = makeDevice('A', vault, { ...EMPTY, tasks: [task(1, '2026-06-18T10:00:00.000Z')] });
+
+    // Let it settle (pull-then-push + HWM-on-pull take a couple cycles to quiesce).
+    for (let i = 0; i < 6; i++) await A.engine.dbSyncCycle();
+    const settled = batchSpy.mock.calls.length;
+
+    // Further no-change cycles must push NOTHING — this is what breaks the loop.
+    await A.engine.dbSyncCycle();
+    await A.engine.dbSyncCycle();
+    expect(batchSpy.mock.calls.length).toBe(settled);
+
+    // A genuine content change still pushes instantly (real nudges preserved).
+    A.data.tasks.push(task(2, '2026-06-18T11:00:00.000Z'));
+    await A.engine.dbSyncCycle();
+    expect(batchSpy.mock.calls.length).toBeGreaterThan(settled);
+  });
+
+  it('a field that CHANGES every cycle NEVER converges — re-pushed forever (the loop the horizon fix removes)', async () => {
+    // Reproduces the root cause: a synced singleton whose value moves each build
+    // (as tombstonePrunedBefore did via Date.now()) is dirty every cycle and
+    // re-pushed forever. This is why the horizon had to be made stable.
+    const vault = createMemoryVault();
+    const batchSpy = vi.spyOn(vault, 'batch');
+    let key = null;
+    let data = { ...EMPTY, tasks: [task(1, '2026-06-18T10:00:00.000Z')] };
+    let tick = 0;
+    const engine = createDbEngine({
+      vaultClient: vault,
+      storageKeyPrefix: 'dev-moving',
+      deviceId: 'device-moving',
+      nativeGetSyncKey: () => key,
+      nativeStoreSyncKey: (v) => { key = v; },
+      // A moving singleton value (stands in for the old Date.now()-per-build field).
+      getData: () => ({ ...clone(data), movingHorizon: new Date(tick * 3600000).toISOString() }),
+      commitData: (d) => { data = d; },
+    });
+
+    // Warm up so the initial full-seed settles, then advance the field every cycle.
+    for (let i = 0; i < 3; i++) { tick += 1; await engine.dbSyncCycle(); }
+    const before = batchSpy.mock.calls.length;
+    for (let i = 0; i < 4; i++) { tick += 1; await engine.dbSyncCycle(); }
+    // Every one of those 4 cycles re-pushed the moving row — it never quiesces.
+    expect(batchSpy.mock.calls.length).toBeGreaterThanOrEqual(before + 4);
+  });
+
   it('a cross-list move (unscheduled → scheduled) ends under exactly one kind on both devices', async () => {
     const vault = createMemoryVault();
     const start = { ...EMPTY, unscheduledTasks: [task(1003, '2026-06-18T10:00:00.000Z')] };

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -182,7 +182,9 @@ export async function openWebSseStream({ connection, signal, onOpen, onEvent, fe
  *
  * @param {object} p
  * @param {(kind:'sync'|'intents') => void} p.onDrain
- * @param {number} [p.debounceMs]
+ * @param {number} [p.debounceMs]     coalesce a micro-burst before draining
+ * @param {number} [p.minIntervalMs]  hard throttle: min gap between drains (0 = off)
+ * @param {() => number} [p.now]      clock (injectable for tests)
  * @param {typeof setTimeout}  [p.setTimeoutFn]
  * @param {typeof clearTimeout}[p.clearTimeoutFn]
  * @param {(msg:string, err:any) => void} [p.onDrainError]
@@ -192,11 +194,14 @@ export function createNudgeCoalescer({
   debounceMs = 400,
   setTimeoutFn = setTimeout,
   clearTimeoutFn = clearTimeout,
+  minIntervalMs = 0,
+  now = () => Date.now(),
   onDrainError,
 } = {}) {
   let lastSeq = -Infinity;
   let timer = null;
   let pending = new Set();
+  let lastFlushAt = -Infinity;
 
   const runDrain = (kind) => {
     try {
@@ -208,6 +213,7 @@ export function createNudgeCoalescer({
 
   const flush = () => {
     timer = null;
+    lastFlushAt = now();
     const kinds = pending;
     pending = new Set();
     // Deterministic order: sync before intents.
@@ -215,11 +221,19 @@ export function createNudgeCoalescer({
     if (kinds.has('intents')) runDrain('intents');
   };
 
+  // Schedule a coalesced flush. THROTTLE: at most one flush per minIntervalMs.
+  // This is the hard cap that stops a drain→push→self-nudge→drain feedback loop
+  // (or a foreign-intent flood) from hammering the app many times per second and
+  // flickering the UI. When idle it stays near-instant (debounceMs); under a
+  // sustained nudge stream it drains at most once per minIntervalMs. Polling
+  // remains the backstop for anything a throttled/coalesced nudge defers.
   const schedule = (kind) => {
     if (kind === 'both') { pending.add('sync'); pending.add('intents'); }
     else pending.add(kind);
-    if (timer) clearTimeoutFn(timer);
-    timer = setTimeoutFn(flush, debounceMs);
+    if (timer) return; // a flush is already scheduled — it will pick up this kind
+    const sinceFlush = now() - lastFlushAt;
+    const wait = Math.max(debounceMs, minIntervalMs - sinceFlush);
+    timer = setTimeoutFn(flush, wait);
   };
 
   /**

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -183,8 +183,6 @@ export async function openWebSseStream({ connection, signal, onOpen, onEvent, fe
  * @param {object} p
  * @param {(kind:'sync'|'intents') => void} p.onDrain
  * @param {number} [p.debounceMs]     coalesce a micro-burst before draining
- * @param {number} [p.minIntervalMs]  hard throttle: min gap between drains (0 = off)
- * @param {() => number} [p.now]      clock (injectable for tests)
  * @param {typeof setTimeout}  [p.setTimeoutFn]
  * @param {typeof clearTimeout}[p.clearTimeoutFn]
  * @param {(msg:string, err:any) => void} [p.onDrainError]
@@ -194,14 +192,11 @@ export function createNudgeCoalescer({
   debounceMs = 400,
   setTimeoutFn = setTimeout,
   clearTimeoutFn = clearTimeout,
-  minIntervalMs = 0,
-  now = () => Date.now(),
   onDrainError,
 } = {}) {
   let lastSeq = -Infinity;
   let timer = null;
   let pending = new Set();
-  let lastFlushAt = -Infinity;
 
   const runDrain = (kind) => {
     try {
@@ -213,7 +208,6 @@ export function createNudgeCoalescer({
 
   const flush = () => {
     timer = null;
-    lastFlushAt = now();
     const kinds = pending;
     pending = new Set();
     // Deterministic order: sync before intents.
@@ -221,19 +215,17 @@ export function createNudgeCoalescer({
     if (kinds.has('intents')) runDrain('intents');
   };
 
-  // Schedule a coalesced flush. THROTTLE: at most one flush per minIntervalMs.
-  // This is the hard cap that stops a drain→push→self-nudge→drain feedback loop
-  // (or a foreign-intent flood) from hammering the app many times per second and
-  // flickering the UI. When idle it stays near-instant (debounceMs); under a
-  // sustained nudge stream it drains at most once per minIntervalMs. Polling
-  // remains the backstop for anything a throttled/coalesced nudge defers.
+  // Coalesce a micro-burst of nudges into a single drain (debounce ONLY — no
+  // throttle). The self-nudge loop that once needed a 5s throttle is fixed at the
+  // root: a sync cycle with no content change no longer pushes anything, so it no
+  // longer advances the account seq or nudges (see utils/tombstoneHorizon.js).
+  // Drains therefore fire near-instantly on real changes, which is the point of
+  // SSE. Polling remains the backstop for any coalesced nudge.
   const schedule = (kind) => {
     if (kind === 'both') { pending.add('sync'); pending.add('intents'); }
     else pending.add(kind);
-    if (timer) return; // a flush is already scheduled — it will pick up this kind
-    const sinceFlush = now() - lastFlushAt;
-    const wait = Math.max(debounceMs, minIntervalMs - sinceFlush);
-    timer = setTimeoutFn(flush, wait);
+    if (timer) clearTimeoutFn(timer);
+    timer = setTimeoutFn(flush, debounceMs);
   };
 
   /**

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -137,6 +137,27 @@ describe('createNudgeCoalescer — seq cursor + debounce', () => {
     expect(c.getCursor()).toBe(4);
   });
 
+  it('THROTTLE: a continuous nudge stream drains at most once per minIntervalMs (no hammering)', () => {
+    const onDrain = vi.fn();
+    const c = createNudgeCoalescer({ onDrain, debounceMs: 400, minIntervalMs: 5000 });
+
+    // First nudge after idle drains near-instantly (debounce only).
+    c.handleEvent({ seq: 1, kind: 'sync' });
+    vi.advanceTimersByTime(400);
+    expect(onDrain).toHaveBeenCalledTimes(1);
+
+    // Now hammer: a nudge every 200ms for 4s (like the feedback loop). Without the
+    // throttle this would drain ~20 times; with it, at most once more in that window.
+    for (let t = 0; t < 4000; t += 200) {
+      c.handleEvent({ seq: 2 + t / 200, kind: 'sync' });
+      vi.advanceTimersByTime(200);
+    }
+    expect(onDrain).toHaveBeenCalledTimes(1); // still throttled (5s not yet elapsed)
+
+    vi.advanceTimersByTime(1200); // cross the 5s boundary
+    expect(onDrain).toHaveBeenCalledTimes(2); // exactly one more drain for the whole burst
+  });
+
   it("routes kind to the matching drain; a 'sync' nudge does not drain intents", () => {
     const onDrain = vi.fn();
     const c = createNudgeCoalescer({ onDrain, debounceMs: 100 });

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -137,25 +137,19 @@ describe('createNudgeCoalescer — seq cursor + debounce', () => {
     expect(c.getCursor()).toBe(4);
   });
 
-  it('THROTTLE: a continuous nudge stream drains at most once per minIntervalMs (no hammering)', () => {
+  it('NO THROTTLE: a real nudge drains after the light debounce (near-instant, not capped at 5s)', () => {
     const onDrain = vi.fn();
-    const c = createNudgeCoalescer({ onDrain, debounceMs: 400, minIntervalMs: 5000 });
+    const c = createNudgeCoalescer({ onDrain, debounceMs: 400 });
 
-    // First nudge after idle drains near-instantly (debounce only).
     c.handleEvent({ seq: 1, kind: 'sync' });
     vi.advanceTimersByTime(400);
-    expect(onDrain).toHaveBeenCalledTimes(1);
+    expect(onDrain).toHaveBeenCalledTimes(1); // fired at the debounce, no 5s throttle
 
-    // Now hammer: a nudge every 200ms for 4s (like the feedback loop). Without the
-    // throttle this would drain ~20 times; with it, at most once more in that window.
-    for (let t = 0; t < 4000; t += 200) {
-      c.handleEvent({ seq: 2 + t / 200, kind: 'sync' });
-      vi.advanceTimersByTime(200);
-    }
-    expect(onDrain).toHaveBeenCalledTimes(1); // still throttled (5s not yet elapsed)
-
-    vi.advanceTimersByTime(1200); // cross the 5s boundary
-    expect(onDrain).toHaveBeenCalledTimes(2); // exactly one more drain for the whole burst
+    // A second real change a moment later drains again promptly — not withheld for
+    // any multi-second throttle window.
+    c.handleEvent({ seq: 2, kind: 'sync' });
+    vi.advanceTimersByTime(400);
+    expect(onDrain).toHaveBeenCalledTimes(2);
   });
 
   it("routes kind to the matching drain; a 'sync' nudge does not drain intents", () => {

--- a/src/utils/tombstoneHorizon.js
+++ b/src/utils/tombstoneHorizon.js
@@ -1,0 +1,39 @@
+// Stable tombstone-pruning horizon for the sync payload.
+//
+// WHY THIS EXISTS: buildSyncPayload used to compute `tombstonePrunedBefore` as
+// `new Date(Date.now() - retention).toISOString()` on EVERY call. That singleton
+// row therefore changed on every sync cycle, so the DB engine's snapshot-diff
+// (src/sync/dbEngine.js) marked it dirty and re-pushed it every cycle — a real
+// content-row write that advances the account seq with no actual change. Under
+// SSE, the vault nudges on every seq advance, the nudge triggers another cycle,
+// and it re-pushes the horizon again → a continuous self-nudge loop (the
+// "heartbeat"). Under polling the same self-write happened once every few minutes
+// and went unnoticed; SSE just made it continuous.
+//
+// THE FIX: floor the horizon to the start of the UTC day so the value is STABLE
+// across the many sync cycles within a day. Then an unchanged cycle produces an
+// empty dirty set → no push → no seq advance → no self-nudge. The horizon still
+// advances (once per day), so tombstones still age out.
+//
+// SAFETY: this value is only the resurrection FENCE (merge.js syncHorizon) and the
+// reported "pruned-before" marker. The ACTUAL tombstone pruning uses a fresh
+// `Date.now() - retention` computed inside the merge, independent of this field —
+// so a coarser fence does not change what gets pruned. Flooring makes the fence at
+// most 24h earlier at the ~90-day mark, which is conservative (keeps tombstones
+// slightly longer; suppresses resurrection marginally less) and well within the
+// field's inherently fuzzy semantics.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * @param {number} retentionDays  sync retention window in days (<=0 → no horizon)
+ * @param {number} [nowMs]        current epoch ms (injectable for tests)
+ * @returns {string|null}         ISO timestamp floored to the UTC day, or null
+ */
+export function tombstoneHorizon(retentionDays, nowMs = Date.now()) {
+  if (!(retentionDays > 0)) return null;
+  const cutoff = nowMs - retentionDays * DAY_MS;
+  // Floor to the UTC-day boundary → identical output for every call within a day.
+  const floored = Math.floor(cutoff / DAY_MS) * DAY_MS;
+  return new Date(floored).toISOString();
+}

--- a/src/utils/tombstoneHorizon.test.js
+++ b/src/utils/tombstoneHorizon.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { tombstoneHorizon } from './tombstoneHorizon.js';
+
+// The horizon must be STABLE across the many sync cycles within a day. A value
+// that changed every call (the old `Date.now()`-per-build code) made the synced
+// singleton row differ every cycle → re-pushed every cycle → account seq advance
+// → SSE self-nudge loop. These lock in the stability that removes that loop.
+
+const DAY = 24 * 60 * 60 * 1000;
+const at = (iso) => new Date(iso).getTime();
+
+describe('tombstoneHorizon', () => {
+  it('is IDENTICAL for every call within the same UTC day (no per-cycle churn)', () => {
+    const morning = at('2026-07-04T00:00:00.000Z');
+    const evening = at('2026-07-04T23:59:59.000Z');
+    // Many "cycles" a few seconds apart across the day → one and the same value.
+    const a = tombstoneHorizon(90, morning);
+    const b = tombstoneHorizon(90, morning + 3000);
+    const c = tombstoneHorizon(90, evening);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it('advances by exactly one day when the UTC day rolls over', () => {
+    const day1 = tombstoneHorizon(90, at('2026-07-04T12:00:00.000Z'));
+    const day2 = tombstoneHorizon(90, at('2026-07-05T00:00:00.000Z'));
+    expect(day2).not.toBe(day1);
+    expect(at(day2) - at(day1)).toBe(DAY);
+  });
+
+  it('returns a UTC-midnight ISO exactly retentionDays before today', () => {
+    const now = at('2026-07-04T15:30:00.000Z');
+    // 90 days before the UTC-midnight of 2026-07-04 is 2026-04-05T00:00:00Z.
+    expect(tombstoneHorizon(90, now)).toBe('2026-04-05T00:00:00.000Z');
+  });
+
+  it('never emits a horizon LATER than the true cutoff (conservative for pruning)', () => {
+    const now = at('2026-07-04T15:30:00.000Z');
+    const trueCutoff = now - 90 * DAY;
+    expect(at(tombstoneHorizon(90, now))).toBeLessThanOrEqual(trueCutoff);
+  });
+
+  it('returns null when retention is disabled (<= 0)', () => {
+    expect(tombstoneHorizon(0, Date.now())).toBeNull();
+    expect(tombstoneHorizon(-5, Date.now())).toBeNull();
+  });
+});


### PR DESCRIPTION
## Root cause

The SSE "heartbeat" was a self-nudge loop. `buildSyncPayload` computed `tombstonePrunedBefore` from `Date.now()` **on every call** (`App.jsx`), so that synced singleton row's value changed every sync cycle. The DB engine's snapshot-diff (`src/sync/dbEngine.js`) therefore marked it dirty every cycle and re-pushed it — a real content-row `batch` write that advances the account seq **with no actual change**. Under SSE the vault nudges on every seq advance → the nudge triggers another cycle → which re-pushes the horizon again → continuous loop. Under polling the same self-write happened once every few minutes and went unnoticed; SSE made it continuous.

This is **not** a re-push/echo-guard bug — the remote-apply guards are untouched. It's a moving field in the payload.

## Part 1 — the fix (dayGLANCE)

- **`src/utils/tombstoneHorizon.js`** (new): floors the horizon to the UTC day so the value is **stable across the many cycles within a day**. An unchanged cycle now yields an empty dirty set → no `batch` → no seq advance → no self-nudge. The horizon still advances once/day so tombstones still age out. **Pruning is unaffected** — the merge computes its own fresh `Date.now()-retention` cutoff (`merge.js:820`), so a day-granular fence changes nothing that gets pruned; the resurrection fence is at most ~24h earlier at the 90-day mark (conservative).
- **`src/App.jsx`**: `buildSyncPayload` now uses `tombstoneHorizon(syncRetentionDays)` instead of the per-call `Date.now()` computation.

## Part 2 — remove the throttle band-aid

- **`createNudgeCoalescer`**: dropped the 5s `minIntervalMs` throttle; back to **debounce-only** (400ms coalesce of rapid legit bursts). The hook no longer sets `minIntervalMs`. With the loop fixed, drains fire **near-instantly** on real changes — the point of SSE. Polling remains the backstop. (The reconnect flap-guard is unrelated and stays.)

## Tests

- `tombstoneHorizon.test.js`: identical for every call within a UTC day (no per-cycle churn); advances exactly one day at rollover; never later than the true cutoff; null when retention ≤ 0.
- `dbEngineWiring.test.js`: **stable content converges** (repeated cycles stop pushing; a real change still pushes instantly); **a field that changes every cycle never converges** (re-pushed forever) — the exact loop the horizon fix removes.
- `vaultEventStream.test.js`: throttle test replaced with "no throttle — a real nudge drains after the light debounce, not capped at 5s".

Full suite **512 pass**, lint clean, web + electron builds pass, electron `tsc --noEmit` clean.

## Scope / coordination

- Does **not** touch merge logic, encryption, or the remote-apply guards.
- The **glance-vault** device-cursor bookkeeping-nudge (the server-side "don't nudge on a device updating its own cursor" distinction) is being handled separately by the maintainer — I don't have access to that repo. This dayGLANCE fix removes the confirmed client-side driver (the moving-field content re-push); the server change covers the bookkeeping-write nudge.
- The **intents-key-unlock** bug (passphrase unlocks the sync key but not the vault-intents key) is a separate follow-up, untouched here.

## Verify on-device

With this built: connect SSE on macOS, make **no** changes, and watch `window.__glanceVaultSse` — on an idle account `events`/`drains` should **stop climbing** (was climbing continuously before). A real edit on another device should drain within ~1s (no 5s cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_