### PR TITLE
feat: voice quick-add without AI (deterministic parse + platform speech)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6472,6 +6472,7 @@ const DayPlanner = () => {
     aiConfig, allTags, colors,
     tasks, setTasks,
     unscheduledTasks, setUnscheduledTasks,
+    setRecurringTasks,
     isVisibleForUser,
     pushUndo, moveToRecycleBin,
     showVoiceInput, setShowVoiceInput,

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -247,7 +247,10 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
         })()}
       </div>
     )}
-    {aiConfig.enabled && aiConfig.features.voiceTaskInput && (
+    {/* Voice quick-add works without AI (deterministic parsing + platform
+        speech recognition), so the button is no longer gated on AI being
+        enabled — only on the feature toggle (default on). */}
+    {aiConfig.features?.voiceTaskInput !== false && (
       <button
         onClick={() => setShowVoiceInput(true)}
         className={`flex-shrink-0 self-stretch flex items-center px-2.5 rounded-lg transition-colors ${darkMode ? 'bg-white/10 text-purple-400' : 'bg-black/5 text-purple-600'} hover:opacity-80`}

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -156,7 +156,8 @@ const MobileGlanceSection = () => {
         <Filter size={16} />
       </button>
     )}
-    {aiConfig.enabled && aiConfig.features.voiceTaskInput && (
+    {/* Voice quick-add works without AI — gated only on the feature toggle. */}
+    {aiConfig.features?.voiceTaskInput !== false && (
       <button
         onClick={() => setShowVoiceInput(true)}
         className={`flex-shrink-0 px-2.5 self-stretch flex items-center rounded-lg transition-colors ${darkMode ? 'bg-white/10 text-purple-400' : 'bg-black/5 text-purple-600'}`}

--- a/src/components/VoiceInputModal.jsx
+++ b/src/components/VoiceInputModal.jsx
@@ -49,8 +49,8 @@ const VoiceInputModal = () => {
 
               {!voiceParsedTasks && !voiceParsedEdits ? (
                 <>
-                  {/* Recording UI — uses MediaRecorder + AI transcription (works in all browsers) */}
-                  {!voiceManualMode && voiceCanRecord && voiceHasTranscription ? (
+                  {/* Recording UI — AI transcription, native on-device STT, or Web Speech */}
+                  {!voiceManualMode && voiceHasTranscription ? (
                     <div className="text-center space-y-4">
                       {/* Processing spinner (transcribe + parse) */}
                       {voiceIsTranscribing ? (
@@ -96,13 +96,11 @@ const VoiceInputModal = () => {
                   ) : (
                     <div className="space-y-3">
                       {/* Text input — shown when voice not available or user chose to type */}
-                      {!voiceCanRecord || !voiceHasTranscription ? (
+                      {!voiceHasTranscription ? (
                         <p className={`text-xs ${textSecondary}`}>
-                          {!aiConfig.enabled
-                            ? 'Configure an AI provider in settings to enable voice recording. Type your tasks below.'
-                            : !supportsTranscription(aiConfig)
-                            ? `${PROVIDER_LABELS[aiConfig.provider] || aiConfig.provider} doesn't support voice transcription. Use OpenAI or Gemini for voice, or type below.`
-                            : 'Voice recording is not available. Type your tasks below.'}
+                          {aiConfig.enabled && !supportsTranscription(aiConfig)
+                            ? `Voice recording isn't available here, and ${PROVIDER_LABELS[aiConfig.provider] || aiConfig.provider} doesn't support transcription. Type your tasks below — dates, times, and repeats are still understood.`
+                            : 'Voice recording is not available on this device. Type your tasks below — dates, times, and repeats are still understood.'}
                         </p>
                       ) : null}
                       <textarea
@@ -114,7 +112,7 @@ const VoiceInputModal = () => {
                         rows={3}
                         autoFocus
                       />
-                      {voiceCanRecord && voiceHasTranscription && (
+                      {voiceHasTranscription && (
                         <button
                           onClick={() => { setVoiceManualMode(false); setVoiceTranscript(''); }}
                           className={`text-xs ${textSecondary} hover:underline`}
@@ -140,7 +138,7 @@ const VoiceInputModal = () => {
                         ) : (
                           <Plus size={14} />
                         )}
-                        {voiceIsParsing ? 'Parsing...' : aiConfig.enabled ? 'Parse with AI' : 'Add as Task'}
+                        {voiceIsParsing ? 'Parsing...' : aiConfig.enabled ? 'Parse with AI' : 'Parse'}
                         {!voiceIsParsing && <kbd className="ml-1 px-1 py-0.5 rounded bg-white/20 text-[10px] font-mono">↵</kbd>}
                       </button>
                     </div>
@@ -150,7 +148,7 @@ const VoiceInputModal = () => {
                     <p className="text-xs text-amber-500 mt-2">
                       {voiceManualMode
                         ? voiceParseError
-                        : `AI parsing error: ${voiceParseError}. Added as plain task.`}
+                        : `AI parsing error: ${voiceParseError}. Parsed without AI instead.`}
                     </p>
                   )}
                 </>
@@ -228,6 +226,9 @@ const VoiceInputModal = () => {
                                   {task.date && <span>{task.date}</span>}
                                   {task.time && <span>{task.time}</span>}
                                   <span>{task.duration}min</span>
+                                  {task.recurrenceDisplay && (
+                                    <span className="px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-300">{task.recurrenceDisplay}</span>
+                                  )}
                                   {task.priority > 0 && (
                                     <span className={priorityColors[task.priority]}>
                                       {'!'.repeat(task.priority)} {priorityLabels[task.priority]}

--- a/src/hooks/useVoiceInput.js
+++ b/src/hooks/useVoiceInput.js
@@ -187,6 +187,12 @@ export default function useVoiceInput({
           if (e.error === 'not-allowed' || e.error === 'service-not-allowed') {
             setVoiceParseError('Microphone access denied. Please allow microphone permissions in your browser settings.');
             setVoiceMicError('error');
+          } else if (e.error === 'network') {
+            // The browser streams speech to its vendor's recognition service;
+            // 'network' means that service is unreachable. Some browsers fail
+            // instantly on certain platforms (e.g. Edge outside Windows).
+            setVoiceParseError("This browser couldn't reach its speech recognition service, so voice input isn't available here. You can type instead, or try a different browser.");
+            setVoiceMicError('error');
           } else if (e.error !== 'aborted' && e.error !== 'no-speech') {
             setVoiceParseError(`Speech recognition error: ${e.error}`);
             setVoiceMicError('error');

--- a/src/hooks/useVoiceInput.js
+++ b/src/hooks/useVoiceInput.js
@@ -1,8 +1,12 @@
 import { useEffect, useCallback } from 'react';
 import { aiTranscribe, aiJSON, supportsTranscription } from '../ai.js';
 import { voiceParseSystemPrompt, voiceParseUserPrompt } from '../ai-prompts.js';
-import { nativeStartRecording, nativeStopRecording, triggerHaptic } from '../native.js';
+import {
+  nativeStartRecording, nativeStopRecording, triggerHaptic,
+  nativeSupportsSpeech, nativeStartSpeech, nativeStopSpeech, nativeCancelSpeech,
+} from '../native.js';
 import { dateToString } from '../utils/taskUtils.js';
+import { parseTranscriptTasks } from '../utils/voiceQuickAdd.js';
 
 /**
  * Voice input pipeline — extracted from App.jsx (see "App.jsx — Ongoing
@@ -23,6 +27,7 @@ export default function useVoiceInput({
   aiConfig, allTags, colors,
   tasks, setTasks,
   unscheduledTasks, setUnscheduledTasks,
+  setRecurringTasks,
   isVisibleForUser,
   pushUndo, moveToRecycleBin,
   showVoiceInput, setShowVoiceInput,
@@ -42,6 +47,66 @@ export default function useVoiceInput({
   // Always-fresh tag list for the inline parse in voiceStopRecording.
   voiceAllTagsRef.current = allTags;
 
+  // ── Capability matrix ──────────────────────────────────────────────────────
+  // Transcription (speech → text), in priority order:
+  //   1. AI transcription (Whisper/Gemini)     — needs a configured provider
+  //   2. Native on-device STT (Android/iOS)    — free, no AI required
+  //   3. Web Speech API (browser/PWA)          — free, no AI required
+  //   4. Typing fallback                        — always available
+  // Parsing (text → tasks): AI when configured, else the deterministic
+  // quickAddParser (parseTranscriptTasks) — voice no longer requires AI.
+  const aiKeyed = !!(aiConfig.apiKey || aiConfig.provider === 'ollama');
+  const canWhisper = aiConfig.enabled && supportsTranscription(aiConfig) && aiKeyed;
+  const canAIParse = aiConfig.enabled && aiKeyed;
+  const webSpeechAvailable = typeof window !== 'undefined' &&
+    !!(window.SpeechRecognition || window.webkitSpeechRecognition);
+
+  // ── Shared parse: transcript → parsed tasks/edits ──────────────────────────
+  // AI parse when available (multi-task + edit commands), deterministic
+  // quickAddParser otherwise — and as the fallback when the AI call fails.
+  const parseTranscriptNow = useCallback(async (text) => {
+    const trimmed = (text || '').trim();
+    if (!trimmed) return;
+    if (!canAIParse) {
+      setVoiceParsedTasks(parseTranscriptTasks(trimmed));
+      setVoiceParsedEdits([]);
+      return;
+    }
+    setVoiceIsParsing(true);
+    try {
+      const context = {
+        todayDate: dateToString(new Date()),
+        existingTags: voiceAllTagsRef.current,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        existingTasks: voiceBuildTaskContextRef.current(),
+      };
+      const result = await aiJSON(voiceParseSystemPrompt(context), voiceParseUserPrompt(trimmed), aiConfig);
+      const cap = s => s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+      let newTasks = [];
+      let edits = [];
+      if (Array.isArray(result)) {
+        newTasks = result;
+      } else if (result && typeof result === 'object') {
+        newTasks = Array.isArray(result.newTasks) ? result.newTasks : [];
+        edits = Array.isArray(result.edits) ? result.edits : [];
+      }
+      setVoiceParsedTasks(newTasks.map(t => ({ ...t, title: cap(t.title) })));
+      setVoiceParsedEdits(edits.map(edit => {
+        const match = voiceResolveTaskMatchRef.current(edit.taskMatch);
+        return { ...edit, resolvedTask: match?.task || null, source: match?.source || null };
+      }));
+    } catch (parseErr) {
+      // AI parse failed — fall back to the deterministic parser instead of a
+      // bare title-only task.
+      setVoiceParseError(parseErr.message);
+      setVoiceParsedTasks(parseTranscriptTasks(trimmed));
+      setVoiceParsedEdits([]);
+    }
+    setVoiceIsParsing(false);
+    // Omitted names are stable setters and *Ref values; keyed on the AI config.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [aiConfig, canAIParse]);
+
   // Voice input — reset state when modal opens, cleanup on close
   useEffect(() => {
     if (showVoiceInput) {
@@ -56,11 +121,17 @@ export default function useVoiceInput({
       setVoiceManualMode(false);
       setVoiceMicError(null);
     } else {
-      // Cleanup MediaRecorder on modal close
+      // Cleanup recording/recognition on modal close
       const ref = voiceRecorderRef.current;
       if (ref) {
-        if (ref.recorder.state !== 'inactive') ref.recorder.stop();
-        ref.stream.getTracks().forEach(t => t.stop());
+        if (ref.speech) {
+          try { ref.speech.abort(); } catch { /* already stopped */ }
+        } else if (ref.nativeSpeech) {
+          nativeCancelSpeech();
+        } else if (ref.recorder) {
+          if (ref.recorder.state !== 'inactive') ref.recorder.stop();
+          ref.stream.getTracks().forEach(t => t.stop());
+        }
         voiceRecorderRef.current = null;
       }
       voiceAudioChunksRef.current = [];
@@ -71,12 +142,80 @@ export default function useVoiceInput({
   }, [showVoiceInput]);
 
   const voiceStartRecording = useCallback(async () => {
-    if (!voiceCanRecord) return;
     setVoiceMicError(null);
     setVoiceParseError('');
     setVoiceTranscript('');
     setVoiceParsedTasks(null);
     setVoiceParsedEdits(null);
+
+    // No AI transcription configured → platform speech recognition. The final
+    // transcript is parsed by parseTranscriptNow (AI if a non-transcribing
+    // provider is configured, deterministic otherwise).
+    if (!canWhisper) {
+      // Native on-device STT (Android SpeechRecognizer / iOS SFSpeechRecognizer)
+      if (nativeSupportsSpeech()) {
+        const result = nativeStartSpeech();
+        if (result === 'ok') {
+          voiceRecorderRef.current = { nativeSpeech: true };
+          setVoiceIsRecording(true);
+        } else {
+          setVoiceParseError(`Speech recognition error: ${result?.error ?? 'unknown'}`);
+          setVoiceMicError('error');
+        }
+        return;
+      }
+      // Web Speech API (browser / PWA)
+      const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (SR) {
+        const recognition = new SR();
+        recognition.lang = navigator.language || 'en-US';
+        recognition.continuous = true;
+        recognition.interimResults = true;
+        let finalText = '';
+        recognition.onresult = (e) => {
+          let interim = '';
+          finalText = '';
+          for (const res of e.results) {
+            if (res.isFinal) finalText += res[0].transcript;
+            else interim += res[0].transcript;
+          }
+          setVoiceTranscript((finalText + interim).trim());
+        };
+        recognition.onerror = (e) => {
+          voiceRecorderRef.current = null;
+          setVoiceIsRecording(false);
+          if (e.error === 'not-allowed' || e.error === 'service-not-allowed') {
+            setVoiceParseError('Microphone access denied. Please allow microphone permissions in your browser settings.');
+            setVoiceMicError('error');
+          } else if (e.error !== 'aborted' && e.error !== 'no-speech') {
+            setVoiceParseError(`Speech recognition error: ${e.error}`);
+            setVoiceMicError('error');
+          }
+        };
+        recognition.onend = () => {
+          // Fires after stop() or when the engine decides speech ended.
+          if (voiceRecorderRef.current?.speech === recognition) {
+            voiceRecorderRef.current = null;
+            setVoiceIsRecording(false);
+            const text = finalText.trim();
+            setVoiceTranscript(text);
+            if (text) parseTranscriptNow(text);
+          }
+        };
+        try {
+          recognition.start();
+          voiceRecorderRef.current = { speech: recognition };
+          setVoiceIsRecording(true);
+        } catch (err) {
+          setVoiceParseError(`Speech recognition error: ${err.message}`);
+          setVoiceMicError('error');
+        }
+        return;
+      }
+      return; // no speech path available — the modal shows typing mode instead
+    }
+
+    if (!voiceCanRecord) return;
 
     // On Android, use the native MediaRecorder bridge instead of WebView getUserMedia,
     // which is unreliable and produces NotReadableError on many devices/WebView versions.
@@ -124,6 +263,34 @@ export default function useVoiceInput({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [voiceCanRecord]);
 
+  // Native STT event channel: partial transcripts stream in live, the final
+  // transcript triggers the parse, and errors fall back to typing mode.
+  useEffect(() => {
+    if (!showVoiceInput) return;
+    window.__speechEvent = (ev) => {
+      const e = typeof ev === 'string' ? JSON.parse(ev) : ev;
+      if (e.status === 'partial') {
+        setVoiceTranscript(e.text || '');
+      } else if (e.status === 'final') {
+        voiceRecorderRef.current = null;
+        setVoiceIsRecording(false);
+        setVoiceIsTranscribing(false);
+        const text = (e.text || '').trim();
+        setVoiceTranscript(text);
+        if (text) parseTranscriptNow(text);
+      } else if (e.status === 'error') {
+        voiceRecorderRef.current = null;
+        setVoiceIsRecording(false);
+        setVoiceIsTranscribing(false);
+        setVoiceParseError(`Speech recognition error: ${e.message || 'unknown'}`);
+        setVoiceMicError('error');
+      }
+    };
+    return () => { delete window.__speechEvent; };
+    // Omitted names are stable state setters / refs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showVoiceInput, parseTranscriptNow]);
+
   // When the voice modal is opened via the Android launcher shortcut, auto-start recording.
   useEffect(() => {
     if (showVoiceInput && voiceAutoStartRef.current) {
@@ -135,6 +302,21 @@ export default function useVoiceInput({
   const voiceStopRecording = useCallback(async () => {
     const ref = voiceRecorderRef.current;
     if (!ref) return;
+
+    // Platform speech-recognition paths — no audio blob involved.
+    if (ref.speech) {
+      // Web Speech: onend clears state, sets the final transcript, and parses.
+      try { ref.speech.stop(); } catch { /* already stopped */ }
+      return;
+    }
+    if (ref.nativeSpeech) {
+      // Native STT: the final transcript arrives via window.__speechEvent.
+      voiceRecorderRef.current = null;
+      setVoiceIsRecording(false);
+      setVoiceIsTranscribing(true);
+      nativeStopSpeech();
+      return;
+    }
 
     let blob;
 
@@ -174,36 +356,8 @@ export default function useVoiceInput({
       try {
         const text = (await aiTranscribe(blob, aiConfig)).trim();
         setVoiceTranscript(text);
-        // Immediately parse into tasks
-        if (text && aiConfig.enabled && (aiConfig.apiKey || aiConfig.provider === 'ollama')) {
-          setVoiceIsParsing(true);
-          try {
-            const context = { todayDate: dateToString(new Date()), existingTags: voiceAllTagsRef.current, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone, existingTasks: voiceBuildTaskContextRef.current() };
-            const result = await aiJSON(voiceParseSystemPrompt(context), voiceParseUserPrompt(text), aiConfig);
-            const cap = s => s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
-            let newTasks = [];
-            let edits = [];
-            if (Array.isArray(result)) {
-              newTasks = result;
-            } else if (result && typeof result === 'object') {
-              newTasks = Array.isArray(result.newTasks) ? result.newTasks : [];
-              edits = Array.isArray(result.edits) ? result.edits : [];
-            }
-            setVoiceParsedTasks(newTasks.map(t => ({ ...t, title: cap(t.title) })));
-            const resolved = edits.map(edit => {
-              const match = voiceResolveTaskMatchRef.current(edit.taskMatch);
-              return { ...edit, resolvedTask: match?.task || null, source: match?.source || null };
-            });
-            setVoiceParsedEdits(resolved);
-          } catch (parseErr) {
-            setVoiceParseError(parseErr.message);
-            setVoiceParsedTasks([{ title: text.charAt(0).toUpperCase() + text.slice(1), tags: [], date: null, time: null, duration: 30, priority: 0, deadline: null, notes: '' }]);
-            setVoiceParsedEdits([]);
-          }
-          setVoiceIsParsing(false);
-        } else {
-          setVoiceParsedTasks([{ title: text.charAt(0).toUpperCase() + text.slice(1), tags: [], date: null, time: null, duration: 30, priority: 0, deadline: null, notes: '' }]);
-        }
+        // Immediately parse into tasks — AI when available, deterministic otherwise.
+        if (text) await parseTranscriptNow(text);
       } catch (err) {
         console.error('Transcription error:', err);
         setVoiceParseError(`Transcription failed: ${err.message}`);
@@ -213,7 +367,7 @@ export default function useVoiceInput({
     }
     // Omitted names are all stable state setters and *Ref values; keyed on aiConfig.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [aiConfig]);
+  }, [aiConfig, parseTranscriptNow]);
 
   // Voice input — parse and add callbacks (must be after allTags is defined)
   // Build a text summary of existing tasks for AI context
@@ -264,51 +418,15 @@ export default function useVoiceInput({
   }, [tasks, unscheduledTasks, isVisibleForUser]);
   voiceResolveTaskMatchRef.current = resolveTaskMatch;
 
+  // Parse the current transcript (typed or transcribed). Despite the legacy
+  // name, this uses AI only when a provider is configured — otherwise the
+  // deterministic quickAddParser handles it (see parseTranscriptNow).
   const voiceParseWithAI = useCallback(async () => {
     const text = voiceTranscript.trim();
     if (!text) return;
-    const cap = s => s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
-    if (!aiConfig.enabled || (!aiConfig.apiKey && aiConfig.provider !== 'ollama')) {
-      setVoiceParsedTasks([{ title: cap(text), tags: [], date: null, time: null, duration: 30, priority: 0, deadline: null, notes: '' }]);
-      setVoiceParsedEdits([]);
-      return;
-    }
-    setVoiceIsParsing(true);
     setVoiceParseError('');
-    try {
-      const context = {
-        todayDate: dateToString(new Date()),
-        existingTags: allTags,
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        existingTasks: buildTaskContextForAI(),
-      };
-      const result = await aiJSON(voiceParseSystemPrompt(context), voiceParseUserPrompt(text), aiConfig);
-
-      // Handle both old format (array) and new format ({ newTasks, edits })
-      let newTasks = [];
-      let edits = [];
-      if (Array.isArray(result)) {
-        newTasks = result;
-      } else if (result && typeof result === 'object') {
-        newTasks = Array.isArray(result.newTasks) ? result.newTasks : [];
-        edits = Array.isArray(result.edits) ? result.edits : [];
-      }
-
-      setVoiceParsedTasks(newTasks.map(t => ({ ...t, title: cap(t.title) })));
-
-      // Resolve each edit command to an actual task
-      const resolved = edits.map(edit => {
-        const match = resolveTaskMatch(edit.taskMatch);
-        return { ...edit, resolvedTask: match?.task || null, source: match?.source || null };
-      });
-      setVoiceParsedEdits(resolved);
-    } catch (err) {
-      setVoiceParseError(err.message);
-      setVoiceParsedTasks([{ title: cap(text), tags: [], date: null, time: null, duration: 30, priority: 0, deadline: null, notes: '' }]);
-      setVoiceParsedEdits([]);
-    }
-    setVoiceIsParsing(false);
-  }, [voiceTranscript, aiConfig, allTags, buildTaskContextForAI, resolveTaskMatch, setVoiceIsParsing, setVoiceParseError, setVoiceParsedEdits, setVoiceParsedTasks]);
+    await parseTranscriptNow(text);
+  }, [voiceTranscript, parseTranscriptNow, setVoiceParseError]);
 
   // Apply all parsed changes (new tasks + edit commands)
   const voiceApplyAllChanges = useCallback(() => {
@@ -324,7 +442,24 @@ export default function useVoiceInput({
         const tagStr = (parsed.tags || []).map(t => ` #${t}`).join('');
         const rawTitle = parsed.title + tagStr;
         const title = rawTitle.charAt(0).toUpperCase() + rawTitle.slice(1);
-        if (parsed.date && parsed.time) {
+        if (parsed.recurrence && parsed.date && setRecurringTasks) {
+          // Deterministic parse can carry a recurrence ("every 2 weeks") —
+          // create a recurring template, mirroring addTask's template shape.
+          setRecurringTasks(prev => [...prev, {
+            id: taskId,
+            title,
+            startTime: parsed.time || '00:00',
+            duration: parsed.duration || 30,
+            color: colors[0].class,
+            isAllDay: !parsed.time,
+            notes: parsed.notes || '',
+            subtasks: [],
+            recurrence: { ...parsed.recurrence, startDate: parsed.date },
+            completedDates: [],
+            exceptions: {},
+            lastModified: new Date().toISOString(),
+          }]);
+        } else if (parsed.date && parsed.time) {
           setTasks(prev => [...prev, { id: taskId, title, startTime: parsed.time, duration: parsed.duration || 30, date: parsed.date, color: colors[0].class, completed: false, isAllDay: false, notes: parsed.notes || '', subtasks: [] }]);
         } else {
           const inboxTask = { id: taskId, title, duration: parsed.duration || 30, color: colors[0].class, completed: false, isAllDay: false, notes: parsed.notes || '', subtasks: [], priority: parsed.priority || 0 };
@@ -422,7 +557,9 @@ export default function useVoiceInput({
   }, [voiceParsedTasks, voiceParsedEdits]);
 
   // Voice input keyboard shortcuts (SPACE to hold-record, T for typing, ENTER to parse/accept)
-  const voiceHasTranscription = aiConfig.enabled && supportsTranscription(aiConfig);
+  // "Can we turn speech into text at all?" — any of: AI transcription (needs
+  // the MediaRecorder pipeline), native on-device STT, or the Web Speech API.
+  const voiceHasTranscription = (canWhisper && voiceCanRecord) || nativeSupportsSpeech() || webSpeechAvailable;
   useEffect(() => {
     if (!showVoiceInput) return;
 
@@ -442,7 +579,7 @@ export default function useVoiceInput({
       if (isTextInput) return;
 
       // SPACE hold-to-record (desktop only, not on parsed/transcribing screen)
-      if (e.key === ' ' && !isTouchDevice && !voiceParsedTasks && !voiceManualMode && !voiceIsTranscribing && voiceCanRecord && voiceHasTranscription) {
+      if (e.key === ' ' && !isTouchDevice && !voiceParsedTasks && !voiceManualMode && !voiceIsTranscribing && voiceHasTranscription) {
         e.preventDefault();
         if (!voiceIsRecording && !e.repeat) {
           voiceStartRecording();

--- a/src/native.js
+++ b/src/native.js
@@ -520,6 +520,45 @@ export const nativeStopRecording = () => {
   return new Blob([arr], { type: 'audio/m4a' });
 };
 
+// ── Speech recognition (on-device STT — no AI provider required) ─────────────
+//
+// Contract implemented by the native apps (Android SpeechRecognizer, iOS
+// SFSpeechRecognizer):
+//   bridge.supportsSpeechRecognition() → 'true' | 'false'
+//   bridge.startSpeechRecognition()    → 'ok' | '{"error": "..."}'
+//   bridge.stopSpeechRecognition()     → 'ok'   (final text arrives via event)
+//   bridge.cancelSpeechRecognition()   → 'ok'   (no final event)
+// Results are delivered to the WebView via the global callback:
+//   window.__speechEvent({ status: 'partial'|'final'|'error', text?, message? })
+
+/** True when the native layer offers on-device speech recognition. */
+export const nativeSupportsSpeech = () => {
+  const bridge = nativeBridge();
+  if (!bridge?.supportsSpeechRecognition) return false;
+  try { return bridge.supportsSpeechRecognition() === 'true'; } catch { return false; }
+};
+
+/** Starts native speech recognition. Returns 'ok', { error }, or null (no bridge). */
+export const nativeStartSpeech = () => {
+  const bridge = nativeBridge();
+  if (!bridge?.startSpeechRecognition) return null;
+  const result = bridge.startSpeechRecognition();
+  if (result === 'ok') return 'ok';
+  try { return JSON.parse(result); } catch { return { error: result }; }
+};
+
+/** Stops recognition; the final transcript arrives via window.__speechEvent. */
+export const nativeStopSpeech = () => {
+  const bridge = nativeBridge();
+  bridge?.stopSpeechRecognition?.();
+};
+
+/** Cancels recognition without a final result event. */
+export const nativeCancelSpeech = () => {
+  const bridge = nativeBridge();
+  bridge?.cancelSpeechRecognition?.();
+};
+
 // ── Focus mode ────────────────────────────────────────────────────────────────
 
 /**

--- a/src/utils/quickAddParser.js
+++ b/src/utils/quickAddParser.js
@@ -598,12 +598,14 @@ export const parseQuickAdd = (text, { now = new Date() } = {}) => {
 
 /**
  * Remove accepted NL spans from a title (called at save, before cleanTitle).
- * Tag spans are kept — tags live inline in the title by app convention.
+ * Tag spans are kept by default — tags live inline in the title by app
+ * convention. The voice pipeline passes includeTags: true because it carries
+ * tags as a separate array and re-appends them on apply.
  */
-export const stripSpans = (title, spans) => {
+export const stripSpans = (title, spans, { includeTags = false } = {}) => {
   if (!spans || !spans.length) return title;
   const remove = spans
-    .filter((s) => s.type !== 'tag')
+    .filter((s) => includeTags || s.type !== 'tag')
     .sort((a, b) => b.start - a.start);
   let out = title;
   for (const s of remove) {

--- a/src/utils/voiceQuickAdd.js
+++ b/src/utils/voiceQuickAdd.js
@@ -1,0 +1,107 @@
+// Deterministic voice-transcript → task parsing. No AI required.
+//
+// Turns a spoken/typed utterance ("remind me to call mom tomorrow at 3 p.m.")
+// into the same parsed-task shape the AI voice parser produces, using the
+// deterministic quickAddParser. Used whenever no AI provider is configured for
+// parsing, and as the fallback when the AI parse call fails.
+//
+// v1 scope (documented, deliberate):
+// - ONE task per utterance. No multi-task splitting ("...and..." is ambiguous
+//   without a language model) and no edit commands ("mark X done") — those
+//   remain AI-only features.
+// - English vocabulary, matching quickAddParser.
+
+import { parseQuickAdd, stripSpans } from './quickAddParser.js';
+
+const pad2 = (n) => String(n).padStart(2, '0');
+const toDateStr = (d) => `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+
+// Spoken lead-ins to discard: "add a task to", "remind me to", "new task",
+// "create a task called" … Only stripped at the very start of the utterance.
+const LEAD_IN_RE = /^\s*(?:please\s+)?(?:(?:add|create|make)\s+(?:a\s+)?(?:new\s+)?task(?:\s+(?:to|called|named|for))?|remind\s+me\s+to|remember\s+to|new\s+task|task)\b[:,]?\s+/i;
+
+/**
+ * Normalize common speech-to-text artifacts so the deterministic parser sees
+ * the vocabulary it expects:
+ * - "3 p.m." / "3 P.M." → "3 pm"    (dotted meridiems break \b matching)
+ * - "hashtag work" / "hash tag work" → "#work"
+ * - trailing sentence punctuation from STT engines
+ */
+export const normalizeTranscript = (text) => {
+  return text
+    .replace(/\b([ap])\.m\.?/gi, (_, letter) => `${letter.toLowerCase()}m`)
+    .replace(/\bhash\s?tag\s+([a-zA-Z]\w*)/gi, '#$1')
+    .replace(/[.!?]+\s*$/, '')
+    .trim();
+};
+
+/**
+ * Parse a transcript into an array of parsed-task objects matching the AI
+ * voice parser's shape: { title, tags, date, time, duration, priority,
+ * deadline, notes, recurrence? }. Always returns exactly one task (v1).
+ *
+ * Voice-specific defaults on top of quickAddParser:
+ * - a time with no date anchors to today ("call mom at 3pm" = today)
+ * - a recurrence with no date anchors its start to today
+ *
+ * @param {string} text  Raw transcript.
+ * @param {object} [opts]
+ * @param {Date}   [opts.now]  Clock injection for tests.
+ */
+export const parseTranscriptTasks = (text, { now = new Date() } = {}) => {
+  const normalized = normalizeTranscript(text || '');
+  if (!normalized) return [];
+
+  const stripped = normalized.replace(LEAD_IN_RE, '');
+  const body = stripped.trim() ? stripped : normalized;
+
+  const { spans } = parseQuickAdd(body, { now });
+  const bySpanType = (t) => spans.find((s) => s.type === t);
+  const dateSpan = bySpanType('date');
+  const timeSpan = bySpanType('time');
+  const rangeSpan = bySpanType('timerange');
+  const durSpan = bySpanType('duration');
+  const recSpan = bySpanType('recurrence');
+  const tags = spans.filter((s) => s.type === 'tag').map((s) => s.value);
+
+  const todayStr = toDateStr(new Date(now));
+
+  let date = dateSpan ? dateSpan.value : null;
+  let time = null;
+  let duration = 30;
+  if (rangeSpan) {
+    time = rangeSpan.value.startTime;
+    duration = rangeSpan.value.duration;
+  }
+  if (timeSpan) time = timeSpan.value;
+  if (!time) {
+    const implied = dateSpan?.impliedTime || recSpan?.impliedTime;
+    if (implied) time = implied;
+  }
+  if (durSpan) duration = durSpan.value;
+
+  // A concrete time with no date means today; a recurrence needs a start date.
+  if (!date && (time || recSpan)) date = todayStr;
+
+  // Title: strip every parsed phrase, tags included (they're re-applied from
+  // the tags array). Fall back to the whole utterance if stripping ate it all.
+  let title = stripSpans(body, spans, { includeTags: true });
+  if (!title) title = body;
+  title = title.charAt(0).toUpperCase() + title.slice(1);
+
+  const task = {
+    title,
+    tags,
+    date,
+    time,
+    duration,
+    priority: 0,
+    deadline: null,
+    notes: '',
+  };
+  if (recSpan) {
+    task.recurrence = recSpan.value;
+    task.recurrenceDisplay = recSpan.display;
+  }
+  return [task];
+};

--- a/src/utils/voiceQuickAdd.test.js
+++ b/src/utils/voiceQuickAdd.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeTranscript, parseTranscriptTasks } from './voiceQuickAdd.js';
+
+// Same pinned clock as quickAddParser.test.js: Monday, July 27 2026.
+const NOW = new Date(2026, 6, 27, 10, 0, 0);
+const P = (text) => parseTranscriptTasks(text, { now: NOW });
+
+describe('normalizeTranscript', () => {
+  it.each([
+    ['call mom at 3 p.m.', 'call mom at 3 pm'],
+    ['standup at 9 A.M.', 'standup at 9 am'],
+    ['gym hashtag fitness tomorrow', 'gym #fitness tomorrow'],
+    ['gym hash tag fitness', 'gym #fitness'],
+    ['Buy milk.', 'Buy milk'],
+    ['Really?!', 'Really'],
+  ])('%s → %s', (input, expected) => {
+    expect(normalizeTranscript(input)).toBe(expected);
+  });
+});
+
+describe('parseTranscriptTasks', () => {
+  it('parses the spoken headline phrase end to end', () => {
+    const [task] = P('remind me to see the dentist tomorrow at 3 p.m. every 2 weeks');
+    expect(task).toMatchObject({
+      title: 'See the dentist',
+      date: '2026-07-28',
+      time: '15:00',
+      recurrence: { type: 'biweekly' },
+      recurrenceDisplay: 'Every 2 weeks',
+    });
+  });
+
+  it.each([
+    ['add a task to buy milk', 'Buy milk'],
+    ['add task call the bank', 'Call the bank'],
+    ['create a new task to water plants', 'Water plants'],
+    ['new task: email Sam', 'Email Sam'],
+    ['remember to stretch', 'Stretch'],
+    ['please remind me to breathe', 'Breathe'],
+  ])('strips lead-in: %s → %s', (text, title) => {
+    expect(P(text)[0].title).toBe(title);
+  });
+
+  it('keeps an utterance that is ONLY a lead-in-looking phrase', () => {
+    // "task" alone would strip to nothing → falls back to the utterance
+    const [task] = P('task');
+    expect(task.title).toBe('Task');
+  });
+
+  it('anchors a bare time to today', () => {
+    const [task] = P('call mom at 3pm');
+    expect(task).toMatchObject({ title: 'Call mom', date: '2026-07-27', time: '15:00' });
+  });
+
+  it('anchors a bare recurrence to today', () => {
+    const [task] = P('water the plants every morning');
+    expect(task).toMatchObject({
+      date: '2026-07-27',
+      time: '09:00', // implied by "every morning"
+      recurrence: { type: 'daily' },
+    });
+  });
+
+  it('no date and no time → inbox-shaped (date null)', () => {
+    const [task] = P('buy milk');
+    expect(task).toMatchObject({ title: 'Buy milk', date: null, time: null, duration: 30 });
+  });
+
+  it('extracts tags into the array and out of the title', () => {
+    const [task] = P('gym hashtag fitness tomorrow morning');
+    expect(task.tags).toEqual(['fitness']);
+    expect(task.title).toBe('Gym');
+    expect(task).toMatchObject({ date: '2026-07-28', time: '09:00' });
+  });
+
+  it('time range sets time + duration', () => {
+    const [task] = P('deep work friday 9-11am');
+    expect(task).toMatchObject({ date: '2026-07-31', time: '09:00', duration: 120 });
+  });
+
+  it('explicit duration wins', () => {
+    const [task] = P('review PRs tomorrow for 45 min');
+    expect(task).toMatchObject({ date: '2026-07-28', duration: 45 });
+  });
+
+  it('returns [] for empty input', () => {
+    expect(P('')).toEqual([]);
+    expect(P('   ')).toEqual([]);
+  });
+
+  it('is deterministic', () => {
+    expect(P('dentist tomorrow 3pm')).toEqual(P('dentist tomorrow 3pm'));
+  });
+});


### PR DESCRIPTION
**PR A of the voice-without-AI series** (A = web, B = Android STT bridge, C = iOS STT bridge). Stacked on #1267 (`nl-quick-add`) because it reuses `quickAddParser` — GitHub will retarget to `main` automatically when #1267 merges.

Voice input no longer requires an AI provider. The old behavior — gate the button on AI, and "just fail" (bare title-only task) without it — is gone.

## The two legs, each with a no-AI path

**Parsing (text → tasks).** No AI configured, or the AI parse call fails → the transcript runs through the deterministic `quickAddParser` via new `utils/voiceQuickAdd.js`:
- lead-in stripping: *"remind me to…"*, *"add a task to…"*, *"new task:"*
- STT normalization: `"3 p.m."` → `3pm`, spoken `"hashtag work"` → `#work`, trailing punctuation
- date / time / range / duration / tag extraction (same engine as the quick-add chips)
- **recurrence — which the AI parse never supported**: "dentist tomorrow at 3 p.m. every 2 weeks" spoken aloud creates a real recurring template on apply
- a bare time ("call mom at 3pm") or bare recurrence anchors to today

*v1 scope, deliberate:* one task per utterance. Multi-task splitting and edit commands ("mark report as done") remain AI-only — those genuinely need a language model.

**Transcription (speech → text), priority order:**
1. **AI transcription** (Whisper/Gemini) — unchanged for configured users
2. **Native on-device STT** — new `DayGlanceNative` speech contract in `native.js` (`supportsSpeechRecognition` / `start` / `stop` / `cancel` + `window.__speechEvent`); inert until PRs B/C land the Kotlin/Swift sides
3. **Web Speech API** — browser/PWA, free, no key, live interim transcript while speaking
4. **Typing** — always works, now fully parsed instead of dumped as a bare title

Nice combo that falls out for free: an Anthropic/Ollama user (AI parse but no transcription support) gets platform STT for speech + AI for parsing.

## Un-gating

- Voice buttons (sidebar + mobile) now show when `features.voiceTaskInput !== false` (default **on**) — no longer requires AI enabled.
- Modal copy no longer says "Configure an AI provider" — typing works for everyone, and the parse button reads **"Parse with AI"** / **"Parse"** depending on config.
- AI-parse-failure copy: "Parsed without AI instead" (because it now is).

## Refactor

`voiceParseWithAI` and the post-transcription inline parse (previously a duplicated `aiJSON` block) now share one `parseTranscriptNow` path.

## Tests

22 new (`voiceQuickAdd.test.js`): lead-ins, STT normalization, today-anchoring, recurrence, tags, ranges, determinism. Suite **975 passing**, lint + build clean.

## Platform notes / honest limits

- **Electron**: no Web Speech in Chromium-without-key; desktop stays Whisper-or-typing (typing is now parsed, so still a real upgrade).
- Chrome's Web Speech routes audio via Google's servers (free, no key); Safari uses on-device dictation. Truly-offline speech on the web isn't a thing without shipping a model.
- Web Speech behavior needs a manual browser pass (vitest can't exercise `SpeechRecognition`): mic button in a no-AI profile → speak → live transcript → parsed preview.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_