### PR TITLE
Stop the tray popup persisting loadData's normalization write-back

### DIFF
--- a/src/hooks/useDataPersistence.js
+++ b/src/hooks/useDataPersistence.js
@@ -12,6 +12,13 @@ import { stampTimestamps } from '../utils/stampTimestamps.js';
 const isSubscriptionImport = (t) =>
   !t._native && t.imported && !t.isTaskCalendar && t.importSource !== 'file';
 
+// The tray popup must never write to localStorage — it holds a snapshot of
+// state as of the last reload and would overwrite fresher main-window data
+// (same invariant as useSaveOnChange.js). loadData's normalization write-back
+// runs on every tray mount and reload, so it needs the guard too: the tray
+// still reads and normalizes for its own render, it just never persists.
+const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+
 export default function useDataPersistence({
   // setters for loadData
   setTasks, setUnscheduledTasks, setRecycleBin, setRecurringTasks,
@@ -70,14 +77,14 @@ export default function useDataPersistence({
         notes: t.notes ?? '',
         subtasks: t.subtasks ?? []
       })) : [];
-      if (tasksData) localStorage.setItem('day-planner-tasks', JSON.stringify(parsedTasks));
+      if (tasksData && !isTrayMode) localStorage.setItem('day-planner-tasks', JSON.stringify(parsedTasks));
 
       const parsedUnscheduled = unscheduledData ? JSON.parse(unscheduledData).map(t => ({
         ...t,
         notes: t.notes ?? '',
         subtasks: t.subtasks ?? []
       })) : [];
-      if (unscheduledData) localStorage.setItem('day-planner-unscheduled', JSON.stringify(parsedUnscheduled));
+      if (unscheduledData && !isTrayMode) localStorage.setItem('day-planner-unscheduled', JSON.stringify(parsedUnscheduled));
 
       // Load tasks normally; preserve any _native events already queued by Effect B
       // if it raced ahead of loadData in React's state update batch. On native-
@@ -128,7 +135,7 @@ export default function useDataPersistence({
         setTodayRoutines([]);
         setRoutinesDate(todayStr);
         setRemovedTodayRoutineIds({});
-        localStorage.removeItem('day-planner-removed-today-routine-ids');
+        if (!isTrayMode) localStorage.removeItem('day-planner-removed-today-routine-ids');
       }
 
       // Load habit tracking data
@@ -137,7 +144,7 @@ export default function useDataPersistence({
         const parsedHabits = JSON.parse(habitsData).map(h =>
           h.scheduledDays ? h : { ...h, scheduledDays: [0, 1, 2, 3, 4, 5, 6] }
         );
-        localStorage.setItem('day-planner-habits', JSON.stringify(parsedHabits));
+        if (!isTrayMode) localStorage.setItem('day-planner-habits', JSON.stringify(parsedHabits));
         setHabits(parsedHabits);
       }
       const habitLogsData = localStorage.getItem('day-planner-habit-logs');

--- a/src/hooks/useDataPersistence.test.js
+++ b/src/hooks/useDataPersistence.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// hasNativeCalendar() reaches for the native/Electron bridges, which don't
+// exist under vitest's node environment. Pin it off so loadData takes the
+// plain-web path; the subscription-import filter it gates is not under test.
+vi.mock('../utils/nativeCalendar.js', () => ({ hasNativeCalendar: () => false }));
+
+// isTrayMode is derived once at module load from window.location.search, so each
+// mode needs its own module instance — set the URL, then import.
+async function loadHookAs(mode) {
+  vi.resetModules();
+  globalThis.window = { location: { search: mode === 'tray' ? '?tray=1' : '' } };
+  const mod = await import('./useDataPersistence.js');
+  return mod.default;
+}
+
+// A task missing `notes`/`subtasks` — exactly what the normalization pass fills
+// in, so the write-back has something real to persist.
+const STORED_TASKS = JSON.stringify([{ id: 't1', title: 'Task', date: '2026-08-01' }]);
+const STORED_UNSCHEDULED = JSON.stringify([{ id: 'u1', title: 'Inbox item' }]);
+// A habit missing `scheduledDays`, the habits-branch normalization.
+const STORED_HABITS = JSON.stringify([{ id: 'h1', name: 'Water', target: 8 }]);
+
+function makeProps() {
+  const setters = {};
+  const noop = (name) => { setters[name] = vi.fn(); return setters[name]; };
+  return {
+    props: {
+      setTasks: noop('setTasks'),
+      setUnscheduledTasks: noop('setUnscheduledTasks'),
+      setRecycleBin: noop('setRecycleBin'),
+      setRecurringTasks: noop('setRecurringTasks'),
+      setDarkMode: noop('setDarkMode'),
+      setSyncUrl: noop('setSyncUrl'),
+      setTaskCalendarUrl: noop('setTaskCalendarUrl'),
+      setCompletedTaskUids: noop('setCompletedTaskUids'),
+      setDailyNotes: noop('setDailyNotes'),
+      setRoutineDefinitions: noop('setRoutineDefinitions'),
+      setTodayRoutines: noop('setTodayRoutines'),
+      setRoutinesDate: noop('setRoutinesDate'),
+      setRemovedTodayRoutineIds: noop('setRemovedTodayRoutineIds'),
+      setHabits: noop('setHabits'),
+      setHabitLogs: noop('setHabitLogs'),
+      setHabitsEnabled: noop('setHabitsEnabled'),
+      setRoutinesEnabled: noop('setRoutinesEnabled'),
+      setGoals: noop('setGoals'),
+      setProjects: noop('setProjects'),
+      setAreas: noop('setAreas'),
+      setGoalsProjectsEnabled: noop('setGoalsProjectsEnabled'),
+      setDataLoaded: noop('setDataLoaded'),
+      setUnscheduledOrderTimestamp: noop('setUnscheduledOrderTimestamp'),
+      setUndoToast: noop('setUndoToast'),
+      suppressTimestampRef: { current: false },
+      cloudSyncInitialDoneRef: { current: false },
+      cloudSyncConfig: null,
+    },
+    setters,
+  };
+}
+
+// Only the keys loadData reads; everything else returns null.
+const STORE = {
+  'day-planner-tasks': STORED_TASKS,
+  'day-planner-unscheduled': STORED_UNSCHEDULED,
+  'day-planner-habits': STORED_HABITS,
+};
+
+describe('loadData normalization write-back', () => {
+  let setItem;
+  let removeItem;
+
+  beforeEach(() => {
+    setItem = vi.fn();
+    removeItem = vi.fn();
+    globalThis.localStorage = {
+      getItem: vi.fn((k) => STORE[k] ?? null),
+      setItem,
+      removeItem,
+    };
+  });
+
+  afterEach(() => {
+    delete globalThis.localStorage;
+    delete globalThis.window;
+  });
+
+  it('persists the normalized values in the main window', async () => {
+    const useDataPersistence = await loadHookAs('main');
+    const { props } = makeProps();
+
+    useDataPersistence(props).loadData();
+
+    // All four write sites fire. Without this the normalization is lost and
+    // stampTaskTimestamps re-stamps lastModified on every task at next load.
+    const written = Object.fromEntries(setItem.mock.calls);
+    expect(JSON.parse(written['day-planner-tasks'])[0])
+      .toMatchObject({ id: 't1', notes: '', subtasks: [] });
+    expect(JSON.parse(written['day-planner-unscheduled'])[0])
+      .toMatchObject({ id: 'u1', notes: '', subtasks: [] });
+    expect(JSON.parse(written['day-planner-habits'])[0])
+      .toMatchObject({ id: 'h1', scheduledDays: [0, 1, 2, 3, 4, 5, 6] });
+    expect(removeItem).toHaveBeenCalledWith('day-planner-removed-today-routine-ids');
+  });
+
+  it('writes nothing to localStorage in tray mode', async () => {
+    const useDataPersistence = await loadHookAs('tray');
+    const { props } = makeProps();
+
+    useDataPersistence(props).loadData();
+
+    // The tray holds a snapshot as of its last reload; persisting from it would
+    // overwrite fresher main-window data (useSaveOnChange.js:5).
+    expect(setItem).not.toHaveBeenCalled();
+    expect(removeItem).not.toHaveBeenCalled();
+  });
+
+  it('still reads and normalizes in tray mode, only skipping persistence', async () => {
+    const useDataPersistence = await loadHookAs('tray');
+    const { props, setters } = makeProps();
+
+    useDataPersistence(props).loadData();
+
+    // setTasks takes an updater; run it to see the value the tray would render.
+    const tasksUpdater = setters.setTasks.mock.calls[0][0];
+    expect(tasksUpdater([])[0]).toMatchObject({ id: 't1', notes: '', subtasks: [] });
+
+    expect(setters.setUnscheduledTasks).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'u1', notes: '', subtasks: [] }),
+    ]);
+    expect(setters.setHabits).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'h1', scheduledDays: [0, 1, 2, 3, 4, 5, 6] }),
+    ]);
+    // The routine-id reset still updates React state; only the removeItem is skipped.
+    expect(setters.setRemovedTodayRoutineIds).toHaveBeenCalledWith({});
+    expect(setters.setDataLoaded).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
## Why

`useSaveOnChange.js:5` documents the invariant:

> The tray popup must never write to localStorage — it holds a snapshot of state as of the last reload and would overwrite fresher main-window data.

`loadData` was exempt from it. It runs on every tray mount and every tray reload — `useAppInit.js:15` calls it *before* its own `isTrayMode` bail on line 16 — and wrote four keys unconditionally.

The writes are guarded only on *"did this key exist"*, never on whether normalization actually changed anything:

| Site | Guard before | What it writes |
|---|---|---|
| `:73` | `if (tasksData)` | `day-planner-tasks` |
| `:80` | `if (unscheduledData)` | `day-planner-unscheduled` |
| `:131` | `else` branch of the routines-date check | `removeItem` `day-planner-removed-today-routine-ids` |
| `:140` | `if (habitsData)` | `day-planner-habits` |

At `:140` the per-habit `.map` *is* conditional, but the `setItem` sits outside it, so a fully-normalized habit list is still re-serialized and written.

## Severity, stated honestly

This was not corrupting content. The writes are value-idempotent when nothing needed normalizing, and the tray never stamps `lastModified` (`useSaveOnChange` bails before `saveData`). What it was doing was letting a renderer holding a stale snapshot rewrite keys the main window owns, outside any lock — the exact thing the invariant exists to prevent.

## What changed

Added the module-level `isTrayMode` derivation (same one-liner as the other 12 sites) and guarded the four write sites. **Reads, parsing and normalization are untouched** — the tray still renders normalized values, it just stops persisting them.

## Verification

New `src/hooks/useDataPersistence.test.js` — the first test for this hook — covers both halves, since "the tray writes nothing" is only safe if the main window still writes:

- **main window** persists all four normalizations (`notes`/`subtasks` defaults, habit `scheduledDays`, and the routine-id `removeItem`)
- **tray** persists none of them
- **tray still normalizes** — `setTasks`/`setUnscheduledTasks`/`setHabits` receive the same normalized values, and `setRemovedTodayRoutineIds({})` still fires; only the `removeItem` is skipped

All three assertions were mutation-tested: dropping the guard on the tasks write and on the habits write each fail the tray test, and forcing `isTrayMode = true` fails the main-window test — that last one is what proves the write-back isn't lost.

Full suite green: 65 files / 1005 tests. `eslint src --max-warnings 0` clean. Both electron tsconfigs clean.

## Note on the branch

The follow-up work originally targeted `claude/dayglance-macos-tray-arch-4ax2r2`, but that branch's PR (#1297) is already merged, so per `CLAUDE.md` this is a fresh branch cut from current `main` (`4ffde96`) rather than new commits stacked on merged history.

## Scope

Nothing else touched — no other tray guard, no read logic, no normalization logic, and the native calendar effects are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_