### PR TITLE
Bump Android versionCode to 178 for the fattened 4.0.0 build

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 177
+        versionCode = 178
         versionName = "4.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

versionCode 177 (#1231) was built and presumably uploaded to Play Console, and Play rejects reused version codes even for unreleased drafts. The rebuild that now carries the full merged feature set (still shipping as versionName **4.0.0**) gets 178. If 177 was never actually uploaded, 178 is still harmless — the code just skips a number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_