### PR TITLE
Spec: Phase 7 implementation notes (README canonical, site capability card)

### DIFF
--- a/docs/mcp-server-spec.md
+++ b/docs/mcp-server-spec.md
@@ -541,6 +541,8 @@ Three OS config snippets. Bridge install paths per build type. Troubleshooting f
 
 **Exit:** a self-hoster can go from zero to a working tool call without asking a question.
 
+Notes from implementation: division of labor decided and enforced — the bridge README (glance-apps/mcp-bridge) is the canonical how-to covering every install path (setup button for direct-download macOS/Windows; unsigned `.mcpb` with the mcpb-CLI signing bug noted; `npx` manual entry, the only Linux path; Claude Code direct HTTP with no bridge), plus an eight-item troubleshooting section and the renderer requirement; the site page (glance-apps-dotcom, dayGLANCE app page) is an "AI Assistants" capability card in the GLANCEvault-precedent stack that explains the capability for someone who does not know MCP, leads with the decision-making facts (assistant reads go to the assistant's model provider; local-only; off by default with reads/writes/device-calendar as separate opt-ins), and links to the README rather than restating any setup. The MAS manual-token path is stated with its reason (a container read would trigger a macOS consent prompt attributed to "node" naming neither product). One documentation landmine made a hard rule: no `url` field may appear in any `claude_desktop_config.json` example, even as a counterexample — Claude Desktop silently rewrites the file and drops the whole `mcpServers` block when it sees one; the only `url` in the README sits in a block explicitly labeled as Claude Code's `.mcp.json`.
+
 ### Phase 8: Legal and store
 **Repos:** legal docs, ASC
 


### PR DESCRIPTION
## Summary

Records Phase 7's implementation in the spec's phasing section, following the notes-from-implementation convention of earlier phases: the division of labor (bridge README as the canonical how-to; site page as a GLANCEvault-precedent capability card that links to it), the MAS manual-token rationale, and the hard documentation rule that no `url` field may appear in any `claude_desktop_config.json` example (Claude Desktop silently drops the whole `mcpServers` block).

Companion changes, separate PRs per repo:
- glance-apps/mcp-bridge branch `docs/canonical-setup`: README replaced with the canonical setup guide (every install path scoped by build/platform, MAS token path with reason, 8-item troubleshooting, renderer requirement)
- krelltunez/glance-apps-dotcom PR #24: "AI Assistants" capability card on the dayGLANCE page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_