### PR TITLE
Bump Android versionCode to 179

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 178
+        versionCode = 179
         versionName = "4.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

178 was built and uploaded during 4.0.0 device testing; the next build (with testing rounds 1–2 merged) needs a fresh code. versionName stays 4.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_