### PR TITLE
Revert the resurrection-fence fix — it churns under the newerIso merge

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 153
+        versionCode = 154
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,6 @@ import { gatherTrmnlData, pushToTrmnl, TRMNL_MARKUP_FULL, TRMNL_MARKUP_HALF_HORI
 import { checkForUpdate } from './versionCheck.js';
 import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { tombstoneHorizon } from './utils/tombstoneHorizon.js';
-import { TOMBSTONE_RETENTION_DAYS } from './sync/tombstoneRetention.js';
 import { preserveArchived } from './utils/preserveArchived.js';
 import { mergeObsidianDailyNotes } from './utils/mergeObsidianDailyNotes.js';
 import { mergeObsidianTasks } from './utils/mergeObsidianTasks.js';
@@ -5898,18 +5897,21 @@ const DayPlanner = () => {
         multiUserEnabled,
         multiUserEnabledUpdatedAt: localStorage.getItem('dayglance-multi-user-enabled-updated-at') || null,
         users,
-        // The resurrection FENCE. It MUST match the tombstone GC horizon, which is
-        // the FIXED 60-day window (TOMBSTONE_RETENTION_DAYS), NOT the user's "Keep
-        // past events" setting (syncRetentionDays). Tombstone GC was decoupled to a
-        // fixed 60 days; leaving the fence on syncRetentionDays left a resurrection
-        // gap: with retention > 60 the fence sat further back than the 60-day GC, so
-        // a zombie aged 60→retention days had its tombstone GC'd yet slipped under
-        // the fence and resurrected; with retention 0 the fence was null (no fence)
-        // while tombstones still GC'd at 60. Pinning the fence to 60 == GC closes
-        // both. Floored to the UTC day so the row is STABLE across cycles (a fresh
-        // Date.now() re-pushed it every cycle → seq advance → SSE self-nudge loop;
-        // see utils/tombstoneHorizon.js).
-        tombstonePrunedBefore: tombstoneHorizon(TOMBSTONE_RETENTION_DAYS),
+        // Floored to the UTC day so this row is STABLE across sync cycles. A
+        // fresh Date.now() here changed the value every cycle, so the snapshot-
+        // diff re-pushed it every cycle → account seq advance → SSE self-nudge
+        // loop. See utils/tombstoneHorizon.js. (Pruning uses a fresh cutoff in
+        // the merge, so a day-granular fence changes nothing that gets pruned.)
+        //
+        // NOTE: this is intentionally still syncRetentionDays, NOT the fixed 60-day
+        // horizon. The value is merged with newerIso (dbAdapter.js) — monotonic,
+        // keeps the newest — so all devices MUST compute the SAME value or the ones
+        // emitting an older value churn forever (getData recomputes a value newerIso
+        // won't accept back). A fixed-60 fence is OLDER than a retention<60 device's
+        // value, so it never converges. Aligning the fence with the fixed-60 GC
+        // (the resurrection gap at retention>60 / retention=0) needs the merge
+        // reconciled first — tracked as a follow-up, not a one-line swap.
+        tombstonePrunedBefore: tombstoneHorizon(syncRetentionDays),
       }
     };
   };

--- a/src/sync/tombstoneResurrection.test.js
+++ b/src/sync/tombstoneResurrection.test.js
@@ -152,31 +152,3 @@ describe('tombstone GC — the >60-day boundary is real (unchanged by the fix)',
     expect(data.tasks.find((t) => t.id === 'X')).toBeTruthy();
   });
 });
-
-// ─────────────────────────────────────────────────────────────────────────────
-// The resurrection FENCE must track the FIXED 60-day tombstone GC horizon, not the
-// user's "Keep past events" (syncRetentionDays). buildSyncPayload now emits
-// tombstonePrunedBefore = tombstoneHorizon(TOMBSTONE_RETENTION_DAYS) = 60 days. When
-// retention was wider (e.g. 90), the OLD retention-based fence sat further back than
-// the 60-day GC, so a local-only zombie aged 60→90 days had its tombstone GCd yet
-// slipped under the fence and resurrected. Pinning the fence to 60 closes the gap.
-// ─────────────────────────────────────────────────────────────────────────────
-describe('resurrection fence tracks the fixed 60-day GC, independent of syncRetentionDays', () => {
-  const zombie70 = { id: 'X', title: 'buy milk', lastModified: daysAgo(70) };
-
-  it('a 70-day local-only zombie IS caught by the fixed 60-day fence (gap closed)', () => {
-    const localStale = { ...EMPTY, tasks: [zombie70], deletedTaskIds: {} };
-    // Fence at 60 days — what tombstoneHorizon(TOMBSTONE_RETENTION_DAYS) yields now,
-    // regardless of the retention arg (90 here).
-    const remoteUpToDate = { ...EMPTY, tasks: [], deletedTaskIds: {}, tombstonePrunedBefore: daysAgo(60) };
-    const { data } = mergeSyncData(localStale, remoteUpToDate, 90);
-    expect(data.tasks.find((t) => t.id === 'X')).toBeUndefined(); // 70d older than 60d fence → dropped
-  });
-
-  it('DISCRIMINATOR: the OLD retention-based fence (90d) let the same zombie through', () => {
-    const localStale = { ...EMPTY, tasks: [zombie70], deletedTaskIds: {} };
-    const remoteOldFence = { ...EMPTY, tasks: [], deletedTaskIds: {}, tombstonePrunedBefore: daysAgo(90) };
-    const { data } = mergeSyncData(localStale, remoteOldFence, 90);
-    expect(data.tasks.find((t) => t.id === 'X')).toBeTruthy(); // 70d newer than 90d fence → survived (the bug)
-  });
-});

--- a/src/utils/tombstoneHorizon.js
+++ b/src/utils/tombstoneHorizon.js
@@ -16,13 +16,17 @@
 // advances (once per day), so tombstones still age out.
 //
 // SAFETY: this value is only the resurrection FENCE (merge.js syncHorizon) and the
-// reported "pruned-before" marker. It MUST be computed from the SAME horizon the
-// tombstone GC uses — the fixed 60-day window (TOMBSTONE_RETENTION_DAYS), passed by
-// the caller — NOT the user's "Keep past events" setting. The fence tells peers
-// "I've pruned tombstones older than this, so don't resurrect items older than
-// this"; if it disagrees with the GC horizon a zombie in the gap resurrects (see
-// buildSyncPayload). Flooring to the UTC day keeps the row stable across the many
-// cycles within a day (an unstable value re-pushes every cycle → SSE self-nudge).
+// reported "pruned-before" marker. The ACTUAL tombstone pruning uses a fresh
+// `Date.now() - retention` computed inside the merge, independent of this field —
+// so a coarser fence does not change what gets pruned. Flooring makes the fence at
+// most 24h earlier at the ~90-day mark, which is conservative (keeps tombstones
+// slightly longer; suppresses resurrection marginally less) and well within the
+// field's inherently fuzzy semantics.
+//
+// NOTE: the value is passed by the caller (buildSyncPayload) as syncRetentionDays,
+// NOT the fixed-60 GC horizon. It's merged with newerIso (monotonic newest), so all
+// devices must compute the SAME value or the older-valued ones churn forever. See
+// the note at the buildSyncPayload call site.
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Revert #1142's fence change (the Obsidian fixes stay)

PR #1142 pinned `tombstonePrunedBefore` to a fixed 60-day horizon. That **introduced a new every-cycle loop**, seen live with the Android app open:

```
[push] changed singleton:tombstonePrunedBefore — value: 2026-06-07 -> 2026-05-08
… every cycle, forever …
```

**Why it churns:** `tombstonePrunedBefore` is merged with `newerIso` (monotonic — keeps the newest value, `dbAdapter.js:456`). A retention-30 device already had the **30-day** value (`2026-06-07`) in the vault. The fix made `buildSyncPayload` recompute the **60-day** value (`2026-05-08`), which is *older*; `newerIso` never accepts the older value back, so `getData` (recomputed fresh each call) never matched the stored value → the singleton went dirty every cycle → push → seq advance → SSE self-nudge loop. It can't converge while any device emits a shorter-retention (newer) value — i.e. the default 30.

**Revert:** restore `tombstonePrunedBefore = tombstoneHorizon(syncRetentionDays)` so all same-retention devices compute the same value and converge. Notes left at the call site and in `tombstoneHorizon.js` explaining why it can't simply be the fixed-60 GC horizon.

## What's unaffected

The Obsidian merge-not-replace + conservative deletion-tombstone fixes from #1140/#1141 are **not** touched and are working — `dailyNotes` is stable in the log, no more `[pull] DELETE dailyNotes ↔ new` churn.

## Follow-up (re-opened, needs real design)

The original goal — align the fence with the fixed-60 GC to close the resurrection gap at retention > 60 and retention = 0 — is **not** a one-line swap. It has to reconcile the `newerIso` merge (and the file-tier equivalent) so a corrected value can converge without churning, and deal with a stale newer value already stuck in the vault. Tracked, not attempted here. Note the gap only affects retention > 60 / 0; the default 30 is unaffected.

- Suite passes, build clean. Android `versionCode` 154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_