### PR TITLE
Stop Obsidian-driven SSE sync loop: stabilize daily-note timestamps

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import { checkForUpdate } from './versionCheck.js';
 import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { tombstoneHorizon } from './utils/tombstoneHorizon.js';
 import { preserveArchived } from './utils/preserveArchived.js';
+import { preserveDailyNoteTimestamps } from './utils/preserveDailyNoteTimestamps.js';
 import { stripHealthSourcedLogs } from './utils/healthLogFilter.js';
 import { webdavFetch } from './utils/cloudSyncProviders.js';
 import { autoBackupDB, createAutoBackupProvidersForFolder, AUTO_BACKUP_RETENTION, AUTO_BACKUP_INTERVALS } from './utils/autoBackup.js';
@@ -3193,16 +3194,13 @@ const DayPlanner = () => {
             obsidianConfig?.dailyNotePattern || 'yyyy-MM-dd',
           );
 
-      // Update daily notes — replace with Obsidian-sourced notes
-      setDailyNotes(prev => {
-        const next = {};
-        // Keep non-Obsidian notes (from dates without Obsidian files, if integration was just enabled)
-        // Actually when Obsidian is enabled, Obsidian is the ONLY source — so just use the result
-        for (const [dateStr, note] of Object.entries(result.dailyNotes)) {
-          next[dateStr] = note;
-        }
-        return next;
-      });
+      // Update daily notes — replace with Obsidian-sourced notes. Obsidian is the
+      // sole source when enabled, so the scan result fully defines the map. But the
+      // native bridge has no file mtime, so syncObsidianVaultNative stamps a fresh
+      // `lastModified` on every scan (src/obsidian.js) — which would re-push every
+      // note each scan and drive the SSE self-nudge loop. Carry the prior timestamp
+      // forward for notes whose text is unchanged so only genuine edits re-push.
+      setDailyNotes(prev => preserveDailyNoteTimestamps(prev, result.dailyNotes));
 
       // App-only fields that live in dayGLANCE but NOT in the Obsidian markdown,
       // so a re-parse (parseTasksFromMarkdown) can't reproduce them. They must be
@@ -3216,6 +3214,10 @@ const DayPlanner = () => {
         ...(old.deadline ? { deadline: old.deadline } : {}),
         ...(old.archived !== undefined ? { archived: old.archived } : {}),
         ...(old.completedAt !== undefined ? { completedAt: old.completedAt } : {}),
+        // assignedUserSyncIds is an app-only synced field (user assignment) that
+        // the markdown re-parse can't reproduce; without this an assigned Obsidian
+        // task drops it on every re-scan → the same per-cycle false-diff/re-push.
+        ...(old.assignedUserSyncIds !== undefined ? { assignedUserSyncIds: old.assignedUserSyncIds } : {}),
       });
 
       // Update tasks — remove old Obsidian imports, add fresh ones.

--- a/src/utils/preserveDailyNoteTimestamps.js
+++ b/src/utils/preserveDailyNoteTimestamps.js
@@ -1,0 +1,33 @@
+// Keep Obsidian daily-note `lastModified` stable across scans when the note text
+// hasn't changed.
+//
+// WHY: the native Obsidian bridge (Android) exposes no file mtime, so
+// syncObsidianVaultNative / readDailyNoteNative stamp `lastModified: new
+// Date().toISOString()` on EVERY scan (src/obsidian.js). Each 5-minute poll or
+// visibility-triggered re-scan therefore rewrites `lastModified` on every daily
+// note, even when nothing changed. Those rows then false-diff in the DB-sync
+// snapshot every scan → push → account seq advance → SSE self-nudge loop (the
+// same failure class as the tombstonePrunedBefore full-precision churn). The
+// browser File System Access path avoids this by deriving `lastModified` from the
+// real file mtime (stable), so this only bites native shells.
+//
+// FIX: when a scanned note's `text` matches the copy we already hold, carry the
+// prior `lastModified` forward so the row is byte-identical and does NOT re-push.
+// A note new to `prev`, or one whose text genuinely changed, keeps the incoming
+// timestamp — mirrors stampTimestamps' "unchanged → keep stored lastModified"
+// rule for tasks. `lastModified` still drives per-date LWW across devices, so a
+// real edit (text change) advances it and wins the merge exactly as before.
+//
+// @param {Record<string, {text:string, lastModified?:string}>} prev      current in-memory notes
+// @param {Record<string, {text:string, lastModified?:string}>} incoming  freshly scanned notes
+// @returns {Record<string, object>} incoming with unchanged notes' lastModified preserved
+export function preserveDailyNoteTimestamps(prev, incoming) {
+  const out = {};
+  for (const [date, note] of Object.entries(incoming || {})) {
+    const old = prev && prev[date];
+    out[date] = (old && old.text === note.text && old.lastModified)
+      ? { ...note, lastModified: old.lastModified }
+      : note;
+  }
+  return out;
+}

--- a/src/utils/preserveDailyNoteTimestamps.test.js
+++ b/src/utils/preserveDailyNoteTimestamps.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { preserveDailyNoteTimestamps } from './preserveDailyNoteTimestamps.js';
+
+// The native Obsidian scan restamps `lastModified` every scan (no file mtime on
+// the bridge). These tests lock in that an unchanged note round-trips with a
+// STABLE lastModified — so it does not false-diff / re-push every scan (the SSE
+// self-nudge loop) — while a genuine text edit still advances the timestamp.
+
+const scanned = (text, lastModified) => ({ text, lastModified, fromObsidian: true });
+
+describe('preserveDailyNoteTimestamps', () => {
+  it('keeps the prior lastModified when a note text is unchanged', () => {
+    const prev = { '2026-04-19': scanned('## Notes', '2026-04-19T10:00:00.000Z') };
+    const incoming = { '2026-04-19': scanned('## Notes', '2026-07-07T14:22:31.004Z') }; // fresh scan stamp
+    const out = preserveDailyNoteTimestamps(prev, incoming);
+    expect(out['2026-04-19'].lastModified).toBe('2026-04-19T10:00:00.000Z'); // stable, not the scan stamp
+    expect(out['2026-04-19'].text).toBe('## Notes');
+    expect(out['2026-04-19'].fromObsidian).toBe(true);
+  });
+
+  it('is idempotent across repeated scans — lastModified never drifts', () => {
+    let prev = { '2026-04-19': scanned('body', '2026-04-19T10:00:00.000Z') };
+    for (let scan = 0; scan < 5; scan++) {
+      // Each scan hands us a brand-new "now" timestamp (what the native bridge does).
+      const incoming = { '2026-04-19': scanned('body', `2026-07-0${scan + 1}T00:00:00.000Z`) };
+      const out = preserveDailyNoteTimestamps(prev, incoming);
+      expect(out['2026-04-19'].lastModified).toBe('2026-04-19T10:00:00.000Z'); // never moves
+      prev = out; // persist + reload next scan
+    }
+  });
+
+  it('advances lastModified when the note text genuinely changed', () => {
+    const prev = { '2026-04-19': scanned('old body', '2026-04-19T10:00:00.000Z') };
+    const incoming = { '2026-04-19': scanned('new body', '2026-07-07T14:22:31.004Z') };
+    const out = preserveDailyNoteTimestamps(prev, incoming);
+    expect(out['2026-04-19'].lastModified).toBe('2026-07-07T14:22:31.004Z'); // real edit wins
+    expect(out['2026-04-19'].text).toBe('new body');
+  });
+
+  it('keeps the incoming timestamp for a note new to prev', () => {
+    const out = preserveDailyNoteTimestamps({}, { '2026-05-01': scanned('x', '2026-05-01T09:00:00.000Z') });
+    expect(out['2026-05-01'].lastModified).toBe('2026-05-01T09:00:00.000Z');
+  });
+
+  it('drops notes no longer present in the scan (Obsidian is the sole source)', () => {
+    const prev = { '2026-04-19': scanned('a', '2026-04-19T10:00:00.000Z') };
+    const out = preserveDailyNoteTimestamps(prev, { '2026-04-20': scanned('b', '2026-04-20T10:00:00.000Z') });
+    expect(out['2026-04-19']).toBeUndefined();
+    expect(out['2026-04-20']).toBeDefined();
+  });
+
+  it('tolerates null/undefined inputs', () => {
+    expect(preserveDailyNoteTimestamps(null, null)).toEqual({});
+    expect(preserveDailyNoteTimestamps(undefined, { d: scanned('t', 'ts') })).toEqual({ d: scanned('t', 'ts') });
+  });
+});

--- a/src/utils/stampTimestamps.test.js
+++ b/src/utils/stampTimestamps.test.js
@@ -78,6 +78,27 @@ describe('stampTimestamps', () => {
     expect(stampTimestamps(inMemory, stored, 'NOW')[0].lastModified).toBe('NOW');
   });
 
+  // ── Round-trip: an archived:true inbox item stays archived and does NOT
+  // false-diff once the store also holds archived:true. This is the day-planner-
+  // unscheduled store→load→payload path an archived task takes every cycle: the
+  // load normalize adds notes/subtasks defaults, the stamper compares, and the
+  // item must round-trip byte-identical (archived kept, lastModified stable) so it
+  // never re-pushes on an unchanged cycle. Guards against a regression that would
+  // strip archived on this path.
+  it('round-trips archived:true store→load→save with NO false-diff across cycles', () => {
+    const t0 = ISO(100);
+    // Store already carries archived:true (written by a prior save).
+    let stored = [{ id: 1, title: 'Archived inbox', completed: true, archived: true, lastModified: t0 }];
+    for (let cycle = 0; cycle < 3; cycle++) {
+      // loadData adds notes/subtasks defaults into in-memory state (App normalize).
+      const inMemory = stored.map(t => ({ ...t, notes: t.notes ?? '', subtasks: t.subtasks ?? [] }));
+      const out = stampTimestamps(inMemory, stored, ISO(0));
+      expect(out[0].archived).toBe(true);          // archived survives the round-trip
+      expect(out[0].lastModified).toBe(t0);         // no fabricated timestamp → no re-push
+      stored = out;                                 // persist + reload next cycle
+    }
+  });
+
   describe('onRestamp diagnostic', () => {
     it('reports the changed fields when an existing task is re-stamped', () => {
       const prev = [{ id: 1, title: 'A', completed: false, lastModified: ISO(100) }];


### PR DESCRIPTION
## Summary

The Android-driven SSE self-nudge loop (visible on macOS/Electron when Android keeps the sync cycle hot) is driven by the **native Obsidian scan**, not by a lost `archived` flag.

The native Obsidian bridge exposes no file mtime, so `syncObsidianVaultNative` / `readDailyNoteNative` stamp `lastModified: new Date().toISOString()` on **every** scan (`src/obsidian.js:1260`, `:1083`). Each 5-minute poll or visibility-triggered re-scan rewrites `lastModified` on every daily note even when nothing changed. Those rows then false-diff in the DB-sync snapshot every scan → push → account seq advance → SSE self-nudge loop — the same failure class as the `tombstonePrunedBefore` full-precision churn. The browser File System Access path is immune because it derives `lastModified` from the real file mtime (`src/obsidian.js:948`), which is why a clean debug build (no Obsidian data) doesn't reproduce it.

## Fix

- New util `preserveDailyNoteTimestamps` carries the prior `lastModified` forward for notes whose `text` is unchanged, applied in `performObsidianSync`'s `setDailyNotes`. Only genuinely edited notes advance their timestamp — mirrors `stampTimestamps`' unchanged-keeps-stored rule for tasks. `lastModified` still drives per-date LWW across devices, so a real edit wins the merge exactly as before.

## Completeness audit (the `archived` hypothesis)

Every producer of an inbox/unscheduled row already preserves `archived`: `loadData`, `saveData`, `buildSyncPayload`, `applyEngineData` (the original `preserveArchived` fix), `restoreBackup`, the file-tier merge (`mergeSync.js`), and the DB adapter (`shredState`/`reassembleState`/`upsertCollection`). There is **no second strip path**. The `archived: undefined -> true` seen in the push log is the expected one-time `upsertCollection` superset carry (see `archivedPreservation.test.js`), which self-heals in a single cycle. An `archived:true` store→load round-trip test was added and **passes on the pre-fix code**, locking the invariant in.

One genuine other-field drop the audit surfaced: the Obsidian re-import did not restore `assignedUserSyncIds` (an app-only synced field), so an assigned Obsidian task dropped it on every re-scan → its own false-diff. Added it to `preserveObsidianAppFields`.

## Tests

- New `preserveDailyNoteTimestamps` suite: stable/idempotent across repeated scans, advances `lastModified` only on real text edits, handles new/removed dates and null inputs.
- New `archived:true` store→load round-trip test (no false-diff across cycles).
- Full suite: **584 passing**. Production build clean.

## Verification notes

Verified via unit tests (dailyNotes idempotency across 5 scans; archived round-trip stability) plus the full suite and build. The live two-device Android-open `[push]` measurement was not run in this environment — to confirm on-device, enable `dayglance-debug-push` and check that an unchanged cycle shows `written:0 deleted:0` with no `dailyNotes:*` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_