### PR TITLE
Ask before restoring from iCloud on a fresh install

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -984,5 +984,19 @@
       "error": "error",
       "unsupported": "no iCloud on this platform"
     }
+  },
+  "icloudFirstRun": {
+    "title": "Data found in iCloud",
+    "body": "iCloud has a copy of your dayGLANCE data: {{tasks}} tasks and {{inbox}} inbox items. This device has none yet.",
+    "lastModified": "Last updated {{when}}",
+    "restore": "Restore from iCloud",
+    "restoreHint": "Bring this data onto this device and keep syncing.",
+    "startFresh": "Start fresh on this device",
+    "startFreshHint": "Begin empty and turn iCloud sync off here. The iCloud copy and your other devices are left alone. You can turn it back on in Settings."
+  },
+  "icloudSync": {
+    "title": "iCloud sync",
+    "onHint": "On. This device syncs with your other Apple devices automatically.",
+    "offHint": "Off on this device. The iCloud copy and your other devices are unaffected."
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -984,5 +984,19 @@
       "error": "erreur",
       "unsupported": "pas d'iCloud sur cette plateforme"
     }
+  },
+  "icloudFirstRun": {
+    "title": "Données trouvées dans iCloud",
+    "body": "iCloud contient une copie de vos données dayGLANCE : {{tasks}} tâches et {{inbox}} éléments de boîte de réception. Cet appareil n'en a pas encore.",
+    "lastModified": "Dernière mise à jour {{when}}",
+    "restore": "Restaurer depuis iCloud",
+    "restoreHint": "Récupérer ces données sur cet appareil et continuer la synchronisation.",
+    "startFresh": "Repartir de zéro sur cet appareil",
+    "startFreshHint": "Commencer à vide et désactiver la synchronisation iCloud ici. La copie iCloud et vos autres appareils ne sont pas touchés. Vous pouvez la réactiver dans les réglages."
+  },
+  "icloudSync": {
+    "title": "Synchronisation iCloud",
+    "onHint": "Activée. Cet appareil se synchronise automatiquement avec vos autres appareils Apple.",
+    "offHint": "Désactivée sur cet appareil. La copie iCloud et vos autres appareils ne sont pas affectés."
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,10 @@ import { autoBackupDB, createAutoBackupProvidersForFolder, AUTO_BACKUP_RETENTION
 import { LIVE_BACKUP_FILENAME } from './utils/folderBackup.js';
 import { collectDeviceSettings, applyDeviceSettings } from './utils/deviceSettings.js';
 import { isResetInProgress } from './utils/resetAppData.js';
+import {
+  isICloudSyncEnabled, setICloudSyncEnabled, getICloudSyncPref,
+  shouldPromptFirstRun, payloadHasData,
+} from './utils/icloudSyncPref.js';
 import useFolderBackup from './hooks/useFolderBackup.js';
 import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOnlyTask, getLinkUrl, hasOnlySubtasks, renderTitle, highlightMatch, renderTitleWithoutTags, extractShareTitle } from './utils/textFormatting.jsx';
 import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate, computeTaskCalendarTombstones, computeRecurringSeriesTombstones } from './utils/taskUtils.js';
@@ -52,6 +56,7 @@ import GoalDashboard from './components/goals/GoalDashboard.jsx';
 import WeeklyReviewReminderCard from './components/WeeklyReviewReminderCard.jsx';
 import IncompleteTasksModal from './components/IncompleteTasksModal.jsx';
 import BackupMenuModal from './components/BackupMenuModal.jsx';
+import ICloudFirstRunModal from './components/ICloudFirstRunModal.jsx';
 import RestoreConfirmModal from './components/RestoreConfirmModal.jsx';
 import AutoBackupManagerModal from './components/AutoBackupManagerModal.jsx';
 import ImportCalendarModal from './components/ImportCalendarModal.jsx';
@@ -2302,6 +2307,11 @@ const DayPlanner = () => {
   const openNewInboxTaskRef = useRef(null);
   const openNewTaskFormRef = useRef(null);
   const iCloudLastWriteAtRef = useRef(0);
+  // First-run restore choice. The ref gates the sync loop synchronously (state
+  // lands a render too late to stop the next 15-second tick); the state drives the
+  // modal. Null when nothing is pending.
+  const icloudFirstRunPromptRef = useRef(false);
+  const [icloudFirstRun, setICloudFirstRun] = useState(null);
 
   const isElectronMac = () =>
     !!(window.electronAPI?.isElectron && window.electronAPI?.platform === 'darwin');
@@ -2337,6 +2347,15 @@ const DayPlanner = () => {
     // run: React state still holds the pre-reset data, so seeding or merging from
     // it would write every task straight back into iCloud. Cleared by the reload.
     if (isResetInProgress()) return;
+    // The user chose "start fresh on this device" at first run (or switched iCloud
+    // off in settings). Fully inert: nothing read is applied, nothing is written,
+    // so the container copy and every other device are untouched. Absence of a
+    // decision still means ON — zero-config stays the default for everyone.
+    if (!isICloudSyncEnabled()) return;
+    // A pending first-run choice must not be pre-empted by the 15-second poll:
+    // merging now is precisely the silent restore the prompt exists to offer a way
+    // out of.
+    if (icloudFirstRunPromptRef.current) return;
     // iCloud and WebDAV are independent transports — don't gate iCloud on the
     // WebDAV engine's isSyncing() state. If WebDAV is stuck in a retry loop
     // (e.g. persistent 412), iCloud sync would be permanently blocked.
@@ -2423,6 +2442,27 @@ const DayPlanner = () => {
       }
       if (!remote?.data) return;
 
+      // First launch on a device with no data of its own, facing a cloud copy that
+      // survived an uninstall. Ask instead of restoring silently — see
+      // utils/icloudSyncPref.js for why the toggle cannot be remembered across a
+      // reinstall. Returning here leaves the snapshot untouched; the choice
+      // handler resumes or disables sync.
+      const localDataForPrompt = buildSyncPayload().data;
+      if (shouldPromptFirstRun({
+        decided: getICloudSyncPref() !== null,
+        remoteHasData: payloadHasData(remote.data),
+        localHasData: payloadHasData(localDataForPrompt),
+        icloudAvailable: true,
+      })) {
+        icloudFirstRunPromptRef.current = true;
+        setICloudFirstRun({
+          taskCount: remote.data.tasks?.length ?? 0,
+          inboxCount: remote.data.unscheduledTasks?.length ?? 0,
+          lastModified: remote.lastModified ?? null,
+        });
+        return;
+      }
+
       const localData = buildSyncPayload().data;
       const { data: mergedData, localChanged, remoteChanged } = mergeSyncData(localData, remote.data, syncRetentionDays);
 
@@ -2447,6 +2487,26 @@ const DayPlanner = () => {
 
   // Keep ref fresh so interval and event listeners always call the latest closure.
   iCloudSyncRef.current = iCloudSync;
+
+  // First-run choice handlers. Both record a decision so the prompt never returns;
+  // that is what setICloudSyncEnabled(true) is for on the restore path, where the
+  // sync behaviour itself is unchanged.
+  const acceptICloudRestore = () => {
+    setICloudSyncEnabled(true);
+    setICloudFirstRun(null);
+    icloudFirstRunPromptRef.current = false;
+    // Run immediately rather than waiting up to 15 seconds for the next tick.
+    iCloudSyncRef.current?.();
+  };
+
+  const declineICloudRestore = () => {
+    setICloudSyncEnabled(false);
+    setICloudFirstRun(null);
+    icloudFirstRunPromptRef.current = false;
+    // Nothing else to do: the gate at the top of iCloudSync now returns early, so
+    // the container copy is never read or written from this device. Other devices
+    // keep theirs. Reversible from Settings → Cloud Sync.
+  };
 
   // Run once on startup after data is loaded.
   useEffect(() => {
@@ -8629,6 +8689,19 @@ const DayPlanner = () => {
       {/* Import Calendar Modal */}
       <ImportCalendarModal />
 
+
+      {/* First-run iCloud restore choice. Sits alongside the WebDAV conflict
+          dialog below, which covers the same moment for the file tier. */}
+      <ICloudFirstRunModal
+        info={icloudFirstRun}
+        onRestore={acceptICloudRestore}
+        onStartFresh={declineICloudRestore}
+        cardBg={cardBg}
+        borderClass={borderClass}
+        textPrimary={textPrimary}
+        textSecondary={textSecondary}
+        darkMode={darkMode}
+      />
 
       {cloudSyncConflict && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">

--- a/src/components/ICloudFirstRunModal.jsx
+++ b/src/components/ICloudFirstRunModal.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Cloud } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Offered once, on a launch that finds cloud data and no local data.
+ *
+ * The situation it exists for: deleting the iOS app does not delete
+ * dayglance-sync.json (it lives in the ubiquity container, outside the sandbox,
+ * and any Mac running dayGLANCE keeps writing to it), and reinstalling re-grants
+ * the iCloud entitlement, so the per-app toggle comes back ON. The app then found
+ * the surviving copy and restored everything with no prompt and no way to decline
+ * — which reads as "deleting the app did nothing".
+ *
+ * The toggle resetting is OS state we cannot control, and the preference cannot be
+ * remembered because localStorage goes with the app. Restoring *silently* is the
+ * part that was ours to fix.
+ *
+ * Mirrors the WebDAV first-sync dialog (app.existingDataFound) in shape, with two
+ * choices rather than three: at first run local is empty, so "merge" and "use the
+ * cloud copy" are the same act.
+ */
+const ICloudFirstRunModal = ({
+  info, onRestore, onStartFresh,
+  cardBg, borderClass, textPrimary, textSecondary, darkMode,
+}) => {
+  const { t } = useTranslation();
+  if (!info) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className={`${cardBg} rounded-lg shadow-xl p-6 ${borderClass} border max-w-sm w-full`}>
+        <div className="flex items-center gap-3 mb-4">
+          <div className="p-2 rounded-full bg-blue-100 dark:bg-blue-900/30">
+            <Cloud size={20} className="text-blue-600 dark:text-blue-400" />
+          </div>
+          <h3 className={`text-lg font-semibold ${textPrimary}`}>{t('icloudFirstRun.title')}</h3>
+        </div>
+
+        <p className={`${textSecondary} mb-2`}>
+          {t('icloudFirstRun.body', { tasks: info.taskCount, inbox: info.inboxCount })}
+        </p>
+        {info.lastModified && (
+          <p className={`text-xs ${textSecondary} mb-4`}>
+            {t('icloudFirstRun.lastModified', { when: new Date(info.lastModified).toLocaleString() })}
+          </p>
+        )}
+
+        <div className="space-y-3">
+          <button
+            onClick={onRestore}
+            className="w-full px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-left transition-colors"
+          >
+            <div className="font-medium">{t('icloudFirstRun.restore')}</div>
+            <div className="text-sm text-blue-100">{t('icloudFirstRun.restoreHint')}</div>
+          </button>
+          <button
+            onClick={onStartFresh}
+            className={`w-full px-4 py-3 ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-100 hover:bg-stone-200'} ${textPrimary} rounded-lg text-left transition-colors`}
+          >
+            <div className="font-medium">{t('icloudFirstRun.startFresh')}</div>
+            <div className={`text-sm ${textSecondary}`}>{t('icloudFirstRun.startFreshHint')}</div>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ICloudFirstRunModal;

--- a/src/components/ICloudSyncToggle.jsx
+++ b/src/components/ICloudSyncToggle.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { isICloudSyncEnabled, setICloudSyncEnabled } from '../utils/icloudSyncPref.js';
+
+/**
+ * On/off switch for this device's iCloud sync.
+ *
+ * Two reasons it exists rather than leaving iCloud purely zero-config:
+ *
+ *  1. It makes the first-run "start fresh on this device" choice reversible. That
+ *     choice writes the same preference this reads, so a user who declined the
+ *     restore has somewhere to change their mind.
+ *  2. macOS has no alternative. electron/icloud.ts resolves the container by raw
+ *     filesystem path and never registers with the iCloud daemon, so the Mac app
+ *     never appears under "Apps syncing to iCloud Drive" and System Settings
+ *     offers no way to stop it. This is the only off switch that platform has.
+ *
+ * Default stays ON: the preference is tri-state and absence means enabled, so
+ * existing users are unaffected and zero-config still holds.
+ *
+ * Turning it off is inert, not destructive — the container copy stays where it is
+ * and other devices keep syncing. Turning it back on resumes on the next cycle,
+ * which will merge whatever the cloud copy now holds.
+ */
+const ICloudSyncToggle = ({ darkMode, textPrimary, textSecondary, borderClass }) => {
+  const { t } = useTranslation();
+  const [enabled, setEnabled] = useState(() => isICloudSyncEnabled());
+
+  const toggle = () => {
+    const next = !enabled;
+    setICloudSyncEnabled(next);
+    setEnabled(next);
+  };
+
+  return (
+    <div className={`rounded-lg border ${borderClass} p-3`}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className={`text-sm font-medium ${textPrimary}`}>{t('icloudSync.title')}</p>
+          <p className={`text-xs ${textSecondary}`}>
+            {enabled ? t('icloudSync.onHint') : t('icloudSync.offHint')}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={toggle}
+          role="switch"
+          aria-checked={enabled}
+          aria-label={t('icloudSync.title')}
+          className={`relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors ${
+            enabled ? 'bg-green-500' : darkMode ? 'bg-gray-600' : 'bg-stone-300'
+          }`}
+        >
+          <span
+            className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform transition-transform ${
+              enabled ? 'translate-x-5' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ICloudSyncToggle;

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -16,6 +16,7 @@ import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, listVaultNotes } from '../obsidian.js';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
 import ICloudDiagnostics from './ICloudDiagnostics.jsx';
+import ICloudSyncToggle from './ICloudSyncToggle.jsx';
 import AutoBackupSettingsForm from './AutoBackupSettingsForm.jsx';
 import ResetAppDataSection from './ResetAppDataSection.jsx';
 import FrameEditor from './FrameEditor.jsx';
@@ -1473,12 +1474,20 @@ const MobileSettingsPanel = () => {
       {/* Apple platforms only — on Android/web every probe reports unsupported,
           so the panel would be an empty box. */}
       {isICloudAvailable() && (
-        <ICloudDiagnostics
-          darkMode={darkMode}
-          textPrimary={textPrimary}
-          textSecondary={textSecondary}
-          borderClass={borderClass}
-        />
+        <>
+          <ICloudSyncToggle
+            darkMode={darkMode}
+            textPrimary={textPrimary}
+            textSecondary={textSecondary}
+            borderClass={borderClass}
+          />
+          <ICloudDiagnostics
+            darkMode={darkMode}
+            textPrimary={textPrimary}
+            textSecondary={textSecondary}
+            borderClass={borderClass}
+          />
+        </>
       )}
     </div>
     );

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -6,6 +6,7 @@ import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
 import ICloudDiagnostics from './ICloudDiagnostics.jsx';
+import ICloudSyncToggle from './ICloudSyncToggle.jsx';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
 import { isNativeAndroid, nativeGetCalendars, nativeGetAutomationIntentsEnabled, nativeSetAutomationIntentsEnabled } from '../native.js';
@@ -814,12 +815,20 @@ const SettingsModal = () => {
                       {/* Apple platforms only — on Android/web every probe reports
                           unsupported, so the panel would be an empty box. */}
                       {isICloudAvailable() && (
-                        <ICloudDiagnostics
-                          darkMode={darkMode}
-                          textPrimary={textPrimary}
-                          textSecondary={textSecondary}
-                          borderClass={borderClass}
-                        />
+                        <>
+                          <ICloudSyncToggle
+                            darkMode={darkMode}
+                            textPrimary={textPrimary}
+                            textSecondary={textSecondary}
+                            borderClass={borderClass}
+                          />
+                          <ICloudDiagnostics
+                            darkMode={darkMode}
+                            textPrimary={textPrimary}
+                            textSecondary={textSecondary}
+                            borderClass={borderClass}
+                          />
+                        </>
                       )}
                       </>)}
                     </div>

--- a/src/utils/icloudSyncPref.js
+++ b/src/utils/icloudSyncPref.js
@@ -1,0 +1,105 @@
+/**
+ * Per-device iCloud sync preference, and the first-run decision behind it.
+ *
+ * ── Why this exists ────────────────────────────────────────────────────────
+ * iCloud sync is zero-config and always-on for Apple builds, which is the right
+ * default and stays the default here. The problem it caused is narrower: when a
+ * user deletes the iOS app and reinstalls it, iOS grants the iCloud entitlement
+ * afresh and the per-app iCloud toggle comes back ON — the "off" they had chosen
+ * lived in iOS's per-app state for an app that no longer exists. Meanwhile
+ * dayglance-sync.json survived in the ubiquity container (it lives outside the
+ * sandbox, and any Mac running dayGLANCE keeps writing to it), so the app finds
+ * it, merges it, and every task returns. Confirmed on-device: the same install
+ * reported `container: unavailable` before deletion and `AVAILABLE` after
+ * reinstall, with nothing touched in between.
+ *
+ * Nothing in the app can stop that toggle resetting — it is OS state we do not
+ * own, and the user's preference cannot be remembered because localStorage goes
+ * with the app. What the app CAN stop doing is restoring silently. So the first
+ * launch that finds cloud data and no local data asks, and this module is where
+ * the answer lives.
+ *
+ * ── Tri-state, deliberately ────────────────────────────────────────────────
+ * The stored value is absent / 'true' / 'false', and absence is NOT "off":
+ *
+ *   absent  — no decision yet. iCloud sync runs (preserving zero-config for every
+ *             existing user), and the first-run prompt may ask if this looks like
+ *             a fresh install facing populated cloud data.
+ *   'true'  — the user chose to restore, or re-enabled sync later.
+ *   'false' — the user chose to start fresh on this device. Sync is fully inert:
+ *             no read applied, no write. The container copy is left alone, so
+ *             other devices are unaffected.
+ *
+ * Treating absence as "on" is what keeps this from becoming a breaking change for
+ * everyone already syncing.
+ */
+
+export const ICLOUD_SYNC_PREF_KEY = 'dayglance-icloud-sync-enabled';
+
+const read = (storage) => {
+  try {
+    return storage?.getItem(ICLOUD_SYNC_PREF_KEY) ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * The raw stored decision.
+ * @returns {'true'|'false'|null} null when the user has not decided.
+ */
+export function getICloudSyncPref(storage = typeof window !== 'undefined' ? window.localStorage : null) {
+  const v = read(storage);
+  return v === 'true' || v === 'false' ? v : null;
+}
+
+/**
+ * Whether iCloud sync should run on this device.
+ * Absence means yes — zero-config is the default and must stay it.
+ */
+export function isICloudSyncEnabled(storage = typeof window !== 'undefined' ? window.localStorage : null) {
+  return getICloudSyncPref(storage) !== 'false';
+}
+
+/** Records the decision. Persisting `true` matters: it also marks the prompt answered. */
+export function setICloudSyncEnabled(enabled, storage = typeof window !== 'undefined' ? window.localStorage : null) {
+  try {
+    storage?.setItem(ICLOUD_SYNC_PREF_KEY, enabled ? 'true' : 'false');
+  } catch {
+    /* private mode / quota — the in-memory choice still holds for this session */
+  }
+}
+
+/**
+ * Whether to interrupt this launch and ask.
+ *
+ * All four conditions are load-bearing:
+ *
+ *   • no decision recorded — asking twice would be nagging, and a user who chose
+ *     'restore' must not be re-asked on every launch;
+ *   • the container holds real data — nothing to offer otherwise;
+ *   • this device has NO local data — the case being fixed is a fresh install
+ *     facing a surviving cloud copy. A device with its own data is an ordinary
+ *     merge, and prompting there would interrupt every existing user exactly once
+ *     for no reason, which is the main risk this guard exists to avoid;
+ *   • iCloud is actually reachable — otherwise there is no restore to decline.
+ *
+ * @param {{decided: boolean, remoteHasData: boolean, localHasData: boolean, icloudAvailable: boolean}} s
+ * @returns {boolean}
+ */
+export function shouldPromptFirstRun({ decided, remoteHasData, localHasData, icloudAvailable } = {}) {
+  return !!(!decided && remoteHasData && !localHasData && icloudAvailable);
+}
+
+/**
+ * Does this payload carry anything worth restoring?
+ *
+ * Counts tasks and inbox items only. A snapshot can carry settings, tombstones and
+ * empty collections while holding no actual content — offering to "restore" that
+ * is a prompt with nothing behind it.
+ */
+export function payloadHasData(data) {
+  if (!data || typeof data !== 'object') return false;
+  const n = (v) => (Array.isArray(v) ? v.length : 0);
+  return n(data.tasks) + n(data.unscheduledTasks) > 0;
+}

--- a/src/utils/icloudSyncPref.test.js
+++ b/src/utils/icloudSyncPref.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ICLOUD_SYNC_PREF_KEY,
+  getICloudSyncPref,
+  isICloudSyncEnabled,
+  setICloudSyncEnabled,
+  shouldPromptFirstRun,
+  payloadHasData,
+} from './icloudSyncPref.js';
+
+const store = (initial = {}) => {
+  const map = { ...initial };
+  return {
+    map,
+    getItem: (k) => (k in map ? map[k] : null),
+    setItem: (k, v) => { map[k] = String(v); },
+  };
+};
+
+const throwingStore = () => ({
+  getItem: () => { throw new Error('denied'); },
+  setItem: () => { throw new Error('denied'); },
+});
+
+describe('getICloudSyncPref', () => {
+  it('is null before any decision', () => {
+    expect(getICloudSyncPref(store())).toBeNull();
+  });
+
+  it('reads back both decisions', () => {
+    expect(getICloudSyncPref(store({ [ICLOUD_SYNC_PREF_KEY]: 'true' }))).toBe('true');
+    expect(getICloudSyncPref(store({ [ICLOUD_SYNC_PREF_KEY]: 'false' }))).toBe('false');
+  });
+
+  it('treats a junk value as undecided rather than trusting it', () => {
+    expect(getICloudSyncPref(store({ [ICLOUD_SYNC_PREF_KEY]: 'yes' }))).toBeNull();
+  });
+
+  it('survives throwing storage', () => {
+    expect(getICloudSyncPref(throwingStore())).toBeNull();
+  });
+});
+
+describe('isICloudSyncEnabled', () => {
+  // The compatibility guarantee: shipping this must not switch anyone's sync off.
+  it('defaults to enabled when no decision has been made', () => {
+    expect(isICloudSyncEnabled(store())).toBe(true);
+  });
+
+  it('is enabled after choosing restore', () => {
+    expect(isICloudSyncEnabled(store({ [ICLOUD_SYNC_PREF_KEY]: 'true' }))).toBe(true);
+  });
+
+  it('is disabled only by an explicit false', () => {
+    expect(isICloudSyncEnabled(store({ [ICLOUD_SYNC_PREF_KEY]: 'false' }))).toBe(false);
+  });
+
+  it('stays enabled when storage throws', () => {
+    expect(isICloudSyncEnabled(throwingStore())).toBe(true);
+  });
+});
+
+describe('setICloudSyncEnabled', () => {
+  it('persists both decisions as strings', () => {
+    const s = store();
+    setICloudSyncEnabled(true, s);
+    expect(s.map[ICLOUD_SYNC_PREF_KEY]).toBe('true');
+    setICloudSyncEnabled(false, s);
+    expect(s.map[ICLOUD_SYNC_PREF_KEY]).toBe('false');
+  });
+
+  // Persisting 'true' is what stops the prompt reappearing every launch.
+  it('marks the prompt answered even when the answer is restore', () => {
+    const s = store();
+    setICloudSyncEnabled(true, s);
+    expect(getICloudSyncPref(s)).not.toBeNull();
+  });
+
+  it('does not throw when storage refuses', () => {
+    expect(() => setICloudSyncEnabled(true, throwingStore())).not.toThrow();
+  });
+});
+
+describe('shouldPromptFirstRun', () => {
+  const base = { decided: false, remoteHasData: true, localHasData: false, icloudAvailable: true };
+
+  it('prompts on a fresh install facing populated cloud data', () => {
+    expect(shouldPromptFirstRun(base)).toBe(true);
+  });
+
+  // The guard that matters most: existing users must never see this.
+  it('does not prompt a device that already has its own data', () => {
+    expect(shouldPromptFirstRun({ ...base, localHasData: true })).toBe(false);
+  });
+
+  it('does not prompt once a decision exists', () => {
+    expect(shouldPromptFirstRun({ ...base, decided: true })).toBe(false);
+  });
+
+  it('does not prompt when the cloud copy is empty', () => {
+    expect(shouldPromptFirstRun({ ...base, remoteHasData: false })).toBe(false);
+  });
+
+  it('does not prompt when iCloud is unreachable', () => {
+    expect(shouldPromptFirstRun({ ...base, icloudAvailable: false })).toBe(false);
+  });
+
+  it('does not prompt with no arguments', () => {
+    expect(shouldPromptFirstRun()).toBe(false);
+    expect(shouldPromptFirstRun({})).toBe(false);
+  });
+});
+
+describe('payloadHasData', () => {
+  it('counts tasks and inbox items', () => {
+    expect(payloadHasData({ tasks: [{ id: 1 }] })).toBe(true);
+    expect(payloadHasData({ unscheduledTasks: [{ id: 1 }] })).toBe(true);
+    expect(payloadHasData({ tasks: [{ id: 1 }], unscheduledTasks: [{ id: 2 }] })).toBe(true);
+  });
+
+  // A snapshot full of settings and tombstones but no content is not worth
+  // interrupting a launch to offer.
+  it('is false for a payload with no actual content', () => {
+    expect(payloadHasData({ tasks: [], unscheduledTasks: [] })).toBe(false);
+    expect(payloadHasData({ darkMode: true, deletedTaskIds: { a: '2026-01-01' } })).toBe(false);
+    expect(payloadHasData({})).toBe(false);
+  });
+
+  it('is false for missing or non-object input', () => {
+    expect(payloadHasData(null)).toBe(false);
+    expect(payloadHasData(undefined)).toBe(false);
+    expect(payloadHasData('nope')).toBe(false);
+  });
+
+  it('ignores non-array collections rather than throwing', () => {
+    expect(payloadHasData({ tasks: 'lots' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## The bug, now confirmed on-device

Deleting the iOS app doesn't delete `dayglance-sync.json` — it lives in the ubiquity container, outside the sandbox, and any Mac running dayGLANCE keeps writing to it. Reinstalling re-grants the iCloud entitlement, so **the per-app iCloud toggle comes back ON**: the "off" the user chose lived in iOS's per-app state for an app that no longer exists. The app then found the surviving copy and restored everything with no prompt and no way to decline, which reads as *"deleting the app did nothing."*

The diagnostics panel confirmed it. Same install, nothing changed in between:

| | Before deletion | After reinstall |
|---|---|---|
| `container` | **unavailable** `{"available":false}` | **AVAILABLE** `{"available":true}` |
| `snapshot file` | error — iCloud not available | downloading |
| local tasks | 543 | 551 |

The counts moving is the tell: pure localStorage survival would reproduce the old numbers exactly. Different numbers mean a merge with a newer copy.

## What's fixable and what isn't

The toggle resetting is OS state we don't own. The preference can't be remembered either, because localStorage goes with the app. So the app will always come back with iCloud on, and there is nothing to be done about that.

Restoring **silently** is the part that was ours. WebDAV already handles this moment properly (`app.existingDataFound` — merge / use server / use local). iCloud had no equivalent. It does now, with two options rather than three: at first run local is empty, so "merge" and "use the cloud copy" are the same act.

## Design notes

**The preference is tri-state, and absence means enabled.** `absent` → sync runs (zero-config preserved for every existing user); `'true'` → chose restore, or re-enabled later; `'false'` → chose start fresh. Treating absence as *on* is what keeps this from switching anyone's sync off on upgrade.

**The prompt gate is a ref, not state.** State lands a render too late to stop the next 15-second poll — which would perform exactly the silent restore the prompt exists to offer a way out of.

**Four conditions guard the prompt**, and the load-bearing one is *"this device has no local data."* Without it every existing user gets interrupted once, for nothing. `payloadHasData` counts tasks and inbox items only, so a snapshot carrying nothing but settings and tombstones doesn't trigger a prompt with nothing behind it.

**"Start fresh" is inert, not destructive.** Sync goes off for this device only; the container copy stays and other devices are untouched. That's deliberately *not* the reset's `everywhere` scope — a first-run screen is the wrong place to offer something that clears the copy your Mac depends on.

**The settings toggle** makes the choice reversible, and incidentally gives macOS its only off switch: `electron/icloud.ts` resolves the container by raw filesystem path and never registers with the iCloud daemon, so the Mac app never appears under "Apps syncing to iCloud Drive" and System Settings offers no way to stop it.

## Testing

- `src/utils/icloudSyncPref.test.js` — 21 cases. Covers absence-means-enabled, junk values treated as undecided, throwing storage, that choosing *restore* still records a decision so the prompt can't reappear, and each of the four prompt guards independently.
- Full suite: **1210 tests / 80 files passing**.
- `eslint --max-warnings 0` clean, `npm run audit` clean, web build succeeds.
- The modal itself hasn't been exercised on a device — it needs a reinstall against a populated container to appear.

## Not done here

`App.jsx` guards iCloud re-seeding on `day-planner-cloud-sync-last-synced`, a key only the WebDAV engine writes — so on an iCloud-only device that guard can never fire. Real latent bug, left for its own change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWTFj6JEjp8NUd71HzHHai)_