### PR TITLE
Fix Windows/Linux app quitting during first-launch startup

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -39,6 +39,11 @@ const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL'] ?? 'http://localh
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let isQuitting = false;
+// True once the main window has been created for the first time. Guards the
+// window-all-closed → app.quit() handler so transient utility windows created
+// DURING startup (the file:// storage-migration reader/writer) can't trip it
+// before the real window exists. See the window-all-closed handler.
+let didCreateMainWindow = false;
 let trayWindow: BrowserWindow | null = null;
 let trayNeedsReload = false;
 let trayReloadTimer: ReturnType<typeof setTimeout> | null = null;
@@ -104,6 +109,7 @@ function saveWindowState(state: WindowState): void {
 
 function createWindow(): BrowserWindow {
   const saved = loadWindowState();
+  didCreateMainWindow = true;
 
   mainWindow = new BrowserWindow({
     width: saved.width,
@@ -744,5 +750,15 @@ app.on('will-quit', () => {
 
 app.on('window-all-closed', () => {
   // On macOS the app stays alive in the tray; the user can reopen from there or the dock.
-  if (process.platform !== 'darwin') app.quit();
+  //
+  // The didCreateMainWindow guard is critical on Windows/Linux: startup runs
+  // migrateFileToAppStorage() BEFORE the main window is created, and that
+  // migration briefly opens then destroys hidden BrowserWindows (the file://
+  // localStorage reader/writer). Destroying the last of those fires
+  // window-all-closed while zero real windows exist yet — without the guard we
+  // would app.quit() mid-startup and the process would exit before ever showing
+  // a window (the app installed but "never launched"). macOS was unaffected only
+  // because this branch is darwin-exempt. Once the main window has been created,
+  // a genuine all-windows-closed on Windows/Linux still quits as intended.
+  if (process.platform !== 'darwin' && didCreateMainWindow) app.quit();
 });


### PR DESCRIPTION
## Problem

On **first launch**, the Windows (and Linux) build installs and spawns a process that **immediately exits — no window ever appears, and nothing is left running in Task Manager**. The macOS build is unaffected.

## Root cause

`app.whenReady()` runs `migrateFileToAppStorage()` **before** `createWindow()`. That one-time migration briefly opens and then `destroy()`s hidden `BrowserWindow`s (the file:// localStorage reader and the app:// writer). `destroy()` emits the window's `closed` event, so destroying the last of those transient windows fires **`window-all-closed`** while **zero real windows exist yet**.

The handler was:

```js
app.on('window-all-closed', () => {
  if (process.platform !== 'darwin') app.quit();
});
```

So on Windows/Linux the app calls `app.quit()` **mid-startup, before `createWindow()` is ever reached** → the process exits with no window. macOS escaped it only because this branch is darwin-exempt (the app stays alive in the tray/dock), which is why the DMG works.

It only bites on **first launch** because the migration runs once (guarded by a flag file); its transient hidden windows are what trip the quit.

This also explains why the earlier `@glance-apps/billing` guard (PR #1205) didn't fix the launch: billing is registered *after* `createWindow()`, so on Windows the app was already exiting during migration and never reached it. That fix was still correct — it would have thrown once startup got that far — just not the bug killing first launch.

## Fix

Track `didCreateMainWindow` and only honor `window-all-closed → app.quit()` on Windows/Linux **once the real main window has been created**. Transient startup windows can no longer trigger a quit; a genuine all-windows-closed after launch still quits as intended.

## Verification

- `tsc -p tsconfig.electron.json` — passes
- `vitest run electron/` — 10/10 pass
- Mechanism confirmed against Electron semantics: `BrowserWindow.destroy()` emits `closed`, and `window-all-closed` fires off the `closed` events when the window count reaches zero.

Note: I can't launch the Electron binary in the build sandbox (egress policy blocks the download), so this is verified by static analysis + typecheck + tests and the confirmed event mechanism, not an on-device run. A first-launch smoke-test of a fresh Windows install off this branch is the final confirmation — worth deleting `%APPDATA%\dayGLANCE` first so the migration path actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZUmrdNjPX1x5ohSWQ3zZu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZUmrdNjPX1x5ohSWQ3zZu)_