### PR TITLE
iOS: day-summary Live Activity (Dynamic Island + lock screen)

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+#if canImport(ActivityKit)
+import ActivityKit
+
+/// Drives the day-summary Live Activity from the widget snapshot.
+///
+/// Single entry point, zero new JS surface: WidgetBridge.updateSnapshot already
+/// receives the full snapshot JSON on every renderer push, and this bridge just
+/// decodes the `daySummary` key out of the same string. The math never lives
+/// here — the JS side precomputes everything (the projection IS
+/// computeDaySummary), so the island always agrees with the in-app strip.
+///
+/// Lifecycle, on record:
+///  - No `daySummary`, or `unblocked` null (empty day, no declared window):
+///    END the activity. The strip renders nothing in that state; so do we.
+///  - The date rolled over: yesterday's activity ends, today's is requested —
+///    an activity's fixed attributes can't change, so a new day is a new
+///    activity by construction.
+///  - Otherwise: update in place, or request if none is live. iOS ends Live
+///    Activities after ~8h on its own; because a request happens on any
+///    snapshot push with none live, the next app foreground re-establishes it
+///    without dedicated plumbing.
+///  - staleDate is ~45 min out on every update: with no server push (privacy-
+///    first, no backend), numbers only refresh while the app runs, and the
+///    island dims rather than presenting stale numbers as current.
+@available(iOS 16.2, *)
+final class LiveActivityBridge {
+    static let shared = LiveActivityBridge()
+
+    private static let staleAfter: TimeInterval = 45 * 60
+
+    // Only the fields this bridge needs; unknown snapshot keys are ignored.
+    private struct SnapshotEnvelope: Decodable {
+        var daySummary: DaySummaryPayload?
+    }
+    private struct DaySummaryPayload: Decodable {
+        var date: String?
+        var unblocked: String?
+        var effort: String?
+        var restore: String?
+        var done: String?
+    }
+
+    func sync(fromSnapshotJSON json: String) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+
+        let payload = (try? JSONDecoder().decode(SnapshotEnvelope.self, from: Data(json.utf8)))?.daySummary
+
+        guard let payload,
+              let date = payload.date,
+              let unblocked = payload.unblocked,
+              let effort = payload.effort,
+              let restore = payload.restore,
+              let done = payload.done else {
+            endAll()
+            return
+        }
+
+        let state = DaySummaryAttributes.ContentState(
+            unblocked: unblocked, effort: effort, restore: restore, done: done)
+        let content = ActivityContent(state: state, staleDate: Date().addingTimeInterval(Self.staleAfter))
+
+        Task {
+            // A new day is a new activity: end anything describing another date.
+            for activity in Activity<DaySummaryAttributes>.activities where activity.attributes.date != date {
+                await activity.end(nil, dismissalPolicy: .immediate)
+            }
+
+            if let live = Activity<DaySummaryAttributes>.activities.first(where: { $0.attributes.date == date }) {
+                await live.update(content)
+            } else {
+                // Best-effort: request can throw (per-app activity cap, user
+                // disabled Live Activities mid-session). The widgets still
+                // carry the numbers, so failure here costs only the island.
+                _ = try? Activity.request(
+                    attributes: DaySummaryAttributes(date: date),
+                    content: content)
+            }
+        }
+    }
+
+    private func endAll() {
+        Task {
+            for activity in Activity<DaySummaryAttributes>.activities {
+                await activity.end(nil, dismissalPolicy: .immediate)
+            }
+        }
+    }
+}
+#endif

--- a/dayglance-ios/DayGlance/Bridges/WidgetBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/WidgetBridge.swift
@@ -14,6 +14,11 @@ final class WidgetBridge {
               let defaults = UserDefaults(suiteName: "group.com.dayglance.app") else { return }
         defaults.set(data, forKey: "widgetSnapshot")
         WidgetCenter.shared.reloadAllTimelines()
+        // Same JSON drives the day-summary Live Activity — one entry point,
+        // no separate JS bridge call to keep in sync.
+        if #available(iOS 16.2, *) {
+            LiveActivityBridge.shared.sync(fromSnapshotJSON: json)
+        }
     }
 
     func getPendingAction() -> String {

--- a/dayglance-ios/DayGlanceWidget/DayGlanceWidgetBundle.swift
+++ b/dayglance-ios/DayGlanceWidget/DayGlanceWidgetBundle.swift
@@ -7,6 +7,7 @@ struct DayGlanceWidgetBundle: WidgetBundle {
         UpNextWidget()
         GoalWidget()
         ProjectWidget()
+        DaySummaryLiveActivity()
         // Control Center controls — iOS 18+ only (the Controls API doesn't exist
         // before then). Mirror the Home Screen Quick Actions.
         if #available(iOS 18.0, *) {

--- a/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
+++ b/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
@@ -1,0 +1,113 @@
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+// Day-summary Live Activity: the summary strip's four numbers on the lock
+// screen and in the Dynamic Island. Pure metadata plane — four short strings,
+// no media — rendered from ContentState pushed by the app's
+// LiveActivityBridge; this extension never reads the App Group or computes
+// anything.
+//
+// Iconography mirrors the in-app strip: bolt (lucide Zap) for Effort, leaf for
+// Restore, in the same indigo/green family. System colors are used rather than
+// exact hexes so the island adapts to its always-dark rendering correctly.
+//
+// Staleness: the bridge sets a staleDate on every update. When the app hasn't
+// refreshed the numbers (completions made on another device sync in only when
+// the iOS app next wakes), `context.isStale` dims the content instead of
+// presenting old numbers as current — honesty over polish.
+
+private let effortColor = Color.indigo
+private let restoreColor = Color.green
+private let unblockedColor = Color.teal
+
+struct DaySummaryLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: DaySummaryAttributes.self) { context in
+            // ── Lock screen / notification banner ────────────────────────
+            LockScreenView(state: context.state, isStale: context.isStale)
+                .activityBackgroundTint(Color.black.opacity(0.55))
+                .activitySystemActionForegroundColor(.white)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // ── Expanded ─────────────────────────────────────────────
+                DynamicIslandExpandedRegion(.leading) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(context.state.unblocked)
+                            .font(.title3.weight(.semibold))
+                            .foregroundStyle(unblockedColor)
+                        Text("unblocked")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.leading, 4)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text(context.state.done)
+                            .font(.title3.weight(.semibold))
+                        Text("done")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.trailing, 4)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    HStack(spacing: 14) {
+                        Label(context.state.effort, systemImage: "bolt.fill")
+                            .foregroundStyle(effortColor)
+                        Label(context.state.restore, systemImage: "leaf.fill")
+                            .foregroundStyle(restoreColor)
+                    }
+                    .font(.footnote.weight(.medium))
+                    .labelStyle(.titleAndIcon)
+                    .opacity(context.isStale ? 0.5 : 1)
+                }
+            } compactLeading: {
+                Image(systemName: "hourglass")
+                    .foregroundStyle(unblockedColor)
+            } compactTrailing: {
+                Text(context.state.unblocked)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(unblockedColor)
+                    .opacity(context.isStale ? 0.5 : 1)
+            } minimal: {
+                Image(systemName: "hourglass")
+                    .foregroundStyle(unblockedColor)
+            }
+        }
+    }
+}
+
+private struct LockScreenView: View {
+    let state: DaySummaryAttributes.ContentState
+    let isStale: Bool
+
+    var body: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(state.unblocked)
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(unblockedColor)
+                Text("unblocked")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 4) {
+                HStack(spacing: 10) {
+                    Label(state.effort, systemImage: "bolt.fill")
+                        .foregroundStyle(effortColor)
+                    Label(state.restore, systemImage: "leaf.fill")
+                        .foregroundStyle(restoreColor)
+                }
+                .font(.footnote.weight(.medium))
+                Text("\(state.done) done")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(14)
+        .opacity(isStale ? 0.55 : 1)
+    }
+}

--- a/dayglance-ios/Shared/DaySummaryAttributes.swift
+++ b/dayglance-ios/Shared/DaySummaryAttributes.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+#if canImport(ActivityKit)
+import ActivityKit
+
+/// Live Activity attributes for the day-summary strip (Dynamic Island + lock
+/// screen). Compiled into BOTH the app target (which starts/updates the
+/// activity from the widget snapshot — see LiveActivityBridge) and the widget
+/// extension (which renders it — see DaySummaryLiveActivity), so it lives in
+/// Shared/.
+///
+/// Everything mutable is in ContentState: the numbers change all day, and the
+/// activity's fixed attributes cannot. `date` is fixed — a new day is a NEW
+/// activity (the bridge ends yesterday's and requests today's), which keeps
+/// midnight semantics trivial.
+///
+/// The strings arrive PREFORMATTED from JS (formatMinutes), so the island's
+/// wording is byte-identical to the in-app strip and the math is never
+/// re-implemented in Swift: the projection is computeDaySummary, serialized in
+/// the snapshot's `daySummary` key.
+@available(iOS 16.1, *)
+struct DaySummaryAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        /// "3h 20m" — the headline. Never "0m for an unmeasurable day": the
+        /// bridge ends the activity instead when there is nothing to measure.
+        var unblocked: String
+        /// "5h 30m" effort / "2h 30m" restore — the energy split.
+        var effort: String
+        var restore: String
+        /// "1h 30m/7h" — done/planned.
+        var done: String
+    }
+
+    /// 'YYYY-MM-DD' this activity describes. Fixed for the activity's lifetime.
+    var date: String
+}
+#endif

--- a/dayglance-ios/project.yml
+++ b/dayglance-ios/project.yml
@@ -34,6 +34,9 @@ targets:
       - path: DayGlance
         excludes:
           - Resources/web/**
+      # ActivityKit attributes shared with the widget extension (the app
+      # starts/updates the Live Activity; the extension renders it).
+      - path: Shared
     dependencies:
       - package: RevenueCat
         product: RevenueCat
@@ -83,6 +86,8 @@ targets:
         CFBundleDisplayName: dayGLANCE
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        # Day-summary Live Activity (Dynamic Island + lock screen).
+        NSSupportsLiveActivities: true
         UILaunchScreen:
           UIColorName: "LaunchBackground"
           UIImageName: "LaunchImage"
@@ -149,6 +154,7 @@ targets:
     deploymentTarget: "17.0"
     sources:
       - path: DayGlanceWidget
+      - path: Shared
     entitlements:
       path: DayGlanceWidget/DayGlanceWidget.entitlements
       properties:


### PR DESCRIPTION
The Swift half of the Live Activity pair. **Companion to #1309** (the JS data plane) — mergeable in either order, but the island only lights up once both are in a build.

## ⚠️ Not compiled here — needs your Xcode

This container has no Swift toolchain. The code targets iOS 16.2+ ActivityKit APIs (`ActivityContent`/`staleDate`) behind availability guards; deployment targets check out (app 16.0, widget 17.0). **Verification loop:** `xcodegen` (the project.yml changed), build, run on a device — Dynamic Island testing wants a physical iPhone 14 Pro+ or the simulator's island support. Treat every line as unreviewed-by-a-compiler until then.

## What it shows

The strip's four numbers, wording byte-identical to the app (strings arrive preformatted from `formatMinutes`):

- **Compact island:** `⏳ 3h 20m` (unblocked — the headline)
- **Expanded:** unblocked leading, done/planned trailing, `⚡ effort · 🌿 restore` across the bottom
- **Lock screen:** the same, one row
- Iconography mirrors the strip — `bolt.fill` for Effort, `leaf.fill` for Restore, system indigo/green (system colors over exact hexes so the always-dark island renders correctly)

## Architecture: zero new surface

The extension **never computes or reads anything** — it renders `ContentState` pushed by the app. `LiveActivityBridge` decodes `daySummary` out of the *same JSON* `WidgetBridge.updateSnapshot` already receives on every renderer push. One entry point, no new JS bridge call, and the island agrees with the in-app strip by construction (the math ran once, in JS, through the synced day window from #1308).

`DaySummaryAttributes` lives in a new `Shared/` folder compiled into both targets (app starts/updates; extension renders) — `project.yml` gains the sources entry for each plus `NSSupportsLiveActivities`.

## Lifecycle decisions, on record

| Situation | Behavior |
|---|---|
| Empty day, no declared window (`unblocked: null`) | **End** the activity — the strip renders nothing in that state; so does the island |
| Date rolls over | Yesterday's activity ends, today's is requested (attributes are fixed; a new day is a new activity by construction) |
| iOS's ~8h Live Activity cap | No dedicated plumbing: any snapshot push with no live activity re-requests one, and the app pushes a snapshot whenever it wakes |
| Numbers go stale (completions synced from another device land only when the iOS app next runs — no server push in a privacy-first, no-backend app) | `staleDate` ~45 min after every update; the views **dim** stale numbers via `context.isStale` rather than presenting them as current |
| `Activity.request` fails (per-app cap, user disabled Live Activities) | Best-effort: swallowed — the widgets still carry the numbers; only the island is lost |

## What to check on device

1. Island appears after opening the app with a windowed/blocked day; numbers match the strip exactly.
2. Complete a block → island updates while the app is foregrounded.
3. Leave the app closed >45 min → island dims (stale).
4. Clear the day window on an empty day → activity ends.
5. Cross midnight with the activity live → old one ends, new one appears on next app wake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_