### PR TITLE
Summary strip phase 3: planned vs done per category

### DIFF
--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -242,19 +242,31 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
           </span>
         );
 
+        // Planned-vs-done, quiet until there is progress: with nothing done a
+        // chip reads exactly as before (total minutes — no "0m/4h" scolding at
+        // 8am). Once something completes it becomes done/planned. Denominator
+        // is COMPLETABLE minutes: read-only calendar events are fixtures with
+        // no completion to track, so a tag whose total includes them shows a
+        // smaller denominator than its headline total — that is the honest
+        // number, not a bug.
+        const chipValue = (total, done, completable) =>
+          done > 0 ? `${formatMinutes(done)}/${formatMinutes(completable)}` : formatMinutes(total);
+
         const tagChips = (
           <>
             {summary.categories.map((c) => (
               <span key={c.tag} className={pill}>
                 <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: c.colorHex }} />
                 <span className={textPrimary}>#{c.tag}</span>
-                <span className={textSecondary}>{formatMinutes(c.minutes)}</span>
+                <span className={textSecondary}>{chipValue(c.minutes, c.doneMinutes, c.completableMinutes)}</span>
               </span>
             ))}
             {summary.untaggedMinutes > 0 && (
               <span className={pill}>
                 <span className={`w-2 h-2 rounded-full flex-shrink-0 ${darkMode ? 'bg-gray-500' : 'bg-stone-400'}`} />
-                <span className={textSecondary}>untagged {formatMinutes(summary.untaggedMinutes)}</span>
+                <span className={textSecondary}>
+                  untagged {chipValue(summary.untaggedMinutes, summary.untaggedDoneMinutes, summary.untaggedCompletableMinutes)}
+                </span>
               </span>
             )}
           </>

--- a/src/utils/daySummary.js
+++ b/src/utils/daySummary.js
@@ -3,7 +3,7 @@ import { taskColorToHex } from './colorUtils.js';
 import { deriveBlockEnergy, ENERGY_RESTORE } from './energyAxis.js';
 
 // Summary-strip rollup for one day of timeline blocks (category totals,
-// unblocked time, and the effort/restore energy axis). Pure — takes the day's task list and returns numbers, so
+// unblocked time, the effort/restore energy axis, and planned-vs-done). Pure — takes the day's task list and returns numbers, so
 // the strip UI stays presentational and the math is testable in isolation. This
 // same function is the future Live Activity projection: the widget needs exactly
 // this output, no rendering attached.
@@ -16,6 +16,12 @@ import { deriveBlockEnergy, ENERGY_RESTORE } from './energyAxis.js';
 //    exactly what unblocked time is measuring.
 //  - Completed blocks still count. This is a summary of the day's shape, not a
 //    todo list; completing a meeting doesn't un-spend the hour.
+//  - Planned-vs-done is planned vs DONE (completion state), not vs actual
+//    time spent — the model records that a block completed, not how long it
+//    really took. Read-only calendar events (imported, non-task-calendar,
+//    incl. native) can never be completed, so they are FIXTURES: excluded from
+//    the done metric on BOTH sides, or they would permanently depress it. They
+//    still count fully toward category totals and blocked time.
 //  - Category totals sum RAW block durations per tag ("total time per label").
 //    A block tagged #work #deep contributes its full duration to both labels,
 //    so category minutes can exceed wall-clock time — per-label sums, not a
@@ -74,8 +80,14 @@ export function formatMinutes(min) {
  *                     same rule as the past-end-of-day clamp, a 6am run with a
  *                     7am start marker must never yield negative numbers.
  * @returns {{
- *   categories: Array<{tag: string, minutes: number, colorHex: string}>,
+ *   categories: Array<{tag: string, minutes: number, colorHex: string,
+ *                      doneMinutes: number, completableMinutes: number}>,
  *   untaggedMinutes: number,
+ *   untaggedDoneMinutes: number,
+ *   untaggedCompletableMinutes: number,
+ *   doneMinutes: number,          // day totals, completable blocks only —
+ *   completableMinutes: number,   // the Live Activity's day-progress figure
+ *
  *   effortMinutes: number,   // raw per-block sums — a partition of block
  *   restoreMinutes: number,  // minutes (see energyAxis.js), so like the
  *                            // category totals they can exceed wall-clock
@@ -102,6 +114,10 @@ export function computeDaySummary(dayTasks, endOfDayTime = null, dayWindow = nul
     return {
       categories: [],
       untaggedMinutes: 0,
+      untaggedDoneMinutes: 0,
+      untaggedCompletableMinutes: 0,
+      doneMinutes: 0,
+      completableMinutes: 0,
       effortMinutes: 0,
       restoreMinutes: 0,
       blockedMinutes: 0,
@@ -117,7 +133,13 @@ export function computeDaySummary(dayTasks, endOfDayTime = null, dayWindow = nul
   // color, by minutes" is the honest rule; ties resolve to first-seen.
   const tagMinutes = new Map();
   const tagColorMinutes = new Map();
+  const tagDoneMinutes = new Map();
+  const tagCompletableMinutes = new Map();
   let untaggedMinutes = 0;
+  let untaggedDoneMinutes = 0;
+  let untaggedCompletableMinutes = 0;
+  let doneMinutes = 0;
+  let completableMinutes = 0;
   let effortMinutes = 0;
   let restoreMinutes = 0;
   const intervals = [];
@@ -130,14 +152,30 @@ export function computeDaySummary(dayTasks, endOfDayTime = null, dayWindow = nul
     if (deriveBlockEnergy(t) === ENERGY_RESTORE) restoreMinutes += minutes;
     else effortMinutes += minutes;
 
+    // Fixture check: a read-only calendar event has no completion to track.
+    const completable = !(t.imported && !t.isTaskCalendar);
+    const done = completable && t.completed ? minutes : 0;
+    if (completable) {
+      completableMinutes += minutes;
+      doneMinutes += done;
+    }
+
     const tags = extractTags(t.title || '');
     if (tags.length === 0) {
       untaggedMinutes += minutes;
+      if (completable) {
+        untaggedCompletableMinutes += minutes;
+        untaggedDoneMinutes += done;
+      }
       continue;
     }
     const hex = taskColorToHex(t.color, t.nativeCalendarColor);
     for (const tag of tags) {
       tagMinutes.set(tag, (tagMinutes.get(tag) || 0) + minutes);
+      if (completable) {
+        tagCompletableMinutes.set(tag, (tagCompletableMinutes.get(tag) || 0) + minutes);
+        tagDoneMinutes.set(tag, (tagDoneMinutes.get(tag) || 0) + done);
+      }
       if (!tagColorMinutes.has(tag)) tagColorMinutes.set(tag, new Map());
       const colors = tagColorMinutes.get(tag);
       colors.set(hex, (colors.get(hex) || 0) + minutes);
@@ -151,7 +189,11 @@ export function computeDaySummary(dayTasks, endOfDayTime = null, dayWindow = nul
       for (const [hex, min] of tagColorMinutes.get(tag)) {
         if (min > best) { best = min; colorHex = hex; }
       }
-      return { tag, minutes, colorHex };
+      return {
+        tag, minutes, colorHex,
+        doneMinutes: tagDoneMinutes.get(tag) || 0,
+        completableMinutes: tagCompletableMinutes.get(tag) || 0,
+      };
     })
     .sort((a, b) => b.minutes - a.minutes || a.tag.localeCompare(b.tag));
 
@@ -173,5 +215,11 @@ export function computeDaySummary(dayTasks, endOfDayTime = null, dayWindow = nul
   const blockedMinutes = mergedCoverage(intervals);
   const unblockedMinutes = Math.max(0, windowEndMin - windowStartMin - blockedMinutes);
 
-  return { categories, untaggedMinutes, effortMinutes, restoreMinutes, blockedMinutes, unblockedMinutes, windowStartMin, windowEndMin };
+  return {
+    categories,
+    untaggedMinutes, untaggedDoneMinutes, untaggedCompletableMinutes,
+    doneMinutes, completableMinutes,
+    effortMinutes, restoreMinutes,
+    blockedMinutes, unblockedMinutes, windowStartMin, windowEndMin,
+  };
 }

--- a/src/utils/daySummary.test.js
+++ b/src/utils/daySummary.test.js
@@ -41,7 +41,10 @@ describe('computeDaySummary — scope rules', () => {
 
   it('counts completed blocks — completing a meeting does not un-spend the hour', () => {
     const s = computeDaySummary([block('09:00', 60, '#work', { completed: true })]);
-    expect(s.categories).toEqual([{ tag: 'work', minutes: 60, colorHex: '#3b82f6' }]);
+    expect(s.categories).toEqual([{
+      tag: 'work', minutes: 60, colorHex: '#3b82f6',
+      doneMinutes: 60, completableMinutes: 60,
+    }]);
     expect(s.blockedMinutes).toBe(60);
   });
 });
@@ -136,6 +139,60 @@ describe('computeDaySummary — unblocked time', () => {
     const s = computeDaySummary([block('21:00', 120, 'late')], '22:00');
     expect(s.windowEndMin).toBe(23 * 60);
     expect(s.unblockedMinutes).toBe(0);
+  });
+});
+
+describe('computeDaySummary — planned vs done', () => {
+  it('sums done minutes per category from completion state', () => {
+    const s = computeDaySummary([
+      block('09:00', 90, 'Deep block #work', { completed: true }),
+      block('11:00', 60, 'Emails #work'),
+      block('12:00', 30, 'Walk #health', { completed: true }),
+    ]);
+    const work = s.categories.find((c) => c.tag === 'work');
+    expect(work.doneMinutes).toBe(90);
+    expect(work.completableMinutes).toBe(150);
+    expect(s.doneMinutes).toBe(120);
+    expect(s.completableMinutes).toBe(180);
+  });
+
+  it('read-only calendar events are fixtures: excluded from BOTH sides of the metric', () => {
+    // A native event can never be completed; counting it would permanently
+    // depress the done fraction. It still counts toward the category total.
+    const s = computeDaySummary([
+      block('09:00', 60, 'Standup #work', { imported: true, _native: true }),
+      block('10:00', 60, 'Prep #work', { completed: true }),
+    ]);
+    const work = s.categories.find((c) => c.tag === 'work');
+    expect(work.minutes).toBe(120);           // total keeps the fixture
+    expect(work.completableMinutes).toBe(60); // the metric does not
+    expect(work.doneMinutes).toBe(60);
+    expect(s.completableMinutes).toBe(60);
+  });
+
+  it('task-calendar to-dos CAN complete, so they are in the metric', () => {
+    const s = computeDaySummary([
+      block('09:00', 30, 'Errand', { imported: true, isTaskCalendar: true, completed: true }),
+    ]);
+    expect(s.doneMinutes).toBe(30);
+    expect(s.completableMinutes).toBe(30);
+  });
+
+  it('tracks the untagged bucket with the same rules', () => {
+    const s = computeDaySummary([
+      block('09:00', 45, 'errands', { completed: true }),
+      block('10:00', 30, 'more errands'),
+      block('11:00', 60, 'Dentist', { imported: true, _native: true }),
+    ]);
+    expect(s.untaggedMinutes).toBe(135);
+    expect(s.untaggedDoneMinutes).toBe(45);
+    expect(s.untaggedCompletableMinutes).toBe(75);
+  });
+
+  it('a day with nothing done reports zero done, full completable', () => {
+    const s = computeDaySummary([block('09:00', 60, '#work')]);
+    expect(s.doneMinutes).toBe(0);
+    expect(s.completableMinutes).toBe(60);
   });
 });
 


### PR DESCRIPTION
The last metric from the design notes, cut clean from `main` with phases 1–2 merged underneath. Three files, +124.

## Renamed honestly: planned vs **done**, not planned vs actual

Established back in the original assessment: the data model records that a block completed (a boolean plus a *date-only* `completedAt`) — never how long it truly took. The only actual-duration signal is `focusMinutes`, which exists only for blocks worked in Focus/HyperGlance mode; it can enrich this later. So the metric answers the question the data can answer: **"did I do what I blocked?"** — per category, minutes of completed blocks against minutes planned.

## Quiet until there's progress

- Nothing done yet → `#work 4h`, exactly as today. No `0m/4h` scolding over morning coffee.
- Something completed → `#work 1h 30m/4h`.
- No percentages, no color changes, no new pill. The design notes' tone rule ("determines whether the strip reads as clarifying or as scolding") applies to this metric hardest of all.
- The untagged chip follows the same rule.

## The fixture rule

Read-only calendar events (`imported && !isTaskCalendar`, including native EventKit events) can **never** be completed — counting them would permanently depress every number they touch. They're excluded from the metric on **both** sides: not in done, not in the denominator. They still count fully toward category totals, blocked, and unblocked (phases 1–2 semantics untouched). Task-calendar to-dos complete like any task and are included.

Documented consequence: a tag whose headline total includes fixture minutes shows a slash denominator *smaller* than that total (`#meeting 3h` → completes become `1h/2h` if 1h of it is a native event). That's the honest number, not a bug.

## Selector

Per-category `doneMinutes`/`completableMinutes`, untagged equivalents, and day-level totals. The day-level figure is the Live Activity projection's progress number — free, as with every phase, because the projection *is* this function.

## Tests

5 new: per-category done sums, the fixture rule (both sides + total unaffected), task-calendar inclusion, untagged bucket, zero-done day. One existing test updated for the widened category shape (strict-equality assertion now covers the new fields). Full suite **73 files / 1088 tests** green; lint and both production builds clean.

Not covered, per the established caveat: the chip rendering itself. Manual pass: complete a block and watch its chip flip to `done/planned`; check a native-event-heavy tag shows the smaller denominator.

## Strip series complete

With this, all four metrics from the original design notes are in: category totals, unblocked time (+ day-window markers beyond the notes), Effort/Restore, planned-vs-done. Remaining from the notes, all deliberately deferred with reasons on record: Live Activity (iOS build), day-window sync (file-tier merge + vault `_kind` + iOS), marker drag (pending real-world need), `focusMinutes` enrichment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_