### PR TITLE
Release tooling: bump-version script and RELEASING.md runbook

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,144 @@
+# Releasing dayGLANCE
+
+The runbook for shipping a dayGLANCE release across web, Electron desktop
+(direct + Mac App Store), Android, and iOS. `package.json` "version" is the
+single source of truth; the version bumper propagates it everywhere else.
+
+Reference IDs and URLs:
+
+- Apple App Store app ID (`APPLE_APP_ID`): `6771540599` (wired into the README
+  and the web smart app banner).
+- Privacy policy: https://docs.dayglance.app/en/privacy-policy
+- EULA: https://www.glance-apps.com/eula
+
+---
+
+## 1. Pre-release checklist
+
+### 1.1 Bump the version
+
+Use the bumper, never hand-edit the numbers:
+
+```
+npm run bump 4.0.0            # preview with --dry-run first if unsure
+```
+
+This updates `package.json` "version", the Android `versionName` (full x.y.z)
+and `versionCode` (+1), and the README shields.io badge. iOS
+`MARKETING_VERSION` and the Electron `CFBundleShortVersionString` derive from
+`package.json` at build time, so they need no manual edit. Review the diff and
+commit the bump before building.
+
+### 1.2 Quality gates
+
+```
+npm run lint
+npm test
+```
+
+Both must be clean and green before tagging.
+
+### 1.3 Device smoke tests
+
+Run these once each on real hardware or a representative simulator:
+
+- iOS: external links open in the system browser; the HealthKit permission
+  prompt is deferred until first use (not on launch); a vault SSE
+  auth-failure surfaces to the user once (no silent retry storm).
+- Android: vault SSE stream connects and the WebView renders the app.
+- Electron: the Mac App Store restore-purchase flow works, and the
+  file-to-app storage migration runs cleanly on an upgrade.
+
+### 1.4 App Store Connect metadata
+
+Confirm the listing has:
+
+- Privacy policy URL: https://docs.dayglance.app/en/privacy-policy
+- Support URL set.
+- EULA: https://www.glance-apps.com/eula
+- Review notes disclose the reviewer-unlock code so the reviewer can get past
+  the paywall.
+- ATS justification documented for user-configured http WebDAV/CalDAV
+  endpoints (arbitrary-loads is allowed because the server address is
+  user-provided, not an app-controlled host).
+
+---
+
+## 2. Build and sign per platform
+
+### Web (Vercel)
+
+Production deploys from the default branch via Vercel. No manual build step;
+merging to the production branch ships the web app.
+
+### Electron desktop (direct distribution)
+
+Handled by CI. `.github/workflows/release-desktop.yml` runs on a `v*` tag push
+(or manual dispatch) and builds the macOS DMG/zip (signed + notarized via
+`CSC_LINK`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`,
+`MAC_PROVISIONING_PROFILE`), the Windows `.exe`, and the Linux `.AppImage`,
+then attaches them to a DRAFT GitHub release.
+
+### Electron Mac App Store (MAS)
+
+Built locally (not in CI):
+
+```
+npm run build:electron:mas
+```
+
+Produces a universal MAS package for upload to App Store Connect via Transporter
+or Xcode.
+
+### Android (AAB + APK)
+
+```
+./build-and-install.sh --release
+```
+
+Builds the Play AAB (`outputs/dayglance.aab`) for the Play Store plus the Play
+and GitHub release APKs (`outputs/dayglance.apk`, `outputs/dayglance-github.apk`).
+Upload the AAB to the Play Console; keep the GitHub APK for the release assets.
+
+### iOS
+
+```
+npm run ios            # build:ios + ios:generate
+```
+
+`npm run ios:generate` MUST run after the bump so the regenerated Xcode project
+picks up the new `MARKETING_VERSION` from `package.json` (a bare `xcodegen`
+would leave it empty). Then open `dayglance-ios/DayGlance.xcodeproj` in Xcode,
+archive, and upload to App Store Connect.
+
+---
+
+## 3. Release sequencing
+
+Order matters, because publishing the GitHub release is what triggers the
+downstream Docker and website workflows. Do it LAST.
+
+1. Push the version tag: `git tag v4.0.0 && git push origin v4.0.0`.
+2. CI (`release-desktop.yml`) builds the desktop apps and creates a DRAFT
+   release with the DMG/zip/exe/AppImage attached.
+3. Manually attach the Android GitHub APK (`outputs/dayglance-github.apk`) to
+   the draft.
+4. Write the release notes.
+5. PUBLISH the release LAST. Publishing fires:
+   - `publish-ghcr.yml`: builds and pushes the multi-arch Docker image to
+     GHCR (tags: semver, major.minor, latest).
+   - `trigger-site-rebuild.yml`: POSTs the Vercel deploy hook to rebuild
+     glance-apps.com so the site reflects the new release.
+
+Submit the App Store (iOS + MAS) and Play Store builds for review in parallel;
+their approval timelines are independent of the GitHub release.
+
+---
+
+## 4. Post-release verification
+
+- App Store / Play Store / MAS listings show the new version once approved.
+- GHCR image published: `ghcr.io/<owner>/dayglance:4.0.0` and `:latest`
+  pulled and run.
+- glance-apps.com rebuilt and shows the new release.
+- GitHub release has all desktop artifacts plus the Android APK attached.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "ios": "npm run build:ios && npm run ios:generate",
     "preview": "vite preview",
     "reviewer-code": "node scripts/reviewer-code.js",
+    "bump": "node scripts/bump-version.mjs",
     "lint": "eslint src --max-warnings 0",
     "test": "vitest run",
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+//
+// dayGLANCE version bumper.
+//
+// Sets the app's marketing version everywhere it is hard-coded, in one shot,
+// so a release never ships with mismatched numbers across platforms.
+//
+// package.json "version" is the source of truth. The iOS project
+// (CFBundleShortVersionString / MARKETING_VERSION) and the Electron desktop
+// build (CFBundleShortVersionString) both read package.json at build time
+// — see scripts/gen-ios-project.sh and electron-builder — so those need no
+// direct edit here. The locations this script rewrites are the ones that do
+// NOT derive from package.json automatically:
+//
+//   1. package.json               "version"      (the source of truth)
+//   2. dayglance-android build.gradle.kts  versionName  (string, set to x.y.z)
+//                                          versionCode  (integer, +1 each bump)
+//   3. README.md                  shields.io version badge URL
+//
+// Behavior:
+//   node scripts/bump-version.mjs 4.0.0            # bump for real
+//   node scripts/bump-version.mjs 4.0.0 --dry-run  # print, write nothing
+//
+// It validates the arg is semver x.y.z, prints every change old -> new, and
+// ERRORS loudly if any expected pattern is missing rather than silently
+// no-op'ing. It does NOT git-commit or tag — that stays a human step.
+//
+// Usage:  npm run bump 4.0.0   (alias for this script)
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+// ── Args ────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const version = args.find((a) => !a.startsWith('--'));
+
+function die(msg) {
+  console.error(`bump-version: ${msg}`);
+  process.exit(1);
+}
+
+if (!version) {
+  die('missing version argument. Usage: node scripts/bump-version.mjs X.Y.Z [--dry-run]');
+}
+
+// Strict semver x.y.z — no prerelease/build metadata, no leading "v".
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  die(`"${version}" is not a valid X.Y.Z version (expected e.g. 4.0.0).`);
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+const changes = []; // { file, label, from, to }
+
+function read(rel) {
+  const abs = path.join(ROOT, rel);
+  if (!fs.existsSync(abs)) die(`expected file not found: ${rel}`);
+  return { abs, text: fs.readFileSync(abs, 'utf8') };
+}
+
+// Apply a single regex substitution; ERROR if the pattern is not found so a
+// drifted file can never be silently skipped. `re` MUST be shaped
+// (prefix)(value)(suffix) — group 2 is the old value used in the report.
+function sub(text, re, replacer, { file, label, to }) {
+  const m = text.match(re);
+  if (!m) {
+    die(`could not find ${label} in ${file} (pattern ${re}). Aborting — no files written.`);
+  }
+  const from = m[2];
+  const next = text.replace(re, replacer);
+  changes.push({ file, label, from, to });
+  return next;
+}
+
+// ── 1. package.json ──────────────────────────────────────────────────────
+const pkg = read('package.json');
+const pkgText = sub(
+  pkg.text,
+  /("version":\s*")(\d+\.\d+\.\d+)(")/,
+  (_all, pre, _old, post) => `${pre}${version}${post}`,
+  { file: 'package.json', label: 'version', to: version },
+);
+
+// ── 2. dayglance-android/app/build.gradle.kts ─────────────────────────────
+// versionName is unified to the full x.y.z. It had previously been "3.10"
+// (no patch component), which drifts from package.json's x.y.z and makes the
+// Play Store listing look out of step with iOS/Electron. Always write x.y.z.
+const gradleRel = 'dayglance-android/app/build.gradle.kts';
+const gradle = read(gradleRel);
+let gradleText = sub(
+  gradle.text,
+  /(versionName\s*=\s*")([^"]+)(")/,
+  (_all, pre, _old, post) => `${pre}${version}${post}`,
+  { file: gradleRel, label: 'versionName', to: version },
+);
+
+// versionCode is a monotonically increasing integer for the Play Store;
+// increment it by 1 rather than deriving it from the marketing version.
+const codeRe = /(versionCode\s*=\s*)(\d+)/;
+const codeMatch = gradle.text.match(codeRe);
+if (!codeMatch) {
+  die(`could not find versionCode in ${gradleRel}. Aborting — no files written.`);
+}
+const oldCode = parseInt(codeMatch[2], 10);
+const newCode = oldCode + 1;
+gradleText = gradleText.replace(codeRe, (_all, pre) => `${pre}${newCode}`);
+changes.push({ file: gradleRel, label: 'versionCode', from: String(oldCode), to: String(newCode) });
+
+// ── 3. README.md shields.io badge ─────────────────────────────────────────
+// e.g.  https://img.shields.io/badge/version-3.10.0-green.svg
+const readme = read('README.md');
+const readmeText = sub(
+  readme.text,
+  /(shields\.io\/badge\/version-)(\d+\.\d+\.\d+)(-)/,
+  (_all, pre, _old, post) => `${pre}${version}${post}`,
+  { file: 'README.md', label: 'version badge', to: version },
+);
+
+// ── Report ────────────────────────────────────────────────────────────────
+console.log(`bump-version: setting version to ${version}${dryRun ? '  (dry run — nothing written)' : ''}\n`);
+for (const c of changes) {
+  console.log(`  ${c.file}`);
+  console.log(`    ${c.label}: ${c.from} -> ${c.to}`);
+}
+console.log('');
+
+if (dryRun) {
+  console.log('Dry run complete. Re-run without --dry-run to write these changes.');
+  process.exit(0);
+}
+
+// ── Write ─────────────────────────────────────────────────────────────────
+fs.writeFileSync(pkg.abs, pkgText);
+fs.writeFileSync(gradle.abs, gradleText);
+fs.writeFileSync(readme.abs, readmeText);
+
+console.log('Files written.\n');
+console.log('Next steps:');
+console.log('  1. Review the diff:   git diff');
+console.log('  2. Commit the bump:   git add -A && git commit');
+console.log('  3. Regenerate the iOS project so MARKETING_VERSION updates BEFORE archiving:');
+console.log('       npm run ios:generate');
+console.log('  4. Follow RELEASING.md for the full tag / build / publish sequence.');


### PR DESCRIPTION
Closes the round-1 finding that the version bump is manual across multiple surfaces with no checklist.

## scripts/bump-version.mjs (`npm run bump 4.0.0`)
One command updates every place a version string lives:
- `package.json` (source of truth; iOS `MARKETING_VERSION` and Electron `CFBundleShortVersionString` derive from it at build time, so no other edits needed)
- `dayglance-android/app/build.gradle.kts` `versionName` (unified to full x.y.z; it had drifted to two-component "3.10") and `versionCode` (auto-incremented)
- README version badge

Semver-validated, `--dry-run` supported, errors loudly if any target pattern is missing (no silent no-ops), never commits or tags (the human drives git), and prints the reminder to run `npm run ios:generate` after bumping so the Xcode project picks up the new marketing version.

Verified: dry-run and real-run produce exactly the expected edits (3.10.0 → 4.0.0, versionCode 164 → 165), then reverted — **this PR contains no version change**, only the tooling.

## RELEASING.md
Consolidated release runbook built from the actual workflows and scripts: pre-release checklist (bump, tests, the device smoke-test items from the recent hardening PRs, App Store Connect metadata including the reviewer-code disclosure and ATS justification), per-platform build/sign steps, and the release **sequencing** that matters here: tag → CI desktop draft → attach APK → write notes → publish LAST, because publishing triggers the Docker push and the marketing-site rebuild.

Verification: 712/712 tests, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_