### PR TITLE
iOS: fix Lifetime purchase dead-ending (not in RevenueCat Offering)

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/SubscriptionBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/SubscriptionBridge.swift
@@ -15,6 +15,8 @@ final class SubscriptionBridge {
     weak var webView: WKWebView?
 
     private let entitlementId = "pro"
+    private let productYearly = "com.dayglance.pro.yearly"
+    private let productLifetime = "com.dayglance.pro.lifetime"
 
     // MARK: - RevenueCat configuration
 
@@ -68,14 +70,27 @@ final class SubscriptionBridge {
     func purchase(productId: String) {
         Task {
             do {
-                let offerings = try await Purchases.shared.offerings()
-                guard let package = offerings.current?.availablePackages.first(where: {
-                    $0.storeProduct.productIdentifier == productId
-                }) else {
-                    fireBillingEvent(status: "error", code: 1, message: "Product not found", productId: productId)
-                    return
+                let result: PurchaseResultData
+                // Prefer the configured Offering package (preserves intro-offer
+                // metadata for the annual free trial), but fall back to the bare
+                // StoreKit product so a product that exists in App Store Connect but
+                // isn't attached to the current RevenueCat Offering — the usual case
+                // for the lifetime non-consumable — still purchases instead of
+                // dead-ending on "Product not found" (which surfaced as an endless
+                // spinner on the paywall: no StoreKit sheet, no login prompt).
+                if let offerings = try? await Purchases.shared.offerings(),
+                   let package = offerings.current?.availablePackages.first(where: {
+                       $0.storeProduct.productIdentifier == productId
+                   }) {
+                    result = try await Purchases.shared.purchase(package: package)
+                } else {
+                    let products = await Purchases.shared.products([productId])
+                    guard let product = products.first else {
+                        fireBillingEvent(status: "error", code: 1, message: "Product not found", productId: productId)
+                        return
+                    }
+                    result = try await Purchases.shared.purchase(product: product)
                 }
-                let result = try await Purchases.shared.purchase(package: package)
                 if result.userCancelled {
                     fireBillingEvent(status: "cancelled", code: -1, message: "User cancelled", productId: productId)
                 } else {
@@ -116,14 +131,16 @@ final class SubscriptionBridge {
 
     private func fetchPricesInBackground() {
         Task {
-            guard let offerings = try? await Purchases.shared.offerings(),
-                  let packages = offerings.current?.availablePackages else { return }
-            for pkg in packages {
-                let id    = pkg.storeProduct.productIdentifier
-                let price = pkg.storeProduct.localizedPriceString
-                if id.contains("yearly") || id.contains("annual") {
+            // Fetch prices by explicit product ID rather than only from the current
+            // Offering, so the lifetime price still populates even when the lifetime
+            // non-consumable isn't attached to the Offering in RevenueCat (otherwise
+            // the Lifetime card shows "Loading…" forever).
+            let products = await Purchases.shared.products([productYearly, productLifetime])
+            for product in products {
+                let price = product.localizedPriceString
+                if product.productIdentifier == productYearly {
                     UserDefaults.standard.set(price, forKey: "rc_price_yearly")
-                } else if id.contains("lifetime") {
+                } else if product.productIdentifier == productLifetime {
                     UserDefaults.standard.set(price, forKey: "rc_price_lifetime")
                 }
             }


### PR DESCRIPTION
## Problem

Tapping **Lifetime** on the iOS paywall spun forever — no StoreKit purchase sheet, no login prompt, no error.

`SubscriptionBridge.purchase()` looked for the product **only** in the current RevenueCat **Offering**:

```swift
guard let package = offerings.current?.availablePackages.first(where: {
    $0.storeProduct.productIdentifier == productId
}) else { /* dead-end */ }
```

The lifetime **non-consumable** typically isn't attached to the Offering (subscriptions usually are; one-time products usually aren't). When the package wasn't found, the call bailed before ever reaching StoreKit, so no purchase sheet appeared. This is **iOS-only** — Android (Play Billing) and Electron (StoreKit `inAppPurchase`) purchase by product ID directly, which is why only iOS Lifetime broke. The same Offering-only lookup also fed the price display, so the Lifetime card likely showed "Loading…" indefinitely.

## Fix

- **`purchase()`** — prefer the Offering package (preserves intro-offer metadata for the annual free trial), but **fall back to `Purchases.products([id])` + `purchase(product:)`** so a product that exists in App Store Connect but isn't in the Offering still purchases. A genuinely missing product now fires a clear `Product not found` error instead of a silent spinner.
- **`fetchPricesInBackground()`** — fetch prices by explicit product ID instead of only from the Offering, so the Lifetime price populates.

## Note on RevenueCat config (worth doing anyway)

This code change makes Lifetime work **regardless** of Offering setup, but for correctness you may still want to add the lifetime product to your RevenueCat Offering so it carries full paywall/offer metadata. Also confirm the product IDs (`com.dayglance.pro.yearly`, `com.dayglance.pro.lifetime`) match App Store Connect exactly and both products are in a purchasable state (agreements active, "Ready to Submit").

## Verification

- Swift change only; no JS/TS touched. Could not compile in this environment (no Xcode) — **please build in Xcode and test the Lifetime purchase on a device/TestFlight with a sandbox account.**
- Expected: tapping Lifetime now presents the StoreKit sheet; a real missing product shows a "Product not found" error rather than an endless spinner; the Lifetime price renders instead of "Loading…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_