### PR TITLE
Fix archived being dropped on load (preserve across whole-entity LWW)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2372,7 +2372,9 @@ const DayPlanner = () => {
       if (!hasChanges) return prev;
       return prev.map(t =>
         (t.completed && !t.archived && t.completedAt && new Date(t.completedAt).getTime() < cutoff)
-          ? { ...t, archived: true }
+          // Stamp lastModified so the archive wins whole-entity LWW and isn't
+          // dropped by a newer non-archived copy from another device.
+          ? { ...t, archived: true, lastModified: new Date().toISOString() }
           : t
       );
     });
@@ -3192,16 +3194,30 @@ const DayPlanner = () => {
         return next;
       });
 
+      // App-only fields that live in dayGLANCE but NOT in the Obsidian markdown,
+      // so a re-parse (parseTasksFromMarkdown) can't reproduce them. They must be
+      // carried over from the existing in-memory copy or every cold-open re-sync
+      // silently wipes them — which for `archived`/`completedAt` on a completed
+      // task looked like a phantom change and re-stamped lastModified every load
+      // (the DB-sync push churn). Only carry a value that is actually present so we
+      // never inject undefined keys.
+      const preserveObsidianAppFields = (old) => ({
+        ...(old.projectId ? { projectId: old.projectId } : {}),
+        ...(old.deadline ? { deadline: old.deadline } : {}),
+        ...(old.archived !== undefined ? { archived: old.archived } : {}),
+        ...(old.completedAt !== undefined ? { completedAt: old.completedAt } : {}),
+      });
+
       // Update tasks — remove old Obsidian imports, add fresh ones.
-      // Preserve app-only fields (projectId, deadline) that aren't stored in the
-      // Obsidian markdown and would otherwise be wiped on every re-sync.
+      // Preserve app-only fields that aren't stored in the Obsidian markdown and
+      // would otherwise be wiped on every re-sync.
       setTasks(prev => {
         const nonObsidian = prev.filter(t => t.importSource !== 'obsidian');
         const oldObsidianMap = new Map(prev.filter(t => t.importSource === 'obsidian').map(t => [String(t.id), t]));
         const merged = result.scheduledTasks.map(t => {
           const old = oldObsidianMap.get(String(t.id));
           if (!old) return t;
-          return { ...t, ...(old.projectId ? { projectId: old.projectId } : {}), ...(old.deadline ? { deadline: old.deadline } : {}) };
+          return { ...t, ...preserveObsidianAppFields(old) };
         });
         return [...nonObsidian, ...merged];
       });
@@ -3215,7 +3231,7 @@ const DayPlanner = () => {
         const merged = result.inboxTasks.map(t => {
           const old = oldObsidianMap.get(String(t.id));
           if (!old) return t;
-          return { ...t, ...(old.projectId ? { projectId: old.projectId } : {}), ...(old.deadline ? { deadline: old.deadline } : {}) };
+          return { ...t, ...preserveObsidianAppFields(old) };
         });
         return [...nonObsidian, ...merged];
       });
@@ -7528,11 +7544,17 @@ const DayPlanner = () => {
   clearDeadlineRef.current = clearDeadline;
   moveToInboxRef.current = moveToInbox;
 
+  // Archiving/unarchiving IS a modification, so it must bump lastModified — the
+  // sync engines resolve tasks by whole-entity last-writer-wins, so without a
+  // fresh timestamp the archived copy loses to any newer non-archived copy from
+  // another device and `archived` is silently dropped (habits already stamp on
+  // archive; tasks didn't). The stamp also lets an unarchive propagate instead of
+  // being clobbered by a stale archived:true elsewhere.
   const archiveInboxTask = (id) => {
-    setUnscheduledTasks(prev => prev.map(t => t.id === id ? { ...t, archived: true } : t));
+    setUnscheduledTasks(prev => prev.map(t => t.id === id ? { ...t, archived: true, lastModified: new Date().toISOString() } : t));
   };
   const restoreArchivedInboxTask = (id) => {
-    setUnscheduledTasks(prev => prev.map(t => t.id === id ? { ...t, archived: false } : t));
+    setUnscheduledTasks(prev => prev.map(t => t.id === id ? { ...t, archived: false, lastModified: new Date().toISOString() } : t));
   };
 
   // Focus mode availability: current task or back-to-back block >= 45 min remaining

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -338,5 +338,31 @@ export const mergeSyncData = (local, remote, retentionDays) => {
       if (Object.prototype.hasOwnProperty.call(local, tsKey)) result.data[tsKey] = local[tsKey];
     }
   }
+
+  // Preserve the "sticky" `archived` flag across whole-entity LWW. The upstream
+  // merge keeps the newer copy WHOLE, so if that copy simply never carried
+  // `archived` (a device that never archived the item, edited later), the archive
+  // is dropped — which then re-stamps lastModified on every cold-open (the DB-sync
+  // push churn). Restore archived:true when the merged winner OMITS it (undefined)
+  // but either original side had archived:true. An explicit archived:false is a
+  // real unarchive (present, not undefined) → left as-is so it still propagates.
+  for (const listKey of ['tasks', 'unscheduledTasks', 'recycleBin']) {
+    const mergedList = result.data[listKey];
+    if (!Array.isArray(mergedList)) continue;
+    const localById = new Map((local?.[listKey] || []).map((t) => [String(t.id), t]));
+    const remoteById = new Map((remote?.[listKey] || []).map((t) => [String(t.id), t]));
+    for (const item of mergedList) {
+      if (!item || item.archived !== undefined) continue;
+      const l = localById.get(String(item.id));
+      const r = remoteById.get(String(item.id));
+      if (l?.archived === true || r?.archived === true) {
+        item.archived = true;
+        // The side whose copy we enriched needs the corrected value written back.
+        if (l?.archived !== true) result.localChanged = true;
+        if (r?.archived !== true) result.remoteChanged = true;
+      }
+    }
+  }
+
   return result;
 };

--- a/src/sync/archivedPreservation.test.js
+++ b/src/sync/archivedPreservation.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { mergeSyncData } from '../mergeSync.js';
+import { applyRemoteEntity } from './dbAdapter.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regression: the `archived` flag survives whole-entity last-writer-wins on BOTH
+// sync transports.
+//
+// Root cause (confirmed by reproduction): archiving a task did not bump
+// `lastModified`, so an older archived copy loses LWW to a newer copy from a
+// device that never archived it. Both the file-tier merge (mergeArrayById, whole
+// winner) and the vault merge (upsertCollection, whole replace) then drop
+// `archived`, leaving the in-memory task with `archived: undefined` while storage
+// keeps `archived: true` — a phantom diff that re-stamps lastModified on every
+// cold-open (the DB-sync push churn / SSE self-nudge).
+//
+// The fix carries `archived: true` forward when the LWW winner OMITS it (undefined)
+// but either side had it, while an explicit `archived: false` (a real unarchive)
+// still propagates. Complemented by the write side stamping lastModified on
+// archive/unarchive (in App.jsx) so future toggles win LWW outright.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const item = (extra) => ({
+  id: 'x1', title: 'old inbox', completed: true, completedAt: '2026-06-21',
+  lastModified: '2026-06-21T10:00:00.000Z', ...extra,
+});
+
+describe('file-tier mergeSyncData preserves archived across LWW', () => {
+  it('local archived:true vs a NEWER remote without archived → archived kept', () => {
+    const local = { unscheduledTasks: [item({ archived: true })] };
+    const remote = { unscheduledTasks: [item({ lastModified: '2026-07-01T10:00:00.000Z' })] };
+    const { data } = mergeSyncData(local, remote, 90);
+    expect(data.unscheduledTasks[0].archived).toBe(true);       // not dropped
+    expect(data.unscheduledTasks[0].completedAt).toBe('2026-06-21'); // other fields intact
+  });
+
+  it('honors a real unarchive: NEWER remote archived:false wins over local archived:true', () => {
+    const local = { unscheduledTasks: [item({ archived: true })] };
+    const remote = { unscheduledTasks: [item({ archived: false, lastModified: '2026-07-01T10:00:00.000Z' })] };
+    const { data } = mergeSyncData(local, remote, 90);
+    expect(data.unscheduledTasks[0].archived).toBe(false); // explicit false is not clobbered
+  });
+
+  it('remote archived:true vs a NEWER local without archived → archived kept', () => {
+    const local = { unscheduledTasks: [item({ lastModified: '2026-07-01T10:00:00.000Z' })] };
+    const remote = { unscheduledTasks: [item({ archived: true })] };
+    const { data } = mergeSyncData(local, remote, 90);
+    expect(data.unscheduledTasks[0].archived).toBe(true);
+  });
+
+  it('a never-archived task stays absent (no archived key injected)', () => {
+    const local = { unscheduledTasks: [item()] };
+    const remote = { unscheduledTasks: [item({ lastModified: '2026-07-01T10:00:00.000Z' })] };
+    const { data } = mergeSyncData(local, remote, 90);
+    expect(data.unscheduledTasks[0].archived).toBeUndefined();
+  });
+});
+
+describe('vault applyRemoteEntity preserves archived across LWW', () => {
+  it('pulling a remote task WITHOUT archived over local archived:true keeps it + re-pushes', () => {
+    const data = { unscheduledTasks: [item({ archived: true })] };
+    const pulled = { _kind: 'unscheduledTasks', value: item({ lastModified: '2026-07-01T10:00:00.000Z' }) };
+    const rePush = applyRemoteEntity(data, pulled);
+    expect(data.unscheduledTasks[0].archived).toBe(true);   // carried forward
+    expect(rePush).toHaveLength(1);                          // vault converges to the superset
+  });
+
+  it('pulling an explicit archived:false (unarchive) is honored, no re-push', () => {
+    const data = { unscheduledTasks: [item({ archived: true })] };
+    const pulled = { _kind: 'unscheduledTasks', value: item({ archived: false, lastModified: '2026-07-01T10:00:00.000Z' }) };
+    const rePush = applyRemoteEntity(data, pulled);
+    expect(data.unscheduledTasks[0].archived).toBe(false);
+    expect(rePush).toEqual([]);
+  });
+
+  it('pulling over a non-archived local leaves it absent, no re-push', () => {
+    const data = { unscheduledTasks: [item()] };
+    const pulled = { _kind: 'unscheduledTasks', value: item({ lastModified: '2026-07-01T10:00:00.000Z' }) };
+    const rePush = applyRemoteEntity(data, pulled);
+    expect(data.unscheduledTasks[0].archived).toBeUndefined();
+    expect(rePush).toEqual([]);
+  });
+});

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -293,8 +293,25 @@ function upsertCollection(data, kind, value) {
   const idOf = (x) => String(x[cfg.idField] ?? x.id);
   const id = idOf(value);
   const idx = data[kind].findIndex((x) => x != null && idOf(x) === id);
-  if (idx >= 0) data[kind][idx] = value;
-  else data[kind].push(value);
+  if (idx >= 0) {
+    // Whole-entity LWW replaces the local row with the pulled winner. But a
+    // "sticky" app-only flag the winner never carried — `archived` — would be
+    // silently lost: archiving didn't always bump lastModified, so an older
+    // archived copy can be beaten by a newer copy from a device that never
+    // archived it. Carry archived forward when the winner OMITS it (undefined)
+    // but our local copy had archived:true. An explicit archived:false on the
+    // winner is a real unarchive and is honored (not undefined → not carried).
+    const local = data[kind][idx];
+    const merged = (value && value.archived === undefined && local && local.archived === true)
+      ? { ...value, archived: true }
+      : value;
+    data[kind][idx] = merged;
+    // Re-push when we enriched the pulled row so the vault converges to the
+    // superset (mirrors the bundle-superset re-push).
+    return merged !== value ? [makeEntityId(kind, id)] : [];
+  }
+  data[kind].push(value);
+  return [];
 }
 
 // Apply one pulled row, merging it into `data`. Returns an array of entityIds
@@ -314,8 +331,7 @@ export function applyRemoteEntity(data, entity) {
     return applyRemoteRecurring(data, entity.value);
   }
   if (COLLECTION_KINDS[kind]) {
-    upsertCollection(data, kind, entity.value);
-    return [];
+    return upsertCollection(data, kind, entity.value);
   }
   if (kind === DATE_MAP_KIND) {
     if (!data[DATE_MAP_KIND] || typeof data[DATE_MAP_KIND] !== 'object') data[DATE_MAP_KIND] = {};


### PR DESCRIPTION
## The real root cause (measured, not guessed)

The `[stamp-debug]` instrumentation gave ground truth: a `completed:true` + `archived:true` inbox task loads into state with **`archived: undefined`** while localStorage keeps **`archived: true`** — a phantom diff that re-stamps `lastModified` every cold-open, driving the DB-sync push churn / SSE self-nudge. Only completed+archived items trip it, which is why it reproduced on the MAS build's data but not dev.

The prior `?? false` fix couldn't help: this is a genuine `true`-vs-`undefined` divergence, not an absent≡false normalization gap.

**Root cause:** the sync engines resolve tasks by **whole-entity last-writer-wins**, and archiving never bumped `lastModified` (habits do; tasks didn't). So an older archived copy loses LWW to a newer copy from a device that never archived it, and the winner — pushed/replaced whole — drops the app-only `archived` flag. Reproduced directly: `local archived:true` + newer `remote` without archived → merged loses `archived` (while `completedAt`, which the remote *did* carry, survives — matching the captured values exactly).

## Fix (both sides)

- **Write side** (`App.jsx`): archive/unarchive now bump `lastModified` (auto-archive, `archiveInboxTask`, `restoreArchivedInboxTask`) so the toggle wins LWW outright and an unarchive propagates instead of being clobbered.
- **Merge side — file-tier** (`mergeSync.js`): after the upstream merge, restore `archived:true` when the winner omits it (`undefined`) but either side had it; an explicit `archived:false` (real unarchive) is left to propagate. **Heals existing archived items** with a stale `lastModified` — no migration needed.
- **Merge side — vault** (`dbAdapter.js` `upsertCollection`): same carry-forward when a pulled row replaces a local `archived:true`, and re-push the enriched superset so the vault converges.
- **Obsidian re-sync** (`App.jsx:3204/3218`): the re-import rebuilt tasks preserving only `projectId`/`deadline`, wiping other app-only fields absent from markdown. Now also preserves `archived` + `completedAt` (a second, state-only archived-drop path the investigation surfaced).

## Tests
`src/sync/archivedPreservation.test.js` — `archived` survives a newer no-archived winner on **both** transports; a real unarchive still propagates; a never-archived task stays absent (no injected key). Full suite **541** + build + lint green.

## Verify on-device
The `[stamp-debug]` value logging is **intentionally left in** so you can confirm the fix: with `dayglance-debug-stamp='1'`, a cold-open should log **no** `changed: ['archived']` re-stamp and stop pushing these items. Once you confirm, I'll strip the instrumentation in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_