### PR TITLE
Surface unportable vault filenames in Settings → Obsidian

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -740,6 +740,12 @@ const DayPlanner = () => {
   // Wikilink autocomplete candidates — bare note names from the connected vault.
   // Populated when the vault connects (native or FSA) and used by task-title inputs.
   const [wikilinkCandidates, setWikilinkCandidates] = useState([]);
+  // Vault entries whose names may not sync to Windows or Android devices
+  // (issue #1358) — [{ path, reason }], computed during the same vault scan
+  // that populates wikilinkCandidates and listed read-only in Settings →
+  // Obsidian. Informational, not an error: the harm is conditional on
+  // multi-platform sync dayGLANCE cannot detect.
+  const [unportableVaultFiles, setUnportableVaultFiles] = useState([]);
 
   // Auto-Backup state. Saved configs predating a section (e.g. `folder`) get
   // that section's defaults merged in so downstream code can assume the shape.
@@ -2698,6 +2704,7 @@ const DayPlanner = () => {
     unscheduledTasks, setUnscheduledTasks,
     setDailyNotes,
     setWikilinkCandidates,
+    setUnportableVaultFiles,
     obsidianConfig, setObsidianConfig,
     setObsidianSyncStatus, setObsidianSyncError, setObsidianLastSynced,
     obsidianVaultHandleRef, obsidianSyncInProgressRef, obsidianPrevTaskStateRef,
@@ -8250,6 +8257,7 @@ const DayPlanner = () => {
     obsidianSyncError, setObsidianSyncError,
     obsidianLastSynced, setObsidianLastSynced,
     wikilinkCandidates, setWikilinkCandidates,
+    unportableVaultFiles, setUnportableVaultFiles,
 
     // ── TRMNL ─────────────────────────────────────────────────────────────────
     trmnlConfig, setTrmnlConfig,

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -13,7 +13,8 @@ import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from '../constants/habits
 import { getDeviceId, isNativeAndroid, isNativeApp, nativeGetCalendars, nativePickVault, nativeGetAutomationIntentsEnabled, nativeSetAutomationIntentsEnabled } from '../native.js';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
-import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, listVaultNotes, formatDatePattern } from '../obsidian.js';
+import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, scanVaultNotes, formatDatePattern } from '../obsidian.js';
+import UnportableVaultNamesPanel from './UnportableVaultNamesPanel.jsx';
 import { validateDailyNotePattern, validateVaultFolderSetting } from '../utils/obsidianFilename.js';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
 import ICloudDiagnostics from './ICloudDiagnostics.jsx';
@@ -94,6 +95,7 @@ const MobileSettingsPanel = () => {
     obsidianConfig, setObsidianConfig,
     obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
     wikilinkCandidates, setWikilinkCandidates,
+    unportableVaultFiles, setUnportableVaultFiles,
     cloudSyncTest, cloudSyncNow,
     vaultSyncNow, vaultBootstrapSync, vaultStatus, vaultError, vaultLastSynced, vaultSkipped, vaultEnabled,
     syncAll, performObsidianSync, performRemoteBackup, nativeClearVault,
@@ -1596,6 +1598,7 @@ const MobileSettingsPanel = () => {
                     setObsidianConfig(null);
                     setObsidianLastSynced(null);
                     setWikilinkCandidates([]);
+                    setUnportableVaultFiles?.([]);
                     localStorage.removeItem('day-planner-obsidian-last-synced');
                     setTasks(prev => prev.filter(t => t.importSource !== 'obsidian'));
                     setUnscheduledTasks(prev => prev.filter(t => t.importSource !== 'obsidian'));
@@ -1770,6 +1773,7 @@ const MobileSettingsPanel = () => {
                 obsidianVaultHandleRef.current = null;
                 setObsidianConfig(null);
                 setObsidianLastSynced(null);
+                setUnportableVaultFiles?.([]);
                 localStorage.removeItem('day-planner-obsidian-last-synced');
                 setTasks(prev => prev.filter(t => t.importSource !== 'obsidian'));
                 setUnscheduledTasks(prev => prev.filter(t => t.importSource !== 'obsidian'));
@@ -1784,6 +1788,7 @@ const MobileSettingsPanel = () => {
           {obsidianLastSynced && (
             <p className={`text-xs ${textSecondary}`}>{t('common.lastSynced')}: {new Date(obsidianLastSynced).toLocaleString()}</p>
           )}
+          <UnportableVaultNamesPanel entries={unportableVaultFiles} darkMode={darkMode} textSecondary={textSecondary} />
         </div>
       ) : (
         <button
@@ -1796,7 +1801,7 @@ const MobileSettingsPanel = () => {
             if (handle) {
               obsidianVaultHandleRef.current = handle;
               setObsidianConfig({ enabled: true, dailyNotesPath: '', vaultName: handle.name });
-              listVaultNotes(handle).then(names => setWikilinkCandidates(names)).catch(() => {});
+              scanVaultNotes(handle).then(({ names, unportable }) => { setWikilinkCandidates(names); setUnportableVaultFiles?.(unportable); }).catch(() => {});
             }
           }}
           className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 flex items-center gap-2 text-sm"

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -14,6 +14,7 @@ import { isNativeAndroid, nativeGetCalendars, nativeGetAutomationIntentsEnabled,
 import { hasNativeCalendar, electronCalendarAvailable, electronGetCalendars } from '../utils/nativeCalendar.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, formatDatePattern } from '../obsidian.js';
 import { validateDailyNotePattern, validateVaultFolderSetting } from '../utils/obsidianFilename.js';
+import UnportableVaultNamesPanel from './UnportableVaultNamesPanel.jsx';
 import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from '../intents/useIntentPoller.js';
 import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUsers.js';
 import { isAvailable as isICloudAvailable } from '../intents/icloudFileTransport.js';
@@ -74,7 +75,7 @@ const SettingsModal = () => {
     syncAll, isSyncing, calSyncLastSynced,
     availableCalendars, setAvailableCalendars, calendarFilter, setCalendarFilter,
     obsidianConfig, setObsidianConfig, obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
-    obsidianVaultHandleRef,
+    obsidianVaultHandleRef, unportableVaultFiles, setUnportableVaultFiles,
     performObsidianSync,
     trmnlConfig, setTrmnlConfig, trmnlSyncStatus, trmnlLastSynced, performTrmnlSync,
     setShowIntentActivityLog,
@@ -1680,6 +1681,7 @@ const SettingsModal = () => {
                                 obsidianVaultHandleRef.current = null;
                                 setObsidianConfig(null);
                                 setObsidianLastSynced(null);
+                                setUnportableVaultFiles?.([]);
                                 localStorage.removeItem('day-planner-obsidian-last-synced');
                                 // Remove Obsidian-imported tasks
                                 setTasks(prev => prev.filter(t => t.importSource !== 'obsidian'));
@@ -1701,6 +1703,7 @@ const SettingsModal = () => {
                               {t('common.lastSynced')}: {new Date(obsidianLastSynced).toLocaleString()}
                             </p>
                           )}
+                          <UnportableVaultNamesPanel entries={unportableVaultFiles} darkMode={darkMode} textSecondary={textSecondary} />
                         </div>
                       ) : (
                         <button

--- a/src/components/UnportableVaultNamesPanel.jsx
+++ b/src/components/UnportableVaultNamesPanel.jsx
@@ -1,0 +1,39 @@
+import { AlertTriangle } from 'lucide-react';
+
+/**
+ * Read-only Settings → Obsidian listing of vault entries whose names may not
+ * sync to Windows or Android devices (issue #1358). Entries come from the
+ * vault scan that already populates wikilink candidates; the rules are the
+ * creation-gate union from utils/vaultPortability.js.
+ *
+ * Deliberately informational (amber, not red) and deliberately read-only:
+ * a macOS-only user has no actual problem, and renaming a note here would
+ * break every wikilink to it across the vault. Renames belong in Obsidian,
+ * which updates backlinks.
+ */
+export default function UnportableVaultNamesPanel({ entries, darkMode, textSecondary }) {
+  if (!entries || entries.length === 0) return null;
+  return (
+    <div className={`mt-3 p-3 rounded-lg border ${darkMode ? 'border-amber-700/50 bg-amber-900/20' : 'border-amber-300 bg-amber-50'}`}>
+      <p className={`text-xs font-medium flex items-center gap-1.5 ${darkMode ? 'text-amber-300' : 'text-amber-700'}`}>
+        <AlertTriangle size={14} className="flex-shrink-0" />
+        {entries.length === 1
+          ? '1 vault file has a name that may not sync to Windows or Android devices'
+          : `${entries.length} vault files have names that may not sync to Windows or Android devices`}
+      </p>
+      <p className={`text-xs mt-1 ${textSecondary}`}>
+        dayGLANCE no longer creates names like these, but it never renames existing
+        notes: a rename breaks the links pointing at the note from the rest of the
+        vault. To fix one, rename it inside Obsidian, which updates its backlinks.
+      </p>
+      <ul className="mt-2 max-h-40 overflow-y-auto space-y-1.5">
+        {entries.map((f) => (
+          <li key={f.path} className="text-xs">
+            <span className={`font-mono break-all ${darkMode ? 'text-gray-200' : 'text-stone-800'}`}>{f.path}</span>
+            <span className={`block ${textSecondary}`}>{f.reason}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -4,7 +4,7 @@ import {
   syncObsidianVault, syncObsidianVaultNative,
   writeTaskStateToFile, writeTaskStateNative,
   simpleHash as obsidianSimpleHash,
-  readWikiNote, writeWikiNote, listVaultNotes,
+  readWikiNote, writeWikiNote, scanVaultNotes,
   OBSIDIAN_IMPORT_WINDOW_DAYS, obsidianWindowCutoffDate,
 } from '../obsidian.js';
 import {
@@ -13,6 +13,7 @@ import {
   nativeListNotes, nativeSetVaultSettings,
 } from '../native.js';
 import { validateWikiNoteName } from '../utils/obsidianFilename.js';
+import { classifyVaultPaths } from '../utils/vaultPortability.js';
 import { mergeObsidianDailyNotes } from '../utils/mergeObsidianDailyNotes.js';
 import { mergeObsidianTasks } from '../utils/mergeObsidianTasks.js';
 import { detectObsidianDeletions, addObsidianTombstones } from '../utils/obsidianDeletions.js';
@@ -38,6 +39,7 @@ export default function useObsidianSync({
   unscheduledTasks, setUnscheduledTasks,
   setDailyNotes,
   setWikilinkCandidates,
+  setUnportableVaultFiles,
   obsidianConfig, setObsidianConfig,
   setObsidianSyncStatus, setObsidianSyncError, setObsidianLastSynced,
   obsidianVaultHandleRef, obsidianSyncInProgressRef, obsidianPrevTaskStateRef,
@@ -154,7 +156,7 @@ export default function useObsidianSync({
         const handle = await getVaultAccess();
         if (!handle) return;
         obsidianVaultHandleRef.current = handle;
-        listVaultNotes(handle).then(names => setWikilinkCandidates(names)).catch(() => {});
+        scanVaultNotes(handle).then(({ names, unportable }) => { setWikilinkCandidates(names); setUnportableVaultFiles?.(unportable); }).catch(() => {});
       } catch {
         return;
       }
@@ -298,7 +300,10 @@ export default function useObsidianSync({
           // Populate wikilink autocomplete candidates from the vault index
           try {
             const notes = nativeListNotes('');
-            if (notes) setWikilinkCandidates(notes.map(p => p.split('/').pop().replace(/\.md$/i, '')).sort((a, b) => a.localeCompare(b)));
+            if (notes) {
+              setWikilinkCandidates(notes.map(p => p.split('/').pop().replace(/\.md$/i, '')).sort((a, b) => a.localeCompare(b)));
+              setUnportableVaultFiles?.(classifyVaultPaths(notes));
+            }
           } catch {}
         } else {
           // No Obsidian configured — release the splash immediately
@@ -317,7 +322,7 @@ export default function useObsidianSync({
         if (handle) {
           obsidianVaultHandleRef.current = handle;
           performObsidianSync();
-          listVaultNotes(handle).then(names => setWikilinkCandidates(names)).catch(() => {});
+          scanVaultNotes(handle).then(({ names, unportable }) => { setWikilinkCandidates(names); setUnportableVaultFiles?.(unportable); }).catch(() => {});
         }
       } catch (err) {
         console.error('Obsidian: failed to restore vault access', err);
@@ -351,7 +356,10 @@ export default function useObsidianSync({
             requestAnimationFrame(() => setTimeout(() => {
               try {
                 const notes = nativeListNotes('');
-                if (notes) setWikilinkCandidates(notes.map(p => p.split('/').pop().replace(/\.md$/i, '')).sort((a, b) => a.localeCompare(b)));
+                if (notes) {
+              setWikilinkCandidates(notes.map(p => p.split('/').pop().replace(/\.md$/i, '')).sort((a, b) => a.localeCompare(b)));
+              setUnportableVaultFiles?.(classifyVaultPaths(notes));
+            }
               } catch {}
             }, 0));
           }

--- a/src/hooks/useObsidianSync.retry.test.js
+++ b/src/hooks/useObsidianSync.retry.test.js
@@ -27,7 +27,7 @@ vi.mock('../obsidian.js', () => ({
   simpleHash: vi.fn(() => 'h'),
   readWikiNote: vi.fn(async () => null),
   writeWikiNote: vi.fn(async () => {}),
-  listVaultNotes: vi.fn(async () => []),
+  scanVaultNotes: vi.fn(async () => ({ names: [], unportable: [] })),
   OBSIDIAN_IMPORT_WINDOW_DAYS: 90,
   obsidianWindowCutoffDate: vi.fn(() => null),
 }));

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -18,6 +18,7 @@ import {
   validateWikiNoteName,
   validateVaultFolderSetting,
 } from './utils/obsidianFilename.js';
+import { unportableEntryReason } from './utils/vaultPortability.js';
 
 // How far back the Obsidian daily-note scan reads, in days. DELIBERATELY FIXED and
 // decoupled from the calendar "Keep past events" retention (syncRetentionDays):
@@ -635,24 +636,37 @@ export async function writeWikiNote(vaultHandle, noteName, content, newNotesFold
 }
 
 /**
- * Return a sorted array of all vault note names (bare, without .md extension).
- * Used to populate the wikilink autocomplete candidates list.
- * Scans at most 8 levels deep and ignores hidden directories (starting with '.').
+ * Scan the vault once and return everything the single traversal can tell us:
+ *  - names: sorted bare note names (without .md), for wikilink autocomplete.
+ *  - unportable: [{ path, reason }] of entries whose names may not sync to
+ *    Windows or Android devices (issue #1358; rules in
+ *    utils/vaultPortability.js). Computed during this scan precisely so the
+ *    Settings -> Obsidian listing costs no traversal of its own.
+ * Scans at most 8 levels deep and ignores hidden directories (starting with
+ * '.'), both unchanged from the original wikilink-candidates scan.
  */
-export async function listVaultNotes(vaultHandle) {
+export async function scanVaultNotes(vaultHandle) {
   const names = [];
-  async function scan(dir, depth) {
+  const unportable = [];
+  async function scan(dir, depth, prefix) {
     if (depth > 8) return;
     for await (const [name, handle] of dir.entries()) {
-      if (handle.kind === 'file' && name.endsWith('.md')) {
-        names.push(name.slice(0, -3));
+      if (handle.kind === 'file') {
+        if (name.endsWith('.md')) names.push(name.slice(0, -3));
+        const reason = unportableEntryReason(name, 'file');
+        if (reason) unportable.push({ path: prefix + name, reason });
       } else if (handle.kind === 'directory' && !name.startsWith('.')) {
-        await scan(handle, depth + 1);
+        const reason = unportableEntryReason(name, 'directory');
+        if (reason) unportable.push({ path: prefix + name + '/', reason });
+        await scan(handle, depth + 1, prefix + name + '/');
       }
     }
   }
-  await scan(vaultHandle, 0);
-  return names.sort((a, b) => a.localeCompare(b));
+  await scan(vaultHandle, 0, '');
+  return {
+    names: names.sort((a, b) => a.localeCompare(b)),
+    unportable: unportable.sort((a, b) => a.path.localeCompare(b.path)),
+  };
 }
 
 /**

--- a/src/obsidian.scan.test.js
+++ b/src/obsidian.scan.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { scanVaultNotes } from './obsidian.js';
+
+// scanVaultNotes drives BOTH outputs of the one vault traversal: the wikilink
+// autocomplete candidates (names, unchanged behavior from the original
+// listVaultNotes) and the issue #1358 unportable-name listing, computed in
+// the same pass so the Settings -> Obsidian panel costs no traversal of its
+// own. The fake handles below mirror the FileSystemDirectoryHandle surface
+// the scan uses: kind + async entries().
+
+const file = (name) => [name, { kind: 'file' }];
+const dir = (name, children) => [name, {
+  kind: 'directory',
+  entries: async function* entries() { yield* children; },
+}];
+const rootOf = (children) => ({ entries: async function* entries() { yield* children; } });
+
+describe('scanVaultNotes', () => {
+  it('collects sorted bare note names and unportable entries in one pass', async () => {
+    const root = rootOf([
+      file('Zebra.md'),
+      file('Alpha.md'),
+      file('plans?.md'),
+      file('notes.png'),
+      dir('Daily', [file('2026-08-16.md'), file('Meeting notes .md')]),
+    ]);
+    const { names, unportable } = await scanVaultNotes(root);
+    expect(names).toEqual(['2026-08-16', 'Alpha', 'Meeting notes ', 'plans?', 'Zebra']);
+    expect(unportable).toEqual([
+      { path: 'Daily/Meeting notes .md', reason: expect.stringMatching(/space just before its extension/) },
+      { path: 'plans?.md', reason: expect.stringMatching(/"\?"/) },
+    ]);
+  });
+
+  it('reports vault-relative paths, so nested findings are locatable', async () => {
+    const root = rootOf([
+      dir('Projects', [dir('2026', [file('CON.md')])]),
+    ]);
+    const { unportable } = await scanVaultNotes(root);
+    expect(unportable).toEqual([
+      { path: 'Projects/2026/CON.md', reason: expect.stringMatching(/reserved device name/) },
+    ]);
+  });
+
+  it('reports an unportable folder once and still scans inside it', async () => {
+    const root = rootOf([
+      dir('Bad|Folder', [file('fine.md'), file('also bad?.md')]),
+    ]);
+    const { names, unportable } = await scanVaultNotes(root);
+    expect(names).toEqual(['also bad?', 'fine']);
+    expect(unportable.map((e) => e.path)).toEqual(['Bad|Folder/', 'Bad|Folder/also bad?.md']);
+    // The folder entry carries its own reason; the fine.md inside it is not
+    // re-reported (one finding per offending NAME, not per affected path).
+    expect(unportable[0].reason).toMatch(/"\|"/);
+  });
+
+  it('never enters hidden directories and never reports hidden files', async () => {
+    const root = rootOf([
+      dir('.obsidian', [file('bad:config.md')]),
+      file('.DS_Store'),
+      file('ok.md'),
+    ]);
+    const { names, unportable } = await scanVaultNotes(root);
+    expect(names).toEqual(['ok']);
+    expect(unportable).toEqual([]);
+  });
+
+  it('clean vaults produce an empty listing (the panel renders nothing)', async () => {
+    const root = rootOf([file('A.md'), dir('Daily', [file('2026-01-01.md')])]);
+    const { unportable } = await scanVaultNotes(root);
+    expect(unportable).toEqual([]);
+  });
+});

--- a/src/utils/vaultPortability.js
+++ b/src/utils/vaultPortability.js
@@ -1,0 +1,82 @@
+// Audit-side classification of EXISTING vault entry names against the same
+// portability union the creation gate enforces (utils/obsidianFilename.js,
+// PR #1357): [ ] # ^ | * " \ / : ? < >, control characters, leading dot,
+// trailing dot or space (including before the extension), and Windows
+// reserved device names (case-insensitive, with or without an extension).
+//
+// The creation gate stops dayGLANCE from bringing NEW unportable names into
+// being; this module powers the read-only Settings -> Obsidian listing of
+// names already present in the vault (issue #1358), including names
+// dayGLANCE itself created before the validator existed. The listing is
+// phrased as "may not sync to Windows or Android devices", never as an
+// error: a macOS-only user has no actual problem, and the harm is
+// conditional on multi-platform sync that dayGLANCE cannot detect. It is
+// read-only by design: renaming a note breaks every other link to it across
+// the vault, and updating backlinks is Obsidian's job, not ours.
+//
+// HIDDEN ENTRIES ARE DELIBERATELY EXCLUDED from the audit even though the
+// union set refuses leading dots. Obsidian treats dot-entries (.obsidian,
+// .trash, .DS_Store) as invisible and does not sync them, so they cannot
+// break a sync that never carries them, and reporting .DS_Store on every
+// macOS vault would bury the real findings in noise. The creation gate still
+// refuses leading dots: a note dayGLANCE creates must be visible to
+// Obsidian. (Hidden DIRECTORIES are additionally never traversed by the
+// vault scan, unchanged behavior.)
+
+import { validateVaultNameSegment } from './obsidianFilename.js';
+
+export function isHiddenName(name) {
+  return typeof name === 'string' && name.startsWith('.');
+}
+
+/**
+ * Why one vault entry name is unportable, or null when it is fine (or hidden,
+ * see the header). `kind` is 'file' or 'directory', matching the
+ * FileSystemHandle kinds the vault scan iterates.
+ *
+ * Files get one check beyond the plain segment rules: a trailing dot or
+ * space BEFORE the extension ("Meeting notes .md"). The creation gate never
+ * sees that shape because it validates the stem before composing ".md" onto
+ * it; here the on-disk name arrives already composed, so the stem is
+ * re-derived from the LAST dot (multi-dot names like "Draft v1.2 .md" must
+ * flag on the space before ".md", not resolve the stem at the first dot).
+ */
+export function unportableEntryReason(name, kind) {
+  if (typeof name !== 'string' || name.length === 0) return null;
+  if (isHiddenName(name)) return null;
+  const plain = validateVaultNameSegment(name);
+  if (plain) return plain;
+  if (kind === 'directory') return null;
+  const lastDot = name.lastIndexOf('.');
+  if (lastDot > 0) {
+    const stem = name.slice(0, lastDot);
+    if (stem.endsWith('.') || stem.endsWith(' ')) {
+      return `name has a ${stem.endsWith('.') ? 'dot' : 'space'} just before its extension, which Windows and sync tools can silently mishandle`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Classify a flat list of vault-relative paths ("Folder/Note.md"), the shape
+ * the native (Android/iOS) vault index returns. Folder segments are checked
+ * as directories and the final segment as a file; a path under any hidden
+ * segment is skipped entirely (Obsidian-invisible, see the header). Returns
+ * [{ path, reason }] sorted by path, one entry per offending path, with the
+ * FIRST offending segment's reason.
+ */
+export function classifyVaultPaths(paths) {
+  const out = [];
+  for (const p of paths ?? []) {
+    if (typeof p !== 'string' || p.length === 0) continue;
+    const segments = p.split('/').filter(Boolean);
+    if (segments.length === 0 || segments.some(isHiddenName)) continue;
+    let reason = null;
+    for (let i = 0; i < segments.length - 1 && !reason; i++) {
+      reason = unportableEntryReason(segments[i], 'directory');
+    }
+    if (!reason) reason = unportableEntryReason(segments[segments.length - 1], 'file');
+    if (reason) out.push({ path: p, reason });
+  }
+  return out.sort((a, b) => a.path.localeCompare(b.path));
+}

--- a/src/utils/vaultPortability.test.js
+++ b/src/utils/vaultPortability.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { unportableEntryReason, classifyVaultPaths, isHiddenName } from './vaultPortability.js';
+
+// The audit-side twin of the creation gate (obsidianFilename.js, PR #1357):
+// existing vault names classified against the same portability union, for the
+// read-only Settings -> Obsidian listing (issue #1358). The union: the
+// character set [ ] # ^ | * " \ / : ? < >, control characters, leading dot,
+// trailing dot or space including before the extension, and Windows reserved
+// device names case-insensitively, with or without an extension.
+
+describe('unportableEntryReason: the union rules on file names', () => {
+  it('flags every refused character', () => {
+    for (const name of [
+      'plan [draft].md', 'notes#1.md', 'block^ref.md', 'a|b.md', 'star*.md',
+      'quo"te.md', 'back\\slash.md', 'sla/sh.md', 'co:lon.md', 'what?.md',
+      'le<ss.md', 'gr>eater.md',
+    ]) {
+      expect(unportableEntryReason(name, 'file'), name).toBeTruthy();
+    }
+  });
+
+  it('flags control characters', () => {
+    expect(unportableEntryReason('bad\x07name.md', 'file')).toMatch(/control character/);
+  });
+
+  it('flags Windows reserved device names, case-insensitive, with or without extensions', () => {
+    expect(unportableEntryReason('CON.md', 'file')).toMatch(/reserved device name/);
+    expect(unportableEntryReason('con.md', 'file')).toMatch(/reserved device name/);
+    expect(unportableEntryReason('COM3.md', 'file')).toMatch(/reserved device name/);
+    expect(unportableEntryReason('LPT9.backup.md', 'file')).toMatch(/reserved device name/);
+    expect(unportableEntryReason('aux', 'directory')).toMatch(/reserved device name/);
+  });
+
+  it('flags a trailing dot or space on the full name (extensionless files)', () => {
+    expect(unportableEntryReason('notes ', 'file')).toMatch(/space/);
+    expect(unportableEntryReason('notes.', 'file')).toMatch(/dot/);
+  });
+
+  it('flags a trailing dot or space BEFORE the extension', () => {
+    expect(unportableEntryReason('Meeting notes .md', 'file')).toMatch(/space just before its extension/);
+    expect(unportableEntryReason('notes..md', 'file')).toMatch(/dot just before its extension/);
+    // Multi-dot names must derive the stem from the LAST dot: resolving at
+    // the first dot would call the stem "Draft v1" and miss the space.
+    expect(unportableEntryReason('Draft v1.2 .md', 'file')).toMatch(/space just before its extension/);
+    // Attachments sync too; the rule is not .md-specific.
+    expect(unportableEntryReason('screenshot .png', 'file')).toMatch(/space just before its extension/);
+  });
+
+  it('flags unportable directory names (the folder poisons every path under it)', () => {
+    expect(unportableEntryReason('Projects?', 'directory')).toBeTruthy();
+    expect(unportableEntryReason('2026: plans', 'directory')).toBeTruthy();
+  });
+
+  it('accepts ordinary portable names', () => {
+    for (const name of [
+      'Plan.md', 'Résumé.md', 'foo-bar (draft).md', 'a.b.md', '2026-08-16.md',
+      'CONTINUE.md', 'constants.md', 'notes.png', 'Projects',
+    ]) {
+      expect(unportableEntryReason(name, name === 'Projects' ? 'directory' : 'file'), name).toBeNull();
+    }
+  });
+
+  it('skips hidden entries: Obsidian never syncs dotfiles, so they cannot break sync', () => {
+    // Deliberate narrowing of the union's leading-dot rule for the AUDIT
+    // only: reporting .DS_Store on every macOS vault would bury the real
+    // findings, and the creation gate still refuses leading dots.
+    expect(unportableEntryReason('.DS_Store', 'file')).toBeNull();
+    expect(unportableEntryReason('.hidden note?.md', 'file')).toBeNull();
+    expect(unportableEntryReason('.obsidian', 'directory')).toBeNull();
+    expect(isHiddenName('.trash')).toBe(true);
+    expect(isHiddenName('trash')).toBe(false);
+  });
+
+  it('tolerates junk input', () => {
+    expect(unportableEntryReason('', 'file')).toBeNull();
+    expect(unportableEntryReason(null, 'file')).toBeNull();
+    expect(unportableEntryReason(undefined, 'directory')).toBeNull();
+  });
+});
+
+describe('classifyVaultPaths: the native (Android/iOS) vault index shape', () => {
+  it('checks folder segments as directories and the last segment as a file', () => {
+    const out = classifyVaultPaths([
+      'Daily/2026-08-16.md',
+      'Bad?Folder/fine.md',
+      'Folder/bad:note.md',
+      'Deep/Nested/what?.md',
+    ]);
+    expect(out.map((e) => e.path)).toEqual(['Bad?Folder/fine.md', 'Deep/Nested/what?.md', 'Folder/bad:note.md']);
+    // A folder problem is reported with the folder's reason, so the user
+    // knows which segment to fix.
+    expect(out[0].reason).toMatch(/"\?"/);
+  });
+
+  it('reports the trailing-space-before-extension shape on native paths too', () => {
+    const out = classifyVaultPaths(['Daily/Meeting notes .md']);
+    expect(out).toHaveLength(1);
+    expect(out[0].reason).toMatch(/space just before its extension/);
+  });
+
+  it('skips anything under a hidden segment and tolerates junk', () => {
+    expect(classifyVaultPaths(['.obsidian/plugins/x?.md', '.trash/bad:name.md'])).toEqual([]);
+    expect(classifyVaultPaths(null)).toEqual([]);
+    expect(classifyVaultPaths(['', 42, {}])).toEqual([]);
+  });
+
+  it('returns entries sorted by path', () => {
+    const out = classifyVaultPaths(['z?.md', 'a?.md']);
+    expect(out.map((e) => e.path)).toEqual(['a?.md', 'z?.md']);
+  });
+});


### PR DESCRIPTION
Closes #1358.

## What this adds

A read-only panel in Settings → Obsidian (desktop `SettingsModal` and `MobileSettingsPanel`, one shared `UnportableVaultNamesPanel` component) listing existing vault entries whose names may not sync to Windows or Android devices, with the specific reason under each path. It renders only when there is something to show, is styled amber rather than red, and contains no actions: renaming a note breaks every wikilink to it across the vault, and updating backlinks is Obsidian's job. The copy says so and points the user at renaming inside Obsidian.

## Honoring the issue's constraints

- **No new traversal.** `listVaultNotes` (the wikilink-candidates scan) becomes `scanVaultNotes` and returns `{ names, unportable }` from its single pass: every entry the scan already enumerates is classified as it streams by. The `names` output is byte-for-byte the old behavior (including its locale sort and hidden-directory skip). On native (Android/iOS), the existing `nativeListNotes` index array is classified with `classifyVaultPaths`, also with no extra I/O. All four scan sites (vault restore, handle re-acquire, native config detect, mobile connect) populate the listing; all three disconnect paths clear it.
- **The PR #1357 union.** Classification reuses `validateVaultNameSegment` directly, so the audit and the creation gate cannot drift, plus the one shape the creation gate never sees: a trailing dot or space **before** the extension ("Meeting notes .md"), with the stem derived from the LAST dot so multi-dot names like "Draft v1.2 .md" classify correctly. Reserved device names with extensions ("CON.md", "LPT9.backup.md") come through the shared validator. Attachments are covered too ("screenshot .png"): the scan already enumerates every file, and Obsidian syncs attachments.
- **Conditional phrasing, not an error.** Headline: "N vault files have names that may not sync to Windows or Android devices."
- **Read-only.** Verified structurally: the rendered panel contains zero interactive elements.

## One deliberate narrowing, flagged for review

Hidden entries (`.DS_Store`, `.obsidian/**`, dotfiles) are excluded from the **audit** even though the union set refuses leading dots. Obsidian treats dot-entries as invisible and never syncs them, so they cannot break a sync that never carries them, and reporting `.DS_Store` on every macOS vault would bury the real findings in noise. The **creation** gate still refuses leading dots. Documented in the module header and pinned by tests on both the classifier and the scan. Relatedly, an unportable folder is reported once (its name poisons every path under it) and portable names inside it are not re-reported.

## Verification

Live end-to-end on Linux under xvfb: seeded a vault containing `plans?.md`, `Meeting notes .md`, `CON.md`, `Bad|Folder/inner.md`, `.obsidian/bad:config.md`, `.DS_Store`, and clean files; pointed `obsidian-vault.json` at it; enabled the integration; drove the real Settings modal over CDP. The panel rendered exactly the 4 expected findings ("4 vault files have names that may not sync to Windows or Android devices"), with `Bad|Folder/` reported once, the clean `inner.md` not re-reported, both hidden entries absent, and zero interactive elements in the panel.

- 21 new unit tests (`vaultPortability.test.js` for the rules and native-path classification, `obsidian.scan.test.js` for the single-pass scan against fake directory handles)
- Mutation-verified: 10 mutants across the classifier and the scan (hidden-skip removal, extension-stem removal, first-dot regression, folder-segment skip, prefix loss, hidden-dir traversal, kind confusion, sort removal), all killed
- Full suite: 115 files, 1743 tests passing; ESLint clean on all touched files

Not run here: the native Android/iOS index path was verified at the unit level (`classifyVaultPaths`), not on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_