### PR TITLE
Never push a task the device's own tombstones say is deleted (end the resurrection war)

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 161
+        versionCode = 162
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { tombstoneCutoff } from './sync/tombstoneRetention.js';
 import { preserveArchived } from './utils/preserveArchived.js';
 import { rescueUnsyncedTasks } from './utils/rescueUnsyncedTasks.js';
+import { dropResurrectedTasks } from './utils/dropResurrectedTasks.js';
 import { partitionExpiredSingleDayFrames } from './utils/expiredFrames.js';
 import { mergeObsidianDailyNotes } from './utils/mergeObsidianDailyNotes.js';
 import { mergeObsidianTasks } from './utils/mergeObsidianTasks.js';
@@ -5845,16 +5846,22 @@ const DayPlanner = () => {
     // migrated flag is already set, writing a leaked URL into this device's entry.
     let calendarConfigByUser = {};
     try { calendarConfigByUser = JSON.parse(localStorage.getItem('day-planner-calendar-config-by-user') || '{}'); } catch { calendarConfigByUser = {}; }
+    // Never push a task this device's own tombstones say is deleted — otherwise a
+    // stale local copy resurrects a genuinely-deleted task fleet-wide (the delete↔
+    // re-add war). Drops only tombstoned-and-older tasks; a restored task (newer than
+    // its tombstone) is kept. See utils/dropResurrectedTasks.js.
+    let payloadDeletedTaskIds = {};
+    try { payloadDeletedTaskIds = JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}'); } catch { payloadDeletedTaskIds = {}; }
     return {
       version: 2,
       lastModified: new Date().toISOString(),
       data: {
         tasks: stampTaskTimestamps(
-          tasks.filter(t => !t._native && keepImported(t)),
+          dropResurrectedTasks(tasks.filter(t => !t._native && keepImported(t)), payloadDeletedTaskIds),
           'day-planner-tasks'
         ),
         unscheduledTasks: stampTaskTimestamps(
-          unscheduledTasks.filter(keepImported),
+          dropResurrectedTasks(unscheduledTasks.filter(keepImported), payloadDeletedTaskIds),
           'day-planner-unscheduled'
         ),
         unscheduledOrderTimestamp,

--- a/src/utils/dropResurrectedTasks.js
+++ b/src/utils/dropResurrectedTasks.js
@@ -1,0 +1,39 @@
+// A device must never PUSH a task its own tombstones say is deleted.
+//
+// THE HAZARD: buildSyncPayload broadcasts whatever is in the in-memory task lists.
+// If a stale local copy of a deleted task lingers in state (e.g. a local re-read
+// restores it, or a merge race), the device re-uploads it live every cycle — and a
+// peer that holds the tombstone dutifully re-deletes it, then this device re-pushes
+// it: a delete↔re-add war over a task the user genuinely deleted (observed: 11 tasks
+// tombstoned across weeks on one device, resurrected forever by the other).
+//
+// THE FILTER: drop a task from the outbound payload when it is tombstoned AND the
+// tombstone is NEWER than the task's lastModified — i.e. the deletion is the latest
+// word. This mirrors the merge's own suppression rule (@glance-apps/sync
+// mergeArrayById: `deletedIds[id] > item.lastModified` drops the item), just applied
+// at the PUSH side so a device can't resurrect its own deleted task in the first
+// place. A legitimately RESTORED task (un-deleted, so its lastModified is newer than
+// the tombstone) is kept and syncs normally. An unparseable/absent tombstone keeps
+// the task (fail-safe: never drop live data on a bad tombstone).
+//
+// Applied to the active task lists (tasks, unscheduledTasks) only — never recycleBin
+// (binned tasks are intentionally synced) and never tombstone-free tasks.
+
+/**
+ * @param {Array<{id:*, lastModified?:string}>} tasks
+ * @param {Record<string,string>} [deletedIds]  {id → ISO deletion timestamp}
+ * @returns {object[]} tasks minus any whose deletion is newer than the task
+ */
+export function dropResurrectedTasks(tasks, deletedIds = {}) {
+  if (!Array.isArray(tasks)) return [];
+  const tomb = deletedIds && typeof deletedIds === 'object' ? deletedIds : {};
+  return tasks.filter((t) => {
+    if (!t) return false;
+    const ts = tomb[String(t.id)];
+    if (!ts) return true; // not tombstoned → keep
+    const del = new Date(ts).getTime();
+    if (Number.isNaN(del)) return true; // unparseable tombstone → keep (fail-safe)
+    const mod = new Date(t.lastModified || 0).getTime();
+    return del <= mod; // keep only if the task is at least as new as its deletion
+  });
+}

--- a/src/utils/dropResurrectedTasks.test.js
+++ b/src/utils/dropResurrectedTasks.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { dropResurrectedTasks } from './dropResurrectedTasks.js';
+
+const task = (id, lastModified) => ({ id, title: id, lastModified });
+
+describe('dropResurrectedTasks', () => {
+  it('keeps a task with no tombstone', () => {
+    const out = dropResurrectedTasks([task('a', '2026-07-01T00:00:00Z')], {});
+    expect(out.map((t) => t.id)).toEqual(['a']);
+  });
+
+  it('DROPS a task whose deletion is newer than the task (the resurrection fix)', () => {
+    // The exact incident: task lingers in state with an old lastModified, but its
+    // tombstone is newer → the deletion is the latest word → do not push it.
+    const tasks = [task('dead', '2026-05-01T00:00:00Z')];
+    const deleted = { dead: '2026-06-26T04:46:50.527Z' };
+    expect(dropResurrectedTasks(tasks, deleted)).toEqual([]);
+  });
+
+  it('KEEPS a restored task whose lastModified is newer than the tombstone', () => {
+    // User un-deleted it after the tombstone → it must sync normally.
+    const tasks = [task('restored', '2026-07-05T00:00:00Z')];
+    const deleted = { restored: '2026-06-01T00:00:00Z' };
+    expect(dropResurrectedTasks(tasks, deleted).map((t) => t.id)).toEqual(['restored']);
+  });
+
+  it('keeps a task tombstoned at the SAME instant (tie → not older → kept)', () => {
+    const ts = '2026-06-10T00:00:00.000Z';
+    expect(dropResurrectedTasks([task('t', ts)], { t: ts }).map((x) => x.id)).toEqual(['t']);
+  });
+
+  it('mixes correctly: drops the dead one, keeps the live and the restored', () => {
+    const tasks = [
+      task('live', '2026-07-01T00:00:00Z'),           // no tombstone
+      task('dead', '2026-05-01T00:00:00Z'),           // tombstone newer → drop
+      task('restored', '2026-07-08T00:00:00Z'),       // tombstone older → keep
+    ];
+    const deleted = { dead: '2026-06-26T00:00:00Z', restored: '2026-06-01T00:00:00Z' };
+    expect(dropResurrectedTasks(tasks, deleted).map((t) => t.id)).toEqual(['live', 'restored']);
+  });
+
+  it('keeps a task with an unparseable tombstone (fail-safe — never drop on bad data)', () => {
+    expect(dropResurrectedTasks([task('t', '2026-05-01T00:00:00Z')], { t: 'not-a-date' }).map((x) => x.id)).toEqual(['t']);
+  });
+
+  it('treats a task with no lastModified as epoch → dropped if tombstoned', () => {
+    expect(dropResurrectedTasks([{ id: 'x' }], { x: '2026-01-01T00:00:00Z' })).toEqual([]);
+  });
+
+  it('tolerates empty / null inputs', () => {
+    expect(dropResurrectedTasks(null, {})).toEqual([]);
+    expect(dropResurrectedTasks([], null)).toEqual([]);
+    expect(dropResurrectedTasks([task('a', '2026-07-01T00:00:00Z')], null).map((t) => t.id)).toEqual(['a']);
+  });
+});


### PR DESCRIPTION
## The bug (Loop 1, confirmed on-device)

`buildSyncPayload` broadcasts whatever is in the in-memory task lists. When a stale local copy of a **genuinely-deleted** task lingers in state (a local re-read restoring it, a merge race), the device re-uploads it **live** every cycle; a peer that holds the tombstone re-deletes it; this device re-pushes it — a **delete↔re-add war** over a task the user actually deleted.

**Confirmed from the device:** 11 tasks, tombstoned *individually across five weeks* on the Mac (2026-05-30 → 2026-06-26 — i.e. deliberate deletions, not a glitch), resurrected forever by the phone. The phone runs **every prior guard** (versionCode 161: #1147/#1148/#1149/#1150) and still does this — because the receive-side guards can't stop a device **broadcasting its own dead task**.

## The fix

`dropResurrectedTasks` filters the outbound payload's active lists (`tasks`, `unscheduledTasks`), dropping a task **only when it is tombstoned AND the tombstone is newer than the task's `lastModified`** — i.e. the deletion is the latest word.

This mirrors the merge's own rule (`@glance-apps/sync` `mergeArrayById` drops an item when `deletedIds[id] > item.lastModified`), applied at the **push** side so a device can't resurrect its own deleted task in the first place.

- A legitimately **restored** task (un-deleted → `lastModified` newer than the tombstone) is **kept** and syncs normally.
- An absent/unparseable tombstone **keeps** the task (fail-safe — never drop live data on bad data).
- `recycleBin` is untouched — binned tasks are intentionally synced.

**Why this ends the loop:** once a device stops broadcasting these, its next snapshot-diff sees them gone from `getData`, and — since they *are* tombstoned — the #1148 delete-guard lets that delete through. So the deletion finally **converges** instead of ping-ponging.

## Tests

`dropResurrectedTasks.test.js`: drops tombstoned-and-older; keeps restored-newer, tie, untombstoned, bad-tombstone; mixed; empty/null. Full suite **669 passed**, lint clean.

Android `versionCode` 161 → 162 — build **both** devices; the fix has to be on the device doing the resurrecting (the phone) to stop it, and on the Mac so neither can do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_