### PR TITLE
Live Activity: energy glyph inside the island ring, and tint it

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
@@ -63,6 +63,7 @@ final class LiveActivityBridge {
         var title: String?
         var timeLabel: String?
         var inProgress: Bool?
+        var energy: String?
         var countdownStartMs: Double?
         var countdownEndMs: Double?
     }
@@ -100,6 +101,7 @@ final class LiveActivityBridge {
             countdownStart: msToDate(up?.countdownStartMs),
             countdownEnd: msToDate(up?.countdownEndMs),
             inProgress: up?.inProgress ?? false,
+            blockEnergy: up?.energy,
             done: done, effort: effort, restore: restore,
             doneLabel: labels?.done ?? "done",
             remainingLabel: labels?.remaining ?? "remaining",

--- a/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
+++ b/dayglance-ios/DayGlanceWidget/DaySummaryLiveActivity.swift
@@ -24,6 +24,26 @@ private let effortColor = Color.indigo
 private let restoreColor = Color.green
 private let unblockedColor = Color.teal
 
+// Energy of the current-or-next block, as resolved by JS (deriveBlockEnergy).
+// Anything else — an old snapshot without the field, or a value a future build
+// adds — falls through to the neutral ring and no glyph, so this extension never
+// asserts an energy the app did not send.
+private func energyColor(_ energy: String?) -> Color {
+    switch energy {
+    case "effort": return effortColor
+    case "restore": return restoreColor
+    default: return unblockedColor
+    }
+}
+
+private func energySymbol(_ energy: String?) -> String? {
+    switch energy {
+    case "effort": return "bolt.fill"
+    case "restore": return "leaf.fill"
+    default: return nil
+    }
+}
+
 // The live countdown: the OS renders the remaining time in the interval,
 // showing 0:00 once it has passed (next to a label that is still factual).
 // Falls back to the given string when there is no interval to count.
@@ -40,11 +60,14 @@ private func countdownText(_ state: DaySummaryAttributes.ContentState, fallback:
 // text (ProgressView over the interval ticks with zero updates and zero
 // pushes), so the compact leading slot shows shape while the trailing shows
 // number. In progress it drains as the block runs down; upcoming it drains
-// toward the start. Labels are empty on purpose — the numeric countdown
-// already lives on the trailing side, and the empty currentValueLabel is the
-// slot where a per-block energy glyph could later sit inside the ring.
-// Falls back to the hourglass when there is nothing to animate (no more
-// blocks today).
+// toward the start.
+//
+// The ring carries the block's ENERGY two ways — its tint, and the bolt/leaf
+// glyph in currentValueLabel (the ring's center) — so the smallest island state
+// says what KIND of block is running, not just how much of it is left. The
+// `label` slot stays empty: the numeric countdown already lives on the trailing
+// side. Falls back to the hourglass when there is nothing to animate (no more
+// blocks today), untinted — no block means no energy to report.
 @ViewBuilder
 private func countdownRing(_ state: DaySummaryAttributes.ContentState) -> some View {
     if let start = state.countdownStart, let end = state.countdownEnd, start < end {
@@ -57,9 +80,22 @@ private func countdownRing(_ state: DaySummaryAttributes.ContentState) -> some V
         // Apple's first-party surfaces (Timer) sit tighter only because they
         // are system-rendered, not ActivityKit extensions.
         ProgressView(timerInterval: start...end, countsDown: true,
-                     label: { EmptyView() }, currentValueLabel: { EmptyView() })
+                     label: { EmptyView() },
+                     currentValueLabel: {
+                         // 8pt inside an 18pt ring: the glyph has to clear the
+                         // stroke on both sides, so it reads as a mark rather
+                         // than a legible icon — which is the intent. Bolt and
+                         // leaf are distinguishable at this size by silhouette.
+                         if let symbol = energySymbol(state.blockEnergy) {
+                             Image(systemName: symbol)
+                                 .font(.system(size: 8, weight: .bold))
+                                 .foregroundStyle(energyColor(state.blockEnergy))
+                         } else {
+                             EmptyView()
+                         }
+                     })
             .progressViewStyle(.circular)
-            .tint(unblockedColor)
+            .tint(energyColor(state.blockEnergy))
             .frame(width: 18, height: 18)
     } else {
         Image(systemName: "hourglass")

--- a/dayglance-ios/Shared/DaySummaryAttributes.swift
+++ b/dayglance-ios/Shared/DaySummaryAttributes.swift
@@ -39,6 +39,13 @@ struct DaySummaryAttributes: ActivityAttributes {
         /// Whether the block had started when this state was pushed — picks
         /// the caption ("remaining" vs "starts in"), nothing else.
         var inProgress: Bool
+        /// "effort" | "restore" for the current-or-next block, resolved by JS
+        /// (deriveBlockEnergy — per-block override, then #tag/title keywords).
+        /// Tints the countdown ring and picks the glyph inside it. Optional and
+        /// unvalidated on purpose: an old snapshot, or any value this build does
+        /// not know, falls back to the neutral ring rather than asserting an
+        /// energy the app never sent.
+        var blockEnergy: String?
         /// "1h 30m/7h" — done/planned.
         var done: String
         /// "5h 30m" effort / "2h 30m" restore — the energy split. Unblocked

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7246,16 +7246,21 @@ const DayPlanner = () => {
       .map(s => { const [h, m] = s.startTime.split(':').map(Number); return { ...s, startMin: h * 60 + m }; })
       .filter(s => nowMinW < s.startMin + s.duration)
       .sort((a, b) => a.startMin - b.startMin)[0] || null;
+    // energy is resolved from the SOURCE block, never from the projected title:
+    // nextTaskItem.title has already had its #tags and [[wikilinks]] stripped
+    // for display, and the per-block `energy` override is not projected at all,
+    // so deriving from it would silently drop both of deriveBlockEnergy's
+    // stronger signals. nextTaskCandidate / nextHGForUpNext still carry them.
     const nextUpNext = (() => {
       const taskMin = nextTaskItem ? timeToMinutes(nextTaskItem.startTime) : Infinity;
       const hgMin = nextHGForUpNext ? nextHGForUpNext.startMin : Infinity;
       if (nextHGForUpNext && hgMin <= taskMin) {
         const tc = nextHGForUpNext.taskCount;
         const tcLabel = tc > 0 ? ` · ${tc} task${tc !== 1 ? 's' : ''}` : '';
-        return { title: 'hyperGLANCE', startTime: nextHGForUpNext.startTime, duration: nextHGForUpNext.duration, bodyPrefix: `${nextHGForUpNext.title}${tcLabel} · ` };
+        return { title: 'hyperGLANCE', startTime: nextHGForUpNext.startTime, duration: nextHGForUpNext.duration, energy: deriveBlockEnergy(nextHGForUpNext), bodyPrefix: `${nextHGForUpNext.title}${tcLabel} · ` };
       }
       if (nextTaskItem)
-        return { title: nextTaskItem.title, startTime: nextTaskItem.startTime, duration: nextTaskItem.duration, bodyPrefix: '' };
+        return { title: nextTaskItem.title, startTime: nextTaskItem.startTime, duration: nextTaskItem.duration, energy: deriveBlockEnergy(nextTaskCandidate), bodyPrefix: '' };
       return null;
     })();
 

--- a/src/utils/liveActivity.js
+++ b/src/utils/liveActivity.js
@@ -14,6 +14,15 @@
 // down time remaining); upcoming → now..start (counts down to the start).
 // After the interval passes without an update it reads 0:00 next to a label
 // that is still factual, and the activity's staleDate dims it.
+//
+// The fact also carries the block's ENERGY ('effort' | 'restore'), which tints
+// the island's countdown ring and picks the bolt/leaf glyph inside it — the
+// same pairing the in-app strip uses. Callers that already resolved it (the
+// snapshot builder does, from the unstripped source block) pass it on the entry
+// and deriveBlockEnergy returns it untouched; anything else falls back to
+// deriving from the title, so the field is never absent.
+
+import { deriveBlockEnergy } from './energyAxis.js';
 
 const toHHMM = (ms) => {
   const t = new Date(ms);
@@ -21,13 +30,14 @@ const toHHMM = (ms) => {
 };
 
 /**
- * @param {{title?: string, startTime?: string, duration?: number}|null} entry
- *   today's current-or-next block ('HH:MM' start, minutes duration)
+ * @param {{title?: string, startTime?: string, duration?: number, energy?: string}|null} entry
+ *   today's current-or-next block ('HH:MM' start, minutes duration, optional
+ *   resolved 'effort'|'restore')
  * @param {number} nowMs epoch ms "now" (startTime is resolved against its day)
  * @param {(hhmm: string) => string} formatTime display formatter (12h/24h)
  * @param {{until?: string, at?: string}} [words] localized label words
  *   (defaults are English so tests and non-localized callers stay stable)
- * @returns {{title, inProgress, timeLabel, countdownStartMs, countdownEndMs}|null}
+ * @returns {{title, inProgress, timeLabel, energy, countdownStartMs, countdownEndMs}|null}
  */
 export function buildUpNextFact(entry, nowMs, formatTime, words) {
   if (!entry || !entry.startTime) return null;
@@ -43,6 +53,7 @@ export function buildUpNextFact(entry, nowMs, formatTime, words) {
     title: entry.title || '',
     inProgress,
     timeLabel: inProgress ? `${w.until} ${formatTime(toHHMM(endMs))}` : `${w.at} ${formatTime(toHHMM(startMs))}`,
+    energy: deriveBlockEnergy(entry),
     countdownStartMs: inProgress ? startMs : nowMs,
     countdownEndMs: inProgress ? endMs : startMs,
   };

--- a/src/utils/liveActivity.test.js
+++ b/src/utils/liveActivity.test.js
@@ -55,6 +55,24 @@ describe('buildUpNextFact', () => {
     expect(running.timeLabel).toBe('bis 15:00');
   });
 
+  it('passes a resolved energy through untouched', () => {
+    // The snapshot builder resolves energy from the unstripped source block, so
+    // a title that would derive the other way must not override it.
+    const f = buildUpNextFact({ title: 'Lunch with investors', startTime: '12:00', duration: 60, energy: 'effort' }, at(11, 0), fmt);
+    expect(f.energy).toBe('effort');
+  });
+
+  it('falls back to deriving energy from the title', () => {
+    expect(buildUpNextFact({ title: 'Deep work', startTime: '13:00', duration: 60 }, at(12, 0), fmt).energy).toBe('effort');
+    expect(buildUpNextFact({ title: 'Morning walk', startTime: '13:00', duration: 60 }, at(12, 0), fmt).energy).toBe('restore');
+  });
+
+  it('always names an energy, even with nothing to go on', () => {
+    // The island tints its ring from this field; an absent value would leave the
+    // ring's color undefined rather than neutral.
+    expect(buildUpNextFact({ startTime: '13:00', duration: 60 }, at(12, 0), fmt).energy).toBe('effort');
+  });
+
   it('label wording goes through the caller-provided formatter', () => {
     const twelveHour = (t) => {
       const [h, m] = t.split(':').map(Number);


### PR DESCRIPTION
## What

The Dynamic Island's countdown ring showed how much of the current block was left, but nothing about what kind of block it was. Now it carries the block's energy two ways:

- **Tint** — indigo for Effort, green for Restore (the strip's palette), replacing the flat teal.
- **Glyph** — `bolt.fill` / `leaf.fill` in `currentValueLabel`, the ring's center. That slot was already sitting empty with a comment marking it for exactly this.

Both the `compactLeading` and `minimal` island states use `countdownRing`, so the smallest state now says what kind of block is running, not just how much is left.

## The `energy` field

Resolved from the **source** block, not the projected one. `nextTaskItem.title` has already had its `#tags` and `[[wikilinks]]` stripped for display, and the projection doesn't carry the per-block `energy` override at all — so deriving from it would drop both of `deriveBlockEnergy`'s stronger signals and quietly fall back to keyword-matching a stripped title. `nextTaskCandidate` / `nextHGForUpNext` still have both, so the derivation happens there.

`buildUpNextFact` then runs the value through `deriveBlockEnergy`, which returns an already-resolved energy untouched and otherwise derives from the title. The field is therefore never absent, so the ring always has a color to use.

The field rides along in `snapshotFingerprint` automatically (it's a rest-spread exclusion list, not a whitelist), so a block whose energy differs from the last push still triggers one.

## Swift

`ContentState.blockEnergy` is an optional, unvalidated `String?`. An old snapshot — or any value a future build adds — falls through to the neutral teal ring and no glyph rather than asserting an energy the app never sent. The hourglass fallback (no more blocks today) stays untinted for the same reason: no block means no energy to report.

Android is unaffected — `UpNextNotificationUpdater` reads the same object with `optString`/`optInt`, so the added key is ignored.

## Testing

- `npm run lint` — clean
- `npm test` — 1258 tests across 82 files passing (4 new on `buildUpNextFact`: pass-through of a resolved energy, title-derived fallback both ways, and the never-absent guarantee)
- `npm run build` — succeeds

**The Swift is unverified.** There's no Swift toolchain in this environment, so the four iOS files are not compile-checked and the ring has not been seen rendering. Two things specifically want a device or simulator look:

1. Whether `currentValueLabel` renders at all inside a `.circular` `ProgressView` in an ActivityKit extension — the existing comment asserts the slot is usable, but that was written as a plan, not a result.
2. Whether an 8pt glyph inside the 18pt ring reads as bolt-vs-leaf or just as a smudge. The frame is fixed at 18pt by the sensor-housing constraint documented in that function, so the glyph size is the only free variable if it's too tight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NriiJeAxCZyNSUUzUNehvx)_