### PR TITLE
MCP Phase 2: renderer IPC bridge and four read tools

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,6 +14,7 @@ import { APP_SCHEME, APP_HOST, APP_BASE_URL, resolveAppRequest } from './appProt
 import { shouldQuitOnAllWindowsClosed } from './startupQuit.js';
 import { initStartupLog, logStartup } from './startupLog.js';
 import { startMcpServer } from './mcpServer.js';
+import { createRendererBridge } from './mcpRendererBridge.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -883,14 +884,26 @@ app.whenReady().then(async () => {
 
   const win = createWindow();
   createWsServer(() => live(mainWindow));
-  // MCP listener — Phase 1: dev flag only, no settings UI or consent gate yet
-  // (those are Phase 5, docs/mcp-server-spec.md §10). Token comes from the
-  // environment for now; the discovery file is Phase 6. Off means off: without
-  // the flag no port is bound at all.
+  // MCP listener — Phase 2: read tools over renderer IPC, still dev flag only
+  // (settings UI and the consent gate are Phase 5, docs/mcp-server-spec.md
+  // §10). Token comes from the environment for now; the discovery file is
+  // Phase 6. Off means off: without the flag no port is bound at all.
   if (process.env['DAYGLANCE_MCP_DEV'] === '1') {
     startMcpServer({
       token: process.env['DAYGLANCE_MCP_TOKEN'] ?? '',
       portOverride: process.env['DAYGLANCE_MCP_PORT'],
+      readDeps: {
+        // Getter, not a reference: requests must target the CURRENT main
+        // window even if it is recreated (same posture as createWsServer).
+        bridge: createRendererBridge(() => live(mainWindow)),
+        now: Date.now,
+        // Resolved on the machine, never inferred from the client (§5.3).
+        timeZone: () => Intl.DateTimeFormat().resolvedOptions().timeZone,
+        // Device-calendar consent tier (§6.3). Phase 2 source is an env var;
+        // Phase 5 replaces this closure with the settings-backed tier and
+        // nothing in the tool code changes.
+        includeNativeEvents: () => process.env['DAYGLANCE_MCP_CALENDAR'] === '1',
+      },
     });
   }
   registerSubscriptionHandlers(win);

--- a/electron/mcpDates.test.ts
+++ b/electron/mcpDates.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { isValidLocalDate, localDateOf, dateEnvelope } from './mcpDates.js';
+
+// §5.3 is the correctness core of Phase 2: local calendar dates only, resolved
+// server-side, correct across DST boundaries in both directions. These tests
+// pin the boundaries with fixed UTC instants so they never depend on the
+// machine's own clock or zone.
+
+const utc = (s: string) => Date.parse(s);
+
+describe('isValidLocalDate', () => {
+  it('accepts real local calendar dates', () => {
+    expect(isValidLocalDate('2026-08-09')).toBe(true);
+    expect(isValidLocalDate('2026-01-01')).toBe(true);
+    expect(isValidLocalDate('2026-12-31')).toBe(true);
+  });
+
+  it('accepts Feb 29 only in leap years (divisible-by-4, century, 400 rules)', () => {
+    expect(isValidLocalDate('2028-02-29')).toBe(true);  // ordinary leap year
+    expect(isValidLocalDate('2026-02-29')).toBe(false); // not a leap year
+    expect(isValidLocalDate('2100-02-29')).toBe(false); // century, not /400
+    expect(isValidLocalDate('2000-02-29')).toBe(true);  // /400
+    expect(isValidLocalDate('2200-02-29')).toBe(false); // /200 but not /400 — pins the exact rule
+  });
+
+  it('rejects dates that do not exist', () => {
+    expect(isValidLocalDate('2026-02-30')).toBe(false);
+    expect(isValidLocalDate('2026-04-31')).toBe(false);
+    expect(isValidLocalDate('2026-13-01')).toBe(false);
+    expect(isValidLocalDate('2026-00-10')).toBe(false);
+    expect(isValidLocalDate('2026-06-00')).toBe(false);
+    expect(isValidLocalDate('2026-06-32')).toBe(false);
+  });
+
+  it('rejects anything with a time component, offset, or Z (§5.3: no UTC, no offsets)', () => {
+    expect(isValidLocalDate('2026-08-09T00:00:00Z')).toBe(false);
+    expect(isValidLocalDate('2026-08-09T12:00')).toBe(false);
+    expect(isValidLocalDate('2026-08-09+02:00')).toBe(false);
+    expect(isValidLocalDate('2026-08-09 ')).toBe(false);
+    expect(isValidLocalDate(' 2026-08-09')).toBe(false);
+  });
+
+  it('rejects non-canonical shapes and non-strings', () => {
+    expect(isValidLocalDate('2026-8-9')).toBe(false);
+    expect(isValidLocalDate('26-08-09')).toBe(false);
+    expect(isValidLocalDate('20260809')).toBe(false);
+    expect(isValidLocalDate('')).toBe(false);
+    expect(isValidLocalDate(undefined)).toBe(false);
+    expect(isValidLocalDate(null)).toBe(false);
+    expect(isValidLocalDate(20260809)).toBe(false);
+    expect(isValidLocalDate(new Date())).toBe(false);
+  });
+
+  it('accepts a date whose 2am does not exist — DST shortens hours, never the calendar', () => {
+    expect(isValidLocalDate('2026-03-08')).toBe(true); // US spring-forward day
+    expect(isValidLocalDate('2026-11-01')).toBe(true); // US fall-back day
+  });
+});
+
+describe('localDateOf — DST boundaries in both directions', () => {
+  // US spring forward: America/Chicago jumps 01:59:59 CST -> 03:00:00 CDT at
+  // 2026-03-08T08:00:00Z. The calendar date must not skip or repeat.
+  it('spring forward (America/Chicago, 2026-03-08)', () => {
+    expect(localDateOf(utc('2026-03-08T07:59:59Z'), 'America/Chicago')).toBe('2026-03-08'); // 01:59:59 CST
+    expect(localDateOf(utc('2026-03-08T08:00:00Z'), 'America/Chicago')).toBe('2026-03-08'); // 03:00:00 CDT
+    expect(localDateOf(utc('2026-03-08T05:59:59Z'), 'America/Chicago')).toBe('2026-03-07'); // 23:59:59 CST
+    expect(localDateOf(utc('2026-03-08T06:00:00Z'), 'America/Chicago')).toBe('2026-03-08'); // midnight CST
+    expect(localDateOf(utc('2026-03-09T04:59:59Z'), 'America/Chicago')).toBe('2026-03-08'); // 23:59:59 CDT — day ends an hour earlier in UTC
+    expect(localDateOf(utc('2026-03-09T05:00:00Z'), 'America/Chicago')).toBe('2026-03-09');
+  });
+
+  // US fall back: 01:59:59 CDT -> 01:00:00 CST at 2026-11-01T07:00:00Z.
+  // The 1am hour happens twice; the date stays 2026-11-01 throughout.
+  it('fall back (America/Chicago, 2026-11-01)', () => {
+    expect(localDateOf(utc('2026-11-01T06:59:59Z'), 'America/Chicago')).toBe('2026-11-01'); // 01:59:59 CDT (first 1am)
+    expect(localDateOf(utc('2026-11-01T07:00:00Z'), 'America/Chicago')).toBe('2026-11-01'); // 01:00:00 CST (second 1am)
+    expect(localDateOf(utc('2026-11-01T04:59:59Z'), 'America/Chicago')).toBe('2026-10-31'); // 23:59:59 CDT
+    expect(localDateOf(utc('2026-11-01T05:00:00Z'), 'America/Chicago')).toBe('2026-11-01'); // midnight CDT
+    expect(localDateOf(utc('2026-11-02T05:59:59Z'), 'America/Chicago')).toBe('2026-11-01'); // 23:59:59 CST — day ends an hour later in UTC
+    expect(localDateOf(utc('2026-11-02T06:00:00Z'), 'America/Chicago')).toBe('2026-11-02');
+  });
+
+  // Southern hemisphere runs the opposite direction on different dates —
+  // Australia/Sydney falls back 2026-04-05 and springs forward 2026-10-04.
+  it('southern hemisphere (Australia/Sydney)', () => {
+    expect(localDateOf(utc('2026-04-04T15:59:59Z'), 'Australia/Sydney')).toBe('2026-04-05'); // 02:59:59 AEDT (first pass)
+    expect(localDateOf(utc('2026-04-04T16:00:00Z'), 'Australia/Sydney')).toBe('2026-04-05'); // 02:00:00 AEST
+    expect(localDateOf(utc('2026-10-03T15:59:59Z'), 'Australia/Sydney')).toBe('2026-10-04'); // 01:59:59 AEST
+    expect(localDateOf(utc('2026-10-03T16:00:00Z'), 'Australia/Sydney')).toBe('2026-10-04'); // 03:00:00 AEDT
+  });
+
+  it('the same instant is different calendar dates in different zones', () => {
+    const t = utc('2026-08-09T03:00:00Z');
+    expect(localDateOf(t, 'America/Chicago')).toBe('2026-08-08'); // 22:00 the day before
+    expect(localDateOf(t, 'Asia/Tokyo')).toBe('2026-08-09');      // 12:00 that day
+    expect(localDateOf(t, 'UTC')).toBe('2026-08-09');
+  });
+
+  it('output is always the strict YYYY-MM-DD shape its own validator accepts', () => {
+    for (const tz of ['America/Chicago', 'Asia/Tokyo', 'Pacific/Kiritimati', 'Pacific/Niue']) {
+      const d = localDateOf(utc('2026-01-01T11:00:00Z'), tz);
+      expect(isValidLocalDate(d)).toBe(true);
+    }
+  });
+});
+
+describe('dateEnvelope', () => {
+  it('echoes the resolved date and IANA timezone (§5.3)', () => {
+    expect(dateEnvelope('2026-08-09', 'America/Chicago')).toEqual({
+      date: '2026-08-09',
+      timezone: 'America/Chicago',
+    });
+  });
+});

--- a/electron/mcpDates.ts
+++ b/electron/mcpDates.ts
@@ -1,0 +1,72 @@
+// Local-calendar-date semantics for the MCP tool surface (spec §5.3), extracted
+// as pure functions so the correctness core of Phase 2 can be unit-tested
+// without booting Electron (same pattern as startupQuit.ts / calendarCache.ts).
+//
+// THE §5.3 RULES THIS ENCODES:
+//  - All dates in the tool surface are LOCAL calendar dates, YYYY-MM-DD, no
+//    time component, no UTC, no offsets, no `Z`.
+//  - Every response echoes the resolved date and the IANA timezone.
+//  - The server never infers the current date from the client: `get_today`
+//    resolves it here, from the machine clock and the machine timezone.
+//
+// Both functions take the clock reading and timezone as ARGUMENTS (injectable,
+// like calendarCache's `now`), so tests can cross DST boundaries in any zone
+// without touching process state.
+
+/**
+ * Strict local-calendar-date validation: exactly `YYYY-MM-DD`, and a date that
+ * actually exists (2026-02-30 and 2026-13-01 are rejected; 2028-02-29 is
+ * accepted — leap year). No time component, no offset, no `Z` — a client that
+ * sends `2026-08-09T00:00:00Z` is asking a UTC question the tool surface
+ * refuses to answer (§5.3).
+ *
+ * Note DST does NOT shorten the calendar: every local date exists even when
+ * one of its wall-clock hours does not (2026-03-08 in America/Chicago has no
+ * 02:30, but the DATE is valid). Nonexistent/ambiguous TIMES matter only for
+ * Phase 3 writes.
+ */
+export function isValidLocalDate(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!m) return false;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  if (month < 1 || month > 12) return false;
+  const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  const daysInMonth = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+  return day >= 1 && day <= daysInMonth;
+}
+
+/**
+ * The local calendar date of `epochMs` in `timeZone`, as `YYYY-MM-DD`.
+ *
+ * en-CA is the locale whose date format IS YYYY-MM-DD; Intl does the timezone
+ * math (including DST) that hand-rolled offset arithmetic always gets wrong at
+ * the boundaries. This is the ONLY place `get_today` resolves from — never the
+ * client's idea of the date (§5.3).
+ */
+export function localDateOf(epochMs: number, timeZone: string): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date(epochMs));
+}
+
+/**
+ * The `{date, timezone}` echo every dated tool response carries (§5.3).
+ * Validation of caller-supplied dates happens BEFORE this — by construction an
+ * envelope only ever contains a date this module produced or validated.
+ */
+export interface DateEnvelope {
+  /** The resolved local calendar date the response is about. */
+  date: string;
+  /** The IANA timezone the server resolved (e.g. "America/Chicago"). */
+  timezone: string;
+}
+
+export function dateEnvelope(date: string, timeZone: string): DateEnvelope {
+  return { date, timezone: timeZone };
+}

--- a/electron/mcpPagination.test.ts
+++ b/electron/mcpPagination.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import {
+  paginate,
+  encodeCursor,
+  decodeCursor,
+  DEFAULT_LIST_LIMIT,
+  MAX_LIST_LIMIT,
+} from './mcpPagination.js';
+
+// §5.1 under test: default cap 50, truncation flag, working cursor — and the
+// §5.2 direction that bad inputs are validation failures, not silent clamps.
+
+const LIST = Array.from({ length: 120 }, (_, i) => ({ id: `t${i}` }));
+
+describe('paginate — happy path', () => {
+  it('defaults to a 50-item page with truncation flag and cursor', () => {
+    expect(DEFAULT_LIST_LIMIT).toBe(50);
+    const r = paginate(LIST, {});
+    if (!r.ok) throw new Error(r.reason);
+    expect(r.items).toHaveLength(50);
+    expect(r.items[0]).toEqual({ id: 't0' });
+    expect(r.truncated).toBe(true);
+    expect(r.nextCursor).not.toBeNull();
+    expect(r.total).toBe(120);
+  });
+
+  it('walks the whole list through cursors without gaps or repeats', () => {
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    for (let guard = 0; guard < 10; guard++) {
+      const r = paginate(LIST, { cursor });
+      if (!r.ok) throw new Error(r.reason);
+      seen.push(...r.items.map((t) => t.id));
+      if (!r.truncated) {
+        expect(r.nextCursor).toBeNull();
+        break;
+      }
+      cursor = r.nextCursor!;
+    }
+    expect(seen).toEqual(LIST.map((t) => t.id));
+  });
+
+  it('final page is not truncated and carries no cursor', () => {
+    const r = paginate(LIST, { cursor: encodeCursor(100) });
+    if (!r.ok) throw new Error(r.reason);
+    expect(r.items).toHaveLength(20);
+    expect(r.truncated).toBe(false);
+    expect(r.nextCursor).toBeNull();
+  });
+
+  it('a list at exactly the limit is not truncated', () => {
+    const r = paginate(LIST.slice(0, 50), {});
+    if (!r.ok) throw new Error(r.reason);
+    expect(r.items).toHaveLength(50);
+    expect(r.truncated).toBe(false);
+    expect(r.nextCursor).toBeNull();
+  });
+
+  it('honors an explicit limit', () => {
+    const r = paginate(LIST, { limit: 10 });
+    if (!r.ok) throw new Error(r.reason);
+    expect(r.items).toHaveLength(10);
+    expect(r.truncated).toBe(true);
+  });
+
+  it('a cursor at or past the end returns an empty final page (list may have shrunk)', () => {
+    const r = paginate(LIST, { cursor: encodeCursor(120) });
+    if (!r.ok) throw new Error(r.reason);
+    expect(r.items).toEqual([]);
+    expect(r.truncated).toBe(false);
+    expect(r.nextCursor).toBeNull();
+    const r2 = paginate(LIST, { cursor: encodeCursor(10_000) });
+    if (!r2.ok) throw new Error(r2.reason);
+    expect(r2.items).toEqual([]);
+  });
+
+  it('an empty list yields an empty, unt runcated page', () => {
+    const r = paginate([], {});
+    if (!r.ok) throw new Error(r.reason);
+    expect(r.items).toEqual([]);
+    expect(r.truncated).toBe(false);
+    expect(r.nextCursor).toBeNull();
+    expect(r.total).toBe(0);
+  });
+});
+
+describe('paginate — validation failures, never silent clamps', () => {
+  it('rejects a limit above the ceiling instead of clamping', () => {
+    const r = paginate(LIST, { limit: MAX_LIST_LIMIT + 1 });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.reason).toContain(String(MAX_LIST_LIMIT));
+  });
+
+  it('accepts a limit exactly at the ceiling', () => {
+    expect(paginate(LIST, { limit: MAX_LIST_LIMIT }).ok).toBe(true);
+  });
+
+  it('rejects zero, negative, fractional, and non-numeric limits', () => {
+    for (const limit of [0, -1, 2.5, '50', null, NaN]) {
+      const r = paginate(LIST, { limit });
+      expect(r.ok, `limit ${String(limit)}`).toBe(false);
+    }
+  });
+
+  it('rejects cursors it did not mint', () => {
+    for (const cursor of ['', 'abc', 'dgc1.!!!', 'dgc2.eyJvIjowfQ', 42, {}]) {
+      const r = paginate(LIST, { cursor });
+      expect(r.ok, `cursor ${String(cursor)}`).toBe(false);
+    }
+  });
+
+  it('rejects a hand-tampered cursor whose offset is negative or fractional', () => {
+    const forge = (o: unknown) => 'dgc1.' + Buffer.from(JSON.stringify({ o })).toString('base64url');
+    for (const o of [-1, 1.5, '3', null]) {
+      expect(paginate(LIST, { cursor: forge(o) }).ok, `offset ${String(o)}`).toBe(false);
+    }
+  });
+});
+
+describe('cursor round-trip', () => {
+  it('decode(encode(n)) === n', () => {
+    for (const n of [0, 1, 50, 119, 10_000]) {
+      expect(decodeCursor(encodeCursor(n))).toBe(n);
+    }
+  });
+
+  it('cursors are opaque-prefixed and versioned', () => {
+    expect(encodeCursor(0).startsWith('dgc1.')).toBe(true);
+  });
+});

--- a/electron/mcpPagination.ts
+++ b/electron/mcpPagination.ts
@@ -1,0 +1,93 @@
+// Pagination for MCP list tools (spec §5.1: cap the default, return a
+// truncation flag plus cursor), extracted as pure functions so the paging
+// decisions can be unit-tested without Electron or the SDK.
+//
+// There are NO sessions on this transport (§3.7), so the cursor must be fully
+// self-contained: an opaque base64url token carrying the offset. Opaque so
+// clients cannot construct or increment one themselves and then depend on the
+// encoding; self-contained so any request, from any client instance, can
+// resume the walk. The list can mutate between pages — offset resume is the
+// documented, bounded inaccuracy (a shifted item may repeat or be skipped),
+// which is acceptable for an inbox read and costs no server state.
+
+/** §5.1 suggested default cap: an unbounded dump wastes the client's context. */
+export const DEFAULT_LIST_LIMIT = 50;
+/** Upper bound on caller-supplied limits; a model asking for 10_000 gets an error, not a dump. */
+export const MAX_LIST_LIMIT = 200;
+
+const CURSOR_PREFIX = 'dgc1.'; // dayGLANCE cursor, version 1
+
+export function encodeCursor(offset: number): string {
+  return CURSOR_PREFIX + Buffer.from(JSON.stringify({ o: offset }), 'utf8').toString('base64url');
+}
+
+/** Returns the offset, or null for anything not produced by encodeCursor. */
+export function decodeCursor(cursor: string): number | null {
+  if (!cursor.startsWith(CURSOR_PREFIX)) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor.slice(CURSOR_PREFIX.length), 'base64url').toString('utf8')) as {
+      o?: unknown;
+    };
+    const offset = parsed.o;
+    if (typeof offset !== 'number' || !Number.isInteger(offset) || offset < 0) return null;
+    return offset;
+  } catch {
+    return null;
+  }
+}
+
+export type PageResult<T> =
+  | {
+      ok: true;
+      items: T[];
+      /** True when items remain past this page — the §5.1 truncation flag. */
+      truncated: boolean;
+      /** Present exactly when truncated. */
+      nextCursor: string | null;
+      /** Total items in the full list, so the model can report "50 of 312". */
+      total: number;
+    }
+  | { ok: false; reason: string };
+
+/**
+ * Slice one page. Invalid limit/cursor inputs are validation failures the tool
+ * layer maps to a typed error (§5.2) — never silently clamped to something the
+ * caller did not ask for, with one exception: a limit above MAX_LIST_LIMIT is
+ * an error rather than a clamp, so the model learns the real ceiling.
+ */
+export function paginate<T>(items: T[], opts: { limit?: unknown; cursor?: unknown }): PageResult<T> {
+  let limit = DEFAULT_LIST_LIMIT;
+  if (opts.limit !== undefined) {
+    if (typeof opts.limit !== 'number' || !Number.isInteger(opts.limit) || opts.limit < 1) {
+      return { ok: false, reason: `limit must be an integer >= 1, got ${JSON.stringify(opts.limit)}` };
+    }
+    if (opts.limit > MAX_LIST_LIMIT) {
+      return { ok: false, reason: `limit must be <= ${MAX_LIST_LIMIT}, got ${opts.limit}` };
+    }
+    limit = opts.limit;
+  }
+
+  let offset = 0;
+  if (opts.cursor !== undefined) {
+    if (typeof opts.cursor !== 'string') {
+      return { ok: false, reason: 'cursor must be a string from a previous response' };
+    }
+    const decoded = decodeCursor(opts.cursor);
+    if (decoded === null) {
+      return { ok: false, reason: 'cursor is not valid; use the nextCursor from a previous response' };
+    }
+    offset = decoded;
+  }
+
+  // An offset at or past the end returns an empty final page rather than an
+  // error: the list may legitimately have shrunk since the cursor was issued.
+  const page = items.slice(offset, offset + limit);
+  const truncated = offset + limit < items.length;
+  return {
+    ok: true,
+    items: page,
+    truncated,
+    nextCursor: truncated ? encodeCursor(offset + limit) : null,
+    total: items.length,
+  };
+}

--- a/electron/mcpReadTools.ts
+++ b/electron/mcpReadTools.ts
@@ -1,0 +1,150 @@
+// The four Phase 2 read tools (spec §5.1), registered onto a per-request
+// McpServer instance by the mcpServer.ts factory.
+//
+// §3.7 DISCIPLINE: this module holds no state. Everything the tools need
+// arrives as `deps` — the renderer bridge, the clock, the timezone, and the
+// device-calendar consent tier — owned at module scope by main.ts and closed
+// over by the factory. Phase 5 swaps the tier's SOURCE (env var → settings)
+// without touching anything in this file: `includeNativeEvents` is already a
+// function, not a value.
+//
+// §5.2 ERRORS: every failure is a tool error (isError: true) with a JSON body
+// carrying { error: { code, message } } the model can branch on. Codes used
+// here: renderer_unavailable, not_found, validation, internal. An unavailable
+// renderer is NEVER an empty result — an empty result set is indistinguishable
+// from an empty day, and the model would confidently report a clear schedule.
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/server';
+import type { RendererBridge } from './mcpRendererBridge.js';
+import { isValidLocalDate, localDateOf, dateEnvelope } from './mcpDates.js';
+import { paginate, DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT } from './mcpPagination.js';
+
+export interface ReadToolDeps {
+  bridge: RendererBridge;
+  /** Injectable clock, same idiom as calendarCache.ts. */
+  now: () => number;
+  /** The IANA timezone the server resolves — never inferred from the client (§5.3). */
+  timeZone: () => string;
+  /** Device-calendar consent tier (§6.3). Phase 2 reads an env var behind this; Phase 5 swaps the source. */
+  includeNativeEvents: () => boolean;
+}
+
+type ToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+};
+
+const ok = (data: Record<string, unknown>): ToolResult => ({
+  content: [{ type: 'text', text: JSON.stringify(data) }],
+  structuredContent: data,
+});
+
+const toolError = (code: string, message: string): ToolResult => ({
+  isError: true,
+  content: [{ type: 'text', text: JSON.stringify({ error: { code, message } }) }],
+});
+
+/** Map a renderer bridge failure onto the §5.2 typed error, verbatim codes. */
+const bridgeError = (r: { ok: false; error: { code: string; message: string } }): ToolResult =>
+  toolError(r.error.code, r.error.message);
+
+const NATIVE_NOTE =
+  ' Items with type "device_calendar_event" are read-only device calendar events: ' +
+  'dayGLANCE cannot modify, move, resize, or complete them.';
+
+export function registerReadTools(server: McpServer, deps: ReadToolDeps): void {
+  const getDay = async (date: string): Promise<ToolResult> => {
+    const r = await deps.bridge.request('get_day', {
+      date,
+      include_native: deps.includeNativeEvents(),
+    });
+    if (!r.ok) return bridgeError(r);
+    const data = r.data as Record<string, unknown>;
+    return ok({ ...dateEnvelope(date, deps.timeZone()), ...data });
+  };
+
+  server.registerTool(
+    'dayglance_get_today',
+    {
+      description:
+        "Today's schedule from dayGLANCE. Resolves the current LOCAL calendar date on the " +
+        'user\'s machine — use this instead of guessing the date. Response echoes the resolved ' +
+        'date and IANA timezone; times are local wall-clock HH:MM.' + NATIVE_NOTE,
+    },
+    async () => getDay(localDateOf(deps.now(), deps.timeZone())),
+  );
+
+  server.registerTool(
+    'dayglance_get_day',
+    {
+      description:
+        'The dayGLANCE schedule for one LOCAL calendar date (YYYY-MM-DD, no time component, ' +
+        'no UTC, no offsets). Response echoes the resolved date and IANA timezone; times are ' +
+        'local wall-clock HH:MM. For the current date, prefer dayglance_get_today.' + NATIVE_NOTE,
+      inputSchema: z.object({
+        date: z.string().describe('Local calendar date, strict YYYY-MM-DD. Not a timestamp.'),
+      }),
+    },
+    async ({ date }) => {
+      if (!isValidLocalDate(date)) {
+        return toolError(
+          'validation',
+          `date must be a real local calendar date in strict YYYY-MM-DD form (no time, no timezone), got ${JSON.stringify(date)}`,
+        );
+      }
+      return getDay(date);
+    },
+  );
+
+  server.registerTool(
+    'dayglance_list_unscheduled_tasks',
+    {
+      description:
+        "The dayGLANCE inbox: tasks not yet scheduled onto a day. Paginated — default page " +
+        `${DEFAULT_LIST_LIMIT}, max ${MAX_LIST_LIMIT}; when truncated is true, pass next_cursor ` +
+        'back as cursor for the next page.',
+      inputSchema: z.object({
+        limit: z.number().int().optional().describe(`Page size, 1-${MAX_LIST_LIMIT}. Default ${DEFAULT_LIST_LIMIT}.`),
+        cursor: z.string().optional().describe('Opaque cursor from a previous response\'s next_cursor.'),
+      }),
+    },
+    async ({ limit, cursor }) => {
+      const r = await deps.bridge.request('list_unscheduled', {});
+      if (!r.ok) return bridgeError(r);
+      const items = (r.data as { items: unknown[] }).items ?? [];
+      const page = paginate(items, { limit, cursor });
+      if (!page.ok) return toolError('validation', page.reason);
+      return ok({
+        items: page.items,
+        truncated: page.truncated,
+        next_cursor: page.nextCursor,
+        total: page.total,
+        timezone: deps.timeZone(),
+      });
+    },
+  );
+
+  server.registerTool(
+    'dayglance_get_goal_progress',
+    {
+      description:
+        'Goal and project progress from dayGLANCE. Progress is duration-weighted, matching ' +
+        "what the app itself shows. Scope with goal_id for one goal's tree; window is " +
+        "'active' (default) or 'all' (includes archived/completed goals and projects).",
+      inputSchema: z.object({
+        goal_id: z.string().optional().describe('Narrow to one goal by id.'),
+        window: z.enum(['active', 'all']).optional().describe("Status scope. Default 'active'."),
+      }),
+    },
+    async ({ goal_id, window }) => {
+      const params: Record<string, unknown> = {};
+      if (goal_id !== undefined) params['goal_id'] = goal_id;
+      if (window !== undefined) params['window'] = window;
+      const r = await deps.bridge.request('goal_progress', params);
+      if (!r.ok) return bridgeError(r);
+      return ok({ ...(r.data as Record<string, unknown>), timezone: deps.timeZone() });
+    },
+  );
+}

--- a/electron/mcpRendererBridge.ts
+++ b/electron/mcpRendererBridge.ts
@@ -1,0 +1,119 @@
+// Main→renderer request/response channel for MCP reads (spec §10 Phase 2),
+// with the §3.3 health check built into every call.
+//
+// HEALTH CHECK, NOT EXISTENCE CHECK: a crashed renderer leaves a mainWindow
+// object that live() still considers healthy — isDestroyed() does not catch a
+// dead render process (render-process-gone only logs; see main.ts). So no
+// answer within the timeout means UNAVAILABLE, regardless of what the window
+// object claims. The renderer answers synchronously inside its IPC callback
+// (no React render round-trip — see useMcpBridge.js), so the timeout can be
+// short: an alive renderer replies in single-digit milliseconds even while
+// hidden and background-throttled, because IPC delivery is not a timer.
+//
+// TRAY GUARD: requests are only ever sent to the main window's webContents,
+// and responses from ANY other sender are dropped here — so the tray popup
+// (which runs the same App tree on a stale snapshot) can never answer even if
+// its renderer were subscribed. Same posture as the tray:data-changed guard.
+
+import { BrowserWindow, ipcMain } from 'electron';
+
+/** One-second ping ceiling: ~100x the expected reply latency of a live renderer. */
+export const PING_TIMEOUT_MS = 1000;
+/** Data requests get headroom for a large day payload or a GC pause. */
+export const REQUEST_TIMEOUT_MS = 3000;
+
+export type RendererResult =
+  | { ok: true; data: unknown }
+  | { ok: false; error: { code: string; message: string } };
+
+const UNAVAILABLE: RendererResult = {
+  ok: false,
+  error: {
+    code: 'renderer_unavailable',
+    message:
+      'The dayGLANCE window is not responding (it may have crashed or be restarting). ' +
+      'Data is temporarily unreadable — this is NOT an empty schedule. Retry shortly.',
+  },
+};
+
+export interface RendererBridge {
+  /** Send one request; resolves with the renderer's answer or a typed unavailable error. Never rejects, never hangs. */
+  request(method: string, params?: unknown, timeoutMs?: number): Promise<RendererResult>;
+  /** The §3.3 health check: cheap, short-timeout round trip. */
+  ping(): Promise<boolean>;
+  dispose(): void;
+}
+
+/**
+ * Accepts a getter (never a captured window reference) for the same reason
+ * ws-server.ts does: the main window can be recreated, and requests must
+ * always target the current one.
+ */
+export function createRendererBridge(getMainWindow: () => BrowserWindow | null): RendererBridge {
+  let nextId = 1;
+  const pending = new Map<number, { resolve: (r: RendererResult) => void; timer: NodeJS.Timeout }>();
+
+  const onResponse = (event: Electron.IpcMainEvent, raw: unknown): void => {
+    // Only the main window may answer. A response from the tray popup (or any
+    // future window) is dropped unanswered; the request then times out to
+    // unavailable rather than being served from a stale snapshot.
+    const mw = getMainWindow();
+    if (!mw || event.sender !== mw.webContents) return;
+
+    const response = raw as { id?: unknown; ok?: unknown; data?: unknown; error?: unknown };
+    if (typeof response?.id !== 'number') return;
+    const entry = pending.get(response.id);
+    if (!entry) return; // late reply after timeout — already answered unavailable
+    pending.delete(response.id);
+    clearTimeout(entry.timer);
+
+    if (response.ok === true) {
+      entry.resolve({ ok: true, data: response.data });
+    } else {
+      const err = (response.error ?? {}) as { code?: unknown; message?: unknown };
+      entry.resolve({
+        ok: false,
+        error: {
+          code: typeof err.code === 'string' ? err.code : 'internal',
+          message: typeof err.message === 'string' ? err.message : 'Renderer reported an error',
+        },
+      });
+    }
+  };
+  ipcMain.on('mcp:response', onResponse);
+
+  const request = (method: string, params: unknown = {}, timeoutMs = REQUEST_TIMEOUT_MS): Promise<RendererResult> => {
+    const mw = getMainWindow();
+    if (!mw) return Promise.resolve(UNAVAILABLE);
+
+    return new Promise((resolve) => {
+      const id = nextId++;
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        resolve(UNAVAILABLE);
+      }, timeoutMs);
+      pending.set(id, { resolve, timer });
+      try {
+        mw.webContents.send('mcp:request', { id, method, params });
+      } catch {
+        // A destroyed webContents throws synchronously — same verdict.
+        pending.delete(id);
+        clearTimeout(timer);
+        resolve(UNAVAILABLE);
+      }
+    });
+  };
+
+  return {
+    request,
+    ping: async () => (await request('ping', {}, PING_TIMEOUT_MS)).ok,
+    dispose: () => {
+      ipcMain.removeListener('mcp:response', onResponse);
+      for (const [id, entry] of pending) {
+        clearTimeout(entry.timer);
+        entry.resolve(UNAVAILABLE);
+        pending.delete(id);
+      }
+    },
+  };
+}

--- a/electron/mcpServer.ts
+++ b/electron/mcpServer.ts
@@ -23,6 +23,7 @@ import {
 } from '@modelcontextprotocol/node';
 import { checkBearerToken, unauthorizedResponse } from './mcpAuth.js';
 import { resolveMcpPort, describeBindFailure } from './mcpPort.js';
+import { registerReadTools, type ReadToolDeps } from './mcpReadTools.js';
 
 export const MCP_ENDPOINT_PATH = '/mcp';
 
@@ -31,6 +32,13 @@ export interface McpServerOptions {
   token: string;
   /** Raw user/env port override; resolution and validation are mcpPort.ts's job. */
   portOverride?: unknown;
+  /**
+   * Dependencies for the read tools (Phase 2): renderer bridge, clock,
+   * timezone, and consent-tier sources. Owned by main.ts at module scope and
+   * closed over by the per-request factory (§3.7). Optional so the listener
+   * can still start in a pure-skeleton mode (tests, early dev).
+   */
+  readDeps?: ReadToolDeps;
   log?: (msg: string) => void;
   logError?: (msg: string) => void;
 }
@@ -67,18 +75,19 @@ export function startMcpServer(opts: McpServerOptions): http.Server | null {
         'dayglance_ping',
         {
           description:
-            'Phase 1 stub: returns static data confirming the dayGLANCE MCP listener is reachable. ' +
-            'Real schedule/task tools arrive in Phase 2.',
+            'Connectivity check: returns static data confirming the dayGLANCE MCP listener is reachable. ' +
+            'Does not touch user data.',
         },
         async () => ({
           content: [
             {
               type: 'text',
-              text: JSON.stringify({ ok: true, server: 'dayGLANCE MCP (Phase 1 skeleton)' }),
+              text: JSON.stringify({ ok: true, server: 'dayGLANCE MCP' }),
             },
           ],
         }),
       );
+      if (opts.readDeps) registerReadTools(server, opts.readDeps);
       return server;
     },
     { onerror: (err) => logError(`[dayGLANCE] MCP handler error: ${String(err)}`) },

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -64,6 +64,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // clock tick, which would reload the tray four times a minute for nothing.
   notifyDataChanged: () => ipcRenderer.send('tray:data-changed'),
 
+  // MCP read bridge (main window only — the tray never subscribes, see
+  // src/hooks/useMcpBridge.js). Main sends correlated requests over
+  // 'mcp:request'; the renderer answers on 'mcp:response'. The main-process
+  // side additionally drops responses from any webContents other than the
+  // main window's (electron/mcpRendererBridge.ts).
+  onMcpRequest: (callback: (request: unknown) => void) => {
+    const handler = (_: Electron.IpcRendererEvent, request: unknown) => callback(request);
+    ipcRenderer.on('mcp:request', handler);
+    return () => ipcRenderer.removeListener('mcp:request', handler);
+  },
+  mcpRespond: (response: unknown) => ipcRenderer.send('mcp:response', response),
+
   // Show or clear the reminder dot (●) next to the tray icon.
   setTrayIndicator: (on: boolean) => ipcRenderer.send('tray:set-indicator', on),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^17.0.8",
-        "ws": "^8.21.0"
+        "ws": "^8.21.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@electron/notarize": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^17.0.8",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "zod": "^4.4.3"
   },
   "overrides": {
     "@hono/node-server": ">=2.0.5",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -128,6 +128,7 @@ import useNewTaskInput from './hooks/useNewTaskInput.js';
 import useTaskFormHelpers from './hooks/useTaskFormHelpers.js';
 import useTaskActions from './hooks/useTaskActions.js';
 import useElectronBridge from './hooks/useElectronBridge.js';
+import useMcpBridge from './hooks/useMcpBridge.js';
 import useRecycleBin from './hooks/useRecycleBin.js';
 import useReminderEngine from './hooks/useReminderEngine.js';
 import useReminders from './hooks/useReminders.js';
@@ -6776,6 +6777,19 @@ const DayPlanner = () => {
       })
       .filter(s => !s.isOverdue && s.date === todayStr && s.startTime);
   }, [goalsProjectsEnabled, hgVisibleProjects, currentTime]);
+
+  // MCP read bridge (docs/mcp-server-spec.md §10 Phase 2): answers main-process
+  // data requests from live state. Inert in the tray popup and outside Electron.
+  // Deliberately its own hook + tested pure model (src/utils/mcpReadModel.js),
+  // NOT part of useElectronBridge — see the §11 risk register.
+  useMcpBridge({
+    tasks,
+    recurringTasks,
+    unscheduledTasks,
+    goals,
+    projects,
+    isVisibleForUser,
+  });
 
   useElectronBridge({
     todayAgenda,

--- a/src/hooks/useMcpBridge.js
+++ b/src/hooks/useMcpBridge.js
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react';
+import { isTrayMode } from '../utils/trayMode.js';
+import { handleMcpRequest } from '../utils/mcpReadModel.js';
+
+// The renderer half of the MCP IPC channel (docs/mcp-server-spec.md §10
+// Phase 2), following the useTrayPopupVisible precedent from PR #1302: this
+// hook is a thin subscription and nothing else — every decision lives in the
+// unit-tested pure module src/utils/mcpReadModel.js. Deliberately NOT in
+// useElectronBridge.js, which has no test coverage (§11 risk register).
+//
+// MAIN WINDOW ONLY. The tray popup runs this same App tree but holds a
+// snapshot as of its last reload — answering from it would serve stale data.
+// The main process also drops responses from any sender other than the main
+// window (electron/mcpRendererBridge.ts), so this bail is the second of two
+// independent guards.
+//
+// Requests are answered synchronously from a ref of the CURRENT state slices
+// — live React state, exactly what the user sees — inside the IPC callback
+// itself. No setState, no render round-trip, so hidden-window throttling
+// cannot delay the reply: if this renderer is alive, the answer is immediate,
+// which is what makes the main process's short ping timeout (§3.3 health
+// check, not existence check) safe.
+export default function useMcpBridge(state) {
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  useEffect(() => {
+    if (isTrayMode) return undefined;
+    if (!window.electronAPI?.onMcpRequest) return undefined;
+    return window.electronAPI.onMcpRequest((request) => {
+      let response;
+      try {
+        response = handleMcpRequest(stateRef.current, request);
+      } catch (err) {
+        // A throwing model must still answer — silence here would read as a
+        // dead renderer and turn one bad request into "dayGLANCE unavailable".
+        response = { ok: false, error: { code: 'internal', message: String(err?.message ?? err) } };
+      }
+      window.electronAPI.mcpRespond({ id: request?.id, ...response });
+    });
+  }, []);
+}

--- a/src/utils/mcpReadModel.js
+++ b/src/utils/mcpReadModel.js
@@ -1,0 +1,221 @@
+// Pure read models for the MCP tool surface (docs/mcp-server-spec.md §5.1),
+// following the trayFetchGate.js precedent from PR #1302: the React-coupled
+// part (src/hooks/useMcpBridge.js) stays a thin subscription, and every
+// decision that matters lives here, dependency-free and unit-tested.
+//
+// READ SOURCE: these functions take LIVE React state slices — what the user
+// sees in the main window right now — never localStorage. That is deliberate:
+// _native device-calendar events are never persisted (useDataPersistence.js
+// filters them out of every write), so a localStorage read could never include
+// them, and everything else would lag state by one commit for no benefit.
+//
+// _native events (spec §5.1, revision 4): flagged with the distinct type
+// 'device_calendar_event' plus read_only: true in ALL output, and included
+// only when the caller (the Electron main process, which owns the consent
+// tier) asks for them via include_native. The tier decision never lives here.
+
+import { getOccurrencesInRange } from './recurrenceEngine.js';
+import { calculateGoalProgress } from './goalProgress.js';
+import { calculateProjectProgress } from './projectProgress.js';
+
+/**
+ * The §5.1 distinct type flag. 'device_calendar_event' marks data that came
+ * from the user's device calendar (EventKit) rather than from dayGLANCE, so
+ * neither the model nor a human reading a transcript can confuse the two.
+ */
+export function blockType(task) {
+  if (task._native) return 'device_calendar_event';
+  if (task.isRecurring) return 'recurring_task';
+  return 'task';
+}
+
+/** One scheduled block in tool output. Field names are snake_case wire names. */
+export function toBlock(task) {
+  const type = blockType(task);
+  const block = {
+    id: task.id,
+    type,
+    title: task.title ?? '',
+    date: task.date ?? null,
+    start_time: task.isAllDay ? null : (task.startTime ?? null), // local wall-clock HH:MM (§5.3)
+    duration_minutes: typeof task.duration === 'number' ? task.duration : null,
+    all_day: !!task.isAllDay,
+    completed: !!task.completed,
+  };
+  if (task.projectId) block.project_id = task.projectId;
+  // Device calendar events cannot be modified through dayGLANCE (EventKit
+  // read access only) — carried on every item, not just in tool descriptions.
+  if (type === 'device_calendar_event') block.read_only = true;
+  return block;
+}
+
+/**
+ * Expand recurring templates into instances for ONE date. Mirrors the
+ * App.jsx expansion (exception overrides per field) with one deliberate
+ * difference: no "hide past uncompleted" rule — that is a UI display choice,
+ * and an MCP read of a past day should report what was scheduled.
+ */
+export function expandRecurringForDate(recurringTasks, date) {
+  const instances = [];
+  for (const template of recurringTasks ?? []) {
+    const occurrences = getOccurrencesInRange(template, date, date);
+    for (const dateStr of occurrences) {
+      if (dateStr !== date) continue;
+      const exception = template.exceptions?.[dateStr];
+      instances.push({
+        id: `recurring-${template.id}-${dateStr}`,
+        title: exception?.title ?? template.title,
+        startTime: exception?.startTime ?? template.startTime,
+        duration: exception?.duration ?? template.duration,
+        completed: (template.completedDates || []).includes(dateStr),
+        isAllDay: exception?.isAllDay ?? template.isAllDay ?? false,
+        assignedUserSyncIds: exception?.assignedUserSyncIds ?? template.assignedUserSyncIds,
+        date: dateStr,
+        isRecurring: true,
+      });
+    }
+  }
+  return instances;
+}
+
+/**
+ * The blocks for one local calendar date: concrete tasks on that date,
+ * recurring instances expanded for it, and (when include_native) device
+ * calendar events. Sorted all-day first, then by wall-clock start.
+ */
+export function buildDayBlocks(state, params) {
+  const { tasks = [], recurringTasks = [], isVisibleForUser = () => true } = state;
+  const { date, include_native: includeNative = false } = params;
+
+  const onDate = tasks.filter((t) => t.date === date && isVisibleForUser(t));
+  const concrete = includeNative ? onDate : onDate.filter((t) => !t._native);
+  const recurring = expandRecurringForDate(recurringTasks, date).filter(isVisibleForUser);
+
+  const toMinutes = (hhmm) => {
+    const m = /^(\d{1,2}):(\d{2})$/.exec(hhmm ?? '');
+    return m ? Number(m[1]) * 60 + Number(m[2]) : Number.MAX_SAFE_INTEGER;
+  };
+  const blocks = [...concrete, ...recurring].map(toBlock).sort((a, b) => {
+    if (a.all_day !== b.all_day) return a.all_day ? -1 : 1;
+    return toMinutes(a.start_time) - toMinutes(b.start_time);
+  });
+  return { blocks };
+}
+
+/** The unscheduled inbox, unpaginated — the main process owns paging (§5.1). */
+export function buildUnscheduledItems(state) {
+  const { unscheduledTasks = [], isVisibleForUser = () => true } = state;
+  return {
+    items: unscheduledTasks.filter(isVisibleForUser).map((t) => {
+      const item = {
+        id: t.id,
+        type: 'task',
+        title: t.title ?? '',
+        priority: typeof t.priority === 'number' ? t.priority : 0,
+        completed: !!t.completed,
+      };
+      if (t.deadline) item.deadline = t.deadline;
+      if (t.projectId) item.project_id = t.projectId;
+      if (t.notes) item.notes = t.notes;
+      return item;
+    }),
+  };
+}
+
+/**
+ * Goal and project progress (§5.1: needs scope arguments — unscoped it returns
+ * either too little or an unbounded tree).
+ *
+ *  - goal_id: narrow to one goal; unknown id is a not_found the tool layer
+ *    turns into a typed error.
+ *  - window: 'active' (default) or 'all' — goal/project status filter.
+ *
+ * Progress math reuses the exact functions the UI uses (goalProgress.js,
+ * projectProgress.js), so MCP never reports numbers the window would not show.
+ */
+export function buildGoalProgress(state, params) {
+  const {
+    goals = [], projects = [], tasks = [], unscheduledTasks = [],
+    isVisibleForUser = () => true,
+  } = state;
+  const { goal_id: goalId, window: windowParam } = params ?? {};
+
+  const scope = windowParam === undefined || windowParam === 'active' ? 'active'
+    : windowParam === 'all' ? 'all'
+      : null;
+  if (scope === null) {
+    return { notFound: false, invalid: `window must be 'active' or 'all', got ${JSON.stringify(windowParam)}` };
+  }
+
+  const inScope = (entity) => scope === 'all' || entity.status === 'active';
+  const allTasks = [...tasks, ...unscheduledTasks].filter(isVisibleForUser);
+  // Progress denominators deliberately exclude device calendar events: they are
+  // not completable dayGLANCE work and would dilute every percentage.
+  const progressTasks = allTasks.filter((t) => !t._native);
+
+  const visibleGoals = goals.filter((g) => isVisibleForUser(g) && inScope(g));
+  const selected = goalId === undefined ? visibleGoals : visibleGoals.filter((g) => g.id === goalId);
+  if (goalId !== undefined && selected.length === 0) {
+    return { notFound: true, invalid: null };
+  }
+
+  const mapProject = (p) => {
+    const projectTasks = progressTasks.filter((t) => t.projectId === p.id && !t.archived);
+    return {
+      id: p.id,
+      title: p.title,
+      status: p.status,
+      progress_percent: Math.round(calculateProjectProgress(p.id, progressTasks) * 100),
+      tasks_done: projectTasks.filter((t) => t.completed).length,
+      tasks_total: projectTasks.length,
+    };
+  };
+
+  const result = selected.map((g) => ({
+    id: g.id,
+    title: g.title,
+    status: g.status,
+    target_date: g.targetDate ?? null,
+    progress_percent: Math.round(calculateGoalProgress(g.id, projects, progressTasks) * 100),
+    projects: projects
+      .filter((p) => p.goalId === g.id && isVisibleForUser(p) && inScope(p))
+      .map(mapProject),
+  }));
+
+  // Projects with no parent goal are real work the model should see when the
+  // question is unscoped; under a goal_id they are out of scope by definition.
+  const standalone = goalId === undefined
+    ? projects.filter((p) => !p.goalId && isVisibleForUser(p) && inScope(p)).map(mapProject)
+    : [];
+
+  return { notFound: false, invalid: null, goals: result, standalone_projects: standalone };
+}
+
+/**
+ * The renderer-side dispatcher for main-process MCP requests. Every method
+ * returns { ok: true, data } or { ok: false, error: { code, message } } —
+ * the main process maps these onto §5.2 typed tool errors verbatim.
+ *
+ * 'ping' is the §3.3 health check: a crashed renderer cannot run this
+ * function, so answering at all IS the health signal.
+ */
+export function handleMcpRequest(state, request) {
+  const method = request?.method;
+  const params = request?.params ?? {};
+  switch (method) {
+    case 'ping':
+      return { ok: true, data: { pong: true } };
+    case 'get_day':
+      return { ok: true, data: buildDayBlocks(state, params) };
+    case 'list_unscheduled':
+      return { ok: true, data: buildUnscheduledItems(state) };
+    case 'goal_progress': {
+      const r = buildGoalProgress(state, params);
+      if (r.invalid) return { ok: false, error: { code: 'validation', message: r.invalid } };
+      if (r.notFound) return { ok: false, error: { code: 'not_found', message: `No goal with id ${JSON.stringify(params.goal_id)}` } };
+      return { ok: true, data: { goals: r.goals, standalone_projects: r.standalone_projects } };
+    }
+    default:
+      return { ok: false, error: { code: 'validation', message: `Unknown method ${JSON.stringify(method)}` } };
+  }
+}

--- a/src/utils/mcpReadModel.test.js
+++ b/src/utils/mcpReadModel.test.js
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import {
+  blockType,
+  toBlock,
+  expandRecurringForDate,
+  buildDayBlocks,
+  buildUnscheduledItems,
+  buildGoalProgress,
+  handleMcpRequest,
+} from './mcpReadModel.js';
+
+// The renderer half of the MCP read surface. The load-bearing assertions:
+// _native events carry the distinct type + read_only flag in ALL output
+// (spec §5.1 r4) and are absent unless include_native is set; recurring
+// templates expand for the requested date; goal math matches the UI's own
+// progress functions; the dispatcher returns typed errors, never throws.
+
+const T = (over = {}) => ({
+  id: 'id-1', title: 'Task', date: '2026-08-10', startTime: '09:00',
+  duration: 60, completed: false, isAllDay: false, ...over,
+});
+
+describe('blockType / toBlock — the §5.1 distinct type flag', () => {
+  it('flags _native as device_calendar_event with read_only, everywhere', () => {
+    const b = toBlock(T({ _native: true, id: 'native-cal-abc' }));
+    expect(b.type).toBe('device_calendar_event');
+    expect(b.read_only).toBe(true);
+  });
+
+  it('dayGLANCE tasks are type task and carry NO read_only flag', () => {
+    const b = toBlock(T());
+    expect(b.type).toBe('task');
+    expect(b).not.toHaveProperty('read_only');
+  });
+
+  it('imported alone does NOT mark a device event (CalDAV/ICS also set imported)', () => {
+    expect(blockType(T({ imported: true }))).toBe('task');
+  });
+
+  it('all-day blocks have a null start_time (no fake midnight)', () => {
+    const b = toBlock(T({ isAllDay: true, startTime: '00:00' }));
+    expect(b.all_day).toBe(true);
+    expect(b.start_time).toBeNull();
+  });
+});
+
+describe('expandRecurringForDate', () => {
+  const template = {
+    id: 'r1', title: 'Standup', startTime: '10:00', duration: 15,
+    recurrence: { type: 'daily', startDate: '2026-01-01' },
+    completedDates: ['2026-08-10'],
+  };
+
+  it('produces the instance for the requested date with completion state', () => {
+    const [inst] = expandRecurringForDate([template], '2026-08-10');
+    expect(inst).toMatchObject({
+      id: 'recurring-r1-2026-08-10', title: 'Standup', date: '2026-08-10',
+      completed: true, isRecurring: true,
+    });
+    expect(expandRecurringForDate([template], '2026-08-11')[0].completed).toBe(false);
+  });
+
+  it('applies per-date exception overrides field by field', () => {
+    const withException = {
+      ...template,
+      exceptions: { '2026-08-10': { title: 'Standup (moved)', startTime: '11:30' } },
+    };
+    const [inst] = expandRecurringForDate([withException], '2026-08-10');
+    expect(inst.title).toBe('Standup (moved)');
+    expect(inst.startTime).toBe('11:30');
+    expect(inst.duration).toBe(15); // un-overridden fields fall back to the template
+  });
+
+  it('includes past uncompleted instances — reads report what was scheduled', () => {
+    const past = expandRecurringForDate([{ ...template, completedDates: [] }], '2026-02-01');
+    expect(past).toHaveLength(1);
+    expect(past[0].completed).toBe(false);
+  });
+
+  it('returns nothing for a date before the recurrence starts or with no templates', () => {
+    expect(expandRecurringForDate([template], '2025-12-31')).toEqual([]);
+    expect(expandRecurringForDate([], '2026-08-10')).toEqual([]);
+    expect(expandRecurringForDate(undefined, '2026-08-10')).toEqual([]);
+  });
+});
+
+describe('buildDayBlocks', () => {
+  const state = {
+    tasks: [
+      T({ id: 'a', date: '2026-08-10', startTime: '14:00' }),
+      T({ id: 'b', date: '2026-08-10', startTime: '08:00' }),
+      T({ id: 'allday', date: '2026-08-10', isAllDay: true, startTime: null }),
+      T({ id: 'other-day', date: '2026-08-11' }),
+      T({ id: 'native-cal-e1', date: '2026-08-10', _native: true, imported: true, startTime: '10:00' }),
+    ],
+    recurringTasks: [{
+      id: 'r1', title: 'Standup', startTime: '10:30', duration: 15,
+      recurrence: { type: 'daily', startDate: '2026-01-01' },
+    }],
+  };
+
+  it('returns only the requested date, all-day first then by wall-clock start', () => {
+    const { blocks } = buildDayBlocks(state, { date: '2026-08-10', include_native: true });
+    expect(blocks.map((b) => b.id)).toEqual(['allday', 'b', 'native-cal-e1', 'recurring-r1-2026-08-10', 'a']);
+  });
+
+  it('excludes _native events unless include_native — absent means absent, not unflagged', () => {
+    const { blocks } = buildDayBlocks(state, { date: '2026-08-10' });
+    expect(blocks.some((b) => b.type === 'device_calendar_event')).toBe(false);
+    const withNative = buildDayBlocks(state, { date: '2026-08-10', include_native: true }).blocks;
+    const native = withNative.find((b) => b.id === 'native-cal-e1');
+    expect(native.type).toBe('device_calendar_event');
+    expect(native.read_only).toBe(true);
+  });
+
+  it('applies the multi-user visibility predicate the window applies', () => {
+    const scoped = { ...state, isVisibleForUser: (t) => t.id !== 'a' };
+    const { blocks } = buildDayBlocks(scoped, { date: '2026-08-10', include_native: true });
+    expect(blocks.some((b) => b.id === 'a')).toBe(false);
+  });
+
+  it('an empty day is an empty blocks array (available ≠ empty is the transport layer)', () => {
+    expect(buildDayBlocks(state, { date: '2027-01-01' }).blocks.filter((b) => !b.type.includes('recurring'))).toEqual(
+      expect.any(Array),
+    );
+    expect(buildDayBlocks({ tasks: [], recurringTasks: [] }, { date: '2026-08-10' }).blocks).toEqual([]);
+  });
+});
+
+describe('buildUnscheduledItems', () => {
+  it('maps the inbox with priority/deadline and applies visibility', () => {
+    const state = {
+      unscheduledTasks: [
+        { id: 'u1', title: 'Buy milk', priority: 2, deadline: '2026-08-20', notes: 'oat' },
+        { id: 'u2', title: 'Hidden' },
+      ],
+      isVisibleForUser: (t) => t.id !== 'u2',
+    };
+    const { items } = buildUnscheduledItems(state);
+    expect(items).toEqual([{
+      id: 'u1', type: 'task', title: 'Buy milk', priority: 2,
+      completed: false, deadline: '2026-08-20', notes: 'oat',
+    }]);
+  });
+});
+
+describe('buildGoalProgress', () => {
+  const state = {
+    goals: [
+      { id: 'g1', title: 'Ship v5', status: 'active' },
+      { id: 'g2', title: 'Old goal', status: 'archived' },
+    ],
+    projects: [
+      { id: 'p1', title: 'Backend', status: 'active', goalId: 'g1' },
+      { id: 'p2', title: 'Standalone', status: 'active' },
+    ],
+    tasks: [
+      T({ id: 't1', projectId: 'p1', duration: 60, completed: true }),
+      T({ id: 't2', projectId: 'p1', duration: 60, completed: false }),
+      T({ id: 'n1', projectId: 'p1', duration: 600, completed: false, _native: true }),
+    ],
+    unscheduledTasks: [{ id: 'u1', projectId: 'p2', title: 'x', completed: false }],
+  };
+
+  it('computes duration-weighted progress with the UI math, excluding _native from denominators', () => {
+    const r = buildGoalProgress(state, {});
+    expect(r.goals).toHaveLength(1); // default window active
+    const g = r.goals[0];
+    expect(g.progress_percent).toBe(50); // 60 done / 120 total — the 600-min native event must not dilute
+    expect(g.projects[0]).toMatchObject({ id: 'p1', tasks_done: 1, tasks_total: 2 });
+    expect(r.standalone_projects.map((p) => p.id)).toEqual(['p2']);
+  });
+
+  it("window: 'all' includes archived goals; unscoped default is active-only", () => {
+    expect(buildGoalProgress(state, { window: 'all' }).goals.map((g) => g.id)).toEqual(['g1', 'g2']);
+  });
+
+  it('goal_id narrows to one goal and drops standalone projects', () => {
+    const r = buildGoalProgress(state, { goal_id: 'g1' });
+    expect(r.goals.map((g) => g.id)).toEqual(['g1']);
+    expect(r.standalone_projects).toEqual([]);
+  });
+
+  it('unknown goal_id is notFound; bad window is invalid', () => {
+    expect(buildGoalProgress(state, { goal_id: 'nope' }).notFound).toBe(true);
+    expect(buildGoalProgress(state, { window: 'weekly' }).invalid).toContain('window');
+  });
+});
+
+describe('handleMcpRequest — the dispatcher', () => {
+  const state = { tasks: [], recurringTasks: [], unscheduledTasks: [], goals: [], projects: [] };
+
+  it('ping answers ok — running at all is the §3.3 health signal', () => {
+    expect(handleMcpRequest(state, { method: 'ping' })).toEqual({ ok: true, data: { pong: true } });
+  });
+
+  it('routes the three read methods', () => {
+    expect(handleMcpRequest(state, { method: 'get_day', params: { date: '2026-08-10' } }).ok).toBe(true);
+    expect(handleMcpRequest(state, { method: 'list_unscheduled' }).ok).toBe(true);
+    expect(handleMcpRequest(state, { method: 'goal_progress', params: {} }).ok).toBe(true);
+  });
+
+  it('maps model failures onto typed error codes (§5.2)', () => {
+    const nf = handleMcpRequest(state, { method: 'goal_progress', params: { goal_id: 'nope' } });
+    expect(nf).toMatchObject({ ok: false, error: { code: 'not_found' } });
+    const bad = handleMcpRequest(state, { method: 'goal_progress', params: { window: 'x' } });
+    expect(bad).toMatchObject({ ok: false, error: { code: 'validation' } });
+    const unknown = handleMcpRequest(state, { method: 'explode' });
+    expect(unknown).toMatchObject({ ok: false, error: { code: 'validation' } });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of `docs/mcp-server-spec.md` §10: a main→renderer IPC channel with a real health check, and the four read tools — `dayglance_get_today`, `dayglance_get_day`, `dayglance_list_unscheduled_tasks`, `dayglance_get_goal_progress` — behind the existing `DAYGLANCE_MCP_DEV=1` flag. No writes, no UI, nothing in `useElectronBridge.js`.

**Read source:** live renderer React state over IPC — what the user sees in the main window — never localStorage. Decisive reason: `_native` device calendar events are never persisted (`useDataPersistence.js` filters them from every write and read), so a localStorage read structurally could not include them; for everything else localStorage lags state by one React commit for no benefit.

**Pieces:**
- `electron/mcpRendererBridge.ts` — correlated request/response over `mcp:request`/`mcp:response`. Health check, not existence check (§3.3): no answer within the timeout (ping 1s, data 3s) means `renderer_unavailable`, regardless of what `live()`/`isDestroyed()` claim, because a crashed render process leaves both true. Responses from any sender but the main window's webContents are dropped, so the tray popup's stale snapshot can never answer (second guard: `useMcpBridge` also bails in tray mode).
- `src/utils/mcpReadModel.js` — pure, tested read models per the `trayFetchGate.js` precedent (PR #1302): day blocks with per-date recurring expansion via `recurrenceEngine`, inbox items, and goal/project progress reusing `goalProgress.js`/`projectProgress.js` — the UI's own duration-weighted math, with `_native` events excluded from denominators. `_native` output carries `type: "device_calendar_event"` plus `read_only: true` everywhere (spec r4 §5.1).
- `src/hooks/useMcpBridge.js` — thin subscription answering synchronously from a state ref inside the IPC callback: no setState, no render round-trip, so hidden-window throttling cannot delay a reply — which is what makes the short ping timeout safe.
- `electron/mcpDates.ts` — the §5.3 correctness core: strict `YYYY-MM-DD` local-date validation (real calendar dates only; timestamps/offsets/`Z` rejected; full leap-year rules) and server-side date resolution via `Intl`. Every dated response echoes `{date, timezone}`; `get_today` resolves on the machine, never from the client.
- `electron/mcpPagination.ts` — default 50 / max 200, opaque self-contained cursor (no sessions per §3.7), truncation flag + total; invalid limits/cursors are typed validation errors, never silent clamps.
- `electron/mcpReadTools.ts` — tool registration with zod schemas. The device-calendar consent tier (§6.3) arrives as an `includeNativeEvents()` closure: Phase 2 sources it from `DAYGLANCE_MCP_CALENDAR`, Phase 5 swaps the source without touching tool code. Descriptions state that dayGLANCE cannot modify device calendar events. Typed errors per §5.2 (`renderer_unavailable` / `not_found` / `validation`); an unavailable renderer is never an empty result.

## Exit criteria (all verified)

1. ✅ **Real data with the main window backgrounded** — seeded the real app (xvfb, Vite renderer) via CDP; MCP Inspector and curl returned the seeded schedule, sorted, with recurring instances expanded. Replies come from the IPC callback, not the render loop, so window visibility cannot affect them (the §3.3 measurement showed the hidden macOS window's timers still fire; this path doesn't even need timers).
2. ✅ **DST both directions** — unit tests pin America/Chicago spring-forward and fall-back at the exact UTC boundary instants, plus southern-hemisphere Sydney and cross-date-line zones; live, `get_today` resolved `2026-08-10` under `Pacific/Kiritimati` while UTC read `2026-08-09`, echoing the zone.
3. ✅ **Killed renderer → typed error** — CDP `Page.crash` (the exact §3.3 scenario: dead render process, `live()` still happy) produced the `renderer_unavailable` tool error in 3.0s. No hang, no empty result, and the message states explicitly it is not an empty schedule.
4. ✅ **`_native` tier** — live: `include_native` observed at the renderer boundary flipping `false`/`true` with `DAYGLANCE_MCP_CALENDAR`; unit: given `include_native`, events are included and flagged (`device_calendar_event` + `read_only`), and absent otherwise (EventKit events don't exist on Linux, so the flag-vs-absence behavior itself is pinned by the model tests).
5. ✅ **Pagination** — live walk of a 60-item inbox: page 1 = 50 items, `truncated: true`, working cursor; page 2 = 10 items, `truncated: false`, `next_cursor: null`; garbage cursor → typed validation error.
6. ✅ **Unit + mutation tests** — 46 new tests (dates 12, pagination 14, read model 20); 27/27 hand-applied mutants killed (one initial survivor — the `%400` leap rule — exposed a missing `2200-02-29` assertion, now added).

Full suite: 91 files / 1376 tests green; lint and both tsc configs clean.

## Tested vs not

Unit-tested and mutation-verified: `mcpDates`, `mcpPagination`, `mcpReadModel`. Verified live but not unit-tested (thin wiring by design): `mcpRendererBridge`, `mcpReadTools`, `useMcpBridge`, the preload/main/App.jsx glue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_