### PR TITLE
Fix macOS receipt validation: remove rejected `platform` body field

### DIFF
--- a/electron/subscription.ts
+++ b/electron/subscription.ts
@@ -190,8 +190,11 @@ async function fetchEntitlementStatus(): Promise<{ active: boolean; productId: s
   if (hasReceipt) {
     try {
       const fetchToken = fs.readFileSync(receiptPath!).toString('base64');
+      // Platform is conveyed via the X-Platform header (rcFetch). Putting it in the
+      // body is rejected: HTTP 400 {"code":7226,"message":"platform: Extra inputs
+      // are not permitted"} — which silently broke EVERY Mac receipt validation.
       const data = await rcFetch('POST', '/receipts', {
-        app_user_id: appUserId, fetch_token: fetchToken, platform: 'macos',
+        app_user_id: appUserId, fetch_token: fetchToken,
       });
       const sub = (data as any)?.subscriber;
       console.info('[subscription] POST /receipts entitlements =',


### PR DESCRIPTION
## The smoking gun

The diagnostics from #1191 caught it in the Terminal on the first run:

```
[subscription] receipt validation failed (indeterminate):
RevenueCat POST /receipts → HTTP 400: {"code":7226,"message":"platform: Extra inputs are not permitted"}
```

`POST /receipts` does **not** accept a `platform` field in the request body — platform is conveyed via the `X-Platform` header, which `rcFetch` already sends. The stray body field meant **every Mac receipt POST since the feature shipped was rejected at input validation**, before RevenueCat ever looked at the receipt.

This one field explains the entire macOS saga:
- Mac purchases never credited the Mac's `app_user_id` in RevenueCat (they only ever appeared via the iOS SDK posting the shared Apple-account receipt).
- Launch entitlement checks never succeeded; the old code couldn't distinguish the 400 from "not subscribed," so it re-locked the paywall on every relaunch/refresh/minimize.
- Setting the App Store shared secret appeared to do nothing — requests never got far enough to need it.

## Fix

Remove `platform` from the POST body (one line). The header stays.

## Expected after merge + rebuild

- Terminal shows `POST /receipts entitlements = {"pro":{…}}` — real validation, end to end.
- The Mac's customer in RevenueCat gets credited/aliased properly.
- A genuinely lapsed subscription re-locks correctly (the case #1191 alone couldn't cover).
- #1191's fail-open rules + lifetime latch remain as the safety net rather than the only thing keeping the app unlocked.

## Verification

- `tsc -p tsconfig.electron.json`: clean. One-line body change; no behavioral surface beyond the request shape.
- Please rebuild, run from Terminal once more, and confirm the `POST /receipts entitlements =` line shows the `pro` entitlement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_