### PR TITLE
ci: gate on npm run audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
-# Lint, test, and build on every PR and on pushes to main. Gates on ESLint
-# errors (not warnings) and the Vitest suite.
+# Lint, test, build, and dependency-audit on every PR and on pushes to main.
+# Gates on ESLint errors (not warnings), the Vitest suite, and any untriaged
+# npm advisory (`npm run audit` — see scripts/audit-check.mjs).
 on:
   pull_request:
   push:
@@ -22,6 +23,11 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # Fails only on advisories not already triaged in scripts/audit-check.mjs
+      # (deferred or accepted). A genuinely new vulnerability fails the PR.
+      - name: Audit dependencies
+        run: npm run audit
 
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
Adds an **Audit dependencies** step to `ci.yml` that runs the filtered gate (`npm run audit` → `scripts/audit-check.mjs`) right after `npm ci`.

- **Passes** on the already-triaged advisories (the 4 deferred vite/esbuild + 1 accepted `brace-expansion`).
- **Fails the PR** only when a *new, untriaged* advisory appears — so a dependency change that introduces a vulnerability can't merge unnoticed.

Placed before lint/test/build so it fails fast. Verified `npm run audit` exits 0 on `main` as of this branch, so it won't red existing PRs.

**Operational note:** `npm run audit` calls the npm advisory API, so this step needs registry network access (fine on GitHub runners) — a transient registry outage would fail the step; re-run if that ever happens.

New advisories triage the same way as before: fix it, or add an entry to `scripts/audit-check.mjs` with a disposition + reason + review date.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_