### PR TITLE
Bump @glance-apps/mcp-bridge to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       "devDependencies": {
         "@electron/notarize": "^3.1.1",
         "@eslint/js": "^9.39.4",
-        "@glance-apps/mcp-bridge": "^0.1.0",
+        "@glance-apps/mcp-bridge": "^0.1.1",
         "@modelcontextprotocol/client": "2.0.0",
         "@types/node": "^24.0.0",
         "@types/react": "^18.2.15",
@@ -2608,9 +2608,9 @@
       }
     },
     "node_modules/@glance-apps/mcp-bridge": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/mcp-bridge/-/mcp-bridge-0.1.0.tgz",
-      "integrity": "sha512-NQaExU+lK7wsNwTbvaIGTE9e/KsC2b4fJUTLw6vzBTcJiJ6AWrzHYGakORNK2av2vyWt1grHU0KDVUaEuFDqJg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@glance-apps/mcp-bridge/-/mcp-bridge-0.1.1.tgz",
+      "integrity": "sha512-VebyC6yNBstgNoCAQC5iollg6DK5FLQubwK+6DO3I7qIrnU6kXGXSqZNMAtfmzenFK8Kq+P04gRlrTiR/m5lNQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@electron/notarize": "^3.1.1",
     "@eslint/js": "^9.39.4",
-    "@glance-apps/mcp-bridge": "^0.1.0",
+    "@glance-apps/mcp-bridge": "^0.1.1",
     "@modelcontextprotocol/client": "2.0.0",
     "@types/node": "^24.0.0",
     "@types/react": "^18.2.15",


### PR DESCRIPTION
## Summary

Aligns the bundled bridge with the published 0.1.1 release, which treats unexpanded Claude Desktop `${user_config.*}` templates as unset (blank Token/Port fields in the extension no longer shadow the discovery file and 401). The bundled-bridge path dayGLANCE ships never hits that bug — the app spawns the bridge without those env templates — so this is version alignment with the npm/`.mcpb` release, not an app behavior change.

## Verification

- Lockfile resolves `0.1.1` from the npm registry with integrity hash; installed copy contains the template guard
- `npm ci` clean from scratch
- Full suite: 105 files, 1602/1602 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_