### PR TITLE
Guard will-quit globalShortcut teardown on app-ready

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,7 +14,7 @@ import { registerStorefrontHandlers } from './storefront.js';
 import { registerICloudHandlers } from './icloud.js';
 import { registerObsidianHandlers } from './obsidian.js';
 import { APP_SCHEME, APP_HOST, APP_BASE_URL, resolveAppRequest } from './appProtocol.js';
-import { shouldQuitOnAllWindowsClosed } from './startupQuit.js';
+import { shouldQuitOnAllWindowsClosed, shouldUnregisterShortcutsOnQuit } from './startupQuit.js';
 import { initStartupLog, logStartup } from './startupLog.js';
 import { startMcpServer } from './mcpServer.js';
 import { generateMcpToken } from './mcpAuth.js';
@@ -1478,6 +1478,16 @@ app.whenReady().then(async () => {
 app.on('before-quit', () => { isQuitting = true; });
 
 app.on('will-quit', () => {
+  // Guarded on app-ready (startupQuit.ts, issue #1352): globalShortcut throws
+  // before ready, and the throw aborts the rest of the will-quit emit chain.
+  // Under electronmon's kill sequence that skipped later listener is its
+  // app.exit(signal), so the "killed" app resumed startup and kept the
+  // single-instance lock and the 7892 port. Before ready nothing can be
+  // registered (hotkeys register via renderer IPC), so skipping loses nothing.
+  if (!shouldUnregisterShortcutsOnQuit(app.isReady())) {
+    logStartup('will-quit: globalShortcut teardown skipped (app not ready)');
+    return;
+  }
   globalShortcut.unregisterAll();
 });
 

--- a/electron/startupQuit.test.ts
+++ b/electron/startupQuit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { shouldQuitOnAllWindowsClosed } from './startupQuit.js';
+import { shouldQuitOnAllWindowsClosed, shouldUnregisterShortcutsOnQuit } from './startupQuit.js';
 
 // Regression test for the Windows/Linux "installs but never launches" bug: the
 // storage migration creates and destroys hidden BrowserWindows BEFORE the main
@@ -29,5 +29,29 @@ describe('shouldQuitOnAllWindowsClosed', () => {
       expect(shouldQuitOnAllWindowsClosed('win32', true)).toBe(true);
       expect(shouldQuitOnAllWindowsClosed('linux', true)).toBe(true);
     });
+  });
+});
+
+// Regression test for issue #1352: a will-quit that fires before app-ready
+// (electronmon's kill sequence during a slow/colliding startup) must skip the
+// globalShortcut teardown. globalShortcut throws before ready, and the throw
+// aborts the rest of the synchronous will-quit emit chain: under electronmon
+// the skipped listener is app.exit(signal), and the observed result was a
+// "killed" app that resumed startup and kept the single-instance lock and the
+// ws://7892 port, plus a modal error dialog from electronmon's
+// uncaughtException handler.
+
+describe('shouldUnregisterShortcutsOnQuit', () => {
+  it('unregisters on a normal quit (app is ready)', () => {
+    // If this returns false, every quit leaks registered global hotkeys until
+    // the OS reclaims them at process exit.
+    expect(shouldUnregisterShortcutsOnQuit(true)).toBe(true);
+  });
+
+  it('skips before app-ready: globalShortcut would throw and abort the quit', () => {
+    // THE REGRESSION: returning true here re-introduces the issue #1352 throw.
+    // Nothing is lost by skipping: hotkeys register via renderer IPC, which
+    // requires a ready app, so pre-ready there is nothing to unregister.
+    expect(shouldUnregisterShortcutsOnQuit(false)).toBe(false);
   });
 });

--- a/electron/startupQuit.ts
+++ b/electron/startupQuit.ts
@@ -29,3 +29,30 @@ export function shouldQuitOnAllWindowsClosed(
   if (platform === 'darwin') return false;
   return mainWindowCreated;
 }
+
+/**
+ * Whether the `will-quit` teardown may call into globalShortcut (issue #1352).
+ *
+ * Every globalShortcut API throws "globalShortcut cannot be used before the
+ * app is ready", and `will-quit` CAN fire before ready: electronmon's kill
+ * sequence (hook.js exit -> reset) registers its own will-quit listener and
+ * calls app.quit() the moment its reset message arrives, which during a slow
+ * or colliding startup lands before app-ready.
+ *
+ * The throw is worse than the visible error dialog: it aborts the rest of the
+ * synchronous will-quit emit chain, so listeners registered after ours never
+ * run. Under electronmon the skipped listener is `app.exit(signal)`, and the
+ * observed result is a "killed" app that resumes startup, creates its window,
+ * and keeps holding the single-instance lock and the ws://7892 port the
+ * restarted instance needs.
+ *
+ * Skipping the unregister before ready loses nothing: hotkeys are registered
+ * only via renderer IPC (set-global-hotkey / set-main-window-hotkey), which
+ * requires a ready app with a loaded window, so before ready there is nothing
+ * registered to clean up.
+ *
+ * @param appIsReady `app.isReady()` at the moment `will-quit` fires
+ */
+export function shouldUnregisterShortcutsOnQuit(appIsReady: boolean): boolean {
+  return appIsReady;
+}


### PR DESCRIPTION
Closes #1352.

## The handler and the throw

The `globalShortcut.unregisterAll()` from the issue lives in the `will-quit` handler (`electron/main.ts`, previously a single unguarded statement). `globalShortcut` throws "cannot be used before the app is ready", and `will-quit` can fire before ready: electronmon's kill sequence (`hook.js` `exit` → `reset`) registers its own `will-quit` listener and calls `app.quit()` the moment its reset message arrives, which during a slow or colliding startup lands before app-ready.

Two corrections to the issue text, as directed: the "related in kind to the open `render-process-gone` item" line is stale (that item was fixed in #1381), and the issue did not ask the question that turned out to matter most: whether the throw aborts the rest of teardown. It does, at the emit-chain level.

## What the throw actually costs (reproduced live)

Repro on Linux under xvfb: electron spawned with electronmon's hook over an IPC channel, `'reset'` sent before app-ready. Observed pre-fix:

1. The exact stack from the issue (`hook.js` `exit` → `reset` → our `will-quit` handler → throw), plus the modal "Electron encountered an error" dialog, which comes from **electronmon's own `uncaughtException` handler** (`showErrorBox`), not Electron default behavior.
2. Our own handler has nothing after the call, but the throw aborts the rest of the **synchronous `will-quit` emit chain**: electronmon's `app.exit(37)` listener (registered after ours) never runs, so its exit-code contract with its parent is broken.
3. Electron's quit is abandoned entirely: the "killed" app **resumed startup**, fired `app ready`, created its window, and bound `ws://7892` while still holding the single-instance lock. That is the same shape as the Vite port-collision loop the issue was filed under: the process told to die keeps the port the restart needs.

So the dialog is a symptom; the real bug is an aborted kill.

## Which teardown paths are affected (all induced, before and after)

| Path | How induced | Pre-fix | Post-fix |
|---|---|---|---|
| electronmon kill before ready | spawn with `--require hook.js` + IPC, send `'reset'` immediately | throw, aborted quit, resumed startup, dialog | clean exit **37**, skip logged |
| electronmon kill of running app | same, `'reset'` after `app ready` + window load | clean exit 37 | clean exit 37 |
| Normal quit (window close) | CDP `/json/close` on the page target (plain HTTP, no attached debugger) | clean exit 0, full quit sequence | clean exit 0 |
| Doomed second instance | instance A running, spawn plain instance B | clean exit 0; `will-quit` is never emitted on the pre-ready `app.quit()` at module scope, so this path never threw | clean exit 0 |
| SIGTERM | `kill -TERM` on running app | clean exit 0 | clean exit 0 |

Normal quit in a packaged-build shape is therefore unaffected by the bug (app is ready by then), and the second-instance pre-ready quit never emits `will-quit` at all; the throw is specific to a quit initiated after the event loop starts but before ready, which in practice is electronmon's kill sequence. Determined by running each path, not inferred from the code.

Temporary trace logging (since removed) confirmed the full quit sequence (`before-quit` → `will-quit` → `quit`) completes on the clean paths, so nothing else was being skipped: the handler's only statement is the guarded call, window-state saving happens on window `close`, and the renderer save pass is independent of `will-quit`. One earlier false alarm during verification: an apparent normal-quit hang was my own probe's lingering CDP WebSocket keeping the debugger attached, resolved by closing the page over plain HTTP instead.

## The fix

Guarding, not suppression: `will-quit` skips the `globalShortcut` teardown when the app never became ready. Nothing is lost by skipping: hotkeys are registered only via renderer IPC (`set-global-hotkey` / `set-main-window-hotkey`), which requires a ready app with a loaded window, so pre-ready there is nothing to unregister. With the guard, the emit chain completes and electronmon's `app.exit(37)` runs: the kill actually kills.

- `electron/startupQuit.ts`: `shouldUnregisterShortcutsOnQuit(appIsReady)`, a pure function alongside `shouldQuitOnAllWindowsClosed`, with the full rationale in its doc comment.
- `electron/main.ts`: the handler consults it and logs `will-quit: globalShortcut teardown skipped (app not ready)` to the startup log when it skips, so the skip is observable in the field.
- `electron/startupQuit.test.ts`: both directions unit-tested with regression comments.

This closes the last unguarded lifecycle gap of the #1352/#1381 family: the other `globalShortcut` calls are reachable only via renderer IPC (post-ready by construction) and already wrap their unregisters in try/catch; `before-quit` only sets `isQuitting`; `window-all-closed` is guarded by `shouldQuitOnAllWindowsClosed`.

## Mutation verification

3 mutants, all killed: `return true` (unguarded regression) and `return false` (never unregister) on the pure function, killed by the unit tests; and a live wiring mutant that strips the guard from `main.ts`, rebuilds, and re-runs the electronmon repro, killed by the throw coming back. The harness restores sources via finally/exit/signal hooks and ends with a byte-identity check.

## Verification

- Full suite: 112 files, 1706 tests passing
- `tsc --noEmit` clean for both electron tsconfigs
- All five live teardown scenarios clean post-fix (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_