### PR TITLE
Fix Electron dev-mode white screen: CSP blocked vite's react-refresh preamble

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -194,6 +194,18 @@ function createWindow(): BrowserWindow {
     logStartup(`preload-error: ${preloadPath}: ${err?.message ?? err}`));
 
   if (DEV) {
+    // concurrently starts vite and electron together, so the first load can
+    // beat the dev server and fail with ERR_CONNECTION_REFUSED. A failed dev
+    // load used to leave the window white forever; keep retrying until the
+    // server comes up (also covers vite restarts). ERR_ABORTED (-3) is a
+    // superseded navigation, not a server failure — never retry those.
+    mainWindow.webContents.on('did-fail-load', (_e, code, _desc, url) => {
+      if (code === -3 || !url?.startsWith(VITE_DEV_SERVER_URL)) return;
+      setTimeout(() => {
+        logStartup(`dev server load failed (${code}) — retrying`);
+        mainWindow?.loadURL(VITE_DEV_SERVER_URL);
+      }, 1000);
+    });
     mainWindow.loadURL(VITE_DEV_SERVER_URL);
   } else {
     mainWindow.loadURL(APP_BASE_URL);
@@ -729,6 +741,16 @@ app.whenReady().then(async () => {
   ].join('; ');
 
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    // DEV: leave the vite dev server's responses alone. The strict CSP breaks
+    // dev in two ways — script-src 'self' blocks the inline react-refresh
+    // preamble ("@vitejs/plugin-react can't detect preamble" → every module
+    // throws → permanent white screen), and connect-src without ws: would
+    // block the HMR websocket. The dev origin is trusted localhost only;
+    // packaged builds never hit this branch and keep the full CSP.
+    if (DEV && details.url.startsWith(VITE_DEV_SERVER_URL)) {
+      callback({ responseHeaders: details.responseHeaders });
+      return;
+    }
     callback({
       responseHeaders: {
         ...details.responseHeaders,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint src --max-warnings 0",
     "test": "vitest run",
     "audit": "node scripts/audit-check.mjs",
-    "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5173 electronmon .\"",
+    "dev:electron": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && concurrently -n renderer,main,preload,electron -c cyan,yellow,magenta,green \"vite --port 5183 --strictPort\" \"npx tsc -p tsconfig.electron.json -w --preserveWatchOutput\" \"npx tsc -p tsconfig.electron.preload.json -w --preserveWatchOutput\" \"VITE_DEV_SERVER_URL=http://localhost:5183 electronmon .\"",
     "build:calendar-helper": "bash scripts/build-calendar-helper.sh",
     "build:icloud-helper": "bash scripts/build-icloud-helper.sh",
     "build:helpers": "npm run build:calendar-helper",


### PR DESCRIPTION
## Diagnosis

Reproduced by building and launching the actual Electron app headless (xvfb + Playwright `_electron`). **The packaged `app://` path on current `main` is healthy** — full UI, no renderer errors. The white screen is `npm run dev:electron`, where three defects compound:

1. **CSP kills the dev renderer** (the root cause). The `onHeadersReceived` hook — added with the MAS security hardening, which is why dev worked "long ago" — stamps the strict CSP onto *every* response, including the vite dev server's. `script-src 'self'` blocks the inline react-refresh preamble vite injects into `index.html`, so every component module throws `@vitejs/plugin-react can't detect preamble` and the window stays white forever (captured verbatim from the renderer). `connect-src` without `ws:` would also strangle the HMR websocket.
2. **Port drift.** The script pinned Electron to `http://localhost:5173` while vite silently auto-increments when 5173 is busy — e.g. another GLANCE app's dev server. Electron then loads a dead (white screen) or wrong port.
3. **Startup race.** `concurrently` launches Electron and vite together; if the window loads before vite listens, the `ERR_CONNECTION_REFUSED` was logged (visible in `dayglance-startup.log`) but never retried — white forever.

## Fixes

- `onHeadersReceived` passes dev-origin responses through untouched in DEV; every other response — and everything in packaged builds — keeps the full CSP.
- `dev:electron` pins both sides to **5183** (away from other vite apps' 5173 default) with `--strictPort`, so a collision fails loudly in the terminal instead of drifting silently.
- Failed dev-server loads retry every second until the server is up (`ERR_ABORTED` excluded, so superseded navigations don't loop).

## Verification (all headless, real Electron)

- Dev mode with vite up: renders fully, no preamble error.
- Dev mode with vite started 5s **after** Electron: window recovers via the retry loop (`dev server load failed (-102) — retrying` ×3 in the startup log, then `did-finish-load`).
- Forced production path: `app://dayglance/` renders fully **and** an injected inline script is still blocked, proving the strict CSP remains enforced where it matters.
- Electron unit tests (18), full suite (987), lint — all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_