### PR TITLE
Split Welcome-modal restore into folder and file buttons

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -504,7 +504,10 @@
     "mobileSettingsToggles": "Schnellschalter für häufige Einstellungen",
     "mobileSettingsSync": "Kalender synchronisieren",
     "mobileSettingsCloud": "Cloud-Synchronisierung zwischen Geräten einrichten",
-    "mobileSettingsBackup": "Daten sichern und wiederherstellen"
+    "mobileSettingsBackup": "Daten sichern und wiederherstellen",
+    "restoreFromBackup": "Aus einem Backup wiederherstellen",
+    "restoreFromFolder": "Aus Backup-Ordner wiederherstellen",
+    "restoreFromFile": "Aus Datei wiederherstellen"
   },
   "gettingStarted": {
     "title": "Erste Schritte",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -505,7 +505,9 @@
     "mobileSettingsSync": "Sync your calendars",
     "mobileSettingsCloud": "Set up cloud sync between devices",
     "mobileSettingsBackup": "Backup and restore your data",
-    "restoreFromBackup": "Restore from a backup"
+    "restoreFromBackup": "Restore from a backup",
+    "restoreFromFolder": "Restore from Backup Folder",
+    "restoreFromFile": "Restore from File"
   },
   "gettingStarted": {
     "title": "Getting Started",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -504,7 +504,10 @@
     "mobileSettingsToggles": "Interruptores rápidos para ajustes comunes",
     "mobileSettingsSync": "Sincroniza tus calendarios",
     "mobileSettingsCloud": "Configura la sincronización en la nube entre dispositivos",
-    "mobileSettingsBackup": "Haz copia de seguridad y restaura tus datos"
+    "mobileSettingsBackup": "Haz copia de seguridad y restaura tus datos",
+    "restoreFromBackup": "Restaurar desde una copia de seguridad",
+    "restoreFromFolder": "Restaurar desde la carpeta de copias",
+    "restoreFromFile": "Restaurar desde un archivo"
   },
   "gettingStarted": {
     "title": "Primeros pasos",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -505,7 +505,9 @@
     "mobileSettingsSync": "Synchronisez vos calendriers",
     "mobileSettingsCloud": "Configurez la synchro cloud entre appareils",
     "mobileSettingsBackup": "Sauvegardez et restaurez vos données",
-    "restoreFromBackup": "Restaurer depuis une sauvegarde"
+    "restoreFromBackup": "Restaurer depuis une sauvegarde",
+    "restoreFromFolder": "Restaurer depuis le dossier de sauvegarde",
+    "restoreFromFile": "Restaurer depuis un fichier"
   },
   "gettingStarted": {
     "title": "Premiers pas",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -504,7 +504,10 @@
     "mobileSettingsToggles": "Interruttori rapidi per le impostazioni comuni",
     "mobileSettingsSync": "Sincronizza i tuoi calendari",
     "mobileSettingsCloud": "Configura la sincronizzazione cloud tra dispositivi",
-    "mobileSettingsBackup": "Fai il backup e ripristina i tuoi dati"
+    "mobileSettingsBackup": "Fai il backup e ripristina i tuoi dati",
+    "restoreFromBackup": "Ripristina da un backup",
+    "restoreFromFolder": "Ripristina dalla cartella di backup",
+    "restoreFromFile": "Ripristina da file"
   },
   "gettingStarted": {
     "title": "Per iniziare",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -504,7 +504,10 @@
     "mobileSettingsToggles": "Interruptores rápidos para definições comuns",
     "mobileSettingsSync": "Sincronize os seus calendários",
     "mobileSettingsCloud": "Configure a sincronização na nuvem entre dispositivos",
-    "mobileSettingsBackup": "Faça cópia de segurança e restaure os seus dados"
+    "mobileSettingsBackup": "Faça cópia de segurança e restaure os seus dados",
+    "restoreFromBackup": "Restaurar a partir de uma cópia de segurança",
+    "restoreFromFolder": "Restaurar da pasta de cópias de segurança",
+    "restoreFromFile": "Restaurar de um ficheiro"
   },
   "gettingStarted": {
     "title": "Primeiros passos",

--- a/src/components/DesktopWelcomeModal.jsx
+++ b/src/components/DesktopWelcomeModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Wordmark from './Wordmark';
 import {
   BarChart3, Calendar, CalendarDays, ChevronLeft, ChevronRight,
-  Cloud, Eye, FileText, Filter, Flag, FolderOpen, Gauge, GripVertical, Inbox, LayoutGrid, Mic, Moon,
+  Cloud, Eye, FileText, FileUp, Filter, Flag, FolderOpen, Gauge, GripVertical, Inbox, LayoutGrid, Mic, Moon,
   NotebookPen, Plus, RefreshCw, Search, Settings, Sun,
   Target, Zap,
 } from 'lucide-react';
@@ -51,15 +51,31 @@ const DesktopWelcomeModal = () => {
               <p className={`${textSecondary} text-xs mt-3`}>{t('onboarding.welcomeLocal')}</p>
               <p className={`${textSecondary} text-sm mt-4`}>{t('onboarding.welcomeTour')}</p>
               {folderBackup?.supported ? (
-                <button
-                  onClick={() => restoreFromBackupFolder()}
-                  className={`mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} transition-colors`}
-                >
-                  <FolderOpen size={14} /> {t('onboarding.restoreFromBackup')}
-                </button>
+                // Two distinct restore paths where Folder Backup exists: the
+                // folder flow (one dialog restores AND reconnects continuous
+                // folder backup) vs a plain exported-.json file restore. One
+                // combined button confused file-restore users with a directory
+                // picker their backup file can't be selected in.
+                <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+                  <button
+                    onClick={() => restoreFromBackupFolder()}
+                    className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} transition-colors`}
+                  >
+                    <FolderOpen size={14} /> {t('onboarding.restoreFromFolder')}
+                  </button>
+                  <label className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg cursor-pointer ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} transition-colors`}>
+                    <FileUp size={14} /> {t('onboarding.restoreFromFile')}
+                    <input
+                      type="file"
+                      accept=".json"
+                      className="hidden"
+                      onChange={(e) => { const f = e.target.files[0]; if (f) restoreBackup(f); e.target.value = ''; }}
+                    />
+                  </label>
+                </div>
               ) : (
                 <label className={`mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg cursor-pointer ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} transition-colors`}>
-                  <FolderOpen size={14} /> {t('onboarding.restoreFromBackup')}
+                  <FileUp size={14} /> {t('onboarding.restoreFromBackup')}
                   <input
                     type="file"
                     accept=".json"

--- a/src/components/MobileWelcomeModal.jsx
+++ b/src/components/MobileWelcomeModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Wordmark from './Wordmark';
 import {
   BarChart3, Calendar, ChevronLeft, ChevronRight,
-  Cloud, Eye, Filter, Flag, FolderOpen, Inbox, Mic, NotebookPen,
+  Cloud, Eye, FileUp, Filter, Flag, Inbox, Mic, NotebookPen,
   RefreshCw, Search, Settings, Target, Trash2, Zap,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -47,7 +47,7 @@ const MobileWelcomeModal = () => {
             <p className={`text-lg ${textPrimary}`}>{t('onboarding.welcomeTitle')}</p>
             <p className={`${textSecondary} text-xs mt-4`}>{t('onboarding.welcomeLocal')}</p>
             <label className={`mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg cursor-pointer ${darkMode ? 'bg-gray-700' : 'bg-stone-200'} ${textPrimary}`}>
-              <FolderOpen size={14} /> {t('onboarding.restoreFromBackup')}
+              <FileUp size={14} /> {t('onboarding.restoreFromBackup')}
               <input
                 type="file"
                 accept=".json"


### PR DESCRIPTION
## Problem

Where Folder Backup is supported (Chrome/Edge, including the installed PWA), the Welcome modal's single "Restore from a backup" button went straight to the **directory** picker. A user holding a regular exported `.json` backup couldn't select their file — and doing the natural thing (picking the folder that contains it) dead-ends with "No dayglance-data.json backup was found in that folder", because the folder flow only reads the live file. File restore was effectively unreachable from the welcome screen on exactly the browsers that have the folder feature.

## What changed

- **Chrome/Edge (`folderBackup.supported`):** two side-by-side buttons — **Restore from Backup Folder** (`FolderOpen` icon; one dialog restores and re-arms continuous folder backup) and **Restore from File** (`FileUp` icon; the classic exported-backup picker).
- **Firefox/Safari desktop and the mobile welcome modal:** keep their single file-picker button unchanged, except the icon changes `FolderOpen` → `FileUp` to match what the control actually opens (it was always a file input).
- **Locales:** `restoreFromFolder` / `restoreFromFile` added to all six locales (en/de/es/fr/it/pt). Also backfilled the previously-missing `restoreFromBackup` translations in de/es/it/pt (only en/fr had it; the others were falling back to English).

Per discussion, no tooltips and no folder-picker "recognizer" for exported snapshots — the two labeled buttons carry the distinction on their own.

## Verification

- Full test suite 814/814, `eslint --max-warnings 0` clean, web build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkHpDuC8GFgstiQhDRpaNJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkHpDuC8GFgstiQhDRpaNJ)_