### PR TITLE
Suppress AI on the China storefront on iOS too

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/StorefrontBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/StorefrontBridge.swift
@@ -11,9 +11,16 @@ import StoreKit
 /// this IS the App Store app, so the storefront resolves directly and reliably.
 enum StorefrontBridge {
 
-    /// The storefront country as an ISO 3166-1 alpha-3 code (e.g. "CHN"), or "" when
-    /// StoreKit has not resolved a storefront yet.
+    /// The storefront country (ISO alpha-3, e.g. "CHN"), or — if StoreKit hasn't
+    /// resolved a storefront yet (it can be nil momentarily at cold launch) — the
+    /// device region as a fallback (ISO alpha-2, e.g. "CN"). "" only if neither is
+    /// available. The web layer checks both "CN" and "CHN", so either form gates
+    /// correctly. This mirrors the macOS build's StoreKit-then-region approach and
+    /// ensures a timing gap can never silently leave AI active on the CN storefront.
     static func countryCode() -> String {
-        SKPaymentQueue.default().storefront?.countryCode ?? ""
+        if let code = SKPaymentQueue.default().storefront?.countryCode, !code.isEmpty {
+            return code
+        }
+        return Locale.current.region?.identifier ?? ""
     }
 }

--- a/dayglance-ios/DayGlance/Bridges/StorefrontBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/StorefrontBridge.swift
@@ -1,0 +1,19 @@
+import StoreKit
+
+/// Reports the App Store storefront country so the web layer can gate features that
+/// are legally restricted on some storefronts — specifically suppressing generative-
+/// AI on the China (CN) storefront per App Store Review Guideline 5 (Deep Synthesis /
+/// MIIT).
+///
+/// Uses StoreKit's synchronous `SKPaymentQueue.storefront` (iOS 13+), which fits the
+/// synchronous DayGlanceNative bridge. Unlike the macOS Electron build — which can
+/// only read the OS region because a spawned helper isn't the App Store process —
+/// this IS the App Store app, so the storefront resolves directly and reliably.
+enum StorefrontBridge {
+
+    /// The storefront country as an ISO 3166-1 alpha-3 code (e.g. "CHN"), or "" when
+    /// StoreKit has not resolved a storefront yet.
+    static func countryCode() -> String {
+        SKPaymentQueue.default().storefront?.countryCode ?? ""
+    }
+}

--- a/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
+++ b/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
@@ -63,6 +63,11 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
             guard let date = args.first as? String else { return #"{"durationMinutes":0,"stages":[]}"# }
             return HealthBridge.shared.getSleep(date: date)
 
+        // App Store storefront (region) — used to gate region-restricted features,
+        // e.g. suppressing generative-AI on the China storefront (Guideline 5 / MIIT).
+        case "getStorefrontCountry":
+            return StorefrontBridge.countryCode()
+
         // Phase 3 — EventKit
         case "getCalendarAuthStatus":
             return CalendarBridge.shared.getAuthStatus()

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1034,25 +1034,31 @@ const DayPlanner = () => {
     weeklyAIError, setWeeklyAIError,
   } = useVoiceAI();
 
-  // Regional AI suppression: the Mac App Store build must deactivate its
-  // generative-AI features on the China (CN) storefront to comply with App Store
-  // Review Guideline 5 (Deep Synthesis / MIIT licensing). We ask the main process
-  // for the region (OS locale country — see electron/storefront.ts for why the
-  // true StoreKit storefront isn't readable here) and, when it resolves to China,
-  // force the AI config off and hide the AI settings section. Non-macOS platforms
-  // expose no such API, so this stays false there (no change).
+  // Regional AI suppression: on the China (CN) App Store storefront the app must
+  // deactivate its generative-AI features to comply with App Store Review Guideline 5
+  // (Deep Synthesis / MIIT licensing). When the storefront is China we force the AI
+  // config off and hide the AI settings section. Signal by platform:
+  //   - macOS (Electron): async over IPC — StoreKit storefront with an OS-region
+  //     fallback (see electron/storefront.ts).
+  //   - iOS: synchronous StoreKit storefront via the native bridge — the app is the
+  //     App Store client, so the storefront resolves directly (no helper needed).
+  //   - Android / web: no App Store storefront, so suppression stays off.
   const [aiSuppressed, setAiSuppressed] = useState(false);
   useEffect(() => {
-    const api = typeof window !== 'undefined' ? window.electronAPI : null;
-    if (!api?.getStorefrontCountry) return;
     let cancelled = false;
-    api.getStorefrontCountry()
-      .then((res) => {
-        if (cancelled) return;
-        const c = (res?.country || '').toUpperCase();
-        if (c === 'CN' || c === 'CHN') setAiSuppressed(true);
-      })
-      .catch(() => {});
+    const isChina = (country) => {
+      const c = (country || '').toUpperCase();
+      return c === 'CN' || c === 'CHN';
+    };
+    const electron = typeof window !== 'undefined' ? window.electronAPI : null;
+    if (electron?.getStorefrontCountry) {
+      electron.getStorefrontCountry()
+        .then((res) => { if (!cancelled && isChina(res?.country)) setAiSuppressed(true); })
+        .catch(() => {});
+    } else if (typeof window !== 'undefined' && window.DayGlanceIOS && window.DayGlanceNative?.getStorefrontCountry) {
+      // Synchronous native bridge call — returns the alpha-3 storefront code.
+      try { if (isChina(window.DayGlanceNative.getStorefrontCountry())) setAiSuppressed(true); } catch {}
+    }
     return () => { cancelled = true; };
   }, []);
 


### PR DESCRIPTION
## Summary

The China AI-suppression (Guideline 5 / MIIT) from the earlier work shipped **macOS-only**. The gate reads `window.electronAPI.getStorefrontCountry()`, which doesn't exist on iOS, so `aiSuppressed` stayed `false` and the generative-AI feature was **fully active on the iOS China storefront**. Apple flagged this on macOS but not (yet) iOS — a latent 5.0 exposure. This closes it on iOS.

Bonus: it's *more* reliable on iOS than macOS. The Mac build can only read the OS region (a spawned helper isn't the App Store process), but iOS *is* the App Store client, so StoreKit returns the true storefront.

## Changes

- **`StorefrontBridge.swift`** (new) — `SKPaymentQueue.storefront.countryCode`, synchronous (iOS 13+; target is 16). Returns the ISO alpha-3 storefront code (e.g. `"CHN"`) or `""`.
- **`BridgeSchemeHandler.swift`** — routes `getStorefrontCountry` to it.
- **`src/App.jsx`** — the `aiSuppressed` effect now reads the Electron IPC (macOS) **or** the iOS native bridge; China on either forces the effective AI config `enabled: false` and hides the AI settings. The consuming wiring (effective config at `App.jsx:1070`, `MobileSettingsPanel` hide at 298/1153) already exists from the earlier China PR — this just supplies the iOS signal.

Android and web have no App Store storefront, so they're untouched (`window.electronAPI` and `window.DayGlanceIOS` both absent → gate no-ops).

XcodeGen globs the `DayGlance` directory, so the new Swift file is picked up on project regen — no `project.yml` change.

## Verification

- `eslint` + `vite build` pass.
- **Needs on-device iOS testing** (Swift can't be built here): on a China-storefront account, confirm the AI settings section is hidden and AI calls are off; on a non-China account, confirm AI is present as normal. StoreKit storefront reflects the signed-in App Store account's region.

## Why this matters now

You're resubmitting iOS anyway, and this makes the China attestation *true* on iOS — so you can safely add the China line to the iOS review notes (previously it would have been a false claim). Also double-check the **iOS** China listing metadata has OpenAI/ChatGPT references scrubbed, same as macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPAc9TWHSPYYBZNfikqRLX)_