### PR TITLE
Name every Linux AppImage after its architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,16 @@ Native builds for macOS, Windows and Linux are on the [releases page](https://gi
 
 | Platform | Artifact | Architectures |
 |---|---|---|
-| macOS | `.dmg`, `.zip` | Intel and Apple Silicon |
+| macOS | `.dmg`, `.zip` | Intel (`x64`) and Apple Silicon (`arm64`) |
 | Windows | `.exe` installer | x64 |
-| Linux | `.AppImage` | x64 and arm64 |
+| Linux | `dayGLANCE-<version>-x64.AppImage` | x64 |
+| Linux | `dayGLANCE-<version>-arm64.AppImage` | arm64 |
+
+Every Linux artifact names its architecture, so pick the one matching `uname -m`: `x86_64` takes the `x64` build, `aarch64` takes `arm64`. Running the wrong one fails with `cannot execute binary file: exec format error`.
 
 The arm64 AppImage covers 64-bit Raspberry Pi OS and other aarch64 desktops. 32-bit systems reporting `armv7l` are not covered. If you only want the planner itself on an ARM board rather than the desktop features, the Docker image above is lighter.
+
+AppImages need FUSE. If launching complains about it, either install `libfuse2` or run with `--appimage-extract-and-run`.
 
 ---
 

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -198,6 +198,21 @@ module.exports = {
     // (ubuntu-24.04-arm) instead.
     //
     // 64-bit only. 32-bit Raspberry Pi OS reports armv7l and is not covered.
+    //
+    // artifactName exists to force the arch into EVERY name, including x64's.
+    // electron-builder suppresses the arch suffix for a platform's default arch
+    // unless a pattern is user-specified: expandArtifactNamePattern only strips it
+    // when `!isUserForced`, and artifactPatternConfig sets isUserForced from the
+    // mere presence of artifactName (app-builder-lib/out/platformPackager.js).
+    // Without this, the pair ships as dayGLANCE-4.4.0.AppImage (x64, unlabelled)
+    // and dayGLANCE-4.4.0-arm64.AppImage, so the x64 build reads as the generic
+    // one and gets downloaded onto ARM hardware, where it fails with a bare
+    // "exec format error". Both names now carry their arch.
+    //
+    // ${arch} expands through Arch[arch], so the values are x64 and arm64, not
+    // x86_64. Matching electron-builder's own vocabulary beats inventing a
+    // synonym, and "x86" would be wrong outright since it reads as 32-bit.
+    artifactName: '${productName}-${version}-${arch}.${ext}',
     target: [{ target: 'AppImage', arch: ['x64', 'arm64'] }],
   },
 };

--- a/electron/bridgePackaging.test.ts
+++ b/electron/bridgePackaging.test.ts
@@ -99,3 +99,25 @@ describe('desktop target architectures are declared, never inherited from the ho
     }
   });
 });
+
+// Naming, which is a usability failure rather than a build failure: both
+// AppImages built correctly, but the x64 one was called
+// dayGLANCE-<version>.AppImage with no arch in it, so it read as "the Linux
+// build" and got downloaded onto a Raspberry Pi. electron-builder strips the
+// arch suffix for the default arch UNLESS artifactName is user-specified, so
+// the presence of that pattern is load-bearing, not cosmetic.
+describe('Linux artifact names carry their architecture', () => {
+  it('linux sets artifactName, which is what stops x64 losing its suffix', () => {
+    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
+    const pattern = (config['linux'] as { artifactName?: string } | undefined)?.artifactName;
+    expect(pattern, 'without artifactName, x64 builds as an unlabelled name').toBeDefined();
+    expect(pattern).toContain('${arch}');
+  });
+
+  it('the pattern keeps the version and the extension placeholder too', () => {
+    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
+    const pattern = (config['linux'] as { artifactName?: string } | undefined)?.artifactName ?? '';
+    expect(pattern).toContain('${version}');
+    expect(pattern).toContain('${ext}');
+  });
+});


### PR DESCRIPTION
Follow-up to #1407. Both AppImages build correctly — the problem is that only one of them says which is which.

## The problem

```
dayGLANCE-4.4.0.AppImage          ← x64, unlabelled
dayGLANCE-4.4.0-arm64.AppImage    ← arm64
```

The unlabelled one reads as "the Linux build", so it's the one an ARM user reaches for, and it fails with a bare `cannot execute binary file: exec format error` that names no cause. Adding arm64 support made the naming actively misleading in a way it wasn't when x64 was the only option.

## Why x64 lost its suffix

electron-builder suppresses the arch suffix for a platform's default arch — but only while no pattern is user-specified. From `app-builder-lib/out/platformPackager.js`:

```js
expandArtifactNamePattern(...) {
  const { pattern, isUserForced } = this.artifactPatternConfig(...)
  return this.computeArtifactName(pattern, ext,
    !isUserForced && skipDefaultArch && arch === defaultArchFromString(defaultArch) ? null : arch)
}
artifactPatternConfig(...) {
  const userSpecifiedPattern = targetSpecificOptions?.artifactName
    || this.platformSpecificBuildOptions.artifactName || this.config.artifactName
  return { isUserForced: !!userSpecifiedPattern, ... }
}
```

`isUserForced` comes from the mere *presence* of `artifactName`. So setting the pattern is what forces x64 to be labelled — it's load-bearing, not cosmetic, and the tests assert it for that reason.

## The naming

`dayGLANCE-<version>-x64.AppImage` and `dayGLANCE-<version>-arm64.AppImage`.

`${arch}` resolves through `Arch[arch]`, which yields `x64` and `arm64` — not `x86_64`. I went with electron-builder's own vocabulary rather than introducing a synonym, and `x86` would be wrong outright since it reads as 32-bit.

## ⚠️ A stale asset needs deleting by hand

The draft release currently holds `dayGLANCE-4.4.0.AppImage`. The next build produces **no file by that name**, so `action-gh-release` won't overwrite it — it only replaces matching filenames. Left alone, the release ships a stale unlabelled x64 build next to the new correctly-named pair, which is worse than the problem being fixed.

```
gh release delete-asset untagged-0e28151458fa965c41ae dayGLANCE-4.4.0.AppImage --repo krelltunez/dayGLANCE
```

Expected final count: **seven** desktop assets (2 dmg, 2 mac zip, 1 exe, 2 AppImage), plus the Android APK.

## Tests

- `linux` declares `artifactName` containing `${arch}` — the thing that stops x64 going unlabelled
- The pattern retains `${version}` and `${ext}`

Verified to fail against the config without `artifactName`, on exactly those two, with the other nine green.

## README

Both Linux artifacts listed by name, with instructions to match them against `uname -m`. The `exec format error` string is quoted verbatim so a search lands on the answer, and the `libfuse2` requirement is noted with the `--appimage-extract-and-run` fallback.

## Verification

Lint clean, `tsconfig.electron.json` clean, 1871 tests across 125 files green. Naming behavior is verified by reading the installed electron-builder's resolution logic, not by running a build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L314TaA4GF71TM2Hgg6KTW)_