### PR TITLE
Desktop: startup-quit regression test + startup logging safety net

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -10,6 +10,8 @@ import { registerCalendarHandlers } from './calendar.js';
 import { registerICloudHandlers } from './icloud.js';
 import { registerObsidianHandlers } from './obsidian.js';
 import { APP_SCHEME, APP_HOST, APP_BASE_URL, resolveAppRequest } from './appProtocol.js';
+import { shouldQuitOnAllWindowsClosed } from './startupQuit.js';
+import { initStartupLog, logStartup } from './startupLog.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -32,6 +34,19 @@ protocol.registerSchemesAsPrivileged([
 // every Electron build since main.ts was created, so existing users are already
 // here. The MAS build's distinct bundle ID (com.dayglance) does not move it either.
 app.setPath('userData', path.join(app.getPath('appData'), 'dayGLANCE'));
+
+// Startup logging — a bounded record in userData (dayglance-startup.log) that a
+// user can send after a bad launch. Initialized as early as possible (right
+// after userData is pinned) so it captures crashes that happen before app-ready.
+// Best-effort: it never throws into startup. See electron/startupLog.ts.
+initStartupLog(app.getPath('userData'));
+logStartup('main process module loaded');
+process.on('uncaughtException', (err) => {
+  logStartup(`uncaughtException: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
+});
+process.on('unhandledRejection', (reason) => {
+  logStartup(`unhandledRejection: ${reason instanceof Error ? reason.stack ?? reason.message : String(reason)}`);
+});
 
 const DEV = !app.isPackaged;
 const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL'] ?? 'http://localhost:5173';
@@ -110,6 +125,7 @@ function saveWindowState(state: WindowState): void {
 function createWindow(): BrowserWindow {
   const saved = loadWindowState();
   didCreateMainWindow = true;
+  logStartup('createWindow: called');
 
   mainWindow = new BrowserWindow({
     width: saved.width,
@@ -149,7 +165,32 @@ function createWindow(): BrowserWindow {
   // Show the window only after the renderer has painted its first frame,
   // preventing the white screen that appears when the window is shown before
   // React has had a chance to render anything.
-  mainWindow.once('ready-to-show', () => { live(mainWindow)?.show(); });
+  //
+  // Safety net: if ready-to-show never fires (a renderer that fails to load or
+  // paint), force the window visible after a grace period rather than leaving an
+  // invisible process the user can only find in Task Manager. A visible window —
+  // even blank — is reportable; a silent one is the "installed but never
+  // launched" black hole. The timeout is long enough never to race a normal
+  // startup. Both paths are logged so dayglance-startup.log shows which fired.
+  const SHOW_FALLBACK_MS = 10_000;
+  let shown = false;
+  const showOnce = (why: string) => {
+    if (shown) return;
+    shown = true;
+    logStartup(`main window show (${why})`);
+    live(mainWindow)?.show();
+  };
+  const fallbackShow = setTimeout(() => showOnce('fallback-timeout'), SHOW_FALLBACK_MS);
+  mainWindow.once('ready-to-show', () => { clearTimeout(fallbackShow); showOnce('ready-to-show'); });
+
+  // Startup diagnostics — high-signal failure events written to the startup log.
+  mainWindow.webContents.on('did-finish-load', () => logStartup('main window did-finish-load'));
+  mainWindow.webContents.on('did-fail-load', (_e, code, desc, url) =>
+    logStartup(`did-fail-load: code=${code} "${desc}" url=${url}`));
+  mainWindow.webContents.on('render-process-gone', (_e, details) =>
+    logStartup(`render-process-gone: reason=${details.reason} exitCode=${details.exitCode}`));
+  mainWindow.webContents.on('preload-error', (_e, preloadPath, err) =>
+    logStartup(`preload-error: ${preloadPath}: ${err?.message ?? err}`));
 
   if (DEV) {
     mainWindow.loadURL(VITE_DEV_SERVER_URL);
@@ -662,6 +703,7 @@ app.whenReady().then(async () => {
   // A doomed second instance may still reach 'ready' before app.quit() takes
   // effect; bail before creating any windows so it never steals the port/state.
   if (!gotSingleInstanceLock) return;
+  logStartup('app ready');
 
   // Content Security Policy — applied to every response the renderer loads.
   // script-src 'self': only scripts from the app bundle (no inline scripts, no eval).
@@ -726,7 +768,9 @@ app.whenReady().then(async () => {
   // boots with the migrated localStorage. The protocol handler above must already
   // be registered (the writer window loads app://). Awaited so createWindow() sees
   // the migrated data; failures are swallowed inside and never block startup.
+  logStartup('storage migration: start');
   await migrateFileToAppStorage();
+  logStartup('storage migration: done');
 
   const win = createWindow();
   createWsServer(() => live(mainWindow));
@@ -760,5 +804,8 @@ app.on('window-all-closed', () => {
   // a window (the app installed but "never launched"). macOS was unaffected only
   // because this branch is darwin-exempt. Once the main window has been created,
   // a genuine all-windows-closed on Windows/Linux still quits as intended.
-  if (process.platform !== 'darwin' && didCreateMainWindow) app.quit();
+  if (shouldQuitOnAllWindowsClosed(process.platform, didCreateMainWindow)) {
+    logStartup('window-all-closed → app.quit()');
+    app.quit();
+  }
 });

--- a/electron/startupLog.test.ts
+++ b/electron/startupLog.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  initStartupLog,
+  logStartup,
+  startupLogPath,
+  STARTUP_LOG_FILENAME,
+  MAX_LOG_BYTES,
+  __resetStartupLogForTests,
+} from './startupLog.js';
+
+// The logger does real fs I/O against a temp userData dir. It must be
+// bounded (never grow without limit) and must never throw into startup.
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dayglance-startuplog-'));
+  __resetStartupLogForTests();
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('initStartupLog / logStartup', () => {
+  it('creates the log under userData and appends timestamped lines', () => {
+    const p = initStartupLog(dir);
+    expect(p).toBe(path.join(dir, STARTUP_LOG_FILENAME));
+    expect(startupLogPath()).toBe(p);
+
+    logStartup('createWindow: called');
+    logStartup('main window ready-to-show');
+
+    const contents = fs.readFileSync(p!, 'utf-8');
+    expect(contents).toContain('===== session');
+    expect(contents).toContain('createWindow: called');
+    expect(contents).toContain('main window ready-to-show');
+  });
+
+  it('preserves prior sessions across inits (appends a new session header)', () => {
+    initStartupLog(dir);
+    logStartup('first launch line');
+    __resetStartupLogForTests();
+
+    initStartupLog(dir);
+    const contents = fs.readFileSync(path.join(dir, STARTUP_LOG_FILENAME), 'utf-8');
+    // Old content kept, and a second session header added.
+    expect(contents).toContain('first launch line');
+    expect(contents.match(/===== session/g)?.length).toBe(2);
+  });
+
+  it('drops an oversized log on init so it can never grow without bound', () => {
+    const target = path.join(dir, STARTUP_LOG_FILENAME);
+    fs.writeFileSync(target, 'x'.repeat(MAX_LOG_BYTES + 1));
+
+    initStartupLog(dir);
+    const contents = fs.readFileSync(target, 'utf-8');
+    expect(contents).not.toContain('xxxx'); // stale bulk gone
+    expect(contents).toContain('===== session'); // fresh header only
+    expect(contents.length).toBeLessThan(MAX_LOG_BYTES);
+  });
+
+  it('logStartup is a no-op (no throw) before init', () => {
+    expect(() => logStartup('should be ignored')).not.toThrow();
+    expect(startupLogPath()).toBeNull();
+  });
+});

--- a/electron/startupLog.ts
+++ b/electron/startupLog.ts
@@ -1,0 +1,71 @@
+// Lightweight startup logger — a support aid for diagnosing desktop launch
+// problems that only reproduce on a user's machine (the Windows "installs but
+// never launches" class of bug). It appends timestamped milestones and any
+// load/crash events to a small, bounded file in userData so a user can send it
+// after a bad launch. Best-effort throughout: logging must NEVER throw into the
+// startup path, so every fs call is guarded.
+//
+// The pure file bookkeeping lives here (no electron import) so it is unit
+// testable; main.ts injects the userData directory and wires the electron event
+// milestones.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const STARTUP_LOG_FILENAME = 'dayglance-startup.log';
+
+// Keep the file tiny — it's a rolling record of recent launches, not a full
+// trace. When the existing log exceeds this, it's dropped on the next init so it
+// can never grow without bound across launches.
+export const MAX_LOG_BYTES = 256 * 1024;
+
+let logPath: string | null = null;
+
+function stamp(): string {
+  // new Date() is fine in app code (unlike workflow scripts); wrapped so a
+  // hypothetical environment quirk can't break logging.
+  try { return new Date().toISOString(); } catch { return '?'; }
+}
+
+/**
+ * Point the logger at <userDataDir>/dayglance-startup.log and open a new session
+ * section. Preserves prior contents unless the file has grown past MAX_LOG_BYTES,
+ * in which case it starts fresh. Returns the resolved path (or null on failure).
+ */
+export function initStartupLog(userDataDir: string): string | null {
+  try {
+    const target = path.join(userDataDir, STARTUP_LOG_FILENAME);
+    let prior = '';
+    try {
+      if (fs.statSync(target).size <= MAX_LOG_BYTES) {
+        prior = fs.readFileSync(target, 'utf-8');
+      }
+      // Oversized → drop it; `prior` stays empty so we start clean.
+    } catch { /* no existing log — first run */ }
+    const header = `\n===== session ${stamp()} platform=${process.platform} pid=${process.pid} =====\n`;
+    fs.writeFileSync(target, prior + header);
+    logPath = target;
+    return logPath;
+  } catch {
+    logPath = null;
+    return null;
+  }
+}
+
+/** Append one timestamped line. No-op until initStartupLog has run. */
+export function logStartup(message: string): void {
+  if (!logPath) return;
+  try {
+    fs.appendFileSync(logPath, `[${stamp()}] ${message}\n`);
+  } catch { /* best-effort — never break startup */ }
+}
+
+/** The active log path, or null if logging isn't initialized. */
+export function startupLogPath(): string | null {
+  return logPath;
+}
+
+// Test-only: reset module state between cases.
+export function __resetStartupLogForTests(): void {
+  logPath = null;
+}

--- a/electron/startupQuit.test.ts
+++ b/electron/startupQuit.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { shouldQuitOnAllWindowsClosed } from './startupQuit.js';
+
+// Regression test for the Windows/Linux "installs but never launches" bug: the
+// storage migration creates and destroys hidden BrowserWindows BEFORE the main
+// window exists, firing window-all-closed with zero real windows. The handler
+// must NOT quit in that state, or the process exits mid-startup.
+
+describe('shouldQuitOnAllWindowsClosed', () => {
+  describe('macOS — never quits on window-all-closed (stays in tray/dock)', () => {
+    it('does not quit before the main window is created', () => {
+      expect(shouldQuitOnAllWindowsClosed('darwin', false)).toBe(false);
+    });
+    it('does not quit after the main window is created either', () => {
+      expect(shouldQuitOnAllWindowsClosed('darwin', true)).toBe(false);
+    });
+  });
+
+  describe('Windows/Linux — must survive transient startup windows', () => {
+    it('does NOT quit before the main window exists (the migration reader/writer case)', () => {
+      // THE REGRESSION: a hidden migration window closing during startup must not
+      // trip app.quit(). If this ever returns true again, Windows/Linux first
+      // launch dies before showing a window.
+      expect(shouldQuitOnAllWindowsClosed('win32', false)).toBe(false);
+      expect(shouldQuitOnAllWindowsClosed('linux', false)).toBe(false);
+    });
+
+    it('DOES quit once the main window has been created and all windows later close', () => {
+      expect(shouldQuitOnAllWindowsClosed('win32', true)).toBe(true);
+      expect(shouldQuitOnAllWindowsClosed('linux', true)).toBe(true);
+    });
+  });
+});

--- a/electron/startupQuit.ts
+++ b/electron/startupQuit.ts
@@ -1,0 +1,31 @@
+// Decision logic for the `window-all-closed` → `app.quit()` handler, extracted
+// as a pure function so the startup-safety invariant can be unit-tested without
+// booting Electron (same pattern as appProtocol.ts).
+//
+// THE BUG THIS ENCODES: startup runs migrateFileToAppStorage() BEFORE the main
+// window is created, and that migration briefly opens then destroys hidden
+// BrowserWindows (the file:// localStorage reader / app:// writer). Destroying
+// the last of those fires `window-all-closed` while zero real windows exist yet.
+// If the handler quits on that, the app exits mid-startup and never shows a
+// window — the "installs but never launches" failure seen on Windows/Linux.
+// macOS was unaffected only because it never quits on window-all-closed.
+
+/**
+ * Whether the `window-all-closed` event should quit the app.
+ *
+ *  - macOS (`darwin`): never — the app stays alive in the tray/dock and is
+ *    reopened from there. (Matches long-standing platform convention.)
+ *  - Windows/Linux: only once the real main window has been created. Before
+ *    that, a `window-all-closed` can only be coming from a transient startup
+ *    utility window, and quitting on it would kill the app before launch.
+ *
+ * @param platform          `process.platform`
+ * @param mainWindowCreated whether `createWindow()` has run at least once
+ */
+export function shouldQuitOnAllWindowsClosed(
+  platform: NodeJS.Platform,
+  mainWindowCreated: boolean,
+): boolean {
+  if (platform === 'darwin') return false;
+  return mainWindowCreated;
+}


### PR DESCRIPTION
Follow-up to the Windows/Linux "installs but never launches" fix (#1206). Two hardening changes so it can't silently regress and so the next weird desktop launch report is diagnosable. No behavior change on a healthy launch.

## 1. Regression test for the startup-quit guard

`window-all-closed` firing during the pre-window storage migration (which opens then destroys hidden BrowserWindows) is what killed first launch. The quit decision is now a pure function, `shouldQuitOnAllWindowsClosed(platform, mainWindowCreated)`, extracted so it's unit-testable without booting Electron (same pattern as `appProtocol.ts`).

`startupQuit.test.ts` pins the invariant explicitly:
- macOS never quits on `window-all-closed` (tray/dock), before or after window creation.
- **Windows/Linux must NOT quit before the main window exists** — the regression case. If this ever flips back to `true`, first launch dies mid-startup.
- Windows/Linux DO quit once the main window has existed and all windows later close.

## 2. Startup logging safety net

`startupLog.ts` — a bounded, best-effort logger writing `dayglance-startup.log` to userData:
- Milestones: module loaded, app ready, storage migration start/done, createWindow, window show (and *why* it showed).
- Failure events: `did-fail-load`, `render-process-gone`, `preload-error`, plus process-level `uncaughtException` / `unhandledRejection`.
- Never throws into startup; capped at 256KB so it can't grow without bound; each launch appends a session header.

`main.ts` also gets a **10s fallback that forces the window visible** if `ready-to-show` never fires — so a failed launch surfaces a reportable (if blank) window instead of the silent invisible process that made this bug so hard to pin down. The log records which path showed the window.

This directly addresses the debugging pain from this saga: had it existed, the migration-quit and the earlier `inAppPurchase` throw would both have been obvious from the log instead of inferred blind.

## Verification

- `tsc -p tsconfig.electron.json` — passes
- `vitest run` — **794 tests pass** (includes 4 new quit-guard + 4 new logger tests)
- `tsconfig.electron.json` already excludes `**/*.test.ts`, so the tests don't ship; the two runtime modules do.

Note: as with the prior desktop PRs, I can't launch Electron in the build sandbox (egress policy blocks the binary), so the runtime wiring is verified by typecheck + the pure-logic tests, not an on-device run. The logger/fallback are best-effort and guarded, but a real first-launch check off this branch is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZUmrdNjPX1x5ohSWQ3zZu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZUmrdNjPX1x5ohSWQ3zZu)_