### PR TITLE
Bucket flavor for the shared task editor: no pressure fields, notes & subtasks in

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3337,9 +3337,12 @@ const DayPlanner = () => {
         title: cleanTitle(newTask.title),
         duration: newTask.duration,
         color: newTask.color || colors[0].class,
-        deadline: newTask.deadline || null,
-        priority: newTask.priority || 0,
-        projectId: newTask.projectId || undefined,
+        // Bucket items stay pressure-free: the editor hides these controls for
+        // them, but sigils typed in the title ($fri, !2) could still seed
+        // newTask — force the stripped state at the source of truth.
+        deadline: t.bucketId ? null : (newTask.deadline || null),
+        priority: t.bucketId ? 0 : (newTask.priority || 0),
+        projectId: t.bucketId ? undefined : (newTask.projectId || undefined),
         assignedUserSyncIds: mobileEditingTask.assignedUserSyncIds ?? t.assignedUserSyncIds,
         transitionId: crypto.randomUUID(),
       } : t));

--- a/src/components/BucketListModal.jsx
+++ b/src/components/BucketListModal.jsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ArrowRightLeft, CalendarClock, Eye, EyeOff, GripVertical, Inbox, Plus, Telescope, Trash2, X } from 'lucide-react';
+import { ArrowRightLeft, CalendarClock, CheckSquare, Eye, EyeOff, FileText, GripVertical, Inbox, Plus, Telescope, Trash2, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { BUCKET_LIST_IDS, promoteToInbox } from '../utils/bucketList.js';
-import { renderFormattedText } from '../utils/textFormatting.jsx';
+import { renderFormattedText, hasNotesOrSubtasks, hasOnlySubtasks } from '../utils/textFormatting.jsx';
 
 // Same iOS detection as ProjectPlanner/ProjectCard: grip-only touch drag on
 // iOS, where whole-row HTML5 drag hijacks the gesture.
@@ -249,9 +249,15 @@ const BucketListModal = () => {
         <button
           type="button"
           onClick={() => editItem(task)}
-          className={`flex-1 min-w-0 text-left text-sm truncate ${task.completed ? `line-through ${textSecondary}` : textPrimary}`}
+          className={`flex-1 min-w-0 text-left text-sm truncate flex items-center gap-1.5 ${task.completed ? `line-through ${textSecondary}` : textPrimary}`}
         >
-          {task.title}
+          <span className="truncate">{task.title}</span>
+          {/* Passive has-notes glyph (not a button — the editor is the surface) */}
+          {hasNotesOrSubtasks(task) && (
+            hasOnlySubtasks(task)
+              ? <CheckSquare size={11} className={`flex-shrink-0 ${textSecondary} opacity-60`} />
+              : <FileText size={11} className={`flex-shrink-0 ${textSecondary} opacity-60`} />
+          )}
         </button>
         <div className={`flex items-center gap-0.5 flex-shrink-0 ${isMobile ? '' : 'opacity-0 group-hover:opacity-100 transition-opacity'}`}>
           {!task.completed && (

--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -8,6 +8,8 @@ import { SOURCE_APPS } from '../native.js';
 import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
 import QuickAddChips from './QuickAddChips.jsx';
 import LastGlanceBadge from './LastGlanceBadge.jsx';
+import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
+import { extractWikilinks } from '../utils/taskUtils.js';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
 import { getProjectColor } from '../utils/colorUtils.js';
@@ -37,8 +39,10 @@ const DesktopNewTaskModal = () => {
     applySuggestionForNewTask,
     handleNewTaskInputChange, handleNewTaskInputKeyDown,
     dismissNlChip,
+    unscheduledTasks,
+    updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
   } = useDayPlannerCtx();
-  const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, triggerTaskAISuggestion, goals, projects, goalsProjectsEnabled, multiUserEnabled, users } = useFeaturesCtx();
+  const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, triggerTaskAISuggestion, goals, projects, goalsProjectsEnabled, multiUserEnabled, users, aiSubtasksLoadingForTask, generateAISubtasks } = useFeaturesCtx();
   const { wikilinkCandidates = [] } = useSyncCtx() || {};
 
   // Wikilink autocomplete: detect [[partial at end of title
@@ -52,6 +56,17 @@ const DesktopNewTaskModal = () => {
     setNewTask(prev => ({ ...prev, title: newTitle }));
     newTaskInputRef.current?.focus();
   };
+
+  // Bucket List items use this editor in inbox flavor, but the Bucket is
+  // deliberately pressure-free: no deadline, no priority, no project. Those
+  // controls are hidden (a stored deadline would be inert anyway — every
+  // deadline/priority consumer excludes bucket items), and the freed space
+  // hosts the notes & subtasks panel, which has no other surface in the
+  // Bucket List UI.
+  const isBucketItem = !!mobileEditingTask?.bucketId;
+  const liveBucketTask = isBucketItem
+    ? unscheduledTasks.find(t => t.id === mobileEditingTask.id)
+    : null;
 
   if (!showAddTask || isMobile) return null;
 
@@ -207,8 +222,9 @@ const DesktopNewTaskModal = () => {
                   )
                 )}
               </div>
-              {/* Project assignment (only when Goals & Projects is enabled) */}
-              {goalsProjectsEnabled && (
+              {/* Project assignment (only when Goals & Projects is enabled;
+                  never for Bucket List items — a PLANNER without a project) */}
+              {goalsProjectsEnabled && !isBucketItem && (
                 <div>
                   <label className={`block text-sm ${textSecondary} mb-1`}>{t('task.project')}</label>
                   <select
@@ -355,6 +371,23 @@ const DesktopNewTaskModal = () => {
                         )}
                       </div>
                     </div>
+                    {/* Bucket items: duration instead of priority/deadline (the
+                        desktop inbox flavor otherwise has no duration control) */}
+                    {isBucketItem && (
+                      <div>
+                        <label className={`block text-sm ${textSecondary} mb-1`}>{t('task.duration')}</label>
+                        <select
+                          value={newTask.duration}
+                          onChange={(e) => setNewTask({ ...newTask, duration: parseInt(e.target.value) })}
+                          className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'}`}
+                        >
+                          {durationOptions.map(minutes => (
+                            <option key={minutes} value={minutes}>{minutes} min</option>
+                          ))}
+                        </select>
+                      </div>
+                    )}
+                    {!isBucketItem && (<>
                     <div>
                       <label className={`block text-sm ${textSecondary} mb-1`}>{t('task.priority')}</label>
                       <button
@@ -459,6 +492,7 @@ const DesktopNewTaskModal = () => {
                         )}
                       </div>
                     </div>
+                    </>)}
                   </>
                 ) : (
                   <>
@@ -668,6 +702,26 @@ const DesktopNewTaskModal = () => {
                   </>
                 )}
               </div>
+              {/* Notes & subtasks for Bucket List items — their only surface,
+                  since bucket rows have no expandable panel */}
+              {isBucketItem && liveBucketTask && (
+                <div className={`border ${borderClass} rounded-lg overflow-hidden`}>
+                  <NotesSubtasksPanel
+                    task={liveBucketTask}
+                    isInbox={true}
+                    darkMode={darkMode}
+                    updateTaskNotes={updateTaskNotes}
+                    addSubtask={addSubtask}
+                    toggleSubtask={toggleSubtask}
+                    deleteSubtask={deleteSubtask}
+                    updateSubtaskTitle={updateSubtaskTitle}
+                    aiConfig={aiConfig}
+                    aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
+                    onGenerateSubtasks={generateAISubtasks}
+                    wikilinks={extractWikilinks(liveBucketTask.title).length > 0 ? extractWikilinks(liveBucketTask.title) : undefined}
+                  />
+                </div>
+              )}
               <div className="flex gap-2 pt-2">
                 <button
                   type="submit"

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -7,6 +7,8 @@ import { useSyncCtx } from '../context/SyncContext.jsx';
 import { SOURCE_APPS } from '../native.js';
 import LastGlanceBadge from './LastGlanceBadge.jsx';
 import QuickAddChips from './QuickAddChips.jsx';
+import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
+import { extractWikilinks } from '../utils/taskUtils.js';
 import { dateToString, extractTags, getRecurrenceLabel } from '../utils/taskUtils.js';
 import { getRecurrencePresets } from '../utils/recurrenceEngine.js';
 import { getProjectColor } from '../utils/colorUtils.js';
@@ -32,8 +34,10 @@ const MobileNewTaskModal = () => {
     sendTaskToBucket,
     handleNewTaskInputChange,
     dismissNlChip,
+    unscheduledTasks,
+    updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
   } = useDayPlannerCtx();
-  const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, triggerTaskAISuggestion, goals, projects, goalsProjectsEnabled, multiUserEnabled, users } = useFeaturesCtx();
+  const { aiConfig, taskAISuggestion, setTaskAISuggestion, taskAISuggestionLoading, triggerTaskAISuggestion, goals, projects, goalsProjectsEnabled, multiUserEnabled, users, aiSubtasksLoadingForTask, generateAISubtasks } = useFeaturesCtx();
   const { wikilinkCandidates = [] } = useSyncCtx() || {};
 
   // Wikilink autocomplete: detect [[partial at end of title
@@ -47,6 +51,14 @@ const MobileNewTaskModal = () => {
     setNewTask(prev => ({ ...prev, title: newTitle }));
     newTaskInputRef.current?.focus();
   };
+
+  // Bucket List items: no priority/deadline/project (pressure-free by design —
+  // stored values would be inert anyway), and the editor is the only surface
+  // for their notes & subtasks.
+  const isBucketItem = !!mobileEditingTask?.bucketId;
+  const liveBucketTask = isBucketItem
+    ? unscheduledTasks.find(t => t.id === mobileEditingTask.id)
+    : null;
 
   return (
     <>
@@ -168,8 +180,9 @@ const MobileNewTaskModal = () => {
                 )}
               </div>
 
-              {/* Project assignment (only when Goals & Projects is enabled) */}
-              {goalsProjectsEnabled && (
+              {/* Project assignment (only when Goals & Projects is enabled;
+                  never for Bucket List items — a PLANNER without a project) */}
+              {goalsProjectsEnabled && !isBucketItem && (
                 <div>
                   <label className={`block text-sm ${textSecondary} mb-1`}>{t('task.project')}</label>
                   <select
@@ -307,6 +320,7 @@ const MobileNewTaskModal = () => {
               {/* Fields grid */}
               {newTask.openInInbox ? (
                 <div className="grid grid-cols-2 gap-3">
+                  {!isBucketItem && (<>
                   <div>
                     <label className={`block text-sm ${textSecondary} mb-1`}>{t('task.priority')}</label>
                     <button
@@ -354,6 +368,7 @@ const MobileNewTaskModal = () => {
                       )}
                     </div>
                   </div>
+                  </>)}
                   <div className="col-span-2">
                     <label className={`block text-sm ${textSecondary} mb-1`}>{t('task.duration')}</label>
                     <select
@@ -541,6 +556,27 @@ const MobileNewTaskModal = () => {
                       </div>
                     )}
                   </>)}
+                </div>
+              )}
+
+              {/* Notes & subtasks for Bucket List items — their only surface,
+                  since bucket rows have no expandable panel */}
+              {isBucketItem && liveBucketTask && (
+                <div className={`border ${borderClass} rounded-lg overflow-hidden`}>
+                  <NotesSubtasksPanel
+                    task={liveBucketTask}
+                    isInbox={true}
+                    darkMode={darkMode}
+                    updateTaskNotes={updateTaskNotes}
+                    addSubtask={addSubtask}
+                    toggleSubtask={toggleSubtask}
+                    deleteSubtask={deleteSubtask}
+                    updateSubtaskTitle={updateSubtaskTitle}
+                    aiConfig={aiConfig}
+                    aiSubtasksLoadingForTask={aiSubtasksLoadingForTask}
+                    onGenerateSubtasks={generateAISubtasks}
+                    wikilinks={extractWikilinks(liveBucketTask.title).length > 0 ? extractWikilinks(liveBucketTask.title) : undefined}
+                  />
                 </div>
               )}
 


### PR DESCRIPTION
## Summary

Editing a Bucket List item opens the shared inbox-flavor editor, which contradicted the "no deadlines, no nags" tagline in two ways:

- **Inert fields**: deadline/priority set there were stored but did nothing — demotion strips them and every deadline/priority consumer excludes bucket items.
- **Project leak**: the project picker could assign a bucket item to a project, making it appear in that project's PLANNER while also living in the bucket (ProjectPlanner has no `bucketId` filtering — it isn't Inbox machinery).

## Changes

When `mobileEditingTask.bucketId` is set (both `DesktopNewTaskModal` and `MobileNewTaskModal`):

- **Hidden**: priority, deadline, and the project picker.
- **Added — duration on desktop**: the desktop inbox flavor had no duration control at all (it only existed in the scheduled branch and the mobile editor), so bucket items get a duration select in the freed grid space.
- **Added — notes & subtasks**: the editor embeds `NotesSubtasksPanel` (live task lookup so subtask toggles reflect immediately). This was the missing surface: bucket rows have no expandable panel and no room for more buttons, so the editor — already one tap away via the row title — is where notes/subtasks live. Bucket rows show a small passive glyph beside the title when an item has notes or subtasks.
- **Save-path hardening**: the inbox save branch forces `deadline: null` / `priority: 0` / `projectId: undefined` for bucket items, closing the sigil loophole (`$fri` or `!2` typed into the title field would otherwise seed them past the hidden controls).

Plain Inbox editing is unchanged.

## Testing

Headless-browser verified: bucket item editor shows Color + Duration + notes/subtasks panel and none of the pressure fields; adding a note through the panel persists and surfaces the row glyph (and ticked the notes onboarding item, confirming the panel is fully wired); a plain new-inbox editor still shows Priority and Deadline. Full suite passing (987 tests), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_