### PR TITLE
Keep note-backed Obsidian tasks stable across a sync apply (fix the flicker)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6169,8 +6169,12 @@ const DayPlanner = () => {
     // — that resurrects a task deleted on another device (the seed-task ping-pong).
     // See utils/rescueUnsyncedTasks.js.
     const rescueDeletedIds = data.deletedTaskIds || {};
-    if (normalizedTasks) setTasks(prev => rescueUnsyncedTasks(preserveArchived(normalizedTasks, prev), prev, rescueDeletedIds));
-    if (normalizedUnsched) setUnscheduledTasks(prev => rescueUnsyncedTasks(preserveArchived(normalizedUnsched, prev), prev, rescueDeletedIds));
+    // Obsidian tasks are rescuable (re-derived from the local vault), but a
+    // genuinely vault-deleted one must stay gone — honor its deletedObsidianKeys
+    // tombstone. See utils/rescueUnsyncedTasks.js (the ala7ur flicker fix).
+    const rescueObsidianTombstones = data.deletedObsidianKeys || {};
+    if (normalizedTasks) setTasks(prev => rescueUnsyncedTasks(preserveArchived(normalizedTasks, prev), prev, rescueDeletedIds, undefined, rescueObsidianTombstones));
+    if (normalizedUnsched) setUnscheduledTasks(prev => rescueUnsyncedTasks(preserveArchived(normalizedUnsched, prev), prev, rescueDeletedIds, undefined, rescueObsidianTombstones));
     if (data.unscheduledOrderTimestamp) {
       setUnscheduledOrderTimestamp(data.unscheduledOrderTimestamp);
       localStorage.setItem('day-planner-unscheduled-order-ts', data.unscheduledOrderTimestamp);

--- a/src/utils/rescueUnsyncedTasks.js
+++ b/src/utils/rescueUnsyncedTasks.js
@@ -1,9 +1,9 @@
 // After a sync merge is applied to React state, re-add device-local tasks that
-// the merge never governed — native OS tasks, imported calendar items, and
-// external-intent tasks — which buildSyncPayload excludes from the payload (or
-// which were added locally in the race window between payload-build and apply),
-// so the merged result legitimately doesn't contain them and a plain replace
-// would drop them.
+// the merge never governed — native OS tasks, imported calendar items, external-
+// intent tasks, and Obsidian-derived tasks — which buildSyncPayload excludes from
+// the payload (or which were added locally in the race window between payload-
+// build and apply), so the merged result legitimately doesn't contain them and a
+// plain replace would drop them.
 //
 // THE TOMBSTONE GUARD (the fix): a task that IS synced but carries one of those
 // flags (e.g. old seed data with `imported: true`) sits in a gap — buildSyncPayload
@@ -15,6 +15,20 @@
 // elsewhere and must stay deleted. An untombstoned flagged task is still a genuine
 // race-add and is preserved.
 //
+// OBSIDIAN TASKS (the ala7ur fix): an Obsidian task (`importSource: 'obsidian'`)
+// is re-derived from the local vault every scan, so it is device-owned in the same
+// sense as a native/imported task — but it is ALSO a synced vault row, so the two
+// subsystems race. Symptom: the Obsidian scan adds the task to state, then the very
+// next DB-sync apply commits a merged set that (transiently) lacks it and — because
+// it was not rescuable — drops it; the next scan re-adds it; repeat. That is the
+// observed appear/vanish flicker of a note-backed task (e.g. an inline-dated task
+// living in a differently-dated daily note). Making Obsidian tasks rescuable keeps
+// a live, note-backed task stable across a merge apply that omits it. A GENUINELY
+// vault-deleted task still stays gone: it is tombstoned in `deletedObsidianKeys`
+// (the Obsidian deletion map, last-writer-wins via isObsidianTombstoned), so the
+// rescue leaves it deleted — no resurrection. Deleting it in the dayGLANCE UI
+// (which writes `deletedTaskIds`) is likewise honored by the shared guard below.
+//
 // KNOWN BOUNDARY (not a flaw): a tombstone only lives 60 days (the fence/GC window,
 // src/sync/tombstoneRetention.js). A device offline longer than 60 days still holds
 // the task in `prev`, its tombstone has been GC'd, and the fence-suppressed merged
@@ -22,25 +36,45 @@
 // same 60-day limit the resurrection fence has, inherent to a finite tombstone
 // policy, not specific to this rescue.
 
-// Default: the merge doesn't govern native / imported / intent tasks.
-export const isDefaultRescuable = (t) => !!(t && (t._native || t.imported || t._intentKey));
+import { isObsidianTombstoned } from './obsidianDeletions.js';
+
+// Default: the merge doesn't govern native / imported / intent / Obsidian tasks —
+// each is re-provided locally (OS bridge, calendar re-import, external intent, or
+// vault re-scan), so the merged set legitimately omitting one is not a deletion.
+export const isDefaultRescuable = (t) =>
+  !!(t && (t._native || t.imported || t._intentKey || t.importSource === 'obsidian'));
 
 /**
  * @param {object[]} mergedList  the merged/committed list to keep as-is
  * @param {object[]} prevList    the current in-memory list (may hold local-only tasks)
  * @param {Record<string,string>} [deletedIds]  merged deletedTaskIds tombstones {id → ISO}
  * @param {(t:object)=>boolean} [isRescuable]  which prev-only tasks are eligible to rescue
+ * @param {Record<string,string>} [obsidianTombstones]  merged deletedObsidianKeys {id → ISO};
+ *   an Obsidian task tombstoned here (deletion at least as new as the task) is NOT rescued.
  * @returns {object[]} mergedList followed by the rescued (untombstoned) prev-only tasks
  */
-export function rescueUnsyncedTasks(mergedList, prevList, deletedIds = {}, isRescuable = isDefaultRescuable) {
+export function rescueUnsyncedTasks(
+  mergedList,
+  prevList,
+  deletedIds = {},
+  isRescuable = isDefaultRescuable,
+  obsidianTombstones = {},
+) {
   const merged = Array.isArray(mergedList) ? mergedList : [];
   const mergedIds = new Set(merged.map((t) => String(t.id)));
   const tombstoned = deletedIds || {};
-  const rescued = (Array.isArray(prevList) ? prevList : []).filter((t) =>
-    t
-    && !mergedIds.has(String(t.id))
-    && isRescuable(t)
-    && !tombstoned[String(t.id)]   // never resurrect a task the merge has tombstoned
-  );
+  const obsidianTombs = obsidianTombstones || {};
+  const rescued = (Array.isArray(prevList) ? prevList : []).filter((t) => {
+    if (!t) return false;
+    const id = String(t.id);
+    if (mergedIds.has(id)) return false;          // already present in the merged set
+    if (!isRescuable(t)) return false;            // merge governs this task — an absence is a real delete
+    if (tombstoned[id]) return false;             // deleted elsewhere (in-app / DB) — stay deleted
+    // A vault-deleted Obsidian task stays deleted (LWW: deletion at least as new
+    // as the task). A re-created / still-note-backed task (newer than any deletion)
+    // is kept.
+    if (t.importSource === 'obsidian' && isObsidianTombstoned(obsidianTombs, id, t.lastModified)) return false;
+    return true;
+  });
   return [...merged, ...rescued];
 }

--- a/src/utils/rescueUnsyncedTasks.test.js
+++ b/src/utils/rescueUnsyncedTasks.test.js
@@ -6,6 +6,7 @@ const imported = (id, extra = {}) => ({ id, title: id, imported: true, ...extra 
 const native = (id) => ({ id, title: id, _native: true });
 const intent = (id) => ({ id, title: id, _intentKey: `k-${id}` });
 const plain = (id) => ({ id, title: id });
+const obsidian = (id, lastModified) => ({ id, title: id, importSource: 'obsidian', lastModified });
 
 describe('rescueUnsyncedTasks', () => {
   it('preserves an untombstoned local-only imported task (the race-add rescue is intact)', () => {
@@ -68,11 +69,59 @@ describe('rescueUnsyncedTasks', () => {
     expect(rescueUnsyncedTasks(merged('a'), null).map((t) => t.id)).toEqual(['a']);
   });
 
-  it('isDefaultRescuable flags native / imported / intent, not plain', () => {
+  it('isDefaultRescuable flags native / imported / intent / obsidian, not plain', () => {
     expect(isDefaultRescuable(native('n'))).toBe(true);
     expect(isDefaultRescuable(imported('i'))).toBe(true);
     expect(isDefaultRescuable(intent('t'))).toBe(true);
+    expect(isDefaultRescuable(obsidian('o', '2026-05-01T00:00:00.000Z'))).toBe(true);
     expect(isDefaultRescuable(plain('p'))).toBe(false);
     expect(isDefaultRescuable(null)).toBe(false);
+  });
+
+  describe('Obsidian tasks (the ala7ur flicker fix)', () => {
+    it('RESCUES a live, note-backed Obsidian task the merge apply transiently omitted', () => {
+      // The Obsidian scan added obsidian-2026-04-23-ala7ur to state; a DB-sync apply
+      // then committed a merged set lacking it. It has no tombstone → keep it, so it
+      // does not flicker out of state every cycle.
+      const prev = [obsidian('obsidian-2026-04-23-ala7ur', '2026-04-23T09:30:00.000Z')];
+      const out = rescueUnsyncedTasks(merged('a'), prev, {}, undefined, {});
+      expect(out.map((t) => t.id)).toEqual(['a', 'obsidian-2026-04-23-ala7ur']);
+    });
+
+    it('does NOT rescue an Obsidian task deleted from the vault (deletedObsidianKeys wins)', () => {
+      // The note line was removed; detectObsidianDeletions tombstoned it with a
+      // deletion newer than the task. The rescue must leave it deleted.
+      const prev = [obsidian('obsidian-2026-04-23-ala7ur', '2026-04-23T09:30:00.000Z')];
+      const obsidianTombs = { 'obsidian-2026-04-23-ala7ur': '2026-06-01T00:00:00.000Z' };
+      const out = rescueUnsyncedTasks(merged('a'), prev, {}, undefined, obsidianTombs);
+      expect(out.map((t) => t.id)).toEqual(['a']); // stays deleted
+    });
+
+    it('RESCUES an Obsidian task re-created in the vault after its tombstone (LWW resurrect)', () => {
+      // The user re-added the line; the fresh copy is newer than the deletion, so it
+      // wins last-writer-wins and comes back — mirroring isObsidianTombstoned.
+      const prev = [obsidian('obsidian-2026-04-23-ala7ur', '2026-07-05T00:00:00.000Z')];
+      const obsidianTombs = { 'obsidian-2026-04-23-ala7ur': '2026-06-01T00:00:00.000Z' };
+      const out = rescueUnsyncedTasks(merged('a'), prev, {}, undefined, obsidianTombs);
+      expect(out.map((t) => t.id)).toEqual(['a', 'obsidian-2026-04-23-ala7ur']);
+    });
+
+    it('does NOT rescue an Obsidian task the user deleted in-app (deletedTaskIds guard still applies)', () => {
+      // Deleting inside dayGLANCE writes deletedTaskIds; that shared guard covers
+      // Obsidian tasks too, so an in-app delete is honored.
+      const prev = [obsidian('obsidian-2026-04-23-ala7ur', '2026-04-23T09:30:00.000Z')];
+      const out = rescueUnsyncedTasks(
+        merged('a'), prev,
+        { 'obsidian-2026-04-23-ala7ur': '2026-06-26T00:00:00.000Z' },
+        undefined, {},
+      );
+      expect(out.map((t) => t.id)).toEqual(['a']);
+    });
+
+    it('rescues an Obsidian task already present in merged? no — no duplication', () => {
+      const prev = [obsidian('dup', '2026-05-01T00:00:00.000Z')];
+      const out = rescueUnsyncedTasks(merged('dup'), prev, {}, undefined, {});
+      expect(out.map((t) => t.id)).toEqual(['dup']);
+    });
   });
 });


### PR DESCRIPTION
## What

An Obsidian task (`importSource:'obsidian'`) is re-derived from the local vault on every scan, so it is device-owned in the same sense as a native/imported task — but it is **also** a synced vault row, so the two subsystems race:

1. The Obsidian scan adds the task to state → it **appears**.
2. The next DB-sync apply commits a merged set that (transiently) lacks it and — because Obsidian tasks were **not** rescuable in `rescueUnsyncedTasks` — drops it → it **vanishes**.
3. The next scan re-adds it → repeat.

That is the observed appear/vanish flicker of a note-backed task — reproducible on macOS by forcing an Obsidian sync (task appears briefly, then disappears). The concrete case that surfaced it: an inline-dated task (`2026-04-23 …`) living in a differently-dated daily note (`2026-04-19`), which is a legitimate task that should sync cleanly.

## Fix

Make Obsidian tasks rescuable so a live, note-backed task survives a merge apply that omits it — guarded so a genuine deletion still propagates:

- `isDefaultRescuable` now includes `importSource === 'obsidian'`.
- `rescueUnsyncedTasks` takes the merged `deletedObsidianKeys` map and does **not** rescue an Obsidian task whose vault-deletion tombstone is at least as new as the task (last-writer-wins via `isObsidianTombstoned`) — so removing the line from the note still deletes it everywhere, and a later re-creation (newer) correctly comes back.
- The existing `deletedTaskIds` guard still covers an in-app delete of an Obsidian task.
- `applyEngineData` passes `data.deletedObsidianKeys` at both task/inbox rescue sites.

Net: `ala7ur`-style tasks stay stable in state → no more push/vanish/guard-skip churn — while genuine vault and in-app deletions are unaffected.

## Tests

`src/utils/rescueUnsyncedTasks.test.js` adds coverage for: a live note-backed Obsidian task is rescued; a vault-deleted one (tombstoned in `deletedObsidianKeys`) stays deleted; a re-created one (newer than its tombstone) resurrects; an in-app delete (`deletedTaskIds`) is honored; no duplication when already in the merged set. Full suite green (674 tests).

## Validation

Directly checkable with the repro: force an Obsidian sync on macOS — the inline-dated task should appear and **stay** instead of flickering out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_