### PR TITLE
Day-window START/END markers: per-day bounds the summary strip measures against

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -111,6 +111,7 @@ import useStats from './hooks/useStats.js';
 import useComputedViews from './hooks/useComputedViews.js';
 import useTaskDerived from './hooks/useTaskDerived.js';
 import useDeadlinePriority from './hooks/useDeadlinePriority.js';
+import useDayWindows from './hooks/useDayWindows.js';
 import useConflictDetection from './hooks/useConflictDetection.js';
 import useNewTaskInput from './hooks/useNewTaskInput.js';
 import useTaskFormHelpers from './hooks/useTaskFormHelpers.js';
@@ -1388,6 +1389,11 @@ const DayPlanner = () => {
     visibleDays,
     mobileActiveTab,
   });
+  // Per-day START/STOP timeline markers (sticky-forward, device-local) — the
+  // summary strip measures unblocked time against them and the grids render
+  // them as marker lines. See src/hooks/useDayWindows.js.
+  const { getDayWindow, setDayWindow, clearDayWindow } = useDayWindows();
+
   const { pendingPriorities, cyclePriority, getDeadlineTasksForDate } = useDeadlinePriority({
     unscheduledTasks,
     setUnscheduledTasks,
@@ -8229,6 +8235,7 @@ const DayPlanner = () => {
     saveFrame, deleteFrame, skipFrameForDay,
     openFrameAdjust, openFrameSchedule, saveFrameAdjust,
     getFrameInstancesForDate,
+    getDayWindow, setDayWindow, clearDayWindow,
     runSmartSchedule, applySmartSchedule,
     runReschedule, applyReschedule,
     computeAvailableSlots,

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -4,6 +4,7 @@ import { formatHourLabel } from '../utils/timeFormatting.jsx';
 import { dateToString } from '../utils/taskUtils.js';
 import { columnTimeFromEvent } from '../utils/dragUtils.js';
 import TimelineTaskCardContent from './TimelineTaskCardContent.jsx';
+import DayWindowMarkers from './DayWindowMarkers.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import useDayViewHourHeight from '../hooks/useDayViewHourHeight.js';
@@ -264,6 +265,16 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             </div>
           </div>
         )}
+
+        {/* Day-window START/END marker lines */}
+        <div className="absolute top-0 left-16 right-0 bottom-0 pointer-events-none">
+          <DayWindowMarkers
+            dateStr={col.dateStr}
+            minToTop={(m) => (m - colStartMin) * hourHeight / 60}
+            clipStartMin={colStartMin}
+            clipEndMin={colEndMin}
+          />
+        </div>
 
         {/* GTD Frame background zones — behind tasks */}
         {(() => {

--- a/src/components/DayWindowMarkers.jsx
+++ b/src/components/DayWindowMarkers.jsx
@@ -7,8 +7,9 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 // to integrate with both the desktop and the phone drag systems.
 //
 // Dashed teal/indigo, deliberately distinct from the solid red current-time
-// line and from the GTD frame bands. Labels sit at the right edge, away from
-// the frame labels that occupy the left.
+// line and from the GTD frame bands. Labels sit centered on the line — both
+// along it and straddling it — clear of the frame labels (top-left) and the
+// current-time dot (left edge).
 
 const START_COLOR = '#14b8a6'; // teal-500
 const STOP_COLOR = '#6366f1'; // indigo-500
@@ -18,7 +19,7 @@ function MarkerLine({ topPx, color, label }) {
     <div className="absolute left-0 right-0 pointer-events-none z-[5]" style={{ top: `${topPx}px` }}>
       <div className="border-t-2 border-dashed" style={{ borderColor: color }} />
       <span
-        className="absolute right-1 -top-2 px-1 rounded text-[9px] font-semibold uppercase tracking-wide text-white"
+        className="absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2 px-1 rounded text-[9px] font-semibold uppercase tracking-wide text-white"
         style={{ backgroundColor: color }}
       >
         {label}

--- a/src/components/DayWindowMarkers.jsx
+++ b/src/components/DayWindowMarkers.jsx
@@ -1,0 +1,60 @@
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+
+// START/STOP day-window marker lines on the timeline grid. Render-only in
+// phase A — the window is set and moved from the summary strip's day-window
+// menu; making the lines themselves draggable is a later phase because it has
+// to integrate with both the desktop and the phone drag systems.
+//
+// Dashed teal/indigo, deliberately distinct from the solid red current-time
+// line and from the GTD frame bands. Labels sit at the right edge, away from
+// the frame labels that occupy the left.
+
+const START_COLOR = '#14b8a6'; // teal-500
+const STOP_COLOR = '#6366f1'; // indigo-500
+
+function MarkerLine({ topPx, color, label }) {
+  return (
+    <div className="absolute left-0 right-0 pointer-events-none z-[5]" style={{ top: `${topPx}px` }}>
+      <div className="border-t-2 border-dashed" style={{ borderColor: color }} />
+      <span
+        className="absolute right-1 -top-2 px-1 rounded text-[9px] font-semibold uppercase tracking-wide text-white"
+        style={{ backgroundColor: color }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * @param dateStr      Day this column renders ('YYYY-MM-DD').
+ * @param minToTop     Optional minutes→px transform for views whose columns
+ *                     cover a slice of the day (DayView's 8-hour blocks).
+ *                     Defaults to the shared minutesToPosition.
+ * @param clipStartMin Optional visible range: a marker outside it is simply
+ * @param clipEndMin   not drawn in this column.
+ */
+export default function DayWindowMarkers({ dateStr, minToTop, clipStartMin = 0, clipEndMin = 1440 }) {
+  const { minutesToPosition, timeToMinutes } = useDayPlannerCtx();
+  const { getDayWindow } = useFeaturesCtx();
+
+  const window = getDayWindow?.(dateStr);
+  if (!window) return null;
+
+  const toTop = minToTop ?? minutesToPosition;
+  const lines = [];
+  if (window.start) {
+    const min = timeToMinutes(window.start);
+    if (min >= clipStartMin && min < clipEndMin) {
+      lines.push(<MarkerLine key="start" topPx={Math.round(toTop(min))} color={START_COLOR} label="start" />);
+    }
+  }
+  if (window.stop) {
+    const min = timeToMinutes(window.stop);
+    if (min >= clipStartMin && min < clipEndMin) {
+      lines.push(<MarkerLine key="stop" topPx={Math.round(toTop(min))} color={STOP_COLOR} label="end" />);
+    }
+  }
+  return lines.length > 0 ? <>{lines}</> : null;
+}

--- a/src/components/MobileTimeGrid.jsx
+++ b/src/components/MobileTimeGrid.jsx
@@ -8,6 +8,7 @@ import { isNativeAndroid } from '../native.js';
 import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
 import { dateToString, extractWikilinks } from '../utils/taskUtils.js';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import DayWindowMarkers from './DayWindowMarkers.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { getHGBarsForDate } from '../hooks/useHyperGlance.js';
@@ -142,6 +143,9 @@ const MobileTimeGrid = () => {
           data-date-column={dateStr}
           className={`flex-1 relative ${dayIndex > 0 ? `border-l ${borderClass}` : ''}`}
         >
+          {/* Day-window START/END marker lines */}
+          <DayWindowMarkers dateStr={dateStr} />
+
           {/* GTD Frame background zones */}
           {frameInstances.map(frame => {
             const frameStartMin = timeToMinutes(frame.start);

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { ChevronDown, ChevronUp, MoreHorizontal } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -112,17 +113,19 @@ export default function SummaryStrip({ phone = false }) {
               the <span className={`font-semibold ${textPrimary}`}>Starts</span> and{' '}
               <span className={`font-semibold ${textPrimary}`}>Ends</span> window.
             </p>
-            <div className="flex items-center justify-between gap-2">
-              <span className={textSecondary}>Starts</span>
-              <button onClick={() => setPickerField('start')} className={timeBtnCls}>
-                {dayWindow?.start ? formatTime(dayWindow.start) : 'Set…'}
-              </button>
-            </div>
-            <div className="flex items-center justify-between gap-2">
-              <span className={textSecondary}>Ends</span>
-              <button onClick={() => setPickerField('stop')} className={timeBtnCls}>
-                {dayWindow?.stop ? formatTime(dayWindow.stop) : 'Set…'}
-              </button>
+            <div className="flex items-center justify-between gap-3">
+              <span className="flex items-center gap-1.5">
+                <span className={textSecondary}>Starts</span>
+                <button onClick={() => setPickerField('start')} className={timeBtnCls}>
+                  {dayWindow?.start ? formatTime(dayWindow.start) : 'Set…'}
+                </button>
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className={textSecondary}>Ends</span>
+                <button onClick={() => setPickerField('stop')} className={timeBtnCls}>
+                  {dayWindow?.stop ? formatTime(dayWindow.stop) : 'Set…'}
+                </button>
+              </span>
             </div>
             <button
               onClick={() => { clearDayWindow(dateStr); setMenuOpen(false); }}
@@ -131,16 +134,22 @@ export default function SummaryStrip({ phone = false }) {
               Clear for this day
             </button>
           </div>
-          {/* Same clock picker as FrameEditor/reminders/routines — full-screen
-              overlay at z-[90], above the menu. Unset bounds seed with a
-              sensible default so the clock has a hand to start from. */}
-          {pickerField && (
+          {/* Same clock picker as FrameEditor/reminders/routines. PORTALED to
+              document.body (established pattern: ProjectCard, SchedTaskCard),
+              for two reasons this container creates: pointer-events-none is
+              inherited, which made an in-place picker click-transparent (taps
+              fell through to the menu backdrop and closed everything), and the
+              sticky z-30 stacking context would cap the picker's z-[90] below
+              root-level chrome like the phone FAB. Unset bounds seed the clock
+              at 08:00 / 22:00 so it has a hand to start from. */}
+          {pickerField && createPortal(
             <ClockTimePicker
               value={(pickerField === 'start' ? dayWindow?.start : dayWindow?.stop) ?? (pickerField === 'start' ? '08:00' : '22:00')}
               onChange={(t) => { updateWindow(pickerField, t); setPickerField(null); }}
               onClose={() => setPickerField(null)}
               darkMode={darkMode} isTablet={isTablet ?? false} use24HourClock={use24HourClock}
-            />
+            />,
+            document.body,
           )}
         </>
       )}

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { ChevronDown, ChevronUp, MoreHorizontal } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import ClockTimePicker from './ClockTimePicker.jsx';
 import { dateToString, formatShortDate } from '../utils/taskUtils.js';
 import { computeDaySummary, formatMinutes } from '../utils/daySummary.js';
 
@@ -39,6 +40,7 @@ export default function SummaryStrip({ phone = false }) {
   const {
     selectedDate, getTasksForDate, listEndOfDayTime,
     darkMode, textPrimary, textSecondary, borderClass, cardBg,
+    use24HourClock, isTablet, formatTime,
   } = useDayPlannerCtx();
   const { getDayWindow, setDayWindow, clearDayWindow } = useFeaturesCtx();
 
@@ -53,6 +55,8 @@ export default function SummaryStrip({ phone = false }) {
   };
 
   const [menuOpen, setMenuOpen] = useState(false);
+  // Which bound the clock picker is editing: 'start' | 'stop' | null.
+  const [pickerField, setPickerField] = useState(null);
 
   const dateStr = dateToString(selectedDate);
   const dayWindow = getDayWindow?.(dateStr) ?? null;
@@ -84,7 +88,9 @@ export default function SummaryStrip({ phone = false }) {
     });
   };
 
-  const inputCls = `px-1.5 py-0.5 rounded border text-xs ${darkMode ? 'bg-gray-800 border-gray-600 text-gray-200' : 'bg-white border-stone-300 text-stone-800'}`;
+  // Trigger buttons open the same clock picker used everywhere else in the app
+  // (FrameEditor, reminders, routines) instead of a bare native time input.
+  const timeBtnCls = `px-2.5 py-1 rounded-lg border text-xs font-medium ${darkMode ? 'bg-gray-800 border-gray-600 text-gray-200 hover:bg-gray-700' : 'bg-white border-stone-300 text-stone-800 hover:bg-stone-50'}`;
 
   const unblockedLabel = (
     <span className="flex items-baseline gap-1">
@@ -99,30 +105,25 @@ export default function SummaryStrip({ phone = false }) {
         <>
           {/* Backdrop closes on any outside tap/click. */}
           <div className="fixed inset-0 z-40 pointer-events-auto" onClick={() => setMenuOpen(false)} />
-          <div className={`absolute bottom-full mb-1 left-2 z-50 pointer-events-auto w-56 rounded-lg border shadow-xl p-3 space-y-2 text-xs ${cardBg} ${borderClass}`}>
+          <div className={`absolute bottom-full mb-1 left-2 z-50 pointer-events-auto w-60 rounded-lg border shadow-xl p-3 space-y-2.5 text-xs ${cardBg} ${borderClass}`}>
             <div className={`font-semibold ${textPrimary}`}>Day window</div>
-            <div className={textSecondary}>{formatShortDate(selectedDate)}</div>
+            <p className={textSecondary}>
+              Applies to this and future days. Unblocked time is measured between
+              the <span className={`font-semibold ${textPrimary}`}>Starts</span> and{' '}
+              <span className={`font-semibold ${textPrimary}`}>Ends</span> window.
+            </p>
             <div className="flex items-center justify-between gap-2">
               <span className={textSecondary}>Starts</span>
-              <input
-                type="time"
-                value={dayWindow?.start ?? ''}
-                onChange={(e) => updateWindow('start', e.target.value)}
-                className={inputCls}
-              />
+              <button onClick={() => setPickerField('start')} className={timeBtnCls}>
+                {dayWindow?.start ? formatTime(dayWindow.start) : 'Set…'}
+              </button>
             </div>
             <div className="flex items-center justify-between gap-2">
               <span className={textSecondary}>Ends</span>
-              <input
-                type="time"
-                value={dayWindow?.stop ?? ''}
-                onChange={(e) => updateWindow('stop', e.target.value)}
-                className={inputCls}
-              />
+              <button onClick={() => setPickerField('stop')} className={timeBtnCls}>
+                {dayWindow?.stop ? formatTime(dayWindow.stop) : 'Set…'}
+              </button>
             </div>
-            <p className={`${textSecondary} opacity-70`}>
-              Applies to this and future days. Unblocked time is measured inside it.
-            </p>
             <button
               onClick={() => { clearDayWindow(dateStr); setMenuOpen(false); }}
               className={`w-full py-1 rounded border ${borderClass} ${textSecondary} hover:opacity-80`}
@@ -130,6 +131,17 @@ export default function SummaryStrip({ phone = false }) {
               Clear for this day
             </button>
           </div>
+          {/* Same clock picker as FrameEditor/reminders/routines — full-screen
+              overlay at z-[90], above the menu. Unset bounds seed with a
+              sensible default so the clock has a hand to start from. */}
+          {pickerField && (
+            <ClockTimePicker
+              value={(pickerField === 'start' ? dayWindow?.start : dayWindow?.stop) ?? (pickerField === 'start' ? '08:00' : '22:00')}
+              onChange={(t) => { updateWindow(pickerField, t); setPickerField(null); }}
+              onClose={() => setPickerField(null)}
+              darkMode={darkMode} isTablet={isTablet ?? false} use24HourClock={use24HourClock}
+            />
+          )}
         </>
       )}
       {phone && collapsed ? (

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react';
-import { ChevronDown, ChevronUp } from 'lucide-react';
+import { ChevronDown, ChevronUp, MoreHorizontal } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
-import { formatShortDate } from '../utils/taskUtils.js';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { dateToString, formatShortDate } from '../utils/taskUtils.js';
 import { computeDaySummary, formatMinutes } from '../utils/daySummary.js';
 
 // Collapse choice is a per-window view preference, same class as
@@ -16,6 +17,11 @@ const COLLAPSE_KEY = 'day-planner-summary-strip-collapsed';
  * time, and total time per #tag. Sticky inside the timeline's scroll container,
  * so it costs no layout height; the pill row is width-fit with pointer events
  * scoped to itself, so the grid stays clickable around it.
+ *
+ * The unblocked pill carries a three-dot menu for the day's START/STOP window
+ * (useDayWindows): set or clear the day's bounds, sticky-forward. The menu is a
+ * sibling of the pill row, not a child — the row scrolls horizontally and would
+ * clip anything popping out of it.
  *
  * Each pill carries its own opaque-ish blurred background instead of the row
  * having one — floating over arbitrary block colors, per-pill backdrop-blur +
@@ -32,8 +38,9 @@ const COLLAPSE_KEY = 'day-planner-summary-strip-collapsed';
 export default function SummaryStrip({ phone = false }) {
   const {
     selectedDate, getTasksForDate, listEndOfDayTime,
-    darkMode, textPrimary, textSecondary,
+    darkMode, textPrimary, textSecondary, borderClass, cardBg,
   } = useDayPlannerCtx();
+  const { getDayWindow, setDayWindow, clearDayWindow } = useFeaturesCtx();
 
   const [collapsed, setCollapsed] = useState(
     () => phone && localStorage.getItem(COLLAPSE_KEY) !== '0',
@@ -45,21 +52,39 @@ export default function SummaryStrip({ phone = false }) {
     });
   };
 
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const dateStr = dateToString(selectedDate);
+  const dayWindow = getDayWindow?.(dateStr) ?? null;
+
   // Tag filter deliberately bypassed: a filtered timeline still occupies the
   // whole day, and computing "unblocked" from a filtered subset would report
   // hidden hours as free.
   const summary = useMemo(
-    () => computeDaySummary(getTasksForDate(selectedDate, false), listEndOfDayTime),
-    [getTasksForDate, selectedDate, listEndOfDayTime],
+    () => computeDaySummary(getTasksForDate(selectedDate, false), listEndOfDayTime, dayWindow),
+    [getTasksForDate, selectedDate, listEndOfDayTime, dayWindow],
   );
 
-  // Empty day: nothing to summarize, and "0m unblocked" would claim the
-  // opposite of the truth. Render nothing rather than an empty row.
+  // Empty day with no declared window: nothing to summarize, and "0m unblocked"
+  // would claim the opposite of the truth. Render nothing rather than an empty
+  // row. (With START/STOP set, an empty day IS measurable and renders.)
   if (summary.unblockedMinutes === null) return null;
 
   const pill = `flex items-center gap-1.5 px-2.5 py-1 rounded-full flex-shrink-0 border shadow-sm backdrop-blur-sm ${
     darkMode ? 'bg-gray-900/85 border-gray-700' : 'bg-white/90 border-stone-200'
   }`;
+
+  // Menu edits act on the RESOLVED window (day entry or inherited default) —
+  // what the user sees in the inputs is what gets stored. Setting either bound
+  // is sticky-forward (also becomes the default); Clear affects this day only.
+  const updateWindow = (field, value) => {
+    setDayWindow(dateStr, {
+      start: field === 'start' ? (value || null) : dayWindow?.start ?? null,
+      stop: field === 'stop' ? (value || null) : dayWindow?.stop ?? null,
+    });
+  };
+
+  const inputCls = `px-1.5 py-0.5 rounded border text-xs ${darkMode ? 'bg-gray-800 border-gray-600 text-gray-200' : 'bg-white border-stone-300 text-stone-800'}`;
 
   const unblockedLabel = (
     <span className="flex items-baseline gap-1">
@@ -70,6 +95,43 @@ export default function SummaryStrip({ phone = false }) {
 
   return (
     <div className={`sticky bottom-0 z-30 pl-2 pb-2 pointer-events-none ${phone ? 'pr-20' : 'pr-2'}`}>
+      {menuOpen && (
+        <>
+          {/* Backdrop closes on any outside tap/click. */}
+          <div className="fixed inset-0 z-40 pointer-events-auto" onClick={() => setMenuOpen(false)} />
+          <div className={`absolute bottom-full mb-1 left-2 z-50 pointer-events-auto w-56 rounded-lg border shadow-xl p-3 space-y-2 text-xs ${cardBg} ${borderClass}`}>
+            <div className={`font-semibold ${textPrimary}`}>Day window</div>
+            <div className={textSecondary}>{formatShortDate(selectedDate)}</div>
+            <div className="flex items-center justify-between gap-2">
+              <span className={textSecondary}>Starts</span>
+              <input
+                type="time"
+                value={dayWindow?.start ?? ''}
+                onChange={(e) => updateWindow('start', e.target.value)}
+                className={inputCls}
+              />
+            </div>
+            <div className="flex items-center justify-between gap-2">
+              <span className={textSecondary}>Ends</span>
+              <input
+                type="time"
+                value={dayWindow?.stop ?? ''}
+                onChange={(e) => updateWindow('stop', e.target.value)}
+                className={inputCls}
+              />
+            </div>
+            <p className={`${textSecondary} opacity-70`}>
+              Applies to this and future days. Unblocked time is measured inside it.
+            </p>
+            <button
+              onClick={() => { clearDayWindow(dateStr); setMenuOpen(false); }}
+              className={`w-full py-1 rounded border ${borderClass} ${textSecondary} hover:opacity-80`}
+            >
+              Clear for this day
+            </button>
+          </div>
+        </>
+      )}
       {phone && collapsed ? (
         <button onClick={toggle} className={`${pill} pointer-events-auto max-w-full text-xs`}>
           <ChevronUp size={13} className={`flex-shrink-0 ${textSecondary}`} />
@@ -93,7 +155,16 @@ export default function SummaryStrip({ phone = false }) {
               <span className={`font-medium ${textPrimary}`}>{formatShortDate(selectedDate)}</span>
             </span>
           )}
-          <span className={pill}>{unblockedLabel}</span>
+          <span className={pill}>
+            {unblockedLabel}
+            <button
+              onClick={() => setMenuOpen((o) => !o)}
+              className={`-mr-1 p-0.5 rounded-full ${textSecondary} hover:opacity-70`}
+              aria-label="Day window options"
+            >
+              <MoreHorizontal size={13} />
+            </button>
+          </span>
           {summary.categories.map((c) => (
             <span key={c.tag} className={pill}>
               <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: c.colorHex }} />

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -106,7 +106,7 @@ export default function SummaryStrip({ phone = false }) {
         <>
           {/* Backdrop closes on any outside tap/click. */}
           <div className="fixed inset-0 z-40 pointer-events-auto" onClick={() => setMenuOpen(false)} />
-          <div className={`absolute bottom-full mb-1 left-2 z-50 pointer-events-auto w-60 rounded-lg border shadow-xl p-3 space-y-2.5 text-xs ${cardBg} ${borderClass}`}>
+          <div className={`absolute bottom-full mb-1 left-2 z-50 pointer-events-auto w-72 rounded-lg border shadow-xl p-3 space-y-2.5 text-xs ${cardBg} ${borderClass}`}>
             <div className={`font-semibold ${textPrimary}`}>Day window</div>
             <p className={textSecondary}>
               Applies to this and future days. Unblocked time is measured between

--- a/src/components/TimeGrid.jsx
+++ b/src/components/TimeGrid.jsx
@@ -12,6 +12,7 @@ import SuggestionAutocomplete from './SuggestionAutocomplete.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
 import TimelineTaskCardContent from './TimelineTaskCardContent.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import DayWindowMarkers from './DayWindowMarkers.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { getHGBarsForDate } from '../hooks/useHyperGlance.js';
@@ -167,6 +168,9 @@ const TimeGrid = () => {
           data-date-column={dateStr}
           className={`flex-1 relative ${dayIndex > 0 ? `border-l ${borderClass}` : ''}`}
         >
+          {/* Day-window START/END marker lines */}
+          <DayWindowMarkers dateStr={dateStr} />
+
           {/* GTD Frame background zones */}
           {frameInstances.map(frame => {
             const frameStartMin = timeToMinutes(frame.start);

--- a/src/hooks/useDayWindows.js
+++ b/src/hooks/useDayWindows.js
@@ -1,0 +1,73 @@
+import { useCallback, useState } from 'react';
+
+// Per-day START/STOP markers for the timeline — the user's declared day window,
+// set directly on the timeline (via the summary strip's day-window menu) rather
+// than in settings. The summary strip measures unblocked time against it.
+//
+// STICKY-FORWARD SEMANTICS: setting a day's window also becomes the default for
+// every day without its own entry (the alarm-clock mental model — you adjust
+// today and tomorrow inherits it). Clearing writes an explicit "off" entry for
+// that day only, so one quiet Sunday doesn't erase the defaults.
+//
+// Resolution order per date: explicit entry (including explicit off) → defaults
+// → none. A consequence worth stating: past days without an explicit entry
+// resolve to the CURRENT defaults, not whatever the defaults were at the time.
+// Freezing history would require stamping every day as it passes; not worth it
+// until something (weekly review?) consumes historical windows.
+//
+// DEVICE-LOCAL, deliberately: syncing this needs a file-tier merge rule, a
+// GLANCEvault _kind, and iOS awareness — its own change. Until then two devices
+// can disagree about a day's window; the blocks themselves still sync.
+
+const STORAGE_KEY = 'day-planner-day-windows';
+
+// Shape: { defaults: {start,stop}|null, byDate: { 'YYYY-MM-DD': {start,stop} } }
+// where start/stop are 'HH:MM' or null (explicit off).
+function load() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
+    if (raw && typeof raw === 'object') {
+      return { defaults: raw.defaults ?? null, byDate: raw.byDate ?? {} };
+    }
+  } catch { /* corrupt — start fresh */ }
+  return { defaults: null, byDate: {} };
+}
+
+export default function useDayWindows() {
+  const [windows, setWindows] = useState(load);
+
+  // Persist inside the mutators, not an on-change effect: the tray popup runs
+  // this hook too (same App tree), and an effect would write on tray mount.
+  // Mutators are unreachable from the tray — it renders no timeline — so writes
+  // stay main-window-only without needing the tray guard.
+  const persist = (next) => {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(next)); } catch { /* ignore */ }
+    return next;
+  };
+
+  /** Resolved window for a date: {start, stop} with 'HH:MM'|null fields, or null when none applies. */
+  const getDayWindow = useCallback((dateStr) => {
+    const entry = windows.byDate[dateStr];
+    const w = entry !== undefined ? entry : windows.defaults;
+    if (!w || (!w.start && !w.stop)) return null;
+    return { start: w.start ?? null, stop: w.stop ?? null };
+  }, [windows]);
+
+  /** Set a day's window; sticky-forward, so it also becomes the default. */
+  const setDayWindow = useCallback((dateStr, { start = null, stop = null }) => {
+    setWindows((prev) => persist({
+      defaults: { start, stop },
+      byDate: { ...prev.byDate, [dateStr]: { start, stop } },
+    }));
+  }, []);
+
+  /** Explicitly no window for this day; defaults stay intact for other days. */
+  const clearDayWindow = useCallback((dateStr) => {
+    setWindows((prev) => persist({
+      defaults: prev.defaults,
+      byDate: { ...prev.byDate, [dateStr]: { start: null, stop: null } },
+    }));
+  }, []);
+
+  return { getDayWindow, setDayWindow, clearDayWindow };
+}

--- a/src/hooks/useDayWindows.test.js
+++ b/src/hooks/useDayWindows.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Single-useState harness: the hook keeps all state in one useState, so a box
+// that applies functional updates lets each useDayWindows() call see current
+// state without a renderer (same spirit as the captured-effect tests).
+let box;
+let initialized;
+vi.mock('react', () => ({
+  useState: (init) => {
+    if (!initialized) {
+      box = typeof init === 'function' ? init() : init;
+      initialized = true;
+    }
+    return [box, (up) => { box = typeof up === 'function' ? up(box) : up; }];
+  },
+  useCallback: (fn) => fn,
+}));
+
+const { default: useDayWindows } = await import('./useDayWindows.js');
+
+describe('useDayWindows', () => {
+  let setItem;
+
+  beforeEach(() => {
+    initialized = false;
+    box = undefined;
+    setItem = vi.fn();
+    globalThis.localStorage = { getItem: vi.fn(() => null), setItem, removeItem: vi.fn() };
+  });
+
+  afterEach(() => {
+    delete globalThis.localStorage;
+  });
+
+  it('resolves to null when nothing has ever been set', () => {
+    const { getDayWindow } = useDayWindows();
+    expect(getDayWindow('2026-08-06')).toBeNull();
+  });
+
+  it('setting a day is sticky-forward: other days inherit it as the default', () => {
+    useDayWindows().setDayWindow('2026-08-06', { start: '07:00', stop: '22:00' });
+    const { getDayWindow } = useDayWindows();
+
+    // The day itself.
+    expect(getDayWindow('2026-08-06')).toEqual({ start: '07:00', stop: '22:00' });
+    // A day never touched — past or future — inherits the default.
+    expect(getDayWindow('2026-08-20')).toEqual({ start: '07:00', stop: '22:00' });
+  });
+
+  it('a later edit updates the default without rewriting explicitly-set days', () => {
+    useDayWindows().setDayWindow('2026-08-06', { start: '07:00', stop: '22:00' });
+    useDayWindows().setDayWindow('2026-08-07', { start: '09:00', stop: '21:00' });
+    const { getDayWindow } = useDayWindows();
+
+    // The alarm-clock model: Wednesday keeps its own entry; untouched days
+    // follow the most recent edit.
+    expect(getDayWindow('2026-08-06')).toEqual({ start: '07:00', stop: '22:00' });
+    expect(getDayWindow('2026-08-07')).toEqual({ start: '09:00', stop: '21:00' });
+    expect(getDayWindow('2026-08-15')).toEqual({ start: '09:00', stop: '21:00' });
+  });
+
+  it('clearing writes an explicit off for that day only — defaults survive', () => {
+    useDayWindows().setDayWindow('2026-08-06', { start: '07:00', stop: '22:00' });
+    useDayWindows().clearDayWindow('2026-08-09');
+    const { getDayWindow } = useDayWindows();
+
+    // One quiet Sunday off does not erase the standing window.
+    expect(getDayWindow('2026-08-09')).toBeNull();
+    expect(getDayWindow('2026-08-10')).toEqual({ start: '07:00', stop: '22:00' });
+  });
+
+  it('a single-bound window resolves with the other bound null', () => {
+    useDayWindows().setDayWindow('2026-08-06', { start: '07:00' });
+    expect(useDayWindows().getDayWindow('2026-08-06')).toEqual({ start: '07:00', stop: null });
+  });
+
+  it('persists on every mutation', () => {
+    useDayWindows().setDayWindow('2026-08-06', { start: '07:00', stop: '22:00' });
+    expect(setItem).toHaveBeenCalledTimes(1);
+    const [key, value] = setItem.mock.calls[0];
+    expect(key).toBe('day-planner-day-windows');
+    expect(JSON.parse(value)).toEqual({
+      defaults: { start: '07:00', stop: '22:00' },
+      byDate: { '2026-08-06': { start: '07:00', stop: '22:00' } },
+    });
+  });
+
+  it('survives corrupt storage by starting fresh', () => {
+    globalThis.localStorage.getItem = vi.fn(() => '{not json');
+    expect(useDayWindows().getDayWindow('2026-08-06')).toBeNull();
+  });
+});

--- a/src/utils/daySummary.js
+++ b/src/utils/daySummary.js
@@ -64,6 +64,14 @@ export function formatMinutes(min) {
  *                     null, the window is just the span of the blocks and
  *                     unblocked time means gaps between them — no bedtime is
  *                     assumed on the user's behalf.
+ * @param dayWindow    Optional user-set START/STOP markers for this day:
+ *                     {start: 'HH:MM'|null, stop: 'HH:MM'|null}. An explicit
+ *                     declaration of the day's bounds, so it takes precedence:
+ *                     start opens the window before the first block (morning
+ *                     slack finally counts), stop supersedes endOfDayTime.
+ *                     Blocks OUTSIDE the markers still extend the window —
+ *                     same rule as the past-end-of-day clamp, a 6am run with a
+ *                     7am start marker must never yield negative numbers.
  * @returns {{
  *   categories: Array<{tag: string, minutes: number, colorHex: string}>,
  *   untaggedMinutes: number,
@@ -73,19 +81,26 @@ export function formatMinutes(min) {
  *   windowEndMin: number|null,
  * }}
  */
-export function computeDaySummary(dayTasks, endOfDayTime = null) {
+export function computeDaySummary(dayTasks, endOfDayTime = null, dayWindow = null) {
   const timed = (dayTasks || []).filter(
     (t) => t && !t.isAllDay && t.startTime && (t.duration || 0) > 0,
   );
 
+  const markerStart = dayWindow?.start ? timeToMin(dayWindow.start) : null;
+  const markerStop = dayWindow?.stop ? timeToMin(dayWindow.stop) : null;
+
   if (timed.length === 0) {
+    // With BOTH markers set, an empty day is finally measurable: the whole
+    // declared window is unblocked. Without them there is still no honest
+    // window, so null keeps meaning "nothing to measure".
+    const hasFullWindow = markerStart !== null && markerStop !== null && markerStop > markerStart;
     return {
       categories: [],
       untaggedMinutes: 0,
       blockedMinutes: 0,
-      unblockedMinutes: null,
-      windowStartMin: null,
-      windowEndMin: null,
+      unblockedMinutes: hasFullWindow ? markerStop - markerStart : null,
+      windowStartMin: hasFullWindow ? markerStart : null,
+      windowEndMin: hasFullWindow ? markerStop : null,
     };
   }
 
@@ -128,13 +143,20 @@ export function computeDaySummary(dayTasks, endOfDayTime = null) {
     })
     .sort((a, b) => b.minutes - a.minutes || a.tag.localeCompare(b.tag));
 
-  const windowStartMin = Math.min(...intervals.map(([s]) => s));
+  const earliestStart = Math.min(...intervals.map(([s]) => s));
   const latestEnd = Math.max(...intervals.map(([, e]) => e));
-  // A block running past the configured end-of-day extends the window rather
-  // than producing negative unblocked time.
-  const windowEndMin = endOfDayTime
-    ? Math.max(latestEnd, timeToMin(endOfDayTime))
-    : latestEnd;
+  // Left edge: the start marker opens the window ahead of the first block, so
+  // morning slack counts; a block earlier than the marker extends it further.
+  const windowStartMin = markerStart !== null
+    ? Math.min(markerStart, earliestStart)
+    : earliestStart;
+  // Right edge precedence: stop marker (an explicit declaration) supersedes the
+  // list-view end-of-day setting. Either way a block running past the edge
+  // extends the window rather than producing negative unblocked time.
+  const rightEdge = markerStop !== null
+    ? markerStop
+    : (endOfDayTime ? timeToMin(endOfDayTime) : null);
+  const windowEndMin = rightEdge !== null ? Math.max(latestEnd, rightEdge) : latestEnd;
 
   const blockedMinutes = mergedCoverage(intervals);
   const unblockedMinutes = Math.max(0, windowEndMin - windowStartMin - blockedMinutes);

--- a/src/utils/daySummary.test.js
+++ b/src/utils/daySummary.test.js
@@ -138,3 +138,55 @@ describe('computeDaySummary — unblocked time', () => {
     expect(s.unblockedMinutes).toBe(0);
   });
 });
+
+describe('computeDaySummary — START/STOP day-window markers', () => {
+  it('the start marker opens the window before the first block, so morning slack counts', () => {
+    // Day starts 07:00, first block 09:00–10:00 → 2h of morning now count.
+    const s = computeDaySummary([block('09:00', 60, 'a')], null, { start: '07:00', stop: null });
+    expect(s.windowStartMin).toBe(7 * 60);
+    expect(s.unblockedMinutes).toBe(2 * 60);
+  });
+
+  it('the stop marker bounds the evening', () => {
+    const s = computeDaySummary([block('09:00', 60, 'a')], null, { start: null, stop: '21:00' });
+    expect(s.windowEndMin).toBe(21 * 60);
+    expect(s.unblockedMinutes).toBe(11 * 60);
+  });
+
+  it('the stop marker supersedes the list-view end-of-day setting', () => {
+    // Markers are an explicit per-day declaration; endOfDayTime is a borrowed
+    // list-view global. When both exist the marker wins.
+    const s = computeDaySummary([block('09:00', 60, 'a')], '23:00', { start: null, stop: '21:00' });
+    expect(s.windowEndMin).toBe(21 * 60);
+  });
+
+  it('a block outside the markers extends the window rather than going negative', () => {
+    // 6am run with a 07:00 start marker: same clamp rule as past-end-of-day.
+    const s = computeDaySummary(
+      [block('06:00', 60, 'run'), block('09:00', 60, 'work')],
+      null,
+      { start: '07:00', stop: '10:30' },
+    );
+    expect(s.windowStartMin).toBe(6 * 60);
+    expect(s.blockedMinutes).toBe(120);
+    expect(s.unblockedMinutes).toBe(4.5 * 60 - 120);
+  });
+
+  it('an empty day with both markers reports the whole window as unblocked', () => {
+    // Markers make an empty day measurable — the strip can finally render for
+    // a day with nothing scheduled yet.
+    const s = computeDaySummary([], null, { start: '08:00', stop: '22:00' });
+    expect(s.unblockedMinutes).toBe(14 * 60);
+    expect(s.windowStartMin).toBe(8 * 60);
+    expect(s.windowEndMin).toBe(22 * 60);
+  });
+
+  it('an empty day with only one marker still reports null', () => {
+    expect(computeDaySummary([], null, { start: '08:00', stop: null }).unblockedMinutes).toBeNull();
+    expect(computeDaySummary([], null, { start: null, stop: '22:00' }).unblockedMinutes).toBeNull();
+  });
+
+  it('an inverted empty-day window (stop before start) reports null rather than negative', () => {
+    expect(computeDaySummary([], null, { start: '22:00', stop: '08:00' }).unblockedMinutes).toBeNull();
+  });
+});


### PR DESCRIPTION
**Stacked on #1304** — base is `summary-strip-phase1`; GitHub will retarget to `main` automatically when that merges. Merge #1304 first.

Phase A of the START/STOP marker idea: declare when your day starts and ends, per day, directly from the timeline — and unblocked time is measured inside that window instead of only between blocks.

## How it works

**Setting:** three-dot menu on the strip's unblocked pill → *Day window* popover with Starts/Ends time inputs and *Clear for this day*. Edits apply live (the unblocked number updates as you type).

**Sticky-forward, as decided:** setting a day also becomes the default for every day without its own entry — adjust today, tomorrow inherits it. Explicitly-set days are never rewritten by later edits, and *Clear* writes an explicit off for that day only, so one quiet Sunday doesn't erase the standing window.

**Only-on-set, as decided:** no markers, no lines, and nobody's unblocked number changes on upgrade until they touch the menu.

**Markers:** dashed teal **START** / indigo **END** lines with small labels, rendered in all three grids — `TimeGrid`, `DayView` (with its sliced-column transform + clipping), `MobileTimeGrid`. Distinct from the solid red now-line and the frame bands; labels sit right-aligned, away from frame labels on the left.

## Selector semantics (all tested)

- `start` opens the window ahead of the first block — morning slack finally counts.
- `stop` bounds the evening and **supersedes the borrowed list-view end-of-day setting** (an explicit per-day declaration beats a global).
- A block outside the markers extends the window rather than going negative — same clamp rule as the existing past-end-of-day case (the 6am run with a 7am start marker).
- With both markers set, an **empty day becomes measurable**: the whole window reports as unblocked and the strip now renders for it.
- Single-marker and inverted empty-day windows resolve conservatively (`null`, never negative).

## Deliberately deferred

- **Dragging the marker lines.** They're render-only; moving them is menu-driven this phase. Draggable markers must integrate with both the desktop drag system (~1,400 lines) and the phone long-press system — the most delicate untested code in the repo — and that deserves its own pass (phases B/C from the design discussion).
- **Sync.** Day windows are **device-local** for now: syncing the slice needs a file-tier merge rule, a GLANCEvault `_kind` in `dbAdapter`, and iOS awareness — scoped as its own change. Until then two devices can disagree about a day's window; the blocks themselves still sync. Persistence happens inside the mutators rather than an on-change effect, so the tray popup (same App tree, no timeline) can never write the key.

## Known gap, stated plainly

The menu lives on the unblocked pill, and the strip hides on an empty day with no window — so the **first** window must be set on a day that has at least one block. Sticky-forward then covers empty days. If that feels wrong in practice, the fix is an empty-day affordance (a lone "set day window" pill), which I left out to keep the empty timeline clean.

## Tests

14 new: 7 selector (marker semantics above) + 7 hook (sticky-forward inheritance, later-edit behavior, explicit-off clear, single-bound, persistence shape, corrupt-storage recovery). Full suite 71 files / 1074 tests green; lint and both production builds clean.

Not covered, per the established caveat: the popover UI, the marker-line rendering, and the App context wiring — no renderer test infrastructure. Worth a manual pass on: setting a window on the multi-day view (markers should appear on every visible day via the default), the DayView 8-hour block slicing, and the popover on phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_