### PR TITLE
MCP inbox filtering: bucket exclusion fix, scope/include_completed, cursor-bound filters

### DIFF
--- a/docs/mcp-inbox-filter-findings.md
+++ b/docs/mcp-inbox-filter-findings.md
@@ -1,0 +1,117 @@
+# Inbox filtering for `dayglance_list_unscheduled_tasks` — discovery findings
+
+Step 1 of the inbox-filtering work: how the app actually differentiates and filters
+unscheduled tasks, established from the code before any implementation. Each finding cites
+its source.
+
+## 1. What the app's inbox filter actually is
+
+**There is no persisted predicate object and no saved-filter record with an id.** The app's
+inbox filter is six independent pieces of per-device UI state, each its own localStorage key,
+composed at render time:
+
+| State | Default | localStorage key |
+|---|---|---|
+| `hideCompletedInbox` | `false` | `hideCompletedInbox` |
+| `hideProjectTasksInbox` | **`true`** (project tasks hidden by default) | `hideProjectTasksInbox` |
+| `hideStandaloneTasksInbox` | `false` | `hideStandaloneTasksInbox` |
+| `inboxPriorityFilter` | `0` (no threshold) | `inboxPriorityFilter` |
+| `inboxTagFilter` | `[]` | `inboxTagFilter` |
+| `inboxProjectFilter` | `[]` | `inboxProjectFilter` |
+
+(App.jsx:559–578.) All six are in the device-settings backup roster
+(`src/utils/deviceSettings.js:38–45` — "the inbox filter bar, in full"), so they are part of
+the device-settings backup/restore work, but as raw per-device values, not as a nameable
+filter entity anything could reference.
+
+The composition lives in **`src/hooks/useComputedViews.js` → `filteredUnscheduledTasks`**
+(:84–116), which applies, in order: the unconditional exclusions (`notBucketed`,
+`!task.archived`, `isVisibleForUser` for multi-user), the project/standalone toggles (gated
+on `goalsProjectsEnabled`; `inboxProjectFilter` overrides both toggles when non-empty), the
+priority threshold, a hardcoded `!(task.completed && task.deadline)` exclusion, the
+completed toggle, and the tag filter (`extractTags` over the title), then sorts. This
+composed chain is the only thing that IS the "app's inbox filter", and it exists nowhere
+but in that memo.
+
+## 2. How bucket-list tasks are separated
+
+**A structured field, not a tag convention.** Bucket items are ordinary rows in
+`unscheduledTasks` carrying a **`bucketId`** field (`'b1' | 'b2'` — exactly two lists,
+deliberately capped; `src/utils/bucketList.js:13`). The predicate is centralized:
+
+```js
+// src/utils/bucketList.js:34
+export const notBucketed = (task) => !task?.bucketId;
+```
+
+The module documents it as "the unconditional Inbox exclusion. Applied at every
+unscheduledTasks consumer that feeds Inbox lists, counts, or nag machinery" — and unlike the
+project toggles it is not user-toggleable. Demoting a task to the bucket strips deadline and
+priority (bucket items are pre-commitment). Tags do exist in the app (parsed from the title
+by `extractTags`, `src/utils/taskUtils.js:17`, centralized), but bucket membership is not
+tag-based and never was.
+
+The current MCP item shape omits `bucketId` entirely (`buildUnscheduledItems`,
+`src/utils/mcpReadModel.js:140`), which is why bucket items are indistinguishable on the
+wire today.
+
+## 3. Is the predicate reusable server-side?
+
+Split answer, and the split is the design:
+
+- **The composed UI filter is NOT reusable as a unit.** It is entangled with per-device UI
+  state (six localStorage values), a feature flag (`goalsProjectsEnabled`), and the
+  multi-user visibility closure. Two devices can hold different filter states for the same
+  vault; "the user's current filter" is not a stable server-side referent, and exposing a
+  reference to it would make MCP results depend on invisible per-device chrome.
+- **The individual dimensions ARE reusable, trivially.** The three distinctions that matter
+  (bucket membership, project membership, completion) are all structural task fields
+  (`bucketId`, `projectId`, `completed`), and the one nontrivial predicate (`notBucketed`)
+  is a pure, centralized one-liner that the renderer-side MCP read model can import
+  directly — `src/trmnl.js` already imports it (line 11). No tag-string parsing is required
+  for any of them.
+
+## 4. The TRMNL standalone-count path
+
+`src/trmnl.js:147–148`:
+
+```js
+// Inbox count — standalone tasks only (exclude those tied to a project)
+const inboxCount = unscheduledTasks.filter((t) => notBucketed(t) && !t.completed && !t.projectId).length;
+```
+
+Exactly the "standalone open inbox" predicate, built from the imported `notBucketed` plus
+the two structural fields. There is nothing to invent: the MCP filter for the motivating
+use case is this line's predicate, reused.
+
+## Pipeline fact relevant to Step 2
+
+There is no database and no query engine: `unscheduledTasks` is an in-memory renderer array.
+Today `buildUnscheduledItems` (renderer) maps the **full array** over IPC to the main
+process, and `paginate` (`electron/mcpPagination.ts`, offset cursor `dgc1.` +
+base64 `{"o":N}`) slices it there. So "filter in the query layer" concretely means:
+**filter in `buildUnscheduledItems`, before the array crosses to `paginate`** — then
+`total`, `truncated`, and `next_cursor` are computed against the filtered set by
+construction. The full-array IPC hop is main↔renderer in-process and cheap at these sizes;
+the cost being eliminated is the 347 items crossing the MCP wire and the model's context.
+
+## Recommended design (for review, not implemented)
+
+No reusable persisted predicate exists to reference by id — that branch is closed. But
+inventing a filtering language is not needed either: the app's own distinctions are three
+structural dimensions, so the tool gains **filter selection, not predicates**:
+
+- `scope`: `'all'` (default) | `'standalone'` | `'project'` | `'bucket'` — implemented with
+  the imported `notBucketed` and `projectId`, matching the app's own partition
+  (`standalone` = `notBucketed && !projectId`, the TRMNL predicate's shape).
+- `include_completed`: boolean, **default `true`** (wire-compatible; the app's
+  `hideCompletedInbox` equivalent, inverted so absence changes nothing).
+
+Explicitly out, per the non-goals: tag filters (title parsing), priority thresholds,
+project-id narrowing, and the app's `archived` / `completed-with-deadline` /
+`isVisibleForUser` specials — the last already applies to the MCP list today and stays as
+is. Cursor binding (Step 3): encode `{o, f}` where `f` is the canonical filter tuple;
+mismatch between cursor and arguments → `validation` error.
+
+With `scope: 'standalone'`, `include_completed: false`, the tool returns precisely what
+TRMNL counts and what the app's inbox shows under the equivalent toggles.

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -66,15 +66,28 @@ One local calendar date's schedule. For the current date prefer `dayglance_get_t
 | `date` | string | yes | Strict `YYYY-MM-DD`, a real local calendar date. Not a timestamp. |
 
 ### `dayglance_list_unscheduled_tasks`
-The inbox: tasks not yet scheduled onto a day. Paginated.
+The inbox: tasks not yet scheduled onto a day. Paginated, with opt-in filter selection.
+**Bucket List (someday/maybe) items are never returned** — the app's unconditional inbox
+exclusion applies here, not a filter argument, and `bucketId` never appears on the wire.
 
 | Param | Type | Required | Notes |
 |---|---|---|---|
 | `limit` | integer | no | Page size 1–200. Default 50. |
-| `cursor` | string | no | Opaque cursor from a previous response's `next_cursor`. |
+| `cursor` | string | no | Opaque cursor from a previous response's `next_cursor`. Bound to the filters it was issued under (see below). |
+| `scope` | `'all'` \| `'standalone'` \| `'project'` | no | Default `'all'` (every unscheduled task). `'standalone'`: tasks not attached to a project — what the app itself counts as the inbox. `'project'`: only project-attached tasks. |
+| `include_completed` | boolean | no | Default `true`. Pass `false` for open tasks only. |
 
 Returns `{ items, truncated, next_cursor, total, timezone }`. Items carry `id`, `title`,
 `priority` (0–3), `completed`, and `deadline` / `project_id` / `notes` when set.
+
+Filtering happens before pagination: `total`, `truncated`, and `next_cursor` always describe
+the **filtered** set. A filter matching nothing returns an empty list with `total: 0`, not an
+error. Cursors encode the resolved filter they were minted under; presenting a cursor with
+different filter arguments is a `validation` error naming both sides — restart with a fresh
+call (no cursor) to change filters. Defaults are resolved before comparison, so omitting
+`include_completed` on one page and passing `include_completed: true` on the next never
+mismatches. `scope: 'standalone'` with `include_completed: false` is the app's own inbox
+count (the same predicate the TRMNL integration uses).
 
 ### `dayglance_list_users` *(exists only while multi-user mode is on)*
 The household members tasks can be assigned to. Returns active users as `{ id, name }`;

--- a/electron/mcpInboxFilter.test.ts
+++ b/electron/mcpInboxFilter.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { resolveInboxFilter } from './mcpInboxFilter.js';
+
+// The canonicalization contract: defaults resolve BEFORE anything compares
+// or encodes, so semantically identical requests always produce identical
+// tuples — omitted-vs-explicit defaults can never mismatch across pages.
+
+describe('resolveInboxFilter', () => {
+  it('resolves defaults: scope all, include_completed true', () => {
+    const r = resolveInboxFilter({});
+    expect(r).toEqual({
+      ok: true,
+      filter: { scope: 'all', includeCompleted: true, key: 'scope=all;completed=1' },
+    });
+  });
+
+  it('omitted and explicit defaults produce IDENTICAL canonical keys', () => {
+    const omitted = resolveInboxFilter({});
+    const explicit = resolveInboxFilter({ scope: 'all', include_completed: true });
+    if (!omitted.ok || !explicit.ok) throw new Error('expected ok');
+    expect(omitted.filter.key).toBe(explicit.filter.key);
+  });
+
+  it('each scope and completion combination has a distinct stable key', () => {
+    const keys = new Set<string>();
+    for (const scope of ['all', 'standalone', 'project'] as const) {
+      for (const include_completed of [true, false]) {
+        const r = resolveInboxFilter({ scope, include_completed });
+        if (!r.ok) throw new Error(r.message);
+        keys.add(r.filter.key);
+      }
+    }
+    expect(keys.size).toBe(6);
+    expect(keys.has('scope=standalone;completed=0')).toBe(true);
+  });
+
+  it('rejects unknown scopes, naming the valid set (no bucket scope by design)', () => {
+    for (const bad of ['bucket', 'inbox', '', 42, null]) {
+      const r = resolveInboxFilter({ scope: bad });
+      expect(r.ok, `scope ${String(bad)}`).toBe(false);
+      if (!r.ok) expect(r.message).toContain('"standalone"');
+    }
+  });
+
+  it('rejects non-boolean include_completed', () => {
+    for (const bad of ['true', 1, 0, null]) {
+      expect(resolveInboxFilter({ include_completed: bad }).ok, String(bad)).toBe(false);
+    }
+  });
+});

--- a/electron/mcpInboxFilter.ts
+++ b/electron/mcpInboxFilter.ts
@@ -1,0 +1,60 @@
+// Canonical filter resolution for dayglance_list_unscheduled_tasks, pure and
+// unit-tested. The resolved tuple — not the raw arguments — is what gets
+// applied by the renderer read model AND encoded into pagination cursors, so
+// semantically identical requests always produce identical tuples: a caller
+// that omits include_completed on page one and passes include_completed: true
+// explicitly on page two is requesting the same filter and must never see a
+// mismatch error. Defaults resolve here, once, before anything compares.
+//
+// The vocabulary is FILTER SELECTION over the app's own structural task
+// fields (bucketId is handled upstream as the unconditional exclusion;
+// projectId and completed are the two selectable axes). Deliberately no tag
+// parsing, no priority thresholds, no project-id narrowing, and no 'bucket'
+// scope: bucket access would belong to a separate tool.
+
+export const INBOX_SCOPES = ['all', 'standalone', 'project'] as const;
+export type InboxScope = (typeof INBOX_SCOPES)[number];
+
+export interface ResolvedInboxFilter {
+  scope: InboxScope;
+  includeCompleted: boolean;
+  /**
+   * Canonical string form, stable key order, built from RESOLVED values.
+   * Encoded into cursors and compared across pages; also readable in the
+   * mismatch error message.
+   */
+  key: string;
+}
+
+export type InboxFilterResult =
+  | { ok: true; filter: ResolvedInboxFilter }
+  | { ok: false; message: string };
+
+export function resolveInboxFilter(args: { scope?: unknown; include_completed?: unknown }): InboxFilterResult {
+  const { scope, include_completed } = args;
+
+  let scopeValue: InboxScope = 'all';
+  if (scope !== undefined) {
+    if (typeof scope !== 'string' || !(INBOX_SCOPES as readonly string[]).includes(scope)) {
+      return { ok: false, message: `scope must be one of ${INBOX_SCOPES.map((s) => `"${s}"`).join(', ')}, got ${JSON.stringify(scope)}` };
+    }
+    scopeValue = scope as InboxScope;
+  }
+
+  let includeCompleted = true;
+  if (include_completed !== undefined) {
+    if (typeof include_completed !== 'boolean') {
+      return { ok: false, message: `include_completed must be a boolean, got ${JSON.stringify(include_completed)}` };
+    }
+    includeCompleted = include_completed;
+  }
+
+  return {
+    ok: true,
+    filter: {
+      scope: scopeValue,
+      includeCompleted,
+      key: `scope=${scopeValue};completed=${includeCompleted ? '1' : '0'}`,
+    },
+  };
+}

--- a/electron/mcpPagination.test.ts
+++ b/electron/mcpPagination.test.ts
@@ -9,13 +9,19 @@ import {
 
 // §5.1 under test: default cap 50, truncation flag, working cursor — and the
 // §5.2 direction that bad inputs are validation failures, not silent clamps.
+// The cursor carries the canonical filter key of the walk it belongs to;
+// every paginated call must present the same key or get a validation error,
+// and pre-filter cursors (offset only, no key) are malformed.
 
 const LIST = Array.from({ length: 120 }, (_, i) => ({ id: `t${i}` }));
+const F = 'scope=all;completed=1';
+const page = <T>(items: T[], opts: { limit?: unknown; cursor?: unknown; filterKey?: string }) =>
+  paginate(items, { filterKey: F, ...opts });
 
 describe('paginate — happy path', () => {
   it('defaults to a 50-item page with truncation flag and cursor', () => {
     expect(DEFAULT_LIST_LIMIT).toBe(50);
-    const r = paginate(LIST, {});
+    const r = page(LIST, {});
     if (!r.ok) throw new Error(r.reason);
     expect(r.items).toHaveLength(50);
     expect(r.items[0]).toEqual({ id: 't0' });
@@ -28,7 +34,7 @@ describe('paginate — happy path', () => {
     const seen: string[] = [];
     let cursor: string | undefined;
     for (let guard = 0; guard < 10; guard++) {
-      const r = paginate(LIST, { cursor });
+      const r = page(LIST, { cursor });
       if (!r.ok) throw new Error(r.reason);
       seen.push(...r.items.map((t) => t.id));
       if (!r.truncated) {
@@ -40,8 +46,36 @@ describe('paginate — happy path', () => {
     expect(seen).toEqual(LIST.map((t) => t.id));
   });
 
+  it('walks cleanly at limit 1, at the ceiling, and when size is an exact multiple of limit', () => {
+    for (const [items, limit] of [
+      [LIST.slice(0, 7), 1],
+      [LIST, MAX_LIST_LIMIT],
+      [LIST.slice(0, 40), 10], // exact multiple: final page full, then done
+    ] as const) {
+      const seen: string[] = [];
+      let cursor: string | undefined;
+      let pages = 0;
+      for (let guard = 0; guard < 200; guard++) {
+        const r = page(items, { limit, cursor });
+        if (!r.ok) throw new Error(r.reason);
+        expect(r.total).toBe(items.length);
+        pages += 1;
+        seen.push(...r.items.map((t) => t.id));
+        if (!r.truncated) {
+          // No empty trailing page: an exact-multiple walk ends on a FULL page.
+          if (items.length > 0) expect(r.items.length).toBeGreaterThan(0);
+          break;
+        }
+        expect(r.items).toHaveLength(limit); // no short intermediate pages
+        cursor = r.nextCursor!;
+      }
+      expect(seen).toEqual(items.map((t) => t.id));
+      expect(pages).toBe(Math.max(1, Math.ceil(items.length / limit)));
+    }
+  });
+
   it('final page is not truncated and carries no cursor', () => {
-    const r = paginate(LIST, { cursor: encodeCursor(100) });
+    const r = page(LIST, { cursor: encodeCursor(100, F) });
     if (!r.ok) throw new Error(r.reason);
     expect(r.items).toHaveLength(20);
     expect(r.truncated).toBe(false);
@@ -49,7 +83,7 @@ describe('paginate — happy path', () => {
   });
 
   it('a list at exactly the limit is not truncated', () => {
-    const r = paginate(LIST.slice(0, 50), {});
+    const r = page(LIST.slice(0, 50), {});
     if (!r.ok) throw new Error(r.reason);
     expect(r.items).toHaveLength(50);
     expect(r.truncated).toBe(false);
@@ -57,25 +91,25 @@ describe('paginate — happy path', () => {
   });
 
   it('honors an explicit limit', () => {
-    const r = paginate(LIST, { limit: 10 });
+    const r = page(LIST, { limit: 10 });
     if (!r.ok) throw new Error(r.reason);
     expect(r.items).toHaveLength(10);
     expect(r.truncated).toBe(true);
   });
 
   it('a cursor at or past the end returns an empty final page (list may have shrunk)', () => {
-    const r = paginate(LIST, { cursor: encodeCursor(120) });
+    const r = page(LIST, { cursor: encodeCursor(120, F) });
     if (!r.ok) throw new Error(r.reason);
     expect(r.items).toEqual([]);
     expect(r.truncated).toBe(false);
     expect(r.nextCursor).toBeNull();
-    const r2 = paginate(LIST, { cursor: encodeCursor(10_000) });
+    const r2 = page(LIST, { cursor: encodeCursor(10_000, F) });
     if (!r2.ok) throw new Error(r2.reason);
     expect(r2.items).toEqual([]);
   });
 
-  it('an empty list yields an empty, unt runcated page', () => {
-    const r = paginate([], {});
+  it('an empty list yields an empty, untruncated page', () => {
+    const r = page([], {});
     if (!r.ok) throw new Error(r.reason);
     expect(r.items).toEqual([]);
     expect(r.truncated).toBe(false);
@@ -84,48 +118,78 @@ describe('paginate — happy path', () => {
   });
 });
 
+describe('paginate — filter binding', () => {
+  it('a cursor from filter A replayed under filter B is a validation error naming both', () => {
+    const first = page(LIST, { filterKey: 'scope=standalone;completed=0' });
+    if (!first.ok) throw new Error(first.reason);
+    const r = page(LIST, { cursor: first.nextCursor!, filterKey: 'scope=all;completed=1' });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.reason).toContain('scope=standalone;completed=0');
+    expect(r.reason).toContain('scope=all;completed=1');
+    expect(r.reason).toContain('restart');
+  });
+
+  it('the same filter key across pages walks cleanly', () => {
+    const key = 'scope=standalone;completed=0';
+    const first = page(LIST, { limit: 50, filterKey: key });
+    if (!first.ok) throw new Error(first.reason);
+    const second = page(LIST, { cursor: first.nextCursor!, limit: 50, filterKey: key });
+    expect(second.ok).toBe(true);
+  });
+
+  it('pre-filter cursors (offset only, no filter key) are malformed, never an implicit all', () => {
+    const legacy = 'dgc1.' + Buffer.from(JSON.stringify({ o: 50 })).toString('base64url');
+    const r = page(LIST, { cursor: legacy });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.reason).toContain('not valid');
+  });
+});
+
 describe('paginate — validation failures, never silent clamps', () => {
   it('rejects a limit above the ceiling instead of clamping', () => {
-    const r = paginate(LIST, { limit: MAX_LIST_LIMIT + 1 });
+    const r = page(LIST, { limit: MAX_LIST_LIMIT + 1 });
     expect(r.ok).toBe(false);
     if (r.ok) throw new Error('expected failure');
     expect(r.reason).toContain(String(MAX_LIST_LIMIT));
   });
 
   it('accepts a limit exactly at the ceiling', () => {
-    expect(paginate(LIST, { limit: MAX_LIST_LIMIT }).ok).toBe(true);
+    expect(page(LIST, { limit: MAX_LIST_LIMIT }).ok).toBe(true);
   });
 
   it('rejects zero, negative, fractional, and non-numeric limits', () => {
     for (const limit of [0, -1, 2.5, '50', null, NaN]) {
-      const r = paginate(LIST, { limit });
+      const r = page(LIST, { limit });
       expect(r.ok, `limit ${String(limit)}`).toBe(false);
     }
   });
 
   it('rejects cursors it did not mint', () => {
     for (const cursor of ['', 'abc', 'dgc1.!!!', 'dgc2.eyJvIjowfQ', 42, {}]) {
-      const r = paginate(LIST, { cursor });
+      const r = page(LIST, { cursor });
       expect(r.ok, `cursor ${String(cursor)}`).toBe(false);
     }
   });
 
-  it('rejects a hand-tampered cursor whose offset is negative or fractional', () => {
-    const forge = (o: unknown) => 'dgc1.' + Buffer.from(JSON.stringify({ o })).toString('base64url');
+  it('rejects a hand-tampered cursor whose offset is negative or fractional, or whose filter key is not a string', () => {
+    const forge = (o: unknown, f: unknown = F) => 'dgc1.' + Buffer.from(JSON.stringify({ o, f })).toString('base64url');
     for (const o of [-1, 1.5, '3', null]) {
-      expect(paginate(LIST, { cursor: forge(o) }).ok, `offset ${String(o)}`).toBe(false);
+      expect(page(LIST, { cursor: forge(o) }).ok, `offset ${String(o)}`).toBe(false);
     }
+    expect(page(LIST, { cursor: forge(0, 42) }).ok).toBe(false);
   });
 });
 
 describe('cursor round-trip', () => {
-  it('decode(encode(n)) === n', () => {
+  it('decode(encode(n, f)) round-trips offset and filter key', () => {
     for (const n of [0, 1, 50, 119, 10_000]) {
-      expect(decodeCursor(encodeCursor(n))).toBe(n);
+      expect(decodeCursor(encodeCursor(n, F))).toEqual({ offset: n, filterKey: F });
     }
   });
 
   it('cursors are opaque-prefixed and versioned', () => {
-    expect(encodeCursor(0).startsWith('dgc1.')).toBe(true);
+    expect(encodeCursor(0, F).startsWith('dgc1.')).toBe(true);
   });
 });

--- a/electron/mcpPagination.test.ts
+++ b/electron/mcpPagination.test.ts
@@ -182,6 +182,29 @@ describe('paginate — validation failures, never silent clamps', () => {
   });
 });
 
+describe('filtered totals — the field never lies', () => {
+  it('total reflects the (pre-filtered) input set, not any larger population it came from', () => {
+    // The tool layer filters in the read model BEFORE paginate ever sees the
+    // array, so paginate's total is definitionally the filtered count. This
+    // pins the composed behavior: a filtered subset paginated to completion
+    // reports the subset's size on every page and walks exactly that many rows.
+    const population = Array.from({ length: 347 }, (_, i) => ({ id: `t${i}`, open: i % 5 === 0 }));
+    const filtered = population.filter((t) => t.open); // 70 rows, standing in for the read-model filter
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    for (let guard = 0; guard < 100; guard++) {
+      const r = page(filtered, { limit: 7, cursor, filterKey: 'scope=standalone;completed=0' });
+      if (!r.ok) throw new Error(r.reason);
+      expect(r.total).toBe(filtered.length);
+      expect(r.total).not.toBe(population.length);
+      seen.push(...r.items.map((t) => t.id));
+      if (!r.truncated) break;
+      cursor = r.nextCursor!;
+    }
+    expect(seen).toEqual(filtered.map((t) => t.id));
+  });
+});
+
 describe('cursor round-trip', () => {
   it('decode(encode(n, f)) round-trips offset and filter key', () => {
     for (const n of [0, 1, 50, 119, 10_000]) {

--- a/electron/mcpPagination.ts
+++ b/electron/mcpPagination.ts
@@ -3,12 +3,22 @@
 // decisions can be unit-tested without Electron or the SDK.
 //
 // There are NO sessions on this transport (§3.7), so the cursor must be fully
-// self-contained: an opaque base64url token carrying the offset. Opaque so
-// clients cannot construct or increment one themselves and then depend on the
-// encoding; self-contained so any request, from any client instance, can
-// resume the walk. The list can mutate between pages — offset resume is the
-// documented, bounded inaccuracy (a shifted item may repeat or be skipped),
-// which is acceptable for an inbox read and costs no server state.
+// self-contained: an opaque base64url token carrying the offset AND the
+// canonical filter key the walk was started under. Opaque so clients cannot
+// construct or increment one themselves and then depend on the encoding;
+// self-contained so any request, from any client instance, can resume the
+// walk. The list can mutate between pages — offset resume is the documented,
+// bounded inaccuracy (a shifted item may repeat or be skipped), which is
+// acceptable for an inbox read and costs no server state.
+//
+// FILTER BINDING: an offset alone is ambiguous once filtering exists (offset
+// 200 means different rows under different filters), so the cursor carries
+// the filter key and every paginated call compares the request's resolved
+// key against it. A difference is a validation error naming both sides —
+// never silently honored, because a mid-pagination filter change produces a
+// result window that corresponds to no coherent query. Cursors without a
+// filter key (the pre-filter dgc1 shape) are rejected as malformed rather
+// than treated as an implicit 'all'.
 
 /** §5.1 suggested default cap: an unbounded dump wastes the client's context. */
 export const DEFAULT_LIST_LIMIT = 50;
@@ -17,20 +27,22 @@ export const MAX_LIST_LIMIT = 200;
 
 const CURSOR_PREFIX = 'dgc1.'; // dayGLANCE cursor, version 1
 
-export function encodeCursor(offset: number): string {
-  return CURSOR_PREFIX + Buffer.from(JSON.stringify({ o: offset }), 'utf8').toString('base64url');
+export function encodeCursor(offset: number, filterKey: string): string {
+  return CURSOR_PREFIX + Buffer.from(JSON.stringify({ o: offset, f: filterKey }), 'utf8').toString('base64url');
 }
 
-/** Returns the offset, or null for anything not produced by encodeCursor. */
-export function decodeCursor(cursor: string): number | null {
+/** Returns {offset, filterKey}, or null for anything not produced by encodeCursor. */
+export function decodeCursor(cursor: string): { offset: number; filterKey: string } | null {
   if (!cursor.startsWith(CURSOR_PREFIX)) return null;
   try {
     const parsed = JSON.parse(Buffer.from(cursor.slice(CURSOR_PREFIX.length), 'base64url').toString('utf8')) as {
       o?: unknown;
+      f?: unknown;
     };
     const offset = parsed.o;
     if (typeof offset !== 'number' || !Number.isInteger(offset) || offset < 0) return null;
-    return offset;
+    if (typeof parsed.f !== 'string') return null;
+    return { offset, filterKey: parsed.f };
   } catch {
     return null;
   }
@@ -55,7 +67,7 @@ export type PageResult<T> =
  * caller did not ask for, with one exception: a limit above MAX_LIST_LIMIT is
  * an error rather than a clamp, so the model learns the real ceiling.
  */
-export function paginate<T>(items: T[], opts: { limit?: unknown; cursor?: unknown }): PageResult<T> {
+export function paginate<T>(items: T[], opts: { limit?: unknown; cursor?: unknown; filterKey: string }): PageResult<T> {
   let limit = DEFAULT_LIST_LIMIT;
   if (opts.limit !== undefined) {
     if (typeof opts.limit !== 'number' || !Number.isInteger(opts.limit) || opts.limit < 1) {
@@ -74,9 +86,17 @@ export function paginate<T>(items: T[], opts: { limit?: unknown; cursor?: unknow
     }
     const decoded = decodeCursor(opts.cursor);
     if (decoded === null) {
-      return { ok: false, reason: 'cursor is not valid; use the nextCursor from a previous response' };
+      return { ok: false, reason: 'cursor is not valid; use the next_cursor from a previous response' };
     }
-    offset = decoded;
+    if (decoded.filterKey !== opts.filterKey) {
+      return {
+        ok: false,
+        reason:
+          `cursor was issued under a different filter (cursor: ${decoded.filterKey}; this call: ${opts.filterKey}). ` +
+          'Changing filters mid-pagination is not supported; restart with a fresh call and no cursor.',
+      };
+    }
+    offset = decoded.offset;
   }
 
   // An offset at or past the end returns an empty final page rather than an
@@ -87,7 +107,7 @@ export function paginate<T>(items: T[], opts: { limit?: unknown; cursor?: unknow
     ok: true,
     items: page,
     truncated,
-    nextCursor: truncated ? encodeCursor(offset + limit) : null,
+    nextCursor: truncated ? encodeCursor(offset + limit, opts.filterKey) : null,
     total: items.length,
   };
 }

--- a/electron/mcpReadTools.ts
+++ b/electron/mcpReadTools.ts
@@ -19,6 +19,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { RendererBridge } from './mcpRendererBridge.js';
 import { isValidLocalDate, localDateOf, dateEnvelope } from './mcpDates.js';
 import { paginate, DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT } from './mcpPagination.js';
+import { resolveInboxFilter } from './mcpInboxFilter.js';
 
 export interface ReadToolDeps {
   bridge: RendererBridge;
@@ -115,13 +116,26 @@ export function registerReadTools(server: McpServer, deps: ReadToolDeps): void {
       inputSchema: z.object({
         limit: z.number().int().optional().describe(`Page size, 1-${MAX_LIST_LIMIT}. Default ${DEFAULT_LIST_LIMIT}.`),
         cursor: z.string().optional().describe('Opaque cursor from a previous response\'s next_cursor.'),
+        scope: z.enum(['all', 'standalone', 'project']).optional().describe(
+          'Which inbox tasks to return. "all" (default): every unscheduled task. "standalone": tasks not ' +
+          'attached to any project (what the app counts as the inbox). "project": only tasks attached to a project.'),
+        include_completed: z.boolean().optional().describe(
+          'Default true. Pass false to return only open tasks.'),
       }),
     },
-    async ({ limit, cursor }) => {
-      const r = await deps.bridge.request('list_unscheduled', {});
+    async ({ limit, cursor, scope, include_completed }) => {
+      // Resolve defaults BEFORE anything compares or encodes: the canonical
+      // tuple is what the renderer applies and what the cursor carries, so
+      // omitted-vs-explicit defaults can never mismatch across pages.
+      const resolved = resolveInboxFilter({ scope, include_completed });
+      if (!resolved.ok) return toolError('validation', resolved.message);
+      const { filter } = resolved;
+      const r = await deps.bridge.request('list_unscheduled', {
+        filter: { scope: filter.scope, includeCompleted: filter.includeCompleted },
+      });
       if (!r.ok) return bridgeError(r);
       const items = (r.data as { items: unknown[] }).items ?? [];
-      const page = paginate(items, { limit, cursor });
+      const page = paginate(items, { limit, cursor, filterKey: filter.key });
       if (!page.ok) return toolError('validation', page.reason);
       return ok({
         items: page.items,

--- a/electron/mcpReadTools.ts
+++ b/electron/mcpReadTools.ts
@@ -112,7 +112,14 @@ export function registerReadTools(server: McpServer, deps: ReadToolDeps): void {
       description:
         "The dayGLANCE inbox: tasks not yet scheduled onto a day. Paginated, default page " +
         `${DEFAULT_LIST_LIMIT}, max ${MAX_LIST_LIMIT}; when truncated is true, pass next_cursor ` +
-        'back as cursor for the next page.',
+        'back as cursor for the next page. Filters: scope "all" returns every unscheduled task ' +
+        '(the default), "standalone" only tasks not attached to a project (what the app itself ' +
+        'counts as the inbox), "project" only project-attached tasks; include_completed defaults ' +
+        'to true, pass false for open tasks only. total, truncated, and next_cursor always ' +
+        'describe the FILTERED set. Bucket List (someday/maybe) items are never returned by this ' +
+        'tool. A cursor is bound to the filters it was issued under: changing scope or ' +
+        'include_completed mid-pagination is a validation error, so to change filters, restart ' +
+        'with a fresh call and no cursor.',
       inputSchema: z.object({
         limit: z.number().int().optional().describe(`Page size, 1-${MAX_LIST_LIMIT}. Default ${DEFAULT_LIST_LIMIT}.`),
         cursor: z.string().optional().describe('Opaque cursor from a previous response\'s next_cursor.'),

--- a/src/utils/mcpReadModel.js
+++ b/src/utils/mcpReadModel.js
@@ -138,8 +138,15 @@ export function buildWeek(state, params) {
 }
 
 /** The unscheduled inbox, unpaginated — the main process owns paging (§5.1). */
-export function buildUnscheduledItems(state) {
+export function buildUnscheduledItems(state, filter = {}) {
   const { unscheduledTasks = [], isVisibleForUser = () => true } = state;
+  // Filter selection over structural fields, resolved by the main process
+  // (electron/mcpInboxFilter.ts) and applied HERE, before the array crosses
+  // IPC to paginate — so total/truncated/next_cursor are computed against
+  // the filtered set by construction, never by post-filtering a page. The
+  // predicates are the app's own: 'standalone' is the TRMNL inbox-count
+  // shape (notBucketed && !projectId), with completion a separate axis.
+  const { scope = 'all', includeCompleted = true } = filter;
   return {
     // Bucket List items never appear in Inbox output — the unconditional
     // exclusion utils/bucketList.js documents for EVERY consumer feeding
@@ -147,7 +154,12 @@ export function buildUnscheduledItems(state) {
     // invariant (bucket items leaked into MCP results). Unconditional by
     // design: not a scope value, not behind an argument — a caller wanting
     // bucket items needs a separate tool, so this list stays one thing.
-    items: unscheduledTasks.filter(notBucketed).filter(isVisibleForUser).map((t) => {
+    items: unscheduledTasks
+      .filter(notBucketed)
+      .filter(isVisibleForUser)
+      .filter((t) => (scope === 'standalone' ? !t.projectId : scope === 'project' ? !!t.projectId : true))
+      .filter((t) => includeCompleted || !t.completed)
+      .map((t) => {
       const item = {
         id: t.id,
         type: 'task',
@@ -268,7 +280,7 @@ export function handleMcpRequest(state, request) {
     case 'get_week':
       return { ok: true, data: buildWeek(state, params) };
     case 'list_unscheduled':
-      return { ok: true, data: buildUnscheduledItems(state) };
+      return { ok: true, data: buildUnscheduledItems(state, params?.filter) };
     case 'list_users':
       return { ok: true, data: buildUsers(state) };
     case 'goal_progress': {

--- a/src/utils/mcpReadModel.js
+++ b/src/utils/mcpReadModel.js
@@ -17,6 +17,7 @@
 import { getOccurrencesInRange } from './recurrenceEngine.js';
 import { calculateGoalProgress } from './goalProgress.js';
 import { calculateProjectProgress } from './projectProgress.js';
+import { notBucketed } from './bucketList.js';
 
 /**
  * The §5.1 distinct type flag. 'device_calendar_event' marks data that came
@@ -140,7 +141,13 @@ export function buildWeek(state, params) {
 export function buildUnscheduledItems(state) {
   const { unscheduledTasks = [], isVisibleForUser = () => true } = state;
   return {
-    items: unscheduledTasks.filter(isVisibleForUser).map((t) => {
+    // Bucket List items never appear in Inbox output — the unconditional
+    // exclusion utils/bucketList.js documents for EVERY consumer feeding
+    // inbox lists or counts. This was the one consumer that missed the
+    // invariant (bucket items leaked into MCP results). Unconditional by
+    // design: not a scope value, not behind an argument — a caller wanting
+    // bucket items needs a separate tool, so this list stays one thing.
+    items: unscheduledTasks.filter(notBucketed).filter(isVisibleForUser).map((t) => {
       const item = {
         id: t.id,
         type: 'task',

--- a/src/utils/mcpReadModel.test.js
+++ b/src/utils/mcpReadModel.test.js
@@ -145,6 +145,21 @@ describe('buildUnscheduledItems', () => {
       completed: false, deadline: '2026-08-20', notes: 'oat',
     }]);
   });
+
+  it('excludes Bucket List items unconditionally — the bucketList.js invariant', () => {
+    const state = {
+      unscheduledTasks: [
+        { id: 'u1', title: 'Get bloodwork done' },
+        { id: 'b1', title: 'Go to US Open in NYC', bucketId: 'b1' },
+        { id: 'b2', title: 'Honeymoon encore trip', bucketId: 'b2' },
+      ],
+    };
+    const { items } = buildUnscheduledItems(state);
+    expect(items.map((i) => i.id)).toEqual(['u1']);
+    // And bucketId never reaches the wire: the tool excludes bucket items
+    // rather than labeling them.
+    expect(JSON.stringify(items)).not.toContain('bucketId');
+  });
 });
 
 describe('buildGoalProgress', () => {

--- a/src/utils/mcpReadModel.test.js
+++ b/src/utils/mcpReadModel.test.js
@@ -146,6 +146,36 @@ describe('buildUnscheduledItems', () => {
     }]);
   });
 
+  it('scope and includeCompleted filter over structural fields; defaults change nothing', () => {
+    const state = {
+      unscheduledTasks: [
+        { id: 's-open', title: 'Standalone open' },
+        { id: 's-done', title: 'Standalone done', completed: true },
+        { id: 'p-open', title: 'Project open', projectId: 'p1' },
+        { id: 'p-done', title: 'Project done', projectId: 'p1', completed: true },
+        { id: 'bucket', title: 'Someday', bucketId: 'b1' },
+      ],
+    };
+    const ids = (filter) => buildUnscheduledItems(state, filter).items.map((i) => i.id);
+    // Defaults (explicit or omitted) = everything non-bucketed.
+    expect(ids(undefined)).toEqual(['s-open', 's-done', 'p-open', 'p-done']);
+    expect(ids({ scope: 'all', includeCompleted: true })).toEqual(['s-open', 's-done', 'p-open', 'p-done']);
+    // The TRMNL standalone-open shape.
+    expect(ids({ scope: 'standalone', includeCompleted: false })).toEqual(['s-open']);
+    expect(ids({ scope: 'standalone' })).toEqual(['s-open', 's-done']);
+    expect(ids({ scope: 'project' })).toEqual(['p-open', 'p-done']);
+    expect(ids({ includeCompleted: false })).toEqual(['s-open', 'p-open']);
+    // Bucket items appear under NO argument combination.
+    for (const f of [undefined, { scope: 'all' }, { scope: 'standalone' }, { scope: 'project' }, { includeCompleted: false }]) {
+      expect(ids(f)).not.toContain('bucket');
+    }
+  });
+
+  it('a filter matching nothing returns an empty list, not an error', () => {
+    const state = { unscheduledTasks: [{ id: 'p1', title: 'Project only', projectId: 'p' }] };
+    expect(buildUnscheduledItems(state, { scope: 'standalone' }).items).toEqual([]);
+  });
+
   it('excludes Bucket List items unconditionally — the bucketList.js invariant', () => {
     const state = {
       unscheduledTasks: [


### PR DESCRIPTION
## Summary

Implements Steps 2–5 of the inbox-filtering spec on top of the accepted Step 1 discovery (`docs/mcp-inbox-filter-findings.md`, first commit on this branch). One commit per step, in the prescribed order.

### The bug fix (release-note as a fix, not a filter)

`buildUnscheduledItems` was the one `unscheduledTasks` consumer missing the unconditional `notBucketed` exclusion that `utils/bucketList.js` documents for every inbox surface — bucket items leaked into MCP results. Now applied unconditionally, importing the same predicate `trmnl.js` uses. **Deliberate behavior change for no-argument calls**: the removed items are ones no other inbox surface has ever shown. There is no `'bucket'` scope by design; agent access to the bucket list is future work for a separate tool. `bucketId` stays off the wire.

### Filtering (query layer, before pagination)

`scope: 'all' | 'standalone' | 'project'` (default `'all'`) and `include_completed` (default `true`, wire-compatible) — filter selection over structural fields using the app's own predicates, applied in the read model **before** the array reaches `paginate`, so `total`, `truncated`, and `next_cursor` describe the filtered set by construction. `'standalone'` is the TRMNL inbox-count predicate shape. No tag parsing, no priority thresholds; `archived`/visibility handling untouched.

### Cursor binding

Defaults resolve into a canonical tuple (`electron/mcpInboxFilter.ts`, pure) **before** anything compares or encodes — omitted-vs-explicit defaults can never mismatch across pages. Cursors carry `{o, f}`; a cursor replayed under a different resolved filter returns a `validation` error naming both sides and directing a restart; pre-filter offset-only cursors are rejected as malformed, never treated as implicit `'all'`.

### Verification

- 23 new/updated tests across `mcpInboxFilter`, `mcpPagination`, `mcpReadModel`; full suite **107 files, 1652/1652**
- Mutation harness: **10/10 killed** (default drift, key omission, bucket-scope acceptance, silent mismatch honor, legacy-cursor leniency, scope/completion inversions, scope-dependent bucket exclusion)
- Live over MCP against a seeded vault reproducing the spec's structure: unfiltered total drops by exactly the bucket count with "Go to US Open in NYC" and "Honeymoon encore trip" absent and "Get bloodwork done" present; `standalone` and `standalone+open` totals correct; **standalone-open count matches the TRMNL predicate computed over the same data** (spec item 3); `limit: 2` walk = pages 2+2+1, walked rows == `total`, no repeats; filter-A cursor under filter B errors naming both filters; legacy `dgc1.{"o":N}` cursor rejected; omitted-then-explicit `include_completed` walks cleanly

Final confirmation on the real vault is yours: expect the unfiltered baseline to drop by the bucket count, and item 3's MCP number to equal the app's inbox under equivalent toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_