### PR TITLE
Add SCHED dashboard view for desktop (C2)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -286,7 +286,7 @@ const DayPlanner = () => {
   const [viewMode, setViewMode] = useState(() => {
     // URL ?view= param takes priority over defaultView on cold load.
     const urlView = new URLSearchParams(window.location.search).get('view');
-    if (urlView && ['multi', 'day', 'week'].includes(urlView)) return urlView;
+    if (urlView && ['multi', 'day', 'week', 'sched'].includes(urlView)) return urlView;
     const def = localStorage.getItem('day-planner-default-view');
     return def ? JSON.parse(def) : 'multi';
   });
@@ -5588,7 +5588,8 @@ const DayPlanner = () => {
   // Seven dates for week view — strict (calendar week) or rolling (today + 6 days).
   // Empty array when not in week mode so it doesn't affect other views.
   const weekViewDates = useMemo(() => {
-    if (effectiveViewMode !== 'week') return [];
+    // The week strip drives both WEEK view columns and the SCHED date navigation.
+    if (effectiveViewMode !== 'week' && effectiveViewMode !== 'sched') return [];
     const base = new Date(selectedDate);
     base.setHours(0, 0, 0, 0);
     const todayStr = dateToString(new Date());

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -29,6 +29,7 @@ const CalendarHeader = () => {
     visibleDates,
     selectedDate,
     canShowViewCycler, effectiveViewMode,
+    goToDate,
     mobileViewMode,
     use24HourClock, dayViewColumns,
     weekViewDates,
@@ -157,7 +158,39 @@ const CalendarHeader = () => {
   className={`border-b ${borderClass} ${cardBg} flex`}
   style={effectiveViewMode === 'day' ? { display: 'grid', gridTemplateColumns: `repeat(${dayViewColumns.length}, 1fr)` } : undefined}
 >
-  {effectiveViewMode === 'week' ? (
+  {effectiveViewMode === 'sched' ? (
+    /* SCHED view: gutter cell + 7 clickable dates that set the agenda's starting day */
+    <>
+      <div
+        className={`flex-shrink-0 border-r ${borderClass} flex items-center justify-center`}
+        style={{ width: WEEK_GUTTER_W, minHeight: 'var(--header-row-h)' }}
+      >
+        {isTablet && !isLandscape ? <MobileViewToggle /> : (canShowViewCycler && <ViewCycler />)}
+      </div>
+      {weekViewDates.map((date, idx) => {
+        const dateStr = dateToString(date);
+        const isDateToday = dateStr === dateToString(new Date());
+        const isSelected = dateStr === dateToString(selectedDate);
+        return (
+          <button
+            key={dateStr}
+            onClick={() => goToDate(date)}
+            className={`flex-1 flex items-center justify-center py-1.5 px-1 text-center transition-colors ${idx > 0 ? `border-l ${borderClass}` : ''}
+              ${isSelected ? (darkMode ? 'bg-blue-900/40' : 'bg-blue-100') : isDateToday ? (darkMode ? 'bg-blue-900/20' : 'bg-blue-50') : ''}`}
+            style={{ minHeight: 'var(--header-row-h)' }}
+            title={`Start agenda at ${dateStr}`}
+          >
+            <div className={`font-bold flex items-center justify-center gap-1.5 ${isDateToday || isSelected ? 'text-blue-600' : textPrimary}`}>
+              <span>{['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][date.getDay()]}</span>
+              <span className={`font-normal ${isDateToday || isSelected ? 'text-blue-500' : textSecondary}`}>
+                {date.getMonth() + 1}/{date.getDate()}
+              </span>
+            </div>
+          </button>
+        );
+      })}
+    </>
+  ) : effectiveViewMode === 'week' ? (
     /* Week view: gutter cell + 7 day-header cells */
     <>
       <div

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -13,6 +13,7 @@ import CalendarHeader from './CalendarHeader.jsx';
 import TimeGrid from './TimeGrid.jsx';
 import DayView from './DayView.jsx';
 import WeekView from './WeekView.jsx';
+import SchedDashboard from './sched/SchedDashboard.jsx';
 import InboxArchivedBar from './InboxArchivedBar.jsx';
 import GlanceSidebar from './GlanceSidebar.jsx';
 import InboxSidebar from './InboxSidebar.jsx';
@@ -831,6 +832,7 @@ const DesktopLayout = () => {
                     {effectiveViewMode === 'multi' && <TimeGrid />}
                     {effectiveViewMode === 'day' && <DayView />}
                     {effectiveViewMode === 'week' && <WeekView />}
+                    {effectiveViewMode === 'sched' && <SchedDashboard />}
                   </>
               }
             </div>

--- a/src/components/ViewCycler.jsx
+++ b/src/components/ViewCycler.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 
-const STATES = ['multi', 'day', 'week'];
-const LABELS = { multi: 'MULTI', day: 'DAY', week: 'WEEK' };
+const STATES = ['multi', 'day', 'week', 'sched'];
+const LABELS = { multi: 'MULTI', day: 'DAY', week: 'WEEK', sched: 'SCHED' };
 const ORANGE = '#fe8b00';
 
 const MultiIcon = () => (
@@ -36,7 +36,17 @@ const WeekIcon = () => (
   </svg>
 );
 
-const ICONS = { multi: MultiIcon, day: DayIcon, week: WeekIcon };
+const SchedIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+    {/* Day-group headers with task blocks beneath — the agenda silhouette */}
+    <rect x="2" y="2"    width="9"  height="2.5" rx="1" fill={ORANGE} />
+    <rect x="2" y="6"    width="16" height="3.5" rx="1" fill={ORANGE} fillOpacity="0.7" />
+    <rect x="2" y="11.5" width="9"  height="2.5" rx="1" fill={ORANGE} />
+    <rect x="2" y="15.5" width="16" height="3.5" rx="1" fill={ORANGE} fillOpacity="0.7" />
+  </svg>
+);
+
+const ICONS = { multi: MultiIcon, day: DayIcon, week: WeekIcon, sched: SchedIcon };
 
 const ViewCycler = () => {
   const { viewMode, setViewMode, textSecondary } = useDayPlannerCtx();
@@ -52,7 +62,7 @@ const ViewCycler = () => {
     <button
       onClick={cycle}
       className="flex flex-col items-center justify-center gap-0.5 w-full h-full py-1 hover:bg-black/5 dark:hover:bg-white/5 transition-colors rounded"
-      title={`View: ${LABELS[viewMode]} (1/2/3 to switch)`}
+      title={`View: ${LABELS[viewMode]} (1/2/3/4 to switch)`}
       aria-label={`Current view: ${LABELS[viewMode]}. Click to cycle view.`}
     >
       <Icon />

--- a/src/components/sched/SchedDashboard.jsx
+++ b/src/components/sched/SchedDashboard.jsx
@@ -1,0 +1,205 @@
+import React, { useState } from 'react';
+import { ChevronDown, ChevronRight, Eye, EyeOff, Plus, X } from 'lucide-react';
+import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
+import { useTranslation } from 'react-i18next';
+import { dateToString } from '../../utils/taskUtils.js';
+import { TASK_COLORS } from '../../utils/colorUtils.js';
+import { EMPTY_SCHED_FILTERS, toggleSchedFilter } from '../../utils/schedAgenda.js';
+import useSchedAgendaState, { LOAD_MORE_DAYS } from './useSchedAgendaState.js';
+import SchedTaskCard from './SchedTaskCard.jsx';
+
+/** One collapsible section of the desktop filter rail. */
+const RailSection = ({ title, count, children, defaultOpen = true }) => {
+  const { borderClass, textPrimary, textSecondary, hoverBg } = useDayPlannerCtx();
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className={`border-b ${borderClass} pb-3`}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        className={`w-full flex items-center justify-between py-1.5 px-1 rounded ${hoverBg} transition-colors`}
+      >
+        <span className={`text-xs font-semibold uppercase tracking-wide ${textPrimary}`}>
+          {title}{count ? <span className="ml-1.5 text-blue-500">{count}</span> : null}
+        </span>
+        {open ? <ChevronDown size={13} className={textSecondary} /> : <ChevronRight size={13} className={textSecondary} />}
+      </button>
+      {open && <div className="pt-1.5">{children}</div>}
+    </div>
+  );
+};
+
+/**
+ * Desktop SCHED dashboard — Todoist-Upcoming-style day-grouped agenda that
+ * replaces the timeline when the view cycler is on SCHED. The date navigation
+ * above sets the agenda's starting day; filters live in the right-hand rail.
+ */
+const SchedDashboard = () => {
+  const { cardBg, borderClass, textPrimary, textSecondary, hoverBg } = useDayPlannerCtx();
+  const { projects, goalsProjectsEnabled } = useFeaturesCtx();
+  const { t } = useTranslation();
+
+  const {
+    visibleDays, filtersActive,
+    filters, setFilters,
+    availableColors, availableTags,
+    showEmptyDays, toggleEmptyDays,
+    showMoreDays,
+    addTaskOnDay,
+  } = useSchedAgendaState();
+
+  const todayStr = dateToString(new Date());
+  const tomorrowStr = dateToString(new Date(Date.now() + 86400000));
+
+  const dayLabel = (day) => {
+    const base = day.date.toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric' });
+    if (day.dateStr === todayStr) return `${base} · ${t('common.today', 'Today')}`;
+    if (day.dateStr === tomorrowStr) return `${base} · ${t('common.tomorrow', 'Tomorrow')}`;
+    return base;
+  };
+
+  const colorOptions = TASK_COLORS.filter(c => availableColors.has(c.class));
+  const activeProjects = goalsProjectsEnabled
+    ? projects.filter(p => p.status !== 'archived' && p.status !== 'completed')
+    : [];
+
+  const chip = (selected) => `px-2 py-0.5 rounded-full text-xs font-medium border transition-colors ${
+    selected
+      ? 'bg-blue-600 text-white border-blue-600'
+      : `${borderClass} ${textSecondary} ${hoverBg}`
+  }`;
+
+  return (
+    <div className="flex items-start">
+      {/* Agenda */}
+      <div className="flex-1 min-w-0 px-6 py-4">
+        <div className="max-w-2xl mx-auto flex flex-col gap-4">
+          {visibleDays.map(day => (
+            <div key={day.dateStr} className="flex flex-col gap-1.5">
+              <div className={`flex items-center justify-between border-b ${borderClass} pb-1`}>
+                <span className={`text-sm font-semibold ${day.dateStr === todayStr ? 'text-blue-500' : textPrimary}`}>
+                  {dayLabel(day)}
+                </span>
+                <button
+                  onClick={() => addTaskOnDay(day.dateStr)}
+                  className={`p-1 rounded ${hoverBg} ${textSecondary} transition-colors`}
+                  title={t('task.addTask', 'Add task')}
+                  aria-label={`Add task on ${day.dateStr}`}
+                >
+                  <Plus size={14} />
+                </button>
+              </div>
+              {day.tasks.length > 0 ? (
+                day.tasks.map(task => <SchedTaskCard key={task.id} task={task} />)
+              ) : (
+                <button
+                  onClick={() => addTaskOnDay(day.dateStr)}
+                  className={`flex items-center justify-center gap-1.5 rounded-xl border border-dashed ${borderClass} py-2 text-xs ${textSecondary} ${hoverBg} transition-colors`}
+                >
+                  <Plus size={13} />
+                  {t('task.addTask', 'Add task')}
+                </button>
+              )}
+            </div>
+          ))}
+
+          {visibleDays.length === 0 && (
+            <p className={`text-sm ${textSecondary} text-center py-10`}>
+              {filtersActive ? 'No tasks match the current filters.' : 'Nothing scheduled in this window.'}
+            </p>
+          )}
+
+          <button
+            onClick={showMoreDays}
+            className={`flex items-center justify-center gap-1.5 py-2 text-xs font-medium ${textSecondary} ${hoverBg} rounded-xl border ${borderClass} transition-colors`}
+          >
+            <ChevronDown size={13} />
+            Show {LOAD_MORE_DAYS} more days
+          </button>
+        </div>
+      </div>
+
+      {/* Filter rail */}
+      <div
+        className={`w-64 flex-shrink-0 border-l ${borderClass} ${cardBg} px-3 py-3 flex flex-col gap-3`}
+        style={{ position: 'sticky', top: 'calc(var(--header-row-h, 40px) + 4px)' }}
+      >
+        <div className="flex items-center justify-between px-1">
+          <span className={`text-xs font-semibold uppercase tracking-wide ${textSecondary}`}>Filters</span>
+          {filtersActive && (
+            <button
+              onClick={() => setFilters(EMPTY_SCHED_FILTERS)}
+              className="flex items-center gap-1 text-xs font-medium text-blue-500"
+            >
+              <X size={11} />
+              Clear
+            </button>
+          )}
+        </div>
+
+        <RailSection title="Colors" count={filters.colors.length}>
+          {colorOptions.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5 px-1">
+              {colorOptions.map(c => (
+                <button
+                  key={c.class}
+                  onClick={() => setFilters(f => toggleSchedFilter(f, 'colors', c.class))}
+                  className={`w-6 h-6 rounded-full ${c.class} transition-transform ${
+                    filters.colors.includes(c.class) ? 'ring-2 ring-offset-2 ring-blue-500 scale-110' : 'hover:scale-110 opacity-80'
+                  }`}
+                  aria-label={c.name}
+                />
+              ))}
+            </div>
+          ) : <p className={`text-xs ${textSecondary} px-1`}>No colors in view.</p>}
+        </RailSection>
+
+        <RailSection title="Tags" count={filters.tags.length}>
+          {availableTags.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5 px-1">
+              {availableTags.map(tag => (
+                <button key={tag} onClick={() => setFilters(f => toggleSchedFilter(f, 'tags', tag))} className={chip(filters.tags.includes(tag))}>
+                  #{tag}
+                </button>
+              ))}
+            </div>
+          ) : <p className={`text-xs ${textSecondary} px-1`}>No tags in view.</p>}
+        </RailSection>
+
+        {goalsProjectsEnabled && (
+          <RailSection title="Projects" count={filters.projectIds.length}>
+            {activeProjects.length > 0 ? (
+              <div className="flex flex-col gap-1 px-1">
+                {activeProjects.map(p => (
+                  <button
+                    key={p.id}
+                    onClick={() => setFilters(f => toggleSchedFilter(f, 'projectIds', p.id))}
+                    className={`text-left ${chip(filters.projectIds.includes(p.id))} truncate`}
+                  >
+                    {p.title}
+                  </button>
+                ))}
+                <button
+                  onClick={() => setFilters(f => toggleSchedFilter(f, 'projectIds', 'none'))}
+                  className={`text-left ${chip(filters.projectIds.includes('none'))}`}
+                >
+                  No project
+                </button>
+              </div>
+            ) : <p className={`text-xs ${textSecondary} px-1`}>No active projects.</p>}
+          </RailSection>
+        )}
+
+        <button
+          onClick={toggleEmptyDays}
+          className={`flex items-center gap-1.5 text-xs font-medium px-2 py-1.5 rounded-lg border ${borderClass} ${textSecondary} ${hoverBg} transition-colors`}
+        >
+          {showEmptyDays ? <Eye size={13} /> : <EyeOff size={13} />}
+          {showEmptyDays ? 'Hide empty days' : 'Show empty days'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SchedDashboard;

--- a/src/components/sched/SchedView.jsx
+++ b/src/components/sched/SchedView.jsx
@@ -1,75 +1,30 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { ChevronDown, Eye, EyeOff, ListFilter, Plus } from 'lucide-react';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useTranslation } from 'react-i18next';
-import { dateToString, extractTags } from '../../utils/taskUtils.js';
-import { EMPTY_SCHED_FILTERS, hasActiveSchedFilters, taskMatchesSchedFilters } from '../../utils/schedAgenda.js';
+import { dateToString } from '../../utils/taskUtils.js';
+import useSchedAgendaState, { LOAD_MORE_DAYS } from './useSchedAgendaState.js';
 import SchedTaskCard from './SchedTaskCard.jsx';
 import SchedFilterPopup from './SchedFilterPopup.jsx';
-
-const INITIAL_DAYS = 14;
-const LOAD_MORE_DAYS = 14;
 
 /**
  * SCHED — scrollable day-grouped agenda of scheduled tasks, starting at the
  * currently selected day. Third mobile/tablet view alongside GRID and LIST;
- * the desktop dashboard variant reuses the same building blocks.
+ * the desktop dashboard (SchedDashboard) shares the same agenda state.
  */
 const SchedView = () => {
-  const {
-    selectedDate, tasks, expandedRecurringTasks,
-    getTasksForDate,
-    darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg,
-    setNewTask, setShowAddTask,
-  } = useDayPlannerCtx();
+  const { borderClass, textSecondary, hoverBg } = useDayPlannerCtx();
   const { t } = useTranslation();
-
-  const [daysShown, setDaysShown] = useState(INITIAL_DAYS);
-  const [filters, setFilters] = useState(EMPTY_SCHED_FILTERS);
   const [showFilters, setShowFilters] = useState(false);
-  const [showEmptyDays, setShowEmptyDays] = useState(
-    () => localStorage.getItem('day-planner-sched-show-empty') === 'true'
-  );
 
-  const toggleEmptyDays = () => setShowEmptyDays(v => {
-    localStorage.setItem('day-planner-sched-show-empty', String(!v));
-    return !v;
-  });
-
-  // Unfiltered agenda window (day → tasks), all-day first then by start time.
-  const rawDays = useMemo(() => {
-    const out = [];
-    for (let i = 0; i < daysShown; i++) {
-      const date = new Date(selectedDate);
-      date.setDate(date.getDate() + i);
-      const dayTasks = getTasksForDate(date)
-        .filter(task => !task.isExample)
-        .sort((a, b) =>
-          ((a.isAllDay ? 0 : 1) - (b.isAllDay ? 0 : 1)) ||
-          (a.startTime || '').localeCompare(b.startTime || '')
-        );
-      out.push({ date, dateStr: dateToString(date), tasks: dayTasks });
-    }
-    return out;
-    // getTasksForDate reads tasks + expandedRecurringTasks internally.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedDate, daysShown, tasks, expandedRecurringTasks]);
-
-  // Filter options offered by the popup come from the visible window.
-  const { availableColors, availableTags } = useMemo(() => {
-    const colors = new Set();
-    const tags = new Set();
-    rawDays.forEach(d => d.tasks.forEach(task => {
-      if (task.color) colors.add(task.color);
-      extractTags(task.title || '').forEach(tag => tags.add(tag));
-    }));
-    return { availableColors: colors, availableTags: [...tags].sort() };
-  }, [rawDays]);
-
-  const days = useMemo(() =>
-    rawDays.map(d => ({ ...d, tasks: d.tasks.filter(task => taskMatchesSchedFilters(task, filters)) })),
-    [rawDays, filters]
-  );
+  const {
+    visibleDays, filtersActive,
+    filters, setFilters,
+    availableColors, availableTags,
+    showEmptyDays, toggleEmptyDays,
+    showMoreDays,
+    addTaskOnDay,
+  } = useSchedAgendaState();
 
   const todayStr = dateToString(new Date());
   const tomorrowStr = dateToString(new Date(Date.now() + 86400000));
@@ -80,14 +35,6 @@ const SchedView = () => {
     if (day.dateStr === tomorrowStr) return `${t('common.tomorrow', 'Tomorrow')} · ${base}`;
     return base;
   };
-
-  const addTaskOnDay = (dateStr) => {
-    setNewTask({ title: '', startTime: '09:00', duration: 30, date: dateStr, isAllDay: false, recurrence: null });
-    setShowAddTask(true);
-  };
-
-  const filtersActive = hasActiveSchedFilters(filters);
-  const visibleDays = days.filter(d => showEmptyDays || d.tasks.length > 0);
 
   return (
     <div className="flex flex-col gap-3 px-3 pb-24 pt-2">
@@ -142,7 +89,7 @@ const SchedView = () => {
 
       {/* Extend window */}
       <button
-        onClick={() => setDaysShown(n => n + LOAD_MORE_DAYS)}
+        onClick={showMoreDays}
         className={`flex items-center justify-center gap-1.5 py-2.5 text-xs font-medium ${textSecondary} ${hoverBg} rounded-xl border ${borderClass} transition-colors`}
       >
         <ChevronDown size={13} />

--- a/src/components/sched/useSchedAgendaState.js
+++ b/src/components/sched/useSchedAgendaState.js
@@ -1,0 +1,86 @@
+import { useMemo, useState } from 'react';
+import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
+import { dateToString, extractTags } from '../../utils/taskUtils.js';
+import { EMPTY_SCHED_FILTERS, hasActiveSchedFilters, taskMatchesSchedFilters } from '../../utils/schedAgenda.js';
+
+export const INITIAL_DAYS = 14;
+export const LOAD_MORE_DAYS = 14;
+
+/**
+ * Shared state for the SCHED agenda (mobile SchedView + desktop
+ * SchedDashboard): the rolling day window anchored on selectedDate,
+ * filter state, filter options derived from the visible window, the
+ * empty-days preference, and the add-task-on-day helper.
+ */
+export default function useSchedAgendaState() {
+  const {
+    selectedDate, tasks, expandedRecurringTasks,
+    getTasksForDate,
+    setNewTask, setShowAddTask,
+  } = useDayPlannerCtx();
+
+  const [daysShown, setDaysShown] = useState(INITIAL_DAYS);
+  const [filters, setFilters] = useState(EMPTY_SCHED_FILTERS);
+  const [showEmptyDays, setShowEmptyDays] = useState(
+    () => localStorage.getItem('day-planner-sched-show-empty') === 'true'
+  );
+
+  const toggleEmptyDays = () => setShowEmptyDays(v => {
+    localStorage.setItem('day-planner-sched-show-empty', String(!v));
+    return !v;
+  });
+
+  const showMoreDays = () => setDaysShown(n => n + LOAD_MORE_DAYS);
+
+  // Unfiltered agenda window (day → tasks), all-day first then by start time.
+  const rawDays = useMemo(() => {
+    const out = [];
+    for (let i = 0; i < daysShown; i++) {
+      const date = new Date(selectedDate);
+      date.setDate(date.getDate() + i);
+      const dayTasks = getTasksForDate(date)
+        .filter(task => !task.isExample)
+        .sort((a, b) =>
+          ((a.isAllDay ? 0 : 1) - (b.isAllDay ? 0 : 1)) ||
+          (a.startTime || '').localeCompare(b.startTime || '')
+        );
+      out.push({ date, dateStr: dateToString(date), tasks: dayTasks });
+    }
+    return out;
+    // getTasksForDate reads tasks + expandedRecurringTasks internally.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedDate, daysShown, tasks, expandedRecurringTasks]);
+
+  // Filter options offered in the UI come from the visible window.
+  const { availableColors, availableTags } = useMemo(() => {
+    const colors = new Set();
+    const tags = new Set();
+    rawDays.forEach(d => d.tasks.forEach(task => {
+      if (task.color) colors.add(task.color);
+      extractTags(task.title || '').forEach(tag => tags.add(tag));
+    }));
+    return { availableColors: colors, availableTags: [...tags].sort() };
+  }, [rawDays]);
+
+  const days = useMemo(() =>
+    rawDays.map(d => ({ ...d, tasks: d.tasks.filter(task => taskMatchesSchedFilters(task, filters)) })),
+    [rawDays, filters]
+  );
+
+  const filtersActive = hasActiveSchedFilters(filters);
+  const visibleDays = days.filter(d => showEmptyDays || d.tasks.length > 0);
+
+  const addTaskOnDay = (dateStr) => {
+    setNewTask({ title: '', startTime: '09:00', duration: 30, date: dateStr, isAllDay: false, recurrence: null });
+    setShowAddTask(true);
+  };
+
+  return {
+    days, visibleDays, filtersActive,
+    filters, setFilters,
+    availableColors, availableTags,
+    showEmptyDays, toggleEmptyDays,
+    showMoreDays,
+    addTaskOnDay,
+  };
+}

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -252,7 +252,7 @@ export default function useKeyboardShortcuts({
         }
       }
 
-      // 1/2/3 to jump directly to multi/day/week view
+      // 1/2/3/4 to jump directly to multi/day/week/sched view
       if (e.key === '1' && noModifiers && canShowViewCycler) {
         e.preventDefault();
         setViewMode('multi');
@@ -264,6 +264,10 @@ export default function useKeyboardShortcuts({
       if (e.key === '3' && noModifiers && canShowViewCycler) {
         e.preventDefault();
         setViewMode('week');
+      }
+      if (e.key === '4' && noModifiers && canShowViewCycler) {
+        e.preventDefault();
+        setViewMode('sched');
       }
 
       // Arrow left/right to navigate dates


### PR DESCRIPTION
## Summary

**C2 of the SCHED workstream** — stacked on C1 (#1240). Chain so far: A1 → A2 → C1 → this.

SCHED joins **MULTI / DAY / WEEK** as a fourth desktop view mode, cycling in the `ViewCycler` and reachable via the new `4` shortcut (`1/2/3/4`). When active, the timeline is replaced by a **Todoist-Upcoming-style dashboard**, per the reference screenshot:

- **Clickable week strip**: in SCHED, the date-header row renders the 7-day strip with clickable dates — picking one sets the agenda's starting day (mobile-consistent). `weekViewDates` now feeds SCHED too, so the rolling/fixed week navigation and prev/next arrows behave exactly as in WEEK view.
- **Day-grouped agenda** (centered column): same task cards as mobile SCHED; every day header carries an add-task button, and visible empty days get the inline dashed one.
- **Right-hand filter rail**: collapsible Colors / Tags / Projects sections (options limited to what's in the visible window), a clear-all, and the empty-days toggle. Same OR-within/AND-across semantics as the mobile popup, same shared util.

Structural note: the agenda state (day window, filter state, derived options, empty-days preference, add-on-day helper) is extracted into `useSchedAgendaState`, now consumed by both the mobile `SchedView` and desktop `SchedDashboard` — one behavior, two skins. Narrow-viewport behavior matches WEEK: below the view-cycler breakpoint the app falls back to MULTI.

## Testing

- Full suite passes: 839 tests / 59 files; `vite build` clean.
- Manual checks on merge: cycle to SCHED with the button and with `4`; click a date in the strip and confirm the agenda re-anchors; filter by project from the rail; collapse a rail section; shrink the window below the 3-day breakpoint and confirm fallback to MULTI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_