### PR TITLE
Fix Mac paywall returning on relaunch: persist the optimistic unlock

### DIFF
--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -193,6 +193,18 @@ export function useSubscription() {
       const restoredActive = parsed.message === 'restore_complete_active';
       if (purchased || restoredActive) {
         setStatus((prev) => (prev.active ? prev : { active: true, productId: parsed.productId || prev.productId || null }));
+        // Electron/macOS: PERSIST the unlock immediately, not just in React state.
+        // The cold-launch receipt check often comes back indeterminate (macOS hasn't
+        // materialized the App Store receipt yet), so the only thing that keeps the
+        // app unlocked across relaunches is this cached value. Previously the
+        // optimistic unlock lived only for the session and the paywall returned on
+        // every reopen; a later determinate check (real receipt) still corrects it.
+        if (ELECTRON) {
+          try {
+            localStorage.setItem('rc_electron_status',
+              JSON.stringify({ active: true, productId: parsed.productId || null }));
+          } catch {}
+        }
         if (BILLING) setPrices(readPricesAndroid());
         if (IOS)     setPrices(readPricesIOS());
         reconcileStatus(); // fill accurate productId; never re-locks


### PR DESCRIPTION
## Problem

Even with #1184, the Mac paywall returned on **every** relaunch: you could Restore or re-purchase to get in, but quitting and reopening showed the wall again.

#1184 stopped a cold-launch *indeterminate* receipt check from downgrading an active user — but it relied on the renderer's `rc_electron_status` cache already holding `active:true`. That cache is only written from a **determinate-active** status read. On a Mac build whose App Store receipt isn't materialized yet (local build / TestFlight), the launch read stays *indeterminate*, so the cache was **never written active**. The purchase/restore optimistic unlock lived only in React state for the session, so it evaporated on quit.

## Fix

Persist the unlock to `rc_electron_status` the moment a `success` purchase or an active restore (`restore_complete_active`) fires — not only when a determinate status read happens. So the unlock survives relaunch. A later determinate check (real receipt present, e.g. a genuine App Store install) still corrects it if the entitlement has actually lapsed.

## Verification

- `npm test`: 755/755 passing
- `npm run lint`: clean on the changed file
- Please retest on the Mac build: purchase or restore, quit, reopen → should stay unlocked without Restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_