### PR TITLE
Bucket List: show row actions on tablet; no keyboard pop in the editor

### DIFF
--- a/src/components/BucketListModal.jsx
+++ b/src/components/BucketListModal.jsx
@@ -23,7 +23,7 @@ const IS_IOS = typeof navigator !== 'undefined' && (
  */
 const BucketListModal = () => {
   const {
-    isMobile,
+    isMobile, isTablet,
     darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg,
     unscheduledTasks, setUnscheduledTasks, reorderUnscheduledTasks,
     scheduleTaskAtNextSlot, moveToRecycleBin, openMobileEditTask,
@@ -259,7 +259,9 @@ const BucketListModal = () => {
               : <FileText size={11} className={`flex-shrink-0 ${textSecondary} opacity-60`} />
           )}
         </button>
-        <div className={`flex items-center gap-0.5 flex-shrink-0 ${isMobile ? '' : 'opacity-0 group-hover:opacity-100 transition-opacity'}`}>
+        {/* Hover-reveal is desktop-only: tablets share the desktop layout but
+            have no hover, which left these buttons permanently invisible. */}
+        <div className={`flex items-center gap-0.5 flex-shrink-0 ${(isMobile || isTablet) ? '' : 'opacity-0 group-hover:opacity-100 transition-opacity'}`}>
           {!task.completed && (
             <>
               <button type="button" onClick={() => sendToInbox(task)} title={t('bucket.sendToInbox')} className={`p-1 rounded ${hoverBg}`}>

--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -710,6 +710,7 @@ const DesktopNewTaskModal = () => {
                     task={liveBucketTask}
                     isInbox={true}
                     darkMode={darkMode}
+                    noAutoFocus
                     updateTaskNotes={updateTaskNotes}
                     addSubtask={addSubtask}
                     toggleSubtask={toggleSubtask}

--- a/src/components/MobileNewTaskModal.jsx
+++ b/src/components/MobileNewTaskModal.jsx
@@ -567,6 +567,7 @@ const MobileNewTaskModal = () => {
                     task={liveBucketTask}
                     isInbox={true}
                     darkMode={darkMode}
+                    noAutoFocus
                     updateTaskNotes={updateTaskNotes}
                     addSubtask={addSubtask}
                     toggleSubtask={toggleSubtask}


### PR DESCRIPTION
## Summary

Two tablet/phone fixes for the Bucket List:

1. **Invisible row actions on tablet.** Tablets share the desktop layout, so the row action buttons (send to Inbox, schedule, move, delete) were hover-revealed (`opacity-0 group-hover:opacity-100`) — permanently invisible on a device with no hover. They now render at full opacity when `isMobile || isTablet`; hover-reveal remains desktop-only.

2. **Keyboard pop on open.** The editor's embedded `NotesSubtasksPanel` starts in edit mode when the task has no notes, and its textarea autofocuses by default — so opening a notes-less bucket item raised the keyboard on phones and tablets. Both editors now pass `noAutoFocus`, the same flag every other panel embed site (DesktopLayout, MobileLayout, FocusMode, HyperGlance, MobileGlanceSection) already uses.

## Testing

Verified in headless Chromium with tablet emulation (1024px, touch-primary, no hover): row action buttons render at opacity 1 without hover, and after opening a no-notes bucket item the focused element is a button, not the notes textarea. Full suite passing (995 tests), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_