### PR TITLE
Fix vault-sync churn: release file-tier zombie-dropped tasks from the diff baseline

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1901,10 +1901,6 @@ const DayPlanner = () => {
       // exclusion rule buildSyncPayload uses (payloadExclusions.js) — a
       // baseline row of an excluded class is neither a delete nor a glitch.
       isMultiUserEnabled: () => engineCallbacksRef.current.multiUserEnabled === true,
-      // Feeds the retention-aged release branch: a completed task pruned past
-      // this window by the file tier vanishes from getData() with no tombstone;
-      // the classifier releases it from the baseline instead of healing forever.
-      getSyncRetentionDays: () => engineCallbacksRef.current.syncRetentionDays ?? 90,
       onStatusChange: (s) => {
         setVaultStatus(s);
         if (s === 'success') {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1901,6 +1901,10 @@ const DayPlanner = () => {
       // exclusion rule buildSyncPayload uses (payloadExclusions.js) — a
       // baseline row of an excluded class is neither a delete nor a glitch.
       isMultiUserEnabled: () => engineCallbacksRef.current.multiUserEnabled === true,
+      // Feeds the retention-aged release branch: a completed task pruned past
+      // this window by the file tier vanishes from getData() with no tombstone;
+      // the classifier releases it from the baseline instead of healing forever.
+      getSyncRetentionDays: () => engineCallbacksRef.current.syncRetentionDays ?? 90,
       onStatusChange: (s) => {
         setVaultStatus(s);
         if (s === 'success') {

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -41,7 +41,7 @@ import {
 } from './dbAdapter.js';
 import { pruneAllTombstones, tombstoneCutoff } from './tombstoneRetention.js';
 import { partitionSnapshotDeletes } from './snapshotDeleteGuard.js';
-import { isPayloadExcludedEntity, isRetentionReleasableEntity } from './payloadExclusions.js';
+import { isPayloadExcludedEntity, agedOutReleaseReason } from './payloadExclusions.js';
 import { shredHashes, hashMapsEqual, mergeMidCycleEdits } from './commitMerge.js';
 
 const APP_ID = 'dayglance';
@@ -505,22 +505,20 @@ export function createDbEngine(callbacks = {}) {
           wantDelete, cur, mirror, getPrevEntity,
           // Baseline-release classification: a baseline row whose last-known copy
           // can NEVER reappear in getData() is neither a delete nor a glitch, and
-          // healing it every cycle is the churn loop this closes. Two independent
-          // causes, each with its own reason string (payloadExclusions.js):
-          //   'payload-excluded' — a class buildSyncPayload structurally excludes
-          //     (native / non-synced imports); same predicate the payload uses.
-          //   'retention-aged'   — a completed task this device aged out of its
-          //     live list (auto-archived, or pruned past the retention window by
-          //     the file tier), invisibly to the vault.
+          // healing it every cycle is the churn loop this closes. Causes, each
+          // with its own reason string (payloadExclusions.js):
+          //   'payload-excluded'        — a class buildSyncPayload structurally
+          //     excludes (native / non-synced imports); the payload's own rule.
+          //   'completed' / 'sync-horizon' — a task the file tier's zombie-drop
+          //     keeps out of getData() (completed & aged, or older than the sync
+          //     horizon), invisibly to the vault. The horizon is the SAME 60-day
+          //     tombstoneCutoff the file-tier merge uses as tombstonePrunedBefore.
           (eid) => {
             const ent = getPrevEntity(eid);
             if (isPayloadExcludedEntity(ent, {
               multiUserEnabled: callbacks.isMultiUserEnabled?.() === true,
             })) return 'payload-excluded';
-            if (isRetentionReleasableEntity(ent, {
-              retentionDays: callbacks.getSyncRetentionDays?.() ?? 0,
-            })) return 'retention-aged';
-            return false;
+            return agedOutReleaseReason(ent, { horizonMs: tombstoneCutoff().getTime() });
           },
         );
         glitchSkipped = skipped;
@@ -529,13 +527,14 @@ export function createDbEngine(callbacks = {}) {
           // untouched in the vault; the next SAVED snapshot (hashed from the
           // mirror, which never contains them) simply stops tracking them. Info-
           // level on purpose — this is a one-time convergence, not a problem.
-          let nPayload = 0, nRetention = 0;
+          const counts = { 'payload-excluded': 0, completed: 0, 'sync-horizon': 0 };
           for (const eid of excluded) {
-            if (reasons[eid] === 'retention-aged') nRetention++; else nPayload++;
+            if (reasons[eid] in counts) counts[reasons[eid]]++;
           }
           const breakdown = [
-            nPayload ? `${nPayload} payload-excluded (native / non-synced imports)` : '',
-            nRetention ? `${nRetention} retention-aged (completed tasks this device aged out)` : '',
+            counts['payload-excluded'] ? `${counts['payload-excluded']} payload-excluded (native / non-synced imports)` : '',
+            counts.completed ? `${counts.completed} completed (aged out of the working set)` : '',
+            counts['sync-horizon'] ? `${counts['sync-horizon']} sync-horizon (older than the file-tier zombie-drop fence)` : '',
           ].filter(Boolean).join(', ');
           console.info(
             `[push] baseline: released ${excluded.length} row(s) — ${breakdown}. ` +

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -41,7 +41,7 @@ import {
 } from './dbAdapter.js';
 import { pruneAllTombstones, tombstoneCutoff } from './tombstoneRetention.js';
 import { partitionSnapshotDeletes } from './snapshotDeleteGuard.js';
-import { isPayloadExcludedEntity } from './payloadExclusions.js';
+import { isPayloadExcludedEntity, isRetentionReleasableEntity } from './payloadExclusions.js';
 import { shredHashes, hashMapsEqual, mergeMidCycleEdits } from './commitMerge.js';
 
 const APP_ID = 'dayglance';
@@ -503,14 +503,25 @@ export function createDbEngine(callbacks = {}) {
         };
         const { propagate, skipped, excluded, reasons } = partitionSnapshotDeletes(
           wantDelete, cur, mirror, getPrevEntity,
-          // Payload-excluded classification: a baseline row whose last-known copy
-          // belongs to a class buildSyncPayload structurally excludes can NEVER
-          // reappear in getData() — it is neither a delete nor a glitch, and
-          // healing it every cycle is the churn loop this closes. The predicate
-          // is the same one buildSyncPayload uses (payloadExclusions.js).
-          (eid) => isPayloadExcludedEntity(getPrevEntity(eid), {
-            multiUserEnabled: callbacks.isMultiUserEnabled?.() === true,
-          }),
+          // Baseline-release classification: a baseline row whose last-known copy
+          // can NEVER reappear in getData() is neither a delete nor a glitch, and
+          // healing it every cycle is the churn loop this closes. Two independent
+          // causes, each with its own reason string (payloadExclusions.js):
+          //   'payload-excluded' — a class buildSyncPayload structurally excludes
+          //     (native / non-synced imports); same predicate the payload uses.
+          //   'retention-aged'   — a completed task this device aged out of its
+          //     live list (auto-archived, or pruned past the retention window by
+          //     the file tier), invisibly to the vault.
+          (eid) => {
+            const ent = getPrevEntity(eid);
+            if (isPayloadExcludedEntity(ent, {
+              multiUserEnabled: callbacks.isMultiUserEnabled?.() === true,
+            })) return 'payload-excluded';
+            if (isRetentionReleasableEntity(ent, {
+              retentionDays: callbacks.getSyncRetentionDays?.() ?? 0,
+            })) return 'retention-aged';
+            return false;
+          },
         );
         glitchSkipped = skipped;
         if (excluded.length) {
@@ -518,11 +529,19 @@ export function createDbEngine(callbacks = {}) {
           // untouched in the vault; the next SAVED snapshot (hashed from the
           // mirror, which never contains them) simply stops tracking them. Info-
           // level on purpose — this is a one-time convergence, not a problem.
+          let nPayload = 0, nRetention = 0;
+          for (const eid of excluded) {
+            if (reasons[eid] === 'retention-aged') nRetention++; else nPayload++;
+          }
+          const breakdown = [
+            nPayload ? `${nPayload} payload-excluded (native / non-synced imports)` : '',
+            nRetention ? `${nRetention} retention-aged (completed tasks this device aged out)` : '',
+          ].filter(Boolean).join(', ');
           console.info(
-            `[push] baseline: released ${excluded.length} payload-excluded row(s) — ` +
-            `vault rows of classes this device's payload never lists (native / non-synced imports). ` +
+            `[push] baseline: released ${excluded.length} row(s) — ${breakdown}. ` +
             `Not deletes, not glitches; nothing was fetched or removed from the vault. Ids:`,
-            excluded.slice(0, 10), excluded.length > 10 ? `(+${excluded.length - 10} more)` : ''
+            excluded.slice(0, 10).map((id) => `${id} (${reasons[id]})`),
+            excluded.length > 10 ? `(+${excluded.length - 10} more)` : ''
           );
         }
         for (const id of propagate) {

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -1013,6 +1013,131 @@ describe('Wave B — payload-excluded baseline rows (the fresh-device churn loop
   });
 });
 
+describe('Wave C — retention-aged release: the two-tier prune-vs-vault fight (wife\'s-Mac churn)', () => {
+  beforeEach(() => {
+    global.localStorage = memLocalStorage();
+    setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 'tok', accountId: 'acct1' });
+    setSyncPassphrase('correct horse battery staple');
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  const snapOf = (name) => JSON.parse(global.localStorage.getItem(`dev-${name}-db-sync-snapshot`) || 'null');
+
+  // A device whose getData models the FILE TIER's retention prune: completed
+  // tasks that are archived, or completed + older than the retention window,
+  // have been aged out of React state (WebDAV/iCloud retention) and so never
+  // appear in the payload — while their rows still sit in the vault. This is the
+  // exact split-brain behind the observed churn: the file tier removes them, the
+  // vault vanish-guard keeps re-fetching them. retentionDays is wired through so
+  // the classifier can release the aged-but-unarchived population too.
+  function makeRetentionDevice(name, vault, initial, retentionDays = 30) {
+    let data = clone(initial);
+    let nativeKey = null;
+    const nowMs = Date.now();
+    const aged = (t) => {
+      if (!t.completed) return false;
+      if (t.archived) return true;
+      const ms = Date.parse(t.completedAt || t.lastModified || '');
+      return Number.isFinite(ms) && ms < nowMs - retentionDays * 86400e3;
+    };
+    const engine = createDbEngine({
+      vaultClient: vault,
+      storageKeyPrefix: `dev-${name}`,
+      deviceId: `device-${name}`,
+      nativeGetSyncKey: () => nativeKey,
+      nativeStoreSyncKey: (v) => { nativeKey = v; },
+      getData: () => {
+        const d = clone(data);
+        d.tasks = d.tasks.filter((t) => !aged(t));
+        d.unscheduledTasks = d.unscheduledTasks.filter((t) => !aged(t));
+        return d;
+      },
+      commitData: (d) => { data = d; },
+      isMultiUserEnabled: () => false,
+      getSyncRetentionDays: () => retentionDays,
+    });
+    return { engine, get data() { return data; } };
+  }
+
+  it('THE FIGHT ends: completed+archived and completed+aged rows in the baseline are RELEASED once — no heal storm, vault untouched', async () => {
+    const vault = createMemoryVault({ rowGet: true });
+    // An old/peer device seeds the vault with the two stuck populations plus one
+    // live synced task, exactly as the wife's-Mac console showed.
+    const archivedInbox = task(500, '2026-04-01T10:00:00.000Z', { completed: true, archived: true });
+    const agedScheduled = task(501, '2026-04-02T10:00:00.000Z', {
+      completed: true, completedAt: '2026-04-02T10:00:00.000Z', date: '2026-04-02',
+    });
+    const live = task(502, '2026-06-18T10:00:00.000Z');
+    const A = makeDevice('A', vault, {
+      ...EMPTY,
+      unscheduledTasks: [archivedInbox],
+      tasks: [agedScheduled, live],
+    });
+    await A.engine.dbSyncCycle();
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const getRowSpy = vi.spyOn(vault, 'getRow');
+    const delSpy = vi.spyOn(vault, 'deleteRow');
+
+    // The retention device full-pulls all three rows into mirror + snapshot, but
+    // its payload never lists the two aged ones (the file tier pruned them).
+    const B = makeRetentionDevice('B', vault, { ...EMPTY });
+    await B.engine.dbSyncCycle(); // full pull ingests all rows into the baseline
+    expect(snapOf('B')['unscheduledTasks:500']).toBeDefined();
+    expect(snapOf('B')['tasks:501']).toBeDefined();
+
+    await B.engine.dbSyncCycle(); // classification cycle: both aged rows released
+    await B.engine.dbSyncCycle(); // must already be clean
+    await B.engine.dbSyncCycle(); // and STAY clean — no re-fight
+
+    // Released as retention-aged exactly once, then silence.
+    const released = infoSpy.mock.calls.filter((c) => String(c[0]).includes('retention-aged'));
+    expect(released).toHaveLength(1);
+    // No GUARD skip/recover churn — this was the endless stream of GUARD messages.
+    expect(warnSpy.mock.calls.filter((c) => String(c[0]).includes('GUARD'))).toEqual([]);
+    // The heal NEVER fetched the aged rows — that per-row storm is what pinned
+    // the inbox count and rate-limited the vault.
+    expect(getRowSpy.mock.calls.some((c) => c[1] === 'unscheduledTasks:500')).toBe(false);
+    expect(getRowSpy.mock.calls.some((c) => c[1] === 'tasks:501')).toBe(false);
+    // NOTHING was deleted from the vault — the rows survive for other devices
+    // (this is the "deletes nothing" guarantee of the guard-side release).
+    const deleted = delSpy.mock.calls.map((c) => c[1]);
+    expect(deleted).not.toContain('unscheduledTasks:500');
+    expect(deleted).not.toContain('tasks:501');
+    expect(await vault.getRow('dayglance', 'unscheduledTasks:500')).not.toBeNull();
+    expect(await vault.getRow('dayglance', 'tasks:501')).not.toBeNull();
+    // The baseline stops tracking the aged rows; the live synced row is unaffected.
+    expect(snapOf('B')['unscheduledTasks:500']).toBeUndefined();
+    expect(snapOf('B')['tasks:501']).toBeUndefined();
+    expect(snapOf('B')['tasks:502']).toBeDefined();
+    expect(B.data.tasks.some((t) => t.id === 502)).toBe(true);
+  });
+
+  it('CONTRAST: an ACTIVE (not-completed) task that transiently vanishes is NOT released — it still heals', async () => {
+    // The release is completion-gated: a live task that briefly drops out of
+    // getData must never be swept up as "retention-aged" — it heals as before.
+    const vault = createMemoryVault({ rowGet: true });
+    const A = makeDevice('A', vault, {
+      ...EMPTY,
+      tasks: [task(600, '2026-04-01T10:00:00.000Z'), task(601, '2026-06-18T10:00:00.000Z')],
+    });
+    const B = makeRetentionDevice('B', vault, { ...EMPTY });
+    await runRounds(A, B);
+    expect(B.data.tasks.map((t) => t.id).sort()).toEqual([600, 601]);
+
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const getRowSpy = vi.spyOn(vault, 'getRow');
+    // 600 is OLD but NOT completed → the retention filter does not drop it; force
+    // a transient shrink on A instead and confirm it heals (not released).
+    A.data.tasks = A.data.tasks.filter((t) => t.id !== 600);
+    await A.engine.dbSyncCycle();
+    expect(getRowSpy.mock.calls.some((c) => c[1] === 'tasks:600')).toBe(true); // healed, not released
+    expect(infoSpy.mock.calls.filter((c) => String(c[0]).includes('retention-aged'))).toEqual([]);
+    expect(A.data.tasks.map((t) => t.id)).toContain(600);
+  });
+});
+
 describe('issue #1196 — the midnight rollover speaks the vanish-delete guard\'s language', () => {
   beforeEach(() => {
     global.localStorage = memLocalStorage();

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -1013,7 +1013,7 @@ describe('Wave B — payload-excluded baseline rows (the fresh-device churn loop
   });
 });
 
-describe('Wave C — retention-aged release: the two-tier prune-vs-vault fight (wife\'s-Mac churn)', () => {
+describe('Wave C — file-tier aged-out release: the zombie-drop-vs-vault fight (wife\'s-Mac churn)', () => {
   beforeEach(() => {
     global.localStorage = memLocalStorage();
     setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 'tok', accountId: 'acct1' });
@@ -1023,22 +1023,21 @@ describe('Wave C — retention-aged release: the two-tier prune-vs-vault fight (
 
   const snapOf = (name) => JSON.parse(global.localStorage.getItem(`dev-${name}-db-sync-snapshot`) || 'null');
 
-  // A device whose getData models the FILE TIER's retention prune: completed
-  // tasks that are archived, or completed + older than the retention window,
-  // have been aged out of React state (WebDAV/iCloud retention) and so never
-  // appear in the payload — while their rows still sit in the vault. This is the
-  // exact split-brain behind the observed churn: the file tier removes them, the
-  // vault vanish-guard keeps re-fetching them. retentionDays is wired through so
-  // the classifier can release the aged-but-unarchived population too.
-  function makeRetentionDevice(name, vault, initial, retentionDays = 30) {
+  // A device whose getData models the FILE TIER's zombie-drop (@glance-apps/sync
+  // mergeArrayById): a local-only task that is completed, or whose lastModified
+  // predates the 60-day sync horizon (tombstonePrunedBefore), is silently dropped
+  // from React state — while its row still sits in the vault. This is the exact
+  // split-brain behind the observed churn: the file tier removes it, the vault
+  // vanish-guard keeps re-fetching it. No getSyncRetentionDays wiring — the
+  // classifier derives the horizon from tombstoneCutoff() itself.
+  const HORIZON = Date.now() - 60 * 86400e3;
+  function makeZombieDropDevice(name, vault, initial) {
     let data = clone(initial);
     let nativeKey = null;
-    const nowMs = Date.now();
-    const aged = (t) => {
-      if (!t.completed) return false;
-      if (t.archived) return true;
-      const ms = Date.parse(t.completedAt || t.lastModified || '');
-      return Number.isFinite(ms) && ms < nowMs - retentionDays * 86400e3;
+    const zombie = (t) => {
+      if (t.completed === true) return true; // completed rows the app aged out
+      const lm = Date.parse(t.lastModified || '');
+      return Number.isFinite(lm) && lm < HORIZON; // older than the sync horizon
     };
     const engine = createDbEngine({
       vaultClient: vault,
@@ -1048,30 +1047,28 @@ describe('Wave C — retention-aged release: the two-tier prune-vs-vault fight (
       nativeStoreSyncKey: (v) => { nativeKey = v; },
       getData: () => {
         const d = clone(data);
-        d.tasks = d.tasks.filter((t) => !aged(t));
-        d.unscheduledTasks = d.unscheduledTasks.filter((t) => !aged(t));
+        d.tasks = d.tasks.filter((t) => !zombie(t));
+        d.unscheduledTasks = d.unscheduledTasks.filter((t) => !zombie(t));
         return d;
       },
       commitData: (d) => { data = d; },
       isMultiUserEnabled: () => false,
-      getSyncRetentionDays: () => retentionDays,
     });
     return { engine, get data() { return data; } };
   }
 
-  it('THE FIGHT ends: completed+archived and completed+aged rows in the baseline are RELEASED once — no heal storm, vault untouched', async () => {
+  it('THE FIGHT ends: completed (inbox+scheduled) and horizon-aged rows are RELEASED once — no heal storm, vault untouched', async () => {
     const vault = createMemoryVault({ rowGet: true });
-    // An old/peer device seeds the vault with the two stuck populations plus one
-    // live synced task, exactly as the wife's-Mac console showed.
-    const archivedInbox = task(500, '2026-04-01T10:00:00.000Z', { completed: true, archived: true });
-    const agedScheduled = task(501, '2026-04-02T10:00:00.000Z', {
-      completed: true, completedAt: '2026-04-02T10:00:00.000Z', date: '2026-04-02',
-    });
-    const live = task(502, '2026-06-18T10:00:00.000Z');
+    // An old/peer device seeds the vault with the observed stuck populations plus
+    // one live synced task, as the wife's-Mac console showed.
+    const completedInbox = task(500, '2026-04-01T10:00:00.000Z', { completed: true, archived: true });
+    const completedScheduled = task(501, '2026-04-02T10:00:00.000Z', { completed: true, date: '2026-04-02' }); // the 65: completed, NOT archived
+    const staleIncomplete = task(503, '2026-01-05T10:00:00.000Z'); // >60d, incomplete → 'sync-horizon'
+    const live = task(502, new Date(Date.now() - 86400e3).toISOString()); // recent + incomplete → stays live for any run date
     const A = makeDevice('A', vault, {
       ...EMPTY,
-      unscheduledTasks: [archivedInbox],
-      tasks: [agedScheduled, live],
+      unscheduledTasks: [completedInbox],
+      tasks: [completedScheduled, staleIncomplete, live],
     });
     await A.engine.dbSyncCycle();
 
@@ -1080,60 +1077,68 @@ describe('Wave C — retention-aged release: the two-tier prune-vs-vault fight (
     const getRowSpy = vi.spyOn(vault, 'getRow');
     const delSpy = vi.spyOn(vault, 'deleteRow');
 
-    // The retention device full-pulls all three rows into mirror + snapshot, but
-    // its payload never lists the two aged ones (the file tier pruned them).
-    const B = makeRetentionDevice('B', vault, { ...EMPTY });
+    // The zombie-drop device full-pulls all rows into mirror + snapshot, but its
+    // payload never lists the three aged ones (the file tier dropped them).
+    const B = makeZombieDropDevice('B', vault, { ...EMPTY });
     await B.engine.dbSyncCycle(); // full pull ingests all rows into the baseline
     expect(snapOf('B')['unscheduledTasks:500']).toBeDefined();
     expect(snapOf('B')['tasks:501']).toBeDefined();
+    expect(snapOf('B')['tasks:503']).toBeDefined();
 
-    await B.engine.dbSyncCycle(); // classification cycle: both aged rows released
+    await B.engine.dbSyncCycle(); // classification cycle: the three aged rows released
     await B.engine.dbSyncCycle(); // must already be clean
     await B.engine.dbSyncCycle(); // and STAY clean — no re-fight
 
-    // Released as retention-aged exactly once, then silence.
-    const released = infoSpy.mock.calls.filter((c) => String(c[0]).includes('retention-aged'));
+    // Released exactly once, then silence — and the log names both causes.
+    const released = infoSpy.mock.calls.filter((c) => /completed|sync-horizon/.test(String(c[0])));
     expect(released).toHaveLength(1);
+    expect(String(released[0][0])).toContain('completed');
+    expect(String(released[0][0])).toContain('sync-horizon');
     // No GUARD skip/recover churn — this was the endless stream of GUARD messages.
     expect(warnSpy.mock.calls.filter((c) => String(c[0]).includes('GUARD'))).toEqual([]);
-    // The heal NEVER fetched the aged rows — that per-row storm is what pinned
-    // the inbox count and rate-limited the vault.
-    expect(getRowSpy.mock.calls.some((c) => c[1] === 'unscheduledTasks:500')).toBe(false);
-    expect(getRowSpy.mock.calls.some((c) => c[1] === 'tasks:501')).toBe(false);
+    // The heal NEVER fetched the aged rows — that per-row storm pinned the count
+    // and rate-limited the vault.
+    for (const id of ['unscheduledTasks:500', 'tasks:501', 'tasks:503']) {
+      expect(getRowSpy.mock.calls.some((c) => c[1] === id)).toBe(false);
+    }
     // NOTHING was deleted from the vault — the rows survive for other devices
-    // (this is the "deletes nothing" guarantee of the guard-side release).
+    // (the "deletes nothing" guarantee of the guard-side release).
     const deleted = delSpy.mock.calls.map((c) => c[1]);
-    expect(deleted).not.toContain('unscheduledTasks:500');
-    expect(deleted).not.toContain('tasks:501');
+    for (const id of ['unscheduledTasks:500', 'tasks:501', 'tasks:503']) {
+      expect(deleted).not.toContain(id);
+    }
     expect(await vault.getRow('dayglance', 'unscheduledTasks:500')).not.toBeNull();
     expect(await vault.getRow('dayglance', 'tasks:501')).not.toBeNull();
     // The baseline stops tracking the aged rows; the live synced row is unaffected.
     expect(snapOf('B')['unscheduledTasks:500']).toBeUndefined();
     expect(snapOf('B')['tasks:501']).toBeUndefined();
+    expect(snapOf('B')['tasks:503']).toBeUndefined();
     expect(snapOf('B')['tasks:502']).toBeDefined();
     expect(B.data.tasks.some((t) => t.id === 502)).toBe(true);
   });
 
-  it('CONTRAST: an ACTIVE (not-completed) task that transiently vanishes is NOT released — it still heals', async () => {
-    // The release is completion-gated: a live task that briefly drops out of
-    // getData must never be swept up as "retention-aged" — it heals as before.
+  it('CONTRAST: a RECENT active task that transiently vanishes is NOT released — it still heals', async () => {
+    // A live, recently-touched task that briefly drops out of getData must never
+    // be swept up as aged-out — it fails both branches (incomplete + fresh) and
+    // heals via the row re-fetch, exactly as before.
     const vault = createMemoryVault({ rowGet: true });
+    const recent = new Date(Date.now() - 86400e3).toISOString(); // yesterday: inside the horizon for any wall-clock run
     const A = makeDevice('A', vault, {
       ...EMPTY,
-      tasks: [task(600, '2026-04-01T10:00:00.000Z'), task(601, '2026-06-18T10:00:00.000Z')],
+      tasks: [task(600, recent), task(601, recent)],
     });
-    const B = makeRetentionDevice('B', vault, { ...EMPTY });
+    const B = makeZombieDropDevice('B', vault, { ...EMPTY });
     await runRounds(A, B);
     expect(B.data.tasks.map((t) => t.id).sort()).toEqual([600, 601]);
 
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const getRowSpy = vi.spyOn(vault, 'getRow');
-    // 600 is OLD but NOT completed → the retention filter does not drop it; force
-    // a transient shrink on A instead and confirm it heals (not released).
+    // 600 is recent AND incomplete → neither branch fires; force a transient
+    // shrink on A and confirm it heals (not released).
     A.data.tasks = A.data.tasks.filter((t) => t.id !== 600);
     await A.engine.dbSyncCycle();
     expect(getRowSpy.mock.calls.some((c) => c[1] === 'tasks:600')).toBe(true); // healed, not released
-    expect(infoSpy.mock.calls.filter((c) => String(c[0]).includes('retention-aged'))).toEqual([]);
+    expect(infoSpy.mock.calls.filter((c) => /completed|sync-horizon/.test(String(c[0])))).toEqual([]);
     expect(A.data.tasks.map((t) => t.id)).toContain(600);
   });
 });

--- a/src/sync/payloadExclusions.js
+++ b/src/sync/payloadExclusions.js
@@ -45,46 +45,50 @@ export function isPayloadExcludedEntity(entity, { multiUserEnabled = false } = {
   return false;
 }
 
-const parseMs = (v) => {
-  if (v == null) return NaN;
-  const t = new Date(v).getTime();
-  return Number.isNaN(t) ? NaN : t;
-};
-
 /**
- * True when [entity] — a mirror/snapshot wrap ({ _kind, value }) — is a task the
- * DEVICE has intentionally aged out of its live list, so the vault delete guard
- * should release it from the diff baseline rather than heal-fetch it forever.
+ * Reason to RELEASE a would-be-glitch vanish whose snapshot copy the FILE TIER
+ * (WebDAV / iCloud) will keep out of getData() every cycle — or null to keep the
+ * glitch classification. Healing such a row is FUTILE: the file tier re-drops it,
+ * the vault vanish-guard re-fetches it, forever (the observed endless GUARD churn
+ * — 85 completed inbox rows + 65 completed scheduled rows on a device whose file
+ * tier had aged them out while the vault kept resurrecting them).
  *
- * The file tier (WebDAV / iCloud) prunes old completed tasks per the retention
- * window WITHOUT writing a vault tombstone. Those rows then vanish from getData()
- * while still sitting in the vault, so the snapshot diff flags them as would-be
- * deletes with no fingerprint → 'glitch' → per-row re-fetch → re-commit →
- * re-vanish, every cycle (the observed 85-inbox + 150-scheduled churn on a device
- * synced to a peer that keeps re-adding them). These are NOT glitches: the row is
- * deterministically absent because the device aged it out. Two shapes qualify,
- * both COMPLETED (never release an active task):
- *   • completed && archived                          — auto-archived inbox item
- *   • completed && (completedAt|lastModified older    — pruned by the retention
- *     than retentionDays)                               window on the file tier
- * Only `tasks` / `unscheduledTasks` kinds are eligible. retentionDays <= 0 (or
- * unparseable timestamps) disables the age branch — archived still qualifies.
+ * The mechanism is the shared file-tier merge's ZOMBIE-DROP (@glance-apps/sync
+ * merge.js, mergeArrayById): a task that is local-only in the remote file AND
+ * whose `lastModified` predates the remote's `tombstonePrunedBefore` (dayGLANCE
+ * sets this to the 60-day tombstoneCutoff — see mergeSync.js) is SILENTLY dropped
+ * rather than re-uploaded, on the theory its tombstone was already GC'd. Such a
+ * row can therefore never reappear in getData(), yet it sits in the vault and the
+ * snapshot baseline — a permanent would-be-delete with no fingerprint. Two shapes
+ * qualify (tasks / unscheduledTasks only):
+ *   'completed'    — a completed task. Completed rows stop being touched, so their
+ *                    lastModified goes stale and the file tier zombie-drops them;
+ *                    and a completed row that PERSISTENTLY vanishes is being aged
+ *                    out, not glitching. (Every observed stuck row is completed.)
+ *   'sync-horizon' — ANY row (incl. incomplete) whose lastModified predates the
+ *                    sync horizon: this is exactly the zombie-drop condition, so
+ *                    the file tier will re-drop it every cycle.
  *
- * @param {object} entity  wrapped entity ({ _kind, value })
- * @param {{ retentionDays?: number, now?: number }} [opts]
- * @returns {boolean}
+ * Release = not propagated as a delete, not heal-fetched, dropped from the diff
+ * baseline. The vault row is UNTOUCHED (it survives for other devices); the next
+ * saved snapshot stops tracking it and the loop ends. Only would-be 'glitch' rows
+ * reach here — tombstoned / stale-tombstone / cross-list are decided first.
+ *
+ * @param {object} entity  wrapped entity ({ _kind, value }, see dbAdapter.js)
+ * @param {{ horizonMs?: number }} [opts]  horizonMs = the file-tier sync-horizon
+ *   epoch ms (tombstoneCutoff().getTime()); omit / non-finite → skip the horizon
+ *   branch (the 'completed' branch still applies).
+ * @returns {'completed'|'sync-horizon'|null}
  */
-export function isRetentionReleasableEntity(entity, { retentionDays = 0, now = NaN } = {}) {
-  if (!entity || typeof entity !== 'object') return false;
-  if (entity._kind !== 'tasks' && entity._kind !== 'unscheduledTasks') return false;
+export function agedOutReleaseReason(entity, { horizonMs = NaN } = {}) {
+  if (!entity || typeof entity !== 'object') return null;
+  if (entity._kind !== 'tasks' && entity._kind !== 'unscheduledTasks') return null;
   const t = entity.value;
-  if (!t || typeof t !== 'object') return false;
-  if (!t.completed) return false;
-  if (t.archived === true) return true;
-  const days = Number(retentionDays);
-  if (!Number.isFinite(days) || days <= 0) return false;
-  const nowMs = Number.isFinite(now) ? now : Date.now();
-  const stamp = parseMs(t.completedAt) || parseMs(t.lastModified);
-  if (Number.isNaN(stamp) || !stamp) return false;
-  return stamp < nowMs - days * 24 * 60 * 60 * 1000;
+  if (!t || typeof t !== 'object') return null;
+  if (t.completed === true) return 'completed';
+  if (Number.isFinite(horizonMs)) {
+    const lm = new Date(t.lastModified).getTime();
+    if (Number.isFinite(lm) && lm < horizonMs) return 'sync-horizon';
+  }
+  return null;
 }

--- a/src/sync/payloadExclusions.js
+++ b/src/sync/payloadExclusions.js
@@ -44,3 +44,47 @@ export function isPayloadExcludedEntity(entity, { multiUserEnabled = false } = {
   if (entity._kind === 'unscheduledTasks') return !keepImportedTask(t, multiUserEnabled);
   return false;
 }
+
+const parseMs = (v) => {
+  if (v == null) return NaN;
+  const t = new Date(v).getTime();
+  return Number.isNaN(t) ? NaN : t;
+};
+
+/**
+ * True when [entity] — a mirror/snapshot wrap ({ _kind, value }) — is a task the
+ * DEVICE has intentionally aged out of its live list, so the vault delete guard
+ * should release it from the diff baseline rather than heal-fetch it forever.
+ *
+ * The file tier (WebDAV / iCloud) prunes old completed tasks per the retention
+ * window WITHOUT writing a vault tombstone. Those rows then vanish from getData()
+ * while still sitting in the vault, so the snapshot diff flags them as would-be
+ * deletes with no fingerprint → 'glitch' → per-row re-fetch → re-commit →
+ * re-vanish, every cycle (the observed 85-inbox + 150-scheduled churn on a device
+ * synced to a peer that keeps re-adding them). These are NOT glitches: the row is
+ * deterministically absent because the device aged it out. Two shapes qualify,
+ * both COMPLETED (never release an active task):
+ *   • completed && archived                          — auto-archived inbox item
+ *   • completed && (completedAt|lastModified older    — pruned by the retention
+ *     than retentionDays)                               window on the file tier
+ * Only `tasks` / `unscheduledTasks` kinds are eligible. retentionDays <= 0 (or
+ * unparseable timestamps) disables the age branch — archived still qualifies.
+ *
+ * @param {object} entity  wrapped entity ({ _kind, value })
+ * @param {{ retentionDays?: number, now?: number }} [opts]
+ * @returns {boolean}
+ */
+export function isRetentionReleasableEntity(entity, { retentionDays = 0, now = NaN } = {}) {
+  if (!entity || typeof entity !== 'object') return false;
+  if (entity._kind !== 'tasks' && entity._kind !== 'unscheduledTasks') return false;
+  const t = entity.value;
+  if (!t || typeof t !== 'object') return false;
+  if (!t.completed) return false;
+  if (t.archived === true) return true;
+  const days = Number(retentionDays);
+  if (!Number.isFinite(days) || days <= 0) return false;
+  const nowMs = Number.isFinite(now) ? now : Date.now();
+  const stamp = parseMs(t.completedAt) || parseMs(t.lastModified);
+  if (Number.isNaN(stamp) || !stamp) return false;
+  return stamp < nowMs - days * 24 * 60 * 60 * 1000;
+}

--- a/src/sync/payloadExclusions.test.js
+++ b/src/sync/payloadExclusions.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { keepImportedTask, isPayloadExcludedEntity, isRetentionReleasableEntity } from './payloadExclusions.js';
+import { keepImportedTask, isPayloadExcludedEntity, agedOutReleaseReason } from './payloadExclusions.js';
 
 describe('payloadExclusions — the shared buildSyncPayload rule', () => {
   it('drops read-only CalDAV imports; keeps task-calendar to-dos and ICS file imports', () => {
@@ -36,47 +36,50 @@ describe('payloadExclusions — the shared buildSyncPayload rule', () => {
   });
 });
 
-describe('isRetentionReleasableEntity — device-aged-out completed tasks', () => {
+describe('agedOutReleaseReason — the file-tier zombie-drop populations', () => {
   const NOW = Date.parse('2026-07-14T00:00:00Z');
+  const HORIZON = NOW - 60 * 86400000; // tombstoneCutoff() epoch ms (60-day fence)
   const daysAgo = (n) => new Date(NOW - n * 86400000).toISOString();
-  const rel = (kind, value, retentionDays = 30) =>
-    isRetentionReleasableEntity({ _kind: kind, value }, { retentionDays, now: NOW });
+  const rel = (kind, value, horizonMs = HORIZON) =>
+    agedOutReleaseReason({ _kind: kind, value }, { horizonMs });
 
-  it('releases completed + archived regardless of age (auto-archived inbox item)', () => {
-    // The 85-inbox population: completed + archived, no retention needed.
-    expect(rel('unscheduledTasks', { completed: true, archived: true, lastModified: daysAgo(78) })).toBe(true);
-    expect(rel('tasks', { completed: true, archived: true, lastModified: daysAgo(1) })).toBe(true);
-    // archived even disables the age gate: releases with retentionDays 0.
-    expect(rel('unscheduledTasks', { completed: true, archived: true }, 0)).toBe(true);
+  it("releases EVERY completed task as 'completed', at any age or archived state", () => {
+    // The observed stuck set is 100% completed (85 inbox archived + 65 scheduled
+    // not-archived) — the 'completed' branch covers both, no age needed.
+    expect(rel('unscheduledTasks', { completed: true, archived: true, lastModified: daysAgo(90) })).toBe('completed');
+    expect(rel('tasks', { completed: true, archived: false, lastModified: daysAgo(90) })).toBe('completed'); // the 65 scheduled
+    expect(rel('tasks', { completed: true, lastModified: daysAgo(1) })).toBe('completed'); // recent completed still releasable
+    expect(rel('unscheduledTasks', { completed: true })).toBe('completed'); // no timestamps needed
   });
 
-  it('releases completed tasks aged past the retention window even when not archived', () => {
-    // The 150-scheduled population: completed, past retention, NOT archived.
-    expect(rel('tasks', { completed: true, completedAt: daysAgo(45) })).toBe(true);
-    expect(rel('tasks', { completed: true, lastModified: daysAgo(45) })).toBe(true); // completedAt absent → lastModified
+  it("releases an incomplete task older than the sync horizon as 'sync-horizon' (the zombie-drop condition)", () => {
+    expect(rel('tasks', { completed: false, lastModified: daysAgo(61) })).toBe('sync-horizon');
+    expect(rel('unscheduledTasks', { lastModified: daysAgo(120) })).toBe('sync-horizon');
   });
 
-  it('keeps completed tasks still inside the retention window', () => {
-    expect(rel('tasks', { completed: true, completedAt: daysAgo(10) })).toBe(false);
-    expect(rel('unscheduledTasks', { completed: true, lastModified: daysAgo(29) })).toBe(false);
+  it('KEEPS an incomplete task newer than the horizon (a genuine transient glitch heals as before)', () => {
+    expect(rel('tasks', { completed: false, lastModified: daysAgo(59) })).toBeNull();
+    expect(rel('tasks', { lastModified: daysAgo(1) })).toBeNull();
   });
 
-  it('never releases an active (not-completed) task, however old', () => {
-    expect(rel('tasks', { completed: false, archived: true, lastModified: daysAgo(365) })).toBe(false);
-    expect(rel('tasks', { archived: true, lastModified: daysAgo(365) })).toBe(false);
-    expect(rel('tasks', { completed: true, lastModified: daysAgo(365) })).toBe(true); // control
+  it('mirrors the zombie-drop: no lastModified on an incomplete row → not horizon-releasable', () => {
+    // merge.js only drops a local-only task that HAS a timestamp predating the
+    // fence; a row with no lastModified is not a zombie, so we heal it.
+    expect(rel('tasks', { completed: false })).toBeNull();
+    expect(rel('tasks', { completed: false, lastModified: 'not-a-date' })).toBeNull();
   });
 
-  it('is scoped to task kinds and disables the age branch when retention is off', () => {
-    expect(rel('recycleBin', { completed: true, completedAt: daysAgo(365) })).toBe(false);
-    expect(rel('singleton', { completed: true, archived: true })).toBe(false);
-    // retentionDays <= 0 (or unset) → only archived qualifies; aged-but-unarchived does not.
-    expect(rel('tasks', { completed: true, completedAt: daysAgo(365) }, 0)).toBe(false);
+  it('is scoped to task kinds; the horizon branch is skipped without a finite horizon', () => {
+    expect(rel('recycleBin', { completed: true })).toBeNull();
+    expect(rel('singleton', { lastModified: daysAgo(365) })).toBeNull();
+    // No horizon supplied → the horizon branch is inert, but 'completed' still fires.
+    expect(agedOutReleaseReason({ _kind: 'tasks', value: { lastModified: daysAgo(365) } }, {})).toBeNull();
+    expect(agedOutReleaseReason({ _kind: 'tasks', value: { completed: true } }, {})).toBe('completed');
   });
 
-  it('fails safe on unparseable input / timestamps', () => {
-    expect(isRetentionReleasableEntity(null, { retentionDays: 30, now: NOW })).toBe(false);
-    expect(rel('tasks', null)).toBe(false);
-    expect(rel('tasks', { completed: true, completedAt: 'not-a-date' })).toBe(false); // unparseable, unarchived → keep
+  it('fails safe on unparseable input', () => {
+    expect(agedOutReleaseReason(null, { horizonMs: HORIZON })).toBeNull();
+    expect(rel('tasks', null)).toBeNull();
+    expect(rel('tasks', undefined)).toBeNull();
   });
 });

--- a/src/sync/payloadExclusions.test.js
+++ b/src/sync/payloadExclusions.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { keepImportedTask, isPayloadExcludedEntity } from './payloadExclusions.js';
+import { keepImportedTask, isPayloadExcludedEntity, isRetentionReleasableEntity } from './payloadExclusions.js';
 
 describe('payloadExclusions — the shared buildSyncPayload rule', () => {
   it('drops read-only CalDAV imports; keeps task-calendar to-dos and ICS file imports', () => {
@@ -33,5 +33,50 @@ describe('payloadExclusions — the shared buildSyncPayload rule', () => {
     expect(isPayloadExcludedEntity('tasks:900')).toBe(false);
     expect(isPayloadExcludedEntity({ _kind: 'tasks' })).toBe(false);
     expect(isPayloadExcludedEntity({ _kind: 'tasks', value: null })).toBe(false);
+  });
+});
+
+describe('isRetentionReleasableEntity — device-aged-out completed tasks', () => {
+  const NOW = Date.parse('2026-07-14T00:00:00Z');
+  const daysAgo = (n) => new Date(NOW - n * 86400000).toISOString();
+  const rel = (kind, value, retentionDays = 30) =>
+    isRetentionReleasableEntity({ _kind: kind, value }, { retentionDays, now: NOW });
+
+  it('releases completed + archived regardless of age (auto-archived inbox item)', () => {
+    // The 85-inbox population: completed + archived, no retention needed.
+    expect(rel('unscheduledTasks', { completed: true, archived: true, lastModified: daysAgo(78) })).toBe(true);
+    expect(rel('tasks', { completed: true, archived: true, lastModified: daysAgo(1) })).toBe(true);
+    // archived even disables the age gate: releases with retentionDays 0.
+    expect(rel('unscheduledTasks', { completed: true, archived: true }, 0)).toBe(true);
+  });
+
+  it('releases completed tasks aged past the retention window even when not archived', () => {
+    // The 150-scheduled population: completed, past retention, NOT archived.
+    expect(rel('tasks', { completed: true, completedAt: daysAgo(45) })).toBe(true);
+    expect(rel('tasks', { completed: true, lastModified: daysAgo(45) })).toBe(true); // completedAt absent → lastModified
+  });
+
+  it('keeps completed tasks still inside the retention window', () => {
+    expect(rel('tasks', { completed: true, completedAt: daysAgo(10) })).toBe(false);
+    expect(rel('unscheduledTasks', { completed: true, lastModified: daysAgo(29) })).toBe(false);
+  });
+
+  it('never releases an active (not-completed) task, however old', () => {
+    expect(rel('tasks', { completed: false, archived: true, lastModified: daysAgo(365) })).toBe(false);
+    expect(rel('tasks', { archived: true, lastModified: daysAgo(365) })).toBe(false);
+    expect(rel('tasks', { completed: true, lastModified: daysAgo(365) })).toBe(true); // control
+  });
+
+  it('is scoped to task kinds and disables the age branch when retention is off', () => {
+    expect(rel('recycleBin', { completed: true, completedAt: daysAgo(365) })).toBe(false);
+    expect(rel('singleton', { completed: true, archived: true })).toBe(false);
+    // retentionDays <= 0 (or unset) → only archived qualifies; aged-but-unarchived does not.
+    expect(rel('tasks', { completed: true, completedAt: daysAgo(365) }, 0)).toBe(false);
+  });
+
+  it('fails safe on unparseable input / timestamps', () => {
+    expect(isRetentionReleasableEntity(null, { retentionDays: 30, now: NOW })).toBe(false);
+    expect(rel('tasks', null)).toBe(false);
+    expect(rel('tasks', { completed: true, completedAt: 'not-a-date' })).toBe(false); // unparseable, unarchived → keep
   });
 });

--- a/src/sync/snapshotDeleteGuard.js
+++ b/src/sync/snapshotDeleteGuard.js
@@ -92,17 +92,20 @@ const parseTs = (v) => (v == null ? NaN : new Date(v).getTime());
  *   compared against the tombstone (see THE TIMESTAMP RULE above). Omitted / null
  *   result / unparseable lastModified → the tombstone authorizes unconditionally.
  * @returns {{ propagate: string[], skipped: string[], excluded: string[], reasons: Record<string,string> }}
- * @param {(entityId: string) => boolean} [isExcludedDeletedEntity]  true when the
- *   vanished copy belongs to a class the payload builder STRUCTURALLY excludes
- *   (src/sync/payloadExclusions.js). Such a row can sit in the baseline while
- *   being permanently unable to appear in `cur` — it is neither a delete (no
- *   tombstone) nor a glitch (nothing transient about a deterministic filter),
- *   so it lands in the `excluded` bucket: not propagated, not heal-fetched,
- *   simply released from the baseline. Without this bucket a fresh device that
- *   full-pulled legacy excluded-class vault rows re-fetches every one of them
- *   EVERY cycle, forever (the observed recover loop that rate-limited the
- *   vault). Only would-be 'glitch' rows are tested: tombstoned, stale-tombstone,
- *   and cross-list classifications are unaffected. Omitted → prior behavior.
+ * @param {(entityId: string) => (boolean|string)} [isExcludedDeletedEntity]  called
+ *   for a would-be 'glitch' row; return a truthy value when the vanished copy is
+ *   one this device will NEVER reproduce in `cur`, so healing it every cycle is a
+ *   futile loop. Two independent causes qualify (src/sync/payloadExclusions.js):
+ *   a class the payload builder STRUCTURALLY excludes (native / non-synced
+ *   imports), or a task this device INTENTIONALLY AGED OUT (completed + archived,
+ *   or completed + older than the retention window — pruned locally / by the file
+ *   tier, invisibly to the vault). Either lands in the `excluded` bucket: not
+ *   propagated, not heal-fetched, simply released from the baseline (the vault
+ *   row is untouched; the next saved snapshot stops tracking it). Return a reason
+ *   STRING ('payload-excluded' | 'retention-aged') for accurate diagnostics, or
+ *   `true` for the default 'payload-excluded'. Only would-be 'glitch' rows are
+ *   tested — tombstoned, stale-tombstone, and cross-list are unaffected. Omitted
+ *   → prior behavior.
  */
 export function partitionSnapshotDeletes(deleteEntityIds, cur, mirror, getDeletedEntity, isExcludedDeletedEntity) {
   const ids = Array.isArray(deleteEntityIds) ? deleteEntityIds : [];
@@ -151,12 +154,20 @@ export function partitionSnapshotDeletes(deleteEntityIds, cur, mirror, getDelete
   // to a class the payload builder structurally excludes). Diagnostic only;
   // callers that ignore it are unaffected.
   const reasons = {};
-  const isExcluded = (eid) => {
-    if (typeof isExcludedDeletedEntity !== 'function') return false;
-    try { return isExcludedDeletedEntity(eid) === true; } catch { return false; }
+  // Release reason for a would-be 'glitch' row, or null to keep the glitch
+  // classification. The predicate may return a specific reason STRING (e.g.
+  // 'retention-aged') for accurate diagnostics, or `true` for the original
+  // 'payload-excluded' meaning (back-compat with the #1198 callers).
+  const releaseReason = (eid) => {
+    if (typeof isExcludedDeletedEntity !== 'function') return null;
+    let r;
+    try { r = isExcludedDeletedEntity(eid); } catch { return null; }
+    if (r === true) return 'payload-excluded';
+    return typeof r === 'string' && r ? r : null;
   };
   for (const eid of ids) {
     const id = bareId(eid);
+    let rr;
     if (tombstoned.has(id)) {
       const tombTs = tombstoned.get(id);
       const lastMod = deletedLastModified(eid);
@@ -170,7 +181,7 @@ export function partitionSnapshotDeletes(deleteEntityIds, cur, mirror, getDelete
         skipped.push(eid); reasons[eid] = 'stale-tombstone';
       }
     } else if (liveBareIds.has(id)) { propagate.push(eid); reasons[eid] = 'cross-list'; }
-    else if (isExcluded(eid)) { excluded.push(eid); reasons[eid] = 'payload-excluded'; }
+    else if ((rr = releaseReason(eid))) { excluded.push(eid); reasons[eid] = rr; }
     else { skipped.push(eid); reasons[eid] = 'glitch'; }
   }
   return { propagate, skipped, excluded, reasons };

--- a/src/sync/snapshotDeleteGuard.js
+++ b/src/sync/snapshotDeleteGuard.js
@@ -95,15 +95,15 @@ const parseTs = (v) => (v == null ? NaN : new Date(v).getTime());
  * @param {(entityId: string) => (boolean|string)} [isExcludedDeletedEntity]  called
  *   for a would-be 'glitch' row; return a truthy value when the vanished copy is
  *   one this device will NEVER reproduce in `cur`, so healing it every cycle is a
- *   futile loop. Two independent causes qualify (src/sync/payloadExclusions.js):
- *   a class the payload builder STRUCTURALLY excludes (native / non-synced
- *   imports), or a task this device INTENTIONALLY AGED OUT (completed + archived,
- *   or completed + older than the retention window — pruned locally / by the file
- *   tier, invisibly to the vault). Either lands in the `excluded` bucket: not
- *   propagated, not heal-fetched, simply released from the baseline (the vault
- *   row is untouched; the next saved snapshot stops tracking it). Return a reason
- *   STRING ('payload-excluded' | 'retention-aged') for accurate diagnostics, or
- *   `true` for the default 'payload-excluded'. Only would-be 'glitch' rows are
+ *   futile loop. Independent causes qualify (src/sync/payloadExclusions.js): a
+ *   class the payload builder STRUCTURALLY excludes (native / non-synced imports),
+ *   or a task the FILE TIER's zombie-drop keeps out of getData() (completed, or
+ *   older than the sync horizon — dropped by WebDAV/iCloud merge, invisibly to
+ *   the vault). Either lands in the `excluded` bucket: not propagated, not
+ *   heal-fetched, simply released from the baseline (the vault row is untouched;
+ *   the next saved snapshot stops tracking it). Return a reason STRING
+ *   ('payload-excluded' | 'completed' | 'sync-horizon') for accurate diagnostics,
+ *   or `true` for the default 'payload-excluded'. Only would-be 'glitch' rows are
  *   tested — tombstoned, stale-tombstone, and cross-list are unaffected. Omitted
  *   → prior behavior.
  */

--- a/src/sync/snapshotDeleteGuard.test.js
+++ b/src/sync/snapshotDeleteGuard.test.js
@@ -233,14 +233,14 @@ describe('payload-excluded classification (the fresh-device churn fix)', () => {
     expect(excluded).toHaveLength(150);
   });
 
-  it('carries a SPECIFIC reason string from the predicate (e.g. retention-aged) into reasons', () => {
-    // The predicate may name WHY a row is released — the retention-aged branch
-    // returns 'retention-aged' so diagnostics distinguish it from payload-excluded.
+  it('carries a SPECIFIC reason string from the predicate (e.g. sync-horizon) into reasons', () => {
+    // The predicate may name WHY a row is released — the file-tier aged-out branch
+    // returns 'completed' / 'sync-horizon' so diagnostics distinguish the cause.
     const { excluded, reasons } = partitionSnapshotDeletes(
-      ['unscheduledTasks:X'], curOf(), {}, undefined, () => 'retention-aged',
+      ['unscheduledTasks:X'], curOf(), {}, undefined, () => 'sync-horizon',
     );
     expect(excluded).toEqual(['unscheduledTasks:X']);
-    expect(reasons['unscheduledTasks:X']).toBe('retention-aged');
+    expect(reasons['unscheduledTasks:X']).toBe('sync-horizon');
   });
 
   it('an empty-string reason is falsy → keeps the glitch classification', () => {

--- a/src/sync/snapshotDeleteGuard.test.js
+++ b/src/sync/snapshotDeleteGuard.test.js
@@ -232,4 +232,23 @@ describe('payload-excluded classification (the fresh-device churn fix)', () => {
     expect(skipped).toEqual([]);
     expect(excluded).toHaveLength(150);
   });
+
+  it('carries a SPECIFIC reason string from the predicate (e.g. retention-aged) into reasons', () => {
+    // The predicate may name WHY a row is released — the retention-aged branch
+    // returns 'retention-aged' so diagnostics distinguish it from payload-excluded.
+    const { excluded, reasons } = partitionSnapshotDeletes(
+      ['unscheduledTasks:X'], curOf(), {}, undefined, () => 'retention-aged',
+    );
+    expect(excluded).toEqual(['unscheduledTasks:X']);
+    expect(reasons['unscheduledTasks:X']).toBe('retention-aged');
+  });
+
+  it('an empty-string reason is falsy → keeps the glitch classification', () => {
+    const { skipped, excluded, reasons } = partitionSnapshotDeletes(
+      ['tasks:X'], curOf(), {}, undefined, () => '',
+    );
+    expect(excluded).toEqual([]);
+    expect(skipped).toEqual(['tasks:X']);
+    expect(reasons['tasks:X']).toBe('glitch');
+  });
 });


### PR DESCRIPTION
## The bug

Persistent `GUARD` churn on a device synced to a peer that keeps re-adding rows (the wife's-Mac console: inbox count pinned, endless GUARD messages, vault getting rate-limited). Two populations of stuck rows were classified as `glitch` and healed **every cycle, forever**:

- **~85 completed inbox** rows (`unscheduledTasks`, completed + archived)
- **~65 completed scheduled** rows (`tasks`, completed, **not** archived)

Every stuck row is `completed` (`neither: 0` incomplete in the probe).

## Root cause — a two-tier fight (the real remover)

Traced to the shared file-tier merge's **zombie-drop** (`@glance-apps/sync` `mergeArrayById`): a task that is **local-only in the remote iCloud/WebDAV file** AND whose **`lastModified` predates the remote's `tombstonePrunedBefore`** — which dayGLANCE sets to the **60-day `tombstoneCutoff`** (`mergeSync.js`) — is **silently dropped** from React state rather than re-uploaded (its tombstone is presumed already GC'd). The row still sits in the vault and the snapshot baseline, so the push diff flags it as a would-be delete with no fingerprint:

```
glitch → per-row re-fetch (heal) → re-commit → file tier re-drops → re-vanish → …
```

The drop is **completion-agnostic**; the stuck set is 100% completed only because completed rows stop being touched, so their `lastModified` goes stale and crosses the fence. The 30-day retention window is a red herring — it only prunes `completedTaskUids`/imported events, not the task arrays.

## The fix (device-local, deletes nothing)

These aren't glitches — the file tier will keep them out of `getData()` forever. So **release** them from the diff baseline instead of healing them. The vault row is **untouched** (survives for every other device); the next saved snapshot stops tracking them → the loop ends after one release. Inert on the healthy device (the predicate only runs on rows that vanished from *that* device's `getData()`).

### Changes

- **`payloadExclusions.js`** — `agedOutReleaseReason(entity, { horizonMs })` → `'completed' | 'sync-horizon' | null`. `'completed'` releases any completed task (covers 100% of the observed stuck set, inbox + scheduled, at any age); `'sync-horizon'` releases any row whose `lastModified` predates the horizon — the **exact zombie-drop condition**, so it also catches old *incomplete* zombies. Never releases a recent active task; an incomplete row with no `lastModified` is kept (mirrors `merge.js`).
- **`dbEngine.js`** — derive the horizon from `tombstoneCutoff()` (the same 60-day fence the file tier uses as `tombstonePrunedBefore`); combine with the existing `payload-excluded` predicate; break the release log down by the three reasons.
- **`snapshotDeleteGuard.js`** — the release predicate returns a reason **string** (`'payload-excluded' | 'completed' | 'sync-horizon'`); `true` keeps the `#1198` back-compat meaning.

## Tests

- `agedOutReleaseReason` unit coverage: completed at any age/archived state, `sync-horizon` for old incomplete rows, recent active rows kept, no-timestamp fails safe, task-kind scoping, horizon-off.
- Guard string-reason plumbing.
- **Wave C** end-to-end reproduction now models the **zombie-drop** (a device whose `getData()` drops completed + horizon-aged rows): the fight ends after **one** release naming both causes, no `GUARD` warnings, no heal fetches for the aged rows, vault rows untouched, live synced row unaffected. Plus a contrast case proving a recent active transient-vanish still heals. Timestamps made wall-clock-robust.

Full suite green (786 passing), lint clean, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu1rDx1mCGDzwTK8yVBTnn