### PR TITLE
Bump @glance-apps/billing 0.1.1 → 0.2.2 (suite parity, no behavior change)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
-        "@glance-apps/billing": "0.1.1",
+        "@glance-apps/billing": "0.2.2",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.10.0",
         "@modelcontextprotocol/node": "2.0.0",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/@glance-apps/billing": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.1.1.tgz",
-      "integrity": "sha512-7dayiwwDAEyhZbtwtg1GOj9uJixCIS2kI/qXx12S63ec+sbrgNlXFkJ+MpgV/pE04Mq5ndJo8DiYJmGnDfjI9Q==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.2.2.tgz",
+      "integrity": "sha512-sp10Lb5fDD4rRmIfPjxKj9tBlxG855y0UWPMVThWK7+854pT8bEzx5NWHjiWtl9suuraR0XP4/mz3OsOTXBFGA==",
       "license": "MIT",
       "peerDependencies": {
         "electron": ">=28",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:electron:mas": "npm run build:helpers && DAYGLANCE_MAS_BUILD=1 vite build --config vite.config.electron.js && npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.electron.preload.json && DAYGLANCE_APP_ID=com.dayglance electron-builder --config electron-builder.config.cjs --mac mas --universal --publish never"
   },
   "dependencies": {
-    "@glance-apps/billing": "0.1.1",
+    "@glance-apps/billing": "0.2.2",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.10.0",
     "@modelcontextprotocol/node": "2.0.0",


### PR DESCRIPTION
Parity bump so all three GLANCE apps pin the same `@glance-apps/billing` version. Pinned exact (`"0.2.2"`, no range), matching the previous pin style.

**Verified to change zero shipped bytes for dayGLANCE.** A full-tree diff of 0.1.1 → 0.2.1 → 0.2.2 shows `dist/` (the engine, react hook, all four adapters, `billingErrorMessage`, electron-main) byte-identical across all three versions. Every change in the 0.2.x line lives in the bundled native Android Gradle module — the PBL 8 migration in 0.2.0/0.2.1, and in 0.2.2 the ported connection-lifecycle and ack-retry fixes (`BillingConnectionPolicy.kt`, `AckRetryPolicy.kt`, `AckRetryWorker.kt`, `BillingStore.kt`, plus tests). dayGLANCE never builds that module: its Android shell isn't Capacitor, nothing includes `:glance-apps-billing`, and its Play billing runs through the in-repo `BillingManager.kt`, which already carries those fixes natively (#1389, #1390).

Verification: full JS suite green — 121 files, 1785 tests — including `paywallErrorMessage.test.js`, which asserts the shared mapper's five specific strings and its fallback verbatim against the installed package, so a wording change in `billingErrorMessage` would have failed loudly. It didn't; the mapper is unchanged.

Diff is `package.json` + `package-lock.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_