### PR TITLE
Explain multi-user correctly on an iCloud-only device

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -349,7 +349,7 @@
     "removeFileImportedConfirm": "Remove all {{n}} file-imported events? Re-importing the file brings them back.",
     "liveActivity": "Live Activity",
     "liveActivityDesc": "Today's plan in the Dynamic Island and on the Lock Screen. Widens the island, which hides the signal icons next to the clock.",
-    "multiUserICloudOnly": "Requires a shared sync destination. iCloud syncs your own devices under one Apple ID, so it cannot give two people a shared list — set up GLANCEvault or WebDAV sync for that."
+    "multiUserICloudOnly": "Requires a shared sync destination. iCloud syncs your own devices under one Apple ID, so it cannot give two people a shared list. Set up GLANCEvault or WebDAV sync for that."
   },
   "task": {
     "newScheduled": "New Scheduled Task",
@@ -948,17 +948,17 @@
     "warning": "This erases all tasks, notes, habits, goals, projects and settings on this device, and cannot be undone. Export a backup first if you want to keep a copy.",
     "exportFirst": "Export a backup first",
     "scopeDevice": "This device only",
-    "scopeDeviceHint": "The copy in iCloud is kept, and this device can read it straight back — even if syncing is off. Use this only to fix a bad local state, not to start over.",
+    "scopeDeviceHint": "The copy in iCloud is kept, and this device can read it straight back even if syncing is off. Use this only to fix a bad local state, not to start over.",
     "scopeEverywhere": "This device and iCloud",
     "scopeEverywhereHint": "Also deletes the copy in iCloud, so nothing restores it here or on a reinstall.",
     "confirm": "Erase everything",
     "working": "Erasing…",
     "partialFailure": "Some data could not be cleared:",
-    "otherDevices": "Quitting dayGLANCE elsewhere is not enough — a device that is closed restores its copy the next time you open it, and one left running restores it within seconds. To actually start over, reset every device, and do not reopen the others until you have."
+    "otherDevices": "Quitting dayGLANCE elsewhere is not enough. A device that is closed restores its copy the next time you open it, and one left running restores it within seconds. To actually start over, reset every device, and do not reopen the others until you have."
   },
   "icloudDiag": {
     "title": "iCloud diagnostics",
-    "hint": "Read-only. Reports what this device currently sees in the iCloud container — nothing is written, deleted or synced.",
+    "hint": "Read-only. Reports what this device currently sees in the iCloud container. Nothing is written, deleted or synced.",
     "run": "Run check",
     "running": "Checking…",
     "platform": "Platform",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -348,7 +348,8 @@
     "removeFileImported": "Remove file-imported events",
     "removeFileImportedConfirm": "Remove all {{n}} file-imported events? Re-importing the file brings them back.",
     "liveActivity": "Live Activity",
-    "liveActivityDesc": "Today's plan in the Dynamic Island and on the Lock Screen. Widens the island, which hides the signal icons next to the clock."
+    "liveActivityDesc": "Today's plan in the Dynamic Island and on the Lock Screen. Widens the island, which hides the signal icons next to the clock.",
+    "multiUserICloudOnly": "Requires a shared sync destination. iCloud syncs your own devices under one Apple ID, so it cannot give two people a shared list — set up GLANCEvault or WebDAV sync for that."
   },
   "task": {
     "newScheduled": "New Scheduled Task",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -349,7 +349,7 @@
     "removeFileImportedConfirm": "Supprimer les {{n}} événements importés depuis un fichier ? Réimporter le fichier les restaurera.",
     "liveActivity": "Activité en direct",
     "liveActivityDesc": "Le plan du jour dans la Dynamic Island et sur l'écran verrouillé. Élargit l'île et masque les icônes de signal près de l'horloge.",
-    "multiUserICloudOnly": "Nécessite une destination de synchronisation partagée. iCloud synchronise vos propres appareils sous un seul identifiant Apple et ne peut donc pas donner une liste partagée à deux personnes — configurez GLANCEvault ou WebDAV pour cela."
+    "multiUserICloudOnly": "Nécessite une destination de synchronisation partagée. iCloud synchronise vos propres appareils sous un seul identifiant Apple et ne peut donc pas donner une liste partagée à deux personnes. Configurez GLANCEvault ou WebDAV pour cela."
   },
   "task": {
     "newScheduled": "Nouvelle tâche planifiée",
@@ -948,17 +948,17 @@
     "warning": "Cette action efface toutes les tâches, notes, habitudes, objectifs, projets et réglages de cet appareil, et est irréversible. Exportez une sauvegarde d'abord si vous voulez en garder une copie.",
     "exportFirst": "Exporter une sauvegarde d'abord",
     "scopeDevice": "Cet appareil uniquement",
-    "scopeDeviceHint": "La copie dans iCloud est conservée, et cet appareil peut la relire directement — même si la synchronisation est désactivée. À n'utiliser que pour corriger un état local défectueux, pas pour repartir de zéro.",
+    "scopeDeviceHint": "La copie dans iCloud est conservée, et cet appareil peut la relire directement même si la synchronisation est désactivée. À n'utiliser que pour corriger un état local défectueux, pas pour repartir de zéro.",
     "scopeEverywhere": "Cet appareil et iCloud",
     "scopeEverywhereHint": "Supprime aussi la copie dans iCloud, afin que rien ne la restaure ici ni après une réinstallation.",
     "confirm": "Tout effacer",
     "working": "Effacement…",
     "partialFailure": "Certaines données n'ont pas pu être effacées :",
-    "otherDevices": "Quitter dayGLANCE ailleurs ne suffit pas — un appareil fermé restaure sa copie à la prochaine ouverture, et un appareil resté ouvert la restaure en quelques secondes. Pour vraiment repartir de zéro, réinitialisez chaque appareil, et ne rouvrez pas les autres avant de l'avoir fait."
+    "otherDevices": "Quitter dayGLANCE ailleurs ne suffit pas. Un appareil fermé restaure sa copie à la prochaine ouverture, et un appareil resté ouvert la restaure en quelques secondes. Pour vraiment repartir de zéro, réinitialisez chaque appareil, et ne rouvrez pas les autres avant de l'avoir fait."
   },
   "icloudDiag": {
     "title": "Diagnostic iCloud",
-    "hint": "Lecture seule. Indique ce que cet appareil voit actuellement dans le conteneur iCloud — rien n'est écrit, supprimé ni synchronisé.",
+    "hint": "Lecture seule. Indique ce que cet appareil voit actuellement dans le conteneur iCloud. Rien n'est écrit, supprimé ni synchronisé.",
     "run": "Lancer le test",
     "running": "Vérification…",
     "platform": "Plateforme",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -348,7 +348,8 @@
     "removeFileImported": "Supprimer les événements importés depuis un fichier",
     "removeFileImportedConfirm": "Supprimer les {{n}} événements importés depuis un fichier ? Réimporter le fichier les restaurera.",
     "liveActivity": "Activité en direct",
-    "liveActivityDesc": "Le plan du jour dans la Dynamic Island et sur l'écran verrouillé. Élargit l'île et masque les icônes de signal près de l'horloge."
+    "liveActivityDesc": "Le plan du jour dans la Dynamic Island et sur l'écran verrouillé. Élargit l'île et masque les icônes de signal près de l'horloge.",
+    "multiUserICloudOnly": "Nécessite une destination de synchronisation partagée. iCloud synchronise vos propres appareils sous un seul identifiant Apple et ne peut donc pas donner une liste partagée à deux personnes — configurez GLANCEvault ou WebDAV pour cela."
   },
   "task": {
     "newScheduled": "Nouvelle tâche planifiée",

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -25,7 +25,7 @@ import UserOwnerSwitcher from './UserOwnerSwitcher.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { isVaultEnabled } from '../sync/vaultConfig.js';
-import { multiUserToggleLocked } from '../utils/multiUserGate.js';
+import { multiUserToggleLocked, multiUserUnavailableReason, canSyncUserRoster } from '../utils/multiUserGate.js';
 import { getDbIntentsConfig, setDbIntentsConfig, getDbIntentsConnection } from '../intents/dbIntentsConfig.js';
 import { getIcloudIntentsEnabledFlag, setIcloudIntentsEnabled } from '../intents/icloudIntentsConfig.js';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
@@ -134,6 +134,18 @@ const MobileSettingsPanel = () => {
   } = useFeaturesCtx();
   // Gate multi-user when sync is unconfigured; never trap an already-on toggle.
   const multiUserLocked = multiUserToggleLocked({ cloudSyncConfigured, multiUserEnabled });
+  // "Requires cloud sync" is wrong on an iCloud-only device — that user IS
+  // syncing, just to a destination only they can reach. Pick the sentence that
+  // matches their situation instead of the generic one.
+  const multiUserReason = multiUserUnavailableReason({
+    cloudSyncConfigured,
+    icloudAvailable: isICloudAvailable(),
+  });
+  const multiUserRosterSyncable = canSyncUserRoster({
+    multiUserEnabled,
+    cloudSyncEnabled: cloudSyncConfig?.enabled,
+    icloudAvailable: isICloudAvailable(),
+  });
   // iOS uses HealthKit lazy authorization (permission requested on first read), so
   // it has no explicit permission check/request. On iOS the health-habit "Add"
   // button is always enabled and the dead "Continue" button is hidden — see the
@@ -2817,12 +2829,14 @@ const MobileSettingsPanel = () => {
           <span className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform transition-transform ${multiUserEnabled ? 'translate-x-5' : 'translate-x-0'}`} />
         </button>
       </div>
-      {!cloudSyncConfigured && (
-        <p className={`text-xs ${textSecondary} -mt-2`}>{t('settings.multiUserRequiresSync')}</p>
+      {multiUserReason !== 'none' && (
+        <p className={`text-xs ${textSecondary} -mt-2`}>
+          {t(multiUserReason === 'icloud-only' ? 'settings.multiUserICloudOnly' : 'settings.multiUserRequiresSync')}
+        </p>
       )}
       <div className="flex items-center justify-between gap-3">
         <p className={`text-xs ${textSecondary}`}>Share dayGLANCE with your household. Tasks can be assigned to specific people; unassigned tasks are visible to everyone.</p>
-        {(cloudSyncConfig?.enabled || isICloudAvailable()) && (
+        {multiUserRosterSyncable && (
           <button
             type="button"
             disabled={muSyncStatus === 'syncing'}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -16,7 +16,7 @@ import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUser
 import { isAvailable as isICloudAvailable } from '../intents/icloudFileTransport.js';
 import { getSyncPassphrase, setSyncPassphrase } from '../utils/crypto.js';
 import { isVaultEnabled } from '../sync/vaultConfig.js';
-import { multiUserToggleLocked } from '../utils/multiUserGate.js';
+import { multiUserToggleLocked, multiUserUnavailableReason, canSyncUserRoster } from '../utils/multiUserGate.js';
 import { getDbIntentsConfig, setDbIntentsConfig, getDbIntentsConnection } from '../intents/dbIntentsConfig.js';
 import { getIcloudIntentsEnabledFlag, setIcloudIntentsEnabled } from '../intents/icloudIntentsConfig.js';
 import { setupIntentsEncryption } from '../intents/intentsEncryptionSetup.js';
@@ -97,6 +97,18 @@ const SettingsModal = () => {
   // unconfigured. Never trap: an already-on toggle stays enabled so it can be
   // turned off.
   const multiUserLocked = multiUserToggleLocked({ cloudSyncConfigured, multiUserEnabled });
+  // "Requires cloud sync" is wrong on an iCloud-only device — that user IS
+  // syncing, just to a destination only they can reach. Pick the sentence that
+  // matches their situation instead of the generic one.
+  const multiUserReason = multiUserUnavailableReason({
+    cloudSyncConfigured,
+    icloudAvailable: isICloudAvailable(),
+  });
+  const multiUserRosterSyncable = canSyncUserRoster({
+    multiUserEnabled,
+    cloudSyncEnabled: cloudSyncConfig?.enabled,
+    icloudAvailable: isICloudAvailable(),
+  });
   const [addingUser, setAddingUser] = useState(false);
   const [newUserName, setNewUserName] = useState('');
   const [editingUserId, setEditingUserId] = useState(null);
@@ -1095,14 +1107,16 @@ const SettingsModal = () => {
                               <span className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform transition-transform ${multiUserEnabled ? 'translate-x-5' : 'translate-x-0'}`} />
                             </button>
                           </div>
-                          {!cloudSyncConfigured && (
-                            <p className={`text-xs ${textSecondary} -mt-2`}>{t('settings.multiUserRequiresSync')}</p>
+                          {multiUserReason !== 'none' && (
+                            <p className={`text-xs ${textSecondary} -mt-2`}>
+                              {t(multiUserReason === 'icloud-only' ? 'settings.multiUserICloudOnly' : 'settings.multiUserRequiresSync')}
+                            </p>
                           )}
                           <div className="flex items-center justify-between gap-3">
                             <p className={`${textSecondary} text-xs`}>
                               Share dayGLANCE with your household. Tasks can be assigned to specific people; unassigned tasks are visible to everyone.
                             </p>
-                            {(cloudSyncConfig?.enabled || isICloudAvailable()) && (
+                            {multiUserRosterSyncable && (
                               <button
                                 type="button"
                                 disabled={userSyncStatus === 'syncing'}

--- a/src/utils/multiUserGate.js
+++ b/src/utils/multiUserGate.js
@@ -26,3 +26,48 @@ export function canEnableMultiUser({ cloudSyncEnabled, vaultEnabled } = {}) {
 export function multiUserToggleLocked({ cloudSyncConfigured, multiUserEnabled } = {}) {
   return !cloudSyncConfigured && !multiUserEnabled;
 }
+
+/**
+ * Which explanation to show under a multi-user toggle that cannot be enabled.
+ *
+ * "Requires cloud sync" is accurate on a device with no sync at all, and it is
+ * actionable — go set up WebDAV or GLANCEvault. On an Apple device syncing via
+ * iCloud it is simply wrong: that user IS syncing, and telling them otherwise
+ * sends them looking for a setting that will not help. iCloud is per-Apple-ID, so
+ * it moves one person's data between their own devices; it cannot give two people
+ * a shared destination, which is the thing multi-user needs. That is a different
+ * sentence, not a missing one — hence a reason code rather than a boolean.
+ *
+ * Returns:
+ *   'none'        — sync is configured; multi-user is available, show nothing.
+ *   'icloud-only' — the only transport is iCloud, which cannot back multi-user.
+ *   'no-sync'     — no transport at all; setting one up is the fix.
+ *
+ * @param {{cloudSyncConfigured?: boolean, icloudAvailable?: boolean}} opts
+ * @returns {'none'|'icloud-only'|'no-sync'}
+ */
+export function multiUserUnavailableReason({ cloudSyncConfigured, icloudAvailable } = {}) {
+  if (cloudSyncConfigured) return 'none';
+  return icloudAvailable ? 'icloud-only' : 'no-sync';
+}
+
+/**
+ * Whether to offer the "sync users" roster action.
+ *
+ * Gated on multi-user actually being ON, not merely on a transport existing. The
+ * previous condition (WebDAV enabled OR iCloud reachable) put a working
+ * household-roster sync button directly beneath a locked toggle that said sync
+ * was not configured — an iCloud-only device got both halves of a contradiction
+ * on one screen. With multi-user off there is no roster to sync in the first
+ * place, so the button has nothing to do.
+ *
+ * The iCloud transport stays supported for the never-trapped case: multi-user
+ * enabled while WebDAV is off, where syncSharedUsersViaICloud is the only way to
+ * reconcile the roster.
+ *
+ * @param {{multiUserEnabled?: boolean, cloudSyncEnabled?: boolean, icloudAvailable?: boolean}} opts
+ * @returns {boolean}
+ */
+export function canSyncUserRoster({ multiUserEnabled, cloudSyncEnabled, icloudAvailable } = {}) {
+  return !!(multiUserEnabled && (cloudSyncEnabled || icloudAvailable));
+}

--- a/src/utils/multiUserGate.test.js
+++ b/src/utils/multiUserGate.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { canEnableMultiUser, multiUserToggleLocked } from './multiUserGate.js';
+import {
+  canEnableMultiUser,
+  multiUserToggleLocked,
+  multiUserUnavailableReason,
+  canSyncUserRoster,
+} from './multiUserGate.js';
 
 describe('canEnableMultiUser', () => {
   it('is false when neither sync tier is configured', () => {
@@ -29,5 +34,55 @@ describe('multiUserToggleLocked (never-trap rule)', () => {
 
   it('never traps: stays unlocked when multi-user is already on despite unconfigured sync', () => {
     expect(multiUserToggleLocked({ cloudSyncConfigured: false, multiUserEnabled: true })).toBe(false);
+  });
+});
+
+describe('multiUserUnavailableReason', () => {
+  it('shows nothing when sync is configured', () => {
+    expect(multiUserUnavailableReason({ cloudSyncConfigured: true, icloudAvailable: false })).toBe('none');
+    // Configured wins even on an Apple device that also has iCloud.
+    expect(multiUserUnavailableReason({ cloudSyncConfigured: true, icloudAvailable: true })).toBe('none');
+  });
+
+  // The case this exists for: telling an iCloud user they have no sync is wrong
+  // and sends them hunting for a setting that would not help.
+  it('distinguishes an iCloud-only device from a device with no sync', () => {
+    expect(multiUserUnavailableReason({ cloudSyncConfigured: false, icloudAvailable: true })).toBe('icloud-only');
+    expect(multiUserUnavailableReason({ cloudSyncConfigured: false, icloudAvailable: false })).toBe('no-sync');
+  });
+
+  it('defaults to no-sync with no arguments', () => {
+    expect(multiUserUnavailableReason()).toBe('no-sync');
+    expect(multiUserUnavailableReason({})).toBe('no-sync');
+  });
+});
+
+describe('canSyncUserRoster', () => {
+  // The contradiction being fixed: a working roster-sync button rendered
+  // directly beneath a locked toggle saying sync was not configured.
+  it('is hidden on an iCloud-only device with multi-user off', () => {
+    expect(canSyncUserRoster({ multiUserEnabled: false, cloudSyncEnabled: false, icloudAvailable: true })).toBe(false);
+  });
+
+  it('is hidden whenever multi-user is off, even with WebDAV configured', () => {
+    expect(canSyncUserRoster({ multiUserEnabled: false, cloudSyncEnabled: true, icloudAvailable: false })).toBe(false);
+  });
+
+  it('is shown with multi-user on and WebDAV configured', () => {
+    expect(canSyncUserRoster({ multiUserEnabled: true, cloudSyncEnabled: true, icloudAvailable: false })).toBe(true);
+  });
+
+  // Never-trapped device: multi-user on, WebDAV off, iCloud reachable. The iCloud
+  // roster transport is the only way to reconcile users here, so keep it.
+  it('is shown for a never-trapped device where iCloud is the only transport', () => {
+    expect(canSyncUserRoster({ multiUserEnabled: true, cloudSyncEnabled: false, icloudAvailable: true })).toBe(true);
+  });
+
+  it('is hidden with multi-user on but no transport at all', () => {
+    expect(canSyncUserRoster({ multiUserEnabled: true, cloudSyncEnabled: false, icloudAvailable: false })).toBe(false);
+  });
+
+  it('defaults to hidden with no arguments', () => {
+    expect(canSyncUserRoster()).toBe(false);
   });
 });


### PR DESCRIPTION
## The problem

Two things go wrong on the same screen when a device's only sync is iCloud.

**The hint is wrong.** `canEnableMultiUser` counts only the WebDAV file tier and GLANCEvault, so an iCloud-only device gets a locked toggle plus:

> Requires cloud sync. Set up GLANCEvault or WebDAV sync first.

That's accurate and actionable on a device with no sync at all. On an Apple device syncing via iCloud it's just false — the user *is* syncing, and the message sends them hunting for a setting that wouldn't help. iCloud is per-Apple-ID: it moves one person's data between their own devices and can't give two people a shared destination, which is exactly what multi-user needs. That's a *different sentence*, not a missing one.

**And the screen contradicts itself.** The "sync users" button rendered on:

```jsx
{(cloudSyncConfig?.enabled || isICloudAvailable()) && (   // MobileSettingsPanel, SettingsModal
```

— with no reference to multi-user at all. So an iCloud-only user saw a *working* household-roster sync button (backed by a real `syncSharedUsersViaICloud` implementation) sitting directly beneath a locked toggle telling them sync wasn't configured. Both halves of a contradiction on one screen.

## What changed

`multiUserGate.js` gains two helpers, alongside the existing never-trap rule:

- **`multiUserUnavailableReason({ cloudSyncConfigured, icloudAvailable })`** → `'none' | 'icloud-only' | 'no-sync'`. A reason code rather than a boolean, because the two unavailable cases need different sentences. Both surfaces render the matching string.
- **`canSyncUserRoster({ multiUserEnabled, cloudSyncEnabled, icloudAvailable })`** → gates the roster button on multi-user actually being **on**. With it off there's no roster to sync in the first place.

New string, shown only for `'icloud-only'`:

> Requires a shared sync destination. iCloud syncs your own devices under one Apple ID, so it cannot give two people a shared list — set up GLANCEvault or WebDAV sync for that.

## Decisions worth flagging

**The section stays visible.** Hiding it on iCloud-only devices was the other option on the table, and it's what was originally asked for — but it removes the explanation entirely and leaves the feature silently absent, which is the opposite of the problem being fixed. Worth a second look if you'd rather hide it after seeing this.

**The iCloud roster transport is kept.** Narrowing the button could have made `syncSharedUsersViaICloud` dead code. It isn't: for a never-trapped device (multi-user on, WebDAV since turned off, iCloud reachable) it's the only way to reconcile the roster. The new gate preserves exactly that case.

**Both helpers live in `multiUserGate.js`** rather than inline in each surface — the mobile and desktop panels disagreeing is what produced the contradiction in the first place.

## Testing

- `src/utils/multiUserGate.test.js` — extended to cover both helpers: the iCloud-only vs no-sync split, configured-wins-over-iCloud, and all four roster-button combinations including the never-trapped device.
- Full suite: **1198 tests / 80 files passing**.
- `eslint --max-warnings 0` clean, `npm run audit` clean, web build succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWTFj6JEjp8NUd71HzHHai)_