### PR TITLE
android: bump versionCode to 182 for internal testing

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 35
-        versionCode = 181
+        versionCode = 182
         versionName = "4.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Play requires a unique, incremented `versionCode` for **every** upload — internal testing tracks included — and `181` is already used by v4.0.0. Bump `181 → 182` so the Billing 8 build can go up to internal testing for the device pass (throwaway license-tester account, per `docs/internal/testing-billing.md`).

`versionName` stays `4.0.0` — this is a test upload, not a release. The next production release (API 36 + Billing, per #1245) will bump both as appropriate.

One-line change to `dayglance-android/app/build.gradle.kts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_