### PR TITLE
MCP Phase 4: three read-only resources over the existing read path

### DIFF
--- a/electron/mcpResources.ts
+++ b/electron/mcpResources.ts
@@ -1,0 +1,101 @@
+// The three Phase 4 read-only resources (spec §5.4), registered onto a
+// per-request McpServer instance by the mcpServer.ts factory.
+//
+// NO SUBSCRIPTIONS — deferred per §5.4: they would add a stateful session
+// dimension to the HTTP transport, and §3.7 keeps this transport sessionless.
+//
+// SAME READ PATH AS THE TOOLS: every resource goes over the same renderer
+// bridge to the same pure read models (mcpReadModel.js) the Phase 2 tools
+// use — no second read path. §5.3 semantics: the server resolves today from
+// its own clock and timezone (never the client's), and every payload echoes
+// the resolved date and IANA timezone. _native device-calendar events ride
+// the same consent tier as the tools (deps.includeNativeEvents) and carry the
+// same distinct type flag, applied inside the shared model.
+//
+// ERRORS: a resource read has no isError content channel, so failures THROW
+// and surface as a JSON-RPC error whose message leads with the same §5.2 code
+// the tools use (e.g. "[renderer_unavailable] …"). Never empty contents — an
+// empty schedule payload is indistinguishable from an empty day (§3.3).
+
+import type { McpServer } from '@modelcontextprotocol/server';
+import type { ReadToolDeps } from './mcpReadTools.js';
+import { localDateOf, dateEnvelope } from './mcpDates.js';
+
+const MIME = 'application/json';
+
+function resourceError(code: string, message: string): Error {
+  return new Error(`[${code}] ${message}`);
+}
+
+export function registerResources(server: McpServer, deps: ReadToolDeps): void {
+  /** Shared fetch: renderer request → JSON contents, or a typed throw. */
+  const read = async (
+    uri: string,
+    method: string,
+    params: Record<string, unknown>,
+    envelope: Record<string, unknown>,
+  ) => {
+    const r = await deps.bridge.request(method, params);
+    if (!r.ok) throw resourceError(r.error.code, r.error.message);
+    return {
+      contents: [{
+        uri,
+        mimeType: MIME,
+        text: JSON.stringify({ ...envelope, ...(r.data as Record<string, unknown>) }),
+      }],
+    };
+  };
+
+  server.registerResource(
+    'dayglance-schedule-today',
+    'dayglance://schedule/today',
+    {
+      title: "Today's schedule",
+      description:
+        "Today's dayGLANCE blocks and completion state. The date is resolved on the user's machine " +
+        '(local calendar date, §5.3) and echoed with the IANA timezone. Items with type ' +
+        '"device_calendar_event" are read-only device calendar events.',
+      mimeType: MIME,
+    },
+    async (uri) => {
+      const today = localDateOf(deps.now(), deps.timeZone());
+      return read(uri.href, 'get_day', {
+        date: today,
+        include_native: deps.includeNativeEvents(),
+      }, dateEnvelope(today, deps.timeZone()) as unknown as Record<string, unknown>);
+    },
+  );
+
+  server.registerResource(
+    'dayglance-schedule-week-current',
+    'dayglance://schedule/week/current',
+    {
+      title: 'Current week',
+      description:
+        'The current calendar week of dayGLANCE blocks — the week containing today, starting on the ' +
+        "user's configured week-start day (echoed as week_start_day, 0=Sunday). Dates and times are " +
+        'local (§5.3); the resolved date and IANA timezone are echoed.',
+      mimeType: MIME,
+    },
+    async (uri) => {
+      const today = localDateOf(deps.now(), deps.timeZone());
+      return read(uri.href, 'get_week', {
+        date: today,
+        include_native: deps.includeNativeEvents(),
+      }, { resolved_date: today, timezone: deps.timeZone() });
+    },
+  );
+
+  server.registerResource(
+    'dayglance-goals-tree',
+    'dayglance://goals/tree',
+    {
+      title: 'Goals and projects',
+      description:
+        'The dayGLANCE goal and project hierarchy with duration-weighted progress (active goals and ' +
+        'projects, matching what the app shows). Same data as the dayglance_get_goal_progress tool.',
+      mimeType: MIME,
+    },
+    async (uri) => read(uri.href, 'goal_progress', {}, { timezone: deps.timeZone() }),
+  );
+}

--- a/electron/mcpServer.ts
+++ b/electron/mcpServer.ts
@@ -25,6 +25,7 @@ import { checkBearerToken, unauthorizedResponse } from './mcpAuth.js';
 import { resolveMcpPort, describeBindFailure } from './mcpPort.js';
 import { registerReadTools, type ReadToolDeps } from './mcpReadTools.js';
 import { registerWriteTools, type WriteToolDeps } from './mcpWriteTools.js';
+import { registerResources } from './mcpResources.js';
 
 export const MCP_ENDPOINT_PATH = '/mcp';
 
@@ -94,7 +95,12 @@ export function startMcpServer(opts: McpServerOptions): http.Server | null {
           ],
         }),
       );
-      if (opts.readDeps) registerReadTools(server, opts.readDeps);
+      if (opts.readDeps) {
+        registerReadTools(server, opts.readDeps);
+        // Phase 4 resources share the read tools' deps: same bridge, same
+        // clock/timezone, same consent tier (§5.4 — no second read path).
+        registerResources(server, opts.readDeps);
+      }
       if (opts.writeDeps) registerWriteTools(server, opts.writeDeps);
       return server;
     },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6819,6 +6819,8 @@ const DayPlanner = () => {
     goals,
     projects,
     isVisibleForUser,
+    // Phase 4 week resource honors the user's week-start setting (0=Sunday).
+    weekStartDay,
   }, {
     // Write setters (Phase 3): handleMcpWrite applies the canonical shapes
     // from src/utils/taskMutations.js through these — the same store layer

--- a/src/utils/mcpReadModel.js
+++ b/src/utils/mcpReadModel.js
@@ -102,6 +102,40 @@ export function buildDayBlocks(state, params) {
   return { blocks };
 }
 
+/**
+ * The 7 local calendar dates of the week containing `dateStr`, starting on the
+ * user's weekStartDay setting (App.jsx: 0=Sunday, 1=Monday, any 0-6). Pure
+ * y/m/d arithmetic via a local Date at noon — noon so no DST transition can
+ * shift the calendar date when adding days.
+ *
+ * This is the STRICT calendar week (the week containing today), deliberately
+ * ignoring the weekViewMode='rolling' display preference: a rolling 7-day
+ * strip anchored at today is a view of the NEXT seven days, not "the current
+ * week", which is what the dayglance://schedule/week/current URI names.
+ */
+export function weekDatesFor(dateStr, weekStartDay) {
+  const start = Number.isInteger(weekStartDay) && weekStartDay >= 0 && weekStartDay <= 6 ? weekStartDay : 0;
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const base = new Date(y, m - 1, d, 12, 0, 0);
+  const diff = (base.getDay() - start + 7) % 7;
+  return Array.from({ length: 7 }, (_, i) => {
+    const day = new Date(y, m - 1, d - diff + i, 12, 0, 0);
+    const p = (n) => String(n).padStart(2, '0');
+    return `${day.getFullYear()}-${p(day.getMonth() + 1)}-${p(day.getDate())}`;
+  });
+}
+
+/** The week resource payload: the day model repeated across the strict week. */
+export function buildWeek(state, params) {
+  const { date, include_native: includeNative = false } = params;
+  const weekStartDay = Number.isInteger(state.weekStartDay) ? state.weekStartDay : 0;
+  const days = weekDatesFor(date, weekStartDay).map((dayDate) => ({
+    date: dayDate,
+    ...buildDayBlocks(state, { date: dayDate, include_native: includeNative }),
+  }));
+  return { week_start_day: weekStartDay, days };
+}
+
 /** The unscheduled inbox, unpaginated — the main process owns paging (§5.1). */
 export function buildUnscheduledItems(state) {
   const { unscheduledTasks = [], isVisibleForUser = () => true } = state;
@@ -207,6 +241,8 @@ export function handleMcpRequest(state, request) {
       return { ok: true, data: { pong: true } };
     case 'get_day':
       return { ok: true, data: buildDayBlocks(state, params) };
+    case 'get_week':
+      return { ok: true, data: buildWeek(state, params) };
     case 'list_unscheduled':
       return { ok: true, data: buildUnscheduledItems(state) };
     case 'goal_progress': {

--- a/src/utils/mcpReadModel.test.js
+++ b/src/utils/mcpReadModel.test.js
@@ -6,6 +6,8 @@ import {
   buildDayBlocks,
   buildUnscheduledItems,
   buildGoalProgress,
+  weekDatesFor,
+  buildWeek,
   handleMcpRequest,
 } from './mcpReadModel.js';
 
@@ -187,6 +189,95 @@ describe('buildGoalProgress', () => {
   });
 });
 
+describe('weekDatesFor — the strict calendar week, honoring weekStartDay', () => {
+  it('Sunday start (0, the app default): 2026-08-12 is a Wednesday', () => {
+    expect(weekDatesFor('2026-08-12', 0)).toEqual([
+      '2026-08-09', '2026-08-10', '2026-08-11', '2026-08-12', '2026-08-13', '2026-08-14', '2026-08-15',
+    ]);
+  });
+
+  it('Monday start (1) shifts the same date into a different week window', () => {
+    expect(weekDatesFor('2026-08-12', 1)).toEqual([
+      '2026-08-10', '2026-08-11', '2026-08-12', '2026-08-13', '2026-08-14', '2026-08-15', '2026-08-16',
+    ]);
+  });
+
+  it('every weekStartDay value 0-6 starts the week on that weekday and contains the date', () => {
+    for (let start = 0; start <= 6; start++) {
+      const days = weekDatesFor('2026-08-12', start);
+      expect(days).toHaveLength(7);
+      const [y, m, d] = days[0].split('-').map(Number);
+      expect(new Date(y, m - 1, d, 12).getDay(), `start=${start}`).toBe(start);
+      expect(days, `start=${start}`).toContain('2026-08-12');
+    }
+  });
+
+  it('a date ON the start day begins its own week (diff 0, not 7)', () => {
+    // 2026-08-09 is a Sunday.
+    expect(weekDatesFor('2026-08-09', 0)[0]).toBe('2026-08-09');
+  });
+
+  it('crosses month and year boundaries correctly', () => {
+    // 2026-01-01 is a Thursday; the Sunday-start week runs 2025-12-28 .. 2026-01-03.
+    expect(weekDatesFor('2026-01-01', 0)).toEqual([
+      '2025-12-28', '2025-12-29', '2025-12-30', '2025-12-31', '2026-01-01', '2026-01-02', '2026-01-03',
+    ]);
+    expect(weekDatesFor('2028-02-29', 1)).toContain('2028-02-29'); // leap day inside its week
+  });
+
+  it('spans a DST transition without skipping or repeating a date', () => {
+    // US spring forward 2026-03-08 (Sunday). Week must be 7 distinct consecutive dates.
+    const days = weekDatesFor('2026-03-10', 0);
+    expect(days).toEqual([
+      '2026-03-08', '2026-03-09', '2026-03-10', '2026-03-11', '2026-03-12', '2026-03-13', '2026-03-14',
+    ]);
+  });
+
+  it('falls back to Sunday for invalid weekStartDay values', () => {
+    for (const bad of [-1, 7, 1.5, '1', null, undefined]) {
+      expect(weekDatesFor('2026-08-12', bad)[0], String(bad)).toBe('2026-08-09');
+    }
+  });
+});
+
+describe('buildWeek — the day model repeated across the week', () => {
+  const state = {
+    weekStartDay: 1,
+    tasks: [
+      T({ id: 'mon', date: '2026-08-10', startTime: '09:00' }),
+      T({ id: 'sun-next', date: '2026-08-16', startTime: '10:00' }),
+      T({ id: 'outside', date: '2026-08-17', startTime: '10:00' }),
+      T({ id: 'native-cal-w1', date: '2026-08-12', _native: true, imported: true, startTime: '11:00' }),
+    ],
+    recurringTasks: [],
+  };
+
+  it('returns 7 days honoring weekStartDay, each shaped exactly like get_day', () => {
+    const week = buildWeek(state, { date: '2026-08-12', include_native: true });
+    expect(week.week_start_day).toBe(1);
+    expect(week.days).toHaveLength(7);
+    expect(week.days[0].date).toBe('2026-08-10');
+    expect(week.days[0].blocks.map((b) => b.id)).toEqual(['mon']);
+    expect(week.days[6].date).toBe('2026-08-16');
+    expect(week.days[6].blocks.map((b) => b.id)).toEqual(['sun-next']);
+    expect(week.days.flatMap((d) => d.blocks.map((b) => b.id))).not.toContain('outside');
+    const native = week.days[2].blocks.find((b) => b.id === 'native-cal-w1');
+    expect(native.type).toBe('device_calendar_event');
+    expect(native.read_only).toBe(true);
+  });
+
+  it('excludes _native events when include_native is off — same gate as get_day', () => {
+    const week = buildWeek(state, { date: '2026-08-12' });
+    expect(week.days.flatMap((d) => d.blocks.map((b) => b.type))).not.toContain('device_calendar_event');
+  });
+
+  it('defaults week_start_day to 0 when the slice is absent', () => {
+    const week = buildWeek({ tasks: [], recurringTasks: [] }, { date: '2026-08-12' });
+    expect(week.week_start_day).toBe(0);
+    expect(week.days[0].date).toBe('2026-08-09');
+  });
+});
+
 describe('handleMcpRequest — the dispatcher', () => {
   const state = { tasks: [], recurringTasks: [], unscheduledTasks: [], goals: [], projects: [] };
 
@@ -194,8 +285,9 @@ describe('handleMcpRequest — the dispatcher', () => {
     expect(handleMcpRequest(state, { method: 'ping' })).toEqual({ ok: true, data: { pong: true } });
   });
 
-  it('routes the three read methods', () => {
+  it('routes the four read methods', () => {
     expect(handleMcpRequest(state, { method: 'get_day', params: { date: '2026-08-10' } }).ok).toBe(true);
+    expect(handleMcpRequest(state, { method: 'get_week', params: { date: '2026-08-10' } }).ok).toBe(true);
     expect(handleMcpRequest(state, { method: 'list_unscheduled' }).ok).toBe(true);
     expect(handleMcpRequest(state, { method: 'goal_progress', params: {} }).ok).toBe(true);
   });


### PR DESCRIPTION
## Summary

Phase 4 of `docs/mcp-server-spec.md` §5.4: `dayglance://schedule/today`, `dayglance://schedule/week/current`, and `dayglance://goals/tree`, registered per-request by the same factory as the tools (§3.7). **No subscriptions** — deferred per §5.4. **No second read path**: every resource rides the Phase 2 renderer bridge to the shared pure models; the week needed new range logic, so the existing model was extended (`weekDatesFor` + `buildWeek` in `mcpReadModel.js`) rather than paralleled.

**"Current week" decision (from the pre-implementation check):** the app has a `weekStartDay` setting (0=Sunday default, persisted, user-settable) and the resources honor it, echoing it as `week_start_day`. The week view's data shape is the day model repeated — 7 dates, no distinct shape — so the payload is 7 `get_day`-shaped entries. The separate `weekViewMode='rolling'` display preference is deliberately **not** honored: a rolling strip anchored at today is "the next seven days," not "the current week" that the URI names.

**Same semantics as the tools:** server-resolved local date + IANA timezone echoed (§5.3); `_native` events gated on the same consent tier and carrying the same `device_calendar_event` + `read_only` flags (applied inside the shared model, so tools and resources cannot drift); failures **throw** as JSON-RPC errors led by the §5.2 code (`[renderer_unavailable] …`) since resources have no `isError` content channel — never empty contents.

## Exit criteria

1. ✅ All three resources listed and read from MCP Inspector against the live app with real seeded data.
2. ✅ `weekStartDay` honored, verified live both ways: `weekStartDay=1` → Mon 08-10..Sun 08-16, *excluding* a Sunday block; flipped to `0` → Sun 08-09..Sat 08-15, *including* it.
3. ✅ CDP `Page.crash` then `resources/read` → JSON-RPC error `[renderer_unavailable] … this is NOT an empty schedule`, no empty contents, no hang.
4. ✅ `include_native` observed at the renderer boundary flipping `false`/`true` with `DAYGLANCE_MCP_CALENDAR`; flag-vs-absence in week output pinned by unit tests (EventKit events can't exist on Linux).
5. ✅ 10 new tests (`weekDatesFor`: all 7 start values, on-start-day dates, month/year/DST boundaries, invalid fallbacks; `buildWeek`: shape, tier gate, default); mutants 8/9 killed, 1 equivalent (noon-vs-midnight anchor is unobservable under field-based date arithmetic; kept as defense-in-depth for zones whose midnight doesn't exist on DST days).

## Tested vs not

Unit-tested + mutation-verified: `weekDatesFor`, `buildWeek`, the `get_week` dispatcher route. Verified live but untested wiring, as in prior phases: `electron/mcpResources.ts` registration and the one-line `App.jsx`/`mcpServer.ts` glue.

Full suite: 99 files / 1470 tests; lint and both tsc configs clean. Still behind `DAYGLANCE_MCP_DEV=1`; nothing in `useElectronBridge.js`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_