### PR TITLE
Extract the tray-mode predicate to a single definition

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -160,11 +160,11 @@ import ReviewerBanner from './components/ReviewerBanner.jsx';
 import { useSubscription } from './hooks/useSubscription.js';
 import { useTranslation } from 'react-i18next';
 import { syncErrorText } from './sync/syncErrors.js';
+import { isTrayMode } from './utils/trayMode.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
 const toBase64 = (str) => btoa(String.fromCharCode(...new TextEncoder().encode(str)));
-
 
 
 // Cloud sync provider abstraction
@@ -214,8 +214,6 @@ const TimePicker = ({ value, onChange, use24HourClock, borderClass, darkMode }) 
 // Smart Schedule panel — shows AI scheduling UI
 // FrameNudgeCard extracted to src/components/FrameNudgeCard.jsx
 
-
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
 
 // How far back/forward the spotlight search fetches native (device) calendar events.
 // The timeline only loads a ±2-day window, so a broader range is fetched on demand
@@ -1753,7 +1751,6 @@ const DayPlanner = () => {
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
   }, [mobileActiveTab, mobileSettingsView, isMobile]);
-
 
 
   // Track for onboarding when sync is set up

--- a/src/hooks/useAppInit.js
+++ b/src/hooks/useAppInit.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { isNativeAndroid, isNativeApp } from '../native.js';
 
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+import { isTrayMode } from '../utils/trayMode.js';
 
 export default function useAppInit({
   loadData, fetchAllDailyContent, setContentRotation,

--- a/src/hooks/useDataPersistence.js
+++ b/src/hooks/useDataPersistence.js
@@ -17,7 +17,7 @@ const isSubscriptionImport = (t) =>
 // (same invariant as useSaveOnChange.js). loadData's normalization write-back
 // runs on every tray mount and reload, so it needs the guard too: the tray
 // still reads and normalizes for its own render, it just never persists.
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+import { isTrayMode } from '../utils/trayMode.js';
 
 export default function useDataPersistence({
   // setters for loadData

--- a/src/hooks/useElectronBridge.js
+++ b/src/hooks/useElectronBridge.js
@@ -23,6 +23,7 @@ import {
   MSG_DAY_HG_COMPLETE,
   MSG_DAY_HG_TASK_COMPLETE,
 } from '../../electron/protocol';
+import { isTrayMode } from '../utils/trayMode.js';
 
 const timeToMinutes = (time) => {
   if (!time) return 0;
@@ -30,7 +31,6 @@ const timeToMinutes = (time) => {
   return h * 60 + (m || 0);
 };
 
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
 
 // Inline habit color map (mirrors HABIT_COLORS ring values from src/constants/habits.js)
 const HABIT_COLOR_HEX = {

--- a/src/hooks/useReminderEngine.js
+++ b/src/hooks/useReminderEngine.js
@@ -4,7 +4,7 @@ import { isNativeAndroid, isNativeApp, nativeShowNotification, nativeShowTaskNot
 
 // The tray popup runs the same App tree — skip the reminder engine there so
 // sounds and notifications don't fire twice (once per renderer process).
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+import { isTrayMode } from '../utils/trayMode.js';
 
 // Pure local helpers
 const timeToMinutes = (time) => {

--- a/src/hooks/useSaveOnChange.js
+++ b/src/hooks/useSaveOnChange.js
@@ -4,7 +4,7 @@ import { notifyTrayDataChanged } from '../utils/trayNotify.js';
 
 // The tray popup must never write to localStorage — it holds a snapshot of
 // state as of the last reload and would overwrite fresher main-window data.
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+import { isTrayMode } from '../utils/trayMode.js';
 
 export default function useSaveOnChange({
   saveData, checkConflicts,

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -23,13 +23,13 @@ import {
   detectSseTransport,
   openWebSseStream,
 } from '../sync/vaultEventStream.js';
+import { isTrayMode } from '../utils/trayMode.js';
 
 // The global the native shell invokes to push SSE messages into the renderer
 // (see the BRIDGE CONTRACT in vaultEventStream.js). Kept as a named constant so
 // the Android/iOS shells and this file can't drift.
 const NATIVE_SSE_RECEIVE = '__glanceVaultSseReceive';
 
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
 
 /**
  * @param {object} p

--- a/src/hooks/useWeather.js
+++ b/src/hooks/useWeather.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+import { isTrayMode } from '../utils/trayMode.js';
 
 const getWeatherCondition = (code) => {
   if (code === 0) return 'Clear';

--- a/src/intents/dbIntentsTransport.js
+++ b/src/intents/dbIntentsTransport.js
@@ -80,7 +80,7 @@ export class KeyUnavailableError extends Error {
 
 // The tray popup holds a read-only snapshot and must never poll — processing an
 // event would consume it before the main window can act (mirrors useIntentPoller).
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+import { isTrayMode } from '../utils/trayMode.js';
 
 // Module-level lock: prevents React StrictMode's double-mount from running two
 // concurrent polls, which would both read the same cursor and double-process.

--- a/src/intents/useGoalNotifyEmitter.js
+++ b/src/intents/useGoalNotifyEmitter.js
@@ -5,7 +5,7 @@ import { enabledIntentTargets } from './emitTargets.js';
 import { enqueueAndFlush } from './outboxEmit.js';
 import { logActivity } from './intentLog.js';
 
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+import { isTrayMode } from '../utils/trayMode.js';
 
 function shouldEmit(goal) {
   return !!(goal.source_app && goal.source_entity_id);

--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -20,7 +20,7 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 // The tray popup holds a read-only state snapshot; it must never poll for
 // intents because processing an event would advance the cursor and consume
 // the event before the main window can act on it.
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+import { isTrayMode } from '../utils/trayMode.js';
 
 // Module-level lock: prevents React StrictMode's double-mount from running two
 // concurrent poll() calls, which would both see cursor=null and duplicate tasks.

--- a/src/intents/useNotifyEmitter.js
+++ b/src/intents/useNotifyEmitter.js
@@ -9,7 +9,7 @@ import { isNativeAndroid } from '../native';
 // The tray holds a read-only state snapshot. Any task-state changes in tray
 // mode (e.g. from an iCloud sync download) were already handled by the main
 // window. Emitting here would produce duplicate WebDAV notify events.
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+import { isTrayMode } from '../utils/trayMode.js';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 

--- a/src/intents/useOutboxFlush.js
+++ b/src/intents/useOutboxFlush.js
@@ -13,7 +13,7 @@ import { flush } from './outbox.js';
 import { deliverers } from './deliverers.js';
 import { reconcileOutboxActivity } from './intentLog.js';
 
-const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
+import { isTrayMode } from '../utils/trayMode.js';
 
 // Match the WebDAV poller's foreground cadence (2 minutes).
 const FLUSH_INTERVAL_MS = 2 * 60 * 1000;

--- a/src/utils/trayMode.js
+++ b/src/utils/trayMode.js
@@ -1,0 +1,19 @@
+// Is this renderer the macOS tray popup?
+//
+// The popup loads the SAME entry point as the main window with `?tray=1`
+// appended (electron/main.ts createTrayWindow), so it runs the entire App tree.
+// Every module that must behave differently there — skip a poll, skip a write,
+// render the compact view — tests this predicate. It had been copy-pasted
+// verbatim into 13 modules; this is the single definition.
+//
+// Evaluated once at module load, exactly as the copies it replaces were: the
+// query string cannot change without a reload, and the popup is reloaded rather
+// than navigated (see the 'tray:data-changed' handler in electron/main.ts).
+//
+// `window.location?.search ?? ''` rather than `window.location.search`: the
+// optional chaining is what utils/trayNotify.js already used, and it keeps the
+// predicate total under SSR/test environments where a stubbed `window` may have
+// no `location`. In a browser the two are indistinguishable.
+export const isTrayMode =
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location?.search ?? '').has('tray');

--- a/src/utils/trayNotify.js
+++ b/src/utils/trayNotify.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { isTrayMode } from './trayMode.js';
 
 // The macOS tray popup renders from a snapshot of localStorage taken at its last
 // reload, so it has to be told when a value it reads has changed. This module is
@@ -8,10 +9,8 @@ import { useEffect, useRef } from 'react';
 // The tray guard lives here rather than at each call site because the popup runs
 // the same App tree as the main window, so every persist effect that emits also
 // runs inside the tray. Guarding centrally means a new call site cannot forget it
-// and send the popup into a reload loop.
-const isTrayMode =
-  typeof window !== 'undefined' &&
-  new URLSearchParams(window.location?.search ?? '').has('tray');
+// and send the popup into a reload loop. The predicate itself lives in
+// trayMode.js — this module is one of its consumers, not its owner.
 
 // Off-safe everywhere: no-ops on web (no electronAPI), under SSR/tests (no
 // window), and inside the tray popup itself.


### PR DESCRIPTION
## Why

The tray popup loads the same entry point as the main window with `?tray=1` (`electron/main.ts` `createTrayWindow`), so it runs the entire App tree. Every module that must behave differently there tests for it — and that test was copy-pasted verbatim into **13 modules**, with a 14th near-copy in `utils/trayNotify.js` that had already drifted.

## Sites

**14 URL-derived definitions, collapsed to 1.** Thirteen were byte-identical:

```js
const isTrayMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('tray');
```

`App.jsx:218`, `useSaveOnChange:7`, `useWeather:3`, `useDataPersistence:20`, `useElectronBridge:33`, `useReminderEngine:7`, `useAppInit:4`, `useVaultEventStream:32`, `useGoalNotifyEmitter:8`, `useOutboxFlush:16`, `useIntentPoller:23`, `dbIntentsTransport:83`, `useNotifyEmitter:12`.

**The 14th had drifted** — `utils/trayNotify.js:12` used `window.location?.search ?? ''`. That is the only divergence in the codebase, and it is the form kept (see below).

Those definitions feed **43 guards**, **1 render branch** (`App.jsx:8239`, the `return <TrayApp/>`), and **2 pass-onward sites**.

**Left alone — threaded as data across an API boundary:**

| Site | Form |
|---|---|
| `useObsidianSync` | receives `isTrayMode` in its deps object (`App.jsx:2573`), 4 guards inside |
| `useFolderBackup` | receives it renamed as `disabled: isTrayMode` (`App.jsx:4300`) |

Collapsing these would change hook signatures, which is a refactor of the API, not a deduplication.

**Left alone — a different predicate entirely:** `GlanceSidebar.jsx:131` `const isTray = variant === 'tray'`, driven by the component's `variant` prop rather than the URL, with ~20 usages. Same word, unrelated mechanism.

## The one deliberate deviation

I kept `trayNotify.js`'s optional-chained form as the survivor rather than the 13-copy majority form:

```js
new URLSearchParams(window.location?.search ?? '').has('tray')
```

In a browser `window.location` always exists, so the two are indistinguishable. They differ only under a stubbed `window` with no `location`, where the majority form throws a `TypeError` and this one returns `false`. The surviving form is the strictly more defensive of the two and nothing depends on the crash. Flagging it because "pure refactor" deserves the asterisk.

## Verification

- **Full suite green with zero test modifications** — 65 files / 1005 tests. `git status` confirms no `.test.js` file was touched, which was the explicit bar for this change.
- `eslint src --max-warnings 0` clean.
- Both electron tsconfigs clean.
- **Both production builds run** (`vite build` and `vite build --config vite.config.electron.js`). This mattered: my first pass spliced two imports into the middle of multi-line `import { ... }` statements in `useElectronBridge.js` and `useVaultEventStream.js`. The test suite passed anyway — neither module is imported by any test — and only the build and lint caught it. Fixed and re-verified.

## Diff

15 files, +35 −20. Twelve are a one-line swap of the derivation for an import; `App.jsx` is −3 (the derivation plus surrounding blank lines); `trayNotify.js` is −4/+2; `utils/trayMode.js` is new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_