### PR TITLE
Guard iCloud reseeding on a record iCloud actually writes

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -990,7 +990,8 @@
     "vaultSynced": "GLANCEvault last synced",
     "configured": "configured",
     "notConfigured": "not configured",
-    "none": "(none)"
+    "none": "(none)",
+    "icloudSynced": "iCloud last synced"
   },
   "icloudFirstRun": {
     "title": "Data found in iCloud",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -990,7 +990,8 @@
     "vaultSynced": "Dernière synchro GLANCEvault",
     "configured": "configuré",
     "notConfigured": "non configuré",
-    "none": "(aucun)"
+    "none": "(aucun)",
+    "icloudSynced": "Dernière synchro iCloud"
   },
   "icloudFirstRun": {
     "title": "Données trouvées dans iCloud",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import {
   isICloudSyncEnabled, setICloudSyncEnabled, getICloudSyncPref,
   shouldPromptFirstRun, payloadHasData,
 } from './utils/icloudSyncPref.js';
+import { evaluateMissingSnapshot, ICLOUD_LAST_SYNCED_KEY } from './utils/icloudSeedGuard.js';
 import useFolderBackup from './hooks/useFolderBackup.js';
 import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOnlyTask, getLinkUrl, hasOnlySubtasks, renderTitle, highlightMatch, renderTitleWithoutTags, extractShareTitle } from './utils/textFormatting.jsx';
 import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate, computeTaskCalendarTombstones, computeRecurringSeriesTombstones } from './utils/taskUtils.js';
@@ -2311,6 +2312,10 @@ const DayPlanner = () => {
   // lands a render too late to stop the next 15-second tick); the state drives the
   // modal. Null when nothing is pending.
   const icloudFirstRunPromptRef = useRef(false);
+  // Epoch ms of the first consecutive cycle that found the snapshot absent, or 0
+  // when it was last seen present. Distinguishes a transient iCloud eviction from
+  // a file that is really gone (utils/icloudSeedGuard.js).
+  const iCloudMissingSinceRef = useRef(0);
   const [icloudFirstRun, setICloudFirstRun] = useState(null);
 
   const isElectronMac = () =>
@@ -2395,11 +2400,20 @@ const DayPlanner = () => {
         // No remote file yet — seed it with local data, but only if state is hydrated.
         // If React state is empty but localStorage has tasks, we'd wipe the cloud file.
         //
-        // On iOS, iCloud can temporarily evict a file and report it as absent without
-        // placing a .icloud placeholder. If we have a previous sync record, the file
-        // almost certainly exists but is just not downloaded yet — skip seeding and
-        // let the next 15-second poll retry after iCloud restores it.
-        if (onIOS && localStorage.getItem('day-planner-cloud-sync-last-synced')) return;
+        // iCloud can temporarily evict the file and report it absent without leaving
+        // a .icloud placeholder, so an absent file is only treated as first run when
+        // this device has never read a real snapshot, or has been seeing it absent
+        // for long enough that eviction no longer explains it. See
+        // utils/icloudSeedGuard.js — including why the previous version of this
+        // guard, keyed on day-planner-cloud-sync-last-synced, never fired for the
+        // iCloud-only devices it was written for.
+        const missing = evaluateMissingSnapshot({
+          hasSyncedBefore: !!localStorage.getItem(ICLOUD_LAST_SYNCED_KEY),
+          missingSince: iCloudMissingSinceRef.current,
+          now: Date.now(),
+        });
+        iCloudMissingSinceRef.current = missing.missingSince;
+        if (missing.skip) return;
         const localTaskCount = JSON.parse(localStorage.getItem('day-planner-tasks') || '[]').length;
         const localInboxCount = JSON.parse(localStorage.getItem('day-planner-unscheduled') || '[]').length;
         const payload = buildSyncPayload();
@@ -2441,6 +2455,15 @@ const DayPlanner = () => {
         }
       }
       if (!remote?.data) return;
+
+      // A real snapshot came back, so the container demonstrably works from this
+      // device. Record that — it is what a later absence is measured against, and
+      // it is iCloud's OWN record: the WebDAV key this used to rely on is written
+      // by a tier an iCloud-only device never runs. Stamped before the first-run
+      // prompt below, because reading the snapshot is what proves the container
+      // works, regardless of what the user then chooses to do with it.
+      localStorage.setItem(ICLOUD_LAST_SYNCED_KEY, new Date().toISOString());
+      iCloudMissingSinceRef.current = 0;
 
       // First launch on a device with no data of its own, facing a cloud copy that
       // survived an uninstall. Ask instead of restoring silently — see

--- a/src/components/ICloudDiagnostics.jsx
+++ b/src/components/ICloudDiagnostics.jsx
@@ -116,6 +116,11 @@ const ICloudDiagnostics = ({ darkMode, textPrimary, textSecondary, borderClass }
               <Row label={t('icloudDiag.snapshotError')} value={report.snapshot.error} />
             )}
 
+            {/* iCloud's own sync record. Until it existed this panel could only
+                show the WebDAV key, so an iCloud-only device always read "never"
+                — true of WebDAV, and silent about the tier it actually used. */}
+            <Row label={t('icloudDiag.icloudSynced')} value={report.transports.icloud?.lastSynced ?? t('icloudDiag.never')} />
+
             {/* The other transports. Without these, an unavailable container
                 leaves "so where did this data come from?" unanswerable. */}
             <Row

--- a/src/utils/icloudDiagnostics.js
+++ b/src/utils/icloudDiagnostics.js
@@ -25,6 +25,11 @@
  * Every platform API is injected so the whole thing is testable without a device.
  */
 
+// The one import here: the key is owned by the seed guard, which writes it. A
+// second copy of the string literal is exactly how this module ended up reporting
+// a key that belonged to a different sync tier.
+import { ICLOUD_LAST_SYNCED_KEY } from './icloudSeedGuard.js';
+
 /** Shape returned when a probe cannot run on this platform. */
 const UNSUPPORTED = 'unsupported';
 
@@ -158,6 +163,11 @@ export function readSyncTransports({ localStorage } = {}) {
   const vaultCfg = json('dayglance-vault-config');
 
   return {
+    // iCloud's own record, written by iCloudSync on every cycle that reads a real
+    // snapshot. Before it existed, this panel could only show the WebDAV key, so
+    // an iCloud-only device always reported "never" — accurate about WebDAV, and
+    // silent about the only tier it actually used.
+    icloud: { lastSynced: get(ICLOUD_LAST_SYNCED_KEY) },
     webdav: {
       configured: !!webdavCfg?.enabled,
       provider: webdavCfg?.provider ?? null,
@@ -268,8 +278,9 @@ export function formatDiagnosticsReport({ platform, available, snapshot, local, 
   }
   if (snapshot.error) lines.push(`  error:         ${snapshot.error}`);
 
-  const t = transports ?? { webdav: {}, vault: {} };
+  const t = transports ?? { icloud: {}, webdav: {}, vault: {} };
   lines.push(
+    `icloud synced:   ${t.icloud?.lastSynced ?? 'never'}`,
     `webdav sync:     ${t.webdav.configured ? `configured (${t.webdav.provider ?? 'unknown'})` : 'not configured'}`,
     `  last synced:   ${t.webdav.lastSynced ?? 'never'}`,
     `glancevault:     ${t.vault.configured ? 'configured' : 'not configured'}`,

--- a/src/utils/icloudDiagnostics.test.js
+++ b/src/utils/icloudDiagnostics.test.js
@@ -169,6 +169,20 @@ describe('readSyncTransports', () => {
     const r = readSyncTransports({ localStorage: fakeLocalStorage() });
     expect(r.webdav).toEqual({ configured: false, provider: null, lastSynced: null });
     expect(r.vault).toEqual({ configured: false, lastSynced: null });
+    expect(r.icloud).toEqual({ lastSynced: null });
+  });
+
+  // iCloud's record is its own key. Reading the WebDAV one is the bug that made
+  // an iCloud-only device report "never" no matter how much it had synced.
+  it("reports iCloud's own sync record, not the WebDAV one", () => {
+    const r = readSyncTransports({
+      localStorage: fakeLocalStorage({
+        'dayglance-icloud-last-synced': '2026-08-08T11:00:00.000Z',
+        'day-planner-cloud-sync-last-synced': '2020-01-01T00:00:00.000Z',
+      }),
+    });
+    expect(r.icloud.lastSynced).toBe('2026-08-08T11:00:00.000Z');
+    expect(r.webdav.lastSynced).toBe('2020-01-01T00:00:00.000Z');
   });
 
   it('reports a configured WebDAV tier with provider and record', () => {

--- a/src/utils/icloudSeedGuard.js
+++ b/src/utils/icloudSeedGuard.js
@@ -1,0 +1,78 @@
+/**
+ * Decides what an absent iCloud snapshot means: genuine first run, or a file the
+ * iCloud daemon has temporarily taken away.
+ *
+ * ── The bug this replaces ──────────────────────────────────────────────────
+ * App.jsx guarded the seed path with:
+ *
+ *     if (onIOS && localStorage.getItem('day-planner-cloud-sync-last-synced')) return;
+ *
+ * intending "we have synced before, so an absent file is eviction rather than
+ * first run — wait for the daemon to bring it back". But that key is written only
+ * by the WebDAV tier (@glance-apps/sync engine.js, and the three WebDAV
+ * conflict-dialog handlers). iCloud sync never writes it. So on a device syncing
+ * only over iCloud — the zero-config Apple setup, the default on iOS — the key
+ * was never set, the condition was always false, and the guard was dead code on
+ * exactly the platform and configuration its own comment described. It could only
+ * ever fire for someone running iOS *and* WebDAV.
+ *
+ * Falling through meant the device republished its own snapshot over the evicted
+ * one. The union merge means another device generally reconciles it rather than
+ * data being destroyed, so this is churn rather than loss: a device that is
+ * behind overwrites the container with a staler copy, and every spurious write
+ * adds a version to the CloudKit document zone that ICLOUD_WRITE_THROTTLE_MS
+ * exists to avoid.
+ *
+ * ── Why a grace window rather than a plain flag ────────────────────────────
+ * Making the guard actually fire introduces a failure the broken version could
+ * not have: if the snapshot is genuinely gone — the user deleted it, the
+ * container was reset, iCloud was signed out and back in — a device that refuses
+ * to seed refuses forever, and sync silently stops with no way back.
+ *
+ * So absence is timed rather than trusted. A file missing briefly is treated as
+ * eviction and left alone; a file missing well past any plausible restore is
+ * treated as really gone, and the device seeds it again. Both failure modes are
+ * bounded, and the recovery is automatic in each direction.
+ */
+
+/** Written by iCloud sync itself on every cycle that reads a real snapshot. */
+export const ICLOUD_LAST_SYNCED_KEY = 'dayglance-icloud-last-synced';
+
+/**
+ * How long an absent snapshot is assumed to be a temporary eviction.
+ *
+ * ICloudBridge.readSync already calls startDownloadingUbiquitousItem when the
+ * file is missing, so a restore is in flight from the first observation and
+ * normally lands in seconds. Ten minutes is far past that while still being a
+ * delay a user would sit through rather than a permanent stall.
+ */
+export const MISSING_GRACE_MS = 10 * 60 * 1000;
+
+/**
+ * @param {object} s
+ * @param {boolean} s.hasSyncedBefore  this device has previously read a real snapshot
+ * @param {number}  s.missingSince     epoch ms of the first consecutive sighting of
+ *                                     the file as absent, or 0 if it was present last cycle
+ * @param {number}  s.now              epoch ms
+ * @param {number} [s.graceMs]
+ * @returns {{skip: boolean, missingSince: number}}
+ *   skip         — true to leave the container alone this cycle
+ *   missingSince — the value to carry into the next cycle (0 clears the streak)
+ */
+export function evaluateMissingSnapshot({ hasSyncedBefore, missingSince, now, graceMs = MISSING_GRACE_MS } = {}) {
+  // Never synced: nothing can have been evicted, so this is a real first run and
+  // seeding is the correct, necessary behaviour. Unchanged from before.
+  if (!hasSyncedBefore) return { skip: false, missingSince: 0 };
+
+  // First cycle seeing it absent. Start the clock and wait — this is the eviction
+  // case the original guard was written for.
+  if (!missingSince) return { skip: true, missingSince: now };
+
+  // Still inside the window: keep waiting, preserving the original sighting so the
+  // window measures the whole streak rather than restarting every cycle.
+  if (now - missingSince < graceMs) return { skip: true, missingSince };
+
+  // Gone long enough that eviction no longer explains it. Seed, and clear the
+  // streak so the next absence starts its own window.
+  return { skip: false, missingSince: 0 };
+}

--- a/src/utils/icloudSeedGuard.test.js
+++ b/src/utils/icloudSeedGuard.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateMissingSnapshot,
+  MISSING_GRACE_MS,
+  ICLOUD_LAST_SYNCED_KEY,
+} from './icloudSeedGuard.js';
+
+const T0 = 1_700_000_000_000;
+
+describe('evaluateMissingSnapshot', () => {
+  // Unchanged behaviour: a device that has never synced must still seed, or a
+  // genuinely new container never gets created.
+  it('seeds on a real first run', () => {
+    expect(evaluateMissingSnapshot({ hasSyncedBefore: false, missingSince: 0, now: T0 }))
+      .toEqual({ skip: false, missingSince: 0 });
+  });
+
+  it('seeds on first run even if a stale missing-streak is somehow carried in', () => {
+    expect(evaluateMissingSnapshot({ hasSyncedBefore: false, missingSince: T0 - 1e6, now: T0 }))
+      .toEqual({ skip: false, missingSince: 0 });
+  });
+
+  // The case the original guard meant to cover and never did.
+  it('waits on the first sighting of an absent file after a prior sync', () => {
+    expect(evaluateMissingSnapshot({ hasSyncedBefore: true, missingSince: 0, now: T0 }))
+      .toEqual({ skip: true, missingSince: T0 });
+  });
+
+  it('keeps waiting inside the grace window', () => {
+    const r = evaluateMissingSnapshot({
+      hasSyncedBefore: true, missingSince: T0, now: T0 + MISSING_GRACE_MS - 1,
+    });
+    expect(r).toEqual({ skip: true, missingSince: T0 });
+  });
+
+  // The streak must measure the whole absence, not restart each cycle — otherwise
+  // the window never elapses and the stall becomes permanent.
+  it('preserves the original sighting across repeated cycles', () => {
+    let state = { missingSince: 0 };
+    for (const offset of [0, 15_000, 30_000, 45_000]) {
+      state = evaluateMissingSnapshot({
+        hasSyncedBefore: true, missingSince: state.missingSince, now: T0 + offset,
+      });
+      expect(state.skip).toBe(true);
+    }
+    expect(state.missingSince).toBe(T0);
+  });
+
+  // The failure the broken guard could not have caused, and which this must not
+  // introduce: a genuinely deleted snapshot leaving sync stalled forever.
+  it('seeds again once the file has been absent past the grace window', () => {
+    expect(evaluateMissingSnapshot({
+      hasSyncedBefore: true, missingSince: T0, now: T0 + MISSING_GRACE_MS,
+    })).toEqual({ skip: false, missingSince: 0 });
+  });
+
+  it('clears the streak when it decides to seed, so the next absence starts fresh', () => {
+    const recovered = evaluateMissingSnapshot({
+      hasSyncedBefore: true, missingSince: T0, now: T0 + MISSING_GRACE_MS + 1,
+    });
+    expect(recovered.missingSince).toBe(0);
+    // Next absence begins its own window rather than firing immediately.
+    const next = evaluateMissingSnapshot({
+      hasSyncedBefore: true, missingSince: recovered.missingSince, now: T0 + 1e7,
+    });
+    expect(next).toEqual({ skip: true, missingSince: T0 + 1e7 });
+  });
+
+  it('honours a custom grace window', () => {
+    const opts = { hasSyncedBefore: true, missingSince: T0, graceMs: 1000 };
+    expect(evaluateMissingSnapshot({ ...opts, now: T0 + 999 }).skip).toBe(true);
+    expect(evaluateMissingSnapshot({ ...opts, now: T0 + 1000 }).skip).toBe(false);
+  });
+
+  it('seeds with no arguments rather than stalling on an undefined state', () => {
+    expect(evaluateMissingSnapshot()).toEqual({ skip: false, missingSince: 0 });
+    expect(evaluateMissingSnapshot({})).toEqual({ skip: false, missingSince: 0 });
+  });
+});
+
+describe('ICLOUD_LAST_SYNCED_KEY', () => {
+  // The whole bug was reading a key another tier owned. This one must be
+  // iCloud's own, distinct from the WebDAV and GLANCEvault records.
+  it('is distinct from the WebDAV and vault sync records', () => {
+    expect(ICLOUD_LAST_SYNCED_KEY).toBe('dayglance-icloud-last-synced');
+    expect(ICLOUD_LAST_SYNCED_KEY).not.toBe('day-planner-cloud-sync-last-synced');
+    expect(ICLOUD_LAST_SYNCED_KEY).not.toBe('dayglance-vault-db-sync-last-synced');
+  });
+});


### PR DESCRIPTION
## The bug

`iCloudSync` guarded its seed path with:

```js
if (onIOS && localStorage.getItem('day-planner-cloud-sync-last-synced')) return;
```

The intent, per the comment above it: iCloud can evict `dayglance-sync.json` and report it absent without leaving a `.icloud` placeholder, so an absent file on a device that has synced before is eviction, not first run — wait for the daemon rather than reseeding.

But that key is written in exactly five places, all WebDAV:

- `@glance-apps/sync/src/engine.js:256` and `:408` — the WebDAV engine
- `App.jsx` ×3 — the buttons in the WebDAV conflict dialog

**iCloud sync never wrote it.** So on a device syncing only over iCloud — the zero-config Apple setup, the default on iOS — the key was never set, the condition was always false, and the guard was dead code on exactly the platform and configuration its own comment described. It could fire only for someone running iOS *and* WebDAV, who needs it least.

## What went wrong in practice

Execution fell through to the seed path, and the device republished its own snapshot over the evicted one. The next check (`localTaskCount > 0 && payloadTaskCount === 0`) catches a different problem — a hydration race — and doesn't help here, because after an eviction the local state is perfectly valid.

Severity, honestly: **churn rather than loss.** The union merge means another device generally reconciles it. The cost is a device that's behind overwriting the container with a staler copy that then has to be re-reconciled, plus a spurious write adding a version to the CloudKit document zone — the thing `ICLOUD_WRITE_THROTTLE_MS` exists to avoid.

## The fix

iCloud stamps its own key (`dayglance-icloud-last-synced`) on every cycle that reads a real snapshot, and the guard reads that.

**Why a grace window rather than a plain flag.** Making the guard fire for the first time introduces a failure the broken version *could not have*: a snapshot that is genuinely gone — deleted, container reset, iCloud signed out and back in — would stall a refusing device forever with no way back. So absence is timed rather than trusted: brief absence is eviction and left alone, absence past ten minutes is real and gets reseeded. Both directions recover on their own, and the streak measures the whole absence rather than restarting each cycle (which would make the window never elapse).

**`onIOS &&` is dropped.** Eviction isn't iOS-exclusive, and the window bounds the downside on macOS equally.

## Side effect worth having

The diagnostics panel can finally report an iCloud sync time. It previously had only the WebDAV key, so an iCloud-only device always read `never` — accurate about WebDAV, silent about the only tier it used. That's precisely the row that read `never` on the device during this investigation while iCloud was demonstrably working.

The key is imported from the module that owns it rather than restated as a literal — a second copy of a key string is how this module came to report a different tier's record in the first place.

## Testing

- `src/utils/icloudSeedGuard.test.js` — 10 cases. First run still seeds; first absence waits; the streak is preserved across cycles; the window elapsing reseeds and clears; a custom window; and no-args seeds rather than stalling on undefined state.
- `icloudDiagnostics.test.js` — added a case asserting the iCloud record is read from iCloud's key and not WebDAV's, with both present and different.
- Full suite: **1237 tests / 81 files passing**.
- `eslint --max-warnings 0`, `npm run audit`, and the web build all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWTFj6JEjp8NUd71HzHHai)_