### PR TITLE
Add Manually Schedule button to GLANCE frame sections with free time

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import {
   AlertCircle, AlertTriangle, BookOpen, BrainCircuit,
-  Calendar, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
+  Calendar, CalendarClock, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronUp, Clock, Filter, Flag, Hash, Inbox, LayoutGrid, Loader,
   Mic, Minus, Moon, Plus, RefreshCw, Search,
   Settings, Sparkles, Sun, Target, Trash2, X, Zap,
@@ -103,6 +103,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     goalsDashboardFocusId, setGoalsDashboardFocusId,
     getFrameInstancesForDate,
     computeAvailableSlots,
+    openFrameSchedule,
     showVoiceInput, setShowVoiceInput,
     voiceCanRecord,
     healthPerms,
@@ -1139,11 +1140,22 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                   <span className={`text-xs ${textSecondary}`}>{formatTime(section.frame.start)} – {formatTime(section.frame.end)}</span>
                 </div>
                 {section.totalAvail > 0 && (
-                  <p className="mt-1">
+                  <div className="mt-1 flex items-center gap-1">
                     <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${darkMode ? 'bg-blue-900/40 text-blue-300' : 'bg-blue-100 text-blue-700'}`}>
                       {availStr} available
                     </span>
-                  </p>
+                    {/* Manually Schedule shortcut — tray has no modal layer, so main-window only */}
+                    {!isTray && (
+                      <button
+                        onClick={() => openFrameSchedule(section.frame.frameId, section.frame.date)}
+                        className={`p-1 rounded-full transition-colors ${darkMode ? 'text-blue-300 hover:bg-blue-900/40' : 'text-blue-700 hover:bg-blue-100'}`}
+                        title={t('frames.manualSchedule')}
+                        aria-label={t('frames.manualSchedule')}
+                      >
+                        <CalendarClock size={14} />
+                      </button>
+                    )}
+                  </div>
                 )}
               </div>
               <div className="px-2 pb-1.5">

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import {
   AlertCircle, AlertTriangle, BookOpen, BrainCircuit,
-  Calendar, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
+  Calendar, CalendarClock, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronUp, Clock, ExternalLink, FileText, Filter, Flag, Inbox, LayoutGrid,
   Loader, Mic, Minus, Moon, Plus, RefreshCw,
   Search, Settings, Sparkles, Sun, Target, Trash2, X, Zap,
@@ -112,6 +112,7 @@ const MobileGlanceSection = () => {
     openRoutinesDashboard,
     enterHyperGlanceMode,
     getFrameInstancesForDate, computeAvailableSlots,
+    openFrameSchedule,
     showVoiceInput, setShowVoiceInput,
     voiceCanRecord,
     healthPerms,
@@ -1036,11 +1037,19 @@ const MobileGlanceSection = () => {
                   <span className={`text-xs ${textSecondary}`}>{formatTime(section.frame.start)} – {formatTime(section.frame.end)}</span>
                 </div>
                 {section.totalAvail > 0 && (
-                  <p className="mt-1">
+                  <div className="mt-1 flex items-center gap-1">
                     <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${darkMode ? 'bg-blue-900/40 text-blue-300' : 'bg-blue-100 text-blue-700'}`}>
                       {availStr} available
                     </span>
-                  </p>
+                    <button
+                      onClick={() => openFrameSchedule(section.frame.frameId, section.frame.date)}
+                      className={`p-1 rounded-full transition-colors ${darkMode ? 'text-blue-300 active:bg-blue-900/40' : 'text-blue-700 active:bg-blue-100'}`}
+                      title={t('frames.manualSchedule')}
+                      aria-label={t('frames.manualSchedule')}
+                    >
+                      <CalendarClock size={14} />
+                    </button>
+                  </div>
                 )}
               </div>
               <div className="px-2 pb-1.5">


### PR DESCRIPTION
## What changed

When a Frame section in the GLANCE agenda has available time, the availability badge row now includes a small `CalendarClock` icon button that opens the **Manually Schedule** modal for that frame/date directly (`openFrameSchedule`). Previously the modal was only reachable via the frame's context menu on the timeline.

- **Gate:** the button renders exactly where the availability badge does (`section.totalAvail > 0`), so frames with no free time — or fully blocked by calendar events — never show it.
- **Both agenda surfaces:** `GlanceSidebar.jsx` (desktop/tablet/tray variants) and `MobileGlanceSection.jsx`. In the tray variant the button is hidden, since the tray window doesn't render the app's modal layer.
- **Icon:** `CalendarClock` rather than plain `Clock` — a clock as requested, but distinct from the frame context menu's `Clock`, which already means "Adjust time" there.
- **i18n:** reuses the existing `frames.manualSchedule` string (present in all six locales) for the tooltip and `aria-label`; no new keys.

## Verification

- Full test suite 814/814, `eslint --max-warnings 0` clean, web build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkHpDuC8GFgstiQhDRpaNJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkHpDuC8GFgstiQhDRpaNJ)_