### PR TITLE
Suppress AI features on the China App Store storefront

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist-electron
 dist-app
 electron/native/calendar-helper/build/
 electron/native/icloud-helper/build/
+electron/native/storefront-helper/build/
 electron/*.provisionprofile
 outputs
 dayglance-android/app/src/main/assets/web

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -79,10 +79,11 @@ module.exports = {
       NSCalendarsUsageDescription: 'dayGLANCE shows your calendar events alongside your tasks.',
       NSCalendarsFullAccessUsageDescription: 'dayGLANCE shows your calendar events alongside your tasks.',
     },
-    // Bundle the signed EventKit helper (built by scripts/build-calendar-helper.sh)
-    // into Contents/Resources/calendar-helper. electron-builder signs nested binaries.
+    // Bundle the signed EventKit + StoreKit-storefront helpers (built by
+    // scripts/build-helpers) into Contents/Resources. electron-builder signs nested binaries.
     extraResources: [
       { from: 'electron/native/calendar-helper/build/dayglance-calendar-helper', to: 'calendar-helper/dayglance-calendar-helper' },
+      { from: 'electron/native/storefront-helper/build/dayglance-storefront-helper', to: 'storefront-helper/dayglance-storefront-helper' },
     ],
     target: [
       { target: 'dmg', arch: ['x64', 'arm64'] },
@@ -110,6 +111,7 @@ module.exports = {
     },
     extraResources: [
       { from: 'electron/native/calendar-helper/build/dayglance-calendar-helper', to: 'calendar-helper/dayglance-calendar-helper' },
+      { from: 'electron/native/storefront-helper/build/dayglance-storefront-helper', to: 'storefront-helper/dayglance-storefront-helper' },
     ],
     // Universal (x86_64 + arm64) so the App Store accepts the build for every Mac.
     // Without this it defaults to the host arch only (arm64), which Apple rejects

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { createWsServer } from './ws-server.js';
 import { registerSubscriptionHandlers } from './subscription.js';
 import { registerCalendarHandlers } from './calendar.js';
+import { registerStorefrontHandlers } from './storefront.js';
 import { registerICloudHandlers } from './icloud.js';
 import { registerObsidianHandlers } from './obsidian.js';
 import { APP_SCHEME, APP_HOST, APP_BASE_URL, resolveAppRequest } from './appProtocol.js';
@@ -732,6 +733,7 @@ app.whenReady().then(async () => {
   createWsServer(() => live(mainWindow));
   registerSubscriptionHandlers(win);
   registerCalendarHandlers();
+  registerStorefrontHandlers();
   registerICloudHandlers(() => live(mainWindow));
   registerObsidianHandlers();
   if (process.platform === 'darwin') createTray();

--- a/electron/native/storefront-helper/Sources/main.swift
+++ b/electron/native/storefront-helper/Sources/main.swift
@@ -1,0 +1,63 @@
+import Foundation
+import StoreKit
+
+// dayglance-storefront-helper
+//
+// A tiny CLI spawned by the Electron main process to report the Mac App Store
+// storefront the app is running under. Used to comply with regional legal
+// requirements — specifically suppressing generative-AI features on the China
+// (CN) storefront per App Store Review Guideline 5 (Deep Synthesis / MIIT).
+//
+// Subcommand:
+//   country → {"countryCode":"CHN"}  (ISO 3166-1 alpha-3, matching StoreKit)
+//           → {"countryCode":null}   (storefront could not be determined)
+//
+// The main process treats a null/absent result as "unknown" and falls back to
+// the OS region (app.getLocaleCountryCode), so a nil here never silently
+// disables AI for the whole world — see electron/storefront.ts.
+
+func printCountry(_ code: String?) {
+    let obj: [String: Any] = ["countryCode": code as Any]
+    if let data = try? JSONSerialization.data(withJSONObject: obj),
+       let s = String(data: data, encoding: .utf8) {
+        print(s)
+    } else {
+        print("{\"countryCode\":null}")
+    }
+}
+
+// Prefer StoreKit 2's Storefront.current (macOS 12+, authoritative, async).
+// Fall back to StoreKit 1's SKPaymentQueue.storefront (macOS 11+), then nil.
+// Both expose the storefront country as an ISO 3166-1 alpha-3 code.
+func resolveAndExit() {
+    if #available(macOS 12.0, *) {
+        Task {
+            let sk2 = await Storefront.current?.countryCode
+            if let sk2 = sk2, !sk2.isEmpty {
+                printCountry(sk2)
+            } else if let sk1 = SKPaymentQueue.default().storefront?.countryCode, !sk1.isEmpty {
+                printCountry(sk1)
+            } else {
+                printCountry(nil)
+            }
+            exit(0)
+        }
+        // Keep the process alive for the async Task above; exit(0) inside it ends us.
+        RunLoop.main.run()
+    } else if #available(macOS 11.0, *) {
+        printCountry(SKPaymentQueue.default().storefront?.countryCode)
+        exit(0)
+    } else {
+        printCountry(nil)
+        exit(0)
+    }
+}
+
+let args = Array(CommandLine.arguments.dropFirst())
+switch args.first {
+case "country":
+    resolveAndExit()
+default:
+    printCountry(nil)
+    exit(1)
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -114,12 +114,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('subscription:prices-ready', handler);
   },
 
-  // App Store storefront country (uppercase ISO code, alpha-2 or alpha-3; '' if
-  // unknown). Prefers StoreKit's storefront, falls back to the OS region. Used to
-  // comply with regional legal requirements — e.g. suppressing generative-AI
-  // features on the China storefront (App Store Guideline 5 / MIIT). macOS only;
-  // other platforms have no such API and this channel returns ''.
-  getStorefrontCountry: (): Promise<string> => ipcRenderer.invoke('storefront:country'),
+  // App Store storefront country + the source that produced it:
+  //   { country: string, source: 'storekit' | 'locale' | 'none' }
+  // country is an uppercase ISO code (alpha-2 or alpha-3; '' if unknown). `source`
+  // lets a tester confirm StoreKit resolved inside the helper ('storekit') vs. the
+  // OS-region fallback ('locale'). Used to comply with regional legal requirements —
+  // e.g. suppressing generative-AI features on the China storefront (App Store
+  // Guideline 5 / MIIT). macOS only; other platforms return { country: '', source: 'none' }.
+  getStorefrontCountry: (): Promise<{ country: string; source: 'storekit' | 'locale' | 'none' }> =>
+    ipcRenderer.invoke('storefront:country'),
 
   // iCloud sync — reads/writes dayglance-sync.json in the shared ubiquitous container.
   // macOS only; returns null/false on other platforms.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -114,6 +114,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('subscription:prices-ready', handler);
   },
 
+  // App Store storefront country (uppercase ISO code, alpha-2 or alpha-3; '' if
+  // unknown). Prefers StoreKit's storefront, falls back to the OS region. Used to
+  // comply with regional legal requirements — e.g. suppressing generative-AI
+  // features on the China storefront (App Store Guideline 5 / MIIT). macOS only;
+  // other platforms have no such API and this channel returns ''.
+  getStorefrontCountry: (): Promise<string> => ipcRenderer.invoke('storefront:country'),
+
   // iCloud sync — reads/writes dayglance-sync.json in the shared ubiquitous container.
   // macOS only; returns null/false on other platforms.
   readICloud: (): Promise<string | null> => ipcRenderer.invoke('icloud:read'),

--- a/electron/storefront.ts
+++ b/electron/storefront.ts
@@ -1,0 +1,87 @@
+import { ipcMain, app } from 'electron';
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// ── App Store storefront detection (macOS) ──────────────────────────────────
+//
+// Reports the storefront country the app is running under so the renderer can
+// suppress region-restricted features — specifically generative-AI on the China
+// (CN) storefront, per App Store Review Guideline 5 (Deep Synthesis / MIIT).
+//
+// Two signals, in order of authority:
+//   1. StoreKit storefront via the signed Swift helper (dayglance-storefront-helper).
+//      This is the correct signal — it's the actual App Store storefront, not the
+//      device's region. Emits an ISO 3166-1 alpha-3 code (e.g. "CHN").
+//   2. OS region via app.getLocaleCountryCode() (ISO alpha-2, e.g. "CN"), used
+//      only when the helper is missing, times out, or returns nothing.
+//
+// The fallback matters: it is unverified whether StoreKit resolves a storefront
+// inside a spawned (non-App-Store) helper process. If the helper returns null,
+// the locale fallback still catches a reviewer testing from a CN-configured Mac,
+// so the feature is never left visibly active in the China review environment —
+// and a null never disables AI worldwide (that would need the locale to be CN too).
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const HELPER_NAME = 'dayglance-storefront-helper';
+
+function helperPath(): string | null {
+  const candidates = app.isPackaged
+    ? [path.join(process.resourcesPath, 'storefront-helper', HELPER_NAME)]
+    : [path.join(__dirname, '..', 'electron', 'native', 'storefront-helper', 'build', HELPER_NAME)];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+// Spawns the helper and resolves its parsed JSON stdout. A hung StoreKit call is
+// bounded by the timeout, after which resolveStorefrontCountry falls back to locale.
+function runHelper(args: string[]): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const bin = helperPath();
+    if (!bin) { reject(new Error('storefront helper not found')); return; }
+    execFile(bin, args, { timeout: 10_000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
+      if (err) { reject(err); return; }
+      try {
+        resolve(JSON.parse(stdout.toString().trim() || 'null'));
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}
+
+const norm = (code: string | null | undefined): string => (code || '').toUpperCase();
+
+// Resolves the storefront country as an uppercase ISO code (alpha-2 or alpha-3),
+// or '' when unknown. StoreKit's alpha-3 is preferred; locale's alpha-2 is the
+// fallback. The renderer treats both "CN" and "CHN" as the China storefront.
+async function resolveStorefrontCountry(): Promise<string> {
+  if (process.platform === 'darwin') {
+    try {
+      const res = await runHelper(['country']) as { countryCode?: string | null } | null;
+      const sk = norm(res?.countryCode);
+      if (sk) return sk;
+    } catch {
+      // helper missing / errored / timed out — fall through to locale
+    }
+  }
+  try {
+    return norm(app.getLocaleCountryCode());
+  } catch {
+    return '';
+  }
+}
+
+export function registerStorefrontHandlers(): void {
+  ipcMain.handle('storefront:country', async () => {
+    try {
+      return await resolveStorefrontCountry();
+    } catch {
+      return '';
+    }
+  });
+}

--- a/electron/storefront.ts
+++ b/electron/storefront.ts
@@ -56,32 +56,40 @@ function runHelper(args: string[]): Promise<unknown> {
 
 const norm = (code: string | null | undefined): string => (code || '').toUpperCase();
 
+// Where the resolved country came from — surfaced to the renderer so a tester can
+// confirm StoreKit actually resolved inside the helper ('storekit') rather than the
+// OS-region fallback carrying it ('locale'). 'none' means neither produced a value.
+export type StorefrontSource = 'storekit' | 'locale' | 'none';
+export interface StorefrontResult { country: string; source: StorefrontSource; }
+
 // Resolves the storefront country as an uppercase ISO code (alpha-2 or alpha-3),
-// or '' when unknown. StoreKit's alpha-3 is preferred; locale's alpha-2 is the
+// tagged with its source. StoreKit's alpha-3 is preferred; locale's alpha-2 is the
 // fallback. The renderer treats both "CN" and "CHN" as the China storefront.
-async function resolveStorefrontCountry(): Promise<string> {
+async function resolveStorefront(): Promise<StorefrontResult> {
   if (process.platform === 'darwin') {
     try {
       const res = await runHelper(['country']) as { countryCode?: string | null } | null;
       const sk = norm(res?.countryCode);
-      if (sk) return sk;
+      if (sk) return { country: sk, source: 'storekit' };
     } catch {
       // helper missing / errored / timed out — fall through to locale
     }
   }
   try {
-    return norm(app.getLocaleCountryCode());
+    const loc = norm(app.getLocaleCountryCode());
+    if (loc) return { country: loc, source: 'locale' };
   } catch {
-    return '';
+    // getLocaleCountryCode unavailable — fall through to 'none'
   }
+  return { country: '', source: 'none' };
 }
 
 export function registerStorefrontHandlers(): void {
   ipcMain.handle('storefront:country', async () => {
     try {
-      return await resolveStorefrontCountry();
+      return await resolveStorefront();
     } catch {
-      return '';
+      return { country: '', source: 'none' } as StorefrontResult;
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
     "build:calendar-helper": "bash scripts/build-calendar-helper.sh",
     "build:icloud-helper": "bash scripts/build-icloud-helper.sh",
-    "build:helpers": "npm run build:calendar-helper",
+    "build:storefront-helper": "bash scripts/build-storefront-helper.sh",
+    "build:helpers": "npm run build:calendar-helper && npm run build:storefront-helper",
     "build:electron": "npm run build:helpers && vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs",
     "build:electron:release": "npm run build:helpers && vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && electron-builder --config electron-builder.config.cjs --publish never",
     "build:electron:mas": "npm run build:helpers && vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && DAYGLANCE_APP_ID=com.dayglance electron-builder --config electron-builder.config.cjs --mac mas --universal --publish never"

--- a/scripts/build-storefront-helper.sh
+++ b/scripts/build-storefront-helper.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Compiles the macOS StoreKit storefront helper to a universal (x64 + arm64)
+# binary that electron-builder bundles into the app via `mac.extraResources`.
+#
+# Output: electron/native/storefront-helper/build/dayglance-storefront-helper
+#
+# No-op (exit 0) on non-macOS hosts or when `swiftc` is unavailable, so the rest
+# of the build pipeline still runs on Linux/Windows/CI — the helper is macOS-only
+# and is only required when producing a macOS (dmg/zip/mas) build.
+
+set -euo pipefail
+
+HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../electron/native/storefront-helper" && pwd)"
+SRC="$HELPER_DIR/Sources/main.swift"
+OUT_DIR="$HELPER_DIR/build"
+OUT="$OUT_DIR/dayglance-storefront-helper"
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "build-storefront-helper: skipping (not macOS)"
+  exit 0
+fi
+
+if ! command -v swiftc >/dev/null 2>&1; then
+  echo "build-storefront-helper: skipping (swiftc not found — install Xcode command line tools)"
+  exit 0
+fi
+
+mkdir -p "$OUT_DIR"
+
+echo "build-storefront-helper: compiling universal binary → $OUT"
+swiftc -O \
+  -framework StoreKit -framework Foundation \
+  -target arm64-apple-macos11.0 \
+  -o "$OUT_DIR/dayglance-storefront-helper-arm64" \
+  "$SRC"
+
+swiftc -O \
+  -framework StoreKit -framework Foundation \
+  -target x86_64-apple-macos11.0 \
+  -o "$OUT_DIR/dayglance-storefront-helper-x64" \
+  "$SRC"
+
+lipo -create \
+  "$OUT_DIR/dayglance-storefront-helper-arm64" \
+  "$OUT_DIR/dayglance-storefront-helper-x64" \
+  -output "$OUT"
+
+rm -f "$OUT_DIR/dayglance-storefront-helper-arm64" "$OUT_DIR/dayglance-storefront-helper-x64"
+chmod +x "$OUT"
+
+echo "build-storefront-helper: done"
+lipo -info "$OUT" || true

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1038,9 +1038,14 @@ const DayPlanner = () => {
     if (!api?.getStorefrontCountry) return;
     let cancelled = false;
     api.getStorefrontCountry()
-      .then((country) => {
+      .then((res) => {
         if (cancelled) return;
-        const c = (country || '').toUpperCase();
+        const c = (res?.country || '').toUpperCase();
+        const source = res?.source || 'none';
+        // Diagnostic (intentionally not DEV-gated so it's visible in the packaged
+        // MAS build's DevTools): confirms whether the storefront came from StoreKit
+        // inside the helper vs. the OS-region fallback.
+        console.info(`[storefront] country=${c || '(unknown)'} source=${source}`);
         if (c === 'CN' || c === 'CHN') setAiSuppressed(true);
       })
       .catch(() => {});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -984,7 +984,7 @@ const DayPlanner = () => {
 
   // AI configuration, voice input, and weekly review state
   const {
-    aiConfig, setAiConfig,
+    aiConfig: rawAiConfig, setAiConfig,
     aiConnectionStatus, setAiConnectionStatus,
     aiConnectionMessage, setAiConnectionMessage,
     aiOllamaHelp, setAiOllamaHelp,
@@ -1025,6 +1025,36 @@ const DayPlanner = () => {
     weeklyAILoading, setWeeklyAILoading,
     weeklyAIError, setWeeklyAIError,
   } = useVoiceAI();
+
+  // Regional AI suppression: the Mac App Store build must deactivate its
+  // generative-AI features on the China (CN) storefront to comply with App Store
+  // Review Guideline 5 (Deep Synthesis / MIIT licensing). We ask the main process
+  // for the storefront country (StoreKit, with an OS-region fallback) and, when it
+  // resolves to China, force the AI config off and hide the AI settings section.
+  // Non-macOS platforms expose no such API, so this stays false there (no change).
+  const [aiSuppressed, setAiSuppressed] = useState(false);
+  useEffect(() => {
+    const api = typeof window !== 'undefined' ? window.electronAPI : null;
+    if (!api?.getStorefrontCountry) return;
+    let cancelled = false;
+    api.getStorefrontCountry()
+      .then((country) => {
+        if (cancelled) return;
+        const c = (country || '').toUpperCase();
+        if (c === 'CN' || c === 'CHN') setAiSuppressed(true);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  // Effective AI config seen by every consumer (App effects + FeaturesContext).
+  // When suppressed we force `enabled: false` so all AI calls short-circuit, without
+  // mutating the user's stored config (they keep their settings if they ever leave
+  // the CN storefront). When not suppressed this is the raw config unchanged.
+  const aiConfig = useMemo(
+    () => (aiSuppressed ? { ...rawAiConfig, enabled: false } : rawAiConfig),
+    [rawAiConfig, aiSuppressed],
+  );
 
   // GTD Frames state
   const {
@@ -9175,7 +9205,7 @@ const DayPlanner = () => {
     wakeLockSentinel, focusModeAvailable,
 
     // ── AI / Voice ────────────────────────────────────────────────────────────
-    aiConfig, setAiConfig,
+    aiConfig, setAiConfig, aiSuppressed,
     aiConnectionStatus, setAiConnectionStatus,
     aiConnectionMessage, setAiConnectionMessage,
     aiOllamaHelp, setAiOllamaHelp,

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -115,7 +115,7 @@ const MobileSettingsPanel = () => {
     smartScheduleError, setSmartScheduleError,
     smartScheduleAccepted, setSmartScheduleAccepted,
     runSmartSchedule, applySmartSchedule,
-    aiConfig, setAiConfig,
+    aiConfig, setAiConfig, aiSuppressed,
     aiConnectionStatus, setAiConnectionStatus,
     aiConnectionMessage, setAiConnectionMessage,
     aiOllamaHelp, setAiOllamaHelp,
@@ -289,6 +289,8 @@ const MobileSettingsPanel = () => {
         <Activity size={24} className={mobileSettingsView === 'habits' ? 'text-green-500' : habitsEnabled ? 'text-green-500' : textSecondary} />
         <span className={`text-xs font-medium ${textPrimary}`}>{habitsEnabled ? t('settings.habitsOn') : t('settings.habitsOff')}</span>
       </button>
+      {/* AI tile hidden on the China App Store storefront (Guideline 5 / MIIT). */}
+      {!aiSuppressed && (
       <button
         onClick={() => setMobileSettingsView('ai')}
         className={`${cardBg} border ${borderClass} rounded-xl p-4 flex flex-col items-center gap-2`}
@@ -296,6 +298,7 @@ const MobileSettingsPanel = () => {
         {aiConfig.enabled ? <BrainCircuit size={24} className="text-purple-400" /> : <BrainCircuit size={24} className={textSecondary} />}
         <span className={`text-xs font-medium ${textPrimary}`}>{aiConfig.enabled ? t('settings.aiOn') : t('settings.aiOff')}</span>
       </button>
+      )}
     </div>
 
     {/* Sync buttons */}
@@ -1141,8 +1144,8 @@ const MobileSettingsPanel = () => {
     </div>
   )}
 
-  {/* AI settings sub-view */}
-  {mobileSettingsView === 'ai' && (
+  {/* AI settings sub-view — suppressed on the China App Store storefront (Guideline 5 / MIIT). */}
+  {mobileSettingsView === 'ai' && !aiSuppressed && (
     <div className="px-4 py-4 space-y-4">
       <button
         onClick={() => setMobileSettingsView('main')}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -78,7 +78,7 @@ const SettingsModal = () => {
     habitsEnabled, setHabitsEnabled,
     routinesEnabled, setRoutinesEnabled,
     goalsProjectsEnabled, setGoalsProjectsEnabled,
-    aiConfig, setAiConfig,
+    aiConfig, setAiConfig, aiSuppressed,
     aiConnectionStatus, setAiConnectionStatus, aiConnectionMessage, setAiConnectionMessage,
     aiOllamaHelp, setAiOllamaHelp,
     multiUserEnabled, setMultiUserEnabled,
@@ -1230,9 +1230,11 @@ const SettingsModal = () => {
                       )}
                     </div>
 
+                    {/* AI Features Section — hidden on the China App Store storefront
+                        to comply with App Store Review Guideline 5 (Deep Synthesis / MIIT). */}
+                    {!aiSuppressed && (<>
                     <hr className={borderClass} />
 
-                    {/* AI Features Section */}
                     <div className="space-y-3">
                       <button onClick={() => toggleSettingsSection('ai')} className={`font-medium ${textPrimary} flex items-center gap-2 w-full text-left`}>
                         <BrainCircuit size={16} className={aiConfig.enabled ? 'text-purple-400' : textSecondary} />
@@ -1454,6 +1456,7 @@ const SettingsModal = () => {
                       )}
                       </>)}
                     </div>
+                    </>)}
 
                     {(!isMobile || isNativeAndroid()) && (<>
                     <hr className={borderClass} />


### PR DESCRIPTION
## Summary

Complies with App Store Review Guideline 5 (Deep Synthesis / MIIT licensing) by **deactivating the generative-AI features on the China (CN) storefront** of the Mac App Store build. Apple rejected the app because it references generative-AI functionality that isn't licensed to operate in China; this change detects the App Store storefront at runtime and turns the AI features off (and hides their UI) when it is China. All other storefronts and non-macOS platforms are unaffected.

The metadata half of the rejection (removing the "OpenAI" reference from the App Store listing description) is handled separately in App Store Connect and is not part of this diff.

## How it works

1. **Storefront detection (new signed native helper).** `electron/native/storefront-helper` is a small StoreKit CLI, spawned by the main process, that reports the storefront country (`country` → `{"countryCode":"CHN"}`, ISO alpha-3). It mirrors the existing EventKit `calendar-helper` pattern — universal binary, build script, `extraResources` bundling, sandbox+inherit entitlements.
2. **Fallback.** `electron/storefront.ts` prefers the helper's StoreKit result but falls back to the OS region (`app.getLocaleCountryCode()`) when the helper is missing, errors, or times out. This guarantees a China-configured review Mac still trips the gate, and ensures a null result never disables AI worldwide (that would require the locale to be China too).
3. **Preload bridge.** `getStorefrontCountry()` is exposed on `electronAPI`.
4. **The gate (renderer).** `App.jsx` queries the storefront on mount; when it resolves to `CN`/`CHN` it derives an effective `aiConfig` with `enabled: false` **without mutating the user's stored config**. Because `aiConfig.enabled` is the single choke point for every AI path (and `aiComplete`/`aiTranscribe` throw when it's false), this deactivates morning/evening summaries, smart scheduling, duration estimates, voice parse/transcribe, and the weekly AI summary in one place. The AI settings section is hidden in both `SettingsModal` and `MobileSettingsPanel` (the latter because the desktop window renders the mobile layout below 721px wide), so the user-visible "OpenAI" provider label never appears on the China storefront.

## Files

- `electron/native/storefront-helper/Sources/main.swift` — StoreKit storefront CLI (new)
- `scripts/build-storefront-helper.sh` — universal-binary build script (new)
- `electron/storefront.ts` — main-process resolver + IPC handler (new)
- `electron/main.ts`, `electron/preload.ts` — register/expose the handler
- `package.json`, `electron-builder.config.cjs`, `.gitignore` — build + packaging wiring
- `src/App.jsx` — storefront query, effective-config gate, context plumbing
- `src/components/SettingsModal.jsx`, `src/components/MobileSettingsPanel.jsx` — hide the AI section on CN

## Verification

- `tsc` (electron main + preload), `vite build`, and `eslint` all pass.
- **Requires on-device verification** (not possible in CI/Linux): whether StoreKit resolves a storefront inside a spawned helper process. If it returns null in production, the `getLocaleCountryCode()` fallback covers the reviewer case; confirm by running the packaged helper binary with the `country` argument on a Mac.

## Scope / follow-ups

- macOS (MAS) build only — the gate triggers where `electronAPI.getStorefrontCountry` exists. The iOS app ships the same AI feature to the CN App Store and will need the equivalent gate via a Capacitor storefront plugin (separate change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPAc9TWHSPYYBZNfikqRLX)_