### PR TITLE
MCP status modal: dismiss on Escape

### DIFF
--- a/src/components/McpStatusControls.jsx
+++ b/src/components/McpStatusControls.jsx
@@ -298,7 +298,17 @@ export function McpStatusModal({ mcp, darkMode, open, onClose, borderClass, card
   const textSecondary = darkMode ? 'text-gray-400' : 'text-stone-500';
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
+    // Escape-close follows the DatePicker/DailyNotesModal backdrop idiom: the
+    // backdrop takes focus on mount (tabIndex -1 + ref focus) so the keydown
+    // lands here without a document-level listener, and bubbling still
+    // delivers it when focus sits on a control inside the card.
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 outline-none"
+      onClick={onClose}
+      onKeyDown={(e) => { if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); onClose(); } }}
+      tabIndex={-1}
+      ref={(el) => el && el.focus()}
+    >
       <div
         className={`${cardBg} rounded-xl shadow-xl border ${borderClass} w-full max-w-sm mx-4 overflow-hidden`}
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Summary

The desktop MCP server modal (status, tier, journal list, per-task/bulk undo) closed only via the X button or a backdrop click. Escape now closes it too.

Implementation follows the existing DatePicker/DailyNotesModal backdrop idiom rather than a document-level listener: the backdrop takes focus on mount (`tabIndex={-1}` + ref focus), so the keydown lands on it directly, and event bubbling still delivers Escape when focus is on a control inside the card (the Undo/Turn off/X buttons).

## Verification

- Live on Linux via CDP against the running app: Escape closes the open modal both from the freshly-focused backdrop and with focus placed on a button inside the card
- Full suite 106 files, 1639/1639; eslint clean on the touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_