### PR TITLE
Gate iCloud GLANCEintents behind an explicit opt-in

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -336,7 +336,10 @@
     "glanceEncryption": "Verschlüsselung",
     "glanceActivity": "Aktivität",
     "syncFolder": "Synchronisierungsordner",
-    "enableE2EEncryption": "Ende-zu-Ende-Verschlüsselung aktivieren"
+    "enableE2EEncryption": "Ende-zu-Ende-Verschlüsselung aktivieren",
+    "icloudIntents": "iCloud-Intents",
+    "icloudIntentsDesc": "Teilen Sie Aufgaben-Intents über iCloud Drive mit anderen GLANCE-Apps. Die Dateien werden automatisch zwischen Ihren Apple-Geräten synchronisiert.",
+    "icloudIntentsEnable": "iCloud-Intents aktivieren"
   },
   "task": {
     "newScheduled": "Neue geplante Aufgabe",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -336,7 +336,10 @@
     "glanceEncryption": "Encryption",
     "glanceActivity": "Activity",
     "syncFolder": "Sync folder",
-    "enableE2EEncryption": "Enable end-to-end encryption"
+    "enableE2EEncryption": "Enable end-to-end encryption",
+    "icloudIntents": "iCloud intents",
+    "icloudIntentsDesc": "Share task intents with other GLANCE apps through iCloud Drive. Files sync automatically across your Apple devices.",
+    "icloudIntentsEnable": "Enable iCloud intents"
   },
   "task": {
     "newScheduled": "New Scheduled Task",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -336,7 +336,10 @@
     "glanceEncryption": "Cifrado",
     "glanceActivity": "Actividad",
     "syncFolder": "Carpeta de sincronización",
-    "enableE2EEncryption": "Activar cifrado de extremo a extremo"
+    "enableE2EEncryption": "Activar cifrado de extremo a extremo",
+    "icloudIntents": "Intents de iCloud",
+    "icloudIntentsDesc": "Comparte los intents de tareas con otras apps de GLANCE mediante iCloud Drive. Los archivos se sincronizan automáticamente entre tus dispositivos Apple.",
+    "icloudIntentsEnable": "Activar los intents de iCloud"
   },
   "task": {
     "newScheduled": "Nueva tarea programada",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -336,7 +336,10 @@
     "glanceEncryption": "Chiffrement",
     "glanceActivity": "Activité",
     "syncFolder": "Dossier de synchronisation",
-    "enableE2EEncryption": "Activer le chiffrement de bout en bout"
+    "enableE2EEncryption": "Activer le chiffrement de bout en bout",
+    "icloudIntents": "Intents iCloud",
+    "icloudIntentsDesc": "Partagez les intents de tâches avec les autres applications GLANCE via iCloud Drive. Les fichiers se synchronisent automatiquement entre vos appareils Apple.",
+    "icloudIntentsEnable": "Activer les intents iCloud"
   },
   "task": {
     "newScheduled": "Nouvelle tâche planifiée",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -336,7 +336,10 @@
     "glanceEncryption": "Crittografia",
     "glanceActivity": "Attività",
     "syncFolder": "Cartella di sincronizzazione",
-    "enableE2EEncryption": "Attiva crittografia end-to-end"
+    "enableE2EEncryption": "Attiva crittografia end-to-end",
+    "icloudIntents": "Intent di iCloud",
+    "icloudIntentsDesc": "Condividi gli intent delle attività con le altre app GLANCE tramite iCloud Drive. I file si sincronizzano automaticamente tra i tuoi dispositivi Apple.",
+    "icloudIntentsEnable": "Abilita gli intent di iCloud"
   },
   "task": {
     "newScheduled": "Nuova attività pianificata",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -336,7 +336,10 @@
     "glanceEncryption": "Encriptação",
     "glanceActivity": "Atividade",
     "syncFolder": "Pasta de sincronização",
-    "enableE2EEncryption": "Ativar encriptação ponta a ponta"
+    "enableE2EEncryption": "Ativar encriptação ponta a ponta",
+    "icloudIntents": "Intents do iCloud",
+    "icloudIntentsDesc": "Partilhe os intents de tarefas com outras aplicações GLANCE através do iCloud Drive. Os ficheiros são sincronizados automaticamente entre os seus dispositivos Apple.",
+    "icloudIntentsEnable": "Ativar os intents do iCloud"
   },
   "task": {
     "newScheduled": "Nova tarefa agendada",

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -25,6 +25,7 @@ import { useSyncCtx } from '../context/SyncContext.jsx';
 import { isVaultEnabled } from '../sync/vaultConfig.js';
 import { multiUserToggleLocked } from '../utils/multiUserGate.js';
 import { getDbIntentsConfig, setDbIntentsConfig, getDbIntentsConnection } from '../intents/dbIntentsConfig.js';
+import { getIcloudIntentsEnabledFlag, setIcloudIntentsEnabled } from '../intents/icloudIntentsConfig.js';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from '../intents/useIntentPoller.js';
 import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUsers.js';
@@ -153,6 +154,10 @@ const MobileSettingsPanel = () => {
   // Vault intents key-setup phase: null | 'passphrase-needed' | 'running' | { error }.
   const [dbIntentsSetupPhase, setDbIntentsSetupPhase] = useState(null);
   const [dbIntentsPassphraseInput, setDbIntentsPassphraseInput] = useState('');
+  // iCloud intents opt-in gate. DEFAULT OFF — activation (emit + poll) only runs
+  // when the user flips this on, matching WebDAV/vault gating.
+  const [icloudIntentsEnabled, setIcloudIntentsEnabledState] = useState(() => getIcloudIntentsEnabledFlag());
+  const [icloudIntentsSaved, setIcloudIntentsSaved] = useState(false);
   // Android automation intents (Tasker) opt-in gate. DEFAULT OFF — the native
   // SharedPreferences flag is the source of truth; mirror it for the toggle.
   const [automationIntentsEnabled, setAutomationIntentsEnabled] = useState(
@@ -2137,6 +2142,54 @@ const MobileSettingsPanel = () => {
             );
           })()}
         </div>
+
+        {/* iCloud intents opt-in — Apple platforms only (isICloudAvailable() is
+            false on Android/web). Gates ACTIVATION of the iCloud intents transport
+            (emit + poll); default OFF so the path stays inert until the user opts in. */}
+        {isICloudAvailable() && (
+          <div>
+            <h5 className={sectionCls}>
+              <span className="flex items-center gap-2">
+                <Cloud size={14} className={textSecondary} />
+                {t('settings.icloudIntents')}
+              </span>
+            </h5>
+            <p className={`${textSecondary} text-xs mb-3`}>
+              {t('settings.icloudIntentsDesc')}
+            </p>
+            <div className={`flex items-start gap-3 p-3 rounded-lg border ${borderClass}`}>
+              <input
+                type="checkbox"
+                id="icloud-intents-toggle-mobile"
+                checked={icloudIntentsEnabled}
+                onChange={e => setIcloudIntentsEnabledState(e.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded"
+              />
+              <div>
+                <label htmlFor="icloud-intents-toggle-mobile" className={`text-sm font-medium ${textPrimary} cursor-pointer`}>
+                  {t('settings.icloudIntentsEnable')}
+                </label>
+              </div>
+            </div>
+            <button
+              onClick={() => {
+                const wasEnabled = getIcloudIntentsEnabledFlag();
+                setIcloudIntentsEnabled(icloudIntentsEnabled);
+                // Reload so the intent poller remounts and re-reads the opt-in
+                // (mirrors the GLANCEvault intents toggle's reload-on-change).
+                if (wasEnabled !== icloudIntentsEnabled) {
+                  window.location.reload();
+                  return;
+                }
+                setIcloudIntentsSaved(true);
+                setTimeout(() => setIcloudIntentsSaved(false), 2000);
+              }}
+              className="mt-3 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+            >
+              {icloudIntentsSaved ? 'Saved' : 'Save'}
+            </button>
+          </div>
+        )}
       </div>
     );
   })()}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -17,6 +17,7 @@ import { getSyncPassphrase, setSyncPassphrase } from '../utils/crypto.js';
 import { isVaultEnabled } from '../sync/vaultConfig.js';
 import { multiUserToggleLocked } from '../utils/multiUserGate.js';
 import { getDbIntentsConfig, setDbIntentsConfig, getDbIntentsConnection } from '../intents/dbIntentsConfig.js';
+import { getIcloudIntentsEnabledFlag, setIcloudIntentsEnabled } from '../intents/icloudIntentsConfig.js';
 import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
 import { ensureVaultIntentsKey, setupVaultIntentsEncryption } from '../intents/vaultIntentsSetup.js';
 import { flushOutboxNow } from '../intents/useOutboxFlush.js';
@@ -127,6 +128,10 @@ const SettingsModal = () => {
   // Vault intents key-setup phase: null | 'passphrase-needed' | 'running' | { error }.
   const [dbIntentsSetupPhase, setDbIntentsSetupPhase] = useState(null);
   const [dbIntentsPassphraseInput, setDbIntentsPassphraseInput] = useState('');
+  // iCloud intents opt-in gate. DEFAULT OFF — activation (emit + poll) only runs
+  // when the user flips this on, matching WebDAV/vault gating.
+  const [icloudIntentsEnabled, setIcloudIntentsEnabledState] = useState(() => getIcloudIntentsEnabledFlag());
+  const [icloudIntentsSaved, setIcloudIntentsSaved] = useState(false);
   // Android automation intents (Tasker) opt-in gate. DEFAULT OFF — the flag is
   // the single source of truth in native SharedPreferences; we mirror it here so
   // the toggle reflects the persisted value. Only shown on native Android.
@@ -2147,6 +2152,53 @@ const SettingsModal = () => {
                           );
                         })()}
                       </div>
+
+                      {/* iCloud intents opt-in — Apple platforms only (isICloudAvailable()
+                          is false on Android/web). Gates ACTIVATION of the iCloud intents
+                          transport (emit + poll); default OFF so the path stays inert
+                          until the user opts in. */}
+                      {isICloudAvailable() && (
+                        <div className={`mt-4 pt-4 border-t ${borderClass} space-y-3`}>
+                          <div className="flex items-center gap-2">
+                            <Cloud size={14} className={textSecondary} />
+                            <span className={`text-sm font-medium ${textPrimary}`}>{t('settings.icloudIntents')}</span>
+                          </div>
+                          <p className={`${textSecondary} text-xs`}>
+                            {t('settings.icloudIntentsDesc')}
+                          </p>
+                          <div className={`flex items-start gap-3 p-3 rounded-lg border ${borderClass}`}>
+                            <input
+                              type="checkbox"
+                              id="icloud-intents-toggle"
+                              checked={icloudIntentsEnabled}
+                              onChange={e => setIcloudIntentsEnabledState(e.target.checked)}
+                              className="mt-0.5 h-4 w-4 rounded"
+                            />
+                            <div>
+                              <label htmlFor="icloud-intents-toggle" className={`text-sm font-medium ${textPrimary} cursor-pointer`}>
+                                {t('settings.icloudIntentsEnable')}
+                              </label>
+                            </div>
+                          </div>
+                          <button
+                            onClick={() => {
+                              const wasEnabled = getIcloudIntentsEnabledFlag();
+                              setIcloudIntentsEnabled(icloudIntentsEnabled);
+                              // Reload so the intent poller remounts and re-reads the
+                              // opt-in (mirrors the GLANCEvault intents reload-on-change).
+                              if (wasEnabled !== icloudIntentsEnabled) {
+                                window.location.reload();
+                                return;
+                              }
+                              setIcloudIntentsSaved(true);
+                              setTimeout(() => setIcloudIntentsSaved(false), 2000);
+                            }}
+                            className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+                          >
+                            {icloudIntentsSaved ? t('common.saved') : t('common.save')}
+                          </button>
+                        </div>
+                      )}
                       </>)}
                     </div>
 

--- a/src/intents/emitTargets.js
+++ b/src/intents/emitTargets.js
@@ -3,8 +3,8 @@
 // emit sites so they enqueue with a consistent target set. Only ENABLED targets
 // are included — the outbox then drives each one through its deliverer.
 
-import * as iCloudTransport from './icloudFileTransport.js';
 import { isDbIntentsEnabled } from './dbIntentsConfig.js';
+import { isIcloudIntentsEnabled } from './icloudIntentsConfig.js';
 
 /**
  * @param {object|null} config - the WebDAV intents config (INTENT_CONFIG_KEY)
@@ -13,7 +13,7 @@ import { isDbIntentsEnabled } from './dbIntentsConfig.js';
 export function enabledIntentTargets(config) {
   const targets = [];
   if (config?.webdavUrl && config?.username && config?.appPassword) targets.push('webdav');
-  if (iCloudTransport.isAvailable()) targets.push('icloud');
+  if (isIcloudIntentsEnabled()) targets.push('icloud');
   if (isDbIntentsEnabled()) targets.push('vault');
   return targets;
 }

--- a/src/intents/emitTargets.test.js
+++ b/src/intents/emitTargets.test.js
@@ -1,12 +1,21 @@
-import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import { enabledIntentTargets } from './emitTargets.js';
+import { isIcloudIntentsEnabled, ICLOUD_INTENTS_ENABLED_KEY } from './icloudIntentsConfig.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // enabledIntentTargets decides which transports an emit goes to AND gates the
-// "Track in lifeGLANCE" share UI. iCloud is unavailable in this environment, so
-// these cover the WebDAV/vault matrix — crucially the vault-only case, which
-// must yield a target even with no WebDAV config (the bug this guards against).
+// "Track in lifeGLANCE" share UI. These cover the WebDAV/vault/iCloud matrix —
+// crucially the vault-only case (a target even with no WebDAV config) and the
+// iCloud OPT-IN gate: 'icloud' must be excluded unless iCloud is BOTH available
+// AND explicitly enabled, so the "opt-in, off by default" claim holds.
 // ─────────────────────────────────────────────────────────────────────────────
+
+// iCloud availability is a module-level platform check; mock it so we can drive
+// both the available and unavailable branches. Only isAvailable is consumed here.
+let mockIcloudAvailable = false;
+vi.mock('./icloudFileTransport.js', () => ({
+  isAvailable: () => mockIcloudAvailable,
+}));
 
 function memLocalStorage() {
   const m = new Map();
@@ -17,7 +26,10 @@ function memLocalStorage() {
     clear: () => m.clear(),
   };
 }
-beforeEach(() => { global.localStorage = memLocalStorage(); });
+beforeEach(() => {
+  global.localStorage = memLocalStorage();
+  mockIcloudAvailable = false;
+});
 afterAll(() => { delete global.localStorage; });
 
 const WEBDAV = { webdavUrl: 'https://dav', username: 'u', appPassword: 'p' };
@@ -25,6 +37,10 @@ const WEBDAV = { webdavUrl: 'https://dav', username: 'u', appPassword: 'p' };
 function enableVault() {
   localStorage.setItem('dayglance-db-intents-config', JSON.stringify({ enabled: true }));
   localStorage.setItem('dayglance-vault-config', JSON.stringify({ enabled: true, vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' }));
+}
+
+function optInICloud() {
+  localStorage.setItem(ICLOUD_INTENTS_ENABLED_KEY, 'true');
 }
 
 describe('enabledIntentTargets', () => {
@@ -49,5 +65,42 @@ describe('enabledIntentTargets', () => {
 
   it('does not count WebDAV when the config is incomplete', () => {
     expect(enabledIntentTargets({ webdavUrl: 'https://dav' })).toEqual([]);
+  });
+
+  it('EXCLUDES "icloud" when iCloud is available but the opt-in is off', () => {
+    mockIcloudAvailable = true;
+    // no opt-in flag written
+    expect(enabledIntentTargets(null)).toEqual([]);
+    expect(enabledIntentTargets(WEBDAV)).toEqual(['webdav']);
+  });
+
+  it('EXCLUDES "icloud" when opted in but iCloud is unavailable (e.g. Android/web)', () => {
+    mockIcloudAvailable = false;
+    optInICloud();
+    expect(enabledIntentTargets(null)).toEqual([]);
+  });
+
+  it('INCLUDES "icloud" only when iCloud is available AND opted in', () => {
+    mockIcloudAvailable = true;
+    optInICloud();
+    expect(enabledIntentTargets(null)).toEqual(['icloud']);
+    expect(enabledIntentTargets(WEBDAV)).toEqual(['webdav', 'icloud']);
+  });
+});
+
+describe('isIcloudIntentsEnabled', () => {
+  it('requires BOTH availability and the opt-in flag', () => {
+    // neither
+    expect(isIcloudIntentsEnabled()).toBe(false);
+    // available only
+    mockIcloudAvailable = true;
+    expect(isIcloudIntentsEnabled()).toBe(false);
+    // opted in only
+    mockIcloudAvailable = false;
+    optInICloud();
+    expect(isIcloudIntentsEnabled()).toBe(false);
+    // both
+    mockIcloudAvailable = true;
+    expect(isIcloudIntentsEnabled()).toBe(true);
   });
 });

--- a/src/intents/icloudIntentsConfig.js
+++ b/src/intents/icloudIntentsConfig.js
@@ -1,0 +1,44 @@
+// iCloud INTENTS opt-in gate.
+//
+// The iCloud file transport is available on Apple platforms whenever an iCloud
+// container is reachable, but ACTIVATING the intents path (emitting to iCloud +
+// polling the iCloud event log) must be an explicit user choice — matching the
+// WebDAV transport (gated on configured creds) and the GLANCEvault DB transport
+// (gated on isDbIntentsEnabled()). Without this opt-in the privacy claim that
+// "GLANCEintents is opt-in and off by default" would be false for the iCloud path.
+//
+// This module is deliberately tiny: a single persisted boolean flag, default
+// FALSE. isIcloudIntentsEnabled() returns true ONLY when the platform supports
+// iCloud AND the user has flipped the flag on — both must hold. The iCloud
+// transport's own file operations (icloudFileTransport.js) remain callable
+// regardless; this gates ACTIVATION, not the transport itself.
+
+import { isAvailable as isICloudAvailable } from './icloudFileTransport.js';
+
+export const ICLOUD_INTENTS_ENABLED_KEY = 'dayglance-icloud-intents-enabled';
+
+/** The raw opt-in flag, independent of platform availability. @returns {boolean} */
+export function getIcloudIntentsEnabledFlag() {
+  try {
+    return localStorage.getItem(ICLOUD_INTENTS_ENABLED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** Persist the opt-in flag. Removes the key when disabling. */
+export function setIcloudIntentsEnabled(enabled) {
+  try {
+    if (enabled) localStorage.setItem(ICLOUD_INTENTS_ENABLED_KEY, 'true');
+    else localStorage.removeItem(ICLOUD_INTENTS_ENABLED_KEY);
+  } catch {
+    /* ignore persistence failures (private mode, quota, etc.) */
+  }
+}
+
+// True only when iCloud is available on this platform AND the user has opted in.
+// Both the emit target and the poller are gated on this; when false the iCloud
+// intents path is fully inert (no send, no poll).
+export function isIcloudIntentsEnabled() {
+  return isICloudAvailable() && getIcloudIntentsEnabledFlag();
+}

--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -5,6 +5,7 @@ import { webdavFetch } from '../utils/cloudSyncProviders.js';
 import { handleIntent } from './handleIntent.js';
 import { logActivity } from './intentLog.js';
 import * as iCloudTransport from './icloudFileTransport.js';
+import { isIcloudIntentsEnabled } from './icloudIntentsConfig.js';
 
 export const INTENT_CONFIG_KEY = 'dayglance-intent-config';
 export const MULTI_USER_CONFIG_KEY = 'dayglance-multi-user-config';
@@ -590,7 +591,7 @@ export function useIntentPoller(context) {
     })();
 
     const hasWebDAV = !!(config?.webdavUrl && config?.username && config?.appPassword);
-    const hasICloud = iCloudTransport.isAvailable();
+    const hasICloud = isIcloudIntentsEnabled();
     if (!hasWebDAV && !hasICloud) return;
 
     const fgMs = config?.foregroundInterval ?? DEFAULT_FG_MS;
@@ -610,7 +611,7 @@ export function useIntentPoller(context) {
       if (destroyed) return;
       try {
         await poll(config, contextRef.current);           // WebDAV (no-ops if not configured)
-        if (iCloudTransport.isAvailable()) {
+        if (isIcloudIntentsEnabled()) {
           await pollICloud(config, contextRef.current);   // iCloud (sequential, sees advanced cursor)
         }
       } catch (err) {


### PR DESCRIPTION
The iCloud GLANCEintents transport auto-activated whenever an iCloud container was available, with no user opt-in — unlike WebDAV (gated on configured creds) and vault (gated on `isDbIntentsEnabled()`). That made the privacy policy's "GLANCEintents is opt-in and off by default" claim false for the iCloud path.

- New `src/intents/icloudIntentsConfig.js` (mirrors `dbIntentsConfig`): a single persisted boolean (`dayglance-icloud-intents-enabled`, default off). `isIcloudIntentsEnabled()` returns true only when iCloud is available **and** the user opted in.
- Gated **all three** activation sites through it: the emit-target selector (`emitTargets.js`) and **both** poller sites — the mount gate and the per-poll iCloud branch in `runPoll`. That second poller site was a genuine third driver: a WebDAV-configured user with iCloud opt-in off would otherwise still have iCloud polled. The transport's own file-op guards (`writeEventFileICloud`, `runIntentGCICloud`) are left untouched — they gate the transport, not activation.
- Settings toggle in both `SettingsModal` and `MobileSettingsPanel`, shown only on Apple platforms (`isAvailable()`), placed with the existing WebDAV/vault intent controls, reloading on change like the vault toggle. New `settings.icloudIntents*` strings in all six locales.

Default off is correct: this is a v4.0.0 transport, so off-by-default is the right launch posture, and cross-app iCloud pickup is now one switch.

## Verification
- `npm test`: 755/755 (4 new gate tests) · lint clean · six locales parse, key-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_