### PR TITLE
Use the real file mtime for native Obsidian daily-note scans

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 160
+        versionCode = 161
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
@@ -282,7 +282,7 @@ class ObsidianRepository(private val context: Context) {
 
     /**
      * Returns a JSON array of all daily notes in [folder] at or after [cutoff] (yyyy-MM-dd).
-     * Each entry: { "date": "yyyy-MM-dd", "text": "<markdown content>" }.
+     * Each entry: { "date": "yyyy-MM-dd", "text": "<markdown content>", "lastModified": "<ISO-8601>" }.
      * Pass an empty [cutoff] to return all notes.
      * Returns "[]" if the vault isn't configured or the folder doesn't exist.
      *
@@ -303,6 +303,10 @@ class ObsidianRepository(private val context: Context) {
                 arr.put(JSONObject().apply {
                     put("date", dateStr)
                     put("text", readText(file))
+                    // The file's REAL modification time, so the web frontend's merge
+                    // uses a truthful last-writer-wins timestamp instead of stamping
+                    // every scanned note as "now". Mirrors getNote() below.
+                    put("lastModified", Instant.ofEpochMilli(file.lastModified()).toString())
                 })
             }
         // Pre-warm the note URI index on the same sync pass so bare-name

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -1188,6 +1188,25 @@ if (typeof window !== 'undefined' && !window.__obsidianDispatch) {
   };
 }
 
+/**
+ * Resolve the lastModified for a native daily-note scan entry.
+ *
+ * The native scan (getAllDailyNotes) carries each file's REAL modification time in
+ * `entry.lastModified` once the Kotlin bridge reports it (ObsidianRepository.kt).
+ * Older app/bridge builds omit it — fall back to `nowIso` so a scan still works
+ * during the rollout. Using the real mtime instead of a fresh "now" stops the native
+ * side from stamping every note as just-modified on every sync — the false-LWW /
+ * churn source the web (File System Access) path never had, since it always used the
+ * file's real `file.lastModified`.
+ *
+ * @param {{lastModified?: string}} entry  one native note entry
+ * @param {string} nowIso                  fallback timestamp (current time, ISO)
+ * @returns {string}
+ */
+export function nativeNoteLastModified(entry, nowIso) {
+  return (entry && entry.lastModified) || nowIso;
+}
+
 export async function syncObsidianVaultNative(folder, retentionDays, existingTasks, existingInbox) {
   const bridge = typeof window !== 'undefined' ? window.DayGlanceObsidian : null;
   if (!bridge) throw new Error('Obsidian bridge unavailable');
@@ -1222,7 +1241,7 @@ export async function syncObsidianVaultNative(folder, retentionDays, existingTas
 
   // Prefer the batch getAllDailyNotesAsync method (non-blocking: SAF I/O runs on a
   // background thread and callbacks back via JS) over the synchronous alternatives.
-  let noteEntries; // [{ date, text }]
+  let noteEntries; // [{ date, text, lastModified? }] — lastModified present from getAllDailyNotes
   if (bridge.getAllDailyNotesAsync) {
     // Non-blocking path: runs SAF I/O on a background thread, callbacks via JS
     if (!window.__obsidianCbs) window.__obsidianCbs = {};
@@ -1268,11 +1287,14 @@ export async function syncObsidianVaultNative(folder, retentionDays, existingTas
     throw new Error('Obsidian bridge is missing required methods (getAllDailyNotes or listNotes)');
   }
 
-  for (const { date: dateStr, text } of noteEntries) {
+  for (const entry of noteEntries) {
+    const { date: dateStr, text } = entry;
     if (!dateStr || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) continue;
     if (text === null || text === undefined) continue;
 
-    dailyNotes[dateStr] = { text, lastModified: new Date().toISOString(), fromObsidian: true };
+    // Use the file's REAL mtime from the native scan; fall back to now for older
+    // bridge builds that don't report it yet. See nativeNoteLastModified.
+    dailyNotes[dateStr] = { text, lastModified: nativeNoteLastModified(entry, new Date().toISOString()), fromObsidian: true };
 
     const { scheduledTasks, inboxTasks } = parseTasksFromMarkdown(text, dateStr);
 

--- a/src/obsidianNativeMtime.test.js
+++ b/src/obsidianNativeMtime.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { nativeNoteLastModified } from './obsidian.js';
+
+const NOW = '2026-07-09T12:00:00.000Z';
+
+describe('nativeNoteLastModified (native scan uses the real file mtime)', () => {
+  it('uses the real mtime the native bridge reports', () => {
+    const entry = { date: '2026-05-01', text: '# note', lastModified: '2026-05-01T09:30:00.000Z' };
+    expect(nativeNoteLastModified(entry, NOW)).toBe('2026-05-01T09:30:00.000Z');
+  });
+
+  it('falls back to now for an older bridge build that omits lastModified', () => {
+    // Rollout safety: app updated before the native side reports mtime.
+    expect(nativeNoteLastModified({ date: '2026-05-01', text: '# note' }, NOW)).toBe(NOW);
+  });
+
+  it('falls back to now for an empty-string mtime (never stamps a note with "")', () => {
+    expect(nativeNoteLastModified({ lastModified: '' }, NOW)).toBe(NOW);
+  });
+
+  it('tolerates a missing/null entry', () => {
+    expect(nativeNoteLastModified(null, NOW)).toBe(NOW);
+    expect(nativeNoteLastModified(undefined, NOW)).toBe(NOW);
+  });
+});


### PR DESCRIPTION
## What & why

The Android native daily-note scan stamped every note's `lastModified` with **`new Date()` ("now")** on each sync (`obsidian.js` `syncObsidianVaultNative`), while the web / File-System-Access path used the file's **real mtime** (`new Date(file.lastModified)`). So native timestamps were always bogus-fresh — churn, and native wrongly winning cross-device last-writer-wins with a fake-recent stamp. The mtime was already available on Android (`DocumentFile.lastModified()`, used by `getNote()`), just not plumbed into the scan.

## The change (two coordinated edits)

**Kotlin —** `ObsidianRepository.getAllDailyNotes` now includes each file's real mtime:
```kotlin
put("lastModified", Instant.ofEpochMilli(file.lastModified()).toString())
```
Both bridge entry points — `getAllDailyNotes` **and** `getAllDailyNotesAsync` — route through this one method, so the single edit covers both.

**JS —** `syncObsidianVaultNative` uses `entry.lastModified` via a small tested helper `nativeNoteLastModified()`, **falling back to `now`** when the bridge doesn't report it — so a scan still works during rollout (app updated before the native side, or an older bridge build).

## Notes

- **Partly masked before** by `mergeObsidianDailyNotes` (it preserves the prior `lastModified` for unchanged text). This makes the timestamp *correct* rather than leaning on that masking.
- **Scope:** the batch daily-note scan only. The single-note native reads (`readDailyNoteNative` JS / `getDailyNote` Kotlin) still synthesize "now" — lower-traffic, and `getDailyNote` returns a bare string so carrying mtime there needs a return-shape change. Left as a small follow-up.
- **Edge case:** a SAF provider that reports no mtime yields epoch `0` — same behavior `getNote()` already has today. Rare, and the merge's text-preservation covers the common case.

## Tests

`obsidianNativeMtime.test.js`: uses the reported mtime; falls back for missing / empty-string / null. Full suite **655 passed**, lint clean.

**Verification needs a device build** (Kotlin isn't in the vitest suite): drop a file with a known old mtime in the vault, sync, confirm the note carries that mtime rather than "now."

Android `versionCode` 159 → 161 (160 is claimed by the open #1149; 161 keeps them distinct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_