### PR TITLE
Island: restore 18pt ring + negative-padding pull toward the cutout

### DIFF
--- a/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
+++ b/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
@@ -48,18 +48,21 @@ private func countdownText(_ state: DaySummaryAttributes.ContentState, fallback:
 @ViewBuilder
 private func countdownRing(_ state: DaySummaryAttributes.ContentState) -> some View {
     if let start = state.countdownStart, let end = state.countdownEnd, start < end {
-        // Explicitly sized: the circular gauge's natural size over-claims the
-        // compact slot. 15pt matches the ink of the system Timer's compact
-        // glyph — the tightest the slot gets from our side. What remains is
-        // ActivityKit's own inner margin around the sensor housing (not ours
-        // to shrink; Apple's first-party island surfaces are system-rendered
-        // and not bound by it, which is why Timer sits closer than any
-        // ActivityKit app can).
+        // 18pt ring (15 read as shrunken, and shrinking the claim proved the
+        // cutout gap is ActivityKit's own inner margin, not our width). The
+        // negative trailing padding is the one lever against that margin: it
+        // narrows the LAYOUT claim on the cutout side so the system's fixed
+        // margin is measured from a line 5pt inside the ring, letting the
+        // visual spill that far toward the housing. Apple's first-party
+        // surfaces (Timer) are system-rendered and sit tighter than any
+        // ActivityKit app can by honest means; if this overlaps the cutout on
+        // some model, dial the -5 down rather than up.
         ProgressView(timerInterval: start...end, countsDown: true,
                      label: { EmptyView() }, currentValueLabel: { EmptyView() })
             .progressViewStyle(.circular)
             .tint(unblockedColor)
-            .frame(width: 15, height: 15)
+            .frame(width: 18, height: 18)
+            .padding(.trailing, -5)
     } else {
         Image(systemName: "hourglass")
             .foregroundStyle(unblockedColor)


### PR DESCRIPTION
Round 2 on the compact-ring gap, informed by round 1's result.

## What round 1 proved

The gap **didn't track the ring's size** — shrinking the layout claim from 18→15pt just made the circle smaller while the dead space stayed put. That's the diagnostic answer: the gap is **ActivityKit's fixed inner margin** around the sensor housing, not our width. (And Apple's own island surfaces like Timer are system-rendered, exempt from that margin — the benchmark is unreachable by honest means.)

## This PR

1. **Ring restored to 18pt** — 15 read as shrunken for no benefit.
2. **`.padding(.trailing, -5)`** on the ring — the one lever that acts on the margin itself. Negative padding narrows the *layout* claim on the cutout side, so the system measures its fixed margin from a line 5pt inside the ring, and the visual spills that far toward the housing. This is the community workaround shipping apps use for exactly this.

## Interpreting the build

- Ring visibly closer to the cutout → it works; if it ever *touches* the cutout on another model, dial `-5` down (not up).
- No visible change → the margin is enforced after layout on this OS version, the floor is real, and the chase officially ends with the 18pt ring and a clear conscience.

⚠️ Swift-only, not compiled here; no new files — plain rebuild.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_