### PR TITLE
Rebind S from Smart Schedule to Settings; fix shortcut helper labels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3617,7 +3617,7 @@ const DayPlanner = () => {
     habitsEnabled, setHabitsEnabled, setShowHabitModal,
     goalsProjectsEnabled, setGoalsProjectsEnabled, showGoalsDashboard, setShowGoalsDashboard,
     gtdFrames: myFrames, setShowRescheduleModal, setRescheduleResults, setRescheduleError,
-    setMobileActiveTab, setMobileSettingsView, setFramesModalTab, setEditingFrame, setShowFramesModal,
+    setMobileActiveTab, setMobileSettingsView, setShowSettings,
     changeDate, setSelectedDate,
     setViewMode, canShowViewCycler,
   });

--- a/src/components/ShortcutHelpModal.jsx
+++ b/src/components/ShortcutHelpModal.jsx
@@ -31,8 +31,8 @@ const ShortcutHelpModal = () => {
               ['\u2190 / \u2192', t('shortcuts.prevNextDay')],
               ['M', t('shortcuts.toggleMonthView')],
               ...(canShowViewCycler ? [
-                ['1', t('shortcuts.viewDay')],
-                ['2', t('shortcuts.view3Day')],
+                ['1', t('shortcuts.view3Day')],
+                ['2', t('shortcuts.viewDay')],
                 ['3', t('shortcuts.viewWeek')],
               ] : []),
             ].map(([key, desc]) => (
@@ -52,6 +52,7 @@ const ShortcutHelpModal = () => {
                 ['H', t('shortcuts.habitsShortcut')],
                 ['L', t('shortcuts.intentLog')],
                 ['D', t('shortcuts.toggleDarkMode')],
+                ['S', t('common.settings')],
                 ['B', t('shortcuts.backupMenu')],
                 [',', t('shortcuts.sidePanelGlance')],
                 ['.', t('shortcuts.sidePanelInbox')],
@@ -82,7 +83,6 @@ const ShortcutHelpModal = () => {
             {[
               ['N', t('shortcuts.newScheduledTask')],
               ['I', t('shortcuts.newInboxTask')],
-              ['S', t('shortcuts.smartSchedule')],
               ['E', t('shortcuts.rescheduleTasks')],
               ['V', t('shortcuts.voiceTaskInput')],
               ['R', t('shortcuts.routinesDashboard')],

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -54,8 +54,8 @@ export default function useKeyboardShortcuts({
   goalsProjectsEnabled, setGoalsProjectsEnabled, setShowGoalsDashboard,
   // reschedule ('e')
   gtdFrames, setShowRescheduleModal, setRescheduleResults, setRescheduleError,
-  // smart schedule ('s')
-  setMobileActiveTab, setMobileSettingsView, setFramesModalTab, setEditingFrame, setShowFramesModal,
+  // settings ('s')
+  setMobileActiveTab, setMobileSettingsView, setShowSettings,
   // date navigation (arrows)
   changeDate, setSelectedDate,
   // view cycler (1/2/3)
@@ -240,18 +240,15 @@ export default function useKeyboardShortcuts({
         setRescheduleError('');
       }
 
-      // 's' for smart schedule (open frames modal on schedule tab)
-      if (e.key === 's' && noModifiers && aiConfig?.enabled && aiConfig.features?.smartScheduling && gtdFrames.filter(f => f.enabled).length > 0) {
+      // 's' for settings (Smart Schedule moved off the shortcut — it stays
+      // reachable via the Inbox button, GLANCE AI prompts, and the Frames FAB)
+      if (e.key === 's' && noModifiers) {
         e.preventDefault();
         if (isMobile) {
           setMobileActiveTab('settings');
-          setMobileSettingsView('frames');
-          setFramesModalTab('schedule');
-          setEditingFrame(null);
+          setMobileSettingsView('main');
         } else {
-          setShowFramesModal(true);
-          setFramesModalTab('schedule');
-          setEditingFrame(null);
+          setShowSettings(true);
         }
       }
 


### PR DESCRIPTION
## What changed

- **`S` now opens Settings instead of Smart Schedule.** Smart Schedule is an AI feature not everyone uses, and it stays reachable through the Inbox button, the GLANCE AI prompts (when a Frame is active), and the Frames FAB on the timeline. The new binding is unconditional (no AI-config gate): desktop opens the Settings modal, mobile switches to the settings tab at its main view. The hook no longer needs `setFramesModalTab` / `setEditingFrame` / `setShowFramesModal`, so those props were dropped from the hook and its App.jsx call site.
- **Keyboard Shortcuts helper updated:** `S` removed from CREATE and added to APP (labeled with the existing `common.settings` key, so no new translation strings were needed).
- **Helper audit fix:** the view-cycler rows had `1` labeled "View: Day" and `2` labeled "View: 3-day", but the code maps `1` → the 3-day (`multi`) view and `2` → Day (`ViewCycler.jsx` `STATES = ['multi', 'day', 'week']`). Labels now match the actual bindings.

## Helper completeness audit

Cross-checked every binding in `useKeyboardShortcuts.js` plus the standalone `L` (intent activity log) handler in App.jsx against the modal: all global shortcuts are listed and correctly sectioned — nothing missing besides the label swap above. Voice-modal-internal keys (hold-Space to record, `T` for typing mode, `Enter` to accept) are scoped to that modal and not listed in the global helper, matching its current structure.

## Verification

- Full test suite 814/814, `eslint --max-warnings 0` clean, web build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkHpDuC8GFgstiQhDRpaNJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkHpDuC8GFgstiQhDRpaNJ)_