### PR TITLE
intents: prompt for the passphrase when the vault-intents key is missing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,7 +81,7 @@ import { getGlanceHGInstances, isHGSessionReachable } from './hooks/useHyperGlan
 import { useIntentPoller, INTENT_CONFIG_KEY } from './intents/useIntentPoller.js';
 import { useDbIntentPoller, drainDbIntents } from './intents/dbIntentsTransport.js';
 import { ensureVaultIntentsKeyReady } from './intents/vaultIntentsSetup.js';
-import { getDbIntentsConnection } from './intents/dbIntentsConfig.js';
+import { getDbIntentsConnection, isDbIntentsEnabled } from './intents/dbIntentsConfig.js';
 import { useVaultEventStream } from './hooks/useVaultEventStream.js';
 import { useNotifyEmitter } from './intents/useNotifyEmitter.js';
 import { useGoalNotifyEmitter } from './intents/useGoalNotifyEmitter.js';
@@ -10325,7 +10325,7 @@ const DayPlanner = () => {
       {/* Sync passphrase prompt — shown on app load when an encrypted transport
           (WebDAV encryption or GLANCEvault) is active but no cached key was found
           in device storage (e.g. new device, or first launch after key isolation). */}
-      {(cloudSyncConfig?.encryptionEnabled || isVaultEnabled()) && syncKeyReady === false && (
+      {(cloudSyncConfig?.encryptionEnabled || isVaultEnabled() || isDbIntentsEnabled()) && syncKeyReady === false && (
         <SyncPassphraseModal
           darkMode={darkMode}
           textPrimary={textPrimary}

--- a/src/hooks/useCloudSync.js
+++ b/src/hooks/useCloudSync.js
@@ -2,6 +2,8 @@ import { useState, useRef, useEffect } from 'react';
 import { initSessionKey } from '../utils/crypto.js';
 import { isVaultEnabled } from '../sync/vaultConfig.js';
 import { restoreDbRootKey } from '../sync/dbEngine.js';
+import { isDbIntentsEnabled } from '../intents/dbIntentsConfig.js';
+import { loadVaultIntentsRootKey } from '../intents/intentsKeyStore.js';
 
 const useCloudSync = () => {
   const [cloudSyncConfig, setCloudSyncConfig] = useState(() => {
@@ -84,8 +86,18 @@ const useCloudSync = () => {
 
     const needFileKey  = !!(config?.enabled && config?.encryptionEnabled);
     const needVaultKey = isVaultEnabled();
+    // The vault INTENTS key lives in its OWN origin-partitioned IndexedDB slot and
+    // ALSO needs the passphrase to derive. It must be in the readiness gate too:
+    // otherwise, when the DB SYNC key is already cached (so restoreDbRootKey
+    // succeeds and no prompt appears), a store MISSING the vault-intents key — e.g.
+    // after the file://→app:// origin migration — never gets a chance to derive it
+    // (the passphrase is never in memory), and inbound intents stay stuck on
+    // KeyUnavailableError. Gating on its presence makes the app prompt once; the
+    // entered passphrase then derives + caches it (App's derive-on-unlock effect),
+    // and it never prompts again for it.
+    const needVaultIntentsKey = isDbIntentsEnabled();
 
-    if (!needFileKey && !needVaultKey) {
+    if (!needFileKey && !needVaultKey && !needVaultIntentsKey) {
       // No encrypted transport active — no passphrase needed.
       setSyncKeyReady(true);
       return;
@@ -94,11 +106,14 @@ const useCloudSync = () => {
     Promise.all([
       needFileKey  ? initSessionKey()   : Promise.resolve(true),
       needVaultKey ? restoreDbRootKey() : Promise.resolve(true),
-    ]).then(([fileOk, vaultOk]) => {
+      // Presence check only (no derivation) — a cached key means ready; absent
+      // means prompt. Never throws.
+      needVaultIntentsKey ? loadVaultIntentsRootKey().then((k) => !!k).catch(() => false) : Promise.resolve(true),
+    ]).then(([fileOk, vaultOk, vaultIntentsOk]) => {
       // Ready only when every active tier restored its key; otherwise App shows
       // the passphrase prompt, and the entered passphrase re-derives + caches the
-      // missing key(s) on the next sync.
-      setSyncKeyReady(fileOk && vaultOk);
+      // missing key(s) on the next sync / on the derive-on-unlock effect.
+      setSyncKeyReady(fileOk && vaultOk && vaultIntentsOk);
     });
   }, []);
 


### PR DESCRIPTION
Completes the vault-intents-key fix. The derive-on-unlock + before-drain wiring only helps when the passphrase is in memory — but on a normal relaunch the DB sync key is already cached, so restoreDbRootKey succeeds, no passphrase prompt appears, and the passphrase is never available to derive the (separately-stored, origin-partitioned) vault-intents key. Result: an already-migrated app:// store would stay stuck on KeyUnavailableError with no way to recover.

Fix: put the vault-intents key in the sync readiness gate. useCloudSync now also checks loadVaultIntentsRootKey() (presence only, never throws) when DB intents is enabled; if it's absent, syncKeyReady stays false so the passphrase modal shows. The entered passphrase then derives + caches the key (the derive-on-unlock effect) — so the user is prompted at most ONCE per fresh/wiped store, and never again once it's cached. The modal gate also now includes isDbIntentsEnabled() so a DB-intents user whose vault SYNC is off still gets the prompt.

Additive for everyone else: isDbIntentsEnabled() is false without a DB intents config + vault connection, so non-intents users' readiness/prompt is unchanged.


Claude-Session: https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH