### PR TITLE
iPad: compact summary strip in GRID, and show it at all in LIST

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -836,7 +836,16 @@ const DesktopLayout = () => {
                   two-column timeline). tabletListView covers both LIST and
                   SCHED; the toggle's mode picks which one renders. */}
               {tabletListView
-                ? (mobileViewMode === 'sched' ? <SchedView /> : <MobileListView hideInboxHandle />)
+                ? (mobileViewMode === 'sched' ? <SchedView /> : (
+                    <>
+                      <MobileListView hideInboxHandle />
+                      {/* The tablet's LIST strip, placed exactly as MobileLayout
+                          places the phone's: statically after the day's content,
+                          in the same scroll flow. SCHED gets none — it is a
+                          dashboard, not a timeline, on every device. */}
+                      <SummaryStrip compact staticPlacement />
+                    </>
+                  ))
                 : <>
                     {effectiveViewMode === 'multi' && <TimeGrid />}
                     {effectiveViewMode === 'day' && <DayView />}
@@ -844,8 +853,16 @@ const DesktopLayout = () => {
                     {effectiveViewMode === 'sched' && <SchedDashboard />}
                     {/* Summary strip — sticky over the timeline's own scroll
                         container so it stays visible without reserving layout
-                        height. Timeline views only; sched is a dashboard. */}
-                    {effectiveViewMode !== 'sched' && <SummaryStrip />}
+                        height. Timeline views only; sched is a dashboard.
+                        PORTRAIT tablet takes the compact (touch) variant: this
+                        file is shared with desktop, but a tablet in portrait is
+                        a one-column touch timeline and wants the phone's
+                        collapsible, stacked strip — minus the FAB clearance,
+                        since nothing floats over the tablet timeline. Landscape
+                        is excluded on the same grounds LIST view is (see
+                        tabletListView): the two-column landscape timeline IS
+                        the desktop layout, and takes the desktop strip. */}
+                    {effectiveViewMode !== 'sched' && <SummaryStrip compact={isTablet && !isLandscape} />}
                   </>
               }
             </div>

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -790,13 +790,14 @@ const MobileLayout = () => {
                   {mobileViewMode === 'grid' && <MobileTimeGrid />}
                   {mobileViewMode === 'list' && <MobileListView />}
                   {mobileViewMode === 'sched' && <SchedView />}
-                  {/* Summary strip. Phone variant: collapsible, no date pill,
+                  {/* Summary strip. Compact (touch) variant plus the phone-only
                       FAB clearance. GRID floats it sticky over the timeline;
                       LIST places it statically after the day's content — a
                       sticky overlay there reads as an extension of the list's
-                      spine, so it sits below the day as its own element. */}
-                  {mobileViewMode === 'grid' && <SummaryStrip phone />}
-                  {mobileViewMode === 'list' && <SummaryStrip phone staticPlacement />}
+                      spine, so it sits below the day as its own element.
+                      DesktopLayout renders the tablet's pair the same way. */}
+                  {mobileViewMode === 'grid' && <SummaryStrip compact fabClearance />}
+                  {mobileViewMode === 'list' && <SummaryStrip compact fabClearance staticPlacement />}
                 </div>
 
                 {/* Mobile notes panel overlay for timeline tasks (including deadline tasks) */}

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -8,9 +8,9 @@ import { dateToString, formatShortDate } from '../utils/taskUtils.js';
 import { computeDaySummary, formatMinutes } from '../utils/daySummary.js';
 
 // Collapse choice is a per-window view preference, same class as
-// minimizedSections. Default collapsed: the strip only collapses on phone,
-// where timeline vertical space is tightest, and the collapsed pill still
-// carries the headline numbers.
+// minimizedSections. Default collapsed: the strip only collapses on touch
+// devices, where timeline vertical space is the scarce resource, and the
+// collapsed pill still carries the headline numbers.
 const COLLAPSE_KEY = 'day-planner-summary-strip-collapsed';
 
 // Exported (with summaryPillClass) so TitlebarSummaryStrip renders the exact
@@ -47,20 +47,24 @@ export const summaryPillClass = (darkMode) =>
  *
  * All data comes from context; the math lives in utils/daySummary.js.
  *
- * @param phone Phone timeline variant: collapsible to a single pill, no date
- *              pill (the phone timeline shows exactly one day, so the heading
- *              would restate the header), right clearance for the new-task FAB
- *              (fixed right-4 w-14, z-40 — above this row's z-30), and the
- *              expanded row WRAPS to more lines instead of scrolling
- *              horizontally. Desktop/tablet pass nothing.
- * @param staticPlacement In-flow instead of sticky — used by mobile LIST view,
- *              where a sticky overlay reads as an extension of the list's
- *              spine. Static places the strip after the day's content as its
- *              own element.
+ * @param compact Touch timeline variant — phone AND tablet, which share this
+ *              component with desktop but not its input model: collapsible to a
+ *              single pill (a tap target, and timeline vertical space is the
+ *              scarce resource on a touch device), and the expanded row STACKS
+ *              instead of scrolling horizontally, because a horizontally
+ *              scrollable row inside a vertically scrolling timeline is a
+ *              gesture conflict. Desktop passes nothing.
+ * @param fabClearance Right padding for the phone's new-task FAB (fixed
+ *              right-4 w-14, z-40 — above this row's z-30). Phone only: tablet
+ *              and desktop have no floating button over the timeline, and the
+ *              gap would just be dead space.
+ * @param staticPlacement In-flow instead of sticky — used by LIST view, where a
+ *              sticky overlay reads as an extension of the list's spine. Static
+ *              places the strip after the day's content as its own element.
  */
-export default function SummaryStrip({ phone = false, staticPlacement = false }) {
+export default function SummaryStrip({ compact = false, fabClearance = false, staticPlacement = false }) {
   const {
-    selectedDate, getTasksForDate, listEndOfDayTime,
+    selectedDate, getTasksForDate, listEndOfDayTime, visibleDays,
     darkMode, textPrimary, textSecondary,
   } = useDayPlannerCtx();
   const {
@@ -70,7 +74,7 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
   const { t } = useTranslation();
 
   const [collapsed, setCollapsed] = useState(
-    () => phone && localStorage.getItem(COLLAPSE_KEY) !== '0',
+    () => compact && localStorage.getItem(COLLAPSE_KEY) !== '0',
   );
   const toggle = () => {
     setCollapsed((c) => {
@@ -112,6 +116,16 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
     </span>
   );
 
+  // The date pill pins which day the numbers describe — only worth its place
+  // when the timeline shows more than one day. Every compact caller today is a
+  // single-day timeline (phone, and portrait tablet at visibleDays 1), where it
+  // would just restate the date already in the header; the visibleDays test is
+  // what keeps that true rather than assuming it, since the compact layouts
+  // have no room to spare and would otherwise carry a redundant row. Desktop
+  // keeps it unconditionally — a horizontal row has the width, and narrowing
+  // that is not this change's business.
+  const showDatePill = !compact || visibleDays > 1;
+
   // Empty day, no declared window: no numbers to show, so the strip becomes the
   // one-time setup hint. Once a window is set anywhere, sticky-forward defaults
   // cover every future day and this state never recurs.
@@ -120,8 +134,8 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
   // Static (LIST) gets real top padding: it sits right under the day's
   // closing "Good work" line and needs visible separation from it.
   const container = staticPlacement
-    ? `relative pt-4 pb-2 pl-2 pointer-events-none ${phone ? 'pr-20' : 'pr-2'}`
-    : `sticky bottom-0 z-30 pl-2 pb-2 pointer-events-none ${phone ? 'pr-20' : 'pr-2'}`;
+    ? `relative pt-4 pb-2 pl-2 pointer-events-none ${fabClearance ? 'pr-20' : 'pr-2'}`
+    : `sticky bottom-0 z-30 pl-2 pb-2 pointer-events-none ${fabClearance ? 'pr-20' : 'pr-2'}`;
 
   return (
     <div className={container}>
@@ -140,7 +154,7 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
           <MoreHorizontal size={13} className="flex-shrink-0" />
           {t('strip.setDayWindow')}
         </button>
-      ) : phone && collapsed ? (
+      ) : compact && collapsed ? (
         <button onClick={toggle} className={`${pill} pointer-events-auto max-w-full text-xs`}>
           <ChevronUp size={13} className={`flex-shrink-0 ${textSecondary}`} />
           {unblockedLabel}
@@ -148,16 +162,23 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
           {energyCompact}
         </button>
       ) : (() => {
-        // On phone, the whole unblocked pill toggles the collapse — symmetric
-        // with the collapsed pill, which expands from a tap anywhere on it.
-        // Only the three-dot menu opts out (stopPropagation). The caret stays
-        // as a visual indicator, not the sole target.
+        // On a touch device the whole unblocked pill toggles the collapse —
+        // symmetric with the collapsed pill, which expands from a tap anywhere
+        // on it. Only the three-dot menu opts out (stopPropagation). The caret
+        // stays as a visual indicator, not the sole target.
+        // Day/date heading — see showDatePill for when it earns its place.
+        const datePill = showDatePill && (
+          <span className={pill}>
+            <span className={`font-medium ${textPrimary}`}>{formatShortDate(selectedDate)}</span>
+          </span>
+        );
+
         const unblockedPill = (
           <span
-            className={`${pill} ${phone ? 'cursor-pointer' : ''}`}
-            onClick={phone ? toggle : undefined}
+            className={`${pill} ${compact ? 'cursor-pointer' : ''}`}
+            onClick={compact ? toggle : undefined}
           >
-            {phone && <ChevronDown size={13} className={`-ml-1 flex-shrink-0 ${textSecondary}`} />}
+            {compact && <ChevronDown size={13} className={`-ml-1 flex-shrink-0 ${textSecondary}`} />}
             {unblockedLabel}
             <button
               onClick={(e) => { e.stopPropagation(); setMenuOpen(!menuOpen); }}
@@ -218,7 +239,7 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
           </>
         );
 
-        // Floating phone strip: the unblocked pill is the ANCHOR — it keeps
+        // Floating touch strip: the unblocked pill is the ANCHOR — it keeps
         // the exact bottom-left position it has when collapsed, so the
         // collapse target never moves. Everything else fans out UPWARD in its
         // own row: energy directly above, tag chips above that. One pill per
@@ -227,7 +248,7 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
         // (anchor stability) and slid underneath it on narrow phones. The
         // in-flow LIST strip reads top-down instead, so there everything
         // stays one wrapping row growing downward.
-        if (phone && !staticPlacement) {
+        if (compact && !staticPlacement) {
           return (
             <div className="pointer-events-auto w-fit max-w-full flex flex-col items-start gap-1.5 text-xs">
               <div className="flex flex-wrap items-center gap-1.5">{tagChips}</div>
@@ -239,16 +260,9 @@ export default function SummaryStrip({ phone = false, staticPlacement = false })
 
         return (
           <div className={`pointer-events-auto w-fit max-w-full flex items-center gap-1.5 text-xs ${
-            phone ? 'flex-wrap' : `overflow-x-auto ${darkMode ? 'dark-scrollbar' : ''}`
+            compact ? 'flex-wrap' : `overflow-x-auto ${darkMode ? 'dark-scrollbar' : ''}`
           }`}>
-            {/* Day/date heading — pins which day the numbers describe, which
-                the multi-day desktop view otherwise leaves ambiguous. The
-                phone timeline shows exactly one day, so there it is dropped. */}
-            {!phone && (
-              <span className={pill}>
-                <span className={`font-medium ${textPrimary}`}>{formatShortDate(selectedDate)}</span>
-              </span>
-            )}
+            {datePill}
             {unblockedPill}
             {energyPill}
             {tagChips}


### PR DESCRIPTION
## What

Two iPad summary-strip problems, both falling out of the tablet sharing `DesktopLayout`:

**GRID** gave the tablet the desktop strip — a horizontal, non-collapsible row. A portrait tablet is a one-column touch timeline, so it wants what the phone has: collapsible to a single pill, and stacked rather than scrolling sideways inside a vertically scrolling timeline.

**LIST** rendered no strip at all. The `tabletListView` branch swaps in `MobileListView` but never picked up the strip `MobileLayout` renders beside it, so the day's numbers vanished when the toggle was flipped.

## `phone` → `compact`

The prop describes a touch *layout*, not a device, so it's renamed — and the two things inside it that really were phone-specific are pulled out rather than inherited by the tablet:

- **FAB clearance** (`pr-20`) is now its own `fabClearance` prop, passed by `MobileLayout` only. Nothing floats over the tablet timeline — DesktopLayout's FABs live inside the GLANCE panel — so on iPad that padding would be dead space.
- **The date pill** now keys on `visibleDays` instead of on the variant: `!compact || visibleDays > 1`. It exists to disambiguate a multi-day timeline. Phone and portrait tablet both show exactly one day, so it would only restate the header; desktop keeps it unconditionally. Keying it on the real condition rather than on `compact` is what stops the tablet from inheriting "no date pill" as an accident.

## Landscape is excluded

`compact={isTablet && !isLandscape}`, matching how LIST view already scopes itself (`tabletListView`) and the note at `App.jsx:352` that landscape tablet "drops out of tablet mode entirely". The two-column landscape timeline *is* the desktop layout, and takes the desktop strip.

This also keeps the compact layouts single-day, which matters: the stacked fan-out and the collapsed pill have no date pill, and adding one to either would have meant either moving the collapse anchor or widening the collapsed pill.

## Behavior summary

| Surface | Before | After |
|---|---|---|
| Phone GRID / LIST | compact, FAB clearance | unchanged |
| iPad portrait GRID | desktop row | compact, collapsible, stacked |
| iPad portrait LIST | **nothing** | compact, static after the day |
| iPad portrait SCHED | nothing | unchanged (dashboard, not a timeline) |
| iPad landscape | desktop row | unchanged |
| Desktop | desktop row | unchanged |

## Testing

- `npm run lint` — clean
- `npm test` — 1255 tests across 82 files passing
- `npm run build` — succeeds

Not verified on an actual iPad — there's no jsdom or testing-library in the project, so no component test could cover this either, and the render paths are behind touch/viewport detection I can't exercise here. Two things worth a look on device: that the LIST strip lands after the day's content in the same scroll flow (it's placed as `MobileLayout` places the phone's, in a parent that scrolls on tablet portrait), and that the GRID strip defaults to **collapsed** on first open — that's inherited from the phone default and shares its `localStorage` key. Easy to change if an iPad's extra room means it should start expanded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NriiJeAxCZyNSUUzUNehvx)_