### PR TITLE
SCHED routine pills: tap completes, press-and-hold picks the time

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 180
+        versionCode = 181
         versionName = "4.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -872,7 +872,7 @@
     "currentViewTap": "Aktuelle Ansicht: {{view}}. Tippen zum Wechseln.",
     "deadline": "Frist",
     "deadlineTapToSchedule": "Frist — tippen, um eine Uhrzeit zu wählen",
-    "routineTapToSchedule": "Routine — tippen, um eine Uhrzeit zu wählen"
+    "routineTapHint": "Tippen zum Abhaken · halten, um eine Uhrzeit zu wählen"
   },
   "planner": {
     "standaloneProject": "Eigenständiges Projekt",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -872,7 +872,7 @@
     "currentViewTap": "Current view: {{view}}. Tap to switch.",
     "deadline": "Deadline",
     "deadlineTapToSchedule": "Deadline — tap to pick a time",
-    "routineTapToSchedule": "Routine — tap to pick a time"
+    "routineTapHint": "Tap to complete · hold to pick a time"
   },
   "planner": {
     "standaloneProject": "Standalone project",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -872,7 +872,7 @@
     "currentViewTap": "Vista actual: {{view}}. Toca para cambiar.",
     "deadline": "Fecha límite",
     "deadlineTapToSchedule": "Fecha límite: toca para elegir una hora",
-    "routineTapToSchedule": "Rutina: toca para elegir una hora"
+    "routineTapHint": "Toca para completar · mantén pulsado para elegir una hora"
   },
   "planner": {
     "standaloneProject": "Proyecto independiente",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -872,7 +872,7 @@
     "currentViewTap": "Vue actuelle : {{view}}. Touchez pour changer.",
     "deadline": "Échéance",
     "deadlineTapToSchedule": "Échéance — touchez pour choisir une heure",
-    "routineTapToSchedule": "Routine — touchez pour choisir une heure"
+    "routineTapHint": "Touchez pour terminer · maintenez pour choisir une heure"
   },
   "planner": {
     "standaloneProject": "Projet indépendant",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -872,7 +872,7 @@
     "currentViewTap": "Vista attuale: {{view}}. Tocca per cambiare.",
     "deadline": "Scadenza",
     "deadlineTapToSchedule": "Scadenza — tocca per scegliere un orario",
-    "routineTapToSchedule": "Routine — tocca per scegliere un orario"
+    "routineTapHint": "Tocca per completare · tieni premuto per scegliere un orario"
   },
   "planner": {
     "standaloneProject": "Progetto indipendente",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -872,7 +872,7 @@
     "currentViewTap": "Vista atual: {{view}}. Toque para mudar.",
     "deadline": "Prazo",
     "deadlineTapToSchedule": "Prazo — toque para escolher uma hora",
-    "routineTapToSchedule": "Rotina — toque para escolher uma hora"
+    "routineTapHint": "Toque para concluir · mantenha premido para escolher uma hora"
   },
   "planner": {
     "standaloneProject": "Projeto independente",

--- a/src/components/sched/SchedDayExtras.jsx
+++ b/src/components/sched/SchedDayExtras.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { CalendarPlus } from 'lucide-react';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
@@ -60,8 +60,13 @@ export const SchedDeadlineCard = ({ task, dateStr }) => {
   );
 };
 
+/** How long a press must be held before it means "pick a time" instead of
+    "toggle complete". Matches typical platform long-press timing. */
+const LONG_PRESS_MS = 500;
+
 /** Today's routines as the familiar teal pills. All-day (unplaced) pills come
-    first; placed ones show their time. Tapping opens the time picker. */
+    first; placed ones show their time. Tap toggles completion (like routine
+    chips everywhere else); press-and-hold opens the time picker. */
 export const SchedRoutinePills = () => {
   const {
     darkMode, scheduleRoutineAt, formatTime, use24HourClock, isTablet,
@@ -69,11 +74,24 @@ export const SchedRoutinePills = () => {
   // Routine state lives in the FEATURES context (same as TimeGrid), not the
   // day-planner one — destructuring it from the wrong context reads undefined
   // and silently renders nothing.
-  const { routinesEnabled, todayRoutines, routineCompletions } = useFeaturesCtx();
+  const { routinesEnabled, todayRoutines, routineCompletions, toggleRoutineCompletion } = useFeaturesCtx();
   const { t } = useTranslation();
   const [pickerFor, setPickerFor] = useState(null);
+  // { timer, longFired } — longFired swallows the click that follows a
+  // completed long-press so it doesn't ALSO toggle completion.
+  const pressRef = useRef({ timer: null, longFired: false });
 
   if (!routinesEnabled || todayRoutines.length === 0) return null;
+
+  const startPress = (routine) => {
+    pressRef.current.longFired = false;
+    clearTimeout(pressRef.current.timer);
+    pressRef.current.timer = setTimeout(() => {
+      pressRef.current.longFired = true;
+      setPickerFor(routine);
+    }, LONG_PRESS_MS);
+  };
+  const cancelPress = () => clearTimeout(pressRef.current.timer);
 
   const sorted = [...todayRoutines].sort((a, b) =>
     ((a.isAllDay || !a.startTime) ? 0 : 1) - ((b.isAllDay || !b.startTime) ? 0 : 1) ||
@@ -84,11 +102,21 @@ export const SchedRoutinePills = () => {
       {sorted.map(r => (
         <button
           key={r.id}
-          onClick={() => setPickerFor(r)}
-          className={`rounded-full px-2.5 py-1 text-[11px] font-medium transition-opacity ${
+          onPointerDown={() => startPress(r)}
+          onPointerUp={cancelPress}
+          onPointerLeave={cancelPress}
+          onPointerCancel={cancelPress}
+          onTouchMove={cancelPress}
+          onContextMenu={e => e.preventDefault()}
+          onClick={() => {
+            if (pressRef.current.longFired) { pressRef.current.longFired = false; return; }
+            cancelPress();
+            toggleRoutineCompletion(r.id);
+          }}
+          className={`rounded-full px-2.5 py-1 text-[11px] font-medium transition-opacity select-none dnd-no-select ${
             darkMode ? 'bg-teal-700/80 text-teal-100' : 'bg-teal-600/80 text-white'
           } ${routineCompletions[r.id] ? 'line-through opacity-75' : ''}`}
-          title={t('sched.routineTapToSchedule', 'Routine — tap to pick a time')}
+          title={t('sched.routineTapHint', 'Tap to complete · hold to pick a time')}
         >
           {r.startTime && !r.isAllDay ? `${formatTime(r.startTime)} · ` : ''}{r.name}
         </button>


### PR DESCRIPTION
## Summary

Routine pills in SCHED get the gesture split discussed: **tap toggles completion** (the everyday action, matching how routine chips behave in LIST view — line-through on/off), and **press-and-hold (~500ms) opens the clock picker** to set or change the routine's time.

Implementation notes:
- Pointer events, so it works as touch long-press on phones/tablets AND click-and-hold on desktop.
- The click that follows a fired long-press is swallowed so it can't also toggle completion; moving (scrolling) or leaving the pill cancels the hold.
- Context menu + text selection suppressed on the pills so iOS long-presses don't trigger the callout/magnifier.
- Tooltip now reads "Tap to complete · hold to pick a time" (localized in all six languages; the superseded tap-to-schedule key removed).

## Testing

Full suite green (861); build clean. Hands-on: tap a pill → strike-through; tap again → back; hold → picker, pick a time → pill shows the time and the block lands on the timeline; hold-then-release-early → treated as a tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUM5nicM4pp68UJLosy7WH)_