### PR TITLE
Testing round 2: SCHED deadlines/routines, recurring-window fix, intent resurrection fix, and more

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -869,7 +869,10 @@
     "viewTooltip": "Ansicht: {{view}} ({{keys}} oder C zum Wechseln)",
     "viewAria": "Aktuelle Ansicht: {{view}}. Klicken zum Wechseln.",
     "switchToView": "Zur Ansicht {{view}} wechseln",
-    "currentViewTap": "Aktuelle Ansicht: {{view}}. Tippen zum Wechseln."
+    "currentViewTap": "Aktuelle Ansicht: {{view}}. Tippen zum Wechseln.",
+    "deadline": "Frist",
+    "deadlineTapToSchedule": "Frist — tippen, um eine Uhrzeit zu wählen",
+    "routineTapToSchedule": "Routine — tippen, um eine Uhrzeit zu wählen"
   },
   "planner": {
     "standaloneProject": "Eigenständiges Projekt",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -869,7 +869,10 @@
     "viewTooltip": "View: {{view}} ({{keys}} or C to switch)",
     "viewAria": "Current view: {{view}}. Click to cycle view.",
     "switchToView": "Switch to {{view}} view",
-    "currentViewTap": "Current view: {{view}}. Tap to switch."
+    "currentViewTap": "Current view: {{view}}. Tap to switch.",
+    "deadline": "Deadline",
+    "deadlineTapToSchedule": "Deadline — tap to pick a time",
+    "routineTapToSchedule": "Routine — tap to pick a time"
   },
   "planner": {
     "standaloneProject": "Standalone project",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -869,7 +869,10 @@
     "viewTooltip": "Vista: {{view}} ({{keys}} o C para cambiar)",
     "viewAria": "Vista actual: {{view}}. Haz clic para cambiar.",
     "switchToView": "Cambiar a la vista {{view}}",
-    "currentViewTap": "Vista actual: {{view}}. Toca para cambiar."
+    "currentViewTap": "Vista actual: {{view}}. Toca para cambiar.",
+    "deadline": "Fecha límite",
+    "deadlineTapToSchedule": "Fecha límite: toca para elegir una hora",
+    "routineTapToSchedule": "Rutina: toca para elegir una hora"
   },
   "planner": {
     "standaloneProject": "Proyecto independiente",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -869,7 +869,10 @@
     "viewTooltip": "Vue : {{view}} ({{keys}} ou C pour changer)",
     "viewAria": "Vue actuelle : {{view}}. Cliquez pour changer.",
     "switchToView": "Passer à la vue {{view}}",
-    "currentViewTap": "Vue actuelle : {{view}}. Touchez pour changer."
+    "currentViewTap": "Vue actuelle : {{view}}. Touchez pour changer.",
+    "deadline": "Échéance",
+    "deadlineTapToSchedule": "Échéance — touchez pour choisir une heure",
+    "routineTapToSchedule": "Routine — touchez pour choisir une heure"
   },
   "planner": {
     "standaloneProject": "Projet indépendant",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -869,7 +869,10 @@
     "viewTooltip": "Vista: {{view}} ({{keys}} o C per cambiare)",
     "viewAria": "Vista attuale: {{view}}. Fai clic per cambiare.",
     "switchToView": "Passa alla vista {{view}}",
-    "currentViewTap": "Vista attuale: {{view}}. Tocca per cambiare."
+    "currentViewTap": "Vista attuale: {{view}}. Tocca per cambiare.",
+    "deadline": "Scadenza",
+    "deadlineTapToSchedule": "Scadenza — tocca per scegliere un orario",
+    "routineTapToSchedule": "Routine — tocca per scegliere un orario"
   },
   "planner": {
     "standaloneProject": "Progetto indipendente",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -869,7 +869,10 @@
     "viewTooltip": "Vista: {{view}} ({{keys}} ou C para mudar)",
     "viewAria": "Vista atual: {{view}}. Clique para mudar.",
     "switchToView": "Mudar para a vista {{view}}",
-    "currentViewTap": "Vista atual: {{view}}. Toque para mudar."
+    "currentViewTap": "Vista atual: {{view}}. Toque para mudar.",
+    "deadline": "Prazo",
+    "deadlineTapToSchedule": "Prazo — toque para escolher uma hora",
+    "routineTapToSchedule": "Rotina — toque para escolher uma hora"
   },
   "planner": {
     "standaloneProject": "Projeto independente",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -312,10 +312,27 @@ const DayPlanner = () => {
     const saved = localStorage.getItem('day-planner-day-view-mode');
     return saved ? JSON.parse(saved) : 'calendar-day';
   });
-  const [mobileViewMode, setMobileViewMode] = useState(() => {
-    const saved = localStorage.getItem('day-planner-mobile-view-mode');
-    return saved ? JSON.parse(saved) : 'grid';
+  // Mobile view DEFAULT (what the app opens in) vs the LIVE mode (what the
+  // header toggle switches during a session). Previously one persisted value
+  // played both roles, so using SCHED for a while silently became the new
+  // default. The live mode is now session-only; only the settings pickers
+  // write the default. Legacy fallback: the old live-mode key seeds the
+  // default once for existing installs.
+  const [mobileDefaultView, _setMobileDefaultView] = useState(() => {
+    const saved = localStorage.getItem('day-planner-mobile-default-view')
+      || localStorage.getItem('day-planner-mobile-view-mode');
+    try { return saved ? JSON.parse(saved) : 'grid'; } catch { return 'grid'; }
   });
+  const setMobileDefaultView = (mode) => {
+    _setMobileDefaultView(mode);
+    localStorage.setItem('day-planner-mobile-default-view', JSON.stringify(mode));
+  };
+  const [mobileViewMode, setMobileViewMode] = useState(mobileDefaultView);
+  // SCHED agenda rolling-window length (days). Lives here, not in
+  // useSchedAgendaState, because expandedRecurringTasks must expand recurring
+  // occurrences across the agenda's whole window — the hook's consumers all
+  // read through getTasksForDate.
+  const [schedDaysShown, setSchedDaysShown] = useState(14);
   // LIST view is a portrait-only tablet feature; in landscape the tablet always
   // uses the two-column timeline (and hides the LIST/GRID toggle). This mirrors
   // how wider Android tablets behave, where landscape drops out of tablet mode
@@ -919,6 +936,15 @@ const DayPlanner = () => {
     () => allTodayRoutines.filter(r => ownedBy(r, meUserSyncId)),
     [allTodayRoutines, ownedBy, meUserSyncId]
   );
+
+  // SCHED: give a routine a concrete time today (pill → placed timeline block),
+  // the tap-a-time equivalent of dragging the pill onto the grid.
+  const scheduleRoutineAt = (routineId, startTime) => {
+    setTodayRoutines(prev => prev.map(r => r.id === routineId
+      ? { ...r, startTime, isAllDay: false, duration: r.duration || 15, lastModified: new Date().toISOString() }
+      : r));
+    playUISound('tick');
+  };
 
   // Legacy unowned habits / routine chips / today-routines / frames are
   // intentionally NOT auto-migrated to the current user. Claiming is explicit
@@ -1604,9 +1630,8 @@ const DayPlanner = () => {
   useEffect(() => {
     localStorage.setItem('day-planner-week-view-mode', JSON.stringify(weekViewMode));
   }, [weekViewMode]);
-  useEffect(() => {
-    localStorage.setItem('day-planner-mobile-view-mode', JSON.stringify(mobileViewMode));
-  }, [mobileViewMode]);
+  // mobileViewMode is deliberately NOT persisted — the session opens in
+  // mobileDefaultView (settings picker) and header toggling is ephemeral.
   useEffect(() => {
     if (listEndOfDayTime === null) {
       localStorage.removeItem('day-planner-list-end-of-day');
@@ -5676,7 +5701,14 @@ const DayPlanner = () => {
   // In week view, expand over the full week range (which may extend beyond visibleDates).
   const expandedRecurringTasks = useMemo(() => {
     if (recurringTasks.length === 0) return [];
-    const allDateStrs = [...visibleDates, ...weekViewDates].map(d => dateToString(d)).sort();
+    // The SCHED agenda window (mobile SchedView / desktop SchedDashboard)
+    // reads days well beyond visibleDates/weekViewDates — on phones weekViewDates
+    // is even empty (effectiveViewMode is 'multi'). Always include the agenda's
+    // full rolling window so recurring occurrences exist for every rendered day.
+    const schedWindowEnd = new Date(selectedDate);
+    schedWindowEnd.setDate(schedWindowEnd.getDate() + schedDaysShown - 1);
+    const allDateStrs = [...visibleDates, ...weekViewDates, selectedDate, schedWindowEnd]
+      .map(d => dateToString(d)).sort();
     const rangeStart = allDateStrs[0];
     const rangeEnd = allDateStrs[allDateStrs.length - 1];
     const today = getTodayStr();
@@ -5710,7 +5742,7 @@ const DayPlanner = () => {
       }
     }
     return instances;
-  }, [recurringTasks, visibleDates, weekViewDates]);
+  }, [recurringTasks, visibleDates, weekViewDates, selectedDate, schedDaysShown]);
   expandedRecurringTasksRef.current = expandedRecurringTasks;
 
   // Build today's non-overdue HG sessions for the reminder engine.
@@ -6347,6 +6379,7 @@ const DayPlanner = () => {
     recordDeletedTaskTombstone,
     scheduleTaskAtNextSlot,
     manuallyScheduleTask,
+    scheduleDeadlineTaskAt,
     hgCompleteTask,
     focusCompleteTask,
     focusUpdateTaskNotes,
@@ -7550,6 +7583,8 @@ const DayPlanner = () => {
     tabletActiveTab, setTabletActiveTab,
     mobileActiveTab, setMobileActiveTab,
     mobileViewMode, setMobileViewMode, tabletListView,
+    mobileDefaultView, setMobileDefaultView,
+    schedDaysShown, setSchedDaysShown,
     listEndOfDayTime, setListEndOfDayTime,
     glancePage, setGlancePage,
     mobileWelcomeStep, setMobileWelcomeStep,
@@ -7740,7 +7775,7 @@ const DayPlanner = () => {
     applySuggestionForEdit, handleEditKeyDown, handleEditInputChange,
     handleNewTaskInputChange, handleNewTaskInputKeyDown, applySuggestionForNewTask,
     buildSuggestions,
-    manuallyScheduleTask, scheduleTaskAtNextSlot,
+    manuallyScheduleTask, scheduleTaskAtNextSlot, scheduleDeadlineTaskAt, scheduleRoutineAt,
     openNewTaskAtTime, openNewTaskForm, openNewInboxTask,
     recordDeletedTaskTombstone, parseRecurringId,
     expandMultiDayEvent,

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -61,6 +61,7 @@ const MobileSettingsPanel = () => {
     formatTime,
     toggleSettingsSection,
     mobileViewMode, setMobileViewMode,
+    mobileDefaultView, setMobileDefaultView,
     listEndOfDayTime, setListEndOfDayTime,
     glancePage, setGlancePage,
   } = useDayPlannerCtx();
@@ -495,9 +496,9 @@ const MobileSettingsPanel = () => {
           {['grid', 'list', 'sched'].map(mode => (
             <button
               key={mode}
-              onClick={() => setMobileViewMode(mode)}
+              onClick={() => { setMobileDefaultView(mode); setMobileViewMode(mode); }}
               className={`flex-1 py-2 rounded-lg text-sm font-medium border transition-colors ${
-                mobileViewMode === mode
+                mobileDefaultView === mode
                   ? 'bg-blue-600 text-white border-blue-600'
                   : `${darkMode ? 'bg-gray-700 border-gray-600' : 'bg-white border-stone-300'} ${textPrimary}`
               }`}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -51,6 +51,7 @@ const SettingsModal = () => {
     canShowViewCycler, schedOnlyCycler, setViewMode,
     glancePage, setGlancePage,
     mobileViewMode, setMobileViewMode,
+    mobileDefaultView, setMobileDefaultView,
     listEndOfDayTime, setListEndOfDayTime,
     formatTime,
   } = useDayPlannerCtx();
@@ -395,9 +396,9 @@ const SettingsModal = () => {
                               {['grid', 'list', 'sched'].map(mode => (
                                 <button
                                   key={mode}
-                                  onClick={() => setMobileViewMode(mode)}
+                                  onClick={() => { setMobileDefaultView(mode); setMobileViewMode(mode); }}
                                   className={`flex-1 py-2 rounded-lg text-sm font-medium border transition-colors ${
-                                    mobileViewMode === mode
+                                    mobileDefaultView === mode
                                       ? 'bg-blue-600 text-white border-blue-600'
                                       : `${darkMode ? 'bg-gray-700 border-gray-600' : 'bg-white border-stone-300'} ${textPrimary}`
                                   }`}

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -211,32 +211,32 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
         </select>
       </div>
 
-      {/* Start date */}
-      <div className="flex flex-col gap-1">
-        <label className={`text-xs font-medium ${textSecondary}`}>{t('goals.startDate')}</label>
-        <input
-          type="date"
-          value={startDate}
-          onChange={e => setStartDate(e.target.value)}
-          className={`px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-            darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'
-          }`}
-        />
-      </div>
-
-      {/* Target date */}
-      <div className="flex flex-col gap-1">
-        <label className={`text-xs font-medium ${textSecondary}`}>{t('common.targetDate')}</label>
-        <input
-          type="date"
-          value={targetDate}
-          onChange={e => setTargetDate(e.target.value)}
-          className={`px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-            darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'
-          }`}
-        />
+      {/* Start / Target dates — one row */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1 min-w-0">
+          <label className={`text-xs font-medium ${textSecondary}`}>{t('goals.startDate')}</label>
+          <input
+            type="date"
+            value={startDate}
+            onChange={e => setStartDate(e.target.value)}
+            className={`w-full min-w-0 px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'
+            }`}
+          />
+        </div>
+        <div className="flex flex-col gap-1 min-w-0">
+          <label className={`text-xs font-medium ${textSecondary}`}>{t('common.targetDate')}</label>
+          <input
+            type="date"
+            value={targetDate}
+            onChange={e => setTargetDate(e.target.value)}
+            className={`w-full min-w-0 px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              darkMode ? 'bg-gray-700 text-gray-100' : 'bg-white text-stone-900'
+            }`}
+          />
+        </div>
         {startAfterTarget && (
-          <p className="text-xs text-amber-500">{t('goals.startAfterTarget')}</p>
+          <p className="text-xs text-amber-500 col-span-2">{t('goals.startAfterTarget')}</p>
         )}
       </div>
 
@@ -630,7 +630,10 @@ const GoalMiniCard = ({ goal, onClick }) => {
 
   const allTasks = useMemo(() => [...tasks, ...unscheduledTasks].filter(isVisibleForUser), [tasks, unscheduledTasks, isVisibleForUser]);
   const childProjects = useMemo(() => projects.filter(p => p.goalId === goal.id && p.status !== 'archived'), [projects, goal.id]);
-  const hasStalledProject = useMemo(() => childProjects.some(p => isProjectStalled(p.id, allTasks, p)), [childProjects, allTasks]);
+  const hasStalledProject = useMemo(
+    () => !goal.hideStalled && childProjects.some(p => isProjectStalled(p.id, allTasks, p)),
+    [childProjects, allTasks, goal.hideStalled]
+  );
   const showCaution = isOverdue || hasStalledProject;
   const goalProgress = useMemo(() => calculateGoalProgress(goal.id, childProjects, allTasks), [goal.id, childProjects, allTasks]);
   const allProjectsDone = childProjects.length > 0 && goalProgress >= 1;
@@ -1482,7 +1485,7 @@ const MobileDashboard = ({
                   const nonArchivedProjects = activeProjects.filter(p => p.goalId === goal.id);
                   const isCompleted = goal.status === 'completed';
                   const allProjectsDone = nonArchivedProjects.length > 0 && goalProgress >= 1;
-                  const hasStalledProject = nonArchivedProjects.some(p => isProjectStalled(p.id, allTasks, p));
+                  const hasStalledProject = !goal.hideStalled && nonArchivedProjects.some(p => isProjectStalled(p.id, allTasks, p));
                   let daysLabel = null, daysUrgent = false, isOverdue = false;
                   if (goal.targetDate) {
                     const today = new Date(); today.setHours(0, 0, 0, 0);

--- a/src/components/sched/SchedDashboard.jsx
+++ b/src/components/sched/SchedDashboard.jsx
@@ -9,15 +9,25 @@ import { EMPTY_SCHED_FILTERS, toggleSchedFilter, groupProjectsForFilter } from '
 import useSchedAgendaState, { LOAD_MORE_DAYS } from './useSchedAgendaState.js';
 import SchedTaskCard from './SchedTaskCard.jsx';
 import SchedFilterPresets from './SchedFilterPresets.jsx';
+import { SchedDeadlineCard, SchedRoutinePills } from './SchedDayExtras.jsx';
 
-/** One collapsible section of the desktop filter rail. */
-const RailSection = ({ title, count, children, defaultOpen = true }) => {
+/** One collapsible section of the desktop filter rail. Collapsed state is
+    persisted per section (storageKey, stable across locales) so the rail
+    survives reloads the way the user left it. */
+const RailSection = ({ title, storageKey, count, children, defaultOpen = true }) => {
   const { borderClass, textPrimary, textSecondary, hoverBg } = useDayPlannerCtx();
-  const [open, setOpen] = useState(defaultOpen);
+  const [open, setOpen] = useState(() => {
+    const saved = localStorage.getItem(`day-planner-sched-rail-${storageKey}`);
+    return saved === null ? defaultOpen : saved === 'true';
+  });
+  const toggle = () => setOpen(o => {
+    localStorage.setItem(`day-planner-sched-rail-${storageKey}`, String(!o));
+    return !o;
+  });
   return (
     <div className={`border-b ${borderClass} pb-3`}>
       <button
-        onClick={() => setOpen(o => !o)}
+        onClick={toggle}
         className={`w-full flex items-center justify-between py-1.5 px-1 rounded ${hoverBg} transition-colors`}
       >
         <span className={`text-xs font-semibold uppercase tracking-wide ${textPrimary}`}>
@@ -105,6 +115,10 @@ const SchedDashboard = () => {
                   <Plus size={14} />
                 </button>
               </div>
+              {day.deadlineTasks.map(task => (
+                <SchedDeadlineCard key={`deadline-${task.id}`} task={task} dateStr={day.dateStr} />
+              ))}
+              {day.dateStr === todayStr && <SchedRoutinePills />}
               {day.tasks.length > 0 ? (
                 day.tasks.map(task => <SchedTaskCard key={task.id} task={task} showProject />)
               ) : (
@@ -154,7 +168,7 @@ const SchedDashboard = () => {
         </div>
 
         {(filterPresets.length > 0 || filtersActive) && (
-          <RailSection title={t('sched.presets', 'Presets')} count={0}>
+          <RailSection title={t('sched.presets', 'Presets')} storageKey="presets" count={0}>
             <div className="px-1">
               <SchedFilterPresets
                 filters={filters}
@@ -167,7 +181,7 @@ const SchedDashboard = () => {
           </RailSection>
         )}
 
-        <RailSection title={t('sched.colors', 'Colors')} count={filters.colors.length}>
+        <RailSection title={t('sched.colors', 'Colors')} storageKey="colors" count={filters.colors.length}>
           {colorOptions.length > 0 ? (
             <div className="flex flex-wrap gap-1.5 px-1">
               {colorOptions.map(c => (
@@ -184,7 +198,7 @@ const SchedDashboard = () => {
           ) : <p className={`text-xs ${textSecondary} px-1`}>{t('sched.noColorsInView', 'No colors in view.')}</p>}
         </RailSection>
 
-        <RailSection title={t('sched.tags', 'Tags')} count={filters.tags.length}>
+        <RailSection title={t('sched.tags', 'Tags')} storageKey="tags" count={filters.tags.length}>
           {availableTags.length > 0 ? (
             <div className="flex flex-wrap gap-1.5 px-1">
               {availableTags.map(tag => (
@@ -197,7 +211,7 @@ const SchedDashboard = () => {
         </RailSection>
 
         {goalsProjectsEnabled && (
-          <RailSection title={t('sched.projects', 'Projects')} count={filters.projectIds.length}>
+          <RailSection title={t('sched.projects', 'Projects')} storageKey="projects" count={filters.projectIds.length}>
             {projectGroups.length > 0 ? (
               <div className="flex flex-col gap-2 px-1">
                 {projectGroups.map(group => (
@@ -227,7 +241,7 @@ const SchedDashboard = () => {
           </RailSection>
         )}
 
-        <RailSection title={t('sched.recurring', 'Recurring')} count={nextInstanceOnly ? 1 : 0}>
+        <RailSection title={t('sched.recurring', 'Recurring')} storageKey="recurring" count={nextInstanceOnly ? 1 : 0}>
           <div className="flex gap-1.5 px-1">
             <button onClick={() => nextInstanceOnly && toggleNextInstanceOnly()} className={chip(!nextInstanceOnly)}>
               {t('sched.allInstances', 'All instances')}

--- a/src/components/sched/SchedDayExtras.jsx
+++ b/src/components/sched/SchedDayExtras.jsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import { CalendarPlus } from 'lucide-react';
+import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
+import { useTranslation } from 'react-i18next';
+import { taskColorToHex } from '../../utils/colorUtils.js';
+import { renderTitleWithoutTags } from '../../utils/textFormatting.jsx';
+import ClockTimePicker from '../ClockTimePicker.jsx';
+
+/**
+ * Non-task rows in a SCHED day group: deadline tasks and (today only) routine
+ * pills. Both are "not yet on the clock" items — tapping opens a time picker
+ * that schedules them into the day, mirroring what dragging them onto the
+ * timeline does in the MULTI views.
+ */
+
+/** A deadline task on its deadline day — all-day-task look with a dashed
+    border and a calendar affordance; tap picks a time on that day. */
+export const SchedDeadlineCard = ({ task, dateStr }) => {
+  const {
+    darkMode, cardBg, borderClass, textPrimary, textSecondary,
+    scheduleDeadlineTaskAt, use24HourClock, isTablet,
+  } = useDayPlannerCtx();
+  const { t } = useTranslation();
+  const [showPicker, setShowPicker] = useState(false);
+  const hex = taskColorToHex(task.color);
+
+  return (
+    <>
+      <div
+        onClick={() => !task.completed && setShowPicker(true)}
+        className={`flex items-center gap-2 rounded-xl border border-dashed ${borderClass} ${cardBg} px-3 py-2 ${
+          task.completed ? 'opacity-55' : 'cursor-pointer active:opacity-70'
+        }`}
+        style={{ borderLeft: `4px solid ${hex}` }}
+        title={t('sched.deadlineTapToSchedule', 'Deadline — tap to pick a time')}
+      >
+        <div className="flex flex-col min-w-0 flex-1 gap-0.5">
+          <span className={`text-sm font-medium ${textPrimary} truncate ${task.completed ? 'line-through' : ''}`}>
+            {renderTitleWithoutTags(task.title || '') || task.title}
+          </span>
+          <span className={`text-xs ${textSecondary} flex items-center gap-1.5`}>
+            <span className="font-medium text-red-400">{t('sched.deadline', 'Deadline')}</span>
+            {task.duration ? <span>{task.duration}m</span> : null}
+          </span>
+        </div>
+        {!task.completed && (
+          <CalendarPlus size={14} className={`flex-shrink-0 ${textSecondary} opacity-60`} />
+        )}
+      </div>
+      {showPicker && (
+        <ClockTimePicker
+          value="09:00"
+          onChange={(time) => { setShowPicker(false); scheduleDeadlineTaskAt(task.id, dateStr, time); }}
+          onClose={() => setShowPicker(false)}
+          darkMode={darkMode} isTablet={isTablet} use24HourClock={use24HourClock}
+        />
+      )}
+    </>
+  );
+};
+
+/** Today's routines as the familiar teal pills. All-day (unplaced) pills come
+    first; placed ones show their time. Tapping opens the time picker. */
+export const SchedRoutinePills = () => {
+  const {
+    darkMode, routinesEnabled, todayRoutines, routineCompletions,
+    scheduleRoutineAt, formatTime, use24HourClock, isTablet,
+  } = useDayPlannerCtx();
+  const { t } = useTranslation();
+  const [pickerFor, setPickerFor] = useState(null);
+
+  if (!routinesEnabled || todayRoutines.length === 0) return null;
+
+  const sorted = [...todayRoutines].sort((a, b) =>
+    ((a.isAllDay || !a.startTime) ? 0 : 1) - ((b.isAllDay || !b.startTime) ? 0 : 1) ||
+    (a.startTime || '').localeCompare(b.startTime || ''));
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {sorted.map(r => (
+        <button
+          key={r.id}
+          onClick={() => setPickerFor(r)}
+          className={`rounded-full px-2.5 py-1 text-[11px] font-medium transition-opacity ${
+            darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'
+          } ${routineCompletions[r.id] ? 'line-through opacity-75' : ''}`}
+          title={t('sched.routineTapToSchedule', 'Routine — tap to pick a time')}
+        >
+          {r.startTime && !r.isAllDay ? `${formatTime(r.startTime)} · ` : ''}{r.name}
+        </button>
+      ))}
+      {pickerFor && (
+        <ClockTimePicker
+          value={(!pickerFor.isAllDay && pickerFor.startTime) || '09:00'}
+          onChange={(time) => { const id = pickerFor.id; setPickerFor(null); scheduleRoutineAt(id, time); }}
+          onClose={() => setPickerFor(null)}
+          darkMode={darkMode} isTablet={isTablet} use24HourClock={use24HourClock}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/components/sched/SchedTaskCard.jsx
+++ b/src/components/sched/SchedTaskCard.jsx
@@ -58,7 +58,9 @@ const SchedTaskCard = ({ task, isInbox = false, showProject = false, onEdit = nu
     ? t('task.allDay', 'All day')
     : task.startTime
       ? `${formatTime(task.startTime)}${task.duration ? ` · ${task.duration}m` : ''}`
-      : '';
+      // Unscheduled (planner column): no time yet, but the duration is still
+      // useful planning information — show it where the time would sit.
+      : task.duration ? `${task.duration}m` : '';
 
   // Past-time treatment (Todoist model): a task whose start time has passed
   // stays in place with a red time label; a calendar event that has ENDED

--- a/src/components/sched/SchedView.jsx
+++ b/src/components/sched/SchedView.jsx
@@ -6,6 +6,7 @@ import { dateToString } from '../../utils/taskUtils.js';
 import useSchedAgendaState, { LOAD_MORE_DAYS } from './useSchedAgendaState.js';
 import SchedTaskCard from './SchedTaskCard.jsx';
 import SchedFilterPopup from './SchedFilterPopup.jsx';
+import { SchedDeadlineCard, SchedRoutinePills } from './SchedDayExtras.jsx';
 
 /**
  * SCHED — scrollable day-grouped agenda of scheduled tasks, starting at the
@@ -89,6 +90,10 @@ const SchedView = () => {
           <div className={`text-xs font-semibold uppercase tracking-wide ${day.dateStr === todayStr ? 'text-blue-500' : textSecondary} pt-1`}>
             {dayLabel(day)}
           </div>
+          {day.deadlineTasks.map(task => (
+            <SchedDeadlineCard key={`deadline-${task.id}`} task={task} dateStr={day.dateStr} />
+          ))}
+          {day.dateStr === todayStr && <SchedRoutinePills />}
           {day.tasks.length > 0 ? (
             day.tasks.map(task => <SchedTaskCard key={task.id} task={task} showProject />)
           ) : (

--- a/src/components/sched/useSchedAgendaState.js
+++ b/src/components/sched/useSchedAgendaState.js
@@ -17,14 +17,16 @@ const PRESETS_KEY = 'day-planner-sched-filter-presets';
  */
 export default function useSchedAgendaState() {
   const {
-    selectedDate, tasks, expandedRecurringTasks,
-    getTasksForDate,
+    selectedDate, tasks, unscheduledTasks, expandedRecurringTasks,
+    getTasksForDate, getDeadlineTasksForDate,
     setNewTask, setShowAddTask,
     scheduleTaskAtNextSlot,
+    routinesEnabled, todayRoutines,
+    // Window length lives in App state so expandedRecurringTasks can expand
+    // recurring occurrences across the agenda's whole rolling window.
+    schedDaysShown: daysShown, setSchedDaysShown: setDaysShown,
   } = useDayPlannerCtx();
   const { isVisibleForUser } = useFeaturesCtx();
-
-  const [daysShown, setDaysShown] = useState(INITIAL_DAYS);
   const [filters, setFilters] = useState(EMPTY_SCHED_FILTERS);
   const [showEmptyDays, setShowEmptyDays] = useState(
     () => localStorage.getItem('day-planner-sched-show-empty') === 'true'
@@ -96,12 +98,14 @@ export default function useSchedAgendaState() {
           ((a.isAllDay ? 0 : 1) - (b.isAllDay ? 0 : 1)) ||
           (a.startTime || '').localeCompare(b.startTime || '')
         );
-      out.push({ date, dateStr: dateToString(date), tasks: dayTasks });
+      const dateStr = dateToString(date);
+      out.push({ date, dateStr, tasks: dayTasks, deadlineTasks: getDeadlineTasksForDate(dateStr) });
     }
     return out;
-    // getTasksForDate reads tasks + expandedRecurringTasks internally.
+    // getTasksForDate reads tasks + expandedRecurringTasks internally;
+    // getDeadlineTasksForDate reads unscheduledTasks.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedDate, daysShown, tasks, expandedRecurringTasks]);
+  }, [selectedDate, daysShown, tasks, unscheduledTasks, expandedRecurringTasks]);
 
   // Filter options offered in the UI come from the visible window.
   const { availableColors, availableTags } = useMemo(() => {
@@ -116,11 +120,20 @@ export default function useSchedAgendaState() {
 
   const days = useMemo(() => {
     const base = nextInstanceOnly ? limitRecurringToNextInstance(rawDays) : rawDays;
-    return base.map(d => ({ ...d, tasks: d.tasks.filter(task => taskMatchesSchedFilters(task, filters)) }));
+    return base.map(d => ({
+      ...d,
+      tasks: d.tasks.filter(task => taskMatchesSchedFilters(task, filters)),
+      deadlineTasks: d.deadlineTasks.filter(task => taskMatchesSchedFilters(task, filters)),
+    }));
   }, [rawDays, filters, nextInstanceOnly]);
 
   const filtersActive = hasActiveSchedFilters(filters);
-  const visibleDays = days.filter(d => showEmptyDays || d.tasks.length > 0);
+  // Today never counts as empty while routine pills are pending on it.
+  const todayHasRoutines = routinesEnabled && todayRoutines.length > 0;
+  const agendaTodayStr = dateToString(new Date());
+  const visibleDays = days.filter(d =>
+    showEmptyDays || d.tasks.length > 0 || d.deadlineTasks.length > 0 ||
+    (d.dateStr === agendaTodayStr && todayHasRoutines));
 
   // Incomplete tasks scheduled before today AND before the visible window, so
   // they never duplicate a rendered day group. Plain tasks only: imported

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -757,6 +757,26 @@ export default function useTaskActions({
     });
   };
 
+  // SCHED: give a deadline task a concrete slot on a given day (deadline card
+  // → scheduled task). Deadline and priority are stripped, matching what
+  // dragging a deadline chip onto the time grid does.
+  const scheduleDeadlineTaskAt = (taskId, dateStr, startTime) => {
+    const task = unscheduledTasks.find(t => t.id === taskId);
+    if (!task) return;
+    pushUndo();
+    const { priority, deadline, ...preserved } = task;
+    setUnscheduledTasks(prev => prev.filter(t => t.id !== taskId));
+    setTasks(prev => [...prev, {
+      ...preserved,
+      date: dateStr,
+      startTime,
+      duration: task.duration || 30,
+      isAllDay: false,
+      lastModified: new Date().toISOString(),
+    }]);
+    playUISound('pop');
+  };
+
   // ── Focus mode wrappers ──────────────────────────────────────────────────
 
   const focusCompleteTask = (taskId) => {
@@ -847,6 +867,7 @@ export default function useTaskActions({
     // Schedule
     scheduleTaskAtNextSlot,
     manuallyScheduleTask,
+    scheduleDeadlineTaskAt,
     // HG wrapper
     hgCompleteTask,
     // Focus wrappers

--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -51,7 +51,7 @@ function clearGoalTombstone(goalId) {
 // Derive a deterministic UUID from a seed string so that two devices
 // processing the same intent create tasks with the same ID, letting the sync
 // engine deduplicate them naturally rather than keeping both copies.
-async function deterministicTaskId(seed) {
+export async function deterministicTaskId(seed) {
   const data = new TextEncoder().encode(seed);
   const hash = new Uint8Array(await crypto.subtle.digest('SHA-256', data));
   hash[6] = (hash[6] & 0x0f) | 0x40; // version 4
@@ -260,6 +260,7 @@ async function handleCreate(payload, context) {
     goals = [],
     addGoal,
     eventId,
+    deletedTaskIds, // optional override for the tombstone lookup (tests)
   } = context;
 
   const v = validate(CreateSchema, payload);
@@ -355,6 +356,38 @@ async function handleCreate(payload, context) {
     : eventId
       ? await deterministicTaskId(eventId)
       : crypto.randomUUID();
+
+  // Re-delivery guards: transports can re-present old create events (a file
+  // transport whose files outlive the local cursor, a wiped cursor after a
+  // reinstall/restore). The incomplete-match branch above upgrades live
+  // copies; here we make the create a NO-OP instead of a resurrection when:
+  //   (a) the same intentKey already exists COMPLETED in either list — the
+  //       completion synced through another channel and must stand;
+  //   (b) the deterministic id already exists anywhere (cross-list — e.g. the
+  //       task was created unscheduled and later scheduled) or is tombstoned
+  //       (completed copy deleted or aged past the retention window).
+  if (intentKey) {
+    const completedExisting =
+      tasks.find(t => t._intentKey === intentKey && t.completed) ||
+      unscheduledTasks.find(t => t._intentKey === intentKey && t.completed);
+    if (completedExisting) {
+      return ok({ task_id: completedExisting.id, warning: 'Task already completed; ignored re-delivered create' });
+    }
+  }
+  const idExists =
+    tasks.some(t => t.id === taskId) ||
+    unscheduledTasks.some(t => t.id === taskId) ||
+    recurringTasks.some(t => t.id === taskId);
+  const isTombstoned = (() => {
+    if (deletedTaskIds) return !!deletedTaskIds[taskId];
+    try {
+      return !!JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}')[taskId];
+    } catch { return false; }
+  })();
+  if (idExists || isTombstoned) {
+    return ok({ task_id: taskId, warning: 'Task already exists or was deleted; ignored re-delivered create' });
+  }
+
   const projectId = resolveProjectId(normalized.project, projects);
   const taskTitle = rebuildTitle(cleanedTitle, tags);
 

--- a/src/intents/handleIntent.test.js
+++ b/src/intents/handleIntent.test.js
@@ -579,6 +579,7 @@ function makeCapture(initial = {}) {
     get _tasks() { return state.tasks; },
     get _inbox() { return state.unscheduledTasks; },
     get _recurring() { return state.recurringTasks; },
+    ...(initial.deletedTaskIds ? { deletedTaskIds: initial.deletedTaskIds } : {}),
   };
   return ctx;
 }
@@ -692,6 +693,66 @@ describe('handleIntent create execution', () => {
     await handleIntent('create', { title: 'Quick task' }, ctx);
     expect(ctx._inbox[0].color).toBe('bg-blue-500');
     expect(ctx._inbox[0].duration).toBe(30);
+  });
+
+  // ── Re-delivery guards: a transport re-presenting an old create event must
+  //    never resurrect a task whose completion synced through another channel ──
+
+  it('no-ops a re-delivered create whose task is already completed', async () => {
+    const key = await createKey('app.lastglance', 'chore_42', '2026-06-01');
+    const existing = { id: 'tsk_1', title: 'Chore', _intentKey: key, completed: true };
+    const ctx = makeCapture({ tasks: [existing] });
+
+    const r = await handleIntent('create', {
+      title: 'Chore',
+      source_app: 'app.lastglance',
+      source_entity_id: 'chore_42',
+      due: '2026-06-01',
+    }, ctx);
+
+    expect(r.success).toBe(true);
+    expect(r.task_id).toBe('tsk_1');
+    expect(r.warning).toContain('already completed');
+    expect(ctx._tasks).toHaveLength(1);
+    expect(ctx._tasks[0].completed).toBe(true);
+    expect(ctx._inbox).toHaveLength(0);
+  });
+
+  it('no-ops a re-delivered create when the completed copy lives in the other list', async () => {
+    const key = await createKey('app.lastglance', 'chore_43', null);
+    const existing = { id: 'tsk_2', title: 'Chore', _intentKey: key, completed: true };
+    // Original was created unscheduled (no due) but was later scheduled — the
+    // completed copy now lives in tasks while the redelivered create targets inbox.
+    const ctx = makeCapture({ tasks: [existing] });
+
+    const r = await handleIntent('create', {
+      title: 'Chore',
+      source_app: 'app.lastglance',
+      source_entity_id: 'chore_43',
+    }, ctx);
+
+    expect(r.success).toBe(true);
+    expect(r.warning).toContain('already completed');
+    expect(ctx._inbox).toHaveLength(0);
+  });
+
+  it('no-ops a re-delivered create whose deterministic id is tombstoned', async () => {
+    const key = await createKey('app.lastglance', 'chore_44', '2026-06-01');
+    const { deterministicTaskId } = await import('./handleIntent.js');
+    const doomedId = await deterministicTaskId(key);
+    const ctx = makeCapture({ deletedTaskIds: { [doomedId]: '2026-07-01T00:00:00Z' } });
+
+    const r = await handleIntent('create', {
+      title: 'Chore',
+      source_app: 'app.lastglance',
+      source_entity_id: 'chore_44',
+      due: '2026-06-01',
+    }, ctx);
+
+    expect(r.success).toBe(true);
+    expect(r.warning).toContain('ignored re-delivered create');
+    expect(ctx._tasks).toHaveLength(0);
+    expect(ctx._inbox).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

All eight items from testing round 2, in your numbering:

1. **Recurring tasks missing from single-column SCHED** — root cause: `expandedRecurringTasks` only expanded across `visibleDates + weekViewDates`, and on phones/tablet-portrait `weekViewDates` is empty (their `effectiveViewMode` is `multi`), leaving only the selected day expanded. This also silently hid recurring tasks from **days 8+ at every width** (the week strip covers 7 of the agenda's 14+). The agenda window length now lives in App state (`schedDaysShown`, shared by both SCHED skins and "show more days") and always feeds the expansion range.
2. **Edit Goal**: Start date + Target date on one row (the too-early warning spans both).
3. **Hide Stalled** now also suppresses the caution triangle in the goal-card path that never checked it (both goal-card variants guarded).
4. **Unscheduled planner cards** show the task duration on the meta row, same spot as scheduled cards' time.
5. **GLANCEintents resurrection (your iOS suspicion — confirmed, with a twist)**: the completion not flowing back through the transport is only half of it. The intent files/events legitimately outlive processing (GC-based, no per-file ack), and every device tracks its own local cursor — so a stale/wiped cursor (reinstall, restore) re-presents old creates. The real hole was in `handleIntent`: its idempotency check deliberately matched only **incomplete** tasks, so a re-delivered create for a completed task fell through to "create new" — with the deterministic ID resurrecting it as incomplete, and last-writer-wins spreading that everywhere. Creates now **no-op** when the intentKey matches a completed copy in either list, when the deterministic id already exists anywhere (cross-list), or when it's tombstoned (deleted/retention-pruned). 3 new tests.
6. **SCHED filter rail** remembers each section's collapsed state across reloads (locale-stable storage keys).
7. **Mobile view default decoupled from live view**: the app opens in the settings-picked default (new `day-planner-mobile-default-view`, seeded once from the legacy key so nobody's preference changes on update); header toggling is session-only. Prefer LIST, browse SCHED all day, come back to LIST.
8. **SCHED is now fully featured — deadlines + routines**:
   - **Deadline tasks** appear on their deadline day: all-day-style card with a **dashed border**, red "Deadline" label, duration, and a calendar icon. Tapping opens the clock time-picker and schedules the task at that time on that day (deadline/priority stripped — same semantics as dragging a deadline chip onto the grid). Completed ones render checked-off, read-only.
   - **Routines** appear in today's group as the familiar **teal pills** (placed ones show their time, completed ones strike through). Tapping opens the time picker to place/re-place them — the tap equivalent of dragging a pill onto the timeline. One design call to sanity-check: routines only exist as today-instances, so they show **on today only**; future days can't show routines that haven't been instantiated yet.
   - Days with only deadlines/routines no longer count as "empty" days.

## Testing

- Full suite: **861 tests / 60 files** green (3 new intent-guard tests); `vite build` clean.
- Hands-on worth doing: recurring tasks on phone SCHED across the full 14 days and after "show more days"; deadline card → time picker → lands at the picked slot; routine pill → picker → pill shows its time and the block appears in MULTI; LIST-default + SCHED browsing + app relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_