### PR TITLE
Android: bump versionCode to 173

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 172
+        versionCode = 173
         versionName = "4.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Bumps the Android `versionCode` 172 → 173 so the vault-sync churn fix (#1202) can ship in a new Play/GitHub build. No `versionName` change (stays `4.0.0`).

This is the release-carrier for the file-tier zombie-drop release fix — building Android, iOS, and macOS/Electron off `main` after this merges gives all platforms the identical, reviewed web bundle ahead of the Apple review freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu1rDx1mCGDzwTK8yVBTnn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fu1rDx1mCGDzwTK8yVBTnn)_