### PR TITLE
Add Bucket List — a someday/maybe space outside the Inbox (v4.1.0)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -886,5 +886,22 @@
     "noUnscheduledTasks": "Keine ungeplanten Aufgaben.",
     "addTaskPlaceholder": "Aufgabe hinzufügen…",
     "addTaskToProject": "Aufgabe zum Projekt hinzufügen"
+  },
+  "bucket": {
+    "title": "Bucket List",
+    "subtitle": "Irgendwann / vielleicht — keine Fristen, kein Drängeln",
+    "sendToBucket": "Auf die Bucket List",
+    "sendToInbox": "In den Posteingang verschieben",
+    "scheduleNextSlot": "Im nächsten freien Slot einplanen",
+    "moveToList": "Nach {{list}} verschieben",
+    "delete": "Löschen",
+    "renameList": "Liste umbenennen",
+    "hideList": "Diese Liste ausblenden",
+    "showList": "{{list}} anzeigen",
+    "addToList": "Zu {{list}} hinzufügen…",
+    "empty": "Noch nichts hier.",
+    "notesPlaceholder": "Notizen für diesen Bereich — Träume, Kriterien, Links…",
+    "showCompleted": "Erledigte anzeigen",
+    "hideCompleted": "Erledigte ausblenden"
   }
 }

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -889,7 +889,7 @@
   },
   "bucket": {
     "title": "Bucket List",
-    "subtitle": "Irgendwann / vielleicht — keine Fristen, kein Drängeln",
+    "subtitle": "Irgendwann / vielleicht. Keine Fristen, kein Drängeln.",
     "sendToBucket": "Auf die Bucket List",
     "sendToInbox": "In den Posteingang verschieben",
     "scheduleNextSlot": "Im nächsten freien Slot einplanen",
@@ -900,7 +900,7 @@
     "showList": "{{list}} anzeigen",
     "addToList": "Zu {{list}} hinzufügen…",
     "empty": "Noch nichts hier.",
-    "notesPlaceholder": "Notizen für diesen Bereich — Träume, Kriterien, Links…",
+    "notesPlaceholder": "Notizen für diesen Bereich: Träume, Kriterien, Links…",
     "showCompleted": "Erledigte anzeigen",
     "hideCompleted": "Erledigte ausblenden"
   }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -889,7 +889,7 @@
   },
   "bucket": {
     "title": "Bucket List",
-    "subtitle": "Someday / maybe — no deadlines, no nags",
+    "subtitle": "Someday / maybe. No deadlines, no nags.",
     "sendToBucket": "Send to Bucket List",
     "sendToInbox": "Send to Inbox",
     "scheduleNextSlot": "Schedule at next open slot",
@@ -900,7 +900,7 @@
     "showList": "Show {{list}}",
     "addToList": "Add to {{list}}…",
     "empty": "Nothing here yet.",
-    "notesPlaceholder": "Notes for this space — dreams, criteria, links…",
+    "notesPlaceholder": "Notes for this space: dreams, criteria, links…",
     "showCompleted": "Show completed",
     "hideCompleted": "Hide completed"
   }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -886,5 +886,22 @@
     "noUnscheduledTasks": "No unscheduled tasks.",
     "addTaskPlaceholder": "Add a task…",
     "addTaskToProject": "Add task to project"
+  },
+  "bucket": {
+    "title": "Bucket List",
+    "subtitle": "Someday / maybe — no deadlines, no nags",
+    "sendToBucket": "Send to Bucket List",
+    "sendToInbox": "Send to Inbox",
+    "scheduleNextSlot": "Schedule at next open slot",
+    "moveToList": "Move to {{list}}",
+    "delete": "Delete",
+    "renameList": "Rename list",
+    "hideList": "Hide this list",
+    "showList": "Show {{list}}",
+    "addToList": "Add to {{list}}…",
+    "empty": "Nothing here yet.",
+    "notesPlaceholder": "Notes for this space — dreams, criteria, links…",
+    "showCompleted": "Show completed",
+    "hideCompleted": "Hide completed"
   }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -889,7 +889,7 @@
   },
   "bucket": {
     "title": "Bucket List",
-    "subtitle": "Algún día / quizás — sin fechas límite, sin presiones",
+    "subtitle": "Algún día / quizás. Sin fechas límite, sin presiones.",
     "sendToBucket": "Enviar a la Bucket List",
     "sendToInbox": "Enviar a la bandeja de entrada",
     "scheduleNextSlot": "Programar en el próximo hueco libre",
@@ -900,7 +900,7 @@
     "showList": "Mostrar {{list}}",
     "addToList": "Añadir a {{list}}…",
     "empty": "Aún no hay nada aquí.",
-    "notesPlaceholder": "Notas para este espacio — sueños, criterios, enlaces…",
+    "notesPlaceholder": "Notas para este espacio: sueños, criterios, enlaces…",
     "showCompleted": "Mostrar completadas",
     "hideCompleted": "Ocultar completadas"
   }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -886,5 +886,22 @@
     "noUnscheduledTasks": "No hay tareas sin programar.",
     "addTaskPlaceholder": "Añadir una tarea…",
     "addTaskToProject": "Añadir tarea al proyecto"
+  },
+  "bucket": {
+    "title": "Bucket List",
+    "subtitle": "Algún día / quizás — sin fechas límite, sin presiones",
+    "sendToBucket": "Enviar a la Bucket List",
+    "sendToInbox": "Enviar a la bandeja de entrada",
+    "scheduleNextSlot": "Programar en el próximo hueco libre",
+    "moveToList": "Mover a {{list}}",
+    "delete": "Eliminar",
+    "renameList": "Renombrar lista",
+    "hideList": "Ocultar esta lista",
+    "showList": "Mostrar {{list}}",
+    "addToList": "Añadir a {{list}}…",
+    "empty": "Aún no hay nada aquí.",
+    "notesPlaceholder": "Notas para este espacio — sueños, criterios, enlaces…",
+    "showCompleted": "Mostrar completadas",
+    "hideCompleted": "Ocultar completadas"
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -886,5 +886,22 @@
     "noUnscheduledTasks": "Aucune tâche non planifiée.",
     "addTaskPlaceholder": "Ajouter une tâche…",
     "addTaskToProject": "Ajouter une tâche au projet"
+  },
+  "bucket": {
+    "title": "Bucket List",
+    "subtitle": "Un jour / peut-être — sans échéances, sans pression",
+    "sendToBucket": "Envoyer vers la Bucket List",
+    "sendToInbox": "Envoyer vers la boîte de réception",
+    "scheduleNextSlot": "Planifier au prochain créneau libre",
+    "moveToList": "Déplacer vers {{list}}",
+    "delete": "Supprimer",
+    "renameList": "Renommer la liste",
+    "hideList": "Masquer cette liste",
+    "showList": "Afficher {{list}}",
+    "addToList": "Ajouter à {{list}}…",
+    "empty": "Rien ici pour l’instant.",
+    "notesPlaceholder": "Notes pour cet espace — rêves, critères, liens…",
+    "showCompleted": "Afficher les terminées",
+    "hideCompleted": "Masquer les terminées"
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -889,7 +889,7 @@
   },
   "bucket": {
     "title": "Bucket List",
-    "subtitle": "Un jour / peut-être — sans échéances, sans pression",
+    "subtitle": "Un jour / peut-être. Sans échéances, sans pression.",
     "sendToBucket": "Envoyer vers la Bucket List",
     "sendToInbox": "Envoyer vers la boîte de réception",
     "scheduleNextSlot": "Planifier au prochain créneau libre",
@@ -900,7 +900,7 @@
     "showList": "Afficher {{list}}",
     "addToList": "Ajouter à {{list}}…",
     "empty": "Rien ici pour l’instant.",
-    "notesPlaceholder": "Notes pour cet espace — rêves, critères, liens…",
+    "notesPlaceholder": "Notes pour cet espace : rêves, critères, liens…",
     "showCompleted": "Afficher les terminées",
     "hideCompleted": "Masquer les terminées"
   }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -889,7 +889,7 @@
   },
   "bucket": {
     "title": "Bucket List",
-    "subtitle": "Un giorno / forse — senza scadenze, senza assilli",
+    "subtitle": "Un giorno / forse. Senza scadenze, senza assilli.",
     "sendToBucket": "Invia alla Bucket List",
     "sendToInbox": "Invia alla posta in arrivo",
     "scheduleNextSlot": "Pianifica nel prossimo slot libero",
@@ -900,7 +900,7 @@
     "showList": "Mostra {{list}}",
     "addToList": "Aggiungi a {{list}}…",
     "empty": "Ancora niente qui.",
-    "notesPlaceholder": "Note per questo spazio — sogni, criteri, link…",
+    "notesPlaceholder": "Note per questo spazio: sogni, criteri, link…",
     "showCompleted": "Mostra completate",
     "hideCompleted": "Nascondi completate"
   }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -886,5 +886,22 @@
     "noUnscheduledTasks": "Nessuna attività non programmata.",
     "addTaskPlaceholder": "Aggiungi un'attività…",
     "addTaskToProject": "Aggiungi attività al progetto"
+  },
+  "bucket": {
+    "title": "Bucket List",
+    "subtitle": "Un giorno / forse — senza scadenze, senza assilli",
+    "sendToBucket": "Invia alla Bucket List",
+    "sendToInbox": "Invia alla posta in arrivo",
+    "scheduleNextSlot": "Pianifica nel prossimo slot libero",
+    "moveToList": "Sposta in {{list}}",
+    "delete": "Elimina",
+    "renameList": "Rinomina lista",
+    "hideList": "Nascondi questa lista",
+    "showList": "Mostra {{list}}",
+    "addToList": "Aggiungi a {{list}}…",
+    "empty": "Ancora niente qui.",
+    "notesPlaceholder": "Note per questo spazio — sogni, criteri, link…",
+    "showCompleted": "Mostra completate",
+    "hideCompleted": "Nascondi completate"
   }
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -886,5 +886,22 @@
     "noUnscheduledTasks": "Sem tarefas não agendadas.",
     "addTaskPlaceholder": "Adicionar uma tarefa…",
     "addTaskToProject": "Adicionar tarefa ao projeto"
+  },
+  "bucket": {
+    "title": "Bucket List",
+    "subtitle": "Um dia / talvez — sem prazos, sem cobranças",
+    "sendToBucket": "Enviar para a Bucket List",
+    "sendToInbox": "Enviar para a caixa de entrada",
+    "scheduleNextSlot": "Agendar no próximo espaço livre",
+    "moveToList": "Mover para {{list}}",
+    "delete": "Eliminar",
+    "renameList": "Renomear lista",
+    "hideList": "Ocultar esta lista",
+    "showList": "Mostrar {{list}}",
+    "addToList": "Adicionar a {{list}}…",
+    "empty": "Ainda não há nada aqui.",
+    "notesPlaceholder": "Notas para este espaço — sonhos, critérios, links…",
+    "showCompleted": "Mostrar concluídas",
+    "hideCompleted": "Ocultar concluídas"
   }
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -889,7 +889,7 @@
   },
   "bucket": {
     "title": "Bucket List",
-    "subtitle": "Um dia / talvez — sem prazos, sem cobranças",
+    "subtitle": "Um dia / talvez. Sem prazos, sem cobranças.",
     "sendToBucket": "Enviar para a Bucket List",
     "sendToInbox": "Enviar para a caixa de entrada",
     "scheduleNextSlot": "Agendar no próximo espaço livre",
@@ -900,7 +900,7 @@
     "showList": "Mostrar {{list}}",
     "addToList": "Adicionar a {{list}}…",
     "empty": "Ainda não há nada aqui.",
-    "notesPlaceholder": "Notas para este espaço — sonhos, critérios, links…",
+    "notesPlaceholder": "Notas para este espaço: sonhos, critérios, links…",
     "showCompleted": "Mostrar concluídas",
     "hideCompleted": "Ocultar concluídas"
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import { collectDeviceSettings, applyDeviceSettings } from './utils/deviceSettin
 import useFolderBackup from './hooks/useFolderBackup.js';
 import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOnlyTask, getLinkUrl, hasOnlySubtasks, renderTitle, highlightMatch, renderTitleWithoutTags, extractShareTitle } from './utils/textFormatting.jsx';
 import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate, computeTaskCalendarTombstones, computeRecurringSeriesTombstones } from './utils/taskUtils.js';
+import { notBucketed, demoteToBucket, normalizeBucketConfig } from './utils/bucketList.js';
 import { parseICS, parseDatetime, filterByDateWindow, expandMultiDayEvent } from './utils/icsParser.js';
 import { TASK_COLORS, TAILWIND_TO_HEX, taskColorToHex, getProjectColor } from './utils/colorUtils.js';
 import { calculateGoalProgress } from './utils/goalProgress.js';
@@ -150,6 +151,7 @@ import FramesModal from './components/FramesModal.jsx';
 import MobileWelcomeModal from './components/MobileWelcomeModal.jsx';
 import DesktopWelcomeModal from './components/DesktopWelcomeModal.jsx';
 import SpotlightModal from './components/SpotlightModal.jsx';
+import BucketListModal from './components/BucketListModal.jsx';
 import HabitModal from './components/HabitModal.jsx';
 import SubscriptionWall from './components/SubscriptionWall.jsx';
 import ReviewerBanner from './components/ReviewerBanner.jsx';
@@ -544,6 +546,19 @@ const DayPlanner = () => {
   const [priorityPromptDismissed, setPriorityPromptDismissed] = useState(() => {
     return localStorage.getItem('priorityPromptDismissed') === 'true';
   });
+  // Bucket List — someday/maybe space (see utils/bucketList.js). Config
+  // (headings, second-list hidden, shared notes) is synced via the cloud
+  // payload like gtdFrames; bucket ITEMS are unscheduledTasks with a bucketId.
+  const [bucketConfig, setBucketConfig] = useState(() => {
+    try { return normalizeBucketConfig(JSON.parse(localStorage.getItem('day-planner-bucket-config') || 'null')); }
+    catch { return normalizeBucketConfig(null); }
+  });
+  useEffect(() => {
+    localStorage.setItem('day-planner-bucket-config', JSON.stringify(bucketConfig));
+  }, [bucketConfig]);
+  const updateBucketConfig = (patch) =>
+    setBucketConfig(prev => normalizeBucketConfig({ ...prev, ...patch, updatedAt: new Date().toISOString() }));
+  const [showBucketList, setShowBucketList] = useState(false);
   // Tablet layout state
   // Mobile layout state
   const [mobileActiveTab, setMobileActiveTab] = useState('dayglance');
@@ -1996,7 +2011,7 @@ const DayPlanner = () => {
       cloudSyncEngineRef.current.upload();
     }, 5000);
     return () => { if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current); };
-  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, allTodayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, cloudSyncConfig?.enabled, syncKeyReady, multiUserEnabled, users, cloudSyncDebounceRef, dataLoaded, suppressCloudUploadRef]);
+  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, allTodayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, bucketConfig, cloudSyncConfig?.enabled, syncKeyReady, multiUserEnabled, users, cloudSyncDebounceRef, dataLoaded, suppressCloudUploadRef]);
 
   // ── GLANCEvault DB transport ─────────────────────────────────────────────
   // Row-grained sync that runs ALONGSIDE the file-tier WebDAV engine (it shares
@@ -2515,10 +2530,12 @@ const DayPlanner = () => {
     if (isTrayMode || !dataLoaded || inboxAutoArchiveDays === 0) return;
     const cutoff = Date.now() - inboxAutoArchiveDays * 86400000;
     setUnscheduledTasks(prev => {
-      const hasChanges = prev.some(t => t.completed && !t.archived && t.completedAt && new Date(t.completedAt).getTime() < cutoff);
+      // Bucket List items are exempt — the Bucket is a parking lot, not a queue
+      // to be swept. Completed bucket items stay until the user deletes them.
+      const hasChanges = prev.some(t => notBucketed(t) && t.completed && !t.archived && t.completedAt && new Date(t.completedAt).getTime() < cutoff);
       if (!hasChanges) return prev;
       return prev.map(t =>
-        (t.completed && !t.archived && t.completedAt && new Date(t.completedAt).getTime() < cutoff)
+        (notBucketed(t) && t.completed && !t.archived && t.completedAt && new Date(t.completedAt).getTime() < cutoff)
           // Stamp lastModified so the archive wins whole-entity LWW and isn't
           // dropped by a newer non-archived copy from another device.
           ? { ...t, archived: true, lastModified: new Date().toISOString() }
@@ -2786,9 +2803,9 @@ const DayPlanner = () => {
       }
     }
 
-    // Inbox tasks with past deadlines
+    // Inbox tasks with past deadlines (bucket items never nag)
     const overdueDeadlines = unscheduledTasks.filter(t =>
-      t.deadline && t.deadline < todayStr && !t.completed && !t.isExample && isVisibleForUser(t)
+      notBucketed(t) && t.deadline && t.deadline < todayStr && !t.completed && !t.isExample && isVisibleForUser(t)
     ).map(t => ({ ...t, _overdueType: 'deadline' }));
 
     return [...overdueScheduled, ...todayRecurring, ...overdueRecurringAllDay, ...overdueDeadlines];
@@ -2985,7 +3002,7 @@ const DayPlanner = () => {
       // calendar events carry no assignment and remain included.
       const mergeVars = gatherTrmnlData({
         tasks: tasks.filter(isVisibleForUser),
-        unscheduledTasks: unscheduledTasks.filter(isVisibleForUser),
+        unscheduledTasks: unscheduledTasks.filter(t => notBucketed(t) && isVisibleForUser(t)),
         recurringTasks: recurringTasks.filter(isVisibleForUser),
         selectedDate: today,
         use24HourClock: use24HourClock,
@@ -3053,6 +3070,7 @@ const DayPlanner = () => {
     showAddTask, setShowAddTask, setShowNewTaskDeadlinePicker,
     showRecurrencePicker, setShowRecurrencePicker,
     focusLogModalDate, setFocusLogModalDate,
+    showBucketList, setShowBucketList,
   });
 
   useKeyboardShortcuts({
@@ -5140,6 +5158,7 @@ const DayPlanner = () => {
         routinesEnabled,
         routinesEnabledUpdatedAt: localStorage.getItem('day-planner-routines-enabled-updated-at') || null,
         gtdFrames,
+        bucketConfig,
         goals,
         deletedGoalIds: JSON.parse(localStorage.getItem('day-planner-deleted-goal-ids') || '{}'),
         projects,
@@ -5330,6 +5349,11 @@ const DayPlanner = () => {
     if (data.gtdFrames) {
       localStorage.setItem('day-planner-gtd-frames', JSON.stringify(data.gtdFrames));
       setGtdFrames(data.gtdFrames);
+    }
+    if (data.bucketConfig) {
+      const normalized = normalizeBucketConfig(data.bucketConfig);
+      localStorage.setItem('day-planner-bucket-config', JSON.stringify(normalized));
+      setBucketConfig(normalized);
     }
     if (data.goals) {
       localStorage.setItem('day-planner-goals', JSON.stringify(data.goals));
@@ -5973,7 +5997,7 @@ const DayPlanner = () => {
     const allTodayTasks = [...tasks, ...todayRecurring];
 
     const allDay = allTodayTasks.filter(t => t.date === today && t.isAllDay && !t.completed && isVisibleForUser(t));
-    const deadlines = unscheduledTasks.filter(t => t.deadline === today && t.deadline >= today && !t.completed && isVisibleForUser(t));
+    const deadlines = unscheduledTasks.filter(t => notBucketed(t) && t.deadline === today && t.deadline >= today && !t.completed && isVisibleForUser(t));
     const scheduled = allTodayTasks.filter(t => {
       if (t.date !== today || t.isAllDay || !isVisibleForUser(t)) return false;
       const [h, m] = (t.startTime || '0:0').split(':').map(Number);
@@ -6040,7 +6064,7 @@ const DayPlanner = () => {
       // No more scheduled tasks — gap is rest of day (cap at a large number)
       gapMinutes = 24 * 60 - nowMin;
     }
-    const incompleteInbox = unscheduledTasks.filter(t => !t.completed && !t.isExample && isVisibleForUser(t));
+    const incompleteInbox = unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample && isVisibleForUser(t));
     const showNudge = gapMinutes >= 60 && incompleteInbox.length > 0;
     return { insertAfterIndex, nowTimeStr, showNudge, inboxCount: incompleteInbox.length, gapMinutes, insideTask };
   }, [todayAgenda, currentTime, unscheduledTasks, isVisibleForUser]);
@@ -6076,7 +6100,7 @@ const DayPlanner = () => {
     const allTasks = [...regularTasks, ...recurringInstances];
     const userTasks = allTasks.filter(t => !t.imported || t.isTaskCalendar);
     const calendarEvents = allTasks.filter(t => t.imported && !t.isTaskCalendar);
-    const deadlines = unscheduledTasks.filter(t => t.deadline === tomorrowStr && !t.completed && !t.isExample && isVisibleForUser(t));
+    const deadlines = unscheduledTasks.filter(t => notBucketed(t) && t.deadline === tomorrowStr && !t.completed && !t.isExample && isVisibleForUser(t));
     const scheduledItems = allTasks.filter(t => t.startTime && !t.isAllDay);
 
     // First start time (earliest scheduled item)
@@ -6216,7 +6240,7 @@ const DayPlanner = () => {
         }
         return true;
       });
-      const inboxItems = unscheduledTasks.filter(t => !t.completed && !t.isExample && isVisibleForUser(t));
+      const inboxItems = unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample && isVisibleForUser(t));
       // Only include tasks that can actually fit in the available slot.
       // Tasks with no duration are always included (we don't know how long they take).
       const candidates = [
@@ -6499,6 +6523,17 @@ const DayPlanner = () => {
   };
   const restoreArchivedInboxTask = (id) => {
     setUnscheduledTasks(prev => prev.map(t => t.id === id ? { ...t, archived: false, lastModified: new Date().toISOString() } : t));
+  };
+
+  // Demote an Inbox task to the Bucket List (first list). Strips deadline and
+  // priority — the Bucket is deliberately pressure-free — so this goes through
+  // undo rather than trying to restore them on promote.
+  const sendTaskToBucket = (taskId) => {
+    const task = unscheduledTasks.find(t => t.id === taskId);
+    if (!task) return;
+    pushUndo();
+    setUnscheduledTasks(prev => prev.map(t => t.id === taskId ? demoteToBucket(t) : t));
+    setUndoToast({ message: `"${task.title}" sent to Bucket List`, actionable: true });
   };
 
   // Focus mode availability: current task or back-to-back block >= 45 min remaining
@@ -7203,7 +7238,7 @@ const DayPlanner = () => {
       const todayStr = dateToString(today);
       // Gather inbox tasks (non-completed, non-example, non-project)
       // Project tasks belong to their project cards and shouldn't be auto-scheduled from here
-      const inboxTasks = unscheduledTasks.filter(t => !t.completed && !t.isExample && (!goalsProjectsEnabled || !t.projectId) && isVisibleForUser(t));
+      const inboxTasks = unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample && (!goalsProjectsEnabled || !t.projectId) && isVisibleForUser(t));
       if (inboxTasks.length === 0) {
         setSmartScheduleError('No inbox tasks to schedule.');
         setSmartScheduleLoading(false);
@@ -7664,6 +7699,11 @@ const DayPlanner = () => {
     spotlightQuery, setSpotlightQuery,
     spotlightSelectedIndex, setSpotlightSelectedIndex,
     spotlightResults,
+
+    // ── Bucket List ───────────────────────────────────────────────────────────
+    bucketConfig, updateBucketConfig,
+    showBucketList, setShowBucketList,
+    sendTaskToBucket,
 
     // ── Daily notes ───────────────────────────────────────────────────────────
     dailyNotes, setDailyNotes,
@@ -9152,6 +9192,7 @@ const DayPlanner = () => {
 
       {/* Spotlight Search */}
       {showSpotlight && <SpotlightModal />}
+      {showBucketList && <BucketListModal />}
 
       {/* Settings Modal */}
       {showSettings && <SettingsModal />}

--- a/src/components/BucketListModal.jsx
+++ b/src/components/BucketListModal.jsx
@@ -1,0 +1,440 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ArrowRightLeft, CalendarClock, Eye, EyeOff, GripVertical, Inbox, Plus, Telescope, Trash2, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { BUCKET_LIST_IDS, promoteToInbox } from '../utils/bucketList.js';
+import { renderFormattedText } from '../utils/textFormatting.jsx';
+
+// Same iOS detection as ProjectPlanner/ProjectCard: grip-only touch drag on
+// iOS, where whole-row HTML5 drag hijacks the gesture.
+const IS_IOS = typeof navigator !== 'undefined' && (
+  /iP(hone|ad|od)/.test(navigator.platform || '') ||
+  (/Mac/.test(navigator.platform || '') && (navigator.maxTouchPoints || 0) > 1) ||
+  (typeof window !== 'undefined' && !!window.DayGlanceIOS)
+);
+
+/**
+ * Bucket List — the someday/maybe space. A PLANNER without a project: same
+ * shell (shared notes panel, task rows, quick-add, drag-to-reorder), two
+ * lists max with user-editable headings, second list hideable. Items are
+ * unscheduledTasks with a bucketId, excluded from all Inbox machinery
+ * (see utils/bucketList.js). Accessed from GLANCE.
+ */
+const BucketListModal = () => {
+  const {
+    isMobile,
+    darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg,
+    unscheduledTasks, setUnscheduledTasks, reorderUnscheduledTasks,
+    scheduleTaskAtNextSlot, moveToRecycleBin, openMobileEditTask,
+    bucketConfig, updateBucketConfig,
+    setShowBucketList,
+    pushUndo, setUndoToast,
+    colors,
+  } = useDayPlannerCtx();
+  const { isVisibleForUser } = useFeaturesCtx();
+  const { t } = useTranslation();
+
+  const [notes, setNotes] = useState(bucketConfig.notes || '');
+  const [editingNotes, setEditingNotes] = useState(!(bucketConfig.notes || '').trim());
+  const [editingHeading, setEditingHeading] = useState(null); // 'b1' | 'b2' | null
+  const [headingDraft, setHeadingDraft] = useState('');
+  const [quickAdd, setQuickAdd] = useState({ b1: '', b2: '' });
+  const [showCompleted, setShowCompleted] = useState(true);
+  const [drag, setDrag] = useState({ listId: null, idx: null, overIdx: null });
+  const touchDragRef = useRef({ active: false, listId: null, fromIdx: null, overIdx: null });
+
+  const saveNotes = () => {
+    if ((bucketConfig.notes || '') !== notes) {
+      updateBucketConfig({ notes: notes.trim() });
+    }
+  };
+  const closeModal = () => { saveNotes(); setShowBucketList(false); };
+
+  // Save notes on unmount too (ProjectPlanner's pattern) — Escape-close and
+  // the editor opening over us bypass closeModal/blur.
+  const saveNotesRef = useRef(saveNotes);
+  saveNotesRef.current = saveNotes;
+  useEffect(() => () => saveNotesRef.current(), []);
+
+  // Items per list; completed sink to the bottom of their list.
+  const lists = useMemo(() => {
+    const byList = {};
+    for (const id of BUCKET_LIST_IDS) {
+      let items = unscheduledTasks.filter(t => t.bucketId === id && !t.archived && isVisibleForUser(t));
+      if (!showCompleted) items = items.filter(t => !t.completed);
+      byList[id] = items.sort((a, b) => (a.completed ? 1 : 0) - (b.completed ? 1 : 0));
+    }
+    return byList;
+  }, [unscheduledTasks, isVisibleForUser, showCompleted]);
+
+  const hasAnyCompleted = useMemo(
+    () => unscheduledTasks.some(t => t.bucketId && !t.archived && t.completed),
+    [unscheduledTasks]
+  );
+  const hiddenCount = useMemo(
+    () => unscheduledTasks.filter(t => t.bucketId === 'b2' && !t.archived && !t.completed && isVisibleForUser(t)).length,
+    [unscheduledTasks, isVisibleForUser]
+  );
+
+  // ── Row actions ───────────────────────────────────────────────────────────
+
+  const stamp = () => new Date().toISOString();
+
+  const toggleComplete = (task) => {
+    setUnscheduledTasks(prev => prev.map(t => t.id === task.id
+      ? { ...t, completed: !t.completed, completedAt: !t.completed ? stamp() : undefined, lastModified: stamp() }
+      : t));
+  };
+
+  const sendToInbox = (task) => {
+    pushUndo();
+    setUnscheduledTasks(prev => prev.map(t => t.id === task.id ? promoteToInbox(t) : t));
+    setUndoToast({ message: `"${task.title}" sent to Inbox`, actionable: true });
+  };
+
+  const scheduleNextSlot = (task) => {
+    pushUndo();
+    // scheduleTaskAtNextSlot strips bucketId when moving to the timeline.
+    scheduleTaskAtNextSlot(task.id, true);
+  };
+
+  const moveToOtherList = (task) => {
+    const other = task.bucketId === 'b1' ? 'b2' : 'b1';
+    setUnscheduledTasks(prev => prev.map(t => t.id === task.id
+      ? { ...t, bucketId: other, lastModified: stamp() }
+      : t));
+  };
+
+  const deleteItem = (task) => {
+    moveToRecycleBin(task.id, true);
+  };
+
+  const editItem = (task) => {
+    saveNotes();
+    // Inbox flavor — bucket items live in unscheduledTasks, and the inbox
+    // save path spread-updates in place, preserving bucketId.
+    openMobileEditTask(task, true);
+  };
+
+  const handleQuickAdd = (e, listId) => {
+    e.preventDefault();
+    const title = (quickAdd[listId] || '').trim();
+    if (!title) return;
+    setUnscheduledTasks(prev => [...prev, {
+      id: crypto.randomUUID(),
+      title,
+      duration: 30,
+      color: colors[0].class,
+      completed: false,
+      isAllDay: false,
+      notes: '',
+      subtasks: [],
+      priority: 0,
+      bucketId: listId,
+      lastModified: stamp(),
+    }]);
+    setQuickAdd(prev => ({ ...prev, [listId]: '' }));
+  };
+
+  // ── Headings ──────────────────────────────────────────────────────────────
+
+  const startHeadingEdit = (id) => {
+    setEditingHeading(id);
+    setHeadingDraft(bucketConfig.headings[id]);
+  };
+  const saveHeading = () => {
+    const value = headingDraft.trim();
+    if (value && value !== bucketConfig.headings[editingHeading]) {
+      updateBucketConfig({ headings: { ...bucketConfig.headings, [editingHeading]: value } });
+    }
+    setEditingHeading(null);
+  };
+
+  // ── Drag-to-reorder within a list (ProjectPlanner's pattern) ─────────────
+
+  const incompleteOf = (listId) => lists[listId].filter(t => !t.completed);
+
+  const applyReorder = (listId, fromIdx, toIdx) => {
+    const items = incompleteOf(listId);
+    const fromId = items[fromIdx]?.id;
+    const toId = items[toIdx]?.id;
+    if (!fromId || !toId) return;
+    const next = [...unscheduledTasks];
+    const fromFull = next.findIndex(t => t.id === fromId);
+    const toFull = next.findIndex(t => t.id === toId);
+    const [moved] = next.splice(fromFull, 1);
+    next.splice(toFull, 0, moved);
+    reorderUnscheduledTasks(next);
+  };
+
+  const handleDrop = (e, listId, idx) => {
+    e.preventDefault();
+    if (drag.listId === listId && drag.idx !== null && drag.idx !== idx) {
+      applyReorder(listId, drag.idx, idx);
+    }
+    setDrag({ listId: null, idx: null, overIdx: null });
+  };
+
+  // Grip-only touch drag for iOS (document-level non-passive listeners,
+  // dragstart cancelled for the gesture — ProjectCard's proven pattern).
+  const handleGripTouchStart = (e, listId, idx) => {
+    touchDragRef.current = { active: true, listId, fromIdx: idx, overIdx: null };
+    setDrag({ listId, idx, overIdx: null });
+
+    const onMove = (moveEvent) => {
+      if (!touchDragRef.current.active) return;
+      moveEvent.preventDefault();
+      const touch = moveEvent.touches[0];
+      if (!touch) return;
+      const el = document.elementFromPoint(touch.clientX, touch.clientY);
+      const taskEl = el?.closest(`[data-bucket-drag="${listId}"]`);
+      if (taskEl) {
+        const overIdx = parseInt(taskEl.getAttribute('data-drag-idx'), 10);
+        if (!isNaN(overIdx)) {
+          touchDragRef.current.overIdx = overIdx;
+          setDrag(prev => ({ ...prev, overIdx }));
+        }
+      }
+    };
+    const preventDrag = (de) => de.preventDefault();
+    const onEnd = () => {
+      document.removeEventListener('touchmove', onMove);
+      document.removeEventListener('touchend', onEnd);
+      document.removeEventListener('touchcancel', onEnd);
+      document.removeEventListener('dragstart', preventDrag);
+      const { active, listId: lId, fromIdx, overIdx } = touchDragRef.current;
+      touchDragRef.current = { active: false, listId: null, fromIdx: null, overIdx: null };
+      if (active && fromIdx !== null && overIdx !== null && fromIdx !== overIdx) {
+        applyReorder(lId, fromIdx, overIdx);
+      }
+      setDrag({ listId: null, idx: null, overIdx: null });
+    };
+    document.addEventListener('touchmove', onMove, { passive: false });
+    document.addEventListener('touchend', onEnd);
+    document.addEventListener('touchcancel', onEnd);
+    document.addEventListener('dragstart', preventDrag);
+  };
+
+  // ── Render helpers ────────────────────────────────────────────────────────
+
+  const renderRow = (task, listId, idx, draggable) => {
+    const isDragOver = drag.listId === listId && drag.overIdx === idx;
+    return (
+      <div
+        key={task.id}
+        data-bucket-drag={draggable ? listId : undefined}
+        data-drag-idx={draggable ? idx : undefined}
+        draggable={draggable && !IS_IOS}
+        onDragStart={draggable && !IS_IOS ? (e) => { setDrag({ listId, idx, overIdx: null }); e.dataTransfer.effectAllowed = 'move'; } : undefined}
+        onDragOver={draggable ? (e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; if (drag.listId === listId && idx !== drag.overIdx) setDrag(prev => ({ ...prev, overIdx: idx })); } : undefined}
+        onDrop={draggable ? (e) => handleDrop(e, listId, idx) : undefined}
+        onDragEnd={draggable ? () => setDrag({ listId: null, idx: null, overIdx: null }) : undefined}
+        className={`group flex items-center gap-2 px-2 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700/40' : 'bg-stone-50'} ${isDragOver ? 'ring-2 ring-sky-400' : ''}`}
+      >
+        {draggable && (
+          <span
+            className={`flex-shrink-0 cursor-grab touch-none ${textSecondary} opacity-40 group-hover:opacity-80`}
+            onTouchStart={IS_IOS ? (e) => handleGripTouchStart(e, listId, idx) : undefined}
+          >
+            <GripVertical size={14} />
+          </span>
+        )}
+        <input
+          type="checkbox"
+          checked={!!task.completed}
+          onChange={() => toggleComplete(task)}
+          className="flex-shrink-0 w-4 h-4 rounded accent-sky-500 cursor-pointer"
+        />
+        <button
+          type="button"
+          onClick={() => editItem(task)}
+          className={`flex-1 min-w-0 text-left text-sm truncate ${task.completed ? `line-through ${textSecondary}` : textPrimary}`}
+        >
+          {task.title}
+        </button>
+        <div className={`flex items-center gap-0.5 flex-shrink-0 ${isMobile ? '' : 'opacity-0 group-hover:opacity-100 transition-opacity'}`}>
+          {!task.completed && (
+            <>
+              <button type="button" onClick={() => sendToInbox(task)} title={t('bucket.sendToInbox')} className={`p-1 rounded ${hoverBg}`}>
+                <Inbox size={14} className={textSecondary} />
+              </button>
+              <button type="button" onClick={() => scheduleNextSlot(task)} title={t('bucket.scheduleNextSlot')} className={`p-1 rounded ${hoverBg}`}>
+                <CalendarClock size={14} className={textSecondary} />
+              </button>
+              <button
+                type="button"
+                onClick={() => moveToOtherList(task)}
+                title={t('bucket.moveToList', { list: bucketConfig.headings[task.bucketId === 'b1' ? 'b2' : 'b1'] })}
+                className={`p-1 rounded ${hoverBg}`}
+              >
+                <ArrowRightLeft size={14} className={textSecondary} />
+              </button>
+            </>
+          )}
+          <button type="button" onClick={() => deleteItem(task)} title={t('bucket.delete')} className={`p-1 rounded ${hoverBg}`}>
+            <Trash2 size={14} className={textSecondary} />
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  const renderList = (listId) => {
+    const items = lists[listId];
+    const incomplete = items.filter(t => !t.completed);
+    const completed = items.filter(t => t.completed);
+    return (
+      <div className="flex-1 min-w-0 flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          {editingHeading === listId ? (
+            <input
+              type="text"
+              value={headingDraft}
+              onChange={(e) => setHeadingDraft(e.target.value)}
+              onBlur={saveHeading}
+              onKeyDown={(e) => { if (e.key === 'Enter') saveHeading(); if (e.key === 'Escape') setEditingHeading(null); }}
+              autoFocus
+              maxLength={40}
+              className={`text-sm font-semibold px-1.5 py-0.5 rounded border ${borderClass} ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} focus:outline-none focus:ring-2 focus:ring-sky-500 min-w-0`}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => startHeadingEdit(listId)}
+              title={t('bucket.renameList')}
+              className={`text-sm font-semibold ${textPrimary} hover:underline decoration-dotted truncate`}
+            >
+              {bucketConfig.headings[listId]}
+              <span className={`ml-1.5 font-normal ${textSecondary}`}>{incomplete.length || ''}</span>
+            </button>
+          )}
+          {listId === 'b2' && (
+            <button
+              type="button"
+              onClick={() => updateBucketConfig({ secondListHidden: true })}
+              title={t('bucket.hideList')}
+              className={`p-1 rounded ${hoverBg} flex-shrink-0`}
+            >
+              <EyeOff size={14} className={textSecondary} />
+            </button>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          {incomplete.map((task, idx) => renderRow(task, listId, idx, true))}
+          {incomplete.length === 0 && (
+            <p className={`text-xs italic ${textSecondary} px-2 py-3`}>{t('bucket.empty')}</p>
+          )}
+          {showCompleted && completed.map((task) => renderRow(task, listId, null, false))}
+        </div>
+
+        <form onSubmit={(e) => handleQuickAdd(e, listId)} className="flex items-center gap-1.5 mt-1">
+          <input
+            type="text"
+            value={quickAdd[listId]}
+            onChange={(e) => setQuickAdd(prev => ({ ...prev, [listId]: e.target.value }))}
+            placeholder={t('bucket.addToList', { list: bucketConfig.headings[listId] })}
+            className={`flex-1 min-w-0 px-2.5 py-1.5 text-sm border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-500 ${darkMode ? 'bg-gray-700 text-white placeholder:text-gray-500' : 'bg-white text-stone-900 placeholder:text-stone-400'}`}
+          />
+          <button
+            type="submit"
+            disabled={!(quickAdd[listId] || '').trim()}
+            className="p-1.5 rounded-lg bg-sky-600 text-white hover:bg-sky-700 disabled:opacity-40 flex-shrink-0"
+          >
+            <Plus size={14} />
+          </button>
+        </form>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className={`fixed inset-0 z-[70] flex ${isMobile ? 'flex-col justify-end' : 'items-center justify-center p-6'}`}
+      onClick={closeModal}
+    >
+      <div className="absolute inset-0 bg-black/45" />
+      <div
+        onClick={e => e.stopPropagation()}
+        className={`relative ${cardBg} shadow-2xl flex flex-col ${
+          isMobile
+            ? 'rounded-t-2xl max-h-[92dvh] w-full overflow-y-auto overscroll-contain'
+            : 'rounded-2xl w-full max-w-3xl max-h-[85vh] overflow-hidden'
+        }`}
+        style={isMobile ? { WebkitOverflowScrolling: 'touch' } : undefined}
+      >
+        {/* Header — sticky while the mobile sheet scrolls (PLANNER pattern) */}
+        <div className={isMobile ? 'sticky top-0 z-10' : 'flex-shrink-0'}>
+          <div className="h-1.5 bg-sky-500" />
+          <div className={`flex items-center justify-between px-4 py-3 border-b ${borderClass} ${cardBg}`}>
+            <div className="flex items-center gap-2 min-w-0">
+              <Telescope size={18} className="text-sky-500 flex-shrink-0" />
+              <div className="flex flex-col min-w-0">
+                <span className={`text-base font-semibold ${textPrimary}`}>{t('bucket.title')}</span>
+                <span className={`text-xs ${textSecondary}`}>{t('bucket.subtitle')}</span>
+              </div>
+            </div>
+            <div className="flex items-center gap-1">
+              {hasAnyCompleted && (
+                <button
+                  type="button"
+                  onClick={() => setShowCompleted(v => !v)}
+                  title={showCompleted ? t('bucket.hideCompleted') : t('bucket.showCompleted')}
+                  className={`p-1.5 rounded-lg ${hoverBg}`}
+                >
+                  {showCompleted ? <Eye size={16} className={textSecondary} /> : <EyeOff size={16} className={textSecondary} />}
+                </button>
+              )}
+              <button type="button" onClick={closeModal} className={`p-1.5 rounded-lg ${hoverBg}`}>
+                <X size={18} className={textSecondary} />
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className={`p-4 flex flex-col gap-4 ${isMobile ? '' : 'overflow-y-auto'}`}>
+          {/* Shared bucket-level notes (one panel, not per-list) */}
+          {editingNotes ? (
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              onBlur={() => { saveNotes(); if (notes.trim()) setEditingNotes(false); }}
+              onKeyDown={(e) => { if (e.key === 'Enter' && e.shiftKey) { e.preventDefault(); saveNotes(); if (notes.trim()) setEditingNotes(false); } }}
+              placeholder={t('bucket.notesPlaceholder')}
+              rows={2}
+              className={`w-full px-3 py-2 text-sm border ${borderClass} rounded-lg resize-y focus:outline-none focus:ring-2 focus:ring-sky-500 ${darkMode ? 'bg-gray-700 text-white placeholder:text-gray-500' : 'bg-white text-stone-900 placeholder:text-stone-400'}`}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEditingNotes(true)}
+              className={`text-left text-sm ${textSecondary} whitespace-pre-wrap px-3 py-2 rounded-lg ${hoverBg}`}
+            >
+              {renderFormattedText(notes)}
+            </button>
+          )}
+
+          {/* The two lists — side by side on desktop, stacked on mobile */}
+          <div className={`flex gap-6 ${isMobile ? 'flex-col' : 'flex-row'}`}>
+            {renderList('b1')}
+            {!bucketConfig.secondListHidden && renderList('b2')}
+          </div>
+
+          {bucketConfig.secondListHidden && (
+            <button
+              type="button"
+              onClick={() => updateBucketConfig({ secondListHidden: false })}
+              className={`self-start text-xs ${textSecondary} hover:underline flex items-center gap-1`}
+            >
+              <Eye size={12} />
+              {t('bucket.showList', { list: bucketConfig.headings.b2 })}{hiddenCount > 0 ? ` (${hiddenCount})` : ''}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BucketListModal;

--- a/src/components/BucketListModal.jsx
+++ b/src/components/BucketListModal.jsx
@@ -69,8 +69,8 @@ const BucketListModal = () => {
   }, [unscheduledTasks, isVisibleForUser, showCompleted]);
 
   const hasAnyCompleted = useMemo(
-    () => unscheduledTasks.some(t => t.bucketId && !t.archived && t.completed),
-    [unscheduledTasks]
+    () => unscheduledTasks.some(t => t.bucketId && !t.archived && t.completed && isVisibleForUser(t)),
+    [unscheduledTasks, isVisibleForUser]
   );
   const hiddenCount = useMemo(
     () => unscheduledTasks.filter(t => t.bucketId === 'b2' && !t.archived && !t.completed && isVisibleForUser(t)).length,

--- a/src/components/FramesModal.jsx
+++ b/src/components/FramesModal.jsx
@@ -7,6 +7,7 @@ import SmartSchedulePanel from './SmartSchedulePanel.jsx';
 import UserOwnerSwitcher from './UserOwnerSwitcher.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { notBucketed } from '../utils/bucketList.js';
 
 const FramesModal = () => {
   const { t } = useTranslation();
@@ -170,7 +171,7 @@ const FramesModal = () => {
           {aiConfig?.enabled && aiConfig.features?.smartScheduling && framesModalTab === 'schedule' && (
             <SmartSchedulePanel
               aiConfig={aiConfig}
-              inboxTasks={unscheduledTasks.filter(t => !t.completed && !t.isExample)}
+              inboxTasks={unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample)}
               smartScheduleResults={smartScheduleResults}
               smartScheduleLoading={smartScheduleLoading}
               smartScheduleError={smartScheduleError}

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -4,7 +4,7 @@ import {
   Calendar, CalendarClock, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronUp, Clock, Filter, Flag, Hash, Inbox, LayoutGrid, Loader,
   Mic, Minus, Moon, Plus, RefreshCw, Search,
-  Settings, Sparkles, Sun, Target, Trash2, X, Zap,
+  Settings, Sparkles, Sun, Target, Telescope, Trash2, X, Zap,
 } from 'lucide-react';
 import { renderTitle } from '../utils/textFormatting.jsx';
 import GoalRing from './GoalRing.jsx';
@@ -19,6 +19,7 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { getGlanceHGInstances, isHGSessionReachable } from '../hooks/useHyperGlance.js';
 import { useTranslation } from 'react-i18next';
+import { notBucketed } from '../utils/bucketList.js';
 
 const GlanceSidebar = ({ variant = 'desktop' }) => {
   const {
@@ -106,6 +107,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     computeAvailableSlots,
     openFrameSchedule,
     showVoiceInput, setShowVoiceInput,
+    setShowBucketList,
     voiceCanRecord,
     healthPerms,
     isVisibleForUser,
@@ -256,6 +258,13 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
         <Mic size={16} />
       </button>
     )}
+    <button
+      onClick={() => setShowBucketList(true)}
+      className={`flex-shrink-0 self-stretch flex items-center px-2.5 rounded-lg transition-colors ${darkMode ? 'bg-white/10 text-sky-400' : 'bg-black/5 text-sky-600'} hover:opacity-80`}
+      title={t('bucket.title')}
+    >
+      <Telescope size={16} />
+    </button>
   </div>}
 
   {/* Habits / Goals carousel */}
@@ -531,7 +540,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
         {morningGlanceText && !morningGlanceLoading && (
           <p className={`text-sm leading-relaxed ${textPrimary}`}>{morningGlanceText}</p>
         )}
-        {morningGlanceText && !morningGlanceLoading && aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
+        {morningGlanceText && !morningGlanceLoading && aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample).length > 0 && (
           <button
             onClick={() => isTray ? openMainAt({ action: 'schedule-inbox' }) : (setShowFramesModal(true), setFramesModalTab('schedule'), setEditingFrame(null))}
             className={`mt-2 flex items-center gap-1.5 text-xs font-medium transition-colors ${darkMode ? 'text-purple-400 hover:text-purple-300' : 'text-purple-600 hover:text-purple-700'}`}

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -71,6 +71,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     setHideProjectTasksInbox, setHideStandaloneTasksInbox,
     goToDate, scrollToHour, effectiveViewMode,
     glancePage, setGlancePage,
+    setShowBucketList,
   } = useDayPlannerCtx();
   const {
     habitLongPressTimer,
@@ -107,7 +108,6 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     computeAvailableSlots,
     openFrameSchedule,
     showVoiceInput, setShowVoiceInput,
-    setShowBucketList,
     voiceCanRecord,
     healthPerms,
     isVisibleForUser,

--- a/src/components/InboxArchivedBar.jsx
+++ b/src/components/InboxArchivedBar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Archive, ChevronDown, RotateCcw } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { notBucketed } from '../utils/bucketList.js';
 
 const InboxArchivedBar = () => {
   const {
@@ -13,7 +14,7 @@ const InboxArchivedBar = () => {
   } = useDayPlannerCtx();
   const { goalsProjectsEnabled, projects } = useFeaturesCtx();
 
-  const archivedTasks = unscheduledTasks.filter(t => t.archived && !t.imported);
+  const archivedTasks = unscheduledTasks.filter(t => notBucketed(t) && t.archived && !t.imported);
 
   if (archivedTasks.length === 0) return null;
 

--- a/src/components/InboxFilterPopover.jsx
+++ b/src/components/InboxFilterPopover.jsx
@@ -5,6 +5,7 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { extractTags } from '../utils/taskUtils.js';
 import { useTranslation } from 'react-i18next';
+import { notBucketed } from '../utils/bucketList.js';
 
 /**
  * Popover for inbox filtering. Attach a ref to the trigger button and pass it
@@ -57,7 +58,7 @@ const InboxFilterPopover = ({ open, onClose, buttonRef }) => {
   // Tags and projects present in inbox tasks
   const inboxTags = useMemo(() => {
     const tagSet = new Set();
-    unscheduledTasks.forEach(t => extractTags(t.title).forEach(tag => tagSet.add(tag)));
+    unscheduledTasks.filter(notBucketed).forEach(t => extractTags(t.title).forEach(tag => tagSet.add(tag)));
     return Array.from(tagSet).sort();
   }, [unscheduledTasks]);
 

--- a/src/components/InboxSidebar.jsx
+++ b/src/components/InboxSidebar.jsx
@@ -2,7 +2,7 @@ import React, { useState, useRef } from 'react';
 import {
   AlertCircle, Archive, BookOpen, BrainCircuit,
   Calendar, Check, CheckSquare, ExternalLink,
-  FileText, Filter, Inbox, Pencil, Plus, Settings,
+  FileText, Filter, Inbox, Pencil, Plus, Settings, Telescope,
 } from 'lucide-react';
 import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
 import { dateToString, extractWikilinks, formatDeadlineDate } from '../utils/taskUtils.js';
@@ -14,6 +14,7 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { useTranslation } from 'react-i18next';
+import { notBucketed } from '../utils/bucketList.js';
 
 const InboxSidebar = ({ variant = 'desktop' }) => {
   const {
@@ -41,6 +42,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
     applySuggestionForEdit,
     cyclePriority,
     archiveInboxTask,
+    sendTaskToBucket,
     openMobileEditTask,
     updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
     handleDragStart, handleDragEnd,
@@ -97,7 +99,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
           <Plus size={14} strokeWidth={3} />
           <span className="text-xs font-medium">{t('common.newTask')}</span>
         </button>
-        {aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
+        {aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample).length > 0 && (
           <button
             onClick={() => { setShowFramesModal(true); setFramesModalTab('schedule'); setEditingFrame(null); }}
             className="px-2.5 flex items-center justify-center gap-1 py-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
@@ -109,7 +111,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
         )}
       </div>
       <div className="flex items-center gap-0.5">
-        {unscheduledTasks.filter(t => !t.deadline).length > 0 && (
+        {unscheduledTasks.filter(t => notBucketed(t) && !t.deadline).length > 0 && (
           <>
             <button
               ref={node => { if (node) inboxFilterBtnRef.current = node; }}
@@ -323,6 +325,15 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
                   >
                     <Pencil size={14} />
                   </button>
+                  {!task.completed && (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); sendTaskToBucket(task.id); }}
+                      className="hover:bg-white/20 rounded p-1 transition-colors opacity-40 hover:opacity-100"
+                      title={t('bucket.sendToBucket')}
+                    >
+                      <Telescope size={14} />
+                    </button>
+                  )}
                 </div>
                 <div className="flex items-center justify-between mt-1">
                   {task.completed ? (
@@ -400,7 +411,7 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
       >
         <Plus size={16} strokeWidth={3} />
       </button>
-      {aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
+      {aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample).length > 0 && (
         <button
           onClick={() => { setShowFramesModal(true); setFramesModalTab('schedule'); setEditingFrame(null); }}
           className="p-2 flex items-center justify-center bg-blue-600 text-white rounded-lg active:bg-blue-700 transition-colors"
@@ -445,25 +456,25 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
       <div className="flex flex-col items-center justify-center py-12 px-6">
         <div className={`relative w-16 h-16 rounded-2xl ${darkMode ? 'bg-emerald-500/15' : 'bg-emerald-50'} flex items-center justify-center mb-4`}>
           <Inbox size={28} className={`${darkMode ? 'text-emerald-400' : 'text-emerald-500'}`} />
-          {unscheduledTasks.filter(t => !t.isExample).length === 0 && (
+          {unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0 && (
             <Check size={14} className={`absolute -top-1 -right-1 ${darkMode ? 'text-emerald-400' : 'text-emerald-500'}`} />
           )}
         </div>
         <p className={`text-base font-semibold ${textPrimary} mb-1`}>
-          {unscheduledTasks.filter(t => !t.isExample).length === 0
+          {unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0
             ? "Inbox zero"
-            : unscheduledTasks.filter(t => !t.isExample).length === 0
+            : unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0
               ? "All overdue"
               : "No matches"}
         </p>
         <p className={`text-sm ${textSecondary} text-center mb-5`}>
-          {unscheduledTasks.filter(t => !t.isExample).length === 0
+          {unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0
             ? "Add tasks here to schedule later"
-            : unscheduledTasks.filter(t => !t.isExample).length === 0
+            : unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0
               ? "All inbox tasks have overdue deadlines"
               : "No tasks match the current filter"}
         </p>
-        {unscheduledTasks.filter(t => !t.isExample).length === 0 && (
+        {unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0 && (
           <button
             onClick={openNewInboxTask}
             className={`flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium ${darkMode ? 'bg-emerald-500 text-white active:bg-emerald-600' : 'bg-emerald-500 text-white active:bg-emerald-600'} transition-colors`}
@@ -603,6 +614,15 @@ const InboxSidebar = ({ variant = 'desktop' }) => {
                         />
                       )}
                     </div>
+                    {!task.completed && (
+                      <button
+                        onClick={(e) => { e.stopPropagation(); sendTaskToBucket(task.id); }}
+                        className="hover:bg-white/20 rounded p-1 transition-colors opacity-40 hover:opacity-100"
+                        title={t('bucket.sendToBucket')}
+                      >
+                        <Telescope size={14} />
+                      </button>
+                    )}
                   </div>
                   <div className="flex items-center justify-between w-full">
                     {task.completed ? (

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -76,6 +76,7 @@ const MobileGlanceSection = () => {
     goToDate, scrollToHour,
     glancePage, setGlancePage,
     mobileViewMode,
+    setShowBucketList,
   } = useDayPlannerCtx();
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
   const {
@@ -115,7 +116,6 @@ const MobileGlanceSection = () => {
     getFrameInstancesForDate, computeAvailableSlots,
     openFrameSchedule,
     showVoiceInput, setShowVoiceInput,
-    setShowBucketList,
     voiceCanRecord,
     healthPerms,
     isVisibleForUser,

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -4,7 +4,7 @@ import {
   Calendar, CalendarClock, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronUp, Clock, ExternalLink, FileText, Filter, Flag, Inbox, LayoutGrid,
   Loader, Mic, Minus, Moon, Plus, RefreshCw,
-  Search, Settings, Sparkles, Sun, Target, Trash2, X, Zap,
+  Search, Settings, Sparkles, Sun, Target, Telescope, Trash2, X, Zap,
 } from 'lucide-react';
 import { renderTitle, renderFormattedText, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
 import { dateToString, extractTags, extractWikilinks, formatDeadlineDate } from '../utils/taskUtils.js';
@@ -21,6 +21,7 @@ import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { getGlanceHGInstances, isHGSessionReachable } from '../hooks/useHyperGlance.js';
 import { useTranslation } from 'react-i18next';
+import { notBucketed } from '../utils/bucketList.js';
 
 const MobileGlanceSection = () => {
   const {
@@ -114,6 +115,7 @@ const MobileGlanceSection = () => {
     getFrameInstancesForDate, computeAvailableSlots,
     openFrameSchedule,
     showVoiceInput, setShowVoiceInput,
+    setShowBucketList,
     voiceCanRecord,
     healthPerms,
     isVisibleForUser,
@@ -164,6 +166,13 @@ const MobileGlanceSection = () => {
         <Mic size={16} />
       </button>
     )}
+    <button
+      onClick={() => setShowBucketList(true)}
+      className={`flex-shrink-0 px-2.5 self-stretch flex items-center rounded-lg transition-colors ${darkMode ? 'bg-white/10 text-sky-400' : 'bg-black/5 text-sky-600'}`}
+      title={t('bucket.title')}
+    >
+      <Telescope size={16} />
+    </button>
   </div>
   {/* Habits / Goals carousel */}
   {(() => {
@@ -438,7 +447,7 @@ const MobileGlanceSection = () => {
         {morningGlanceText && !morningGlanceLoading && (
           <p className={`text-sm leading-relaxed ${textPrimary}`}>{morningGlanceText}</p>
         )}
-        {morningGlanceText && !morningGlanceLoading && aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
+        {morningGlanceText && !morningGlanceLoading && aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample).length > 0 && (
           <button
             onClick={() => { setMobileActiveTab('settings'); setMobileSettingsView('frames'); setFramesModalTab('schedule'); }}
             className={`mt-2 flex items-center gap-1.5 text-xs font-medium transition-colors ${darkMode ? 'text-purple-400 hover:text-purple-300' : 'text-purple-600 hover:text-purple-700'}`}

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -42,6 +42,7 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import InboxFilterPopover from './InboxFilterPopover.jsx';
 import InboxArchivedBar from './InboxArchivedBar.jsx';
 import { useTranslation } from 'react-i18next';
+import { notBucketed } from '../utils/bucketList.js';
 
 const MobileLayout = () => {
   const [tzBannerDismissed, setTzBannerDismissed] = useState(false);
@@ -589,7 +590,7 @@ const MobileLayout = () => {
                       <Plus size={14} strokeWidth={3} />
                       <span className="text-xs font-medium">{t('common.newTask')}</span>
                     </button>
-                    {aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => !t.completed && !t.isExample).length > 0 && (
+                    {aiConfig?.enabled && aiConfig.features?.smartScheduling && myFrames.filter(f => f.enabled).length > 0 && unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample).length > 0 && (
                       <button
                         onClick={() => { setMobileActiveTab('settings'); setMobileSettingsView('frames'); setFramesModalTab('schedule'); setEditingFrame(null); }}
                         className="flex items-center justify-center gap-1 px-2.5 py-1.5 bg-blue-600 text-white rounded-lg active:bg-blue-700 transition-colors"
@@ -880,25 +881,25 @@ const MobileLayout = () => {
                     <div className="flex flex-col items-center justify-center py-12 px-6">
                       <div className={`relative w-16 h-16 rounded-2xl ${darkMode ? 'bg-emerald-500/15' : 'bg-emerald-50'} flex items-center justify-center mb-4`}>
                         <Inbox size={28} className={`${darkMode ? 'text-emerald-400' : 'text-emerald-500'}`} />
-                        {unscheduledTasks.filter(t => !t.isExample).length === 0 && (
+                        {unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0 && (
                           <Check size={14} className={`absolute -top-1 -right-1 ${darkMode ? 'text-emerald-400' : 'text-emerald-500'}`} />
                         )}
                       </div>
                       <p className={`text-base font-semibold ${textPrimary} mb-1`}>
-                        {unscheduledTasks.filter(t => !t.isExample).length === 0
+                        {unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0
                           ? "Inbox zero"
-                          : unscheduledTasks.filter(t => !t.isExample).length === 0
+                          : unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0
                             ? "All overdue"
                             : "No matches"}
                       </p>
                       <p className={`text-sm ${textSecondary} text-center mb-5`}>
-                        {unscheduledTasks.filter(t => !t.isExample).length === 0
+                        {unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0
                           ? "Add tasks here to schedule later"
-                          : unscheduledTasks.filter(t => !t.isExample).length === 0
+                          : unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0
                             ? "All inbox tasks have overdue deadlines"
                             : "No tasks match the current filter"}
                       </p>
-                      {unscheduledTasks.filter(t => !t.isExample).length === 0 && (
+                      {unscheduledTasks.filter(t => notBucketed(t) && !t.isExample).length === 0 && (
                         <button
                           onClick={openNewInboxTask}
                           className={`flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium ${darkMode ? 'bg-emerald-500 text-white active:bg-emerald-600' : 'bg-emerald-500 text-white active:bg-emerald-600'} transition-colors`}

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BookOpen, Calendar, Check, Loader, Sparkles, X } from 'lucide-react';
+import { BookOpen, Calendar, Check, Loader, Sparkles, Telescope, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -28,6 +28,7 @@ const MobileNewTaskModal = () => {
     setShowDatePicker, setShowTimePicker, setShowRecurrenceEndDatePicker,
     addTask, saveMobileEditTask, saveMobileEditNativeEvent,
     moveToRecycleBin, clearNativeEventOverride,
+    sendTaskToBucket,
     handleNewTaskInputChange,
   } = useDayPlannerCtx();
   const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, triggerTaskAISuggestion, goals, projects, goalsProjectsEnabled, multiUserEnabled, users } = useFeaturesCtx();
@@ -546,6 +547,23 @@ const MobileNewTaskModal = () => {
                   {mobileEditingTask ? t('task.saveChanges') : newTask.openInInbox ? (newTask.projectId ? t('task.addToProject') : t('task.addToInbox')) : newTask.projectId && newTask.keepUnscheduled ? t('task.addToProject') : newTask.projectId ? t('task.addToProjectAndSchedule') : t('task.addToSchedule')}
                 </button>
               </div>
+
+              {/* Send-to-Bucket for inbox tasks in edit mode */}
+              {mobileEditingTask && mobileEditIsInbox && !mobileEditingTask.bucketId && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    sendTaskToBucket(mobileEditingTask.id);
+                    setShowAddTask(false);
+                    setMobileEditingTask(null);
+                    setMobileEditIsInbox(false);
+                  }}
+                  className={`w-full px-4 py-3 rounded-lg font-medium flex items-center justify-center gap-2 ${darkMode ? 'bg-sky-900/40 text-sky-300 hover:bg-sky-900/60' : 'bg-sky-50 text-sky-700 hover:bg-sky-100'}`}
+                >
+                  <Telescope size={16} />
+                  {t('bucket.sendToBucket')}
+                </button>
+              )}
 
               {/* Delete button for edit mode */}
               {mobileEditingTask && (

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -36,6 +36,7 @@ import { ensureVaultIntentsKey, setupVaultIntentsEncryption } from '../intents/v
 import { flushOutboxNow } from '../intents/useOutboxFlush.js';
 import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
 import { useTranslation } from 'react-i18next';
+import { notBucketed } from '../utils/bucketList.js';
 
 const MobileSettingsPanel = () => {
   const {
@@ -2354,7 +2355,7 @@ const MobileSettingsPanel = () => {
       {aiConfig?.enabled && aiConfig.features?.smartScheduling && framesModalTab === 'schedule' && (
         <SmartSchedulePanel
           aiConfig={aiConfig}
-          inboxTasks={unscheduledTasks.filter(t => !t.completed && !t.isExample)}
+          inboxTasks={unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample)}
           smartScheduleResults={smartScheduleResults}
           smartScheduleLoading={smartScheduleLoading}
           smartScheduleError={smartScheduleError}

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -7,6 +7,7 @@ import { getOccurrencesInRange } from '../utils/recurrenceEngine.js';
 import { calculateProjectProgress, isProjectStalled } from '../utils/projectProgress.js';
 import { calculateGoalProgress } from '../utils/goalProgress.js';
 import { useTranslation } from 'react-i18next';
+import { notBucketed } from '../utils/bucketList.js';
 
 const WeeklyReviewModal = () => {
   const {
@@ -477,7 +478,7 @@ const WeeklyReviewModal = () => {
           bestDayCount,
           incompleteCount: pastIncomplete.length,
           tagBreakdown,
-          inboxCount: unscheduledTasks.filter(t => !t.completed && !t.isExample && (!goalsProjectsEnabled || !t.projectId)).length,
+          inboxCount: unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample && (!goalsProjectsEnabled || !t.projectId)).length,
           projectTaskCount: goalsProjectsEnabled ? unscheduledTasks.filter(t => !t.completed && !t.isExample && t.projectId).length : 0,
           nextWeekTaskCount: nextScheduled,
           nextWeekTopTasks,

--- a/src/hooks/useComputedViews.js
+++ b/src/hooks/useComputedViews.js
@@ -1,5 +1,6 @@
 import { useMemo, useCallback } from 'react';
 import { dateToString, extractTags } from '../utils/taskUtils.js';
+import { notBucketed } from '../utils/bucketList.js';
 
 export default function useComputedViews({
   tasks,
@@ -64,6 +65,10 @@ export default function useComputedViews({
   // If the feature is toggled off, the exclusion is lifted so nothing is hidden.
   const filteredUnscheduledTasks = useMemo(
     () => unscheduledTasks
+      // Bucket List items never appear in the Inbox — unconditional (unlike
+      // the user-toggleable project exclusion below). The Inbox nags; the
+      // Bucket doesn't.
+      .filter(notBucketed)
       .filter(task => !task.archived)
       // Multi-user: only show tasks assigned to "me" (or unassigned). Other
       // surfaces already filter via isVisibleForUser; the inbox list was the

--- a/src/hooks/useDailyBriefings.js
+++ b/src/hooks/useDailyBriefings.js
@@ -6,6 +6,7 @@ import {
 } from '../ai-prompts.js';
 import { dateToString, localDateStr } from '../utils/taskUtils.js';
 import { getOccurrencesInRange } from '../utils/recurrenceEngine.js';
+import { notBucketed } from '../utils/bucketList.js';
 
 /**
  * AI daily briefings — extracted from App.jsx (see "App.jsx — Ongoing
@@ -55,18 +56,18 @@ export default function useDailyBriefings({
         return occs.map(() => ({ title: t.title, time: t.startTime, completed: (t.completedDates || []).includes(todayStr) }));
       }).filter(t => !t.completed);
       // Inbox count — split into free inbox tasks vs project-assigned tasks
-      const activeUnscheduled = unscheduledTasks.filter(t => !t.completed && !t.isExample && isVisibleForUser(t));
+      const activeUnscheduled = unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample && isVisibleForUser(t));
       const inboxCount = activeUnscheduled.filter(t => !goalsProjectsEnabled || !t.projectId).length;
       const projectTaskCount = goalsProjectsEnabled ? activeUnscheduled.filter(t => t.projectId).length : 0;
       // Overdue tasks
       const overdue = getOverdueTasks();
       const overdueTasks = overdue.filter(t => t.date !== todayStr).slice(0, 5);
       // Deadlines
-      const deadlinesToday = unscheduledTasks.filter(t => t.deadline === todayStr && !t.completed && isVisibleForUser(t));
+      const deadlinesToday = unscheduledTasks.filter(t => notBucketed(t) && t.deadline === todayStr && !t.completed && isVisibleForUser(t));
       const nextWeek = new Date(todayDate);
       nextWeek.setDate(nextWeek.getDate() + 7);
       const nextWeekStr = dateToString(nextWeek);
-      const upcomingDeadlines = unscheduledTasks.filter(t => t.deadline && t.deadline > todayStr && t.deadline <= nextWeekStr && !t.completed && isVisibleForUser(t)).slice(0, 5);
+      const upcomingDeadlines = unscheduledTasks.filter(t => notBucketed(t) && t.deadline && t.deadline > todayStr && t.deadline <= nextWeekStr && !t.completed && isVisibleForUser(t)).slice(0, 5);
       // Total minutes
       const totalMinutes = scheduledToday.reduce((s, t) => s + (t.duration || 0), 0)
         + todayRecurring.reduce((s, t) => s + 30, 0) // recurring default 30
@@ -154,7 +155,7 @@ export default function useDailyBriefings({
         .map(t => ({ title: t.title, time: t.startTime, isAllDay: t.isAllDay || false }))
         .sort((a, b) => (a.time || '').localeCompare(b.time || ''));
       // For suggestions, only surface free inbox tasks — project tasks have their own home
-      const inboxItems = unscheduledTasks.filter(t => !t.completed && !t.isExample && (!goalsProjectsEnabled || !t.projectId) && isVisibleForUser(t))
+      const inboxItems = unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample && (!goalsProjectsEnabled || !t.projectId) && isVisibleForUser(t))
         .sort((a, b) => (b.priority || 0) - (a.priority || 0));
 
       const total = completedToday.length + incompleteToday.length;

--- a/src/hooks/useDeadlinePriority.js
+++ b/src/hooks/useDeadlinePriority.js
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
+import { notBucketed } from '../utils/bucketList.js';
 
 export default function useDeadlinePriority({
   unscheduledTasks,
@@ -19,7 +20,7 @@ export default function useDeadlinePriority({
   const getDeadlineTasksForDate = (dateStr) => {
     const todayStr = dateToString(new Date());
     return unscheduledTasks.filter(t =>
-      t.deadline === dateStr && (t.deadline >= todayStr || t.completed) && isVisibleForUser(t)
+      notBucketed(t) && t.deadline === dateStr && (t.deadline >= todayStr || t.completed) && isVisibleForUser(t)
     );
   };
 

--- a/src/hooks/useModalClose.js
+++ b/src/hooks/useModalClose.js
@@ -23,6 +23,7 @@ export default function useModalClose({
   showAddTask, setShowAddTask, setShowNewTaskDeadlinePicker,
   showRecurrencePicker, setShowRecurrencePicker,
   focusLogModalDate, setFocusLogModalDate,
+  showBucketList, setShowBucketList,
 }) {
   useEffect(() => {
     const handleEscape = (e) => {
@@ -141,6 +142,12 @@ export default function useModalClose({
         }
         return;
       }
+      // After showAddTask so a task editor opened from the Bucket List closes first.
+      if (showBucketList) {
+        e.preventDefault();
+        setShowBucketList(false);
+        return;
+      }
     };
 
     document.addEventListener('keydown', handleEscape);
@@ -148,5 +155,5 @@ export default function useModalClose({
     // Deps list the open-modal flags the Escape handler branches on. The only
     // omitted names are the setX state setters, which React guarantees are stable.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focusLogModalDate, taskContextMenu, timelineContextMenu, quickAddFrameModal, frameContextMenu, frameAdjustModal, frameScheduleModal, showFramesModal, showSpotlight, showHelpModal, showShortcutHelp, editingRecurrenceTaskId, showMonthView, showAutoBackupManager, showBackupMenu, showVoiceInput, showSettings, showRemindersSettings, showWeeklyReview, showMobileDailySummary, showAddTask, showRecurrencePicker]);
+  }, [focusLogModalDate, taskContextMenu, timelineContextMenu, quickAddFrameModal, frameContextMenu, frameAdjustModal, frameScheduleModal, showFramesModal, showSpotlight, showHelpModal, showShortcutHelp, editingRecurrenceTaskId, showMonthView, showAutoBackupManager, showBackupMenu, showVoiceInput, showSettings, showRemindersSettings, showWeeklyReview, showMobileDailySummary, showAddTask, showRecurrencePicker, showBucketList]);
 }

--- a/src/hooks/useStats.js
+++ b/src/hooks/useStats.js
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { dateToString } from '../utils/taskUtils.js';
 import { getOccurrencesInRange } from '../utils/recurrenceEngine.js';
+import { notBucketed } from '../utils/bucketList.js';
 
 export default function useStats({ tasks: rawTasks, unscheduledTasks: rawUnscheduled, recurringTasks: rawRecurring, goals: rawGoals = [], projects: rawProjects = [], isVisibleForUser = () => true }) {
   const todayStr = dateToString(new Date());
@@ -22,7 +23,7 @@ export default function useStats({ tasks: rawTasks, unscheduledTasks: rawUnsched
   );
 
   const deadlineInboxTasks = useMemo(
-    () => unscheduledTasks.filter(t => t.deadline && t.deadline <= todayStr),
+    () => unscheduledTasks.filter(t => notBucketed(t) && t.deadline && t.deadline <= todayStr),
     [unscheduledTasks, todayStr]
   );
 
@@ -71,7 +72,7 @@ export default function useStats({ tasks: rawTasks, unscheduledTasks: rawUnsched
       isRecurring: true,
     }));
   });
-  const todayDeadlineInboxTasks = unscheduledTasks.filter(t => t.deadline === actualTodayStr);
+  const todayDeadlineInboxTasks = unscheduledTasks.filter(t => notBucketed(t) && t.deadline === actualTodayStr);
   const actualTodayTasks = [
     ...tasks.filter(t => t.date === actualTodayStr),
     ...todayRecurringInstances,
@@ -87,10 +88,10 @@ export default function useStats({ tasks: rawTasks, unscheduledTasks: rawUnsched
     + deadlineInboxTasks.reduce((sum, t) => sum + (t.focusMinutes || 0), 0);
 
   // Inbox completion stats — pure inbox only (no projectId, no deadline)
-  const inboxCompletedToday = unscheduledTasks.filter(t => t.completed && !t.deadline && !t.projectId && t.completedAt && t.completedAt.startsWith(todayStr));
+  const inboxCompletedToday = unscheduledTasks.filter(t => notBucketed(t) && t.completed && !t.deadline && !t.projectId && t.completedAt && t.completedAt.startsWith(todayStr));
   const inboxCompletedTodayCount = inboxCompletedToday.length;
   const inboxCompletedTodayMinutes = inboxCompletedToday.reduce((sum, t) => sum + (t.duration || 0), 0);
-  const allTimeInboxCompleted = unscheduledTasks.filter(t => t.completed && !t.deadline && !t.projectId);
+  const allTimeInboxCompleted = unscheduledTasks.filter(t => notBucketed(t) && t.completed && !t.deadline && !t.projectId);
   const allTimeInboxCompletedCount = allTimeInboxCompleted.length;
   const allTimeInboxCompletedMinutes = allTimeInboxCompleted.reduce((sum, t) => sum + (t.duration || 0), 0);
 
@@ -185,7 +186,7 @@ export default function useStats({ tasks: rawTasks, unscheduledTasks: rawUnsched
         }
       });
     });
-    const deadlineInboxIncomplete = unscheduledTasks.filter(t => t.deadline && t.deadline <= todayStr && !t.completed && !isTodayAndFuture(t));
+    const deadlineInboxIncomplete = unscheduledTasks.filter(t => notBucketed(t) && t.deadline && t.deadline <= todayStr && !t.completed && !isTodayAndFuture(t));
     return [...regularIncomplete, ...recurringIncomplete, ...deadlineInboxIncomplete]
       .sort((a, b) => ((a.date || a.deadline || '').localeCompare(b.date || b.deadline || '')) || (a.startTime || '').localeCompare(b.startTime || ''));
   }, [nonImportedTasks, recurringTasks, todayStr, unscheduledTasks]);

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -1,4 +1,5 @@
 import { cleanTitle } from '../utils/suggestionParser.js';
+import { stripBucketId } from '../utils/bucketList.js';
 import { dateToString, extractTags, formatDeadlineDate } from '../utils/taskUtils.js';
 import { TASK_COLORS } from '../utils/colorUtils.js';
 import { triggerHaptic } from '../native.js';
@@ -710,7 +711,7 @@ export default function useTaskActions({
       const task = unscheduledTasks.find(t => t.id === taskId);
       if (!task) return;
       setUnscheduledTasks(prev => prev.filter(t => t.id !== taskId));
-      setTasks(prev => [...prev, { ...task, startTime: nextSlotTime, date: todayStr, isAllDay: false }]);
+      setTasks(prev => [...prev, { ...stripBucketId(task), startTime: nextSlotTime, date: todayStr, isAllDay: false }]);
     } else {
       setTasks(prev => prev.map(t => t.id === taskId ? { ...t, startTime: nextSlotTime, date: todayStr } : t));
     }

--- a/src/hooks/useVoiceInput.js
+++ b/src/hooks/useVoiceInput.js
@@ -3,6 +3,7 @@ import { aiTranscribe, aiJSON, supportsTranscription } from '../ai.js';
 import { voiceParseSystemPrompt, voiceParseUserPrompt } from '../ai-prompts.js';
 import { nativeStartRecording, nativeStopRecording, triggerHaptic } from '../native.js';
 import { dateToString } from '../utils/taskUtils.js';
+import { notBucketed } from '../utils/bucketList.js';
 
 /**
  * Voice input pipeline — extracted from App.jsx (see "App.jsx — Ongoing
@@ -234,7 +235,7 @@ export default function useVoiceInput({
       lines.push(d);
     });
     // Inbox tasks (uncompleted)
-    unscheduledTasks.filter(t => !t.completed && !t.isExample).slice(0, 20).forEach(t => {
+    unscheduledTasks.filter(t => notBucketed(t) && !t.completed && !t.isExample).slice(0, 20).forEach(t => {
       let d = `"${t.title}" — inbox, ${t.duration || 30}min`;
       if (t.priority > 0) d += `, priority: ${['none', 'low', 'medium', 'high'][t.priority]}`;
       if (t.deadline) d += `, deadline: ${t.deadline}`;

--- a/src/trmnl.js
+++ b/src/trmnl.js
@@ -8,6 +8,7 @@
  */
 
 import { getOccurrencesInRange } from './utils/recurrenceEngine.js';
+import { notBucketed } from './utils/bucketList.js';
 
 // ---------------------------------------------------------------------------
 // Data helpers
@@ -144,7 +145,7 @@ export function gatherTrmnlData({
   const nextTask = upcoming[0] || null;
 
   // Inbox count — standalone tasks only (exclude those tied to a project)
-  const inboxCount = unscheduledTasks.filter((t) => !t.completed && !t.projectId).length;
+  const inboxCount = unscheduledTasks.filter((t) => notBucketed(t) && !t.completed && !t.projectId).length;
 
   // Habits summary
   const todayLogs = habitLogs[today] || {};

--- a/src/utils/bucketList.js
+++ b/src/utils/bucketList.js
@@ -1,0 +1,88 @@
+// Bucket List — someday/maybe space for pre-commitment tasks.
+//
+// Bucket items ARE unscheduledTasks (same array, same sync/backup/undo/
+// recycle-bin machinery for free) distinguished by a `bucketId` field, and
+// EXCLUDED from all Inbox behavior: lists, counts, auto-archive, overdue/
+// deadline/priority machinery, frame- and smart-scheduling. The Inbox nags;
+// the Bucket doesn't.
+//
+// Exactly two lists ('b1' | 'b2') — user-editable headings live in the synced
+// bucketConfig, the ids are stable. Deliberately capped at two: more lists is
+// Kanban sneaking back in.
+
+export const BUCKET_LIST_IDS = ['b1', 'b2'];
+
+export const DEFAULT_BUCKET_CONFIG = {
+  headings: { b1: 'Someday', b2: 'Anytime' },
+  secondListHidden: false,
+  notes: '',
+};
+
+/** True when a task lives in the Bucket List (any list). */
+export const isBucketTask = (task) => !!task?.bucketId;
+
+/**
+ * The unconditional Inbox exclusion. Applied at every unscheduledTasks
+ * consumer that feeds Inbox lists, counts, or nag machinery — ahead of the
+ * feature-gated project filters (unlike hideProjectTasksInbox, this is not
+ * user-toggleable).
+ */
+export const notBucketed = (task) => !task?.bucketId;
+
+/**
+ * Demote an Inbox task into the Bucket List (the main entry point in
+ * practice). Deadline and priority are STRIPPED — bucket items are
+ * pre-commitment, and hidden state that resurfaces as an instantly-overdue
+ * nag on promotion would be worse than losing it.
+ *
+ * @param {object} task  The inbox task.
+ * @param {string} [listId]  Target list; defaults to the first list.
+ */
+export const demoteToBucket = (task, listId = BUCKET_LIST_IDS[0]) => {
+  const { deadline, priority, ...rest } = task;
+  void deadline; void priority;
+  return {
+    ...rest,
+    bucketId: BUCKET_LIST_IDS.includes(listId) ? listId : BUCKET_LIST_IDS[0],
+    lastModified: new Date().toISOString(),
+  };
+};
+
+/**
+ * Promote a bucket item back to the Inbox: drop bucketId, start fresh
+ * (priority 0, no deadline — demotion already stripped them, but a synced
+ * item from an older client could still carry them).
+ */
+export const promoteToInbox = (task) => {
+  const { bucketId, deadline, priority, ...rest } = task;
+  void bucketId; void deadline; void priority;
+  return {
+    ...rest,
+    priority: 0,
+    lastModified: new Date().toISOString(),
+  };
+};
+
+/**
+ * Strip bucket membership for scheduling (schedule-to-next-slot on a bucket
+ * item): the scheduled copy must not carry bucketId.
+ */
+export const stripBucketId = (task) => {
+  const { bucketId, ...rest } = task;
+  void bucketId;
+  return rest;
+};
+
+/** Normalize a possibly-partial synced config against the defaults. */
+export const normalizeBucketConfig = (raw) => {
+  if (!raw || typeof raw !== 'object') return { ...DEFAULT_BUCKET_CONFIG };
+  return {
+    headings: {
+      b1: typeof raw.headings?.b1 === 'string' && raw.headings.b1.trim() ? raw.headings.b1 : DEFAULT_BUCKET_CONFIG.headings.b1,
+      b2: typeof raw.headings?.b2 === 'string' && raw.headings.b2.trim() ? raw.headings.b2 : DEFAULT_BUCKET_CONFIG.headings.b2,
+    },
+    secondListHidden: !!raw.secondListHidden,
+    notes: typeof raw.notes === 'string' ? raw.notes : '',
+    ...(raw.updatedAt ? { updatedAt: raw.updatedAt } : {}),
+  };
+};

--- a/src/utils/bucketList.test.js
+++ b/src/utils/bucketList.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BUCKET_LIST_IDS,
+  DEFAULT_BUCKET_CONFIG,
+  isBucketTask,
+  notBucketed,
+  demoteToBucket,
+  promoteToInbox,
+  stripBucketId,
+  normalizeBucketConfig,
+} from './bucketList.js';
+
+describe('predicates', () => {
+  it('isBucketTask / notBucketed split on bucketId', () => {
+    expect(isBucketTask({ bucketId: 'b1' })).toBe(true);
+    expect(isBucketTask({ bucketId: 'b2' })).toBe(true);
+    expect(isBucketTask({})).toBe(false);
+    expect(isBucketTask(null)).toBe(false);
+    expect(notBucketed({ bucketId: 'b1' })).toBe(false);
+    expect(notBucketed({ title: 'x' })).toBe(true);
+  });
+});
+
+describe('demoteToBucket', () => {
+  const inboxTask = {
+    id: 't1', title: 'Learn woodworking', duration: 30,
+    priority: 3, deadline: '2026-01-01', notes: 'someday', subtasks: [],
+  };
+
+  it('strips deadline and priority and lands in the first list by default', () => {
+    const bucketed = demoteToBucket(inboxTask);
+    expect(bucketed.bucketId).toBe('b1');
+    expect(bucketed).not.toHaveProperty('deadline');
+    expect(bucketed).not.toHaveProperty('priority');
+    expect(bucketed.title).toBe('Learn woodworking');
+    expect(bucketed.notes).toBe('someday');
+    expect(bucketed.lastModified).toBeTruthy();
+  });
+
+  it('accepts an explicit target list and rejects unknown ids', () => {
+    expect(demoteToBucket(inboxTask, 'b2').bucketId).toBe('b2');
+    expect(demoteToBucket(inboxTask, 'b9').bucketId).toBe('b1');
+  });
+
+  it('does not mutate the original', () => {
+    demoteToBucket(inboxTask);
+    expect(inboxTask.priority).toBe(3);
+    expect(inboxTask.deadline).toBe('2026-01-01');
+  });
+});
+
+describe('promoteToInbox', () => {
+  it('drops bucketId and starts fresh (priority 0, no deadline)', () => {
+    const promoted = promoteToInbox({ id: 't2', title: 'x', bucketId: 'b2' });
+    expect(promoted).not.toHaveProperty('bucketId');
+    expect(promoted.priority).toBe(0);
+    expect(promoted).not.toHaveProperty('deadline');
+    expect(promoted.lastModified).toBeTruthy();
+  });
+
+  it('clears stale deadline/priority from older clients', () => {
+    const promoted = promoteToInbox({ id: 't3', title: 'x', bucketId: 'b1', deadline: '2020-01-01', priority: 2 });
+    expect(promoted).not.toHaveProperty('deadline');
+    expect(promoted.priority).toBe(0);
+  });
+});
+
+describe('stripBucketId', () => {
+  it('removes only bucketId', () => {
+    const out = stripBucketId({ id: 't4', bucketId: 'b1', title: 'x', duration: 45 });
+    expect(out).toEqual({ id: 't4', title: 'x', duration: 45 });
+  });
+});
+
+describe('normalizeBucketConfig', () => {
+  it('returns defaults for missing/garbage input', () => {
+    expect(normalizeBucketConfig(null)).toEqual(DEFAULT_BUCKET_CONFIG);
+    expect(normalizeBucketConfig('nope')).toEqual(DEFAULT_BUCKET_CONFIG);
+  });
+
+  it('keeps valid values and fills gaps', () => {
+    const cfg = normalizeBucketConfig({ headings: { b1: 'Dreams' }, secondListHidden: true });
+    expect(cfg.headings.b1).toBe('Dreams');
+    expect(cfg.headings.b2).toBe('Anytime');
+    expect(cfg.secondListHidden).toBe(true);
+    expect(cfg.notes).toBe('');
+  });
+
+  it('rejects blank headings', () => {
+    expect(normalizeBucketConfig({ headings: { b1: '   ' } }).headings.b1).toBe('Someday');
+  });
+
+  it('preserves updatedAt for sync merges', () => {
+    expect(normalizeBucketConfig({ updatedAt: '2026-01-01T00:00:00Z' }).updatedAt).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('there are exactly two lists', () => {
+    expect(BUCKET_LIST_IDS).toHaveLength(2);
+  });
+});

--- a/src/utils/frameScheduleTasks.js
+++ b/src/utils/frameScheduleTasks.js
@@ -1,4 +1,5 @@
 import { extractTags } from './taskUtils.js';
+import { notBucketed } from './bucketList.js';
 
 // Builds the task list for the Manually Schedule (frame schedule) modal.
 //
@@ -27,6 +28,7 @@ export function filterFrameScheduleTasks(unscheduledTasks, {
   affinityOnly = false,
 } = {}) {
   return (unscheduledTasks || [])
+    .filter(notBucketed)
     .filter(t => !t.completed && !t.isExample && (!t.deadline || t.deadline === dateStr))
     .filter(t => isVisibleForUser(t))
     .filter(t => {


### PR DESCRIPTION
## Summary

**Bucket List** is a pressure-free someday/maybe space — a PLANNER without a project. Same shell (shared notes panel, task rows, quick-add, drag-to-reorder), opened from GLANCE via a Telescope header button. The Inbox nags; the Bucket doesn't.

> ⏸️ **Parked for v4.1.0** — do not merge until the release train opens (alongside #1267, #1268, #1269, #1270).

## How it works

- **Items are `unscheduledTasks` with a `bucketId`** (`b1`/`b2`), so cloud sync, backups, undo, and the recycle bin all work with zero new plumbing.
- **Excluded from all Inbox machinery** via a `notBucketed()` filter — unconditional, unlike the user-toggleable project exclusion. Covered consumers: the Inbox choke point in `useComputedViews`, auto-archive sweep, overdue/deadline chips, GLANCEahead, smart schedule, frame nudges/scheduling, weekly review, stats, morning/evening briefings, voice AI task context, TRMNL payload, native/widget payload, tag filter universe, and archived-bar (17 inline sites + the choke point, each count-verified).
- **Two lists max** with click-to-rename headings (defaults **Someday** / **Anytime**); the second list can be hidden. Deliberately capped at two — more lists is Kanban sneaking back in.
- **One shared notes panel** at bucket level (not per-list), saved on blur/close/unmount.
- **Config syncs**: headings, hidden state, and notes persist to `day-planner-bucket-config` and ride the cloud payload with whole-value LWW (the `gtdFrames` pattern).

## Promotion / demotion paths

- **Send to Bucket List** (the main entry point in practice): on desktop Inbox rows and in the mobile task editor. Demotion **strips deadline and priority** — the Bucket is deliberately pressure-free. Always lands in the first list. Undoable.
- **Send to Inbox**: promotes back with priority 0, no deadline. Undoable.
- **Schedule at next open slot** directly from a bucket row; `scheduleTaskAtNextSlot` now strips `bucketId` at the source (a no-op for normal tasks).
- Move between lists, edit (inbox-flavor editor, preserves `bucketId`), delete to recycle bin.

## UI details

- `BucketListModal` clones the ProjectPlanner shell: z-\[70\] between dashboard (60) and editor (80), sky-500 accent, Telescope icon, desktop side-by-side / mobile stacked sheet with sticky header, HTML5 drag + iOS grip-touch reorder through `reorderUnscheduledTasks` (sync-safe manual ordering), completed items sink with a show/hide toggle, Escape-close wired through `useModalClose` (after the task editor, so nesting closes in order).
- `bucket.*` translation keys added to all six locales (en/de/es/fr/it/pt), matching existing Inbox terminology per language.

## Testing

- New `src/utils/bucketList.test.js` (12 tests) covering demote/promote/strip semantics and config normalization.
- Full suite: **873 tests passing**, lint clean (`--max-warnings 0`), production build succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_