### PR TITLE
Fix SCHED routine pills reading routine state from the wrong context

### DIFF
--- a/src/components/sched/SchedDayExtras.jsx
+++ b/src/components/sched/SchedDayExtras.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { CalendarPlus } from 'lucide-react';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
 import { useTranslation } from 'react-i18next';
 import { taskColorToHex } from '../../utils/colorUtils.js';
 import { renderTitleWithoutTags } from '../../utils/textFormatting.jsx';
@@ -63,9 +64,12 @@ export const SchedDeadlineCard = ({ task, dateStr }) => {
     first; placed ones show their time. Tapping opens the time picker. */
 export const SchedRoutinePills = () => {
   const {
-    darkMode, routinesEnabled, todayRoutines, routineCompletions,
-    scheduleRoutineAt, formatTime, use24HourClock, isTablet,
+    darkMode, scheduleRoutineAt, formatTime, use24HourClock, isTablet,
   } = useDayPlannerCtx();
+  // Routine state lives in the FEATURES context (same as TimeGrid), not the
+  // day-planner one — destructuring it from the wrong context reads undefined
+  // and silently renders nothing.
+  const { routinesEnabled, todayRoutines, routineCompletions } = useFeaturesCtx();
   const { t } = useTranslation();
   const [pickerFor, setPickerFor] = useState(null);
 

--- a/src/components/sched/useSchedAgendaState.js
+++ b/src/components/sched/useSchedAgendaState.js
@@ -21,12 +21,12 @@ export default function useSchedAgendaState() {
     getTasksForDate, getDeadlineTasksForDate,
     setNewTask, setShowAddTask,
     scheduleTaskAtNextSlot,
-    routinesEnabled, todayRoutines,
     // Window length lives in App state so expandedRecurringTasks can expand
     // recurring occurrences across the agenda's whole rolling window.
     schedDaysShown: daysShown, setSchedDaysShown: setDaysShown,
   } = useDayPlannerCtx();
-  const { isVisibleForUser } = useFeaturesCtx();
+  // Routine state lives in the FEATURES context (same as TimeGrid).
+  const { isVisibleForUser, routinesEnabled, todayRoutines } = useFeaturesCtx();
   const [filters, setFilters] = useState(EMPTY_SCHED_FILTERS);
   const [showEmptyDays, setShowEmptyDays] = useState(
     () => localStorage.getItem('day-planner-sched-show-empty') === 'true'


### PR DESCRIPTION
## Summary

Routine pills never rendered in SCHED: `routinesEnabled` / `todayRoutines` / `routineCompletions` live in the **features** context (that's where TimeGrid reads them), but `SchedRoutinePills` and the agenda hook's today-not-empty check destructured them from the **day-planner** context — all `undefined`, so the pill row silently bailed out. Deadline cards worked because their data genuinely comes from the day-planner context, which is why #8 looked half-shipped.

Both consumers now read routine state from `useFeaturesCtx()`; `scheduleRoutineAt` stays in the day-planner context where it was correctly registered.

## Testing

Full suite green (861); build clean. Hands-on: place routines for today, open SCHED — teal pills under today's header, tap → clock picker → pill gains its time and the block lands on the MULTI timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_