### PR TITLE
Rework the resurrection fence to a fixed 60-day cutoff

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 156
+        versionCode = 157
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import { voiceParseSystemPrompt, voiceParseUserPrompt, taskSuggestSystemPrompt, 
 import { gatherTrmnlData, pushToTrmnl, TRMNL_MARKUP_FULL, TRMNL_MARKUP_HALF_HORIZONTAL, TRMNL_MARKUP_HALF_VERTICAL, TRMNL_MARKUP_QUADRANT } from './trmnl.js';
 import { checkForUpdate } from './versionCheck.js';
 import { getStorageUsage, formatBytes } from './utils/storage.js';
-import { tombstoneHorizon } from './utils/tombstoneHorizon.js';
+import { tombstoneCutoff } from './sync/tombstoneRetention.js';
 import { preserveArchived } from './utils/preserveArchived.js';
 import { partitionExpiredSingleDayFrames } from './utils/expiredFrames.js';
 import { mergeObsidianDailyNotes } from './utils/mergeObsidianDailyNotes.js';
@@ -5908,21 +5908,25 @@ const DayPlanner = () => {
         multiUserEnabled,
         multiUserEnabledUpdatedAt: localStorage.getItem('dayglance-multi-user-enabled-updated-at') || null,
         users,
-        // Floored to the UTC day so this row is STABLE across sync cycles. A
-        // fresh Date.now() here changed the value every cycle, so the snapshot-
-        // diff re-pushed it every cycle → account seq advance → SSE self-nudge
-        // loop. See utils/tombstoneHorizon.js. (Pruning uses a fresh cutoff in
-        // the merge, so a day-granular fence changes nothing that gets pruned.)
+        // The resurrection fence: local-only items older than this are presumed
+        // pruned-and-deleted elsewhere and dropped rather than resurrected
+        // (merge.js syncHorizon). It MUST equal the tombstone-GC window, because a
+        // tombstone only lives 60 days (src/sync/tombstoneRetention.js): <60d-old
+        // deletions are caught by the surviving tombstone, >60d ones by this fence,
+        // and the two windows must abut with no gap. So the fence is the SAME fixed
+        // tombstoneCutoff() — NOT syncRetentionDays.
         //
-        // NOTE: this is intentionally still syncRetentionDays, NOT the fixed 60-day
-        // horizon. The value is merged with newerIso (dbAdapter.js) — monotonic,
-        // keeps the newest — so all devices MUST compute the SAME value or the ones
-        // emitting an older value churn forever (getData recomputes a value newerIso
-        // won't accept back). A fixed-60 fence is OLDER than a retention<60 device's
-        // value, so it never converges. Aligning the fence with the fixed-60 GC
-        // (the resurrection gap at retention>60 / retention=0) needs the merge
-        // reconciled first — tracked as a follow-up, not a one-line swap.
-        tombstonePrunedBefore: tombstoneHorizon(syncRetentionDays),
+        // Because it is now a pure function of the current UTC day, every device
+        // computes the identical value with no cross-device information, so the
+        // vault/file merges recompute-and-overwrite it (dbAdapter.js, mergeSync.js)
+        // instead of newerIso/max()-merging it. That is what escapes the monotonic-
+        // max() trap that made a fixed value churn forever (PR #1142): a peer's
+        // value can never be "newer" in a way we must preserve. Day-floored (via
+        // tombstoneCutoff) so the value is STABLE across the many cycles within a
+        // day — the snapshot-diff sees no change → no push → no SSE self-nudge.
+        // Residual: at UTC midnight the cutoff advances one day, so a single
+        // tombstonePrunedBefore change appears once and self-heals within a cycle.
+        tombstonePrunedBefore: tombstoneCutoff().toISOString(),
       }
     };
   };

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -396,5 +396,22 @@ export const mergeSyncData = (local, remote, retentionDays) => {
     if (!tombstoneMapsEqual(merged, remote?.[key] || {})) result.remoteChanged = true;
   }
 
+  // Override the upstream resurrection fence (which was max(localFence, remoteFence)
+  // — the monotonic-max() trap that made a fixed fence churn forever, PR #1142)
+  // with the locally-recomputed cutoff. The fence must equal the 60-day tombstone-GC
+  // window (entries younger are caught by the surviving tombstone, older by the
+  // fence, the two abutting with no gap), and it is a pure function of the current
+  // UTC day, so every device recomputes the identical value — no cross-device
+  // information to preserve, hence overwrite rather than merge. Same canonical
+  // tombstoneCutoff() the payload (buildSyncPayload) and vault merge (dbAdapter.js)
+  // use — one flooring implementation, no skew.
+  //
+  // Deliberately does NOT raise localChanged/remoteChanged: the fence is a derived
+  // value every device recomputes for itself (buildSyncPayload emits it fresh, and
+  // this merge overwrites any pulled value), so a stored copy that differs is
+  // self-healing on read and needs no propagation. Flagging it would re-introduce a
+  // per-cycle write/upload — the very churn this rework removes.
+  result.data.tombstonePrunedBefore = tombstoneCutoff().toISOString();
+
   return result;
 };

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -27,8 +27,7 @@
 // per-completion remodeling.
 
 import { mergeHabitLogs, mergeRoutineDefinitions, mergeRoutineCompletions, mergeCompletedDates } from '../mergeSync.js';
-import { floorToUtcDayIso } from '../utils/tombstoneHorizon.js';
-import { TOMBSTONE_BUNDLE_KEYS } from './tombstoneRetention.js';
+import { TOMBSTONE_BUNDLE_KEYS, tombstoneCutoff } from './tombstoneRetention.js';
 
 // ── Collection kinds: each array element is one row, keyed by a stable id, with
 // entity-grain last-writer-wins on tsField (the same grain the file-tier merge
@@ -454,12 +453,16 @@ function mergeBundle(data, key, value, extra) {
       data[key] = newerIso(data[key], value);
       return;
     case 'tombstonePrunedBefore':
-      // Floor the merged value to the UTC day so it matches the day-floored value
-      // buildSyncPayload produces (utils/tombstoneHorizon.js). Without the floor,
-      // newerIso keeps a same-day FULL-PRECISION remote value (e.g. …18:25:50Z),
-      // which never equals the floored payload value (…00:00:00Z) → the singleton
-      // row is dirty every cycle → push → seq advance → SSE self-nudge loop.
-      data[key] = floorToUtcDayIso(newerIso(data[key], value));
+      // Recompute-and-overwrite, IGNORING the pulled value. The fence is a pure
+      // function of the current UTC day (= the fixed 60-day tombstone-GC window),
+      // so the peer's value carries no information we can't reproduce locally.
+      // newerIso/max()-merging it was the monotonic-max() trap: a stuck-high peer
+      // value could never be lowered, so a device emitting the correct (lower)
+      // value re-pushed forever without ever converging (PR #1142). Overwriting
+      // with the locally-recomputed cutoff converges in one cycle. Same canonical
+      // tombstoneCutoff() the payload (App.jsx buildSyncPayload) and the file-tier
+      // merge (mergeSync.js) use — one flooring implementation, no skew.
+      data[key] = tombstoneCutoff().toISOString();
       return;
     case 'syncUrl':
     case 'taskCalendarUrl':

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -4,6 +4,7 @@ import { createDbEngine } from './dbEngine.js';
 import { getVaultConfig, setVaultConfig, isVaultEnabled } from './vaultConfig.js';
 import { getDeviceId } from './deviceId.js';
 import { registerDbEngine, markDirty, schedulePush } from './dirtyTracker.js';
+import { tombstoneCutoff } from './tombstoneRetention.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // STAGE 2 PART B — live wiring. These exercise the REAL @glance-apps/sync
@@ -229,43 +230,47 @@ describe('Part B — end-to-end two-device sync via the REAL engine', () => {
     expect(batchSpy.mock.calls.length).toBeGreaterThanOrEqual(before + 4);
   });
 
-  it('tombstonePrunedBefore CONVERGES — a floored payload vs a stuck full-precision vault value stops pushing', async () => {
-    // Reproduces the confirmed loop: buildSyncPayload emits the day-FLOORED horizon
-    // every cycle, but the vault/merge held a same-day FULL-PRECISION value, so the
-    // singleton row was dirty every cycle → push → SSE self-nudge. The fix floors
-    // BOTH sides (utils/tombstoneHorizon.js + dbAdapter bundle merge) so an
-    // unchanged cycle produces no push.
+  it('tombstonePrunedBefore CONVERGES — a stuck-HIGH vault value is overwritten with the recomputed cutoff and pushing stops', async () => {
+    // Fence rework: the horizon is a pure function of the current UTC day
+    // (tombstoneCutoff() = the fixed 60-day GC window). getData emits it every cycle
+    // and the merge RECOMPUTES-and-OVERWRITES it, so a peer's value can never
+    // survive as "newer". This is the fix to the monotonic-max() trap that made a
+    // fixed value churn forever (PR #1142): max()/newerIso could never LOWER a
+    // stuck-high value, so the device emitting the correct (lower) value re-pushed
+    // it every cycle without converging. Here a peer seeds a FUTURE (stuck-high)
+    // fence; the real engine must drag it down to the cutoff and then quiesce.
     const vault = createMemoryVault();
-    const FULL = '2026-06-04T18:25:50.481Z';        // stuck pre-fix value
-    const FLOORED = '2026-06-04T00:00:00.000Z';     // what tombstoneHorizon() emits
+    const STUCK_HIGH = '2099-01-01T12:34:56.789Z'; // a value max() could never lower
+    const cutoff = tombstoneCutoff().toISOString(); // what buildSyncPayload emits
 
-    // Seed the vault with the FULL-PRECISION value via another device.
-    const B = makeDevice('B', vault, { ...EMPTY, tombstonePrunedBefore: FULL });
+    // Seed the vault with the stuck-high value via another device.
+    const B = makeDevice('B', vault, { ...EMPTY, tombstonePrunedBefore: STUCK_HIGH });
     await B.engine.dbSyncCycle();
 
-    // Device A's getData ALWAYS returns the floored value (as buildSyncPayload does).
+    // Device A's getData ALWAYS returns the recomputed cutoff (as buildSyncPayload does).
     let key = null;
     let data = { ...EMPTY };
     const engineA = createDbEngine({
       vaultClient: vault,
-      storageKeyPrefix: 'dev-A-floor',
-      deviceId: 'device-A-floor',
+      storageKeyPrefix: 'dev-A-fence',
+      deviceId: 'device-A-fence',
       nativeGetSyncKey: () => key,
       nativeStoreSyncKey: (v) => { key = v; },
-      getData: () => ({ ...clone(data), tombstonePrunedBefore: FLOORED }),
+      getData: () => ({ ...clone(data), tombstonePrunedBefore: cutoff }),
       commitData: (d) => { data = d; },
     });
 
     const batchSpy = vi.spyOn(vault, 'batch');
-    for (let i = 0; i < 6; i++) await engineA.dbSyncCycle();  // settle
+    for (let i = 0; i < 6; i++) await engineA.dbSyncCycle();  // settle (incl. the corrective re-push)
     const settled = batchSpy.mock.calls.length;
 
-    // Unchanged cycles now push NOTHING — floored payload == floored stored value.
+    // Unchanged cycles now push NOTHING — recomputed payload == overwritten stored value.
     await engineA.dbSyncCycle();
     await engineA.dbSyncCycle();
     expect(batchSpy.mock.calls.length).toBe(settled);
-    // And the merged/committed value is the floored form.
-    expect(data.tombstonePrunedBefore).toBe(FLOORED);
+    // The stuck-high value was overwritten with the local cutoff — NOT kept (which
+    // newerIso/max() would have done, churning forever).
+    expect(data.tombstonePrunedBefore).toBe(cutoff);
   });
 
   it('a cross-list move (unscheduled → scheduled) ends under exactly one kind on both devices', async () => {

--- a/src/sync/tombstoneFence.test.js
+++ b/src/sync/tombstoneFence.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { createVault, createDevice, syncToConvergence } from './dbVaultSim.js';
+import { makeEntityId, SINGLETON_KIND, applyRemoteEntity } from './dbAdapter.js';
+import { tombstoneCutoff } from './tombstoneRetention.js';
+import { mergeSyncData } from '../mergeSync.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE FENCE REWORK (tombstonePrunedBefore): CONVERGENCE.
+//
+// The resurrection fence is now a PURE FUNCTION of the current UTC day
+// (= tombstoneCutoff(), the fixed 60-day GC window). The peer's value therefore
+// carries no information a device can't reproduce locally, so all three sites
+// recompute-and-OVERWRITE it rather than newerIso/max()-merging it:
+//   • the payload (App.jsx buildSyncPayload → tombstoneCutoff().toISOString())
+//   • the VAULT merge (dbAdapter.js mergeBundle 'tombstonePrunedBefore')
+//   • the FILE-tier merge (mergeSync.js override)
+// This is the fix to the monotonic-max() trap of PR #1142: max() could never
+// LOWER a stuck-high value, so a device emitting the correct (lower) value
+// re-pushed forever without converging.
+//
+// Residual (documented, NOT "zero churn"): the cutoff advances one UTC day per
+// day, so around midnight one device briefly computes yesterday's value and the
+// other today's — a single tombstonePrunedBefore change that self-heals within a
+// cycle. Case (b) proves the self-heal.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DAY = 86400000;
+const daysAgo = (n) => new Date(Date.now() - n * DAY).toISOString();
+const singleton = (value) => ({ _kind: SINGLETON_KIND, _key: 'tombstonePrunedBefore', value });
+const FENCE_ID = makeEntityId(SINGLETON_KIND, 'tombstonePrunedBefore');
+
+const emptyData = () => ({
+  tasks: [], unscheduledTasks: [], recycleBin: [], recurringTasks: [],
+  completedTaskUids: [], deletedTaskIds: {},
+  syncUrl: null, taskCalendarUrl: null,
+  routineDefinitions: {}, todayRoutines: [], routinesDate: '',
+  minimizedSections: {}, use24HourClock: false,
+});
+
+describe('fence rework — one canonical tombstoneCutoff(), no reimplemented flooring', () => {
+  it('CONDITION 1: payload, vault merge, and file-tier merge all emit the identical value', () => {
+    const canonical = tombstoneCutoff().toISOString();
+
+    // VAULT tier (dbAdapter.mergeBundle via applyRemoteEntity): whatever the peer
+    // sent, we store the locally-recomputed cutoff.
+    const vaultData = {};
+    applyRemoteEntity(vaultData, singleton(daysAgo(3)));
+
+    // FILE tier (mergeSync override).
+    const { data: fileData } = mergeSyncData(emptyData(), emptyData(), 30);
+
+    expect(vaultData.tombstonePrunedBefore).toBe(canonical);
+    expect(fileData.tombstonePrunedBefore).toBe(canonical);
+    // The payload emits tombstoneCutoff().toISOString() directly (App.jsx) — the
+    // SAME call, so it is identical by construction. If any site reimplemented the
+    // flooring instead of calling tombstoneCutoff(), these would drift and this
+    // assertion would catch it.
+  });
+});
+
+describe('fence rework — convergence (CONDITION 2)', () => {
+  it('(a) a stuck-HIGH peer value is overwritten with the local cutoff in one merge', () => {
+    const future = new Date(Date.now() + 30 * DAY).toISOString(); // a stuck-high fence
+    const data = { tombstonePrunedBefore: future };
+    const rePush = applyRemoteEntity(data, singleton(future));
+
+    // Overwritten with the recomputed cutoff — NOT kept at the stuck-high value
+    // (which max()/newerIso would have done forever).
+    expect(data.tombstonePrunedBefore).toBe(tombstoneCutoff().toISOString());
+    // We pulled the stuck-high row but now hold the corrected (lower) value, so we
+    // re-push it to drag the vault/peer down. That re-push TERMINATES: once the
+    // vault holds the cutoff, the next merge stores the same cutoff → no re-push.
+    expect(rePush).toEqual([FENCE_ID]);
+  });
+
+  it('(a) no churn: the merged value equals the getData recompute → a clean cycle', () => {
+    // The #1142 churn was: merge stored the (higher) peer value, but getData
+    // recomputed the (lower) payload value every cycle → perpetual snapshot-diff.
+    // Now both are tombstoneCutoff(), so the fixed point is reached.
+    const mirror = {};
+    applyRemoteEntity(mirror, singleton(new Date(Date.now() + 30 * DAY).toISOString()));
+    const getDataRecompute = tombstoneCutoff().toISOString(); // what buildSyncPayload emits
+    expect(mirror.tombstonePrunedBefore).toBe(getDataRecompute); // no diff → no re-push
+  });
+
+  it('(a) two devices with divergent stuck values converge (does not hang)', () => {
+    const vault = createVault();
+    const a = createDevice('A', { tombstonePrunedBefore: new Date(Date.now() + 30 * DAY).toISOString() });
+    const b = createDevice('B', { tombstonePrunedBefore: daysAgo(120) });
+    a.mutate(() => [FENCE_ID]);
+    b.mutate(() => [FENCE_ID]);
+    syncToConvergence(a, b, vault); // throws if it never settles
+    expect(a.data.tombstonePrunedBefore).toBe(tombstoneCutoff().toISOString());
+    expect(b.data.tombstonePrunedBefore).toBe(tombstoneCutoff().toISOString());
+  });
+
+  it('(b) UTC-midnight rollover: an adjacent-day peer value self-heals to the current cutoff', () => {
+    const yesterday = new Date(tombstoneCutoff().getTime() - DAY).toISOString();
+    const mirror = { tombstonePrunedBefore: yesterday };
+    // Peer still on yesterday's cutoff (it hasn't rolled over yet).
+    const rePush = applyRemoteEntity(mirror, singleton(yesterday));
+    // We compute TODAY's cutoff and overwrite — the fence advances exactly one day.
+    expect(mirror.tombstonePrunedBefore).toBe(tombstoneCutoff().toISOString());
+    // We re-push today's value so the lagging peer is dragged forward within a cycle.
+    expect(rePush).toEqual([FENCE_ID]);
+    // Once both are on today's value the merge is a no-op — the self-heal terminates.
+    const rePush2 = applyRemoteEntity(mirror, singleton(tombstoneCutoff().toISOString()));
+    expect(rePush2).toEqual([]);
+  });
+
+  it('(c) mixed retention (90d, 30d, 0) all land on the SAME today-60 fence', () => {
+    const cutoff = tombstoneCutoff().toISOString();
+    for (const retention of [90, 30, 0]) {
+      // Sides carry deliberately different stale fence values AND different
+      // retention — none of it changes the result.
+      const local = { ...emptyData(), tombstonePrunedBefore: daysAgo(90) };
+      const remote = { ...emptyData(), tombstonePrunedBefore: daysAgo(30) };
+      const { data } = mergeSyncData(local, remote, retention);
+      expect(data.tombstonePrunedBefore).toBe(cutoff);
+    }
+    // The VAULT tier takes no retention parameter at all (dbAdapter.mergeBundle),
+    // so it is retention-agnostic by construction — proven in CONDITION 1 above.
+  });
+});
+
+describe('fence rework — stability within a day (CONDITION 3 residual is bounded)', () => {
+  it('is STABLE across the many cycles of a single UTC day (only advances at midnight)', () => {
+    const morning = tombstoneCutoff(Date.parse('2026-07-06T00:00:01.000Z')).toISOString();
+    const night = tombstoneCutoff(Date.parse('2026-07-06T23:59:59.000Z')).toISOString();
+    expect(morning).toBe(night); // same UTC day → identical → no intra-day churn
+    const nextDay = tombstoneCutoff(Date.parse('2026-07-07T00:00:01.000Z')).toISOString();
+    expect(nextDay).not.toBe(night); // advances exactly once, at the UTC boundary
+  });
+});

--- a/src/sync/tombstoneResurrection.test.js
+++ b/src/sync/tombstoneResurrection.test.js
@@ -152,3 +152,57 @@ describe('tombstone GC — the >60-day boundary is real (unchanged by the fix)',
     expect(data.tasks.find((t) => t.id === 'X')).toBeTruthy();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FENCE REWORK safety, derived from the requirement (NOT retrofitted to output).
+//
+// The fence a peer now emits is the PRODUCED value tombstoneCutoff().toISOString()
+// (App.jsx buildSyncPayload / dbAdapter / mergeSync — all the same call), i.e.
+// today-60. merge.js:88 drops a LOCAL-only item strictly older than that fence.
+// The rework is safe iff the fence draws the zombie/live line at EXACTLY the
+// 60-day tombstone-GC window, in BOTH directions:
+//   • UP  (no resurrection):   a local-only item older than 60d whose tombstone
+//                              has been GC'd is dropped, not re-uploaded.
+//   • DOWN (no data loss):     a genuinely recent local-only item — a real edit on
+//                              a device that was merely offline — is NOT dropped.
+// The DOWN direction is the one that broke two days ago (PR #1142 churn / the
+// fear of eating live data); it is asserted here against the real produced fence.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('fence rework — the PRODUCED today-60 fence is safe in both directions', () => {
+  const producedFence = () => tombstoneCutoff().toISOString();
+
+  it('UP: drops a local-only zombie older than 60 days (deleted-and-pruned stays gone)', () => {
+    // Deleted >60d ago on a peer, tombstone since GC'd; this stale device still holds
+    // X live. The produced fence must suppress it rather than resurrect it.
+    const localStale = { ...EMPTY, tasks: [{ id: 'X', title: 'buy milk', lastModified: daysAgo(75) }], deletedTaskIds: {} };
+    const remoteUpToDate = { ...EMPTY, tasks: [], deletedTaskIds: {}, tombstonePrunedBefore: producedFence() };
+    const { data } = mergeSyncData(localStale, remoteUpToDate, 30);
+    expect(data.tasks.find((t) => t.id === 'X')).toBeUndefined(); // 75d > 60d → dropped
+  });
+
+  it('DOWN: KEEPS a genuinely recent local-only item (an offline edit is not eaten)', () => {
+    // A real task created on a device that was simply offline for a bit — never
+    // deleted, no tombstone. It must survive the fence, or the fix loses live data.
+    const recent = { id: 'R', title: 'new idea', lastModified: daysAgo(10) };
+    const localOffline = { ...EMPTY, tasks: [recent], deletedTaskIds: {} };
+    const remoteUpToDate = { ...EMPTY, tasks: [], deletedTaskIds: {}, tombstonePrunedBefore: producedFence() };
+    const { data } = mergeSyncData(localOffline, remoteUpToDate, 30);
+    expect(data.tasks.find((t) => t.id === 'R')).toBeTruthy(); // 10d < 60d → preserved
+  });
+
+  it('the zombie/live boundary is 60 days, INDEPENDENT of syncRetentionDays', () => {
+    // The whole point of the rework: retention no longer moves the fence. A 30d and
+    // a 90d device both draw the line at the identical 60-day point. (Floored
+    // cutoff ∈ [now-61d, now-60d], so 59d is always kept and 61d always dropped,
+    // regardless of the time of day the test runs.)
+    const keep = { id: 'A', title: 'keep', lastModified: daysAgo(59) };
+    const drop = { id: 'B', title: 'drop', lastModified: daysAgo(61) };
+    for (const retention of [30, 90]) {
+      const local = { ...EMPTY, tasks: [keep, drop], deletedTaskIds: {} };
+      const remote = { ...EMPTY, tasks: [], deletedTaskIds: {}, tombstonePrunedBefore: producedFence() };
+      const { data } = mergeSyncData(local, remote, retention);
+      expect(data.tasks.find((t) => t.id === 'A')).toBeTruthy();    // 59d < 60d → kept
+      expect(data.tasks.find((t) => t.id === 'B')).toBeUndefined(); // 61d > 60d → dropped
+    }
+  });
+});

--- a/src/utils/tombstoneHorizon.js
+++ b/src/utils/tombstoneHorizon.js
@@ -23,10 +23,14 @@
 // slightly longer; suppresses resurrection marginally less) and well within the
 // field's inherently fuzzy semantics.
 //
-// NOTE: the value is passed by the caller (buildSyncPayload) as syncRetentionDays,
-// NOT the fixed-60 GC horizon. It's merged with newerIso (monotonic newest), so all
-// devices must compute the SAME value or the older-valued ones churn forever. See
-// the note at the buildSyncPayload call site.
+// NOTE: as of the fence rework, the production resurrection fence
+// (tombstonePrunedBefore) no longer flows through tombstoneHorizon(syncRetentionDays).
+// It is computed by tombstoneCutoff() (src/sync/tombstoneRetention.js) — the fixed
+// 60-day GC window — and RECOMPUTED-AND-OVERWRITTEN on merge (dbAdapter.js,
+// mergeSync.js) rather than newerIso/max()-merged, which is what escapes the
+// monotonic-max() trap (PR #1142). tombstoneHorizon() remains only as the tested
+// day-flooring helper; floorToUtcDayIso below is the shared flooring primitive that
+// tombstoneCutoff() builds on, so both sides floor identically.
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## What & why

`tombstonePrunedBefore` — the `merge.js` resurrection fence — was computed as `tombstoneHorizon(syncRetentionDays)` and merged across devices with `newerIso`/`max()`. Two problems:

1. **Data integrity (the real reason, not cosmetic):** tombstone pruning runs at a **fixed 60 days**, but a `retention>60` device (e.g. a 90-day Mac) emitted a fence of `today-90`. Anything deleted **60–90 days ago** had its tombstone GC'd yet sat **above** the fence → it resurrected on the file tier. Live data-integrity bug.
2. **Churn:** `newerIso`/`max()` is monotonic — it can never **lower** a stuck-high peer value, so a device emitting the correct (lower) value re-pushed it every cycle without converging. This is the [#1142] regression that was previously reverted.

## The fix

The fence is now the **same fixed `tombstoneCutoff()`** as the GC window, so the two windows abut with no gap:
- **<60d** deletions are suppressed by the surviving tombstone,
- **>60d** ones by the fence.

Because the value is a **pure function of the current UTC day**, it carries no cross-device information — so every site **recompute-and-overwrites** it instead of merging, which structurally escapes the `max()` trap.

One canonical `tombstoneCutoff()` (UTC-day floored) is called from **all three sites** — `buildSyncPayload` (App.jsx), the vault merge (`dbAdapter.js`), and the file-tier merge (`mergeSync.js`) — with **no reimplemented flooring**, so the sides cannot skew. The file-tier override sets the value but deliberately does **not** raise `localChanged`/`remoteChanged`: the fence is self-healing on read, and propagating it would re-introduce the per-cycle write.

## Load-bearing invariant (verified)

Safe only if tombstones genuinely persist a full 60 days on **every** device regardless of `syncRetentionDays`. Traced every path that can shrink a persisted bundle — both are fixed-60 and retention-independent:
- **Vault:** `dbEngine.js` `pruneAllTombstones(mirror, tombstoneCutoff())`.
- **File tier:** `mergeSync.js` reconstructs from the raw union and prunes at `tombstoneCutoff()`, overwriting the upstream retention-based prune; upstream suppression runs on the **unpruned** union first.

The one remaining `syncRetentionDays` use near tombstones (App.jsx task-calendar tombstoning) only **adds** entries — not a deletion path.

## Residual (documented — not "zero churn")

The cutoff advances one UTC day per day, so at midnight a single `tombstonePrunedBefore` change appears once and self-heals within a cycle. Benign.

## Proofs

- **`tombstoneFence.test.js` (new):** canonical-value identity across all three sites; convergence for (a) stuck-high overwrite, (b) UTC-midnight rollover self-heal, (c) mixed 90d/30d/0 retention all landing on today-60; intra-day stability.
- **`tombstoneResurrection.test.js`:** new block derived from the safety requirement asserting **both** directions against the *produced* fence — a >60d local-only zombie is dropped (no resurrection) **and** a recent offline edit is not dropped (no data loss), boundary pinned at 60d independent of `syncRetentionDays`.
- **`dbEngineWiring.test.js`:** re-derived the engine convergence test — a stuck-high vault value is overwritten with the recomputed cutoff and pushing stops (previously asserted the superseded flooring-both-sides behavior).

Full suite: **634 passed**. Lint clean.

Android `versionCode` 156 → 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_