### PR TITLE
Fix the two Xcode warnings in the iOS bridges

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/CalendarBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/CalendarBridge.swift
@@ -56,7 +56,11 @@ final class CalendarBridge {
             case .restricted:    status = "restricted"
             case .denied:        status = "denied"
             case .authorized:    status = "authorized"
-            @unknown default:    status = "unknown"
+            // Plain default (not @unknown) on purpose: it absorbs the iOS 17+
+            // cases (.fullAccess/.writeOnly), which can never be returned on the
+            // OS versions this branch runs on, without tripping the
+            // switch-must-be-exhaustive warning.
+            default:             status = "unknown"
             }
         }
         return #"{"status":"\#(status)"}"#

--- a/dayglance-ios/DayGlance/Bridges/SubscriptionBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/SubscriptionBridge.swift
@@ -243,7 +243,7 @@ final class SubscriptionBridge {
     }
 
     private func checkTrialEligibilityInBackground() {
-        Purchases.shared.checkTrialOrIntroDiscountEligibility(["com.dayglance.pro.yearly"]) { results in
+        Purchases.shared.checkTrialOrIntroDiscountEligibility(productIdentifiers: ["com.dayglance.pro.yearly"]) { results in
             guard let status = results["com.dayglance.pro.yearly"]?.status else { return }
             switch status {
             case .eligible:


### PR DESCRIPTION
## Summary

First of the v4.1.0 cleanup PRs — resolves both Xcode build warnings flagged during the 4.0.0 release build.

- **CalendarBridge** — the pre-iOS-17 authorization-status switch tripped "Switch must be exhaustive" because the SDK's `EKAuthorizationStatus` enum includes the iOS 17+ cases (`.fullAccess`, `.writeOnly`) at compile time, even though they can never be returned on the OS versions that branch runs on. Replaced `@unknown default` with a plain `default` (with a comment explaining why), which absorbs those cases without changing behavior — anything unexpected still reports `"unknown"`.
- **SubscriptionBridge** — adopted the renamed `checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)`; the unlabeled variant is deprecated in RevenueCat 5.x. Identical behavior, just the new label.

The third build warning (the "Copy Web Assets" script phase running every build) is intentionally untouched — re-running that phase every build is the safe behavior for keeping the web bundle current.

## Testing

- No behavior change on any reachable code path; both edits are warning hygiene.
- Needs an Xcode build to confirm both warnings are gone (Swift isn't compilable in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_