### PR TITLE
Island: OS-animated block-progress ring in the compact leading slot

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
@@ -72,7 +72,9 @@ final class LiveActivityBridge {
 
         guard let payload = envelope?.daySummary,
               let date = payload.date,
-              let unblocked = payload.unblocked,
+              // unblocked is the empty-day sentinel, not display data: null
+              // means nothing to measure (the strip shows nothing) → end.
+              payload.unblocked != nil,
               let effort = payload.effort,
               let restore = payload.restore,
               let done = payload.done else {
@@ -88,7 +90,7 @@ final class LiveActivityBridge {
             countdownStart: msToDate(up?.countdownStartMs),
             countdownEnd: msToDate(up?.countdownEndMs),
             inProgress: up?.inProgress ?? false,
-            done: done, unblocked: unblocked, effort: effort, restore: restore)
+            done: done, effort: effort, restore: restore)
         let content = ActivityContent(state: state, staleDate: Date().addingTimeInterval(Self.staleAfter))
 
         Task {

--- a/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
+++ b/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
@@ -35,6 +35,29 @@ private func countdownText(_ state: DaySummaryAttributes.ContentState, fallback:
     }
 }
 
+// The live block-progress RING: same OS-animated mechanism as the countdown
+// text (ProgressView over the interval ticks with zero updates and zero
+// pushes), so the compact leading slot shows shape while the trailing shows
+// number. In progress it drains as the block runs down; upcoming it drains
+// toward the start. Labels are empty on purpose — the numeric countdown
+// already lives on the trailing side, and the empty currentValueLabel is the
+// slot where a per-block energy glyph could later sit inside the ring.
+// Falls back to the hourglass when there is nothing to animate (no more
+// blocks today).
+@ViewBuilder
+private func countdownRing(_ state: DaySummaryAttributes.ContentState) -> some View {
+    if let start = state.countdownStart, let end = state.countdownEnd, start < end {
+        ProgressView(timerInterval: start...end, countsDown: true,
+                     label: { EmptyView() }, currentValueLabel: { EmptyView() })
+            .progressViewStyle(.circular)
+            .tint(unblockedColor)
+    } else {
+        Image(systemName: "hourglass")
+            .foregroundStyle(unblockedColor)
+            .imageScale(.small)
+    }
+}
+
 struct DaySummaryLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: DaySummaryAttributes.self) { context in
@@ -89,8 +112,8 @@ struct DaySummaryLiveActivity: Widget {
                     .opacity(context.isStale ? 0.5 : 1)
                 }
             } compactLeading: {
-                Image(systemName: "hourglass")
-                    .foregroundStyle(unblockedColor)
+                countdownRing(context.state)
+                    .opacity(context.isStale ? 0.5 : 1)
             } compactTrailing: {
                 countdownText(context.state, fallback: context.state.done)
                     .font(.caption2.weight(.semibold))
@@ -100,8 +123,7 @@ struct DaySummaryLiveActivity: Widget {
                     .multilineTextAlignment(.trailing)
                     .opacity(context.isStale ? 0.5 : 1)
             } minimal: {
-                Image(systemName: "hourglass")
-                    .foregroundStyle(unblockedColor)
+                countdownRing(context.state)
             }
         }
     }

--- a/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
+++ b/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
@@ -84,12 +84,16 @@ struct DaySummaryLiveActivity: Widget {
                 }
                 DynamicIslandExpandedRegion(.trailing) {
                     VStack(alignment: .trailing, spacing: 2) {
+                        // Timer text must never wrap: an hours-long countdown
+                        // ("2:02:01") overflows a fixed width at title3, and a
+                        // wrapped timer splits mid-digit. One line, scale down.
                         countdownText(context.state, fallback: context.state.done)
                             .font(.title3.weight(.semibold))
                             .monospacedDigit()
                             .foregroundStyle(unblockedColor)
-                            .frame(maxWidth: 72)
-                            .multilineTextAlignment(.trailing)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.55)
+                            .frame(maxWidth: 84, alignment: .trailing)
                         Text(context.state.blockTitle == nil ? "done"
                              : context.state.inProgress ? "remaining" : "starts in")
                             .font(.caption2)
@@ -98,10 +102,13 @@ struct DaySummaryLiveActivity: Widget {
                     .padding(.trailing, 4)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    HStack(spacing: 14) {
+                    // Three labels can outgrow the row (long done + effort +
+                    // restore values clipped the leaf's number at the edge):
+                    // one line each, shrink together before anything clips.
+                    HStack(spacing: 10) {
                         Label("\(context.state.done) done", systemImage: "checkmark.circle")
                             .foregroundStyle(.secondary)
-                        Spacer()
+                        Spacer(minLength: 6)
                         Label(context.state.effort, systemImage: "bolt.fill")
                             .foregroundStyle(effortColor)
                         Label(context.state.restore, systemImage: "leaf.fill")
@@ -109,6 +116,8 @@ struct DaySummaryLiveActivity: Widget {
                     }
                     .font(.footnote.weight(.medium))
                     .labelStyle(.titleAndIcon)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
                     .opacity(context.isStale ? 0.5 : 1)
                 }
             } compactLeading: {
@@ -119,8 +128,9 @@ struct DaySummaryLiveActivity: Widget {
                     .font(.caption2.weight(.semibold))
                     .monospacedDigit()
                     .foregroundStyle(unblockedColor)
-                    .frame(maxWidth: 56)
-                    .multilineTextAlignment(.trailing)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+                    .frame(maxWidth: 56, alignment: .trailing)
                     .opacity(context.isStale ? 0.5 : 1)
             } minimal: {
                 countdownRing(context.state)
@@ -152,6 +162,8 @@ private struct LockScreenView: View {
                         .foregroundStyle(restoreColor)
                 }
                 .font(.footnote.weight(.medium))
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
                 Text("\(state.done) done")
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
+++ b/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
@@ -2,8 +2,9 @@ import ActivityKit
 import WidgetKit
 import SwiftUI
 
-// Day-summary Live Activity: schedule facts in the Dynamic Island, the
-// summary strip's numbers on the lock screen. Pure metadata plane — short
+// Day-summary Live Activity: schedule facts in the Dynamic Island, and a
+// lock-screen banner that mirrors the expanded island (block + done on the
+// left, countdown + energy on the right). Pure metadata plane — short
 // strings and a countdown interval, no media — rendered from ContentState
 // pushed by the app's LiveActivityBridge; this extension never reads the App
 // Group or computes anything.
@@ -143,18 +144,43 @@ private struct LockScreenView: View {
     let state: DaySummaryAttributes.ContentState
     let isStale: Bool
 
+    // Mirrors the EXPANDED island: block title + time + done progress on the
+    // left, live countdown + energy split on the right. Unblocked time is
+    // in-app currency, not glance currency — it lives in the summary strip,
+    // not here.
     var body: some View {
-        HStack(spacing: 16) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(state.unblocked)
-                    .font(.title2.weight(.semibold))
-                    .foregroundStyle(unblockedColor)
-                Text("unblocked")
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(state.blockTitle ?? "No more blocks today")
+                    .font(.headline)
+                    .lineLimit(2)
+                if let time = state.blockTime {
+                    Text(time)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Label("\(state.done) done", systemImage: "checkmark.circle")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
-            Spacer()
+            Spacer(minLength: 8)
             VStack(alignment: .trailing, spacing: 4) {
+                // Same live countdown as the island; when there is nothing to
+                // count (no more blocks), the right side is just the energy
+                // split — done already sits on the left, so no fallback text.
+                if let start = state.countdownStart, let end = state.countdownEnd, start < end {
+                    Text(timerInterval: start...end, countsDown: true)
+                        .font(.title2.weight(.semibold))
+                        .monospacedDigit()
+                        .foregroundStyle(unblockedColor)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.55)
+                        .frame(maxWidth: 96, alignment: .trailing)
+                    Text(state.inProgress ? "remaining" : "starts in")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
                 HStack(spacing: 10) {
                     Label(state.effort, systemImage: "bolt.fill")
                         .foregroundStyle(effortColor)
@@ -164,9 +190,6 @@ private struct LockScreenView: View {
                 .font(.footnote.weight(.medium))
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
-                Text("\(state.done) done")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
         }
         .padding(14)

--- a/dayglance-ios/Shared/DaySummaryAttributes.swift
+++ b/dayglance-ios/Shared/DaySummaryAttributes.swift
@@ -41,9 +41,10 @@ struct DaySummaryAttributes: ActivityAttributes {
         var inProgress: Bool
         /// "1h 30m/7h" — done/planned.
         var done: String
-        /// "3h 20m" — lock screen only; in-app currency, not glance currency.
-        var unblocked: String
-        /// "5h 30m" effort / "2h 30m" restore — the energy split.
+        /// "5h 30m" effort / "2h 30m" restore — the energy split. Unblocked
+        /// time is deliberately NOT carried: no Live Activity surface renders
+        /// it (in-app currency, not glance currency) — though the bridge still
+        /// reads it from the snapshot as the empty-day end signal.
         var effort: String
         var restore: String
     }


### PR DESCRIPTION
Option A from the island-left-side discussion (the ring), expanded-view overflow fixes from on-device testing, and the lock-screen banner redesigned to mirror the expanded island.

## Commit 1 — the ring

- **Compact leading**: a circular `ProgressView(timerInterval:)` over the *same* `countdownStart...countdownEnd` interval the trailing countdown text uses. The OS animates it every second with **zero updates and zero pushes** — the identical mechanism to the timer text, and the same pattern Apple's Timer app uses in its island. In progress, the ring drains as the block runs down; upcoming, it drains toward the start. Shape on the left, number on the right.
- **Minimal** (shown when two apps have Live Activities at once): the same ring — a draining circle is the natural minimal glyph.
- The hourglass survives only as the fallback when there's no interval to animate (no more blocks today), now `imageScale(.small)`.
- Labels on the ProgressView are deliberately empty: the numeric countdown already lives on the trailing side, and the empty `currentValueLabel` is **exactly the slot where option C would later put a per-block energy glyph inside the ring** (bolt/leaf + matching indigo/green tint). That follow-up needs a small `upNext` payload addition; this change needs **no JS at all** — ContentState already carries the interval.

## Commit 2 — expanded-view overflow fixes (from device screenshot)

An hours-long countdown (`2:02:01`) overflowed the expanded trailing frame at title3 and **wrapped mid-digit** (`2:02:0` / `1`), and the bottom row's restore value was **clipped at the right edge** when done + effort + restore were all long. Standard timer-text treatment applied everywhere a countdown or value row has finite width — `lineLimit(1)` + `minimumScaleFactor`, so text shrinks in place instead of wrapping or clipping:

- Expanded trailing: scale to 0.55, frame widened 72→84pt, trailing-aligned.
- Expanded bottom row: scale to 0.75, spacing 14→10, `Spacer(minLength: 6)`.
- Compact trailing: scale 0.6 guard (previously fit an hours countdown only by luck).
- Lock screen energy row: scale 0.8 guard for long values / large text sizes.

## Commit 3 — lock screen mirrors the expanded island

The banner now answers the same question the island does: **left** = block title + factual time label (`at 6:45 PM` / `until 8:00 PM`) + `✓ 1h 15m/4h done`; **right** = the live countdown (`Text(timerInterval:)` ticks on the lock screen exactly as in the island) with its `remaining`/`starts in` caption, plus the bolt/leaf energy split. When nothing is left today, the right side is just the energy split — done already sits on the left.

**Unblocked now renders on no Live Activity surface** (it's in-app currency; the summary strip owns it), so `ContentState` drops the field rather than carrying one no view reads. The bridge's empty-day lifecycle guard is untouched — it reads `unblocked` from the *snapshot* as the nothing-to-measure sentinel (null → end), now as a presence check.

## Verification

⚠️ Swift-only, **not compiled here** (no Xcode in this container). No new files and no `project.yml` change — plain rebuild in Xcode suffices, no `xcodegen`.

On-device checks:
1. Compact island: ring on the left visibly drains during a block; countdown on the right agrees with it.
2. Between blocks (upcoming), the ring drains toward the block's start time.
3. No more blocks today → small hourglass fallback; lock screen right side shows only the energy split.
4. Start a system Timer while the activity is live → our activity's minimal presentation is the ring.
5. Stale dimming still applies everywhere.
6. With a 2h+ block upcoming/running: expanded countdown stays on one line (smaller if needed), and the bottom row shows the full leaf value with nothing clipped.
7. **Lock screen: block title/time + done on the left, ticking countdown + energy on the right; countdown stays one line even for long durations.**