### PR TITLE
iOS: restore NSHealthUpdateUsageDescription (upload validator requires it)

### DIFF
--- a/dayglance-ios/project.yml
+++ b/dayglance-ios/project.yml
@@ -106,6 +106,7 @@ targets:
         # Separately, file the annual BIS self-classification report.
         ITSAppUsesNonExemptEncryption: false
         NSHealthShareUsageDescription: "dayGLANCE reads your step count and sleep data to show your daily activity and recovery on the home screen."
+        NSHealthUpdateUsageDescription: "dayGLANCE only reads your step count and sleep data. It never writes data to Apple Health; this notice is required because the app links Health APIs."
         NSCalendarsUsageDescription: "dayGLANCE reads your calendars to show upcoming events on the home screen."
         NSCalendarsFullAccessUsageDescription: "dayGLANCE reads your calendars to show upcoming events on the home screen and can create calendar events from your tasks."
         NSCalendarsWriteOnlyAccessUsageDescription: "dayGLANCE can create calendar events from your tasks."


### PR DESCRIPTION
Fixes the ITMS-90683 upload failure introduced by #1174.

Apple's upload validation is **symbol-based, not behavior-based**: `HealthBridge` calls `requestAuthorization(toShare:read:)` with `toShare: nil` — genuinely read-only at runtime — but the method signature references the write-capable API, so the validator requires `NSHealthUpdateUsageDescription` to exist regardless (there is no read-only variant of the call, so no code-level fix exists).

The key returns with **honest text** this time — stating the app never writes to Health — rather than the pre-#1174 string, which incorrectly described read access on the write key. The privacy policy's "never written back to HealthKit" claim is unaffected: this is a static plist declaration the validator demands, not a permission the app requests (write authorization is still never requested).

After merging: `npm run ios` (regenerate + rebuild), re-archive, re-upload. The date-based build number auto-increments, so the failed upload doesn't block the retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_