### PR TITLE
Add continuous folder backup with welcome-modal restore

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -504,7 +504,8 @@
     "mobileSettingsToggles": "Quick toggles for common settings",
     "mobileSettingsSync": "Sync your calendars",
     "mobileSettingsCloud": "Set up cloud sync between devices",
-    "mobileSettingsBackup": "Backup and restore your data"
+    "mobileSettingsBackup": "Backup and restore your data",
+    "restoreFromBackup": "Restore from a backup"
   },
   "gettingStarted": {
     "title": "Getting Started",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -504,7 +504,8 @@
     "mobileSettingsToggles": "Boutons de réglage rapide",
     "mobileSettingsSync": "Synchronisez vos calendriers",
     "mobileSettingsCloud": "Configurez la synchro cloud entre appareils",
-    "mobileSettingsBackup": "Sauvegardez et restaurez vos données"
+    "mobileSettingsBackup": "Sauvegardez et restaurez vos données",
+    "restoreFromBackup": "Restaurer depuis une sauvegarde"
   },
   "gettingStarted": {
     "title": "Premiers pas",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,8 @@ import { detectObsidianDeletions, addObsidianTombstones } from './utils/obsidian
 import { stripHealthSourcedLogs } from './utils/healthLogFilter.js';
 import { webdavFetch } from './utils/cloudSyncProviders.js';
 import { autoBackupDB, createAutoBackupProvidersForFolder, AUTO_BACKUP_RETENTION, AUTO_BACKUP_INTERVALS } from './utils/autoBackup.js';
+import { LIVE_BACKUP_FILENAME } from './utils/folderBackup.js';
+import useFolderBackup from './hooks/useFolderBackup.js';
 import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOnlyTask, getLinkUrl, hasOnlySubtasks, renderTitle, highlightMatch, renderTitleWithoutTags, extractShareTitle } from './utils/textFormatting.jsx';
 import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate, computeTaskCalendarTombstones, computeRecurringSeriesTombstones } from './utils/taskUtils.js';
 import { TASK_COLORS, TAILWIND_TO_HEX, taskColorToHex } from './utils/colorUtils.js';
@@ -655,16 +657,26 @@ const DayPlanner = () => {
   // Populated when the vault connects (native or FSA) and used by task-title inputs.
   const [wikilinkCandidates, setWikilinkCandidates] = useState([]);
 
-  // Auto-Backup state
+  // Auto-Backup state. Saved configs predating a section (e.g. `folder`) get
+  // that section's defaults merged in so downstream code can assume the shape.
   const [autoBackupConfig, setAutoBackupConfig] = useState(() => {
+    const defaults = {
+      local: { enabled: false, frequency: 'daily' },
+      remote: { enabled: false, frequency: 'daily', provider: 'nextcloud' },
+      folder: { enabled: false, snapshotFrequency: 'daily' },
+    };
     try {
       const saved = localStorage.getItem('day-planner-auto-backup-config');
-      if (saved) return JSON.parse(saved);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        return {
+          local: { ...defaults.local, ...parsed.local },
+          remote: { ...defaults.remote, ...parsed.remote },
+          folder: { ...defaults.folder, ...parsed.folder },
+        };
+      }
     } catch {}
-    return {
-      local: { enabled: false, frequency: 'daily' },
-      remote: { enabled: false, frequency: 'daily', provider: 'nextcloud' }
-    };
+    return defaults;
   });
   const [autoBackupStatus, setAutoBackupStatus] = useState(() => ({
     local: { lastBackup: localStorage.getItem('day-planner-auto-backup-local-last') || null, status: 'idle' },
@@ -1444,8 +1456,17 @@ const DayPlanner = () => {
     setUndoToast,
   });
 
+  // Set below once useFolderBackup is instantiated (it needs
+  // buildAutoBackupPayload, which is declared further down). Effects only run
+  // after the full render pass, so the ref is populated before first use.
+  const folderBackupWriteRef = useRef(null);
+
   useSaveOnChange({
-    saveData, checkConflicts,
+    // Piggyback the folder-backup write-through on the same debounce-free save
+    // pass that persists to localStorage: after saveData() the storage is
+    // fresh, which is exactly what buildAutoBackupPayload reads.
+    saveData: () => { saveData(); folderBackupWriteRef.current?.(); },
+    checkConflicts,
     dataLoaded,
     suppressClearPendingRef, suppressCloudUploadRef, suppressTimestampRef,
     tasks, unscheduledTasks, recycleBin, taskCalendarUrl, syncUrl, syncRetentionDays,
@@ -5087,6 +5108,7 @@ const DayPlanner = () => {
         projects: JSON.parse(localStorage.getItem('day-planner-projects') || '[]'),
         areas: JSON.parse(localStorage.getItem('day-planner-areas') || '[]'),
         goalsProjectsEnabled: JSON.parse(localStorage.getItem('day-planner-goals-projects-enabled') || 'false'),
+        autoBackupConfig: JSON.parse(localStorage.getItem('day-planner-auto-backup-config') || 'null'),
       }
     };
 
@@ -5137,8 +5159,25 @@ const DayPlanner = () => {
       projects: JSON.parse(localStorage.getItem('day-planner-projects') || '[]'),
       areas: JSON.parse(localStorage.getItem('day-planner-areas') || '[]'),
       goalsProjectsEnabled: JSON.parse(localStorage.getItem('day-planner-goals-projects-enabled') || 'false'),
+      autoBackupConfig: JSON.parse(localStorage.getItem('day-planner-auto-backup-config') || 'null'),
     }
   });
+
+  // Continuous write-through backup to a local folder (File System Access API).
+  // Feeds off the same payload as the other auto-backup flavors; scheduleWrite
+  // is invoked after every saveData() pass via folderBackupWriteRef.
+  const folderBackup = useFolderBackup({
+    enabled: autoBackupConfig.folder?.enabled ?? false,
+    snapshotFrequency: autoBackupConfig.folder?.snapshotFrequency || 'daily',
+    dataLoaded,
+    disabled: isTrayMode,
+    buildPayload: buildAutoBackupPayload,
+    onNeedsReconnect: () => setUndoToast({
+      message: 'Folder backup paused — reconnect it in Backup → Auto-Backup to resume.',
+      actionable: false,
+    }),
+  });
+  folderBackupWriteRef.current = folderBackup.scheduleWrite;
 
   const performLocalBackup = async (frequency) => {
     try {
@@ -5272,9 +5311,52 @@ const DayPlanner = () => {
     e.target.value = '';
   };
 
-  // Restore data from backup file
-  const restoreBackup = () => {
-    if (!pendingBackupFile) return;
+  // Write a backup payload's data section back into localStorage. Shared by
+  // the file-based restore (restoreBackup) and the folder-based restore
+  // (restoreFromBackupFolder); callers handle cursor reset + reload.
+  const applyBackupToLocalStorage = (data) => {
+    if (data.tasks) localStorage.setItem('day-planner-tasks', JSON.stringify(data.tasks));
+    if (data.unscheduledTasks) localStorage.setItem('day-planner-unscheduled', JSON.stringify(data.unscheduledTasks));
+    if (data.recycleBin) localStorage.setItem('day-planner-recycle-bin', JSON.stringify(data.recycleBin));
+    if (data.darkMode !== undefined) localStorage.setItem('day-planner-darkmode', JSON.stringify(data.darkMode));
+    if (data.syncUrl !== undefined) localStorage.setItem('day-planner-sync-url', data.syncUrl);
+    if (data.taskCalendarUrl !== undefined) localStorage.setItem('day-planner-task-calendar-url', data.taskCalendarUrl);
+    if (data.taskCalendarAuth) localStorage.setItem('day-planner-task-calendar-auth', JSON.stringify(data.taskCalendarAuth));
+    if (data.completedTaskUids) localStorage.setItem('day-planner-task-completed-uids', JSON.stringify(data.completedTaskUids));
+    if (data.recurringTasks) localStorage.setItem('day-planner-recurring-tasks', JSON.stringify(data.recurringTasks));
+    if (data.routineDefinitions) localStorage.setItem('day-planner-routine-definitions', JSON.stringify(data.routineDefinitions));
+    if (data.selectedTags) localStorage.setItem('day-planner-selected-tags', JSON.stringify(data.selectedTags));
+    if (data.minimizedSections) localStorage.setItem('minimizedSections', JSON.stringify(data.minimizedSections));
+    if (data.cloudSyncConfig) localStorage.setItem('day-planner-cloud-sync-config', JSON.stringify(data.cloudSyncConfig));
+    if (data.reminderSettings) localStorage.setItem('day-planner-reminder-settings', JSON.stringify(data.reminderSettings));
+    if (data.use24HourClock !== undefined) localStorage.setItem('day-planner-use-24h-clock', JSON.stringify(data.use24HourClock));
+    if (data.weatherZip !== undefined) localStorage.setItem('day-planner-weather-zip', data.weatherZip);
+    if (data.weatherTempUnit !== undefined) localStorage.setItem('day-planner-weather-temp-unit', data.weatherTempUnit);
+    if (data.habits) localStorage.setItem('day-planner-habits', JSON.stringify(data.habits));
+    if (data.habitLogs) localStorage.setItem('day-planner-habit-logs', JSON.stringify(data.habitLogs));
+    // If backup has habits data, always enable habits regardless of the backed-up toggle value
+    // (the toggle may have been incorrectly saved as false by an earlier bug)
+    const habitsEnabledVal = (data.habits && data.habits.filter(h => !h.archived).length > 0) ? true : (data.habitsEnabled ?? false);
+    localStorage.setItem('day-planner-habits-enabled', JSON.stringify(habitsEnabledVal));
+    // Same for routines
+    const hasRoutineDefs = data.routineDefinitions && Object.values(data.routineDefinitions).some(arr => arr.length > 0);
+    const routinesEnabledVal = hasRoutineDefs ? true : (data.routinesEnabled ?? false);
+    localStorage.setItem('day-planner-routines-enabled', JSON.stringify(routinesEnabledVal));
+    if (data.aiConfig) localStorage.setItem('day-planner-ai-config', JSON.stringify(data.aiConfig));
+    if (data.obsidianConfig) localStorage.setItem('day-planner-obsidian-config', JSON.stringify(data.obsidianConfig));
+    if (data.calendarFilter) localStorage.setItem('day-planner-calendar-filter', JSON.stringify(data.calendarFilter));
+    if (data.goals) localStorage.setItem('day-planner-goals', JSON.stringify(data.goals));
+    if (data.projects) localStorage.setItem('day-planner-projects', JSON.stringify(data.projects));
+    if (data.areas) localStorage.setItem('day-planner-areas', JSON.stringify(data.areas));
+    if (data.goalsProjectsEnabled !== undefined) localStorage.setItem('day-planner-goals-projects-enabled', JSON.stringify(data.goalsProjectsEnabled));
+    if (data.autoBackupConfig) localStorage.setItem('day-planner-auto-backup-config', JSON.stringify(data.autoBackupConfig));
+  };
+
+  // Restore data from backup file. `file` defaults to the staged pendingBackupFile
+  // (the confirm-modal flow); the welcome-modal restore passes the picked file
+  // directly since the app is empty there and needs no confirmation step.
+  const restoreBackup = (file = pendingBackupFile) => {
+    if (!file) return;
 
     const reader = new FileReader();
     reader.onload = (e) => {
@@ -5286,42 +5368,7 @@ const DayPlanner = () => {
           throw new Error('Invalid backup file format');
         }
 
-        // Restore all data
-        const { data } = backup;
-        if (data.tasks) localStorage.setItem('day-planner-tasks', JSON.stringify(data.tasks));
-        if (data.unscheduledTasks) localStorage.setItem('day-planner-unscheduled', JSON.stringify(data.unscheduledTasks));
-        if (data.recycleBin) localStorage.setItem('day-planner-recycle-bin', JSON.stringify(data.recycleBin));
-        if (data.darkMode !== undefined) localStorage.setItem('day-planner-darkmode', JSON.stringify(data.darkMode));
-        if (data.syncUrl !== undefined) localStorage.setItem('day-planner-sync-url', data.syncUrl);
-        if (data.taskCalendarUrl !== undefined) localStorage.setItem('day-planner-task-calendar-url', data.taskCalendarUrl);
-        if (data.taskCalendarAuth) localStorage.setItem('day-planner-task-calendar-auth', JSON.stringify(data.taskCalendarAuth));
-        if (data.completedTaskUids) localStorage.setItem('day-planner-task-completed-uids', JSON.stringify(data.completedTaskUids));
-        if (data.recurringTasks) localStorage.setItem('day-planner-recurring-tasks', JSON.stringify(data.recurringTasks));
-        if (data.routineDefinitions) localStorage.setItem('day-planner-routine-definitions', JSON.stringify(data.routineDefinitions));
-        if (data.selectedTags) localStorage.setItem('day-planner-selected-tags', JSON.stringify(data.selectedTags));
-        if (data.minimizedSections) localStorage.setItem('minimizedSections', JSON.stringify(data.minimizedSections));
-        if (data.cloudSyncConfig) localStorage.setItem('day-planner-cloud-sync-config', JSON.stringify(data.cloudSyncConfig));
-        if (data.reminderSettings) localStorage.setItem('day-planner-reminder-settings', JSON.stringify(data.reminderSettings));
-        if (data.use24HourClock !== undefined) localStorage.setItem('day-planner-use-24h-clock', JSON.stringify(data.use24HourClock));
-        if (data.weatherZip !== undefined) localStorage.setItem('day-planner-weather-zip', data.weatherZip);
-        if (data.weatherTempUnit !== undefined) localStorage.setItem('day-planner-weather-temp-unit', data.weatherTempUnit);
-        if (data.habits) localStorage.setItem('day-planner-habits', JSON.stringify(data.habits));
-        if (data.habitLogs) localStorage.setItem('day-planner-habit-logs', JSON.stringify(data.habitLogs));
-        // If backup has habits data, always enable habits regardless of the backed-up toggle value
-        // (the toggle may have been incorrectly saved as false by an earlier bug)
-        const habitsEnabledVal = (data.habits && data.habits.filter(h => !h.archived).length > 0) ? true : (data.habitsEnabled ?? false);
-        localStorage.setItem('day-planner-habits-enabled', JSON.stringify(habitsEnabledVal));
-        // Same for routines
-        const hasRoutineDefs = data.routineDefinitions && Object.values(data.routineDefinitions).some(arr => arr.length > 0);
-        const routinesEnabledVal = hasRoutineDefs ? true : (data.routinesEnabled ?? false);
-        localStorage.setItem('day-planner-routines-enabled', JSON.stringify(routinesEnabledVal));
-        if (data.aiConfig) localStorage.setItem('day-planner-ai-config', JSON.stringify(data.aiConfig));
-        if (data.obsidianConfig) localStorage.setItem('day-planner-obsidian-config', JSON.stringify(data.obsidianConfig));
-        if (data.calendarFilter) localStorage.setItem('day-planner-calendar-filter', JSON.stringify(data.calendarFilter));
-        if (data.goals) localStorage.setItem('day-planner-goals', JSON.stringify(data.goals));
-        if (data.projects) localStorage.setItem('day-planner-projects', JSON.stringify(data.projects));
-        if (data.areas) localStorage.setItem('day-planner-areas', JSON.stringify(data.areas));
-        if (data.goalsProjectsEnabled !== undefined) localStorage.setItem('day-planner-goals-projects-enabled', JSON.stringify(data.goalsProjectsEnabled));
+        applyBackupToLocalStorage(backup.data);
 
         // Full-state replacement → invalidate the vault sync cursors (see
         // restoreFromAutoBackup for the stale-snapshot/stale-HWM hazard).
@@ -5345,7 +5392,37 @@ const DayPlanner = () => {
       setPendingBackupFile(null);
       setShowRestoreConfirm(false);
     };
-    reader.readAsText(pendingBackupFile);
+    reader.readAsText(file);
+  };
+
+  // Restore from the folder backup's live file. Reuses the stored folder handle
+  // when permission can be (re-)granted, otherwise opens the folder picker —
+  // one dialog restores AND reconnects write-through. Used by the welcome
+  // modal's "Restore from a backup" and the Auto-Backup manager.
+  const restoreFromBackupFolder = async () => {
+    try {
+      const { payload } = await folderBackup.openForRestore();
+      if (!payload?.data) {
+        alert(`No ${LIVE_BACKUP_FILENAME} backup was found in that folder.`);
+        return;
+      }
+      applyBackupToLocalStorage(payload.data);
+      // Re-arm folder backup after the reload regardless of what the backed-up
+      // config said — the user just restored from this folder, so keep writing
+      // to it. The handle is already persisted by openForRestore.
+      try {
+        const cfg = JSON.parse(localStorage.getItem('day-planner-auto-backup-config') || '{}');
+        cfg.folder = { snapshotFrequency: 'daily', ...cfg.folder, enabled: true };
+        localStorage.setItem('day-planner-auto-backup-config', JSON.stringify(cfg));
+      } catch { /* ignore */ }
+      // Full-state replacement → invalidate the vault sync cursors (see
+      // restoreFromAutoBackup for the stale-snapshot/stale-HWM hazard).
+      resetVaultSyncCursor();
+      window.location.reload();
+    } catch (err) {
+      if (err?.name === 'AbortError') return; // user cancelled the picker
+      alert('Failed to restore from backup folder: ' + err.message);
+    }
   };
 
   // Fetches an ICS/CalDAV URL, routing through the Vercel proxy on web or via
@@ -9154,6 +9231,7 @@ const DayPlanner = () => {
     buildAutoBackupPayload, loadAutoBackupHistory,
     deleteLocalAutoBackup, deleteRemoteAutoBackup,
     restoreFromAutoBackup, restoreFromRemoteBackup,
+    folderBackup, restoreFromBackupFolder,
     exportBackup, restoreBackup,
     handleFileUpload, handleBackupFileSelect, processImportFile,
     buildSyncPayload,

--- a/src/components/AutoBackupManagerModal.jsx
+++ b/src/components/AutoBackupManagerModal.jsx
@@ -15,6 +15,7 @@ const AutoBackupManagerModal = () => {
     loadAutoBackupHistory, performRemoteBackup,
     restoreFromAutoBackup, restoreFromRemoteBackup,
     deleteLocalAutoBackup, deleteRemoteAutoBackup,
+    folderBackup, restoreFromBackupFolder,
   } = useSyncCtx();
 
   const [localExpanded, setLocalExpanded] = useState(false);
@@ -78,6 +79,8 @@ const AutoBackupManagerModal = () => {
                   borderClass={borderClass}
                   hoverBg={hoverBg}
                   onRemoteBackupNow={performRemoteBackup}
+                  folderBackup={folderBackup}
+                  onFolderRestore={restoreFromBackupFolder}
                 />
               ) : (
                 <div className="space-y-6">

--- a/src/components/AutoBackupSettingsForm.jsx
+++ b/src/components/AutoBackupSettingsForm.jsx
@@ -1,22 +1,44 @@
 import React, { useState } from 'react';
-import { Save, Cloud } from 'lucide-react';
+import { Save, Cloud, FolderOpen } from 'lucide-react';
 import { autoBackupProviders } from '../utils/autoBackup.js';
 import { useTranslation } from 'react-i18next';
 
 // Auto-Backup Settings Form (extracted to avoid hooks-in-conditional issues)
-const AutoBackupSettingsForm = ({ config, setConfig, status, darkMode, textPrimary, textSecondary, borderClass, hoverBg, onRemoteBackupNow }) => {
+const AutoBackupSettingsForm = ({ config, setConfig, status, darkMode, textPrimary, textSecondary, borderClass, hoverBg, onRemoteBackupNow, folderBackup, onFolderRestore }) => {
   const { t } = useTranslation();
   const [testResult, setTestResult] = useState(null);
   const [testing, setTesting] = useState(false);
+  // Set when the picked folder already contains a backup with data: the user
+  // chooses between restoring it and replacing it with this device's data.
+  const [folderPrompt, setFolderPrompt] = useState(null); // { savedAt } | null
 
   const localConfig = config.local;
   const remoteConfig = config.remote;
+  const folderConfig = config.folder || { enabled: false, snapshotFrequency: 'daily' };
   const providerKey = remoteConfig.provider || 'nextcloud';
   const provider = autoBackupProviders[providerKey];
   const remoteFieldsFilled = provider.configFields.every(f => remoteConfig[f.key]);
 
   const updateLocal = (updates) => setConfig(prev => ({ ...prev, local: { ...prev.local, ...updates } }));
   const updateRemote = (updates) => setConfig(prev => ({ ...prev, remote: { ...prev.remote, ...updates } }));
+  const updateFolder = (updates) => setConfig(prev => ({ ...prev, folder: { ...prev.folder, ...updates } }));
+
+  const handleFolderConnect = async () => {
+    const res = await folderBackup.connect();
+    if (!res?.ok) return;
+    if (res.existing) {
+      setFolderPrompt({ savedAt: res.existing.timestamp || res.existing.exportedAt || null });
+    } else {
+      setFolderPrompt(null);
+      updateFolder({ enabled: true });
+    }
+  };
+
+  const handleFolderDisconnect = async () => {
+    setFolderPrompt(null);
+    await folderBackup.disconnect();
+    updateFolder({ enabled: false });
+  };
 
   const handleTest = async () => {
     setTesting(true);
@@ -69,6 +91,143 @@ const AutoBackupSettingsForm = ({ config, setConfig, status, darkMode, textPrima
           )}
         </div>
       </div>
+
+      {/* Folder Backup Settings — continuous write-through to a local folder.
+          Web/PWA only (File System Access API); the section is hidden where
+          unsupported (Firefox/Safari, Electron, native). */}
+      {folderBackup?.supported && (
+        <div>
+          <h4 className={`font-medium ${textPrimary} mb-3 flex items-center gap-2`}>
+            <FolderOpen size={16} />
+            Folder Backup
+          </h4>
+          <div className="space-y-3 ml-1">
+            <p className={`text-xs ${textSecondary}`}>
+              Continuously saves your data to a folder on this computer, so it survives
+              even if the browser clears site data when it closes. Keeps a live copy
+              plus periodic snapshots. Nothing leaves this machine.
+            </p>
+
+            {folderPrompt ? (
+              <div className={`p-3 rounded-lg border ${borderClass} ${darkMode ? 'bg-amber-900/20' : 'bg-amber-50'} space-y-2`}>
+                <p className={`text-sm ${textPrimary}`}>
+                  This folder already contains a dayGLANCE backup
+                  {folderPrompt.savedAt ? ` (saved ${new Date(folderPrompt.savedAt).toLocaleString()})` : ''}.
+                  Restore it, or replace it with this device&apos;s current data?
+                </p>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <button
+                    onClick={() => onFolderRestore()}
+                    className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                  >
+                    Restore backup
+                  </button>
+                  <button
+                    onClick={() => { folderBackup.armOverwrite(); updateFolder({ enabled: true }); setFolderPrompt(null); }}
+                    className={`px-3 py-1.5 text-sm rounded-lg ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} transition-colors`}
+                  >
+                    Replace with current data
+                  </button>
+                  <button
+                    onClick={handleFolderDisconnect}
+                    className={`px-3 py-1.5 text-sm rounded-lg ${textSecondary} ${hoverBg} transition-colors`}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : !folderConfig.enabled || !folderBackup.folderName ? (
+              <div className="space-y-2">
+                {folderConfig.enabled && !folderBackup.folderName && (
+                  <p className={`text-xs ${darkMode ? 'text-amber-400' : 'text-amber-700'}`}>
+                    Folder backup is enabled but the folder connection didn&apos;t survive —
+                    choose your backup folder to reconnect. If it already contains a
+                    backup, you&apos;ll be offered to restore it.
+                  </p>
+                )}
+                <button
+                  onClick={handleFolderConnect}
+                  className={`px-3 py-1.5 text-sm rounded-lg ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} transition-colors`}
+                >
+                  Choose folder…
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <p className={`text-sm ${textPrimary}`}>
+                  Backing up to <strong>{folderBackup.folderName}</strong>
+                </p>
+
+                {folderBackup.permission === 'prompt' && (
+                  <div className={`p-3 rounded-lg border ${borderClass} ${darkMode ? 'bg-amber-900/20' : 'bg-amber-50'}`}>
+                    <p className={`text-xs ${darkMode ? 'text-amber-300' : 'text-amber-800'} mb-2`}>
+                      The browser needs permission again before backups can resume.
+                    </p>
+                    <button
+                      onClick={() => folderBackup.reconnect()}
+                      className="px-3 py-1.5 text-sm bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors"
+                    >
+                      Reconnect
+                    </button>
+                  </div>
+                )}
+
+                {folderBackup.status === 'guarded' && (
+                  <div className={`p-3 rounded-lg border ${borderClass} ${darkMode ? 'bg-amber-900/20' : 'bg-amber-50'}`}>
+                    <p className={`text-xs ${darkMode ? 'text-amber-300' : 'text-amber-800'} mb-2`}>
+                      Backup paused: the folder&apos;s backup contains data but this app is
+                      currently empty, so it won&apos;t be overwritten. Restore the backup,
+                      or disconnect if you really want to start fresh.
+                    </p>
+                    <button
+                      onClick={() => onFolderRestore()}
+                      className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                    >
+                      Restore backup
+                    </button>
+                  </div>
+                )}
+
+                {folderBackup.status === 'error' && (
+                  <p className="text-xs text-red-500">
+                    The last backup write failed — check that the folder still exists and is writable.
+                  </p>
+                )}
+
+                <div>
+                  <label className={`block text-sm ${textSecondary} mb-1`}>Snapshot frequency</label>
+                  <select
+                    value={folderConfig.snapshotFrequency || 'daily'}
+                    onChange={(e) => updateFolder({ snapshotFrequency: e.target.value })}
+                    className={`px-3 py-1.5 border ${borderClass} rounded-lg ${darkMode ? 'bg-gray-700 text-white' : 'bg-white'}`}
+                  >
+                    <option value="hourly">{t('backup.hourly')}</option>
+                    <option value="daily">{t('backup.daily')}</option>
+                    <option value="weekly">{t('backup.weekly')}</option>
+                  </select>
+                  <p className={`text-xs ${textSecondary} mt-1`}>
+                    The live copy is updated within seconds of every change; snapshots are
+                    extra point-in-time files kept on this cadence.
+                  </p>
+                </div>
+
+                {folderBackup.lastWritten && (
+                  <p className={`text-xs ${textSecondary}`}>
+                    Last saved: {new Date(folderBackup.lastWritten).toLocaleString()}
+                  </p>
+                )}
+
+                <button
+                  onClick={handleFolderDisconnect}
+                  className={`px-3 py-1.5 text-sm rounded-lg ${textSecondary} ${hoverBg} transition-colors`}
+                >
+                  Disconnect
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Remote Backup Settings */}
       <div>

--- a/src/components/DesktopWelcomeModal.jsx
+++ b/src/components/DesktopWelcomeModal.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import Wordmark from './Wordmark';
 import {
   BarChart3, Calendar, CalendarDays, ChevronLeft, ChevronRight,
-  Cloud, Eye, FileText, Filter, Flag, Gauge, GripVertical, Inbox, LayoutGrid, Mic, Moon,
+  Cloud, Eye, FileText, Filter, Flag, FolderOpen, Gauge, GripVertical, Inbox, LayoutGrid, Mic, Moon,
   NotebookPen, Plus, RefreshCw, Search, Settings, Sun,
   Target, Zap,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useSyncCtx } from '../context/SyncContext.jsx';
 
 const DesktopWelcomeModal = () => {
   const { t } = useTranslation();
@@ -17,6 +18,11 @@ const DesktopWelcomeModal = () => {
     setShowSettings,
     darkMode, cardBg, borderClass, textPrimary, textSecondary,
   } = useDayPlannerCtx();
+  // The welcome modal shows exactly when the app has no data — which is also
+  // the state after a wiped browser profile. Offer restore right here: the
+  // folder flow (one dialog restores AND reconnects continuous folder backup)
+  // where the File System Access API exists, a plain backup-file picker elsewhere.
+  const { folderBackup, restoreFromBackupFolder, restoreBackup } = useSyncCtx();
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
@@ -44,6 +50,24 @@ const DesktopWelcomeModal = () => {
               <p className={`text-lg ${textPrimary}`}>{t('onboarding.welcomeTitle')}</p>
               <p className={`${textSecondary} text-xs mt-3`}>{t('onboarding.welcomeLocal')}</p>
               <p className={`${textSecondary} text-sm mt-4`}>{t('onboarding.welcomeTour')}</p>
+              {folderBackup?.supported ? (
+                <button
+                  onClick={() => restoreFromBackupFolder()}
+                  className={`mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} transition-colors`}
+                >
+                  <FolderOpen size={14} /> {t('onboarding.restoreFromBackup')}
+                </button>
+              ) : (
+                <label className={`mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg cursor-pointer ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} transition-colors`}>
+                  <FolderOpen size={14} /> {t('onboarding.restoreFromBackup')}
+                  <input
+                    type="file"
+                    accept=".json"
+                    className="hidden"
+                    onChange={(e) => { const f = e.target.files[0]; if (f) restoreBackup(f); e.target.value = ''; }}
+                  />
+                </label>
+              )}
               <div className={`mt-5 flex items-center justify-center gap-2 text-xs ${textSecondary}`}>
                 <a href="https://glance-apps.com/dayglance/privacy" target="_blank" rel="noopener noreferrer" className="underline hover:text-blue-500 transition-colors">{t('onboarding.privacyPolicy')}</a>
                 <span className="opacity-50">·</span>

--- a/src/components/MobileWelcomeModal.jsx
+++ b/src/components/MobileWelcomeModal.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import Wordmark from './Wordmark';
 import {
   BarChart3, Calendar, ChevronLeft, ChevronRight,
-  Cloud, Eye, Filter, Flag, Inbox, Mic, NotebookPen,
+  Cloud, Eye, Filter, Flag, FolderOpen, Inbox, Mic, NotebookPen,
   RefreshCw, Search, Settings, Target, Trash2, Zap,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useSyncCtx } from '../context/SyncContext.jsx';
 import { isFileSystemAccessSupported } from '../obsidian.js';
 import { isNativeApp } from '../native.js';
 
@@ -18,6 +19,10 @@ const MobileWelcomeModal = () => {
     setShowSettings,
     darkMode, textPrimary, textSecondary,
   } = useDayPlannerCtx();
+  // Restore entry point for returning users (the welcome modal shows exactly
+  // when the app has no data). Mobile browsers lack the File System Access
+  // API, so this is always the plain backup-file picker here.
+  const { restoreBackup } = useSyncCtx();
   // Obsidian needs the File System Access API (Chromium desktop) or a native
   // bridge; hide the onboarding mention where it can't actually be enabled.
   const obsidianAvailable = isFileSystemAccessSupported() || isNativeApp();
@@ -41,6 +46,15 @@ const MobileWelcomeModal = () => {
             <div className="mb-6"><Wordmark className="text-5xl" darkMode={darkMode} /></div>
             <p className={`text-lg ${textPrimary}`}>{t('onboarding.welcomeTitle')}</p>
             <p className={`${textSecondary} text-xs mt-4`}>{t('onboarding.welcomeLocal')}</p>
+            <label className={`mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg cursor-pointer ${darkMode ? 'bg-gray-700' : 'bg-stone-200'} ${textPrimary}`}>
+              <FolderOpen size={14} /> {t('onboarding.restoreFromBackup')}
+              <input
+                type="file"
+                accept=".json"
+                className="hidden"
+                onChange={(e) => { const f = e.target.files[0]; if (f) restoreBackup(f); e.target.value = ''; }}
+              />
+            </label>
             <div className={`mt-5 flex items-center justify-center gap-2 text-xs ${textSecondary}`}>
               <a href="https://glance-apps.com/dayglance/privacy" target="_blank" rel="noopener noreferrer" className="underline hover:text-blue-500 transition-colors">{t('onboarding.privacyPolicy')}</a>
               <span className="opacity-50">·</span>

--- a/src/hooks/useFolderBackup.js
+++ b/src/hooks/useFolderBackup.js
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AUTO_BACKUP_INTERVALS, AUTO_BACKUP_RETENTION } from '../utils/autoBackup.js';
+import {
+  isFolderBackupSupported, pickBackupFolder, loadFolderHandle, removeFolderHandle,
+  queryFolderPermission, requestFolderPermission,
+  readLiveBackup, writeLiveBackup, writeSnapshotBackup, payloadHasData,
+} from '../utils/folderBackup.js';
+
+// Debounce between a data save and the folder write. Short on purpose: on
+// wipe-on-exit machines the whole point is that closing the window costs
+// nothing, so the live file should trail the app by seconds, not minutes.
+// visibilitychange/pagehide flush whatever is still pending.
+const WRITE_DEBOUNCE_MS = 2500;
+
+const LIVE_LAST_KEY = 'day-planner-folder-backup-live-last';
+const SNAPSHOT_LAST_KEY = 'day-planner-folder-backup-snapshot-last';
+
+/**
+ * Continuous backup of the app's data to a user-chosen local folder via the
+ * File System Access API (see src/utils/folderBackup.js for the file layout
+ * and why this exists).
+ *
+ * State machine, per session:
+ *   no handle            → 'disconnected' when the feature is enabled but the
+ *                          stored handle is gone (wiped profile) — UI offers
+ *                          the folder picker, which doubles as the restore flow.
+ *   handle, no permission→ permission 'prompt' — UI offers one-click Reconnect;
+ *                          onNeedsReconnect fires once so the user notices.
+ *   handle + permission  → armed: every scheduleWrite() debounces into a live
+ *                          file write, plus cadence snapshots with retention.
+ *
+ * Empty-state guard: the hook never overwrites a live file that has data with
+ * a payload that has none ('guarded' status). That combination means the app
+ * state was lost, not edited — restoring, not mirroring, is what's wanted.
+ */
+export default function useFolderBackup({
+  enabled, snapshotFrequency, dataLoaded, disabled,
+  buildPayload, onNeedsReconnect,
+}) {
+  const supported = isFolderBackupSupported();
+
+  const [folderName, setFolderName] = useState(null); // null = no handle this session
+  const [permission, setPermission] = useState(null); // 'granted' | 'prompt' | null
+  // 'idle' | 'writing' | 'error' | 'guarded' | 'disconnected'
+  const [status, setStatus] = useState('idle');
+  const [lastWritten, setLastWritten] = useState(() => {
+    try { return localStorage.getItem(LIVE_LAST_KEY); } catch { return null; }
+  });
+
+  const handleRef = useRef(null);
+  const armedRef = useRef(false);
+  const liveHasDataRef = useRef(false);
+  const debounceRef = useRef(null);
+  const writingRef = useRef(false);
+  const writePendingRef = useRef(false);
+  const notifiedReconnectRef = useRef(false);
+
+  // Latest-value refs so the stable callbacks below never close over stale props.
+  const buildPayloadRef = useRef(buildPayload);
+  buildPayloadRef.current = buildPayload;
+  const snapshotFrequencyRef = useRef(snapshotFrequency);
+  snapshotFrequencyRef.current = snapshotFrequency;
+  const onNeedsReconnectRef = useRef(onNeedsReconnect);
+  onNeedsReconnectRef.current = onNeedsReconnect;
+
+  const doWrite = useCallback(async () => {
+    const handle = handleRef.current;
+    if (!handle || !armedRef.current) return;
+    if (writingRef.current) { writePendingRef.current = true; return; }
+    writingRef.current = true;
+    try {
+      const payload = buildPayloadRef.current?.();
+      if (!payload) return;
+      if (!payloadHasData(payload) && liveHasDataRef.current) {
+        armedRef.current = false;
+        setStatus('guarded');
+        return;
+      }
+      setStatus('writing');
+      await writeLiveBackup(handle, payload);
+      liveHasDataRef.current = payloadHasData(payload);
+      const now = new Date().toISOString();
+      try { localStorage.setItem(LIVE_LAST_KEY, now); } catch { /* ignore */ }
+      setLastWritten(now);
+      setStatus('idle');
+
+      // Cadence snapshot alongside the live write. The last-snapshot marker
+      // lives in localStorage; on wipe-on-exit machines it resets each session,
+      // giving one snapshot per session — exactly the history those machines
+      // otherwise lack. Retention pruning bounds the file count either way.
+      const freq = snapshotFrequencyRef.current || 'daily';
+      let last = null;
+      try { last = localStorage.getItem(SNAPSHOT_LAST_KEY); } catch { /* ignore */ }
+      const interval = AUTO_BACKUP_INTERVALS[freq] ?? AUTO_BACKUP_INTERVALS.daily;
+      const elapsed = last ? (Date.now() - new Date(last).getTime()) / 1000 : Infinity;
+      if (elapsed >= interval) {
+        await writeSnapshotBackup(handle, payload, AUTO_BACKUP_RETENTION[freq] ?? 30);
+        try { localStorage.setItem(SNAPSHOT_LAST_KEY, now); } catch { /* ignore */ }
+      }
+    } catch (err) {
+      console.error('Folder backup write failed:', err);
+      setStatus('error');
+    } finally {
+      writingRef.current = false;
+      if (writePendingRef.current) {
+        writePendingRef.current = false;
+        doWrite();
+      }
+    }
+  }, []);
+
+  // Called (via a ref) after every saveData() pass. Cheap no-op until armed.
+  const scheduleWrite = useCallback(() => {
+    if (!armedRef.current) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
+      doWrite();
+    }, WRITE_DEBOUNCE_MS);
+  }, [doWrite]);
+
+  // Arm write-through for `handle`, unless the empty-state guard trips.
+  const evaluateAndArm = useCallback(async (handle) => {
+    let live = null;
+    try {
+      live = await readLiveBackup(handle);
+    } catch (err) {
+      console.error('Folder backup: could not read live file:', err);
+    }
+    liveHasDataRef.current = payloadHasData(live);
+    const current = buildPayloadRef.current?.();
+    if (liveHasDataRef.current && current && !payloadHasData(current)) {
+      armedRef.current = false;
+      setStatus('guarded');
+      return false;
+    }
+    armedRef.current = true;
+    setStatus('idle');
+    doWrite();
+    return true;
+  }, [doWrite]);
+
+  /**
+   * Pick a folder (user gesture). If it already holds a live backup with data,
+   * does NOT arm — returns { existing } so the caller can ask the user whether
+   * to restore it or replace it with this device's current data.
+   */
+  const connect = useCallback(async () => {
+    try {
+      const handle = await pickBackupFolder();
+      handleRef.current = handle;
+      setFolderName(handle.name);
+      setPermission('granted');
+      let existing = null;
+      try { existing = await readLiveBackup(handle); } catch { /* treat as absent */ }
+      if (payloadHasData(existing)) {
+        armedRef.current = false;
+        liveHasDataRef.current = true;
+        return { ok: true, existing };
+      }
+      liveHasDataRef.current = false;
+      armedRef.current = true;
+      setStatus('idle');
+      doWrite();
+      return { ok: true, existing: null };
+    } catch (err) {
+      if (err?.name === 'AbortError') return { ok: false, cancelled: true };
+      console.error('Folder backup connect failed:', err);
+      return { ok: false, error: err.message };
+    }
+  }, [doWrite]);
+
+  // User explicitly chose to replace the folder's backup with current data
+  // (the "Replace" branch of the connect prompt) — consent overrides the guard.
+  const armOverwrite = useCallback(() => {
+    liveHasDataRef.current = false;
+    armedRef.current = true;
+    setStatus('idle');
+    doWrite();
+  }, [doWrite]);
+
+  // Re-grant permission on the stored handle (user gesture), then arm.
+  const reconnect = useCallback(async () => {
+    let handle = handleRef.current;
+    if (!handle) {
+      try { handle = await loadFolderHandle(); } catch { handle = null; }
+    }
+    if (!handle) return { ok: false };
+    try {
+      const p = await requestFolderPermission(handle);
+      setPermission(p);
+      if (p !== 'granted') return { ok: false };
+      handleRef.current = handle;
+      setFolderName(handle.name);
+      const armed = await evaluateAndArm(handle);
+      return { ok: true, armed };
+    } catch (err) {
+      console.error('Folder backup reconnect failed:', err);
+      return { ok: false, error: err.message };
+    }
+  }, [evaluateAndArm]);
+
+  const disconnect = useCallback(async () => {
+    if (debounceRef.current) { clearTimeout(debounceRef.current); debounceRef.current = null; }
+    armedRef.current = false;
+    handleRef.current = null;
+    setFolderName(null);
+    setPermission(null);
+    setStatus('idle');
+    try { await removeFolderHandle(); } catch { /* ignore */ }
+  }, []);
+
+  /**
+   * Restore entry point (user gesture): reuse the stored handle when it can be
+   * (re-)granted, otherwise open the picker. Returns { handle, payload } with
+   * payload null when the folder has no readable live backup. Throws
+   * AbortError when the user cancels the picker.
+   */
+  const openForRestore = useCallback(async () => {
+    let handle = handleRef.current;
+    if (!handle) {
+      try { handle = await loadFolderHandle(); } catch { handle = null; }
+    }
+    if (handle) {
+      let p = await queryFolderPermission(handle);
+      if (p !== 'granted') p = await requestFolderPermission(handle);
+      if (p !== 'granted') handle = null;
+    }
+    if (!handle) handle = await pickBackupFolder();
+    handleRef.current = handle;
+    setFolderName(handle.name);
+    setPermission('granted');
+    const payload = await readLiveBackup(handle);
+    return { handle, payload };
+  }, []);
+
+  // Session start: reload the persisted handle and arm if permission survived.
+  useEffect(() => {
+    if (disabled || !supported || !dataLoaded || !enabled) return;
+    if (handleRef.current) return; // already connected via connect()/restore
+    let stale = false;
+    (async () => {
+      let handle = null;
+      try { handle = await loadFolderHandle(); } catch { /* ignore */ }
+      if (stale) return;
+      if (!handle) {
+        // Enabled (config restored from a backup) but the handle didn't survive
+        // the profile wipe — the UI offers the picker to reconnect.
+        setStatus('disconnected');
+        return;
+      }
+      handleRef.current = handle;
+      setFolderName(handle.name);
+      let p = 'prompt';
+      try { p = await queryFolderPermission(handle); } catch { /* ignore */ }
+      if (stale) return;
+      setPermission(p);
+      if (p === 'granted') {
+        await evaluateAndArm(handle);
+      } else if (!notifiedReconnectRef.current) {
+        // requestPermission needs a user gesture, so just surface it once.
+        notifiedReconnectRef.current = true;
+        onNeedsReconnectRef.current?.();
+      }
+    })();
+    return () => { stale = true; };
+  }, [disabled, supported, dataLoaded, enabled, evaluateAndArm]);
+
+  // Flush a pending debounced write when the app is being closed or hidden —
+  // best effort, but Chrome reliably fires visibilitychange before a PWA
+  // window closes, and the debounce window is short.
+  useEffect(() => {
+    if (disabled || !supported) return;
+    const flush = () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+        doWrite();
+      }
+    };
+    const onVisibility = () => { if (document.visibilityState === 'hidden') flush(); };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('pagehide', flush);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('pagehide', flush);
+    };
+  }, [disabled, supported, doWrite]);
+
+  return {
+    supported, folderName, permission, status, lastWritten,
+    connect, reconnect, disconnect, armOverwrite, scheduleWrite, openForRestore,
+  };
+}

--- a/src/utils/folderBackup.js
+++ b/src/utils/folderBackup.js
@@ -1,0 +1,223 @@
+/**
+ * Local Folder Backup (File System Access API)
+ *
+ * Continuously mirrors the app's data into a user-chosen folder on the local
+ * disk. Designed for environments where the browser wipes site data on close
+ * (managed/enterprise Chrome, kiosk profiles): everything the app persists in
+ * localStorage/IndexedDB is lost between sessions, but a real file on disk
+ * survives. No data ever leaves the machine.
+ *
+ * Layout inside the chosen folder:
+ *   dayglance-data.json                   — the LIVE file, rewritten (debounced)
+ *                                           on every save; what restore reads.
+ *   dayglance-backup-YYYY-MM-DD-HHMM.json — point-in-time snapshots on the
+ *                                           configured cadence, pruned to a
+ *                                           retention count. Safety net against
+ *                                           the live file faithfully mirroring
+ *                                           a mistake (bulk delete, bad merge).
+ *
+ * The directory handle is persisted in IndexedDB (same pattern as the Obsidian
+ * vault integration) so reconnecting is a single click when the profile
+ * survives. On a wipe-on-exit machine the handle is lost too — the welcome
+ * modal's "Restore from a backup" flow re-picks the folder, restores, and
+ * re-arms in one dialog.
+ */
+
+export const LIVE_BACKUP_FILENAME = 'dayglance-data.json';
+export const SNAPSHOT_PREFIX = 'dayglance-backup-';
+
+const SNAPSHOT_RE = /^dayglance-backup-\d{4}-\d{2}-\d{2}-\d{4}\.json$/;
+
+// ---------------------------------------------------------------------------
+// Feature detection
+// ---------------------------------------------------------------------------
+
+// Web/PWA only. Electron routes folder access through the main process (the
+// renderer's FS Access handles can't persist under the MAS sandbox) and ships
+// with real disk persistence anyway; native WebViews lack showDirectoryPicker.
+export function isFolderBackupSupported() {
+  return (
+    typeof window !== 'undefined' &&
+    'showDirectoryPicker' in window &&
+    !window.electronAPI?.isElectron
+  );
+}
+
+// ---------------------------------------------------------------------------
+// IndexedDB — persist the folder directory handle across sessions
+// ---------------------------------------------------------------------------
+
+const DB_NAME = 'dayglance-folder-backup';
+const DB_VERSION = 1;
+const STORE_NAME = 'handles';
+const HANDLE_KEY = 'folder';
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function saveFolderHandle(handle) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(handle, HANDLE_KEY);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function loadFolderHandle() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).get(HANDLE_KEY);
+    req.onsuccess = () => resolve(req.result || null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function removeFolderHandle() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(HANDLE_KEY);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Permissions
+// ---------------------------------------------------------------------------
+
+export function queryFolderPermission(handle) {
+  return handle.queryPermission({ mode: 'readwrite' });
+}
+
+// Must be called from a user gesture.
+export function requestFolderPermission(handle) {
+  return handle.requestPermission({ mode: 'readwrite' });
+}
+
+// Must be called from a user gesture. Persists the picked handle; persistence
+// failure is non-fatal — the session still works, only next-launch reconnect
+// falls back to the picker.
+export async function pickBackupFolder() {
+  const handle = await window.showDirectoryPicker({ mode: 'readwrite' });
+  try {
+    await saveFolderHandle(handle);
+  } catch (err) {
+    console.warn('Folder backup: could not persist folder handle:', err);
+  }
+  return handle;
+}
+
+// ---------------------------------------------------------------------------
+// Reads / writes
+// ---------------------------------------------------------------------------
+
+/**
+ * Read and parse the live backup file. Returns null when the file doesn't
+ * exist or contains invalid JSON (a corrupt live file should not brick the
+ * connect/restore flows — the next write-through replaces it). Permission and
+ * I/O errors still throw.
+ */
+export async function readLiveBackup(dirHandle) {
+  let file;
+  try {
+    const fh = await dirHandle.getFileHandle(LIVE_BACKUP_FILENAME);
+    file = await fh.getFile();
+  } catch (e) {
+    if (e?.name === 'NotFoundError') return null;
+    throw e;
+  }
+  try {
+    return JSON.parse(await file.text());
+  } catch {
+    return null;
+  }
+}
+
+async function writeJsonFile(dirHandle, filename, payload) {
+  const fh = await dirHandle.getFileHandle(filename, { create: true });
+  // createWritable stages into a temp file and atomically swaps on close, so a
+  // crash mid-write never corrupts the existing copy.
+  const writable = await fh.createWritable();
+  await writable.write(JSON.stringify(payload, null, 2));
+  await writable.close();
+}
+
+export function writeLiveBackup(dirHandle, payload) {
+  return writeJsonFile(dirHandle, LIVE_BACKUP_FILENAME, payload);
+}
+
+// ---------------------------------------------------------------------------
+// Snapshots
+// ---------------------------------------------------------------------------
+
+// Zero-padded local timestamp so filenames sort lexically = chronologically.
+export function snapshotFilename(now = new Date()) {
+  const p = (n) => String(n).padStart(2, '0');
+  return (
+    `${SNAPSHOT_PREFIX}${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())}` +
+    `-${p(now.getHours())}${p(now.getMinutes())}.json`
+  );
+}
+
+/** Snapshot filenames in the folder, newest first. */
+export async function listSnapshots(dirHandle) {
+  const names = [];
+  for await (const [name, entry] of dirHandle.entries()) {
+    if (entry.kind === 'file' && SNAPSHOT_RE.test(name)) names.push(name);
+  }
+  return names.sort().reverse();
+}
+
+/** Delete snapshots beyond `keep`, newest kept. Returns surviving names. */
+export async function pruneSnapshots(dirHandle, keep) {
+  const names = await listSnapshots(dirHandle);
+  for (const name of names.slice(keep)) {
+    await dirHandle.removeEntry(name);
+  }
+  return names.slice(0, keep);
+}
+
+export async function writeSnapshotBackup(dirHandle, payload, keep, now = new Date()) {
+  await writeJsonFile(dirHandle, snapshotFilename(now), payload);
+  await pruneSnapshots(dirHandle, keep);
+}
+
+// ---------------------------------------------------------------------------
+// Payload inspection
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a backup payload contains any user data worth protecting. Used by
+ * the empty-state guard: a payload with no tasks/habits/goals/etc. must never
+ * overwrite a live file that has them (e.g. a freshly wiped profile arming
+ * write-through before the user restores).
+ */
+export function payloadHasData(payload) {
+  const d = payload?.data;
+  if (!d) return false;
+  const lists = [
+    d.tasks, d.unscheduledTasks, d.recycleBin, d.recurringTasks,
+    d.habits, d.goals, d.projects, d.areas,
+  ];
+  if (lists.some((l) => Array.isArray(l) && l.length > 0)) return true;
+  if (d.routineDefinitions &&
+      Object.values(d.routineDefinitions).some((v) => Array.isArray(v) && v.length > 0)) {
+    return true;
+  }
+  return false;
+}

--- a/src/utils/folderBackup.test.js
+++ b/src/utils/folderBackup.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LIVE_BACKUP_FILENAME,
+  payloadHasData,
+  snapshotFilename,
+  listSnapshots,
+  pruneSnapshots,
+  readLiveBackup,
+  writeLiveBackup,
+  writeSnapshotBackup,
+} from './folderBackup.js';
+
+// Minimal in-memory FileSystemDirectoryHandle: just the surface folderBackup.js
+// drives (entries/getFileHandle/removeEntry, file read + atomic-ish write).
+function makeDirHandle(files = {}) {
+  const store = new Map(Object.entries(files));
+  return {
+    kind: 'directory',
+    name: 'TestFolder',
+    async *entries() {
+      for (const name of store.keys()) yield [name, { kind: 'file' }];
+    },
+    async getFileHandle(name, opts) {
+      if (!store.has(name)) {
+        if (!opts?.create) {
+          const e = new Error(`${name} not found`);
+          e.name = 'NotFoundError';
+          throw e;
+        }
+        store.set(name, '');
+      }
+      return {
+        kind: 'file',
+        async getFile() {
+          return { text: async () => store.get(name) };
+        },
+        async createWritable() {
+          let buf = '';
+          return {
+            write: async (chunk) => { buf += chunk; },
+            close: async () => { store.set(name, buf); },
+          };
+        },
+      };
+    },
+    async removeEntry(name) {
+      if (!store.delete(name)) {
+        const e = new Error(`${name} not found`);
+        e.name = 'NotFoundError';
+        throw e;
+      }
+    },
+    _store: store,
+  };
+}
+
+const payloadWith = (data) => ({ type: 'auto-backup', version: 1, timestamp: '2026-07-19T09:00:00.000Z', data });
+
+describe('payloadHasData', () => {
+  it('is false for null, missing data, and empty collections', () => {
+    expect(payloadHasData(null)).toBe(false);
+    expect(payloadHasData({})).toBe(false);
+    expect(payloadHasData(payloadWith({}))).toBe(false);
+    expect(payloadHasData(payloadWith({
+      tasks: [], unscheduledTasks: [], habits: [], goals: [], routineDefinitions: { morning: [] },
+    }))).toBe(false);
+  });
+
+  it('is true when any user collection has entries', () => {
+    expect(payloadHasData(payloadWith({ tasks: [{ id: 1 }] }))).toBe(true);
+    expect(payloadHasData(payloadWith({ tasks: [], habits: [{ id: 'h' }] }))).toBe(true);
+    expect(payloadHasData(payloadWith({ recycleBin: [{ id: 1 }] }))).toBe(true);
+    expect(payloadHasData(payloadWith({ routineDefinitions: { morning: [{ id: 'r' }] } }))).toBe(true);
+  });
+});
+
+describe('snapshotFilename', () => {
+  it('formats a zero-padded local timestamp that sorts chronologically', () => {
+    const name = snapshotFilename(new Date(2026, 0, 5, 7, 3));
+    expect(name).toBe('dayglance-backup-2026-01-05-0703.json');
+    const later = snapshotFilename(new Date(2026, 0, 5, 12, 0));
+    expect([later, name].sort()).toEqual([name, later]);
+  });
+});
+
+describe('live file read/write', () => {
+  it('round-trips a payload through the live file', async () => {
+    const dir = makeDirHandle();
+    const payload = payloadWith({ tasks: [{ id: 1, title: 'write me' }] });
+    await writeLiveBackup(dir, payload);
+    expect(await readLiveBackup(dir)).toEqual(payload);
+  });
+
+  it('returns null when the live file is missing or corrupt', async () => {
+    expect(await readLiveBackup(makeDirHandle())).toBe(null);
+    const corrupt = makeDirHandle({ [LIVE_BACKUP_FILENAME]: '{not json' });
+    expect(await readLiveBackup(corrupt)).toBe(null);
+  });
+});
+
+describe('snapshots', () => {
+  it('lists only snapshot-named files, newest first', async () => {
+    const dir = makeDirHandle({
+      [LIVE_BACKUP_FILENAME]: '{}',
+      'dayglance-backup-2026-07-18-0900.json': '{}',
+      'dayglance-backup-2026-07-19-0900.json': '{}',
+      'unrelated.json': '{}',
+      // Manual exports use the date-only name; they are not snapshots and
+      // must never be pruned.
+      'dayglance-backup-2026-07-19.json': '{}',
+    });
+    expect(await listSnapshots(dir)).toEqual([
+      'dayglance-backup-2026-07-19-0900.json',
+      'dayglance-backup-2026-07-18-0900.json',
+    ]);
+  });
+
+  it('prunes oldest snapshots beyond the retention count', async () => {
+    const dir = makeDirHandle({
+      'dayglance-backup-2026-07-16-0900.json': '{}',
+      'dayglance-backup-2026-07-17-0900.json': '{}',
+      'dayglance-backup-2026-07-18-0900.json': '{}',
+    });
+    const kept = await pruneSnapshots(dir, 2);
+    expect(kept).toEqual([
+      'dayglance-backup-2026-07-18-0900.json',
+      'dayglance-backup-2026-07-17-0900.json',
+    ]);
+    expect(dir._store.has('dayglance-backup-2026-07-16-0900.json')).toBe(false);
+  });
+
+  it('writeSnapshotBackup writes the snapshot then applies retention', async () => {
+    const dir = makeDirHandle({
+      'dayglance-backup-2026-07-17-0900.json': '{}',
+      'dayglance-backup-2026-07-18-0900.json': '{}',
+    });
+    await writeSnapshotBackup(dir, payloadWith({ tasks: [{ id: 1 }] }), 2, new Date(2026, 6, 19, 9, 0));
+    expect([...dir._store.keys()].sort()).toEqual([
+      'dayglance-backup-2026-07-18-0900.json',
+      'dayglance-backup-2026-07-19-0900.json',
+    ]);
+    expect(JSON.parse(dir._store.get('dayglance-backup-2026-07-19-0900.json')).data.tasks).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

A new **Folder Backup** flavor in the Auto-Backup manager: the app continuously mirrors its data into a user-chosen folder on the local disk via the File System Access API, plus a **"Restore from a backup"** entry point on the first step of the welcome modal.

## Why

On managed/enterprise machines, Chrome is often configured to clear site data when the browser closes — which wipes localStorage *and* IndexedDB, so both the app's data and its existing "local" (IndexedDB) auto-backups are lost on every launch, and cloud sync may be off the table by policy. A real file on disk survives the wipe, and nothing leaves the machine.

The welcome modal is the natural restore surface because it appears exactly when the app has no data — i.e. right after a wipe. On such machines the whole launch ritual becomes: open app → click "Restore from a backup" → pick the folder → everything is back *and* write-through is re-armed, all in one dialog.

## How

**Inside the chosen folder:**
- `dayglance-data.json` — live file, rewritten (2.5 s debounce, flushed on `visibilitychange`/`pagehide`) after every save
- `dayglance-backup-YYYY-MM-DD-HHMM.json` — snapshots on the configured cadence (hourly/daily/weekly), pruned to the existing `AUTO_BACKUP_RETENTION` counts — a safety net against the live file faithfully mirroring a mistake

**Key pieces:**
- `src/utils/folderBackup.js` — handle persistence in IndexedDB (same pattern as the Obsidian vault), atomic live-file writes, snapshot naming/pruning, `payloadHasData()` (+ unit tests)
- `src/hooks/useFolderBackup.js` — session state machine: reload the stored handle on launch, arm when permission survives, one-click reconnect when it doesn't, **empty-state guard** (never overwrite a backup that has data with an empty app state)
- Auto-Backup manager — connect/reconnect/disconnect, snapshot frequency, restore-or-replace prompt when the picked folder already contains a backup; section hidden where the FS Access API is unavailable (Firefox/Safari, Electron, native)
- Welcome modal (desktop + mobile) — folder-based restore where supported, plain backup-file picker fallback elsewhere (`restoreBackup` now accepts a direct `file` argument)
- Backup payloads now include `autoBackupConfig`, so a restore re-enables folder backup automatically

## Testing

- `npm test` — 802 passed (includes new `folderBackup.test.js`)
- `npm run lint` — clean; `vite build` — clean
- Playwright E2E against the dev server with a stubbed `showDirectoryPicker`: welcome-modal folder restore (data + config restored, write-through re-armed), reconnect hint after handle loss, restore-or-replace prompt, snapshot on first armed write, debounced write-through after adding a task via the UI, and the non-FSA file-input restore path — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017b17kdb2Fpvtot3gKErDYM

---
_Generated by [Claude Code](https://claude.ai/code/session_017b17kdb2Fpvtot3gKErDYM)_