### PR TITLE
Push the widget snapshot only when its content changed

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ import {
   shouldPromptFirstRun, payloadHasData,
 } from './utils/icloudSyncPref.js';
 import { evaluateMissingSnapshot, ICLOUD_LAST_SYNCED_KEY } from './utils/icloudSeedGuard.js';
+import { evaluateSnapshotPush } from './utils/widgetSnapshotDedupe.js';
 import useFolderBackup from './hooks/useFolderBackup.js';
 import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOnlyTask, getLinkUrl, hasOnlySubtasks, renderTitle, highlightMatch, renderTitleWithoutTags, extractShareTitle } from './utils/textFormatting.jsx';
 import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate, computeTaskCalendarTombstones, computeRecurringSeriesTombstones } from './utils/taskUtils.js';
@@ -6857,6 +6858,11 @@ const DayPlanner = () => {
   // block boundary (advances the Up Next widget / Live Activity label while
   // the app is open).
   const [widgetSnapshotTick, setWidgetSnapshotTick] = useState(0);
+  // Content fingerprint of the last snapshot actually sent across the bridge, so
+  // an unchanged one is not re-pushed. Empty on mount, so the first push after a
+  // launch or reload always goes through and the widget is never left holding
+  // whatever the previous process left behind.
+  const lastWidgetSnapshotRef = useRef('');
 
   // ── Native Android widget snapshot sync ──────────────────────────────────
   // Pushes a rich snapshot of today's agenda to the native widget via NativeBridge.
@@ -7327,9 +7333,21 @@ const DayPlanner = () => {
       updatedAt: Date.now(),
     };
 
-    try {
-      window.DayGlanceNative.updateWidgetSnapshot(JSON.stringify(snapshot));
-    } catch (_) {}
+    // Only push when the snapshot's CONTENT changed. This effect re-runs on the
+    // 15-second currentTime tick and on every render that rebuilds one of its
+    // derived array deps, so most runs produce a snapshot identical to the last
+    // one — 108 consecutive byte-identical pushes were observed on an idle
+    // device. Each push is a synchronous bridge XHR that blocks the JS thread,
+    // and each one makes the native side run reloadAllTimelines() and sync the
+    // Live Activity. The comparison must exclude `updatedAt` or it never matches;
+    // see utils/widgetSnapshotDedupe.js.
+    const { push, fingerprint } = evaluateSnapshotPush(snapshot, lastWidgetSnapshotRef.current);
+    if (push) {
+      lastWidgetSnapshotRef.current = fingerprint;
+      try {
+        window.DayGlanceNative.updateWidgetSnapshot(JSON.stringify(snapshot));
+      } catch (_) {}
+    }
 
     // Re-push at the next block boundary so "at 3:30 PM" flips to "until
     // 5:00 PM" (and the Up Next widget advances) while the app is open. iOS

--- a/src/utils/widgetSnapshotDedupe.js
+++ b/src/utils/widgetSnapshotDedupe.js
@@ -1,0 +1,71 @@
+/**
+ * Skips widget-snapshot pushes whose content has not changed.
+ *
+ * ── Why ────────────────────────────────────────────────────────────────────
+ * The snapshot effect re-runs far more often than the snapshot changes. Its
+ * dependency array includes `currentTime` (a 15-second interval) and several
+ * derived arrays — todayAgenda, activeHabits, hgVisibleProjects, glanceAhead —
+ * that are rebuilt each render, so their identity changes even when their
+ * contents do not. Observed on a real device: 108 consecutive pushes of a
+ * byte-identical 13 KB payload while the app sat idle.
+ *
+ * Each push is more expensive than it looks. The bridge is a SYNCHRONOUS XHR
+ * (see bridgeScript() in WebView.swift), so every call blocks the JS thread for
+ * the round trip; and on the native side WidgetBridge.updateSnapshot runs
+ * WidgetCenter.reloadAllTimelines() and LiveActivityBridge.sync() each time. A
+ * hundred redundant pushes is a hundred timeline reloads for data that did not
+ * move.
+ *
+ * ── The trap ───────────────────────────────────────────────────────────────
+ * The obvious fix — remember the last JSON and compare — does nothing, because
+ * the snapshot ends with `updatedAt: Date.now()`. Every serialization differs,
+ * so a naive comparison never matches and every push still goes through. (It is
+ * also why the byte counts looked identical while the bytes were not: a
+ * millisecond timestamp is always 13 digits.) The comparison has to exclude that
+ * field, which is what this module is for.
+ *
+ * Everything else in the snapshot is stable between block boundaries:
+ * computeDaySummary takes no clock argument, and buildUpNextFact's output is a
+ * boundary-derived label plus an absolute countdownEndMs that SwiftUI counts
+ * down on its own. So excluding `updatedAt` is sufficient, not merely necessary.
+ */
+
+/**
+ * Content fingerprint of a snapshot: its JSON minus the always-changing
+ * `updatedAt` stamp.
+ *
+ * Key order is insertion order and the snapshot is built from a single object
+ * literal, so stringify is stable across calls and safe to compare directly.
+ *
+ * @param {object} snapshot
+ * @returns {string}
+ */
+export function snapshotFingerprint(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') return '';
+  // eslint-disable-next-line no-unused-vars
+  const { updatedAt, ...rest } = snapshot;
+  try {
+    return JSON.stringify(rest);
+  } catch {
+    // A cyclic or otherwise unserialisable snapshot cannot be fingerprinted.
+    // Return '' so the caller pushes rather than silently suppressing an update
+    // — failing toward "send it" is the safe direction for a widget.
+    return '';
+  }
+}
+
+/**
+ * Decides whether this snapshot needs sending.
+ *
+ * An empty fingerprint (unserialisable snapshot) always pushes: a widget showing
+ * stale data is a worse failure than a redundant bridge call.
+ *
+ * @param {object} snapshot
+ * @param {string} lastFingerprint  fingerprint of the last snapshot actually sent
+ * @returns {{push: boolean, fingerprint: string}}
+ */
+export function evaluateSnapshotPush(snapshot, lastFingerprint) {
+  const fingerprint = snapshotFingerprint(snapshot);
+  if (!fingerprint) return { push: true, fingerprint: '' };
+  return { push: fingerprint !== lastFingerprint, fingerprint };
+}

--- a/src/utils/widgetSnapshotDedupe.test.js
+++ b/src/utils/widgetSnapshotDedupe.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { snapshotFingerprint, evaluateSnapshotPush } from './widgetSnapshotDedupe.js';
+
+const snap = (over = {}) => ({
+  date: '2026-08-08',
+  sections: [{ id: 1, title: 'Work' }],
+  daySummary: { unblockedMinutes: 120, done: '1h/4h' },
+  updatedAt: 1_700_000_000_000,
+  ...over,
+});
+
+describe('snapshotFingerprint', () => {
+  // The whole point: updatedAt changes on every build and must not count.
+  it('ignores updatedAt', () => {
+    expect(snapshotFingerprint(snap({ updatedAt: 1 })))
+      .toBe(snapshotFingerprint(snap({ updatedAt: 999_999_999 })));
+  });
+
+  it('changes when real content changes', () => {
+    expect(snapshotFingerprint(snap()))
+      .not.toBe(snapshotFingerprint(snap({ sections: [{ id: 1, title: 'Home' }] })));
+  });
+
+  it('notices a nested change', () => {
+    expect(snapshotFingerprint(snap()))
+      .not.toBe(snapshotFingerprint(snap({ daySummary: { unblockedMinutes: 90, done: '1h/4h' } })));
+  });
+
+  it('notices a field being added or removed', () => {
+    expect(snapshotFingerprint(snap())).not.toBe(snapshotFingerprint(snap({ extra: true })));
+  });
+
+  it('returns empty for non-objects', () => {
+    expect(snapshotFingerprint(null)).toBe('');
+    expect(snapshotFingerprint(undefined)).toBe('');
+    expect(snapshotFingerprint('nope')).toBe('');
+  });
+
+  it('returns empty rather than throwing on a cyclic snapshot', () => {
+    const cyclic = snap();
+    cyclic.self = cyclic;
+    expect(snapshotFingerprint(cyclic)).toBe('');
+  });
+});
+
+describe('evaluateSnapshotPush', () => {
+  it('pushes the first snapshot, when nothing has been sent yet', () => {
+    const r = evaluateSnapshotPush(snap(), '');
+    expect(r.push).toBe(true);
+    expect(r.fingerprint).not.toBe('');
+  });
+
+  // The 108-identical-pushes case from the device.
+  it('skips a re-push whose only difference is the timestamp', () => {
+    const first = evaluateSnapshotPush(snap({ updatedAt: 1 }), '');
+    const second = evaluateSnapshotPush(snap({ updatedAt: 2 }), first.fingerprint);
+    expect(second.push).toBe(false);
+    expect(second.fingerprint).toBe(first.fingerprint);
+  });
+
+  it('pushes again once content actually changes', () => {
+    const first = evaluateSnapshotPush(snap(), '');
+    const changed = evaluateSnapshotPush(snap({ date: '2026-08-09' }), first.fingerprint);
+    expect(changed.push).toBe(true);
+    expect(changed.fingerprint).not.toBe(first.fingerprint);
+  });
+
+  it('collapses a long idle run to a single push', () => {
+    let last = '';
+    let pushes = 0;
+    for (let i = 0; i < 108; i++) {
+      const r = evaluateSnapshotPush(snap({ updatedAt: 1_700_000_000_000 + i * 15_000 }), last);
+      if (r.push) pushes++;
+      last = r.fingerprint;
+    }
+    expect(pushes).toBe(1);
+  });
+
+  // Failing toward "send it": a widget showing stale data is worse than a
+  // redundant bridge call.
+  it('pushes when the snapshot cannot be fingerprinted', () => {
+    const cyclic = snap();
+    cyclic.self = cyclic;
+    expect(evaluateSnapshotPush(cyclic, 'anything').push).toBe(true);
+  });
+
+  it('pushes a fresh snapshot after an unserialisable one, not suppressing it', () => {
+    const cyclic = snap();
+    cyclic.self = cyclic;
+    const bad = evaluateSnapshotPush(cyclic, '');
+    expect(bad.fingerprint).toBe('');
+    // The empty fingerprint must not match the next real one and swallow it.
+    expect(evaluateSnapshotPush(snap(), bad.fingerprint).push).toBe(true);
+  });
+});


### PR DESCRIPTION
## Measured, not theorised

Instrumenting `updateWidgetSnapshot` on a real device showed **108 consecutive pushes of a byte-identical 13 KB payload** while the app sat idle.

Two causes:

- The effect's dependency array (`App.jsx`) includes `currentTime`, updated by a 15-second `setInterval`, plus `todayAgenda`, `activeHabits`, `hgVisibleProjects` and `glanceAhead` — derived arrays rebuilt each render, so their identity changes even when their contents don't.
- Nothing compared the result against the last snapshot sent. The call was unconditional.

## Why it costs more than it looks

The bridge is a **synchronous XHR** (`bridgeScript()` in `WebView.swift` — `xhr.open(url, false)`), so every call blocks the JS thread for the full round trip with a 13 KB payload. On the native side, `WidgetBridge.updateSnapshot` then runs `WidgetCenter.reloadAllTimelines()` *and* `LiveActivityBridge.sync()`.

A hundred redundant pushes is a hundred timeline reloads for data that didn't move.

## The trap

Remembering the last JSON and comparing does **nothing** on its own. The snapshot ends with `updatedAt: Date.now()`, so every serialization differs, the comparison never matches, and every push still goes through.

It's also why the byte counts looked identical while the bytes weren't: a millisecond timestamp is always 13 digits.

So the fingerprint excludes `updatedAt`.

## Why excluding it is sufficient, not merely necessary

Worth checking rather than assuming, since a dedupe that suppresses real updates would be a much worse bug than the one it fixes:

- `computeDaySummary(dayTasks, endOfDayTime, dayWindow)` takes no clock argument — its output doesn't drift with wall time.
- The only other `Date.now()` feeds `buildUpNextFact`, whose output is a boundary-derived label plus an absolute `countdownEndMs` that SwiftUI counts down on its own (`Text(timerInterval:)`).

So content genuinely is stable between block boundaries, and the `widgetSnapshotTick` boundary re-push still changes the label, still changes the fingerprint, and still goes through.

## Failure directions

- An unserialisable snapshot fingerprints as `''` and **always pushes** — a widget showing stale data is a worse failure than a redundant bridge call.
- The ref starts empty on mount, so the first push after any launch or reload is never suppressed and the widget is never left holding what a previous process left behind.

## Testing

- `src/utils/widgetSnapshotDedupe.test.js` — 12 cases: `updatedAt` ignored, real/nested/added-field changes detected, cyclic snapshots handled without throwing, an empty fingerprint never swallowing the next real push, and a loop asserting 108 timestamp-only rebuilds collapse to exactly **1** push.
- Full suite: **1249 tests / 82 files passing**.
- `eslint --max-warnings 0`, `npm run audit`, and the web build all clean.
- Not yet re-measured on device — the console instrumentation from the original measurement will confirm it once this is in a build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWTFj6JEjp8NUd71HzHHai)_