### PR TITLE
ci: emit clean multi-arch manifest (provenance/sbom off)

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -52,6 +52,12 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          # Emit a clean manifest list (just the amd64 + arm64 images). Without
+          # these, buildx adds provenance/SBOM attestation manifests as extra
+          # "unknown/unknown" entries in the index, which older Docker/containerd
+          # clients can choke on when resolving a platform (see #1257).
+          provenance: false
+          sbom: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Background

Follow-up to #1258 / #1257. Investigation showed the GHCR images were **already multi-arch** (amd64 + arm64) all along — arm64 was never missing. The reporter's `no matching manifest for linux/arm64/v8` turned out to be a **pull-side manifest-resolution** problem, not a missing build: the arm64 image was present in the registry but their client didn't select it. Pulling a fresh `4.0.1` resolved it for them.

## Change

Set `provenance: false` and `sbom: false` on the GHCR build-push step.

By default, buildx attaches provenance/SBOM **attestation manifests** to the image index as extra `unknown/unknown` entries. Some older Docker/containerd clients mishandle an OCI image index that carries those entries when resolving a platform — the exact class of symptom seen in #1257. Turning them off publishes a **clean manifest list containing only the `linux/amd64` and `linux/arm64` images**, which maximises compatibility with older clients.

## Impact

- No change to the actual app images — same two platforms, just without the attestation side-manifests.
- Purely a CI/packaging hardening; app code, Electron, Android, and iOS are untouched.
- Nothing here is urgent — current tags (`latest`, `4.0`, `4.0.1`) already resolve correctly for up-to-date clients. This reduces the chance of the old-client class of report recurring.

Ref #1257

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_