### PR TITLE
Make HealthKit habits reachable on iOS; trim unused Health types

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/HealthBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/HealthBridge.swift
@@ -11,11 +11,12 @@ final class HealthBridge {
 
     private let store = HKHealthStore()
 
+    // Only the two types the app actually reads. Heart-rate-variability and
+    // resting-heart-rate were previously declared here but never queried; unused
+    // HealthKit type references draw Guideline 2.5.1 scrutiny, so they are removed.
     private let readTypes: Set<HKObjectType> = [
         HKQuantityType(.stepCount),
         HKCategoryType(.sleepAnalysis),
-        HKQuantityType(.heartRateVariabilitySDNN),
-        HKQuantityType(.restingHeartRate),
     ]
 
     // MARK: - Authorization (deferred)

--- a/src/components/HabitModal.jsx
+++ b/src/components/HabitModal.jsx
@@ -24,6 +24,15 @@ const HabitModal = () => {
     meUserSyncId, managedBy, hasUnownedHabits, claimUnownedHabits,
   } = useFeaturesCtx();
 
+  // iOS reads HealthKit with lazy authorization — the permission sheet is presented
+  // by the native HealthBridge on the first getSteps/getSleep read, so there is no
+  // explicit permission check/request like Android's Health Connect. The health-habit
+  // tiles below gate on this: on iOS the "Add" button is always enabled and the
+  // "Authorize" button is hidden. Without it the button stays permanently disabled,
+  // because the iOS bridge exposes no checkStepsPermission (healthPerms never turns
+  // true), which is what made the HealthKit feature unreachable on iOS.
+  const isIOS = typeof window !== 'undefined' && !!window.DayGlanceIOS;
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => { setShowHabitModal(false); setEditingHabit(null); }}>
       <div className={`${cardBg} rounded-xl shadow-2xl max-w-lg w-full mx-4 max-h-[85vh] overflow-hidden flex flex-col`} onClick={(e) => e.stopPropagation()}>
@@ -336,8 +345,8 @@ const HabitModal = () => {
                 </button>
               )}
 
-              {/* Health Connect steps suggestion — only shown on Android with native bridge */}
-              {window.DayGlanceNative && !activeHabits.some(h => h.source === 'healthConnect' && h.unit === 'steps') && activeHabits.length < 8 && (
+              {/* Steps health-habit suggestion — iOS (HealthKit) and Android (Health Connect). */}
+              {window.DayGlanceNative && !activeHabits.some(h => (h.source === 'healthKit' || h.source === 'healthConnect') && h.unit === 'steps') && activeHabits.length < 8 && (
                 <div className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${darkMode ? 'border-green-800 bg-green-950/40' : 'border-green-200 bg-green-50'}`}>
                   <Footprints size={22} className="text-green-500 flex-shrink-0" />
                   <div className="flex-1 min-w-0">
@@ -345,7 +354,7 @@ const HabitModal = () => {
                     <div className={`text-xs ${darkMode ? 'text-green-500' : 'text-green-600'} mt-0.5`}>{t('habit.trackStepsHint')}</div>
                   </div>
                   <div className="flex gap-1.5 flex-shrink-0">
-                    {!healthPerms?.steps && (
+                    {!isIOS && !healthPerms?.steps && (
                       <button
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-500 text-white hover:bg-green-600 active:bg-green-700 transition-colors"
@@ -354,9 +363,9 @@ const HabitModal = () => {
                       </button>
                     )}
                     <button
-                      onClick={healthPerms?.steps ? addStepsHabit : undefined}
-                      disabled={!healthPerms?.steps}
-                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.steps ? 'bg-green-500 text-white hover:bg-green-600 active:bg-green-700' : 'bg-green-500/30 text-white/50 cursor-not-allowed'}`}
+                      onClick={(isIOS || healthPerms?.steps) ? addStepsHabit : undefined}
+                      disabled={!isIOS && !healthPerms?.steps}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${(isIOS || healthPerms?.steps) ? 'bg-green-500 text-white hover:bg-green-600 active:bg-green-700' : 'bg-green-500/30 text-white/50 cursor-not-allowed'}`}
                     >
                       {t('common.add')}
                     </button>
@@ -364,8 +373,8 @@ const HabitModal = () => {
                 </div>
               )}
 
-              {/* Health Connect sleep suggestion — only shown on Android with native bridge */}
-              {window.DayGlanceNative && !activeHabits.some(h => h.source === 'healthConnect' && h.unit === 'min') && activeHabits.length < 8 && (
+              {/* Sleep health-habit suggestion — iOS (HealthKit) and Android (Health Connect). */}
+              {window.DayGlanceNative && !activeHabits.some(h => (h.source === 'healthKit' || h.source === 'healthConnect') && h.unit === 'min') && activeHabits.length < 8 && (
                 <div className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${darkMode ? 'border-indigo-800 bg-indigo-950/40' : 'border-indigo-200 bg-indigo-50'}`}>
                   <Moon size={22} className="text-indigo-500 flex-shrink-0" />
                   <div className="flex-1 min-w-0">
@@ -373,7 +382,7 @@ const HabitModal = () => {
                     <div className={`text-xs ${darkMode ? 'text-indigo-500' : 'text-indigo-600'} mt-0.5`}>{t('habit.trackSleepHint')}</div>
                   </div>
                   <div className="flex gap-1.5 flex-shrink-0">
-                    {!healthPerms?.sleep && (
+                    {!isIOS && !healthPerms?.sleep && (
                       <button
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700 transition-colors"
@@ -382,9 +391,9 @@ const HabitModal = () => {
                       </button>
                     )}
                     <button
-                      onClick={healthPerms?.sleep ? addSleepHabit : undefined}
-                      disabled={!healthPerms?.sleep}
-                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.sleep ? 'bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700' : 'bg-indigo-500/30 text-white/50 cursor-not-allowed'}`}
+                      onClick={(isIOS || healthPerms?.sleep) ? addSleepHabit : undefined}
+                      disabled={!isIOS && !healthPerms?.sleep}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${(isIOS || healthPerms?.sleep) ? 'bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700' : 'bg-indigo-500/30 text-white/50 cursor-not-allowed'}`}
                     >
                       {t('common.add')}
                     </button>

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -128,6 +128,11 @@ const MobileSettingsPanel = () => {
   } = useFeaturesCtx();
   // Gate multi-user when sync is unconfigured; never trap an already-on toggle.
   const multiUserLocked = multiUserToggleLocked({ cloudSyncConfigured, multiUserEnabled });
+  // iOS uses HealthKit lazy authorization (permission requested on first read), so
+  // it has no explicit permission check/request. On iOS the health-habit "Add"
+  // button is always enabled and the dead "Authorize" button is hidden — see the
+  // matching note in HabitModal.jsx and refreshHealthPerms in useHabits.js.
+  const isIOS = typeof window !== 'undefined' && !!window.DayGlanceIOS;
 
   const [intentForm, setIntentForm] = useState(() => {
     const raw = localStorage.getItem(INTENT_CONFIG_KEY);
@@ -2611,15 +2616,15 @@ const MobileSettingsPanel = () => {
                   {t('habit.addHabit')}
                 </button>
               )}
-              {window.DayGlanceNative && !activeHabits.some(h => h.source === 'healthConnect' && h.unit === 'steps') && activeHabits.length < 8 && (
+              {window.DayGlanceNative && !activeHabits.some(h => (h.source === 'healthKit' || h.source === 'healthConnect') && h.unit === 'steps') && activeHabits.length < 8 && (
                 <div className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${darkMode ? 'border-green-800 bg-green-950/40' : 'border-green-200 bg-green-50'}`}>
                   <Footprints size={22} className="text-green-500 flex-shrink-0" />
                   <div className="flex-1 min-w-0">
                     <div className={`text-sm font-semibold ${darkMode ? 'text-green-300' : 'text-green-800'}`}>Track steps automatically</div>
-                    <div className={`text-xs ${darkMode ? 'text-green-500' : 'text-green-600'} mt-0.5`}>Pulls from Health Connect — no manual tapping</div>
+                    <div className={`text-xs ${darkMode ? 'text-green-500' : 'text-green-600'} mt-0.5`}>Pulls from {isIOS ? 'Apple Health' : 'Health Connect'} — no manual tapping</div>
                   </div>
                   <div className="flex gap-1.5 flex-shrink-0">
-                    {!healthPerms?.steps && (
+                    {!isIOS && !healthPerms?.steps && (
                       <button
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-500 text-white hover:bg-green-600 active:bg-green-700 transition-colors"
@@ -2628,24 +2633,24 @@ const MobileSettingsPanel = () => {
                       </button>
                     )}
                     <button
-                      onClick={healthPerms?.steps ? addStepsHabit : undefined}
-                      disabled={!healthPerms?.steps}
-                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.steps ? 'bg-green-500 text-white hover:bg-green-600 active:bg-green-700' : 'bg-green-500/30 text-white/50 cursor-not-allowed'}`}
+                      onClick={(isIOS || healthPerms?.steps) ? addStepsHabit : undefined}
+                      disabled={!isIOS && !healthPerms?.steps}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${(isIOS || healthPerms?.steps) ? 'bg-green-500 text-white hover:bg-green-600 active:bg-green-700' : 'bg-green-500/30 text-white/50 cursor-not-allowed'}`}
                     >
                       Add
                     </button>
                   </div>
                 </div>
               )}
-              {window.DayGlanceNative && !activeHabits.some(h => h.source === 'healthConnect' && h.unit === 'min') && activeHabits.length < 8 && (
+              {window.DayGlanceNative && !activeHabits.some(h => (h.source === 'healthKit' || h.source === 'healthConnect') && h.unit === 'min') && activeHabits.length < 8 && (
                 <div className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${darkMode ? 'border-indigo-800 bg-indigo-950/40' : 'border-indigo-200 bg-indigo-50'}`}>
                   <Moon size={22} className="text-indigo-500 flex-shrink-0" />
                   <div className="flex-1 min-w-0">
                     <div className={`text-sm font-semibold ${darkMode ? 'text-indigo-300' : 'text-indigo-800'}`}>Track sleep automatically</div>
-                    <div className={`text-xs ${darkMode ? 'text-indigo-500' : 'text-indigo-600'} mt-0.5`}>Pulls from Health Connect — no manual tapping</div>
+                    <div className={`text-xs ${darkMode ? 'text-indigo-500' : 'text-indigo-600'} mt-0.5`}>Pulls from {isIOS ? 'Apple Health' : 'Health Connect'} — no manual tapping</div>
                   </div>
                   <div className="flex gap-1.5 flex-shrink-0">
-                    {!healthPerms?.sleep && (
+                    {!isIOS && !healthPerms?.sleep && (
                       <button
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700 transition-colors"
@@ -2654,9 +2659,9 @@ const MobileSettingsPanel = () => {
                       </button>
                     )}
                     <button
-                      onClick={healthPerms?.sleep ? addSleepHabit : undefined}
-                      disabled={!healthPerms?.sleep}
-                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.sleep ? 'bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700' : 'bg-indigo-500/30 text-white/50 cursor-not-allowed'}`}
+                      onClick={(isIOS || healthPerms?.sleep) ? addSleepHabit : undefined}
+                      disabled={!isIOS && !healthPerms?.sleep}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${(isIOS || healthPerms?.sleep) ? 'bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700' : 'bg-indigo-500/30 text-white/50 cursor-not-allowed'}`}
                     >
                       Add
                     </button>

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -277,7 +277,12 @@ const useHabits = ({ playUISound, hrOwnerRef }) => {
   const [healthPerms, setHealthPerms] = useState({ steps: null, sleep: null });
 
   const refreshHealthPerms = () => {
-    if (!window.DayGlanceNative) return;
+    // iOS has no synchronous permission check — HealthKit authorization is lazy
+    // (the native bridge presents the sheet on the first getSteps/getSleep read).
+    // Leave healthPerms null on iOS so the sync below never skips a read (a skip
+    // would suppress the lazy prompt); getSteps/getSleep return 0 when access is
+    // denied. Android (Health Connect) reports real permission state.
+    if (!window.DayGlanceNative || window.DayGlanceIOS) return;
     try {
       const steps = window.DayGlanceNative.checkStepsPermission() === 'granted';
       const sleep = window.DayGlanceNative.checkSleepPermission() === 'granted';


### PR DESCRIPTION
## Summary

Fixes the iOS **Guideline 2.5.1** rejection ("binary references HealthKit but no feature appears to use health data"). The HealthKit feature wasn't just hard to find — **it was unreachable on iOS**, so the reviewer correctly saw no working health feature.

## Root cause

The "Track steps / Track sleep" habit tiles in `HabitModal` were written for Android's **Health Connect**, which has an explicit permission model:

- the **Add** button is disabled unless `healthPerms.steps` / `healthPerms.sleep` is `true` (`useHabits.js` derives that from `checkStepsPermission()`/`checkSleepPermission()`), and
- an **Authorize** button calls `requestHealthPermission()`.

But the iOS bridge (`BridgeSchemeHandler.dispatchNative`) implements **only** `getSteps` and `getSleep` — `checkStepsPermission`, `checkSleepPermission`, and `requestHealthPermission` all fall through to `default: return "null"`. So on iOS:

- `healthPerms` never becomes `true` → the **Add** button is permanently disabled;
- **Authorize** does nothing (the user confirmed this independently).

Result: no way to create a health-linked habit, so nothing ever calls HealthKit.

iOS is designed to use **lazy authorization** instead — `HealthBridge` presents the permission sheet on the first `getSteps`/`getSleep` read — but the JS UI was never adapted to that model.

## Changes

- **`src/components/HabitModal.jsx`** — gate the health-habit tiles on an `isIOS` flag (`window.DayGlanceIOS`, the existing iOS marker):
  - on iOS the **Add** button is always enabled — tapping it creates the habit, and the first health sync triggers the HealthKit permission prompt (lazy auth);
  - on iOS the dead **Authorize** button is hidden;
  - tiles now dedupe against `'healthKit'` habits too (not only `'healthConnect'`), so they disappear once added on iOS.
  - Android behaviour is unchanged.
- **`dayglance-ios/DayGlance/Bridges/HealthBridge.swift`** — trim `readTypes` to the two types actually queried (`stepCount`, `sleepAnalysis`); `heartRateVariabilitySDNN` and `restingHeartRate` were declared but never read, and unused HealthKit references invite 2.5.1 scrutiny.

## Verification

- `eslint` + `vite build` pass; health util tests (`healthHabitChanges`, `healthLogFilter`) green (17 passing).
- **Needs on-device iOS testing** (can't run here): open Habits → Add habit → tap **Add** on "Track steps" or "Track sleep" → the HealthKit permission sheet should appear on the first sync, and the habit ring should fill from Health after granting.

## Reviewer notes (for resubmission)

> HealthKit is used to auto-track step-count and sleep habits. To see it: open the Habits screen, tap "+" to add a habit, and on the "Track steps" or "Track sleep" suggestion tap "Add". iOS then presents the HealthKit permission prompt; once granted, the habit's progress fills automatically from Health each day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPAc9TWHSPYYBZNfikqRLX)_