### PR TITLE
Fix Windows/Linux desktop launch via @glance-apps/billing 0.1.1 + Android versionCode 174

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 173
+        versionCode = 174
         versionName = "4.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dayglance",
       "version": "4.0.0",
       "dependencies": {
-        "@glance-apps/billing": "0.1.0",
+        "@glance-apps/billing": "0.1.1",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.6.0",
         "i18next": "^26.3.1",
@@ -2561,9 +2561,9 @@
       }
     },
     "node_modules/@glance-apps/billing": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.1.0.tgz",
-      "integrity": "sha512-HmrIf7ZuqRKDz/4kPG02qf2CGBzaWAO7wEYhfuN8au/oo2mPDPxge5BmLqqVrdEf/swo7MiBdZ2pURmXTRsjxw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.1.1.tgz",
+      "integrity": "sha512-7dayiwwDAEyhZbtwtg1GOj9uJixCIS2kI/qXx12S63ec+sbrgNlXFkJ+MpgV/pE04Mq5ndJo8DiYJmGnDfjI9Q==",
       "license": "MIT",
       "peerDependencies": {
         "electron": ">=28",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:electron:mas": "npm run build:helpers && vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && DAYGLANCE_APP_ID=com.dayglance electron-builder --config electron-builder.config.cjs --mac mas --universal --publish never"
   },
   "dependencies": {
-    "@glance-apps/billing": "0.1.0",
+    "@glance-apps/billing": "0.1.1",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.6.0",
     "i18next": "^26.3.1",


### PR DESCRIPTION
## Summary

Fixes the Windows (and Linux) desktop app failing to launch — installs and spawns a process, but no window ever paints. The macOS DMG was unaffected.

### Root cause (fixed upstream in `@glance-apps/billing` 0.1.1)

`registerElectronBilling` registered the StoreKit `inAppPurchase` transaction observer unconditionally:

```js
inAppPurchase.on('transactions-updated', …)
```

Electron's `inAppPurchase` module is **macOS-only**, so this threw on Windows/Linux. Because it ran inside the app's `whenReady` startup (right after the main window is created), the throw aborted every registrar after it (calendar, iCloud, Obsidian, global shortcuts) and left the `subscription:*` IPC handlers unregistered — so the renderer's `subscriptionStatus()` invoke rejected with *"No handler registered"* and the window never finished loading. macOS was fine because `inAppPurchase` exists there.

0.1.1 guards the observer with `process.platform === 'darwin'`. Every other `inAppPurchase` access in the module was already platform-guarded, and the `subscription:*` handlers already return correct free-build values off macOS, so no dayGLANCE code change is needed beyond consuming the fixed version — `registerSubscriptionHandlers` calls `registerElectronBilling` unconditionally and is now safe on every platform.

## Changes

- **`package.json` / `package-lock.json`** — bump `@glance-apps/billing` `0.1.0` → `0.1.1`.
- **`dayglance-android/app/build.gradle.kts`** — bump `versionCode` `173` → `174` so all platforms rebuild on the same code for a coordinated release.

## Verification

- `tsc -p tsconfig.electron.json` — passes
- `vitest run electron/` — 10/10 pass
- Confirmed the `process.platform === 'darwin'` guard is present in the installed `@glance-apps/billing` 0.1.1 build.

Note: the actual Windows Electron binary couldn't be launched in the build sandbox (Electron download is blocked), so this is verified by static analysis + typecheck + tests. A smoke-test of a Windows build off this branch is the final end-to-end confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZUmrdNjPX1x5ohSWQ3zZu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZUmrdNjPX1x5ohSWQ3zZu)_