### PR TITLE
Fix SSE loop for real: floor tombstonePrunedBefore on BOTH the payload and merge sides

### DIFF
--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -27,6 +27,7 @@
 // per-completion remodeling.
 
 import { mergeHabitLogs, mergeRoutineDefinitions, mergeRoutineCompletions, mergeCompletedDates } from '../mergeSync.js';
+import { floorToUtcDayIso } from '../utils/tombstoneHorizon.js';
 
 // ── Collection kinds: each array element is one row, keyed by a stable id, with
 // entity-grain last-writer-wins on tsField (the same grain the file-tier merge
@@ -432,8 +433,15 @@ function mergeBundle(data, key, value, extra) {
       data.routinesDate = (data.routinesDate && data.routinesDate > value) ? data.routinesDate : value;
       return;
     case 'unscheduledOrderTimestamp':
-    case 'tombstonePrunedBefore':
       data[key] = newerIso(data[key], value);
+      return;
+    case 'tombstonePrunedBefore':
+      // Floor the merged value to the UTC day so it matches the day-floored value
+      // buildSyncPayload produces (utils/tombstoneHorizon.js). Without the floor,
+      // newerIso keeps a same-day FULL-PRECISION remote value (e.g. …18:25:50Z),
+      // which never equals the floored payload value (…00:00:00Z) → the singleton
+      // row is dirty every cycle → push → seq advance → SSE self-nudge loop.
+      data[key] = floorToUtcDayIso(newerIso(data[key], value));
       return;
     case 'syncUrl':
     case 'taskCalendarUrl':

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -229,6 +229,45 @@ describe('Part B — end-to-end two-device sync via the REAL engine', () => {
     expect(batchSpy.mock.calls.length).toBeGreaterThanOrEqual(before + 4);
   });
 
+  it('tombstonePrunedBefore CONVERGES — a floored payload vs a stuck full-precision vault value stops pushing', async () => {
+    // Reproduces the confirmed loop: buildSyncPayload emits the day-FLOORED horizon
+    // every cycle, but the vault/merge held a same-day FULL-PRECISION value, so the
+    // singleton row was dirty every cycle → push → SSE self-nudge. The fix floors
+    // BOTH sides (utils/tombstoneHorizon.js + dbAdapter bundle merge) so an
+    // unchanged cycle produces no push.
+    const vault = createMemoryVault();
+    const FULL = '2026-06-04T18:25:50.481Z';        // stuck pre-fix value
+    const FLOORED = '2026-06-04T00:00:00.000Z';     // what tombstoneHorizon() emits
+
+    // Seed the vault with the FULL-PRECISION value via another device.
+    const B = makeDevice('B', vault, { ...EMPTY, tombstonePrunedBefore: FULL });
+    await B.engine.dbSyncCycle();
+
+    // Device A's getData ALWAYS returns the floored value (as buildSyncPayload does).
+    let key = null;
+    let data = { ...EMPTY };
+    const engineA = createDbEngine({
+      vaultClient: vault,
+      storageKeyPrefix: 'dev-A-floor',
+      deviceId: 'device-A-floor',
+      nativeGetSyncKey: () => key,
+      nativeStoreSyncKey: (v) => { key = v; },
+      getData: () => ({ ...clone(data), tombstonePrunedBefore: FLOORED }),
+      commitData: (d) => { data = d; },
+    });
+
+    const batchSpy = vi.spyOn(vault, 'batch');
+    for (let i = 0; i < 6; i++) await engineA.dbSyncCycle();  // settle
+    const settled = batchSpy.mock.calls.length;
+
+    // Unchanged cycles now push NOTHING — floored payload == floored stored value.
+    await engineA.dbSyncCycle();
+    await engineA.dbSyncCycle();
+    expect(batchSpy.mock.calls.length).toBe(settled);
+    // And the merged/committed value is the floored form.
+    expect(data.tombstonePrunedBefore).toBe(FLOORED);
+  });
+
   it('a cross-list move (unscheduled → scheduled) ends under exactly one kind on both devices', async () => {
     const vault = createMemoryVault();
     const start = { ...EMPTY, unscheduledTasks: [task(1003, '2026-06-18T10:00:00.000Z')] };

--- a/src/utils/tombstoneHorizon.js
+++ b/src/utils/tombstoneHorizon.js
@@ -30,10 +30,30 @@ const DAY_MS = 24 * 60 * 60 * 1000;
  * @param {number} [nowMs]        current epoch ms (injectable for tests)
  * @returns {string|null}         ISO timestamp floored to the UTC day, or null
  */
+/**
+ * Floor an ISO timestamp to the start of its UTC day, as an ISO string.
+ * null/undefined/unparseable pass through unchanged. Idempotent.
+ *
+ * This is the CANONICAL form of tombstonePrunedBefore. It must be applied
+ * everywhere the value is produced (buildSyncPayload → tombstoneHorizon) AND
+ * everywhere it is merged/stored (dbAdapter's bundle merge) — otherwise the two
+ * sides disagree: buildSyncPayload emits the day-floored value while the merge
+ * keeps a same-day FULL-PRECISION remote value (newerIso picks the newer raw
+ * timestamp), so the singleton row is dirty on every cycle → push → account seq
+ * advance → SSE self-nudge loop. Flooring both sides makes floored == floored so
+ * an unchanged cycle produces no push.
+ *
+ * @param {string|null|undefined} iso
+ * @returns {string|null|undefined}
+ */
+export function floorToUtcDayIso(iso) {
+  if (!iso) return iso;
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return iso;
+  return new Date(Math.floor(t / DAY_MS) * DAY_MS).toISOString();
+}
+
 export function tombstoneHorizon(retentionDays, nowMs = Date.now()) {
   if (!(retentionDays > 0)) return null;
-  const cutoff = nowMs - retentionDays * DAY_MS;
-  // Floor to the UTC-day boundary → identical output for every call within a day.
-  const floored = Math.floor(cutoff / DAY_MS) * DAY_MS;
-  return new Date(floored).toISOString();
+  return floorToUtcDayIso(new Date(nowMs - retentionDays * DAY_MS).toISOString());
 }

--- a/src/utils/tombstoneHorizon.test.js
+++ b/src/utils/tombstoneHorizon.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { tombstoneHorizon } from './tombstoneHorizon.js';
+import { tombstoneHorizon, floorToUtcDayIso } from './tombstoneHorizon.js';
 
 // The horizon must be STABLE across the many sync cycles within a day. A value
 // that changed every call (the old `Date.now()`-per-build code) made the synced
@@ -43,5 +43,33 @@ describe('tombstoneHorizon', () => {
   it('returns null when retention is disabled (<= 0)', () => {
     expect(tombstoneHorizon(0, Date.now())).toBeNull();
     expect(tombstoneHorizon(-5, Date.now())).toBeNull();
+  });
+});
+
+describe('floorToUtcDayIso — the canonical form both sides must use', () => {
+  it('floors a full-precision timestamp to UTC midnight of the same day', () => {
+    // The exact case from the ground-truth push log.
+    expect(floorToUtcDayIso('2026-06-04T18:25:50.481Z')).toBe('2026-06-04T00:00:00.000Z');
+  });
+
+  it('is idempotent — flooring an already-floored value is a no-op (round-trip equal)', () => {
+    const floored = '2026-06-04T00:00:00.000Z';
+    expect(floorToUtcDayIso(floored)).toBe(floored);
+  });
+
+  it('makes a full-precision value ROUND-TRIP EQUAL to the floored payload value', () => {
+    // buildSyncPayload emits tombstoneHorizon() (floored); the merge stores
+    // floorToUtcDayIso(remote). Both must be equal for the same day so the
+    // snapshot-diff sees no change.
+    const now = new Date('2026-09-02T15:30:00.000Z').getTime();
+    const payloadValue = tombstoneHorizon(90, now);          // floored, e.g. 2026-06-04T00:00:00.000Z
+    const stuckFullPrecisionRemote = '2026-06-04T18:25:50.481Z'; // same day, full precision
+    expect(floorToUtcDayIso(stuckFullPrecisionRemote)).toBe(payloadValue);
+  });
+
+  it('passes null/undefined/unparseable through unchanged', () => {
+    expect(floorToUtcDayIso(null)).toBeNull();
+    expect(floorToUtcDayIso(undefined)).toBeUndefined();
+    expect(floorToUtcDayIso('not-a-date')).toBe('not-a-date');
   });
 });


### PR DESCRIPTION
## Ground truth

The `dayglance-debug-push` diagnostic named the driver definitively: `singleton:tombstonePrunedBefore` pushed **every cycle**, with the diff:
```
value: 2026-06-04T18:25:50.481Z -> 2026-06-04T00:00:00.000Z
```
The snapshot/stored copy held a **same-day full-precision** value while `buildSyncPayload` emitted the **day-floored** `tombstoneHorizon()`. Same day, different time → never equal → perpetual dirty → push → account seq advance → SSE self-nudge loop.

## The asymmetry

The earlier fix floored the **produce** side (`buildSyncPayload → tombstoneHorizon`) but not the **merge** side. `dbAdapter`'s bundle merge used `newerIso(local, remote)`, which keeps a same-day full-precision remote value (`…18:25` > `…00:00`). That un-floored value flowed into the mirror → snapshot → was re-pushed every cycle and never converged.

## Fix — floor both sides to the same canonical UTC-day value

- **`src/utils/tombstoneHorizon.js`**: extract `floorToUtcDayIso(iso)` (idempotent; passes `null`/unparseable through); `tombstoneHorizon()` now composes it.
- **`src/sync/dbAdapter.js`**: the `tombstonePrunedBefore` bundle merge floors the result — `data[key] = floorToUtcDayIso(newerIso(data[key], value))` — so a stuck full-precision remote is floored down to equal the payload value. Converges in one cycle (the floored value is pushed once, then floored == floored → no dirty → no push). Pruning is unaffected — the merge computes its own fresh cutoff (`merge.js:820`).

## Tests (verified they FAIL without the fix)

I removed the floor and confirmed the convergence test fails — `expected 8 to be 6`, i.e. `vault.batch` kept firing every cycle (the loop) — then restored it.

- `floorToUtcDayIso`: floors full precision to UTC midnight, idempotent, **round-trips EQUAL** to `tombstoneHorizon()` for the same day, passes `null`/unparseable through.
- `dbEngineWiring`: a floored payload vs a stuck full-precision vault value **CONVERGES** — unchanged cycles push nothing, and the committed value is floored.

Full suite **517 pass**, lint clean, web + electron builds pass.

## On-device verification

The `dayglance-debug-push` diagnostic is **intentionally left in** so you can confirm on-device: with the flag on, an unchanged cycle should now log **no** `tombstonePrunedBefore` push (no "client DID write", no dirty id). Once you confirm, I'll send a follow-up to remove the diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_