### PR TITLE
Add gated pull-side diagnostic for the vault delete↔create ping-pong

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 148
+        versionCode = 149
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -268,11 +268,22 @@ export function createDbEngine(callbacks = {}) {
     nativeStoreSyncKey,
     getLocalEntity: (entityId) => adapterGetLocalEntity(mirror, entityId),
     applyRemoteEntity: (entityId, entity) => {
+      // TEMP diagnostic (gated on dayglance-debug-push): a remote row that revives
+      // a row this device had dropped is the "re-created" half of a delete↔create
+      // ping-pong. Logging every applied entityId shows whether the churn arrives
+      // FROM the vault (another device re-pushing) vs originates locally.
+      if (debugPushEnabled()) console.log('[pull] apply', entityId);
       // Bundle merges may leave us richer than the clobbered vault row; re-push
       // the superset so it converges at the vault (see dbAdapter / stage-2 doc).
       for (const id of adapterApplyRemoteEntity(mirror, entity)) engine.markDirty(id);
     },
-    applyRemoteDelete: (entityId) => adapterApplyRemoteDelete(mirror, entityId),
+    applyRemoteDelete: (entityId) => {
+      // TEMP diagnostic (gated): a remote DELETE row for a row we still hold live
+      // is the "deleted" half of the ping-pong — it proves the delete came from
+      // the vault log (a peer's soft-delete), not from local state loss.
+      if (debugPushEnabled()) console.log('[pull] DELETE', entityId);
+      return adapterApplyRemoteDelete(mirror, entityId);
+    },
     isInsertOnly,
     getEntityLastModified,
     onStatusChange: callbacks.onStatusChange,
@@ -309,6 +320,16 @@ export function createDbEngine(callbacks = {}) {
 
       // Seed the dirty set: full snapshot on first-ever sync, else the diff.
       const pushDbg = debugPushEnabled();
+      // TEMP diagnostic (gated): log what getData() actually handed us this cycle.
+      // A collection that momentarily drops to 0 (then refills next cycle) is the
+      // "deleted → new" churn seen from the source side — it distinguishes a real
+      // state wipe (count goes 0) from a remote delete-row (count stays, [pull]
+      // DELETE fires instead).
+      if (pushDbg) {
+        const cnt = (k) => Array.isArray(mirror[k]) ? mirror[k].length
+          : (mirror[k] && typeof mirror[k] === 'object' ? Object.keys(mirror[k]).length : 0);
+        console.log(`[push] getData counts → tasks:${cnt('tasks')} unscheduled:${cnt('unscheduledTasks')} gtdFrames:${cnt('gtdFrames')} dailyNotes:${cnt('dailyNotes')} goals:${cnt('goals')} projects:${cnt('projects')}`);
+      }
       const dbgChanges = pushDbg ? [] : null; // [{ id, kind, diff:[] }]
       if (engine.getHighWaterMark() === 0) {
         for (const row of shredState(mirror)) engine.markDirty(row.entityId);


### PR DESCRIPTION
## Summary

The Android-driven SSE sync loop **persists** after the daily-note timestamp fix (PR #1137, versionCode 148). The post-fix macOS `[push]` log shows the real signature is not a field drift but **whole rows going absent from the snapshot and reappearing** — dailyNotes, Obsidian tasks, and gtdFrames **deleted then re-created under the same id**. That is a delete↔create ping-pong.

With only the GLANCEvault (DB) tier active, a vault delete is a **per-row soft-delete in the seq log** (the tombstone singletons are not consulted on this tier). So a same-id delete-then-recreate means one device keeps deleting a row while another keeps re-creating it. To identify the source without further guesswork, this PR adds a **gated diagnostic** (no behavior change).

## What it logs (gated on the existing `dayglance-debug-push` flag)

- `[pull] apply <entityId>` — every remote row applied during pull
- `[pull] DELETE <entityId>` — every remote delete row applied during pull
- `[push] getData counts → …` — per-cycle collection counts from `getData()`

## Why

These three signals disambiguate the driver on the cycle where a row is deleted:

- A **peer soft-delete** arriving via the vault → `[pull] DELETE …` fires while the collection count stays put (resurrection ping-pong between devices).
- A **local state wipe** → the collection count drops to 0, then refills the next cycle (something on this device emptied state).
- **Snapshot/commit divergence** → neither fires, yet the snapshot-diff still reports the row.

Leading hypothesis it will confirm or rule out: `performObsidianSync` replaces the whole `dailyNotes` map and Obsidian task set with this device's scan, so when two devices' scans differ they delete each other's rows and the vault ping-pongs them — in which case `[pull] apply dailyNotes:…` will fire on one device right after the other deletes it.

## Notes

- Diagnostic only; intended to be removed once the driver is confirmed.
- Android `versionCode` bumped 148 → 149 so the build can be deployed to the device.
- Tests: sync suite 130 passing; production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_