### PR TITLE
Translate the Getting Started checklist items

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -527,7 +527,20 @@
   },
   "gettingStarted": {
     "title": "Erste Schritte",
-    "imGoodToGo": "Ich bin bereit"
+    "imGoodToGo": "Ich bin bereit",
+    "items": {
+      "inbox": "Erste Aufgabe im Posteingang hinzufügen",
+      "scheduled": "Erste geplante Aufgabe hinzufügen",
+      "dragMobile": "Eine Aufgabe aus dem Posteingang planen",
+      "dragDesktop": "Eine Aufgabe in die Zeitplanansicht ziehen",
+      "priority": "Priorität oder Frist festlegen",
+      "notes": "Notizen oder Unteraufgaben zu einer Aufgabe hinzufügen",
+      "tags": "#Tags im Aufgabentitel verwenden",
+      "recurring": "Wiederkehrende Aufgabe erstellen",
+      "focus": "Fokusmodus ausprobieren",
+      "sync": "Kalendersynchronisierung einrichten",
+      "optional": "Routinen, Gewohnheiten oder KI aktivieren"
+    }
   },
   "habit": {
     "manageHabits": "Gewohnheiten verwalten",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -527,7 +527,20 @@
   },
   "gettingStarted": {
     "title": "Getting Started",
-    "imGoodToGo": "I'm Good to Go"
+    "imGoodToGo": "I'm Good to Go",
+    "items": {
+      "inbox": "Add your first inbox task",
+      "scheduled": "Add your first scheduled task",
+      "dragMobile": "Schedule a task from inbox",
+      "dragDesktop": "Drag a task to the timeline",
+      "priority": "Set a priority or deadline",
+      "notes": "Add notes or subtasks to a task",
+      "tags": "Use #tags in a task title",
+      "recurring": "Create a recurring task",
+      "focus": "Try Focus Mode",
+      "sync": "Set up calendar sync",
+      "optional": "Enable routines, habits, or AI"
+    }
   },
   "habit": {
     "manageHabits": "Manage Habits",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -527,7 +527,20 @@
   },
   "gettingStarted": {
     "title": "Primeros pasos",
-    "imGoodToGo": "¡Estoy listo!"
+    "imGoodToGo": "¡Estoy listo!",
+    "items": {
+      "inbox": "Añade tu primera tarea a la bandeja de entrada",
+      "scheduled": "Añade tu primera tarea programada",
+      "dragMobile": "Programa una tarea desde la bandeja de entrada",
+      "dragDesktop": "Arrastra una tarea a la agenda",
+      "priority": "Establece una prioridad o fecha límite",
+      "notes": "Añade notas o subtareas a una tarea",
+      "tags": "Usa #etiquetas en el título de una tarea",
+      "recurring": "Crea una tarea recurrente",
+      "focus": "Prueba el Modo Enfoque",
+      "sync": "Configura la sincronización de calendario",
+      "optional": "Activa rutinas, hábitos o IA"
+    }
   },
   "habit": {
     "manageHabits": "Gestionar hábitos",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -527,7 +527,20 @@
   },
   "gettingStarted": {
     "title": "Premiers pas",
-    "imGoodToGo": "C'est parti !"
+    "imGoodToGo": "C'est parti !",
+    "items": {
+      "inbox": "Ajoutez votre première tâche à la boîte de réception",
+      "scheduled": "Ajoutez votre première tâche planifiée",
+      "dragMobile": "Planifiez une tâche depuis la boîte de réception",
+      "dragDesktop": "Faites glisser une tâche vers l'agenda",
+      "priority": "Définissez une priorité ou une échéance",
+      "notes": "Ajoutez des notes ou des sous-tâches à une tâche",
+      "tags": "Utilisez des #tags dans le titre d'une tâche",
+      "recurring": "Créez une tâche récurrente",
+      "focus": "Essayez le Mode Focus",
+      "sync": "Configurez la synchronisation du calendrier",
+      "optional": "Activez les routines, habitudes ou l'IA"
+    }
   },
   "habit": {
     "manageHabits": "Gérer les habitudes",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -527,7 +527,20 @@
   },
   "gettingStarted": {
     "title": "Per iniziare",
-    "imGoodToGo": "Sono pronto!"
+    "imGoodToGo": "Sono pronto!",
+    "items": {
+      "inbox": "Aggiungi la tua prima attività in arrivo",
+      "scheduled": "Aggiungi la tua prima attività pianificata",
+      "dragMobile": "Pianifica un'attività da In arrivo",
+      "dragDesktop": "Trascina un'attività nell'agenda",
+      "priority": "Imposta una priorità o una scadenza",
+      "notes": "Aggiungi note o sottoattività a un'attività",
+      "tags": "Usa i #tag nel titolo di un'attività",
+      "recurring": "Crea un'attività ricorrente",
+      "focus": "Prova la Modalità Focus",
+      "sync": "Configura la sincronizzazione del calendario",
+      "optional": "Attiva routine, abitudini o IA"
+    }
   },
   "habit": {
     "manageHabits": "Gestisci abitudini",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -527,7 +527,20 @@
   },
   "gettingStarted": {
     "title": "Primeiros passos",
-    "imGoodToGo": "Estou pronto!"
+    "imGoodToGo": "Estou pronto!",
+    "items": {
+      "inbox": "Adicione a sua primeira tarefa na caixa de entrada",
+      "scheduled": "Adicione a sua primeira tarefa agendada",
+      "dragMobile": "Agende uma tarefa a partir da caixa de entrada",
+      "dragDesktop": "Arraste uma tarefa para a agenda",
+      "priority": "Defina uma prioridade ou prazo",
+      "notes": "Adicione notas ou subtarefas a uma tarefa",
+      "tags": "Utilize #etiquetas no título de uma tarefa",
+      "recurring": "Crie uma tarefa recorrente",
+      "focus": "Experimente o Modo Foco",
+      "sync": "Configure a sincronização de calendário",
+      "optional": "Ative rotinas, hábitos ou IA"
+    }
   },
   "habit": {
     "manageHabits": "Gerir hábitos",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5806,18 +5806,21 @@ const DayPlanner = () => {
   // Getting Started checklist - uses persistent progress tracking
   const gettingStartedItems = useMemo(() => {
     return [
-      { id: 'inbox', label: 'Add your first inbox task', completed: onboardingProgress.hasAddedInboxTask },
-      { id: 'scheduled', label: 'Add your first scheduled task', completed: onboardingProgress.hasAddedScheduledTask },
-      { id: 'drag', label: isMobile ? 'Schedule a task from inbox' : 'Drag a task to the timeline', completed: onboardingProgress.hasDraggedToTimeline },
-      { id: 'priority', label: 'Set a priority or deadline', completed: onboardingProgress.hasSetPriority || onboardingProgress.hasAddedDeadline },
-      { id: 'notes', label: 'Add notes or subtasks to a task', completed: onboardingProgress.hasAddedNotes },
-      { id: 'tags', label: 'Use #tags in a task title', completed: onboardingProgress.hasUsedTags },
-      { id: 'recurring', label: 'Create a recurring task', completed: onboardingProgress.hasCreatedRecurring },
-      { id: 'focus', label: 'Try Focus Mode', completed: onboardingProgress.hasUsedFocusMode },
-      { id: 'sync', label: 'Set up calendar sync', completed: onboardingProgress.hasSetupSync },
-      { id: 'optional', label: 'Enable routines, habits, or AI', completed: onboardingProgress.hasEnabledOptionalFeature },
+      { id: 'inbox', label: t('gettingStarted.items.inbox'), completed: onboardingProgress.hasAddedInboxTask },
+      { id: 'scheduled', label: t('gettingStarted.items.scheduled'), completed: onboardingProgress.hasAddedScheduledTask },
+      { id: 'drag', label: isMobile ? t('gettingStarted.items.dragMobile') : t('gettingStarted.items.dragDesktop'), completed: onboardingProgress.hasDraggedToTimeline },
+      { id: 'priority', label: t('gettingStarted.items.priority'), completed: onboardingProgress.hasSetPriority || onboardingProgress.hasAddedDeadline },
+      { id: 'notes', label: t('gettingStarted.items.notes'), completed: onboardingProgress.hasAddedNotes },
+      { id: 'tags', label: t('gettingStarted.items.tags'), completed: onboardingProgress.hasUsedTags },
+      { id: 'recurring', label: t('gettingStarted.items.recurring'), completed: onboardingProgress.hasCreatedRecurring },
+      { id: 'focus', label: t('gettingStarted.items.focus'), completed: onboardingProgress.hasUsedFocusMode },
+      { id: 'sync', label: t('gettingStarted.items.sync'), completed: onboardingProgress.hasSetupSync },
+      { id: 'optional', label: t('gettingStarted.items.optional'), completed: onboardingProgress.hasEnabledOptionalFeature },
     ];
-  }, [onboardingProgress, isMobile]);
+    // t belongs in the deps: without it the memo holds the labels from whichever
+    // language was active when it last ran, so switching language in Settings
+    // would leave this list stranded in the old one.
+  }, [onboardingProgress, isMobile, t]);
 
   const allGettingStartedComplete = gettingStartedItems.every(item => item.completed);
   const gettingStartedCompleteCount = gettingStartedItems.filter(item => item.completed).length;


### PR DESCRIPTION
Closes #1398. Stacked on #1396 — base retargets to `main` automatically when that merges.

## The gap

The ten checklist labels were string literals in `App.jsx`, so the panel around them translated and its contents did not. A Portuguese user saw "Primeiros passos" as the heading, "Estou pronto!" as the button, and ten English rows between them — worse than if none of it were localized. This is first-run onboarding: the first screen a new non-English user sees.

## What

Adds `gettingStarted.items` to all six locales — **11 strings**, since the drag step has separate mobile and desktop wordings — and reads the labels through `t()`.

Terms follow each locale's existing glossary rather than fresh coinages: `Posteingang` / `bandeja de entrada` / `boîte de réception` / `In arrivo` / `caixa de entrada` for the inbox, plus each file's established rendering of the timeline view, Focus Mode, deadline and AI. Register matches each file as before — German infinitive (already the house style for action labels, e.g. "KI-Funktionen aktivieren"), Spanish and Italian informal, French `vous`, Portuguese European.

## The one thing worth reviewing

`t` is now in the `useMemo` dependency list. Without it the memo would hold whichever language was active when it last ran, so switching language in Settings would leave this list stranded in the old one — a bug that only became reachable when #1396 added the picker.

## Verification

Verified in a browser rather than by inspection, since this repo's tests mock React and would not catch either failure mode:

- All six languages render their own checklist items on load, with no English leaking through.
- A live switch from English to French re-translates the list in place: `was-en=true now-fr=true stale-en=false`.

Plus 1846 tests across 123 files, `npm run lint` clean, and all four Vite configs building green. The strict parity check added in #1396 means the `en` keys could not have landed without all five other locales.

## Not verified

No native-speaker review, consistent with the rest of this app's localization.

---
_Generated by [Claude Code](https://claude.ai/code/session_011jW12PHxwiY9cjScEqw5Da)_