### PR TITLE
macOS title bar: today's summary-strip pills in the empty drag region

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -12,6 +12,7 @@ import DesktopHeader from './DesktopHeader.jsx';
 import CalendarHeader from './CalendarHeader.jsx';
 import TimeGrid from './TimeGrid.jsx';
 import SummaryStrip from './SummaryStrip.jsx';
+import TitlebarSummaryStrip from './TitlebarSummaryStrip.jsx';
 import DayView from './DayView.jsx';
 import WeekView from './WeekView.jsx';
 import SchedDashboard from './sched/SchedDashboard.jsx';
@@ -450,7 +451,9 @@ const DesktopLayout = () => {
 
   return (
       <>
-      {/* macOS traffic-light drag region — doubles as the NOW bar when a task is running */}
+      {/* macOS traffic-light drag region — the NOW bar when a task is running,
+          today's summary-strip pills otherwise (TitlebarSummaryStrip). Both are
+          display-only, so the whole bar stays a drag area. */}
       {isElectronMac && (() => {
         const todayStr = dateToString(new Date());
         const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
@@ -469,11 +472,13 @@ const DesktopLayout = () => {
                 : ''
             }`}
           >
-            {runningTask && (
+            {runningTask ? (
               <>
                 <span className="w-2 h-2 rounded-full bg-amber-400 animate-pulse flex-shrink-0" />
                 <span className="truncate">{t('common.now')}: {runningTask.title}</span>
               </>
+            ) : (
+              <TitlebarSummaryStrip />
             )}
           </div>
         );

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -13,8 +13,15 @@ import { computeDaySummary, formatMinutes } from '../utils/daySummary.js';
 // carries the headline numbers.
 const COLLAPSE_KEY = 'day-planner-summary-strip-collapsed';
 
-const EFFORT_DOT = '#6366f1'; // indigo — matches the END marker
-const RESTORE_DOT = '#22c55e'; // green-500 — leaf-green per review; the START marker keeps its teal
+// Exported (with summaryPillClass) so TitlebarSummaryStrip renders the exact
+// same pills — one definition, no drift between the strip and the title bar.
+export const EFFORT_DOT = '#6366f1'; // indigo — matches the END marker
+export const RESTORE_DOT = '#22c55e'; // green-500 — leaf-green per review; the START marker keeps its teal
+
+export const summaryPillClass = (darkMode) =>
+  `flex items-center gap-1.5 px-2.5 py-1 rounded-full flex-shrink-0 border shadow-sm backdrop-blur-sm ${
+    darkMode ? 'bg-gray-900/85 border-gray-700' : 'bg-white/90 border-stone-200'
+  }`;
 
 /**
  * Summary strip: rolls the viewed day's timeline blocks into a row of pills —
@@ -86,9 +93,7 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
     [getTasksForDate, selectedDate, listEndOfDayTime, dayWindow],
   );
 
-  const pill = `flex items-center gap-1.5 px-2.5 py-1 rounded-full flex-shrink-0 border shadow-sm backdrop-blur-sm ${
-    darkMode ? 'bg-gray-900/85 border-gray-700' : 'bg-white/90 border-stone-200'
-  }`;
+  const pill = summaryPillClass(darkMode);
 
   // Menu edits act on the RESOLVED window (day entry or inherited default) —
   // what the user sees in the inputs is what gets stored. Setting either bound

--- a/src/components/TitlebarSummaryStrip.jsx
+++ b/src/components/TitlebarSummaryStrip.jsx
@@ -1,0 +1,79 @@
+import { useMemo } from 'react';
+import { Leaf, Zap } from 'lucide-react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { dateToString } from '../utils/taskUtils.js';
+import { computeDaySummary, formatMinutes } from '../utils/daySummary.js';
+import { summaryPillClass, EFFORT_DOT, RESTORE_DOT } from './SummaryStrip.jsx';
+
+/**
+ * macOS title bar summary strip — TODAY's headline numbers in the otherwise
+ * empty hiddenInset title bar. The bar is app-rendered chrome (DesktopLayout's
+ * 28px drag-region div), so these are literally the same pills as the
+ * in-timeline strip: class and dot palette are imported from SummaryStrip,
+ * not copied, and the math is the same computeDaySummary call.
+ *
+ * Deliberately DISPLAY-ONLY: the whole bar stays a WebkitAppRegion drag area —
+ * no buttons, no day-window menu (the in-timeline strip owns editing), so
+ * nothing here needs no-drag carve-outs and dragging the window keeps working
+ * everywhere in the bar.
+ *
+ * Always describes TODAY (a title bar is global chrome, not tied to the
+ * selected date) and yields entirely to the NOW bar while a task is running —
+ * DesktopLayout renders one or the other, never both.
+ *
+ * Content order matches the strip: unblocked, Effort/Restore, tag chips (with
+ * the same quiet-until-progress done/planned values). The untagged chip and
+ * empty-day setup hint are omitted — bar width is finite and setup lives in
+ * the timeline. Overflowing chips clip at the right edge.
+ */
+export default function TitlebarSummaryStrip() {
+  const {
+    getTasksForDate, listEndOfDayTime, currentTime,
+    darkMode, textPrimary, textSecondary,
+  } = useDayPlannerCtx();
+  const { getDayWindow } = useFeaturesCtx();
+
+  // currentTime ticks every minute, so the numbers roll forward while the
+  // window sits idle and the date flips correctly at midnight.
+  const todayStr = dateToString(currentTime);
+  const summary = useMemo(
+    () => computeDaySummary(
+      getTasksForDate(new Date(currentTime), false),
+      listEndOfDayTime,
+      getDayWindow?.(todayStr) ?? null,
+    ),
+    [getTasksForDate, listEndOfDayTime, getDayWindow, currentTime, todayStr],
+  );
+
+  // Nothing to measure (empty day, no declared window): leave the bar empty.
+  if (summary.unblockedMinutes === null) return null;
+
+  const pill = summaryPillClass(darkMode);
+  const chipValue = (total, done, completable) =>
+    done > 0 ? `${formatMinutes(done)}/${formatMinutes(completable)}` : formatMinutes(total);
+
+  return (
+    <div className="flex items-center gap-1.5 text-xs font-normal overflow-hidden max-w-full">
+      <span className={pill}>
+        <span className={`font-semibold ${textPrimary}`}>{formatMinutes(summary.unblockedMinutes)}</span>
+        <span className={textSecondary}>unblocked</span>
+      </span>
+      {summary.blockedMinutes > 0 && (
+        <span className={pill}>
+          <Zap size={12} className="flex-shrink-0" style={{ color: EFFORT_DOT }} />
+          <span className={textSecondary}>{formatMinutes(summary.effortMinutes)}</span>
+          <Leaf size={12} className="flex-shrink-0 ml-0.5" style={{ color: RESTORE_DOT }} />
+          <span className={textSecondary}>{formatMinutes(summary.restoreMinutes)}</span>
+        </span>
+      )}
+      {summary.categories.map((c) => (
+        <span key={c.tag} className={pill}>
+          <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: c.colorHex }} />
+          <span className={textPrimary}>#{c.tag}</span>
+          <span className={textSecondary}>{chipValue(c.minutes, c.doneMinutes, c.completableMinutes)}</span>
+        </span>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
The "crazy idea", v1. The macOS title bar was already app-rendered chrome — `titleBarStyle: 'hiddenInset'` plus DesktopLayout's 28px drag-region div (home of the NOW bar) — so the summary strip up there is **the same React pills**, not a re-creation.

## What it does

- When **no task is running**: the bar shows **today's** summary — `3h 20m unblocked` · `⚡2h 🍃1h` · tag chips (with the same quiet-until-progress `done/planned` values as the strip).
- When **a task is running**: the amber NOW bar renders exactly as before — it keeps priority, never both.
- Empty day with no declared window: the bar stays empty (no setup hint in the title bar — that lives in the timeline strip).

## Design decisions

- **Identical visuals by construction**: `SummaryStrip` now exports `summaryPillClass`, `EFFORT_DOT`, `RESTORE_DOT`, and `TitlebarSummaryStrip` imports them — one pill definition, zero drift. Same `computeDaySummary` math.
- **Display-only, deliberately**: the entire bar remains a `WebkitAppRegion: drag` area with no no-drag carve-outs. No day-window menu up there — editing stays in the timeline strip. This keeps window-dragging working everywhere in the bar and the v1 scope honest.
- **Always today**: a title bar is global chrome, not tied to the selected date. Recomputes on the ticking `currentTime`, so numbers roll forward while idle and the date flips at midnight.
- **Finite width**: untagged chip omitted; overflowing tag chips clip at the right edge. If it feels crowded on smaller windows we can cap to headline pills only.

Pill height (`py-1` + text-xs + borders ≈ 26px) fits the 28px bar with a hair of clearance.

## Verification

- `npx eslint src --max-warnings 0` — clean; `npx vitest run` — 1107 green; all four bundles build.
- Needs your eyes on a real Mac: pill legibility over the app background at 28px, drag behavior over the pills, NOW bar handoff when a task starts/ends, and whether tag chips feel like too much (easy to cap to headline-only).

Independent of #1311/#1312/#1313 — merge in any order. (Tiny heads-up: #1312 also touches `SummaryStrip.jsx`; regions don't overlap, so no conflict expected.)