### PR TITLE
Hide today's summary strip while the macOS title bar carries the pills

### DIFF
--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -13,6 +13,7 @@ import { WEEK_GUTTER_W } from './WeekView.jsx';
 import { isNativeAndroid, nativeUpdateEvent } from '../native.js';
 import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask } from '../utils/textFormatting.jsx';
 import { dateToString, extractWikilinks, formatDeadlineDate, formatShortDate } from '../utils/taskUtils.js';
+import { findRunningTask } from '../utils/runningTask.js';
 import { HABIT_COLORS, HABIT_ICONS } from '../constants/habits.js';
 import { MiniHabitRing } from './HabitRing.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
@@ -73,7 +74,7 @@ const CalendarHeader = () => {
     getTasksForDate, getDeadlineTasksForDate,
     getTaskCalendarStyle,
     setTaskRef,
-    formatTime, timeToMinutes, minutesToTime,
+    formatTime, minutesToTime,
     setEditingRecurrenceTaskId,
     updateDragAutoScroll,
     updateTaskNotes, addSubtask, toggleSubtask, deleteSubtask, updateSubtaskTitle,
@@ -377,14 +378,7 @@ const CalendarHeader = () => {
 {/* Now bar - current running task (suppressed on Electron Mac where it shows in the title bar) */}
 {(() => {
   if (window.electronAPI?.isElectron && window.electronAPI?.platform === 'darwin') return null;
-  const todayStr = dateToString(new Date());
-  const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
-  const runningTask = [...tasks, ...expandedRecurringTasks].find(t =>
-    t.date === todayStr && !t.isAllDay && !t.completed &&
-    !(t.imported && !t.isTaskCalendar) &&
-    nowMin >= timeToMinutes(t.startTime || '0:00') &&
-    nowMin < timeToMinutes(t.startTime || '0:00') + (t.duration || 0)
-  );
+  const runningTask = findRunningTask([...tasks, ...expandedRecurringTasks]);
   if (!runningTask) return null;
   return (
     <div className={`flex items-center gap-2 px-4 py-1.5 text-xs font-semibold ${darkMode ? 'bg-amber-900/40 text-amber-300 border-b border-amber-700/40' : 'bg-amber-50 text-amber-800 border-b border-amber-200'}`}>

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -5,6 +5,7 @@ import {
   RefreshCw, Save, Settings, Sun, Trash2, X,
 } from 'lucide-react';
 import { dateToString, extractWikilinks, formatDateRange } from '../utils/taskUtils.js';
+import { findRunningTask } from '../utils/runningTask.js';
 import { renderTitle } from '../utils/textFormatting.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
 import { hasNativeCalendar } from '../utils/nativeCalendar.js';
@@ -211,7 +212,7 @@ const DesktopLayout = () => {
     weekStartDay,
     getTodayStr, getOverdueTasks,
     getTaskCalendarStyle,
-    timeToMinutes, minutesToTime,
+    minutesToTime,
     selectAllTags, clearTagFilter, toggleTag,
     handleSpotlightSelect,
     updateDailyNote,
@@ -449,40 +450,38 @@ const DesktopLayout = () => {
   const isElectronMac = window.electronAPI?.isElectron && window.electronAPI?.platform === 'darwin';
   const titlebarH = isElectronMac ? 28 : 0;
 
+  // The title bar shows the NOW bar while a task is running and today's pills
+  // otherwise, so this one lookup decides both what the bar renders and whether
+  // the in-timeline strip is redundant. Skipped off macOS, where there is no bar.
+  const titlebarRunningTask = isElectronMac
+    ? findRunningTask([...tasks, ...expandedRecurringTasks])
+    : undefined;
+  const titlebarPills = isElectronMac && !titlebarRunningTask;
+
   return (
       <>
       {/* macOS traffic-light drag region — the NOW bar when a task is running,
           today's summary-strip pills otherwise (TitlebarSummaryStrip). Both are
           display-only, so the whole bar stays a drag area. */}
-      {isElectronMac && (() => {
-        const todayStr = dateToString(new Date());
-        const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
-        const runningTask = [...tasks, ...expandedRecurringTasks].find(t =>
-          t.date === todayStr && !t.isAllDay && !t.completed &&
-          !(t.imported && !t.isTaskCalendar) &&
-          nowMin >= timeToMinutes(t.startTime || '0:00') &&
-          nowMin < timeToMinutes(t.startTime || '0:00') + (t.duration || 0)
-        );
-        return (
-          <div
-            style={{ height: titlebarH, WebkitAppRegion: 'drag', flexShrink: 0, paddingLeft: '85px', paddingRight: '85px' }}
-            className={`flex items-center justify-center gap-2 text-xs font-semibold overflow-hidden ${
-              runningTask
-                ? (darkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-50 text-amber-800')
-                : ''
-            }`}
-          >
-            {runningTask ? (
-              <>
-                <span className="w-2 h-2 rounded-full bg-amber-400 animate-pulse flex-shrink-0" />
-                <span className="truncate">{t('common.now')}: {runningTask.title}</span>
-              </>
-            ) : (
-              <TitlebarSummaryStrip />
-            )}
-          </div>
-        );
-      })()}
+      {isElectronMac && (
+        <div
+          style={{ height: titlebarH, WebkitAppRegion: 'drag', flexShrink: 0, paddingLeft: '85px', paddingRight: '85px' }}
+          className={`flex items-center justify-center gap-2 text-xs font-semibold overflow-hidden ${
+            titlebarRunningTask
+              ? (darkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-50 text-amber-800')
+              : ''
+          }`}
+        >
+          {titlebarRunningTask ? (
+            <>
+              <span className="w-2 h-2 rounded-full bg-amber-400 animate-pulse flex-shrink-0" />
+              <span className="truncate">{t('common.now')}: {titlebarRunningTask.title}</span>
+            </>
+          ) : (
+            <TitlebarSummaryStrip />
+          )}
+        </div>
+      )}
       {/* Desktop & Tablet Layout */}
       {!isTablet && <DesktopHeader />}
 
@@ -844,8 +843,10 @@ const DesktopLayout = () => {
                     {effectiveViewMode === 'sched' && <SchedDashboard />}
                     {/* Summary strip — sticky over the timeline's own scroll
                         container so it stays visible without reserving layout
-                        height. Timeline views only; sched is a dashboard. */}
-                    {effectiveViewMode !== 'sched' && <SummaryStrip />}
+                        height. Timeline views only; sched is a dashboard.
+                        titlebarPills lets it stand down for today while the
+                        macOS title bar carries the same numbers. */}
+                    {effectiveViewMode !== 'sched' && <SummaryStrip titlebarPills={titlebarPills} />}
                   </>
               }
             </div>

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -13,6 +13,7 @@ import {
 import { isNativeAndroid, isNativeApp, nativeUpdateEvent } from '../native.js';
 import { renderTitle, getLinkUrl, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, isObsidianNoteOnlyTask, renderFormattedText } from '../utils/textFormatting.jsx';
 import { dateToString, extractTags, extractWikilinks, formatDate, formatDateRange, formatDeadlineDate, formatShortDate } from '../utils/taskUtils.js';
+import { findRunningTask } from '../utils/runningTask.js';
 import { HABIT_COLORS, HABIT_ICONS } from '../constants/habits.js';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
@@ -713,14 +714,7 @@ const MobileLayout = () => {
                   <div ref={mobileDateHeaderRef} className={`sticky top-0 z-40 ${cardBg}`}>
                   {/* Current task banner */}
                   {(() => {
-                    const todayStr = dateToString(new Date());
-                    const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
-                    const runningTask = [...tasks, ...expandedRecurringTasks].find(t =>
-                      t.date === todayStr && !t.isAllDay && !t.completed &&
-                      !(t.imported && !t.isTaskCalendar) &&
-                      nowMin >= timeToMinutes(t.startTime || '0:00') &&
-                      nowMin < timeToMinutes(t.startTime || '0:00') + (t.duration || 0)
-                    );
+                    const runningTask = findRunningTask([...tasks, ...expandedRecurringTasks]);
                     if (!runningTask) return null;
                     return (
                       <div className={`flex items-center gap-2 px-3 py-1.5 text-xs font-semibold ${darkMode ? 'bg-amber-900/40 text-amber-300 border-b border-amber-700/40' : 'bg-amber-50 text-amber-800 border-b border-amber-200'}`}>

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -57,10 +57,16 @@ export const summaryPillClass = (darkMode) =>
  *              where a sticky overlay reads as an extension of the list's
  *              spine. Static places the strip after the day's content as its
  *              own element.
+ * @param titlebarPills The macOS title bar is currently carrying today's pills
+ *              (DesktopLayout, Electron on darwin, no task running). The bar is
+ *              pinned to TODAY, so when today is also the viewed day the two
+ *              readouts say the same thing — the strip then hides its pills and
+ *              leaves the numbers to the bar. Any other day still needs the
+ *              strip, since the bar cannot describe it.
  */
-export default function SummaryStrip({ phone = false, staticPlacement = false }) {
+export default function SummaryStrip({ phone = false, staticPlacement = false, titlebarPills = false }) {
   const {
-    selectedDate, getTasksForDate, listEndOfDayTime,
+    selectedDate, getTasksForDate, listEndOfDayTime, isToday,
     darkMode, textPrimary, textSecondary,
   } = useDayPlannerCtx();
   const {
@@ -117,6 +123,12 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
   // cover every future day and this state never recurs.
   const isEmptyHint = summary.unblockedMinutes === null;
 
+  // Redundant with the macOS title bar: same day, same numbers, and the bar is
+  // actually rendering them. The empty-day hint is deliberately excluded — the
+  // title bar omits it (setup lives in the timeline), so hiding here would leave
+  // a fresh day with no way to set the window at all.
+  const pillsHidden = titlebarPills && isToday && !isEmptyHint;
+
   // Static (LIST) gets real top padding: it sits right under the day's
   // closing "Good work" line and needs visible separation from it.
   const container = staticPlacement
@@ -132,7 +144,10 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
           anchorClass="absolute bottom-full mb-1 left-2"
         />
       )}
-      {isEmptyHint ? (
+      {/* Pills hidden, popover still mounted: the grid's START/END marker chips
+          open it through the shared featuresCtx flag and this is its only host
+          on the timeline, so unmounting the whole strip would leave them dead. */}
+      {pillsHidden ? null : isEmptyHint ? (
         <button
           onClick={() => setMenuOpen(true)}
           className={`${pill} pointer-events-auto text-xs ${textSecondary} hover:opacity-80`}

--- a/src/utils/runningTask.js
+++ b/src/utils/runningTask.js
@@ -1,0 +1,40 @@
+import { dateToString } from './taskUtils.js';
+
+// Which timed task, if any, is running right now — the source of truth behind
+// the "NOW: <task>" banner. Three surfaces render that banner (DesktopLayout's
+// macOS title bar, CalendarHeader everywhere else on desktop, MobileLayout) and
+// each carried its own copy of the predicate.
+//
+// One definition matters now that DesktopLayout also hides today's summary strip
+// while the title bar carries the pills: that decision and the title bar's own
+// NOW-bar-or-pills choice must read the same answer. If they ever drifted, the
+// strip would hide on a day the NOW bar had taken the bar over, and today's
+// numbers would disappear from the window entirely.
+//
+// Not running: all-day tasks (no start/duration to sit inside of), completed
+// tasks, and read-only imported calendar events — those are fixtures rather than
+// work in progress, with isTaskCalendar marking the writable ones back in.
+
+const timeToMinutes = (time) => {
+  const [hours, minutes] = (time || '0:00').split(':').map(Number);
+  return hours * 60 + minutes;
+};
+
+/**
+ * @param tasks Every task to consider, already flattened — scheduled tasks plus
+ *              expanded recurring instances.
+ * @param now   Moment to test against; defaults to this instant. Callers render
+ *              on a one-minute tick, so passing nothing re-reads the clock each
+ *              render rather than pinning it.
+ * @returns The first task covering `now`, or undefined when nothing is running.
+ */
+export const findRunningTask = (tasks, now = new Date()) => {
+  const todayStr = dateToString(now);
+  const nowMin = now.getHours() * 60 + now.getMinutes();
+  return tasks.find((task) => {
+    if (task.date !== todayStr || task.isAllDay || task.completed) return false;
+    if (task.imported && !task.isTaskCalendar) return false;
+    const start = timeToMinutes(task.startTime);
+    return nowMin >= start && nowMin < start + (task.duration || 0);
+  });
+};

--- a/src/utils/runningTask.test.js
+++ b/src/utils/runningTask.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { findRunningTask } from './runningTask.js';
+
+// 2026-03-10, 10:30 local — the moment every case below is tested against.
+const NOW = new Date(2026, 2, 10, 10, 30);
+const TODAY = '2026-03-10';
+
+const task = (extra = {}) => ({
+  id: 't1', date: TODAY, startTime: '10:00', duration: 60, title: 'Deep work', ...extra,
+});
+
+describe('findRunningTask', () => {
+  it('finds the task whose span covers now', () => {
+    expect(findRunningTask([task()], NOW)?.id).toBe('t1');
+  });
+
+  it('treats the span as start-inclusive and end-exclusive', () => {
+    // Starting exactly now counts; ending exactly now does not, so back-to-back
+    // tasks never both report as running.
+    expect(findRunningTask([task({ startTime: '10:30' })], NOW)?.id).toBe('t1');
+    expect(findRunningTask([task({ startTime: '09:30' })], NOW)).toBeUndefined();
+  });
+
+  it('ignores tasks outside the current span', () => {
+    expect(findRunningTask([task({ startTime: '11:00' })], NOW)).toBeUndefined();
+    expect(findRunningTask([task({ startTime: '08:00', duration: 30 })], NOW)).toBeUndefined();
+  });
+
+  it('ignores a zero-duration task', () => {
+    expect(findRunningTask([task({ startTime: '10:30', duration: 0 })], NOW)).toBeUndefined();
+  });
+
+  it('ignores tasks on another day at the same clock time', () => {
+    expect(findRunningTask([task({ date: '2026-03-09' })], NOW)).toBeUndefined();
+    expect(findRunningTask([task({ date: '2026-03-11' })], NOW)).toBeUndefined();
+  });
+
+  it('ignores all-day and completed tasks', () => {
+    expect(findRunningTask([task({ isAllDay: true })], NOW)).toBeUndefined();
+    expect(findRunningTask([task({ completed: true })], NOW)).toBeUndefined();
+  });
+
+  it('ignores read-only imported events but keeps writable task-calendar ones', () => {
+    expect(findRunningTask([task({ imported: true })], NOW)).toBeUndefined();
+    expect(findRunningTask([task({ imported: true, isTaskCalendar: true })], NOW)?.id).toBe('t1');
+  });
+
+  it('defaults a missing start time to midnight rather than throwing', () => {
+    expect(findRunningTask([task({ startTime: undefined })], NOW)).toBeUndefined();
+    expect(findRunningTask([task({ startTime: undefined, duration: 1440 })], NOW)?.id).toBe('t1');
+  });
+
+  it('returns the first match when spans overlap', () => {
+    const overlapping = [task({ id: 'a' }), task({ id: 'b', startTime: '10:15' })];
+    expect(findRunningTask(overlapping, NOW)?.id).toBe('a');
+  });
+
+  it('returns undefined for an empty list', () => {
+    expect(findRunningTask([], NOW)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

On macOS the title bar renders **today's** summary pills. When the timeline is also showing today, the same numbers appeared twice. This hides the in-timeline `SummaryStrip` in exactly that case.

Viewing any other day still shows the strip — the title bar is pinned to today and can't describe them.

## Two states that deliberately keep the strip

Being "on macOS viewing today" isn't sufficient — the title bar doesn't always have the pills up:

1. **A task is running.** The NOW bar takes the title bar over, so the pills aren't on screen and the strip is the only readout left.
2. **Empty day, no declared window.** `TitlebarSummaryStrip` returns `null` in that state and omits the "Set day window" hint by design (setup lives in the timeline). Hiding the strip too would leave a fresh day with no way to set a window at all — the onboarding path.

So the predicate is `isElectronMac && !runningTask && isToday && !isEmptyHint`. DesktopLayout owns the first two (it decides NOW-bar-vs-pills); SummaryStrip owns the last two, since it already computes the summary.

## The popover still needs a host

When the pills are hidden, the strip still mounts `DayWindowMenu`. The grid's START/END marker chips (`DayWindowMarkers`) open it through the shared `featuresCtx` `dayWindowMenuOpen` flag, and the strip is its only host on the timeline — unmounting the whole component would leave those chips dead.

## Refactor: `utils/runningTask.js`

The running-task predicate was copied verbatim in three places (`DesktopLayout`, `CalendarHeader`, `MobileLayout`). I needed it lifted out of DesktopLayout's IIFE anyway so the strip and the title bar could share one answer, so it's now a tested pure util used by all three.

This is more than tidiness here: if the strip's idea of "running" ever drifted from the title bar's, the strip would hide on a day the NOW bar had taken over and today's numbers would vanish from the window entirely.

Also dropped `timeToMinutes` from two context destructures where it became unused, and flattened DesktopLayout's title-bar IIFE now that it computes nothing.

## Testing

- `npm run lint` — clean
- `npm test` — 1265 tests across 83 files passing (10 new, covering the span boundaries, day matching, all-day/completed/imported exclusions, and the missing-start-time default)
- `npm run build` — succeeds

Not verified in a running Electron window — the macOS title bar path can't be exercised here. The behavior change is gated behind `window.electronAPI.platform === 'darwin'`, so web, Windows, Linux, tablet, and phone render exactly as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NriiJeAxCZyNSUUzUNehvx)_