### PR TITLE
Bump version to 4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="screenshots/badges/google-play.png" alt="Get it on Google Play" height="60">](https://play.google.com/store/apps/details?id=com.dayglance.app) [<img src="screenshots/badges/app-store.svg" alt="Download on the App Store" height="60">](https://apps.apple.com/app/id6771540599)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-4.1.1-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-4.2.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         // fallback for plain gradle/IDE builds and no longer needs a commit
         // per Play upload.
         versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 185
-        versionName = "4.1.1"
+        versionName = "4.2.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "@glance-apps/billing": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dayglance",
   "private": true,
   "license": "MIT",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
Version bump for the **v4.2.0** release, via `npm run bump 4.2.0` (never hand-edited): `package.json` (source of truth), Android `versionName`, README badge, lockfile. iOS `MARKETING_VERSION` and Electron `CFBundleShortVersionString` derive from `package.json` at build time. Android `versionCode` is supplied per build by `build-and-install.sh` (handled separately).

## What ships in 4.2.0 (since 4.1.1)

### Features
- **Summary strip** (desktop, tablet, phone GRID + LIST): per-tag totals, unblocked time, Effort/Restore energy axis, planned-vs-done chips (#1304, #1306, #1307)
- **Day windows**: START/STOP timeline markers with sticky-forward defaults (#1305), synced across devices on both tiers (#1308)
- **iOS Live Activity / Dynamic Island** (opt-in, default off): up-next schedule facts with live countdown and progress ring, lock-screen banner mirroring the expanded island (#1309–#1311, #1318, #1319, #1322–#1324)
- **macOS title bar summary strip**: today's pills in the previously empty title bar, with date pill and the day-window editor (#1314, #1320)
- **GLANCEahead next-alarm line** on Android (#1313)

### Fixes & internals
- Recurring-task expansion now always includes today (title bar / GLANCE / widget / NOW bar correctness while viewing other days, #1321)
- LIST view scroll reset, phone strip fan-out, goal-badge `{{title}}`, strip spacing (#1312)
- Vault SSE client documented to the real wire contract, dead kind-dispatch removed (#1316); seed-gate/pull-order coupling documented (#1317)
- macOS tray arc: `tray:data-changed` channel, tray-mode guards, calendar-helper caching, visibility-gated EventKit fetch, Obsidian open fix (#1297–#1303)

## Post-merge (per RELEASING.md)

1. `npm run ios:generate` **before** archiving (MARKETING_VERSION updates at generate time)
2. Follow the tag / build / publish sequence
3. Android `versionCode` per build via `build-and-install.sh --release`

Quality gates re-run on the bump commit: lint clean, 1120 tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_