### PR TITLE
Sync: fix the mirror-commit data-loss cluster (mid-cycle edits, glitch recovery, restore reset)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,7 +77,7 @@ import useTrmnlSync from './hooks/useTrmnlSync.js';
 import useObsidian from './hooks/useObsidian.js';
 import useCloudSync from './hooks/useCloudSync.js';
 import { createDayGlanceEngine } from './sync/adapter.js';
-import { createDbEngine } from './sync/dbEngine.js';
+import { createDbEngine, resetVaultSyncCursor } from './sync/dbEngine.js';
 import { registerDbEngine } from './sync/dirtyTracker.js';
 import { isVaultEnabled } from './sync/vaultConfig.js';
 import { encryptData, decryptData, isEncryptedEnvelope, hasEncryptionReady } from './utils/crypto.js';
@@ -5148,6 +5148,12 @@ const DayPlanner = () => {
       const { data } = record.data;
       if (data.aiConfig) localStorage.setItem('day-planner-ai-config', JSON.stringify(data.aiConfig));
       if (data.obsidianConfig) localStorage.setItem('day-planner-obsidian-config', JSON.stringify(data.obsidianConfig));
+      // Restoring replaces the FULL local state, so the vault sync cursors no
+      // longer describe it: the stale snapshot would diff the restored (older)
+      // rows as dirty and push them OVER the vault's newer rows, and the stale
+      // pull HWM would skip forever every vault row the backup lacks. Clear them
+      // so the post-reload cycle full-pulls and LWW-merges (never blind-pushes).
+      resetVaultSyncCursor();
       applyEngineData(data);
       window.location.reload();
     } catch (err) {
@@ -5163,6 +5169,9 @@ const DayPlanner = () => {
       if (!backup?.data) throw new Error('Invalid backup file');
       if (backup.data.aiConfig) localStorage.setItem('day-planner-ai-config', JSON.stringify(backup.data.aiConfig));
       if (backup.data.obsidianConfig) localStorage.setItem('day-planner-obsidian-config', JSON.stringify(backup.data.obsidianConfig));
+      // Full-state replacement → invalidate the vault sync cursors (see
+      // restoreFromAutoBackup for the stale-snapshot/stale-HWM hazard).
+      resetVaultSyncCursor();
       applyEngineData(backup.data);
       window.location.reload();
     } catch (err) {
@@ -5261,6 +5270,10 @@ const DayPlanner = () => {
         if (data.projects) localStorage.setItem('day-planner-projects', JSON.stringify(data.projects));
         if (data.areas) localStorage.setItem('day-planner-areas', JSON.stringify(data.areas));
         if (data.goalsProjectsEnabled !== undefined) localStorage.setItem('day-planner-goals-projects-enabled', JSON.stringify(data.goalsProjectsEnabled));
+
+        // Full-state replacement → invalidate the vault sync cursors (see
+        // restoreFromAutoBackup for the stale-snapshot/stale-HWM hazard).
+        resetVaultSyncCursor();
 
         // Reload app to reflect changes
         // On Android WebView, use href assignment for a full reload; fall back to reload()

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -3,7 +3,7 @@ import { AlertTriangle, Eye, EyeOff } from 'lucide-react';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { setupEncryptionKey, setSyncPassphrase, clearEncryptionKey, getSyncPassphrase } from '../utils/crypto.js';
 import { getVaultConfig, setVaultConfig } from '../sync/vaultConfig.js';
-import { createDbEngine, resetDbRootKey } from '../sync/dbEngine.js';
+import { createDbEngine, resetDbRootKey, resetVaultSyncCursor } from '../sync/dbEngine.js';
 import { testVaultConnection } from '../sync/vaultConnectionTest.js';
 import { useTranslation } from 'react-i18next';
 
@@ -147,7 +147,17 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
     // current passphrase + the server's account salt. Without this, a key cached
     // during an earlier attempt (wrong/old passphrase) stays locked in and pulling
     // another device's rows fails with "Decryption failed".
-    if (vaultChanged) await resetDbRootKey();
+    //
+    // Likewise drop the persisted sync cursors (snapshot / pull HWM / push-ack /
+    // dirty set): they describe the PREVIOUS link. Re-linking (possibly to a
+    // different vault/account) with a stale HWM would skip every existing vault
+    // row below it, and a stale snapshot would diff local rows as clean/dirty
+    // against the wrong baseline. Fresh cursors make the first cycle a full pull
+    // + full-seed, which merges per-entity LWW (see resetVaultSyncCursor).
+    if (vaultChanged) {
+      await resetDbRootKey();
+      resetVaultSyncCursor();
+    }
 
     // Run the first real sync NOW, while the passphrase is in memory: this caches
     // the DB root key (IndexedDB on web, OS keystore on native) AND uploads/downloads

--- a/src/sync/commitMerge.js
+++ b/src/sync/commitMerge.js
@@ -1,0 +1,176 @@
+// Merge-aware commit for the GLANCEvault DB cycle (src/sync/dbEngine.js).
+//
+// THE HAZARD THIS CLOSES: dbEngine clones app state into a per-cycle MIRROR at
+// cycle start, runs the (async, network-bound) pull/push against the mirror, and
+// finally hands the mirror to commitData — where App.jsx's applyEngineData
+// REPLACES tasks/notes/etc. wholesale. Any ordinary user write made DURING the
+// network window (a new task, an edit) exists only in live state, not in the
+// mirror, so the commit silently reverts it; and because the post-cycle snapshot
+// used to be taken from that same mirror, the reverted write never showed up as
+// a diff again — it was never marked dirty, never pushed, permanently lost.
+//
+// THE FIX: at commit time, re-read live state and merge every MID-CYCLE live
+// change into the mirror before it is committed:
+//
+//   • An entity whose live hash equals its cycle-start hash was untouched
+//     mid-cycle → the pulled/merged mirror copy stands (remote changes land).
+//   • An entity that changed mid-cycle and is ALSO present in the mirror is a
+//     genuine concurrent-edit conflict (the pull may have updated the same row):
+//     resolve by LAST-WRITER-WINS on lastModified. Ties (and entities with no
+//     lastModified semantics at all) prefer LIVE state — the user's in-hand edit
+//     — mirroring the engine's own pull rule where local wins on a non-older
+//     timestamp (@glance-apps/sync dbEngine.js applyRemoteRow).
+//   • A live entity with NO mirror copy either (a) never existed at cycle start
+//     → it was created mid-cycle and MUST survive, or (b) existed at cycle start
+//     but was removed from the mirror by a pulled delete / cross-list reconcile
+//     while the user was editing it. A delete row carries no lastModified to LWW
+//     against, so (b) biases toward KEEPING the edit (fail-safe toward data; a
+//     genuinely tombstoned delete still wins long-term via its tombstone bundle).
+//   • Singleton bundles changed mid-cycle are merged through the SAME per-bundle
+//     strategy the pull uses (union / per-key LWW via applyRemoteEntity), so
+//     neither a pulled peer edit nor the mid-cycle local edit to a different
+//     entry is lost. Device-local bundles are the exception: the pull merge
+//     deliberately keeps "local" — which at commit time is the STALE mirror copy
+//     — so for those the live value is written through directly.
+//   • An entity present in the mirror but gone from live either (a) was pulled
+//     in from a peer this cycle (absent at cycle start too) → keep it, or (b)
+//     was deleted locally mid-cycle → honor the deletion, but ONLY when it bears
+//     a real-deletion fingerprint (tombstone / cross-list survivor) per
+//     partitionSnapshotDeletes — a bare mid-cycle vanish is a glitch-suspect and
+//     the mirror copy is kept (same bias as snapshotDeleteGuard).
+//
+// WHY SURVIVORS STILL GET PUSHED (the snapshot contract): dbEngine saves the
+// post-cycle snapshot from the mirror AS PUSHED/PULLED (i.e. BEFORE this merge),
+// which is the vault-consistent state. A surviving mid-cycle edit is therefore
+// committed to live state but ABSENT from the snapshot, so the NEXT cycle's
+// snapshot-diff marks it dirty and pushes it. Full trace in dbEngine.js at the
+// call site.
+
+import {
+  shredState,
+  getLocalEntity,
+  applyRemoteEntity,
+  applyRemoteDelete,
+  getEntityLastModified,
+  entityKind,
+  SINGLETON_KIND,
+  isDeviceLocalBundle,
+} from './dbAdapter.js';
+import { partitionSnapshotDeletes } from './snapshotDeleteGuard.js';
+
+// The one hash used for every snapshot/diff comparison in the DB tier. Both the
+// persisted post-cycle snapshot (dbEngine) and the mid-cycle-change detection
+// here MUST use the same function, or diffs would misfire.
+export const hashEntity = (entity) => JSON.stringify(entity);
+
+// entityId → entity-hash for a whole payload — the snapshot/diff currency.
+export function shredHashes(data) {
+  const map = {};
+  for (const row of shredState(data)) map[row.entityId] = hashEntity(row.entity);
+  return map;
+}
+
+// Key-set + value equality of two hash maps (order-independent).
+export function hashMapsEqual(a, b) {
+  const ka = Object.keys(a || {});
+  const kb = Object.keys(b || {});
+  if (ka.length !== kb.length) return false;
+  for (const k of ka) if (b[k] !== a[k]) return false;
+  return true;
+}
+
+const ts = (v) => {
+  if (v == null) return 0;
+  const t = new Date(v).getTime();
+  return Number.isNaN(t) ? 0 : t;
+};
+
+// Write one live entity into the mirror verbatim. Collections/notes go through
+// applyRemoteEntity (plain upsert; recurring templates additionally union their
+// completedDates with the mirror copy, which only ever ADDS pulled completions).
+// Singletons are written directly — applyRemoteEntity would run the pull merge,
+// which for device-local bundles keeps the (stale) mirror copy.
+function injectLive(mirror, entity) {
+  if (entityKind(entity) === SINGLETON_KIND) {
+    mirror[entity._key] = entity.value;
+    if (entity._extra) Object.assign(mirror, entity._extra);
+    return;
+  }
+  applyRemoteEntity(mirror, entity);
+}
+
+/**
+ * Merge mid-cycle live edits into the per-cycle mirror before it is committed.
+ * Mutates `mirror` in place (it is a per-cycle clone).
+ *
+ * @param {object} mirror      the pulled/merged/pushed cycle mirror
+ * @param {Record<string,string>} baseHashes  shredHashes of the state at cycle START
+ * @param {object} live        a fresh clone of getData() taken at commit time
+ * @returns {{ survivors: string[], honoredDeletes: string[], keptVanishes: string[],
+ *             liveHashes: Record<string,string> }}
+ *   survivors:      live entityIds written into the commit (created/edited mid-cycle)
+ *   honoredDeletes: mirror entityIds removed because live deleted them mid-cycle
+ *                   (tombstoned / cross-list — real deletions only)
+ *   keptVanishes:   live-absent entityIds KEPT in the commit (bare mid-cycle
+ *                   vanish with no deletion fingerprint — glitch-suspect)
+ *   liveHashes:     shredHashes of `live` (reusable by the caller's no-op check)
+ */
+export function mergeMidCycleEdits(mirror, baseHashes, live) {
+  const base = baseHashes || {};
+  const liveData = live || {};
+  const liveRows = shredState(liveData);
+  const liveHashes = {};
+  for (const row of liveRows) liveHashes[row.entityId] = hashEntity(row.entity);
+
+  const survivors = [];
+  for (const row of liveRows) {
+    const id = row.entityId;
+    if (base[id] === liveHashes[id]) continue; // untouched mid-cycle → pull result stands
+    const liveEntity = row.entity;
+    const mirrorEntity = getLocalEntity(mirror, id);
+
+    if (mirrorEntity == null) {
+      // Created mid-cycle (no cycle-start copy) — or edited mid-cycle while a
+      // pulled delete/reconcile removed it from the mirror. Either way the live
+      // copy survives (see header: bias toward keeping a concurrent edit).
+      injectLive(mirror, liveEntity);
+      survivors.push(id);
+      continue;
+    }
+
+    if (entityKind(liveEntity) === SINGLETON_KIND) {
+      // Run the live edit through the same per-bundle merge the pull uses, so a
+      // pulled peer edit and the mid-cycle local edit BOTH land (union bundles),
+      // and timestamped config pairs resolve by their own LWW.
+      applyRemoteEntity(mirror, liveEntity);
+      // Device-local bundles: the merge keeps "local" = the stale mirror copy;
+      // the live value is this device's truth — write it through.
+      if (isDeviceLocalBundle(mirror, liveEntity._key)) injectLive(mirror, liveEntity);
+      survivors.push(id);
+      continue;
+    }
+
+    // Concurrent edit vs. (possibly) pulled update of the SAME entity: LWW on
+    // lastModified. Ties and timestamp-less entities prefer LIVE (see header).
+    if (ts(getEntityLastModified(liveEntity)) >= ts(getEntityLastModified(mirrorEntity))) {
+      injectLive(mirror, liveEntity);
+      survivors.push(id);
+    }
+    // else: the mirror copy (a strictly newer pulled write) wins — nothing to do.
+  }
+
+  // Mid-cycle local deletions: in the cycle-start state and still in the mirror,
+  // but gone from live. Honor only REAL deletions (tombstoned / cross-list); a
+  // bare vanish is a glitch-suspect and the mirror copy is kept — exactly the
+  // snapshotDeleteGuard bias, applied to the commit instead of the push.
+  const wantDelete = [];
+  for (const id of Object.keys(base)) {
+    if (liveHashes[id] !== undefined) continue;      // still live
+    if (getLocalEntity(mirror, id) == null) continue; // already gone from the mirror
+    wantDelete.push(id);
+  }
+  const { propagate, skipped } = partitionSnapshotDeletes(wantDelete, liveHashes, liveData);
+  for (const id of propagate) applyRemoteDelete(mirror, id);
+
+  return { survivors, honoredDeletes: propagate, keptVanishes: skipped, liveHashes };
+}

--- a/src/sync/commitMerge.test.js
+++ b/src/sync/commitMerge.test.js
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import { mergeMidCycleEdits, shredHashes, hashMapsEqual, hashEntity } from './commitMerge.js';
+
+// Unit tests for the merge-aware commit (Bug: commitData used to clobber any
+// local write made during the async pull/push window). These drive the pure
+// helper directly; the end-to-end path through the real engine is covered in
+// dbEngineWiring.test.js ("mid-cycle writes survive").
+
+const task = (id, lastModified, extra = {}) => ({
+  id, title: `task ${id}`, duration: 30, completed: false, lastModified, ...extra,
+});
+const clone = (x) => JSON.parse(JSON.stringify(x));
+
+const BASE = {
+  tasks: [task(1, '2026-07-01T10:00:00.000Z')],
+  unscheduledTasks: [],
+  recycleBin: [],
+  dailyNotes: { '2026-07-01': { text: 'note', lastModified: '2026-07-01T08:00:00.000Z' } },
+  completedTaskUids: ['a'],
+  deletedTaskIds: {},
+  use24HourClock: false,
+};
+
+// Convenience: run the merge for a given (mirror, live) pair against BASE.
+function run(mutateMirror, mutateLive, base = BASE) {
+  const mirror = clone(base);
+  const live = clone(base);
+  mutateMirror?.(mirror);
+  mutateLive?.(live);
+  const baseHashes = shredHashes(base);
+  const res = mergeMidCycleEdits(mirror, baseHashes, live);
+  return { mirror, live, ...res };
+}
+
+describe('mergeMidCycleEdits — mid-cycle live changes fold into the commit', () => {
+  it('a task CREATED mid-cycle (no mirror copy, no cycle-start copy) survives', () => {
+    const { mirror, survivors } = run(
+      null,
+      (live) => live.tasks.push(task(2, '2026-07-01T11:00:00.000Z')),
+    );
+    expect(mirror.tasks.map((t) => t.id)).toEqual([1, 2]);
+    expect(survivors).toContain('tasks:2');
+  });
+
+  it('a mid-cycle EDIT beats an untouched mirror copy (live newer)', () => {
+    const { mirror } = run(
+      null,
+      (live) => { live.tasks[0] = task(1, '2026-07-01T12:00:00.000Z', { title: 'edited mid-cycle' }); },
+    );
+    expect(mirror.tasks[0].title).toBe('edited mid-cycle');
+  });
+
+  it('SAME-entity conflict resolves by LWW: a strictly newer pulled write wins over an older mid-cycle edit', () => {
+    const { mirror, survivors } = run(
+      (m) => { m.tasks[0] = task(1, '2026-07-01T13:00:00.000Z', { title: 'pulled remote' }); },
+      (live) => { live.tasks[0] = task(1, '2026-07-01T12:00:00.000Z', { title: 'edited mid-cycle' }); },
+    );
+    expect(mirror.tasks[0].title).toBe('pulled remote');
+    expect(survivors).not.toContain('tasks:1');
+  });
+
+  it('SAME-entity conflict resolves by LWW: a newer mid-cycle edit wins over the pulled write', () => {
+    const { mirror } = run(
+      (m) => { m.tasks[0] = task(1, '2026-07-01T12:00:00.000Z', { title: 'pulled remote' }); },
+      (live) => { live.tasks[0] = task(1, '2026-07-01T13:00:00.000Z', { title: 'edited mid-cycle' }); },
+    );
+    expect(mirror.tasks[0].title).toBe('edited mid-cycle');
+  });
+
+  it('a timestamp TIE prefers the live (in-hand) edit — mirrors the engine local-keeps-on-tie rule', () => {
+    const { mirror } = run(
+      (m) => { m.tasks[0] = task(1, '2026-07-01T12:00:00.000Z', { title: 'pulled remote' }); },
+      (live) => { live.tasks[0] = task(1, '2026-07-01T12:00:00.000Z', { title: 'edited mid-cycle' }); },
+    );
+    expect(mirror.tasks[0].title).toBe('edited mid-cycle');
+  });
+
+  it('an entity with NO lastModified semantics prefers live', () => {
+    const base = { ...clone(BASE), tasks: [{ id: 1, title: 'no ts' }] };
+    const { mirror } = run(
+      (m) => { m.tasks[0] = { id: 1, title: 'pulled, also no ts' }; },
+      (live) => { live.tasks[0] = { id: 1, title: 'live, no ts' }; },
+      base,
+    );
+    expect(mirror.tasks[0].title).toBe('live, no ts');
+  });
+
+  it('an UNTOUCHED entity keeps the pulled mirror version (remote changes land)', () => {
+    const { mirror } = run(
+      (m) => { m.tasks[0] = task(1, '2026-07-01T13:00:00.000Z', { title: 'pulled remote' }); },
+      null,
+    );
+    expect(mirror.tasks[0].title).toBe('pulled remote');
+  });
+
+  it('a REMOTE DELETE of an untouched entity is honored (mirror stands)', () => {
+    const { mirror } = run((m) => { m.tasks = []; }, null);
+    expect(mirror.tasks).toEqual([]);
+  });
+
+  it('a REMOTE DELETE racing a mid-cycle EDIT keeps the edit (bias toward data)', () => {
+    const { mirror, survivors } = run(
+      (m) => { m.tasks = []; }, // pull removed it from the mirror
+      (live) => { live.tasks[0] = task(1, '2026-07-01T12:00:00.000Z', { title: 'edited mid-cycle' }); },
+    );
+    expect(mirror.tasks.map((t) => t.id)).toEqual([1]);
+    expect(mirror.tasks[0].title).toBe('edited mid-cycle');
+    expect(survivors).toContain('tasks:1');
+  });
+
+  it('a MID-CYCLE LOCAL DELETE with a tombstone is honored (removed from the commit)', () => {
+    const { mirror, honoredDeletes } = run(
+      null,
+      (live) => {
+        live.tasks = [];
+        live.deletedTaskIds = { 1: '2026-07-01T12:00:00.000Z' };
+      },
+    );
+    expect(mirror.tasks).toEqual([]);
+    expect(honoredDeletes).toEqual(['tasks:1']);
+    // the tombstone bundle change itself also landed in the commit
+    expect(mirror.deletedTaskIds).toEqual({ 1: '2026-07-01T12:00:00.000Z' });
+  });
+
+  it('a MID-CYCLE cross-list move is honored (old-kind copy removed, new-kind copy injected)', () => {
+    const { mirror, honoredDeletes, survivors } = run(
+      null,
+      (live) => {
+        live.tasks = [];
+        live.unscheduledTasks = [task(1, '2026-07-01T12:00:00.000Z')];
+      },
+    );
+    expect(mirror.tasks).toEqual([]);
+    expect(mirror.unscheduledTasks.map((t) => t.id)).toEqual([1]);
+    expect(honoredDeletes).toEqual(['tasks:1']);
+    expect(survivors).toContain('unscheduledTasks:1');
+  });
+
+  it('a BARE mid-cycle vanish (no tombstone, no cross-list copy) is KEPT — glitch-suspect', () => {
+    const { mirror, keptVanishes, honoredDeletes } = run(
+      null,
+      (live) => { live.tasks = []; }, // vanished with no fingerprint
+    );
+    expect(mirror.tasks.map((t) => t.id)).toEqual([1]);
+    expect(keptVanishes).toEqual(['tasks:1']);
+    expect(honoredDeletes).toEqual([]);
+  });
+
+  it('a NEW remote entity absent from live and cycle-start state is kept (pull lands)', () => {
+    const { mirror, honoredDeletes } = run(
+      (m) => { m.tasks.push(task(9, '2026-07-01T13:00:00.000Z')); },
+      null,
+    );
+    expect(mirror.tasks.map((t) => t.id)).toEqual([1, 9]);
+    expect(honoredDeletes).toEqual([]);
+  });
+
+  it('UNION bundles merge live and pulled edits (neither is lost)', () => {
+    const { mirror } = run(
+      (m) => { m.completedTaskUids = ['a', 'from-remote']; },
+      (live) => { live.completedTaskUids = ['a', 'from-live']; },
+    );
+    expect(new Set(mirror.completedTaskUids)).toEqual(new Set(['a', 'from-remote', 'from-live']));
+  });
+
+  it('DEVICE-LOCAL bundles take the live value (the pull merge would keep the stale mirror copy)', () => {
+    const { mirror } = run(
+      null,
+      (live) => { live.use24HourClock = true; },
+    );
+    expect(mirror.use24HourClock).toBe(true);
+  });
+
+  it('dailyNotes resolve per-date: pulled-newer date wins, live-new date is injected', () => {
+    const { mirror } = run(
+      (m) => { m.dailyNotes['2026-07-01'] = { text: 'remote note', lastModified: '2026-07-01T13:00:00.000Z' }; },
+      (live) => {
+        live.dailyNotes['2026-07-01'] = { text: 'live note', lastModified: '2026-07-01T09:00:00.000Z' };
+        live.dailyNotes['2026-07-02'] = { text: 'new live note', lastModified: '2026-07-01T12:00:00.000Z' };
+      },
+    );
+    expect(mirror.dailyNotes['2026-07-01'].text).toBe('remote note');
+    expect(mirror.dailyNotes['2026-07-02'].text).toBe('new live note');
+  });
+});
+
+describe('shredHashes / hashMapsEqual', () => {
+  it('hashes every row and compares maps order-independently', () => {
+    const a = shredHashes(BASE);
+    expect(a['tasks:1']).toBe(hashEntity({ _kind: 'tasks', value: BASE.tasks[0] }));
+    const b = shredHashes(clone(BASE));
+    expect(hashMapsEqual(a, b)).toBe(true);
+    const c = shredHashes({ ...clone(BASE), tasks: [task(1, '2026-07-02T10:00:00.000Z')] });
+    expect(hashMapsEqual(a, c)).toBe(false);
+    const d = shredHashes({ ...clone(BASE), tasks: [] });
+    expect(hashMapsEqual(a, d)).toBe(false); // key-set difference
+  });
+});

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -406,6 +406,12 @@ const MULTIUSER_DEVICE_LOCAL = new Set([
 const keptLocalBundle = (data, key) =>
   ALWAYS_DEVICE_LOCAL.has(key) || (MULTIUSER_DEVICE_LOCAL.has(key) && !!data.multiUserEnabled);
 
+// Exported for the commit merge (src/sync/commitMerge.js): for a device-local
+// bundle the pull merge keeps "local" — which at commit-merge time is the STALE
+// cycle-start mirror copy — so the commit must write the LIVE value through
+// directly instead.
+export const isDeviceLocalBundle = keptLocalBundle;
+
 function mergeBundle(data, key, value, extra) {
   if (TOMBSTONE_BUNDLES.has(key)) {
     data[key] = MERGE.unionNewerIso(data[key] || {}, value || {});

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -21,13 +21,17 @@
 //     React/localStorage state directly, and the merged mirror is handed to
 //     commitData once per cycle. commitData writes through the app's existing
 //     applyPayload (which sets the suppress flags), so a pulled row never bounces
-//     back out as a file-tier upload or a re-push.
+//     back out as a file-tier upload or a re-push. Because applyPayload has
+//     REPLACE semantics, the commit is MERGE-AWARE: user writes made during the
+//     async network window are folded into the mirror at commit time
+//     (src/sync/commitMerge.js) so they survive; the post-cycle snapshot stays
+//     the PRE-merge (vault-consistent) mirror so those survivors diff dirty and
+//     push next cycle. See the commit block in dbSyncCycle.
 
-import { createDbSyncEngine, clearDbRootKey, initDbRootKey } from '@glance-apps/sync';
+import { createDbSyncEngine, clearDbRootKey, initDbRootKey, decryptEntity } from '@glance-apps/sync';
 import { getVaultConfig, isVaultEnabled } from './vaultConfig.js';
 import { getDeviceId } from './deviceId.js';
 import {
-  shredState,
   getLocalEntity as adapterGetLocalEntity,
   applyRemoteEntity as adapterApplyRemoteEntity,
   applyRemoteDelete as adapterApplyRemoteDelete,
@@ -37,9 +41,51 @@ import {
 } from './dbAdapter.js';
 import { pruneAllTombstones, tombstoneCutoff } from './tombstoneRetention.js';
 import { partitionSnapshotDeletes } from './snapshotDeleteGuard.js';
+import { shredHashes, hashMapsEqual, mergeMidCycleEdits } from './commitMerge.js';
 
 const APP_ID = 'dayglance';
 const CRYPTO_DB_NAME = 'dayglance-db-crypto';
+
+// The storage prefix App.jsx's engine uses (tests override it per device).
+const DEFAULT_STORAGE_KEY_PREFIX = 'dayglance-vault';
+
+// Every persisted cursor/baseline the DB tier keeps between cycles:
+//   -db-sync-snapshot   the wrapper's post-cycle diff baseline (this file)
+//   -db-sync-hwm        the engine's PULL cursor (@glance-apps/sync dbEngine.js)
+//   -db-sync-push-ack   the engine's push idempotency marker
+//   -db-sync-dirty      the engine's persisted dirty set
+//   -db-sync-quarantine the engine's undecryptable-row retry set (seq-based,
+//                       meaningless after a cursor reset — the full re-pull
+//                       re-lists those rows anyway)
+const SYNC_CURSOR_KEY_SUFFIXES = [
+  '-db-sync-snapshot',
+  '-db-sync-hwm',
+  '-db-sync-push-ack',
+  '-db-sync-dirty',
+  '-db-sync-quarantine',
+];
+
+// Reset the DB tier's persisted sync-cursor state. MUST be called by every
+// full-state-replacement path (restore from a local/remote backup, restore from
+// a backup file, vault link/re-link/unlink) BEFORE the app reloads:
+//
+//  • The stale SNAPSHOT would diff the restored (older) rows as "changed" and
+//    push them over the vault's NEWER rows.
+//  • The stale pull HWM would skip forever every vault row whose seq is below
+//    it — rows the restored data no longer contains are never re-pulled.
+//  • The stale DIRTY set / push-ack refer to pre-restore state.
+//
+// After the reset the next cycle runs the first-sync path (HWM=0 + empty
+// snapshot): the wrapper full-seeds the dirty set and then pulls BEFORE it
+// pushes, and the engine's pull applies per-entity last-writer-wins — a vault
+// row newer than the restored copy wins AND removes that entity from the dirty
+// set (@glance-apps/sync dbEngine.js applyRemoteRow), so the full-seed MERGES;
+// it never blind-pushes restored-but-older rows over newer vault rows.
+export function resetVaultSyncCursor(storageKeyPrefix = DEFAULT_STORAGE_KEY_PREFIX) {
+  for (const suffix of SYNC_CURSOR_KEY_SUFFIXES) {
+    try { localStorage.removeItem(`${storageKeyPrefix}${suffix}`); } catch { /* ignore */ }
+  }
+}
 
 // Native keystore slot for the DB root key. On native shells the bridge exposes a
 // SINGLE legacy slot (getSyncKey/storeSyncKey) that the WebDAV file tier already
@@ -103,14 +149,9 @@ export async function restoreDbRootKey() {
 }
 
 const clone = (x) => (x == null ? x : JSON.parse(JSON.stringify(x)));
-const hashOf = (entity) => JSON.stringify(entity);
-
-// entityId → entity-hash for the whole current state. Used to diff for dirtiness.
-function snapshotShred(data) {
-  const map = {};
-  for (const row of shredState(data)) map[row.entityId] = hashOf(row.entity);
-  return map;
-}
+// entityId → entity-hash maps (shredHashes) are the diff/snapshot currency;
+// they live in commitMerge.js so the dirty diff and the commit merge are
+// guaranteed to hash identically.
 
 // ─── TEMPORARY push diagnostic (gated) ────────────────────────────────────────
 // Set localStorage 'dayglance-debug-push' = '1' to log, every cycle that pushes,
@@ -161,7 +202,7 @@ function debugDiffLeaves(a, b, path = '', out = []) {
 export function createDbEngine(callbacks = {}) {
   if (!callbacks.vaultClient && !isVaultEnabled()) return null;
   const cfg = getVaultConfig() || {};
-  const storageKeyPrefix = callbacks.storageKeyPrefix || 'dayglance-vault';
+  const storageKeyPrefix = callbacks.storageKeyPrefix || DEFAULT_STORAGE_KEY_PREFIX;
   const SNAPSHOT_KEY = `${storageKeyPrefix}-db-sync-snapshot`;
 
   // On native shells the root key is stored in the OS keystore (mirrors the file
@@ -294,6 +335,50 @@ export function createDbEngine(callbacks = {}) {
   // In-flight guard so a debounced push never overlaps a cadence-triggered cycle.
   let syncing = false;
 
+  // Re-fetch glitch-skipped rows by id and re-inject them into the mirror (see
+  // the call site in dbSyncCycle for the full rationale). Uses the vault's
+  // single-row GET — the same surface the engine's quarantine self-heal uses —
+  // and the package's decryptEntity, which reads the SAME per-account root key
+  // the engine's own pull just used (module-level key state in dbCrypto), so a
+  // row that pulled fine will heal fine. Resolution outcomes per entityId:
+  //   • row fetched + decrypted → re-injected into the mirror (recovered)
+  //   • row absent/deleted at the vault → nothing to recover; the local absence
+  //     matches the vault (convergence, not divergence) → resolved
+  //   • no row-get on this client / fetch or decrypt failed → UNRESOLVED,
+  //     returned to the caller (which withholds the snapshot and retries next
+  //     cycle).
+  const healGlitchSkips = async (skippedIds) => {
+    const unresolved = [];
+    const recovered = [];
+    const canGetRow = typeof engine.vault?.getRow === 'function';
+    for (const entityId of skippedIds) {
+      // Already back in the mirror — the pull happened to re-list the row (e.g.
+      // its seq sat above our cursor after all). Nothing to fetch.
+      if (adapterGetLocalEntity(mirror, entityId) != null) continue;
+      if (!canGetRow) { unresolved.push(entityId); continue; }
+      try {
+        const row = await engine.vault.getRow(APP_ID, entityId, cfg.accountId);
+        if (row == null || row.deleted || !row.envelope) continue; // vault agrees it's gone
+        const entity = await decryptEntity(row.envelope, entityId);
+        // Plain insert (the row is absent from the mirror by definition). Any
+        // enrichment re-push ids are ignored: the vault already holds this row,
+        // and the snapshot diff re-pushes any divergence next cycle anyway.
+        adapterApplyRemoteEntity(mirror, entity);
+        recovered.push(entityId);
+      } catch {
+        unresolved.push(entityId); // transient failure — retry next cycle
+      }
+    }
+    if (recovered.length) {
+      console.warn(
+        `[push] GUARD: recovered ${recovered.length} row(s) from the vault after a local-state vanish ` +
+        `(re-fetched by id and re-committed). Ids:`,
+        recovered.slice(0, 25), recovered.length > 25 ? `(+${recovered.length - 25} more)` : ''
+      );
+    }
+    return unresolved;
+  };
+
   // dayGLANCE wraps the engine's push/pull steps in its own cycle so it can
   // (1) seed the dirty set by diffing app state into the mirror, (2) commit the
   // merged mirror back to React/localStorage ONLY on success, and (3) run
@@ -336,12 +421,18 @@ export function createDbEngine(callbacks = {}) {
         pushCountsLine = `[push] getData counts → tasks:${cnt('tasks')} unscheduled:${cnt('unscheduledTasks')} gtdFrames:${cnt('gtdFrames')} dailyNotes:${cnt('dailyNotes')} goals:${cnt('goals')} projects:${cnt('projects')}`;
       }
       const dbgChanges = pushDbg ? [] : null; // [{ id, kind, diff:[] }]
+      // entityId → hash of the state as of cycle START. Reused three ways: the
+      // dirty diff below, the mid-cycle-edit detection in the commit merge, and
+      // (via the HWM=0 branch) the full seed.
+      const baseHashes = shredHashes(mirror);
+      // Bug-2 state: glitch-suspect vanish-deletes the guard skipped this cycle.
+      let glitchSkipped = [];
       if (engine.getHighWaterMark() === 0) {
-        for (const row of shredState(mirror)) engine.markDirty(row.entityId);
+        for (const id of Object.keys(baseHashes)) engine.markDirty(id);
         if (pushDbg) console.log('[push] initial full-seed cycle (HWM=0) — every row dirty');
       } else {
         const prev = loadSnapshot();
-        const cur = snapshotShred(mirror);
+        const cur = baseHashes;
         for (const [id, h] of Object.entries(cur)) {
           if (prev[id] === h) continue;
           engine.markDirty(id);
@@ -363,6 +454,7 @@ export function createDbEngine(callbacks = {}) {
           wantDelete.push(id);
         }
         const { propagate, skipped, reasons } = partitionSnapshotDeletes(wantDelete, cur, mirror);
+        glitchSkipped = skipped;
         for (const id of propagate) {
           engine.markDirty(id); // deletes
           if (dbgChanges) dbgChanges.push({ id, kind: 'deleted', diff: [] });
@@ -387,6 +479,20 @@ export function createDbEngine(callbacks = {}) {
       // The engine's onRowsSkipped fires from its own dbSyncCycle, which we
       // bypass — so surface undecryptable-row skips from the pull result here.
       if (pull && pull.skipped > 0) callbacks.onRowsSkipped?.(pull.skipped, pull.skippedEntityIds || []);
+      // Glitch-skip RECOVERY: a skipped (glitch-suspect) vanish-delete names a
+      // row that is missing from local state but still live in the vault, and
+      // whose seq sits BELOW the pull cursor (this device consumed it long ago)
+      // — an incremental pull will NEVER re-list it. Without recovery a
+      // PERSISTENT local shrink leaves this device permanently missing rows the
+      // rest of the fleet still has. Re-fetch each such row by id (the same
+      // row-get API the engine's quarantine self-heal uses) and re-inject it
+      // into the mirror, so the commit below restores it to live state. Runs
+      // BEFORE reconcile/prune/snapshot so the healed rows flow through the
+      // rest of the cycle like any pulled row. Ids that could NOT be resolved
+      // (no row-get on this client, network error, undecryptable) poison the
+      // snapshot save below.
+      let glitchUnresolved = [];
+      if (glitchSkipped.length) glitchUnresolved = await healGlitchSkips(glitchSkipped);
       reconcileCrossList(
         mirror,
         (id) => engine.markDirty(id),
@@ -438,8 +544,71 @@ export function createDbEngine(callbacks = {}) {
       }
       await engine.updateDeviceCursor();
 
-      callbacks.commitData?.(clone(mirror));
-      saveSnapshot(snapshotShred(mirror));
+      // ── MERGE-AWARE COMMIT ─────────────────────────────────────────────────
+      // The mirror was cloned from app state at cycle START; any user write made
+      // during the async pull/push window above exists only in LIVE state. A
+      // plain commitData(mirror) (which applyEngineData applies with replace
+      // semantics) would revert those writes — and snapshotting that same mirror
+      // made the loss permanent (never dirty, never pushed). So: capture the
+      // VAULT-CONSISTENT snapshot first (the mirror exactly as pushed/pulled),
+      // then merge mid-cycle live edits into the mirror (commitMerge.js) and
+      // commit THAT.
+      //
+      // WHY THE SNAPSHOT IS THE PRE-MERGE MIRROR — the surviving-edit trace:
+      //   cycle N   : task T@t1 everywhere. User edits T→T'@t2 during N's pull.
+      //               Commit merge: live T'@t2 vs mirror T@t1 → live wins →
+      //               commit contains T'. Snapshot saved = pushed mirror = T@t1.
+      //   cycle N+1 : diff live(T'@t2) vs snapshot(T@t1) → hash differs → T is
+      //               marked DIRTY → pushed. Snapshot now advances to T'.
+      // Snapshotting the post-merge (committed) state instead would put T' in
+      // the baseline, so cycle N+1 would see live == snapshot, never mark it
+      // dirty, and the surviving edit would sit locally forever without ever
+      // reaching the vault. The snapshot therefore always means "the state the
+      // vault knows"; any local deviation from it is exactly the dirt to push.
+      // (Same trace for a task CREATED mid-cycle: in the commit, absent from the
+      // snapshot → 'new' in cycle N+1's diff → pushed. And for a pulled remote
+      // change: in the snapshot AND in the commit → clean, no echo re-push.)
+      const vaultSnapshot = shredHashes(mirror);
+      const liveNow = clone(callbacks.getData()) || {};
+      const { survivors, honoredDeletes, liveHashes } = mergeMidCycleEdits(mirror, baseHashes, liveNow);
+      if (survivors.length || honoredDeletes.length) {
+        // An injected mid-cycle row can collide cross-list with a pulled copy of
+        // the same id under another kind — dedupe deterministically; the loser
+        // is marked dirty so its stale vault row is soft-deleted next push.
+        reconcileCrossList(mirror, (id) => engine.markDirty(id));
+        if (debugPushEnabled()) {
+          console.log('[commit] mid-cycle merge — survivors:', survivors, 'honored deletes:', honoredDeletes);
+        }
+      }
+      // Cheap safety net on top of the merge: when the pull applied nothing and
+      // the merged commit is byte-identical to current live state, commitData is
+      // a pure no-op replace — skip it entirely (no spurious re-render, and no
+      // window at all in which a replace could race a concurrent write).
+      const mergedHashes = (survivors.length || honoredDeletes.length) ? shredHashes(mirror) : vaultSnapshot;
+      const commitIsNoop = (pull?.applied ?? 0) === 0 && hashMapsEqual(mergedHashes, liveHashes);
+      if (!commitIsNoop) callbacks.commitData?.(clone(mirror));
+
+      // A cycle with UNRESOLVED glitch-skips is poisoned: saving its snapshot
+      // would drop the vanished rows from the diff baseline, silencing the guard
+      // forever (they sit below the pull HWM, so nothing would ever bring them
+      // back). Withholding the snapshot keeps them in the baseline: a TRANSIENT
+      // shrink self-heals next cycle (live regains the rows → hashes match the
+      // old snapshot → clean), and a PERSISTENT shrink re-triggers the guard +
+      // row-get heal next cycle. Withholding is safe for the push side: rows
+      // pushed this cycle were acked, so re-diffing them next cycle just re-sends
+      // idempotent upserts; propagated DELETES re-propagate only while their
+      // tombstone / cross-list fingerprint still holds (they can never enter the
+      // skipped/glitch set, so no guard loop) and a repeated soft-delete is
+      // idempotent at the vault.
+      if (glitchUnresolved.length === 0) {
+        saveSnapshot(vaultSnapshot);
+      } else {
+        console.warn(
+          `[push] GUARD: ${glitchUnresolved.length} glitch-suspect row(s) could not be re-fetched from the vault — ` +
+          `snapshot withheld this cycle so they stay in the diff baseline and recovery retries next cycle. Ids:`,
+          glitchUnresolved.slice(0, 25), glitchUnresolved.length > 25 ? `(+${glitchUnresolved.length - 25} more)` : ''
+        );
+      }
       callbacks.onStatusChange?.('success');
       return { applied: pull?.applied ?? 0, skipped: pull?.skipped ?? 0, skippedEntityIds: pull?.skippedEntityIds ?? [] };
     } catch (err) {

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -267,20 +267,27 @@ export function createDbEngine(callbacks = {}) {
         : undefined);
 
   // Diagnostic: wrap the transport so every vault request logs its method, full
-  // URL (which carries accountId + entityId) and HTTP status on failure. Turns a
-  // bare "get row failed: 400" into the exact request that produced it, so we can
-  // see at a glance whether accountId is populated and which entityId/route the
+  // URL path (which carries the entityId and route; the accountId query string is
+  // redacted below) and HTTP status on failure. Turns a bare "get row failed: 400"
+  // into the request that produced it, so we can see which entityId/route the
   // server rejected — instead of guessing across repos. Quiet on success.
   const rawFetch = fetchImpl || ((...a) => globalThis.fetch(...a));
+  // The query string is redacted from failure logs: it carries the accountId,
+  // which shouldn't be printed on every transient failure (console captures,
+  // attached debuggers). Origin + path keep the diagnostic value — the route and
+  // entityId — described above.
+  const redactedUrl = (url) => {
+    try { const u = new URL(String(url)); return u.origin + u.pathname; } catch { return '<vault url>'; }
+  };
   const loggingFetch = async (url, opts = {}) => {
     let res;
     try {
       res = await rawFetch(url, opts);
     } catch (e) {
-      console.warn('[dayglance vault]', opts.method || 'GET', String(url), '→ network error:', e?.message || e);
+      console.warn('[dayglance vault]', opts.method || 'GET', redactedUrl(url), '→ network error:', e?.message || e);
       throw e;
     }
-    if (!res || res.ok === false) console.warn('[dayglance vault]', opts.method || 'GET', String(url), '→', res?.status);
+    if (!res || res.ok === false) console.warn('[dayglance vault]', opts.method || 'GET', redactedUrl(url), '→', res?.status);
     return res;
   };
 

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, beforeAll, afterEach, afterAll, vi } from 'vitest';
 import { setSyncPassphrase, createDbSyncEngine } from '@glance-apps/sync';
-import { createDbEngine } from './dbEngine.js';
+import { createDbEngine, resetVaultSyncCursor } from './dbEngine.js';
 import { getVaultConfig, setVaultConfig, isVaultEnabled } from './vaultConfig.js';
 import { getDeviceId } from './deviceId.js';
 import { registerDbEngine, markDirty, schedulePush } from './dirtyTracker.js';
@@ -23,12 +23,17 @@ function memLocalStorage() {
 }
 
 // In-memory GLANCEvault: one row per entityId (upsert, last-write-wins), global
-// seq. Mirrors the real vaultClient surface the engine calls.
-function createMemoryVault() {
+// seq. Mirrors the real vaultClient surface the engine calls. Pass
+// { rowGet: true } to also expose the single-row GET the real client has
+// (vaultClient.getRow — null on 404/deleted): it enables the engine's key
+// verifier AND the wrapper's glitch-skip row re-fetch heal. Off by default so
+// the long-standing tests keep their hardcoded seq expectations (the verifier
+// writes a keycheck row at seq 1).
+function createMemoryVault({ rowGet = false } = {}) {
   const salts = new Map();
   const log = new Map();
   let seq = 0;
-  return {
+  const vault = {
     async getSalt(accountId) { return salts.get(accountId) || null; },
     async putSalt(accountId, fresh) { if (!salts.has(accountId)) salts.set(accountId, fresh); return salts.get(accountId); },
     async batch(app, { rows }) {
@@ -42,6 +47,13 @@ function createMemoryVault() {
     },
     async device() { return { updated: true }; },
   };
+  if (rowGet) {
+    vault.getRow = async (app, entityId) => {
+      const r = log.get(entityId);
+      return r && !r.deleted ? { entityId: r.entityId, seq: r.seq, envelope: r.envelope, deleted: false } : null;
+    };
+  }
+  return vault;
 }
 
 // Hermetic teardown: never let fake timers or the localStorage shim leak into
@@ -313,8 +325,10 @@ describe('Part B — end-to-end two-device sync via the REAL engine', () => {
     await runRounds(A, B);
     // The guard skips the un-tombstoned vanish → the deletion does NOT propagate:
     // device B (which never glitched) still holds the live task. No fleet-wide loss.
-    // (The guard stops the SPREAD of a local glitch; it does not self-restore the
-    // glitched device — A stays locally short until the row is next re-pushed to it.)
+    // (This vault exposes no getRow, so the row re-fetch heal is unavailable and A
+    // stays locally short — the poisoned cycle withholds its snapshot so the row
+    // stays in the diff baseline. The heal + snapshot-withholding mechanics are
+    // covered in the "glitch shrink" describe below.)
     expect(B.data.tasks.map((t) => t.id)).toContain(700);
 
     // REAL DELETE: A removes 701 AND records its tombstone (what every delete path
@@ -530,5 +544,293 @@ describe('Electron transport — proxyFetch is called positionally (real request
     await B.engine.dbSyncCycle();
 
     expect(B.data.tasks.map((t) => t.id)).toContain(42);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WAVE A (pre-4.0 review) — the three data-loss fixes, end-to-end through the
+// REAL engine:
+//   1. Merge-aware commit: local writes made DURING a cycle's network window
+//      survive the commit and are pushed on the next cycle (commitMerge.js).
+//   2. Glitch-shrink poisoned cycle: skipped (un-tombstoned) vanish-deletes
+//      withhold the snapshot and are healed by a vault row re-fetch.
+//   3. Restore/re-link: resetVaultSyncCursor forces a full LWW pull-merge; a
+//      stale restore never pushes over newer vault rows and previously-missed
+//      rows reappear.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Wave A — merge-aware commit: mid-cycle writes survive and get pushed', () => {
+  beforeEach(() => {
+    global.localStorage = memLocalStorage();
+    setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 'tok', accountId: 'acct1' });
+    setSyncPassphrase('correct horse battery staple');
+  });
+
+  // Interleave hook: run `fn` once, from inside the cycle's PULL (vault.list),
+  // i.e. after the mirror was cloned but before commit — exactly the network
+  // window in which a user write used to be clobbered.
+  function onNextPull(vault, fn) {
+    const origList = vault.list.bind(vault);
+    let fired = false;
+    vault.list = async (...args) => {
+      if (!fired) { fired = true; fn(); }
+      return origList(...args);
+    };
+    return () => { vault.list = origList; };
+  }
+
+  it('a task CREATED and another EDITED during the network window survive the commit AND push next cycle', async () => {
+    const vault = createMemoryVault();
+    const A = makeDevice('A', vault, { ...EMPTY, tasks: [task(1, '2026-06-18T10:00:00.000Z')] });
+    const B = makeDevice('B', vault, { ...EMPTY });
+    await runRounds(A, B);
+
+    // B pushes a new row so A's next pull actually applies remote changes —
+    // proving the merge path (not just the applied===0 skip-commit shortcut).
+    B.data.tasks.push(task(3, '2026-06-18T11:00:00.000Z'));
+    await B.engine.dbSyncCycle();
+
+    const restore = onNextPull(vault, () => {
+      // Mid-cycle user writes on A: edit task 1, create task 2.
+      const t1 = A.data.tasks.find((t) => t.id === 1);
+      t1.title = 'edited mid-cycle';
+      t1.lastModified = '2026-06-18T12:00:00.000Z';
+      A.data.tasks.push(task(2, '2026-06-18T12:00:00.000Z'));
+    });
+    await A.engine.dbSyncCycle();
+    restore();
+
+    // (a) The pull LANDED (task 3 from B) and (b) BOTH mid-cycle writes survived.
+    expect(A.data.tasks.map((t) => t.id).sort()).toEqual([1, 2, 3]);
+    expect(A.data.tasks.find((t) => t.id === 1).title).toBe('edited mid-cycle');
+
+    // The snapshot contract: the saved snapshot is the VAULT-consistent (pre-merge)
+    // state, so the survivors are absent/stale in it — that's what makes them
+    // dirty next cycle.
+    const snap = JSON.parse(global.localStorage.getItem('dev-A-db-sync-snapshot'));
+    expect(snap['tasks:2']).toBeUndefined();
+    expect(snap['tasks:1']).not.toContain('edited mid-cycle');
+
+    // (c) Next cycle PUSHES them: B converges on both writes.
+    await A.engine.dbSyncCycle();
+    await B.engine.dbSyncCycle();
+    expect(B.data.tasks.map((t) => t.id).sort()).toEqual([1, 2, 3]);
+    expect(B.data.tasks.find((t) => t.id === 1).title).toBe('edited mid-cycle');
+
+    // ...and the snapshot advanced to include them (no perpetual re-push).
+    const snap2 = JSON.parse(global.localStorage.getItem('dev-A-db-sync-snapshot'));
+    expect(snap2['tasks:2']).toBeDefined();
+    expect(snap2['tasks:1']).toContain('edited mid-cycle');
+  });
+
+  it('a mid-cycle edit racing a pull of the SAME entity resolves by LWW (both directions)', async () => {
+    const vault = createMemoryVault();
+    const A = makeDevice('A', vault, { ...EMPTY, tasks: [task(5, '2026-06-18T10:00:00.000Z'), task(6, '2026-06-18T10:00:00.000Z')] });
+    const B = makeDevice('B', vault, { ...EMPTY });
+    await runRounds(A, B);
+
+    // Direction 1: B's pulled write is NEWER than A's mid-cycle edit → B wins.
+    const t5 = B.data.tasks.find((t) => t.id === 5);
+    t5.title = 'B newer';
+    t5.lastModified = '2026-06-18T13:00:00.000Z';
+    await B.engine.dbSyncCycle();
+    let restore = onNextPull(vault, () => {
+      const mine = A.data.tasks.find((t) => t.id === 5);
+      mine.title = 'A older mid-cycle';
+      mine.lastModified = '2026-06-18T12:00:00.000Z';
+    });
+    await A.engine.dbSyncCycle();
+    restore();
+    expect(A.data.tasks.find((t) => t.id === 5).title).toBe('B newer');
+
+    // Direction 2: A's mid-cycle edit is NEWER than B's pulled write → A wins
+    // and A's version reaches B.
+    const t6 = B.data.tasks.find((t) => t.id === 6);
+    t6.title = 'B older';
+    t6.lastModified = '2026-06-18T12:00:00.000Z';
+    await B.engine.dbSyncCycle();
+    restore = onNextPull(vault, () => {
+      const mine = A.data.tasks.find((t) => t.id === 6);
+      mine.title = 'A newer mid-cycle';
+      mine.lastModified = '2026-06-18T13:00:00.000Z';
+    });
+    await A.engine.dbSyncCycle();
+    restore();
+    expect(A.data.tasks.find((t) => t.id === 6).title).toBe('A newer mid-cycle');
+    await A.engine.dbSyncCycle(); // pushes the surviving edit
+    await B.engine.dbSyncCycle();
+    expect(B.data.tasks.find((t) => t.id === 6).title).toBe('A newer mid-cycle');
+  });
+});
+
+describe('Wave A — glitch shrink: poisoned cycle withholds the snapshot; row re-fetch heals', () => {
+  beforeEach(() => {
+    global.localStorage = memLocalStorage();
+    setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 'tok', accountId: 'acct1' });
+    setSyncPassphrase('correct horse battery staple');
+  });
+
+  const snapOf = (name) => JSON.parse(global.localStorage.getItem(`dev-${name}-db-sync-snapshot`) || 'null');
+  const deletedIds = (spy) => spy.mock.calls.map((c) => c[1]);
+
+  it('HEAL: a persistent un-tombstoned shrink is recovered by re-fetching the vault row (no delete, no divergence)', async () => {
+    const vault = createMemoryVault({ rowGet: true }); // real-client surface: single-row GET available
+    const A = makeDevice('A', vault, {
+      ...EMPTY,
+      tasks: [task(800, '2026-06-18T10:00:00.000Z'), task(801, '2026-06-18T10:00:00.000Z')],
+    });
+    const B = makeDevice('B', vault, { ...EMPTY });
+    await runRounds(A, B);
+
+    const delSpy = vi.spyOn(vault, 'deleteRow');
+    // PERSISTENT glitch: 800 vanishes from A's live state with no tombstone and
+    // never comes back on its own. Its vault seq sits below A's pull cursor, so
+    // only the row re-fetch can recover it.
+    A.data.tasks = A.data.tasks.filter((t) => t.id !== 800);
+    await A.engine.dbSyncCycle();
+
+    // Recovered: the vault row was re-fetched, re-injected, and committed back.
+    expect(A.data.tasks.map((t) => t.id)).toContain(800);
+    // No delete was ever pushed for the glitched row.
+    expect(deletedIds(delSpy)).not.toContain('tasks:800');
+    // The healed cycle is clean → its snapshot WAS saved and still holds the row.
+    expect(snapOf('A')['tasks:800']).toBeDefined();
+    // Fleet unaffected, and stays converged on subsequent cycles.
+    await runRounds(A, B, 2);
+    expect(B.data.tasks.map((t) => t.id).sort()).toEqual([800, 801]);
+    expect(A.data.tasks.map((t) => t.id).sort()).toEqual([800, 801]);
+  });
+
+  it('ABORT-ONLY (no row-get): the poisoned cycle withholds the snapshot; a transient shrink self-heals next cycle', async () => {
+    const vault = createMemoryVault(); // no getRow → heal unavailable
+    const A = makeDevice('A', vault, {
+      ...EMPTY,
+      tasks: [task(810, '2026-06-18T10:00:00.000Z'), task(811, '2026-06-18T10:00:00.000Z')],
+    });
+    const B = makeDevice('B', vault, { ...EMPTY });
+    await runRounds(A, B);
+
+    const delSpy = vi.spyOn(vault, 'deleteRow');
+    const snapBefore = snapOf('A');
+    expect(snapBefore['tasks:810']).toBeDefined();
+
+    // A peer pushes a new row: the poisoned cycle must still LAND pulled
+    // changes (the pull advances the HWM past them, so aborting the commit
+    // outright would lose them forever — only the SNAPSHOT is withheld).
+    B.data.tasks.push(task(812, '2026-06-18T11:00:00.000Z'));
+    await B.engine.dbSyncCycle();
+
+    // TRANSIENT glitch: 810 vanishes for one cycle.
+    const kept = A.data.tasks.find((t) => t.id === 810);
+    A.data.tasks = A.data.tasks.filter((t) => t.id !== 810);
+    await A.engine.dbSyncCycle();
+
+    // Poisoned: no delete pushed, snapshot NOT overwritten — the row stays in
+    // the diff baseline (had the shrunk snapshot been saved, the row would have
+    // silently left the baseline forever). The pulled row still landed.
+    expect(deletedIds(delSpy)).not.toContain('tasks:810');
+    expect(snapOf('A')['tasks:810']).toBe(snapBefore['tasks:810']);
+    expect(A.data.tasks.map((t) => t.id)).toContain(812);
+
+    // The glitch heals (live state regains the identical row) → next cycle is
+    // clean against the PRESERVED snapshot: no dirt, no delete, snapshot saved.
+    A.data.tasks.push(kept);
+    await A.engine.dbSyncCycle();
+    expect(deletedIds(delSpy)).not.toContain('tasks:810');
+    await runRounds(A, B, 2);
+    expect(A.data.tasks.map((t) => t.id).sort()).toEqual([810, 811, 812]);
+    expect(B.data.tasks.map((t) => t.id).sort()).toEqual([810, 811, 812]);
+  });
+
+  it('ABORT-ONLY persistent shrink never loop-propagates deletes; a REAL tombstoned delete still propagates (idempotently)', async () => {
+    const vault = createMemoryVault(); // no getRow
+    const A = makeDevice('A', vault, {
+      ...EMPTY,
+      tasks: [task(820, '2026-06-18T10:00:00.000Z'), task(821, '2026-06-18T10:00:00.000Z')],
+    });
+    const B = makeDevice('B', vault, { ...EMPTY });
+    await runRounds(A, B);
+
+    const delSpy = vi.spyOn(vault, 'deleteRow');
+    // 820 glitch-vanishes PERSISTENTLY while 821 is GENUINELY deleted (tombstoned).
+    A.data.tasks = A.data.tasks.filter((t) => t.id !== 820 && t.id !== 821);
+    A.data.deletedTaskIds = { ...(A.data.deletedTaskIds || {}), 821: '2026-07-08T00:00:00.000Z' };
+
+    // Several poisoned cycles in a row (the snapshot is withheld each time, so
+    // the tombstoned delete re-propagates — that re-propagation must stay an
+    // idempotent soft-delete and must never drag the glitched row with it).
+    for (let i = 0; i < 3; i++) await A.engine.dbSyncCycle();
+    const ids = deletedIds(delSpy);
+    expect(ids).toContain('tasks:821');       // real delete propagated
+    expect(ids).not.toContain('tasks:820');   // glitch NEVER propagated, no loop
+
+    await runRounds(A, B, 2);
+    expect(B.data.tasks.map((t) => t.id)).toContain(820);     // fleet kept the glitched row
+    expect(B.data.tasks.map((t) => t.id)).not.toContain(821); // real delete stuck
+  });
+});
+
+describe('Wave A — restore/re-link: resetVaultSyncCursor forces a full LWW pull-merge', () => {
+  beforeEach(() => {
+    global.localStorage = memLocalStorage();
+    setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 'tok', accountId: 'acct1' });
+    setSyncPassphrase('correct horse battery staple');
+  });
+
+  it('clears exactly the cursor/baseline keys (default and custom prefix), keeping config + last-synced', () => {
+    const cursorKeys = ['snapshot', 'hwm', 'push-ack', 'dirty', 'quarantine'];
+    for (const k of cursorKeys) global.localStorage.setItem(`dayglance-vault-db-sync-${k}`, 'stale');
+    global.localStorage.setItem('dayglance-vault-db-sync-config', 'keep');
+    global.localStorage.setItem('dayglance-vault-db-sync-last-synced', 'keep');
+    resetVaultSyncCursor(); // default prefix = the app's engine prefix
+    for (const k of cursorKeys) expect(global.localStorage.getItem(`dayglance-vault-db-sync-${k}`)).toBeNull();
+    expect(global.localStorage.getItem('dayglance-vault-db-sync-config')).toBe('keep');
+    expect(global.localStorage.getItem('dayglance-vault-db-sync-last-synced')).toBe('keep');
+
+    global.localStorage.setItem('dev-X-db-sync-hwm', '42');
+    resetVaultSyncCursor('dev-X');
+    expect(global.localStorage.getItem('dev-X-db-sync-hwm')).toBeNull();
+  });
+
+  it('after a stale restore, the next cycle FULL-pulls: newer vault rows win, missed rows reappear, and the stale copy is never pushed', async () => {
+    const vault = createMemoryVault();
+    const A = makeDevice('A', vault, { ...EMPTY, tasks: [task(1, '2026-06-18T10:00:00.000Z')] });
+    const B = makeDevice('B', vault, { ...EMPTY });
+    await runRounds(A, B);
+
+    // The fleet advances past the (future) backup: B edits task 1 and creates
+    // task 2; A pulls both, so A's HWM/snapshot now describe the ADVANCED state.
+    B.data.tasks = [
+      task(1, '2026-06-20T10:00:00.000Z', { title: 'newer from B' }),
+      task(2, '2026-06-20T11:00:00.000Z'),
+    ];
+    await runRounds(A, B);
+    expect(A.data.tasks.find((t) => t.id === 1).title).toBe('newer from B');
+    expect(A.data.tasks.map((t) => t.id)).toContain(2);
+
+    // A restores an OLD backup: a stale copy of task 1, task 2 missing — a full
+    // state replacement. Without a cursor reset, the stale snapshot would diff
+    // task 1 as dirty (stale push over B's newer row) and task 2 would sit below
+    // the pull HWM forever. The restore paths call resetVaultSyncCursor:
+    A.data.tasks = [task(1, '2026-06-18T10:00:00.000Z', { title: 'stale restored copy' })];
+    resetVaultSyncCursor('dev-A');
+
+    const batchSpy = vi.spyOn(vault, 'batch');
+    await A.engine.dbSyncCycle();
+    await A.engine.dbSyncCycle();
+
+    // Full pull re-applied everything: B's newer row won over the restored copy
+    // (LWW) and the previously-missed row reappeared.
+    expect(A.data.tasks.find((t) => t.id === 1).title).toBe('newer from B');
+    expect(A.data.tasks.map((t) => t.id)).toContain(2);
+
+    // The stale copy was NEVER pushed: the full-seed marks it dirty, but the
+    // pull (which runs first) sees the vault's newer row win and un-dirties it.
+    const pushedIds = batchSpy.mock.calls.flatMap(([, { rows }]) => rows.map((r) => r.entityId));
+    expect(pushedIds).not.toContain('tasks:1');
+
+    // And the vault/fleet still holds the newer version.
+    await B.engine.dbSyncCycle();
+    expect(B.data.tasks.find((t) => t.id === 1).title).toBe('newer from B');
+    expect(B.data.tasks.map((t) => t.id)).toContain(2);
   });
 });

--- a/src/sync/snapshotDeleteGuard.js
+++ b/src/sync/snapshotDeleteGuard.js
@@ -19,10 +19,15 @@
 //     DIFFERENT kind, so the id still appears somewhere in getData().
 // An entity that vanishes from memory with NEITHER a tombstone NOR a surviving copy
 // under another kind has no legitimate delete path — it is a suspected glitch. We
-// skip its delete: the row stays in the vault and is simply re-pulled next cycle
-// (fail-safe toward KEEPING data). A skipped glitch-delete costs at most a stale row
-// that resurrects; propagating it costs real, irreversible data loss — so we bias
-// hard toward keeping.
+// skip its delete: the row stays in the vault (fail-safe toward KEEPING data).
+// NOTE the row is NOT "simply re-pulled next cycle" — its seq sits below the pull
+// cursor, so an incremental pull never re-lists it. Recovery is the caller's job:
+// dbEngine.js re-fetches each skipped row by id (vault row-get) and re-injects it
+// into the commit, and withholds the cycle's snapshot while any skipped row remains
+// unrecovered so the row stays in the diff baseline (a transient shrink then
+// self-heals against the OLD snapshot). A skipped glitch-delete costs at most a
+// stale row that resurrects; propagating it costs real, irreversible data loss —
+// so we bias hard toward keeping.
 //
 // Real deletions (tombstoned) and real moves (id survives elsewhere) are unaffected
 // and still propagate exactly as before.


### PR DESCRIPTION
Wave A of the v4.0.0 GLANCEvault review: three single-device data-loss bugs sharing one root cause — the sync cycle's cloned mirror being committed back over live state.

## 1. Mid-cycle user writes silently and permanently lost (the big one)
A task created or edited during a sync cycle's network window (0.5–3s, triggered by any SSE nudge from a peer) was reverted by the wholesale `commitData(mirror)` replace, then made permanent by snapshotting that same mirror — never dirty, never pushed, gone.

**Fix:** merge-aware commit (`src/sync/commitMerge.js`). At commit time live state is re-read and folded into the mirror: untouched entities keep the pull result; same-entity conflicts resolve by LWW on `lastModified` (ties prefer the user's live edit, mirroring the engine's own pull rule); mid-cycle creations always survive; a remote delete racing a mid-cycle edit keeps the edit (fail-safe toward data; a real tombstone still wins long-term); singletons re-merge through the pull's own per-bundle strategy; mid-cycle local deletes are honored only with a tombstone/cross-list fingerprint (a bare vanish is glitch-suspect and kept).

**The snapshot contract (deliberate, load-bearing):** the post-cycle snapshot is the PRE-merge, vault-consistent mirror — so a surviving mid-cycle edit differs from the snapshot next cycle, gets marked dirty, and is pushed. Snapshotting the merged state instead would strand survivors locally forever. Full trace in the code at the call site.

Plus a safety net: when the pull applied nothing and the merged commit hashes identical to live state, `commitData` is skipped entirely (no replace window at all).

## 2. Glitch-delete guard: protect the device too, not just the fleet
When `partitionSnapshotDeletes` skips glitch-suspect vanish-deletes, the cycle previously still committed and snapshotted the shrunk mirror; the surviving vault rows sat below the pull cursor and were never re-pulled — permanent silent divergence.

**Fix:** heal-first — each skipped id is re-fetched by id via the vault row-get (the same surface the quarantine self-heal uses), decrypted, and re-injected into the commit. Rows the vault agrees are gone count as resolved. If any id can't be resolved (no row-get, network, decrypt failure), the **snapshot is withheld** for the cycle so the rows stay in the diff baseline: transient shrinks self-heal next cycle, persistent shrinks retry the heal. The (merged) commit still runs on poisoned cycles — the pull cursor has already advanced, so aborting would lose pulled remote changes forever. Push-side traced: re-diffed upserts re-send idempotently; re-propagated deletes are tombstoned by construction and can't re-enter the guard (spy-asserted over 3 poisoned cycles).

## 3. Restore-from-backup / vault re-link now resets the sync cursors
Restoring a backup (all three paths) or changing the vault link kept the old snapshot, pull HWM, push-ack, and dirty set — pushing stale backup rows over the vault's newer copies and permanently skipping everything below the stale cursor.

**Fix:** `resetVaultSyncCursor()` clears snapshot/HWM/push-ack/dirty/quarantine before reload on all three restore paths and on vault link change. Verified the post-reset first cycle **merges** (full pull runs before the full-seed push, and the engine's LWW pull removes newer-on-vault entities from the dirty set) — restored-but-older rows are never blind-pushed; test asserts via a `batch` spy.

## Verification
- 24 new tests: 16 unit (`commitMerge.test.js` — LWW both directions, ties, creations, remote-delete-vs-edit, tombstoned mid-cycle delete, cross-list move, bare vanish, union + device-local bundles, dailyNotes) and 7 end-to-end wiring tests (mid-cycle create+edit survive AND push next cycle, same-entity LWW, glitch heal via row re-fetch, snapshot withholding + transient self-heal, persistent-shrink no-delete-loop, cursor-reset key hygiene, full restore scenario)
- Full suite: **699/699 pass** · lint clean
- `@glance-apps/sync` package untouched (its transport-level conflict-semantics divergence is tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_