### PR TITLE
Android: bump versionCode to 172

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 171
+        versionCode = 172
         versionName = "4.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
versionCode 171 → 172 for a fresh device-rollout build. versionName stays `4.0.0`.

Rolls up everything merged since 171:
- `@glance-apps/billing` 0.1.0 consumed from npm (workspace retired, #1200)
- vault-sync excluded-row churn fix (#1198)
- routine midnight-resurrection fix (#1196 / #1199)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu1rDx1mCGDzwTK8yVBTnn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fu1rDx1mCGDzwTK8yVBTnn)_