### PR TITLE
Fix paywall not dismissing after a successful purchase/restore

### DIFF
--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -157,25 +157,50 @@ export function useSubscription() {
 
   const isOnNativePlatform = !!(BILLING || IOS || ELECTRON);
 
+  // Re-read entitlement from the authoritative native source, but never
+  // downgrade an already-active state. A confirmed purchase/restore validates
+  // before the event fires, yet the native entitlement cache can briefly lag
+  // (StoreKit sandbox especially), so an immediate single read often comes back
+  // inactive. Re-read on a few short delays and only apply an ACTIVE result —
+  // this fills the accurate productId without ever re-locking the wall.
+  const reconcileStatus = useCallback(() => {
+    const applyIfActive = (s) => { if (s && s.active) setStatus(s); };
+    [0, 1200, 3000].forEach((delay) => setTimeout(() => {
+      if (ELECTRON) {
+        window.electronAPI.subscriptionStatus().then((s) => {
+          if (s && s.active) {
+            setStatus(s);
+            try { localStorage.setItem('rc_electron_status', JSON.stringify(s)); } catch {}
+          }
+        }).catch(() => {});
+      } else if (BILLING) {
+        applyIfActive(readStatusAndroid());
+      } else if (IOS) {
+        applyIfActive(readStatusIOS());
+      }
+    }, delay));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   // ── Billing event handler (shared by all platforms) ──────────────────────
   const handleBillingEvent = useCallback((ev) => {
     try {
       const parsed = typeof ev === 'string' ? JSON.parse(ev) : ev;
-      if (parsed.status === 'success') {
-        // Re-read entitlement after a confirmed purchase.
-        if (BILLING) { setStatus(readStatusAndroid()); setPrices(readPricesAndroid()); }
-        if (IOS)     { setStatus(readStatusIOS());     setPrices(readPricesIOS()); }
-        if (ELECTRON) {
-          window.electronAPI.subscriptionStatus().then(s => {
-            setStatus(s);
-            try { localStorage.setItem('rc_electron_status', JSON.stringify(s)); } catch {}
-          }).catch(() => {});
-        }
+      // A 'success' purchase event and an active restore ('restore_complete_active')
+      // are both only emitted AFTER the platform validates the entitlement, so
+      // unlock immediately rather than waiting on a possibly-stale cache read —
+      // that lag previously left the paywall up after a completed purchase.
+      const purchased = parsed.status === 'success';
+      const restoredActive = parsed.message === 'restore_complete_active';
+      if (purchased || restoredActive) {
+        setStatus((prev) => (prev.active ? prev : { active: true, productId: parsed.productId || prev.productId || null }));
+        if (BILLING) setPrices(readPricesAndroid());
+        if (IOS)     setPrices(readPricesIOS());
+        reconcileStatus(); // fill accurate productId; never re-locks
       }
       setBillingEvent({ ...parsed, ts: Date.now() });
       if (timeoutRef.current) { clearTimeout(timeoutRef.current); timeoutRef.current = null; }
     } catch {}
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [reconcileStatus]);
 
   // Register window.__billingEvent — fired by Android and iOS bridges.
   useEffect(() => {


### PR DESCRIPTION
## Problem

After a successful in-app purchase, the transaction completes ("successful") but the paywall stays on screen — it doesn't auto-dismiss. Found while testing StoreKit sandbox purchases.

**Root cause (purchase):** On a `success` billing event, `handleBillingEvent` re-read the native entitlement cache *immediately* (`readStatusIOS()` on iOS, `subscriptionStatus()` on Electron). That cache lags right after a purchase — StoreKit **sandbox** especially — so the read returns `active:false`, `isPro` never flips true, and the gate in `App.jsx` keeps `<SubscriptionWall>` mounted even though the purchase validated.

**Root cause (restore):** Worse for Restore. When an active subscription is restored, iOS and Electron report it as `status:'cancelled'` with `message:'restore_complete_active'` (a deliberate pattern so the spinner clears without showing a "new purchase" UI). That never matched the `status === 'success'` branch, so the entitlement was never re-read and a *successful restore* also failed to dismiss the wall.

## Fix

A `success` purchase event and an active restore are both emitted **only after** the platform has validated the entitlement, so treat them as authoritative:

- **Unlock optimistically and immediately** — set `{ active: true, productId }` from the event, so the wall dismisses the instant the purchase/restore is confirmed.
- **Reconcile in the background** — re-read the authoritative native status at 0 / 1.2 / 3s and apply the result *only if it is active*. This fills in the accurate `productId` and confirms on Electron's async path, while a transient stale (`active:false`) read can never re-lock the wall.

No native (Swift/Kotlin/Electron) changes required — the bridges already fire the correct events; this is purely the JS handler in `useSubscription`.

## Verification

- `npm test`: 755/755 passing
- `npm run lint`: clean on the changed file (`--max-warnings 0`)
- Please re-run the sandbox purchase test: buy Annual, confirm the wall dismisses on its own; then reinstall and use **Restore purchase** to confirm restore dismisses it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_