### PR TITLE
Correct stale comments about Obsidian vault access

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -258,7 +258,7 @@ On **Android**, the native `HttpBridge` makes HTTP requests directly from Kotlin
 
 Obsidian tasks are treated as a **read source**: dayGLANCE imports tasks from daily notes and writes completion state back, but the vault is never the authoritative store. The app owns scheduling.
 
-### Desktop (File System Access API)
+### Desktop browser / PWA (File System Access API)
 
 The user picks their vault root with `window.showDirectoryPicker()`. The directory handle is persisted in IndexedDB so permission only needs to be granted once per session.
 
@@ -269,6 +269,19 @@ User picks vault root
   → file.text() → parse markdown
   → write back: fileHandle.createWritable() → write(content)
 ```
+
+### Electron (main-process vault access)
+
+All Electron builds (dev, Developer ID, MAS) bypass the renderer's FSA path: the
+folder is picked with the native dialog and all file I/O runs in the main process
+(`electron/obsidian.ts`), which the renderer drives through an FSA-shaped shim
+(`src/obsidianElectronHandle.js`) so the sync logic above runs unchanged. On MAS
+the dialog returns a security-scoped bookmark (persisted to
+`userData/obsidian-vault.json`, re-opened on launch via
+`app.startAccessingSecurityScopedResource`) because a restored FSA handle cannot
+re-establish sandbox access; unsandboxed builds read/write the picked path
+directly. Currently macOS-only: `obsidian:pick`/`obsidian:restore` return `null`
+on Windows/Linux.
 
 ### Android (Storage Access Framework)
 

--- a/electron/entitlements.mas.plist
+++ b/electron/entitlements.mas.plist
@@ -30,12 +30,16 @@
     <!-- Obsidian vault: user picks folder via open panel -->
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
-    <!-- Persist that folder access across relaunches. The Obsidian integration uses
-         the File System Access API (showDirectoryPicker) and stores the directory
-         handle in IndexedDB; on the next launch Chromium needs an app-scoped
-         security-scoped bookmark to re-establish sandbox access to that folder.
-         Without this, a restored handle reports "granted" but writes fail with
-         "could not be modified due to the state of the underlying filesystem". -->
+    <!-- Persist that folder access across relaunches. Consumed by the main-process
+         vault path in electron/obsidian.ts: the folder is picked with
+         dialog.showOpenDialog({ securityScopedBookmarks: true }), the returned
+         bookmark is persisted to userData/obsidian-vault.json, and obsidian:restore
+         calls app.startAccessingSecurityScopedResource(bookmark) on each launch.
+         (The renderer's File System Access path is browser/PWA-only: under the
+         sandbox Chromium cannot resolve bookmarks for a restored FSA handle — it
+         reports "granted" but every write fails with "could not be modified due to
+         the state of the underlying filesystem" — which is why the main process
+         owns vault access on Electron.) -->
     <key>com.apple.security.files.bookmarks.app-scope</key>
     <true/>
     <!-- iCloud CloudDocuments sync -->

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,9 +4,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   isElectron: true,
   platform: process.platform,
   // True only in the Mac App Store (sandboxed) build. Electron sets process.mas
-  // for the `mas` target. Used to gate sandbox-only behavior (e.g. Obsidian vault
-  // access via the main process) so the unsandboxed Developer ID / dev build keeps
-  // its proven File System Access path unchanged.
+  // for the `mas` target. Used to suppress behavior App Store review disallows —
+  // today that is the GitHub-releases update check (App.jsx) and its update
+  // banner (SettingsModal.jsx). NOTE: it does NOT gate Obsidian vault access.
+  // ALL Electron builds (dev, Developer ID, MAS) route the vault through the
+  // main process; the renderer keys that solely on the presence of
+  // window.electronAPI.obsidian, exposed unconditionally below. Only the
+  // security-scoped-bookmark half of that path is MAS-specific, and it is
+  // handled inside electron/obsidian.ts, not gated here.
   isMAS: process.mas === true,
 
   // Renderer pushes app state to connected WebSocket clients (e.g. Stream Deck plugin)

--- a/src/obsidianElectronHandle.js
+++ b/src/obsidianElectronHandle.js
@@ -6,10 +6,12 @@
  * createWritable().write()/.close(), and NotFoundError semantics), backed by the
  * Electron main process via window.electronAPI.obsidian.*.
  *
- * This lets all of obsidian.js's proven markdown/sync logic run unchanged on the
- * Mac App Store build, where the vault folder is accessed in the main process
- * through a security-scoped bookmark (the renderer's own FS Access handle can't
- * persist across relaunch under the sandbox).
+ * This lets all of obsidian.js's proven markdown/sync logic run unchanged on
+ * EVERY Electron build (dev, Developer ID, and MAS — see the unification note
+ * in src/obsidian.js), where the vault folder is accessed in the main process.
+ * The security-scoped bookmark half of that path is MAS-specific: under the
+ * sandbox the renderer's own FS Access handle can't persist across relaunch,
+ * while the unsandboxed builds simply read/write the picked path directly.
  */
 
 function notFoundError() {


### PR DESCRIPTION
## Summary

Comment/doc text only — no behavior change. The touched comments described the superseded vault-access design (renderer FSA handle persisted in IndexedDB, main-process path gated to MAS). Reality since the unification: **all** Electron builds route vault access through the main process, keyed on the presence of `window.electronAPI.obsidian`; only the security-scoped-bookmark half is MAS-specific.

- **`electron/preload.ts`** — the `isMAS` comment claimed it gates "Obsidian vault access via the main process." It doesn't; its real consumers are the GitHub-releases update check (`App.jsx`) and update banner (`SettingsModal.jsx`). Rewritten to say what it actually gates and where the vault path is actually keyed.
- **`electron/entitlements.mas.plist`** — the `files.bookmarks.app-scope` comment described Chromium resolving a persisted FSA handle. Rewritten: the entitlement is consumed by the main-process dialog path (`showOpenDialog({securityScopedBookmarks: true})` → bookmark persisted to `userData/obsidian-vault.json` → `app.startAccessingSecurityScopedResource` on each launch), with the old FSA failure mode kept as the explanation for why the main process owns vault access.
- **`src/obsidianElectronHandle.js`** (found in the sweep) — header said the shim exists for "the Mac App Store build"; it runs on every Electron build. Rewritten.
- **`ARCHITECTURE.md`** (found in the sweep) — the "Desktop (File System Access API)" section described only the browser/PWA path as if it were the desktop app's. Retitled to "Desktop browser / PWA" and added an "Electron (main-process vault access)" section, including the current macOS-only gate on `obsidian:pick`/`obsidian:restore`.

Checked accurate and left alone: the `src/obsidian.js` header and unification/migration notes, and the `electron/obsidian.ts` header (both already describe the current design).

Validated: preload tsc clean, lint clean, plist XML well-formed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_