### PR TITLE
Retry EINTR on iCloud container reads and writes

### DIFF
--- a/electron/fsRetry.test.ts
+++ b/electron/fsRetry.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { retryTransientFs, isTransientFsError, TRANSIENT_FS_CODES } from './fsRetry.js';
+
+const errno = (code: string) => Object.assign(new Error(`${code}: something, read`), { code });
+
+describe('isTransientFsError', () => {
+  it('recognises the interruption codes', () => {
+    expect(isTransientFsError(errno('EINTR'))).toBe(true);
+    expect(isTransientFsError(errno('EAGAIN'))).toBe(true);
+  });
+
+  // Narrow on purpose: retrying these would slow a correct answer down, or
+  // paper over a condition that persists.
+  it('does not treat persistent or meaningful errors as transient', () => {
+    expect(isTransientFsError(errno('ENOENT'))).toBe(false);
+    expect(isTransientFsError(errno('EBUSY'))).toBe(false);
+    expect(isTransientFsError(errno('EACCES'))).toBe(false);
+    expect(isTransientFsError(errno('EPERM'))).toBe(false);
+  });
+
+  it('handles junk without throwing', () => {
+    expect(isTransientFsError(null)).toBe(false);
+    expect(isTransientFsError(undefined)).toBe(false);
+    expect(isTransientFsError('EINTR')).toBe(false);       // a bare string has no .code
+    expect(isTransientFsError(new Error('EINTR'))).toBe(false); // message, not code
+  });
+
+  it('exposes exactly the two codes', () => {
+    expect([...TRANSIENT_FS_CODES].sort()).toEqual(['EAGAIN', 'EINTR']);
+  });
+});
+
+describe('retryTransientFs', () => {
+  it('returns the value without retrying when the call succeeds', () => {
+    const op = vi.fn(() => 'contents');
+    expect(retryTransientFs(op)).toBe('contents');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  // The reported failure: EINTR on the first read, fine on the reissue.
+  it('reissues after EINTR and returns the eventual result', () => {
+    let calls = 0;
+    const op = vi.fn(() => {
+      calls++;
+      if (calls === 1) throw errno('EINTR');
+      return 'contents';
+    });
+    expect(retryTransientFs(op)).toBe('contents');
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps trying up to the attempt limit', () => {
+    let calls = 0;
+    const op = vi.fn(() => {
+      calls++;
+      if (calls < 3) throw errno('EINTR');
+      return 'ok';
+    });
+    expect(retryTransientFs(op, 3)).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  // A genuine failure must not be delayed behind pointless retries — icloud.ts
+  // relies on ENOENT-shaped answers reaching it promptly.
+  it('rethrows a non-transient error on the first attempt', () => {
+    const op = vi.fn(() => { throw errno('EACCES'); });
+    expect(() => retryTransientFs(op)).toThrow(/EACCES/);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows a transient error that never resolves, rather than looping', () => {
+    const op = vi.fn(() => { throw errno('EINTR'); });
+    expect(() => retryTransientFs(op, 3)).toThrow(/EINTR/);
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it('always makes at least one attempt, whatever the count says', () => {
+    const op = vi.fn(() => 'once');
+    expect(retryTransientFs(op, 0)).toBe('once');
+    expect(retryTransientFs(op, -5)).toBe('once');
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves the thrown error object, not just its message', () => {
+    const original = errno('EPERM');
+    try {
+      retryTransientFs(() => { throw original; });
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBe(original);
+    }
+  });
+});

--- a/electron/fsRetry.ts
+++ b/electron/fsRetry.ts
@@ -1,0 +1,71 @@
+/**
+ * Retry wrapper for filesystem calls against the iCloud container.
+ *
+ * ── Why ────────────────────────────────────────────────────────────────────
+ * Observed in a Mac App Store build:
+ *
+ *     iCloud unavailable: EINTR: interrupted system call, read
+ *
+ * EINTR means the read(2) syscall was interrupted by a signal before it
+ * transferred anything. It is not an iCloud problem, not a permissions problem,
+ * and not a missing file: the correct response has always been to reissue the
+ * call. Node retries EINTR internally in some paths but not in fs.readFileSync,
+ * and reads from ~/Library/Mobile Documents are unusually exposed to it because
+ * the iCloud daemon is materialising the file underneath us.
+ *
+ * Unretried, it surfaced through icloud.ts's catch-all as a structured error,
+ * which the renderer reports as "iCloud unavailable" and flashes as a sync
+ * failure — a scary, wrong message for a condition that resolves on the next
+ * attempt.
+ *
+ * ── No delay between attempts, deliberately ────────────────────────────────
+ * The interrupting signal has already been handled by the time the call returns,
+ * so an immediate reissue is the standard remedy and normally succeeds first
+ * time. A sleep here would block the Electron main process, which is worse than
+ * the error being fixed.
+ */
+
+/**
+ * Errno codes that mean "the call did not happen, try it again".
+ *
+ * Deliberately narrow. EBUSY and ENOENT are NOT here: EBUSY can persist for as
+ * long as another process holds the file, and ENOENT is a real answer about the
+ * world that callers already handle (icloud.ts distinguishes "no remote file
+ * yet" from "iCloud unavailable" on exactly that basis). Retrying either would
+ * turn a fast, correct result into a slow, identical one.
+ */
+export const TRANSIENT_FS_CODES: ReadonlySet<string> = new Set(['EINTR', 'EAGAIN']);
+
+/** True when an error is one of the retryable interruptions. */
+export function isTransientFsError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'string' && TRANSIENT_FS_CODES.has(code);
+}
+
+/**
+ * Runs a synchronous filesystem operation, reissuing it on a transient
+ * interruption.
+ *
+ * Anything not in TRANSIENT_FS_CODES is rethrown on the first attempt, so a
+ * genuine failure (no iCloud account, permissions, a corrupt path) still reaches
+ * the caller's error handling immediately rather than after N pointless retries.
+ * A transient error that survives every attempt is also rethrown, since at that
+ * point it is no longer behaving transiently and the caller should hear about it.
+ *
+ * @param op        the filesystem call
+ * @param attempts  total attempts including the first (minimum 1)
+ */
+export function retryTransientFs<T>(op: () => T, attempts = 3): T {
+  const total = Math.max(1, attempts);
+  let lastErr: unknown;
+  for (let i = 0; i < total; i++) {
+    try {
+      return op();
+    } catch (err) {
+      if (!isTransientFsError(err)) throw err;
+      lastErr = err;
+    }
+  }
+  throw lastErr;
+}

--- a/electron/icloud.ts
+++ b/electron/icloud.ts
@@ -1,6 +1,7 @@
 import { ipcMain, app, BrowserWindow } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
+import { retryTransientFs } from './fsRetry.js';
 
 // ── iCloud sync (macOS) ─────────────────────────────────────────────────────
 //
@@ -62,7 +63,7 @@ export function registerICloudHandlers(getWindow: () => BrowserWindow | null): v
         }
         return null;
       }
-      return fs.readFileSync(filePath, 'utf-8');
+      return retryTransientFs(() => fs.readFileSync(filePath, 'utf-8'));
     } catch (e: unknown) {
       // Return a structured error so the renderer can distinguish "iCloud not
       // available / not signed in" from "no remote file yet" (null).
@@ -82,7 +83,7 @@ export function registerICloudHandlers(getWindow: () => BrowserWindow | null): v
       // those xattrs bird does not recognise the file as needing re-upload.
       // Writing to the existing fd preserves the inode (and all xattrs) so bird
       // sees a normal modification event and queues the upload.
-      fs.writeFileSync(filePath, json, { encoding: 'utf-8' });
+      retryTransientFs(() => fs.writeFileSync(filePath, json, { encoding: 'utf-8' }));
       lastMacOSWriteTime = Date.now();
       return true;
     } catch { return false; }
@@ -112,7 +113,7 @@ export function registerICloudHandlers(getWindow: () => BrowserWindow | null): v
         }
         return null;
       }
-      return fs.readFileSync(filePath, 'utf-8');
+      return retryTransientFs(() => fs.readFileSync(filePath, 'utf-8'));
     } catch { return null; }
   });
 
@@ -122,7 +123,7 @@ export function registerICloudHandlers(getWindow: () => BrowserWindow | null): v
       const filePath = path.join(await iCloudDocumentsDir(), relativePath);
       fs.mkdirSync(path.dirname(filePath), { recursive: true });
       // Write in-place (not rename) to preserve iCloud xattrs so bird queues the upload.
-      fs.writeFileSync(filePath, content, { encoding: 'utf-8' });
+      retryTransientFs(() => fs.writeFileSync(filePath, content, { encoding: 'utf-8' }));
       return true;
     } catch { return false; }
   });
@@ -173,7 +174,7 @@ async function startICloudWatch(getWindow: () => BrowserWindow | null): Promise<
         debounce = setTimeout(() => {
           try {
             if (!fs.existsSync(syncPath)) return;
-            const content = fs.readFileSync(syncPath, 'utf-8');
+            const content = retryTransientFs(() => fs.readFileSync(syncPath, 'utf-8'));
             const win = getWindow();
             win?.webContents.send('icloud:changed', content);
           } catch {}


### PR DESCRIPTION
## The error

From a Mac App Store build:

```
iCloud unavailable: EINTR: interrupted system call, read
```

`EINTR` means `read(2)` was interrupted by a signal before transferring anything. It is not an iCloud problem, not permissions, and not a missing file: the correct response has always been to reissue the call. Node retries `EINTR` internally in some paths but **not** in `fs.readFileSync`, and reads from `~/Library/Mobile Documents` are unusually exposed to it because the iCloud daemon is materialising the file underneath us.

Unretried, it fell through `icloud.ts`'s catch-all into a structured error, which the renderer reports as **"iCloud unavailable"** and flashes as a sync failure. A scary and wrong message for a condition that succeeds on the next attempt.

## What changed

`electron/fsRetry.ts` (new) wraps the four calls that transfer container bytes: both `readFileSync` paths, both `writeFileSync` paths, and the `fs.watch` reader.

`existsSync`, `readdirSync`, `mkdirSync` and `unlinkSync` are deliberately left alone — they are metadata operations that don't block on iCloud materialising anything.

**No delay between attempts.** The interrupting signal has already been handled by the time the call returns, so an immediate reissue is the standard remedy and normally succeeds first time. A sleep here would block the Electron main process, which is worse than the error being fixed.

**`TRANSIENT_FS_CODES` is `EINTR` and `EAGAIN` only.** `EBUSY` can persist for as long as another process holds the file, and `ENOENT` is a real answer that `icloud.ts` depends on receiving promptly — it's how the read handler distinguishes "no remote file yet" (`null`) from "iCloud unavailable" (structured error). Retrying either would turn a fast correct result into a slow identical one.

Non-transient errors rethrow on the **first** attempt, so genuine failures reach the existing error handling as immediately as they did before.

## Testing

- `electron/fsRetry.test.ts` — 11 cases: the reported EINTR-then-success sequence, retry up to the limit, a persistent transient rethrowing rather than looping forever, non-transient errors rethrowing on the first attempt without retries, junk input, and error identity preserved through the rethrow.
- `npx tsc -p tsconfig.electron.json --noEmit` clean.
- Full suite: **1266 tests passing**. `npm run lint`, `npm run audit`, `npm run build` clean.

## Release note

Worth landing before the 4.3.0 tag. The version bump is already on `main`, so merging this keeps it 4.3.0 — no re-bump needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWTFj6JEjp8NUd71HzHHai)_