### PR TITLE
Add SCHED agenda view for phones and tablets (C1)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -311,7 +311,7 @@ const DayPlanner = () => {
   // uses the two-column timeline (and hides the LIST/GRID toggle). This mirrors
   // how wider Android tablets behave, where landscape drops out of tablet mode
   // entirely. (On phones, list view is independent of orientation.)
-  const tabletListView = isTablet && !isLandscape && mobileViewMode === 'list';
+  const tabletListView = isTablet && !isLandscape && (mobileViewMode === 'list' || mobileViewMode === 'sched');
   const [glancePage, setGlancePage] = useState(() => {
     const saved = localStorage.getItem('day-planner-glance-page');
     return saved !== null ? parseInt(saved, 10) : 0;
@@ -8950,7 +8950,7 @@ const DayPlanner = () => {
       )}
 
       {/* Refocus timeline toast — all form factors except mobile list view */}
-      {timelineScrolledAway && effectiveViewMode === 'multi' && !((isMobile && mobileViewMode === 'list') || tabletListView) && (
+      {timelineScrolledAway && effectiveViewMode === 'multi' && !((isMobile && (mobileViewMode === 'list' || mobileViewMode === 'sched')) || tabletListView) && (
         <div className="fixed left-1/2 -translate-x-1/2 z-50 pointer-events-auto" style={{ bottom: isMobile ? 'calc(5rem + env(safe-area-inset-bottom, 0px))' : '1.5rem' }}>
           <button
             onClick={() => { setTimelineScrolledAway(false); scrollToCurrentHour(true); }}

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -538,7 +538,7 @@ const CalendarHeader = () => {
 )}
 
 {/* Multi-mode all-day tasks section */}
-{effectiveViewMode === 'multi' && !(isTablet && !isLandscape && mobileViewMode === 'list') && (visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay) || getDeadlineTasksForDate(dateToString(date)).length > 0) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (
+{effectiveViewMode === 'multi' && !(isTablet && !isLandscape && (mobileViewMode === 'list' || mobileViewMode === 'sched')) && (visibleDates.some(date => getTasksForDate(date).some(t => t.isAllDay) || getDeadlineTasksForDate(dateToString(date)).length > 0) || (routinesEnabled && todayRoutines.some(r => r.isAllDay))) && (
   <div ref={(el) => { if (isTablet) mobileAllDaySectionRef.current = el; }} className={`flex border-b ${borderClass} ${cardBg}`}>
     <div className={`w-16 flex-shrink-0 px-3 py-2 text-xs font-semibold ${textSecondary} border-r ${borderClass}`}>
       ALL DAY

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -1117,7 +1117,7 @@ const MobileGlanceSection = () => {
       tomorrow.setDate(tomorrow.getDate() + 1);
       setMobileActiveTab('timeline');
       goToDate(tomorrow);
-      if (mobileViewMode === 'list') {
+      if (mobileViewMode === 'list' || mobileViewMode === 'sched') {
         setTimeout(() => calendarRef.current?.scrollTo({ top: 0, behavior: 'smooth' }), 150);
       } else if (firstStartTime) {
         setTimeout(() => scrollToHour(firstStartTime), 150);

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -35,6 +35,7 @@ import MobileBottomSheets from './MobileBottomSheets.jsx';
 import MobileGlanceSection from './MobileGlanceSection.jsx';
 import MobileViewToggle from './MobileViewToggle.jsx';
 import MobileListView from './MobileListView.jsx';
+import SchedView from './sched/SchedView.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -785,6 +786,7 @@ const MobileLayout = () => {
 
                   {mobileViewMode === 'grid' && <MobileTimeGrid />}
                   {mobileViewMode === 'list' && <MobileListView />}
+                  {mobileViewMode === 'sched' && <SchedView />}
                 </div>
 
                 {/* Mobile notes panel overlay for timeline tasks (including deadline tasks) */}

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -491,7 +491,7 @@ const MobileSettingsPanel = () => {
         </div>
         <p className={`text-xs ${textSecondary}`}>{t('settings.viewDefaultDesc')}</p>
         <div className="flex gap-2">
-          {['grid', 'list'].map(mode => (
+          {['grid', 'list', 'sched'].map(mode => (
             <button
               key={mode}
               onClick={() => setMobileViewMode(mode)}
@@ -501,7 +501,7 @@ const MobileSettingsPanel = () => {
                   : `${darkMode ? 'bg-gray-700 border-gray-600' : 'bg-white border-stone-300'} ${textPrimary}`
               }`}
             >
-              {mode === 'grid' ? 'GRID' : 'LIST'}
+              {mode.toUpperCase()}
             </button>
           ))}
         </div>

--- a/src/components/MobileViewToggle.jsx
+++ b/src/components/MobileViewToggle.jsx
@@ -23,21 +23,34 @@ const ListIcon = () => (
   </svg>
 );
 
+const SchedIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    {/* Day-group headers with task blocks beneath — the agenda silhouette */}
+    <rect x="1" y="1"  width="8"  height="2.5" rx="1" fill={ORANGE} />
+    <rect x="1" y="5"  width="16" height="3.5" rx="1" fill={ORANGE} fillOpacity="0.7" />
+    <rect x="1" y="10.5" width="8"  height="2.5" rx="1" fill={ORANGE} />
+    <rect x="1" y="14.5" width="16" height="3.5" rx="1" fill={ORANGE} fillOpacity="0.7" />
+  </svg>
+);
+
+// GRID → LIST → SCHED → GRID
+const NEXT_MODE = { grid: 'list', list: 'sched', sched: 'grid' };
+
 const MobileViewToggle = () => {
   const { mobileViewMode, setMobileViewMode, textSecondary } = useDayPlannerCtx();
 
-  const toggle = () => setMobileViewMode(prev => prev === 'grid' ? 'list' : 'grid');
+  const toggle = () => setMobileViewMode(prev => NEXT_MODE[prev] || 'grid');
 
   return (
     <button
       onClick={toggle}
       className="flex flex-col items-center justify-center gap-0.5 w-full h-full py-1 hover:bg-black/5 dark:hover:bg-white/5 active:bg-black/10 dark:active:bg-white/10 transition-colors"
-      aria-label={`Switch to ${mobileViewMode === 'grid' ? 'list' : 'grid'} view`}
+      aria-label={`Switch to ${(NEXT_MODE[mobileViewMode] || 'grid').toUpperCase()} view`}
       title={`Current view: ${mobileViewMode.toUpperCase()}. Tap to switch.`}
     >
-      {mobileViewMode === 'grid' ? <GridIcon /> : <ListIcon />}
+      {mobileViewMode === 'grid' ? <GridIcon /> : mobileViewMode === 'sched' ? <SchedIcon /> : <ListIcon />}
       <span className={`text-[9px] font-semibold tracking-widest uppercase ${textSecondary} leading-none`}>
-        {mobileViewMode === 'grid' ? 'GRID' : 'LIST'}
+        {mobileViewMode.toUpperCase()}
       </span>
     </button>
   );

--- a/src/components/sched/SchedFilterPopup.jsx
+++ b/src/components/sched/SchedFilterPopup.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { X } from 'lucide-react';
+import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
+import { TASK_COLORS } from '../../utils/colorUtils.js';
+import { hasActiveSchedFilters, toggleSchedFilter, EMPTY_SCHED_FILTERS } from '../../utils/schedAgenda.js';
+
+/**
+ * SCHED filter sheet: colors, tags, projects. Empty selection in a section
+ * means "everything"; selections within a section OR together, sections AND.
+ * `availableColors`/`availableTags` come from the visible agenda window so the
+ * sheet never offers options that can't match anything.
+ */
+const SchedFilterPopup = ({ filters, setFilters, availableColors, availableTags, onClose }) => {
+  const { darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg } = useDayPlannerCtx();
+  const { projects, goalsProjectsEnabled } = useFeaturesCtx();
+
+  const colorOptions = TASK_COLORS.filter(c => availableColors.has(c.class));
+  const activeProjects = goalsProjectsEnabled
+    ? projects.filter(p => p.status !== 'archived' && p.status !== 'completed')
+    : [];
+
+  const chip = (selected) => `px-2.5 py-1 rounded-full text-xs font-medium border transition-colors ${
+    selected
+      ? 'bg-blue-600 text-white border-blue-600'
+      : `${borderClass} ${textSecondary} ${hoverBg}`
+  }`;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col justify-end sm:items-center sm:justify-center" onClick={onClose}>
+      <div className="absolute inset-0 bg-black/40" />
+      <div
+        onClick={e => e.stopPropagation()}
+        className={`relative ${cardBg} rounded-t-2xl sm:rounded-2xl shadow-2xl w-full sm:max-w-md max-h-[75vh] overflow-y-auto p-5 flex flex-col gap-4`}
+      >
+        <div className="flex items-center justify-between">
+          <h3 className={`text-base font-semibold ${textPrimary}`}>Filter tasks</h3>
+          <div className="flex items-center gap-2">
+            {hasActiveSchedFilters(filters) && (
+              <button
+                onClick={() => setFilters(EMPTY_SCHED_FILTERS)}
+                className="text-xs font-medium text-blue-500"
+              >
+                Clear all
+              </button>
+            )}
+            <button onClick={onClose} className={`p-1 rounded-lg ${hoverBg}`} aria-label="Close filters">
+              <X size={16} className={textSecondary} />
+            </button>
+          </div>
+        </div>
+
+        {/* Colors */}
+        {colorOptions.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <span className={`text-xs font-medium ${textSecondary}`}>Colors</span>
+            <div className="flex flex-wrap gap-2">
+              {colorOptions.map(c => (
+                <button
+                  key={c.class}
+                  onClick={() => setFilters(f => toggleSchedFilter(f, 'colors', c.class))}
+                  className={`w-7 h-7 rounded-full ${c.class} transition-transform ${
+                    filters.colors.includes(c.class) ? 'ring-2 ring-offset-2 ring-blue-500 scale-110' : 'hover:scale-110 opacity-80'
+                  }`}
+                  aria-label={c.name}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Tags */}
+        {availableTags.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <span className={`text-xs font-medium ${textSecondary}`}>Tags</span>
+            <div className="flex flex-wrap gap-1.5">
+              {availableTags.map(tag => (
+                <button key={tag} onClick={() => setFilters(f => toggleSchedFilter(f, 'tags', tag))} className={chip(filters.tags.includes(tag))}>
+                  #{tag}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Projects */}
+        {goalsProjectsEnabled && activeProjects.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <span className={`text-xs font-medium ${textSecondary}`}>Projects</span>
+            <div className="flex flex-wrap gap-1.5">
+              {activeProjects.map(p => (
+                <button key={p.id} onClick={() => setFilters(f => toggleSchedFilter(f, 'projectIds', p.id))} className={chip(filters.projectIds.includes(p.id))}>
+                  {p.title}
+                </button>
+              ))}
+              <button onClick={() => setFilters(f => toggleSchedFilter(f, 'projectIds', 'none'))} className={chip(filters.projectIds.includes('none'))}>
+                No project
+              </button>
+            </div>
+          </div>
+        )}
+
+        {colorOptions.length === 0 && availableTags.length === 0 && (!goalsProjectsEnabled || activeProjects.length === 0) && (
+          <p className={`text-sm ${textSecondary}`}>Nothing to filter yet — schedule some tasks first.</p>
+        )}
+
+        <p className={`text-[11px] ${textSecondary} ${darkMode ? 'opacity-50' : 'opacity-60'}`}>
+          Selections within a section match any; sections combine.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default SchedFilterPopup;

--- a/src/components/sched/SchedTaskCard.jsx
+++ b/src/components/sched/SchedTaskCard.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { CheckCircle2, Circle, Repeat } from 'lucide-react';
+import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
+import { taskColorToHex } from '../../utils/colorUtils.js';
+
+/**
+ * Compact task card for the SCHED agenda (mobile + desktop dashboards).
+ * Color accent on the left, completion toggle, title, time/duration line.
+ * Imported calendar events render read-only (no editor on tap).
+ */
+const SchedTaskCard = ({ task }) => {
+  const {
+    darkMode, cardBg, borderClass, textPrimary, textSecondary,
+    formatTime, toggleComplete, openMobileEditTask,
+  } = useDayPlannerCtx();
+
+  const hex = taskColorToHex(task.color, task.nativeCalendarColor);
+  const isEvent = task.imported && !task.isTaskCalendar;
+  const isRecurring = typeof task.id === 'string' && task.id.startsWith('recurring-');
+
+  const timeLabel = task.isAllDay
+    ? 'All day'
+    : task.startTime
+      ? `${formatTime(task.startTime)}${task.duration ? ` · ${task.duration}m` : ''}`
+      : '';
+
+  return (
+    <div
+      onClick={() => { if (!isEvent) openMobileEditTask(task, false); }}
+      className={`flex items-center gap-2.5 rounded-xl border ${borderClass} ${cardBg} px-3 py-2.5 ${
+        isEvent ? '' : 'cursor-pointer active:opacity-70'
+      } ${task.completed ? 'opacity-55' : ''}`}
+      style={{ borderLeft: `4px solid ${hex}` }}
+    >
+      {!isEvent && (
+        <button
+          onClick={e => { e.stopPropagation(); toggleComplete(task.id); }}
+          className="flex-shrink-0 p-0.5"
+          aria-label={task.completed ? 'Mark incomplete' : 'Mark complete'}
+        >
+          {task.completed
+            ? <CheckCircle2 size={18} className="text-green-500" />
+            : <Circle size={18} className={darkMode ? 'text-gray-600' : 'text-stone-300'} />}
+        </button>
+      )}
+      <div className="flex flex-col min-w-0 flex-1">
+        <span className={`text-sm font-medium ${textPrimary} truncate ${task.completed ? 'line-through' : ''}`}>
+          {task.title}
+        </span>
+        {timeLabel && (
+          <span className={`text-xs ${textSecondary} flex items-center gap-1`}>
+            {timeLabel}
+            {isRecurring && <Repeat size={10} className="opacity-60" />}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SchedTaskCard;

--- a/src/components/sched/SchedView.jsx
+++ b/src/components/sched/SchedView.jsx
@@ -1,0 +1,165 @@
+import React, { useMemo, useState } from 'react';
+import { ChevronDown, Eye, EyeOff, ListFilter, Plus } from 'lucide-react';
+import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
+import { useTranslation } from 'react-i18next';
+import { dateToString, extractTags } from '../../utils/taskUtils.js';
+import { EMPTY_SCHED_FILTERS, hasActiveSchedFilters, taskMatchesSchedFilters } from '../../utils/schedAgenda.js';
+import SchedTaskCard from './SchedTaskCard.jsx';
+import SchedFilterPopup from './SchedFilterPopup.jsx';
+
+const INITIAL_DAYS = 14;
+const LOAD_MORE_DAYS = 14;
+
+/**
+ * SCHED — scrollable day-grouped agenda of scheduled tasks, starting at the
+ * currently selected day. Third mobile/tablet view alongside GRID and LIST;
+ * the desktop dashboard variant reuses the same building blocks.
+ */
+const SchedView = () => {
+  const {
+    selectedDate, tasks, expandedRecurringTasks,
+    getTasksForDate,
+    darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg,
+    setNewTask, setShowAddTask,
+  } = useDayPlannerCtx();
+  const { t } = useTranslation();
+
+  const [daysShown, setDaysShown] = useState(INITIAL_DAYS);
+  const [filters, setFilters] = useState(EMPTY_SCHED_FILTERS);
+  const [showFilters, setShowFilters] = useState(false);
+  const [showEmptyDays, setShowEmptyDays] = useState(
+    () => localStorage.getItem('day-planner-sched-show-empty') === 'true'
+  );
+
+  const toggleEmptyDays = () => setShowEmptyDays(v => {
+    localStorage.setItem('day-planner-sched-show-empty', String(!v));
+    return !v;
+  });
+
+  // Unfiltered agenda window (day → tasks), all-day first then by start time.
+  const rawDays = useMemo(() => {
+    const out = [];
+    for (let i = 0; i < daysShown; i++) {
+      const date = new Date(selectedDate);
+      date.setDate(date.getDate() + i);
+      const dayTasks = getTasksForDate(date)
+        .filter(task => !task.isExample)
+        .sort((a, b) =>
+          ((a.isAllDay ? 0 : 1) - (b.isAllDay ? 0 : 1)) ||
+          (a.startTime || '').localeCompare(b.startTime || '')
+        );
+      out.push({ date, dateStr: dateToString(date), tasks: dayTasks });
+    }
+    return out;
+    // getTasksForDate reads tasks + expandedRecurringTasks internally.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedDate, daysShown, tasks, expandedRecurringTasks]);
+
+  // Filter options offered by the popup come from the visible window.
+  const { availableColors, availableTags } = useMemo(() => {
+    const colors = new Set();
+    const tags = new Set();
+    rawDays.forEach(d => d.tasks.forEach(task => {
+      if (task.color) colors.add(task.color);
+      extractTags(task.title || '').forEach(tag => tags.add(tag));
+    }));
+    return { availableColors: colors, availableTags: [...tags].sort() };
+  }, [rawDays]);
+
+  const days = useMemo(() =>
+    rawDays.map(d => ({ ...d, tasks: d.tasks.filter(task => taskMatchesSchedFilters(task, filters)) })),
+    [rawDays, filters]
+  );
+
+  const todayStr = dateToString(new Date());
+  const tomorrowStr = dateToString(new Date(Date.now() + 86400000));
+
+  const dayLabel = (day) => {
+    const base = day.date.toLocaleDateString(undefined, { weekday: 'long', month: 'short', day: 'numeric' });
+    if (day.dateStr === todayStr) return `${t('common.today', 'Today')} · ${base}`;
+    if (day.dateStr === tomorrowStr) return `${t('common.tomorrow', 'Tomorrow')} · ${base}`;
+    return base;
+  };
+
+  const addTaskOnDay = (dateStr) => {
+    setNewTask({ title: '', startTime: '09:00', duration: 30, date: dateStr, isAllDay: false, recurrence: null });
+    setShowAddTask(true);
+  };
+
+  const filtersActive = hasActiveSchedFilters(filters);
+  const visibleDays = days.filter(d => showEmptyDays || d.tasks.length > 0);
+
+  return (
+    <div className="flex flex-col gap-3 px-3 pb-24 pt-2">
+      {/* Controls */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => setShowFilters(true)}
+          className={`flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded-lg border transition-colors ${
+            filtersActive
+              ? 'bg-blue-600 text-white border-blue-600'
+              : `${borderClass} ${textSecondary} ${hoverBg}`
+          }`}
+        >
+          <ListFilter size={13} />
+          Filter{filtersActive ? ` · ${filters.colors.length + filters.tags.length + filters.projectIds.length}` : ''}
+        </button>
+        <button
+          onClick={toggleEmptyDays}
+          className={`flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded-lg border ${borderClass} ${textSecondary} ${hoverBg} transition-colors`}
+          title={showEmptyDays ? 'Hide empty days' : 'Show empty days'}
+        >
+          {showEmptyDays ? <Eye size={13} /> : <EyeOff size={13} />}
+          Empty days
+        </button>
+      </div>
+
+      {/* Day groups */}
+      {visibleDays.map(day => (
+        <div key={day.dateStr} className="flex flex-col gap-1.5">
+          <div className={`text-xs font-semibold uppercase tracking-wide ${day.dateStr === todayStr ? 'text-blue-500' : textSecondary} pt-1`}>
+            {dayLabel(day)}
+          </div>
+          {day.tasks.length > 0 ? (
+            day.tasks.map(task => <SchedTaskCard key={task.id} task={task} />)
+          ) : (
+            <button
+              onClick={() => addTaskOnDay(day.dateStr)}
+              className={`flex items-center justify-center gap-1.5 rounded-xl border border-dashed ${borderClass} py-2.5 text-xs ${textSecondary} ${hoverBg} transition-colors`}
+            >
+              <Plus size={13} />
+              {t('task.addTask', 'Add task')}
+            </button>
+          )}
+        </div>
+      ))}
+
+      {visibleDays.length === 0 && (
+        <p className={`text-sm ${textSecondary} text-center py-8`}>
+          {filtersActive ? 'No tasks match the current filters.' : 'Nothing scheduled in this window.'}
+        </p>
+      )}
+
+      {/* Extend window */}
+      <button
+        onClick={() => setDaysShown(n => n + LOAD_MORE_DAYS)}
+        className={`flex items-center justify-center gap-1.5 py-2.5 text-xs font-medium ${textSecondary} ${hoverBg} rounded-xl border ${borderClass} transition-colors`}
+      >
+        <ChevronDown size={13} />
+        Show {LOAD_MORE_DAYS} more days
+      </button>
+
+      {showFilters && (
+        <SchedFilterPopup
+          filters={filters}
+          setFilters={setFilters}
+          availableColors={availableColors}
+          availableTags={availableTags}
+          onClose={() => setShowFilters(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default SchedView;

--- a/src/utils/schedAgenda.js
+++ b/src/utils/schedAgenda.js
@@ -1,0 +1,37 @@
+import { extractTags } from './taskUtils.js';
+
+/**
+ * SCHED view filtering.
+ *
+ * Filters shape: { colors: string[], tags: string[], projectIds: string[] }.
+ * An empty array means "no filter" for that dimension; a task must match
+ * every non-empty dimension (AND across dimensions, OR within one).
+ * The 'none' sentinel in projectIds matches tasks without a project.
+ */
+export const EMPTY_SCHED_FILTERS = Object.freeze({ colors: [], tags: [], projectIds: [] });
+
+export const hasActiveSchedFilters = (filters) =>
+  !!(filters && (filters.colors.length || filters.tags.length || filters.projectIds.length));
+
+export const taskMatchesSchedFilters = (task, filters) => {
+  if (!hasActiveSchedFilters(filters)) return true;
+  if (filters.colors.length && !filters.colors.includes(task.color)) return false;
+  if (filters.tags.length) {
+    const taskTags = extractTags(task.title || '');
+    if (!filters.tags.some(tag => taskTags.includes(tag))) return false;
+  }
+  if (filters.projectIds.length) {
+    const pid = task.projectId || 'none';
+    if (!filters.projectIds.includes(pid)) return false;
+  }
+  return true;
+};
+
+/** Toggles a value in one filter dimension, returning a new filters object. */
+export const toggleSchedFilter = (filters, dimension, value) => {
+  const list = filters[dimension];
+  return {
+    ...filters,
+    [dimension]: list.includes(value) ? list.filter(v => v !== value) : [...list, value],
+  };
+};

--- a/src/utils/schedAgenda.test.js
+++ b/src/utils/schedAgenda.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { EMPTY_SCHED_FILTERS, hasActiveSchedFilters, taskMatchesSchedFilters, toggleSchedFilter } from './schedAgenda.js';
+
+const task = { title: 'Write report #work #deep', color: 'bg-red-500', projectId: 'p1' };
+
+describe('taskMatchesSchedFilters', () => {
+  it('passes everything when no filters are active', () => {
+    expect(taskMatchesSchedFilters(task, EMPTY_SCHED_FILTERS)).toBe(true);
+    expect(hasActiveSchedFilters(EMPTY_SCHED_FILTERS)).toBe(false);
+  });
+
+  it('filters by color', () => {
+    expect(taskMatchesSchedFilters(task, { colors: ['bg-red-500'], tags: [], projectIds: [] })).toBe(true);
+    expect(taskMatchesSchedFilters(task, { colors: ['bg-green-500'], tags: [], projectIds: [] })).toBe(false);
+  });
+
+  it('filters by tag (OR within tags)', () => {
+    expect(taskMatchesSchedFilters(task, { colors: [], tags: ['work'], projectIds: [] })).toBe(true);
+    expect(taskMatchesSchedFilters(task, { colors: [], tags: ['home', 'deep'], projectIds: [] })).toBe(true);
+    expect(taskMatchesSchedFilters(task, { colors: [], tags: ['home'], projectIds: [] })).toBe(false);
+  });
+
+  it('filters by project, with none sentinel for project-less tasks', () => {
+    expect(taskMatchesSchedFilters(task, { colors: [], tags: [], projectIds: ['p1'] })).toBe(true);
+    expect(taskMatchesSchedFilters(task, { colors: [], tags: [], projectIds: ['p2'] })).toBe(false);
+    const free = { title: 'Free task', color: 'bg-blue-500' };
+    expect(taskMatchesSchedFilters(free, { colors: [], tags: [], projectIds: ['none'] })).toBe(true);
+    expect(taskMatchesSchedFilters(free, { colors: [], tags: [], projectIds: ['p1'] })).toBe(false);
+  });
+
+  it('ANDs across dimensions', () => {
+    expect(taskMatchesSchedFilters(task, { colors: ['bg-red-500'], tags: ['work'], projectIds: ['p1'] })).toBe(true);
+    expect(taskMatchesSchedFilters(task, { colors: ['bg-red-500'], tags: ['home'], projectIds: ['p1'] })).toBe(false);
+  });
+});
+
+describe('toggleSchedFilter', () => {
+  it('adds and removes values immutably', () => {
+    const withRed = toggleSchedFilter(EMPTY_SCHED_FILTERS, 'colors', 'bg-red-500');
+    expect(withRed.colors).toEqual(['bg-red-500']);
+    expect(EMPTY_SCHED_FILTERS.colors).toEqual([]);
+    expect(toggleSchedFilter(withRed, 'colors', 'bg-red-500').colors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

**C1 of the SCHED workstream** — stacked on A2 (#1239), keeping the whole feature chain linear in your planned merge order (A1 → A2 → C1 → C2 → B).

New third view for phones and tablets, joining the cycle **GRID → LIST → SCHED** (toggle button + settings view-default picker):

- **Day-grouped agenda** starting at the currently selected day: each day is a header group with task cards beneath — all-day tasks first, then by start time, recurring occurrences included (it reuses the context's `getTasksForDate`, same as LIST).
- **Filtering** via a bottom-sheet popup: colors, tags, and projects, offering only options that actually appear in the visible window. Selections within a section match any (OR); sections combine (AND). Matching logic is a pure util (`src/utils/schedAgenda.js`) with 6 tests.
- **Empty-days toggle** (persisted in localStorage): hidden by default; when shown, each empty day renders a dashed add-task button that opens the new-task sheet prefilled with that date.
- **14-day window** with a "show 14 more" extender.

Task cards support completion toggling and tap-to-edit; imported calendar events render read-only. Components live under `src/components/sched/` (`SchedView`, `SchedTaskCard`, `SchedFilterPopup`) specifically so the C2 desktop dashboard can reuse the card and filter pieces.

Integration details: the tablet-portrait special-casing and floating-UI suppression that applied to LIST (`tabletListView`, the multi-view floating header, GLANCEahead scroll behavior) now treat SCHED the same way.

## Testing

- Full suite passes: 839 tests / 59 files (6 new); `vite build` clean.
- Manual checks on merge: cycle the view toggle through all three modes on a phone; filter by a tag and confirm day groups collapse to matching tasks; enable empty days and add a task from a future empty day; confirm the tablet-portrait toggle still hides in landscape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_