### PR TITLE
Native Android SSE push + fix archived cold-open re-stamp

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -45,6 +45,7 @@ import com.dayglance.app.billing.BillingManager
 import com.dayglance.app.billing.SubscriptionBridge
 import com.dayglance.app.bridge.NativeBridge
 import com.dayglance.app.bridge.ObsidianBridge
+import com.dayglance.app.sse.VaultSseClient
 import com.dayglance.app.data.HealthRepository
 import com.dayglance.app.data.SharedDataStore
 import com.dayglance.app.databinding.ActivityMainBinding
@@ -67,6 +68,10 @@ class MainActivity : AppCompatActivity() {
     private lateinit var webView: WebView
     private lateinit var nativeBridge: NativeBridge
     private lateinit var obsidianBridge: ObsidianBridge
+    // Native GLANCEvault SSE reader (Path 2). Owns the /events socket + lifecycle;
+    // pushes frames into the WebView. Foreground/background is driven from onStart/
+    // onStop; the renderer drives enable/disable via the NativeBridge callbacks.
+    private lateinit var vaultSseClient: VaultSseClient
     private lateinit var healthRepository: HealthRepository
     private lateinit var dataStore: com.dayglance.app.data.SharedDataStore
     private lateinit var billingManager: BillingManager
@@ -227,6 +232,20 @@ class MainActivity : AppCompatActivity() {
         healthRepository = HealthRepository(this)
         subscriptionBridge = SubscriptionBridge(billingManager, dataStore, webView)
         obsidianBridge = ObsidianBridge(this, webView)
+
+        // Native SSE reader. frameSink hops to the main thread and pushes the JSON
+        // message into the renderer's bridge receiver. The message is already valid
+        // JSON (built with org.json), so it is also a valid JS object literal —
+        // window.__glanceVaultSseReceive(<obj>) — with no injection risk.
+        vaultSseClient = VaultSseClient(frameSink = { json ->
+            webView.post {
+                webView.evaluateJavascript(
+                    "window.__glanceVaultSseReceive && window.__glanceVaultSseReceive($json)",
+                    null
+                )
+            }
+        })
+
         nativeBridge = NativeBridge(
             context = this,
             healthRepository = healthRepository,
@@ -238,6 +257,12 @@ class MainActivity : AppCompatActivity() {
             },
             onAppReady = {
                 runOnUiThread { appReady = true }
+            },
+            onStartVaultSse = { url, token, accountId ->
+                vaultSseClient.enable(url, token, accountId)
+            },
+            onStopVaultSse = {
+                vaultSseClient.disable()
             }
         )
 
@@ -475,6 +500,9 @@ class MainActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
+        // App is foreground → allow the native SSE reader to connect (it only opens
+        // if the renderer has also declared SSE desired via startVaultSse).
+        vaultSseClient.setForeground(true)
         if (BuildConfig.BILLING_ENABLED && !BuildConfig.DEBUG) {
             billingManager.activity = this
             billingManager.connect()
@@ -483,6 +511,10 @@ class MainActivity : AppCompatActivity() {
 
     override fun onStop() {
         super.onStop()
+        // App backgrounded → drop the SSE socket (battery + no point streaming while
+        // hidden). Polling backstops the gap; on return onStart reconnects and the
+        // server's initial 'connected' frame reconciles anything missed.
+        vaultSseClient.setForeground(false)
         if (BuildConfig.BILLING_ENABLED && !BuildConfig.DEBUG) {
             billingManager.activity = null
             billingManager.disconnect()
@@ -490,6 +522,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        // Tear the SSE reader down cleanly — no leaked connection or coroutine.
+        vaultSseClient.shutdown()
         if (intentForwardReceiverRegistered) {
             unregisterReceiver(intentForwardReceiver)
             intentForwardReceiverRegistered = false

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -30,6 +30,12 @@ class NativeBridge(
     healthRepository: HealthRepository,
     onRequestHealthPermission: () -> Unit,
     private val onAppReady: (() -> Unit)? = null,
+    // GLANCEvault native SSE (Path 2). The renderer drives these to declare "SSE
+    // desired on/off" and hand over the vault connection; the Activity wires them
+    // to a VaultSseClient that owns the actual socket + lifecycle. Default no-ops so
+    // a shell that doesn't provide them simply reports SSE unsupported.
+    private val onStartVaultSse: ((url: String, token: String, accountId: String) -> Unit)? = null,
+    private val onStopVaultSse: (() -> Unit)? = null,
 ) {
 
     private val health = HealthBridge(healthRepository, onRequestHealthPermission)
@@ -288,6 +294,32 @@ class NativeBridge(
     @JavascriptInterface
     fun httpRequest(method: String, url: String, headersJson: String, body: String): String =
         http.request(method, url, headersJson, body)
+
+    // ── GLANCEvault native SSE (Path 2) ───────────────────────────────────────
+
+    /**
+     * Capability probe read by the renderer's `detectSseTransport()`. Returning
+     * true is what makes the renderer pick the 'native-bridge' transport (a native
+     * SSE reader feeding frames in) instead of degrading to polling-only.
+     */
+    @JavascriptInterface
+    fun isVaultSseSupported(): Boolean = true
+
+    /**
+     * Renderer → "SSE desired ON" with the vault connection. The native reader
+     * connects when the Activity is foreground and reconnects on drop; the renderer
+     * keeps polling as the backstop regardless.
+     */
+    @JavascriptInterface
+    fun startVaultSse(vaultUrl: String, token: String, accountId: String) {
+        onStartVaultSse?.invoke(vaultUrl, token, accountId)
+    }
+
+    /** Renderer → "SSE desired OFF" (vault disabled / teardown). */
+    @JavascriptInterface
+    fun stopVaultSse() {
+        onStopVaultSse?.invoke()
+    }
 
     // ── File sharing ─────────────────────────────────────────────────────────
 

--- a/dayglance-android/app/src/main/java/com/dayglance/app/sse/SseBackoff.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/sse/SseBackoff.kt
@@ -1,0 +1,49 @@
+package com.dayglance.app.sse
+
+/**
+ * Capped exponential backoff with a stability reset — the Kotlin mirror of the
+ * reconnect policy in `createVaultEventClient` (src/sync/vaultEventStream.js).
+ *
+ * A connection that stays open at least [minStableMs] is treated as healthy and
+ * resets the attempt counter, so a genuine long-lived stream that finally drops
+ * reconnects promptly. A connection that opens then drops immediately (a flap —
+ * server closing fast, proxy timeout, network reset) keeps backing off, up to
+ * [maxMs], so a broken endpoint can never storm the vault with reconnects.
+ *
+ * Pure and deterministic, so it is unit-testable with no clock or network.
+ */
+class SseBackoff(
+    private val baseMs: Long = 1_000,
+    private val maxMs: Long = 30_000,
+    private val minStableMs: Long = 5_000,
+) {
+
+    private var attempt = 0
+
+    /**
+     * The delay to wait before the NEXT reconnect attempt, then advances the
+     * counter. `base * 2^attempt`, capped at [maxMs]. The shift amount is clamped
+     * so a large attempt count can't overflow / wrap the Long shift.
+     */
+    fun nextDelayMs(): Long {
+        val shift = attempt.coerceIn(0, 30)
+        val delay = minOf(maxMs, baseMs shl shift)
+        attempt++
+        return delay
+    }
+
+    /**
+     * Record that a connection closed, given how long it had been open. Resets the
+     * backoff only when the connection was open at least [minStableMs] (a healthy
+     * stream), so the next reconnect starts back at [baseMs] rather than continuing
+     * to grow; a flap leaves the counter climbing.
+     */
+    fun onClosed(openDurationMs: Long) {
+        if (openDurationMs >= minStableMs) attempt = 0
+    }
+
+    /** Reset the backoff to its initial state. */
+    fun reset() {
+        attempt = 0
+    }
+}

--- a/dayglance-android/app/src/main/java/com/dayglance/app/sse/SseFraming.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/sse/SseFraming.kt
@@ -1,0 +1,53 @@
+package com.dayglance.app.sse
+
+/**
+ * Incremental Server-Sent-Events frame boundary detector — the Kotlin mirror of
+ * the renderer's `drainSseBuffer` (src/sync/vaultEventStream.js).
+ *
+ * It does ONLY transport-level framing: accumulate stream text across reads, split
+ * complete event blocks on the blank-line delimiter, and hand each block back
+ * verbatim. It deliberately does NOT parse `{seq,kind}` — that extraction stays in
+ * the renderer's single `parseSseFrame`, which this shell feeds each block through
+ * via the bridge. Keeping ONE `{seq,kind}` parser (in the renderer) is the whole
+ * point of the bridge-fed design: the native side is a dumb, robust byte framer.
+ *
+ * Stateful per instance (holds the partial-block remainder between reads) and pure
+ * otherwise, so it is unit-testable with no network.
+ */
+class SseFraming {
+
+    private val buffer = StringBuilder()
+
+    /**
+     * Append a decoded stream chunk and return every COMPLETE event block now
+     * available (delimited by a blank line). CRLF/CR are normalised to LF first,
+     * matching the renderer. Comment-only / heartbeat blocks (no `data:` line) are
+     * dropped here so the bridge isn't woken ~every 25 s for a frame the renderer
+     * would only parse to null anyway — a bandwidth/wakeup optimisation, not a
+     * correctness one (the renderer's parser would ignore them regardless).
+     */
+    fun append(chunk: String): List<String> {
+        buffer.append(chunk.replace("\r\n", "\n").replace('\r', '\n'))
+        val blocks = mutableListOf<String>()
+        var idx = buffer.indexOf("\n\n")
+        while (idx != -1) {
+            val block = buffer.substring(0, idx)
+            buffer.delete(0, idx + 2)
+            if (hasDataLine(block)) blocks.add(block)
+            idx = buffer.indexOf("\n\n")
+        }
+        return blocks
+    }
+
+    /**
+     * Discard any partial block. Called when a connection drops and a new one is
+     * opened, so a half-received event from the dead stream can't be glued onto the
+     * first bytes of the fresh stream.
+     */
+    fun reset() {
+        buffer.setLength(0)
+    }
+
+    private fun hasDataLine(block: String): Boolean =
+        block.split('\n').any { it.startsWith("data:") }
+}

--- a/dayglance-android/app/src/main/java/com/dayglance/app/sse/VaultSseClient.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/sse/VaultSseClient.kt
@@ -1,0 +1,183 @@
+package com.dayglance.app.sse
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Native GLANCEvault SSE reader (Path 2 — see the scoping investigation).
+ *
+ * The WebView cannot stream `text/event-stream` through the buffered bridge
+ * (`window.DayGlanceNative.httpRequest` returns the whole body as one string), so
+ * the SHELL opens the stream instead: an authenticated `GET {vaultUrl}/events`
+ * with the Bearer device token, read incrementally, framed into SSE event blocks
+ * ([SseFraming]), and each block pushed into the renderer via [frameSink] (which
+ * the Activity wires to `window.__glanceVaultSseReceive`). The renderer reuses its
+ * EXISTING `parseSseFrame` + coalescer + drains — this class owns ONLY the socket,
+ * its lifecycle, and reconnect.
+ *
+ * Because this is a native HTTP client (no browser origin), it needs NO vault CORS
+ * change. POLLING in the renderer stays the correctness backstop; these pushes only
+ * add instant drains on top.
+ *
+ * LIFECYCLE — the reader runs only when BOTH are true:
+ *   • the renderer has declared SSE desired ([enable] / [disable]), and
+ *   • the Activity is foreground ([setForeground]).
+ * It drops on background and reconnects with capped exponential backoff on any drop
+ * ([SseBackoff]). Every transition funnels through [reconcile], which starts or
+ * stops the SINGLE reader coroutine, so there is never more than one connection.
+ *
+ * RECONNECT-RECONCILE — on each (re)connect the vault sends an initial
+ * `{seq, kind:"connected"}` frame; it flows through [frameSink] like any other, so
+ * the renderer's coalescer drains and catches anything missed while disconnected.
+ */
+class VaultSseClient(
+    private val frameSink: (String) -> Unit,
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var readerJob: Job? = null
+
+    // The connection currently being read, so cancellation (background / disable)
+    // can force-close it and unblock the reader's blocking read().
+    @Volatile private var activeConnection: HttpURLConnection? = null
+
+    @Volatile private var desired = false
+    @Volatile private var foreground = false
+    @Volatile private var vaultUrl: String? = null
+    @Volatile private var token: String? = null
+    @Volatile private var accountId: String? = null
+
+    /** Renderer → "SSE desired ON", with the vault connection params. */
+    @Synchronized
+    fun enable(url: String, bearer: String, account: String) {
+        vaultUrl = url.trimEnd('/')
+        token = bearer
+        accountId = account
+        desired = true
+        reconcile()
+    }
+
+    /** Renderer → "SSE desired OFF". */
+    @Synchronized
+    fun disable() {
+        desired = false
+        reconcile()
+    }
+
+    /** Activity foreground/background (onStart / onStop). */
+    @Synchronized
+    fun setForeground(fg: Boolean) {
+        foreground = fg
+        reconcile()
+    }
+
+    /** Full teardown — Activity destroyed. No leaked connection or coroutine. */
+    @Synchronized
+    fun shutdown() {
+        desired = false
+        foreground = false
+        stopReader()
+        scope.cancel()
+    }
+
+    private fun shouldRun(): Boolean =
+        desired && foreground && vaultUrl != null && token != null && accountId != null
+
+    private fun reconcile() {
+        if (shouldRun()) startReader() else stopReader()
+    }
+
+    private fun startReader() {
+        if (readerJob?.isActive == true) return
+        val url = vaultUrl ?: return
+        val bearer = token ?: return
+        val account = accountId ?: return
+        readerJob = scope.launch { runLoop(url, bearer, account) }
+    }
+
+    private fun stopReader() {
+        readerJob?.cancel()
+        readerJob = null
+        // Unblock a reader parked in a blocking read(): coroutine cancellation alone
+        // won't interrupt java.io, so force-close the socket.
+        try { activeConnection?.disconnect() } catch (_: Exception) {}
+    }
+
+    private suspend fun runLoop(url: String, bearer: String, account: String) {
+        val backoff = SseBackoff()
+        while (coroutineContext[Job]?.isActive == true) {
+            val openedAt = System.currentTimeMillis()
+            try {
+                connectAndRead(url, bearer, account)
+            } catch (e: Exception) {
+                if (coroutineContext[Job]?.isActive != true) return // cancelled → done
+                Log.w(TAG, "SSE read error: ${e.message}")
+                push(JSONObject().put("type", "error").put("message", e.message ?: "sse error"))
+            }
+            if (coroutineContext[Job]?.isActive != true) return
+            // The stream ended (server close / read timeout / drop). Tell the
+            // renderer, then reconnect with backoff — resetting it only if the
+            // connection had been healthy long enough.
+            push(JSONObject().put("type", "closed"))
+            backoff.onClosed(System.currentTimeMillis() - openedAt)
+            delay(backoff.nextDelayMs())
+        }
+    }
+
+    private suspend fun connectAndRead(url: String, bearer: String, account: String) {
+        val target = URL("$url/events?accountId=" + URLEncoder.encode(account, "UTF-8"))
+        val conn = (target.openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            setRequestProperty("Authorization", "Bearer $bearer")
+            setRequestProperty("Accept", "text/event-stream")
+            connectTimeout = 20_000
+            // Longer than the ~25 s server heartbeat so a healthy idle stream never
+            // trips it, but a silently-dead connection is detected and reconnected
+            // within the timeout instead of parking forever.
+            readTimeout = 60_000
+            instanceFollowRedirects = true
+        }
+        activeConnection = conn
+        try {
+            val code = conn.responseCode
+            if (code !in 200..299) throw RuntimeException("vault SSE connect failed: $code")
+            push(JSONObject().put("type", "open"))
+
+            val framing = SseFraming()
+            val reader = BufferedReader(InputStreamReader(conn.inputStream, Charsets.UTF_8))
+            val chunk = CharArray(2048)
+            while (coroutineContext[Job]?.isActive == true) {
+                val n = reader.read(chunk) // blocks until data, EOF (-1), or read timeout
+                if (n == -1) break         // server closed the stream
+                for (block in framing.append(String(chunk, 0, n))) {
+                    push(JSONObject().put("type", "frame").put("block", block))
+                }
+            }
+        } finally {
+            activeConnection = null
+            try { conn.disconnect() } catch (_: Exception) {}
+        }
+    }
+
+    private fun push(msg: JSONObject) {
+        // frameSink hops to the main thread + evaluateJavascript (Activity-wired).
+        frameSink(msg.toString())
+    }
+
+    companion object {
+        private const val TAG = "VaultSseClient"
+    }
+}

--- a/dayglance-android/app/src/test/java/com/dayglance/app/sse/SseBackoffTest.kt
+++ b/dayglance-android/app/src/test/java/com/dayglance/app/sse/SseBackoffTest.kt
@@ -1,0 +1,59 @@
+package com.dayglance.app.sse
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for the native reconnect backoff. Mirrors the flap-guard / stability-
+ * reset policy the renderer's createVaultEventClient is tested for, so native and
+ * web reconnect behaviour match: a flap keeps backing off (no storm), a healthy
+ * connection resets so a later drop reconnects fast.
+ */
+class SseBackoffTest {
+
+    @Test
+    fun `grows exponentially and caps at maxMs`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, minStableMs = 5_000)
+        assertEquals(1_000, b.nextDelayMs())  // 1000 * 2^0
+        assertEquals(2_000, b.nextDelayMs())  // 2^1
+        assertEquals(4_000, b.nextDelayMs())  // 2^2
+        assertEquals(8_000, b.nextDelayMs())  // 2^3
+        assertEquals(16_000, b.nextDelayMs()) // 2^4
+        assertEquals(30_000, b.nextDelayMs()) // 32000 capped to 30000
+        assertEquals(30_000, b.nextDelayMs()) // stays capped
+    }
+
+    @Test
+    fun `a flap (closed before minStableMs) does NOT reset — backoff keeps growing`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 60_000, minStableMs = 5_000)
+        assertEquals(1_000, b.nextDelayMs())
+        b.onClosed(50)                        // opened then dropped fast → no reset
+        assertEquals(2_000, b.nextDelayMs())  // continues to grow, no 1s storm
+        b.onClosed(100)
+        assertEquals(4_000, b.nextDelayMs())
+    }
+
+    @Test
+    fun `a stable connection (open past minStableMs) resets so the next reconnect is fast`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 60_000, minStableMs = 5_000)
+        b.nextDelayMs(); b.nextDelayMs(); b.nextDelayMs() // climb to attempt=3
+        b.onClosed(10_000)                    // healthy: open 10s ≥ 5s → reset
+        assertEquals(1_000, b.nextDelayMs())  // back to base
+    }
+
+    @Test
+    fun `reset returns to base`() {
+        val b = SseBackoff(baseMs = 500)
+        b.nextDelayMs(); b.nextDelayMs()
+        b.reset()
+        assertEquals(500, b.nextDelayMs())
+    }
+
+    @Test
+    fun `many attempts never overflow the delay (stays capped, non-negative)`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, minStableMs = 5_000)
+        repeat(200) { b.nextDelayMs() }
+        val d = b.nextDelayMs()
+        assertEquals(30_000, d) // clamped shift → no overflow/wrap to a bogus delay
+    }
+}

--- a/dayglance-android/app/src/test/java/com/dayglance/app/sse/SseFramingTest.kt
+++ b/dayglance-android/app/src/test/java/com/dayglance/app/sse/SseFramingTest.kt
@@ -1,0 +1,71 @@
+package com.dayglance.app.sse
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the native SSE frame boundary detector. Mirrors the behaviour the
+ * renderer's drainSseBuffer is tested for (src/sync/vaultEventStream.test.js), so
+ * the native framing and the JS parser agree on what a "complete event block" is.
+ */
+class SseFramingTest {
+
+    @Test
+    fun `emits complete blocks and carries the partial remainder across reads`() {
+        val f = SseFraming()
+        // Two complete events plus a partial third, split awkwardly across reads.
+        val first = f.append("data: {\"seq\":1,\"kind\":\"sync\"}\n\ndata: {\"seq\":2,")
+        assertEquals(listOf("data: {\"seq\":1,\"kind\":\"sync\"}"), first)
+
+        // The partial "data: {\"seq\":2," is buffered — nothing emitted yet.
+        val second = f.append("\"kind\":\"intents\"}\n\n")
+        assertEquals(listOf("data: {\"seq\":2,\"kind\":\"intents\"}"), second)
+    }
+
+    @Test
+    fun `normalizes CRLF and CR frame boundaries`() {
+        val f = SseFraming()
+        val blocks = f.append("data: {\"seq\":7,\"kind\":\"sync\"}\r\n\r\n")
+        assertEquals(listOf("data: {\"seq\":7,\"kind\":\"sync\"}"), blocks)
+    }
+
+    @Test
+    fun `drops heartbeat and comment-only blocks (no data line)`() {
+        val f = SseFraming()
+        val blocks = f.append(": keep-alive\n\nevent: ping\n\ndata: {\"seq\":4,\"kind\":\"sync\"}\n\n")
+        // Only the block carrying a data: line is forwarded.
+        assertEquals(listOf("data: {\"seq\":4,\"kind\":\"sync\"}"), blocks)
+    }
+
+    @Test
+    fun `multi-line data block is forwarded verbatim for the renderer to parse`() {
+        val f = SseFraming()
+        val block = "event: intents\nid: 9\ndata: {\"seq\":9,\"kind\":\"intents\"}"
+        val blocks = f.append("$block\n\n")
+        assertEquals(listOf(block), blocks)
+    }
+
+    @Test
+    fun `reset discards a partial block so a new stream does not glue onto the old`() {
+        val f = SseFraming()
+        f.append("data: {\"seq\":1,") // partial, buffered
+        f.reset()
+        // Fresh stream after reconnect: the leftover partial must be gone.
+        val blocks = f.append("data: {\"seq\":2,\"kind\":\"sync\"}\n\n")
+        assertEquals(listOf("data: {\"seq\":2,\"kind\":\"sync\"}"), blocks)
+    }
+
+    @Test
+    fun `handles several complete blocks in one chunk`() {
+        val f = SseFraming()
+        val blocks = f.append(
+            "data: {\"seq\":1,\"kind\":\"connected\"}\n\n" +
+                "data: {\"seq\":2,\"kind\":\"sync\"}\n\n" +
+                "data: {\"seq\":3,\"kind\":\"intents\"}\n\n"
+        )
+        assertEquals(3, blocks.size)
+        assertTrue(blocks[0].contains("connected"))
+        assertTrue(blocks[2].contains("intents"))
+    }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1162,9 +1162,11 @@ const DayPlanner = () => {
 
   // GLANCEvault SSE push — instant drain on a server nudge, ADDED on top of the
   // permanent poll backstops (never replacing them). Opens only when vault sync
-  // is enabled and the app is active; web-only (fetch-stream), degrades to
-  // polling on native/electron. Nudges trigger the EXISTING drains: dbSyncCycle
-  // for sync, drainDbIntents for intents. See useVaultEventStream / vaultEventStream.
+  // is enabled and the app is active. Transport per platform: web/Electron stream
+  // via direct fetch; Android (and later iOS) via a NATIVE reader that pushes
+  // frames through the bridge (native-bridge); an older native shell without the
+  // reader degrades to polling. Nudges trigger the EXISTING drains: dbSyncCycle for
+  // sync, drainDbIntents for intents. See useVaultEventStream / vaultEventStream.
   useVaultEventStream({
     dataLoaded,
     drainSync: useCallback(() => dbEngineRef.current?.dbSyncCycle?.(), []),

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -19,9 +19,15 @@ import { isVaultEnabled, getVaultConfig } from '../sync/vaultConfig.js';
 import {
   createNudgeCoalescer,
   createVaultEventClient,
+  createBridgeSseClient,
   detectSseTransport,
   openWebSseStream,
 } from '../sync/vaultEventStream.js';
+
+// The global the native shell invokes to push SSE messages into the renderer
+// (see the BRIDGE CONTRACT in vaultEventStream.js). Kept as a named constant so
+// the Android/iOS shells and this file can't drift.
+const NATIVE_SSE_RECEIVE = '__glanceVaultSseReceive';
 
 const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
 
@@ -43,11 +49,12 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
     if (isTrayMode || !dataLoaded || !isVaultEnabled()) return undefined;
 
     const transport = detectSseTransport();
-    if (transport !== 'web') {
-      // Native WebView / SSR: the vault HTTP path is fully buffered and cannot
-      // stream frames, so SSE is unavailable — degrade cleanly to polling (which
-      // is already running). Nothing to open, nothing to clean up. (Electron is
-      // NOT here — it reports 'web' and streams directly from the app:// origin.)
+    if (transport !== 'web' && transport !== 'native-bridge') {
+      // 'native-unsupported' (older native shell) / 'none' (SSR): the vault HTTP
+      // path is fully buffered / absent and cannot stream frames, so SSE is
+      // unavailable — degrade cleanly to polling (already running). Nothing to
+      // open, nothing to clean up. (Electron is NOT here — it reports 'web' and
+      // streams directly from the app:// origin.)
       if (import.meta.env?.DEV) {
         console.info('[vault-sse] streaming unavailable on', transport, '— polling backstop only');
       }
@@ -55,11 +62,11 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
     }
 
     // Observability: a live, inspectable snapshot so SSE health can be checked in
-    // a packaged/MAS build with no devtools — run `window.__glanceVaultSse` in the
-    // console (or read it from a diagnostics panel). Counters make a reconnect
-    // STORM (many connects, few events) immediately obvious. Logging is always-on
-    // (not DEV-gated) but low-volume: one line per lifecycle transition, not per
-    // heartbeat.
+    // a packaged/MAS/native build with no devtools — run `window.__glanceVaultSse`
+    // in the console (or read it from a diagnostics panel). Counters make a
+    // reconnect STORM (many connects, few events) immediately obvious. Logging is
+    // always-on (not DEV-gated) but low-volume: one line per lifecycle transition,
+    // not per heartbeat.
     const diag = {
       state: 'idle',
       connects: 0,
@@ -86,27 +93,60 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
       onDrainError: (msg, err) => console.warn('[vault-sse]', msg, err?.message || err),
     });
 
+    // The frame → coalescer funnel is identical for both transports; only the
+    // socket owner differs (JS fetch loop vs native shell).
+    const onEvent = (evt) => {
+      diag.events += 1;
+      if (evt && typeof evt.seq === 'number') { diag.lastEventSeq = evt.seq; diag.lastEventKind = evt.kind; }
+      coalescer.handleEvent(evt);
+    };
+    const onStateChange = (state, detail) => {
+      diag.state = state;
+      if (state === 'connecting') diag.connects += 1;
+      if (state === 'open') diag.lastConnectedAt = new Date().toISOString();
+      if (state === 'error') { diag.lastError = detail?.message || String(detail || 'error'); console.warn('[vault-sse] error:', diag.lastError); }
+      else console.info('[vault-sse]', state, `(connects=${diag.connects} events=${diag.events} drains=${diag.drains})`);
+    };
+    const getConnection = () => {
+      const c = getVaultConfig();
+      return c && c.vaultUrl && c.vaultToken && c.accountId
+        ? { vaultUrl: c.vaultUrl, vaultToken: c.vaultToken, accountId: c.accountId }
+        : null;
+    };
+
+    // ── NATIVE-BRIDGE: the native shell owns the socket + reconnect + fg/bg ──────
+    if (transport === 'native-bridge') {
+      const bridge = window.DayGlanceNative;
+      const client = createBridgeSseClient({
+        getConnection,
+        // JS → native: hand over the connection and say "SSE desired on".
+        startNative: (c) => bridge.startVaultSse(c.vaultUrl, c.vaultToken, c.accountId),
+        stopNative: () => bridge.stopVaultSse?.(),
+        onEvent,
+        onStateChange,
+      });
+      // native → JS push target. The shell calls window.__glanceVaultSseReceive(msg)
+      // per the bridge contract; route it into the client.
+      window[NATIVE_SSE_RECEIVE] = client.receive;
+      // No visibilitychange wiring here: the native shell owns foreground/background
+      // (Activity lifecycle) and reconnect. The renderer only declares intent (on)
+      // and hands over the connection; native connects when it's actually visible.
+      client.start();
+
+      return () => {
+        client.stop();
+        if (window[NATIVE_SSE_RECEIVE] === client.receive) delete window[NATIVE_SSE_RECEIVE];
+        coalescer.cancel();
+      };
+    }
+
+    // ── WEB / ELECTRON: JS owns the fetch stream + reconnect/backoff ────────────
     const client = createVaultEventClient({
       supported: true,
-      getConnection: () => {
-        const c = getVaultConfig();
-        return c && c.vaultUrl && c.vaultToken && c.accountId
-          ? { vaultUrl: c.vaultUrl, vaultToken: c.vaultToken, accountId: c.accountId }
-          : null;
-      },
+      getConnection,
       openStream: openWebSseStream,
-      onEvent: (evt) => {
-        diag.events += 1;
-        if (evt && typeof evt.seq === 'number') { diag.lastEventSeq = evt.seq; diag.lastEventKind = evt.kind; }
-        coalescer.handleEvent(evt);
-      },
-      onStateChange: (state, detail) => {
-        diag.state = state;
-        if (state === 'connecting') diag.connects += 1;
-        if (state === 'open') diag.lastConnectedAt = new Date().toISOString();
-        if (state === 'error') { diag.lastError = detail?.message || String(detail || 'error'); console.warn('[vault-sse] error:', diag.lastError); }
-        else console.info('[vault-sse]', state, `(connects=${diag.connects} events=${diag.events} drains=${diag.drains})`);
-      },
+      onEvent,
+      onStateChange,
     });
 
     // Drop SSE on background, reopen on foreground. The (re)connect delivers a

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -33,8 +33,37 @@
 //   • NATIVE (Android/iOS WebView): the vault HTTP path is the synchronous,
 //     fully-BUFFERED bridge (window.DayGlanceNative.httpRequest) — it returns the
 //     whole body as one string and cannot deliver incremental frames, so
-//     streaming SSE is structurally impossible. detectSseTransport() reports this
-//     and the client does not open — the device degrades cleanly to polling.
+//     streaming SSE INSIDE THE WEBVIEW is structurally impossible. Instead the
+//     NATIVE SHELL opens the /events stream itself (a Kotlin/Swift SSE reader,
+//     over a native HTTP client — no browser origin, so NO vault CORS change) and
+//     pushes each raw SSE block into the renderer via a bridge callback
+//     (window.__glanceVaultSseReceive). The renderer reuses the SAME parseSseFrame
+//     + coalescer + drains — only the transport INPUT differs. This is the
+//     "bridge-fed" transport (see createBridgeSseClient). A shell that advertises
+//     the capability (DayGlanceNative.isVaultSseSupported() === true) reports
+//     'native-bridge'; an older shell without it stays 'native-unsupported' and
+//     degrades cleanly to polling.
+//
+// BRIDGE CONTRACT (renderer ↔ native shell), used by the 'native-bridge' path:
+//   JS → native (methods on window.DayGlanceNative):
+//     • isVaultSseSupported() → boolean   capability probe (detectSseTransport).
+//     • startVaultSse(vaultUrl, token, accountId)   "SSE desired ON" + connection
+//       params. The native reader owns the socket: it connects when foreground,
+//       drops on background, and reconnects with backoff — all transparent to JS.
+//     • stopVaultSse()                    "SSE desired OFF" — native tears down.
+//   native → JS (native invokes window.__glanceVaultSseReceive(msg), msg an object
+//   or JSON string):
+//     • {type:'open'}                     a native (re)connection was established.
+//     • {type:'frame', block:'<raw SSE event block>'}   one SSE event; the renderer
+//       runs it through the EXISTING parseSseFrame → {seq,kind} → coalescer. On a
+//       native reconnect the server's initial {seq,kind:'connected'} arrives as a
+//       frame here, so reconnect-reconcile is automatic (coalescer drains both).
+//     • {type:'closed'}                   the native stream dropped (native will
+//       reconnect); informational for diagnostics.
+//     • {type:'error', message}           a native connect/read error; native owns
+//       the retry, so this is informational only.
+//   POLLING stays the correctness backstop on native exactly as on web/Electron —
+//   bridge-fed nudges only ADD instant drains on top.
 
 // ─── SSE frame parsing ────────────────────────────────────────────────────────
 
@@ -92,20 +121,49 @@ export function drainSseBuffer(buffer, onEvent) {
  *                          browsers/PWA AND Electron: Electron's renderer is
  *                          Chromium loading from app://dayglance, so its direct
  *                          fetch streams text/event-stream just like a browser.
- *   'native-unsupported' — Android/iOS WebView: buffered synchronous bridge.
+ *   'native-bridge'      — Android/iOS WebView whose native shell advertises a
+ *                          native SSE reader (isVaultSseSupported() === true): the
+ *                          shell opens the stream and pushes frames in via the
+ *                          bridge (see createBridgeSseClient). No vault CORS change.
+ *   'native-unsupported' — a native WebView whose shell has the buffered bridge but
+ *                          NOT the SSE reader (older build) — degrade to polling.
  *   'none'               — no window / no streaming fetch (e.g. tests, SSR).
- * Only 'web' opens a stream; every other value degrades cleanly to polling.
+ * 'web' and 'native-bridge' open a stream; every other value degrades to polling.
  */
 export function detectSseTransport() {
   if (typeof window === 'undefined') return 'none';
-  // The native WebView bridge (window.DayGlanceNative.httpRequest) is synchronous
-  // and returns the whole body as one string — it cannot stream frames.
-  if (window.DayGlanceNative?.httpRequest) return 'native-unsupported';
+  // Native WebView: the vault HTTP path is the synchronous, whole-body bridge
+  // (window.DayGlanceNative.httpRequest) — it cannot stream frames. But the native
+  // SHELL can, and pushes them in. Use the bridge-fed transport when the shell
+  // advertises the capability; otherwise (older shell) fall back to polling.
+  const bridge = window.DayGlanceNative;
+  if (bridge?.httpRequest) {
+    return nativeSseSupported(bridge) ? 'native-bridge' : 'native-unsupported';
+  }
   // Electron is intentionally NOT special-cased here: its renderer fetch streams
   // like any Chromium fetch. The buffering IPC proxy is only for request/response
   // vault/WebDAV/CalDAV calls; SSE uses the direct fetch below (openWebSseStream).
   if (typeof fetch === 'function' && typeof ReadableStream !== 'undefined') return 'web';
   return 'none';
+}
+
+/**
+ * True only when the native shell exposes a working native SSE reader. Probed via
+ * an explicit capability method so:
+ *   • an OLDER Android shell (bridge present, no startVaultSse) → false → polling;
+ *   • the iOS shell whose bridge is a Proxy fabricating EVERY method name still
+ *     reports false until its handler actually returns true (its stubbed reply is
+ *     the string "null", not true), so iOS keeps polling until its reader ships.
+ * Only a literal boolean true (or the string 'true') counts as supported.
+ */
+function nativeSseSupported(bridge) {
+  if (typeof bridge.startVaultSse !== 'function') return false;
+  try {
+    const v = typeof bridge.isVaultSseSupported === 'function' ? bridge.isVaultSseSupported() : false;
+    return v === true || v === 'true';
+  } catch {
+    return false;
+  }
 }
 
 // ─── web streaming reader ─────────────────────────────────────────────────────
@@ -352,6 +410,96 @@ export function createVaultEventClient({
       onStateChange?.('stopped');
     },
     isRunning: () => !stopped,
+    isSupported: () => supported,
+  };
+}
+
+// ─── bridge-fed client (native shell owns the socket) ─────────────────────────
+
+/**
+ * The renderer half of the 'native-bridge' transport. Unlike createVaultEventClient
+ * (which owns a fetch stream + JS-side reconnect/backoff), here the NATIVE SHELL
+ * owns the socket and its whole lifecycle: it connects when foreground, drops on
+ * background, and reconnects with backoff — all invisible to JS. This client's job
+ * is only to (a) tell native "SSE desired on/off" with the connection params, and
+ * (b) funnel the raw SSE blocks native pushes back through the SAME parseSseFrame +
+ * onEvent (→ coalescer → drain) the web path uses. There is deliberately NO JS
+ * reconnect loop here — reconnect belongs to exactly ONE owner per transport, and
+ * for native that owner is the shell (see Stage 2). Polling remains the backstop.
+ *
+ * `receive` is the function the native shell invokes (as window.__glanceVaultSseReceive)
+ * — see the BRIDGE CONTRACT at the top of this file for the message shapes.
+ *
+ * @param {object} p
+ * @param {() => ({vaultUrl:string,vaultToken:string,accountId:string}|null)} p.getConnection
+ * @param {(c:object) => void} p.startNative  tell the shell to open (given the connection)
+ * @param {() => void}         p.stopNative   tell the shell to tear down
+ * @param {(evt:object) => void} p.onEvent    parsed {seq,kind} frame → coalescer.handleEvent
+ * @param {(state:string, detail?:any) => void} [p.onStateChange]
+ * @param {boolean} [p.supported]
+ * @param {(block:string, onEvent:(e:object)=>void) => void} [p.parseFrame] injectable (tests)
+ */
+export function createBridgeSseClient({
+  getConnection,
+  startNative,
+  stopNative,
+  onEvent,
+  onStateChange,
+  supported = true,
+} = {}) {
+  let running = false;
+
+  // The native shell pushes messages here. Accepts a parsed object OR a JSON
+  // string (evaluateJavascript with an object literal delivers an object; a shell
+  // that stringifies is handled too). Never throws — a malformed push is ignored
+  // so it can't break the bridge.
+  const receive = (msg) => {
+    if (typeof msg === 'string') {
+      try { msg = JSON.parse(msg); } catch { return; }
+    }
+    if (!msg || typeof msg !== 'object') return;
+    switch (msg.type) {
+      case 'open':
+        onStateChange?.('open');
+        break;
+      case 'frame': {
+        // Reuse the EXISTING parser: native did transport + frame boundary
+        // detection; {seq,kind} extraction stays in ONE place (parseSseFrame).
+        if (typeof msg.block === 'string') {
+          const evt = parseSseFrame(msg.block);
+          if (evt) onEvent?.(evt);
+        }
+        break;
+      }
+      case 'closed':
+        onStateChange?.('closed');
+        break;
+      case 'error':
+        onStateChange?.('error', msg.message);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return {
+    receive,
+    start() {
+      if (!supported || running) return false;
+      const connection = getConnection?.();
+      if (!connection) return false; // nothing to connect to → polling covers it
+      running = true;
+      onStateChange?.('connecting');
+      try { startNative?.(connection); } catch (err) { onStateChange?.('error', err?.message || String(err)); }
+      return true;
+    },
+    stop() {
+      if (!running) return;
+      running = false;
+      try { stopNative?.(); } catch { /* ignore — teardown must not throw */ }
+      onStateChange?.('stopped');
+    },
+    isRunning: () => running,
     isSupported: () => supported,
   };
 }

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -6,6 +6,7 @@ import {
   openWebSseStream,
   createNudgeCoalescer,
   createVaultEventClient,
+  createBridgeSseClient,
 } from './vaultEventStream.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -90,8 +91,36 @@ describe('detectSseTransport', () => {
     expect(detectSseTransport()).toBe('web');
   });
 
-  it('returns native-unsupported when the native bridge is present', () => {
+  it('returns native-unsupported when the native bridge lacks the SSE reader (older shell)', () => {
+    // Bridge present (httpRequest) but no startVaultSse / capability → polling.
     global.window = { DayGlanceNative: { httpRequest: () => {} } };
+    expect(detectSseTransport()).toBe('native-unsupported');
+  });
+
+  it('returns native-bridge when the shell advertises a native SSE reader', () => {
+    global.window = {
+      DayGlanceNative: {
+        httpRequest: () => {},
+        startVaultSse: () => {},
+        stopVaultSse: () => {},
+        isVaultSseSupported: () => true,
+      },
+    };
+    expect(detectSseTransport()).toBe('native-bridge');
+  });
+
+  it('stays native-unsupported when the shell fabricates methods but the probe is not true (iOS Proxy)', () => {
+    // Mirrors iOS's Proxy bridge: every method name resolves to a function, but the
+    // unimplemented capability probe replies with the string "null" — not true — so
+    // iOS keeps polling until its native reader ships.
+    global.window = {
+      DayGlanceNative: new Proxy({ httpRequest: () => {} }, {
+        get(target, prop) {
+          if (prop in target) return target[prop];
+          return () => 'null';
+        },
+      }),
+    };
     expect(detectSseTransport()).toBe('native-unsupported');
   });
 
@@ -459,5 +488,109 @@ describe('openWebSseStream — web fetch-stream path', () => {
       onEvent: () => {},
       fetchImpl,
     })).rejects.toThrow();
+  });
+});
+
+// ─── bridge-fed client (native shell owns the socket) ─────────────────────────
+
+describe('createBridgeSseClient — native bridge-fed transport', () => {
+  const conn = { vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' };
+
+  it('start() hands the connection to native; stop() tears native down', () => {
+    const startNative = vi.fn();
+    const stopNative = vi.fn();
+    const client = createBridgeSseClient({
+      getConnection: () => conn, startNative, stopNative, onEvent: () => {},
+    });
+
+    expect(client.start()).toBe(true);
+    expect(startNative).toHaveBeenCalledWith(conn);
+    expect(client.isRunning()).toBe(true);
+    // Idempotent: a second start does not re-open.
+    expect(client.start()).toBe(false);
+    expect(startNative).toHaveBeenCalledTimes(1);
+
+    client.stop();
+    expect(stopNative).toHaveBeenCalledTimes(1);
+    expect(client.isRunning()).toBe(false);
+  });
+
+  it('does not start when there is no connection (nothing to connect to)', () => {
+    const startNative = vi.fn();
+    const client = createBridgeSseClient({
+      getConnection: () => null, startNative, stopNative: () => {}, onEvent: () => {},
+    });
+    expect(client.start()).toBe(false);
+    expect(startNative).not.toHaveBeenCalled();
+    expect(client.isRunning()).toBe(false);
+  });
+
+  it('a pushed {type:frame,block} is parsed by the SHARED parseSseFrame and reaches onEvent', () => {
+    const events = [];
+    const client = createBridgeSseClient({
+      getConnection: () => conn, startNative: () => {}, stopNative: () => {},
+      onEvent: (e) => events.push(e),
+    });
+    // native pushes a raw SSE block (its transport did frame-boundary detection).
+    client.receive({ type: 'frame', block: 'data: {"seq":11,"kind":"sync"}' });
+    // heartbeat/comment block → parseSseFrame returns null → ignored.
+    client.receive({ type: 'frame', block: ': keep-alive' });
+    client.receive({ type: 'frame', block: 'data: {"seq":12,"kind":"intents"}' });
+    expect(events).toEqual([{ seq: 11, kind: 'sync' }, { seq: 12, kind: 'intents' }]);
+  });
+
+  it('END-TO-END: a pushed frame drives the EXISTING coalescer → drain (reconnect-reconcile too)', () => {
+    vi.useFakeTimers();
+    const onDrain = vi.fn();
+    const coalescer = createNudgeCoalescer({ onDrain, debounceMs: 10 });
+    const client = createBridgeSseClient({
+      getConnection: () => conn, startNative: () => {}, stopNative: () => {},
+      onEvent: coalescer.handleEvent,
+    });
+    client.start();
+
+    // A real sync change nudged in from native → sync drain.
+    client.receive({ type: 'frame', block: 'data: {"seq":1,"kind":"sync"}' });
+    vi.advanceTimersByTime(10);
+    expect(onDrain).toHaveBeenCalledTimes(1);
+    expect(onDrain).toHaveBeenCalledWith('sync');
+    onDrain.mockClear();
+
+    // Native reconnects → server's initial 'connected' frame arrives here →
+    // reconcile drains BOTH (catches anything missed while the socket was down).
+    client.receive({ type: 'open' }); // informational
+    client.receive({ type: 'frame', block: 'data: {"seq":5,"kind":"connected"}' });
+    vi.advanceTimersByTime(10);
+    expect(onDrain).toHaveBeenCalledTimes(2); // sync + intents
+    vi.useRealTimers();
+  });
+
+  it('accepts a JSON-STRING push (shell that stringifies) and ignores malformed pushes', () => {
+    const events = [];
+    const client = createBridgeSseClient({
+      getConnection: () => conn, startNative: () => {}, stopNative: () => {},
+      onEvent: (e) => events.push(e),
+    });
+    client.receive(JSON.stringify({ type: 'frame', block: 'data: {"seq":3,"kind":"sync"}' }));
+    // Malformed pushes must never throw.
+    expect(() => client.receive('not json')).not.toThrow();
+    expect(() => client.receive(null)).not.toThrow();
+    expect(() => client.receive({ type: 'frame' })).not.toThrow(); // no block
+    expect(events).toEqual([{ seq: 3, kind: 'sync' }]);
+  });
+
+  it('routes lifecycle messages to onStateChange (open/closed/error)', () => {
+    const states = [];
+    const client = createBridgeSseClient({
+      getConnection: () => conn, startNative: () => {}, stopNative: () => {},
+      onEvent: () => {}, onStateChange: (s, d) => states.push([s, d]),
+    });
+    client.start(); // 'connecting'
+    client.receive({ type: 'open' });
+    client.receive({ type: 'closed' });
+    client.receive({ type: 'error', message: 'boom' });
+    client.stop(); // 'stopped'
+    expect(states.map((s) => s[0])).toEqual(['connecting', 'open', 'closed', 'error', 'stopped']);
+    expect(states.find((s) => s[0] === 'error')[1]).toBe('boom');
   });
 });

--- a/src/utils/stampTimestamps.js
+++ b/src/utils/stampTimestamps.js
@@ -15,13 +15,31 @@
 // Strip `lastModified` and default the fields that are normalized into in-memory
 // tasks (see loadData / applyEngineData) but may be missing from the stored copy,
 // so a passive default-add doesn't register as a user edit.
+//
+// `archived` belongs here for the SAME reason as notes/subtasks: a task that was
+// never archived carries no `archived` key in storage, but an unarchive (or a
+// merge from a device that does set it) leaves `archived: false` in memory. Absent
+// and `false` are the SAME state ("not archived"), so they must compare equal —
+// otherwise every cold-open re-stamps `lastModified` on those items (changed:
+// ['archived']), which then dirties them for the DB-sync push. Canonicalising both
+// sides to `false` makes archived round-trip identically for the diff while a real
+// archive (`archived: true`) still reads as a genuine change.
 function normalizeField(task) {
   const { lastModified: _omit, ...rest } = task;
-  return { ...rest, notes: rest.notes ?? '', subtasks: rest.subtasks ?? [] };
+  return { ...rest, notes: rest.notes ?? '', subtasks: rest.subtasks ?? [], archived: rest.archived ?? false };
 }
 
+// Order-INSENSITIVE stringify of the normalized task. A defaulted field (archived,
+// notes, subtasks) lands at a different key position depending on whether it was
+// already present in the stored copy or added by normalizeField — so a plain
+// JSON.stringify would flag two semantically-equal objects as different purely on
+// key order. Sorting the top-level keys makes the comparison depend on VALUES, not
+// insertion order (diffKeys is already per-key, so it needs no change).
 function normalizedForCompare(task) {
-  return JSON.stringify(normalizeField(task));
+  const n = normalizeField(task);
+  const sorted = {};
+  for (const k of Object.keys(n).sort()) sorted[k] = n[k];
+  return JSON.stringify(sorted);
 }
 
 // Keys whose (normalized) values differ between the stored and in-memory copy.

--- a/src/utils/stampTimestamps.test.js
+++ b/src/utils/stampTimestamps.test.js
@@ -40,6 +40,44 @@ describe('stampTimestamps', () => {
     expect(out[0].lastModified).toBe(stored[0].lastModified); // NOT ISO(0)
   });
 
+  // ── Regression: cold-open re-stamp on `archived` (day-planner-unscheduled) ───
+  // Same class as the tombstonePrunedBefore false-diff: a never-archived task has
+  // no `archived` key in storage, but in-memory it carries `archived: false` (from
+  // an unarchive elsewhere or a merge). Absent ≡ false, so the stamper must treat
+  // them as equal and NOT fabricate a new lastModified on every cold-open.
+  it('does NOT re-stamp when storage lacks `archived` but memory has archived:false', () => {
+    const stored = [{ id: 1, title: 'Inbox item', completed: false, lastModified: ISO(100) }];
+    const inMemory = [{ id: 1, title: 'Inbox item', completed: false, notes: '', subtasks: [], archived: false, lastModified: ISO(100) }];
+    const out = stampTimestamps(inMemory, stored, ISO(0));
+    expect(out[0].lastModified).toBe(stored[0].lastModified); // stable — no false-diff
+  });
+
+  it('does NOT re-stamp the reverse: storage has archived:false, memory omits it', () => {
+    const stored = [{ id: 1, title: 'Inbox item', archived: false, lastModified: ISO(100) }];
+    const inMemory = [{ id: 1, title: 'Inbox item', lastModified: ISO(100) }];
+    expect(stampTimestamps(inMemory, stored, ISO(0))[0].lastModified).toBe(stored[0].lastModified);
+  });
+
+  it('round-trips: store→load leaves archived:false stable across repeated saves (no drift)', () => {
+    // Cold-open cycle: state carries archived:false; storage was written without it
+    // (older data). First save must not re-stamp, and the item stays stable on the
+    // next cycle too (idempotent — never dirties).
+    const t0 = ISO(100);
+    let stored = [{ id: 1, title: 'Item', completed: false, lastModified: t0 }];
+    const inMemory = [{ id: 1, title: 'Item', completed: false, notes: '', subtasks: [], archived: false, lastModified: t0 }];
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const out = stampTimestamps(inMemory, stored, ISO(0));
+      expect(out[0].lastModified).toBe(t0); // never fabricated
+      stored = out; // persist and re-load next cycle
+    }
+  });
+
+  it('a REAL archive still re-stamps (archived:true vs absent is a genuine change)', () => {
+    const stored = [{ id: 1, title: 'Item', lastModified: ISO(100) }];
+    const inMemory = [{ id: 1, title: 'Item', archived: true, lastModified: ISO(100) }];
+    expect(stampTimestamps(inMemory, stored, 'NOW')[0].lastModified).toBe('NOW');
+  });
+
   describe('onRestamp diagnostic', () => {
     it('reports the changed fields when an existing task is re-stamped', () => {
       const prev = [{ id: 1, title: 'A', completed: false, lastModified: ISO(100) }];
@@ -56,6 +94,8 @@ describe('stampTimestamps', () => {
       stampTimestamps([{ id: 1, title: 'A', lastModified: ISO(100) }], [{ id: 1, title: 'A', lastModified: ISO(100) }], 'NOW', onRestamp);
       // default-only diff (the resurrection vector — must stay silent)
       stampTimestamps([{ id: 2, title: 'B', notes: '', subtasks: [], lastModified: ISO(100) }], [{ id: 2, title: 'B', lastModified: ISO(100) }], 'NOW', onRestamp);
+      // archived absent-vs-false (the cold-open re-stamp we fixed — must stay silent)
+      stampTimestamps([{ id: 4, title: 'D', archived: false, lastModified: ISO(100) }], [{ id: 4, title: 'D', lastModified: ISO(100) }], 'NOW', onRestamp);
       // new task
       stampTimestamps([{ id: 3, title: 'C' }], [], 'NOW', onRestamp);
       expect(calls).toEqual([]);


### PR DESCRIPTION
Two independent changes on this branch.

## 1. Native Android SSE push (`2ca6336`)

Real-time GLANCEvault SSE on Android (Path 2 from the scoping investigation). The WebView can't stream `text/event-stream` through the buffered bridge, so the native shell opens `/events` itself, frames the events, and pushes each raw SSE block into the renderer via a bridge callback. The renderer **reuses its existing `parseSseFrame` + coalescer + drains** — only the transport input is new. Native connects with a native HTTP client (no browser origin), so **no vault CORS change** is needed. **Polling stays the correctness backstop, unchanged.**

**Renderer (shared with the future iOS port)**
- `vaultEventStream.js`: `createBridgeSseClient` (native shell owns the socket; JS funnels pushed blocks through the shared parser → coalescer). `detectSseTransport` returns `native-bridge` when the shell advertises a reader (`isVaultSseSupported() === true`), else `native-unsupported` → polling. An explicit capability probe keeps the current iOS Proxy shell on polling until its reader ships. Full bridge contract documented in-file.
- `useVaultEventStream.js`: branches web vs native-bridge; registers `window.__glanceVaultSseReceive`; leaves foreground/background to the shell on native. Diagnostics (`window.__glanceVaultSse`) cover both.

**Android shell** (`com.dayglance.app.sse`)
- `SseFraming` (incremental SSE block boundaries, drops heartbeats), `SseBackoff` (capped exponential backoff + stability reset — mirrors the JS flap-guard), `VaultSseClient` (authenticated streaming GET over `HttpURLConnection` on a coroutine; foreground+desired lifecycle; reconnect with backoff; reconnect-reconcile via the server's initial `connected` frame; clean teardown).
- `NativeBridge`: `startVaultSse` / `stopVaultSse` / `isVaultSseSupported`.
- `MainActivity`: constructs the client, wires the frame sink to `evaluateJavascript`, drives foreground in `onStart`/`onStop` and teardown in `onDestroy`.

## 2. Fix archived cold-open re-stamp (`55549a8`)

Every cold-open re-stamped a batch of `day-planner-unscheduled` items (`[stamp]` debug reported `changed: ['archived']`), fabricating a fresh `lastModified` that dirtied them for the DB-sync push — same class as the `tombstonePrunedBefore` false-diff.

Root cause: a never-archived task has no `archived` key in storage, but an unarchive or a merge leaves `archived: false` in memory. `normalizeField` canonicalized `notes`/`subtasks` (absent≡default) but omitted `archived`. Fix in `src/utils/stampTimestamps.js`:
- default `archived: rest.archived ?? false` so absent≡false (a real `archived: true` still reads as a genuine change; behavior of archiving is unchanged);
- sort top-level keys before stringify in `normalizedForCompare` — the defaulted field's key position varied, and the whole-object `JSON.stringify` was order-sensitive, so semantically-equal objects mis-compared on order alone. The compare now depends on values, not insertion order.

Result: a cold-open with no real change → no re-stamp → stable `lastModified` → not dirty → no push.

## Testing
- Renderer suite **534 passing** (incl. `detectSseTransport` native-bridge cases; bridge-client drains a pushed frame through the real coalescer incl. reconnect-reconcile; archived absent-vs-false round-trip + real-archive still stamps). Web build + lint green.
- Kotlin JUnit **11 passing** (SseFraming boundary/heartbeat/reset; SseBackoff growth/flap/reset), run via the embedded Kotlin compiler; `VaultSseClient` type-checks clean.

## Must verify on-device (real Android build)
1. With vault sync enabled, `window.__glanceVaultSse.transport === 'native-bridge'` and `state` reaches `open`.
2. A change on another device drains the Android app within ~1s (not on the next poll).
3. Kill connectivity → native socket drops, polling still delivers; on reconnect the `connected` frame reconciles.
4. Background/foreground drops+reconnects with no reconnect storm.
5. Older shell without the reader still reports `native-unsupported` and runs polling-only.
6. With `dayglance-debug-stamp` on, a cold-open no longer logs `changed: ['archived']` and does not push these items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_