### PR TITLE
Fix both MAS-console diagnostics: bucketConfig merge + routine-rollover release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1598,9 +1598,9 @@
       }
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1804,6 +1804,16 @@
       },
       "engines": {
         "node": ">=16.4"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
@@ -2390,9 +2400,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2481,9 +2491,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4931,29 +4941,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/app-builder-lib/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/app-builder-lib/node_modules/ci-info": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -5359,13 +5346,26 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6136,9 +6136,9 @@
       }
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6874,9 +6874,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7123,6 +7123,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -9181,29 +9191,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -10590,9 +10577,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
     "ws": "^8.21.0"
   },
   "overrides": {
-    "serialize-javascript": ">=7.0.5"
+    "serialize-javascript": ">=7.0.5",
+    "brace-expansion@1": "^1.1.18",
+    "brace-expansion@2": "^2.1.4",
+    "brace-expansion@5": "^5.0.9"
   },
   "devDependencies": {
     "@electron/notarize": "^3.1.1",

--- a/scripts/audit-check.mjs
+++ b/scripts/audit-check.mjs
@@ -20,16 +20,10 @@
 import { spawnSync } from 'node:child_process';
 
 const ACK = {
-  'GHSA-mh99-v99m-4gvg': {
-    disposition: 'accept',
-    pkg: 'brace-expansion',
-    reason:
-      'Dev/build-only DoS, pulled transitively by eslint + electron-builder ' +
-      '(via minimatch/glob). No in-major patch exists (fix requires eslint 10 / ' +
-      'electron-builder majors, or a cross-major override we judged too risky). ' +
-      'Not in production.',
-    review: '2026-12-31',
-  },
+  // GHSA-mh99-v99m-4gvg (brace-expansion) was accepted here while no in-major
+  // patch existed. Its bypass advisory (GHSA-rgw5-rvv9-x895) shipped in-major
+  // fixes for BOTH (1.1.18 / 2.1.4 / 5.0.9), now forced via package.json
+  // per-major overrides — so both advisories are FIXED, not acknowledged.
   'GHSA-fx2h-pf6j-xcff': {
     disposition: 'defer', pkg: 'vite',
     reason: 'Dev-server `server.fs.deny` bypass (Windows only). Fix with the vite 5->8 upgrade.',

--- a/src/mergeSync.canary.test.js
+++ b/src/mergeSync.canary.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { mergeSyncData } from './mergeSync.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FILE-TIER SLICE-COVERAGE CANARY
+//
+// The upstream merge (@glance-apps/sync mergeSyncData) DROPS unknown keys, and
+// unlike the vault tier (whose mergeBundle default case at least WARNS), the
+// file tier has no tripwire: a payload key without merge handling silently
+// vanishes from every merged file. That is exactly how bucketConfig shipped
+// broken — heading edits never propagated and each re-upload removed the slice
+// (fixed alongside this canary); dayWindows only avoided the same fate because
+// its wrapper line was written up front.
+//
+// This test mechanizes the audit that found it, permanently:
+//   1. The payload key list is parsed from buildSyncPayload's SOURCE
+//     (src/App.jsx), so the canary cannot drift from what the app actually
+//     uploads — a new payload key fails test 1 until it is added to the
+//     fixture below, and then fails tests 2/3 until it actually survives the
+//     merge (upstream, wrapper, or a documented device-local exemption).
+//   2/3. Every fixture key must survive mergeSyncData in BOTH directions:
+//     local-only (our data survives a merge against an empty remote — and gets
+//     re-uploaded) and remote-only (another device's data reaches us).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const APP_SRC = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), 'App.jsx'), 'utf8');
+
+function payloadKeysFromSource() {
+  const start = APP_SRC.indexOf('const buildSyncPayload');
+  expect(start).toBeGreaterThan(-1);
+  // The function is small; 200 lines comfortably covers it without reaching
+  // the next `data: {` in the file.
+  const slice = APP_SRC.slice(start).split('\n').slice(0, 200);
+  const end = slice.findIndex((l) => l === '  };');
+  const body = slice.slice(0, end === -1 ? undefined : end).join('\n');
+  // Keys of the `data: { ... }` object sit at exactly 8-space indent
+  // (version/lastModified/data are at 6): `key: expr,` OR shorthand `key,`.
+  // Comments and deeper-indented call arguments never match.
+  const keys = [...body.matchAll(/^ {8}([A-Za-z][A-Za-z0-9]*)[,:]/gm)].map((m) => m[1]);
+  expect(keys.length).toBeGreaterThan(30); // parse sanity — the payload is big
+  return keys;
+}
+
+// Keys the FILE tier deliberately does not carry: per-device values whose
+// merged-file absence is the mechanism that keeps them local (see
+// ALWAYS_DEVICE_LOCAL in dbAdapter.js — "weather not in merge output", and
+// multiUserEnabled is per-device on BOTH tiers so one household member's
+// toggle never flips everyone's).
+const DEVICE_LOCAL_ON_FILE_TIER = new Set([
+  'weatherZip', 'weatherTempUnit', 'multiUserEnabled', 'multiUserEnabledUpdatedAt',
+]);
+
+const ISO = '2026-08-01T10:00:00.000Z';
+
+// One non-empty, type-correct sentinel per payload key. Non-empty matters:
+// several wrapper blocks route a slice only when a side HAS it, so an empty
+// value could pass vacuously.
+const REPRESENTATIVE = {
+  tasks: [{ id: 't1', title: 'task', date: '2026-08-01', lastModified: ISO }],
+  unscheduledTasks: [{ id: 'u1', title: 'inbox', lastModified: ISO }],
+  unscheduledOrderTimestamp: ISO,
+  recycleBin: [{ id: 'r1', title: 'binned', lastModified: ISO }],
+  syncUrl: 'https://dav.example.com/cal',
+  taskCalendarUrl: 'https://dav.example.com/tasks',
+  calendarConfigByUser: { u1: { syncUrl: 'https://x', updatedAt: ISO } },
+  completedTaskUids: ['uid-1::2026-08-01'],
+  recurringTasks: [{ id: 'rec1', title: 'series', recurrence: { type: 'daily' }, completedDates: [], lastModified: ISO }],
+  routineDefinitions: { morning: [{ id: 'chip1', name: 'stretch' }] },
+  todayRoutines: [{ id: 'chip1', name: 'stretch', lastModified: ISO }],
+  routinesDate: '2026-08-01',
+  routineCompletions: { chip1: true },
+  routineCompletionTimestamps: { chip1: ISO },
+  minimizedSections: { inbox: true },
+  use24HourClock: true,
+  weatherZip: '60601',
+  weatherTempUnit: 'F',
+  deletedTaskIds: { gone1: ISO },
+  deletedRoutineChipIds: { gonechip: ISO },
+  deletedFrameIds: { goneframe: ISO },
+  deletedObsidianKeys: { '2026-07-01': ISO },
+  removedTodayRoutineIds: { removedchip: ISO },
+  dailyNotes: { '2026-08-01': 'a note' },
+  dayWindows: { defaults: { start: '08:00', stop: '22:00', lastModified: ISO } },
+  habits: [{ id: 'h1', name: 'walk', lastModified: ISO }],
+  habitLogs: { '2026-08-01': { h1: 1 } },
+  habitLogTimestamps: { '2026-08-01:h1': ISO },
+  habitsEnabled: true,
+  habitsEnabledUpdatedAt: ISO,
+  deletedHabitIds: { gonehabit: ISO },
+  routinesEnabled: true,
+  routinesEnabledUpdatedAt: ISO,
+  gtdFrames: [{ id: 'f1', label: 'Deep', start: '09:00', end: '11:00', lastModified: ISO }],
+  bucketConfig: { headings: { b1: 'Anytime', b2: 'Someday' }, secondListHidden: false, notes: '', updatedAt: ISO },
+  goals: [{ id: 'g1', title: 'goal', status: 'active', updatedAt: ISO }],
+  deletedGoalIds: { gonegoal: ISO },
+  projects: [{ id: 'p1', title: 'project', status: 'active', updatedAt: ISO }],
+  deletedProjectIds: { goneproject: ISO },
+  areas: [{ id: 'a1', title: 'area', updatedAt: ISO }],
+  deletedAreaIds: { gonearea: ISO },
+  goalsProjectsEnabled: true,
+  goalsProjectsEnabledUpdatedAt: ISO,
+  obsidianConfig: { dailyNotesFolder: 'Daily' },
+  obsidianConfigUpdatedAt: ISO,
+  multiUserEnabled: false,
+  multiUserEnabledUpdatedAt: ISO,
+  users: [{ syncId: 'u1', name: 'Me', updatedAt: ISO }],
+  tombstonePrunedBefore: ISO,
+};
+
+const emptyData = () => ({
+  tasks: [], unscheduledTasks: [], recycleBin: [], recurringTasks: [],
+  completedTaskUids: [], deletedTaskIds: {},
+  syncUrl: null, taskCalendarUrl: null,
+  routineDefinitions: {}, todayRoutines: [], routinesDate: '',
+  minimizedSections: {}, use24HourClock: false,
+});
+
+describe('file-tier slice-coverage canary', () => {
+  it('1. the fixture covers every key buildSyncPayload actually uploads (parsed from source)', () => {
+    const sourceKeys = payloadKeysFromSource();
+    const missing = sourceKeys.filter((k) => !(k in REPRESENTATIVE));
+    // A new payload key lands here first: add a non-empty sentinel above AND
+    // make sure the slice survives the merge (tests 2/3) — that means upstream
+    // handling, a wrapper block in mergeSync.js, or a documented device-local
+    // exemption. Do not just append to the fixture and move on.
+    expect(missing).toEqual([]);
+  });
+
+  it('2. every slice survives a merge as the LOCAL side (against an empty remote)', () => {
+    const { data } = mergeSyncData({ ...REPRESENTATIVE }, emptyData());
+    const dropped = Object.keys(REPRESENTATIVE)
+      .filter((k) => !DEVICE_LOCAL_ON_FILE_TIER.has(k))
+      .filter((k) => data[k] === undefined);
+    expect(dropped).toEqual([]);
+  });
+
+  it('3. every slice survives a merge as the REMOTE side (another device reaches us)', () => {
+    const { data } = mergeSyncData(emptyData(), { ...REPRESENTATIVE });
+    const dropped = Object.keys(REPRESENTATIVE)
+      .filter((k) => !DEVICE_LOCAL_ON_FILE_TIER.has(k))
+      .filter((k) => data[k] === undefined);
+    expect(dropped).toEqual([]);
+  });
+});

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -309,6 +309,28 @@ export const mergeSyncData = (local, remote, retentionDays) => {
     if (!dayWindowMapsEqual(mergedW, rw)) result.remoteChanged = true;
   }
 
+  // Bucket List config (headings / secondListHidden / notes): whole-object LWW
+  // by its embedded updatedAt (stamped on every setBucketConfig edit). The
+  // upstream merge predates this slice and DROPS unknown keys, so without this
+  // wrapper the merged file silently lost bucketConfig on every file-tier
+  // merge — heading edits never propagated between devices, and each re-upload
+  // removed the slice from the file. Remote wins ties (pickConfigByTs
+  // convention), matching the vault bundle's mergeBundle case exactly so the
+  // two tiers cannot disagree.
+  if (local?.bucketConfig || remote?.bucketConfig) {
+    const lb = local?.bucketConfig || null;
+    const rb = remote?.bucketConfig || null;
+    const bts = (v) => { const t = new Date(v ?? 0).getTime(); return Number.isNaN(t) ? 0 : t; };
+    const winner = bts(rb?.updatedAt) >= bts(lb?.updatedAt) ? (rb || lb) : lb;
+    result.data.bucketConfig = winner;
+    // Same change-flag contract as dayWindows above: localChanged triggers the
+    // local apply, remoteChanged the re-upload that heals a remote file
+    // missing the slice (one written by an older client — or by any client
+    // before this fix existed).
+    if (winner !== lb) result.localChanged = true;
+    if (winner !== rb) result.remoteChanged = true;
+  }
+
   // Recurring completions ride inside the shared template row, which the upstream
   // merge resolves by whole-row LWW — re-merge each series' completedDates by date
   // so a completion is never clobbered by a concurrent edit to the same series

--- a/src/sync/bucketConfigSync.test.js
+++ b/src/sync/bucketConfigSync.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { applyRemoteEntity } from './dbAdapter.js';
+import { mergeSyncData } from '../mergeSync.js';
+
+// Cross-tier wiring for the bucketConfig slice (Bucket List headings /
+// secondListHidden / notes), mirroring dayWindowSync.integration.test.js:
+// before these merges existed, the vault tier fell to the default
+// LWW-overwrite (the '[dbAdapter] bundle has no merge strategy' console
+// warning observed in production) and the FILE tier silently DROPPED the
+// slice — the upstream merge predates it and discards unknown keys, so
+// heading edits never propagated and each re-upload removed them from the
+// file. Resolution on both tiers: whole-object LWW by the embedded
+// updatedAt (stamped on every setBucketConfig edit), remote wins ties.
+
+const cfg = (b1, updatedAt) => ({
+  headings: { b1, b2: 'Someday' }, secondListHidden: false, notes: '', updatedAt,
+});
+
+const emptyData = () => ({
+  tasks: [], unscheduledTasks: [], recycleBin: [], recurringTasks: [],
+  completedTaskUids: [], deletedTaskIds: {},
+  syncUrl: null, taskCalendarUrl: null,
+  routineDefinitions: {}, todayRoutines: [], routinesDate: '',
+  minimizedSections: {}, use24HourClock: false,
+});
+
+describe('GLANCEvault tier — bucketConfig singleton bundle', () => {
+  it('a newer pulled config wins', () => {
+    const data = { ...emptyData(), bucketConfig: cfg('Anytime', '2026-08-01T10:00:00Z') };
+    applyRemoteEntity(data, {
+      _kind: 'singleton', _key: 'bucketConfig',
+      value: cfg('Later', '2026-08-02T10:00:00Z'),
+    });
+    expect(data.bucketConfig.headings.b1).toBe('Later');
+  });
+
+  it('an older pulled config loses — the local edit survives the pull', () => {
+    const data = { ...emptyData(), bucketConfig: cfg('Renamed', '2026-08-02T10:00:00Z') };
+    applyRemoteEntity(data, {
+      _kind: 'singleton', _key: 'bucketConfig',
+      value: cfg('Anytime', '2026-08-01T10:00:00Z'),
+    });
+    expect(data.bucketConfig.headings.b1).toBe('Renamed');
+  });
+});
+
+describe('file tier — mergeSyncData wrapper routes bucketConfig', () => {
+  it('the slice SURVIVES the merge at all (the upstream merge drops unknown keys)', () => {
+    const local = { ...emptyData(), bucketConfig: cfg('Anytime', '2026-08-01T10:00:00Z') };
+    const { data, remoteChanged } = mergeSyncData(local, emptyData());
+    expect(data.bucketConfig).toEqual(cfg('Anytime', '2026-08-01T10:00:00Z'));
+    // Heals a remote file missing the slice (older client, or pre-fix uploads).
+    expect(remoteChanged).toBe(true);
+  });
+
+  it('newer side wins in both directions', () => {
+    const older = { ...emptyData(), bucketConfig: cfg('Anytime', '2026-08-01T10:00:00Z') };
+    const newer = { ...emptyData(), bucketConfig: cfg('Renamed', '2026-08-02T10:00:00Z') };
+    expect(mergeSyncData(older, newer).data.bucketConfig.headings.b1).toBe('Renamed');
+    expect(mergeSyncData(newer, older).data.bucketConfig.headings.b1).toBe('Renamed');
+  });
+
+  it('a losing local edit flags localChanged so the apply actually runs', () => {
+    const local = { ...emptyData(), bucketConfig: cfg('Stale', '2026-08-01T10:00:00Z') };
+    const remote = { ...emptyData(), bucketConfig: cfg('Fresh', '2026-08-02T10:00:00Z') };
+    const { localChanged } = mergeSyncData(local, remote);
+    expect(localChanged).toBe(true);
+  });
+});

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -488,6 +488,14 @@ function mergeBundle(data, key, value, extra) {
       data.dayWindows = mergeDayWindowMaps(data.dayWindows || {}, value || {});
       return;
     }
+    case 'bucketConfig': {
+      // Whole-object LWW by the config's embedded updatedAt (stamped on every
+      // setBucketConfig edit); remote wins ties via pickByTs, matching the
+      // file tier's wrapper (mergeSync.js) so the tiers cannot disagree.
+      // Field grain isn't warranted for three rarely-edited fields.
+      data.bucketConfig = pickByTs(data.bucketConfig, data.bucketConfig?.updatedAt, value, value?.updatedAt);
+      return;
+    }
     case 'calendarConfigByUser': {
       // {syncId → {syncUrl, taskCalendarUrl, auth?, updatedAt}}: union by syncId,
       // keep the newer entry per user (LWW). Each device reads only its own

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -535,7 +535,13 @@ export function createDbEngine(callbacks = {}) {
             if (isPayloadExcludedEntity(ent, {
               multiUserEnabled: callbacks.isMultiUserEnabled?.() === true,
             })) return 'payload-excluded';
-            return agedOutReleaseReason(ent, { horizonMs: tombstoneCutoff().getTime() });
+            return agedOutReleaseReason(ent, {
+              horizonMs: tombstoneCutoff().getTime(),
+              // Local midnight: a todayRoutines chip last touched before it is
+              // a prior-day chip the rollover cleared by design ('routine-
+              // rollover'), not a glitch to heal.
+              dayStartMs: new Date().setHours(0, 0, 0, 0),
+            });
           },
         );
         glitchSkipped = skipped;
@@ -544,7 +550,7 @@ export function createDbEngine(callbacks = {}) {
           // untouched in the vault; the next SAVED snapshot (hashed from the
           // mirror, which never contains them) simply stops tracking them. Info-
           // level on purpose — this is a one-time convergence, not a problem.
-          const counts = { 'payload-excluded': 0, completed: 0, 'sync-horizon': 0 };
+          const counts = { 'payload-excluded': 0, completed: 0, 'sync-horizon': 0, 'routine-rollover': 0 };
           for (const eid of excluded) {
             if (reasons[eid] in counts) counts[reasons[eid]]++;
           }
@@ -552,6 +558,7 @@ export function createDbEngine(callbacks = {}) {
             counts['payload-excluded'] ? `${counts['payload-excluded']} payload-excluded (native / non-synced imports)` : '',
             counts.completed ? `${counts.completed} completed (aged out of the working set)` : '',
             counts['sync-horizon'] ? `${counts['sync-horizon']} sync-horizon (older than the file-tier zombie-drop fence)` : '',
+            counts['routine-rollover'] ? `${counts['routine-rollover']} routine-rollover (prior-day chips the midnight rollover cleared)` : '',
           ].filter(Boolean).join(', ');
           console.info(
             `[push] baseline: released ${excluded.length} row(s) — ${breakdown}. ` +

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -1195,10 +1195,11 @@ describe('issue #1196 — the midnight rollover speaks the vanish-delete guard\'
     expect(snap['todayRoutines:chipA']).toBeUndefined();
   });
 
-  it('CONTROL (the pre-fix bug): a bare clear with a WIPED tombstone map is skipped by the guard and resurrected by the heal', async () => {
+  it('CONTROL (the pre-fix shape): a bare clear with a WIPED tombstone map — PRIOR-DAY chips are released, not healed', async () => {
     const vault = createMemoryVault({ rowGet: true });
     const A = makeDevice('A', vault, {
       ...EMPTY,
+      // lastModified predates the REAL test-run day's midnight → prior-day.
       todayRoutines: [routine('chipA', '2026-06-18T10:00:00.000Z')],
       routinesDate: '2026-06-18',
       removedTodayRoutineIds: {},
@@ -1213,8 +1214,38 @@ describe('issue #1196 — the midnight rollover speaks the vanish-delete guard\'
     A.data.routinesDate = '2026-06-19';
     await A.engine.dbSyncCycle();
 
-    // Guard skips the un-tombstoned vanish and the heal resurrects the row —
-    // this is the reported symptom, pinned here so the fix's contract is clear.
+    // Pre-release-classifier, this was the reported #1196 symptom: guard skips
+    // the un-tombstoned vanish and the heal resurrects the row. The
+    // 'routine-rollover' baseline release now catches it instead: a prior-day
+    // chip can never legitimately reappear in getData(), so it is neither
+    // deleted fleet-wide nor healed back — no GUARD churn, no resurrection,
+    // and the baseline stops tracking it.
+    expect(warnSpy.mock.calls.filter((c) => String(c[0]).includes('GUARD'))).toEqual([]);
+    expect(A.data.todayRoutines).toEqual([]);
+    const snap = JSON.parse(global.localStorage.getItem('dev-A-db-sync-snapshot') || '{}');
+    expect(snap['todayRoutines:chipA']).toBeUndefined();
+  });
+
+  it('CONTROL (guard machinery intact): a SAME-DAY chip vanishing without a tombstone is still glitch-skipped and healed', async () => {
+    const vault = createMemoryVault({ rowGet: true });
+    // Stamped "now": at or after the current day's midnight, so the
+    // routine-rollover release must NOT claim it — a same-day vanish with no
+    // fingerprint is a genuine glitch-suspect and heals exactly as before.
+    const A = makeDevice('A', vault, {
+      ...EMPTY,
+      todayRoutines: [routine('chipA', new Date().toISOString())],
+      routinesDate: '2026-06-18',
+      removedTodayRoutineIds: {},
+    });
+    await A.engine.dbSyncCycle();
+    await A.engine.dbSyncCycle();
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    A.data.todayRoutines = [];
+    A.data.routinesDate = '2026-06-19';
+    await A.engine.dbSyncCycle();
+
     expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('GUARD'))).toBe(true);
     expect(A.data.todayRoutines.map((r) => r.id)).toContain('chipA');
   });

--- a/src/sync/payloadExclusions.js
+++ b/src/sync/payloadExclusions.js
@@ -69,22 +69,43 @@ export function isPayloadExcludedEntity(entity, { multiUserEnabled = false } = {
  *                    sync horizon: this is exactly the zombie-drop condition, so
  *                    the file tier will re-drop it every cycle.
  *
+ * A third shape covers routine chips ('todayRoutines' only):
+ *   'routine-rollover' — a chip whose lastModified predates the CURRENT day's
+ *                    start. Chips live for exactly one day: the midnight
+ *                    rollover rebuilds todayRoutines for the new date, so a
+ *                    prior-day ad-hoc chip vanishes with no tombstone by
+ *                    design (removedTodayRoutineIds marks user removals,
+ *                    deletedRoutineChipIds deleted definitions — rollover
+ *                    marks nothing). The file tier understands this via
+ *                    routinesDate (@glance-apps/sync mergeSyncData); the
+ *                    vanish-guard cannot, so without this release a stale
+ *                    chip is glitch-flagged and heal-fetched forever. A chip
+ *                    touched TODAY stays a glitch-suspect and heals normally.
+ *
  * Release = not propagated as a delete, not heal-fetched, dropped from the diff
  * baseline. The vault row is UNTOUCHED (it survives for other devices); the next
  * saved snapshot stops tracking it and the loop ends. Only would-be 'glitch' rows
  * reach here — tombstoned / stale-tombstone / cross-list are decided first.
  *
  * @param {object} entity  wrapped entity ({ _kind, value }, see dbAdapter.js)
- * @param {{ horizonMs?: number }} [opts]  horizonMs = the file-tier sync-horizon
- *   epoch ms (tombstoneCutoff().getTime()); omit / non-finite → skip the horizon
- *   branch (the 'completed' branch still applies).
- * @returns {'completed'|'sync-horizon'|null}
+ * @param {{ horizonMs?: number, dayStartMs?: number }} [opts]
+ *   horizonMs = the file-tier sync-horizon epoch ms (tombstoneCutoff().getTime());
+ *   dayStartMs = epoch ms of the current day's local midnight. Either omitted /
+ *   non-finite → its branch is skipped (fail toward keeping).
+ * @returns {'completed'|'sync-horizon'|'routine-rollover'|null}
  */
-export function agedOutReleaseReason(entity, { horizonMs = NaN } = {}) {
+export function agedOutReleaseReason(entity, { horizonMs = NaN, dayStartMs = NaN } = {}) {
   if (!entity || typeof entity !== 'object') return null;
-  if (entity._kind !== 'tasks' && entity._kind !== 'unscheduledTasks') return null;
   const t = entity.value;
   if (!t || typeof t !== 'object') return null;
+  if (entity._kind === 'todayRoutines') {
+    if (Number.isFinite(dayStartMs)) {
+      const lm = new Date(t.lastModified).getTime();
+      if (Number.isFinite(lm) && lm < dayStartMs) return 'routine-rollover';
+    }
+    return null;
+  }
+  if (entity._kind !== 'tasks' && entity._kind !== 'unscheduledTasks') return null;
   if (t.completed === true) return 'completed';
   if (Number.isFinite(horizonMs)) {
     const lm = new Date(t.lastModified).getTime();

--- a/src/sync/payloadExclusions.test.js
+++ b/src/sync/payloadExclusions.test.js
@@ -83,3 +83,33 @@ describe('agedOutReleaseReason — the file-tier zombie-drop populations', () =>
     expect(rel('tasks', undefined)).toBeNull();
   });
 });
+
+describe('agedOutReleaseReason — routine-rollover (prior-day chips)', () => {
+  const DAY_START = new Date('2026-08-03T00:00:00').getTime();
+  const rel = (value, opts = { dayStartMs: DAY_START }) =>
+    agedOutReleaseReason({ _kind: 'todayRoutines', value }, opts);
+
+  it('RELEASES a chip last touched before today — the midnight rollover cleared it by design', () => {
+    expect(rel({ id: '1770477319151', lastModified: '2026-02-07T14:00:00Z' })).toBe('routine-rollover');
+    expect(rel({ id: 'x', lastModified: '2026-08-02T23:59:00' })).toBe('routine-rollover');
+  });
+
+  it("KEEPS a chip touched today — a same-day vanish is still a glitch-suspect and heals", () => {
+    expect(rel({ id: 'x', lastModified: '2026-08-03T08:00:00' })).toBeNull();
+  });
+
+  it('fails safe: no dayStartMs, or no parseable lastModified → keep the glitch classification', () => {
+    expect(rel({ id: 'x', lastModified: '2026-02-07T14:00:00Z' }, {})).toBeNull();
+    expect(rel({ id: 'x' })).toBeNull();
+    expect(rel({ id: 'x', lastModified: 'not-a-date' })).toBeNull();
+  });
+
+  it('routine-rollover is scoped to todayRoutines; task kinds never take the branch', () => {
+    expect(agedOutReleaseReason(
+      { _kind: 'tasks', value: { lastModified: '2026-02-07T14:00:00Z' } },
+      { dayStartMs: DAY_START },
+    )).toBeNull();
+    // And a todayRoutines chip never takes the task branches ('completed').
+    expect(rel({ id: 'x', completed: true, lastModified: '2026-08-03T08:00:00' })).toBeNull();
+  });
+});


### PR DESCRIPTION
Both console diagnostics from the MAS build turned out to be real, and one was worse than its warning. A follow-up commit adds the **pre-release audit** for other instances of both bug classes, plus a permanent canary.

## 1. `bucketConfig has no merge strategy` — a double gap

- **Vault tier** (the warning you saw): the bundle fell to the default LWW overwrite — a pulled config clobbered local edits regardless of age.
- **File tier** (silent, worse): upstream `mergeSyncData` predates the slice and **drops unknown keys**, and the wrapper never re-added `bucketConfig` — so it vanished from every WebDAV/iCloud merge. Heading edits never propagated between devices, and each re-upload removed the slice from the file.

**Fix**: both tiers resolve identically — whole-object LWW by the config's embedded `updatedAt`, remote wins ties. `mergeBundle` case on the vault tier; post-merge wrapper on the file tier with the standard heal flags.

## 2. `GUARD: skipped 4 vanish-delete(s) … todayRoutines … (glitch)` — permanent churn

Prior-day **ad-hoc routine chips** (three from February). The midnight rollover clears `todayRoutines` with **no tombstone by design**; the file tier understands this via `routinesDate`, the vanish-guard cannot — so stale chips were glitch-flagged and heal-churned every cycle. **Fix**: new `'routine-rollover'` baseline-release class — a chip whose `lastModified` predates today's local midnight can never reappear in `getData()`, so it's released (not deleted fleet-wide, not healed). Same-day chips keep full glitch protection. The #1196 control test is re-pinned as two controls (prior-day → released; same-day → still guarded and healed).

## 3. Pre-release audit (commit 2) — both classes swept

**Class A — slice coverage.** Mechanical matrix over all **49** `buildSyncPayload` keys × (upstream merge / wrapper / dbAdapter): `bucketConfig` was the **only** gap. The nine tombstone maps merge generically on both tiers (`TOMBSTONE_BUNDLE_KEYS` loops); `areas` is a full collection kind; weather + `multiUserEnabled(+UpdatedAt)` are device-local on both tiers by documented design.

**Class B — tombstone-less vanish paths.** Every collection audited: bin-empty tombstones every row; restore is a cross-list move; both recurring series-delete sites tombstone; `users` are soft-deleted (flag, row stays); habits/goals/projects/areas/frames all have tombstone maps; `completedTaskUids` pruning is a bundle value change, not an entity vanish. The routines rollover was the only instance.

**The lasting piece — a file-tier canary** (`mergeSync.canary.test.js`): the vault tier warns on an unhandled bundle, but the file tier silently drops unknown keys — exactly how bucketConfig shipped broken. The canary (1) **parses the payload key list from `buildSyncPayload`'s source** so it can't drift — a new payload key fails the canary until its merge story exists; (2) asserts every non-device-local slice survives `mergeSyncData` in **both directions** with non-empty sentinels. Mutation-verified: reintroducing the bucketConfig gap fails 2 canary tests, **naming the dropped key**.

## Verification

- 14 new tests total (classifier ×5, bucketConfig tiers ×6, canary ×3); full suite **1134 green**; lint clean; all four bundles build.
- Mutation checks: file-tier wrapper removal → 3 + 2 canary failures; vault case removal → 1; classifier flip → 3.
- On your Mac after merging: both console messages disappear (the four chips release once with an info line, then silence), and bucket heading edits propagate across devices for the first time.