### PR TITLE
Sync package-lock.json to 4.0.0 and teach bump-version to update it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "3.10.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "3.10.0",
+      "version": "4.0.0",
       "dependencies": {
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.6.0",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -164,6 +164,22 @@ const readmeText = sub(
   { file: 'README.md', label: 'version badge', to: version },
 );
 
+// ── 4. package-lock.json ──────────────────────────────────────────────────
+// npm records the app's own version in TWO places in the lockfile (the root
+// "version" and packages[""]."version"). If the bump doesn't update them,
+// the next `npm install` rewrites the lockfile to match package.json and
+// leaves an uncommitted diff. Edit via JSON, not regex: JSON.stringify(obj, 2)
+// reproduces npm's formatting byte-for-byte (verified), and it can only touch
+// the root package's version, never a dependency's.
+const lockRel = 'package-lock.json';
+const lock = read(lockRel);
+const lockObj = JSON.parse(lock.text);
+const oldLockVersion = lockObj.version;
+lockObj.version = version;
+if (lockObj.packages && lockObj.packages['']) lockObj.packages[''].version = version;
+const lockText = JSON.stringify(lockObj, null, 2) + '\n';
+changes.push({ file: lockRel, label: 'version', from: oldLockVersion, to: version });
+
 // ── Report ────────────────────────────────────────────────────────────────
 console.log(`bump-version: setting version to ${version}${dryRun ? '  (dry run — nothing written)' : ''}\n`);
 for (const c of changes) {
@@ -181,6 +197,7 @@ if (dryRun) {
 fs.writeFileSync(pkg.abs, pkgText);
 fs.writeFileSync(gradle.abs, gradleText);
 fs.writeFileSync(readme.abs, readmeText);
+fs.writeFileSync(lock.abs, lockText);
 
 console.log('Files written.\n');
 console.log('Next steps:');


### PR DESCRIPTION
The 4.0.0 bump (#1177) updated `package.json` but not `package-lock.json`, so the lockfile's `version` fields stayed at 3.10.0 on `main`. Every `npm install` then re-corrects them to 4.0.0, leaving a perpetual uncommitted diff.

- Commits the corrected lockfile (4.0.0).
- Adds `package-lock.json` to the files `scripts/bump-version.mjs` rewrites, so future version bumps keep it in sync. Uses a JSON round-trip (`JSON.stringify(obj, null, 2) + '\n'`) that reproduces npm's formatting byte-for-byte (verified) and only touches the root package's two `version` fields, never a dependency's.

No dependency changes; only the app's own version string. Dry-run confirmed the script now lists the lockfile among its targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_