### PR TITLE
Fix no-op Restore button in the backup confirmation dialog

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5352,11 +5352,14 @@ const DayPlanner = () => {
     if (data.autoBackupConfig) localStorage.setItem('day-planner-auto-backup-config', JSON.stringify(data.autoBackupConfig));
   };
 
-  // Restore data from backup file. `file` defaults to the staged pendingBackupFile
-  // (the confirm-modal flow); the welcome-modal restore passes the picked file
-  // directly since the app is empty there and needs no confirmation step.
-  const restoreBackup = (file = pendingBackupFile) => {
-    if (!file) return;
+  // Restore data from backup file. Falls back to the staged pendingBackupFile
+  // (the confirm-modal flow, where this is wired directly as a click handler and
+  // therefore receives the click EVENT — hence the Blob check, not a default
+  // parameter); the welcome-modal restore passes the picked File directly since
+  // the app is empty there and needs no confirmation step.
+  const restoreBackup = (file) => {
+    const backupFile = file instanceof Blob ? file : pendingBackupFile;
+    if (!backupFile) return;
 
     const reader = new FileReader();
     reader.onload = (e) => {
@@ -5392,7 +5395,7 @@ const DayPlanner = () => {
       setPendingBackupFile(null);
       setShowRestoreConfirm(false);
     };
-    reader.readAsText(file);
+    reader.readAsText(backupFile);
   };
 
   // Restore from the folder backup's live file. Reuses the stored folder handle


### PR DESCRIPTION
## What

Fixes a regression from #1219: in the Backup & Restore confirmation dialog (Backup menu → Restore Backup → pick file → **Restore**), the Restore button did nothing.

## Why

`RestoreConfirmModal` wires `restoreBackup` directly as `onClick`, so React passes the click **event** as the first argument. #1219 changed the signature to `restoreBackup = (file = pendingBackupFile)` for the welcome-modal restore — but a default parameter only applies when the argument is `undefined`. The truthy event object was taken as the "file", and `FileReader.readAsText(event)` threw synchronously (outside any catch), leaving the button a silent no-op.

## How

`restoreBackup` now accepts its argument only when it's an actual `Blob`/`File` (`file instanceof Blob`) and falls back to the staged `pendingBackupFile` otherwise, so both call styles — direct click handler and explicit File from the welcome-modal restore — work.

## Testing

- Playwright E2E of the exact broken flow (backup menu → Restore Backup → file → confirm → Restore): fails with a page error and no navigation on the unfixed code, passes with the fix (backup applied, restored task visible after reload)
- Re-ran the welcome-modal file-restore E2E path — still working
- `npm test` (802 passed), `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017b17kdb2Fpvtot3gKErDYM

---
_Generated by [Claude Code](https://claude.ai/code/session_017b17kdb2Fpvtot3gKErDYM)_