### PR TITLE
Bump Android versionCode to 146

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 145
+        versionCode = 146
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Bumps the Android `versionCode` from 145 to 146 in `dayglance-android/app/build.gradle.kts`. `versionName` stays at 3.10. No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DK6cDssPcK5qDfkS97ASey

---
_Generated by [Claude Code](https://claude.ai/code/session_01DK6cDssPcK5qDfkS97ASey)_