### PR TITLE
Localize all 4.2.0 strings in six languages (JS + island via payload)

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
@@ -49,6 +49,15 @@ final class LiveActivityBridge {
         var restore: String?
         var done: String?
         var upNext: UpNextPayload?
+        var labels: LabelsPayload?
+    }
+    // The island's Swift-rendered words, localized by the JS side (see the
+    // snapshot's daySummary.labels). English fallbacks cover old snapshots.
+    private struct LabelsPayload: Decodable {
+        var done: String?
+        var remaining: String?
+        var startsIn: String?
+        var noMoreBlocks: String?
     }
     private struct UpNextPayload: Decodable {
         var title: String?
@@ -83,6 +92,7 @@ final class LiveActivityBridge {
         }
 
         let up = payload.upNext
+        let labels = payload.labels
         let msToDate: (Double?) -> Date? = { ms in ms.map { Date(timeIntervalSince1970: $0 / 1000) } }
         let state = DaySummaryAttributes.ContentState(
             blockTitle: up?.title,
@@ -90,7 +100,11 @@ final class LiveActivityBridge {
             countdownStart: msToDate(up?.countdownStartMs),
             countdownEnd: msToDate(up?.countdownEndMs),
             inProgress: up?.inProgress ?? false,
-            done: done, effort: effort, restore: restore)
+            done: done, effort: effort, restore: restore,
+            doneLabel: labels?.done ?? "done",
+            remainingLabel: labels?.remaining ?? "remaining",
+            startsInLabel: labels?.startsIn ?? "starts in",
+            noMoreBlocksLabel: labels?.noMoreBlocks ?? "No more blocks today")
         let content = ActivityContent(state: state, staleDate: Date().addingTimeInterval(Self.staleAfter))
 
         Task {

--- a/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
+++ b/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
@@ -80,7 +80,7 @@ struct DaySummaryLiveActivity: Widget {
                 // ── Expanded ─────────────────────────────────────────────
                 DynamicIslandExpandedRegion(.leading) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(context.state.blockTitle ?? "No more blocks today")
+                        Text(context.state.blockTitle ?? context.state.noMoreBlocksLabel)
                             .font(.subheadline.weight(.semibold))
                             .lineLimit(2)
                         if let time = context.state.blockTime {
@@ -108,8 +108,8 @@ struct DaySummaryLiveActivity: Widget {
                             .minimumScaleFactor(0.55)
                             .multilineTextAlignment(.trailing)
                             .frame(maxWidth: 84, alignment: .trailing)
-                        Text(context.state.blockTitle == nil ? "done"
-                             : context.state.inProgress ? "remaining" : "starts in")
+                        Text(context.state.blockTitle == nil ? context.state.doneLabel
+                             : context.state.inProgress ? context.state.remainingLabel : context.state.startsInLabel)
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
@@ -120,7 +120,7 @@ struct DaySummaryLiveActivity: Widget {
                     // restore values clipped the leaf's number at the edge):
                     // one line each, shrink together before anything clips.
                     HStack(spacing: 10) {
-                        Label("\(context.state.done) done", systemImage: "checkmark.circle")
+                        Label("\(context.state.done) \(context.state.doneLabel)", systemImage: "checkmark.circle")
                             .foregroundStyle(.secondary)
                         Spacer(minLength: 6)
                         Label(context.state.effort, systemImage: "bolt.fill")
@@ -171,7 +171,7 @@ private struct LockScreenView: View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top, spacing: 16) {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(state.blockTitle ?? "No more blocks today")
+                    Text(state.blockTitle ?? state.noMoreBlocksLabel)
                         .font(.headline)
                         .lineLimit(2)
                     if let time = state.blockTime {
@@ -197,14 +197,14 @@ private struct LockScreenView: View {
                             .minimumScaleFactor(0.55)
                             .multilineTextAlignment(.trailing)
                             .frame(maxWidth: 84, alignment: .trailing)
-                        Text(state.inProgress ? "remaining" : "starts in")
+                        Text(state.inProgress ? state.remainingLabel : state.startsInLabel)
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
                 }
             }
             HStack(spacing: 10) {
-                Label("\(state.done) done", systemImage: "checkmark.circle")
+                Label("\(state.done) \(state.doneLabel)", systemImage: "checkmark.circle")
                     .foregroundStyle(.secondary)
                 Spacer(minLength: 6)
                 Label(state.effort, systemImage: "bolt.fill")

--- a/dayglance-ios/Shared/DaySummaryAttributes.swift
+++ b/dayglance-ios/Shared/DaySummaryAttributes.swift
@@ -47,6 +47,14 @@ struct DaySummaryAttributes: ActivityAttributes {
         /// reads it from the snapshot as the empty-day end signal.
         var effort: String
         var restore: String
+        /// The four words this extension renders itself, LOCALIZED BY JS and
+        /// delivered in the snapshot's `labels` — the JS side owns all island
+        /// wording, so the iOS project needs no localization infrastructure.
+        /// The bridge falls back to English when an old snapshot lacks them.
+        var doneLabel: String
+        var remainingLabel: String
+        var startsInLabel: String
+        var noMoreBlocksLabel: String
     }
 
     /// 'YYYY-MM-DD' this activity describes. Fixed for the activity's lifetime.

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -346,7 +346,9 @@
     "portraitViewDefault": "Hochformat-Ansicht",
     "landscapeViewDefault": "Querformat-Ansicht",
     "removeFileImported": "Aus Datei importierte Termine entfernen",
-    "removeFileImportedConfirm": "Alle {{n}} aus Datei importierten Termine entfernen? Ein erneuter Datei-Import stellt sie wieder her."
+    "removeFileImportedConfirm": "Alle {{n}} aus Datei importierten Termine entfernen? Ein erneuter Datei-Import stellt sie wieder her.",
+    "liveActivity": "Live-Aktivität",
+    "liveActivityDesc": "Der heutige Plan in der Dynamic Island und auf dem Sperrbildschirm. Verbreitert die Island und verdeckt die Signalsymbole neben der Uhr."
   },
   "task": {
     "newScheduled": "Neue geplante Aufgabe",
@@ -758,7 +760,9 @@
     "proposedSchedule": "Vorgeschlagener Zeitplan",
     "couldNotBePlaced": "Konnte nicht platziert werden",
     "incompleteTasks": "Unerledigte Aufgaben",
-    "allTasksCompleted": "Alle Aufgaben abgeschlossen!"
+    "allTasksCompleted": "Alle Aufgaben abgeschlossen!",
+    "alarmAt": "Wecker um",
+    "dayStartsAt": "Tag beginnt um"
   },
   "goals": {
     "goalOptional": "Ziel (optional)",
@@ -913,5 +917,28 @@
     "notesPlaceholder": "Notizen für diesen Bereich: Träume, Kriterien, Links…",
     "showCompleted": "Erledigte anzeigen",
     "hideCompleted": "Erledigte ausblenden"
+  },
+  "strip": {
+    "unblocked": "frei",
+    "effort": "Einsatz",
+    "restore": "Erholung",
+    "untagged": "ohne Tags",
+    "setDayWindow": "Tagesfenster festlegen…",
+    "dayWindow": "Tagesfenster",
+    "dayWindowDesc": "Gilt für diesen und alle folgenden Tage. Die freie Zeit wird zwischen Beginn und Ende des Fensters gemessen.",
+    "starts": "Beginnt",
+    "ends": "Endet",
+    "set": "Festlegen…",
+    "clearForDay": "Für diesen Tag löschen",
+    "markerStart": "start",
+    "markerEnd": "ende",
+    "energyLabel": "Energie: {{value}}",
+    "energyAuto": "Energie: Auto ({{value}})",
+    "until": "bis",
+    "at": "um",
+    "done": "erledigt",
+    "remaining": "verbleibend",
+    "startsIn": "beginnt in",
+    "noMoreBlocks": "Keine weiteren Blöcke heute"
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -346,7 +346,9 @@
     "icloudIntentsDesc": "Share task intents with other GLANCE apps through iCloud Drive. Files sync automatically across your Apple devices.",
     "icloudIntentsEnable": "Enable iCloud intents",
     "removeFileImported": "Remove file-imported events",
-    "removeFileImportedConfirm": "Remove all {{n}} file-imported events? Re-importing the file brings them back."
+    "removeFileImportedConfirm": "Remove all {{n}} file-imported events? Re-importing the file brings them back.",
+    "liveActivity": "Live Activity",
+    "liveActivityDesc": "Today's plan in the Dynamic Island and on the Lock Screen. Widens the island, which hides the signal icons next to the clock."
   },
   "task": {
     "newScheduled": "New Scheduled Task",
@@ -758,7 +760,9 @@
     "proposedSchedule": "Proposed Schedule",
     "couldNotBePlaced": "Could not be placed",
     "incompleteTasks": "Incomplete Tasks",
-    "allTasksCompleted": "All tasks completed!"
+    "allTasksCompleted": "All tasks completed!",
+    "alarmAt": "Alarm at",
+    "dayStartsAt": "Day starts at"
   },
   "goals": {
     "goalOptional": "Goal (optional)",
@@ -913,5 +917,28 @@
     "notesPlaceholder": "Notes for this space: dreams, criteria, links…",
     "showCompleted": "Show completed",
     "hideCompleted": "Hide completed"
+  },
+  "strip": {
+    "unblocked": "unblocked",
+    "effort": "Effort",
+    "restore": "Restore",
+    "untagged": "untagged",
+    "setDayWindow": "Set day window…",
+    "dayWindow": "Day window",
+    "dayWindowDesc": "Applies to this and future days. Unblocked time is measured between the Starts and Ends window.",
+    "starts": "Starts",
+    "ends": "Ends",
+    "set": "Set…",
+    "clearForDay": "Clear for this day",
+    "markerStart": "start",
+    "markerEnd": "end",
+    "energyLabel": "Energy: {{value}}",
+    "energyAuto": "Energy: Auto ({{value}})",
+    "until": "until",
+    "at": "at",
+    "done": "done",
+    "remaining": "remaining",
+    "startsIn": "starts in",
+    "noMoreBlocks": "No more blocks today"
   }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -346,7 +346,9 @@
     "portraitViewDefault": "Vista en vertical",
     "landscapeViewDefault": "Vista en horizontal",
     "removeFileImported": "Eliminar eventos importados de archivo",
-    "removeFileImportedConfirm": "¿Eliminar los {{n}} eventos importados de archivo? Volver a importar el archivo los restaura."
+    "removeFileImportedConfirm": "¿Eliminar los {{n}} eventos importados de archivo? Volver a importar el archivo los restaura.",
+    "liveActivity": "Actividad en Vivo",
+    "liveActivityDesc": "El plan de hoy en la Dynamic Island y en la pantalla de bloqueo. Ensancha la isla y oculta los iconos de señal junto al reloj."
   },
   "task": {
     "newScheduled": "Nueva tarea programada",
@@ -758,7 +760,9 @@
     "proposedSchedule": "Horario propuesto",
     "couldNotBePlaced": "No se pudo colocar",
     "incompleteTasks": "Tareas incompletas",
-    "allTasksCompleted": "¡Todas las tareas completadas!"
+    "allTasksCompleted": "¡Todas las tareas completadas!",
+    "alarmAt": "Alarma a las",
+    "dayStartsAt": "El día empieza a las"
   },
   "goals": {
     "goalOptional": "Objetivo (opcional)",
@@ -913,5 +917,28 @@
     "notesPlaceholder": "Notas para este espacio: sueños, criterios, enlaces…",
     "showCompleted": "Mostrar completadas",
     "hideCompleted": "Ocultar completadas"
+  },
+  "strip": {
+    "unblocked": "libre",
+    "effort": "Esfuerzo",
+    "restore": "Descanso",
+    "untagged": "sin etiqueta",
+    "setDayWindow": "Definir ventana del día…",
+    "dayWindow": "Ventana del día",
+    "dayWindowDesc": "Se aplica a este día y a los siguientes. El tiempo libre se mide entre el inicio y el fin de la ventana.",
+    "starts": "Empieza",
+    "ends": "Termina",
+    "set": "Definir…",
+    "clearForDay": "Borrar para este día",
+    "markerStart": "inicio",
+    "markerEnd": "fin",
+    "energyLabel": "Energía: {{value}}",
+    "energyAuto": "Energía: Auto ({{value}})",
+    "until": "hasta las",
+    "at": "a las",
+    "done": "hecho",
+    "remaining": "restante",
+    "startsIn": "empieza en",
+    "noMoreBlocks": "No quedan bloques hoy"
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -346,7 +346,9 @@
     "portraitViewDefault": "Vue en portrait",
     "landscapeViewDefault": "Vue en paysage",
     "removeFileImported": "Supprimer les événements importés depuis un fichier",
-    "removeFileImportedConfirm": "Supprimer les {{n}} événements importés depuis un fichier ? Réimporter le fichier les restaurera."
+    "removeFileImportedConfirm": "Supprimer les {{n}} événements importés depuis un fichier ? Réimporter le fichier les restaurera.",
+    "liveActivity": "Activité en direct",
+    "liveActivityDesc": "Le plan du jour dans la Dynamic Island et sur l'écran verrouillé. Élargit l'île et masque les icônes de signal près de l'horloge."
   },
   "task": {
     "newScheduled": "Nouvelle tâche planifiée",
@@ -758,7 +760,9 @@
     "proposedSchedule": "Planning proposé",
     "couldNotBePlaced": "Impossible à placer",
     "incompleteTasks": "Tâches incomplètes",
-    "allTasksCompleted": "Toutes les tâches sont terminées !"
+    "allTasksCompleted": "Toutes les tâches sont terminées !",
+    "alarmAt": "Réveil à",
+    "dayStartsAt": "La journée commence à"
   },
   "goals": {
     "goalOptional": "Objectif (optionnel)",
@@ -913,5 +917,28 @@
     "notesPlaceholder": "Notes pour cet espace : rêves, critères, liens…",
     "showCompleted": "Afficher les terminées",
     "hideCompleted": "Masquer les terminées"
+  },
+  "strip": {
+    "unblocked": "libre",
+    "effort": "Effort",
+    "restore": "Repos",
+    "untagged": "sans tag",
+    "setDayWindow": "Définir la fenêtre du jour…",
+    "dayWindow": "Fenêtre du jour",
+    "dayWindowDesc": "S'applique à ce jour et aux suivants. Le temps libre est mesuré entre le début et la fin de la fenêtre.",
+    "starts": "Début",
+    "ends": "Fin",
+    "set": "Définir…",
+    "clearForDay": "Effacer pour ce jour",
+    "markerStart": "début",
+    "markerEnd": "fin",
+    "energyLabel": "Énergie : {{value}}",
+    "energyAuto": "Énergie : Auto ({{value}})",
+    "until": "jusqu'à",
+    "at": "à",
+    "done": "fait",
+    "remaining": "restant",
+    "startsIn": "commence dans",
+    "noMoreBlocks": "Plus de blocs aujourd'hui"
   }
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -346,7 +346,9 @@
     "portraitViewDefault": "Vista verticale",
     "landscapeViewDefault": "Vista orizzontale",
     "removeFileImported": "Rimuovi gli eventi importati da file",
-    "removeFileImportedConfirm": "Rimuovere tutti i {{n}} eventi importati da file? Reimportando il file verranno ripristinati."
+    "removeFileImportedConfirm": "Rimuovere tutti i {{n}} eventi importati da file? Reimportando il file verranno ripristinati.",
+    "liveActivity": "Attività in tempo reale",
+    "liveActivityDesc": "Il piano di oggi nella Dynamic Island e nella schermata di blocco. Allarga l'isola e nasconde le icone del segnale accanto all'orologio."
   },
   "task": {
     "newScheduled": "Nuova attività pianificata",
@@ -758,7 +760,9 @@
     "proposedSchedule": "Programma proposto",
     "couldNotBePlaced": "Non è stato possibile posizionare",
     "incompleteTasks": "Attività incomplete",
-    "allTasksCompleted": "Tutte le attività completate!"
+    "allTasksCompleted": "Tutte le attività completate!",
+    "alarmAt": "Sveglia alle",
+    "dayStartsAt": "La giornata inizia alle"
   },
   "goals": {
     "goalOptional": "Obiettivo (opzionale)",
@@ -913,5 +917,28 @@
     "notesPlaceholder": "Note per questo spazio: sogni, criteri, link…",
     "showCompleted": "Mostra completate",
     "hideCompleted": "Nascondi completate"
+  },
+  "strip": {
+    "unblocked": "libero",
+    "effort": "Sforzo",
+    "restore": "Recupero",
+    "untagged": "senza tag",
+    "setDayWindow": "Imposta finestra del giorno…",
+    "dayWindow": "Finestra del giorno",
+    "dayWindowDesc": "Vale per questo giorno e per i successivi. Il tempo libero è misurato tra l'inizio e la fine della finestra.",
+    "starts": "Inizia",
+    "ends": "Termina",
+    "set": "Imposta…",
+    "clearForDay": "Cancella per questo giorno",
+    "markerStart": "inizio",
+    "markerEnd": "fine",
+    "energyLabel": "Energia: {{value}}",
+    "energyAuto": "Energia: Auto ({{value}})",
+    "until": "fino alle",
+    "at": "alle",
+    "done": "fatto",
+    "remaining": "rimanente",
+    "startsIn": "inizia tra",
+    "noMoreBlocks": "Nessun altro blocco oggi"
   }
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -346,7 +346,9 @@
     "portraitViewDefault": "Vista vertical",
     "landscapeViewDefault": "Vista horizontal",
     "removeFileImported": "Remover eventos importados de ficheiro",
-    "removeFileImportedConfirm": "Remover os {{n}} eventos importados de ficheiro? Reimportar o ficheiro irá restaurá-los."
+    "removeFileImportedConfirm": "Remover os {{n}} eventos importados de ficheiro? Reimportar o ficheiro irá restaurá-los.",
+    "liveActivity": "Atividade ao Vivo",
+    "liveActivityDesc": "O plano de hoje na Dynamic Island e na tela de bloqueio. Alarga a ilha e oculta os ícones de sinal ao lado do relógio."
   },
   "task": {
     "newScheduled": "Nova tarefa agendada",
@@ -758,7 +760,9 @@
     "proposedSchedule": "Horário proposto",
     "couldNotBePlaced": "Não foi possível colocar",
     "incompleteTasks": "Tarefas incompletas",
-    "allTasksCompleted": "Todas as tarefas concluídas!"
+    "allTasksCompleted": "Todas as tarefas concluídas!",
+    "alarmAt": "Alarme às",
+    "dayStartsAt": "O dia começa às"
   },
   "goals": {
     "goalOptional": "Objetivo (opcional)",
@@ -913,5 +917,28 @@
     "notesPlaceholder": "Notas para este espaço: sonhos, critérios, links…",
     "showCompleted": "Mostrar concluídas",
     "hideCompleted": "Ocultar concluídas"
+  },
+  "strip": {
+    "unblocked": "livre",
+    "effort": "Esforço",
+    "restore": "Descanso",
+    "untagged": "sem etiqueta",
+    "setDayWindow": "Definir janela do dia…",
+    "dayWindow": "Janela do dia",
+    "dayWindowDesc": "Aplica-se a este dia e aos seguintes. O tempo livre é medido entre o início e o fim da janela.",
+    "starts": "Começa",
+    "ends": "Termina",
+    "set": "Definir…",
+    "clearForDay": "Limpar para este dia",
+    "markerStart": "início",
+    "markerEnd": "fim",
+    "energyLabel": "Energia: {{value}}",
+    "energyAuto": "Energia: Auto ({{value}})",
+    "until": "até",
+    "at": "às",
+    "done": "feito",
+    "remaining": "restante",
+    "startsIn": "começa em",
+    "noMoreBlocks": "Sem mais blocos hoje"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7221,8 +7221,18 @@ const DayPlanner = () => {
                 nextUpNext.bodyPrefix
                   ? { ...nextUpNext, title: `${nextUpNext.bodyPrefix}${nextUpNext.title}` }
                   : nextUpNext,
-                Date.now(), formatTime)
+                Date.now(), formatTime,
+                { until: t('strip.until'), at: t('strip.at') })
             : null,
+          // The island's four Swift-rendered words, localized HERE like every
+          // other island string — the JS side owns all wording, so the iOS
+          // project needs no localization infrastructure of its own.
+          labels: {
+            done: t('strip.done'),
+            remaining: t('strip.remaining'),
+            startsIn: t('strip.startsIn'),
+            noMoreBlocks: t('strip.noMoreBlocks'),
+          },
         };
       })(),
       updatedAt: Date.now(),
@@ -7269,6 +7279,7 @@ const DayPlanner = () => {
     listEndOfDayTime,
     liveActivityEnabled,
     widgetSnapshotTick,
+    t,
   ]);
 
   // Phase 11 — Spotlight indexing: keep Spotlight in sync with non-archived,
@@ -9656,7 +9667,7 @@ const DayPlanner = () => {
               {hasEnergy && (() => {
                 const override = ctxTask?.energy === 'restore' || ctxTask?.energy === 'effort' ? ctxTask.energy : null;
                 const derived = ctxTask ? deriveBlockEnergy(ctxTask) : 'effort';
-                const pretty = (e) => (e === 'restore' ? 'Restore' : 'Effort');
+                const pretty = (e) => (e === 'restore' ? t('strip.restore') : t('strip.effort'));
                 const next = override === null ? 'restore' : override === 'restore' ? 'effort' : null;
                 return (
                   <button
@@ -9664,7 +9675,7 @@ const DayPlanner = () => {
                     onClick={() => { setTaskEnergy(taskId, next, isInbox); setTaskContextMenu(null); }}
                   >
                     <Zap size={14} />
-                    {override ? `Energy: ${pretty(override)}` : `Energy: Auto (${pretty(derived)})`}
+                    {override ? t('strip.energyLabel', { value: pretty(override) }) : t('strip.energyAuto', { value: pretty(derived) })}
                   </button>
                 );
               })()}

--- a/src/components/DayWindowMarkers.jsx
+++ b/src/components/DayWindowMarkers.jsx
@@ -1,5 +1,6 @@
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import { useTranslation } from 'react-i18next';
 
 // START/STOP day-window marker lines on the timeline grid. Render-only in
 // phase A — the window is set and moved from the summary strip's day-window
@@ -50,6 +51,7 @@ function MarkerLine({ topPx, color, label, onOpenMenu }) {
 export default function DayWindowMarkers({ dateStr, minToTop, clipStartMin = 0, clipEndMin = 1440 }) {
   const { minutesToPosition, timeToMinutes } = useDayPlannerCtx();
   const { getDayWindow, setDayWindowMenuOpen } = useFeaturesCtx();
+  const { t } = useTranslation();
 
   const window = getDayWindow?.(dateStr);
   if (!window) return null;
@@ -59,13 +61,13 @@ export default function DayWindowMarkers({ dateStr, minToTop, clipStartMin = 0, 
   if (window.start) {
     const min = timeToMinutes(window.start);
     if (min >= clipStartMin && min < clipEndMin) {
-      lines.push(<MarkerLine key="start" topPx={Math.round(toTop(min))} color={START_COLOR} label="start" onOpenMenu={() => setDayWindowMenuOpen?.(true)} />);
+      lines.push(<MarkerLine key="start" topPx={Math.round(toTop(min))} color={START_COLOR} label={t('strip.markerStart')} onOpenMenu={() => setDayWindowMenuOpen?.(true)} />);
     }
   }
   if (window.stop) {
     const min = timeToMinutes(window.stop);
     if (min >= clipStartMin && min < clipEndMin) {
-      lines.push(<MarkerLine key="stop" topPx={Math.round(toTop(min))} color={STOP_COLOR} label="end" onOpenMenu={() => setDayWindowMenuOpen?.(true)} />);
+      lines.push(<MarkerLine key="stop" topPx={Math.round(toTop(min))} color={STOP_COLOR} label={t('strip.markerEnd')} onOpenMenu={() => setDayWindowMenuOpen?.(true)} />);
     }
   }
   return lines.length > 0 ? <>{lines}</> : null;

--- a/src/components/DayWindowMenu.jsx
+++ b/src/components/DayWindowMenu.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import ClockTimePicker from './ClockTimePicker.jsx';
@@ -29,6 +30,7 @@ export default function DayWindowMenu({ dateStr, onClose, anchorClass = '', anch
     use24HourClock, isTablet, formatTime,
   } = useDayPlannerCtx();
   const { getDayWindow, setDayWindow, clearDayWindow } = useFeaturesCtx();
+  const { t } = useTranslation();
 
   // Which bound the clock picker is editing: 'start' | 'stop' | null.
   const [pickerField, setPickerField] = useState(null);
@@ -54,23 +56,19 @@ export default function DayWindowMenu({ dateStr, onClose, anchorClass = '', anch
         className={`${anchorClass} z-50 pointer-events-auto w-72 rounded-lg border shadow-xl p-3 space-y-2.5 text-xs ${cardBg} ${borderClass}`}
         style={anchorStyle}
       >
-        <div className={`font-semibold ${textPrimary}`}>Day window</div>
-        <p className={textSecondary}>
-          Applies to this and future days. Unblocked time is measured between
-          the <span className={`font-semibold ${textPrimary}`}>Starts</span> and{' '}
-          <span className={`font-semibold ${textPrimary}`}>Ends</span> window.
-        </p>
+        <div className={`font-semibold ${textPrimary}`}>{t('strip.dayWindow')}</div>
+        <p className={textSecondary}>{t('strip.dayWindowDesc')}</p>
         <div className="flex items-center justify-between gap-3">
           <span className="flex items-center gap-1.5">
-            <span className={textSecondary}>Starts</span>
+            <span className={textSecondary}>{t('strip.starts')}</span>
             <button onClick={() => setPickerField('start')} className={timeBtnCls}>
-              {dayWindow?.start ? formatTime(dayWindow.start) : 'Set…'}
+              {dayWindow?.start ? formatTime(dayWindow.start) : t('strip.set')}
             </button>
           </span>
           <span className="flex items-center gap-1.5">
-            <span className={textSecondary}>Ends</span>
+            <span className={textSecondary}>{t('strip.ends')}</span>
             <button onClick={() => setPickerField('stop')} className={timeBtnCls}>
-              {dayWindow?.stop ? formatTime(dayWindow.stop) : 'Set…'}
+              {dayWindow?.stop ? formatTime(dayWindow.stop) : t('strip.set')}
             </button>
           </span>
         </div>
@@ -78,7 +76,7 @@ export default function DayWindowMenu({ dateStr, onClose, anchorClass = '', anch
           onClick={() => { clearDayWindow(dateStr); onClose(); }}
           className={`w-full py-1 rounded border ${borderClass} ${textSecondary} hover:opacity-80`}
         >
-          Clear for this day
+          {t('strip.clearForDay')}
         </button>
       </div>
       {pickerField && createPortal(

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -1288,7 +1288,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
     const alarmLine = alarmMs ? (
       <div className="flex items-center gap-2">
         <AlarmClock size={13} className={textSecondary} />
-        <span className={`text-sm ${textPrimary}`}>Alarm at <span className="font-medium">{formatTime(alarmHHMM(alarmMs))}</span></span>
+        <span className={`text-sm ${textPrimary}`}>{t('app.alarmAt')} <span className="font-medium">{formatTime(alarmHHMM(alarmMs))}</span></span>
       </div>
     ) : null;
     const handleGlanceAheadClick = () => {
@@ -1320,7 +1320,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
             {firstStartTime && (
               <div className="flex items-center gap-2">
                 <Clock size={13} className={textSecondary} />
-                <span className={`text-sm ${textPrimary}`}>Day starts at <span className="font-medium">{formatTime(firstStartTime)}</span></span>
+                <span className={`text-sm ${textPrimary}`}>{t('app.dayStartsAt')} <span className="font-medium">{formatTime(firstStartTime)}</span></span>
               </div>
             )}
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1">

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -1134,7 +1134,7 @@ const MobileGlanceSection = () => {
     const alarmLine = alarmMs ? (
       <div className="flex items-center gap-2">
         <AlarmClock size={13} className={textSecondary} />
-        <span className={`text-sm ${textPrimary}`}>Alarm at <span className="font-medium">{formatTime(alarmHHMM(alarmMs))}</span></span>
+        <span className={`text-sm ${textPrimary}`}>{t('app.alarmAt')} <span className="font-medium">{formatTime(alarmHHMM(alarmMs))}</span></span>
       </div>
     ) : null;
     const handleGlanceAheadClick = () => {
@@ -1167,7 +1167,7 @@ const MobileGlanceSection = () => {
             {firstStartTime && (
               <div className="flex items-center gap-2">
                 <Clock size={13} className={textSecondary} />
-                <span className={`text-sm ${textPrimary}`}>Day starts at <span className="font-medium">{formatTime(firstStartTime)}</span></span>
+                <span className={`text-sm ${textPrimary}`}>{t('app.dayStartsAt')} <span className="font-medium">{formatTime(firstStartTime)}</span></span>
               </div>
             )}
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1">

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -882,10 +882,8 @@ const MobileSettingsPanel = () => {
             </div>
           </div>
           <div>
-            <span className={`text-sm ${textPrimary}`}>Live Activity</span>
-            <p className={`text-xs ${textSecondary}`}>
-              Today's plan in the Dynamic Island and on the Lock Screen. Widens the island, which hides the signal icons next to the clock.
-            </p>
+            <span className={`text-sm ${textPrimary}`}>{t('settings.liveActivity')}</span>
+            <p className={`text-xs ${textSecondary}`}>{t('settings.liveActivityDesc')}</p>
           </div>
         </label>
       )}

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { ChevronDown, ChevronUp, Leaf, MoreHorizontal, Zap } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import DayWindowMenu from './DayWindowMenu.jsx';
@@ -66,6 +67,7 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
     getDayWindow,
     dayWindowMenuOpen: menuOpen, setDayWindowMenuOpen: setMenuOpen,
   } = useFeaturesCtx();
+  const { t } = useTranslation();
 
   const [collapsed, setCollapsed] = useState(
     () => phone && localStorage.getItem(COLLAPSE_KEY) !== '0',
@@ -93,7 +95,7 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
   const unblockedLabel = (
     <span className="flex items-baseline gap-1">
       <span className={`font-semibold ${textPrimary}`}>{formatMinutes(summary.unblockedMinutes ?? 0)}</span>
-      <span className={textSecondary}>unblocked</span>
+      <span className={textSecondary}>{t('strip.unblocked')}</span>
     </span>
   );
 
@@ -136,7 +138,7 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
           className={`${pill} pointer-events-auto text-xs ${textSecondary} hover:opacity-80`}
         >
           <MoreHorizontal size={13} className="flex-shrink-0" />
-          Set day window…
+          {t('strip.setDayWindow')}
         </button>
       ) : phone && collapsed ? (
         <button onClick={toggle} className={`${pill} pointer-events-auto max-w-full text-xs`}>
@@ -178,10 +180,10 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
         const energyPill = summary.blockedMinutes > 0 && (
           <span className={pill}>
             <Zap size={13} className="flex-shrink-0" style={{ color: EFFORT_DOT }} />
-            <span className={textPrimary}>Effort</span>
+            <span className={textPrimary}>{t('strip.effort')}</span>
             <span className={textSecondary}>{formatMinutes(summary.effortMinutes)}</span>
             <Leaf size={13} className="flex-shrink-0 ml-0.5" style={{ color: RESTORE_DOT }} />
-            <span className={textPrimary}>Restore</span>
+            <span className={textPrimary}>{t('strip.restore')}</span>
             <span className={textSecondary}>{formatMinutes(summary.restoreMinutes)}</span>
           </span>
         );
@@ -209,7 +211,7 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
               <span className={pill}>
                 <span className={`w-2 h-2 rounded-full flex-shrink-0 ${darkMode ? 'bg-gray-500' : 'bg-stone-400'}`} />
                 <span className={textSecondary}>
-                  untagged {chipValue(summary.untaggedMinutes, summary.untaggedDoneMinutes, summary.untaggedCompletableMinutes)}
+                  {t('strip.untagged')} {chipValue(summary.untaggedMinutes, summary.untaggedDoneMinutes, summary.untaggedCompletableMinutes)}
                 </span>
               </span>
             )}

--- a/src/components/TitlebarSummaryStrip.jsx
+++ b/src/components/TitlebarSummaryStrip.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Leaf, MoreHorizontal, Zap } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { dateToString, formatShortDate } from '../utils/taskUtils.js';
@@ -37,6 +38,7 @@ export default function TitlebarSummaryStrip() {
     darkMode, textPrimary, textSecondary,
   } = useDayPlannerCtx();
   const { getDayWindow } = useFeaturesCtx();
+  const { t } = useTranslation();
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuLeft, setMenuLeft] = useState(12);
@@ -81,7 +83,7 @@ export default function TitlebarSummaryStrip() {
         onClick={openMenu}
       >
         <span className={`font-semibold ${textPrimary}`}>{formatMinutes(summary.unblockedMinutes)}</span>
-        <span className={textSecondary}>unblocked</span>
+        <span className={textSecondary}>{t('strip.unblocked')}</span>
         <MoreHorizontal size={13} className={`-mr-1 flex-shrink-0 ${textSecondary}`} />
       </span>
       {summary.blockedMinutes > 0 && (

--- a/src/utils/liveActivity.js
+++ b/src/utils/liveActivity.js
@@ -25,12 +25,15 @@ const toHHMM = (ms) => {
  *   today's current-or-next block ('HH:MM' start, minutes duration)
  * @param {number} nowMs epoch ms "now" (startTime is resolved against its day)
  * @param {(hhmm: string) => string} formatTime display formatter (12h/24h)
+ * @param {{until?: string, at?: string}} [words] localized label words
+ *   (defaults are English so tests and non-localized callers stay stable)
  * @returns {{title, inProgress, timeLabel, countdownStartMs, countdownEndMs}|null}
  */
-export function buildUpNextFact(entry, nowMs, formatTime) {
+export function buildUpNextFact(entry, nowMs, formatTime, words) {
   if (!entry || !entry.startTime) return null;
   const parts = String(entry.startTime).split(':').map(Number);
   if (parts.length < 2 || !Number.isFinite(parts[0]) || !Number.isFinite(parts[1])) return null;
+  const w = { until: 'until', at: 'at', ...(words || {}) };
   const d = new Date(nowMs);
   d.setHours(parts[0], parts[1], 0, 0);
   const startMs = d.getTime();
@@ -39,7 +42,7 @@ export function buildUpNextFact(entry, nowMs, formatTime) {
   return {
     title: entry.title || '',
     inProgress,
-    timeLabel: inProgress ? `until ${formatTime(toHHMM(endMs))}` : `at ${formatTime(toHHMM(startMs))}`,
+    timeLabel: inProgress ? `${w.until} ${formatTime(toHHMM(endMs))}` : `${w.at} ${formatTime(toHHMM(startMs))}`,
     countdownStartMs: inProgress ? startMs : nowMs,
     countdownEndMs: inProgress ? endMs : startMs,
   };

--- a/src/utils/liveActivity.test.js
+++ b/src/utils/liveActivity.test.js
@@ -48,6 +48,13 @@ describe('buildUpNextFact', () => {
     expect(buildUpNextFact({ title: 'x', startTime: 'junk' }, at(9, 0), fmt)).toBeNull();
   });
 
+  it('localized label words replace the English defaults', () => {
+    const upcoming = buildUpNextFact({ title: 'x', startTime: '15:30', duration: 30 }, at(14, 0), fmt, { until: 'bis', at: 'um' });
+    expect(upcoming.timeLabel).toBe('um 15:30');
+    const running = buildUpNextFact({ title: 'x', startTime: '13:00', duration: 120 }, at(14, 0), fmt, { until: 'bis', at: 'um' });
+    expect(running.timeLabel).toBe('bis 15:00');
+  });
+
   it('label wording goes through the caller-provided formatter', () => {
     const twelveHour = (t) => {
       const [h, m] = t.split(':').map(Number);


### PR DESCRIPTION
Pre-release blocker for v4.2.0: the new features shipped with literal English strings, breaking the v4.1.0 standard of localizing every new feature in all six languages. This closes the gap end-to-end — including the Dynamic Island.

## JS side (six locales: en, de, es, fr, it, pt)

New `strip` section (21 keys) plus `settings.liveActivity`/`liveActivityDesc` and `app.alarmAt`/`dayStartsAt`, wired through `t()` in:

- **SummaryStrip + TitlebarSummaryStrip**: unblocked / Effort / Restore / untagged / "Set day window…"
- **DayWindowMenu**: heading, description, Starts/Ends, "Set…", "Clear for this day". The description's inline bold spans became one plain translatable sentence — word order can't survive markup splicing across six languages.
- **DayWindowMarkers**: the start/end chips (uppercased by CSS, so lowercase keys localize cleanly)
- **Energy context-menu item**: `Energy: {{value}}` / `Energy: Auto ({{value}})` with localized Effort/Restore values
- **Live Activity toggle** (label follows Apple's own locale terms: Live-Aktivität, Actividad en Vivo, Activité en direct, Attività in tempo reale, Atividade ao Vivo)
- **GLANCEahead**: "Alarm at" / "Day starts at" as prefix keys (styled time appended; all six languages put the time last)

## The island — localized through the payload, zero iOS infrastructure

Consistent with the architecture ("JS owns all island wording"):

- `buildUpNextFact` accepts localized `until`/`at` words — English defaults keep existing tests and callers stable (+1 test asserting the words flow through)
- The snapshot's `daySummary` gains `labels: {done, remaining, startsIn, noMoreBlocks}`, built with `t()` (and `t` added to the effect deps so a language switch refreshes the widgets)
- `ContentState` carries the four words; the bridge falls back to English for old snapshots; the Swift views render **only** payload strings — no String Catalog, no `.lproj`, nothing to maintain in Xcode

## Verification

- All six locale files parse; lint clean; **1121 tests** green (+1); web, Electron, iOS, and Android bundles all build
- Swift not compiled here; no new files — plain rebuild
- Worth a quick device/desktop pass in German (the longest strings — "Tagesfenster festlegen…", "Keine weiteren Blöcke heute") to confirm pill and island layouts hold; the island's existing one-line + scale-down guards should absorb them

Once merged, the 4.2.0 release notes can honestly close with the localization line again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmCS1UZrYtstNcEft7D21s)_