### PR TITLE
SCHED: pulse a NOW label beside the in-progress dot

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -881,7 +881,8 @@
     "hideCompleted": "Erledigte ausblenden",
     "showPastEvents": "Vergangene Termine anzeigen",
     "hidePastEvents": "Vergangene Termine ausblenden",
-    "happeningNow": "Läuft gerade"
+    "happeningNow": "Läuft gerade",
+    "nowLabel": "Jetzt"
   },
   "planner": {
     "standaloneProject": "Eigenständiges Projekt",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -881,7 +881,8 @@
     "hideCompleted": "Hide completed",
     "showPastEvents": "Show past events",
     "hidePastEvents": "Hide past events",
-    "happeningNow": "Happening now"
+    "happeningNow": "Happening now",
+    "nowLabel": "Now"
   },
   "planner": {
     "standaloneProject": "Standalone project",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -881,7 +881,8 @@
     "hideCompleted": "Ocultar completadas",
     "showPastEvents": "Mostrar eventos pasados",
     "hidePastEvents": "Ocultar eventos pasados",
-    "happeningNow": "En curso"
+    "happeningNow": "En curso",
+    "nowLabel": "Ahora"
   },
   "planner": {
     "standaloneProject": "Proyecto independiente",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -881,7 +881,8 @@
     "hideCompleted": "Masquer les terminées",
     "showPastEvents": "Afficher les événements passés",
     "hidePastEvents": "Masquer les événements passés",
-    "happeningNow": "En cours"
+    "happeningNow": "En cours",
+    "nowLabel": "En cours"
   },
   "planner": {
     "standaloneProject": "Projet indépendant",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -881,7 +881,8 @@
     "hideCompleted": "Nascondi completate",
     "showPastEvents": "Mostra eventi passati",
     "hidePastEvents": "Nascondi eventi passati",
-    "happeningNow": "In corso"
+    "happeningNow": "In corso",
+    "nowLabel": "Ora"
   },
   "planner": {
     "standaloneProject": "Progetto indipendente",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -881,7 +881,8 @@
     "hideCompleted": "Ocultar concluídas",
     "showPastEvents": "Mostrar eventos passados",
     "hidePastEvents": "Ocultar eventos passados",
-    "happeningNow": "A decorrer"
+    "happeningNow": "A decorrer",
+    "nowLabel": "Agora"
   },
   "planner": {
     "standaloneProject": "Projeto independente",

--- a/src/components/sched/SchedTaskCard.jsx
+++ b/src/components/sched/SchedTaskCard.jsx
@@ -161,9 +161,14 @@ const SchedTaskCard = ({ task, isInbox = false, showProject = false, onEdit = nu
             )}
             {inProgress && (
               <span
-                className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse flex-shrink-0"
+                className="flex items-center gap-1 animate-pulse flex-shrink-0"
                 title={t('sched.happeningNow', 'Happening now')}
-              />
+              >
+                <span className="w-1.5 h-1.5 rounded-full bg-red-500" />
+                <span className="text-[10px] font-semibold uppercase tracking-wide text-red-500">
+                  {t('sched.nowLabel', 'Now')}
+                </span>
+              </span>
             )}
             {timeLabel && (
               <span className={`flex-shrink-0 ${isPastDueTask ? 'text-red-400 font-medium' : ''}`}>{timeLabel}</span>


### PR DESCRIPTION
## Summary

The in-progress dot alone was too subtle. The dot and a small uppercase red "Now" label now pulse together as one unit on in-progress SCHED cards. Localized in all six languages (Now / Jetzt / Ahora / En cours / Ora / Agora — French uses "En cours" since "Maintenant" is unwieldy at chip size).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_