### PR TITLE
Fix macOS fullscreen bugs: ESC exits fullscreen, close no longer leaves a black screen

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -188,7 +188,17 @@ function createWindow(): BrowserWindow {
   mainWindow.on('close', (event) => {
     if (process.platform === 'darwin' && !isQuitting) {
       event.preventDefault();
-      live(mainWindow)?.hide();
+      const win = live(mainWindow);
+      if (!win) return;
+      // Hiding a window that's in native macOS fullscreen strands its fullscreen
+      // Space as an empty black screen — leave fullscreen first, then hide once
+      // the transition completes.
+      if (win.isFullScreen()) {
+        win.once('leave-full-screen', () => live(mainWindow)?.hide());
+        win.setFullScreen(false);
+      } else {
+        win.hide();
+      }
       return;
     }
     saveWindowState({ ...normalBounds, maximized: live(mainWindow)?.isMaximized() ?? false });
@@ -505,6 +515,14 @@ ipcMain.handle('proxy-fetch', async (_event, method: string, url: string, header
 // Dock badge — macOS only
 ipcMain.on('set-badge-count', (_event, count: number) => {
   if (process.platform === 'darwin') app.setBadgeCount(count);
+});
+
+// Escape → leave native (green-button) fullscreen. macOS doesn't do this by
+// default; the renderer sends this only for an Escape no modal/editor consumed
+// (see src/hooks/useFullscreenEscape.js). No-op when the window isn't fullscreen.
+ipcMain.on('window:exit-fullscreen', (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (win && !win.isDestroyed() && win.isFullScreen()) win.setFullScreen(false);
 });
 
 // Tray popup requests the main window to show and navigate to a specific location.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -33,6 +33,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Sets the macOS dock badge to the number of incomplete tasks today.
   setBadgeCount: (count: number) => ipcRenderer.send('set-badge-count', count),
+  // Asks the main process to leave native fullscreen (no-op when not fullscreen).
+  exitFullscreen: () => ipcRenderer.send('window:exit-fullscreen'),
   // Reports the app's dark-mode choice so the next launch's window backing
   // surface matches the theme instead of flashing white (see main.ts).
   setWindowTheme: (darkMode: boolean) => ipcRenderer.send('window:set-theme', darkMode),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -127,6 +127,7 @@ import useAppInit from './hooks/useAppInit.js';
 import useSaveOnChange from './hooks/useSaveOnChange.js';
 import useTimelineScroll from './hooks/useTimelineScroll.js';
 import useModalClose from './hooks/useModalClose.js';
+import useFullscreenEscape from './hooks/useFullscreenEscape.js';
 import useMobileInteractions from './hooks/useMobileInteractions.js';
 import useKeyboardShortcuts from './hooks/useKeyboardShortcuts.js';
 import { DayPlannerContext } from './context/DayPlannerContext.jsx';
@@ -3084,6 +3085,10 @@ const DayPlanner = () => {
     focusLogModalDate, setFocusLogModalDate,
     showBucketList, setShowBucketList,
   });
+
+  // Escape leaves macOS fullscreen — but only an Escape that useModalClose (and
+  // every other document-level handler) left unconsumed; see the hook.
+  useFullscreenEscape();
 
   useKeyboardShortcuts({
     performUndo, performRedo,

--- a/src/hooks/useFullscreenEscape.js
+++ b/src/hooks/useFullscreenEscape.js
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+// Escape exits native macOS (green-button) fullscreen. macOS/Electron don't do
+// this by default, so users who enter fullscreen expect ESC to work and find
+// only the green button / Ctrl+Cmd+F do.
+//
+// The listener is on `window`, in the bubble phase: document-level handlers
+// (useModalClose, popover closers, …) run first, so an Escape that closed a
+// modal arrives here already defaultPrevented and is ignored — one press closes
+// the modal, a second press leaves fullscreen. Handlers that stopPropagation()
+// keep the event from reaching window at all, which has the same effect.
+// Escape inside a text field means "cancel editing", never "leave fullscreen".
+// The main process no-ops unless its window is actually fullscreen, so this can
+// fire unconditionally otherwise (and is harmless in the tray popup).
+export default function useFullscreenEscape() {
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.isElectron || typeof api.exitFullscreen !== 'function') return undefined;
+
+    const onKeyDown = (e) => {
+      if (e.key !== 'Escape' || e.defaultPrevented) return;
+      const t = e.target;
+      if (t instanceof HTMLElement && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+      api.exitFullscreen();
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+}


### PR DESCRIPTION
Fixes two macOS window-management bugs reported by a user on a MacBook Air M2 (macOS Tahoe 26.5.2):

## 1. Red button while in fullscreen → black screen

The macOS close handler in `electron/main.ts` intercepts close and calls `hide()` so the app keeps running in the tray. But hiding a window that's in native (green-button) fullscreen strands its dedicated macOS Space as an empty black screen — a well-known Electron/AppKit interaction.

**Fix:** the close handler now checks `isFullScreen()`. If fullscreen, it exits fullscreen first and hides the window only after the `leave-full-screen` transition completes; otherwise it hides immediately as before. Quit behavior is unchanged.

## 2. ESC doesn't exit fullscreen

macOS/AppKit doesn't map ESC to "leave fullscreen" by default, and the app never implemented it — so after pressing the green button, only the green button or Ctrl+Cmd+F would get you back to windowed mode.

**Fix:**
- New renderer hook `src/hooks/useFullscreenEscape.js` (wired in `App.jsx` per the established hook-extraction pattern). It listens for `keydown` on `window` in the bubble phase, which guarantees every document-level Escape handler (`useModalClose`, popover closers, etc.) runs first. An Escape that closed a modal arrives `defaultPrevented` and is ignored — one press closes the modal, the next press leaves fullscreen. Escape inside inputs/textareas/contenteditable is also ignored (that means "cancel editing").
- New `window:exit-fullscreen` IPC channel (preload: `exitFullscreen()`), which no-ops in the main process unless the sender's window is actually fullscreen — so the unconditional renderer send is harmless in windowed mode and in the tray popup.

## Testing

- `tsc` clean for both electron main and preload configs
- `npm run lint` clean
- `npm test`: 995 tests passing (63 files)
- Not exercised on real macOS hardware in this environment — worth a quick manual check: green button → ESC returns to windowed; green button → red button no longer black-screens and the app reopens from tray/dock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CR9UDwxj9VEqzZQppZNgCa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CR9UDwxj9VEqzZQppZNgCa)_