### PR TITLE
android: use billing (Java) instead of billing-ktx to fix Kotlin 1.9 build

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -160,8 +160,8 @@ dependencies {
     // DocumentFile — Storage Access Framework wrapper for Obsidian vault file I/O
     implementation(libs.androidx.documentfile)
 
-    // Google Play Billing
-    implementation(libs.billing.ktx)
+    // Google Play Billing (base Java artifact — see note in libs.versions.toml)
+    implementation(libs.billing)
 
     // Chrome Custom Tabs — privacy policy link in PermissionsRationaleActivity
     implementation(libs.browser)

--- a/dayglance-android/gradle/libs.versions.toml
+++ b/dayglance-android/gradle/libs.versions.toml
@@ -52,8 +52,12 @@ androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscree
 # DocumentFile (Storage Access Framework — Obsidian vault file I/O)
 androidx-documentfile = { group = "androidx.documentfile", name = "documentfile", version.ref = "documentfile" }
 
-# Google Play Billing
-billing-ktx = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "billing" }
+# Google Play Billing — use the plain Java artifact, NOT billing-ktx. The 8.x
+# -ktx artifact ships Kotlin 2.1 metadata, which this project's Kotlin 1.9
+# compiler can't read ("incompatible version of Kotlin ... metadata is 2.1.0").
+# We only call base BillingClient callback APIs (suspend wrapping is done locally
+# with kotlinx-coroutines), so the ktx extensions aren't needed.
+billing = { group = "com.android.billingclient", name = "billing", version.ref = "billing" }
 
 # Chrome Custom Tabs (Health Connect permission rationale — privacy policy link)
 browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }


### PR DESCRIPTION
## Problem

The Billing 8 build fails at Kotlin compile:

```
jetified-billing-ktx-8.0.0 ... Module was compiled with an incompatible
version of Kotlin. The binary version of its metadata is 2.1.0, expected
version is 1.9.0.
```

(fails `kspPlayReleaseKotlin` and `kspGithubReleaseKotlin`.) The **`billing-ktx`** artifact for 8.x is built with **Kotlin 2.1**, but the project is on **Kotlin 1.9.24**, so the compiler can't read its metadata.

## Fix

Depend on the plain **`com.android.billingclient:billing`** artifact instead of `billing-ktx`. It's pure Java with no Kotlin metadata, so it builds cleanly on Kotlin 1.9 — and it keeps billing decoupled from the project's Kotlin version (one less thing entangled with the future API 36 / toolchain bump).

**No code change.** `BillingManager` only calls base `BillingClient` callback APIs (`queryProductDetailsAsync`, `queryPurchasesAsync`, `consumeAsync`, …) and does its own `suspendCancellableCoroutine` wrapping — it never used the ktx extension functions. Verified every `com.android.billingclient` import is a base API class.

## Alternative (not taken)

Bumping Kotlin 1.9.24 → 2.1.x would also satisfy `billing-ktx`, but that's a much larger, riskier change (K2 compiler, KSP realignment) and belongs with the deliberate API 36 toolchain upgrade — not a prerequisite for testing Billing 8. Since we don't use the ktx extensions, dropping them is the smaller, permanent fix.

Ref #1245

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_