### PR TITLE
Warn when sync is off, not when it is working; drop remaining em dashes

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -852,7 +852,7 @@
     "recurringTasks": "Recurring tasks",
     "allInstances": "All instances",
     "nextOnly": "Next only",
-    "nothingToFilter": "Nothing to filter yet — schedule some tasks first.",
+    "nothingToFilter": "Nothing to filter yet. Schedule some tasks first.",
     "filterHint": "Selections within a section match any; sections combine.",
     "addTaskOnDate": "Add task on {{date}}",
     "closeFilters": "Close filters",
@@ -876,7 +876,7 @@
     "switchToView": "Switch to {{view}} view",
     "currentViewTap": "Current view: {{view}}. Tap to switch.",
     "deadline": "Deadline",
-    "deadlineTapToSchedule": "Deadline — tap to pick a time",
+    "deadlineTapToSchedule": "Deadline: tap to pick a time",
     "routineTapHint": "Tap to complete · hold to pick a time",
     "completedTasks": "Completed tasks",
     "pastEvents": "Past events",
@@ -976,7 +976,6 @@
     "never": "never",
     "copy": "Copy report",
     "copied": "Copied",
-    "readingNote": "This device resolves an iCloud container and found a populated snapshot in it. If you have turned iCloud off for dayGLANCE, that is the bug: the app is reading a store you disabled, and a reinstall will read it too.",
     "state": {
       "present": "present",
       "absent": "not found",
@@ -991,7 +990,11 @@
     "configured": "configured",
     "notConfigured": "not configured",
     "none": "(none)",
-    "icloudSynced": "iCloud last synced"
+    "icloudSynced": "iCloud last synced",
+    "syncPref": "Sync on this device",
+    "on": "on",
+    "off": "off",
+    "notSyncingNote": "This device is not syncing with iCloud, so its data stays here only. Other devices will not see changes made here, and changes made elsewhere will not arrive."
   },
   "icloudFirstRun": {
     "title": "Data found in iCloud",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -852,7 +852,7 @@
     "recurringTasks": "Tâches récurrentes",
     "allInstances": "Toutes les occurrences",
     "nextOnly": "Prochaine seulement",
-    "nothingToFilter": "Rien à filtrer pour l'instant — planifiez d'abord des tâches.",
+    "nothingToFilter": "Rien à filtrer pour l'instant. Planifiez d'abord des tâches.",
     "filterHint": "Les sélections d'une même section s'additionnent ; les sections se combinent.",
     "addTaskOnDate": "Ajouter une tâche le {{date}}",
     "closeFilters": "Fermer les filtres",
@@ -876,7 +876,7 @@
     "switchToView": "Passer à la vue {{view}}",
     "currentViewTap": "Vue actuelle : {{view}}. Touchez pour changer.",
     "deadline": "Échéance",
-    "deadlineTapToSchedule": "Échéance — touchez pour choisir une heure",
+    "deadlineTapToSchedule": "Échéance : touchez pour choisir une heure",
     "routineTapHint": "Touchez pour terminer · maintenez pour choisir une heure",
     "completedTasks": "Tâches terminées",
     "pastEvents": "Événements passés",
@@ -976,7 +976,6 @@
     "never": "jamais",
     "copy": "Copier le rapport",
     "copied": "Copié",
-    "readingNote": "Cet appareil résout un conteneur iCloud et y a trouvé un instantané rempli. Si vous avez désactivé iCloud pour dayGLANCE, c'est le bug : l'application lit un stockage que vous avez désactivé, et une réinstallation le lira aussi.",
     "state": {
       "present": "présent",
       "absent": "introuvable",
@@ -991,7 +990,11 @@
     "configured": "configuré",
     "notConfigured": "non configuré",
     "none": "(aucun)",
-    "icloudSynced": "Dernière synchro iCloud"
+    "icloudSynced": "Dernière synchro iCloud",
+    "syncPref": "Synchro sur cet appareil",
+    "on": "activée",
+    "off": "désactivée",
+    "notSyncingNote": "Cet appareil ne se synchronise pas avec iCloud ; ses données restent ici uniquement. Les autres appareils ne verront pas les modifications faites ici, et celles faites ailleurs n'arriveront pas."
   },
   "icloudFirstRun": {
     "title": "Données trouvées dans iCloud",

--- a/src/components/ICloudDiagnostics.jsx
+++ b/src/components/ICloudDiagnostics.jsx
@@ -116,6 +116,16 @@ const ICloudDiagnostics = ({ darkMode, textPrimary, textSecondary, borderClass }
               <Row label={t('icloudDiag.snapshotError')} value={report.snapshot.error} />
             )}
 
+            {/* The in-app preference, which #1333's "start fresh on this device"
+                sets. Without this row a device with a perfectly reachable
+                container but sync deliberately switched off looks identical to a
+                healthy one. */}
+            <Row
+              label={t('icloudDiag.syncPref')}
+              value={report.syncEnabled ? t('icloudDiag.on') : t('icloudDiag.off')}
+              tone={report.syncEnabled ? undefined : 'text-amber-600 dark:text-amber-400'}
+            />
+
             {/* iCloud's own sync record. Until it existed this panel could only
                 show the WebDAV key, so an iCloud-only device always read "never"
                 — true of WebDAV, and silent about the tier it actually used. */}
@@ -142,11 +152,18 @@ const ICloudDiagnostics = ({ darkMode, textPrimary, textSecondary, borderClass }
             />
           </div>
 
-          {/* The finding worth calling out: a resolvable container is exactly what
-              a user who has switched iCloud off does not expect to see. */}
-          {report.available.value === true && report.snapshot.state === 'present' && (
+          {/* Flag the state the user would want to know about but cannot see:
+              this device holds data and is NOT syncing it anywhere.
+
+              The previous version fired on `available && snapshot present`, which
+              is the NORMAL working state for every iCloud user — it dated from the
+              hypothesis that the app read containers the user had disabled, and
+              on-device testing disproved that (the probe correctly reports false
+              when iCloud is off). So it told healthy users their setup was broken.
+              Warn about sync being off, not about sync working. */}
+          {report.local.taskCount > 0 && (report.available.value === false || !report.syncEnabled) && (
             <p className="text-xs text-amber-800 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 rounded p-2">
-              {t('icloudDiag.readingNote')}
+              {t('icloudDiag.notSyncingNote')}
             </p>
           )}
 

--- a/src/utils/icloudDiagnostics.js
+++ b/src/utils/icloudDiagnostics.js
@@ -14,12 +14,16 @@
  * and it needs a Mac, a cable, and two settings toggles. This module answers the
  * same question from inside the app on any build.
  *
- * The reading that matters most: ICloudBridge.isAvailable() is a bare
- * `containerURL() != nil`, which answers "can I resolve a path", NOT "is iCloud
- * enabled for this app". If `available` reports true on a device where the user
- * has switched dayGLANCE's iCloud toggle OFF, that is the bug — the app is
- * reading a store the user believes they disabled. If it reports false, the
- * iCloud theory is dead and the surviving store is something else.
+ * What it found, on device: the container reported `unavailable` before the app
+ * was deleted and `AVAILABLE` after it was reinstalled, with nothing touched in
+ * between. Reinstalling re-grants the iCloud entitlement, so the per-app toggle
+ * comes back on and the surviving snapshot is read again.
+ *
+ * Note what that ruled OUT, since an earlier version of this file asserted it:
+ * isAvailable() is a bare `containerURL() != nil`, and the theory was that it
+ * reported true for containers the user had disabled. It does not — with iCloud
+ * off for dayGLANCE it correctly returned `{"available":false}`. Availability is
+ * honest; the toggle resetting on reinstall is the actual mechanism.
  *
  * Read-only by construction: nothing here writes, deletes, or triggers a sync.
  * Every platform API is injected so the whole thing is testable without a device.
@@ -29,6 +33,7 @@
 // second copy of the string literal is exactly how this module ended up reporting
 // a key that belonged to a different sync tier.
 import { ICLOUD_LAST_SYNCED_KEY } from './icloudSeedGuard.js';
+import { isICloudSyncEnabled } from './icloudSyncPref.js';
 
 /** Shape returned when a probe cannot run on this platform. */
 const UNSUPPORTED = 'unsupported';
@@ -46,7 +51,7 @@ export function utf8Bytes(str, TextEncoderImpl = typeof TextEncoder !== 'undefin
 
 /** Human-readable byte count. Diagnostics are read by people, not parsers. */
 export function formatBytes(n) {
-  if (!Number.isFinite(n) || n < 0) return '—';
+  if (!Number.isFinite(n) || n < 0) return '(none)';
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;
@@ -248,6 +253,11 @@ export async function collectICloudDiagnostics(deps = defaultDeps()) {
     platform,
     available,
     snapshot,
+    // The in-app preference is separate from container availability: a device can
+    // resolve the container perfectly and still be deliberately not syncing,
+    // because the user chose "start fresh" at first run or switched it off in
+    // settings. Reporting only availability would show those as healthy.
+    syncEnabled: isICloudSyncEnabled(deps.localStorage),
     local: readLocalState(deps),
     transports: readSyncTransports(deps),
   };
@@ -257,7 +267,7 @@ export async function collectICloudDiagnostics(deps = defaultDeps()) {
  * Plain-text report for the copy-to-clipboard button, so a user can paste the
  * findings into an issue without retyping or screenshotting them.
  */
-export function formatDiagnosticsReport({ platform, available, snapshot, local, transports }) {
+export function formatDiagnosticsReport({ platform, available, snapshot, local, transports, syncEnabled }) {
   const none = '(none)';
   const lines = [
     'dayGLANCE iCloud diagnostics',
@@ -280,6 +290,7 @@ export function formatDiagnosticsReport({ platform, available, snapshot, local, 
 
   const t = transports ?? { icloud: {}, webdav: {}, vault: {} };
   lines.push(
+    `sync on device:  ${syncEnabled === false ? 'OFF' : 'on'}`,
     `icloud synced:   ${t.icloud?.lastSynced ?? 'never'}`,
     `webdav sync:     ${t.webdav.configured ? `configured (${t.webdav.provider ?? 'unknown'})` : 'not configured'}`,
     `  last synced:   ${t.webdav.lastSynced ?? 'never'}`,

--- a/src/utils/icloudDiagnostics.test.js
+++ b/src/utils/icloudDiagnostics.test.js
@@ -239,8 +239,8 @@ describe('utf8Bytes / formatBytes', () => {
     expect(formatBytes(512)).toBe('512 B');
     expect(formatBytes(2048)).toBe('2.0 KB');
     expect(formatBytes(3 * 1024 * 1024)).toBe('3.0 MB');
-    expect(formatBytes(-1)).toBe('—');
-    expect(formatBytes(NaN)).toBe('—');
+    expect(formatBytes(-1)).toBe('(none)');
+    expect(formatBytes(NaN)).toBe('(none)');
   });
 });
 
@@ -276,6 +276,28 @@ describe('collectICloudDiagnostics', () => {
     expect(r.snapshot.state).toBe('present');
     expect(r.snapshot.taskCount).toBeGreaterThan(0);
     expect(r.local.taskCount).toBe(0);
+  });
+
+  // A device can resolve the container perfectly and still be deliberately not
+  // syncing (#1333's "start fresh"). Reporting only availability shows that as
+  // healthy, which is the state the panel most needs to distinguish.
+  it('reports the in-app sync preference alongside availability', async () => {
+    const bridge = {
+      iCloudAvailable: () => '{"available":true}',
+      readICloudSync: () => payload(),
+    };
+    const on = await collectICloudDiagnostics({
+      nativeBridge: bridge, localStorage: fakeLocalStorage(),
+    });
+    expect(on.syncEnabled).toBe(true);          // absence of a preference means on
+
+    const off = await collectICloudDiagnostics({
+      nativeBridge: bridge,
+      localStorage: fakeLocalStorage({ 'dayglance-icloud-sync-enabled': 'false' }),
+    });
+    expect(off.syncEnabled).toBe(false);
+    expect(off.available.value).toBe(true);     // container fine, sync off anyway
+    expect(formatDiagnosticsReport(off)).toMatch(/sync on device:\s+OFF/);
   });
 
   it('gathers a macOS report and awaits the async read', async () => {


### PR DESCRIPTION
## The warning fired on healthy users

`ICloudDiagnostics.jsx` showed an amber note when:

```jsx
report.available.value === true && report.snapshot.state === 'present'
```

That's the **normal working state** for everyone syncing over iCloud, and the text told them *"that is the bug: the app is reading a store you disabled."*

It dated from the hypothesis that `isAvailable()` reported true for containers the user had switched off. The first on-device run disproved that — with iCloud off for dayGLANCE it correctly returned `{"available":false}`. So the note was a false alarm on the majority case, announcing a bug that doesn't exist.

**Inverted.** It now fires when this device holds data and is *not* syncing it anywhere — the state a user would actually want to know about and cannot otherwise see.

## New row: the in-app preference

A device can resolve the container perfectly and still be deliberately not syncing, because the user chose "start fresh on this device" at first run (#1333) or switched it off in settings. Reporting only availability showed that as healthy. There's now a **Sync on this device** row, amber when off, and a `sync on device:` line in the copyable report.

## Header corrected

The module header carried the same disproven hypothesis. It now records what the device runs actually showed — `unavailable` before deletion, `AVAILABLE` after reinstall — and explicitly notes what that ruled out, so the next reader doesn't re-derive the dead theory.

## Em dashes

The last two in user-facing copy (`sched.nothingToFilter`, `sched.deadlineTapToSchedule`), plus one hiding in `formatBytes`' invalid-input fallback, which renders in the panel. Both locales verified programmatically clean.

## Testing

- New case asserting `syncEnabled` is reported independently of availability, including the container-fine-but-sync-off combination and its appearance in the report text.
- Full suite: **1255 tests / 82 files passing**.
- `eslint --max-warnings 0`, `npm run audit`, and the web build all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWTFj6JEjp8NUd71HzHHai)_