### PR TITLE
Move privacy policy URL to glance-apps.com/dayglance/privacy; add Legal to Help modal

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/PermissionsRationaleActivity.kt
@@ -55,7 +55,7 @@ class PermissionsRationaleActivity : AppCompatActivity() {
                         .build()
                 )
                 .build()
-                .launchUrl(this, Uri.parse("https://docs.dayglance.app/en/privacy-policy"))
+                .launchUrl(this, Uri.parse("https://glance-apps.com/dayglance/privacy"))
         }
     }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -538,7 +538,14 @@ ipcMain.on('ws:push-state', (event) => {
 // build (CFBundleShortVersionString + CFBundleVersion).
 app.setAboutPanelOptions({
   copyright: 'Copyright © 2026 GLANCE Apps',
-  credits: 'Support: support@glance-apps.com\nWeb: https://www.glance-apps.com/',
+  // credits is a plain string (Electron doesn't accept an attributed/RTF value
+  // here), so the URLs render as readable, copyable text rather than links.
+  credits: [
+    'Support: support@glance-apps.com',
+    'Web: https://www.glance-apps.com/',
+    'Privacy: https://glance-apps.com/dayglance/privacy',
+    'Terms: https://www.glance-apps.com/eula',
+  ].join('\n'),
 });
 
 // Single-instance lock: only one dayGLANCE process may run at a time. A second

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -720,6 +720,7 @@
     "helpFeedback": "Hilfe & Feedback",
     "documentation": "Dokumentation",
     "contactIssues": "Kontakt & Probleme",
+    "legal": "Rechtliches",
     "gettingStartedChecklist": "Erste-Schritte-Checkliste",
     "gettingStartedChecklistHint": "Geführte Checkliste in der Seitenleiste anzeigen",
     "goalDueToday": "Heute fälliges Ziel: {{title}}",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -720,6 +720,7 @@
     "helpFeedback": "Help & Feedback",
     "documentation": "Documentation",
     "contactIssues": "Contact & Issues",
+    "legal": "Legal",
     "gettingStartedChecklist": "Getting Started checklist",
     "gettingStartedChecklistHint": "Show the guided checklist in the sidebar",
     "goalDueToday": "Goal due today: {{title}}",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -720,6 +720,7 @@
     "helpFeedback": "Ayuda y comentarios",
     "documentation": "Documentación",
     "contactIssues": "Contacto y problemas",
+    "legal": "Aviso legal",
     "gettingStartedChecklist": "Lista de primeros pasos",
     "gettingStartedChecklistHint": "Mostrar la lista guiada en la barra lateral",
     "goalDueToday": "Objetivo con fecha límite hoy: {{title}}",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -720,6 +720,7 @@
     "helpFeedback": "Aide & Retours",
     "documentation": "Documentation",
     "contactIssues": "Contact & Problèmes",
+    "legal": "Mentions légales",
     "gettingStartedChecklist": "Liste de démarrage",
     "gettingStartedChecklistHint": "Afficher la liste guidée dans le panneau latéral",
     "goalDueToday": "Objectif à rendre aujourd'hui : {{title}}",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -720,6 +720,7 @@
     "helpFeedback": "Aiuto e feedback",
     "documentation": "Documentazione",
     "contactIssues": "Contatti e problemi",
+    "legal": "Note legali",
     "gettingStartedChecklist": "Checklist per iniziare",
     "gettingStartedChecklistHint": "Mostra la checklist guidata nella barra laterale",
     "goalDueToday": "Obiettivo in scadenza oggi: {{title}}",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -720,6 +720,7 @@
     "helpFeedback": "Ajuda e feedback",
     "documentation": "Documentação",
     "contactIssues": "Contacto e problemas",
+    "legal": "Informação legal",
     "gettingStartedChecklist": "Lista de primeiros passos",
     "gettingStartedChecklistHint": "Mostrar a lista guiada na barra lateral",
     "goalDueToday": "Objetivo com prazo hoje: {{title}}",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10355,6 +10355,29 @@ const DayPlanner = () => {
                 </a>
               </div>
 
+              {/* Legal */}
+              <div>
+                <p className={`text-xs font-semibold uppercase tracking-wide ${textSecondary} mb-2`}>{t('app.legal')}</p>
+                <a
+                  href="https://glance-apps.com/dayglance/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-blue-500 hover:text-blue-400 transition-colors text-sm font-medium"
+                >
+                  <ExternalLink size={14} />
+                  {t('onboarding.privacyPolicy')}
+                </a>
+                <a
+                  href="https://www.glance-apps.com/eula"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-blue-500 hover:text-blue-400 transition-colors text-sm font-medium mt-1.5"
+                >
+                  <ExternalLink size={14} />
+                  {t('onboarding.termsOfUse')}
+                </a>
+              </div>
+
               {/* Getting Started toggle */}
               <div className={`pt-4 border-t ${borderClass}`}>
                 <div className="flex items-center justify-between">

--- a/src/components/DesktopWelcomeModal.jsx
+++ b/src/components/DesktopWelcomeModal.jsx
@@ -45,7 +45,7 @@ const DesktopWelcomeModal = () => {
               <p className={`${textSecondary} text-xs mt-3`}>{t('onboarding.welcomeLocal')}</p>
               <p className={`${textSecondary} text-sm mt-4`}>{t('onboarding.welcomeTour')}</p>
               <div className={`mt-5 flex items-center justify-center gap-2 text-xs ${textSecondary}`}>
-                <a href="https://docs.dayglance.app/en/privacy-policy" target="_blank" rel="noopener noreferrer" className="underline hover:text-blue-500 transition-colors">{t('onboarding.privacyPolicy')}</a>
+                <a href="https://glance-apps.com/dayglance/privacy" target="_blank" rel="noopener noreferrer" className="underline hover:text-blue-500 transition-colors">{t('onboarding.privacyPolicy')}</a>
                 <span className="opacity-50">·</span>
                 <a href="https://www.glance-apps.com/eula" target="_blank" rel="noopener noreferrer" className="underline hover:text-blue-500 transition-colors">{t('onboarding.termsOfUse')}</a>
               </div>

--- a/src/components/MobileWelcomeModal.jsx
+++ b/src/components/MobileWelcomeModal.jsx
@@ -42,7 +42,7 @@ const MobileWelcomeModal = () => {
             <p className={`text-lg ${textPrimary}`}>{t('onboarding.welcomeTitle')}</p>
             <p className={`${textSecondary} text-xs mt-4`}>{t('onboarding.welcomeLocal')}</p>
             <div className={`mt-5 flex items-center justify-center gap-2 text-xs ${textSecondary}`}>
-              <a href="https://docs.dayglance.app/en/privacy-policy" target="_blank" rel="noopener noreferrer" className="underline hover:text-blue-500 transition-colors">{t('onboarding.privacyPolicy')}</a>
+              <a href="https://glance-apps.com/dayglance/privacy" target="_blank" rel="noopener noreferrer" className="underline hover:text-blue-500 transition-colors">{t('onboarding.privacyPolicy')}</a>
               <span className="opacity-50">·</span>
               <a href="https://www.glance-apps.com/eula" target="_blank" rel="noopener noreferrer" className="underline hover:text-blue-500 transition-colors">{t('onboarding.termsOfUse')}</a>
             </div>

--- a/src/components/SubscriptionWall.jsx
+++ b/src/components/SubscriptionWall.jsx
@@ -181,7 +181,7 @@ export default function SubscriptionWall({
       {/* Legal links — required by App Store guideline 3.1.2 for auto-renewable subscriptions */}
       <div className={`mb-6 flex items-center justify-center gap-2 text-xs ${sub}`}>
         <button
-          onClick={() => window.open('https://docs.dayglance.app/en/privacy-policy', '_blank', 'noopener')}
+          onClick={() => window.open('https://glance-apps.com/dayglance/privacy', '_blank', 'noopener')}
           className="underline hover:opacity-80 transition-opacity"
         >
           Privacy Policy


### PR DESCRIPTION
## 1. Paywall link
`SubscriptionWall.jsx` Privacy Policy link → `https://glance-apps.com/dayglance/privacy`.

## 2. Every other reference (searched the whole tree)
The old `docs.dayglance.app/en/privacy-policy` also appeared in:
- Both welcome/onboarding modals (`DesktopWelcomeModal`, `MobileWelcomeModal`)
- **`PermissionsRationaleActivity.kt`** — the Android Health Connect permissions-rationale screen. This URL is surfaced to Google Play review for Health Connect apps, so it matters that it's correct and live.

All updated. The EULA URL (`glance-apps.com/eula`) is unchanged. Zero stale references remain (verified by grep across src, public, native, electron, docs).

## 3. Legal section in the Help ("?") modal
Added a Legal section (Privacy Policy + Terms of Use) after Contact, mirroring that section's markup and reusing the existing `onboarding.privacyPolicy` / `onboarding.termsOfUse` strings plus a new `app.legal` header translated in all six locales.

## Verification
- `npm test`: 751/751 · lint clean · six locales parse, key-identical (747 keys)

⚠️ Before this ships, confirm `https://glance-apps.com/dayglance/privacy` is live — App Store Connect and Google Play both require a reachable privacy URL, and the Android Health Connect rationale link will 404 for reviewers otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_