### PR TITLE
session-start hook: npm ci instead of npm install

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -25,5 +25,22 @@ fi
 git fetch origin main
 git merge origin/main --no-edit
 
-# Install npm dependencies
-npm install
+# Install npm dependencies.
+#
+# `npm ci`, not `npm install`: it installs exactly what package-lock.json
+# specifies and never rewrites it. `npm install` recomputes the dependency tree
+# and writes the lockfile even when package.json has not changed, so every
+# session start produced a lockfile that could differ from the committed one —
+# which then collided with any other regeneration and left `both modified:
+# package-lock.json` conflicts in clones that had done the same thing.
+#
+# A failure here means package.json and package-lock.json have genuinely drifted.
+# That is worth stopping for rather than papering over with a fallback to
+# `npm install`: CI runs `npm ci` too, so the same drift would fail there anyway,
+# and silently regenerating the lockfile is what caused the conflicts to begin
+# with. Fix it once, at the source, and commit the result.
+if ! npm ci; then
+  echo "session-start: npm ci failed — package.json and package-lock.json have drifted." >&2
+  echo "  Regenerate and commit:  npm install --package-lock-only && git add package-lock.json" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Why

`npm install` recomputes the dependency tree and **rewrites `package-lock.json`** even when `package.json` hasn't changed. The session-start hook ran it on every session, so each one produced a lockfile that could differ from the committed one.

That collided with any other regeneration — a local clone running `npm install`, or the four times the lockfile was regenerated for the audit-gate pins during the iCloud work — and left conflicts like:

```
Unmerged paths:
        both modified:   package-lock.json
```

which look like they came from nowhere, because nobody typed the command that caused them.

`npm ci` installs exactly what the lockfile specifies and never writes it.

## No fallback, deliberately

`npm ci || npm install` was the obvious softening and it's the wrong call: silently regenerating the lockfile is precisely the behaviour that caused the conflicts. A failure here means `package.json` and `package-lock.json` have genuinely drifted, and CI would fail on it anyway since it also runs `npm ci` — better to surface that at session start than to paper over it and discover it later.

Rather than dying with a bare non-zero exit from `set -e`, the hook prints the one-line fix:

```
session-start: npm ci failed — package.json and package-lock.json have drifted.
  Regenerate and commit:  npm install --package-lock-only && git add package-lock.json
```

## Verification

- `bash -n` clean on the modified hook.
- Ran `npm ci` in a clean tree and confirmed `git status` showed **no** change to `package-lock.json` — the exact case where `npm install` would have rewritten it.
- `npm run audit`, `npm run lint`, `npm test` all still pass (no source changes; the hook is the whole diff).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWTFj6JEjp8NUd71HzHHai)_