### PR TITLE
Stop Escape in the desktop task editor from closing the modal beneath it

### DIFF
--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -73,6 +73,12 @@ const DesktopNewTaskModal = () => {
             onKeyDown={(e) => {
               if (e.key === 'Escape') {
                 e.preventDefault();
+                // Consume the event: without this it bubbles on to useModalClose's
+                // document listener, which by then sees showAddTask already false
+                // (React flushes before the event reaches document) and closes the
+                // next open modal underneath — e.g. the Bucket List this editor
+                // was opened from.
+                e.stopPropagation();
                 if (showRecurrencePicker) {
                   setShowRecurrencePicker(false);
                 } else if (showNewTaskDeadlinePicker) {


### PR DESCRIPTION
## Summary

With the Bucket List open and a task editor opened from it, a single Escape closed **both** modals. Root cause: `DesktopNewTaskModal` closes itself in its own form `onKeyDown` Escape handler, but never consumed the event. The keystroke kept bubbling to `useModalClose`'s document-level listener — and because React flushes the state update (and re-registers that listener via its effect) before the native event reaches `document`, the listener saw `showAddTask` already false and fell through to the next open modal in its chain, closing the Bucket List too.

This fall-through existed before but was harmless: `showAddTask` was the last branch in the chain, so there was nothing beneath it to hit until the Bucket List branch was added after it.

**Fix**: one `e.stopPropagation()` in the editor's Escape branch — the editor consumed the keypress, so the event ends there. The keyboard path where focus is outside the form (backdrop focus) is unaffected: the form handler never fires there, and `useModalClose`'s own `showAddTask` branch closes the editor as before, returning early so the bucket survives.

## Testing

Headless-browser verified: bucket → edit an item → Escape closes only the editor (bucket stays) → second Escape closes the bucket. No page errors. Full suite passing (987 tests), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_