### PR TITLE
Widget snapshot: day-summary projection for the Live Activity

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -86,6 +86,7 @@ import useCloudSync from './hooks/useCloudSync.js';
 import { createDayGlanceEngine } from './sync/adapter.js';
 import { createDbEngine, resetVaultSyncCursor } from './sync/dbEngine.js';
 import { deriveBlockEnergy } from './utils/energyAxis.js';
+import { computeDaySummary, formatMinutes } from './utils/daySummary.js';
 import { registerDbEngine } from './sync/dirtyTracker.js';
 import { isVaultEnabled } from './sync/vaultConfig.js';
 import { keepImportedTask } from './sync/payloadExclusions.js';
@@ -7159,6 +7160,32 @@ const DayPlanner = () => {
       nextTask: nextTaskItem,
       upcomingTasks: upcomingTaskItems,
       nextUpNext,
+      // ── Day-summary projection (Live Activity / Dynamic Island) ────────
+      // The strip's numbers for TODAY, precomputed here so the native side
+      // never re-implements the math: the projection IS computeDaySummary.
+      // Raw minutes plus preformatted strings (formatMinutes keeps the
+      // wording identical to the in-app strip); metadata only, no media
+      // bytes. unblockedMinutes is null on an empty day with no declared
+      // window — the native side should show nothing rather than "0m".
+      daySummary: (() => {
+        const win = getDayWindow(todayStr);
+        const sum = computeDaySummary(getTasksForDate(today, false), listEndOfDayTime, win);
+        return {
+          date: todayStr,
+          windowStart: win?.start ?? null,
+          windowEnd: win?.stop ?? null,
+          unblockedMinutes: sum.unblockedMinutes,
+          blockedMinutes: sum.blockedMinutes,
+          effortMinutes: sum.effortMinutes,
+          restoreMinutes: sum.restoreMinutes,
+          doneMinutes: sum.doneMinutes,
+          completableMinutes: sum.completableMinutes,
+          unblocked: sum.unblockedMinutes === null ? null : formatMinutes(sum.unblockedMinutes),
+          effort: formatMinutes(sum.effortMinutes),
+          restore: formatMinutes(sum.restoreMinutes),
+          done: `${formatMinutes(sum.doneMinutes)}/${formatMinutes(sum.completableMinutes)}`,
+        };
+      })(),
       updatedAt: Date.now(),
     };
 
@@ -7186,6 +7213,10 @@ const DayPlanner = () => {
     hgVisibleProjects,
     goals,
     goalsProjectsEnabled,
+    // Day-summary projection inputs (getTasksForDate is the same per-render
+    // helper class as the omissions noted above).
+    dayWindows,
+    listEndOfDayTime,
   ]);
 
   // Phase 11 — Spotlight indexing: keep Spotlight in sync with non-archived,


### PR DESCRIPTION
The JS half of the Live Activity pair — the data plane. The Swift half (ActivityKit + Dynamic Island views) follows as its own PR.

## What

The iOS/Android widget snapshot (the JSON already flowing over `updateWidgetSnapshot` → `WidgetBridge` → App Group) gains a `daySummary` key: **the strip's numbers for today, precomputed in JS**. The native side never re-implements the math — the projection *is* `computeDaySummary`, with the synced day window (#1308) and the end-of-day fallback applied exactly as the in-app strip applies them. This is what makes the island and the desktop strip agree by construction.

```json
"daySummary": {
  "date": "2026-08-06",
  "windowStart": "07:30", "windowEnd": "22:00",
  "unblockedMinutes": 200, "blockedMinutes": 480,
  "effortMinutes": 330, "restoreMinutes": 150,
  "doneMinutes": 90, "completableMinutes": 420,
  "unblocked": "3h 20m", "effort": "5h 30m", "restore": "2h 30m", "done": "1h 30m/7h"
}
```

- **Raw minutes and preformatted strings both** — strings keep the wording byte-identical to the strip (`formatMinutes`), raw values leave the native side free to render progress bars later.
- **`unblockedMinutes: null`** on an empty day with no declared window — the native side should render nothing rather than `0m`, mirroring the strip's own empty-day honesty rule.
- Metadata only, no media bytes — a few hundred bytes against the bridge's 200 KB cap.
- Snapshot effect deps gain `dayWindows` + `listEndOfDayTime`, so a window edit — or a *synced pull* of one — refreshes the widgets and, later, the island.

## Verification

Full suite **76 files / 1107 tests** green; lint clean; web, electron, **and iOS** production bundles all build. The projection math itself is the already-tested selector; this PR adds serialization only.

## Next (the Swift PR)

`DaySummaryAttributes` + Dynamic Island/lock-screen views in the widget extension, a manager driven from `WidgetBridge.updateSnapshot` (single entry point — no new JS bridge), `NSSupportsLiveActivities` in `project.yml`, plus the lifecycle decisions on record: staleness surfaced via ActivityKit's `staleDate`, and the ~8h system cap handled by re-request on app foreground. That PR needs your Xcode for the build/test loop — deployment targets check out (app 16.0 / widget 17.0, both past the 16.1 ActivityKit floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_