### PR TITLE
Add equal jitter to the vault SSE reconnect backoff (both mirrors)

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/sse/SseBackoff.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/sse/SseBackoff.kt
@@ -1,8 +1,10 @@
 package com.dayglance.app.sse
 
 /**
- * Capped exponential backoff with a stability reset — the Kotlin mirror of the
- * reconnect policy in `createVaultEventClient` (src/sync/vaultEventStream.js).
+ * Capped exponential backoff with equal jitter and a stability reset — the
+ * Kotlin mirror of the reconnect policy in `createVaultEventClient`
+ * (src/sync/vaultEventStream.js, see backoffDelayMs there). Change both
+ * together.
  *
  * A connection that stays open at least [minStableMs] is treated as healthy and
  * resets the attempt counter, so a genuine long-lived stream that finally drops
@@ -10,26 +12,38 @@ package com.dayglance.app.sse
  * server closing fast, proxy timeout, network reset) keeps backing off, up to
  * [maxMs], so a broken endpoint can never storm the vault with reconnects.
  *
- * Pure and deterministic, so it is unit-testable with no clock or network.
+ * EQUAL JITTER on top: the exponential's lower half is kept as a floor that
+ * still grows with the attempt count (the politeness the stability reset
+ * protects), and the upper half is spread uniformly, so the many devices
+ * dropped by a single vault restart reconnect scattered instead of in aligned
+ * 1s/2s/4s… waves against the vault's per-IP rate limiter. Full jitter would
+ * decorrelate harder but can retry almost immediately after a failure, which
+ * undoes the backoff's purpose. The cap applies to the exponential BEFORE
+ * jitter, so every delay is < [maxMs] and ≥ [baseMs]/2 (never zero).
+ *
+ * Pure, and deterministic with an injected [random] source (the SseBackoff
+ * clock-injection pattern), so it is unit-testable with no clock or network.
  */
 class SseBackoff(
     private val baseMs: Long = 1_000,
     private val maxMs: Long = 30_000,
     private val minStableMs: Long = 5_000,
+    private val random: () -> Double = { Math.random() },
 ) {
 
     private var attempt = 0
 
     /**
      * The delay to wait before the NEXT reconnect attempt, then advances the
-     * counter. `base * 2^attempt`, capped at [maxMs]. The shift amount is clamped
-     * so a large attempt count can't overflow / wrap the Long shift.
+     * counter. `base * 2^attempt` capped at [maxMs], then equal jitter: the
+     * result is uniform in [exp/2, exp). The shift amount is clamped so a
+     * large attempt count can't overflow / wrap the Long shift.
      */
     fun nextDelayMs(): Long {
         val shift = attempt.coerceIn(0, 30)
-        val delay = minOf(maxMs, baseMs shl shift)
+        val exp = minOf(maxMs, baseMs shl shift)
         attempt++
-        return delay
+        return exp / 2 + (random() * (exp / 2)).toLong()
     }
 
     /**

--- a/dayglance-android/app/src/test/java/com/dayglance/app/sse/SseBackoffTest.kt
+++ b/dayglance-android/app/src/test/java/com/dayglance/app/sse/SseBackoffTest.kt
@@ -1,6 +1,7 @@
 package com.dayglance.app.sse
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -8,12 +9,19 @@ import org.junit.Test
  * reset policy the renderer's createVaultEventClient is tested for, so native and
  * web reconnect behaviour match: a flap keeps backing off (no storm), a healthy
  * connection resets so a later drop reconnects fast.
+ *
+ * The ladder tests inject `random = { 1.0 }`: with equal jitter the delay is
+ * exp/2 + r*(exp/2), so the upper edge recovers the pre-jitter exponential
+ * ladder exactly and the original assertions (and their comments) stay true.
+ * The jitter itself is covered by the seeded-distribution tests below.
  */
 class SseBackoffTest {
 
+    private val ceiling: () -> Double = { 1.0 }
+
     @Test
     fun `grows exponentially and caps at maxMs`() {
-        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, minStableMs = 5_000)
+        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, minStableMs = 5_000, random = ceiling)
         assertEquals(1_000, b.nextDelayMs())  // 1000 * 2^0
         assertEquals(2_000, b.nextDelayMs())  // 2^1
         assertEquals(4_000, b.nextDelayMs())  // 2^2
@@ -25,7 +33,7 @@ class SseBackoffTest {
 
     @Test
     fun `a flap (closed before minStableMs) does NOT reset — backoff keeps growing`() {
-        val b = SseBackoff(baseMs = 1_000, maxMs = 60_000, minStableMs = 5_000)
+        val b = SseBackoff(baseMs = 1_000, maxMs = 60_000, minStableMs = 5_000, random = ceiling)
         assertEquals(1_000, b.nextDelayMs())
         b.onClosed(50)                        // opened then dropped fast → no reset
         assertEquals(2_000, b.nextDelayMs())  // continues to grow, no 1s storm
@@ -35,7 +43,7 @@ class SseBackoffTest {
 
     @Test
     fun `a stable connection (open past minStableMs) resets so the next reconnect is fast`() {
-        val b = SseBackoff(baseMs = 1_000, maxMs = 60_000, minStableMs = 5_000)
+        val b = SseBackoff(baseMs = 1_000, maxMs = 60_000, minStableMs = 5_000, random = ceiling)
         b.nextDelayMs(); b.nextDelayMs(); b.nextDelayMs() // climb to attempt=3
         b.onClosed(10_000)                    // healthy: open 10s ≥ 5s → reset
         assertEquals(1_000, b.nextDelayMs())  // back to base
@@ -43,7 +51,7 @@ class SseBackoffTest {
 
     @Test
     fun `reset returns to base`() {
-        val b = SseBackoff(baseMs = 500)
+        val b = SseBackoff(baseMs = 500, random = ceiling)
         b.nextDelayMs(); b.nextDelayMs()
         b.reset()
         assertEquals(500, b.nextDelayMs())
@@ -51,9 +59,56 @@ class SseBackoffTest {
 
     @Test
     fun `many attempts never overflow the delay (stays capped, non-negative)`() {
-        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, minStableMs = 5_000)
+        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, minStableMs = 5_000, random = ceiling)
         repeat(200) { b.nextDelayMs() }
         val d = b.nextDelayMs()
         assertEquals(30_000, d) // clamped shift → no overflow/wrap to a bogus delay
+    }
+
+    // ── Equal jitter (seeded, deterministic) ─────────────────────────────────
+
+    @Test
+    fun `jitter spreads same-attempt delays instead of one aligned value (the anti-wave property)`() {
+        // Many clients dropped by the same vault restart must not share a
+        // schedule. Without jitter every attempt-3 delay is exactly 8000 and
+        // this test fails on the distinct-count assertion (the negative
+        // control removes the jitter to prove that).
+        val rnd = java.util.Random(42)
+        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, random = { rnd.nextDouble() })
+        val samples = (1..500).map {
+            b.reset()
+            repeat(3) { b.nextDelayMs() }
+            b.nextDelayMs()                   // the attempt-3 delay: exp = 8000
+        }
+        assertTrue("expected a spread, got ${samples.distinct().size} distinct", samples.distinct().size > 100)
+        assertTrue("floor: every sample ≥ exp/2", samples.all { it >= 4_000 })
+        assertTrue("range: every sample < exp", samples.all { it < 8_000 })
+    }
+
+    @Test
+    fun `the cap still caps and the floor holds at high attempt counts`() {
+        val rnd = java.util.Random(7)
+        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, random = { rnd.nextDouble() })
+        repeat(40) { b.nextDelayMs() }        // deep past the cap
+        val samples = (1..500).map { b.nextDelayMs() }
+        assertTrue("cap: no sample may exceed maxMs", samples.all { it < 30_000 })
+        assertTrue("floor at cap: ≥ maxMs/2", samples.all { it >= 15_000 })
+    }
+
+    @Test
+    fun `no delay is ever zero or negative, from the very first attempt`() {
+        val rnd = java.util.Random(3)
+        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, random = { rnd.nextDouble() })
+        val first = (1..200).map { b.reset(); b.nextDelayMs() }
+        assertTrue("attempt-0 floor is base/2", first.all { it >= 500 })
+    }
+
+    @Test
+    fun `deterministic with a seeded source - same seed, same sequence`() {
+        val a = SseBackoff(random = java.util.Random(99)::nextDouble)
+        val b = SseBackoff(random = java.util.Random(99)::nextDouble)
+        val seqA = (1..6).map { a.nextDelayMs() }
+        val seqB = (1..6).map { b.nextDelayMs() }
+        assertEquals(seqA, seqB)
     }
 }

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -322,6 +322,28 @@ export function createNudgeCoalescer({
 // ─── connection client (reconnect + backoff) ──────────────────────────────────
 
 /**
+ * Reconnect delay for `attempt` (0-based): capped exponential with EQUAL
+ * JITTER. The exponential's lower half is kept as a floor that still grows
+ * with the attempt count — the politeness the flap guard (minStableMs)
+ * exists to protect — and the upper half is spread uniformly, so the many
+ * clients (or tabs behind one IP) dropped by a single vault restart
+ * reconnect scattered instead of in aligned 1s/2s/4s… waves against the
+ * vault's per-IP rate limiter. Full jitter (random(0, delay)) would
+ * decorrelate harder but can retry almost immediately after a failure,
+ * which undoes the backoff's purpose. The cap applies to the exponential
+ * BEFORE jitter, so every sample is < maxMs and ≥ baseMs/2 (never zero).
+ *
+ * Mirrored by SseBackoff.nextDelayMs
+ * (dayglance-android/.../sse/SseBackoff.kt) — change both together.
+ *
+ * @param {{attempt:number, baseMs:number, maxMs:number, random:() => number}} p
+ */
+export function backoffDelayMs({ attempt, baseMs, maxMs, random }) {
+  const exp = Math.min(maxMs, baseMs * 2 ** attempt);
+  return Math.floor(exp / 2 + random() * (exp / 2));
+}
+
+/**
  * Manages the SSE connection lifecycle: connect, pump events through onEvent,
  * and on any drop reconnect with capped exponential backoff. It NEVER touches
  * polling — polling is a separate effect and remains the backstop for every gap
@@ -342,6 +364,8 @@ export function createNudgeCoalescer({
  * @param {typeof setTimeout}  [p.setTimeoutFn]
  * @param {typeof clearTimeout}[p.clearTimeoutFn]
  * @param {() => number} [p.now]       clock (injectable for tests)
+ * @param {() => number} [p.randomFn]  uniform [0,1) source for the backoff
+ *                                     jitter (injectable so tests stay deterministic)
  * @param {(state:string, detail?:any) => void} [p.onStateChange]
  */
 export function createVaultEventClient({
@@ -355,6 +379,7 @@ export function createVaultEventClient({
   setTimeoutFn = setTimeout,
   clearTimeoutFn = clearTimeout,
   now = () => Date.now(),
+  randomFn = Math.random,
   onStateChange,
 } = {}) {
   let stopped = true;
@@ -400,7 +425,9 @@ export function createVaultEventClient({
       // healthy; a flapping open/close keeps backing off (up to backoffMaxMs) so a
       // broken endpoint can't storm.
       if (now() - startedAt >= minStableMs) attempt = 0;
-      const delay = Math.min(backoffMaxMs, backoffBaseMs * 2 ** attempt);
+      const delay = backoffDelayMs({
+        attempt, baseMs: backoffBaseMs, maxMs: backoffMaxMs, random: randomFn,
+      });
       attempt += 1;
       await new Promise((resolve) => { reconnectTimer = setTimeoutFn(resolve, delay); });
       reconnectTimer = null;

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -7,6 +7,7 @@ import {
   createNudgeCoalescer,
   createVaultEventClient,
   createBridgeSseClient,
+  backoffDelayMs,
 } from './vaultEventStream.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -299,6 +300,9 @@ describe('createVaultEventClient — lifecycle, reconnect, reconcile', () => {
       onEvent: coalescer.handleEvent,
       backoffBaseMs: 1000,
       backoffMaxMs: 30000,
+      // Equal jitter's upper edge recovers the pre-jitter ladder, keeping
+      // this test's exact timer arithmetic (and its comments) true.
+      randomFn: () => 1,
     });
 
     client.start();
@@ -336,6 +340,7 @@ describe('createVaultEventClient — lifecycle, reconnect, reconcile', () => {
       backoffBaseMs: 1000,
       backoffMaxMs: 60000,
       minStableMs: 5000,
+      randomFn: () => 1, // upper edge = pre-jitter ladder; see jitter tests below
     });
     client.start();
     expect(s.calls).toHaveLength(1);
@@ -368,6 +373,7 @@ describe('createVaultEventClient — lifecycle, reconnect, reconcile', () => {
       onEvent: () => {},
       backoffBaseMs: 1000,
       minStableMs: 5000,
+      randomFn: () => 1, // upper edge = pre-jitter ladder
     });
     client.start();
     vi.advanceTimersByTime(5000);                // healthy: stayed open 5s
@@ -622,5 +628,78 @@ describe('createBridgeSseClient — native bridge-fed transport', () => {
     expect(states.find((s) => s[0] === 'error')[1]).toEqual({
       message: 'vault SSE refused: insecure http URL', code: 'insecure',
     });
+  });
+});
+
+describe('backoffDelayMs — equal jitter (mirrored by SseBackoff.kt; change both together)', () => {
+  // Seeded LCG so every assertion is deterministic — the injected-source
+  // pattern this codebase uses for clocks, applied to randomness.
+  const lcg = (seed) => () => {
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+    return seed / 2 ** 32;
+  };
+
+  it('spreads same-attempt delays instead of one aligned value (the anti-wave property)', () => {
+    // Many clients dropped by the same vault restart must not share a
+    // schedule. Without jitter every attempt-3 delay is exactly 8000 and the
+    // distinct-count assertion fails — that is the negative control.
+    const random = lcg(42);
+    const samples = Array.from({ length: 500 }, () =>
+      backoffDelayMs({ attempt: 3, baseMs: 1000, maxMs: 30000, random }));
+    expect(new Set(samples).size).toBeGreaterThan(100);
+    expect(samples.every((d) => d >= 4000)).toBe(true); // floor: exp/2
+    expect(samples.every((d) => d < 8000)).toBe(true);  // range: < exp
+  });
+
+  it('the cap still caps and the floor holds at high attempt counts', () => {
+    const random = lcg(7);
+    const samples = Array.from({ length: 500 }, () =>
+      backoffDelayMs({ attempt: 20, baseMs: 1000, maxMs: 30000, random }));
+    expect(samples.every((d) => d < 30000)).toBe(true);  // never exceeds max
+    expect(samples.every((d) => d >= 15000)).toBe(true); // floor at cap: max/2
+  });
+
+  it('no delay is ever zero or negative, from the very first attempt', () => {
+    const random = lcg(3);
+    const samples = Array.from({ length: 200 }, () =>
+      backoffDelayMs({ attempt: 0, baseMs: 1000, maxMs: 30000, random }));
+    expect(samples.every((d) => d >= 500)).toBe(true); // attempt-0 floor: base/2
+  });
+
+  it('deterministic with a seeded source — same seed, same sequence', () => {
+    const seq = (seed) => {
+      const random = lcg(seed);
+      return Array.from({ length: 6 }, (_, i) =>
+        backoffDelayMs({ attempt: i, baseMs: 1000, maxMs: 30000, random }));
+    };
+    expect(seq(99)).toEqual(seq(99));
+  });
+
+  it('the client waits at least the floor before reconnecting (behavioural floor check)', async () => {
+    // randomFn () => 0 pins every delay to its floor exp/2: after the first
+    // instant drop the reconnect must NOT fire before 500ms, and must at 500.
+    vi.useFakeTimers();
+    const calls = [];
+    const client = createVaultEventClient({
+      supported: true,
+      getConnection: () => ({ vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' }),
+      openStream: async (args) => { calls.push(args); throw new Error('refused'); },
+      onEvent: () => {},
+      backoffBaseMs: 1000,
+      backoffMaxMs: 30000,
+      minStableMs: 5000,
+      randomFn: () => 0,
+    });
+    client.start();
+    await Promise.resolve(); await Promise.resolve();
+    expect(calls).toHaveLength(1);
+    vi.advanceTimersByTime(499);                 // just under the attempt-0 floor
+    await Promise.resolve(); await Promise.resolve();
+    expect(calls).toHaveLength(1);               // no early retry
+    vi.advanceTimersByTime(1);                   // 500ms: the floor
+    await Promise.resolve(); await Promise.resolve();
+    expect(calls).toHaveLength(2);
+    client.stop();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
Both reconnect backoffs — JS `createVaultEventClient` and its Kotlin mirror `SseBackoff` — were exponential-capped with zero randomization, so every client dropped by one vault restart reconnected on an identical schedule synchronized to the disconnect instant: aligned waves at 1s/2s/4s/8s/16s/30s into the vault's per-IP rate limiter. The stability reset keeps each client individually polite; only jitter decorrelates clients from each other.

## Jitter shape: equal jitter, and why

`delay = exp/2 + random(0, exp/2)` where `exp` is the capped exponential. Full jitter (`random(0, exp)`) decorrelates hardest, but its lower tail retries almost immediately after a failure — and a floor that grows with the attempt count is precisely the property the stability reset exists to protect (a flapping endpoint must keep getting slower, never faster). Equal jitter keeps that floor while spreading each wave across half its interval, which is ample decorrelation for this population. The cap applies to the exponential **before** jitter, so every sample is `< maxMs` and `≥ baseMs/2`: the cap still caps, and no delay can be zero or negative.

Constants untouched: base 1000ms, ×2, cap 30000ms, `minStableMs` 5000ms — same numbers, both platforms. The stability reset is untouched: same line, same behavior, still covered by its original tests.

## How the mirrors were kept in step

Same formula, same integer semantics (`Math.floor` in JS mirrors Kotlin's `Long` truncation), same injectable-source pattern, changed in one PR. The JS side extracts the computation as the pure exported `backoffDelayMs` (so the distribution is directly testable) with a doc note "Mirrored by SseBackoff.nextDelayMs — change both together"; the Kotlin header keeps its mirror claim, now naming `backoffDelayMs` specifically, with the same change-both-together note. The claim is true again in both directions.

## Determinism in tests

The random source is injected, never global — the codebase's clock-injection pattern applied to randomness: `createVaultEventClient({ randomFn })` (default `Math.random`) and `SseBackoff(random = ...)` (default `Math.random()`). The Kotlin class doc now reads "deterministic with an injected random source", which is the honest version of its old "pure and deterministic" claim.

The pre-existing exact-ladder tests survive unchanged in substance by injecting `random = 1`: equal jitter's upper edge `exp/2 + 1.0·(exp/2) = exp` recovers the pre-jitter ladder exactly, so every original assertion (1000, 2000, 4000, …, capped 30000) and its comments stay true, including the flap-guard and stability-reset timing tests.

New seeded tests (LCG on the JS side, `java.util.Random(seed)` on Kotlin — deterministic on both):
- **Spread** — 500 samples at attempt 3 produce >100 distinct values, all in `[4000, 8000)`.
- **Cap at high attempts** — 500 samples deep past the cap: all `< 30000`, all `≥ 15000` (floor at cap).
- **Never zero** — attempt-0 samples all `≥ 500`.
- **Determinism** — same seed, same 6-delay sequence, both platforms.
- **Behavioural floor** (JS, through the client's real timer loop) — with `randomFn: () => 0`, no reconnect at 499ms, reconnect at 500ms.

## Negative control

With the jitter removed from each implementation (`return exp` — the old behavior):
- Kotlin: `jitter spreads same-attempt delays…` and `the cap still caps and the floor holds…` **FAILED**, BUILD FAILED; restored byte-identical → green.
- JS: 3 tests failed (spread, cap/floor, behavioural floor); restored → green.

A test that passes either way proves nothing; these don't.

## Verification

- JS: `vaultEventStream.test.js` 45/45; **full suite 121 files, 1790 tests, green.**
- Kotlin: `SseBackoffTest` 9/9 in the plain-JVM Gradle scratchpad (byte-identical copies of both files).
- Kotlin caveat, stated plainly: `SseBackoff.kt` is pure and fully covered by the JVM run, but the Android app around it (VaultSseClient wiring, unchanged — the new ctor param is defaulted, so no call site changed) can't be compiled here (no Android SDK). No device or real vault needed: the changed logic is exercised end-to-end by the JS client tests and the JVM Kotlin tests.

Out of scope and untouched: `@glance-apps/sync`'s own backoff (separate mechanism), the vault server's limiter, and everything else in the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKze5is3YCXoe4XrCjmsNw)_