### PR TITLE
Android: make purchase acknowledgement reliable

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/AckRetryPolicy.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/AckRetryPolicy.kt
@@ -1,0 +1,92 @@
+package com.dayglance.app.billing
+
+/**
+ * Decision logic for retrying Google Play purchase acknowledgement — the pure
+ * half of the ack-retry lane (the SseBackoff pattern: decisions in a
+ * dependency-free file with tests, wiring in AckRetryWorker/BillingManager).
+ * No Play Billing import on purpose, so the tests run on a plain JVM; the
+ * response-code constants below are Play's stable public API values.
+ *
+ * WHY THIS EXISTS: Google Play auto-refunds any purchase not acknowledged
+ * within three days and revokes the entitlement. The ack call used to be
+ * fire-and-forget; if it failed (dropped connection right after purchase) and
+ * the user did not reopen the app within 72 hours, they were silently
+ * refunded and lost what they paid for. The retry lane this file decides for
+ * must terminate correctly in every case:
+ *
+ *  - OK, or a fresh Play query reporting the purchase already acknowledged
+ *    (isAcknowledged is treated as AUTHORITATIVE success) → done.
+ *  - ITEM_NOT_OWNED / DEVELOPER_ERROR → terminal: the purchase no longer
+ *    exists for us (refunded, consumed) or the token is malformed; retrying
+ *    forever would hammer Play for a purchase that can never be acknowledged.
+ *    The pending record is cleared but the diagnostic evidence is kept.
+ *  - Everything else → retry, until the pending record is older than the
+ *    three-day acknowledgement window; then stop, evidence kept.
+ *
+ * CONSERVATIVE BY DESIGN: only the two clearly-terminal codes give up early.
+ * A retry that gives up wrongly costs the user a refund and us a sale; a
+ * retry that continues wrongly costs a log line. Connection failures are
+ * never treated as terminal at all — only an actual acknowledge response can
+ * claim the purchase is gone.
+ */
+object AckRetryPolicy {
+
+    // BillingClient.BillingResponseCode values (stable public constants),
+    // declared locally to keep this file JVM-pure.
+    const val OK = 0
+    const val DEVELOPER_ERROR = 5
+    const val ITEM_NOT_OWNED = 8
+
+    /**
+     * Play's acknowledgement window: three days from purchase. The pending
+     * record's firstFailedAt is a lower bound on purchase age, so measuring
+     * the window from it never gives up early.
+     */
+    const val ACK_WINDOW_MS: Long = 3L * 24 * 60 * 60 * 1000
+
+    enum class Decision {
+        /** Acknowledged (now or previously). Clear the pending record. */
+        SUCCESS,
+        /** Transient failure inside the window. Keep the record, retry later. */
+        RETRY,
+        /** The purchase can never be acknowledged. Clear the record, keep evidence. */
+        GIVE_UP_TERMINAL,
+        /** The window has passed; Play has already resolved it one way or the
+         *  other. Clear the record, keep evidence. */
+        GIVE_UP_WINDOW,
+    }
+
+    /**
+     * Decide the outcome of one acknowledge attempt.
+     *
+     * @param responseCode        BillingResponseCode from acknowledgePurchase
+     * @param alreadyAcknowledged isAcknowledged from a FRESH purchases query,
+     *                            checked before attempting the ack — authoritative
+     *                            success regardless of any response code
+     * @param firstFailedAtMs     epoch ms of the first failed ack for this token
+     * @param nowMs               injected clock
+     */
+    fun decide(
+        responseCode: Int,
+        alreadyAcknowledged: Boolean,
+        firstFailedAtMs: Long,
+        nowMs: Long,
+    ): Decision {
+        if (alreadyAcknowledged || responseCode == OK) return Decision.SUCCESS
+        if (responseCode == ITEM_NOT_OWNED || responseCode == DEVELOPER_ERROR) {
+            return Decision.GIVE_UP_TERMINAL
+        }
+        if (nowMs - firstFailedAtMs >= ACK_WINDOW_MS) return Decision.GIVE_UP_WINDOW
+        return Decision.RETRY
+    }
+
+    /**
+     * Decide the outcome of a failed billing CONNECTION (the ack was never
+     * attempted). Never terminal — a setup failure says nothing about the
+     * purchase — but still window-capped so the chain cannot run forever.
+     */
+    fun decideConnectionFailure(firstFailedAtMs: Long, nowMs: Long): Decision {
+        if (nowMs - firstFailedAtMs >= ACK_WINDOW_MS) return Decision.GIVE_UP_WINDOW
+        return Decision.RETRY
+    }
+}

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/AckRetryWorker.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/AckRetryWorker.kt
@@ -1,0 +1,241 @@
+package com.dayglance.app.billing
+
+import android.content.Context
+import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.android.billingclient.api.AcknowledgePurchaseParams
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClientStateListener
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.PendingPurchasesParams
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.QueryPurchasesParams
+import com.dayglance.app.data.SharedDataStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.resume
+
+/**
+ * WorkManager retry lane for Google Play purchase acknowledgement.
+ *
+ * Google refunds any purchase not acknowledged within three days. The pending
+ * record in [SharedDataStore] (written the moment an ack fails, see
+ * [recordFailureAndSchedule]) is the durable obligation; this worker drains it.
+ * WorkManager persists the job across process death and device reboot, waits
+ * for connectivity (NetworkType.CONNECTED), and drives the exponential backoff
+ * (Result.retry) — which is exactly the coverage the failure needs: the user
+ * closing the app right after a failed ack, and not reopening it for days, is
+ * the scenario the three-day refund punishes.
+ *
+ * DELIBERATELY INDEPENDENT of BillingManager's shared BillingClient: this
+ * worker constructs its own short-lived client per attempt and always closes
+ * it. The shared instance is built once and endConnection()'d on every
+ * onStop; Google documents a BillingClient as non-reusable after
+ * endConnection, so a retry lane that leaned on it could be leaning on a dead
+ * client (the reuse hazard is reported separately and NOT fixed here). A
+ * fresh client per attempt cannot inherit that state.
+ *
+ * Decisions (what is success, what is terminal, when to stop) live in the
+ * pure [AckRetryPolicy]; this file is wiring. Entitlement is NEVER touched
+ * here: acknowledgement is an obligation to Google, not a condition of
+ * service, and subscriptionActive is owned by the purchase/query paths.
+ */
+class AckRetryWorker(
+    private val appContext: Context,
+    workerParams: WorkerParameters,
+) : CoroutineWorker(appContext, workerParams) {
+
+    companion object {
+        private const val TAG = "DayGlanceBilling"
+        const val UNIQUE_WORK_NAME = "billing-ack-retry"
+
+        /**
+         * Enqueue the retry chain. ExistingWorkPolicy.KEEP so a chain already
+         * mid-backoff keeps its position (the pending record in SharedDataStore
+         * is the single source of truth for WHAT to acknowledge — the running
+         * chain reads it at attempt time, so scheduling is idempotent and safe
+         * to call as a backstop from queryPurchases).
+         */
+        fun schedule(context: Context) {
+            val request = OneTimeWorkRequestBuilder<AckRetryWorker>()
+                .setConstraints(
+                    Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+                )
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 1, TimeUnit.MINUTES)
+                .build()
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.KEEP, request)
+        }
+
+        /**
+         * Record a failed acknowledge attempt and make sure the retry chain is
+         * scheduled. Called from BillingManager's ack callback (both the
+         * purchase-time ack and the launch re-ack) and from this worker.
+         * A failure for a NEW token replaces the record and re-anchors the
+         * window; repeat failures for the same token only bump the attempt
+         * count, so firstFailedAt keeps measuring from the first failure.
+         */
+        fun recordFailureAndSchedule(
+            context: Context,
+            dataStore: SharedDataStore,
+            token: String,
+            productId: String?,
+            responseCode: Int,
+            nowMs: Long = System.currentTimeMillis(),
+        ) {
+            if (dataStore.pendingAckToken != token) {
+                dataStore.pendingAckToken = token
+                dataStore.pendingAckProductId = productId
+                dataStore.pendingAckFirstFailedAt = nowMs
+                dataStore.pendingAckAttempts = 1
+            } else {
+                dataStore.pendingAckAttempts = dataStore.pendingAckAttempts + 1
+            }
+            dataStore.lastAckOutcome = "retrying"
+            dataStore.lastAckFailureCode = responseCode
+            dataStore.lastAckFailureAt = nowMs
+            Log.w(
+                TAG,
+                "acknowledgePurchase failed: code=$responseCode token=…${token.takeLast(8)} " +
+                    "attempt=${dataStore.pendingAckAttempts} — retry scheduled " +
+                    "(Play refunds unacknowledged purchases after 3 days)"
+            )
+            schedule(context)
+        }
+
+        /**
+         * Record a successful acknowledgement (first try or retry) and clear
+         * any matching pending record. Success for a DIFFERENT token leaves an
+         * unrelated pending record alone.
+         */
+        fun recordSuccess(dataStore: SharedDataStore, token: String) {
+            if (dataStore.pendingAckToken == token) clearPending(dataStore)
+            dataStore.lastAckOutcome = "success"
+            dataStore.lastAckSuccessAt = System.currentTimeMillis()
+        }
+
+        private fun clearPending(dataStore: SharedDataStore) {
+            dataStore.pendingAckToken = null
+            dataStore.pendingAckProductId = null
+            dataStore.pendingAckFirstFailedAt = 0L
+            dataStore.pendingAckAttempts = 0
+        }
+
+        private fun giveUp(dataStore: SharedDataStore, outcome: String, token: String, attempts: Int) {
+            clearPending(dataStore)
+            dataStore.lastAckOutcome = outcome
+            Log.w(
+                TAG,
+                "acknowledgePurchase given up ($outcome): token=…${token.takeLast(8)} after $attempts attempt(s) — " +
+                    "evidence kept in billing diagnostics"
+            )
+        }
+    }
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        val dataStore = SharedDataStore(appContext)
+        val token = dataStore.pendingAckToken ?: return@withContext Result.success()
+        val firstFailedAt = dataStore.pendingAckFirstFailedAt
+        val now = System.currentTimeMillis()
+
+        // Own short-lived client — see the class header. The listener is
+        // required by the builder but purchases never arrive through a worker.
+        val client = BillingClient.newBuilder(appContext)
+            .setListener { _, _ -> }
+            .enablePendingPurchases(PendingPurchasesParams.newBuilder().enableOneTimeProducts().build())
+            .build()
+        try {
+            val setup = connect(client)
+            if (setup.responseCode != BillingClient.BillingResponseCode.OK) {
+                return@withContext when (AckRetryPolicy.decideConnectionFailure(firstFailedAt, now)) {
+                    AckRetryPolicy.Decision.GIVE_UP_WINDOW -> {
+                        giveUp(dataStore, "gave_up_window", token, dataStore.pendingAckAttempts)
+                        Result.success()
+                    }
+                    else -> {
+                        // Connection failures are never terminal (policy): count
+                        // the attempt and let WorkManager's backoff space the next.
+                        recordFailureAndSchedule(appContext, dataStore, token,
+                            dataStore.pendingAckProductId, setup.responseCode, now)
+                        Result.retry()
+                    }
+                }
+            }
+
+            // Authoritative check first: a fresh query saying isAcknowledged
+            // wins over any response code (the conservative idempotence rule —
+            // double-ack handling must treat "already acknowledged" as success,
+            // never as an error to retry forever).
+            val alreadyAcked = queryAllPurchases(client)
+                .firstOrNull { it.purchaseToken == token }?.isAcknowledged == true
+
+            val ackCode = if (alreadyAcked) AckRetryPolicy.OK else acknowledge(client, token)
+
+            when (AckRetryPolicy.decide(ackCode, alreadyAcked, firstFailedAt, now)) {
+                AckRetryPolicy.Decision.SUCCESS -> {
+                    val attempts = dataStore.pendingAckAttempts
+                    recordSuccess(dataStore, token)
+                    Log.w(TAG, "acknowledgePurchase recovered on retry: token=…${token.takeLast(8)} after $attempts failed attempt(s)")
+                    Result.success()
+                }
+                AckRetryPolicy.Decision.GIVE_UP_TERMINAL -> {
+                    giveUp(dataStore, "gave_up_terminal", token, dataStore.pendingAckAttempts)
+                    Result.success()
+                }
+                AckRetryPolicy.Decision.GIVE_UP_WINDOW -> {
+                    giveUp(dataStore, "gave_up_window", token, dataStore.pendingAckAttempts)
+                    Result.success()
+                }
+                AckRetryPolicy.Decision.RETRY -> {
+                    recordFailureAndSchedule(appContext, dataStore, token,
+                        dataStore.pendingAckProductId, ackCode, now)
+                    Result.retry()
+                }
+            }
+        } finally {
+            runCatching { client.endConnection() }
+        }
+    }
+
+    private suspend fun connect(client: BillingClient): BillingResult =
+        suspendCancellableCoroutine { cont ->
+            val resumed = AtomicBoolean(false)
+            client.startConnection(object : BillingClientStateListener {
+                override fun onBillingSetupFinished(result: BillingResult) {
+                    if (resumed.compareAndSet(false, true)) cont.resume(result)
+                }
+                override fun onBillingServiceDisconnected() {
+                    // A later attempt gets a fresh client; nothing to do here.
+                }
+            })
+        }
+
+    private suspend fun queryAllPurchases(client: BillingClient): List<Purchase> {
+        val subs = queryPurchasesForType(client, BillingClient.ProductType.SUBS)
+        val inapp = queryPurchasesForType(client, BillingClient.ProductType.INAPP)
+        return subs + inapp
+    }
+
+    private suspend fun queryPurchasesForType(client: BillingClient, productType: String): List<Purchase> =
+        suspendCancellableCoroutine { cont ->
+            client.queryPurchasesAsync(
+                QueryPurchasesParams.newBuilder().setProductType(productType).build()
+            ) { _, purchases -> cont.resume(purchases) }
+        }
+
+    private suspend fun acknowledge(client: BillingClient, token: String): Int =
+        suspendCancellableCoroutine { cont ->
+            val params = AcknowledgePurchaseParams.newBuilder().setPurchaseToken(token).build()
+            client.acknowledgePurchase(params) { result -> cont.resume(result.responseCode) }
+        }
+}

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
@@ -206,7 +206,18 @@ class BillingManager(
                 .firstOrNull { it.purchaseState == Purchase.PurchaseState.PURCHASED }
 
             if (active != null) {
-                if (!active.isAcknowledged) acknowledgePurchase(active)
+                if (!active.isAcknowledged) {
+                    // Opportunistic re-ack lane: outcome-aware (recorded and
+                    // retried on failure via acknowledgePurchase), no longer a
+                    // blind extra attempt.
+                    acknowledgePurchase(active)
+                } else if (dataStore.pendingAckToken == active.purchaseToken) {
+                    // Play reports the pending token acknowledged (the retry
+                    // worker, a prior blind re-ack, or Play itself caught up):
+                    // isAcknowledged from a fresh query is authoritative success.
+                    AckRetryWorker.recordSuccess(dataStore, active.purchaseToken)
+                    logd("pending ack cleared: Play reports token=…${active.purchaseToken.takeLast(8)} acknowledged")
+                }
                 dataStore.subscriptionActive = true
                 dataStore.subscriptionProductId = active.products.firstOrNull()
                 dataStore.subscriptionToken = active.purchaseToken
@@ -215,6 +226,12 @@ class BillingManager(
                 dataStore.subscriptionProductId = null
                 dataStore.subscriptionToken = null
             }
+            // Backstop: a pending-ack record with no live retry chain (WorkManager
+            // state cleared by the OS or the user) gets re-scheduled here. KEEP
+            // policy makes this a no-op while the chain is alive. The worker's
+            // own query settles a record whose purchase has since vanished
+            // (terminal ITEM_NOT_OWNED) or aged out (three-day window).
+            if (dataStore.pendingAckToken != null) AckRetryWorker.schedule(context)
             onPurchasesQueried?.invoke()
             onPurchasesQueried = null
         }
@@ -321,11 +338,32 @@ class BillingManager(
         onBillingEvent?.invoke("success", BillingClient.BillingResponseCode.OK, "", pid)
     }
 
+    /**
+     * Acknowledge a purchase, with the result recorded rather than discarded.
+     * Play refunds any purchase not acknowledged within three days, so a
+     * failure here is real money: it is persisted as a pending-ack record and
+     * retried by AckRetryWorker (WorkManager: survives process death and
+     * reboot, waits for connectivity, exponential backoff) until it succeeds,
+     * proves terminal, or ages past the three-day window. Entitlement is NOT
+     * gated on any of this — subscriptionActive is set by the callers before
+     * or regardless of the ack outcome, deliberately.
+     */
     private fun acknowledgePurchase(purchase: Purchase) {
+        val token = purchase.purchaseToken
+        val productId = purchase.products.firstOrNull()
         val params = AcknowledgePurchaseParams.newBuilder()
-            .setPurchaseToken(purchase.purchaseToken)
+            .setPurchaseToken(token)
             .build()
-        billingClient.acknowledgePurchase(params) { /* fire and forget */ }
+        billingClient.acknowledgePurchase(params) { result ->
+            if (result.responseCode == BillingClient.BillingResponseCode.OK) {
+                AckRetryWorker.recordSuccess(dataStore, token)
+                logd("acknowledgePurchase OK: token=…${token.takeLast(8)}")
+            } else {
+                AckRetryWorker.recordFailureAndSchedule(
+                    context, dataStore, token, productId, result.responseCode
+                )
+            }
+        }
     }
 
     fun consumePurchase(token: String, onComplete: (success: Boolean) -> Unit) {

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/SubscriptionBridge.kt
@@ -126,6 +126,44 @@ class SubscriptionBridge(
         """{"dayglance_pro_annual":${dataStore.trialEligibleAnnual}}"""
 
     /**
+     * Read-only acknowledgement diagnostics — the "make failure visible"
+     * surface for the ack-retry lane (billing/AckRetryPolicy.kt). Reachable
+     * through the web layer's hidden dev menu (the same 7-tap path that arms
+     * consumeTestPurchase), and cheap enough to call anytime. No analytics
+     * pipeline: this plus the Log.w lines in the retry lane are the whole
+     * mechanism.
+     *
+     * The pending token is truncated to its last 8 characters (the logd
+     * convention in BillingManager): enough to correlate with logcat, not
+     * enough to leak a usable purchase token to the page.
+     *
+     * Response:
+     *   {"pendingAck": {"tokenTail": "…abc12345", "productId": "...",
+     *                   "firstFailedAt": 0, "attempts": 0} | null,
+     *    "lastOutcome": "success"|"retrying"|"gave_up_terminal"|"gave_up_window"|null,
+     *    "lastFailureCode": 0, "lastFailureAt": 0, "lastSuccessAt": 0}
+     */
+    @JavascriptInterface
+    fun getBillingDiagnostics(): String {
+        val pendingToken = dataStore.pendingAckToken
+        val pending = if (pendingToken != null) {
+            JSONObject().apply {
+                put("tokenTail", "…" + pendingToken.takeLast(8))
+                put("productId", dataStore.pendingAckProductId ?: "")
+                put("firstFailedAt", dataStore.pendingAckFirstFailedAt)
+                put("attempts", dataStore.pendingAckAttempts)
+            }
+        } else JSONObject.NULL
+        return JSONObject().apply {
+            put("pendingAck", pending)
+            put("lastOutcome", dataStore.lastAckOutcome ?: JSONObject.NULL)
+            put("lastFailureCode", dataStore.lastAckFailureCode)
+            put("lastFailureAt", dataStore.lastAckFailureAt)
+            put("lastSuccessAt", dataStore.lastAckSuccessAt)
+        }.toString()
+    }
+
+    /**
      * Consumes the stored lifetime purchase token so it can be bought again.
      * Only available on play builds (BILLING_ENABLED=true). Intended for testing.
      * Result is delivered via window.__billingEvent with status "consumed" or "consume_failed".

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/SharedDataStore.kt
@@ -227,6 +227,66 @@ class SharedDataStore(context: Context) {
             else remove(KEY_SUBSCRIPTION_TOKEN)
         }
 
+    // ── Purchase acknowledgement retry (see billing/AckRetryPolicy.kt) ──────
+    // The pending record is what makes a failed acknowledgement durable: it is
+    // written the moment an ack fails and survives process death, so the retry
+    // lane (AckRetryWorker) always has something to work from. Cleared only on
+    // authoritative success or a terminal/window give-up.
+
+    /** Purchase token awaiting acknowledgement after a failed ack, or null. */
+    var pendingAckToken: String?
+        get() = prefs.getString(KEY_PENDING_ACK_TOKEN, null)
+        set(value) = prefs.edit {
+            if (value != null) putString(KEY_PENDING_ACK_TOKEN, value)
+            else remove(KEY_PENDING_ACK_TOKEN)
+        }
+
+    /** Product id for the pending-ack purchase (diagnostics only). */
+    var pendingAckProductId: String?
+        get() = prefs.getString(KEY_PENDING_ACK_PRODUCT_ID, null)
+        set(value) = prefs.edit {
+            if (value != null) putString(KEY_PENDING_ACK_PRODUCT_ID, value)
+            else remove(KEY_PENDING_ACK_PRODUCT_ID)
+        }
+
+    /** Epoch ms of the FIRST failed ack for the pending token — the anchor the
+     *  three-day give-up window is measured from. 0 = none. */
+    var pendingAckFirstFailedAt: Long
+        get() = prefs.getLong(KEY_PENDING_ACK_FIRST_FAILED_AT, 0L)
+        set(value) = prefs.edit { putLong(KEY_PENDING_ACK_FIRST_FAILED_AT, value) }
+
+    /** Failed attempts so far for the pending token (diagnostics). */
+    var pendingAckAttempts: Int
+        get() = prefs.getInt(KEY_PENDING_ACK_ATTEMPTS, 0)
+        set(value) = prefs.edit { putInt(KEY_PENDING_ACK_ATTEMPTS, value) }
+
+    // Acknowledgement diagnostics — the "make failure visible" record. Written
+    // on every outcome and NEVER cleared, so a support conversation (or the
+    // hidden dev menu, via SubscriptionBridge.getBillingDiagnostics) can see
+    // what happened after the fact. lastAckOutcome values: "success",
+    // "retrying", "gave_up_terminal", "gave_up_window".
+    var lastAckOutcome: String?
+        get() = prefs.getString(KEY_LAST_ACK_OUTCOME, null)
+        set(value) = prefs.edit {
+            if (value != null) putString(KEY_LAST_ACK_OUTCOME, value)
+            else remove(KEY_LAST_ACK_OUTCOME)
+        }
+
+    /** BillingResponseCode of the most recent failed ack. 0 = none recorded. */
+    var lastAckFailureCode: Int
+        get() = prefs.getInt(KEY_LAST_ACK_FAILURE_CODE, 0)
+        set(value) = prefs.edit { putInt(KEY_LAST_ACK_FAILURE_CODE, value) }
+
+    /** Epoch ms of the most recent failed ack. 0 = never. */
+    var lastAckFailureAt: Long
+        get() = prefs.getLong(KEY_LAST_ACK_FAILURE_AT, 0L)
+        set(value) = prefs.edit { putLong(KEY_LAST_ACK_FAILURE_AT, value) }
+
+    /** Epoch ms of the most recent successful ack (first try or retry). 0 = never. */
+    var lastAckSuccessAt: Long
+        get() = prefs.getLong(KEY_LAST_ACK_SUCCESS_AT, 0L)
+        set(value) = prefs.edit { putLong(KEY_LAST_ACK_SUCCESS_AT, value) }
+
     /** Localized price string for the annual plan, e.g. "£19.99". Null until first Play query. */
     var productPriceAnnual: String?
         get() = prefs.getString(KEY_PRODUCT_PRICE_ANNUAL, null)
@@ -305,6 +365,14 @@ class SharedDataStore(context: Context) {
         private const val KEY_PRODUCT_PRICE_LIFETIME = "product_price_lifetime"
         private const val KEY_TRIAL_ELIGIBLE_ANNUAL  = "trial_eligible_annual"
         private const val KEY_TRIAL_DAYS_ANNUAL      = "trial_days_annual"
+        private const val KEY_PENDING_ACK_TOKEN           = "pending_ack_token"
+        private const val KEY_PENDING_ACK_PRODUCT_ID      = "pending_ack_product_id"
+        private const val KEY_PENDING_ACK_FIRST_FAILED_AT = "pending_ack_first_failed_at"
+        private const val KEY_PENDING_ACK_ATTEMPTS        = "pending_ack_attempts"
+        private const val KEY_LAST_ACK_OUTCOME            = "last_ack_outcome"
+        private const val KEY_LAST_ACK_FAILURE_CODE       = "last_ack_failure_code"
+        private const val KEY_LAST_ACK_FAILURE_AT         = "last_ack_failure_at"
+        private const val KEY_LAST_ACK_SUCCESS_AT         = "last_ack_success_at"
 
         const val DEFAULT_DAILY_NOTE_PATTERN = "yyyy-MM-dd"
         const val DEFAULT_NEW_NOTES_FOLDER = "dayGLANCE"

--- a/dayglance-android/app/src/test/java/com/dayglance/app/billing/AckRetryPolicyTest.kt
+++ b/dayglance-android/app/src/test/java/com/dayglance/app/billing/AckRetryPolicyTest.kt
@@ -1,0 +1,113 @@
+package com.dayglance.app.billing
+
+import com.dayglance.app.billing.AckRetryPolicy.Decision
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for the acknowledgement retry decisions (plain JVM, no billing
+ * client, injected clock — the SseBackoff precedent).
+ *
+ * The stakes each rule protects: Play refunds any purchase not acknowledged
+ * within three days, so giving up wrongly costs the user a refund and us a
+ * sale; continuing wrongly costs a log line. Hence: only ITEM_NOT_OWNED and
+ * DEVELOPER_ERROR are terminal, a fresh query's isAcknowledged is
+ * authoritative success over ANY response code, and connection failures are
+ * never terminal at all.
+ */
+class AckRetryPolicyTest {
+
+    private val t0 = 1_000_000L
+
+    // BillingResponseCode values not mirrored in the policy (it only names the
+    // ones it treats specially); listed here to drive the everything-else rule.
+    private val transientCodes = listOf(
+        -2, // FEATURE_NOT_SUPPORTED
+        -1, // SERVICE_DISCONNECTED
+        1,  // USER_CANCELED (should not occur on ack; still not terminal)
+        2,  // SERVICE_UNAVAILABLE
+        3,  // BILLING_UNAVAILABLE
+        4,  // ITEM_UNAVAILABLE
+        6,  // ERROR
+        7,  // ITEM_ALREADY_OWNED (not an ack code; conservative -> retry)
+        12, // NETWORK_ERROR
+    )
+
+    @Test
+    fun `OK is success`() {
+        assertEquals(Decision.SUCCESS, AckRetryPolicy.decide(AckRetryPolicy.OK, false, t0, t0))
+    }
+
+    @Test
+    fun `already-acknowledged from a fresh query is authoritative success over EVERY code`() {
+        // The idempotence rule: acknowledging an already-acknowledged purchase
+        // must be handled as success, never as an error to retry forever —
+        // even when the response code would otherwise be terminal.
+        val everyCode = transientCodes + listOf(
+            AckRetryPolicy.OK, AckRetryPolicy.ITEM_NOT_OWNED, AckRetryPolicy.DEVELOPER_ERROR,
+        )
+        for (code in everyCode) {
+            assertEquals(
+                "code=$code with alreadyAcknowledged must be SUCCESS",
+                Decision.SUCCESS,
+                AckRetryPolicy.decide(code, true, t0, t0 + AckRetryPolicy.ACK_WINDOW_MS * 2),
+            )
+        }
+    }
+
+    @Test
+    fun `ITEM_NOT_OWNED and DEVELOPER_ERROR are terminal immediately`() {
+        // A purchase that no longer exists (refunded, consumed) or a malformed
+        // token can never be acknowledged; retrying forever would hammer Play.
+        assertEquals(Decision.GIVE_UP_TERMINAL, AckRetryPolicy.decide(AckRetryPolicy.ITEM_NOT_OWNED, false, t0, t0))
+        assertEquals(Decision.GIVE_UP_TERMINAL, AckRetryPolicy.decide(AckRetryPolicy.DEVELOPER_ERROR, false, t0, t0))
+    }
+
+    @Test
+    fun `terminal codes stay terminal past the window (evidence names the real reason)`() {
+        val late = t0 + AckRetryPolicy.ACK_WINDOW_MS + 1
+        assertEquals(Decision.GIVE_UP_TERMINAL, AckRetryPolicy.decide(AckRetryPolicy.ITEM_NOT_OWNED, false, t0, late))
+    }
+
+    @Test
+    fun `every other code retries inside the window`() {
+        for (code in transientCodes) {
+            assertEquals(
+                "code=$code inside the window must RETRY",
+                Decision.RETRY,
+                AckRetryPolicy.decide(code, false, t0, t0 + 60_000),
+            )
+        }
+    }
+
+    @Test
+    fun `the three-day window ends the retry chain, boundary exact`() {
+        val justInside = t0 + AckRetryPolicy.ACK_WINDOW_MS - 1
+        val atWindow = t0 + AckRetryPolicy.ACK_WINDOW_MS
+        assertEquals(Decision.RETRY, AckRetryPolicy.decide(6, false, t0, justInside))
+        assertEquals(Decision.GIVE_UP_WINDOW, AckRetryPolicy.decide(6, false, t0, atWindow))
+    }
+
+    @Test
+    fun `a failed ack retried later succeeds on OK (the recovery path)`() {
+        // The sequence the retry lane exists for: fail transiently, retry, land.
+        assertEquals(Decision.RETRY, AckRetryPolicy.decide(12, false, t0, t0))
+        assertEquals(Decision.SUCCESS, AckRetryPolicy.decide(AckRetryPolicy.OK, false, t0, t0 + 120_000))
+    }
+
+    @Test
+    fun `connection failures are never terminal, only window-capped`() {
+        // A setup failure says nothing about the purchase: DEVELOPER_ERROR-class
+        // codes from startConnection must not clear the pending record.
+        assertEquals(Decision.RETRY, AckRetryPolicy.decideConnectionFailure(t0, t0 + 60_000))
+        assertEquals(
+            Decision.GIVE_UP_WINDOW,
+            AckRetryPolicy.decideConnectionFailure(t0, t0 + AckRetryPolicy.ACK_WINDOW_MS),
+        )
+    }
+
+    @Test
+    fun `the window constant is Play's three days`() {
+        assertEquals(3L * 24 * 60 * 60 * 1000, AckRetryPolicy.ACK_WINDOW_MS)
+    }
+}


### PR DESCRIPTION
Google Play refunds any purchase not acknowledged within three days and revokes the entitlement. The ack was fire-and-forget; this PR gives a failed ack a durable pending record, a WorkManager retry lane that survives process death and reboot, correct termination, and a visibility mechanism. Entitlement is never gated on any of it.

## Answers to the six questions

**1. The current acknowledgement path, end to end.** `BillingManager.handlePurchase` receives the purchase from the Play listener, sets `subscriptionActive = true` and stores product id/token, fires the `"success"` billing event to the web layer, and calls `acknowledgePurchase(purchase)`. That method built `AcknowledgePurchaseParams` and called `billingClient.acknowledgePurchase(params) { /* fire and forget */ }` — an empty callback. The result was discarded, nothing was logged on success or failure, and the user saw nothing either way (the `"success"` event had already fired, independent of the ack).

**2. The launch re-acknowledgement, and how solid it is.** `queryPurchases()` runs from `onBillingSetupFinished` after a successful connection, so it is correctly ordered — it does not race the connection on the normal launch path. It queries SUBS and INAPP via `queryPurchasesAsync` and re-acks any active purchase with `!isAcknowledged`. Two real weaknesses: (a) the re-ack call was the same fire-and-forget method, so a failed re-ack was just as invisible and had no follow-up; (b) `SubscriptionBridge.refresh()` calls `queryPurchases()` directly from JS, and that path races the `isReady` guard — if the client isn't ready the call silently does nothing. The refresh() race is **reported and left** (see below), per the go-ahead.

**3. Can the app represent "bought but not acked"?** It could not. `SharedDataStore` had `subscriptionActive/ProductId/Token` and nothing else — an unacknowledged purchase was indistinguishable from an acknowledged one, so a retry had nothing durable to work from. This PR adds exactly that representation: the pending-ack record.

**4. What the user experiences between a failed ack and a successful re-ack.** They have Pro. `handlePurchase` sets `subscriptionActive` unconditionally, before and regardless of the ack outcome, and `SubscriptionBridge.getStatus()` reads that flag. The paywall does not reappear and nothing is shown. That ordering is deliberate and this PR does not disturb it. The user only loses Pro if the three days elapse and Google refunds — which is the failure this PR exists to prevent.

**5. Has this ever happened?** Unknowable, and that is the finding. The failure was invisible **threefold**: not logged (empty callback), not persisted (no state that could record it), and not reported (no analytics or crash-reporting pipeline, by design). There is no way to know how often, if ever, a user has been silently refunded. After this PR the same event leaves a `Log.w` line, a persisted diagnostics record, and a dev-menu surface.

**6. Anything that makes the design wrong or awkward here.** One thing, bigger than this task: `BillingManager` builds its `BillingClient` once in the constructor, `MainActivity.onStart` calls `connect()` and `onStop` calls `disconnect()` → `endConnection()`. Google documents a BillingClient as **not reusable after `endConnection()`** — so on the second foreground the shared client may be permanently dead, which would break purchases, restores, and the launch re-ack lane far beyond acknowledgement. This is the **reuse hazard, reported and left**: you are running the device check (launch → background → foreground, watch `onBillingSetupFinished` on the second connect); if confirmed, the connection-lifecycle fix is its own item ahead of the queue. Nothing in this PR fixes it, and nothing in this PR depends on the answer — see retry-lane independence below.

## Where the pending state lives and why it survives the case that matters

`SharedDataStore` (SharedPreferences): `pendingAckToken`, `pendingAckProductId`, `pendingAckFirstFailedAt`, `pendingAckAttempts`. Written synchronously in the ack failure callback, before anything else happens. The scenario the three-day refund punishes is *the user closes the app right after a failed ack and doesn't reopen it for days* — an in-memory retry dies with the process, which is exactly then. SharedPreferences survives process death and reboot; WorkManager's persisted job queue survives the same, so both the obligation (the record) and the appointment to fulfil it (the work request) outlive the process.

## How the retry terminates

Decisions live in `AckRetryPolicy` (pure Kotlin, no Play Billing import, tested on plain JVM — the `SseBackoff` pattern):

- **Success:** response `OK`, or `isAcknowledged == true` from a fresh `queryPurchasesAsync` — the fresh query is **authoritative over every response code**, which is also the idempotence rule: acknowledging an already-acknowledged purchase resolves as success, never as an error to retry forever. Pending record cleared.
- **Terminal:** `ITEM_NOT_OWNED` (purchase refunded/consumed — no longer exists for us) and `DEVELOPER_ERROR` (malformed request). A purchase that can never be acknowledged stops immediately; the pending record is cleared but the diagnostic evidence is kept (`lastAckOutcome = "gave_up_terminal"`, code, timestamp). This is the guard against retrying forever at a purchase that no longer exists.
- **Everything else:** retry with WorkManager's exponential backoff, until `firstFailedAt` is three days old, then stop with evidence kept (`"gave_up_window"` — Play has already resolved it one way or the other by then). `firstFailedAt` is a lower bound on purchase age, so the window never gives up early.
- **Connection failures are never terminal** — a setup failure says nothing about the purchase — but they are window-capped so the chain cannot run forever.

The conservative rule throughout: a retry that gives up wrongly costs the user a refund and us a sale; a retry that continues wrongly costs a log line.

## The failure-visibility mechanism

No analytics pipeline. Three layers, all cheap:
1. **`Log.w` on every failure and give-up** (the file's convention keeps `Log.w` in release builds), with the response code, attempt count, and the token's last 8 characters for correlation.
2. **Persisted diagnostics in `SharedDataStore`** — `lastAckOutcome` (`success` / `retrying` / `gave_up_terminal` / `gave_up_window`), `lastAckFailureCode/At`, `lastAckSuccessAt` — written on every outcome and never cleared, so a support conversation can reconstruct what happened after the fact.
3. **`SubscriptionBridge.getBillingDiagnostics()`** — read-only JSON reachable through the existing hidden dev menu (the 7-tap path that arms `consumeTestPurchase`). The pending token is truncated to its last 8 characters: enough to correlate with logcat, not enough to leak a usable purchase token to the page.

## Retry-lane independence from the shared client

`AckRetryWorker` constructs its **own short-lived BillingClient per attempt** and always closes it in a `finally`. It never touches `BillingManager`'s shared instance. This is deliberate: given the reuse hazard above, a retry lane leaning on the shared client could be leaning on a dead one — precisely when the retry matters most (app backgrounded after a failed ack). A fresh client per attempt cannot inherit that state, so the retry lane is correct **whichever way the device check comes out**.

## Non-trivial design decisions

- **`ExistingWorkPolicy.KEEP` with the pending record as single source of truth.** The worker reads *what* to acknowledge from `SharedDataStore` at attempt time, not from work input data. Scheduling is therefore idempotent — `queryPurchases()` re-schedules as a backstop whenever a pending record exists (covers WorkManager state cleared by the OS or the user), and KEEP makes that a no-op while a chain is already mid-backoff.
- **A new token replaces the pending record** (single-slot). This app sells one subscription and one lifetime product; two simultaneously-pending acks would require two purchases with two failed acks inside three days. The newer purchase wins the slot; the older one is still covered by the launch re-ack lane, which now records outcomes too.
- **`Result.success()` on give-up**, not `Result.failure()` — give-up is a decided outcome that must stop the chain; the evidence lives in the diagnostics, not in WorkManager's state.
- **The launch re-ack lane is now outcome-aware** rather than a second blind attempt: it routes through the same recording ack, and when a fresh query shows the pending token acknowledged, it clears the record (`isAcknowledged` authoritative).
- **Entitlement ordering untouched**: `subscriptionActive` is set exactly where it was set before, unconditionally. The worker never writes it.
- **Backoff starts at 1 minute, exponential** — patient by design; the window is three days, there is no hurry, and hammering Play buys nothing.

## Verification

**Machine-verified (plain-JVM Gradle scratchpad, since this environment has no Android SDK and CI runs only the JS suite):** the 9 `AckRetryPolicyTest` tests were copied byte-identical with `AckRetryPolicy.kt` into a standalone `kotlin("jvm")` project and run with Gradle 9.3.1:

```
tests="9" skipped="0" failures="0" errors="0"
  OK is success
  already-acknowledged from a fresh query is authoritative success over EVERY code
  ITEM_NOT_OWNED and DEVELOPER_ERROR are terminal immediately
  terminal codes stay terminal past the window (evidence names the real reason)
  every other code retries inside the window
  the three-day window ends the retry chain, boundary exact
  a failed ack retried later succeeds on OK (the recovery path)
  connection failures are never terminal, only window-capped
  the window constant is Play's three days
BUILD SUCCESSFUL
```

Negative control: deleting the terminal rule from the policy copy made the suite fail (2 failures, BUILD FAILED); restoring it went green again — the tests do discriminate.

This covers verification items 1, 2, 4, 5 and 6 **at the logic level**: normal purchase → `OK` → success; injected transient failure → `RETRY` → later `OK` → success; double-ack → `alreadyAcknowledged` authoritative success over every code; entitlement untouched by construction (the worker has no write path to `subscriptionActive`); failed ack → persisted record + `Log.w` by construction.

**Verified by inspection only, stated plainly:** everything Android-framework-shaped. The Kotlin in `AckRetryWorker`, `BillingManager`, `SharedDataStore`, `SubscriptionBridge` cannot be compiled here (no Android SDK) and WorkManager execution, process-death survival (item 3), and real Play behaviour cannot be demonstrated in this environment at all. Hence:

## Device test steps (for you to run)

*Prereqs for all three: a release play-flavor build (debug never connects billing), a license-tester account, and `adb logcat -s DayGlanceBilling` running. The dev menu is 7 taps on the plan label; `getBillingDiagnostics()` can be called from the page console via `window.DayGlanceBilling.getBillingDiagnostics()`.*

**A. Normal purchase acknowledges, unchanged from today (item 1).**
1. Buy the annual sub with the license tester.
2. Expect: Pro immediately, no new dialog or delay; logcat shows `acknowledgePurchase OK: token=…XXXXXXXX`.
3. `getBillingDiagnostics()` → `pendingAck: null`, `lastOutcome: "success"`, `lastSuccessAt` recent.
4. In Play Console the order should show acknowledged (or simply: no refund after 3 days).

**B. Failed ack is retried and pending state survives restart (items 2, 3, 6).** Inject the failure with airplane mode at the exact gap:
1. Start the purchase; the Play sheet completes while Play services has the order; the ack needs the network moments later. Practical injection: complete the purchase sheet, then immediately toggle airplane mode ON before returning to the app (a few tries may be needed; alternatively `adb shell svc wifi disable && adb shell svc data disable` bound to a button press). The purchase arrives via the listener from cache; the ack call fails.
2. Expect logcat: `acknowledgePurchase failed: code=… attempt=1 — retry scheduled (Play refunds unacknowledged purchases after 3 days)`. Confirm you STILL have Pro (item 5, entitlement never gated).
3. `getBillingDiagnostics()` → `pendingAck` non-null with `attempts ≥ 1`, `lastOutcome: "retrying"` (item 6 evidence).
4. Force-stop the app (`adb shell am force-stop com.dayglance.app`) with airplane mode still on. Do NOT reopen it.
5. Re-enable the network. WorkManager should run the worker without the app being opened (give it the backoff interval; `adb shell dumpsys jobscheduler | grep -A4 dayglance` shows the pending job). Expect logcat: `acknowledgePurchase recovered on retry: token=…XXXXXXXX after N failed attempt(s)`.
6. Reopen the app: `getBillingDiagnostics()` → `pendingAck: null`, `lastOutcome: "success"`. Pro still active. Survival across force-stop is the item-3 proof.

**C. Double acknowledgement is harmless (item 4).**
1. With an already-acknowledged purchase active, seed a fake pending record by re-triggering the flow — simplest real-world path: after test B recovers, background and reopen the app so `queryPurchases()` runs against the acknowledged purchase. Expect either nothing (record already clear) or `pending ack cleared: Play reports token=…XXXXXXXX acknowledged`.
2. Stronger version: repeat test B but restore the network after step 3 *without* force-stopping, then also reopen the app while the worker is mid-backoff — both the launch re-ack lane and the worker may attempt the ack. Expect exactly one success outcome, no error events to the web layer, Pro uninterrupted, and no anomaly on the order in Play Console.

**D. The standing reuse-hazard check (yours, unchanged).** Launch → background → foreground; watch whether `onBillingSetupFinished` fires with `OK` on the second connect. Whatever the result, the retry lane above is unaffected; if it confirms the hazard, the connection-lifecycle fix is the next item.

## Reported and left (out of scope here, per the go-ahead)

- **BillingClient reuse hazard** (question 6 above) — potentially breaks all shared-client billing on second foreground; awaiting your device check; fix is its own item.
- **`refresh()` race on `isReady`** — a JS-triggered refresh before the client is ready silently no-ops. Real, adjacent, untouched.

Also untouched: RevenueCat, iOS/macOS purchase paths, the other subscription hardening items, paywall/UI, sync/vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_