### PR TITLE
Freeze the sync-wiring test clock, so the suite stops aging into failure

### DIFF
--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -57,6 +57,27 @@ function createMemoryVault({ rowGet = false } = {}) {
   return vault;
 }
 
+// FROZEN CLOCK. Every fixture below stamps lastModified with a hardcoded date —
+// '2026-06-18T10:00:00.000Z' and friends — chosen to mean "recent, comfortably
+// inside the sync horizon". Against the REAL wall clock that meaning decays:
+// dbEngine classifies a row whose lastModified predates tombstoneCutoff() (the
+// fixed 60-day fence) as 'sync-horizon' aged-out and RELEASES it instead of
+// healing it. So these tests passed until the wall clock walked 60 days past
+// the fixture date and then failed on every run, with no commit to blame — a
+// green CI run at 23:37 UTC and a red one at 01:12 UTC on the same tree.
+//
+// Pinning "now" to 2026-07-10 makes each hardcoded date keep the meaning it was
+// written with, permanently: the '2026-06-18' rows are 22 days old (live), the
+// '2026-07-08' tombstone is 2 days old (live), and the deliberately stale
+// fixtures ('2026-01-05', the completed '2026-04-0x' pair) stay well aged out.
+// Only Date is faked — setTimeout and friends stay real, so nothing that awaits
+// a genuine timer hangs.
+const FIXTURE_NOW = new Date('2026-07-10T12:00:00.000Z');
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(FIXTURE_NOW);
+});
+
 // Hermetic teardown: never let fake timers or the localStorage shim leak into
 // other test files sharing this worker.
 afterEach(() => { vi.useRealTimers(); });
@@ -1030,14 +1051,22 @@ describe('Wave C — file-tier aged-out release: the zombie-drop-vs-vault fight 
   // split-brain behind the observed churn: the file tier removes it, the vault
   // vanish-guard keeps re-fetching it. No getSyncRetentionDays wiring — the
   // classifier derives the horizon from tombstoneCutoff() itself.
-  const HORIZON = Date.now() - 60 * 86400e3;
+  // Read LAZILY, per call. A describe body is evaluated at collection time —
+  // before any beforeEach, so before the frozen clock is installed — and a
+  // Date.now() captured there would pin the REAL wall clock while every fixture
+  // below runs on the fake one. The two horizons then drift apart by however
+  // long ago this file was written, and the zombie-drop model starts dropping
+  // rows the engine still considers live: exactly the fight this test asserts
+  // has ended. Deriving it from tombstoneCutoff() also removes the duplicated
+  // 60-day constant, so the model and the classifier cannot disagree at all.
+  const horizonMs = () => tombstoneCutoff().getTime();
   function makeZombieDropDevice(name, vault, initial) {
     let data = clone(initial);
     let nativeKey = null;
     const zombie = (t) => {
       if (t.completed === true) return true; // completed rows the app aged out
       const lm = Date.parse(t.lastModified || '');
-      return Number.isFinite(lm) && lm < HORIZON; // older than the sync horizon
+      return Number.isFinite(lm) && lm < horizonMs(); // older than the sync horizon
     };
     const engine = createDbEngine({
       vaultClient: vault,


### PR DESCRIPTION
## What happened

CI went red on `main` at 341887b — the merge of #1397, which changed nothing but Portuguese locale JSON, a language picker and their tests. Four failures, all in `src/sync/dbEngineWiring.test.js`, a file that PR touched in no way.

#1397 did not cause it. The same four tests fail on d7e40ef, the parent commit, run in isolation with nothing merged — and d7e40ef's own CI was **green** 95 minutes earlier.

```
d7e40ef  23:37 UTC Aug 17  ✅ green
341887b  01:12 UTC Aug 18  ❌ 4 failed | 1935 passed
```

Same tests, opposite results, and the tree in between only gained translations. What changed between those two runs was the date.

## Root cause

The fixtures stamp `lastModified` as `'2026-06-18T10:00:00.000Z'`, chosen to mean *recent, comfortably inside the sync horizon*. `dbEngine` classifies any row older than `tombstoneCutoff()` — the day-floored fixed 60-day fence — as `'sync-horizon'` aged-out, and **releases** it instead of healing it. That is what the four tests assert against.

Sixty days after 2026-06-18 is 2026-08-17. Because the cutoff floors to the UTC day, it stepped past the fixtures at midnight UTC:

| run date | `tombstoneCutoff()` | fixture at 2026-06-18T10:00Z |
|---|---|---|
| 2026-08-17 | 2026-06-18T00:00Z | newer → live ✅ |
| 2026-08-18 | 2026-06-19T00:00Z | older → aged out ❌ |

The 23:37 run landed on the last hour the fixtures were valid. Every run since fails, and would have failed on any commit, or none.

## The fix

Pin the file's clock to 2026-07-10 so each hardcoded date keeps the meaning it was written with, permanently — `'2026-06-18'` rows 22 days old and live, the `'2026-07-08'` tombstone 2 days old and live, and the deliberately stale fixtures (`'2026-01-05'`, the completed `'2026-04-0x'` pair) still well aged out. Only `Date` is faked, via `toFake: ['Date']`, so `setTimeout` and the existing debounce tests that depend on real timers are untouched.

Freezing the clock alone left one test still failing at future dates. `Wave C` captured `Date.now()` in its **describe body** — evaluated at collection time, before any `beforeEach`, so it escaped the frozen clock entirely. Its zombie-drop model ran on the real wall clock while its fixtures ran on the fake one, and the gap between them grew by a day per day. It now derives the horizon lazily from `tombstoneCutoff()`, which is the source the classifier itself uses, so the model and the classifier can no longer disagree — and the file's duplicate copy of the 60-day constant goes away with it.

## Verification

The file was run against a shifted system clock at a spread of dates:

| simulated run date | before | after |
|---|---|---|
| 2026-08-17 23:37Z | 30/30 ✅ | 30/30 ✅ |
| 2026-08-18 01:12Z | 4 failed ❌ | 30/30 ✅ |
| 2026-12-25 | 4 failed ❌ | 30/30 ✅ |
| 2028-03-01 | 4 failed ❌ | 30/30 ✅ |
| 2031-11-09 | 4 failed ❌ | 30/30 ✅ |

Full suite on this branch: **1939 passed across 127 files** — the same counts the red CI run reported, now entirely green. `npm run lint` clean.

The rest of the suite was swept the same way at 2026-09-20 and 2027-02-14 and stayed 1939/1939, so no sibling time bomb is waiting behind this one.

## Note

Only the test fixtures were wrong here; no production sync behavior changed. Aging a row out at the 60-day fence is correct — the test was simply asserting on rows that had quietly crossed it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhfqeK38ohHfYcuXQTf42T)_