### PR TITLE
feat: natural-language quick-add with tappable undo chips

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1386,7 +1386,8 @@ const DayPlanner = () => {
     handleNewTaskInputChange,
     handleNewTaskInputKeyDown,
     applySuggestionForNewTask,
-  } = useNewTaskInput({ allTags, showAddTask });
+    dismissNlChip,
+  } = useNewTaskInput({ allTags, showAddTask, isEditing: !!(mobileEditingTask || mobileEditingNativeEvent) });
 
   // Show all 24 hours (full day) - scrollable
   const hours = Array.from({ length: 24 }, (_, i) => i);
@@ -7774,6 +7775,7 @@ const DayPlanner = () => {
     startEditingTask, saveTaskTitle, cancelEditingTask,
     applySuggestionForEdit, handleEditKeyDown, handleEditInputChange,
     handleNewTaskInputChange, handleNewTaskInputKeyDown, applySuggestionForNewTask,
+    dismissNlChip,
     buildSuggestions,
     manuallyScheduleTask, scheduleTaskAtNextSlot, scheduleDeadlineTaskAt, scheduleRoutineAt,
     openNewTaskAtTime, openNewTaskForm, openNewInboxTask,

--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -6,6 +6,7 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { SOURCE_APPS } from '../native.js';
 import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
+import QuickAddChips from './QuickAddChips.jsx';
 import LastGlanceBadge from './LastGlanceBadge.jsx';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
@@ -35,6 +36,7 @@ const DesktopNewTaskModal = () => {
     addTask, saveMobileEditTask, moveToRecycleBin,
     applySuggestionForNewTask,
     handleNewTaskInputChange, handleNewTaskInputKeyDown,
+    dismissNlChip,
   } = useDayPlannerCtx();
   const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, triggerTaskAISuggestion, goals, projects, goalsProjectsEnabled, multiUserEnabled, users } = useFeaturesCtx();
   const { wikilinkCandidates = [] } = useSyncCtx() || {};
@@ -127,6 +129,10 @@ const DesktopNewTaskModal = () => {
                     textPrimary={textPrimary}
                     hoverBg={hoverBg}
                   />
+                )}
+                {/* Natural-language parse chips — tap to undo a parse */}
+                {!mobileEditingTask && (
+                  <QuickAddChips chips={newTask.nlChips} onDismiss={dismissNlChip} darkMode={darkMode} />
                 )}
                 {/* Wikilink autocomplete dropdown */}
                 {wikilinkSuggestions.length > 0 && (

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -6,6 +6,7 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { SOURCE_APPS } from '../native.js';
 import LastGlanceBadge from './LastGlanceBadge.jsx';
+import QuickAddChips from './QuickAddChips.jsx';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
 import { getProjectColor } from '../utils/colorUtils.js';
@@ -29,6 +30,7 @@ const MobileNewTaskModal = () => {
     addTask, saveMobileEditTask, saveMobileEditNativeEvent,
     moveToRecycleBin, clearNativeEventOverride,
     handleNewTaskInputChange,
+    dismissNlChip,
   } = useDayPlannerCtx();
   const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, triggerTaskAISuggestion, goals, projects, goalsProjectsEnabled, multiUserEnabled, users } = useFeaturesCtx();
   const { wikilinkCandidates = [] } = useSyncCtx() || {};
@@ -93,6 +95,10 @@ const MobileNewTaskModal = () => {
                   autoFocus={!mobileEditingTask && !newTask.title}
                   className={`w-full px-3 py-3 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white'} text-base`}
                 />
+                {/* Natural-language parse chips — tap to undo a parse */}
+                {!mobileEditingTask && !mobileEditingNativeEvent && (
+                  <QuickAddChips chips={newTask.nlChips} onDismiss={dismissNlChip} darkMode={darkMode} />
+                )}
                 {/* Wikilink autocomplete dropdown */}
                 {wikilinkSuggestions.length > 0 && (
                   <div className={`absolute top-full left-0 mt-1 ${cardBg} rounded-lg p-1 z-50 shadow-xl border ${borderClass} w-full max-h-48 overflow-y-auto`}>

--- a/src/components/QuickAddChips.jsx
+++ b/src/components/QuickAddChips.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Calendar, Clock, Hash, Repeat, Timer, X } from 'lucide-react';
+
+// Chip row for natural-language quick-add parses ("dentist tomorrow 3pm every
+// 2 weeks" → Tomorrow / 3:00 PM / Every 2 weeks). Rendered under the title
+// input in the new-task modals. Tapping a chip undoes that parse: the phrase
+// stays as plain title text and the auto-applied field reverts
+// (useNewTaskInput.dismissNlChip).
+
+const ICONS = {
+  date: Calendar,
+  time: Clock,
+  timerange: Clock,
+  recurrence: Repeat,
+  duration: Timer,
+  tag: Hash,
+};
+
+const QuickAddChips = ({ chips, onDismiss, darkMode }) => {
+  if (!chips || chips.length === 0) return null;
+  return (
+    <div className="mt-1.5 flex flex-wrap gap-1.5" aria-label="Detected task details">
+      {chips.map((chip) => {
+        const Icon = ICONS[chip.type] || Calendar;
+        const label = chip.inboxDate ? `Deadline: ${chip.display}` : chip.display;
+        return (
+          <button
+            key={`${chip.sig}-${chip.start}`}
+            type="button"
+            onClick={() => onDismiss(chip)}
+            // Keep focus in the title input while dismissing
+            onMouseDown={(e) => e.preventDefault()}
+            title={`Remove: ${label}`}
+            className={`inline-flex items-center gap-1 rounded-full pl-2 pr-1.5 py-0.5 text-xs font-medium transition-colors ${
+              darkMode
+                ? 'bg-blue-500/15 text-blue-300 hover:bg-blue-500/25'
+                : 'bg-blue-50 text-blue-700 hover:bg-blue-100'
+            }`}
+          >
+            <Icon size={11} className="flex-shrink-0 opacity-70" />
+            <span>{label}</span>
+            <X size={11} className="flex-shrink-0 opacity-50" />
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default QuickAddChips;

--- a/src/hooks/useNewTaskInput.js
+++ b/src/hooks/useNewTaskInput.js
@@ -6,9 +6,25 @@ import {
   getDateCandidates, getTimeCandidates,
   completeShortcutText,
 } from '../utils/suggestionParser.js';
+import { parseQuickAdd, spanSignature } from '../utils/quickAddParser.js';
 
-export default function useNewTaskInput({ allTags, showAddTask }) {
+// Deep-enough equality for NL-applied values (strings, numbers, small
+// recurrence objects). Used to detect whether the user manually changed a
+// field after the NL layer set it.
+const sameVal = (a, b) => JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+
+export default function useNewTaskInput({ allTags, showAddTask, isEditing = false }) {
   const [newTask, setNewTask] = useState({ title: '', startTime: '09:00', duration: 30 });
+  // Natural-language layer bookkeeping:
+  // - dismissedNlRef: span signatures the user rejected via chip tap — those
+  //   phrases stay plain text until the input is next reset.
+  // - nlAppliedRef / nlBaselineRef: per-field record of what the NL layer set
+  //   and what the field held before, so removing a chip (dismiss OR editing
+  //   the phrase away) reverts the field — unless the user changed it manually
+  //   in the meantime (then the user's value wins).
+  const dismissedNlRef = useRef(new Set());
+  const nlAppliedRef = useRef({});
+  const nlBaselineRef = useRef({});
   const [showNewTaskDeadlinePicker, setShowNewTaskDeadlinePicker] = useState(false);
   const [suggestions, setSuggestions] = useState([]);
   const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(0);
@@ -134,14 +150,106 @@ export default function useNewTaskInput({ allTags, showAddTask }) {
     return allSuggestions;
   };
 
+  // ── Natural-language layer ────────────────────────────────────────────────
+  // Parses bare phrases ("tomorrow 3pm every 2 weeks") into chips + task
+  // fields. Runs alongside the sigil system: sigil regions are masked inside
+  // parseQuickAdd, and sigil auto-apply runs AFTER (explicit syntax wins).
+
+  // Parse `title`, drop dismissed/mode-inapplicable spans, and return the
+  // task patched with applied fields + chip/strip metadata.
+  const applyNlLayer = (prev, title) => {
+    // NL parsing is for CREATING tasks only. When editing an existing task,
+    // typing "tomorrow" into a title must never silently reschedule it.
+    if (isEditing) {
+      return { ...prev, title, nlChips: [], nlSpans: [] };
+    }
+    const isInbox = !!prev.openInInbox;
+    let spans = parseQuickAdd(title).spans
+      .filter(s => !dismissedNlRef.current.has(spanSignature(s)));
+    // Inbox tasks aren't scheduled or recurring: only tags, a deadline-style
+    // date, and duration make sense there.
+    if (isInbox) spans = spans.filter(s => ['tag', 'date', 'duration'].includes(s.type));
+
+    const bySpanType = (t) => spans.find(s => s.type === t);
+    const dateSpan = bySpanType('date');
+    const timeSpan = bySpanType('time');
+    const rangeSpan = bySpanType('timerange');
+    const durSpan = bySpanType('duration');
+    const recSpan = bySpanType('recurrence');
+
+    // Desired field values from the current spans.
+    const desired = {};
+    if (isInbox) {
+      if (dateSpan) desired.deadline = dateSpan.value;
+      if (durSpan) desired.duration = durSpan.value;
+    } else {
+      if (dateSpan) desired.date = dateSpan.value;
+      if (rangeSpan) {
+        desired.startTime = rangeSpan.value.startTime;
+        desired.duration = rangeSpan.value.duration;
+      }
+      if (timeSpan) desired.startTime = timeSpan.value;
+      else if (!rangeSpan) {
+        const implied = dateSpan?.impliedTime || recSpan?.impliedTime;
+        if (implied) desired.startTime = implied;
+      }
+      if (durSpan) desired.duration = durSpan.value;
+      if (recSpan) desired.recurrence = recSpan.value;
+    }
+
+    // Apply new values / revert vanished ones. A field is only touched while
+    // it still holds what the NL layer last wrote — manual edits win.
+    const next = { ...prev, title };
+    const applied = nlAppliedRef.current;
+    const baselines = nlBaselineRef.current;
+    for (const f of ['date', 'startTime', 'duration', 'recurrence', 'deadline']) {
+      if (f in desired) {
+        if (!(f in applied)) baselines[f] = prev[f]; // first claim → remember what to restore
+        if (!(f in applied) || sameVal(prev[f], applied[f])) {
+          next[f] = desired[f];
+          applied[f] = desired[f];
+        }
+      } else if (f in applied) {
+        if (sameVal(prev[f], applied[f])) next[f] = baselines[f];
+        delete applied[f];
+        delete baselines[f];
+      }
+    }
+    if ('startTime' in desired && prev.isAllDay) next.isAllDay = false;
+
+    // Chips for the UI (tags included); spans to strip from the title at save
+    // (tags excluded — tag text stays in the title by app convention).
+    next.nlChips = spans.map(s => ({ ...s, sig: spanSignature(s), inboxDate: isInbox && s.type === 'date' }));
+    next.nlSpans = spans.filter(s => s.type !== 'tag');
+    return next;
+  };
+
+  // Chip tap = undo that parse. Non-tag chips: remember the dismissal (the
+  // phrase stays plain text) and revert the field. Tag chips: delete the #tag
+  // token from the title itself.
+  const dismissNlChip = (chip) => {
+    if (chip.type === 'tag') {
+      setNewTask(prev => {
+        const title = (prev.title.slice(0, chip.start) + prev.title.slice(chip.end))
+          .replace(/\s{2,}/g, ' ').trimStart();
+        return applyNlLayer(prev, title);
+      });
+      newTaskInputRef.current?.focus();
+      return;
+    }
+    dismissedNlRef.current.add(chip.sig);
+    setNewTask(prev => applyNlLayer(prev, prev.title));
+    newTaskInputRef.current?.focus();
+  };
+
   // Handle suggestions for new task input
   const handleNewTaskInputChange = (e) => {
     const value = e.target.value;
     const cursorPos = e.target.selectionStart;
     const allSuggestions = buildSuggestions(value, cursorPos, newTask.openInInbox);
 
-    // Auto-apply attribute suggestions in real-time as the user types
-    const updates = { title: value };
+    // Auto-apply sigil suggestions in real-time as the user types
+    const updates = {};
     for (const s of allSuggestions) {
       // Use first (best) match per type, not last
       if (s.type === 'date' && !('date' in updates)) updates.date = s.value;
@@ -150,7 +258,8 @@ export default function useNewTaskInput({ allTags, showAddTask }) {
       else if (s.type === 'priority' && !('priority' in updates)) updates.priority = s.value;
       else if (s.type === 'duration' && !('duration' in updates)) updates.duration = s.value;
     }
-    setNewTask(prev => ({ ...prev, ...updates }));
+    // NL layer first, sigil updates second — explicit sigil syntax wins.
+    setNewTask(prev => ({ ...applyNlLayer(prev, value), ...updates }));
 
     if (allSuggestions.length > 0) {
       setSuggestions(allSuggestions);
@@ -267,12 +376,15 @@ export default function useNewTaskInput({ allTags, showAddTask }) {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showSuggestions]);
 
-  // Reset tag suggestions when add task modal closes
+  // Reset tag suggestions and NL-layer bookkeeping when add task modal closes
   useEffect(() => {
     if (!showAddTask) {
       setShowSuggestions(false);
       setSuggestions([]);
       setSelectedSuggestionIndex(0);
+      dismissedNlRef.current = new Set();
+      nlAppliedRef.current = {};
+      nlBaselineRef.current = {};
     }
   }, [showAddTask]);
 
@@ -294,5 +406,6 @@ export default function useNewTaskInput({ allTags, showAddTask }) {
     handleNewTaskInputChange,
     handleNewTaskInputKeyDown,
     applySuggestionForNewTask,
+    dismissNlChip,
   };
 }

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -1,4 +1,5 @@
 import { cleanTitle } from '../utils/suggestionParser.js';
+import { stripSpans } from '../utils/quickAddParser.js';
 import { dateToString, extractTags, formatDeadlineDate } from '../utils/taskUtils.js';
 import { TASK_COLORS } from '../utils/colorUtils.js';
 import { triggerHaptic } from '../native.js';
@@ -127,6 +128,12 @@ export default function useTaskActions({
     if (newTask.title.trim()) {
       pushUndo();
 
+      // Remove natural-language phrases the quick-add layer parsed into task
+      // fields ("tomorrow 3pm every 2 weeks"); their values already live on
+      // newTask. Dismissed chips are not in nlSpans, so their text survives.
+      // cleanTitle then strips sigil shorthand as before.
+      const savedTitle = cleanTitle(stripSpans(newTask.title, newTask.nlSpans));
+
       // Determine whether this task should be linked to an Obsidian daily note.
       // Recurring and swipe-scheduling paths are excluded: recurring tasks use
       // their own ID scheme; swipe-scheduling preserves an existing task's ID.
@@ -134,7 +141,7 @@ export default function useTaskActions({
       const hasObsidianTag = tags.includes('obsidian');
       const isRecurring = !!newTask.recurrence;
       const isSwipeSchedule = !!swipeSchedulingInboxTaskId.current;
-      const rawObsidianTitle = hasObsidianTag ? stripTag(cleanTitle(newTask.title), 'obsidian') : null;
+      const rawObsidianTitle = hasObsidianTag ? stripTag(savedTitle, 'obsidian') : null;
       // Skip if stripping the tag leaves an empty title (e.g. task titled only "#obsidian")
       const obsidianMeta = (hasObsidianTag && rawObsidianTitle && !isRecurring && !isSwipeSchedule && getObsidianTaskMeta)
         ? getObsidianTaskMeta(rawObsidianTitle)
@@ -146,7 +153,7 @@ export default function useTaskActions({
       let scheduledAdjustedStartTime = newTask.startTime || null;
       const task = {
         id: taskId,
-        title: cleanTitle(newTask.title),
+        title: savedTitle,
         duration: newTask.duration,
         color: newTask.color || colors[0].class,
         completed: false,
@@ -172,7 +179,7 @@ export default function useTaskActions({
         const taskDate = newTask.date || dateToString(selectedDate);
         const template = {
           id: taskId,
-          title: cleanTitle(newTask.title),
+          title: savedTitle,
           startTime: newTask.isAllDay ? '00:00' : newTask.startTime,
           duration: newTask.duration,
           color: newTask.color || colors[0].class,
@@ -205,7 +212,7 @@ export default function useTaskActions({
           const { priority, deadline, ...preserved } = inboxTask;
           setTasks(prev => [...prev, {
             ...preserved,
-            title: cleanTitle(newTask.title),
+            title: savedTitle,
             duration: newTask.duration,
             color: newTask.color || colors[0].class,
             isAllDay: newTask.isAllDay || false,

--- a/src/utils/quickAddParser.js
+++ b/src/utils/quickAddParser.js
@@ -1,0 +1,616 @@
+// Natural-language quick-add parser — deterministic, offline, no AI.
+//
+// Parses Todoist/Fantastical-style phrases out of free task text:
+//
+//   "dentist tomorrow 3pm every 2 weeks"
+//     → date span (tomorrow), time span (3pm), recurrence span (biweekly)
+//
+// Design rules (load-bearing — see quickAddParser.test.js):
+//
+// - PURE + DETERMINISTIC. Same text + same `now` → same result. `now` is
+//   injectable for tests. English vocabulary only, matching the existing
+//   @/~ sigil parser (suggestionParser.js).
+// - SPAN-BASED. Every detection carries [start, end) indices into the ORIGINAL
+//   text so the UI can render chips, dismiss individual parses, and strip the
+//   matched text at save (stripSpans). Text is never rewritten while typing —
+//   same convention as the sigil system (cleanTitle strips at save).
+// - COEXISTS WITH SIGILS. Regions claimed by the explicit shortcut characters
+//   (@date ~time $deadline %duration !priority) are masked out first, so
+//   "@tomorrow" is never double-parsed by the NL layer.
+// - HONEST ABOUT THE ENGINE. recurrenceEngine.js supports daily / weekly /
+//   biweekly / monthly / yearly (+ daysOfWeek / monthDay / monthWeekday).
+//   Phrases it cannot represent ("every 3 days") are deliberately NOT parsed —
+//   the text stays in the title rather than silently mis-scheduling.
+// - ONE ENTITY PER TYPE, LAST MATCH WINS. People write the title first and
+//   qualifiers last ("standup friday 9am"), so the right-most date/time/etc.
+//   is applied. Within a stage, earlier matchers are more specific and claim
+//   their text first (overlap dedupe), THEN last-match-wins runs.
+//
+// Stage order matters: tags → recurrence → time-range → time → date →
+// duration. Each stage masks the text it claims so "every monday" is a
+// recurrence, not a date; "3-4pm" is a range, not the time "4pm".
+
+const DAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+const DAY_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const DAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+// Abbreviation → day index. Multiple spellings per day (thu/thur/thurs, tue/tues).
+const DAY_ABBREVS = {
+  sun: 0, mon: 1, tue: 2, tues: 2, wed: 3, thu: 4, thur: 4, thurs: 4, fri: 5, sat: 6,
+};
+const MONTH_NAMES = ['january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december'];
+const MONTH_ABBREVS = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'];
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// Day-part → default start time. Values mirror suggestionParser's naturalTimes.
+const DAYPARTS = { morning: '09:00', afternoon: '14:00', evening: '18:00', night: '21:00' };
+
+const DAY_ALT = `${DAY_NAMES.join('|')}|${Object.keys(DAY_ABBREVS).join('|')}`;
+const DAYPART_ALT = Object.keys(DAYPARTS).join('|');
+const ORDINALS = { first: 1, second: 2, third: 3, fourth: 4, fifth: 5, '1st': 1, '2nd': 2, '3rd': 3, '4th': 4, '5th': 5 };
+
+const pad2 = (n) => String(n).padStart(2, '0');
+const toDateStr = (d) => `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+const toTimeStr = (h, m = 0) => `${pad2(h)}:${pad2(m)}`;
+
+const display12h = (timeStr) => {
+  const [h, m] = timeStr.split(':').map(Number);
+  const ampm = h >= 12 ? 'PM' : 'AM';
+  const dh = h % 12 === 0 ? 12 : h % 12;
+  return `${dh}:${pad2(m)} ${ampm}`;
+};
+
+const ordinalSuffix = (n) =>
+  n % 10 === 1 && n !== 11 ? 'st' : n % 10 === 2 && n !== 12 ? 'nd' : n % 10 === 3 && n !== 13 ? 'rd' : 'th';
+
+const dayIndexOf = (word) => {
+  const w = word.toLowerCase();
+  const full = DAY_NAMES.indexOf(w);
+  if (full !== -1) return full;
+  return w in DAY_ABBREVS ? DAY_ABBREVS[w] : -1;
+};
+
+// Next occurrence of weekday `idx`; matches the sigil parser's semantics:
+// if today IS that weekday, jump a full week.
+const nextWeekday = (now, idx) => {
+  const d = new Date(now);
+  let add = idx - d.getDay();
+  if (add <= 0) add += 7;
+  d.setDate(d.getDate() + add);
+  return d;
+};
+
+// Bare-hour meridiem rule for "at 3" / "from 3 to 5" (no am/pm given):
+// working-hours assumption — 8..11 → AM, 12 → noon, 1..7 → PM, 13..23 → 24h.
+// Deterministic; the chip shows the resolved time so surprises are visible.
+const bareHourTo24 = (h) => {
+  if (h >= 13 && h <= 23) return h;
+  if (h >= 8 && h <= 12) return h;
+  return h + 12; // 1..7 → 13..19
+};
+
+const meridiemTo24 = (h, ap) => {
+  if (ap === 'pm') return h === 12 ? 12 : h + 12;
+  return h === 12 ? 0 : h; // am
+};
+
+// ---------------------------------------------------------------------------
+// Masking helpers
+// ---------------------------------------------------------------------------
+
+// Blank a [start,end) region with spaces, preserving all other indices.
+const maskRange = (chars, start, end) => {
+  for (let i = start; i < end; i++) chars[i] = ' ';
+};
+
+// Mask every sigil-claimed region so the NL layer never double-parses them.
+// Patterns mirror cleanTitle() in suggestionParser.js.
+const SIGIL_PATTERNS = [
+  /@[\w\s/\-,]*/g,
+  /~[\w\s:]*/g,
+  /\$[\w\s/\-,]*/g,
+  /%\d+/g,
+  /!{1,3}(?=\s|$)/g,
+];
+const maskSigils = (chars, text) => {
+  for (const pat of SIGIL_PATTERNS) {
+    pat.lastIndex = 0;
+    let m;
+    while ((m = pat.exec(text)) !== null) {
+      if (m[0].length === 0) { pat.lastIndex++; continue; }
+      maskRange(chars, m.index, m.index + m[0].length);
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Stage: tags (#tag) — chips only; the text stays in the title (app convention:
+// tags live inline and are extracted at save by extractTags).
+// ---------------------------------------------------------------------------
+
+const matchTags = (masked, spans) => {
+  const re = /(^|\s)#([a-zA-Z]\w*)/g;
+  let m;
+  while ((m = re.exec(masked)) !== null) {
+    const start = m.index + m[1].length;
+    spans.push({
+      type: 'tag',
+      start,
+      end: start + 1 + m[2].length,
+      value: m[2].toLowerCase(),
+      display: `#${m[2].toLowerCase()}`,
+    });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Stage: recurrence
+// ---------------------------------------------------------------------------
+
+// Parse "mon, wed and fri" / "tuesday/thursday" into sorted unique day indices.
+const parseDayList = (listText) => {
+  const days = [];
+  const re = new RegExp(`\\b(${DAY_ALT})\\b`, 'gi');
+  let m;
+  while ((m = re.exec(listText)) !== null) {
+    const idx = dayIndexOf(m[1]);
+    if (idx !== -1 && !days.includes(idx)) days.push(idx);
+  }
+  return days.sort((a, b) => a - b);
+};
+
+const describeDays = (days) =>
+  days.length === 1 ? DAY_LABELS[days[0]] : days.map((d) => DAY_SHORT[d]).join('/');
+
+const DAY_LIST_RE = `(?:${DAY_ALT})(?:\\s*(?:,|and|&|\\/)\\s*(?:${DAY_ALT}))*`;
+
+// Ordered most-specific-first; the first rule family that matches wins.
+const RECURRENCE_RULES = [
+  // every 2 weeks [on <days>] / every other week / biweekly / fortnightly
+  {
+    re: new RegExp(`\\b(?:every\\s+(?:2|two)\\s+weeks|every\\s+other\\s+week|bi-?weekly|fortnightly)(?:\\s+on\\s+(${DAY_LIST_RE}))?\\b`, 'gi'),
+    build: (m) => {
+      const days = m[1] ? parseDayList(m[1]) : [];
+      return {
+        value: days.length ? { type: 'biweekly', daysOfWeek: days } : { type: 'biweekly' },
+        display: days.length ? `Every 2 weeks on ${describeDays(days)}` : 'Every 2 weeks',
+      };
+    },
+  },
+  // every other <weekday>
+  {
+    re: new RegExp(`\\bevery\\s+other\\s+(${DAY_ALT})\\b`, 'gi'),
+    build: (m) => {
+      const idx = dayIndexOf(m[1]);
+      if (idx === -1) return null;
+      return { value: { type: 'biweekly', daysOfWeek: [idx] }, display: `Every 2 weeks on ${DAY_LABELS[idx]}` };
+    },
+  },
+  // every Nth [of the month] → monthly on day N ("rent every 1st")
+  {
+    re: /\bevery\s+(\d{1,2})(?:st|nd|rd|th)(?:\s+of\s+(?:the|each|every)\s+month)?\b/gi,
+    build: (m) => {
+      const day = parseInt(m[1], 10);
+      if (day < 1 || day > 31) return null;
+      return {
+        value: { type: 'monthly', monthDay: day, monthWeekday: null },
+        display: `Monthly on the ${day}${ordinalSuffix(day)}`,
+      };
+    },
+  },
+  // every first|1st..fifth|5th <weekday> [of the month] → monthly monthWeekday
+  {
+    re: new RegExp(`\\bevery\\s+(first|second|third|fourth|fifth|[1-5](?:st|nd|rd|th))\\s+(${DAY_ALT})(?:\\s+of\\s+(?:the|each|every)\\s+month)?\\b`, 'gi'),
+    build: (m) => {
+      const week = ORDINALS[m[1].toLowerCase()];
+      const idx = dayIndexOf(m[2]);
+      if (!week || idx === -1) return null;
+      const ordLabels = ['', '1st', '2nd', '3rd', '4th', '5th'];
+      return {
+        value: { type: 'monthly', monthDay: null, monthWeekday: { week, day: idx } },
+        display: `Monthly on the ${ordLabels[week]} ${DAY_LABELS[idx]}`,
+      };
+    },
+  },
+  // every week [on <days>] / weekly [on <days>]
+  {
+    re: new RegExp(`\\b(?:every\\s+week|weekly)(?:\\s+on\\s+(${DAY_LIST_RE}))?\\b`, 'gi'),
+    build: (m) => {
+      const days = m[1] ? parseDayList(m[1]) : [];
+      return {
+        value: days.length ? { type: 'weekly', daysOfWeek: days } : { type: 'weekly' },
+        display: days.length ? `Every week on ${describeDays(days)}` : 'Every week',
+      };
+    },
+  },
+  // every weekday / every weekend
+  {
+    re: /\bevery\s+weekdays?\b/gi,
+    build: () => ({ value: { type: 'weekly', daysOfWeek: [1, 2, 3, 4, 5] }, display: 'Every weekday (Mon-Fri)' }),
+  },
+  {
+    re: /\bevery\s+weekends?\b/gi,
+    build: () => ({ value: { type: 'weekly', daysOfWeek: [0, 6] }, display: 'Every weekend (Sat-Sun)' }),
+  },
+  // every <day list> ("every monday", "every mon and wed")
+  {
+    re: new RegExp(`\\bevery\\s+(${DAY_LIST_RE})\\b`, 'gi'),
+    build: (m) => {
+      const days = parseDayList(m[1]);
+      if (!days.length) return null;
+      return { value: { type: 'weekly', daysOfWeek: days }, display: `Every week on ${describeDays(days)}` };
+    },
+  },
+  // every day / daily; every morning|afternoon|evening|night → daily + implied time
+  {
+    re: new RegExp(`\\bevery\\s+(day|${DAYPART_ALT})\\b|\\bdaily\\b`, 'gi'),
+    build: (m) => {
+      const part = m[1]?.toLowerCase();
+      if (part && part !== 'day') {
+        return {
+          value: { type: 'daily' },
+          display: `Every ${part} (${display12h(DAYPARTS[part])})`,
+          impliedTime: DAYPARTS[part],
+        };
+      }
+      return { value: { type: 'daily' }, display: 'Every day' };
+    },
+  },
+  // every month / monthly (bare)
+  {
+    re: /\b(?:every\s+month|monthly)\b/gi,
+    build: () => ({ value: { type: 'monthly' }, display: 'Every month' }),
+  },
+  // every year / yearly / annually
+  {
+    re: /\b(?:every\s+year|yearly|annually)\b/gi,
+    build: () => ({ value: { type: 'yearly' }, display: 'Every year' }),
+  },
+  // NOTE deliberately absent: "every N days/weeks/months" for arbitrary N —
+  // recurrenceEngine.js cannot represent those, so we leave the text alone.
+];
+
+const matchRecurrence = (masked, spans) => {
+  for (const rule of RECURRENCE_RULES) {
+    rule.re.lastIndex = 0;
+    let m;
+    while ((m = rule.re.exec(masked)) !== null) {
+      const built = rule.build(m);
+      if (!built) continue;
+      spans.push({ type: 'recurrence', start: m.index, end: m.index + m[0].length, ...built });
+    }
+    if (spans.length) break; // first (most specific) matching rule family wins
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Stage: time range → startTime + duration
+// ---------------------------------------------------------------------------
+
+const TIME_PART = '(\\d{1,2})(?::(\\d{2}))?\\s*(am|pm)?';
+
+const resolveRangeSide = (h, ap, fallbackAp) => {
+  if (ap) return meridiemTo24(h, ap);
+  if (h >= 13 && h <= 23) return h;
+  if (fallbackAp) return meridiemTo24(h, fallbackAp);
+  return bareHourTo24(h);
+};
+
+const matchTimeRange = (masked, spans) => {
+  // "from 3 to 4:30" | "3-4pm" | "3pm - 5pm" | "9am to noonish" (no).
+  // Guard: bare "N-N" (no meridiem, no :MM anywhere, no from/at prefix) is
+  // NOT a range — could be "sections 3-4". One anchor required.
+  const re = new RegExp(`\\b(from\\s+|at\\s+)?${TIME_PART}\\s*(?:-|–|to)\\s*${TIME_PART}\\b`, 'gi');
+  let m;
+  while ((m = re.exec(masked)) !== null) {
+    const [, prefix, h1s, m1s, ap1, h2s, m2s, ap2] = m;
+    const anchored = !!(prefix || ap1 || ap2 || m1s || m2s);
+    if (!anchored) continue;
+    const h1 = parseInt(h1s, 10);
+    const h2 = parseInt(h2s, 10);
+    if (h1 > 23 || h2 > 23) continue;
+    const min1 = m1s ? parseInt(m1s, 10) : 0;
+    const min2 = m2s ? parseInt(m2s, 10) : 0;
+    if (min1 > 59 || min2 > 59) continue;
+
+    // Resolve the end first (its meridiem back-propagates to the start).
+    const end24 = resolveRangeSide(h2, ap2, ap1);
+    let start24 = resolveRangeSide(h1, ap1, ap2);
+    let startMins = start24 * 60 + min1;
+    let endMins = end24 * 60 + min2;
+    // "11-1pm": pm-propagated start (23:00) overshoots the end → try AM start.
+    if (startMins >= endMins && !ap1 && h1 >= 1 && h1 <= 12) {
+      const alt = meridiemTo24(h1, 'am') * 60 + min1;
+      if (alt < endMins) { start24 = meridiemTo24(h1, 'am'); startMins = alt; }
+    }
+    // Explicit overnight ("11pm to 1am") — wrap past midnight.
+    if (startMins >= endMins) endMins += 24 * 60;
+    const duration = endMins - startMins;
+    if (duration <= 0 || duration > 24 * 60) continue;
+
+    const endDisplay = display12h(toTimeStr(Math.floor((endMins % (24 * 60)) / 60), endMins % 60));
+    spans.push({
+      type: 'timerange',
+      start: m.index,
+      end: m.index + m[0].length,
+      value: { startTime: toTimeStr(start24, min1), duration },
+      display: `${display12h(toTimeStr(start24, min1))} – ${endDisplay}`,
+    });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Stage: time (single)
+// ---------------------------------------------------------------------------
+
+const matchTime = (masked, spans) => {
+  const push = (m, timeStr) => {
+    spans.push({ type: 'time', start: m.index, end: m.index + m[0].length, value: timeStr, display: display12h(timeStr) });
+  };
+  let m;
+
+  // noon / midnight, optionally prefixed with "at "
+  let re = /\b(?:at\s+)?(noon|midnight)\b/gi;
+  while ((m = re.exec(masked)) !== null) {
+    push(m, m[1].toLowerCase() === 'noon' ? '12:00' : '00:00');
+  }
+
+  // H[:MM] am/pm — "3pm", "3:30 pm"
+  re = /\b(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)\b/gi;
+  while ((m = re.exec(masked)) !== null) {
+    const h = parseInt(m[1], 10);
+    const mins = m[2] ? parseInt(m[2], 10) : 0;
+    if (h < 1 || h > 12 || mins > 59) continue;
+    push(m, toTimeStr(meridiemTo24(h, m[3].toLowerCase()), mins));
+  }
+
+  // 24h / bare-colon HH:MM — "15:00", "9:30" (taken literally: 09:30)
+  re = /\b(?:at\s+)?(\d{1,2}):(\d{2})\b(?!\s*(?:am|pm))/gi;
+  while ((m = re.exec(masked)) !== null) {
+    const h = parseInt(m[1], 10);
+    const mins = parseInt(m[2], 10);
+    if (h > 23 || mins > 59) continue;
+    push(m, toTimeStr(h, mins));
+  }
+
+  // "at H" bare hour — requires the "at" anchor; working-hours meridiem rule.
+  re = /\bat\s+(\d{1,2})\b(?!\s*(?::|am|pm))/gi;
+  while ((m = re.exec(masked)) !== null) {
+    const h = parseInt(m[1], 10);
+    if (h < 1 || h > 23) continue;
+    push(m, toTimeStr(bareHourTo24(h), 0));
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Stage: date
+// ---------------------------------------------------------------------------
+
+const matchDate = (masked, spans, now) => {
+  const today = new Date(now);
+  today.setHours(12, 0, 0, 0);
+  const push = (m, date, display, impliedTime) => {
+    spans.push({
+      type: 'date',
+      start: m.index,
+      end: m.index + m[0].length,
+      value: toDateStr(date),
+      display,
+      ...(impliedTime ? { impliedTime } : {}),
+    });
+  };
+  let m;
+
+  // tonight → today + 21:00
+  let re = /\btonight\b/gi;
+  while ((m = re.exec(masked)) !== null) push(m, today, 'Tonight', '21:00');
+
+  // today/tomorrow/yesterday (+abbrevs) with optional day-part suffix
+  re = new RegExp(`\\b(?:on\\s+)?(today|tod|tomorrow|tmrw|tmr|tom|yesterday)(?:\\s+(${DAYPART_ALT}))?\\b`, 'gi');
+  while ((m = re.exec(masked)) !== null) {
+    const kw = m[1].toLowerCase();
+    const d = new Date(today);
+    let label;
+    if (kw === 'yesterday') { d.setDate(d.getDate() - 1); label = 'Yesterday'; }
+    else if (kw === 'today' || kw === 'tod') { label = 'Today'; }
+    else { d.setDate(d.getDate() + 1); label = 'Tomorrow'; }
+    const part = m[2]?.toLowerCase();
+    push(m, d, part ? `${label} ${part}` : label, part ? DAYPARTS[part] : undefined);
+  }
+
+  // "this morning/afternoon/evening/night" → today + implied time
+  re = new RegExp(`\\bthis\\s+(${DAYPART_ALT})\\b`, 'gi');
+  while ((m = re.exec(masked)) !== null) {
+    const part = m[1].toLowerCase();
+    push(m, today, `Today ${part}`, DAYPARTS[part]);
+  }
+
+  // next week → +7 days
+  re = /\b(?:on\s+)?next\s+week\b/gi;
+  while ((m = re.exec(masked)) !== null) {
+    const d = new Date(today);
+    d.setDate(d.getDate() + 7);
+    push(m, d, 'Next week');
+  }
+
+  // [on|next] <weekday> [daypart] — same semantics as the sigil parser:
+  // both "friday" and "next friday" mean the next future Friday.
+  re = new RegExp(`\\b(?:(on|next)\\s+)?(${DAY_ALT})(?:\\s+(${DAYPART_ALT}))?\\b`, 'gi');
+  while ((m = re.exec(masked)) !== null) {
+    const idx = dayIndexOf(m[2]);
+    if (idx === -1) continue;
+    const d = nextWeekday(today, idx);
+    const part = m[3]?.toLowerCase();
+    const label = (m[1]?.toLowerCase() === 'next' ? `Next ${DAY_LABELS[idx]}` : DAY_LABELS[idx]) + (part ? ` ${part}` : '');
+    push(m, d, label, part ? DAYPARTS[part] : undefined);
+  }
+
+  // in N days/weeks/months  ("in a week" too)
+  re = /\bin\s+(\d{1,3}|an?)\s+(day|week|month)s?\b/gi;
+  while ((m = re.exec(masked)) !== null) {
+    const n = m[1] === 'a' || m[1] === 'an' ? 1 : parseInt(m[1], 10);
+    if (!n || n > 365) continue;
+    const unit = m[2].toLowerCase();
+    const d = new Date(today);
+    if (unit === 'day') d.setDate(d.getDate() + n);
+    else if (unit === 'week') d.setDate(d.getDate() + n * 7);
+    else d.setMonth(d.getMonth() + n);
+    push(m, d, `In ${n} ${unit}${n === 1 ? '' : 's'}`);
+  }
+
+  // Month D[st|nd|rd|th][, YYYY] — "june 3", "Jun 3rd 2027". No year → roll
+  // forward to next year if the date has already passed (quick-add intent).
+  // Bare month names ("May") deliberately do NOT parse — too title-collision-prone.
+  const monthAlt = `${MONTH_NAMES.join('|')}|${MONTH_ABBREVS.join('|')}`;
+  re = new RegExp(`\\b(?:on\\s+)?(${monthAlt})\\s+(\\d{1,2})(?:st|nd|rd|th)?(?:[,\\s]\\s*(\\d{4}))?\\b`, 'gi');
+  while ((m = re.exec(masked)) !== null) {
+    const mw = m[1].toLowerCase();
+    let mi = MONTH_NAMES.indexOf(mw);
+    if (mi === -1) mi = MONTH_ABBREVS.indexOf(mw);
+    if (mi === -1) continue;
+    const day = parseInt(m[2], 10);
+    if (day < 1 || day > 31) continue;
+    let year = m[3] ? parseInt(m[3], 10) : today.getFullYear();
+    let d = new Date(year, mi, day, 12, 0, 0);
+    if (d.getDate() !== day) continue; // e.g. Feb 30
+    if (!m[3] && d < today) { year += 1; d = new Date(year, mi, day, 12, 0, 0); }
+    const yearSuffix = year !== today.getFullYear() ? `, ${year}` : '';
+    push(m, d, `${MONTH_LABELS[mi]} ${day}${yearSuffix}`);
+  }
+
+  // M/D[/YYYY] — slash dates. (Dash form deliberately omitted: bare "3-4" is
+  // a range or section number, not a date.)
+  re = /\b(?:on\s+)?(\d{1,2})\/(\d{1,2})(?:\/(\d{4}))?\b/g;
+  while ((m = re.exec(masked)) !== null) {
+    const mo = parseInt(m[1], 10);
+    const day = parseInt(m[2], 10);
+    if (mo < 1 || mo > 12 || day < 1 || day > 31) continue;
+    let year = m[3] ? parseInt(m[3], 10) : today.getFullYear();
+    let d = new Date(year, mo - 1, day, 12, 0, 0);
+    if (d.getDate() !== day) continue;
+    if (!m[3] && d < today) { year += 1; d = new Date(year, mo - 1, day, 12, 0, 0); }
+    const yearSuffix = year !== today.getFullYear() ? `, ${year}` : '';
+    push(m, d, `${MONTH_LABELS[mo - 1]} ${day}${yearSuffix}`);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Stage: duration — "for 30 min", "for 1h", "for 1.5 hours", "for an hour",
+// plus glued compact forms "1h30m" / "90m" / "2h" without "for".
+// ---------------------------------------------------------------------------
+
+const fmtDuration = (mins) => {
+  const h = Math.floor(mins / 60);
+  const r = mins % 60;
+  return h > 0 ? `${h}h${r ? ` ${r}m` : ''}` : `${mins}m`;
+};
+
+const matchDuration = (masked, spans) => {
+  const push = (m, mins) => {
+    if (mins < 1 || mins > 24 * 60) return;
+    spans.push({ type: 'duration', start: m.index, end: m.index + m[0].length, value: mins, display: `For ${fmtDuration(mins)}` });
+  };
+  let m;
+
+  let re = /\bfor\s+(?:(an?)\s+hour|(half)\s+an?\s+hour|(\d+(?:\.\d+)?)\s*(h(?:ou)?rs?|h|m(?:in(?:ute)?s?)?)(?:\s*(\d{1,2})\s*m(?:in(?:ute)?s?)?)?)\b/gi;
+  while ((m = re.exec(masked)) !== null) {
+    let mins;
+    if (m[1]) mins = 60; // "for an hour"
+    else if (m[2]) mins = 30; // "for half an hour"
+    else {
+      const n = parseFloat(m[3]);
+      const unit = m[4].toLowerCase();
+      mins = unit.startsWith('h') ? Math.round(n * 60) : Math.round(n);
+      if (m[5]) mins += parseInt(m[5], 10); // "for 1h 30m"
+    }
+    push(m, mins);
+  }
+
+  // Compact glued forms only (no space between number and unit) — avoids
+  // stealing legitimate text like "100 m sprint".
+  re = /\b(\d{1,2})h(?:(\d{1,2})m)?\b|\b(\d{1,3})m\b/gi;
+  while ((m = re.exec(masked)) !== null) {
+    let mins;
+    if (m[3]) mins = parseInt(m[3], 10);
+    else mins = parseInt(m[1], 10) * 60 + (m[2] ? parseInt(m[2], 10) : 0);
+    if (mins < 5) continue; // "3m" almost certainly isn't a duration
+    push(m, mins);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse natural-language entities out of quick-add text.
+ *
+ * @param {string} text  Raw input text.
+ * @param {object} [opts]
+ * @param {Date}   [opts.now]  Clock injection for tests.
+ * @returns {{ spans: Array<{type, start, end, text, value, display, impliedTime?}> }}
+ *   At most one span per type (last match wins), except 'tag' (all tags kept).
+ *   Types: 'tag' | 'recurrence' | 'timerange' | 'time' | 'date' | 'duration'.
+ */
+export const parseQuickAdd = (text, { now = new Date() } = {}) => {
+  if (!text || !text.trim()) return { spans: [] };
+
+  const chars = text.split('');
+  maskSigils(chars, text);
+
+  const all = [];
+  const runStage = (fn, ...extra) => {
+    const masked = chars.join('');
+    const candidates = [];
+    fn(masked, candidates, ...extra);
+    if (!candidates.length) return;
+
+    // 1. Overlap dedupe in push order: matchers within a stage run
+    //    most-specific-first, so the first span claiming a region wins
+    //    ("3:30 pm" beats the bare "3:30" 24h reading).
+    const claimed = [];
+    for (const s of candidates) {
+      if (claimed.some((c) => s.start < c.end && c.start < s.end)) continue;
+      claimed.push(s);
+    }
+
+    // 2. Last match wins (right-most span) — except tags, which all survive.
+    let kept = claimed;
+    if (claimed[0].type !== 'tag') {
+      kept = [claimed.reduce((a, b) => (b.start >= a.start ? b : a))];
+    }
+
+    for (const s of kept) {
+      s.text = text.slice(s.start, s.end);
+      all.push(s);
+      maskRange(chars, s.start, s.end);
+    }
+  };
+
+  runStage(matchTags);
+  runStage(matchRecurrence);
+  runStage(matchTimeRange);
+  runStage(matchTime);
+  runStage(matchDate, now);
+  runStage(matchDuration);
+
+  return { spans: all.sort((a, b) => a.start - b.start) };
+};
+
+/**
+ * Remove accepted NL spans from a title (called at save, before cleanTitle).
+ * Tag spans are kept — tags live inline in the title by app convention.
+ */
+export const stripSpans = (title, spans) => {
+  if (!spans || !spans.length) return title;
+  const remove = spans
+    .filter((s) => s.type !== 'tag')
+    .sort((a, b) => b.start - a.start);
+  let out = title;
+  for (const s of remove) {
+    out = out.slice(0, s.start) + out.slice(s.end);
+  }
+  return out.replace(/\s+/g, ' ').trim();
+};
+
+/** Stable identity for a span so dismissals survive re-parsing while typing. */
+export const spanSignature = (span) => `${span.type}:${span.text.toLowerCase()}`;

--- a/src/utils/quickAddParser.test.js
+++ b/src/utils/quickAddParser.test.js
@@ -1,0 +1,299 @@
+import { describe, it, expect } from 'vitest';
+import { parseQuickAdd, stripSpans, spanSignature } from './quickAddParser.js';
+
+// Pinned clock: Monday, July 27 2026, 10:00 local.
+// Derived anchors used throughout:
+//   today            → 2026-07-27 (Mon)
+//   tomorrow         → 2026-07-28 (Tue)
+//   friday           → 2026-07-31
+//   monday           → 2026-08-03 (today IS Monday → next week, sigil semantics)
+//   next week        → 2026-08-03
+const NOW = new Date(2026, 6, 27, 10, 0, 0);
+
+const P = (text) => parseQuickAdd(text, { now: NOW });
+const span = (result, type) => result.spans.find((s) => s.type === type);
+
+describe('parseQuickAdd — headline', () => {
+  it('parses "dentist tomorrow 3pm every 2 weeks" into date + time + recurrence', () => {
+    const r = P('dentist tomorrow 3pm every 2 weeks');
+    expect(span(r, 'date')).toMatchObject({ value: '2026-07-28', display: 'Tomorrow', text: 'tomorrow' });
+    expect(span(r, 'time')).toMatchObject({ value: '15:00', display: '3:00 PM', text: '3pm' });
+    expect(span(r, 'recurrence')).toMatchObject({
+      value: { type: 'biweekly' },
+      display: 'Every 2 weeks',
+      text: 'every 2 weeks',
+    });
+    expect(stripSpans('dentist tomorrow 3pm every 2 weeks', r.spans)).toBe('dentist');
+  });
+});
+
+describe('dates', () => {
+  it.each([
+    ['pay bills today', '2026-07-27', 'Today'],
+    ['ship tmrw', '2026-07-28', 'Tomorrow'],
+    ['review tom', '2026-07-28', 'Tomorrow'],
+    ['groceries friday', '2026-07-31', 'Friday'],
+    ['groceries fri', '2026-07-31', 'Friday'],
+    ['standup monday', '2026-08-03', 'Monday'], // today is Monday → next one
+    ['call next tuesday', '2026-07-28', 'Next Tuesday'],
+    ['plan next week', '2026-08-03', 'Next week'],
+    ['follow up in 3 days', '2026-07-30', 'In 3 days'],
+    ['renew in 2 weeks', '2026-08-10', 'In 2 weeks'],
+    ['checkup in a month', '2026-08-27', 'In 1 month'],
+    ['party on dec 1', '2026-12-01', 'Dec 1'],
+    ['taxes june 3', '2027-06-03', 'Jun 3, 2027'], // past this year → rolls forward
+    ['review june 3rd 2027', '2027-06-03', 'Jun 3, 2027'],
+    ['dentist 8/15', '2026-08-15', 'Aug 15'],
+    ['renewal 3/4', '2027-03-04', 'Mar 4, 2027'], // past → rolls forward
+  ])('%s → %s (%s)', (text, value, display) => {
+    const r = P(text);
+    expect(span(r, 'date')).toMatchObject({ value, display });
+  });
+
+  it('parses date + day-part with implied time', () => {
+    const r = P('gym tomorrow morning');
+    expect(span(r, 'date')).toMatchObject({ value: '2026-07-28', display: 'Tomorrow morning', impliedTime: '09:00' });
+  });
+
+  it('parses "tonight" as today with implied 9 PM', () => {
+    const r = P('movie tonight');
+    expect(span(r, 'date')).toMatchObject({ value: '2026-07-27', display: 'Tonight', impliedTime: '21:00' });
+  });
+
+  it('parses "this afternoon" as today with implied time', () => {
+    const r = P('errands this afternoon');
+    expect(span(r, 'date')).toMatchObject({ value: '2026-07-27', impliedTime: '14:00' });
+  });
+
+  it('includes the "on" connector in the span so stripping is clean', () => {
+    const r = P('dentist on friday');
+    expect(span(r, 'date').text).toBe('on friday');
+    expect(stripSpans('dentist on friday', r.spans)).toBe('dentist');
+  });
+
+  it('does NOT parse bare month names ("email May about budget")', () => {
+    expect(span(P('email May about budget'), 'date')).toBeUndefined();
+  });
+
+  it('does NOT parse invalid calendar dates (feb 30, 2/30)', () => {
+    expect(span(P('note feb 30'), 'date')).toBeUndefined();
+    expect(span(P('note 2/30'), 'date')).toBeUndefined();
+  });
+
+  it('last date wins when several appear', () => {
+    const r = P('move sat to sun');
+    expect(span(r, 'date').display).toBe('Sunday');
+  });
+});
+
+describe('times', () => {
+  it.each([
+    ['call mom 3pm', '15:00', '3:00 PM'],
+    ['call mom at 3:30 pm', '15:30', '3:30 PM'],
+    ['sync 9am', '09:00', '9:00 AM'],
+    ['ops review 15:00', '15:00', '3:00 PM'],
+    ['brief at 9:30', '09:30', '9:30 AM'],
+    ['lunch at noon', '12:00', '12:00 PM'],
+    ['backup at midnight', '00:00', '12:00 AM'],
+    ['12pm check', '12:00', '12:00 PM'],
+    ['12am check', '00:00', '12:00 AM'],
+  ])('%s → %s', (text, value, display) => {
+    const r = P(text);
+    expect(span(r, 'time')).toMatchObject({ value, display });
+  });
+
+  it.each([
+    ['call at 3', '15:00'], // 1-7 bare → PM (working-hours rule)
+    ['call at 7', '19:00'],
+    ['standup at 8', '08:00'], // 8-11 bare → AM
+    ['standup at 11', '11:00'],
+    ['lunch at 12', '12:00'], // 12 bare → noon
+    ['ops at 14', '14:00'], // ≥13 → 24h literal
+  ])('bare-hour rule: %s → %s', (text, value) => {
+    expect(span(P(text), 'time')).toMatchObject({ value });
+  });
+
+  it('does NOT parse a bare number without the "at" anchor', () => {
+    expect(span(P('review section 3'), 'time')).toBeUndefined();
+  });
+
+  it('includes the "at" connector in the span text', () => {
+    const r = P('dinner at 6pm');
+    expect(span(r, 'time').text).toBe('at 6pm');
+    expect(stripSpans('dinner at 6pm', r.spans)).toBe('dinner');
+  });
+});
+
+describe('time ranges → startTime + duration', () => {
+  it.each([
+    ['meeting 3-4pm', '15:00', 60],
+    ['meeting 3pm-5pm', '15:00', 120],
+    ['flight from 9 to 11', '09:00', 120],
+    ['deep work 9:30-11:00', '09:30', 90],
+    ['brunch 11-1pm', '11:00', 120], // pm back-propagation would overshoot → AM start
+    ['shift 11pm to 1am', '23:00', 120], // overnight wrap
+    ['workshop from 1 to 4:30', '13:00', 210],
+  ])('%s → start %s, %d min', (text, startTime, duration) => {
+    const r = P(text);
+    expect(span(r, 'timerange')).toMatchObject({ value: { startTime, duration } });
+  });
+
+  it('does NOT parse an unanchored "N-N" (section numbers)', () => {
+    const r = P('read sections 3-4');
+    expect(span(r, 'timerange')).toBeUndefined();
+    expect(span(r, 'time')).toBeUndefined();
+  });
+
+  it('range beats single time for the same text', () => {
+    const r = P('sync 3-4pm');
+    expect(span(r, 'timerange')).toBeDefined();
+    expect(span(r, 'time')).toBeUndefined();
+  });
+});
+
+describe('recurrence', () => {
+  it.each([
+    ['water plants every day', { type: 'daily' }, 'Every day'],
+    ['journal daily', { type: 'daily' }, 'Every day'],
+    ['standup every weekday', { type: 'weekly', daysOfWeek: [1, 2, 3, 4, 5] }, 'Every weekday (Mon-Fri)'],
+    ['hike every weekend', { type: 'weekly', daysOfWeek: [0, 6] }, 'Every weekend (Sat-Sun)'],
+    ['review every week', { type: 'weekly' }, 'Every week'],
+    ['sync every monday', { type: 'weekly', daysOfWeek: [1] }, 'Every week on Monday'],
+    ['gym every mon and wed', { type: 'weekly', daysOfWeek: [1, 3] }, 'Every week on Mon/Wed'],
+    ['run every tue/thu/sat', { type: 'weekly', daysOfWeek: [2, 4, 6] }, 'Every week on Tue/Thu/Sat'],
+    ['payday every 2 weeks', { type: 'biweekly' }, 'Every 2 weeks'],
+    ['sprint every other week', { type: 'biweekly' }, 'Every 2 weeks'],
+    ['1:1 every other friday', { type: 'biweekly', daysOfWeek: [5] }, 'Every 2 weeks on Friday'],
+    ['sync every 2 weeks on tue', { type: 'biweekly', daysOfWeek: [2] }, 'Every 2 weeks on Tuesday'],
+    ['rent every month', { type: 'monthly' }, 'Every month'],
+    ['invoice monthly', { type: 'monthly' }, 'Every month'],
+    ['rent every 1st', { type: 'monthly', monthDay: 1, monthWeekday: null }, 'Monthly on the 1st'],
+    ['payroll every 15th of the month', { type: 'monthly', monthDay: 15, monthWeekday: null }, 'Monthly on the 15th'],
+    ['retro every first monday of the month', { type: 'monthly', monthDay: null, monthWeekday: { week: 1, day: 1 } }, 'Monthly on the 1st Monday'],
+    ['insurance every year', { type: 'yearly' }, 'Every year'],
+    ['renewal annually', { type: 'yearly' }, 'Every year'],
+  ])('%s', (text, value, display) => {
+    const r = P(text);
+    expect(span(r, 'recurrence')).toMatchObject({ value, display });
+  });
+
+  it('parses "every morning" as daily with implied time', () => {
+    const r = P('meditate every morning');
+    expect(span(r, 'recurrence')).toMatchObject({ value: { type: 'daily' }, impliedTime: '09:00' });
+  });
+
+  it('recurrence claims its weekday — "every monday" is not also a date', () => {
+    const r = P('sync every monday');
+    expect(span(r, 'date')).toBeUndefined();
+  });
+
+  it('does NOT parse unrepresentable intervals (engine honesty)', () => {
+    expect(span(P('water every 3 days'), 'recurrence')).toBeUndefined();
+    expect(span(P('report every 6 weeks'), 'recurrence')).toBeUndefined();
+    expect(span(P('deep clean every 2 months'), 'recurrence')).toBeUndefined();
+  });
+});
+
+describe('durations', () => {
+  it.each([
+    ['deep work for 90 min', 90],
+    ['deep work for 1.5 hours', 90],
+    ['call for an hour', 60],
+    ['nap for half an hour', 30],
+    ['pairing for 1h 30m', 90],
+    ['workout 45m', 45],
+    ['focus 2h', 120],
+    ['focus 1h30m', 90],
+  ])('%s → %d min', (text, mins) => {
+    expect(span(P(text), 'duration')).toMatchObject({ value: mins });
+  });
+
+  it('does NOT steal spaced units or tiny values', () => {
+    expect(span(P('run 100 m sprint'), 'duration')).toBeUndefined();
+    expect(span(P('grab 3m hex key'), 'duration')).toBeUndefined();
+    expect(span(P('swim for 5 miles'), 'duration')).toBeUndefined();
+  });
+});
+
+describe('tags', () => {
+  it('emits a chip per tag and keeps tag text in the title on strip', () => {
+    const r = P('gym #fitness #health tomorrow');
+    const tags = r.spans.filter((s) => s.type === 'tag');
+    expect(tags.map((t) => t.value)).toEqual(['fitness', 'health']);
+    expect(stripSpans('gym #fitness #health tomorrow', r.spans)).toBe('gym #fitness #health');
+  });
+});
+
+describe('sigil coexistence', () => {
+  it('never double-parses inside a sigil region', () => {
+    // The @sigil region extends greedily (same as cleanTitle) — the whole
+    // trailing region belongs to the sigil system, not the NL layer.
+    const r = P('review @tomorrow 3pm');
+    expect(span(r, 'date')).toBeUndefined();
+    expect(span(r, 'time')).toBeUndefined();
+  });
+
+  it('parses NL text that precedes a sigil', () => {
+    const r = P('review 3pm @tomorrow');
+    expect(span(r, 'time')).toMatchObject({ value: '15:00' });
+    expect(span(r, 'date')).toBeUndefined();
+  });
+
+  it('ignores ~time and %duration sigil regions', () => {
+    const r = P('write up %45 ~3pm');
+    expect(span(r, 'time')).toBeUndefined();
+    expect(span(r, 'duration')).toBeUndefined();
+  });
+});
+
+describe('combinations', () => {
+  it('date + range + tag: "board prep #work friday 2-3:30pm"', () => {
+    const r = P('board prep #work friday 2-3:30pm');
+    expect(span(r, 'tag')).toMatchObject({ value: 'work' });
+    expect(span(r, 'date')).toMatchObject({ value: '2026-07-31' });
+    expect(span(r, 'timerange')).toMatchObject({ value: { startTime: '14:00', duration: 90 } });
+    expect(stripSpans('board prep #work friday 2-3:30pm', r.spans)).toBe('board prep #work');
+  });
+
+  it('recurrence + time: "standup every weekday at 9:15"', () => {
+    const r = P('standup every weekday at 9:15');
+    expect(span(r, 'recurrence')).toMatchObject({ value: { type: 'weekly', daysOfWeek: [1, 2, 3, 4, 5] } });
+    expect(span(r, 'time')).toMatchObject({ value: '09:15' });
+    expect(stripSpans('standup every weekday at 9:15', r.spans)).toBe('standup');
+  });
+
+  it('duration + date: "deep work for 2 hours tomorrow"', () => {
+    const r = P('deep work for 2 hours tomorrow');
+    expect(span(r, 'duration')).toMatchObject({ value: 120 });
+    expect(span(r, 'date')).toMatchObject({ value: '2026-07-28' });
+    expect(stripSpans('deep work for 2 hours tomorrow', r.spans)).toBe('deep work');
+  });
+});
+
+describe('plumbing', () => {
+  it('returns no spans for empty/plain text', () => {
+    expect(P('').spans).toEqual([]);
+    expect(P('buy milk').spans).toEqual([]);
+    expect(P('summarize meeting notes').spans).toEqual([]);
+  });
+
+  it('span.text always mirrors the original slice', () => {
+    const text = 'dentist Tomorrow 3PM every 2 weeks';
+    const r = P(text);
+    for (const s of r.spans) {
+      expect(s.text).toBe(text.slice(s.start, s.end));
+    }
+  });
+
+  it('spanSignature is stable across case', () => {
+    const a = span(P('x Tomorrow'), 'date');
+    const b = span(P('x tomorrow'), 'date');
+    expect(spanSignature(a)).toBe(spanSignature(b));
+  });
+
+  it('is deterministic: same input + now → identical output', () => {
+    const one = P('dentist tomorrow 3pm every 2 weeks');
+    const two = P('dentist tomorrow 3pm every 2 weeks');
+    expect(one).toEqual(two);
+  });
+});


### PR DESCRIPTION
The v4.1.0 headliner: Todoist/Fantastical-style parsing in the quick-add boxes. **Deterministic parser — no AI, instant, offline, predictable.**

## What it does

Type `dentist tomorrow 3pm every 2 weeks` → the date, time, and biweekly recurrence auto-fill, each shown as a **chip** under the input:

> 📅 Tomorrow  🕒 3:00 PM  🔁 Every 2 weeks

- **Tap a chip to undo** that parse: the phrase stays as plain title text and the auto-filled field reverts — unless you changed it manually in the meantime (manual edits always win).
- At save, accepted phrases are **stripped from the title** (`"dentist"`), dismissed ones are kept. Same strip-at-save convention as the existing sigil system.

## Grammar (all deterministic, span-based)

| Kind | Examples |
|---|---|
| Dates | `today` `tomorrow` `tonight` `fri` `next tuesday` `next week` `in 3 days` `june 3` (past → rolls to next year) `8/15` |
| Times | `3pm` `3:30pm` `15:00` `at 3` (working-hours rule: 1–7→PM, 8–12→AM) `noon` `tomorrow morning` (implied 9:00) |
| Ranges | `3-4pm` `from 9 to 11` `11pm to 1am` → startTime + duration |
| Durations | `for 30 min` `for 1.5 hours` `for an hour` `45m` `1h30m` |
| Recurrence | `every day` `every weekday` `every mon and wed` `every other friday` `every 2 weeks on tue` `every 1st` `every first monday of the month` `yearly` |
| Tags | `#tag` chips (text stays in the title, per app convention) |

**Deliberate honesty rules:**
- `every 3 days` / `every 6 weeks` — **not parsed**. `recurrenceEngine.js` can't represent arbitrary intervals, so the text is left alone instead of silently mis-scheduling.
- Bare month names (`email May about budget`) and bare numbers (`section 3`) never parse — chips make false positives cheap, but the grammar avoids the obvious traps up front.
- Bare `N-N` (`sections 3-4`) is not a time range; ranges need an anchor (am/pm, `:MM`, or `from`).

## Architecture

- **`src/utils/quickAddParser.js`** — pure, span-based, injectable clock. Stage order (tags → recurrence → range → time → date → duration) with masking so `every monday` is a recurrence, not a date, and `3-4pm` is a range, not the time `4pm`. One entity per type, **last match wins** (qualifiers come after the title).
- **Sigil coexistence** — `@ ~ $ % !` regions are masked before NL parsing (never double-parsed); sigil auto-apply runs after NL, so explicit syntax wins.
- **`useNewTaskInput`** — chip state, dismissal signatures, and per-field baseline/revert bookkeeping (dismissing a chip restores what the field held before the NL layer claimed it).
- **`QuickAddChips.jsx`** — chip row wired into both Desktop and Mobile new-task modals (the two surfaces feeding `addTask`; Spotlight is search-only).
- **Modes:** inbox quick-add maps a date to the **deadline** and skips time/recurrence. The NL layer is **disabled when editing** an existing task or native event — typing "tomorrow" into an old title must never silently reschedule it.
- Recurrence values only use shapes the engine supports; `startDate` is stamped by `addTask` exactly as the recurrence picker does.

## Tests

**92 new parser tests** with a pinned clock (headline phrase, every grammar row, bare-hour rule, range inference incl. `11-1pm` and overnight, engine-honesty negatives, sigil coexistence, strip round-trips, determinism). Full suite: **953 passing**; lint + build clean.

## Known limits (v1)

- English vocabulary only (matches the existing sigil parser).
- Chip labels aren't i18n'd yet (parser output is inherently English).
- Voice input pipeline untouched — its transcript could be routed through this parser later as a follow-up.

Not merging — parked for the v4.1.0 train.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_