### PR TITLE
Bucket tags: hide from GLANCE tag filter and Bucket List rows

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1356,6 +1356,7 @@ const DayPlanner = () => {
   const {
     todayTasks,
     allTags,
+    filterableTags,
     incompleteTodayTasks,
     filterByTags,
     filteredUnscheduledTasks,
@@ -7673,7 +7674,7 @@ const DayPlanner = () => {
     selectedTags, setSelectedTags,
     showUntagged, setShowUntagged,
     showMobileTagFilter, setShowMobileTagFilter,
-    allTags,
+    allTags, filterableTags,
 
     // ── Task modals & editing ─────────────────────────────────────────────────
     showAddTask, setShowAddTask,

--- a/src/components/BucketListModal.jsx
+++ b/src/components/BucketListModal.jsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { BUCKET_LIST_IDS, promoteToInbox } from '../utils/bucketList.js';
-import { renderFormattedText, hasNotesOrSubtasks, hasOnlySubtasks } from '../utils/textFormatting.jsx';
+import { renderFormattedText, renderTitleWithoutTags, hasNotesOrSubtasks, hasOnlySubtasks } from '../utils/textFormatting.jsx';
 
 // Same iOS detection as ProjectPlanner/ProjectCard: grip-only touch drag on
 // iOS, where whole-row HTML5 drag hijacks the gesture.
@@ -251,7 +251,9 @@ const BucketListModal = () => {
           onClick={() => editItem(task)}
           className={`flex-1 min-w-0 text-left text-sm truncate flex items-center gap-1.5 ${task.completed ? `line-through ${textSecondary}` : textPrimary}`}
         >
-          <span className="truncate">{task.title}</span>
+          {/* Tags stay in the stored title (searchable, editable in the task
+              editor) but are visual noise in the pressure-free Bucket rows. */}
+          <span className="truncate">{renderTitleWithoutTags(task.title || '') || task.title}</span>
           {/* Passive has-notes glyph (not a button — the editor is the surface) */}
           {hasNotesOrSubtasks(task) && (
             hasOnlySubtasks(task)

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -38,7 +38,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     recurringTasks, setRecurringTasks,
     selectedTags,
     showMobileTagFilter, setShowMobileTagFilter,
-    allTags,
+    filterableTags,
     taskContextMenu, setTaskContextMenu,
     minimizedSections,
     activeFrameForNudge, activeFrameNudgeKey,
@@ -177,13 +177,13 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
       <span className="text-sm truncate">{t('common.search')}</span>
       {isDesktop && <span className={`ml-auto text-xs ${textSecondary}`}>Ctrl+K</span>}
     </button>
-    {allTags.length > 0 && (
+    {filterableTags.length > 0 && (
       <div className="flex-shrink-0 self-stretch flex items-center">
         <button
           ref={tagFilterBtnRef}
           onClick={() => setShowMobileTagFilter(v => !v)}
           className={`px-2.5 h-full flex items-center rounded-lg transition-colors ${
-            !allTags.every(tag => selectedTags.includes(tag))
+            !filterableTags.every(tag => selectedTags.includes(tag))
               ? 'bg-blue-500 text-white'
               : darkMode ? 'bg-white/10 text-gray-400' : 'bg-black/5 text-stone-400'
           } ${interactionClass}`}
@@ -207,7 +207,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                   <span className={`text-sm font-semibold ${textPrimary}`}>{t('common.filterByTag')}</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  {allTags.every(tag => selectedTags.includes(tag)) ? (
+                  {filterableTags.every(tag => selectedTags.includes(tag)) ? (
                     <button onClick={clearTagFilter} className="text-xs text-blue-500 hover:text-blue-600 font-medium">Clear</button>
                   ) : (
                     <button onClick={selectAllTags} className="text-xs text-blue-500 hover:text-blue-600 font-medium">Select All</button>
@@ -215,7 +215,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                 </div>
               </div>
               <div className="py-1 max-h-[300px] overflow-y-auto">
-                {allTags.map(tag => {
+                {filterableTags.map(tag => {
                   const highlightDates = effectiveViewMode === 'sched' && weekViewDates.length ? weekViewDates : visibleDates;
                   const visibleDateStrs = new Set(highlightDates.map(d => dateToString(d)));
                   const regularCount = tasks.filter(t => !t.imported && visibleDateStrs.has(t.date) && extractTags(t.title).includes(tag)).length;

--- a/src/components/MobileBottomSheets.jsx
+++ b/src/components/MobileBottomSheets.jsx
@@ -23,7 +23,7 @@ const MobileBottomSheets = () => {
     recycleBin, setRecycleBin,
     completedTaskUids,
     selectedTags,
-    allTags,
+    filterableTags,
     showUntagged, setShowUntagged,
     showMobileTagFilter, setShowMobileTagFilter,
     showMobileDailySummary, setShowMobileDailySummary,
@@ -162,7 +162,7 @@ const MobileBottomSheets = () => {
           <span className={`font-semibold ${textPrimary}`}>{t('common.filterByTag')}</span>
         </div>
         <div className="flex items-center gap-3">
-          {allTags.every(tag => selectedTags.includes(tag)) ? (
+          {filterableTags.every(tag => selectedTags.includes(tag)) ? (
             <button
               onClick={clearTagFilter}
               className="text-sm text-blue-500 hover:text-blue-600 active:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 dark:active:text-blue-200 font-medium transition-colors"
@@ -199,7 +199,7 @@ const MobileBottomSheets = () => {
             if (!visibleDateStrs.has(t.date)) continue;
             for (const tag of extractTags(t.title)) tagCounts[tag] = (tagCounts[tag] || 0) + 1;
           }
-          return allTags.map(tag => {
+          return filterableTags.map(tag => {
           const tagCount = tagCounts[tag] || 0;
           return (
             <button

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -39,7 +39,7 @@ const MobileGlanceSection = () => {
     recurringTasks, setRecurringTasks,
     selectedTags,
     showMobileTagFilter, setShowMobileTagFilter,
-    allTags,
+    filterableTags,
     taskContextMenu, setTaskContextMenu,
     expandedNotesTaskId, setExpandedNotesTaskId,
     showDeadlinePicker, setShowDeadlinePicker,
@@ -148,11 +148,11 @@ const MobileGlanceSection = () => {
           and this matches the desktop/tablet GLANCE button. */}
       <span className="text-sm">{t('common.search')}</span>
     </button>
-    {allTags.length > 0 && (
+    {filterableTags.length > 0 && (
       <button
         onClick={() => setShowMobileTagFilter(true)}
         className={`relative flex-shrink-0 px-2.5 self-stretch flex items-center rounded-lg transition-colors ${
-          !allTags.every(tag => selectedTags.includes(tag))
+          !filterableTags.every(tag => selectedTags.includes(tag))
             ? 'bg-blue-500 text-white'
             : darkMode ? 'bg-white/10 text-gray-400' : 'bg-black/5 text-stone-400'
         }`}

--- a/src/hooks/useComputedViews.js
+++ b/src/hooks/useComputedViews.js
@@ -38,6 +38,24 @@ export default function useComputedViews({
     return Array.from(tagSet).sort();
   }, [tasks, unscheduledTasks, recurringTasks]);
 
+  // Tags offered by the GLANCE tag-filter UIs. Bucket List items are excluded:
+  // their tasks never appear in the filtered views, so a bucket-only tag would
+  // be a filter option that matches nothing. allTags stays complete for the
+  // #-autocomplete and AI context, where bucket vocabulary is useful.
+  const filterableTags = useMemo(() => {
+    const tagSet = new Set();
+    tasks.filter(t => !t.imported).forEach(task => {
+      extractTags(task.title).forEach(tag => tagSet.add(tag));
+    });
+    unscheduledTasks.filter(t => !t.imported && notBucketed(t)).forEach(task => {
+      extractTags(task.title).forEach(tag => tagSet.add(tag));
+    });
+    recurringTasks.forEach(template => {
+      extractTags(template.title).forEach(tag => tagSet.add(tag));
+    });
+    return Array.from(tagSet).sort();
+  }, [tasks, unscheduledTasks, recurringTasks]);
+
   // Incomplete scheduled tasks from today (used by rescheduling feature)
   const incompleteTodayTasks = useMemo(() => {
     const todayStr = dateToString(new Date());
@@ -110,6 +128,7 @@ export default function useComputedViews({
   return {
     todayTasks,
     allTags,
+    filterableTags,
     incompleteTodayTasks,
     filterByTags,
     filteredUnscheduledTasks,


### PR DESCRIPTION
## Summary

Tags on bucket items remain in the stored title — Spotlight still finds them, and the task editor's title field shows them for editing — but they no longer surface in two places where they'd mislead:

- **GLANCE tag-filter UIs** (desktop popover, mobile filter sheet, and their filter-active indicators) now consume a new `filterableTags` list that excludes Bucket List items. A tag used only on bucket items was previously a filter option that could never match a visible task. `allTags` stays complete and keeps feeding the `#` autocomplete and AI context, where bucket vocabulary is useful.
- **Bucket List rows** render titles through `renderTitleWithoutTags` (same treatment as SCHED cards) — the tags are visual noise in the pressure-free space.

## Testing

Full suite passing (995 tests), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThzaGrqYU9FUT4DvocjrdC)_