### PR TITLE
Frame Manually Schedule: respect multi-user, apply inbox filters, add affinity toggle

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -657,7 +657,17 @@
     "frameOff": "Aus",
     "tagAffinity": "Tag-Affinität",
     "noActiveFrames": "Keine aktiven Rahmen",
-    "newFrame": "Neuer Rahmen"
+    "newFrame": "Neuer Rahmen",
+    "manualSchedule": "Manuell planen",
+    "minAvailable": "{{minutes}} Min. verfügbar",
+    "noInboxTasks": "Keine Posteingangsaufgaben zum Einplanen",
+    "matchingTags": "Passende Tags",
+    "allTasks": "Alle Aufgaben",
+    "inboxFiltersApplied": "Posteingangsfilter angewendet",
+    "showAllInboxTasks": "Alle Posteingangsaufgaben anzeigen",
+    "noSlotLargeEnough": "Kein Zeitfenster ist groß genug für eine Aufgabe von {{minutes}} Min.",
+    "scheduleInFrame": "In {{frame}} einplanen",
+    "taskMinutes": "{{minutes}} Min."
   },
   "routines": {
     "whatsInRoutine": "Was enthält die heutige Routine?",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -657,7 +657,17 @@
     "frameOff": "Off",
     "tagAffinity": "Tag Affinity",
     "noActiveFrames": "No Active Frames",
-    "newFrame": "New Frame"
+    "newFrame": "New Frame",
+    "manualSchedule": "Manually Schedule",
+    "minAvailable": "{{minutes}} min available",
+    "noInboxTasks": "No inbox tasks to schedule",
+    "matchingTags": "Matching tags",
+    "allTasks": "All tasks",
+    "inboxFiltersApplied": "Inbox filters applied",
+    "showAllInboxTasks": "Show all inbox tasks",
+    "noSlotLargeEnough": "No slot large enough for a {{minutes}} min task",
+    "scheduleInFrame": "Schedule in {{frame}}",
+    "taskMinutes": "{{minutes}} min"
   },
   "routines": {
     "whatsInRoutine": "What’s in today’s routine?",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -657,7 +657,17 @@
     "frameOff": "Desactivado",
     "tagAffinity": "Afinidad de etiqueta",
     "noActiveFrames": "No hay bloques activos",
-    "newFrame": "Nuevo bloque"
+    "newFrame": "Nuevo bloque",
+    "manualSchedule": "Programar manualmente",
+    "minAvailable": "{{minutes}} min disponibles",
+    "noInboxTasks": "No hay tareas en la bandeja de entrada para programar",
+    "matchingTags": "Etiquetas coincidentes",
+    "allTasks": "Todas las tareas",
+    "inboxFiltersApplied": "Filtros de bandeja de entrada aplicados",
+    "showAllInboxTasks": "Mostrar todas las tareas de la bandeja de entrada",
+    "noSlotLargeEnough": "No hay hueco suficiente para una tarea de {{minutes}} min",
+    "scheduleInFrame": "Programar en {{frame}}",
+    "taskMinutes": "{{minutes}} min"
   },
   "routines": {
     "whatsInRoutine": "¿Qué hay en la rutina de hoy?",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -657,7 +657,17 @@
     "frameOff": "Désactivée",
     "tagAffinity": "Affinité d'étiquette",
     "noActiveFrames": "Aucune plage active",
-    "newFrame": "Nouvelle plage"
+    "newFrame": "Nouvelle plage",
+    "manualSchedule": "Planifier manuellement",
+    "minAvailable": "{{minutes}} min disponibles",
+    "noInboxTasks": "Aucune tâche de la boîte de réception à planifier",
+    "matchingTags": "Étiquettes correspondantes",
+    "allTasks": "Toutes les tâches",
+    "inboxFiltersApplied": "Filtres de la boîte de réception appliqués",
+    "showAllInboxTasks": "Afficher toutes les tâches de la boîte de réception",
+    "noSlotLargeEnough": "Aucun créneau assez grand pour une tâche de {{minutes}} min",
+    "scheduleInFrame": "Planifier dans {{frame}}",
+    "taskMinutes": "{{minutes}} min"
   },
   "routines": {
     "whatsInRoutine": "Que contient la routine d'aujourd'hui ?",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -657,7 +657,17 @@
     "frameOff": "Disattivo",
     "tagAffinity": "Affinità etichetta",
     "noActiveFrames": "Nessun blocco attivo",
-    "newFrame": "Nuovo blocco"
+    "newFrame": "Nuovo blocco",
+    "manualSchedule": "Pianifica manualmente",
+    "minAvailable": "{{minutes}} min disponibili",
+    "noInboxTasks": "Nessuna attività in arrivo da pianificare",
+    "matchingTags": "Etichette corrispondenti",
+    "allTasks": "Tutte le attività",
+    "inboxFiltersApplied": "Filtri della casella in arrivo applicati",
+    "showAllInboxTasks": "Mostra tutte le attività in arrivo",
+    "noSlotLargeEnough": "Nessuno spazio abbastanza grande per un'attività di {{minutes}} min",
+    "scheduleInFrame": "Pianifica in {{frame}}",
+    "taskMinutes": "{{minutes}} min"
   },
   "routines": {
     "whatsInRoutine": "Cosa c'è nella routine di oggi?",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -657,7 +657,17 @@
     "frameOff": "Desativado",
     "tagAffinity": "Afinidade de etiqueta",
     "noActiveFrames": "Sem blocos ativos",
-    "newFrame": "Novo bloco"
+    "newFrame": "Novo bloco",
+    "manualSchedule": "Agendar manualmente",
+    "minAvailable": "{{minutes}} min disponíveis",
+    "noInboxTasks": "Sem tarefas na caixa de entrada para agendar",
+    "matchingTags": "Etiquetas correspondentes",
+    "allTasks": "Todas as tarefas",
+    "inboxFiltersApplied": "Filtros da caixa de entrada aplicados",
+    "showAllInboxTasks": "Mostrar todas as tarefas da caixa de entrada",
+    "noSlotLargeEnough": "Nenhum espaço suficientemente grande para uma tarefa de {{minutes}} min",
+    "scheduleInFrame": "Agendar em {{frame}}",
+    "taskMinutes": "{{minutes}} min"
   },
   "routines": {
     "whatsInRoutine": "O que está na rotina de hoje?",

--- a/src/components/FrameScheduleModal.jsx
+++ b/src/components/FrameScheduleModal.jsx
@@ -1,18 +1,35 @@
-import React from 'react';
-import { Inbox, Calendar } from 'lucide-react';
+import React, { useState } from 'react';
+import { Inbox, Calendar, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { stripWikilinks } from '../utils/taskUtils.js';
+import { filterFrameScheduleTasks } from '../utils/frameScheduleTasks.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 
 const FrameScheduleModal = () => {
-  const { unscheduledTasks, manuallyScheduleTask, darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg } = useDayPlannerCtx();
-  const { frameScheduleModal, setFrameScheduleModal, computeAvailableSlots } = useFeaturesCtx();
+  const { unscheduledTasks, manuallyScheduleTask, darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg, inboxTagFilter, inboxProjectFilter } = useDayPlannerCtx();
+  const { frameScheduleModal, setFrameScheduleModal, computeAvailableSlots, isVisibleForUser, goalsProjectsEnabled } = useFeaturesCtx();
+  const { t } = useTranslation();
 
-  const inboxTasks = unscheduledTasks.filter(t => !t.completed && !t.isExample && (!t.deadline || t.deadline === frameScheduleModal.dateStr)).sort((a, b) => {
-    const aHasDeadline = a.deadline ? 1 : 0;
-    const bHasDeadline = b.deadline ? 1 : 0;
-    if (bHasDeadline !== aHasDeadline) return bHasDeadline - aHasDeadline;
-    return (b.priority || 0) - (a.priority || 0);
+  const tagAffinity = frameScheduleModal.frame.tagAffinity || [];
+  const hasAffinity = tagAffinity.length > 0;
+  // Default to affinity matching when the frame declares one
+  const [affinityOnly, setAffinityOnly] = useState(hasAffinity);
+  // The inbox project filter only exists when goals/projects is enabled
+  // (mirrors useComputedViews, which gates it the same way)
+  const effectiveProjectFilter = goalsProjectsEnabled ? inboxProjectFilter : [];
+  const inboxFiltersActive = inboxTagFilter.length > 0 || effectiveProjectFilter.length > 0;
+  // Local dismissal only; never mutates the persisted inbox filter state
+  const [applyInboxFilters, setApplyInboxFilters] = useState(true);
+
+  const inboxTasks = filterFrameScheduleTasks(unscheduledTasks, {
+    dateStr: frameScheduleModal.dateStr,
+    isVisibleForUser,
+    inboxTagFilter,
+    inboxProjectFilter: effectiveProjectFilter,
+    applyInboxFilters,
+    tagAffinity,
+    affinityOnly,
   });
   const frameInstance = {
     frameId: frameScheduleModal.frameId,
@@ -24,23 +41,56 @@ const FrameScheduleModal = () => {
   const availableSlots = computeAvailableSlots(frameInstance, new Date(frameScheduleModal.dateStr + 'T12:00:00'));
   const totalAvailable = availableSlots.reduce((sum, s) => sum + s.minutes, 0);
 
+  const segmentOn = darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900 shadow-sm';
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[70]" onClick={() => setFrameScheduleModal(null)}>
       <div className={`${cardBg} rounded-lg shadow-xl border ${borderClass} w-80 max-h-[70vh] flex flex-col`} onClick={(e) => e.stopPropagation()}>
         <div className={`p-4 border-b ${borderClass}`}>
-          <h3 className={`font-semibold ${textPrimary}`}>Manually Schedule</h3>
+          <h3 className={`font-semibold ${textPrimary}`}>{t('frames.manualSchedule')}</h3>
           <p className={`text-xs ${textSecondary} mt-1`}>
             {frameScheduleModal.frame.label} &middot; {frameScheduleModal.dateStr}
           </p>
           <p className="mt-1.5">
-            <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${darkMode ? 'bg-blue-900/40 text-blue-300' : 'bg-blue-100 text-blue-700'}`}>{totalAvailable}min available</span>
+            <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${darkMode ? 'bg-blue-900/40 text-blue-300' : 'bg-blue-100 text-blue-700'}`}>{t('frames.minAvailable', { minutes: totalAvailable })}</span>
           </p>
+          {hasAffinity && (
+            <div className={`flex rounded-lg ${darkMode ? 'bg-gray-800' : 'bg-stone-200'} p-0.5 mt-2`}>
+              <button
+                onClick={() => setAffinityOnly(true)}
+                className={`flex-1 py-1 rounded-md text-xs font-medium transition-colors ${affinityOnly ? segmentOn : textSecondary}`}
+              >
+                {t('frames.matchingTags')}
+              </button>
+              <button
+                onClick={() => setAffinityOnly(false)}
+                className={`flex-1 py-1 rounded-md text-xs font-medium transition-colors ${!affinityOnly ? segmentOn : textSecondary}`}
+              >
+                {t('frames.allTasks')}
+              </button>
+            </div>
+          )}
+          {inboxFiltersActive && applyInboxFilters && (
+            <p className="mt-2">
+              <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${darkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-100 text-amber-700'}`}>
+                {t('frames.inboxFiltersApplied')}
+                <button
+                  onClick={() => setApplyInboxFilters(false)}
+                  className="hover:opacity-70 transition-opacity"
+                  title={t('frames.showAllInboxTasks')}
+                  aria-label={t('frames.showAllInboxTasks')}
+                >
+                  <X size={12} />
+                </button>
+              </span>
+            </p>
+          )}
         </div>
         <div className="flex-1 overflow-y-auto p-2">
           {inboxTasks.length === 0 ? (
             <div className={`text-center py-8 ${textSecondary} text-sm`}>
               <Inbox size={24} className="mx-auto mb-2 opacity-50" />
-              No inbox tasks to schedule
+              {t('frames.noInboxTasks')}
             </div>
           ) : (
             inboxTasks.map(task => {
@@ -51,13 +101,13 @@ const FrameScheduleModal = () => {
                   className={`w-full text-left px-3 py-2.5 rounded-lg mb-1 transition-colors flex items-start gap-2 ${!fits ? 'opacity-50 cursor-not-allowed' : hoverBg}`}
                   onClick={() => fits && manuallyScheduleTask(task.id)}
                   disabled={!fits}
-                  title={!fits ? `No slot large enough for ${task.duration || 30}min task` : `Schedule in ${frameScheduleModal.frame.label}`}
+                  title={!fits ? t('frames.noSlotLargeEnough', { minutes: task.duration || 30 }) : t('frames.scheduleInFrame', { frame: frameScheduleModal.frame.label })}
                 >
                   <div className={`w-2 h-2 rounded-full mt-1.5 flex-shrink-0 ${task.color || 'bg-blue-500'}`} />
                   <div className="flex-1 min-w-0">
                     <div className={`text-sm ${textPrimary} truncate`}>{stripWikilinks(task.title)}</div>
                     <div className={`text-xs ${textSecondary} flex items-center gap-2 mt-0.5`}>
-                      <span>{task.duration || 30}min</span>
+                      <span>{t('frames.taskMinutes', { minutes: task.duration || 30 })}</span>
                       {task.priority >= 1 && <span className={task.priority >= 2 ? 'text-red-500' : 'text-amber-500'}>P{task.priority}</span>}
                       {task.deadline && <span className="flex items-center gap-0.5"><Calendar size={10} />{task.deadline}</span>}
                     </div>
@@ -68,7 +118,7 @@ const FrameScheduleModal = () => {
           )}
         </div>
         <div className={`p-3 border-t ${borderClass}`}>
-          <button onClick={() => setFrameScheduleModal(null)} className={`w-full px-3 py-2 rounded-lg text-sm ${textSecondary} ${hoverBg} transition-colors`}>Cancel</button>
+          <button onClick={() => setFrameScheduleModal(null)} className={`w-full px-3 py-2 rounded-lg text-sm ${textSecondary} ${hoverBg} transition-colors`}>{t('common.cancel')}</button>
         </div>
       </div>
     </div>

--- a/src/utils/frameScheduleTasks.js
+++ b/src/utils/frameScheduleTasks.js
@@ -1,0 +1,52 @@
+import { extractTags } from './taskUtils.js';
+
+// Builds the task list for the Manually Schedule (frame schedule) modal.
+//
+// Filtering rules, in order:
+// - never show completed or example tasks (pre-existing behavior)
+// - only tasks visible to the current user (same isVisibleForUser rule
+//   applied by every other surface: visible when multi-user is off, the task
+//   is unassigned, or it is assigned to "me")
+// - only tasks with no deadline or a deadline on the frame's date
+// - when applyInboxFilters is true, mirror the inbox list's own filters
+//   (see useComputedViews.filteredUnscheduledTasks):
+//   - inboxProjectFilter non-empty: keep only tasks in one of those projects
+//   - inboxTagFilter non-empty: keep only tasks whose #tags match one
+// - when affinityOnly is true and the frame has a tagAffinity, keep only
+//   tasks whose #tags contain at least one affinity tag (the same exact-tag
+//   rule Smart Schedule's auto-fill prompt applies)
+//
+// Sort: tasks with a deadline first, then by priority (descending).
+export function filterFrameScheduleTasks(unscheduledTasks, {
+  dateStr,
+  isVisibleForUser = () => true,
+  inboxTagFilter = [],
+  inboxProjectFilter = [],
+  applyInboxFilters = false,
+  tagAffinity = [],
+  affinityOnly = false,
+} = {}) {
+  return (unscheduledTasks || [])
+    .filter(t => !t.completed && !t.isExample && (!t.deadline || t.deadline === dateStr))
+    .filter(t => isVisibleForUser(t))
+    .filter(t => {
+      if (!applyInboxFilters) return true;
+      if (inboxProjectFilter.length > 0 && !(t.projectId && inboxProjectFilter.includes(t.projectId))) return false;
+      if (inboxTagFilter.length > 0) {
+        const taskTags = extractTags(t.title);
+        return inboxTagFilter.some(tag => taskTags.includes(tag));
+      }
+      return true;
+    })
+    .filter(t => {
+      if (!affinityOnly || tagAffinity.length === 0) return true;
+      const taskTags = extractTags(t.title);
+      return tagAffinity.some(tag => taskTags.includes(tag));
+    })
+    .sort((a, b) => {
+      const aHasDeadline = a.deadline ? 1 : 0;
+      const bHasDeadline = b.deadline ? 1 : 0;
+      if (bHasDeadline !== aHasDeadline) return bHasDeadline - aHasDeadline;
+      return (b.priority || 0) - (a.priority || 0);
+    });
+}

--- a/src/utils/frameScheduleTasks.test.js
+++ b/src/utils/frameScheduleTasks.test.js
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import { filterFrameScheduleTasks } from './frameScheduleTasks.js';
+
+const DATE = '2026-07-10';
+
+const task = (id, overrides = {}) => ({ id, title: `Task ${id}`, ...overrides });
+const ids = (list) => list.map(t => t.id);
+
+describe('filterFrameScheduleTasks', () => {
+  describe('base rules (pre-existing behavior preserved)', () => {
+    it('excludes completed and example tasks', () => {
+      const tasks = [
+        task('a'),
+        task('b', { completed: true }),
+        task('c', { isExample: true }),
+      ];
+      expect(ids(filterFrameScheduleTasks(tasks, { dateStr: DATE }))).toEqual(['a']);
+    });
+
+    it('keeps tasks with no deadline or a deadline on the frame date, drops others', () => {
+      const tasks = [
+        task('none'),
+        task('today', { deadline: DATE }),
+        task('other', { deadline: '2026-07-11' }),
+      ];
+      expect(ids(filterFrameScheduleTasks(tasks, { dateStr: DATE }))).toEqual(['today', 'none']);
+    });
+
+    it('sorts deadline tasks first, then by priority descending', () => {
+      const tasks = [
+        task('p1', { priority: 1 }),
+        task('p2', { priority: 2 }),
+        task('d0', { deadline: DATE }),
+        task('d2', { deadline: DATE, priority: 2 }),
+        task('p0'),
+      ];
+      expect(ids(filterFrameScheduleTasks(tasks, { dateStr: DATE }))).toEqual(['d2', 'd0', 'p2', 'p1', 'p0']);
+    });
+
+    it('tolerates null input', () => {
+      expect(filterFrameScheduleTasks(null, { dateStr: DATE })).toEqual([]);
+    });
+  });
+
+  describe('user visibility', () => {
+    // Mirrors App.jsx isVisibleForUser: multi-user on, me = 'u1'
+    const isVisibleForUser = (t) => {
+      const assigned = t.assignedUserSyncIds ?? [];
+      return assigned.length === 0 || assigned.includes('u1');
+    };
+
+    it('always applies isVisibleForUser: hides tasks assigned only to others', () => {
+      const tasks = [
+        task('mine', { assignedUserSyncIds: ['u1'] }),
+        task('theirs', { assignedUserSyncIds: ['u2'] }),
+        task('shared', { assignedUserSyncIds: ['u1', 'u2'] }),
+      ];
+      expect(ids(filterFrameScheduleTasks(tasks, { dateStr: DATE, isVisibleForUser })))
+        .toEqual(['mine', 'shared']);
+    });
+
+    it('keeps unassigned tasks visible in multi-user mode', () => {
+      const tasks = [task('unassigned'), task('theirs', { assignedUserSyncIds: ['u2'] })];
+      expect(ids(filterFrameScheduleTasks(tasks, { dateStr: DATE, isVisibleForUser })))
+        .toEqual(['unassigned']);
+    });
+
+    it('shows everything when visibility is not constrained (multi-user off)', () => {
+      const tasks = [task('a', { assignedUserSyncIds: ['u2'] }), task('b')];
+      expect(ids(filterFrameScheduleTasks(tasks, { dateStr: DATE }))).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('inbox filters', () => {
+    const tasks = [
+      task('work', { title: 'Ship it #work' }),
+      task('home', { title: 'Laundry #home' }),
+      task('plain', { title: 'No tags here' }),
+      task('proj', { title: 'Project task', projectId: 'p1' }),
+    ];
+
+    it('applies the inbox tag filter when active (same any-match rule as the inbox list)', () => {
+      const out = filterFrameScheduleTasks(tasks, {
+        dateStr: DATE, applyInboxFilters: true, inboxTagFilter: ['work'],
+      });
+      expect(ids(out)).toEqual(['work']);
+    });
+
+    it('applies the inbox project filter when active (task must belong to a selected project)', () => {
+      const out = filterFrameScheduleTasks(tasks, {
+        dateStr: DATE, applyInboxFilters: true, inboxProjectFilter: ['p1'],
+      });
+      expect(ids(out)).toEqual(['proj']);
+    });
+
+    it('ignores inbox filters when applyInboxFilters is false (chip dismissed)', () => {
+      const out = filterFrameScheduleTasks(tasks, {
+        dateStr: DATE, applyInboxFilters: false, inboxTagFilter: ['work'], inboxProjectFilter: ['p1'],
+      });
+      expect(ids(out)).toEqual(['work', 'home', 'plain', 'proj']);
+    });
+
+    it('empty inbox filters do not restrict the list even when applied', () => {
+      const out = filterFrameScheduleTasks(tasks, { dateStr: DATE, applyInboxFilters: true });
+      expect(ids(out)).toEqual(['work', 'home', 'plain', 'proj']);
+    });
+  });
+
+  describe('frame tag affinity', () => {
+    const tasks = [
+      task('deep', { title: 'Write spec #deep' }),
+      task('both', { title: 'Review #deep #admin' }),
+      task('admin', { title: 'Expenses #admin' }),
+      task('plain', { title: 'Untagged task' }),
+    ];
+
+    it('affinityOnly keeps only tasks whose tags match the frame affinity', () => {
+      const out = filterFrameScheduleTasks(tasks, {
+        dateStr: DATE, tagAffinity: ['deep'], affinityOnly: true,
+      });
+      expect(ids(out)).toEqual(['deep', 'both']);
+    });
+
+    it('matches any affinity tag (exact-tag any-match, like auto-fill)', () => {
+      const out = filterFrameScheduleTasks(tasks, {
+        dateStr: DATE, tagAffinity: ['deep', 'admin'], affinityOnly: true,
+      });
+      expect(ids(out)).toEqual(['deep', 'both', 'admin']);
+    });
+
+    it('affinity matching is case-insensitive on task titles (tags are extracted lowercased)', () => {
+      const out = filterFrameScheduleTasks([task('caps', { title: 'Focus #Deep' })], {
+        dateStr: DATE, tagAffinity: ['deep'], affinityOnly: true,
+      });
+      expect(ids(out)).toEqual(['caps']);
+    });
+
+    it('toggle off ("All tasks") shows everything regardless of affinity', () => {
+      const out = filterFrameScheduleTasks(tasks, {
+        dateStr: DATE, tagAffinity: ['deep'], affinityOnly: false,
+      });
+      expect(ids(out)).toEqual(['deep', 'both', 'admin', 'plain']);
+    });
+
+    it('affinityOnly with an empty affinity is a no-op', () => {
+      const out = filterFrameScheduleTasks(tasks, {
+        dateStr: DATE, tagAffinity: [], affinityOnly: true,
+      });
+      expect(ids(out)).toEqual(['deep', 'both', 'admin', 'plain']);
+    });
+  });
+
+  it('composes all filters: visibility, inbox filters, affinity, deadline, sort', () => {
+    const isVisibleForUser = (t) => {
+      const assigned = t.assignedUserSyncIds ?? [];
+      return assigned.length === 0 || assigned.includes('u1');
+    };
+    const tasks = [
+      task('keep-deadline', { title: 'A #work', deadline: DATE, priority: 1 }),
+      task('keep-priority', { title: 'B #work', priority: 2 }),
+      task('keep-low', { title: 'C #work' }),
+      task('wrong-user', { title: 'D #work', assignedUserSyncIds: ['u2'] }),
+      task('wrong-tag', { title: 'E #home' }),
+      task('no-affinity', { title: 'F #work #other' }),
+      task('wrong-deadline', { title: 'G #work', deadline: '2026-08-01' }),
+      task('done', { title: 'H #work', completed: true }),
+    ];
+    const out = filterFrameScheduleTasks(tasks, {
+      dateStr: DATE,
+      isVisibleForUser,
+      applyInboxFilters: true,
+      inboxTagFilter: ['work', 'home'],
+      tagAffinity: ['work'],
+      affinityOnly: true,
+    });
+    expect(ids(out)).toEqual(['keep-deadline', 'keep-priority', 'keep-low', 'no-affinity']);
+  });
+});


### PR DESCRIPTION
Fixes the three issues with the GTD Frames "Manually Schedule" modal:

1. **Multi-user respected** — the task list now applies the shared `isVisibleForUser` rule (already exposed via FeaturesContext), so other members' assigned tasks no longer appear. Always on, matching every other surface.
2. **Inbox filters auto-applied** — when the persisted `inboxTagFilter`/`inboxProjectFilter` are active, the modal applies them with the exact semantics `useComputedViews` uses for the inbox itself (including the goals/projects feature gating). A dismissible chip in the modal shows "Inbox filters applied"; its X clears them for this modal only, never mutating the persisted inbox state, so a filtered-short list is always explained and always escapable.
3. **Affinity toggle** — a "Matching tags / All tasks" segmented control (styled after FramesModal's existing segments) renders when the frame declares a `tagAffinity`, defaulting to Matching. The matcher mirrors what Smart Schedule instructs the AI to do (exact tag, any-match, case-insensitive via `extractTags`), so manual and automatic scheduling agree on what "matches" means. Frames without affinity see no toggle.

Implementation notes:
- All list-derivation extracted to a pure helper (`src/utils/frameScheduleTasks.js`) preserving the existing rules exactly (completed/example exclusion, deadline empty-or-today, deadline-then-priority sort) — 17 unit tests cover visibility, filters, affinity, and their composition.
- The modal's hardcoded English (it predated the i18n sweep) now goes through `t()`: 10 new `frames.*` keys translated in all six locales, key sets identical (745 each), no em dashes.
- Affinity default re-evaluates per opening (the modal is conditionally mounted, verified at App.jsx:10707).

## Verification
- `npm test`: 745/745 (17 new) · lint clean · six locales parse and key-match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_