### PR TITLE
iOS: make TestFlight builds Web-Inspector-inspectable (not App Store)

### DIFF
--- a/dayglance-ios/DayGlance/WebView/WebView.swift
+++ b/dayglance-ios/DayGlance/WebView/WebView.swift
@@ -38,9 +38,18 @@ struct WebView: UIViewRepresentable {
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
 
-        #if DEBUG
-        if #available(iOS 16.4, *) { webView.isInspectable = true }
-        #endif
+        // Web Inspector (Safari → Develop). iOS 16.4+ defaults isInspectable to
+        // false, so a distribution build is otherwise un-inspectable. Enable it in
+        // Debug (Xcode runs) AND TestFlight (sandbox receipt) so beta test builds
+        // are debuggable — but NEVER in an App Store production build.
+        if #available(iOS 16.4, *) {
+            #if DEBUG
+            webView.isInspectable = true
+            #else
+            let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+            webView.isInspectable = isTestFlight
+            #endif
+        }
 
         // Reload the page after permission dialogs close so the web app can
         // re-fetch health and calendar data with fresh authorization.


### PR DESCRIPTION
## Why

On iOS 16.4+, `WKWebView.isInspectable` defaults to `false`, and inspectability was gated to `#if DEBUG` only. TestFlight is a **Release** build, so it couldn't be opened in Safari's Web Inspector — blocking on-device debugging of the web layer (needed right now to diagnose why native SSE isn't delivering instant updates on iOS).

## What

Enable `isInspectable` in **Debug** (Xcode runs) **and TestFlight** (detected via the sandbox App Store receipt), but keep it **false for App Store production** builds:

```swift
if #available(iOS 16.4, *) {
    #if DEBUG
    webView.isInspectable = true
    #else
    let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
    webView.isInspectable = isTestFlight
    #endif
}
```

TestFlight and Xcode dev builds carry a `sandboxReceipt`; App Store builds carry a `receipt`, so production stays non-inspectable. iOS build number is date-based (no version bump).

## After building this to TestFlight

Safari → Develop → *[device]* → **dg:///index.html** will now attach, and the SSE diagnostics work:
```js
window.__glanceVaultSse            // expect transport: 'native-bridge', connects, events, drains
window.DayGlanceNative.isVaultSseSupported()   // expect "true"
localStorage.setItem('dayglance-debug-push','1'); location.reload();  // verbose [vault-sse]/[push] logs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_