### PR TITLE
iOS HealthKit: explicit Authorize button (implement the native methods)

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/HealthBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/HealthBridge.swift
@@ -19,45 +19,51 @@ final class HealthBridge {
         HKCategoryType(.sleepAnalysis),
     ]
 
-    // MARK: - Authorization (deferred)
+    // MARK: - Authorization (explicit)
     //
-    // Authorization is NO LONGER requested at launch (guideline 5.1.1 — reviewers
-    // dislike an unprompted HealthKit dialog in the startup cascade). Instead it is
-    // requested lazily the first time the web layer actually reads health data
-    // (getSteps / getSleep), i.e. only when a health-linked habit exists and its
-    // count is being fetched.
-    //
-    // The request is fired asynchronously so it never blocks the synchronous bridge
-    // thread (getSteps/getSleep hold the main thread on a semaphore while the query
-    // runs; presenting the permission sheet from a blocked main thread would
-    // deadlock). When the sheet closes we post .dayGlanceReloadWebView — the same
+    // Authorization is requested only when the user taps "Authorize" on a health-
+    // habit tile — never at launch (guideline 5.1.1). requestAuthorization() presents
+    // the sheet from a clean, user-initiated context (not from inside a semaphore-
+    // blocked read, which is fragile), then posts .dayGlanceReloadWebView — the same
     // reload-after-permission mechanism the calendar flow uses — so the web layer
-    // re-runs its health sync and the counts load with access granted.
+    // re-reads permission state and health counts once access is determined.
     //
-    // If the user already responded in a previous session, getRequestStatusForAuthorization
-    // reports .unnecessary, no sheet is shown, and the query below runs immediately —
-    // startup behaviour is unchanged for already-authorized users.
+    // permissionAsked() is the UI gate. HealthKit deliberately does NOT reveal
+    // whether READ access was granted — only whether the app has already prompted:
+    // getRequestStatusForAuthorization reports .unnecessary once the user has
+    // responded (granted OR denied) and .shouldRequest before that. So "granted"
+    // here means "the user has answered the prompt", which is enough to enable the
+    // "Add" button. If they denied, reads simply return 0 (iOS exposes no way to
+    // detect a read denial or re-prompt; the user re-enables in Settings › Health).
 
-    private var authorizationRequested = false
-
-    /// Requests HealthKit authorization once, lazily, the first time health data is
-    /// read. No-op if health data is unavailable or a request has already been made
-    /// this session. Non-blocking.
-    private func ensureAuthorizationRequested() {
-        guard HKHealthStore.isHealthDataAvailable(), !authorizationRequested else { return }
-        authorizationRequested = true
-        store.getRequestStatusForAuthorization(toShare: [], read: readTypes) { [weak self] status, error in
-            guard let self, error == nil, status == .shouldRequest else { return }
-            DispatchQueue.main.async {
-                self.store.requestAuthorization(toShare: nil, read: self.readTypes) { _, _ in
-                    // Sheet dismissed (granted or denied): reload so the web layer
-                    // re-reads health data now that authorization is determined.
-                    DispatchQueue.main.async {
-                        NotificationCenter.default.post(name: .dayGlanceReloadWebView, object: nil)
-                    }
+    /// Presents the HealthKit authorization sheet (user-initiated, from the Authorize
+    /// button). Non-blocking. Posts .dayGlanceReloadWebView when the sheet is
+    /// dismissed so the web layer re-reads permission state and health data.
+    func requestAuthorization() {
+        guard HKHealthStore.isHealthDataAvailable() else { return }
+        DispatchQueue.main.async {
+            self.store.requestAuthorization(toShare: nil, read: self.readTypes) { _, _ in
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: .dayGlanceReloadWebView, object: nil)
                 }
             }
         }
+    }
+
+    /// "granted" once the user has responded to the authorization prompt (the only
+    /// signal HealthKit exposes for read types), "notDetermined" before that.
+    /// Synchronous: blocks on a semaphore while the status callback runs on its
+    /// background queue (bounded by a 3s timeout).
+    func permissionAsked() -> String {
+        guard HKHealthStore.isHealthDataAvailable() else { return "notDetermined" }
+        let semaphore = DispatchSemaphore(value: 0)
+        var result = "notDetermined"
+        store.getRequestStatusForAuthorization(toShare: [], read: readTypes) { status, _ in
+            if status == .unnecessary { result = "granted" }
+            semaphore.signal()
+        }
+        _ = semaphore.wait(timeout: .now() + 3)
+        return result
     }
 
     // MARK: - Steps
@@ -68,9 +74,6 @@ final class HealthBridge {
               let day = parseDate(date) else {
             return #"{"steps":0,"goal":10000}"#
         }
-
-        // Lazily request authorization on first actual read (see notes above).
-        ensureAuthorizationRequested()
 
         let calendar = Calendar.current
         let start = calendar.startOfDay(for: day)
@@ -107,9 +110,6 @@ final class HealthBridge {
               let day = parseDate(date) else {
             return #"{"durationMinutes":0,"stages":[]}"#
         }
-
-        // Lazily request authorization on first actual read (see notes above).
-        ensureAuthorizationRequested()
 
         let calendar    = Calendar.current
         let noon        = calendar.date(bySettingHour: 12, minute: 0, second: 0, of: day)!

--- a/dayglance-ios/DayGlance/ContentView.swift
+++ b/dayglance-ios/DayGlance/ContentView.swift
@@ -14,8 +14,8 @@ struct ContentView: View {
 
                 // HealthKit authorization is intentionally NOT requested here
                 // (guideline 5.1.1 — no unprompted HealthKit dialog in the launch
-                // cascade). It is requested lazily on first health-data read; see
-                // HealthBridge.ensureAuthorizationRequested().
+                // cascade). It is requested only when the user taps "Authorize" on a
+                // health-habit tile; see HealthBridge.requestAuthorization().
 
                 await withCheckedContinuation { continuation in
                     CalendarBridge.shared.requestAuthorization { continuation.resume() }

--- a/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
+++ b/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
@@ -49,6 +49,13 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
         switch method {
 
         // Phase 2 — HealthKit
+        case "requestHealthPermission":
+            HealthBridge.shared.requestAuthorization()
+            return "null"
+        case "checkStepsPermission", "checkSleepPermission":
+            // HealthKit exposes one combined status for the read set, so both map to
+            // the same "have we prompted yet" signal.
+            return HealthBridge.shared.permissionAsked()
         case "getSteps":
             guard let date = args.first as? String else { return #"{"steps":0,"goal":10000}"# }
             return HealthBridge.shared.getSteps(date: date)

--- a/src/components/HabitModal.jsx
+++ b/src/components/HabitModal.jsx
@@ -24,15 +24,6 @@ const HabitModal = () => {
     meUserSyncId, managedBy, hasUnownedHabits, claimUnownedHabits,
   } = useFeaturesCtx();
 
-  // iOS reads HealthKit with lazy authorization — the permission sheet is presented
-  // by the native HealthBridge on the first getSteps/getSleep read, so there is no
-  // explicit permission check/request like Android's Health Connect. The health-habit
-  // tiles below gate on this: on iOS the "Add" button is always enabled and the
-  // "Authorize" button is hidden. Without it the button stays permanently disabled,
-  // because the iOS bridge exposes no checkStepsPermission (healthPerms never turns
-  // true), which is what made the HealthKit feature unreachable on iOS.
-  const isIOS = typeof window !== 'undefined' && !!window.DayGlanceIOS;
-
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => { setShowHabitModal(false); setEditingHabit(null); }}>
       <div className={`${cardBg} rounded-xl shadow-2xl max-w-lg w-full mx-4 max-h-[85vh] overflow-hidden flex flex-col`} onClick={(e) => e.stopPropagation()}>
@@ -354,7 +345,7 @@ const HabitModal = () => {
                     <div className={`text-xs ${darkMode ? 'text-green-500' : 'text-green-600'} mt-0.5`}>{t('habit.trackStepsHint')}</div>
                   </div>
                   <div className="flex gap-1.5 flex-shrink-0">
-                    {!isIOS && !healthPerms?.steps && (
+                    {!healthPerms?.steps && (
                       <button
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-500 text-white hover:bg-green-600 active:bg-green-700 transition-colors"
@@ -363,9 +354,9 @@ const HabitModal = () => {
                       </button>
                     )}
                     <button
-                      onClick={(isIOS || healthPerms?.steps) ? addStepsHabit : undefined}
-                      disabled={!isIOS && !healthPerms?.steps}
-                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${(isIOS || healthPerms?.steps) ? 'bg-green-500 text-white hover:bg-green-600 active:bg-green-700' : 'bg-green-500/30 text-white/50 cursor-not-allowed'}`}
+                      onClick={healthPerms?.steps ? addStepsHabit : undefined}
+                      disabled={!healthPerms?.steps}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.steps ? 'bg-green-500 text-white hover:bg-green-600 active:bg-green-700' : 'bg-green-500/30 text-white/50 cursor-not-allowed'}`}
                     >
                       {t('common.add')}
                     </button>
@@ -382,7 +373,7 @@ const HabitModal = () => {
                     <div className={`text-xs ${darkMode ? 'text-indigo-500' : 'text-indigo-600'} mt-0.5`}>{t('habit.trackSleepHint')}</div>
                   </div>
                   <div className="flex gap-1.5 flex-shrink-0">
-                    {!isIOS && !healthPerms?.sleep && (
+                    {!healthPerms?.sleep && (
                       <button
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700 transition-colors"
@@ -391,9 +382,9 @@ const HabitModal = () => {
                       </button>
                     )}
                     <button
-                      onClick={(isIOS || healthPerms?.sleep) ? addSleepHabit : undefined}
-                      disabled={!isIOS && !healthPerms?.sleep}
-                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${(isIOS || healthPerms?.sleep) ? 'bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700' : 'bg-indigo-500/30 text-white/50 cursor-not-allowed'}`}
+                      onClick={healthPerms?.sleep ? addSleepHabit : undefined}
+                      disabled={!healthPerms?.sleep}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.sleep ? 'bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700' : 'bg-indigo-500/30 text-white/50 cursor-not-allowed'}`}
                     >
                       {t('common.add')}
                     </button>

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -2624,7 +2624,7 @@ const MobileSettingsPanel = () => {
                     <div className={`text-xs ${darkMode ? 'text-green-500' : 'text-green-600'} mt-0.5`}>Pulls from {isIOS ? 'Apple Health' : 'Health Connect'} — no manual tapping</div>
                   </div>
                   <div className="flex gap-1.5 flex-shrink-0">
-                    {!isIOS && !healthPerms?.steps && (
+                    {!healthPerms?.steps && (
                       <button
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-500 text-white hover:bg-green-600 active:bg-green-700 transition-colors"
@@ -2633,9 +2633,9 @@ const MobileSettingsPanel = () => {
                       </button>
                     )}
                     <button
-                      onClick={(isIOS || healthPerms?.steps) ? addStepsHabit : undefined}
-                      disabled={!isIOS && !healthPerms?.steps}
-                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${(isIOS || healthPerms?.steps) ? 'bg-green-500 text-white hover:bg-green-600 active:bg-green-700' : 'bg-green-500/30 text-white/50 cursor-not-allowed'}`}
+                      onClick={healthPerms?.steps ? addStepsHabit : undefined}
+                      disabled={!healthPerms?.steps}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.steps ? 'bg-green-500 text-white hover:bg-green-600 active:bg-green-700' : 'bg-green-500/30 text-white/50 cursor-not-allowed'}`}
                     >
                       Add
                     </button>
@@ -2650,7 +2650,7 @@ const MobileSettingsPanel = () => {
                     <div className={`text-xs ${darkMode ? 'text-indigo-500' : 'text-indigo-600'} mt-0.5`}>Pulls from {isIOS ? 'Apple Health' : 'Health Connect'} — no manual tapping</div>
                   </div>
                   <div className="flex gap-1.5 flex-shrink-0">
-                    {!isIOS && !healthPerms?.sleep && (
+                    {!healthPerms?.sleep && (
                       <button
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700 transition-colors"
@@ -2659,9 +2659,9 @@ const MobileSettingsPanel = () => {
                       </button>
                     )}
                     <button
-                      onClick={(isIOS || healthPerms?.sleep) ? addSleepHabit : undefined}
-                      disabled={!isIOS && !healthPerms?.sleep}
-                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${(isIOS || healthPerms?.sleep) ? 'bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700' : 'bg-indigo-500/30 text-white/50 cursor-not-allowed'}`}
+                      onClick={healthPerms?.sleep ? addSleepHabit : undefined}
+                      disabled={!healthPerms?.sleep}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors ${healthPerms?.sleep ? 'bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700' : 'bg-indigo-500/30 text-white/50 cursor-not-allowed'}`}
                     >
                       Add
                     </button>

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -277,12 +277,12 @@ const useHabits = ({ playUISound, hrOwnerRef }) => {
   const [healthPerms, setHealthPerms] = useState({ steps: null, sleep: null });
 
   const refreshHealthPerms = () => {
-    // iOS has no synchronous permission check — HealthKit authorization is lazy
-    // (the native bridge presents the sheet on the first getSteps/getSleep read).
-    // Leave healthPerms null on iOS so the sync below never skips a read (a skip
-    // would suppress the lazy prompt); getSteps/getSleep return 0 when access is
-    // denied. Android (Health Connect) reports real permission state.
-    if (!window.DayGlanceNative || window.DayGlanceIOS) return;
+    // checkStepsPermission/checkSleepPermission report whether the user has answered
+    // the health-permission prompt ('granted' once answered). On iOS this reflects
+    // "has the HealthKit sheet been responded to" — HealthKit can't reveal read-grant
+    // status, only that it was asked, which is enough to gate the "Add" button behind
+    // an explicit "Authorize" tap. Android (Health Connect) reports real grant state.
+    if (!window.DayGlanceNative) return;
     try {
       const steps = window.DayGlanceNative.checkStepsPermission() === 'granted';
       const sleep = window.DayGlanceNative.checkSleepPermission() === 'granted';


### PR DESCRIPTION
## Summary

Replaces the lazy-auth approach from #1211 with the explicit two-button flow (Authorize → then Add). The habit UI *always* had that model — it just called `checkStepsPermission()` / `requestHealthPermission()`, which the iOS bridge never implemented (they hit `default: return "null"`). So the real fix is to implement those methods, not work around them.

Why explicit beats lazy: the lazy path presented the HealthKit sheet from *inside* `getSteps`, which holds the main thread on a semaphore — a fragile place to pop a modal, and it didn't reliably prompt on device. An **Authorize** tap calls `requestAuthorization` from a clean, user-initiated context, and it shows App Review the HealthKit prompt exactly when they tap it.

## Changes

**Native**
- `HealthBridge.swift` — removed the lazy `ensureAuthorizationRequested()` (and its calls in `getSteps`/`getSleep`); added:
  - `requestAuthorization()` — presents the sheet on the Authorize tap, then posts the existing `.dayGlanceReloadWebView` so the web layer re-reads permission + counts.
  - `permissionAsked()` — the UI gate. HealthKit hides read-grant status, so this reports whether the user has *answered* the prompt (`.unnecessary` → `"granted"`), which is enough to enable **Add**. A denial just reads 0 (iOS gives no way to detect read-denial or re-prompt; user re-enables in Settings › Health).
- `BridgeSchemeHandler.swift` — route `requestHealthPermission`, `checkStepsPermission`, `checkSleepPermission` to those methods.
- `ContentView.swift` — comment updated (auth still not requested at launch).

**Web (revert #1211's iOS workaround)**
- `HabitModal.jsx`, `MobileSettingsPanel.jsx` — restore the original `healthPerms`-driven gating (Authorize shown until answered, Add disabled until then); kept the `'healthKit'` tile dedupe and the "Apple Health" copy.
- `useHabits.js` — `refreshHealthPerms` runs on iOS again (the native methods now return real values).

## Flow

Add habit → tile shows **Authorize** (Add disabled) → tap Authorize → HealthKit sheet → grant → app reloads → **Add** enables → tap Add → habit reads Health. No launch prompt (5.1.1); the sheet appears on the Authorize tap.

On a device that already answered the prompt (e.g. from the old launch-time build), `permissionAsked()` returns `"granted"`, so **Add** is enabled immediately and reads data — no re-prompt (correct).

## Verification

- `eslint` + `vite build` pass; health util tests green (17). No dangling refs to the removed native symbols.
- **Needs on-device iOS testing** (Swift can't be built here). To see the Authorize → prompt flow on a device that already granted, reset first: Settings › Privacy & Security › Health › dayGLANCE › turn all off, then reinstall.

## Known minor UX

Granting reloads the web view (the established calendar-permission pattern), which closes the add-habit modal; the user reopens it and taps the now-enabled **Add**. Can be smoothed later with a non-reload perms refresh if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPAc9TWHSPYYBZNfikqRLX)_