### PR TITLE
GLANCE sidebar: shorten search button label to "Search"

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -172,7 +172,9 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
       className={`flex-1 flex items-center gap-2 px-3 py-2.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-black/5 text-stone-400'} transition-colors ${interactionClass}`}
     >
       <Search size={16} />
-      <span className="text-sm">{t('spotlight.searchPlaceholder')}</span>
+      {/* Short label — the row also holds filter/voice/bucket buttons, and
+          "Search tasks..." wraps to two lines in the remaining width. */}
+      <span className="text-sm truncate">{t('common.search')}</span>
       {isDesktop && <span className={`ml-auto text-xs ${textSecondary}`}>Ctrl+K</span>}
     </button>
     {allTags.length > 0 && (


### PR DESCRIPTION
## Summary

With the filter, voice, and Bucket List buttons now sharing the GLANCE header row on desktop/tablet, "Search tasks..." no longer fits and wrapped to two lines. The button label now uses the existing `common.search` key ("Search" — already translated in all six locales), with a `truncate` guard for narrow widths. The Spotlight modal's own input placeholder keeps the longer "Search tasks..." text, and the mobile GLANCE section is unchanged.

Verified in a headless browser: the button renders at single-line height (40px) with the shortcut chip and both icon buttons fitting beside it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_