### PR TITLE
Add "Remove file-imported events" action to settings

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -344,7 +344,9 @@
     "icloudIntentsEnable": "iCloud-Intents aktivieren",
     "viewSched": "SCHED",
     "portraitViewDefault": "Hochformat-Ansicht",
-    "landscapeViewDefault": "Querformat-Ansicht"
+    "landscapeViewDefault": "Querformat-Ansicht",
+    "removeFileImported": "Aus Datei importierte Termine entfernen",
+    "removeFileImportedConfirm": "Alle {{n}} aus Datei importierten Termine entfernen? Ein erneuter Datei-Import stellt sie wieder her."
   },
   "task": {
     "newScheduled": "Neue geplante Aufgabe",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -344,7 +344,9 @@
     "enableE2EEncryption": "Enable end-to-end encryption",
     "icloudIntents": "iCloud intents",
     "icloudIntentsDesc": "Share task intents with other GLANCE apps through iCloud Drive. Files sync automatically across your Apple devices.",
-    "icloudIntentsEnable": "Enable iCloud intents"
+    "icloudIntentsEnable": "Enable iCloud intents",
+    "removeFileImported": "Remove file-imported events",
+    "removeFileImportedConfirm": "Remove all {{n}} file-imported events? Re-importing the file brings them back."
   },
   "task": {
     "newScheduled": "New Scheduled Task",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -344,7 +344,9 @@
     "icloudIntentsEnable": "Activar los intents de iCloud",
     "viewSched": "SCHED",
     "portraitViewDefault": "Vista en vertical",
-    "landscapeViewDefault": "Vista en horizontal"
+    "landscapeViewDefault": "Vista en horizontal",
+    "removeFileImported": "Eliminar eventos importados de archivo",
+    "removeFileImportedConfirm": "¿Eliminar los {{n}} eventos importados de archivo? Volver a importar el archivo los restaura."
   },
   "task": {
     "newScheduled": "Nueva tarea programada",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -344,7 +344,9 @@
     "icloudIntentsEnable": "Activer les intents iCloud",
     "viewSched": "SCHED",
     "portraitViewDefault": "Vue en portrait",
-    "landscapeViewDefault": "Vue en paysage"
+    "landscapeViewDefault": "Vue en paysage",
+    "removeFileImported": "Supprimer les événements importés depuis un fichier",
+    "removeFileImportedConfirm": "Supprimer les {{n}} événements importés depuis un fichier ? Réimporter le fichier les restaurera."
   },
   "task": {
     "newScheduled": "Nouvelle tâche planifiée",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -344,7 +344,9 @@
     "icloudIntentsEnable": "Abilita gli intent di iCloud",
     "viewSched": "SCHED",
     "portraitViewDefault": "Vista verticale",
-    "landscapeViewDefault": "Vista orizzontale"
+    "landscapeViewDefault": "Vista orizzontale",
+    "removeFileImported": "Rimuovi gli eventi importati da file",
+    "removeFileImportedConfirm": "Rimuovere tutti i {{n}} eventi importati da file? Reimportando il file verranno ripristinati."
   },
   "task": {
     "newScheduled": "Nuova attività pianificata",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -344,7 +344,9 @@
     "icloudIntentsEnable": "Ativar os intents do iCloud",
     "viewSched": "SCHED",
     "portraitViewDefault": "Vista vertical",
-    "landscapeViewDefault": "Vista horizontal"
+    "landscapeViewDefault": "Vista horizontal",
+    "removeFileImported": "Remover eventos importados de ficheiro",
+    "removeFileImportedConfirm": "Remover os {{n}} eventos importados de ficheiro? Reimportar o ficheiro irá restaurá-los."
   },
   "task": {
     "newScheduled": "Nova tarefa agendada",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4091,6 +4091,29 @@ const DayPlanner = () => {
     reader.readAsText(pendingImportFile);
   };
 
+  // Delete every file-imported calendar EVENT (importSource 'file', not task
+  // calendar). URL-subscribed events are replaced wholesale on every sync, but
+  // file imports are first-class synced data with no other removal path — the
+  // only way to change them was importing another file over them. Tombstones
+  // are written so the cloud merge doesn't resurrect the removed copies.
+  const removeFileImportedEvents = () => {
+    const isFileEvent = (t) => t.imported && !t.isTaskCalendar && t.importSource === 'file';
+    const targets = tasks.filter(isFileEvent);
+    if (targets.length === 0) return;
+    try {
+      const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}');
+      const nowIso = new Date().toISOString();
+      for (const t of targets) tombstones[t.id] = nowIso;
+      localStorage.setItem('day-planner-deleted-task-ids', JSON.stringify(tombstones));
+    } catch { /* removal still proceeds; worst case a copy syncs back */ }
+    setTasks(prev => prev.filter(t => !isFileEvent(t)));
+    setSyncNotification({
+      type: 'success',
+      title: 'iCal Import',
+      message: `Removed ${targets.length} file-imported event${targets.length !== 1 ? 's' : ''}`
+    });
+  };
+
   // Export all app data as a JSON backup file
   const exportBackup = () => {
     const backup = {
@@ -7868,7 +7891,7 @@ const DayPlanner = () => {
     restoreFromAutoBackup, restoreFromRemoteBackup,
     folderBackup, restoreFromBackupFolder,
     exportBackup, restoreBackup,
-    handleFileUpload, handleBackupFileSelect, processImportFile,
+    handleFileUpload, handleBackupFileSelect, processImportFile, removeFileImportedEvents,
     buildSyncPayload,
     fetchAllDailyContent, fetchWeather,
   };

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -41,7 +41,7 @@ const MobileSettingsPanel = () => {
   const {
     isPro, isAndroidApp, isIOSApp, isElectronApp, subProductId,
     consumeTestPurchase, canConsumeTestPurchase,
-    setTasks, setUnscheduledTasks,
+    tasks, setTasks, setUnscheduledTasks,
     darkMode, setDarkMode,
     mobileSettingsView, setMobileSettingsView,
     use24HourClock, setUse24HourClock,
@@ -92,6 +92,7 @@ const MobileSettingsPanel = () => {
     deleteLocalAutoBackup, deleteRemoteAutoBackup,
     exportBackup, handleFileUpload, handleBackupFileSelect,
     setShowIntentActivityLog,
+    removeFileImportedEvents,
   } = useSyncCtx();
   const {
     routinesEnabled, setRoutinesEnabled,
@@ -812,6 +813,21 @@ const MobileSettingsPanel = () => {
           {t('settings.chooseIcsFile')}
           <input type="file" accept=".ics" onChange={(e) => { handleFileUpload(e); setMobileSettingsView('main'); }} className="hidden" />
         </label>
+        {(() => {
+          const count = tasks.filter(t2 => t2.imported && !t2.isTaskCalendar && t2.importSource === 'file').length;
+          return count > 0 && (
+            <button
+              onClick={() => {
+                if (window.confirm(t('settings.removeFileImportedConfirm', 'Remove all {{n}} file-imported events? Re-importing the file brings them back.', { n: count }))) {
+                  removeFileImportedEvents();
+                }
+              }}
+              className="block text-xs font-medium text-red-500"
+            >
+              {t('settings.removeFileImported', 'Remove file-imported events')} ({count})
+            </button>
+          );
+        })()}
       </div>
 
     </div>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -43,7 +43,7 @@ const SettingsModal = () => {
     weatherZip, setWeatherZip, fetchWeather, weatherTempUnit, setWeatherTempUnit,
     weatherEnabled, setWeatherEnabled,
     dailyContentEnabled, setDailyContentEnabled,
-    setTasks, setUnscheduledTasks,
+    tasks, setTasks, setUnscheduledTasks,
     dailyNoteTemplate, setDailyNoteTemplate,
     defaultView, setDefaultView,
     dayViewMode, setDayViewMode,
@@ -73,7 +73,12 @@ const SettingsModal = () => {
     performObsidianSync,
     trmnlConfig, setTrmnlConfig, trmnlSyncStatus, trmnlLastSynced, performTrmnlSync,
     setShowIntentActivityLog,
+    removeFileImportedEvents,
   } = useSyncCtx();
+
+  const fileImportedEventCount = tasks.filter(
+    t => t.imported && !t.isTaskCalendar && t.importSource === 'file'
+  ).length;
   const {
     habitsEnabled, setHabitsEnabled,
     routinesEnabled, setRoutinesEnabled,
@@ -1027,6 +1032,18 @@ const SettingsModal = () => {
                           <input type="file" accept=".ics" onChange={(e) => { handleFileUpload(e); setShowSettings(false); }} className="hidden" />
                         </label>
                         <p className={`text-xs ${textSecondary}`}>{t('settings.importIcsDesc')}</p>
+                        {fileImportedEventCount > 0 && (
+                          <button
+                            onClick={() => {
+                              if (window.confirm(t('settings.removeFileImportedConfirm', 'Remove all {{n}} file-imported events? Re-importing the file brings them back.', { n: fileImportedEventCount }))) {
+                                removeFileImportedEvents();
+                              }
+                            }}
+                            className="text-xs font-medium text-red-500 hover:text-red-600 transition-colors"
+                          >
+                            {t('settings.removeFileImported', 'Remove file-imported events')} ({fileImportedEventCount})
+                          </button>
+                        )}
                       </div>
                       </>)}
                     </div>


### PR DESCRIPTION
## Summary

Follow-up to the Outlook timezone investigation: file-imported calendar events are first-class synced data with **no removal path** — the only way to change them was importing another file over them (URL-subscribed events, by contrast, are replaced wholesale on every sync).

- New `removeFileImportedEvents` in App.jsx: deletes every `importSource: 'file'` calendar event (task-calendar file imports untouched), **writing tombstones first** so the cloud merge can't resurrect the removed copies on other devices.
- Surfaced as a destructive text button with a live count — "Remove file-imported events (N)" — under the iCal import controls in both desktop Settings (Calendar Sync section) and the mobile settings panel. Hidden entirely when N = 0, and gated behind a confirm that notes re-importing the file brings them back.
- Localized in all six languages.

## Testing

- Full suite green (861 tests); `vite build` clean.
- Hands-on: import an `.ics` as calendar events → button appears with the count → confirm → events vanish and the notification reports the removal; verify they stay gone after a cloud sync round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_