### PR TITLE
fix(sync): stop applyEngineData from stripping archived (keeps debug in to verify)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import { checkForUpdate } from './versionCheck.js';
 import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { tombstoneHorizon } from './utils/tombstoneHorizon.js';
 import { installUnscheduledStoreProbe, probeSetter } from './utils/debugArchivedProbe.js';
+import { preserveArchived } from './utils/preserveArchived.js';
 import { stripHealthSourcedLogs } from './utils/healthLogFilter.js';
 import { webdavFetch } from './utils/cloudSyncProviders.js';
 import { autoBackupDB, createAutoBackupProvidersForFolder, AUTO_BACKUP_RETENTION, AUTO_BACKUP_INTERVALS } from './utils/autoBackup.js';
@@ -5923,6 +5924,15 @@ const DayPlanner = () => {
     // tasks appear newer than actual remote changes during merge.
     const normalizeTasks = (tasks) => tasks.map(t => ({ ...t, notes: t.notes ?? '', subtasks: t.subtasks ?? [] }));
 
+    // Preserve the app-only `archived` flag from the CURRENT in-memory copy when
+    // the merged/remote copy OMITS it — otherwise this apply silently un-archives
+    // items and re-stamps lastModified every sync (confirmed via the archived
+    // probe: applyEngineData is the second-pass stripper). A real remote unarchive
+    // sends archived:false explicitly and still propagates; only an ABSENT flag
+    // falls back to local. Keyed across both lists so a scheduled↔inbox move still
+    // matches. See utils/preserveArchived.js.
+    const existingArchivedList = [...tasks, ...unscheduledTasks];
+
     // Drop CalDAV-imported calendar events from the cloud sync payload — they are ephemeral
     // derivatives of the remote feed and must not be cloud-synced or the merge engine will
     // resurrect deleted events. On native, the OS bridge re-provides them; on PWA, CalDAV
@@ -5934,8 +5944,8 @@ const DayPlanner = () => {
       !(t.imported && !t.isTaskCalendar && t.importSource !== 'file')
       && !(multiUserEnabled && t.imported && t.importSource === 'sync'));
 
-    const normalizedTasks = data.tasks ? filterTasks(normalizeTasks(data.tasks)) : null;
-    const normalizedUnsched = data.unscheduledTasks ? filterTasks(normalizeTasks(data.unscheduledTasks)) : null;
+    const normalizedTasks = data.tasks ? preserveArchived(filterTasks(normalizeTasks(data.tasks)), existingArchivedList) : null;
+    const normalizedUnsched = data.unscheduledTasks ? preserveArchived(filterTasks(normalizeTasks(data.unscheduledTasks)), existingArchivedList) : null;
 
     // Update localStorage
     if (normalizedTasks) localStorage.setItem('day-planner-tasks', JSON.stringify(normalizedTasks));

--- a/src/utils/preserveArchived.js
+++ b/src/utils/preserveArchived.js
@@ -1,0 +1,28 @@
+// Preserve the app-only `archived` flag across a sync/merge apply.
+//
+// `archived` is a dayGLANCE-local flag. A remote row from a device that never
+// archived the item — or an older row the whole-entity last-writer-wins merge
+// picked without it — arrives with `archived` ABSENT. Applying that copy as-is
+// silently un-archives the item AND, because it differs from the healed in-memory
+// state, re-stamps `lastModified` on every sync — an endless push/strip churn.
+//
+// Rule: when the incoming copy OMITS `archived` (value is `undefined`), fall back
+// to the current in-memory value. A genuine remote unarchive sends
+// `archived: false` EXPLICITLY, which is NOT `undefined`, so it is left untouched
+// and still propagates. Items are matched by id.
+//
+// @param {object[]} incoming  the merged/remote tasks about to be applied
+// @param {object[]} existing  the current in-memory tasks (source of the local flag)
+// @returns {object[]} incoming with `archived` back-filled where it was absent
+export function preserveArchived(incoming, existing) {
+  const local = new Map(
+    (existing || [])
+      .filter((t) => t && t.archived !== undefined)
+      .map((t) => [String(t.id), t.archived]),
+  );
+  return (incoming || []).map((t) => {
+    if (!t || t.archived !== undefined) return t;
+    const localArchived = local.get(String(t.id));
+    return localArchived === undefined ? t : { ...t, archived: localArchived };
+  });
+}

--- a/src/utils/preserveArchived.test.js
+++ b/src/utils/preserveArchived.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { preserveArchived } from './preserveArchived.js';
+
+// The applyEngineData second-pass strip: a merged/remote copy that OMITS `archived`
+// must not silently un-archive a locally-archived item (which also caused the
+// re-stamp/push churn). A real remote unarchive (archived:false explicit) still wins.
+
+describe('preserveArchived', () => {
+  it('back-fills archived:true when the incoming copy omits it (the churn fix)', () => {
+    const existing = [{ id: 'a', archived: true }];
+    const incoming = [{ id: 'a', title: 'x' }]; // merged row dropped archived
+    expect(preserveArchived(incoming, existing)).toEqual([{ id: 'a', title: 'x', archived: true }]);
+  });
+
+  it('does NOT override an explicit remote unarchive (archived:false propagates)', () => {
+    const existing = [{ id: 'a', archived: true }];
+    const incoming = [{ id: 'a', title: 'x', archived: false }];
+    expect(preserveArchived(incoming, existing)[0].archived).toBe(false);
+  });
+
+  it('leaves a never-archived item alone (no archived key injected)', () => {
+    const existing = [{ id: 'a' }];
+    const incoming = [{ id: 'a', title: 'x' }];
+    const out = preserveArchived(incoming, existing);
+    expect('archived' in out[0]).toBe(false);
+  });
+
+  it('carries a local archived:false forward when incoming omits it', () => {
+    // Local explicitly un-archived; incoming (older) lacks the flag → keep local false.
+    const existing = [{ id: 'a', archived: false }];
+    const incoming = [{ id: 'a', title: 'x' }];
+    expect(preserveArchived(incoming, existing)[0].archived).toBe(false);
+  });
+
+  it('an incoming archived:true is kept even if local lacks it', () => {
+    const existing = [{ id: 'a' }];
+    const incoming = [{ id: 'a', archived: true }];
+    expect(preserveArchived(incoming, existing)[0].archived).toBe(true);
+  });
+
+  it('matches by id across both lists (scheduled↔inbox move) and ignores unmatched', () => {
+    const existing = [{ id: 'sched-1', archived: true }, { id: 'inbox-9', archived: true }];
+    const incoming = [{ id: 'inbox-9', title: 'moved' }, { id: 'new-1', title: 'fresh' }];
+    const out = preserveArchived(incoming, existing);
+    expect(out[0].archived).toBe(true);          // matched → healed
+    expect('archived' in out[1]).toBe(false);     // no local match → untouched
+  });
+
+  it('handles empty/undefined inputs without throwing', () => {
+    expect(preserveArchived(undefined, undefined)).toEqual([]);
+    expect(preserveArchived([], [{ id: 'a', archived: true }])).toEqual([]);
+    expect(preserveArchived([{ id: 'a' }], undefined)).toEqual([{ id: 'a' }]);
+  });
+
+  it('the 24-item repro: all locally-archived items survive a merge that dropped archived', () => {
+    const ids = Array.from({ length: 24 }, (_, i) => `id-${i}`);
+    const existing = ids.map((id) => ({ id, completed: true, archived: true }));
+    const incoming = ids.map((id) => ({ id, completed: true })); // vault row without archived
+    const out = preserveArchived(incoming, existing);
+    expect(out.every((t) => t.archived === true)).toBe(true);
+  });
+});


### PR DESCRIPTION
## The fix
The archived probe named the second-pass stripper: the vault DB engine's `commitData → applyPayload` (`applyEngineData`) rebuilds `unscheduledTasks` from the merged payload, and `normalizeTasks` defaulted `notes`/`subtasks` but **not `archived`**. When the merged/remote copy omits `archived`, applying it as-is silently un-archives the item and — differing from the healed in-memory state — re-stamps `lastModified` every sync: the endless push/strip churn.

`applyEngineData` now preserves the app-only `archived` flag from the current in-memory copy when the incoming copy **omits** it (`undefined`). A real remote unarchive sends `archived:false` **explicitly**, so it still propagates. Applied to both scheduled + inbox, matched by id across both lists. Extracted to `utils/preserveArchived.js`.

## User impact
Archived completed inbox items **stay archived** (they stop creeping back into the inbox), and the constant background sync churn stops. A deliberate unarchive on another device still works.

## Debug intentionally kept IN
Per request — the `[archived-set]`/`[archived-store]` probes, `[stamp-debug]`, and the `setUnscheduledTasks` wrapper are **still in** so you can confirm the fix on-device before cleanup.

## Tests
`utils/preserveArchived.test.js` (8): the 24-item repro, explicit-unarchive propagation, never-archived untouched, local `false` carried, id-match across lists, empty inputs. Full suite **549** + lint + build green.

## Verify on-device
Build, `dayglance-debug-stamp='1'`, cold-open a few times. Expect: **no** `[archived-set] … STRIPPED` for those 24 items, no `changed: ['archived']` re-stamp, and the drain/push loop settles. Once you're satisfied, I'll ship a follow-up that strips all the debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_