### PR TITLE
Local-integrations copy cleanup + corrupt-config recovery for Stream Deck

### DIFF
--- a/electron/localIntegrations.test.ts
+++ b/electron/localIntegrations.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   defaultConfig,
   decideStreamDeckMigration,
+  interpretConfigFile,
+  recoverFromConfigFile,
   normalizeConfig,
   mcpGates,
   applyTransition,
@@ -51,6 +53,67 @@ describe('decideStreamDeckMigration — the §6.2 blocking item', () => {
       .toEqual({ migrate: false });
     expect(decideStreamDeckMigration({ configFileExists: true, priorInstallEvidence: false }))
       .toEqual({ migrate: false });
+  });
+});
+
+describe('interpretConfigFile — corrupt is absent, not a choice', () => {
+  it('null content is absent', () => {
+    expect(interpretConfigFile(null)).toEqual({ state: 'absent' });
+  });
+
+  it('a parseable object is valid, normalized tolerantly', () => {
+    const config = enabledConfig();
+    expect(interpretConfigFile(JSON.stringify(config))).toEqual({ state: 'valid', config });
+    expect(interpretConfigFile('{}')).toEqual({ state: 'valid', config: defaultConfig() });
+  });
+
+  it('unparseable content is corrupt', () => {
+    for (const raw of ['{oops', '', 'not json at all', '{"mcp": }']) {
+      expect(interpretConfigFile(raw)).toEqual({ state: 'corrupt' });
+    }
+  });
+
+  it('parseable non-objects are corrupt too (no user wrote 42 as their config)', () => {
+    for (const raw of ['42', '"off"', '[]', 'null', 'true']) {
+      expect(interpretConfigFile(raw)).toEqual({ state: 'corrupt' });
+    }
+  });
+});
+
+describe('recoverFromConfigFile — the split failure mode (§6.2)', () => {
+  it('valid file: used as-is, never re-migrated (deliberate off stays off)', () => {
+    const off = JSON.stringify(defaultConfig()); // a user who turned everything off
+    const r = recoverFromConfigFile(off, true); // even with upgrade evidence present
+    expect(r.action).toBe('use');
+    expect(r.corrupt).toBe(false);
+    expect(r.config.streamDeck.enabled).toBe(false);
+  });
+
+  it('corrupt file + upgrade evidence: Stream Deck restored to ON, MCP stays off', () => {
+    const r = recoverFromConfigFile('{oops', true);
+    expect(r.action).toBe('migrate');
+    expect(r.corrupt).toBe(true);
+    expect(r.config.streamDeck).toEqual({ enabled: true, migratedFromUnconditional: true });
+    // MCP fails closed: the migration never enables it, whatever was in the file.
+    expect(r.config.mcp.readTier).toBe('off');
+    expect(r.config.mcp.writesEnabled).toBe(false);
+    expect(r.config.mcp.token).toBeNull();
+  });
+
+  it('corrupt file + no evidence: everything stays off', () => {
+    const r = recoverFromConfigFile('{oops', false);
+    expect(r.action).toBe('migrate');
+    expect(r.corrupt).toBe(true);
+    expect(r.config).toEqual(defaultConfig());
+  });
+
+  it('absent file migrates but is not flagged corrupt (nothing to preserve)', () => {
+    const withEvidence = recoverFromConfigFile(null, true);
+    expect(withEvidence).toMatchObject({ action: 'migrate', corrupt: false });
+    expect(withEvidence.config.streamDeck.enabled).toBe(true);
+    const fresh = recoverFromConfigFile(null, false);
+    expect(fresh).toMatchObject({ action: 'migrate', corrupt: false });
+    expect(fresh.config).toEqual(defaultConfig());
   });
 });
 

--- a/electron/localIntegrations.ts
+++ b/electron/localIntegrations.ts
@@ -7,9 +7,12 @@
 // unconditionally enabled since it existed. Introducing an off-by-default
 // toggle would silently kill every existing user's buttons on auto-update —
 // no error, dead keys. So existing installs MIGRATE TO ON exactly once, and
-// the config file itself is the one-time flag: once it exists, migration
-// never runs again, so a user's later "off" can never be re-enabled by an
-// update. Fresh installs start with everything off.
+// a READABLE config file is the one-time flag: while one exists and parses,
+// migration never runs again, so a user's later "off" can never be
+// re-enabled by an update. A corrupt/unparseable file is NOT a choice the
+// user made — it is treated as absent and the migration re-runs against the
+// on-disk evidence (see interpretConfigFile). Fresh installs start with
+// everything off.
 
 export type McpReadTier = 'off' | 'dayglance' | 'dayglance_calendar';
 
@@ -74,6 +77,69 @@ export function decideStreamDeckMigration(input: {
 }): { migrate: false } | { migrate: true; enabled: boolean } {
   if (input.configFileExists) return { migrate: false };
   return { migrate: true, enabled: input.priorInstallEvidence };
+}
+
+/**
+ * Classify the on-disk config file's CONTENT (main.ts owns the reading).
+ *
+ * - null (file absent, or unreadable with the read error swallowed upstream
+ *   mapped to '') → 'absent'
+ * - JSON that parses to a plain object → 'valid', normalized tolerantly
+ * - anything else (parse failure, or JSON that is not an object — no user
+ *   ever wrote `42` as their integrations config) → 'corrupt'
+ *
+ * 'corrupt' exists because the two integrations must fail DIFFERENTLY (§6.2):
+ * MCP fails closed — nobody consented to a listener, so off is right. Stream
+ * Deck fails OPEN to the migration: it ran unconditionally before the toggle
+ * existed, so a user with a mangled config would otherwise lose their buttons
+ * silently, blamed on a file they have never heard of. A corrupt file is
+ * therefore treated as ABSENT (re-run the migration against the on-disk
+ * evidence), not as an all-off choice the user never made.
+ */
+export function interpretConfigFile(fileContent: string | null):
+  | { state: 'absent' }
+  | { state: 'corrupt' }
+  | { state: 'valid'; config: LocalIntegrationsConfig } {
+  if (fileContent === null) return { state: 'absent' };
+  try {
+    const parsed: unknown = JSON.parse(fileContent);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return { state: 'valid', config: normalizeConfig(parsed) };
+    }
+  } catch {
+    // fall through: unparseable is corrupt
+  }
+  return { state: 'corrupt' };
+}
+
+/**
+ * The whole startup decision, pure: file content in, config out.
+ *
+ * - 'use': a valid config file is the sole authority (the one-time §6.2 flag
+ *   working as designed — a deliberate "off" survives every update).
+ * - 'migrate': absent OR corrupt content re-runs the §6.2 migration against
+ *   the prior-install evidence. Upgrade evidence restores Stream Deck to ON;
+ *   MCP stays off either way, because the migration never enables it — a
+ *   fresh consent is the only path to a bound listener.
+ *
+ * `corrupt` tells main.ts to preserve the unreadable file (moved aside, never
+ * overwritten in place) and to log the recovery.
+ */
+export function recoverFromConfigFile(
+  fileContent: string | null,
+  priorInstallEvidence: boolean,
+): { action: 'use' | 'migrate'; config: LocalIntegrationsConfig; corrupt: boolean } {
+  const interpreted = interpretConfigFile(fileContent);
+  if (interpreted.state === 'valid') {
+    return { action: 'use', config: interpreted.config, corrupt: false };
+  }
+  const decision = decideStreamDeckMigration({ configFileExists: false, priorInstallEvidence });
+  const config = defaultConfig();
+  if (decision.migrate && decision.enabled) {
+    config.streamDeck.enabled = true;
+    config.streamDeck.migratedFromUnconditional = true;
+  }
+  return { action: 'migrate', config, corrupt: interpreted.state === 'corrupt' };
 }
 
 /** Tolerant load: anything malformed collapses to safe defaults (everything off). */

--- a/electron/localIntegrations.ts
+++ b/electron/localIntegrations.ts
@@ -206,7 +206,7 @@ export function applyTransition(
 
     case 'rotate-token': {
       if (config.mcp.token === null) {
-        return { ok: false, error: 'No token to rotate — enable MCP first' };
+        return { ok: false, error: 'No token to rotate; enable MCP first' };
       }
       next.mcp.token = deps.generateToken();
       return { ok: true, config: next };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -20,8 +20,7 @@ import { generateMcpToken } from './mcpAuth.js';
 import { resolveMcpPort, describeBindFailure, DEFAULT_MCP_PORT } from './mcpPort.js';
 import {
   defaultConfig as defaultIntegrationsConfig,
-  decideStreamDeckMigration,
-  normalizeConfig as normalizeIntegrationsConfig,
+  recoverFromConfigFile,
   mcpGates,
   applyTransition as applyIntegrationsTransition,
   listenerEffects,
@@ -862,19 +861,20 @@ function saveIntegrationsConfig(): void {
 // Stream Deck on for users who never had it (§6.2 inverted).
 function loadOrMigrateIntegrationsConfig(): void {
   const cfgPath = integrationsConfigPath();
+
+  // Read the file; every decision about the CONTENT is pure and tested
+  // (localIntegrations.ts). A file that exists but cannot be read maps to ''
+  // (unparseable), so it takes the same corrupt-recovery path below.
+  let fileContent: string | null = null;
   if (fs.existsSync(cfgPath)) {
-    // The file's existence is the one-time migration flag: once it exists it
-    // is the sole authority, so a user's deliberate "off" survives every
-    // subsequent update. Unreadable content fails toward all-off — it never
-    // re-runs the migration.
     try {
-      integrationsConfig = normalizeIntegrationsConfig(JSON.parse(fs.readFileSync(cfgPath, 'utf-8')));
+      fileContent = fs.readFileSync(cfgPath, 'utf-8');
     } catch (err) {
-      console.error('[dayGLANCE] Unreadable local-integrations config; using defaults (all off):', err);
-      integrationsConfig = defaultIntegrationsConfig();
+      console.error('[dayGLANCE] local-integrations config could not be read:', err);
+      fileContent = '';
     }
-    return;
   }
+
   // Any userData artifact only a previous RUN could have written. The startup
   // log is deliberately not usable here — initStartupLog() already created it
   // for THIS run at module load.
@@ -882,17 +882,34 @@ function loadOrMigrateIntegrationsConfig(): void {
     fs.existsSync(winStatePath()) ||
     fs.existsSync(WINDOW_THEME_FILE()) ||
     fs.existsSync(path.join(app.getPath('userData'), STORAGE_MIGRATION_FLAG));
-  const decision = decideStreamDeckMigration({ configFileExists: false, priorInstallEvidence });
-  integrationsConfig = defaultIntegrationsConfig();
-  if (decision.migrate && decision.enabled) {
-    // Upgrade: the Stream Deck listener shipped unconditionally before this
-    // config existed, so existing users keep it ON with no action needed.
-    integrationsConfig.streamDeck.enabled = true;
-    integrationsConfig.streamDeck.migratedFromUnconditional = true;
+
+  const result = recoverFromConfigFile(fileContent, priorInstallEvidence);
+  integrationsConfig = result.config;
+  if (result.action === 'use') return;
+
+  if (result.corrupt) {
+    // A corrupt file is not a choice the user made: MCP fails closed (the
+    // migration never enables it), but Stream Deck re-migrates from the
+    // evidence so existing users keep their buttons. Preserve the corrupt
+    // file rather than overwriting it in place — it is the only record of
+    // what the user actually had.
+    const asidePath = `${cfgPath}.corrupt`;
+    try {
+      fs.rmSync(asidePath, { force: true }); // Windows rename refuses to overwrite
+      fs.renameSync(cfgPath, asidePath);
+      logStartup('local integrations: config unreadable; preserved as local-integrations.json.corrupt');
+      console.error(
+        `[dayGLANCE] local-integrations.json was unreadable. It was preserved as ${asidePath} and the Stream Deck migration re-ran.`,
+      );
+    } catch (err) {
+      console.error('[dayGLANCE] Failed to move the corrupt local-integrations config aside:', err);
+    }
   }
+
   saveIntegrationsConfig();
   logStartup(
-    `local integrations: config created (streamDeck ${integrationsConfig.streamDeck.enabled ? 'ON — upgrade migration' : 'off — fresh install'})`,
+    `local integrations: config ${result.corrupt ? 'recovered from corrupt file' : 'created'} ` +
+    `(streamDeck ${integrationsConfig.streamDeck.enabled ? 'ON — upgrade migration' : 'off — fresh install'})`,
   );
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -989,7 +989,7 @@ function startMcpListener(): void {
   });
   if (!srv) {
     // startMcpServer already logged why; mirror it into settings.
-    mcpStatus = { running: false, error: 'MCP server could not start — see the startup log for details.' };
+    mcpStatus = { running: false, error: 'MCP server could not start. See the startup log for details.' };
     pushIntegrationsStatus();
     return;
   }

--- a/electron/mcpPort.ts
+++ b/electron/mcpPort.ts
@@ -67,7 +67,7 @@ export function resolveMcpPort(override: unknown): PortResolution {
 export function describeBindFailure(port: number, err: { code?: string; message?: string }): string {
   if (err.code === 'EADDRINUSE') {
     return `MCP server could not start: port ${port} is already in use by another process. ` +
-      'Pick a different port explicitly — dayGLANCE will not scan for a free one, because ' +
+      'Pick a different port explicitly; dayGLANCE will not scan for a free one, because ' +
       'configured MCP clients point at a fixed port.';
   }
   if (err.code === 'EACCES') {

--- a/src/components/LocalIntegrationsSettings.jsx
+++ b/src/components/LocalIntegrationsSettings.jsx
@@ -21,12 +21,12 @@ import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 export const MCP_BASE_CONSENT = {
   title: 'Allow other apps to read your dayGLANCE data?',
   paragraphs: [
-    'This lets other applications running on this computer — typically an AI assistant such as Claude Desktop — read your dayGLANCE data: your schedule, tasks, goals, and projects.',
+    'This lets other applications running on this computer, typically an AI assistant such as Claude Desktop, read your dayGLANCE data: your schedule, tasks, goals, and projects.',
     'AI assistants usually send what they read to their AI provider over the internet as part of your conversations. Once another app has read your data, dayGLANCE cannot see or control what it does with it.',
     'This is outside dayGLANCE’s encryption and no-server-access guarantees: dayGLANCE itself still never uploads your data anywhere, but an app you connect might.',
     'Only apps on this computer that present your access token (shown in settings after enabling) can connect.',
   ],
-  accept: 'I understand — enable read access',
+  accept: 'I understand, enable read access',
 };
 
 // Required content (device calendar tier): must additionally NAME what it
@@ -35,21 +35,21 @@ export const MCP_BASE_CONSENT = {
 export const MCP_CALENDAR_CONSENT = {
   title: 'Also share device calendar events?',
   paragraphs: [
-    'This adds events from your device’s calendar accounts (work, school, shared family calendars) to what connected apps can read — not just data you created in dayGLANCE.',
+    'This adds events from your device’s calendar accounts (work, school, shared family calendars) to what connected apps can read, not just data you created in dayGLANCE.',
     'Calendar events often contain other people’s information: event titles, attendee names and emails, and details of meetings other people invited you to. You did not create that information, and those people have not agreed to share it with an AI assistant or any other app.',
     'Connected apps can read these events exactly like your dayGLANCE data, and typically send them to an AI provider over the internet.',
     'Leave this off to share only the data you created in dayGLANCE yourself.',
   ],
-  accept: 'I understand — include calendar events',
+  accept: 'I understand, include calendar events',
 };
 
 export const MCP_WRITES_CONSENT = {
   title: 'Allow connected apps to change your schedule?',
   paragraphs: [
-    'Connected apps will be able to add, complete, move, and edit tasks — the same changes you can make yourself — without asking you before each one.',
+    'Connected apps will be able to add, complete, move, and edit tasks (the same changes you can make yourself) without asking you before each one.',
     'Changes are rate-limited and can never touch device calendar events, but a misbehaving app could still rearrange or complete tasks you did not intend. You can turn this off at any time.',
   ],
-  accept: 'I understand — allow changes',
+  accept: 'I understand, allow changes',
 };
 
 const READ_TIER_OPTIONS = [
@@ -306,7 +306,7 @@ const LocalIntegrationsSettings = () => {
                 </div>
                 <p className={`text-xs ${textSecondary} mt-1`}>
                   {rotated
-                    ? 'New token generated — the old one no longer works. Update your MCP clients.'
+                    ? 'New token generated. The old one no longer works, so update your MCP clients.'
                     : 'Paste this into your MCP client as the Bearer token. Rotating it cuts off every client using the old one.'}
                 </p>
               </div>
@@ -330,7 +330,7 @@ const LocalIntegrationsSettings = () => {
                 </div>
                 <p className={`text-xs ${textSecondary} mt-1`}>
                   Endpoint: <code className={`px-1 py-0.5 rounded ${darkMode ? 'bg-gray-700' : 'bg-stone-200'}`}>http://127.0.0.1:{ports.mcpEffective ?? ports.mcpDefault}/mcp</code>
-                  {' '}— leave the port empty for the default. dayGLANCE never picks a different port by itself.
+                  {'. '}Leave the port empty for the default. dayGLANCE never picks a different port by itself.
                 </p>
               </div>
 


### PR DESCRIPTION
Two Phase 5a follow-ups.

## Corrupt-config recovery (§6.2 correction)

**Previous behavior:** a `local-integrations.json` that existed but could not be parsed fell to all-off and never re-ran the migration. The failure was effectively silent: one `console.error` to stderr (invisible in a packaged app), nothing in the startup log, no error state in settings, and the corrupt file stayed in place so every launch repeated all-off. A Stream Deck user with a mangled config lost their buttons with no signal anywhere.

**Now:** an unreadable or unparseable config is treated as **absent**, so the §6.2 migration re-runs against the on-disk evidence — upgrade machines get Stream Deck back ON; MCP stays off either way, because the migration never enables it (fail-closed stands for MCP, where nobody consented to a listener; a fresh consent is the only path to a bound one). The corrupt file is preserved as `local-integrations.json.corrupt` rather than overwritten in place, and the recovery is written to the startup log.

- Decisions are pure and tested: `interpretConfigFile` (absent / corrupt / valid) and `recoverFromConfigFile` in `localIntegrations.ts`; `main.ts` keeps only the read, the move-aside, and the logging. A **valid** config remains the sole authority — a deliberate all-off file is never re-migrated, even with upgrade evidence present.
- Boundary choice: parseable non-object JSON (`42`, `[]`, `"off"`) counts as corrupt — no user wrote that as a config. Object-shaped configs keep the existing tolerant per-field normalization.
- **Verified live** on the built branch, both required paths: corrupt config + `window-state.json` evidence → Stream Deck ON with `migratedFromUnconditional`, MCP off, token null, port 7892 bound, 7893 unbound, corrupt file preserved byte-for-byte, recovery line logged; corrupt config with no evidence → everything off, no ports, corrupt file preserved.
- **Mutation-verified:** 25/25 mutants killed, including six new recovery mutants (corrupt-as-valid regression, non-object acceptance, valid-config bypass, evidence ignored, provenance dropped, corrupt flag lost).

## Em-dash removal from user-facing copy

Every em dash is gone from the Phase 5a user-facing strings, rewritten with commas, colons, parentheses, or sentence breaks — no en dashes or hyphens substituted:

- Consent dialogs (`LocalIntegrationsSettings.jsx`): all §6.4 paragraphs and the accept-button labels. The whole file was swept, not just the dialog bodies; remaining em dashes in that file are code comments only, which never render.
- Settings hints: token-rotation notice, endpoint/port hint.
- Main-process strings surfaced in settings: the rotate-without-token refusal, the port-collision message (`describeBindFailure`), and the MCP fallback error.

Full suite: 1506 tests / 100 files green; `tsc` and eslint clean.