### PR TITLE
Obsidian vault access on Windows/Linux, with portable-filename validation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -280,8 +280,10 @@ the dialog returns a security-scoped bookmark (persisted to
 `userData/obsidian-vault.json`, re-opened on launch via
 `app.startAccessingSecurityScopedResource`) because a restored FSA handle cannot
 re-establish sandbox access; unsandboxed builds read/write the picked path
-directly. Currently macOS-only: `obsidian:pick`/`obsidian:restore` return `null`
-on Windows/Linux.
+directly (Windows/Linux/dev-macOS). On non-macOS platforms `obsidian:restore`
+verifies the stored vault path still exists and is readable before restoring —
+there is no bookmark whose resolution would otherwise catch a moved or
+unmounted vault.
 
 ### Android (Storage Access Framework)
 

--- a/electron/obsidian.ts
+++ b/electron/obsidian.ts
@@ -72,7 +72,6 @@ export function registerObsidianHandlers(): void {
   // Native folder picker. Returns { path, name } and persists the security-scoped
   // bookmark so access survives relaunch. null if the user cancels.
   ipcMain.handle('obsidian:pick', async (event) => {
-    if (process.platform !== 'darwin') return null;
     const opts = {
       properties: ['openDirectory', 'createDirectory'] as Array<'openDirectory' | 'createDirectory'>,
       securityScopedBookmarks: true,
@@ -91,12 +90,26 @@ export function registerObsidianHandlers(): void {
     return { path: dir, name: path.basename(dir) };
   });
 
-  // Re-open a previously-picked vault on launch. Resolves the stored bookmark and
-  // begins access. Returns { path, name } or null if nothing is configured.
+  // Re-open a previously-picked vault on launch. Resolves the stored bookmark
+  // (macOS) and begins access. Returns { path, name } or null if nothing is
+  // configured — null is the same signal the renderer already treats as
+  // "not connected", so the Settings UI falls back to the Select Vault button.
   ipcMain.handle('obsidian:restore', async () => {
-    if (process.platform !== 'darwin') return null;
     const cfg = loadConfig();
     if (!cfg) return null;
+    // Off-macOS there is no bookmark to fail at resolve time, so a vault on a
+    // removed drive, unmounted share, or remapped drive letter would restore
+    // "successfully" and then throw on the first fs call at write time.
+    // Check reachability here instead and fail the restore cleanly (config is
+    // kept, matching macOS stale-bookmark behavior — a re-pick overwrites it).
+    if (process.platform !== 'darwin') {
+      try {
+        fs.accessSync(cfg.path, fs.constants.R_OK);
+        if (!fs.statSync(cfg.path).isDirectory()) return null;
+      } catch {
+        return null;
+      }
+    }
     vaultBasePath = cfg.path;
     beginAccess(cfg.bookmark);
     return { path: cfg.path, name: path.basename(cfg.path) };

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -205,9 +205,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('tray:focus-quick-add', handler);
   },
 
-  // Obsidian vault (macOS) — folder access held by the main process via a
-  // security-scoped bookmark so it survives relaunch under the App Sandbox. The
-  // renderer drives file I/O through the shim in src/obsidianElectronHandle.js.
+  // Obsidian vault — folder access held by the main process on every desktop
+  // platform. On macOS a security-scoped bookmark keeps it alive across
+  // relaunch under the App Sandbox; on Windows/Linux a plain persisted path is
+  // used and restore verifies it is still reachable. The renderer drives file
+  // I/O through the shim in src/obsidianElectronHandle.js.
   obsidian: {
     pick: (): Promise<{ path: string; name: string } | null> => ipcRenderer.invoke('obsidian:pick'),
     restore: (): Promise<{ path: string; name: string } | null> => ipcRenderer.invoke('obsidian:restore'),

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -13,7 +13,8 @@ import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from '../constants/habits
 import { getDeviceId, isNativeAndroid, isNativeApp, nativeGetCalendars, nativePickVault, nativeGetAutomationIntentsEnabled, nativeSetAutomationIntentsEnabled } from '../native.js';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
-import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, listVaultNotes } from '../obsidian.js';
+import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, listVaultNotes, formatDatePattern } from '../obsidian.js';
+import { validateDailyNotePattern, validateVaultFolderSetting } from '../utils/obsidianFilename.js';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
 import ICloudDiagnostics from './ICloudDiagnostics.jsx';
 import ICloudSyncToggle from './ICloudSyncToggle.jsx';
@@ -1609,6 +1610,9 @@ const MobileSettingsPanel = () => {
                 onChange={(e) => setObsidianConfig(prev => ({ ...prev, newNotesFolder: e.target.value }))}
                 className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
               />
+                            {validateVaultFolderSetting(obsidianConfig.newNotesFolder) && (
+                <p className="text-xs text-red-500 mt-1">{validateVaultFolderSetting(obsidianConfig.newNotesFolder)}</p>
+              )}
               <p className={`text-xs ${textSecondary} mt-1`}>Where new notes created in dayGLANCE are saved. Leave empty for vault root.</p>
             </div>
           )}
@@ -1623,6 +1627,9 @@ const MobileSettingsPanel = () => {
                 onChange={(e) => setObsidianConfig(prev => ({ ...prev, dailyNotePattern: e.target.value }))}
                 className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
               />
+                            {validateDailyNotePattern(obsidianConfig.dailyNotePattern, formatDatePattern) && (
+                <p className="text-xs text-red-500 mt-1">{validateDailyNotePattern(obsidianConfig.dailyNotePattern, formatDatePattern)}</p>
+              )}
               <p className={`text-xs ${textSecondary} mt-1`}>Date pattern for daily note filenames (without .md). e.g. "yyyy-MM-dd", "dd-MM-yyyy", "MMMM dd, yyyy"</p>
             </div>
           )}
@@ -1686,7 +1693,10 @@ const MobileSettingsPanel = () => {
               onChange={(e) => setObsidianConfig(prev => ({ ...prev, newNotesFolder: e.target.value }))}
               className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
             />
-            <p className={`text-xs ${textSecondary} mt-1`}>Where new notes created in dayGLANCE are saved. Leave empty for vault root.</p>
+                          {validateVaultFolderSetting(obsidianConfig.newNotesFolder) && (
+                <p className="text-xs text-red-500 mt-1">{validateVaultFolderSetting(obsidianConfig.newNotesFolder)}</p>
+              )}
+              <p className={`text-xs ${textSecondary} mt-1`}>Where new notes created in dayGLANCE are saved. Leave empty for vault root.</p>
           </div>
           <div>
             <label className={`block text-sm ${textSecondary} mb-1`}>{t('settings.obsidianFilenamePattern')}</label>
@@ -1697,7 +1707,10 @@ const MobileSettingsPanel = () => {
               onChange={(e) => setObsidianConfig(prev => ({ ...prev, dailyNotePattern: e.target.value }))}
               className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
             />
-            <p className={`text-xs ${textSecondary} mt-1`}>Date pattern for daily note filenames (without .md). e.g. "yyyy-MM-dd", "dd-MM-yyyy", "MMMM dd, yyyy"</p>
+                          {validateDailyNotePattern(obsidianConfig.dailyNotePattern, formatDatePattern) && (
+                <p className="text-xs text-red-500 mt-1">{validateDailyNotePattern(obsidianConfig.dailyNotePattern, formatDatePattern)}</p>
+              )}
+              <p className={`text-xs ${textSecondary} mt-1`}>Date pattern for daily note filenames (without .md). e.g. "yyyy-MM-dd", "dd-MM-yyyy", "MMMM dd, yyyy"</p>
           </div>
           <div>
             <label className={`block text-sm ${textSecondary} mb-1`}>{t('settings.obsidianTaskHeading')}</label>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -11,7 +11,8 @@ import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
 import { isNativeAndroid, nativeGetCalendars, nativeGetAutomationIntentsEnabled, nativeSetAutomationIntentsEnabled } from '../native.js';
 import { hasNativeCalendar, electronCalendarAvailable, electronGetCalendars } from '../utils/nativeCalendar.js';
-import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault } from '../obsidian.js';
+import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, formatDatePattern } from '../obsidian.js';
+import { validateDailyNotePattern, validateVaultFolderSetting } from '../utils/obsidianFilename.js';
 import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from '../intents/useIntentPoller.js';
 import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUsers.js';
 import { isAvailable as isICloudAvailable } from '../intents/icloudFileTransport.js';
@@ -71,7 +72,7 @@ const SettingsModal = () => {
     syncRetentionDays, setSyncRetentionDays,
     syncAll, isSyncing, calSyncLastSynced,
     availableCalendars, setAvailableCalendars, calendarFilter, setCalendarFilter,
-    obsidianConfig, setObsidianConfig, obsidianSyncStatus, obsidianLastSynced, setObsidianLastSynced,
+    obsidianConfig, setObsidianConfig, obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
     obsidianVaultHandleRef,
     performObsidianSync,
     trmnlConfig, setTrmnlConfig, trmnlSyncStatus, trmnlLastSynced, performTrmnlSync,
@@ -1604,6 +1605,11 @@ const SettingsModal = () => {
                               onChange={(e) => setObsidianConfig(prev => ({ ...prev, newNotesFolder: e.target.value }))}
                               className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
                             />
+                            {validateVaultFolderSetting(obsidianConfig.newNotesFolder) && (
+                              <p className="text-xs text-red-500 mt-1">
+                                {validateVaultFolderSetting(obsidianConfig.newNotesFolder)}
+                              </p>
+                            )}
                             <p className={`text-xs ${textSecondary} mt-1`}>
                               Where new notes created in dayGLANCE are saved. Leave empty for vault root.
                             </p>
@@ -1619,6 +1625,11 @@ const SettingsModal = () => {
                               onChange={(e) => setObsidianConfig(prev => ({ ...prev, dailyNotePattern: e.target.value }))}
                               className={`w-full px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`}
                             />
+                            {validateDailyNotePattern(obsidianConfig.dailyNotePattern, formatDatePattern) && (
+                              <p className="text-xs text-red-500 mt-1">
+                                {validateDailyNotePattern(obsidianConfig.dailyNotePattern, formatDatePattern)}
+                              </p>
+                            )}
                             <p className={`text-xs ${textSecondary} mt-1`}>
                               Date pattern for daily note filenames (without .md). e.g. "yyyy-MM-dd", "dd-MM-yyyy", "MMMM dd, yyyy"
                             </p>
@@ -1682,7 +1693,7 @@ const SettingsModal = () => {
                             <p className={`text-xs text-green-500`}>{t('settings.obsidianSyncComplete')}</p>
                           )}
                           {obsidianSyncStatus === 'error' && (
-                            <p className={`text-xs text-red-500`}>{t('settings.obsidianSyncFailed')}</p>
+                            <p className={`text-xs text-red-500`}>{t('settings.obsidianSyncFailed')}{obsidianSyncError ? `: ${obsidianSyncError}` : ''}</p>
                           )}
                           {obsidianLastSynced && (
                             <p className={`text-xs ${textSecondary}`}>

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -139,10 +139,16 @@ export default function useObsidianSync({
   // Obsidian vault sync — reads daily notes + imports tasks
   const performObsidianSync = async () => {
     if (obsidianSyncInProgressRef.current) return;
-    // If the vault handle was lost (e.g. permission expired after page reload),
-    // try to re-acquire it. When called from a button click this will trigger
-    // the browser's requestPermission prompt. When called from a timer/visibility
-    // event without a user gesture it will silently return null and we skip.
+    // No vault handle — a failed startup restore (unmounted drive, sleeping
+    // network share, stale macOS bookmark) or an expired browser permission.
+    // Re-acquire it here: this runs on EVERY sync trigger — the 5-minute poll,
+    // the visibility-change handler (neither is gated on a handle anymore),
+    // and the manual Sync Now button — so a vault that comes back reachable
+    // reconnects on the next tick without user action. On Electron this is one
+    // obsidian:restore IPC ending in one fs access check; in the browser, a
+    // button click can prompt for permission, while a timer/visibility caller
+    // without a user gesture silently gets null. Null → skip, silently: a
+    // still-missing vault must not produce an error state once per poll.
     if (!obsidianVaultHandleRef.current) {
       try {
         const handle = await getVaultAccess();
@@ -352,9 +358,10 @@ export default function useObsidianSync({
         } catch {}
         return;
       }
-      if (obsidianVaultHandleRef.current) {
-        performObsidianSync();
-      }
+      // Deliberately NOT gated on a connected handle: performObsidianSync
+      // re-acquires a lost one itself (see its null-handle branch), so a vault
+      // that failed restore at startup reconnects when the user comes back.
+      performObsidianSync();
     };
     document.addEventListener('visibilitychange', handleVisibility);
     return () => document.removeEventListener('visibilitychange', handleVisibility);
@@ -366,8 +373,12 @@ export default function useObsidianSync({
   // Obsidian sync: poll every 5 minutes while open
   useEffect(() => {
     if (isTrayMode || !obsidianConfig?.enabled) return;
+    // Deliberately NOT gated on a connected handle — same reason as the
+    // visibility handler above: the poll is also the retry path for a vault
+    // on a slow-mounting drive or network share. A still-missing vault costs
+    // one silent restore attempt per tick and produces no error state.
     const timer = setInterval(() => {
-      if (obsidianVaultHandleRef.current) performObsidianSync();
+      performObsidianSync();
     }, 5 * 60 * 1000);
     return () => clearInterval(timer);
     // performObsidianSync is read at call time; the poll is keyed on enabled,

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -65,18 +65,24 @@ export default function useObsidianSync({
     if (!handle) return;
     // Strip [[Note#Heading]] fragment for write path too
     const notePath = noteName.split('#')[0].trim();
-    // Refuse names that would break the vault on another synced platform
-    // (Windows/Android forbid characters that are legal here — see
-    // utils/obsidianFilename.js). Surfaced through the same visible sync-error
-    // state performObsidianSync uses; the old console.error was a silent write
-    // loss the user could never see.
-    const reason = validateWikiNoteName(notePath);
-    if (reason) {
-      setObsidianSyncError(`Note "${notePath}" was not written: ${reason}. Edit the [[wikilink]] in the task title.`);
-      setObsidianSyncStatus('error');
-      return;
-    }
+    // Portability gate on CREATION ONLY (see writeWikiNote): the existence
+    // check runs before the validator, so a note that already exists is
+    // written whatever its name — the harm is in creating NEW unportable
+    // names, and refusing writes to existing files would strand the task in a
+    // permanent error state. Refusals surface through the same visible
+    // sync-error state performObsidianSync uses; the old console.error was a
+    // silent write loss the user could never see.
     if (handle === 'native') {
+      // Android: same ordering — only validate when the note doesn't exist yet.
+      const existing = await Promise.resolve(nativeGetNote(notePath)).catch(() => null);
+      if (!existing) {
+        const reason = validateWikiNoteName(notePath);
+        if (reason) {
+          setObsidianSyncError(`Note "${notePath}" was not written: ${reason}. Edit the [[wikilink]] in the task title.`);
+          setObsidianSyncStatus('error');
+          return;
+        }
+      }
       nativeWriteNote(notePath, content);
       return;
     }
@@ -84,7 +90,9 @@ export default function useObsidianSync({
       await writeWikiNote(handle, notePath, content, obsidianConfig?.newNotesFolder ?? 'dayGLANCE');
     } catch (err) {
       console.error('Failed to write wiki note:', err);
-      setObsidianSyncError(err.message);
+      setObsidianSyncError(err.code === 'unportable_name' && err.reason
+        ? `Note "${notePath}" was not written: ${err.reason}. Edit the [[wikilink]] in the task title.`
+        : err.message);
       setObsidianSyncStatus('error');
     }
   }, [obsidianConfig?.newNotesFolder, obsidianVaultHandleRef, setObsidianSyncError, setObsidianSyncStatus]);

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -12,6 +12,7 @@ import {
   nativeGetVaultConfig, nativeGetNote, nativeWriteNote, nativeOpenNote,
   nativeListNotes, nativeSetVaultSettings,
 } from '../native.js';
+import { validateWikiNoteName } from '../utils/obsidianFilename.js';
 import { mergeObsidianDailyNotes } from '../utils/mergeObsidianDailyNotes.js';
 import { mergeObsidianTasks } from '../utils/mergeObsidianTasks.js';
 import { detectObsidianDeletions, addObsidianTombstones } from '../utils/obsidianDeletions.js';
@@ -64,6 +65,17 @@ export default function useObsidianSync({
     if (!handle) return;
     // Strip [[Note#Heading]] fragment for write path too
     const notePath = noteName.split('#')[0].trim();
+    // Refuse names that would break the vault on another synced platform
+    // (Windows/Android forbid characters that are legal here — see
+    // utils/obsidianFilename.js). Surfaced through the same visible sync-error
+    // state performObsidianSync uses; the old console.error was a silent write
+    // loss the user could never see.
+    const reason = validateWikiNoteName(notePath);
+    if (reason) {
+      setObsidianSyncError(`Note "${notePath}" was not written: ${reason}. Edit the [[wikilink]] in the task title.`);
+      setObsidianSyncStatus('error');
+      return;
+    }
     if (handle === 'native') {
       nativeWriteNote(notePath, content);
       return;
@@ -72,8 +84,10 @@ export default function useObsidianSync({
       await writeWikiNote(handle, notePath, content, obsidianConfig?.newNotesFolder ?? 'dayGLANCE');
     } catch (err) {
       console.error('Failed to write wiki note:', err);
+      setObsidianSyncError(err.message);
+      setObsidianSyncStatus('error');
     }
-  }, [obsidianConfig?.newNotesFolder, obsidianVaultHandleRef]);
+  }, [obsidianConfig?.newNotesFolder, obsidianVaultHandleRef, setObsidianSyncError, setObsidianSyncStatus]);
 
   // Opens a vault note in the Obsidian app (Android) or via obsidian:// URI (web/desktop).
   const openInObsidian = useCallback((noteName) => {

--- a/src/hooks/useObsidianSync.retry.test.js
+++ b/src/hooks/useObsidianSync.retry.test.js
@@ -44,7 +44,7 @@ vi.mock('../native.js', () => ({
 
 const { default: useObsidianSync } = await import('./useObsidianSync.js');
 
-function mountHook() {
+function useMountedObsidianSync() {
   effects.length = 0;
   const obsidianVaultHandleRef = { current: null };
   const setObsidianSyncStatus = vi.fn();
@@ -87,7 +87,7 @@ beforeEach(() => {
 
 describe('restore retry — poll and visibility ticks are not gated on a handle', () => {
   it('failed restore, then vault reachable: the next poll tick reconnects without user action', async () => {
-    const { obsidianVaultHandleRef, interval } = mountHook();
+    const { obsidianVaultHandleRef, interval } = useMountedObsidianSync();
     expect(interval.cb).toBeTypeOf('function');
 
     // Vault still unreachable: tick retries restore, stays disconnected, silently.
@@ -104,7 +104,7 @@ describe('restore retry — poll and visibility ticks are not gated on a handle'
   });
 
   it('visibility-change tick does the same', async () => {
-    const { obsidianVaultHandleRef, listeners } = mountHook();
+    const { obsidianVaultHandleRef, listeners } = useMountedObsidianSync();
     expect(listeners.visibilitychange).toBeTypeOf('function');
 
     const handle = { kind: 'directory', name: 'Vault' };
@@ -115,7 +115,7 @@ describe('restore retry — poll and visibility ticks are not gated on a handle'
   });
 
   it('a genuinely missing vault costs one silent attempt per tick — no error state, no loop', async () => {
-    const { obsidianVaultHandleRef, interval, setObsidianSyncStatus } = mountHook();
+    const { obsidianVaultHandleRef, interval, setObsidianSyncStatus } = useMountedObsidianSync();
     getVaultAccess.mockResolvedValue(null);
     await interval.cb();
     await interval.cb();

--- a/src/hooks/useObsidianSync.retry.test.js
+++ b/src/hooks/useObsidianSync.retry.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The restore-retry seam: a vault that failed restore at startup (unmounted
+// drive, sleeping network share, stale bookmark) must reconnect on the next
+// sync tick WITHOUT user action. The 5-minute poll and the visibility-change
+// handler are deliberately not gated on a connected handle — they call
+// performObsidianSync unconditionally, and its null-handle branch re-acquires
+// the vault via getVaultAccess. These tests pin exactly that seam with the
+// useSaveOnChange.test.js capture pattern (no DOM renderer): capture the
+// hook's effects, run the poll/visibility effect, and watch getVaultAccess.
+
+const effects = [];
+vi.mock('react', () => ({
+  useEffect: (fn, deps) => { effects.push({ fn, deps }); },
+  useCallback: (fn) => fn,
+  useRef: (init) => ({ current: init }),
+}));
+
+const getVaultAccess = vi.fn();
+vi.mock('../obsidian.js', () => ({
+  tryRestoreVaultAccess: vi.fn(async () => null),
+  getVaultAccess: (...a) => getVaultAccess(...a),
+  syncObsidianVault: vi.fn(async () => null),
+  syncObsidianVaultNative: vi.fn(async () => null),
+  writeTaskStateToFile: vi.fn(async () => {}),
+  writeTaskStateNative: vi.fn(() => {}),
+  simpleHash: vi.fn(() => 'h'),
+  readWikiNote: vi.fn(async () => null),
+  writeWikiNote: vi.fn(async () => {}),
+  listVaultNotes: vi.fn(async () => []),
+  OBSIDIAN_IMPORT_WINDOW_DAYS: 90,
+  obsidianWindowCutoffDate: vi.fn(() => null),
+}));
+vi.mock('../native.js', () => ({
+  isNativeAndroid: () => false,
+  isNativeApp: () => false,
+  nativeGetVaultConfig: vi.fn(() => null),
+  nativeGetNote: vi.fn(() => null),
+  nativeWriteNote: vi.fn(),
+  nativeOpenNote: vi.fn(),
+  nativeListNotes: vi.fn(() => []),
+  nativeSetVaultSettings: vi.fn(),
+}));
+
+const { default: useObsidianSync } = await import('./useObsidianSync.js');
+
+function mountHook() {
+  effects.length = 0;
+  const obsidianVaultHandleRef = { current: null };
+  const setObsidianSyncStatus = vi.fn();
+  useObsidianSync({
+    isTrayMode: false,
+    dataLoaded: true,
+    tasks: [], setTasks: vi.fn(),
+    unscheduledTasks: [], setUnscheduledTasks: vi.fn(),
+    setDailyNotes: vi.fn(),
+    setWikilinkCandidates: vi.fn(),
+    obsidianConfig: { enabled: true, dailyNotesPath: '', dailyNotePattern: 'yyyy-MM-dd' },
+    setObsidianConfig: vi.fn(),
+    setObsidianSyncStatus,
+    setObsidianSyncError: vi.fn(),
+    setObsidianLastSynced: vi.fn(),
+    obsidianVaultHandleRef,
+    obsidianSyncInProgressRef: { current: false },
+    obsidianPrevTaskStateRef: { current: null },
+    obsidianTasksRef: { current: [] },
+    obsidianInboxRef: { current: [] },
+  });
+  // Identify the effects by what they install rather than by ordinal position.
+  const interval = { cb: null };
+  const listeners = {};
+  vi.stubGlobal('setInterval', (cb) => { interval.cb = cb; return 1; });
+  vi.stubGlobal('clearInterval', () => {});
+  vi.stubGlobal('document', {
+    addEventListener: (type, cb) => { listeners[type] = cb; },
+    removeEventListener: () => {},
+    visibilityState: 'visible',
+  });
+  for (const e of effects) e.fn();
+  return { obsidianVaultHandleRef, interval, listeners, setObsidianSyncStatus };
+}
+
+beforeEach(() => {
+  getVaultAccess.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe('restore retry — poll and visibility ticks are not gated on a handle', () => {
+  it('failed restore, then vault reachable: the next poll tick reconnects without user action', async () => {
+    const { obsidianVaultHandleRef, interval } = mountHook();
+    expect(interval.cb).toBeTypeOf('function');
+
+    // Vault still unreachable: tick retries restore, stays disconnected, silently.
+    getVaultAccess.mockResolvedValueOnce(null);
+    await interval.cb();
+    expect(getVaultAccess).toHaveBeenCalledTimes(1); // the old gate would have made this 0
+    expect(obsidianVaultHandleRef.current).toBeNull();
+
+    // Vault came back: the very next tick reconnects.
+    const handle = { kind: 'directory', name: 'Vault' };
+    getVaultAccess.mockResolvedValueOnce(handle);
+    await interval.cb();
+    expect(obsidianVaultHandleRef.current).toBe(handle);
+  });
+
+  it('visibility-change tick does the same', async () => {
+    const { obsidianVaultHandleRef, listeners } = mountHook();
+    expect(listeners.visibilitychange).toBeTypeOf('function');
+
+    const handle = { kind: 'directory', name: 'Vault' };
+    getVaultAccess.mockResolvedValueOnce(handle);
+    await listeners.visibilitychange();
+    expect(getVaultAccess).toHaveBeenCalledTimes(1);
+    expect(obsidianVaultHandleRef.current).toBe(handle);
+  });
+
+  it('a genuinely missing vault costs one silent attempt per tick — no error state, no loop', async () => {
+    const { obsidianVaultHandleRef, interval, setObsidianSyncStatus } = mountHook();
+    getVaultAccess.mockResolvedValue(null);
+    await interval.cb();
+    await interval.cb();
+    await interval.cb();
+    expect(getVaultAccess).toHaveBeenCalledTimes(3); // exactly one per tick
+    expect(obsidianVaultHandleRef.current).toBeNull();
+    expect(setObsidianSyncStatus).not.toHaveBeenCalled(); // silent: no 'syncing', no 'error'
+  });
+});

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -326,19 +326,28 @@ function dailyNoteFilename(dateStr, pattern) {
 }
 
 /**
- * Write-side variant: validates the rendered stem before it becomes a new
- * filename. A backstop for patterns saved before entry-time validation
- * shipped (the Settings inputs are the primary check). Deliberately NOT
- * applied on reads — files a legacy pattern already created must stay
- * readable so existing daily notes keep syncing in.
+ * Write-side file-handle resolution with the portability gate on CREATION
+ * ONLY. ORDERING IS THE POINT: the existence check runs BEFORE the validator.
+ * A daily note that already exists gets written regardless of its name — the
+ * portability harm is entirely in bringing a NEW unportable name into being;
+ * a file already in the vault is already there whether or not we write to it,
+ * and refusing would strand sync in a permanent error state. The validator
+ * (backstop for patterns saved before entry-time validation shipped — the
+ * Settings inputs are the primary check) gates only the create branch.
+ * Reads never validate, so legacy-named files always stay readable.
  */
-function dailyNoteFilenameForWrite(dateStr, pattern) {
+async function getDailyNoteHandleForWrite(dirHandle, dateStr, pattern) {
   const name = dailyNoteFilename(dateStr, pattern);
+  try {
+    return await dirHandle.getFileHandle(name); // exists → write proceeds, name notwithstanding
+  } catch (err) {
+    if (err.name !== 'NotFoundError') throw err;
+  }
   const reason = validateVaultNameSegment(name.slice(0, -3));
   if (reason) {
     throw new Error(`Obsidian: daily note pattern "${pattern}" renders an unusable filename — ${reason}. Fix the pattern in Settings → Obsidian.`);
   }
-  return name;
+  return dirHandle.getFileHandle(name, { create: true });
 }
 
 /**
@@ -364,7 +373,7 @@ async function readDailyNoteFile(dirHandle, dateStr, pattern) {
 export async function writeDailyNoteFile(vaultHandle, dailyNotesPath, dateStr, content, pattern) {
   assertSafeDateStr(dateStr);
   const dirHandle = await getDailyNotesDir(vaultHandle, dailyNotesPath);
-  const fileHandle = await dirHandle.getFileHandle(dailyNoteFilenameForWrite(dateStr, pattern), { create: true });
+  const fileHandle = await getDailyNoteHandleForWrite(dirHandle, dateStr, pattern);
   const writable = await fileHandle.createWritable();
   await writable.write(content);
   await writable.close();
@@ -483,7 +492,7 @@ export async function appendTaskToDailyNote(vaultHandle, dailyNotesPath, dateStr
   const sorted = heading && heading.trim()
     ? sortTaskLinesInSection(lines, heading.trim(), dateStr)
     : lines;
-  const fileHandle = await dirHandle.getFileHandle(dailyNoteFilenameForWrite(dateStr, pattern), { create: true });
+  const fileHandle = await getDailyNoteHandleForWrite(dirHandle, dateStr, pattern);
   const writable = await fileHandle.createWritable();
   await writable.write(sorted.join('\n'));
   await writable.close();
@@ -559,39 +568,65 @@ export async function writeWikiNote(vaultHandle, noteName, content, newNotesFold
       throw new Error(`Obsidian: unsafe path segment "${part}" in wiki note name`);
     }
   }
-  // Portability gate (see utils/obsidianFilename.js): a name like "plans?" is
-  // perfectly creatable here on macOS/Linux — and by Obsidian itself there —
-  // but breaks the same vault when it syncs to Windows or Android. Refuse and
-  // let the caller surface it rather than plant a sync-breaking file.
-  {
-    const reason = validateWikiNoteName(noteName);
-    if (reason) throw new Error(`Obsidian: cannot create note "${noteName}" — ${reason}`);
-    const folderReason = validateVaultFolderSetting(newNotesFolder);
-    if (folderReason) throw new Error(`Obsidian: new-notes folder "${newNotesFolder}" is unusable — ${folderReason}. Fix it in Settings → Obsidian.`);
-  }
   const mdFileName = `${parts[parts.length - 1]}.md`;
 
-  let fileHandle;
+  // ORDERING IS THE POINT: existence check BEFORE the portability gate.
+  // The portability harm is entirely in bringing a NEW unportable name into
+  // being — a file already sitting in the vault is already affecting sync
+  // whether or not we write to it again, and refusing the write would strand
+  // the task in a permanent error state whose only remedy breaks its link to
+  // a note that visibly exists. So: exists → write, name notwithstanding;
+  // missing → validate before creating (see utils/obsidianFilename.js — a
+  // name like "plans?" is creatable here on macOS/Linux, and by Obsidian
+  // itself there, but breaks the same vault on Windows/Android).
+  let fileHandle = null;
   if (parts.length > 1) {
-    // Explicit path — create dirs as needed
+    // Explicit path — probe WITHOUT create
     let dir = vaultHandle;
+    let dirsExist = true;
     for (const part of parts.slice(0, -1)) {
-      dir = await dir.getDirectoryHandle(part, { create: true });
+      try { dir = await dir.getDirectoryHandle(part); }
+      catch (err) { if (err.name === 'NotFoundError') { dirsExist = false; break; } throw err; }
     }
-    fileHandle = await dir.getFileHandle(mdFileName, { create: true });
+    if (dirsExist) {
+      try { fileHandle = await dir.getFileHandle(mdFileName); }
+      catch (err) { if (err.name !== 'NotFoundError') throw err; }
+    }
   } else {
-    // Bare name — write to existing location, or create in newNotesFolder (or vault root)
-    fileHandle = await findFileHandleInDir(vaultHandle, mdFileName)
-      ?? await (async () => {
-        if (newNotesFolder) {
-          let dir = vaultHandle;
-          for (const segment of newNotesFolder.split('/').filter(Boolean)) {
-            dir = await dir.getDirectoryHandle(segment, { create: true });
-          }
-          return dir.getFileHandle(mdFileName, { create: true });
-        }
-        return vaultHandle.getFileHandle(mdFileName, { create: true });
-      })();
+    // Bare name — an existing note anywhere in the vault is written in place
+    fileHandle = await findFileHandleInDir(vaultHandle, mdFileName);
+  }
+
+  if (!fileHandle) {
+    // CREATION ONLY: the portability gate.
+    const reason = validateWikiNoteName(noteName);
+    if (reason) {
+      const err = new Error(`Obsidian: cannot create note "${noteName}" — ${reason}`);
+      err.code = 'unportable_name';
+      err.reason = reason; // callers compose user-facing copy from the bare reason
+      throw err;
+    }
+    if (parts.length > 1) {
+      let dir = vaultHandle;
+      for (const part of parts.slice(0, -1)) {
+        dir = await dir.getDirectoryHandle(part, { create: true });
+      }
+      fileHandle = await dir.getFileHandle(mdFileName, { create: true });
+    } else if (newNotesFolder) {
+      const folderReason = validateVaultFolderSetting(newNotesFolder);
+      if (folderReason) {
+        const err = new Error(`Obsidian: new-notes folder "${newNotesFolder}" is unusable — ${folderReason}. Fix it in Settings → Obsidian.`);
+        err.code = 'unportable_name';
+        throw err;
+      }
+      let dir = vaultHandle;
+      for (const segment of newNotesFolder.split('/').filter(Boolean)) {
+        dir = await dir.getDirectoryHandle(segment, { create: true });
+      }
+      fileHandle = await dir.getFileHandle(mdFileName, { create: true });
+    } else {
+      fileHandle = await vaultHandle.getFileHandle(mdFileName, { create: true });
+    }
   }
 
   const writable = await fileHandle.createWritable();

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -13,6 +13,11 @@
  */
 
 import { makeElectronVaultHandle } from './obsidianElectronHandle.js';
+import {
+  validateVaultNameSegment,
+  validateWikiNoteName,
+  validateVaultFolderSetting,
+} from './utils/obsidianFilename.js';
 
 // How far back the Obsidian daily-note scan reads, in days. DELIBERATELY FIXED and
 // decoupled from the calendar "Keep past events" retention (syncRetentionDays):
@@ -321,6 +326,22 @@ function dailyNoteFilename(dateStr, pattern) {
 }
 
 /**
+ * Write-side variant: validates the rendered stem before it becomes a new
+ * filename. A backstop for patterns saved before entry-time validation
+ * shipped (the Settings inputs are the primary check). Deliberately NOT
+ * applied on reads — files a legacy pattern already created must stay
+ * readable so existing daily notes keep syncing in.
+ */
+function dailyNoteFilenameForWrite(dateStr, pattern) {
+  const name = dailyNoteFilename(dateStr, pattern);
+  const reason = validateVaultNameSegment(name.slice(0, -3));
+  if (reason) {
+    throw new Error(`Obsidian: daily note pattern "${pattern}" renders an unusable filename — ${reason}. Fix the pattern in Settings → Obsidian.`);
+  }
+  return name;
+}
+
+/**
  * Read a single daily note markdown file. Returns the text or null.
  * @param {string} [pattern] DateTimeFormatter-style filename pattern (default "yyyy-MM-dd")
  */
@@ -343,7 +364,7 @@ async function readDailyNoteFile(dirHandle, dateStr, pattern) {
 export async function writeDailyNoteFile(vaultHandle, dailyNotesPath, dateStr, content, pattern) {
   assertSafeDateStr(dateStr);
   const dirHandle = await getDailyNotesDir(vaultHandle, dailyNotesPath);
-  const fileHandle = await dirHandle.getFileHandle(dailyNoteFilename(dateStr, pattern), { create: true });
+  const fileHandle = await dirHandle.getFileHandle(dailyNoteFilenameForWrite(dateStr, pattern), { create: true });
   const writable = await fileHandle.createWritable();
   await writable.write(content);
   await writable.close();
@@ -462,7 +483,7 @@ export async function appendTaskToDailyNote(vaultHandle, dailyNotesPath, dateStr
   const sorted = heading && heading.trim()
     ? sortTaskLinesInSection(lines, heading.trim(), dateStr)
     : lines;
-  const fileHandle = await dirHandle.getFileHandle(dailyNoteFilename(dateStr, pattern), { create: true });
+  const fileHandle = await dirHandle.getFileHandle(dailyNoteFilenameForWrite(dateStr, pattern), { create: true });
   const writable = await fileHandle.createWritable();
   await writable.write(sorted.join('\n'));
   await writable.close();
@@ -537,6 +558,16 @@ export async function writeWikiNote(vaultHandle, noteName, content, newNotesFold
     if (part === '..' || part === '.') {
       throw new Error(`Obsidian: unsafe path segment "${part}" in wiki note name`);
     }
+  }
+  // Portability gate (see utils/obsidianFilename.js): a name like "plans?" is
+  // perfectly creatable here on macOS/Linux — and by Obsidian itself there —
+  // but breaks the same vault when it syncs to Windows or Android. Refuse and
+  // let the caller surface it rather than plant a sync-breaking file.
+  {
+    const reason = validateWikiNoteName(noteName);
+    if (reason) throw new Error(`Obsidian: cannot create note "${noteName}" — ${reason}`);
+    const folderReason = validateVaultFolderSetting(newNotesFolder);
+    if (folderReason) throw new Error(`Obsidian: new-notes folder "${newNotesFolder}" is unusable — ${folderReason}. Fix it in Settings → Obsidian.`);
   }
   const mdFileName = `${parts[parts.length - 1]}.md`;
 

--- a/src/obsidian.vaultWrites.test.js
+++ b/src/obsidian.vaultWrites.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { writeWikiNote, writeDailyNoteFile } from './obsidian.js';
+
+// The creation-only portability gate, and above all its ORDERING: the
+// existence check runs BEFORE the validator, so a file already in the vault
+// is written whatever its name (the portability harm is only in creating NEW
+// unportable names), while creation of an invalid name is refused with the
+// unchanged message.
+
+// Minimal in-memory FSA mock. Structure: nested objects, string = file content.
+function nfe() {
+  const e = new Error('A requested file or directory could not be found.');
+  e.name = 'NotFoundError';
+  return e;
+}
+function makeFile(parent, name) {
+  return {
+    kind: 'file',
+    name,
+    async getFile() {
+      return { text: async () => parent[name], lastModified: 1 };
+    },
+    async createWritable() {
+      let buf = '';
+      return {
+        write: async (chunk) => { buf += chunk; },
+        close: async () => { parent[name] = buf; },
+      };
+    },
+  };
+}
+function makeDir(node, name = '') {
+  return {
+    kind: 'directory',
+    name,
+    async getFileHandle(n, opts) {
+      if (typeof node[n] === 'string') return makeFile(node, n);
+      if (opts?.create) { node[n] = ''; return makeFile(node, n); }
+      throw nfe();
+    },
+    async getDirectoryHandle(n, opts) {
+      if (node[n] && typeof node[n] === 'object') return makeDir(node[n], n);
+      if (opts?.create) { node[n] = {}; return makeDir(node[n], n); }
+      throw nfe();
+    },
+    async *entries() {
+      for (const [n, v] of Object.entries(node)) {
+        yield [n, typeof v === 'string' ? makeFile(node, n) : makeDir(v, n)];
+      }
+    },
+  };
+}
+
+describe('writeWikiNote — existence check BEFORE the portability gate', () => {
+  it('invalid name, file already exists → write proceeds, no error — twice in a row', async () => {
+    const fs = { 'emails: urgent?.md': 'old' };
+    const vault = makeDir(fs);
+    await writeWikiNote(vault, 'emails: urgent?', 'first write');
+    expect(fs['emails: urgent?.md']).toBe('first write');
+    await writeWikiNote(vault, 'emails: urgent?', 'second write');
+    expect(fs['emails: urgent?.md']).toBe('second write');
+  });
+
+  it('invalid name in a subfolder, file exists → write proceeds (bare-name vault search)', async () => {
+    const fs = { archive: { 'CON.md': 'old' } };
+    await writeWikiNote(makeDir(fs), 'CON', 'updated');
+    expect(fs.archive['CON.md']).toBe('updated');
+  });
+
+  it('invalid name, file does NOT exist → refused with the unchanged message; nothing created', async () => {
+    const fs = { 'other.md': 'x' };
+    const err = await writeWikiNote(makeDir(fs), 'emails: urgent?', 'body').catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain('cannot create note "emails: urgent?"');
+    expect(err.message).toContain(':');
+    expect(err.code).toBe('unportable_name');
+    expect(err.reason).toBeTruthy();
+    expect(Object.keys(fs)).toEqual(['other.md']); // no file, no folder side effects
+  });
+
+  it('explicit Folder/Name path: existing invalid file writes; missing invalid file refuses without creating the folder chain', async () => {
+    const fs = { projects: { 'notes?.md': 'old' } };
+    await writeWikiNote(makeDir(fs), 'projects/notes?', 'updated');
+    expect(fs.projects['notes?.md']).toBe('updated');
+
+    const err = await writeWikiNote(makeDir(fs), 'newdir/notes?', 'body').catch((e) => e);
+    expect(err.code).toBe('unportable_name');
+    expect(fs.newdir).toBeUndefined(); // the existence probe must not create directories
+  });
+
+  it('valid name, missing → created in newNotesFolder; valid name, existing → written in place', async () => {
+    const fs = {};
+    await writeWikiNote(makeDir(fs), 'Fresh note', 'hello', 'dayGLANCE');
+    expect(fs.dayGLANCE['Fresh note.md']).toBe('hello');
+    await writeWikiNote(makeDir(fs), 'Fresh note', 'hello again', 'dayGLANCE');
+    expect(fs.dayGLANCE['Fresh note.md']).toBe('hello again');
+  });
+
+  it('an invalid newNotesFolder only matters when a note must be created there', async () => {
+    const fs = { 'Existing.md': 'old' };
+    // Existing note: bad folder setting is irrelevant — the write lands in place.
+    await writeWikiNote(makeDir(fs), 'Existing', 'new', 'bad?folder');
+    expect(fs['Existing.md']).toBe('new');
+    // New note: the folder would have to be created — refused.
+    const err = await writeWikiNote(makeDir(fs), 'Fresh', 'body', 'bad?folder').catch((e) => e);
+    expect(err.code).toBe('unportable_name');
+    expect(err.message).toContain('new-notes folder');
+  });
+});
+
+describe('daily-note writes — same ordering via getDailyNoteHandleForWrite', () => {
+  it('legacy bad pattern, file already exists → write proceeds', async () => {
+    const fs = { daily: { 'notes: 2026-08-10.md': 'old' } };
+    await writeDailyNoteFile(makeDir(fs), 'daily', '2026-08-10', 'updated', 'notes: yyyy-MM-dd');
+    expect(fs.daily['notes: 2026-08-10.md']).toBe('updated');
+  });
+
+  it('bad pattern, file missing → refused naming the pattern; nothing created', async () => {
+    const fs = { daily: {} };
+    const err = await writeDailyNoteFile(makeDir(fs), 'daily', '2026-08-10', 'body', 'notes: yyyy-MM-dd').catch((e) => e);
+    expect(err.message).toContain('renders an unusable filename');
+    expect(err.message).toContain('notes: yyyy-MM-dd');
+    expect(Object.keys(fs.daily)).toEqual([]);
+  });
+
+  it('default pattern → creates and writes', async () => {
+    const fs = { daily: {} };
+    await writeDailyNoteFile(makeDir(fs), 'daily', '2026-08-10', 'today', undefined);
+    expect(fs.daily['2026-08-10.md']).toBe('today');
+  });
+});

--- a/src/utils/obsidianFilename.js
+++ b/src/utils/obsidianFilename.js
@@ -1,0 +1,117 @@
+// Vault filename validation for the Obsidian integration, extracted as pure
+// functions (trayFetchGate.js style) so the rules are unit-testable.
+//
+// WHY REFUSE, AND ON WHAT GROUNDS: dayGLANCE derives some vault filenames from
+// user-typed text — [[wikilink]] targets in task titles become "<name>.md",
+// and the dailyNotePattern / newNotesFolder settings flow into filenames and
+// folder names. The refused set below is the UNION of what is unusable on ANY
+// platform an Obsidian vault might sync to, so that a note dayGLANCE creates
+// on one OS never breaks the same vault on another:
+//
+//   [ ] # ^ |    — forbidden by Obsidian itself on every platform (they
+//                  collide with wikilink/tag/block-ID syntax; ^ is the
+//                  block-ID sigil dayGLANCE plans to use as ^dg-<id>)
+//   * " : ? < >  — filesystem-illegal on Windows (and Android forbids
+//                  * ? " as well); PERFECTLY LEGAL on macOS/Linux, and
+//                  Obsidian on those platforms will happily create such
+//                  notes — we refuse them anyway purely for portability,
+//                  NOT because Obsidian would
+//   \ /          — path separators ('/' is a legal FOLDER separator in a
+//                  wikilink like [[Folder/Name]]; callers split on it first
+//                  and validate each segment, so a bare segment never
+//                  legitimately contains either)
+//   0x00-0x1F    — control characters, illegal on Windows, unusable anywhere
+//   leading dot  — hidden file; Obsidian refuses on every platform
+//   trailing dot/space — Windows strips these at the Win32 layer, silently
+//                  creating a DIFFERENTLY-named file rather than erroring
+//   CON PRN AUX NUL COM1-9 LPT1-9 — Windows reserved device names,
+//                  case-insensitive, and reserved WITH an extension too
+//                  ("CON.md" is still CON; the stem before the first dot is
+//                  what Windows reserves)
+
+const INVALID_CHAR_RE = /[[\]#^|*"\\/:?<>]/;
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_RE = /[\x00-\x1f]/;
+const RESERVED_STEM_RE = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i;
+
+/**
+ * Validate ONE filename segment (a note name without folders, or one folder
+ * name). Returns null when acceptable, or a human-readable reason naming the
+ * offending character — callers prepend context ("edit the task title").
+ */
+export function validateVaultNameSegment(segment) {
+  if (typeof segment !== 'string' || segment.length === 0) {
+    return 'name is empty';
+  }
+  const control = segment.match(CONTROL_CHAR_RE);
+  if (control) {
+    return `name contains a control character (0x${control[0].charCodeAt(0).toString(16).padStart(2, '0')})`;
+  }
+  const bad = segment.match(INVALID_CHAR_RE);
+  if (bad) {
+    return `name contains "${bad[0]}" — not portable across the platforms an Obsidian vault can sync to`;
+  }
+  if (segment.startsWith('.')) {
+    return 'name starts with "." (hidden file)';
+  }
+  if (segment.endsWith('.') || segment.endsWith(' ')) {
+    return `name ends with a ${segment.endsWith('.') ? 'dot' : 'space'} — Windows silently strips it, creating a differently-named file`;
+  }
+  const stem = segment.split('.')[0];
+  if (RESERVED_STEM_RE.test(stem)) {
+    return `"${stem}" is a reserved device name on Windows (reserved even with an extension)`;
+  }
+  return null;
+}
+
+/**
+ * Validate a wikilink target, which may contain '/' folder separators
+ * ([[Folder/Name]]). Each segment is validated separately, preserving the
+ * existing Folder/Name support. Returns null or a reason.
+ */
+export function validateWikiNoteName(name) {
+  if (typeof name !== 'string' || name.split('/').filter(Boolean).length === 0) {
+    return 'note name is empty';
+  }
+  for (const segment of name.split('/').filter(Boolean)) {
+    const reason = validateVaultNameSegment(segment);
+    if (reason) return reason;
+  }
+  return null;
+}
+
+/**
+ * Validate the newNotesFolder setting: zero or more '/'-separated folder
+ * segments. Empty means vault root and is valid.
+ */
+export function validateVaultFolderSetting(folder) {
+  if (!folder) return null;
+  for (const segment of String(folder).split('/').filter(Boolean)) {
+    const reason = validateVaultNameSegment(segment);
+    if (reason) return reason;
+  }
+  return null;
+}
+
+/**
+ * Validate a dailyNotePattern by validating its RENDERED output, since the
+ * pattern itself contains format tokens ("yyyy-MM-dd" is not a filename).
+ * The rendered stem must also be a single segment: a '/' in the output would
+ * silently nest daily notes into subfolders on one code path and throw on
+ * another.
+ *
+ * @param pattern            the user-typed pattern
+ * @param formatDatePattern  injected from obsidian.js (keeps this module pure)
+ */
+export function validateDailyNotePattern(pattern, formatDatePattern) {
+  if (!pattern) return null; // empty falls back to the yyyy-MM-dd default
+  let rendered;
+  try {
+    // A date with double-digit month and day, so padding differences can't
+    // mask an illegal literal character in the pattern.
+    rendered = String(formatDatePattern(new Date(2026, 11, 31), pattern));
+  } catch {
+    return 'pattern could not be rendered';
+  }
+  return validateVaultNameSegment(rendered);
+}

--- a/src/utils/obsidianFilename.test.js
+++ b/src/utils/obsidianFilename.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateVaultNameSegment,
+  validateWikiNoteName,
+  validateVaultFolderSetting,
+  validateDailyNotePattern,
+} from './obsidianFilename.js';
+import { formatDatePattern } from '../obsidian.js';
+
+// The union rule under test: refuse anything unusable on ANY platform an
+// Obsidian vault can sync to. Load-bearing nuance: ? * " < > are LEGAL on
+// macOS/Linux and Obsidian will create such notes there — the refusal is on
+// portability grounds, and the messages must say so, never claim Obsidian
+// rejects them.
+
+describe('validateVaultNameSegment — accepts', () => {
+  it('ordinary names, unicode, internal dots and spaces', () => {
+    for (const name of [
+      'Meeting notes', '2026-08-10', 'emails urgent', 'Björn plans',
+      'v1.2 release notes', 'draft (2)', "client's brief", 'a', '日記',
+      'CONTRACT', 'console', 'COM10', 'LPT0', 'nulled',
+    ]) {
+      expect(validateVaultNameSegment(name), name).toBeNull();
+    }
+  });
+});
+
+describe('validateVaultNameSegment — refuses the union set', () => {
+  it('every character in the union set, message naming the character', () => {
+    for (const ch of ['[', ']', '#', '^', '|', '*', '"', '\\', '/', ':', '?', '<', '>']) {
+      const reason = validateVaultNameSegment(`emails ${ch} urgent`);
+      expect(reason, ch).not.toBeNull();
+      expect(reason, ch).toContain(ch === '\\' ? '\\' : ch);
+    }
+  });
+
+  it('the message states portability grounds, not that Obsidian refuses', () => {
+    const reason = validateVaultNameSegment('emails urgent?');
+    expect(reason).toContain('"?"');
+    expect(reason).toMatch(/portable|platforms/i);
+    expect(reason).not.toMatch(/obsidian (would|rejects|refuses)/i);
+  });
+
+  it('control characters', () => {
+    expect(validateVaultNameSegment('a\x00b')).toContain('control character');
+    expect(validateVaultNameSegment('a\x1fb')).toContain('control character');
+    expect(validateVaultNameSegment('tab\there')).toContain('control character');
+  });
+
+  it('leading dot; trailing dot; trailing space', () => {
+    expect(validateVaultNameSegment('.hidden')).toContain('starts with');
+    expect(validateVaultNameSegment('notes.')).toContain('dot');
+    expect(validateVaultNameSegment('notes ')).toContain('space');
+  });
+
+  it('Windows reserved device names, case-insensitive, with and without extension', () => {
+    for (const name of ['CON', 'con', 'Con', 'PRN', 'AUX', 'NUL', 'COM1', 'com9', 'LPT1', 'lpt9']) {
+      expect(validateVaultNameSegment(name), name).toContain('reserved');
+    }
+    // Reserved WITH an extension: the stem before the first dot is what Windows reserves.
+    expect(validateVaultNameSegment('CON.md')).toContain('reserved');
+    expect(validateVaultNameSegment('con.backup.md')).toContain('reserved');
+    expect(validateVaultNameSegment('NUL.txt')).toContain('reserved');
+  });
+
+  it('empty and non-string', () => {
+    expect(validateVaultNameSegment('')).not.toBeNull();
+    expect(validateVaultNameSegment(undefined)).not.toBeNull();
+  });
+});
+
+describe('validateWikiNoteName — Folder/Name support preserved', () => {
+  it('validates each / segment separately, so folder links stay legal', () => {
+    expect(validateWikiNoteName('Projects/Q3 planning')).toBeNull();
+    expect(validateWikiNoteName('a/b/c')).toBeNull();
+  });
+
+  it('rejects when any segment violates the set', () => {
+    expect(validateWikiNoteName('Projects/emails: urgent')).toContain(':');
+    expect(validateWikiNoteName('CON/notes')).toContain('reserved');
+    expect(validateWikiNoteName('ok/notes.')).toContain('dot');
+  });
+
+  it('rejects empty targets', () => {
+    expect(validateWikiNoteName('')).not.toBeNull();
+    expect(validateWikiNoteName('///')).not.toBeNull();
+  });
+});
+
+describe('validateVaultFolderSetting', () => {
+  it('empty means vault root and is valid; normal folders pass', () => {
+    expect(validateVaultFolderSetting('')).toBeNull();
+    expect(validateVaultFolderSetting(undefined)).toBeNull();
+    expect(validateVaultFolderSetting('dayGLANCE')).toBeNull();
+    expect(validateVaultFolderSetting('notes/from dayGLANCE')).toBeNull();
+  });
+
+  it('rejects illegal segments', () => {
+    expect(validateVaultFolderSetting('notes?')).toContain('?');
+    expect(validateVaultFolderSetting('a/COM1/b')).toContain('reserved');
+  });
+});
+
+describe('validateDailyNotePattern — validates the RENDERED output', () => {
+  it('the default and common patterns pass', () => {
+    expect(validateDailyNotePattern('yyyy-MM-dd', formatDatePattern)).toBeNull();
+    expect(validateDailyNotePattern('dd MMM yyyy', formatDatePattern)).toBeNull();
+    expect(validateDailyNotePattern('', formatDatePattern)).toBeNull(); // falls back to default
+  });
+
+  it('a pattern whose rendered output contains an illegal literal is rejected', () => {
+    expect(validateDailyNotePattern('notes: yyyy-MM-dd', formatDatePattern)).toContain(':');
+    expect(validateDailyNotePattern('yyyy/MM/dd', formatDatePattern)).toContain('/');
+    expect(validateDailyNotePattern('yyyy-MM-dd?', formatDatePattern)).toContain('?');
+  });
+
+  it('format tokens themselves are not treated as literals (M vs MM padding cannot mask)', () => {
+    // Rendered against 2026-12-31: double-digit month and day.
+    expect(validateDailyNotePattern('M-d-yy', formatDatePattern)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Removes the darwin gates on `obsidian:pick`/`obsidian:restore` so Electron on Windows/Linux gets real vault access, adds cross-platform filename validation for vault filenames derived from user text — **on creation only** — and makes the sync ticks retry a failed vault restore.

> ~~Stacked on #1356~~ — #1356 has merged; `main` is merged back into this branch.

> **⚠️ Release notes — two behavior changes beyond Windows/Linux support:**
> 1. **macOS + Android:** dayGLANCE previously created vault notes with names like `emails: urgent?.md` on macOS — legal there, and Obsidian on macOS will happily create such notes itself — but those names break the same vault when it syncs to Windows (`: ? * " < >` illegal) or Android (`* ? "` illegal). **Creating** such notes is now refused with a visible error on all platforms, on portability grounds (explicitly *not* because Obsidian would refuse them — Obsidian's own restrictions are OS-specific and narrower).
> 2. **macOS (and everywhere): vaults now reconnect on their own.** A vault on an unmounted external drive or a sleeping network share used to stay disconnected for the whole session after a failed launch-time restore, until the user noticed and manually re-picked or hit Sync Now. Now the 5-minute sync poll and the app-refocus handler retry the restore, so the vault reconnects automatically when the volume returns.

## Restore retry (new)

Both background sync triggers were gated on `obsidianVaultHandleRef.current`, which made `performObsidianSync`'s re-acquire branch unreachable from them — a failed startup restore was terminal for the session. The gates are removed (the effects were already keyed on `obsidianConfig?.enabled`); a still-missing vault costs one **silent** `obsidian:restore` round trip (one fs access check in main) per tick — no error state, no loop, bounded at once per 5-minute poll plus once per refocus. The stale comment describing the retry as existing behavior is rewritten. 3 tests pin the seam: failed-then-reachable reconnects on the next poll tick and on a visibility tick without user action; a missing vault is exactly one silent attempt per tick.

## Creation-only gating — the ordering is the point

**The existence check runs BEFORE the validator gate**, in every gated path:

| Case | Behavior |
|---|---|
| invalid name, file already exists | **write proceeds, no error** |
| invalid name, file does not exist | refused, visible error naming the character and pointing at the `[[wikilink]]` in the task title |
| valid name | unchanged |

Rationale: the portability harm is entirely in bringing a *new* unportable name into being. A file already in the vault is already affecting sync whether or not dayGLANCE writes to it again; refusing bought zero portability and stranded the task in a permanent error state whose only remedy broke its link to an existing note. Mechanics: `writeWikiNote` probes for the file first (explicit `Folder/Name` paths navigate **without** `create`, so the probe cannot leave empty directories behind; bare names use the existing whole-vault search); `newNotesFolder` is validated only on the branch that would create inside it; daily notes get the same ordering via `getDailyNoteHandleForWrite` (an existing note written under a legacy bad pattern keeps working). The Android/native branch checks `nativeGetNote` before validating. Reads stay exempt. Deliberately **no** warning UI for existing bad names (a macOS-only user with `foo?.md` has no actual problem) — tracked in #1358 — and deliberately **no** rename-and-relink (renaming breaks every other link to the note; backlink updates are Obsidian's job).

## The gate removal

- `obsidian:pick` and `obsidian:restore` work on every desktop platform. `securityScopedBookmarks: true` stays unconditional (`result.bookmarks` is simply undefined off-macOS); the config's `bookmark` field was already optional, so **no schema migration** — existing macOS `{path, bookmark}` entries are untouched and new Windows/Linux entries are `{path}`.
- **Non-darwin restore reachability check:** with no bookmark to fail at resolve time, a vault on a removed drive/unmounted share/remapped letter would previously restore "successfully" and throw at first write. `obsidian:restore` now verifies the path exists and is a readable directory; failure returns `null` — the exact signal the renderer already maps to "not connected", config kept — and with the retry above, recovery is automatic once the path is reachable again.

## The validation set (union of all synced platforms)

`[ ] # ^ |` (Obsidian-forbidden everywhere; `^` is the planned `^dg-` block-ID sigil), `* " : ? < >` (Windows; Android forbids `* ? "`), `\` `/` within a segment (`/` remains the `[[Folder/Name]]` separator — segments validated individually), control chars, leading dot, trailing dot/space, and `CON PRN AUX NUL COM1-9 LPT1-9` case-insensitive **including with an extension** (`CON.md` is still `CON`).

- `src/utils/obsidianFilename.js` — pure validators, 15 unit tests.
- `src/obsidian.vaultWrites.test.js` — 9 tests on the creation-only ordering.
- `src/hooks/useObsidianSync.retry.test.js` — 3 tests on the restore retry.
- **Entry-time validation** with inline feedback on `dailyNotePattern` and `newNotesFolder` in both Settings surfaces (pattern validated by **rendering** against 2026-12-31); write-time checks remain as backstops for pre-existing configs.

## Verification

- **xvfb smoke (Linux, real app, dialog stubbed in build output only):** pick → write → **quit → relaunch → restore → write** all land on disk with a plain-path config; **moved vault** → restore returns `null` cleanly, write without a restored vault returns `false`, config retained for re-pick.
- **Windows/UNC path handling** (verified via `path.win32` simulation of `resolveInVault`, 13 cases): drive-letter and `\\server\share` vaults resolve normal/nested paths; `..` escapes, same/other-drive absolute injection, drive-relative (`D:foo`), cross-share and cross-host UNC injection all rejected.
- Full suite 99 files / 1460 tests, lint, and both tsc configs green.

## Remaining for hardware (owner)

Mapped drive letter, OneDrive Files-On-Demand vault, non-ASCII vault path, UNC vault, 260-char path limit — plus confirming the refusal error copy reads clearly. The mapped-drive/SMB cases now double as retry tests: disconnect the share, relaunch, reconnect the share, and the vault should come back within one poll interval or on refocus.