### PR TITLE
Summary strip polish + LIST scroll reset + goal badge {{title}} fix

### DIFF
--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -491,7 +491,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
                 <Flag size={13} className="text-amber-400 flex-shrink-0" />
                 <span className={`text-sm font-medium ${textPrimary} truncate`}>{g.title}</span>
               </div>
-              <span className={`text-xs flex-shrink-0 font-medium px-1.5 py-0.5 rounded ${darkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-100 text-amber-700'}`}>{t('app.goalDueToday')}</span>
+              <span className={`text-xs flex-shrink-0 font-medium px-1.5 py-0.5 rounded ${darkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-100 text-amber-700'}`}>{t('goals.dueToday')}</span>
             </div>
             <div className="flex items-center gap-2">
               <div className={`flex-1 h-1.5 rounded-full ${darkMode ? 'bg-gray-600' : 'bg-stone-200'}`}>

--- a/src/components/MobileBottomSheets.jsx
+++ b/src/components/MobileBottomSheets.jsx
@@ -311,13 +311,13 @@ const MobileBottomSheets = () => {
                 {todayDueGoals.map(g => (
                   <div key={g.id} className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium ${darkMode ? 'bg-yellow-900/30 text-yellow-300' : 'bg-yellow-50 text-yellow-700'}`}>
                     <Flag size={14} className="flex-shrink-0" />
-                    <span className="truncate">{t('app.goalDueToday')}: {g.title}</span>
+                    <span className="truncate">{t('app.goalDueToday', { title: g.title })}</span>
                   </div>
                 ))}
                 {todayCompletedGoals.map(g => (
                   <div key={g.id} className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium ${darkMode ? 'bg-amber-900/30 text-amber-300' : 'bg-amber-50 text-amber-700'}`}>
                     <Flag size={14} className="flex-shrink-0" />
-                    <span className="truncate">{t('app.goalComplete')}: {g.title}</span>
+                    <span className="truncate">{t('app.goalComplete', { title: g.title })}</span>
                   </div>
                 ))}
                 {todayCompletedProjects.map(p => (

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -396,7 +396,7 @@ const MobileGlanceSection = () => {
                 <Flag size={13} className="text-amber-400 flex-shrink-0" />
                 <span className={`text-sm font-medium ${textPrimary} truncate`}>{g.title}</span>
               </div>
-              <span className={`text-xs flex-shrink-0 font-medium px-1.5 py-0.5 rounded ${darkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-100 text-amber-700'}`}>{t('app.goalDueToday')}</span>
+              <span className={`text-xs flex-shrink-0 font-medium px-1.5 py-0.5 rounded ${darkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-100 text-amber-700'}`}>{t('goals.dueToday')}</span>
             </div>
             <div className="flex items-center gap-2">
               <div className={`flex-1 h-1.5 rounded-full ${darkMode ? 'bg-gray-600' : 'bg-stone-200'}`}>

--- a/src/components/MobileListView.jsx
+++ b/src/components/MobileListView.jsx
@@ -1181,12 +1181,22 @@ const MobileListView = ({ hideInboxHandle = false }) => {
       setTasks, setTodayRoutines, updateProject, dateStr, playUISound, setListDragTargetAllDay]);
 
   // ── Scroll to "now" on mount / date change ─────────────────────────────────
+  // The scroll container is SHARED with the grid view, whose 24h canvas is far
+  // taller than the list — a view switch inherits the grid's scrollTop, which
+  // the shorter list clamps to its bottom. So this must always normalize, not
+  // just when a dedicated now row exists: without one (a block is in progress,
+  // so the list STARTS with it — or another day, which starts at its first
+  // item), the top of the list already is "now" and 0 is the right target.
   useEffect(() => {
-    if (!isToday || !nowRowRef.current || !calendarRef?.current) return;
+    if (!calendarRef?.current) return;
     const timer = setTimeout(() => {
       const container = calendarRef.current;
-      const nowEl     = nowRowRef.current;
-      if (!container || !nowEl) return;
+      if (!container) return;
+      const nowEl = isToday ? nowRowRef.current : null;
+      if (!nowEl) {
+        container.scrollTo({ top: 0, behavior: 'auto' });
+        return;
+      }
       const cRect  = container.getBoundingClientRect();
       const nRect  = nowEl.getBoundingClientRect();
       const target = container.scrollTop + (nRect.top - cRect.top) - 32;

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -129,8 +129,10 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
   // cover every future day and this state never recurs.
   const isEmptyHint = summary.unblockedMinutes === null;
 
+  // Static (LIST) gets real top padding: it sits right under the day's
+  // closing "Good work" line and needs visible separation from it.
   const container = staticPlacement
-    ? `relative pt-1 pb-2 pl-2 pointer-events-none ${phone ? 'pr-20' : 'pr-2'}`
+    ? `relative pt-4 pb-2 pl-2 pointer-events-none ${phone ? 'pr-20' : 'pr-2'}`
     : `sticky bottom-0 z-30 pl-2 pb-2 pointer-events-none ${phone ? 'pr-20' : 'pr-2'}`;
 
   return (
@@ -272,19 +274,21 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
           </>
         );
 
-        // Floating phone strip: the anchor row (unblocked + energy) keeps the
-        // exact position it has when collapsed — the container is stuck to the
-        // bottom, so the tag chips FAN OUT UPWARD above it and the collapse
-        // target never moves. The in-flow LIST strip reads top-down instead,
-        // so there everything stays one wrapping row growing downward.
+        // Floating phone strip: the unblocked pill is the ANCHOR — it keeps
+        // the exact bottom-left position it has when collapsed, so the
+        // collapse target never moves. Everything else fans out UPWARD in its
+        // own row: energy directly above, tag chips above that. One pill per
+        // row on the anchor levels also keeps the fan-out clear of the
+        // new-task FAB — unblocked + energy side by side could not wrap
+        // (anchor stability) and slid underneath it on narrow phones. The
+        // in-flow LIST strip reads top-down instead, so there everything
+        // stays one wrapping row growing downward.
         if (phone && !staticPlacement) {
           return (
             <div className="pointer-events-auto w-fit max-w-full flex flex-col items-start gap-1.5 text-xs">
               <div className="flex flex-wrap items-center gap-1.5">{tagChips}</div>
-              <div className="flex items-center gap-1.5">
-                {unblockedPill}
-                {energyPill}
-              </div>
+              {energyPill && <div className="flex items-center">{energyPill}</div>}
+              <div className="flex items-center">{unblockedPill}</div>
             </div>
           );
         }


### PR DESCRIPTION
Four small independent fixes (branched from `main`, independent of #1311 — merge in any order):

1. **Phone GRID expanded fan-out** — the unblocked pill is now the sole bottom anchor; Effort/Restore gets its own row above it, tag chips above that. The old side-by-side anchor row (`unblocked + energy`) couldn't wrap — anchor stability was the point — so on narrow phones it slid underneath the new-task FAB. One pill per row on the anchor levels keeps everything clear of it, and the collapse target still never moves.

2. **LIST strip separation** — `staticPlacement` top padding `pt-1` → `pt-4`, so the strip sits visibly apart from the "Good work · rest up" line.

3. **LIST view landing at the bottom on view switch** — the scroll container is shared with the 24-hour grid, whose canvas is far taller than the list; switching views inherited the grid's large `scrollTop`, which the shorter list clamps to its bottom. The list's scroll-to-now effect only corrected this when a dedicated now row existed — and a busy day mid-block has none, because the list then *starts* with the in-progress item. The effect now always normalizes: to the now row when present, otherwise to the top — which in the list **is** "now" (today's list starts at the current moment; other days start at their first item). Not actually caused by the summary strip — the bail-out predates it — but the strip made the state easier to notice.

4. **Stray `{{title}}` on goals due today** — `app.goalDueToday` is `"Goal due today: {{title}}"`, but the GLANCE badges (mobile GLANCE section + desktop sidebar) called it with no interpolation param, so i18next rendered the placeholder literally — right next to the goal title the card already shows. Badges now use `goals.dueToday` ("Due today"), which exists in all six locales. `MobileBottomSheets` had the third variant (`t('app.goalDueToday')`: `{g.title}` — placeholder *and* a manually appended title); it now passes the param like the desktop call site, and the same fix applies to its `app.goalComplete` line.

## Verification

- `npx eslint src --max-warnings 0` — clean
- `npx vitest run` — 1107 tests green
- Web, Electron, and iOS production bundles all build

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_