### PR TITLE
chore(android): bump versionCode to 145

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 144
+        versionCode = 145
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Bumps the Android `versionCode` from 144 → 145 so the native Android SSE build (#1124) can be uploaded/installed for testing.

- `versionCode` only; `versionName` stays `3.10`.
- No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_