### PR TITLE
Mobile inbox: add the send-to-Bucket telescope button to task rows

### DIFF
--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -7,7 +7,7 @@ import {
   Eye, FileText, Filter, Flag, Flame, FolderOpen, GitBranch, Globe, GripVertical, Hash, HelpCircle,
   Inbox, Key, Layers, LayoutGrid, Link, Loader, Menu, Mic, Minus, Moon, MoreHorizontal,
   NotebookPen, Plus, RefreshCw, Save, Search, Settings, SkipForward, Sparkles,
-  Sun, Target, Trash2, TrendingUp, Trophy, Undo2, Upload, Volume2, VolumeX,
+  Sun, Target, Telescope, Trash2, TrendingUp, Trophy, Undo2, Upload, Volume2, VolumeX,
   Wifi, X, Zap,
 } from 'lucide-react';
 import { isNativeAndroid, isNativeApp, nativeUpdateEvent } from '../native.js';
@@ -255,6 +255,7 @@ const MobileLayout = () => {
     confirmEmptyBin, emptyRecycleBin,
     hideStandaloneTasksInbox, inboxTagFilter, inboxProjectFilter, setInboxProjectFilter,
     archiveInboxTask,
+    sendTaskToBucket,
   } = useDayPlannerCtx();
   const { t } = useTranslation();
 
@@ -1039,6 +1040,15 @@ const MobileLayout = () => {
                                       />
                                     )}
                                   </div>
+                                  {!task.completed && (
+                                    <button
+                                      onClick={(e) => { e.stopPropagation(); sendTaskToBucket(task.id); }}
+                                      className="hover:bg-white/20 rounded p-1 transition-colors opacity-40"
+                                      title={t('bucket.sendToBucket')}
+                                    >
+                                      <Telescope size={14} />
+                                    </button>
+                                  )}
                                 </div>
                                 <div className="flex items-center justify-between w-full">
                                   {task.completed ? (


### PR DESCRIPTION
## Summary

The desktop and tablet inbox rows got the Telescope (send to Bucket List) action when the Bucket List shipped, but the mobile Inbox tab's rows were missed — there, the action was only reachable through the task editor. This adds the same button to the mobile rows: beside the deadline picker, incomplete tasks only, `sendTaskToBucket` with the existing undo toast, localized title via `bucket.sendToBucket`.

## Testing

Verified in headless Chromium with phone emulation (390×844, touch): the telescope renders on an inbox row, tapping it removes the task from the Inbox and shows the "sent to Bucket List" undo toast. Full suite passing (995 tests), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_