### PR TITLE
Fix App Store rejection: paywall feature list + health permission button wording

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -150,7 +150,7 @@ class MainActivity : AppCompatActivity() {
     private val requestHealthPermissions = registerForActivityResult(
         PermissionController.createRequestPermissionResultContract()
     ) { _ ->
-        // Notify JS so the Authorize/Add buttons update immediately without
+        // Notify JS so the Continue/Add buttons update immediately without
         // depending on visibilitychange (which is unreliable when webView.onPause
         // is intentionally skipped).
         webView.evaluateJavascript(

--- a/dayglance-ios/DayGlance/Bridges/HealthBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/HealthBridge.swift
@@ -21,7 +21,7 @@ final class HealthBridge {
 
     // MARK: - Authorization (explicit)
     //
-    // Authorization is requested only when the user taps "Authorize" on a health-
+    // Authorization is requested only when the user taps "Continue" on a health-
     // habit tile — never at launch (guideline 5.1.1). requestAuthorization() presents
     // the sheet from a clean, user-initiated context (not from inside a semaphore-
     // blocked read, which is fragile), then posts .dayGlanceReloadWebView — the same
@@ -36,7 +36,7 @@ final class HealthBridge {
     // "Add" button. If they denied, reads simply return 0 (iOS exposes no way to
     // detect a read denial or re-prompt; the user re-enables in Settings › Health).
 
-    /// Presents the HealthKit authorization sheet (user-initiated, from the Authorize
+    /// Presents the HealthKit authorization sheet (user-initiated, from the Continue
     /// button). Non-blocking. Posts .dayGlanceReloadWebView when the sheet is
     /// dismissed so the web layer re-reads permission state and health data.
     func requestAuthorization() {

--- a/dayglance-ios/DayGlance/ContentView.swift
+++ b/dayglance-ios/DayGlance/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
 
                 // HealthKit authorization is intentionally NOT requested here
                 // (guideline 5.1.1 — no unprompted HealthKit dialog in the launch
-                // cascade). It is requested only when the user taps "Authorize" on a
+                // cascade). It is requested only when the user taps "Continue" on a
                 // health-habit tile; see HealthBridge.requestAuthorization().
 
                 await withCheckedContinuation { continuation in

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -83,7 +83,7 @@
     "disconnect": "Trennen",
     "disable": "Deaktivieren",
     "refresh": "Aktualisieren",
-    "authorize": "Autorisieren",
+    "continue": "Weiter",
     "settings": "Einstellungen",
     "back": "Zurück",
     "next": "Weiter",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -83,7 +83,7 @@
     "disconnect": "Disconnect",
     "disable": "Disable",
     "refresh": "Refresh",
-    "authorize": "Authorize",
+    "continue": "Continue",
     "settings": "Settings",
     "back": "Back",
     "next": "Next",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -83,7 +83,7 @@
     "disconnect": "Desconectar",
     "disable": "Desactivar",
     "refresh": "Actualizar",
-    "authorize": "Autorizar",
+    "continue": "Continuar",
     "settings": "Ajustes",
     "back": "Atrás",
     "next": "Siguiente",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -83,7 +83,7 @@
     "disconnect": "Déconnecter",
     "disable": "Désactiver",
     "refresh": "Actualiser",
-    "authorize": "Autoriser",
+    "continue": "Continuer",
     "settings": "Paramètres",
     "back": "Retour",
     "next": "Suivant",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -83,7 +83,7 @@
     "disconnect": "Disconnetti",
     "disable": "Disattiva",
     "refresh": "Aggiorna",
-    "authorize": "Autorizza",
+    "continue": "Continua",
     "settings": "Impostazioni",
     "back": "Indietro",
     "next": "Avanti",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -83,7 +83,7 @@
     "disconnect": "Desligar",
     "disable": "Desativar",
     "refresh": "Atualizar",
-    "authorize": "Autorizar",
+    "continue": "Continuar",
     "settings": "Definições",
     "back": "Voltar",
     "next": "Seguinte",

--- a/src/components/HabitModal.jsx
+++ b/src/components/HabitModal.jsx
@@ -350,7 +350,7 @@ const HabitModal = () => {
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-500 text-white hover:bg-green-600 active:bg-green-700 transition-colors"
                       >
-                        {t('common.authorize')}
+                        {t('common.continue')}
                       </button>
                     )}
                     <button
@@ -378,7 +378,7 @@ const HabitModal = () => {
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700 transition-colors"
                       >
-                        {t('common.authorize')}
+                        {t('common.continue')}
                       </button>
                     )}
                     <button

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -130,7 +130,7 @@ const MobileSettingsPanel = () => {
   const multiUserLocked = multiUserToggleLocked({ cloudSyncConfigured, multiUserEnabled });
   // iOS uses HealthKit lazy authorization (permission requested on first read), so
   // it has no explicit permission check/request. On iOS the health-habit "Add"
-  // button is always enabled and the dead "Authorize" button is hidden — see the
+  // button is always enabled and the dead "Continue" button is hidden — see the
   // matching note in HabitModal.jsx and refreshHealthPerms in useHabits.js.
   const isIOS = typeof window !== 'undefined' && !!window.DayGlanceIOS;
 
@@ -2629,7 +2629,7 @@ const MobileSettingsPanel = () => {
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-500 text-white hover:bg-green-600 active:bg-green-700 transition-colors"
                       >
-                        Authorize
+                        Continue
                       </button>
                     )}
                     <button
@@ -2655,7 +2655,7 @@ const MobileSettingsPanel = () => {
                         onClick={() => { try { window.DayGlanceNative.requestHealthPermission(); } catch (e) {} }}
                         className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-500 text-white hover:bg-indigo-600 active:bg-indigo-700 transition-colors"
                       >
-                        Authorize
+                        Continue
                       </button>
                     )}
                     <button

--- a/src/components/SubscriptionWall.jsx
+++ b/src/components/SubscriptionWall.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Wordmark from './Wordmark';
-import { Loader } from 'lucide-react';
+import { Check, Loader } from 'lucide-react';
 
 /**
  * Full-screen paywall shown on Android, iOS, and macOS when the user has no active subscription.
@@ -94,7 +94,11 @@ export default function SubscriptionWall({
   }
 
   return (
-    <div className={`fixed inset-0 z-[9999] flex flex-col items-center justify-center px-6 ${bg}`}>
+    // Outer layer scrolls; the inner min-h-full wrapper keeps the content
+    // vertically centered on tall screens without clipping the top of the
+    // page on short ones (the classic justify-center + overflow pitfall).
+    <div className={`fixed inset-0 z-[9999] overflow-y-auto ${bg}`}>
+    <div className="min-h-full flex flex-col items-center justify-center px-6 py-8">
 
       {/* Logo */}
       <div className="mb-6 flex flex-col items-center gap-2">
@@ -114,6 +118,31 @@ export default function SubscriptionWall({
               : 'Free to start, nothing charged today. Cancel anytime, keep your data.')
           : 'Pick a plan to pick up where you left off. Your data is safe and waiting.'}
       </p>
+
+      {/* What the purchase includes — guideline 3.1.2(c) requires the paywall to
+          clearly describe what the user receives for the price. Both plans unlock
+          the identical feature set, so one list covers both. Keep bullets limited
+          to features that ship on every paywalled platform (iOS, Android, macOS). */}
+      <div className="w-full max-w-xs mb-6">
+        <p className={`text-xs font-semibold uppercase tracking-wide mb-2 ${sub}`}>
+          Every plan unlocks the full app
+        </p>
+        <ul className="space-y-1.5">
+          {[
+            'Visual day planner with time blocking',
+            'Tasks, projects, routines & goals',
+            'Sync with your device calendar',
+            'Habit tracking with streaks & stats',
+            'Reminders and notifications',
+            'Cross-device sync via your own cloud',
+          ].map(feature => (
+            <li key={feature} className="flex items-start gap-2">
+              <Check size={14} className="text-green-500 flex-shrink-0 mt-0.5" />
+              <span className={`text-xs leading-snug ${text}`}>{feature}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
 
       {/* Error message */}
       {errorMsg && (
@@ -242,6 +271,7 @@ export default function SubscriptionWall({
         </div>
       )}
 
+    </div>
     </div>
   );
 }

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -281,7 +281,7 @@ const useHabits = ({ playUISound, hrOwnerRef }) => {
     // the health-permission prompt ('granted' once answered). On iOS this reflects
     // "has the HealthKit sheet been responded to" — HealthKit can't reveal read-grant
     // status, only that it was asked, which is enough to gate the "Add" button behind
-    // an explicit "Authorize" tap. Android (Health Connect) reports real grant state.
+    // an explicit "Continue" tap. Android (Health Connect) reports real grant state.
     if (!window.DayGlanceNative) return;
     try {
       const steps = window.DayGlanceNative.checkStepsPermission() === 'granted';


### PR DESCRIPTION
Addresses both issues from the July 18 App Store review (submission `4f715b82-b195-4fc7-a9d4-027fb6c88804`, version 4.0).

## Guideline 3.1.2(c) — subscription doesn't describe what the user receives

The paywall showed plan names, prices, trial terms, and the renewal disclosure, but never said what the purchase actually includes. `SubscriptionWall` now renders an "Every plan unlocks the full app" checklist above the plan cards:

- Visual day planner with time blocking
- Tasks, projects, routines & goals
- Sync with your device calendar
- Habit tracking with streaks & stats
- Reminders and notifications
- Cross-device sync via your own cloud

Bullets are limited to features that ship on every paywalled platform (iOS, Android, macOS), since all three share this component. Because the wall got taller, the layout was also made scroll-safe: the outer layer is now `overflow-y-auto` with a `min-h-full` centered inner wrapper, so short screens scroll instead of clipping the top.

> Note: the same review point may also apply to the subscription description in App Store Connect — worth double-checking that the `com.dayglance.pro.yearly` product description there lists what Pro includes. That part can't be fixed in code.

## Guideline 5.1.1(iv) — "Authorise" button before the HealthKit prompt

The health-habit tiles ("Track steps/sleep automatically") showed an **Authorize** button ahead of the HealthKit permission sheet. Apple requires neutral wording like "Continue" or "Next" on pre-permission buttons.

- Renamed the button to **Continue** in `MobileSettingsPanel` (hardcoded strings) and `HabitModal` (via i18n).
- Replaced the now-unused `common.authorize` locale key with `common.continue` in all six languages (en/de/es/fr/it/pt), using each language's standard "Continue" wording.
- Updated stale code comments referencing the old label (iOS `ContentView`/`HealthBridge`, Android `MainActivity`, `useHabits`, `MobileSettingsPanel`).

The tile's explanatory text itself is unchanged — informational pre-permission context is explicitly allowed; only the button word was the violation.

## Verification

- All 794 tests pass (53 files)
- `npm run build` succeeds
- All six locale JSON files validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1hrn1KykgWYDwdLhC14B8

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1hrn1KykgWYDwdLhC14B8)_