### PR TITLE
iOS SSE: expose reader internals via vaultSseDebugState (diagnose the stall)

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/VaultSseBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/VaultSseBridge.swift
@@ -58,15 +58,29 @@ final class VaultSseBridge {
     // notices it is no longer the current generation and exits.
     private var generation = 0
 
+    // ── TEMP diagnostic counters (read via debugState() / the vaultSseDebugState
+    // bridge method). They disambiguate a stuck reader without native-log access:
+    // reader-not-running vs connect-hang vs bad-status vs frames-not-reaching-JS.
+    // Strip once the iOS SSE path is confirmed healthy.
+    private var connectAttempts = 0
+    private var lastStatus: Int?
+    private var lastError: String?
+    private var opensPushed = 0
+    private var framesPushed = 0
+    private var pushDropped = 0
+    private var startCalls = 0
+
     // Dedicated session: a request-idle timeout longer than the ~25s server
     // heartbeat (a healthy idle stream never trips it, a silently-dead one is
     // detected within the window), and never a cached response. A stored `let`
     // (not lazy) so its first use from the reader Task can't race initialization.
+    // waitsForConnectivity is OFF so a stalled connect surfaces as an error/timeout
+    // (visible in debugState) rather than parking indefinitely.
     private let session: URLSession = {
         let cfg = URLSessionConfiguration.default
         cfg.timeoutIntervalForRequest = 60
         cfg.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        cfg.waitsForConnectivity = true
+        cfg.waitsForConnectivity = false
         return URLSession(configuration: cfg)
     }()
 
@@ -79,12 +93,40 @@ final class VaultSseBridge {
     /// Renderer → "SSE desired ON", with the vault connection params.
     func start(vaultUrl: String, token: String, accountId: String) {
         lock.lock()
+        startCalls += 1
         self.vaultUrl = trimTrailingSlashes(vaultUrl)
         self.token = token
         self.accountId = accountId
         self.desired = true
         reconcileLocked()
         lock.unlock()
+    }
+
+    /// TEMP diagnostic snapshot of the reader's internal state, as a JSON string.
+    /// Read from the web console via window.DayGlanceNative.vaultSseDebugState().
+    /// Disambiguates a stuck reader: reader-not-running vs connect-hang (attempts
+    /// but no status) vs bad-status vs frames-not-reaching-JS (hasWebView false /
+    /// pushDropped > 0). Strip once the iOS SSE path is confirmed healthy.
+    func debugState() -> String {
+        lock.lock(); defer { lock.unlock() }
+        let dict: [String: Any] = [
+            "startCalls": startCalls,
+            "desired": desired,
+            "foreground": foreground,
+            "readerRunning": readerTask != nil,
+            "generation": generation,
+            "hasWebView": webView != nil,
+            "haveParams": vaultUrl != nil && token != nil && accountId != nil,
+            "connectAttempts": connectAttempts,
+            "lastStatus": lastStatus as Any,
+            "lastError": lastError as Any,
+            "opensPushed": opensPushed,
+            "framesPushed": framesPushed,
+            "pushDropped": pushDropped,
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: dict),
+              let json = String(data: data, encoding: .utf8) else { return "{}" }
+        return json
     }
 
     /// Renderer → "SSE desired OFF".
@@ -138,6 +180,7 @@ final class VaultSseBridge {
                 return
             } catch {
                 if Task.isCancelled || currentGeneration() != gen { return }
+                recordError(error.localizedDescription)
                 push(["type": "error", "message": error.localizedDescription])
             }
             if Task.isCancelled || currentGeneration() != gen { return }
@@ -161,11 +204,13 @@ final class VaultSseBridge {
         req.setValue("text/event-stream", forHTTPHeaderField: "Accept")
         req.timeoutInterval = 60
 
+        recordConnectAttempt()
         let (bytes, response) = try await session.bytes(for: req)
-        guard let status = (response as? HTTPURLResponse)?.statusCode, (200...299).contains(status) else {
-            let code = (response as? HTTPURLResponse)?.statusCode ?? 0
-            throw NSError(domain: "VaultSse", code: code,
-                          userInfo: [NSLocalizedDescriptionKey: "vault SSE connect failed: \(code)"])
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        recordStatus(status)
+        guard (200...299).contains(status) else {
+            throw NSError(domain: "VaultSse", code: status,
+                          userInfo: [NSLocalizedDescriptionKey: "vault SSE connect failed: \(status)"])
         }
         push(["type": "open"])
 
@@ -197,16 +242,31 @@ final class VaultSseBridge {
         guard JSONSerialization.isValidJSONObject(msg),
               let data = try? JSONSerialization.data(withJSONObject: msg),
               let json = String(data: data, encoding: .utf8) else { return }
+        // Count by type and detect a dropped push (weak webView gone) BEFORE the
+        // async hop, so debugState() reflects the real delivery outcome.
+        let type = msg["type"] as? String ?? "?"
+        lock.lock()
+        let wv = webView
+        if wv == nil { pushDropped += 1 }
+        else if type == "open" { opensPushed += 1 }
+        else if type == "frame" { framesPushed += 1 }
+        lock.unlock()
+        guard let webView = wv else { return }
         // JSON is valid JS object-literal syntax, so the renderer receives an object
         // (createBridgeSseClient.receive accepts an object OR a JSON string). Building
         // via JSONSerialization escapes quotes/newlines/unicode in the block safely.
-        DispatchQueue.main.async { [weak self] in
-            self?.webView?.evaluateJavaScript(
+        DispatchQueue.main.async {
+            webView.evaluateJavaScript(
                 "window.__glanceVaultSseReceive && window.__glanceVaultSseReceive(\(json))",
                 completionHandler: nil
             )
         }
     }
+
+    // TEMP diagnostic recorders (lock-guarded so debugState reads a consistent view).
+    private func recordConnectAttempt() { lock.lock(); connectAttempts += 1; lock.unlock() }
+    private func recordStatus(_ s: Int) { lock.lock(); lastStatus = s; lock.unlock() }
+    private func recordError(_ e: String) { lock.lock(); lastError = e; lock.unlock() }
 
     // MARK: - Helpers
 

--- a/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
+++ b/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
@@ -241,6 +241,9 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
         case "stopVaultSse":
             VaultSseBridge.shared.stop()
             return "null"
+        // TEMP diagnostic: reader internals as JSON (read from the web console).
+        case "vaultSseDebugState":
+            return VaultSseBridge.shared.debugState()
 
         default:
             return "null"


### PR DESCRIPTION
## Why

On iOS the native SSE reader is stuck at `state: "connecting"` — no `open`, no `error`, `events: 0`. A buffered `httpRequest` probe to `/events` confirmed the endpoint is reachable and streaming, so the connection path works and the stall is inside the Swift reader or the frame-push back to JS. This exposes the reader's internal state **through the bridge** so we can pinpoint it from the web console (no Console.app, and independent of the push path that may itself be the problem).

## What (TEMP diagnostic)

- New bridge method — read it in Safari Web Inspector:
  ```js
  JSON.parse(window.DayGlanceNative.vaultSseDebugState())
  ```
  Returns:
  ```
  { startCalls, desired, foreground, readerRunning, generation, hasWebView,
    haveParams, connectAttempts, lastStatus, lastError,
    opensPushed, framesPushed, pushDropped }
  ```
- `waitsForConnectivity` flipped to **false** so a stalled connect surfaces as a timeout/error in `lastError` instead of parking indefinitely.

## How to read it

- `readerRunning: false` → the reader never started (foreground/desired gating): check `desired` / `foreground`.
- `connectAttempts >= 1` but `lastStatus: null` and `lastError: null` → hung in `bytes(for:)` (connect not returning).
- `lastStatus: 401/403/…` → auth/endpoint rejects the streaming request.
- `lastStatus: 200`, `opensPushed >= 1`, but `hasWebView: false` / `pushDropped > 0` → the reader works but frames aren't reaching JS (weak WebView ref gone).
- `framesPushed > 0` while `window.__glanceVaultSse.events` stays 0 → frames reach JS but the receiver isn't wired.

Marked TEMP; I'll strip it (and apply the actual fix) once we see which branch it is. iOS build number is date-based (no bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbyMHF7ACvX4GnLQ2qSRQ)_