### PR TITLE
Vault transport hardening: SSE stall/OOM fixes, terminal auth errors, https policy, safe migration retry

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/sse/SseFraming.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/sse/SseFraming.kt
@@ -14,7 +14,14 @@ package com.dayglance.app.sse
  * Stateful per instance (holds the partial-block remainder between reads) and pure
  * otherwise, so it is unit-testable with no network.
  */
-class SseFraming {
+class SseFraming(
+    // Cap on the retained (un-delimited) buffer. A server that streams bytes but
+    // never the "\n\n" block delimiter would otherwise grow this without bound
+    // (memory exhaustion). Real vault events are tiny nudges, so 1 MB is far above
+    // anything legitimate; a breach is treated as a stream failure by the caller.
+    // Mirrors the iOS VaultSseBridge cap.
+    private val maxBufferChars: Int = 1_048_576,
+) {
 
     private val buffer = StringBuilder()
 
@@ -36,6 +43,13 @@ class SseFraming {
             if (hasDataLine(block)) blocks.add(block)
             idx = buffer.indexOf("\n\n")
         }
+        // After draining every complete block, whatever remains is a single partial
+        // block still awaiting its delimiter. If that alone exceeds the cap the peer
+        // is misbehaving (or hostile) — bail so the caller can drop and reconnect
+        // rather than buffer unboundedly.
+        if (buffer.length > maxBufferChars) {
+            throw SseFramingOverflowException(buffer.length, maxBufferChars)
+        }
         return blocks
     }
 
@@ -51,3 +65,12 @@ class SseFraming {
     private fun hasDataLine(block: String): Boolean =
         block.split('\n').any { it.startsWith("data:") }
 }
+
+/**
+ * Thrown by [SseFraming.append] when the retained partial-block buffer exceeds its
+ * cap. The reader treats it like any other read failure (drop the connection and
+ * reconnect with backoff), so a server that never delimits frames can't exhaust
+ * memory.
+ */
+class SseFramingOverflowException(size: Int, cap: Int) :
+    RuntimeException("SSE frame buffer exceeded cap: $size > $cap chars")

--- a/dayglance-android/app/src/main/java/com/dayglance/app/sse/VaultSseClient.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/sse/VaultSseClient.kt
@@ -122,6 +122,15 @@ class VaultSseClient(
             val openedAt = System.currentTimeMillis()
             try {
                 connectAndRead(url, bearer, account)
+            } catch (e: SseTerminalException) {
+                // TERMINAL (auth failure / insecure URL): retrying can't help, so stop
+                // the reader entirely — no reconnect. Push a coded event so the renderer
+                // surfaces it exactly once instead of every 30s. A later enable() (user
+                // fixed the token/URL) launches a fresh reader normally.
+                if (coroutineContext[Job]?.isActive != true) return
+                Log.w(TAG, "SSE terminal (${e.code}): ${e.message}")
+                push(JSONObject().put("type", "error").put("code", e.code).put("message", e.message ?: e.code))
+                return
             } catch (e: Exception) {
                 if (coroutineContext[Job]?.isActive != true) return // cancelled → done
                 Log.w(TAG, "SSE read error: ${e.message}")
@@ -139,6 +148,14 @@ class VaultSseClient(
 
     private suspend fun connectAndRead(url: String, bearer: String, account: String) {
         val target = URL("$url/events?accountId=" + URLEncoder.encode(account, "UTF-8"))
+        // Belt-and-braces (the settings form is the primary gate): never send the
+        // Bearer token over cleartext http on the public internet. https is always
+        // fine; http is allowed only for loopback/LAN hosts. A refusal is TERMINAL —
+        // reconnecting can't fix a bad scheme. (Android's manifest also blocks
+        // cleartext to non-local hosts; this fails EARLY and with a clear reason.)
+        if (!isSecureOrLanUrl(target)) {
+            throw SseTerminalException("insecure", "vault SSE refused: insecure http URL")
+        }
         val conn = (target.openConnection() as HttpURLConnection).apply {
             requestMethod = "GET"
             setRequestProperty("Authorization", "Bearer $bearer")
@@ -153,6 +170,13 @@ class VaultSseClient(
         activeConnection = conn
         try {
             val code = conn.responseCode
+            // 401/403 are auth failures — a revoked/invalid device token. Retrying just
+            // reconnects forever at the 30s cap and re-hits the same 401, so this is
+            // TERMINAL: stop the reader and push a distinct coded event the renderer
+            // surfaces once. A fresh enable() (user fixed the token) reconnects normally.
+            if (code == 401 || code == 403) {
+                throw SseTerminalException("auth", "vault SSE auth failed: $code")
+            }
             if (code !in 200..299) throw RuntimeException("vault SSE connect failed: $code")
             push(JSONObject().put("type", "open"))
 
@@ -177,7 +201,45 @@ class VaultSseClient(
         frameSink(msg.toString())
     }
 
+    // ── URL transport-security allowlist (mirrors src/sync/vaultUrlPolicy.js) ──────
+
+    /** https is always allowed; http only for loopback/LAN hosts; anything else no. */
+    private fun isSecureOrLanUrl(url: URL): Boolean {
+        val scheme = (url.protocol ?: "").lowercase()
+        if (scheme == "https") return true
+        if (scheme != "http") return false
+        return isLocalOrLanHost(url.host ?: "")
+    }
+
+    /** True for loopback / private-LAN / *.local hosts, where cleartext http is ok. */
+    private fun isLocalOrLanHost(rawHost: String): Boolean {
+        var host = rawHost.trim().lowercase()
+        if (host.startsWith("[") && host.endsWith("]")) host = host.substring(1, host.length - 1)
+        if (host.isEmpty()) return false
+        if (host == "localhost" || host.endsWith(".localhost")) return true
+        if (host == "::1") return true
+        if (host.endsWith(".local")) return true
+        val m = Regex("""^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$""").find(host) ?: return false
+        val octets = m.groupValues.drop(1).map { it.toInt() }
+        if (octets.any { it > 255 }) return false
+        val (a, b) = octets
+        return when {
+            a == 127 -> true               // 127.0.0.0/8 loopback
+            a == 10 -> true                // 10.0.0.0/8
+            a == 192 && b == 168 -> true   // 192.168.0.0/16
+            a == 172 && b in 16..31 -> true // 172.16.0.0/12
+            else -> false
+        }
+    }
+
     companion object {
         private const val TAG = "VaultSseClient"
     }
 }
+
+/**
+ * A TERMINAL SSE error: the reader must stop and NOT reconnect (retrying can't help).
+ * [code] distinguishes the cause for the renderer ('auth' = revoked/invalid token;
+ * 'insecure' = refused cleartext URL). Mirrors iOS's SseTerminalError.
+ */
+class SseTerminalException(val code: String, message: String) : Exception(message)

--- a/dayglance-android/app/src/test/java/com/dayglance/app/sse/SseFramingTest.kt
+++ b/dayglance-android/app/src/test/java/com/dayglance/app/sse/SseFramingTest.kt
@@ -56,6 +56,23 @@ class SseFramingTest {
         assertEquals(listOf("data: {\"seq\":2,\"kind\":\"sync\"}"), blocks)
     }
 
+    @Test(expected = SseFramingOverflowException::class)
+    fun `throws when a single undelimited frame exceeds the cap`() {
+        // A server that streams bytes but never the "\n\n" delimiter must not grow the
+        // buffer without bound — append throws once the retained partial exceeds the cap.
+        val f = SseFraming(maxBufferChars = 1024)
+        f.append("data: " + "x".repeat(2000)) // no blank-line boundary, over cap
+    }
+
+    @Test
+    fun `does not throw while the buffer stays under the cap and still drains`() {
+        val f = SseFraming(maxBufferChars = 1024)
+        // Under-cap partial is retained (no throw); a later delimiter completes it.
+        assertEquals(emptyList<String>(), f.append("data: {\"seq\":1,"))
+        val blocks = f.append("\"kind\":\"sync\"}\n\n")
+        assertEquals(listOf("data: {\"seq\":1,\"kind\":\"sync\"}"), blocks)
+    }
+
     @Test
     fun `handles several complete blocks in one chunk`() {
         val f = SseFraming()

--- a/dayglance-ios/DayGlance/Bridges/VaultSseBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/VaultSseBridge.swift
@@ -45,6 +45,11 @@ final class VaultSseBridge {
 
     // ── State (guarded by `lock`, mirroring Android's @Synchronized) ─────────────
     private let lock = NSLock()
+    // Framing-buffer cap (both the raw byte buffer and the decoded remainder). Real
+    // vault events are tiny nudges; anything approaching 1 MB without a frame delimiter
+    // is a misbehaving/hostile server, so we drop the connection rather than grow
+    // unboundedly. Mirrors Android's SseFraming cap.
+    private static let maxBufferBytes = 1_048_576
     private var desired = false
     // Foreground defaults true: the WebView only runs (and thus only calls
     // startVaultSse) when the scene is active, and scenePhase.onChange won't fire
@@ -139,6 +144,14 @@ final class VaultSseBridge {
                 try await connectAndRead(url: url, bearer: bearer, account: account, generation: gen)
             } catch is CancellationError {
                 return
+            } catch let term as SseTerminalError {
+                // TERMINAL (auth failure / insecure URL): stop the reader entirely, no
+                // reconnect. Push a coded event so the renderer surfaces it exactly once
+                // instead of every 30s. A later start() (user fixed the token/URL) spins
+                // up a fresh reader normally.
+                if Task.isCancelled || currentGeneration() != gen { return }
+                push(["type": "error", "code": term.code, "message": term.message])
+                return
             } catch {
                 if Task.isCancelled || currentGeneration() != gen { return }
                 push(["type": "error", "message": error.localizedDescription])
@@ -158,6 +171,14 @@ final class VaultSseBridge {
         comps.queryItems = [URLQueryItem(name: "accountId", value: account)]
         guard let target = comps.url else { throw URLError(.badURL) }
 
+        // Belt-and-braces (the settings form is the primary gate): never send the
+        // Bearer token over cleartext http on the public internet. https is always
+        // fine; http is allowed only for loopback/LAN hosts. A refusal is TERMINAL —
+        // reconnecting can't fix a bad scheme — so it takes the no-retry path below.
+        guard Self.isSecureOrLanUrl(target) else {
+            throw SseTerminalError(code: "insecure", message: "vault SSE refused: insecure http URL")
+        }
+
         var req = URLRequest(url: target)
         req.httpMethod = "GET"
         req.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
@@ -166,6 +187,14 @@ final class VaultSseBridge {
 
         let (bytes, response) = try await session.bytes(for: req)
         let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        // 401/403 are auth failures — a revoked/invalid device token. Retrying can't
+        // fix them (it would just reconnect forever at the 30s cap and re-hit the same
+        // 401), so this is TERMINAL: stop the reader, push a distinct coded event so
+        // the renderer surfaces it once. A fresh start() (after the user fixes the
+        // token) begins a new reader normally.
+        if status == 401 || status == 403 {
+            throw SseTerminalError(code: "auth", message: "vault SSE auth failed: \(status)")
+        }
         guard (200...299).contains(status) else {
             throw NSError(domain: "VaultSse", code: status,
                           userInfo: [NSLocalizedDescriptionKey: "vault SSE connect failed: \(status)"])
@@ -186,8 +215,21 @@ final class VaultSseBridge {
         for try await byte in bytes {
             if Task.isCancelled || currentGeneration() != gen { break }
             byteBuf.append(byte)
+            // Cap the un-decoded byte buffer: a server that streams bytes but NEVER a
+            // 0x0A ('\n') would otherwise grow this without bound (memory exhaustion).
+            // Real events are tiny. Treat a breach as a stream failure (generic error →
+            // backoff/reconnect), NOT terminal — a transient bad peer may recover.
+            if byteBuf.count > Self.maxBufferBytes {
+                throw SseStreamOverflowError()
+            }
             guard byte == 0x0A else { continue }
-            guard let chunk = String(bytes: byteBuf, encoding: .utf8) else { continue }
+            // Decode with String(decoding:as:) which NEVER fails: invalid UTF-8 is
+            // replaced with U+FFFD (matching Android's InputStreamReader). The previous
+            // failable init returned nil and `continue`d WITHOUT clearing byteBuf, so a
+            // single bad byte permanently stalled the stream (every later '\n'
+            // re-decoded a growing buffer, no frame ever emitted, and the socket looked
+            // healthy so reconnect never fired). byteBuf is now ALWAYS cleared here.
+            let chunk = String(decoding: byteBuf, as: UTF8.self)
             byteBuf.removeAll(keepingCapacity: true)
             pending += chunk.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
             while let boundary = pending.range(of: "\n\n") {
@@ -196,6 +238,12 @@ final class VaultSseBridge {
                 if block.split(separator: "\n", omittingEmptySubsequences: false).contains(where: { $0.hasPrefix("data:") }) {
                     push(["type": "frame", "block": block])
                 }
+            }
+            // Cap the framing remainder too: a server that sends '\n' bytes but never
+            // the "\n\n" block delimiter would grow `pending` without bound. Same
+            // treatment: fail the stream into backoff/reconnect.
+            if pending.utf8.count > Self.maxBufferBytes {
+                throw SseStreamOverflowError()
             }
         }
     }
@@ -236,7 +284,52 @@ final class VaultSseBridge {
         while out.hasSuffix("/") { out.removeLast() }
         return out
     }
+
+    // MARK: - URL transport-security allowlist (mirrors src/sync/vaultUrlPolicy.js)
+
+    /// https is always allowed; http only for loopback/LAN hosts. Any other scheme is
+    /// rejected. Keep in agreement with classifyVaultUrl (renderer) and Android.
+    private static func isSecureOrLanUrl(_ url: URL) -> Bool {
+        let scheme = (url.scheme ?? "").lowercased()
+        if scheme == "https" { return true }
+        if scheme != "http" { return false }
+        return isLocalOrLanHost(url.host ?? "")
+    }
+
+    /// True for loopback / private-LAN / *.local hosts, for which cleartext http is
+    /// acceptable. Foundation's URL.host already strips IPv6 brackets; the bracket
+    /// strip below is defensive.
+    private static func isLocalOrLanHost(_ rawHost: String) -> Bool {
+        var host = rawHost.lowercased()
+        if host.hasPrefix("[") && host.hasSuffix("]") { host = String(host.dropFirst().dropLast()) }
+        if host.isEmpty { return false }
+        if host == "localhost" || host.hasSuffix(".localhost") { return true }
+        if host == "::1" { return true }
+        if host.hasSuffix(".local") { return true }
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 4 else { return false }
+        let octets = parts.compactMap { Int($0) }
+        guard octets.count == 4, octets.allSatisfy({ $0 >= 0 && $0 <= 255 }) else { return false }
+        let a = octets[0], b = octets[1]
+        if a == 127 { return true }              // 127.0.0.0/8 loopback
+        if a == 10 { return true }               // 10.0.0.0/8
+        if a == 192 && b == 168 { return true }  // 192.168.0.0/16
+        if a == 172 && (16...31).contains(b) { return true } // 172.16.0.0/12
+        return false
+    }
 }
+
+/// A TERMINAL stream error: the reader must stop and NOT reconnect (retrying can't
+/// help). `code` distinguishes the cause for the renderer ('auth' = revoked/invalid
+/// token; 'insecure' = refused cleartext URL). Mirrors Android's SseTerminalException.
+private struct SseTerminalError: Error {
+    let code: String
+    let message: String
+}
+
+/// A NON-terminal stream failure: the SSE framing buffer exceeded its cap. Handled
+/// like any read error — backoff + reconnect (a transient bad peer may recover).
+private struct SseStreamOverflowError: Error {}
 
 /// Capped exponential backoff with a stability reset — the Swift mirror of Android's
 /// `SseBackoff` and the renderer's reconnect policy in `createVaultEventClient`.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -618,14 +618,20 @@ async function migrateFileToAppStorage(): Promise<void> {
       return;
     }
 
-    // 2) WRITE into the app:// localStorage (file:// wins on conflict; app://-only
-    //    keys are left intact). Same session as the main window, so the writes are
-    //    visible to it immediately.
+    // 2) WRITE into the app:// localStorage. Only keys that do NOT already exist in
+    //    the target are set (app://-only keys are left intact regardless). This is
+    //    IDENTICAL to "file:// wins" on a true first run (the target bucket is empty,
+    //    so every file:// key is written), but makes a RETRY non-destructive: if a
+    //    previous launch migrated but crashed before writing the done-flag, the retry
+    //    must not clobber newer app:// data the running app has since written with the
+    //    stale file:// snapshot. Skipping already-present keys makes retries purely
+    //    additive. Same session as the main window, so the writes are visible to it
+    //    immediately.
     const writer = mkHidden();
     try {
       await writer.loadURL(APP_BASE_URL + 'storage-bridge.html'); // app://dayglance origin
       await writer.webContents.executeJavaScript(
-        `(function(){var d=${JSON.stringify(fileData)};for(var k in d){localStorage.setItem(k,d[k]);}return true;})()`,
+        `(function(){var d=${JSON.stringify(fileData)};for(var k in d){if(localStorage.getItem(k)===null){localStorage.setItem(k,d[k]);}}return true;})()`,
       );
     } finally {
       if (!writer.isDestroyed()) writer.destroy();

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -17,6 +17,11 @@
       "vaultUnreachable": "GLANCEvault konnte nicht erreicht werden. Überprüfen Sie die Vault-URL und das Gerätetoken. ({{detail}})",
       "requestFailed": "Anfrage fehlgeschlagen",
       "iCloudUnavailable": "iCloud nicht verfügbar: {{error}}"
+    },
+    "vaultUrl": {
+      "invalid": "Geben Sie eine gültige Vault-URL ein.",
+      "httpRejected": "Unsichere Verbindung. Verwenden Sie https:// für einen Vault im öffentlichen Internet. Einfaches http:// ist nur in einem vertrauenswürdigen lokalen Netzwerk erlaubt (localhost oder eine LAN-Adresse).",
+      "insecureLanWarning": "Unverschlüsselte Verbindung: nur in einem vertrauenswürdigen Netzwerk verwenden."
     }
   },
   "common": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -17,6 +17,11 @@
       "vaultUnreachable": "Couldn't reach GLANCEvault. Check the vault URL and device token. ({{detail}})",
       "requestFailed": "request failed",
       "iCloudUnavailable": "iCloud unavailable: {{error}}"
+    },
+    "vaultUrl": {
+      "invalid": "Enter a valid vault URL.",
+      "httpRejected": "Insecure connection. Use https:// for a vault on the public internet. Plain http:// is only allowed on a trusted local network (localhost or a LAN address).",
+      "insecureLanWarning": "Unencrypted connection: only use on a trusted network."
     }
   },
   "common": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -17,6 +17,11 @@
       "vaultUnreachable": "No se pudo conectar con GLANCEvault. Comprueba la URL del vault y el token del dispositivo. ({{detail}})",
       "requestFailed": "la solicitud falló",
       "iCloudUnavailable": "iCloud no disponible: {{error}}"
+    },
+    "vaultUrl": {
+      "invalid": "Introduce una URL de vault válida.",
+      "httpRejected": "Conexión no segura. Usa https:// para un vault en la internet pública. El http:// simple solo se permite en una red local de confianza (localhost o una dirección LAN).",
+      "insecureLanWarning": "Conexión sin cifrar: úsala solo en una red de confianza."
     }
   },
   "common": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -17,6 +17,11 @@
       "vaultUnreachable": "Impossible de joindre GLANCEvault. Vérifiez l'URL du coffre et le jeton d'appareil. ({{detail}})",
       "requestFailed": "échec de la requête",
       "iCloudUnavailable": "iCloud indisponible : {{error}}"
+    },
+    "vaultUrl": {
+      "invalid": "Saisissez une URL de vault valide.",
+      "httpRejected": "Connexion non sécurisée. Utilisez https:// pour un vault sur l'internet public. Le http:// simple n'est autorisé que sur un réseau local de confiance (localhost ou une adresse LAN).",
+      "insecureLanWarning": "Connexion non chiffrée : à utiliser uniquement sur un réseau de confiance."
     }
   },
   "common": {

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -17,6 +17,11 @@
       "vaultUnreachable": "Impossibile raggiungere GLANCEvault. Controlla l'URL del vault e il token del dispositivo. ({{detail}})",
       "requestFailed": "richiesta fallita",
       "iCloudUnavailable": "iCloud non disponibile: {{error}}"
+    },
+    "vaultUrl": {
+      "invalid": "Inserisci un URL del vault valido.",
+      "httpRejected": "Connessione non sicura. Usa https:// per un vault sulla rete internet pubblica. Il semplice http:// è consentito solo su una rete locale attendibile (localhost o un indirizzo LAN).",
+      "insecureLanWarning": "Connessione non cifrata: usala solo su una rete attendibile."
     }
   },
   "common": {

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -17,6 +17,11 @@
       "vaultUnreachable": "Não foi possível contactar o GLANCEvault. Verifique o URL do vault e o token do dispositivo. ({{detail}})",
       "requestFailed": "pedido falhou",
       "iCloudUnavailable": "iCloud indisponível: {{error}}"
+    },
+    "vaultUrl": {
+      "invalid": "Introduza um URL de vault válido.",
+      "httpRejected": "Ligação não segura. Utilize https:// para um vault na internet pública. O http:// simples só é permitido numa rede local de confiança (localhost ou um endereço LAN).",
+      "insecureLanWarning": "Ligação não encriptada: utilize apenas numa rede de confiança."
     }
   },
   "common": {

--- a/src/components/CloudSyncSettingsForm.jsx
+++ b/src/components/CloudSyncSettingsForm.jsx
@@ -5,6 +5,7 @@ import { setupEncryptionKey, setSyncPassphrase, clearEncryptionKey, getSyncPassp
 import { getVaultConfig, setVaultConfig } from '../sync/vaultConfig.js';
 import { createDbEngine, resetDbRootKey } from '../sync/dbEngine.js';
 import { testVaultConnection } from '../sync/vaultConnectionTest.js';
+import { classifyVaultUrl } from '../sync/vaultUrlPolicy.js';
 import { useTranslation } from 'react-i18next';
 
 // Cloud sync settings form (extracted to avoid hooks-in-conditional issues)
@@ -74,6 +75,11 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   // (re)enter it in the encryption field above. A passphrase setup must therefore
   // exist (encryption on, or already configured) and a passphrase must be in hand.
   const vaultFilled = vaultEnabled && !!vaultUrl.trim() && !!vaultToken.trim() && !!vaultAccountId.trim();
+  // Transport-security check on the vault URL: block cleartext http:// on the public
+  // internet (the Bearer token would travel unencrypted), allow it on localhost/LAN
+  // with a warning. Only meaningful once a URL is typed; empty is handled by vaultFilled.
+  const vaultUrlCheck = classifyVaultUrl(vaultUrl);
+  const vaultUrlOk = !vaultFilled || vaultUrlCheck.ok;
   const passphraseAvailable = !!getSyncPassphrase() || passphrase.length > 0;
   const vaultEncryptionReady = encryptionEnabled || alreadyEncrypted;
 
@@ -96,7 +102,7 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   // on the WebDAV connection) OR the user is turning the vault OFF — so a
   // vault-only device can disable it even though nothing remains configured.
   const vaultBeingDisabled = !!vaultOriginal?.enabled && !vaultEnabled;
-  const canSave = (webdavActive || vaultFilled || vaultBeingDisabled || webdavBeingDisabled) && passphraseValid && !passphraseMismatch && vaultReady;
+  const canSave = (webdavActive || vaultFilled || vaultBeingDisabled || webdavBeingDisabled) && passphraseValid && !passphraseMismatch && vaultReady && vaultUrlOk;
 
   const handleTest = async () => {
     setTesting(true);
@@ -108,6 +114,12 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
 
   const handleSave = async () => {
     setVaultBootstrapError(null);
+    // Refuse to save a vault whose URL would send the Bearer token over cleartext on
+    // the public internet (canSave already blocks this; this is the defensive guard).
+    if (vaultFilled && !vaultUrlCheck.ok) {
+      setVaultBootstrapError(t(vaultUrlCheck.messageKey));
+      return;
+    }
     // WebDAV is marked enabled only when the user toggled it on AND the connection is
     // configured — so enabling GLANCEvault alone never writes a bogus enabled WebDAV
     // config, and unchecking the toggle disables sync while keeping the credentials.
@@ -214,6 +226,13 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
   // it just tells the user whether the credentials work, so bad vault credentials
   // no longer save silently and fail invisibly at first sync.
   const handleVaultTest = async () => {
+    // Enforce the same URL policy before probing: a cleartext public URL never
+    // reaches the network (the token would leak in the test request too).
+    const urlCheck = classifyVaultUrl(vaultUrl);
+    if (!urlCheck.ok) {
+      setVaultTestResult({ ok: false, message: t(urlCheck.messageKey) });
+      return;
+    }
     setVaultTesting(true);
     setVaultTestResult(null);
     try {
@@ -447,6 +466,12 @@ const CloudSyncSettingsForm = ({ darkMode, textPrimary, textSecondary, borderCla
                 onChange={(e) => setVaultUrl(e.target.value)}
                 className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none leading-normal text-base ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
               />
+              {vaultUrl.trim() && !vaultUrlCheck.ok && (
+                <p className="text-xs text-red-500 mt-0.5">{t(vaultUrlCheck.messageKey)}</p>
+              )}
+              {vaultUrl.trim() && vaultUrlCheck.ok && vaultUrlCheck.warning && (
+                <p className="text-xs text-amber-500 mt-0.5">{t(vaultUrlCheck.messageKey)}</p>
+              )}
             </div>
             <div>
               <label className={`block text-sm ${textSecondary} mb-1`}>Device token</label>

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -77,6 +77,7 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
       lastEventSeq: null,
       lastEventKind: null,
       lastError: null,
+      terminal: null,
       lastConnectedAt: null,
       transport,
     };
@@ -113,7 +114,16 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
       diag.state = state;
       if (state === 'connecting') diag.connects += 1;
       if (state === 'open') diag.lastConnectedAt = new Date().toISOString();
-      if (state === 'error') { diag.lastError = detail?.message || String(detail || 'error'); console.warn('[vault-sse] error:', diag.lastError); }
+      if (state === 'error') {
+        diag.lastError = detail?.message || String(detail || 'error');
+        // A terminal code (native-bridge only) means the native reader stopped and
+        // will NOT reconnect — e.g. a revoked token ('auth') or a refused cleartext
+        // URL ('insecure'). Record it and warn once (native won't re-emit every 30s);
+        // fixing the token in settings reloads the app and starts a fresh reader.
+        diag.terminal = detail?.code || null;
+        if (detail?.code) console.warn(`[vault-sse] terminal error (${detail.code}) — native stopped, not reconnecting:`, diag.lastError);
+        else console.warn('[vault-sse] error:', diag.lastError);
+      }
       else if (sseDebug()) console.info('[vault-sse]', state, `(connects=${diag.connects} events=${diag.events} drains=${diag.drains})`);
     };
     const getConnection = () => {

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -475,7 +475,12 @@ export function createBridgeSseClient({
         onStateChange?.('closed');
         break;
       case 'error':
-        onStateChange?.('error', msg.message);
+        // A native error may carry a terminal `code` (e.g. 'auth' for a revoked
+        // token, 'insecure' for a refused cleartext URL). Native stops reading and
+        // will NOT reconnect on a terminal code, so this surfaces exactly once —
+        // pass the code through so the consumer can distinguish it. Non-terminal
+        // errors keep the legacy string-detail shape (native owns the retry).
+        onStateChange?.('error', msg.code ? { message: msg.message, code: msg.code } : msg.message);
         break;
       default:
         break;

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -593,4 +593,28 @@ describe('createBridgeSseClient — native bridge-fed transport', () => {
     expect(states.map((s) => s[0])).toEqual(['connecting', 'open', 'closed', 'error', 'stopped']);
     expect(states.find((s) => s[0] === 'error')[1]).toBe('boom');
   });
+
+  it('passes a terminal error CODE through as a detail object (auth token revoked)', () => {
+    const states = [];
+    const client = createBridgeSseClient({
+      getConnection: () => conn, startNative: () => {}, stopNative: () => {},
+      onEvent: () => {}, onStateChange: (s, d) => states.push([s, d]),
+    });
+    // Native stops the reader on 401/403 and pushes a terminal, coded error ONCE.
+    client.receive({ type: 'error', code: 'auth', message: 'vault SSE auth failed: 401' });
+    const err = states.find((s) => s[0] === 'error');
+    expect(err[1]).toEqual({ message: 'vault SSE auth failed: 401', code: 'auth' });
+  });
+
+  it('passes an insecure-URL terminal code through the same way', () => {
+    const states = [];
+    const client = createBridgeSseClient({
+      getConnection: () => conn, startNative: () => {}, stopNative: () => {},
+      onEvent: () => {}, onStateChange: (s, d) => states.push([s, d]),
+    });
+    client.receive({ type: 'error', code: 'insecure', message: 'vault SSE refused: insecure http URL' });
+    expect(states.find((s) => s[0] === 'error')[1]).toEqual({
+      message: 'vault SSE refused: insecure http URL', code: 'insecure',
+    });
+  });
 });

--- a/src/sync/vaultUrlPolicy.js
+++ b/src/sync/vaultUrlPolicy.js
@@ -1,0 +1,63 @@
+// GLANCEvault URL transport-security policy (shared by the settings form's Save +
+// Test Connection paths). The native Android/iOS shells enforce the SAME rule as a
+// belt-and-braces check before opening a stream (see VaultSseClient.kt /
+// VaultSseBridge.swift), so keep this logic and theirs in agreement.
+//
+// RULE: the Bearer device token must not travel over cleartext on the public
+// internet. Require https://, EXCEPT allow http:// for loopback and LAN hosts
+// (localhost, 127.0.0.0/8, ::1, RFC1918 ranges, *.local) — self-hosters running a
+// vault on their own network are a real audience — but flag that http:// case with
+// a warning so it is a deliberate, informed choice. A plain-internet http:// URL is
+// rejected outright.
+
+/**
+ * True when an http:// host is a loopback or private-LAN address for which
+ * cleartext is acceptable. Mirrors isLocalOrLanHost in the native shells.
+ * @param {string} rawHost hostname (no scheme/port), IPv6 may be bracketed
+ */
+export function isLocalOrLanHost(rawHost) {
+  let host = (rawHost || '').trim().toLowerCase();
+  if (!host) return false;
+  // Strip IPv6 brackets: new URL('http://[::1]').hostname yields '[::1]'.
+  if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1);
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (host === '::1') return true;
+  if (host.endsWith('.local')) return true; // mDNS / Bonjour LAN names
+  const m = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return false;
+  const a = Number(m[1]);
+  const b = Number(m[2]);
+  if (m.slice(1).some((o) => Number(o) > 255)) return false;
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  return false;
+}
+
+/**
+ * Classify a vault URL for the settings form.
+ * @param {string} rawUrl the URL the user typed
+ * @returns {{ok: boolean, warning?: boolean, messageKey?: string}}
+ *   ok=false      → block save/test; messageKey names the error to show.
+ *   ok=true,warning=true → allowed, but show messageKey as an inline warning.
+ *   ok=true (no warning) → https:// (or another accepted secure form): no message.
+ */
+export function classifyVaultUrl(rawUrl) {
+  const url = (rawUrl || '').trim();
+  if (!url) return { ok: false, messageKey: 'sync.vaultUrl.invalid' };
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, messageKey: 'sync.vaultUrl.invalid' };
+  }
+  const scheme = parsed.protocol.toLowerCase();
+  if (scheme === 'https:') return { ok: true };
+  if (scheme !== 'http:') return { ok: false, messageKey: 'sync.vaultUrl.invalid' };
+  // http:// — acceptable only for loopback/LAN hosts, and even then with a warning.
+  if (isLocalOrLanHost(parsed.hostname)) {
+    return { ok: true, warning: true, messageKey: 'sync.vaultUrl.insecureLanWarning' };
+  }
+  return { ok: false, messageKey: 'sync.vaultUrl.httpRejected' };
+}

--- a/src/sync/vaultUrlPolicy.test.js
+++ b/src/sync/vaultUrlPolicy.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { classifyVaultUrl, isLocalOrLanHost } from './vaultUrlPolicy.js';
+
+// The vault Bearer token must never travel over cleartext on the public internet.
+// classifyVaultUrl gates the settings form's Save + Test Connection; the native
+// shells enforce the same rule before opening a stream.
+
+describe('classifyVaultUrl', () => {
+  it('accepts https:// without a warning', () => {
+    expect(classifyVaultUrl('https://vault.example.com')).toEqual({ ok: true });
+    expect(classifyVaultUrl('https://vault.example.com:8443/path')).toEqual({ ok: true });
+  });
+
+  it('rejects a plain-internet http:// URL', () => {
+    const r = classifyVaultUrl('http://vault.example.com');
+    expect(r.ok).toBe(false);
+    expect(r.messageKey).toBe('sync.vaultUrl.httpRejected');
+  });
+
+  it('allows http:// on localhost with a warning', () => {
+    const r = classifyVaultUrl('http://localhost:8080');
+    expect(r.ok).toBe(true);
+    expect(r.warning).toBe(true);
+    expect(r.messageKey).toBe('sync.vaultUrl.insecureLanWarning');
+  });
+
+  it('allows http:// on loopback / LAN / .local hosts with a warning', () => {
+    for (const u of [
+      'http://127.0.0.1',
+      'http://127.5.6.7:9000',
+      'http://[::1]:3000',
+      'http://10.1.2.3',
+      'http://192.168.1.50/events',
+      'http://172.16.0.1',
+      'http://172.31.255.254',
+      'http://vault.local',
+      'http://my-nas.localhost',
+    ]) {
+      const r = classifyVaultUrl(u);
+      expect(r.ok, u).toBe(true);
+      expect(r.warning, u).toBe(true);
+    }
+  });
+
+  it('rejects http:// on a public IP even inside 172.x that is not 172.16-31', () => {
+    expect(classifyVaultUrl('http://172.15.0.1').ok).toBe(false);
+    expect(classifyVaultUrl('http://172.32.0.1').ok).toBe(false);
+    expect(classifyVaultUrl('http://8.8.8.8').ok).toBe(false);
+  });
+
+  it('rejects empty / malformed / non-http(s) URLs as invalid', () => {
+    expect(classifyVaultUrl('').messageKey).toBe('sync.vaultUrl.invalid');
+    expect(classifyVaultUrl('   ').messageKey).toBe('sync.vaultUrl.invalid');
+    expect(classifyVaultUrl('not a url').messageKey).toBe('sync.vaultUrl.invalid');
+    expect(classifyVaultUrl('ftp://vault.example.com').messageKey).toBe('sync.vaultUrl.invalid');
+  });
+});
+
+describe('isLocalOrLanHost', () => {
+  it('recognizes loopback and private ranges', () => {
+    expect(isLocalOrLanHost('localhost')).toBe(true);
+    expect(isLocalOrLanHost('127.0.0.1')).toBe(true);
+    expect(isLocalOrLanHost('::1')).toBe(true);
+    expect(isLocalOrLanHost('[::1]')).toBe(true);
+    expect(isLocalOrLanHost('10.0.0.1')).toBe(true);
+    expect(isLocalOrLanHost('192.168.0.1')).toBe(true);
+    expect(isLocalOrLanHost('172.20.5.5')).toBe(true);
+    expect(isLocalOrLanHost('printer.local')).toBe(true);
+  });
+
+  it('rejects public hosts and out-of-range octets', () => {
+    expect(isLocalOrLanHost('vault.example.com')).toBe(false);
+    expect(isLocalOrLanHost('8.8.8.8')).toBe(false);
+    expect(isLocalOrLanHost('172.15.0.1')).toBe(false);
+    expect(isLocalOrLanHost('172.32.0.1')).toBe(false);
+    expect(isLocalOrLanHost('999.1.1.1')).toBe(false);
+    expect(isLocalOrLanHost('')).toBe(false);
+  });
+});


### PR DESCRIPTION
Wave B of the v4.0.0 GLANCEvault review (companion to #1160; if both are open, merge #1160 first — the settings form is touched by both and this branch will show at most a trivial conflict there).

## Fixes
1. **iOS SSE: invalid UTF-8 no longer stalls the stream.** The failable decode returned nil without clearing the byte buffer, so one malformed byte meant unbounded buffer growth, zero frames forever, and no reconnect (the connection looked healthy). Now decodes with U+FFFD substitution, matching Android's behavior.
2. **1 MB cap on SSE framing buffers (both platforms).** A server that never sends the frame delimiter previously grew the buffers without bound. Overflow now drops the connection into the existing backoff/reconnect path. Cap is checked on the retained partial after draining complete blocks, so legitimate large multi-block chunks pass. Kotlin tests added.
3. **401/403 is now terminal.** Auth failures stop the reader entirely (previously: reconnect forever every 30s with a revoked token) and surface once to the renderer as `{ type: 'error', code: 'auth' }`. A fresh `startVaultSse` after the user fixes the token starts a new reader (fresh-start path traced on both platforms).
4. **https policy for the vault URL.** New shared `vaultUrlPolicy.js`: require `https://`; allow `http://` only for loopback/RFC1918/`.local` hosts (self-hosters) with an inline amber warning; reject public-internet `http://` with a clear message. Enforced in the form's Save + Test Connection, and mirrored as belt-and-braces checks in the native SSE clients (refused URLs fail into the terminal path with `code: 'insecure'`). Previously an `http://` URL sent the Bearer device token in cleartext on iOS and failed with an unexplained generic error on Android. New strings translated in all six locales.
5. **Electron storage-migration retry is now non-destructive.** The one-time `file://` → `app://` localStorage migration re-ran with "file wins" after a failed attempt, able to roll newer data back to a stale snapshot. The writer now only sets keys that don't already exist — identical on a true first run, purely additive on retry.

## Verification
- `npm test`: 685/685 (10 new: 8 URL-policy unit tests, 2 terminal-error stream tests) · lint clean · electron main+preload tsc pass
- All six locale files parse with identical key sets; no em dashes in new strings
- Swift/Kotlin verified by reading (no SDKs here): catch ordering (terminal before generic), no-leak throw paths, buffer reset on reconnect, host-allowlist parity with the JS policy — please include vault SSE in the device smoke tests (kill the token server-side and confirm the app stops retrying and surfaces the error once)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_