### PR TITLE
SCHED: in-progress pulsing dot + persisted completed/past visibility toggles

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -872,7 +872,16 @@
     "currentViewTap": "Aktuelle Ansicht: {{view}}. Tippen zum Wechseln.",
     "deadline": "Frist",
     "deadlineTapToSchedule": "Frist — tippen, um eine Uhrzeit zu wählen",
-    "routineTapHint": "Tippen zum Abhaken · halten, um eine Uhrzeit zu wählen"
+    "routineTapHint": "Tippen zum Abhaken · halten, um eine Uhrzeit zu wählen",
+    "completedTasks": "Erledigte Aufgaben",
+    "pastEvents": "Vergangene Termine",
+    "show": "Anzeigen",
+    "hide": "Ausblenden",
+    "showCompleted": "Erledigte anzeigen",
+    "hideCompleted": "Erledigte ausblenden",
+    "showPastEvents": "Vergangene Termine anzeigen",
+    "hidePastEvents": "Vergangene Termine ausblenden",
+    "happeningNow": "Läuft gerade"
   },
   "planner": {
     "standaloneProject": "Eigenständiges Projekt",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -872,7 +872,16 @@
     "currentViewTap": "Current view: {{view}}. Tap to switch.",
     "deadline": "Deadline",
     "deadlineTapToSchedule": "Deadline — tap to pick a time",
-    "routineTapHint": "Tap to complete · hold to pick a time"
+    "routineTapHint": "Tap to complete · hold to pick a time",
+    "completedTasks": "Completed tasks",
+    "pastEvents": "Past events",
+    "show": "Show",
+    "hide": "Hide",
+    "showCompleted": "Show completed",
+    "hideCompleted": "Hide completed",
+    "showPastEvents": "Show past events",
+    "hidePastEvents": "Hide past events",
+    "happeningNow": "Happening now"
   },
   "planner": {
     "standaloneProject": "Standalone project",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -872,7 +872,16 @@
     "currentViewTap": "Vista actual: {{view}}. Toca para cambiar.",
     "deadline": "Fecha límite",
     "deadlineTapToSchedule": "Fecha límite: toca para elegir una hora",
-    "routineTapHint": "Toca para completar · mantén pulsado para elegir una hora"
+    "routineTapHint": "Toca para completar · mantén pulsado para elegir una hora",
+    "completedTasks": "Tareas completadas",
+    "pastEvents": "Eventos pasados",
+    "show": "Mostrar",
+    "hide": "Ocultar",
+    "showCompleted": "Mostrar completadas",
+    "hideCompleted": "Ocultar completadas",
+    "showPastEvents": "Mostrar eventos pasados",
+    "hidePastEvents": "Ocultar eventos pasados",
+    "happeningNow": "En curso"
   },
   "planner": {
     "standaloneProject": "Proyecto independiente",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -872,7 +872,16 @@
     "currentViewTap": "Vue actuelle : {{view}}. Touchez pour changer.",
     "deadline": "Échéance",
     "deadlineTapToSchedule": "Échéance — touchez pour choisir une heure",
-    "routineTapHint": "Touchez pour terminer · maintenez pour choisir une heure"
+    "routineTapHint": "Touchez pour terminer · maintenez pour choisir une heure",
+    "completedTasks": "Tâches terminées",
+    "pastEvents": "Événements passés",
+    "show": "Afficher",
+    "hide": "Masquer",
+    "showCompleted": "Afficher les terminées",
+    "hideCompleted": "Masquer les terminées",
+    "showPastEvents": "Afficher les événements passés",
+    "hidePastEvents": "Masquer les événements passés",
+    "happeningNow": "En cours"
   },
   "planner": {
     "standaloneProject": "Projet indépendant",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -872,7 +872,16 @@
     "currentViewTap": "Vista attuale: {{view}}. Tocca per cambiare.",
     "deadline": "Scadenza",
     "deadlineTapToSchedule": "Scadenza — tocca per scegliere un orario",
-    "routineTapHint": "Tocca per completare · tieni premuto per scegliere un orario"
+    "routineTapHint": "Tocca per completare · tieni premuto per scegliere un orario",
+    "completedTasks": "Attività completate",
+    "pastEvents": "Eventi passati",
+    "show": "Mostra",
+    "hide": "Nascondi",
+    "showCompleted": "Mostra completate",
+    "hideCompleted": "Nascondi completate",
+    "showPastEvents": "Mostra eventi passati",
+    "hidePastEvents": "Nascondi eventi passati",
+    "happeningNow": "In corso"
   },
   "planner": {
     "standaloneProject": "Progetto indipendente",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -872,7 +872,16 @@
     "currentViewTap": "Vista atual: {{view}}. Toque para mudar.",
     "deadline": "Prazo",
     "deadlineTapToSchedule": "Prazo — toque para escolher uma hora",
-    "routineTapHint": "Toque para concluir · mantenha premido para escolher uma hora"
+    "routineTapHint": "Toque para concluir · mantenha premido para escolher uma hora",
+    "completedTasks": "Tarefas concluídas",
+    "pastEvents": "Eventos passados",
+    "show": "Mostrar",
+    "hide": "Ocultar",
+    "showCompleted": "Mostrar concluídas",
+    "hideCompleted": "Ocultar concluídas",
+    "showPastEvents": "Mostrar eventos passados",
+    "hidePastEvents": "Ocultar eventos passados",
+    "happeningNow": "A decorrer"
   },
   "planner": {
     "standaloneProject": "Projeto independente",

--- a/src/components/sched/SchedDashboard.jsx
+++ b/src/components/sched/SchedDashboard.jsx
@@ -58,6 +58,8 @@ const SchedDashboard = () => {
     availableColors, availableTags,
     showEmptyDays, toggleEmptyDays,
     nextInstanceOnly, toggleNextInstanceOnly,
+    hideCompleted, toggleHideCompleted,
+    hidePastEvents, toggleHidePastEvents,
     showMoreDays,
     addTaskOnDay,
   } = useSchedAgendaState();
@@ -258,6 +260,20 @@ const SchedDashboard = () => {
         >
           {showEmptyDays ? <Eye size={13} /> : <EyeOff size={13} />}
           {showEmptyDays ? t('sched.hideEmptyDays', 'Hide empty days') : t('sched.showEmptyDays', 'Show empty days')}
+        </button>
+        <button
+          onClick={toggleHideCompleted}
+          className={`flex items-center gap-1.5 text-xs font-medium px-2 py-1.5 rounded-lg border ${borderClass} ${textSecondary} ${hoverBg} transition-colors`}
+        >
+          {hideCompleted ? <EyeOff size={13} /> : <Eye size={13} />}
+          {hideCompleted ? t('sched.showCompleted', 'Show completed') : t('sched.hideCompleted', 'Hide completed')}
+        </button>
+        <button
+          onClick={toggleHidePastEvents}
+          className={`flex items-center gap-1.5 text-xs font-medium px-2 py-1.5 rounded-lg border ${borderClass} ${textSecondary} ${hoverBg} transition-colors`}
+        >
+          {hidePastEvents ? <EyeOff size={13} /> : <Eye size={13} />}
+          {hidePastEvents ? t('sched.showPastEvents', 'Show past events') : t('sched.hidePastEvents', 'Hide past events')}
         </button>
       </div>
     </div>

--- a/src/components/sched/SchedFilterPopup.jsx
+++ b/src/components/sched/SchedFilterPopup.jsx
@@ -16,7 +16,10 @@ import SchedFilterPresets from './SchedFilterPresets.jsx';
 const SchedFilterPopup = ({
   filters, setFilters,
   filterPresets, saveFilterPreset, deleteFilterPreset, applyFilterPreset,
-  availableColors, availableTags, nextInstanceOnly, toggleNextInstanceOnly, onClose,
+  availableColors, availableTags, nextInstanceOnly, toggleNextInstanceOnly,
+  hideCompleted, toggleHideCompleted,
+  hidePastEvents, toggleHidePastEvents,
+  onClose,
 }) => {
   const { darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg } = useDayPlannerCtx();
   const { projects, goals, goalsProjectsEnabled } = useFeaturesCtx();
@@ -135,6 +138,30 @@ const SchedFilterPopup = ({
             </button>
             <button onClick={() => !nextInstanceOnly && toggleNextInstanceOnly()} className={chip(nextInstanceOnly)}>
               {t('sched.nextOnly', 'Next only')}
+            </button>
+          </div>
+        </div>
+
+        {/* Completed / past events — view preferences like Recurring above */}
+        <div className="flex flex-col gap-1.5">
+          <span className={`text-xs font-medium ${textSecondary}`}>{t('sched.completedTasks', 'Completed tasks')}</span>
+          <div className="flex gap-1.5">
+            <button onClick={() => hideCompleted && toggleHideCompleted()} className={chip(!hideCompleted)}>
+              {t('sched.show', 'Show')}
+            </button>
+            <button onClick={() => !hideCompleted && toggleHideCompleted()} className={chip(hideCompleted)}>
+              {t('sched.hide', 'Hide')}
+            </button>
+          </div>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <span className={`text-xs font-medium ${textSecondary}`}>{t('sched.pastEvents', 'Past events')}</span>
+          <div className="flex gap-1.5">
+            <button onClick={() => hidePastEvents && toggleHidePastEvents()} className={chip(!hidePastEvents)}>
+              {t('sched.show', 'Show')}
+            </button>
+            <button onClick={() => !hidePastEvents && toggleHidePastEvents()} className={chip(hidePastEvents)}>
+              {t('sched.hide', 'Hide')}
             </button>
           </div>
         </div>

--- a/src/components/sched/SchedTaskCard.jsx
+++ b/src/components/sched/SchedTaskCard.jsx
@@ -75,7 +75,14 @@ const SchedTaskCard = ({ task, isInbox = false, showProject = false, onEdit = nu
     task.date < todayStr ||
     (task.date === todayStr && (startMin + (isEvent ? (task.duration || 0) : 0)) < nowMin)
   );
-  const isPastDueTask = timePassed && !isEvent && !task.completed;
+  // Happening right now: today's timed card whose window contains the current
+  // minute. Tasks default to 30 min (matching the scheduler); events with no
+  // duration are instantaneous. In-progress tasks are NOT past-due — the red
+  // label starts when the window ends, the dot covers the window itself.
+  const durationMin = task.duration || (isEvent ? 0 : 30);
+  const inProgress = !task.isAllDay && !task.completed && startMin !== null &&
+    task.date === todayStr && startMin <= nowMin && nowMin < startMin + durationMin;
+  const isPastDueTask = timePassed && !isEvent && !task.completed && !inProgress;
   const isFinishedEvent = timePassed && isEvent;
 
   const subtasks = task.subtasks || [];
@@ -151,6 +158,12 @@ const SchedTaskCard = ({ task, isInbox = false, showProject = false, onEdit = nu
               <span className="flex-shrink-0 font-medium text-amber-500">
                 {new Date(task.date + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
               </span>
+            )}
+            {inProgress && (
+              <span
+                className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse flex-shrink-0"
+                title={t('sched.happeningNow', 'Happening now')}
+              />
             )}
             {timeLabel && (
               <span className={`flex-shrink-0 ${isPastDueTask ? 'text-red-400 font-medium' : ''}`}>{timeLabel}</span>

--- a/src/components/sched/SchedView.jsx
+++ b/src/components/sched/SchedView.jsx
@@ -33,6 +33,8 @@ const SchedView = () => {
     availableColors, availableTags,
     showEmptyDays, toggleEmptyDays,
     nextInstanceOnly, toggleNextInstanceOnly,
+    hideCompleted, toggleHideCompleted,
+    hidePastEvents, toggleHidePastEvents,
     showMoreDays,
     addTaskOnDay,
   } = useSchedAgendaState();
@@ -135,6 +137,10 @@ const SchedView = () => {
           availableTags={availableTags}
           nextInstanceOnly={nextInstanceOnly}
           toggleNextInstanceOnly={toggleNextInstanceOnly}
+          hideCompleted={hideCompleted}
+          toggleHideCompleted={toggleHideCompleted}
+          hidePastEvents={hidePastEvents}
+          toggleHidePastEvents={toggleHidePastEvents}
           onClose={() => setShowFilters(false)}
         />
       )}

--- a/src/components/sched/useSchedAgendaState.js
+++ b/src/components/sched/useSchedAgendaState.js
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
 import { dateToString, extractTags } from '../../utils/taskUtils.js';
-import { EMPTY_SCHED_FILTERS, hasActiveSchedFilters, taskMatchesSchedFilters, limitRecurringToNextInstance, schedFiltersEqual } from '../../utils/schedAgenda.js';
+import { EMPTY_SCHED_FILTERS, hasActiveSchedFilters, taskMatchesSchedFilters, limitRecurringToNextInstance, schedFiltersEqual, isPastEvent } from '../../utils/schedAgenda.js';
 
 export const INITIAL_DAYS = 14;
 export const LOAD_MORE_DAYS = 14;
@@ -21,6 +21,7 @@ export default function useSchedAgendaState() {
     getTasksForDate, getDeadlineTasksForDate,
     setNewTask, setShowAddTask,
     scheduleTaskAtNextSlot,
+    currentTime,
     // Window length lives in App state so expandedRecurringTasks can expand
     // recurring occurrences across the agenda's whole rolling window.
     schedDaysShown: daysShown, setSchedDaysShown: setDaysShown,
@@ -36,6 +37,15 @@ export default function useSchedAgendaState() {
   // it doesn't count toward the active-filter badge.
   const [nextInstanceOnly, setNextInstanceOnly] = useState(
     () => localStorage.getItem('day-planner-sched-next-instance-only') === 'true'
+  );
+  // Visibility preferences (same persistence pattern as nextInstanceOnly):
+  // hide completed tasks, and hide imported calendar events that have ended.
+  // View preferences, not filters — they don't count toward the filter badge.
+  const [hideCompleted, setHideCompleted] = useState(
+    () => localStorage.getItem('day-planner-sched-hide-completed') === 'true'
+  );
+  const [hidePastEvents, setHidePastEvents] = useState(
+    () => localStorage.getItem('day-planner-sched-hide-past-events') === 'true'
   );
 
   // Saved filter presets — named color/tag/project combos, persisted across
@@ -81,6 +91,16 @@ export default function useSchedAgendaState() {
     return !v;
   });
 
+  const toggleHideCompleted = () => setHideCompleted(v => {
+    localStorage.setItem('day-planner-sched-hide-completed', String(!v));
+    return !v;
+  });
+
+  const toggleHidePastEvents = () => setHidePastEvents(v => {
+    localStorage.setItem('day-planner-sched-hide-past-events', String(!v));
+    return !v;
+  });
+
   const showMoreDays = () => setDaysShown(n => n + LOAD_MORE_DAYS);
 
   // Unfiltered agenda window (day → tasks), all-day first then by start time.
@@ -122,10 +142,15 @@ export default function useSchedAgendaState() {
     const base = nextInstanceOnly ? limitRecurringToNextInstance(rawDays) : rawDays;
     return base.map(d => ({
       ...d,
-      tasks: d.tasks.filter(task => taskMatchesSchedFilters(task, filters)),
-      deadlineTasks: d.deadlineTasks.filter(task => taskMatchesSchedFilters(task, filters)),
+      tasks: d.tasks.filter(task =>
+        taskMatchesSchedFilters(task, filters) &&
+        (!hideCompleted || !task.completed) &&
+        (!hidePastEvents || !isPastEvent(task, currentTime))),
+      deadlineTasks: d.deadlineTasks.filter(task =>
+        taskMatchesSchedFilters(task, filters) &&
+        (!hideCompleted || !task.completed)),
     }));
-  }, [rawDays, filters, nextInstanceOnly]);
+  }, [rawDays, filters, nextInstanceOnly, hideCompleted, hidePastEvents, currentTime]);
 
   const filtersActive = hasActiveSchedFilters(filters);
   // Today never counts as empty while routine pills are pending on it.
@@ -167,6 +192,8 @@ export default function useSchedAgendaState() {
     availableColors, availableTags,
     showEmptyDays, toggleEmptyDays,
     nextInstanceOnly, toggleNextInstanceOnly,
+    hideCompleted, toggleHideCompleted,
+    hidePastEvents, toggleHidePastEvents,
     showMoreDays,
     addTaskOnDay,
   };

--- a/src/utils/schedAgenda.js
+++ b/src/utils/schedAgenda.js
@@ -1,4 +1,4 @@
-import { extractTags } from './taskUtils.js';
+import { dateToString, extractTags } from './taskUtils.js';
 
 /**
  * SCHED view filtering.
@@ -68,6 +68,22 @@ export const groupProjectsForFilter = (projects, goals) => {
   // isStandalone lets the UI swap the label for its translation.
   if (standalone.length) groups.push({ label: 'Standalone', isStandalone: true, projects: standalone });
   return groups;
+};
+
+/**
+ * True for imported calendar events that have already ENDED relative to `now`
+ * (the "hide past events" view preference). Tasks — even past-due ones — are
+ * never "past" here: they stay actionable until completed, and completed
+ * tasks have their own toggle. All-day events last until their day ends.
+ */
+export const isPastEvent = (task, now) => {
+  if (!task.imported || task.isTaskCalendar || !task.date) return false;
+  const todayStr = dateToString(now);
+  if (task.date < todayStr) return true;
+  if (task.date > todayStr || task.isAllDay || !task.startTime) return false;
+  const startMin = parseInt(task.startTime.slice(0, 2), 10) * 60 + parseInt(task.startTime.slice(3, 5), 10);
+  const nowMin = now.getHours() * 60 + now.getMinutes();
+  return startMin + (task.duration || 0) <= nowMin;
 };
 
 /** Matches expanded recurring-occurrence ids: recurring-<templateId>-YYYY-MM-DD */

--- a/src/utils/schedAgenda.test.js
+++ b/src/utils/schedAgenda.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { EMPTY_SCHED_FILTERS, hasActiveSchedFilters, taskMatchesSchedFilters, toggleSchedFilter, groupProjectsForFilter, limitRecurringToNextInstance, schedFiltersEqual } from './schedAgenda.js';
+import { EMPTY_SCHED_FILTERS, hasActiveSchedFilters, taskMatchesSchedFilters, toggleSchedFilter, groupProjectsForFilter, limitRecurringToNextInstance, schedFiltersEqual, isPastEvent } from './schedAgenda.js';
 
 const task = { title: 'Write report #work #deep', color: 'bg-red-500', projectId: 'p1' };
 
@@ -124,5 +124,48 @@ describe('limitRecurringToNextInstance', () => {
     const out = limitRecurringToNextInstance(days);
     expect(out[0].tasks).toHaveLength(1);
     expect(out[1].tasks).toHaveLength(0);
+  });
+});
+
+describe('isPastEvent', () => {
+  // 2026-07-28 at 14:00
+  const now = new Date('2026-07-28T14:00:00');
+  const event = (over) => ({ imported: true, date: '2026-07-28', startTime: '09:00', duration: 60, ...over });
+
+  it('ignores non-imported tasks entirely, even past-dated ones', () => {
+    expect(isPastEvent({ date: '2026-07-01', startTime: '09:00', duration: 30 }, now)).toBe(false);
+  });
+
+  it('ignores task-calendar imports (they behave like tasks)', () => {
+    expect(isPastEvent(event({ isTaskCalendar: true }), now)).toBe(false);
+  });
+
+  it('ignores events without a date', () => {
+    expect(isPastEvent(event({ date: undefined }), now)).toBe(false);
+  });
+
+  it('marks events on earlier days as past', () => {
+    expect(isPastEvent(event({ date: '2026-07-27' }), now)).toBe(true);
+  });
+
+  it('never marks events on later days', () => {
+    expect(isPastEvent(event({ date: '2026-07-29' }), now)).toBe(false);
+  });
+
+  it("today: past once the event's end has been reached", () => {
+    expect(isPastEvent(event({ startTime: '09:00', duration: 60 }), now)).toBe(true);   // ended 10:00
+    expect(isPastEvent(event({ startTime: '13:00', duration: 60 }), now)).toBe(true);   // ends exactly 14:00
+    expect(isPastEvent(event({ startTime: '13:30', duration: 60 }), now)).toBe(false);  // in progress
+    expect(isPastEvent(event({ startTime: '15:00', duration: 60 }), now)).toBe(false);  // upcoming
+  });
+
+  it('all-day events last until the day ends', () => {
+    expect(isPastEvent(event({ isAllDay: true, startTime: '00:00' }), now)).toBe(false);
+    expect(isPastEvent(event({ isAllDay: true, startTime: '00:00', date: '2026-07-27' }), now)).toBe(true);
+  });
+
+  it('zero-duration events are past once their start time passes', () => {
+    expect(isPastEvent(event({ startTime: '13:00', duration: 0 }), now)).toBe(true);
+    expect(isPastEvent(event({ startTime: '14:30', duration: 0 }), now)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Two SCHED improvements:

**In-progress indicator.** Today's timed, incomplete cards whose window contains the current minute (tasks default to 30 min, events to their stated duration) show a small pulsing dot beside the time, in the timeline now-marker red, with a "Happening now" tooltip. Ticks off the app's live `currentTime`, so it appears and disappears on its own. Related refinement: an in-progress *task* is no longer painted with the past-due red time label — red now starts when the task's window ends, the dot covers the window itself.

**Show/hide completed & past.** Two independent view preferences, following the RECURRING (`nextInstanceOnly`) pattern exactly — persisted to `day-planner-sched-*` localStorage keys, survive reload, and don't count toward the active-filter badge:

- **Completed tasks — Show/Hide**: applies to day cards and deadline chips.
- **Past events — Show/Hide**: hides imported calendar events that have ended (all-day events last until their day ends). Tasks are never hidden by this — a past-due unfinished task is still actionable. Completed tasks and past events only, per the discussed scope.

Both appear in the mobile FILTERS sheet as Show/Hide chip pairs under the Recurring section, and in the desktop rail as eye-toggle buttons alongside "Show empty days".

`isPastEvent` is a pure util in `schedAgenda.js` with 8 new tests (day boundaries, end-exactly-now, in-progress, all-day, zero-duration, task-calendar imports excluded).

## Testing

Headless-browser verified with seeded data: the pulsing dot renders only on the in-progress card; both rail toggles hide their targets; after reload the preferences persist (rail shows "Show completed"/"Show past events" and the past event stays hidden). Full suite passing (995 tests), lint clean, build succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_