### PR TITLE
Translate RevenueCat error codes to shared billing-event vocabulary

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/SubscriptionBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/SubscriptionBridge.swift
@@ -140,11 +140,42 @@ final class SubscriptionBridge {
                     fireBillingEvent(status: "success", code: 0, message: "ok", productId: productId)
                 }
             } catch {
-                let rcError = error as? RevenueCat.ErrorCode
-                let code = rcError?.rawValue ?? 0
-                fireBillingEvent(status: "error", code: code, message: error.localizedDescription, productId: productId)
+                fireBillingError(error, productId: productId)
             }
         }
+    }
+
+    /// Delivers a thrown purchase/restore error to JS in the shared billing-event
+    /// code space (Play Billing response codes) that @glance-apps/billing's
+    /// billingErrorMessage understands. RevenueCat's raw ErrorCode values collide
+    /// with that vocabulary — e.g. productAlreadyPurchased is raw value 6, which
+    /// the paywall would render as "Network error" — so translate instead of
+    /// passing rawValue through.
+    private func fireBillingError(_ error: Error, productId: String) {
+        guard let rcError = error as? RevenueCat.ErrorCode else {
+            fireBillingEvent(status: "error", code: 0, message: error.localizedDescription, productId: productId)
+            return
+        }
+        // A dismissed StoreKit sheet can surface as a thrown purchaseCancelledError
+        // rather than result.userCancelled — not an error the user should see.
+        if rcError == .purchaseCancelledError {
+            fireBillingEvent(status: "cancelled", code: -1, message: "User cancelled", productId: productId)
+            return
+        }
+        let code: Int
+        switch rcError {
+        case .purchaseNotAllowedError:
+            code = 3 // "Billing is not available on this device."
+        case .storeProblemError, .productNotAvailableForPurchaseError:
+            code = 4 // "This subscription isn't available right now. Please try again later."
+        case .networkError, .offlineConnectionError, .productRequestTimedOut:
+            code = 6 // "Network error. Please check your connection and try again."
+        case .productAlreadyPurchasedError, .receiptAlreadyInUseError:
+            code = 7 // "You already own this item."
+        default:
+            code = 0 // "Something went wrong with the purchase. Please try again."
+        }
+        fireBillingEvent(status: "error", code: code, message: error.localizedDescription, productId: productId)
     }
 
     func restorePurchases() {
@@ -159,7 +190,7 @@ final class SubscriptionBridge {
                                  message: active ? "restore_complete_active" : "restore_complete",
                                  productId: productId)
             } catch {
-                fireBillingEvent(status: "error", code: 0, message: error.localizedDescription, productId: "")
+                fireBillingError(error, productId: "")
             }
         }
     }


### PR DESCRIPTION
## Summary

The iOS bridge passed RevenueCat `ErrorCode` raw values straight through to the JS billing-event channel, but `@glance-apps/billing`'s `billingErrorMessage` interprets codes in the **Play Billing response-code** space. The two vocabularies collide, so iOS purchase failures showed wrong or unhelpfully generic messages on the paywall:

| RevenueCat error | Raw value | Message the paywall showed |
|---|---|---|
| `productAlreadyPurchasedError` | 6 | "Network error. Please check your connection…" ❌ |
| `receiptAlreadyInUseError` | 7 | "You already own this item." (coincidentally right) |
| `productNotAvailableForPurchaseError` | 5 | generic "Something went wrong…" |
| `storeProblemError` | 2 | generic "Something went wrong…" |
| `networkError` / `offlineConnectionError` | 10 / 35 | generic "Something went wrong…" |

This is the same failure surface that showed up in App Store review — the reviewer's purchase attempt failed with the catch-all message instead of something diagnostic.

## Changes

- Add `fireBillingError(_:productId:)` to `SubscriptionBridge.swift` that maps RevenueCat errors into the code vocabulary `billingErrorMessage` understands (billing not allowed → 3, product/store unavailable → 4, network → 6, already owned → 7, everything else → 0/generic).
- Treat a *thrown* `purchaseCancelledError` as a cancellation event, matching the existing `result.userCancelled` path — a dismissed StoreKit sheet no longer flashes "Product not found."
- Route `restorePurchases()` failures through the same translation so restore errors (previously always generic) get accurate messages too.

No JS/web changes — the shared package's message table is unchanged; the bridge now speaks its language.

## Testing

- Swift can't be compiled in this environment (no Xcode toolchain); all `ErrorCode` cases used exist in RevenueCat 5.x, which `project.yml` pins via `minorVersion: "5.0.0"`.
- Behavior is verifiable on device by triggering an airplane-mode purchase (should now show the network message rather than the generic one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_