### PR TITLE
Update CLAUDE.md: all App.jsx decomposition candidates are done

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,17 +32,15 @@ Do **not** post comments to GitHub issues directly using `mcp__github__add_issue
 
 # App.jsx — Ongoing Decomposition
 
-`App.jsx` started at ~30,000 lines and has been reduced to ~8,500 across three refactor passes. It is still the largest file and has known areas worth extracting **opportunistically** — i.e. when a feature or bugfix already touches that area, not as a dedicated refactor pass.
+`App.jsx` started at ~30,000 lines and has been reduced to ~9,600 across four refactor passes. All previously listed extraction candidates are done:
 
-## Remaining candidates
-
-- **ICS/CalDAV parser** (`~lines 2900–3200`): RRULE expansion, VTODO handling, and date parsing are self-contained utility logic with no UI dependency. Could move to `src/utils/icsParser.js`.
-- **Voice input pipeline**: The `voiceParseAndApply`, `voiceApplyAllChanges`, and related callbacks are substantial and cohesive. Candidate for a `useVoiceInput` hook.
-- **Morning summary / AI features**: `generateMorningSummary` and surrounding AI callback logic could become a `useMorningSummary` hook.
-- **Obsidian sync handlers**: The inline Obsidian sync callbacks could move to a `useObsidianSync` hook (the pattern is already established with `useTaskActions`, `useDragDrop`, etc.).
-- **Native calendar integration**: The `nativeEventToTask` function and fetch logic around Android calendar sync are self-contained and could move to `src/utils/nativeCalendar.js`.
+- **ICS/CalDAV parser** → `src/utils/icsParser.js` (with tests)
+- **Voice input pipeline** → `src/hooks/useVoiceInput.js`
+- **Morning summary / evening reflection** → `src/hooks/useDailyBriefings.js`
+- **Obsidian sync handlers** → `src/hooks/useObsidianSync.js`
+- **Native calendar integration** → `src/utils/nativeCalendar.js` (with tests)
 
 ## Guidance
 
-When adding a new feature or fixing a bug in one of these areas, consider extracting the surrounding logic at the same time if it keeps the diff focused and doesn't bloat the PR scope. Don't extract for its own sake — only when it makes the change cleaner.
+App.jsx is still the largest file. When adding a new feature or fixing a bug there, consider extracting the surrounding logic into a hook (`src/hooks/`) or pure utility module (`src/utils/`, with tests) at the same time — the deps-object hook pattern (`useTaskActions`, `useObsidianSync`, etc.) is well established. Extract opportunistically, when it keeps the diff focused; don't extract for its own sake.
 


### PR DESCRIPTION
## Summary

**Stacked PR #6 (final) of the v4.1.0 pile** — targets the voice-input branch (#1236). Merge order: #1232 → #1233 → #1234 → #1235 → #1236 → this.

Rewrites the "App.jsx — Ongoing Decomposition" section of CLAUDE.md: every listed extraction candidate is now complete (the native-calendar one had already been done before this stack), so the stale candidate list is replaced with a record of where each piece landed, plus updated guidance pointing future work at the established hook/utility patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_