### PR TITLE
Stop the seed-task resurrection: tombstone-guard the post-merge task rescue

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 157
+        versionCode = 158
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import { checkForUpdate } from './versionCheck.js';
 import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { tombstoneCutoff } from './sync/tombstoneRetention.js';
 import { preserveArchived } from './utils/preserveArchived.js';
+import { rescueUnsyncedTasks } from './utils/rescueUnsyncedTasks.js';
 import { partitionExpiredSingleDayFrames } from './utils/expiredFrames.js';
 import { mergeObsidianDailyNotes } from './utils/mergeObsidianDailyNotes.js';
 import { mergeObsidianTasks } from './utils/mergeObsidianTasks.js';
@@ -6157,16 +6158,13 @@ const DayPlanner = () => {
     // which React guarantees is fresh (the closure/refs above can lag the very
     // latest heal). This is what stops the setState from clobbering a locally-
     // archived item when the merged copy omits the flag.
-    if (normalizedTasks) setTasks(prev => {
-      const preserved = preserveArchived(normalizedTasks, prev);
-      const mergedIds = new Set(preserved.map(t => String(t.id)));
-      return [...preserved, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
-    });
-    if (normalizedUnsched) setUnscheduledTasks(prev => {
-      const preserved = preserveArchived(normalizedUnsched, prev);
-      const mergedIds = new Set(preserved.map(t => String(t.id)));
-      return [...preserved, ...prev.filter(t => !mergedIds.has(String(t.id)) && (t._native || t.imported || t._intentKey))];
-    });
+    // Rescue local-only native/imported/intent tasks the merge didn't govern, but
+    // NEVER re-add a task the merge has tombstoned (deletedTaskIds, merged post-pull)
+    // — that resurrects a task deleted on another device (the seed-task ping-pong).
+    // See utils/rescueUnsyncedTasks.js.
+    const rescueDeletedIds = data.deletedTaskIds || {};
+    if (normalizedTasks) setTasks(prev => rescueUnsyncedTasks(preserveArchived(normalizedTasks, prev), prev, rescueDeletedIds));
+    if (normalizedUnsched) setUnscheduledTasks(prev => rescueUnsyncedTasks(preserveArchived(normalizedUnsched, prev), prev, rescueDeletedIds));
     if (data.unscheduledOrderTimestamp) {
       setUnscheduledOrderTimestamp(data.unscheduledOrderTimestamp);
       localStorage.setItem('day-planner-unscheduled-order-ts', data.unscheduledOrderTimestamp);
@@ -6175,10 +6173,8 @@ const DayPlanner = () => {
     if (!perUserCalendar && data.syncUrl !== undefined) setSyncUrl(data.syncUrl);
     if (!perUserCalendar && data.taskCalendarUrl !== undefined) setTaskCalendarUrl(data.taskCalendarUrl);
     if (data.completedTaskUids) setCompletedTaskUids(new Set(data.completedTaskUids));
-    if (data.recurringTasks) setRecurringTasks(prev => {
-      const mergedIds = new Set(data.recurringTasks.map(t => String(t.id)));
-      return [...data.recurringTasks, ...prev.filter(t => !mergedIds.has(String(t.id)) && t._intentKey)];
-    });
+    if (data.recurringTasks) setRecurringTasks(prev =>
+      rescueUnsyncedTasks(data.recurringTasks, prev, rescueDeletedIds, t => !!t._intentKey));
     if (data.routineDefinitions) setRoutineDefinitions(data.routineDefinitions);
     // Only apply today's routine state if the remote data is from today — matching
     // the localStorage guard above. If routinesDate is stale/off, applying it would

--- a/src/utils/rescueUnsyncedTasks.js
+++ b/src/utils/rescueUnsyncedTasks.js
@@ -1,0 +1,46 @@
+// After a sync merge is applied to React state, re-add device-local tasks that
+// the merge never governed — native OS tasks, imported calendar items, and
+// external-intent tasks — which buildSyncPayload excludes from the payload (or
+// which were added locally in the race window between payload-build and apply),
+// so the merged result legitimately doesn't contain them and a plain replace
+// would drop them.
+//
+// THE TOMBSTONE GUARD (the fix): a task that IS synced but carries one of those
+// flags (e.g. old seed data with `imported: true`) sits in a gap — buildSyncPayload
+// pushes it, so a delete on another device propagates here as an absence from the
+// merged set, yet the flag-based rescue re-adds it every cycle. buildSyncPayload
+// then re-pushes it and the peer re-deletes it: the seed-task resurrection
+// ping-pong. The rescue therefore MUST skip any id the merge has tombstoned
+// (`deletedIds`, the merged post-pull deletedTaskIds set) — those were deleted
+// elsewhere and must stay deleted. An untombstoned flagged task is still a genuine
+// race-add and is preserved.
+//
+// KNOWN BOUNDARY (not a flaw): a tombstone only lives 60 days (the fence/GC window,
+// src/sync/tombstoneRetention.js). A device offline longer than 60 days still holds
+// the task in `prev`, its tombstone has been GC'd, and the fence-suppressed merged
+// set lacks it — so the guard can't fire and the re-add resurrects it. This is the
+// same 60-day limit the resurrection fence has, inherent to a finite tombstone
+// policy, not specific to this rescue.
+
+// Default: the merge doesn't govern native / imported / intent tasks.
+export const isDefaultRescuable = (t) => !!(t && (t._native || t.imported || t._intentKey));
+
+/**
+ * @param {object[]} mergedList  the merged/committed list to keep as-is
+ * @param {object[]} prevList    the current in-memory list (may hold local-only tasks)
+ * @param {Record<string,string>} [deletedIds]  merged deletedTaskIds tombstones {id → ISO}
+ * @param {(t:object)=>boolean} [isRescuable]  which prev-only tasks are eligible to rescue
+ * @returns {object[]} mergedList followed by the rescued (untombstoned) prev-only tasks
+ */
+export function rescueUnsyncedTasks(mergedList, prevList, deletedIds = {}, isRescuable = isDefaultRescuable) {
+  const merged = Array.isArray(mergedList) ? mergedList : [];
+  const mergedIds = new Set(merged.map((t) => String(t.id)));
+  const tombstoned = deletedIds || {};
+  const rescued = (Array.isArray(prevList) ? prevList : []).filter((t) =>
+    t
+    && !mergedIds.has(String(t.id))
+    && isRescuable(t)
+    && !tombstoned[String(t.id)]   // never resurrect a task the merge has tombstoned
+  );
+  return [...merged, ...rescued];
+}

--- a/src/utils/rescueUnsyncedTasks.test.js
+++ b/src/utils/rescueUnsyncedTasks.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { rescueUnsyncedTasks, isDefaultRescuable } from './rescueUnsyncedTasks.js';
+
+const merged = (...ids) => ids.map((id) => ({ id, title: id }));
+const imported = (id, extra = {}) => ({ id, title: id, imported: true, ...extra });
+const native = (id) => ({ id, title: id, _native: true });
+const intent = (id) => ({ id, title: id, _intentKey: `k-${id}` });
+const plain = (id) => ({ id, title: id });
+
+describe('rescueUnsyncedTasks', () => {
+  it('preserves an untombstoned local-only imported task (the race-add rescue is intact)', () => {
+    const prev = [imported('imp-1')];
+    const out = rescueUnsyncedTasks(merged('a'), prev, {});
+    expect(out.map((t) => t.id)).toEqual(['a', 'imp-1']);
+  });
+
+  it('DROPS a tombstoned imported task — no resurrection (the seed-task fix)', () => {
+    // The merge dropped imp-1 because a peer deleted it; deletedTaskIds carries the
+    // tombstone. Without the guard the flag-based rescue would re-add it every sync.
+    const prev = [imported('imp-1')];
+    const deletedIds = { 'imp-1': '2026-07-01T00:00:00.000Z' };
+    const out = rescueUnsyncedTasks(merged('a'), prev, deletedIds);
+    expect(out.map((t) => t.id)).toEqual(['a']); // imp-1 stays gone
+  });
+
+  it('preserves a native task and drops a tombstoned one independently', () => {
+    const prev = [native('nat-live'), native('nat-dead')];
+    const out = rescueUnsyncedTasks(merged('a'), prev, { 'nat-dead': '2026-07-01T00:00:00.000Z' });
+    expect(out.map((t) => t.id)).toEqual(['a', 'nat-live']);
+  });
+
+  it('never rescues a plain (unflagged) synced task, tombstoned or not', () => {
+    // Plain tasks are governed entirely by the merge — absence means deleted.
+    const prev = [plain('p-1')];
+    expect(rescueUnsyncedTasks(merged('a'), prev, {}).map((t) => t.id)).toEqual(['a']);
+    expect(rescueUnsyncedTasks(merged('a'), prev, { 'p-1': '2026-07-01T00:00:00.000Z' }).map((t) => t.id)).toEqual(['a']);
+  });
+
+  it('does not rescue a task already present in the merged list (no duplication)', () => {
+    const prev = [imported('a')]; // same id as a merged item
+    const out = rescueUnsyncedTasks(merged('a'), prev, {});
+    expect(out.map((t) => t.id)).toEqual(['a']);
+  });
+
+  it('honors a custom rescuable predicate (recurring: _intentKey only) with the same tombstone guard', () => {
+    const prev = [intent('int-live'), intent('int-dead'), imported('imp-x')];
+    const isRescuable = (t) => !!t._intentKey;
+    const out = rescueUnsyncedTasks(merged('a'), prev, { 'int-dead': '2026-07-01T00:00:00.000Z' }, isRescuable);
+    // imp-x is not _intentKey → not eligible; int-dead is tombstoned → dropped.
+    expect(out.map((t) => t.id)).toEqual(['a', 'int-live']);
+  });
+
+  it('KNOWN 60-DAY BOUNDARY: an offline-past-60 task has no tombstone, so it IS resurrected', () => {
+    // Device offline > 60 days: the task is still in prev, its tombstone has been
+    // GC'd (deletedIds no longer has it), and the fence-suppressed merge lacks it.
+    // The guard cannot fire — the re-add resurrects it. This is the inherent limit
+    // of a 60-day tombstone policy (same boundary as the resurrection fence), and is
+    // asserted here so it reads as a documented boundary, not a future regression.
+    const prev = [imported('imp-ancient')];
+    const deletedIdsAfterGc = {}; // tombstone pruned at 60 days
+    const out = rescueUnsyncedTasks(merged('a'), prev, deletedIdsAfterGc);
+    expect(out.map((t) => t.id)).toEqual(['a', 'imp-ancient']); // resurrected — known limit
+  });
+
+  it('tolerates empty / null inputs', () => {
+    expect(rescueUnsyncedTasks(null, null, null)).toEqual([]);
+    expect(rescueUnsyncedTasks([], undefined)).toEqual([]);
+    expect(rescueUnsyncedTasks(merged('a'), null).map((t) => t.id)).toEqual(['a']);
+  });
+
+  it('isDefaultRescuable flags native / imported / intent, not plain', () => {
+    expect(isDefaultRescuable(native('n'))).toBe(true);
+    expect(isDefaultRescuable(imported('i'))).toBe(true);
+    expect(isDefaultRescuable(intent('t'))).toBe(true);
+    expect(isDefaultRescuable(plain('p'))).toBe(false);
+    expect(isDefaultRescuable(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Root cause

`applyEngineData` re-adds local-only tasks the sync merge didn't govern — `_native`, `imported`, and `_intentKey` tasks — so a plain replace of React state doesn't drop them (they're excluded from `buildSyncPayload`, or were added in the race window between payload-build and apply). The rescue filtered on `_native || imported || _intentKey` with **no check against tombstones**.

That resurrects any such task **deleted on another device**. Old seed data carries `imported: true` and still passes `buildSyncPayload`'s `keepImported` filter (it's `isTaskCalendar`/`file`-imported, not read-only CalDAV), so it sits in a gap: **synced** — so a peer's delete propagates here as an absence from the merged set — yet **blanket-re-added every cycle**. `buildSyncPayload` then reads React `tasks`, re-pushes it, the peer re-deletes it, forever. That's the `demo-*` / `hg-demo-*` ping-pong (`tasks:544→451→544`, `unscheduled:288→192→288`).

## Fix

The rescue now skips any id the merge has tombstoned. Extracted into a pure, tested helper (`utils/rescueUnsyncedTasks.js`), which also de-duplicates the three identical inline re-adds (`tasks`, `unscheduledTasks`, `recurringTasks`).

```js
&& !deletedIds[String(t.id)]   // never resurrect a task the merge has tombstoned
```

An untombstoned flagged task is still a genuine race-add and is preserved — the rescue's original purpose is intact.

## Verified during implementation

- **Guard reads the merged post-pull tombstone set.** `applyEngineData` runs as `commitData(clone(mirror))` at `dbEngine.js:396`, *after* `pullRemoteChanges()` and `pruneAllTombstones(mirror)`; the `deletedTaskIds` singleton unions in during pull. So `data.deletedTaskIds` is the merged, pruned set — the Mac sees the peer's tombstone on the **same cycle**. Convergence is immediate, not +1 cycle.
- **Known 60-day boundary (asserted, not a flaw).** A device offline > 60 days holds the task in `prev`, its tombstone GC'd, and the fence-suppressed merge lacks it — the guard can't fire and the re-add resurrects it. Same 60-day limit as the resurrection fence (#1146), inherent to a finite tombstone policy. Covered by a test so it reads as a documented boundary.

## Convergence caveat (corrects an earlier claim)

Auto-heal depends on the fence rework (#1146, now merged) making tombstone GC uniform at 60 days. This heals a ping-ponging task **only while its tombstone is still inside the 60-day window**. A demo task deleted > 60 days ago has had its tombstone pruned and needs **one manual re-delete** to re-tombstone. `deletedTaskIds` is never used to filter active tasks and the pasted log carries no tombstone timestamps, so I can't bucket them from here — but the churning IDs encode an **April-2026 creation**, so some plausibly fall past the window.

To bucket them on-device (DevTools console on the Mac):

```js
(() => {
  const t = JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}');
  const cut = Date.now() - 60*86400000;
  const demo = Object.entries(t).filter(([id]) => id.startsWith('demo-') || id.startsWith('hg-demo-'));
  const live = demo.filter(([,ts]) => Date.parse(ts) >= cut);
  const pruned = Object.keys(Object.fromEntries(demo)); // ids present; anything ping-ponging but ABSENT here has no tombstone
  console.log('demo tombstones still live (<60d, auto-heal):', live.map(([id]) => id));
  console.log('demo tombstones present total:', demo.length, '— any churning id NOT in this list was GC\'d and needs one manual re-delete');
})();
```

## Architectural note (on record, not fixed here)

The reason a UI-state rescue can corrupt sync at all is that **`buildSyncPayload` reads React `tasks` rather than the committed engine mirror**. The guard is the right fix inside that architecture, but that coupling — app state, not the mirror, being the sync source of truth — is where the next bug in this class will come from. Flagging it deliberately; out of scope for this PR.

## Tests

`utils/rescueUnsyncedTasks.test.js` (9 cases): untombstoned imported/native preserved (rescue intact); tombstoned imported/native/intent dropped (no resurrection); plain synced tasks never rescued; no duplication; custom `_intentKey` predicate for recurring; the offline-past-60 boundary; empty/null tolerance.

Full suite: **643 passed**. Lint clean.

Android `versionCode` 157 → 158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_