### PR TITLE
Project card UI: standalone colors, eyeball details toggle, per-goal stalled opt-out (A2)

### DIFF
--- a/src/components/goals/GoalCard.jsx
+++ b/src/components/goals/GoalCard.jsx
@@ -55,7 +55,9 @@ const GoalCard = forwardRef(
     }
 
     // Caution: goal is overdue or has at least one stalled child project
-    const hasStalledProject = projects.some(p => isProjectStalled(p.id, allTasks, p));
+    // Per-goal opt-out: hideStalled suppresses the stalled contribution to the
+    // caution indicator (overdue-based caution is unaffected).
+    const hasStalledProject = !goal.hideStalled && projects.some(p => isProjectStalled(p.id, allTasks, p));
     const showCaution = isOverdue || hasStalledProject;
     // All non-archived projects complete → offer one-click completion
     const nonArchivedProjects = projects.filter(p => p.status !== 'archived');

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -323,15 +323,20 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
       {/* Hide Stalled flags — per-goal opt-out for slow-burn goals. Suppresses
           the Stalled badge on this goal's projects and the goal's stalled-based
           caution indicator (overdue caution is unaffected). */}
-      <label className="flex items-center gap-2 cursor-pointer select-none">
-        <input
-          type="checkbox"
-          checked={hideStalled}
-          onChange={e => setHideStalled(e.target.checked)}
-          className="w-4 h-4 rounded accent-blue-500"
-        />
-        <span className={`text-sm ${textSecondary}`}>Hide Stalled flags for this goal</span>
-      </label>
+      <div className="flex flex-col gap-1">
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={hideStalled}
+            onChange={e => setHideStalled(e.target.checked)}
+            className="w-4 h-4 rounded accent-blue-500"
+          />
+          <span className={`text-sm ${textSecondary}`}>Hide Stalled flags for this goal</span>
+        </label>
+        <p className={`text-xs ${textSecondary} opacity-60 ml-6`}>
+          Hides the Stalled badge on this goal and all of its child projects.
+        </p>
+      </div>
 
       {/* Track in lifeGLANCE — checkbox when not yet shared (new OR existing goal),
           read-only indicator once it already lives in lifeGLANCE. */}

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -138,6 +138,7 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
   const [colorTouched, setColorTouched] = useState(!!initial);
   const [status, setStatus] = useState(initial?.status || 'active');
   const [assignedUserSyncIds, setAssignedUserSyncIds] = useState(initial?.assignedUserSyncIds || []);
+  const [hideStalled, setHideStalled] = useState(initial?.hideStalled || false);
   const [trackInLifeGlance, setTrackInLifeGlance] = useState(false);
 
   // "Completed" only available when all child projects are completed (or none exist)
@@ -155,7 +156,7 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!title.trim()) return;
-    onSave({ title: title.trim(), description: description.trim(), areaId: areaId || undefined, startDate: startDate || undefined, targetDate: targetDate || undefined, color, status, assignedUserSyncIds, trackInLifeGlance: showLifeGlanceCheckbox && !alreadyShared && trackInLifeGlance });
+    onSave({ title: title.trim(), description: description.trim(), areaId: areaId || undefined, startDate: startDate || undefined, targetDate: targetDate || undefined, color, status, assignedUserSyncIds, hideStalled, trackInLifeGlance: showLifeGlanceCheckbox && !alreadyShared && trackInLifeGlance });
   };
 
   return (
@@ -318,6 +319,19 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
           )}
         </div>
       )}
+
+      {/* Hide Stalled flags — per-goal opt-out for slow-burn goals. Suppresses
+          the Stalled badge on this goal's projects and the goal's stalled-based
+          caution indicator (overdue caution is unaffected). */}
+      <label className="flex items-center gap-2 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={hideStalled}
+          onChange={e => setHideStalled(e.target.checked)}
+          className="w-4 h-4 rounded accent-blue-500"
+        />
+        <span className={`text-sm ${textSecondary}`}>Hide Stalled flags for this goal</span>
+      </label>
 
       {/* Track in lifeGLANCE — checkbox when not yet shared (new OR existing goal),
           read-only indicator once it already lives in lifeGLANCE. */}

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import ConfirmDialog from '../ConfirmDialog.jsx';
 import {
   AlertTriangle, BookOpen, Calendar, CheckCircle2, CheckSquare, ChevronDown,
-  Edit2, ExternalLink, FileText, GripVertical, LogIn, Plus,
+  Edit2, ExternalLink, Eye, EyeOff, FileText, GripVertical, LogIn, Plus,
   Square, Trash2, X, Zap,
 } from 'lucide-react';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
@@ -57,7 +57,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
     mobileActiveTab,
   } = useDayPlannerCtx();
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
-  const { goals, deleteProject, generateAISubtasks, aiSubtasksLoadingForTask, aiConfig, showGoalsDashboard, enterHyperGlanceMode, isVisibleForUser } = useFeaturesCtx();
+  const { goals, deleteProject, updateProject, generateAISubtasks, aiSubtasksLoadingForTask, aiConfig, showGoalsDashboard, enterHyperGlanceMode, isVisibleForUser } = useFeaturesCtx();
 
   const isScheduled = (t) => !!tasks.find(s => s.id === t.id);
 
@@ -97,11 +97,13 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
   const handleDelete = () => setShowConfirm(true);
 
   const parentGoal = project.goalId ? goals.find(g => g.id === project.goalId) : null;
-  // Effective project color (own color → goal color → blue). Standalone cards
-  // keep goalHex null for now — the colored treatment for them lands with the
-  // standalone-card UI pass.
+  // Effective project color (own color → goal color → blue); standalone cards
+  // are colored the same way as goal children.
   const projectColor = getProjectColor(project, parentGoal);
-  const goalHex = parentGoal ? toHex(projectColor) : null;
+  const projectHex = toHex(projectColor);
+  // Eyeball toggle (standalone cards only): hides task count, progress bars,
+  // and completed tasks. Persisted on the project so it syncs and survives reloads.
+  const detailsHidden = !parentGoal && !!project.detailsHidden;
 
   // Multi-user: only count/show the current user's tasks within the project.
   const allTasks = [...tasks, ...unscheduledTasks].filter(isVisibleForUser);
@@ -110,7 +112,8 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
   const totalCount = projectTasks.length;
   const progress = calculateProjectProgress(project.id, allTasks);
   const hasHGSession = !!getActiveHGInstance(project, currentTimeMinutes);
-  const stalled = !!project.goalId && !hasHGSession && isProjectStalled(project.id, allTasks, project);
+  // Per-goal opt-out: a goal with hideStalled suppresses the badge on its projects.
+  const stalled = !!project.goalId && !parentGoal?.hideStalled && !hasHGSession && isProjectStalled(project.id, allTasks, project);
 
   // All project tasks: unscheduled (in array order) then scheduled (by date), completed last
   const projectUnscheduled = unscheduledTasks.filter(t => t.projectId === project.id && !t.archived && isVisibleForUser(t));
@@ -123,8 +126,11 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
     ...projectUnscheduled.filter(t => t.completed),
   ];
   const VISIBLE_COUNT = 3;
-  const hasMore = allProjectDisplayTasks.length > VISIBLE_COUNT;
-  const visibleTasks = tasksExpanded ? allProjectDisplayTasks : allProjectDisplayTasks.slice(0, VISIBLE_COUNT);
+  const displayableTasks = detailsHidden
+    ? allProjectDisplayTasks.filter(t => !t.completed)
+    : allProjectDisplayTasks;
+  const hasMore = displayableTasks.length > VISIBLE_COUNT;
+  const visibleTasks = tasksExpanded ? displayableTasks : displayableTasks.slice(0, VISIBLE_COUNT);
   const expandedTask = allProjectDisplayTasks.find(t => t.id === expandedNotesTaskId) ?? null;
 
   // ── Drag-to-reorder ────────────────────────────────────────────────────────
@@ -263,7 +269,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
           className={`flex flex-col rounded-xl border overflow-hidden ${
             darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'
           } ${isMobile ? 'w-full' : 'min-w-[180px] max-w-[260px] w-full'}`}
-          style={goalHex ? { borderLeft: `3px solid ${goalHex}88` } : {}}
+          style={{ borderLeft: `3px solid ${projectHex}88` }}
         >
           {/* Row 1: title + edit/delete */}
           <div className="flex items-center gap-1.5 px-3 pt-2.5 pb-1 dnd-no-select">
@@ -347,10 +353,8 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
         darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'
       } ${isMobile ? 'w-full' : 'min-w-[180px] max-w-[260px] w-full'}`}
     >
-      {/* Goal color bar */}
-      {goalHex && (
-        <div className="h-1.5 flex-shrink-0" style={{ background: goalHex + 'bb' }} />
-      )}
+      {/* Project color bar */}
+      <div className="h-1.5 flex-shrink-0" style={{ background: projectHex + 'bb' }} />
       {/* Card body */}
       <div className="flex flex-col gap-2 p-3">
         {/* Header: title + badges + edit + delete */}
@@ -434,6 +438,18 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
                 Stalled
               </span>
             )}
+            {!parentGoal && (
+              <button
+                onClick={() => updateProject(project.id, { detailsHidden: !project.detailsHidden })}
+                className={`p-1 rounded-lg transition-colors ${
+                  darkMode ? 'text-gray-600 hover:text-gray-300 hover:bg-gray-700' : 'text-stone-300 hover:text-stone-600 hover:bg-stone-100'
+                }`}
+                title={detailsHidden ? 'Show details' : 'Hide details'}
+                aria-label={detailsHidden ? 'Show project details' : 'Hide project details'}
+              >
+                {detailsHidden ? <EyeOff size={12} /> : <Eye size={12} />}
+              </button>
+            )}
             <button
               onClick={() => onEditClick?.()}
               className={`p-1 rounded-lg transition-colors ${
@@ -455,16 +471,18 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
           </div>
         </div>
 
-        {/* Task count */}
-        <span className={`text-xs ${textSecondary}`}>
-          {completedCount}/{totalCount} task{totalCount !== 1 ? 's' : ''}
-        </span>
+        {/* Task count — hidden by the standalone-card eyeball toggle */}
+        {!detailsHidden && (
+          <span className={`text-xs ${textSecondary}`}>
+            {completedCount}/{totalCount} task{totalCount !== 1 ? 's' : ''}
+          </span>
+        )}
 
-        {/* Progress bar */}
-        <ProjectProgress progress={progress} compact />
+        {/* Progress bar — hidden by the standalone-card eyeball toggle */}
+        {!detailsHidden && <ProjectProgress progress={progress} compact />}
 
         {/* Unscheduled task list */}
-        {allProjectDisplayTasks.length > 0 && (
+        {displayableTasks.length > 0 && (
           <div className={`flex flex-col gap-0.5 pt-2 border-t ${borderClass}`}>
             {visibleTasks.map((t) => {
               const scheduled = isScheduled(t);
@@ -491,7 +509,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
                       ? darkMode ? 'border-t-2 border-blue-400' : 'border-t-2 border-blue-500'
                       : ''
                   }`}
-                  style={goalHex ? { borderLeft: `2px solid ${goalHex}99` } : {}}
+                  style={{ borderLeft: `2px solid ${projectHex}99` }}
                 >
                   <button
                     onClick={() => toggleTaskComplete(t.id)}


### PR DESCRIPTION
## Summary

**A2 of the Goals & Projects workstream** — stacked on A1 (#1238).

- **Standalone project cards get color.** The top color bar and task-row accents that goal-child cards already had now render on standalone cards too, using A1's effective project color (own color → blue default). The compact (completed) card's left border matches.
- **Eyeball SHOW/HIDE toggle on standalone cards.** A new Eye/EyeOff button next to the edit/delete controls hides the task count (`N/N tasks`), the progress bar, and completed tasks in the card's list. Persisted per-project (`project.detailsHidden`), so it syncs across devices and survives reloads — per our design decision.
- **Per-goal "Hide Stalled flags" checkbox** in the Goal form. When set, the Stalled badge is suppressed on all of that goal's child projects, and stalled projects stop contributing to the goal's amber caution indicator (overdue-based caution is unaffected). Other goals keep their badges — this is the slow-burn-goal opt-out, deliberately per-goal rather than global.

## Testing

- Full suite passes: 833 tests / 58 files; `vite build` clean.
- Manual checks on merge: toggle the eyeball on a standalone card with completed tasks (count, bar, and completed rows should vanish; incomplete tasks stay); set Hide Stalled on a goal with a stalled project (badge and amber dot should clear); confirm goal-child cards look unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_