### PR TITLE
Android: fix the BillingClient connection lifecycle

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -523,11 +523,23 @@ class MainActivity : AppCompatActivity() {
         vaultSseClient.setForeground(false)
         if (BuildConfig.BILLING_ENABLED && !BuildConfig.DEBUG) {
             billingManager.activity = null
-            billingManager.disconnect()
+            // Deliberately NOT ending the billing connection here. A
+            // BillingClient is dead forever after endConnection(), so the old
+            // teardown-on-onStop killed billing (restores, purchases, the
+            // entitlement refresh) for the rest of the process after the
+            // first background cycle. The connection is kept alive across
+            // backgrounding; final teardown is onDestroy's destroy().
         }
     }
 
     override fun onDestroy() {
+        // Required, not cleanup: this activity handles orientation/screenSize/
+        // screenLayout/keyboardHidden config changes itself but NOT uiMode or
+        // locale, so a dark-mode toggle or language change recreates the
+        // activity and builds a new BillingManager + client. The old binding
+        // used to be released by onStop's disconnect purely by accident;
+        // without this call, every recreation would leak a service binding.
+        if (::billingManager.isInitialized) billingManager.destroy()
         // Release the platform speech recognizer (no-op if never attached).
         if (::nativeBridge.isInitialized) nativeBridge.destroySpeechBridge()
         // Tear the SSE reader down cleanly — no leaked connection or coroutine.

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingConnectionPolicy.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingConnectionPolicy.kt
@@ -1,0 +1,80 @@
+package com.dayglance.app.billing
+
+/**
+ * Decision table for the shared BillingClient's connection lifecycle — the
+ * pure half of the connection-ownership fix (the AckRetryPolicy pattern:
+ * decisions in a dependency-free file with tests, wiring in BillingManager).
+ * No Play Billing import on purpose, so the tests run on a plain JVM; the
+ * constants below are Play's stable public BillingClient.ConnectionState
+ * values.
+ *
+ * WHY THIS EXISTS: a BillingClient cannot be reused after endConnection() —
+ * confirmed on a real device ("Client was already closed and can't be
+ * reused"). The old lifecycle built one client per activity and closed it on
+ * every onStop, so after the first background/foreground cycle every billing
+ * operation in that process silently no-opped: restore reported success from
+ * the stale cache, purchases errored with billing_not_ready, and
+ * queryPurchases (entitlement refresh + the re-acknowledgement lane) never
+ * ran again until process death.
+ *
+ * The invariant the two decisions enforce, structurally rather than by
+ * remembering to check:
+ *
+ *  - [clientAction], consulted on EVERY access to the shared client: a CLOSED
+ *    instance is never handed out — it is replaced first, so the closed
+ *    object becomes unreachable and reuse-after-endConnection is impossible
+ *    by construction.
+ *  - [connectAction], consulted by the foreground connect: startConnection is
+ *    only issued when it will do something — never re-issued on a live
+ *    connection (keep-alive across backgrounds), never stacked on a
+ *    connection already in flight (rapid foregrounds).
+ */
+object BillingConnectionPolicy {
+
+    // BillingClient.ConnectionState values (stable public constants),
+    // declared locally to keep this file JVM-pure.
+    const val DISCONNECTED = 0
+    const val CONNECTING = 1
+    const val CONNECTED = 2
+    const val CLOSED = 3
+
+    enum class ClientAction {
+        /** The held instance is safe to hand out (it may still need connecting). */
+        REUSE,
+        /** The held instance is closed and can never be used again: replace it
+         *  with a fresh one before doing anything. */
+        RECREATE,
+    }
+
+    enum class ConnectAction {
+        /** Live connection: nothing to start — proceed straight to the
+         *  on-foreground queries. */
+        ALREADY_CONNECTED,
+        /** A startConnection is already in flight: issuing another stacks
+         *  setup callbacks for nothing. Let the in-flight one finish. */
+        WAIT,
+        /** No connection and none in flight: startConnection now. */
+        CONNECT,
+    }
+
+    /**
+     * Decide, for every access to the shared client, whether the held
+     * instance may be used or must be replaced first.
+     */
+    fun clientAction(connectionState: Int): ClientAction =
+        if (connectionState == CLOSED) ClientAction.RECREATE else ClientAction.REUSE
+
+    /**
+     * Decide what the foreground connect should do, given the state of an
+     * instance [clientAction] already deemed usable. CLOSED still maps to
+     * CONNECT as defence in depth: it is unreachable through the accessor
+     * (a closed instance is replaced first, and a fresh client starts
+     * DISCONNECTED), but the total function's answer for a replacement
+     * client is to connect it.
+     */
+    fun connectAction(connectionState: Int): ConnectAction = when (connectionState) {
+        CONNECTED -> ConnectAction.ALREADY_CONNECTED
+        CONNECTING -> ConnectAction.WAIT
+        else -> ConnectAction.CONNECT
+    }
+}

--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
@@ -28,7 +28,22 @@ import kotlin.coroutines.resume
  * Annual plan → Play Console: Monetize → Subscriptions (product type SUBS).
  * Lifetime plan → Play Console: Monetize → In-app products (product type INAPP).
  *
- * Call [connect] from Activity.onStart() and [disconnect] from Activity.onStop().
+ * Lifecycle: call [connect] from Activity.onStart() and [destroy] from
+ * Activity.onDestroy(). Nothing is called on onStop — the connection is
+ * deliberately kept alive across backgrounding. A BillingClient is dead
+ * forever after endConnection() (device-confirmed: "Client was already
+ * closed and can't be reused"), and the old close-on-onStop lifecycle left
+ * every billing operation silently no-opping after the first
+ * background/foreground cycle. The Play service binding is cheap to hold and
+ * Google's own samples keep it for the life of the process.
+ *
+ * The shared client lives behind [client], the single accessor that replaces
+ * a CLOSED instance before handing anything out (decision table in
+ * [BillingConnectionPolicy]) — reuse of a closed client is impossible by
+ * construction, not avoided by convention. AckRetryWorker deliberately does
+ * NOT go through this accessor: its retry lane owns a short-lived client per
+ * attempt precisely so it never depends on the shared instance's lifecycle.
+ *
  * Set [activity] before calling [launchPurchaseFlow].
  */
 class BillingManager(
@@ -94,23 +109,82 @@ class BillingManager(
         }
     }
 
-    private val billingClient: BillingClient = BillingClient.newBuilder(context)
-        .setListener(purchasesUpdatedListener)
-        .enablePendingPurchases(PendingPurchasesParams.newBuilder().enableOneTimeProducts().build())
-        .build()
+    /**
+     * The ONLY reference to the shared BillingClient, and it is never touched
+     * directly — every use goes through [client]. Lazily built: debug and
+     * github-flavor builds, which never connect, never construct one either.
+     */
+    private var billingClient: BillingClient? = null
 
+    /**
+     * Single accessor for the shared client. Consults
+     * [BillingConnectionPolicy.clientAction]: a CLOSED instance (dead forever,
+     * per Play's documentation and the device-confirmed warning) is replaced
+     * with a fresh one before anything is handed out, which makes the closed
+     * object unreachable. Synchronized because billing entry points span the
+     * main thread (onStart) and the WebView's JS thread (SubscriptionBridge).
+     *
+     * A fresh instance starts DISCONNECTED and holds no service binding until
+     * startConnection — so an accessor hit after [destroy] (e.g. a late JS
+     * bridge call during teardown) creates only an inert object, never a leak.
+     */
+    @Synchronized
+    private fun client(): BillingClient {
+        val held = billingClient
+        if (held != null &&
+            BillingConnectionPolicy.clientAction(held.connectionState) ==
+                BillingConnectionPolicy.ClientAction.REUSE
+        ) {
+            return held
+        }
+        val fresh = BillingClient.newBuilder(context)
+            .setListener(purchasesUpdatedListener)
+            .enablePendingPurchases(PendingPurchasesParams.newBuilder().enableOneTimeProducts().build())
+            // PBL 8: service drops (Play killing the binding while we hold the
+            // client) reconnect themselves instead of waiting for the next
+            // foreground connect().
+            .enableAutoServiceReconnection()
+            .build()
+        billingClient = fresh
+        return fresh
+    }
+
+    /**
+     * Idempotent foreground connect — called from Activity.onStart() on every
+     * foreground. [BillingConnectionPolicy.connectAction] decides: a live
+     * connection skips straight to the queries (keep-alive), an in-flight
+     * connection is left to finish (its setup callback runs the queries), and
+     * only a disconnected client actually starts a connection. Either path
+     * ends with [queryPurchases] running on this foreground, which is what
+     * keeps entitlement fresh and the re-acknowledgement lane live.
+     */
     fun connect() {
-        billingClient.startConnection(object : BillingClientStateListener {
-            override fun onBillingSetupFinished(result: BillingResult) {
-                if (result.responseCode == BillingClient.BillingResponseCode.OK) {
-                    queryPurchases()
-                    queryProductPrices()
-                }
+        val client = client()
+        when (BillingConnectionPolicy.connectAction(client.connectionState)) {
+            BillingConnectionPolicy.ConnectAction.ALREADY_CONNECTED -> {
+                queryPurchases()
+                queryProductPrices()
             }
-            override fun onBillingServiceDisconnected() {
-                // Play will retry automatically; we reconnect on next connect() call.
+            BillingConnectionPolicy.ConnectAction.WAIT -> {
+                // startConnection already in flight; its onBillingSetupFinished
+                // will run the queries. Stacking another does nothing useful.
             }
-        })
+            BillingConnectionPolicy.ConnectAction.CONNECT -> {
+                client.startConnection(object : BillingClientStateListener {
+                    override fun onBillingSetupFinished(result: BillingResult) {
+                        if (result.responseCode == BillingClient.BillingResponseCode.OK) {
+                            queryPurchases()
+                            queryProductPrices()
+                        }
+                    }
+                    override fun onBillingServiceDisconnected() {
+                        // enableAutoServiceReconnection re-establishes the
+                        // service connection on this same instance; the next
+                        // onStart's connect() is the backstop.
+                    }
+                })
+            }
+        }
     }
 
     /**
@@ -120,7 +194,8 @@ class BillingManager(
      * Lifetime (INAPP): reads oneTimePurchaseOfferDetailsList[0].formattedPrice directly.
      */
     fun queryProductPrices() {
-        if (!billingClient.isReady) return
+        val client = client()
+        if (!client.isReady) return
 
         val subsParams = QueryProductDetailsParams.newBuilder()
             .setProductList(SUBSCRIPTION_PRODUCTS.map { id ->
@@ -141,7 +216,7 @@ class BillingManager(
             .build()
 
         scope.launch {
-            billingClient.queryProductDetailsAsync(subsParams) { result, queryResult ->
+            client.queryProductDetailsAsync(subsParams) { result, queryResult ->
                 if (result.responseCode != BillingClient.BillingResponseCode.OK) return@queryProductDetailsAsync
                 for (details in queryResult.productDetailsList) {
                     if (details.productId != PRODUCT_ANNUAL) continue
@@ -165,7 +240,7 @@ class BillingManager(
                         ?.let { dataStore.trialDaysAnnual = it }
                 }
             }
-            billingClient.queryProductDetailsAsync(inappParams) { result, queryResult ->
+            client.queryProductDetailsAsync(inappParams) { result, queryResult ->
                 if (result.responseCode != BillingClient.BillingResponseCode.OK) return@queryProductDetailsAsync
                 for (details in queryResult.productDetailsList) {
                     // PBL 8 replaced the singular oneTimePurchaseOfferDetails with a list
@@ -177,8 +252,24 @@ class BillingManager(
         }
     }
 
-    fun disconnect() {
-        billingClient.endConnection()
+    /**
+     * Final teardown for THIS manager instance — Activity.onDestroy() only,
+     * never onStop. Required, not cleanup: MainActivity handles
+     * orientation/screenSize/screenLayout/keyboardHidden config changes
+     * itself but NOT uiMode or locale, so a dark-mode toggle or language
+     * change recreates the activity, which builds a new manager and client.
+     * The old binding used to be released by onStop's disconnect purely by
+     * accident; without this, every recreation would leak a binding.
+     *
+     * Under the accessor invariant each client is closed at most once, and
+     * only here — which is also why the "Receiver is not registered" warning
+     * (a second endConnection on an already-closed client) should never
+     * appear again. Deliberately does not construct: closing nothing is fine.
+     */
+    @Synchronized
+    fun destroy() {
+        billingClient?.endConnection()
+        billingClient = null
     }
 
     /** "P14D" → 14, "P2W" → 14. Months/years approximated (unused for trials in practice). */
@@ -189,20 +280,21 @@ class BillingManager(
         null
     }
 
-    private suspend fun queryPurchasesForType(productType: String): List<Purchase> =
+    private suspend fun queryPurchasesForType(client: BillingClient, productType: String): List<Purchase> =
         suspendCancellableCoroutine { cont ->
-            billingClient.queryPurchasesAsync(
+            client.queryPurchasesAsync(
                 QueryPurchasesParams.newBuilder().setProductType(productType).build()
             ) { _, purchases -> cont.resume(purchases) }
         }
 
     fun queryPurchases() {
-        if (!billingClient.isReady) return
+        val client = client()
+        if (!client.isReady) return
         scope.launch {
-            val activeSub = queryPurchasesForType(BillingClient.ProductType.SUBS)
+            val activeSub = queryPurchasesForType(client, BillingClient.ProductType.SUBS)
                 .firstOrNull { it.purchaseState == Purchase.PurchaseState.PURCHASED }
 
-            val active = activeSub ?: queryPurchasesForType(BillingClient.ProductType.INAPP)
+            val active = activeSub ?: queryPurchasesForType(client, BillingClient.ProductType.INAPP)
                 .firstOrNull { it.purchaseState == Purchase.PurchaseState.PURCHASED }
 
             if (active != null) {
@@ -248,7 +340,8 @@ class BillingManager(
             onBillingEvent?.invoke("error", BillingClient.BillingResponseCode.DEVELOPER_ERROR, "activity_null", productId)
             return
         }
-        if (!billingClient.isReady) {
+        val client = client()
+        if (!client.isReady) {
             Log.w(TAG, "launchPurchaseFlow($productId): client not ready")
             onBillingEvent?.invoke("error", BillingClient.BillingResponseCode.SERVICE_DISCONNECTED, "billing_not_ready", productId)
             return
@@ -270,7 +363,7 @@ class BillingManager(
             .build()
 
         scope.launch {
-            billingClient.queryProductDetailsAsync(params) { result, queryResult ->
+            client.queryProductDetailsAsync(params) { result, queryResult ->
                 // PBL 8: the callback now delivers a QueryProductDetailsResult; the fetched
                 // items live on .productDetailsList (unfetched products are reported separately).
                 val detailsList = queryResult.productDetailsList
@@ -317,7 +410,7 @@ class BillingManager(
                     .build()
 
                 act.runOnUiThread {
-                    val launchResult = billingClient.launchBillingFlow(act, flowParams)
+                    val launchResult = client.launchBillingFlow(act, flowParams)
                     logd("launchBillingFlow: code=${launchResult.responseCode} msg='${launchResult.debugMessage}' ts=${System.currentTimeMillis()}")
                     if (launchResult.responseCode != BillingClient.BillingResponseCode.OK) {
                         onBillingEvent?.invoke("error", launchResult.responseCode, launchResult.debugMessage, productId)
@@ -354,7 +447,7 @@ class BillingManager(
         val params = AcknowledgePurchaseParams.newBuilder()
             .setPurchaseToken(token)
             .build()
-        billingClient.acknowledgePurchase(params) { result ->
+        client().acknowledgePurchase(params) { result ->
             if (result.responseCode == BillingClient.BillingResponseCode.OK) {
                 AckRetryWorker.recordSuccess(dataStore, token)
                 logd("acknowledgePurchase OK: token=…${token.takeLast(8)}")
@@ -372,7 +465,8 @@ class BillingManager(
         dataStore.subscriptionProductId = null
         dataStore.subscriptionToken = null
 
-        if (!billingClient.isReady) {
+        val client = client()
+        if (!client.isReady) {
             onComplete(true)
             return
         }
@@ -381,11 +475,11 @@ class BillingManager(
             // dataStore. When an annual test subscription is active, queryPurchases() stores
             // the SUBS token (SUBS has priority), leaving the lifetime INAPP token untouched.
             // Querying INAPP directly ensures the lifetime token is always consumed.
-            val inappPurchases = queryPurchasesForType(BillingClient.ProductType.INAPP)
+            val inappPurchases = queryPurchasesForType(client, BillingClient.ProductType.INAPP)
             for (purchase in inappPurchases) {
                 val p = ConsumeParams.newBuilder().setPurchaseToken(purchase.purchaseToken).build()
                 suspendCancellableCoroutine { cont ->
-                    billingClient.consumeAsync(p) { result, _ ->
+                    client.consumeAsync(p) { result, _ ->
                         logd("consumeAsync INAPP ${purchase.purchaseToken.takeLast(8)}: code=${result.responseCode} msg='${result.debugMessage}'")
                         cont.resume(Unit)
                     }
@@ -396,7 +490,7 @@ class BillingManager(
             if (inappPurchases.none { it.purchaseToken == token }) {
                 val p = ConsumeParams.newBuilder().setPurchaseToken(token).build()
                 suspendCancellableCoroutine { cont ->
-                    billingClient.consumeAsync(p) { result, _ ->
+                    client.consumeAsync(p) { result, _ ->
                         logd("consumeAsync stored token ${token.takeLast(8)}: code=${result.responseCode} msg='${result.debugMessage}'")
                         cont.resume(Unit)
                     }

--- a/dayglance-android/app/src/test/java/com/dayglance/app/billing/BillingConnectionPolicyTest.kt
+++ b/dayglance-android/app/src/test/java/com/dayglance/app/billing/BillingConnectionPolicyTest.kt
@@ -1,0 +1,132 @@
+package com.dayglance.app.billing
+
+import com.dayglance.app.billing.BillingConnectionPolicy.ClientAction
+import com.dayglance.app.billing.BillingConnectionPolicy.ConnectAction
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Unit tests for the connection-lifecycle decisions (plain JVM, no billing
+ * client — the AckRetryPolicy precedent).
+ *
+ * The stakes: a BillingClient is dead forever after endConnection(). The old
+ * lifecycle reconnected a closed instance on every foreground after the
+ * first, which silently broke restores, purchases, and the entitlement
+ * refresh for the rest of the process. These decisions make that reuse
+ * impossible (closed instances are replaced before use) while keeping
+ * connect idempotent (no churn, no stacked startConnection calls).
+ */
+class BillingConnectionPolicyTest {
+
+    private val allStates = listOf(
+        BillingConnectionPolicy.DISCONNECTED,
+        BillingConnectionPolicy.CONNECTING,
+        BillingConnectionPolicy.CONNECTED,
+        BillingConnectionPolicy.CLOSED,
+    )
+
+    @Test
+    fun `a closed client is never reused - it is replaced`() {
+        assertEquals(
+            ClientAction.RECREATE,
+            BillingConnectionPolicy.clientAction(BillingConnectionPolicy.CLOSED),
+        )
+    }
+
+    @Test
+    fun `every non-closed state hands the held instance out unchanged`() {
+        for (state in allStates.filter { it != BillingConnectionPolicy.CLOSED }) {
+            assertEquals(
+                "state=$state must REUSE",
+                ClientAction.REUSE,
+                BillingConnectionPolicy.clientAction(state),
+            )
+        }
+    }
+
+    @Test
+    fun `the invariant - no state both hands out and is closed`() {
+        // Property form of the fix: for every state, either the instance is
+        // not closed, or it is replaced. There is no third cell in the
+        // table, which is what "impossible by construction" means.
+        for (state in allStates) {
+            val handedOut = BillingConnectionPolicy.clientAction(state) == ClientAction.REUSE
+            assertFalse(
+                "state=$state would hand out a closed client",
+                handedOut && state == BillingConnectionPolicy.CLOSED,
+            )
+        }
+    }
+
+    @Test
+    fun `foreground connect on a live connection does nothing (keep-alive)`() {
+        assertEquals(
+            ConnectAction.ALREADY_CONNECTED,
+            BillingConnectionPolicy.connectAction(BillingConnectionPolicy.CONNECTED),
+        )
+    }
+
+    @Test
+    fun `foreground connect while connecting waits - no stacked startConnection`() {
+        // Rapid background/foreground cycles must not pile startConnection
+        // calls onto the attempt already in flight.
+        assertEquals(
+            ConnectAction.WAIT,
+            BillingConnectionPolicy.connectAction(BillingConnectionPolicy.CONNECTING),
+        )
+    }
+
+    @Test
+    fun `disconnected connects - first launch and after a service drop`() {
+        assertEquals(
+            ConnectAction.CONNECT,
+            BillingConnectionPolicy.connectAction(BillingConnectionPolicy.DISCONNECTED),
+        )
+    }
+
+    @Test
+    fun `closed maps to connect as defence in depth`() {
+        // Unreachable through the accessor (clientAction replaces CLOSED
+        // first, and a fresh client starts DISCONNECTED), but the total
+        // function's right answer for the replacement client is: connect.
+        assertEquals(
+            ConnectAction.CONNECT,
+            BillingConnectionPolicy.connectAction(BillingConnectionPolicy.CLOSED),
+        )
+    }
+
+    @Test
+    fun `the constants are Play's ConnectionState values`() {
+        // BillingClient.ConnectionState: DISCONNECTED=0, CONNECTING=1,
+        // CONNECTED=2, CLOSED=3 — mirrored locally so the policy stays
+        // JVM-pure; this pins the mirror to the documented values.
+        assertEquals(0, BillingConnectionPolicy.DISCONNECTED)
+        assertEquals(1, BillingConnectionPolicy.CONNECTING)
+        assertEquals(2, BillingConnectionPolicy.CONNECTED)
+        assertEquals(3, BillingConnectionPolicy.CLOSED)
+    }
+
+    @Test
+    fun `the confirmed device sequence - background and foreground twice`() {
+        // The sequence from the device check that confirmed the hazard:
+        // connect, background, foreground, background, foreground. Old code
+        // closed the client on each background and reconnected the dead
+        // instance. Under the new table the client is never closed on
+        // background, so each foreground is a no-op reuse of the live
+        // connection — and if anything ever HAS closed it, the table
+        // replaces rather than reuses.
+        assertEquals(
+            ClientAction.REUSE,
+            BillingConnectionPolicy.clientAction(BillingConnectionPolicy.CONNECTED),
+        )
+        assertEquals(
+            ConnectAction.ALREADY_CONNECTED,
+            BillingConnectionPolicy.connectAction(BillingConnectionPolicy.CONNECTED),
+        )
+        assertEquals(
+            ClientAction.RECREATE,
+            BillingConnectionPolicy.clientAction(BillingConnectionPolicy.CLOSED),
+        )
+    }
+}


### PR DESCRIPTION
The reuse hazard flagged in #1389 is device-confirmed: `BillingManager` built its `BillingClient` once in the constructor, `onStop` called `endConnection()`, and `onStart` reconnected the same dead instance — `Client was already closed and can't be reused`. After one background/foreground cycle, billing was silently dead for the rest of the process. This PR keeps the connection alive across backgrounding and makes reuse of a closed client structurally impossible.

## The two findings that put this ahead of the queue

**Restore did not fail silently — it reported success.** The Android adapter in `@glance-apps/billing` implements `restore()` as `bridge.refresh()` → `queryPurchases()`, which no-ops on `!isReady` (permanently true on a dead client), then re-reads `getStatus()` after a 4-second settle and reports `restore_complete` from the **stale cache**. A user restoring after backgrounding was told it worked, having queried nothing — worse than an error, because it says the problem is solved and sends them away.

**New purchases failed too.** `launchPurchaseFlow` hits the `isReady` guard and errors with `billing_not_ready`. Someone who backgrounds mid-decision — checking a card, a password — returned to a paywall that could not sell to them until process death. A revenue path, not a stale cache. Neither has bitten yet (four purchasers, zero refunds), which is why this is a proper fix rather than an urgent one.

## The lifecycle as changed

| | Before | After |
|---|---|---|
| Construction | once, in the constructor | lazily, behind a single accessor that replaces a CLOSED instance |
| `onStart` | `startConnection` on whatever instance exists (dead after cycle 1) | idempotent `connect()`: live connection → straight to queries; in-flight → wait; disconnected → connect |
| `onStop` | `endConnection()` — the bug | nothing (connection kept alive across backgrounding) |
| `onDestroy` | nothing | `destroy()` — the only `endConnection` |
| Service drops | wait for next `onStart` (which reconnected a dead client) | `enableAutoServiceReconnection()` (PBL 8, already our version) self-heals |

**The invariant, and why it's structural rather than remembered:** the client is a `private var` touched in exactly two places — the `@Synchronized private fun client()` accessor and `destroy()`. Every operation goes through the accessor, which consults the pure decision table (`BillingConnectionPolicy.clientAction`): a CLOSED instance is replaced with a fresh one *before anything is handed out*, so the closed object becomes unreachable. A call site added by anyone later goes through the accessor because there is nothing else to hold. `connectAction` makes `connect()` idempotent: CONNECTED → skip straight to `queryPurchases()`/`queryProductPrices()` (so the on-foreground refresh still happens under keep-alive), CONNECTING → wait (no stacked `startConnection` from rapid foregrounds), DISCONNECTED → connect.

**Reconnection is reliable, not best-effort:** no absorbing dead state exists. A failed connection attempt closes nothing, so the next trigger — the next foreground, or auto-reconnection after a service drop — retries on a client that is still legal to connect (or on a fresh replacement if anything ever closed it).

## The `onDestroy` requirement — required, not cleanup

`MainActivity` declares `configChanges="orientation|screenSize|screenLayout|keyboardHidden"` — **not `uiMode` or locale**. A dark-mode toggle or a language change therefore recreates the activity, which builds a new `BillingManager` and a new client. Under the old code the outgoing instance's binding was released by `onStop`'s disconnect **purely by accident**. Removing the `onStop` teardown without adding `onDestroy` teardown would leak a service binding on every recreation — the kind of change that ships fine and puzzles someone for a week later. So `destroy()` in `onDestroy` is part of the fix itself. Under the invariant each client is closed at most once, and only there — which is also why `BillingBroadcastManager: Receiver is not registered` (a second `endConnection` on an already-closed client) should never appear again; if it does, something else is wrong.

## Verdicts carried from the report

- **`refresh()` race: separate defect, queued separately.** `queryPurchases()` still returns early on `!isReady` with no deferral. This fix makes the losing state rare again rather than permanent — shrunk back to the cold-start window and transient drops — but a refresh racing the cold-start connect still silently does nothing.
- **Blind restore timer: priority drops.** The adapter's 4-second settle now reads a genuinely refreshed status instead of a guaranteed-stale one. Still blind, but blind over fresh data — the queued item deserves a lower slot.
- **`consumeTestPurchase` wart** (clears local entitlement, then discovers `!isReady`, then reports success): pre-existing, dev-menu only, made rarer by this fix, left alone as agreed.

## #1389's retry lane is untouched

`AckRetryWorker` still builds its own short-lived client per attempt and closes it in a `finally`; it does **not** go through the new accessor, keeping the deliberate independence from the shared instance's lifecycle. Brief overlap of the two clients is harmless (separate instances, both bounded). The interaction is positive: with `queryPurchases()` now running on **every foreground** instead of only fresh process launches, #1389's opportunistic re-acknowledgement lane and its backstop re-scheduling finally behave the way that PR's description assumed. Nothing in this work revealed a problem with #1389. Entitlement ordering is untouched: `handlePurchase` still sets `subscriptionActive` unconditionally.

## Non-trivial design decisions

- **Lazy construction.** The client is only built on first use, so debug and github-flavor builds — which never call `connect()` — never construct one at all. A late accessor hit after `destroy()` (e.g. a JS bridge call racing teardown) creates only an inert DISCONNECTED object: no binding exists until `startConnection`, and `connect()` is never called after `onDestroy`, so it cannot leak.
- **`connect()` runs the queries on the ALREADY_CONNECTED path.** Under keep-alive, `onBillingSetupFinished` no longer fires per foreground, so the on-foreground refresh had to move into `connect()` itself — otherwise the fix would have quietly reintroduced "queryPurchases only on fresh launches" from the other direction.
- **Each operation captures the client once** (`val client = client()`) and uses that instance throughout its async chain, rather than re-resolving mid-operation.
- **`destroy()` deliberately does not construct** — tearing down nothing is fine; a teardown path that could build a client would be its own hazard.

## Verification

**Machine-verified (plain-JVM Gradle scratchpad; this environment has no Android SDK and CI runs only the JS suite):** `BillingConnectionPolicyTest` — 9 tests copied byte-identical with the policy into the standalone `kotlin("jvm")` project:

```
BillingConnectionPolicyTest: tests="9" skipped="0" failures="0" errors="0"
  a closed client is never reused - it is replaced
  every non-closed state hands the held instance out unchanged
  the invariant - no state both hands out and is closed
  foreground connect on a live connection does nothing (keep-alive)
  foreground connect while connecting waits - no stacked startConnection
  disconnected connects - first launch and after a service drop
  closed maps to connect as defence in depth
  the constants are Play's ConnectionState values
  the confirmed device sequence - background and foreground twice
AckRetryPolicyTest: tests="9" failures="0"   (still green alongside)
BUILD SUCCESSFUL
```

**Negative control:** with the fix removed from the policy copy (`clientAction` returning `REUSE` unconditionally — i.e., handing out closed clients, the old behaviour), the suite fails exactly where it should:

```
a closed client is never reused - it is replaced                    FAILED
the invariant - no state both hands out and is closed               FAILED
the confirmed device sequence - background and foreground twice     FAILED
```

Restored byte-identical → green again.

**Verified by inspection only, stated plainly:** the wiring — the accessor, lazy construction, `enableAutoServiceReconnection()`, the `onStart`/`onStop`/`onDestroy` changes — cannot be compiled here (no Android SDK), and actual connection behaviour, binding release, and Play interactions cannot be demonstrated off-device at all. Hence:

## Device scripts (licensed tester account)

*Prereqs for all: a release play-flavor build (debug never connects billing), `adb logcat -s DayGlanceBilling BillingClient BillingBroadcastManager` running. Dev menu: 7 taps on the plan label; diagnostics via `window.DayGlanceBilling.getBillingDiagnostics()` in the page console.*

**1. Background/foreground twice — the confirmed repro, now clean.**
Launch the app cold. Background it (home button), wait ~5 s, foreground. Repeat once more.
Expect: no `Client was already closed and can't be reused`, no `Receiver is not registered`, at any point. (There is no per-connection success log line; the proof a connection is live is that script 4's query runs.) Fail state: either warning appearing means the fix regressed or something else is closing the client.

**2. Restore after backgrounding actually queries.**
With a purchase on the account: launch, background, foreground (the old kill condition), then open the paywall and tap Restore.
Expect: Pro restored/confirmed from a **live** query. To distinguish from the old lie: clear local state first if you want a strict test (Settings → Apps → dayGLANCE → Clear storage, launch, background, foreground, Restore) — under the old code this could never succeed in a backgrounded-once process; post-fix it must.

**3. Purchase after backgrounding reaches the Play sheet.**
On an account with no active purchase: launch, background, foreground, open the paywall, tap purchase.
Expect: the Play purchase sheet opens. Old behaviour: error event `billing_not_ready`, no sheet. You can cancel the sheet — reaching it is the pass condition (and cancelling exercises the unchanged cancel path).

**4. `queryPurchases` runs on a foreground after backgrounding.**
While a subscription is active: launch, background, foreground.
Expect within a few seconds of the foreground: the entitlement cache refreshed from Play. Observable without new logging: cancel the test subscription in Play beforehand and let it expire, then background/foreground — the paywall should reappear on a foreground, not only after a process restart. Alternatively, with a pending-ack record seeded (script 5), the foreground clears it — same code path.

**5. The acknowledgement retry lane alongside the change.**
Re-run PR #1389's device script B (ack failure injected via airplane mode at the purchase gap, force-stop, network back, WorkManager recovers). Nothing in this PR touches that lane; expect identical behaviour. Additionally: with a pending-ack record present, a mere background/foreground (no process restart) should now log `pending ack cleared: Play reports token=…XXXXXXXX acknowledged` if the worker already landed it — that line firing on a *foreground* rather than a fresh launch is the positive interaction proof.

**6. Activity recreation without a leaked binding.**
With the app foreground, toggle system dark mode (recreates the activity — uiMode is not in `configChanges`). Then verify billing still works: open the paywall (prices present), background/foreground once, Restore or a purchase attempt reaches Play.
Expect: no billing warnings across the recreation, everything live afterwards. The leak itself is not directly visible in logcat; absence of `Receiver is not registered` plus working billing after several dark-mode toggles is the practical pass. For a stricter check: `adb shell dumpsys activity services com.android.vending | grep -c dayglance` should not grow with repeated toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_