### PR TITLE
Pin @glance-apps/sync 1.6.1 and fix WebDAV ETag/export/provider-key issues

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/HttpBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/HttpBridge.kt
@@ -49,6 +49,13 @@ class HttpBridge {
             connection.readTimeout = 20_000
             connection.instanceFollowRedirects = true
 
+            // Without this, HttpURLConnection silently adds Accept-Encoding: gzip,
+            // and Apache mod_deflate rewrites the ETag on encoded responses
+            // ("xyz" -> "xyz-gzip"), so every If-Match PUT 412s and WebDAV sync
+            // wedges (lastGLANCE #232). Set before caller headers so an explicit
+            // Accept-Encoding from JS still wins.
+            connection.setRequestProperty("Accept-Encoding", "identity")
+
             // Apply request headers
             try {
                 val headers = JSONObject(headersJson)

--- a/dayglance-ios/DayGlance/Bridges/HttpBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/HttpBridge.swift
@@ -28,6 +28,13 @@ final class HttpBridge {
         // current file on the server, not a URLSession-cached copy.
         req.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
 
+        // Without this, URLSession silently adds Accept-Encoding: gzip, and
+        // Apache mod_deflate rewrites the ETag on encoded responses
+        // ("xyz" -> "xyz-gzip"), so every If-Match PUT 412s and WebDAV sync
+        // wedges (lastGLANCE #232). Set before caller headers so an explicit
+        // Accept-Encoding from JS still wins.
+        req.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
+
         // Apply caller-supplied headers
         if let data = headersJson.data(using: .utf8),
            let headers = try? JSONSerialization.jsonObject(with: data) as? [String: String] {

--- a/dayglance-ios/DayGlance/Bridges/ShareBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/ShareBridge.swift
@@ -1,0 +1,57 @@
+import UIKit
+
+/// iOS share bridge for window.DayGlanceNative.shareFile.
+///
+/// The web `<a download>` trick is never handled by WKWebView — blob downloads
+/// need a WKDownload delegate this shell doesn't implement — so backup export
+/// writes the file to the temp directory and presents the system share sheet,
+/// mirroring Android's NativeBridge.shareFile() (cache dir + FileProvider +
+/// ACTION_SEND).
+final class ShareBridge {
+
+    static let shared = ShareBridge()
+
+    /// Writes [content] to the temp dir as [filename] and presents
+    /// UIActivityViewController from the root view controller.
+    ///
+    /// Returns { success: true } once the sheet is scheduled, or
+    /// { success: false, error } if the file can't be written. A dismissed
+    /// share sheet is a cancel, not an error, so it stays success — the
+    /// synchronous bridge returns before the sheet resolves anyway.
+    func shareFile(filename: String, content: String) -> String {
+        // Strip path separators so the suggested filename can't escape tmp/.
+        let safeName = filename
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "\\", with: "_")
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(safeName)
+        do {
+            try content.write(to: fileURL, atomically: true, encoding: .utf8)
+        } catch {
+            return resultJSON(success: false, error: error.localizedDescription)
+        }
+        DispatchQueue.main.async {
+            guard let rootVC = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .first?.windows.first?.rootViewController else { return }
+            let activityVC = UIActivityViewController(activityItems: [fileURL], applicationActivities: nil)
+            // iPad presents this as a popover and traps without an anchor.
+            if let popover = activityVC.popoverPresentationController {
+                popover.sourceView = rootVC.view
+                popover.sourceRect = CGRect(x: rootVC.view.bounds.midX, y: rootVC.view.bounds.midY, width: 0, height: 0)
+                popover.permittedArrowDirections = []
+            }
+            rootVC.present(activityVC, animated: true)
+        }
+        return resultJSON(success: true, error: nil)
+    }
+
+    private func resultJSON(success: Bool, error: String?) -> String {
+        var payload: [String: Any] = ["success": success]
+        if let error { payload["error"] = error }
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let str = String(data: data, encoding: .utf8) {
+            return str
+        }
+        return #"{"success":false,"error":"serialization error"}"#
+    }
+}

--- a/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
+++ b/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
@@ -142,6 +142,16 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
             }
             return HttpBridge.shared.request(method: method, url: url, headersJson: headers, body: body)
 
+        // Backup export — system share sheet (the WKWebView never handles
+        // <a download> on blob URLs, same reason Android has shareFile).
+        case "shareFile":
+            guard args.count >= 2,
+                  let filename = args[0] as? String,
+                  let content  = args[1] as? String else {
+                return #"{"success":false,"error":"missing args"}"#
+            }
+            return ShareBridge.shared.shareFile(filename: filename, content: content)
+
         // Phase 7 — iCloud Sync
         case "readICloudSync":
             return ICloudBridge.shared.readSync()

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,11 @@
     "": {
       "name": "dayglance",
       "version": "4.0.0",
+      "license": "MIT",
       "dependencies": {
         "@glance-apps/billing": "0.1.1",
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "1.6.0",
+        "@glance-apps/sync": "1.6.1",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -2591,9 +2592,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.6.0.tgz",
-      "integrity": "sha512-1rDJNg7HYTfvEFrCy2oVMtiWhdNGNa3avk4JqKQfE888Zw0Sv0EevBGUAR6S8nnxlK5CN1ZOPhh5TKOWTUhSPg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.6.1.tgz",
+      "integrity": "sha512-cRdLWkX7AreC4h0Gz0lnxum/Nn/uq4OO+Jcjjxq8e4uhT5c3Z25kBDXXbA5VxLw5HGtHYBQanTy4QuYyTzBspw==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@glance-apps/billing": "0.1.1",
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "1.6.0",
+    "@glance-apps/sync": "1.6.1",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import { mergeObsidianTasks } from './utils/mergeObsidianTasks.js';
 import { detectObsidianDeletions, addObsidianTombstones } from './utils/obsidianDeletions.js';
 import { stripHealthSourcedLogs } from './utils/healthLogFilter.js';
 import { webdavFetch } from './utils/cloudSyncProviders.js';
+import { normalizeEtag } from '@glance-apps/sync';
 import { autoBackupDB, createAutoBackupProvidersForFolder, AUTO_BACKUP_RETENTION, AUTO_BACKUP_INTERVALS } from './utils/autoBackup.js';
 import { LIVE_BACKUP_FILENAME } from './utils/folderBackup.js';
 import useFolderBackup from './hooks/useFolderBackup.js';
@@ -2405,7 +2406,7 @@ const DayPlanner = () => {
       const base = cloudSyncConfig.nextcloudUrl.replace(/\/+$/, '');
       const user = encodeURIComponent(cloudSyncConfig.username);
       oldFolderPath = `${base}/remote.php/dav/files/${user}/dayglance/`;
-    } else if (provider === 'generic' && cloudSyncConfig.webdavUrl) {
+    } else if (provider === 'webdav' && cloudSyncConfig.webdavUrl) {
       const base = cloudSyncConfig.webdavUrl.replace(/\/+$/, '');
       oldFolderPath = `${base}/dayglance/`;
     }
@@ -5127,10 +5128,16 @@ const DayPlanner = () => {
     const filename = `dayglance-backup-${dateToString(new Date())}.json`;
     const jsonStr = JSON.stringify(backup, null, 2);
 
-    // On Android the <a download> trick is silently ignored inside a WebView.
-    // Use the native share sheet instead so the user can save to Files / Drive.
-    if (isNativeAndroid()) {
-      nativeShareFile(filename, jsonStr);
+    // In both native WebViews the <a download> trick is silently ignored
+    // (Android WebView has no DownloadListener; WKWebView never handles blob
+    // downloads). Use the native share sheet instead so the user can save to
+    // Files / Drive. A null result means the share sheet was dismissed or the
+    // bridge is missing — dismissal is a cancel, but success:false is an error.
+    if (isNativeApp()) {
+      const result = nativeShareFile(filename, jsonStr);
+      if (result && result.success === false) {
+        setSyncNotification({ type: 'error', title: 'Backup Export', message: `Could not export backup: ${result.error || 'unknown error'}` });
+      }
       return;
     }
 
@@ -5672,7 +5679,10 @@ const DayPlanner = () => {
         return;
       }
 
-      const icsEtag = getRes.headers.get('etag') || null;
+      // Normalize before If-Match: Apache mod_deflate rewrites ETags on
+      // gzip-encoded responses ("xyz" -> "xyz-gzip") and nginx downgrades them
+      // to weak (W/"xyz"), either of which makes the PUT below 412 forever.
+      const icsEtag = normalizeEtag(getRes.headers.get('etag')) || null;
       let icsContent = await getRes.text();
       // RFC 5545 §3.1 unfold: remove CRLF/LF followed by a whitespace continuation
       // so that line-folded properties match our single-line regexes reliably.

--- a/src/intents/sharedUsers.js
+++ b/src/intents/sharedUsers.js
@@ -6,10 +6,10 @@ const DEFAULT_USERS_PATH = '/GLANCE/users/';
 
 /**
  * Derive the WebDAV base URL and auth from a cloudSyncConfig object.
- * Supports both 'nextcloud' and 'generic' provider shapes.
+ * Supports the 'nextcloud', 'koofr', and 'webdav' provider shapes.
  * Returns null if the config is missing required fields.
  */
-function resolveWebDAV(cloudSyncConfig) {
+export function resolveWebDAV(cloudSyncConfig) {
   if (!cloudSyncConfig?.enabled) return null;
   const provider = cloudSyncConfig.provider || 'nextcloud';
   if (provider === 'nextcloud') {
@@ -18,6 +18,12 @@ function resolveWebDAV(cloudSyncConfig) {
     const base = nextcloudUrl.replace(/\/+$/, '');
     const user = encodeURIComponent(username);
     return { baseUrl: `${base}/remote.php/dav/files/${user}`, username, appPassword };
+  } else if (provider === 'koofr') {
+    // Koofr configs carry no URL key — the WebDAV root is fixed (mirrors the
+    // koofr provider in @glance-apps/sync providers.js).
+    const { username, appPassword } = cloudSyncConfig;
+    if (!username || !appPassword) return null;
+    return { baseUrl: 'https://app.koofr.net/dav/Koofr', username, appPassword };
   } else {
     const { webdavUrl, username, appPassword } = cloudSyncConfig;
     if (!webdavUrl || !username || !appPassword) return null;

--- a/src/intents/sharedUsers.test.js
+++ b/src/intents/sharedUsers.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// sharedUsers.js pulls in webdavFetch (window-dependent) and the iCloud
+// transport at module level; neither is exercised by resolveWebDAV, so stub
+// them out to keep this a pure node test.
+vi.mock('../utils/cloudSyncProviders.js', () => ({ webdavFetch: vi.fn() }));
+vi.mock('./icloudFileTransport.js', () => ({ isAvailable: () => false }));
+
+import { resolveWebDAV } from './sharedUsers.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveWebDAV derives the shared-users WebDAV endpoint from cloudSyncConfig.
+// Each provider stores its server location under a DIFFERENT key (nextcloudUrl /
+// webdavUrl / none at all for Koofr), so a gate written against one provider's
+// key silently disables the feature for the others — the lastGLANCE class-5
+// bug family. These pin the per-provider shapes, especially Koofr's fixed root.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('resolveWebDAV', () => {
+  it('returns null when sync is disabled, whatever else is set', () => {
+    expect(resolveWebDAV({ enabled: false, provider: 'nextcloud', nextcloudUrl: 'https://nc.example.com', username: 'u', appPassword: 'p' })).toBeNull();
+    expect(resolveWebDAV(null)).toBeNull();
+    expect(resolveWebDAV(undefined)).toBeNull();
+  });
+
+  it('builds the Nextcloud files path (default provider when key is absent)', () => {
+    const config = { enabled: true, nextcloudUrl: 'https://nc.example.com/', username: 'user@host', appPassword: 'p' };
+    expect(resolveWebDAV(config)).toEqual({
+      baseUrl: 'https://nc.example.com/remote.php/dav/files/user%40host',
+      username: 'user@host',
+      appPassword: 'p',
+    });
+    expect(resolveWebDAV({ ...config, provider: 'nextcloud' })).toEqual(resolveWebDAV(config));
+  });
+
+  it('returns null for a Nextcloud config missing any required field', () => {
+    expect(resolveWebDAV({ enabled: true, provider: 'nextcloud', username: 'u', appPassword: 'p' })).toBeNull();
+    expect(resolveWebDAV({ enabled: true, provider: 'nextcloud', nextcloudUrl: 'https://nc', appPassword: 'p' })).toBeNull();
+    expect(resolveWebDAV({ enabled: true, provider: 'nextcloud', nextcloudUrl: 'https://nc', username: 'u' })).toBeNull();
+  });
+
+  it('uses the fixed Koofr WebDAV root — Koofr configs carry no URL key', () => {
+    expect(resolveWebDAV({ enabled: true, provider: 'koofr', username: 'u@example.com', appPassword: 'p' })).toEqual({
+      baseUrl: 'https://app.koofr.net/dav/Koofr',
+      username: 'u@example.com',
+      appPassword: 'p',
+    });
+  });
+
+  it('returns null for a Koofr config missing credentials', () => {
+    expect(resolveWebDAV({ enabled: true, provider: 'koofr', username: 'u' })).toBeNull();
+    expect(resolveWebDAV({ enabled: true, provider: 'koofr', appPassword: 'p' })).toBeNull();
+  });
+
+  it('uses webdavUrl for the generic webdav provider, stripping trailing slashes', () => {
+    expect(resolveWebDAV({ enabled: true, provider: 'webdav', webdavUrl: 'https://dav.example.com//', username: 'u', appPassword: 'p' })).toEqual({
+      baseUrl: 'https://dav.example.com',
+      username: 'u',
+      appPassword: 'p',
+    });
+  });
+
+  it('returns null for a generic config missing webdavUrl', () => {
+    expect(resolveWebDAV({ enabled: true, provider: 'webdav', username: 'u', appPassword: 'p' })).toBeNull();
+  });
+});

--- a/src/sync/normalizeEtag.test.js
+++ b/src/sync/normalizeEtag.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeEtag } from '@glance-apps/sync';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App.jsx's CalDAV completion sync normalizes the captured ETag before using it
+// as If-Match (syncTaskCompletionToCalDAV). That depends on the exact contract
+// of @glance-apps/sync's normalizeEtag (added in 1.6.1): strip a weak-validator
+// prefix and Apache's content-coding suffixes, pass everything else through.
+// These pin that contract so a future engine bump can't silently change it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('normalizeEtag (engine contract)', () => {
+  it('passes clean strong ETags through unchanged', () => {
+    expect(normalizeEtag('"abc123"')).toBe('"abc123"');
+  });
+
+  it('strips the weak-validator prefix (nginx gzip downgrade)', () => {
+    expect(normalizeEtag('W/"abc123"')).toBe('"abc123"');
+  });
+
+  it('strips Apache mod_deflate content-coding suffixes inside the quotes', () => {
+    expect(normalizeEtag('"abc123-gzip"')).toBe('"abc123"');
+    expect(normalizeEtag('"abc123-br"')).toBe('"abc123"');
+  });
+
+  it('handles a weak, suffixed ETag (nginx in front of Apache)', () => {
+    expect(normalizeEtag('W/"abc123-gzip"')).toBe('"abc123"');
+  });
+
+  it('passes null and undefined through (no ETag header captured)', () => {
+    expect(normalizeEtag(null)).toBeNull();
+    expect(normalizeEtag(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Audit of dayGLANCE against the Android WebDAV bug family fixed in lastGLANCE (issues #232/#233), plus the engine bump that ships the upstream half of the fix.

## Engine bump

- `@glance-apps/sync` `1.6.0` → `1.6.1`, kept as an exact pin. 1.6.1 adds ETag normalization at capture time (`normalizeEtag`, now exported) and a termination guarantee for the 412 loop (a second consecutive `PRECONDITION_FAILED` falls back to one unconditional upload). `@glance-apps/intents` (`1.4.0`) and `@glance-apps/billing` (`0.1.1`) were confirmed already pinned exact.

## Transport context

dayGLANCE does **not** use CapacitorHttp. WebDAV travels through a synchronous native bridge (`window.DayGlanceNative.httpRequest`) on both platforms — Kotlin `HttpURLConnection` on Android (`dayglance-android/.../HttpBridge.kt`), Swift `URLSession` on iOS (`dayglance-ios/.../HttpBridge.swift`) — passed as `nativeHttpRequest` to `createSyncEngine`.

## Fixes

- **ETag mangling (lastGLANCE #232):** both native bridges now send `Accept-Encoding: identity` (caller-overridable) so Apache mod_deflate can never rewrite the ETag at the source — `HttpURLConnection`/`URLSession` otherwise request gzip implicitly. The app-level CalDAV completion sync in `App.jsx` captured a raw ETag and replayed it as `If-Match` outside the engine's normalized path; it now runs the value through `normalizeEtag`.
- **Provider-key mismatches:** the legacy-folder migration notice checked `provider === 'generic'`, but the stored key is `'webdav'` — the branch never matched. Shared-users sync (`resolveWebDAV`) had no Koofr branch; Koofr configs carry no URL key, so it silently returned null. It now uses Koofr's fixed WebDAV root (`https://app.koofr.net/dav/Koofr`).
- **Dead export button (iOS):** backup export only routed **Android** to the native share sheet; iOS fell through to the `<a download>` anchor path, which WKWebView silently ignores. Added `ShareBridge.swift` (temp-dir write + `UIActivityViewController`, iPad popover anchor included), a `shareFile` case in `BridgeSchemeHandler`, and the JS guard is now `isNativeApp()`. Export failures now surface a notification instead of being swallowed.

## Did not apply

- **WebDAV verbs rejected (lastGLANCE #233):** Android's bridge already catches `ProtocolException` and sets non-core verbs (PROPFIND/MKCOL) via reflection; iOS URLSession accepts arbitrary verbs. No call sites swallow verb failures — the bridge returns `{status: 0, ok: false, error}` which every caller checks.
- **Auto-backup provider fallback:** the auto-backup provider map has only `nextcloud` and `webdav`, each with its own config fields; there is no Koofr fallback path that could build `undefined/...` URLs.

## Tests

- `src/intents/sharedUsers.test.js` — `resolveWebDAV` per-provider shapes (Nextcloud path building, Koofr fixed root, generic `webdavUrl`, missing-field nulls).
- `src/sync/normalizeEtag.test.js` — pins the engine's `normalizeEtag` contract the CalDAV path now depends on.
- Full suite 814/814, `eslint --max-warnings 0` clean, web build passes.

## Not verifiable in this environment

- Kotlin (`HttpBridge.kt`) and Swift (`ShareBridge.swift`, `BridgeSchemeHandler.swift`, `HttpBridge.swift`) changes compile-checked by eye only — no Android SDK or Xcode here. Please build both shells locally; `ShareBridge.swift` is picked up by the next `npm run ios:generate` (xcodegen).
- The `HttpURLConnection` reflection fallback for PROPFIND/MKCOL should be sanity-checked once on a modern Android device alongside the new `Accept-Encoding` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkHpDuC8GFgstiQhDRpaNJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkHpDuC8GFgstiQhDRpaNJ)_