### PR TITLE
GLANCEahead: show the device's next alarm (Android)

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -1,5 +1,6 @@
 package com.dayglance.app.bridge
 
+import android.app.AlarmManager
 import android.content.Context
 import android.content.Intent
 import android.media.MediaRecorder
@@ -204,6 +205,19 @@ class NativeBridge(
 
     @JavascriptInterface
     fun getTasksFromNote(path: String): String = obsidian.getTasksFromNote(path)
+
+    // ── Next alarm (GLANCEahead) ────────────────────────────────────────────
+
+    /**
+     * Epoch millis of the device's next alarm clock, or -1 when none is set.
+     * AlarmManager.getNextAlarmClock() needs no permission — it only exposes
+     * what the status bar alarm icon already shows. GLANCEahead uses this for
+     * its "when am I waking up?" line.
+     */
+    @JavascriptInterface
+    fun getNextAlarm(): Long =
+        (context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager)
+            ?.nextAlarmClock?.triggerTime ?: -1L
 
     // ── Notifications ───────────────────────────────────────────────────────
 

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -1,12 +1,14 @@
 import React, { useRef } from 'react';
 import {
-  AlertCircle, AlertTriangle, BookOpen, BrainCircuit,
+  AlarmClock, AlertCircle, AlertTriangle, BookOpen, BrainCircuit,
   Calendar, CalendarClock, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronUp, Clock, Filter, Flag, Hash, Inbox, LayoutGrid, Loader,
   Mic, Minus, Moon, Plus, RefreshCw, Search,
   Settings, Sparkles, Sun, Target, Telescope, Trash2, X, Zap,
 } from 'lucide-react';
 import { renderTitle } from '../utils/textFormatting.jsx';
+import { nativeGetNextAlarm } from '../native.js';
+import { nextAlarmWithinTomorrow, alarmHHMM } from '../utils/nextAlarm.js';
 import GoalRing from './GoalRing.jsx';
 import { dateToString, extractTags, extractWikilinks, formatDeadlineDate } from '../utils/taskUtils.js';
 import { calculateGoalProgress } from '../utils/goalProgress.js';
@@ -1278,6 +1280,17 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     const committedH = Math.floor(committedMinutes / 60);
     const committedM = committedMinutes % 60;
     const committedStr = committedH > 0 ? `${committedH}h${committedM > 0 ? ` ${committedM}m` : ''}` : committedM > 0 ? `${committedM}m` : null;
+    // Device's next alarm clock (Android bridge; null everywhere else — iOS
+    // has no API for Clock alarms, and desktop/tray have no bridge). Read per
+    // render: this section re-renders every minute via currentTime, so the
+    // line tracks alarm edits without any subscription machinery.
+    const alarmMs = nextAlarmWithinTomorrow(currentTime.getTime(), nativeGetNextAlarm());
+    const alarmLine = alarmMs ? (
+      <div className="flex items-center gap-2">
+        <AlarmClock size={13} className={textSecondary} />
+        <span className={`text-sm ${textPrimary}`}>Alarm at <span className="font-medium">{formatTime(alarmHHMM(alarmMs))}</span></span>
+      </div>
+    ) : null;
     const handleGlanceAheadClick = () => {
       const tomorrow = new Date();
       tomorrow.setDate(tomorrow.getDate() + 1);
@@ -1297,9 +1310,13 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
           </span>
         </div>
         {isEmpty ? (
-          <p className={`text-sm ${textSecondary} italic`}>{t('app.tomorrowWideOpen')}</p>
+          <div className="space-y-1">
+            <p className={`text-sm ${textSecondary} italic`}>{t('app.tomorrowWideOpen')}</p>
+            {alarmLine}
+          </div>
         ) : (
           <div className="space-y-1">
+            {alarmLine}
             {firstStartTime && (
               <div className="flex items-center gap-2">
                 <Clock size={13} className={textSecondary} />

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -1,11 +1,13 @@
 import React, { useRef } from 'react';
 import {
-  AlertCircle, AlertTriangle, BookOpen, BrainCircuit,
+  AlarmClock, AlertCircle, AlertTriangle, BookOpen, BrainCircuit,
   Calendar, CalendarClock, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
   ChevronUp, Clock, ExternalLink, FileText, Filter, Flag, Inbox, LayoutGrid,
   Loader, Mic, Minus, Moon, Plus, RefreshCw,
   Search, Settings, Sparkles, Sun, Target, Telescope, Trash2, X, Zap,
 } from 'lucide-react';
+import { nativeGetNextAlarm } from '../native.js';
+import { nextAlarmWithinTomorrow, alarmHHMM } from '../utils/nextAlarm.js';
 import { renderTitle, renderFormattedText, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
 import { dateToString, extractTags, extractWikilinks, formatDeadlineDate } from '../utils/taskUtils.js';
 import { calculateGoalProgress } from '../utils/goalProgress.js';
@@ -1124,6 +1126,17 @@ const MobileGlanceSection = () => {
     const committedH = Math.floor(committedMinutes / 60);
     const committedM = committedMinutes % 60;
     const committedStr = committedH > 0 ? `${committedH}h${committedM > 0 ? ` ${committedM}m` : ''}` : committedM > 0 ? `${committedM}m` : null;
+    // Device's next alarm clock (Android bridge; null everywhere else — iOS
+    // has no API for Clock alarms). Read per render: this section re-renders
+    // every minute via currentTime, so the line tracks alarm edits without
+    // any subscription machinery.
+    const alarmMs = nextAlarmWithinTomorrow(currentTime.getTime(), nativeGetNextAlarm());
+    const alarmLine = alarmMs ? (
+      <div className="flex items-center gap-2">
+        <AlarmClock size={13} className={textSecondary} />
+        <span className={`text-sm ${textPrimary}`}>Alarm at <span className="font-medium">{formatTime(alarmHHMM(alarmMs))}</span></span>
+      </div>
+    ) : null;
     const handleGlanceAheadClick = () => {
       const tomorrow = new Date();
       tomorrow.setDate(tomorrow.getDate() + 1);
@@ -1144,9 +1157,13 @@ const MobileGlanceSection = () => {
           </span>
         </div>
         {isEmpty ? (
-          <p className={`text-sm ${textSecondary} italic`}>{t('app.tomorrowWideOpen')}</p>
+          <div className="space-y-1">
+            <p className={`text-sm ${textSecondary} italic`}>{t('app.tomorrowWideOpen')}</p>
+            {alarmLine}
+          </div>
         ) : (
           <div className="space-y-1">
+            {alarmLine}
             {firstStartTime && (
               <div className="flex items-center gap-2">
                 <Clock size={13} className={textSecondary} />

--- a/src/native.js
+++ b/src/native.js
@@ -133,6 +133,23 @@ export const nativeGetSleep = async (date) => {
   }
 };
 
+/**
+ * Epoch ms of the device's next alarm clock, or null when none is set or the
+ * platform can't say. Android-only: AlarmManager.getNextAlarmClock() needs no
+ * permission; iOS has no API for reading the user's Clock alarms, so the iOS
+ * bridge simply never implements this and callers fall through to null.
+ */
+export const nativeGetNextAlarm = () => {
+  const bridge = nativeBridge();
+  if (!bridge?.getNextAlarm) return null;
+  try {
+    const ms = Number(bridge.getNextAlarm());
+    return Number.isFinite(ms) && ms > 0 ? ms : null;
+  } catch {
+    return null;
+  }
+};
+
 export const nativeGetCalendars = () => {
   const bridge = nativeBridge();
   if (!bridge?.getCalendars) return [];

--- a/src/utils/nextAlarm.js
+++ b/src/utils/nextAlarm.js
@@ -1,0 +1,25 @@
+// GLANCEahead's "next alarm" line — the bedtime question is "when am I waking
+// up?", so the device's next alarm clock is only relevant while it rings
+// before the END OF TOMORROW (GLANCEahead is a tomorrow preview; an alarm set
+// for next Saturday is not an answer). Android-only in practice: iOS has no
+// API for reading the user's Clock alarms.
+
+/**
+ * @param {number} nowMs epoch ms "now"
+ * @param {number|null} alarmMs epoch ms of the device's next alarm clock
+ * @returns {number|null} alarmMs when it rings after now and before the end
+ *   of tomorrow (local time), else null
+ */
+export function nextAlarmWithinTomorrow(nowMs, alarmMs) {
+  if (!alarmMs || alarmMs <= nowMs) return null;
+  const end = new Date(nowMs);
+  end.setDate(end.getDate() + 1);
+  end.setHours(23, 59, 59, 999);
+  return alarmMs <= end.getTime() ? alarmMs : null;
+}
+
+/** 'HH:MM' of an epoch-ms instant, ready for the app's formatTime. */
+export function alarmHHMM(alarmMs) {
+  const d = new Date(alarmMs);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}

--- a/src/utils/nextAlarm.test.js
+++ b/src/utils/nextAlarm.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { nextAlarmWithinTomorrow, alarmHHMM } from './nextAlarm.js';
+
+// Local-time epoch ms on a fixed base day (Aug 2) + day offset.
+const at = (dayOffset, h, m) => new Date(2026, 7, 2 + dayOffset, h, m, 0, 0).getTime();
+
+describe('nextAlarmWithinTomorrow', () => {
+  const now = at(0, 22, 30); // 10:30pm tonight
+
+  it('an alarm tomorrow morning passes through', () => {
+    expect(nextAlarmWithinTomorrow(now, at(1, 6, 30))).toBe(at(1, 6, 30));
+  });
+
+  it('an alarm later tonight passes through', () => {
+    expect(nextAlarmWithinTomorrow(now, at(0, 23, 45))).toBe(at(0, 23, 45));
+  });
+
+  it('the end of tomorrow is inclusive; the day after is out', () => {
+    expect(nextAlarmWithinTomorrow(now, at(1, 23, 59))).toBe(at(1, 23, 59));
+    expect(nextAlarmWithinTomorrow(now, at(2, 0, 30))).toBeNull();
+  });
+
+  it('null, absent, or past alarms yield null', () => {
+    expect(nextAlarmWithinTomorrow(now, null)).toBeNull();
+    expect(nextAlarmWithinTomorrow(now, 0)).toBeNull();
+    expect(nextAlarmWithinTomorrow(now, at(0, 8, 0))).toBeNull(); // this morning
+  });
+});
+
+describe('alarmHHMM', () => {
+  it('formats padded local HH:MM', () => {
+    expect(alarmHHMM(at(1, 6, 5))).toBe('06:05');
+    expect(alarmHHMM(at(1, 23, 45))).toBe('23:45');
+  });
+});


### PR DESCRIPTION
Adds the "when am I waking up?" line to GLANCEahead: **⏰ Alarm at 6:30 AM**, sourced from the device's next alarm clock.

## How

- **Kotlin** (⚠️ not compiled here): `NativeBridge.getNextAlarm(): Long` — `AlarmManager.getNextAlarmClock()?.triggerTime ?: -1`. No permission required; this is the same information the status-bar alarm icon already shows.
- **`native.js`**: `nativeGetNextAlarm()` — guarded helper returning epoch ms or `null` when the bridge/method is absent. iOS has **no API for reading Clock alarms** (AlarmKit only manages an app's own alarms), so the iOS bridge simply never implements the method and every other platform (web, Electron, tray) falls through to `null` — no platform gating needed anywhere.
- **`src/utils/nextAlarm.js`** (+5 tests): `nextAlarmWithinTomorrow(nowMs, alarmMs)` clamps the line to alarms ringing **before the end of tomorrow** — GLANCEahead is a tomorrow preview, and an alarm set for next Saturday is not an answer to tonight's question. `alarmHHMM` feeds the app's `formatTime` so 12/24h follows the user's setting.
- **UI**: the line renders in both GLANCEahead sections (mobile GLANCE tab + desktop/tray sidebar), first in the detail list (before "Day starts at"), and **also on the "Tomorrow is wide open" empty state** — an empty tomorrow with an alarm set is exactly the going-to-bed case. Values are read per render; the sections already re-render every minute via `currentTime`, so alarm edits show up without subscription machinery.

## Verification

- `npx eslint src --max-warnings 0` — clean
- `npx vitest run` — **1112 tests** green (5 new)
- Web, Electron, Android, and iOS bundles all build
- Kotlin needs a device build: set an alarm for tomorrow → line appears in GLANCEahead in the evening; dismiss all alarms → line disappears within a minute; alarm ≥ day after tomorrow → hidden

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_