### PR TITLE
debug(archived): capture setter call-site stack (probe fix)

### DIFF
--- a/src/utils/debugArchivedProbe.js
+++ b/src/utils/debugArchivedProbe.js
@@ -71,15 +71,21 @@ export function installUnscheduledStoreProbe() {
  * @param {Function} rawSetter  the useState setter to wrap
  */
 export function probeSetter(label, rawSetter) {
-  return (update) =>
-    rawSetter((prev) => {
+  return (update) => {
+    // Capture the stack at the CALL SITE (synchronously, now). The strip check has
+    // to run inside the functional updater — but that updater is invoked LATER by
+    // React during render, so a console.trace in there traces the render, not the
+    // caller. So we snapshot the call-site stack here and only print it if the
+    // resulting update turns out to strip archived.
+    const callSite = debugOn() ? new Error('call-site') : null;
+    return rawSetter((prev) => {
       const next = typeof update === 'function' ? update(prev) : update;
-      if (debugOn() && Array.isArray(next) && Array.isArray(prev)) {
+      if (callSite && Array.isArray(next) && Array.isArray(prev)) {
         try {
           const stripped = strippedIds(prev, next);
           if (stripped.length) {
             console.warn(`[archived-set] ${label} STRIPPED archived for`, stripped, '(true → undefined)');
-            console.trace(`[archived-set] ↑ stack of the ${label} call`);
+            console.warn(`[archived-set] ↑ CALL-SITE stack (the code that called ${label}):\n`, callSite.stack);
           }
         } catch {
           /* diagnostic must never throw */
@@ -87,4 +93,5 @@ export function probeSetter(label, rawSetter) {
       }
       return next;
     });
+  };
 }


### PR DESCRIPTION
Fixes the setter probe from #1129 so it names the **actual caller** of `setUnscheduledTasks` that strips `archived`.

**What the first probe got wrong:** the strip check ran *inside* the functional updater, which React invokes during render — so `console.trace` traced React internals + the component, not the code that called the setter. Now it captures `new Error()` at the synchronous call site and prints that stack only when the update strips `archived`.

## Ground truth captured so far
- Store probe: `commitData` (applyEngineData) **healed** the obsidian item, stripped 0 — the #1127 carry-forward is working.
- Setter probe: a `setUnscheduledTasks` call strips `archived` (`true → undefined`) on **24 regular (UUID) inbox items**, effect-driven, **after** the heal.
- **Not** the Obsidian re-sync: `syncObsidianVault` only rebuilds obsidian-id items (`allInbox` is built from parsed markdown); the App-level setter keeps non-obsidian items as-is. The 24 stripped ids are UUIDs, not `obsidian-…`.

The call-site stack from this build will name the exact effect/caller.

Lint + build green.

## How to use
Merge, build, `dayglance-debug-stamp='1'`, cold-open, and paste the **`[archived-set] … CALL-SITE stack`** block for the 24-item strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_