### PR TITLE
Vault SSE client: make code, comments, and tests tell the wire truth

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/sse/SseFraming.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/sse/SseFraming.kt
@@ -6,10 +6,11 @@ package com.dayglance.app.sse
  *
  * It does ONLY transport-level framing: accumulate stream text across reads, split
  * complete event blocks on the blank-line delimiter, and hand each block back
- * verbatim. It deliberately does NOT parse `{seq,kind}` — that extraction stays in
- * the renderer's single `parseSseFrame`, which this shell feeds each block through
- * via the bridge. Keeping ONE `{seq,kind}` parser (in the renderer) is the whole
- * point of the bridge-fed design: the native side is a dumb, robust byte framer.
+ * verbatim. It deliberately does NOT parse the `{seq}` nudge — that extraction
+ * stays in the renderer's single `parseSseFrame`, which this shell feeds each
+ * block through via the bridge. Keeping ONE nudge parser (in the renderer) is the
+ * whole point of the bridge-fed design: the native side is a dumb, robust byte
+ * framer.
  *
  * Stateful per instance (holds the partial-block remainder between reads) and pure
  * otherwise, so it is unit-testable with no network.

--- a/dayglance-android/app/src/main/java/com/dayglance/app/sse/VaultSseClient.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/sse/VaultSseClient.kt
@@ -39,9 +39,10 @@ import kotlin.coroutines.coroutineContext
  * ([SseBackoff]). Every transition funnels through [reconcile], which starts or
  * stops the SINGLE reader coroutine, so there is never more than one connection.
  *
- * RECONNECT-RECONCILE — on each (re)connect the vault sends an initial
- * `{seq, kind:"connected"}` frame; it flows through [frameSink] like any other, so
- * the renderer's coalescer drains and catches anything missed while disconnected.
+ * RECONNECT-RECONCILE — on each (re)connect the vault sends its `ready` frame
+ * carrying the account's latest seq (`{"seq":N}`); it flows through [frameSink]
+ * like any other, so the renderer's coalescer drains and catches anything missed
+ * while disconnected.
  */
 class VaultSseClient(
     private val frameSink: (String) -> Unit,

--- a/dayglance-ios/DayGlance/Bridges/VaultSseBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/VaultSseBridge.swift
@@ -24,7 +24,7 @@ import WebKit
 /// native → JS (window.__glanceVaultSseReceive(msg)):
 ///   • {type:"open"}                  a (re)connection was established.
 ///   • {type:"frame", block:"<raw SSE event block>"}   one SSE event; the renderer
-///     runs it through parseSseFrame → {seq,kind} → coalescer.
+///     runs it through parseSseFrame → {seq} → coalescer.
 ///   • {type:"closed"}                the stream dropped (we will reconnect).
 ///   • {type:"error", message}        a connect/read error (we own the retry).
 ///
@@ -33,9 +33,9 @@ import WebKit
 /// ContentView's scenePhase). It drops on background and reconnects with capped
 /// exponential backoff on any drop. Every transition funnels through [reconcile],
 /// which starts or cancels the SINGLE reader Task, so there is never more than one
-/// connection. On each (re)connect the vault sends an initial `{seq,kind:"connected"}`
-/// frame; it flows through as a normal frame, so the coalescer reconciles anything
-/// missed while disconnected.
+/// connection. On each (re)connect the vault sends its `ready` frame carrying the
+/// account's latest seq (`{"seq":N}`); it flows through as a normal frame, so the
+/// coalescer reconciles anything missed while disconnected.
 final class VaultSseBridge {
 
     static let shared = VaultSseBridge()

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -2,9 +2,9 @@
 //
 // Opens the authenticated /events stream when the vault is enabled AND the app is
 // active, turns nudges into instant drains of the EXISTING sync/intents drains
-// (debounced), reconnects with backoff on any drop, reconciles via the initial
-// {seq, kind:'connected'} on (re)connect, and tears the connection down cleanly
-// on background / unmount / vault-disabled. The pure transport lives in
+// (debounced), reconnects with backoff on any drop, reconciles via the server's
+// initial `ready` frame (the account's latest seq) on (re)connect, and tears the
+// connection down cleanly on background / unmount / vault-disabled. The pure transport lives in
 // ../sync/vaultEventStream.js; this file only wires it to React + the app.
 //
 // CORE INVARIANT: this is purely ADDITIVE. It never starts, stops, or slows the
@@ -75,7 +75,6 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
       events: 0,
       drains: 0,
       lastEventSeq: null,
-      lastEventKind: null,
       lastError: null,
       terminal: null,
       lastConnectedAt: null,
@@ -107,7 +106,7 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
     // socket owner differs (JS fetch loop vs native shell).
     const onEvent = (evt) => {
       diag.events += 1;
-      if (evt && typeof evt.seq === 'number') { diag.lastEventSeq = evt.seq; diag.lastEventKind = evt.kind; }
+      if (evt && typeof evt.seq === 'number') diag.lastEventSeq = evt.seq;
       coalescer.handleEvent(evt);
     };
     const onStateChange = (state, detail) => {
@@ -169,7 +168,7 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
     });
 
     // Drop SSE on background, reopen on foreground. The (re)connect delivers a
-    // fresh {seq, kind:'connected'} that reconciles anything missed while hidden;
+    // fresh `ready` seq that reconciles anything missed while hidden;
     // polling/foreground-drain covers the gap regardless.
     const onVisibility = () => {
       if (document.visibilityState === 'visible') client.start();

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -1,9 +1,18 @@
 // GLANCEvault SSE push client (Phase 9, client step 1).
 //
-// The glance-vault server emits authenticated per-account Server-Sent Events at
-// GET {vaultUrl}/events: an initial {seq, kind:'connected'} on connect, then
-// {seq, kind:'sync'|'intents'} nudges when the account's seq advances, plus ~25s
-// heartbeat comments. A nudge carries ONLY the latest account seq — no payload.
+// WIRE CONTRACT (verified against the glance-vault server source — routes/events.ts
+// frame(), realtime/hub.ts Nudge): the server emits authenticated per-account
+// named SSE events at GET {vaultUrl}/events whose data is exactly {"seq":N}:
+//   • `event: ready`    — once per successful connection, carrying the account's
+//     latest seq (0 for a never-written account); the reconnect reconcile point.
+//   • `event: activity` — whenever the account seq advances.
+// plus comment-line heartbeats (`: ...`) every ~20s. Nothing else is on the wire:
+// no kind/scope discriminator, no `id:`, no `retry:` (reconnect timing is entirely
+// client-owned; the server never reads Last-Event-ID). A nudge carries ONLY the
+// latest account seq — no payload, and no hint of WHAT advanced: sync writes,
+// intent landings, and blob bookkeeping all draw from the one per-account counter
+// (blob bookkeeping without even emitting), so the only correct response to any
+// nudge is to drain everything.
 //
 // This module is the PURE, transport-level core (no React). It exists to let
 // dayGLANCE drain INSTANTLY on a nudge instead of waiting for the poll, while the
@@ -55,9 +64,10 @@
 //   or JSON string):
 //     • {type:'open'}                     a native (re)connection was established.
 //     • {type:'frame', block:'<raw SSE event block>'}   one SSE event; the renderer
-//       runs it through the EXISTING parseSseFrame → {seq,kind} → coalescer. On a
-//       native reconnect the server's initial {seq,kind:'connected'} arrives as a
-//       frame here, so reconnect-reconcile is automatic (coalescer drains both).
+//       runs it through the EXISTING parseSseFrame → {seq} → coalescer. On a
+//       native reconnect the server's `ready` frame (latest account seq) arrives
+//       as a frame here, so reconnect-reconcile is automatic (an advanced seq
+//       drains everything).
 //     • {type:'closed'}                   the native stream dropped (native will
 //       reconnect); informational for diagnostics.
 //     • {type:'error', message}           a native connect/read error; native owns
@@ -69,12 +79,15 @@
 
 /**
  * Parse ONE SSE event block (the text between blank-line boundaries) into the
- * nudge object {seq, kind}, or null if the block carries no usable data.
+ * nudge object {seq}, or null if the block carries no usable data.
  *
- * Ignores comment lines (leading ':', used for heartbeats) and non-data fields
- * (event:, id:, retry:). Concatenates multiple data: lines per the SSE spec, then
- * JSON-parses. Returns null on a heartbeat-only block or unparseable data so the
- * caller can skip it.
+ * The event NAME (`ready` | `activity`) is deliberately not surfaced: both carry
+ * the same instruction — the account seq advanced past what we knew — so the
+ * data line is the whole contract. Ignores comment lines (leading ':', used for
+ * heartbeats) and non-data fields (event:, id:, retry: — the server sends only
+ * event: and data: today; tolerating the rest is plain SSE-spec hygiene).
+ * Concatenates multiple data: lines per the SSE spec, then JSON-parses. Returns
+ * null on a heartbeat-only block or unparseable data so the caller can skip it.
  */
 export function parseSseFrame(block) {
   if (!block) return null;
@@ -148,12 +161,14 @@ export function detectSseTransport() {
 }
 
 /**
- * True only when the native shell exposes a working native SSE reader. Probed via
- * an explicit capability method so:
+ * True only when the native shell exposes a working native SSE reader. Both
+ * shells ship one today (Android VaultSseClient.kt, iOS VaultSseBridge.swift),
+ * but the probe stays strict because a bridge's mere method presence proves
+ * nothing:
  *   • an OLDER Android shell (bridge present, no startVaultSse) → false → polling;
- *   • the iOS shell whose bridge is a Proxy fabricating EVERY method name still
- *     reports false until its handler actually returns true (its stubbed reply is
- *     the string "null", not true), so iOS keeps polling until its reader ships.
+ *   • the iOS bridge is a Proxy that fabricates EVERY method name — an
+ *     unimplemented probe there replies the string "null", not true — so only a
+ *     shell whose handler genuinely implements the reader can probe true.
  * Only a literal boolean true (or the string 'true') counts as supported.
  */
 function nativeSseSupported(bridge) {
@@ -170,7 +185,7 @@ function nativeSseSupported(bridge) {
 
 /**
  * Open the vault /events SSE stream over a fetch streaming body (WEB path) and
- * pump parsed {seq, kind} nudges to onEvent until the stream ends or the signal
+ * pump parsed {seq} nudges to onEvent until the stream ends or the signal
  * aborts. Authenticates with the same device-token Bearer the other vault calls
  * use and scopes to accountId (query param, mirroring the sync/intents endpoints).
  *
@@ -223,20 +238,23 @@ export async function openWebSseStream({ connection, signal, onOpen, onEvent, fe
  * Turns a stream of nudge events into debounced drain calls, with a seq cursor so
  * stale/duplicate nudges are ignored.
  *
- * The account seq is a single unified monotonic counter on the server (a sync
- * write and an intent landing both advance it), so ONE cursor across kinds is
+ * The account seq is a single unified monotonic counter on the server — sync
+ * writes, intent landings, and blob bookkeeping all advance it — so ONE cursor is
  * correct: an event is "behind" (worth acting on) only when its seq exceeds the
  * highest we've already reacted to. A nudge whose seq is <= the cursor is a
  * duplicate/stale signal and is ignored.
  *
- * On acting, we schedule the drain implied by kind: 'sync' -> sync drain,
- * 'intents' -> intents drain, anything else (incl. the 'connected' reconcile) ->
- * BOTH, since we can't tell which side advanced. Rapid nudges within debounceMs
- * coalesce into a single drain per kind.
+ * Every accepted nudge drains BOTH sides. The wire carries no scope (data is
+ * exactly {"seq":N}), and the shared counter means a scope couldn't safely
+ * narrow a drain even if one existed — the client can never tell which side
+ * advanced, and blob bookkeeping advances the seq while emitting nothing at all.
+ * Rapid nudges within debounceMs coalesce into a single drain pair.
  *
- * onDrain(kind) is called with 'sync' or 'intents' (never 'both' — 'both' fans
- * out to one 'sync' + one 'intents' call). It is invoked inside a try/catch so a
- * throwing drain can never break the debounce timer or the SSE loop.
+ * onDrain(kind) is called with 'sync' then 'intents' on each flush. The split
+ * callback is kept deliberately: it is the ONE seam where routing would slot in
+ * if a future server ever scoped its nudges — no such protocol exists or is
+ * planned today. It is invoked inside a try/catch so a throwing drain can never
+ * break the debounce timer or the SSE loop.
  *
  * @param {object} p
  * @param {(kind:'sync'|'intents') => void} p.onDrain
@@ -254,7 +272,6 @@ export function createNudgeCoalescer({
 } = {}) {
   let lastSeq = -Infinity;
   let timer = null;
-  let pending = new Set();
 
   const runDrain = (kind) => {
     try {
@@ -266,11 +283,9 @@ export function createNudgeCoalescer({
 
   const flush = () => {
     timer = null;
-    const kinds = pending;
-    pending = new Set();
     // Deterministic order: sync before intents.
-    if (kinds.has('sync')) runDrain('sync');
-    if (kinds.has('intents')) runDrain('intents');
+    runDrain('sync');
+    runDrain('intents');
   };
 
   // Coalesce a micro-burst of nudges into a single drain (debounce ONLY — no
@@ -279,9 +294,7 @@ export function createNudgeCoalescer({
   // longer advances the account seq or nudges (see utils/tombstoneHorizon.js).
   // Drains therefore fire near-instantly on real changes, which is the point of
   // SSE. Polling remains the backstop for any coalesced nudge.
-  const schedule = (kind) => {
-    if (kind === 'both') { pending.add('sync'); pending.add('intents'); }
-    else pending.add(kind);
+  const schedule = () => {
     if (timer) clearTimeoutFn(timer);
     timer = setTimeoutFn(flush, debounceMs);
   };
@@ -294,17 +307,15 @@ export function createNudgeCoalescer({
     if (!evt || typeof evt.seq !== 'number' || Number.isNaN(evt.seq)) return false;
     if (evt.seq <= lastSeq) return false; // not behind — coalesced/stale, ignore
     lastSeq = evt.seq;
-    if (evt.kind === 'sync') schedule('sync');
-    else if (evt.kind === 'intents') schedule('intents');
-    else schedule('both'); // 'connected' reconcile or unknown kind → drain both
+    schedule();
     return true;
   };
 
   return {
     handleEvent,
     getCursor: () => lastSeq,
-    // Flush any pending debounce immediately (used on teardown if desired).
-    cancel: () => { if (timer) { clearTimeoutFn(timer); timer = null; } pending = new Set(); },
+    // Cancel any pending debounce (used on teardown).
+    cancel: () => { if (timer) { clearTimeoutFn(timer); timer = null; } },
   };
 }
 
@@ -434,7 +445,7 @@ export function createVaultEventClient({
  * @param {() => ({vaultUrl:string,vaultToken:string,accountId:string}|null)} p.getConnection
  * @param {(c:object) => void} p.startNative  tell the shell to open (given the connection)
  * @param {() => void}         p.stopNative   tell the shell to tear down
- * @param {(evt:object) => void} p.onEvent    parsed {seq,kind} frame → coalescer.handleEvent
+ * @param {(evt:object) => void} p.onEvent    parsed {seq} frame → coalescer.handleEvent
  * @param {(state:string, detail?:any) => void} [p.onStateChange]
  * @param {boolean} [p.supported]
  * @param {(block:string, onEvent:(e:object)=>void) => void} [p.parseFrame] injectable (tests)
@@ -464,7 +475,7 @@ export function createBridgeSseClient({
         break;
       case 'frame': {
         // Reuse the EXISTING parser: native did transport + frame boundary
-        // detection; {seq,kind} extraction stays in ONE place (parseSseFrame).
+        // detection; {seq} extraction stays in ONE place (parseSseFrame).
         if (typeof msg.block === 'string') {
           const evt = parseSseFrame(msg.block);
           if (evt) onEvent?.(evt);

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -26,27 +26,33 @@ import {
 //     unit-tested below by faking window.
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Frame-level tests use the server's REAL wire blocks: named events `ready`
+// (once per successful connection) and `activity` (seq advanced), data exactly
+// {"seq":N}, comment-line heartbeats. There is no kind/scope field on the wire.
 describe('parseSseFrame', () => {
-  it('parses a data: line as JSON into {seq, kind}', () => {
-    expect(parseSseFrame('data: {"seq":5,"kind":"sync"}')).toEqual({ seq: 5, kind: 'sync' });
+  it('parses a real ready frame — the event name is ignored, data is the contract', () => {
+    expect(parseSseFrame('event: ready\ndata: {"seq":3}')).toEqual({ seq: 3 });
+  });
+
+  it('parses a real activity frame', () => {
+    expect(parseSseFrame('event: activity\ndata: {"seq":7}')).toEqual({ seq: 7 });
   });
 
   it('ignores heartbeat/comment lines (leading colon) → null', () => {
-    expect(parseSseFrame(': keep-alive')).toBeNull();
+    expect(parseSseFrame(': heartbeat')).toBeNull();
   });
 
-  it('ignores event:/id: fields and reads only data:', () => {
-    const block = 'event: intents\nid: 9\ndata: {"seq":9,"kind":"intents"}';
-    expect(parseSseFrame(block)).toEqual({ seq: 9, kind: 'intents' });
+  it('tolerates id:/retry: fields the server never sends today (SSE-spec hygiene)', () => {
+    const block = 'event: activity\nid: 9\nretry: 3000\ndata: {"seq":9}';
+    expect(parseSseFrame(block)).toEqual({ seq: 9 });
   });
 
   it('concatenates multiple data: lines before JSON.parse', () => {
-    const block = 'data: {"seq":3,\ndata: "kind":"connected"}';
-    expect(parseSseFrame(block)).toEqual({ seq: 3, kind: 'connected' });
+    expect(parseSseFrame('data: {"seq":\ndata: 3}')).toEqual({ seq: 3 });
   });
 
   it('returns null for a block with no data', () => {
-    expect(parseSseFrame('event: ping')).toBeNull();
+    expect(parseSseFrame('event: ready')).toBeNull();
   });
 
   it('returns null for unparseable data', () => {
@@ -58,23 +64,23 @@ describe('drainSseBuffer', () => {
   it('emits complete frames and returns the partial remainder', () => {
     const events = [];
     const rest = drainSseBuffer(
-      'data: {"seq":1,"kind":"sync"}\n\ndata: {"seq":2,"kind":"intents"}\n\ndata: {"seq":3',
+      'event: ready\ndata: {"seq":1}\n\nevent: activity\ndata: {"seq":2}\n\nevent: activity\ndata: {"seq":3',
       (e) => events.push(e),
     );
-    expect(events).toEqual([{ seq: 1, kind: 'sync' }, { seq: 2, kind: 'intents' }]);
-    expect(rest).toBe('data: {"seq":3'); // partial frame carried forward
+    expect(events).toEqual([{ seq: 1 }, { seq: 2 }]);
+    expect(rest).toBe('event: activity\ndata: {"seq":3'); // partial frame carried forward
   });
 
   it('normalizes CRLF frame boundaries', () => {
     const events = [];
-    drainSseBuffer('data: {"seq":7,"kind":"sync"}\r\n\r\n', (e) => events.push(e));
-    expect(events).toEqual([{ seq: 7, kind: 'sync' }]);
+    drainSseBuffer('event: activity\r\ndata: {"seq":7}\r\n\r\n', (e) => events.push(e));
+    expect(events).toEqual([{ seq: 7 }]);
   });
 
   it('skips heartbeat frames', () => {
     const events = [];
-    const rest = drainSseBuffer(': hb\n\ndata: {"seq":4,"kind":"sync"}\n\n', (e) => events.push(e));
-    expect(events).toEqual([{ seq: 4, kind: 'sync' }]);
+    const rest = drainSseBuffer(': heartbeat\n\nevent: activity\ndata: {"seq":4}\n\n', (e) => events.push(e));
+    expect(events).toEqual([{ seq: 4 }]);
     expect(rest).toBe('');
   });
 });
@@ -110,9 +116,10 @@ describe('detectSseTransport', () => {
   });
 
   it('stays native-unsupported when the shell fabricates methods but the probe is not true (iOS Proxy)', () => {
-    // Mirrors iOS's Proxy bridge: every method name resolves to a function, but the
-    // unimplemented capability probe replies with the string "null" — not true — so
-    // iOS keeps polling until its native reader ships.
+    // Mirrors the iOS Proxy bridge PATTERN: every method name resolves to a
+    // function, so mere presence proves nothing. An unimplemented capability
+    // probe replies the string "null" — not true — so a shell without a real
+    // reader (an older build, or a stub) stays on polling.
     global.window = {
       DayGlanceNative: new Proxy({ httpRequest: () => {} }, {
         get(target, prop) {
@@ -142,27 +149,28 @@ describe('createNudgeCoalescer — seq cursor + debounce', () => {
     const onDrain = vi.fn();
     const c = createNudgeCoalescer({ onDrain, debounceMs: 100 });
 
-    expect(c.handleEvent({ seq: 5, kind: 'sync' })).toBe(true); // ahead → act
-    expect(c.handleEvent({ seq: 5, kind: 'sync' })).toBe(false); // equal → ignore
-    expect(c.handleEvent({ seq: 4, kind: 'sync' })).toBe(false); // behind → ignore
+    expect(c.handleEvent({ seq: 5 })).toBe(true); // ahead → act
+    expect(c.handleEvent({ seq: 5 })).toBe(false); // equal → ignore
+    expect(c.handleEvent({ seq: 4 })).toBe(false); // behind → ignore
 
     vi.advanceTimersByTime(100);
-    expect(onDrain).toHaveBeenCalledTimes(1);
-    expect(onDrain).toHaveBeenCalledWith('sync');
+    // The wire carries no scope, and the shared account counter means none could
+    // safely narrow a drain → every accepted nudge drains BOTH sides.
+    expect(onDrain.mock.calls.map((a) => a[0])).toEqual(['sync', 'intents']);
   });
 
-  it('coalesces a rapid burst of nudges into a single drain', () => {
+  it('coalesces a rapid burst of nudges into a single drain pair', () => {
     const onDrain = vi.fn();
     const c = createNudgeCoalescer({ onDrain, debounceMs: 100 });
 
-    c.handleEvent({ seq: 1, kind: 'sync' });
-    c.handleEvent({ seq: 2, kind: 'sync' });
-    c.handleEvent({ seq: 3, kind: 'sync' });
+    c.handleEvent({ seq: 1 });
+    c.handleEvent({ seq: 2 });
+    c.handleEvent({ seq: 3 });
     vi.advanceTimersByTime(50); // still within debounce
-    c.handleEvent({ seq: 4, kind: 'sync' });
+    c.handleEvent({ seq: 4 });
     vi.advanceTimersByTime(100);
 
-    expect(onDrain).toHaveBeenCalledTimes(1); // one drain for the whole burst
+    expect(onDrain).toHaveBeenCalledTimes(2); // ONE sync + ONE intents for the whole burst
     expect(c.getCursor()).toBe(4);
   });
 
@@ -170,31 +178,29 @@ describe('createNudgeCoalescer — seq cursor + debounce', () => {
     const onDrain = vi.fn();
     const c = createNudgeCoalescer({ onDrain, debounceMs: 400 });
 
-    c.handleEvent({ seq: 1, kind: 'sync' });
+    c.handleEvent({ seq: 1 });
     vi.advanceTimersByTime(400);
-    expect(onDrain).toHaveBeenCalledTimes(1); // fired at the debounce, no 5s throttle
+    expect(onDrain).toHaveBeenCalledTimes(2); // fired at the debounce, no 5s throttle
 
     // A second real change a moment later drains again promptly — not withheld for
     // any multi-second throttle window.
-    c.handleEvent({ seq: 2, kind: 'sync' });
+    c.handleEvent({ seq: 2 });
     vi.advanceTimersByTime(400);
-    expect(onDrain).toHaveBeenCalledTimes(2);
+    expect(onDrain).toHaveBeenCalledTimes(4);
   });
 
-  it("routes kind to the matching drain; a 'sync' nudge does not drain intents", () => {
+  it('drains sync BEFORE intents on every flush (deterministic order)', () => {
     const onDrain = vi.fn();
     const c = createNudgeCoalescer({ onDrain, debounceMs: 100 });
-    c.handleEvent({ seq: 10, kind: 'sync' });
+    c.handleEvent({ seq: 10 });
     vi.advanceTimersByTime(100);
-    expect(onDrain).toHaveBeenCalledTimes(1);
-    expect(onDrain).toHaveBeenCalledWith('sync');
-    expect(onDrain).not.toHaveBeenCalledWith('intents');
+    expect(onDrain.mock.calls.map((a) => a[0])).toEqual(['sync', 'intents']);
   });
 
-  it("drains BOTH on a 'connected' reconcile and on unknown kinds", () => {
+  it('the ready reconcile frame is just a nudge — an advanced seq drains both sides', () => {
     const onDrain = vi.fn();
     const c = createNudgeCoalescer({ onDrain, debounceMs: 100 });
-    c.handleEvent({ seq: 20, kind: 'connected' });
+    c.handleEvent({ seq: 20 }); // ready delivers {"seq":N} like any activity frame
     vi.advanceTimersByTime(100);
     expect(onDrain.mock.calls.map((a) => a[0])).toEqual(['sync', 'intents']);
   });
@@ -203,13 +209,13 @@ describe('createNudgeCoalescer — seq cursor + debounce', () => {
     const onDrain = vi.fn(() => { throw new Error('boom'); });
     const onDrainError = vi.fn();
     const c = createNudgeCoalescer({ onDrain, onDrainError, debounceMs: 50 });
-    c.handleEvent({ seq: 1, kind: 'sync' });
+    c.handleEvent({ seq: 1 });
     expect(() => vi.advanceTimersByTime(50)).not.toThrow();
-    expect(onDrainError).toHaveBeenCalled();
+    expect(onDrainError).toHaveBeenCalledTimes(2); // both throwing drains surfaced
     // A later nudge still acts — the coalescer self-heals.
-    c.handleEvent({ seq: 2, kind: 'intents' });
+    c.handleEvent({ seq: 2 });
     vi.advanceTimersByTime(50);
-    expect(onDrain).toHaveBeenCalledTimes(2);
+    expect(onDrain).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -276,8 +282,8 @@ describe('createVaultEventClient — lifecycle, reconnect, reconcile', () => {
     });
     client.start();
     expect(s.calls).toHaveLength(1);
-    s.push({ seq: 1, kind: 'sync' });
-    expect(events).toEqual([{ seq: 1, kind: 'sync' }]);
+    s.push({ seq: 1 });
+    expect(events).toEqual([{ seq: 1 }]);
     client.stop();
   });
 
@@ -296,8 +302,9 @@ describe('createVaultEventClient — lifecycle, reconnect, reconcile', () => {
     });
 
     client.start();
-    // First connect: server reports current account seq 5 → reconcile drains both.
-    s.calls[0].onEvent({ seq: 5, kind: 'connected' });
+    // First connect: the server's `ready` frame reports account seq 5 →
+    // reconcile drains both.
+    s.calls[0].onEvent({ seq: 5 });
     vi.advanceTimersByTime(10);
     expect(onDrain).toHaveBeenCalledTimes(2); // sync + intents
     onDrain.mockClear();
@@ -312,7 +319,7 @@ describe('createVaultEventClient — lifecycle, reconnect, reconcile', () => {
     await Promise.resolve(); await Promise.resolve();
     expect(s.calls.length).toBeGreaterThanOrEqual(2);
     const reconnected = s.calls[s.calls.length - 1];
-    reconnected.onEvent({ seq: 7, kind: 'connected' }); // catches the missed change
+    reconnected.onEvent({ seq: 7 }); // fresh ready seq catches the missed change
     vi.advanceTimersByTime(10);
     expect(onDrain).toHaveBeenCalledTimes(2); // reconcile drain on reconnect
 
@@ -449,9 +456,9 @@ describe('createVaultEventClient — lifecycle, reconnect, reconcile', () => {
 describe('openWebSseStream — web fetch-stream path', () => {
   it('sets the Bearer header + accountId, and pumps parsed frames', async () => {
     const chunks = [
-      'data: {"seq":1,"kind":"connected"}\n\n',
+      'event: ready\ndata: {"seq":1}\n\n',
       ': heartbeat\n\n',
-      'data: {"seq":2,"kind":"sync"}\n\n',
+      'event: activity\ndata: {"seq":2}\n\n',
     ];
     let i = 0;
     const reader = {
@@ -478,7 +485,7 @@ describe('openWebSseStream — web fetch-stream path', () => {
     expect(capturedInit.headers.Authorization).toBe('Bearer tok-9');
     expect(capturedInit.headers.Accept).toBe('text/event-stream');
     expect(onOpen).toHaveBeenCalledTimes(1);
-    expect(events).toEqual([{ seq: 1, kind: 'connected' }, { seq: 2, kind: 'sync' }]);
+    expect(events).toEqual([{ seq: 1 }, { seq: 2 }]);
   });
 
   it('throws on a non-OK response so the client reconnects (never a silent hang)', async () => {
@@ -532,11 +539,11 @@ describe('createBridgeSseClient — native bridge-fed transport', () => {
       onEvent: (e) => events.push(e),
     });
     // native pushes a raw SSE block (its transport did frame-boundary detection).
-    client.receive({ type: 'frame', block: 'data: {"seq":11,"kind":"sync"}' });
+    client.receive({ type: 'frame', block: 'event: activity\ndata: {"seq":11}' });
     // heartbeat/comment block → parseSseFrame returns null → ignored.
-    client.receive({ type: 'frame', block: ': keep-alive' });
-    client.receive({ type: 'frame', block: 'data: {"seq":12,"kind":"intents"}' });
-    expect(events).toEqual([{ seq: 11, kind: 'sync' }, { seq: 12, kind: 'intents' }]);
+    client.receive({ type: 'frame', block: ': heartbeat' });
+    client.receive({ type: 'frame', block: 'event: activity\ndata: {"seq":12}' });
+    expect(events).toEqual([{ seq: 11 }, { seq: 12 }]);
   });
 
   it('END-TO-END: a pushed frame drives the EXISTING coalescer → drain (reconnect-reconcile too)', () => {
@@ -549,17 +556,16 @@ describe('createBridgeSseClient — native bridge-fed transport', () => {
     });
     client.start();
 
-    // A real sync change nudged in from native → sync drain.
-    client.receive({ type: 'frame', block: 'data: {"seq":1,"kind":"sync"}' });
+    // A real change nudged in from native → both drains (nudges carry no scope).
+    client.receive({ type: 'frame', block: 'event: activity\ndata: {"seq":1}' });
     vi.advanceTimersByTime(10);
-    expect(onDrain).toHaveBeenCalledTimes(1);
-    expect(onDrain).toHaveBeenCalledWith('sync');
+    expect(onDrain.mock.calls.map((a) => a[0])).toEqual(['sync', 'intents']);
     onDrain.mockClear();
 
-    // Native reconnects → server's initial 'connected' frame arrives here →
-    // reconcile drains BOTH (catches anything missed while the socket was down).
+    // Native reconnects → the server's `ready` frame arrives here → reconcile
+    // drains BOTH (catches anything missed while the socket was down).
     client.receive({ type: 'open' }); // informational
-    client.receive({ type: 'frame', block: 'data: {"seq":5,"kind":"connected"}' });
+    client.receive({ type: 'frame', block: 'event: ready\ndata: {"seq":5}' });
     vi.advanceTimersByTime(10);
     expect(onDrain).toHaveBeenCalledTimes(2); // sync + intents
     vi.useRealTimers();
@@ -571,12 +577,12 @@ describe('createBridgeSseClient — native bridge-fed transport', () => {
       getConnection: () => conn, startNative: () => {}, stopNative: () => {},
       onEvent: (e) => events.push(e),
     });
-    client.receive(JSON.stringify({ type: 'frame', block: 'data: {"seq":3,"kind":"sync"}' }));
+    client.receive(JSON.stringify({ type: 'frame', block: 'event: activity\ndata: {"seq":3}' }));
     // Malformed pushes must never throw.
     expect(() => client.receive('not json')).not.toThrow();
     expect(() => client.receive(null)).not.toThrow();
     expect(() => client.receive({ type: 'frame' })).not.toThrow(); // no block
-    expect(events).toEqual([{ seq: 3, kind: 'sync' }]);
+    expect(events).toEqual([{ seq: 3 }]);
   });
 
   it('routes lifecycle messages to onStateChange (open/closed/error)', () => {


### PR DESCRIPTION
Cleanup ahead of the lastGLANCE port: the vault SSE client's comments and tests described a wire protocol that does not exist. Behavior was already correct — this PR makes the code tell the truth.

## The fiction, and why the client worked anyway

Comments and tests throughout claimed the server sends `{seq, kind:'connected'|'sync'|'intents'}` nudges. The real wire (verified against the glance-vault server source — `routes/events.ts` `frame()`, `realtime/hub.ts` `Nudge` — and confirmed live): named events **`ready`** (once per successful connection, carrying the account's latest seq; 0 for a never-written account) and **`activity`** (seq advanced), data exactly `{"seq":N}`, ~20s comment heartbeats, no `id:`/`retry:`, no kind or scope of any sort.

The client worked because `parseSseFrame` ignores `event:` names — every real frame reached the coalescer kind-less and always took the unknown-kind **drain-both** fallback, which happens to be the correct behavior (nudges aren't scoped, drains are idempotent). The `kind` dispatch was dead code posing as a contract; the tests fabricated frames (one even invented `event: intents`) and so proved routing the server can never exercise.

## Decision: simplify (delete the kind branches), keep the seam

Not "documented-as-speculative" — deleted, because the server-side investigation showed the machinery isn't dead-pending-a-feature, it's dispatch on a field that was never specified, designed, or emittable:

- The emit sites discard the cause before the `Nudge` type (one field: `seq`) is even built; adding a kind is a real wire/interface change, not a latent capability.
- Sync writes, intent landings, **and blob bookkeeping** all draw from one schema-enforced per-account counter — so even a hypothetical kind **could not safely narrow a drain** (the client can't tell which side advanced), and blob bookkeeping advances the seq while emitting nothing, so no kind taxonomy could be complete.
- No design, branch, or spec reference for scoped nudges exists; spec §14 is nudge-only `{seq}`. (The likely origin of the fiction: a name collision with the *entity* `_kind` field of spec §5.2, which is sealed inside the encrypted envelope and never touches SSE.)

**What's kept — the seam**: `onDrain('sync'|'intents')` fires exactly as before, sync before intents on every flush, so the hook wiring (`dbSyncCycle` / `drainDbIntents`) is untouched and any future routing has one dispatch point to slot into. That callback split is the only part of the machinery a real scoped protocol would reuse.

## What changed

- `createNudgeCoalescer`: kind branches and the pending-set removed; every accepted (seq-advancing) nudge schedules one debounced flush that drains sync then intents. Docs rewritten around the unified counter (including the blob-advance subtlety).
- Headers/docs in `vaultEventStream.js` + `useVaultEventStream.js` rewritten to the real contract (incl. 20s heartbeats, client-owned reconnect, `ready` reconcile semantics). Dropped `diag.lastEventKind` — it was **always `undefined`** in production, a live symptom of the fiction.
- Tests: frame-level tests now use **real wire blocks** (`event: ready\ndata: {"seq":3}`, `event: activity\ndata: {"seq":7}`, `: heartbeat`); coalescer tests feed `{seq}`. Assertion strength went **up**: drain *order* is now asserted (previously only membership).
- Stale `nativeSseSupported` doc fixed — the iOS reader shipped in #1155; the strict probe's ongoing purpose (older shells / the iOS Proxy bridge fabricating method names) is now what the comment says. Same fix in the mirrored test comment.
- `{seq,kind}` fiction removed from transport-only comments in `SseFraming.kt`, `VaultSseClient.kt`, `VaultSseBridge.swift` — zero behavior changes in the bridges.

## Verification

- **No behavior change, demonstrated**: the rewritten tests pass against **both** the old and the new implementation (observed directly when an accidental revert ran the new tests over the old code) — against the real wire the two are indistinguishable.
- Mutation checks: swapping drain order kills 4 tests; removing the seq-cursor guard kills 1.
- `npx eslint src --max-warnings 0` clean; **1120 tests** green (net +1); web, Electron, iOS, and Android bundles all build.
- Reconnect/backoff logic untouched (no diff in `createVaultEventClient`).

The lastGLANCE port can now copy this client and inherit the actual contract: connect → `ready.seq` reconcile → any `activity` drains sync + intents → polling stays the correctness backstop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_