### PR TITLE
MCP Phase 5a: local-integrations settings, consent tiers, Stream Deck migration

### DIFF
--- a/electron/localIntegrations.test.ts
+++ b/electron/localIntegrations.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest';
+import {
+  defaultConfig,
+  decideStreamDeckMigration,
+  normalizeConfig,
+  mcpGates,
+  applyTransition,
+  listenerEffects,
+  type LocalIntegrationsConfig,
+  type TransitionAction,
+} from './localIntegrations.js';
+
+// §6.2's blocking migration, §6.3's tiers, and the consent-state machine.
+// Load-bearing: an upgrade turns Stream Deck ON exactly once; a user's OFF
+// sticks forever after; no path reaches an MCP-bound state without a fresh
+// consent confirmation in the action itself.
+
+const deps = {
+  nowIso: () => '2026-08-12T12:00:00.000Z',
+  generateToken: () => 'tok-' + 'a'.repeat(60),
+  resolvePort: (v: unknown) =>
+    typeof v === 'number' && Number.isInteger(v) && v >= 1 && v <= 65535
+      ? ({ ok: true, port: v } as const)
+      : ({ ok: false, reason: `bad port ${JSON.stringify(v)}` } as const),
+};
+
+const apply = (config: LocalIntegrationsConfig, action: TransitionAction) =>
+  applyTransition(config, action, deps);
+
+const enabledConfig = (tier: 'dayglance' | 'dayglance_calendar' = 'dayglance') => {
+  const r = apply(defaultConfig(), {
+    type: 'set-mcp-read-tier', tier, consentConfirmed: true, calendarConsentConfirmed: true,
+  });
+  if (!r.ok) throw new Error(r.error);
+  return r.config;
+};
+
+describe('decideStreamDeckMigration — the §6.2 blocking item', () => {
+  it('upgrade (no config, prior install evidence) → migrate to ON', () => {
+    expect(decideStreamDeckMigration({ configFileExists: false, priorInstallEvidence: true }))
+      .toEqual({ migrate: true, enabled: true });
+  });
+
+  it('fresh install (no config, no evidence) → migrate to OFF', () => {
+    expect(decideStreamDeckMigration({ configFileExists: false, priorInstallEvidence: false }))
+      .toEqual({ migrate: true, enabled: false });
+  });
+
+  it('config file exists → NEVER migrate again, whatever the evidence says', () => {
+    expect(decideStreamDeckMigration({ configFileExists: true, priorInstallEvidence: true }))
+      .toEqual({ migrate: false });
+    expect(decideStreamDeckMigration({ configFileExists: true, priorInstallEvidence: false }))
+      .toEqual({ migrate: false });
+  });
+});
+
+describe('normalizeConfig — tolerant load, fails toward off', () => {
+  it('garbage collapses to the all-off defaults', () => {
+    for (const raw of [null, undefined, 42, 'x', [], {}]) {
+      expect(normalizeConfig(raw)).toEqual(defaultConfig());
+    }
+  });
+
+  it('round-trips a valid config', () => {
+    const config = enabledConfig('dayglance_calendar');
+    expect(normalizeConfig(JSON.parse(JSON.stringify(config)))).toEqual(config);
+  });
+
+  it('writesEnabled cannot survive without a read tier (writes ride on reads, §6.3)', () => {
+    const raw = { mcp: { readTier: 'off', writesEnabled: true, token: 't' } };
+    expect(normalizeConfig(raw).mcp.writesEnabled).toBe(false);
+  });
+
+  it('unknown tiers collapse to off', () => {
+    expect(normalizeConfig({ mcp: { readTier: 'everything' } }).mcp.readTier).toBe('off');
+  });
+});
+
+describe('mcpGates — §6.3 tier resolution', () => {
+  it('off: not bound, nothing included', () => {
+    expect(mcpGates(defaultConfig())).toEqual({ bound: false, includeNative: false, includeWrites: false });
+  });
+
+  it('dayglance tier: bound, _native excluded, writes off by default', () => {
+    expect(mcpGates(enabledConfig('dayglance'))).toEqual({ bound: true, includeNative: false, includeWrites: false });
+  });
+
+  it('calendar tier: bound with _native included', () => {
+    expect(mcpGates(enabledConfig('dayglance_calendar'))).toEqual({ bound: true, includeNative: true, includeWrites: false });
+  });
+
+  it('writes gate only opens on top of a bound read tier', () => {
+    const withWrites = apply(enabledConfig(), { type: 'set-mcp-writes', enabled: true, writesConsentConfirmed: true });
+    if (!withWrites.ok) throw new Error(withWrites.error);
+    expect(mcpGates(withWrites.config).includeWrites).toBe(true);
+  });
+
+  it('a tier without a token is NOT bound (fail closed)', () => {
+    const config = enabledConfig();
+    config.mcp.token = null;
+    expect(mcpGates(config).bound).toBe(false);
+    expect(mcpGates(config).includeNative).toBe(false);
+  });
+
+  it('writes never leak through an unbound config', () => {
+    const withWrites = apply(enabledConfig(), { type: 'set-mcp-writes', enabled: true, writesConsentConfirmed: true });
+    if (!withWrites.ok) throw new Error(withWrites.error);
+    withWrites.config.mcp.token = null; // unbound (fail-closed) but writesEnabled still true
+    expect(mcpGates(withWrites.config).includeWrites).toBe(false);
+  });
+});
+
+describe('applyTransition — consent-state machine', () => {
+  it('enabling reads from off REQUIRES a fresh consentConfirmed', () => {
+    const refused = apply(defaultConfig(), { type: 'set-mcp-read-tier', tier: 'dayglance' });
+    expect(refused.ok).toBe(false);
+    const alsoRefused = apply(defaultConfig(), { type: 'set-mcp-read-tier', tier: 'dayglance', consentConfirmed: false });
+    expect(alsoRefused.ok).toBe(false);
+  });
+
+  it('a stored consent stamp never substitutes for the dialog on re-enable', () => {
+    const off = apply(enabledConfig(), { type: 'set-mcp-read-tier', tier: 'off' });
+    if (!off.ok) throw new Error(off.error);
+    expect(off.config.mcp.consentAcceptedAt).not.toBeNull(); // history kept…
+    const reEnable = apply(off.config, { type: 'set-mcp-read-tier', tier: 'dayglance' });
+    expect(reEnable.ok).toBe(false); // …but the dialog is required again
+  });
+
+  it('the calendar tier needs its own consent, both from off and as an upgrade from dayglance', () => {
+    const fromOff = apply(defaultConfig(), { type: 'set-mcp-read-tier', tier: 'dayglance_calendar', consentConfirmed: true });
+    expect(fromOff.ok).toBe(false);
+    const upgrade = apply(enabledConfig('dayglance'), { type: 'set-mcp-read-tier', tier: 'dayglance_calendar' });
+    expect(upgrade.ok).toBe(false);
+    const upgradeOk = apply(enabledConfig('dayglance'), {
+      type: 'set-mcp-read-tier', tier: 'dayglance_calendar', calendarConsentConfirmed: true,
+    });
+    expect(upgradeOk.ok).toBe(true);
+  });
+
+  it('downgrading calendar → dayglance and any tier → off need no consent', () => {
+    const down = apply(enabledConfig('dayglance_calendar'), { type: 'set-mcp-read-tier', tier: 'dayglance' });
+    expect(down.ok).toBe(true);
+    const off = apply(enabledConfig(), { type: 'set-mcp-read-tier', tier: 'off' });
+    expect(off.ok).toBe(true);
+  });
+
+  it('first enable mints the token; re-enable keeps the existing one', () => {
+    const first = apply(defaultConfig(), { type: 'set-mcp-read-tier', tier: 'dayglance', consentConfirmed: true });
+    if (!first.ok) throw new Error(first.error);
+    expect(first.config.mcp.token).toBe(deps.generateToken());
+    const config = enabledConfig();
+    config.mcp.token = 'existing-token';
+    const off = apply(config, { type: 'set-mcp-read-tier', tier: 'off' });
+    if (!off.ok) throw new Error(off.error);
+    const back = apply(off.config, { type: 'set-mcp-read-tier', tier: 'dayglance', consentConfirmed: true });
+    if (!back.ok) throw new Error(back.error);
+    expect(back.config.mcp.token).toBe('existing-token');
+  });
+
+  it('turning reads off also turns writes off', () => {
+    const w = apply(enabledConfig(), { type: 'set-mcp-writes', enabled: true, writesConsentConfirmed: true });
+    if (!w.ok) throw new Error(w.error);
+    const off = apply(w.config, { type: 'set-mcp-read-tier', tier: 'off' });
+    if (!off.ok) throw new Error(off.error);
+    expect(off.config.mcp.writesEnabled).toBe(false);
+  });
+
+  it('writes: refused with reads off, refused without confirmation, disable always allowed', () => {
+    expect(apply(defaultConfig(), { type: 'set-mcp-writes', enabled: true, writesConsentConfirmed: true }).ok).toBe(false);
+    expect(apply(enabledConfig(), { type: 'set-mcp-writes', enabled: true }).ok).toBe(false);
+    expect(apply(enabledConfig(), { type: 'set-mcp-writes', enabled: false }).ok).toBe(true);
+  });
+
+  it('rotate-token replaces the token and refuses when none exists', () => {
+    const config = enabledConfig();
+    config.mcp.token = 'old-token';
+    const rotated = apply(config, { type: 'rotate-token' });
+    if (!rotated.ok) throw new Error(rotated.error);
+    expect(rotated.config.mcp.token).toBe(deps.generateToken());
+    expect(rotated.config.mcp.token).not.toBe('old-token');
+    expect(apply(defaultConfig(), { type: 'rotate-token' }).ok).toBe(false);
+  });
+
+  it('set-mcp-port validates via the injected resolver and never scans', () => {
+    const okPort = apply(defaultConfig(), { type: 'set-mcp-port', portOverride: 7900 });
+    if (!okPort.ok) throw new Error(okPort.error);
+    expect(okPort.config.mcp.portOverride).toBe(7900);
+    expect(apply(defaultConfig(), { type: 'set-mcp-port', portOverride: 'seven' }).ok).toBe(false);
+    const cleared = apply(okPort.config, { type: 'set-mcp-port', portOverride: null });
+    if (!cleared.ok) throw new Error(cleared.error);
+    expect(cleared.config.mcp.portOverride).toBeNull();
+  });
+
+  it('user toggling Stream Deck clears the migration provenance', () => {
+    const migrated = defaultConfig();
+    migrated.streamDeck.enabled = true;
+    migrated.streamDeck.migratedFromUnconditional = true;
+    const off = apply(migrated, { type: 'set-stream-deck', enabled: false });
+    if (!off.ok) throw new Error(off.error);
+    expect(off.config.streamDeck).toEqual({ enabled: false, migratedFromUnconditional: false });
+  });
+
+  it('never mutates its input', () => {
+    const config = defaultConfig();
+    const frozen = JSON.stringify(config);
+    apply(config, { type: 'set-mcp-read-tier', tier: 'dayglance', consentConfirmed: true });
+    apply(config, { type: 'set-stream-deck', enabled: true });
+    expect(JSON.stringify(config)).toBe(frozen);
+  });
+});
+
+describe('listenerEffects — reconciliation diff', () => {
+  it('stream deck start/stop/none', () => {
+    const off = defaultConfig();
+    const on = apply(off, { type: 'set-stream-deck', enabled: true });
+    if (!on.ok) throw new Error(on.error);
+    expect(listenerEffects(off, on.config).streamDeck).toBe('start');
+    expect(listenerEffects(on.config, off).streamDeck).toBe('stop');
+    expect(listenerEffects(off, off).streamDeck).toBe('none');
+  });
+
+  it('mcp start on bind, stop on unbind, restart on port change while bound', () => {
+    const off = defaultConfig();
+    const on = enabledConfig();
+    expect(listenerEffects(off, on).mcp).toBe('start');
+    expect(listenerEffects(on, off).mcp).toBe('stop');
+    const moved = apply(on, { type: 'set-mcp-port', portOverride: 7900 });
+    if (!moved.ok) throw new Error(moved.error);
+    expect(listenerEffects(on, moved.config).mcp).toBe('restart');
+  });
+
+  it('token rotation is NOT a restart — the getter makes it instant', () => {
+    const on = enabledConfig();
+    const rotated = apply(on, { type: 'rotate-token' });
+    if (!rotated.ok) throw new Error(rotated.error);
+    expect(listenerEffects(on, rotated.config).mcp).toBe('none');
+  });
+
+  it('tier changes while bound are none (gates re-read live)', () => {
+    const day = enabledConfig('dayglance');
+    const cal = apply(day, { type: 'set-mcp-read-tier', tier: 'dayglance_calendar', calendarConsentConfirmed: true });
+    if (!cal.ok) throw new Error(cal.error);
+    expect(listenerEffects(day, cal.config).mcp).toBe('none');
+  });
+});

--- a/electron/localIntegrations.ts
+++ b/electron/localIntegrations.ts
@@ -1,0 +1,258 @@
+// Local-integrations configuration decisions (spec §6.2/§6.3), extracted as
+// pure functions in the startupQuit.ts style: migration, tier resolution, and
+// consent-state transitions all live here, tested; file I/O and listener
+// lifecycle live in main.ts.
+//
+// THE BLOCKING ITEM (§6.2): the Stream Deck listener has shipped
+// unconditionally enabled since it existed. Introducing an off-by-default
+// toggle would silently kill every existing user's buttons on auto-update —
+// no error, dead keys. So existing installs MIGRATE TO ON exactly once, and
+// the config file itself is the one-time flag: once it exists, migration
+// never runs again, so a user's later "off" can never be re-enabled by an
+// update. Fresh installs start with everything off.
+
+export type McpReadTier = 'off' | 'dayglance' | 'dayglance_calendar';
+
+export interface LocalIntegrationsConfig {
+  version: 1;
+  streamDeck: {
+    enabled: boolean;
+    /** True when `enabled` came from the §6.2 upgrade migration, not a user choice. */
+    migratedFromUnconditional: boolean;
+  };
+  mcp: {
+    readTier: McpReadTier;
+    /** Writes are a separate opt-in ON TOP of a read tier (§6.3). */
+    writesEnabled: boolean;
+    /** Pre-shared bearer token; null until first enable. */
+    token: string | null;
+    /** User port override; null = DEFAULT_MCP_PORT. */
+    portOverride: number | null;
+    /** When the §6.4 base consent copy was accepted. */
+    consentAcceptedAt: string | null;
+    /** When the device-calendar tier's own copy (§6.4) was accepted. */
+    calendarConsentAcceptedAt: string | null;
+    /** When the writes opt-in was confirmed. */
+    writesConsentAcceptedAt: string | null;
+  };
+}
+
+export function defaultConfig(): LocalIntegrationsConfig {
+  return {
+    version: 1,
+    streamDeck: { enabled: false, migratedFromUnconditional: false },
+    mcp: {
+      readTier: 'off',
+      writesEnabled: false,
+      token: null,
+      portOverride: null,
+      consentAcceptedAt: null,
+      calendarConsentAcceptedAt: null,
+      writesConsentAcceptedAt: null,
+    },
+  };
+}
+
+/**
+ * The §6.2 migration decision, made once at startup BEFORE any listener binds.
+ *
+ * - Config file exists → it is the authority; never migrate again. This is
+ *   what makes a user's deliberate "off" stick across every later update.
+ * - No config file + evidence of a prior install → upgrade: Stream Deck ON.
+ * - No config file + no evidence → fresh install: everything off.
+ *
+ * `priorInstallEvidence` is "any pre-existing userData artifact that only a
+ * previous RUN could have created" — window-state.json (written on window
+ * close/move), window-theme.json (written on first theme report), or the
+ * .origin-migrated-file-to-app-v1 flag (written on first run of any modern
+ * version). The startup log is NOT usable evidence: it is created at module
+ * load of the current run, before this decision executes.
+ */
+export function decideStreamDeckMigration(input: {
+  configFileExists: boolean;
+  priorInstallEvidence: boolean;
+}): { migrate: false } | { migrate: true; enabled: boolean } {
+  if (input.configFileExists) return { migrate: false };
+  return { migrate: true, enabled: input.priorInstallEvidence };
+}
+
+/** Tolerant load: anything malformed collapses to safe defaults (everything off). */
+export function normalizeConfig(raw: unknown): LocalIntegrationsConfig {
+  const base = defaultConfig();
+  if (typeof raw !== 'object' || raw === null) return base;
+  const r = raw as Record<string, any>;
+  const sd = typeof r['streamDeck'] === 'object' && r['streamDeck'] !== null ? r['streamDeck'] : {};
+  const mcp = typeof r['mcp'] === 'object' && r['mcp'] !== null ? r['mcp'] : {};
+  const tier: McpReadTier = mcp.readTier === 'dayglance' || mcp.readTier === 'dayglance_calendar' ? mcp.readTier : 'off';
+  const str = (v: unknown) => (typeof v === 'string' && v.length > 0 ? v : null);
+  return {
+    version: 1,
+    streamDeck: {
+      enabled: sd.enabled === true,
+      migratedFromUnconditional: sd.migratedFromUnconditional === true,
+    },
+    mcp: {
+      readTier: tier,
+      writesEnabled: mcp.writesEnabled === true && tier !== 'off',
+      token: str(mcp.token),
+      portOverride: Number.isInteger(mcp.portOverride) ? mcp.portOverride : null,
+      consentAcceptedAt: str(mcp.consentAcceptedAt),
+      calendarConsentAcceptedAt: str(mcp.calendarConsentAcceptedAt),
+      writesConsentAcceptedAt: str(mcp.writesConsentAcceptedAt),
+    },
+  };
+}
+
+/**
+ * Tier resolution (§6.3): the three gates the listeners consume. These are
+ * the values behind the closures main.ts hands to the tool modules — the
+ * closures Phase 2/3 built precisely so this swap touches no tool code.
+ */
+export function mcpGates(config: LocalIntegrationsConfig): {
+  bound: boolean;
+  includeNative: boolean;
+  includeWrites: boolean;
+} {
+  const bound = config.mcp.readTier !== 'off' && config.mcp.token !== null;
+  return {
+    bound,
+    includeNative: bound && config.mcp.readTier === 'dayglance_calendar',
+    includeWrites: bound && config.mcp.writesEnabled,
+  };
+}
+
+export type TransitionAction =
+  | { type: 'set-stream-deck'; enabled: boolean }
+  | { type: 'set-mcp-read-tier'; tier: McpReadTier; consentConfirmed?: boolean; calendarConsentConfirmed?: boolean }
+  | { type: 'set-mcp-writes'; enabled: boolean; writesConsentConfirmed?: boolean }
+  | { type: 'rotate-token' }
+  | { type: 'set-mcp-port'; portOverride: unknown };
+
+export type TransitionResult =
+  | { ok: true; config: LocalIntegrationsConfig }
+  | { ok: false; error: string };
+
+export interface TransitionDeps {
+  nowIso: () => string;
+  /** Injectable so tests need no CSPRNG; main.ts passes generateMcpToken. */
+  generateToken: () => string;
+  /** Injectable port validation; main.ts passes resolveMcpPort. */
+  resolvePort: (override: unknown) => { ok: true; port: number } | { ok: false; reason: string };
+}
+
+/**
+ * The consent-state machine (§6.3/§6.4). Every enabling transition demands a
+ * FRESH confirmation in the action — stored stamps record history, they never
+ * substitute for the dialog. MCP cannot reach a bound state through any path
+ * that skips the consent copy.
+ */
+export function applyTransition(
+  config: LocalIntegrationsConfig,
+  action: TransitionAction,
+  deps: TransitionDeps,
+): TransitionResult {
+  const next: LocalIntegrationsConfig = JSON.parse(JSON.stringify(config));
+
+  switch (action.type) {
+    case 'set-stream-deck': {
+      next.streamDeck.enabled = action.enabled === true;
+      // Any explicit user choice supersedes the migration provenance.
+      next.streamDeck.migratedFromUnconditional = false;
+      return { ok: true, config: next };
+    }
+
+    case 'set-mcp-read-tier': {
+      const { tier } = action;
+      if (tier !== 'off' && tier !== 'dayglance' && tier !== 'dayglance_calendar') {
+        return { ok: false, error: `Unknown read tier ${JSON.stringify(tier)}` };
+      }
+      if (tier === 'off') {
+        next.mcp.readTier = 'off';
+        // Writes ride on top of a read tier (§6.3): no reads, no writes.
+        next.mcp.writesEnabled = false;
+        return { ok: true, config: next };
+      }
+      const enablingFromOff = config.mcp.readTier === 'off';
+      if (enablingFromOff && action.consentConfirmed !== true) {
+        return { ok: false, error: 'Enabling MCP reads requires accepting the consent notice' };
+      }
+      if (tier === 'dayglance_calendar' && config.mcp.readTier !== 'dayglance_calendar' && action.calendarConsentConfirmed !== true) {
+        return { ok: false, error: 'Including device calendar events requires accepting the device-calendar consent notice' };
+      }
+      if (enablingFromOff) next.mcp.consentAcceptedAt = deps.nowIso();
+      if (tier === 'dayglance_calendar' && config.mcp.readTier !== 'dayglance_calendar') {
+        next.mcp.calendarConsentAcceptedAt = deps.nowIso();
+      }
+      if (next.mcp.token === null) next.mcp.token = deps.generateToken();
+      next.mcp.readTier = tier;
+      return { ok: true, config: next };
+    }
+
+    case 'set-mcp-writes': {
+      if (action.enabled !== true) {
+        next.mcp.writesEnabled = false;
+        return { ok: true, config: next };
+      }
+      if (config.mcp.readTier === 'off') {
+        return { ok: false, error: 'Writes require a read tier to be enabled first (§6.3)' };
+      }
+      if (action.writesConsentConfirmed !== true) {
+        return { ok: false, error: 'Enabling MCP writes requires accepting the writes notice' };
+      }
+      next.mcp.writesEnabled = true;
+      next.mcp.writesConsentAcceptedAt = deps.nowIso();
+      return { ok: true, config: next };
+    }
+
+    case 'rotate-token': {
+      if (config.mcp.token === null) {
+        return { ok: false, error: 'No token to rotate — enable MCP first' };
+      }
+      next.mcp.token = deps.generateToken();
+      return { ok: true, config: next };
+    }
+
+    case 'set-mcp-port': {
+      const raw = action.portOverride;
+      if (raw === null || raw === undefined || raw === '') {
+        next.mcp.portOverride = null; // back to the default port
+        return { ok: true, config: next };
+      }
+      const resolved = deps.resolvePort(raw);
+      if (!resolved.ok) return { ok: false, error: resolved.reason };
+      next.mcp.portOverride = resolved.port;
+      return { ok: true, config: next };
+    }
+
+    default:
+      return { ok: false, error: `Unknown action ${JSON.stringify((action as { type?: string }).type)}` };
+  }
+}
+
+/**
+ * What the listener lifecycle must do after a config change. Pure diff, so
+ * the reconciler in main.ts stays a dumb executor.
+ *
+ * MCP 'restart' covers a port change while bound. A TOKEN change is
+ * deliberately NOT a restart: the listener reads the token through a getter
+ * on every request, so rotation invalidates the old token on the very next
+ * request with zero downtime.
+ */
+export function listenerEffects(
+  before: LocalIntegrationsConfig,
+  after: LocalIntegrationsConfig,
+): { streamDeck: 'start' | 'stop' | 'none'; mcp: 'start' | 'stop' | 'restart' | 'none' } {
+  const sdBefore = before.streamDeck.enabled;
+  const sdAfter = after.streamDeck.enabled;
+  const streamDeck = sdBefore === sdAfter ? 'none' : sdAfter ? 'start' : 'stop';
+
+  const boundBefore = mcpGates(before).bound;
+  const boundAfter = mcpGates(after).bound;
+  let mcp: 'start' | 'stop' | 'restart' | 'none';
+  if (!boundBefore && boundAfter) mcp = 'start';
+  else if (boundBefore && !boundAfter) mcp = 'stop';
+  else if (boundBefore && boundAfter && before.mcp.portOverride !== after.mcp.portOverride) mcp = 'restart';
+  else mcp = 'none';
+
+  return { streamDeck, mcp };
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,7 +4,9 @@ import fs from 'node:fs';
 import dns from 'node:dns';
 import nodeNet from 'node:net';
 import { fileURLToPath } from 'node:url';
-import { createWsServer } from './ws-server.js';
+import { createWsServer, WS_PORT } from './ws-server.js';
+import type { WebSocketServer } from 'ws';
+import type http from 'node:http';
 import { registerSubscriptionHandlers } from './subscription.js';
 import { registerCalendarHandlers } from './calendar.js';
 import { registerStorefrontHandlers } from './storefront.js';
@@ -14,7 +16,20 @@ import { APP_SCHEME, APP_HOST, APP_BASE_URL, resolveAppRequest } from './appProt
 import { shouldQuitOnAllWindowsClosed } from './startupQuit.js';
 import { initStartupLog, logStartup } from './startupLog.js';
 import { startMcpServer } from './mcpServer.js';
-import { createRendererBridge } from './mcpRendererBridge.js';
+import { generateMcpToken } from './mcpAuth.js';
+import { resolveMcpPort, describeBindFailure, DEFAULT_MCP_PORT } from './mcpPort.js';
+import {
+  defaultConfig as defaultIntegrationsConfig,
+  decideStreamDeckMigration,
+  normalizeConfig as normalizeIntegrationsConfig,
+  mcpGates,
+  applyTransition as applyIntegrationsTransition,
+  listenerEffects,
+  type LocalIntegrationsConfig,
+  type TransitionAction,
+} from './localIntegrations.js';
+import { createRendererBridge, type RendererBridge } from './mcpRendererBridge.js';
+import type { WriteToolDeps } from './mcpWriteTools.js';
 import { createWriteGate } from './mcpWriteGate.js';
 import { createIdempotencyStore } from './mcpIdempotency.js';
 import { trayReloadDebounceMs } from './trayReloadPolicy.js';
@@ -809,6 +824,235 @@ async function migrateFileToAppStorage(): Promise<void> {
   }
 }
 
+// ── Local integrations: Stream Deck + MCP (spec §6.2/§6.3, Phase 5a) ────────
+// Every DECISION (migration, tier resolution, consent transitions, listener
+// reconciliation) lives in localIntegrations.ts, pure and unit-tested. This
+// block owns only what cannot be pure: file I/O, listener lifecycle, and IPC.
+
+const LOCAL_INTEGRATIONS_FILE = 'local-integrations.json';
+function integrationsConfigPath(): string {
+  return path.join(app.getPath('userData'), LOCAL_INTEGRATIONS_FILE);
+}
+
+let integrationsConfig: LocalIntegrationsConfig = defaultIntegrationsConfig();
+let wsServerHandle: WebSocketServer | null = null;
+let mcpServerHandle: http.Server | null = null;
+let streamDeckStatus: { running: boolean; error: string | null } = { running: false, error: null };
+let mcpStatus: { running: boolean; error: string | null } = { running: false, error: null };
+
+// Created on first MCP start and reused across stop/start cycles: the bridge
+// registers an ipcMain listener (restarting must not stack another one), and
+// a long-lived gate + idempotency store mean toggling the port cannot be used
+// to reset rate-limit strikes or the write-replay window.
+let mcpBridge: RendererBridge | null = null;
+let mcpWriteGate: ReturnType<typeof createWriteGate> | null = null;
+let mcpIdempotencyStore: WriteToolDeps['store'] | null = null;
+
+function saveIntegrationsConfig(): void {
+  try {
+    fs.writeFileSync(integrationsConfigPath(), JSON.stringify(integrationsConfig, null, 2));
+  } catch (err) {
+    console.error('[dayGLANCE] Failed to save local-integrations config:', err);
+  }
+}
+
+// MUST run before migrateFileToAppStorage(): that migration stamps its
+// done-flag even on a FRESH install, so reading the prior-install evidence
+// after it would make every fresh install look like an upgrade and switch
+// Stream Deck on for users who never had it (§6.2 inverted).
+function loadOrMigrateIntegrationsConfig(): void {
+  const cfgPath = integrationsConfigPath();
+  if (fs.existsSync(cfgPath)) {
+    // The file's existence is the one-time migration flag: once it exists it
+    // is the sole authority, so a user's deliberate "off" survives every
+    // subsequent update. Unreadable content fails toward all-off — it never
+    // re-runs the migration.
+    try {
+      integrationsConfig = normalizeIntegrationsConfig(JSON.parse(fs.readFileSync(cfgPath, 'utf-8')));
+    } catch (err) {
+      console.error('[dayGLANCE] Unreadable local-integrations config; using defaults (all off):', err);
+      integrationsConfig = defaultIntegrationsConfig();
+    }
+    return;
+  }
+  // Any userData artifact only a previous RUN could have written. The startup
+  // log is deliberately not usable here — initStartupLog() already created it
+  // for THIS run at module load.
+  const priorInstallEvidence =
+    fs.existsSync(winStatePath()) ||
+    fs.existsSync(WINDOW_THEME_FILE()) ||
+    fs.existsSync(path.join(app.getPath('userData'), STORAGE_MIGRATION_FLAG));
+  const decision = decideStreamDeckMigration({ configFileExists: false, priorInstallEvidence });
+  integrationsConfig = defaultIntegrationsConfig();
+  if (decision.migrate && decision.enabled) {
+    // Upgrade: the Stream Deck listener shipped unconditionally before this
+    // config existed, so existing users keep it ON with no action needed.
+    integrationsConfig.streamDeck.enabled = true;
+    integrationsConfig.streamDeck.migratedFromUnconditional = true;
+  }
+  saveIntegrationsConfig();
+  logStartup(
+    `local integrations: config created (streamDeck ${integrationsConfig.streamDeck.enabled ? 'ON — upgrade migration' : 'off — fresh install'})`,
+  );
+}
+
+function pushIntegrationsStatus(): void {
+  live(mainWindow)?.webContents.send('local-integrations:status', integrationsSnapshot());
+}
+
+function startStreamDeckListener(): void {
+  if (wsServerHandle) return;
+  streamDeckStatus = { running: false, error: null };
+  const wss = createWsServer(() => live(mainWindow));
+  wsServerHandle = wss;
+  wss.on('listening', () => {
+    streamDeckStatus = { running: true, error: null };
+    pushIntegrationsStatus();
+  });
+  wss.on('error', (err: NodeJS.ErrnoException) => {
+    // Loud, specific, and no port-scan fallback — same posture as MCP (§3.4).
+    streamDeckStatus = {
+      running: false,
+      error: err.code === 'EADDRINUSE'
+        ? `Port ${WS_PORT} is already in use by another process. The Stream Deck plugin expects this exact port, so dayGLANCE will not pick another one. Quit the conflicting process, then toggle Stream Deck support off and on.`
+        : `Stream Deck listener failed: ${err.code ?? err.message ?? 'unknown error'}`,
+    };
+    pushIntegrationsStatus();
+  });
+}
+
+function stopStreamDeckListener(): void {
+  const wss = wsServerHandle;
+  wsServerHandle = null;
+  streamDeckStatus = { running: false, error: null };
+  if (wss) {
+    for (const client of wss.clients) client.terminate();
+    wss.close();
+  }
+  pushIntegrationsStatus();
+}
+
+function startMcpListener(): void {
+  if (mcpServerHandle) return;
+  if (!mcpGates(integrationsConfig).bound) return; // off means off: no port bound (§6.3)
+
+  const resolved = resolveMcpPort(integrationsConfig.mcp.portOverride);
+  if (!resolved.ok) {
+    mcpStatus = { running: false, error: resolved.reason };
+    pushIntegrationsStatus();
+    return;
+  }
+
+  if (!mcpBridge) mcpBridge = createRendererBridge(() => live(mainWindow));
+  if (!mcpWriteGate) mcpWriteGate = createWriteGate();
+  if (!mcpIdempotencyStore) mcpIdempotencyStore = createIdempotencyStore();
+  // Resolved on the machine, never inferred from the client (§5.3).
+  const mcpTimeZone = () => Intl.DateTimeFormat().resolvedOptions().timeZone;
+  // Getter, read per request: settings-driven rotation invalidates the old
+  // token on the very next request, no restart involved.
+  const mcpToken = () => integrationsConfig.mcp.token ?? '';
+
+  mcpStatus = { running: false, error: null };
+  const srv = startMcpServer({
+    token: mcpToken,
+    portOverride: integrationsConfig.mcp.portOverride,
+    readDeps: {
+      bridge: mcpBridge,
+      now: Date.now,
+      timeZone: mcpTimeZone,
+      // §6.3 device-calendar tier, settings-backed (this closure replaced the
+      // DAYGLANCE_MCP_CALENDAR env var — tool code unchanged, as designed).
+      includeNativeEvents: () => mcpGates(integrationsConfig).includeNative,
+    },
+    writeDeps: {
+      bridge: mcpBridge,
+      gate: mcpWriteGate,
+      store: mcpIdempotencyStore,
+      token: mcpToken,
+      // §6.3 writes opt-in, settings-backed (replaced DAYGLANCE_MCP_WRITES).
+      includeWrites: () => mcpGates(integrationsConfig).includeWrites,
+      noteMcpWrite: () => { lastMcpWriteAt = Date.now(); },
+      // §4.3: repeated rate-limit violations auto-disable writes with a
+      // notification. Fires exactly once, on the disable edge.
+      onWritesDisabled: () => {
+        console.error('[dayGLANCE] MCP writes auto-disabled after repeated rate-limit violations.');
+        if (Notification.isSupported()) {
+          new Notification({
+            title: 'dayGLANCE MCP writes disabled',
+            body: 'An MCP client repeatedly exceeded the write rate limit. Writes stay off until dayGLANCE restarts.',
+          }).show();
+        }
+      },
+      now: Date.now,
+      timeZone: mcpTimeZone,
+    },
+  });
+  if (!srv) {
+    // startMcpServer already logged why; mirror it into settings.
+    mcpStatus = { running: false, error: 'MCP server could not start — see the startup log for details.' };
+    pushIntegrationsStatus();
+    return;
+  }
+  mcpServerHandle = srv;
+  srv.on('listening', () => {
+    mcpStatus = { running: true, error: null };
+    pushIntegrationsStatus();
+  });
+  srv.on('error', (err: NodeJS.ErrnoException) => {
+    // The §3.4 loud collision: named port, no scan, shown in settings.
+    mcpStatus = { running: false, error: describeBindFailure(resolved.port, err) };
+    pushIntegrationsStatus();
+  });
+}
+
+function stopMcpListener(onClosed?: () => void): void {
+  const srv = mcpServerHandle;
+  mcpServerHandle = null;
+  mcpStatus = { running: false, error: null };
+  pushIntegrationsStatus();
+  if (!srv) { onClosed?.(); return; }
+  srv.close(() => { onClosed?.(); });
+  // Destroy live connections (idle keep-alives, open SSE streams) so the port
+  // is actually released now — close() alone waits on them indefinitely, which
+  // would make a port-change restart race its own rebind.
+  srv.closeAllConnections();
+}
+
+function integrationsSnapshot() {
+  const resolved = resolveMcpPort(integrationsConfig.mcp.portOverride);
+  return {
+    config: integrationsConfig,
+    gates: mcpGates(integrationsConfig),
+    ports: {
+      streamDeck: WS_PORT,
+      mcpDefault: DEFAULT_MCP_PORT,
+      mcpEffective: resolved.ok ? resolved.port : null,
+    },
+    status: { streamDeck: streamDeckStatus, mcp: mcpStatus },
+  };
+}
+
+function registerLocalIntegrationsHandlers(): void {
+  ipcMain.handle('local-integrations:get', () => integrationsSnapshot());
+  ipcMain.handle('local-integrations:transition', (_event, action: unknown) => {
+    const result = applyIntegrationsTransition(integrationsConfig, action as TransitionAction, {
+      nowIso: () => new Date().toISOString(),
+      generateToken: generateMcpToken,
+      resolvePort: resolveMcpPort,
+    });
+    if (!result.ok) return { ok: false, error: result.error };
+    const effects = listenerEffects(integrationsConfig, result.config);
+    integrationsConfig = result.config;
+    saveIntegrationsConfig();
+    if (effects.streamDeck === 'start') startStreamDeckListener();
+    else if (effects.streamDeck === 'stop') stopStreamDeckListener();
+    if (effects.mcp === 'start') startMcpListener();
+    else if (effects.mcp === 'stop') stopMcpListener();
+    else if (effects.mcp === 'restart') stopMcpListener(() => startMcpListener());
+    return { ok: true, snapshot: integrationsSnapshot() };
+  });
+}
+
 app.whenReady().then(async () => {
   // A doomed second instance may still reach 'ready' before app.quit() takes
   // effect; bail before creating any windows so it never steals the port/state.
@@ -888,61 +1132,26 @@ app.whenReady().then(async () => {
   // boots with the migrated localStorage. The protocol handler above must already
   // be registered (the writer window loads app://). Awaited so createWindow() sees
   // the migrated data; failures are swallowed inside and never block startup.
+  // Local-integrations config load + the §6.2 one-time Stream Deck migration.
+  // Ordering is load-bearing: migrateFileToAppStorage() below stamps its
+  // done-flag even on a fresh install, and that flag is one of the
+  // prior-install signals — so this MUST read the evidence first.
+  loadOrMigrateIntegrationsConfig();
+
   logStartup('storage migration: start');
   await migrateFileToAppStorage();
   logStartup('storage migration: done');
 
   const win = createWindow();
-  createWsServer(() => live(mainWindow));
-  // MCP listener — Phase 2: read tools over renderer IPC, still dev flag only
-  // (settings UI and the consent gate are Phase 5, docs/mcp-server-spec.md
-  // §10). Token comes from the environment for now; the discovery file is
-  // Phase 6. Off means off: without the flag no port is bound at all.
-  if (process.env['DAYGLANCE_MCP_DEV'] === '1') {
-    // Getter, not a reference: requests must target the CURRENT main
-    // window even if it is recreated (same posture as createWsServer).
-    const mcpBridge = createRendererBridge(() => live(mainWindow));
-    const mcpToken = process.env['DAYGLANCE_MCP_TOKEN'] ?? '';
-    // Resolved on the machine, never inferred from the client (§5.3).
-    const mcpTimeZone = () => Intl.DateTimeFormat().resolvedOptions().timeZone;
-    startMcpServer({
-      token: mcpToken,
-      portOverride: process.env['DAYGLANCE_MCP_PORT'],
-      readDeps: {
-        bridge: mcpBridge,
-        now: Date.now,
-        timeZone: mcpTimeZone,
-        // Device-calendar consent tier (§6.3). Phase 2 source is an env var;
-        // Phase 5 replaces this closure with the settings-backed tier and
-        // nothing in the tool code changes.
-        includeNativeEvents: () => process.env['DAYGLANCE_MCP_CALENDAR'] === '1',
-      },
-      writeDeps: {
-        bridge: mcpBridge,
-        gate: createWriteGate(),
-        store: createIdempotencyStore(),
-        token: () => mcpToken,
-        // Read-write consent tier (§6.3, second opt-in). Env-sourced now;
-        // Phase 5 swaps the source without touching tool code — same pattern
-        // as includeNativeEvents above.
-        includeWrites: () => process.env['DAYGLANCE_MCP_WRITES'] === '1',
-        noteMcpWrite: () => { lastMcpWriteAt = Date.now(); },
-        // §4.3: repeated rate-limit violations auto-disable writes with a
-        // notification. Fires exactly once, on the disable edge.
-        onWritesDisabled: () => {
-          console.error('[dayGLANCE] MCP writes auto-disabled after repeated rate-limit violations.');
-          if (Notification.isSupported()) {
-            new Notification({
-              title: 'dayGLANCE MCP writes disabled',
-              body: 'An MCP client repeatedly exceeded the write rate limit. Writes stay off until dayGLANCE restarts.',
-            }).show();
-          }
-        },
-        now: Date.now,
-        timeZone: mcpTimeZone,
-      },
-    });
-  }
+  // Both local listeners are settings-gated (§6.2, Phase 5a): the Stream Deck
+  // toggle is ON for upgraded installs via the migration above, and the MCP
+  // listener binds only when a read tier was enabled through the consent flow
+  // — startMcpListener() no-ops otherwise, so off means no port bound at all.
+  // The DAYGLANCE_MCP_DEV/TOKEN/PORT/CALENDAR/WRITES env vars are gone; the
+  // config file is the sole source.
+  registerLocalIntegrationsHandlers();
+  if (integrationsConfig.streamDeck.enabled) startStreamDeckListener();
+  startMcpListener();
   registerSubscriptionHandlers(win);
   registerCalendarHandlers();
   registerStorefrontHandlers();

--- a/electron/mcpServer.ts
+++ b/electron/mcpServer.ts
@@ -29,8 +29,13 @@ import { registerWriteTools, type WriteToolDeps } from './mcpWriteTools.js';
 export const MCP_ENDPOINT_PATH = '/mcp';
 
 export interface McpServerOptions {
-  /** The pre-shared bearer token. Empty is refused — the listener fails closed. */
-  token: string;
+  /**
+   * The pre-shared bearer token, as a value or a getter. A getter is read on
+   * EVERY request, which is what makes settings-driven rotation (§6.2)
+   * invalidate the old token on the very next request without a restart.
+   * Empty is refused at start — the listener fails closed.
+   */
+  token: string | (() => string);
   /** Raw user/env port override; resolution and validation are mcpPort.ts's job. */
   portOverride?: unknown;
   /**
@@ -60,7 +65,8 @@ export function startMcpServer(opts: McpServerOptions): http.Server | null {
   const log = opts.log ?? ((m: string) => console.log(m));
   const logError = opts.logError ?? ((m: string) => console.error(m));
 
-  if (!opts.token) {
+  const getToken = typeof opts.token === 'function' ? opts.token : () => opts.token as string;
+  if (!getToken()) {
     logError('[dayGLANCE] MCP server not started: no bearer token configured (refusing to listen unauthenticated).');
     return null;
   }
@@ -124,7 +130,7 @@ export function startMcpServer(opts: McpServerOptions): http.Server | null {
     if (!validateHost(req, res)) return;
     if (!validateOrigin(req, res)) return;
 
-    const auth = checkBearerToken(req.headers['authorization'], opts.token);
+    const auth = checkBearerToken(req.headers['authorization'], getToken());
     if (!auth.ok) {
       // One identical 401 for every rejection reason — see unauthorizedResponse().
       const rejection = unauthorizedResponse();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -81,6 +81,23 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   mcpRespond: (response: unknown) => ipcRenderer.send('mcp:response', response),
 
+  // Local integrations settings (Stream Deck + MCP, spec §6.2/§6.3). The
+  // renderer never mutates the config directly: it sends typed transition
+  // actions and the main process's consent-state machine accepts or refuses
+  // them (electron/localIntegrations.ts).
+  localIntegrations: {
+    get: (): Promise<unknown> => ipcRenderer.invoke('local-integrations:get'),
+    transition: (action: unknown): Promise<unknown> =>
+      ipcRenderer.invoke('local-integrations:transition', action),
+    // Main pushes a fresh snapshot when listener state changes underneath the
+    // UI (e.g. a port collision discovered after the toggle returned).
+    onStatus: (callback: (snapshot: unknown) => void) => {
+      const handler = (_: Electron.IpcRendererEvent, snapshot: unknown) => callback(snapshot);
+      ipcRenderer.on('local-integrations:status', handler);
+      return () => ipcRenderer.removeListener('local-integrations:status', handler);
+    },
+  },
+
   // Show or clear the reminder dot (●) next to the tray icon.
   setTrayIndicator: (on: boolean) => ipcRenderer.send('tray:set-indicator', on),
 

--- a/electron/ws-server.ts
+++ b/electron/ws-server.ts
@@ -4,7 +4,7 @@ import { randomBytes } from 'node:crypto';
 import { MSG_DAY_TOKEN, MSG_DAY_AUTH, PROTOCOL_VERSION } from './protocol.js';
 import type { OutboundMessage } from './protocol.js';
 
-const WS_PORT = 7892;
+export const WS_PORT = 7892;
 
 // A browser client (property inspector) that fails to present a valid token this
 // quickly is dropped — closes the "connect and sit idle to hold a slot" vector.
@@ -99,7 +99,7 @@ export function createWsServer(getMainWindow: () => BrowserWindow | null): WebSo
   });
 
   // Broadcast state updates from the renderer to all connected clients
-  ipcMain.on('ws:push-state', (_event, state: OutboundMessage) => {
+  const onPushState = (_event: unknown, state: OutboundMessage): void => {
     const payload = JSON.stringify(state);
     lastState = payload;
     for (const client of clients) {
@@ -107,6 +107,14 @@ export function createWsServer(getMainWindow: () => BrowserWindow | null): WebSo
         client.send(payload);
       }
     }
+  };
+  ipcMain.on('ws:push-state', onPushState);
+
+  // The settings toggle (Phase 5a) can stop and later restart this listener.
+  // Detach the IPC handler when the server closes, or every start would stack
+  // another 'ws:push-state' listener onto ipcMain.
+  wss.on('close', () => {
+    ipcMain.removeListener('ws:push-state', onPushState);
   });
 
   return wss;

--- a/src/components/LocalIntegrationsSettings.jsx
+++ b/src/components/LocalIntegrationsSettings.jsx
@@ -1,0 +1,383 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { AlertTriangle, Check, ChevronDown, Copy, Plug, RefreshCw } from 'lucide-react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+
+// Local integrations settings (docs/mcp-server-spec.md §6.2/§6.3/§6.4):
+// the Stream Deck listener toggle and the MCP server's consent-tiered
+// controls, shared between SettingsModal (desktop) and MobileSettingsPanel
+// (narrow windows). Renders nothing outside Electron.
+//
+// The renderer holds NO authority here: every change is a typed transition
+// action sent to the main process, whose consent-state machine
+// (electron/localIntegrations.ts) accepts or refuses it. In particular the
+// consentConfirmed flags are only ever set by the Accept button of the
+// matching dialog below — there is no code path that enables MCP without one.
+
+// ── §6.4 consent copy ────────────────────────────────────────────────────────
+// Required content (base): other apps on this computer can read the data;
+// those apps typically send it to an AI provider over the internet; dayGLANCE
+// cannot see or control what they do; this falls outside dayGLANCE's
+// encryption / no-server-access guarantees.
+export const MCP_BASE_CONSENT = {
+  title: 'Allow other apps to read your dayGLANCE data?',
+  paragraphs: [
+    'This lets other applications running on this computer — typically an AI assistant such as Claude Desktop — read your dayGLANCE data: your schedule, tasks, goals, and projects.',
+    'AI assistants usually send what they read to their AI provider over the internet as part of your conversations. Once another app has read your data, dayGLANCE cannot see or control what it does with it.',
+    'This is outside dayGLANCE’s encryption and no-server-access guarantees: dayGLANCE itself still never uploads your data anywhere, but an app you connect might.',
+    'Only apps on this computer that present your access token (shown in settings after enabling) can connect.',
+  ],
+  accept: 'I understand — enable read access',
+};
+
+// Required content (device calendar tier): must additionally NAME what it
+// exposes — event titles, attendees; other people's information the user did
+// not create and those people did not consent to share.
+export const MCP_CALENDAR_CONSENT = {
+  title: 'Also share device calendar events?',
+  paragraphs: [
+    'This adds events from your device’s calendar accounts (work, school, shared family calendars) to what connected apps can read — not just data you created in dayGLANCE.',
+    'Calendar events often contain other people’s information: event titles, attendee names and emails, and details of meetings other people invited you to. You did not create that information, and those people have not agreed to share it with an AI assistant or any other app.',
+    'Connected apps can read these events exactly like your dayGLANCE data, and typically send them to an AI provider over the internet.',
+    'Leave this off to share only the data you created in dayGLANCE yourself.',
+  ],
+  accept: 'I understand — include calendar events',
+};
+
+export const MCP_WRITES_CONSENT = {
+  title: 'Allow connected apps to change your schedule?',
+  paragraphs: [
+    'Connected apps will be able to add, complete, move, and edit tasks — the same changes you can make yourself — without asking you before each one.',
+    'Changes are rate-limited and can never touch device calendar events, but a misbehaving app could still rearrange or complete tasks you did not intend. You can turn this off at any time.',
+  ],
+  accept: 'I understand — allow changes',
+};
+
+const READ_TIER_OPTIONS = [
+  {
+    tier: 'off',
+    label: 'Off',
+    description: 'No MCP server runs and no port is opened.',
+  },
+  {
+    tier: 'dayglance',
+    label: 'dayGLANCE data only',
+    description: 'Schedule, tasks, goals, and projects you created in dayGLANCE. Device calendar events are excluded.',
+  },
+  {
+    tier: 'dayglance_calendar',
+    label: 'Include device calendar events',
+    description: 'Everything above, plus events from your device calendar accounts (marked read-only).',
+  },
+];
+
+const LocalIntegrationsSettings = () => {
+  const {
+    collapsedSettings, toggleSettingsSection,
+    darkMode, borderClass, textPrimary, textSecondary,
+  } = useDayPlannerCtx();
+
+  const api = typeof window !== 'undefined' ? window.electronAPI?.localIntegrations : undefined;
+  const [snapshot, setSnapshot] = useState(null);
+  // { copy, onAccept } — one dialog at a time; the calendar-from-off flow
+  // chains base → calendar so each notice is accepted on its own.
+  const [consent, setConsent] = useState(null);
+  const [actionError, setActionError] = useState(null);
+  const [portDraft, setPortDraft] = useState(null); // null = not editing
+  const [copied, setCopied] = useState(false);
+  const [rotated, setRotated] = useState(false);
+  const copiedTimer = useRef(null);
+
+  useEffect(() => {
+    if (!api) return undefined;
+    let mounted = true;
+    api.get().then((s) => { if (mounted) setSnapshot(s); });
+    const unsubscribe = api.onStatus((s) => setSnapshot(s));
+    return () => {
+      mounted = false;
+      unsubscribe?.();
+      if (copiedTimer.current) clearTimeout(copiedTimer.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!api || !snapshot) return null;
+
+  const { config, status, ports } = snapshot;
+  const readTier = config.mcp.readTier;
+  const mcpOn = readTier !== 'off';
+
+  const transition = async (action) => {
+    setActionError(null);
+    const result = await api.transition(action);
+    if (result?.ok) {
+      setSnapshot(result.snapshot);
+      return true;
+    }
+    setActionError(result?.error || 'The change was refused.');
+    return false;
+  };
+
+  const requestReadTier = (tier) => {
+    setActionError(null);
+    if (tier === readTier) return;
+    // Downgrades (calendar → dayglance, anything → off) need no consent.
+    if (tier === 'off' || (tier === 'dayglance' && readTier === 'dayglance_calendar')) {
+      transition({ type: 'set-mcp-read-tier', tier });
+      return;
+    }
+    if (readTier === 'off') {
+      // Enabling from off always passes the base notice; the calendar tier
+      // then additionally passes its own notice, one dialog after the other.
+      setConsent({
+        copy: MCP_BASE_CONSENT,
+        onAccept: () => {
+          if (tier === 'dayglance') {
+            setConsent(null);
+            transition({ type: 'set-mcp-read-tier', tier, consentConfirmed: true });
+          } else {
+            setConsent({
+              copy: MCP_CALENDAR_CONSENT,
+              onAccept: () => {
+                setConsent(null);
+                transition({
+                  type: 'set-mcp-read-tier', tier,
+                  consentConfirmed: true, calendarConsentConfirmed: true,
+                });
+              },
+            });
+          }
+        },
+      });
+      return;
+    }
+    // Upgrade dayglance → dayglance_calendar: the calendar notice alone.
+    setConsent({
+      copy: MCP_CALENDAR_CONSENT,
+      onAccept: () => {
+        setConsent(null);
+        transition({ type: 'set-mcp-read-tier', tier, calendarConsentConfirmed: true });
+      },
+    });
+  };
+
+  const requestWrites = (enabled) => {
+    setActionError(null);
+    if (!enabled) {
+      transition({ type: 'set-mcp-writes', enabled: false });
+      return;
+    }
+    setConsent({
+      copy: MCP_WRITES_CONSENT,
+      onAccept: () => {
+        setConsent(null);
+        transition({ type: 'set-mcp-writes', enabled: true, writesConsentConfirmed: true });
+      },
+    });
+  };
+
+  const copyToken = async () => {
+    try {
+      await navigator.clipboard.writeText(config.mcp.token || '');
+      setCopied(true);
+      if (copiedTimer.current) clearTimeout(copiedTimer.current);
+      copiedTimer.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard denied — the token stays selectable in the input
+    }
+  };
+
+  const rotateToken = async () => {
+    setRotated(false);
+    if (await transition({ type: 'rotate-token' })) setRotated(true);
+  };
+
+  const applyPort = async () => {
+    const raw = (portDraft ?? '').trim();
+    const okApplied = await transition({
+      type: 'set-mcp-port',
+      portOverride: raw === '' ? null : raw,
+    });
+    if (okApplied) setPortDraft(null);
+  };
+
+  const inputClass = `px-3 py-2 border ${borderClass} rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} text-sm`;
+  const smallBtn = `px-3 py-2 ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} rounded-lg text-sm transition-colors flex items-center gap-1.5`;
+
+  const toggle = (checked, onChange, label, sub) => (
+    <label className="flex items-center gap-3 cursor-pointer">
+      <div className="relative flex-shrink-0">
+        <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} className="sr-only" />
+        <div className={`w-10 h-6 rounded-full transition-colors ${checked ? 'bg-blue-600' : darkMode ? 'bg-gray-600' : 'bg-stone-300'}`}>
+          <div className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${checked ? 'translate-x-5' : 'translate-x-1'}`} />
+        </div>
+      </div>
+      <span className={`text-sm ${textPrimary}`}>
+        {label}
+        {sub && <span className={`block text-xs ${textSecondary}`}>{sub}</span>}
+      </span>
+    </label>
+  );
+
+  const listenerError = (message) => (
+    <div className={`p-3 rounded-lg border flex items-start gap-2 ${darkMode ? 'bg-red-900/20 border-red-800' : 'bg-red-50 border-red-200'}`}>
+      <AlertTriangle size={14} className={`flex-shrink-0 mt-0.5 ${darkMode ? 'text-red-400' : 'text-red-600'}`} />
+      <p className={`text-xs ${darkMode ? 'text-red-300' : 'text-red-700'}`}>{message}</p>
+    </div>
+  );
+
+  const anyEnabled = config.streamDeck.enabled || mcpOn;
+
+  return (
+    <>
+      <hr className={borderClass} />
+      <div className="space-y-3">
+        <button onClick={() => toggleSettingsSection('localIntegrations')} className={`font-medium ${textPrimary} flex items-center gap-2 w-full text-left`}>
+          <Plug size={16} className={textSecondary} />
+          Local Integrations
+          {anyEnabled && <span className="mr-1 w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />}
+          <ChevronDown size={16} className={`ml-auto flex-shrink-0 ${textSecondary} transition-transform ${collapsedSettings.localIntegrations ? '' : 'rotate-180'}`} />
+        </button>
+        {!collapsedSettings.localIntegrations && (<>
+          <p className={`${textSecondary} text-xs`}>
+            Connections for other apps running on this computer. Both listen on 127.0.0.1 only and are never reachable from the network.
+          </p>
+
+          {/* Stream Deck (port 7892) — independent of the MCP server (§6.2) */}
+          <div className="space-y-2">
+            {toggle(
+              config.streamDeck.enabled,
+              (enabled) => transition({ type: 'set-stream-deck', enabled }),
+              'Stream Deck support',
+              `Lets the dayGLANCE Stream Deck plugin show and control your day (port ${ports.streamDeck}).`,
+            )}
+            {config.streamDeck.enabled && status.streamDeck.error && listenerError(status.streamDeck.error)}
+          </div>
+
+          {/* MCP server (port 7893 by default) */}
+          <div className="space-y-2 pt-1">
+            <h4 className={`text-sm font-medium ${textPrimary}`}>MCP server (AI assistants)</h4>
+            <p className={`text-xs ${textSecondary}`}>
+              Lets AI assistants on this computer read your schedule over the Model Context Protocol. What they can see is up to you:
+            </p>
+            <div className="space-y-1.5" role="radiogroup" aria-label="MCP read access">
+              {READ_TIER_OPTIONS.map(({ tier, label, description }) => (
+                <label key={tier} className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="mcp-read-tier"
+                    checked={readTier === tier}
+                    onChange={() => requestReadTier(tier)}
+                    className="mt-0.5"
+                  />
+                  <span className={`text-sm ${textPrimary}`}>
+                    {label}
+                    <span className={`block text-xs ${textSecondary}`}>{description}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+
+            {mcpOn && (<>
+              {toggle(
+                config.mcp.writesEnabled,
+                requestWrites,
+                'Allow schedule changes',
+                'Separate opt-in: connected apps may add, complete, move, and edit tasks.',
+              )}
+
+              {/* Token — displayed for manual copy into the MCP client's config. */}
+              <div>
+                <label className={`block text-sm ${textSecondary} mb-1`}>Access token</label>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    readOnly
+                    value={config.mcp.token || ''}
+                    onFocus={(e) => e.target.select()}
+                    className={`${inputClass} flex-1 min-w-0 font-mono text-xs`}
+                  />
+                  <button onClick={copyToken} className={smallBtn} title="Copy token">
+                    {copied ? <Check size={14} className="text-green-500" /> : <Copy size={14} />}
+                  </button>
+                  <button onClick={rotateToken} className={smallBtn} title="Generate a new token. The old one stops working immediately.">
+                    <RefreshCw size={14} />
+                    Rotate
+                  </button>
+                </div>
+                <p className={`text-xs ${textSecondary} mt-1`}>
+                  {rotated
+                    ? 'New token generated — the old one no longer works. Update your MCP clients.'
+                    : 'Paste this into your MCP client as the Bearer token. Rotating it cuts off every client using the old one.'}
+                </p>
+              </div>
+
+              {/* Port override — §3.4: one fixed port, collisions surface loudly, never scanned around. */}
+              <div>
+                <label className={`block text-sm ${textSecondary} mb-1`}>Port</label>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    placeholder={String(ports.mcpDefault)}
+                    value={portDraft ?? (config.mcp.portOverride ?? '')}
+                    onChange={(e) => setPortDraft(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter' && portDraft !== null) applyPort(); }}
+                    className={`${inputClass} w-28`}
+                  />
+                  {portDraft !== null && (
+                    <button onClick={applyPort} className={smallBtn}>Apply</button>
+                  )}
+                </div>
+                <p className={`text-xs ${textSecondary} mt-1`}>
+                  Endpoint: <code className={`px-1 py-0.5 rounded ${darkMode ? 'bg-gray-700' : 'bg-stone-200'}`}>http://127.0.0.1:{ports.mcpEffective ?? ports.mcpDefault}/mcp</code>
+                  {' '}— leave the port empty for the default. dayGLANCE never picks a different port by itself.
+                </p>
+              </div>
+
+              {status.mcp.running && (
+                <p className="text-xs text-green-500">MCP server running on 127.0.0.1:{ports.mcpEffective}.</p>
+              )}
+              {status.mcp.error && listenerError(status.mcp.error)}
+            </>)}
+          </div>
+
+          {actionError && listenerError(actionError)}
+        </>)}
+      </div>
+
+      {/* §6.4 consent dialog — the ONLY source of consentConfirmed flags. */}
+      {consent && (
+        <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/50 p-4" onClick={() => setConsent(null)}>
+          <div
+            className={`w-full max-w-md rounded-xl border ${borderClass} ${darkMode ? 'bg-gray-800' : 'bg-white'} p-5 space-y-3 shadow-xl`}
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-label={consent.copy.title}
+          >
+            <h4 className={`font-semibold ${textPrimary}`}>{consent.copy.title}</h4>
+            {consent.copy.paragraphs.map((text, i) => (
+              <p key={i} className={`text-sm ${textSecondary}`}>{text}</p>
+            ))}
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                onClick={() => setConsent(null)}
+                className={`px-4 py-2 ${darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-stone-200 hover:bg-stone-300'} ${textPrimary} rounded-lg text-sm transition-colors`}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={consent.onAccept}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm"
+              >
+                {consent.copy.accept}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default LocalIntegrationsSettings;

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -25,6 +25,7 @@ import SmartSchedulePanel from './SmartSchedulePanel.jsx';
 import MobileRoutinesTab from './MobileRoutinesTab.jsx';
 import UserOwnerSwitcher from './UserOwnerSwitcher.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import LocalIntegrationsSettings from './LocalIntegrationsSettings.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { isVaultEnabled } from '../sync/vaultConfig.js';
 import { multiUserToggleLocked, multiUserUnavailableReason, canSyncUserRoster } from '../utils/multiUserGate.js';
@@ -3037,6 +3038,10 @@ const MobileSettingsPanel = () => {
       )}
     </div>
   )}
+
+  {/* Local Integrations (Stream Deck + MCP) — only renders when a narrow
+      Electron window shows the mobile layout; nothing on true mobile. */}
+  <LocalIntegrationsSettings />
 </div>
   );
 };

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -5,6 +5,7 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
+import LocalIntegrationsSettings from './LocalIntegrationsSettings.jsx';
 import ICloudDiagnostics from './ICloudDiagnostics.jsx';
 import ICloudSyncToggle from './ICloudSyncToggle.jsx';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
@@ -1804,6 +1805,10 @@ const SettingsModal = () => {
 
                       </>)}
                     </div>
+
+                    {/* Local Integrations (Stream Deck + MCP) — Electron only,
+                        renders nothing on web/mobile builds. */}
+                    <LocalIntegrationsSettings />
 
                     <hr className={borderClass} />
 


### PR DESCRIPTION
Implements Phase 5a of `docs/mcp-server-spec.md` (§6.2, §6.3, §6.4): the settings surface, consent tiers, and the blocking Stream Deck migration.

## The blocking item first (§6.2)

The Stream Deck listener has shipped unconditionally enabled since it existed, so an off-by-default toggle would silently kill every existing user's buttons on auto-update. The migration runs at startup **before any listener binds**:

- **Existing installs** (evidence: `window-state.json`, `window-theme.json`, or the `.origin-migrated-file-to-app-v1` storage flag) → Stream Deck **ON**, provenance recorded as `migratedFromUnconditional`.
- **Fresh installs** → everything off.
- **One-time flag:** the config file (`userData/local-integrations.json`) itself is the flag. Once it exists it is the sole authority — a user's deliberate "off" survives every later update; even an unreadable config fails toward off and never re-migrates.
- **Ordering is load-bearing:** `migrateFileToAppStorage()` stamps its done-flag even on fresh installs, so the evidence is read before it runs — otherwise every fresh install would look like an upgrade.

## What changed

- **`electron/localIntegrations.ts`** (new, pure, tested): migration decision, tolerant config load, §6.3 tier gates, the consent-state machine (every enabling transition demands a fresh confirmation in the action — stored consent stamps never substitute for the dialog), and the listener-reconciliation diff. 28 unit tests; **19/19 mutants killed** by the sed-style mutation harness.
- **`electron/main.ts`**: config load/save, startup migration, settings-gated listener lifecycle, `local-integrations:get`/`transition` IPC, loud §3.4 bind-failure surfacing into settings. The `DAYGLANCE_MCP_DEV/TOKEN/PORT/CALENDAR/WRITES` env vars are **gone** — the Phase 2/3 consent closures now read the config. Tool code (`mcpReadTools.ts`/`mcpWriteTools.ts`) is untouched, as those closures were designed for.
- **`electron/mcpServer.ts`**: bearer token accepted as a getter read on every request, so rotation invalidates the old token on the very next request with no restart. (Listener plumbing, not tool code.)
- **`electron/ws-server.ts`**: detaches its `ws:push-state` IPC handler on close so settings-driven stop/start cannot stack listeners; exports `WS_PORT`.
- **`src/components/LocalIntegrationsSettings.jsx`** (new, shared by `SettingsModal` and `MobileSettingsPanel`, renders nothing outside Electron): two **independent** toggles (§6.2), the three-tier read selector + separate writes opt-in (§6.3), §6.4 consent dialogs, token display/copy/rotate, port override. The renderer holds no authority — it sends typed actions; the main-process state machine accepts or refuses.

## Consent model (§6.3)

Reads have three tiers: **Off** (no port bound at all) → **dayGLANCE data only** (`_native` excluded) → **Include device calendar events** (separate opt-in with its own §6.4 copy naming attendees/other-people's-data). Writes are a further opt-in on top of any read tier and drop automatically when reads turn off. Writes can never leak through an unbound config (fail-closed on missing token).

## Live verification (xvfb + CDP + real MCP HTTP client, all on this branch's build)

1. **Upgrade path simulated live**: userData with `window-state.json` and no config → launch → config created with Stream Deck ON, port 7892 listening, a simulated no-Origin plugin client received `day:token` + `day:state` with zero user action. MCP stayed unbound.
2. **Off stays off**: Stream Deck disabled via the real transition (7892 closed live), then relaunched with the prior-install evidence still on disk → stayed off; no re-migration.
3. **Fresh install**: empty userData → config all-off, neither 7892 nor 7893 bound with the app fully running.
4. **No consent bypass**: enabling without/with-false `consentConfirmed` refused (also calendar tier with only base consent); UI radio does not flip while the dialog is up; Cancel leaves the tier off; only Accept enables.
5. **Tier gating over real HTTP**: `dayglance_get_day` 200 with the minted token; `dayglance_create_task` → typed `read_only_mode` error while writes off, real task created after the writes consent.
6. **Rotation**: old token 401 on the immediately following request, new token 200, server never restarted.
7. **Port collision**: squatter on 7900 + port override → settings status shows the exact "will not scan" message; neighbors stayed closed; old port released.
8. **Mutation-verified**: 19/19 mutants killed across migration, normalization, gates, transitions, and effects.

Full suite: 1488 tests / 100 files passing; electron + preload `tsc` clean; renderer + electron vite builds clean; eslint clean.

## Not in this PR (Phase 5b, per spec)

No tray indicator, no write journal. `useElectronBridge.js` untouched. The §6.4 consent copy is in `LocalIntegrationsSettings.jsx` as exported constants — flagged for wording review before ship.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_