### PR TITLE
Gate the Multi-User toggle behind cloud sync being configured

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -231,6 +231,7 @@
     "multiUserMode": "Mehrbenutzer-Modus",
     "multiUserModeHint": "Aufgaben bestimmten Haushaltsmitgliedern zuweisen",
     "multiUserPeople": "Personen",
+    "multiUserRequiresSync": "Erfordert Cloud-Synchronisierung. Richten Sie zuerst GLANCEvault oder WebDAV-Synchronisierung ein.",
     "usersSyncPath": "Benutzer-Synchronisierungspfad",
     "syncFailed": "Fehlgeschlagen",
     "aiFeatures": "KI-Funktionen",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -231,6 +231,7 @@
     "multiUserMode": "Multi-user mode",
     "multiUserModeHint": "Tag chores with specific household members",
     "multiUserPeople": "People",
+    "multiUserRequiresSync": "Requires cloud sync. Set up GLANCEvault or WebDAV sync first.",
     "usersSyncPath": "Users sync path",
     "syncFailed": "Failed",
     "aiFeatures": "AI Features",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -231,6 +231,7 @@
     "multiUserMode": "Modo multiusuario",
     "multiUserModeHint": "Asigna tareas domésticas a miembros del hogar",
     "multiUserPeople": "Personas",
+    "multiUserRequiresSync": "Requiere sincronización en la nube. Configura primero GLANCEvault o la sincronización WebDAV.",
     "usersSyncPath": "Ruta de sincronización de usuarios",
     "syncFailed": "Error",
     "aiFeatures": "Funciones de IA",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -231,6 +231,7 @@
     "multiUserMode": "Mode multi-utilisateur",
     "multiUserModeHint": "Attribuez des tâches à des membres du foyer",
     "multiUserPeople": "Personnes",
+    "multiUserRequiresSync": "Nécessite la synchronisation cloud. Configurez d'abord GLANCEvault ou la synchronisation WebDAV.",
     "usersSyncPath": "Chemin de synchronisation des utilisateurs",
     "syncFailed": "Échec",
     "aiFeatures": "Fonctionnalités IA",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -231,6 +231,7 @@
     "multiUserMode": "Modalità multiutente",
     "multiUserModeHint": "Assegna attività domestiche a membri della famiglia",
     "multiUserPeople": "Persone",
+    "multiUserRequiresSync": "Richiede la sincronizzazione cloud. Configura prima GLANCEvault o la sincronizzazione WebDAV.",
     "usersSyncPath": "Percorso sincronizzazione utenti",
     "syncFailed": "Fallito",
     "aiFeatures": "Funzioni IA",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -231,6 +231,7 @@
     "multiUserMode": "Modo multiutilizador",
     "multiUserModeHint": "Atribuir tarefas domésticas a membros da família",
     "multiUserPeople": "Pessoas",
+    "multiUserRequiresSync": "Requer sincronização na nuvem. Configure primeiro o GLANCEvault ou a sincronização WebDAV.",
     "usersSyncPath": "Caminho de sincronização de utilizadores",
     "syncFailed": "Falhou",
     "aiFeatures": "Funcionalidades de IA",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,6 +80,7 @@ import { createDayGlanceEngine } from './sync/adapter.js';
 import { createDbEngine, resetVaultSyncCursor } from './sync/dbEngine.js';
 import { registerDbEngine } from './sync/dirtyTracker.js';
 import { isVaultEnabled } from './sync/vaultConfig.js';
+import { canEnableMultiUser } from './utils/multiUserGate.js';
 import { encryptData, decryptData, isEncryptedEnvelope, hasEncryptionReady } from './utils/crypto.js';
 import useCalendarSync from './hooks/useCalendarSync.js';
 import useBackup from './hooks/useBackup.js';
@@ -9229,6 +9230,15 @@ const DayPlanner = () => {
 
     // ── Multi-user ────────────────────────────────────────────────────────────
     multiUserEnabled, setMultiUserEnabled,
+    // Reactive: cloudSyncConfig is state, so this recomputes on every WebDAV
+    // config change. isVaultEnabled() reads localStorage, but a vault
+    // enable/disable always reloads the app (CloudSyncSettingsForm), so a
+    // render-time read is current. Multi-user is meaningless without one of
+    // these sync tiers, so settings gate the toggle on it.
+    cloudSyncConfigured: canEnableMultiUser({
+      cloudSyncEnabled: cloudSyncConfig?.enabled,
+      vaultEnabled: isVaultEnabled(),
+    }),
     users, setUsers,
     meUserSyncId, setMeUserSyncId,
     isVisibleForUser,

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -23,6 +23,7 @@ import UserOwnerSwitcher from './UserOwnerSwitcher.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { isVaultEnabled } from '../sync/vaultConfig.js';
+import { multiUserToggleLocked } from '../utils/multiUserGate.js';
 import { getDbIntentsConfig, setDbIntentsConfig, getDbIntentsConnection } from '../intents/dbIntentsConfig.js';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from '../intents/useIntentPoller.js';
@@ -122,7 +123,10 @@ const MobileSettingsPanel = () => {
     applyReminderPreset, updateCategoryReminder,
     users, setUsers, meUserSyncId, setMeUserSyncId,
     multiUserEnabled, setMultiUserEnabled,
+    cloudSyncConfigured,
   } = useFeaturesCtx();
+  // Gate multi-user when sync is unconfigured; never trap an already-on toggle.
+  const multiUserLocked = multiUserToggleLocked({ cloudSyncConfigured, multiUserEnabled });
 
   const [intentForm, setIntentForm] = useState(() => {
     const raw = localStorage.getItem(INTENT_CONFIG_KEY);
@@ -2645,18 +2649,22 @@ const MobileSettingsPanel = () => {
         </div>
         <button
           type="button"
+          disabled={multiUserLocked}
           onClick={() => {
             const next = !multiUserEnabled;
             setMultiUserEnabled(next);
             localStorage.setItem('dayglance-multi-user-enabled', JSON.stringify(next));
           }}
-          className={`relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors ${multiUserEnabled ? 'bg-green-500' : darkMode ? 'bg-gray-600' : 'bg-stone-300'}`}
+          className={`relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors ${multiUserEnabled ? 'bg-green-500' : darkMode ? 'bg-gray-600' : 'bg-stone-300'} ${multiUserLocked ? 'opacity-60 cursor-not-allowed' : ''}`}
           role="switch"
           aria-checked={multiUserEnabled}
         >
           <span className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform transition-transform ${multiUserEnabled ? 'translate-x-5' : 'translate-x-0'}`} />
         </button>
       </div>
+      {!cloudSyncConfigured && (
+        <p className={`text-xs ${textSecondary} -mt-2`}>{t('settings.multiUserRequiresSync')}</p>
+      )}
       <div className="flex items-center justify-between gap-3">
         <p className={`text-xs ${textSecondary}`}>Share dayGLANCE with your household. Tasks can be assigned to specific people; unassigned tasks are visible to everyone.</p>
         {(cloudSyncConfig?.enabled || isICloudAvailable()) && (

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -15,6 +15,7 @@ import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUser
 import { isAvailable as isICloudAvailable } from '../intents/icloudFileTransport.js';
 import { getSyncPassphrase, setSyncPassphrase } from '../utils/crypto.js';
 import { isVaultEnabled } from '../sync/vaultConfig.js';
+import { multiUserToggleLocked } from '../utils/multiUserGate.js';
 import { getDbIntentsConfig, setDbIntentsConfig, getDbIntentsConnection } from '../intents/dbIntentsConfig.js';
 import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
 import { ensureVaultIntentsKey, setupVaultIntentsEncryption } from '../intents/vaultIntentsSetup.js';
@@ -80,9 +81,14 @@ const SettingsModal = () => {
     aiConnectionStatus, setAiConnectionStatus, aiConnectionMessage, setAiConnectionMessage,
     aiOllamaHelp, setAiOllamaHelp,
     multiUserEnabled, setMultiUserEnabled,
+    cloudSyncConfigured,
     users, setUsers,
     meUserSyncId, setMeUserSyncId,
   } = useFeaturesCtx();
+  // Multi-user only matters across synced devices; gate the toggle when sync is
+  // unconfigured. Never trap: an already-on toggle stays enabled so it can be
+  // turned off.
+  const multiUserLocked = multiUserToggleLocked({ cloudSyncConfigured, multiUserEnabled });
   const [addingUser, setAddingUser] = useState(false);
   const [newUserName, setNewUserName] = useState('');
   const [editingUserId, setEditingUserId] = useState(null);
@@ -1014,18 +1020,22 @@ const SettingsModal = () => {
                             </div>
                             <button
                               type="button"
+                              disabled={multiUserLocked}
                               onClick={() => {
                                 const next = !multiUserEnabled;
                                 setMultiUserEnabled(next);
                                 localStorage.setItem('dayglance-multi-user-enabled', JSON.stringify(next));
                               }}
-                              className={`relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors ${multiUserEnabled ? 'bg-green-500' : darkMode ? 'bg-gray-600' : 'bg-stone-300'}`}
+                              className={`relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors ${multiUserEnabled ? 'bg-green-500' : darkMode ? 'bg-gray-600' : 'bg-stone-300'} ${multiUserLocked ? 'opacity-60 cursor-not-allowed' : ''}`}
                               role="switch"
                               aria-checked={multiUserEnabled}
                             >
                               <span className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform transition-transform ${multiUserEnabled ? 'translate-x-5' : 'translate-x-0'}`} />
                             </button>
                           </div>
+                          {!cloudSyncConfigured && (
+                            <p className={`text-xs ${textSecondary} -mt-2`}>{t('settings.multiUserRequiresSync')}</p>
+                          )}
                           <div className="flex items-center justify-between gap-3">
                             <p className={`${textSecondary} text-xs`}>
                               Share dayGLANCE with your household. Tasks can be assigned to specific people; unassigned tasks are visible to everyone.

--- a/src/utils/multiUserGate.js
+++ b/src/utils/multiUserGate.js
@@ -1,0 +1,28 @@
+// Multi-user gating. Multi-user (users/assignments) only does anything across
+// synced devices, so it is useless without cloud sync configured — either the
+// WebDAV file tier (cloudSyncConfig.enabled) or the GLANCEvault DB tier
+// (isVaultEnabled). These helpers centralize the "requires sync" rule and,
+// crucially, the never-trap rule so both settings surfaces behave identically.
+
+/**
+ * Whether cloud sync is configured enough to make multi-user meaningful.
+ * @param {{cloudSyncEnabled?: boolean, vaultEnabled?: boolean}} opts
+ * @returns {boolean}
+ */
+export function canEnableMultiUser({ cloudSyncEnabled, vaultEnabled } = {}) {
+  return !!(cloudSyncEnabled || vaultEnabled);
+}
+
+/**
+ * Whether the multi-user toggle should be rendered disabled.
+ *
+ * Disabled only when sync is unconfigured AND multi-user is currently off.
+ * Never trap: if multi-user is already on (legacy state, or sync was turned off
+ * after enabling it), the toggle stays enabled so the user can turn it back off.
+ *
+ * @param {{cloudSyncConfigured?: boolean, multiUserEnabled?: boolean}} opts
+ * @returns {boolean}
+ */
+export function multiUserToggleLocked({ cloudSyncConfigured, multiUserEnabled } = {}) {
+  return !cloudSyncConfigured && !multiUserEnabled;
+}

--- a/src/utils/multiUserGate.test.js
+++ b/src/utils/multiUserGate.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { canEnableMultiUser, multiUserToggleLocked } from './multiUserGate.js';
+
+describe('canEnableMultiUser', () => {
+  it('is false when neither sync tier is configured', () => {
+    expect(canEnableMultiUser({ cloudSyncEnabled: false, vaultEnabled: false })).toBe(false);
+    expect(canEnableMultiUser({})).toBe(false);
+    expect(canEnableMultiUser()).toBe(false);
+  });
+
+  it('is true when the WebDAV file tier is enabled', () => {
+    expect(canEnableMultiUser({ cloudSyncEnabled: true, vaultEnabled: false })).toBe(true);
+  });
+
+  it('is true when the GLANCEvault tier is enabled', () => {
+    expect(canEnableMultiUser({ cloudSyncEnabled: false, vaultEnabled: true })).toBe(true);
+  });
+});
+
+describe('multiUserToggleLocked (never-trap rule)', () => {
+  it('locks the toggle only when sync is unconfigured and multi-user is off', () => {
+    expect(multiUserToggleLocked({ cloudSyncConfigured: false, multiUserEnabled: false })).toBe(true);
+  });
+
+  it('stays unlocked when sync is configured', () => {
+    expect(multiUserToggleLocked({ cloudSyncConfigured: true, multiUserEnabled: false })).toBe(false);
+    expect(multiUserToggleLocked({ cloudSyncConfigured: true, multiUserEnabled: true })).toBe(false);
+  });
+
+  it('never traps: stays unlocked when multi-user is already on despite unconfigured sync', () => {
+    expect(multiUserToggleLocked({ cloudSyncConfigured: false, multiUserEnabled: true })).toBe(false);
+  });
+});


### PR DESCRIPTION
Multi-user only matters across synced devices, but its toggle was live on desktop and mobile even with no sync configured — inviting users to enable a feature that can't do anything.

- **Disabled, not hidden**: when neither sync tier is configured (WebDAV `cloudSyncConfig.enabled` or GLANCEvault `isVaultEnabled()`), the toggle renders disabled with a hint: "Requires cloud sync. Set up GLANCEvault or WebDAV sync first." (translated in all six locales). The feature stays discoverable and the reason is explicit.
- **Never traps state**: if multi-user is already on and sync is later unconfigured, the toggle stays enabled so it can be turned off (hint still shows). Nothing auto-flips the user's setting. This rule is pinned by unit tests in the new `multiUserGate.js` helper.
- **Reactive signal**: `cloudSyncConfigured` is computed in the FeaturesContext value from React state (WebDAV) plus a render-time `isVaultEnabled()` read — safe because vault link changes always reload the app, the same established pattern the sync context already uses.

## Verification
- `npm test`: 751/751 (6 new) · lint clean · six locales parse with identical key sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_