### PR TITLE
PLANNER: hideable SCHEDULED list, per project

### DIFF
--- a/src/components/projects/ProjectPlanner.jsx
+++ b/src/components/projects/ProjectPlanner.jsx
@@ -5,6 +5,7 @@ import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
 import { useTranslation } from 'react-i18next';
 import { dateToString } from '../../utils/taskUtils.js';
 import { getProjectColor, taskColorToHex, hexToRgba } from '../../utils/colorUtils.js';
+import { plannerColumns } from '../../utils/plannerColumns.js';
 import { renderFormattedText } from '../../utils/textFormatting.jsx';
 
 // Same iOS detection as ProjectCard: grip-only touch drag on iOS, where
@@ -47,6 +48,12 @@ const ProjectPlanner = ({ project, onClose }) => {
   // Mobile shows the two task columns as tabs (they'd otherwise stack, hiding
   // Unscheduled below the fold); desktop keeps them side by side.
   const [activeTab, setActiveTab] = useState('scheduled');
+  // Per-project SCHEDULED-list hiding (the Bucket List secondListHidden
+  // pattern): persisted on the project record like its notes, so each
+  // planner remembers its own choice and it syncs with the project.
+  const scheduledHidden = !!project.plannerScheduledHidden;
+  const { effectiveTab, showTabs, showScheduled, showUnscheduled, gridColumns } =
+    plannerColumns({ isMobile, activeTab, scheduledHidden });
   const [dragIdx, setDragIdx] = useState(null);
   const [dragOverIdx, setDragOverIdx] = useState(null);
   const touchDragRef = useRef({ active: false, fromIdx: null, overIdx: null });
@@ -109,6 +116,8 @@ const ProjectPlanner = ({ project, onClose }) => {
   const hasAnyCompleted = useMemo(() =>
     [...tasks, ...unscheduledTasks].some(task => task.projectId === project.id && !task.archived && task.completed),
     [tasks, unscheduledTasks, project.id]);
+
+  const incompleteScheduledCount = scheduledDays.reduce((n, g) => n + (g.dateStr ? g.tasks.length : 0), 0);
 
   const todayStr = dateToString(new Date());
   const dayHeading = (dateStr) => {
@@ -320,19 +329,19 @@ const ProjectPlanner = ({ project, onClose }) => {
           </div>
 
           {/* Task columns — tabbed on mobile, side by side on desktop */}
-          {isMobile && (
+          {showTabs && (
             <div className={`flex rounded-lg border ${borderClass} p-0.5 gap-0.5`}>
               {[
-                { key: 'scheduled', label: t('planner.scheduled', 'Scheduled'), count: scheduledDays.reduce((n, g) => n + (g.dateStr ? g.tasks.length : 0), 0) },
+                { key: 'scheduled', label: t('planner.scheduled', 'Scheduled'), count: incompleteScheduledCount },
                 { key: 'unscheduled', label: t('task.unscheduled', 'Unscheduled'), count: incompleteUnscheduled.length },
               ].map(tab => (
                 <button
                   key={tab.key}
                   onClick={() => setActiveTab(tab.key)}
                   className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-semibold uppercase tracking-wide transition-colors ${
-                    activeTab === tab.key ? 'text-white' : `${textSecondary} ${hoverBg}`
+                    effectiveTab === tab.key ? 'text-white' : `${textSecondary} ${hoverBg}`
                   }`}
-                  style={activeTab === tab.key ? { background: projectHex } : undefined}
+                  style={effectiveTab === tab.key ? { background: projectHex } : undefined}
                 >
                   {tab.label}
                   {tab.count > 0 && <span className="opacity-70">{tab.count}</span>}
@@ -340,15 +349,25 @@ const ProjectPlanner = ({ project, onClose }) => {
               ))}
             </div>
           )}
-          <div className={`grid gap-4 ${isMobile ? 'grid-cols-1' : 'grid-cols-2'}`}>
+          <div className={`grid gap-4 ${gridColumns === 2 ? 'grid-cols-2' : 'grid-cols-1'}`}>
             {/* Scheduled */}
-            {(!isMobile || activeTab === 'scheduled') && (
+            {showScheduled && (
             <div className="flex flex-col gap-2 min-w-0">
-              {!isMobile && (
-                <span className={`text-xs font-semibold uppercase tracking-wide ${textSecondary}`}>
-                  {t('planner.scheduled', 'Scheduled')}
-                </span>
-              )}
+              <div className="flex items-center justify-between gap-2">
+                {!isMobile ? (
+                  <span className={`text-xs font-semibold uppercase tracking-wide ${textSecondary}`}>
+                    {t('planner.scheduled', 'Scheduled')}
+                  </span>
+                ) : <span />}
+                <button
+                  type="button"
+                  onClick={() => updateProject(project.id, { plannerScheduledHidden: true })}
+                  title={t('planner.hideScheduled', 'Hide Scheduled list')}
+                  className={`p-1 rounded ${hoverBg} flex-shrink-0`}
+                >
+                  <EyeOff size={14} className={textSecondary} />
+                </button>
+              </div>
               {scheduledDays.length > 0 ? scheduledDays.map(group => (
                 <div key={group.dateStr ?? 'completed'} className="flex flex-col gap-1">
                   <span className={`text-[11px] font-semibold ${group.dateStr === todayStr ? 'text-blue-500' : textSecondary} ${group.dateStr ? '' : 'opacity-60'}`}>
@@ -363,7 +382,7 @@ const ProjectPlanner = ({ project, onClose }) => {
             )}
 
             {/* Unscheduled */}
-            {(!isMobile || activeTab === 'unscheduled') && (
+            {showUnscheduled && (
             <div className="flex flex-col gap-2 min-w-0">
               {!isMobile && (
                 <span className={`text-xs font-semibold uppercase tracking-wide ${textSecondary}`}>
@@ -420,6 +439,17 @@ const ProjectPlanner = ({ project, onClose }) => {
             </div>
             )}
           </div>
+
+          {scheduledHidden && (
+            <button
+              type="button"
+              onClick={() => updateProject(project.id, { plannerScheduledHidden: false })}
+              className={`self-start text-xs ${textSecondary} hover:underline flex items-center gap-1`}
+            >
+              <Eye size={12} />
+              {t('planner.showScheduled', 'Show Scheduled')}{incompleteScheduledCount > 0 ? ` (${incompleteScheduledCount})` : ''}
+            </button>
+          )}
 
           {/* hyperGLANCE settings (moved here from the Edit Project form) */}
           <HyperGlanceEditor

--- a/src/utils/plannerColumns.js
+++ b/src/utils/plannerColumns.js
@@ -1,0 +1,21 @@
+// Column visibility for the per-project PLANNER, extracted pure so hiding the
+// SCHEDULED list (the Bucket List secondListHidden pattern, applied per
+// project via project.plannerScheduledHidden) has one tested source of truth
+// instead of four JSX conditions that can drift.
+//
+// Mobile shows the two columns as tabs; desktop shows them side by side.
+// Hiding SCHEDULED removes its tab and column everywhere, forces the mobile
+// view onto Unscheduled, collapses the desktop grid to one column, and the
+// planner renders a "Show Scheduled" affordance in its place (the Bucket
+// List's show-again button, count included).
+
+export function plannerColumns({ isMobile, activeTab, scheduledHidden }) {
+  const effectiveTab = scheduledHidden ? 'unscheduled' : activeTab;
+  return {
+    effectiveTab,
+    showTabs: isMobile && !scheduledHidden,
+    showScheduled: !scheduledHidden && (!isMobile || effectiveTab === 'scheduled'),
+    showUnscheduled: !isMobile || effectiveTab === 'unscheduled',
+    gridColumns: !isMobile && !scheduledHidden ? 2 : 1,
+  };
+}

--- a/src/utils/plannerColumns.test.js
+++ b/src/utils/plannerColumns.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { plannerColumns } from './plannerColumns.js';
+
+// The contract (Bucket List secondListHidden behavior, per project): hiding
+// SCHEDULED removes its tab and column on every layout, forces the mobile
+// view onto Unscheduled, and collapses the desktop grid to one column;
+// showing it restores the exact pre-feature layout.
+
+describe('plannerColumns', () => {
+  it('desktop, not hidden: both columns side by side, no tabs', () => {
+    expect(plannerColumns({ isMobile: false, activeTab: 'scheduled', scheduledHidden: false })).toEqual({
+      effectiveTab: 'scheduled', showTabs: false, showScheduled: true, showUnscheduled: true, gridColumns: 2,
+    });
+  });
+
+  it('desktop, hidden: only Unscheduled, single column', () => {
+    expect(plannerColumns({ isMobile: false, activeTab: 'scheduled', scheduledHidden: true })).toEqual({
+      effectiveTab: 'unscheduled', showTabs: false, showScheduled: false, showUnscheduled: true, gridColumns: 1,
+    });
+  });
+
+  it('mobile, not hidden: tabs shown, the active tab decides the visible column', () => {
+    expect(plannerColumns({ isMobile: true, activeTab: 'scheduled', scheduledHidden: false })).toEqual({
+      effectiveTab: 'scheduled', showTabs: true, showScheduled: true, showUnscheduled: false, gridColumns: 1,
+    });
+    expect(plannerColumns({ isMobile: true, activeTab: 'unscheduled', scheduledHidden: false })).toEqual({
+      effectiveTab: 'unscheduled', showTabs: true, showScheduled: false, showUnscheduled: true, gridColumns: 1,
+    });
+  });
+
+  it('mobile, hidden: no tabs, forced onto Unscheduled even if Scheduled was the active tab', () => {
+    // THE POINT of effectiveTab: hiding while the Scheduled tab is active must
+    // not leave the planner showing a hidden list (or nothing at all).
+    expect(plannerColumns({ isMobile: true, activeTab: 'scheduled', scheduledHidden: true })).toEqual({
+      effectiveTab: 'unscheduled', showTabs: false, showScheduled: false, showUnscheduled: true, gridColumns: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The Bucket List's hide-Someday behavior, applied to the per-project PLANNER's SCHEDULED list: an `EyeOff` button in the column header hides it, and a small "Show Scheduled (N)" text button restores it, N being the incomplete scheduled count (the same number the mobile tab badge shows, omitted when zero) — matching the Bucket List affordances exactly.

Per the review decision, the hidden state is **per project**: stored as `plannerScheduledHidden` on the project record via `updateProject`, so it syncs with the project like its notes and hyperGLANCE settings, and each planner remembers its own choice.

## Implementation

Column visibility is a single pure function, `plannerColumns({ isMobile, activeTab, scheduledHidden })` (`src/utils/plannerColumns.js`), instead of four JSX conditions that could drift:
- hiding removes the Scheduled **tab** and **column** on every layout
- the mobile view is forced onto Unscheduled (`effectiveTab`) — hiding while the Scheduled tab is active must not strand the planner showing a hidden list
- the desktop grid collapses to one column, and restores to two on re-show

On mobile the tab bar disappears entirely while hidden (one tab is not a choice); the hide button renders right-aligned in the scheduled column on both layouts since the mobile column has no text header (the tab carries the label).

## Verification

Live on desktop under xvfb via CDP: seeded a project with one scheduled and one unscheduled task, opened the Goals & Projects dashboard, expanded the card, opened the PLANNER, and drove the full round trip — hide removed the column and surfaced **"Show Scheduled (1)"**, the stored project record showed `plannerScheduledHidden: true`, and re-show restored the two-column layout and cleared the flag.

- 4 unit tests on the visibility function
- Mutation-verified: 5 mutants (forced-tab removal, tabs-stay-visible, hide-flag ignored on the column, wrong tab source, grid stays two columns), all killed
- Full suite: 114 files, 1729 tests passing; ESLint clean

**Handback:** the mobile layout path is covered by the pure function and the shared render conditions but was not driven live; worth a quick look on your Android build (tab bar disappears when hidden, "Show Scheduled (N)" appears below the Unscheduled list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_