### PR TITLE
Linux desktop integration: a deb that installs, plus icon, category and description

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -16,7 +16,7 @@ jobs:
           - os: windows-latest
             artifact_glob: "dist-app/*.exe"
           - os: ubuntu-latest
-            artifact_glob: "dist-app/*.AppImage"
+            artifact_glob: "dist-app/*.AppImage dist-app/*.deb"
 
     runs-on: ${{ matrix.os }}
 
@@ -67,6 +67,7 @@ jobs:
             dist-app/*-mac.zip
             dist-app/*.exe
             dist-app/*.AppImage
+            dist-app/*.deb
           if-no-files-found: ignore
 
   release:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -72,6 +72,15 @@ jobs:
 
   release:
     needs: build
+    # Tag pushes only. Without this, a workflow_dispatch run against a branch
+    # reaches action-gh-release with no tag and either fails or writes a
+    # release nobody asked for. Guarding it makes manual dispatch a safe
+    # build-only smoke test: artifacts get produced and can be downloaded,
+    # and no release is touched. That is the only way to exercise a packaging
+    # change before tagging, since ci.yml runs the web build and never
+    # electron-builder — so packaging bugs have historically had the release
+    # itself as their first real test.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -88,6 +88,43 @@ The arm64 AppImage covers 64-bit Raspberry Pi OS and other aarch64 desktops. 32-
 
 AppImages need FUSE. If launching complains about it, either install `libfuse2` or run with `--appimage-extract-and-run`.
 
+#### Running it on Linux
+
+An AppImage is not installed. It is a single self-contained executable that stays wherever you saved it, so there is no setup step and nothing to uninstall later:
+
+```bash
+chmod +x dayGLANCE-<version>-arm64.AppImage
+./dayGLANCE-<version>-arm64.AppImage
+```
+
+It will **not** appear in your applications menu on its own. Two ways to get it there:
+
+**[AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher)** — install it once and every AppImage you open offers to integrate itself, moving the file somewhere sensible and creating the menu entry for you. This is the least work if you use AppImages for anything else.
+
+**A desktop entry by hand** — move the AppImage somewhere permanent, then write one file:
+
+```bash
+mkdir -p ~/.local/bin ~/.local/share/applications
+mv dayGLANCE-*.AppImage ~/.local/bin/dayglance
+chmod +x ~/.local/bin/dayglance
+
+cat > ~/.local/share/applications/dayglance.desktop <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=dayGLANCE
+Comment=Your day, at a glance
+Exec=/home/YOUR_USER/.local/bin/dayglance
+Icon=dayglance
+Terminal=false
+Categories=Office;Calendar;
+StartupWMClass=dayGLANCE
+EOF
+
+update-desktop-database ~/.local/share/applications 2>/dev/null || true
+```
+
+Replace `YOUR_USER`, since `Exec` does not expand `~`. For the icon, extract it from the AppImage with `./dayglance --appimage-extract` and copy `squashfs-root/dayglance.png` to `~/.local/share/icons/`, or point `Icon=` at any PNG path.
+
 ---
 
 ## Android App

--- a/README.md
+++ b/README.md
@@ -79,16 +79,26 @@ Native builds for macOS, Windows and Linux are on the [releases page](https://gi
 |---|---|---|
 | macOS | `.dmg`, `.zip` | Intel (`x64`) and Apple Silicon (`arm64`) |
 | Windows | `.exe` installer | x64 |
-| Linux | `dayGLANCE-<version>-x64.AppImage` | x64 |
-| Linux | `dayGLANCE-<version>-arm64.AppImage` | arm64 |
+| Linux | `dayglance_<version>_amd64.deb`, `dayglance_<version>_arm64.deb` | x64 and arm64 |
+| Linux | `dayGLANCE-<version>-x64.AppImage`, `dayGLANCE-<version>-arm64.AppImage` | x64 and arm64 |
 
-Every Linux artifact names its architecture, so pick the one matching `uname -m`: `x86_64` takes the `x64` build, `aarch64` takes `arm64`. Running the wrong one fails with `cannot execute binary file: exec format error`.
+Every Linux artifact names its architecture. Check yours with `uname -m`: `x86_64` takes the `x64` AppImage or the `amd64` deb, `aarch64` takes either `arm64` file. Debian and AppImage spell 64-bit Intel differently, `amd64` versus `x64`, but they mean the same thing. Running the wrong architecture fails with `cannot execute binary file: exec format error`.
 
 The arm64 AppImage covers 64-bit Raspberry Pi OS and other aarch64 desktops. 32-bit systems reporting `armv7l` are not covered. If you only want the planner itself on an ARM board rather than the desktop features, the Docker image above is lighter.
 
 AppImages need FUSE. If launching complains about it, either install `libfuse2` or run with `--appimage-extract-and-run`.
 
-#### Running it on Linux
+#### Installing on Linux
+
+**On Debian, Ubuntu, Raspberry Pi OS or anything else with `apt`, take the `.deb`.** It installs properly: the app lands in your applications menu with its icon, and `apt remove dayglance` takes it away again.
+
+```bash
+sudo apt install ./dayglance_<version>_arm64.deb
+```
+
+Then launch it from your menu, or run `dayglance` from a terminal.
+
+#### The AppImage, if you would rather stay portable
 
 An AppImage is not installed. It is a single self-contained executable that stays wherever you saved it, so there is no setup step and nothing to uninstall later:
 

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -175,6 +175,18 @@ module.exports = {
     ],
     target: [{ target: 'nsis' }],
   },
+  // Per-target options. artifactName lives HERE rather than on the target entry
+  // or the linux block. TargetConfiguration is additionalProperties:false with
+  // only `target` and `arch`, so an artifactName inside one invalidates the whole
+  // array (electron-builder then reports the unhelpful "linux.target.0 should be
+  // a string"). And at linux level it would rename the deb too, where Debian
+  // convention is name_version_arch.deb with arch as amd64 — not
+  // dayGLANCE-4.4.0-x64.deb. This block is the AppImage's targetSpecificOptions,
+  // so it still sets isUserForced and x64 keeps the arch suffix it would
+  // otherwise lose as the default arch.
+  appImage: {
+    artifactName: '${productName}-${version}-${arch}.${ext}',
+  },
   linux: {
     // No bridge, by design (§7): there is no Claude Desktop on Linux, and an
     // AppImage's mount path changes every launch, so an absolute path written into
@@ -258,12 +270,7 @@ module.exports = {
     // than a personal address.
     maintainer: 'GLANCE Apps <hello@glance-apps.com>',
     target: [
-      // artifactName sits on the TARGET, not the platform: at platform level it
-      // would rename the deb too, and Debian's convention is
-      // name_version_arch.deb with arch as amd64, not ${productName}-...-x64.deb.
-      // Target-specific patterns still set isUserForced, so x64 keeps its suffix.
-      { target: 'AppImage', arch: ['x64', 'arm64'],
-        artifactName: '${productName}-${version}-${arch}.${ext}' },
+      { target: 'AppImage', arch: ['x64', 'arm64'] },
       // deb exists because an AppImage is not installed: it is a loose executable
       // that never creates a menu entry, so "where is it after installing" had no
       // good answer. A deb unpacks to /opt, registers the .desktop file written

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -212,7 +212,6 @@ module.exports = {
     // ${arch} expands through Arch[arch], so the values are x64 and arm64, not
     // x86_64. Matching electron-builder's own vocabulary beats inventing a
     // synonym, and "x86" would be wrong outright since it reads as 32-bit.
-    artifactName: '${productName}-${version}-${arch}.${ext}',
     // Desktop-entry metadata. electron-builder writes Name, Exec, Type, Terminal,
     // Icon and StartupWMClass itself (LinuxTargetHelper), so only the keys it
     // cannot infer are set here. All three of these were missing:
@@ -248,6 +247,29 @@ module.exports = {
         Keywords: 'planner;schedule;tasks;todo;calendar;timeblocking;habits;goals;',
       },
     },
-    target: [{ target: 'AppImage', arch: ['x64', 'arm64'] }],
+    // maintainer is REQUIRED by the deb target and by nothing else. FpmTarget's
+    // checkOptions throws before building on a missing homepage (package.json,
+    // added alongside this) or a missing maintainer, taken from here or from a
+    // package.json author carrying an email. Declaring a deb target without both
+    // does not degrade, it FAILS THE LINUX BUILD.
+    //
+    // This address ships inside every published package and is readable by anyone
+    // who installs one, so it is deliberately the project's public contact rather
+    // than a personal address.
+    maintainer: 'GLANCE Apps <hello@glance-apps.com>',
+    target: [
+      // artifactName sits on the TARGET, not the platform: at platform level it
+      // would rename the deb too, and Debian's convention is
+      // name_version_arch.deb with arch as amd64, not ${productName}-...-x64.deb.
+      // Target-specific patterns still set isUserForced, so x64 keeps its suffix.
+      { target: 'AppImage', arch: ['x64', 'arm64'],
+        artifactName: '${productName}-${version}-${arch}.${ext}' },
+      // deb exists because an AppImage is not installed: it is a loose executable
+      // that never creates a menu entry, so "where is it after installing" had no
+      // good answer. A deb unpacks to /opt, registers the .desktop file written
+      // from the metadata above, and uninstalls with apt like anything else.
+      // AppImage stays for distros without dpkg and for people who want portable.
+      { target: 'deb', arch: ['x64', 'arm64'] },
+    ],
   },
 };

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -213,6 +213,41 @@ module.exports = {
     // x86_64. Matching electron-builder's own vocabulary beats inventing a
     // synonym, and "x86" would be wrong outright since it reads as 32-bit.
     artifactName: '${productName}-${version}-${arch}.${ext}',
+    // Desktop-entry metadata. electron-builder writes Name, Exec, Type, Terminal,
+    // Icon and StartupWMClass itself (LinuxTargetHelper), so only the keys it
+    // cannot infer are set here. All three of these were missing:
+    //
+    // category — REQUIRED, not optional. Left unset, LinuxTargetHelper tries to
+    //   map mac.category, and its macToLinuxCategory table has no entry for
+    //   public.app-category.productivity (graphics-design, developer-tools,
+    //   education, games, video, utilities, social-networking, finance, music
+    //   only). The mapping fails, Categories is omitted entirely, and the app
+    //   lands in the launcher's catch-all "Other" section. Office is the main
+    //   freedesktop category; Calendar is a registered additional one.
+    //
+    // icon — without it, computeDesktopIcons falls through every source
+    //   (linux.icon, mac.icon, config.icon) and then looks for a `public/icons`
+    //   directory, which does not exist, so it reaches getDefaultFrameworkIcon
+    //   and ships the GENERIC ELECTRON ICON. resolveIcon logs "default Electron
+    //   icon is used" when that happens, which has been in the build output all
+    //   along. Resolved against buildResources (public/) first, so the bare
+    //   filename is the right form. icon-512.png is 512x512 RGBA, comfortably
+    //   over the 256x256 floor for generating a Linux icon set.
+    //
+    // description — becomes the .desktop Comment, shown as the tooltip and in
+    //   launcher search results. package.json has no description field, so
+    //   getDescription resolved to empty and the key was dropped. Set here
+    //   rather than in package.json to keep the change scoped to Linux.
+    category: 'Office;Calendar',
+    description: 'Your day, at a glance',
+    icon: 'icon-512.png',
+    desktop: {
+      entry: {
+        // Launcher search terms. Trailing semicolon per the freedesktop spec for
+        // list values; electron-builder appends one to Categories but not here.
+        Keywords: 'planner;schedule;tasks;todo;calendar;timeblocking;habits;goals;',
+      },
+    },
     target: [{ target: 'AppImage', arch: ['x64', 'arm64'] }],
   },
 };

--- a/electron/bridgePackaging.test.ts
+++ b/electron/bridgePackaging.test.ts
@@ -121,3 +121,63 @@ describe('Linux artifact names carry their architecture', () => {
     expect(pattern).toContain('${ext}');
   });
 });
+
+// Desktop-entry metadata. electron-builder writes Name, Exec, Type, Terminal,
+// Icon and StartupWMClass itself, so these assertions cover only the keys it
+// cannot infer — each of which was silently absent, and each of which fails in a
+// way no build error reports: no launcher category, the generic Electron icon,
+// and an empty tooltip.
+describe('Linux desktop-entry metadata is set, since none of it can be inferred', () => {
+  const linuxOf = (config: Record<string, never>) =>
+    config['linux'] as unknown as {
+      category?: string;
+      icon?: string;
+      description?: string;
+      desktop?: { entry?: Record<string, string> };
+    };
+
+  it('category is explicit, because mac.category cannot map to a Linux one', () => {
+    // macToLinuxCategory covers graphics-design, developer-tools, education,
+    // games, video, utilities, social-networking, finance and music. There is no
+    // productivity entry, so relying on the fallback yields no Categories at all.
+    const linux = linuxOf(loadConfig({ DAYGLANCE_APP_ID: undefined }));
+    expect(linux.category, 'unset category means no Categories key').toBeTruthy();
+    expect(linux.category).toContain('Office');
+  });
+
+  it('an icon is named, or the build ships the generic Electron one', () => {
+    const linux = linuxOf(loadConfig({ DAYGLANCE_APP_ID: undefined }));
+    expect(linux.icon, 'no icon source reaches getDefaultFrameworkIcon').toBeTruthy();
+  });
+
+  it('the named icon exists under buildResources and is a PNG', () => {
+    // resolveIcon searches [buildResourcesDir, projectDir], and buildResources is
+    // public/, so a bare filename must exist there. A missing file falls back
+    // silently rather than failing the build, which is why this is asserted.
+    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
+    const icon = linuxOf(config).icon as string;
+    const buildResources = (config['directories'] as unknown as { buildResources: string }).buildResources;
+    const full = require('node:path').join(buildResources, icon);
+    expect(require('node:fs').existsSync(full), `${full} must exist`).toBe(true);
+    expect(icon.endsWith('.png'), 'Linux icon sets are generated from a PNG').toBe(true);
+  });
+
+  it('a description is set, so the .desktop Comment is not dropped', () => {
+    // getDescription falls back to package.json description, which is unset.
+    const linux = linuxOf(loadConfig({ DAYGLANCE_APP_ID: undefined }));
+    expect(linux.description).toBeTruthy();
+  });
+
+  it('Keywords is a semicolon-terminated list, per the freedesktop spec', () => {
+    const entry = linuxOf(loadConfig({ DAYGLANCE_APP_ID: undefined })).desktop?.entry ?? {};
+    expect(entry['Keywords']).toBeTruthy();
+    expect(entry['Keywords']?.endsWith(';'), 'list values must end with ;').toBe(true);
+  });
+
+  it('StartupWMClass is NOT overridden: electron-builder derives it correctly', () => {
+    // It must match Electron's app_id. Hardcoding a guess here would break
+    // window-to-launcher association rather than fix it.
+    const entry = linuxOf(loadConfig({ DAYGLANCE_APP_ID: undefined })).desktop?.entry ?? {};
+    expect(entry['StartupWMClass']).toBeUndefined();
+  });
+});

--- a/electron/bridgePackaging.test.ts
+++ b/electron/bridgePackaging.test.ts
@@ -114,13 +114,17 @@ describe('Linux artifact names carry their architecture', () => {
       artifactName?: string;
     }[];
 
-  it('the AppImage target sets artifactName, stopping x64 losing its suffix', () => {
-    const appImage = linuxTargets(loadConfig({ DAYGLANCE_APP_ID: undefined }))
-      .find((t) => t.target === 'AppImage');
-    expect(appImage?.artifactName, 'without it, x64 builds unlabelled').toBeDefined();
-    expect(appImage?.artifactName).toContain('${arch}');
-    expect(appImage?.artifactName).toContain('${version}');
-    expect(appImage?.artifactName).toContain('${ext}');
+  it('the appImage block sets artifactName, stopping x64 losing its suffix', () => {
+    // Not on the target entry: TargetConfiguration is additionalProperties:false,
+    // so an artifactName there invalidates the array. This block is the AppImage's
+    // targetSpecificOptions, so it still counts as user-forced.
+    const pattern = (loadConfig({ DAYGLANCE_APP_ID: undefined })['appImage'] as unknown as {
+      artifactName?: string;
+    })?.artifactName;
+    expect(pattern, 'without it, x64 builds unlabelled').toBeDefined();
+    expect(pattern).toContain('${arch}');
+    expect(pattern).toContain('${version}');
+    expect(pattern).toContain('${ext}');
   });
 
   it('the pattern is NOT set platform-wide, which would rename the deb too', () => {
@@ -130,12 +134,12 @@ describe('Linux artifact names carry their architecture', () => {
     expect((config['linux'] as unknown as { artifactName?: string }).artifactName).toBeUndefined();
   });
 
-  it('deb takes electron-builder default naming', () => {
-    const deb = linuxTargets(loadConfig({ DAYGLANCE_APP_ID: undefined }))
-      .find((t) => t.target === 'deb');
+  it('no deb block overrides naming, so it keeps the Debian convention', () => {
+    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
+    const deb = linuxTargets(config).find((t) => t.target === 'deb');
     expect(deb, 'a deb target must exist for a real install').toBeDefined();
-    expect(deb?.artifactName).toBeUndefined();
     expect(deb?.arch).toEqual(['x64', 'arm64']);
+    expect((config['deb'] as unknown as { artifactName?: string })?.artifactName).toBeUndefined();
   });
 
   it('maintainer is set, without which the deb target throws before building', () => {

--- a/electron/bridgePackaging.test.ts
+++ b/electron/bridgePackaging.test.ts
@@ -107,20 +107,55 @@ describe('desktop target architectures are declared, never inherited from the ho
 // arch suffix for the default arch UNLESS artifactName is user-specified, so
 // the presence of that pattern is load-bearing, not cosmetic.
 describe('Linux artifact names carry their architecture', () => {
-  it('linux sets artifactName, which is what stops x64 losing its suffix', () => {
-    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
-    const pattern = (config['linux'] as { artifactName?: string } | undefined)?.artifactName;
-    expect(pattern, 'without artifactName, x64 builds as an unlabelled name').toBeDefined();
-    expect(pattern).toContain('${arch}');
+  const linuxTargets = (config: Record<string, never>) =>
+    ((config['linux'] as unknown as { target?: unknown })?.target ?? []) as {
+      target: string;
+      arch?: string[];
+      artifactName?: string;
+    }[];
+
+  it('the AppImage target sets artifactName, stopping x64 losing its suffix', () => {
+    const appImage = linuxTargets(loadConfig({ DAYGLANCE_APP_ID: undefined }))
+      .find((t) => t.target === 'AppImage');
+    expect(appImage?.artifactName, 'without it, x64 builds unlabelled').toBeDefined();
+    expect(appImage?.artifactName).toContain('${arch}');
+    expect(appImage?.artifactName).toContain('${version}');
+    expect(appImage?.artifactName).toContain('${ext}');
   });
 
-  it('the pattern keeps the version and the extension placeholder too', () => {
+  it('the pattern is NOT set platform-wide, which would rename the deb too', () => {
+    // Debian convention is name_version_arch.deb with arch as amd64. A
+    // platform-level pattern would impose ${productName}-...-x64.deb on it.
     const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
-    const pattern = (config['linux'] as { artifactName?: string } | undefined)?.artifactName ?? '';
-    expect(pattern).toContain('${version}');
-    expect(pattern).toContain('${ext}');
+    expect((config['linux'] as unknown as { artifactName?: string }).artifactName).toBeUndefined();
+  });
+
+  it('deb takes electron-builder default naming', () => {
+    const deb = linuxTargets(loadConfig({ DAYGLANCE_APP_ID: undefined }))
+      .find((t) => t.target === 'deb');
+    expect(deb, 'a deb target must exist for a real install').toBeDefined();
+    expect(deb?.artifactName).toBeUndefined();
+    expect(deb?.arch).toEqual(['x64', 'arm64']);
+  });
+
+  it('maintainer is set, without which the deb target throws before building', () => {
+    // FpmTarget.checkOptions requires homepage (package.json) and a maintainer
+    // from linux.maintainer or a package.json author with an email. Missing
+    // either fails the Linux build outright rather than degrading.
+    const linux = config_maintainer(loadConfig({ DAYGLANCE_APP_ID: undefined }));
+    expect(linux, 'no maintainer means the Linux job fails').toBeTruthy();
+    expect(linux).toMatch(/<[^@\s]+@[^>\s]+>/);
+  });
+
+  it('package.json declares homepage, the other field fpm requires', () => {
+    const pkg = JSON.parse(require('node:fs').readFileSync('package.json', 'utf-8'));
+    expect(pkg.homepage, 'computePackageUrl reads metadata.homepage first').toBeTruthy();
   });
 });
+
+function config_maintainer(config: Record<string, never>): string | undefined {
+  return (config['linux'] as unknown as { maintainer?: string }).maintainer;
+}
 
 // Desktop-entry metadata. electron-builder writes Name, Exec, Type, Terminal,
 // Icon and StartupWMClass itself, so these assertions cover only the keys it

--- a/electron/builderConfigSchema.test.ts
+++ b/electron/builderConfigSchema.test.ts
@@ -1,0 +1,73 @@
+// Validates electron-builder.config.cjs against electron-builder's OWN JSON
+// schema, the same one it runs at build time.
+//
+// This exists because a config that loads fine in Node can still be rejected by
+// electron-builder, and nothing in the pull-request path would notice: ci.yml
+// runs the Vite web build and never invokes electron-builder, so a malformed
+// config's first contact with reality is the release build.
+//
+// The specific failure that prompted it: artifactName was put inside a target
+// entry. TargetConfiguration is additionalProperties:false with only `target`
+// and `arch`, so the extra key invalidated the entry, and electron-builder
+// reported "configuration.linux.target.0 should be one of these: string" —
+// which points at the array, not at the offending property. The build died in
+// 14 seconds having packaged nothing.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+function loadConfig(env: Record<string, string | undefined>) {
+  const saved = { ...process.env };
+  Object.assign(process.env, env);
+  try {
+    delete require.cache[require.resolve('../electron-builder.config.cjs')];
+    return require('../electron-builder.config.cjs');
+  } finally {
+    for (const k of Object.keys(process.env)) delete process.env[k];
+    Object.assign(process.env, saved);
+  }
+}
+
+/** electron-builder's schema rejects unknown keys it injects itself. */
+function validate(config: Record<string, unknown>) {
+  const Ajv = require('ajv');
+  const schema = require('app-builder-lib/scheme.json');
+  const ajv = new Ajv({ allErrors: true, strict: false, verbose: true });
+  const check = ajv.compile(schema);
+  // Mirrors what electron-builder strips before validating.
+  const { ...rest } = config;
+  const ok = check(rest);
+  return { ok, errors: check.errors ?? [] };
+}
+
+describe('electron-builder.config.cjs matches electron-builder’s schema', () => {
+  it.each([
+    ['direct build', undefined],
+    ['MAS build', 'com.dayglance'],
+  ])('%s validates', (_label, appId) => {
+    const { ok, errors } = validate(loadConfig({ DAYGLANCE_APP_ID: appId }));
+    const detail = errors
+      .map((e: { instancePath?: string; message?: string }) => `${e.instancePath} ${e.message}`)
+      .join('\n');
+    expect(ok, detail).toBe(true);
+  });
+
+  it('target entries carry only target and arch, the keys the schema allows', () => {
+    // TargetConfiguration is additionalProperties:false. Anything else belongs
+    // in a per-target block (appImage, deb) or on the platform.
+    const config = loadConfig({ DAYGLANCE_APP_ID: undefined });
+    for (const platform of ['mac', 'win', 'linux']) {
+      const targets = (config[platform]?.target ?? []) as Record<string, unknown>[];
+      for (const t of targets) {
+        if (typeof t === 'string') continue;
+        expect(Object.keys(t).sort(), `${platform}: ${JSON.stringify(t)}`)
+          .toEqual(expect.arrayContaining(['target']));
+        for (const key of Object.keys(t)) {
+          expect(['target', 'arch'], `${platform}.target has illegal key "${key}"`).toContain(key);
+        }
+      }
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "license": "MIT",
   "version": "4.4.0",
+  "homepage": "https://dayglance.app",
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
Follow-up to #1407 and #1408. Now that ARM users have a working desktop app, this makes it install and look like one.

Two commits: the desktop-entry metadata, then the `deb` target that consumes it.

## 1. The metadata was entirely absent

electron-builder writes `Name`, `Exec`, `Type`, `Terminal`, `Icon` and `StartupWMClass` itself, so only the keys it cannot infer were missing — and it could not infer any of these. Every failure is silent: no build error, nothing visible until a Linux user has the app in front of them.

**`category` → no launcher category.** Unset, so `LinuxTargetHelper` fell back to mapping `mac.category`. `macToLinuxCategory` has no `productivity` entry — it covers graphics-design, developer-tools, education, games, video, utilities, social-networking, finance and music only. The mapping failed, `Categories` was omitted, and the app landed in the launcher's catch-all "Other". Now `Office;Calendar`.

**`icon` → the generic Electron icon.** `computeDesktopIcons` fell through `linux.icon`, `mac.icon` and `config.icon`, then looked for a `public/icons` directory that doesn't exist, and reached `getDefaultFrameworkIcon()`. `resolveIcon` logs `"default Electron icon is used"` whenever that happens, so it has been in the build output since April. `public/` had `icon.icns` and `icon.ico` but no PNG, which is what Linux resolution wants. Now `icon-512.png`.

**`description` → empty tooltip.** Becomes the `.desktop` `Comment`. `getDescription` falls back to `package.json` `description`, which is unset, so the key was dropped.

`Keywords` added for launcher search. `StartupWMClass` deliberately **not** set — electron-builder derives it to match Electron's `app_id`, and a guess would break window-to-launcher association rather than fix it. A test pins that absence.

## 2. The deb, which is the actual answer

An AppImage is a loose executable that never creates a menu entry. The `.deb` unpacks to `/opt`, registers the `.desktop` file built from the metadata above, appears in the launcher with its icon, and removes with `apt remove dayglance`. AppImage stays for distros without dpkg and for people who want portable. Both are built x64 and arm64.

**`maintainer` is what unblocked this, and it isn't optional.** `FpmTarget.checkOptions` runs before any packaging and throws on a missing `homepage` or `maintainer` — so a deb target without both doesn't degrade, it **fails the Linux job**. `homepage` is added to `package.json` (`computePackageUrl` reads `metadata.homepage` first); the maintainer is `GLANCE Apps <hello@glance-apps.com>`, the project's public contact rather than a personal address, since it's readable by anyone who installs a package.

**`artifactName` moved from the platform block onto the AppImage target.** At platform level it would have renamed the deb too, and Debian's convention is `name_version_arch.deb` with arch as `amd64` — not `dayGLANCE-4.4.0-x64.deb`. Target-specific patterns still set `isUserForced`, so x64 keeps the suffix that was the point of #1408.

The workflow globs `dist-app/*.deb` in both the matrix entry and the upload step.

## README

Leads with the deb for apt-based systems, Raspberry Pi OS included, and keeps the AppImage instructions below for the portable case — including AppImageLauncher, a hand-written `.desktop` file, and that `Exec` can't expand `~`. The architecture note now covers both spellings, since `amd64` and `x64` mean the same thing and only one appears on each file.

## Tests

Eleven assertions across both commits. Each verified to fail against the state before its change:

- metadata: 5 fail without category/icon/description/Keywords, `StartupWMClass` correctly green in both
- deb: 2 fail without the target and maintainer

The icon test checks the file **exists** under `buildResources`, not just that a name is set — a missing icon falls back silently rather than failing the build, which is the exact failure mode here.

## Verification

Lint clean, `tsconfig.electron.json` clean, 1880 tests across 125 files green. `version` untouched at 4.4.0.

**The deb has never been built.** fpm runs only on the Linux runner, so this PR's CI job is its first real exercise — check it before retagging. Then install the arm64 deb on a Pi to confirm the menu entry and icon actually land.