### PR TITLE
Guard the vault engine against broadcasting a local-state glitch as fleet-wide deletion

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 158
+        versionCode = 159
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -36,6 +36,7 @@ import {
   reconcileCrossList,
 } from './dbAdapter.js';
 import { pruneAllTombstones, tombstoneCutoff } from './tombstoneRetention.js';
+import { partitionSnapshotDeletes } from './snapshotDeleteGuard.js';
 
 const APP_ID = 'dayglance';
 const CRYPTO_DB_NAME = 'dayglance-db-crypto';
@@ -347,10 +348,27 @@ export function createDbEngine(callbacks = {}) {
             dbgChanges.push({ id, kind: prev[id] === undefined ? 'new' : 'changed', diff: debugDiffLeaves(a, b) });
           }
         }
+        // Deletes: an entity in the last snapshot but absent from getData(). Guard
+        // against a transient in-memory shrink (a bad merge / load-save race) being
+        // broadcast as permanent fleet-wide deletion — a real delete leaves a
+        // tombstone or moves the id to another list; a bare vanish with neither is a
+        // suspected glitch and is kept, not deleted. See snapshotDeleteGuard.js.
+        const wantDelete = [];
         for (const id of Object.keys(prev)) {
           if (id in cur) continue;
+          wantDelete.push(id);
+        }
+        const { propagate, skipped } = partitionSnapshotDeletes(wantDelete, cur, mirror);
+        for (const id of propagate) {
           engine.markDirty(id); // deletes
           if (dbgChanges) dbgChanges.push({ id, kind: 'deleted', diff: [] });
+        }
+        if (skipped.length) {
+          console.warn(
+            `[push] GUARD: skipped ${skipped.length} un-tombstoned vanish-delete(s) — ` +
+            `suspected local-state glitch, rows kept (would-be fleet-wide deletion). ` +
+            `Ids:`, skipped.slice(0, 25), skipped.length > 25 ? `(+${skipped.length - 25} more)` : ''
+          );
         }
       }
 

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -293,6 +293,39 @@ describe('Part B — end-to-end two-device sync via the REAL engine', () => {
       expect(inUnsched).toBe(false);
     }
   });
+
+  it('GUARD: a glitch-vanish is NOT propagated (kept), but a tombstoned delete IS', async () => {
+    // Reproduces the incident end-to-end through the REAL cycle: a device's in-memory
+    // task list transiently shrinks. Without the guard the diff broadcasts that as a
+    // permanent delete and the fleet loses a live, un-deleted task. 700 exercises the
+    // glitch path; 701 the genuine-deletion path.
+    const vault = createMemoryVault();
+    const A = makeDevice('A', vault, {
+      ...EMPTY,
+      tasks: [task(700, '2026-06-18T10:00:00.000Z'), task(701, '2026-06-18T10:00:00.000Z')],
+    });
+    const B = makeDevice('B', vault, { ...EMPTY });
+    await runRounds(A, B);
+    expect(B.data.tasks.map((t) => t.id).sort()).toEqual([700, 701]); // both converged
+
+    // GLITCH: A drops 700 from memory with NO tombstone (a transient shrink).
+    A.data.tasks = A.data.tasks.filter((t) => t.id !== 700);
+    await runRounds(A, B);
+    // The guard skips the un-tombstoned vanish → the deletion does NOT propagate:
+    // device B (which never glitched) still holds the live task. No fleet-wide loss.
+    // (The guard stops the SPREAD of a local glitch; it does not self-restore the
+    // glitched device — A stays locally short until the row is next re-pushed to it.)
+    expect(B.data.tasks.map((t) => t.id)).toContain(700);
+
+    // REAL DELETE: A removes 701 AND records its tombstone (what every delete path
+    // does). Now it is a genuine deletion, not a glitch.
+    A.data.tasks = A.data.tasks.filter((t) => t.id !== 701);
+    A.data.deletedTaskIds = { ...(A.data.deletedTaskIds || {}), 701: '2026-07-08T00:00:00.000Z' };
+    await runRounds(A, B);
+    // Tombstoned → the delete propagates and sticks; the glitch-kept 700 stays safe.
+    expect(B.data.tasks.map((t) => t.id)).not.toContain(701);
+    expect(B.data.tasks.map((t) => t.id)).toContain(700);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/sync/snapshotDeleteGuard.js
+++ b/src/sync/snapshotDeleteGuard.js
@@ -1,0 +1,76 @@
+// Guard against the vault engine broadcasting a LOCAL-STATE GLITCH as permanent,
+// fleet-wide deletion.
+//
+// THE HAZARD: src/sync/dbEngine.js seeds its push dirty-set by diffing the current
+// in-memory payload (getData()) against the last-pushed snapshot. Any entity that
+// was in the snapshot but is missing from getData() is marked as a DELETE and
+// soft-deleted in the vault — where every other device then applies it. That diff
+// has no way to tell "the user deleted this" from "the in-memory list transiently
+// shrank" (a bad merge, a load/save race, an interrupted apply). So one device
+// briefly dropping N tasks in memory deletes those N REAL tasks for the whole fleet.
+// Observed: a device that diverged to a smaller task set emitted ~160 deletes for
+// live, un-deleted tasks; the healthy device kept re-adding them → a delete↔re-add
+// war over real data.
+//
+// THE INVARIANT: a genuine deletion always leaves a fingerprint.
+//   • A permanent delete writes a deletion tombstone (deletedTaskIds / deletedFrameIds
+//     / … — every delete path does this; see useRecycleBin, useTaskActions), OR
+//   • a move (task → recycle bin, cross-list) keeps the entity's id present under a
+//     DIFFERENT kind, so the id still appears somewhere in getData().
+// An entity that vanishes from memory with NEITHER a tombstone NOR a surviving copy
+// under another kind has no legitimate delete path — it is a suspected glitch. We
+// skip its delete: the row stays in the vault and is simply re-pulled next cycle
+// (fail-safe toward KEEPING data). A skipped glitch-delete costs at most a stale row
+// that resurrects; propagating it costs real, irreversible data loss — so we bias
+// hard toward keeping.
+//
+// Real deletions (tombstoned) and real moves (id survives elsewhere) are unaffected
+// and still propagate exactly as before.
+
+import { TOMBSTONE_BUNDLE_KEYS } from './tombstoneRetention.js';
+
+// Bare id from an entityId ("tasks:abc" → "abc"). entityIds are "kind:id" and ids
+// are UUIDs / stable keys, so the bare id is globally unique across kinds.
+function bareId(entityId) {
+  const s = String(entityId);
+  const i = s.indexOf(':');
+  return i < 0 ? s : s.slice(i + 1);
+}
+
+/**
+ * Split the snapshot-diff's would-be deletes into those safe to propagate and those
+ * to skip as suspected local-state glitches.
+ *
+ * @param {string[]} deleteEntityIds  entityIds the diff wants to delete (in snapshot, absent from cur)
+ * @param {Record<string, unknown>} cur  current shredded state, keyed by entityId (snapshotShred output)
+ * @param {object} mirror  the payload/mirror carrying the deletion tombstone bundles
+ * @returns {{ propagate: string[], skipped: string[] }}
+ */
+export function partitionSnapshotDeletes(deleteEntityIds, cur, mirror) {
+  const ids = Array.isArray(deleteEntityIds) ? deleteEntityIds : [];
+
+  // Every bare id present anywhere in the current payload (any kind). A cross-list
+  // move leaves the id here under its new kind, so its old-kind delete is legitimate.
+  const liveBareIds = new Set();
+  for (const eid of Object.keys(cur || {})) liveBareIds.add(bareId(eid));
+
+  // Union of every deletion tombstone across all bundles. A real delete tombstones
+  // the id; membership here means the delete is intentional.
+  const tombstoned = new Set();
+  const m = mirror && typeof mirror === 'object' ? mirror : {};
+  for (const key of TOMBSTONE_BUNDLE_KEYS) {
+    const bundle = m[key];
+    if (bundle && typeof bundle === 'object') {
+      for (const id of Object.keys(bundle)) tombstoned.add(String(id));
+    }
+  }
+
+  const propagate = [];
+  const skipped = [];
+  for (const eid of ids) {
+    const id = bareId(eid);
+    if (tombstoned.has(id) || liveBareIds.has(id)) propagate.push(eid);
+    else skipped.push(eid);
+  }
+  return { propagate, skipped };
+}

--- a/src/sync/snapshotDeleteGuard.test.js
+++ b/src/sync/snapshotDeleteGuard.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { partitionSnapshotDeletes } from './snapshotDeleteGuard.js';
+
+// cur is snapshotShred output: { entityId -> hash }. Only the KEYS matter here.
+const curOf = (...entityIds) => Object.fromEntries(entityIds.map((e) => [e, '#']));
+
+describe('partitionSnapshotDeletes', () => {
+  it('SKIPS an un-tombstoned vanish — the glitch-shrink (no fleet-wide deletion)', () => {
+    // tasks:X was in the snapshot, is gone from getData(), has no tombstone, and its
+    // id appears nowhere else. That is a local-state glitch, not a deletion → keep it.
+    const { propagate, skipped } = partitionSnapshotDeletes(['tasks:X'], curOf(), {});
+    expect(propagate).toEqual([]);
+    expect(skipped).toEqual(['tasks:X']);
+  });
+
+  it('PROPAGATES a tombstoned delete — a real permanent deletion still works', () => {
+    const mirror = { deletedTaskIds: { X: '2026-07-08T00:00:00.000Z' } };
+    const { propagate, skipped } = partitionSnapshotDeletes(['tasks:X'], curOf(), mirror);
+    expect(propagate).toEqual(['tasks:X']);
+    expect(skipped).toEqual([]);
+  });
+
+  it('PROPAGATES a cross-list move — task → recycle bin keeps the id under recycleBin', () => {
+    // tasks:X is gone but recycleBin:X is present: the id survived under another kind,
+    // so the old-kind row must be deleted. Not a glitch.
+    const { propagate, skipped } = partitionSnapshotDeletes(['tasks:X'], curOf('recycleBin:X'), {});
+    expect(propagate).toEqual(['tasks:X']);
+    expect(skipped).toEqual([]);
+  });
+
+  it('honors tombstones across all bundle kinds (frames, goals, projects, areas, …)', () => {
+    const mirror = {
+      deletedFrameIds: { f1: 't' },
+      deletedGoalIds: { g1: 't' },
+      deletedProjectIds: { p1: 't' },
+      deletedAreaIds: { a1: 't' },
+      deletedObsidianKeys: { '2026-04-27': 't' },
+    };
+    const del = ['gtdFrames:f1', 'goals:g1', 'projects:p1', 'areas:a1', 'tasks:2026-04-27'];
+    const { propagate, skipped } = partitionSnapshotDeletes(del, curOf(), mirror);
+    expect(propagate.sort()).toEqual(del.sort());
+    expect(skipped).toEqual([]);
+  });
+
+  it('THE WAR: a 160-task glitch-shrink is fully skipped (none tombstoned, none moved)', () => {
+    // Reproduces the observed incident: a device diverged to a smaller set and the
+    // diff wanted to delete ~160 live, un-deleted tasks. All are kept.
+    const del = [];
+    for (let i = 0; i < 67; i++) del.push(`tasks:t${i}`);
+    for (let i = 0; i < 93; i++) del.push(`unscheduledTasks:u${i}`);
+    const { propagate, skipped } = partitionSnapshotDeletes(del, curOf(), { deletedTaskIds: {} });
+    expect(propagate).toEqual([]);
+    expect(skipped).toHaveLength(160);
+  });
+
+  it('MIXED: keeps glitch vanishes, propagates the genuinely-deleted and moved ones', () => {
+    const mirror = { deletedTaskIds: { real: 't' } };
+    const cur = curOf('recycleBin:moved'); // "moved" survives in the bin
+    const del = ['tasks:real', 'tasks:moved', 'tasks:glitch1', 'tasks:glitch2'];
+    const { propagate, skipped } = partitionSnapshotDeletes(del, cur, mirror);
+    expect(propagate.sort()).toEqual(['tasks:moved', 'tasks:real']);
+    expect(skipped.sort()).toEqual(['tasks:glitch1', 'tasks:glitch2']);
+  });
+
+  it('tolerates empty / missing inputs', () => {
+    expect(partitionSnapshotDeletes([], {}, {})).toEqual({ propagate: [], skipped: [] });
+    expect(partitionSnapshotDeletes(null, null, null)).toEqual({ propagate: [], skipped: [] });
+  });
+});


### PR DESCRIPTION
## The bug (the real one behind the task war)

`dbEngine.js` seeds its push dirty-set by diffing the current in-memory payload (`getData()`) against the last-pushed snapshot. **Any entity in the snapshot but absent from `getData()` is marked as a DELETE** and soft-deleted in the vault — where every device then applies it. That diff cannot tell *"the user deleted this"* from *"the in-memory list transiently shrank"* (a bad merge, a load/save race, an interrupted apply). So one device briefly dropping N tasks in memory **permanently deletes those N real tasks for the whole fleet.**

**Observed incident:** a device diverged to a smaller task set and emitted ~160 deletes for live, un-deleted tasks — real user data ("Text Jake re Patio", "Whole Foods", "App Work"…). The healthy device kept re-adding them → a delete↔re-add war, with the tasks one glitch on the other device away from being gone everywhere. A live check confirmed the deletes were **not tombstone-backed** (only 5 of 793 live tasks carried a tombstone) — a pure glitch-shrink, not real deletions.

This is why the resurrection fixes (#1146, #1147) didn't touch it: those stop things *coming back*; this is the opposite and more dangerous failure — spurious *deletion*. The "re-adding" device was actually **defending** your data.

## The fix

A genuine deletion always leaves a fingerprint:
- a **deletion tombstone** (`deletedTaskIds` / `deletedFrameIds` / … — every delete path writes one), or
- the id **moving to another list** (task → recycle bin), which keeps it present under a different kind.

An entity that vanishes from memory with **neither** has no legitimate delete path — it's a suspected glitch. `partitionSnapshotDeletes` (new, pure, tested) splits the diff's would-be deletes into *propagate* vs *skip* on that basis; the engine skips the glitch ones (keeps the row, logs a `[push] GUARD` warning) and propagates the rest. It biases hard toward **keeping data** — a skipped glitch costs at most a stale row; propagating it costs irreversible loss.

Real deletions (tombstoned) and real moves (id survives under another kind) propagate exactly as before.

## Scope / limit (deliberately not over-reached)

The guard stops the **spread** of a local glitch. It does **not** self-restore the device that glitched — the vault won't re-deliver a row whose seq that device already consumed, so that device stays locally short until the row is next re-pushed/re-pulled. The underlying cause of a device dropping tasks *in memory* is a separate investigation; this change makes that cause **non-catastrophic** (it can no longer wipe real data fleet-wide) and ends the war. Asserted as a known limitation in the test rather than hidden.

## Tests

- `snapshotDeleteGuard.test.js`: glitch-skip, tombstone-propagate, cross-list-move-propagate, all-bundle-kinds, the **160-task incident**, mixed, empty/null.
- `dbEngineWiring.test.js`: an end-to-end case driving the **wired** guard through the real `dbSyncCycle` — a glitch-vanish is kept (B still holds it), a tombstoned delete propagates and sticks.

Full suite **651 passed**, lint clean. Android `versionCode` 158 → 159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_