### PR TITLE
Fix #1196: routines resurrecting after midnight, already marked done

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,7 +70,7 @@ import useTagFilter from './hooks/useTagFilter.js';
 import useOnboarding from './hooks/useOnboarding.js';
 import useDailyContent from './hooks/useDailyContent.js';
 import useHabits from './hooks/useHabits.js';
-import useRoutines from './hooks/useRoutines.js';
+import useRoutines, { sanitizeMergedRoutineCompletions, startOfTodayIso } from './hooks/useRoutines.js';
 import useGoalsProjects from './hooks/useGoalsProjects.js';
 import useFocusMode from './hooks/useFocusMode.js';
 import useTrmnlSync from './hooks/useTrmnlSync.js';
@@ -6037,11 +6037,28 @@ const DayPlanner = () => {
     // Only apply todayRoutines/routinesDate if the remote data is from today.
     // If it's from a previous day, skip it — local state (already cleared by loadData) is correct.
     const todayStr = dateToString(new Date());
+    // Sanitize merged completions for today (#1196 symptom 2): a merged payload
+    // can carry a PRIOR-day completion this device never tombstoned (offline
+    // overnight while another device completed the routine), and the mirror's
+    // routinesDate merges to newest so the today-gate above always passes.
+    // Applying it verbatim renders the routine already-done. Drop stale entries
+    // and raise their timestamps to the midnight tombstone so the heal also
+    // propagates back to the fleet on the next push; genuine today-completions
+    // and un-complete markers pass through verbatim (see the helper's doc).
+    const sanitizedRoutineState = data.routineCompletions
+      ? sanitizeMergedRoutineCompletions(
+          data.routineCompletions, data.routineCompletionTimestamps || {}, todayStr, startOfTodayIso(),
+        )
+      : null;
     if (data.routinesDate === todayStr) {
       if (data.todayRoutines) localStorage.setItem('day-planner-today-routines', JSON.stringify(data.todayRoutines));
       localStorage.setItem('day-planner-routines-date', data.routinesDate);
-      if (data.routineCompletions) localStorage.setItem('day-planner-routine-completions', JSON.stringify(data.routineCompletions));
-      if (data.routineCompletionTimestamps) localStorage.setItem('day-planner-routine-completion-timestamps', JSON.stringify(data.routineCompletionTimestamps));
+      if (sanitizedRoutineState) {
+        localStorage.setItem('day-planner-routine-completions', JSON.stringify(sanitizedRoutineState.completions));
+        localStorage.setItem('day-planner-routine-completion-timestamps', JSON.stringify(sanitizedRoutineState.timestamps));
+      } else if (data.routineCompletionTimestamps) {
+        localStorage.setItem('day-planner-routine-completion-timestamps', JSON.stringify(data.routineCompletionTimestamps));
+      }
     }
     // selectedTags is a per-device UI preference and is not applied to state here.
     // minimizedSections is synced to localStorage so the same section layout follows the user across devices.
@@ -6206,11 +6223,16 @@ const DayPlanner = () => {
     // Only apply today's routine state if the remote data is from today — matching
     // the localStorage guard above. If routinesDate is stale/off, applying it would
     // trigger the auto-clear effect in useRoutines and wipe todayRoutines to [].
-    if (data.routinesDate === dateToString(new Date())) {
+    // Completions apply SANITIZED (#1196 symptom 2 — see sanitizedRoutineState above).
+    if (data.routinesDate === todayStr) {
       if (data.todayRoutines) setTodayRoutines(data.todayRoutines);
       setRoutinesDate(data.routinesDate);
-      if (data.routineCompletions) setRoutineCompletions(data.routineCompletions);
-      if (data.routineCompletionTimestamps) setRoutineCompletionTimestamps(data.routineCompletionTimestamps);
+      if (sanitizedRoutineState) {
+        setRoutineCompletions(sanitizedRoutineState.completions);
+        setRoutineCompletionTimestamps(sanitizedRoutineState.timestamps);
+      } else if (data.routineCompletionTimestamps) {
+        setRoutineCompletionTimestamps(data.routineCompletionTimestamps);
+      }
     }
     if (data.use24HourClock !== undefined) setUse24HourClock(data.use24HourClock);
     if (data.weatherZip !== undefined) setWeatherZip(data.weatherZip);

--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -42,6 +42,38 @@ export const resetRoutineCompletionsForToday = (
   return { completions, timestamps };
 };
 
+// Sanitize a MERGED (sync-apply) routine-completion payload for today (#1196
+// symptom 2). A merged payload can carry a PRIOR-day completion — e.g. this
+// device was offline overnight, so it never stamped a midnight tombstone for a
+// completion made yesterday evening on another device; the stale remote
+// timestamp then beats the absent local one in the LWW merge. Applying that
+// payload verbatim renders the routine already-done today (every render site
+// keys on presence in routineCompletions).
+//
+// Unlike resetRoutineCompletionsForToday (the LOAD-time reset), this must NOT
+// rewrite timestamps wholesale: an un-complete marker (timestamp present,
+// completion absent) carries its real recency and downgrading it to midnight
+// would let a stale remote complete win the next merge. So: keep today's
+// completions and ALL timestamps verbatim; only a dropped stale completion has
+// its timestamp raised to the midnight tombstone (midnight out-dates any
+// prior-day stamp, so the heal propagates back to the fleet instead of only
+// masking the symptom locally).
+export const sanitizeMergedRoutineCompletions = (
+  incomingCompletions = {}, incomingTimestamps = {}, todayStr, midnightIso,
+) => {
+  const completions = {};
+  const timestamps = { ...incomingTimestamps };
+  for (const [id, date] of Object.entries(incomingCompletions)) {
+    if (date === todayStr) {
+      completions[id] = date;
+    } else {
+      const t = timestamps[id];
+      if (!(typeof t === 'string' && t >= midnightIso)) timestamps[id] = midnightIso;
+    }
+  }
+  return { completions, timestamps };
+};
+
 const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, hrOwnerRef }) => {
   // The dashboard's active owner (multi-user) or null in single-user mode.
   const currentOwner = () => hrOwnerRef?.current ?? null;
@@ -107,9 +139,26 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
   useEffect(() => {
     const todayStr = dateToString(new Date());
     if (routinesDate && routinesDate !== todayStr) {
+      // Speak the vanish-delete guard's language (#1196 symptom 1): every row
+      // this clear removes gets a removal tombstone stamped at local midnight,
+      // MERGED into the map (never wipe it — mid-day removal tombstones must
+      // survive for offline peers; the 60-day tombstone retention prunes them).
+      // Without the tombstone the guard classifies the cleared rows as a
+      // suspected local-state glitch and its heal re-fetches them from the
+      // vault — yesterday's routines resurrect onto today's timeline. The
+      // midnight stamp satisfies the guard's stale-tombstone rule (cleared
+      // rows' lastModified predates midnight) while staying OLDER than any
+      // same-chip re-placement made later today (handleRoutinesDone also
+      // clears the tombstone on local re-add), so fresh placements still win.
+      const midnightIso = startOfTodayIso();
+      if (todayRoutines.length > 0) {
+        const withCleared = { ...removedTodayRoutineIds };
+        for (const r of todayRoutines) withCleared[String(r.id)] = midnightIso;
+        setRemovedTodayRoutineIds(withCleared);
+        localStorage.setItem('day-planner-removed-today-routine-ids', JSON.stringify(withCleared));
+      }
       setTodayRoutines([]);
       setRoutinesDate(todayStr);
-      setRemovedTodayRoutineIds({});
       setRoutineCompletions({});
       // Don't just drop the completion timestamps — a bare clear leaves no
       // signal, so any device/vault snapshot still holding yesterday's
@@ -122,7 +171,6 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
       // Stamp the reset at local midnight of the new day — the same instant the
       // load-time reset uses — so an un-complete made later today on another
       // device still out-dates this tombstone and wins the merge.
-      const midnightIso = startOfTodayIso();
       const tombstones = {};
       for (const id of new Set([
         ...Object.keys(routineCompletions),
@@ -131,13 +179,13 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
         tombstones[id] = midnightIso;
       }
       setRoutineCompletionTimestamps(tombstones);
-      localStorage.removeItem('day-planner-removed-today-routine-ids');
       localStorage.setItem('day-planner-routine-completions', '{}');
       localStorage.setItem('day-planner-routine-completion-timestamps', JSON.stringify(tombstones));
     }
-    // routineCompletions/routineCompletionTimestamps are read only to build the
-    // rollover tombstones; the guard above no-ops every other (toggle-driven) run.
-  }, [currentTime, routinesDate, routineCompletions, routineCompletionTimestamps]);
+    // routineCompletions/routineCompletionTimestamps/todayRoutines/
+    // removedTodayRoutineIds are read only to build the rollover tombstones;
+    // the guard above no-ops every other (toggle-driven) run.
+  }, [currentTime, routinesDate, routineCompletions, routineCompletionTimestamps, todayRoutines, removedTodayRoutineIds]);
 
   const toggleRoutineCompletion = (routineId) => {
     const todayStr = dateToString(new Date());

--- a/src/hooks/useRoutines.test.js
+++ b/src/hooks/useRoutines.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resetRoutineCompletionsForToday, startOfTodayIso } from './useRoutines.js';
+import { resetRoutineCompletionsForToday, sanitizeMergedRoutineCompletions, startOfTodayIso } from './useRoutines.js';
 
 const TODAY = '2026-07-03';
 const MIDNIGHT = '2026-07-03T00:00:00.000Z'; // local-midnight stand-in for the tests
@@ -58,5 +58,63 @@ describe('startOfTodayIso', () => {
     expect(d.getMinutes()).toBe(0);
     expect(d.getSeconds()).toBe(0);
     expect(d.getMilliseconds()).toBe(0);
+  });
+});
+
+describe('sanitizeMergedRoutineCompletions (#1196 symptom 2 — sync-apply)', () => {
+  it('drops a stale prior-day completion and raises its timestamp to the midnight tombstone', () => {
+    const { completions, timestamps } = sanitizeMergedRoutineCompletions(
+      { chip1: YESTERDAY }, { chip1: YESTERDAY_TS }, TODAY, MIDNIGHT,
+    );
+    expect(completions.chip1).toBeUndefined(); // never renders as done today
+    expect(timestamps.chip1).toBe(MIDNIGHT);   // and the heal wins the next LWW merge
+  });
+
+  it("keeps today's completions verbatim", () => {
+    const { completions, timestamps } = sanitizeMergedRoutineCompletions(
+      { chip1: TODAY }, { chip1: TODAY_MORNING_TS }, TODAY, MIDNIGHT,
+    );
+    expect(completions.chip1).toBe(TODAY);
+    expect(timestamps.chip1).toBe(TODAY_MORNING_TS);
+  });
+
+  it('passes un-complete markers through VERBATIM — never downgrades their recency', () => {
+    // An un-complete made today at 09:00 (timestamp present, completion absent)
+    // must keep its real timestamp: rewriting it to midnight would let a stale
+    // remote complete from 08:00 win the next merge and resurrect the completion.
+    const { completions, timestamps } = sanitizeMergedRoutineCompletions(
+      {}, { chip1: TODAY_MORNING_TS }, TODAY, MIDNIGHT,
+    );
+    expect(completions.chip1).toBeUndefined();
+    expect(timestamps.chip1).toBe(TODAY_MORNING_TS);
+  });
+
+  it('does not lower a stale completion whose timestamp is already past midnight', () => {
+    // Inconsistent pair (yesterday-dated completion, today-stamped ts — clock skew
+    // or a cross-midnight write): the completion is still dropped, but the newer
+    // timestamp is kept so LWW ordering is preserved.
+    const { completions, timestamps } = sanitizeMergedRoutineCompletions(
+      { chip1: YESTERDAY }, { chip1: TODAY_MORNING_TS }, TODAY, MIDNIGHT,
+    );
+    expect(completions.chip1).toBeUndefined();
+    expect(timestamps.chip1).toBe(TODAY_MORNING_TS);
+  });
+
+  it('tolerates a stale completion with no timestamp at all (legacy data)', () => {
+    const { completions, timestamps } = sanitizeMergedRoutineCompletions(
+      { chip1: YESTERDAY }, {}, TODAY, MIDNIGHT,
+    );
+    expect(completions.chip1).toBeUndefined();
+    expect(timestamps.chip1).toBe(MIDNIGHT);
+  });
+
+  it('mixed payload: filters per-entry, leaves unrelated timestamps untouched', () => {
+    const { completions, timestamps } = sanitizeMergedRoutineCompletions(
+      { done: TODAY, stale: YESTERDAY },
+      { done: TODAY_MORNING_TS, stale: YESTERDAY_TS, marker: TODAY_MORNING_TS },
+      TODAY, MIDNIGHT,
+    );
+    expect(completions).toEqual({ done: TODAY });
+    expect(timestamps).toEqual({ done: TODAY_MORNING_TS, stale: MIDNIGHT, marker: TODAY_MORNING_TS });
   });
 });

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -1012,3 +1012,80 @@ describe('Wave B — payload-excluded baseline rows (the fresh-device churn loop
     expect(A.data.tasks).toHaveLength(12);
   });
 });
+
+describe('issue #1196 — the midnight rollover speaks the vanish-delete guard\'s language', () => {
+  beforeEach(() => {
+    global.localStorage = memLocalStorage();
+    setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 'tok', accountId: 'acct1' });
+    setSyncPassphrase('correct horse battery staple');
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  const routine = (id, lastModified) => ({
+    id, name: `routine ${id}`, bucket: 'everyday', startTime: '08:00',
+    duration: 15, isAllDay: false, lastModified,
+  });
+
+  it('a midnight clear WITH removal tombstones propagates real deletes — no guard skip, no heal, no resurrection', async () => {
+    const vault = createMemoryVault({ rowGet: true });
+    const A = makeDevice('A', vault, {
+      ...EMPTY,
+      todayRoutines: [routine('chipA', '2026-06-18T10:00:00.000Z'), routine('chipB', '2026-06-18T21:00:00.000Z')],
+      routinesDate: '2026-06-18',
+      removedTodayRoutineIds: {},
+    });
+    await A.engine.dbSyncCycle();
+    await A.engine.dbSyncCycle(); // settle the baseline
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const getRowSpy = vi.spyOn(vault, 'getRow');
+
+    // What useRoutines' FIXED rollover effect now writes at day change: rows
+    // cleared, removal tombstones stamped at local midnight of the new day.
+    const midnightIso = '2026-06-19T00:00:00.000Z';
+    A.data.removedTodayRoutineIds = { chipA: midnightIso, chipB: midnightIso };
+    A.data.todayRoutines = [];
+    A.data.routinesDate = '2026-06-19';
+    await A.engine.dbSyncCycle();
+
+    // Tombstone-authorized: no glitch classification, so no skip and no per-row
+    // heal fetches — the resurrection mechanics never engage.
+    expect(warnSpy.mock.calls.filter((c) => String(c[0]).includes('GUARD'))).toEqual([]);
+    expect(getRowSpy.mock.calls.some((c) => String(c[1]).startsWith('todayRoutines:'))).toBe(false);
+    // The vault rows are genuinely deleted (memory vault getRow → null when deleted).
+    expect(await vault.getRow('dayglance', 'todayRoutines:chipA')).toBeNull();
+    expect(await vault.getRow('dayglance', 'todayRoutines:chipB')).toBeNull();
+
+    // And they STAY gone across further cycles — yesterday's routines do not
+    // reappear on today's timeline.
+    await A.engine.dbSyncCycle();
+    await A.engine.dbSyncCycle();
+    expect(A.data.todayRoutines).toEqual([]);
+    const snap = JSON.parse(global.localStorage.getItem('dev-A-db-sync-snapshot') || '{}');
+    expect(snap['todayRoutines:chipA']).toBeUndefined();
+  });
+
+  it('CONTROL (the pre-fix bug): a bare clear with a WIPED tombstone map is skipped by the guard and resurrected by the heal', async () => {
+    const vault = createMemoryVault({ rowGet: true });
+    const A = makeDevice('A', vault, {
+      ...EMPTY,
+      todayRoutines: [routine('chipA', '2026-06-18T10:00:00.000Z')],
+      routinesDate: '2026-06-18',
+      removedTodayRoutineIds: {},
+    });
+    await A.engine.dbSyncCycle();
+    await A.engine.dbSyncCycle();
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // The OLD rollover: rows cleared, tombstone map wiped — no removal signal.
+    A.data.todayRoutines = [];
+    A.data.routinesDate = '2026-06-19';
+    await A.engine.dbSyncCycle();
+
+    // Guard skips the un-tombstoned vanish and the heal resurrects the row —
+    // this is the reported symptom, pinned here so the fix's contract is clear.
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('GUARD'))).toBe(true);
+    expect(A.data.todayRoutines.map((r) => r.id)).toContain('chipA');
+  });
+});


### PR DESCRIPTION
Closes #1196. Implements the issue's fix directions A and B, and covers C with a test. **Stacked on #1198** (the wiring-test file builds on its additions) — merge #1198 first and GitHub will retarget this to `main`; the diff here shows only the #1196 changes.

## Symptom 1 — resurrection (direction A, primary fix)

The midnight rollover cleared `todayRoutines` and **wiped** `removedTodayRoutineIds` — no removal signal. The vanish-delete guard then (correctly) classified the cleared rows as glitch-suspects and the heal re-fetched them from the vault; `routinesDate` merges to newest (already today), so the rollover never re-fired. The workflow had silently depended on pre-guard behavior where a bare vanish propagated as fleet-wide deletes.

The rollover now stamps every cleared row into `removedTodayRoutineIds` at **local midnight**, *merged* into the map rather than replacing it (mid-day removal tombstones must survive for offline peers; the existing 60-day retention prunes the map — `removedTodayRoutineIds` is already in `TOMBSTONE_BUNDLE_KEYS`). The guard's stale-tombstone rule authorizes the deletes (cleared rows carry yesterday's `lastModified`), while a same-chip re-placement later today still wins: locally `handleRoutinesDone` clears the tombstone on re-add, and cross-device the **pull-before-push** cycle ordering turns a pending delete into an upsert of the newer row.

## Symptom 2 — "already done" (direction B, at the choke point)

Done-ness rendering is presence-only at ~15 sites, and `applyEngineData` — the single apply path for **both** transports — applied merged completions **verbatim** behind a `routinesDate === today` gate that a post-rollover mirror always passes. So a prior-day completion this device never tombstoned (offline overnight while another device completed the routine; stale remote ts beats absent local ts in LWW) rendered as done today.

Rather than ~15 scattered `=== todayStr` comparisons, the fix sanitizes at the choke point via a new `sanitizeMergedRoutineCompletions`: stale prior-day completions are **dropped and their timestamps raised to the midnight tombstone**, so the heal propagates back to the fleet on the next push instead of only masking the symptom locally. Today's completions and **un-complete markers pass through verbatim** — this is why the load-time reset helper couldn't be reused: it would downgrade genuine un-complete recency to midnight on every pull and let stale remote completes win the merge. With state guaranteed to contain only today's completions, every presence-only render site and the presence-based toggle are correct by construction, including future ones.

## Direction C — verified

The new wiring test proves a tombstone-authorized removal propagates real deletes with zero guard involvement; mid-day removals use the identical mechanism with `now` stamps.

## Verification

8 new tests (**836 total, all green**; eslint + web build clean):
- 6 sanitizer units, including the un-complete-verbatim rule and the clock-skew completion/timestamp pair;
- 2 end-to-end wiring tests through the real engine + crypto: the fixed rollover (deletes propagate, **zero** heal fetches, rows stay gone across cycles, baseline converges) and a **control test pinning the pre-fix bug** (bare clear → guard skip → heal resurrection), so the contract this fix establishes is explicit in the suite.

Field signature after shipping: crossing midnight produces no GUARD lines at all — the rollover's deletes propagate silently, and yesterday's routines stay gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu1rDx1mCGDzwTK8yVBTnn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fu1rDx1mCGDzwTK8yVBTnn)_