### PR TITLE
Settings: green calendar dot when a native calendar source is active

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -511,6 +511,13 @@ const DayPlanner = () => {
   // When a native calendar source is present (mobile bridge or macOS EventKit),
   // calendar events come from there — only the task calendar URL matters for sync.
   const calSyncConfigured = hasNativeCalendar() ? !!taskCalendarUrl : !!(syncUrl || taskCalendarUrl);
+  // The settings-panel "configured" dot: green when ANY calendar source is
+  // live — CalDAV/task URLs, or the native calendar actually delivering
+  // (availableCalendars only populates once access is granted and calendars
+  // exist). Distinct from calSyncConfigured, which gates the CalDAV sync
+  // machinery and must stay false-for-native-only so the sync button doesn't
+  // offer to sync events that don't sync.
+  const calendarSourceActive = calSyncConfigured || availableCalendars.length > 0;
   const [calendarUrlAuth, setCalendarUrlAuth] = useState(() => {
     const saved = localStorage.getItem('day-planner-calendar-url-auth');
     return saved ? JSON.parse(saved) : { username: '', password: '' };
@@ -7874,7 +7881,7 @@ const DayPlanner = () => {
     syncRetentionDays, setSyncRetentionDays,
     calSyncStatus, setCalSyncStatus,
     calSyncLastSynced, setCalSyncLastSynced,
-    calSyncConfigured,
+    calSyncConfigured, calendarSourceActive,
     showCalendarUrlHint, setShowCalendarUrlHint,
     availableCalendars, setAvailableCalendars,
     calendarFilter, setCalendarFilter,

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -73,7 +73,7 @@ const MobileSettingsPanel = () => {
     taskCalendarAuth, setTaskCalendarAuth,
     syncCalendarCreds, setSyncCalendarCreds,
     syncRetentionDays, setSyncRetentionDays,
-    calSyncStatus, calSyncLastSynced, calSyncConfigured,
+    calSyncStatus, calSyncLastSynced, calSyncConfigured, calendarSourceActive,
     availableCalendars, setAvailableCalendars,
     calendarFilter, setCalendarFilter,
     calendarUrlAuth, setCalendarUrlAuth,
@@ -599,7 +599,7 @@ const MobileSettingsPanel = () => {
         <button onClick={() => toggleSettingsSection('calSync')} className={`font-medium ${textPrimary} flex items-center gap-2 w-full text-left`}>
           <RefreshCw size={16} className={textSecondary} />
           {t('settings.calendarSync')}
-          {calSyncConfigured && <span className="mr-1 w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />}
+          {calendarSourceActive && <span className="mr-1 w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />}
           <ChevronDown size={16} className={`ml-auto flex-shrink-0 ${textSecondary} transition-transform ${collapsedSettings.calSync ? '' : 'rotate-180'}`} />
         </button>
         {!collapsedSettings.calSync && (<>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -61,7 +61,7 @@ const SettingsModal = () => {
     cloudSyncStatus, cloudSyncError, cloudSyncNow,
     vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced, vaultSkipped,
     syncKeyReady, setSyncKeyReady,
-    calSyncConfigured, syncUrl, setSyncUrl,
+    calSyncConfigured, calendarSourceActive, syncUrl, setSyncUrl,
     showCalendarUrlHint, setShowCalendarUrlHint,
     calendarUrlAuth, setCalendarUrlAuth,
     taskCalendarUrl, setTaskCalendarUrl, taskCalendarAuth, setTaskCalendarAuth,
@@ -820,7 +820,7 @@ const SettingsModal = () => {
                       <button onClick={() => toggleSettingsSection('calSync')} className={`font-medium ${textPrimary} flex items-center gap-2 w-full text-left`}>
                         <RefreshCw size={16} className={textSecondary} />
                         {t('settings.calendarSync')}
-                        {calSyncConfigured && <span className="mr-1 w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />}
+                        {calendarSourceActive && <span className="mr-1 w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />}
                         <ChevronDown size={16} className={`ml-auto flex-shrink-0 ${textSecondary} transition-transform ${collapsedSettings.calSync ? '' : 'rotate-180'}`} />
                       </button>
                       {!collapsedSettings.calSync && (<>


### PR DESCRIPTION
## Summary

On native-calendar devices (macOS EventKit via Electron, the mobile bridge) the settings panel's Calendar row showed no green status dot unless a task-calendar URL was *also* configured — a working native calendar looked unconfigured.

Root cause: the dot reused `calSyncConfigured`, which deliberately ignores native sources because it gates the CalDAV **sync machinery** (native events don't sync over CalDAV, so the sync button must stay disabled without a URL). Correct for sync, wrong for "is a calendar configured."

## Change

New `calendarSourceActive` flag drives the dot in both `SettingsModal` (desktop/tablet) and `MobileSettingsPanel`:

```
calendarSourceActive = calSyncConfigured || availableCalendars.length > 0
```

`availableCalendars` populates only after the native bridge actually returns calendars (access granted, calendars exist) — so an Electron build where calendar permission was never granted still correctly shows unconfigured, rather than keying off the bridge merely existing. Sync-button gating and the header sync icon are untouched.

## Testing

Full suite passing (987 tests), lint clean, build succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_