### PR TITLE
Add per-project PLANNER dashboard; move description + hyperGLANCE out of the project form (B)

### DIFF
--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -36,7 +36,6 @@ import {
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
 import { TASK_COLORS, TAILWIND_TO_HEX, hexToRgba, PROJECT_FALLBACK_COLOR } from '../../utils/colorUtils.js';
-import { HG_ICON_GROUPS, HG_COLORS, HG_DAYS } from '../../hooks/useHyperGlance.js';
 import { dateToString } from '../../utils/taskUtils.js';
 import { calculateGoalProgress } from '../../utils/goalProgress.js';
 import { isProjectStalled } from '../../utils/projectProgress.js';
@@ -47,8 +46,6 @@ import GoalProgress from './GoalProgress.jsx';
 import ProjectCard from '../projects/ProjectCard.jsx';
 import ConfirmDialog from '../ConfirmDialog.jsx';
 import UserAssignmentPicker from '../UserAssignmentPicker.jsx';
-import DatePicker from '../DatePicker.jsx';
-import ClockTimePicker from '../ClockTimePicker.jsx';
 import { emitGoalCreate } from '../../intents/emitGoalCreate.js';
 import { INTENT_CONFIG_KEY } from '../../intents/useIntentPoller.js';
 import { enabledIntentTargets } from '../../intents/emitTargets.js';
@@ -73,13 +70,6 @@ const toLightBg = (bgClass, dark) => {
   return dark ? hexToRgba(hex, 0.13) : hexToRgba(hex, 0.09);
 };
 
-const nextQuarterHour = () => {
-  const now = new Date();
-  const m = now.getMinutes();
-  const next = Math.ceil((m + 1) / 15) * 15;
-  const h = (now.getHours() + Math.floor(next / 60)) % 24;
-  return `${String(h).padStart(2, '0')}:${String(next % 60).padStart(2, '0')}`;
-};
 
 // ─── Goal sorting helpers ─────────────────────────────────────────────────────
 
@@ -397,12 +387,6 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
 };
 
 // ─── hyperGLANCE icon lookup map ──────────────────────────────────────────────
-const HG_ICON_MAP = {
-  BookOpen, GraduationCap, Brain, Calculator, FlaskConical, Pencil, Globe, Microscope, BookMarked,
-  Briefcase, Code2, LineChart, Target, LayoutDashboard, Clipboard, Users, Mail, Rocket,
-  Dumbbell, Heart, Activity, Apple, Moon, Bike, Leaf, Trophy, Flame,
-  Music, Camera, Palette, Lightbulb, Wand2, Headphones, Mic, Film, Star,
-};
 
 // ─── Project form (create / edit) ─────────────────────────────────────────────
 
@@ -413,7 +397,6 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
   const { t } = useTranslation();
 
   const [title, setTitle] = useState(initial?.title || '');
-  const [description, setDescription] = useState(initial?.description || '');
   const [goalId, setGoalId] = useState(initial?.goalId || defaultGoalId || '');
   const [status, setStatus] = useState(initial?.status || 'active');
   // Copy-at-creation inheritance: a new project defaults its color and assigned
@@ -430,41 +413,6 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
   );
   const [usersTouched, setUsersTouched] = useState(!!initial);
 
-  // ── hyperGLANCE state ────────────────────────────────────────────────────
-  const initHG = initial?.hyperglance || {};
-  const [hgEnabled, setHgEnabled] = useState(initHG.enabled || false);
-  const [hgIcon, setHgIcon] = useState(initHG.icon || 'BookOpen');
-  const [hgColor, setHgColor] = useState(initHG.color || '#4f46e5');
-  const [hgIsRecurring, setHgIsRecurring] = useState(initHG.isRecurring !== false);
-  const [hgScheduledDays, setHgScheduledDays] = useState(initHG.scheduledDays || []);
-  const [hgScheduledDate, setHgScheduledDate] = useState(initHG.scheduledDate || dateToString(new Date()));
-  const [hgScheduledTime, setHgScheduledTime] = useState(initHG.scheduledTime || nextQuarterHour());
-  const [hgDuration, setHgDuration] = useState(initHG.scheduledDuration || 60);
-  const [hgTemplateTasks, setHgTemplateTasks] = useState(initHG.templateTasks || []);
-  const [hgNewTask, setHgNewTask] = useState('');
-  const [editingTemplateTask, setEditingTemplateTask] = useState(null); // { id, name, notes }
-  const [showHgDatePicker, setShowHgDatePicker] = useState(false);
-  const [showHgTimePicker, setShowHgTimePicker] = useState(false);
-
-  const toggleHGDay = (day) => {
-    setHgScheduledDays(prev =>
-      prev.includes(day) ? prev.filter(d => d !== day) : [...prev, day]
-    );
-  };
-
-  const addHGTemplateTask = () => {
-    if (!hgNewTask.trim()) return;
-    setHgTemplateTasks(prev => [...prev, { id: crypto.randomUUID(), name: hgNewTask.trim(), notes: '' }]);
-    setHgNewTask('');
-  };
-
-  const removeHGTemplateTask = (id) => setHgTemplateTasks(prev => prev.filter(t => t.id !== id));
-  const saveEditingTemplateTask = () => {
-    if (!editingTemplateTask) return;
-    setHgTemplateTasks(prev => prev.map(t => t.id === editingTemplateTask.id ? { ...t, name: editingTemplateTask.name, notes: editingTemplateTask.notes } : t));
-    setEditingTemplateTask(null);
-  };
-
   // "Completed" only available when all project tasks are completed (or none exist)
   const projectTasks = initial
     ? [...tasks, ...unscheduledTasks].filter(t => t.projectId === initial.id && !t.archived)
@@ -474,20 +422,9 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!title.trim()) return;
-    const hyperglance = hgEnabled ? {
-      enabled: true,
-      icon: hgIcon,
-      color: hgColor,
-      isRecurring: hgIsRecurring,
-      scheduledDays: hgIsRecurring ? hgScheduledDays : [],
-      scheduledDate: hgIsRecurring ? null : (hgScheduledDate || null),
-      scheduledTime: hgScheduledTime,
-      scheduledDuration: Math.max(15, Math.round(hgDuration / 15) * 15),
-      templateTasks: hgTemplateTasks,
-      completions: initHG.completions || [],
-      createdAt: initHG.createdAt || new Date().toISOString(),
-    } : null;
-    onSave({ title: title.trim(), description: description.trim(), goalId: goalId || undefined, status, color, assignedUserSyncIds, hyperglance });
+    // description and hyperglance are managed in the Project Planner now;
+    // omitting them here preserves existing values on save (updateProject merges).
+    onSave({ title: title.trim(), goalId: goalId || undefined, status, color, assignedUserSyncIds });
   };
 
   const activeGoals = goals.filter(g => g.status !== 'archived');
@@ -511,20 +448,6 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
           onChange={e => setTitle(e.target.value)}
           placeholder="e.g. Cloud Sync"
           className={`px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-            darkMode ? 'bg-gray-700 text-gray-100 placeholder-gray-500' : 'bg-white text-stone-900 placeholder-stone-400'
-          }`}
-        />
-      </div>
-
-      {/* Description */}
-      <div className="flex flex-col gap-1">
-        <label className={`text-xs font-medium ${textSecondary}`}>Description</label>
-        <textarea
-          value={description}
-          onChange={e => setDescription(e.target.value)}
-          placeholder="Optional description…"
-          rows={2}
-          className={`px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none ${
             darkMode ? 'bg-gray-700 text-gray-100 placeholder-gray-500' : 'bg-white text-stone-900 placeholder-stone-400'
           }`}
         />
@@ -614,266 +537,6 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
               Complete all tasks first to mark this project as done.
             </p>
           )}
-        </div>
-      )}
-
-      {/* ── hyperGLANCE section ────────────────────────────────────────── */}
-      <div className={`rounded-xl border ${borderClass} overflow-hidden`}>
-        {/* Toggle row */}
-        <button
-          type="button"
-          onClick={() => setHgEnabled(v => !v)}
-          className={`w-full flex items-center justify-between px-3 py-2.5 ${hoverBg} transition-colors`}
-        >
-          <div className="flex items-center gap-2">
-            <Zap size={15} className={hgEnabled ? 'text-yellow-400' : textSecondary} />
-            <span className={`text-sm font-medium ${hgEnabled ? textPrimary : textSecondary}`}>
-              hyperGLANCE
-            </span>
-            {hgEnabled && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-yellow-400/20 text-yellow-400 font-semibold">ON</span>
-            )}
-          </div>
-          <ChevronDown size={14} className={`${textSecondary} transition-transform ${hgEnabled ? 'rotate-180' : ''}`} />
-        </button>
-
-        {hgEnabled && (
-          <div className={`px-3 pb-4 pt-1 space-y-4 border-t ${borderClass}`}>
-            {/* Icon picker */}
-            <div className="flex flex-col gap-1.5">
-              <label className={`text-xs font-medium ${textSecondary}`}>Icon</label>
-              {HG_ICON_GROUPS.map(({ group, icons }) => (
-                <div key={group}>
-                  <div className={`text-[10px] font-medium ${textSecondary} opacity-60 mb-1`}>{group}</div>
-                  <div className="flex flex-wrap gap-1">
-                    {icons.map(iconName => {
-                      const Ic = HG_ICON_MAP[iconName];
-                      if (!Ic) return null;
-                      return (
-                        <button
-                          key={iconName}
-                          type="button"
-                          onClick={() => setHgIcon(iconName)}
-                          className={`w-8 h-8 rounded-lg flex items-center justify-center transition-colors ${
-                            hgIcon === iconName
-                              ? 'ring-2'
-                              : `${hoverBg} opacity-60 hover:opacity-100`
-                          }`}
-                          style={hgIcon === iconName ? { ringColor: hgColor, backgroundColor: hexToRgba(hgColor, 0.125) } : {}}
-                          title={iconName}
-                        >
-                          <Ic size={15} style={{ color: hgIcon === iconName ? hgColor : undefined }} className={hgIcon === iconName ? '' : textSecondary} />
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            {/* Color picker */}
-            <div className="flex flex-col gap-1.5">
-              <label className={`text-xs font-medium ${textSecondary}`}>Color</label>
-              <div className="flex flex-wrap gap-2">
-                {HG_COLORS.map(c => (
-                  <button
-                    key={c.value}
-                    type="button"
-                    onClick={() => setHgColor(c.value)}
-                    className={`w-7 h-7 rounded-full transition-all ${hgColor === c.value ? 'ring-2 ring-offset-2' : 'opacity-70 hover:opacity-100'}`}
-                    style={{ backgroundColor: c.value, ringColor: c.value }}
-                    title={c.label}
-                  />
-                ))}
-              </div>
-            </div>
-
-            {/* Schedule type */}
-            <div className="flex flex-col gap-1.5">
-              <label className={`text-xs font-medium ${textSecondary}`}>Schedule</label>
-              <div className={`flex rounded-lg border ${borderClass} overflow-hidden`}>
-                {[{ value: true, label: 'Recurring' }, { value: false, label: 'One-off' }].map(opt => (
-                  <button
-                    key={String(opt.value)}
-                    type="button"
-                    onClick={() => setHgIsRecurring(opt.value)}
-                    className={`flex-1 py-1.5 text-xs font-medium transition-colors ${
-                      hgIsRecurring === opt.value ? 'bg-blue-600 text-white' : `${textSecondary} ${hoverBg}`
-                    }`}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Recurring: day picker */}
-            {hgIsRecurring && (
-              <div className="flex flex-col gap-1.5">
-                <label className={`text-xs font-medium ${textSecondary}`}>Days</label>
-                <div className="flex gap-1 flex-wrap">
-                  {HG_DAYS.slice(1).concat(HG_DAYS[0]).map(day => (
-                    <button
-                      key={day}
-                      type="button"
-                      onClick={() => toggleHGDay(day)}
-                      className={`px-2 py-1 rounded-md text-[11px] font-medium transition-colors ${
-                        hgScheduledDays.includes(day)
-                          ? 'text-white'
-                          : `${textSecondary} ${hoverBg} opacity-60`
-                      }`}
-                      style={hgScheduledDays.includes(day) ? { backgroundColor: hgColor } : {}}
-                    >
-                      {day.charAt(0).toUpperCase() + day.slice(1, 3)}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* One-off: date picker */}
-            {!hgIsRecurring && (
-              <div className="flex flex-col gap-1.5">
-                <label className={`text-xs font-medium ${textSecondary}`}>Date</label>
-                <button
-                  type="button"
-                  onClick={() => setShowHgDatePicker(true)}
-                  className={`px-3 py-2 text-sm rounded-lg border ${borderClass} text-left ${darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'}`}
-                >
-                  {hgScheduledDate
-                    ? new Date(hgScheduledDate + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
-                    : 'Select date…'}
-                </button>
-                {showHgDatePicker && (
-                  <DatePicker
-                    value={hgScheduledDate}
-                    onChange={(d) => { setHgScheduledDate(d); setShowHgDatePicker(false); }}
-                    onClose={() => setShowHgDatePicker(false)}
-                  />
-                )}
-              </div>
-            )}
-
-            {/* Time + Duration row */}
-            <div className="flex gap-3">
-              <div className="flex flex-col gap-1.5 flex-1">
-                <label className={`text-xs font-medium ${textSecondary}`}>Start time</label>
-                <button
-                  type="button"
-                  onClick={() => setShowHgTimePicker(true)}
-                  className={`px-3 py-2 text-sm rounded-lg border ${borderClass} text-left ${darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'}`}
-                >
-                  {(() => {
-                    const [h, m] = (hgScheduledTime || '09:00').split(':').map(Number);
-                    if (use24HourClock) return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
-                    const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
-                    const ampm = h < 12 ? 'AM' : 'PM';
-                    return `${h12}:${String(m).padStart(2, '0')} ${ampm}`;
-                  })()}
-                </button>
-                {showHgTimePicker && (
-                  <ClockTimePicker
-                    value={hgScheduledTime}
-                    onChange={(t) => { setHgScheduledTime(t); setShowHgTimePicker(false); }}
-                    onClose={() => setShowHgTimePicker(false)}
-                    darkMode={darkMode} isTablet={isTablet} use24HourClock={use24HourClock}
-                  />
-                )}
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <label className={`text-xs font-medium ${textSecondary}`}>Duration</label>
-                <div className="flex items-center gap-1.5">
-                  <button
-                    type="button"
-                    onClick={() => setHgDuration(d => Math.max(15, d - 15))}
-                    className={`w-8 h-8 rounded-lg border ${borderClass} flex items-center justify-center text-base font-bold ${hoverBg} ${textPrimary} transition-colors`}
-                  >−</button>
-                  <span className={`text-sm font-medium ${textPrimary} w-14 text-center`}>{hgDuration}m</span>
-                  <button
-                    type="button"
-                    onClick={() => setHgDuration(d => Math.min(480, d + 15))}
-                    className={`w-8 h-8 rounded-lg border ${borderClass} flex items-center justify-center text-base font-bold ${hoverBg} ${textPrimary} transition-colors`}
-                  >+</button>
-                </div>
-              </div>
-            </div>
-
-            {/* Template tasks */}
-            {hgIsRecurring && (
-              <div className="flex flex-col gap-1.5">
-                <label className={`text-xs font-medium ${textSecondary}`}>
-                  Template tasks <span className="opacity-50 font-normal">(instantiated each session)</span>
-                </label>
-                {hgTemplateTasks.map(t => (
-                  <div key={t.id} className={`flex items-center gap-2 px-2 py-1.5 rounded-lg ${darkMode ? 'bg-gray-700/50' : 'bg-stone-50'}`}>
-                    <span className={`flex-1 text-sm ${textPrimary}`}>{t.name}</span>
-                    {t.notes && <span className={`text-xs ${textSecondary} truncate max-w-[120px]`} title={t.notes}>{t.notes}</span>}
-                    <button type="button" onClick={() => setEditingTemplateTask({ id: t.id, name: t.name, notes: t.notes || '' })} className={`p-0.5 rounded ${hoverBg}`}>
-                      <Pencil size={13} className={textSecondary} />
-                    </button>
-                    <button type="button" onClick={() => removeHGTemplateTask(t.id)} className={`p-0.5 rounded ${hoverBg}`}>
-                      <Trash2 size={13} className="text-red-400" />
-                    </button>
-                  </div>
-                ))}
-                <div className="flex gap-2 mt-1">
-                  <input
-                    type="text"
-                    value={hgNewTask}
-                    onChange={e => setHgNewTask(e.target.value)}
-                    onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addHGTemplateTask(); } }}
-                    placeholder="Add task…"
-                    className={`flex-1 px-2 py-1.5 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                      darkMode ? 'bg-gray-700 text-gray-100 placeholder-gray-500' : 'bg-white text-stone-900 placeholder-stone-400'
-                    }`}
-                  />
-                  <button
-                    type="button"
-                    onClick={addHGTemplateTask}
-                    disabled={!hgNewTask.trim()}
-                    className="px-2 py-1.5 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-40"
-                  >
-                    <Plus size={14} />
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Template task edit modal */}
-      {editingTemplateTask && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[80]" onClick={() => setEditingTemplateTask(null)}>
-          <div className={`${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'} border rounded-xl shadow-2xl p-4 w-80 mx-4`} onClick={e => e.stopPropagation()}>
-            <h4 className={`text-sm font-semibold ${textPrimary} mb-3`}>{t('goals.editTemplateTask')}</h4>
-            <div className="space-y-3">
-              <div>
-                <label className={`text-xs font-medium ${textSecondary} mb-1 block`}>Name</label>
-                <input
-                  type="text"
-                  value={editingTemplateTask.name}
-                  onChange={e => setEditingTemplateTask(prev => ({ ...prev, name: e.target.value }))}
-                  className={`w-full px-2 py-1.5 text-sm rounded-lg border ${darkMode ? 'bg-gray-700 border-gray-600 text-gray-100' : 'bg-white border-stone-300 text-stone-900'} focus:outline-none focus:ring-2 focus:ring-blue-500`}
-                  autoFocus
-                />
-              </div>
-              <div>
-                <label className={`text-xs font-medium ${textSecondary} mb-1 block`}>Note <span className="font-normal opacity-60">(carried into each session)</span></label>
-                <textarea
-                  value={editingTemplateTask.notes}
-                  onChange={e => setEditingTemplateTask(prev => ({ ...prev, notes: e.target.value }))}
-                  rows={3}
-                  placeholder="Optional note…"
-                  className={`w-full px-2 py-1.5 text-sm rounded-lg border resize-none ${darkMode ? 'bg-gray-700 border-gray-600 text-gray-100 placeholder-gray-500' : 'bg-white border-stone-300 text-stone-900 placeholder-stone-400'} focus:outline-none focus:ring-2 focus:ring-blue-500`}
-                />
-              </div>
-            </div>
-            <div className="flex gap-2 justify-end mt-4">
-              <button type="button" onClick={() => setEditingTemplateTask(null)} className={`px-3 py-1.5 text-sm rounded-lg ${hoverBg} ${textSecondary} transition-colors`}>Cancel</button>
-              <button type="button" onClick={saveEditingTemplateTask} disabled={!editingTemplateTask.name.trim()} className="px-3 py-1.5 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium disabled:opacity-50">Save</button>
-            </div>
-          </div>
         </div>
       )}
 

--- a/src/components/projects/HyperGlanceEditor.jsx
+++ b/src/components/projects/HyperGlanceEditor.jsx
@@ -1,0 +1,365 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Activity, Apple, Bike, BookMarked, BookOpen, Brain, Briefcase, Calculator,
+  Camera, ChevronDown, Clipboard, Code2, Dumbbell, Film, FlaskConical, Flame,
+  Globe, GraduationCap, Headphones, Heart, LayoutDashboard, Leaf, Lightbulb,
+  LineChart, Mail, Mic, Microscope, Moon, Music, Palette, Pencil, Plus, Rocket,
+  Star, Target, Trash2, Trophy, Users, Wand2, Zap,
+} from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
+import { HG_ICON_GROUPS, HG_COLORS, HG_DAYS } from '../../hooks/useHyperGlance.js';
+import { hexToRgba } from '../../utils/colorUtils.js';
+import { dateToString } from '../../utils/taskUtils.js';
+import DatePicker from '../DatePicker.jsx';
+import ClockTimePicker from '../ClockTimePicker.jsx';
+
+const HG_ICON_MAP = {
+  BookOpen, GraduationCap, Brain, Calculator, FlaskConical, Pencil, Globe, Microscope, BookMarked,
+  Briefcase, Code2, LineChart, Target, LayoutDashboard, Clipboard, Users, Mail, Rocket,
+  Dumbbell, Heart, Activity, Apple, Moon, Bike, Leaf, Trophy, Flame,
+  Music, Camera, Palette, Lightbulb, Wand2, Headphones, Mic, Film, Star,
+};
+
+const nextQuarterHour = () => {
+  const now = new Date();
+  const minutes = now.getMinutes();
+  const next = Math.ceil(minutes / 15) * 15;
+  if (next === 60) { now.setHours(now.getHours() + 1); now.setMinutes(0); }
+  else now.setMinutes(next);
+  return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+};
+
+/**
+ * Self-contained hyperGLANCE settings editor — extracted from ProjectForm and
+ * now hosted by the Project Planner. Owns its form state and emits the
+ * assembled hyperglance object (or null when disabled) through onChange on
+ * every user change; the initial value never triggers an emit, so mounting
+ * the editor can't dirty the project.
+ */
+const HyperGlanceEditor = ({ value, onChange }) => {
+  const { darkMode, borderClass, textPrimary, textSecondary, hoverBg, use24HourClock, isTablet } =
+    useDayPlannerCtx();
+  const { t } = useTranslation();
+
+  const initHG = value || {};
+  const [hgEnabled, setHgEnabled] = useState(initHG.enabled || false);
+  const [hgIcon, setHgIcon] = useState(initHG.icon || 'BookOpen');
+  const [hgColor, setHgColor] = useState(initHG.color || '#4f46e5');
+  const [hgIsRecurring, setHgIsRecurring] = useState(initHG.isRecurring !== false);
+  const [hgScheduledDays, setHgScheduledDays] = useState(initHG.scheduledDays || []);
+  const [hgScheduledDate, setHgScheduledDate] = useState(initHG.scheduledDate || dateToString(new Date()));
+  const [hgScheduledTime, setHgScheduledTime] = useState(initHG.scheduledTime || nextQuarterHour());
+  const [hgDuration, setHgDuration] = useState(initHG.scheduledDuration || 60);
+  const [hgTemplateTasks, setHgTemplateTasks] = useState(initHG.templateTasks || []);
+  const [hgNewTask, setHgNewTask] = useState('');
+  const [editingTemplateTask, setEditingTemplateTask] = useState(null); // { id, name, notes }
+  const [showHgDatePicker, setShowHgDatePicker] = useState(false);
+  const [showHgTimePicker, setShowHgTimePicker] = useState(false);
+
+  const toggleHGDay = (day) => {
+    setHgScheduledDays(prev =>
+      prev.includes(day) ? prev.filter(d => d !== day) : [...prev, day]
+    );
+  };
+
+  const addHGTemplateTask = () => {
+    if (!hgNewTask.trim()) return;
+    setHgTemplateTasks(prev => [...prev, { id: crypto.randomUUID(), name: hgNewTask.trim(), notes: '' }]);
+    setHgNewTask('');
+  };
+
+  const removeHGTemplateTask = (id) => setHgTemplateTasks(prev => prev.filter(t => t.id !== id));
+  const saveEditingTemplateTask = () => {
+    if (!editingTemplateTask) return;
+    setHgTemplateTasks(prev => prev.map(t => t.id === editingTemplateTask.id ? { ...t, name: editingTemplateTask.name, notes: editingTemplateTask.notes } : t));
+    setEditingTemplateTask(null);
+  };
+
+  // Emit the assembled hyperglance object on user changes (skip mount).
+  const mountedRef = useRef(false);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  useEffect(() => {
+    if (!mountedRef.current) { mountedRef.current = true; return; }
+    const hyperglance = hgEnabled ? {
+      enabled: true,
+      icon: hgIcon,
+      color: hgColor,
+      isRecurring: hgIsRecurring,
+      scheduledDays: hgIsRecurring ? hgScheduledDays : [],
+      scheduledDate: hgIsRecurring ? null : (hgScheduledDate || null),
+      scheduledTime: hgScheduledTime,
+      scheduledDuration: Math.max(15, Math.round(hgDuration / 15) * 15),
+      templateTasks: hgTemplateTasks,
+      completions: initHG.completions || [],
+      createdAt: initHG.createdAt || new Date().toISOString(),
+    } : null;
+    onChangeRef.current?.(hyperglance);
+    // initHG fields are carried through, not inputs to re-emit on.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hgEnabled, hgIcon, hgColor, hgIsRecurring, hgScheduledDays, hgScheduledDate, hgScheduledTime, hgDuration, hgTemplateTasks]);
+
+  return (
+    <div className={`rounded-xl border ${borderClass} overflow-hidden`}>
+      {/* Toggle row */}
+      <button
+        type="button"
+        onClick={() => setHgEnabled(v => !v)}
+        className={`w-full flex items-center justify-between px-3 py-2.5 ${hoverBg} transition-colors`}
+      >
+        <div className="flex items-center gap-2">
+          <Zap size={15} className={hgEnabled ? 'text-yellow-400' : textSecondary} />
+          <span className={`text-sm font-medium ${hgEnabled ? textPrimary : textSecondary}`}>
+            hyperGLANCE
+          </span>
+          {hgEnabled && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-yellow-400/20 text-yellow-400 font-semibold">ON</span>
+          )}
+        </div>
+        <ChevronDown size={14} className={`${textSecondary} transition-transform ${hgEnabled ? 'rotate-180' : ''}`} />
+      </button>
+
+      {hgEnabled && (
+        <div className={`px-3 pb-4 pt-1 space-y-4 border-t ${borderClass}`}>
+          {/* Icon picker */}
+          <div className="flex flex-col gap-1.5">
+            <label className={`text-xs font-medium ${textSecondary}`}>Icon</label>
+            {HG_ICON_GROUPS.map(({ group, icons }) => (
+              <div key={group}>
+                <div className={`text-[10px] font-medium ${textSecondary} opacity-60 mb-1`}>{group}</div>
+                <div className="flex flex-wrap gap-1">
+                  {icons.map(iconName => {
+                    const Ic = HG_ICON_MAP[iconName];
+                    if (!Ic) return null;
+                    return (
+                      <button
+                        key={iconName}
+                        type="button"
+                        onClick={() => setHgIcon(iconName)}
+                        className={`w-8 h-8 rounded-lg flex items-center justify-center transition-colors ${
+                          hgIcon === iconName
+                            ? 'ring-2'
+                            : `${hoverBg} opacity-60 hover:opacity-100`
+                        }`}
+                        style={hgIcon === iconName ? { ringColor: hgColor, backgroundColor: hexToRgba(hgColor, 0.125) } : {}}
+                        title={iconName}
+                      >
+                        <Ic size={15} style={{ color: hgIcon === iconName ? hgColor : undefined }} className={hgIcon === iconName ? '' : textSecondary} />
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Color picker */}
+          <div className="flex flex-col gap-1.5">
+            <label className={`text-xs font-medium ${textSecondary}`}>Color</label>
+            <div className="flex flex-wrap gap-2">
+              {HG_COLORS.map(c => (
+                <button
+                  key={c.value}
+                  type="button"
+                  onClick={() => setHgColor(c.value)}
+                  className={`w-7 h-7 rounded-full transition-all ${hgColor === c.value ? 'ring-2 ring-offset-2' : 'opacity-70 hover:opacity-100'}`}
+                  style={{ backgroundColor: c.value, ringColor: c.value }}
+                  title={c.label}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Schedule type */}
+          <div className="flex flex-col gap-1.5">
+            <label className={`text-xs font-medium ${textSecondary}`}>Schedule</label>
+            <div className={`flex rounded-lg border ${borderClass} overflow-hidden`}>
+              {[{ value: true, label: 'Recurring' }, { value: false, label: 'One-off' }].map(opt => (
+                <button
+                  key={String(opt.value)}
+                  type="button"
+                  onClick={() => setHgIsRecurring(opt.value)}
+                  className={`flex-1 py-1.5 text-xs font-medium transition-colors ${
+                    hgIsRecurring === opt.value ? 'bg-blue-600 text-white' : `${textSecondary} ${hoverBg}`
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Recurring: day picker */}
+          {hgIsRecurring && (
+            <div className="flex flex-col gap-1.5">
+              <label className={`text-xs font-medium ${textSecondary}`}>Days</label>
+              <div className="flex gap-1 flex-wrap">
+                {HG_DAYS.slice(1).concat(HG_DAYS[0]).map(day => (
+                  <button
+                    key={day}
+                    type="button"
+                    onClick={() => toggleHGDay(day)}
+                    className={`px-2 py-1 rounded-md text-[11px] font-medium transition-colors ${
+                      hgScheduledDays.includes(day)
+                        ? 'text-white'
+                        : `${textSecondary} ${hoverBg} opacity-60`
+                    }`}
+                    style={hgScheduledDays.includes(day) ? { backgroundColor: hgColor } : {}}
+                  >
+                    {day.charAt(0).toUpperCase() + day.slice(1, 3)}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* One-off: date picker */}
+          {!hgIsRecurring && (
+            <div className="flex flex-col gap-1.5">
+              <label className={`text-xs font-medium ${textSecondary}`}>Date</label>
+              <button
+                type="button"
+                onClick={() => setShowHgDatePicker(true)}
+                className={`px-3 py-2 text-sm rounded-lg border ${borderClass} text-left ${darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'}`}
+              >
+                {hgScheduledDate
+                  ? new Date(hgScheduledDate + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+                  : 'Select date…'}
+              </button>
+              {showHgDatePicker && (
+                <DatePicker
+                  value={hgScheduledDate}
+                  onChange={(d) => { setHgScheduledDate(d); setShowHgDatePicker(false); }}
+                  onClose={() => setShowHgDatePicker(false)}
+                />
+              )}
+            </div>
+          )}
+
+          {/* Time + Duration row */}
+          <div className="flex gap-3">
+            <div className="flex flex-col gap-1.5 flex-1">
+              <label className={`text-xs font-medium ${textSecondary}`}>Start time</label>
+              <button
+                type="button"
+                onClick={() => setShowHgTimePicker(true)}
+                className={`px-3 py-2 text-sm rounded-lg border ${borderClass} text-left ${darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'}`}
+              >
+                {(() => {
+                  const [h, m] = (hgScheduledTime || '09:00').split(':').map(Number);
+                  if (use24HourClock) return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+                  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+                  const ampm = h < 12 ? 'AM' : 'PM';
+                  return `${h12}:${String(m).padStart(2, '0')} ${ampm}`;
+                })()}
+              </button>
+              {showHgTimePicker && (
+                <ClockTimePicker
+                  value={hgScheduledTime}
+                  onChange={(t) => { setHgScheduledTime(t); setShowHgTimePicker(false); }}
+                  onClose={() => setShowHgTimePicker(false)}
+                  darkMode={darkMode} isTablet={isTablet} use24HourClock={use24HourClock}
+                />
+              )}
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className={`text-xs font-medium ${textSecondary}`}>Duration</label>
+              <div className="flex items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => setHgDuration(d => Math.max(15, d - 15))}
+                  className={`w-8 h-8 rounded-lg border ${borderClass} flex items-center justify-center text-base font-bold ${hoverBg} ${textPrimary} transition-colors`}
+                >−</button>
+                <span className={`text-sm font-medium ${textPrimary} w-14 text-center`}>{hgDuration}m</span>
+                <button
+                  type="button"
+                  onClick={() => setHgDuration(d => Math.min(480, d + 15))}
+                  className={`w-8 h-8 rounded-lg border ${borderClass} flex items-center justify-center text-base font-bold ${hoverBg} ${textPrimary} transition-colors`}
+                >+</button>
+              </div>
+            </div>
+          </div>
+
+          {/* Template tasks */}
+          {hgIsRecurring && (
+            <div className="flex flex-col gap-1.5">
+              <label className={`text-xs font-medium ${textSecondary}`}>
+                Template tasks <span className="opacity-50 font-normal">(instantiated each session)</span>
+              </label>
+              {hgTemplateTasks.map(tt => (
+                <div key={tt.id} className={`flex items-center gap-2 px-2 py-1.5 rounded-lg ${darkMode ? 'bg-gray-700/50' : 'bg-stone-50'}`}>
+                  <span className={`flex-1 text-sm ${textPrimary}`}>{tt.name}</span>
+                  {tt.notes && <span className={`text-xs ${textSecondary} truncate max-w-[120px]`} title={tt.notes}>{tt.notes}</span>}
+                  <button type="button" onClick={() => setEditingTemplateTask({ id: tt.id, name: tt.name, notes: tt.notes || '' })} className={`p-0.5 rounded ${hoverBg}`}>
+                    <Pencil size={13} className={textSecondary} />
+                  </button>
+                  <button type="button" onClick={() => removeHGTemplateTask(tt.id)} className={`p-0.5 rounded ${hoverBg}`}>
+                    <Trash2 size={13} className="text-red-400" />
+                  </button>
+                </div>
+              ))}
+              <div className="flex gap-2 mt-1">
+                <input
+                  type="text"
+                  value={hgNewTask}
+                  onChange={e => setHgNewTask(e.target.value)}
+                  onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addHGTemplateTask(); } }}
+                  placeholder="Add task…"
+                  className={`flex-1 px-2 py-1.5 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                    darkMode ? 'bg-gray-700 text-gray-100 placeholder-gray-500' : 'bg-white text-stone-900 placeholder-stone-400'
+                  }`}
+                />
+                <button
+                  type="button"
+                  onClick={addHGTemplateTask}
+                  disabled={!hgNewTask.trim()}
+                  className="px-2 py-1.5 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-40"
+                >
+                  <Plus size={14} />
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Template task edit modal */}
+      {editingTemplateTask && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[80]" onClick={() => setEditingTemplateTask(null)}>
+          <div className={`${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-stone-200'} border rounded-xl shadow-2xl p-4 w-80 mx-4`} onClick={e => e.stopPropagation()}>
+            <h4 className={`text-sm font-semibold ${textPrimary} mb-3`}>{t('goals.editTemplateTask')}</h4>
+            <div className="space-y-3">
+              <div>
+                <label className={`text-xs font-medium ${textSecondary} mb-1 block`}>Name</label>
+                <input
+                  type="text"
+                  value={editingTemplateTask.name}
+                  onChange={e => setEditingTemplateTask(prev => ({ ...prev, name: e.target.value }))}
+                  className={`w-full px-2 py-1.5 text-sm rounded-lg border ${darkMode ? 'bg-gray-700 border-gray-600 text-gray-100' : 'bg-white border-stone-300 text-stone-900'} focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                  autoFocus
+                />
+              </div>
+              <div>
+                <label className={`text-xs font-medium ${textSecondary} mb-1 block`}>Note <span className="font-normal opacity-60">(carried into each session)</span></label>
+                <textarea
+                  value={editingTemplateTask.notes}
+                  onChange={e => setEditingTemplateTask(prev => ({ ...prev, notes: e.target.value }))}
+                  rows={3}
+                  placeholder="Optional note…"
+                  className={`w-full px-2 py-1.5 text-sm rounded-lg border resize-none ${darkMode ? 'bg-gray-700 border-gray-600 text-gray-100 placeholder-gray-500' : 'bg-white border-stone-300 text-stone-900 placeholder-stone-400'} focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                />
+              </div>
+            </div>
+            <div className="flex gap-2 justify-end mt-4">
+              <button type="button" onClick={() => setEditingTemplateTask(null)} className={`px-3 py-1.5 text-sm rounded-lg ${hoverBg} ${textSecondary} transition-colors`}>Cancel</button>
+              <button type="button" onClick={saveEditingTemplateTask} disabled={!editingTemplateTask.name.trim()} className="px-3 py-1.5 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium disabled:opacity-50">Save</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HyperGlanceEditor;

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -1,10 +1,11 @@
 import React, { forwardRef, useState, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import ConfirmDialog from '../ConfirmDialog.jsx';
+import ProjectPlanner from './ProjectPlanner.jsx';
 import {
   AlertTriangle, BookOpen, Calendar, CheckCircle2, CheckSquare, ChevronDown,
-  Edit2, ExternalLink, Eye, EyeOff, FileText, GripVertical, LogIn, Plus,
-  Square, Trash2, X, Zap,
+  Edit2, ExternalLink, Eye, EyeOff, FileText, GripVertical, LayoutDashboard,
+  LogIn, Plus, Square, Trash2, X, Zap,
 } from 'lucide-react';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../../context/SyncContext.jsx';
@@ -93,6 +94,8 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
   const [dragIdx, setDragIdx] = useState(null);
   const [dragOverIdx, setDragOverIdx] = useState(null);
   const touchDragRef = useRef({ active: false, fromIdx: null, overIdx: null });
+
+  const [showPlanner, setShowPlanner] = useState(false);
 
   const handleDelete = () => setShowConfirm(true);
 
@@ -654,6 +657,16 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
             Add task
           </button>
         )}
+
+        {/* PLANNER — per-project planning dashboard (notes, hyperGLANCE, task columns) */}
+        <button
+          onClick={() => setShowPlanner(true)}
+          className={`flex items-center justify-center gap-1.5 text-[11px] font-semibold tracking-widest uppercase rounded-lg px-2 py-1.5 border ${borderClass} ${hoverBg} transition-colors w-full`}
+          style={{ color: projectHex }}
+        >
+          <LayoutDashboard size={12} />
+          Planner
+        </button>
       </div>
     </div>
 
@@ -683,6 +696,11 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
           onOpenInObsidian={extractWikilinks(expandedTask.title).length > 0 ? openInObsidian : undefined}
         />
       </div>,
+      document.body
+    )}
+
+    {showPlanner && createPortal(
+      <ProjectPlanner project={project} onClose={() => setShowPlanner(false)} />,
       document.body
     )}
 

--- a/src/components/projects/ProjectPlanner.jsx
+++ b/src/components/projects/ProjectPlanner.jsx
@@ -1,0 +1,206 @@
+import React, { useMemo, useState } from 'react';
+import { Plus, X } from 'lucide-react';
+import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
+import { useTranslation } from 'react-i18next';
+import { dateToString } from '../../utils/taskUtils.js';
+import { getProjectColor, taskColorToHex, hexToRgba } from '../../utils/colorUtils.js';
+import SchedTaskCard from '../sched/SchedTaskCard.jsx';
+import HyperGlanceEditor from './HyperGlanceEditor.jsx';
+
+/**
+ * PLANNER — a per-project planning dashboard, themed to the project's color.
+ * Bottom sheet on mobile, centered modal on desktop. Hosts the project's
+ * description and hyperGLANCE settings (both moved here from the Edit Project
+ * form) plus scheduled/unscheduled task columns with a quick-add.
+ */
+const ProjectPlanner = ({ project, onClose }) => {
+  const {
+    isMobile,
+    darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg,
+    tasks, unscheduledTasks, setUnscheduledTasks,
+  } = useDayPlannerCtx();
+  const { goals, updateProject, isVisibleForUser } = useFeaturesCtx();
+  const { t } = useTranslation();
+
+  const parentGoal = project.goalId ? goals.find(g => g.id === project.goalId) : null;
+  const projectColor = getProjectColor(project, parentGoal);
+  const projectHex = taskColorToHex(projectColor);
+
+  const [description, setDescription] = useState(project.description || '');
+  const [quickAddTitle, setQuickAddTitle] = useState('');
+
+  const saveDescription = () => {
+    if ((project.description || '') !== description) {
+      updateProject(project.id, { description: description.trim() });
+    }
+  };
+
+  // Project tasks, split into the two columns. Completed tasks sink to the
+  // bottom of their column; scheduled tasks group by day.
+  const { scheduledDays, unscheduled } = useMemo(() => {
+    const mine = (list) => list.filter(task =>
+      task.projectId === project.id && !task.archived && isVisibleForUser(task));
+    const scheduled = mine(tasks).sort((a, b) =>
+      (a.completed ? 1 : 0) - (b.completed ? 1 : 0) ||
+      (a.date || '').localeCompare(b.date || '') ||
+      (a.startTime || '').localeCompare(b.startTime || ''));
+    const byDay = [];
+    for (const task of scheduled.filter(task => !task.completed)) {
+      const last = byDay[byDay.length - 1];
+      if (last && last.dateStr === task.date) last.tasks.push(task);
+      else byDay.push({ dateStr: task.date, tasks: [task] });
+    }
+    const completedScheduled = scheduled.filter(task => task.completed);
+    if (completedScheduled.length) byDay.push({ dateStr: null, tasks: completedScheduled });
+    const inbox = mine(unscheduledTasks).sort((a, b) => (a.completed ? 1 : 0) - (b.completed ? 1 : 0));
+    return { scheduledDays: byDay, unscheduled: inbox };
+  }, [tasks, unscheduledTasks, project.id, isVisibleForUser]);
+
+  const todayStr = dateToString(new Date());
+  const dayHeading = (dateStr) => {
+    if (!dateStr) return 'Completed';
+    const d = new Date(dateStr + 'T00:00:00');
+    const base = d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+    return dateStr === todayStr ? `${t('common.today', 'Today')} · ${base}` : base;
+  };
+
+  // Quick-add an unscheduled project task — same inheritance as the card
+  // quick-add: effective project color + the project's assigned users.
+  const handleQuickAdd = (e) => {
+    e.preventDefault();
+    const title = quickAddTitle.trim();
+    if (!title) return;
+    setUnscheduledTasks(prev => [...prev, {
+      id: crypto.randomUUID(),
+      title,
+      duration: 30,
+      color: projectColor,
+      completed: false,
+      isAllDay: false,
+      notes: '',
+      subtasks: [],
+      priority: 0,
+      projectId: project.id,
+      ...(project.assignedUserSyncIds?.length ? { assignedUserSyncIds: project.assignedUserSyncIds } : {}),
+      lastModified: new Date().toISOString(),
+    }]);
+    setQuickAddTitle('');
+  };
+
+  return (
+    <div
+      className={`fixed inset-0 z-[70] flex ${isMobile ? 'flex-col justify-end' : 'items-center justify-center p-6'}`}
+      onClick={() => { saveDescription(); onClose(); }}
+    >
+      <div className="absolute inset-0 bg-black/45" />
+      <div
+        onClick={e => e.stopPropagation()}
+        className={`relative ${cardBg} shadow-2xl flex flex-col overflow-hidden ${
+          isMobile
+            ? 'rounded-t-2xl max-h-[92vh] w-full'
+            : 'rounded-2xl w-full max-w-3xl max-h-[85vh]'
+        }`}
+      >
+        {/* Project color bar + header */}
+        <div className="h-1.5 flex-shrink-0" style={{ background: projectHex }} />
+        <div
+          className={`flex items-center justify-between px-4 py-3 border-b ${borderClass} flex-shrink-0`}
+          style={{ background: hexToRgba(projectHex, darkMode ? 0.12 : 0.07) }}
+        >
+          <div className="flex flex-col min-w-0">
+            <span className={`text-base font-semibold ${textPrimary} truncate`}>{project.title}</span>
+            <span className={`text-xs ${textSecondary}`}>
+              {parentGoal ? parentGoal.title : 'Standalone project'} · Planner
+            </span>
+          </div>
+          <button
+            onClick={() => { saveDescription(); onClose(); }}
+            className={`p-1.5 rounded-lg ${hoverBg} flex-shrink-0`}
+            aria-label="Close planner"
+          >
+            <X size={16} className={textSecondary} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto p-4 flex flex-col gap-4">
+          {/* Description / notes */}
+          <div className="flex flex-col gap-1">
+            <label className={`text-xs font-medium ${textSecondary}`}>Notes</label>
+            <textarea
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              onBlur={saveDescription}
+              placeholder="What is this project about? Plans, links, context…"
+              rows={3}
+              className={`px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 resize-none ${
+                darkMode ? 'bg-gray-700 text-gray-100 placeholder-gray-500' : 'bg-white text-stone-900 placeholder-stone-400'
+              }`}
+              style={{ '--tw-ring-color': projectHex }}
+            />
+          </div>
+
+          {/* Task columns */}
+          <div className={`grid gap-4 ${isMobile ? 'grid-cols-1' : 'grid-cols-2'}`}>
+            {/* Scheduled */}
+            <div className="flex flex-col gap-2 min-w-0">
+              <span className={`text-xs font-semibold uppercase tracking-wide ${textSecondary}`}>
+                Scheduled
+              </span>
+              {scheduledDays.length > 0 ? scheduledDays.map(group => (
+                <div key={group.dateStr ?? 'completed'} className="flex flex-col gap-1">
+                  <span className={`text-[11px] font-semibold ${group.dateStr === todayStr ? 'text-blue-500' : textSecondary} ${group.dateStr ? '' : 'opacity-60'}`}>
+                    {dayHeading(group.dateStr)}
+                  </span>
+                  {group.tasks.map(task => <SchedTaskCard key={task.id} task={task} />)}
+                </div>
+              )) : (
+                <p className={`text-xs ${textSecondary} opacity-70 py-2`}>Nothing scheduled yet.</p>
+              )}
+            </div>
+
+            {/* Unscheduled */}
+            <div className="flex flex-col gap-2 min-w-0">
+              <span className={`text-xs font-semibold uppercase tracking-wide ${textSecondary}`}>
+                Unscheduled
+              </span>
+              {unscheduled.length > 0 ? (
+                unscheduled.map(task => <SchedTaskCard key={task.id} task={task} isInbox />)
+              ) : (
+                <p className={`text-xs ${textSecondary} opacity-70 py-2`}>No unscheduled tasks.</p>
+              )}
+              <form onSubmit={handleQuickAdd} className="flex gap-2">
+                <input
+                  value={quickAddTitle}
+                  onChange={e => setQuickAddTitle(e.target.value)}
+                  placeholder="Add a task…"
+                  className={`flex-1 min-w-0 px-2.5 py-1.5 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                    darkMode ? 'bg-gray-700 text-gray-100 placeholder-gray-500' : 'bg-white text-stone-900 placeholder-stone-400'
+                  }`}
+                />
+                <button
+                  type="submit"
+                  disabled={!quickAddTitle.trim()}
+                  className="px-2.5 py-1.5 rounded-lg text-white disabled:opacity-40 transition-opacity"
+                  style={{ background: projectHex }}
+                  aria-label="Add task to project"
+                >
+                  <Plus size={14} />
+                </button>
+              </form>
+            </div>
+          </div>
+
+          {/* hyperGLANCE settings (moved here from the Edit Project form) */}
+          <HyperGlanceEditor
+            value={project.hyperglance}
+            onChange={hg => updateProject(project.id, { hyperglance: hg })}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectPlanner;

--- a/src/components/sched/SchedTaskCard.jsx
+++ b/src/components/sched/SchedTaskCard.jsx
@@ -8,7 +8,7 @@ import { taskColorToHex } from '../../utils/colorUtils.js';
  * Color accent on the left, completion toggle, title, time/duration line.
  * Imported calendar events render read-only (no editor on tap).
  */
-const SchedTaskCard = ({ task }) => {
+const SchedTaskCard = ({ task, isInbox = false }) => {
   const {
     darkMode, cardBg, borderClass, textPrimary, textSecondary,
     formatTime, toggleComplete, openMobileEditTask,
@@ -26,7 +26,7 @@ const SchedTaskCard = ({ task }) => {
 
   return (
     <div
-      onClick={() => { if (!isEvent) openMobileEditTask(task, false); }}
+      onClick={() => { if (!isEvent) openMobileEditTask(task, isInbox); }}
       className={`flex items-center gap-2.5 rounded-xl border ${borderClass} ${cardBg} px-3 py-2.5 ${
         isEvent ? '' : 'cursor-pointer active:opacity-70'
       } ${task.completed ? 'opacity-55' : ''}`}
@@ -34,7 +34,7 @@ const SchedTaskCard = ({ task }) => {
     >
       {!isEvent && (
         <button
-          onClick={e => { e.stopPropagation(); toggleComplete(task.id); }}
+          onClick={e => { e.stopPropagation(); toggleComplete(task.id, isInbox); }}
           className="flex-shrink-0 p-0.5"
           aria-label={task.completed ? 'Mark incomplete' : 'Mark complete'}
         >


### PR DESCRIPTION
## Summary

**B — the final feature PR of this batch** — stacked on C2 (#1241). Full chain: A1 → A2 → C1 → C2 → this.

Every project card gets a **PLANNER** button (tinted to the project's effective color) that opens a per-project planning dashboard — **bottom sheet on mobile, centered modal on desktop**, per our design decision, themed to the project color (header tint + accent bar).

What lives in the planner:

- **Notes** — the project description, autosaved on blur and on close. Moved out of the New/Edit Project form per your notes, along with hyperGLANCE — the form is now a slim identity editor (title, goal, color, users, status).
- **Scheduled / Unscheduled task columns** (side-by-side on desktop, stacked on mobile), reusing the SCHED task cards: the scheduled column groups by day like the SCHED view, completed tasks sink to a dimmed bottom group, and the unscheduled column has a quick-add that inherits the project's color and assigned users (A1 semantics).
- **hyperGLANCE settings**, via a new self-contained `HyperGlanceEditor` extracted verbatim from ProjectForm (icon/color pickers, recurring/one-off schedule, template tasks, edit modal). It emits the assembled config only on *user* changes — mounting the planner can never dirty the project or churn sync — and saves immediately through `updateProject`.

Safety detail: ProjectForm now **omits** `description`/`hyperglance` from its save payload, so `updateProject`'s merge preserves whatever the planner has saved — editing a project's title can't clobber its HG config. `SchedTaskCard` gained an `isInbox` prop so the unscheduled column completes/edits inbox tasks through the correct paths.

## Testing

- Full suite passes: 839 tests / 59 files; `vite build` clean.
- Manual checks on merge: open the planner from a goal-child and a standalone card (theming should match card color); edit notes, close, reopen Edit Project and save — notes must survive; toggle hyperGLANCE settings in the planner and confirm the card's HG chip updates; quick-add from the planner on a user-assigned project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_