### PR TITLE
Gate the test-purchase reset to lifetime entitlements + honest dialog copy

### DIFF
--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -436,8 +436,10 @@ const MobileSettingsPanel = () => {
         confirmingPurchaseReset ? (
           <div className={`w-full ${cardBg} border border-red-500/40 rounded-xl p-3 space-y-2`}>
             <p className={`text-xs ${textSecondary} leading-relaxed`}>
-              This permanently revokes this account&apos;s purchase from Google Play.
-              It is not a refresh and cannot be undone. For internal testing only.
+              This permanently revokes this account&apos;s lifetime purchase from
+              Google Play. It is not a refresh and cannot be undone. It has no
+              effect on subscriptions: cancel in Google Play and let the
+              subscription expire instead. For internal testing only.
             </p>
             <div className="flex gap-2">
               <button

--- a/src/hooks/useSubscription.js
+++ b/src/hooks/useSubscription.js
@@ -76,7 +76,12 @@ export function useSubscription() {
     isAndroidApp:  !!BILLING,
     isIOSApp:      IOS,
     isElectronApp: ELECTRON,
-    canConsumeTestPurchase: billing.canConsumeTestPurchase,
+    // The dev-only "reset test purchase" tool goes through Play's consumeAsync,
+    // which only works on INAPP (lifetime) purchases — never subscriptions.
+    // Hide the tool when the active entitlement is the subscription so it
+    // can't offer a revoke that silently no-ops (subscriptions reset by
+    // cancelling in Play and waiting for expiry).
+    canConsumeTestPurchase: billing.canConsumeTestPurchase && billing.productId !== ANDROID_PRODUCTS.yearly,
     isLoading: billing.isLoading,
     subscribe: billing.subscribe,
     restore: billing.restore,


### PR DESCRIPTION
## Summary

The dev-only 7-tap "Reset test purchase" tool calls Play's `consumeAsync`, which only works on INAPP (lifetime) purchases — it silently no-ops on subscriptions. During internal testing that reads as a broken revoke (paywall flashes, then the still-active subscription unlocks again). Two small changes make the tool honest:

- **Gating** (`useSubscription.js`): `canConsumeTestPurchase` is now false when the active entitlement is the subscription product (`dayglance_pro_annual`), so the tool doesn't render at all when it couldn't do anything. Lifetime and unknown/provisional entitlements keep the current behavior.
- **Copy** (`MobileSettingsPanel.jsx`): the confirm dialog now says it revokes the *lifetime* purchase and states plainly that subscriptions reset by cancelling in Google Play and waiting for expiry.

No native changes needed — `consumePurchase` in dayglance-android is untouched, and no end-user-facing behavior changes (the tool is behind the adapter capability check, 7 taps, and a confirm dialog).

## Testing

Full suite passing (987 tests), lint clean (`--max-warnings 0`), production build succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_