### PR TITLE
Android: fix web-assets guard breaking every build at configuration time

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -114,7 +114,16 @@ androidComponents {
                 }
             }
         }
-        tasks.named("merge${capName}Assets").configure { dependsOn(verifyWebAssets) }
+        // The variant's tasks are NOT yet registered while onVariants runs (AGP
+        // creates them after the variant API callbacks), so tasks.named() here
+        // throws "Task with name 'mergeXxxAssets' not found" at configuration
+        // time and breaks every build. configureEach is lazy: it also applies to
+        // tasks created later, so the dependency attaches when AGP registers the
+        // merge task.
+        val mergeTaskName = "merge${capName}Assets"
+        tasks.configureEach {
+            if (name == mergeTaskName) dependsOn(verifyWebAssets)
+        }
     }
 }
 


### PR DESCRIPTION
The #1166 web-assets guard wired its task dependency with `tasks.named("merge${Variant}Assets")` **inside** `onVariants` — but AGP registers a variant's tasks *after* the variant-API callbacks run, so the lookup threw at configuration time and failed every build, debug included:

```
Task with name 'mergePlayReleaseAssets' not found in project ':app'.
```

Fix: attach the dependency via `tasks.configureEach { if (name == mergeTaskName) dependsOn(verifyWebAssets) }`, which applies lazily to tasks as AGP creates them. The verify task itself (release-only, clear error pointing at `npm run build:android`) is unchanged.

Verification here is by reading only (no Android SDK in this environment). Please confirm locally, in order:
1. `assembleDebug` (or a debug run) succeeds — this was the "breaks every build" symptom
2. Release build **without** `assets/web/` fails with the guard's message (the guard's intended behavior, now actually reachable)
3. Release build with assets succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_