### PR TITLE
Quiet the sync console by default: only log real activity

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 163
+        versionCode = 164
         versionName = "3.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -64,9 +64,11 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
     // Observability: a live, inspectable snapshot so SSE health can be checked in
     // a packaged/MAS/native build with no devtools — run `window.__glanceVaultSse`
     // in the console (or read it from a diagnostics panel). Counters make a
-    // reconnect STORM (many connects, few events) immediately obvious. Logging is
-    // always-on (not DEV-gated) but low-volume: one line per lifecycle transition,
-    // not per heartbeat.
+    // reconnect STORM (many connects, few events) immediately obvious. The snapshot
+    // is ALWAYS live (updated every transition/drain); the per-transition CONSOLE
+    // lines are gated behind the `dayglance-debug-push` flag so production stays
+    // quiet — flip the flag to trace lifecycle, or just read window.__glanceVaultSse.
+    // Genuine errors still log unconditionally.
     const diag = {
       state: 'idle',
       connects: 0,
@@ -80,13 +82,20 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
     };
     if (typeof window !== 'undefined') window.__glanceVaultSse = diag;
 
+    // Console tracing is opt-in (the diag snapshot above is the always-on channel);
+    // gate on the same flag as the DB-sync push logging so one switch traces both.
+    const sseDebug = () => {
+      try { return typeof localStorage !== 'undefined' && localStorage.getItem('dayglance-debug-push') === '1'; }
+      catch { return false; }
+    };
+
     const coalescer = createNudgeCoalescer({
       // Debounce-only (no throttle). The self-nudge loop is fixed at the root — a
       // no-content sync cycle no longer pushes/nudges (utils/tombstoneHorizon.js) —
       // so drains fire near-instantly on real changes, restoring SSE's low latency.
       onDrain: (kind) => {
         diag.drains += 1;
-        console.info('[vault-sse] drain →', kind);
+        if (sseDebug()) console.info('[vault-sse] drain →', kind);
         if (kind === 'sync') drainSyncRef.current?.();
         else if (kind === 'intents') drainIntentsRef.current?.();
       },
@@ -105,7 +114,7 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
       if (state === 'connecting') diag.connects += 1;
       if (state === 'open') diag.lastConnectedAt = new Date().toISOString();
       if (state === 'error') { diag.lastError = detail?.message || String(detail || 'error'); console.warn('[vault-sse] error:', diag.lastError); }
-      else console.info('[vault-sse]', state, `(connects=${diag.connects} events=${diag.events} drains=${diag.drains})`);
+      else if (sseDebug()) console.info('[vault-sse]', state, `(connects=${diag.connects} events=${diag.events} drains=${diag.drains})`);
     };
     const getConnection = () => {
       const c = getVaultConfig();

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -326,10 +326,14 @@ export function createDbEngine(callbacks = {}) {
       // "deleted → new" churn seen from the source side — it distinguishes a real
       // state wipe (count goes 0) from a remote delete-row (count stays, [pull]
       // DELETE fires instead).
+      // Capture the seed-time payload counts, but DON'T log yet — only an ACTIVE
+      // cycle (wrote / deleted / pulled / had dirty rows) prints its summary, so a
+      // converged fleet's every-tick no-op cycles stay silent even with the flag on.
+      let pushCountsLine = null;
       if (pushDbg) {
         const cnt = (k) => Array.isArray(mirror[k]) ? mirror[k].length
           : (mirror[k] && typeof mirror[k] === 'object' ? Object.keys(mirror[k]).length : 0);
-        console.log(`[push] getData counts → tasks:${cnt('tasks')} unscheduled:${cnt('unscheduledTasks')} gtdFrames:${cnt('gtdFrames')} dailyNotes:${cnt('dailyNotes')} goals:${cnt('goals')} projects:${cnt('projects')}`);
+        pushCountsLine = `[push] getData counts → tasks:${cnt('tasks')} unscheduled:${cnt('unscheduledTasks')} gtdFrames:${cnt('gtdFrames')} dailyNotes:${cnt('dailyNotes')} goals:${cnt('goals')} projects:${cnt('projects')}`;
       }
       const dbgChanges = pushDbg ? [] : null; // [{ id, kind, diff:[] }]
       if (engine.getHighWaterMark() === 0) {
@@ -415,14 +419,21 @@ export function createDbEngine(callbacks = {}) {
       const pushRes = await engine.pushDirtyRows();        // push merged superset + local changes
       if (pushDbg) {
         const wrote = (pushRes?.written ?? 0) + (pushRes?.deleted ?? 0);
-        console.log(`[push] cycle → vault.batch written:${pushRes?.written ?? 0} deleted:${pushRes?.deleted ?? 0} — client ${wrote > 0 ? 'DID' : 'did NOT'} write this cycle`);
-        console.log('[push] dirty ids this cycle:', dirtyBeforePush ?? []);
-        if (dbgChanges && dbgChanges.length) {
-          for (const c of dbgChanges) {
-            console.log(`[push]   snapshot-diff ${c.kind} ${c.id}${c.diff.length ? ` — ${c.diff.join('; ')}` : ''}`);
+        // Only a cycle that actually moved data logs — wrote/deleted to the vault,
+        // pulled remote changes, or had a non-empty dirty set. A pure no-op tick
+        // (the common case in a converged fleet) stays silent.
+        const active = wrote > 0 || (pull?.applied ?? 0) > 0 || (dirtyBeforePush?.length ?? 0) > 0 || (dbgChanges?.length ?? 0) > 0;
+        if (active) {
+          if (pushCountsLine) console.log(pushCountsLine);
+          console.log(`[push] cycle → vault.batch written:${pushRes?.written ?? 0} deleted:${pushRes?.deleted ?? 0} — client ${wrote > 0 ? 'DID' : 'did NOT'} write this cycle`);
+          console.log('[push] dirty ids this cycle:', dirtyBeforePush ?? []);
+          if (dbgChanges && dbgChanges.length) {
+            for (const c of dbgChanges) {
+              console.log(`[push]   snapshot-diff ${c.kind} ${c.id}${c.diff.length ? ` — ${c.diff.join('; ')}` : ''}`);
+            }
+          } else {
+            console.log('[push]   dirt came from pull re-push / cross-list reconcile (superset), not a moving payload field');
           }
-        } else {
-          console.log('[push]   snapshot-diff found NO changed rows → dirt came from pull re-push / cross-list reconcile (superset), not a moving payload field');
         }
       }
       await engine.updateDeviceCursor();


### PR DESCRIPTION
## Why

The sync console floods even in normal use. Two sources:
- The `[vault-sse]` lifecycle lines (`connecting`/`open`/`stopped`) and the `drain → sync|intents` pair were **always-on** — and `drain` fires on every SSE nudge, so it's chatty, not "one line per transition."
- The `[push]` cycle summary (`getData counts` / `cycle → …written:0` / `dirty ids:[]` / `NO changed rows`) printed **every tick**, including the no-op cycles that dominate a converged fleet.

The result was a wall of logging even with nothing happening.

## What

Logging-only change; no control-flow impact on sync:

- **`[vault-sse]`**: gate the routine lifecycle + `drain` lines behind the same `dayglance-debug-push` flag as the DB-sync logging. Genuine errors (`[vault-sse] error:`) still log unconditionally, and `window.__glanceVaultSse` stays live for on-demand inspection (`connects`/`events`/`drains`/`lastError`/…), so observability is preserved without per-nudge spam.
- **`[push]` cycle summary**: capture the seed-time counts but only print the summary when the cycle **actually moved data** — wrote/deleted to the vault, pulled remote changes, or had a non-empty dirty set. A pure no-op tick stays silent.

The cross-list/propagating-delete war detectors (#1153) are unchanged.

## Net behavior

- **Flag off** (`dayglance-debug-push` unset): console is quiet except real errors.
- **Flag on**: full trace, but no per-tick no-op spam — so it's now usable as a **standing tripwire** for the delete-war (leave it on; it only speaks when something real syncs, and lights up if the war recurs).

`versionCode` → 164. Full suite green (675).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_