### PR TITLE
Desktop/tablet editor: send-to-Bucket button for inbox tasks

### DIFF
--- a/src/components/DesktopNewTaskModal.jsx
+++ b/src/components/DesktopNewTaskModal.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BookOpen, Calendar, Check, Loader, Sparkles, X } from 'lucide-react';
+import { BookOpen, Calendar, Check, Loader, Sparkles, Telescope, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -35,7 +35,7 @@ const DesktopNewTaskModal = () => {
     deadlinePickerTaskId, setDeadlinePickerTaskId,
     tasks,
     suggestions, showSuggestions, selectedSuggestionIndex, suggestionContext,
-    addTask, saveMobileEditTask, moveToRecycleBin,
+    addTask, saveMobileEditTask, moveToRecycleBin, sendTaskToBucket,
     applySuggestionForNewTask,
     handleNewTaskInputChange, handleNewTaskInputKeyDown,
     dismissNlChip,
@@ -730,6 +730,22 @@ const DesktopNewTaskModal = () => {
                 >
                   {mobileEditingTask ? t('task.saveChanges') : newTask.openInInbox ? (newTask.projectId ? t('task.addToProject') : t('task.addToInbox')) : newTask.projectId && newTask.keepUnscheduled ? t('task.addToProject') : newTask.projectId ? t('task.addToProjectAndSchedule') : t('task.addToSchedule')}
                 </button>
+                {/* Send-to-Bucket for inbox tasks — parity with the mobile editor */}
+                {mobileEditingTask && mobileEditIsInbox && !mobileEditingTask.bucketId && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      sendTaskToBucket(mobileEditingTask.id);
+                      setShowAddTask(false);
+                      setMobileEditingTask(null);
+                      setMobileEditIsInbox(false);
+                    }}
+                    title={t('bucket.sendToBucket')}
+                    className={`px-3 py-2 rounded-lg transition-colors ${darkMode ? 'bg-sky-900/40 text-sky-300 hover:bg-sky-900/60' : 'bg-sky-50 text-sky-700 hover:bg-sky-100'}`}
+                  >
+                    <Telescope size={16} />
+                  </button>
+                )}
                 {mobileEditingTask && (
                   <button
                     type="button"


### PR DESCRIPTION
## Summary

Result of a mobile ↔ desktop/tablet parity sweep across the v4.1.0 features: the mobile editor gained a "Send to Bucket List" button when the Bucket List shipped, but `DesktopNewTaskModal` — which is also the **tablet** editor — never did. Same gating (`mobileEditIsInbox && !bucketId`), same `sendTaskToBucket` demote path with the undo toast, rendered as a compact telescope button in the editor's action row beside Delete.

The rest of the sweep came back clean: the tablet inbox panel (`InboxSidebar variant="tablet"`) already has the row telescope, `MobileListView` renders no inbox rows, and voice buttons, GLANCE entry points, SCHED visibility toggles, quick-add chips, and the editor's bucket flavor are all present on every surface that hosts them.

## Testing

Headless-verified: editing an inbox task on desktop shows the telescope in the action row; clicking it demotes the task, closes the editor, and shows the undo toast. Full suite passing (995 tests), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_