### PR TITLE
Replace execSync with argv-based spawnSync in codesign hook

### DIFF
--- a/scripts/codesign-ad-hoc.cjs
+++ b/scripts/codesign-ad-hoc.cjs
@@ -11,8 +11,18 @@
 // the xattr/detritus cleanup still runs (it's harmless and prevents codesign
 // failures on CI), but the ad-hoc --sign - step is skipped.
 
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const path = require('path');
+
+exports._spawnSync = spawnSync;
+
+function runOrThrow(command, args) {
+  const result = exports._spawnSync(command, args, { stdio: 'inherit' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`[codesign-ad-hoc] ${command} exited with status ${result.status}`);
+  }
+}
 
 exports.default = async function codesignAdHoc({ appOutDir, packager, electronPlatformName }) {
   if (packager.platform.name !== 'mac') return;
@@ -26,9 +36,9 @@ exports.default = async function codesignAdHoc({ appOutDir, packager, electronPl
   // xattr -cr handles all file types including symlinks inside Electron frameworks
   // (e.g. Versions/Current) that the previous find -not -type l approach skipped.
   console.log(`[codesign-ad-hoc] Removing ._* resource fork files from ${appPath}`);
-  execSync(`find ${JSON.stringify(appPath)} -name "._*" -delete`);
+  runOrThrow('find', [appPath, '-name', '._*', '-delete']);
   console.log(`[codesign-ad-hoc] Clearing xattrs on ${appPath}`);
-  execSync(`xattr -cr ${JSON.stringify(appPath)}`);
+  runOrThrow('xattr', ['-cr', appPath]);
   // MAS builds are always signed by electron-builder with the Mac App Store
   // distribution identity (from the keychain) — never ad-hoc sign them, or the
   // App Store signature would be invalid. The xattr cleanup above still helps.
@@ -41,5 +51,7 @@ exports.default = async function codesignAdHoc({ appOutDir, packager, electronPl
     return;
   }
   console.log(`[codesign-ad-hoc] Signing ${appPath}`);
-  execSync(`codesign --sign - --deep --force ${JSON.stringify(appPath)}`);
+  runOrThrow('codesign', ['--sign', '-', '--deep', '--force', appPath]);
 };
+
+exports.runOrThrow = runOrThrow;

--- a/scripts/codesign-ad-hoc.test.js
+++ b/scripts/codesign-ad-hoc.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const mod = require('./codesign-ad-hoc.cjs');
+const codesignAdHoc = mod.default;
+const { runOrThrow } = mod;
+
+const mockSpawnSync = vi.fn();
+
+beforeEach(() => {
+  mockSpawnSync.mockReset();
+  mockSpawnSync.mockReturnValue({ status: 0, error: null });
+  mod._spawnSync = mockSpawnSync;
+  delete process.env.CSC_LINK;
+});
+
+describe('runOrThrow', () => {
+  it('does not throw when command succeeds', () => {
+    mockSpawnSync.mockReturnValue({ status: 0, error: null });
+    expect(() => runOrThrow('codesign', ['--sign', '-'])).not.toThrow();
+  });
+
+  it('throws when command exits with non-zero status', () => {
+    mockSpawnSync.mockReturnValue({ status: 1, error: null });
+    expect(() => runOrThrow('codesign', ['--sign', '-']))
+      .toThrow('[codesign-ad-hoc] codesign exited with status 1');
+  });
+
+  it('throws the spawn error when the executable cannot be started', () => {
+    const err = new Error('spawn codesign ENOENT');
+    err.code = 'ENOENT';
+    mockSpawnSync.mockReturnValue({ status: null, error: err });
+    expect(() => runOrThrow('codesign', ['--sign', '-']))
+      .toThrow('ENOENT');
+  });
+
+  it('passes arguments as an array without shell splitting', () => {
+    mockSpawnSync.mockReturnValue({ status: 0, error: null });
+    runOrThrow('codesign', ['--sign', '-', '/path/with spaces/App.app']);
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'codesign',
+      ['--sign', '-', '/path/with spaces/App.app'],
+      { stdio: 'inherit' },
+    );
+  });
+});
+
+describe('codesignAdHoc', () => {
+  it('skips entirely on non-mac platforms', async () => {
+    const ctx = {
+      appOutDir: '/build/mac-arm64',
+      packager: { platform: { name: 'linux' }, appInfo: { productName: 'dayGLANCE' } },
+      electronPlatformName: 'darwin',
+    };
+    await codesignAdHoc(ctx);
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('preserves appOutDir containing .. without rewriting', async () => {
+    const ctx = {
+      appOutDir: '/build/../output/mac-arm64',
+      packager: { platform: { name: 'mac' }, appInfo: { productName: 'dayGLANCE' } },
+      electronPlatformName: 'darwin',
+    };
+    await codesignAdHoc(ctx);
+    const expectedPath = path.join('/build/../output/mac-arm64', 'dayGLANCE.app');
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'find',
+      [expectedPath, '-name', '._*', '-delete'],
+      { stdio: 'inherit' },
+    );
+  });
+
+  it('runs find, xattr, and codesign in order', async () => {
+    const ctx = {
+      appOutDir: '/build/mac-arm64',
+      packager: { platform: { name: 'mac' }, appInfo: { productName: 'dayGLANCE' } },
+      electronPlatformName: 'darwin',
+    };
+    await codesignAdHoc(ctx);
+    const calls = mockSpawnSync.mock.calls.map(c => c[0]);
+    expect(calls).toEqual(['find', 'xattr', 'codesign']);
+  });
+
+  it('skips codesign for MAS builds but still cleans detritus', async () => {
+    const ctx = {
+      appOutDir: '/build/mac-arm64',
+      packager: { platform: { name: 'mac' }, appInfo: { productName: 'dayGLANCE' } },
+      electronPlatformName: 'mas',
+    };
+    await codesignAdHoc(ctx);
+    const calls = mockSpawnSync.mock.calls.map(c => c[0]);
+    expect(calls).toEqual(['find', 'xattr']);
+  });
+
+  it('skips codesign when CSC_LINK is set', async () => {
+    process.env.CSC_LINK = '/path/to/cert.p12';
+    const ctx = {
+      appOutDir: '/build/mac-arm64',
+      packager: { platform: { name: 'mac' }, appInfo: { productName: 'dayGLANCE' } },
+      electronPlatformName: 'darwin',
+    };
+    await codesignAdHoc(ctx);
+    const calls = mockSpawnSync.mock.calls.map(c => c[0]);
+    expect(calls).toEqual(['find', 'xattr']);
+  });
+
+  it('throws when a command fails, halting the build', async () => {
+    mockSpawnSync.mockReturnValueOnce({ status: 0, error: null });
+    mockSpawnSync.mockReturnValueOnce({ status: 1, error: null });
+    const ctx = {
+      appOutDir: '/build/mac-arm64',
+      packager: { platform: { name: 'mac' }, appInfo: { productName: 'dayGLANCE' } },
+      electronPlatformName: 'darwin',
+    };
+    await expect(codesignAdHoc(ctx))
+      .rejects.toThrow('[codesign-ad-hoc] xattr exited with status 1');
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces shell-interpolated `execSync` calls in the `afterPack` codesign hook with `spawnSync` using argument arrays — eliminates shell interpretation entirely
- Adds a `runOrThrow` wrapper that throws on spawn errors or non-zero exit status, preserving `execSync`'s build-halting behavior
- No path sanitization or rewriting — `appOutDir` and `productName` are build-time values from electron-builder, not user input

This is a defensive cleanup, not a security fix. Semgrep flags the use of `child_process` in this hook, but the arguments are build-time values rather than end-user input. The change is still worthwhile: argv-based invocation is more robust against paths containing shell metacharacters, and the explicit error propagation makes failure modes clearer.

## Test plan

- [x] `npx vitest run scripts/codesign-ad-hoc.test.js` — 10 tests pass
- [ ] Verify macOS build still signs correctly (`npm run build` on mac)

🤖 Generated with [Claude Code](https://claude.com/claude-code)