### PR TITLE
Voice: recompute the record path when the AI config changes

### DIFF
--- a/src/hooks/useVoiceInput.js
+++ b/src/hooks/useVoiceInput.js
@@ -265,10 +265,13 @@ export default function useVoiceInput({
       setVoiceParseError(msg);
       setVoiceMicError('error');
     }
-    // Omitted names are all stable state setters and *Ref values; keyed on
-    // voiceCanRecord.
+    // Omitted names are all stable state setters and *Ref values. canWhisper
+    // MUST be a dependency: it routes between platform speech and the
+    // record-then-transcribe path, and a stale closure after toggling AI off
+    // mid-session kept recording audio for a transcriber that no longer
+    // existed ("Transcription failed: AI is not configured").
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [voiceCanRecord]);
+  }, [voiceCanRecord, canWhisper]);
 
   // Native STT event channel: partial transcripts stream in live, the final
   // transcript triggers the parse, and errors fall back to typing mode.


### PR DESCRIPTION
## Summary

Fixes the reported Android "Transcription failed: AI is not configured" after turning AI off — which turned out to be a **toggle-order bug on every platform**, not an Android one.

`voiceStartRecording` was memoized on `[voiceCanRecord]` only, but it routes between platform speech recognition and the record-then-transcribe path based on `canWhisper` (derived from `aiConfig`). Toggling AI off **mid-session** left a stale closure with `canWhisper=true`: the mic kept recording audio for the Whisper path, and the stop handler — which *does* key on `aiConfig` — then called `aiTranscribe` against the now-disabled config and failed. A relaunch rebuilt the closure and everything worked, which is why iOS "worked great": same code, different toggle-then-relaunch order.

Fix: `canWhisper` joins the dependency array, so the callback re-routes to the on-device recognizer the moment AI is turned off. The Android SpeechRecognizer bridge itself was never at fault.

## Testing

Full suite passing (995), lint clean. On-device confirmation: toggle AI off and tap the mic **in the same session** — it should now use the native recognizer (live transcript, no "Transcription failed").

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_