### PR TITLE
Android: bump versionCode to 184

### DIFF
--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.dayglance.app"
         minSdk = 26  // Android 8.0 — required for Health Connect
         targetSdk = 36
-        versionCode = 183
+        versionCode = 184
         versionName = "4.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

`versionCode` 183 → 184 in `dayglance-android/app/build.gradle.kts`, for the next internal-testing upload. Nothing else changes — `versionName` stays `4.0.0` and the web `package.json` stays `4.0.1` while testing continues, per the no-other-bumps instruction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_