### PR TITLE
Fix Mac paywall reappearing on relaunch when the receipt isn't ready

### DIFF
--- a/electron/subscription.ts
+++ b/electron/subscription.ts
@@ -100,10 +100,22 @@ async function rcFetch(method: string, endpoint: string, body?: object): Promise
 // status. Using POST /receipts rather than GET /subscribers means RevenueCat derives
 // the customer identity from the Apple ID embedded in the receipt — no separate
 // persisted user ID is needed, and cross-device restore just works via Apple ID.
-async function fetchEntitlementStatus(): Promise<{ active: boolean; productId: string | null }> {
+// `indeterminate: true` means the check could NOT be completed — no App Store
+// receipt on disk yet (very common on a COLD LAUNCH: macOS often doesn't
+// materialize the receipt until a StoreKit refresh/restore runs, which is exactly
+// why "Restore Purchase" recovers access when a fresh launch showed the paywall),
+// or a network/RevenueCat failure. Callers MUST treat indeterminate as "unknown",
+// never as "inactive": a paying user must not be downgraded and shown the paywall
+// just because the receipt wasn't ready or the network hiccuped. A DEFINITIVE
+// inactive (RC validated the receipt and the entitlement is absent or expired) is
+// returned WITHOUT the flag, so a genuinely lapsed subscription still re-locks.
+async function fetchEntitlementStatus(): Promise<{ active: boolean; productId: string | null; indeterminate?: boolean }> {
+  let receiptPath: string | null = null;
+  try { receiptPath = inAppPurchase.getReceiptURL(); } catch { receiptPath = null; }
+  if (!receiptPath || !fs.existsSync(receiptPath)) {
+    return { active: false, productId: null, indeterminate: true };
+  }
   try {
-    const receiptPath = inAppPurchase.getReceiptURL();
-    if (!receiptPath || !fs.existsSync(receiptPath)) return { active: false, productId: null };
     const fetchToken = fs.readFileSync(receiptPath).toString('base64');
     const data = await rcFetch('POST', '/receipts', {
       app_user_id: getStableAnonymousId(),
@@ -111,7 +123,7 @@ async function fetchEntitlementStatus(): Promise<{ active: boolean; productId: s
       platform: 'macos',
     }) as any;
     const ent = data?.subscriber?.entitlements?.[ENTITLEMENT_ID];
-    if (!ent) return { active: false, productId: null };
+    if (!ent) return { active: false, productId: null }; // definitive: no entitlement
     // Subscriptions have expires_date; lifetime non-consumables do not.
     if (ent.expires_date) {
       const active = new Date(ent.expires_date) > new Date();
@@ -119,7 +131,8 @@ async function fetchEntitlementStatus(): Promise<{ active: boolean; productId: s
     }
     return { active: true, productId: ent.product_identifier ?? null };
   } catch {
-    return { active: false, productId: null };
+    // Network / RevenueCat / parse failure — couldn't determine. Fail open.
+    return { active: false, productId: null, indeterminate: true };
   }
 }
 

--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -246,6 +246,12 @@ export function useSubscription() {
 
     if (ELECTRON) {
       window.electronAPI.subscriptionStatus().then(s => {
+        // Indeterminate = the main process couldn't verify (no receipt yet on a cold
+        // launch, or a network/RC failure). Keep the cached last-known-good state
+        // rather than downgrading to the paywall; "Restore Purchase" forces a receipt
+        // refresh for an authoritative answer. A determinate result (active OR a real
+        // expiry) is always applied.
+        if (!s || s.indeterminate) return;
         setStatus(s);
         try { localStorage.setItem('rc_electron_status', JSON.stringify(s)); } catch {}
       }).catch(() => {});
@@ -263,6 +269,12 @@ export function useSubscription() {
     }
     if (ELECTRON) {
       window.electronAPI.subscriptionStatus().then(s => {
+        // Indeterminate = the main process couldn't verify (no receipt yet on a cold
+        // launch, or a network/RC failure). Keep the cached last-known-good state
+        // rather than downgrading to the paywall; "Restore Purchase" forces a receipt
+        // refresh for an authoritative answer. A determinate result (active OR a real
+        // expiry) is always applied.
+        if (!s || s.indeterminate) return;
         setStatus(s);
         try { localStorage.setItem('rc_electron_status', JSON.stringify(s)); } catch {}
       }).catch(() => {});


### PR DESCRIPTION
## Problem

On the Mac / Mac App Store build, the paywall reappeared after quitting and relaunching **even with an active subscription** — an immediate reopen still showed it, and **only "Restore Purchase" recovered access.**

**Root cause:** on launch the app re-validates the App Store receipt with RevenueCat (`fetchEntitlementStatus`). On macOS the receipt frequently **isn't materialized on disk until a StoreKit refresh/restore runs**, so a cold launch reads an empty `getReceiptURL()` and returns `{ active: false }` — which is indistinguishable from a genuine "not subscribed." The renderer applied that unconditionally, re-showing the wall and overwriting the cached-active state.

That's exactly why **Restore worked**: `restoreCompletedTransactions()` forces StoreKit to refresh the receipt, after which the *same* RevenueCat call validates and returns active. The launch path just never triggered that refresh.

The same `{ active: false }` path was also hit on any **network / RevenueCat error**, so a paying user opening the app offline would likewise be locked out.

## Fix — fail open on "indeterminate"

- **`electron/subscription.ts`:** `fetchEntitlementStatus` now returns `indeterminate: true` when it **cannot verify** — no receipt on disk yet, or a network/RC/parse failure — distinct from a **definitive inactive** (RC validated the receipt and the entitlement is genuinely absent or expired), which is returned *without* the flag so a truly lapsed subscription still re-locks.
- **`src/hooks/useSubscription.js`:** the launch and visibility-refresh Electron paths now **skip indeterminate results** and keep the cached last-known-good entitlement instead of downgrading to the paywall. (The purchase already caches `active:true`, so an immediate reopen stays unlocked.) A determinate result — active *or* a real expiry — is still always applied.

This matches StoreKit/RevenueCat best practice: never lock out a previously-active user on an unverifiable check; only downgrade on a confirmed expiry.

## Verification

- `npm test`: 755/755 passing
- `npx tsc -p tsconfig.electron.json`: clean
- `npm run lint` on the changed hook: clean
- Please re-test on the Mac build: buy (or restore), quit, immediately relaunch → the app should stay unlocked without needing Restore. A genuinely expired sandbox sub should still show the wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_