### PR TITLE
Instrument the bare-delete emitters to pin the delete-war source

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 162
+        versionCode = 163
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -513,7 +513,7 @@ function mergeBundle(data, key, value, extra) {
 // lastModified, ties broken by CROSS_LIST_PRIORITY — and report each removed
 // copy via onLoser so the caller can soft-delete its stale ${kind}:${id} row,
 // converging the vault. Deterministic, so every device picks the same winner.
-export function reconcileCrossList(data, onLoser) {
+export function reconcileCrossList(data, onLoser, onCollision) {
   const byId = new Map();
   for (const kind of TASK_KINDS) {
     for (const item of (data[kind] || [])) {
@@ -530,6 +530,18 @@ export function reconcileCrossList(data, onLoser) {
       if (d !== 0) return d;
       return CROSS_LIST_PRIORITY.indexOf(a.kind) - CROSS_LIST_PRIORITY.indexOf(b.kind);
     });
+    // Optional diagnostic: report the collision (which kinds held this id, with
+    // their timestamps, and which won) BEFORE the losers are soft-deleted. This
+    // is how a cross-list-driven bare-delete war is caught even when the emitting
+    // device is a peer — the collision surfaces in every device's merged mirror.
+    if (onCollision) {
+      onCollision({
+        id,
+        kinds: entries.map((e) => ({ kind: e.kind, lastModified: e.item.lastModified })),
+        winner: entries[0].kind,
+        losers: entries.slice(1).map((e) => e.kind),
+      });
+    }
     for (const loser of entries.slice(1)) {
       data[loser.kind] = (data[loser.kind] || []).filter((x) => String(x.id) !== id);
       if (onLoser) onLoser(makeEntityId(loser.kind, id));

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -358,10 +358,16 @@ export function createDbEngine(callbacks = {}) {
           if (id in cur) continue;
           wantDelete.push(id);
         }
-        const { propagate, skipped } = partitionSnapshotDeletes(wantDelete, cur, mirror);
+        const { propagate, skipped, reasons } = partitionSnapshotDeletes(wantDelete, cur, mirror);
         for (const id of propagate) {
           engine.markDirty(id); // deletes
           if (dbgChanges) dbgChanges.push({ id, kind: 'deleted', diff: [] });
+        }
+        // Diagnostic: name WHY each delete is being propagated (tombstoned = real
+        // deletion; cross-list = the id survives under another kind). Catches a
+        // bare-delete this device emits and its cause. Gated on dayglance-debug-push.
+        if (debugPushEnabled() && propagate.length) {
+          console.warn('[push] propagating delete(s):', propagate.map((id) => `${id} (${reasons[id]})`));
         }
         if (skipped.length) {
           console.warn(
@@ -377,7 +383,17 @@ export function createDbEngine(callbacks = {}) {
       // The engine's onRowsSkipped fires from its own dbSyncCycle, which we
       // bypass — so surface undecryptable-row skips from the pull result here.
       if (pull && pull.skipped > 0) callbacks.onRowsSkipped?.(pull.skipped, pull.skippedEntityIds || []);
-      reconcileCrossList(mirror, (id) => engine.markDirty(id));
+      reconcileCrossList(
+        mirror,
+        (id) => engine.markDirty(id),
+        // Diagnostic: log every cross-list collision in the MERGED MIRROR (the
+        // shared vault state), so a bare-delete war driven by a peer's stale
+        // second-kind copy (e.g. a lingering recycleBin row) is visible on THIS
+        // device even though the peer emits the delete. Gated on dayglance-debug-push.
+        debugPushEnabled()
+          ? (c) => console.warn(`[reconcile] cross-list collision ${c.id} → keep ${c.winner}, delete [${c.losers.join(', ')}] |`, c.kinds)
+          : undefined,
+      );
       // Age tombstones out at the fixed 60-day window (src/sync/tombstoneRetention.js).
       // The vault bundle merge is grow-only (dbAdapter unionNewerIso), so a pull
       // re-adds every tombstone a peer still holds; without this the mirror would

--- a/src/sync/snapshotDeleteGuard.js
+++ b/src/sync/snapshotDeleteGuard.js
@@ -67,10 +67,16 @@ export function partitionSnapshotDeletes(deleteEntityIds, cur, mirror) {
 
   const propagate = [];
   const skipped = [];
+  // Why each entityId landed where it did — 'tombstoned' (a real deletion), a
+  // cross-list move ('cross-list', the id survives under another kind), or a
+  // suspected 'glitch' (skipped). Diagnostic only; callers that ignore it are
+  // unaffected.
+  const reasons = {};
   for (const eid of ids) {
     const id = bareId(eid);
-    if (tombstoned.has(id) || liveBareIds.has(id)) propagate.push(eid);
-    else skipped.push(eid);
+    if (tombstoned.has(id)) { propagate.push(eid); reasons[eid] = 'tombstoned'; }
+    else if (liveBareIds.has(id)) { propagate.push(eid); reasons[eid] = 'cross-list'; }
+    else { skipped.push(eid); reasons[eid] = 'glitch'; }
   }
-  return { propagate, skipped };
+  return { propagate, skipped, reasons };
 }

--- a/src/sync/snapshotDeleteGuard.test.js
+++ b/src/sync/snapshotDeleteGuard.test.js
@@ -62,8 +62,20 @@ describe('partitionSnapshotDeletes', () => {
     expect(skipped.sort()).toEqual(['tasks:glitch1', 'tasks:glitch2']);
   });
 
+  it('reports a reason per entityId (tombstoned / cross-list / glitch) for diagnostics', () => {
+    const mirror = { deletedTaskIds: { real: 't' } };
+    const cur = curOf('recycleBin:moved');
+    const del = ['tasks:real', 'tasks:moved', 'tasks:glitch1'];
+    const { reasons } = partitionSnapshotDeletes(del, cur, mirror);
+    expect(reasons).toEqual({
+      'tasks:real': 'tombstoned',
+      'tasks:moved': 'cross-list',
+      'tasks:glitch1': 'glitch',
+    });
+  });
+
   it('tolerates empty / missing inputs', () => {
-    expect(partitionSnapshotDeletes([], {}, {})).toEqual({ propagate: [], skipped: [] });
-    expect(partitionSnapshotDeletes(null, null, null)).toEqual({ propagate: [], skipped: [] });
+    expect(partitionSnapshotDeletes([], {}, {})).toEqual({ propagate: [], skipped: [], reasons: {} });
+    expect(partitionSnapshotDeletes(null, null, null)).toEqual({ propagate: [], skipped: [], reasons: {} });
   });
 });


### PR DESCRIPTION
## Why

The task delete↔re-add war (the 4 archived inbox tasks + the 11 deleted tasks) is driven by an **un-timestamped bare delete** that's authoritative-by-fiat. We confirmed the engine applies deletes unconditionally and can't fix it there (deletes carry no timestamp). The fix belongs app-side — but first we need to know **which emitter** produces the bare delete: the snapshot-diff vanish path or `reconcileCrossList`. The Mac's own snapshot can't reveal it (the emitting device is the phone, which isn't inspectable), so this adds logging that surfaces the cause from data the Mac *can* see.

## What (diagnostic only, zero behavior change)

Both logs are gated on the existing `dayglance-debug-push` flag; the new param/return field are additive:

- **`reconcileCrossList`** gains an optional `onCollision` reporter. `dbEngine` logs every cross-list collision found in the **merged mirror** — i.e. the shared vault state. If a peer has pushed a stale second-kind copy (e.g. a lingering `recycleBin:` row) for one of these ids, the collision appears in *every* device's mirror, so it's visible on the Mac even though the phone emits the delete.
- **`partitionSnapshotDeletes`** now returns a per-id `reason` (`tombstoned` / `cross-list` / `glitch`); `dbEngine` logs the reason for each delete it propagates, so a Mac-emitted delete names its own cause.

`versionCode` → 163 so the instrumented build installs as an update on both devices.

## How to use it

1. Build/deploy to **both** devices; on the Mac set `localStorage['dayglance-debug-push'] = '1'`.
2. Trigger the flare (foreground/sync the phone the way it churned before) with the Mac console open.
3. Look for:
   - `[reconcile] cross-list collision <id> → keep <kind>, delete [<kinds>] | …` for any of the 15 ids → the war is a **cross-list collision** (a stale second-kind copy); fix goes in `reconcileCrossList`/priority.
   - `[push] propagating delete(s): <id> (cross-list|tombstoned)` → a delete this device emits, with its cause.
   - If **neither** fires for the 4 during a flare → it's a pure snapshot-diff vanish on the phone, and we instrument that path next.

Once we see which fires, I'll write the actual convergence fix on its own branch. Full suite green (675). Revert-friendly — pure diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_