### PR TITLE
Add project colors with copy-at-creation inheritance (A1)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,7 +23,7 @@ import useFolderBackup from './hooks/useFolderBackup.js';
 import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOnlyTask, getLinkUrl, hasOnlySubtasks, renderTitle, highlightMatch, renderTitleWithoutTags, extractShareTitle } from './utils/textFormatting.jsx';
 import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate, computeTaskCalendarTombstones, computeRecurringSeriesTombstones } from './utils/taskUtils.js';
 import { parseICS, parseDatetime, filterByDateWindow, expandMultiDayEvent } from './utils/icsParser.js';
-import { TASK_COLORS, TAILWIND_TO_HEX, taskColorToHex } from './utils/colorUtils.js';
+import { TASK_COLORS, TAILWIND_TO_HEX, taskColorToHex, getProjectColor } from './utils/colorUtils.js';
 import { calculateGoalProgress } from './utils/goalProgress.js';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from './constants/habits.js';
 import { FRAME_COLORS, DAY_LABELS } from './constants/frames.js';
@@ -3857,12 +3857,13 @@ const DayPlanner = () => {
     );
     if (alreadyInstantiated) return;
     const parentGoal = project.goalId ? goals.find(g => g.id === project.goalId) : null;
-    const taskColor = parentGoal?.color || 'bg-blue-500';
+    const taskColor = getProjectColor(project, parentGoal);
     const newTasks = templates.map(tmpl => ({
       id: `hg-${project.id}-${sessionDate}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       title: tmpl.name,
       ...(tmpl.notes ? { notes: tmpl.notes } : {}),
       color: taskColor,
+      ...(project.assignedUserSyncIds?.length ? { assignedUserSyncIds: project.assignedUserSyncIds } : {}),
       projectId: project.id,
       hyperglanceSessionDate: sessionDate,
       completed: false,

--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -9,6 +9,7 @@ import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
 import LastGlanceBadge from './LastGlanceBadge.jsx';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
+import { getProjectColor } from '../utils/colorUtils.js';
 
 const DesktopNewTaskModal = () => {
   const { t } = useTranslation();
@@ -204,7 +205,15 @@ const DesktopNewTaskModal = () => {
                       const pid = e.target.value || null;
                       const proj = pid ? projects.find(p => p.id === pid) : null;
                       const parentGoal = proj?.goalId ? goals.find(g => g.id === proj.goalId) : null;
-                      setNewTask({ ...newTask, projectId: pid, ...(parentGoal?.color ? { color: parentGoal.color } : {}) });
+                      // Copy-at-creation inheritance: adopting a project stamps its
+                      // effective color and assigned users onto the draft task
+                      // (deselecting clears the inherited users).
+                      setNewTask({
+                        ...newTask,
+                        projectId: pid,
+                        ...(proj ? { color: getProjectColor(proj, parentGoal) } : {}),
+                        assignedUserSyncIds: proj?.assignedUserSyncIds || [],
+                      });
                     }}
                     className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
                   >

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -8,6 +8,7 @@ import { SOURCE_APPS } from '../native.js';
 import LastGlanceBadge from './LastGlanceBadge.jsx';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
+import { getProjectColor } from '../utils/colorUtils.js';
 
 const MobileNewTaskModal = () => {
   const { t } = useTranslation();
@@ -170,7 +171,15 @@ const MobileNewTaskModal = () => {
                       const pid = e.target.value || null;
                       const proj = pid ? projects.find(p => p.id === pid) : null;
                       const parentGoal = proj?.goalId ? goals.find(g => g.id === proj.goalId) : null;
-                      setNewTask({ ...newTask, projectId: pid, ...(parentGoal?.color ? { color: parentGoal.color } : {}) });
+                      // Copy-at-creation inheritance: adopting a project stamps its
+                      // effective color and assigned users onto the draft task
+                      // (deselecting clears the inherited users).
+                      setNewTask({
+                        ...newTask,
+                        projectId: pid,
+                        ...(proj ? { color: getProjectColor(proj, parentGoal) } : {}),
+                        assignedUserSyncIds: proj?.assignedUserSyncIds || [],
+                      });
                     }}
                     className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
                   >

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -35,7 +35,7 @@ import {
 } from 'lucide-react';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
-import { TASK_COLORS, TAILWIND_TO_HEX, hexToRgba } from '../../utils/colorUtils.js';
+import { TASK_COLORS, TAILWIND_TO_HEX, hexToRgba, PROJECT_FALLBACK_COLOR } from '../../utils/colorUtils.js';
 import { HG_ICON_GROUPS, HG_COLORS, HG_DAYS } from '../../hooks/useHyperGlance.js';
 import { dateToString } from '../../utils/taskUtils.js';
 import { calculateGoalProgress } from '../../utils/goalProgress.js';
@@ -133,6 +133,9 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
   );
   const [targetDate, setTargetDate] = useState(initial?.targetDate || '');
   const [color, setColor] = useState(initial?.color || TASK_COLORS[0].class);
+  // New goals inherit the selected area's color until the user explicitly
+  // picks one (copy-at-creation: editing an existing goal never auto-changes).
+  const [colorTouched, setColorTouched] = useState(!!initial);
   const [status, setStatus] = useState(initial?.status || 'active');
   const [assignedUserSyncIds, setAssignedUserSyncIds] = useState(initial?.assignedUserSyncIds || []);
   const [trackInLifeGlance, setTrackInLifeGlance] = useState(false);
@@ -198,7 +201,14 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
         <label className={`text-xs font-medium ${textSecondary}`}>{t('goals.area')}</label>
         <select
           value={areaId}
-          onChange={e => setAreaId(e.target.value)}
+          onChange={e => {
+            const nextAreaId = e.target.value;
+            setAreaId(nextAreaId);
+            if (!colorTouched) {
+              const area = nextAreaId ? areas.find(a => a.id === nextAreaId) : null;
+              setColor(area?.color || TASK_COLORS[0].class);
+            }
+          }}
           className={`px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
             darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'
           }`}
@@ -247,7 +257,7 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
             <button
               key={c.class}
               type="button"
-              onClick={() => setColor(c.class)}
+              onClick={() => { setColor(c.class); setColorTouched(true); }}
               className={`w-7 h-7 rounded-full ${c.class} transition-transform ${
                 color === c.class ? 'ring-2 ring-offset-2 ring-blue-500 scale-110' : 'hover:scale-110'
               }`}
@@ -387,7 +397,19 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
   const [description, setDescription] = useState(initial?.description || '');
   const [goalId, setGoalId] = useState(initial?.goalId || defaultGoalId || '');
   const [status, setStatus] = useState(initial?.status || 'active');
-  const [assignedUserSyncIds, setAssignedUserSyncIds] = useState(initial?.assignedUserSyncIds || []);
+  // Copy-at-creation inheritance: a new project defaults its color and assigned
+  // users from the selected goal (standalone default: blue / nobody) and keeps
+  // following the goal picker until the user explicitly overrides. Editing an
+  // existing project never auto-changes either field.
+  const initialGoal = (initial?.goalId || defaultGoalId)
+    ? goals.find(g => g.id === (initial?.goalId || defaultGoalId))
+    : null;
+  const [color, setColor] = useState(initial?.color || initialGoal?.color || PROJECT_FALLBACK_COLOR);
+  const [colorTouched, setColorTouched] = useState(!!initial);
+  const [assignedUserSyncIds, setAssignedUserSyncIds] = useState(
+    initial?.assignedUserSyncIds || (initial ? [] : initialGoal?.assignedUserSyncIds || [])
+  );
+  const [usersTouched, setUsersTouched] = useState(!!initial);
 
   // ── hyperGLANCE state ────────────────────────────────────────────────────
   const initHG = initial?.hyperglance || {};
@@ -446,7 +468,7 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
       completions: initHG.completions || [],
       createdAt: initHG.createdAt || new Date().toISOString(),
     } : null;
-    onSave({ title: title.trim(), description: description.trim(), goalId: goalId || undefined, status, assignedUserSyncIds, hyperglance });
+    onSave({ title: title.trim(), description: description.trim(), goalId: goalId || undefined, status, color, assignedUserSyncIds, hyperglance });
   };
 
   const activeGoals = goals.filter(g => g.status !== 'archived');
@@ -494,7 +516,13 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
         <label className={`text-xs font-medium ${textSecondary}`}>{t('goals.goalOptional')}</label>
         <select
           value={goalId}
-          onChange={e => setGoalId(e.target.value)}
+          onChange={e => {
+            const nextGoalId = e.target.value;
+            setGoalId(nextGoalId);
+            const goal = nextGoalId ? goals.find(g => g.id === nextGoalId) : null;
+            if (!colorTouched) setColor(goal?.color || PROJECT_FALLBACK_COLOR);
+            if (!usersTouched) setAssignedUserSyncIds(goal?.assignedUserSyncIds || []);
+          }}
           className={`px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
             darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'
           }`}
@@ -506,12 +534,30 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
         </select>
       </div>
 
+      {/* Color — defaults to the goal's color (blue when standalone) until overridden */}
+      <div className="flex flex-col gap-1.5">
+        <label className={`text-xs font-medium ${textSecondary}`}>{t('common.color')}</label>
+        <div className="grid grid-cols-9 gap-2 w-full">
+          {TASK_COLORS.map(c => (
+            <button
+              key={c.class}
+              type="button"
+              onClick={() => { setColor(c.class); setColorTouched(true); }}
+              className={`w-7 h-7 rounded-full ${c.class} transition-transform ${
+                color === c.class ? 'ring-2 ring-offset-2 ring-blue-500 scale-110' : 'hover:scale-110'
+              }`}
+              aria-label={c.name}
+            />
+          ))}
+        </div>
+      </div>
+
       {/* Assigned users — multi-user only */}
       <UserAssignmentPicker
         enabled={multiUserEnabled}
         users={users}
         value={assignedUserSyncIds}
-        onChange={setAssignedUserSyncIds}
+        onChange={ids => { setAssignedUserSyncIds(ids); setUsersTouched(true); }}
         darkMode={darkMode}
         borderClass={borderClass}
         textSecondary={textSecondary}

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -10,7 +10,7 @@ import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
 import { calculateProjectProgress, isProjectStalled } from '../../utils/projectProgress.js';
-import { TAILWIND_TO_HEX, hexToRgba } from '../../utils/colorUtils.js';
+import { TAILWIND_TO_HEX, hexToRgba, getProjectColor } from '../../utils/colorUtils.js';
 import ProjectProgress from './ProjectProgress.jsx';
 import NotesSubtasksPanel from '../NotesSubtasksPanel.jsx';
 import { renderTitle, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, getLinkUrl, isObsidianNoteOnlyTask } from '../../utils/textFormatting.jsx';
@@ -97,7 +97,11 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
   const handleDelete = () => setShowConfirm(true);
 
   const parentGoal = project.goalId ? goals.find(g => g.id === project.goalId) : null;
-  const goalHex = parentGoal ? toHex(parentGoal.color || 'bg-blue-500') : null;
+  // Effective project color (own color → goal color → blue). Standalone cards
+  // keep goalHex null for now — the colored treatment for them lands with the
+  // standalone-card UI pass.
+  const projectColor = getProjectColor(project, parentGoal);
+  const goalHex = parentGoal ? toHex(projectColor) : null;
 
   // Multi-user: only count/show the current user's tasks within the project.
   const allTasks = [...tasks, ...unscheduledTasks].filter(isVisibleForUser);
@@ -232,13 +236,14 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
       id: crypto.randomUUID(),
       title,
       duration: 30,
-      color: parentGoal?.color || 'bg-blue-500',
+      color: projectColor,
       completed: false,
       isAllDay: false,
       notes: '',
       subtasks: [],
       priority: 0,
       projectId: project.id,
+      ...(project.assignedUserSyncIds?.length ? { assignedUserSyncIds: project.assignedUserSyncIds } : {}),
       lastModified: new Date().toISOString(),
     };
     setUnscheduledTasks(prev => [...prev, newTask]);

--- a/src/utils/colorUtils.js
+++ b/src/utils/colorUtils.js
@@ -82,3 +82,16 @@ export const taskColorToHex = (color, nativeCalendarColor) => {
   if (color.startsWith('#')) return color;
   return TAILWIND_TO_HEX[color] || '#3b82f6';
 };
+
+/** Default color for projects with no explicit color and no parent goal. */
+export const PROJECT_FALLBACK_COLOR = 'bg-blue-500';
+
+/**
+ * Effective display color for a project: its own color if one was picked,
+ * else the parent goal's color, else the standalone default (blue).
+ * Colors are copied at creation (a later goal-color change does not ripple
+ * into existing projects that saved their own color), but projects created
+ * before the color field existed fall through to the goal here.
+ */
+export const getProjectColor = (project, parentGoal) =>
+  project?.color || parentGoal?.color || PROJECT_FALLBACK_COLOR;

--- a/src/utils/colorUtils.test.js
+++ b/src/utils/colorUtils.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { getProjectColor, PROJECT_FALLBACK_COLOR } from './colorUtils.js';
+
+describe('getProjectColor', () => {
+  it('prefers the project own color', () => {
+    expect(getProjectColor({ color: 'bg-red-500' }, { color: 'bg-green-500' })).toBe('bg-red-500');
+  });
+
+  it('falls back to the parent goal color when the project has none', () => {
+    expect(getProjectColor({}, { color: 'bg-green-500' })).toBe('bg-green-500');
+  });
+
+  it('defaults to blue for standalone projects without a color', () => {
+    expect(getProjectColor({}, null)).toBe(PROJECT_FALLBACK_COLOR);
+    expect(getProjectColor(undefined, undefined)).toBe(PROJECT_FALLBACK_COLOR);
+  });
+});


### PR DESCRIPTION
## Summary

**First feature PR of the Goals & Projects workstream (A1)** — stacked on the v4.1.0 refactor pile (targets #1237; merge the stack bottom-up first: #1232 → … → #1237 → this).

Projects now have their own `color` field with a picker in the New/Edit Project form, and color/user inheritance flows through the whole creation chain. All inheritance is **copy-at-creation** (per our design discussion): values are stamped when the child is created; later changes to the parent never ripple into existing children.

- **Area → Goal**: a new goal's color defaults to the selected area's color, live-following the area dropdown until the user explicitly picks a color. Editing an existing goal never auto-changes it.
- **Goal → Project**: the new color picker defaults to the parent goal's color (blue for standalone), and assigned users default from the goal — both follow the goal dropdown until explicitly overridden, then save on the project.
- **Project → Task**: tasks created in a project context inherit the project's effective color and assigned users at three sites: the project-card quick-add, hyperGLANCE template-task instantiation, and the project picker in both new-task modals (which previously copied only the goal's color and ignored users).

**Effective color** is resolved by a new `getProjectColor(project, parentGoal)` helper in `colorUtils` (own color → goal color → blue), so projects created before this field existed keep exactly their current goal-derived appearance. `ProjectCard`'s color bar now honors a project-level override; standalone cards deliberately stay uncolored until the A2 card-UI pass.

## Testing

- New `colorUtils.test.js` covers the resolution chain (3 tests).
- Full suite passes: 833 tests / 58 files; `vite build` clean.
- Manual checks worth doing on merge: create a project inside a goal and confirm the picker preselects the goal color; override it and confirm the card bar changes; quick-add a task on a user-assigned project and confirm the task inherits the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_