### PR TITLE
Android: honest not-ready purchase message + reconnect on failure

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/billing/BillingManager.kt
@@ -342,8 +342,19 @@ class BillingManager(
         }
         val client = client()
         if (!client.isReady) {
-            Log.w(TAG, "launchPurchaseFlow($productId): client not ready")
+            Log.w(TAG, "launchPurchaseFlow($productId): client not ready — kicking a connection attempt")
             onBillingEvent?.invoke("error", BillingClient.BillingResponseCode.SERVICE_DISCONNECTED, "billing_not_ready", productId)
+            // The paywall tells the user to try again in a moment; make that
+            // advice true by establishing the connection the retry needs,
+            // instead of hoping unrelated connection work is in flight.
+            // connect() routes through the accessor (a CLOSED client is
+            // replaced, never reused) and BillingConnectionPolicy (CONNECTING
+            // maps to WAIT, so repeated taps on a slow connection cannot stack
+            // startConnection calls). Deliberately NO auto-resume: the
+            // purchase is not re-launched when the connection lands — a Play
+            // sheet appearing seconds after a failure, possibly after the
+            // user navigated away, is worse than a second tap.
+            connect()
             return
         }
 

--- a/dayglance-android/app/src/test/java/com/dayglance/app/billing/BillingConnectionPolicyTest.kt
+++ b/dayglance-android/app/src/test/java/com/dayglance/app/billing/BillingConnectionPolicyTest.kt
@@ -97,6 +97,28 @@ class BillingConnectionPolicyTest {
     }
 
     @Test
+    fun `repeated buy taps during a slow connect never stack`() {
+        // The not-ready purchase guard kicks connect() on every failed tap
+        // (launchPurchaseFlow's billing_not_ready path), so a user hammering
+        // buy on a slow connection is the same shape as rapid foregrounds.
+        // First tap finds DISCONNECTED and starts the one attempt; every
+        // further tap while that attempt is in flight must WAIT — this is
+        // the rule that keeps the reconnect-on-failure change from stacking
+        // startConnection calls.
+        assertEquals(
+            ConnectAction.CONNECT,
+            BillingConnectionPolicy.connectAction(BillingConnectionPolicy.DISCONNECTED),
+        )
+        repeat(5) {
+            assertEquals(
+                "tap ${it + 2} while connecting must WAIT",
+                ConnectAction.WAIT,
+                BillingConnectionPolicy.connectAction(BillingConnectionPolicy.CONNECTING),
+            )
+        }
+    }
+
+    @Test
     fun `the constants are Play's ConnectionState values`() {
         // BillingClient.ConnectionState: DISCONNECTED=0, CONNECTING=1,
         // CONNECTED=2, CLOSED=3 — mirrored locally so the policy stays

--- a/src/components/SubscriptionWall.jsx
+++ b/src/components/SubscriptionWall.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Wordmark from './Wordmark';
 import { Check, Loader } from 'lucide-react';
+import { paywallErrorMessage } from '../utils/paywallErrorMessage.js';
 
 /**
  * Full-screen paywall shown on Android, iOS, and macOS when the user has no active subscription.
@@ -49,7 +50,12 @@ export default function SubscriptionWall({
     if (!billingEvent) return;
     setPending(null);
     if (billingEvent.status === 'error') {
-      setErrorMsg(billingErrorMessage?.(billingEvent.code) ?? 'Something went wrong. Please try again.');
+      // isAndroid: this wall only renders on the three native platforms, and
+      // isIOSApp covers both Apple ones — so !isIOSApp here means Android.
+      setErrorMsg(paywallErrorMessage(billingEvent, {
+        isAndroid: !isIOSApp,
+        mapCode: billingErrorMessage,
+      }));
     } else {
       setErrorMsg(null);
     }

--- a/src/utils/paywallErrorMessage.js
+++ b/src/utils/paywallErrorMessage.js
@@ -1,0 +1,32 @@
+/**
+ * Chooses the paywall banner string for a terminal billing error event.
+ *
+ * Exists for one honest sentence: on Android, code -1 (Play Billing's
+ * SERVICE_DISCONNECTED) means the billing connection is not up — most often
+ * the `billing_not_ready` guard in launchPurchaseFlow firing during the
+ * cold-start connection window or right after a transient service drop. The
+ * package's generic fallback ("Something went wrong with the purchase...")
+ * vaguely implicates a purchase that was never attempted and gives no sense
+ * of whether retrying is worthwhile. It IS worthwhile: the native guard now
+ * kicks a reconnect on this exact failure, so a retry lands on a connection
+ * that is actually being established.
+ *
+ * Every other code passes through the shared mapper untouched — the five
+ * specific strings (product not found, billing unavailable, subscription
+ * unavailable, network error, already owned) and its own fallback are the
+ * package's business, not ours.
+ *
+ * Android-only by design: -1 is a Play Billing response code. On iOS/macOS
+ * the code space is StoreKit/RevenueCat's, where -1 has no such meaning.
+ */
+export const BILLING_NOT_READY_MESSAGE =
+  'Still connecting to Google Play. Please try again in a moment.';
+
+const PLAY_SERVICE_DISCONNECTED = -1;
+
+export function paywallErrorMessage(event, { isAndroid = false, mapCode } = {}) {
+  if (isAndroid && event?.code === PLAY_SERVICE_DISCONNECTED) {
+    return BILLING_NOT_READY_MESSAGE;
+  }
+  return mapCode?.(event?.code) ?? 'Something went wrong. Please try again.';
+}

--- a/src/utils/paywallErrorMessage.test.js
+++ b/src/utils/paywallErrorMessage.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { billingErrorMessage } from '@glance-apps/billing';
+import {
+  paywallErrorMessage,
+  BILLING_NOT_READY_MESSAGE,
+} from './paywallErrorMessage.js';
+
+// The wall calls this with { isAndroid, mapCode: billingErrorMessage } — the
+// tests use the real shared mapper so the pass-through assertions guard the
+// actual strings users see, not a stub's.
+const onAndroid = { isAndroid: true, mapCode: billingErrorMessage };
+const onApple = { isAndroid: false, mapCode: billingErrorMessage };
+
+describe('paywallErrorMessage', () => {
+  it('maps Android code -1 (SERVICE_DISCONNECTED / billing_not_ready) to the honest connecting message', () => {
+    const ev = { status: 'error', code: -1, message: 'billing_not_ready', productId: 'dayglance_pro_annual' };
+    expect(paywallErrorMessage(ev, onAndroid)).toBe(BILLING_NOT_READY_MESSAGE);
+  });
+
+  it('also covers a mid-purchase SERVICE_DISCONNECTED, which carries a Play debugMessage instead', () => {
+    // The purchasesUpdatedListener error branch forwards Play's own -1 with
+    // whatever debugMessage Play attached; the condition is the same (the
+    // connection to Play is not up) so the message is the same.
+    const ev = { status: 'error', code: -1, message: 'Service connection is disconnected.', productId: '' };
+    expect(paywallErrorMessage(ev, onAndroid)).toBe(BILLING_NOT_READY_MESSAGE);
+  });
+
+  it('leaves the five specifically-mapped codes untouched (regression guard)', () => {
+    // These are the shared mapper's strings verbatim — if the package
+    // rewords them, this test should fail so the pass-through is re-checked.
+    for (const [code, expected] of [
+      [1, 'Product not found. Please try again later.'],
+      [3, 'Billing is not available on this device.'],
+      [4, "This subscription isn't available right now. Please try again later."],
+      [6, 'Network error. Please check your connection and try again.'],
+      [7, 'You already own this item.'],
+    ]) {
+      expect(paywallErrorMessage({ status: 'error', code }, onAndroid)).toBe(expected);
+    }
+  });
+
+  it('leaves unknown codes on the shared mapper fallback, not the not-ready message', () => {
+    expect(paywallErrorMessage({ status: 'error', code: 5 }, onAndroid)).toBe(
+      'Something went wrong with the purchase. Please try again.',
+    );
+  });
+
+  it('does not apply the Android meaning of -1 on Apple platforms', () => {
+    // -1 is a Play Billing response code; on iOS/macOS the code space is
+    // StoreKit/RevenueCat's, so -1 must fall through to the shared mapper.
+    const ev = { status: 'error', code: -1, message: '' };
+    expect(paywallErrorMessage(ev, onApple)).toBe(
+      'Something went wrong with the purchase. Please try again.',
+    );
+  });
+
+  it('degrades to a generic message when no mapper is supplied', () => {
+    expect(paywallErrorMessage({ status: 'error', code: 6 }, { isAndroid: false })).toBe(
+      'Something went wrong. Please try again.',
+    );
+  });
+});


### PR DESCRIPTION
Closes the remainder of the not-ready purchase path after #1389/#1390: the user now reads what actually happened, and the retry they're invited to make runs against a connection that is actually being established.

## Change 1: the wording, and how it fits the mapper's voice

**Chosen string:** `Still connecting to Google Play. Please try again in a moment.`

The five specifically-mapped codes all follow the same pattern — a short declarative statement of what happened, then a "Please …" action ("Product not found. Please try again later.", "Network error. Please check your connection and try again."). The new string keeps that shape, names the actual condition (a connection still coming up, not a failed purchase), and makes the action time-bound ("in a moment") because that is genuinely how long it takes post-#1390.

**Where it lives, and why in-app:** the mapping conceptually belongs in `@glance-apps/billing`'s `billingErrorMessage`, but dayGLANCE consumes that package from npm (pinned 0.1.1; the source isn't in this repo), so the change lands as `src/utils/paywallErrorMessage.js` — a pure wrapper the wall calls with `{ isAndroid, mapCode: billingErrorMessage }`. One design point makes the wrapper's shape worth keeping even after a package-side fix: `billingErrorMessage(code)` is shared by all three platforms, and `-1` only carries the "Play connection not up" meaning on Android — on iOS/macOS the code space is StoreKit/RevenueCat's. The wrapper therefore gates on platform; a package-side version needs the same platform awareness rather than an unconditional `case -1` (see the handoff note below).

**Localization:** none involved — the paywall's strings (`SubscriptionWall.jsx`) are hardcoded English on every platform, so the new string is English-only like its neighbours.

## Change 2: the reconnect, routed through #1390's machinery

The `billing_not_ready` guard in `launchPurchaseFlow` now calls `connect()` after emitting the error event. Both of the things to get right are inherited rather than re-implemented:

- **Accessor:** `connect()` obtains the client via the #1390 accessor, so a CLOSED instance is replaced before use — this change adds no direct client access anywhere (the invariant's "two touch points" stays two).
- **No stacking:** `connect()` consults `BillingConnectionPolicy.connectAction`, where CONNECTING → WAIT. A user hammering buy on a slow connection is exactly the rapid-foregrounds shape that rule was written for: the first failed tap finds DISCONNECTED and starts the one attempt; every further tap while it's in flight waits. A new policy test (`repeated buy taps during a slow connect never stack`) pins this sequence explicitly.

In the guard path the client is by definition not ready, so the ALREADY_CONNECTED branch (which runs the queries) is unreachable from here — **the happy path is untouched**: a ready client never enters the guard, and no connection attempt or delay is added to a normal purchase.

**Deliberately no auto-resume.** The purchase is not re-launched when the connection lands. The user tapped, it failed, they were told to try again; a Play sheet appearing seconds later — possibly after they navigated away — is worse than a second tap. The comment at the guard says so, so a future reader doesn't "fix" it.

## The `refresh()` deferral item — reported, not done

Not made trivially easy, and not done. This change reconnects but deliberately resumes nothing, which is the opposite half of the deferral problem: deferral requires remembering *what* to run when the connection lands (a queued `queryPurchases`), i.e. resume semantics with their own staleness questions. Nothing here builds that machinery; the queued item stands as-is.

## Verification

**JS (repo's real CI suite, vitest):** `paywallErrorMessage.test.js` — 6 tests: Android `-1` with `billing_not_ready`, Android `-1` with a Play debugMessage (mid-purchase disconnect, same condition), pass-through regression guards for all five mapped codes **using the real shared mapper's strings verbatim**, unknown-code fallback, Apple `-1` falling through, and no-mapper degradation. Full suite: **121 files, 1785 tests, all passing.**

Negative control (JS): with the special case deleted from the wrapper, exactly the two not-ready tests fail (`2 failed | 4 passed`); restored → green.

**Kotlin (plain-JVM scratchpad, byte-identical copies):** `BillingConnectionPolicyTest` now 10 tests, 0 failures (ack suite still green alongside).

Negative control (Kotlin): with CONNECTING mutated to CONNECT — the stacking behaviour this change must not have — both the new repeated-taps test and the original while-connecting test fail; restored byte-identical → green.

**Verified by inspection only, stated plainly:** the one-line `connect()` call in the guard compiles against the Android SDK (absent here) and its runtime behaviour — the actual reconnect, and the message rendering on a device — is device-only. Hence:

## Device steps (licensed tester account)

*Prereqs: release play-flavor build, `adb logcat -s DayGlanceBilling` running, an account able to reach the paywall (no active purchase).*

1. **Cold start, tap buy during the connecting window.** Force-stop the app, launch, and tap a plan as fast as possible after the paywall renders (the connection usually lands within ~1–2 s, so be quick; airplane mode ON before launch widens the window — turn it off right after the tap). Expect the banner to read "Still connecting to Google Play. Please try again in a moment." — not "Something went wrong with the purchase." Logcat: `launchPurchaseFlow(...): client not ready — kicking a connection attempt`.
2. **Tap again immediately.** Expect the Play sheet to open (the kicked connection has landed). Cancel the sheet; reaching it is the pass.
3. **Hammer buy during the window.** Repeat step 1's setup and tap the plan 4–5 times quickly. Expect exactly one connection establishment in logcat — the `client not ready` line may repeat per tap, but there should be no interleaved churn of repeated setup/teardown, and no `Client was already closed` ever. Then one more tap reaches the sheet.
4. **Normal purchase on a ready client.** Launch, wait a few seconds, buy. Expect: identical to today — sheet opens directly, no `client not ready` line, no extra connection activity.

## Package-side handoff (you own `@glance-apps/billing`)

For the package (which also serves lifeGLANCE/lastGLANCE via the Capacitor adapter): the equivalent of change 1 is the same string for code `-1`, but **gated to Android** rather than added as an unconditional `case -1` in the shared `billingErrorMessage` — either an options parameter (`billingErrorMessage(code, { platform })`) or mapping in the Android-side adapters, since the adapter already knows its platform. The equivalent of change 2 (`connect()` in `PlayBillingCore`'s not-ready guard) **must wait for the package to take #1390's lifecycle fix first** — `PlayBillingCore` still has the constructor-built client with endConnection-on-stop, and kicking `startConnection` from the guard there would reconnect a closed client, making things worse, not better. Order: lifecycle fix (with `BillingConnectionPolicy`), then this.

Out of scope and untouched, per the phase prompt: #1389's retry lane, #1390's lifecycle (this change only calls into it), iOS/macOS paths, the other queued items. Nothing in this work revealed a problem with either prior PR. The four existing purchasers never see this path (active entitlement → no paywall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_