### PR TITLE
Build the Linux AppImage for arm64 as well as x64

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ services:
 docker compose up -d
 ```
 
+The image is built for `linux/amd64` and `linux/arm64`, so it runs on a Raspberry Pi or other ARM single-board computer as well as on an x86 server. Docker pulls the right one automatically.
+
 Available at `http://localhost:6767`. For HTTPS with Caddy:
 
 ```caddy
@@ -68,6 +70,18 @@ npm run dev
 Open [http://localhost:5173](http://localhost:5173). For production: `npm run build`.
 
 → See the [full deployment guide](https://docs.dayglance.app/self-hosting) for reverse proxy setup and update instructions.
+
+### Desktop App
+
+Native builds for macOS, Windows and Linux are on the [releases page](https://github.com/krelltunez/dayglance/releases). The desktop app adds what a browser cannot do: the menu bar or tray popup, the Stream Deck listener, native calendar access, and the local MCP server for AI assistants.
+
+| Platform | Artifact | Architectures |
+|---|---|---|
+| macOS | `.dmg`, `.zip` | Intel and Apple Silicon |
+| Windows | `.exe` installer | x64 |
+| Linux | `.AppImage` | x64 and arm64 |
+
+The arm64 AppImage covers 64-bit Raspberry Pi OS and other aarch64 desktops. 32-bit systems reporting `armv7l` are not covered. If you only want the planner itself on an ARM board rather than the desktop features, the Docker image above is lighter.
 
 ---
 

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -180,6 +180,24 @@ module.exports = {
     // AppImage's mount path changes every launch, so an absolute path written into
     // a config would go stale on the next run. Linux connects via npx instead, and
     // the renderer's setup button does not render there.
-    target: [{ target: 'AppImage' }],
+    //
+    // arch is EXPLICIT here, and must stay that way. Omitting it does not mean
+    // "every architecture", it means "whatever the build host happens to be" —
+    // and the host is ubuntu-latest, so for three releases the only Linux artifact
+    // was x64. Nothing decided to exclude ARM; the default decided, silently, and
+    // a Raspberry Pi user downloading the AppImage got "cannot execute binary
+    // file" with nothing explaining why. mac had arch spelled out from the start
+    // because Apple Silicon makes the omission fail loudly; Linux never forced
+    // the question.
+    //
+    // Cross-packaging arm64 from an x64 runner is sound HERE specifically because
+    // no runtime dependency is native (every .node in node_modules is build
+    // tooling: rolldown, rollup, lightningcss). electron-builder fetches the
+    // arm64 Electron dist and wraps the same JS, so there is nothing to compile.
+    // Adding a native runtime dep invalidates that and this needs an arm64 runner
+    // (ubuntu-24.04-arm) instead.
+    //
+    // 64-bit only. 32-bit Raspberry Pi OS reports armv7l and is not covered.
+    target: [{ target: 'AppImage', arch: ['x64', 'arm64'] }],
   },
 };

--- a/electron/bridgePackaging.test.ts
+++ b/electron/bridgePackaging.test.ts
@@ -63,3 +63,39 @@ describe('MCP bridge packaging — every platform with a setup button ships one'
     expect(resourcesOf(config as never).some((r) => r.from === BRIDGE)).toBe(false);
   });
 });
+
+// Architecture is a separate failure mode from packaging, and a quieter one.
+// An omitted `arch` does not mean "all architectures", it means "whatever the
+// build host is" — ubuntu-latest, so x64. Three releases shipped a Linux
+// AppImage that could not run on a Raspberry Pi, and nothing anywhere said so:
+// the config looked complete, the build succeeded, the artifact uploaded.
+// Only a user on aarch64 would ever find out, via "cannot execute binary file".
+describe('desktop target architectures are declared, never inherited from the host', () => {
+  const targetsOf = (block: { target?: unknown } | undefined) => {
+    const t = block?.target;
+    return Array.isArray(t) ? (t as { target: string; arch?: string | string[] }[]) : [];
+  };
+
+  it('the Linux AppImage covers x64 AND arm64, so ARM SBCs get a real app', () => {
+    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
+    const appImage = targetsOf(config['linux']).find((t) => t.target === 'AppImage');
+    expect(appImage, 'linux must declare an AppImage target').toBeDefined();
+    expect(appImage?.arch, 'omitting arch silently yields host-arch only').toEqual(['x64', 'arm64']);
+  });
+
+  it('every Linux and macOS target names its arch explicitly', () => {
+    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
+    for (const platform of ['linux', 'mac']) {
+      for (const t of targetsOf(config[platform])) {
+        expect(t.arch, `${platform}.${t.target} must declare arch, not inherit it`).toBeDefined();
+      }
+    }
+  });
+
+  it('mac still covers both architectures, unchanged', () => {
+    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
+    for (const t of targetsOf(config['mac'])) {
+      expect(t.arch).toEqual(['x64', 'arm64']);
+    }
+  });
+});


### PR DESCRIPTION
For v4.4.0. Gives Raspberry Pi and other aarch64 desktops a real dayGLANCE app instead of only the self-hosted web build.

## Nothing chose x64

```js
linux: { target: [{ target: 'AppImage' }] },   // no arch
```

Omitting `arch` does not mean "every architecture" — electron-builder reads it as *the build host's* architecture, and the host is `ubuntu-latest`. So three releases shipped a Linux artifact that cannot run on a Pi, and the failure surfaces as `cannot execute binary file` with nothing explaining why.

The contrast is in the same file. `mac` has carried `arch: ['x64', 'arm64']` from the start, because Apple Silicon makes the omission fail loudly. Linux never forced the question, so the default stood unexamined since `6b34fbf9` (2026-05-03) — where the block went in as a one-line aside inside a commit about Developer ID signing and notarization.

Worth noting the arm64 Docker image has existed since 2026-03-20 and still does. ARM users have had the planner all along; what they lacked was the desktop app, and nothing anywhere recorded that split.

## Why cross-packaging is safe here

No runtime dependency is native. Every `.node` in `node_modules` is build tooling — rolldown, rollup, lightningcss — which runs on the CI host and never ships. electron-builder fetches the arm64 Electron dist and wraps the same JavaScript, so there is nothing to compile and no QEMU involved.

That reasoning is written into the config, because it stops being true the moment a native runtime dep is added, at which point this needs an arm64 runner (`ubuntu-24.04-arm`) instead.

No workflow change: the upload step globs `dist-app/*.AppImage`, which matches both the x64 and `-arm64` names.

## Tests

Two new assertions, and the second is the one that matters long-term:

- The Linux AppImage declares `['x64', 'arm64']`
- **Every** Linux and macOS target declares `arch` explicitly rather than inheriting it, so the next target added can't repeat this silently

Verified to fail against the previous config on exactly those two, with the other seven staying green.

## README

New Desktop App section with artifact and architecture per platform, plus a note that the Docker image is `linux/amd64` and `linux/arm64`.

This is the part that actually let the gap persist: arm64 Docker shipped in March and was never documented, so ARM support read as missing when it was half-present. A table makes the split visible.

## Scope

64-bit only. 32-bit Raspberry Pi OS reports `armv7l` and is out of scope.

## Verification

Lint clean, `tsconfig.electron.json` clean, 1869 tests across 125 files green.

**Not verified on hardware.** The arm64 AppImage needs to launch on a real Pi before the release is published — the config is asserted, the binary is not.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L314TaA4GF71TM2Hgg6KTW)_