### PR TITLE
Report the other sync tiers, and stop sizing sentinel responses

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -972,7 +972,6 @@
     "lastModified": "File modified",
     "remoteCounts": "In file (tasks / inbox)",
     "localCounts": "On device (tasks / inbox)",
-    "lastSynced": "Last synced",
     "never": "never",
     "copy": "Copy report",
     "copied": "Copied",
@@ -983,6 +982,13 @@
       "downloading": "downloading from iCloud",
       "error": "error",
       "unsupported": "no iCloud on this platform"
-    }
+    },
+    "webdav": "WebDAV sync",
+    "webdavSynced": "WebDAV last synced",
+    "vault": "GLANCEvault",
+    "vaultSynced": "GLANCEvault last synced",
+    "configured": "configured",
+    "notConfigured": "not configured",
+    "none": "(none)"
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -972,7 +972,6 @@
     "lastModified": "Fichier modifié",
     "remoteCounts": "Dans le fichier (tâches / boîte)",
     "localCounts": "Sur l'appareil (tâches / boîte)",
-    "lastSynced": "Dernière synchro",
     "never": "jamais",
     "copy": "Copier le rapport",
     "copied": "Copié",
@@ -983,6 +982,13 @@
       "downloading": "téléchargement depuis iCloud",
       "error": "erreur",
       "unsupported": "pas d'iCloud sur cette plateforme"
-    }
+    },
+    "webdav": "Synchro WebDAV",
+    "webdavSynced": "Dernière synchro WebDAV",
+    "vault": "GLANCEvault",
+    "vaultSynced": "Dernière synchro GLANCEvault",
+    "configured": "configuré",
+    "notConfigured": "non configuré",
+    "none": "(aucun)"
   }
 }

--- a/src/components/ICloudDiagnostics.jsx
+++ b/src/components/ICloudDiagnostics.jsx
@@ -99,24 +99,42 @@ const ICloudDiagnostics = ({ darkMode, textPrimary, textSecondary, borderClass }
               <Row label={t('icloudDiag.containerError')} value={report.available.error} />
             )}
             <Row label={t('icloudDiag.snapshot')} value={snapshotLabel(report.snapshot)} />
-            {report.snapshot.state !== 'absent' && report.snapshot.state !== 'unsupported' && (
+            {/* Only when there are real file bytes. A sentinel response is the
+                bridge's status object, not a file, and showing its length as a
+                size reads as though a tiny file exists. */}
+            {(report.snapshot.state === 'present' || report.snapshot.bytes > 0) && (
               <>
                 <Row label={t('icloudDiag.size')} value={formatBytes(report.snapshot.bytes)} />
-                <Row label={t('icloudDiag.lastModified')} value={report.snapshot.lastModified ?? '—'} />
+                <Row label={t('icloudDiag.lastModified')} value={report.snapshot.lastModified ?? t('icloudDiag.none')} />
                 <Row
                   label={t('icloudDiag.remoteCounts')}
-                  value={`${report.snapshot.taskCount ?? '—'} / ${report.snapshot.inboxCount ?? '—'}`}
+                  value={`${report.snapshot.taskCount ?? t('icloudDiag.none')} / ${report.snapshot.inboxCount ?? t('icloudDiag.none')}`}
                 />
               </>
             )}
             {report.snapshot.error && (
               <Row label={t('icloudDiag.snapshotError')} value={report.snapshot.error} />
             )}
+
+            {/* The other transports. Without these, an unavailable container
+                leaves "so where did this data come from?" unanswerable. */}
+            <Row
+              label={t('icloudDiag.webdav')}
+              value={report.transports.webdav.configured
+                ? `${t('icloudDiag.configured')} (${report.transports.webdav.provider ?? '?'})`
+                : t('icloudDiag.notConfigured')}
+            />
+            <Row label={t('icloudDiag.webdavSynced')} value={report.transports.webdav.lastSynced ?? t('icloudDiag.never')} />
+            <Row
+              label={t('icloudDiag.vault')}
+              value={report.transports.vault.configured ? t('icloudDiag.configured') : t('icloudDiag.notConfigured')}
+            />
+            <Row label={t('icloudDiag.vaultSynced')} value={report.transports.vault.lastSynced ?? t('icloudDiag.never')} />
+
             <Row
               label={t('icloudDiag.localCounts')}
               value={`${report.local.taskCount} / ${report.local.inboxCount}`}
             />
-            <Row label={t('icloudDiag.lastSynced')} value={report.local.lastSynced ?? t('icloudDiag.never')} />
           </div>
 
           {/* The finding worth calling out: a resolvable container is exactly what

--- a/src/utils/icloudDiagnostics.js
+++ b/src/utils/icloudDiagnostics.js
@@ -112,8 +112,13 @@ export function classifySnapshot(raw, deps = {}) {
     return { ...empty, state: 'error', bytes, error: `unparseable JSON (${err?.message ?? err})` };
   }
 
-  if (parsed?.downloading) return { ...empty, state: 'downloading', bytes };
-  if (parsed?.error) return { ...empty, state: 'error', bytes, error: String(parsed.error) };
+  // Sentinels are the bridge's own status objects, NOT file content, so they get
+  // no size. Reporting one read as "32 B" invites the reader to believe a 32-byte
+  // file exists — it does not; that is the length of {"error":"iCloud not
+  // available"}. The corrupt case above keeps its byte count, because there the
+  // bytes really are the file.
+  if (parsed?.downloading) return { ...empty, state: 'downloading' };
+  if (parsed?.error) return { ...empty, state: 'error', error: String(parsed.error) };
 
   return {
     state: 'present',
@@ -123,6 +128,47 @@ export function classifySnapshot(raw, deps = {}) {
     taskCount: Array.isArray(parsed?.data?.tasks) ? parsed.data.tasks.length : null,
     inboxCount: Array.isArray(parsed?.data?.unscheduledTasks) ? parsed.data.unscheduledTasks.length : null,
     error: null,
+  };
+}
+
+/**
+ * The OTHER sync transports, so the report can rule them in or out.
+ *
+ * The first version of this module reported only iCloud, which left a hole: on a
+ * device where the container is unavailable, "where did this data come from?" has
+ * two remaining answers — local storage survived, or a network tier restored it —
+ * and the report could not distinguish them. Any network restore needs config that
+ * itself lives in localStorage, so showing whether that config is present is what
+ * closes the loop.
+ *
+ * Note the two tiers keep separate records under different prefixes:
+ * `day-planner-cloud-sync-*` for the WebDAV file tier (@glance-apps/sync engine.js)
+ * and `dayglance-vault-db-sync-*` for GLANCEvault (dbEngine.js). iCloud writes
+ * NEITHER, which is why a device syncing only over iCloud reports "never" for both.
+ */
+export function readSyncTransports({ localStorage } = {}) {
+  const get = (k) => {
+    try { return localStorage?.getItem(k) ?? null; } catch { return null; }
+  };
+  const json = (k) => {
+    try { return JSON.parse(get(k) || 'null'); } catch { return null; }
+  };
+
+  const webdavCfg = json('day-planner-cloud-sync-config');
+  const vaultCfg = json('dayglance-vault-config');
+
+  return {
+    webdav: {
+      configured: !!webdavCfg?.enabled,
+      provider: webdavCfg?.provider ?? null,
+      lastSynced: get('day-planner-cloud-sync-last-synced'),
+    },
+    vault: {
+      // Mirrors isVaultEnabled() in sync/vaultConfig.js — read directly rather
+      // than imported so this module stays injectable and testable.
+      configured: !!(vaultCfg?.enabled && vaultCfg?.vaultUrl && vaultCfg?.vaultToken && vaultCfg?.accountId),
+      lastSynced: get('dayglance-vault-db-sync-last-synced'),
+    },
   };
 }
 
@@ -188,14 +234,21 @@ export async function collectICloudDiagnostics(deps = defaultDeps()) {
     ? { state: UNSUPPORTED, bytes: 0, lastModified: null, version: null, taskCount: null, inboxCount: null, error: null }
     : classifySnapshot(raw, deps);
 
-  return { platform, available, snapshot, local: readLocalState(deps) };
+  return {
+    platform,
+    available,
+    snapshot,
+    local: readLocalState(deps),
+    transports: readSyncTransports(deps),
+  };
 }
 
 /**
  * Plain-text report for the copy-to-clipboard button, so a user can paste the
  * findings into an issue without retyping or screenshotting them.
  */
-export function formatDiagnosticsReport({ platform, available, snapshot, local }) {
+export function formatDiagnosticsReport({ platform, available, snapshot, local, transports }) {
+  const none = '(none)';
   const lines = [
     'dayGLANCE iCloud diagnostics',
     `platform:        ${platform}`,
@@ -203,17 +256,26 @@ export function formatDiagnosticsReport({ platform, available, snapshot, local }
   ];
   if (available.raw) lines.push(`  raw:           ${available.raw}`);
   if (available.error) lines.push(`  error:         ${available.error}`);
-  lines.push(
-    `snapshot file:   ${snapshot.state}`,
-    `  size:          ${formatBytes(snapshot.bytes)}`,
-    `  lastModified:  ${snapshot.lastModified ?? '—'}`,
-    `  tasks/inbox:   ${snapshot.taskCount ?? '—'} / ${snapshot.inboxCount ?? '—'}`,
-  );
+  lines.push(`snapshot file:   ${snapshot.state}`);
+  // Size/mtime/counts only mean something when there are real file bytes; for a
+  // sentinel state they would all read as blanks or, worse, as a tiny file.
+  if (snapshot.state === 'present' || snapshot.bytes > 0) {
+    lines.push(
+      `  size:          ${formatBytes(snapshot.bytes)}`,
+      `  lastModified:  ${snapshot.lastModified ?? none}`,
+      `  tasks/inbox:   ${snapshot.taskCount ?? none} / ${snapshot.inboxCount ?? none}`,
+    );
+  }
   if (snapshot.error) lines.push(`  error:         ${snapshot.error}`);
+
+  const t = transports ?? { webdav: {}, vault: {} };
   lines.push(
+    `webdav sync:     ${t.webdav.configured ? `configured (${t.webdav.provider ?? 'unknown'})` : 'not configured'}`,
+    `  last synced:   ${t.webdav.lastSynced ?? 'never'}`,
+    `glancevault:     ${t.vault.configured ? 'configured' : 'not configured'}`,
+    `  last synced:   ${t.vault.lastSynced ?? 'never'}`,
     `local tasks:     ${local.taskCount}`,
     `local inbox:     ${local.inboxCount}`,
-    `last synced:     ${local.lastSynced ?? 'never'}`,
   );
   return lines.join('\n');
 }

--- a/src/utils/icloudDiagnostics.test.js
+++ b/src/utils/icloudDiagnostics.test.js
@@ -7,6 +7,7 @@ import {
   readLocalState,
   formatBytes,
   formatDiagnosticsReport,
+  readSyncTransports,
   utf8Bytes,
 } from './icloudDiagnostics.js';
 
@@ -107,6 +108,13 @@ describe('classifySnapshot', () => {
     expect(s.error).toBe('iCloud not available');
   });
 
+  // Regression: a sentinel is the bridge's status object, not file content.
+  // Reporting its length made an unavailable container look like a 32-byte file.
+  it('reports no size for sentinel responses', () => {
+    expect(classifySnapshot('{"error":"iCloud not available"}').bytes).toBe(0);
+    expect(classifySnapshot('{"downloading":true}').bytes).toBe(0);
+  });
+
   // A corrupt file still means the file EXISTS, which is the fact under
   // investigation — so it must not be reported as absent.
   it('reports unparseable bytes as an error while still counting them', () => {
@@ -151,6 +159,56 @@ describe('readLocalState', () => {
   it('survives storage access throwing', () => {
     const r = readLocalState({ localStorage: { getItem: () => { throw new Error('denied'); } } });
     expect(r).toEqual({ taskCount: 0, inboxCount: 0, lastSynced: null });
+  });
+});
+
+// ── readSyncTransports ─────────────────────────────────────────────────────
+
+describe('readSyncTransports', () => {
+  it('reports both tiers unconfigured on a bare store', () => {
+    const r = readSyncTransports({ localStorage: fakeLocalStorage() });
+    expect(r.webdav).toEqual({ configured: false, provider: null, lastSynced: null });
+    expect(r.vault).toEqual({ configured: false, lastSynced: null });
+  });
+
+  it('reports a configured WebDAV tier with provider and record', () => {
+    const r = readSyncTransports({
+      localStorage: fakeLocalStorage({
+        'day-planner-cloud-sync-config': '{"enabled":true,"provider":"nextcloud"}',
+        'day-planner-cloud-sync-last-synced': '2026-08-08T09:00:00.000Z',
+      }),
+    });
+    expect(r.webdav).toEqual({
+      configured: true, provider: 'nextcloud', lastSynced: '2026-08-08T09:00:00.000Z',
+    });
+  });
+
+  it('does not count a WebDAV config that exists but is disabled', () => {
+    const r = readSyncTransports({
+      localStorage: fakeLocalStorage({ 'day-planner-cloud-sync-config': '{"enabled":false,"provider":"koofr"}' }),
+    });
+    expect(r.webdav.configured).toBe(false);
+  });
+
+  // Mirrors isVaultEnabled(): every field must be present, not just `enabled`.
+  it('requires a complete vault config, not just the enabled flag', () => {
+    const partial = readSyncTransports({
+      localStorage: fakeLocalStorage({ 'dayglance-vault-config': '{"enabled":true,"vaultUrl":"https://v"}' }),
+    });
+    expect(partial.vault.configured).toBe(false);
+
+    const complete = readSyncTransports({
+      localStorage: fakeLocalStorage({
+        'dayglance-vault-config': '{"enabled":true,"vaultUrl":"https://v","vaultToken":"t","accountId":"a"}',
+        'dayglance-vault-db-sync-last-synced': '2026-08-08T10:00:00.000Z',
+      }),
+    });
+    expect(complete.vault).toEqual({ configured: true, lastSynced: '2026-08-08T10:00:00.000Z' });
+  });
+
+  it('survives corrupt config JSON and throwing storage', () => {
+    expect(readSyncTransports({ localStorage: fakeLocalStorage({ 'dayglance-vault-config': '{oops' }) }).vault.configured).toBe(false);
+    expect(readSyncTransports({ localStorage: { getItem: () => { throw new Error('denied'); } } }).webdav.configured).toBe(false);
   });
 });
 
@@ -268,7 +326,30 @@ describe('formatDiagnosticsReport', () => {
     expect(text).toMatch(/container:\s+AVAILABLE/);
     expect(text).toMatch(/snapshot file:\s+present/);
     expect(text).toMatch(/tasks\/inbox:\s+2 \/ 1/);
-    expect(text).toMatch(/last synced:\s+never/);
+    expect(text).toMatch(/webdav sync:\s+not configured/);
+    expect(text).toMatch(/glancevault:\s+not configured/);
+  });
+
+  // The shape of the real report that closed this investigation: container
+  // unavailable, no network tier configured, yet a full local dataset.
+  it('shows an unavailable container with no transports and local data intact', async () => {
+    const r = await collectICloudDiagnostics({
+      nativeBridge: {
+        iCloudAvailable: () => '{"available":false}',
+        readICloudSync: () => '{"error":"iCloud not available"}',
+      },
+      localStorage: fakeLocalStorage({
+        'day-planner-tasks': JSON.stringify(Array.from({ length: 543 }, (_, i) => ({ id: i }))),
+        'day-planner-unscheduled': JSON.stringify(Array.from({ length: 373 }, (_, i) => ({ id: i }))),
+      }),
+    });
+    const text = formatDiagnosticsReport(r);
+    expect(text).toMatch(/container:\s+unavailable/);
+    expect(text).toMatch(/webdav sync:\s+not configured/);
+    expect(text).toMatch(/glancevault:\s+not configured/);
+    expect(text).toMatch(/local tasks:\s+543/);
+    // No size line: the sentinel is not a file.
+    expect(text).not.toMatch(/size:/);
   });
 
   it('says so plainly when the platform cannot probe availability', () => {


### PR DESCRIPTION
Two flaws in the diagnostics panel that the first real run on a device exposed.

## A sentinel is not a file

`classifySnapshot` computed `bytes` from the raw response *before* classifying it, so an unavailable container reported:

```
snapshot file:   error
  size:          32 B
  error:         iCloud not available
```

Those 32 bytes are the length of `{"error":"iCloud not available"}` — the bridge's own status object, not a file. A human reading that report reasonably concludes a small file exists. Sentinel states (`error`, `downloading`) now carry no size at all. The corrupt-but-present case keeps its byte count, because there the bytes really are the file.

## The report couldn't answer its own follow-up question

With the container unavailable, "so where did this data come from?" has two remaining answers — local storage survived, or a network tier restored it — and the report showed nothing at all about the network tiers.

It now reports both:

```
webdav sync:     not configured
  last synced:   never
glancevault:     not configured
  last synced:   never
```

Any network restore path needs config that itself lives in `localStorage`, so showing whether that config is present is what closes the loop: both tiers unconfigured plus an unreachable container means nothing could have pulled data in over the network.

## The single "last synced" row was misleading

That key (`day-planner-cloud-sync-last-synced`) is written by the WebDAV engine (`@glance-apps/sync/src/engine.js`). GLANCEvault keeps its own under a different prefix (`dayglance-vault-db-sync-last-synced`, `dbEngine.js`). **iCloud writes neither.**

So "last synced: never" on a device syncing over iCloud said nothing whatsoever about iCloud, while looking like it did. Replaced with one row per tier, each labelled with the tier it belongs to.

Worth noting separately: `App.jsx:2383` guards iCloud re-seeding on `day-planner-cloud-sync-last-synced`, a key the iCloud path never writes — so on an iCloud-only device that guard can never fire. Not touched here; flagging it as a real latent bug for its own change.

## Testing

- `src/utils/icloudDiagnostics.test.js` — 40 cases (was 33). New coverage for `readSyncTransports` (both tiers, disabled-but-present config, the vault's all-fields-required rule mirroring `isVaultEnabled()`, corrupt JSON, throwing storage), the sentinel-has-no-size regression, and an end-to-end case reproducing the exact report shape from the device run.
- Full suite: **1196 tests / 80 files passing**.
- `eslint --max-warnings 0` clean, `npm run audit` clean, build succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWTFj6JEjp8NUd71HzHHai)_