### PR TITLE
Fix nested-form breakage and border glitch in the bucket item editor

### DIFF
--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -705,7 +705,7 @@ const DesktopNewTaskModal = () => {
               {/* Notes & subtasks for Bucket List items — their only surface,
                   since bucket rows have no expandable panel */}
               {isBucketItem && liveBucketTask && (
-                <div className={`border ${borderClass} rounded-lg overflow-hidden`}>
+                <div>
                   <NotesSubtasksPanel
                     task={liveBucketTask}
                     isInbox={true}

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -562,7 +562,7 @@ const MobileNewTaskModal = () => {
               {/* Notes & subtasks for Bucket List items — their only surface,
                   since bucket rows have no expandable panel */}
               {isBucketItem && liveBucketTask && (
-                <div className={`border ${borderClass} rounded-lg overflow-hidden`}>
+                <div>
                   <NotesSubtasksPanel
                     task={liveBucketTask}
                     isInbox={true}

--- a/src/components/NotesSubtasksPanel.jsx
+++ b/src/components/NotesSubtasksPanel.jsx
@@ -213,8 +213,14 @@ const NotesSubtasksPanel = ({
     if (localNotes !== (task.notes || '')) updateTaskNotes(task.id, localNotes, isInbox);
   };
 
+  // Called from the add-subtask input's Enter keydown and nothing else.
+  // preventDefault matters when the panel renders inside the task editor's
+  // <form> (bucket items): the input's form owner is that outer form, so an
+  // unhandled Enter would implicitly submit it — saving and closing the
+  // editor. stopPropagation keeps the keydown from the editor's onKeyDown.
   const handleAddSubtask = (e) => {
     e.preventDefault();
+    e.stopPropagation();
     if (localSubtaskText.trim()) {
       addSubtask(task.id, localSubtaskText, isInbox);
       setLocalSubtaskText('');
@@ -386,6 +392,7 @@ const NotesSubtasksPanel = ({
             {task.subtasks.map((subtask) => (
               <div key={subtask.id} className="flex items-center gap-2 group">
                 <button
+                  type="button"
                   onClick={() => toggleSubtask(task.id, subtask.id, isInbox)}
                   className={`rounded flex-shrink-0 border-2 w-4 h-4 flex items-center justify-center transition-colors ${th.checkbox} ${subtask.completed ? 'opacity-60' : ''}`}
                 >
@@ -418,6 +425,7 @@ const NotesSubtasksPanel = ({
                   </span>
                 )}
                 <button
+                  type="button"
                   onClick={() => deleteSubtask(task.id, subtask.id, isInbox)}
                   className={`md:opacity-0 md:group-hover:opacity-100 opacity-60 rounded p-0.5 transition-opacity ${th.deleteBtn}`}
                   title="Delete subtask"
@@ -429,17 +437,23 @@ const NotesSubtasksPanel = ({
           </div>
         )}
 
-        {/* Add subtask input */}
-        <form onSubmit={handleAddSubtask} className="flex items-center gap-2">
+        {/* Add subtask input. Deliberately NOT a <form>: the panel can render
+            inside the task editor's <form> (bucket items), and a nested form
+            is invalid HTML whose submit bypasses React entirely — the browser
+            performs a native GET submission and reloads the whole app. Enter
+            is handled on the input instead (preventDefault also stops the
+            outer form's implicit submission). */}
+        <div className="flex items-center gap-2">
           <Plus size={14} className={th.addIcon} />
           <input
             type="text"
             value={localSubtaskText}
             onChange={(e) => setLocalSubtaskText(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleAddSubtask(e); }}
             placeholder="Add subtask..."
             className={`flex-1 bg-transparent text-sm px-1 py-0.5 outline-none border-b ${th.addInput} ${th.addBorder}`}
           />
-        </form>
+        </div>
       </div>
 
     </div>


### PR DESCRIPTION
## Summary

Follow-up to #1276. The reported border/background misalignment turned out to be the small problem — investigating it in the browser surfaced a serious one underneath.

**The border glitch**: `NotesSubtasksPanel` is its own rounded card with a top margin, so the `border rounded-lg` wrapper I put around it visibly misaligned with the panel's fill. The wrapper border is removed; the panel's own card styling stands alone.

**The real bug**: embedding the panel inside the task editor's `<form>` nested the panel's add-subtask `<form>` — invalid HTML whose submit **bypasses React's event system entirely**. Pressing Enter in the "Add subtask…" input performed a native GET form submission that reloaded the whole app (URL becomes `/?`): subtask lost, editor and Bucket List gone. Neither form's `onSubmit` ever fired, so no amount of `stopPropagation` could fix it.

Fixes, all in `NotesSubtasksPanel` (safe for its existing row-panel usages):

- The add-subtask row is now a plain `div`; Enter is handled on the input via `onKeyDown`, with `preventDefault` so the keystroke can't implicitly submit the surrounding editor form either.
- The subtask checkbox and delete buttons get `type="button"` — bare `<button>`s default to `type="submit"`, so clicking them inside the editor form would have submitted-and-closed it.

## Testing

Headless-browser verified on the exact repro: Enter in the subtask input adds the subtask with zero navigations and the editor open; toggling the subtask checkbox doesn't submit; Save Changes still closes the editor with the Bucket List intact underneath; the row glyph appears. Full suite passing (987 tests), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_