### PR TITLE
Translate the de/es/it/pt backlog and add a language picker

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -353,7 +353,8 @@
     "removeFileImportedConfirm": "Alle {{n}} aus Datei importierten Termine entfernen? Ein erneuter Datei-Import stellt sie wieder her.",
     "liveActivity": "Live-Aktivität",
     "liveActivityDesc": "Der heutige Plan in der Dynamic Island und auf dem Sperrbildschirm. Verbreitert die Island und verdeckt die Signalsymbole neben der Uhr.",
-    "multiUserICloudOnly": "Erfordert ein gemeinsames Sync-Ziel. iCloud synchronisiert Ihre eigenen Geräte unter einer Apple-ID und kann zwei Personen daher keine gemeinsame Liste bereitstellen. Richten Sie dafür GLANCEvault oder WebDAV-Sync ein."
+    "multiUserICloudOnly": "Erfordert ein gemeinsames Sync-Ziel. iCloud synchronisiert Ihre eigenen Geräte unter einer Apple-ID und kann zwei Personen daher keine gemeinsame Liste bereitstellen. Richten Sie dafür GLANCEvault oder WebDAV-Sync ein.",
+    "language": "Sprache"
   },
   "task": {
     "newScheduled": "Neue geplante Aufgabe",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -16,7 +16,9 @@
       "passphraseNeeded": "Geben Sie oben Ihre Sync-Passphrase ein, um GLANCEvault zu aktivieren.",
       "vaultUnreachable": "GLANCEvault konnte nicht erreicht werden. Überprüfen Sie die Vault-URL und das Gerätetoken. ({{detail}})",
       "requestFailed": "Anfrage fehlgeschlagen",
-      "iCloudUnavailable": "iCloud nicht verfügbar: {{error}}"
+      "iCloudUnavailable": "iCloud nicht verfügbar: {{error}}",
+      "CREDENTIAL_INVALID": "Der Sync-Server akzeptiert den Sync-Zugriff dieses Geräts nicht mehr. Ihre Änderungen sind auf diesem Gerät gespeichert. Bitten Sie die Person, die Ihren Sync-Server betreibt, den Zugriff für dieses Gerät wiederherzustellen.",
+      "QUOTA_EXCEEDED": "Der Sync-Server hat das Limit für dieses Konto erreicht. Ihre Änderungen sind auf diesem Gerät gespeichert und die Synchronisierung versucht es automatisch erneut. Bitten Sie die Person, die Ihren Sync-Server betreibt, das Limit zu erhöhen."
     },
     "vaultUrl": {
       "invalid": "Geben Sie eine gültige Vault-URL ein.",
@@ -350,7 +352,8 @@
     "removeFileImported": "Aus Datei importierte Termine entfernen",
     "removeFileImportedConfirm": "Alle {{n}} aus Datei importierten Termine entfernen? Ein erneuter Datei-Import stellt sie wieder her.",
     "liveActivity": "Live-Aktivität",
-    "liveActivityDesc": "Der heutige Plan in der Dynamic Island und auf dem Sperrbildschirm. Verbreitert die Island und verdeckt die Signalsymbole neben der Uhr."
+    "liveActivityDesc": "Der heutige Plan in der Dynamic Island und auf dem Sperrbildschirm. Verbreitert die Island und verdeckt die Signalsymbole neben der Uhr.",
+    "multiUserICloudOnly": "Erfordert ein gemeinsames Sync-Ziel. iCloud synchronisiert Ihre eigenen Geräte unter einer Apple-ID und kann zwei Personen daher keine gemeinsame Liste bereitstellen. Richten Sie dafür GLANCEvault oder WebDAV-Sync ein."
   },
   "task": {
     "newScheduled": "Neue geplante Aufgabe",
@@ -942,5 +945,73 @@
     "remaining": "verbleibend",
     "startsIn": "beginnt in",
     "noMoreBlocks": "Keine weiteren Blöcke heute"
+  },
+  "reset": {
+    "title": "App-Daten zurücksetzen",
+    "subtitle": "Alles löschen und leer neu beginnen",
+    "warning": "Damit werden alle Aufgaben, Notizen, Gewohnheiten, Ziele, Projekte und Einstellungen auf diesem Gerät gelöscht, und das kann nicht rückgängig gemacht werden. Exportieren Sie zuerst eine Sicherung, wenn Sie eine Kopie behalten möchten.",
+    "exportFirst": "Zuerst eine Sicherung exportieren",
+    "scopeDevice": "Nur dieses Gerät",
+    "scopeDeviceHint": "Die Kopie in iCloud bleibt erhalten, und dieses Gerät kann sie direkt wieder lesen, auch wenn die Synchronisierung ausgeschaltet ist. Verwenden Sie dies nur, um einen fehlerhaften lokalen Zustand zu beheben, nicht für einen Neuanfang.",
+    "scopeEverywhere": "Dieses Gerät und iCloud",
+    "scopeEverywhereHint": "Löscht auch die Kopie in iCloud, sodass sie weder hier noch bei einer Neuinstallation wiederhergestellt wird.",
+    "confirm": "Alles löschen",
+    "working": "Wird gelöscht…",
+    "partialFailure": "Einige Daten konnten nicht gelöscht werden:",
+    "otherDevices": "Andere Geräte behalten ihre eigene Kopie und stellen sie wieder her. Setzen Sie sie nacheinander zurück: Beenden Sie dayGLANCE überall, öffnen Sie dann ein einzelnes Gerät, setzen Sie es zurück und beenden Sie es wieder, bevor Sie zum nächsten übergehen."
+  },
+  "icloudDiag": {
+    "title": "iCloud-Diagnose",
+    "hint": "Nur lesend. Zeigt an, was dieses Gerät derzeit im iCloud-Container sieht. Es wird nichts geschrieben, gelöscht oder synchronisiert.",
+    "run": "Prüfung starten",
+    "running": "Wird geprüft…",
+    "platform": "Plattform",
+    "container": "Container",
+    "containerError": "Container-Fehler",
+    "available": "VERFÜGBAR",
+    "unavailable": "nicht verfügbar",
+    "notProbeable": "auf dieser Plattform nicht prüfbar",
+    "snapshot": "Snapshot-Datei",
+    "snapshotError": "Snapshot-Fehler",
+    "size": "Größe",
+    "lastModified": "Datei geändert",
+    "remoteCounts": "In Datei (Aufgaben / Posteingang)",
+    "localCounts": "Auf Gerät (Aufgaben / Posteingang)",
+    "never": "nie",
+    "copy": "Bericht kopieren",
+    "copied": "Kopiert",
+    "state": {
+      "present": "vorhanden",
+      "absent": "nicht gefunden",
+      "downloading": "wird aus iCloud geladen",
+      "error": "Fehler",
+      "unsupported": "kein iCloud auf dieser Plattform"
+    },
+    "webdav": "WebDAV-Sync",
+    "webdavSynced": "WebDAV zuletzt synchronisiert",
+    "vault": "GLANCEvault",
+    "vaultSynced": "GLANCEvault zuletzt synchronisiert",
+    "configured": "konfiguriert",
+    "notConfigured": "nicht konfiguriert",
+    "none": "(keine)",
+    "icloudSynced": "iCloud zuletzt synchronisiert",
+    "syncPref": "Synchronisierung auf diesem Gerät",
+    "on": "ein",
+    "off": "aus",
+    "notSyncingNote": "Dieses Gerät synchronisiert nicht mit iCloud, seine Daten bleiben also nur hier. Andere Geräte sehen hier vorgenommene Änderungen nicht, und anderswo vorgenommene Änderungen kommen nicht an."
+  },
+  "icloudFirstRun": {
+    "title": "Daten in iCloud gefunden",
+    "body": "In iCloud liegt eine Kopie Ihrer dayGLANCE-Daten: {{tasks}} Aufgaben und {{inbox}} Posteingangseinträge. Auf diesem Gerät sind noch keine vorhanden.",
+    "lastModified": "Zuletzt aktualisiert {{when}}",
+    "restore": "Aus iCloud wiederherstellen",
+    "restoreHint": "Diese Daten auf dieses Gerät holen und weiter synchronisieren.",
+    "startFresh": "Auf diesem Gerät neu beginnen",
+    "startFreshHint": "Leer beginnen und die iCloud-Synchronisierung hier ausschalten. Die iCloud-Kopie und Ihre anderen Geräte bleiben unberührt. Sie können sie in den Einstellungen wieder einschalten."
+  },
+  "icloudSync": {
+    "title": "iCloud-Synchronisierung",
+    "onHint": "Ein. Dieses Gerät synchronisiert automatisch mit Ihren anderen Apple-Geräten.",
+    "offHint": "Auf diesem Gerät aus. Die iCloud-Kopie und Ihre anderen Geräte sind nicht betroffen."
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -353,7 +353,8 @@
     "removeFileImportedConfirm": "Remove all {{n}} file-imported events? Re-importing the file brings them back.",
     "liveActivity": "Live Activity",
     "liveActivityDesc": "Today's plan in the Dynamic Island and on the Lock Screen. Widens the island, which hides the signal icons next to the clock.",
-    "multiUserICloudOnly": "Requires a shared sync destination. iCloud syncs your own devices under one Apple ID, so it cannot give two people a shared list. Set up GLANCEvault or WebDAV sync for that."
+    "multiUserICloudOnly": "Requires a shared sync destination. iCloud syncs your own devices under one Apple ID, so it cannot give two people a shared list. Set up GLANCEvault or WebDAV sync for that.",
+    "language": "Language"
   },
   "task": {
     "newScheduled": "New Scheduled Task",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -353,7 +353,8 @@
     "removeFileImportedConfirm": "¿Eliminar los {{n}} eventos importados de archivo? Volver a importar el archivo los restaura.",
     "liveActivity": "Actividad en Vivo",
     "liveActivityDesc": "El plan de hoy en la Dynamic Island y en la pantalla de bloqueo. Ensancha la isla y oculta los iconos de señal junto al reloj.",
-    "multiUserICloudOnly": "Requiere un destino de sincronización compartido. iCloud sincroniza tus propios dispositivos con un mismo Apple ID, así que no puede darle una lista compartida a dos personas. Configura GLANCEvault o sincronización WebDAV para eso."
+    "multiUserICloudOnly": "Requiere un destino de sincronización compartido. iCloud sincroniza tus propios dispositivos con un mismo Apple ID, así que no puede darle una lista compartida a dos personas. Configura GLANCEvault o sincronización WebDAV para eso.",
+    "language": "Idioma"
   },
   "task": {
     "newScheduled": "Nueva tarea programada",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -16,7 +16,9 @@
       "passphraseNeeded": "Introduce arriba tu frase de contraseña de sincronización para activar GLANCEvault.",
       "vaultUnreachable": "No se pudo conectar con GLANCEvault. Comprueba la URL del vault y el token del dispositivo. ({{detail}})",
       "requestFailed": "la solicitud falló",
-      "iCloudUnavailable": "iCloud no disponible: {{error}}"
+      "iCloudUnavailable": "iCloud no disponible: {{error}}",
+      "CREDENTIAL_INVALID": "El servidor de sincronización ya no acepta el acceso de este dispositivo. Tus cambios están guardados en este dispositivo. Pide a quien administra tu servidor de sincronización que restaure el acceso para este dispositivo.",
+      "QUOTA_EXCEEDED": "El servidor de sincronización ha alcanzado el límite de esta cuenta. Tus cambios están guardados en este dispositivo y la sincronización se reintentará automáticamente. Pide a quien administra tu servidor de sincronización que aumente el límite."
     },
     "vaultUrl": {
       "invalid": "Introduce una URL de vault válida.",
@@ -350,7 +352,8 @@
     "removeFileImported": "Eliminar eventos importados de archivo",
     "removeFileImportedConfirm": "¿Eliminar los {{n}} eventos importados de archivo? Volver a importar el archivo los restaura.",
     "liveActivity": "Actividad en Vivo",
-    "liveActivityDesc": "El plan de hoy en la Dynamic Island y en la pantalla de bloqueo. Ensancha la isla y oculta los iconos de señal junto al reloj."
+    "liveActivityDesc": "El plan de hoy en la Dynamic Island y en la pantalla de bloqueo. Ensancha la isla y oculta los iconos de señal junto al reloj.",
+    "multiUserICloudOnly": "Requiere un destino de sincronización compartido. iCloud sincroniza tus propios dispositivos con un mismo Apple ID, así que no puede darle una lista compartida a dos personas. Configura GLANCEvault o sincronización WebDAV para eso."
   },
   "task": {
     "newScheduled": "Nueva tarea programada",
@@ -942,5 +945,73 @@
     "remaining": "restante",
     "startsIn": "empieza en",
     "noMoreBlocks": "No quedan bloques hoy"
+  },
+  "reset": {
+    "title": "Restablecer datos de la app",
+    "subtitle": "Borrar todo y empezar desde cero",
+    "warning": "Esto borra todas las tareas, notas, hábitos, objetivos, proyectos y ajustes de este dispositivo, y no se puede deshacer. Exporta una copia de seguridad primero si quieres conservar una copia.",
+    "exportFirst": "Exportar una copia de seguridad primero",
+    "scopeDevice": "Solo este dispositivo",
+    "scopeDeviceHint": "La copia en iCloud se conserva, y este dispositivo puede volver a leerla directamente aunque la sincronización esté desactivada. Usa esto solo para corregir un estado local defectuoso, no para empezar de nuevo.",
+    "scopeEverywhere": "Este dispositivo e iCloud",
+    "scopeEverywhereHint": "También elimina la copia en iCloud, de modo que nada la restaure aquí ni al reinstalar.",
+    "confirm": "Borrar todo",
+    "working": "Borrando…",
+    "partialFailure": "Algunos datos no se pudieron borrar:",
+    "otherDevices": "Los demás dispositivos conservan su propia copia y la restaurarán. Restablécelos de uno en uno: cierra dayGLANCE en todas partes, luego abre un solo dispositivo, restablécelo y ciérralo de nuevo antes de pasar al siguiente."
+  },
+  "icloudDiag": {
+    "title": "Diagnóstico de iCloud",
+    "hint": "Solo lectura. Informa de lo que este dispositivo ve actualmente en el contenedor de iCloud. No se escribe, elimina ni sincroniza nada.",
+    "run": "Ejecutar comprobación",
+    "running": "Comprobando…",
+    "platform": "Plataforma",
+    "container": "Contenedor",
+    "containerError": "Error de contenedor",
+    "available": "DISPONIBLE",
+    "unavailable": "no disponible",
+    "notProbeable": "no se puede comprobar en esta plataforma",
+    "snapshot": "Archivo de instantánea",
+    "snapshotError": "Error de instantánea",
+    "size": "Tamaño",
+    "lastModified": "Archivo modificado",
+    "remoteCounts": "En el archivo (tareas / bandeja)",
+    "localCounts": "En el dispositivo (tareas / bandeja)",
+    "never": "nunca",
+    "copy": "Copiar informe",
+    "copied": "Copiado",
+    "state": {
+      "present": "presente",
+      "absent": "no encontrado",
+      "downloading": "descargando de iCloud",
+      "error": "error",
+      "unsupported": "sin iCloud en esta plataforma"
+    },
+    "webdav": "Sincronización WebDAV",
+    "webdavSynced": "WebDAV sincronizado por última vez",
+    "vault": "GLANCEvault",
+    "vaultSynced": "GLANCEvault sincronizado por última vez",
+    "configured": "configurado",
+    "notConfigured": "no configurado",
+    "none": "(ninguno)",
+    "icloudSynced": "iCloud sincronizado por última vez",
+    "syncPref": "Sincronización en este dispositivo",
+    "on": "activada",
+    "off": "desactivada",
+    "notSyncingNote": "Este dispositivo no se sincroniza con iCloud, así que sus datos se quedan solo aquí. Los demás dispositivos no verán los cambios hechos aquí, y los cambios hechos en otro sitio no llegarán."
+  },
+  "icloudFirstRun": {
+    "title": "Datos encontrados en iCloud",
+    "body": "iCloud tiene una copia de tus datos de dayGLANCE: {{tasks}} tareas y {{inbox}} elementos de la bandeja. Este dispositivo aún no tiene ninguno.",
+    "lastModified": "Última actualización {{when}}",
+    "restore": "Restaurar desde iCloud",
+    "restoreHint": "Traer estos datos a este dispositivo y seguir sincronizando.",
+    "startFresh": "Empezar de cero en este dispositivo",
+    "startFreshHint": "Empieza vacío y desactiva aquí la sincronización con iCloud. La copia en iCloud y tus otros dispositivos no se tocan. Puedes volver a activarla en Ajustes."
+  },
+  "icloudSync": {
+    "title": "Sincronización con iCloud",
+    "onHint": "Activada. Este dispositivo se sincroniza automáticamente con tus otros dispositivos Apple.",
+    "offHint": "Desactivada en este dispositivo. La copia en iCloud y tus otros dispositivos no se ven afectados."
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -353,7 +353,8 @@
     "removeFileImportedConfirm": "Supprimer les {{n}} événements importés depuis un fichier ? Réimporter le fichier les restaurera.",
     "liveActivity": "Activité en direct",
     "liveActivityDesc": "Le plan du jour dans la Dynamic Island et sur l'écran verrouillé. Élargit l'île et masque les icônes de signal près de l'horloge.",
-    "multiUserICloudOnly": "Nécessite une destination de synchronisation partagée. iCloud synchronise vos propres appareils sous un seul identifiant Apple et ne peut donc pas donner une liste partagée à deux personnes. Configurez GLANCEvault ou WebDAV pour cela."
+    "multiUserICloudOnly": "Nécessite une destination de synchronisation partagée. iCloud synchronise vos propres appareils sous un seul identifiant Apple et ne peut donc pas donner une liste partagée à deux personnes. Configurez GLANCEvault ou WebDAV pour cela.",
+    "language": "Langue"
   },
   "task": {
     "newScheduled": "Nouvelle tâche planifiée",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -353,7 +353,8 @@
     "removeFileImportedConfirm": "Rimuovere tutti i {{n}} eventi importati da file? Reimportando il file verranno ripristinati.",
     "liveActivity": "Attività in tempo reale",
     "liveActivityDesc": "Il piano di oggi nella Dynamic Island e nella schermata di blocco. Allarga l'isola e nasconde le icone del segnale accanto all'orologio.",
-    "multiUserICloudOnly": "Richiede una destinazione di sincronizzazione condivisa. iCloud sincronizza i tuoi dispositivi con un unico Apple ID, quindi non può fornire una lista condivisa a due persone. Configura GLANCEvault o la sincronizzazione WebDAV per farlo."
+    "multiUserICloudOnly": "Richiede una destinazione di sincronizzazione condivisa. iCloud sincronizza i tuoi dispositivi con un unico Apple ID, quindi non può fornire una lista condivisa a due persone. Configura GLANCEvault o la sincronizzazione WebDAV per farlo.",
+    "language": "Lingua"
   },
   "task": {
     "newScheduled": "Nuova attività pianificata",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -16,7 +16,9 @@
       "passphraseNeeded": "Inserisci sopra la tua passphrase di sincronizzazione per attivare GLANCEvault.",
       "vaultUnreachable": "Impossibile raggiungere GLANCEvault. Controlla l'URL del vault e il token del dispositivo. ({{detail}})",
       "requestFailed": "richiesta fallita",
-      "iCloudUnavailable": "iCloud non disponibile: {{error}}"
+      "iCloudUnavailable": "iCloud non disponibile: {{error}}",
+      "CREDENTIAL_INVALID": "Il server di sincronizzazione non accetta più l'accesso di questo dispositivo. Le tue modifiche sono salvate su questo dispositivo. Chiedi a chi gestisce il tuo server di sincronizzazione di ripristinare l'accesso per questo dispositivo.",
+      "QUOTA_EXCEEDED": "Il server di sincronizzazione ha raggiunto il limite di questo account. Le tue modifiche sono salvate su questo dispositivo e la sincronizzazione riproverà automaticamente. Chiedi a chi gestisce il tuo server di sincronizzazione di aumentare il limite."
     },
     "vaultUrl": {
       "invalid": "Inserisci un URL del vault valido.",
@@ -350,7 +352,8 @@
     "removeFileImported": "Rimuovi gli eventi importati da file",
     "removeFileImportedConfirm": "Rimuovere tutti i {{n}} eventi importati da file? Reimportando il file verranno ripristinati.",
     "liveActivity": "Attività in tempo reale",
-    "liveActivityDesc": "Il piano di oggi nella Dynamic Island e nella schermata di blocco. Allarga l'isola e nasconde le icone del segnale accanto all'orologio."
+    "liveActivityDesc": "Il piano di oggi nella Dynamic Island e nella schermata di blocco. Allarga l'isola e nasconde le icone del segnale accanto all'orologio.",
+    "multiUserICloudOnly": "Richiede una destinazione di sincronizzazione condivisa. iCloud sincronizza i tuoi dispositivi con un unico Apple ID, quindi non può fornire una lista condivisa a due persone. Configura GLANCEvault o la sincronizzazione WebDAV per farlo."
   },
   "task": {
     "newScheduled": "Nuova attività pianificata",
@@ -942,5 +945,73 @@
     "remaining": "rimanente",
     "startsIn": "inizia tra",
     "noMoreBlocks": "Nessun altro blocco oggi"
+  },
+  "reset": {
+    "title": "Reimposta i dati dell'app",
+    "subtitle": "Cancella tutto e riparti da zero",
+    "warning": "Questo cancella tutte le attività, le note, le abitudini, gli obiettivi, i progetti e le impostazioni su questo dispositivo, e non può essere annullato. Esporta prima un backup se vuoi conservarne una copia.",
+    "exportFirst": "Esporta prima un backup",
+    "scopeDevice": "Solo questo dispositivo",
+    "scopeDeviceHint": "La copia su iCloud viene mantenuta e questo dispositivo può rileggerla direttamente anche se la sincronizzazione è disattivata. Usa questa opzione solo per correggere uno stato locale danneggiato, non per ricominciare.",
+    "scopeEverywhere": "Questo dispositivo e iCloud",
+    "scopeEverywhereHint": "Elimina anche la copia su iCloud, così nulla la ripristina qui o dopo una reinstallazione.",
+    "confirm": "Cancella tutto",
+    "working": "Cancellazione…",
+    "partialFailure": "Non è stato possibile cancellare alcuni dati:",
+    "otherDevices": "Gli altri dispositivi conservano la propria copia e la ripristineranno. Reimpostali uno alla volta: chiudi dayGLANCE ovunque, poi apri un solo dispositivo, reimpostalo e chiudilo di nuovo prima di passare al successivo."
+  },
+  "icloudDiag": {
+    "title": "Diagnostica iCloud",
+    "hint": "Sola lettura. Riporta ciò che questo dispositivo vede attualmente nel container iCloud. Non viene scritto, eliminato né sincronizzato nulla.",
+    "run": "Esegui controllo",
+    "running": "Controllo in corso…",
+    "platform": "Piattaforma",
+    "container": "Container",
+    "containerError": "Errore del container",
+    "available": "DISPONIBILE",
+    "unavailable": "non disponibile",
+    "notProbeable": "non verificabile su questa piattaforma",
+    "snapshot": "File snapshot",
+    "snapshotError": "Errore snapshot",
+    "size": "Dimensione",
+    "lastModified": "File modificato",
+    "remoteCounts": "Nel file (attività / in arrivo)",
+    "localCounts": "Sul dispositivo (attività / in arrivo)",
+    "never": "mai",
+    "copy": "Copia report",
+    "copied": "Copiato",
+    "state": {
+      "present": "presente",
+      "absent": "non trovato",
+      "downloading": "download da iCloud in corso",
+      "error": "errore",
+      "unsupported": "nessun iCloud su questa piattaforma"
+    },
+    "webdav": "Sincronizzazione WebDAV",
+    "webdavSynced": "WebDAV sincronizzato l'ultima volta",
+    "vault": "GLANCEvault",
+    "vaultSynced": "GLANCEvault sincronizzato l'ultima volta",
+    "configured": "configurato",
+    "notConfigured": "non configurato",
+    "none": "(nessuno)",
+    "icloudSynced": "iCloud sincronizzato l'ultima volta",
+    "syncPref": "Sincronizzazione su questo dispositivo",
+    "on": "attiva",
+    "off": "disattivata",
+    "notSyncingNote": "Questo dispositivo non si sincronizza con iCloud, quindi i suoi dati restano solo qui. Gli altri dispositivi non vedranno le modifiche fatte qui e le modifiche fatte altrove non arriveranno."
+  },
+  "icloudFirstRun": {
+    "title": "Dati trovati su iCloud",
+    "body": "iCloud ha una copia dei tuoi dati dayGLANCE: {{tasks}} attività e {{inbox}} elementi in arrivo. Questo dispositivo non ne ha ancora.",
+    "lastModified": "Ultimo aggiornamento {{when}}",
+    "restore": "Ripristina da iCloud",
+    "restoreHint": "Porta questi dati su questo dispositivo e continua a sincronizzare.",
+    "startFresh": "Ricomincia da zero su questo dispositivo",
+    "startFreshHint": "Parti vuoto e disattiva qui la sincronizzazione con iCloud. La copia su iCloud e gli altri tuoi dispositivi restano invariati. Puoi riattivarla nelle Impostazioni."
+  },
+  "icloudSync": {
+    "title": "Sincronizzazione iCloud",
+    "onHint": "Attiva. Questo dispositivo si sincronizza automaticamente con gli altri tuoi dispositivi Apple.",
+    "offHint": "Disattivata su questo dispositivo. La copia su iCloud e gli altri tuoi dispositivi non sono interessati."
   }
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -16,7 +16,9 @@
       "passphraseNeeded": "Introduza acima a sua frase-passe de sincronização para ativar o GLANCEvault.",
       "vaultUnreachable": "Não foi possível contactar o GLANCEvault. Verifique o URL do vault e o token do dispositivo. ({{detail}})",
       "requestFailed": "pedido falhou",
-      "iCloudUnavailable": "iCloud indisponível: {{error}}"
+      "iCloudUnavailable": "iCloud indisponível: {{error}}",
+      "CREDENTIAL_INVALID": "O servidor de sincronização já não aceita o acesso deste dispositivo. As suas alterações estão guardadas neste dispositivo. Peça a quem gere o seu servidor de sincronização para restaurar o acesso deste dispositivo.",
+      "QUOTA_EXCEEDED": "O servidor de sincronização atingiu o limite desta conta. As suas alterações estão guardadas neste dispositivo e a sincronização será repetida automaticamente. Peça a quem gere o seu servidor de sincronização para aumentar o limite."
     },
     "vaultUrl": {
       "invalid": "Introduza um URL de vault válido.",
@@ -350,7 +352,8 @@
     "removeFileImported": "Remover eventos importados de ficheiro",
     "removeFileImportedConfirm": "Remover os {{n}} eventos importados de ficheiro? Reimportar o ficheiro irá restaurá-los.",
     "liveActivity": "Atividade ao Vivo",
-    "liveActivityDesc": "O plano de hoje na Dynamic Island e na tela de bloqueio. Alarga a ilha e oculta os ícones de sinal ao lado do relógio."
+    "liveActivityDesc": "O plano de hoje na Dynamic Island e na tela de bloqueio. Alarga a ilha e oculta os ícones de sinal ao lado do relógio.",
+    "multiUserICloudOnly": "Requer um destino de sincronização partilhado. O iCloud sincroniza os seus próprios dispositivos com um mesmo Apple ID, pelo que não pode dar uma lista partilhada a duas pessoas. Configure o GLANCEvault ou a sincronização WebDAV para isso."
   },
   "task": {
     "newScheduled": "Nova tarefa agendada",
@@ -942,5 +945,73 @@
     "remaining": "restante",
     "startsIn": "começa em",
     "noMoreBlocks": "Sem mais blocos hoje"
+  },
+  "reset": {
+    "title": "Repor dados da aplicação",
+    "subtitle": "Apagar tudo e começar do zero",
+    "warning": "Isto apaga todas as tarefas, notas, hábitos, objetivos, projetos e definições neste dispositivo, e não pode ser anulado. Exporte primeiro uma cópia de segurança se quiser guardar uma cópia.",
+    "exportFirst": "Exportar primeiro uma cópia de segurança",
+    "scopeDevice": "Apenas este dispositivo",
+    "scopeDeviceHint": "A cópia no iCloud é mantida, e este dispositivo pode voltar a lê-la diretamente mesmo com a sincronização desativada. Use isto apenas para corrigir um estado local incorreto, não para recomeçar.",
+    "scopeEverywhere": "Este dispositivo e o iCloud",
+    "scopeEverywhereHint": "Elimina também a cópia no iCloud, para que nada a restaure aqui nem numa reinstalação.",
+    "confirm": "Apagar tudo",
+    "working": "A apagar…",
+    "partialFailure": "Não foi possível limpar alguns dados:",
+    "otherDevices": "Os outros dispositivos mantêm a sua própria cópia e irão restaurá-la. Reponha-os um de cada vez: feche o dayGLANCE em todos, depois abra um único dispositivo, reponha-o e feche-o novamente antes de passar ao seguinte."
+  },
+  "icloudDiag": {
+    "title": "Diagnóstico do iCloud",
+    "hint": "Apenas de leitura. Indica o que este dispositivo vê atualmente no contentor do iCloud. Nada é escrito, eliminado ou sincronizado.",
+    "run": "Executar verificação",
+    "running": "A verificar…",
+    "platform": "Plataforma",
+    "container": "Contentor",
+    "containerError": "Erro do contentor",
+    "available": "DISPONÍVEL",
+    "unavailable": "indisponível",
+    "notProbeable": "não verificável nesta plataforma",
+    "snapshot": "Ficheiro de instantâneo",
+    "snapshotError": "Erro do instantâneo",
+    "size": "Tamanho",
+    "lastModified": "Ficheiro modificado",
+    "remoteCounts": "No ficheiro (tarefas / caixa de entrada)",
+    "localCounts": "No dispositivo (tarefas / caixa de entrada)",
+    "never": "nunca",
+    "copy": "Copiar relatório",
+    "copied": "Copiado",
+    "state": {
+      "present": "presente",
+      "absent": "não encontrado",
+      "downloading": "a transferir do iCloud",
+      "error": "erro",
+      "unsupported": "sem iCloud nesta plataforma"
+    },
+    "webdav": "Sincronização WebDAV",
+    "webdavSynced": "WebDAV sincronizado pela última vez",
+    "vault": "GLANCEvault",
+    "vaultSynced": "GLANCEvault sincronizado pela última vez",
+    "configured": "configurado",
+    "notConfigured": "não configurado",
+    "none": "(nenhum)",
+    "icloudSynced": "iCloud sincronizado pela última vez",
+    "syncPref": "Sincronização neste dispositivo",
+    "on": "ativada",
+    "off": "desativada",
+    "notSyncingNote": "Este dispositivo não está a sincronizar com o iCloud, pelo que os seus dados ficam apenas aqui. Os outros dispositivos não verão as alterações feitas aqui, e as alterações feitas noutro local não chegarão."
+  },
+  "icloudFirstRun": {
+    "title": "Dados encontrados no iCloud",
+    "body": "O iCloud tem uma cópia dos seus dados do dayGLANCE: {{tasks}} tarefas e {{inbox}} itens da caixa de entrada. Este dispositivo ainda não tem nenhum.",
+    "lastModified": "Última atualização {{when}}",
+    "restore": "Restaurar a partir do iCloud",
+    "restoreHint": "Trazer estes dados para este dispositivo e continuar a sincronizar.",
+    "startFresh": "Começar do zero neste dispositivo",
+    "startFreshHint": "Comece vazio e desative aqui a sincronização com o iCloud. A cópia no iCloud e os seus outros dispositivos não são afetados. Pode voltar a ativá-la nas Definições."
+  },
+  "icloudSync": {
+    "title": "Sincronização com o iCloud",
+    "onHint": "Ativada. Este dispositivo sincroniza automaticamente com os seus outros dispositivos Apple.",
+    "offHint": "Desativada neste dispositivo. A cópia no iCloud e os seus outros dispositivos não são afetados."
   }
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -353,7 +353,8 @@
     "removeFileImportedConfirm": "Remover os {{n}} eventos importados de ficheiro? Reimportar o ficheiro irá restaurá-los.",
     "liveActivity": "Atividade ao Vivo",
     "liveActivityDesc": "O plano de hoje na Dynamic Island e na tela de bloqueio. Alarga a ilha e oculta os ícones de sinal ao lado do relógio.",
-    "multiUserICloudOnly": "Requer um destino de sincronização partilhado. O iCloud sincroniza os seus próprios dispositivos com um mesmo Apple ID, pelo que não pode dar uma lista partilhada a duas pessoas. Configure o GLANCEvault ou a sincronização WebDAV para isso."
+    "multiUserICloudOnly": "Requer um destino de sincronização partilhado. O iCloud sincroniza os seus próprios dispositivos com um mesmo Apple ID, pelo que não pode dar uma lista partilhada a duas pessoas. Configure o GLANCEvault ou a sincronização WebDAV para isso.",
+    "language": "Idioma"
   },
   "task": {
     "newScheduled": "Nova tarefa agendada",

--- a/src/components/LanguagePicker.jsx
+++ b/src/components/LanguagePicker.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { languages } from '../locales.js';
+
+/**
+ * The language's own name for itself, derived from the tag rather than a table
+ * that would have to be kept in step with the locale directory.
+ *
+ * Intl returns these lowercase in several languages ("français", "português"),
+ * which is right mid-sentence but reads as a typo in a standalone list, so the
+ * first letter is uppercased in the language's own casing rules.
+ */
+export function nativeLanguageName(tag) {
+  try {
+    const name = new Intl.DisplayNames([tag], { type: 'language' }).of(tag);
+    // Intl echoes the input back when it has no name for the tag.
+    if (!name || name === tag) return tag;
+    return name.charAt(0).toLocaleUpperCase(tag) + name.slice(1);
+  } catch {
+    return tag;
+  }
+}
+
+/**
+ * Resolve what i18next reports to one of the options actually in the list, so
+ * the select never falls back to displaying its first entry while a different
+ * language is live. A detected tag can be regional ("en-US") or unsupported.
+ */
+export function selectedLanguage(reported, available = languages) {
+  if (available.includes(reported)) return reported;
+  const base = String(reported ?? '').split('-')[0];
+  if (available.includes(base)) return base;
+  return available.includes('en') ? 'en' : available[0];
+}
+
+export default function LanguagePicker({ className, id }) {
+  const { i18n } = useTranslation();
+  const value = selectedLanguage(i18n.resolvedLanguage || i18n.language);
+
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => i18n.changeLanguage(e.target.value)}
+      className={className}
+    >
+      {languages.map((lng) => (
+        <option key={lng} value={lng}>
+          {nativeLanguageName(lng)}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/LanguagePicker.test.js
+++ b/src/components/LanguagePicker.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { nativeLanguageName, selectedLanguage } from './LanguagePicker.jsx';
+import { languages } from '../locales.js';
+
+describe('nativeLanguageName', () => {
+  // The point of the picker: someone who cannot read the current UI language
+  // has to recognise their own. Each name is therefore in its own language,
+  // not the active one.
+  it.each([
+    ['de', 'Deutsch'],
+    ['en', 'English'],
+    ['es', 'Español'],
+    ['fr', 'Français'],
+    ['it', 'Italiano'],
+    ['pt', 'Português'],
+  ])('names %s in its own language', (tag, expected) => {
+    expect(nativeLanguageName(tag)).toBe(expected);
+  });
+
+  it('covers every shipped language', () => {
+    for (const lng of languages) {
+      const name = nativeLanguageName(lng);
+      expect(name, `${lng} has no display name`).toBeTypeOf('string');
+      expect(name, `${lng} fell back to the raw tag`).not.toBe(lng);
+    }
+  });
+
+  it('falls back to the tag rather than throwing on an unknown one', () => {
+    expect(nativeLanguageName('zz')).toBe('zz');
+    expect(nativeLanguageName(undefined)).toBe(undefined);
+  });
+});
+
+describe('selectedLanguage', () => {
+  // A select whose value matches no option silently displays its first entry,
+  // which would show "Deutsch" to an English user.
+  it('passes through a tag that is already an option', () => {
+    expect(selectedLanguage('pt')).toBe('pt');
+  });
+
+  it('reduces a regional tag to the base language', () => {
+    expect(selectedLanguage('en-US')).toBe('en');
+    expect(selectedLanguage('pt-BR')).toBe('pt');
+  });
+
+  it('falls back to en for a language that is not shipped', () => {
+    expect(selectedLanguage('ja')).toBe('en');
+  });
+
+  it('handles a missing value', () => {
+    expect(selectedLanguage(undefined)).toBe('en');
+    expect(selectedLanguage(null)).toBe('en');
+  });
+
+  it('falls back to the first option when en is not available', () => {
+    expect(selectedLanguage('ja', ['de', 'fr'])).toBe('de');
+  });
+
+  it('always returns something the picker can render', () => {
+    for (const reported of ['en', 'de-AT', 'zz', '', undefined]) {
+      expect(languages).toContain(selectedLanguage(reported));
+    }
+  });
+});

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -43,6 +43,7 @@ import { ensureVaultIntentsKey, setupVaultIntentsEncryption } from '../intents/v
 import { flushOutboxNow } from '../intents/useOutboxFlush.js';
 import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
 import { useTranslation } from 'react-i18next';
+import LanguagePicker from './LanguagePicker.jsx';
 import { notBucketed } from '../utils/bucketList.js';
 
 const MobileSettingsPanel = () => {
@@ -583,6 +584,19 @@ const MobileSettingsPanel = () => {
             </div>
           </div>
         )}
+      </div>
+
+      {/* Language */}
+      <hr className={borderClass} />
+      <div className="space-y-2">
+        <label htmlFor="mobile-settings-language" className={`font-medium ${textPrimary} flex items-center gap-2`}>
+          <Globe size={16} className={textSecondary} />
+          {t('settings.language')}
+        </label>
+        <LanguagePicker
+          id="mobile-settings-language"
+          className={`w-full px-3 py-2 text-sm rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} focus:outline-none focus:ring-2 focus:ring-blue-500`}
+        />
       </div>
 
       {/* Home timezone */}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -28,6 +28,7 @@ import { ensureVaultIntentsKey, setupVaultIntentsEncryption } from '../intents/v
 import { flushOutboxNow } from '../intents/useOutboxFlush.js';
 import { loadIntentsRootKey, clearIntentsRootKey } from '../intents/intentsKeyStore.js';
 import { useTranslation } from 'react-i18next';
+import LanguagePicker from './LanguagePicker.jsx';
 
 const SettingsModal = () => {
   const { t } = useTranslation();
@@ -484,6 +485,13 @@ const SettingsModal = () => {
                         <Clock size={16} className={textSecondary} />
                         {t('settings.localization')}
                       </h4>
+                      <div>
+                        <label htmlFor="settings-language" className={`block text-xs ${textSecondary} mb-1.5`}>{t('settings.language')}</label>
+                        <LanguagePicker
+                          id="settings-language"
+                          className={`w-full px-2 py-1.5 text-xs rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700 text-white' : 'bg-white text-stone-900'} focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                        />
+                      </div>
                       <div>
                         <label className={`block text-xs ${textSecondary} mb-1.5`}>{t('settings.clockFormat')}</label>
                         <div className="flex gap-2">

--- a/src/locales.test.js
+++ b/src/locales.test.js
@@ -44,24 +44,37 @@ describe('locale bundles', () => {
     expect(value, `${lng} still carries the English string`).not.toBe(en);
   });
 
-  // de/es/it/pt were frozen while they were unreachable, so they sit behind en
-  // by a fixed set of keys; those fall back to English per key rather than
-  // breaking. Pinning the number keeps the gap from widening unnoticed and
-  // fails loudly once the backlog is translated, as the prompt to lower it.
+  // de/es/it/pt were 61 keys behind en, having been frozen while they were
+  // unreachable. That backlog is translated, so this is now a strict parity
+  // check rather than a ratchet: a key added to en without translations fails
+  // here instead of silently rendering English.
   describe('coverage against en', () => {
-    const KNOWN_GAP = { de: 61, es: 61, fr: 0, it: 61, pt: 61 };
-
-    it.each(TRANSLATED)('%s is missing exactly its known number of keys', (lng) => {
+    it.each(TRANSLATED)('%s covers every key in en', (lng) => {
       const missing = [...keysOf('en')].filter((k) => !keysOf(lng).has(k));
       expect(
-        missing.length,
-        `${lng} gap changed — translate the backlog and lower KNOWN_GAP, or investigate the new omissions:\n  ${missing.slice(0, 10).join('\n  ')}`,
-      ).toBe(KNOWN_GAP[lng]);
+        missing,
+        `${lng} is missing keys that en has — translate them:\n  ${missing.slice(0, 10).join('\n  ')}`,
+      ).toEqual([]);
     });
 
     it.each(TRANSLATED)('%s carries no keys that en does not', (lng) => {
       const extra = [...keysOf(lng)].filter((k) => !keysOf('en').has(k));
       expect(extra, `${lng} has keys absent from en`).toEqual([]);
     });
+  });
+
+  // The backlog covered four namespaces at once. Spot-checking one string from
+  // each catches a namespace merged in as an untranslated copy of the English.
+  describe('backlog namespaces are actually translated', () => {
+    const SAMPLES = ['reset.title', 'icloudDiag.title', 'icloudFirstRun.title', 'icloudSync.title'];
+    const get = (lng, key) => key.split('.').reduce((o, k) => o?.[k], bundles[lng]);
+
+    it.each(TRANSLATED.flatMap((lng) => SAMPLES.map((key) => [lng, key])))(
+      '%s translates %s',
+      (lng, key) => {
+        expect(get(lng, key), `${lng} is missing ${key}`).toBeTypeOf('string');
+        expect(get(lng, key), `${lng} left ${key} in English`).not.toBe(get('en', key));
+      },
+    );
   });
 });


### PR DESCRIPTION
Follows #1395, which made `de`, `es`, `it` and `pt` load at all. Two commits: the translation backlog, then the picker.

## The 61-key backlog

Those four languages were frozen at 892 keys while they were unreachable, so `en` had moved 61 ahead: the two sync engine error messages, the multi-user iCloud note, and the `reset`, `icloudDiag`, `icloudFirstRun` and `icloudSync` namespaces in full. Until now they rendered in English even after #1395.

Each language follows the register already established in its own file rather than a suite-wide default:

| | Register |
|---|---|
| `de` | formal *Sie/Ihr* — 892 strings, 66 formal, **0** informal |
| `es` | informal *tú* |
| `it` | informal *tu* |
| `pt` | European, formal *o seu* — `ficheiro`, `definições`, `contentor`, `a apagar` |

`sync.errors.CREDENTIAL_INVALID` and `QUOTA_EXCEEDED` are shared wording across the suite, so `es`, `it` and `pt` are lifted verbatim from lastGLANCE, whose `pt` is also European. **German is the exception:** lastGLANCE and lifeGLANCE address the user as *du*, dayGLANCE as *Sie* throughout, so it is adapted rather than copied — consistency inside the app beats byte-identity across apps for a string read next to 891 others. Worth knowing if you ever diff the suite's sync strings and find German the odd one out.

All six locales now sit at 953 keys with matching `{{placeholders}}`. `locales.test.js` drops its ratchet for a strict parity check, so a key added to `en` without translations now fails instead of silently rendering English.

## The picker

Language was detection-only — whatever the browser reported, with no override. Adds a picker to the Localization section of the desktop settings modal and to the mobile settings panel, both backed by one `LanguagePicker` component so the two can't drift.

Each language is listed under its own name (Deutsch, Español, Português), since someone who can't read the current UI language still has to find theirs. Those names come from `Intl.DisplayNames` keyed on the tag rather than a hand-kept table, so a new locale directory appears named correctly with no further wiring — the same derive-from-disk approach `locales.js` already uses.

`selectedLanguage()` maps whatever i18next reports onto an option that actually exists: a `<select>` whose value matches no option silently renders its first entry, which would show "Deutsch" to an English user whose browser reported `en-US`. Regional tags reduce to their base, unknown ones fall back to `en`. i18next's existing localStorage cache persists the choice, so no new storage.

## Verification

1846 tests passing across 123 files (34 new), `npm run lint` clean, and all four Vite configs building with exit 0 and no precache warning. Main chunk 3.04 MB, unchanged by the backlog since those strings land in the per-language chunks.

Not verified: the picker exercised in a running app. The repo's tests mock React rather than render, so the new tests cover `nativeLanguageName` and `selectedLanguage` as pure functions and the wiring is by inspection — worth a click through both settings surfaces before the release, particularly that switching language repaints immediately now that bundles load as chunks.

---
_Generated by [Claude Code](https://claude.ai/code/session_011jW12PHxwiY9cjScEqw5Da)_