### PR TITLE
Persist Getting Started checklist dismissal through backups

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1476,6 +1476,16 @@ const DayPlanner = () => {
     dailyNotes, users, routineCompletions, multiUserEnabled,
   });
 
+  // Onboarding flags aren't part of the useSaveOnChange data slices, so a
+  // checklist dismissal alone would never reach the folder backup — and the
+  // Getting Started checklist would reappear every session on wipe-on-exit
+  // machines. useOnboarding's own effects persist the flags to localStorage in
+  // the same commit, well before the debounced write builds its payload.
+  useEffect(() => {
+    if (!dataLoaded) return;
+    folderBackupWriteRef.current?.();
+  }, [dataLoaded, gettingStartedDismissed, onboardingProgress]);
+
   const { timelineScrolledAway, setTimelineScrolledAway, scrollToCurrentHour, scrollToHour } = useTimelineScroll({
     calendarRef, timeGridRef,
     selectedDate,
@@ -5109,6 +5119,8 @@ const DayPlanner = () => {
         areas: JSON.parse(localStorage.getItem('day-planner-areas') || '[]'),
         goalsProjectsEnabled: JSON.parse(localStorage.getItem('day-planner-goals-projects-enabled') || 'false'),
         autoBackupConfig: JSON.parse(localStorage.getItem('day-planner-auto-backup-config') || 'null'),
+        gettingStartedDismissed: localStorage.getItem('gettingStartedDismissed') === 'true',
+        onboardingProgress: JSON.parse(localStorage.getItem('onboardingProgress') || 'null'),
       }
     };
 
@@ -5160,6 +5172,8 @@ const DayPlanner = () => {
       areas: JSON.parse(localStorage.getItem('day-planner-areas') || '[]'),
       goalsProjectsEnabled: JSON.parse(localStorage.getItem('day-planner-goals-projects-enabled') || 'false'),
       autoBackupConfig: JSON.parse(localStorage.getItem('day-planner-auto-backup-config') || 'null'),
+      gettingStartedDismissed: localStorage.getItem('gettingStartedDismissed') === 'true',
+      onboardingProgress: JSON.parse(localStorage.getItem('onboardingProgress') || 'null'),
     }
   });
 
@@ -5350,6 +5364,13 @@ const DayPlanner = () => {
     if (data.areas) localStorage.setItem('day-planner-areas', JSON.stringify(data.areas));
     if (data.goalsProjectsEnabled !== undefined) localStorage.setItem('day-planner-goals-projects-enabled', JSON.stringify(data.goalsProjectsEnabled));
     if (data.autoBackupConfig) localStorage.setItem('day-planner-auto-backup-config', JSON.stringify(data.autoBackupConfig));
+    // Onboarding flags: the Getting Started checklist can also be re-enabled
+    // from settings (key removed), so an explicit false must clear the key.
+    if (data.gettingStartedDismissed !== undefined) {
+      if (data.gettingStartedDismissed) localStorage.setItem('gettingStartedDismissed', 'true');
+      else localStorage.removeItem('gettingStartedDismissed');
+    }
+    if (data.onboardingProgress) localStorage.setItem('onboardingProgress', JSON.stringify(data.onboardingProgress));
   };
 
   // Restore data from backup file. Falls back to the staged pendingBackupFile


### PR DESCRIPTION
## What

The Getting Started checklist reappeared on every launch on wipe-on-exit machines, even after being dismissed and even with folder backup active. Its dismissal (and the checklist's progress) now round-trips through backups.

## Why

Two gaps:
1. `gettingStartedDismissed` and `onboardingProgress` weren't part of any backup payload, so a folder restore brought everything back *except* the dismissal — the checklist returned each session.
2. Dismissing the checklist changes none of the data slices `useSaveOnChange` watches, so even with the flag in the payload, a dismissal alone would never have triggered a write to the live file — dismiss-then-close would still lose it.

## How

- `exportBackup` and `buildAutoBackupPayload` now include `gettingStartedDismissed` and `onboardingProgress`
- `applyBackupToLocalStorage` restores both; an explicit `false` clears the key (matching the settings toggle, which re-enables the checklist by removing it)
- A new effect schedules a folder-backup write when either onboarding flag changes, so the dismissal reaches the live file within the normal debounce even with no other edits

## Testing

- Playwright E2E, both directions: (A) fresh profile → connect folder → dismiss checklist with **no task edits** → live file contains `gettingStartedDismissed: true` within the debounce window; (B) welcome-modal restore of a live file carrying the flag → flag and progress restored, checklist stays hidden
- `npm test` (802 passed), `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017b17kdb2Fpvtot3gKErDYM

---
_Generated by [Claude Code](https://claude.ai/code/session_017b17kdb2Fpvtot3gKErDYM)_