### PR TITLE
Clarify the MIT-source / paid-build licensing model

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,11 @@ Please open an issue before starting large changes so we can discuss approach. F
 
 ## License
 
-[MIT](LICENSE): free to use, self-host, modify, and distribute.
+The **source code** is [MIT-licensed](LICENSE): free to build, self-host, modify, and distribute. Free builds (the Android APK and the Electron desktop app) are available on the [releases page](https://github.com/krelltunez/dayglance/releases).
+
+The **paid Google Play and App Store builds** are a convenience distribution that funds continued development. When you buy those, you're paying for the packaged, signed, auto-updating binary and the store experience around it, not for the code itself, which remains free under the MIT license above.
+
+**Trademarks:** the dayGLANCE name, logo, and app icon are trademarks of the project and are **not** covered by the MIT license. The MIT license grants rights to the code only; it does not grant permission to use the dayGLANCE branding on your own builds or distributions.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "dayglance",
   "private": true,
+  "license": "MIT",
   "version": "4.0.0",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
## What

Makes the "MIT source, sold as a paid app" relationship explicit in both the manifest and the README, and carves the branding out of the license grant.

## Changes

1. **`package.json`** — added `"license": "MIT"` so the manifest matches the existing `LICENSE` file. `"private": true` is preserved (it only blocks `npm publish`, unrelated to app licensing).
2. **README License section** — reworded to explain the model:
   - The source is MIT: free to build, self-host, modify, and distribute, with free APK/Electron builds on the releases page.
   - The paid Google Play / App Store builds are a convenience distribution that funds development. You're paying for the packaged, signed, auto-updating binary, not the code.
3. **Trademark note** (in the README License section) — the dayGLANCE name, logo, and app icon are trademarks and are **not** covered by the MIT license.

## Why

MIT is silent on trademarks, so the name and logo aren't granted regardless, but the README invites free "distribution," which creates ambiguity about the branding. The explicit note removes it: the grant is to the code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017b17kdb2Fpvtot3gKErDYM

---
_Generated by [Claude Code](https://claude.ai/code/session_017b17kdb2Fpvtot3gKErDYM)_