### PR TITLE
debug(stamp): log actual archived prev/cur value+type on re-stamp

### DIFF
--- a/src/hooks/useDataPersistence.js
+++ b/src/hooks/useDataPersistence.js
@@ -41,8 +41,23 @@ export default function useDataPersistence({
     let onRestamp;
     try {
       if (localStorage.getItem('dayglance-debug-stamp') === '1') {
-        onRestamp = ({ id, changedKeys }) =>
+        onRestamp = ({ id, changedKeys, changed, prev, cur }) => {
           console.warn(`[stamp] re-stamped ${storageKey} ${id} — changed:`, changedKeys);
+          // Ground truth: the ACTUAL old-vs-new value AND type for each changed
+          // field, so we can see EXACTLY what differs (undefined vs false vs true
+          // vs "false") rather than assuming. This is what pins the real mismatch.
+          (changed || []).forEach(({ key, prev: pv, cur: cv }) => {
+            console.warn(
+              `[stamp-debug] ${storageKey} ${id} ${key}: prev=`, pv, `(${typeof pv})`,
+              'cur=', cv, `(${typeof cv})`,
+            );
+          });
+          // Item context — reveals the auto-archive convergence path in one paste.
+          console.warn(`[stamp-debug] ${storageKey} ${id} context:`, {
+            prev: prev && { archived: prev.archived, completed: prev.completed, completedAt: prev.completedAt, lastModified: prev.lastModified },
+            cur: cur && { archived: cur.archived, completed: cur.completed, completedAt: cur.completedAt, lastModified: cur.lastModified },
+          });
+        };
       }
     } catch { /* ignore */ }
     return stampTimestamps(currentTasks, prev, new Date().toISOString(), onRestamp);

--- a/src/utils/stampTimestamps.js
+++ b/src/utils/stampTimestamps.js
@@ -83,7 +83,16 @@ export function stampTimestamps(currentTasks, prevTasks, now, onRestamp) {
         return { ...t, lastModified: prevTask.lastModified };
       }
       if (onRestamp) {
-        try { onRestamp({ id: t.id, changedKeys: diffKeys(prevTask, t) }); } catch { /* diagnostic must never throw */ }
+        // Include the RAW (pre-normalization) prev/cur value for each changed key
+        // so a debug build can log EXACTLY what differs — undefined vs false vs
+        // true vs a string — instead of us guessing. `changed` carries the raw
+        // values (not the `?? false`-normalized ones) so absent shows as undefined.
+        const changedKeys = diffKeys(prevTask, t);
+        const changed = changedKeys.map((k) => ({ key: k, prev: prevTask[k], cur: t[k] }));
+        // Also hand over the raw prev/cur so the logger can print item context
+        // (completed/completedAt/lastModified) — enough to tell in ONE paste whether
+        // this is the auto-archive convergence path or something else.
+        try { onRestamp({ id: t.id, changedKeys, changed, prev: prevTask, cur: t }); } catch { /* diagnostic must never throw */ }
       }
     }
     if (!prevTask && t.lastModified) return t;

--- a/src/utils/stampTimestamps.test.js
+++ b/src/utils/stampTimestamps.test.js
@@ -79,12 +79,19 @@ describe('stampTimestamps', () => {
   });
 
   describe('onRestamp diagnostic', () => {
-    it('reports the changed fields when an existing task is re-stamped', () => {
+    it('reports the changed fields (and raw prev/cur values) when a task is re-stamped', () => {
       const prev = [{ id: 1, title: 'A', completed: false, lastModified: ISO(100) }];
       const curr = [{ id: 1, title: 'A', completed: true, lastModified: ISO(100) }];
       const calls = [];
       stampTimestamps(curr, prev, 'NOW', (info) => calls.push(info));
-      expect(calls).toEqual([{ id: 1, changedKeys: ['completed'] }]);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].id).toBe(1);
+      expect(calls[0].changedKeys).toEqual(['completed']);
+      // Raw per-key values for the debug log (undefined/false/true ground truth).
+      expect(calls[0].changed).toEqual([{ key: 'completed', prev: false, cur: true }]);
+      // Raw objects handed through for item-context logging.
+      expect(calls[0].prev).toBe(prev[0]);
+      expect(calls[0].cur).toBe(curr[0]);
     });
 
     it('does NOT fire for unchanged tasks, default-only diffs, or new tasks', () => {


### PR DESCRIPTION
The prior `?? false` fix did **not** stop the cold-open re-stamp — the build still logs `changed: ['archived']`. Since `normalizeField` now equalizes absent≡false on both sides of the compare, a surviving `archived` diff means the **raw values genuinely differ** (one side `true`, the other `false`/absent) — a real value divergence, not a normalization gap. Rather than guess a third time, this instruments the actual values.

Gated behind the existing `dayglance-debug-stamp` flag (no behavior change):
- `stampTimestamps` hands the diagnostic the RAW per-key prev/cur value for each changed field, plus the raw prev/cur objects.
- `useDataPersistence` logs, per changed field:
  ```
  [stamp-debug] day-planner-unscheduled <id> archived: prev=<v>(<typeof>) cur=<v>(<typeof>)
  [stamp-debug] day-planner-unscheduled <id> context: { prev:{archived,completed,completedAt,lastModified}, cur:{…} }
  ```

Full renderer suite (534) + build green.

## How to use
1. Merge + build, then in the console set `localStorage['dayglance-debug-stamp'] = '1'` and reload (cold-open).
2. Paste the `[stamp-debug] … archived:` line and the `context:` line for a re-stamped item.

That single paste pins the real mismatch (undefined vs false vs true, and whether it's the auto-archive convergence path) — then I ship the exact both-sides fix + round-trip test, no more guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_