### PR TITLE
Fix Mac paywall prices stuck on "Loading…" (startup push race)

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -101,6 +101,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('subscription:purchase', productId),
   subscriptionRestore: (): Promise<void> =>
     ipcRenderer.invoke('subscription:restore'),
+  subscriptionPrices: (): Promise<{ yearly: string | null; lifetime: string | null }> =>
+    ipcRenderer.invoke('subscription:prices'),
   onSubscriptionEvent: (callback: (event: unknown) => void) => {
     const handler = (_: Electron.IpcRendererEvent, event: unknown) => callback(event);
     ipcRenderer.on('subscription:event', handler);

--- a/electron/subscription.ts
+++ b/electron/subscription.ts
@@ -14,6 +14,13 @@ const ENTITLEMENT_ID   = 'pro';
 const PRODUCT_YEARLY   = 'com.dayglance.pro.yearly';
 const PRODUCT_LIFETIME = 'com.dayglance.pro.lifetime';
 
+// Cached StoreKit prices, populated once at startup. The renderer both receives a
+// 'subscription:prices-ready' push AND can pull via 'subscription:prices'. The pull
+// closes the race where the push fired before the paywall mounted its listener —
+// Electron drops renderer-directed messages sent before a listener exists, which
+// left the price stuck on "Loading…" even though the fetch succeeded.
+let cachedPrices: { yearly: string | null; lifetime: string | null } = { yearly: null, lifetime: null };
+
 // ── Anonymous app user ID ─────────────────────────────────────────────────────
 // Derived from a hash of the userData path — stable per user+app installation,
 // no file I/O required. Identity is validated against the MAS receipt rather than
@@ -144,11 +151,12 @@ export function registerSubscriptionHandlers(window: BrowserWindow): void {
   // Fetch prices once from StoreKit on startup and cache them.
   if (process.platform === 'darwin' && inAppPurchase.canMakePayments()) {
     inAppPurchase.getProducts([PRODUCT_YEARLY, PRODUCT_LIFETIME]).then((products) => {
-      const prices: Record<string, string> = {};
+      const prices: { yearly: string | null; lifetime: string | null } = { yearly: null, lifetime: null };
       for (const p of products) {
         if (p.productIdentifier === PRODUCT_YEARLY)   prices.yearly   = p.formattedPrice;
         if (p.productIdentifier === PRODUCT_LIFETIME) prices.lifetime = p.formattedPrice;
       }
+      cachedPrices = prices;
       live()?.webContents.send('subscription:prices-ready', prices);
     }).catch(() => {});
   }
@@ -193,12 +201,10 @@ export function registerSubscriptionHandlers(window: BrowserWindow): void {
     return fetchEntitlementStatus();
   });
 
-  // Return last-known cached prices (already fetched at startup above).
-  ipcMain.handle('subscription:prices', () => {
-    // Prices are delivered via 'subscription:prices-ready' push on startup;
-    // this handle is a fallback for late callers.
-    return {};
-  });
+  // Return last-known cached prices. The renderer pulls this on mount so a paywall
+  // that mounted after the startup 'subscription:prices-ready' push (dropped, since
+  // no listener existed yet) still gets prices instead of showing "Loading…".
+  ipcMain.handle('subscription:prices', () => cachedPrices);
 
   // Open the Mac App Store purchase sheet via StoreKit.
   ipcMain.handle('subscription:purchase', async (_event, productId: string) => {

--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -237,6 +237,19 @@ export function useSubscription() {
     return unsub;
   }, []);
 
+  // Electron: also PULL cached prices on mount. The startup push can fire before
+  // this component registers its listener (Electron drops the message), which left
+  // the price stuck on "Loading…". The pull recovers prices already fetched; if the
+  // fetch hasn't finished yet, the push above still delivers them.
+  useEffect(() => {
+    if (!ELECTRON) return;
+    window.electronAPI.subscriptionPrices?.().then((p) => {
+      if (p && (p.yearly || p.lifetime)) {
+        setPrices({ yearly: p.yearly ?? null, lifetime: p.lifetime ?? null });
+      }
+    }).catch(() => {});
+  }, []);
+
   // On mount: background refresh for each platform.
   useEffect(() => {
     if (BILLING) {


### PR DESCRIPTION
## Problem

On the Mac paywall both price fields show **"Loading…"** indefinitely (the `$19.99` in the descriptions is the hardcoded fallback, not the live StoreKit price).

The macOS main process fetches StoreKit prices once at startup and **pushes** them via `subscription:prices-ready` — but:
- it never **caches** them (despite the comment saying it does), and
- the `subscription:prices` IPC handler was a stub that returned `{}`.

The renderer relied entirely on catching that single push. If the push fired **before** the React paywall mounted and registered its listener, Electron **dropped** the message (renderer-directed IPC isn't queued), so the price stayed "Loading…" forever — even though the fetch itself succeeded. Purchase still worked because it buys by product ID directly, independent of this block, which is why prices could be broken while purchasing was fine.

## Fix

- **Cache** the fetched prices in the main process.
- `subscription:prices` now returns the cached prices instead of `{}`.
- Expose `subscriptionPrices()` in preload.
- The renderer **pulls** cached prices on mount, in addition to listening for the push. The pull recovers prices already fetched; if the fetch is still in flight, the push delivers them. Either ordering now works.

## Verification

- `npm test`: 755/755
- `tsc` (electron main + preload): clean
- `npm run lint` (changed hook): clean
- Please rebuild the Mac app: the Annual/Lifetime cards should show real prices instead of "Loading…".

**Note:** this fixes the race. If prices *still_ show "Loading…" after this, it would mean `getProducts()` is returning empty — i.e., the products aren't fetchable in that particular Mac build (same class of thing iOS hit before TestFlight). But since purchasing already works on your Mac build, the products are reachable, so this race is the expected cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_