### PR TITLE
Sync: tombstone-timestamp rule in the delete guard + @glance-apps/sync 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.10.0",
       "dependencies": {
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "1.5.2",
+        "@glance-apps/sync": "^1.6.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -2517,9 +2517,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.2.tgz",
-      "integrity": "sha512-S+O/bsGxtkDzcVBPhI8DlTiy89cfOwe9XGFaZoD3G1m2kZzOW9RnKNqHYuPSP2+Auy0RFPBQla+45nhm6WuN+A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.6.0.tgz",
+      "integrity": "sha512-1rDJNg7HYTfvEFrCy2oVMtiWhdNGNa3avk4JqKQfE888Zw0Sv0EevBGUAR6S8nnxlK5CN1ZOPhh5TKOWTUhSPg==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.10.0",
       "dependencies": {
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "^1.6.0",
+        "@glance-apps/sync": "1.6.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "^1.6.0",
+    "@glance-apps/sync": "1.6.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "1.5.2",
+    "@glance-apps/sync": "^1.6.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/src/sync/commitMerge.js
+++ b/src/sync/commitMerge.js
@@ -35,9 +35,11 @@
 //   • An entity present in the mirror but gone from live either (a) was pulled
 //     in from a peer this cycle (absent at cycle start too) → keep it, or (b)
 //     was deleted locally mid-cycle → honor the deletion, but ONLY when it bears
-//     a real-deletion fingerprint (tombstone / cross-list survivor) per
-//     partitionSnapshotDeletes — a bare mid-cycle vanish is a glitch-suspect and
-//     the mirror copy is kept (same bias as snapshotDeleteGuard).
+//     a real-deletion fingerprint (a tombstone at least as new as the mirror
+//     copy being deleted, or a cross-list survivor) per partitionSnapshotDeletes
+//     — a bare mid-cycle vanish, or one blessed only by a STALE tombstone left
+//     over from before the entity was revived, is a glitch-suspect and the
+//     mirror copy is kept (same bias as snapshotDeleteGuard).
 //
 // WHY SURVIVORS STILL GET PUSHED (the snapshot contract): dbEngine saves the
 // post-cycle snapshot from the mirror AS PUSHED/PULLED (i.e. BEFORE this merge),
@@ -169,7 +171,13 @@ export function mergeMidCycleEdits(mirror, baseHashes, live) {
     if (getLocalEntity(mirror, id) == null) continue; // already gone from the mirror
     wantDelete.push(id);
   }
-  const { propagate, skipped } = partitionSnapshotDeletes(wantDelete, liveHashes, liveData);
+  // Same stale-tombstone rule as the push guard: the copy being deleted here is
+  // the MIRROR copy (possibly a pulled update newer than cycle start), so its
+  // lastModified is what the live tombstone must be at least as new as. A stale
+  // tombstone (revived entity) demotes the vanish to glitch-suspect → kept.
+  const { propagate, skipped } = partitionSnapshotDeletes(
+    wantDelete, liveHashes, liveData, (eid) => getLocalEntity(mirror, eid),
+  );
   for (const id of propagate) applyRemoteDelete(mirror, id);
 
   return { survivors, honoredDeletes: propagate, keptVanishes: skipped, liveHashes };

--- a/src/sync/commitMerge.test.js
+++ b/src/sync/commitMerge.test.js
@@ -136,6 +136,53 @@ describe('mergeMidCycleEdits — mid-cycle live changes fold into the commit', (
     expect(survivors).toContain('unscheduledTasks:1');
   });
 
+  it('a MID-CYCLE vanish blessed only by a STALE tombstone is KEPT (revived task, lingering tombstone)', () => {
+    // Task 1 (lastModified 2026-07-01T10:00) was deleted and REVIVED days before
+    // this cycle; its tombstone from the original deletion lingers (60-day
+    // retention). A transient live-state shrink drops it mid-cycle. The stale
+    // tombstone must not bless the vanish — the mirror copy is kept.
+    const { mirror, keptVanishes, honoredDeletes } = run(
+      null,
+      (live) => {
+        live.tasks = [];
+        live.deletedTaskIds = { 1: '2026-06-20T12:00:00.000Z' }; // 11 days OLDER than the copy
+      },
+    );
+    expect(mirror.tasks.map((t) => t.id)).toEqual([1]);
+    expect(keptVanishes).toEqual(['tasks:1']);
+    expect(honoredDeletes).toEqual([]);
+  });
+
+  it('a MID-CYCLE delete compares the tombstone against the MIRROR copy (a newer pulled edit beats it)', () => {
+    // The pull updated task 1 to a strictly newer copy while the local user
+    // deleted it mid-cycle — but the tombstone predates the pulled edit by more
+    // than the epsilon, so edit-beats-delete: the pulled copy survives.
+    const { mirror, keptVanishes } = run(
+      (m) => { m.tasks[0] = task(1, '2026-07-01T13:00:00.000Z', { title: 'pulled newer' }); },
+      (live) => {
+        live.tasks = [];
+        live.deletedTaskIds = { 1: '2026-07-01T12:00:00.000Z' }; // older than the pulled copy
+      },
+    );
+    expect(mirror.tasks.map((t) => t.id)).toEqual([1]);
+    expect(mirror.tasks[0].title).toBe('pulled newer');
+    expect(keptVanishes).toEqual(['tasks:1']);
+  });
+
+  it('a MID-CYCLE delete with a tombstone within the epsilon BEFORE lastModified still lands (same-op stamping)', () => {
+    // moveToRecycleBin stamps the copy's lastModified up to ~1s ahead of the
+    // wall clock; a tombstone written moments earlier is still a REAL delete.
+    const { mirror, honoredDeletes } = run(
+      (m) => { m.tasks[0] = task(1, '2026-07-01T12:00:01.000Z'); },
+      (live) => {
+        live.tasks = [];
+        live.deletedTaskIds = { 1: '2026-07-01T12:00:00.000Z' }; // 1s before the copy's stamp
+      },
+    );
+    expect(mirror.tasks).toEqual([]);
+    expect(honoredDeletes).toEqual(['tasks:1']);
+  });
+
   it('a BARE mid-cycle vanish (no tombstone, no cross-list copy) is KEPT — glitch-suspect', () => {
     const { mirror, keptVanishes, honoredDeletes } = run(
       null,

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -460,7 +460,16 @@ export function createDbEngine(callbacks = {}) {
           if (id in cur) continue;
           wantDelete.push(id);
         }
-        const { propagate, skipped, reasons } = partitionSnapshotDeletes(wantDelete, cur, mirror);
+        // The deletion candidates' last-known copies live in the SNAPSHOT (prev):
+        // each value is hashEntity(entity) = JSON.stringify of the wrapped entity,
+        // so parsing it back recovers the copy being deleted — letting the guard
+        // compare its lastModified against the tombstone (stale-tombstone rule).
+        // wantDelete is a small set, so the parse cost is negligible.
+        const { propagate, skipped, reasons } = partitionSnapshotDeletes(wantDelete, cur, mirror, (eid) => {
+          const h = prev[eid];
+          if (typeof h !== 'string') return null;
+          try { return JSON.parse(h); } catch { return null; }
+        });
         glitchSkipped = skipped;
         for (const id of propagate) {
           engine.markDirty(id); // deletes
@@ -474,9 +483,12 @@ export function createDbEngine(callbacks = {}) {
         }
         if (skipped.length) {
           console.warn(
-            `[push] GUARD: skipped ${skipped.length} un-tombstoned vanish-delete(s) — ` +
+            `[push] GUARD: skipped ${skipped.length} vanish-delete(s) — ` +
             `suspected local-state glitch, rows kept (would-be fleet-wide deletion). ` +
-            `Ids:`, skipped.slice(0, 25), skipped.length > 25 ? `(+${skipped.length - 25} more)` : ''
+            // 'glitch' = un-tombstoned vanish; 'stale-tombstone' = tombstoned, but the
+            // deleted copy is newer than its lingering tombstone (revived entity).
+            `Ids:`, skipped.slice(0, 25).map((id) => `${id} (${reasons[id]})`),
+            skipped.length > 25 ? `(+${skipped.length - 25} more)` : ''
           );
         }
       }

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -741,6 +741,58 @@ describe('Wave A — glitch shrink: poisoned cycle withholds the snapshot; row r
     expect(B.data.tasks.map((t) => t.id).sort()).toEqual([810, 811, 812]);
   });
 
+  it('STALE TOMBSTONE: a revived task with a lingering tombstone survives a transient shrink (no delete pushed, row heals); a fresh re-delete still propagates', async () => {
+    // The revived-task window: delete (tombstone written) → task legitimately
+    // comes back with a NEWER lastModified (edit-beats-delete / recycle-bin
+    // restore) while the tombstone lingers for up to 60 days. A transient
+    // local-state shrink during that window must NOT be blessed by the stale
+    // tombstone — that would be a real, fleet-wide deletion of a live task.
+    const vault = createMemoryVault({ rowGet: true }); // heal available, as on the real client
+    const now = Date.now();
+    const iso = (ms) => new Date(ms).toISOString();
+    const A = makeDevice('A', vault, {
+      ...EMPTY,
+      tasks: [task(900, iso(now - 10 * 86400e3)), task(901, iso(now - 10 * 86400e3))],
+    });
+    const B = makeDevice('B', vault, { ...EMPTY });
+    await runRounds(A, B);
+    expect(B.data.tasks.map((t) => t.id).sort()).toEqual([900, 901]);
+
+    // GENUINE DELETE (5 days ago): tombstone + removal → propagates fleet-wide.
+    A.data.tasks = A.data.tasks.filter((t) => t.id !== 900);
+    A.data.deletedTaskIds = { ...(A.data.deletedTaskIds || {}), 900: iso(now - 5 * 86400e3) };
+    await runRounds(A, B);
+    expect(B.data.tasks.map((t) => t.id)).toEqual([901]);
+
+    // REVIVED: the task returns with a fresh lastModified; the tombstone lingers.
+    A.data.tasks.push(task(900, iso(now - 60e3), { title: 'revived' }));
+    await runRounds(A, B);
+    expect(B.data.tasks.find((t) => t.id === 900)?.title).toBe('revived');
+
+    const delSpy = vi.spyOn(vault, 'deleteRow');
+    // TRANSIENT SHRINK: A's live state drops the revived task with no fingerprint
+    // beyond the STALE tombstone.
+    A.data.tasks = A.data.tasks.filter((t) => t.id !== 900);
+    await A.engine.dbSyncCycle();
+
+    // No delete pushed to the vault, and the row-get heal re-injected the revived
+    // row into A's committed state; the clean (healed) cycle saved its snapshot,
+    // so the row persists in the diff baseline.
+    expect(deletedIds(delSpy)).not.toContain('tasks:900');
+    expect(A.data.tasks.find((t) => t.id === 900)?.title).toBe('revived');
+    expect(snapOf('A')['tasks:900']).toBeDefined();
+    await runRounds(A, B, 2);
+    expect(B.data.tasks.find((t) => t.id === 900)?.title).toBe('revived'); // fleet unaffected
+
+    // INVERSE: a genuine RE-DELETE with a FRESH tombstone still soft-deletes.
+    A.data.tasks = A.data.tasks.filter((t) => t.id !== 900);
+    A.data.deletedTaskIds = { ...(A.data.deletedTaskIds || {}), 900: iso(Date.now()) };
+    await runRounds(A, B);
+    expect(deletedIds(delSpy)).toContain('tasks:900');
+    expect(A.data.tasks.map((t) => t.id)).toEqual([901]);
+    expect(B.data.tasks.map((t) => t.id)).toEqual([901]);
+  });
+
   it('ABORT-ONLY persistent shrink never loop-propagates deletes; a REAL tombstoned delete still propagates (idempotently)', async () => {
     const vault = createMemoryVault(); // no getRow
     const A = makeDevice('A', vault, {

--- a/src/sync/snapshotDeleteGuard.js
+++ b/src/sync/snapshotDeleteGuard.js
@@ -29,10 +29,46 @@
 // stale row that resurrects; propagating it costs real, irreversible data loss —
 // so we bias hard toward keeping.
 //
+// THE TIMESTAMP RULE: a tombstone only AUTHORIZES a vanish-delete when it is at
+// least as new as the copy being deleted. Tombstones linger for up to 60 days
+// (tombstoneRetention.js), but a task can be deleted and then legitimately come
+// BACK while its tombstone lingers — a newer edit beats the delete under
+// newest-write-wins (a supported vault-tier flow as of @glance-apps/sync 1.6.0),
+// or the user restores it from the recycle bin (useRecycleBin re-stamps
+// lastModified to "now" precisely so the restore wins). During that window a
+// transient shrink that drops the REVIVED task must not be blessed by the stale
+// tombstone. So the tombstone bundles' VALUES (ISO deletion timestamps) are
+// compared against the deleted copy's lastModified (via `getDeletedEntity`):
+//
+//   tombstoneTs >= lastModified − STALE_TOMBSTONE_EPSILON_MS  → real delete, propagate
+//   tombstoneTs <  lastModified − epsilon                     → 'stale-tombstone', skip
+//
+// The epsilon covers real deletes where the same operation stamps the entity's
+// lastModified moments after (or before) writing the tombstone — see the note at
+// STALE_TOMBSTONE_EPSILON_MS. CONSERVATIVE FALLBACKS (all preserve the pre-rule
+// behavior of "any tombstone authorizes"): no `getDeletedEntity` provided, the
+// deleted copy has no parseable lastModified, or the tombstone value is missing/
+// unparseable → the tombstone authorizes the delete. A false "stale" verdict
+// would resurrect a genuinely deleted task (the old war symptom), so only a
+// CLEARLY newer entity demotes its tombstone to glitch-suspect.
+//
 // Real deletions (tombstoned) and real moves (id survives elsewhere) are unaffected
 // and still propagate exactly as before.
 
 import { TOMBSTONE_BUNDLE_KEYS } from './tombstoneRetention.js';
+import { getEntityLastModified } from './dbAdapter.js';
+
+// Tolerance for the tombstone-vs-lastModified comparison. Delete-path audit
+// (2026-07): every tombstone writer stamps `new Date().toISOString()` at delete
+// time and none re-stamps the entity's lastModified during the delete, EXCEPT
+// useTaskActions.moveToRecycleBin, which stamps the bin copy's lastModified to
+// max(now, task.lastModified + 1000) — i.e. up to ~1s in the FUTURE (its
+// anti-zombie stamp). Emptying the bin within that same second (useRecycleBin
+// confirmEmptyBin, tombstone = now) then yields a tombstone up to ~1s OLDER
+// than the recycleBin copy it deletes. 5s covers that 1s worst case five-fold
+// plus modest cross-device clock skew, while staying far below any realistic
+// delete→revive gap.
+export const STALE_TOMBSTONE_EPSILON_MS = 5000;
 
 // Bare id from an entityId ("tasks:abc" → "abc"). entityIds are "kind:id" and ids
 // are UUIDs / stable keys, so the bare id is globally unique across kinds.
@@ -42,6 +78,8 @@ function bareId(entityId) {
   return i < 0 ? s : s.slice(i + 1);
 }
 
+const parseTs = (v) => (v == null ? NaN : new Date(v).getTime());
+
 /**
  * Split the snapshot-diff's would-be deletes into those safe to propagate and those
  * to skip as suspected local-state glitches.
@@ -49,9 +87,13 @@ function bareId(entityId) {
  * @param {string[]} deleteEntityIds  entityIds the diff wants to delete (in snapshot, absent from cur)
  * @param {Record<string, unknown>} cur  current shredded state, keyed by entityId (snapshotShred output)
  * @param {object} mirror  the payload/mirror carrying the deletion tombstone bundles
- * @returns {{ propagate: string[], skipped: string[] }}
+ * @param {(entityId: string) => object|null} [getDeletedEntity]  returns the wrapped
+ *   entity ({ _kind, value }) of the copy being deleted, so its lastModified can be
+ *   compared against the tombstone (see THE TIMESTAMP RULE above). Omitted / null
+ *   result / unparseable lastModified → the tombstone authorizes unconditionally.
+ * @returns {{ propagate: string[], skipped: string[], reasons: Record<string,string> }}
  */
-export function partitionSnapshotDeletes(deleteEntityIds, cur, mirror) {
+export function partitionSnapshotDeletes(deleteEntityIds, cur, mirror, getDeletedEntity) {
   const ids = Array.isArray(deleteEntityIds) ? deleteEntityIds : [];
 
   // Every bare id present anywhere in the current payload (any kind). A cross-list
@@ -59,28 +101,57 @@ export function partitionSnapshotDeletes(deleteEntityIds, cur, mirror) {
   const liveBareIds = new Set();
   for (const eid of Object.keys(cur || {})) liveBareIds.add(bareId(eid));
 
-  // Union of every deletion tombstone across all bundles. A real delete tombstones
-  // the id; membership here means the delete is intentional.
-  const tombstoned = new Set();
+  // Union of every deletion tombstone across all bundles, keeping the NEWEST
+  // parseable timestamp per id (a real re-delete after a revive re-stamps the
+  // tombstone, and the bundle merge keeps the newer value — unionNewerIso). A
+  // missing/unparseable value maps to Infinity: it authorizes unconditionally
+  // (the pre-timestamp-rule behavior; we cannot call it stale if we can't date it).
+  const tombstoned = new Map();
   const m = mirror && typeof mirror === 'object' ? mirror : {};
   for (const key of TOMBSTONE_BUNDLE_KEYS) {
     const bundle = m[key];
     if (bundle && typeof bundle === 'object') {
-      for (const id of Object.keys(bundle)) tombstoned.add(String(id));
+      for (const [id, value] of Object.entries(bundle)) {
+        const t = parseTs(value);
+        const eff = Number.isNaN(t) ? Infinity : t;
+        const prev = tombstoned.get(String(id));
+        if (prev === undefined || eff > prev) tombstoned.set(String(id), eff);
+      }
     }
   }
+
+  // lastModified (epoch ms) of the copy being deleted; NaN when unavailable.
+  const deletedLastModified = (eid) => {
+    if (typeof getDeletedEntity !== 'function') return NaN;
+    let entity = null;
+    try { entity = getDeletedEntity(eid); } catch { entity = null; }
+    return entity == null ? NaN : parseTs(getEntityLastModified(entity));
+  };
 
   const propagate = [];
   const skipped = [];
   // Why each entityId landed where it did — 'tombstoned' (a real deletion), a
-  // cross-list move ('cross-list', the id survives under another kind), or a
-  // suspected 'glitch' (skipped). Diagnostic only; callers that ignore it are
-  // unaffected.
+  // cross-list move ('cross-list', the id survives under another kind), a
+  // suspected 'glitch' (skipped, no fingerprint at all), or 'stale-tombstone'
+  // (skipped: tombstoned, but the deleted copy is clearly newer than the
+  // tombstone — a revived entity whose old tombstone lingers). Diagnostic only;
+  // callers that ignore it are unaffected.
   const reasons = {};
   for (const eid of ids) {
     const id = bareId(eid);
-    if (tombstoned.has(id)) { propagate.push(eid); reasons[eid] = 'tombstoned'; }
-    else if (liveBareIds.has(id)) { propagate.push(eid); reasons[eid] = 'cross-list'; }
+    if (tombstoned.has(id)) {
+      const tombTs = tombstoned.get(id);
+      const lastMod = deletedLastModified(eid);
+      if (Number.isNaN(lastMod) || tombTs >= lastMod - STALE_TOMBSTONE_EPSILON_MS) {
+        propagate.push(eid); reasons[eid] = 'tombstoned';
+      } else if (liveBareIds.has(id)) {
+        // The stale tombstone doesn't bless the delete, but the id survives under
+        // another kind — a legitimate cross-list move, unaffected by the rule.
+        propagate.push(eid); reasons[eid] = 'cross-list';
+      } else {
+        skipped.push(eid); reasons[eid] = 'stale-tombstone';
+      }
+    } else if (liveBareIds.has(id)) { propagate.push(eid); reasons[eid] = 'cross-list'; }
     else { skipped.push(eid); reasons[eid] = 'glitch'; }
   }
   return { propagate, skipped, reasons };

--- a/src/sync/snapshotDeleteGuard.test.js
+++ b/src/sync/snapshotDeleteGuard.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { partitionSnapshotDeletes } from './snapshotDeleteGuard.js';
+import { partitionSnapshotDeletes, STALE_TOMBSTONE_EPSILON_MS } from './snapshotDeleteGuard.js';
 
 // cur is snapshotShred output: { entityId -> hash }. Only the KEYS matter here.
 const curOf = (...entityIds) => Object.fromEntries(entityIds.map((e) => [e, '#']));
@@ -77,5 +77,100 @@ describe('partitionSnapshotDeletes', () => {
   it('tolerates empty / missing inputs', () => {
     expect(partitionSnapshotDeletes([], {}, {})).toEqual({ propagate: [], skipped: [], reasons: {} });
     expect(partitionSnapshotDeletes(null, null, null)).toEqual({ propagate: [], skipped: [], reasons: {} });
+  });
+});
+
+describe('partitionSnapshotDeletes — stale-tombstone rule (tombstone vs lastModified)', () => {
+  const T = Date.parse('2026-07-08T12:00:00.000Z');
+  const iso = (ms) => new Date(ms).toISOString();
+  // getDeletedEntity stub: the wrapped copy being deleted, with a lastModified.
+  const deletedTaskAt = (lastModifiedMs) => () =>
+    ({ _kind: 'tasks', value: { id: 'X', title: 't', lastModified: iso(lastModifiedMs) } });
+
+  it('SKIPS a stale tombstone: the deleted copy is newer by more than the epsilon (revived task)', () => {
+    // Deleted long ago (lingering 60-day tombstone), then revived with a fresh
+    // edit; a transient shrink drops the revived copy. The stale tombstone must
+    // NOT bless the delete — this is the guard's core scenario.
+    const mirror = { deletedTaskIds: { X: iso(T) } };
+    const { propagate, skipped, reasons } = partitionSnapshotDeletes(
+      ['tasks:X'], curOf(), mirror, deletedTaskAt(T + STALE_TOMBSTONE_EPSILON_MS + 1),
+    );
+    expect(propagate).toEqual([]);
+    expect(skipped).toEqual(['tasks:X']);
+    expect(reasons['tasks:X']).toBe('stale-tombstone'); // distinct from bare 'glitch'
+  });
+
+  it('PROPAGATES a real delete: tombstone newer than the deleted copy', () => {
+    const mirror = { deletedTaskIds: { X: iso(T) } };
+    const { propagate, skipped, reasons } = partitionSnapshotDeletes(
+      ['tasks:X'], curOf(), mirror, deletedTaskAt(T - 60 * 60 * 1000),
+    );
+    expect(propagate).toEqual(['tasks:X']);
+    expect(skipped).toEqual([]);
+    expect(reasons['tasks:X']).toBe('tombstoned');
+  });
+
+  it('PROPAGATES within the epsilon: tombstone slightly BEFORE lastModified (same-operation stamping)', () => {
+    // moveToRecycleBin stamps the bin copy's lastModified up to ~1s into the
+    // future; an immediate empty-bin writes a tombstone up to ~1s older. That is
+    // a REAL delete and must still propagate — a false-stale would resurrect it.
+    const mirror = { deletedTaskIds: { X: iso(T) } };
+    const { propagate, skipped } = partitionSnapshotDeletes(
+      ['tasks:X'], curOf(), mirror, deletedTaskAt(T + STALE_TOMBSTONE_EPSILON_MS - 1000),
+    );
+    expect(propagate).toEqual(['tasks:X']);
+    expect(skipped).toEqual([]);
+  });
+
+  it('FALLBACK: a deleted copy with no parseable lastModified → the tombstone authorizes', () => {
+    const mirror = { deletedTaskIds: { X: iso(T) } };
+    for (const getDeleted of [
+      () => ({ _kind: 'tasks', value: { id: 'X', title: 'no ts' } }), // no lastModified
+      () => ({ _kind: 'tasks', value: { id: 'X', lastModified: 'not-a-date' } }),
+      () => null,           // copy not recoverable
+      () => { throw new Error('boom'); }, // lookup failure
+    ]) {
+      const { propagate, skipped } = partitionSnapshotDeletes(['tasks:X'], curOf(), mirror, getDeleted);
+      expect(propagate).toEqual(['tasks:X']);
+      expect(skipped).toEqual([]);
+    }
+  });
+
+  it('FALLBACK: an unparseable tombstone value → authorizes even a newer deleted copy', () => {
+    // Some historical bundle values may not be ISO; we cannot call a tombstone
+    // stale if we cannot date it (a false-stale resurrects a genuine delete).
+    const mirror = { deletedTaskIds: { X: 'not-a-date' } };
+    const { propagate, skipped, reasons } = partitionSnapshotDeletes(
+      ['tasks:X'], curOf(), mirror, deletedTaskAt(T + 10 * 60 * 1000),
+    );
+    expect(propagate).toEqual(['tasks:X']);
+    expect(skipped).toEqual([]);
+    expect(reasons['tasks:X']).toBe('tombstoned');
+  });
+
+  it('FALLBACK: no getDeletedEntity lookup at all → pre-rule behavior (tombstone authorizes)', () => {
+    const mirror = { deletedTaskIds: { X: iso(T) } };
+    const { propagate } = partitionSnapshotDeletes(['tasks:X'], curOf(), mirror);
+    expect(propagate).toEqual(['tasks:X']);
+  });
+
+  it('cross-list moves are unaffected: a stale tombstone + surviving copy under another kind still propagates', () => {
+    const mirror = { deletedTaskIds: { X: iso(T) } };
+    const { propagate, reasons } = partitionSnapshotDeletes(
+      ['tasks:X'], curOf('recycleBin:X'), mirror, deletedTaskAt(T + 10 * 60 * 1000),
+    );
+    expect(propagate).toEqual(['tasks:X']);
+    expect(reasons['tasks:X']).toBe('cross-list');
+  });
+
+  it('keeps the NEWEST tombstone per id across bundles (a re-delete re-stamps and wins)', () => {
+    // Revived at T+1h, then genuinely re-deleted at T+2h: the newer tombstone
+    // must authorize even though an older one lingers alongside.
+    const mirror = { deletedTaskIds: { X: iso(T) }, deletedFrameIds: { X: iso(T + 2 * 60 * 60 * 1000) } };
+    const { propagate, skipped } = partitionSnapshotDeletes(
+      ['tasks:X'], curOf(), mirror, deletedTaskAt(T + 60 * 60 * 1000),
+    );
+    expect(propagate).toEqual(['tasks:X']);
+    expect(skipped).toEqual([]);
   });
 });


### PR DESCRIPTION
The final two items from the GLANCEvault engine review, shipped together because they interact: the package's new semantics make revived-after-delete entities a supported flow, which is exactly what mints the stale tombstones the guard previously mishandled.

## Guard: a tombstone only authorizes a delete when it's at least as new as the copy being deleted
Previously `partitionSnapshotDeletes` treated *any* tombstone-bundle membership as proof of intent — ignoring the timestamps the bundles already carry. A task deleted and then legitimately revived (newer edit wins, or recycle-bin restore) kept its stale tombstone for up to 60 days, and during that window a transient local-state shrink would be blessed as an "intentional" delete and propagated fleet-wide: the one recently-revived id was precisely the id the guard didn't protect.

Now: `tombstoneTs >= lastModified − 5s` authorizes; a clearly-newer deleted copy demotes to a new `'stale-tombstone'` classification (skipped → Wave A's row-get heal path). Details:
- **Epsilon justified by a delete-path audit** of all nine tombstone writers: every one stamps the tombstone at delete time without re-stamping the entity — except `moveToRecycleBin`'s anti-zombie stamp, which can post-date the eventual tombstone by up to ~1s. 5s covers it five-fold plus modest clock skew.
- **Newest tombstone per id** across bundles (a re-delete after a revive re-stamps, and the bundle merge keeps the newer value).
- **Conservative fallbacks preserve old behavior**: missing lookup, unparseable `lastModified`, or undateable tombstone values all still authorize — only a *clearly newer* entity blocks, because a false "stale" verdict would resurrect a genuinely deleted task.
- Applied at both call sites: the cycle's snapshot diff (deleted copy sourced from the `prev` snapshot) and the Wave A mid-cycle commit merge (sourced from the mirror, so a pulled edit racing a mid-cycle local delete is protected too).

## @glance-apps/sync 1.5.2 → 1.6.0
- Pulled deletes now lose to a newer local edit (per-row `deletedAt` stamp; timestamp-less legacy tombstones keep old delete-wins behavior)
- Pushes send upserts before deletes: a cross-list move can no longer transiently vanish fleet-wide on a partial push failure

Full wrapper suite passes against the published package **unchanged** — the Wave A commit-merge semantics already matched the new contract, so the two layers now agree on newest-write-wins end to end.

## Verification
- 724/724 tests (12 new: guard unit tests incl. all fallbacks, commit-merge mid-cycle cases, and an end-to-end revived-task-glitch scenario through the real engine: revive → shrink → no delete pushed, row heals; fresh re-delete still propagates)
- Lint clean; installed package verified against the npm-published shasum (`ec7655d`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_