### PR TITLE
Stop the Health Connect habit re-stamp self-loop

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 154
+        versionCode = 155
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
 import { getDeviceId, isNativeIOS } from '../native.js';
+import { changedHealthHabitIds } from '../utils/healthHabitChanges.js';
 
 const useHabits = ({ playUISound, hrOwnerRef }) => {
   const [habits, setHabits] = useState([]);
@@ -226,31 +227,42 @@ const useHabits = ({ playUISound, hrOwnerRef }) => {
         } catch (e) { /* ignore parse errors */ }
       }
     }
-    if (Object.keys(updates).length > 0) {
-      setHabitLogs(prev => {
-        const next = { ...prev };
-        for (const [dateStr, entries] of Object.entries(updates)) {
-          const prevDay = next[dateStr] || {};
-          const merged = { ...prevDay };
-          for (const [habitId, count] of Object.entries(entries)) {
-            // Never downgrade a count already in state (e.g. a value that arrived
-            // via cloud sync from the other device's health platform).
-            merged[habitId] = Math.max(prevDay[habitId] || 0, count);
-          }
-          next[dateStr] = merged;
+    // Which habits actually got a NEW (higher) count this run. Only these touch
+    // state. Re-stamping every synced habit unconditionally was a self-perpetuating
+    // loop: this function runs from an effect keyed on `habits` (below), and it
+    // bumped lastModified + lastAutoSync.timestamp on every run → `habits` changed →
+    // the effect re-fired → it ran again → … forever, re-pushing the health habits
+    // to the vault every cycle (the SSE self-nudge loop). Math.max means a count
+    // only ever increases, so an idle device (no new steps/sleep) now makes NO
+    // change and the effect goes quiet. syncedTodayIds is kept only for the marker.
+    const changedHabitIds = changedHealthHabitIds(updates, habitLogs);
+    if (changedHabitIds.size === 0) return; // nothing new → don't touch state (breaks the loop)
+
+    setHabitLogs(prev => {
+      const next = { ...prev };
+      for (const [dateStr, entries] of Object.entries(updates)) {
+        const prevDay = next[dateStr] || {};
+        const merged = { ...prevDay };
+        for (const [habitId, count] of Object.entries(entries)) {
+          // Never downgrade a count already in state (e.g. a value that arrived
+          // via cloud sync from the other device's health platform).
+          merged[habitId] = Math.max(prevDay[habitId] || 0, count);
         }
-        return next;
-      });
-    }
-    if (syncedTodayIds.size > 0) {
-      const deviceId = getDeviceId();
-      const platform = isNativeIOS() ? 'iOS' : 'Android';
-      const timestamp = new Date().toISOString();
-      setHabits(prev => prev.map(h => {
-        if (!syncedTodayIds.has(h.id)) return h;
-        return { ...h, lastAutoSync: { deviceId, platform, timestamp }, lastModified: timestamp };
-      }));
-    }
+        next[dateStr] = merged;
+      }
+      return next;
+    });
+
+    // Stamp lastModified/lastAutoSync ONLY on habits whose data actually changed,
+    // and only when today's read succeeded (syncedTodayIds), so a re-sync of
+    // unchanged data never marks the row dirty.
+    const deviceId = getDeviceId();
+    const platform = isNativeIOS() ? 'iOS' : 'Android';
+    const timestamp = new Date().toISOString();
+    setHabits(prev => prev.map(h => {
+      if (!changedHabitIds.has(h.id) || !syncedTodayIds.has(h.id)) return h;
+      return { ...h, lastAutoSync: { deviceId, platform, timestamp }, lastModified: timestamp };
+    }));
   };
 
   // Keep ref current at render time (no stale closure in event listeners)

--- a/src/utils/healthHabitChanges.js
+++ b/src/utils/healthHabitChanges.js
@@ -1,0 +1,28 @@
+// Which health habits got a genuinely NEW value this sync.
+//
+// The Health Connect / HealthKit sync (src/hooks/useHabits.js) runs from an effect
+// keyed on `habits`. It used to re-stamp lastModified + lastAutoSync on every
+// health habit it read each run — so each run changed `habits`, which re-fired the
+// effect, which re-stamped again … a self-perpetuating loop that re-pushed the
+// health habits to the vault every cycle (the SSE self-nudge loop the Mac saw as
+// `[pull] apply habits:…` on every drain).
+//
+// The fix: only touch state for habits whose count actually INCREASED. Health
+// counts are merged with Math.max (never downgraded), so an idle device — no new
+// steps/sleep — produces zero changes, makes no state update, and the effect goes
+// quiet. A real step/sleep increase stamps once, then the immediate re-run reads
+// the now-stored value, finds no change, and stops.
+//
+// @param {Record<string, Record<string, number>>} updates    freshly-read counts, by date then habit id
+// @param {Record<string, Record<string, number>>} habitLogs  current stored counts
+// @returns {Set<string>} ids of habits whose count increased vs stored
+export function changedHealthHabitIds(updates, habitLogs) {
+  const changed = new Set();
+  for (const [dateStr, entries] of Object.entries(updates || {})) {
+    const prevDay = (habitLogs && habitLogs[dateStr]) || {};
+    for (const [habitId, count] of Object.entries(entries || {})) {
+      if (count > (prevDay[habitId] || 0)) changed.add(habitId);
+    }
+  }
+  return changed;
+}

--- a/src/utils/healthHabitChanges.test.js
+++ b/src/utils/healthHabitChanges.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { changedHealthHabitIds } from './healthHabitChanges.js';
+
+describe('changedHealthHabitIds', () => {
+  it('returns EMPTY when every read matches the stored count (idle → no loop)', () => {
+    const stored = { '2026-07-07': { steps: 5000, sleep: 420 } };
+    const updates = { '2026-07-07': { steps: 5000, sleep: 420 } };
+    expect(changedHealthHabitIds(updates, stored).size).toBe(0);
+  });
+
+  it('reports only the habit whose count increased', () => {
+    const stored = { '2026-07-07': { steps: 5000, sleep: 420 } };
+    const updates = { '2026-07-07': { steps: 5200, sleep: 420 } }; // steps up, sleep same
+    expect([...changedHealthHabitIds(updates, stored)]).toEqual(['steps']);
+  });
+
+  it('does NOT report a downgraded read (Math.max floor — never counts as change)', () => {
+    const stored = { '2026-07-07': { steps: 5000 } };
+    const updates = { '2026-07-07': { steps: 4999 } }; // health store briefly lower
+    expect(changedHealthHabitIds(updates, stored).size).toBe(0);
+  });
+
+  it('reports a first-of-day read (no prior value)', () => {
+    expect([...changedHealthHabitIds({ '2026-07-07': { steps: 100 } }, {})]).toEqual(['steps']);
+  });
+
+  it('considers all days in the window, not just today', () => {
+    const stored = { '2026-07-06': { steps: 3000 }, '2026-07-07': { steps: 100 } };
+    const updates = { '2026-07-06': { steps: 3500 }, '2026-07-07': { steps: 100 } };
+    expect([...changedHealthHabitIds(updates, stored)]).toEqual(['steps']); // 07-06 increased
+  });
+
+  it('tolerates empty / missing inputs', () => {
+    expect(changedHealthHabitIds({}, {}).size).toBe(0);
+    expect(changedHealthHabitIds(undefined, undefined).size).toBe(0);
+    expect([...changedHealthHabitIds({ d: { s: 1 } }, undefined)]).toEqual(['s']);
+  });
+});


### PR DESCRIPTION
## The actual remaining driver (measured)

With the fence churn reverted, the log still spammed with the Android app open — but it's **not** the Obsidian work (dailyNotes is stable). The `[pull] apply habits:<id>` on **every drain** is the tell: the phone is re-pushing two health habits continuously.

`syncHealthConnectHabits` (`src/hooks/useHabits.js`) runs from an effect **keyed on `habits`**, and it re-stamped `lastModified` + `lastAutoSync.timestamp = new Date()` on **every** health habit it read each run, **unconditionally**. So:

```
sync → re-stamp habits → `habits` changed → effect re-fires → sync → re-stamp → … forever
```

That self-loop re-pushed the health habits to the vault every cycle, keeping the whole sync hot. It's the same class as the daily-note `new Date()` re-stamp — a pre-existing latent driver that only became visible once the louder dailyNotes churn was fixed.

## Fix

Only touch state for habits whose health count **actually increased** this run (`changedHealthHabitIds`; counts merge with `Math.max`, so they never downgrade):

- **Idle device** (no new steps/sleep) → zero changes → no state update → the effect goes quiet → nothing re-pushes. **Loop broken.**
- **Real increase** → stamp once; the immediate re-run reads the now-stored value, finds no change, and stops.
- `lastAutoSync` now updates on data change rather than on every read — it rides in the synced habit entity, so a per-read bump was itself the churn.

## Tests

- `changedHealthHabitIds`: idle → empty, only-increased reported, `Math.max` downgrade ignored, first-of-day, multi-day window, empty inputs.
- Full suite **619 passing**, build clean. Android `versionCode` 155.

## Honest status

This is a *separate* churner from the Obsidian loop — I've been peeling these one at a time because there are several independent `new Date()`-restamp/resurrection drivers, and each only became visible once the louder one was silenced. After this: dailyNotes ✅, Obsidian tasks ✅, health habits ✅. The one thing still visible in your last log but **not** every-cycle is a `gtdFrames` delete↔re-create at startup (phone deletes 2 frames, Mac re-adds) — it settled in the capture, so I've left it as the next thing to watch rather than pre-emptively touching more code. If it keeps churning after this build, that's the next target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_