### PR TITLE
Release prep: bump version to 4.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="screenshots/badges/google-play.png" alt="Get it on Google Play" height="60">](https://play.google.com/store/apps/details?id=com.dayglance.app) [<img src="screenshots/badges/app-store.svg" alt="Download on the App Store" height="60">](https://apps.apple.com/app/id6771540599)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-4.1.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-4.1.1-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         // fallback for plain gradle/IDE builds and no longer needs a commit
         // per Play upload.
         versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 185
-        versionName = "4.1.0"
+        versionName = "4.1.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@glance-apps/billing": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dayglance",
   "private": true,
   "license": "MIT",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Why

The 4.1.1 bump was made locally yesterday so the macOS fullscreen fix could be built and shipped, but it could never reach `main` — that branch only accepts commits through a pull request. This gets it in through the front door and unsticks the diverged local `main`.

## What

`npm run bump 4.1.1`, run on top of current `main` rather than cherry-picked from the local commit, so `package-lock.json` and the Android `versionName` match exactly what the script produces:

| File | Change |
|---|---|
| `package.json` | `version` 4.1.0 → 4.1.1 |
| `package-lock.json` | `version` 4.1.0 → 4.1.1 |
| `dayglance-android/app/build.gradle.kts` | `versionName` 4.1.0 → 4.1.1 |
| `README.md` | version badge 4.1.0 → 4.1.1 |

No code changes.

## Scope note

Because this sits on top of current `main`, 4.1.1 covers everything merged since 4.1.0 — the macOS fullscreen fixes (#1295) **and** the tray reload trigger (#1297), not just the fullscreen fix the bump was originally cut for. Worth a look before merging if 4.1.1 was meant to be fullscreen-only.

## Follow-up not done here

Per the script's own output and `RELEASING.md`, the iOS project still needs regenerating so `MARKETING_VERSION` picks this up **before** archiving:

```
npm run ios:generate
```

That touches generated Xcode project files and is better done on a Mac as part of the release run, so it's deliberately excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_