### PR TITLE
Sync the day window across devices

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1393,7 +1393,9 @@ const DayPlanner = () => {
   // Per-day START/STOP timeline markers (sticky-forward, device-local) — the
   // summary strip measures unblocked time against them and the grids render
   // them as marker lines. See src/hooks/useDayWindows.js.
-  const { getDayWindow, setDayWindow, clearDayWindow } = useDayWindows();
+  const {
+    dayWindows, dayWindowsRef, getDayWindow, setDayWindow, clearDayWindow, applyRemoteDayWindows,
+  } = useDayWindows();
   // Day-window menu visibility lives here (not in SummaryStrip) so the START/
   // END marker chips on the grid can open the same popover the strip owns.
   const [dayWindowMenuOpen, setDayWindowMenuOpen] = useState(false);
@@ -2044,7 +2046,7 @@ const DayPlanner = () => {
       cloudSyncEngineRef.current.upload();
     }, 5000);
     return () => { if (cloudSyncDebounceRef.current) clearTimeout(cloudSyncDebounceRef.current); };
-  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, allTodayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, gtdFrames, bucketConfig, cloudSyncConfig?.enabled, syncKeyReady, multiUserEnabled, users, cloudSyncDebounceRef, dataLoaded, suppressCloudUploadRef]);
+  }, [tasks, unscheduledTasks, recycleBin, taskCalendarUrl, completedTaskUids, recurringTasks, routineDefinitions, allTodayRoutines, routinesDate, routineCompletions, removedTodayRoutineIds, use24HourClock, habits, habitLogs, habitsEnabled, routinesEnabled, dailyNotes, dayWindows, gtdFrames, bucketConfig, cloudSyncConfig?.enabled, syncKeyReady, multiUserEnabled, users, cloudSyncDebounceRef, dataLoaded, suppressCloudUploadRef]);
 
   // ── GLANCEvault DB transport ─────────────────────────────────────────────
   // Row-grained sync that runs ALONGSIDE the file-tier WebDAV engine (it shares
@@ -5199,6 +5201,10 @@ const DayPlanner = () => {
         deletedObsidianKeys: JSON.parse(localStorage.getItem('day-planner-deleted-obsidian-keys') || '{}'),
         removedTodayRoutineIds,
         dailyNotes,
+        // Per-day START/STOP timeline markers (flat date map + 'defaults',
+        // per-entry lastModified). Read through the ref: the engine can call
+        // this closure a beat after a render.
+        dayWindows: dayWindowsRef.current,
         habits,
         habitLogs,
         habitLogTimestamps: JSON.parse(localStorage.getItem('day-planner-habit-log-timestamps') || '{}'),
@@ -5368,6 +5374,10 @@ const DayPlanner = () => {
       localStorage.setItem('day-planner-daily-notes', JSON.stringify(data.dailyNotes));
       setDailyNotes(data.dailyNotes);
     }
+    // Day windows MERGE (per-entry LWW) rather than overwrite like the slices
+    // above: applyRemoteDayWindows also persists, and is a no-op (no write, no
+    // state change) when nothing pulled is newer.
+    if (data.dayWindows) applyRemoteDayWindows(data.dayWindows);
     if (data.habits) {
       localStorage.setItem('day-planner-habits', JSON.stringify(data.habits));
       setHabits(data.habits);

--- a/src/hooks/useDayWindows.js
+++ b/src/hooks/useDayWindows.js
@@ -1,4 +1,12 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { schedulePush as scheduleVaultPush } from '../sync/dirtyTracker.js';
+import {
+  DAY_WINDOWS_STORAGE_KEY,
+  DEFAULTS_KEY,
+  migrateDayWindows,
+  mergeDayWindowMaps,
+  resolveDayWindow,
+} from '../sync/dayWindowSync.js';
 
 // Per-day START/STOP markers for the timeline — the user's declared day window,
 // set directly on the timeline (via the summary strip's day-window menu) rather
@@ -7,67 +15,82 @@ import { useCallback, useState } from 'react';
 // STICKY-FORWARD SEMANTICS: setting a day's window also becomes the default for
 // every day without its own entry (the alarm-clock mental model — you adjust
 // today and tomorrow inherits it). Clearing writes an explicit "off" entry for
-// that day only, so one quiet Sunday doesn't erase the defaults.
+// that day only, so one quiet Sunday doesn't erase the defaults. In storage the
+// default is just the reserved 'defaults' entry of the same map, so it syncs
+// LWW like any date and needs no special casing anywhere.
 //
-// Resolution order per date: explicit entry (including explicit off) → defaults
-// → none. A consequence worth stating: past days without an explicit entry
-// resolve to the CURRENT defaults, not whatever the defaults were at the time.
-// Freezing history would require stamping every day as it passes; not worth it
-// until something (weekly review?) consumes historical windows.
-//
-// DEVICE-LOCAL, deliberately: syncing this needs a file-tier merge rule, a
-// GLANCEvault _kind, and iOS awareness — its own change. Until then two devices
-// can disagree about a day's window; the blocks themselves still sync.
-
-const STORAGE_KEY = 'day-planner-day-windows';
-
-// Shape: { defaults: {start,stop}|null, byDate: { 'YYYY-MM-DD': {start,stop} } }
-// where start/stop are 'HH:MM' or null (explicit off).
-function load() {
-  try {
-    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
-    if (raw && typeof raw === 'object') {
-      return { defaults: raw.defaults ?? null, byDate: raw.byDate ?? {} };
-    }
-  } catch { /* corrupt — start fresh */ }
-  return { defaults: null, byDate: {} };
-}
+// SYNCED: the map rides the sync payload as `dayWindows` — merged per-entry
+// LWW on the file tier (mergeSync.js) and as a vault singleton bundle
+// (dbAdapter.js), all through the shared primitives in sync/dayWindowSync.js.
+// Shape, migration from the phase-A device-local format, and resolution live
+// there too. iOS/Android inherit automatically: they run this same App tree.
 
 export default function useDayWindows() {
-  const [windows, setWindows] = useState(load);
+  const [windows, setWindows] = useState(() => {
+    try {
+      return migrateDayWindows(JSON.parse(localStorage.getItem(DAY_WINDOWS_STORAGE_KEY) || 'null'));
+    } catch {
+      return {};
+    }
+  });
+
+  // buildSyncPayload runs from render-time closures that can be a beat stale;
+  // the ref always reads the freshest map.
+  const windowsRef = useRef(windows);
+  windowsRef.current = windows;
 
   // Persist inside the mutators, not an on-change effect: the tray popup runs
   // this hook too (same App tree), and an effect would write on tray mount.
   // Mutators are unreachable from the tray — it renders no timeline — so writes
   // stay main-window-only without needing the tray guard.
   const persist = (next) => {
-    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(next)); } catch { /* ignore */ }
+    try { localStorage.setItem(DAY_WINDOWS_STORAGE_KEY, JSON.stringify(next)); } catch { /* ignore */ }
     return next;
   };
 
   /** Resolved window for a date: {start, stop} with 'HH:MM'|null fields, or null when none applies. */
-  const getDayWindow = useCallback((dateStr) => {
-    const entry = windows.byDate[dateStr];
-    const w = entry !== undefined ? entry : windows.defaults;
-    if (!w || (!w.start && !w.stop)) return null;
-    return { start: w.start ?? null, stop: w.stop ?? null };
-  }, [windows]);
+  const getDayWindow = useCallback((dateStr) => resolveDayWindow(windows, dateStr), [windows]);
 
-  /** Set a day's window; sticky-forward, so it also becomes the default. */
+  /**
+   * Set a day's window; sticky-forward, so it also becomes the default. Both
+   * entries are stamped so the edit wins LWW on every other device.
+   */
   const setDayWindow = useCallback((dateStr, { start = null, stop = null }) => {
+    const stamp = new Date().toISOString();
     setWindows((prev) => persist({
-      defaults: { start, stop },
-      byDate: { ...prev.byDate, [dateStr]: { start, stop } },
+      ...prev,
+      [dateStr]: { start, stop, lastModified: stamp },
+      [DEFAULTS_KEY]: { start, stop, lastModified: stamp },
     }));
+    // Push-on-write to the vault (debounced, off-safe no-op when disabled).
+    // The file tier picks the change up via its own effect deps in App.jsx.
+    scheduleVaultPush();
   }, []);
 
-  /** Explicitly no window for this day; defaults stay intact for other days. */
+  /**
+   * Explicitly no window for this day; defaults stay intact for other days.
+   * An explicit-off ENTRY, not a deletion — which is why this slice needs no
+   * tombstones to make clears propagate.
+   */
   const clearDayWindow = useCallback((dateStr) => {
     setWindows((prev) => persist({
-      defaults: prev.defaults,
-      byDate: { ...prev.byDate, [dateStr]: { start: null, stop: null } },
+      ...prev,
+      [dateStr]: { start: null, stop: null, lastModified: new Date().toISOString() },
     }));
+    scheduleVaultPush();
   }, []);
 
-  return { getDayWindow, setDayWindow, clearDayWindow };
+  /**
+   * Merge a pulled map into local state (per-entry LWW; local wins ties).
+   * Called from applyPayload on every sync apply — NOT a user edit, so it never
+   * schedules a push itself; echo suppression is the sync engines' concern.
+   */
+  const applyRemoteDayWindows = useCallback((remoteMap) => {
+    setWindows((prev) => {
+      const merged = mergeDayWindowMaps(prev, migrateDayWindows(remoteMap));
+      return merged === prev ? prev : persist(merged);
+    });
+  }, []);
+
+  return { dayWindows: windows, dayWindowsRef: windowsRef, getDayWindow, setDayWindow, clearDayWindow, applyRemoteDayWindows };
 }

--- a/src/hooks/useDayWindows.test.js
+++ b/src/hooks/useDayWindows.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DEFAULTS_KEY } from '../sync/dayWindowSync.js';
 
 // Single-useState harness: the hook keeps all state in one useState, so a box
 // that applies functional updates lets each useDayWindows() call see current
@@ -14,6 +15,12 @@ vi.mock('react', () => ({
     return [box, (up) => { box = typeof up === 'function' ? up(box) : up; }];
   },
   useCallback: (fn) => fn,
+  useRef: (init) => ({ current: init }),
+}));
+
+const schedulePush = vi.fn();
+vi.mock('../sync/dirtyTracker.js', () => ({
+  schedulePush: (...args) => schedulePush(...args),
 }));
 
 const { default: useDayWindows } = await import('./useDayWindows.js');
@@ -25,6 +32,7 @@ describe('useDayWindows', () => {
     initialized = false;
     box = undefined;
     setItem = vi.fn();
+    schedulePush.mockClear();
     globalThis.localStorage = { getItem: vi.fn(() => null), setItem, removeItem: vi.fn() };
   });
 
@@ -41,7 +49,6 @@ describe('useDayWindows', () => {
     useDayWindows().setDayWindow('2026-08-06', { start: '07:00', stop: '22:00' });
     const { getDayWindow } = useDayWindows();
 
-    // The day itself.
     expect(getDayWindow('2026-08-06')).toEqual({ start: '07:00', stop: '22:00' });
     // A day never touched — past or future — inherits the default.
     expect(getDayWindow('2026-08-20')).toEqual({ start: '07:00', stop: '22:00' });
@@ -52,8 +59,6 @@ describe('useDayWindows', () => {
     useDayWindows().setDayWindow('2026-08-07', { start: '09:00', stop: '21:00' });
     const { getDayWindow } = useDayWindows();
 
-    // The alarm-clock model: Wednesday keeps its own entry; untouched days
-    // follow the most recent edit.
     expect(getDayWindow('2026-08-06')).toEqual({ start: '07:00', stop: '22:00' });
     expect(getDayWindow('2026-08-07')).toEqual({ start: '09:00', stop: '21:00' });
     expect(getDayWindow('2026-08-15')).toEqual({ start: '09:00', stop: '21:00' });
@@ -64,25 +69,66 @@ describe('useDayWindows', () => {
     useDayWindows().clearDayWindow('2026-08-09');
     const { getDayWindow } = useDayWindows();
 
-    // One quiet Sunday off does not erase the standing window.
     expect(getDayWindow('2026-08-09')).toBeNull();
     expect(getDayWindow('2026-08-10')).toEqual({ start: '07:00', stop: '22:00' });
   });
 
-  it('a single-bound window resolves with the other bound null', () => {
-    useDayWindows().setDayWindow('2026-08-06', { start: '07:00' });
-    expect(useDayWindows().getDayWindow('2026-08-06')).toEqual({ start: '07:00', stop: null });
+  it('persists the SYNCED v2 shape: flat map, per-entry lastModified stamps', () => {
+    useDayWindows().setDayWindow('2026-08-06', { start: '07:00', stop: '22:00' });
+    const [key, value] = setItem.mock.calls.at(-1);
+    expect(key).toBe('day-planner-day-windows');
+    const stored = JSON.parse(value);
+    expect(Object.keys(stored).sort()).toEqual(['2026-08-06', DEFAULTS_KEY].sort());
+    for (const e of Object.values(stored)) {
+      expect(e.start).toBe('07:00');
+      expect(e.stop).toBe('22:00');
+      // A real timestamp, not the epoch — the edit must win LWW elsewhere.
+      expect(new Date(e.lastModified).getTime()).toBeGreaterThan(0);
+    }
   });
 
-  it('persists on every mutation', () => {
-    useDayWindows().setDayWindow('2026-08-06', { start: '07:00', stop: '22:00' });
-    expect(setItem).toHaveBeenCalledTimes(1);
-    const [key, value] = setItem.mock.calls[0];
-    expect(key).toBe('day-planner-day-windows');
-    expect(JSON.parse(value)).toEqual({
-      defaults: { start: '07:00', stop: '22:00' },
-      byDate: { '2026-08-06': { start: '07:00', stop: '22:00' } },
+  it('schedules a vault push on every mutation, never on remote apply', () => {
+    const hook = useDayWindows();
+    hook.setDayWindow('2026-08-06', { start: '07:00', stop: '22:00' });
+    hook.clearDayWindow('2026-08-07');
+    expect(schedulePush).toHaveBeenCalledTimes(2);
+
+    schedulePush.mockClear();
+    useDayWindows().applyRemoteDayWindows({
+      '2026-08-08': { start: '06:00', stop: '20:00', lastModified: '2026-08-06T00:00:00Z' },
     });
+    // A pulled change is not a user edit; pushing here would echo every apply.
+    expect(schedulePush).not.toHaveBeenCalled();
+  });
+
+  it('applyRemoteDayWindows merges per-entry LWW and persists only on change', () => {
+    useDayWindows().setDayWindow('2026-08-06', { start: '07:00', stop: '22:00' });
+    const writesBefore = setItem.mock.calls.length;
+
+    // Older remote entry for the same day: nothing changes, nothing persists.
+    useDayWindows().applyRemoteDayWindows({
+      '2026-08-06': { start: '01:00', stop: '02:00', lastModified: '2000-01-01T00:00:00Z' },
+    });
+    expect(setItem.mock.calls.length).toBe(writesBefore);
+    expect(useDayWindows().getDayWindow('2026-08-06')).toEqual({ start: '07:00', stop: '22:00' });
+
+    // A new day from another device lands and persists.
+    useDayWindows().applyRemoteDayWindows({
+      '2026-08-08': { start: '06:00', stop: '20:00', lastModified: '2026-08-06T00:00:00Z' },
+    });
+    expect(setItem.mock.calls.length).toBe(writesBefore + 1);
+    expect(useDayWindows().getDayWindow('2026-08-08')).toEqual({ start: '06:00', stop: '20:00' });
+  });
+
+  it('migrates the phase-A v1 shape on load, preserving semantics', () => {
+    globalThis.localStorage.getItem = vi.fn(() => JSON.stringify({
+      defaults: { start: '08:00', stop: '21:00' },
+      byDate: { '2026-08-05': { start: null, stop: null } },
+    }));
+    const { getDayWindow } = useDayWindows();
+
+    expect(getDayWindow('2026-08-05')).toBeNull(); // explicit off survived
+    expect(getDayWindow('2026-08-06')).toEqual({ start: '08:00', stop: '21:00' });
   });
 
   it('survives corrupt storage by starting fresh', () => {

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -9,6 +9,7 @@ import {
   pruneTombstoneMap,
   unionNewerIso as unionTombstones,
 } from './sync/tombstoneRetention.js';
+import { mergeDayWindowMaps, dayWindowMapsEqual, migrateDayWindows } from './sync/dayWindowSync.js';
 
 export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =>
   mergeArrayById(local, remote, deletedIds, syncHorizon, { timestampField: 'lastModified' });
@@ -290,6 +291,24 @@ export const mergeSyncData = (local, remote, retentionDays) => {
     if (rcFix.localChanged) result.localChanged = true;
     if (rcFix.remoteChanged) result.remoteChanged = true;
   }
+  // Day windows (per-day START/STOP timeline markers): per-entry LWW over a
+  // flat map of dates plus the 'defaults' key — same grain as the vault bundle
+  // (dbAdapter.js), through the same shared merge, so the tiers cannot drift.
+  // The upstream merge predates this slice and drops unknown keys, hence the
+  // wrapper. migrateDayWindows also absorbs a phase-A-shaped map arriving from
+  // a device that wrote the slice before it synced.
+  if (local?.dayWindows || remote?.dayWindows) {
+    const lw = migrateDayWindows(local?.dayWindows);
+    const rw = migrateDayWindows(remote?.dayWindows);
+    const mergedW = mergeDayWindowMaps(lw, rw);
+    result.data.dayWindows = mergedW;
+    // Same change-flag contract as habitLogs above: localChanged triggers the
+    // local write/apply, remoteChanged triggers the re-upload that heals a
+    // remote file missing our entries (e.g. one written by an older client).
+    if (mergedW !== lw) result.localChanged = true;
+    if (!dayWindowMapsEqual(mergedW, rw)) result.remoteChanged = true;
+  }
+
   // Recurring completions ride inside the shared template row, which the upstream
   // merge resolves by whole-row LWW — re-merge each series' completedDates by date
   // so a completion is never clobbered by a concurrent edit to the same series

--- a/src/sync/dayWindowSync.integration.test.js
+++ b/src/sync/dayWindowSync.integration.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { shredState, applyRemoteEntity } from './dbAdapter.js';
+import { mergeSyncData } from '../mergeSync.js';
+import { DEFAULTS_KEY } from './dayWindowSync.js';
+
+// Cross-tier integration: the dayWindows slice through the two real transports.
+// The pure merge is covered in dayWindowSync.test.js; these prove the WIRING —
+// that the vault shreds/applies the slice at per-entry grain and the file-tier
+// wrapper actually routes it (the upstream merge predates the slice and drops
+// unknown keys, so a missing wrapper line would silently lose windows on every
+// file sync).
+
+const entry = (start, stop, lastModified) => ({ start, stop, lastModified });
+
+// Minimal payload-data shape, mirroring mergeSync.test.js's emptyData.
+const emptyData = () => ({
+  tasks: [], unscheduledTasks: [], recycleBin: [], recurringTasks: [],
+  completedTaskUids: [], deletedTaskIds: {},
+  syncUrl: null, taskCalendarUrl: null,
+  routineDefinitions: {}, todayRoutines: [], routinesDate: '',
+  minimizedSections: {}, use24HourClock: false,
+});
+
+describe('GLANCEvault tier — dayWindows singleton bundle', () => {
+  it('shreds the map as one singleton row', () => {
+    const data = {
+      ...emptyData(),
+      dayWindows: {
+        [DEFAULTS_KEY]: entry('08:00', '22:00', '2026-08-06T08:00:00Z'),
+        '2026-08-06': entry('07:00', '21:00', '2026-08-06T09:00:00Z'),
+      },
+    };
+    const rows = shredState(data);
+    const windowRows = rows.filter((r) => r.entity._kind === 'singleton' && r.entity._key === 'dayWindows');
+    expect(windowRows).toHaveLength(1);
+    expect(windowRows[0].entity.value['2026-08-06']).toEqual(entry('07:00', '21:00', '2026-08-06T09:00:00Z'));
+  });
+
+  it('applies a pulled row at per-entry grain: different days both survive, newer entry wins', () => {
+    const data = {
+      ...emptyData(),
+      dayWindows: {
+        '2026-08-06': entry('07:00', '22:00', '2026-08-06T12:00:00Z'), // newer locally
+        '2026-08-07': entry('09:00', '21:00', '2026-08-06T08:00:00Z'),
+      },
+    };
+    applyRemoteEntity(data, {
+      _kind: 'singleton',
+      _key: 'dayWindows',
+      value: {
+        '2026-08-06': entry('01:00', '02:00', '2026-08-06T08:00:00Z'), // older — must lose
+        '2026-08-08': entry('06:00', '20:00', '2026-08-06T10:00:00Z'), // new day — must land
+      },
+    });
+    expect(data.dayWindows['2026-08-06']).toEqual(entry('07:00', '22:00', '2026-08-06T12:00:00Z'));
+    expect(data.dayWindows['2026-08-07']).toEqual(entry('09:00', '21:00', '2026-08-06T08:00:00Z'));
+    expect(data.dayWindows['2026-08-08']).toEqual(entry('06:00', '20:00', '2026-08-06T10:00:00Z'));
+  });
+
+  it('a newer explicit-off propagates through the vault (clears need no tombstones)', () => {
+    const data = {
+      ...emptyData(),
+      dayWindows: { '2026-08-09': entry('08:00', '22:00', '2026-08-06T08:00:00Z') },
+    };
+    applyRemoteEntity(data, {
+      _kind: 'singleton',
+      _key: 'dayWindows',
+      value: { '2026-08-09': entry(null, null, '2026-08-06T12:00:00Z') },
+    });
+    expect(data.dayWindows['2026-08-09']).toEqual(entry(null, null, '2026-08-06T12:00:00Z'));
+  });
+});
+
+describe('file tier — mergeSyncData wrapper routes dayWindows', () => {
+  it('merges per-entry across devices and flags both sides for the heal', () => {
+    const deviceA = {
+      ...emptyData(),
+      dayWindows: {
+        [DEFAULTS_KEY]: entry('08:00', '22:00', '2026-08-06T08:00:00Z'),
+        '2026-08-06': entry('07:00', '21:00', '2026-08-06T09:00:00Z'),
+      },
+    };
+    const deviceB = {
+      ...emptyData(),
+      dayWindows: {
+        [DEFAULTS_KEY]: entry('09:00', '23:00', '2026-08-06T11:00:00Z'), // newer defaults
+        '2026-08-07': entry('06:00', '20:00', '2026-08-06T10:00:00Z'),   // only on B
+      },
+    };
+    const { data, localChanged, remoteChanged } = mergeSyncData(deviceA, deviceB);
+
+    expect(data.dayWindows[DEFAULTS_KEY]).toEqual(entry('09:00', '23:00', '2026-08-06T11:00:00Z'));
+    expect(data.dayWindows['2026-08-06']).toEqual(entry('07:00', '21:00', '2026-08-06T09:00:00Z'));
+    expect(data.dayWindows['2026-08-07']).toEqual(entry('06:00', '20:00', '2026-08-06T10:00:00Z'));
+    // A pulled newer defaults → local must apply; a local-only day missing
+    // remotely → remote file must be healed by a re-upload.
+    expect(localChanged).toBe(true);
+    expect(remoteChanged).toBe(true);
+  });
+
+  it('survives a remote file written by an old client (slice missing): local windows are kept and re-uploaded', () => {
+    // The transitional caveat, pinned: an un-upgraded device's upload omits the
+    // slice; the merge must treat that as "nothing remote", never as a delete.
+    const local = {
+      ...emptyData(),
+      dayWindows: { [DEFAULTS_KEY]: entry('08:00', '22:00', '2026-08-06T08:00:00Z') },
+    };
+    const { data, remoteChanged } = mergeSyncData(local, emptyData());
+    expect(data.dayWindows[DEFAULTS_KEY]).toEqual(entry('08:00', '22:00', '2026-08-06T08:00:00Z'));
+    expect(remoteChanged).toBe(true); // heal the remote file
+  });
+
+  it('identical maps on both sides raise no change flags from this slice', () => {
+    const map = { [DEFAULTS_KEY]: entry('08:00', '22:00', '2026-08-06T08:00:00Z') };
+    const a = { ...emptyData(), dayWindows: { ...map } };
+    const b = { ...emptyData(), dayWindows: { ...map } };
+    const { localChanged, remoteChanged } = mergeSyncData(a, b);
+    expect(localChanged).toBe(false);
+    expect(remoteChanged).toBe(false);
+  });
+});

--- a/src/sync/dayWindowSync.js
+++ b/src/sync/dayWindowSync.js
@@ -1,0 +1,110 @@
+// Day-window sync primitives — the ONE definition of the day-window map's
+// shape, migration, resolution, and merge, shared by every consumer:
+//
+//   - useDayWindows (storage + React state + the strip/markers' resolution)
+//   - mergeSync.js (file-tier WebDAV/iCloud merge wrapper)
+//   - dbAdapter.js (GLANCEvault singleton-bundle merge)
+//
+// One function everywhere means the tiers can never disagree about a merge.
+//
+// SHAPE (v2, synced): a flat map keyed by 'YYYY-MM-DD' plus the reserved key
+// 'defaults', each entry { start: 'HH:MM'|null, stop: 'HH:MM'|null,
+// lastModified: ISO }. 'defaults' is deliberately just another entry — it
+// merges LWW like any date, so sticky-forward defaults travel across devices
+// with no special casing. An entry with both bounds null is an EXPLICIT OFF
+// (that day opted out of the inherited default); clearing writes one rather
+// than deleting, which is why this slice needs no tombstones.
+//
+// v1 (phase A, device-local) was { defaults: {start,stop}|null,
+// byDate: {date → {start,stop}} } with no timestamps. Migration flattens it and
+// stamps entries with the EPOCH, so any real synced edit beats legacy local
+// data; two never-edited devices keep their own copies until the first real
+// edit (ties keep local), which then wins everywhere.
+
+export const DAY_WINDOWS_STORAGE_KEY = 'day-planner-day-windows';
+export const DEFAULTS_KEY = 'defaults';
+
+const EPOCH = '1970-01-01T00:00:00.000Z';
+
+const ts = (v) => {
+  if (v == null) return 0;
+  const t = new Date(v).getTime();
+  return Number.isNaN(t) ? 0 : t;
+};
+
+const isEntry = (e) => e && typeof e === 'object';
+
+/**
+ * Normalize whatever is in storage to the v2 flat map. Accepts v2 (returned
+ * as-is-shaped), v1 ({defaults, byDate} — flattened, epoch-stamped), or
+ * garbage (→ {}).
+ */
+export function migrateDayWindows(raw) {
+  if (!raw || typeof raw !== 'object') return {};
+
+  // v1 marker: the byDate wrapper (v2 keys are dates + 'defaults' directly).
+  if ('byDate' in raw || ('defaults' in raw && !isEntry(raw.defaults?.start) && raw.byDate !== undefined)) {
+    const out = {};
+    if (isEntry(raw.defaults)) {
+      out[DEFAULTS_KEY] = { start: raw.defaults.start ?? null, stop: raw.defaults.stop ?? null, lastModified: EPOCH };
+    }
+    for (const [date, e] of Object.entries(raw.byDate || {})) {
+      if (isEntry(e)) out[date] = { start: e.start ?? null, stop: e.stop ?? null, lastModified: EPOCH };
+    }
+    return out;
+  }
+
+  // v2: keep well-formed entries, stamp any missing lastModified with epoch.
+  const out = {};
+  for (const [key, e] of Object.entries(raw)) {
+    if (!isEntry(e)) continue;
+    out[key] = { start: e.start ?? null, stop: e.stop ?? null, lastModified: e.lastModified ?? EPOCH };
+  }
+  return out;
+}
+
+/**
+ * Per-key last-writer-wins merge. Local wins ties (mirrors the file tier's
+ * mergeCalendarConfigByUser convention). Returns the LOCAL REFERENCE untouched
+ * when nothing remote is newer, so callers can use identity as a cheap
+ * did-anything-change check.
+ */
+export function mergeDayWindowMaps(local, remote) {
+  const l = local || {};
+  const r = remote || {};
+  let out = null; // lazily cloned only when a remote entry wins
+  for (const [key, entry] of Object.entries(r)) {
+    if (!isEntry(entry)) continue;
+    const mine = l[key];
+    if (!mine || ts(entry.lastModified) > ts(mine.lastModified)) {
+      if (!out) out = { ...l };
+      out[key] = { start: entry.start ?? null, stop: entry.stop ?? null, lastModified: entry.lastModified ?? EPOCH };
+    }
+  }
+  return out ?? l;
+}
+
+/** True when the two maps agree entry-for-entry (used to decide a re-push). */
+export function dayWindowMapsEqual(a, b) {
+  const ka = Object.keys(a || {});
+  const kb = Object.keys(b || {});
+  if (ka.length !== kb.length) return false;
+  return ka.every((k) => {
+    const x = (a || {})[k];
+    const y = (b || {})[k];
+    return isEntry(y) && x.start === (y.start ?? null) && x.stop === (y.stop ?? null)
+      && ts(x.lastModified) === ts(y.lastModified);
+  });
+}
+
+/**
+ * Resolve a date's window: explicit entry (including explicit off) → defaults
+ * → none. Returns {start, stop} with 'HH:MM'|null fields, or null when no
+ * window applies.
+ */
+export function resolveDayWindow(map, dateStr) {
+  const m = map || {};
+  const entry = m[dateStr] !== undefined ? m[dateStr] : m[DEFAULTS_KEY];
+  if (!isEntry(entry) || (!entry.start && !entry.stop)) return null;
+  return { start: entry.start ?? null, stop: entry.stop ?? null };
+}

--- a/src/sync/dayWindowSync.test.js
+++ b/src/sync/dayWindowSync.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  migrateDayWindows,
+  mergeDayWindowMaps,
+  dayWindowMapsEqual,
+  resolveDayWindow,
+  DEFAULTS_KEY,
+} from './dayWindowSync.js';
+
+const EPOCH = '1970-01-01T00:00:00.000Z';
+const entry = (start, stop, lastModified) => ({ start, stop, lastModified });
+
+describe('migrateDayWindows', () => {
+  it('flattens the v1 phase-A shape and stamps entries with the epoch', () => {
+    // Epoch, not "now": any REAL synced edit must beat never-edited legacy
+    // data, and two devices migrating at different moments must not race.
+    const v1 = {
+      defaults: { start: '07:00', stop: '22:00' },
+      byDate: { '2026-08-06': { start: '09:00', stop: null } },
+    };
+    expect(migrateDayWindows(v1)).toEqual({
+      [DEFAULTS_KEY]: entry('07:00', '22:00', EPOCH),
+      '2026-08-06': entry('09:00', null, EPOCH),
+    });
+  });
+
+  it('passes a v2 map through, stamping any missing lastModified', () => {
+    const v2 = {
+      [DEFAULTS_KEY]: entry('08:00', '21:00', '2026-08-06T10:00:00.000Z'),
+      '2026-08-07': { start: '09:00', stop: '20:00' }, // no stamp
+    };
+    const out = migrateDayWindows(v2);
+    expect(out[DEFAULTS_KEY].lastModified).toBe('2026-08-06T10:00:00.000Z');
+    expect(out['2026-08-07'].lastModified).toBe(EPOCH);
+  });
+
+  it('returns an empty map for garbage', () => {
+    expect(migrateDayWindows(null)).toEqual({});
+    expect(migrateDayWindows('nope')).toEqual({});
+    expect(migrateDayWindows({ '2026-08-06': 'junk' })).toEqual({});
+  });
+});
+
+describe('mergeDayWindowMaps', () => {
+  it('keeps the newer entry per key', () => {
+    const local = { '2026-08-06': entry('07:00', '22:00', '2026-08-06T08:00:00Z') };
+    const remote = {
+      '2026-08-06': entry('09:00', '21:00', '2026-08-06T12:00:00Z'), // newer
+      '2026-08-07': entry('06:00', '20:00', '2026-08-05T00:00:00Z'), // only remote
+    };
+    expect(mergeDayWindowMaps(local, remote)).toEqual({
+      '2026-08-06': entry('09:00', '21:00', '2026-08-06T12:00:00Z'),
+      '2026-08-07': entry('06:00', '20:00', '2026-08-05T00:00:00Z'),
+    });
+  });
+
+  it('concurrent edits to DIFFERENT days both survive — the point of per-key grain', () => {
+    const local = { '2026-08-06': entry('07:00', '22:00', '2026-08-06T09:00:00Z') };
+    const remote = { '2026-08-07': entry('10:00', '23:00', '2026-08-06T09:00:00Z') };
+    const merged = mergeDayWindowMaps(local, remote);
+    expect(Object.keys(merged).sort()).toEqual(['2026-08-06', '2026-08-07']);
+  });
+
+  it('local wins ties (mergeCalendarConfigByUser convention)', () => {
+    const t = '2026-08-06T09:00:00Z';
+    const local = { '2026-08-06': entry('07:00', null, t) };
+    const remote = { '2026-08-06': entry('08:00', null, t) };
+    expect(mergeDayWindowMaps(local, remote)['2026-08-06'].start).toBe('07:00');
+  });
+
+  it('a NEWER explicit-off beats an older window — clears propagate, no tombstones needed', () => {
+    const local = { '2026-08-06': entry('07:00', '22:00', '2026-08-06T08:00:00Z') };
+    const remote = { '2026-08-06': entry(null, null, '2026-08-06T12:00:00Z') };
+    expect(mergeDayWindowMaps(local, remote)['2026-08-06']).toEqual(entry(null, null, '2026-08-06T12:00:00Z'));
+  });
+
+  it('returns the LOCAL REFERENCE when nothing remote is newer — identity is the change check', () => {
+    const local = { '2026-08-06': entry('07:00', '22:00', '2026-08-06T12:00:00Z') };
+    const remote = { '2026-08-06': entry('09:00', '21:00', '2026-08-06T08:00:00Z') };
+    expect(mergeDayWindowMaps(local, remote)).toBe(local);
+    expect(mergeDayWindowMaps(local, {})).toBe(local);
+    expect(mergeDayWindowMaps(local, null)).toBe(local);
+  });
+});
+
+describe('dayWindowMapsEqual', () => {
+  it('detects a missing or differing entry', () => {
+    const a = { '2026-08-06': entry('07:00', null, '2026-08-06T08:00:00Z') };
+    expect(dayWindowMapsEqual(a, { ...a })).toBe(true);
+    expect(dayWindowMapsEqual(a, {})).toBe(false);
+    expect(dayWindowMapsEqual(a, { '2026-08-06': entry('08:00', null, '2026-08-06T08:00:00Z') })).toBe(false);
+  });
+});
+
+describe('resolveDayWindow', () => {
+  const map = {
+    [DEFAULTS_KEY]: entry('08:00', '22:00', EPOCH),
+    '2026-08-06': entry('10:00', '20:00', EPOCH),
+    '2026-08-09': entry(null, null, EPOCH), // explicit off
+  };
+
+  it('explicit entry beats defaults; untouched days inherit; off is off', () => {
+    expect(resolveDayWindow(map, '2026-08-06')).toEqual({ start: '10:00', stop: '20:00' });
+    expect(resolveDayWindow(map, '2026-08-07')).toEqual({ start: '08:00', stop: '22:00' });
+    expect(resolveDayWindow(map, '2026-08-09')).toBeNull();
+  });
+
+  it('no entry, no defaults → null', () => {
+    expect(resolveDayWindow({}, '2026-08-06')).toBeNull();
+    expect(resolveDayWindow(null, '2026-08-06')).toBeNull();
+  });
+});

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -28,6 +28,7 @@
 
 import { mergeHabitLogs, mergeRoutineDefinitions, mergeRoutineCompletions, mergeCompletedDates } from '../mergeSync.js';
 import { TOMBSTONE_BUNDLE_KEYS, tombstoneCutoff } from './tombstoneRetention.js';
+import { mergeDayWindowMaps } from './dayWindowSync.js';
 
 // ── Collection kinds: each array element is one row, keyed by a stable id, with
 // entity-grain last-writer-wins on tsField (the same grain the file-tier merge
@@ -479,6 +480,14 @@ function mergeBundle(data, key, value, extra) {
       // (mirrors merge.js:810-815).
       data[key] = value || data[key] || '';
       return;
+    case 'dayWindows': {
+      // {date|'defaults' → {start, stop, lastModified}}: union by key, newer
+      // lastModified wins per entry — concurrent edits to DIFFERENT days never
+      // collide, and the sticky-forward 'defaults' entry merges like any date.
+      // Same shared merge as the file tier (sync/dayWindowSync.js).
+      data.dayWindows = mergeDayWindowMaps(data.dayWindows || {}, value || {});
+      return;
+    }
     case 'calendarConfigByUser': {
       // {syncId → {syncUrl, taskCalendarUrl, auth?, updatedAt}}: union by syncId,
       // keep the newer entry per user (LWW). Each device reads only its own


### PR DESCRIPTION
The START/STOP day window has been device-local since phase A — set your morning on the Mac, set it again on the phone. It now rides **both sync transports**, so the window and its sticky-forward default are set once, everywhere. As discussed, this is also a correctness prerequisite for the iOS Live Activity: without it, the Dynamic Island and the desktop strip could disagree about the headline unblocked number.

Runs parallel to #1307 — zero file overlap, either merge order works.

## The shape (v2), and why it needs no tombstones

One flat map: dates plus the reserved `defaults` key, each entry `{start, stop, lastModified}`.

- **`defaults` is deliberately just another entry** — it merges LWW like any date, so sticky-forward travels across devices with zero special casing anywhere in the stack.
- **Clearing writes an explicit-off entry rather than deleting** — a phase-A design choice that pays off here: clears propagate as ordinary newer entries, so this slice needs **no tombstone machinery at all**.
- Phase-A data migrates on load, stamped with the **epoch** — any real synced edit beats never-edited legacy data, and two devices migrating at different moments can't race.

## One merge, every tier

`sync/dayWindowSync.js` owns shape, migration, merge, and resolution; every consumer imports it, so the tiers cannot drift:

| Tier | Wiring |
|---|---|
| **File (WebDAV/iCloud)** | Merged in the `mergeSyncData` wrapper, the `habitLogs` pattern. **Load-bearing line:** the upstream `@glance-apps/sync` merge predates the slice and *drops unknown keys* — mutation-tested (removing the wrapper block fails 2 tests). Change flags follow the habitLogs contract, so a remote file written by an un-upgraded client is **healed by re-upload, never read as a delete** — the transitional caveat, pinned by its own test. |
| **GLANCEvault** | A singleton-bundle case beside `calendarConfigByUser`; shredding is automatic once the key is in the payload. The default branch would clobber per-day grain — mutation-tested (removing the case fails the different-days-both-survive test). |
| **App** | Payload reads through a ref (the engine holds render-time closures); `applyPayload` **merges** rather than overwrites (no-op when nothing pulled is newer); upload debounce gains the dep; the hook's mutators schedule the vault push directly — remote applies never do, so pulls can't echo as pushes. |
| **iOS / Android** | Nothing. Same App tree, same payload — they inherit automatically, which is what makes the Live Activity's numbers agree with the desktop by construction. |

## UI untouched

`useDayWindows` keeps its exact API (`getDayWindow`/`setDayWindow`/`clearDayWindow`), so the strip, the marker lines, and the popover have **zero changes**. It gains `applyRemoteDayWindows` and exposes the map for the payload.

## Tests

26 for the slice: 11 pure (migration incl. epoch rationale, per-key LWW, local-wins-ties, explicit-off propagation, identity-as-change-check, equality), 9 hook (sticky-forward preserved on the new shape, v1 migration with explicit-off surviving, push-on-edit / never-on-apply, persist-only-on-change), 6 cross-tier integration (vault shred/apply grain, explicit-off through the vault, wrapper routing + change flags, **old-client survival**, quiet-when-identical). Both wiring seams mutation-verified.

Full suite **75 files / 1102 tests** green; lint and both production builds clean.

## Worth a manual pass

Two devices against the same vault or WebDAV target: set a window on one, watch it land on the other; clear a single day on one and confirm only that day goes bare elsewhere; and confirm a device still on the previous build doesn't wipe the windows for the fleet (it will drop the slice from its own uploads, and the next upgraded-device sync should heal the file — `remoteChanged` drives the re-upload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_