### PR TITLE
Fix packaged-build startup crash: add hono as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@glance-apps/sync": "1.6.1",
         "@modelcontextprotocol/node": "2.0.0",
         "@modelcontextprotocol/server": "2.0.0",
+        "hono": "^4.13.1",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
@@ -7817,7 +7818,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
       "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@glance-apps/sync": "1.6.1",
     "@modelcontextprotocol/node": "2.0.0",
     "@modelcontextprotocol/server": "2.0.0",
+    "hono": "^4.13.1",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",

--- a/scripts/audit-check.mjs
+++ b/scripts/audit-check.mjs
@@ -31,6 +31,14 @@ const ACK = {
   // SDK only imports getRequestListener (verified compatible across the major;
   // the vulnerable serve-static subpath was never even loaded), so drop the
   // override when @modelcontextprotocol/node's own range moves to ^2.
+  //
+  // RUNTIME COROLLARY of that override: @hono/node-server 2.x imports
+  // "hono/ws" at module load, and hono is only its PEER dependency — npm
+  // installs it in dev, but electron-builder's production-dependency walker
+  // does not collect peer-installed packages into app.asar, which crashed
+  // every packaged build at startup (ERR_MODULE_NOT_FOUND: hono). That is why
+  // "hono" is a DIRECT dependency in package.json — do not remove it as
+  // unused while the override keeps @hono/node-server on 2.x.
   'GHSA-fx2h-pf6j-xcff': {
     disposition: 'defer', pkg: 'vite',
     reason: 'Dev-server `server.fs.deny` bypass (Windows only). Fix with the vite 5->8 upgrade.',


### PR DESCRIPTION
## Summary

Every **packaged** build — Windows NSIS (as reported), macOS, Linux AppImage — crashed at launch with `ERR_MODULE_NOT_FOUND: Cannot find package 'hono'`, imported from `@hono/node-server/dist/index.mjs` inside `app.asar`. The crash hits before any window opens and regardless of the MCP dev flag, because `main.ts` imports `mcpServer.js` unconditionally.

## Why dev and CI never saw it

`hono` is a **peer** dependency of `@hono/node-server`. npm auto-installs peers into dev `node_modules`, so every dev run, test run, and xvfb smoke resolved it fine — but electron-builder's production-dependency walker collects only real dependency edges into `app.asar`, and no package *depends* on `hono`, so it was silently omitted from every packaged artifact.

## Where it came from

The GHSA-frvp-7c67-39w9 audit fix (PR #1350): the `package.json` override moved `@hono/node-server` from the SDK's `^1.19.9` range to the patched **2.x** line — and 2.x imports `hono/ws` at module load, where 1.x did not. A dependency-tree sweep confirms `hono` is the **only** peer-only runtime edge in the MCP import chain (`@modelcontextprotocol/server` is also a peer of `/node`, but it's already our direct dependency).

## Fix + verification

- `hono@^4.13.1` added as a direct dependency (satisfies both peer ranges: SDK `^4.11.4`, node-server `^4`). Audit gate stays green.
- **Reproduced on a real packaged Linux AppImage from `main`:** identical `ERR_MODULE_NOT_FOUND`, identical importer path. **After the fix:** `hono` present in `app.asar`, app boots clean under xvfb (WS listener up, no exceptions).
- Note added next to the override documentation in `scripts/audit-check.mjs` so `hono` isn't later removed as "unused" while the override keeps `@hono/node-server` on 2.x.
- Full suite 99 files / 1460 tests, tsc clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_