### PR TITLE
Bump version to 4.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="screenshots/badges/google-play.png" alt="Get it on Google Play" height="60">](https://play.google.com/store/apps/details?id=com.dayglance.app) [<img src="screenshots/badges/app-store.svg" alt="Download on the App Store" height="60">](https://apps.apple.com/app/id6771540599)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-4.2.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-4.3.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         // fallback for plain gradle/IDE builds and no longer needs a commit
         // per Play upload.
         versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 185
-        versionName = "4.2.0"
+        versionName = "4.3.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "@glance-apps/billing": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dayglance",
   "private": true,
   "license": "MIT",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Why 4.3.0

**Minor, not patch** — the release adds user-facing features, not just fixes. **Not major** — nothing breaks.

Twelve merges since `v4.2.0` (50 files, +3956/−402).

**User-facing:**
- **Reset App Data** — the first way to clear data on any platform (#1329)
- **"Data found in iCloud"** prompt on a fresh install, replacing a silent restore (#1333)
- **Per-device iCloud sync toggle** — macOS's only off switch, since the app never registers with the iCloud daemon (#1333)
- **iCloud diagnostics panel** (#1330, #1332, #1339)
- **Collapsible GLANCE action buttons** (#1345, #1343)
- **iPad summary strip** — compact in GRID, present at all in LIST (#1344)
- **Live Activity** energy glyph inside the island ring (#1343)
- **Escape** dismisses the Day window popover (#1341)

**Fixes and internals:** folder backup now captures the inbox filters (#1346); the summary strip hides while the macOS title bar carries the pills (#1342); the iCloud seed guard reads a key iCloud actually writes (#1335); widget snapshots only push when their content changed (#1336, #1337); dropped widget snapshots are logged rather than silent (#1340); multi-user copy is correct on iCloud-only devices (#1331); audit-gate dependency pins (#1329, #1334).

## Why not major

No sync payload or storage format changes, no removed features, no changed defaults. The two new preferences are tri-state with absence meaning "behave as before", so existing installs are unaffected on upgrade — `isICloudSyncEnabled` returns `true` when unset, and the first-run prompt only fires on a device with no local data.

## Contents

`scripts/bump-version.mjs` wrote exactly four version lines — `package.json`, the Android `versionName`, the README badge, and the lockfile. Diff verified to contain nothing else. iOS `MARKETING_VERSION` and the Electron `CFBundleShortVersionString` derive from `package.json` at build time.

`npm run audit`, `npm run lint`, `npm test` (1255 passing) and `npm run build` all clean.

## Before archiving

- `npm run ios:generate` so the Xcode project picks up the new `MARKETING_VERSION`
- `npm run build:ios` so the archive doesn't ship a stale web bundle
- **Build the Swift in Xcode.** #1340 changed `WidgetBridge.swift` and no workflow compiles Swift, so it is the one change in this release CI has never checked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWTFj6JEjp8NUd71HzHHai)_