### PR TITLE
iOS: silently recover entitlement transferred to another device

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/SubscriptionBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/SubscriptionBridge.swift
@@ -36,6 +36,14 @@ final class SubscriptionBridge {
 
     // MARK: - Synchronous bridge calls
 
+    /// Set once this install has ever observed an active entitlement. Used to tell
+    /// "was entitled, now reads inactive" (worth a silent recovery attempt) apart
+    /// from "never purchased" (show the paywall immediately, no wasted network).
+    private let wasActiveKey = "rc_was_active"
+
+    /// Guards the silent recovery to one attempt per app launch.
+    private var autoSyncAttempted = false
+
     /// Returns `{"active":bool,"productId":string|null}` from RevenueCat's cached info.
     func getStatus() -> String {
         #if DEBUG
@@ -43,9 +51,39 @@ final class SubscriptionBridge {
         #endif
         let info = Purchases.shared.cachedCustomerInfo
         let active = info?.entitlements[entitlementId]?.isActive == true
+        if active {
+            UserDefaults.standard.set(true, forKey: wasActiveKey)
+        } else if UserDefaults.standard.bool(forKey: wasActiveKey) {
+            autoSyncRecover()
+        }
         let productId = info?.entitlements[entitlementId]?.productIdentifier
         let productJson = productId.map { "\"\(esc($0))\"" } ?? "null"
         return "{\"active\":\(active),\"productId\":\(productJson)}"
+    }
+
+    /// Silent entitlement recovery for RevenueCat's "Transfer to new App User ID"
+    /// behavior. The Mac app posts its receipt on every entitlement check, which
+    /// TRANSFERS the shared Apple-account entitlement to the Mac's anonymous
+    /// customer — leaving this install's cache inactive even though the user has
+    /// paid. Instead of showing a paywall the user must manually Restore through,
+    /// sync the local receipt (which transfers the entitlement back) and, if it
+    /// comes back active, fire the same restore_complete_active event the JS
+    /// layer already handles by dismissing the wall. A genuinely lapsed
+    /// subscription stays inactive — syncPurchases posts the receipt, so its
+    /// answer is authoritative. At most one attempt per launch.
+    private func autoSyncRecover() {
+        guard !autoSyncAttempted else { return }
+        autoSyncAttempted = true
+        Task {
+            guard let info = try? await Purchases.shared.syncPurchases() else { return }
+            let ent = info.entitlements[entitlementId]
+            if ent?.isActive == true {
+                UserDefaults.standard.set(true, forKey: wasActiveKey)
+                fireBillingEvent(status: "cancelled", code: 0,
+                                 message: "restore_complete_active",
+                                 productId: ent?.productIdentifier ?? "")
+            }
+        }
     }
 
     /// Returns `{"com.dayglance.pro.yearly": bool}` from the cached eligibility check.


### PR DESCRIPTION
## Problem

RevenueCat's transfer behavior for this project is **"Transfer to new App User ID"** (the legacy "Share between App User IDs" option no longer exists for newer projects). The iOS app and the Mac app use two different anonymous customers for the same person, and the Mac **posts its receipt on every entitlement check** — each post transfers the shared Apple-account entitlement to the Mac's customer. The iPhone's next cache read then shows inactive, and a **paying** dual-device user gets the paywall until they manually tap Restore. Not acceptable.

## Fix — make iOS self-heal the way the Mac already does

- Track whether this install has **ever observed an active entitlement** (`rc_was_active` in UserDefaults).
- Every JS status read already flows through the bridge's `getStatus()`. When it reads inactive on a previously-active install, silently call **`syncPurchases()`** — posting this device's receipt transfers the entitlement back — and on success fire the existing `restore_complete_active` event, which the JS layer already handles by dismissing the wall (the #1183 path). No new JS code.
- The Mac self-heals implicitly (its every check posts the receipt), so with this change **both platforms pull the entitlement back on use** and the transfer ping-pong becomes invisible to the user. Worst case is a brief paywall flash on the second device while the sync round-trips.

## Safety properties

- **Never-purchased installs skip recovery entirely** — no flag set, no network call, paywall shows immediately.
- **A genuinely lapsed subscription stays locked** — `syncPurchases` posts the receipt, so its inactive answer is authoritative; no event fires.
- **One attempt per app launch** — no retry loops.
- Debug builds unaffected (existing `#if DEBUG` early return).

## Verification

Swift-only change; cannot compile here — **please build in Xcode** (it rides the rebuild already planned). To see it work: get entitled on the iPhone, run the Mac app (its check pulls the entitlement), then reopen the iPhone app — it should unlock itself within a second or two instead of requiring Restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPLUFoj334yRbW6a76mkG)_