### PR TITLE
Tombstone expired frames in the startup cleanup (stop gtdFrames resurrection)

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 155
+        versionCode = 156
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import { checkForUpdate } from './versionCheck.js';
 import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { tombstoneHorizon } from './utils/tombstoneHorizon.js';
 import { preserveArchived } from './utils/preserveArchived.js';
+import { partitionExpiredSingleDayFrames } from './utils/expiredFrames.js';
 import { mergeObsidianDailyNotes } from './utils/mergeObsidianDailyNotes.js';
 import { mergeObsidianTasks } from './utils/mergeObsidianTasks.js';
 import { detectObsidianDeletions, addObsidianTombstones } from './utils/obsidianDeletions.js';
@@ -1800,16 +1801,26 @@ const DayPlanner = () => {
     return () => clearTimeout(midnightTimer);
   }, []);
 
-  // Cleanup expired single-day frames (older than 7 days)
+  // Cleanup expired single-day frames (older than 7 days). Keyed on gtdFrames so it
+  // also cleans frames that arrive via sync; it self-limits (once the expired ones
+  // are gone a re-run finds nothing and returns).
   useEffect(() => {
     const sevenDaysAgo = new Date();
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
     const cutoff = dateToString(sevenDaysAgo);
-    setGtdFrames(prev => {
-      const filtered = prev.filter(f => !f.singleDate || f.singleDate >= cutoff);
-      return filtered.length === prev.length ? prev : filtered;
-    });
-  }, [setGtdFrames]); // Run once on app start (setGtdFrames is stable)
+    const { kept, removed } = partitionExpiredSingleDayFrames(gtdFrames, cutoff);
+    if (!removed.length) return;
+    setGtdFrames(kept);
+    // Tombstone the removed frames (like deleteFrame) so cloud sync doesn't
+    // resurrect them from another device or a stale sync file. Without this the
+    // expired frame was only dropped from local state while a live copy survived
+    // elsewhere → it came back on the next sync → delete↔re-create every app open.
+    const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-frame-ids') || '{}');
+    const now = new Date().toISOString();
+    for (const f of removed) tombstones[String(f.id)] = now;
+    localStorage.setItem('day-planner-deleted-frame-ids', JSON.stringify(tombstones));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gtdFrames]);
 
   // Auto-sync calendars on mount and then every 15 minutes when URLs are configured.
   // On native apps, only the task calendar matters — calendar events come from the native bridge.

--- a/src/utils/expiredFrames.js
+++ b/src/utils/expiredFrames.js
@@ -1,0 +1,24 @@
+// Split GTD frames into those kept and those expired.
+//
+// A single-day frame (has `singleDate`) is expired once its date is older than
+// `cutoff` (a 'YYYY-MM-DD' string, typically today − 7 days). Recurring frames
+// (no `singleDate`) never expire.
+//
+// The startup cleanup removes the expired ones — and MUST tombstone them
+// (deletedFrameIds), exactly like the user-facing deleteFrame. Without the
+// tombstone the frame is only dropped from local state while a live copy survives
+// on another device / a stale sync file, and it resurrects on the next sync →
+// the delete↔re-create churn on every app open.
+//
+// @param {Array<{id:*, singleDate?:string}>} frames
+// @param {string} cutoff  'YYYY-MM-DD'; frames with singleDate < cutoff are expired
+// @returns {{ kept: object[], removed: object[] }}
+export function partitionExpiredSingleDayFrames(frames, cutoff) {
+  const kept = [];
+  const removed = [];
+  for (const f of frames || []) {
+    if (f && f.singleDate && f.singleDate < cutoff) removed.push(f);
+    else kept.push(f);
+  }
+  return { kept, removed };
+}

--- a/src/utils/expiredFrames.test.js
+++ b/src/utils/expiredFrames.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { partitionExpiredSingleDayFrames } from './expiredFrames.js';
+
+const cutoff = '2026-07-01';
+
+describe('partitionExpiredSingleDayFrames', () => {
+  it('removes single-day frames older than the cutoff', () => {
+    const frames = [
+      { id: 'a', singleDate: '2026-06-20' }, // expired
+      { id: 'b', singleDate: '2026-07-05' }, // in-window
+    ];
+    const { kept, removed } = partitionExpiredSingleDayFrames(frames, cutoff);
+    expect(kept.map(f => f.id)).toEqual(['b']);
+    expect(removed.map(f => f.id)).toEqual(['a']);
+  });
+
+  it('never removes recurring frames (no singleDate), even old-looking ones', () => {
+    const frames = [{ id: 'r', days: [1, 2, 3] }, { id: 'r2', days: [] }];
+    const { kept, removed } = partitionExpiredSingleDayFrames(frames, cutoff);
+    expect(removed).toEqual([]);
+    expect(kept.map(f => f.id)).toEqual(['r', 'r2']);
+  });
+
+  it('keeps a single-day frame exactly on the cutoff (>= is in-window)', () => {
+    const { removed } = partitionExpiredSingleDayFrames([{ id: 'x', singleDate: cutoff }], cutoff);
+    expect(removed).toEqual([]);
+  });
+
+  it('returns empty removed when nothing is expired (effect will no-op)', () => {
+    const { removed } = partitionExpiredSingleDayFrames([{ id: 'x', singleDate: '2026-07-09' }], cutoff);
+    expect(removed).toEqual([]);
+  });
+
+  it('tolerates empty/null input', () => {
+    expect(partitionExpiredSingleDayFrames(null, cutoff)).toEqual({ kept: [], removed: [] });
+    expect(partitionExpiredSingleDayFrames([], cutoff)).toEqual({ kept: [], removed: [] });
+  });
+});


### PR DESCRIPTION
## The last churner

With the console otherwise calm, the one remaining thing in the log was `gtdFrames` delete↔re-create at every app-open:

```
[push] deleted gtdFrames:29c6159d… / 6131ee1a…   ← cleanup removed 2 expired frames
[pull] DELETE gtdFrames:…                          ← other device did too
getData … gtdFrames:6 → 8                           ← they came back
[push] new gtdFrames:…                              ← re-created, pushed live
```

## Root cause

The expired-single-day-frame cleanup (`App.jsx:1806`) removed frames from state but — unlike the user-facing `deleteFrame` (`App.jsx:8243`, which records a `deletedFrameIds` tombstone) — **recorded no tombstone**. It's the *only* frame-removal path missing it. So the delete never stuck: a live copy survived on another device or a stale sync file (this account was previously on WebDAV), and the frame resurrected on the next sync. Each app-open re-ran the cleanup → delete → resurrect. No data loss (the frames came back), but the cleanup silently never succeeded.

## Fix

The cleanup now records a `deletedFrameIds` tombstone for every frame it removes, exactly like `deleteFrame`. That tombstone:
- syncs and prunes on the fixed 60-day horizon (`TOMBSTONE_BUNDLE_KEYS`),
- lets the file-tier merge (`mergeArrayById` + `deletedFrameIds`) suppress the stale live copy,

so the delete **converges** instead of oscillating.

Also extracted the expiry check to `partitionExpiredSingleDayFrames` (tested) and keyed the effect on `gtdFrames` (not just mount) so it also cleans expired frames that arrive via sync — self-limiting, since once they're removed a re-run finds nothing.

## Tests

- `partitionExpiredSingleDayFrames`: expired removed, recurring (no `singleDate`) never removed, cutoff boundary is inclusive, empty/null input.
- Full suite **624 passing**, build clean. Android `versionCode` 156.

## Status

This should be the last one. After it: dailyNotes ✅ · Obsidian tasks ✅ · health habits ✅ · gtdFrames ✅. If 156 shows a fully quiet console (just `drain → sync` with `written:0`), we're done — and we can pull the temporary `[pull]`/`getData counts` diagnostic in a final cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_