### PR TITLE
Fix MCP bulk-undo resurrection: undone creates move to the recycle bin

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6816,6 +6816,9 @@ const DayPlanner = () => {
     tasks,
     recurringTasks,
     unscheduledTasks,
+    // Bulk undo moves undone creates to the recycle bin (the UI's own delete
+    // shape), so the undo path needs the current bin to append to.
+    recycleBin,
     goals,
     projects,
     isVisibleForUser,
@@ -6829,6 +6832,7 @@ const DayPlanner = () => {
     setTasks,
     setUnscheduledTasks,
     setRecurringTasks,
+    setRecycleBin,
   });
 
   useElectronBridge({

--- a/src/utils/mcpWriteModel.js
+++ b/src/utils/mcpWriteModel.js
@@ -124,10 +124,14 @@ export function handleMcpWrite(state, setters, request) {
       // The §4.3 bulk undo. Not itself journaled (the main process clears the
       // journal on success), and applied through the same store layer as every
       // other write, so sync, GLANCEintents, and tray:data-changed all fire.
+      // Undone creates land in the recycle bin (cross-list move, the UI's own
+      // delete shape) so the vault propagates a legitimate delete instead of
+      // healing back a fingerprint-less vanish — see applyUndoOps.
       const r = applyUndoOps(state, params.ops, { nowIso });
       setters.setTasks(r.tasks);
       setters.setUnscheduledTasks(r.unscheduledTasks);
       setters.setRecurringTasks(r.recurringTasks);
+      setters.setRecycleBin(r.recycleBin);
       return { ok: true, data: { undone: r.undone, skipped: r.skipped } };
     }
     default:

--- a/src/utils/mcpWriteModel.test.js
+++ b/src/utils/mcpWriteModel.test.js
@@ -13,6 +13,7 @@ const makeSetters = () => ({
   setTasks: vi.fn(),
   setUnscheduledTasks: vi.fn(),
   setRecurringTasks: vi.fn(),
+  setRecycleBin: vi.fn(),
 });
 
 const B = (over = {}) => ({
@@ -113,12 +114,13 @@ describe('undo descriptors on write responses', () => {
 });
 
 describe('undo_mcp_writes', () => {
-  it('applies reversal ops through ALL three setters in one commit and reports counts', () => {
+  it('applies reversal ops through ALL four setters in one commit and reports counts', () => {
     const setters = makeSetters();
     const state = {
       tasks: [B({ id: 'c1', title: 'Agent task', date: '2026-08-12', startTime: '15:00' })],
       unscheduledTasks: [],
       recurringTasks: [],
+      recycleBin: [],
     };
     const r = handleMcpWrite(state, setters, {
       method: 'undo_mcp_writes',
@@ -134,9 +136,14 @@ describe('undo_mcp_writes', () => {
     expect(setters.setTasks).toHaveBeenCalledWith([]);
     expect(setters.setUnscheduledTasks).toHaveBeenCalledWith([]);
     expect(setters.setRecurringTasks).toHaveBeenCalledWith([]);
+    // The undone create lands in the recycle bin (cross-list sync fingerprint,
+    // and recoverable), never a bare vanish.
+    const [bin] = setters.setRecycleBin.mock.calls[0];
+    expect(bin).toHaveLength(1);
+    expect(bin[0]).toMatchObject({ id: 'c1', _deletedFrom: 'inbox' });
   });
 
-  it('restored tasks carry a fresh lastModified so sync propagates the undo', () => {
+  it('FIELD-UPDATE ops carry a fresh lastModified so LWW sync propagates them (remove_created is a bin move instead, tested in taskMutations)', () => {
     const setters = makeSetters();
     handleMcpWrite(
       { tasks: [B()], unscheduledTasks: [], recurringTasks: [] },

--- a/src/utils/taskMutations.js
+++ b/src/utils/taskMutations.js
@@ -208,6 +208,22 @@ export function applyResizeBlock(state, { blockId, durationMinutes, transitionId
  * GLANCEintents diff, and tray:data-changed all engage as for a UI edit.
  * Deliberately NOT pushed onto the user's undo stack (it IS the undo).
  *
+ * SYNC SHAPE, per op kind — the two halves fail differently and the guard
+ * in src/sync/snapshotDeleteGuard.js polices the difference:
+ *  - The four restore_* kinds are FIELD UPDATES stamped with a fresh
+ *    lastModified, so newest-write-wins carries the reversal fleet-wide.
+ *  - remove_created is a DELETION, and a bare array filter is exactly the
+ *    fingerprint-less vanish partitionSnapshotDeletes classifies as a
+ *    'glitch' and healGlitchSkips actively restores from the vault (the
+ *    undone task reappeared seconds later — the resurrection bug). So it is
+ *    a RECYCLE-BIN MOVE instead, the same cross-list shape as the UI's
+ *    moveToRecycleBin in useTaskActions.js, including the anti-zombie stamp
+ *    (deletedAt = lastModified = max(now, task.lastModified + 1s)). The bin
+ *    also keeps a whole-session undo itself recoverable, which a tombstone
+ *    would not. No MCP-provenance marker on the bin entry — the shape is
+ *    synced and consumed by undeleteTask on every device; a field nothing
+ *    displays is scope creep (deliberate skip, revisit on user demand).
+ *
  * Tolerant by design: a task the user deleted or edited away since the MCP
  * write is SKIPPED and counted, never an error — the user's own actions
  * outrank the reversal. _native can never appear here (every forward write
@@ -217,16 +233,36 @@ export function applyUndoOps(state, ops, { nowIso }) {
   let tasks = state.tasks ?? [];
   let unscheduled = state.unscheduledTasks ?? [];
   let recurring = state.recurringTasks ?? [];
+  let recycleBin = state.recycleBin ?? [];
   let undone = 0;
   let skipped = 0;
 
   for (const op of ops ?? []) {
     switch (op?.kind) {
       case 'remove_created': {
-        const before = tasks.length + unscheduled.length;
+        const inScheduled = tasks.find((t) => t.id === op.taskId);
+        const inInbox = unscheduled.find((t) => t.id === op.taskId);
+        const task = inInbox ?? inScheduled;
+        if (!task || task._native) { skipped += 1; break; }
+        const actuallyInInbox = !!inInbox && !inScheduled;
+        // The UI's anti-zombie stamp (useTaskActions.js moveToRecycleBin):
+        // strictly newer than the task's own lastModified, so the bin entry
+        // survives horizon pruning and wins the cross-list reconciliation.
+        const deletedStamp = new Date(
+          Math.max(Date.parse(nowIso), (task.lastModified ? Date.parse(task.lastModified) : 0) + 1000),
+        ).toISOString();
+        const binEntry = {
+          ...task,
+          _deletedFrom: actuallyInInbox ? 'inbox' : 'calendar',
+          deletedAt: deletedStamp,
+          lastModified: deletedStamp,
+        };
         tasks = tasks.filter((t) => t.id !== op.taskId);
         unscheduled = unscheduled.filter((t) => t.id !== op.taskId);
-        if (tasks.length + unscheduled.length < before) undone += 1; else skipped += 1;
+        if (!recycleBin.some((t) => t.id === op.taskId)) {
+          recycleBin = [...recycleBin, binEntry];
+        }
+        undone += 1;
         break;
       }
       case 'restore_unscheduled': {
@@ -284,7 +320,7 @@ export function applyUndoOps(state, ops, { nowIso }) {
     }
   }
 
-  return { ok: true, tasks, unscheduledTasks: unscheduled, recurringTasks: recurring, undone, skipped };
+  return { ok: true, tasks, unscheduledTasks: unscheduled, recurringTasks: recurring, recycleBin, undone, skipped };
 }
 
 export function applySetCompletion(state, { taskId, completed, transitionId, todayStr, nowIso }) {

--- a/src/utils/taskMutations.test.js
+++ b/src/utils/taskMutations.test.js
@@ -270,12 +270,31 @@ describe('applyUndoOps — the §4.3 bulk undo (Phase 5b)', () => {
   const NOW2 = '2026-08-10T13:00:00.000Z';
   const run = (state, ops) => applyUndoOps(state, ops, { nowIso: NOW2 });
 
-  it('remove_created deletes the created task from either list', () => {
-    const state = { tasks: [T({ id: 's1' })], unscheduledTasks: [{ id: 'c1', title: 'Created' }] };
+  it('remove_created is a recycle-bin move (the UI delete shape), not a bare removal', () => {
+    const state = { tasks: [T({ id: 's1' })], unscheduledTasks: [{ id: 'c1', title: 'Created', lastModified: '2026-08-10T09:00:00.000Z' }], recycleBin: [] };
     const r = run(state, [{ kind: 'remove_created', taskId: 'c1' }]);
     expect(r.unscheduledTasks).toEqual([]);
+    expect(r.recycleBin).toHaveLength(1);
+    // The exact shape undeleteTask (useRecycleBin.js) consumes on restore:
+    // _deletedFrom routes the destination, deletedAt is stripped.
+    expect(r.recycleBin[0]).toMatchObject({
+      id: 'c1', title: 'Created', _deletedFrom: 'inbox', deletedAt: NOW2, lastModified: NOW2,
+    });
     expect(r.undone).toBe(1);
     expect(state.unscheduledTasks).toHaveLength(1); // pure: input untouched
+    expect(state.recycleBin).toEqual([]);
+  });
+
+  it('remove_created carries the anti-zombie stamp: strictly newer than the task lastModified', () => {
+    // A task whose lastModified IS the undo instant (stamped by an earlier op
+    // in the same pass) must get deletedAt = lastModified + 1s, exactly like
+    // moveToRecycleBin — a same-instant stamp would lose the cross-list
+    // reconciliation and resurrect (the zombie the UI comment describes).
+    const state = { tasks: [], unscheduledTasks: [{ id: 'c1', title: 'x', lastModified: NOW2 }], recycleBin: [] };
+    const r = run(state, [{ kind: 'remove_created', taskId: 'c1' }]);
+    const expected = new Date(Date.parse(NOW2) + 1000).toISOString();
+    expect(r.recycleBin[0].deletedAt).toBe(expected);
+    expect(r.recycleBin[0].lastModified).toBe(expected);
   });
 
   it('restore_unscheduled moves the block back to the inbox with the FULL before-task (priority/deadline survive)', () => {
@@ -324,9 +343,9 @@ describe('applyUndoOps — the §4.3 bulk undo (Phase 5b)', () => {
     expect(back.undone).toBe(1);
   });
 
-  it('a compound create→schedule→move history unwinds in reverse order to nothing', () => {
+  it('a compound create→schedule→move history unwinds in reverse order into the bin', () => {
     // Forward: created in inbox, scheduled to 08-10 09:00, moved to 08-12 15:00.
-    const state = { tasks: [T({ id: 'c1', title: 'Agent task', date: '2026-08-12', startTime: '15:00' })], unscheduledTasks: [] };
+    const state = { tasks: [T({ id: 'c1', title: 'Agent task', date: '2026-08-12', startTime: '15:00' })], unscheduledTasks: [], recycleBin: [] };
     const ops = [ // reverse chronological, as buildUndoPlan produces
       { kind: 'restore_block_fields', blockId: 'c1', before: { date: '2026-08-10', startTime: '09:00', isAllDay: false } },
       { kind: 'restore_unscheduled', taskId: 'c1', beforeTask: { id: 'c1', title: 'Agent task', priority: 0 } },
@@ -335,15 +354,24 @@ describe('applyUndoOps — the §4.3 bulk undo (Phase 5b)', () => {
     const r = run(state, ops);
     expect(r.tasks).toEqual([]);
     expect(r.unscheduledTasks).toEqual([]);
+    expect(r.recycleBin.map((t) => t.id)).toEqual(['c1']); // recoverable, and a sync fingerprint
     expect(r.undone).toBe(3);
     expect(r.skipped).toBe(0);
   });
 
-  it('remove_created also removes a created task the user later scheduled manually', () => {
-    const state = { tasks: [T({ id: 'c2', title: 'Created then dragged' })], unscheduledTasks: [] };
+  it('remove_created on a created task the user later scheduled manually bins it as a calendar delete', () => {
+    const state = { tasks: [T({ id: 'c2', title: 'Created then dragged' })], unscheduledTasks: [], recycleBin: [] };
     const r = run(state, [{ kind: 'remove_created', taskId: 'c2' }]);
     expect(r.tasks).toEqual([]);
+    expect(r.recycleBin[0]).toMatchObject({ id: 'c2', _deletedFrom: 'calendar' });
     expect(r.undone).toBe(1);
+  });
+
+  it('remove_created skips a task already gone (user deleted it) without touching the bin', () => {
+    const state = { tasks: [], unscheduledTasks: [], recycleBin: [{ id: 'c3', title: 'already binned' }] };
+    const r = run(state, [{ kind: 'remove_created', taskId: 'gone' }, { kind: 'remove_created', taskId: 'c3' }]);
+    expect(r.skipped).toBe(2); // missing entirely, and only-in-bin: nothing to move
+    expect(r.recycleBin).toHaveLength(1);
   });
 
   it('restore_unscheduled never duplicates a task already back in the inbox', () => {
@@ -354,6 +382,44 @@ describe('applyUndoOps — the §4.3 bulk undo (Phase 5b)', () => {
     const r = run(state, [{ kind: 'restore_unscheduled', taskId: 'u2', beforeTask: { id: 'u2', title: 'Dup risk' } }]);
     expect(r.unscheduledTasks.filter((t) => t.id === 'u2')).toHaveLength(1);
     expect(r.tasks).toEqual([]);
+  });
+
+  it('SYNC SHAPE: an undone create classifies as a cross-list move, never a glitch (the resurrection bug)', async () => {
+    // The property that was previously unasserted: the vault push guard
+    // (src/sync/snapshotDeleteGuard.js) must see the undone create as a
+    // legitimate delete. A bare filter leaves no fingerprint — no tombstone,
+    // no surviving copy under another kind — which the guard classifies as
+    // 'glitch', skips, and heals BACK from the vault: the undone task
+    // reappeared seconds later on any machine with GLANCEvault active.
+    const { partitionSnapshotDeletes } = await import('../sync/snapshotDeleteGuard.js');
+    const { TASK_KINDS } = await import('../sync/dbAdapter.js');
+
+    const state = { tasks: [], unscheduledTasks: [{ id: 'c1', title: 'Created', lastModified: NOW2 }], recycleBin: [] };
+    const r = run(state, [{ kind: 'remove_created', taskId: 'c1' }]);
+
+    // Shred the post-undo state the way the engine does: entityId = 'kind:id'
+    // per task-shaped kind (dbAdapter.js TASK_KINDS).
+    const slices = { tasks: r.tasks, unscheduledTasks: r.unscheduledTasks, recurringTasks: r.recurringTasks, recycleBin: r.recycleBin };
+    const cur = {};
+    for (const kind of TASK_KINDS) {
+      for (const t of slices[kind] ?? []) cur[`${kind}:${t.id}`] = '{}';
+    }
+
+    // The snapshot diff wants to delete the vanished inbox row; no tombstone
+    // bundles exist (mirror empty) — only the bin copy can legitimize it.
+    const verdict = partitionSnapshotDeletes(['unscheduledTasks:c1'], cur, {});
+    expect(verdict.reasons['unscheduledTasks:c1']).toBe('cross-list');
+    expect(verdict.propagate).toEqual(['unscheduledTasks:c1']);
+    expect(verdict.skipped).toEqual([]);
+
+    // Discriminating control: the OLD behavior (no bin entry) is exactly the
+    // fingerprint-less vanish the guard skips as a suspected glitch — this is
+    // what the fix exists to prevent, pinned so a regression cannot pass.
+    const curWithoutBin = { ...cur };
+    delete curWithoutBin['recycleBin:c1'];
+    const regression = partitionSnapshotDeletes(['unscheduledTasks:c1'], curWithoutBin, {});
+    expect(regression.reasons['unscheduledTasks:c1']).toBe('glitch');
+    expect(regression.skipped).toEqual(['unscheduledTasks:c1']);
   });
 
   it('tolerant: user-deleted tasks, _native targets, and unknown ops are skipped, never errors', () => {


### PR DESCRIPTION
Fixes the bug where bulk-undoing an MCP `create_task` appeared to succeed and the task reappeared seconds later with GLANCEvault sync active.

## Cause

`remove_created` in `applyUndoOps` was a bare array filter — exactly the fingerprint-less vanish the vault's snapshot-delete guard exists to defeat. `partitionSnapshotDeletes` classified it `'glitch'`, skipped the delete, and `healGlitchSkips` re-fetched the row from the vault and re-committed it. With WiFi off the task stayed gone, which was the tell.

## Fix (recycle-bin shape, per decision)

`remove_created` is now a **recycle-bin move**, the same cross-list shape as the UI's own delete (`moveToRecycleBin` in `useTaskActions.js`), including the **anti-zombie stamp**: `deletedAt = lastModified = max(now, task.lastModified + 1s)`, computed purely from the injected `nowIso`. The guard classifies the vanish `'cross-list'` and propagates a legitimate delete; the bin entry survives horizon pruning, wins the cross-list reconciliation (`CROSS_LIST_PRIORITY` puts `recycleBin` first), and keeps a whole-session undo itself recoverable. `_deletedFrom` is set from where the task actually was (`'inbox'`/`'calendar'`), so `undeleteTask` routes the restore correctly.

- **No MCP-provenance marker** on the bin entry — deliberate skip: the shape is synced and consumed cross-device, and a field nothing displays is scope creep.
- Setter surface grows by `setRecycleBin` in the undo path only (`undo_mcp_writes` case + the `useMcpBridge` wiring in App.jsx). The five forward write paths and the other four op kinds are unchanged. `useElectronBridge.js` untouched.

## The sync-shaped test

The previous mutants passed while the sync claim was false because nothing asserted the property that actually matters. The new test shreds post-undo state with the real `TASK_KINDS` and feeds it to the **real** `partitionSnapshotDeletes`: the undone create must classify `'cross-list'` and propagate, and a discriminating control pins that the old shape (no bin entry) classifies `'glitch'` and is skipped. Additional tests pin the anti-zombie stamp (same-instant `lastModified` → `+1s`), the restore destination, the `undeleteTask`-compatible entry shape, and skip behavior for tasks the user already deleted.

**Mutation-verified, 33/33 killed**, including six fix-specific mutants: the bare-filter regression itself, stamp downgraded to bare `nowIso`, destination hardwired, bin `lastModified` left stale, scheduled copy surviving, and `setRecycleBin` dropped.

## Claim correction

The Phase 5b statement "undone tasks carry a fresh `lastModified` so sync propagates the undo" covered the four field-update op kinds and never covered `remove_created` — corrected in the `applyUndoOps` header (which now documents the per-kind sync shape) and the overstated test name. The spec carries no such claim (checked).

## Verified / handed back

- **Verified live** (built branch, real MCP HTTP client): create → bulk undo → task absent from both lists, present in the recycle bin with the correct shape and stamp, shown in the Recycle Bin UI ("Inbox • 30min"), and **restored to the inbox through the real Restore button** (metadata stripped, fresh `lastModified`).
- **Verified at the guard level**: the exact classification that chooses between a propagated delete and the `GUARD: skipped N vanish-delete(s)` log, against the real guard function.
- **Handed back for hardware**: the full vault round trip — no reappearance after a real GLANCEvault sync cycle, and the push log showing a legitimate delete rather than the GUARD skip (criteria 1–2 need a real vault; enable `dayglance-debug-push` to see the propagation reason, expected `cross-list`).

Full suite: 1538 tests / 102 files green; tsc and eslint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_