### PR TITLE
Make the GLANCE action buttons collapsible

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -141,7 +141,9 @@
     "dailyNote": "Tagesnotiz",
     "filterInbox": "Posteingang filtern",
     "today": "Heute",
-    "tomorrow": "Morgen"
+    "tomorrow": "Morgen",
+    "showActions": "Aktionen anzeigen",
+    "hideActions": "Aktionen ausblenden"
   },
   "errorBoundary": {
     "title": "Etwas ist schiefgelaufen",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -141,7 +141,9 @@
     "dailyNote": "Daily Note",
     "filterInbox": "Filter Inbox",
     "today": "Today",
-    "tomorrow": "Tomorrow"
+    "tomorrow": "Tomorrow",
+    "showActions": "Show actions",
+    "hideActions": "Hide actions"
   },
   "errorBoundary": {
     "title": "Something went wrong",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -141,7 +141,9 @@
     "dailyNote": "Nota diaria",
     "filterInbox": "Filtrar bandeja de entrada",
     "today": "Hoy",
-    "tomorrow": "Mañana"
+    "tomorrow": "Mañana",
+    "showActions": "Mostrar acciones",
+    "hideActions": "Ocultar acciones"
   },
   "errorBoundary": {
     "title": "Algo salió mal",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -141,7 +141,9 @@
     "dailyNote": "Note du jour",
     "filterInbox": "Filtrer la boîte de réception",
     "today": "Aujourd'hui",
-    "tomorrow": "Demain"
+    "tomorrow": "Demain",
+    "showActions": "Afficher les actions",
+    "hideActions": "Masquer les actions"
   },
   "errorBoundary": {
     "title": "Une erreur est survenue",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -141,7 +141,9 @@
     "dailyNote": "Nota del giorno",
     "filterInbox": "Filtra in arrivo",
     "today": "Oggi",
-    "tomorrow": "Domani"
+    "tomorrow": "Domani",
+    "showActions": "Mostra azioni",
+    "hideActions": "Nascondi azioni"
   },
   "errorBoundary": {
     "title": "Qualcosa è andato storto",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -141,7 +141,9 @@
     "dailyNote": "Nota diária",
     "filterInbox": "Filtrar caixa de entrada",
     "today": "Hoje",
-    "tomorrow": "Amanhã"
+    "tomorrow": "Amanhã",
+    "showActions": "Mostrar ações",
+    "hideActions": "Ocultar ações"
   },
   "errorBoundary": {
     "title": "Algo correu mal",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8919,63 +8919,11 @@ const DayPlanner = () => {
           >
             <Plus size={28} />
           </button>
-          {/* Glance panel FABs: weekly review (bottom), daily summary (middle), recycle bin (top) — only when glance panel is visible (portrait or landscape glance tab) */}
-          {tabletActiveTab === 'glance' && (<>
-          {/* Daily summary ring FAB */}
-          {(() => {
-            const pct = actualTodayNonImportedTasks.length > 0 ? Math.round(((actualTodayCompletedTasks.length + inboxCompletedTodayCount) / actualTodayNonImportedTasks.length) * 100) : 0;
-            const ringColor = pct >= 100 ? 'stroke-green-500' : pct >= 50 ? 'stroke-amber-500' : 'stroke-red-500';
-            return (
-              <button
-                onClick={() => setShowMobileDailySummary(true)}
-                className={`fixed z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${darkMode ? 'bg-gray-700 active:bg-gray-600' : 'bg-stone-200 active:bg-stone-300'}`}
-                style={{ left: '268px', bottom: '5.5rem' }}
-              >
-                <div className="relative w-11 h-11">
-                  <svg viewBox="0 0 36 36" className="w-11 h-11 -rotate-90">
-                    <circle cx="18" cy="18" r="14" fill="none" strokeWidth="3" className={darkMode ? 'stroke-gray-600' : 'stroke-gray-200'} />
-                    <circle cx="18" cy="18" r="14" fill="none" strokeWidth="3" strokeLinecap="round" className={ringColor}
-                      strokeDasharray={`${(pct / 100) * 87.96} 87.96`}
-                    />
-                  </svg>
-                  <span className={`absolute inset-0 flex items-center justify-center text-[10px] font-bold ${textPrimary}`}>
-                    <ChevronUp size={16} />
-                  </span>
-                </div>
-              </button>
-            );
-          })()}
-          {/* Weekly review FAB */}
-          <button
-            onClick={() => {
-              if (showWeeklyReviewReminder) {
-                weeklyReviewDismissedRef.current = lastWeeklyReviewFiredRef.current;
-                localStorage.setItem('day-planner-weekly-review-dismissed', lastWeeklyReviewFiredRef.current);
-                setShowWeeklyReviewReminder(false);
-              }
-              setShowWeeklyReview(true);
-            }}
-            className={`fixed z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${showWeeklyReviewReminder ? 'bg-blue-600 text-white active:bg-blue-700' : darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-200 text-stone-600 active:bg-stone-300'}`}
-            style={{ left: '268px', bottom: '1.5rem' }}
-          >
-            <BarChart3 size={22} />
-          </button>
-          {/* Recycle bin FAB — only when non-empty, always on top */}
-          {recycleBin.filter(t => !t.isExample).length > 0 && (
-            <button
-              onClick={() => setShowMobileRecycleBin(true)}
-              className={`fixed z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-200 text-stone-600 active:bg-stone-300'}`}
-              style={{ left: '268px', bottom: '9.5rem' }}
-            >
-              <div className="relative">
-                <Trash2 size={22} />
-                <span className="absolute -top-2 -right-3 bg-red-500 text-white text-[10px] font-bold min-w-[16px] h-[16px] flex items-center justify-center rounded-full px-0.5">
-                  {recycleBin.filter(t => !t.isExample).length > 9 ? '9+' : recycleBin.filter(t => !t.isExample).length}
-                </span>
-              </div>
-            </button>
-          )}
-          </>)}
+          {/* The GLANCE panel's own FABs (weekly review, daily summary, recycle
+              bin) are NOT here: they live in components/GlanceFabs.jsx with the
+              panel's other buttons, so one collapse handle folds all of them.
+              These timeline FABs stay — they belong to the calendar, not the
+              panel, and are reachable on every tab. */}
         </>
       )}
 
@@ -8999,63 +8947,8 @@ const DayPlanner = () => {
           >
             <Plus size={28} />
           </button>
-          {/* Desktop Glance panel FABs — matching tablet landscape */}
-          {tabletActiveTab === 'glance' && (<>
-          {/* Daily summary ring FAB */}
-          {(() => {
-            const pct = actualTodayNonImportedTasks.length > 0 ? Math.round(((actualTodayCompletedTasks.length + inboxCompletedTodayCount) / actualTodayNonImportedTasks.length) * 100) : 0;
-            const ringColor = pct >= 100 ? 'stroke-green-500' : pct >= 50 ? 'stroke-amber-500' : 'stroke-red-500';
-            return (
-              <button
-                onClick={() => setShowMobileDailySummary(true)}
-                className={`fixed z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'}`}
-                style={{ left: '268px', bottom: '5.5rem' }}
-              >
-                <div className="relative w-11 h-11">
-                  <svg viewBox="0 0 36 36" className="w-11 h-11 -rotate-90">
-                    <circle cx="18" cy="18" r="14" fill="none" strokeWidth="3" className={darkMode ? 'stroke-gray-600' : 'stroke-gray-200'} />
-                    <circle cx="18" cy="18" r="14" fill="none" strokeWidth="3" strokeLinecap="round" className={ringColor}
-                      strokeDasharray={`${(pct / 100) * 87.96} 87.96`}
-                    />
-                  </svg>
-                  <span className={`absolute inset-0 flex items-center justify-center text-[10px] font-bold ${textPrimary}`}>
-                    <ChevronUp size={16} />
-                  </span>
-                </div>
-              </button>
-            );
-          })()}
-          {/* Weekly review FAB */}
-          <button
-            onClick={() => {
-              if (showWeeklyReviewReminder) {
-                weeklyReviewDismissedRef.current = lastWeeklyReviewFiredRef.current;
-                localStorage.setItem('day-planner-weekly-review-dismissed', lastWeeklyReviewFiredRef.current);
-                setShowWeeklyReviewReminder(false);
-              }
-              setShowWeeklyReview(true);
-            }}
-            className={`fixed z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${showWeeklyReviewReminder ? 'bg-blue-600 text-white hover:bg-blue-700' : darkMode ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-stone-200 text-stone-600 hover:bg-stone-300'}`}
-            style={{ left: '268px', bottom: '1.5rem' }}
-          >
-            <BarChart3 size={22} />
-          </button>
-          {/* Recycle bin FAB — only when non-empty */}
-          {recycleBin.filter(t => !t.isExample).length > 0 && (
-            <button
-              onClick={() => setShowMobileRecycleBin(true)}
-              className={`fixed z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${darkMode ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-stone-200 text-stone-600 hover:bg-stone-300'}`}
-              style={{ left: '268px', bottom: '9.5rem' }}
-            >
-              <div className="relative">
-                <Trash2 size={22} />
-                <span className="absolute -top-2 -right-3 bg-red-500 text-white text-[10px] font-bold min-w-[16px] h-[16px] flex items-center justify-center rounded-full px-0.5">
-                  {recycleBin.filter(t => !t.isExample).length > 9 ? '9+' : recycleBin.filter(t => !t.isExample).length}
-                </span>
-              </div>
-            </button>
-          )}
-          </>)}
+          {/* GLANCE panel FABs: see the tablet branch above — they live in
+              components/GlanceFabs.jsx so one handle collapses the whole set. */}
         </>
       )}
 

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import {
   Bell, BookOpen, ChevronLeft, ChevronRight, Cloud,
-  Eye, GitBranch, HelpCircle, Inbox, Moon, NotebookPen,
+  Eye, HelpCircle, Inbox, Moon,
   RefreshCw, Save, Settings, Sun, Trash2, X,
 } from 'lucide-react';
 import { dateToString, extractWikilinks, formatDateRange } from '../utils/taskUtils.js';
@@ -9,6 +9,7 @@ import { renderTitle } from '../utils/textFormatting.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
 import { hasNativeCalendar } from '../utils/nativeCalendar.js';
 import DesktopHeader from './DesktopHeader.jsx';
+import GlanceFabs from './GlanceFabs.jsx';
 import CalendarHeader from './CalendarHeader.jsx';
 import TimeGrid from './TimeGrid.jsx';
 import SummaryStrip from './SummaryStrip.jsx';
@@ -120,7 +121,7 @@ const DesktopLayout = () => {
     spotlightResults,
     dailyNotes, setDailyNotes,
     dailyNoteTemplate, setDailyNoteTemplate,
-    dailyNotesModalDate, setDailyNotesModalDate,
+    dailyNotesModalDate,
     weather, setWeather,
     weatherZip, setWeatherZip,
     weatherTempUnit, setWeatherTempUnit,
@@ -209,7 +210,7 @@ const DesktopLayout = () => {
     getTasksForDate, getDateIndicators, hasTasksOnDate,
     getDayName, getMonthDays, getNextQuarterHour,
     weekStartDay,
-    getTodayStr, getOverdueTasks,
+    getOverdueTasks,
     getTaskCalendarStyle,
     timeToMinutes, minutesToTime,
     selectAllTags, clearTagFilter, toggleTag,
@@ -413,8 +414,7 @@ const DesktopLayout = () => {
     frameNudgeLoading, setFrameNudgeLoading,
     frameNudgeError, setFrameNudgeError,
     frameNudgeDismissedKey, setFrameNudgeDismissedKey,
-    goals, projects, goalsProjectsEnabled,
-    setShowGoalsDashboard,
+    goals, projects,
     projectFilter, setProjectFilter,
     reminderSettings, setReminderSettings,
     showRemindersSettings, setShowRemindersSettings,
@@ -721,28 +721,8 @@ const DesktopLayout = () => {
                 )}
               </div>
               {tabletActiveTab === 'inbox' && <InboxArchivedBar />}
-              {/* Daily Note FAB — above Goals & Projects FAB */}
-              {tabletActiveTab === 'glance' && (
-                <button
-                  onClick={() => setDailyNotesModalDate(getTodayStr())}
-                  className={`absolute left-4 z-10 h-9 px-3 rounded-full shadow-lg flex items-center gap-1.5 transition-colors ${darkMode ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'}`}
-                  style={{ bottom: goalsProjectsEnabled ? '68px' : '24px' }}
-                  title="Today's daily note"
-                >
-                  {obsidianConfig?.enabled ? <BookOpen size={15} /> : <NotebookPen size={15} />}
-                  <span className="text-xs font-medium whitespace-nowrap">{t('common.dailyNote')}</span>
-                </button>
-              )}
-              {/* Goals & Projects FAB — bottom-left of GLANCE panel */}
-              {goalsProjectsEnabled && tabletActiveTab === 'glance' && (
-                <button
-                  onClick={() => setShowGoalsDashboard(true)}
-                  className={`absolute bottom-6 left-4 z-10 h-9 px-3 rounded-full shadow-lg flex items-center gap-1.5 transition-colors ${darkMode ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'}`}
-                >
-                  <GitBranch size={15} />
-                  <span className="text-xs font-medium whitespace-nowrap">{t('settings.goalsProjects')}</span>
-                </button>
-              )}
+              {/* Action pills + the handle that collapses them, bottom-left. */}
+              {tabletActiveTab === 'glance' && <GlanceFabs />}
             </div>
           )}
 
@@ -793,29 +773,8 @@ const DesktopLayout = () => {
               )}
             </div>
             {tabletActiveTab === 'inbox' && <InboxArchivedBar />}
-            {/* Daily Note FAB — above Goals & Projects FAB */}
-            {tabletActiveTab === 'glance' && (
-              <button
-                onClick={() => setDailyNotesModalDate(getTodayStr())}
-                className={`absolute left-4 z-10 h-9 px-3 rounded-full shadow-lg flex items-center gap-1.5 transition-colors ${darkMode ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'}`}
-                style={{ bottom: goalsProjectsEnabled ? '68px' : '24px' }}
-                title="Today's daily note"
-              >
-                {obsidianConfig?.enabled ? <BookOpen size={15} /> : <NotebookPen size={15} />}
-                <span className="text-xs font-medium whitespace-nowrap">{t('common.dailyNote')}</span>
-              </button>
-            )}
-            {/* Goals & Projects FAB — bottom-left of GLANCE panel */}
-            {goalsProjectsEnabled && tabletActiveTab === 'glance' && (
-              <button
-                onClick={() => setShowGoalsDashboard(true)}
-                className={`absolute bottom-6 left-4 z-10 h-9 px-3 rounded-full shadow-lg flex items-center gap-1.5 transition-colors ${darkMode ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'}`}
-                title="Goals & Projects"
-              >
-                <GitBranch size={15} />
-                <span className="text-xs font-medium whitespace-nowrap">{t('settings.goalsProjects')}</span>
-              </button>
-            )}
+            {/* Action pills + the handle that collapses them, bottom-left. */}
+            {tabletActiveTab === 'glance' && <GlanceFabs />}
           </div>
           )}
 

--- a/src/components/GlanceFabs.jsx
+++ b/src/components/GlanceFabs.jsx
@@ -1,0 +1,83 @@
+import { BookOpen, ChevronDown, ChevronUp, GitBranch, NotebookPen } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { useSyncCtx } from '../context/SyncContext.jsx';
+import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
+import useGlanceFabs from '../hooks/useGlanceFabs.js';
+import { glanceFabStagger, glanceFabVisibilityClass } from '../utils/glanceFabs.js';
+
+/**
+ * The GLANCE panel's action pills (daily note, Goals & Projects) plus the handle
+ * that collapses them, for desktop AND tablet landscape — DesktopLayout renders
+ * the same panel twice (its own 340px sidebar and the tablet's), and carried two
+ * verbatim copies of these buttons before this component existed.
+ *
+ * Absolutely positioned in the panel's bottom-left corner, so the wrapper is
+ * pointer-events-none: it spans a box wider than the pills themselves, and the
+ * GLANCE content underneath has to stay clickable around them.
+ *
+ * The handle is always the bottom-most element and never collapses — it is the
+ * only way back. The pills stack upward from it, so the one that folds away last
+ * is always the one beside it (see glanceFabStagger).
+ *
+ * The phone's version of this lives in MobileLayout: same handle, same state
+ * key, same timing, but circular FABs over the viewport rather than pills in a
+ * panel, so only the behaviour is shared (utils/glanceFabs.js), not the markup.
+ */
+export default function GlanceFabs() {
+  const { darkMode, setDailyNotesModalDate, getTodayStr } = useDayPlannerCtx();
+  const { obsidianConfig } = useSyncCtx();
+  const { goalsProjectsEnabled, setShowGoalsDashboard } = useFeaturesCtx();
+  const { t } = useTranslation();
+  const { collapsed, toggle } = useGlanceFabs();
+
+  // Listed TOP-DOWN, the order they render. The stagger index counts up FROM
+  // the handle, so it is the reverse of this list's index.
+  const actions = [
+    {
+      key: 'dailyNote',
+      icon: obsidianConfig?.enabled ? <BookOpen size={15} /> : <NotebookPen size={15} />,
+      label: t('common.dailyNote'),
+      title: "Today's daily note",
+      onClick: () => setDailyNotesModalDate(getTodayStr()),
+    },
+    goalsProjectsEnabled && {
+      key: 'goals',
+      icon: <GitBranch size={15} />,
+      label: t('settings.goalsProjects'),
+      title: 'Goals & Projects',
+      onClick: () => setShowGoalsDashboard(true),
+    },
+  ].filter(Boolean);
+
+  const pillClass = `h-9 px-3 rounded-full shadow-lg flex items-center gap-1.5 transition-all duration-300 ease-out ${
+    darkMode ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'
+  }`;
+
+  return (
+    <div className="absolute bottom-6 left-4 z-10 flex flex-col items-start gap-2 pointer-events-none">
+      {actions.map((action, i) => (
+        <button
+          key={action.key}
+          onClick={action.onClick}
+          title={action.title}
+          style={{ transitionDelay: `${glanceFabStagger(collapsed, actions.length - 1 - i, actions.length)}ms` }}
+          className={`${pillClass} ${glanceFabVisibilityClass(collapsed)}`}
+        >
+          {action.icon}
+          <span className="text-xs font-medium whitespace-nowrap">{action.label}</span>
+        </button>
+      ))}
+      <button
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        aria-label={collapsed ? t('common.showActions') : t('common.hideActions')}
+        className={`pointer-events-auto w-8 h-8 rounded-full shadow-lg flex items-center justify-center backdrop-blur-sm transition-colors ${
+          darkMode ? 'bg-gray-700/90 text-gray-400 hover:bg-gray-600' : 'bg-stone-100/90 text-stone-500 hover:bg-stone-200'
+        }`}
+      >
+        {collapsed ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+      </button>
+    </div>
+  );
+}

--- a/src/components/GlanceFabs.jsx
+++ b/src/components/GlanceFabs.jsx
@@ -1,4 +1,4 @@
-import { BookOpen, ChevronDown, ChevronUp, GitBranch, NotebookPen } from 'lucide-react';
+import { BarChart3, BookOpen, ChevronDown, ChevronUp, GitBranch, NotebookPen, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
@@ -7,33 +7,59 @@ import useGlanceFabs from '../hooks/useGlanceFabs.js';
 import { glanceFabStagger, glanceFabVisibilityClass } from '../utils/glanceFabs.js';
 
 /**
- * The GLANCE panel's action pills (daily note, Goals & Projects) plus the handle
- * that collapses them, for desktop AND tablet landscape — DesktopLayout renders
- * the same panel twice (its own 340px sidebar and the tablet's), and carried two
- * verbatim copies of these buttons before this component existed.
+ * Every GLANCE panel action button on desktop and tablet, and the one handle
+ * that collapses them — the same two-column arrangement the phone has in
+ * MobileLayout: labelled pills bottom-left (daily note, Goals & Projects),
+ * circular FABs bottom-right (weekly review, daily stats ring, recycle bin),
+ * with the handle at the foot of the right-hand column.
  *
- * Absolutely positioned in the panel's bottom-left corner, so the wrapper is
- * pointer-events-none: it spans a box wider than the pills themselves, and the
- * GLANCE content underneath has to stay clickable around them.
+ * ONE component for both columns is the point, not tidiness. The collapsed flag
+ * is component state, so a second copy of this hook somewhere else would be a
+ * second, independent flag: the handle would fold its own column and leave the
+ * other one sitting there. The right-hand column used to live in App.jsx —
+ * twice, once per platform — which is exactly how it got left behind.
  *
- * The handle is always the bottom-most element and never collapses — it is the
- * only way back. The pills stack upward from it, so the one that folds away last
- * is always the one beside it (see glanceFabStagger).
+ * DesktopLayout renders this in both its own 340px sidebar and the tablet's, so
+ * everything is absolutely positioned against that panel rather than the
+ * viewport (the right column was `fixed left: 268px`, hard-coding the panel's
+ * 340px width minus a button and a margin). Both wrappers are
+ * pointer-events-none: they span boxes wider and taller than the buttons in
+ * them, and the GLANCE content underneath has to stay clickable around them.
  *
- * The phone's version of this lives in MobileLayout: same handle, same state
- * key, same timing, but circular FABs over the viewport rather than pills in a
- * panel, so only the behaviour is shared (utils/glanceFabs.js), not the markup.
+ * The handle never collapses — it is the only way back.
  */
 export default function GlanceFabs() {
-  const { darkMode, setDailyNotesModalDate, getTodayStr } = useDayPlannerCtx();
-  const { obsidianConfig } = useSyncCtx();
-  const { goalsProjectsEnabled, setShowGoalsDashboard } = useFeaturesCtx();
+  const {
+    darkMode, textPrimary, setDailyNotesModalDate, getTodayStr,
+    recycleBin, setShowMobileDailySummary,
+    actualTodayNonImportedTasks, actualTodayCompletedTasks, inboxCompletedTodayCount,
+  } = useDayPlannerCtx();
+  const { obsidianConfig, setShowMobileRecycleBin } = useSyncCtx();
+  const {
+    goalsProjectsEnabled, setShowGoalsDashboard,
+    setShowWeeklyReview, showWeeklyReviewReminder, setShowWeeklyReviewReminder,
+    weeklyReviewDismissedRef, lastWeeklyReviewFiredRef,
+  } = useFeaturesCtx();
   const { t } = useTranslation();
   const { collapsed, toggle } = useGlanceFabs();
 
-  // Listed TOP-DOWN, the order they render. The stagger index counts up FROM
-  // the handle, so it is the reverse of this list's index.
-  const actions = [
+  const binCount = recycleBin.filter((task) => !task.isExample).length;
+
+  // The handle sits in the right column, so that column's height sets the
+  // rhythm both columns animate on. It varies: no recycle-bin button when the
+  // bin is empty.
+  const stackCount = binCount > 0 ? 3 : 2;
+  const delay = (index) => ({ transitionDelay: `${glanceFabStagger(collapsed, index, stackCount)}ms` });
+
+  const fabClass = (extra) => `w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-all duration-300 ease-out ${extra} ${glanceFabVisibilityClass(collapsed)}`;
+  const neutralFab = darkMode ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-stone-200 text-stone-600 hover:bg-stone-300';
+  const pillClass = `h-9 px-3 rounded-full shadow-lg flex items-center gap-1.5 transition-all duration-300 ease-out ${
+    darkMode ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'
+  } ${glanceFabVisibilityClass(collapsed)}`;
+
+  // Listed TOP-DOWN, the order they render; the stagger counts up FROM the
+  // handle, so it is the reverse of this list's index.
+  const pills = [
     {
       key: 'dailyNote',
       icon: obsidianConfig?.enabled ? <BookOpen size={15} /> : <NotebookPen size={15} />,
@@ -50,34 +76,89 @@ export default function GlanceFabs() {
     },
   ].filter(Boolean);
 
-  const pillClass = `h-9 px-3 rounded-full shadow-lg flex items-center gap-1.5 transition-all duration-300 ease-out ${
-    darkMode ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'
-  }`;
+  const donePct = actualTodayNonImportedTasks.length > 0
+    ? Math.round(((actualTodayCompletedTasks.length + inboxCompletedTodayCount) / actualTodayNonImportedTasks.length) * 100)
+    : 0;
+  const ringColor = donePct >= 100 ? 'stroke-green-500' : donePct >= 50 ? 'stroke-amber-500' : 'stroke-red-500';
 
   return (
-    <div className="absolute bottom-6 left-4 z-10 flex flex-col items-start gap-2 pointer-events-none">
-      {actions.map((action, i) => (
+    <>
+      {/* Left column — labelled pills. */}
+      <div className="absolute bottom-6 left-4 z-10 flex flex-col items-start gap-2 pointer-events-none">
+        {pills.map((pill, i) => (
+          <button
+            key={pill.key}
+            onClick={pill.onClick}
+            title={pill.title}
+            style={delay(pills.length - 1 - i)}
+            className={pillClass}
+          >
+            {pill.icon}
+            <span className="text-xs font-medium whitespace-nowrap">{pill.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Right column — circular FABs, resting on the handle. A flex stack, as
+          on the phone: it keeps the narrower handle centred under the 56px
+          buttons and closes the gap by itself when the bin empties. */}
+      <div className="absolute bottom-6 right-4 z-10 flex flex-col items-center gap-2 pointer-events-none">
+        {binCount > 0 && (
+          <button
+            onClick={() => setShowMobileRecycleBin(true)}
+            className={fabClass(neutralFab)}
+            style={delay(2)}
+          >
+            <div className="relative">
+              <Trash2 size={22} />
+              <span className="absolute -top-2 -right-3 bg-red-500 text-white text-[10px] font-bold min-w-[16px] h-[16px] flex items-center justify-center rounded-full px-0.5">
+                {binCount > 9 ? '9+' : binCount}
+              </span>
+            </div>
+          </button>
+        )}
         <button
-          key={action.key}
-          onClick={action.onClick}
-          title={action.title}
-          style={{ transitionDelay: `${glanceFabStagger(collapsed, actions.length - 1 - i, actions.length)}ms` }}
-          className={`${pillClass} ${glanceFabVisibilityClass(collapsed)}`}
+          onClick={() => setShowMobileDailySummary(true)}
+          className={fabClass(darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300')}
+          style={delay(1)}
         >
-          {action.icon}
-          <span className="text-xs font-medium whitespace-nowrap">{action.label}</span>
+          <div className="relative w-11 h-11">
+            <svg viewBox="0 0 36 36" className="w-11 h-11 -rotate-90">
+              <circle cx="18" cy="18" r="14" fill="none" strokeWidth="3" className={darkMode ? 'stroke-gray-600' : 'stroke-gray-200'} />
+              <circle cx="18" cy="18" r="14" fill="none" strokeWidth="3" strokeLinecap="round" className={ringColor}
+                strokeDasharray={`${(donePct / 100) * 87.96} 87.96`}
+              />
+            </svg>
+            <span className={`absolute inset-0 flex items-center justify-center text-[10px] font-bold ${textPrimary}`}>
+              <ChevronUp size={16} />
+            </span>
+          </div>
         </button>
-      ))}
-      <button
-        onClick={toggle}
-        aria-expanded={!collapsed}
-        aria-label={collapsed ? t('common.showActions') : t('common.hideActions')}
-        className={`pointer-events-auto w-8 h-8 rounded-full shadow-lg flex items-center justify-center backdrop-blur-sm transition-colors ${
-          darkMode ? 'bg-gray-700/90 text-gray-400 hover:bg-gray-600' : 'bg-stone-100/90 text-stone-500 hover:bg-stone-200'
-        }`}
-      >
-        {collapsed ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
-      </button>
-    </div>
+        <button
+          onClick={() => {
+            if (showWeeklyReviewReminder) {
+              weeklyReviewDismissedRef.current = lastWeeklyReviewFiredRef.current;
+              localStorage.setItem('day-planner-weekly-review-dismissed', lastWeeklyReviewFiredRef.current);
+              setShowWeeklyReviewReminder(false);
+            }
+            setShowWeeklyReview(true);
+          }}
+          className={fabClass(showWeeklyReviewReminder ? 'bg-blue-600 text-white hover:bg-blue-700' : neutralFab)}
+          style={delay(0)}
+        >
+          <BarChart3 size={22} />
+        </button>
+        <button
+          onClick={toggle}
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? t('common.showActions') : t('common.hideActions')}
+          className={`pointer-events-auto w-11 h-11 rounded-full shadow-lg flex items-center justify-center backdrop-blur-sm transition-colors ${
+            darkMode ? 'bg-gray-700/90 text-gray-400 hover:bg-gray-600' : 'bg-stone-200/90 text-stone-500 hover:bg-stone-300'
+          }`}
+        >
+          {collapsed ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
+        </button>
+      </div>
+    </>
   );
 }

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -44,9 +44,12 @@ import InboxFilterPopover from './InboxFilterPopover.jsx';
 import InboxArchivedBar from './InboxArchivedBar.jsx';
 import { useTranslation } from 'react-i18next';
 import { notBucketed } from '../utils/bucketList.js';
+import useGlanceFabs from '../hooks/useGlanceFabs.js';
+import { glanceFabStagger, glanceFabVisibilityClass } from '../utils/glanceFabs.js';
 
 const MobileLayout = () => {
   const [tzBannerDismissed, setTzBannerDismissed] = useState(false);
+  const { collapsed: glanceFabsCollapsed, toggle: toggleGlanceFabs } = useGlanceFabs();
   const {
     isPhone, isMobile, isTablet, isLandscape,
     visibleDays, visibleDates,
@@ -1165,74 +1168,107 @@ const MobileLayout = () => {
             </>
           )}
 
-          {/* Glance tab FABs - stacked on right: Weekly Review (bottom), Daily Stats (above weekly), Recycle Bin (top) */}
-          {mobileActiveTab === 'dayglance' && (
-            <>
-              {/* Daily Note FAB — bottom-left */}
-              <button
-                onClick={() => setDailyNotesModalDate(getTodayStr())}
-                className={`fixed left-4 z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-200 text-stone-600 active:bg-stone-300'}`}
-                style={{ bottom: 'calc(4.5rem + env(safe-area-inset-bottom, 0px))' }}
-                title="Today's daily note"
-              >
-                {obsidianConfig?.enabled ? <BookOpen size={22} /> : <NotebookPen size={22} />}
-              </button>
-              {/* Daily summary ring FAB */}
-              {(() => {
-                const pct = actualTodayNonImportedTasks.length > 0 ? Math.round(((actualTodayCompletedTasks.length + inboxCompletedTodayCount) / actualTodayNonImportedTasks.length) * 100) : 0;
-                const ringColor = pct >= 100 ? 'stroke-green-500' : pct >= 50 ? 'stroke-amber-500' : 'stroke-red-500';
-                return (
-                  <button
-                    onClick={() => setShowMobileDailySummary(true)}
-                    className={`fixed right-4 z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${darkMode ? 'bg-gray-700 active:bg-gray-600' : 'bg-stone-200 active:bg-stone-300'}`}
-                    style={{ bottom: 'calc(8.5rem + env(safe-area-inset-bottom, 0px))' }}
-                  >
-                    <div className="relative w-11 h-11">
-                      <svg viewBox="0 0 36 36" className="w-11 h-11 -rotate-90">
-                        <circle cx="18" cy="18" r="14" fill="none" strokeWidth="3" className={darkMode ? 'stroke-gray-600' : 'stroke-gray-200'} />
-                        <circle cx="18" cy="18" r="14" fill="none" strokeWidth="3" strokeLinecap="round" className={ringColor}
-                          strokeDasharray={`${(pct / 100) * 87.96} 87.96`}
-                        />
-                      </svg>
-                      <span className={`absolute inset-0 flex items-center justify-center text-[10px] font-bold ${textPrimary}`}>
-                        <ChevronUp size={16} />
-                      </span>
-                    </div>
-                  </button>
-                );
-              })()}
-              {/* Weekly review FAB */}
-              <button
-                onClick={() => {
-                  if (showWeeklyReviewReminder) {
-                    weeklyReviewDismissedRef.current = lastWeeklyReviewFiredRef.current;
-                    localStorage.setItem('day-planner-weekly-review-dismissed', lastWeeklyReviewFiredRef.current);
-                    setShowWeeklyReviewReminder(false);
-                  }
-                  setShowWeeklyReview(true);
-                }}
-                className={`fixed right-4 z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${showWeeklyReviewReminder ? 'bg-blue-600 text-white active:bg-blue-700' : darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-200 text-stone-600 active:bg-stone-300'}`}
-                style={{ bottom: 'calc(4.5rem + env(safe-area-inset-bottom, 0px))' }}
-              >
-                <BarChart3 size={22} />
-              </button>
-              {/* Recycle bin FAB */}
-              {recycleBin.filter(t => !t.isExample).length > 0 && (
+          {/* Glance tab FABs — Daily Note bottom-left, and a right-hand column
+              of Weekly Review (bottom), Daily Stats, Recycle Bin (top) sitting
+              on the collapse handle. All four fold into that one handle; see
+              utils/glanceFabs.js, which the desktop/tablet panel shares. */}
+          {mobileActiveTab === 'dayglance' && (() => {
+            const binCount = recycleBin.filter(t => !t.isExample).length;
+            // Column height drives the stagger: index 0 is the button beside the
+            // handle, and the recycle bin only exists when the bin is non-empty.
+            const stackCount = binCount > 0 ? 3 : 2;
+            const fabClass = (extra) => `w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-all duration-300 ease-out ${extra} ${glanceFabVisibilityClass(glanceFabsCollapsed)}`;
+            const delay = (index) => ({ transitionDelay: `${glanceFabStagger(glanceFabsCollapsed, index, stackCount)}ms` });
+            return (
+              <>
+                {/* Daily Note FAB — bottom-left. Its own element rather than a
+                    column member: it is the lone left-hand button, level with
+                    the handle, so it animates on the handle's own beat (0). */}
                 <button
-                  onClick={() => setShowMobileRecycleBin(true)}
-                  className={`fixed right-4 z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-colors ${darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-200 text-stone-600 active:bg-stone-300'}`}
-                  style={{ bottom: 'calc(12.5rem + env(safe-area-inset-bottom, 0px))' }}
+                  onClick={() => setDailyNotesModalDate(getTodayStr())}
+                  className={`fixed left-4 z-40 ${fabClass(darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-200 text-stone-600 active:bg-stone-300')}`}
+                  style={{ bottom: 'calc(4.5rem + env(safe-area-inset-bottom, 0px))', ...delay(0) }}
+                  title="Today's daily note"
                 >
-                  <div className="relative">
-                    <Trash2 size={22} />
-                    <span className="absolute -top-2 -right-3 bg-red-500 text-white text-[10px] font-bold min-w-[18px] h-[18px] flex items-center justify-center rounded-full px-1">
-                      {recycleBin.filter(t => !t.isExample).length > 9 ? '9+' : recycleBin.filter(t => !t.isExample).length}
-                    </span>
-                  </div>
+                  {obsidianConfig?.enabled ? <BookOpen size={22} /> : <NotebookPen size={22} />}
                 </button>
-              )}
-            </>
-          )}
+                {/* Right-hand column. A flex stack rather than four separately
+                    positioned FABs: it keeps the narrower handle centred under
+                    the 56px buttons, and closes the gap by itself when the
+                    recycle-bin button comes and goes. pointer-events-none on
+                    the wrapper — it is taller than the buttons it holds. */}
+                <div
+                  className="fixed right-4 z-40 flex flex-col items-center gap-2 pointer-events-none"
+                  style={{ bottom: 'calc(4.5rem + env(safe-area-inset-bottom, 0px))' }}
+                >
+                  {/* Recycle bin FAB */}
+                  {binCount > 0 && (
+                    <button
+                      onClick={() => setShowMobileRecycleBin(true)}
+                      className={fabClass(darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-200 text-stone-600 active:bg-stone-300')}
+                      style={delay(2)}
+                    >
+                      <div className="relative">
+                        <Trash2 size={22} />
+                        <span className="absolute -top-2 -right-3 bg-red-500 text-white text-[10px] font-bold min-w-[18px] h-[18px] flex items-center justify-center rounded-full px-1">
+                          {binCount > 9 ? '9+' : binCount}
+                        </span>
+                      </div>
+                    </button>
+                  )}
+                  {/* Daily summary ring FAB */}
+                  {(() => {
+                    const pct = actualTodayNonImportedTasks.length > 0 ? Math.round(((actualTodayCompletedTasks.length + inboxCompletedTodayCount) / actualTodayNonImportedTasks.length) * 100) : 0;
+                    const ringColor = pct >= 100 ? 'stroke-green-500' : pct >= 50 ? 'stroke-amber-500' : 'stroke-red-500';
+                    return (
+                      <button
+                        onClick={() => setShowMobileDailySummary(true)}
+                        className={fabClass(darkMode ? 'bg-gray-700 active:bg-gray-600' : 'bg-stone-200 active:bg-stone-300')}
+                        style={delay(1)}
+                      >
+                        <div className="relative w-11 h-11">
+                          <svg viewBox="0 0 36 36" className="w-11 h-11 -rotate-90">
+                            <circle cx="18" cy="18" r="14" fill="none" strokeWidth="3" className={darkMode ? 'stroke-gray-600' : 'stroke-gray-200'} />
+                            <circle cx="18" cy="18" r="14" fill="none" strokeWidth="3" strokeLinecap="round" className={ringColor}
+                              strokeDasharray={`${(pct / 100) * 87.96} 87.96`}
+                            />
+                          </svg>
+                          <span className={`absolute inset-0 flex items-center justify-center text-[10px] font-bold ${textPrimary}`}>
+                            <ChevronUp size={16} />
+                          </span>
+                        </div>
+                      </button>
+                    );
+                  })()}
+                  {/* Weekly review FAB */}
+                  <button
+                    onClick={() => {
+                      if (showWeeklyReviewReminder) {
+                        weeklyReviewDismissedRef.current = lastWeeklyReviewFiredRef.current;
+                        localStorage.setItem('day-planner-weekly-review-dismissed', lastWeeklyReviewFiredRef.current);
+                        setShowWeeklyReviewReminder(false);
+                      }
+                      setShowWeeklyReview(true);
+                    }}
+                    className={fabClass(showWeeklyReviewReminder ? 'bg-blue-600 text-white active:bg-blue-700' : darkMode ? 'bg-gray-700 text-gray-300 active:bg-gray-600' : 'bg-stone-200 text-stone-600 active:bg-stone-300')}
+                    style={delay(0)}
+                  >
+                    <BarChart3 size={22} />
+                  </button>
+                  {/* The handle — always present, never collapsed: it is the
+                      only way back once the rest have folded away. */}
+                  <button
+                    onClick={toggleGlanceFabs}
+                    aria-expanded={!glanceFabsCollapsed}
+                    aria-label={glanceFabsCollapsed ? t('common.showActions') : t('common.hideActions')}
+                    className={`pointer-events-auto w-11 h-11 rounded-full shadow-lg flex items-center justify-center backdrop-blur-sm transition-colors ${darkMode ? 'bg-gray-700/90 text-gray-400 active:bg-gray-600' : 'bg-stone-200/90 text-stone-500 active:bg-stone-300'}`}
+                  >
+                    {glanceFabsCollapsed ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
+                  </button>
+                </div>
+              </>
+            );
+          })()}
 
           {/* Trash FAB — visible during mobile long-press drag, hidden for routines */}
           {mobileDragTaskIdState !== null && !mobileDragIsRoutine && (

--- a/src/hooks/useGlanceFabs.js
+++ b/src/hooks/useGlanceFabs.js
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { readGlanceFabsCollapsed, writeGlanceFabsCollapsed } from '../utils/glanceFabs.js';
+
+/**
+ * Collapsed state for a layout's GLANCE action buttons.
+ *
+ * MobileLayout and DesktopLayout never render together (App picks one on
+ * isMobile), so an instance per layout is not a split source of truth — they
+ * read and write the same key, so whichever layout a device lands in, the
+ * choice is the one it was left in. Deliberately not lifted into context: no
+ * other surface needs to know, and the buttons are self-contained.
+ */
+export default function useGlanceFabs() {
+  const [collapsed, setCollapsed] = useState(readGlanceFabsCollapsed);
+
+  const toggle = () => setCollapsed((c) => {
+    writeGlanceFabsCollapsed(!c);
+    return !c;
+  });
+
+  return { collapsed, toggle };
+}

--- a/src/utils/glanceFabs.js
+++ b/src/utils/glanceFabs.js
@@ -1,0 +1,61 @@
+// Collapsible GLANCE action buttons — the shared rules behind the phone's FAB
+// stack and the desktop/tablet panel's labelled pills. The two look nothing
+// alike (56px circles over the viewport vs 36px pills inside a side panel), but
+// they collapse identically: everything folds into one persistent handle at the
+// bottom of the column. Timing and hidden-state styling live here so the two
+// layouts cannot drift apart.
+
+// Device-scoped by construction: a `day-planner-` key is excluded from cloud
+// sync and captured by the local folder backup (see utils/deviceSettings.js),
+// which is the lifetime a per-screen view preference wants — collapsing the
+// buttons on a phone must not empty the corner of the user's desktop.
+export const GLANCE_FABS_KEY = 'day-planner-glance-fabs-collapsed';
+
+// Default EXPANDED. These buttons are the only route to the daily note, the
+// weekly review and the recycle bin, so a first run must not hide them behind a
+// handle nobody has been taught to look for.
+export const readGlanceFabsCollapsed = () => {
+  try {
+    return localStorage.getItem(GLANCE_FABS_KEY) === '1';
+  } catch {
+    // Private mode / storage disabled: expanded is the safe direction.
+    return false;
+  }
+};
+
+export const writeGlanceFabsCollapsed = (collapsed) => {
+  try {
+    localStorage.setItem(GLANCE_FABS_KEY, collapsed ? '1' : '0');
+  } catch { /* nothing to do — the session still honours the in-memory choice */ }
+};
+
+// Hidden state: faded, nudged DOWN toward the handle, and slightly shrunk, so
+// the buttons read as folding INTO it rather than blinking out. pointer-events
+// is load-bearing, not decoration — an opacity-0 button still swallows taps,
+// which over the phone timeline would be an invisible dead zone.
+export const glanceFabVisibilityClass = (collapsed) =>
+  collapsed
+    ? 'opacity-0 translate-y-4 scale-90 pointer-events-none'
+    : 'opacity-100 translate-y-0 scale-100 pointer-events-auto';
+
+const STAGGER_STEP_MS = 50;
+
+/**
+ * Per-button animation delay, so the stack unfolds away from the handle and
+ * folds back toward it instead of moving as one block.
+ *
+ * @param collapsed The state being animated INTO.
+ * @param index     Position in the column, 0 = nearest the handle.
+ * @param count     How many buttons the column has right now — it varies: the
+ *                  recycle-bin button exists only when the bin is non-empty,
+ *                  and Goals & Projects only when the feature is on.
+ * @returns delay in ms
+ */
+export const glanceFabStagger = (collapsed, index, count) => {
+  const last = Math.max(0, count - 1);
+  const i = Math.min(Math.max(index, 0), last);
+  // Expanding, the button beside the handle leads; collapsing, the far end
+  // leaves first. Either way the one next to the handle is closest in time to
+  // it, which is what makes the handle read as the thing they fold into.
+  return (collapsed ? last - i : i) * STAGGER_STEP_MS;
+};

--- a/src/utils/glanceFabs.test.js
+++ b/src/utils/glanceFabs.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  GLANCE_FABS_KEY,
+  readGlanceFabsCollapsed,
+  writeGlanceFabsCollapsed,
+  glanceFabVisibilityClass,
+  glanceFabStagger,
+} from './glanceFabs.js';
+
+describe('glanceFabs persistence', () => {
+  let store;
+
+  beforeEach(() => {
+    store = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (k) => (k in store ? store[k] : null),
+      setItem: (k, v) => { store[k] = String(v); },
+    });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('defaults to expanded when nothing is stored', () => {
+    expect(readGlanceFabsCollapsed()).toBe(false);
+  });
+
+  it('round-trips both states', () => {
+    writeGlanceFabsCollapsed(true);
+    expect(store[GLANCE_FABS_KEY]).toBe('1');
+    expect(readGlanceFabsCollapsed()).toBe(true);
+
+    writeGlanceFabsCollapsed(false);
+    expect(store[GLANCE_FABS_KEY]).toBe('0');
+    expect(readGlanceFabsCollapsed()).toBe(false);
+  });
+
+  it('treats any other stored value as expanded', () => {
+    // Only '1' collapses — a stale or corrupt value must not hide the buttons.
+    for (const v of ['0', 'true', '', 'yes']) {
+      store[GLANCE_FABS_KEY] = v;
+      expect(readGlanceFabsCollapsed()).toBe(false);
+    }
+  });
+
+  it('survives storage that throws (private mode)', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('denied'); },
+      setItem: () => { throw new Error('denied'); },
+    });
+    expect(readGlanceFabsCollapsed()).toBe(false);
+    expect(() => writeGlanceFabsCollapsed(true)).not.toThrow();
+  });
+});
+
+describe('glanceFabVisibilityClass', () => {
+  it('makes hidden buttons click-through, not just invisible', () => {
+    expect(glanceFabVisibilityClass(true)).toContain('pointer-events-none');
+    expect(glanceFabVisibilityClass(true)).toContain('opacity-0');
+    expect(glanceFabVisibilityClass(false)).toContain('pointer-events-auto');
+    expect(glanceFabVisibilityClass(false)).toContain('opacity-100');
+  });
+});
+
+describe('glanceFabStagger', () => {
+  it('leads with the button nearest the handle when expanding', () => {
+    expect(glanceFabStagger(false, 0, 3)).toBe(0);
+    expect(glanceFabStagger(false, 1, 3)).toBe(50);
+    expect(glanceFabStagger(false, 2, 3)).toBe(100);
+  });
+
+  it('reverses when collapsing, so the far end leaves first', () => {
+    expect(glanceFabStagger(true, 2, 3)).toBe(0);
+    expect(glanceFabStagger(true, 1, 3)).toBe(50);
+    expect(glanceFabStagger(true, 0, 3)).toBe(100);
+  });
+
+  it('adapts to a column that lost a button', () => {
+    // Recycle bin emptied: the same two survivors re-index against count 2, so
+    // collapsing still ends on the button beside the handle.
+    expect(glanceFabStagger(true, 1, 2)).toBe(0);
+    expect(glanceFabStagger(true, 0, 2)).toBe(50);
+  });
+
+  it('never delays a lone button', () => {
+    expect(glanceFabStagger(false, 0, 1)).toBe(0);
+    expect(glanceFabStagger(true, 0, 1)).toBe(0);
+  });
+
+  it('clamps an index outside the column', () => {
+    expect(glanceFabStagger(false, 9, 3)).toBe(100);
+    expect(glanceFabStagger(false, -1, 3)).toBe(0);
+    expect(glanceFabStagger(true, 0, 0)).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

One persistent handle at the bottom of the column folds the GLANCE action buttons away and back — on phone and on desktop/tablet alike, following the `Ribbon.tsx` pattern from lastGLANCE.

**Phone** (`dayglance` tab): all four fold into a handle that takes the bottom-right slot — Daily Note (bottom-left), Weekly Review, Daily Stats ring, Recycle Bin.

**Desktop / tablet** (GLANCE side panel): the Daily Note and Goals & Projects pills fold into a handle in the panel's bottom-left corner.

The handle itself never collapses — it's the only way back.

## State

Persisted in `day-planner-glance-fabs-collapsed`. That prefix is what makes it device-scoped: `utils/deviceSettings.js` already excludes `day-planner-*` from cloud sync and captures it in the local folder backup, so collapsing on a phone won't empty the corner of the user's desktop, and the choice still survives a reload and a profile restore.

Default is **expanded**. These buttons are the only route to the daily note, the weekly review and the recycle bin, so a first run must not hide them behind a handle nobody has been taught to look for. A `'1'` is the only value that collapses — a stale or corrupt one falls back to expanded, as does storage that throws in private mode.

## What's shared, and what isn't

`utils/glanceFabs.js` (with tests) holds the storage key, the hidden-state classes, and the stagger. Markup is deliberately *not* shared — 56px circles floating over the phone viewport and 36px labelled pills inside a side panel have nothing in common but their timing.

Two details in there are load-bearing rather than decorative:

- `pointer-events-none` on hidden buttons. An `opacity-0` button still swallows taps, which over the phone timeline would leave an invisible dead zone where the FABs used to be.
- The stagger reverses by direction: expanding, the button beside the handle leads; collapsing, the far end leaves first. Either way the one nearest the handle is closest to it in time, which is what makes the handle read as the thing they fold into. It also takes the column's live `count`, because the Recycle Bin button only exists when the bin is non-empty and Goals & Projects only when the feature is on.

## Two refactors this pulled in

**The phone's right-hand column is now a flex stack** rather than four separately positioned FABs. Adding the handle meant rewriting the `4.5 / 8.5 / 12.5rem` offsets anyway, and a flex column does two things those offsets couldn't: it keeps the narrower 44px handle centred under the 56px buttons, and it closes the gap by itself when the Recycle Bin button appears and disappears.

**`GlanceFabs.jsx` is extracted** from `DesktopLayout`, which renders that panel twice — its own 340px sidebar and the tablet's — and carried two verbatim copies of the buttons. The handle would have made it three. This also drops the `goalsProjectsEnabled ? '68px' : '24px'` offset conditional, plus two lucide imports and four context destructures the extraction left dead.

## i18n

`common.showActions` / `common.hideActions` for the handle's `aria-label`, translated in all six locales.

## Testing

- `npm run lint` — clean
- `npm test` — 1265 tests across 83 files passing (10 new on the storage round-trip, the private-mode fallback, and the stagger in both directions)
- `npm run build` — succeeds

Not verified running. No jsdom or testing-library in the project, so the animation and layout are unexercised here — worth a look at the phone stack's vertical rhythm (`gap-2` reproduces the old 8px gaps, but the handle is 44px against the FABs' 56px) and at whether the 300ms transition feels right at the 50ms stagger step, both of which are one-line changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NriiJeAxCZyNSUUzUNehvx)_