### PR TITLE
Summary strip phase 1: per-tag totals + unblocked time on the timeline

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -11,6 +11,7 @@ import { hasNativeCalendar } from '../utils/nativeCalendar.js';
 import DesktopHeader from './DesktopHeader.jsx';
 import CalendarHeader from './CalendarHeader.jsx';
 import TimeGrid from './TimeGrid.jsx';
+import SummaryStrip from './SummaryStrip.jsx';
 import DayView from './DayView.jsx';
 import WeekView from './WeekView.jsx';
 import SchedDashboard from './sched/SchedDashboard.jsx';
@@ -836,6 +837,10 @@ const DesktopLayout = () => {
                     {effectiveViewMode === 'day' && <DayView />}
                     {effectiveViewMode === 'week' && <WeekView />}
                     {effectiveViewMode === 'sched' && <SchedDashboard />}
+                    {/* Summary strip — sticky over the timeline's own scroll
+                        container so it stays visible without reserving layout
+                        height. Timeline views only; sched is a dashboard. */}
+                    {effectiveViewMode !== 'sched' && <SummaryStrip />}
                   </>
               }
             </div>

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -30,6 +30,7 @@ import MobileTabBar from './MobileTabBar.jsx';
 import MobileSettingsPanel from './MobileSettingsPanel.jsx';
 import GoalDashboard from './goals/GoalDashboard.jsx';
 import MobileTimeGrid from './MobileTimeGrid.jsx';
+import SummaryStrip from './SummaryStrip.jsx';
 import MobileAllDaySection from './MobileAllDaySection.jsx';
 import MobileBottomSheets from './MobileBottomSheets.jsx';
 import MobileGlanceSection from './MobileGlanceSection.jsx';
@@ -789,6 +790,10 @@ const MobileLayout = () => {
                   {mobileViewMode === 'grid' && <MobileTimeGrid />}
                   {mobileViewMode === 'list' && <MobileListView />}
                   {mobileViewMode === 'sched' && <SchedView />}
+                  {/* Summary strip — sticky bottom of the timeline scroll
+                      container, so it sits above the tab bar. Collapsible on
+                      phone, where timeline vertical space is tightest. */}
+                  {mobileViewMode !== 'sched' && <SummaryStrip collapsible />}
                 </div>
 
                 {/* Mobile notes panel overlay for timeline tasks (including deadline tasks) */}

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -791,9 +791,10 @@ const MobileLayout = () => {
                   {mobileViewMode === 'list' && <MobileListView />}
                   {mobileViewMode === 'sched' && <SchedView />}
                   {/* Summary strip — sticky bottom of the timeline scroll
-                      container, so it sits above the tab bar. Collapsible on
-                      phone, where timeline vertical space is tightest. */}
-                  {mobileViewMode !== 'sched' && <SummaryStrip collapsible />}
+                      container, so it sits above the tab bar. Phone variant:
+                      collapsible (vertical space is tightest here), no date
+                      pill, and clearance for the new-task FAB. */}
+                  {mobileViewMode !== 'sched' && <SummaryStrip phone />}
                 </div>
 
                 {/* Mobile notes panel overlay for timeline tasks (including deadline tasks) */}

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -23,17 +23,20 @@ const COLLAPSE_KEY = 'day-planner-summary-strip-collapsed';
  *
  * All data comes from context; the math lives in utils/daySummary.js.
  *
- * @param collapsible Phone only — collapses to a single pill (date + unblocked
- *                    time) that expands on tap. Desktop/tablet pass nothing.
+ * @param phone Phone timeline variant: collapsible to a single pill, no date
+ *              pill (the phone timeline shows exactly one day, so the heading
+ *              would restate the header), and right clearance for the new-task
+ *              FAB (fixed right-4 w-14, z-40 — above this row's z-30) so pills
+ *              never slide underneath it. Desktop/tablet pass nothing.
  */
-export default function SummaryStrip({ collapsible = false }) {
+export default function SummaryStrip({ phone = false }) {
   const {
     selectedDate, getTasksForDate, listEndOfDayTime,
     darkMode, textPrimary, textSecondary,
   } = useDayPlannerCtx();
 
   const [collapsed, setCollapsed] = useState(
-    () => collapsible && localStorage.getItem(COLLAPSE_KEY) !== '0',
+    () => phone && localStorage.getItem(COLLAPSE_KEY) !== '0',
   );
   const toggle = () => {
     setCollapsed((c) => {
@@ -66,20 +69,22 @@ export default function SummaryStrip({ collapsible = false }) {
   );
 
   return (
-    <div className="sticky bottom-0 z-30 px-2 pb-2 pointer-events-none">
-      {collapsible && collapsed ? (
+    <div className={`sticky bottom-0 z-30 pl-2 pb-2 pointer-events-none ${phone ? 'pr-20' : 'pr-2'}`}>
+      {phone && collapsed ? (
         <button onClick={toggle} className={`${pill} pointer-events-auto max-w-full text-xs`}>
           <ChevronUp size={13} className={`flex-shrink-0 ${textSecondary}`} />
           {unblockedLabel}
-          <span className={`truncate ${textSecondary}`}>· {formatShortDate(selectedDate)}</span>
         </button>
       ) : (
         <div className={`pointer-events-auto w-fit max-w-full flex items-center gap-1.5 overflow-x-auto text-xs ${darkMode ? 'dark-scrollbar' : ''}`}>
           {/* Day/date heading — pins which day the numbers describe, which the
-              multi-day desktop view otherwise leaves ambiguous. */}
-          <span className={pill}>
-            <span className={`font-medium ${textPrimary}`}>{formatShortDate(selectedDate)}</span>
-          </span>
+              multi-day desktop view otherwise leaves ambiguous. The phone
+              timeline shows exactly one day, so there it is dropped. */}
+          {!phone && (
+            <span className={pill}>
+              <span className={`font-medium ${textPrimary}`}>{formatShortDate(selectedDate)}</span>
+            </span>
+          )}
           <span className={pill}>{unblockedLabel}</span>
           {summary.categories.map((c) => (
             <span key={c.tag} className={pill}>
@@ -94,7 +99,7 @@ export default function SummaryStrip({ collapsible = false }) {
               <span className={textSecondary}>untagged {formatMinutes(summary.untaggedMinutes)}</span>
             </span>
           )}
-          {collapsible && (
+          {phone && (
             <button onClick={toggle} className={`${pill} ${textSecondary}`} aria-label="Collapse summary">
               <ChevronDown size={13} />
             </button>

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -77,14 +77,6 @@ export default function SummaryStrip({ phone = false }) {
         </button>
       ) : (
         <div className={`pointer-events-auto w-fit max-w-full flex items-center gap-1.5 overflow-x-auto text-xs ${darkMode ? 'dark-scrollbar' : ''}`}>
-          {/* Collapse control leads the row: on phone the row scrolls
-              horizontally, and a trailing control would need a scroll to
-              reach every time. */}
-          {phone && (
-            <button onClick={toggle} className={`${pill} ${textSecondary}`} aria-label="Collapse summary">
-              <ChevronDown size={13} />
-            </button>
-          )}
           {/* Day/date heading — pins which day the numbers describe, which the
               multi-day desktop view otherwise leaves ambiguous. The phone
               timeline shows exactly one day, so there it is dropped. */}
@@ -93,7 +85,14 @@ export default function SummaryStrip({ phone = false }) {
               <span className={`font-medium ${textPrimary}`}>{formatShortDate(selectedDate)}</span>
             </span>
           )}
-          <span className={pill}>{unblockedLabel}</span>
+          <span className={pill}>
+            {phone && (
+              <button onClick={toggle} className={`-ml-1 p-0.5 rounded-full ${textSecondary} hover:opacity-70`} aria-label="Collapse summary">
+                <ChevronDown size={13} />
+              </button>
+            )}
+            {unblockedLabel}
+          </span>
           {summary.categories.map((c) => (
             <span key={c.tag} className={pill}>
               <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: c.colorHex }} />

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -1,29 +1,35 @@
 import { useMemo, useState } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { formatShortDate } from '../utils/taskUtils.js';
 import { computeDaySummary, formatMinutes } from '../utils/daySummary.js';
 
 // Collapse choice is a per-window view preference, same class as
 // minimizedSections. Default collapsed: the strip only collapses on phone,
-// where timeline vertical space is tightest, and the collapsed line still
+// where timeline vertical space is tightest, and the collapsed pill still
 // carries the headline number.
 const COLLAPSE_KEY = 'day-planner-summary-strip-collapsed';
 
 /**
- * Summary strip (phase 1): rolls the viewed day's timeline blocks into one
- * glanceable row — unblocked time plus total time per #tag. Sticks to the
- * bottom of the timeline's scroll container, so it stays visible over the grid
- * without costing the layout any fixed height.
+ * Summary strip (phase 1): rolls the viewed day's timeline blocks into a row of
+ * pills floating over the bottom of the timeline — the day/date, unblocked
+ * time, and total time per #tag. Sticky inside the timeline's scroll container,
+ * so it costs no layout height; the pill row is width-fit with pointer events
+ * scoped to itself, so the grid stays clickable around it.
+ *
+ * Each pill carries its own opaque-ish blurred background instead of the row
+ * having one — floating over arbitrary block colors, per-pill backdrop-blur +
+ * border + shadow is what keeps the text legible.
  *
  * All data comes from context; the math lives in utils/daySummary.js.
  *
- * @param collapsible Phone only — renders a one-line summary that expands on
- *                    tap. Desktop/tablet pass nothing and are always expanded.
+ * @param collapsible Phone only — collapses to a single pill (date + unblocked
+ *                    time) that expands on tap. Desktop/tablet pass nothing.
  */
 export default function SummaryStrip({ collapsible = false }) {
   const {
     selectedDate, getTasksForDate, listEndOfDayTime,
-    darkMode, cardBg, borderClass, textPrimary, textSecondary,
+    darkMode, textPrimary, textSecondary,
   } = useDayPlannerCtx();
 
   const [collapsed, setCollapsed] = useState(
@@ -45,52 +51,52 @@ export default function SummaryStrip({ collapsible = false }) {
   );
 
   // Empty day: nothing to summarize, and "0m unblocked" would claim the
-  // opposite of the truth. Render nothing rather than an empty bar.
+  // opposite of the truth. Render nothing rather than an empty row.
   if (summary.unblockedMinutes === null) return null;
 
-  const chipBg = darkMode ? 'bg-white/10' : 'bg-black/5';
-  const topCategory = summary.categories[0];
+  const pill = `flex items-center gap-1.5 px-2.5 py-1 rounded-full flex-shrink-0 border shadow-sm backdrop-blur-sm ${
+    darkMode ? 'bg-gray-900/85 border-gray-700' : 'bg-white/90 border-stone-200'
+  }`;
 
   const unblockedLabel = (
-    <span className="flex items-baseline gap-1 flex-shrink-0">
+    <span className="flex items-baseline gap-1">
       <span className={`font-semibold ${textPrimary}`}>{formatMinutes(summary.unblockedMinutes)}</span>
       <span className={textSecondary}>unblocked</span>
     </span>
   );
 
   return (
-    <div className={`sticky bottom-0 z-30 ${cardBg} border-t ${borderClass} px-3 py-1.5 text-xs`}>
+    <div className="sticky bottom-0 z-30 px-2 pb-2 pointer-events-none">
       {collapsible && collapsed ? (
-        <button onClick={toggle} className="w-full flex items-center gap-2 text-left">
-          <ChevronUp size={14} className={`flex-shrink-0 ${textSecondary}`} />
+        <button onClick={toggle} className={`${pill} pointer-events-auto max-w-full text-xs`}>
+          <ChevronUp size={13} className={`flex-shrink-0 ${textSecondary}`} />
           {unblockedLabel}
-          {topCategory && (
-            <span className={`truncate ${textSecondary}`}>
-              · #{topCategory.tag} {formatMinutes(topCategory.minutes)}
-            </span>
-          )}
+          <span className={`truncate ${textSecondary}`}>· {formatShortDate(selectedDate)}</span>
         </button>
       ) : (
-        <div className="flex items-center gap-2">
-          <div className="flex-1 min-w-0 flex items-center gap-2 overflow-x-auto whitespace-nowrap">
-            {unblockedLabel}
-            {summary.categories.map((c) => (
-              <span key={c.tag} className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full flex-shrink-0 ${chipBg}`}>
-                <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: c.colorHex }} />
-                <span className={textPrimary}>#{c.tag}</span>
-                <span className={textSecondary}>{formatMinutes(c.minutes)}</span>
-              </span>
-            ))}
-            {summary.untaggedMinutes > 0 && (
-              <span className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full flex-shrink-0 ${chipBg}`}>
-                <span className={`w-2 h-2 rounded-full flex-shrink-0 ${darkMode ? 'bg-gray-500' : 'bg-stone-400'}`} />
-                <span className={textSecondary}>untagged {formatMinutes(summary.untaggedMinutes)}</span>
-              </span>
-            )}
-          </div>
+        <div className={`pointer-events-auto w-fit max-w-full flex items-center gap-1.5 overflow-x-auto text-xs ${darkMode ? 'dark-scrollbar' : ''}`}>
+          {/* Day/date heading — pins which day the numbers describe, which the
+              multi-day desktop view otherwise leaves ambiguous. */}
+          <span className={pill}>
+            <span className={`font-medium ${textPrimary}`}>{formatShortDate(selectedDate)}</span>
+          </span>
+          <span className={pill}>{unblockedLabel}</span>
+          {summary.categories.map((c) => (
+            <span key={c.tag} className={pill}>
+              <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: c.colorHex }} />
+              <span className={textPrimary}>#{c.tag}</span>
+              <span className={textSecondary}>{formatMinutes(c.minutes)}</span>
+            </span>
+          ))}
+          {summary.untaggedMinutes > 0 && (
+            <span className={pill}>
+              <span className={`w-2 h-2 rounded-full flex-shrink-0 ${darkMode ? 'bg-gray-500' : 'bg-stone-400'}`} />
+              <span className={textSecondary}>untagged {formatMinutes(summary.untaggedMinutes)}</span>
+            </span>
+          )}
           {collapsible && (
-            <button onClick={toggle} className={`flex-shrink-0 p-0.5 ${textSecondary}`} aria-label="Collapse summary">
-              <ChevronDown size={14} />
+            <button onClick={toggle} className={`${pill} ${textSecondary}`} aria-label="Collapse summary">
+              <ChevronDown size={13} />
             </button>
           )}
         </div>

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -1,0 +1,100 @@
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { computeDaySummary, formatMinutes } from '../utils/daySummary.js';
+
+// Collapse choice is a per-window view preference, same class as
+// minimizedSections. Default collapsed: the strip only collapses on phone,
+// where timeline vertical space is tightest, and the collapsed line still
+// carries the headline number.
+const COLLAPSE_KEY = 'day-planner-summary-strip-collapsed';
+
+/**
+ * Summary strip (phase 1): rolls the viewed day's timeline blocks into one
+ * glanceable row — unblocked time plus total time per #tag. Sticks to the
+ * bottom of the timeline's scroll container, so it stays visible over the grid
+ * without costing the layout any fixed height.
+ *
+ * All data comes from context; the math lives in utils/daySummary.js.
+ *
+ * @param collapsible Phone only — renders a one-line summary that expands on
+ *                    tap. Desktop/tablet pass nothing and are always expanded.
+ */
+export default function SummaryStrip({ collapsible = false }) {
+  const {
+    selectedDate, getTasksForDate, listEndOfDayTime,
+    darkMode, cardBg, borderClass, textPrimary, textSecondary,
+  } = useDayPlannerCtx();
+
+  const [collapsed, setCollapsed] = useState(
+    () => collapsible && localStorage.getItem(COLLAPSE_KEY) !== '0',
+  );
+  const toggle = () => {
+    setCollapsed((c) => {
+      localStorage.setItem(COLLAPSE_KEY, c ? '0' : '1');
+      return !c;
+    });
+  };
+
+  // Tag filter deliberately bypassed: a filtered timeline still occupies the
+  // whole day, and computing "unblocked" from a filtered subset would report
+  // hidden hours as free.
+  const summary = useMemo(
+    () => computeDaySummary(getTasksForDate(selectedDate, false), listEndOfDayTime),
+    [getTasksForDate, selectedDate, listEndOfDayTime],
+  );
+
+  // Empty day: nothing to summarize, and "0m unblocked" would claim the
+  // opposite of the truth. Render nothing rather than an empty bar.
+  if (summary.unblockedMinutes === null) return null;
+
+  const chipBg = darkMode ? 'bg-white/10' : 'bg-black/5';
+  const topCategory = summary.categories[0];
+
+  const unblockedLabel = (
+    <span className="flex items-baseline gap-1 flex-shrink-0">
+      <span className={`font-semibold ${textPrimary}`}>{formatMinutes(summary.unblockedMinutes)}</span>
+      <span className={textSecondary}>unblocked</span>
+    </span>
+  );
+
+  return (
+    <div className={`sticky bottom-0 z-30 ${cardBg} border-t ${borderClass} px-3 py-1.5 text-xs`}>
+      {collapsible && collapsed ? (
+        <button onClick={toggle} className="w-full flex items-center gap-2 text-left">
+          <ChevronUp size={14} className={`flex-shrink-0 ${textSecondary}`} />
+          {unblockedLabel}
+          {topCategory && (
+            <span className={`truncate ${textSecondary}`}>
+              · #{topCategory.tag} {formatMinutes(topCategory.minutes)}
+            </span>
+          )}
+        </button>
+      ) : (
+        <div className="flex items-center gap-2">
+          <div className="flex-1 min-w-0 flex items-center gap-2 overflow-x-auto whitespace-nowrap">
+            {unblockedLabel}
+            {summary.categories.map((c) => (
+              <span key={c.tag} className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full flex-shrink-0 ${chipBg}`}>
+                <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: c.colorHex }} />
+                <span className={textPrimary}>#{c.tag}</span>
+                <span className={textSecondary}>{formatMinutes(c.minutes)}</span>
+              </span>
+            ))}
+            {summary.untaggedMinutes > 0 && (
+              <span className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full flex-shrink-0 ${chipBg}`}>
+                <span className={`w-2 h-2 rounded-full flex-shrink-0 ${darkMode ? 'bg-gray-500' : 'bg-stone-400'}`} />
+                <span className={textSecondary}>untagged {formatMinutes(summary.untaggedMinutes)}</span>
+              </span>
+            )}
+          </div>
+          {collapsible && (
+            <button onClick={toggle} className={`flex-shrink-0 p-0.5 ${textSecondary}`} aria-label="Collapse summary">
+              <ChevronDown size={14} />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -77,6 +77,14 @@ export default function SummaryStrip({ phone = false }) {
         </button>
       ) : (
         <div className={`pointer-events-auto w-fit max-w-full flex items-center gap-1.5 overflow-x-auto text-xs ${darkMode ? 'dark-scrollbar' : ''}`}>
+          {/* Collapse control leads the row: on phone the row scrolls
+              horizontally, and a trailing control would need a scroll to
+              reach every time. */}
+          {phone && (
+            <button onClick={toggle} className={`${pill} ${textSecondary}`} aria-label="Collapse summary">
+              <ChevronDown size={13} />
+            </button>
+          )}
           {/* Day/date heading — pins which day the numbers describe, which the
               multi-day desktop view otherwise leaves ambiguous. The phone
               timeline shows exactly one day, so there it is dropped. */}
@@ -98,11 +106,6 @@ export default function SummaryStrip({ phone = false }) {
               <span className={`w-2 h-2 rounded-full flex-shrink-0 ${darkMode ? 'bg-gray-500' : 'bg-stone-400'}`} />
               <span className={textSecondary}>untagged {formatMinutes(summary.untaggedMinutes)}</span>
             </span>
-          )}
-          {phone && (
-            <button onClick={toggle} className={`${pill} ${textSecondary}`} aria-label="Collapse summary">
-              <ChevronDown size={13} />
-            </button>
           )}
         </div>
       )}

--- a/src/utils/daySummary.js
+++ b/src/utils/daySummary.js
@@ -1,0 +1,143 @@
+import { extractTags } from './taskUtils.js';
+import { taskColorToHex } from './colorUtils.js';
+
+// Summary-strip rollup for one day of timeline blocks (phase 1: category totals
+// + unblocked time). Pure — takes the day's task list and returns numbers, so
+// the strip UI stays presentational and the math is testable in isolation. This
+// same function is the future Live Activity projection: the widget needs exactly
+// this output, no rendering attached.
+//
+// Scope rules, chosen deliberately:
+//  - Only timed blocks count. All-day events have no duration on the timeline
+//    and would swamp every number; blocks without a startTime aren't on the
+//    timeline at all.
+//  - Native/imported calendar events DO count — they occupy real time, which is
+//    exactly what unblocked time is measuring.
+//  - Completed blocks still count. This is a summary of the day's shape, not a
+//    todo list; completing a meeting doesn't un-spend the hour.
+//  - Category totals sum RAW block durations per tag ("total time per label").
+//    A block tagged #work #deep contributes its full duration to both labels,
+//    so category minutes can exceed wall-clock time — per-label sums, not a
+//    partition. Unblocked time is computed separately from merged intervals and
+//    never double-counts.
+
+const timeToMin = (t) => {
+  const [h, m] = String(t).split(':').map(Number);
+  return (h || 0) * 60 + (m || 0);
+};
+
+// Merge possibly-overlapping [start, end) intervals and return total covered
+// minutes. Overlapping and touching blocks must not double-count unblocked time.
+function mergedCoverage(intervals) {
+  if (intervals.length === 0) return 0;
+  const sorted = [...intervals].sort((a, b) => a[0] - b[0]);
+  let total = 0;
+  let [curStart, curEnd] = sorted[0];
+  for (let i = 1; i < sorted.length; i++) {
+    const [s, e] = sorted[i];
+    if (s <= curEnd) {
+      curEnd = Math.max(curEnd, e);
+    } else {
+      total += curEnd - curStart;
+      [curStart, curEnd] = [s, e];
+    }
+  }
+  total += curEnd - curStart;
+  return total;
+}
+
+/** "2h 15m" / "45m" / "3h" / "0m" — durations, not clock times. */
+export function formatMinutes(min) {
+  const m = Math.max(0, Math.round(min));
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  const rem = m % 60;
+  return rem === 0 ? `${h}h` : `${h}h ${rem}m`;
+}
+
+/**
+ * @param dayTasks     Tasks for one date (user blocks + recurring instances +
+ *                     native calendar events — the tasksByDate shape).
+ * @param endOfDayTime Optional "HH:MM" end-of-day setting (listEndOfDayTime).
+ *                     When set, the day window extends to it, so time between
+ *                     the last block and end-of-day counts as unblocked. When
+ *                     null, the window is just the span of the blocks and
+ *                     unblocked time means gaps between them — no bedtime is
+ *                     assumed on the user's behalf.
+ * @returns {{
+ *   categories: Array<{tag: string, minutes: number, colorHex: string}>,
+ *   untaggedMinutes: number,
+ *   blockedMinutes: number,
+ *   unblockedMinutes: number|null,  // null = no timed blocks, nothing to measure
+ *   windowStartMin: number|null,
+ *   windowEndMin: number|null,
+ * }}
+ */
+export function computeDaySummary(dayTasks, endOfDayTime = null) {
+  const timed = (dayTasks || []).filter(
+    (t) => t && !t.isAllDay && t.startTime && (t.duration || 0) > 0,
+  );
+
+  if (timed.length === 0) {
+    return {
+      categories: [],
+      untaggedMinutes: 0,
+      blockedMinutes: 0,
+      unblockedMinutes: null,
+      windowStartMin: null,
+      windowEndMin: null,
+    };
+  }
+
+  // Per-tag minute totals, plus per-tag per-color totals so each category dot
+  // can take the color of the blocks that dominate it. There is no tag→color
+  // mapping in the data model — color is a block property — so "dominant block
+  // color, by minutes" is the honest rule; ties resolve to first-seen.
+  const tagMinutes = new Map();
+  const tagColorMinutes = new Map();
+  let untaggedMinutes = 0;
+  const intervals = [];
+
+  for (const t of timed) {
+    const start = timeToMin(t.startTime);
+    const minutes = t.duration || 0;
+    intervals.push([start, start + minutes]);
+
+    const tags = extractTags(t.title || '');
+    if (tags.length === 0) {
+      untaggedMinutes += minutes;
+      continue;
+    }
+    const hex = taskColorToHex(t.color, t.nativeCalendarColor);
+    for (const tag of tags) {
+      tagMinutes.set(tag, (tagMinutes.get(tag) || 0) + minutes);
+      if (!tagColorMinutes.has(tag)) tagColorMinutes.set(tag, new Map());
+      const colors = tagColorMinutes.get(tag);
+      colors.set(hex, (colors.get(hex) || 0) + minutes);
+    }
+  }
+
+  const categories = [...tagMinutes.entries()]
+    .map(([tag, minutes]) => {
+      let colorHex = '#3b82f6';
+      let best = -1;
+      for (const [hex, min] of tagColorMinutes.get(tag)) {
+        if (min > best) { best = min; colorHex = hex; }
+      }
+      return { tag, minutes, colorHex };
+    })
+    .sort((a, b) => b.minutes - a.minutes || a.tag.localeCompare(b.tag));
+
+  const windowStartMin = Math.min(...intervals.map(([s]) => s));
+  const latestEnd = Math.max(...intervals.map(([, e]) => e));
+  // A block running past the configured end-of-day extends the window rather
+  // than producing negative unblocked time.
+  const windowEndMin = endOfDayTime
+    ? Math.max(latestEnd, timeToMin(endOfDayTime))
+    : latestEnd;
+
+  const blockedMinutes = mergedCoverage(intervals);
+  const unblockedMinutes = Math.max(0, windowEndMin - windowStartMin - blockedMinutes);
+
+  return { categories, untaggedMinutes, blockedMinutes, unblockedMinutes, windowStartMin, windowEndMin };
+}

--- a/src/utils/daySummary.test.js
+++ b/src/utils/daySummary.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { computeDaySummary, formatMinutes } from './daySummary.js';
+
+// Minimal timeline block; tags live in the title as #hashtags, exactly as the
+// timeline stores them.
+const block = (startTime, duration, title = 'Untitled', extra = {}) => ({
+  startTime, duration, title, ...extra,
+});
+
+describe('formatMinutes', () => {
+  it('formats durations, not clock times', () => {
+    expect(formatMinutes(0)).toBe('0m');
+    expect(formatMinutes(45)).toBe('45m');
+    expect(formatMinutes(60)).toBe('1h');
+    expect(formatMinutes(135)).toBe('2h 15m');
+  });
+
+  it('never renders a negative duration', () => {
+    expect(formatMinutes(-30)).toBe('0m');
+  });
+});
+
+describe('computeDaySummary — scope rules', () => {
+  it('returns null unblocked time when there are no timed blocks', () => {
+    // null, not 0: with nothing on the timeline there is no window to measure,
+    // and rendering "0m unblocked" would claim a fully-booked day.
+    const s = computeDaySummary([block(null, 60, '#work no start'), { title: 'allday', isAllDay: true, startTime: '09:00', duration: 60 }]);
+    expect(s.unblockedMinutes).toBeNull();
+    expect(s.categories).toEqual([]);
+  });
+
+  it('excludes all-day events and start-less blocks, includes native events', () => {
+    const s = computeDaySummary([
+      block('09:00', 60, 'Standup #work'),
+      { title: 'Conference', isAllDay: true, startTime: '00:00', duration: 1440 },
+      block('10:00', 30, 'Dentist', { _native: true, nativeCalendarColor: '#ff0000' }),
+    ]);
+    // All-day contributes nothing; the native event blocks real time.
+    expect(s.blockedMinutes).toBe(90);
+  });
+
+  it('counts completed blocks — completing a meeting does not un-spend the hour', () => {
+    const s = computeDaySummary([block('09:00', 60, '#work', { completed: true })]);
+    expect(s.categories).toEqual([{ tag: 'work', minutes: 60, colorHex: '#3b82f6' }]);
+    expect(s.blockedMinutes).toBe(60);
+  });
+});
+
+describe('computeDaySummary — category totals', () => {
+  it('sums minutes per tag and sorts by minutes descending', () => {
+    const s = computeDaySummary([
+      block('09:00', 60, 'Standup #work'),
+      block('10:00', 90, 'Deep block #work'),
+      block('12:00', 30, 'Lunch walk #health'),
+    ]);
+    expect(s.categories.map((c) => [c.tag, c.minutes])).toEqual([
+      ['work', 150],
+      ['health', 30],
+    ]);
+  });
+
+  it('a multi-tag block contributes its full duration to every tag (per-label sums, not a partition)', () => {
+    const s = computeDaySummary([block('09:00', 60, '#work #deep')]);
+    expect(s.categories.map((c) => [c.tag, c.minutes])).toEqual([
+      ['deep', 60],
+      ['work', 60],
+    ]);
+    // ...while blocked time counts the hour once.
+    expect(s.blockedMinutes).toBe(60);
+  });
+
+  it('buckets tagless blocks as untagged so the strip total matches the visible day', () => {
+    const s = computeDaySummary([
+      block('09:00', 60, '#work'),
+      block('10:00', 45, 'errands, no tag'),
+    ]);
+    expect(s.untaggedMinutes).toBe(45);
+  });
+
+  it('gives each tag the color of its dominant block, by minutes', () => {
+    // No tag→color mapping exists in the data model — color is per-block — so a
+    // tag spanning differently-colored blocks takes the color it mostly wears.
+    const s = computeDaySummary([
+      block('09:00', 30, '#work', { color: 'bg-red-500' }),
+      block('10:00', 90, '#work', { color: 'bg-blue-500' }),
+    ]);
+    expect(s.categories[0].colorHex).not.toBe(undefined);
+    expect(s.categories[0].colorHex).toBe(computeDaySummary([block('10:00', 90, '#work', { color: 'bg-blue-500' })]).categories[0].colorHex);
+  });
+
+  it('native calendar color wins for native blocks', () => {
+    const s = computeDaySummary([block('09:00', 60, '#cal', { nativeCalendarColor: '#00ff00' })]);
+    expect(s.categories[0].colorHex).toBe('#00ff00');
+  });
+});
+
+describe('computeDaySummary — unblocked time', () => {
+  it('measures gaps between blocks when no end-of-day is configured', () => {
+    // 09:00–10:00, gap to 11:30, 11:30–12:00 → window 09:00–12:00, 90m blocked.
+    const s = computeDaySummary([
+      block('09:00', 60, 'a'),
+      block('11:30', 30, 'b'),
+    ]);
+    expect(s.windowStartMin).toBe(9 * 60);
+    expect(s.windowEndMin).toBe(12 * 60);
+    expect(s.blockedMinutes).toBe(90);
+    expect(s.unblockedMinutes).toBe(90);
+  });
+
+  it('overlapping blocks never double-count blocked time', () => {
+    // 09:00–10:30 and 10:00–11:00 overlap by 30m: union is 2h, not 2h 30m.
+    const s = computeDaySummary([
+      block('09:00', 90, 'a'),
+      block('10:00', 60, 'b'),
+    ]);
+    expect(s.blockedMinutes).toBe(120);
+    expect(s.unblockedMinutes).toBe(0);
+  });
+
+  it('back-to-back blocks leave no phantom gap', () => {
+    const s = computeDaySummary([
+      block('09:00', 60, 'a'),
+      block('10:00', 60, 'b'),
+    ]);
+    expect(s.unblockedMinutes).toBe(0);
+  });
+
+  it('extends the window to the configured end-of-day', () => {
+    // Last block ends 10:00; end-of-day 22:00 → 12h of unblocked afternoon/evening.
+    const s = computeDaySummary([block('09:00', 60, 'a')], '22:00');
+    expect(s.windowEndMin).toBe(22 * 60);
+    expect(s.unblockedMinutes).toBe(12 * 60);
+  });
+
+  it('a block running past end-of-day extends the window instead of going negative', () => {
+    const s = computeDaySummary([block('21:00', 120, 'late')], '22:00');
+    expect(s.windowEndMin).toBe(23 * 60);
+    expect(s.unblockedMinutes).toBe(0);
+  });
+});


### PR DESCRIPTION
Phase 1 of the summary strip: rolls the viewed day's blocks into one glanceable row at the bottom of the timeline — **unblocked time** plus **total time per #tag**. No data model change. Energy axis and planned-vs-done are later phases.

## What it looks like

- **Desktop/tablet:** always-visible row, sticky at the bottom of the timeline's own scroll container — stays visible over the grid without reserving layout height. Timeline views only (multi/day/week; sched is a dashboard).
- **Phone:** same position (which puts it above the tab bar), but collapsible — the collapsed one-liner still shows unblocked time plus the top category, so the headline number survives the collapse. Choice persists as a per-window view preference (`day-planner-summary-strip-collapsed`).

## The math (`src/utils/daySummary.js`)

Pure selector, deliberately free of rendering — the planned iOS Live Activity needs exactly this output, so the WidgetKit projection later is *this function*, not new logic. Rules it pins down, each tested:

**Unblocked time**
- Window = first block → configured end-of-day (`listEndOfDayTime`), or just the span of blocks when unset — no bedtime is assumed on the user's behalf.
- Intervals are merged first: overlapping and back-to-back blocks never double-count.
- A block running past end-of-day extends the window rather than going negative.
- Empty day → `null`, not 0 — "0m unblocked" would claim a fully-booked day; the strip renders nothing instead.

**Category totals**
- Raw durations summed per tag ("total time per label", per the notes). A `#work #deep` block counts fully toward both — per-label sums, not a partition; unblocked time is computed separately and never double-counts.
- Tagless blocks land in an explicit **untagged** bucket so the strip total matches the visible day.
- Each tag's dot takes the color of its **dominant blocks by minutes** — there is no tag→color mapping in the data model (color is per-block), so this is the honest rule.

**Scope**
- All-day events excluded; native calendar events count (they occupy real time); completed blocks count (completing a meeting doesn't un-spend the hour).
- The tag filter is deliberately bypassed — computing "unblocked" from a filtered timeline would report hidden hours as free.

## Wiring

Zero `App.jsx` changes — the component reads `selectedDate`, `getTasksForDate`, `listEndOfDayTime`, and theme classes from the existing context. Two 5-line insertions in `DesktopLayout`/`MobileLayout`. No tray involvement (the tray renders `GlanceSidebar`, not these layouts).

## Tests

15 new tests on the selector: interval merging (overlap, back-to-back, gaps), end-of-day extension and the past-midnight clamp, the null-vs-zero empty day, multi-tag double-count semantics, untagged bucket, dominant-color rule, native color precedence, all-day/completed/native scope rules, and duration formatting.

Full suite 69 files / 1060 tests green; lint and both production builds clean.

## Worth a look when trying it

The strip summarizes **the viewed day** (`selectedDate`), including on the multi-day desktop view — summarizing the anchor day rather than all visible days is a judgment call worth sanity-checking in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_