### PR TITLE
Gate the tray's calendar fetch on popup visibility; stop it persisting the calendar filter

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -295,7 +295,7 @@ function createTrayWindow(): BrowserWindow {
   // registered its onReminders listener. 800ms is enough for the renderer to
   // finish hydrating; focus state self-corrects within 1s so no re-push needed.
   win.webContents.on('did-finish-load', () => {
-    setTimeout(() => { pushRemindersToTray(); pushCurrentTaskToTray(); }, 800);
+    setTimeout(() => { pushRemindersToTray(); pushCurrentTaskToTray(); pushTrayVisibilityToTray(); }, 800);
   });
 
   win.webContents.setWindowOpenHandler(({ url }) => {
@@ -311,6 +311,7 @@ function createTrayWindow(): BrowserWindow {
   win.on('blur', () => {
     if (win.isDestroyed()) return;
     win.hide();
+    setTrayVisible(false);
     if (trayNeedsReload) {
       trayNeedsReload = false;
       win.webContents.reload();
@@ -359,12 +360,13 @@ function createTray(): void {
   tray.on('click', (_event, bounds) => {
     const tw = live(trayWindow);
     if (!tw) return;
-    if (tw.isVisible()) { tw.hide(); return; }
+    if (tw.isVisible()) { tw.hide(); setTrayVisible(false); return; }
     positionTrayPopup(tw, bounds);
     trayIndicatorOn = false;
     refreshTrayTitle();
     tw.show();
     tw.focus();
+    setTrayVisible(true);
     pushRemindersToTray();
     pushCurrentTaskToTray();
   });
@@ -528,6 +530,7 @@ ipcMain.on('window:exit-fullscreen', (event) => {
 // Tray popup requests the main window to show and navigate to a specific location.
 ipcMain.on('tray:open-main', (_event, payload: unknown) => {
   live(trayWindow)?.hide();
+  setTrayVisible(false);
   const mw = live(mainWindow);
   if (mw) { mw.show(); mw.focus(); mw.webContents.send('tray:navigate', payload); }
 });
@@ -558,6 +561,28 @@ let lastKnownCurrentTask: unknown = null;
 
 function pushCurrentTaskToTray() {
   live(trayWindow)?.webContents.send('tray:current-task', lastKnownCurrentTask);
+}
+
+// Last-known popup visibility. The main process is the authority here — it owns
+// every show/hide call site below — so the renderer never has to infer it from
+// document.visibilityState.
+//
+// The popup is created hidden (createTrayWindow passes show: false), so false is
+// the correct initial value. Cached and re-pushed on did-finish-load for the
+// same reason as the reminder list: the popup reloads in the background, and a
+// reload that lands while it is open must not leave the renderer believing it is
+// hidden until the next transition.
+let lastKnownTrayVisible = false;
+
+function pushTrayVisibilityToTray() {
+  live(trayWindow)?.webContents.send('tray:visibility', lastKnownTrayVisible);
+}
+
+// Single choke point for the popup's visibility so no show/hide path can update
+// the window without telling the renderer.
+function setTrayVisible(visible: boolean) {
+  lastKnownTrayVisible = visible;
+  pushTrayVisibilityToTray();
 }
 
 // Reminder list: cache + forward to tray popup whenever it changes.
@@ -595,12 +620,13 @@ ipcMain.handle('hotkey:register', (_event, accelerator: string) => {
   const ok = globalShortcut.register(accelerator, () => {
     const tw = live(trayWindow);
     if (!tw) return;
-    if (tw.isVisible()) { tw.hide(); return; }
+    if (tw.isVisible()) { tw.hide(); setTrayVisible(false); return; }
     positionTrayPopup(tw, tray?.getBounds());
     trayIndicatorOn = false;
     refreshTrayTitle();
     tw.show();
     tw.focus();
+    setTrayVisible(true);
     pushRemindersToTray();
     pushCurrentTaskToTray();
     tw.webContents.send('tray:focus-quick-add');

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -87,6 +87,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('tray:reminders', handler);
   },
 
+  // Tray popup receives its own on-screen visibility from the main process,
+  // which owns every show/hide call site. Re-sent after each reload, so the
+  // popup knows its current state immediately rather than at the next
+  // transition. Used to skip work that is pointless while it is off screen.
+  onTrayVisibility: (callback: (visible: boolean) => void) => {
+    const handler = (_: Electron.IpcRendererEvent, visible: boolean) => callback(visible);
+    ipcRenderer.on('tray:visibility', handler);
+    return () => ipcRenderer.removeListener('tray:visibility', handler);
+  },
+
   // Main window pushes the currently-in-progress task to the tray popup.
   pushCurrentTask: (task: unknown) => ipcRenderer.send('tray:push-current-task', task),
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -161,6 +161,8 @@ import { useSubscription } from './hooks/useSubscription.js';
 import { useTranslation } from 'react-i18next';
 import { syncErrorText } from './sync/syncErrors.js';
 import { isTrayMode } from './utils/trayMode.js';
+import { shouldFetchNativeEvents } from './utils/trayFetchGate.js';
+import useTrayPopupVisible from './hooks/useTrayPopupVisible.js';
 
 // Encode a string that may contain non-ASCII characters as Base64.
 // btoa() throws InvalidCharacterError for codepoints > 255 (CJK, emoji, etc.).
@@ -577,6 +579,10 @@ const DayPlanner = () => {
   } = useMobileEdit();
   const [mobileEditingNativeEvent, setMobileEditingNativeEvent] = useState(null);
   const [nativeCalendarKey, setNativeCalendarKey] = useState(0);
+  // Tray popup on-screen state, pushed from the main process. Always false in
+  // the main window, which is never gated on it. Gates the native-calendar
+  // event fetch below so a hidden popup doesn't spawn the EventKit helper.
+  const trayPopupVisible = useTrayPopupVisible();
   const [mobileSettingsView, setMobileSettingsView] = useState('main');
   const { showWelcome, setShowWelcome, gettingStartedDismissed, setGettingStartedDismissed, onboardingComplete, setOnboardingComplete, onboardingProgress, setOnboardingProgress } = useOnboarding();
   const [sectionInfoDismissed, setSectionInfoDismissed] = useState(() => {
@@ -3594,6 +3600,11 @@ const DayPlanner = () => {
 
   useEffect(() => {
     if (!hasNativeCalendar()) return;
+    // Tray popup only: skip while it is off screen. Each run spawns the EventKit
+    // helper, and the popup's reloads are scheduled precisely when it is hidden.
+    // trayPopupVisible is in the deps below, so the fetch runs as soon as it is
+    // shown rather than waiting for an unrelated dependency to change.
+    if (!shouldFetchNativeEvents({ isTrayMode, popupVisible: trayPopupVisible })) return;
 
     const dates = [];
     for (let offset = -2; offset <= 2; offset++) {
@@ -3700,7 +3711,7 @@ const DayPlanner = () => {
       return () => { cancelled = true; };
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedDate, calendarFilter, nativeCalendarKey]);
+  }, [selectedDate, calendarFilter, nativeCalendarKey, trayPopupVisible]);
 
   // Wider native-calendar fetch for the spotlight search. The timeline effect above
   // only loads a ±2-day window, so device-calendar events on other dates never reach

--- a/src/hooks/useLocalStoragePersist.js
+++ b/src/hooks/useLocalStoragePersist.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useNotifyTrayOnChange } from '../utils/trayNotify.js';
+import { isTrayMode } from '../utils/trayMode.js';
 
 export default function useLocalStoragePersist({
   minimizedSections,
@@ -95,8 +96,17 @@ export default function useLocalStoragePersist({
     localStorage.setItem('day-planner-auto-backup-config', JSON.stringify(autoBackupConfig));
   }, [autoBackupConfig]);
 
-  // Persist calendar filter whenever it changes
+  // Persist calendar filter whenever it changes.
+  //
+  // Tray-guarded, matching the invariant enforced in loadData and saveData: the
+  // popup holds a snapshot as of its last reload and must never write to
+  // localStorage. This key is not merely written on mount like the others — the
+  // tray can actively CHANGE it, because applyEvents calls setCalendarFilter
+  // when it finds an event whose calendar getCalendars() did not report, and
+  // the tray runs that same fetch. The popup still holds the value in state for
+  // its own render; it just stops persisting it.
   useEffect(() => {
+    if (isTrayMode) return;
     localStorage.setItem('day-planner-calendar-filter', JSON.stringify(calendarFilter));
   }, [calendarFilter]);
 

--- a/src/hooks/useLocalStoragePersist.test.js
+++ b/src/hooks/useLocalStoragePersist.test.js
@@ -107,3 +107,65 @@ describe('useLocalStoragePersist tray invalidation', () => {
       .toHaveBeenCalledWith('hideCompletedInbox', VIEW_PREF.toString());
   });
 });
+
+// isTrayMode is derived once at module load from window.location.search, so the
+// tray needs its own module instance — set the URL, then import.
+async function loadHookAs(mode) {
+  vi.resetModules();
+  effects.length = 0;
+  globalThis.window = { location: { search: mode === 'tray' ? '?tray=1' : '' } };
+  const mod = await import('./useLocalStoragePersist.js');
+  return mod.default;
+}
+
+describe('calendarFilter persistence — tray guard', () => {
+  const FILTER = ['work-cal'];
+  let setItem;
+
+  beforeEach(() => {
+    setItem = vi.fn();
+    globalThis.localStorage = { setItem, getItem: vi.fn(() => null), removeItem: vi.fn() };
+  });
+
+  afterEach(() => {
+    delete globalThis.localStorage;
+    delete globalThis.window;
+  });
+
+  it('the main window persists the calendar filter', () => {
+    // The negative test below is only meaningful if this one holds — otherwise
+    // "tray does not write" could pass because nobody writes.
+    return loadHookAs('main').then((hook) => {
+      hook(baseProps({ calendarFilter: FILTER }));
+      mount();
+      expect(setItem).toHaveBeenCalledWith('day-planner-calendar-filter', JSON.stringify(FILTER));
+    });
+  });
+
+  it('the tray does not persist the calendar filter', async () => {
+    const hook = await loadHookAs('tray');
+    hook(baseProps({ calendarFilter: FILTER }));
+    mount();
+
+    // The tray holds a snapshot as of its last reload and must never write to
+    // localStorage (same invariant as loadData/saveData). This key is the one
+    // the tray can actively CHANGE, via applyEvents → setCalendarFilter when a
+    // fetched event names a calendar getCalendars() did not report.
+    const keys = setItem.mock.calls.map(([k]) => k);
+    expect(keys).not.toContain('day-planner-calendar-filter');
+  });
+
+  it('the tray still stops writing it when the value changes, not just on mount', async () => {
+    const hook = await loadHookAs('tray');
+    hook(baseProps({ calendarFilter: FILTER }));
+    mount();
+    setItem.mockClear();
+
+    // Simulate applyEvents discovering a calendar and extending the filter.
+    change(FILTER);
+
+    expect(setItem).not.toHaveBeenCalledWith(
+      'day-planner-calendar-filter', expect.anything(),
+    );
+  });
+});

--- a/src/hooks/useTrayPopupVisible.js
+++ b/src/hooks/useTrayPopupVisible.js
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { isTrayMode } from '../utils/trayMode.js';
+
+/**
+ * Whether the macOS tray popup is currently on screen, as reported by the main
+ * process over `tray:visibility`.
+ *
+ * The main process is the authority: it owns every show/hide call site (tray
+ * click, global hotkey, blur, tray:open-main), so the renderer never has to
+ * infer this from document.visibilityState — whose behaviour for a hidden
+ * BrowserWindow is a Chromium/platform detail rather than something this app
+ * controls.
+ *
+ * Always false outside the tray popup. The main window is never gated on it,
+ * and returning a constant keeps the value inert in that renderer.
+ */
+export default function useTrayPopupVisible() {
+  // The popup is created hidden (main.ts createTrayWindow passes show: false),
+  // so false is the correct pre-IPC value. The main process re-pushes current
+  // state on did-finish-load, so a reload that lands while the popup is open
+  // corrects this without waiting for the next show/hide transition.
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isTrayMode) return undefined;
+    if (!window.electronAPI?.onTrayVisibility) return undefined;
+    return window.electronAPI.onTrayVisibility((v) => setVisible(v === true));
+  }, []);
+
+  return isTrayMode && visible;
+}

--- a/src/utils/trayFetchGate.js
+++ b/src/utils/trayFetchGate.js
@@ -1,0 +1,28 @@
+// Should this renderer run the native (device) calendar event fetch?
+//
+// Extracted as a pure function so the gating rule is unit-testable without
+// React or Electron (same pattern as electron/startupQuit.ts and
+// electron/calendarCache.ts).
+//
+// WHY: every calendar:get-events call spawns the Swift EventKit helper as a
+// child process. The tray popup runs the same App tree as the main window, so
+// it repeats that spawn on each of its reloads — and those reloads are
+// scheduled precisely when the popup is NOT on screen (electron/main.ts defers
+// a reload to the next blur when it is visible). The common case was therefore
+// a hidden popup spawning the helper for events nobody would look at.
+//
+// Visibility comes from the main process over `tray:visibility` rather than
+// document.visibilityState: main.ts owns every show/hide call site, so it is
+// the authority, and this avoids depending on how Chromium reports a hidden
+// BrowserWindow's page visibility on macOS.
+export function shouldFetchNativeEvents({ isTrayMode, popupVisible }) {
+  // The main window is never gated. It is the renderer that owns sync, notifies
+  // the tray, and serves the Stream Deck payload; its fetch must not depend on
+  // an unrelated popup being on screen.
+  if (!isTrayMode) return true;
+
+  // In the tray, fetch only while the popup is actually on screen. Strict true
+  // so the pre-IPC initial state (and any missing bridge) reads as "not visible"
+  // — the popup is created hidden, so that is also the correct default.
+  return popupVisible === true;
+}

--- a/src/utils/trayFetchGate.test.js
+++ b/src/utils/trayFetchGate.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { shouldFetchNativeEvents } from './trayFetchGate.js';
+
+// Each allowed fetch spawns the Swift EventKit helper as a child process. The
+// tray popup runs the same App tree as the main window and reloads precisely
+// when it is NOT on screen (main.ts defers a reload to the next blur while the
+// popup is visible), so the pre-gate common case was a hidden popup spawning
+// the helper for events nobody would see.
+
+describe('shouldFetchNativeEvents', () => {
+  describe('main window — never gated', () => {
+    it('fetches regardless of the popup being off screen', () => {
+      // The main window owns sync, the tray nudge and the Stream Deck payload;
+      // its fetch must not depend on an unrelated popup's visibility.
+      expect(shouldFetchNativeEvents({ isTrayMode: false, popupVisible: false })).toBe(true);
+      expect(shouldFetchNativeEvents({ isTrayMode: false, popupVisible: true })).toBe(true);
+      expect(shouldFetchNativeEvents({ isTrayMode: false, popupVisible: undefined })).toBe(true);
+    });
+  });
+
+  describe('tray popup — gated on being on screen', () => {
+    it('hidden suppresses the fetch', () => {
+      expect(shouldFetchNativeEvents({ isTrayMode: true, popupVisible: false })).toBe(false);
+    });
+
+    it('visible allows the fetch', () => {
+      expect(shouldFetchNativeEvents({ isTrayMode: true, popupVisible: true })).toBe(true);
+    });
+
+    it('transition hidden → visible flips the gate open', () => {
+      // The renderer keeps popupVisible in the effect's dependency array, so
+      // this flip is what re-runs the effect: events load on show rather than
+      // waiting for selectedDate/calendarFilter to change.
+      const hidden = shouldFetchNativeEvents({ isTrayMode: true, popupVisible: false });
+      const shown = shouldFetchNativeEvents({ isTrayMode: true, popupVisible: true });
+      expect([hidden, shown]).toEqual([false, true]);
+    });
+
+    it('treats unknown visibility as hidden', () => {
+      // Pre-IPC initial state, and any build whose preload lacks the bridge.
+      // The popup is created hidden, so "not yet told" and "hidden" agree.
+      expect(shouldFetchNativeEvents({ isTrayMode: true, popupVisible: undefined })).toBe(false);
+      expect(shouldFetchNativeEvents({ isTrayMode: true, popupVisible: null })).toBe(false);
+    });
+
+    it('requires a strict boolean true, not a truthy value', () => {
+      expect(shouldFetchNativeEvents({ isTrayMode: true, popupVisible: 1 })).toBe(false);
+      expect(shouldFetchNativeEvents({ isTrayMode: true, popupVisible: 'yes' })).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Two independent changes, one commit each.

## Commit 1 — `4c0921e` gate the tray's `get-events` fetch on popup visibility

Every `calendar:get-events` call spawns the Swift EventKit helper as a child process. The tray popup runs the same App tree as the main window, so it repeats that spawn on each reload — and `main.ts` schedules those reloads *precisely when the popup is off screen* (a reload arriving while it's visible is deferred to the next `blur`). The common case was a hidden popup spawning the helper for events nobody would see.

**Visibility comes from the main process over a new `tray:visibility` channel, not `document.visibilityState`.** `main.ts` owns every show/hide call site — tray click (`:366`/`:362`), global hotkey (`:602`), `blur` (`:313`), `tray:open-main` (`:530`) — so it's the authority. This also sidesteps a question I could not answer from code: whether Chromium marks a hidden `BrowserWindow`'s page hidden on macOS is a platform detail, and building the gate on it would have risked a silent no-op.

Follows the `tray:push-reminders` shape including the `lastKnown*` cache re-pushed on `did-finish-load`, so a reload landing while the popup is open doesn't leave the renderer believing it's hidden until the next transition.

`popupVisible` is in the effect's dependency array, so the fetch runs **on show** rather than waiting for `selectedDate`/`calendarFilter` to change.

Only `get-events`, only in tray mode. The access/calendar-list effect is untouched, and the spotlight fetch is already user-initiated.

## Commit 2 — `6b4eaa0` guard `calendarFilter` persistence in tray mode

`useLocalStoragePersist:99` wrote `day-planner-calendar-filter` unguarded. This key is worse than a mount-time echo: the tray can actively **change** it. `applyEvents` calls `setCalendarFilter` when a fetched event names a calendar `getCalendars()` didn't report, and the tray runs that same fetch — so a renderer holding a snapshot as of its last reload could extend a filter the main window owns.

Guarded with the shared `isTrayMode`, matching `loadData`/`saveData`. The popup still holds the value in state and renders its own events through it; it just stops persisting. The `calendarFilter` tray nudge stays — main-window → tray is unaffected.

## Report findings behind these

**Deferring the fetch is safe.** `applyEvents` fully *replaces* the `_native` set rather than accumulating: `setTasks(prev => [...prev.filter(t => !t._native && …), ...fetchedWithOverrides])`. Inputs (dates from `selectedDate`, `calendarFilter`, overrides from localStorage) are read fresh each run. A fetch that runs later produces the same state as one that ran on schedule. Nothing depends on it having run continuously.

**The tray's calendar discovery is deferred, not lost.** Both renderers fetch a ±2-day window, and the tray's is always centred on today — which the main window also covers at every launch, since `selectedDate` initialises to today in both. So the main window re-makes the same discovery and persists it. They can only diverge mid-session while the main window sits parked on a distant date; a relaunch or navigation back toward today re-converges. `availableCalendars` itself is React state and never persisted, so only the `calendarFilter` side effect was ever durable. On that basis the stop-condition in the brief is not met, and commit 2 proceeded — flagging the within-session asymmetry explicitly rather than burying it.

## Spawn count per hidden tray reload

**3 → 1.** `request-access` + `get-calendars` (2) still run — deliberately, they're cheap; `get-events` (1) is now skipped while hidden.

With #1301 merged the access/list pair is cached process-wide, so the two changes compose to **3 → 0 for a hidden reload**, with `get-events` deferred to the moment the popup is shown.

## Test coverage — and what is not covered

| Covered | How |
|---|---|
| `shouldFetchNativeEvents` | 6 tests: hidden suppresses, visible allows, hidden→visible flips open, unknown treated as hidden, strict-boolean, main window never gated |
| `calendarFilter` guard | 3 tests: main window writes, tray doesn't on mount, tray doesn't on change |

Mutation-tested: removing the tray guard fails 2 tests; over-guarding so the main window also skips fails the positive test; both gate directions fail when inverted.

**Not covered, stated plainly:** the renderer half of the IPC. `useTrayPopupVisible.js` is a new hook rather than an addition to `useElectronBridge.js` specifically because that file has *zero* test coverage — I demonstrated on #1300 that a syntax error there passes the full suite and is caught only by lint/build. The new hook is still untested (no renderer test infrastructure — no jsdom, no testing-library), as is the `main.ts` visibility wiring and the `App.jsx` effect. What's verified for those is lint, both tsconfigs, and both production builds. **The show/hide → fetch path needs a manual check on a Mac.**

## Note

Branched off `main`, so #1301's calendar cache isn't included. Both touch `electron/preload.ts` in different places — a trivial merge conflict is possible depending on merge order.

Full suite: 66 files / 1014 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_