### PR TITLE
Mobile GLANCE: match the desktop "Search" button label

### DIFF
--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -144,7 +144,9 @@ const MobileGlanceSection = () => {
       className={`flex-1 flex items-center gap-2 px-3 py-2.5 rounded-lg ${darkMode ? 'bg-white/10 text-gray-400' : 'bg-black/5 text-stone-400'} transition-colors`}
     >
       <Search size={16} />
-      <span className="text-sm">{t('spotlight.searchPlaceholder')}</span>
+      {/* "Search", not "Search tasks..." — Spotlight searches more than tasks,
+          and this matches the desktop/tablet GLANCE button. */}
+      <span className="text-sm">{t('common.search')}</span>
     </button>
     {allTags.length > 0 && (
       <button


### PR DESCRIPTION
## Summary

The mobile GLANCE search button now says "Search" like desktop/tablet (#1283) — Spotlight searches more than tasks, so "Search tasks..." undersold it. Uses the same `common.search` key, already translated in all six locales. The Spotlight modal's own input placeholder is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_