### PR TITLE
Fix Windows/Linux desktop app failing to launch (StoreKit guard)

### DIFF
--- a/electron/subscription.ts
+++ b/electron/subscription.ts
@@ -1,7 +1,8 @@
 import type { BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
 import { registerElectronBilling } from '@glance-apps/billing/electron-main';
 
-// dayGLANCE billing configuration for the Electron (macOS) build.
+// dayGLANCE billing configuration for the Electron build.
 //
 // All of the billing machinery — the RevenueCat REST trust rules, the
 // indeterminate-vs-inactive distinction, the lifetime latch, MAS-receipt
@@ -16,7 +17,48 @@ import { registerElectronBilling } from '@glance-apps/billing/electron-main';
 // there is no separate macOS app or macOS-specific key.
 const RC_API_KEY = 'appl_uHejfwubTbYOTpEPNYFsjXAgnHw';
 
+// StoreKit billing is macOS-only. registerElectronBilling registers an
+// inAppPurchase transaction observer unconditionally, and Electron's
+// `inAppPurchase` module does not exist off macOS — so on Windows/Linux the
+// `inAppPurchase.on(...)` call throws a TypeError. That throw runs inside the
+// app's `whenReady` startup: it aborts every registrar after it (calendar,
+// iCloud, Obsidian, global shortcuts) AND leaves the `subscription:*` IPC
+// handlers unregistered, so the renderer's `subscriptionStatus()` invoke
+// rejects with "No handler registered" instead of resolving. The result on
+// Windows is an app that installs and launches its process but never paints a
+// window (the DMG/Developer-ID Mac build is unaffected — inAppPurchase exists
+// there). See preload.ts, which already documents the intended non-macOS
+// contract ("always returns { active: false }" — really: a resolved value, not
+// a rejection).
+//
+// GitHub-distributed builds (Developer-ID Mac DMG, Windows EXE, Linux AppImage)
+// are free by design — there is no store to purchase through, exactly like the
+// non-MAS macOS path where `subscription:status` returns `{ active: true }`. So
+// off macOS we skip the StoreKit wiring entirely and register free-build no-op
+// handlers that resolve cleanly, keeping the renderer's billing adapter happy.
+function registerFreeBuildHandlers(window: BrowserWindow): void {
+  const fireError = (productId: string) => {
+    if (!window.isDestroyed()) {
+      window.webContents.send('subscription:event', {
+        status: 'error', code: 3, message: 'Billing not available', productId,
+      });
+    }
+  };
+
+  // Free build: unlocked, no store receipt. Mirrors the macOS Developer-ID
+  // (non-MAS) path so GitHub Windows/Linux users get the same unwalled app.
+  ipcMain.handle('subscription:status', () => ({ active: true, productId: null }));
+  ipcMain.handle('subscription:prices', () => ({ yearly: null, lifetime: null, yearlyTrialDays: null }));
+  ipcMain.handle('subscription:purchase', (_event, productId: string) => { fireError(productId ?? ''); });
+  ipcMain.handle('subscription:restore', () => { fireError(''); });
+}
+
 export function registerSubscriptionHandlers(window: BrowserWindow): void {
+  if (process.platform !== 'darwin') {
+    registerFreeBuildHandlers(window);
+    return;
+  }
+
   registerElectronBilling(window, {
     rcApiKey: RC_API_KEY,
     entitlementId: 'pro',


### PR DESCRIPTION
## Problem

The Windows EXE installs and spawns a process, but no window ever paints (the DMG/Developer-ID Mac build is unaffected). Root cause is macOS-only billing code running on a non-macOS platform.

On startup, `registerSubscriptionHandlers()` runs inside `app.whenReady()` right after the main window is created, and calls `registerElectronBilling()` from `@glance-apps/billing/electron-main`. That function registers a StoreKit transaction observer:

```js
inAppPurchase.on('transactions-updated', …)
```

Electron's `inAppPurchase` module **only exists on macOS**, so on Windows/Linux this throws a `TypeError`. Because the throw happens inside the `whenReady` handler it:

- aborts every registrar after it — calendar, iCloud, Obsidian, global shortcuts, `app.on('activate')` — none of which ever run; and
- leaves the `subscription:*` IPC handlers unregistered, so the renderer's `subscriptionStatus()` invoke rejects with *"No handler registered for 'subscription:status'"* instead of resolving. The renderer never finishes booting and the window never shows.

The billing module guards `process.platform === 'darwin'` before every *other* `inAppPurchase` access (price fetch, receipt checks, purchase, restore); the observer registration is the one unguarded access, and it's the line that runs unconditionally at startup.

## Fix

`electron/subscription.ts` — guard the StoreKit wiring to macOS. GitHub-distributed builds (Developer-ID Mac DMG, Windows EXE, Linux AppImage) are free by design, the same as the non-MAS macOS path where `subscription:status` returns `{ active: true }`. Off macOS we now register free-build no-op handlers that resolve cleanly (status → unlocked, prices → nulls, purchase/restore → "billing not available") instead of ever touching `inAppPurchase`. macOS behavior is unchanged.

## Verification

- `tsc -p tsconfig.electron.json` — passes
- `vitest run electron/` — 10/10 pass

Note: the actual Windows Electron binary couldn't be launched in the build sandbox (Electron download is blocked), so this is verified by static analysis + typecheck + tests rather than an on-device launch. A smoke-test of a Windows build off this branch would be the final confirmation.

## Follow-up

The underlying bug is in the published `@glance-apps/billing` package (the unguarded `inAppPurchase.on`). This PR fixes it at dayGLANCE's seam; worth filing upstream so other GLANCE desktop builds don't hit the same crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZUmrdNjPX1x5ohSWQ3zZu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZUmrdNjPX1x5ohSWQ3zZu)_