### PR TITLE
Fix vault-intents key missing after file:// → app:// migration (inbound intents can't decrypt)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,6 +80,8 @@ import useGTDFrames from './hooks/useGTDFrames.js';
 import { getGlanceHGInstances, isHGSessionReachable } from './hooks/useHyperGlance.js';
 import { useIntentPoller, INTENT_CONFIG_KEY } from './intents/useIntentPoller.js';
 import { useDbIntentPoller, drainDbIntents } from './intents/dbIntentsTransport.js';
+import { ensureVaultIntentsKeyReady } from './intents/vaultIntentsSetup.js';
+import { getDbIntentsConnection } from './intents/dbIntentsConfig.js';
 import { useVaultEventStream } from './hooks/useVaultEventStream.js';
 import { useNotifyEmitter } from './intents/useNotifyEmitter.js';
 import { useGoalNotifyEmitter } from './intents/useGoalNotifyEmitter.js';
@@ -1146,7 +1148,13 @@ const DayPlanner = () => {
       if (tab === 'glance' || tab === 'inbox') setTabletActiveTab(tab === 'glance' ? 'glance' : 'inbox');
     },
   };
-  useDbIntentPoller(dbIntentContext);
+  // ensureKey self-heals the vault INTENTS root key before each inbound drain: it
+  // lives in an origin-partitioned IndexedDB slot (vault-root-key), so the
+  // file://→app:// origin switch left the app:// store empty and inbound intents
+  // threw KeyUnavailableError. Best-effort/idempotent (no-op once cached). Stable
+  // ref so the poller effect isn't re-run.
+  const ensureVaultIntentsKeyCb = useCallback(() => ensureVaultIntentsKeyReady(), []);
+  useDbIntentPoller(dbIntentContext, { ensureKey: ensureVaultIntentsKeyCb });
   // Fresh handle on the intents drain context for the SSE push client (below),
   // which triggers the SAME drain outside the poll cadence.
   const dbIntentContextRef = useRef(dbIntentContext);
@@ -1160,8 +1168,27 @@ const DayPlanner = () => {
   useVaultEventStream({
     dataLoaded,
     drainSync: useCallback(() => dbEngineRef.current?.dbSyncCycle?.(), []),
-    drainIntents: useCallback(() => drainDbIntents(dbIntentContextRef.current), []),
+    // Ensure the vault intents key before the SSE-triggered inbound drain too, so a
+    // nudge that arrives before the poller's first drain still decrypts.
+    drainIntents: useCallback(async () => {
+      await ensureVaultIntentsKeyReady();
+      return drainDbIntents(dbIntentContextRef.current);
+    }, []),
   });
+  // Proactively (re-)derive the GLANCEvault INTENTS root key the moment sync is
+  // established with the passphrase in memory — the same trigger that re-derives
+  // the DB sync key. Closes the file://→app:// migration gap: the app:// origin's
+  // IndexedDB starts empty, so the SYNC key re-derived (restoreDbRootKey) but
+  // nothing re-derived the vault-intents key, and inbound intents threw
+  // KeyUnavailableError. Idempotent + best-effort; no-op without a vault connection
+  // or once the key is cached. (The passphrase is in memory right after the unlock
+  // modal, which is exactly when syncKeyReady flips true on a fresh/wiped store.)
+  useEffect(() => {
+    if (isTrayMode || !dataLoaded || !syncKeyReady) return;
+    if (!getDbIntentsConnection()) return;
+    ensureVaultIntentsKeyReady();
+  }, [dataLoaded, syncKeyReady]);
+
   // Guard the intent emitters against sync/remote-apply-driven state changes: a
   // setGoals/setTasks coming from applyEngineData (or any merge apply) must not
   // echo an outbound intent, mirroring how the cloud-upload effect bails on

--- a/src/intents/dbIntentsReceive.test.js
+++ b/src/intents/dbIntentsReceive.test.js
@@ -7,6 +7,7 @@ import { buildEnvelope, buildEncryptedEnvelope, deriveIntentsRootKey, deriveEnve
 vi.mock('./handleIntent.js', () => ({ handleIntent: vi.fn(async () => ({ success: true })) }));
 
 import { routeIncoming, KeyUnavailableError } from './dbIntentsTransport.js';
+import { ensureVaultIntentsKeyReady } from './vaultIntentsSetup.js';
 import { handleIntent } from './handleIntent.js';
 import { getActivityLog } from './intentLog.js';
 
@@ -80,5 +81,37 @@ describe('vault receive plaintext rejection', () => {
     await expect(routeIncoming(env, {}, { loadKey: async () => null }))
       .rejects.toBeInstanceOf(KeyUnavailableError);
     expect(handleIntent).not.toHaveBeenCalled();
+  });
+
+  it('(fix) after ensureVaultIntentsKeyReady derives the key, the SAME inbound row decrypts — no KeyUnavailableError', async () => {
+    const SALT = new Uint8Array(16).fill(7);
+    // The app://-origin store starts EMPTY; the self-heal wrapper derives + caches
+    // the vault intents key (as it now does on unlock and before each drain).
+    const slot = { key: null };
+    const ok = await ensureVaultIntentsKeyReady({
+      loadKey: async () => slot.key,
+      storeKey: async (k) => { slot.key = k; },
+      getSyncPassphrase: () => 'pw',
+      connection: { vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' },
+      vaultClient: { getSalt: async () => SALT },
+    });
+    expect(ok).toBe(true);
+    expect(slot.key).not.toBeNull();
+
+    // A sender (another device) encrypts with the SAME passphrase + vault salt.
+    const senderKey = await deriveIntentsRootKey('pw', SALT);
+    const env = await buildEncryptedEnvelope({
+      action: 'notify', payload: validPayload(), emittedBy: 'app.lifeglance', eventId: '20260101T000000Z-ddd444',
+    }, (salt) => deriveEnvelopeKey(senderKey, salt));
+
+    // routeIncoming loads the now-derived vault key → decrypts and routes; NO throw.
+    let threw = null;
+    let outcome;
+    try { outcome = await routeIncoming(env, {}, { loadKey: async () => slot.key }); }
+    catch (e) { threw = e; }
+    expect(threw).toBeNull(); // not KeyUnavailableError anymore
+    expect(outcome).toBe('ok');
+    expect(handleIntent).toHaveBeenCalledTimes(1);
+    expect(handleIntent.mock.calls[0][1].title).toBe('inbound');
   });
 });

--- a/src/intents/dbIntentsTransport.js
+++ b/src/intents/dbIntentsTransport.js
@@ -529,10 +529,20 @@ export async function drainDbIntents(context, opts) {
  * on an interval. Receive-only — there is no push; sends happen at the emit sites.
  *
  * context shape: same as useIntentPoller (tasks, setters, goals, navigate, …).
+ *
+ * @param {object} context
+ * @param {object} [opts]
+ * @param {() => Promise<any>} [opts.ensureKey] best-effort hook run BEFORE each
+ *   drain so the vault intents key is (re-)derived if absent (e.g. after the
+ *   file://→app:// origin migration left an empty key store). Injected — not
+ *   imported here — to avoid a dbIntentsTransport↔vaultIntentsSetup import cycle.
+ *   Must never throw.
  */
-export function useDbIntentPoller(context) {
+export function useDbIntentPoller(context, opts = {}) {
   const contextRef = useRef(context);
   contextRef.current = context;
+  const ensureKeyRef = useRef(opts.ensureKey);
+  ensureKeyRef.current = opts.ensureKey;
 
   useEffect(() => {
     if (isTrayMode) return;
@@ -551,6 +561,9 @@ export function useDbIntentPoller(context) {
     const runPoll = async () => {
       if (destroyed) return;
       try {
+        // Self-heal the vault intents key before draining so inbound rows can
+        // decrypt instead of throwing KeyUnavailableError. Best-effort/no-throw.
+        try { await ensureKeyRef.current?.(); } catch { /* never blocks the drain */ }
         await poll(contextRef.current);
       } catch (err) {
         console.warn('[db-intent] poll error:', err.message);

--- a/src/intents/vaultIntentsSetup.js
+++ b/src/intents/vaultIntentsSetup.js
@@ -117,3 +117,33 @@ export async function ensureVaultIntentsKey(opts = {}) {
   await setupVaultIntentsEncryption(passphrase, opts);
   return { ok: true };
 }
+
+/**
+ * Best-effort self-heal wrapper around ensureVaultIntentsKey for the app's
+ * unlock/drain wiring. NEVER throws — so it can be called before an intents drain,
+ * on passphrase unlock, or after the file://→app:// origin migration (which starts
+ * with an empty, origin-partitioned IndexedDB store) without risking sync, unlock,
+ * or the drain itself. Idempotent: a no-op when the vault intents key is already
+ * cached. Returns true iff the key is present after the call.
+ *
+ * @param {object} [opts] passed through to ensureVaultIntentsKey (injection seams)
+ * @returns {Promise<boolean>}
+ */
+export async function ensureVaultIntentsKeyReady(opts = {}) {
+  try {
+    const res = await ensureVaultIntentsKey(opts);
+    if (res.ok) {
+      if (!res.alreadySetUp) {
+        console.info('[vault-intents] root key derived + cached into the vault-root-key slot (inbound intents can now decrypt)');
+      }
+      return true;
+    }
+    // needsPassphrase — can't derive yet (passphrase not in memory). A later unlock
+    // or drain retries; the intents drain holds harmlessly until then.
+    return false;
+  } catch (err) {
+    // NO_CONNECTION / NO_VAULT_SALT / transient network — defer, never break.
+    console.warn('[vault-intents] key derivation deferred:', err?.code || err?.message || err);
+    return false;
+  }
+}

--- a/src/intents/vaultIntentsSetup.test.js
+++ b/src/intents/vaultIntentsSetup.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { deriveEnvelopeKey } from '@glance-apps/intents';
 import {
   ensureVaultIntentsKey,
+  ensureVaultIntentsKeyReady,
   setupVaultIntentsEncryption,
   VaultIntentsSetupError,
 } from './vaultIntentsSetup.js';
@@ -143,5 +144,54 @@ describe('setupVaultIntentsEncryption', () => {
     });
     expect(key).toBeDefined();
     expect(slot.peek()).toBe(key);
+  });
+});
+
+// The self-heal wrapper wired into unlock + before every inbound drain. It must
+// NEVER throw (can't break sync/unlock/the drain) and must be idempotent.
+describe('ensureVaultIntentsKeyReady (self-heal wrapper)', () => {
+  it('after unlock on a store lacking the key, derives it (returns true, key now loadable)', async () => {
+    const slot = memSlot(); // empty store, as after the file://→app:// migration
+    const ok = await ensureVaultIntentsKeyReady({
+      loadKey: slot.loadKey, storeKey: slot.storeKey,
+      getSyncPassphrase: () => 'correct horse battery staple',
+      connection: CONN, vaultClient: okVaultClient(),
+    });
+    expect(ok).toBe(true);
+    expect(slot.storeKey).toHaveBeenCalledTimes(1);
+    expect(await slot.loadKey()).not.toBeNull(); // loadVaultIntentsRootKey non-null
+  });
+
+  it('is idempotent — an already-present key is NOT clobbered and not re-derived', async () => {
+    const slot = memSlot({ alreadyCached: true }); // any truthy cached key
+    const vaultClient = okVaultClient();
+    const ok = await ensureVaultIntentsKeyReady({
+      loadKey: slot.loadKey, storeKey: slot.storeKey,
+      getSyncPassphrase: () => 'pw', connection: CONN, vaultClient,
+    });
+    expect(ok).toBe(true);
+    expect(slot.storeKey).not.toHaveBeenCalled();   // no clobber
+    expect(vaultClient.getSalt).not.toHaveBeenCalled(); // didn't even reach derivation
+  });
+
+  it('returns false and NEVER throws when the passphrase is unavailable (drain holds, retries later)', async () => {
+    const slot = memSlot();
+    const ok = await ensureVaultIntentsKeyReady({
+      loadKey: slot.loadKey, storeKey: slot.storeKey,
+      getSyncPassphrase: () => null, connection: CONN, vaultClient: okVaultClient(),
+    });
+    expect(ok).toBe(false);
+    expect(slot.storeKey).not.toHaveBeenCalled();
+  });
+
+  it('returns false and NEVER throws when the vault has no salt yet (does not invent one)', async () => {
+    const slot = memSlot();
+    const ok = await ensureVaultIntentsKeyReady({
+      loadKey: slot.loadKey, storeKey: slot.storeKey,
+      getSyncPassphrase: () => 'pw', connection: CONN,
+      vaultClient: { getSalt: vi.fn(async () => null) },
+    });
+    expect(ok).toBe(false);
+    expect(slot.storeKey).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Symptom (confirmed)

After the Electron `file://` → `app://` origin switch, inbound vault intents throw `KeyUnavailableError` ("vault intents key not available" → "gave up after 5"), while **sync works** and **outbound delivers**.

## Part 1 — investigation (read-only findings)

1. **The migration** copies `localStorage` only. Browser storage is origin-partitioned, and the vault-intents root key lives in **IndexedDB** — `intentsKeyStore.js:13` `VAULT_ROOT_KEY_RECORD = 'vault-root-key'`. So the `app://` origin's IndexedDB starts **empty** and `loadVaultIntentsRootKey()` (`intentsKeyStore.js:88-100`) returns `null`. The migration re-established the **sync** key (via `restoreDbRootKey`, `useCloudSync.js:96`) but never the vault-intents key.
2. **Why outbound works but inbound fails:** the vault-intents key is only needed to **decrypt** inbound rows (`routeIncoming` → `loadVaultIntentsRootKey`, `dbIntentsTransport.js:262-275`). Outbound "works" because it targets WebDAV/iCloud (their own key) or **sync** (the DB root key, which self-heals). The **vault** deliverer actually *also* holds without the key (`deliverers.js:122-128`) — it just wasn't the visible symptom.
3. **Origin-partitioned store:** confirmed — the key is IndexedDB-resident in the dedicated `vault-root-key` slot, distinct from the WebDAV `root-key` slot (`intentsKeyStore.js:5-13`).
4. **Where it should derive:** `ensureVaultIntentsKey`/`setupVaultIntentsEncryption` (`vaultIntentsSetup.js:63-119`) derive from the passphrase + the **real vault salt** (`client.getSalt(accountId)`) into the dedicated slot — but were only wired into the **Settings toggle**, never unlock/migration.
5. **Fresh-install blast radius:** brand-new installs go through normal setup (both keys) and are unaffected; **only migrating-from-`file://` (or any fresh/wiped store) users** hit this.

## Part 2 — the fix

Re-establish the vault-intents key wherever sync is established, robustly (self-heals whenever the key is absent):

- **`vaultIntentsSetup.js`**: `ensureVaultIntentsKeyReady()` — a best-effort, **never-throwing**, **idempotent** wrapper over the existing `ensureVaultIntentsKey` (real vault salt, dedicated slot, no-op if already cached, no-clobber).
- **`App.jsx`** (proactive): derive the moment sync is established with the passphrase in memory — an effect on `syncKeyReady` + a vault connection, the same trigger that re-derives the DB sync key. On a fresh/wiped/`app://` store the unlock modal shows (both IDB stores are empty), so the passphrase is in memory exactly then.
- **`App.jsx` + `dbIntentsTransport.js`** (gate the drain): ensure the key **before every inbound drain** — `useDbIntentPoller` runs an injected `ensureKey` before `poll()`, and the SSE-triggered drain ensures first. Injected (not imported) to avoid a `dbIntentsTransport ↔ vaultIntentsSetup` import cycle.

Never invents a salt, never writes the WebDAV slot, never clobbers an existing key, non-fatal on transient failure (retries next unlock/drain).

## Tests

- `ensureVaultIntentsKeyReady`: derives on an empty store (key loadable **non-null**); **idempotent** (already-present key not clobbered / not re-derived); returns `false` and **never throws** when the passphrase is unavailable or the vault has no salt.
- `dbIntentsReceive`: the existing test proves no-key → `KeyUnavailableError`; the **new** test proves that after `ensureVaultIntentsKeyReady` derives the key, the same inbound encrypted row **decrypts and routes** (no throw).

Full suite **522 pass**, lint clean, web + electron builds pass.

## On-device confirmation

Logging left in — on unlock you should see `[vault-intents] root key derived + cached into the vault-root-key slot (inbound intents can now decrypt)`, and inbound intents should stop throwing `KeyUnavailableError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_