### PR TITLE
Folder backup: capture the inbox filters (and their siblings)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1576,15 +1576,22 @@ const DayPlanner = () => {
     dailyNotes, users, routineCompletions, multiUserEnabled,
   });
 
-  // Onboarding flags aren't part of the useSaveOnChange data slices, so a
-  // checklist dismissal alone would never reach the folder backup — and the
-  // Getting Started checklist would reappear every session on wipe-on-exit
-  // machines. useOnboarding's own effects persist the flags to localStorage in
-  // the same commit, well before the debounced write builds its payload.
+  // View preferences aren't part of the useSaveOnChange data slices, so
+  // changing one alone would never reach the folder backup — the Getting
+  // Started checklist would reappear every session on wipe-on-exit machines,
+  // and the inbox filter bar would come back reset from any restore that
+  // followed a filter-only session. Their own effects (useOnboarding,
+  // useLocalStoragePersist) persist to localStorage in the same commit, well
+  // before the debounced write builds its payload, so a nudge here is enough.
   useEffect(() => {
     if (!dataLoaded) return;
     folderBackupWriteRef.current?.();
-  }, [dataLoaded, gettingStartedDismissed, onboardingProgress]);
+  }, [
+    dataLoaded, gettingStartedDismissed, onboardingProgress,
+    inboxPriorityFilter, inboxTagFilter, inboxProjectFilter,
+    hideCompletedInbox, hideProjectTasksInbox, hideStandaloneTasksInbox,
+    priorityPromptDismissed, sectionInfoDismissed, storageWarnDismissed,
+  ]);
 
   const { timelineScrolledAway, setTimelineScrolledAway, scrollToCurrentHour, scrollToHour } = useTimelineScroll({
     calendarRef, timeGridRef,

--- a/src/utils/deviceSettings.js
+++ b/src/utils/deviceSettings.js
@@ -8,14 +8,48 @@
  * every wipe-on-exit session starts with factory settings.
  *
  * Approach: capture every `day-planner-*` localStorage key verbatim (raw
- * string values), minus an exclusion list of (a) stores the backup payload
- * already carries as first-class fields, and (b) volatile sync cursors and
- * caches that would be stale or meaningless after a restore. Prefix capture is
- * deliberate — new settings keys added later ride along automatically instead
- * of re-opening this gap.
+ * string values), plus a fixed list of older keys that predate that naming
+ * convention, minus an exclusion list of (a) stores the backup payload already
+ * carries as first-class fields, and (b) volatile sync cursors and caches that
+ * would be stale or meaningless after a restore. Prefix capture is deliberate —
+ * new settings keys added later ride along automatically instead of re-opening
+ * this gap.
  */
 
 const KEY_PREFIX = 'day-planner-';
+
+// Settings written before the `day-planner-` convention existed. The prefix
+// rule silently missed every one, so a restored profile came back with a reset
+// inbox filter bar and one-time prompts the user had already dismissed.
+//
+// Named rather than renamed: migrating these keys to the prefix would strand
+// the values already sitting in every existing browser profile, and would need
+// a read-both-write-new shim in each of their owners. This list is closed —
+// nothing should ever be added to it, because anything new gets the prefix and
+// is captured for free.
+//
+// Deliberately NOT here:
+//  - minimizedSections, gettingStartedDismissed, onboardingProgress: the backup
+//    payload already carries these as first-class fields, and duplicating them
+//    is the two-sources-of-truth problem EXCLUDED_KEYS exists to prevent.
+//  - dailyContent: a date-stamped quote/history fetch cache, refetched on the
+//    first run of any new day and therefore stale the moment it is restored.
+const LEGACY_KEYS = new Set([
+  // The inbox filter bar, in full: priority, tag and project filters plus the
+  // three hide toggles. Losing these is what surfaced this gap.
+  'inboxPriorityFilter',
+  'inboxTagFilter',
+  'inboxProjectFilter',
+  'hideCompletedInbox',
+  'hideProjectTasksInbox',
+  'hideStandaloneTasksInbox',
+  // One-time prompts and warnings already dismissed. A restore that re-shows
+  // them reads as the app having forgotten, which is what a backup is for.
+  'priorityPromptDismissed',
+  'sectionInfoDismissed',
+  'welcomeDismissed',
+  'storageWarnDismissed',
+]);
 
 const EXCLUDED_KEYS = new Set([
   // Already first-class fields in the auto-backup payload's `data` object —
@@ -58,10 +92,12 @@ const EXCLUDED_KEYS = new Set([
 ]);
 
 const isCapturable = (key) =>
-  typeof key === 'string' && key.startsWith(KEY_PREFIX) && !EXCLUDED_KEYS.has(key);
+  typeof key === 'string'
+  && (key.startsWith(KEY_PREFIX) || LEGACY_KEYS.has(key))
+  && !EXCLUDED_KEYS.has(key);
 
 /**
- * Snapshot all capturable day-planner-* keys as { key: rawString }.
+ * Snapshot all capturable keys as { key: rawString }.
  * Includes device settings AND device-local data stores the payload doesn't
  * carry as fields (daily notes, frames, focus log, routine state, deletion
  * tombstones), which a wiped profile would otherwise lose.
@@ -78,9 +114,10 @@ export function collectDeviceSettings(storage = localStorage) {
 }
 
 /**
- * Write a captured settings map back into storage. Only day-planner-* keys
- * outside the exclusion list are applied (a hand-edited backup can't plant
- * arbitrary keys), and only string values. Returns the number applied.
+ * Write a captured settings map back into storage. Only keys isCapturable
+ * accepts are applied — the day-planner-* prefix or the closed legacy list,
+ * minus the exclusions — so a hand-edited backup still can't plant arbitrary
+ * keys, and only string values. Returns the number applied.
  */
 export function applyDeviceSettings(settings, storage = localStorage) {
   if (!settings || typeof settings !== 'object') return 0;

--- a/src/utils/deviceSettings.test.js
+++ b/src/utils/deviceSettings.test.js
@@ -30,6 +30,20 @@ describe('collectDeviceSettings', () => {
       // excluded: volatile cursors
       'day-planner-cloud-sync-last-synced': '2026-07-22T00:00:00Z',
       'day-planner-steps-cache': '{"big":"cache"}',
+      // legacy unprefixed settings — the inbox filter bar and dismissals
+      'inboxPriorityFilter': '"high"',
+      'inboxTagFilter': '["work"]',
+      'inboxProjectFilter': '"p1"',
+      'hideCompletedInbox': 'true',
+      'hideProjectTasksInbox': 'false',
+      'hideStandaloneTasksInbox': 'true',
+      'sectionInfoDismissed': '{"inbox":true}',
+      'welcomeDismissed': 'true',
+      // legacy keys the payload owns as first-class fields, or that are caches
+      'minimizedSections': '{"inbox":true}',
+      'gettingStartedDismissed': 'true',
+      'onboardingProgress': '{"step":2}',
+      'dailyContent': '{"date":"2026-07-22"}',
       // not ours
       'someOtherApp-key': 'nope',
       'dayglance-vault-hwm': '42',
@@ -53,6 +67,42 @@ describe('collectDeviceSettings', () => {
     expect(out['day-planner-steps-cache']).toBeUndefined();
     expect(out['someOtherApp-key']).toBeUndefined();
     expect(out['dayglance-vault-hwm']).toBeUndefined();
+  });
+
+  it('captures the whole inbox filter bar despite its unprefixed keys', () => {
+    // These predate the day-planner- convention, so prefix capture alone missed
+    // them and a restore came back with the filter bar reset.
+    const out = collectDeviceSettings(storage);
+    expect(out['inboxPriorityFilter']).toBe('"high"');
+    expect(out['inboxTagFilter']).toBe('["work"]');
+    expect(out['inboxProjectFilter']).toBe('"p1"');
+    expect(out['hideCompletedInbox']).toBe('true');
+    expect(out['hideStandaloneTasksInbox']).toBe('true');
+  });
+
+  it('captures a false toggle rather than treating it as absent', () => {
+    // Raw strings, not truthiness: 'false' is a real user choice to restore.
+    expect(collectDeviceSettings(storage)['hideProjectTasksInbox']).toBe('false');
+  });
+
+  it('captures legacy dismissals so a restore does not re-prompt', () => {
+    const out = collectDeviceSettings(storage);
+    expect(out['sectionInfoDismissed']).toBe('{"inbox":true}');
+    expect(out['welcomeDismissed']).toBe('true');
+  });
+
+  it('leaves legacy keys the payload already owns to the payload', () => {
+    // minimizedSections / gettingStartedDismissed / onboardingProgress are
+    // first-class backup fields; capturing them here would be a second source
+    // of truth for the same setting.
+    const out = collectDeviceSettings(storage);
+    expect(out['minimizedSections']).toBeUndefined();
+    expect(out['gettingStartedDismissed']).toBeUndefined();
+    expect(out['onboardingProgress']).toBeUndefined();
+  });
+
+  it('skips the daily-content cache, which is stale a day after a restore', () => {
+    expect(collectDeviceSettings(storage)['dailyContent']).toBeUndefined();
   });
 });
 
@@ -83,6 +133,23 @@ describe('applyDeviceSettings', () => {
     expect(target.getItem('evil-key')).toBeNull();
     expect(target.getItem('day-planner-tasks')).toBeNull();
     expect(target.getItem('day-planner-weather-zip')).toBeNull();
+  });
+
+  it('restores legacy keys, and only the listed ones', () => {
+    // The legacy list is an allowlist, not an escape hatch for unprefixed keys:
+    // a hand-edited backup still cannot plant one that is not named.
+    const target = makeStorage();
+    const applied = applyDeviceSettings({
+      'inboxPriorityFilter': '"high"',
+      'hideCompletedInbox': 'true',
+      'someOtherApp-key': 'nope',
+      'minimizedSections': '{"inbox":true}',
+    }, target);
+    expect(applied).toBe(2);
+    expect(target.getItem('inboxPriorityFilter')).toBe('"high"');
+    expect(target.getItem('hideCompletedInbox')).toBe('true');
+    expect(target.getItem('someOtherApp-key')).toBeNull();
+    expect(target.getItem('minimizedSections')).toBeNull();
   });
 
   it('tolerates null/garbage input', () => {


### PR DESCRIPTION
## The bug

Restoring from a backup folder came back with the inbox filter bar reset, so the filters had to be re-applied on every entry to the app.

There turned out to be **two independent gaps**, and the setting only survives if both are fixed — the second would have kept a filter-only session out of the file even with the first fixed.

## 1. Capture

`collectDeviceSettings` sweeps every `day-planner-*` key. The inbox filters predate that naming convention and are all unprefixed, so the prefix rule silently skipped them:

`inboxPriorityFilter`, `inboxTagFilter`, `inboxProjectFilter`, `hideCompletedInbox`, `hideProjectTasksInbox`, `hideStandaloneTasksInbox`

The fix adds a **closed `LEGACY_KEYS` list** that `isCapturable` accepts alongside the prefix. The same sweep found four dismissal flags with the identical problem — `priorityPromptDismissed`, `sectionInfoDismissed`, `welcomeDismissed`, `storageWarnDismissed`. A restore that re-shows a prompt the user already dismissed reads as the app having forgotten, which is what the backup is meant to prevent, so they're included.

**Named rather than renamed.** Migrating these keys to the `day-planner-` prefix would strand the values already sitting in every existing browser profile, and would need a read-both-write-new shim in each of their owners. The list is closed — nothing should be added to it, because anything new gets the prefix and is captured for free.

**Still deliberately uncaptured**, and commented as such so the next sweep doesn't "fix" them:

- `minimizedSections`, `gettingStartedDismissed`, `onboardingProgress` — the backup payload already carries these as first-class fields. Capturing them here is exactly the two-sources-of-truth problem `EXCLUDED_KEYS` exists to prevent.
- `dailyContent` — a date-stamped quote/history fetch cache, refetched on the first run of any new day and therefore stale the moment it's restored.
- The `dayglance-*` family (vault config, multi-user, sync cursors) — a different prefix and a different question, including credentials. Out of scope here.

`applyDeviceSettings` keeps its guarantee: the legacy list is an allowlist, not an escape hatch, so a hand-edited backup still can't plant an arbitrary unprefixed key.

## 2. Write trigger

The filters aren't in `useSaveOnChange`'s data slices either, so changing one alone never scheduled a folder-backup write — the file kept the previous session's values until the next task edit happened to flush it.

This is the same failure the effect at `App.jsx:1579` already documents for onboarding flags ("a checklist dismissal alone would never reach the folder backup"), so the fix is to extend that effect rather than add a parallel one. Their `localStorage` writes land in the same commit, well before the debounced write builds its payload, so a nudge is all that's needed.

## Testing

- `npm run lint` — clean
- `npm test` — 1261 tests across 82 files passing (6 new: the filter bar round-trip, `'false'` captured as a real choice rather than dropped as falsy, legacy dismissals, the payload-owned keys staying out, the cache staying out, and the allowlist holding on restore)
- `npm run build` — succeeds

The new capture tests fail against the old `isCapturable` by construction — unprefixed keys returned `undefined`.

Not verified against a real backup folder: the File System Access API round-trip isn't reachable here. The capture and restore halves are covered by unit tests; what's untested end-to-end is that a filter change now flushes to disk promptly, which is the part worth confirming on device — change only a filter, quit, restore, and check the bar comes back.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NriiJeAxCZyNSUUzUNehvx)_