### PR TITLE
Dismiss the Day window popover with Escape

### DIFF
--- a/src/components/DayWindowMenu.jsx
+++ b/src/components/DayWindowMenu.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
@@ -36,6 +36,17 @@ export default function DayWindowMenu({ dateStr, onClose, anchorClass = '', anch
   const [pickerField, setPickerField] = useState(null);
 
   const dayWindow = getDayWindow?.(dateStr) ?? null;
+
+  // Escape closes the popover, matching the other popovers (InboxFilterPopover,
+  // DeadlinePickerPopover). While the clock picker is open Escape belongs to it:
+  // it dismisses the picker and leaves the menu up, so the user lands back where
+  // they were rather than losing the whole popover in one keypress.
+  useEffect(() => {
+    if (pickerField) return undefined;
+    const handler = (e) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [pickerField, onClose]);
 
   const updateWindow = (field, value) => {
     setDayWindow(dateStr, {


### PR DESCRIPTION
## What

The Day window popover (Starts/Ends, used by the Summary Strip) can now be dismissed with `Escape`.

## Why

It previously only closed by clicking the backdrop or pressing "Clear for day" — no keyboard exit. Other popovers in the app (`InboxFilterPopover`, `DeadlinePickerPopover`, `ClockTimePicker`) already close on Escape, so this brings it in line.

## How

A `keydown` listener in `DayWindowMenu` calls `onClose()` on Escape. The effect deliberately unsubscribes while the clock picker is open (`pickerField` is set), so Escape there dismisses the picker and leaves the menu up — the user lands back where they were instead of losing the whole popover in one keypress.

The fix is in the shared `DayWindowMenu`, so both callers get it: `SummaryStrip` (timeline, opens upward) and `TitlebarSummaryStrip` (macOS title bar, portaled to body).

## Testing

- `npm run lint` — clean
- `npm test` — 1255 tests across 82 files passing

No component test added: the project has no jsdom/testing-library setup (tests cover pure utils and hooks only).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NriiJeAxCZyNSUUzUNehvx)_