### PR TITLE
Island: shrink the compact ring to 15pt (system-Timer glyph parity)

### DIFF
--- a/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
+++ b/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
@@ -49,13 +49,17 @@ private func countdownText(_ state: DaySummaryAttributes.ContentState, fallback:
 private func countdownRing(_ state: DaySummaryAttributes.ContentState) -> some View {
     if let start = state.countdownStart, let end = state.countdownEnd, start < end {
         // Explicitly sized: the circular gauge's natural size over-claims the
-        // compact slot, leaving a dead gap between the ring and the sensor
-        // housing. 18pt keeps the slot as tight as the system margins allow.
+        // compact slot. 15pt matches the ink of the system Timer's compact
+        // glyph — the tightest the slot gets from our side. What remains is
+        // ActivityKit's own inner margin around the sensor housing (not ours
+        // to shrink; Apple's first-party island surfaces are system-rendered
+        // and not bound by it, which is why Timer sits closer than any
+        // ActivityKit app can).
         ProgressView(timerInterval: start...end, countsDown: true,
                      label: { EmptyView() }, currentValueLabel: { EmptyView() })
             .progressViewStyle(.circular)
             .tint(unblockedColor)
-            .frame(width: 18, height: 18)
+            .frame(width: 15, height: 15)
     } else {
         Image(systemName: "hourglass")
             .foregroundStyle(unblockedColor)


### PR DESCRIPTION
One-variable experiment for the remaining dead space between the compact ring and the sensor housing.

## The honest breakdown of that gap

1. **Timer is an unfair benchmark**: Apple's own island presentations (Timer included) are system-rendered, not ActivityKit widget extensions — they aren't bound by the public compact margins, and no third-party Live Activity gets as tight to the cutout as they do.
2. **ActivityKit's inner margin** around the sensor region is fixed and not ours to shrink.
3. **Our layout claim** is the one knob we hold: the ring's 18pt frame was still larger than the Timer glyph's ~15pt of ink. This PR drops it to **15×15pt**.

## The diagnostic

This build answers the question empirically: if the gap narrows along with the ring, part of it was our claim (and 15pt is as far as it goes while the ring stays legible). If the gap is unchanged, we've confirmed the system floor and the chase is over.

⚠️ Swift-only, not compiled here; no new files — plain rebuild.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_