### PR TITLE
Ship the MCP bridge on Windows, and stop reporting success without it

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -62,8 +62,13 @@ Local integrations (Electron), whenever the MCP surface has changed:
 - Each of the three consent tiers cannot be enabled without passing its
   own copy, and the device-calendar tier is its own separate dialog.
 - A read and a write both succeed from a real client. Claude Code
-  connects directly; Claude Desktop needs the bridge, so exercise the
-  setup button in a direct-download build.
+  connects directly; Claude Desktop needs the bridge.
+- The setup button, run on macOS AND on Windows, on the real installed
+  artifact. Not one platform standing in for the other: extraResources is
+  declared per platform, so the two builds can and did disagree about
+  whether the bridge is present at all. Confirm Claude Desktop actually
+  starts the server afterward, because a written config proves only that
+  the file was written.
 - A write syncs to a second device and survives a tombstone cycle. This
   needs two real devices, not a local write test.
 - Per-task and bulk undo both reverse a write, and an undone create

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,6 +69,16 @@ Local integrations (Electron), whenever the MCP surface has changed:
   whether the bridge is present at all. Confirm Claude Desktop actually
   starts the server afterward, because a written config proves only that
   the file was written.
+
+  Plan for this one. The button writes an `mcpServers` entry into
+  `claude_desktop_config.json`, while the `.mcpb` bundle installs through
+  Claude Desktop's Extensions pane — two independent mechanisms, neither
+  aware of the other, so a day-to-day machine running the extension cannot
+  test the button without disturbing the setup you rely on. Use a second
+  machine, a VM, or a spare Claude Desktop profile rather than uninstalling
+  the extension. If both paths are ever active at once, expect Claude
+  Desktop to list the dayGLANCE tools twice; they reach the same listener,
+  so it is a confusing surface rather than a correctness problem.
 - A write syncs to a second device and survives a tombstone cycle. This
   needs two real devices, not a local write test.
 - Per-task and bulk undo both reverse a write, and an undone create

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -155,9 +155,31 @@ module.exports = {
     x64ArchFiles: '**/dayglance-*-helper',
   },
   win: {
+    // The MCP bridge must be declared HERE too, not only under mac. extraResources
+    // is a per-platform option: mac's array does not reach the Windows artifact, so
+    // omitting it here shipped an installer with no resources/mcp-bridge at all,
+    // while the "Set up Claude Desktop" button still wrote a config pointing into
+    // it (fixed alongside this; the setup handler now refuses to write when the
+    // bridge is absent rather than reporting success).
+    //
+    // Deliberately NOT hoisted to a top-level extraResources to cover both at once:
+    // the mac block's array would then merge with it, and the mac/mas deepAssign
+    // concatenation documented above makes that merge's result the exact thing this
+    // file already has to reason carefully about. Per-platform is verbose and
+    // obvious; hoisting is terse and subtle.
+    //
+    // isMasBuild is a whole-build env flag, not a per-target one, so it is not
+    // needed here (MAS is a mac-only target), but no Windows build ever sets it.
+    extraResources: [
+      { from: 'node_modules/@glance-apps/mcp-bridge', to: 'mcp-bridge' },
+    ],
     target: [{ target: 'nsis' }],
   },
   linux: {
+    // No bridge, by design (§7): there is no Claude Desktop on Linux, and an
+    // AppImage's mount path changes every launch, so an absolute path written into
+    // a config would go stale on the next run. Linux connects via npx instead, and
+    // the renderer's setup button does not render there.
     target: [{ target: 'AppImage' }],
   },
 };

--- a/electron/bridgePackaging.test.ts
+++ b/electron/bridgePackaging.test.ts
@@ -1,0 +1,65 @@
+// Guards the packaging of the MCP bridge, which is the one part of the "Set up
+// Claude Desktop" path that no other test touches.
+//
+// mcpDesktopConfig.test.ts covers the pure logic thoroughly, win32 included, and
+// it all passed while the Windows installer shipped no bridge at all: the entry
+// was declared under `mac` only, extraResources is per-platform, and the setup
+// button wrote a config pointing into a directory that was never packaged. Path
+// resolution being right is not the same as the file being there.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+/** Load the config the way electron-builder does, under a given build env. */
+function loadConfig(env: Record<string, string | undefined>): Record<string, never> {
+  const saved = { ...process.env };
+  Object.assign(process.env, env);
+  try {
+    delete require.cache[require.resolve('../electron-builder.config.cjs')];
+    return require('../electron-builder.config.cjs');
+  } finally {
+    for (const k of Object.keys(process.env)) delete process.env[k];
+    Object.assign(process.env, saved);
+  }
+}
+
+const BRIDGE = 'node_modules/@glance-apps/mcp-bridge';
+
+function resourcesOf(block: { extraResources?: { from: string; to: string }[] } | undefined) {
+  return block?.extraResources ?? [];
+}
+
+describe('MCP bridge packaging — every platform with a setup button ships one', () => {
+  // The renderer gates the button on ['darwin', 'win32']. Both must package the
+  // bridge, and each declares its own array: mac's does NOT reach win.
+  it.each(['mac', 'win'])('%s bundles the bridge into resources/mcp-bridge', (platform) => {
+    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
+    const entry = resourcesOf(config[platform]).find((r) => r.from === BRIDGE);
+    expect(entry, `${platform}.extraResources must declare the bridge`).toBeDefined();
+    expect(entry?.to).toBe('mcp-bridge');
+  });
+
+  it('linux ships no bridge: no Claude Desktop, and an AppImage mount path goes stale', () => {
+    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
+    expect(resourcesOf(config['linux']).some((r) => r.from === BRIDGE)).toBe(false);
+  });
+
+  it('the MAS build drops the bridge from mac, keeping the calendar helper (§7)', () => {
+    const config = loadConfig({ DAYGLANCE_APP_ID: 'com.dayglance' });
+    const mac = resourcesOf(config['mac']);
+    expect(mac.some((r) => r.from === BRIDGE)).toBe(false);
+    expect(mac.some((r) => r.to.startsWith('calendar-helper'))).toBe(true);
+  });
+
+  it('mas declares no extraResources of its own: deepAssign would concatenate, not replace', () => {
+    const config = loadConfig({ DAYGLANCE_APP_ID: 'com.dayglance' });
+    expect(config['mas']?.['extraResources']).toBeUndefined();
+  });
+
+  it('no bridge entry is hoisted to the top level, where the mac merge gets subtle', () => {
+    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
+    expect(resourcesOf(config as never).some((r) => r.from === BRIDGE)).toBe(false);
+  });
+});

--- a/electron/mcpDesktopConfig.ts
+++ b/electron/mcpDesktopConfig.ts
@@ -42,6 +42,17 @@ export interface BridgeEntry {
 }
 
 /**
+ * Where the bundled bridge lands: resources/mcp-bridge/bridge.js, put there by
+ * the extraResources entry that EVERY direct-download platform must declare
+ * (electron-builder.config.cjs). Exported so the setup handler can check the
+ * file is really there before writing a config that points at it — Windows
+ * shipped without it once, and the button reported success anyway.
+ */
+export function bridgeScriptPath(resourcesPath: string): string {
+  return join(resourcesPath, 'mcp-bridge', 'bridge.js');
+}
+
+/**
  * The config entry: dayGLANCE's own Electron binary run as Node, executing
  * the bundled bridge. No Node install, no network, no npx; the binary is
  * already on disk and already signed. resourcesPath is process.resourcesPath
@@ -50,7 +61,7 @@ export interface BridgeEntry {
 export function bridgeEntry(execPath: string, resourcesPath: string): BridgeEntry {
   return {
     command: execPath,
-    args: [join(resourcesPath, 'mcp-bridge', 'bridge.js')],
+    args: [bridgeScriptPath(resourcesPath)],
     env: { ELECTRON_RUN_AS_NODE: '1' },
   };
 }

--- a/electron/mcpDesktopSetup.ts
+++ b/electron/mcpDesktopSetup.ts
@@ -12,10 +12,10 @@
 // string's absence) against the BUILT artifact.
 
 import { ipcMain } from 'electron';
-import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { claudeConfigPath, bridgeEntry, mergeClaudeConfig, manualEntrySnippet } from './mcpDesktopConfig.js';
+import { claudeConfigPath, bridgeEntry, bridgeScriptPath, mergeClaudeConfig, manualEntrySnippet } from './mcpDesktopConfig.js';
 
 export function registerMcpDesktopSetup(): void {
   ipcMain.handle('mcp-setup:claude-desktop', () => {
@@ -23,6 +23,17 @@ export function registerMcpDesktopSetup(): void {
     const entry = bridgeEntry(process.execPath, process.resourcesPath);
     if (!path) {
       return { ok: false, reason: 'unsupported_platform', manualEntry: manualEntrySnippet(entry) };
+    }
+
+    // The bridge is put here by a per-platform extraResources entry, and a
+    // platform that forgets to declare one still reaches this handler with a
+    // perfectly well-formed entry pointing at nothing. Writing it would leave
+    // the user a config that looks right, a success message, and a client that
+    // silently fails to connect — which is exactly what the Windows build did
+    // before this check existed. Report it instead.
+    const bridgePath = bridgeScriptPath(process.resourcesPath);
+    if (!existsSync(bridgePath)) {
+      return { ok: false, reason: 'bridge_missing', path, bridgePath };
     }
 
     let existingText: string | null = null;

--- a/src/components/LocalIntegrationsSettings.jsx
+++ b/src/components/LocalIntegrationsSettings.jsx
@@ -388,7 +388,11 @@ const LocalIntegrationsSettings = ({ variant }) => {
                       <p className="text-amber-500">
                         {setupResult.reason === 'unparseable'
                           ? 'Your Claude Desktop configuration file could not be parsed, so dayGLANCE did not touch it. To finish setup by hand, fix or empty the file, or paste this entry into it:'
-                          : 'The configuration could not be written automatically. To finish setup by hand, paste this entry into your Claude Desktop configuration file:'}
+                          : setupResult.reason === 'bridge_missing'
+                            /* No manual entry offered here on purpose: it would name the
+                               same missing file. Send them to the published bridge instead. */
+                            ? 'This build did not ship the bridge, so nothing was written. Install the bridge yourself with "npx -y @glance-apps/mcp-bridge", then follow the setup guide to point Claude Desktop at it. Please report this build as broken.'
+                            : 'The configuration could not be written automatically. To finish setup by hand, paste this entry into your Claude Desktop configuration file:'}
                       </p>
                       {setupResult.path && <p className="font-mono break-all">{setupResult.path}</p>}
                       {setupResult.manualEntry && (


### PR DESCRIPTION
Blocks v4.4.0. The "Set up Claude Desktop" button does nothing on Windows.

## What happens

The bridge is copied into `resources/mcp-bridge` by an `extraResources` entry declared **under `mac` only** (`electron-builder.config.cjs:104`). `extraResources` is a per-platform option, so the Windows NSIS installer ships no bridge at all. Nothing else packages it: `files` covers only `dist/**` and `dist-electron/**`, and there is no `asarUnpack` or `extraFiles`.

Every other link in the chain works correctly, which is what makes it silent:

| Step | Windows behavior |
|---|---|
| Button renders | Yes. Gate is `['darwin','win32']`, preload exposes `process.platform` |
| Config path resolves | Yes. `%APPDATA%\Claude\claude_desktop_config.json` |
| Entry is built | Yes, well-formed, `args[0]` = `…\resources\mcp-bridge\bridge.js` |
| File is written | Yes, with a backup, other servers preserved |
| Handler returns | `{ok: true}` |
| UI says | "Claude Desktop configuration created. Restart Claude Desktop to connect." |
| Claude Desktop | Cannot spawn a file that was never packaged |

So the user gets a success message, a config that looks correct on inspection, and a client that never connects.

The entry was written into the `mac` block because that is where the mac/mas `deepAssign` concatenation had to be reasoned about. Windows was simply never given its own copy.

## The fix

**Declare it under `win` too**, rather than hoisting one entry to the top level. A top-level array would then merge with mac's, and how *that* merge resolves is the exact subtlety this file already spends four comments defending against. Per-platform is verbose and obvious; hoisting is terse and subtle. Linux stays deliberately without one, since there is no Claude Desktop there and an AppImage's mount path changes every launch, so a written absolute path would go stale.

**Packaging is no longer trusted.** The setup handler now checks the bridge file exists before writing anything, returning a typed `bridge_missing` otherwise. Any future platform that forgets the declaration produces a visible error instead of a confident lie. That branch deliberately offers **no manual entry** — it would name the same missing file — and instead points at the published npm package and asks the user to report the build.

`bridgeScriptPath` is extracted so the entry builder and the existence check derive the path from one place.

## Test coverage for the layer that had none

`mcpDesktopConfig.test.ts` already covers `win32` path resolution and merge semantics thoroughly, and **every one of those tests passed the whole time**. The paths were always right. The file was not there. Correct path resolution and correct packaging are different claims, and only one of them was being tested.

`electron/bridgePackaging.test.ts` asserts presence for both platforms that render a button, absence for linux, absence under MAS, that `mas` declares no `extraResources` of its own, and that nothing is hoisted to the top level.

**Verified to fail against the pre-fix config** — one assertion, the Windows one, with mac/mas/linux staying green, so the guard is targeted rather than blanket.

## Runbook

The §1.3 smoke item I added last week said "exercise the setup button in a direct-download build", which one platform could satisfy. It now requires macOS **and** Windows against real installed artifacts, and confirming the client actually starts the server, since a written config only proves that a file was written.

## Verification

Lint clean, `tsconfig.electron.json` clean, 1852 tests across 124 files green.

Not verified here: an actual Windows installer. The packaging change is asserted at config level, so **the Windows artifact still needs a hardware check before tagging** — install, click the button, confirm Claude Desktop connects.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L314TaA4GF71TM2Hgg6KTW)_