### PR TITLE
Title bar strip: date pill restored + clickable day-window menu

### DIFF
--- a/src/components/DayWindowMenu.jsx
+++ b/src/components/DayWindowMenu.jsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import ClockTimePicker from './ClockTimePicker.jsx';
+
+/**
+ * The day-window (Starts/Ends) popover — ONE implementation shared by
+ * SummaryStrip (opens upward over the timeline, absolutely positioned in its
+ * container) and TitlebarSummaryStrip (portaled to body, opening downward
+ * under the macOS title bar). Positioning belongs to the CALLER via
+ * anchorClass/anchorStyle on the popover box; the full-screen backdrop and the
+ * clock-picker portal are handled here.
+ *
+ * Menu edits act on the RESOLVED window (day entry or inherited default) —
+ * what the user sees in the inputs is what gets stored. Setting either bound
+ * is sticky-forward (also becomes the default); Clear affects this day only.
+ *
+ * The clock picker is PORTALED to document.body (established pattern:
+ * ProjectCard, SchedTaskCard): SummaryStrip's container is
+ * pointer-events-none (inherited, which made an in-place picker
+ * click-transparent) and its sticky z-30 stacking context would cap the
+ * picker's z-[90] under root-level chrome like the phone FAB. Unset bounds
+ * seed the clock at 08:00 / 22:00 so it has a hand to start from.
+ */
+export default function DayWindowMenu({ dateStr, onClose, anchorClass = '', anchorStyle }) {
+  const {
+    darkMode, textPrimary, textSecondary, borderClass, cardBg,
+    use24HourClock, isTablet, formatTime,
+  } = useDayPlannerCtx();
+  const { getDayWindow, setDayWindow, clearDayWindow } = useFeaturesCtx();
+
+  // Which bound the clock picker is editing: 'start' | 'stop' | null.
+  const [pickerField, setPickerField] = useState(null);
+
+  const dayWindow = getDayWindow?.(dateStr) ?? null;
+
+  const updateWindow = (field, value) => {
+    setDayWindow(dateStr, {
+      start: field === 'start' ? (value || null) : dayWindow?.start ?? null,
+      stop: field === 'stop' ? (value || null) : dayWindow?.stop ?? null,
+    });
+  };
+
+  // Trigger buttons open the same clock picker used everywhere else in the app
+  // (FrameEditor, reminders, routines) instead of a bare native time input.
+  const timeBtnCls = `px-2.5 py-1 rounded-lg border text-xs font-medium ${darkMode ? 'bg-gray-800 border-gray-600 text-gray-200 hover:bg-gray-700' : 'bg-white border-stone-300 text-stone-800 hover:bg-stone-50'}`;
+
+  return (
+    <>
+      {/* Backdrop closes on any outside tap/click. */}
+      <div className="fixed inset-0 z-40 pointer-events-auto" onClick={onClose} />
+      <div
+        className={`${anchorClass} z-50 pointer-events-auto w-72 rounded-lg border shadow-xl p-3 space-y-2.5 text-xs ${cardBg} ${borderClass}`}
+        style={anchorStyle}
+      >
+        <div className={`font-semibold ${textPrimary}`}>Day window</div>
+        <p className={textSecondary}>
+          Applies to this and future days. Unblocked time is measured between
+          the <span className={`font-semibold ${textPrimary}`}>Starts</span> and{' '}
+          <span className={`font-semibold ${textPrimary}`}>Ends</span> window.
+        </p>
+        <div className="flex items-center justify-between gap-3">
+          <span className="flex items-center gap-1.5">
+            <span className={textSecondary}>Starts</span>
+            <button onClick={() => setPickerField('start')} className={timeBtnCls}>
+              {dayWindow?.start ? formatTime(dayWindow.start) : 'Set…'}
+            </button>
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className={textSecondary}>Ends</span>
+            <button onClick={() => setPickerField('stop')} className={timeBtnCls}>
+              {dayWindow?.stop ? formatTime(dayWindow.stop) : 'Set…'}
+            </button>
+          </span>
+        </div>
+        <button
+          onClick={() => { clearDayWindow(dateStr); onClose(); }}
+          className={`w-full py-1 rounded border ${borderClass} ${textSecondary} hover:opacity-80`}
+        >
+          Clear for this day
+        </button>
+      </div>
+      {pickerField && createPortal(
+        <ClockTimePicker
+          value={(pickerField === 'start' ? dayWindow?.start : dayWindow?.stop) ?? (pickerField === 'start' ? '08:00' : '22:00')}
+          onChange={(t) => { updateWindow(pickerField, t); setPickerField(null); }}
+          onClose={() => setPickerField(null)}
+          darkMode={darkMode} isTablet={isTablet ?? false} use24HourClock={use24HourClock}
+        />,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -1,9 +1,8 @@
 import { useMemo, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { ChevronDown, ChevronUp, Leaf, MoreHorizontal, Zap } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
-import ClockTimePicker from './ClockTimePicker.jsx';
+import DayWindowMenu from './DayWindowMenu.jsx';
 import { dateToString, formatShortDate } from '../utils/taskUtils.js';
 import { computeDaySummary, formatMinutes } from '../utils/daySummary.js';
 
@@ -61,11 +60,10 @@ export const summaryPillClass = (darkMode) =>
 export default function SummaryStrip({ phone = false, staticPlacement = false }) {
   const {
     selectedDate, getTasksForDate, listEndOfDayTime,
-    darkMode, textPrimary, textSecondary, borderClass, cardBg,
-    use24HourClock, isTablet, formatTime,
+    darkMode, textPrimary, textSecondary,
   } = useDayPlannerCtx();
   const {
-    getDayWindow, setDayWindow, clearDayWindow,
+    getDayWindow,
     dayWindowMenuOpen: menuOpen, setDayWindowMenuOpen: setMenuOpen,
   } = useFeaturesCtx();
 
@@ -79,9 +77,6 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
     });
   };
 
-  // Which bound the clock picker is editing: 'start' | 'stop' | null.
-  const [pickerField, setPickerField] = useState(null);
-
   const dateStr = dateToString(selectedDate);
   const dayWindow = getDayWindow?.(dateStr) ?? null;
 
@@ -94,20 +89,6 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
   );
 
   const pill = summaryPillClass(darkMode);
-
-  // Menu edits act on the RESOLVED window (day entry or inherited default) —
-  // what the user sees in the inputs is what gets stored. Setting either bound
-  // is sticky-forward (also becomes the default); Clear affects this day only.
-  const updateWindow = (field, value) => {
-    setDayWindow(dateStr, {
-      start: field === 'start' ? (value || null) : dayWindow?.start ?? null,
-      stop: field === 'stop' ? (value || null) : dayWindow?.stop ?? null,
-    });
-  };
-
-  // Trigger buttons open the same clock picker used everywhere else in the app
-  // (FrameEditor, reminders, routines) instead of a bare native time input.
-  const timeBtnCls = `px-2.5 py-1 rounded-lg border text-xs font-medium ${darkMode ? 'bg-gray-800 border-gray-600 text-gray-200 hover:bg-gray-700' : 'bg-white border-stone-300 text-stone-800 hover:bg-stone-50'}`;
 
   const unblockedLabel = (
     <span className="flex items-baseline gap-1">
@@ -143,55 +124,11 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
   return (
     <div className={container}>
       {menuOpen && (
-        <>
-          {/* Backdrop closes on any outside tap/click. */}
-          <div className="fixed inset-0 z-40 pointer-events-auto" onClick={() => setMenuOpen(false)} />
-          <div className={`absolute bottom-full mb-1 left-2 z-50 pointer-events-auto w-72 rounded-lg border shadow-xl p-3 space-y-2.5 text-xs ${cardBg} ${borderClass}`}>
-            <div className={`font-semibold ${textPrimary}`}>Day window</div>
-            <p className={textSecondary}>
-              Applies to this and future days. Unblocked time is measured between
-              the <span className={`font-semibold ${textPrimary}`}>Starts</span> and{' '}
-              <span className={`font-semibold ${textPrimary}`}>Ends</span> window.
-            </p>
-            <div className="flex items-center justify-between gap-3">
-              <span className="flex items-center gap-1.5">
-                <span className={textSecondary}>Starts</span>
-                <button onClick={() => setPickerField('start')} className={timeBtnCls}>
-                  {dayWindow?.start ? formatTime(dayWindow.start) : 'Set…'}
-                </button>
-              </span>
-              <span className="flex items-center gap-1.5">
-                <span className={textSecondary}>Ends</span>
-                <button onClick={() => setPickerField('stop')} className={timeBtnCls}>
-                  {dayWindow?.stop ? formatTime(dayWindow.stop) : 'Set…'}
-                </button>
-              </span>
-            </div>
-            <button
-              onClick={() => { clearDayWindow(dateStr); setMenuOpen(false); }}
-              className={`w-full py-1 rounded border ${borderClass} ${textSecondary} hover:opacity-80`}
-            >
-              Clear for this day
-            </button>
-          </div>
-          {/* Same clock picker as FrameEditor/reminders/routines. PORTALED to
-              document.body (established pattern: ProjectCard, SchedTaskCard),
-              for two reasons this container creates: pointer-events-none is
-              inherited, which made an in-place picker click-transparent (taps
-              fell through to the menu backdrop and closed everything), and the
-              sticky z-30 stacking context would cap the picker's z-[90] below
-              root-level chrome like the phone FAB. Unset bounds seed the clock
-              at 08:00 / 22:00 so it has a hand to start from. */}
-          {pickerField && createPortal(
-            <ClockTimePicker
-              value={(pickerField === 'start' ? dayWindow?.start : dayWindow?.stop) ?? (pickerField === 'start' ? '08:00' : '22:00')}
-              onChange={(t) => { updateWindow(pickerField, t); setPickerField(null); }}
-              onClose={() => setPickerField(null)}
-              darkMode={darkMode} isTablet={isTablet ?? false} use24HourClock={use24HourClock}
-            />,
-            document.body,
-          )}
-        </>
+        <DayWindowMenu
+          dateStr={dateStr}
+          onClose={() => setMenuOpen(false)}
+          anchorClass="absolute bottom-full mb-1 left-2"
+        />
       )}
       {isEmptyHint ? (
         <button

--- a/src/components/TitlebarSummaryStrip.jsx
+++ b/src/components/TitlebarSummaryStrip.jsx
@@ -1,10 +1,12 @@
-import { useMemo } from 'react';
-import { Leaf, Zap } from 'lucide-react';
+import { useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Leaf, MoreHorizontal, Zap } from 'lucide-react';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
-import { dateToString } from '../utils/taskUtils.js';
+import { dateToString, formatShortDate } from '../utils/taskUtils.js';
 import { computeDaySummary, formatMinutes } from '../utils/daySummary.js';
 import { summaryPillClass, EFFORT_DOT, RESTORE_DOT } from './SummaryStrip.jsx';
+import DayWindowMenu from './DayWindowMenu.jsx';
 
 /**
  * macOS title bar summary strip — TODAY's headline numbers in the otherwise
@@ -13,19 +15,21 @@ import { summaryPillClass, EFFORT_DOT, RESTORE_DOT } from './SummaryStrip.jsx';
  * in-timeline strip: class and dot palette are imported from SummaryStrip,
  * not copied, and the math is the same computeDaySummary call.
  *
- * Deliberately DISPLAY-ONLY: the whole bar stays a WebkitAppRegion drag area —
- * no buttons, no day-window menu (the in-timeline strip owns editing), so
- * nothing here needs no-drag carve-outs and dragging the window keeps working
- * everywhere in the bar.
+ * The unblocked pill is INTERACTIVE (WebkitAppRegion no-drag, the one
+ * carve-out): it opens the same shared DayWindowMenu the timeline strip uses,
+ * editing TODAY's window — portaled to document.body and opened DOWNWARD,
+ * because the title bar div is overflow-hidden and sits at the top of the
+ * screen. Everything else stays drag area, so window-dragging keeps working
+ * across the rest of the bar.
  *
  * Always describes TODAY (a title bar is global chrome, not tied to the
  * selected date) and yields entirely to the NOW bar while a task is running —
  * DesktopLayout renders one or the other, never both.
  *
- * Content order matches the strip: unblocked, Effort/Restore, tag chips (with
- * the same quiet-until-progress done/planned values). The untagged chip and
- * empty-day setup hint are omitted — bar width is finite and setup lives in
- * the timeline. Overflowing chips clip at the right edge.
+ * Content order matches the strip: date, unblocked, Effort/Restore, tag chips
+ * (with the same quiet-until-progress done/planned values). The untagged chip
+ * and empty-day setup hint are omitted — bar width is finite and setup lives
+ * in the timeline. Overflowing chips clip at the right edge.
  */
 export default function TitlebarSummaryStrip() {
   const {
@@ -33,6 +37,10 @@ export default function TitlebarSummaryStrip() {
     darkMode, textPrimary, textSecondary,
   } = useDayPlannerCtx();
   const { getDayWindow } = useFeaturesCtx();
+
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuLeft, setMenuLeft] = useState(12);
+  const pillRef = useRef(null);
 
   // currentTime ticks every minute, so the numbers roll forward while the
   // window sits idle and the date flips correctly at midnight.
@@ -53,11 +61,28 @@ export default function TitlebarSummaryStrip() {
   const chipValue = (total, done, completable) =>
     done > 0 ? `${formatMinutes(done)}/${formatMinutes(completable)}` : formatMinutes(total);
 
+  const openMenu = () => {
+    // Anchor the popover under the pill, clamped so its 288px box stays
+    // on-screen at narrow window widths.
+    const r = pillRef.current?.getBoundingClientRect();
+    if (r) setMenuLeft(Math.max(8, Math.min(r.left, window.innerWidth - 296)));
+    setMenuOpen(true);
+  };
+
   return (
     <div className="flex items-center gap-1.5 text-xs font-normal overflow-hidden max-w-full">
       <span className={pill}>
+        <span className={`font-medium ${textPrimary}`}>{formatShortDate(new Date(currentTime))}</span>
+      </span>
+      <span
+        ref={pillRef}
+        className={`${pill} cursor-pointer hover:opacity-80`}
+        style={{ WebkitAppRegion: 'no-drag' }}
+        onClick={openMenu}
+      >
         <span className={`font-semibold ${textPrimary}`}>{formatMinutes(summary.unblockedMinutes)}</span>
         <span className={textSecondary}>unblocked</span>
+        <MoreHorizontal size={13} className={`-mr-1 flex-shrink-0 ${textSecondary}`} />
       </span>
       {summary.blockedMinutes > 0 && (
         <span className={pill}>
@@ -74,6 +99,15 @@ export default function TitlebarSummaryStrip() {
           <span className={textSecondary}>{chipValue(c.minutes, c.doneMinutes, c.completableMinutes)}</span>
         </span>
       ))}
+      {menuOpen && createPortal(
+        <DayWindowMenu
+          dateStr={todayStr}
+          onClose={() => setMenuOpen(false)}
+          anchorClass="fixed"
+          anchorStyle={{ top: 34, left: menuLeft }}
+        />,
+        document.body,
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Title bar feedback round: the date pill returns, and the unblocked pill becomes clickable — which required extracting the day-window popover into a shared component.

## Changes

- **Date pill restored** as the first pill. (It was dropped as redundant-with-always-today; conceded — it anchors what the numbers describe, same as the desktop strip's date pill.)
- **Unblocked pill is now interactive**: the *one* `WebkitAppRegion: no-drag` carve-out in the bar, with the familiar three-dot affordance, opening the day-window popover for **today**. Everything else in the bar remains a drag region, so window-dragging still works everywhere except that single pill.
- **`DayWindowMenu.jsx` extracted** — the popover (backdrop, Starts/Ends clock-picker buttons, sticky-forward semantics, Clear) is now one implementation with caller-owned positioning:
  - `SummaryStrip` anchors it upward over the timeline (`absolute bottom-full` — behavior unchanged).
  - The title bar portals it to `document.body` and opens it **downward** under the bar (the bar's div is `overflow-hidden` and sits at screen top), left-anchored to the pill and clamped on-screen at narrow window widths.

## Why this matters beyond polish

This is the groundwork for the open question of hiding the timeline strip when the title bar carries the pills: editing the day window no longer requires the timeline strip to be visible. That hide (my recommendation: only when the viewed day IS today — see discussion) is deliberately **not** in this PR.

## Verification

- Lint clean; 1120 tests green; web, Electron, iOS, and Android bundles all build.
- On your Mac: date pill leads; clicking the unblocked pill opens the popover below the bar (Starts/Ends clock pickers + Clear working, sticky-forward as in the strip); dragging the window by any other part of the bar still works; popover closes on outside click.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_