### PR TITLE
bump-version: add --code-only mode for internal-test-track uploads

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,6 +29,16 @@ and `versionCode` (+1), and the README shields.io badge. iOS
 `package.json` at build time, so they need no manual edit. Review the diff and
 commit the bump before building.
 
+For an internal-test-track upload that needs a fresh `versionCode` without
+moving the marketing version (Play rejects a re-used `versionCode`), bump the
+code alone:
+
+```
+npm run bump -- --code-only   # Android versionCode +1, nothing else
+```
+
+Commit that one-line change before building the test AAB/APK.
+
 ### 1.2 Quality gates
 
 ```

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -20,12 +20,20 @@
 // Behavior:
 //   node scripts/bump-version.mjs 4.0.0            # bump for real
 //   node scripts/bump-version.mjs 4.0.0 --dry-run  # print, write nothing
+//   node scripts/bump-version.mjs --code-only      # bump ONLY the Android
+//                                                  # versionCode (+1), for
+//                                                  # test-track uploads
+//
+// --code-only takes no version argument and touches nothing but the Android
+// versionCode. Use it for internal-test-track builds that need a fresh
+// versionCode without disturbing the marketing version across platforms.
 //
 // It validates the arg is semver x.y.z, prints every change old -> new, and
 // ERRORS loudly if any expected pattern is missing rather than silently
 // no-op'ing. It does NOT git-commit or tag — that stays a human step.
 //
 // Usage:  npm run bump 4.0.0   (alias for this script)
+//         npm run bump -- --code-only
 
 import fs from 'fs';
 import path from 'path';
@@ -37,6 +45,7 @@ const ROOT = path.resolve(__dirname, '..');
 // ── Args ────────────────────────────────────────────────────────────────
 const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
+const codeOnly = args.includes('--code-only');
 const version = args.find((a) => !a.startsWith('--'));
 
 function die(msg) {
@@ -44,13 +53,18 @@ function die(msg) {
   process.exit(1);
 }
 
-if (!version) {
-  die('missing version argument. Usage: node scripts/bump-version.mjs X.Y.Z [--dry-run]');
-}
-
-// Strict semver x.y.z — no prerelease/build metadata, no leading "v".
-if (!/^\d+\.\d+\.\d+$/.test(version)) {
-  die(`"${version}" is not a valid X.Y.Z version (expected e.g. 4.0.0).`);
+if (codeOnly) {
+  if (version) {
+    die('--code-only bumps only the Android versionCode and takes no version argument.');
+  }
+} else {
+  if (!version) {
+    die('missing version argument. Usage: node scripts/bump-version.mjs X.Y.Z [--dry-run] | --code-only');
+  }
+  // Strict semver x.y.z — no prerelease/build metadata, no leading "v".
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    die(`"${version}" is not a valid X.Y.Z version (expected e.g. 4.0.0).`);
+  }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────
@@ -76,6 +90,45 @@ function sub(text, re, replacer, { file, label, to }) {
   return next;
 }
 
+// Bump the Android versionCode (monotonic integer for the Play Store) by 1.
+// Shared by the full bump and --code-only. Returns the rewritten gradle text.
+const codeRe = /(versionCode\s*=\s*)(\d+)/;
+function bumpVersionCode(gradleRel, gradleTextIn) {
+  const codeMatch = gradleTextIn.match(codeRe);
+  if (!codeMatch) {
+    die(`could not find versionCode in ${gradleRel}. Aborting — no files written.`);
+  }
+  const oldCode = parseInt(codeMatch[2], 10);
+  const newCode = oldCode + 1;
+  changes.push({ file: gradleRel, label: 'versionCode', from: String(oldCode), to: String(newCode) });
+  return gradleTextIn.replace(codeRe, (_all, pre) => `${pre}${newCode}`);
+}
+
+// ── --code-only: bump the Android versionCode and stop ────────────────────
+const gradleRel = 'dayglance-android/app/build.gradle.kts';
+
+if (codeOnly) {
+  const gradle = read(gradleRel);
+  const gradleText = bumpVersionCode(gradleRel, gradle.text);
+
+  console.log(`bump-version: bumping Android versionCode only${dryRun ? '  (dry run — nothing written)' : ''}\n`);
+  for (const c of changes) {
+    console.log(`  ${c.file}`);
+    console.log(`    ${c.label}: ${c.from} -> ${c.to}`);
+  }
+  console.log('');
+
+  if (dryRun) {
+    console.log('Dry run complete. Re-run without --dry-run to write this change.');
+    process.exit(0);
+  }
+  fs.writeFileSync(gradle.abs, gradleText);
+  console.log('File written.\n');
+  console.log('The marketing version is unchanged; only the Android versionCode moved.');
+  console.log('Build the release AAB/APK for your internal test track as usual.');
+  process.exit(0);
+}
+
 // ── 1. package.json ──────────────────────────────────────────────────────
 const pkg = read('package.json');
 const pkgText = sub(
@@ -89,7 +142,6 @@ const pkgText = sub(
 // versionName is unified to the full x.y.z. It had previously been "3.10"
 // (no patch component), which drifts from package.json's x.y.z and makes the
 // Play Store listing look out of step with iOS/Electron. Always write x.y.z.
-const gradleRel = 'dayglance-android/app/build.gradle.kts';
 const gradle = read(gradleRel);
 let gradleText = sub(
   gradle.text,
@@ -100,15 +152,7 @@ let gradleText = sub(
 
 // versionCode is a monotonically increasing integer for the Play Store;
 // increment it by 1 rather than deriving it from the marketing version.
-const codeRe = /(versionCode\s*=\s*)(\d+)/;
-const codeMatch = gradle.text.match(codeRe);
-if (!codeMatch) {
-  die(`could not find versionCode in ${gradleRel}. Aborting — no files written.`);
-}
-const oldCode = parseInt(codeMatch[2], 10);
-const newCode = oldCode + 1;
-gradleText = gradleText.replace(codeRe, (_all, pre) => `${pre}${newCode}`);
-changes.push({ file: gradleRel, label: 'versionCode', from: String(oldCode), to: String(newCode) });
+gradleText = bumpVersionCode(gradleRel, gradleText);
 
 // ── 3. README.md shields.io badge ─────────────────────────────────────────
 // e.g.  https://img.shields.io/badge/version-3.10.0-green.svg


### PR DESCRIPTION
Play rejects a re-used `versionCode`, so uploading a release build to the internal test track needs a fresh code — but you don't want to move the cross-platform marketing version (package.json → iOS/Electron) for a throwaway test build.

Adds `--code-only`:

```
npm run bump -- --code-only              # Android versionCode +1, nothing else
npm run bump -- --code-only --dry-run    # preview
```

- Bumps only the Android `versionCode`; leaves package.json, `versionName`, and the README badge untouched.
- Takes no version argument and errors if given one (`--code-only 4.0.0` is rejected).
- Reuses the same `versionCode` increment logic as the full bump (extracted to a shared helper), so the two paths can't drift.
- Full-bump behavior is byte-for-byte unchanged. Documented in RELEASING.md.

Verified all modes: `--code-only` dry-run and real (164 → 165), the reject-with-version case, and the unchanged full-bump dry-run. This PR itself contains no version change — the script is the deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_