### PR TITLE
Resolve Claude Desktop's config inside its MSIX container on Windows

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1464,7 +1464,14 @@ app.whenReady().then(async () => {
   // A bare catch here made a real failure indistinguishable from the intended
   // MAS no-op, on the one code path whose entire job is to be diagnosable.
   import('./mcpDesktopSetup.js')
-    .then((m) => m.registerMcpDesktopSetup())
+    .then((m) => m.registerMcpDesktopSetup(() => {
+      // Read at click time, not at registration: the port override and the
+      // token both change while the app runs, and a rotated token written into
+      // Claude Desktop's config would otherwise be stale on arrival.
+      const resolved = resolveMcpPort(integrationsConfig.mcp.portOverride);
+      const token = integrationsConfig.mcp.token;
+      return resolved.ok && token ? { port: resolved.port, token } : null;
+    }))
     .catch((err: NodeJS.ErrnoException) => {
       if (err?.code === 'ERR_MODULE_NOT_FOUND' || err?.code === 'MODULE_NOT_FOUND') return;
       logStartup(`mcpDesktopSetup failed to load; the setup button will not work: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);

--- a/electron/mcpDesktopConfig.ts
+++ b/electron/mcpDesktopConfig.ts
@@ -12,24 +12,86 @@
 // other mcpServers entries, all preserved. An unparseable file is NEVER
 // overwritten; the caller reports it and offers manual instructions.
 
-import { join } from 'node:path';
+import { join, posix, win32 } from 'node:path';
+
+// Windows paths are built with win32.join and macOS paths with posix.join,
+// rather than the host-dependent join. These functions take the target platform
+// as an argument, so they must produce that platform's separators no matter
+// which machine they run on. It also makes them testable: the previous Windows
+// test could only assert the result "contains Claude", because a real path
+// comparison would have failed on the Linux CI host, and that weak assertion is
+// what let the MSIX path bug through two releases.
+
+/**
+ * Filesystem probes the Windows resolver needs. Injected so the resolver stays
+ * pure and testable: on Windows the correct path cannot be computed from env
+ * alone, it has to be discovered on disk.
+ */
+export interface DirProbe {
+  /** Entry names in a directory; [] when it does not exist or cannot be read. */
+  readDir(path: string): string[];
+}
+
+/**
+ * WINDOWS IS NOT `%APPDATA%\Claude`. Claude Desktop for Windows ships as an
+ * MSIX package (the claude.ai download, not only the Store one), and Windows
+ * redirects a packaged app's %APPDATA% into its own container:
+ *
+ *   %LOCALAPPDATA%\Packages\Claude_<publisher>\LocalCache\Roaming\Claude\
+ *
+ * dayGLANCE is unpackaged, so its own %APPDATA% resolves to the real
+ * C:\Users\<user>\AppData\Roaming and never sees that redirection. Writing
+ * there produces a valid config file that Claude Desktop never reads: the
+ * Developer pane shows "No servers added" while the file sits on disk looking
+ * correct, which is exactly how this shipped undetected.
+ *
+ * The publisher suffix is not hardcoded. Any `Claude_*` package directory
+ * counts, preferring one that already holds a config, so a machine with more
+ * than one packaged build gets the one actually in use.
+ *
+ * Falls back to the unpackaged location when no package directory exists, which
+ * is what a classic non-MSIX install would use.
+ */
+function windowsClaudeConfigPath(
+  env: Record<string, string | undefined>,
+  probe: DirProbe | null,
+): string | null {
+  const classic = env['APPDATA'] ? win32.join(env['APPDATA'], 'Claude', 'claude_desktop_config.json') : null;
+  const localAppData = env['LOCALAPPDATA'];
+  if (!localAppData || !probe) return classic;
+
+  const packagesDir = win32.join(localAppData, 'Packages');
+  const candidates = probe
+    .readDir(packagesDir)
+    .filter((name) => name.startsWith('Claude_'))
+    .sort()
+    .map((name) => win32.join(packagesDir, name, 'LocalCache', 'Roaming', 'Claude'));
+  if (candidates.length === 0) return classic;
+
+  const withConfig = candidates.find((dir) => probe.readDir(dir).includes('claude_desktop_config.json'));
+  return win32.join(withConfig ?? candidates[0]!, 'claude_desktop_config.json');
+}
 
 /**
  * Claude Desktop's config path, or null on platforms where Claude Desktop
  * does not exist (Linux) or the anchor directory is unknowable. The setup
  * button only renders on darwin and win32, but the resolver stays honest
  * for every input.
+ *
+ * `probe` is only consulted on win32 (see windowsClaudeConfigPath). Passing
+ * null there degrades to the unpackaged path, which is the pre-MSIX behavior.
  */
 export function claudeConfigPath(
   platform: string,
   env: Record<string, string | undefined>,
   home: string,
+  probe: DirProbe | null = null,
 ): string | null {
   switch (platform) {
     case 'darwin':
-      return join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+      return posix.join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
     case 'win32':
-      return env['APPDATA'] ? join(env['APPDATA'], 'Claude', 'claude_desktop_config.json') : null;
+      return windowsClaudeConfigPath(env, probe);
     default:
       return null;
   }
@@ -53,15 +115,44 @@ export function bridgeScriptPath(resourcesPath: string): string {
 }
 
 /**
+ * True when a resolved config path sits inside an MSIX package container. The
+ * two markers together are unambiguous; neither appears in the unpackaged path.
+ */
+export function claudeConfigIsPackaged(configPath: string): boolean {
+  const p = configPath.toLowerCase();
+  return p.includes('\\packages\\') && p.includes('\\localcache\\');
+}
+
+/**
  * The config entry: dayGLANCE's own Electron binary run as Node, executing
  * the bundled bridge. No Node install, no network, no npx; the binary is
  * already on disk and already signed. resourcesPath is process.resourcesPath
  * at runtime, so the path is whatever the installed app actually sees.
+ *
+ * `connection` overrides discovery with an explicit port and token. Required
+ * when Claude Desktop is packaged: the bridge is spawned as its child, inherits
+ * the container's redirected %APPDATA%, and therefore looks for the discovery
+ * file at ...\Packages\Claude_*\LocalCache\Roaming\dayGLANCE\mcp.json, which
+ * dayGLANCE (unpackaged) never writes. Same redirection as the config path
+ * above, one process further down.
+ *
+ * The cost is the token sitting in a plain config file rather than only in the
+ * 0600 discovery file. Accepted because the alternative is a feature that
+ * cannot work at all on packaged installs, and because the .mcpb path already
+ * puts the token in Claude Desktop's own config through user_config.
  */
-export function bridgeEntry(execPath: string, resourcesPath: string): BridgeEntry {
+export function bridgeEntry(
+  execPath: string,
+  resourcesPath: string,
+  connection?: { port: number; token: string } | null,
+): BridgeEntry {
+  const args = [bridgeScriptPath(resourcesPath)];
+  if (connection && connection.token) {
+    args.push('--port', String(connection.port), '--token', connection.token);
+  }
   return {
     command: execPath,
-    args: [bridgeScriptPath(resourcesPath)],
+    args,
     env: { ELECTRON_RUN_AS_NODE: '1' },
   };
 }

--- a/electron/mcpDesktopSetup.ts
+++ b/electron/mcpDesktopSetup.ts
@@ -12,15 +12,36 @@
 // string's absence) against the BUILT artifact.
 
 import { ipcMain } from 'electron';
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { claudeConfigPath, bridgeEntry, bridgeScriptPath, mergeClaudeConfig, manualEntrySnippet } from './mcpDesktopConfig.js';
+import { claudeConfigPath, claudeConfigIsPackaged, bridgeEntry, bridgeScriptPath, mergeClaudeConfig, manualEntrySnippet } from './mcpDesktopConfig.js';
 
-export function registerMcpDesktopSetup(): void {
+/** Never throws: an unreadable or absent directory is simply no candidates. */
+const dirProbe = {
+  readDir(p: string): string[] {
+    try {
+      return readdirSync(p);
+    } catch {
+      return [];
+    }
+  },
+};
+
+/**
+ * @param getConnection supplies the live MCP port and token, used only when
+ *   Claude Desktop is packaged and discovery cannot cross the container
+ *   boundary (see bridgeEntry). Returning null falls back to discovery.
+ */
+export function registerMcpDesktopSetup(
+  getConnection: () => { port: number; token: string } | null = () => null,
+): void {
   ipcMain.handle('mcp-setup:claude-desktop', () => {
-    const path = claudeConfigPath(process.platform, process.env, homedir());
-    const entry = bridgeEntry(process.execPath, process.resourcesPath);
+    const path = claudeConfigPath(process.platform, process.env, homedir(), dirProbe);
+    // Only override discovery where it provably cannot work. An unpackaged
+    // install keeps the 0600 discovery file as the only place the token lives.
+    const connection = path && claudeConfigIsPackaged(path) ? getConnection() : null;
+    const entry = bridgeEntry(process.execPath, process.resourcesPath, connection);
     if (!path) {
       return { ok: false, reason: 'unsupported_platform', manualEntry: manualEntrySnippet(entry) };
     }

--- a/electron/msixClaudeConfig.test.ts
+++ b/electron/msixClaudeConfig.test.ts
@@ -1,0 +1,121 @@
+// Windows config-path resolution against a REAL MSIX layout.
+//
+// The layout below is copied from an actual failing install, not invented:
+//
+//   C:\Users\Krell\AppData\Local\Packages\Claude_pzs8sxrjxfjjc\
+//       LocalCache\Roaming\Claude\claude_desktop_config.json
+//
+// This is the whole reason the feature did not work on Windows. Claude Desktop
+// ships as an MSIX package, Windows redirects a packaged app's %APPDATA% into
+// that container, and dayGLANCE is unpackaged so its own %APPDATA% resolves to
+// the real Roaming directory. The button wrote a valid config to a file Claude
+// Desktop never reads, and reported success.
+//
+// The pre-existing test asserted claudeConfigPath('win32', {APPDATA}) contained
+// 'Claude' and passed for two releases. It could only ever confirm the guess it
+// was written from. These tests probe a directory tree instead.
+
+import { describe, it, expect } from 'vitest';
+import { claudeConfigPath, claudeConfigIsPackaged, bridgeEntry, bridgeScriptPath } from './mcpDesktopConfig.js';
+
+const LOCAL = 'C:\\Users\\Krell\\AppData\\Local';
+const ROAMING = 'C:\\Users\\Krell\\AppData\\Roaming';
+const ENV = { LOCALAPPDATA: LOCAL, APPDATA: ROAMING };
+const PKG = 'Claude_pzs8sxrjxfjjc';
+const PACKAGED = `${LOCAL}\\Packages\\${PKG}\\LocalCache\\Roaming\\Claude\\claude_desktop_config.json`;
+const CLASSIC = `${ROAMING}\\Claude\\claude_desktop_config.json`;
+
+/** A fake tree: map of directory path to entry names. Missing key = absent. */
+function probeOf(tree: Record<string, string[]>) {
+  return { readDir: (p: string) => tree[p] ?? [] };
+}
+
+const packagedTree = probeOf({
+  [`${LOCAL}\\Packages`]: ['Microsoft.WindowsStore_8wekyb3d8bbwe', PKG, 'SomeOther_abc'],
+  [`${LOCAL}\\Packages\\${PKG}\\LocalCache\\Roaming\\Claude`]: ['claude_desktop_config.json', 'config.json'],
+});
+
+describe('claudeConfigPath on Windows — MSIX redirection', () => {
+  it('resolves into the package container when a Claude_* package exists', () => {
+    expect(claudeConfigPath('win32', ENV, 'C:\\Users\\Krell', packagedTree)).toBe(PACKAGED);
+  });
+
+  it('ignores unrelated packages sitting alongside it', () => {
+    const tree = probeOf({ [`${LOCAL}\\Packages`]: ['Microsoft.WindowsStore_8wekyb3d8bbwe', 'Spotify_zpdnekdrzrea0'] });
+    expect(claudeConfigPath('win32', ENV, 'C:\\Users\\Krell', tree)).toBe(CLASSIC);
+  });
+
+  it('falls back to the unpackaged path when no package directory exists', () => {
+    expect(claudeConfigPath('win32', ENV, 'C:\\Users\\Krell', probeOf({}))).toBe(CLASSIC);
+  });
+
+  it('prefers the package that already holds a config when several are present', () => {
+    const other = 'Claude_aaaaaaaaaaaaa';
+    // `other` sorts first, so picking it would be the bug this guards.
+    const tree = probeOf({
+      [`${LOCAL}\\Packages`]: [other, PKG],
+      [`${LOCAL}\\Packages\\${PKG}\\LocalCache\\Roaming\\Claude`]: ['claude_desktop_config.json'],
+    });
+    expect(claudeConfigPath('win32', ENV, 'C:\\Users\\Krell', tree)).toBe(PACKAGED);
+  });
+
+  it('a package with no config yet is still used, so first-run setup lands inside it', () => {
+    const tree = probeOf({ [`${LOCAL}\\Packages`]: [PKG] });
+    expect(claudeConfigPath('win32', ENV, 'C:\\Users\\Krell', tree)).toBe(PACKAGED);
+  });
+
+  it('no probe degrades to the unpackaged path rather than returning null', () => {
+    expect(claudeConfigPath('win32', ENV, 'C:\\Users\\Krell', null)).toBe(CLASSIC);
+  });
+
+  it('no LOCALAPPDATA, and no APPDATA, still resolve as before', () => {
+    expect(claudeConfigPath('win32', { APPDATA: ROAMING }, 'C:\\Users\\Krell', packagedTree)).toBe(CLASSIC);
+    expect(claudeConfigPath('win32', {}, 'C:\\Users\\Krell', packagedTree)).toBeNull();
+  });
+
+  it('macOS is untouched by any of this', () => {
+    expect(claudeConfigPath('darwin', ENV, '/Users/casey', packagedTree))
+      .toBe('/Users/casey/Library/Application Support/Claude/claude_desktop_config.json');
+  });
+});
+
+describe('claudeConfigIsPackaged', () => {
+  it('recognises the container path and nothing else', () => {
+    expect(claudeConfigIsPackaged(PACKAGED)).toBe(true);
+    expect(claudeConfigIsPackaged(CLASSIC)).toBe(false);
+    expect(claudeConfigIsPackaged('/Users/casey/Library/Application Support/Claude/claude_desktop_config.json')).toBe(false);
+  });
+
+  it('is case-insensitive, since Windows paths are', () => {
+    expect(claudeConfigIsPackaged(PACKAGED.toUpperCase())).toBe(true);
+  });
+});
+
+describe('bridgeEntry — explicit connection for packaged installs', () => {
+  const EXE = 'C:\\Program Files\\dayGLANCE\\dayGLANCE.exe';
+  const RES = 'C:\\Program Files\\dayGLANCE\\resources';
+
+  it('omits port and token by default, leaving discovery in charge', () => {
+    expect(bridgeEntry(EXE, RES).args).toEqual([bridgeScriptPath(RES)]);
+  });
+
+  it('passes them explicitly when discovery cannot cross the container', () => {
+    // The bridge inherits the packaged parent's redirected %APPDATA%, so it
+    // would look for the discovery file inside the container, where dayGLANCE
+    // never writes one. Explicit args are the only thing that reaches it.
+    // bridgeScriptPath intentionally uses the host join: its input is the real
+    // process.resourcesPath at runtime, so it is already on the target platform.
+    // The subject here is the appended arguments, not the separator.
+    expect(bridgeEntry(EXE, RES, { port: 7893, token: 'abc123' }).args)
+      .toEqual([bridgeScriptPath(RES), '--port', '7893', '--token', 'abc123']);
+  });
+
+  it('an empty token is not written as an argument', () => {
+    expect(bridgeEntry(EXE, RES, { port: 7893, token: '' }).args).toHaveLength(1);
+  });
+
+  it('the ELECTRON_RUN_AS_NODE env survives either shape', () => {
+    expect(bridgeEntry(EXE, RES).env).toEqual({ ELECTRON_RUN_AS_NODE: '1' });
+    expect(bridgeEntry(EXE, RES, { port: 1, token: 't' }).env).toEqual({ ELECTRON_RUN_AS_NODE: '1' });
+  });
+});


### PR DESCRIPTION
**Needs a Windows hardware check before merging.** The logic is tested against a real MSIX layout, but nothing here has run on Windows.

## The bug

Claude Desktop for Windows ships as an **MSIX package** — including the build downloaded from claude.ai, not only the Store one. Windows redirects a packaged app's `%APPDATA%` into its container:

```
%LOCALAPPDATA%\Packages\Claude_<publisher>\LocalCache\Roaming\Claude\
```

dayGLANCE is unpackaged, so its `%APPDATA%` resolves to the real `Roaming` and never sees the redirection.

| | Path |
|---|---|
| dayGLANCE wrote | `…\AppData\Roaming\Claude\claude_desktop_config.json` |
| Claude Desktop reads | `…\AppData\Local\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\claude_desktop_config.json` |

Both files exist, both are valid, and they are different files. The Developer pane reads "No servers added" while a correct-looking config sits on disk. **This is the ordinary Windows install, not an edge case** — the setup button did not work for any Windows user.

## The fix

**Probe, don't assume.** `%LOCALAPPDATA%\Packages` is scanned for a `Claude_*` directory rather than hardcoding the publisher suffix, preferring one that already holds a config (so a machine with several packaged builds gets the one in use), falling back to the unpackaged path when no package exists.

**The bridge needs the same treatment one process down.** Spawned as a child of the packaged client, it inherits the redirected `%APPDATA%` and looks for the discovery file *inside* the container, where dayGLANCE never writes one. Where the config path is packaged, the entry now carries `--port` and `--token` explicitly.

The tradeoff: the token lives in a plain config file rather than only in the 0600 discovery file. Accepted because the alternative is a feature that cannot work at all on packaged installs, and because the `.mcpb` path already puts the token in Claude Desktop's config through `user_config`.

## Why the tests didn't catch it

The existing assertion was:

```js
expect(claudeConfigPath('win32', { APPDATA: '…' })).toContain('Claude')
```

It could only ever confirm the guess it was written from. And it was weak *for a reason*: `join` is host-dependent, so a real path comparison would have failed on the Linux CI host — the weak assertion was the path of least resistance, and it cost two releases.

Windows paths are now built with `win32.join` and macOS with `posix.join`. These functions take the target platform as an argument, so they must produce that platform's separators regardless of host. That makes exact assertions possible, and `msixClaudeConfig.test.ts` uses the real failing layout transcribed from an actual install: unrelated packages alongside it, multiple Claude packages, a package with no config yet, absent probe, absent env vars, and macOS untouched.

Same technique #1357 used to verify Windows/UNC handling via `path.win32` simulation.

## Verification

Lint clean, `tsconfig.electron.json` clean, 1866 tests across 125 files green.

**Not verified: anything on Windows.** Needed before merge:

1. Click the setup button on a Windows install with packaged Claude Desktop
2. Confirm the entry lands in the `LocalCache\Roaming\Claude` file, not `Roaming\Claude`
3. Confirm it appears under Settings → Developer after a full tray quit
4. Confirm the tools load and a call succeeds — this is what proves the `--port`/`--token` half

---
_Generated by [Claude Code](https://claude.ai/code/session_01L314TaA4GF71TM2Hgg6KTW)_