### PR TITLE
Fix "Open in Obsidian" doing nothing on macOS

### DIFF
--- a/electron/obsidian.ts
+++ b/electron/obsidian.ts
@@ -1,6 +1,7 @@
-import { ipcMain, app, dialog, BrowserWindow } from 'electron';
+import { ipcMain, app, dialog, shell, BrowserWindow } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
+import { buildObsidianOpenUri } from './obsidianUri.js';
 
 // ── Obsidian vault access (Electron) ─────────────────────────────────────────
 //
@@ -99,6 +100,30 @@ export function registerObsidianHandlers(): void {
     vaultBasePath = cfg.path;
     beginAccess(cfg.bookmark);
     return { path: cfg.path, name: path.basename(cfg.path) };
+  });
+
+  // Opens a vault note in the Obsidian app.
+  //
+  // The renderer cannot do this itself: window.open('obsidian://…') is caught by
+  // setWindowOpenHandler and dropped by openExternalSafe, which only permits
+  // http/https so a renderer compromise can't launch arbitrary schemes. Keeping
+  // that allowlist intact, the renderer sends only a note NAME and the URL is
+  // built here from the vault path we already hold — which is also the only
+  // place the real vault name exists (the renderer's handle shim reports the
+  // placeholder 'vault').
+  ipcMain.handle('obsidian:open-note', async (_event, noteName: unknown) => {
+    if (typeof noteName !== 'string') return false;
+    const cfg = loadConfig();
+    if (!cfg?.path) return false;
+    const uri = buildObsidianOpenUri(path.basename(cfg.path), noteName);
+    if (!uri) return false;
+    try {
+      await shell.openExternal(uri);
+      return true;
+    } catch {
+      // Obsidian not installed, or no handler registered for the scheme.
+      return false;
+    }
   });
 
   ipcMain.handle('obsidian:disconnect', async () => {

--- a/electron/obsidianUri.test.ts
+++ b/electron/obsidianUri.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { buildObsidianOpenUri } from './obsidianUri.js';
+
+// Regression tests for "Open in Obsidian" doing nothing on macOS. Two defects
+// met here: the renderer's window.open('obsidian://…') was dropped by the
+// http/https-only external-URL allowlist, and the renderer's Electron vault
+// handle reports the placeholder name 'vault' rather than the real folder. The
+// URL is therefore built in the main process, from the vault path it holds.
+
+describe('buildObsidianOpenUri', () => {
+  it('builds an open URI from the vault folder name and note name', () => {
+    expect(buildObsidianOpenUri('My Vault', 'Project Notes'))
+      .toBe('obsidian://open?vault=My%20Vault&file=Project%20Notes');
+  });
+
+  it('strips the [[Note#Heading]] fragment', () => {
+    // Left in place it percent-encodes to `Meeting%23Agenda` and Obsidian
+    // matches no such file — the button would "work" but open nothing. Matches
+    // what loadWikiNote and saveWikiNote already do with the same input.
+    expect(buildObsidianOpenUri('Vault', 'Meeting#Agenda'))
+      .toBe('obsidian://open?vault=Vault&file=Meeting');
+  });
+
+  it('trims surrounding whitespace from both parts', () => {
+    expect(buildObsidianOpenUri('  Vault  ', '  Note  '))
+      .toBe('obsidian://open?vault=Vault&file=Note');
+    // A wikilink written as [[Note # Heading]] leaves a trailing space.
+    expect(buildObsidianOpenUri('Vault', 'Note # Heading'))
+      .toBe('obsidian://open?vault=Vault&file=Note');
+  });
+
+  it('percent-encodes characters that would otherwise break the query', () => {
+    // Note titles routinely contain these; unencoded, `&` and `#` would split
+    // the query and `/` would be read as a path separator by some handlers.
+    expect(buildObsidianOpenUri('R&D', 'Q1 / Q2 plan'))
+      .toBe('obsidian://open?vault=R%26D&file=Q1%20%2F%20Q2%20plan');
+  });
+
+  it('supports notes in subfolders', () => {
+    expect(buildObsidianOpenUri('Vault', 'Areas/Work/Standup'))
+      .toBe('obsidian://open?vault=Vault&file=Areas%2FWork%2FStandup');
+  });
+
+  it('returns null when the note name is empty or only a heading', () => {
+    expect(buildObsidianOpenUri('Vault', '')).toBeNull();
+    expect(buildObsidianOpenUri('Vault', '   ')).toBeNull();
+    expect(buildObsidianOpenUri('Vault', '#Heading')).toBeNull();
+  });
+
+  it('returns null when the vault name is missing', () => {
+    // No vault configured, or a config whose path resolved to an empty basename.
+    expect(buildObsidianOpenUri('', 'Note')).toBeNull();
+    expect(buildObsidianOpenUri('   ', 'Note')).toBeNull();
+  });
+
+  it('returns null for non-string input rather than building a junk URI', () => {
+    expect(buildObsidianOpenUri(undefined as unknown as string, 'Note')).toBeNull();
+    expect(buildObsidianOpenUri('Vault', null as unknown as string)).toBeNull();
+    expect(buildObsidianOpenUri('Vault', 42 as unknown as string)).toBeNull();
+  });
+});

--- a/electron/obsidianUri.ts
+++ b/electron/obsidianUri.ts
@@ -1,0 +1,35 @@
+// Builds the obsidian:// deep link used by "Open in Obsidian", extracted as a
+// pure function so it can be unit-tested without Electron (same pattern as
+// startupQuit.ts and calendarCache.ts).
+//
+// WHY THIS LIVES IN THE MAIN PROCESS: the renderer cannot open this URL itself.
+// window.open() in a BrowserWindow is intercepted by setWindowOpenHandler, which
+// hands the URL to openExternalSafe() — deliberately restricted to http/https so
+// a renderer compromise can't launch arbitrary schemes. Rather than widen that
+// allowlist, the renderer sends a NOTE NAME over IPC and the main process builds
+// the URL from the vault path it already holds. The renderer never controls the
+// URL, so the allowlist keeps its original security property.
+//
+// It also has to live here for correctness: on Electron the renderer's vault
+// "handle" is a shim (src/obsidianElectronHandle.js) whose name is the constant
+// 'vault', not the real folder name. Only the main process knows the actual
+// vault path, and therefore the vault name Obsidian expects.
+
+/**
+ * @param vaultName Folder name of the vault (i.e. path.basename of its path).
+ * @param noteName  Wikilink target, possibly with a `#Heading` fragment.
+ * @returns The obsidian://open URI, or null when either input is unusable.
+ */
+export function buildObsidianOpenUri(vaultName: string, noteName: string): string | null {
+  if (typeof vaultName !== 'string' || typeof noteName !== 'string') return null;
+
+  const vault = vaultName.trim();
+  // Strip the [[Note#Heading]] fragment, matching loadWikiNote/saveWikiNote:
+  // the whole note file is opened, not a section. Left in place it would be
+  // percent-encoded into the filename (`Note%23Heading`) and match nothing.
+  const note = noteName.split('#')[0].trim();
+
+  if (!vault || !note) return null;
+
+  return `obsidian://open?vault=${encodeURIComponent(vault)}&file=${encodeURIComponent(note)}`;
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -195,6 +195,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     pick: (): Promise<{ path: string; name: string } | null> => ipcRenderer.invoke('obsidian:pick'),
     restore: (): Promise<{ path: string; name: string } | null> => ipcRenderer.invoke('obsidian:restore'),
     disconnect: (): Promise<boolean> => ipcRenderer.invoke('obsidian:disconnect'),
+    // Opens a note in the Obsidian app. The main process builds the obsidian://
+    // URL from the vault path it holds — the renderer passes only a note name,
+    // so the http/https-only external-URL allowlist stays intact.
+    openNote: (noteName: string): Promise<boolean> =>
+      ipcRenderer.invoke('obsidian:open-note', noteName),
     stat: (relativePath: string): Promise<{ kind: 'file' | 'directory' } | null> =>
       ipcRenderer.invoke('obsidian:stat', relativePath),
     listDir: (relativePath: string): Promise<Array<{ name: string; kind: 'file' | 'directory' }>> =>

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -83,7 +83,17 @@ export default function useObsidianSync({
       nativeOpenNote(noteName);
       return;
     }
-    // Web/desktop: construct obsidian:// deep link using the vault folder name
+    // Electron: hand the note name to the main process, which builds the
+    // obsidian:// URL and opens it. The renderer's own window.open() below never
+    // works here — setWindowOpenHandler routes it to openExternalSafe, which
+    // only permits http/https — and `handle` is the shim from
+    // obsidianElectronHandle.js, whose name is the placeholder 'vault' rather
+    // than the real folder name. The main process has both capabilities.
+    if (window.electronAPI?.obsidian?.openNote) {
+      window.electronAPI.obsidian.openNote(noteName);
+      return;
+    }
+    // Web: construct obsidian:// deep link using the vault folder name
     const vaultName = handle.name;
     if (vaultName) {
       window.open(


### PR DESCRIPTION
## Root cause

Two defects, the second hidden behind the first.

**1. The `obsidian://` URL was silently dropped.** `openInObsidian` (`useObsidianSync.js:79`) opens the deep link with `window.open('obsidian://open?vault=…&file=…', '_blank')`. In Electron that's intercepted by `setWindowOpenHandler` (`main.ts:258`), which returns `{ action: 'deny' }` and hands the URL to `openExternalSafe`:

```ts
// Only open http/https URLs in the system browser — prevents javascript:,
// file:, custom-protocol, and other potentially dangerous scheme abuse.
function openExternalSafe(url: string): void {
  const { protocol } = new URL(url);
  if (protocol === 'https:' || protocol === 'http:') shell.openExternal(url);
}
```

So the URL was denied as a navigation **and** refused a handoff to the OS. No error, no console output — the button just did nothing. That restriction is correct and intentional; the bug is that the renderer had no other route.

**2. The vault name would have been wrong anyway.** `preload.ts` exposes `electronAPI.obsidian` unconditionally and `main.ts:889` registers the handlers unconditionally, so **every** Electron build (not just MAS) takes `isElectronObsidian() === true` → `makeElectronVaultHandle()`. That shim hardcodes its name:

```js
return makeDirHandle(api, '', 'vault');   // obsidianElectronHandle.js:119
```

`handle.name` is therefore the literal `'vault'`, and the link would have read `obsidian://open?vault=vault` — naming a vault that doesn't exist. `obsidian:pick`/`obsidian:restore` already return the real `path.basename(dir)`, but `obsidian.js` discards it and uses the result only as a truthiness check.

**Why Android works:** it takes the `handle === 'native'` branch and calls `nativeOpenNote` over the bridge, never touching either path. That matches the report exactly.

## The fix

Rather than widen the allowlist, invert the flow. The renderer sends only a note **name** over a new `obsidian:open-note` channel, and the main process builds the URL from the vault path it already holds.

- **`main.ts` is untouched** — the http/https-only allowlist keeps its original security property, and the renderer never controls a URL.
- The main process is also the only place that knows the real vault folder name, so defect 2 is fixed for free.

The URI builder strips the `[[Note#Heading]]` fragment, matching what `loadWikiNote` and `saveWikiNote` already do with the same input. Left in, it percent-encodes to `Note%23Heading` and matches no file — the button would have launched Obsidian but landed nowhere.

**Web is unchanged**: no `electronAPI.obsidian` bridge there, so it still falls through to `window.open` with the real File System Access handle name.

## Tests

`buildObsidianOpenUri` is a pure function in the style of `startupQuit.ts`/`calendarCache.ts` — 8 tests covering encoding, the heading fragment, whitespace, subfolder notes, `&`/`/` in names, and null returns for empty/non-string input.

Full suite 68 files / 1045 tests green; lint, both tsconfigs, and both production builds clean. `git diff origin/main -- electron/main.ts` is empty, confirming the allowlist wasn't touched.

## Needs a manual check on your Mac

The IPC wiring itself has no automated coverage — only the URL construction does. Worth confirming: the button opens the correct note in the right vault, and a note whose title contains `&` or lives in a subfolder still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_