### PR TITLE
Summary strip phase 2: the Effort/Restore energy axis

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1394,6 +1394,9 @@ const DayPlanner = () => {
   // summary strip measures unblocked time against them and the grids render
   // them as marker lines. See src/hooks/useDayWindows.js.
   const { getDayWindow, setDayWindow, clearDayWindow } = useDayWindows();
+  // Day-window menu visibility lives here (not in SummaryStrip) so the START/
+  // END marker chips on the grid can open the same popover the strip owns.
+  const [dayWindowMenuOpen, setDayWindowMenuOpen] = useState(false);
 
   const { pendingPriorities, cyclePriority, getDeadlineTasksForDate } = useDeadlinePriority({
     unscheduledTasks,
@@ -8246,6 +8249,7 @@ const DayPlanner = () => {
     openFrameAdjust, openFrameSchedule, saveFrameAdjust,
     getFrameInstancesForDate,
     getDayWindow, setDayWindow, clearDayWindow,
+    dayWindowMenuOpen, setDayWindowMenuOpen,
     runSmartSchedule, applySmartSchedule,
     runReschedule, applyReschedule,
     computeAvailableSlots,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -85,6 +85,7 @@ import useVoiceInput from './hooks/useVoiceInput.js';
 import useCloudSync from './hooks/useCloudSync.js';
 import { createDayGlanceEngine } from './sync/adapter.js';
 import { createDbEngine, resetVaultSyncCursor } from './sync/dbEngine.js';
+import { deriveBlockEnergy } from './utils/energyAxis.js';
 import { registerDbEngine } from './sync/dirtyTracker.js';
 import { isVaultEnabled } from './sync/vaultConfig.js';
 import { keepImportedTask } from './sync/payloadExclusions.js';
@@ -2823,6 +2824,10 @@ const DayPlanner = () => {
           isAllDay: true,
           notes: template.notes || '',
           subtasks: template.subtasks || [],
+          // Energy-axis override is series-level (see setTaskEnergy); the
+          // expansion is an explicit field list, so it must be carried here or
+          // instances silently fall back to auto-derivation.
+          energy: template.energy,
           date: dateStr,
           isRecurring: true,
           recurringTemplateId: template.id,
@@ -5799,6 +5804,10 @@ const DayPlanner = () => {
           assignedUserSyncIds: exception?.assignedUserSyncIds ?? template.assignedUserSyncIds,
           notes: template.notes || '',
           subtasks: template.subtasks || [],
+          // Energy-axis override is series-level (see setTaskEnergy); the
+          // expansion is an explicit field list, so it must be carried here or
+          // instances silently fall back to auto-derivation.
+          energy: template.energy,
           date: dateStr,
           isRecurring: true,
           recurringTemplateId: template.id,
@@ -6429,6 +6438,7 @@ const DayPlanner = () => {
     openNewTaskForm,
     openNewInboxTask,
     changeTaskColor,
+    setTaskEnergy,
     updateTaskNotes,
     updateRecurringTemplate,
     updateRecurrencePattern,
@@ -9487,11 +9497,12 @@ const DayPlanner = () => {
         const hasMoveInbox = !isRecurring && !isImported && !isAllDay && !isInbox;
         const hasComplete = !isImported || isTaskCalendar;
         const hasDelete = !isImported;
+        const hasEnergy = !isImported;
         if (!hasEdit && !hasNotes && !hasMoveTomorrow && !hasMoveInbox && !hasComplete && !hasDelete) return null;
         // Clamp menu position to stay within viewport
         const menuWidth = 180;
         const menuItemHeight = 36;
-        const menuItems = [hasEdit, hasNotes, hasMoveTomorrow, hasMoveInbox, hasComplete, hasDelete].filter(Boolean).length;
+        const menuItems = [hasEdit, hasNotes, hasEnergy, hasMoveTomorrow, hasMoveInbox, hasComplete, hasDelete].filter(Boolean).length;
         const menuHeight = menuItems * menuItemHeight + 8;
         const clampedX = Math.min(x, window.innerWidth - menuWidth - 8);
         const clampedY = Math.min(y, window.innerHeight - menuHeight - 8);
@@ -9540,6 +9551,25 @@ const DayPlanner = () => {
                   Notes / subtasks
                 </button>
               )}
+              {/* Energy-axis override (summary strip): cycles auto → Restore →
+                  Effort → auto. The label always names the CURRENT state, with
+                  the auto-derived value shown so the user knows what "Auto"
+                  resolves to before deciding to override it. */}
+              {hasEnergy && (() => {
+                const override = ctxTask?.energy === 'restore' || ctxTask?.energy === 'effort' ? ctxTask.energy : null;
+                const derived = ctxTask ? deriveBlockEnergy(ctxTask) : 'effort';
+                const pretty = (e) => (e === 'restore' ? 'Restore' : 'Effort');
+                const next = override === null ? 'restore' : override === 'restore' ? 'effort' : null;
+                return (
+                  <button
+                    className={`w-full text-left px-3 py-2 text-sm ${textPrimary} ${hoverBg} transition-colors flex items-center gap-2`}
+                    onClick={() => { setTaskEnergy(taskId, next, isInbox); setTaskContextMenu(null); }}
+                  >
+                    <Zap size={14} />
+                    {override ? `Energy: ${pretty(override)}` : `Energy: Auto (${pretty(derived)})`}
+                  </button>
+                );
+              })()}
               {!isImported && aiConfig?.enabled && aiConfig.features?.aiSubtasks && (
                 <button
                   className={`w-full text-left px-3 py-2 text-sm ${textPrimary} ${hoverBg} transition-colors flex items-center gap-2`}

--- a/src/components/DayWindowMarkers.jsx
+++ b/src/components/DayWindowMarkers.jsx
@@ -23,7 +23,13 @@ function MarkerLine({ topPx, color, label, onOpenMenu }) {
           reachable. Dragging is deliberately not offered; the popover is the
           editor until real use proves drag is worth its integration cost. */}
       <button
-        onClick={onOpenMenu}
+        onClick={(e) => {
+          // The chip sits inside a grid column whose own onClick opens the
+          // new-task form at the tapped time — without stopping propagation a
+          // chip tap opened BOTH the popover and that modal.
+          e.stopPropagation();
+          onOpenMenu();
+        }}
         className="absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2 px-1 rounded text-[9px] font-semibold uppercase tracking-wide text-white pointer-events-auto cursor-pointer"
         style={{ backgroundColor: color }}
       >

--- a/src/components/DayWindowMarkers.jsx
+++ b/src/components/DayWindowMarkers.jsx
@@ -14,16 +14,21 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 const START_COLOR = '#14b8a6'; // teal-500
 const STOP_COLOR = '#6366f1'; // indigo-500
 
-function MarkerLine({ topPx, color, label }) {
+function MarkerLine({ topPx, color, label, onOpenMenu }) {
   return (
     <div className="absolute left-0 right-0 pointer-events-none z-[5]" style={{ top: `${topPx}px` }}>
       <div className="border-t-2 border-dashed" style={{ borderColor: color }} />
-      <span
-        className="absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2 px-1 rounded text-[9px] font-semibold uppercase tracking-wide text-white"
+      {/* The chip (just the word, not the line) opens the day-window popover —
+          the line itself stays click-transparent so blocks under it remain
+          reachable. Dragging is deliberately not offered; the popover is the
+          editor until real use proves drag is worth its integration cost. */}
+      <button
+        onClick={onOpenMenu}
+        className="absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2 px-1 rounded text-[9px] font-semibold uppercase tracking-wide text-white pointer-events-auto cursor-pointer"
         style={{ backgroundColor: color }}
       >
         {label}
-      </span>
+      </button>
     </div>
   );
 }
@@ -38,7 +43,7 @@ function MarkerLine({ topPx, color, label }) {
  */
 export default function DayWindowMarkers({ dateStr, minToTop, clipStartMin = 0, clipEndMin = 1440 }) {
   const { minutesToPosition, timeToMinutes } = useDayPlannerCtx();
-  const { getDayWindow } = useFeaturesCtx();
+  const { getDayWindow, setDayWindowMenuOpen } = useFeaturesCtx();
 
   const window = getDayWindow?.(dateStr);
   if (!window) return null;
@@ -48,13 +53,13 @@ export default function DayWindowMarkers({ dateStr, minToTop, clipStartMin = 0, 
   if (window.start) {
     const min = timeToMinutes(window.start);
     if (min >= clipStartMin && min < clipEndMin) {
-      lines.push(<MarkerLine key="start" topPx={Math.round(toTop(min))} color={START_COLOR} label="start" />);
+      lines.push(<MarkerLine key="start" topPx={Math.round(toTop(min))} color={START_COLOR} label="start" onOpenMenu={() => setDayWindowMenuOpen?.(true)} />);
     }
   }
   if (window.stop) {
     const min = timeToMinutes(window.stop);
     if (min >= clipStartMin && min < clipEndMin) {
-      lines.push(<MarkerLine key="stop" topPx={Math.round(toTop(min))} color={STOP_COLOR} label="end" />);
+      lines.push(<MarkerLine key="stop" topPx={Math.round(toTop(min))} color={STOP_COLOR} label="end" onOpenMenu={() => setDayWindowMenuOpen?.(true)} />);
     }
   }
   return lines.length > 0 ? <>{lines}</> : null;

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -790,11 +790,13 @@ const MobileLayout = () => {
                   {mobileViewMode === 'grid' && <MobileTimeGrid />}
                   {mobileViewMode === 'list' && <MobileListView />}
                   {mobileViewMode === 'sched' && <SchedView />}
-                  {/* Summary strip — sticky bottom of the timeline scroll
-                      container, so it sits above the tab bar. Phone variant:
-                      collapsible (vertical space is tightest here), no date
-                      pill, and clearance for the new-task FAB. */}
-                  {mobileViewMode !== 'sched' && <SummaryStrip phone />}
+                  {/* Summary strip. Phone variant: collapsible, no date pill,
+                      FAB clearance. GRID floats it sticky over the timeline;
+                      LIST places it statically after the day's content — a
+                      sticky overlay there reads as an extension of the list's
+                      spine, so it sits below the day as its own element. */}
+                  {mobileViewMode === 'grid' && <SummaryStrip phone />}
+                  {mobileViewMode === 'list' && <SummaryStrip phone staticPlacement />}
                 </div>
 
                 {/* Mobile notes panel overlay for timeline tasks (including deadline tasks) */}

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -538,6 +538,14 @@ function GapRow({ fromMin, toMin, spineColour, textSecondary, formatTime, minute
             <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', marginLeft: -1, width: 2, background: dashedGradient(spineColour), zIndex: 2, pointerEvents: 'none' }} />
           </>
         )}
+        {/* The spine ends AT the end-of-day line: occlude everything below it
+            in this row (the global line runs unbroken behind all rows, and the
+            trail deliberately extends past eod for breathing room — without
+            this the tail reads as connecting to whatever sits below the list,
+            e.g. the summary strip). Same local-erasure pattern as MarkerHalo. */}
+        {eodFrac !== null && pageBg && (
+          <div style={{ position: 'absolute', top: `${eodFrac * 100}%`, bottom: 0, left: '50%', marginLeft: -1, width: 2, background: pageBg, zIndex: 3, pointerEvents: 'none' }} />
+        )}
         {eodFrac !== null && (
           <div style={{
             position: 'absolute', top: `${eodFrac * 100}%`, left: 0, right: 0,

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -14,7 +14,7 @@ import { computeDaySummary, formatMinutes } from '../utils/daySummary.js';
 const COLLAPSE_KEY = 'day-planner-summary-strip-collapsed';
 
 const EFFORT_DOT = '#6366f1'; // indigo — matches the END marker
-const RESTORE_DOT = '#14b8a6'; // teal — matches the START marker
+const RESTORE_DOT = '#22c55e'; // green-500 — leaf-green per review; the START marker keeps its teal
 
 /**
  * Summary strip: rolls the viewed day's timeline blocks into a row of pills —

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { ChevronDown, ChevronUp, MoreHorizontal } from 'lucide-react';
+import { ChevronDown, ChevronUp, Leaf, MoreHorizontal, Zap } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import ClockTimePicker from './ClockTimePicker.jsx';
@@ -117,9 +117,9 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
   // buy nothing.
   const energyCompact = summary.blockedMinutes > 0 && (
     <span className="flex items-center gap-1">
-      <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: EFFORT_DOT }} />
+      <Zap size={12} className="flex-shrink-0" style={{ color: EFFORT_DOT }} />
       <span className={textSecondary}>{formatMinutes(summary.effortMinutes)}</span>
-      <span className="w-2 h-2 rounded-full flex-shrink-0 ml-0.5" style={{ backgroundColor: RESTORE_DOT }} />
+      <Leaf size={12} className="flex-shrink-0 ml-0.5" style={{ color: RESTORE_DOT }} />
       <span className={textSecondary}>{formatMinutes(summary.restoreMinutes)}</span>
     </span>
   );
@@ -227,12 +227,16 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
         // scorecard. Dots reuse the day-window marker palette (indigo/teal)
         // for one coherent color family. Hidden when the day has no blocks
         // (an empty declared window has nothing to classify).
+        // Zap deliberately matches the Energy item in the task context menu, so
+        // the readout and its override control share a glyph. Leaf is the calm
+        // side; an exercise glyph would be wrong here — the classifier files
+        // running/gym under RESTORE, and icons must not contradict the numbers.
         const energyPill = summary.blockedMinutes > 0 && (
           <span className={pill}>
-            <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: EFFORT_DOT }} />
+            <Zap size={13} className="flex-shrink-0" style={{ color: EFFORT_DOT }} />
             <span className={textPrimary}>Effort</span>
             <span className={textSecondary}>{formatMinutes(summary.effortMinutes)}</span>
-            <span className="w-2 h-2 rounded-full flex-shrink-0 ml-0.5" style={{ backgroundColor: RESTORE_DOT }} />
+            <Leaf size={13} className="flex-shrink-0 ml-0.5" style={{ color: RESTORE_DOT }} />
             <span className={textPrimary}>Restore</span>
             <span className={textSecondary}>{formatMinutes(summary.restoreMinutes)}</span>
           </span>

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -183,6 +183,20 @@ export default function SummaryStrip({ phone = false }) {
               <MoreHorizontal size={13} />
             </button>
           </span>
+          {/* Energy axis — one combined pill so it reads as a ratio, not a
+              scorecard. Dots reuse the day-window marker palette (indigo/teal)
+              for one coherent color family. Hidden when the day has no blocks
+              (an empty declared window has nothing to classify). */}
+          {summary.blockedMinutes > 0 && (
+            <span className={pill}>
+              <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: '#6366f1' }} />
+              <span className={textPrimary}>Effort</span>
+              <span className={textSecondary}>{formatMinutes(summary.effortMinutes)}</span>
+              <span className="w-2 h-2 rounded-full flex-shrink-0 ml-0.5" style={{ backgroundColor: '#14b8a6' }} />
+              <span className={textPrimary}>Restore</span>
+              <span className={textSecondary}>{formatMinutes(summary.restoreMinutes)}</span>
+            </span>
+          )}
           {summary.categories.map((c) => (
             <span key={c.tag} className={pill}>
               <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: c.colorHex }} />

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -201,62 +201,96 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
           {energyCompact && <span className={textSecondary}>·</span>}
           {energyCompact}
         </button>
-      ) : (
-        <div className={`pointer-events-auto w-fit max-w-full flex items-center gap-1.5 text-xs ${
-          phone ? 'flex-wrap' : `overflow-x-auto ${darkMode ? 'dark-scrollbar' : ''}`
-        }`}>
-          {/* Day/date heading — pins which day the numbers describe, which the
-              multi-day desktop view otherwise leaves ambiguous. The phone
-              timeline shows exactly one day, so there it is dropped. */}
-          {!phone && (
-            <span className={pill}>
-              <span className={`font-medium ${textPrimary}`}>{formatShortDate(selectedDate)}</span>
-            </span>
-          )}
-          <span className={pill}>
-            {phone && (
-              <button onClick={toggle} className={`-ml-1 p-0.5 rounded-full ${textSecondary} hover:opacity-70`} aria-label="Collapse summary">
-                <ChevronDown size={13} />
-              </button>
-            )}
+      ) : (() => {
+        // On phone, the whole unblocked pill toggles the collapse — symmetric
+        // with the collapsed pill, which expands from a tap anywhere on it.
+        // Only the three-dot menu opts out (stopPropagation). The caret stays
+        // as a visual indicator, not the sole target.
+        const unblockedPill = (
+          <span
+            className={`${pill} ${phone ? 'cursor-pointer' : ''}`}
+            onClick={phone ? toggle : undefined}
+          >
+            {phone && <ChevronDown size={13} className={`-ml-1 flex-shrink-0 ${textSecondary}`} />}
             {unblockedLabel}
             <button
-              onClick={() => setMenuOpen(!menuOpen)}
+              onClick={(e) => { e.stopPropagation(); setMenuOpen(!menuOpen); }}
               className={`-mr-1 p-0.5 rounded-full ${textSecondary} hover:opacity-70`}
               aria-label="Day window options"
             >
               <MoreHorizontal size={13} />
             </button>
           </span>
-          {/* Energy axis — one combined pill so it reads as a ratio, not a
-              scorecard. Dots reuse the day-window marker palette (indigo/teal)
-              for one coherent color family. Hidden when the day has no blocks
-              (an empty declared window has nothing to classify). */}
-          {summary.blockedMinutes > 0 && (
-            <span className={pill}>
-              <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: EFFORT_DOT }} />
-              <span className={textPrimary}>Effort</span>
-              <span className={textSecondary}>{formatMinutes(summary.effortMinutes)}</span>
-              <span className="w-2 h-2 rounded-full flex-shrink-0 ml-0.5" style={{ backgroundColor: RESTORE_DOT }} />
-              <span className={textPrimary}>Restore</span>
-              <span className={textSecondary}>{formatMinutes(summary.restoreMinutes)}</span>
-            </span>
-          )}
-          {summary.categories.map((c) => (
-            <span key={c.tag} className={pill}>
-              <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: c.colorHex }} />
-              <span className={textPrimary}>#{c.tag}</span>
-              <span className={textSecondary}>{formatMinutes(c.minutes)}</span>
-            </span>
-          ))}
-          {summary.untaggedMinutes > 0 && (
-            <span className={pill}>
-              <span className={`w-2 h-2 rounded-full flex-shrink-0 ${darkMode ? 'bg-gray-500' : 'bg-stone-400'}`} />
-              <span className={textSecondary}>untagged {formatMinutes(summary.untaggedMinutes)}</span>
-            </span>
-          )}
-        </div>
-      )}
+        );
+
+        // Energy axis — one combined pill so it reads as a ratio, not a
+        // scorecard. Dots reuse the day-window marker palette (indigo/teal)
+        // for one coherent color family. Hidden when the day has no blocks
+        // (an empty declared window has nothing to classify).
+        const energyPill = summary.blockedMinutes > 0 && (
+          <span className={pill}>
+            <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: EFFORT_DOT }} />
+            <span className={textPrimary}>Effort</span>
+            <span className={textSecondary}>{formatMinutes(summary.effortMinutes)}</span>
+            <span className="w-2 h-2 rounded-full flex-shrink-0 ml-0.5" style={{ backgroundColor: RESTORE_DOT }} />
+            <span className={textPrimary}>Restore</span>
+            <span className={textSecondary}>{formatMinutes(summary.restoreMinutes)}</span>
+          </span>
+        );
+
+        const tagChips = (
+          <>
+            {summary.categories.map((c) => (
+              <span key={c.tag} className={pill}>
+                <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: c.colorHex }} />
+                <span className={textPrimary}>#{c.tag}</span>
+                <span className={textSecondary}>{formatMinutes(c.minutes)}</span>
+              </span>
+            ))}
+            {summary.untaggedMinutes > 0 && (
+              <span className={pill}>
+                <span className={`w-2 h-2 rounded-full flex-shrink-0 ${darkMode ? 'bg-gray-500' : 'bg-stone-400'}`} />
+                <span className={textSecondary}>untagged {formatMinutes(summary.untaggedMinutes)}</span>
+              </span>
+            )}
+          </>
+        );
+
+        // Floating phone strip: the anchor row (unblocked + energy) keeps the
+        // exact position it has when collapsed — the container is stuck to the
+        // bottom, so the tag chips FAN OUT UPWARD above it and the collapse
+        // target never moves. The in-flow LIST strip reads top-down instead,
+        // so there everything stays one wrapping row growing downward.
+        if (phone && !staticPlacement) {
+          return (
+            <div className="pointer-events-auto w-fit max-w-full flex flex-col items-start gap-1.5 text-xs">
+              <div className="flex flex-wrap items-center gap-1.5">{tagChips}</div>
+              <div className="flex items-center gap-1.5">
+                {unblockedPill}
+                {energyPill}
+              </div>
+            </div>
+          );
+        }
+
+        return (
+          <div className={`pointer-events-auto w-fit max-w-full flex items-center gap-1.5 text-xs ${
+            phone ? 'flex-wrap' : `overflow-x-auto ${darkMode ? 'dark-scrollbar' : ''}`
+          }`}>
+            {/* Day/date heading — pins which day the numbers describe, which
+                the multi-day desktop view otherwise leaves ambiguous. The
+                phone timeline shows exactly one day, so there it is dropped. */}
+            {!phone && (
+              <span className={pill}>
+                <span className={`font-medium ${textPrimary}`}>{formatShortDate(selectedDate)}</span>
+              </span>
+            )}
+            {unblockedPill}
+            {energyPill}
+            {tagChips}
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -10,20 +10,29 @@ import { computeDaySummary, formatMinutes } from '../utils/daySummary.js';
 // Collapse choice is a per-window view preference, same class as
 // minimizedSections. Default collapsed: the strip only collapses on phone,
 // where timeline vertical space is tightest, and the collapsed pill still
-// carries the headline number.
+// carries the headline numbers.
 const COLLAPSE_KEY = 'day-planner-summary-strip-collapsed';
 
+const EFFORT_DOT = '#6366f1'; // indigo — matches the END marker
+const RESTORE_DOT = '#14b8a6'; // teal — matches the START marker
+
 /**
- * Summary strip (phase 1): rolls the viewed day's timeline blocks into a row of
- * pills floating over the bottom of the timeline — the day/date, unblocked
- * time, and total time per #tag. Sticky inside the timeline's scroll container,
- * so it costs no layout height; the pill row is width-fit with pointer events
- * scoped to itself, so the grid stays clickable around it.
+ * Summary strip: rolls the viewed day's timeline blocks into a row of pills —
+ * the day/date, unblocked time, the Effort/Restore split, and total time per
+ * #tag. Normally sticky inside the timeline's scroll container so it costs no
+ * layout height, with pointer events scoped to the pills so the grid stays
+ * clickable around them.
  *
  * The unblocked pill carries a three-dot menu for the day's START/STOP window
- * (useDayWindows): set or clear the day's bounds, sticky-forward. The menu is a
- * sibling of the pill row, not a child — the row scrolls horizontally and would
- * clip anything popping out of it.
+ * (useDayWindows). The open state lives in featuresCtx, not here, so the
+ * START/END marker chips on the grid can open the same popover. The menu is a
+ * sibling of the pill row, not a child — the row scrolls/wraps and would clip
+ * anything popping out of it.
+ *
+ * On a day with no blocks AND no declared window there are no numbers to show,
+ * so the strip renders a single quiet "Set day window" pill instead — the
+ * entry point for the one-time setup (sticky-forward defaults mean that once
+ * set, future days inherit it and the hint never reappears).
  *
  * Each pill carries its own opaque-ish blurred background instead of the row
  * having one — floating over arbitrary block colors, per-pill backdrop-blur +
@@ -33,17 +42,25 @@ const COLLAPSE_KEY = 'day-planner-summary-strip-collapsed';
  *
  * @param phone Phone timeline variant: collapsible to a single pill, no date
  *              pill (the phone timeline shows exactly one day, so the heading
- *              would restate the header), and right clearance for the new-task
- *              FAB (fixed right-4 w-14, z-40 — above this row's z-30) so pills
- *              never slide underneath it. Desktop/tablet pass nothing.
+ *              would restate the header), right clearance for the new-task FAB
+ *              (fixed right-4 w-14, z-40 — above this row's z-30), and the
+ *              expanded row WRAPS to more lines instead of scrolling
+ *              horizontally. Desktop/tablet pass nothing.
+ * @param staticPlacement In-flow instead of sticky — used by mobile LIST view,
+ *              where a sticky overlay reads as an extension of the list's
+ *              spine. Static places the strip after the day's content as its
+ *              own element.
  */
-export default function SummaryStrip({ phone = false }) {
+export default function SummaryStrip({ phone = false, staticPlacement = false }) {
   const {
     selectedDate, getTasksForDate, listEndOfDayTime,
     darkMode, textPrimary, textSecondary, borderClass, cardBg,
     use24HourClock, isTablet, formatTime,
   } = useDayPlannerCtx();
-  const { getDayWindow, setDayWindow, clearDayWindow } = useFeaturesCtx();
+  const {
+    getDayWindow, setDayWindow, clearDayWindow,
+    dayWindowMenuOpen: menuOpen, setDayWindowMenuOpen: setMenuOpen,
+  } = useFeaturesCtx();
 
   const [collapsed, setCollapsed] = useState(
     () => phone && localStorage.getItem(COLLAPSE_KEY) !== '0',
@@ -55,7 +72,6 @@ export default function SummaryStrip({ phone = false }) {
     });
   };
 
-  const [menuOpen, setMenuOpen] = useState(false);
   // Which bound the clock picker is editing: 'start' | 'stop' | null.
   const [pickerField, setPickerField] = useState(null);
 
@@ -69,11 +85,6 @@ export default function SummaryStrip({ phone = false }) {
     () => computeDaySummary(getTasksForDate(selectedDate, false), listEndOfDayTime, dayWindow),
     [getTasksForDate, selectedDate, listEndOfDayTime, dayWindow],
   );
-
-  // Empty day with no declared window: nothing to summarize, and "0m unblocked"
-  // would claim the opposite of the truth. Render nothing rather than an empty
-  // row. (With START/STOP set, an empty day IS measurable and renders.)
-  if (summary.unblockedMinutes === null) return null;
 
   const pill = `flex items-center gap-1.5 px-2.5 py-1 rounded-full flex-shrink-0 border shadow-sm backdrop-blur-sm ${
     darkMode ? 'bg-gray-900/85 border-gray-700' : 'bg-white/90 border-stone-200'
@@ -95,13 +106,35 @@ export default function SummaryStrip({ phone = false }) {
 
   const unblockedLabel = (
     <span className="flex items-baseline gap-1">
-      <span className={`font-semibold ${textPrimary}`}>{formatMinutes(summary.unblockedMinutes)}</span>
+      <span className={`font-semibold ${textPrimary}`}>{formatMinutes(summary.unblockedMinutes ?? 0)}</span>
       <span className={textSecondary}>unblocked</span>
     </span>
   );
 
+  // Compact Effort/Restore readout for the collapsed pill: dots + values, no
+  // words. Always included rather than fit-detected — at ~90px it fits beside
+  // the unblocked figure on any phone ≥320px, so measurement machinery would
+  // buy nothing.
+  const energyCompact = summary.blockedMinutes > 0 && (
+    <span className="flex items-center gap-1">
+      <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: EFFORT_DOT }} />
+      <span className={textSecondary}>{formatMinutes(summary.effortMinutes)}</span>
+      <span className="w-2 h-2 rounded-full flex-shrink-0 ml-0.5" style={{ backgroundColor: RESTORE_DOT }} />
+      <span className={textSecondary}>{formatMinutes(summary.restoreMinutes)}</span>
+    </span>
+  );
+
+  // Empty day, no declared window: no numbers to show, so the strip becomes the
+  // one-time setup hint. Once a window is set anywhere, sticky-forward defaults
+  // cover every future day and this state never recurs.
+  const isEmptyHint = summary.unblockedMinutes === null;
+
+  const container = staticPlacement
+    ? `relative pt-1 pb-2 pl-2 pointer-events-none ${phone ? 'pr-20' : 'pr-2'}`
+    : `sticky bottom-0 z-30 pl-2 pb-2 pointer-events-none ${phone ? 'pr-20' : 'pr-2'}`;
+
   return (
-    <div className={`sticky bottom-0 z-30 pl-2 pb-2 pointer-events-none ${phone ? 'pr-20' : 'pr-2'}`}>
+    <div className={container}>
       {menuOpen && (
         <>
           {/* Backdrop closes on any outside tap/click. */}
@@ -153,13 +186,25 @@ export default function SummaryStrip({ phone = false }) {
           )}
         </>
       )}
-      {phone && collapsed ? (
+      {isEmptyHint ? (
+        <button
+          onClick={() => setMenuOpen(true)}
+          className={`${pill} pointer-events-auto text-xs ${textSecondary} hover:opacity-80`}
+        >
+          <MoreHorizontal size={13} className="flex-shrink-0" />
+          Set day window…
+        </button>
+      ) : phone && collapsed ? (
         <button onClick={toggle} className={`${pill} pointer-events-auto max-w-full text-xs`}>
           <ChevronUp size={13} className={`flex-shrink-0 ${textSecondary}`} />
           {unblockedLabel}
+          {energyCompact && <span className={textSecondary}>·</span>}
+          {energyCompact}
         </button>
       ) : (
-        <div className={`pointer-events-auto w-fit max-w-full flex items-center gap-1.5 overflow-x-auto text-xs ${darkMode ? 'dark-scrollbar' : ''}`}>
+        <div className={`pointer-events-auto w-fit max-w-full flex items-center gap-1.5 text-xs ${
+          phone ? 'flex-wrap' : `overflow-x-auto ${darkMode ? 'dark-scrollbar' : ''}`
+        }`}>
           {/* Day/date heading — pins which day the numbers describe, which the
               multi-day desktop view otherwise leaves ambiguous. The phone
               timeline shows exactly one day, so there it is dropped. */}
@@ -176,7 +221,7 @@ export default function SummaryStrip({ phone = false }) {
             )}
             {unblockedLabel}
             <button
-              onClick={() => setMenuOpen((o) => !o)}
+              onClick={() => setMenuOpen(!menuOpen)}
               className={`-mr-1 p-0.5 rounded-full ${textSecondary} hover:opacity-70`}
               aria-label="Day window options"
             >
@@ -189,10 +234,10 @@ export default function SummaryStrip({ phone = false }) {
               (an empty declared window has nothing to classify). */}
           {summary.blockedMinutes > 0 && (
             <span className={pill}>
-              <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: '#6366f1' }} />
+              <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: EFFORT_DOT }} />
               <span className={textPrimary}>Effort</span>
               <span className={textSecondary}>{formatMinutes(summary.effortMinutes)}</span>
-              <span className="w-2 h-2 rounded-full flex-shrink-0 ml-0.5" style={{ backgroundColor: '#14b8a6' }} />
+              <span className="w-2 h-2 rounded-full flex-shrink-0 ml-0.5" style={{ backgroundColor: RESTORE_DOT }} />
               <span className={textPrimary}>Restore</span>
               <span className={textSecondary}>{formatMinutes(summary.restoreMinutes)}</span>
             </span>

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -314,6 +314,26 @@ export default function useTaskActions({
 
   // ── Task update ──────────────────────────────────────────────────────────
 
+  // Energy-axis override (summary strip): 'restore' | 'effort' | null (null =
+  // back to auto-derivation, see utils/energyAxis.js). Same routing as
+  // changeTaskColor: a recurring instance stores the override on its SERIES —
+  // energy is a property of the block's nature, which recurs with it.
+  const setTaskEnergy = (taskId, energy, fromInbox = false) => {
+    pushUndo();
+    if (typeof taskId === 'string' && taskId.startsWith('recurring-')) {
+      const parsed = parseRecurringId(taskId);
+      if (parsed) {
+        setRecurringTasks(prev => prev.map(t =>
+          t.id === parsed.templateId ? { ...t, energy: energy ?? undefined, lastModified: new Date().toISOString() } : t
+        ));
+      }
+      return;
+    }
+    const apply = (task) => (task.id === taskId ? { ...task, energy: energy ?? undefined } : task);
+    if (fromInbox) setUnscheduledTasks(prev => prev.map(apply));
+    else setTasks(prev => prev.map(apply));
+  };
+
   const changeTaskColor = (taskId, newColor, fromInbox = false) => {
     pushUndo();
     if (typeof taskId === 'string' && taskId.startsWith('recurring-')) {
@@ -854,6 +874,7 @@ export default function useTaskActions({
     openNewInboxTask,
     // Update
     changeTaskColor,
+    setTaskEnergy,
     updateTaskNotes,
     updateRecurringTemplate,
     updateRecurrencePattern,

--- a/src/utils/daySummary.js
+++ b/src/utils/daySummary.js
@@ -1,8 +1,9 @@
 import { extractTags } from './taskUtils.js';
 import { taskColorToHex } from './colorUtils.js';
+import { deriveBlockEnergy, ENERGY_RESTORE } from './energyAxis.js';
 
-// Summary-strip rollup for one day of timeline blocks (phase 1: category totals
-// + unblocked time). Pure — takes the day's task list and returns numbers, so
+// Summary-strip rollup for one day of timeline blocks (category totals,
+// unblocked time, and the effort/restore energy axis). Pure — takes the day's task list and returns numbers, so
 // the strip UI stays presentational and the math is testable in isolation. This
 // same function is the future Live Activity projection: the widget needs exactly
 // this output, no rendering attached.
@@ -75,6 +76,10 @@ export function formatMinutes(min) {
  * @returns {{
  *   categories: Array<{tag: string, minutes: number, colorHex: string}>,
  *   untaggedMinutes: number,
+ *   effortMinutes: number,   // raw per-block sums — a partition of block
+ *   restoreMinutes: number,  // minutes (see energyAxis.js), so like the
+ *                            // category totals they can exceed wall-clock
+ *                            // time when blocks overlap.
  *   blockedMinutes: number,
  *   unblockedMinutes: number|null,  // null = no timed blocks, nothing to measure
  *   windowStartMin: number|null,
@@ -97,6 +102,8 @@ export function computeDaySummary(dayTasks, endOfDayTime = null, dayWindow = nul
     return {
       categories: [],
       untaggedMinutes: 0,
+      effortMinutes: 0,
+      restoreMinutes: 0,
       blockedMinutes: 0,
       unblockedMinutes: hasFullWindow ? markerStop - markerStart : null,
       windowStartMin: hasFullWindow ? markerStart : null,
@@ -111,12 +118,17 @@ export function computeDaySummary(dayTasks, endOfDayTime = null, dayWindow = nul
   const tagMinutes = new Map();
   const tagColorMinutes = new Map();
   let untaggedMinutes = 0;
+  let effortMinutes = 0;
+  let restoreMinutes = 0;
   const intervals = [];
 
   for (const t of timed) {
     const start = timeToMin(t.startTime);
     const minutes = t.duration || 0;
     intervals.push([start, start + minutes]);
+
+    if (deriveBlockEnergy(t) === ENERGY_RESTORE) restoreMinutes += minutes;
+    else effortMinutes += minutes;
 
     const tags = extractTags(t.title || '');
     if (tags.length === 0) {
@@ -161,5 +173,5 @@ export function computeDaySummary(dayTasks, endOfDayTime = null, dayWindow = nul
   const blockedMinutes = mergedCoverage(intervals);
   const unblockedMinutes = Math.max(0, windowEndMin - windowStartMin - blockedMinutes);
 
-  return { categories, untaggedMinutes, blockedMinutes, unblockedMinutes, windowStartMin, windowEndMin };
+  return { categories, untaggedMinutes, effortMinutes, restoreMinutes, blockedMinutes, unblockedMinutes, windowStartMin, windowEndMin };
 }

--- a/src/utils/daySummary.test.js
+++ b/src/utils/daySummary.test.js
@@ -139,6 +139,34 @@ describe('computeDaySummary — unblocked time', () => {
   });
 });
 
+describe('computeDaySummary — energy axis', () => {
+  it('partitions block minutes into effort and restore', () => {
+    const s = computeDaySummary([
+      block('09:00', 120, 'Deep work #work'),
+      block('12:00', 45, 'Lunch'),
+      block('17:00', 60, 'Evening run'),
+    ]);
+    expect(s.effortMinutes).toBe(120);
+    expect(s.restoreMinutes).toBe(105);
+    // A partition: every timed block lands on exactly one side.
+    expect(s.effortMinutes + s.restoreMinutes).toBe(225);
+  });
+
+  it('honors the per-block override over the derived default', () => {
+    const s = computeDaySummary([
+      block('12:00', 60, 'Lunch with investors', { energy: 'effort' }),
+    ]);
+    expect(s.effortMinutes).toBe(60);
+    expect(s.restoreMinutes).toBe(0);
+  });
+
+  it('reports zeros for an empty day', () => {
+    const s = computeDaySummary([], null, { start: '08:00', stop: '22:00' });
+    expect(s.effortMinutes).toBe(0);
+    expect(s.restoreMinutes).toBe(0);
+  });
+});
+
 describe('computeDaySummary — START/STOP day-window markers', () => {
   it('the start marker opens the window before the first block, so morning slack counts', () => {
     // Day starts 07:00, first block 09:00–10:00 → 2h of morning now count.

--- a/src/utils/energyAxis.js
+++ b/src/utils/energyAxis.js
@@ -31,6 +31,7 @@ export const RESTORE_KEYWORDS = new Set([
   'health', 'gym', 'workout', 'exercise', 'run', 'running', 'walk', 'yoga',
   'meditate', 'meditation', 'breakfast', 'lunch', 'dinner', 'meal', 'eat',
   'break', 'rest', 'nap', 'sleep', 'recharge', 'recovery',
+  'relax', 'relaxation', 'unwind', 'chill',
 ]);
 
 /**

--- a/src/utils/energyAxis.js
+++ b/src/utils/energyAxis.js
@@ -1,0 +1,51 @@
+import { extractTags } from './taskUtils.js';
+
+// Energy axis (summary strip phase 2): every timed block is either EFFORT
+// (output — work, meetings, errands) or RESTORE (input — meals, movement,
+// rest). Binary by design, and the labels are deliberately judgment-free:
+// "Effort/Restore", never "Grind". Tone decides whether the strip reads as
+// clarifying or as scolding.
+//
+// Resolution order:
+//   1. Explicit per-block override (task.energy) — the user's word is final.
+//   2. Keyword match on the block's #tags and title words → restore.
+//   3. Everything else → effort.
+//
+// Effort is the fallback because scheduled blocks are output by default; the
+// keyword list only argues a block INTO restore, never out of it, so a wrong
+// guess is always one tap away from correct via the override.
+//
+// Deliberately NOT derived from GTD frame energyLevel: that field means energy
+// REQUIRED for the frame's work ("high energy → deep/complex work, low energy →
+// admin/easy tasks" — see ai-prompts.js). A low-energy frame is still effort,
+// so mapping it to restore would misclassify exactly the admin blocks it
+// describes.
+
+export const ENERGY_EFFORT = 'effort';
+export const ENERGY_RESTORE = 'restore';
+
+// Conservative on purpose — false "restore" reads worse than false "effort",
+// and the per-block override exists for everything this list misses. Matched
+// against whole words only, so "restaurant" never matches "rest".
+export const RESTORE_KEYWORDS = new Set([
+  'health', 'gym', 'workout', 'exercise', 'run', 'running', 'walk', 'yoga',
+  'meditate', 'meditation', 'breakfast', 'lunch', 'dinner', 'meal', 'eat',
+  'break', 'rest', 'nap', 'sleep', 'recharge', 'recovery',
+]);
+
+/**
+ * @param task Timeline block (needs title; energy optional).
+ * @returns 'effort' | 'restore'
+ */
+export function deriveBlockEnergy(task) {
+  if (task?.energy === ENERGY_RESTORE || task?.energy === ENERGY_EFFORT) return task.energy;
+  const title = task?.title || '';
+  const words = new Set([
+    ...extractTags(title),
+    ...title.toLowerCase().split(/[^\p{L}]+/u).filter(Boolean),
+  ]);
+  for (const w of words) {
+    if (RESTORE_KEYWORDS.has(w)) return ENERGY_RESTORE;
+  }
+  return ENERGY_EFFORT;
+}

--- a/src/utils/energyAxis.test.js
+++ b/src/utils/energyAxis.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { deriveBlockEnergy, ENERGY_EFFORT, ENERGY_RESTORE } from './energyAxis.js';
+
+describe('deriveBlockEnergy', () => {
+  it('defaults to effort — scheduled blocks are output unless argued otherwise', () => {
+    expect(deriveBlockEnergy({ title: 'Quarterly planning' })).toBe(ENERGY_EFFORT);
+    expect(deriveBlockEnergy({ title: 'Team sync #work' })).toBe(ENERGY_EFFORT);
+    expect(deriveBlockEnergy({ title: '' })).toBe(ENERGY_EFFORT);
+    expect(deriveBlockEnergy({})).toBe(ENERGY_EFFORT);
+  });
+
+  it('classifies restore from a #tag', () => {
+    expect(deriveBlockEnergy({ title: 'Morning session #gym' })).toBe(ENERGY_RESTORE);
+    expect(deriveBlockEnergy({ title: 'Steps #health' })).toBe(ENERGY_RESTORE);
+  });
+
+  it('classifies restore from a plain title word — no tagging required', () => {
+    // The notes' rule: never require per-task tagging.
+    expect(deriveBlockEnergy({ title: 'Lunch with Sam' })).toBe(ENERGY_RESTORE);
+    expect(deriveBlockEnergy({ title: 'Afternoon walk' })).toBe(ENERGY_RESTORE);
+    expect(deriveBlockEnergy({ title: 'Nap' })).toBe(ENERGY_RESTORE);
+  });
+
+  it('matches whole words only — "restaurant" is not "rest"', () => {
+    expect(deriveBlockEnergy({ title: 'Restaurant reservations for the event' })).toBe(ENERGY_EFFORT);
+    expect(deriveBlockEnergy({ title: 'Breakfast catering order' })).toBe(ENERGY_RESTORE); // 'breakfast' IS a whole word here
+  });
+
+  it('the explicit override is final, in both directions', () => {
+    // A working lunch is effort; a deliberately restorative work block is restore.
+    expect(deriveBlockEnergy({ title: 'Lunch with investors', energy: 'effort' })).toBe(ENERGY_EFFORT);
+    expect(deriveBlockEnergy({ title: 'Quarterly planning', energy: 'restore' })).toBe(ENERGY_RESTORE);
+  });
+
+  it('ignores a junk energy value and falls back to derivation', () => {
+    expect(deriveBlockEnergy({ title: 'Lunch', energy: 'banana' })).toBe(ENERGY_RESTORE);
+  });
+});

--- a/src/utils/energyAxis.test.js
+++ b/src/utils/energyAxis.test.js
@@ -12,6 +12,7 @@ describe('deriveBlockEnergy', () => {
   it('classifies restore from a #tag', () => {
     expect(deriveBlockEnergy({ title: 'Morning session #gym' })).toBe(ENERGY_RESTORE);
     expect(deriveBlockEnergy({ title: 'Steps #health' })).toBe(ENERGY_RESTORE);
+    expect(deriveBlockEnergy({ title: 'Evening #relax' })).toBe(ENERGY_RESTORE);
   });
 
   it('classifies restore from a plain title word — no tagging required', () => {


### PR DESCRIPTION
Phase 2 of the summary strip, cut clean from `main` with #1304/#1305 underneath. Every timed block is either **Effort** (output — work, meetings, errands) or **Restore** (input — meals, movement, rest), and the strip shows the day's split as one combined pill after unblocked time — deliberately one pill, so it reads as a ratio rather than a scorecard. Labels are judgment-free per the design notes ("Effort/Restore", never "Grind").

`[Wed, Aug 6] [3h 20m unblocked ⋯] [● Effort 5h 30m ● Restore 1h 15m] [#work 4h] […]`

## Classification (`utils/energyAxis.js`, tested)

1. **Explicit per-block override** (`task.energy`) — the user's word is final, in both directions (a working lunch can be marked effort; a deliberately restorative block can be marked restore).
2. **Conservative whole-word keyword match** on #tags and title words argues a block *into* restore (`lunch`, `walk`, `gym`, `nap`, `break`, …). Whole words only — "restaurant" never matches "rest". The list only argues one direction, so a wrong guess is always one tap from correct.
3. **Everything else is effort** — scheduled blocks are output by default. Nobody is ever required to tag anything, per the notes.

**Deliberately NOT derived from GTD frame `energyLevel`** — this was the plan going in, and the code said no: that field means energy *required* for the frame's work ("low energy → admin/easy tasks", per `ai-prompts.js`). A low-energy frame is still effort; mapping it to restore would misclassify exactly the admin blocks it describes.

## The override

Task context menu (right-click / long-press) gains a three-state cycle: **Auto → Restore → Effort → Auto**. The label always names the current state and what Auto resolves to (`Energy: Auto (Restore)`), so you know what you're overriding before you do. Hidden for imported/native events, which can't persist.

## First schema addition of the strip work

A nullable `energy` field on tasks:

- **Sync-safe:** rides the existing task sync; absent by default, so `stampTaskTimestamps` only re-stamps when a user actually overrides — no upgrade-wide re-stamp.
- **Series-level on recurring tasks:** energy is a property of the block's nature, which recurs with it (same routing as `changeTaskColor`).
- **The subtle one:** the recurring expansion is an **explicit field list, not a spread** — `energy` had to be threaded through both instance builders in `App.jsx`, or a series override would silently never reach the timeline. Worth knowing for any future task field.

## Selector

`effortMinutes` / `restoreMinutes` added to `computeDaySummary` — raw per-block sums, a partition of block minutes (consistent with the category totals' overlap semantics). The Live Activity projection picks the split up for free. The energy pill hides when the day has no blocks (an empty declared window has nothing to classify).

## Tests

9 new: 6 derivation (effort default, tag match, plain-word match with no tagging required, whole-word boundary, override in both directions, junk-value fallback) + 3 selector (partition, override, empty-day zeros). Full suite **73 files / 1083 tests** green; lint and both production builds clean.

Not covered, per the established caveat: the context-menu item and the strip pill (no renderer test infra). Manual pass worth doing: cycle the override on a recurring task and confirm the whole series flips; check the pill on a phone-width row.

## Honest limitations

- The keyword list is English-only and modest by design; the override is the escape hatch. If it misfires in practice the list is one `Set` to edit.
- "Effort" as the default means an unclassifiable block (e.g. `"Stuff"`) counts as effort. Binary was the notes' explicit call; the alternative (an "unclassified" third bucket) was rejected as reintroducing the tagging burden the notes ruled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_