### PR TITLE
Take @glance-apps/sync 1.10.0 with a pull-cursor rollback on failed cycles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@glance-apps/billing": "0.1.1",
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "1.6.1",
+        "@glance-apps/sync": "1.10.0",
         "@modelcontextprotocol/node": "2.0.0",
         "@modelcontextprotocol/server": "2.0.0",
         "hono": "^4.13.1",
@@ -2621,9 +2621,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.6.1.tgz",
-      "integrity": "sha512-cRdLWkX7AreC4h0Gz0lnxum/Nn/uq4OO+Jcjjxq8e4uhT5c3Z25kBDXXbA5VxLw5HGtHYBQanTy4QuYyTzBspw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.10.0.tgz",
+      "integrity": "sha512-/OCQZPm/dsv6OmOMdXj8gjmbKR9F/eXaJdr/8BR7Rs04ScxaSdw1ozSu5cejfLyziMHaelcBecaeKVK8wvmF8A==",
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@glance-apps/billing": "0.1.1",
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "1.6.1",
+    "@glance-apps/sync": "1.10.0",
     "@modelcontextprotocol/node": "2.0.0",
     "@modelcontextprotocol/server": "2.0.0",
     "hono": "^4.13.1",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2,11 +2,13 @@
   "sync": {
     "errors": {
       "AUTH_FAILURE": "Authentication failed. Check your username and password in sync settings.",
+      "CREDENTIAL_INVALID": "The sync server no longer accepts this device's sync access. Your changes are saved on this device. Ask whoever runs your sync server to restore access for this device.",
       "FORBIDDEN": "Sync blocked (403). Your server may be blocking the request.",
       "LOCKED": "Sync is locked by another device. Try again in a moment.",
       "NETWORK_ERROR": "Network error. Check your connection and try again.",
       "PASSPHRASE_REQUIRED": "Enter your sync passphrase to continue.",
       "PRECONDITION_FAILED": "Another device updated first. Retrying.",
+      "QUOTA_EXCEEDED": "The sync server has reached its limit for this account. Your changes are saved on this device and syncing will retry automatically. Ask whoever runs your sync server to raise the limit.",
       "KEY_MISMATCH": "Wrong sync passphrase. It must exactly match the passphrase used on your other devices.",
       "VERIFIER_UNSUPPORTED": "Your GLANCEvault server needs to be updated to support this app version (key verification).",
       "ACCOUNT_ID_REQUIRED": "GLANCEvault is missing an account ID. Re-enter your GLANCEvault details (URL, device token, and account ID) in Cloud Sync settings.",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -2,11 +2,13 @@
   "sync": {
     "errors": {
       "AUTH_FAILURE": "Échec de l'authentification. Vérifiez votre identifiant et votre mot de passe dans les paramètres de synchronisation.",
+      "CREDENTIAL_INVALID": "Le serveur de synchronisation n'accepte plus l'accès de cet appareil. Vos modifications sont enregistrées sur cet appareil. Demandez à la personne qui gère votre serveur de synchronisation de rétablir l'accès pour cet appareil.",
       "FORBIDDEN": "Synchronisation bloquée (403). Votre serveur bloque peut-être la requête.",
       "LOCKED": "La synchronisation est verrouillée par un autre appareil. Réessayez dans un instant.",
       "NETWORK_ERROR": "Erreur réseau. Vérifiez votre connexion et réessayez.",
       "PASSPHRASE_REQUIRED": "Saisissez votre phrase secrète de synchronisation pour continuer.",
       "PRECONDITION_FAILED": "Un autre appareil a effectué la mise à jour en premier. Nouvelle tentative.",
+      "QUOTA_EXCEEDED": "Le serveur de synchronisation a atteint la limite de ce compte. Vos modifications sont enregistrées sur cet appareil et la synchronisation réessaiera automatiquement. Demandez à la personne qui gère votre serveur de synchronisation d'augmenter la limite.",
       "KEY_MISMATCH": "Phrase secrète de synchronisation incorrecte. Elle doit correspondre exactement à celle utilisée sur vos autres appareils.",
       "VERIFIER_UNSUPPORTED": "Votre serveur GLANCEvault doit être mis à jour pour prendre en charge cette version de l'application (vérification de clé).",
       "ACCOUNT_ID_REQUIRED": "Il manque un identifiant de compte à GLANCEvault. Ressaisissez vos informations GLANCEvault (URL, jeton d'appareil et identifiant de compte) dans les paramètres de synchronisation cloud.",

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -447,6 +447,10 @@ export function createDbEngine(callbacks = {}) {
     if (syncing) return;
     syncing = true;
     callbacks.onError?.(null, null);
+    // Pull-cursor value as of cycle start, for the rollback in the catch
+    // below. Captured under the in-flight guard, so nothing else can move the
+    // cursor between here and the rollback.
+    const preCycleHwm = engine.getHighWaterMark();
     try {
       mirror = clone(callbacks.getData()) || {};
 
@@ -730,6 +734,37 @@ export function createDbEngine(callbacks = {}) {
       callbacks.onStatusChange?.('success');
       return { applied: pull?.applied ?? 0, skipped: pull?.skipped ?? 0, skippedEntityIds: pull?.skippedEntityIds ?? [] };
     } catch (err) {
+      // ROLL THE PULL CURSOR BACK to where this cycle started. This looks like
+      // it is fighting the package, and it is — deliberately. As of
+      // @glance-apps/sync 1.10.0 pullRemoteChanges persists the pull cursor
+      // PER PAGE, on the assumption that an applied row is durable the moment
+      // applyRemoteEntity returns. That holds for dbSyncCycle consumers
+      // (lastGLANCE/lifeGLANCE apply straight into their stores); it does not
+      // hold here: our applyRemoteEntity writes into the per-cycle MIRROR,
+      // which this catch discards (commit-only-on-success, above). Without the
+      // rollback, a pull that fails mid-pagination leaves the cursor advanced
+      // past pages whose rows were applied only to the discarded mirror —
+      // those rows sit below the cursor forever, are never re-listed by an
+      // incremental pull, and are unreachable by the glitch heal (which only
+      // re-fetches rows that were in the SNAPSHOT and vanished locally; these
+      // were never in either). Demonstrated as permanent row loss in the
+      // 1.10.0 survey and pinned by dbPullPagination.test.js.
+      //
+      // The rollback restores 1.6.1's mid-pagination failure semantics — a
+      // failed cycle re-pulls from where it started — and goes one step
+      // further: it also rewinds after a pull that SUCCEEDED when a later step
+      // (push, heal, commit) threw, because the mirror is discarded then too
+      // and 1.6.1 had the same loss window on that path. The invariant is
+      // simple: the cursor must never sit ahead of state this device has
+      // actually committed. Re-pulling already-applied rows next cycle is
+      // idempotent (entity-grain LWW).
+      //
+      // The trade, written down: dayGLANCE forfeits 1.10.0's per-page
+      // convergence benefit (a huge backlog on a flaky connection resuming
+      // from the last good page) because it cannot bank it while its commit
+      // is all-or-nothing. Making the benefit safe here would need durable
+      // per-page commits, which is an architecture change, not a bump.
+      try { engine.setHighWaterMark(preCycleHwm); } catch { /* storage unavailable */ }
       const code = err && err.code ? err.code : 'NETWORK_ERROR';
       callbacks.onError?.(err?.message || String(err), code);
       callbacks.onStatusChange?.('error');

--- a/src/sync/dbPullPagination.test.js
+++ b/src/sync/dbPullPagination.test.js
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { setSyncPassphrase } from '@glance-apps/sync';
+import { createDbEngine } from './dbEngine.js';
+import { setVaultConfig } from './vaultConfig.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MULTI-PAGE PULL COVERAGE — the first in this repo. Every other sync test's
+// mock vault returns its whole backlog in one page (hasMore: false), so
+// nothing here-tofore exercised the pagination loop at all, let alone a
+// failure inside it.
+//
+// THE REGRESSION THIS PINS (found in the @glance-apps/sync 1.10.0 survey):
+// 1.10.0 persists the pull cursor PER PAGE, assuming an applied row is
+// durable when applyRemoteEntity returns. dayGLANCE's wrapper applies pulled
+// rows into a per-cycle mirror that is DISCARDED on failure
+// (commit-only-on-success), so a pull failing on page 2 would leave the
+// cursor advanced past page 1's rows while page 1 was never committed —
+// those rows sit below the cursor forever, unreachable by any later
+// incremental pull and by the glitch heal. Demonstrated as permanent row
+// loss before the wrapper grew its cursor rollback (dbEngine.js dbSyncCycle
+// catch); these tests fail without that rollback.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+// In-memory GLANCEvault that serves list() in pages of `pageSize`, with a
+// switch to make the Nth list call throw (the mid-pagination transport
+// failure). Mirrors the surface the real vaultClient exposes to the engine.
+function createPagedVault({ pageSize = 2 } = {}) {
+  const salts = new Map();
+  const log = new Map();
+  let seq = 0;
+  let failListCall = 0; // 0 = never; N = the Nth list() call since arming throws
+  let listCalls = 0;
+  return {
+    async getSalt(accountId) { return salts.get(accountId) || null; },
+    async putSalt(accountId, fresh) { if (!salts.has(accountId)) salts.set(accountId, fresh); return salts.get(accountId); },
+    async batch(app, { rows }) {
+      for (const r of rows) log.set(r.entityId, { entityId: r.entityId, seq: ++seq, envelope: r.envelope, deleted: false });
+      return { maxSeq: seq };
+    },
+    async deleteRow(app, entityId) { log.set(entityId, { entityId, seq: ++seq, envelope: null, deleted: true }); return { seq }; },
+    async list(app, { since }) {
+      listCalls += 1;
+      if (failListCall && listCalls === failListCall) throw new Error('list failed: network blip');
+      const all = [...log.values()].filter((r) => r.seq > since).sort((a, b) => a.seq - b.seq);
+      return { rows: all.slice(0, pageSize), hasMore: all.length > pageSize };
+    },
+    async device() { return { updated: true }; },
+    armFailure(n) { failListCall = n; listCalls = 0; },
+    disarm() { failListCall = 0; listCalls = 0; },
+  };
+}
+
+const EMPTY = {
+  tasks: [], unscheduledTasks: [], recurringTasks: [], recycleBin: [], todayRoutines: [],
+  habits: [], goals: [], projects: [], gtdFrames: [], users: [], dailyNotes: {},
+  completedTaskUids: [], deletedTaskIds: {},
+};
+const clone = (x) => JSON.parse(JSON.stringify(x));
+const task = (id, lastModified) => ({
+  id, title: `task ${id}`, duration: 30, color: 'bg-blue-500', completed: false,
+  notes: '', subtasks: [], lastModified, date: '2026-08-16', startTime: '09:00',
+});
+
+function makeDevice(name, vault, initial) {
+  let data = clone(initial);
+  let nativeKey = null;
+  const engine = createDbEngine({
+    vaultClient: vault,
+    storageKeyPrefix: `dev-${name}`,
+    deviceId: `device-${name}`,
+    nativeGetSyncKey: () => nativeKey,
+    nativeStoreSyncKey: (v) => { nativeKey = v; },
+    getData: () => clone(data),
+    commitData: (d) => { data = d; },
+  });
+  return { engine, get data() { return data; } };
+}
+
+const taskIds = (device) => device.data.tasks.map((t) => t.id).sort();
+
+afterAll(() => { delete global.localStorage; });
+
+describe('multi-page pull: mid-pagination failure must not strand rows below the cursor', () => {
+  let vault;
+  let seeder;
+
+  beforeEach(async () => {
+    global.localStorage = memLocalStorage();
+    setVaultConfig({ enabled: true, vaultUrl: 'https://v', vaultToken: 't', accountId: 'acct' });
+    setSyncPassphrase('pagination-test-passphrase');
+    vault = createPagedVault({ pageSize: 2 });
+    // Seed a two-page backlog (4 rows) from another device.
+    seeder = makeDevice('seeder', vault, {
+      ...EMPTY,
+      tasks: [task('r1', '2026-08-10T10:00:00.000Z'), task('r2', '2026-08-10T10:00:01.000Z'),
+              task('r3', '2026-08-10T10:00:02.000Z'), task('r4', '2026-08-10T10:00:03.000Z')],
+    });
+    await seeder.engine.dbSyncCycle();
+  });
+
+  it('a failed cycle leaves the pull cursor where the cycle started', async () => {
+    const a = makeDevice('A', vault, EMPTY);
+    expect(a.engine.getHighWaterMark()).toBe(0);
+
+    vault.armFailure(2); // page 1 lists fine, page 2's list call throws
+    const failed = await a.engine.dbSyncCycle();
+    vault.disarm();
+
+    expect(failed.error).toMatch(/network blip/);
+    // THE REGRESSION: under 1.10.0 the engine persists the cursor after
+    // page 1, so without the wrapper's rollback this reads 2 — past rows
+    // that were applied only to the discarded mirror.
+    expect(
+      a.engine.getHighWaterMark(),
+      'cursor advanced past pages the failed cycle never committed - the rollback in dbSyncCycle\'s catch is missing or broken',
+    ).toBe(0);
+    // Commit-only-on-success: the failed cycle committed nothing.
+    expect(taskIds(a)).toEqual([]);
+  });
+
+  it('after a mid-pagination failure, one clean cycle converges to ALL rows', async () => {
+    const a = makeDevice('A', vault, EMPTY);
+    vault.armFailure(2);
+    await a.engine.dbSyncCycle();
+    vault.disarm();
+
+    await a.engine.dbSyncCycle();
+    // Without the rollback this converges to only ['r3', 'r4']: r1/r2 sit
+    // below the advanced cursor and no incremental pull ever re-lists them.
+    expect(
+      taskIds(a),
+      'rows consumed by the failed cycle were lost below the cursor (the 1.10.0 per-page persistence hazard)',
+    ).toEqual(['r1', 'r2', 'r3', 'r4']);
+  });
+
+  it('happy path: a multi-page pull with no failure converges in one cycle and advances the cursor', async () => {
+    const a = makeDevice('A', vault, EMPTY);
+    const res = await a.engine.dbSyncCycle();
+    expect(res.error).toBeUndefined();
+    expect(taskIds(a)).toEqual(['r1', 'r2', 'r3', 'r4']);
+    expect(a.engine.getHighWaterMark()).toBeGreaterThan(0);
+  });
+
+  it('steady state: a later multi-page backlog with a mid-pagination failure also recovers', async () => {
+    // Device A converges first (cursor > 0), THEN a new two-page backlog
+    // arrives and its pull fails between pages: the rollback must return the
+    // cursor to the pre-cycle value, not to zero, and the retry must converge.
+    const a = makeDevice('A', vault, EMPTY);
+    await a.engine.dbSyncCycle();
+    const settledHwm = a.engine.getHighWaterMark();
+
+    // New rows appear in the seeder's live data; its wrapper's snapshot diff
+    // marks them dirty at cycle time (no markDirty needed at write sites).
+    const s = seeder.data;
+    s.tasks.push(task('r5', '2026-08-11T10:00:00.000Z'), task('r6', '2026-08-11T10:00:01.000Z'), task('r7', '2026-08-11T10:00:02.000Z'));
+    await seeder.engine.dbSyncCycle();
+
+    vault.armFailure(2);
+    await a.engine.dbSyncCycle();
+    vault.disarm();
+    expect(a.engine.getHighWaterMark()).toBe(settledHwm);
+
+    await a.engine.dbSyncCycle();
+    expect(taskIds(a)).toEqual(['r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7']);
+  });
+});

--- a/src/sync/syncErrors.test.js
+++ b/src/sync/syncErrors.test.js
@@ -25,3 +25,43 @@ describe('syncErrorText', () => {
     expect(syncErrorText(t, 'Plain message', undefined)).toBe('Plain message');
   });
 });
+
+// The two DB-tier codes @glance-apps/sync 1.9.0/1.10.0 introduced. Wording is
+// copied verbatim from what lastGLANCE/lifeGLANCE shipped, with the two
+// constraints that shaped it: the quota message gives NO deletion advice
+// (deletes leave tombstones and reclaim is an operator action, so no user
+// action reduces usage) and points at whoever runs the server; the credential
+// message avoids "password"/"passphrase" (the passphrase prompt is the wrong
+// fix) and leads with local data being safe rather than with sync stopping.
+import en from '../../public/locales/en/translation.json';
+import fr from '../../public/locales/fr/translation.json';
+
+describe('locale coverage for the 1.10.0 engine codes', () => {
+  const realT = (locale) => (key, opts = {}) => {
+    const value = key.split('.').reduce((o, k) => (o == null ? o : o[k]), locale);
+    return typeof value === 'string' ? value : (opts.defaultValue ?? key);
+  };
+
+  it.each([
+    ['QUOTA_EXCEEDED'],
+    ['CREDENTIAL_INVALID'],
+  ])('%s renders from both locales through syncErrorText', (code) => {
+    for (const locale of [en, fr]) {
+      const rendered = syncErrorText(realT(locale), 'engine fallback message', code);
+      expect(rendered, `missing sync.errors.${code}`).not.toBe('engine fallback message');
+      expect(rendered.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('the quota message contains no deletion advice and points at the operator', () => {
+    expect(en.sync.errors.QUOTA_EXCEEDED).not.toMatch(/delete|remove|free up/i);
+    expect(en.sync.errors.QUOTA_EXCEEDED).toMatch(/whoever runs your sync server/);
+    expect(en.sync.errors.QUOTA_EXCEEDED).toMatch(/saved on this device/);
+  });
+
+  it('the credential message avoids passphrase language and reassures first', () => {
+    expect(en.sync.errors.CREDENTIAL_INVALID).not.toMatch(/password|passphrase/i);
+    expect(en.sync.errors.CREDENTIAL_INVALID).toMatch(/^The sync server no longer accepts/);
+    expect(en.sync.errors.CREDENTIAL_INVALID).toMatch(/saved on this device/);
+  });
+});


### PR DESCRIPTION
## Why a version bump carries a behavioral fix

The pre-bump survey found that **1.10.0 introduces a data-loss window specific to dayGLANCE's composed cycle**. 1.10.0 persists the pull cursor **per page**, on the assumption that an applied row is durable the moment `applyRemoteEntity` returns. That assumption holds for `dbSyncCycle` consumers (lastGLANCE and lifeGLANCE apply pulled rows straight into their stores). dayGLANCE's wrapper applies pulled rows into a **per-cycle mirror that is discarded on failure** (commit-only-on-success), so a pull failing on page 2 leaves the cursor advanced past page 1's rows while page 1 was never committed. Those rows sit below the cursor forever: no incremental pull re-lists them, and the glitch heal cannot reach them (it only re-fetches rows that were in the snapshot and vanished locally — these were never in either). Proven with a probe against both versions: under 1.10.0, a device recovering from a mid-pagination first-sync failure converged to `[r3, r4]` out of four rows, with `r1, r2` permanently lost; under 1.6.1 it converged fully. The restore paths (`resetVaultSyncCursor`'s five call sites) manufacture exactly this scenario — a zeroed cursor in front of a large paginated pull.

## The fix: cursor rollback in the wrapper's catch

`src/sync/dbEngine.js`: capture `engine.getHighWaterMark()` at cycle start (under the in-flight guard, so nothing else can move it), restore it with `engine.setHighWaterMark(preCycleHwm)` on any failed cycle. The trade is written down at the rollback site in the survey's terms: the rollback looks like it is fighting the package, and it is, deliberately — **dayGLANCE forfeits 1.10.0's per-page convergence benefit because it cannot bank it while its commit is all-or-nothing**. Making the benefit safe would need durable per-page commits, which is an architecture change, not a bump.

**One design decision surfaced rather than silently chosen:** the rollback fires on *any* failed cycle, not only failed pulls. A cycle whose pull succeeded but whose push/heal/commit threw also discards the mirror, so 1.6.1 had the *same* loss window on that path (its cursor was already advanced by the completed pull). The invariant the rollback enforces is uniform: the cursor never sits ahead of state this device has actually committed. This is therefore slightly *stronger* than a strict 1.6.1 restoration, and strictly safer; re-pulling already-applied rows on the next cycle is idempotent (entity-grain LWW). The seed gate's ordering protection is untouched — it is ordering-based (a failing pull throws past the push in the same `try`), and neither the capture nor the rollback disturbs that ordering.

## The regression test: the repo's first multi-page pull coverage

Every other sync test's mock vault returns its whole backlog in one page (`hasMore: false`), so nothing exercised the pagination loop before this. `src/sync/dbPullPagination.test.js` (4 tests, built from the survey's probe):

1. A failed cycle leaves the pull cursor where the cycle started (asserted directly).
2. After a mid-pagination failure, one clean cycle converges to **all** rows.
3. Happy path: a multi-page pull with no failure converges in one cycle (the control — this test passes with or without the rollback, and is the guard that the rollback does not break normal operation).
4. Steady state: a later multi-page backlog failing mid-pull rolls back to the pre-cycle cursor (not zero) and recovers.

**Verified to fail without the rollback**, since a test that passes either way proves nothing. With the rollback line removed:

```
× a failed cycle leaves the pull cursor where the cycle started
    AssertionError: cursor advanced past pages the failed cycle never committed … expected 2 to be +0
× after a mid-pagination failure, one clean cycle converges to ALL rows
    AssertionError: rows consumed by the failed cycle were lost below the cursor … expected [ 'r3', 'r4' ] to deeply equal [ 'r1', 'r2', 'r3', 'r4' ]
× steady state: a later multi-page backlog with a mid-pagination failure also recovers
    AssertionError: expected 10 to be 6
Tests  3 failed | 1 passed (4)
```

With the rollback restored: 4/4 green.

## Locale keys

`sync.errors.QUOTA_EXCEEDED` and `sync.errors.CREDENTIAL_INVALID` added to `en` and `fr`, **wording copied verbatim from lastGLANCE's shipped locales** (checked out and copied, not approximated), which encode both constraints: the quota message gives no deletion advice (deletes leave tombstones and reclaim is an operator action; it says the data is safe locally and points at whoever runs the server), and the credential message avoids "password"/"passphrase" and leads with local data being safe rather than with sync having stopped. Tests in `syncErrors.test.js` render both keys from both locales through `syncErrorText` and pin both wording constraints. Note: **`CREDENTIAL_INVALID` is unreachable in dayGLANCE today** — shared-token auth cannot mint it, and the wrapper shadows the package cycle that owns the halt — the keys exist for consistency with lastGLANCE/lifeGLANCE and for whenever that changes.

## Two findings on record, beyond this bump

- **Backoff windows cannot be advanced by a composed caller.** The 1.10.0 windows are in-memory objects, and the only writers (`recordFailure`/`clearWindow`) live inside the package's `dbSyncCycle`, which dayGLANCE never invokes. A guard reading `getBackoffState()` from dayGLANCE's composed cycle would read a window that never opens, never escalates, and never closes. Backoff awareness for composed callers requires package support; nothing in this PR attempts it.
- **The package's durability assumption is a design issue, not a dayGLANCE quirk.** 1.10.0 persists a cursor on the assumption that an applied row is durable when `applyRemoteEntity` returns. That holds for two consumers and breaks silently — with data loss — for the third. Either the primitives should not persist a cursor the caller has not committed behind, or the durability contract needs to be explicit in the package. The rollback here is a local mitigation of a package-level problem.

## Scope discipline

Out of scope, per the go-ahead: the `err.quota` descriptor UI (the wrapper forwards only `message` and `code`; the English message already embeds the numbers), extending `SYNC_CURSOR_KEY_SUFFIXES` (the survey established it is complete for every key that can exist in dayGLANCE), anything toward adopting `dbSyncCycle`, backoff awareness, and per-account/enrollment work. The file/WebDAV tier is untouched — `engine.js` is byte-identical between 1.6.1 and 1.10.0 (verified with `cmp` in the survey), and no file-tier code changed here.

## Verification

1. Regression tests pass under 1.10.0 with the rollback; demonstrably fail without it (output above).
2. The probe's original scenario converges: mid-pagination failure, then a clean cycle, ends with all four rows.
3. Multi-page happy path unaffected (test 3).
4. A failed cycle leaves the cursor where it started, asserted directly (test 1) including the non-zero steady-state variant (test 4).
5. Full suite: 119 files, 1769 tests green; ESLint clean; both electron tsconfigs clean.
6. Both locale keys render from both locales through `syncErrorText`, with the wording constraints pinned by test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_