### PR TITLE
Anchor TODAY into the recurring-task expansion window

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5802,11 +5802,19 @@ const DayPlanner = () => {
     // full rolling window so recurring occurrences exist for every rendered day.
     const schedWindowEnd = new Date(selectedDate);
     schedWindowEnd.setDate(schedWindowEnd.getDate() + schedDaysShown - 1);
-    const allDateStrs = [...visibleDates, ...weekViewDates, selectedDate, schedWindowEnd]
-      .map(d => dateToString(d)).sort();
+    const today = getTodayStr();
+    // TODAY is anchored into the range unconditionally: plenty of consumers ask
+    // about today regardless of where the user has navigated — todayAgenda (and
+    // through it GLANCE and the widget snapshot / Live Activity), the macOS NOW
+    // bar and title-bar strip. Without the anchor, navigating wholly past (or
+    // before) today silently dropped today's recurring instances from all of
+    // them — visible as tag pills vanishing from the title bar when paging
+    // forward off a weekend-only recurring task's day.
+    const allDateStrs = [...visibleDates.map(d => dateToString(d)),
+      ...weekViewDates.map(d => dateToString(d)),
+      dateToString(selectedDate), dateToString(schedWindowEnd), today].sort();
     const rangeStart = allDateStrs[0];
     const rangeEnd = allDateStrs[allDateStrs.length - 1];
-    const today = getTodayStr();
     const instances = [];
     for (const template of recurringTasks) {
       const occurrences = getOccurrencesInRange(template, rangeStart, rangeEnd);


### PR DESCRIPTION
Fixes the title-bar strip changing as you page through days — and the bug turned out to be much bigger than the title bar.

## Root cause

`expandedRecurringTasks` expands recurring templates over the range spanned by `visibleDates` / `weekViewDates` / `selectedDate` / the SCHED window — **a range that follows navigation**. Page wholly past (or before) today and today falls out of the range, so today's recurring instances simply stop existing in the expanded set.

The reported symptom — two tag pills dropping from the title bar, both tied to a weekend-only recurring task — is exactly this: viewing today (Sunday), the instances exist; page forward into the week and today leaves the expansion window, so `getTasksForDate(today)` loses them and the title-bar summary (pinned to today by design) recomputes without them.

## Blast radius (all today-pinned consumers, all silently wrong while viewing another day)

- `todayAgenda` filters `expandedRecurringTasks` for today → **GLANCE views** lose today's recurring items,
- and through the widget-snapshot effect, the **Android/iOS widgets and the Live Activity** (`nextTask`, `nextUpNext`, `daySummary`) push wrong today-data while the app sits on another day,
- the **macOS NOW bar** (`[...tasks, ...expandedRecurringTasks].find(...)`) loses a running recurring task,
- the **title-bar strip**, where it was first visible.

## Fix

One change at the root: **today is anchored into the expansion range unconditionally**, so today's instances exist regardless of navigation. The past-instance filter inside the expansion loop is unchanged — it already handles range days before today, which is why widening the range is safe.

## Verification

- Lint clean; 1120 tests green; web, Electron, iOS, and Android bundles all build.
- Repro on your Mac: with the weekend recurring task present today, page forward several days — the title-bar pills (and the NOW bar, if the task is running) now stay identical.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_