### PR TITLE
Ungate the V voice shortcut; add U shortcut for the Bucket List

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3092,6 +3092,7 @@ const DayPlanner = () => {
     setShowBackupMenu,
     isMobile, tabletActiveTab, setTabletActiveTab,
     aiConfig, setShowVoiceInput,
+    showBucketList, setShowBucketList,
     habitsEnabled, setHabitsEnabled, setShowHabitModal,
     goalsProjectsEnabled, setGoalsProjectsEnabled, showGoalsDashboard, setShowGoalsDashboard,
     gtdFrames: myFrames, setShowRescheduleModal, setRescheduleResults, setRescheduleError,

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -264,7 +264,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     <button
       onClick={() => setShowBucketList(true)}
       className={`flex-shrink-0 self-stretch flex items-center px-2.5 rounded-lg transition-colors ${darkMode ? 'bg-white/10 text-sky-400' : 'bg-black/5 text-sky-600'} hover:opacity-80`}
-      title={t('bucket.title')}
+      title={`${t('bucket.title')} (U)`}
     >
       <Telescope size={16} />
     </button>

--- a/src/components/ShortcutHelpModal.jsx
+++ b/src/components/ShortcutHelpModal.jsx
@@ -56,6 +56,7 @@ const ShortcutHelpModal = () => {
                 ['F', t('shortcuts.focusMode')],
                 ['G', t('shortcuts.goalsProjects')],
                 ['H', t('shortcuts.habitsShortcut')],
+                ['U', t('bucket.title')],
                 ['L', t('shortcuts.intentLog')],
                 ['D', t('shortcuts.toggleDarkMode')],
                 ['S', t('common.settings')],

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -27,6 +27,8 @@ export default function useKeyboardShortcuts({
   showAddTask, showFocusMode, showRoutinesDashboard, showShortcutHelp, showSpotlight,
   showSettings, showRemindersSettings, showWeeklyReview, showVoiceInput,
   showHabitModal, showFramesModal, frameAdjustModal, showRescheduleModal, showGoalsDashboard,
+  // bucket list ('u')
+  showBucketList, setShowBucketList,
   // new task ('n' / 'i')
   selectedDate, hoverPreviewTime, hoverPreviewDate,
   setNewTask, setShowAddTask, setHoverPreviewTime, setHoverPreviewDate,
@@ -108,7 +110,7 @@ export default function useKeyboardShortcuts({
       }
 
       // Don't trigger shortcuts when a modal is open (except Escape and ? handled above)
-      if (showAddTask || showFocusMode || showRoutinesDashboard || showShortcutHelp || showSpotlight || showSettings || showRemindersSettings || showWeeklyReview || showVoiceInput || showHabitModal || showFramesModal || frameAdjustModal || showRescheduleModal || showGoalsDashboard) {
+      if (showAddTask || showFocusMode || showRoutinesDashboard || showShortcutHelp || showSpotlight || showSettings || showRemindersSettings || showWeeklyReview || showVoiceInput || showHabitModal || showFramesModal || frameAdjustModal || showRescheduleModal || showGoalsDashboard || showBucketList) {
         return;
       }
 
@@ -208,10 +210,17 @@ export default function useKeyboardShortcuts({
         setShowMobileTagFilter(false);
       }
 
-      // 'v' for voice task input
-      if (e.key === 'v' && noModifiers && aiConfig.enabled && aiConfig.features.voiceTaskInput) {
+      // 'v' for voice task input — same gate as the mic buttons (default on,
+      // no AI required: platform speech + deterministic parse cover the rest)
+      if (e.key === 'v' && noModifiers && aiConfig.features?.voiceTaskInput !== false) {
         e.preventDefault();
         setShowVoiceInput(true);
+      }
+
+      // 'u' for the bUcket List
+      if (e.key === 'u' && noModifiers) {
+        e.preventDefault();
+        setShowBucketList(true);
       }
 
       // 'g' for goals & projects dashboard (also auto-enables the feature on first use)
@@ -312,5 +321,5 @@ export default function useKeyboardShortcuts({
     // action callbacks (changeDate/goToToday/performUndo/performRedo/playUISound),
     // all stable or read through refs — listing them would needlessly re-bind.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedDate, showAddTask, showShortcutHelp, showFocusMode, showRoutinesDashboard, showHabitModal, showMonthView, showSpotlight, showSettings, showRemindersSettings, showWeeklyReview, showVoiceInput, showFramesModal, frameAdjustModal, showRescheduleModal, showGoalsDashboard, hoverPreviewTime, hoverPreviewDate, isMobile, tabletActiveTab, routinesEnabled, habitsEnabled, goalsProjectsEnabled, aiConfig, gtdFrames, canShowViewCycler, effectiveViewMode]);
+  }, [selectedDate, showAddTask, showShortcutHelp, showFocusMode, showRoutinesDashboard, showHabitModal, showMonthView, showSpotlight, showSettings, showRemindersSettings, showWeeklyReview, showVoiceInput, showFramesModal, frameAdjustModal, showRescheduleModal, showGoalsDashboard, showBucketList, hoverPreviewTime, hoverPreviewDate, isMobile, tabletActiveTab, routinesEnabled, habitsEnabled, goalsProjectsEnabled, aiConfig, gtdFrames, canShowViewCycler, effectiveViewMode]);
 }


### PR DESCRIPTION
## Summary

Two keyboard follow-ups to the v4.1.0 features:

- **`V` no longer requires AI.** The voice-without-AI work un-gated the mic buttons (`features.voiceTaskInput !== false`, default on) but the keyboard shortcut still checked `aiConfig.enabled` — keyboard users without AI had a working button and a dead key. The shortcut now uses the exact same gate as the buttons.
- **`U` opens the Bucket List** (b**U**cket — `B` is the backup menu, `T` is go-to-today, `L` is the intent log). The bucket modal is added to the shortcut modal guard so other single-key shortcuts don't fire underneath it while it's open; Escape-close already worked. The shortcut help modal (`?`) lists `U` (reusing the localized `bucket.title`, so no new translation keys), and the desktop telescope tooltip now reads "Bucket List (U)" to match the mic's "(V)" convention.

## Testing

Verified in a headless browser against the dev build: `V` opens the voice modal on a profile with no AI configured, `U` opens the Bucket List, `D` (dark mode) does not fire while the bucket modal is open, and Escape closes it. Full suite passing (987 tests), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_