### PR TITLE
iOS: fix silent share loss, replace the blank share flash, add an iOS build gate

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,91 @@
+name: iOS build
+
+# Verifies the iOS app, widget, and Share Extension still compile after web or
+# native changes. Build-only: no code signing, no device/simulator run, no
+# upload — just a "does Xcode still accept this" gate, since the iOS targets
+# have no other CI coverage (ci.yml is Linux-only and never touches Swift).
+#
+# Runs on macOS (Xcode is macOS-only). Scoped to changes that can affect the iOS
+# build so ordinary web-only PRs don't spend a macOS runner. Note the Xcode
+# project is NOT committed — XcodeGen generates it from dayglance-ios/project.yml
+# on every run, so this builds exactly what that file declares.
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'dayglance-ios/**'
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.ios.js'
+      - 'scripts/gen-ios-project.sh'
+      - '.github/workflows/ios.yml'
+  pull_request:
+    paths:
+      - 'dayglance-ios/**'
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.ios.js'
+      - 'scripts/gen-ios-project.sh'
+      - '.github/workflows/ios.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    # macos-15 for a recent Xcode: DayGlanceWidget targets iOS 17.0, above the
+    # app's and the Share Extension's 16.0.
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select latest Xcode
+        run: sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      # npm run ios = build:ios (vite → dayglance-ios/DayGlance/Resources/web)
+      # then ios:generate (scripts/gen-ios-project.sh → DayGlance.xcodeproj).
+      # BUILD_NUMBER is pinned so CI doesn't depend on the wall clock.
+      - name: Build web assets and generate Xcode project
+        run: npm run ios
+        env:
+          BUILD_NUMBER: '0.0'
+
+      # The project's Copy Web Assets phase only *errors* on a Release build; on
+      # Debug it just warns. Without this check a green Debug build could still
+      # be packaging an app with no web content at all.
+      - name: Verify web assets were produced
+        run: |
+          ASSETS="dayglance-ios/DayGlance/Resources/web/index.html"
+          if [ ! -f "$ASSETS" ]; then
+            echo "::error::Web assets missing at $ASSETS — 'npm run build:ios' produced no index.html."
+            exit 1
+          fi
+          echo "Web assets present: $ASSETS"
+
+      # One scheme covers all three targets: project.yml declares DayGlance with
+      # `targets: DayGlance: all`, and the widget and Share Extension are embedded
+      # dependencies of the app.
+      - name: Build iOS app (no signing)
+        run: |
+          xcodebuild build \
+            -project dayglance-ios/DayGlance.xcodeproj \
+            -scheme DayGlance \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO

--- a/dayglance-ios/DayGlance/Bridges/WidgetBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/WidgetBridge.swift
@@ -69,8 +69,20 @@ final class WidgetBridge {
     func getPendingShares() -> String {
         guard let defaults = UserDefaults(suiteName: Self.appGroup) else { return "[]" }
         let items = defaults.stringArray(forKey: "shareExtensionPending") ?? []
+        guard !items.isEmpty else { return "[]" }
+
+        // Encode with JSONSerialization, never string concatenation. This used to
+        // hand-build the array escaping only \ and ", which leaves control
+        // characters raw — and shared text routinely contains newlines (a shared
+        // paragraph) or tabs. A raw newline inside a JSON string literal is
+        // invalid, so JSON.parse threw on the web side and the entire batch was
+        // discarded, taking any well-formed shares queued alongside it.
+        guard let data = try? JSONSerialization.data(withJSONObject: items),
+              let json = String(data: data, encoding: .utf8) else { return "[]" }
+
+        // Clear only once the payload is safely encoded: bailing out above leaves
+        // the queue intact for the next attempt instead of dropping it.
         defaults.removeObject(forKey: "shareExtensionPending")
-        let json = items.map { "\"\($0.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\""))\"" }.joined(separator: ",")
-        return "[\(json)]"
+        return json
     }
 }

--- a/dayglance-ios/ShareExtension/ShareViewController.swift
+++ b/dayglance-ios/ShareExtension/ShareViewController.swift
@@ -2,15 +2,67 @@ import UIKit
 import Social
 import UniformTypeIdentifiers
 
+/// Share Extension entry point. Receives text / links shared into dayGLANCE from
+/// the iOS share sheet, appends them to the App Group queue under
+/// "shareExtensionPending", and confirms to the user. The app drains that queue
+/// via WidgetBridge.getPendingShares() when it next comes to the foreground and
+/// opens a pre-filled Add-task form.
+///
+/// NOTE ON WHY THIS SHOWS UI: the extension deliberately does not try to open
+/// dayGLANCE. App extensions are barred from opening URLs — the responder-chain
+/// openURL: trick stopped working in iOS 18 and Apple is explicit that this is by
+/// design, not an oversight to route around. (Android differs: its ACTION_SEND
+/// intent-filter really does launch MainActivity, so sharing there opens the app.
+/// The platforms genuinely behave differently and that is not a bug.)
+///
+/// So a share can only land quietly in the App Group. Without UI this presented as
+/// an empty white sheet flashing on screen and vanishing — the default
+/// UIViewController view, shown for however long the async extraction took — which
+/// reads as a failure. This confirmation is that missing feedback.
 class ShareViewController: UIViewController {
+
+    private let appGroup = "group.com.dayglance.app"
+    private let pendingKey = "shareExtensionPending"
+
+    // dayGLANCE brand orange, plus neutrals matching the app's light/dark themes
+    // (Tailwind gray-800/gray-50). Resolved per trait collection so the sheet
+    // follows the system appearance like the rest of the app.
+    private let brand = UIColor(red: 0xFE / 255, green: 0x8B / 255, blue: 0x00 / 255, alpha: 1)
+    private let cardColor = UIColor(dynamicProvider: { traits in
+        traits.userInterfaceStyle == .dark
+            ? UIColor(red: 0x1F / 255, green: 0x29 / 255, blue: 0x37 / 255, alpha: 1)
+            : UIColor.white
+    })
+    private let titleColor = UIColor(dynamicProvider: { traits in
+        traits.userInterfaceStyle == .dark
+            ? UIColor(red: 0xF9 / 255, green: 0xFA / 255, blue: 0xFB / 255, alpha: 1)
+            : UIColor(red: 0x11 / 255, green: 0x18 / 255, blue: 0x27 / 255, alpha: 1)
+    })
+    private let subtitleColor = UIColor(red: 0x9C / 255, green: 0xA3 / 255, blue: 0xAF / 255, alpha: 1)
+
+    private let card = UIView()
+    private let headline = UILabel()
+    private let detail = UILabel()
+    private let doneButton = UIButton(type: .system)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        buildUI()
+    }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         extractContent { [weak self] text in
-            if let text {
-                self?.saveToAppGroup(text: text)
+            guard let self else { return }
+            // loadItem's completion is not guaranteed to be on the main queue.
+            DispatchQueue.main.async {
+                if let text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    self.saveToAppGroup(text: text)
+                    self.show(saved: text)
+                } else {
+                    self.show(saved: nil)
+                }
             }
-            self?.extensionContext?.completeRequest(returningItems: nil)
         }
     }
 
@@ -36,9 +88,73 @@ class ShareViewController: UIViewController {
     }
 
     private func saveToAppGroup(text: String) {
-        guard let defaults = UserDefaults(suiteName: "group.com.dayglance.app") else { return }
-        var pending = defaults.stringArray(forKey: "shareExtensionPending") ?? []
+        guard let defaults = UserDefaults(suiteName: appGroup) else { return }
+        var pending = defaults.stringArray(forKey: pendingKey) ?? []
         pending.append(text)
-        defaults.set(pending, forKey: "shareExtensionPending")
+        defaults.set(pending, forKey: pendingKey)
+    }
+
+    // MARK: - UI
+
+    private func buildUI() {
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+
+        card.backgroundColor = cardColor
+        card.layer.cornerRadius = 16
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.alpha = 0
+        view.addSubview(card)
+
+        headline.font = .systemFont(ofSize: 17, weight: .semibold)
+        headline.textColor = titleColor
+        headline.numberOfLines = 1
+        headline.textAlignment = .center
+
+        detail.font = .systemFont(ofSize: 14)
+        detail.textColor = subtitleColor
+        detail.numberOfLines = 3
+        detail.textAlignment = .center
+
+        doneButton.setTitle("Done", for: .normal)
+        doneButton.setTitleColor(brand, for: .normal)
+        doneButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
+        doneButton.addTarget(self, action: #selector(finish), for: .touchUpInside)
+
+        let stack = UIStackView(arrangedSubviews: [headline, detail, doneButton])
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            card.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            card.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            card.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 32),
+            card.widthAnchor.constraint(lessThanOrEqualToConstant: 340),
+            stack.topAnchor.constraint(equalTo: card.topAnchor, constant: 24),
+            stack.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -20),
+            stack.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -24),
+        ])
+    }
+
+    /// `saved` is the shared text we captured, or nil when there was nothing usable.
+    private func show(saved: String?) {
+        if let saved {
+            let oneLine = saved
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .replacingOccurrences(of: "\n", with: " ")
+            headline.text = "Saved to dayGLANCE"
+            detail.text = "\(oneLine)\n\nIt'll be waiting as a new task next time you open the app."
+        } else {
+            headline.text = "Nothing to save"
+            detail.text = "This item didn't contain any text or link dayGLANCE could use."
+        }
+        UIView.animate(withDuration: 0.2) { self.card.alpha = 1 }
+    }
+
+    @objc private func finish() {
+        extensionContext?.completeRequest(returningItems: nil)
     }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -396,6 +396,9 @@ const DayPlanner = () => {
   // captured when they were bound at mount.
   const selectedDateRef = useRef(selectedDate);
   selectedDateRef.current = selectedDate;
+  // Shares from the iOS Share Extension arrive as a batch, but the Add-task form
+  // shows one at a time. Hold the remainder here and advance as each one closes.
+  const pendingSharesRef = useRef([]);
   const [tasks, setTasks] = useState([]);
   const [unscheduledTasks, setUnscheduledTasks] = useState([]);
   // Live refs to the current task state, reassigned every render. applyEngineData
@@ -1928,27 +1931,23 @@ const DayPlanner = () => {
         }
       }, 200);
       if (window.DayGlanceNative?.getShareExtensionPending) {
+        const raw = window.DayGlanceNative.getShareExtensionPending();
+        let items = null;
         try {
-          const raw = window.DayGlanceNative.getShareExtensionPending();
-          const items = JSON.parse(raw);
-          if (Array.isArray(items) && items.length > 0) {
-            items.forEach(text => {
-              const { title: shareTitle, notes: shareNotes } = extractShareTitle(text);
-              setNewTask({
-                title: shareTitle,
-                notes: shareNotes || undefined,
-                startTime: getNextQuarterHour(),
-                duration: 30,
-                date: dateToString(selectedDateRef.current),
-                isAllDay: false,
-                openInInbox: true,
-                deadline: null,
-                priority: 0,
-              });
-              setShowAddTask(true);
-            });
-          }
-        } catch (_) {}
+          items = JSON.parse(raw);
+        } catch (err) {
+          // The native side has already cleared the queue by this point, so a parse
+          // failure loses the batch. Never swallow it silently — that hid a bug where
+          // shared text containing a newline produced invalid JSON and every queued
+          // share disappeared without a trace.
+          console.error('[share] could not parse pending shares; batch lost:', err, raw);
+        }
+        if (Array.isArray(items) && items.length > 0) {
+          // Queue them: the Add-task form shows one at a time, so opening them in a
+          // loop would just overwrite state and only the last share would survive.
+          pendingSharesRef.current.push(...items);
+          openNextPendingShare();
+        }
       }
     };
     document.addEventListener('visibilitychange', handleVisibility);
@@ -2759,6 +2758,37 @@ const DayPlanner = () => {
     
     return `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}`;
   };
+
+  // Pops the next queued Share Extension item into the Add-task form. No-op when
+  // the queue is empty or the form is already showing one.
+  const openNextPendingShare = () => {
+    if (pendingSharesRef.current.length === 0) return;
+    const text = pendingSharesRef.current.shift();
+    const { title: shareTitle, notes: shareNotes } = extractShareTitle(text);
+    setNewTask({
+      title: shareTitle,
+      notes: shareNotes || undefined,
+      startTime: getNextQuarterHour(),
+      duration: 30,
+      date: dateToString(selectedDateRef.current),
+      isAllDay: false,
+      openInInbox: true,
+      deadline: null,
+      priority: 0,
+    });
+    setShowAddTask(true);
+  };
+
+  // Advance the share queue when the Add-task form closes, whether the user saved
+  // or dismissed — both are a decision about that share. Only fires while shares
+  // are actually queued, so ordinary use of the form is unaffected.
+  useEffect(() => {
+    if (!showAddTask && pendingSharesRef.current.length > 0) openNextPendingShare();
+    // openNextPendingShare is redefined every render but only reads refs and stable
+    // setters; depending on it would re-run this effect on every render instead of
+    // on the open/close transition it's watching.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showAddTask]);
 
   const getTaskCalendarStyle = (task, isDarkMode) => {
     // Native Android calendar events: apply the calendar color from the device.


### PR DESCRIPTION
## What and why

Sharing a web page into dayGLANCE on iOS flashed an empty white popup and appeared to do nothing. The task did show up on next launch, but the experience read as failure. Investigating that surfaced two silent data-loss bugs on the same path.

### 1. Shared text containing a newline destroyed the whole queue

`WidgetBridge.getPendingShares()` hand-built its JSON array, escaping only backslash and quote. Control characters were left raw, and shared text routinely contains newlines (a shared paragraph) or tabs. A raw newline inside a JSON string literal is invalid, so `JSON.parse` threw on the web side. Because the App Group key was already cleared before returning, the entire batch was destroyed: **one multi-line share took every well-formed share queued alongside it.**

Reproduced against the old encoder versus the new one:

```
old  single-line URL        parse OK, round-trip exact
new  single-line URL        parse OK, round-trip exact
old  MULTI-LINE note        THROWS: JSONDecodeError
new  MULTI-LINE note        parse OK, round-trip exact
old  multi-line + others    THROWS: JSONDecodeError     <- two good URLs lost with it
new  multi-line + others    parse OK, round-trip exact
```

Now encoded with `JSONSerialization`, and the key is cleared only after encoding succeeds, so a failure leaves the queue intact for the next attempt instead of dropping it.

### 2. Only the last share of a batch survived

The web drain called `setNewTask` / `setShowAddTask` inside `items.forEach`. Those are React state setters in a synchronous loop, so N shares collapsed to the last one, and the rest were unrecoverable since the key had already been cleared.

Shares now go into a ref queue and open one at a time, advancing as the Add-task form closes, whether the user saved or dismissed (both are a decision about that share).

### 3. The parse failure was swallowed

It sat in a bare `catch (_) {}`, which is why bug 1 went unnoticed. It now logs the error and the raw payload.

### 4. The blank white flash

The Share Extension had no UI, so iOS presented a bare `UIViewController`'s default white view for the duration of the async extraction, then tore it down. There is now a confirmation ("Saved to dayGLANCE", the captured text, Done) that follows the system light/dark appearance and uses the brand orange for the action.

The extension still deliberately does not open the app, and a comment records why so it is not "fixed" later: app extensions are barred from opening URLs, the responder-chain `openURL:` technique stopped working in iOS 18, and Apple is explicit that this is by design. Android genuinely differs, since its `ACTION_SEND` intent-filter does launch `MainActivity`, so the platforms behaving differently here is not a bug.

## Also in this PR: an iOS build gate

`dayglance-ios` has 35 Swift files (~5,100 lines) across the app, widget, and Share Extension with no compile coverage at all. `ci.yml` is Linux-only and never touches Swift, so native regressions could only surface on someone's machine, and the Swift changes above could not otherwise be verified.

Build-only, no signing, path-filtered so web-only PRs do not spend a macOS runner. Two things specific to this repo:

- The `.xcodeproj` is not committed; XcodeGen generates it from `project.yml`. CI installs xcodegen and runs `npm run ios`, so the build always reflects `project.yml` with no checked-in project to drift. `BUILD_NUMBER` is pinned so the generated build number does not depend on the wall clock.
- An explicit web-assets check. The Copy Web Assets phase only errors on Release; on Debug it warns, so a green Debug build could otherwise be packaging an app with no web content.

This is arguably a second logical change and can be split out if preferred. It is bundled because it is what verifies the Swift in this PR.

## Verification

- Lint clean, 1376 tests pass across 91 files. **No test covers the share path**, so that is a no-regression signal only.
- The new iOS workflow passes on this branch. Confirmed from the build log that all four targets compiled (`DayGlance`, `DayGlanceWidget`, `ShareExtension`, `RevenueCat`), both `.appex` bundles passed `ValidateEmbeddedBinary`, and the two changed Swift files compiled for arm64 and x86_64.

**Not verified: anything at runtime.** CI compiles but never launches. These need a device:

1. Share a link from Safari, confirm the sheet appears instead of the white flash, then open the app and check the task is pre-filled.
2. Share a multi-line paragraph from Notes. This is the case that was destroying data.
3. Share several items without opening the app in between, then confirm each one appears in turn rather than only the last.
4. Share something with no usable content, and confirm it says so rather than dismissing silently.
5. Check the sheet in both light and dark appearance.

## Noticed, not addressed

The build gate immediately surfaced two pre-existing issues, left alone to keep this focused:

- `SubscriptionBridge.swift:30` and `:52`: "code after 'return' will never be executed."
- The Copy Web Assets phase declares no outputs, so Xcode reruns it every build and warns about it.

Two gaps in the extension itself, also unchanged: it never reads `attributedContentText`, so a Safari share does not capture the page title (`extractShareTitle` falls back to the hostname), and its activation rule omits `NSExtensionActivationSupportsWebPageWithMaxCount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ)_