### PR TITLE
Fix MAS compile-out: compose files exclusions, stop extraResources concat

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -62,7 +62,20 @@ module.exports = {
   // otherwise ship inside the app bundle, exposing readable source with no runtime
   // benefit. tsconfig keeps sourceMap on for local debugging; this drops them from
   // the packaged build only.
-  files: ['dist/**/*', 'dist-electron/**/*', '!**/*.map'],
+  //
+  // The MAS §7 exclusions live HERE, in the same array as the positives, not in a
+  // per-target mas.files block. electron-builder normalizes this top-level array
+  // into one file-set matcher; a per-target files array becomes a SEPARATE matcher
+  // whose negations cannot exclude anything the top-level matcher includes (the
+  // walks are unioned). Worse, a negation-only per-target array gets '**/*'
+  // prepended, which drags the whole project directory into app.asar.
+  // scripts/verify-mas-compileout.mjs asserts both properties on built artifacts.
+  files: [
+    'dist/**/*',
+    'dist-electron/**/*',
+    '!**/*.map',
+    ...(isMasBuild ? ['!dist-electron/mcpDesktopSetup*', '!dist-electron/mcpDesktopConfig*'] : []),
+  ],
   mac: {
     // null → ad-hoc (dev); undefined → electron-builder auto-selects the signing
     // cert from the Keychain (Developer ID when CSC_LINK is set; the Apple
@@ -82,12 +95,15 @@ module.exports = {
     // Bundle the signed EventKit calendar helper (built by scripts/build-calendar-helper.sh)
     // into Contents/Resources/calendar-helper. electron-builder signs nested binaries.
     // The MCP bridge (spec §3.2) rides along into Contents/Resources/mcp-bridge for
-    // DIRECT builds only: the mas block below declares its OWN extraResources (which
-    // replaces this array), so the bridge never enters the MAS artifact — MAS links
-    // to documentation instead (§7). scripts/verify-mas-compileout.mjs asserts this.
+    // DIRECT builds only, so it is conditionally omitted here. It must NOT be handled
+    // by giving the mas block its own extraResources: electron-builder's deepAssign
+    // CONCATENATES arrays when merging mac options into mas options (it does not
+    // replace them), so anything listed here rides into the MAS artifact regardless
+    // of what the mas block declares. MAS links to documentation instead (§7).
+    // scripts/verify-mas-compileout.mjs asserts this against the built artifact.
     extraResources: [
       { from: 'electron/native/calendar-helper/build/dayglance-calendar-helper', to: 'calendar-helper/dayglance-calendar-helper' },
-      { from: 'node_modules/@glance-apps/mcp-bridge', to: 'mcp-bridge' },
+      ...(isMasBuild ? [] : [{ from: 'node_modules/@glance-apps/mcp-bridge', to: 'mcp-bridge' }]),
     ],
     target: [
       { target: 'dmg', arch: ['x64', 'arm64'] },
@@ -99,13 +115,12 @@ module.exports = {
     // of the MAS artifact, not runtime-gated. Two mechanisms: the renderer's
     // button is dead-code-eliminated by the __MAS_BUILD__ define (see
     // vite.config.electron.js and the build:electron:mas script), and the
-    // main-process setup modules are excluded from packaging right here.
+    // main-process setup modules are excluded from packaging by the isMasBuild
+    // conditional in the TOP-LEVEL files array above — deliberately not by a
+    // files array here, which would become a separate matcher whose negations
+    // don't compose (see the comment on the top-level files array).
     // main.ts loads mcpDesktopSetup dynamically, so this absence is a no-op.
     // Verify against the built artifact with scripts/verify-mas-compileout.mjs.
-    files: [
-      '!dist-electron/mcpDesktopSetup*',
-      '!dist-electron/mcpDesktopConfig*',
-    ],
     hardenedRuntime: false, // MAS builds must NOT use Hardened Runtime — sandbox replaces it
     entitlements: 'electron/entitlements.mas.plist',
     // Child binaries (Electron Helpers + bundled Swift helpers) get the minimal
@@ -124,9 +139,10 @@ module.exports = {
       // App Store Connect from prompting for encryption docs on every upload.
       ITSAppUsesNonExemptEncryption: false,
     },
-    extraResources: [
-      { from: 'electron/native/calendar-helper/build/dayglance-calendar-helper', to: 'calendar-helper/dayglance-calendar-helper' },
-    ],
+    // No extraResources here: deepAssign CONCATENATES this array with mac's when
+    // merging (declaring the calendar helper again would copy it twice). The MAS
+    // artifact inherits mac's extraResources, which the isMasBuild conditional
+    // above already trims to the calendar helper only.
     // Universal (x86_64 + arm64) so the App Store accepts the build for every Mac.
     // Without this it defaults to the host arch only (arm64), which Apple rejects
     // unless the deployment target is 12.0+. The bundled Swift helpers are already

--- a/scripts/verify-mas-compileout.mjs
+++ b/scripts/verify-mas-compileout.mjs
@@ -55,6 +55,18 @@ check('dist-electron/mcpDesktopSetup.js in app.asar', asarList.includes('/dist-e
 check('dist-electron/mcpDesktopConfig.js in app.asar', asarList.includes('/dist-electron/mcpDesktopConfig.js'));
 check('Resources/mcp-bridge bundled bridge', existsSync(join(resourcesDir, 'mcp-bridge', 'bridge.js')));
 
+// Bloat guard, both modes: no source or project directory may ever reach the
+// asar. electron-builder 26 prepends '**/*' to a matcher containing only
+// negations (see electron-builder.config.cjs), which once packaged the whole
+// repo — sources, docs, session config — into a MAS candidate. The four §7
+// checks above would all pass on a direct build with this regression, so it
+// gets its own unconditional assertion.
+for (const dir of ['electron', 'docs', '.claude', 'dayglance-ios']) {
+  const present = asarList.split('\n').some((l) => l.startsWith(`/${dir}/`));
+  console.log(`${present ? 'FAIL' : 'OK  '} project dir /${dir} in app.asar: ${present ? 'present' : 'absent'} (expected absent)`);
+  if (present) problems.push(`/${dir} in app.asar`);
+}
+
 // The renderer bundle: grep the whole asar blob for the button's user-facing
 // string. Grepping the container is crude but exactly right here: if the
 // bytes are anywhere in the artifact, the path is not compiled out.

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -10,6 +10,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "sourceMap": true,
+    // Comments must not reach the packaged app: §7 verification greps the whole
+    // app.asar for feature markers (e.g. "Set up Claude Desktop"), and a comment
+    // anywhere in compiled main-process code would fail a MAS build. Sources and
+    // sourcemaps keep local debugging intact.
+    "removeComments": true,
     "types": ["node", "electron", "ws"]
   },
   "include": ["electron"],

--- a/tsconfig.electron.preload.json
+++ b/tsconfig.electron.preload.json
@@ -10,6 +10,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "sourceMap": true,
+    // Same rationale as tsconfig.electron.json: compiled comments would trip the
+    // §7 whole-asar marker grep (preload.ts mentions the setup button by name).
+    "removeComments": true,
     "types": ["node", "electron"]
   },
   "include": ["electron/preload.ts"]


### PR DESCRIPTION
## Summary

The Phase 6 MAS artifact failed all four §7 checks (App Store 2.5.2 exposure). Root causes were two electron-builder 26 behaviors, confirmed by instrumenting its file filter on a Linux repro of the MAS pack:

1. **Per-target `files` negations don't compose with top-level `files`.** electron-builder normalizes the top-level string array into an object file-set, which becomes a *separate matcher*; matcher walks are unioned, so the mas negations could never exclude the setup modules. Worse, a negation-only per-target array gets `'**/*'` prepended — the MAS asar contained the **entire project directory** (43 MB vs 25 MB, incl. `electron/*.ts`, `docs/`, `.claude/`, `dayglance-ios/`). Fix: the §7 exclusions join the top-level `files` array conditionally on `isMasBuild`, sharing one matcher.
2. **`deepAssign` concatenates arrays** when merging mac options into mas options — mac's mcp-bridge `extraResources` entry rode into the MAS artifact regardless of the mas block's own list (the config comment claiming "replaces" was wrong). Fix: the bridge entry is conditionally omitted from `mac.extraResources` on `isMasBuild`; the mas block declares no `extraResources` at all.

Also:
- **`removeComments` in both electron tsconfigs** — §7 verification greps the whole asar for the marker string, and compiled comments (`preload.ts` names the setup button) would fail a MAS build even with the modules excluded. Chosen over rewording one comment because any future comment naming the feature would silently re-fail §7. The direct build's marker check now passes via the renderer's actual button label.
- **Bloat guard in `verify-mas-compileout.mjs`** — `/electron`, `/docs`, `/.claude`, `/dayglance-ios` must be absent from the asar in *both* modes; the four §7 checks all pass on a direct build even with the whole-project regression.

### Not a live exposure

The pre-Phase-6 config had no `mas.files` block, so released MAS builds (4.3.0 and earlier) never contained the project directory — verified against a pre-Phase-6 direct artifact (`dist`, `dist-electron`, `node_modules`, `package.json` only). The regression existed only between the Phase 6 merge and this fix, with no App Store upload in that window.

### Verification (Linux repro harness, unsigned mac packs)

- MAS pack (`--mac mas --x64`, `DAYGLANCE_MAS_BUILD=1` + `DAYGLANCE_APP_ID` set): **all 8 checks pass**, asar back to 25 MB with only `dist`, `dist-electron`, `node_modules`, `package.json` at the root
- Direct pack (`--mac dir --x64`, no env): **all 8 checks pass** (modules, bridge, and marker present; project dirs absent)
- `npx vitest run`: 105 files, 1602/1602 passing; both electron tsconfigs typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_