### PR TITLE
Fix arm64 GHCR builds (QEMU) + bump to 4.0.1

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Register binfmt/QEMU handlers so buildx can emulate linux/arm64 on the
+      # amd64 runner. Without this, the arm64 leg of the multi-arch build is
+      # silently skipped and only an amd64 image is pushed (see #1257).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-# Build stage - pinned to amd64 because the output is static files (arch-independent)
+# check=skip=FromPlatformFlagConstDisallowed
+# ^ Must be the first line to take effect (a parser directive). The builder
+#   stage is deliberately pinned to amd64, which trips that check; the pin is
+#   intentional, so skip the check rather than emulate the JS build on arm64.
+
+# Build stage - pinned to amd64 because the output is static files (arch-independent).
+# The arm64 image reuses this stage's output and only builds its own production
+# stage (nginx + nodejs) under emulation, so the heavy npm build never runs under QEMU.
 FROM --platform=linux/amd64 node:20-alpine AS builder
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="screenshots/badges/google-play.png" alt="Get it on Google Play" height="60">](https://play.google.com/store/apps/details?id=com.dayglance.app) [<img src="screenshots/badges/app-store.svg" alt="Download on the App Store" height="60">](https://apps.apple.com/app/id6771540599)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-4.0.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-4.0.1-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "@glance-apps/billing": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dayglance",
   "private": true,
   "license": "MIT",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Problem

The GHCR publish workflow declares `platforms: linux/amd64,linux/arm64`, but it never registers QEMU. On the amd64 GitHub runner, buildx therefore builds **only** the runner's native architecture and pushes a single-arch image under a one-entry manifest index — the job goes green, so it went unnoticed.

Verified from build provenance: both the earliest release (`v3.4.0`, June 15) and the latest (`v4.0.0`) record `"platform": "linux/amd64"` as the sole platform, with byte-identical 1609-byte index descriptors. And `docker/setup-qemu-action` has never appeared in the workflow on any ref. So **every published tag — `3.4.0` through `4.0.0`, plus `latest` — is amd64-only**, and arm64 pulls fail with:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

Reported in #1257 (Raspberry Pi / Apple Silicon / ARM cloud). Since `docker-compose.yml` pulls `latest`, compose-based arm64 installs are affected too.

## Fix

- **`.github/workflows/publish-ghcr.yml`** — add `docker/setup-qemu-action@v3` before buildx so the `linux/arm64` leg is actually emulated and a true multi-arch manifest is published.
- **`Dockerfile`** — the builder stage stays pinned to `--platform=linux/amd64` (its output is static, arch-independent), so only the small nginx + `apk add nodejs` production stage runs under emulation; the heavy `npm build` never runs under QEMU. Added a `# check=skip=FromPlatformFlagConstDisallowed` parser directive (must be the first line) to quiet the resulting lint on the intentional pin.

## Version bump

- **`package.json`**, **`package-lock.json`** (dayGLANCE's own version only), and the **README badge** bumped `4.0.0 → 4.0.1` to match the `v4.0.1` tag that will republish the image.
- App code is unchanged from 4.0.0. The native Android / iOS / Electron builds are **not** part of this Docker-only release, so their version configs — including the Android `versionCode` — are intentionally left as-is.

## Releasing

Merge, then tag **`v4.0.1`** from a commit at or after this merge. The `release: published` event re-runs this workflow and republishes `4.0.1`, `4.0`, and `latest` as multi-arch — which also fixes `latest` for compose users.

Fixes #1257