### PR TITLE
MCP Phase 1: loopback Streamable HTTP listener skeleton (dev flag only)

### DIFF
--- a/docs/mcp-server-spec.md
+++ b/docs/mcp-server-spec.md
@@ -547,7 +547,7 @@ Privacy policy updates per §9. Umbrella paragraph. ToU confirmation. MAS descri
 
 ## 13. References
 
-1. MCP transports specification, revision 2025-11-25. stdio and Streamable HTTP are the two standard transports; HTTP+SSE deprecated as of 2025-03-26.
+1. MCP transports specification, revision 2026-07-28 (the spec baseline per the header). stdio and Streamable HTTP are the two standard transports; HTTP+SSE deprecated as of 2025-03-26.
 2. Claude Desktop local MCP configuration accepts stdio servers only; `url` and `type: "http"` entries are dropped and the config is silently rewritten.
 3. Claude Desktop Custom Connectors are brokered through Anthropic infrastructure and cannot reach loopback addresses.
 4. MCPB (`.mcpb`) bundle format for single-click local MCP server installation in Claude Desktop.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -13,6 +13,7 @@ import { registerObsidianHandlers } from './obsidian.js';
 import { APP_SCHEME, APP_HOST, APP_BASE_URL, resolveAppRequest } from './appProtocol.js';
 import { shouldQuitOnAllWindowsClosed } from './startupQuit.js';
 import { initStartupLog, logStartup } from './startupLog.js';
+import { startMcpServer } from './mcpServer.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -882,6 +883,16 @@ app.whenReady().then(async () => {
 
   const win = createWindow();
   createWsServer(() => live(mainWindow));
+  // MCP listener — Phase 1: dev flag only, no settings UI or consent gate yet
+  // (those are Phase 5, docs/mcp-server-spec.md §10). Token comes from the
+  // environment for now; the discovery file is Phase 6. Off means off: without
+  // the flag no port is bound at all.
+  if (process.env['DAYGLANCE_MCP_DEV'] === '1') {
+    startMcpServer({
+      token: process.env['DAYGLANCE_MCP_TOKEN'] ?? '',
+      portOverride: process.env['DAYGLANCE_MCP_PORT'],
+    });
+  }
   registerSubscriptionHandlers(win);
   registerCalendarHandlers();
   registerStorefrontHandlers();

--- a/electron/mcpAuth.test.ts
+++ b/electron/mcpAuth.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateMcpToken,
+  checkBearerToken,
+  unauthorizedResponse,
+} from './mcpAuth.js';
+
+// The MCP listener's whole auth story is this one pre-shared token (spec §3.5).
+// These tests pin both directions: a correct token is accepted in every shape
+// clients legitimately send, and every other shape is refused — with the three
+// refusal reasons distinguishable internally but collapsing to one identical
+// 401 on the wire.
+
+const TOKEN = 'a'.repeat(64);
+
+describe('generateMcpToken', () => {
+  it('produces 64 lowercase hex chars (32 CSPRNG bytes, the ws-server.ts idiom)', () => {
+    const token = generateMcpToken();
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('never repeats across calls', () => {
+    const seen = new Set(Array.from({ length: 50 }, () => generateMcpToken()));
+    expect(seen.size).toBe(50);
+  });
+});
+
+describe('checkBearerToken — accepts', () => {
+  it('accepts the exact token', () => {
+    expect(checkBearerToken(`Bearer ${TOKEN}`, TOKEN)).toEqual({ ok: true });
+  });
+
+  it('accepts a case-variant scheme (RFC 7235: scheme is case-insensitive)', () => {
+    expect(checkBearerToken(`bearer ${TOKEN}`, TOKEN)).toEqual({ ok: true });
+    expect(checkBearerToken(`BEARER ${TOKEN}`, TOKEN)).toEqual({ ok: true });
+  });
+});
+
+describe('checkBearerToken — refuses', () => {
+  it('refuses a missing header as missing-header', () => {
+    expect(checkBearerToken(undefined, TOKEN)).toEqual({ ok: false, reason: 'missing-header' });
+  });
+
+  it('refuses a repeated header as malformed-header', () => {
+    expect(checkBearerToken([`Bearer ${TOKEN}`, `Bearer ${TOKEN}`], TOKEN))
+      .toEqual({ ok: false, reason: 'malformed-header' });
+  });
+
+  it('refuses non-Bearer schemes and shapeless values as malformed-header', () => {
+    expect(checkBearerToken(`Basic ${TOKEN}`, TOKEN)).toEqual({ ok: false, reason: 'malformed-header' });
+    expect(checkBearerToken(TOKEN, TOKEN)).toEqual({ ok: false, reason: 'malformed-header' });
+    expect(checkBearerToken('Bearer', TOKEN)).toEqual({ ok: false, reason: 'malformed-header' });
+    expect(checkBearerToken('Bearer ', TOKEN)).toEqual({ ok: false, reason: 'malformed-header' });
+    expect(checkBearerToken('', TOKEN)).toEqual({ ok: false, reason: 'malformed-header' });
+  });
+
+  it('refuses a wrong token as wrong-token', () => {
+    expect(checkBearerToken(`Bearer ${'b'.repeat(64)}`, TOKEN)).toEqual({ ok: false, reason: 'wrong-token' });
+  });
+
+  it('refuses a wrong token of a different length (hash-then-compare must not throw)', () => {
+    expect(checkBearerToken('Bearer short', TOKEN)).toEqual({ ok: false, reason: 'wrong-token' });
+    expect(checkBearerToken(`Bearer ${TOKEN}x`, TOKEN)).toEqual({ ok: false, reason: 'wrong-token' });
+  });
+
+  it('refuses a prefix or superstring of the real token', () => {
+    expect(checkBearerToken(`Bearer ${TOKEN.slice(0, 63)}`, TOKEN)).toEqual({ ok: false, reason: 'wrong-token' });
+    expect(checkBearerToken(`Bearer ${TOKEN} `, TOKEN)).toEqual({ ok: false, reason: 'wrong-token' });
+  });
+
+  it('fails closed on an empty configured token — even a matching empty presentation', () => {
+    // 'Bearer ' with an empty candidate is malformed before the compare; the
+    // point here is that NO header value can authenticate against ''.
+    expect(checkBearerToken('Bearer x', '')).toEqual({ ok: false, reason: 'wrong-token' });
+    expect(checkBearerToken('Bearer ', '')).toEqual({ ok: false, reason: 'malformed-header' });
+  });
+
+  it('does not treat the token comparison as a regex or trim whitespace into a match', () => {
+    expect(checkBearerToken('Bearer .*', TOKEN)).toEqual({ ok: false, reason: 'wrong-token' });
+  });
+});
+
+describe('unauthorizedResponse', () => {
+  it('is a 401 with WWW-Authenticate and a JSON-RPC error body', () => {
+    const res = unauthorizedResponse();
+    expect(res.status).toBe(401);
+    expect(res.headers['www-authenticate']).toContain('Bearer');
+    expect(JSON.parse(res.body)).toEqual({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Unauthorized' },
+      id: null,
+    });
+  });
+
+  it('is identical no matter why auth failed (the function cannot even see a reason)', () => {
+    // Structural guarantee: zero parameters. If someone adds a reason
+    // parameter to vary the response, this test is the tripwire.
+    expect(unauthorizedResponse.length).toBe(0);
+    expect(unauthorizedResponse()).toEqual(unauthorizedResponse());
+  });
+});

--- a/electron/mcpAuth.ts
+++ b/electron/mcpAuth.ts
@@ -1,0 +1,92 @@
+// Bearer-token auth for the MCP loopback listener (spec §3.5), extracted as
+// pure functions so the auth decisions can be unit-tested without binding a
+// socket or booting Electron (same pattern as startupQuit.ts / calendarCache.ts).
+//
+// Relationship to the Stream Deck handshake (ws-server.ts): the MECHANISM is
+// deliberately different — that server trusts every Origin-less local process
+// and its token only delegates trust to a browser-context property inspector,
+// while this token gates every request. What carries over is the idiom:
+// randomBytes(32).toString('hex'), loopback-only, reject browser origins.
+// See docs/mcp-server-spec.md §3.5 and docs/mcp-phase0-findings.md item 2.
+
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Why a rejection happened. Internal only — logs and (later) the settings
+ * surface may distinguish these, but the HTTP response must not: see
+ * unauthorizedResponse().
+ */
+export type BearerRejection = 'missing-header' | 'malformed-header' | 'wrong-token';
+
+export type BearerCheckResult = { ok: true } | { ok: false; reason: BearerRejection };
+
+/**
+ * Generate the pre-shared MCP bearer token: 32 bytes of CSPRNG output as
+ * 64 hex chars. Same recipe as the Stream Deck session token (ws-server.ts:69),
+ * but this one is persistent and rotatable rather than socket-lifetime.
+ */
+export function generateMcpToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+/**
+ * Check an incoming `Authorization` header against the configured token.
+ *
+ * Comparison is constant-time in the candidate token: both sides are hashed to
+ * fixed-length digests before timingSafeEqual, so neither content nor LENGTH of
+ * the wrong token shapes the timing (timingSafeEqual alone would throw on
+ * length mismatch, which is itself a timing signal).
+ *
+ * The scheme name is case-insensitive per RFC 7235; the token itself is not.
+ *
+ * @param header        the raw `Authorization` request header (node gives
+ *                      string | string[] | undefined; a repeated header is malformed)
+ * @param expectedToken the configured token. An EMPTY expected token never
+ *                      matches anything — a misconfigured listener must fail
+ *                      closed, not open.
+ */
+export function checkBearerToken(
+  header: string | string[] | undefined,
+  expectedToken: string,
+): BearerCheckResult {
+  if (header === undefined) return { ok: false, reason: 'missing-header' };
+  if (Array.isArray(header)) return { ok: false, reason: 'malformed-header' };
+
+  const match = /^Bearer[ ]+(.+)$/i.exec(header);
+  if (!match) return { ok: false, reason: 'malformed-header' };
+
+  // No explicit empty-expectedToken branch: the regex guarantees a non-empty
+  // candidate, and sha256('') never equals sha256(non-empty), so an empty
+  // configured token already fails closed below. Pinned by tests.
+
+  const presented = createHash('sha256').update(match[1]).digest();
+  const expected = createHash('sha256').update(expectedToken).digest();
+  if (!timingSafeEqual(presented, expected)) return { ok: false, reason: 'wrong-token' };
+
+  return { ok: true };
+}
+
+/**
+ * The one and only 401 the listener sends. Deliberately takes NO argument:
+ * missing, malformed, and wrong-token rejections must be indistinguishable to
+ * the caller, and a function that cannot see the reason cannot leak it.
+ * `WWW-Authenticate` is required alongside 401 by RFC 7235 §4.1.
+ */
+export function unauthorizedResponse(): {
+  status: 401;
+  headers: Record<string, string>;
+  body: string;
+} {
+  return {
+    status: 401,
+    headers: {
+      'content-type': 'application/json',
+      'www-authenticate': 'Bearer realm="dayGLANCE MCP"',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Unauthorized' },
+      id: null,
+    }),
+  };
+}

--- a/electron/mcpPort.test.ts
+++ b/electron/mcpPort.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_MCP_PORT, resolveMcpPort, describeBindFailure } from './mcpPort.js';
+
+// §3.4's rule under test: exactly one port comes out of resolution, an invalid
+// override surfaces as an error rather than silently landing on the default,
+// and a bind failure produces a loud, actionable message — never a retry.
+
+describe('resolveMcpPort', () => {
+  it('defaults to 7893, adjacent to the Stream Deck listener on 7892', () => {
+    expect(DEFAULT_MCP_PORT).toBe(7893);
+    expect(resolveMcpPort(undefined)).toEqual({ ok: true, port: 7893 });
+    expect(resolveMcpPort(null)).toEqual({ ok: true, port: 7893 });
+    expect(resolveMcpPort('')).toEqual({ ok: true, port: 7893 });
+    expect(resolveMcpPort('   ')).toEqual({ ok: true, port: 7893 });
+  });
+
+  it('accepts a valid numeric override', () => {
+    expect(resolveMcpPort(8000)).toEqual({ ok: true, port: 8000 });
+    expect(resolveMcpPort(1)).toEqual({ ok: true, port: 1 });
+    expect(resolveMcpPort(65535)).toEqual({ ok: true, port: 65535 });
+  });
+
+  it('accepts a decimal-string override (settings and env values are strings)', () => {
+    expect(resolveMcpPort('8000')).toEqual({ ok: true, port: 8000 });
+    expect(resolveMcpPort(' 7894 ')).toEqual({ ok: true, port: 7894 });
+  });
+
+  it('rejects port 0 — an ephemeral port moves every launch and breaks static client configs', () => {
+    const result = resolveMcpPort(0);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected rejection');
+    expect(result.reason).toContain('ephemeral'); // the message must say WHY, not just fail
+    expect(resolveMcpPort('0').ok).toBe(false);
+  });
+
+  it('rejects out-of-range, fractional, and non-numeric overrides', () => {
+    expect(resolveMcpPort(65536).ok).toBe(false);
+    expect(resolveMcpPort(-1).ok).toBe(false);
+    expect(resolveMcpPort(7893.5).ok).toBe(false);
+    expect(resolveMcpPort(NaN).ok).toBe(false);
+    expect(resolveMcpPort('789a').ok).toBe(false);
+    expect(resolveMcpPort('-1').ok).toBe(false);
+    expect(resolveMcpPort('7893.5').ok).toBe(false);
+    expect(resolveMcpPort(true).ok).toBe(false);
+    expect(resolveMcpPort({}).ok).toBe(false);
+  });
+
+  it('does NOT fall back to the default on an invalid override', () => {
+    // A user who set a port and silently got 7893 anyway has a listener
+    // running where they did not ask for it.
+    const result = resolveMcpPort('not-a-port');
+    expect(result.ok).toBe(false);
+    expect(result).not.toHaveProperty('port');
+  });
+
+  it('resolves to exactly one port — no alternates to scan', () => {
+    const result = resolveMcpPort(8000);
+    if (!result.ok) throw new Error('expected ok');
+    expect(typeof result.port).toBe('number');
+    // The whole resolution is {ok, port} — nothing iterable, no candidate list.
+    expect(Object.keys(result).sort()).toEqual(['ok', 'port']);
+  });
+});
+
+describe('describeBindFailure', () => {
+  it('names the port and the collision for EADDRINUSE, and says there is no scan', () => {
+    const msg = describeBindFailure(7893, { code: 'EADDRINUSE' });
+    expect(msg).toContain('7893');
+    expect(msg).toContain('already in use');
+    expect(msg).toContain('will not scan');
+  });
+
+  it('explains EACCES with the privileged-port hint', () => {
+    const msg = describeBindFailure(80, { code: 'EACCES' });
+    expect(msg).toContain('80');
+    expect(msg).toContain('EACCES');
+  });
+
+  it('falls back to the error code or message for anything else', () => {
+    expect(describeBindFailure(7893, { code: 'EADDRNOTAVAIL' })).toContain('EADDRNOTAVAIL');
+    expect(describeBindFailure(7893, { message: 'boom' })).toContain('boom');
+    expect(describeBindFailure(7893, {})).toContain('unknown error');
+  });
+});

--- a/electron/mcpPort.ts
+++ b/electron/mcpPort.ts
@@ -1,0 +1,78 @@
+// Port resolution for the MCP loopback listener (spec §3.4), extracted as pure
+// functions so the decisions can be unit-tested without binding a socket (same
+// pattern as startupQuit.ts / calendarCache.ts).
+//
+// THE §3.4 RULE THIS ENCODES: client configs are static text files. A listener
+// that silently moves to the next free port breaks every configured client
+// with no signal anywhere. So resolution produces exactly ONE port — never a
+// list, never an iterator — and a bind failure is surfaced loudly instead of
+// retried elsewhere. If you are adding port-scanning here, stop: the fix for a
+// collision is the user picking a port explicitly in settings.
+
+/** Adjacent to the Stream Deck listener on 7892. */
+export const DEFAULT_MCP_PORT = 7893;
+
+export type PortResolution =
+  | { ok: true; port: number }
+  | { ok: false; reason: string };
+
+/**
+ * Resolve the single port the listener will attempt to bind.
+ *
+ * - No override (undefined, null, or empty/whitespace string) → 7893.
+ * - An override must be an integer in [1, 65535], given as a number or a
+ *   decimal string (settings values and env vars arrive as strings).
+ * - Port 0 is rejected explicitly: the OS would assign an ephemeral port that
+ *   moves on every launch, which is the exact breakage the no-scan rule exists
+ *   to prevent.
+ *
+ * Invalid overrides return `ok: false` rather than falling back to the
+ * default: a user who set a port and got 7893 anyway has a listener running
+ * somewhere they did not ask for it.
+ */
+export function resolveMcpPort(override: unknown): PortResolution {
+  if (override === undefined || override === null) return { ok: true, port: DEFAULT_MCP_PORT };
+
+  let value: number;
+  if (typeof override === 'number') {
+    value = override;
+  } else if (typeof override === 'string') {
+    const trimmed = override.trim();
+    if (trimmed === '') return { ok: true, port: DEFAULT_MCP_PORT };
+    if (!/^\d+$/.test(trimmed)) {
+      return { ok: false, reason: `Invalid MCP port override: ${JSON.stringify(override)}` };
+    }
+    value = Number(trimmed);
+  } else {
+    return { ok: false, reason: `Invalid MCP port override of type ${typeof override}` };
+  }
+
+  if (!Number.isInteger(value)) {
+    return { ok: false, reason: `Invalid MCP port override: ${value} is not an integer` };
+  }
+  if (value === 0) {
+    return { ok: false, reason: 'MCP port 0 (ephemeral) would move on every launch; pick a fixed port' };
+  }
+  if (value < 1 || value > 65535) {
+    return { ok: false, reason: `Invalid MCP port override: ${value} is outside 1-65535` };
+  }
+  return { ok: true, port: value };
+}
+
+/**
+ * The loud half of "fail loudly": one message per bind failure, specific for
+ * the collision case so the eventual settings surface (Phase 5) can show the
+ * user something actionable. Never suggests, and must never gain, a retry.
+ */
+export function describeBindFailure(port: number, err: { code?: string; message?: string }): string {
+  if (err.code === 'EADDRINUSE') {
+    return `MCP server could not start: port ${port} is already in use by another process. ` +
+      'Pick a different port explicitly — dayGLANCE will not scan for a free one, because ' +
+      'configured MCP clients point at a fixed port.';
+  }
+  if (err.code === 'EACCES') {
+    return `MCP server could not start: binding 127.0.0.1:${port} was denied (${err.code}). ` +
+      'Ports below 1024 may require elevated privileges; pick a higher port.';
+  }
+  return `MCP server could not start on 127.0.0.1:${port}: ${err.code ?? err.message ?? 'unknown error'}`;
+}

--- a/electron/mcpRateLimit.test.ts
+++ b/electron/mcpRateLimit.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createWriteRateLimiter,
+  DEFAULT_WRITE_LIMIT_PER_MINUTE,
+  DEFAULT_WRITE_WINDOW_MS,
+} from './mcpRateLimit.js';
+
+// §4.3's damage bound under test. The limiter is the only thing standing
+// between a runaway agent loop and an unbounded write storm (plus the tray
+// reload volume each write triggers per §3.6), so the denial direction
+// matters as much as the allow direction.
+
+// Injectable clock, same shape as calendarCache.test.ts.
+function fakeClock(start = 1_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; }, rewind: (ms: number) => { t -= ms; } };
+}
+
+describe('createWriteRateLimiter', () => {
+  it('defaults to 30 writes per 60s window (spec §4.3)', () => {
+    expect(DEFAULT_WRITE_LIMIT_PER_MINUTE).toBe(30);
+    expect(DEFAULT_WRITE_WINDOW_MS).toBe(60_000);
+    const clock = fakeClock();
+    const limiter = createWriteRateLimiter({ now: clock.now });
+    for (let i = 0; i < 30; i++) expect(limiter.tryAcquire('tok')).toBe(true);
+    expect(limiter.tryAcquire('tok')).toBe(false);
+  });
+
+  it('allows up to the limit and refuses the write after it', () => {
+    const clock = fakeClock();
+    const limiter = createWriteRateLimiter({ limit: 3, windowMs: 1000, now: clock.now });
+    expect(limiter.tryAcquire('tok')).toBe(true);
+    expect(limiter.tryAcquire('tok')).toBe(true);
+    expect(limiter.tryAcquire('tok')).toBe(true);
+    expect(limiter.tryAcquire('tok')).toBe(false);
+  });
+
+  it('frees capacity as admissions age out of the sliding window', () => {
+    const clock = fakeClock();
+    const limiter = createWriteRateLimiter({ limit: 2, windowMs: 1000, now: clock.now });
+    limiter.tryAcquire('tok');            // t=0
+    clock.advance(600);
+    limiter.tryAcquire('tok');            // t=600
+    expect(limiter.tryAcquire('tok')).toBe(false); // both in window
+    clock.advance(500);                   // t=1100: the t=0 entry has aged out
+    expect(limiter.tryAcquire('tok')).toBe(true);
+    expect(limiter.tryAcquire('tok')).toBe(false); // t=600 + t=1100 fill it again
+  });
+
+  it('expires an admission at exactly windowMs age (trailing window is exclusive)', () => {
+    const clock = fakeClock();
+    const limiter = createWriteRateLimiter({ limit: 1, windowMs: 1000, now: clock.now });
+    expect(limiter.tryAcquire('tok')).toBe(true);
+    clock.advance(1000); // exactly windowMs later
+    expect(limiter.tryAcquire('tok')).toBe(true);
+  });
+
+  it('is sliding, not fixed-bucket: a boundary-straddling burst cannot double the rate', () => {
+    const clock = fakeClock();
+    const limiter = createWriteRateLimiter({ limit: 2, windowMs: 1000, now: clock.now });
+    clock.advance(900);
+    expect(limiter.tryAcquire('tok')).toBe(true);  // t=900
+    expect(limiter.tryAcquire('tok')).toBe(true);  // t=900
+    clock.advance(200);                            // t=1100 — a new "minute" in bucket terms
+    expect(limiter.tryAcquire('tok')).toBe(false); // still 2 in the trailing 1000ms
+  });
+
+  it('refused writes are not recorded and do not extend the lockout', () => {
+    const clock = fakeClock();
+    const limiter = createWriteRateLimiter({ limit: 1, windowMs: 1000, now: clock.now });
+    expect(limiter.tryAcquire('tok')).toBe(true);   // t=0, expires at t>1000
+    for (let i = 0; i < 10; i++) expect(limiter.tryAcquire('tok')).toBe(false);
+    clock.advance(1001);
+    // If refusals had been recorded, capacity would still be exhausted here.
+    expect(limiter.tryAcquire('tok')).toBe(true);
+  });
+
+  it('keys buckets independently per token', () => {
+    const clock = fakeClock();
+    const limiter = createWriteRateLimiter({ limit: 1, windowMs: 1000, now: clock.now });
+    expect(limiter.tryAcquire('tok-a')).toBe(true);
+    expect(limiter.tryAcquire('tok-a')).toBe(false);
+    expect(limiter.tryAcquire('tok-b')).toBe(true); // a's exhaustion never touches b
+  });
+
+  it('fails closed on a backwards clock jump: past admissions still count', () => {
+    const clock = fakeClock();
+    const limiter = createWriteRateLimiter({ limit: 2, windowMs: 1000, now: clock.now });
+    limiter.tryAcquire('tok');
+    limiter.tryAcquire('tok');
+    clock.rewind(5000); // NTP step: recorded timestamps are now in the "future"
+    expect(limiter.tryAcquire('tok')).toBe(false); // no fresh burst granted
+  });
+
+  it('never allows writes with a non-positive limit', () => {
+    const clock = fakeClock();
+    expect(createWriteRateLimiter({ limit: 0, now: clock.now }).tryAcquire('tok')).toBe(false);
+    expect(createWriteRateLimiter({ limit: -5, now: clock.now }).tryAcquire('tok')).toBe(false);
+  });
+
+  it('reports the in-window admission count for the write journal surface', () => {
+    const clock = fakeClock();
+    const limiter = createWriteRateLimiter({ limit: 5, windowMs: 1000, now: clock.now });
+    expect(limiter.countInWindow('tok')).toBe(0);
+    limiter.tryAcquire('tok');
+    limiter.tryAcquire('tok');
+    expect(limiter.countInWindow('tok')).toBe(2);
+    clock.advance(1001);
+    expect(limiter.countInWindow('tok')).toBe(0);
+  });
+
+  it('reset() drops all buckets (token rotation invalidates old keys wholesale)', () => {
+    const clock = fakeClock();
+    const limiter = createWriteRateLimiter({ limit: 1, windowMs: 1000, now: clock.now });
+    limiter.tryAcquire('tok');
+    expect(limiter.tryAcquire('tok')).toBe(false);
+    limiter.reset();
+    expect(limiter.tryAcquire('tok')).toBe(true);
+  });
+});

--- a/electron/mcpRateLimit.ts
+++ b/electron/mcpRateLimit.ts
@@ -1,0 +1,79 @@
+// Write rate limiting for the MCP listener (spec §4.3), extracted as a pure
+// factory so the limiting decisions can be unit-tested with an injectable
+// clock (same pattern as calendarCache.ts).
+//
+// WHY: the client-side approval flow is the consent surface; this limiter is
+// the damage bound for a runaway agent loop. 30 writes/minute (configurable)
+// also bounds tray-reload volume per §3.6.
+//
+// KEYING: there are no MCP sessions (spec §3.7 — the 2026-07-28 era has no
+// Mcp-Session-Id, and 2025-era clients are served statelessly), so buckets key
+// on the bearer token, the only stable per-caller identity. Module-scope state
+// closed over by the handler factory, never state on an McpServer instance.
+
+/** Spec §4.3 suggested cap. */
+export const DEFAULT_WRITE_LIMIT_PER_MINUTE = 30;
+export const DEFAULT_WRITE_WINDOW_MS = 60_000;
+
+export interface WriteRateLimiterOptions {
+  /** Writes allowed per window. Non-positive means writes are never allowed. */
+  limit?: number;
+  windowMs?: number;
+  /** Injectable clock so tests can advance time without waiting. */
+  now?: () => number;
+}
+
+/**
+ * Sliding-window limiter: a write is allowed while fewer than `limit` writes
+ * were admitted in the trailing `windowMs`. Sliding rather than fixed-bucket,
+ * so a burst straddling a bucket boundary cannot double the effective rate.
+ *
+ * Clock-jump posture is the OPPOSITE of calendarCache.isFresh: there, negative
+ * age fails open (one extra spawn is cheap); here, timestamps that appear to
+ * be in the future still COUNT against the limit (fail closed — the limiter is
+ * a safety bound, and a backwards NTP step must not grant a fresh burst).
+ */
+export function createWriteRateLimiter(opts: WriteRateLimiterOptions = {}) {
+  const limit = opts.limit ?? DEFAULT_WRITE_LIMIT_PER_MINUTE;
+  const windowMs = opts.windowMs ?? DEFAULT_WRITE_WINDOW_MS;
+  const now = opts.now ?? Date.now;
+
+  /** Admission timestamps per key, oldest first, pruned on each check. */
+  const buckets = new Map<string, number[]>();
+
+  return {
+    /**
+     * Try to admit one write for `key` (the bearer token). Returns whether the
+     * write may proceed; an admitted write is recorded, a refused one is not
+     * (refusals must not extend the lockout).
+     */
+    tryAcquire(key: string): boolean {
+      // No explicit limit<=0 early-out: `kept.length < limit` is already false
+      // for every non-positive limit (pinned by tests).
+      const t = now();
+      // A single lower bound implements both rules: in-window entries survive,
+      // and future entries (backwards clock jump) survive too, since ts > t
+      // implies ts > t - windowMs for any positive window.
+      const kept = (buckets.get(key) ?? []).filter((ts) => ts > t - windowMs);
+      const allowed = kept.length < limit;
+      if (allowed) kept.push(t);
+      if (kept.length > 0) {
+        buckets.set(key, kept);
+      } else {
+        buckets.delete(key);
+      }
+      return allowed;
+    },
+
+    /** Admissions currently counted against `key` — for the §4.3 journal/UI later. */
+    countInWindow(key: string): number {
+      const t = now();
+      return (buckets.get(key) ?? []).filter((ts) => ts > t - windowMs).length;
+    },
+
+    /** Drop all state — token rotation invalidates old keys wholesale. */
+    reset(): void {
+      buckets.clear();
+    },
+  };
+}

--- a/electron/mcpServer.ts
+++ b/electron/mcpServer.ts
@@ -1,0 +1,136 @@
+// MCP loopback listener — Phase 1 skeleton (docs/mcp-server-spec.md §10).
+//
+// Streamable HTTP on 127.0.0.1:<port>/mcp, served by @modelcontextprotocol/*
+// v2. Per spec §3.7, NOTHING app-level lives on the McpServer instance: the
+// factory below builds a disposable server per request, closing over
+// module-level state. The only long-lived objects are the node:http server
+// and the handler wrapper.
+//
+// Guard order per request: endpoint path → Host header (SDK) → Origin header
+// (SDK) → bearer token (ours, mcpAuth.ts). MCP-Protocol-Version enforcement is
+// deliberately ABSENT here — the SDK transport handles it (Phase 0 finding;
+// do not duplicate it).
+//
+// Phase 1 scope: one stub tool returning static data, dev flag only. No
+// renderer IPC (Phase 2), no consent gate or UI (Phase 5), no discovery file.
+
+import http from 'node:http';
+import { McpServer, createMcpHandler } from '@modelcontextprotocol/server';
+import {
+  toNodeHandler,
+  localhostHostValidation,
+  localhostOriginValidation,
+} from '@modelcontextprotocol/node';
+import { checkBearerToken, unauthorizedResponse } from './mcpAuth.js';
+import { resolveMcpPort, describeBindFailure } from './mcpPort.js';
+
+export const MCP_ENDPOINT_PATH = '/mcp';
+
+export interface McpServerOptions {
+  /** The pre-shared bearer token. Empty is refused — the listener fails closed. */
+  token: string;
+  /** Raw user/env port override; resolution and validation are mcpPort.ts's job. */
+  portOverride?: unknown;
+  log?: (msg: string) => void;
+  logError?: (msg: string) => void;
+}
+
+/**
+ * Start the MCP listener. Returns the http.Server (caller owns shutdown via
+ * `close()`), or null when it refuses to start — bad port override or missing
+ * token. Refusals are loud (spec §3.4): they log exactly why, and never
+ * fall back to another port or an unauthenticated mode.
+ */
+export function startMcpServer(opts: McpServerOptions): http.Server | null {
+  const log = opts.log ?? ((m: string) => console.log(m));
+  const logError = opts.logError ?? ((m: string) => console.error(m));
+
+  if (!opts.token) {
+    logError('[dayGLANCE] MCP server not started: no bearer token configured (refusing to listen unauthenticated).');
+    return null;
+  }
+  const resolved = resolveMcpPort(opts.portOverride);
+  if (!resolved.ok) {
+    logError(`[dayGLANCE] MCP server not started: ${resolved.reason}`);
+    return null;
+  }
+  const port = resolved.port;
+
+  // Fresh McpServer per request (spec §3.7). Tool registration is cheap; the
+  // instance is discarded when the response completes. Do not hoist the
+  // McpServer out of this factory — that is exactly the v1 cross-client
+  // leakage shape the v2 API exists to prevent.
+  const handler = createMcpHandler(
+    () => {
+      const server = new McpServer({ name: 'dayGLANCE', version: '0.0.1' });
+      server.registerTool(
+        'dayglance_ping',
+        {
+          description:
+            'Phase 1 stub: returns static data confirming the dayGLANCE MCP listener is reachable. ' +
+            'Real schedule/task tools arrive in Phase 2.',
+        },
+        async () => ({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ ok: true, server: 'dayGLANCE MCP (Phase 1 skeleton)' }),
+            },
+          ],
+        }),
+      );
+      return server;
+    },
+    { onerror: (err) => logError(`[dayGLANCE] MCP handler error: ${String(err)}`) },
+  );
+
+  const nodeHandler = toNodeHandler(handler, {
+    onerror: (err) => logError(`[dayGLANCE] MCP adapter error: ${String(err)}`),
+  });
+  // DNS-rebinding defense is SDK configuration, not hand-rolled code (§3.5).
+  // Note these guards write their own 403 and return false when they reject.
+  const validateHost = localhostHostValidation();
+  const validateOrigin = localhostOriginValidation();
+
+  const srv = http.createServer((req, res) => {
+    let path: string;
+    try {
+      path = new URL(req.url ?? '/', `http://127.0.0.1:${port}`).pathname;
+    } catch {
+      path = '/';
+    }
+    if (path !== MCP_ENDPOINT_PATH) {
+      res.writeHead(404, { 'content-type': 'text/plain' });
+      res.end('not found');
+      return;
+    }
+    if (!validateHost(req, res)) return;
+    if (!validateOrigin(req, res)) return;
+
+    const auth = checkBearerToken(req.headers['authorization'], opts.token);
+    if (!auth.ok) {
+      // One identical 401 for every rejection reason — see unauthorizedResponse().
+      const rejection = unauthorizedResponse();
+      res.writeHead(rejection.status, rejection.headers);
+      res.end(rejection.body);
+      return;
+    }
+
+    void nodeHandler(req, res);
+  });
+
+  // Same posture as ws-server.ts:30 — an unhandled 'error' on a fixed-port
+  // listener turns EADDRINUSE into an app-crashing exception. But louder than
+  // the WS server's log line, per §3.4: describeBindFailure names the port and
+  // the no-scan rule. (Phase 5 surfaces this in settings; log-only until then.)
+  srv.on('error', (err: NodeJS.ErrnoException) => {
+    logError(`[dayGLANCE] ${describeBindFailure(port, err)}`);
+  });
+
+  // Loopback only, never 0.0.0.0 (spec hard constraint).
+  srv.listen(port, '127.0.0.1', () => {
+    log(`[dayGLANCE] MCP server listening on http://127.0.0.1:${port}${MCP_ENDPOINT_PATH}`);
+  });
+
+  return srv;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@glance-apps/billing": "0.1.1",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.6.1",
+        "@modelcontextprotocol/node": "2.0.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -24,6 +26,7 @@
       "devDependencies": {
         "@electron/notarize": "^3.1.1",
         "@eslint/js": "^9.39.4",
+        "@modelcontextprotocol/client": "2.0.0",
         "@types/node": "^24.0.0",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
@@ -2607,6 +2610,18 @@
       "integrity": "sha512-cRdLWkX7AreC4h0Gz0lnxum/Nn/uq4OO+Jcjjxq8e4uhT5c3Z25kBDXXbA5VxLw5HGtHYBQanTy4QuYyTzBspw==",
       "license": "MIT"
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -3400,6 +3415,71 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -6987,6 +7067,29 @@
         "url": "https://github.com/bgub/eta?sponsor=1"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/exif-parser": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
@@ -7706,6 +7809,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -8551,6 +8664,16 @@
       "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/jpeg-js": {
@@ -9824,6 +9947,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.13.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkijs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2611,12 +2611,12 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.17",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ws": "^8.21.0"
   },
   "overrides": {
+    "@hono/node-server": ">=2.0.5",
     "serialize-javascript": ">=7.0.5",
     "brace-expansion@1": "^1.1.18",
     "brace-expansion@2": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@glance-apps/billing": "0.1.1",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.6.1",
+    "@modelcontextprotocol/node": "2.0.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",
@@ -52,6 +54,7 @@
   "devDependencies": {
     "@electron/notarize": "^3.1.1",
     "@eslint/js": "^9.39.4",
+    "@modelcontextprotocol/client": "2.0.0",
     "@types/node": "^24.0.0",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",

--- a/scripts/audit-check.mjs
+++ b/scripts/audit-check.mjs
@@ -24,6 +24,13 @@ const ACK = {
   // patch existed. Its bypass advisory (GHSA-rgw5-rvv9-x895) shipped in-major
   // fixes for BOTH (1.1.18 / 2.1.4 / 5.0.9), now forced via package.json
   // per-major overrides — so both advisories are FIXED, not acknowledged.
+  //
+  // GHSA-frvp-7c67-39w9 (@hono/node-server serve-static path traversal, via
+  // @modelcontextprotocol/node) is FIXED the same way: the SDK pins ^1.19.9,
+  // the fix landed in 2.0.5, and a package.json override forces >=2.0.5. The
+  // SDK only imports getRequestListener (verified compatible across the major;
+  // the vulnerable serve-static subpath was never even loaded), so drop the
+  // override when @modelcontextprotocol/node's own range moves to ^2.
   'GHSA-fx2h-pf6j-xcff': {
     disposition: 'defer', pkg: 'vite',
     reason: 'Dev-server `server.fs.deny` bypass (Windows only). Fix with the vite 5->8 upgrade.',


### PR DESCRIPTION
## Summary

Phase 1 of `docs/mcp-server-spec.md` §10, plus a one-line fix to the stale §13 spec-baseline citation that revision 3 missed.

**Step 1 — transport proven before building.** A minimal `createMcpHandler` + `toNodeHandler` server on plain `node:http` was run inside the Electron main process (Electron 43, under xvfb) and MCP Inspector connected, listed, and called a stub tool — confirming by execution what Phase 0 established only from docs and package inspection. Only then was the real module built.

**Step 2 — the pure functions**, in the `startupQuit.ts` / `calendarCache.ts` style, each unit-tested in both directions (35 tests) and mutation-verified (23/24 hand-applied mutants killed; the one survivor is an equivalent mutant — the range check's lower bound is shadowed by the dedicated port-0 rejection):

- `electron/mcpAuth.ts` — bearer check: hash-then-`timingSafeEqual` so neither content nor length of a wrong token shapes timing; missing/malformed/wrong-token distinguishable internally but collapsed to one identical 401 by a zero-argument `unauthorizedResponse()` (structurally unable to leak the reason). Token generation via the `ws-server.ts` idiom (`randomBytes(32).toString('hex')`).
- `electron/mcpPort.ts` — resolution to exactly one port (default 7893, validated override, port 0 rejected); invalid overrides error rather than silently falling back; `describeBindFailure` names the port and the §3.4 no-scan rule.
- `electron/mcpRateLimit.ts` — sliding-window write limiter, 30/min default, keyed on the bearer token per §3.7 (no sessions). Deliberately not wired to anything; writes arrive in Phase 3.

**Step 3 — wiring** (`electron/mcpServer.ts` + 11 lines in `main.ts`): fresh `McpServer` per request via the v2 factory (nothing app-level on the instance, per §3.7); SDK-provided `localhostHostValidation()` / `localhostOriginValidation()`; no hand-rolled `MCP-Protocol-Version` enforcement (SDK transport owns it); bearer check in front of the handler. Bound only when `DAYGLANCE_MCP_DEV=1`; token from `DAYGLANCE_MCP_TOKEN`; no UI, no consent gate, no discovery file (Phases 5–6). Fails closed without a token and loudly on `EADDRINUSE` without crashing the app (the `ws-server.ts` posture, louder message). Nothing touches `useElectronBridge.js`; no renderer IPC.

**Dependencies:** `@modelcontextprotocol/server` + `/node` pinned exactly at 2.0.0 (runtime), `/client` 2.0.0 (dev, for future tests).

## Exit criteria (all verified live, against the compiled module in Electron main)

1. ✅ MCP Inspector connects, lists `dayglance_ping`, and calls it.
2. ✅ Claude Code connects with a static `"type": "http"` config entry and calls the tool.
3. ✅ Missing, malformed (wrong scheme / no scheme / repeated header), and wrong bearer tokens all receive byte-identical 401s.
4. ✅ Browser Origins (`https://evil.example`, `null`) are rejected 403; a rebound Host header is rejected 403; valid token with no Origin or a localhost Origin passes.
5. ✅ All four pure functions tested and mutation-verified as above.

Tested: full suite 88 files / 1330 tests green; `tsc -p tsconfig.electron.json` clean (the v2 packages resolve under the repo's node10 `moduleResolution` — they ship top-level `main`/`types` alongside `exports`).

## Notes vs Phase 0 predictions

Everything Phase 0 predicted about SDK v2 held up at runtime; two environment-only wrinkles are documented in the PR thread history rather than code: the MCP Inspector's HTTP client trips over this CI container's proxy env (scrubbing `HTTPS_PROXY` fixes it — not a server issue), and Electron in the container needs `--no-sandbox` under xvfb.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_