### PR TITLE
Show current deadline in the deadline picker popover

### DIFF
--- a/src/components/DeadlinePickerPopover.jsx
+++ b/src/components/DeadlinePickerPopover.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useLayoutEffect, useEffect } from 'react';
 import { ChevronLeft, ChevronRight, Calendar, X } from 'lucide-react';
-import { dateToString } from '../utils/taskUtils.js';
+import { dateToString, formatDeadlineDate } from '../utils/taskUtils.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 
 const DeadlinePickerPopover = ({ taskId, currentDeadline, onClose }) => {
@@ -222,6 +222,10 @@ const DeadlinePickerPopover = ({ taskId, currentDeadline, onClose }) => {
           {currentDeadline && (
             <>
               <div className={`border-t ${borderClass} my-1`}></div>
+              <div className={`px-3 py-1 text-sm font-medium ${darkMode ? 'text-blue-400' : 'text-blue-600'} flex items-center gap-2`}>
+                <Calendar size={14} />
+                Due {formatDeadlineDate(currentDeadline)}
+              </div>
               <button
                 onClick={() => clearDeadline(taskId)}
                 className={`w-full text-left px-3 py-2 rounded text-sm text-red-500 ${hoverBg} flex items-center gap-2`}


### PR DESCRIPTION
## What changed

When a task already has a deadline, `DeadlinePickerPopover` now shows the currently set date in blue — `Due Today` / `Due Tomorrow` / `Due Jul 24` — between the divider and the **Clear deadline** entry, so you can see exactly what you're about to clear (or replace) without leaving the menu.

- Reuses the existing `formatDeadlineDate` util for the Today/Tomorrow/short-date wording, matching how deadlines are labeled elsewhere in the app.
- Non-interactive label with a `Calendar` icon so it aligns with the other rows; blue shades follow the app's dark/light convention (`text-blue-400` / `text-blue-600`).
- The "Due" prefix keeps it from reading as another quick-pick option.

## Verification

- Full test suite 814/814, `eslint --max-warnings 0` clean, web build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkHpDuC8GFgstiQhDRpaNJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkHpDuC8GFgstiQhDRpaNJ)_