### PR TITLE
fix(sync): preserve archived against fresh state (prev + live refs)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -333,6 +333,16 @@ const DayPlanner = () => {
   selectedDateRef.current = selectedDate;
   const [tasks, setTasks] = useState([]);
   const [unscheduledTasks, _setUnscheduledTasks] = useState([]);
+  // Live refs to the current task state, reassigned every render. applyEngineData
+  // runs from an async sync cycle and its closure can predate loadData / the heal
+  // render, so reading `tasks`/`unscheduledTasks` directly there is STALE — the
+  // archived-preservation must read these refs (whose `.current` is always the
+  // latest committed state) or it back-fills from an empty/undefined baseline and
+  // the strip goes through anyway.
+  const tasksLiveRef = useRef(tasks);
+  tasksLiveRef.current = tasks;
+  const unscheduledLiveRef = useRef(unscheduledTasks);
+  unscheduledLiveRef.current = unscheduledTasks;
   // DEBUG (gated by localStorage 'dayglance-debug-stamp'): wrap the inbox setter so
   // the exact call that strips `archived` (true → undefined) logs a stack trace.
   // Transparent passthrough otherwise — see utils/debugArchivedProbe.js. Stable
@@ -5929,9 +5939,10 @@ const DayPlanner = () => {
     // items and re-stamps lastModified every sync (confirmed via the archived
     // probe: applyEngineData is the second-pass stripper). A real remote unarchive
     // sends archived:false explicitly and still propagates; only an ABSENT flag
-    // falls back to local. Keyed across both lists so a scheduled↔inbox move still
-    // matches. See utils/preserveArchived.js.
-    const existingArchivedList = [...tasks, ...unscheduledTasks];
+    // falls back to local. Read the LIVE refs (not the closure, which can predate
+    // the heal render) for the localStorage writes; the setState calls below use
+    // their own `prev` (the authoritative current state). See utils/preserveArchived.js.
+    const existingArchivedList = [...tasksLiveRef.current, ...unscheduledLiveRef.current];
 
     // Drop CalDAV-imported calendar events from the cloud sync payload — they are ephemeral
     // derivatives of the remote feed and must not be cloud-synced or the merge engine will
@@ -6104,13 +6115,19 @@ const DayPlanner = () => {
     // hasn't rendered yet.  Without this, those queued imported events are
     // silently discarded by the replacement, causing them to vanish until the
     // next calendar sync re-imports them.
+    // Preserve archived against `prev` — the ACTUAL current state at update time,
+    // which React guarantees is fresh (the closure/refs above can lag the very
+    // latest heal). This is what stops the setState from clobbering a locally-
+    // archived item when the merged copy omits the flag.
     if (normalizedTasks) setTasks(prev => {
-      const mergedIds = new Set(normalizedTasks.map(t => String(t.id)));
-      return [...normalizedTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
+      const preserved = preserveArchived(normalizedTasks, prev);
+      const mergedIds = new Set(preserved.map(t => String(t.id)));
+      return [...preserved, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
     });
     if (normalizedUnsched) setUnscheduledTasks(prev => {
-      const mergedIds = new Set(normalizedUnsched.map(t => String(t.id)));
-      return [...normalizedUnsched, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
+      const preserved = preserveArchived(normalizedUnsched, prev);
+      const mergedIds = new Set(preserved.map(t => String(t.id)));
+      return [...preserved, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
     });
     if (data.unscheduledOrderTimestamp) {
       setUnscheduledOrderTimestamp(data.unscheduledOrderTimestamp);


### PR DESCRIPTION
Follow-up to #1131, which didn't take. The probe showed exactly why: my preservation read `applyEngineData`'s **closure** (`tasks`/`unscheduledTasks`), which is **stale** — it can predate the `loadData`/heal render, so it back-filled from an empty baseline and the strip still happened. Meanwhile the probe showed the setter's `prev` genuinely held `archived:true`.

So this preserves against the **authoritative current state**:
- **setState** back-fills against `prev` (React-guaranteed current) — the exact value the probe showed holds `archived:true`, so it stops the strip head-on.
- **localStorage writes** back-fill against live refs (`tasksLiveRef`/`unscheduledLiveRef`, reassigned every render) instead of the stale closure.

`preserveArchived` only fills an *absent* flag, so applying it at both stages is idempotent and safe; an explicit remote unarchive still propagates.

Debug instrumentation still **in** for your on-device check. Full suite **549** + lint + build green.

## On-device
Build, `dayglance-debug-stamp='1'`, cold-open a few times: the `[archived-set] … STRIPPED (true → undefined)` line should be **gone**, and the `[stamp] … changed:['archived']` churn should stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_