### PR TITLE
Live Activity redesign: schedule facts + live countdown, opt-in toggle

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
@@ -8,12 +8,18 @@ import ActivityKit
 /// Single entry point, zero new JS surface: WidgetBridge.updateSnapshot already
 /// receives the full snapshot JSON on every renderer push, and this bridge just
 /// decodes the `daySummary` key out of the same string. The math never lives
-/// here — the JS side precomputes everything (the projection IS
-/// computeDaySummary), so the island always agrees with the in-app strip.
+/// here — the JS side precomputes everything (computeDaySummary for the
+/// numbers, buildUpNextFact for the island's schedule facts), so the island
+/// always agrees with the in-app strip.
 ///
 /// Lifecycle, on record:
+///  - `liveActivityEnabled` false or absent: END. The Live Activity is
+///    OPT-IN (in-app toggle, default off) — the compact island hides the
+///    cellular/wifi status icons, so it must be the user's choice. The
+///    system-level Settings toggle is honored separately via
+///    ActivityAuthorizationInfo.
 ///  - No `daySummary`, or `unblocked` null (empty day, no declared window):
-///    END the activity. The strip renders nothing in that state; so do we.
+///    END. The strip renders nothing in that state; so do we.
 ///  - The date rolled over: yesterday's activity ends, today's is requested —
 ///    an activity's fixed attributes can't change, so a new day is a new
 ///    activity by construction.
@@ -22,8 +28,9 @@ import ActivityKit
 ///    snapshot push with none live, the next app foreground re-establishes it
 ///    without dedicated plumbing.
 ///  - staleDate is ~45 min out on every update: with no server push (privacy-
-///    first, no backend), numbers only refresh while the app runs, and the
-///    island dims rather than presenting stale numbers as current.
+///    first, no backend), state only refreshes while the app runs, and the
+///    island dims rather than presenting stale content as current. The
+///    countdown itself needs no refresh — the OS ticks it.
 @available(iOS 16.2, *)
 final class LiveActivityBridge {
     static let shared = LiveActivityBridge()
@@ -32,6 +39,7 @@ final class LiveActivityBridge {
 
     // Only the fields this bridge needs; unknown snapshot keys are ignored.
     private struct SnapshotEnvelope: Decodable {
+        var liveActivityEnabled: Bool?
         var daySummary: DaySummaryPayload?
     }
     private struct DaySummaryPayload: Decodable {
@@ -40,14 +48,29 @@ final class LiveActivityBridge {
         var effort: String?
         var restore: String?
         var done: String?
+        var upNext: UpNextPayload?
+    }
+    private struct UpNextPayload: Decodable {
+        var title: String?
+        var timeLabel: String?
+        var inProgress: Bool?
+        var countdownStartMs: Double?
+        var countdownEndMs: Double?
     }
 
     func sync(fromSnapshotJSON json: String) {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
 
-        let payload = (try? JSONDecoder().decode(SnapshotEnvelope.self, from: Data(json.utf8)))?.daySummary
+        let envelope = try? JSONDecoder().decode(SnapshotEnvelope.self, from: Data(json.utf8))
 
-        guard let payload,
+        // Opt-in gate first: turning the in-app toggle off (or an old
+        // snapshot without the flag) tears down any live activity.
+        guard envelope?.liveActivityEnabled == true else {
+            endAll()
+            return
+        }
+
+        guard let payload = envelope?.daySummary,
               let date = payload.date,
               let unblocked = payload.unblocked,
               let effort = payload.effort,
@@ -57,8 +80,15 @@ final class LiveActivityBridge {
             return
         }
 
+        let up = payload.upNext
+        let msToDate: (Double?) -> Date? = { ms in ms.map { Date(timeIntervalSince1970: $0 / 1000) } }
         let state = DaySummaryAttributes.ContentState(
-            unblocked: unblocked, effort: effort, restore: restore, done: done)
+            blockTitle: up?.title,
+            blockTime: up?.timeLabel,
+            countdownStart: msToDate(up?.countdownStartMs),
+            countdownEnd: msToDate(up?.countdownEndMs),
+            inProgress: up?.inProgress ?? false,
+            done: done, unblocked: unblocked, effort: effort, restore: restore)
         let content = ActivityContent(state: state, staleDate: Date().addingTimeInterval(Self.staleAfter))
 
         Task {

--- a/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
+++ b/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
@@ -2,24 +2,38 @@ import ActivityKit
 import WidgetKit
 import SwiftUI
 
-// Day-summary Live Activity: the summary strip's four numbers on the lock
-// screen and in the Dynamic Island. Pure metadata plane — four short strings,
-// no media — rendered from ContentState pushed by the app's
-// LiveActivityBridge; this extension never reads the App Group or computes
-// anything.
+// Day-summary Live Activity: schedule facts in the Dynamic Island, the
+// summary strip's numbers on the lock screen. Pure metadata plane — short
+// strings and a countdown interval, no media — rendered from ContentState
+// pushed by the app's LiveActivityBridge; this extension never reads the App
+// Group or computes anything.
 //
-// Iconography mirrors the in-app strip: bolt (lucide Zap) for Effort, leaf for
-// Restore, in the same indigo/green family. System colors are used rather than
-// exact hexes so the island adapts to its always-dark rendering correctly.
+// The island leads with the current-or-next block ("Deep work until 2:00 PM")
+// plus a live countdown. The countdown is Text(timerInterval:) — the OS ticks
+// it every second with no updates and no pushes, so the most glanceable
+// element is also the one that can never go stale. The labels are phrased as
+// schedule facts that stay true after a boundary passes; `context.isStale`
+// dims everything else instead of presenting old state as current.
 //
-// Staleness: the bridge sets a staleDate on every update. When the app hasn't
-// refreshed the numbers (completions made on another device sync in only when
-// the iOS app next wakes), `context.isStale` dims the content instead of
-// presenting old numbers as current — honesty over polish.
+// Iconography mirrors the in-app strip: bolt (lucide Zap) for Effort, leaf
+// for Restore, in the same indigo/green family. System colors are used rather
+// than exact hexes so the island adapts to its always-dark rendering.
 
 private let effortColor = Color.indigo
 private let restoreColor = Color.green
 private let unblockedColor = Color.teal
+
+// The live countdown: the OS renders the remaining time in the interval,
+// showing 0:00 once it has passed (next to a label that is still factual).
+// Falls back to the given string when there is no interval to count.
+@ViewBuilder
+private func countdownText(_ state: DaySummaryAttributes.ContentState, fallback: String) -> some View {
+    if let start = state.countdownStart, let end = state.countdownEnd, start < end {
+        Text(timerInterval: start...end, countsDown: true)
+    } else {
+        Text(fallback)
+    }
+}
 
 struct DaySummaryLiveActivity: Widget {
     var body: some WidgetConfiguration {
@@ -33,20 +47,28 @@ struct DaySummaryLiveActivity: Widget {
                 // ── Expanded ─────────────────────────────────────────────
                 DynamicIslandExpandedRegion(.leading) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(context.state.unblocked)
-                            .font(.title3.weight(.semibold))
-                            .foregroundStyle(unblockedColor)
-                        Text("unblocked")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
+                        Text(context.state.blockTitle ?? "No more blocks today")
+                            .font(.subheadline.weight(.semibold))
+                            .lineLimit(2)
+                        if let time = context.state.blockTime {
+                            Text(time)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                     .padding(.leading, 4)
+                    .opacity(context.isStale ? 0.55 : 1)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
                     VStack(alignment: .trailing, spacing: 2) {
-                        Text(context.state.done)
+                        countdownText(context.state, fallback: context.state.done)
                             .font(.title3.weight(.semibold))
-                        Text("done")
+                            .monospacedDigit()
+                            .foregroundStyle(unblockedColor)
+                            .frame(maxWidth: 72)
+                            .multilineTextAlignment(.trailing)
+                        Text(context.state.blockTitle == nil ? "done"
+                             : context.state.inProgress ? "remaining" : "starts in")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
@@ -54,6 +76,9 @@ struct DaySummaryLiveActivity: Widget {
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     HStack(spacing: 14) {
+                        Label("\(context.state.done) done", systemImage: "checkmark.circle")
+                            .foregroundStyle(.secondary)
+                        Spacer()
                         Label(context.state.effort, systemImage: "bolt.fill")
                             .foregroundStyle(effortColor)
                         Label(context.state.restore, systemImage: "leaf.fill")
@@ -67,9 +92,12 @@ struct DaySummaryLiveActivity: Widget {
                 Image(systemName: "hourglass")
                     .foregroundStyle(unblockedColor)
             } compactTrailing: {
-                Text(context.state.unblocked)
+                countdownText(context.state, fallback: context.state.done)
                     .font(.caption2.weight(.semibold))
+                    .monospacedDigit()
                     .foregroundStyle(unblockedColor)
+                    .frame(maxWidth: 56)
+                    .multilineTextAlignment(.trailing)
                     .opacity(context.isStale ? 0.5 : 1)
             } minimal: {
                 Image(systemName: "hourglass")

--- a/dayglance-ios/Shared/DaySummaryAttributes.swift
+++ b/dayglance-ios/Shared/DaySummaryAttributes.swift
@@ -3,7 +3,7 @@ import Foundation
 #if canImport(ActivityKit)
 import ActivityKit
 
-/// Live Activity attributes for the day-summary strip (Dynamic Island + lock
+/// Live Activity attributes for the day summary (Dynamic Island + lock
 /// screen). Compiled into BOTH the app target (which starts/updates the
 /// activity from the widget snapshot — see LiveActivityBridge) and the widget
 /// extension (which renders it — see DaySummaryLiveActivity), so it lives in
@@ -14,21 +14,38 @@ import ActivityKit
 /// activity (the bridge ends yesterday's and requests today's), which keeps
 /// midnight semantics trivial.
 ///
-/// The strings arrive PREFORMATTED from JS (formatMinutes), so the island's
-/// wording is byte-identical to the in-app strip and the math is never
-/// re-implemented in Swift: the projection is computeDaySummary, serialized in
-/// the snapshot's `daySummary` key.
+/// The island leads with SCHEDULE FACTS, not claims about "now": a no-backend
+/// app cannot update a Live Activity in the background, so "Deep work until
+/// 2:00 PM" (still true when stale) beats "In progress" (false the moment a
+/// boundary passes with the app closed). The live part is the countdown
+/// interval, which SwiftUI's Text(timerInterval:) ticks with zero updates.
+/// All strings arrive PREFORMATTED from JS so wording matches the in-app
+/// strip and the math is never re-implemented in Swift: the projection is
+/// computeDaySummary + buildUpNextFact, serialized in the snapshot's
+/// `daySummary` key.
 @available(iOS 16.1, *)
 struct DaySummaryAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
-        /// "3h 20m" — the headline. Never "0m for an unmeasurable day": the
-        /// bridge ends the activity instead when there is nothing to measure.
+        /// Current-or-next block title (task or hyperGLANCE session), nil
+        /// when nothing is left on today's schedule.
+        var blockTitle: String?
+        /// "until 2:00 PM" (in progress) / "at 3:30 PM" (upcoming) — phrased
+        /// to stay factual when the activity goes stale.
+        var blockTime: String?
+        /// Interval for the OS-driven live countdown: the block itself when
+        /// in progress (time remaining), push-time..start when upcoming.
+        var countdownStart: Date?
+        var countdownEnd: Date?
+        /// Whether the block had started when this state was pushed — picks
+        /// the caption ("remaining" vs "starts in"), nothing else.
+        var inProgress: Bool
+        /// "1h 30m/7h" — done/planned.
+        var done: String
+        /// "3h 20m" — lock screen only; in-app currency, not glance currency.
         var unblocked: String
         /// "5h 30m" effort / "2h 30m" restore — the energy split.
         var effort: String
         var restore: String
-        /// "1h 30m/7h" — done/planned.
-        var done: String
     }
 
     /// 'YYYY-MM-DD' this activity describes. Fixed for the activity's lifetime.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -87,6 +87,7 @@ import { createDayGlanceEngine } from './sync/adapter.js';
 import { createDbEngine, resetVaultSyncCursor } from './sync/dbEngine.js';
 import { deriveBlockEnergy } from './utils/energyAxis.js';
 import { computeDaySummary, formatMinutes } from './utils/daySummary.js';
+import { buildUpNextFact } from './utils/liveActivity.js';
 import { registerDbEngine } from './sync/dirtyTracker.js';
 import { isVaultEnabled } from './sync/vaultConfig.js';
 import { keepImportedTask } from './sync/payloadExclusions.js';
@@ -443,6 +444,15 @@ const DayPlanner = () => {
     return saved !== null ? JSON.parse(saved) : 14;
   });
   useEffect(() => { localStorage.setItem('day-planner-inbox-auto-archive-days', JSON.stringify(inboxAutoArchiveDays)); }, [inboxAutoArchiveDays]);
+  // Live Activity (iOS): OPT-IN, default off — the compact island widens the
+  // sensor housing enough to hide the cellular/wifi status icons, so an
+  // all-day ambient activity must be the user's choice. Device-local (not
+  // synced): each device decides for its own island.
+  const [liveActivityEnabled, setLiveActivityEnabled] = useState(() => {
+    const saved = localStorage.getItem('day-planner-live-activity');
+    return saved !== null ? JSON.parse(saved) : false;
+  });
+  useEffect(() => { localStorage.setItem('day-planner-live-activity', JSON.stringify(liveActivityEnabled)); }, [liveActivityEnabled]);
   const [weekStartDay, setWeekStartDay] = useState(() => {
     const saved = localStorage.getItem('day-planner-week-start-day');
     return saved !== null ? JSON.parse(saved) : 0; // 0=Sunday, 1=Monday
@@ -6746,6 +6756,11 @@ const DayPlanner = () => {
     setShowHabitModal,
   });
 
+  // Bumped by a timer set inside the snapshot effect to re-push at the next
+  // block boundary (advances the Up Next widget / Live Activity label while
+  // the app is open).
+  const [widgetSnapshotTick, setWidgetSnapshotTick] = useState(0);
+
   // ── Native Android widget snapshot sync ──────────────────────────────────
   // Pushes a rich snapshot of today's agenda to the native widget via NativeBridge.
   // Runs whenever tasks, habits, routines, or frames change so the widget is always
@@ -6758,6 +6773,7 @@ const DayPlanner = () => {
   useEffect(() => {
     if (!dataLoaded) return;
     if ((!isNativeAndroid() && !isNativeIOS()) || !window.DayGlanceNative?.updateWidgetSnapshot) return;
+    void widgetSnapshotTick; // re-push scheduled at the next block boundary below
 
     const today = new Date();
     const todayStr = getTodayStr();
@@ -7160,6 +7176,9 @@ const DayPlanner = () => {
       nextTask: nextTaskItem,
       upcomingTasks: upcomingTaskItems,
       nextUpNext,
+      // Opt-in flag for the iOS Live Activity; the bridge ends any live
+      // activity when this is false (or absent, for old snapshots).
+      liveActivityEnabled,
       // ── Day-summary projection (Live Activity / Dynamic Island) ────────
       // The strip's numbers for TODAY, precomputed here so the native side
       // never re-implements the math: the projection IS computeDaySummary.
@@ -7184,6 +7203,18 @@ const DayPlanner = () => {
           effort: formatMinutes(sum.effortMinutes),
           restore: formatMinutes(sum.restoreMinutes),
           done: `${formatMinutes(sum.doneMinutes)}/${formatMinutes(sum.completableMinutes)}`,
+          // The island's schedule-fact pair, built from the same unified
+          // current-or-next entry (task or HG session) the Android Up Next
+          // notification uses. Labels stay factual when stale ("until 2:00
+          // PM" / "at 3:30 PM"); the countdown interval feeds SwiftUI's
+          // Text(timerInterval:), which ticks live with no updates.
+          upNext: nextUpNext
+            ? buildUpNextFact(
+                nextUpNext.bodyPrefix
+                  ? { ...nextUpNext, title: `${nextUpNext.bodyPrefix}${nextUpNext.title}` }
+                  : nextUpNext,
+                Date.now(), formatTime)
+            : null,
         };
       })(),
       updatedAt: Date.now(),
@@ -7192,6 +7223,17 @@ const DayPlanner = () => {
     try {
       window.DayGlanceNative.updateWidgetSnapshot(JSON.stringify(snapshot));
     } catch (_) {}
+
+    // Re-push at the next block boundary so "at 3:30 PM" flips to "until
+    // 5:00 PM" (and the Up Next widget advances) while the app is open. iOS
+    // suspends JS timers in the background; a suspended timer fires on the
+    // next foreground, which is the first moment a refresh is possible anyway.
+    const fact = snapshot.daySummary.upNext;
+    if (fact && fact.countdownEndMs > Date.now()) {
+      const delay = Math.min(fact.countdownEndMs - Date.now() + 2000, 6 * 3600000);
+      const boundaryTimer = setTimeout(() => setWidgetSnapshotTick(t => t + 1), delay);
+      return () => clearTimeout(boundaryTimer);
+    }
     // Keyed on the state that composes the widget snapshot. The omitted names are
     // unstable per-render helpers (computeAvailableSlots/getFrameInstancesForDate/
     // getOverdueTasks/getTodayHabitCount) plus stable isVisibleForUser and the
@@ -7217,6 +7259,8 @@ const DayPlanner = () => {
     // helper class as the omissions noted above).
     dayWindows,
     listEndOfDayTime,
+    liveActivityEnabled,
+    widgetSnapshotTick,
   ]);
 
   // Phase 11 — Spotlight indexing: keep Spotlight in sync with non-archived,
@@ -7729,6 +7773,7 @@ const DayPlanner = () => {
 
     // ── Settings / preferences ────────────────────────────────────────────────
     use24HourClock, setUse24HourClock,
+    liveActivityEnabled, setLiveActivityEnabled,
     inboxAutoArchiveDays, setInboxAutoArchiveDays,
     weekStartDay, setWeekStartDay,
     homeTimezone, setHomeTimezone,

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -46,6 +46,7 @@ const MobileSettingsPanel = () => {
     darkMode, setDarkMode,
     mobileSettingsView, setMobileSettingsView,
     use24HourClock, setUse24HourClock,
+    liveActivityEnabled, setLiveActivityEnabled,
     inboxAutoArchiveDays, setInboxAutoArchiveDays,
     weekStartDay, setWeekStartDay,
     homeTimezone, setHomeTimezone,
@@ -864,6 +865,30 @@ const MobileSettingsPanel = () => {
         </div>
         <span className={`text-sm ${textPrimary}`}>{t('settings.enableReminders')}</span>
       </label>
+
+      {/* Live Activity (iOS only) — opt-in, default off: the compact island
+          hides the cellular/wifi status icons, so it has to be a choice. */}
+      {isIOSApp && (
+        <label className="flex items-center gap-3 cursor-pointer">
+          <div className="relative">
+            <input
+              type="checkbox"
+              checked={liveActivityEnabled}
+              onChange={(e) => setLiveActivityEnabled(e.target.checked)}
+              className="sr-only"
+            />
+            <div className={`w-10 h-6 rounded-full transition-colors ${liveActivityEnabled ? 'bg-blue-600' : darkMode ? 'bg-gray-600' : 'bg-stone-300'}`}>
+              <div className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${liveActivityEnabled ? 'translate-x-5' : 'translate-x-1'}`} />
+            </div>
+          </div>
+          <div>
+            <span className={`text-sm ${textPrimary}`}>Live Activity</span>
+            <p className={`text-xs ${textSecondary}`}>
+              Today's plan in the Dynamic Island and on the Lock Screen. Widens the island, which hides the signal icons next to the clock.
+            </p>
+          </div>
+        </label>
+      )}
 
       {reminderSettings.enabled && (
         <div className="space-y-4">

--- a/src/utils/liveActivity.js
+++ b/src/utils/liveActivity.js
@@ -1,0 +1,46 @@
+// Live Activity "Up Next" projection — turns the snapshot's unified up-next
+// entry (task or hyperGLANCE session; see nextUpNext in App.jsx) into the
+// schedule FACTS the Dynamic Island renders.
+//
+// Phrasing rule: every string must stay true no matter when it is glanced at.
+// A no-backend app cannot update a Live Activity in the background, so claims
+// about "now" ("In progress: X") go wrong the moment a block boundary passes
+// with the app closed. "Deep work until 2:00 PM" / "Standup at 3:30 PM" do
+// not — they describe the schedule, not the present.
+//
+// The live part is delegated to the OS: countdownStartMs..countdownEndMs is
+// the interval for SwiftUI's Text(timerInterval:), which ticks every second
+// with zero updates and zero pushes. In progress → the block itself (counts
+// down time remaining); upcoming → now..start (counts down to the start).
+// After the interval passes without an update it reads 0:00 next to a label
+// that is still factual, and the activity's staleDate dims it.
+
+const toHHMM = (ms) => {
+  const t = new Date(ms);
+  return `${String(t.getHours()).padStart(2, '0')}:${String(t.getMinutes()).padStart(2, '0')}`;
+};
+
+/**
+ * @param {{title?: string, startTime?: string, duration?: number}|null} entry
+ *   today's current-or-next block ('HH:MM' start, minutes duration)
+ * @param {number} nowMs epoch ms "now" (startTime is resolved against its day)
+ * @param {(hhmm: string) => string} formatTime display formatter (12h/24h)
+ * @returns {{title, inProgress, timeLabel, countdownStartMs, countdownEndMs}|null}
+ */
+export function buildUpNextFact(entry, nowMs, formatTime) {
+  if (!entry || !entry.startTime) return null;
+  const parts = String(entry.startTime).split(':').map(Number);
+  if (parts.length < 2 || !Number.isFinite(parts[0]) || !Number.isFinite(parts[1])) return null;
+  const d = new Date(nowMs);
+  d.setHours(parts[0], parts[1], 0, 0);
+  const startMs = d.getTime();
+  const endMs = startMs + (entry.duration || 0) * 60000;
+  const inProgress = nowMs >= startMs;
+  return {
+    title: entry.title || '',
+    inProgress,
+    timeLabel: inProgress ? `until ${formatTime(toHHMM(endMs))}` : `at ${formatTime(toHHMM(startMs))}`,
+    countdownStartMs: inProgress ? startMs : nowMs,
+    countdownEndMs: inProgress ? endMs : startMs,
+  };
+}

--- a/src/utils/liveActivity.test.js
+++ b/src/utils/liveActivity.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { buildUpNextFact } from './liveActivity.js';
+
+// Identity formatter — label WORDING is the caller's formatTime's business.
+const fmt = (t) => t;
+// Local-time epoch ms for a fixed day, mirroring how the snapshot resolves
+// 'HH:MM' against the wall clock.
+const at = (h, m) => new Date(2026, 7, 2, h, m, 0, 0).getTime();
+
+describe('buildUpNextFact', () => {
+  it('upcoming block: "at <start>" label, countdown runs now → start', () => {
+    const f = buildUpNextFact({ title: 'Standup', startTime: '15:30', duration: 30 }, at(14, 0), fmt);
+    expect(f.title).toBe('Standup');
+    expect(f.inProgress).toBe(false);
+    expect(f.timeLabel).toBe('at 15:30');
+    expect(f.countdownStartMs).toBe(at(14, 0));
+    expect(f.countdownEndMs).toBe(at(15, 30));
+  });
+
+  it('in-progress block: "until <end>" label, countdown runs start → end', () => {
+    const f = buildUpNextFact({ title: 'Deep work', startTime: '13:00', duration: 120 }, at(14, 0), fmt);
+    expect(f.inProgress).toBe(true);
+    expect(f.timeLabel).toBe('until 15:00');
+    expect(f.countdownStartMs).toBe(at(13, 0));
+    expect(f.countdownEndMs).toBe(at(15, 0));
+  });
+
+  it('a block starting exactly now is in progress', () => {
+    const f = buildUpNextFact({ title: 'x', startTime: '14:00', duration: 60 }, at(14, 0), fmt);
+    expect(f.inProgress).toBe(true);
+    expect(f.timeLabel).toBe('until 15:00');
+  });
+
+  it('an end past midnight still yields a valid label', () => {
+    const f = buildUpNextFact({ title: 'x', startTime: '23:30', duration: 60 }, at(23, 45), fmt);
+    expect(f.timeLabel).toBe('until 00:30');
+  });
+
+  it('handles unpadded HH:MM and missing duration', () => {
+    const f = buildUpNextFact({ title: 'x', startTime: '9:5' }, at(8, 0), fmt);
+    expect(f.timeLabel).toBe('at 09:05');
+    expect(f.countdownEndMs).toBe(at(9, 5));
+  });
+
+  it('returns null for no entry, empty start time, or junk', () => {
+    expect(buildUpNextFact(null, at(9, 0), fmt)).toBeNull();
+    expect(buildUpNextFact({ title: 'x', startTime: '' }, at(9, 0), fmt)).toBeNull();
+    expect(buildUpNextFact({ title: 'x', startTime: 'junk' }, at(9, 0), fmt)).toBeNull();
+  });
+
+  it('label wording goes through the caller-provided formatter', () => {
+    const twelveHour = (t) => {
+      const [h, m] = t.split(':').map(Number);
+      const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+      return `${h12}:${String(m).padStart(2, '0')} ${h >= 12 ? 'PM' : 'AM'}`;
+    };
+    const f = buildUpNextFact({ title: 'x', startTime: '15:30', duration: 0 }, at(14, 0), twelveHour);
+    expect(f.timeLabel).toBe('at 3:30 PM');
+  });
+});


### PR DESCRIPTION
## What changed

The island's first cut led with **unblocked time** — in-app currency, not glance currency. Outside the app the question is *"what am I supposed to be doing, and for how much longer?"*, so the island now leads with the **current-or-next block and a live countdown**, and the whole Live Activity becomes **opt-in (default off)**.

### JS — data plane (fully verified here)

- **`src/utils/liveActivity.js`** — `buildUpNextFact` turns the snapshot's unified up-next entry (task **or** hyperGLANCE session — the same `nextUpNext` the Android Up Next notification reads) into **schedule facts**:
  - Labels phrased to stay true when stale: `until 2:00 PM` (in progress) / `at 3:30 PM` (upcoming) — never "In progress: X", which goes false the moment a boundary passes with the app closed.
  - A countdown interval (`countdownStartMs..countdownEndMs`) for SwiftUI's `Text(timerInterval:)`, which **the OS ticks every second with zero updates and zero pushes** — the most glanceable element is the one that can never go stale. In progress → the block itself (time remaining); upcoming → now..start.
  - 7 tests, mutation-checked (boundary comparison and interval-selection mutations both caught).
- **Widget snapshot**: `daySummary` gains `upNext`; top level gains `liveActivityEnabled`. The snapshot effect also **re-pushes at the next block boundary** while the app is open, so `at 3:30 PM` flips to `until 5:00 PM` on time (this advances the Up Next widget too). iOS suspends JS timers in the background; a suspended timer fires on next foreground — the first refreshable moment anyway.
- **New setting** `liveActivityEnabled` — device-local (not synced: each device decides for its own island), **default OFF**. The compact island widens the sensor housing enough to hide the cellular/wifi status icons, so an all-day ambient activity must be the user's choice. Toggle lives in mobile **Settings → Notifications**, shown only in the iOS app.

### Swift — presentation (⚠️ NOT compiled here — no Xcode in this container)

No new files and no `project.yml` change, so **a plain rebuild suffices — no `xcodegen` needed**.

- **`DaySummaryAttributes.ContentState`**: `blockTitle` / `blockTime` / `countdownStart` / `countdownEnd` / `inProgress` join `done` / `unblocked` / `effort` / `restore`.
- **Island**: expanded leading = block title + factual time label; trailing = live countdown with a `remaining` / `starts in` / `done` caption; bottom = `✓ 1h 30m/4h done` + bolt/leaf energy split. Compact trailing = the countdown. Minimal/compact leading keep the teal hourglass.
- **Lock screen: unchanged** — unblocked now renders *only* there (plus the in-app strip).
- **Bridge**: decodes the new fields; **ends the activity when `liveActivityEnabled` is false or absent** (old snapshots read as disabled — correct for opt-in). Empty-day end, new-day-new-activity, 45-min `staleDate`, and best-effort `request` all carried over.

### Lifecycle notes

| Situation | Behavior |
|---|---|
| Toggle off (or old snapshot) | activity ends immediately on next push |
| Block boundary passes, app open | boundary timer re-pushes; label + countdown advance |
| Block boundary passes, app closed | countdown reads 0:00 next to a still-true label; 45-min staleDate dims |
| Nothing left today | leading shows "No more blocks today", countdown slot falls back to done |
| hyperGLANCE session is next | title reads "«project» · N tasks · hyperGLANCE" via the existing `bodyPrefix` |

### Device checklist

1. Toggle **off by default**: fresh install shows no activity; Settings → Notifications → Live Activity turns it on (island appears on next snapshot push) and off (island disappears).
2. Island compact shows a **ticking countdown**; expanded shows block title + `until`/`at` time, countdown, done + energy row.
3. With the app **open** across a block boundary, the label flips (`at` → `until`, then to the next block) within ~2s.
4. With the app **closed** past a boundary, countdown sits at 0:00 and content dims after ~45 min; reopening snaps it forward.
5. Lock screen layout is unchanged from #1310.

## Verification

- `npx eslint src --max-warnings 0` — clean
- `npx vitest run` — 74 files / **1114 tests** green (7 new)
- Web, Electron, and iOS production bundles all build

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_