### PR TITLE
Electron: kill the white startup flash with a theme-matched window surface

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, ipcMain, net, protocol, Tray, Menu, nativeImage, globalShortcut, session, screen } from 'electron';
+import { app, BrowserWindow, shell, ipcMain, net, protocol, Tray, Menu, nativeImage, nativeTheme, globalShortcut, session, screen } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
 import dns from 'node:dns';
@@ -123,6 +123,38 @@ function saveWindowState(state: WindowState): void {
   try { fs.writeFileSync(winStatePath(), JSON.stringify(state)); } catch { /* ignore */ }
 }
 
+// ── Window background theme ──────────────────────────────────────────────────
+// A BrowserWindow's backing surface is WHITE by default, and it shows whenever
+// the window is visible before the renderer's first paint — the startup white
+// flash (worst when the 10s fallback show fires before ready-to-show on a slow
+// cold start). Dark-mode is renderer state (localStorage), which the main
+// process can't read, so the renderer reports theme changes over IPC and we
+// persist them here for the NEXT launch's window creation. First launch ever
+// falls back to the OS theme. Colors match theme-init.js / the app shell.
+const WINDOW_THEME_FILE = () => path.join(app.getPath('userData'), 'window-theme.json');
+const DARK_BG = '#1f2937';
+const LIGHT_BG = '#ffffff';
+
+function windowBackgroundColor(): string {
+  try {
+    const raw = fs.readFileSync(WINDOW_THEME_FILE(), 'utf-8');
+    const parsed = JSON.parse(raw) as { darkMode?: boolean };
+    if (typeof parsed.darkMode === 'boolean') return parsed.darkMode ? DARK_BG : LIGHT_BG;
+  } catch { /* first launch or unreadable — fall through to OS theme */ }
+  return nativeTheme.shouldUseDarkColors ? DARK_BG : LIGHT_BG;
+}
+
+ipcMain.on('window:set-theme', (_event, darkMode: unknown) => {
+  const dark = !!darkMode;
+  try {
+    fs.writeFileSync(WINDOW_THEME_FILE(), JSON.stringify({ darkMode: dark }));
+  } catch { /* best-effort — worst case the next launch uses the OS theme */ }
+  // Update live surfaces too, so resize exposure mid-session matches the theme.
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.setBackgroundColor(dark ? DARK_BG : LIGHT_BG);
+  }
+});
+
 function createWindow(): BrowserWindow {
   const saved = loadWindowState();
   didCreateMainWindow = true;
@@ -133,6 +165,7 @@ function createWindow(): BrowserWindow {
     height: saved.height,
     ...(saved.x != null && saved.y != null ? { x: saved.x, y: saved.y } : {}),
     show: false,
+    backgroundColor: windowBackgroundColor(),
     minWidth: 800,
     minHeight: 600,
     titleBarStyle: 'hiddenInset',
@@ -218,6 +251,7 @@ function createTrayWindow(): BrowserWindow {
     width: 320,
     height: 560,
     show: false,
+    backgroundColor: windowBackgroundColor(),
     frame: false,
     resizable: false,
     skipTaskbar: true,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -33,6 +33,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Sets the macOS dock badge to the number of incomplete tasks today.
   setBadgeCount: (count: number) => ipcRenderer.send('set-badge-count', count),
+  // Reports the app's dark-mode choice so the next launch's window backing
+  // surface matches the theme instead of flashing white (see main.ts).
+  setWindowTheme: (darkMode: boolean) => ipcRenderer.send('window:set-theme', darkMode),
 
   // Tray popup tells the main process to show the main window and navigate to a location.
   openMainAt: (payload: unknown) => ipcRenderer.send('tray:open-main', payload),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1624,6 +1624,9 @@ const DayPlanner = () => {
     document.documentElement.classList.toggle('dark', darkMode);
     document.documentElement.style.colorScheme = darkMode ? 'dark' : 'light';
     document.documentElement.style.backgroundColor = darkMode ? '#1f2937' : '#ffffff';
+    // Electron: report the theme so the next launch's window surface is created
+    // in the matching color instead of flashing the default white.
+    window.electronAPI?.setWindowTheme?.(darkMode);
     const themeColorMeta = document.querySelector('meta[name="theme-color"]');
     if (themeColorMeta) themeColorMeta.setAttribute('content', darkMode ? '#1f2937' : '#ffffff');
     // Sync status-bar icon colour with the app's own theme.  The app has its own


### PR DESCRIPTION
## Diagnosis

The macOS "white screen at load" is a **startup flash**, not a hang: the `BrowserWindow` backing surface defaults to white and is what's on screen whenever the window is visible before the renderer's first paint. Normally `ready-to-show` hides that, but the 10-second `fallbackShow` timeout displays the window regardless — on a slow cold start (parsing the bundle from `app://`) the white surface can sit for seconds, which matches "sometimes brief, sometimes a while." In-app reloads are clean because `theme-init.js` paints the *document* dark synchronously — it's the window's own surface that flashes, and no page-side code can fix that.

## Fix

Create the window in the right color. Dark mode is renderer state (localStorage) the main process can't read, so:

- The renderer's existing dark-mode effect reports theme changes via a new `electronAPI.setWindowTheme(darkMode)` IPC call.
- Main persists it to `userData/window-theme.json` and creates both the main window and the tray popup with the matching `backgroundColor` (`#1f2937` / `#ffffff` — the same values `theme-init.js` uses, so the surface and the first document paint agree).
- Live windows update on toggle too (covers resize-exposure mid-session), and a first-ever launch falls back to `nativeTheme.shouldUseDarkColors`.

Light-mode users keep a white surface — for them it was never a flash.

## Verification (headless, real Electron, production `app://` path)

- Launch with no stored theme: surface `#FFFFFF` (OS fallback).
- Press `D` (dark toggle): live surface flips to `#1F2937`, `window-theme.json` written as `{"darkMode":true}`.
- Relaunch: window is **created** with `#1F2937` — no white at any point — and the app renders normally.
- Electron TS compiles clean; full suite (987) and lint pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_