### PR TITLE
MCP Phase 5b: tray indicator, kill switch, write journal, bulk undo

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -30,6 +30,15 @@ import {
 } from './localIntegrations.js';
 import { createRendererBridge, type RendererBridge } from './mcpRendererBridge.js';
 import type { WriteToolDeps } from './mcpWriteTools.js';
+import {
+  appendEntry as appendJournalEntry,
+  journalSnapshot as buildJournalSnapshot,
+  buildUndoPlan,
+  mcpIndicator,
+  composeTrayTitle,
+  type JournalEntry,
+  type JournalRecord,
+} from './mcpJournal.js';
 import { createWriteGate } from './mcpWriteGate.js';
 import { createIdempotencyStore } from './mcpIdempotency.js';
 import { trayReloadDebounceMs } from './trayReloadPolicy.js';
@@ -94,7 +103,13 @@ let registeredMainWindowHotkey: string | null = null;
 let trayIndicatorOn = false;
 let trayFocusTitle = '';
 function refreshTrayTitle() {
-  tray?.setTitle(trayFocusTitle || (trayIndicatorOn ? '●' : ''));
+  // §6.5: the MCP glyph is appended, never displaced — a bound listener stays
+  // visible in the menu bar through focus countdowns and reminder dots alike.
+  tray?.setTitle(composeTrayTitle({
+    focusTitle: trayFocusTitle,
+    reminderOn: trayIndicatorOn,
+    mcpGlyph: mcpIndicator(mcpGates(integrationsConfig)).glyph,
+  }));
 }
 
 // Safe accessor — returns null if the window has been destroyed so callers
@@ -395,13 +410,24 @@ function createTray(): void {
     pushCurrentTaskToTray();
   });
 
-  // Right-click: native Open / Quit menu
+  // Right-click: native Open / Quit menu. When the MCP listener is bound, the
+  // menu also names the current tier and offers the §6.5 kill switch — this
+  // path is pure main-process (runIntegrationsTransition), so it works with
+  // NO window at all: no main window, no popup, no relay to drop.
   tray.on('right-click', () => {
-    tray?.popUpContextMenu(Menu.buildFromTemplate([
+    const gates = mcpGates(integrationsConfig);
+    const template: Electron.MenuItemConstructorOptions[] = [
       { label: 'Open dayGLANCE', click: () => { live(mainWindow)?.show(); live(mainWindow)?.focus(); } },
-      { type: 'separator' },
-      { label: 'Quit', click: () => app.quit() },
-    ]));
+    ];
+    if (gates.bound) {
+      template.push(
+        { type: 'separator' },
+        { label: mcpIndicator(gates).label, enabled: false },
+        { label: 'Turn off MCP server', click: () => killMcpServer() },
+      );
+    }
+    template.push({ type: 'separator' }, { label: 'Quit', click: () => app.quit() });
+    tray?.popUpContextMenu(Menu.buildFromTemplate(template));
   });
 }
 
@@ -896,8 +922,51 @@ function loadOrMigrateIntegrationsConfig(): void {
   );
 }
 
+// ── §4.3 write journal — session-scoped BY DESIGN ────────────────────────────
+// Module scope in the main process (never on the McpServer instance, §3.7,
+// never on disk): it covers the runaway-agent case, so dying with the process
+// is correct. All decisions live in mcpJournal.ts, pure and tested.
+let mcpJournalEntries: JournalEntry[] = [];
+
+function recordMcpJournal(record: JournalRecord): void {
+  mcpJournalEntries = appendJournalEntry(mcpJournalEntries, record, new Date().toISOString());
+  pushMcpJournal();
+}
+
+function pushMcpJournal(): void {
+  const snapshot = buildJournalSnapshot(mcpJournalEntries);
+  for (const win of [live(mainWindow), live(trayWindow)]) {
+    win?.webContents.send('mcp-journal:changed', snapshot);
+  }
+}
+
+function registerMcpJournalHandlers(): void {
+  ipcMain.handle('mcp-journal:get', () => buildJournalSnapshot(mcpJournalEntries));
+  // Bulk undo (§4.3): reverse every session MCP write, applied by the main
+  // window's renderer through taskMutations.js applyUndoOps — the same store
+  // layer as any write, so sync, GLANCEintents, and tray:data-changed all
+  // engage. The journal clears only on a confirmed application.
+  ipcMain.handle('mcp-journal:undo-all', async () => {
+    if (mcpJournalEntries.length === 0) return { ok: false, error: 'No MCP changes to undo.' };
+    if (!mcpBridge) return { ok: false, error: 'The dayGLANCE window is not available.' };
+    const plan = buildUndoPlan(mcpJournalEntries);
+    const r = await mcpBridge.request('undo_mcp_writes', { ops: plan.ops }, 10_000);
+    if (!r.ok) return { ok: false, error: r.error.message };
+    mcpJournalEntries = [];
+    pushMcpJournal();
+    const data = r.data as { undone?: number; skipped?: number };
+    return { ok: true, undone: data?.undone ?? plan.count, skipped: data?.skipped ?? 0 };
+  });
+}
+
 function pushIntegrationsStatus(): void {
-  live(mainWindow)?.webContents.send('local-integrations:status', integrationsSnapshot());
+  const snapshot = integrationsSnapshot();
+  // The tray gets the same push (§6.5): its listener-state display is LIVE
+  // over IPC, deliberately outside the popup's stale data-snapshot cycle.
+  for (const win of [live(mainWindow), live(trayWindow)]) {
+    win?.webContents.send('local-integrations:status', snapshot);
+  }
+  refreshTrayTitle();
 }
 
 function startStreamDeckListener(): void {
@@ -972,6 +1041,8 @@ function startMcpListener(): void {
       // §6.3 writes opt-in, settings-backed (replaced DAYGLANCE_MCP_WRITES).
       includeWrites: () => mcpGates(integrationsConfig).includeWrites,
       noteMcpWrite: () => { lastMcpWriteAt = Date.now(); },
+      // §4.3 write journal (Phase 5b): session-scoped record + tray surface.
+      journal: recordMcpJournal,
       // §4.3: repeated rate-limit violations auto-disable writes with a
       // notification. Fires exactly once, on the disable edge.
       onWritesDisabled: () => {
@@ -1032,23 +1103,39 @@ function integrationsSnapshot() {
   };
 }
 
+// The one transition entry point, shared by the settings/tray IPC handler and
+// the tray icon's native context menu (the §6.5 kill switch path that needs
+// no window at all). Config-owning, so it never routes through a renderer.
+function runIntegrationsTransition(action: TransitionAction): { ok: true } | { ok: false; error: string } {
+  const result = applyIntegrationsTransition(integrationsConfig, action, {
+    nowIso: () => new Date().toISOString(),
+    generateToken: generateMcpToken,
+    resolvePort: resolveMcpPort,
+  });
+  if (!result.ok) return { ok: false, error: result.error };
+  const effects = listenerEffects(integrationsConfig, result.config);
+  integrationsConfig = result.config;
+  saveIntegrationsConfig();
+  if (effects.streamDeck === 'start') startStreamDeckListener();
+  else if (effects.streamDeck === 'stop') stopStreamDeckListener();
+  if (effects.mcp === 'start') startMcpListener();
+  else if (effects.mcp === 'stop') stopMcpListener();
+  else if (effects.mcp === 'restart') stopMcpListener(() => startMcpListener());
+  pushIntegrationsStatus();
+  return { ok: true };
+}
+
+/** The §6.5 kill switch: MCP off (port unbinds; writes drop with the tier). */
+function killMcpServer(): void {
+  const r = runIntegrationsTransition({ type: 'set-mcp-read-tier', tier: 'off' });
+  if (!r.ok) console.error('[dayGLANCE] MCP kill switch failed:', r.error);
+}
+
 function registerLocalIntegrationsHandlers(): void {
   ipcMain.handle('local-integrations:get', () => integrationsSnapshot());
   ipcMain.handle('local-integrations:transition', (_event, action: unknown) => {
-    const result = applyIntegrationsTransition(integrationsConfig, action as TransitionAction, {
-      nowIso: () => new Date().toISOString(),
-      generateToken: generateMcpToken,
-      resolvePort: resolveMcpPort,
-    });
-    if (!result.ok) return { ok: false, error: result.error };
-    const effects = listenerEffects(integrationsConfig, result.config);
-    integrationsConfig = result.config;
-    saveIntegrationsConfig();
-    if (effects.streamDeck === 'start') startStreamDeckListener();
-    else if (effects.streamDeck === 'stop') stopStreamDeckListener();
-    if (effects.mcp === 'start') startMcpListener();
-    else if (effects.mcp === 'stop') stopMcpListener();
-    else if (effects.mcp === 'restart') stopMcpListener(() => startMcpListener());
+    const result = runIntegrationsTransition(action as TransitionAction);
+    if (!result.ok) return result;
     return { ok: true, snapshot: integrationsSnapshot() };
   });
 }
@@ -1150,6 +1237,7 @@ app.whenReady().then(async () => {
   // The DAYGLANCE_MCP_DEV/TOKEN/PORT/CALENDAR/WRITES env vars are gone; the
   // config file is the sole source.
   registerLocalIntegrationsHandlers();
+  registerMcpJournalHandlers();
   if (integrationsConfig.streamDeck.enabled) startStreamDeckListener();
   startMcpListener();
   registerSubscriptionHandlers(win);

--- a/electron/mcpJournal.test.ts
+++ b/electron/mcpJournal.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  appendEntry,
+  journalSnapshot,
+  buildUndoPlan,
+  mcpIndicator,
+  composeTrayTitle,
+  type JournalEntry,
+  type UndoOp,
+} from './mcpJournal.js';
+
+// §4.3 write journal + §6.5 indicator. Load-bearing: the undo plan reverses
+// chronological order (compound histories must unwind), the snapshot never
+// leaks before-state copies to the display surface, and the MCP glyph is
+// distinct from and never displaced by the base tray states.
+
+const op = (taskId: string): UndoOp => ({ kind: 'remove_created', taskId });
+
+const entry = (over: Partial<JournalEntry> = {}): JournalEntry => ({
+  seq: 1, at: '2026-08-12T10:00:00.000Z', tool: 'dayglance_create_task',
+  summary: 'Created "x"', op: op('t1'), ...over,
+});
+
+describe('appendEntry', () => {
+  it('appends immutably with monotonically increasing seq', () => {
+    const first = appendEntry([], { tool: 'dayglance_create_task', summary: 'Created "a"', op: op('a') }, '2026-08-12T10:00:00.000Z');
+    const second = appendEntry(first, { tool: 'dayglance_move_block', summary: 'Moved "a"', op: op('a'), idempotencyKey: 'k1' }, '2026-08-12T10:01:00.000Z');
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(2);
+    expect(second[0].seq).toBe(1);
+    expect(second[1]).toMatchObject({ seq: 2, at: '2026-08-12T10:01:00.000Z', idempotencyKey: 'k1' });
+    expect(second[1].tool).toBe('dayglance_move_block');
+  });
+
+  it('records tool, time, and what changed (exit criterion 3 fields)', () => {
+    const [e] = appendEntry([], { tool: 'dayglance_resize_block', summary: 'Resized "Standup" to 30 min', op: op('r') }, '2026-08-12T11:00:00.000Z');
+    expect(e.tool).toBe('dayglance_resize_block');
+    expect(e.at).toBe('2026-08-12T11:00:00.000Z');
+    expect(e.summary).toContain('Resized');
+  });
+});
+
+describe('journalSnapshot', () => {
+  const entries = Array.from({ length: 60 }, (_, i) => entry({ seq: i + 1, summary: `write ${i + 1}` }));
+
+  it('newest first, display-trimmed, but total stays the full session count', () => {
+    const snap = journalSnapshot(entries);
+    expect(snap.total).toBe(60);
+    expect(snap.entries).toHaveLength(50);
+    expect(snap.entries[0].summary).toBe('write 60');
+    expect(snap.entries[49].summary).toBe('write 11');
+  });
+
+  it('never exposes the undo op (before-state user data) to the display surface', () => {
+    const snap = journalSnapshot([entry()]);
+    expect(snap.entries[0]).not.toHaveProperty('op');
+  });
+});
+
+describe('buildUndoPlan', () => {
+  it('reverses chronological order so compound histories unwind', () => {
+    const entries = [
+      entry({ seq: 1, op: { kind: 'remove_created', taskId: 'a' } }),
+      entry({ seq: 2, op: { kind: 'restore_unscheduled', taskId: 'a', beforeTask: { id: 'a' } } }),
+      entry({ seq: 3, op: { kind: 'restore_block_fields', blockId: 'a', before: { date: '2026-08-12' } } }),
+    ];
+    const plan = buildUndoPlan(entries);
+    expect(plan.count).toBe(3);
+    expect(plan.ops.map((o) => o.kind)).toEqual(['restore_block_fields', 'restore_unscheduled', 'remove_created']);
+  });
+
+  it('empty journal → empty plan', () => {
+    expect(buildUndoPlan([])).toEqual({ count: 0, ops: [] });
+  });
+});
+
+describe('mcpIndicator — §6.5 tier mapping', () => {
+  it('unbound → no glyph', () => {
+    expect(mcpIndicator({ bound: false, includeNative: false, includeWrites: false }))
+      .toEqual({ glyph: '', label: 'MCP server off' });
+  });
+
+  it('reads-only tiers → ⌁, with the tier named', () => {
+    expect(mcpIndicator({ bound: true, includeNative: false, includeWrites: false }))
+      .toEqual({ glyph: '⌁', label: 'MCP on — reads dayGLANCE data' });
+    expect(mcpIndicator({ bound: true, includeNative: true, includeWrites: false }))
+      .toEqual({ glyph: '⌁', label: 'MCP on — reads incl. device calendar' });
+  });
+
+  it('writes tier → distinct glyph ⚡ and "+ writes" in the label', () => {
+    const ind = mcpIndicator({ bound: true, includeNative: false, includeWrites: true });
+    expect(ind.glyph).toBe('⚡');
+    expect(ind.label).toBe('MCP on — reads dayGLANCE data + writes');
+    expect(mcpIndicator({ bound: true, includeNative: true, includeWrites: true }).label)
+      .toBe('MCP on — reads incl. device calendar + writes');
+  });
+
+  it('the glyphs are distinct from the reminder dot', () => {
+    for (const g of ['⌁', '⚡']) expect(g).not.toBe('●');
+  });
+});
+
+describe('composeTrayTitle', () => {
+  it('appends the MCP glyph to focus title and reminder dot instead of replacing them', () => {
+    expect(composeTrayTitle({ focusTitle: '12:34', reminderOn: false, mcpGlyph: '⌁' })).toBe('12:34 ⌁');
+    expect(composeTrayTitle({ focusTitle: '', reminderOn: true, mcpGlyph: '⚡' })).toBe('● ⚡');
+  });
+
+  it('glyph alone when there is no other state; base states unchanged when unbound', () => {
+    expect(composeTrayTitle({ focusTitle: '', reminderOn: false, mcpGlyph: '⌁' })).toBe('⌁');
+    expect(composeTrayTitle({ focusTitle: '', reminderOn: false, mcpGlyph: '' })).toBe('');
+    expect(composeTrayTitle({ focusTitle: '12:34', reminderOn: false, mcpGlyph: '' })).toBe('12:34');
+    expect(composeTrayTitle({ focusTitle: '', reminderOn: true, mcpGlyph: '' })).toBe('●');
+  });
+});

--- a/electron/mcpJournal.test.ts
+++ b/electron/mcpJournal.test.ts
@@ -82,17 +82,17 @@ describe('mcpIndicator — §6.5 tier mapping', () => {
 
   it('reads-only tiers → ⌁, with the tier named', () => {
     expect(mcpIndicator({ bound: true, includeNative: false, includeWrites: false }))
-      .toEqual({ glyph: '⌁', label: 'MCP on — reads dayGLANCE data' });
+      .toEqual({ glyph: '⌁', label: 'MCP on: reads dayGLANCE data' });
     expect(mcpIndicator({ bound: true, includeNative: true, includeWrites: false }))
-      .toEqual({ glyph: '⌁', label: 'MCP on — reads incl. device calendar' });
+      .toEqual({ glyph: '⌁', label: 'MCP on: reads incl. device calendar' });
   });
 
   it('writes tier → distinct glyph ⚡ and "+ writes" in the label', () => {
     const ind = mcpIndicator({ bound: true, includeNative: false, includeWrites: true });
     expect(ind.glyph).toBe('⚡');
-    expect(ind.label).toBe('MCP on — reads dayGLANCE data + writes');
+    expect(ind.label).toBe('MCP on: reads dayGLANCE data + writes');
     expect(mcpIndicator({ bound: true, includeNative: true, includeWrites: true }).label)
-      .toBe('MCP on — reads incl. device calendar + writes');
+      .toBe('MCP on: reads incl. device calendar + writes');
   });
 
   it('the glyphs are distinct from the reminder dot', () => {

--- a/electron/mcpJournal.ts
+++ b/electron/mcpJournal.ts
@@ -1,0 +1,119 @@
+// The §4.3 write journal and §6.5 tray indicator, extracted as pure functions
+// (startupQuit.ts style). The journal is SESSION-SCOPED BY DESIGN: it lives in
+// a module-scope array in main.ts (never on the McpServer instance, §3.7, and
+// never on disk) — it covers the runaway-agent case, not audit history, so a
+// restart wiping it is correct behavior, not a limitation.
+//
+// Undo works from per-entry before-state captured by the renderer at write
+// time, because the journal alone cannot reverse everything: scheduling a
+// task DESTROYS its inbox-only fields (applyScheduleTask strips priority and
+// deadline), and move/resize/completion overwrite values nothing else
+// remembers. Each entry therefore carries exactly the fields its reversal
+// needs — a full before-task for schedule, touched fields otherwise.
+
+/** Reversal instruction, applied by taskMutations.js applyUndoOps in the renderer. */
+export type UndoOp =
+  | { kind: 'remove_created'; taskId: string }
+  | { kind: 'restore_unscheduled'; taskId: string; beforeTask: Record<string, unknown> }
+  | { kind: 'restore_block_fields'; blockId: string; before: Record<string, unknown> }
+  | { kind: 'restore_completion'; taskId: string; before: { completed: boolean; completedAt?: string | null } }
+  | { kind: 'restore_recurring_completion'; templateId: string | number; dateStr: string; wasCompleted: boolean };
+
+export interface JournalEntry {
+  seq: number;
+  /** ISO timestamp of the write (main-process clock). */
+  at: string;
+  /** MCP tool that performed the write, e.g. 'dayglance_create_task'. */
+  tool: string;
+  /** Display-ready description of what changed, built by the renderer. */
+  summary: string;
+  /** The caller's idempotency key, when it sent one. */
+  idempotencyKey?: string;
+  op: UndoOp;
+}
+
+export interface JournalRecord {
+  tool: string;
+  summary: string;
+  idempotencyKey?: string;
+  op: UndoOp;
+}
+
+/**
+ * Append one write to the journal. Immutable (returns a new array) so the
+ * main-process store is a plain reassigned variable, and seq is monotonically
+ * increasing within the session regardless of any future trimming.
+ */
+export function appendEntry(entries: JournalEntry[], record: JournalRecord, nowIso: string): JournalEntry[] {
+  const seq = entries.length > 0 ? entries[entries.length - 1].seq + 1 : 1;
+  const entry: JournalEntry = {
+    seq,
+    at: nowIso,
+    tool: record.tool,
+    summary: record.summary,
+    ...(record.idempotencyKey !== undefined ? { idempotencyKey: record.idempotencyKey } : {}),
+    op: record.op,
+  };
+  return [...entries, entry];
+}
+
+/**
+ * The display snapshot pushed to the tray and main windows: newest first,
+ * bounded so a long agent session cannot flood the 320px popup — the TOTAL
+ * always reports the full session count, so "Undo all (N)" stays honest even
+ * when the list is trimmed for display.
+ */
+export function journalSnapshot(entries: JournalEntry[], displayLimit = 50): {
+  total: number;
+  entries: Array<Omit<JournalEntry, 'op'>>;
+} {
+  return {
+    total: entries.length,
+    entries: entries
+      .slice(-displayLimit)
+      .reverse()
+      // The op carries a full before-task for schedule entries; the display
+      // surface has no use for it and no business holding user data copies.
+      .map(({ op: _op, ...display }) => display),
+  };
+}
+
+/**
+ * Bulk-undo reconstruction: every session write reversed in REVERSE
+ * chronological order, so compound histories unwind correctly — e.g.
+ * create → schedule → move unwinds as restore-fields, restore-to-inbox,
+ * remove-created, each op finding the state its own write produced.
+ */
+export function buildUndoPlan(entries: JournalEntry[]): { count: number; ops: UndoOp[] } {
+  const ops = entries.slice().reverse().map((e) => e.op);
+  return { count: entries.length, ops };
+}
+
+/**
+ * §6.5 tier-to-indicator mapping. The glyph lands in the macOS menu bar next
+ * to the tray icon; the label names the current tier in the popup and the
+ * right-click menu. Requirements: visibly distinct from the base app state
+ * (the reminder dot is '●' and focus titles are countdown text, so both
+ * glyphs here are reserved for MCP), and writes distinguishable from reads.
+ */
+export function mcpIndicator(gates: { bound: boolean; includeNative: boolean; includeWrites: boolean }): {
+  glyph: string;
+  label: string;
+} {
+  if (!gates.bound) return { glyph: '', label: 'MCP server off' };
+  const reads = gates.includeNative ? 'reads incl. device calendar' : 'reads dayGLANCE data';
+  if (gates.includeWrites) return { glyph: '⚡', label: `MCP on — ${reads} + writes` };
+  return { glyph: '⌁', label: `MCP on — ${reads}` };
+}
+
+/**
+ * Menu-bar title composition. Focus countdowns keep priority (they are the
+ * highest-value glanceable state), the reminder dot keeps its slot, and the
+ * MCP glyph is APPENDED rather than replacing either — a bound listener must
+ * stay visible through every other tray state (§6.5: never invisible).
+ */
+export function composeTrayTitle(parts: { focusTitle: string; reminderOn: boolean; mcpGlyph: string }): string {
+  const base = parts.focusTitle || (parts.reminderOn ? '●' : '');
+  if (!parts.mcpGlyph) return base;
+  return base ? `${base} ${parts.mcpGlyph}` : parts.mcpGlyph;
+}

--- a/electron/mcpJournal.ts
+++ b/electron/mcpJournal.ts
@@ -102,8 +102,8 @@ export function mcpIndicator(gates: { bound: boolean; includeNative: boolean; in
 } {
   if (!gates.bound) return { glyph: '', label: 'MCP server off' };
   const reads = gates.includeNative ? 'reads incl. device calendar' : 'reads dayGLANCE data';
-  if (gates.includeWrites) return { glyph: '⚡', label: `MCP on — ${reads} + writes` };
-  return { glyph: '⌁', label: `MCP on — ${reads}` };
+  if (gates.includeWrites) return { glyph: '⚡', label: `MCP on: ${reads} + writes` };
+  return { glyph: '⌁', label: `MCP on: ${reads}` };
 }
 
 /**

--- a/electron/mcpRendererBridge.ts
+++ b/electron/mcpRendererBridge.ts
@@ -23,7 +23,7 @@ export const PING_TIMEOUT_MS = 1000;
 export const REQUEST_TIMEOUT_MS = 3000;
 
 export type RendererResult =
-  | { ok: true; data: unknown }
+  | { ok: true; data: unknown; undo?: unknown }
   | { ok: false; error: { code: string; message: string } };
 
 const UNAVAILABLE: RendererResult = {
@@ -60,7 +60,7 @@ export function createRendererBridge(getMainWindow: () => BrowserWindow | null):
     const mw = getMainWindow();
     if (!mw || event.sender !== mw.webContents) return;
 
-    const response = raw as { id?: unknown; ok?: unknown; data?: unknown; error?: unknown };
+    const response = raw as { id?: unknown; ok?: unknown; data?: unknown; undo?: unknown; error?: unknown };
     if (typeof response?.id !== 'number') return;
     const entry = pending.get(response.id);
     if (!entry) return; // late reply after timeout — already answered unavailable
@@ -68,7 +68,9 @@ export function createRendererBridge(getMainWindow: () => BrowserWindow | null):
     clearTimeout(entry.timer);
 
     if (response.ok === true) {
-      entry.resolve({ ok: true, data: response.data });
+      // `undo` is the §4.3 journal descriptor for writes — main-process-only
+      // metadata, threaded alongside `data` so it never reaches tool output.
+      entry.resolve({ ok: true, data: response.data, ...(response.undo !== undefined ? { undo: response.undo } : {}) });
     } else {
       const err = (response.error ?? {}) as { code?: unknown; message?: unknown };
       entry.resolve({

--- a/electron/mcpWriteTools.ts
+++ b/electron/mcpWriteTools.ts
@@ -34,6 +34,21 @@ import {
   makeStoreKey,
   deterministicTaskIdFromSeed,
 } from './mcpIdempotency.js';
+import type { JournalRecord } from './mcpJournal.js';
+
+/** Renderer-captured undo descriptor, diverted to the §4.3 journal. */
+interface UndoDescriptor {
+  summary: string;
+  op: JournalRecord['op'];
+}
+interface UndoCapture {
+  undo?: UndoDescriptor;
+}
+function isUndoDescriptor(v: unknown): v is UndoDescriptor {
+  return typeof v === 'object' && v !== null
+    && typeof (v as UndoDescriptor).summary === 'string'
+    && typeof (v as UndoDescriptor).op === 'object' && (v as UndoDescriptor).op !== null;
+}
 
 export interface WriteToolDeps {
   bridge: RendererBridge;
@@ -47,6 +62,12 @@ export interface WriteToolDeps {
   noteMcpWrite: () => void;
   /** Fired exactly once when repeated violations auto-disable writes (§4.3). */
   onWritesDisabled: () => void;
+  /**
+   * §4.3 write journal (Phase 5b): called once per successful non-replayed
+   * write with tool, summary, idempotency key, and the reversal op. Optional
+   * so the listener still runs journal-less (tests, skeleton mode).
+   */
+  journal?: (record: JournalRecord) => void;
   now: () => number;
   timeZone: () => string;
 }
@@ -94,7 +115,7 @@ export function registerWriteTools(server: McpServer, deps: WriteToolDeps): void
   const write = async (
     tool: string,
     idempotencyKey: unknown,
-    mutate: (transitionId: string) => Promise<ToolResult>,
+    mutate: (transitionId: string, capture: UndoCapture) => Promise<ToolResult>,
   ): Promise<ToolResult> => {
     if (!deps.includeWrites()) {
       return toolError(
@@ -128,20 +149,38 @@ export function registerWriteTools(server: McpServer, deps: WriteToolDeps): void
     }
 
     const transitionId = typeof idempotencyKey === 'string' ? idempotencyKey : randomUUID();
-    const result = await mutate(transitionId);
+    const capture: UndoCapture = {};
+    const result = await mutate(transitionId, capture);
     if (!result.isError) {
       deps.noteMcpWrite();
+      // §4.3 write journal: record tool, time, what changed, and the reversal
+      // descriptor the renderer captured from the before-state. Replayed
+      // writes carry no descriptor — nothing changed, nothing to journal.
+      if (capture.undo && deps.journal) {
+        deps.journal({
+          tool: `dayglance_${tool}`,
+          ...(typeof idempotencyKey === 'string' ? { idempotencyKey } : {}),
+          summary: capture.undo.summary,
+          op: capture.undo.op,
+        });
+      }
       if (storeKey && result.structuredContent) deps.store.put(storeKey, result.structuredContent);
     }
     return result;
   };
 
-  /** Map a renderer response onto the tool result, preserving §5.2 error codes. */
+  /**
+   * Map a renderer response onto the tool result, preserving §5.2 error codes.
+   * The renderer's `undo` descriptor is diverted into the capture for the
+   * journal — it is main-process metadata and must never reach tool output.
+   */
   const fromRenderer = (
     r: Awaited<ReturnType<RendererBridge['request']>>,
     envelope: Record<string, unknown>,
+    capture?: UndoCapture,
   ): ToolResult => {
     if (!r.ok) return toolError(r.error.code, r.error.message);
+    if (capture && isUndoDescriptor(r.undo)) capture.undo = r.undo;
     return ok({ ...(r.data as Record<string, unknown>), ...envelope });
   };
 
@@ -162,14 +201,14 @@ export function registerWriteTools(server: McpServer, deps: WriteToolDeps): void
       }),
     },
     async ({ title, notes, project_id, idempotency_key }) =>
-      write('create_task', idempotency_key, async (transitionId) => {
+      write('create_task', idempotency_key, async (transitionId, capture) => {
         // Deterministic id from the key (handleIntent precedent): a replayed
         // create converges on the same id and no-ops renderer-side.
         const taskId = idempotency_key !== undefined
           ? deterministicTaskIdFromSeed(makeStoreKey(deps.token(), 'create_task', idempotency_key as string))
           : randomUUID();
         const r = await deps.bridge.request('create_task', { taskId, title, notes, projectId: project_id, transitionId });
-        return fromRenderer(r, { timezone: deps.timeZone() });
+        return fromRenderer(r, { timezone: deps.timeZone() }, capture);
       }),
   );
 
@@ -187,7 +226,7 @@ export function registerWriteTools(server: McpServer, deps: WriteToolDeps): void
       }),
     },
     async ({ task_id, start, duration_minutes, idempotency_key }) =>
-      write('schedule_task', idempotency_key, async (transitionId) => {
+      write('schedule_task', idempotency_key, async (transitionId, capture) => {
         const parsed = parseStart(start, deps.timeZone());
         if ('invalid' in parsed) return toolError('validation', parsed.invalid);
         if (duration_minutes !== undefined) {
@@ -197,7 +236,7 @@ export function registerWriteTools(server: McpServer, deps: WriteToolDeps): void
         const r = await deps.bridge.request('schedule_task', {
           taskId: task_id, date: parsed.date, startTime: parsed.time, durationMinutes: duration_minutes, transitionId,
         });
-        return fromRenderer(r, dateEnvelope(parsed.date, deps.timeZone()) as unknown as Record<string, unknown>);
+        return fromRenderer(r, dateEnvelope(parsed.date, deps.timeZone()) as unknown as Record<string, unknown>, capture);
       }),
   );
 
@@ -214,13 +253,13 @@ export function registerWriteTools(server: McpServer, deps: WriteToolDeps): void
       }),
     },
     async ({ block_id, new_start, idempotency_key }) =>
-      write('move_block', idempotency_key, async (transitionId) => {
+      write('move_block', idempotency_key, async (transitionId, capture) => {
         const parsed = parseStart(new_start, deps.timeZone());
         if ('invalid' in parsed) return toolError('validation', parsed.invalid);
         const r = await deps.bridge.request('move_block', {
           blockId: block_id, date: parsed.date, startTime: parsed.time, transitionId,
         });
-        return fromRenderer(r, dateEnvelope(parsed.date, deps.timeZone()) as unknown as Record<string, unknown>);
+        return fromRenderer(r, dateEnvelope(parsed.date, deps.timeZone()) as unknown as Record<string, unknown>, capture);
       }),
   );
 
@@ -237,13 +276,13 @@ export function registerWriteTools(server: McpServer, deps: WriteToolDeps): void
       }),
     },
     async ({ block_id, duration_minutes, idempotency_key }) =>
-      write('resize_block', idempotency_key, async (transitionId) => {
+      write('resize_block', idempotency_key, async (transitionId, capture) => {
         const durationError = validateDurationMinutes(duration_minutes);
         if (durationError) return toolError('validation', durationError);
         const r = await deps.bridge.request('resize_block', {
           blockId: block_id, durationMinutes: duration_minutes, transitionId,
         });
-        return fromRenderer(r, { timezone: deps.timeZone() });
+        return fromRenderer(r, { timezone: deps.timeZone() }, capture);
       }),
   );
 
@@ -261,12 +300,12 @@ export function registerWriteTools(server: McpServer, deps: WriteToolDeps): void
       }),
     },
     async ({ task_id, completed, idempotency_key }) =>
-      write('set_task_completion', idempotency_key, async (transitionId) => {
+      write('set_task_completion', idempotency_key, async (transitionId, capture) => {
         const r = await deps.bridge.request('set_completion', {
           taskId: task_id, completed, transitionId,
           todayStr: localDateOf(deps.now(), deps.timeZone()),
         });
-        return fromRenderer(r, { timezone: deps.timeZone() });
+        return fromRenderer(r, { timezone: deps.timeZone() }, capture);
       }),
   );
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -98,6 +98,20 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
   },
 
+  // §4.3 write journal — session-scoped record of MCP-originated mutations,
+  // owned by the main process; the tray popup displays it and can trigger
+  // the bulk undo (§6.5). Read-only from the renderer's perspective: entries
+  // are created only by the main process's write pipeline.
+  mcpJournal: {
+    get: (): Promise<unknown> => ipcRenderer.invoke('mcp-journal:get'),
+    undoAll: (): Promise<unknown> => ipcRenderer.invoke('mcp-journal:undo-all'),
+    onChanged: (callback: (snapshot: unknown) => void) => {
+      const handler = (_: Electron.IpcRendererEvent, snapshot: unknown) => callback(snapshot);
+      ipcRenderer.on('mcp-journal:changed', handler);
+      return () => ipcRenderer.removeListener('mcp-journal:changed', handler);
+    },
+  },
+
   // Show or clear the reminder dot (●) next to the tray icon.
   setTrayIndicator: (on: boolean) => ipcRenderer.send('tray:set-indicator', on),
 

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -29,6 +29,7 @@ import FrameNudgeCard from './FrameNudgeCard.jsx';
 import DeadlinePickerPopover from './DeadlinePickerPopover.jsx';
 import MobileTabBar from './MobileTabBar.jsx';
 import MobileSettingsPanel from './MobileSettingsPanel.jsx';
+import TrayMcpStatus from './TrayMcpStatus.jsx';
 import GoalDashboard from './goals/GoalDashboard.jsx';
 import MobileTimeGrid from './MobileTimeGrid.jsx';
 import SummaryStrip from './SummaryStrip.jsx';
@@ -482,6 +483,8 @@ const MobileLayout = () => {
         <>
           {/* Mobile Layout */}
           <div className="mobile-timeline-layout" style={isNativeAndroid() ? { height: 'calc(100dvh - 3.5rem - env(safe-area-inset-top, 0px))' } : undefined}>
+            {/* §6.5 MCP status strip — tray popup only, renders null elsewhere */}
+            <TrayMcpStatus />
             {/* Mobile Header */}
             {mobileActiveTab === 'timeline' && (
               <div className={`${cardBg} border-b ${borderClass} flex-shrink-0 relative ${showMonthView ? 'z-50' : 'z-30'}`}>

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -29,7 +29,6 @@ import FrameNudgeCard from './FrameNudgeCard.jsx';
 import DeadlinePickerPopover from './DeadlinePickerPopover.jsx';
 import MobileTabBar from './MobileTabBar.jsx';
 import MobileSettingsPanel from './MobileSettingsPanel.jsx';
-import TrayMcpStatus from './TrayMcpStatus.jsx';
 import GoalDashboard from './goals/GoalDashboard.jsx';
 import MobileTimeGrid from './MobileTimeGrid.jsx';
 import SummaryStrip from './SummaryStrip.jsx';
@@ -483,8 +482,6 @@ const MobileLayout = () => {
         <>
           {/* Mobile Layout */}
           <div className="mobile-timeline-layout" style={isNativeAndroid() ? { height: 'calc(100dvh - 3.5rem - env(safe-area-inset-top, 0px))' } : undefined}>
-            {/* §6.5 MCP status strip — tray popup only, renders null elsewhere */}
-            <TrayMcpStatus />
             {/* Mobile Header */}
             {mobileActiveTab === 'timeline' && (
               <div className={`${cardBg} border-b ${borderClass} flex-shrink-0 relative ${showMonthView ? 'z-50' : 'z-30'}`}>

--- a/src/components/TrayApp.jsx
+++ b/src/components/TrayApp.jsx
@@ -7,6 +7,7 @@ import TrayReminders from './TrayReminders.jsx';
 import TrayNowBar from './TrayNowBar.jsx';
 import TraySpotlight from './TraySpotlight.jsx';
 import TrayVoice from './TrayVoice.jsx';
+import TrayMcpStatus from './TrayMcpStatus.jsx';
 
 export default function TrayApp({ bgClass, darkMode }) {
   const [overlay, setOverlay] = useState(null); // 'spotlight' | 'voice' | null
@@ -42,6 +43,8 @@ export default function TrayApp({ bgClass, darkMode }) {
         onSearchClick={() => setOverlay('spotlight')}
         onVoiceClick={() => setOverlay('voice')}
       />
+      {/* §6.5 MCP status strip: indicator, tier, kill switch, write journal */}
+      <TrayMcpStatus />
       {focusState ? (
         <TrayFocus darkMode={darkMode} focusState={focusState} />
       ) : (

--- a/src/components/TrayMcpStatus.jsx
+++ b/src/components/TrayMcpStatus.jsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useState } from 'react';
+import { ChevronDown, Power, Undo2, Zap } from 'lucide-react';
+import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { isTrayMode } from '../utils/trayMode.js';
+
+// §6.5 tray surface for the MCP listener: a distinct indicator while the
+// server is bound, the current tier, the one-click kill switch, and the §4.3
+// write journal with bulk undo. Renders ONLY in the tray popup (isTrayMode).
+//
+// Live, not snapshot: everything here arrives over IPC push
+// (local-integrations:status / mcp-journal:changed), deliberately outside the
+// popup's reload-on-data-change cycle — listener state changing while the
+// popup is open updates in place.
+//
+// The tray is forbidden from persisting, and this component honors that by
+// owning no state: the kill switch calls the main process's config transition
+// directly (ipcMain.handle — NOT the tray:background-action relay, which
+// silently drops without a main window), and undo asks the main process to
+// replay the journal through the main window's store layer.
+
+const TrayMcpStatus = () => {
+  const { darkMode, borderClass, textPrimary, textSecondary } = useDayPlannerCtx();
+  const api = typeof window !== 'undefined' ? window.electronAPI : undefined;
+
+  const [snapshot, setSnapshot] = useState(null);
+  const [journal, setJournal] = useState({ total: 0, entries: [] });
+  const [expanded, setExpanded] = useState(false);
+  const [undoBusy, setUndoBusy] = useState(false);
+  const [notice, setNotice] = useState(null);
+
+  useEffect(() => {
+    if (!isTrayMode || !api?.localIntegrations) return undefined;
+    let mounted = true;
+    api.localIntegrations.get().then((s) => { if (mounted) setSnapshot(s); });
+    api.mcpJournal?.get().then((j) => { if (mounted && j) setJournal(j); });
+    const offStatus = api.localIntegrations.onStatus((s) => setSnapshot(s));
+    const offJournal = api.mcpJournal?.onChanged((j) => setJournal(j));
+    return () => { mounted = false; offStatus?.(); offJournal?.(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!isTrayMode || !api?.localIntegrations || !snapshot) return null;
+
+  const { gates } = snapshot;
+  // Visible while the listener is bound OR undoable session writes remain —
+  // the kill switch must not take the undo path down with it.
+  if (!gates.bound && journal.total === 0) return null;
+
+  const tier = !gates.bound ? 'MCP server off'
+    : gates.includeWrites
+      ? (gates.includeNative ? 'Reads incl. device calendar + writes' : 'Reads dayGLANCE data + writes')
+      : (gates.includeNative ? 'Reads incl. device calendar' : 'Reads dayGLANCE data');
+
+  const killSwitch = async () => {
+    setNotice(null);
+    const r = await api.localIntegrations.transition({ type: 'set-mcp-read-tier', tier: 'off' });
+    if (!r?.ok) setNotice(r?.error || 'Could not turn the server off.');
+  };
+
+  const undoAll = async () => {
+    setUndoBusy(true);
+    setNotice(null);
+    try {
+      const r = await api.mcpJournal.undoAll();
+      setNotice(r?.ok
+        ? `Undid ${r.undone} change${r.undone === 1 ? '' : 's'}${r.skipped ? ` (${r.skipped} no longer applicable)` : ''}.`
+        : (r?.error || 'Undo failed.'));
+    } finally {
+      setUndoBusy(false);
+    }
+  };
+
+  const fmtTime = (iso) => {
+    try { return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }); } catch { return ''; }
+  };
+
+  return (
+    <div className={`flex-shrink-0 border-b ${borderClass} ${darkMode ? 'bg-amber-900/15' : 'bg-amber-50'} px-3 py-2 space-y-1.5`}>
+      <div className="flex items-center gap-2">
+        <Zap size={14} className={gates.bound ? 'text-amber-500' : textSecondary} />
+        <div className="flex-1 min-w-0">
+          <div className={`text-xs font-semibold ${textPrimary}`}>
+            {gates.bound ? 'MCP server on' : 'MCP server off'}
+          </div>
+          <div className={`text-[11px] ${textSecondary} truncate`}>{tier}</div>
+        </div>
+        {gates.bound && (
+          <button
+            onClick={killSwitch}
+            className={`flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-medium ${darkMode ? 'bg-red-900/40 text-red-300 hover:bg-red-900/60' : 'bg-red-100 text-red-700 hover:bg-red-200'} transition-colors`}
+            title="Turn the MCP server off. No apps will be able to connect until you re-enable it in Settings."
+          >
+            <Power size={12} />
+            Turn off
+          </button>
+        )}
+      </div>
+
+      {journal.total > 0 && (
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className={`flex items-center gap-1 text-[11px] ${textSecondary} hover:${textPrimary} transition-colors`}
+            >
+              <ChevronDown size={12} className={`transition-transform ${expanded ? 'rotate-180' : ''}`} />
+              {journal.total} change{journal.total === 1 ? '' : 's'} by MCP this session
+            </button>
+            <button
+              onClick={undoAll}
+              disabled={undoBusy}
+              className={`ml-auto flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-medium disabled:opacity-50 ${darkMode ? 'bg-gray-700 text-gray-200 hover:bg-gray-600' : 'bg-stone-200 text-stone-700 hover:bg-stone-300'} transition-colors`}
+              title="Reverse every change MCP clients made since dayGLANCE started (or since the last undo)."
+            >
+              <Undo2 size={12} />
+              {undoBusy ? 'Undoing…' : `Undo all (${journal.total})`}
+            </button>
+          </div>
+          {expanded && (
+            <ul className="max-h-32 overflow-y-auto space-y-0.5">
+              {journal.entries.map((e) => (
+                <li key={e.seq} className={`text-[11px] ${textSecondary} flex gap-1.5`}>
+                  <span className="tabular-nums flex-shrink-0">{fmtTime(e.at)}</span>
+                  <span className="truncate" title={`${e.tool}${e.idempotencyKey ? ` · key ${e.idempotencyKey}` : ''}`}>
+                    {e.summary}
+                  </span>
+                </li>
+              ))}
+              {journal.total > journal.entries.length && (
+                <li className={`text-[11px] ${textSecondary} italic`}>
+                  …and {journal.total - journal.entries.length} earlier (all included in undo)
+                </li>
+              )}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {notice && <p className={`text-[11px] ${textSecondary}`}>{notice}</p>}
+    </div>
+  );
+};
+
+export default TrayMcpStatus;

--- a/src/utils/mcpWriteModel.js
+++ b/src/utils/mcpWriteModel.js
@@ -9,6 +9,12 @@
 // in the same handler tick — React batches them into one commit, so a
 // schedule_task can never land with the task removed from the inbox but not
 // yet on the calendar. A failed validation returns before any setter runs.
+//
+// UNDO DESCRIPTORS (§4.3, Phase 5b): every successful non-replayed write also
+// returns an `undo` envelope — { summary, op } — captured HERE, from the
+// before-state, because this is the only place that still has it: the journal
+// in the main process records it, and bulk undo replays the ops back through
+// applyUndoOps. Replayed writes carry no descriptor (nothing changed).
 
 import {
   applyCreateTask,
@@ -16,21 +22,30 @@ import {
   applyMoveBlock,
   applyResizeBlock,
   applySetCompletion,
+  applyUndoOps,
+  parseRecurringInstanceId,
 } from './taskMutations.js';
 import { toBlock } from './mcpReadModel.js';
 
-const WRITE_METHODS = new Set(['create_task', 'schedule_task', 'move_block', 'resize_block', 'set_completion']);
+const WRITE_METHODS = new Set([
+  'create_task', 'schedule_task', 'move_block', 'resize_block', 'set_completion',
+  'undo_mcp_writes',
+]);
 
 export function isWriteMethod(method) {
   return WRITE_METHODS.has(method);
 }
 
+const q = (title) => `“${title ?? ''}”`;
+const at = (date, startTime) => (startTime ? `${date} ${startTime}` : `${date}`);
+
 /**
  * @param state   live slices: { tasks, unscheduledTasks, recurringTasks }
  * @param setters { setTasks, setUnscheduledTasks, setRecurringTasks }
  * @param request { method, params }
- * Returns { ok:true, data } | { ok:false, error:{ code, message } } — same
- * envelope as handleMcpRequest, mapped by the main process onto §5.2 errors.
+ * Returns { ok:true, data, undo? } | { ok:false, error:{ code, message } } —
+ * same envelope as handleMcpRequest plus the §4.3 undo descriptor, which the
+ * main process journals and strips before anything reaches the MCP client.
  */
 export function handleMcpWrite(state, setters, request) {
   const params = request?.params ?? {};
@@ -41,30 +56,57 @@ export function handleMcpWrite(state, setters, request) {
       const r = applyCreateTask(state, { ...params, nowIso });
       if (!r.ok) return r;
       if (!r.replayed) setters.setUnscheduledTasks(r.unscheduledTasks);
-      return { ok: true, data: { task: inboxItem(r.task), replayed: r.replayed } };
+      const undo = r.replayed ? undefined : {
+        summary: `Created ${q(r.task.title)}`,
+        op: { kind: 'remove_created', taskId: r.task.id },
+      };
+      return { ok: true, data: { task: inboxItem(r.task), replayed: r.replayed }, ...(undo ? { undo } : {}) };
     }
     case 'schedule_task': {
+      // Captured BEFORE the mutation: applyScheduleTask strips priority and
+      // deadline on the way to the calendar, so this snapshot is the only
+      // faithful record of the inbox task.
+      const beforeTask = (state.unscheduledTasks ?? []).find((t) => t.id === params.taskId);
       const r = applyScheduleTask(state, { ...params, nowIso });
       if (!r.ok) return r;
       if (!r.replayed) {
         setters.setUnscheduledTasks(r.unscheduledTasks);
         setters.setTasks(r.tasks);
       }
-      return { ok: true, data: { block: toBlock(r.task), replayed: r.replayed } };
+      const undo = r.replayed || !beforeTask ? undefined : {
+        summary: `Scheduled ${q(beforeTask.title)} at ${at(params.date, params.startTime)}`,
+        op: { kind: 'restore_unscheduled', taskId: params.taskId, beforeTask },
+      };
+      return { ok: true, data: { block: toBlock(r.task), replayed: r.replayed }, ...(undo ? { undo } : {}) };
     }
     case 'move_block': {
+      const before = (state.tasks ?? []).find((t) => t.id === params.blockId);
       const r = applyMoveBlock(state, params);
       if (!r.ok) return r;
       if (!r.replayed) setters.setTasks(r.tasks);
-      return { ok: true, data: { block: toBlock(r.task), replayed: r.replayed } };
+      const undo = r.replayed || !before ? undefined : {
+        summary: `Moved ${q(before.title)} from ${at(before.date, before.startTime)} to ${at(params.date, params.startTime)}`,
+        op: {
+          kind: 'restore_block_fields',
+          blockId: params.blockId,
+          before: { date: before.date, startTime: before.startTime ?? null, isAllDay: !!before.isAllDay },
+        },
+      };
+      return { ok: true, data: { block: toBlock(r.task), replayed: r.replayed }, ...(undo ? { undo } : {}) };
     }
     case 'resize_block': {
+      const before = (state.tasks ?? []).find((t) => t.id === params.blockId);
       const r = applyResizeBlock(state, params);
       if (!r.ok) return r;
       if (!r.replayed) setters.setTasks(r.tasks);
-      return { ok: true, data: { block: toBlock(r.task), replayed: r.replayed } };
+      const undo = r.replayed || !before ? undefined : {
+        summary: `Resized ${q(before.title)} from ${before.duration ?? '?'} to ${params.durationMinutes} min`,
+        op: { kind: 'restore_block_fields', blockId: params.blockId, before: { duration: before.duration ?? null } },
+      };
+      return { ok: true, data: { block: toBlock(r.task), replayed: r.replayed }, ...(undo ? { undo } : {}) };
     }
     case 'set_completion': {
+      const undoSource = completionUndo(state, params);
       const r = applySetCompletion(state, { ...params, nowIso });
       if (!r.ok) return r;
       if (!r.replayed) {
@@ -75,11 +117,47 @@ export function handleMcpWrite(state, setters, request) {
       const entity = r.task.date !== undefined || r.task.startTime !== undefined
         ? { block: toBlock(r.task) }
         : { task: { id: r.task.id, completed: !!r.task.completed } };
-      return { ok: true, data: { ...entity, replayed: r.replayed } };
+      const undo = r.replayed ? undefined : undoSource;
+      return { ok: true, data: { ...entity, replayed: r.replayed }, ...(undo ? { undo } : {}) };
+    }
+    case 'undo_mcp_writes': {
+      // The §4.3 bulk undo. Not itself journaled (the main process clears the
+      // journal on success), and applied through the same store layer as every
+      // other write, so sync, GLANCEintents, and tray:data-changed all fire.
+      const r = applyUndoOps(state, params.ops, { nowIso });
+      setters.setTasks(r.tasks);
+      setters.setUnscheduledTasks(r.unscheduledTasks);
+      setters.setRecurringTasks(r.recurringTasks);
+      return { ok: true, data: { undone: r.undone, skipped: r.skipped } };
     }
     default:
       return { ok: false, error: { code: 'validation', message: `Unknown write method ${JSON.stringify(request?.method)}` } };
   }
+}
+
+/** Before-state for set_completion, across the three branches applySetCompletion handles. */
+function completionUndo(state, { taskId, completed }) {
+  const instance = parseRecurringInstanceId(taskId);
+  if (instance) {
+    const template = (state.recurringTasks ?? []).find((t) => t.id === instance.templateId);
+    if (!template) return undefined;
+    const wasCompleted = (template.completedDates || []).includes(instance.dateStr);
+    return {
+      summary: `Marked ${q(template.title)} (${instance.dateStr}) ${completed ? 'complete' : 'incomplete'}`,
+      op: { kind: 'restore_recurring_completion', templateId: template.id, dateStr: instance.dateStr, wasCompleted },
+    };
+  }
+  const task = (state.unscheduledTasks ?? []).find((t) => t.id === taskId)
+    ?? (state.tasks ?? []).find((t) => t.id === taskId);
+  if (!task) return undefined;
+  return {
+    summary: `Marked ${q(task.title)} ${completed ? 'complete' : 'incomplete'}`,
+    op: {
+      kind: 'restore_completion',
+      taskId,
+      before: { completed: !!task.completed, completedAt: task.completedAt ?? null },
+    },
+  };
 }
 
 /** Inbox-item wire shape, matching buildUnscheduledItems in mcpReadModel.js. */

--- a/src/utils/mcpWriteModel.test.js
+++ b/src/utils/mcpWriteModel.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleMcpWrite, isWriteMethod } from './mcpWriteModel.js';
+
+// Phase 5b additions to the write dispatcher: every successful non-replayed
+// write returns a §4.3 undo descriptor { summary, op } captured from the
+// BEFORE-state (the only place it still exists — schedule strips priority and
+// deadline), replays return none, and undo_mcp_writes applies reversal ops
+// through the same setters as every other write.
+
+const NOW_RE = /^\d{4}-\d{2}-\d{2}T/;
+
+const makeSetters = () => ({
+  setTasks: vi.fn(),
+  setUnscheduledTasks: vi.fn(),
+  setRecurringTasks: vi.fn(),
+});
+
+const B = (over = {}) => ({
+  id: 'b1', title: 'Block', date: '2026-08-10', startTime: '09:00',
+  duration: 60, completed: false, isAllDay: false, ...over,
+});
+
+describe('isWriteMethod', () => {
+  it('routes the five write tools plus undo_mcp_writes', () => {
+    for (const m of ['create_task', 'schedule_task', 'move_block', 'resize_block', 'set_completion', 'undo_mcp_writes']) {
+      expect(isWriteMethod(m)).toBe(true);
+    }
+    expect(isWriteMethod('get_day')).toBe(false);
+  });
+});
+
+describe('undo descriptors on write responses', () => {
+  it('create_task → remove_created; replay carries NO descriptor', () => {
+    const state = { tasks: [], unscheduledTasks: [] };
+    const r = handleMcpWrite(state, makeSetters(), {
+      method: 'create_task', params: { taskId: 'n1', title: 'Buy milk' },
+    });
+    expect(r.ok).toBe(true);
+    expect(r.undo.op).toEqual({ kind: 'remove_created', taskId: 'n1' });
+    expect(r.undo.summary).toContain('Buy milk');
+
+    const replay = handleMcpWrite({ tasks: [], unscheduledTasks: [{ id: 'n1', title: 'Buy milk' }] }, makeSetters(), {
+      method: 'create_task', params: { taskId: 'n1', title: 'Buy milk' },
+    });
+    expect(replay.ok).toBe(true);
+    expect(replay.data.replayed).toBe(true);
+    expect(replay.undo).toBeUndefined();
+  });
+
+  it('schedule_task captures the FULL before-task — priority and deadline survive the round trip', () => {
+    const inbox = { id: 'u1', title: 'Report', priority: 2, deadline: '2026-08-20', duration: 45 };
+    const state = { tasks: [], unscheduledTasks: [inbox] };
+    const r = handleMcpWrite(state, makeSetters(), {
+      method: 'schedule_task',
+      params: { taskId: 'u1', date: '2026-08-11', startTime: '10:00', durationMinutes: 30 },
+    });
+    expect(r.ok).toBe(true);
+    expect(r.undo.op.kind).toBe('restore_unscheduled');
+    expect(r.undo.op.beforeTask).toEqual(inbox); // captured pre-mutation, strip-proof
+    expect(r.undo.summary).toContain('2026-08-11 10:00');
+  });
+
+  it('move_block and resize_block capture exactly the touched before-fields', () => {
+    const state = { tasks: [B()], unscheduledTasks: [] };
+    const move = handleMcpWrite(state, makeSetters(), {
+      method: 'move_block', params: { blockId: 'b1', date: '2026-08-12', startTime: '15:00' },
+    });
+    expect(move.undo.op).toEqual({
+      kind: 'restore_block_fields', blockId: 'b1',
+      before: { date: '2026-08-10', startTime: '09:00', isAllDay: false },
+    });
+    const resize = handleMcpWrite(state, makeSetters(), {
+      method: 'resize_block', params: { blockId: 'b1', durationMinutes: 90 },
+    });
+    expect(resize.undo.op).toEqual({
+      kind: 'restore_block_fields', blockId: 'b1', before: { duration: 60 },
+    });
+  });
+
+  it('set_completion captures prior completed/completedAt; recurring instances capture membership', () => {
+    const state = {
+      tasks: [B({ completed: false })],
+      unscheduledTasks: [],
+      recurringTasks: [{ id: 'r1', title: 'Standup', completedDates: [], recurrence: { type: 'daily', startDate: '2026-01-01' } }],
+    };
+    const flat = handleMcpWrite(state, makeSetters(), {
+      method: 'set_completion', params: { taskId: 'b1', completed: true, todayStr: '2026-08-10' },
+    });
+    expect(flat.undo.op).toEqual({
+      kind: 'restore_completion', taskId: 'b1', before: { completed: false, completedAt: null },
+    });
+    const rec = handleMcpWrite(state, makeSetters(), {
+      method: 'set_completion', params: { taskId: 'recurring-r1-2026-08-10', completed: true, todayStr: '2026-08-10' },
+    });
+    expect(rec.undo.op).toEqual({
+      kind: 'restore_recurring_completion', templateId: 'r1', dateStr: '2026-08-10', wasCompleted: false,
+    });
+    // Setter-idempotent replay (already complete) → no descriptor
+    const replay = handleMcpWrite({ ...state, tasks: [B({ completed: true })] }, makeSetters(), {
+      method: 'set_completion', params: { taskId: 'b1', completed: true, todayStr: '2026-08-10' },
+    });
+    expect(replay.data.replayed).toBe(true);
+    expect(replay.undo).toBeUndefined();
+  });
+
+  it('failed writes return the typed error and no descriptor', () => {
+    const r = handleMcpWrite({ tasks: [], unscheduledTasks: [] }, makeSetters(), {
+      method: 'move_block', params: { blockId: 'nope', date: '2026-08-12', startTime: '15:00' },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.undo).toBeUndefined();
+  });
+});
+
+describe('undo_mcp_writes', () => {
+  it('applies reversal ops through ALL three setters in one commit and reports counts', () => {
+    const setters = makeSetters();
+    const state = {
+      tasks: [B({ id: 'c1', title: 'Agent task', date: '2026-08-12', startTime: '15:00' })],
+      unscheduledTasks: [],
+      recurringTasks: [],
+    };
+    const r = handleMcpWrite(state, setters, {
+      method: 'undo_mcp_writes',
+      params: {
+        ops: [
+          { kind: 'restore_block_fields', blockId: 'c1', before: { date: '2026-08-10', startTime: '09:00', isAllDay: false } },
+          { kind: 'restore_unscheduled', taskId: 'c1', beforeTask: { id: 'c1', title: 'Agent task', priority: 0 } },
+          { kind: 'remove_created', taskId: 'c1' },
+        ],
+      },
+    });
+    expect(r).toEqual({ ok: true, data: { undone: 3, skipped: 0 } });
+    expect(setters.setTasks).toHaveBeenCalledWith([]);
+    expect(setters.setUnscheduledTasks).toHaveBeenCalledWith([]);
+    expect(setters.setRecurringTasks).toHaveBeenCalledWith([]);
+  });
+
+  it('restored tasks carry a fresh lastModified so sync propagates the undo', () => {
+    const setters = makeSetters();
+    handleMcpWrite(
+      { tasks: [B()], unscheduledTasks: [], recurringTasks: [] },
+      setters,
+      { method: 'undo_mcp_writes', params: { ops: [{ kind: 'restore_block_fields', blockId: 'b1', before: { duration: 30 } }] } },
+    );
+    const [next] = setters.setTasks.mock.calls[0];
+    expect(next[0].duration).toBe(30);
+    expect(next[0].lastModified).toMatch(NOW_RE);
+  });
+});

--- a/src/utils/taskMutations.js
+++ b/src/utils/taskMutations.js
@@ -196,6 +196,97 @@ export function applyResizeBlock(state, { blockId, durationMinutes, transitionId
  *    flip without the network half would desync the user's CalDAV server. A
  *    pure module cannot do the network half — v1 rejects.
  */
+/**
+ * BULK UNDO (§4.3): apply a list of reversal ops produced by the main
+ * process's write journal (electron/mcpJournal.ts buildUndoPlan). Ops arrive
+ * in REVERSE chronological order, so compound histories unwind correctly:
+ * create → schedule → move undoes as restore-fields → restore-to-inbox →
+ * remove-created, each op finding exactly the state its write produced.
+ *
+ * Same store-layer path as every other write in this module: the caller
+ * invokes the setters with the returned slices, so the save pass, sync push,
+ * GLANCEintents diff, and tray:data-changed all engage as for a UI edit.
+ * Deliberately NOT pushed onto the user's undo stack (it IS the undo).
+ *
+ * Tolerant by design: a task the user deleted or edited away since the MCP
+ * write is SKIPPED and counted, never an error — the user's own actions
+ * outrank the reversal. _native can never appear here (every forward write
+ * rejects it), but ops touching one are skipped anyway, fail-closed.
+ */
+export function applyUndoOps(state, ops, { nowIso }) {
+  let tasks = state.tasks ?? [];
+  let unscheduled = state.unscheduledTasks ?? [];
+  let recurring = state.recurringTasks ?? [];
+  let undone = 0;
+  let skipped = 0;
+
+  for (const op of ops ?? []) {
+    switch (op?.kind) {
+      case 'remove_created': {
+        const before = tasks.length + unscheduled.length;
+        tasks = tasks.filter((t) => t.id !== op.taskId);
+        unscheduled = unscheduled.filter((t) => t.id !== op.taskId);
+        if (tasks.length + unscheduled.length < before) undone += 1; else skipped += 1;
+        break;
+      }
+      case 'restore_unscheduled': {
+        const scheduled = tasks.find((t) => t.id === op.taskId);
+        if (!scheduled || scheduled._native || !op.beforeTask) { skipped += 1; break; }
+        tasks = tasks.filter((t) => t.id !== op.taskId);
+        if (!unscheduled.some((t) => t.id === op.taskId)) {
+          unscheduled = [...unscheduled, { ...op.beforeTask, lastModified: nowIso }];
+        }
+        undone += 1;
+        break;
+      }
+      case 'restore_block_fields': {
+        const block = tasks.find((t) => t.id === op.blockId);
+        if (!block || block._native || !op.before) { skipped += 1; break; }
+        tasks = tasks.map((t) => (t.id === op.blockId ? { ...t, ...op.before, lastModified: nowIso } : t));
+        undone += 1;
+        break;
+      }
+      case 'restore_completion': {
+        const inInbox = unscheduled.find((t) => t.id === op.taskId);
+        const scheduled = tasks.find((t) => t.id === op.taskId);
+        const task = inInbox ?? scheduled;
+        if (!task || task._native || !op.before) { skipped += 1; break; }
+        const next = {
+          ...task,
+          completed: !!op.before.completed,
+          ...(op.before.completedAt !== undefined ? { completedAt: op.before.completedAt } : {}),
+          lastModified: nowIso,
+        };
+        if (inInbox) unscheduled = unscheduled.map((t) => (t.id === op.taskId ? next : t));
+        else tasks = tasks.map((t) => (t.id === op.taskId ? next : t));
+        undone += 1;
+        break;
+      }
+      case 'restore_recurring_completion': {
+        const template = recurring.find((t) => t.id === op.templateId);
+        if (!template) { skipped += 1; break; }
+        const has = (template.completedDates || []).includes(op.dateStr);
+        if (has === op.wasCompleted) { undone += 1; break; } // already in the before-state
+        const nextTemplate = {
+          ...template,
+          completedDates: op.wasCompleted
+            ? [...(template.completedDates || []), op.dateStr]
+            : (template.completedDates || []).filter((d) => d !== op.dateStr),
+          completedDatesTimestamps: { ...(template.completedDatesTimestamps || {}), [op.dateStr]: nowIso },
+          lastModified: nowIso,
+        };
+        recurring = recurring.map((t) => (t.id === op.templateId ? nextTemplate : t));
+        undone += 1;
+        break;
+      }
+      default:
+        skipped += 1;
+    }
+  }
+
+  return { ok: true, tasks, unscheduledTasks: unscheduled, recurringTasks: recurring, undone, skipped };
+}
+
 export function applySetCompletion(state, { taskId, completed, transitionId, todayStr, nowIso }) {
   const tasks = state.tasks ?? [];
   const unscheduled = state.unscheduledTasks ?? [];

--- a/src/utils/taskMutations.test.js
+++ b/src/utils/taskMutations.test.js
@@ -6,6 +6,7 @@ import {
   applyMoveBlock,
   applyResizeBlock,
   applySetCompletion,
+  applyUndoOps,
   WRITE_ERROR_CODES,
 } from './taskMutations.js';
 
@@ -262,5 +263,112 @@ describe('structural: the module can never write a native override', () => {
     expect(code).not.toMatch(/localStorage/);
     expect(code).not.toMatch(/native-time-overrides/);
     expect(code).not.toMatch(/window\./);
+  });
+});
+
+describe('applyUndoOps — the §4.3 bulk undo (Phase 5b)', () => {
+  const NOW2 = '2026-08-10T13:00:00.000Z';
+  const run = (state, ops) => applyUndoOps(state, ops, { nowIso: NOW2 });
+
+  it('remove_created deletes the created task from either list', () => {
+    const state = { tasks: [T({ id: 's1' })], unscheduledTasks: [{ id: 'c1', title: 'Created' }] };
+    const r = run(state, [{ kind: 'remove_created', taskId: 'c1' }]);
+    expect(r.unscheduledTasks).toEqual([]);
+    expect(r.undone).toBe(1);
+    expect(state.unscheduledTasks).toHaveLength(1); // pure: input untouched
+  });
+
+  it('restore_unscheduled moves the block back to the inbox with the FULL before-task (priority/deadline survive)', () => {
+    const beforeTask = { id: 'u1', title: 'Inbox task', priority: 2, deadline: '2026-08-20', duration: 45 };
+    const state = { tasks: [T({ id: 'u1', title: 'Inbox task', date: '2026-08-11' })], unscheduledTasks: [] };
+    const r = run(state, [{ kind: 'restore_unscheduled', taskId: 'u1', beforeTask }]);
+    expect(r.tasks).toEqual([]);
+    expect(r.unscheduledTasks[0]).toMatchObject({ priority: 2, deadline: '2026-08-20', duration: 45, lastModified: NOW2 });
+    expect(r.undone).toBe(1);
+  });
+
+  it('restore_block_fields puts back exactly the touched fields and stamps lastModified for sync', () => {
+    const state = { tasks: [T({ id: 'b1', date: '2026-08-12', startTime: '15:00', duration: 90 })] };
+    const r = run(state, [
+      { kind: 'restore_block_fields', blockId: 'b1', before: { duration: 60 } },
+      { kind: 'restore_block_fields', blockId: 'b1', before: { date: '2026-08-10', startTime: '09:00', isAllDay: false } },
+    ]);
+    expect(r.tasks[0]).toMatchObject({ date: '2026-08-10', startTime: '09:00', duration: 60, lastModified: NOW2 });
+    expect(r.undone).toBe(2);
+  });
+
+  it('restore_completion restores completed AND completedAt on inbox and scheduled tasks', () => {
+    const state = {
+      tasks: [T({ id: 'b1', completed: true })],
+      unscheduledTasks: [{ id: 'u1', title: 'x', completed: true, completedAt: '2026-08-10' }],
+    };
+    const r = run(state, [
+      { kind: 'restore_completion', taskId: 'b1', before: { completed: false, completedAt: null } },
+      { kind: 'restore_completion', taskId: 'u1', before: { completed: false, completedAt: null } },
+    ]);
+    expect(r.tasks[0].completed).toBe(false);
+    expect(r.unscheduledTasks[0]).toMatchObject({ completed: false, completedAt: null });
+    expect(r.undone).toBe(2);
+  });
+
+  it('restore_recurring_completion restores membership with a fresh per-date timestamp', () => {
+    const state = {
+      recurringTasks: [{ id: 'r1', title: 'Standup', completedDates: ['2026-08-10'], completedDatesTimestamps: {} }],
+    };
+    const r = run(state, [{ kind: 'restore_recurring_completion', templateId: 'r1', dateStr: '2026-08-10', wasCompleted: false }]);
+    expect(r.recurringTasks[0].completedDates).toEqual([]);
+    expect(r.recurringTasks[0].completedDatesTimestamps['2026-08-10']).toBe(NOW2);
+    expect(r.recurringTasks[0].lastModified).toBe(NOW2);
+    const back = run(state, [{ kind: 'restore_recurring_completion', templateId: 'r1', dateStr: '2026-08-10', wasCompleted: true }]);
+    expect(back.recurringTasks[0].completedDates).toEqual(['2026-08-10']); // already there → undone, unchanged
+    expect(back.undone).toBe(1);
+  });
+
+  it('a compound create→schedule→move history unwinds in reverse order to nothing', () => {
+    // Forward: created in inbox, scheduled to 08-10 09:00, moved to 08-12 15:00.
+    const state = { tasks: [T({ id: 'c1', title: 'Agent task', date: '2026-08-12', startTime: '15:00' })], unscheduledTasks: [] };
+    const ops = [ // reverse chronological, as buildUndoPlan produces
+      { kind: 'restore_block_fields', blockId: 'c1', before: { date: '2026-08-10', startTime: '09:00', isAllDay: false } },
+      { kind: 'restore_unscheduled', taskId: 'c1', beforeTask: { id: 'c1', title: 'Agent task', priority: 0 } },
+      { kind: 'remove_created', taskId: 'c1' },
+    ];
+    const r = run(state, ops);
+    expect(r.tasks).toEqual([]);
+    expect(r.unscheduledTasks).toEqual([]);
+    expect(r.undone).toBe(3);
+    expect(r.skipped).toBe(0);
+  });
+
+  it('remove_created also removes a created task the user later scheduled manually', () => {
+    const state = { tasks: [T({ id: 'c2', title: 'Created then dragged' })], unscheduledTasks: [] };
+    const r = run(state, [{ kind: 'remove_created', taskId: 'c2' }]);
+    expect(r.tasks).toEqual([]);
+    expect(r.undone).toBe(1);
+  });
+
+  it('restore_unscheduled never duplicates a task already back in the inbox', () => {
+    const state = {
+      tasks: [T({ id: 'u2', title: 'Dup risk' })],
+      unscheduledTasks: [{ id: 'u2', title: 'Dup risk' }],
+    };
+    const r = run(state, [{ kind: 'restore_unscheduled', taskId: 'u2', beforeTask: { id: 'u2', title: 'Dup risk' } }]);
+    expect(r.unscheduledTasks.filter((t) => t.id === 'u2')).toHaveLength(1);
+    expect(r.tasks).toEqual([]);
+  });
+
+  it('tolerant: user-deleted tasks, _native targets, and unknown ops are skipped, never errors', () => {
+    const state = { tasks: [NATIVE], unscheduledTasks: [] };
+    const r = run(state, [
+      { kind: 'restore_block_fields', blockId: 'gone', before: { duration: 30 } },
+      { kind: 'restore_block_fields', blockId: NATIVE.id, before: { duration: 30 } },
+      { kind: 'restore_completion', taskId: 'gone', before: { completed: false } },
+      { kind: 'restore_completion', taskId: NATIVE.id, before: { completed: true } },
+      { kind: 'restore_unscheduled', taskId: 'gone', beforeTask: { id: 'gone' } },
+      { kind: 'time_travel' },
+    ]);
+    expect(r.ok).toBe(true);
+    expect(r.undone).toBe(0);
+    expect(r.skipped).toBe(6);
+    expect(r.tasks).toEqual([NATIVE]); // native untouched — fields AND completion
   });
 });


### PR DESCRIPTION
Implements Phase 5b of `docs/mcp-server-spec.md` (§4.3 controls 3–4's journal surface, §6.5 visible state). Builds on the settings/consent work from #1361.

## Visible state (§6.5)

The listener's state now shows without opening settings:

- **Menu-bar glyph** while the MCP server is bound — `⌁` for read tiers, `⚡` when writes are enabled — *appended* to focus countdowns and the reminder dot, never displacing them (`composeTrayTitle`).
- **Tray popup strip** (new `TrayMcpStatus`, mounted in `TrayApp`): indicator, current tier spelled out (reads dayGLANCE data / incl. device calendar / + writes), one-click **kill switch**, and the write journal with **Undo all**.
- **Tray icon right-click menu**: the tier label plus a "Turn off MCP server" item — a pure main-process path that needs no window at all.

**Kill-switch relay (reported before implementing):** the `tray:background-action` relay is deliberately NOT used. That pattern forwards task mutations to the main window's renderer and silently drops when no main window exists. Turning the server off is a *config transition owned by the main process*, so the tray popup calls the existing `local-integrations:transition` `ipcMain.handle` directly, and the context-menu path calls the same `runIntegrationsTransition` in-process. Nothing to drop.

## Write journal (§4.3), session-scoped by design

Every successful non-replayed MCP write records tool, time, a display summary, the idempotency key when present, and a reversal op — in memory at module scope in the main process (never on the `McpServer` instance per §3.7, never on disk). It covers the runaway-agent case, not audit history; dying with the process is the point.

**Journal vs. snapshots (reported):** the journal alone cannot reverse everything — `applyScheduleTask` strips `priority`/`deadline`, and move/resize/completion overwrite values nothing else remembers. Each entry therefore carries before-state captured by the renderer at write time (full before-task for schedule, touched fields otherwise): ~400 B typical per entry, ~700 KB/hour at the 30/min rate limit, bounded in practice by the limiter + auto-disable.

## Bulk undo

One action reverses all session MCP writes (or all since the last undo), replaying the journal in **reverse chronological order** through `taskMutations.js applyUndoOps` — the same store layer as every write. So the reversal syncs, emits GLANCEintents, and fires `tray:data-changed` exactly like a UI edit, with no special handling (**confirmed**: intents emission is a prev→next state diff in `planTaskNotifyEmits`; sync + tray reload hang off `useSaveOnChange`'s data deps). Tolerant of user interference: tasks deleted/changed since the MCP write are skipped and counted, never errors. The journal clears only on a confirmed application — a failed undo (renderer unavailable) keeps every entry.

**Tray live state (reported):** listener state and journal arrive over IPC push (`local-integrations:status` / `mcp-journal:changed`, now also sent to the tray window), deliberately outside the popup's stale-snapshot reload cycle — the strip updates while the popup is open.

## Live verification (xvfb + CDP + real MCP HTTP client; tray simulated on Linux by patching the darwin gates in *compiled output only*, mimicking macOS keep-alive semantics)

1. **Indicator + tier**: strip renders in the real tray popup with "MCP server on" and the tier text; glyph/title/menu mapping mutation-verified (`mcpIndicator`, `composeTrayTitle`).
2. **Kill switch with no main window**: main window destroyed (only the tray target left), MCP still bound → clicked "Turn off" in the popup → port 7893 unbound, config persisted `off`, journal strip stayed (entries remain undoable). Bonus: "Undo all" with no main window surfaced the renderer-unavailable notice and kept the journal.
3. **Journal records every write**: all five tools journaled with tool, time, summary, and idempotency keys; a replayed create did **not** journal; before-state never leaks to the display surface.
4. **Bulk undo**: a create → schedule → move → resize → complete history (persisted as `2026-08-13 15:30`, 90 min, completed) fully unwound via the real button — task gone from both persisted lists, journal cleared, counts reported.
5. **No persistence across restart**: after a genuine process restart the journal reads 0 and a fresh write journals from seq 1. (First attempt was invalid — the old process had survived my kill and CDP was still talking to it; redone against a verified-fresh process.)
6. **Mutation-verified**: 27/27 mutants killed across journal recording, undo reconstruction, indicator mapping, and descriptor capture (one *equivalent* mutant — `before.completed: !completed` — documented and replaced in the harness, since non-replayed completion writes always satisfy it).

Full suite: 1527 tests / 102 files green; electron + preload `tsc` clean; eslint clean.

## Not tested live

The macOS menu-bar title itself (`tray.setTitle` is a no-op on Linux) and the native right-click menu click — both feed from the same mutation-verified pure functions and the same `killMcpServer`/`runIntegrationsTransition` path exercised live via the popup. `useElectronBridge.js` untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_