### PR TITLE
iOS: drop the unused HealthKit write-permission declaration

### DIFF
--- a/dayglance-ios/project.yml
+++ b/dayglance-ios/project.yml
@@ -106,7 +106,6 @@ targets:
         # Separately, file the annual BIS self-classification report.
         ITSAppUsesNonExemptEncryption: false
         NSHealthShareUsageDescription: "dayGLANCE reads your step count and sleep data to show your daily activity and recovery on the home screen."
-        NSHealthUpdateUsageDescription: "DayGlance uses Health data to display your steps and sleep activity on your daily timeline."
         NSCalendarsUsageDescription: "dayGLANCE reads your calendars to show upcoming events on the home screen."
         NSCalendarsFullAccessUsageDescription: "dayGLANCE reads your calendars to show upcoming events on the home screen and can create calendar events from your tasks."
         NSCalendarsWriteOnlyAccessUsageDescription: "dayGLANCE can create calendar events from your tasks."


### PR DESCRIPTION
The app never requests HealthKit write access — `HealthBridge` authorizes with `toShare: nil` and has zero save calls — but `project.yml` declared `NSHealthUpdateUsageDescription`, advertising a write capability that doesn't exist (its text was even a read-description pasted onto the write key). The privacy policy states health data is "never written back to HealthKit"; now the binary's declared capabilities say the same thing.

`NSHealthShareUsageDescription` (read) is unchanged. Run `npm run ios:generate` after merging so the regenerated Info.plist drops the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_