### PR TITLE
MCP Phase 3: write tools, idempotency, rate limiting, tray reload policy (+ spec r5)

### DIFF
--- a/docs/mcp-server-spec.md
+++ b/docs/mcp-server-spec.md
@@ -1,9 +1,11 @@
 # dayGLANCE MCP Server: Technical Specification
 
-**Status:** Draft for review, revision 4
+**Status:** Draft for review, revision 5
 **Target:** dayGLANCE Electron builds (macOS, Windows, Linux)
 **Sequencing:** After the 4.1.2 tray release ships
 **Spec baseline:** MCP specification 2026-07-28
+
+**Changes from revision 4:** Three corrections from the Phase 3 mutation-path trace. §3.1's rule restated as "through the same store layer via a shared pure module" — move and resize have no shared UI mutation function to invoke (inline `setTasks` in drag handlers); converting the UI call sites to the shared module is a follow-up, not part of Phase 3. §5.2's idempotency claim corrected: `transitionId` provides delivery dedup at the GLANCEintents outbox, not mutation-level replay protection; `handleIntent.js:347-389` is the only mutation-level precedent and is create-shaped, so move/resize replay protection is new machinery. §3.6 corrected: the tray debounce is trailing but resets per event, coalescing only bursts closer than 500 ms — at the §4.3 rate limit every write triggers a reload; `electron/trayReloadPolicy.ts` (stretched debounce while MCP writes are recent) is the fix.
 
 **Changes from revision 3:** Closed open question 1 — device calendar events are included, behind a separate consent, read-only. §6.3 splits reads into three tiers (off; dayGLANCE data only; include device calendar) with the rationale; §6.4 adds the calendar tier's own consent copy; §5.1 flags `_native` distinctly in all tool output and requires tool descriptions to state the write limit up front; §5.2 adds the typed `_native` write rejection to the tool contract; §10 Phase 3 gains a verification item on the existing `move_block` mutation path.
 
@@ -63,7 +65,9 @@ The corrected argument, and it is stronger:
 
 **Single-writer discipline.** The codebase enforces, by convention and now by guard, that only the main window renderer writes the `day-planner-*` keys. `useSaveOnChange.js:19` bails in tray mode; PR #1299 extended the same guard to `loadData`'s normalization write-back; PR #1302 extended it to `calendarFilter`. Three separate PRs in the 4.1.2 cycle tightened this invariant. The main process introducing a second writer would undo that work directly.
 
-**Rule:** every MCP write invokes the same renderer-side mutation function the UI invokes. No exceptions, no direct storage access, no "fast path."
+**Rule (restated in r5):** every MCP write goes **through the same store layer via a shared pure module** — renderer-side state setters applying the canonical update shapes, so the save pass, dirty tracking, tombstones, and `tray:data-changed` all engage identically. No direct storage access, no "fast path."
+
+The r4 phrasing was "invokes the same renderer-side mutation function the UI invokes." The Phase 3 trace showed that for move and resize **no such function exists**: the UI performs inline `setTasks` calls inside the drag/resize event handlers (`useDragDrop.js`), and `addTask` is a form-submit handler coupled to modal state, undo, and UI sounds. The canonical update shapes are therefore extracted into `src/utils/taskMutations.js` (pure, state-in/state-out, tested); MCP writes use it as of Phase 3. **Follow-up, not Phase 3:** converting the UI drag/resize call sites to the same module, at which point the letter of the original rule holds too. MCP writes deliberately do not push onto the user's undo stack or play UI sounds — the §4.3 write journal is the undo surface for MCP writes.
 
 **Consequences, all correct behavior:**
 - GLANCEintents events fire automatically for MCP-originated mutations.
@@ -160,12 +164,10 @@ PR #1297 established a channel that fires from the persistence path after `saveD
 
 Because MCP writes route through the renderer mutation path (§3.1), they trigger `saveData()`, which fires the emit, which updates the tray popup. **No MCP-specific propagation work is required.** This is the design being coherent rather than lucky, and it is an additional argument for the §3.1 rule.
 
-Two things to verify during implementation:
+**Verified in Phase 3 (r5), and the answer was the bad case:**
 
-1. **Debounce coalescing.** The main process reload is debounced at 500ms. Confirm it is a true trailing debounce that coalesces rather than a leading-edge fire. At 30 writes per minute from an agent this matters; at the tray's historical rate it did not.
-2. **Reload volume under agent load.** Every MCP write produces a tray popup reload. The 4.1.2 work reduced idle reloads from roughly 240/hour to near zero, and the write rate limiter (§4.3) bounds the MCP contribution, but the interaction should be measured rather than assumed.
-
-If reload volume proves problematic, the fix is a longer debounce on the MCP path specifically, not a bypass of the emit.
+1. **Debounce coalescing.** The reload debounce (`main.ts` `tray:data-changed` handler) is a **trailing debounce that resets per event** — it coalesces only bursts closer together than 500 ms. That is the wrong shape for agent load: at the §4.3 rate limit (one write every 2 s), no two events are within 500 ms of each other, so **every write triggers a tray popup reload** — 30 reloads/minute, 1800/hour against the 4.1.2 cycle's hard-won near-zero. (For user-originated saves the shape is right: a drag gesture fires per mousemove tick and coalesces to one reload after release.)
+2. **The fix, per this section's own rule — a longer debounce on the MCP path specifically, never a bypass of the emit:** `electron/trayReloadPolicy.ts`. While an MCP write has landed within the last 10 s, the handler arms a 5 s debounce (longer than the 2 s write cadence, so a sustained agent session coalesces to zero reloads until it goes quiet, then exactly one); otherwise the historical 500 ms. The emit itself is untouched.
 
 ### 3.7 Main-process state
 
@@ -245,7 +247,7 @@ Two requirements on the tool surface:
 - **Writes return the resulting entity state.** Saves a follow-up read.
 - **Errors are tool errors, not protocol errors.** Return `isError: true` with a content block the model can read and recover from. Distinguish at minimum: renderer unavailable, consent revoked, read-only mode, not found, validation failure, rate limited.
 - **`_native` events are rejected by every write tool with a typed error.** `move_block`, `resize_block`, and `set_task_completion` refuse device calendar events regardless of the consent tier. Why: dayGLANCE holds EventKit **read** access only, and the existing `day-planner-native-time-overrides` mechanism shifts local display without touching the actual event — so a "successful" write would create a silent discrepancy between what dayGLANCE shows and what the user's calendar says, which is worse than the refusal.
-- **Idempotency.** Agents retry. Every write accepts an optional `idempotency_key`, mapped onto the existing `transitionId` pattern from GLANCEintents. Reuse the mechanism rather than inventing a second one.
+- **Idempotency (corrected in r5).** Agents retry. Every write accepts an optional `idempotency_key`. The r4 text said to map it onto "the existing `transitionId` pattern" — the Phase 3 trace showed that overstates what exists: `transitionId` is read in exactly one place (`useNotifyEmitter.js`, as the outbound intent's `event_id`) and provides **delivery dedup at the outbox**, not mutation-level replay protection; no local mutation dedups on it. The only mutation-level precedent is `handleIntent.js:347-389` (deterministic task id from the key + existence/tombstone check), and it is create-shaped. So the design is: the key still travels into the emit path as `transitionId` (reusing the delivery dedup that does exist), `create_task` derives a deterministic task id from the key per the `handleIntent` precedent (reuse), and replayed **move/resize/completion** calls are absorbed by a bounded main-process replay store returning the first attempt's result — which is **new machinery, acknowledged as such**, because nothing reusable exists for mutating operations.
 - **No partial success.** A tool call either applies fully or not at all.
 
 ### 5.3 Date and timezone semantics

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, ipcMain, net, protocol, Tray, Menu, nativeImage, nativeTheme, globalShortcut, session, screen } from 'electron';
+import { app, BrowserWindow, shell, ipcMain, net, protocol, Tray, Menu, nativeImage, nativeTheme, globalShortcut, session, screen, Notification } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
 import dns from 'node:dns';
@@ -15,6 +15,9 @@ import { shouldQuitOnAllWindowsClosed } from './startupQuit.js';
 import { initStartupLog, logStartup } from './startupLog.js';
 import { startMcpServer } from './mcpServer.js';
 import { createRendererBridge } from './mcpRendererBridge.js';
+import { createWriteGate } from './mcpWriteGate.js';
+import { createIdempotencyStore } from './mcpIdempotency.js';
+import { trayReloadDebounceMs } from './trayReloadPolicy.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -65,6 +68,10 @@ let didCreateMainWindow = false;
 let trayWindow: BrowserWindow | null = null;
 let trayNeedsReload = false;
 let trayReloadTimer: ReturnType<typeof setTimeout> | null = null;
+// Clock reading of the last MCP-originated write, for the §3.6 tray reload
+// policy (trayReloadPolicy.ts): while an agent is writing, the reload debounce
+// stretches so a write storm coalesces instead of reloading the popup per write.
+let lastMcpWriteAt: number | null = null;
 let registeredHotkey: string | null = null;
 let registeredMainWindowHotkey: string | null = null;
 
@@ -671,10 +678,13 @@ ipcMain.on('tray:data-changed', (event) => {
     trayNeedsReload = true;
   } else {
     if (trayReloadTimer) clearTimeout(trayReloadTimer);
+    // 500ms for user saves; stretched while MCP writes are recent, so an
+    // agent writing at the §4.3 rate limit coalesces to one reload after the
+    // storm instead of one per write. See electron/trayReloadPolicy.ts.
     trayReloadTimer = setTimeout(() => {
       trayReloadTimer = null;
       live(trayWindow)?.webContents.reload();
-    }, 500);
+    }, trayReloadDebounceMs(Date.now(), lastMcpWriteAt));
   }
 });
 
@@ -889,20 +899,47 @@ app.whenReady().then(async () => {
   // §10). Token comes from the environment for now; the discovery file is
   // Phase 6. Off means off: without the flag no port is bound at all.
   if (process.env['DAYGLANCE_MCP_DEV'] === '1') {
+    // Getter, not a reference: requests must target the CURRENT main
+    // window even if it is recreated (same posture as createWsServer).
+    const mcpBridge = createRendererBridge(() => live(mainWindow));
+    const mcpToken = process.env['DAYGLANCE_MCP_TOKEN'] ?? '';
+    // Resolved on the machine, never inferred from the client (§5.3).
+    const mcpTimeZone = () => Intl.DateTimeFormat().resolvedOptions().timeZone;
     startMcpServer({
-      token: process.env['DAYGLANCE_MCP_TOKEN'] ?? '',
+      token: mcpToken,
       portOverride: process.env['DAYGLANCE_MCP_PORT'],
       readDeps: {
-        // Getter, not a reference: requests must target the CURRENT main
-        // window even if it is recreated (same posture as createWsServer).
-        bridge: createRendererBridge(() => live(mainWindow)),
+        bridge: mcpBridge,
         now: Date.now,
-        // Resolved on the machine, never inferred from the client (§5.3).
-        timeZone: () => Intl.DateTimeFormat().resolvedOptions().timeZone,
+        timeZone: mcpTimeZone,
         // Device-calendar consent tier (§6.3). Phase 2 source is an env var;
         // Phase 5 replaces this closure with the settings-backed tier and
         // nothing in the tool code changes.
         includeNativeEvents: () => process.env['DAYGLANCE_MCP_CALENDAR'] === '1',
+      },
+      writeDeps: {
+        bridge: mcpBridge,
+        gate: createWriteGate(),
+        store: createIdempotencyStore(),
+        token: () => mcpToken,
+        // Read-write consent tier (§6.3, second opt-in). Env-sourced now;
+        // Phase 5 swaps the source without touching tool code — same pattern
+        // as includeNativeEvents above.
+        includeWrites: () => process.env['DAYGLANCE_MCP_WRITES'] === '1',
+        noteMcpWrite: () => { lastMcpWriteAt = Date.now(); },
+        // §4.3: repeated rate-limit violations auto-disable writes with a
+        // notification. Fires exactly once, on the disable edge.
+        onWritesDisabled: () => {
+          console.error('[dayGLANCE] MCP writes auto-disabled after repeated rate-limit violations.');
+          if (Notification.isSupported()) {
+            new Notification({
+              title: 'dayGLANCE MCP writes disabled',
+              body: 'An MCP client repeatedly exceeded the write rate limit. Writes stay off until dayGLANCE restarts.',
+            }).show();
+          }
+        },
+        now: Date.now,
+        timeZone: mcpTimeZone,
       },
     });
   }

--- a/electron/mcpIdempotency.test.ts
+++ b/electron/mcpIdempotency.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createIdempotencyStore,
+  isValidIdempotencyKey,
+  makeStoreKey,
+  DEFAULT_IDEMPOTENCY_TTL_MS,
+} from './mcpIdempotency.js';
+
+// §5.2 under test: a replayed idempotency_key returns the FIRST attempt's
+// result and never re-executes the mutation; keys are scoped so tools and
+// tokens cannot collide; the store is bounded in both time and size.
+
+function fakeClock(start = 1_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; }, rewind: (ms: number) => { t -= ms; } };
+}
+
+describe('isValidIdempotencyKey', () => {
+  it('accepts id-shaped keys', () => {
+    for (const k of ['retry-1', 'a', 'A_b.c:d-e', '0'.repeat(128)]) {
+      expect(isValidIdempotencyKey(k), k).toBe(true);
+    }
+  });
+  it('rejects empty, oversized, spaced, and non-string keys', () => {
+    for (const k of ['', '0'.repeat(129), 'has space', 'pipe|char', 'né', 42, null, undefined, {}]) {
+      expect(isValidIdempotencyKey(k), String(k)).toBe(false);
+    }
+  });
+});
+
+describe('makeStoreKey', () => {
+  it('scopes by token and tool', () => {
+    expect(makeStoreKey('t1', 'create_task', 'k')).not.toBe(makeStoreKey('t2', 'create_task', 'k'));
+    expect(makeStoreKey('t1', 'create_task', 'k')).not.toBe(makeStoreKey('t1', 'move_block', 'k'));
+  });
+  it('is collision-proof across segment boundaries (length-prefixed)', () => {
+    expect(makeStoreKey('ab', 'c', 'k')).not.toBe(makeStoreKey('a', 'bc', 'k'));
+    expect(makeStoreKey('a', 'b.c', 'k')).not.toBe(makeStoreKey('a.b', 'c', 'k'));
+    // Even a separator character INSIDE a segment cannot realign boundaries —
+    // this is what the length prefix is for (tokens/tools are not run through
+    // isValidIdempotencyKey, so the store key must not trust their alphabet).
+    expect(makeStoreKey('a|b', 'c', 'k')).not.toBe(makeStoreKey('a', 'b|c', 'k'));
+  });
+});
+
+describe('createIdempotencyStore', () => {
+  it('returns the stored first-attempt result on replay', () => {
+    const clock = fakeClock();
+    const store = createIdempotencyStore<{ id: string }>({ now: clock.now });
+    expect(store.get('k')).toBeNull();
+    store.put('k', { id: 'task-1' });
+    expect(store.get('k')).toEqual({ id: 'task-1' });
+    clock.advance(DEFAULT_IDEMPOTENCY_TTL_MS - 1);
+    expect(store.get('k')).toEqual({ id: 'task-1' }); // still inside the TTL
+  });
+
+  it('expires entries at the TTL', () => {
+    const clock = fakeClock();
+    const store = createIdempotencyStore({ ttlMs: 1000, now: clock.now });
+    store.put('k', 'result');
+    clock.advance(1000);
+    expect(store.get('k')).toBeNull();
+  });
+
+  it('expires on a backwards clock jump rather than trusting a future timestamp', () => {
+    const clock = fakeClock();
+    const store = createIdempotencyStore({ ttlMs: 1000, now: clock.now });
+    store.put('k', 'result');
+    clock.rewind(5000);
+    expect(store.get('k')).toBeNull();
+  });
+
+  it('evicts the least recently WRITTEN entry beyond the cap', () => {
+    const clock = fakeClock();
+    const store = createIdempotencyStore({ maxEntries: 2, now: clock.now });
+    store.put('a', 1);
+    store.put('b', 2);
+    store.put('a', 10);   // rewrite refreshes a's position
+    store.put('c', 3);    // evicts b, the oldest
+    expect(store.get('b')).toBeNull();
+    expect(store.get('a')).toBe(10);
+    expect(store.get('c')).toBe(3);
+    expect(store.size()).toBe(2);
+  });
+
+  it('reset() drops everything (token rotation)', () => {
+    const store = createIdempotencyStore({ now: fakeClock().now });
+    store.put('k', 'v');
+    store.reset();
+    expect(store.get('k')).toBeNull();
+    expect(store.size()).toBe(0);
+  });
+});

--- a/electron/mcpIdempotency.test.ts
+++ b/electron/mcpIdempotency.test.ts
@@ -3,6 +3,7 @@ import {
   createIdempotencyStore,
   isValidIdempotencyKey,
   makeStoreKey,
+  deterministicTaskIdFromSeed,
   DEFAULT_IDEMPOTENCY_TTL_MS,
 } from './mcpIdempotency.js';
 
@@ -40,6 +41,15 @@ describe('makeStoreKey', () => {
     // this is what the length prefix is for (tokens/tools are not run through
     // isValidIdempotencyKey, so the store key must not trust their alphabet).
     expect(makeStoreKey('a|b', 'c', 'k')).not.toBe(makeStoreKey('a', 'b|c', 'k'));
+  });
+});
+
+describe('deterministicTaskIdFromSeed', () => {
+  it('is stable, seed-sensitive, and UUIDv4-shaped (the handleIntent precedent)', () => {
+    const a = deterministicTaskIdFromSeed('token|create_task|k1');
+    expect(a).toBe(deterministicTaskIdFromSeed('token|create_task|k1'));
+    expect(a).not.toBe(deterministicTaskIdFromSeed('token|create_task|k2'));
+    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
   });
 });
 

--- a/electron/mcpIdempotency.ts
+++ b/electron/mcpIdempotency.ts
@@ -1,0 +1,81 @@
+// Idempotency for MCP writes (spec §5.2): agents retry, and a replayed
+// idempotency_key must not produce a second mutation. Pure factory with an
+// injectable clock, same idiom as calendarCache.ts.
+//
+// WHAT THIS STORES: the finished tool result of the first attempt, keyed by
+// (token, tool, idempotency_key). A replay inside the TTL returns that stored
+// result verbatim — the renderer mutation is never re-invoked. The key also
+// travels INTO the mutation as its GLANCEintents transitionId (§5.2: map onto
+// the existing mechanism, don't invent a second one), so the emitted event
+// stream carries the same correlation id the client chose.
+//
+// Keys are scoped per (token, tool): the same key on a different tool is a
+// different operation, and another client (different token) can never replay
+// — or poison — this client's results.
+//
+// TTL exists because agents retry on the seconds-to-minutes scale; remembering
+// keys forever would make the map an unbounded leak (§3.7: module scope, but
+// bounded). LRU cap is the backstop against a key-generating runaway loop.
+
+export const DEFAULT_IDEMPOTENCY_TTL_MS = 10 * 60_000;
+export const DEFAULT_IDEMPOTENCY_MAX_ENTRIES = 500;
+
+export interface IdempotencyStoreOptions {
+  ttlMs?: number;
+  maxEntries?: number;
+  now?: () => number;
+}
+
+/** A caller-supplied key must be shaped like an id, not a payload. */
+export function isValidIdempotencyKey(value: unknown): value is string {
+  return typeof value === 'string' && value.length >= 1 && value.length <= 128 && /^[\w.:-]+$/.test(value);
+}
+
+export function makeStoreKey(token: string, tool: string, idempotencyKey: string): string {
+  // Length-prefixed segments so no crafted key can collide across fields
+  // (("a","b:c") and ("a:b","c") must not meet at "a:b:c").
+  return [token, tool, idempotencyKey].map((s) => `${s.length}.${s}`).join('|');
+}
+
+export function createIdempotencyStore<T>(opts: IdempotencyStoreOptions = {}) {
+  const ttlMs = opts.ttlMs ?? DEFAULT_IDEMPOTENCY_TTL_MS;
+  const maxEntries = opts.maxEntries ?? DEFAULT_IDEMPOTENCY_MAX_ENTRIES;
+  const now = opts.now ?? Date.now;
+
+  // Map iteration order is insertion order — delete+set on write keeps it LRU.
+  const entries = new Map<string, { value: T; storedAt: number }>();
+
+  return {
+    /** The stored first-attempt result, or null when absent/expired. */
+    get(storeKey: string): T | null {
+      const e = entries.get(storeKey);
+      if (!e) return null;
+      const age = now() - e.storedAt;
+      if (age >= ttlMs || age < 0) {
+        // Negative age = clock jumped backwards. Expire rather than trust a
+        // timestamp from the future: the cost is one re-executed mutation,
+        // bounded by the write gate; a never-expiring entry is unbounded.
+        entries.delete(storeKey);
+        return null;
+      }
+      return e.value;
+    },
+
+    put(storeKey: string, value: T): void {
+      entries.delete(storeKey);
+      entries.set(storeKey, { value, storedAt: now() });
+      while (entries.size > maxEntries) {
+        const oldest = entries.keys().next().value as string;
+        entries.delete(oldest);
+      }
+    },
+
+    size(): number {
+      return entries.size;
+    },
+
+    reset(): void {
+      entries.clear();
+    },
+  };
+}

--- a/electron/mcpIdempotency.ts
+++ b/electron/mcpIdempotency.ts
@@ -17,6 +17,8 @@
 // keys forever would make the map an unbounded leak (§3.7: module scope, but
 // bounded). LRU cap is the backstop against a key-generating runaway loop.
 
+import { createHash } from 'node:crypto';
+
 export const DEFAULT_IDEMPOTENCY_TTL_MS = 10 * 60_000;
 export const DEFAULT_IDEMPOTENCY_MAX_ENTRIES = 500;
 
@@ -35,6 +37,22 @@ export function makeStoreKey(token: string, tool: string, idempotencyKey: string
   // Length-prefixed segments so no crafted key can collide across fields
   // (("a","b:c") and ("a:b","c") must not meet at "a:b:c").
   return [token, tool, idempotencyKey].map((s) => `${s.length}.${s}`).join('|');
+}
+
+/**
+ * Deterministic UUIDv4-shaped id from a seed — the handleIntent.js
+ * deterministicTaskId precedent (SHA-256, version/variant bits forced),
+ * synchronous via node:crypto since this runs in the main process. Used by
+ * create_task: the task id derives from the idempotency key, so a replayed
+ * create finds its own id already in state and no-ops (mutation-level
+ * idempotency by construction — the create-shaped reuse §5.2 r5 describes).
+ */
+export function deterministicTaskIdFromSeed(seed: string): string {
+  const hash = createHash('sha256').update(seed, 'utf8').digest();
+  hash[6] = (hash[6]! & 0x0f) | 0x40; // version 4
+  hash[8] = (hash[8]! & 0x3f) | 0x80; // variant
+  const h = hash.subarray(0, 16).toString('hex');
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
 }
 
 export function createIdempotencyStore<T>(opts: IdempotencyStoreOptions = {}) {

--- a/electron/mcpLocalTime.test.ts
+++ b/electron/mcpLocalTime.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidWallTime,
+  resolveLocalTime,
+  validateStartTime,
+  validateDurationMinutes,
+} from './mcpLocalTime.js';
+
+// §5.3's write-side rule: a start landing in a nonexistent or ambiguous local
+// hour is a validation error, never silently resolved. America/Chicago 2026:
+// spring forward 2026-03-08 (02:00→03:00 CST→CDT), fall back 2026-11-01
+// (02:00→01:00 CDT→CST).
+
+describe('isValidWallTime', () => {
+  it('accepts strict 24h HH:MM', () => {
+    for (const t of ['00:00', '09:30', '23:59', '13:05']) expect(isValidWallTime(t)).toBe(true);
+  });
+  it('rejects loose or non-time shapes', () => {
+    for (const t of ['9:30', '24:00', '12:60', '12:5', '12:30:00', '12.30', '', undefined, 930]) {
+      expect(isValidWallTime(t), String(t)).toBe(false);
+    }
+  });
+});
+
+describe('resolveLocalTime — DST classification', () => {
+  const CHI = 'America/Chicago';
+
+  it('classifies the spring-forward gap as nonexistent', () => {
+    expect(resolveLocalTime('2026-03-08', '02:00', CHI)).toEqual({ kind: 'nonexistent' });
+    expect(resolveLocalTime('2026-03-08', '02:30', CHI)).toEqual({ kind: 'nonexistent' });
+    expect(resolveLocalTime('2026-03-08', '02:59', CHI)).toEqual({ kind: 'nonexistent' });
+  });
+
+  it('the edges of the gap are unique', () => {
+    expect(resolveLocalTime('2026-03-08', '01:59', CHI)).toEqual({ kind: 'unique' });
+    expect(resolveLocalTime('2026-03-08', '03:00', CHI)).toEqual({ kind: 'unique' });
+  });
+
+  it('classifies the fall-back repeated hour as ambiguous', () => {
+    expect(resolveLocalTime('2026-11-01', '01:00', CHI)).toEqual({ kind: 'ambiguous' });
+    expect(resolveLocalTime('2026-11-01', '01:30', CHI)).toEqual({ kind: 'ambiguous' });
+    expect(resolveLocalTime('2026-11-01', '01:59', CHI)).toEqual({ kind: 'ambiguous' });
+  });
+
+  it('the edges of the repeat are unique', () => {
+    expect(resolveLocalTime('2026-11-01', '00:59', CHI)).toEqual({ kind: 'unique' });
+    expect(resolveLocalTime('2026-11-01', '02:00', CHI)).toEqual({ kind: 'unique' });
+  });
+
+  it('ordinary times on transition days and all times on ordinary days are unique', () => {
+    expect(resolveLocalTime('2026-03-08', '09:00', CHI)).toEqual({ kind: 'unique' });
+    expect(resolveLocalTime('2026-11-01', '13:30', CHI)).toEqual({ kind: 'unique' });
+    expect(resolveLocalTime('2026-08-10', '02:30', CHI)).toEqual({ kind: 'unique' });
+    expect(resolveLocalTime('2026-08-10', '00:00', 'UTC')).toEqual({ kind: 'unique' });
+  });
+
+  it('southern hemisphere: Sydney skips 02:30 on 2026-10-04 and repeats it on 2026-04-05', () => {
+    expect(resolveLocalTime('2026-10-04', '02:30', 'Australia/Sydney')).toEqual({ kind: 'nonexistent' });
+    expect(resolveLocalTime('2026-04-05', '02:30', 'Australia/Sydney')).toEqual({ kind: 'ambiguous' });
+  });
+
+  it('handles a zone with a 30-minute offset (Adelaide) at its 2026-10-04 gap', () => {
+    expect(resolveLocalTime('2026-10-04', '02:30', 'Australia/Adelaide')).toEqual({ kind: 'nonexistent' });
+    expect(resolveLocalTime('2026-10-04', '03:30', 'Australia/Adelaide')).toEqual({ kind: 'unique' });
+  });
+
+  it('a skipped-entirely calendar day is nonexistent at every hour (Kiribati, 1994-12-31)', () => {
+    // Pacific/Kiritimati jumped from UTC-10:40-adjacent to UTC+14 across
+    // 1994-12-31, so that date never happened there. This pins the candidate
+    // check's DATE clause: an instant showing the right wall TIME on the
+    // wrong DATE must not count as an occurrence.
+    expect(resolveLocalTime('1994-12-31', '12:00', 'Pacific/Kiritimati')).toEqual({ kind: 'nonexistent' });
+  });
+});
+
+describe('validateStartTime', () => {
+  it('null for a normal time; names the failure otherwise', () => {
+    expect(validateStartTime('2026-08-10', '09:00', 'America/Chicago')).toBeNull();
+    expect(validateStartTime('2026-03-08', '02:30', 'America/Chicago')).toContain('does not exist');
+    expect(validateStartTime('2026-11-01', '01:30', 'America/Chicago')).toContain('occurs twice');
+    expect(validateStartTime('2026-08-10', '9:00', 'America/Chicago')).toContain('HH:MM');
+  });
+});
+
+describe('validateDurationMinutes', () => {
+  it('accepts 1..1440 integers', () => {
+    expect(validateDurationMinutes(1)).toBeNull();
+    expect(validateDurationMinutes(60)).toBeNull();
+    expect(validateDurationMinutes(1440)).toBeNull();
+  });
+  it('rejects zero, negatives, fractions, overflows, and non-numbers', () => {
+    for (const v of [0, -30, 2.5, 1441, '60', null, undefined, NaN]) {
+      expect(validateDurationMinutes(v), String(v)).not.toBeNull();
+    }
+  });
+});

--- a/electron/mcpLocalTime.ts
+++ b/electron/mcpLocalTime.ts
@@ -1,0 +1,101 @@
+// Local wall-clock time semantics for MCP write tools (spec §5.3), extracted
+// as pure functions in the mcpDates.ts style.
+//
+// THE §5.3 RULE THIS ENCODES: a schedule_task / move_block call landing in a
+// nonexistent or ambiguous local hour returns a VALIDATION ERROR rather than
+// silently picking one. Spring-forward deletes an hour (02:30 does not exist);
+// fall-back repeats one (01:30 happens twice). dayGLANCE stores wall-clock
+// strings, so what matters is not resolving an instant but refusing times the
+// wall clock will not show (nonexistent) or will show twice (ambiguous) on
+// that date — either would silently mean something other than what the model
+// asked for.
+//
+// Everything takes the timezone as an ARGUMENT; Intl does the zone math.
+
+/** Strict local wall-clock time: HH:MM, 24h, zero-padded. */
+export function isValidWallTime(value: unknown): value is string {
+  return typeof value === 'string' && /^([01]\d|2[0-3]):[0-5]\d$/.test(value);
+}
+
+/** The wall-clock (hour, minute) that `epochMs` shows in `timeZone`. */
+function wallClockAt(epochMs: number, timeZone: string): { h: number; m: number; date: string } {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', hourCycle: 'h23',
+  }).formatToParts(new Date(epochMs));
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? '';
+  return { h: Number(get('hour')), m: Number(get('minute')), date: `${get('year')}-${get('month')}-${get('day')}` };
+}
+
+export type LocalTimeResolution =
+  | { kind: 'unique' }
+  | { kind: 'nonexistent' }   // spring-forward gap: the wall clock skips this time
+  | { kind: 'ambiguous' };    // fall-back repeat: the wall clock shows this time twice
+
+/**
+ * Classify a local (date, HH:MM) in `timeZone`.
+ *
+ * Method: candidate UTC instants are derived from the zone offsets in effect
+ * around that date (offset at local-noon ± 1 day covers every real transition;
+ * no zone shifts more than a few hours). Each candidate that formats back to
+ * exactly the requested wall time is a real occurrence: 0 occurrences →
+ * nonexistent, 1 → unique, 2 → ambiguous.
+ */
+export function resolveLocalTime(date: string, time: string, timeZone: string): LocalTimeResolution {
+  const [y, mo, d] = date.split('-').map(Number);
+  const [h, mi] = time.split(':').map(Number);
+  const asUtc = Date.UTC(y, mo - 1, d, h, mi);
+
+  // Offsets in force shortly before and after: derive from how far the zone's
+  // wall clock is from UTC at probe instants a day apart.
+  const offsets = new Set<number>();
+  for (const probe of [asUtc - 24 * 3600_000, asUtc, asUtc + 24 * 3600_000]) {
+    const wc = wallClockAt(probe, timeZone);
+    const wcUtc = Date.UTC(
+      Number(wc.date.slice(0, 4)), Number(wc.date.slice(5, 7)) - 1, Number(wc.date.slice(8, 10)),
+      wc.h, wc.m,
+    );
+    offsets.add(wcUtc - probe);
+  }
+
+  let occurrences = 0;
+  for (const offset of offsets) {
+    const candidate = asUtc - offset;
+    const wc = wallClockAt(candidate, timeZone);
+    if (wc.date === date && wc.h === h && wc.m === mi) occurrences++;
+  }
+
+  if (occurrences === 0) return { kind: 'nonexistent' };
+  if (occurrences === 1) return { kind: 'unique' };
+  return { kind: 'ambiguous' };
+}
+
+/**
+ * Validate a wall-clock start for a given local date (§5.3). Returns null when
+ * acceptable, or the validation message the tool returns verbatim.
+ */
+export function validateStartTime(date: string, time: string, timeZone: string): string | null {
+  if (!isValidWallTime(time)) {
+    return `start time must be local wall-clock HH:MM (24h, zero-padded), got ${JSON.stringify(time)}`;
+  }
+  const res = resolveLocalTime(date, time, timeZone);
+  if (res.kind === 'nonexistent') {
+    return `${time} does not exist on ${date} in ${timeZone} (DST skips it); pick a time outside the transition gap`;
+  }
+  if (res.kind === 'ambiguous') {
+    return `${time} occurs twice on ${date} in ${timeZone} (DST repeats it); pick an unambiguous time`;
+  }
+  return null;
+}
+
+/** Duration bounds for schedule/resize: a block is 1 minute to 24 hours. */
+export function validateDurationMinutes(value: unknown): string | null {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    return `duration_minutes must be an integer, got ${JSON.stringify(value)}`;
+  }
+  if (value < 1 || value > 1440) {
+    return `duration_minutes must be between 1 and 1440, got ${value}`;
+  }
+  return null;
+}

--- a/electron/mcpServer.ts
+++ b/electron/mcpServer.ts
@@ -24,6 +24,7 @@ import {
 import { checkBearerToken, unauthorizedResponse } from './mcpAuth.js';
 import { resolveMcpPort, describeBindFailure } from './mcpPort.js';
 import { registerReadTools, type ReadToolDeps } from './mcpReadTools.js';
+import { registerWriteTools, type WriteToolDeps } from './mcpWriteTools.js';
 
 export const MCP_ENDPOINT_PATH = '/mcp';
 
@@ -39,6 +40,12 @@ export interface McpServerOptions {
    * can still start in a pure-skeleton mode (tests, early dev).
    */
   readDeps?: ReadToolDeps;
+  /**
+   * Dependencies for the write tools (Phase 3): write gate, replay store,
+   * consent tier, tray-policy hook. Same ownership rules as readDeps (§3.7).
+   * Absent means the write tools are not registered at all.
+   */
+  writeDeps?: WriteToolDeps;
   log?: (msg: string) => void;
   logError?: (msg: string) => void;
 }
@@ -88,6 +95,7 @@ export function startMcpServer(opts: McpServerOptions): http.Server | null {
         }),
       );
       if (opts.readDeps) registerReadTools(server, opts.readDeps);
+      if (opts.writeDeps) registerWriteTools(server, opts.writeDeps);
       return server;
     },
     { onerror: (err) => logError(`[dayGLANCE] MCP handler error: ${String(err)}`) },

--- a/electron/mcpWriteGate.test.ts
+++ b/electron/mcpWriteGate.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { createWriteGate, DEFAULT_VIOLATION_LIMIT } from './mcpWriteGate.js';
+
+// §4.3 under test: exceed the limit → rate_limited tool error; keep hammering
+// → writes auto-disable exactly once (the notification edge), and stay off
+// until an explicit reset.
+
+function fakeClock(start = 1_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; } };
+}
+
+const drain = (gate: ReturnType<typeof createWriteGate>, key: string, n: number) => {
+  for (let i = 0; i < n; i++) expect(gate.tryWrite(key)).toEqual({ allowed: true });
+};
+
+describe('createWriteGate', () => {
+  it('admits up to the rate limit, then returns rate_limited', () => {
+    const clock = fakeClock();
+    const gate = createWriteGate({ limit: 3, windowMs: 1000, now: clock.now });
+    drain(gate, 'tok', 3);
+    expect(gate.tryWrite('tok')).toEqual({ allowed: false, reason: 'rate_limited', disabledNow: false });
+    expect(gate.writesDisabled()).toBe(false);
+  });
+
+  it('recovers capacity when the window slides — a single burst never disables', () => {
+    const clock = fakeClock();
+    const gate = createWriteGate({ limit: 2, windowMs: 1000, now: clock.now });
+    drain(gate, 'tok', 2);
+    expect(gate.tryWrite('tok').allowed).toBe(false); // one violation
+    clock.advance(1100);
+    expect(gate.tryWrite('tok')).toEqual({ allowed: true });
+    expect(gate.writesDisabled()).toBe(false);
+  });
+
+  it(`auto-disables on the ${DEFAULT_VIOLATION_LIMIT}rd violation inside the violation window, flagging the edge once`, () => {
+    const clock = fakeClock();
+    const gate = createWriteGate({ limit: 1, windowMs: 60_000, violationLimit: 3, violationWindowMs: 300_000, now: clock.now });
+    drain(gate, 'tok', 1);
+    expect(gate.tryWrite('tok')).toEqual({ allowed: false, reason: 'rate_limited', disabledNow: false });
+    clock.advance(1000);
+    expect(gate.tryWrite('tok')).toEqual({ allowed: false, reason: 'rate_limited', disabledNow: false });
+    clock.advance(1000);
+    // Third violation in the window: this is the disable edge — notification fires here.
+    expect(gate.tryWrite('tok')).toEqual({ allowed: false, reason: 'writes_disabled', disabledNow: true });
+    // After the edge: still refused, but the edge flag never repeats.
+    expect(gate.tryWrite('tok')).toEqual({ allowed: false, reason: 'writes_disabled', disabledNow: false });
+    expect(gate.writesDisabled()).toBe(true);
+  });
+
+  it('violations spaced beyond the violation window do not accumulate to a disable', () => {
+    const clock = fakeClock();
+    const gate = createWriteGate({ limit: 1, windowMs: 1000, violationLimit: 3, violationWindowMs: 5000, now: clock.now });
+    for (let round = 0; round < 5; round++) {
+      drain(gate, 'tok', 1);
+      expect(gate.tryWrite('tok').reason).toBe('rate_limited'); // one violation per round
+      clock.advance(6000); // beyond the violation window — the strike expires
+    }
+    expect(gate.writesDisabled()).toBe(false);
+  });
+
+  it('the disable is process-wide and does not lift with time — only reset() lifts it', () => {
+    const clock = fakeClock();
+    const gate = createWriteGate({ limit: 1, windowMs: 1000, violationLimit: 2, violationWindowMs: 5000, now: clock.now });
+    drain(gate, 'tok', 1);
+    gate.tryWrite('tok');
+    gate.tryWrite('tok');
+    expect(gate.writesDisabled()).toBe(true);
+    clock.advance(60 * 60_000); // an hour of waiting changes nothing
+    expect(gate.tryWrite('tok')).toEqual({ allowed: false, reason: 'writes_disabled', disabledNow: false });
+    expect(gate.tryWrite('other-token').reason).toBe('writes_disabled'); // runaway protection is global
+    gate.reset();
+    expect(gate.tryWrite('tok')).toEqual({ allowed: true });
+  });
+
+  it('reset() clears accumulated strikes, not just the disabled flag', () => {
+    const clock = fakeClock();
+    const gate = createWriteGate({ limit: 1, windowMs: 60_000, violationLimit: 3, violationWindowMs: 300_000, now: clock.now });
+    drain(gate, 'tok', 1);
+    gate.tryWrite('tok'); // strike 1
+    gate.tryWrite('tok'); // strike 2
+    gate.reset();
+    drain(gate, 'tok', 1);
+    gate.tryWrite('tok'); // post-reset strike 1
+    expect(gate.tryWrite('tok')).toEqual({ allowed: false, reason: 'rate_limited', disabledNow: false }); // strike 2, NOT 4
+    expect(gate.writesDisabled()).toBe(false);
+  });
+
+  it('violation strikes are per token even though the disable is global', () => {
+    const clock = fakeClock();
+    const gate = createWriteGate({ limit: 1, windowMs: 60_000, violationLimit: 3, violationWindowMs: 300_000, now: clock.now });
+    drain(gate, 'a', 1);
+    gate.tryWrite('a'); // a: strike 1
+    gate.tryWrite('a'); // a: strike 2
+    drain(gate, 'b', 1);
+    expect(gate.tryWrite('b')).toEqual({ allowed: false, reason: 'rate_limited', disabledNow: false }); // b: strike 1, not 3
+    expect(gate.writesDisabled()).toBe(false);
+  });
+});

--- a/electron/mcpWriteGate.ts
+++ b/electron/mcpWriteGate.ts
@@ -1,0 +1,74 @@
+// Write admission control for MCP (spec §4.3), composing the Phase 1 rate
+// limiter with the "repeated violation auto-disables writes" escalation.
+// Pure factory with an injectable clock, same idiom as mcpRateLimit.ts.
+//
+// §4.3: exceeding the rate limit returns a tool error; if it RECURS, writes
+// auto-disable with a notification. "Recurs" here: a violation while already
+// in the post-violation grace window — i.e. the caller ignored the first
+// rate-limited error and kept hammering. One burst that trips the limit once
+// is an agent being eager; violations in consecutive windows are a runaway
+// loop, which is exactly what §4.3 exists to bound.
+//
+// Auto-disable is process-lifetime: only an explicit re-enable (Phase 5
+// settings; for now an app restart) lifts it. A runaway loop must not get
+// writes back by waiting.
+
+import { createWriteRateLimiter, type WriteRateLimiterOptions } from './mcpRateLimit.js';
+
+export const DEFAULT_VIOLATION_LIMIT = 3;
+export const DEFAULT_VIOLATION_WINDOW_MS = 5 * 60_000;
+
+export type WriteAdmission =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: 'rate_limited' | 'writes_disabled';
+      /** True exactly once: on the violation that flipped writes off — the wiring fires the §4.3 notification on it. */
+      disabledNow: boolean;
+    };
+
+export interface WriteGateOptions extends WriteRateLimiterOptions {
+  /** Violations within violationWindowMs that trigger auto-disable. */
+  violationLimit?: number;
+  violationWindowMs?: number;
+}
+
+export function createWriteGate(opts: WriteGateOptions = {}) {
+  const now = opts.now ?? Date.now;
+  const violationLimit = opts.violationLimit ?? DEFAULT_VIOLATION_LIMIT;
+  const violationWindowMs = opts.violationWindowMs ?? DEFAULT_VIOLATION_WINDOW_MS;
+  const limiter = createWriteRateLimiter(opts);
+
+  /** Violation timestamps per key, same sliding-window shape as the limiter. */
+  const violations = new Map<string, number[]>();
+  let disabled = false;
+
+  return {
+    /** Admit or refuse one write for `key` (the bearer token). Refusals are §5.2 typed errors upstream. */
+    tryWrite(key: string): WriteAdmission {
+      if (disabled) return { allowed: false, reason: 'writes_disabled', disabledNow: false };
+      if (limiter.tryAcquire(key)) return { allowed: true };
+
+      const t = now();
+      const kept = (violations.get(key) ?? []).filter((ts) => ts > t - violationWindowMs);
+      kept.push(t);
+      violations.set(key, kept);
+      if (kept.length >= violationLimit) {
+        disabled = true;
+        return { allowed: false, reason: 'writes_disabled', disabledNow: true };
+      }
+      return { allowed: false, reason: 'rate_limited', disabledNow: false };
+    },
+
+    writesDisabled(): boolean {
+      return disabled;
+    },
+
+    /** Explicit re-enable (Phase 5 settings surface; app restart until then). */
+    reset(): void {
+      disabled = false;
+      violations.clear();
+      limiter.reset();
+    },
+  };
+}

--- a/electron/mcpWriteTools.ts
+++ b/electron/mcpWriteTools.ts
@@ -1,0 +1,272 @@
+// The five Phase 3 write tools (spec §5.1), registered onto a per-request
+// McpServer instance by the mcpServer.ts factory. §3.7 discipline as in
+// mcpReadTools.ts: this module holds no state — the write gate, replay store,
+// consent tier, and renderer bridge all arrive as deps owned by main.ts.
+//
+// PER-WRITE PIPELINE, in order:
+//   1. consent tier (read-write, §6.3) — off means a read_only_mode error
+//   2. idempotency replay — a known (token, tool, key) returns the FIRST
+//      attempt's stored result; no gate charge, no renderer call. This store
+//      is NEW MACHINERY, named as such (spec §5.2 r5): nothing reusable
+//      exists for mutation-level replay protection on move/resize/completion.
+//      What IS reused: the key travels into the mutation as its GLANCEintents
+//      transitionId (delivery dedup at the outbox — the part of the old §5.2
+//      claim that was true), and create_task derives its task id from the key
+//      per the handleIntent.js deterministic-id precedent, so a create replay
+//      no-ops renderer-side even if this store has been reset.
+//   3. write gate (§4.3) — 30/min sliding window keyed on the token; repeated
+//      violations auto-disable writes and fire the notification once.
+//   4. validation (§5.3) — local calendar date, wall-clock time incl. DST
+//      gap/repeat rejection, duration bounds. All before any mutation.
+//   5. renderer mutation through the shared pure module (§3.1 r5), returning
+//      the resulting entity state (§5.2).
+
+import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import type { RendererBridge } from './mcpRendererBridge.js';
+import { isValidLocalDate, localDateOf, dateEnvelope } from './mcpDates.js';
+import { validateStartTime, validateDurationMinutes } from './mcpLocalTime.js';
+import type { createWriteGate } from './mcpWriteGate.js';
+import {
+  createIdempotencyStore,
+  isValidIdempotencyKey,
+  makeStoreKey,
+  deterministicTaskIdFromSeed,
+} from './mcpIdempotency.js';
+
+export interface WriteToolDeps {
+  bridge: RendererBridge;
+  gate: ReturnType<typeof createWriteGate>;
+  store: ReturnType<typeof createIdempotencyStore<StoredResult>>;
+  /** The bearer token — the gate/replay key (no sessions, §3.7). */
+  token: () => string;
+  /** Read-write consent tier (§6.3). Env-sourced in Phase 3; Phase 5 swaps the source. */
+  includeWrites: () => boolean;
+  /** Marks an MCP write for the §3.6 tray reload policy (trayReloadPolicy.ts). */
+  noteMcpWrite: () => void;
+  /** Fired exactly once when repeated violations auto-disable writes (§4.3). */
+  onWritesDisabled: () => void;
+  now: () => number;
+  timeZone: () => string;
+}
+
+type ToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+};
+type StoredResult = Record<string, unknown>;
+
+const ok = (data: Record<string, unknown>): ToolResult => ({
+  content: [{ type: 'text', text: JSON.stringify(data) }],
+  structuredContent: data,
+});
+const toolError = (code: string, message: string): ToolResult => ({
+  isError: true,
+  content: [{ type: 'text', text: JSON.stringify({ error: { code, message } }) }],
+});
+
+const CANNOT_MODIFY_NATIVE =
+  ' Cannot target device calendar events (type "device_calendar_event"): dayGLANCE has read-only ' +
+  'access to the device calendar, and such calls return a device_calendar_readonly error.';
+
+/** "YYYY-MM-DD HH:MM", both halves validated separately for precise §5.3 errors. */
+function parseStart(start: unknown, timeZone: string): { date: string; time: string } | { invalid: string } {
+  if (typeof start !== 'string' || !/^\S+ \S+$/.test(start)) {
+    return { invalid: `start must be "YYYY-MM-DD HH:MM" (local calendar date + local wall-clock time), got ${JSON.stringify(start)}` };
+  }
+  const [date, time] = start.split(' ') as [string, string];
+  if (!isValidLocalDate(date)) {
+    return { invalid: `start date must be a real local calendar date in strict YYYY-MM-DD form, got ${JSON.stringify(date)}` };
+  }
+  const timeError = validateStartTime(date, time, timeZone);
+  if (timeError) return { invalid: timeError };
+  return { date, time };
+}
+
+export function registerWriteTools(server: McpServer, deps: WriteToolDeps): void {
+  /**
+   * The shared pipeline. `mutate` runs only after consent, replay, gate, and
+   * validation all pass; its transitionId is the caller's idempotency key
+   * when given (the §5.2 emit-path reuse), else a fresh UUID.
+   */
+  const write = async (
+    tool: string,
+    idempotencyKey: unknown,
+    mutate: (transitionId: string) => Promise<ToolResult>,
+  ): Promise<ToolResult> => {
+    if (!deps.includeWrites()) {
+      return toolError(
+        'read_only_mode',
+        'dayGLANCE MCP is in read-only mode; writes are a separate opt-in the user has not enabled.',
+      );
+    }
+
+    let storeKey: string | null = null;
+    if (idempotencyKey !== undefined) {
+      if (!isValidIdempotencyKey(idempotencyKey)) {
+        return toolError('validation', 'idempotency_key must be 1-128 chars of [A-Za-z0-9_.:-]');
+      }
+      storeKey = makeStoreKey(deps.token(), tool, idempotencyKey);
+      const replay = deps.store.get(storeKey);
+      if (replay) return ok({ ...replay, replayed: true });
+    }
+
+    const admission = deps.gate.tryWrite(deps.token());
+    if (!admission.allowed) {
+      if (admission.disabledNow) deps.onWritesDisabled();
+      return admission.reason === 'writes_disabled'
+        ? toolError(
+            'writes_disabled',
+            'MCP writes have been automatically disabled after repeated rate-limit violations. The user must re-enable them (restart dayGLANCE in Phase 3).',
+          )
+        : toolError(
+            'rate_limited',
+            'MCP write rate limit reached (30 writes/minute). Wait for the window to slide before retrying; repeated violations disable writes entirely.',
+          );
+    }
+
+    const transitionId = typeof idempotencyKey === 'string' ? idempotencyKey : randomUUID();
+    const result = await mutate(transitionId);
+    if (!result.isError) {
+      deps.noteMcpWrite();
+      if (storeKey && result.structuredContent) deps.store.put(storeKey, result.structuredContent);
+    }
+    return result;
+  };
+
+  /** Map a renderer response onto the tool result, preserving §5.2 error codes. */
+  const fromRenderer = (
+    r: Awaited<ReturnType<RendererBridge['request']>>,
+    envelope: Record<string, unknown>,
+  ): ToolResult => {
+    if (!r.ok) return toolError(r.error.code, r.error.message);
+    return ok({ ...(r.data as Record<string, unknown>), ...envelope });
+  };
+
+  const IDEMPOTENCY_ARG = z.string().optional()
+    .describe('Optional retry token, 1-128 chars of [A-Za-z0-9_.:-]. Replaying the same key returns the first result without repeating the write.');
+
+  server.registerTool(
+    'dayglance_create_task',
+    {
+      description:
+        'Create a new unscheduled task in the dayGLANCE inbox. Returns the created task. ' +
+        'Use dayglance_schedule_task to place it on a day.',
+      inputSchema: z.object({
+        title: z.string().describe('Task title. Required, non-empty.'),
+        notes: z.string().optional(),
+        project_id: z.string().optional().describe('Attach to a project (see dayglance_get_goal_progress).'),
+        idempotency_key: IDEMPOTENCY_ARG,
+      }),
+    },
+    async ({ title, notes, project_id, idempotency_key }) =>
+      write('create_task', idempotency_key, async (transitionId) => {
+        // Deterministic id from the key (handleIntent precedent): a replayed
+        // create converges on the same id and no-ops renderer-side.
+        const taskId = idempotency_key !== undefined
+          ? deterministicTaskIdFromSeed(makeStoreKey(deps.token(), 'create_task', idempotency_key as string))
+          : randomUUID();
+        const r = await deps.bridge.request('create_task', { taskId, title, notes, projectId: project_id, transitionId });
+        return fromRenderer(r, { timezone: deps.timeZone() });
+      }),
+  );
+
+  server.registerTool(
+    'dayglance_schedule_task',
+    {
+      description:
+        'Schedule an unscheduled dayGLANCE inbox task onto a day and time. start is local: ' +
+        '"YYYY-MM-DD HH:MM", no UTC, no offsets. Returns the resulting block.' + CANNOT_MODIFY_NATIVE,
+      inputSchema: z.object({
+        task_id: z.string(),
+        start: z.string().describe('Local "YYYY-MM-DD HH:MM". Times inside a DST gap or repeat are rejected.'),
+        duration_minutes: z.number().int().optional().describe('1-1440. Defaults to the task\'s own duration, then 30.'),
+        idempotency_key: IDEMPOTENCY_ARG,
+      }),
+    },
+    async ({ task_id, start, duration_minutes, idempotency_key }) =>
+      write('schedule_task', idempotency_key, async (transitionId) => {
+        const parsed = parseStart(start, deps.timeZone());
+        if ('invalid' in parsed) return toolError('validation', parsed.invalid);
+        if (duration_minutes !== undefined) {
+          const durationError = validateDurationMinutes(duration_minutes);
+          if (durationError) return toolError('validation', durationError);
+        }
+        const r = await deps.bridge.request('schedule_task', {
+          taskId: task_id, date: parsed.date, startTime: parsed.time, durationMinutes: duration_minutes, transitionId,
+        });
+        return fromRenderer(r, dateEnvelope(parsed.date, deps.timeZone()) as unknown as Record<string, unknown>);
+      }),
+  );
+
+  server.registerTool(
+    'dayglance_move_block',
+    {
+      description:
+        'Move a scheduled dayGLANCE block to a new local start: new_start is "YYYY-MM-DD HH:MM" ' +
+        '(same or different day). Returns the resulting block.' + CANNOT_MODIFY_NATIVE,
+      inputSchema: z.object({
+        block_id: z.string(),
+        new_start: z.string().describe('Local "YYYY-MM-DD HH:MM". Times inside a DST gap or repeat are rejected.'),
+        idempotency_key: IDEMPOTENCY_ARG,
+      }),
+    },
+    async ({ block_id, new_start, idempotency_key }) =>
+      write('move_block', idempotency_key, async (transitionId) => {
+        const parsed = parseStart(new_start, deps.timeZone());
+        if ('invalid' in parsed) return toolError('validation', parsed.invalid);
+        const r = await deps.bridge.request('move_block', {
+          blockId: block_id, date: parsed.date, startTime: parsed.time, transitionId,
+        });
+        return fromRenderer(r, dateEnvelope(parsed.date, deps.timeZone()) as unknown as Record<string, unknown>);
+      }),
+  );
+
+  server.registerTool(
+    'dayglance_resize_block',
+    {
+      description:
+        'Change the duration of a scheduled dayGLANCE block without moving its start. ' +
+        'Returns the resulting block.' + CANNOT_MODIFY_NATIVE,
+      inputSchema: z.object({
+        block_id: z.string(),
+        duration_minutes: z.number().int().describe('New duration, 1-1440 minutes.'),
+        idempotency_key: IDEMPOTENCY_ARG,
+      }),
+    },
+    async ({ block_id, duration_minutes, idempotency_key }) =>
+      write('resize_block', idempotency_key, async (transitionId) => {
+        const durationError = validateDurationMinutes(duration_minutes);
+        if (durationError) return toolError('validation', durationError);
+        const r = await deps.bridge.request('resize_block', {
+          blockId: block_id, durationMinutes: duration_minutes, transitionId,
+        });
+        return fromRenderer(r, { timezone: deps.timeZone() });
+      }),
+  );
+
+  server.registerTool(
+    'dayglance_set_task_completion',
+    {
+      description:
+        'Set a dayGLANCE task\'s completion state (a setter, not a toggle — safe to retry, and ' +
+        'setting completed:false is the agent\'s own undo). Works for scheduled blocks, inbox ' +
+        'tasks, and recurring-task instances.' + CANNOT_MODIFY_NATIVE,
+      inputSchema: z.object({
+        task_id: z.string(),
+        completed: z.boolean(),
+        idempotency_key: IDEMPOTENCY_ARG,
+      }),
+    },
+    async ({ task_id, completed, idempotency_key }) =>
+      write('set_task_completion', idempotency_key, async (transitionId) => {
+        const r = await deps.bridge.request('set_completion', {
+          taskId: task_id, completed, transitionId,
+          todayStr: localDateOf(deps.now(), deps.timeZone()),
+        });
+        return fromRenderer(r, { timezone: deps.timeZone() });
+      }),
+  );
+}

--- a/electron/trayReloadPolicy.test.ts
+++ b/electron/trayReloadPolicy.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import {
+  trayReloadDebounceMs,
+  TRAY_RELOAD_DEBOUNCE_MS,
+  TRAY_RELOAD_MCP_DEBOUNCE_MS,
+  MCP_WRITE_RECENCY_MS,
+} from './trayReloadPolicy.js';
+
+// §3.6 under test: user saves keep the historical 500 ms debounce; a recent
+// MCP write stretches it past the 2 s write cadence at the §4.3 rate limit,
+// so an agent's write storm coalesces instead of reloading the tray per write.
+
+describe('trayReloadDebounceMs', () => {
+  const NOW = 1_000_000;
+
+  it('uses the historical 500 ms when no MCP write has ever happened', () => {
+    expect(TRAY_RELOAD_DEBOUNCE_MS).toBe(500);
+    expect(trayReloadDebounceMs(NOW, null)).toBe(500);
+  });
+
+  it('stretches while MCP writes are recent — and longer than the 2 s rate-limit cadence', () => {
+    expect(TRAY_RELOAD_MCP_DEBOUNCE_MS).toBeGreaterThan(2_000);
+    expect(trayReloadDebounceMs(NOW, NOW)).toBe(TRAY_RELOAD_MCP_DEBOUNCE_MS);
+    expect(trayReloadDebounceMs(NOW, NOW - MCP_WRITE_RECENCY_MS + 1)).toBe(TRAY_RELOAD_MCP_DEBOUNCE_MS);
+  });
+
+  it('reverts to 500 ms once the last MCP write is old enough', () => {
+    expect(trayReloadDebounceMs(NOW, NOW - MCP_WRITE_RECENCY_MS)).toBe(TRAY_RELOAD_DEBOUNCE_MS);
+    expect(trayReloadDebounceMs(NOW, NOW - 60 * 60_000)).toBe(TRAY_RELOAD_DEBOUNCE_MS);
+  });
+
+  it('fails toward coalescing on a backwards clock jump (future lastMcpWriteAt)', () => {
+    expect(trayReloadDebounceMs(NOW, NOW + 5_000)).toBe(TRAY_RELOAD_MCP_DEBOUNCE_MS);
+  });
+});

--- a/electron/trayReloadPolicy.ts
+++ b/electron/trayReloadPolicy.ts
@@ -1,0 +1,39 @@
+// Tray reload debounce policy under MCP write load (spec §3.6), extracted as a
+// pure function in the startupQuit.ts style.
+//
+// THE PROBLEM (§3.6, measured in Phase 3): the tray:data-changed handler is a
+// true trailing debounce at 500 ms — it coalesces only events closer together
+// than 500 ms. An agent writing at the §4.3 rate limit (30/minute = one write
+// every 2 s) never coalesces: every write becomes a tray popup reload, 30
+// reloads/minute for as long as the agent runs. The 4.1.2 cycle spent three
+// PRs getting idle reloads from ~240/hour to near zero; this would be 1800/hour.
+//
+// THE §3.6-SANCTIONED FIX: a LONGER debounce on the MCP path specifically —
+// never a bypass of the emit. While MCP writes are landing, the debounce
+// stretches so the storm coalesces to nothing; the reload fires once, after
+// the writes go quiet. User-originated saves keep the snappy 500 ms.
+
+/** The historical tray debounce for user-originated saves. */
+export const TRAY_RELOAD_DEBOUNCE_MS = 500;
+/** Stretched debounce while an agent is writing: longer than the 2 s gap at the rate limit. */
+export const TRAY_RELOAD_MCP_DEBOUNCE_MS = 5_000;
+/** How recently an MCP write must have landed for the stretched debounce to apply. */
+export const MCP_WRITE_RECENCY_MS = 10_000;
+
+/**
+ * Which debounce the tray:data-changed handler should arm.
+ *
+ * @param nowMs          current clock reading
+ * @param lastMcpWriteAt clock reading of the last MCP-originated write, or
+ *                       null if none has happened this session
+ *
+ * A backwards clock jump (lastMcpWriteAt in the future) still selects the
+ * stretched debounce: the failure mode of one over-coalesced reload is
+ * strictly better than a reload storm.
+ */
+export function trayReloadDebounceMs(nowMs: number, lastMcpWriteAt: number | null): number {
+  if (lastMcpWriteAt === null) return TRAY_RELOAD_DEBOUNCE_MS;
+  const age = nowMs - lastMcpWriteAt;
+  if (age < MCP_WRITE_RECENCY_MS) return TRAY_RELOAD_MCP_DEBOUNCE_MS;
+  return TRAY_RELOAD_DEBOUNCE_MS;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6789,6 +6789,14 @@ const DayPlanner = () => {
     goals,
     projects,
     isVisibleForUser,
+  }, {
+    // Write setters (Phase 3): handleMcpWrite applies the canonical shapes
+    // from src/utils/taskMutations.js through these — the same store layer
+    // every UI edit uses, so sync, tombstones, and tray:data-changed engage
+    // identically (spec §3.1 r5).
+    setTasks,
+    setUnscheduledTasks,
+    setRecurringTasks,
   });
 
   useElectronBridge({

--- a/src/hooks/useMcpBridge.js
+++ b/src/hooks/useMcpBridge.js
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { isTrayMode } from '../utils/trayMode.js';
 import { handleMcpRequest } from '../utils/mcpReadModel.js';
+import { handleMcpWrite, isWriteMethod } from '../utils/mcpWriteModel.js';
 
 // The renderer half of the MCP IPC channel (docs/mcp-server-spec.md §10
 // Phase 2), following the useTrayPopupVisible precedent from PR #1302: this
@@ -20,9 +21,11 @@ import { handleMcpRequest } from '../utils/mcpReadModel.js';
 // cannot delay the reply: if this renderer is alive, the answer is immediate,
 // which is what makes the main process's short ping timeout (§3.3 health
 // check, not existence check) safe.
-export default function useMcpBridge(state) {
+export default function useMcpBridge(state, setters) {
   const stateRef = useRef(state);
   stateRef.current = state;
+  const settersRef = useRef(setters);
+  settersRef.current = setters;
 
   useEffect(() => {
     if (isTrayMode) return undefined;
@@ -30,7 +33,14 @@ export default function useMcpBridge(state) {
     return window.electronAPI.onMcpRequest((request) => {
       let response;
       try {
-        response = handleMcpRequest(stateRef.current, request);
+        // Writes route through the shared pure-mutation module (spec §3.1 r5)
+        // and reply immediately after the setters are invoked: the mutation is
+        // committed by React's batch in this same task, and the save pass
+        // (useSaveOnChange → saveData → tray:data-changed) follows on the
+        // commit. Reads stay synchronous against the current state ref.
+        response = isWriteMethod(request?.method)
+          ? handleMcpWrite(stateRef.current, settersRef.current ?? {}, request)
+          : handleMcpRequest(stateRef.current, request);
       } catch (err) {
         // A throwing model must still answer — silence here would read as a
         // dead renderer and turn one bad request into "dayGLANCE unavailable".

--- a/src/utils/mcpWriteModel.js
+++ b/src/utils/mcpWriteModel.js
@@ -1,0 +1,98 @@
+// Renderer-side dispatcher for MCP write requests (spec §10 Phase 3),
+// companion to mcpReadModel.js. Pure decisions live in taskMutations.js;
+// this module maps request methods onto them, applies the results through
+// the provided React setters, and shapes the §5.2 response (the resulting
+// entity state, via the same toBlock the read surface uses).
+//
+// ATOMICITY (§5.2 no-partial-success): each mutation computes every affected
+// slice from the same input state, and the setters are invoked back-to-back
+// in the same handler tick — React batches them into one commit, so a
+// schedule_task can never land with the task removed from the inbox but not
+// yet on the calendar. A failed validation returns before any setter runs.
+
+import {
+  applyCreateTask,
+  applyScheduleTask,
+  applyMoveBlock,
+  applyResizeBlock,
+  applySetCompletion,
+} from './taskMutations.js';
+import { toBlock } from './mcpReadModel.js';
+
+const WRITE_METHODS = new Set(['create_task', 'schedule_task', 'move_block', 'resize_block', 'set_completion']);
+
+export function isWriteMethod(method) {
+  return WRITE_METHODS.has(method);
+}
+
+/**
+ * @param state   live slices: { tasks, unscheduledTasks, recurringTasks }
+ * @param setters { setTasks, setUnscheduledTasks, setRecurringTasks }
+ * @param request { method, params }
+ * Returns { ok:true, data } | { ok:false, error:{ code, message } } — same
+ * envelope as handleMcpRequest, mapped by the main process onto §5.2 errors.
+ */
+export function handleMcpWrite(state, setters, request) {
+  const params = request?.params ?? {};
+  const nowIso = new Date().toISOString();
+
+  switch (request?.method) {
+    case 'create_task': {
+      const r = applyCreateTask(state, { ...params, nowIso });
+      if (!r.ok) return r;
+      if (!r.replayed) setters.setUnscheduledTasks(r.unscheduledTasks);
+      return { ok: true, data: { task: inboxItem(r.task), replayed: r.replayed } };
+    }
+    case 'schedule_task': {
+      const r = applyScheduleTask(state, { ...params, nowIso });
+      if (!r.ok) return r;
+      if (!r.replayed) {
+        setters.setUnscheduledTasks(r.unscheduledTasks);
+        setters.setTasks(r.tasks);
+      }
+      return { ok: true, data: { block: toBlock(r.task), replayed: r.replayed } };
+    }
+    case 'move_block': {
+      const r = applyMoveBlock(state, params);
+      if (!r.ok) return r;
+      if (!r.replayed) setters.setTasks(r.tasks);
+      return { ok: true, data: { block: toBlock(r.task), replayed: r.replayed } };
+    }
+    case 'resize_block': {
+      const r = applyResizeBlock(state, params);
+      if (!r.ok) return r;
+      if (!r.replayed) setters.setTasks(r.tasks);
+      return { ok: true, data: { block: toBlock(r.task), replayed: r.replayed } };
+    }
+    case 'set_completion': {
+      const r = applySetCompletion(state, { ...params, nowIso });
+      if (!r.ok) return r;
+      if (!r.replayed) {
+        if (r.recurringTasks) setters.setRecurringTasks(r.recurringTasks);
+        if (r.tasks) setters.setTasks(r.tasks);
+        if (r.unscheduledTasks) setters.setUnscheduledTasks(r.unscheduledTasks);
+      }
+      const entity = r.task.date !== undefined || r.task.startTime !== undefined
+        ? { block: toBlock(r.task) }
+        : { task: { id: r.task.id, completed: !!r.task.completed } };
+      return { ok: true, data: { ...entity, replayed: r.replayed } };
+    }
+    default:
+      return { ok: false, error: { code: 'validation', message: `Unknown write method ${JSON.stringify(request?.method)}` } };
+  }
+}
+
+/** Inbox-item wire shape, matching buildUnscheduledItems in mcpReadModel.js. */
+function inboxItem(t) {
+  const item = {
+    id: t.id,
+    type: 'task',
+    title: t.title ?? '',
+    priority: typeof t.priority === 'number' ? t.priority : 0,
+    completed: !!t.completed,
+  };
+  if (t.deadline) item.deadline = t.deadline;
+  if (t.projectId) item.project_id = t.projectId;
+  if (t.notes) item.notes = t.notes;
+  return item;
+}

--- a/src/utils/taskMutations.js
+++ b/src/utils/taskMutations.js
@@ -1,0 +1,267 @@
+// Canonical task-mutation shapes, extracted as pure state-in/state-out
+// functions (trayFetchGate.js style) for the MCP write path — spec §3.1 as
+// restated in revision 5: every MCP write goes through the same store layer
+// via this shared module, so the save pass, dirty tracking, tombstones, and
+// tray:data-changed all engage identically to a UI edit.
+//
+// EACH SHAPE IS A TRANSCRIPTION of the UI's own write, cited per function.
+// The UI call sites still perform these inline (useDragDrop.js drag/resize
+// handlers, useTaskActions.js) — converting them to call this module is a
+// planned follow-up, deliberately NOT part of Phase 3, so the drag paths
+// stay untouched while MCP lands.
+//
+// DELIBERATE DIFFERENCES from the UI handlers, per spec §3.1 (r5):
+//  - no pushUndo() — the §4.3 write journal is the undo surface for MCP writes
+//  - no playUISound() / haptics — an agent write must not chirp the speaker
+//  - no onboarding-progress side effects
+//
+// _NATIVE GUARD (spec §5.2): dayGLANCE holds EventKit read access only. The
+// UI's drag handlers write the device calendar via nativeUpdateEvent and fall
+// back to display overrides; a store-layer write would be a transient visual
+// lie discarded on the next calendar refetch. Every mutating function here
+// rejects _native explicitly — and none of this module touches localStorage,
+// so no day-planner-native-time-overrides entry can ever be written from it.
+
+export const WRITE_ERROR_CODES = Object.freeze({
+  NOT_FOUND: 'not_found',
+  VALIDATION: 'validation',
+  NATIVE_READONLY: 'device_calendar_readonly',
+});
+
+const err = (code, message) => ({ ok: false, error: { code, message } });
+
+const NATIVE_MSG = (id) =>
+  `${id} is a device calendar event. dayGLANCE has read-only access to the device calendar and cannot modify, move, resize, or complete its events.`;
+
+/** The recurring-instance id shape, mirroring App.jsx parseRecurringId. */
+export function parseRecurringInstanceId(id) {
+  if (typeof id !== 'string' || !id.startsWith('recurring-')) return null;
+  const parts = id.split('-');
+  const dateStr = parts.slice(-3).join('-');
+  const rawTemplateId = parts.slice(1, -3).join('-');
+  const templateId = /^\d+$/.test(rawTemplateId) ? Number(rawTemplateId) : rawTemplateId;
+  return { templateId, dateStr };
+}
+
+/**
+ * CREATE (inbox). Shape transcribed from useTaskActions.js addTask's inbox
+ * branch (:155-174): base task + priority default 0, appended to
+ * unscheduledTasks.
+ *
+ * Idempotent per the handleIntent.js:347-389 precedent (the one create-shaped
+ * mutation-level dedup in the codebase): the caller derives `taskId`
+ * deterministically from its idempotency key, so a replayed create finds the
+ * id already present and returns the existing task unchanged.
+ */
+export function applyCreateTask(state, { taskId, title, notes, projectId, transitionId, nowIso }) {
+  const unscheduled = state.unscheduledTasks ?? [];
+  const trimmed = typeof title === 'string' ? title.trim() : '';
+  if (!trimmed) return err(WRITE_ERROR_CODES.VALIDATION, 'title must be a non-empty string');
+
+  const existing = unscheduled.find((t) => t.id === taskId) ?? (state.tasks ?? []).find((t) => t.id === taskId);
+  if (existing) {
+    return { ok: true, replayed: true, unscheduledTasks: unscheduled, task: existing };
+  }
+
+  const task = {
+    id: taskId,
+    title: trimmed,
+    duration: 30,
+    color: 'bg-blue-500',
+    completed: false,
+    isAllDay: false,
+    notes: typeof notes === 'string' ? notes : '',
+    subtasks: [],
+    priority: 0,
+    ...(projectId ? { projectId } : {}),
+    ...(transitionId ? { transitionId } : {}),
+    lastModified: nowIso,
+  };
+  return { ok: true, replayed: false, unscheduledTasks: [...unscheduled, task], task };
+}
+
+/**
+ * SCHEDULE (inbox → day + time). Shape transcribed from useTaskActions.js
+ * scheduleDeadlineTaskAt (:791-806): strip priority/deadline, remove from the
+ * inbox, append to tasks with date/startTime/duration/isAllDay:false and a
+ * fresh lastModified. transitionId added on top (the drop path at
+ * useDragDrop.js:468 stamps it; the deadline path predates it) so the
+ * GLANCEintents emit correlates to the caller's idempotency key.
+ */
+export function applyScheduleTask(state, { taskId, date, startTime, durationMinutes, transitionId, nowIso }) {
+  const unscheduled = state.unscheduledTasks ?? [];
+  const tasks = state.tasks ?? [];
+
+  const task = unscheduled.find((t) => t.id === taskId);
+  if (!task) {
+    const scheduled = tasks.find((t) => t.id === taskId);
+    if (scheduled?._native) return err(WRITE_ERROR_CODES.NATIVE_READONLY, NATIVE_MSG(taskId));
+    if (scheduled) {
+      // Replay of a completed schedule lands here: already on the calendar.
+      if (scheduled.transitionId && transitionId && scheduled.transitionId === transitionId) {
+        return { ok: true, replayed: true, unscheduledTasks: unscheduled, tasks, task: scheduled };
+      }
+      return err(WRITE_ERROR_CODES.VALIDATION, `${taskId} is already scheduled; use move_block to change its time`);
+    }
+    return err(WRITE_ERROR_CODES.NOT_FOUND, `No unscheduled task with id ${taskId}`);
+  }
+  if (task._native) return err(WRITE_ERROR_CODES.NATIVE_READONLY, NATIVE_MSG(taskId));
+
+  const { priority: _p, deadline: _d, ...preserved } = task;
+  const scheduledTask = {
+    ...preserved,
+    date,
+    startTime,
+    duration: durationMinutes ?? task.duration ?? 30,
+    isAllDay: false,
+    ...(transitionId ? { transitionId } : {}),
+    lastModified: nowIso,
+  };
+  return {
+    ok: true,
+    replayed: false,
+    unscheduledTasks: unscheduled.filter((t) => t.id !== taskId),
+    tasks: [...tasks, scheduledTask],
+    task: scheduledTask,
+  };
+}
+
+/** Shared lookup + guards for the block-mutating tools. */
+function findWritableBlock(tasks, blockId, { operation }) {
+  if (parseRecurringInstanceId(blockId)) {
+    return err(
+      WRITE_ERROR_CODES.VALIDATION,
+      `${blockId} is a recurring-task instance; ${operation} on recurring instances is not supported in v1 — edit the series in dayGLANCE`,
+    );
+  }
+  const task = tasks.find((t) => t.id === blockId);
+  if (!task) return err(WRITE_ERROR_CODES.NOT_FOUND, `No scheduled block with id ${blockId}`);
+  if (task._native) return err(WRITE_ERROR_CODES.NATIVE_READONLY, NATIVE_MSG(blockId));
+  return { ok: true, task };
+}
+
+/**
+ * MOVE. Shape transcribed from the canonical drop handler,
+ * useDragDrop.js:466-470: `{ ...t, startTime, date, isAllDay: false,
+ * transitionId }`. (lastModified is stamped by stampTaskTimestamps in the
+ * save pass, exactly as for the UI drop.)
+ */
+export function applyMoveBlock(state, { blockId, date, startTime, transitionId }) {
+  const tasks = state.tasks ?? [];
+  const found = findWritableBlock(tasks, blockId, { operation: 'move_block' });
+  if (!found.ok) return found;
+
+  if (found.task.transitionId && transitionId && found.task.transitionId === transitionId) {
+    return { ok: true, replayed: true, tasks, task: found.task };
+  }
+  const moved = { ...found.task, startTime, date, isAllDay: false, ...(transitionId ? { transitionId } : {}) };
+  return { ok: true, replayed: false, tasks: tasks.map((t) => (t.id === blockId ? moved : t)), task: moved };
+}
+
+/**
+ * RESIZE. Shape transcribed from the resize loop write,
+ * useDragDrop.js:774-776: `{ ...t, duration }`. transitionId added on top
+ * (the UI resize does not stamp one — noted in the Phase 3 trace) so the
+ * emit correlation holds for MCP.
+ */
+export function applyResizeBlock(state, { blockId, durationMinutes, transitionId }) {
+  const tasks = state.tasks ?? [];
+  const found = findWritableBlock(tasks, blockId, { operation: 'resize_block' });
+  if (!found.ok) return found;
+
+  if (found.task.transitionId && transitionId && found.task.transitionId === transitionId) {
+    return { ok: true, replayed: true, tasks, task: found.task };
+  }
+  const resized = { ...found.task, duration: durationMinutes, ...(transitionId ? { transitionId } : {}) };
+  return { ok: true, replayed: false, tasks: tasks.map((t) => (t.id === blockId ? resized : t)), task: resized };
+}
+
+/**
+ * COMPLETION — a SETTER, not the UI's toggle (§5.1: setter gives the agent
+ * its own undo without a delete-shaped tool), so it is naturally idempotent:
+ * setting the state a task is already in is a no-op replay.
+ *
+ * Branches transcribed from useTaskActions.js toggleComplete:
+ *  - recurring instance (:415-431): completedDates membership on the template,
+ *    stamped per-date in completedDatesTimestamps so sync resolves by
+ *    last-writer-wins per date.
+ *  - inbox (:449-452): completed + completedAt + transitionId.
+ *  - scheduled (:474-476): completed + transitionId (no completedAt — the UI
+ *    scheduled branch does not set it, and this module matches the UI).
+ *
+ * NOT supported here, rejected explicitly rather than half-done:
+ *  - _native events (read-only, see module header)
+ *  - CalDAV task-calendar tasks (isTaskCalendar + icalUid): the UI pairs the
+ *    local flip with a network write (syncTaskCompletionToCalDAV); doing the
+ *    flip without the network half would desync the user's CalDAV server. A
+ *    pure module cannot do the network half — v1 rejects.
+ */
+export function applySetCompletion(state, { taskId, completed, transitionId, todayStr, nowIso }) {
+  const tasks = state.tasks ?? [];
+  const unscheduled = state.unscheduledTasks ?? [];
+  const recurring = state.recurringTasks ?? [];
+
+  const instance = parseRecurringInstanceId(taskId);
+  if (instance) {
+    const template = recurring.find((t) => t.id === instance.templateId);
+    if (!template) return err(WRITE_ERROR_CODES.NOT_FOUND, `No recurring series behind ${taskId}`);
+    const isCompleted = (template.completedDates || []).includes(instance.dateStr);
+    if (isCompleted === completed) {
+      return { ok: true, replayed: true, recurringTasks: recurring, task: { id: taskId, completed } };
+    }
+    const nextTemplate = {
+      ...template,
+      completedDates: completed
+        ? [...(template.completedDates || []), instance.dateStr]
+        : (template.completedDates || []).filter((d) => d !== instance.dateStr),
+      completedDatesTimestamps: { ...(template.completedDatesTimestamps || {}), [instance.dateStr]: nowIso },
+      lastModified: nowIso,
+    };
+    return {
+      ok: true,
+      replayed: false,
+      recurringTasks: recurring.map((t) => (t.id === instance.templateId ? nextTemplate : t)),
+      task: { id: taskId, completed },
+    };
+  }
+
+  const inInbox = unscheduled.find((t) => t.id === taskId);
+  const scheduled = tasks.find((t) => t.id === taskId);
+  const task = inInbox ?? scheduled;
+  if (!task) return err(WRITE_ERROR_CODES.NOT_FOUND, `No task with id ${taskId}`);
+  if (task._native) return err(WRITE_ERROR_CODES.NATIVE_READONLY, NATIVE_MSG(taskId));
+  if (task.isTaskCalendar && task.icalUid) {
+    return err(
+      WRITE_ERROR_CODES.VALIDATION,
+      `${taskId} is a CalDAV task-calendar task; completing it requires a CalDAV write that MCP v1 does not perform`,
+    );
+  }
+
+  if (!!task.completed === completed) {
+    return { ok: true, replayed: true, tasks, unscheduledTasks: unscheduled, task };
+  }
+
+  if (inInbox) {
+    const next = {
+      ...task,
+      completed,
+      completedAt: completed ? todayStr : null,
+      ...(transitionId ? { transitionId } : {}),
+    };
+    return {
+      ok: true,
+      replayed: false,
+      tasks,
+      unscheduledTasks: unscheduled.map((t) => (t.id === taskId ? next : t)),
+      task: next,
+    };
+  }
+  const next = { ...task, completed, ...(transitionId ? { transitionId } : {}) };
+  return {
+    ok: true,
+    replayed: false,
+    tasks: tasks.map((t) => (t.id === taskId ? next : t)),
+    unscheduledTasks: unscheduled,
+    task: next,
+  };
+}

--- a/src/utils/taskMutations.test.js
+++ b/src/utils/taskMutations.test.js
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseRecurringInstanceId,
+  applyCreateTask,
+  applyScheduleTask,
+  applyMoveBlock,
+  applyResizeBlock,
+  applySetCompletion,
+  WRITE_ERROR_CODES,
+} from './taskMutations.js';
+
+// The §3.1 (r5) shared pure module under test. Load-bearing assertions:
+// each shape matches its cited UI transcription; _native is rejected by
+// every mutating function; replays are no-ops returning the existing
+// entity; nothing here can touch localStorage (structural — see the
+// "never writes an override" test).
+
+const NOW = '2026-08-10T12:00:00.000Z';
+const T = (over = {}) => ({
+  id: 'b1', title: 'Block', date: '2026-08-10', startTime: '09:00',
+  duration: 60, completed: false, isAllDay: false, notes: '', subtasks: [], ...over,
+});
+const NATIVE = T({ id: 'native-cal-e1', _native: true, nativeEventId: 'e1', imported: true });
+
+describe('parseRecurringInstanceId', () => {
+  it('mirrors the App.jsx id shape, uuid template ids included', () => {
+    expect(parseRecurringInstanceId('recurring-abc-def-2026-08-10')).toEqual({ templateId: 'abc-def', dateStr: '2026-08-10' });
+    expect(parseRecurringInstanceId('recurring-42-2026-08-10')).toEqual({ templateId: 42, dateStr: '2026-08-10' });
+    expect(parseRecurringInstanceId('b1')).toBeNull();
+    expect(parseRecurringInstanceId(undefined)).toBeNull();
+  });
+});
+
+describe('applyCreateTask', () => {
+  const state = { tasks: [], unscheduledTasks: [{ id: 'u1', title: 'Existing' }] };
+
+  it('appends the addTask inbox shape: duration 30, priority 0, empty notes/subtasks', () => {
+    const r = applyCreateTask(state, { taskId: 'new-1', title: '  Buy milk  ', transitionId: 'k1', nowIso: NOW });
+    expect(r.ok).toBe(true);
+    expect(r.replayed).toBe(false);
+    expect(r.task).toMatchObject({
+      id: 'new-1', title: 'Buy milk', duration: 30, priority: 0,
+      completed: false, isAllDay: false, notes: '', subtasks: [], transitionId: 'k1', lastModified: NOW,
+    });
+    expect(r.unscheduledTasks).toHaveLength(2);
+    expect(state.unscheduledTasks).toHaveLength(1); // pure: input untouched
+  });
+
+  it('carries notes and projectId when given', () => {
+    const r = applyCreateTask(state, { taskId: 'n2', title: 'T', notes: 'context', projectId: 'p1', nowIso: NOW });
+    expect(r.task.notes).toBe('context');
+    expect(r.task.projectId).toBe('p1');
+  });
+
+  it('replay (deterministic id already present) returns the existing task unchanged — the handleIntent precedent', () => {
+    const r = applyCreateTask(state, { taskId: 'u1', title: 'Different title', nowIso: NOW });
+    expect(r.ok).toBe(true);
+    expect(r.replayed).toBe(true);
+    expect(r.task.title).toBe('Existing');
+    expect(r.unscheduledTasks).toBe(state.unscheduledTasks);
+  });
+
+  it('also detects the replayed id among scheduled tasks (task was scheduled after creation)', () => {
+    const r = applyCreateTask({ tasks: [T({ id: 'x' })], unscheduledTasks: [] }, { taskId: 'x', title: 'T', nowIso: NOW });
+    expect(r.replayed).toBe(true);
+  });
+
+  it('rejects an empty or whitespace title', () => {
+    for (const title of ['', '   ', undefined, 42]) {
+      const r = applyCreateTask(state, { taskId: 'n3', title, nowIso: NOW });
+      expect(r.ok, String(title)).toBe(false);
+      expect(r.error.code).toBe(WRITE_ERROR_CODES.VALIDATION);
+    }
+  });
+});
+
+describe('applyScheduleTask', () => {
+  const state = {
+    tasks: [T()],
+    unscheduledTasks: [{ id: 'u1', title: 'Inbox', priority: 2, deadline: '2026-09-01', duration: 45, notes: '', subtasks: [] }],
+  };
+
+  it('moves inbox → calendar with the scheduleDeadlineTaskAt shape: priority/deadline stripped', () => {
+    const r = applyScheduleTask(state, {
+      taskId: 'u1', date: '2026-08-11', startTime: '14:00', durationMinutes: 90, transitionId: 'k1', nowIso: NOW,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.task).toMatchObject({
+      id: 'u1', date: '2026-08-11', startTime: '14:00', duration: 90,
+      isAllDay: false, transitionId: 'k1', lastModified: NOW,
+    });
+    expect(r.task).not.toHaveProperty('priority');
+    expect(r.task).not.toHaveProperty('deadline');
+    expect(r.unscheduledTasks).toEqual([]);
+    expect(r.tasks).toHaveLength(2);
+  });
+
+  it('defaults duration to the task duration, then 30', () => {
+    const r = applyScheduleTask(state, { taskId: 'u1', date: '2026-08-11', startTime: '14:00', nowIso: NOW });
+    expect(r.task.duration).toBe(45);
+    const bare = { unscheduledTasks: [{ id: 'u2', title: 'x' }], tasks: [] };
+    const r2 = applyScheduleTask(bare, { taskId: 'u2', date: '2026-08-11', startTime: '14:00', nowIso: NOW });
+    expect(r2.task.duration).toBe(30);
+  });
+
+  it('replay: an already-scheduled task with the same transitionId no-ops; without it, a validation error points at move_block', () => {
+    const scheduled = { tasks: [T({ id: 'u1', transitionId: 'k1' })], unscheduledTasks: [] };
+    const replay = applyScheduleTask(scheduled, { taskId: 'u1', date: '2026-08-11', startTime: '14:00', transitionId: 'k1', nowIso: NOW });
+    expect(replay.ok).toBe(true);
+    expect(replay.replayed).toBe(true);
+    const fresh = applyScheduleTask(scheduled, { taskId: 'u1', date: '2026-08-11', startTime: '14:00', transitionId: 'other', nowIso: NOW });
+    expect(fresh.ok).toBe(false);
+    expect(fresh.error.message).toContain('move_block');
+  });
+
+  it('not_found for unknown ids; _native rejected with the typed code', () => {
+    expect(applyScheduleTask(state, { taskId: 'nope', date: '2026-08-11', startTime: '14:00', nowIso: NOW }).error.code)
+      .toBe(WRITE_ERROR_CODES.NOT_FOUND);
+    const withNative = { tasks: [NATIVE], unscheduledTasks: [] };
+    expect(applyScheduleTask(withNative, { taskId: 'native-cal-e1', date: '2026-08-11', startTime: '14:00', nowIso: NOW }).error.code)
+      .toBe(WRITE_ERROR_CODES.NATIVE_READONLY);
+  });
+});
+
+describe('applyMoveBlock', () => {
+  const state = { tasks: [T(), NATIVE] };
+
+  it('applies the canonical drop shape: startTime, date, isAllDay false, transitionId', () => {
+    const r = applyMoveBlock(state, { blockId: 'b1', date: '2026-08-12', startTime: '16:30', transitionId: 'k2' });
+    expect(r.ok).toBe(true);
+    expect(r.task).toMatchObject({ id: 'b1', date: '2026-08-12', startTime: '16:30', isAllDay: false, transitionId: 'k2' });
+    expect(r.tasks.find((t) => t.id === 'b1').startTime).toBe('16:30');
+  });
+
+  it('rejects _native with device_calendar_readonly — and cannot write an override (no storage access exists here)', () => {
+    const r = applyMoveBlock(state, { blockId: 'native-cal-e1', date: '2026-08-12', startTime: '16:30' });
+    expect(r.ok).toBe(false);
+    expect(r.error.code).toBe(WRITE_ERROR_CODES.NATIVE_READONLY);
+    expect(r.error.message).toContain('read-only');
+  });
+
+  it('rejects recurring instances in v1 with a message pointing at the series', () => {
+    const r = applyMoveBlock(state, { blockId: 'recurring-r1-2026-08-10', date: '2026-08-12', startTime: '16:30' });
+    expect(r.ok).toBe(false);
+    expect(r.error.code).toBe(WRITE_ERROR_CODES.VALIDATION);
+    expect(r.error.message).toContain('recurring');
+  });
+
+  it('not_found for unknown block ids; replay with the same transitionId no-ops', () => {
+    expect(applyMoveBlock(state, { blockId: 'zzz', date: '2026-08-12', startTime: '10:00' }).error.code)
+      .toBe(WRITE_ERROR_CODES.NOT_FOUND);
+    const moved = { tasks: [T({ transitionId: 'k2' })] };
+    const r = applyMoveBlock(moved, { blockId: 'b1', date: '2026-08-13', startTime: '08:00', transitionId: 'k2' });
+    expect(r.replayed).toBe(true);
+    expect(r.task.date).toBe('2026-08-10'); // unchanged — the first application stands
+  });
+});
+
+describe('applyResizeBlock', () => {
+  const state = { tasks: [T(), NATIVE] };
+
+  it('applies the canonical resize shape: duration only', () => {
+    const r = applyResizeBlock(state, { blockId: 'b1', durationMinutes: 120, transitionId: 'k3' });
+    expect(r.ok).toBe(true);
+    expect(r.task.duration).toBe(120);
+    expect(r.task.startTime).toBe('09:00'); // untouched
+  });
+
+  it('rejects _native and recurring instances, not_found otherwise', () => {
+    expect(applyResizeBlock(state, { blockId: 'native-cal-e1', durationMinutes: 120 }).error.code)
+      .toBe(WRITE_ERROR_CODES.NATIVE_READONLY);
+    expect(applyResizeBlock(state, { blockId: 'recurring-r1-2026-08-10', durationMinutes: 120 }).error.code)
+      .toBe(WRITE_ERROR_CODES.VALIDATION);
+    expect(applyResizeBlock(state, { blockId: 'zzz', durationMinutes: 120 }).error.code)
+      .toBe(WRITE_ERROR_CODES.NOT_FOUND);
+  });
+});
+
+describe('applySetCompletion', () => {
+  const recurringState = {
+    tasks: [], unscheduledTasks: [],
+    recurringTasks: [{ id: 'r1', title: 'Standup', completedDates: ['2026-08-09'], completedDatesTimestamps: {} }],
+  };
+
+  it('completes a scheduled task with a transitionId and no completedAt (matching the UI scheduled branch)', () => {
+    const r = applySetCompletion({ tasks: [T()], unscheduledTasks: [] }, { taskId: 'b1', completed: true, transitionId: 'k4', todayStr: '2026-08-10', nowIso: NOW });
+    expect(r.ok).toBe(true);
+    expect(r.task).toMatchObject({ id: 'b1', completed: true, transitionId: 'k4' });
+    expect(r.task).not.toHaveProperty('completedAt');
+  });
+
+  it('completes an inbox task WITH completedAt (matching the UI inbox branch)', () => {
+    const r = applySetCompletion(
+      { tasks: [], unscheduledTasks: [{ id: 'u1', title: 'x', completed: false }] },
+      { taskId: 'u1', completed: true, transitionId: 'k5', todayStr: '2026-08-10', nowIso: NOW },
+    );
+    expect(r.task.completedAt).toBe('2026-08-10');
+    const undo = applySetCompletion(
+      { tasks: [], unscheduledTasks: [r.task] },
+      { taskId: 'u1', completed: false, todayStr: '2026-08-10', nowIso: NOW },
+    );
+    expect(undo.task.completedAt).toBeNull();
+  });
+
+  it('is a setter, so it is naturally idempotent: setting the current state is a replay no-op', () => {
+    const done = { tasks: [T({ completed: true })], unscheduledTasks: [] };
+    const r = applySetCompletion(done, { taskId: 'b1', completed: true, todayStr: '2026-08-10', nowIso: NOW });
+    expect(r.replayed).toBe(true);
+    expect(r.tasks).toBe(done.tasks);
+  });
+
+  it('recurring instance: toggles completedDates membership with a per-date timestamp (sync LWW per date)', () => {
+    const r = applySetCompletion(recurringState, { taskId: 'recurring-r1-2026-08-10', completed: true, todayStr: '2026-08-10', nowIso: NOW });
+    expect(r.ok).toBe(true);
+    const template = r.recurringTasks[0];
+    expect(template.completedDates).toEqual(['2026-08-09', '2026-08-10']);
+    expect(template.completedDatesTimestamps['2026-08-10']).toBe(NOW);
+    expect(template.lastModified).toBe(NOW);
+
+    const uncomplete = applySetCompletion(
+      { ...recurringState, recurringTasks: r.recurringTasks },
+      { taskId: 'recurring-r1-2026-08-09', completed: false, todayStr: '2026-08-10', nowIso: NOW },
+    );
+    expect(uncomplete.recurringTasks[0].completedDates).toEqual(['2026-08-10']);
+  });
+
+  it('recurring replay: already in the requested state is a no-op', () => {
+    const r = applySetCompletion(recurringState, { taskId: 'recurring-r1-2026-08-09', completed: true, todayStr: '2026-08-10', nowIso: NOW });
+    expect(r.replayed).toBe(true);
+    expect(r.recurringTasks).toBe(recurringState.recurringTasks);
+  });
+
+  it('rejects _native, CalDAV task-calendar tasks, and unknown ids with distinct codes', () => {
+    const s = {
+      tasks: [NATIVE, T({ id: 'cal1', isTaskCalendar: true, icalUid: 'uid-1', imported: true })],
+      unscheduledTasks: [],
+    };
+    expect(applySetCompletion(s, { taskId: 'native-cal-e1', completed: true, todayStr: '2026-08-10', nowIso: NOW }).error.code)
+      .toBe(WRITE_ERROR_CODES.NATIVE_READONLY);
+    const caldav = applySetCompletion(s, { taskId: 'cal1', completed: true, todayStr: '2026-08-10', nowIso: NOW });
+    expect(caldav.error.code).toBe(WRITE_ERROR_CODES.VALIDATION);
+    expect(caldav.error.message).toContain('CalDAV');
+    expect(applySetCompletion(s, { taskId: 'zzz', completed: true, todayStr: '2026-08-10', nowIso: NOW }).error.code)
+      .toBe(WRITE_ERROR_CODES.NOT_FOUND);
+    expect(applySetCompletion({ tasks: [], unscheduledTasks: [], recurringTasks: [] }, { taskId: 'recurring-gone-2026-08-10', completed: true, todayStr: '2026-08-10', nowIso: NOW }).error.code)
+      .toBe(WRITE_ERROR_CODES.NOT_FOUND);
+  });
+});
+
+describe('structural: the module can never write a native override', () => {
+  it('taskMutations.js contains no storage or override access at all', async () => {
+    // The §5.2 guarantee "no override entry is written" is structural: the
+    // module has no localStorage reference to misuse. Read the source and pin
+    // it, so a future edit that adds one fails a test, not a review.
+    const fs = await import('node:fs');
+    const raw = fs.readFileSync(new URL('./taskMutations.js', import.meta.url), 'utf8');
+    // Strip comments — the header legitimately DISCUSSES storage; the code must not touch it.
+    const code = raw
+      .split('\n')
+      .filter((line) => !/^\s*(\/\/|\/?\*)/.test(line))
+      .join('\n');
+    expect(code).not.toMatch(/localStorage/);
+    expect(code).not.toMatch(/native-time-overrides/);
+    expect(code).not.toMatch(/window\./);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of `docs/mcp-server-spec.md` §10, implemented per the ratified **Option C**: the canonical update shapes are extracted into a shared pure module (`src/utils/taskMutations.js`, state-in/state-out, `trayFetchGate` style), each function a cited transcription of the UI's own write. MCP uses it now; converting the UI drag/resize call sites to the same module is a follow-up PR, not this phase. Also includes **spec revision 5** (separate commit): §3.1 restated ("through the same store layer via a shared pure module"), §5.2's idempotency claim corrected (`transitionId` = outbox delivery dedup, not mutation-level replay protection; `handleIntent.js` is the only precedent and is create-shaped), §3.6 corrected (the tray debounce resets per event, so at the §4.3 rate every write would reload the popup — `trayReloadPolicy.ts` recorded as the fix).

**Five tools:** `dayglance_create_task`, `dayglance_schedule_task`, `dayglance_move_block`, `dayglance_resize_block`, `dayglance_set_task_completion` (a setter, not a toggle). No delete tools. Per-write pipeline: consent tier (`DAYGLANCE_MCP_WRITES` behind a closure, Phase 5 swaps the source) → idempotency replay (bounded main-process store — **new machinery, named as such in the code**; the key rides into the emit path as `transitionId`, and `create_task` derives its task id deterministically from the key per the `handleIntent` precedent) → write gate (30/min sliding window; repeated violations auto-disable writes with a one-shot notification) → §5.3 validation (strict local dates, DST gap/repeat rejection, duration bounds) → renderer mutation through the pure module. Writes return the resulting entity (§5.2), apply in one React batch (no partial success), and deliberately skip `pushUndo`/UI sounds — the §4.3 write journal is the MCP undo surface.

**`_native` rejection** is explicit in the write path: every mutating function returns a typed `device_calendar_readonly` error, and the module has no storage access at all (pinned by a structural test), so no `day-planner-native-time-overrides` entry can ever be written from it. Recurring-instance move/resize and CalDAV-task completion are typed v1 rejections rather than half-done writes.

## Exit criteria

1. ⚠️ **Two-device sync — needs your hardware** (this environment has no GLANCEvault/second device). To close: enable writes on device A (`DAYGLANCE_MCP_DEV=1`, `DAYGLANCE_MCP_TOKEN`, `DAYGLANCE_MCP_WRITES=1`), run one `dayglance_create_task` + `dayglance_schedule_task` + `dayglance_move_block` through Claude Code, confirm all three land on device B after sync.
2. ✅ **GLANCEintents event** — verified live: completing a `source_app` task via MCP enqueued a notify with `event_id` equal to the MCP `idempotency_key` (activity log: `event: uncompleted, event_id: intents-002, delivery: queued`).
3. ⚠️ **Tombstone cycle — needs your hardware**: after (1), delete the MCP-created task on device B, sync both, confirm it does not resurrect on A.
4. ✅ **`tray:data-changed`** — verified live with instrumented build output: every MCP write produced exactly one arrival at the main-process handler (persistence chain confirmed via localStorage state).
5. ✅ **Reload volume** — at 2 s write spacing (the §4.3 cadence) every arrival armed the stretched 5000 ms debounce, so the trailing timer never fired mid-storm: zero reloads during sustained writes, one after quiet; a user save in the same session kept the historical 500 ms. Burst past the limit: 20 ok → 2 `rate_limited` → auto-disable on the 3rd violation (notification fired once) → `writes_disabled` thereafter.
6. ✅ **`_native` rejection** — unit-verified on all three write tools (typed error) plus the structural no-storage-access test; live rejection also exercised for recurring instances and unknown ids. (A live `_native` event cannot exist on Linux — EventKit is macOS — so the flag-level behavior is pinned by tests rather than a live device event; the override-absence guarantee is structural.)

Also verified live: create replay converges on the same deterministic task id (`replayed: true`, one task); DST gap (`2026-03-08 02:30`) and repeat (`2026-11-01 01:30`) rejected with §5.3 messages; completion setter idempotent including recurring `completedDates` with per-date LWW timestamps; `read_only_mode` without the writes tier while reads keep working.

## Tested vs not

Unit-tested + mutation-verified: `taskMutations.js` (23 tests, 15/15 mutants killed), `mcpLocalTime` (13, incl. Kiribati skipped-day), `mcpWriteGate` (7), `mcpIdempotency` (9), `trayReloadPolicy` (4) — groundwork modules at 23/24 mutants killed, 1 equivalent. Wiring verified live but not unit-tested, as in Phases 1–2: `mcpWriteTools.ts`, `mcpWriteModel.js`, `useMcpBridge`, `main.ts` glue.

Full suite: 96 files / 1433 tests green; lint and both tsc configs clean.