### PR TITLE
Cache the calendar helper's access and calendar-list results in the main process

### DIFF
--- a/electron/calendar.ts
+++ b/electron/calendar.ts
@@ -3,6 +3,7 @@ import { execFile } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { createCalendarCache } from './calendarCache.js';
 
 // ── macOS native calendar (EventKit) ───────────────────────────────────────────
 //
@@ -51,25 +52,36 @@ function runHelper(args: string[]): Promise<unknown> {
   });
 }
 
+// Module scope, so the cache is shared by every renderer rather than per-sender:
+// the tray popup runs the same App tree as the main window and would otherwise
+// repeat the access + calendar-list spawns on each of its reloads.
+const cache = createCalendarCache();
+
 export function registerCalendarHandlers(): void {
   ipcMain.handle('calendar:request-access', async () => {
     if (!calendarSupported()) return { granted: false };
-    try {
-      const res = await runHelper(['request-access']) as { granted?: boolean } | null;
-      return { granted: !!res?.granted };
-    } catch {
-      return { granted: false };
-    }
+    return cache.requestAccess(async () => {
+      try {
+        const res = await runHelper(['request-access']) as { granted?: boolean } | null;
+        return { granted: !!res?.granted };
+      } catch {
+        return { granted: false };
+      }
+    });
   });
 
-  ipcMain.handle('calendar:get-calendars', async () => {
+  // `force` is passed by the Settings › Device calendars "Refresh" button, which
+  // exists to recover from an empty list; it must always re-query EventKit.
+  ipcMain.handle('calendar:get-calendars', async (_event, force?: boolean) => {
     if (!calendarSupported()) return [];
-    try {
-      const res = await runHelper(['calendars']);
-      return Array.isArray(res) ? res : [];
-    } catch {
-      return [];
-    }
+    return cache.getCalendars(async () => {
+      try {
+        const res = await runHelper(['calendars']);
+        return Array.isArray(res) ? res : [];
+      } catch {
+        return [];
+      }
+    }, force === true);
   });
 
   // Returns a per-day map { "YYYY-MM-DD": Event[] } inclusive of [startDate, endDate].

--- a/electron/calendarCache.test.ts
+++ b/electron/calendarCache.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createCalendarCache,
+  isFresh,
+  accessTtlMs,
+  shouldCacheCalendars,
+  CALENDAR_LIST_TTL_MS,
+  ACCESS_DENIAL_TTL_MS,
+} from './calendarCache.js';
+
+// Every calendar:* IPC call spawns the Swift helper via execFile — one process
+// per call. Both renderers hit those handlers independently (the tray popup runs
+// the same App tree as the main window), so a tray reload used to repeat the
+// access + calendar-list spawns the main window had already done. These tests
+// pin the spawn count, which is the whole point of the cache.
+
+// A stub for the "real spawn" callback. Counting calls IS the assertion: one
+// call here == one helper process in production.
+function spawnCounter<T>(value: T) {
+  const fn = vi.fn(async () => value);
+  return fn;
+}
+
+// Injectable clock so TTL expiry is tested without waiting.
+function fakeClock(start = 1_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; } };
+}
+
+describe('isFresh', () => {
+  it('treats a missing entry as stale', () => {
+    expect(isFresh(null, 0, 1000)).toBe(false);
+  });
+
+  it('serves an entry inside its TTL and not at/after it', () => {
+    const entry = { value: 'x', storedAt: 100 };
+    expect(isFresh(entry, 100, 1000)).toBe(true);
+    expect(isFresh(entry, 1099, 1000)).toBe(true);
+    expect(isFresh(entry, 1100, 1000)).toBe(false); // boundary is exclusive
+    expect(isFresh(entry, 5000, 1000)).toBe(false);
+  });
+
+  it('never caches with a non-positive TTL', () => {
+    expect(isFresh({ value: 'x', storedAt: 100 }, 100, 0)).toBe(false);
+    expect(isFresh({ value: 'x', storedAt: 100 }, 100, -1)).toBe(false);
+  });
+
+  it('never expires with an infinite TTL', () => {
+    expect(isFresh({ value: 'x', storedAt: 0 }, Number.MAX_SAFE_INTEGER, Number.POSITIVE_INFINITY)).toBe(true);
+  });
+
+  it('treats a backwards clock jump as stale rather than infinitely fresh', () => {
+    // NTP correction / wake in a new timezone. One extra spawn beats a value
+    // that can never expire.
+    expect(isFresh({ value: 'x', storedAt: 5000 }, 1000, 1_000_000)).toBe(false);
+  });
+});
+
+describe('accessTtlMs', () => {
+  it('keeps a grant for the process lifetime', () => {
+    expect(accessTtlMs(true)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('keeps a denial only briefly, so System Settings changes are noticed', () => {
+    expect(accessTtlMs(false)).toBe(ACCESS_DENIAL_TTL_MS);
+    expect(ACCESS_DENIAL_TTL_MS).toBeLessThanOrEqual(30_000);
+  });
+});
+
+describe('shouldCacheCalendars', () => {
+  it('caches a non-empty list', () => {
+    expect(shouldCacheCalendars([{ id: 'a' }])).toBe(true);
+  });
+
+  it('does NOT cache an empty list', () => {
+    // "No calendars loaded — tap Refresh" is the state the Settings refresh
+    // button exists to recover from; caching it would make that button look broken.
+    expect(shouldCacheCalendars([])).toBe(false);
+  });
+
+  it('does NOT cache a non-array (helper returned junk)', () => {
+    expect(shouldCacheCalendars(null)).toBe(false);
+    expect(shouldCacheCalendars({ nope: true })).toBe(false);
+  });
+});
+
+describe('createCalendarCache — requestAccess', () => {
+  it('miss spawns, hit does not', async () => {
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = spawnCounter({ granted: true });
+
+    expect(await cache.requestAccess(spawn)).toEqual({ granted: true });
+    expect(spawn).toHaveBeenCalledTimes(1); // miss → one helper process
+
+    expect(await cache.requestAccess(spawn)).toEqual({ granted: true });
+    expect(spawn).toHaveBeenCalledTimes(1); // hit → still one
+  });
+
+  it('keeps a grant indefinitely — a tray reload an hour later spawns nothing', async () => {
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = spawnCounter({ granted: true });
+
+    await cache.requestAccess(spawn);
+    clock.advance(60 * 60 * 1000);
+    await cache.requestAccess(spawn);
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT cache a denial for long — re-spawns once the short TTL lapses', async () => {
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = spawnCounter({ granted: false });
+
+    await cache.requestAccess(spawn);
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    // Still inside the denial window — reused.
+    clock.advance(ACCESS_DENIAL_TTL_MS - 1);
+    await cache.requestAccess(spawn);
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    // Past it — the user may have granted access in System Settings meanwhile.
+    clock.advance(2);
+    await cache.requestAccess(spawn);
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('picks up a grant issued after an earlier denial', async () => {
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = vi.fn()
+      .mockResolvedValueOnce({ granted: false })
+      .mockResolvedValueOnce({ granted: true });
+
+    expect(await cache.requestAccess(spawn)).toEqual({ granted: false });
+    clock.advance(ACCESS_DENIAL_TTL_MS + 1);
+    expect(await cache.requestAccess(spawn)).toEqual({ granted: true });
+
+    // And the grant now sticks.
+    clock.advance(60 * 60 * 1000);
+    expect(await cache.requestAccess(spawn)).toEqual({ granted: true });
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('de-duplicates concurrent callers into one spawn', async () => {
+    // The main window and the tray popup mount within the same second at launch.
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = spawnCounter({ granted: true });
+
+    const [a, b] = await Promise.all([cache.requestAccess(spawn), cache.requestAccess(spawn)]);
+
+    expect(a).toEqual({ granted: true });
+    expect(b).toEqual({ granted: true });
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createCalendarCache — getCalendars', () => {
+  const CALS = [{ id: 'work' }, { id: 'home' }];
+
+  it('miss spawns, hit does not', async () => {
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = spawnCounter(CALS);
+
+    expect(await cache.getCalendars(spawn)).toEqual(CALS);
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    expect(await cache.getCalendars(spawn)).toEqual(CALS);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-spawns once the TTL expires', async () => {
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = spawnCounter(CALS);
+
+    await cache.getCalendars(spawn);
+
+    clock.advance(CALENDAR_LIST_TTL_MS - 1);
+    await cache.getCalendars(spawn);
+    expect(spawn).toHaveBeenCalledTimes(1); // still fresh
+
+    clock.advance(2);
+    await cache.getCalendars(spawn);
+    expect(spawn).toHaveBeenCalledTimes(2); // expired → re-spawn
+  });
+
+  it('never caches an empty list, so every call retries', async () => {
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = spawnCounter([] as unknown[]);
+
+    await cache.getCalendars(spawn);
+    await cache.getCalendars(spawn);
+    await cache.getCalendars(spawn);
+
+    expect(spawn).toHaveBeenCalledTimes(3);
+  });
+
+  it('force bypasses a fresh entry — the Settings Refresh button', async () => {
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = spawnCounter(CALS);
+
+    await cache.getCalendars(spawn);
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    await cache.getCalendars(spawn, true);
+    expect(spawn).toHaveBeenCalledTimes(2); // refreshed despite being fresh
+  });
+
+  it('force refills the cache rather than just bypassing it', async () => {
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = vi.fn()
+      .mockResolvedValueOnce([{ id: 'old' }])
+      .mockResolvedValueOnce([{ id: 'old' }, { id: 'new' }]);
+
+    await cache.getCalendars(spawn);
+    expect(await cache.getCalendars(spawn, true)).toEqual([{ id: 'old' }, { id: 'new' }]);
+
+    // Subsequent non-forced reads see the refreshed list without spawning again.
+    expect(await cache.getCalendars(spawn)).toEqual([{ id: 'old' }, { id: 'new' }]);
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('de-duplicates concurrent callers into one spawn', async () => {
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = spawnCounter(CALS);
+
+    await Promise.all([cache.getCalendars(spawn), cache.getCalendars(spawn)]);
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('a rejected spawn does not poison later calls', async () => {
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const spawn = vi.fn()
+      .mockRejectedValueOnce(new Error('helper missing'))
+      .mockResolvedValueOnce(CALS);
+
+    await expect(cache.getCalendars(spawn)).rejects.toThrow('helper missing');
+    expect(await cache.getCalendars(spawn)).toEqual(CALS);
+  });
+});
+
+describe('createCalendarCache — shared across renderers', () => {
+  it('one instance serves both windows: 2 spawns for a launch, 0 for a tray reload', async () => {
+    // The scenario this whole change exists for. Main window mounts (access +
+    // calendars), then the tray popup mounts and reloads repeatedly.
+    const clock = fakeClock();
+    const cache = createCalendarCache({ now: clock.now });
+    const accessSpawn = spawnCounter({ granted: true });
+    const calendarsSpawn = spawnCounter([{ id: 'work' }]);
+
+    // Main window mount.
+    await cache.requestAccess(accessSpawn);
+    await cache.getCalendars(calendarsSpawn);
+
+    // Tray popup mount, then three reloads.
+    for (let i = 0; i < 4; i++) {
+      await cache.requestAccess(accessSpawn);
+      await cache.getCalendars(calendarsSpawn);
+    }
+
+    expect(accessSpawn).toHaveBeenCalledTimes(1);
+    expect(calendarsSpawn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/calendarCache.ts
+++ b/electron/calendarCache.ts
@@ -1,0 +1,143 @@
+// Spawn-avoidance cache for the macOS calendar helper, extracted from
+// calendar.ts so the caching decisions can be unit-tested without spawning the
+// Swift binary or booting Electron (same pattern as startupQuit.ts).
+//
+// WHY THIS EXISTS: every calendar:* IPC call runs execFile() against the helper
+// binary — one process per call, no reuse. Both renderers hit those handlers
+// independently: the tray popup runs the same App tree as the main window, so a
+// tray reload repeats the access + calendar-list pair the main window already
+// performed. Neither result changes often enough to justify that.
+//
+// Deliberately NOT cached here: calendar:get-events. It is parameterised by date
+// range and is the query users expect to reflect edits immediately.
+
+/** A cached value plus the clock reading at which it was stored. */
+export interface TimedEntry<T> {
+  value: T;
+  storedAt: number;
+}
+
+/** Calendars change rarely, but they do change (a new subscription, a removed account). */
+export const CALENDAR_LIST_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * How long a DENIED access result may be reused.
+ *
+ * Deliberately short: the user can flip the permission in System Settings ›
+ * Privacy & Security › Calendars at any moment and reasonably expects the app
+ * to notice without a restart. A granted result, by contrast, is stable for the
+ * process lifetime — macOS cannot silently downgrade it without terminating us.
+ */
+export const ACCESS_DENIAL_TTL_MS = 10 * 1000;
+
+/**
+ * Whether a cached entry may still be served.
+ *
+ * `ttlMs` of Infinity means "never expires"; a non-positive TTL means "never
+ * cache". A negative age (the clock jumped backwards, e.g. an NTP correction or
+ * a laptop waking in a new timezone) is treated as stale rather than as
+ * infinitely fresh — the failure mode of one extra spawn is strictly better
+ * than serving a value that never expires.
+ */
+export function isFresh<T>(entry: TimedEntry<T> | null, now: number, ttlMs: number): boolean {
+  if (!entry) return false;
+  if (ttlMs <= 0) return false;
+  const age = now - entry.storedAt;
+  if (age < 0) return false;
+  return age < ttlMs;
+}
+
+/** Grants stick for the process lifetime; denials expire quickly. See ACCESS_DENIAL_TTL_MS. */
+export function accessTtlMs(granted: boolean): number {
+  return granted ? Number.POSITIVE_INFINITY : ACCESS_DENIAL_TTL_MS;
+}
+
+/**
+ * Whether a calendar-list result is worth storing.
+ *
+ * An empty list is never cached. It is the exact state the "Refresh" button in
+ * Settings › Device calendars exists to recover from ("No calendars loaded —
+ * tap Refresh"), and caching it would make that button appear broken for the
+ * whole TTL.
+ */
+export function shouldCacheCalendars(list: unknown): list is unknown[] {
+  return Array.isArray(list) && list.length > 0;
+}
+
+export interface AccessResult { granted: boolean }
+
+export interface CalendarCacheOptions {
+  /** Injectable clock so tests can advance time without waiting. */
+  now?: () => number;
+  calendarListTtlMs?: number;
+}
+
+/**
+ * Process-wide cache over the two idempotent helper calls.
+ *
+ * One instance is created at module scope in calendar.ts, so both renderers
+ * share it — the cache is keyed by nothing at all, never by sender.
+ *
+ * Concurrent callers are also de-duplicated: the main window and the tray popup
+ * mount within the same second at launch, so without single-flight they would
+ * both miss the cache and both spawn. In-flight promises are shared and cleared
+ * on settle, so a rejection never poisons later calls.
+ */
+export function createCalendarCache(opts: CalendarCacheOptions = {}) {
+  const now = opts.now ?? Date.now;
+  const calendarListTtlMs = opts.calendarListTtlMs ?? CALENDAR_LIST_TTL_MS;
+
+  let access: TimedEntry<AccessResult> | null = null;
+  let calendars: TimedEntry<unknown[]> | null = null;
+  let accessInFlight: Promise<AccessResult> | null = null;
+  let calendarsInFlight: Promise<unknown[]> | null = null;
+
+  return {
+    /**
+     * `fetchAccess` performs the real spawn. It is only invoked on a miss, and
+     * only once for concurrent callers.
+     */
+    async requestAccess(fetchAccess: () => Promise<AccessResult>): Promise<AccessResult> {
+      if (access && isFresh(access, now(), accessTtlMs(access.value.granted))) return access.value;
+      if (accessInFlight) return accessInFlight;
+
+      accessInFlight = (async () => {
+        const value = await fetchAccess();
+        access = { value, storedAt: now() };
+        return value;
+      })();
+      try {
+        return await accessInFlight;
+      } finally {
+        accessInFlight = null;
+      }
+    },
+
+    /**
+     * `force` bypasses a fresh entry and refills it — wired to the Settings
+     * "Refresh" button so an explicit user refresh always re-queries EventKit.
+     */
+    async getCalendars(fetchCalendars: () => Promise<unknown[]>, force = false): Promise<unknown[]> {
+      if (!force && isFresh(calendars, now(), calendarListTtlMs)) return calendars!.value;
+      if (!force && calendarsInFlight) return calendarsInFlight;
+
+      const run = (async () => {
+        const list = await fetchCalendars();
+        if (shouldCacheCalendars(list)) calendars = { value: list, storedAt: now() };
+        return list;
+      })();
+      if (!force) calendarsInFlight = run;
+      try {
+        return await run;
+      } finally {
+        if (calendarsInFlight === run) calendarsInFlight = null;
+      }
+    },
+
+    /** Test/diagnostic aid — drops both entries. */
+    reset(): void {
+      access = null;
+      calendars = null;
+    },
+  };
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -163,8 +163,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // All return empty/false on non-macOS platforms.
   requestCalendarAccess: (): Promise<{ granted: boolean }> =>
     ipcRenderer.invoke('calendar:request-access'),
-  getCalendars: (): Promise<Array<{ id: string; name: string; accountName: string; color: string }>> =>
-    ipcRenderer.invoke('calendar:get-calendars'),
+  // The main process caches this list (5 min TTL) so both renderers don't each
+  // spawn the helper. `force` bypasses that cache for an explicit user refresh.
+  getCalendars: (force?: boolean): Promise<Array<{ id: string; name: string; accountName: string; color: string }>> =>
+    ipcRenderer.invoke('calendar:get-calendars', force === true),
   // Returns a per-day map { "YYYY-MM-DD": Event[] } covering [startDate, endDate] inclusive.
   getCalendarEvents: (startDate: string, endDate: string): Promise<Record<string, unknown[]>> =>
     ipcRenderer.invoke('calendar:get-events', startDate, endDate),

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -992,7 +992,9 @@ const SettingsModal = () => {
                           <div className="flex items-center justify-between">
                             <p className={`text-sm font-medium ${textPrimary}`}>{t('settings.deviceCalendars')}</p>
                             <button onClick={async () => {
-                              const cals = electronCalendarAvailable() ? await electronGetCalendars() : nativeGetCalendars();
+                              // force: this button is the documented recovery path for an
+                              // empty list, so it must bypass the main-process cache.
+                              const cals = electronCalendarAvailable() ? await electronGetCalendars({ force: true }) : nativeGetCalendars();
                               if (cals.length > 0) setAvailableCalendars(cals);
                             }} className={`text-xs ${textSecondary} underline`}>{t('common.refresh')}</button>
                           </div>

--- a/src/utils/nativeCalendar.js
+++ b/src/utils/nativeCalendar.js
@@ -59,11 +59,19 @@ export const electronRequestCalendarAccess = async () => {
   }
 };
 
-/** Fetches the device calendar list from the Electron helper. */
-export const electronGetCalendars = async () => {
+/**
+ * Fetches the device calendar list from the Electron helper.
+ *
+ * The main process caches the list (5 min TTL) so a tray-popup reload doesn't
+ * re-spawn the helper for a list the main window already fetched. Pass
+ * `{ force: true }` for an explicit user-initiated refresh, which must always
+ * re-query EventKit — an empty list is never cached, but a stale non-empty one
+ * would otherwise hide a calendar the user just added.
+ */
+export const electronGetCalendars = async ({ force = false } = {}) => {
   if (!window.electronAPI?.getCalendars) return [];
   try {
-    return (await window.electronAPI.getCalendars()) ?? [];
+    return (await window.electronAPI.getCalendars(force)) ?? [];
   } catch {
     return [];
   }


### PR DESCRIPTION
## Why

Every `calendar:*` IPC handler shells out to the Swift helper: `execFile(bin, args, { timeout: 15_000, maxBuffer: 16MB })` (`calendar.ts:43`). One process per call, no reuse, no dedup.

Both renderers hit those handlers independently — the tray popup runs the same App tree as the main window — so each tray reload repeated work the main window had already done:

| Effect | Handler(s) | Spawns |
|---|---|---|
| `App.jsx:3576` (deps `[]`) | `calendar:request-access` → `calendar:get-calendars` | 2 |
| `App.jsx:3595` | `calendar:get-events` | 1 |

**3 per tray reload, 2 of them for answers that hadn't changed.**

## What changed

Cached both idempotent calls in the main process. The cache is at **module scope, keyed by nothing** — shared across every renderer, never per-sender.

**Access:** a grant is kept for the process lifetime (macOS can't silently downgrade it without terminating us). A denial is kept for **10 s only** — the user can flip the permission in System Settings › Privacy & Security › Calendars and reasonably expects that to take effect without a restart.

**Calendar list:** 5-minute TTL.

**`get-events` is deliberately untouched** — parameterised by date range, and the query users expect to reflect edits immediately.

## The manual refresh path, preserved two ways

`SettingsModal.jsx:995` is a "Refresh" button beside *Device calendars*, with adjacent copy *"No calendars loaded — tap Refresh, or rebuild the app if this persists."* A naive cache would break it, so:

1. **An empty list is never cached.** That's the exact state the button exists to recover from.
2. **The button passes an explicit `force` flag**, threaded through `preload.ts` → `nativeCalendar.js` → the handler, so a user-initiated refresh always re-queries EventKit even when the cached list is non-empty and fresh. `force` also *refills* the cache rather than merely bypassing it.

`App.jsx`'s call site is unchanged and uses the cache.

## Also: concurrent callers share one spawn

The main window and the tray popup mount within the same second at launch, so without single-flight they'd both miss and both spawn. In-flight promises are shared and cleared on settle, so a rejection can't poison later calls.

## Spawn count per tray reload

**3 → 1** (just `get-events`). The launch pair drops from 2-per-renderer to 2 for the whole process lifetime, minus the 5-minute calendar-list refresh.

## Tests

Cache decisions live in `calendarCache.ts` with an injectable clock, in the style of `startupQuit.ts`, so spawn counts are asserted directly without running the helper or booting Electron. **23 tests**, counting calls to a stub spawn — one call there is one helper process in production. Covers the four requested cases (hit doesn't spawn, miss does, TTL expiry re-spawns, denial isn't cached long) plus `force`, empty-list, backwards-clock, rejection recovery, and an end-to-end "1 launch + 4 tray reloads → 1 access spawn, 1 calendars spawn".

Mutation-tested: caching denials with the grant TTL fails 3 tests, caching empty lists fails 2, ignoring `force` fails 2.

Full suite 66 files / 1028 tests green; lint, both tsconfigs, and both production builds clean.

## Notes

- `TraySpotlight`'s 456-day fetch is **not** per-reload — `TrayApp.jsx:12` initialises `overlay` to `null`, so it mounts only on a search click. I'd left that ambiguous in an earlier report; correcting it here.
- No visibility gating added, no renderer effects in `App.jsx` touched, nothing tray-specific changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_