### PR TITLE
Surface setup-button failures instead of swallowing them

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1457,9 +1457,18 @@ app.whenReady().then(async () => {
   // packaging (electron-builder mas.files filter), so it loads dynamically
   // and its absence is a clean no-op, never a crash. The renderer's setup
   // button is likewise eliminated from the MAS bundle at build time.
+  // The catch distinguishes the two ways this can fail. On MAS the module is
+  // genuinely absent and that is the design, so it stays quiet. ANY OTHER
+  // failure means the ipcMain handler was never registered, and the renderer's
+  // invoke will reject rather than return — so log it instead of swallowing it.
+  // A bare catch here made a real failure indistinguishable from the intended
+  // MAS no-op, on the one code path whose entire job is to be diagnosable.
   import('./mcpDesktopSetup.js')
     .then((m) => m.registerMcpDesktopSetup())
-    .catch(() => { /* absent in the MAS package, by design */ });
+    .catch((err: NodeJS.ErrnoException) => {
+      if (err?.code === 'ERR_MODULE_NOT_FOUND' || err?.code === 'MODULE_NOT_FOUND') return;
+      logStartup(`mcpDesktopSetup failed to load; the setup button will not work: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
+    });
   if (integrationsConfig.streamDeck.enabled) startStreamDeckListener();
   startMcpListener();
   registerSubscriptionHandlers(win);

--- a/src/components/LocalIntegrationsSettings.jsx
+++ b/src/components/LocalIntegrationsSettings.jsx
@@ -364,6 +364,17 @@ const LocalIntegrationsSettings = ({ variant }) => {
                       setSetupResult(null);
                       try {
                         setSetupResult(await window.electronAPI.mcpSetupClaudeDesktop());
+                      } catch (err) {
+                        // A REJECTED invoke, not a returned failure. The handler
+                        // returns {ok:false,...} for everything it can anticipate;
+                        // reaching here means the call never got that far — most
+                        // likely the channel does not exist, because main.ts loads
+                        // the setup module dynamically and swallows any load error.
+                        // Without this branch the rejection is unhandled, no result
+                        // is ever set, and the button silently does nothing, which
+                        // is indistinguishable from the packaging bug it is meant
+                        // to report.
+                        setSetupResult({ ok: false, reason: 'unavailable', error: String(err?.message || err) });
                       } finally {
                         setSetupBusy(false);
                       }
@@ -392,7 +403,9 @@ const LocalIntegrationsSettings = ({ variant }) => {
                             /* No manual entry offered here on purpose: it would name the
                                same missing file. Send them to the published bridge instead. */
                             ? 'This build did not ship the bridge, so nothing was written. Install the bridge yourself with "npx -y @glance-apps/mcp-bridge", then follow the setup guide to point Claude Desktop at it. Please report this build as broken.'
-                            : 'The configuration could not be written automatically. To finish setup by hand, paste this entry into your Claude Desktop configuration file:'}
+                            : setupResult.reason === 'unavailable'
+                              ? 'dayGLANCE could not run setup at all, so nothing was written. This is a fault in the app rather than in your configuration. Restart dayGLANCE, and if it persists, set the bridge up by hand with "npx -y @glance-apps/mcp-bridge" and please report the build.'
+                              : 'The configuration could not be written automatically. To finish setup by hand, paste this entry into your Claude Desktop configuration file:'}
                       </p>
                       {setupResult.path && <p className="font-mono break-all">{setupResult.path}</p>}
                       {setupResult.manualEntry && (


### PR DESCRIPTION
Follow-up to #1401. Two swallow points made a failed "Set up Claude Desktop" indistinguishable from a button that does nothing.

Neither change affects a **working** button. Both change what a broken one tells you.

## 1. The renderer never caught a rejected invoke

`LocalIntegrationsSettings.jsx` used `try`/`finally` with no `catch`. The handler returns `{ok: false, reason}` for everything it can anticipate, so a *rejected* invoke means the call never reached the handler at all. That rejection went unhandled, `setSetupResult` never ran, and the UI rendered neither success nor error — a completely silent button.

Now caught and reported as `reason: 'unavailable'`, with copy that says the fault is in the app rather than the user's configuration, and points at the npm bridge as the manual path.

## 2. main.ts swallowed every module-load failure

```js
import('./mcpDesktopSetup.js')
  .then((m) => m.registerMcpDesktopSetup())
  .catch(() => { /* absent in the MAS package, by design */ });
```

Correct for MAS, where the module is deliberately excluded. But it also hid *any other* load failure — and a module that fails to load never registers its `ipcMain` handler, which is precisely what makes the renderer's invoke reject. The one code path whose entire job is to be diagnosable was the one that couldn't report.

Now silent only for `ERR_MODULE_NOT_FOUND` / `MODULE_NOT_FOUND`; anything else goes to the startup log naming the consequence ("the setup button will not work").

## Why this matters for 4.4.0

The `bridge_missing` guard added in #1401 **resolves** with an error object. It could never have surfaced through a rejected invoke. So #1401's hardening had a hole in it: it made one class of failure visible while a strictly earlier failure stayed silent, and the two produce identical symptoms from the user's side.

This came out of release testing, where a build predating #1401 produced "nothing happens" and there was no way to tell from the UI whether that was the packaging bug, an unregistered handler, or something else.

## Verification

Lint clean, `tsconfig.electron.json` clean, 1852 tests across 124 files green.

Not verified here: the rejection path on a real build, which needs a build where the handler is genuinely unregistered. The change is small and additive — a `catch` arm and a log line — and cannot alter the success path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L314TaA4GF71TM2Hgg6KTW)_