### PR TITLE
Bump Android versionCode to 176

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 175
+        versionCode = 176
         versionName = "4.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Bumps the Android `versionCode` from 175 to 176 for the next Play Store upload. No other changes — `versionName` stays 4.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1hrn1KykgWYDwdLhC14B8

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1hrn1KykgWYDwdLhC14B8)_