### PR TITLE
android: target API 36 + AGP/healthConnect bump

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -14,12 +14,12 @@ val keystoreProperties: Properties? = if (hasKeystore) {
 
 android {
     namespace = "com.dayglance.app"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 182
         versionName = "4.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 36
-        versionCode = 182
+        versionCode = 183
         versionName = "4.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dayglance-android/gradle/libs.versions.toml
+++ b/dayglance-android/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-agp = "8.4.0"
+agp = "8.9.1" # first attempt for compileSdk 36; if the build names a different min AGP, use that
 kotlin = "1.9.24"
 ksp = "1.9.24-1.0.20"
 coreKtx = "1.13.1"
 appcompat = "1.7.0"
 material = "1.12.0"
 constraintlayout = "2.1.4"
-healthConnect = "1.1.0-alpha12" # 1.1.0 stable requires compileSdk 36 + AGP 8.9.1; bump with the post-v4 toolchain upgrade
+healthConnect = "1.1.0" # stable — unblocked by the compileSdk 36 + AGP bump
 workManager = "2.9.0"
 room = "2.6.1"
 coroutines = "1.8.1"


### PR DESCRIPTION
Second half of #1245 (the API 36 / toolchain half; Billing 8 already merged).

Google requires **targetSdk 36** for update submissions after **Aug 31, 2026**.

## Changes
- `compileSdk` / `targetSdk` **35 → 36**
- `agp` **8.4.0 → 8.9.1** — *first attempt*; the local build is the authority on the exact AGP/Gradle/Kotlin combo, since this repo's toolchain is already off the standard matrix (Gradle wrapper is 9.3.1)
- `healthConnect` **1.1.0-alpha12 → 1.1.0** stable (was gated on exactly this bump)

## ⚠️ Not built here — needs local verification
This was edited in an environment with no Android SDK, so it has **not been compiled**. The version numbers are a starting point; the build errors will name the real ones (see the "how" in the linked session). Behavior-change wise, edge-to-edge and predictive back are already handled from the targetSdk 35 work (`MainActivity` inset listener + `OnBackPressedDispatcher`), so this is expected to be version-bumps + a device pass, not new UI code.

- [ ] `./gradlew help` clean (adjust AGP/Gradle/Kotlin if it complains)
- [ ] `./build-and-install.sh` (debug) compiles
- [ ] `./build-and-install.sh --release` builds
- [ ] device pass on API 36: renders correctly, back gesture works

Ref #1245

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_