### PR TITLE
Add reviewer-mode banner with one-tap return to paywall

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -146,6 +146,7 @@ import DesktopWelcomeModal from './components/DesktopWelcomeModal.jsx';
 import SpotlightModal from './components/SpotlightModal.jsx';
 import HabitModal from './components/HabitModal.jsx';
 import SubscriptionWall from './components/SubscriptionWall.jsx';
+import ReviewerBanner from './components/ReviewerBanner.jsx';
 import { useSubscription } from './hooks/useSubscription.js';
 import { useTranslation } from 'react-i18next';
 import { syncErrorText } from './sync/syncErrors.js';
@@ -216,6 +217,13 @@ const DayPlanner = () => {
   const { t } = useTranslation();
   const { isPro, isLoading: subLoading, isAndroidApp, isIOSApp, isElectronApp, productId: subProductId, subscribe, restore, prices: subPrices, trialEligible, trialDays, billingEvent, clearBillingEvent, billingErrorMessage, consumeTestPurchase, canConsumeTestPurchase, isReviewerUnlocked, setReviewerUnlocked } = useSubscription();
   useEffect(() => { if (isReviewerUnlocked) console.info('[dayGLANCE] Reviewer unlock active'); }, [isReviewerUnlocked]);
+  // Leave reviewer mode: clear the stored unlock and reload so the billing engine
+  // re-reads a now-absent key (there is no revoke method on the engine), which
+  // brings back the paywall — and therefore the in-app purchases — immediately.
+  const exitReviewerMode = () => {
+    try { localStorage.removeItem('day-planner-reviewer-unlock'); } catch { /* storage unavailable */ }
+    location.reload();
+  };
   const _visibleDays = useVisibleDays();
   const { isPhone, isMobile, isTablet } = useDeviceType();
   const isLandscape = useIsLandscape();
@@ -10897,6 +10905,14 @@ const DayPlanner = () => {
       <VoiceInputModal />
       {/* GTD Frames Modal (Desktop/Tablet) */}
       {showFramesModal && !isMobile && <FramesModal />}
+
+      {/* Reviewer-mode banner — whenever the app is unlocked via the reviewer
+          bypass code, offer a one-tap way back to the paywall so App Review can
+          always locate the in-app purchases (Guideline 2.1(b)). Reviewer unlock
+          only, never genuine purchasers. */}
+      {isReviewerUnlocked && (
+        <ReviewerBanner darkMode={darkMode} onExit={exitReviewerMode} />
+      )}
 
       {/* Subscription wall — shown on Android, iOS, and macOS when subscription is inactive.
           In dev builds, ?wall in the URL forces it visible for local testing. */}

--- a/src/components/ReviewerBanner.jsx
+++ b/src/components/ReviewerBanner.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ShieldCheck } from 'lucide-react';
+
+/**
+ * Shown whenever the app is unlocked via the reviewer bypass code (App Store
+ * Review Guideline 2.1 / Play Console app-access). It gives App Review — and
+ * anyone testing — a persistent, one-tap way to leave reviewer mode and return
+ * to the paywall, so the in-app purchases are always reachable again.
+ *
+ * Without it, a reviewer who entered the code to get past the hard gate had no
+ * way back to the purchase screen (the launch paywall is the only place the
+ * IAPs are surfaced), which produced a Guideline 2.1(b) "we cannot locate the
+ * In-App Purchases" rejection. This banner is rendered only for the reviewer
+ * unlock (`isReviewerUnlocked`), never for genuine purchasers.
+ */
+export default function ReviewerBanner({ darkMode, onExit }) {
+  return (
+    <div
+      role="status"
+      className={`fixed top-0 inset-x-0 z-[10000] flex flex-wrap items-center justify-center gap-x-3 gap-y-1 px-4 py-2 text-xs ${
+        darkMode
+          ? 'bg-amber-500/15 text-amber-200 border-b border-amber-500/30'
+          : 'bg-amber-100 text-amber-900 border-b border-amber-300'
+      }`}
+    >
+      <span className="flex items-center gap-1.5 font-medium">
+        <ShieldCheck size={14} className="flex-shrink-0" />
+        Reviewer access active — the app is unlocked without a purchase.
+      </span>
+      <button
+        onClick={onExit}
+        className={`rounded-full px-3 py-1 font-semibold transition-colors ${
+          darkMode
+            ? 'bg-amber-400 text-amber-950 hover:bg-amber-300'
+            : 'bg-amber-600 text-white hover:bg-amber-700'
+        }`}
+      >
+        Exit &amp; view plans
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Addresses the **Guideline 2.1(b)** rejection ("we cannot locate the In-App Purchases"). On macOS the launch paywall (`SubscriptionWall`) is the *only* place the in-app purchases are surfaced — Settings has no subscription/restore/upgrade entry. So when App Review entered the reviewer bypass code to get past the hard gate, the paywall disappeared and there was no way back to the IAPs, leaving the reviewer unable to locate them.

This adds a persistent banner while reviewer access is active, with a one-tap way back to the paywall.

## What it does

- New `ReviewerBanner` component, rendered at the app root **only when `isReviewerUnlocked`** is true (never for genuine purchasers).
- Slim fixed top bar: "Reviewer access active — the app is unlocked without a purchase." + an **"Exit & view plans"** button.
- The button calls `exitReviewerMode()`, which clears the stored unlock key (`day-planner-reviewer-unlock`) and reloads. The billing engine's `restoreReviewerUnlock()` then finds no key on the next load, so `isReviewerUnlocked` returns false and — with `!isPro` — the paywall (and both IAPs) reappears immediately.

The billing engine (`@glance-apps/billing`, external to this repo) exposes no revoke method, so the clear-key-and-reload approach keeps the fix entirely within the app.

## Scope

- All gated platforms (iOS, Android, macOS) — the reviewer-code flow is shared, so the banner helps every store's review, not just macOS.
- No change to the billing package, the paywall, or the entitlement logic.

## Files

- `src/components/ReviewerBanner.jsx` — new component
- `src/App.jsx` — import, `exitReviewerMode` handler, conditional render next to `SubscriptionWall`

## Verification

- `eslint` and `vite build` pass.
- Flow traced: reviewer enters code → `isReviewerUnlocked` true → banner shows, paywall hidden (its condition already includes `&& !isReviewerUnlocked`) → "Exit & view plans" clears the key and reloads → paywall returns with both IAPs.
- Runtime UI not driven in CI (reviewer unlock requires a native billing adapter, absent in a browser build).

## Note

Minor: the banner is a fixed full-width strip at the very top and overlaps the first ~32px of the app header while active. Since it only appears in reviewer mode (never for real users), that's an accepted tradeoff; if you'd rather it push content down instead of overlapping, that's a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPAc9TWHSPYYBZNfikqRLX)_