### PR TITLE
Decouple the Obsidian import window from the calendar-retention setting

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 159
+        versionCode = 160
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, Chev
 import { mergeTaskArrays, mergeSyncData } from './mergeSync.js';
 import { hasNativeCalendar, electronGetCalendars, electronGetEventsByDate, electronRequestCalendarAccess, nativeEventToTask } from './utils/nativeCalendar.js';
 import { isNativeAndroid, isNativeApp, isNativeIOS, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeGetVaultConfig, nativeIsVaultConfigured, nativeWriteDailyNote, nativeGetNote, nativeWriteNote, nativeOpenNote, nativeListNotes, nativeClearVault, nativeSetVaultSettings, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeStartRecording, nativeStopRecording, nativeGetWidgetPendingAction, triggerHaptic } from './native.js';
-import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, tryRestoreVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, listVaultNotes, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
+import { isFileSystemAccessSupported, requestVaultAccess, getVaultAccess, tryRestoreVaultAccess, disconnectVault, syncObsidianVault, syncObsidianVaultNative, writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, writeTaskStateToFile, writeTaskStateNative, simpleHash as obsidianSimpleHash, readWikiNote, writeWikiNote, listVaultNotes, appendTaskToDailyNote, appendTaskToDailyNoteNative, OBSIDIAN_IMPORT_WINDOW_DAYS, obsidianWindowCutoffDate } from './obsidian.js';
 import { loadAIConfig, saveAIConfig, aiComplete, aiJSON, aiTranscribe, supportsTranscription, testConnection, DEFAULT_CONFIG, PROVIDER_MODELS, PROVIDER_LABELS } from './ai.js';
 import { voiceParseSystemPrompt, voiceParseUserPrompt, taskSuggestSystemPrompt, taskSuggestUserPrompt, frameNudgeSystemPrompt, frameNudgeUserPrompt, rescheduleSystemPrompt, rescheduleUserPrompt, aiSubtasksSystemPrompt, aiSubtasksUserPrompt, morningSummarySystemPrompt, morningSummaryUserPrompt, eveningReflectionSystemPrompt, eveningReflectionUserPrompt, weeklySummarySystemPrompt, weeklySummaryUserPrompt, smartScheduleSystemPrompt, smartScheduleUserPrompt } from './ai-prompts.js';
 import { gatherTrmnlData, pushToTrmnl, TRMNL_MARKUP_FULL, TRMNL_MARKUP_HALF_HORIZONTAL, TRMNL_MARKUP_HALF_VERTICAL, TRMNL_MARKUP_QUADRANT } from './trmnl.js';
@@ -3192,17 +3192,20 @@ const DayPlanner = () => {
       // not the stale closure from when the interval was set up.
       const currentTasks = obsidianTasksRef.current;
       const currentInbox = obsidianInboxRef.current;
+      // The Obsidian scan window is FIXED (OBSIDIAN_IMPORT_WINDOW_DAYS), decoupled
+      // from the calendar "Keep past events" retention (syncRetentionDays) — that
+      // setting is about imported calendar events, not the vault. See obsidian.js.
       const result = isNative
         ? await syncObsidianVaultNative(
             obsidianConfig?.dailyNotesPath || '',
-            syncRetentionDays,
+            OBSIDIAN_IMPORT_WINDOW_DAYS,
             currentTasks,
             currentInbox,
           )
         : await syncObsidianVault(
             obsidianVaultHandleRef.current,
             obsidianConfig?.dailyNotesPath || '',
-            syncRetentionDays,
+            OBSIDIAN_IMPORT_WINDOW_DAYS,
             currentTasks,
             currentInbox,
             obsidianConfig?.dailyNotePattern || 'yyyy-MM-dd',
@@ -3246,15 +3249,11 @@ const DayPlanner = () => {
       try { tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-obsidian-keys') || '{}'); } catch { tombstones = {}; }
       let lastScanned = [];
       try { lastScanned = JSON.parse(localStorage.getItem('day-planner-obsidian-last-scanned') || '[]'); } catch { lastScanned = []; }
-      // The scan only reads notes/tasks within `syncRetentionDays` of today
-      // (src/obsidian.js), so notes aging out of that window must NOT be mistaken
-      // for deletions. Compute the same cutoff and pass it to the detector.
-      let obsidianCutoff = null;
-      if (syncRetentionDays && syncRetentionDays > 0) {
-        const c = new Date();
-        c.setDate(c.getDate() - syncRetentionDays);
-        obsidianCutoff = `${c.getFullYear()}-${String(c.getMonth() + 1).padStart(2, '0')}-${String(c.getDate()).padStart(2, '0')}`;
-      }
+      // The scan only reads notes/tasks within the fixed Obsidian window of today
+      // (OBSIDIAN_IMPORT_WINDOW_DAYS, src/obsidian.js), so notes aging out of that
+      // window must NOT be mistaken for deletions. Use the SAME helper the scan uses
+      // so the two windows can't drift.
+      const obsidianCutoff = obsidianWindowCutoffDate(OBSIDIAN_IMPORT_WINDOW_DAYS);
       const { deletions, skipped } = detectObsidianDeletions(lastScanned, scannedKeys, obsidianCutoff);
       if (deletions.length) {
         tombstones = addObsidianTombstones(tombstones, deletions, new Date().toISOString());

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -14,6 +14,34 @@
 
 import { makeElectronVaultHandle } from './obsidianElectronHandle.js';
 
+// How far back the Obsidian daily-note scan reads, in days. DELIBERATELY FIXED and
+// decoupled from the calendar "Keep past events" retention (syncRetentionDays):
+// that dropdown governs how long IMPORTED CALENDAR EVENTS are kept, and wiring the
+// vault scan to it meant lowering calendar retention (e.g. to 7 days to save
+// storage) silently stopped importing older daily-note tasks. 90 days is a generous
+// "recent" window that never shrinks the scan for anyone on the common defaults.
+export const OBSIDIAN_IMPORT_WINDOW_DAYS = 90;
+
+/**
+ * Local-date cutoff string 'YYYY-MM-DD' for a scan window of `days` — notes/tasks
+ * dated before it are outside the window. Returns null for an unlimited window
+ * (days <= 0). Uses LOCAL date parts to match daily-note filenames, which are
+ * authored in the user's local timezone.
+ *
+ * Shared by the scan (which skips notes older than the cutoff) AND the deletion
+ * detector (which must NOT mistake a note that aged out of the SAME window for a
+ * vault deletion), so the two windows can never drift apart.
+ *
+ * @param {number} days   window size; <= 0 → unlimited (null)
+ * @param {Date}   [now]  reference "today" (injectable for tests)
+ * @returns {string|null} 'YYYY-MM-DD' cutoff, or null for no limit
+ */
+export function obsidianWindowCutoffDate(days, now = new Date()) {
+  if (!(days > 0)) return null;
+  const c = new Date(now.getFullYear(), now.getMonth(), now.getDate() - days);
+  return `${c.getFullYear()}-${String(c.getMonth() + 1).padStart(2, '0')}-${String(c.getDate()).padStart(2, '0')}`;
+}
+
 // All Electron builds route vault access through the main process (native picker +
 // security-scoped bookmark). Required under the MAS sandbox (a renderer FS Access
 // handle can't persist there); the unsandboxed Developer ID / dev builds simply get
@@ -872,16 +900,8 @@ export async function syncObsidianVault(
 ) {
   const dirHandle = await getDailyNotesDir(vaultHandle, dailyNotesPath);
 
-  // Compute cutoff date string
-  let cutoffStr = '0000-00-00';
-  if (retentionDays && retentionDays > 0) {
-    const today = new Date();
-    const cutoff = new Date(today.getFullYear(), today.getMonth(), today.getDate() - retentionDays);
-    const yyyy = cutoff.getFullYear();
-    const mm = String(cutoff.getMonth() + 1).padStart(2, '0');
-    const dd = String(cutoff.getDate()).padStart(2, '0');
-    cutoffStr = `${yyyy}-${mm}-${dd}`;
-  }
+  // Cutoff date string; '0000-00-00' when the window is unlimited (reads everything).
+  const cutoffStr = obsidianWindowCutoffDate(retentionDays) ?? '0000-00-00';
 
   const dailyNotes = {};
   const allScheduled = [];
@@ -1172,13 +1192,8 @@ export async function syncObsidianVaultNative(folder, retentionDays, existingTas
   const bridge = typeof window !== 'undefined' ? window.DayGlanceObsidian : null;
   if (!bridge) throw new Error('Obsidian bridge unavailable');
 
-  // Compute cutoff date string
-  let cutoffStr = '0000-00-00';
-  if (retentionDays && retentionDays > 0) {
-    const today = new Date();
-    const cutoff = new Date(today.getFullYear(), today.getMonth(), today.getDate() - retentionDays);
-    cutoffStr = `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, '0')}-${String(cutoff.getDate()).padStart(2, '0')}`;
-  }
+  // Cutoff date string; '0000-00-00' when the window is unlimited (reads everything).
+  const cutoffStr = obsidianWindowCutoffDate(retentionDays) ?? '0000-00-00';
 
   // Build lookup of existing Obsidian tasks to preserve app-controlled properties
   const existingTaskMap = {};

--- a/src/obsidianWindow.test.js
+++ b/src/obsidianWindow.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { OBSIDIAN_IMPORT_WINDOW_DAYS, obsidianWindowCutoffDate } from './obsidian.js';
+
+describe('Obsidian import window (decoupled from calendar retention)', () => {
+  it('is a fixed 90-day window', () => {
+    expect(OBSIDIAN_IMPORT_WINDOW_DAYS).toBe(90);
+  });
+
+  it('computes a local YYYY-MM-DD cutoff `days` before the reference date', () => {
+    // 2026-07-08 − 90 days = 2026-04-09
+    expect(obsidianWindowCutoffDate(90, new Date(2026, 6, 8))).toBe('2026-04-09');
+  });
+
+  it('zero-pads month and day', () => {
+    // 2026-03-05 − 30 days = 2026-02-03
+    expect(obsidianWindowCutoffDate(30, new Date(2026, 2, 5))).toBe('2026-02-03');
+  });
+
+  it('crosses year boundaries correctly', () => {
+    // 2026-02-01 − 90 days = 2025-11-03
+    expect(obsidianWindowCutoffDate(90, new Date(2026, 1, 1))).toBe('2025-11-03');
+  });
+
+  it('returns null for an unlimited window (days <= 0)', () => {
+    expect(obsidianWindowCutoffDate(0, new Date(2026, 6, 8))).toBeNull();
+    expect(obsidianWindowCutoffDate(-5, new Date(2026, 6, 8))).toBeNull();
+  });
+
+  it('the default 90-day window resolves to a non-null cutoff', () => {
+    expect(obsidianWindowCutoffDate(OBSIDIAN_IMPORT_WINDOW_DAYS, new Date(2026, 6, 8))).toBe('2026-04-09');
+  });
+});


### PR DESCRIPTION
## What & why

`performObsidianSync` passed `syncRetentionDays` — the calendar **"Keep past events"** dropdown (default 30; options 7 → 365 → unlimited) — straight into:
- the Obsidian daily-note scan as *"how far back to read"* (`syncObsidianVault` / `syncObsidianVaultNative`), and
- the deletion-detection cutoff (so a note that aged out isn't mistaken for a vault deletion).

But that dropdown is about how long **imported calendar events** are kept — nothing to do with the vault. So lowering it (e.g. to 7 days to save calendar storage) silently stopped importing older daily-note tasks. That's the bug.

## The change

The Obsidian scan gets its **own fixed window**: `OBSIDIAN_IMPORT_WINDOW_DAYS = 90`. Generous enough that it doesn't shrink the scan for anyone on the common defaults, and it no longer moves when the unrelated calendar knob changes.

The scan window and the deletion-detection cutoff **must stay identical** — if they drift, a note that merely aged out of the scan window could be mis-tombstoned as a deletion. So both now route through a single shared helper, `obsidianWindowCutoffDate(days)`, which also **de-duplicates** the same cutoff computation that was copied in three places (both scan functions + `performObsidianSync`).

Applies to both transports — PWA/File-System-Access **and** the Android native bridge.

## Decision captured

Chose a **fixed 90-day** window (vs. a new user-facing dropdown or a tighter/unlimited fixed value): keeps settings uncluttered for a niche knob while never regressing anyone who currently runs 30–90d calendar retention. If you later want it user-adjustable, the helper + constant make that a small follow-up.

## Tests

`obsidianWindow.test.js`: the fixed 90-day constant; local `YYYY-MM-DD` cutoff math including zero-padding and year-boundary crossing; `unlimited → null`. Full suite **657 passed**, lint clean.

Android `versionCode` 159 → 160 (touches the native scan — build to verify on device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_