### PR TITLE
Flip Bucket List defaults: Anytime leads, Someday is the hideable list

### DIFF
--- a/src/utils/bucketList.js
+++ b/src/utils/bucketList.js
@@ -13,7 +13,11 @@
 export const BUCKET_LIST_IDS = ['b1', 'b2'];
 
 export const DEFAULT_BUCKET_CONFIG = {
-  headings: { b1: 'Someday', b2: 'Anytime' },
+  // b1 is the demote target and always visible; b2 is hideable. "Anytime"
+  // leads (actionable whenever, just not scheduled — where a demoted Inbox
+  // task naturally lands) with "Someday" as the further-out, review-
+  // occasionally list (the Things 3 convention).
+  headings: { b1: 'Anytime', b2: 'Someday' },
   secondListHidden: false,
   notes: '',
 };

--- a/src/utils/bucketList.test.js
+++ b/src/utils/bucketList.test.js
@@ -81,13 +81,13 @@ describe('normalizeBucketConfig', () => {
   it('keeps valid values and fills gaps', () => {
     const cfg = normalizeBucketConfig({ headings: { b1: 'Dreams' }, secondListHidden: true });
     expect(cfg.headings.b1).toBe('Dreams');
-    expect(cfg.headings.b2).toBe('Anytime');
+    expect(cfg.headings.b2).toBe('Someday');
     expect(cfg.secondListHidden).toBe(true);
     expect(cfg.notes).toBe('');
   });
 
   it('rejects blank headings', () => {
-    expect(normalizeBucketConfig({ headings: { b1: '   ' } }).headings.b1).toBe('Someday');
+    expect(normalizeBucketConfig({ headings: { b1: '   ' } }).headings.b1).toBe('Anytime');
   });
 
   it('preserves updatedAt for sync merges', () => {


### PR DESCRIPTION
## Summary

Swap the default headings: `b1` (the always-visible list where "Send to Bucket List" lands) now defaults to **Anytime**, and `b2` (the hideable list) to **Someday**. This matches the Things 3 convention — Anytime is the actionable-whenever pool, which is what a demoted Inbox task usually is, while Someday is the further-out list you review occasionally (and can hide).

Only the two default strings and their tests change. List ids (`b1`/`b2`), the demote target, hide behavior, and sync are all structural and untouched. `normalizeBucketConfig` fills defaults only for missing/blank headings, so stored configs keep whatever headings they already have — deliberately no auto-migration, since silently swapping user headings that merely *match* the old defaults would be a footgun after release.

## Testing

Full suite passing (987 tests), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_