### PR TITLE
Bucket List: new quick-add items default to their creator

### DIFF
--- a/src/components/BucketListModal.jsx
+++ b/src/components/BucketListModal.jsx
@@ -32,7 +32,7 @@ const BucketListModal = () => {
     pushUndo, setUndoToast,
     colors,
   } = useDayPlannerCtx();
-  const { isVisibleForUser } = useFeaturesCtx();
+  const { isVisibleForUser, multiUserEnabled, meUserSyncId } = useFeaturesCtx();
   const { t } = useTranslation();
 
   const [notes, setNotes] = useState(bucketConfig.notes || '');
@@ -132,6 +132,11 @@ const BucketListModal = () => {
       subtasks: [],
       priority: 0,
       bucketId: listId,
+      // Unlike inbox quick-add (unassigned = visible to everyone), new bucket
+      // items default to their creator: the Bucket is a personal
+      // someday/maybe space, not a shared work queue. Reassignable in the
+      // editor as usual.
+      ...(multiUserEnabled && meUserSyncId ? { assignedUserSyncIds: [meUserSyncId] } : {}),
       lastModified: stamp(),
     }]);
     setQuickAdd(prev => ({ ...prev, [listId]: '' }));


### PR DESCRIPTION
## Summary

In multi-user households, inbox quick-add deliberately creates unassigned (everyone-visible) tasks — a shared triage queue. The Bucket is a personal someday/maybe space, so items created through its quick-add now default to the current user (`assignedUserSyncIds: [meUserSyncId]` when multi-user is enabled). Assignment remains editable in the task editor, demoted inbox tasks keep whatever assignment they had, and single-user installs are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_