### PR TITLE
Guard bump-version.mjs against running on main

### DIFF
--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -33,6 +33,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -59,6 +60,29 @@ if (!version) {
 // Strict semver x.y.z — no prerelease/build metadata, no leading "v".
 if (!/^\d+\.\d+\.\d+$/.test(version)) {
   die(`"${version}" is not a valid X.Y.Z version (expected e.g. 4.0.0).`);
+}
+
+// ── Guard: never run on main ────────────────────────────────────────────
+// The bump lands in a release PR. Written on main, it becomes a local
+// commit that branch protection rejects on the next pull, leaving
+// divergent branches to untangle. Refuse up front, before any file is
+// touched. Deliberately no bypass flag: if this ever needs to run from
+// main, checking out a branch takes five seconds.
+let currentBranch = '';
+try {
+  currentBranch = execSync('git rev-parse --abbrev-ref HEAD', {
+    cwd: ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+} catch {
+  // Not a git checkout (or git unavailable) — nothing for the guard to protect.
+}
+if (currentBranch === 'main') {
+  die('refusing to run on main. A bump written here becomes a local commit ' +
+      'that fights branch protection on the next pull. Create a branch first:\n' +
+      `  git checkout -b bump-v${version}\n` +
+      `then re-run: npm run bump ${version}`);
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
One file, 24 added lines: `bump-version.mjs` now refuses to run when the current branch is `main`.

## The guard and the exact message

The check runs right after argument validation — before any file is read for rewriting, and well before anything is written. Branch detection is one `git rev-parse --abbrev-ref HEAD` via Node's built-in `child_process` (no new dependencies). If the directory isn't a git checkout, the guard skips itself — nothing to protect. On `main`, the script exits 1 with:

```
bump-version: refusing to run on main. A bump written here becomes a local commit that fights branch protection on the next pull. Create a branch first:
  git checkout -b bump-v9.9.9
then re-run: npm run bump 9.9.9
```

(the version in the suggested commands is the one the user passed, so the fix is copy-pasteable). No bypass flag, per the task: checking out a branch takes five seconds.

One factual nuance from reading the script before changing it: `bump-version.mjs` doesn't itself commit — it writes the four files and its "Next steps" output tells the human to `git add -A && git commit`. Run on main, that human commit is what creates the divergent-branches mess. Same hazard, one step later than the task description assumed; the guard is the same either way. The refusal is unconditional on main — `--dry-run` is refused there too, which costs nothing (a dry run on main previews a bump that must not happen there) and keeps the guard a single condition.

## Nothing automated invokes it

Checked every reference in the repo: the `"bump"` alias in `package.json` (`npm run bump`, a human command), and RELEASING.md's manual release steps. No CI workflow, no other script, no hook calls it. A hard refusal breaks no working path.

## Nothing else changed

The diff is the import line plus the guard block. What the script bumps, how it validates, the report format, the Android `versionCode` handling (untouched, still in `build-and-install.sh`), and all messages on other paths are identical.

## Verification

1. **Refuses on main, exit non-zero, before any write:** in an isolated git worktree checked out as a branch literally named `main` (with the guarded script copied in), `node scripts/bump-version.mjs 9.9.9` printed the message above and exited 1; `git status` showed zero modified files besides the copied script itself — nothing was written.
2. **Any other branch unchanged:** on this feature branch, `--dry-run` printed the same four-file report and exited 0; a real run wrote the same four files (`package.json`, `build.gradle.kts`, `README.md`, `package-lock.json`) and exited 0 (then reset).
3. Both together satisfy refusal-before-write: the guard sits above the file-reading section entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_