### PR TITLE
Decouple tombstone retention from "Keep past events" (fixed 60-day GC)

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 146
+        versionCode = 147
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -3,6 +3,12 @@
 // mergeTaskArrays pins timestampField rather than re-exporting the alias
 // directly (which would default to `updatedAt`).
 import { mergeArrayById, mergeSyncData as upstreamMergeSyncData, pruneTombstones } from '@glance-apps/sync';
+import {
+  TOMBSTONE_BUNDLE_KEYS,
+  tombstoneCutoff,
+  pruneTombstoneMap,
+  unionNewerIso as unionTombstones,
+} from './sync/tombstoneRetention.js';
 
 export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =>
   mergeArrayById(local, remote, deletedIds, syncHorizon, { timestampField: 'lastModified' });
@@ -241,6 +247,13 @@ const sameDateSet = (a = [], b = []) => {
   return sa.size === sb.size && [...sa].every((x) => sb.has(x));
 };
 
+// Same keys, same values (order-insensitive) — used to decide whether the
+// 60-day tombstone override actually changed a bundle vs one side.
+const tombstoneMapsEqual = (a = {}, b = {}) => {
+  const ak = Object.keys(a), bk = Object.keys(b);
+  return ak.length === bk.length && ak.every((k) => a[k] === b[k]);
+};
+
 /**
  * Full-sync merge. Delegates to the upstream merge, then overrides the
  * habit-log portion with the deterministic tie-break above so existing stuck
@@ -248,6 +261,11 @@ const sameDateSet = (a = [], b = []) => {
  */
 export const mergeSyncData = (local, remote, retentionDays) => {
   const result = upstreamMergeSyncData(local, remote, retentionDays);
+  // Tombstone GC is its OWN fixed 60-day policy (src/sync/tombstoneRetention.js),
+  // NOT the user's "Keep past events" window (retentionDays). retentionDays still
+  // prunes imported events (completedTaskUids) inside the upstream merge above;
+  // we override only the tombstone bundles below so both sync transports agree.
+  const tsCutoff = tombstoneCutoff();
   const habitLogsFix = mergeHabitLogs(
     local?.habitLogs || {},
     remote?.habitLogs || {},
@@ -320,8 +338,8 @@ export const mergeSyncData = (local, remote, retentionDays) => {
       { timestampField: 'updatedAt' },
     );
     result.data.areas = areasMerge.merged;
-    const cutoff = retentionDays > 0 ? new Date(Date.now() - retentionDays * 86400000) : null;
-    result.data.deletedAreaIds = pruneTombstones(allDeletedAreaIds, cutoff);
+    // Tombstones prune at the fixed 60-day window, not the event-retention setting.
+    result.data.deletedAreaIds = pruneTombstoneMap(allDeletedAreaIds, tsCutoff);
     if (areasMerge.localChanged) result.localChanged = true;
     if (areasMerge.remoteChanged) result.remoteChanged = true;
   }
@@ -362,6 +380,20 @@ export const mergeSyncData = (local, remote, retentionDays) => {
         if (r?.archived !== true) result.remoteChanged = true;
       }
     }
+  }
+
+  // Override the upstream tombstone pruning (which used `retentionDays`) with the
+  // fixed 60-day window so the file-tier and the vault DB tier keep the SAME set.
+  // Reconstruct each bundle from both sides' raw maps (grow-union, newest ts per
+  // id) then prune at 60 days. deletedAreaIds is handled in the areas block above.
+  for (const key of TOMBSTONE_BUNDLE_KEYS) {
+    if (key === 'deletedAreaIds') continue;
+    const merged = pruneTombstoneMap(unionTombstones(local?.[key], remote?.[key]), tsCutoff);
+    result.data[key] = merged;
+    // Only ever RAISE the change flags (never clear another writer's true): if the
+    // 60-day set differs from a side, that side needs the corrected bundle written.
+    if (!tombstoneMapsEqual(merged, local?.[key] || {})) result.localChanged = true;
+    if (!tombstoneMapsEqual(merged, remote?.[key] || {})) result.remoteChanged = true;
   }
 
   return result;

--- a/src/mergeSync.test.js
+++ b/src/mergeSync.test.js
@@ -1925,8 +1925,10 @@ describe('mergeSyncData — tombstone pruning', () => {
     minimizedSections: {}, use24HourClock: false
   });
 
-  it('prunes tombstones older than retention window', () => {
-    const oldTs = new Date(Date.now() - 100 * 86400000).toISOString(); // 100 days ago
+  const daysAgo = (n) => new Date(Date.now() - n * 86400000).toISOString();
+
+  it('prunes tombstones older than the fixed 60-day window', () => {
+    const oldTs = daysAgo(100);
     const recentTs = ts(5); // 5 min ago
     const local = {
       ...emptyData(),
@@ -1945,16 +1947,55 @@ describe('mergeSyncData — tombstone pruning', () => {
     expect(data.removedTodayRoutineIds['old-routine']).toBeUndefined();
   });
 
-  it('keeps all tombstones when retentionDays is 0', () => {
-    const oldTs = new Date(Date.now() - 365 * 86400000).toISOString(); // 1 year ago
+  // ── The heartbeat-loop fix: tombstone GC is decoupled from "Keep past events".
+  // A tombstone inside the fixed 60-day window MUST survive even when the user set
+  // event retention as low as 30 days. Before the fix the file-tier pruned it at 30
+  // while the grow-only vault re-added it, oscillating the singleton every cycle.
+  it('KEEPS a 45-day tombstone even when event retention is 30 days', () => {
+    const local = { ...emptyData(), deletedTaskIds: { 'deleted-45d': daysAgo(45) } };
+    const { data } = mergeSyncData(local, emptyData(), 30);
+    expect(data.deletedTaskIds['deleted-45d']).toBeDefined();
+  });
+
+  it('prunes a 70-day tombstone regardless of a longer event-retention setting', () => {
+    const local = { ...emptyData(), deletedTaskIds: { 'deleted-70d': daysAgo(70) } };
+    const { data } = mergeSyncData(local, emptyData(), 365);
+    expect(data.deletedTaskIds['deleted-70d']).toBeUndefined();
+  });
+
+  it('retentionDays=0 keeps events forever but STILL GCs tombstones at 60 days', () => {
     const local = {
       ...emptyData(),
-      deletedTaskIds: { 'ancient': oldTs },
+      deletedTaskIds: { 'ancient': daysAgo(365), 'recent': daysAgo(10) },
+      completedTaskUids: ['evt::2020-01-01'], // 5+ years old imported event UID
     };
-    const remote = emptyData();
+    const { data } = mergeSyncData(local, emptyData(), 0);
+    // Events: "Keep past events = All" → the ancient UID survives.
+    expect(data.completedTaskUids).toContain('evt::2020-01-01');
+    // Tombstones: fixed 60-day GC, independent of the event setting.
+    expect(data.deletedTaskIds['ancient']).toBeUndefined();
+    expect(data.deletedTaskIds['recent']).toBeDefined();
+  });
 
-    const { data } = mergeSyncData(local, remote, 0);
-    expect(data.deletedTaskIds['ancient']).toBeDefined();
+  it('event retention (completedTaskUids) still honors the user setting, tombstones do not', () => {
+    // 40-day-old event UID + 40-day-old tombstone, event retention = 30 days.
+    const local = {
+      ...emptyData(),
+      deletedTaskIds: { 'deleted-40d': daysAgo(40) },
+      completedTaskUids: ['evt::' + daysAgo(40).slice(0, 10)],
+    };
+    const { data } = mergeSyncData(local, emptyData(), 30);
+    // Event dropped at 30 days (user setting); tombstone kept under the 60-day floor.
+    expect(data.completedTaskUids).toHaveLength(0);
+    expect(data.deletedTaskIds['deleted-40d']).toBeDefined();
+  });
+
+  it('a no-change cycle leaves the tombstone bundles byte-identical (no false-diff → no push)', () => {
+    // The core loop symptom: re-merging the same state must not mutate the bundles,
+    // otherwise the DB engine snapshot-diff flags them dirty every cycle.
+    const stable = { ...emptyData(), deletedTaskIds: { 'a': daysAgo(10), 'b': daysAgo(50) } };
+    const { data } = mergeSyncData(stable, stable, 30);
+    expect(data.deletedTaskIds).toEqual({ 'a': stable.deletedTaskIds.a, 'b': stable.deletedTaskIds.b });
   });
 });
 

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -28,6 +28,7 @@
 
 import { mergeHabitLogs, mergeRoutineDefinitions, mergeRoutineCompletions, mergeCompletedDates } from '../mergeSync.js';
 import { floorToUtcDayIso } from '../utils/tombstoneHorizon.js';
+import { TOMBSTONE_BUNDLE_KEYS } from './tombstoneRetention.js';
 
 // ── Collection kinds: each array element is one row, keyed by a stable id, with
 // entity-grain last-writer-wins on tsField (the same grain the file-tier merge
@@ -376,10 +377,11 @@ const MERGE = {
   },
 };
 
-const TOMBSTONE_BUNDLES = new Set([
-  'deletedTaskIds', 'deletedRoutineChipIds', 'deletedFrameIds', 'removedTodayRoutineIds',
-  'deletedHabitIds', 'deletedGoalIds', 'deletedProjectIds', 'deletedAreaIds',
-]);
+// Grow-only during a single merge (unionNewerIso). Aging tombstones OUT to the
+// fixed 60-day window is a separate concern the DB engine handles on the mirror
+// (dbEngine.js) — see src/sync/tombstoneRetention.js — so this stays a pure,
+// order-independent union and never loses an entry mid-merge.
+export const TOMBSTONE_BUNDLES = new Set(TOMBSTONE_BUNDLE_KEYS);
 // Device-local prefs: the file-tier merge keeps the local value (merge.js:900-901
 // / weather not in merge output), so a pulled value never overwrites it. Listed
 // so the default branch doesn't LWW-clobber them. obsidianConfig is here

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -35,6 +35,7 @@ import {
   getEntityLastModified,
   reconcileCrossList,
 } from './dbAdapter.js';
+import { pruneAllTombstones, tombstoneCutoff } from './tombstoneRetention.js';
 
 const APP_ID = 'dayglance';
 const CRYPTO_DB_NAME = 'dayglance-db-crypto';
@@ -338,6 +339,18 @@ export function createDbEngine(callbacks = {}) {
       // bypass — so surface undecryptable-row skips from the pull result here.
       if (pull && pull.skipped > 0) callbacks.onRowsSkipped?.(pull.skipped, pull.skippedEntityIds || []);
       reconcileCrossList(mirror, (id) => engine.markDirty(id));
+      // Age tombstones out at the fixed 60-day window (src/sync/tombstoneRetention.js).
+      // The vault bundle merge is grow-only (dbAdapter unionNewerIso), so a pull
+      // re-adds every tombstone a peer still holds; without this the mirror would
+      // never shed old tombstones and would disagree with the file-tier merge
+      // (which prunes at 60 days), leaving the singleton row oscillating pruned↔
+      // restored → push → seq advance → SSE self-nudge loop. Pruning HERE — after
+      // pull/reconcile, before the push+snapshot save — means the pushed bundle,
+      // the saved snapshot, and the committed state all carry the same pruned set,
+      // so an unchanged cycle stays clean. The cutoff is day-floored, so the pruned
+      // set only shifts once per day (one push), never every cycle. Local-only GC:
+      // an entry we drop but a peer keeps is simply re-dropped next cycle, no churn.
+      pruneAllTombstones(mirror, tombstoneCutoff());
       callbacks.onStatusChange?.('uploading');
       // TEMP diagnostic: capture the COMPLETE dirty set (snapshot-diff + pull
       // re-push + cross-list reconcile) right before the push, then report what

--- a/src/sync/tombstoneResurrection.test.js
+++ b/src/sync/tombstoneResurrection.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { createVault, createDevice, syncToConvergence } from './dbVaultSim.js';
+import { makeEntityId, SINGLETON_KIND } from './dbAdapter.js';
+import { pruneAllTombstones, tombstoneCutoff } from './tombstoneRetention.js';
+import { mergeSyncData } from '../mergeSync.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RESURRECTION SAFETY for the fixed-60-day tombstone GC.
+//
+// Closes the gap called out in the fix justification: a dedicated test that
+// couples "tombstone pruned at the 60-day window" with "a deletion still
+// propagates and the item does NOT come back". Two independent suppressors are
+// exercised:
+//   • VAULT tier — the entity DELETE ROW (applyRemoteDelete), seq-ordered in the
+//     vault log; the deletedTaskIds singleton is NOT consulted here.
+//   • FILE tier — the deletedTaskIds tombstone (merge.js mergeArrayById), which
+//     drops a stale live re-push whose lastModified predates the deletion.
+// The fix RETAINS the tombstone for 60 days on both tiers, so both suppressors
+// keep working; it only GCs entries older than 60 days.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DAY = 86400000;
+const daysAgo = (n) => new Date(Date.now() - n * DAY).toISOString();
+
+const EMPTY = {
+  tasks: [], unscheduledTasks: [], recurringTasks: [], recycleBin: [], todayRoutines: [],
+  habits: [], goals: [], projects: [], gtdFrames: [], users: [], dailyNotes: {},
+  deletedTaskIds: {},
+};
+
+const TASK_X = { id: 'X', title: 'buy milk', lastModified: daysAgo(80) };
+
+function seededPair(base) {
+  const vault = createVault();
+  const a = createDevice('A', base);
+  const b = createDevice('B', base);
+  // Seed: mark A's whole state dirty and converge so both + the vault share it.
+  a.mutate((d) => [
+    ...d.tasks.map((t) => makeEntityId('tasks', t.id)),
+    makeEntityId(SINGLETON_KIND, 'deletedTaskIds'),
+  ]);
+  syncToConvergence(a, b, vault);
+  return { vault, a, b };
+}
+
+// Delete X on a device: drop the row + record the tombstone, marking both dirty.
+function deleteX(dev, whenIso) {
+  dev.mutate((d) => {
+    d.tasks = d.tasks.filter((t) => t.id !== 'X');
+    d.deletedTaskIds = { ...d.deletedTaskIds, X: whenIso };
+    return [makeEntityId('tasks', 'X'), makeEntityId(SINGLETON_KIND, 'deletedTaskIds')];
+  });
+}
+
+describe('tombstone GC — deletion propagates and survives the 60-day prune', () => {
+  it('deletes on A → B sees it gone (deletion still propagates)', () => {
+    const { vault, a, b } = seededPair({ ...EMPTY, tasks: [TASK_X] });
+    expect(b.data.tasks.find((t) => t.id === 'X')).toBeTruthy(); // both start with X
+
+    deleteX(a, daysAgo(0));
+    syncToConvergence(a, b, vault);
+
+    expect(a.data.tasks.find((t) => t.id === 'X')).toBeUndefined();
+    expect(b.data.tasks.find((t) => t.id === 'X')).toBeUndefined();
+  });
+
+  it('a FRESH tombstone is retained by the 60-day prune (not GCd), item stays gone', () => {
+    const { vault, a, b } = seededPair({ ...EMPTY, tasks: [TASK_X] });
+    deleteX(a, daysAgo(0));
+    syncToConvergence(a, b, vault);
+
+    // The 60-day GC the DB engine runs each cycle — here applied directly.
+    pruneAllTombstones(a.data, tombstoneCutoff());
+    pruneAllTombstones(b.data, tombstoneCutoff());
+
+    expect(a.data.deletedTaskIds.X).toBeDefined(); // 0 days old → kept
+    expect(b.data.deletedTaskIds.X).toBeDefined();
+    expect(b.data.tasks.find((t) => t.id === 'X')).toBeUndefined();
+  });
+
+  it('in a CONVERGED fleet, GCing an ancient (>60d) tombstone does not resurrect X (no live copy exists)', () => {
+    const { vault, a, b } = seededPair({ ...EMPTY, tasks: [TASK_X] });
+    deleteX(a, daysAgo(80));
+    syncToConvergence(a, b, vault);
+
+    // Age both tombstones past the window and GC them.
+    a.data.deletedTaskIds = { X: daysAgo(80) };
+    b.data.deletedTaskIds = { X: daysAgo(80) };
+    pruneAllTombstones(a.data, tombstoneCutoff());
+    expect(a.data.deletedTaskIds.X).toBeUndefined(); // GCd
+    pruneAllTombstones(b.data, tombstoneCutoff());
+
+    syncToConvergence(a, b, vault);
+    // No device holds a live X, so nothing can push it back.
+    expect(a.data.tasks.find((t) => t.id === 'X')).toBeUndefined();
+    expect(b.data.tasks.find((t) => t.id === 'X')).toBeUndefined();
+  });
+});
+
+describe('tombstone GC — the retained tombstone suppresses a stale live re-push (file tier)', () => {
+  it('a stale device re-pushing live X is dropped by the retained tombstone (merge.js:67)', () => {
+    // Local device: deleted X, tombstone fresh (well inside 60 days).
+    const local = { ...EMPTY, tasks: [], deletedTaskIds: { X: daysAgo(1) } };
+    // Stale device re-pushes X live with its ORIGINAL (pre-deletion) lastModified.
+    const remoteStale = { ...EMPTY, tasks: [TASK_X], deletedTaskIds: {} };
+
+    const { data } = mergeSyncData(local, remoteStale, 30);
+    // Tombstone (1 day old) is newer than X.lastModified (80 days old) → X suppressed.
+    expect(data.tasks.find((t) => t.id === 'X')).toBeUndefined();
+    // And the fix kept the tombstone available to do the suppressing.
+    expect(data.deletedTaskIds.X).toBeDefined();
+  });
+
+  it('DISCRIMINATOR: without the tombstone, the same stale re-push WOULD resurrect X', () => {
+    // Proves the previous test passes because of the tombstone, not by accident.
+    const localNoTombstone = { ...EMPTY, tasks: [], deletedTaskIds: {} };
+    const remoteStale = { ...EMPTY, tasks: [TASK_X], deletedTaskIds: {} };
+    const { data } = mergeSyncData(localNoTombstone, remoteStale, 30);
+    // No tombstone and no fence (no tombstonePrunedBefore) → X comes back.
+    expect(data.tasks.find((t) => t.id === 'X')).toBeTruthy();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The HONEST 60-day boundary (documents behavior the fix does NOT change).
+//
+// The resurrection FENCE (merge.js:88, from remote.tombstonePrunedBefore) sits in
+// the FIRST pass only — it guards LOCAL-only zombies (a stale device PULLING).
+// It does NOT guard a REMOTE-only stale re-push (a stale device PUSHING X back):
+// the second pass (merge.js:97-107) suppresses that solely via the tombstone. So:
+//   • ≤60 days: tombstone retained → stale push suppressed (proven above).
+//   • >60 days: tombstone GCd → a stale PUSH resurrects; a stale PULL is still
+//     caught by the fence. This is the accepted finite-retention tradeoff; the fix
+//     LENGTHENS the protected window from ~30 to 60 days, it does not remove the
+//     >60-day boundary.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('tombstone GC — the >60-day boundary is real (unchanged by the fix)', () => {
+  it('the FENCE catches a LOCAL-only stale zombie even with no tombstone (pull direction)', () => {
+    const localStale = { ...EMPTY, tasks: [TASK_X], deletedTaskIds: {} };
+    const remoteUpToDate = { ...EMPTY, tasks: [], deletedTaskIds: {}, tombstonePrunedBefore: daysAgo(30) };
+    const { data } = mergeSyncData(localStale, remoteUpToDate, 30);
+    // X (80d old) is local-only and older than the 30d fence → dropped as zombie.
+    expect(data.tasks.find((t) => t.id === 'X')).toBeUndefined();
+  });
+
+  it('the fence does NOT catch a REMOTE-only stale re-push once the tombstone is GCd (push direction)', () => {
+    const local = { ...EMPTY, tasks: [], deletedTaskIds: {}, tombstonePrunedBefore: daysAgo(30) };
+    const remoteStale = { ...EMPTY, tasks: [TASK_X], deletedTaskIds: {}, tombstonePrunedBefore: daysAgo(30) };
+    const { data } = mergeSyncData(local, remoteStale, 30);
+    // No tombstone (GCd) and no fence in the second pass → X resurrects. This is
+    // the >60-day exposure the fix bounds but does not eliminate.
+    expect(data.tasks.find((t) => t.id === 'X')).toBeTruthy();
+  });
+});

--- a/src/sync/tombstoneRetention.js
+++ b/src/sync/tombstoneRetention.js
@@ -1,0 +1,118 @@
+// Fixed tombstone-retention policy, decoupled from the user-facing "Keep past
+// events" setting (syncRetentionDays / settings.keepPastEvents).
+//
+// WHY THIS EXISTS: dayGLANCE runs two sync transports over the SAME local state:
+//   (a) the file-tier merge (@glance-apps/sync mergeSyncData, WebDAV/iCloud), and
+//   (b) the vault DB engine (src/sync/dbEngine.js, per-row).
+// The file-tier merge prunes deletion tombstones at `syncRetentionDays` — the
+// value behind the "Keep past events" dropdown, which the user may set as low as
+// 7 days. The vault merge (dbAdapter mergeBundle) is grow-only and never prunes.
+// So a tombstone older than the user's event-retention window is DROPPED by the
+// file-tier and immediately RE-ADDED by the grow-only vault union. The two
+// transports write conflicting values to the shared tombstone singleton every
+// cycle → the DB engine's snapshot-diff flags it dirty → push → account seq
+// advance → SSE self-nudge → a continuous "heartbeat" loop.
+//
+// THE FIX: tombstone garbage-collection is its OWN policy, independent of event
+// retention. Both transports prune tombstones at a FIXED window so they always
+// agree: entries newer than the window are kept by both; entries older are
+// dropped by both. The "Keep past events" toggle keeps governing imported-event
+// storage (completedTaskUids) only — it no longer touches tombstones.
+//
+// WHY 60 DAYS (not user-configurable): a tombstone only needs to outlive the
+// longest realistic gap before a stale device next syncs and would otherwise
+// resurrect a deleted item. Sixty days comfortably covers a device left offline
+// for weeks; keeping them longer only grows the payload with no benefit.
+
+import { floorToUtcDayIso } from '../utils/tombstoneHorizon.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const TOMBSTONE_RETENTION_DAYS = 60;
+
+// Canonical list of the deletion-tombstone singleton bundles ({id → ISO} maps).
+// Both the file-tier override (mergeSync.js) and the vault prune (dbEngine.js /
+// dbAdapter.js) iterate this exact set so the two transports stay in lockstep.
+export const TOMBSTONE_BUNDLE_KEYS = [
+  'deletedTaskIds',
+  'deletedRoutineChipIds',
+  'deletedFrameIds',
+  'removedTodayRoutineIds',
+  'deletedHabitIds',
+  'deletedGoalIds',
+  'deletedProjectIds',
+  'deletedAreaIds',
+];
+
+/**
+ * The day-floored cutoff Date: tombstones with a timestamp strictly older than
+ * this are eligible for pruning. Flooring to the UTC day keeps the cutoff STABLE
+ * across the many sync cycles within a day, so an unchanged cycle produces no
+ * snapshot-diff (the same stability trick as tombstoneHorizon).
+ *
+ * @param {number} [nowMs] current epoch ms (injectable for tests)
+ * @returns {Date}
+ */
+export function tombstoneCutoff(nowMs = Date.now()) {
+  const floored = floorToUtcDayIso(new Date(nowMs - TOMBSTONE_RETENTION_DAYS * DAY_MS).toISOString());
+  return new Date(floored);
+}
+
+/**
+ * Drop tombstone entries older than `cutoff`. Absent/unparseable timestamps are
+ * kept (fail-safe: never lose a tombstone we can't date). Returns a NEW object.
+ *
+ * @param {Record<string,string>} map  {id → ISO deletion timestamp}
+ * @param {Date|null} cutoff           entries with ts < cutoff are removed
+ * @returns {Record<string,string>}
+ */
+export function pruneTombstoneMap(map, cutoff) {
+  if (!map || typeof map !== 'object') return {};
+  if (!cutoff) return { ...map };
+  const out = {};
+  for (const [id, ts] of Object.entries(map)) {
+    const t = new Date(ts).getTime();
+    if (Number.isNaN(t) || t >= cutoff.getTime()) out[id] = ts;
+  }
+  return out;
+}
+
+/**
+ * Union two {id → ISO} tombstone maps, keeping the newer timestamp per id
+ * (grow-only set-union — mirrors dbAdapter's MERGE.unionNewerIso). Used to
+ * reconstruct the full cross-device tombstone set before pruning.
+ */
+export function unionNewerIso(a = {}, b = {}) {
+  const out = { ...(a || {}) };
+  for (const [id, ts] of Object.entries(b || {})) {
+    const prev = out[id];
+    out[id] = (!prev || new Date(ts) > new Date(prev)) ? ts : prev;
+  }
+  return out;
+}
+
+/**
+ * Prune every tombstone bundle present on `data` in place, at the fixed 60-day
+ * cutoff. Only mutates keys that already exist (never fabricates an empty
+ * bundle). Returns true if any bundle actually lost an entry, so a caller can
+ * decide whether the change is worth persisting/pushing.
+ *
+ * @param {object} data     a sync payload / app-state object
+ * @param {Date|null} [cutoff]
+ * @returns {boolean} whether anything was pruned
+ */
+export function pruneAllTombstones(data, cutoff = tombstoneCutoff()) {
+  if (!data || typeof data !== 'object' || !cutoff) return false;
+  let changed = false;
+  for (const key of TOMBSTONE_BUNDLE_KEYS) {
+    const map = data[key];
+    if (!map || typeof map !== 'object') continue;
+    const before = Object.keys(map).length;
+    const pruned = pruneTombstoneMap(map, cutoff);
+    if (Object.keys(pruned).length !== before) {
+      data[key] = pruned;
+      changed = true;
+    }
+  }
+  return changed;
+}

--- a/src/sync/tombstoneRetention.test.js
+++ b/src/sync/tombstoneRetention.test.js
@@ -7,7 +7,7 @@ import {
   unionNewerIso,
   pruneAllTombstones,
 } from './tombstoneRetention.js';
-import { applyRemoteEntity, SINGLETON_KIND, TOMBSTONE_BUNDLES } from './dbAdapter.js';
+import { applyRemoteEntity, makeEntityId, SINGLETON_KIND, TOMBSTONE_BUNDLES } from './dbAdapter.js';
 
 const DAY = 86400000;
 const daysAgo = (n) => new Date(Date.now() - n * DAY).toISOString();
@@ -143,5 +143,22 @@ describe('vault cycle — grow-union pull + 60-day prune is a stable no-op', () 
     applyRemoteEntity(mirror, singleton({ a: daysAgo(10), fresh: daysAgo(5) }));
     pruneAllTombstones(mirror, tombstoneCutoff());
     expect(mirror.deletedTaskIds.fresh).toBeDefined();
+  });
+
+  // The superset re-push (dbAdapter applyRemoteEntity → re-push entityId when the
+  // grow-union leaves local a SUPERSET of the pulled row) is the OTHER dirty
+  // source besides the snapshot-diff. Once both tiers converge on the same 60-day
+  // set it must stop emitting — otherwise it would keep writing every cycle.
+  it('emits NO superset re-push once local and remote agree (converged → no churn)', () => {
+    const steady = { a: daysAgo(10), b: daysAgo(50) };
+    const mirror = { deletedTaskIds: { ...steady } };
+    const rePush = applyRemoteEntity(mirror, singleton({ ...steady }));
+    expect(rePush).toEqual([]); // nothing to teach the vault → no write this cycle
+  });
+
+  it('emits a re-push ONLY when local genuinely holds a tombstone the vault lacks (legit propagation, terminates)', () => {
+    const mirror = { deletedTaskIds: { a: daysAgo(10), freshLocal: daysAgo(1) } };
+    const rePush = applyRemoteEntity(mirror, singleton({ a: daysAgo(10) }));
+    expect(rePush).toEqual([makeEntityId(SINGLETON_KIND, 'deletedTaskIds')]);
   });
 });

--- a/src/sync/tombstoneRetention.test.js
+++ b/src/sync/tombstoneRetention.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TOMBSTONE_RETENTION_DAYS,
+  TOMBSTONE_BUNDLE_KEYS,
+  tombstoneCutoff,
+  pruneTombstoneMap,
+  unionNewerIso,
+  pruneAllTombstones,
+} from './tombstoneRetention.js';
+import { applyRemoteEntity, SINGLETON_KIND, TOMBSTONE_BUNDLES } from './dbAdapter.js';
+
+const DAY = 86400000;
+const daysAgo = (n) => new Date(Date.now() - n * DAY).toISOString();
+
+describe('tombstoneRetention — policy constants', () => {
+  it('retention is fixed at 60 days', () => {
+    expect(TOMBSTONE_RETENTION_DAYS).toBe(60);
+  });
+
+  it('the canonical key list matches dbAdapter TOMBSTONE_BUNDLES exactly', () => {
+    expect(new Set(TOMBSTONE_BUNDLE_KEYS)).toEqual(TOMBSTONE_BUNDLES);
+  });
+});
+
+describe('tombstoneCutoff', () => {
+  it('is day-floored ~60 days ago (stable across a day → no per-cycle diff)', () => {
+    const cut = tombstoneCutoff(Date.parse('2026-07-06T18:25:50.000Z'));
+    expect(cut.toISOString()).toBe('2026-05-07T00:00:00.000Z'); // 60 days before, floored to UTC day
+  });
+
+  it('yields the same value for any two moments in the same UTC day', () => {
+    const morning = tombstoneCutoff(Date.parse('2026-07-06T00:00:01.000Z')).getTime();
+    const night = tombstoneCutoff(Date.parse('2026-07-06T23:59:59.000Z')).getTime();
+    expect(morning).toBe(night);
+  });
+});
+
+describe('pruneTombstoneMap', () => {
+  const cut = tombstoneCutoff();
+
+  it('drops entries older than the cutoff, keeps newer ones', () => {
+    const out = pruneTombstoneMap({ old: daysAgo(70), recent: daysAgo(10) }, cut);
+    expect(out).toEqual({ recent: expect.any(String) });
+  });
+
+  it('keeps the boundary case just inside 60 days', () => {
+    const out = pruneTombstoneMap({ inside: daysAgo(59) }, cut);
+    expect(out.inside).toBeDefined();
+  });
+
+  it('keeps unparseable timestamps (fail-safe: never lose an undateable tombstone)', () => {
+    const out = pruneTombstoneMap({ junk: 'not-a-date' }, cut);
+    expect(out.junk).toBe('not-a-date');
+  });
+
+  it('with no cutoff returns a copy unchanged', () => {
+    const src = { a: daysAgo(999) };
+    const out = pruneTombstoneMap(src, null);
+    expect(out).toEqual(src);
+    expect(out).not.toBe(src);
+  });
+});
+
+describe('unionNewerIso', () => {
+  it('keeps the newer timestamp per id', () => {
+    const older = daysAgo(10);
+    const newer = daysAgo(2);
+    const a = { x: older, y: daysAgo(5) };
+    const b = { x: newer, z: daysAgo(1) };
+    const out = unionNewerIso(a, b);
+    expect(out.x).toBe(newer); // b's x is newer than a's x
+    expect(out.y).toBe(a.y);
+    expect(out.z).toBe(b.z);
+  });
+});
+
+describe('pruneAllTombstones', () => {
+  it('prunes every bundle in place and reports change', () => {
+    const data = {
+      deletedTaskIds: { old: daysAgo(70), keep: daysAgo(1) },
+      deletedGoalIds: { keep: daysAgo(3) },
+    };
+    const changed = pruneAllTombstones(data, tombstoneCutoff());
+    expect(changed).toBe(true);
+    expect(data.deletedTaskIds).toEqual({ keep: expect.any(String) });
+    expect(data.deletedGoalIds).toEqual({ keep: expect.any(String) });
+  });
+
+  it('reports NO change when nothing crosses the window (steady state)', () => {
+    const data = { deletedTaskIds: { a: daysAgo(10), b: daysAgo(50) } };
+    const before = JSON.stringify(data);
+    const changed = pruneAllTombstones(data, tombstoneCutoff());
+    expect(changed).toBe(false);
+    expect(JSON.stringify(data)).toBe(before);
+  });
+
+  it('never fabricates an absent bundle', () => {
+    const data = { tasks: [] };
+    pruneAllTombstones(data, tombstoneCutoff());
+    expect('deletedTaskIds' in data).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The heartbeat-loop regression, at the vault tier. The DB engine merges a pulled
+// tombstone bundle with a GROW-ONLY union (dbAdapter mergeBundle → unionNewerIso),
+// so a peer still holding an ancient tombstone re-injects it every pull. dbEngine's
+// dbSyncCycle then prunes the mirror at the fixed 60-day window. This pair must
+// return the bundle to its pre-cycle set so the snapshot-diff sees NO change → no
+// push → no SSE self-nudge loop. (dbSyncCycle itself needs the full crypto engine;
+// here we drive the exact two operations it composes: pull-union then prune.)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('vault cycle — grow-union pull + 60-day prune is a stable no-op', () => {
+  const singleton = (value) => ({ _kind: SINGLETON_KIND, _key: 'deletedTaskIds', value });
+
+  it('drops an ancient tombstone a peer re-injects, converging to the steady set', () => {
+    const steady = { a: daysAgo(10), b: daysAgo(50) };
+    const mirror = { deletedTaskIds: { ...steady } };
+
+    // Peer (old/grow-only device) pushes its bundle including a 70-day tombstone.
+    applyRemoteEntity(mirror, singleton({ ...steady, ancient: daysAgo(70) }));
+    expect(mirror.deletedTaskIds.ancient).toBeDefined(); // grow-union re-added it
+
+    // dbEngine's end-of-cycle prune ages it back out.
+    pruneAllTombstones(mirror, tombstoneCutoff());
+    expect(mirror.deletedTaskIds).toEqual(steady); // identical → not dirty → no push
+  });
+
+  it('is idempotent across repeated cycles (no oscillation)', () => {
+    const steady = { a: daysAgo(10), b: daysAgo(50) };
+    const mirror = { deletedTaskIds: { ...steady } };
+    const peerBundle = { ...steady, ancient: daysAgo(70) };
+
+    for (let cycle = 0; cycle < 5; cycle++) {
+      applyRemoteEntity(mirror, singleton(peerBundle));
+      pruneAllTombstones(mirror, tombstoneCutoff());
+      expect(mirror.deletedTaskIds).toEqual(steady);
+    }
+  });
+
+  it('still propagates a fresh in-window tombstone a peer introduces', () => {
+    const mirror = { deletedTaskIds: { a: daysAgo(10) } };
+    applyRemoteEntity(mirror, singleton({ a: daysAgo(10), fresh: daysAgo(5) }));
+    pruneAllTombstones(mirror, tombstoneCutoff());
+    expect(mirror.deletedTaskIds.fresh).toBeDefined();
+  });
+});


### PR DESCRIPTION
## The loop

The deleted-ID tombstone singletons — `deletedTaskIds`, `deletedRoutineChipIds`, `deletedFrameIds`, `removedTodayRoutineIds`, `deletedHabitIds`, `deletedGoalIds`, `deletedProjectIds`, `deletedAreaIds` — false-diffed on **every** DB-sync push cycle (the `[push]` debug showed `value.<id>: <timestamp> -> undefined` each cycle). Each false-diff is a real content-row write that advances the account seq, and under SSE every seq advance nudges another cycle → a continuous heartbeat loop.

## Root cause (confirmed, not guessed)

Two sync transports share the **same** local tombstone state but pruned it **differently**:

- **File-tier merge** (`@glance-apps/sync` `mergeSyncData`, WebDAV/iCloud) prunes tombstones at `syncRetentionDays` — the value behind the **"Keep past events"** dropdown, which a user may set as low as 7/14/30 days.
- **Vault DB merge** (`dbAdapter` `unionNewerIso`) is **grow-only** and never prunes.

So a tombstone older than the user's event-retention window was **dropped by the file tier and immediately re-added by the vault's grow-union**, oscillating the singleton row pruned↔restored every cycle. On the reporter's setup (`syncRetentionDays = 30`, macOS iCloud), May 20–31 tombstones aged 35–46 days were pruned by the file tier and resurrected by the vault, churning forever.

## Fix — tombstone GC is its own fixed 60-day policy

Tombstone garbage-collection is decoupled from event retention. **Both** transports now prune tombstones at the same day-floored **60-day** window, so they always agree: entries newer than 60 days are kept by both, older are dropped by both — the singleton stops oscillating. The **"Keep past events" toggle still governs imported-event storage** (`completedTaskUids`) only; it no longer touches tombstones. 60 days is fixed and not user-configurable.

Why 60 days: a tombstone only needs to outlive the longest realistic gap before a stale device next syncs and would otherwise resurrect a deleted item. Sixty days comfortably covers a device left offline for weeks; keeping them longer only grows the payload.

## Changes

- **`src/sync/tombstoneRetention.js`** (new): `TOMBSTONE_RETENTION_DAYS = 60`, the canonical tombstone-bundle key list, a day-floored cutoff, and prune/union helpers shared by both tiers.
- **`src/mergeSync.js`** (file tier): after the upstream merge, override the tombstone bundles at the fixed 60-day window (reconstructed from both sides' raw maps, newest ts per id). Event pruning (`completedTaskUids`) still uses the user's setting inside the upstream merge. `deletedAreaIds` switched to the same 60-day cutoff.
- **`src/sync/dbEngine.js`** (vault tier): prune the mirror's tombstone bundles at 60 days after pull/reconcile and **before** the push + snapshot save, so the pushed bundle, the saved snapshot, and the committed state all carry the same set → an unchanged cycle stays clean. The cutoff is day-floored, so the pruned set only shifts once per day (one push), never every cycle. Pruning is local-only GC — an entry a peer still holds is simply re-dropped next cycle, no teach-back churn.
- **`src/sync/dbAdapter.js`**: `TOMBSTONE_BUNDLES` now derives from the canonical list (no drift); the bundle merge stays grow-only within a single merge by design (aging-out is the engine's concern).

## Why both tiers

Raising only the file tier to 60 days stops the reporter's *current* churn (their tombstones are < 60 days, so neither tier prunes them → they agree), but the fight would just move to the > 60-day boundary (file tier prunes, grow-only vault re-adds). Pruning **both** at the same 60-day window is what makes it converge permanently.

## Android

Android doesn't run iCloud and had WebDAV unconfigured, so it wasn't hitting the file-tier prune that caused this loop. It does run the vault DB engine, so it now GCs tombstones at 60 days too — consistent with the file tier, day-floored and local-only, so no new churn.

## Tests

- **`src/sync/tombstoneRetention.test.js`** (new, 15): cutoff day-flooring/stability, prune keep/drop/boundary/undateable, union newest-per-id, and a **vault-cycle regression** — grow-union pull re-injects a 70-day tombstone, the 60-day prune ages it back out, and the bundle returns to its pre-cycle set (idempotent across repeated cycles → not dirty → no push); a fresh in-window tombstone from a peer still propagates.
- **`src/mergeSync.test.js`**: the decoupling — a 45-day tombstone survives even with event retention at 30 days; a 70-day tombstone prunes regardless of a longer event setting; `retentionDays = 0` keeps events forever but still GCs tombstones at 60 days; event retention still honors the user setting while tombstones do not; a no-change cycle leaves the bundles byte-identical.

Full suite **568** + lint + build green.

## Verify on-device (macOS iCloud build, the one that showed the loop)

With `dayglance-debug-push` on, cold-open and let it settle: a no-change cycle should log `snapshot-diff found NO changed rows` and `client did NOT write this cycle` — **no** `singleton:deletedTaskIds … <timestamp> -> undefined` false-diff, no push, no SSE self-nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBqFKAmYQt8zTfwHVgmKJH)_