### PR TITLE
Load the de, es, it and pt translations that were shipping unused

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -2,20 +2,42 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import en from '../public/locales/en/translation.json';
-import fr from '../public/locales/fr/translation.json';
+import { languages, loaders } from './locales.js';
 
-i18n
+// Resolves a language from the lazy chunks in locales.js. i18next only asks for
+// a language it is about to use, so this fetches one bundle, not six.
+const lazyBundles = {
+  type: 'backend',
+  init() {},
+  read(lng, ns, callback) {
+    const load = loaders[lng];
+    // Not a crash: i18next falls back to en, which is bundled below.
+    if (!load) return callback(new Error(`no translation bundle for ${lng}`), null);
+    load().then(
+      (translation) => callback(null, translation),
+      (err) => callback(err, null),
+    );
+  },
+};
+
+// en stays inlined even though the backend could fetch it. It is the fallback
+// every other language leans on for untranslated keys, so it has to be present
+// synchronously — including when a chunk fetch fails offline.
+export const ready = i18n
+  .use(lazyBundles)
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     fallbackLng: 'en',
-    supportedLngs: ['en', 'fr', 'de', 'es', 'it', 'pt'],
+    supportedLngs: languages,
     ns: ['translation'],
     defaultNS: 'translation',
     resources: {
       en: { translation: en },
-      fr: { translation: fr },
     },
+    // Without this, the inlined en above would tell i18next every language is
+    // already in memory and the backend would never be consulted.
+    partialBundledLanguages: true,
     interpolation: {
       escapeValue: false,
     },

--- a/src/locales.js
+++ b/src/locales.js
@@ -1,0 +1,35 @@
+// Translation bundles, derived from what is actually on disk.
+//
+// These were previously listed by hand in i18n.js, which drifted: de, es, it
+// and pt had translation files but no entry in `resources`, so every string in
+// those four languages silently fell back to English. Globbing the directory
+// removes the second place that had to be kept in sync — adding a language is
+// now just adding public/locales/<lng>/translation.json.
+//
+// Bundled rather than fetched from /locales at runtime: dayGLANCE's packaged
+// builds serve the renderer from somewhere other than a web root — app:// in
+// Electron, a relative base on iOS and Android — so a runtime request for
+// /locales/<lng>/translation.json is not reliably resolvable across targets.
+// Going through the bundler means the build resolves each path instead.
+//
+// Lazy, though, so only the language in use is downloaded. Eagerly inlining all
+// six pushed the main chunk from 3.08 MB to 3.25 MB, past the 3 MiB PWA
+// precache ceiling in vite.config.js — and made every user pay for five
+// languages they cannot read. Each language is its own chunk instead, small
+// enough to precache individually.
+const loaderModules = import.meta.glob('../public/locales/*/translation.json', {
+  import: 'default',
+});
+
+// "../public/locales/pt/translation.json" -> "pt"
+function tagOf(path) {
+  return path.split('/').at(-2);
+}
+
+export const loaders = Object.fromEntries(
+  Object.entries(loaderModules).map(([path, load]) => [tagOf(path), load]),
+);
+
+// Sorted so the value is stable across platforms — glob key order follows the
+// filesystem, which is not guaranteed to match between a dev machine and CI.
+export const languages = Object.keys(loaders).sort();

--- a/src/locales.test.js
+++ b/src/locales.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { languages, loaders } from './locales.js';
+
+// Guards the drift that shipped de/es/it/pt as files with no `resources` entry,
+// so every string in those languages silently rendered in English. A test that
+// only checked the files existed would have passed throughout that bug — the
+// assertions below go through the same loaders i18n.js resolves at runtime.
+describe('locale bundles', () => {
+  const EXPECTED = ['de', 'en', 'es', 'fr', 'it', 'pt'];
+  const TRANSLATED = EXPECTED.filter((l) => l !== 'en');
+
+  const bundles = {};
+  beforeAll(async () => {
+    await Promise.all(
+      EXPECTED.map(async (lng) => {
+        bundles[lng] = await loaders[lng]();
+      }),
+    );
+  });
+
+  const flatten = (obj, prefix = '') =>
+    Object.entries(obj).flatMap(([k, v]) => {
+      const key = prefix ? `${prefix}.${k}` : k;
+      return v && typeof v === 'object' && !Array.isArray(v) ? flatten(v, key) : [key];
+    });
+
+  const keysOf = (lng) => new Set(flatten(bundles[lng]));
+
+  it('exposes every shipped language', () => {
+    expect(languages).toEqual(EXPECTED);
+  });
+
+  it.each(EXPECTED)('%s resolves to a non-empty bundle', (lng) => {
+    expect(bundles[lng]).toBeTypeOf('object');
+    expect(Object.keys(bundles[lng]).length).toBeGreaterThan(0);
+  });
+
+  // A bundle can resolve and still be a stub, or be a copy of English that was
+  // never translated. This key is carried by all six languages.
+  it.each(TRANSLATED)('%s translates a shared key into its own text', (lng) => {
+    const en = bundles.en.sync.errors.NETWORK_ERROR;
+    const value = bundles[lng]?.sync?.errors?.NETWORK_ERROR;
+    expect(value, `${lng} is missing sync.errors.NETWORK_ERROR`).toBeTypeOf('string');
+    expect(value, `${lng} still carries the English string`).not.toBe(en);
+  });
+
+  // de/es/it/pt were frozen while they were unreachable, so they sit behind en
+  // by a fixed set of keys; those fall back to English per key rather than
+  // breaking. Pinning the number keeps the gap from widening unnoticed and
+  // fails loudly once the backlog is translated, as the prompt to lower it.
+  describe('coverage against en', () => {
+    const KNOWN_GAP = { de: 61, es: 61, fr: 0, it: 61, pt: 61 };
+
+    it.each(TRANSLATED)('%s is missing exactly its known number of keys', (lng) => {
+      const missing = [...keysOf('en')].filter((k) => !keysOf(lng).has(k));
+      expect(
+        missing.length,
+        `${lng} gap changed — translate the backlog and lower KNOWN_GAP, or investigate the new omissions:\n  ${missing.slice(0, 10).join('\n  ')}`,
+      ).toBe(KNOWN_GAP[lng]);
+    });
+
+    it.each(TRANSLATED)('%s carries no keys that en does not', (lng) => {
+      const extra = [...keysOf(lng)].filter((k) => !keysOf('en').has(k));
+      expect(extra, `${lng} has keys absent from en`).toEqual([]);
+    });
+  });
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
-import './i18n.js'
+import { ready as i18nReady } from './i18n.js'
 
 // crypto.randomUUID() requires a secure context (HTTPS or localhost).
 // When accessed over HTTP on a LAN IP the API is absent and every call throws,
@@ -77,10 +77,21 @@ class ErrorBoundary extends React.Component {
   }
 }
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <ErrorBoundary>
-      <App />
-    </ErrorBoundary>
-  </React.StrictMode>,
-)
+function mount() {
+  ReactDOM.createRoot(document.getElementById('root')).render(
+    <React.StrictMode>
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    </React.StrictMode>,
+  )
+}
+
+// The active language is its own chunk now, so wait for it before the first
+// paint — otherwise a non-English user watches the UI render in English and
+// then swap. A failed fetch still mounts: i18next falls back to bundled en,
+// and a missing translation is a better outcome than a blank screen.
+i18nReady.then(mount, (error) => {
+  console.error('Translations failed to load; continuing in English:', error)
+  mount()
+})


### PR DESCRIPTION
## The gap

`src/i18n.js` listed six languages in `supportedLngs` but registered `resources` for only `en` and `fr`, and nothing else in the app registered the rest — no `addResourceBundle`, no backend (`i18next-http-backend` is a dependency but was never `.use()`d), no dynamic import. `de`, `es`, `it` and `pt` shipped as files under `public/locales/` and were never reachable: every string in those four languages rendered in English.

## What

- **`src/locales.js`** (new) — derives the bundles from the locale directory via `import.meta.glob`, so `supportedLngs` and `resources` can no longer disagree. Adding a language is now adding its file.
- **`src/i18n.js`** — resolves languages through a small i18next backend over those lazy chunks. `en` stays inlined as the synchronous fallback for untranslated keys and for a failed chunk fetch; `partialBundledLanguages` keeps the backend reachable alongside it.
- **`src/main.jsx`** — waits for the active language before the first paint, so a non-English user doesn't watch the UI render in English and then swap. A failed load still mounts, in English, rather than showing a blank screen.

### Why lazy rather than six eager imports

Inlining all six grew the main chunk from 3.08 MB to 3.25 MB and **broke the build** against the 3 MiB `maximumFileSizeToCacheInBytes` precache ceiling in `vite.config.js` — there was only ~60 KB of headroom. It also made every user download five languages they can't read. One chunk per language takes the main chunk to **3.04 MB**, below where it started, since `fr` moves out of it too.

These are the app's first dynamic imports (the baseline build emitted exactly one chunk), so chunk loading is newly exercised on every target. All four build configs pass and emit six chunks; the Electron renderer serves them over its `app://dayglance` scheme (`electron/appProtocol.ts`) with the correct `text/javascript` content type, and iOS/Android use `base: './'`.

## Known gap this does not close

The four languages were frozen while they were unreachable and sit **61 keys behind `en`** (`fr` is complete). Those keys now fall back to English per key rather than the whole language doing so — a large improvement, but not full coverage. The backlog includes `sync.errors.CREDENTIAL_INVALID`, `sync.errors.QUOTA_EXCEEDED` and the `reset.*` group. `src/locales.test.js` pins the number per language so it can't widen unnoticed, and fails once the backlog is translated, as the prompt to lower it.

## Verification

1812 tests passing across 122 files (22 new), `npm run lint` clean, and all four Vite configs (web, electron, ios, android) building with exit 0 and no precache warning.

Not verified: a launched packaged Electron or mobile build actually fetching a locale chunk at runtime. The builds succeed and the Electron protocol handler maps the paths correctly, but that isn't the same as observing it load.

---
_Generated by [Claude Code](https://claude.ai/code/session_011jW12PHxwiY9cjScEqw5Da)_