### PR TITLE
Give the macOS tray popup its own reload trigger instead of the Stream Deck broadcast

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -627,8 +627,15 @@ ipcMain.handle('hotkey:register-main-window', (_event, accelerator: string) => {
   return ok;
 });
 
-// Keep tray popup in sync: reload it in the background whenever state changes
-ipcMain.on('ws:push-state', (event) => {
+// Keep tray popup in sync: reload it in the background whenever persisted data
+// changes. Driven by 'tray:data-changed' — emitted once per save pass from the
+// main window — and NOT by 'ws:push-state', which is the Stream Deck broadcast.
+// That channel re-fires every 15 s off the renderer's clock tick (currentTime is
+// in its dependency array), so it reloaded the popup four times a minute with
+// identical data; it also omits slices the tray renders (recycle bin, daily
+// notes, areas, GTD frames), so some real edits never reached the tray at all.
+// The save pass covers both, and carries no clock dependency.
+ipcMain.on('tray:data-changed', (event) => {
   const tw = live(trayWindow);
   if (!tw) return;
   if (event.sender === tw.webContents) return;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -58,6 +58,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('tray:background-action', handler);
   },
 
+  // Main window signals that persisted data changed, so the tray popup can
+  // reload its snapshot. Deliberately payload-free and on its OWN channel:
+  // ws:push-state is the Stream Deck broadcast and re-fires every 15 s from the
+  // clock tick, which would reload the tray four times a minute for nothing.
+  notifyDataChanged: () => ipcRenderer.send('tray:data-changed'),
+
   // Show or clear the reminder dot (●) next to the tray icon.
   setTrayIndicator: (on: boolean) => ipcRenderer.send('tray:set-indicator', on),
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -125,6 +125,7 @@ import useDataPersistence from './hooks/useDataPersistence.js';
 import useLocalStoragePersist from './hooks/useLocalStoragePersist.js';
 import useAppInit from './hooks/useAppInit.js';
 import useSaveOnChange from './hooks/useSaveOnChange.js';
+import { useNotifyTrayOnChange } from './utils/trayNotify.js';
 import useTimelineScroll from './hooks/useTimelineScroll.js';
 import useModalClose from './hooks/useModalClose.js';
 import useFullscreenEscape from './hooks/useFullscreenEscape.js';
@@ -1626,6 +1627,12 @@ const DayPlanner = () => {
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [expandedNotesTaskId]);
+
+  // The tray popup reads day-planner-darkmode on mount and derives every one of
+  // its colour classes from it, so a theme change has to invalidate its snapshot
+  // or the popup stays light while the app is dark. Persisted here rather than
+  // in useLocalStoragePersist, hence the nudge lives here too.
+  useNotifyTrayOnChange(darkMode);
 
   // Persist darkMode to localStorage and update theme-color meta tag
   useEffect(() => {

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -400,6 +400,12 @@ export default function useElectronBridge({
   // Push state snapshot whenever relevant state changes.
   useEffect(() => {
     if (!window.electronAPI) return;
+    // Main window only. Guarded up here rather than just before the send: the
+    // tray runs this same effect on its own 15 s clock tick, and used to build
+    // the entire payload — goal/project progress, habit rings, tomorrow's
+    // agenda — only to discard it, four times a minute in a background-throttled
+    // renderer. Nothing between here and the send has a side effect.
+    if (isTrayMode) return;
 
     const nowMin = currentTime.getHours() * 60 + currentTime.getMinutes();
     const hgSessions = (todayHGSessions || []);
@@ -526,8 +532,6 @@ export default function useElectronBridge({
       ...activeProjects.filter(p => p.goalId).map(mapProject).sort(sortByProgressAsc),
       ...activeProjects.filter(p => !p.goalId).map(mapProject).sort(sortByProgressAsc),
     ];
-
-    if (isTrayMode) return;
 
     // Dock badge: incomplete scheduled tasks today, excluding imported calendar events
     // (imported events can't be "completed" by the user and shouldn't inflate the badge)

--- a/src/hooks/useLocalStoragePersist.js
+++ b/src/hooks/useLocalStoragePersist.js
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useNotifyTrayOnChange } from '../utils/trayNotify.js';
 
 export default function useLocalStoragePersist({
   minimizedSections,
@@ -98,4 +99,17 @@ export default function useLocalStoragePersist({
   useEffect(() => {
     localStorage.setItem('day-planner-calendar-filter', JSON.stringify(calendarFilter));
   }, [calendarFilter]);
+
+  // ── Tray popup invalidation ───────────────────────────────────────────────
+  // Only for keys the tray actually re-reads on mount. The tray renders its
+  // agenda through formatTime (use24HourClock) and shows native calendar events
+  // filtered by calendarFilter, so a change to either leaves the popup rendering
+  // a stale snapshot until something else happens to reload it.
+  //
+  // Everything else this hook persists is a main-window view preference —
+  // inbox filters, minimizedSections, onboarding dismissals, note template —
+  // which the tray either does not render or is better off keeping its own copy
+  // of, so those deliberately do NOT nudge the tray.
+  useNotifyTrayOnChange(use24HourClock);
+  useNotifyTrayOnChange(calendarFilter);
 }

--- a/src/hooks/useLocalStoragePersist.test.js
+++ b/src/hooks/useLocalStoragePersist.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Same shape as useSaveOnChange.test.js: capture what the hook hands to
+// useEffect rather than rendering it, then drive the captured callbacks to
+// simulate React re-running an effect whose dependency changed.
+const effects = [];
+vi.mock('react', () => ({
+  useEffect: (fn, deps) => { effects.push({ fn, deps }); },
+  // A fresh ref per call is correct here: each useRef call site in one render
+  // gets its own object, and re-running a captured callback closes over the
+  // same one — which is exactly what the mount-skip relies on.
+  useRef: (init) => ({ current: init }),
+}));
+
+const { default: useLocalStoragePersist } = await import('./useLocalStoragePersist.js');
+
+// Distinct object identities so "which effects depend on this value" is
+// unambiguous — booleans would collide with the other boolean preferences.
+const CLOCK = { sentinel: 'use24HourClock' };
+const VIEW_PREF = { sentinel: 'hideCompletedInbox' };
+
+function baseProps(overrides = {}) {
+  return {
+    minimizedSections: {},
+    use24HourClock: CLOCK,
+    inboxPriorityFilter: 'all',
+    hideCompletedInbox: VIEW_PREF,
+    hideProjectTasksInbox: false,
+    hideStandaloneTasksInbox: false,
+    inboxTagFilter: [],
+    inboxProjectFilter: null,
+    priorityPromptDismissed: false,
+    sectionInfoDismissed: {},
+    skipOnboardingPersist: { current: true },
+    dailyNotes: {},
+    suppressCloudUploadRef: { current: false },
+    cloudSyncConfig: null,
+    cloudSyncInitialDoneRef: { current: false },
+    dailyNoteTemplate: '',
+    calendarUrlAuth: {},
+    autoBackupConfig: {},
+    calendarFilter: [],
+    ...overrides,
+  };
+}
+
+const notifyDataChanged = vi.fn();
+
+// Run every captured effect once — the mount pass.
+const mount = () => effects.forEach(e => e.fn());
+// Re-run only the effects that depend on `value` — one dependency changed.
+const change = (value) => effects.filter(e => e.deps?.includes(value)).forEach(e => e.fn());
+
+describe('useLocalStoragePersist tray invalidation', () => {
+  beforeEach(() => {
+    effects.length = 0;
+    notifyDataChanged.mockClear();
+    globalThis.localStorage = { setItem: vi.fn(), getItem: vi.fn(() => null), removeItem: vi.fn() };
+    globalThis.window = { electronAPI: { notifyDataChanged } };
+  });
+
+  afterEach(() => {
+    delete globalThis.window;
+    delete globalThis.localStorage;
+  });
+
+  it('does not nudge the tray on the mount pass', () => {
+    useLocalStoragePersist(baseProps());
+    mount();
+    // Every persist effect fires on mount with the value it just read back out
+    // of localStorage. Emitting there would reload the tray popup on every
+    // main-window load, for no change.
+    expect(notifyDataChanged).not.toHaveBeenCalled();
+  });
+
+  it('nudges the tray exactly once when use24HourClock changes', () => {
+    useLocalStoragePersist(baseProps());
+    mount();
+    notifyDataChanged.mockClear();
+
+    change(CLOCK);
+
+    // The tray renders its agenda through formatTime, so a 12h/24h switch has
+    // to invalidate its snapshot -- and exactly once, not once per effect that
+    // happens to share the dependency.
+    expect(notifyDataChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not nudge the tray for a view-preference-only key', () => {
+    useLocalStoragePersist(baseProps());
+    mount();
+    notifyDataChanged.mockClear();
+
+    change(VIEW_PREF);
+
+    // hideCompletedInbox is main-window inbox chrome the tray never renders;
+    // reloading the popup for it would be pure waste.
+    expect(notifyDataChanged).not.toHaveBeenCalled();
+  });
+
+  it('still persists the view preference it declined to nudge for', () => {
+    useLocalStoragePersist(baseProps());
+    mount();
+    // Guards the negative case above against passing for the wrong reason (a
+    // dropped effect rather than a deliberately absent nudge).
+    expect(globalThis.localStorage.setItem)
+      .toHaveBeenCalledWith('hideCompletedInbox', VIEW_PREF.toString());
+  });
+});

--- a/src/hooks/useSaveOnChange.js
+++ b/src/hooks/useSaveOnChange.js
@@ -18,6 +18,12 @@ export default function useSaveOnChange({
   useEffect(() => {
     if (isTrayMode || !dataLoaded) return;
     saveData();
+    // Tell the tray popup its snapshot is stale, now that saveData() has
+    // committed every key it owns (it is synchronous, so storage is fresh on
+    // return). Payload-free: the tray re-reads localStorage on reload. Reached
+    // only from the main window — the isTrayMode bail above guarantees it — so
+    // the popup can never trigger its own reload loop.
+    if (typeof window !== 'undefined') window.electronAPI?.notifyDataChanged?.();
     checkConflicts();
     // Push-on-write to the GLANCEvault DB transport (debounced 3 s, vault-only).
     // Off-safe no-op when the vault is disabled; skipped while applying remote

--- a/src/hooks/useSaveOnChange.js
+++ b/src/hooks/useSaveOnChange.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { schedulePush as scheduleVaultPush } from '../sync/dirtyTracker.js';
+import { notifyTrayDataChanged } from '../utils/trayNotify.js';
 
 // The tray popup must never write to localStorage — it holds a snapshot of
 // state as of the last reload and would overwrite fresher main-window data.
@@ -20,10 +21,11 @@ export default function useSaveOnChange({
     saveData();
     // Tell the tray popup its snapshot is stale, now that saveData() has
     // committed every key it owns (it is synchronous, so storage is fresh on
-    // return). Payload-free: the tray re-reads localStorage on reload. Reached
-    // only from the main window — the isTrayMode bail above guarantees it — so
-    // the popup can never trigger its own reload loop.
-    if (typeof window !== 'undefined') window.electronAPI?.notifyDataChanged?.();
+    // return). Deliberately not mount-skipped: the dataLoaded gate above means
+    // the first run is the first REAL save pass (post-loadData), which does
+    // rewrite the keys the tray reads, so one reload per main-window launch is
+    // correct rather than spurious.
+    notifyTrayDataChanged();
     checkConflicts();
     // Push-on-write to the GLANCEvault DB transport (debounced 3 s, vault-only).
     // Off-safe no-op when the vault is disabled; skipped while applying remote

--- a/src/hooks/useSaveOnChange.test.js
+++ b/src/hooks/useSaveOnChange.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Capture what useSaveOnChange passes to useEffect (callback + dependency array)
 // without needing a DOM renderer. React re-runs an effect whenever any value in
@@ -67,5 +67,54 @@ describe('useSaveOnChange dependency wiring', () => {
     useSaveOnChange(baseProps({ suppressCloudUploadRef: { current: true } }));
     captured.fn();
     expect(schedulePush).not.toHaveBeenCalled();
+  });
+});
+
+// The tray popup holds a snapshot of localStorage as of its last reload, so it
+// needs a nudge once a save pass has committed. That nudge rides the save pass
+// (not the Stream Deck ws:push-state broadcast, which re-fires every 15 s off
+// the clock tick and omits several slices the tray renders), so it must fire
+// exactly once per save and never when the save is skipped.
+describe('useSaveOnChange tray notification', () => {
+  const notifyDataChanged = vi.fn();
+
+  beforeEach(() => {
+    captured.fn = null;
+    captured.deps = null;
+    notifyDataChanged.mockClear();
+    globalThis.window = { electronAPI: { notifyDataChanged } };
+  });
+
+  afterEach(() => {
+    delete globalThis.window;
+  });
+
+  it('notifies the tray once after saveData() completes', () => {
+    const saveData = vi.fn();
+    useSaveOnChange(baseProps({ saveData }));
+    captured.fn();
+
+    expect(saveData).toHaveBeenCalledTimes(1);
+    expect(notifyDataChanged).toHaveBeenCalledTimes(1);
+    // Ordering matters: the tray re-reads localStorage on reload, so the nudge
+    // is only meaningful once saveData() has committed. saveData is synchronous,
+    // so "after it returns" is sufficient.
+    expect(saveData.mock.invocationCallOrder[0])
+      .toBeLessThan(notifyDataChanged.mock.invocationCallOrder[0]);
+  });
+
+  it('does not notify the tray when the save pass is skipped (data not loaded)', () => {
+    const saveData = vi.fn();
+    useSaveOnChange(baseProps({ saveData, dataLoaded: false }));
+    captured.fn();
+
+    expect(saveData).not.toHaveBeenCalled();
+    expect(notifyDataChanged).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when the bridge is absent (web build, no electronAPI)', () => {
+    globalThis.window = {};
+    useSaveOnChange(baseProps());
+    expect(() => captured.fn()).not.toThrow();
   });
 });

--- a/src/hooks/useSaveOnChange.test.js
+++ b/src/hooks/useSaveOnChange.test.js
@@ -6,8 +6,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // in the deps AND that running the effect calls schedulePush is equivalent to
 // proving "editing that slice schedules a vault push".
 const captured = { fn: null, deps: null };
+// useRef is needed because useSaveOnChange pulls in utils/trayNotify.js, which
+// imports both hooks; a mock missing an export fails at import time.
 vi.mock('react', () => ({
   useEffect: (fn, deps) => { captured.fn = fn; captured.deps = deps; },
+  useRef: (init) => ({ current: init }),
 }));
 
 const schedulePush = vi.fn();

--- a/src/hooks/useVoiceAI.js
+++ b/src/hooks/useVoiceAI.js
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { loadAIConfig, saveAIConfig } from '../ai.js';
 import { localDateStr } from '../utils/taskUtils.js';
+import { useNotifyTrayOnChange } from '../utils/trayNotify.js';
 
 const useVoiceAI = () => {
   // AI configuration state
@@ -92,6 +93,13 @@ const useVoiceAI = () => {
   useEffect(() => {
     saveAIConfig(aiConfig);
   }, [aiConfig]);
+
+  // The tray popup gates its voice button on aiConfig.enabled /
+  // features.voiceTaskInput (TrayHeader) and its morning-glance card on
+  // features.smartScheduling (GlanceSidebar), reading both from
+  // day-planner-ai-config on mount — so toggling AI in Settings has to
+  // invalidate the popup's snapshot.
+  useNotifyTrayOnChange(aiConfig);
 
   return {
     aiConfig, setAiConfig,

--- a/src/utils/trayNotify.js
+++ b/src/utils/trayNotify.js
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react';
+
+// The macOS tray popup renders from a snapshot of localStorage taken at its last
+// reload, so it has to be told when a value it reads has changed. This module is
+// the ONE definition of that nudge — never inline
+// `window.electronAPI?.notifyDataChanged?.()` at a call site.
+//
+// The tray guard lives here rather than at each call site because the popup runs
+// the same App tree as the main window, so every persist effect that emits also
+// runs inside the tray. Guarding centrally means a new call site cannot forget it
+// and send the popup into a reload loop.
+const isTrayMode =
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location?.search ?? '').has('tray');
+
+// Off-safe everywhere: no-ops on web (no electronAPI), under SSR/tests (no
+// window), and inside the tray popup itself.
+export function notifyTrayDataChanged() {
+  if (isTrayMode) return;
+  if (typeof window === 'undefined') return;
+  window.electronAPI?.notifyDataChanged?.();
+}
+
+// Nudge the tray whenever `value` changes, skipping the mount pass.
+//
+// The mount skip is the point of the hook: every persist effect in the app fires
+// once on mount with the value it just read back out of localStorage. Emitting
+// there would reload the tray popup on every main-window load, which is exactly
+// the wasted reload this signal exists to avoid.
+export function useNotifyTrayOnChange(value) {
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
+    notifyTrayDataChanged();
+  }, [value]);
+}


### PR DESCRIPTION
## Why

The tray popup reloaded on every `ws:push-state` — the Stream Deck state broadcast. That effect's dependency array includes `currentTime`, and `App.jsx:1759` ticks `currentTime` every 15 s for reminder responsiveness, so **the popup was being fully reloaded four times a minute on an idle machine**, with byte-identical data each time.

The same coupling also missed real changes. `ws:push-state`'s deps omit `recycleBin`, `dailyNotes`, `areas`, `gtdFrames`, `recurringTasks`, `routineDefinitions` and `habitLogs`, so edits confined to those slices never reloaded the tray at all — it kept showing stale data until an unrelated dep changed or the clock ticked.

So the trigger was simultaneously far too eager and not eager enough, and the 15 s tick was papering over the gaps.

## What changed

**1. Split the reload onto its own channel** (`231947c`)

New payload-free `tray:data-changed`, emitted from `useSaveOnChange` once `saveData()` returns (it's synchronous, so storage is fresh at that point — the same post-save hook point `folderBackupWriteRef` already uses). The main-process listener at `main.ts:631` moves to the new channel, keeping the 500 ms debounce, the deferred-until-blur behavior when the popup is visible, and the ignore-if-sender-is-tray check.

Also hoisted the `isTrayMode` guard in `useElectronBridge` above the snapshot build. The tray runs that effect on its own 15 s tick and was computing the entire payload — goal/project progress, habit rings, tomorrow's agenda — only to discard it at the end, in a background-throttled renderer. Nothing between the new guard position and the send has a side effect.

**2. Cover every persisted value the tray actually renders** (`8a73cb3`)

Removing the 15 s tick exposed a set of gaps it had been masking: any persisted value the tray reads was previously at most 15 s stale regardless of whether anything was keyed on it. Four tray-rendered values were not covered by the save pass:

| Value | Why the tray needs it |
|---|---|
| `darkMode` | every colour class in the popup derives from it |
| `use24HourClock` | the tray agenda formats times through `formatTime` |
| `aiConfig` | gates the tray voice button and the morning-glance card |
| `calendarFilter` | filters the native calendar events the tray shows |

Deliberately **not** emitted: `minimizedSections`, `glancePage`, the inbox filters, onboarding dismissals, note template, calendar URL auth, auto-backup config. Those are main-window view preferences the tray either doesn't render or is better off keeping its own copy of.

The emit is extracted into `src/utils/trayNotify.js` as the single definition, with the tray guard **inside** it rather than at each call site — the popup runs the same App tree, so every persist effect that emits also runs there, and a call site that forgot the guard would put the popup into a reload loop.

Every persist effect fires on mount with the value it just read back out of localStorage, so the companion `useNotifyTrayOnChange` hook skips the mount pass; without it a main-window load would reload the tray for no change. `useSaveOnChange` keeps emitting on its first run, which its `dataLoaded` gate makes the first *real* save rather than a mount artifact — one reload per launch, against ~4/minute before.

## Stream Deck is unaffected

Verified byte-identical:
- `ws-server.ts` untouched, and is now the sole `ws:push-state` listener.
- `preload.ts` `pushState` sender unchanged.
- The `pushState({...})` payload literal and its 40-entry dependency array are untouched — the diff on `useElectronBridge.js` is only the two guard-position lines.
- Cadence unchanged: in the main window `isTrayMode` is `false`, so the hoisted guard is a no-op and the effect proceeds exactly as before, including the 15 s clock-tick re-push.

## Testing

- New `src/hooks/useLocalStoragePersist.test.js`: no nudge on mount, exactly one on `use24HourClock`, none for a view-preference-only key, plus a fourth asserting that key still persists so the negative test can't pass for the wrong reason.
- Extended `src/hooks/useSaveOnChange.test.js`: emit fires exactly once and strictly after `saveData()` (via `invocationCallOrder`), doesn't fire when the save is skipped, doesn't throw with no `electronAPI`.
- All new assertions were mutation-tested — dropping the clock nudge, adding a view-pref nudge, and removing the mount skip each fail the corresponding test.
- Full suite green: 64 files / 1002 tests. `eslint src --max-warnings 0` clean. Both `tsconfig.electron.json` and `tsconfig.electron.preload.json` typecheck clean.

## Not included

Deliberately left for separate changes: `loadData`'s unconditional normalization write-back, the ~30 scattered `isTrayMode` guards and their missing shared helper, `useCloudSync`'s unguarded IndexedDB keystore open in the tray, and the silently-dropped `tray:background-action` when no main window exists.

One thing worth a look separately: the native calendar effects (`App.jsx:3572`, `:3699`) are guarded on `hasNativeCalendar()` only, not `isTrayMode`, so the tray runs its own EventKit fetch on every reload — a live side effect in the popup, not just wasted compute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_