### PR TITLE
Stop recurring work falling through the project surfaces that measure it

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3668,6 +3668,11 @@ const DayPlanner = () => {
         assignedUserSyncIds: mobileEditingTask.assignedUserSyncIds ?? existingTask?.assignedUserSyncIds,
         lastModified: new Date().toISOString()
       };
+      // The original is gone, replaced by a template under a NEW id. Tombstone
+      // it or cloud sync re-adds it from a device that still has it, leaving a
+      // one-off sitting next to the series it became. The mirror-image branch
+      // (recurring -> regular) already tombstones the template it drops.
+      recordDeletedTaskTombstone(taskId);
       setTasks(prev => prev.filter(t => t.id !== taskId));
       setUnscheduledTasks(prev => prev.filter(t => t.id !== taskId));
       setRecurringTasks(prev => [...prev, template]);

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -394,7 +394,7 @@ const WeeklyReviewModal = () => {
                 const weekCompleted = weekTasks.filter(t => t.completed).length;
                 const weekTotal = weekTasks.length;
                 const overallProgress = calculateProjectProgress(p.id, allTasksCombined);
-                const stalled = isProjectStalled(p.id, allTasksCombined, p);
+                const stalled = isProjectStalled(p.id, allTasksCombined, p, recurringTasks);
                 return {
                   id: p.id,
                   title: p.title,

--- a/src/components/goals/GoalCard.jsx
+++ b/src/components/goals/GoalCard.jsx
@@ -26,7 +26,7 @@ import GoalProgress from './GoalProgress.jsx';
 const GoalCard = forwardRef(
   ({ goal, projects, onEdit, onNewProject }, ref) => {
     const {
-      tasks, unscheduledTasks,
+      tasks, unscheduledTasks, recurringTasks,
       darkMode,
       borderClass, textPrimary, textSecondary, hoverBg,
     } = useDayPlannerCtx();
@@ -57,7 +57,7 @@ const GoalCard = forwardRef(
     // Caution: goal is overdue or has at least one stalled child project
     // Per-goal opt-out: hideStalled suppresses the stalled contribution to the
     // caution indicator (overdue-based caution is unaffected).
-    const hasStalledProject = !goal.hideStalled && projects.some(p => isProjectStalled(p.id, allTasks, p));
+    const hasStalledProject = !goal.hideStalled && projects.some(p => isProjectStalled(p.id, allTasks, p, recurringTasks));
     const showCaution = isOverdue || hasStalledProject;
     // All non-archived projects complete → offer one-click completion
     const nonArchivedProjects = projects.filter(p => p.status !== 'archived');

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -607,7 +607,7 @@ export const FormOverlay = ({ children, onClose, mobile, cardBg }) => {
 // ─── Goal mini card (carousel side slots) ────────────────────────────────────
 
 const GoalMiniCard = ({ goal, onClick }) => {
-  const { darkMode, textPrimary, textSecondary, tasks, unscheduledTasks } = useDayPlannerCtx();
+  const { darkMode, textPrimary, textSecondary, tasks, unscheduledTasks, recurringTasks } = useDayPlannerCtx();
   const { projects, updateGoal, isVisibleForUser } = useFeaturesCtx();
   const { t } = useTranslation();
   const today = new Date();
@@ -631,8 +631,8 @@ const GoalMiniCard = ({ goal, onClick }) => {
   const allTasks = useMemo(() => [...tasks, ...unscheduledTasks].filter(isVisibleForUser), [tasks, unscheduledTasks, isVisibleForUser]);
   const childProjects = useMemo(() => projects.filter(p => p.goalId === goal.id && p.status !== 'archived'), [projects, goal.id]);
   const hasStalledProject = useMemo(
-    () => !goal.hideStalled && childProjects.some(p => isProjectStalled(p.id, allTasks, p)),
-    [childProjects, allTasks, goal.hideStalled]
+    () => !goal.hideStalled && childProjects.some(p => isProjectStalled(p.id, allTasks, p, recurringTasks)),
+    [childProjects, allTasks, recurringTasks, goal.hideStalled]
   );
   const showCaution = isOverdue || hasStalledProject;
   const goalProgress = useMemo(() => calculateGoalProgress(goal.id, childProjects, allTasks), [goal.id, childProjects, allTasks]);
@@ -1257,7 +1257,7 @@ const MobileDashboard = ({
   onNewProject,
   isActive = false,
 }) => {
-  const { darkMode, textPrimary, textSecondary, hoverBg, cardBg, borderClass, tasks: scheduledTasks, unscheduledTasks } = useDayPlannerCtx();
+  const { darkMode, textPrimary, textSecondary, hoverBg, cardBg, borderClass, tasks: scheduledTasks, unscheduledTasks, recurringTasks } = useDayPlannerCtx();
   const { updateGoal, moveProject, goalsDashboardFocusId, setGoalsDashboardFocusId, isVisibleForUser } = useFeaturesCtx();
   const { t } = useTranslation();
 
@@ -1485,7 +1485,7 @@ const MobileDashboard = ({
                   const nonArchivedProjects = activeProjects.filter(p => p.goalId === goal.id);
                   const isCompleted = goal.status === 'completed';
                   const allProjectsDone = nonArchivedProjects.length > 0 && goalProgress >= 1;
-                  const hasStalledProject = !goal.hideStalled && nonArchivedProjects.some(p => isProjectStalled(p.id, allTasks, p));
+                  const hasStalledProject = !goal.hideStalled && nonArchivedProjects.some(p => isProjectStalled(p.id, allTasks, p, recurringTasks));
                   let daysLabel = null, daysUrgent = false, isOverdue = false;
                   if (goal.targetDate) {
                     const today = new Date(); today.setHours(0, 0, 0, 0);

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState, useRef } from 'react';
+import React, { forwardRef, useState, useRef, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import ConfirmDialog from '../ConfirmDialog.jsx';
 import {
@@ -119,7 +119,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
   const progress = calculateProjectProgress(project.id, allTasks);
   const hasHGSession = !!getActiveHGInstance(project, currentTimeMinutes);
   // Per-goal opt-out: a goal with hideStalled suppresses the badge on its projects.
-  const stalled = !!project.goalId && !parentGoal?.hideStalled && !hasHGSession && isProjectStalled(project.id, allTasks, project);
+  const stalled = !!project.goalId && !parentGoal?.hideStalled && !hasHGSession && isProjectStalled(project.id, allTasks, project, recurringTasks);
 
   // All project tasks: unscheduled (in array order) then scheduled (by date), completed last
   const projectUnscheduled = unscheduledTasks.filter(t => t.projectId === project.id && !t.archived && isVisibleForUser(t));
@@ -130,7 +130,19 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
   // flood the list). Not counted in totals/progress: a series never completes.
   // Ended series (past endDate / maxOccurrences exhausted) are hidden so
   // finished templates don't become permanent clutter.
-  const projectRecurring = recurringTasks.filter(t => t.projectId === project.id && !t.archived && isVisibleForUser(t) && getNextOccurrence(t) !== null);
+  // Memoised: this card re-renders every minute (currentTimeMinutes), and
+  // getNextOccurrence walks the series. ProjectPlanner already memoises the
+  // same filter.
+  const projectRecurring = useMemo(
+    () => recurringTasks.filter(t => t.projectId === project.id && !t.archived && isVisibleForUser(t) && getNextOccurrence(t) !== null),
+    [recurringTasks, project.id, isVisibleForUser],
+  );
+  // A project whose only work is a recurring series has nothing countable:
+  // series are excluded from totals and progress on purpose (a series never
+  // completes), so the card claimed "0/0 tasks" at a permanent 0% while the
+  // series list underneath showed real work. Show neither rather than report
+  // no progress. A genuinely empty project is unchanged.
+  const nothingToMeasure = totalCount === 0 && projectRecurring.length > 0;
   const allProjectDisplayTasks = [
     ...projectScheduled.filter(t => !t.completed),
     ...projectUnscheduled.filter(t => !t.completed),
@@ -484,14 +496,14 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
         </div>
 
         {/* Task count — hidden by the standalone-card eyeball toggle */}
-        {!detailsHidden && (
+        {!detailsHidden && !nothingToMeasure && (
           <span className={`text-xs ${textSecondary}`}>
             {completedCount}/{totalCount} task{totalCount !== 1 ? 's' : ''}
           </span>
         )}
 
         {/* Progress bar — hidden by the standalone-card eyeball toggle */}
-        {!detailsHidden && <ProjectProgress progress={progress} compact />}
+        {!detailsHidden && !nothingToMeasure && <ProjectProgress progress={progress} compact />}
 
         {/* Unscheduled task list */}
         {displayableTasks.length > 0 && (

--- a/src/utils/mcpReadModel.js
+++ b/src/utils/mcpReadModel.js
@@ -71,6 +71,10 @@ export function expandRecurringForDate(recurringTasks, date) {
         completed: (template.completedDates || []).includes(dateStr),
         isAllDay: exception?.isAllDay ?? template.isAllDay ?? false,
         assignedUserSyncIds: exception?.assignedUserSyncIds ?? template.assignedUserSyncIds,
+        // Series-level, like assignment: the template owns it and every
+        // instance inherits it, so toBlock can emit project_id for a
+        // recurring block the same as for a concrete task.
+        projectId: template.projectId,
         date: dateStr,
         isRecurring: true,
       });

--- a/src/utils/mcpReadModel.test.js
+++ b/src/utils/mcpReadModel.test.js
@@ -85,6 +85,14 @@ describe('expandRecurringForDate', () => {
     expect(expandRecurringForDate([], '2026-08-10')).toEqual([]);
     expect(expandRecurringForDate(undefined, '2026-08-10')).toEqual([]);
   });
+
+  it('inherits the project from the template, so reads report the association', () => {
+    const inProject = { ...template, projectId: 'p1' };
+    expect(expandRecurringForDate([inProject], '2026-08-10')[0].projectId).toBe('p1');
+    expect(toBlock(expandRecurringForDate([inProject], '2026-08-10')[0]).project_id).toBe('p1');
+    // No project: the wire block omits the key rather than sending null.
+    expect(toBlock(expandRecurringForDate([template], '2026-08-10')[0])).not.toHaveProperty('project_id');
+  });
 });
 
 describe('buildDayBlocks', () => {

--- a/src/utils/projectProgress.js
+++ b/src/utils/projectProgress.js
@@ -54,14 +54,18 @@ export function getProjectTotalDuration(projectId, allTasks) {
  * Returns whether a project is stalled:
  *   - project is at least 7 days old (grace period for new projects), AND
  *   - has at least one incomplete task, AND
- *   - no task has completedAt within the last 7 days
+ *   - no task has completedAt within the last 7 days, AND
+ *   - no recurring series of the project was completed in the last 7 days
  *
  * @param {string} projectId
  * @param {Array} allTasks
  * @param {Object} project - the project object (needs createdAt)
+ * @param {Array} [recurringTasks] - templates; their completedDates count as
+ *   activity. Optional so callers with no access to them keep the old
+ *   behaviour, which can only over-report stalling, never under-report it.
  * @returns {boolean}
  */
-export function isProjectStalled(projectId, allTasks, project) {
+export function isProjectStalled(projectId, allTasks, project, recurringTasks = []) {
   // Grace period: don't flag projects created within the last 7 days
   if (project?.createdAt) {
     const ageMs = Date.now() - new Date(project.createdAt).getTime();
@@ -82,6 +86,19 @@ export function isProjectStalled(projectId, allTasks, project) {
   const hasRecentCompletion = projectTasks.some(
     t => t.completed && t.completedAt && t.completedAt >= cutoff
   );
+  if (hasRecentCompletion) return false;
 
-  return !hasRecentCompletion;
+  // A project whose upkeep is a recurring series has no completed rows in
+  // `allTasks` to find — completions live as dates on the template — so
+  // ticking off a daily task every day still read as stalled. Recurring
+  // activity only ever CLEARS the flag: a series is never counted as
+  // outstanding work, so this can suppress a false positive but never raise a
+  // new one.
+  const hasRecentRecurringCompletion = recurringTasks.some(
+    t => t.projectId === projectId
+      && !t.archived
+      && (t.completedDates || []).some(d => d >= cutoff)
+  );
+
+  return !hasRecentRecurringCompletion;
 }

--- a/src/utils/projectProgress.test.js
+++ b/src/utils/projectProgress.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { calculateProjectProgress, getProjectTotalDuration, isProjectStalled } from './projectProgress.js';
+
+// Frozen: isProjectStalled reads Date.now() for both the grace period and the
+// 7-day activity window.
+const NOW = new Date('2026-08-18T12:00:00Z');
+beforeAll(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(NOW);
+});
+afterAll(() => vi.useRealTimers());
+
+const OLD_PROJECT = { id: 'p1', createdAt: '2026-01-01T00:00:00Z' };
+const task = (over = {}) => ({ id: 't', projectId: 'p1', duration: 30, completed: false, ...over });
+
+describe('calculateProjectProgress', () => {
+  it('weights by duration, not task count', () => {
+    // 120 done out of 150 total: a count-based average would say 50%.
+    const tasks = [task({ id: 'a', duration: 120, completed: true }), task({ id: 'b', duration: 30 })];
+    expect(calculateProjectProgress('p1', tasks)).toBeCloseTo(0.8);
+  });
+
+  it('falls back to 30 minutes for tasks with no duration', () => {
+    const tasks = [task({ id: 'a', duration: undefined, completed: true }), task({ id: 'b', duration: 30 })];
+    expect(calculateProjectProgress('p1', tasks)).toBeCloseTo(0.5);
+  });
+
+  it('ignores archived tasks and other projects, and is 0 with nothing to measure', () => {
+    expect(calculateProjectProgress('p1', [task({ archived: true, completed: true })])).toBe(0);
+    expect(calculateProjectProgress('p1', [task({ projectId: 'p2', completed: true })])).toBe(0);
+    expect(calculateProjectProgress('p1', [])).toBe(0);
+  });
+
+  it('reports total duration for goal weighting', () => {
+    expect(getProjectTotalDuration('p1', [task({ id: 'a', duration: 45 }), task({ id: 'b' })])).toBe(75);
+  });
+});
+
+describe('isProjectStalled', () => {
+  it('spares a project inside its 7-day grace period', () => {
+    const fresh = { id: 'p1', createdAt: '2026-08-15T00:00:00Z' };
+    expect(isProjectStalled('p1', [task()], fresh)).toBe(false);
+  });
+
+  it('is not stalled with nothing outstanding', () => {
+    expect(isProjectStalled('p1', [task({ completed: true })], OLD_PROJECT)).toBe(false);
+    expect(isProjectStalled('p1', [], OLD_PROJECT)).toBe(false);
+  });
+
+  it('is stalled with outstanding work and no completion in the last 7 days', () => {
+    expect(isProjectStalled('p1', [task(), task({ id: 'old', completed: true, completedAt: '2026-07-01' })], OLD_PROJECT))
+      .toBe(true);
+  });
+
+  it('is not stalled when a regular task completed inside the window', () => {
+    expect(isProjectStalled('p1', [task(), task({ id: 'r', completed: true, completedAt: '2026-08-17' })], OLD_PROJECT))
+      .toBe(false);
+  });
+
+  // The false positive: upkeep done through a recurring series leaves no
+  // completed row in allTasks, so the project looked abandoned.
+  it('counts a recent recurring completion as activity', () => {
+    const series = [{ id: 's1', projectId: 'p1', completedDates: ['2026-08-17'] }];
+    expect(isProjectStalled('p1', [task()], OLD_PROJECT, series)).toBe(false);
+  });
+
+  it('does not count a stale or foreign or archived series', () => {
+    const stale = [{ id: 's1', projectId: 'p1', completedDates: ['2026-07-01'] }];
+    const foreign = [{ id: 's2', projectId: 'p2', completedDates: ['2026-08-17'] }];
+    const archived = [{ id: 's3', projectId: 'p1', archived: true, completedDates: ['2026-08-17'] }];
+    for (const series of [stale, foreign, archived]) {
+      expect(isProjectStalled('p1', [task()], OLD_PROJECT, series)).toBe(true);
+    }
+  });
+
+  // Recurring data may only clear the flag, never raise it: a project with no
+  // outstanding regular work stays unstalled whatever the series says.
+  it('never introduces a stall that was not already there', () => {
+    const series = [{ id: 's1', projectId: 'p1', completedDates: [] }];
+    expect(isProjectStalled('p1', [], OLD_PROJECT, series)).toBe(false);
+    expect(isProjectStalled('p1', [task({ completed: true })], OLD_PROJECT, series)).toBe(false);
+  });
+
+  it('omitting the argument keeps the previous behaviour', () => {
+    expect(isProjectStalled('p1', [task()], OLD_PROJECT)).toBe(true);
+  });
+});

--- a/src/utils/recurrenceEngine.js
+++ b/src/utils/recurrenceEngine.js
@@ -6,8 +6,13 @@ import { dateToString } from './taskUtils.js';
  *
  * Optimised with fast-forward logic so it doesn't iterate every day from the
  * start date when the range is far in the future.
+ *
+ * `maxResults` stops the walk once that many occurrences are in hand. Callers
+ * that only need the next one (getNextOccurrence, and through it the project
+ * views) would otherwise materialise the whole window to read element 0 — a
+ * daily series over two years built 732 dates to return one.
  */
-export const getOccurrencesInRange = (template, rangeStartStr, rangeEndStr) => {
+export const getOccurrencesInRange = (template, rangeStartStr, rangeEndStr, maxResults = Infinity) => {
   const rec = template.recurrence;
   if (!rec) return [];
   const results = [];
@@ -25,7 +30,7 @@ export const getOccurrencesInRange = (template, rangeStartStr, rangeEndStr) => {
     if (template.exceptions && (template.exceptions[ds]?.deleted || template.exceptions[ds]?.skipped)) { count++; return true; }
     if (d >= rangeStart && d <= rangeEnd) results.push(ds);
     count++;
-    return true;
+    return results.length < maxResults;
   };
 
   if (rec.type === 'daily') {
@@ -38,7 +43,7 @@ export const getOccurrencesInRange = (template, rangeStartStr, rangeEndStr) => {
     }
     while (cursor <= rangeEnd && count < maxOcc) {
       if (endDate && cursor > endDate) break;
-      addIfInRange(cursor);
+      if (!addIfInRange(cursor)) break;
       cursor.setDate(cursor.getDate() + 1);
     }
   } else if (rec.type === 'weekly' || rec.type === 'biweekly') {
@@ -62,14 +67,15 @@ export const getOccurrencesInRange = (template, rangeStartStr, rangeEndStr) => {
       }
     }
     const cursor = new Date(weekStart);
-    while (cursor <= rangeEnd && count < maxOcc) {
+    let stop = false;
+    while (!stop && cursor <= rangeEnd && count < maxOcc) {
       for (const dow of days.sort((a, b) => a - b)) {
         const d = new Date(cursor);
         d.setDate(d.getDate() + dow);
         if (d < startDate) continue;
-        if (endDate && d > endDate) break;
-        if (d > rangeEnd) break;
-        if (!addIfInRange(d)) break;
+        if (endDate && d > endDate) { stop = true; break; }
+        if (d > rangeEnd) { stop = true; break; }
+        if (!addIfInRange(d)) { stop = true; break; }
       }
       cursor.setDate(cursor.getDate() + 7 * step);
     }
@@ -117,17 +123,24 @@ export const getOccurrencesInRange = (template, rangeStartStr, rangeEndStr) => {
   return results;
 };
 
+// How far ahead getNextOccurrence is willing to look. Only a backstop against
+// a pathological search: every real termination comes from the series itself
+// (endDate, maxOccurrences) or from finding the occurrence. It was two years,
+// which quietly reported "no next occurrence" for a series starting further
+// out than that — and callers read that as "ended".
+const NEXT_OCCURRENCE_HORIZON_YEARS = 10;
+
 /**
  * Return the next occurrence date string (YYYY-MM-DD) of a recurring task
- * on or after today, or null if there are no future occurrences within 2 years.
+ * on or after today, or null if the series has no future occurrences.
  */
 export const getNextOccurrence = (template) => {
   const today = dateToString(new Date());
   const futureEnd = new Date();
-  futureEnd.setFullYear(futureEnd.getFullYear() + 2);
+  futureEnd.setFullYear(futureEnd.getFullYear() + NEXT_OCCURRENCE_HORIZON_YEARS);
   const futureEndStr = dateToString(futureEnd);
-  const occurrences = getOccurrencesInRange(template, today, futureEndStr);
-  return occurrences.length > 0 ? occurrences[0] : null;
+  const [next] = getOccurrencesInRange(template, today, futureEndStr, 1);
+  return next ?? null;
 };
 
 /**

--- a/src/utils/recurrenceEngine.test.js
+++ b/src/utils/recurrenceEngine.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { getOccurrencesInRange, getNextOccurrence } from './recurrenceEngine.js';
+
+// The clock is frozen for the whole file. getNextOccurrence reads "today", and
+// a suite that drifts with the calendar ages into failure — which is exactly
+// how the sync-wiring tests went red on a Tuesday morning.
+const NOW = new Date('2026-08-18T12:00:00');
+
+beforeAll(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(NOW);
+});
+afterAll(() => vi.useRealTimers());
+
+const template = (recurrence, extra = {}) => ({ id: 't', recurrence, exceptions: {}, ...extra });
+
+describe('getOccurrencesInRange', () => {
+  it('walks a daily series across the whole window', () => {
+    const t = template({ type: 'daily', startDate: '2026-08-01' });
+    expect(getOccurrencesInRange(t, '2026-08-10', '2026-08-13'))
+      .toEqual(['2026-08-10', '2026-08-11', '2026-08-12', '2026-08-13']);
+  });
+
+  it('hits every selected weekday of a multi-day weekly series', () => {
+    // Mon/Wed/Fri. This is the shape the picker in #1404 will produce.
+    const t = template({ type: 'weekly', daysOfWeek: [1, 3, 5], startDate: '2026-08-03' });
+    expect(getOccurrencesInRange(t, '2026-08-03', '2026-08-09'))
+      .toEqual(['2026-08-03', '2026-08-05', '2026-08-07']);
+  });
+
+  it('skips alternate weeks for biweekly', () => {
+    const t = template({ type: 'biweekly', daysOfWeek: [1], startDate: '2026-08-03' });
+    expect(getOccurrencesInRange(t, '2026-08-03', '2026-09-01'))
+      .toEqual(['2026-08-03', '2026-08-17', '2026-08-31']);
+  });
+
+  it('clamps a monthly day-of-month to short months', () => {
+    const t = template({ type: 'monthly', monthDay: 31, startDate: '2026-01-31' });
+    expect(getOccurrencesInRange(t, '2026-02-01', '2026-02-28')).toEqual(['2026-02-28']);
+  });
+
+  it('honours endDate and maxOccurrences', () => {
+    const ends = template({ type: 'daily', startDate: '2026-08-10', endDate: '2026-08-12' });
+    expect(getOccurrencesInRange(ends, '2026-08-10', '2026-08-20'))
+      .toEqual(['2026-08-10', '2026-08-11', '2026-08-12']);
+
+    const capped = template({ type: 'daily', startDate: '2026-08-10', maxOccurrences: 2 });
+    expect(getOccurrencesInRange(capped, '2026-08-10', '2026-08-20'))
+      .toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('omits dates the template marks deleted or skipped, without shifting the rest', () => {
+    const t = template(
+      { type: 'daily', startDate: '2026-08-10' },
+      { exceptions: { '2026-08-11': { deleted: true }, '2026-08-12': { skipped: true } } },
+    );
+    expect(getOccurrencesInRange(t, '2026-08-10', '2026-08-13'))
+      .toEqual(['2026-08-10', '2026-08-13']);
+  });
+
+  it('returns nothing for a template with no recurrence', () => {
+    expect(getOccurrencesInRange({ id: 'x' }, '2026-08-10', '2026-08-20')).toEqual([]);
+  });
+});
+
+describe('maxResults', () => {
+  // The guarantee the early exit rests on: stopping early must not change WHICH
+  // occurrence comes first, only how much work was done to find it.
+  const cases = [
+    ['daily', { type: 'daily', startDate: '2026-01-01' }],
+    ['weekly, one day', { type: 'weekly', daysOfWeek: [3], startDate: '2026-01-01' }],
+    ['weekly, three days', { type: 'weekly', daysOfWeek: [1, 3, 5], startDate: '2026-01-01' }],
+    ['biweekly', { type: 'biweekly', daysOfWeek: [2], startDate: '2026-01-01' }],
+    ['monthly by date', { type: 'monthly', monthDay: 15, startDate: '2026-01-15' }],
+    ['monthly by weekday', { type: 'monthly', monthWeekday: { week: 2, day: 1 }, startDate: '2026-01-01' }],
+    ['yearly', { type: 'yearly', startDate: '2026-03-01' }],
+  ];
+
+  it.each(cases)('%s: capped result is the prefix of the uncapped one', (_name, rec) => {
+    const t = template(rec);
+    const all = getOccurrencesInRange(t, '2026-08-18', '2028-08-18');
+    expect(getOccurrencesInRange(t, '2026-08-18', '2028-08-18', 1)).toEqual(all.slice(0, 1));
+    expect(getOccurrencesInRange(t, '2026-08-18', '2028-08-18', 3)).toEqual(all.slice(0, 3));
+  });
+
+  it('returns everything available when the cap exceeds the series', () => {
+    const t = template({ type: 'daily', startDate: '2026-08-10', endDate: '2026-08-12' });
+    expect(getOccurrencesInRange(t, '2026-08-10', '2026-08-20', 99))
+      .toEqual(['2026-08-10', '2026-08-11', '2026-08-12']);
+  });
+
+  it('defaults to unbounded, so existing three-argument callers are unchanged', () => {
+    const t = template({ type: 'daily', startDate: '2026-08-10' });
+    expect(getOccurrencesInRange(t, '2026-08-10', '2026-08-20')).toHaveLength(11);
+  });
+});
+
+describe('getNextOccurrence', () => {
+  it('returns today when the series occurs today', () => {
+    expect(getNextOccurrence(template({ type: 'daily', startDate: '2026-01-01' })))
+      .toBe('2026-08-18');
+  });
+
+  it('skips past a date the template deleted', () => {
+    const t = template(
+      { type: 'daily', startDate: '2026-01-01' },
+      { exceptions: { '2026-08-18': { deleted: true } } },
+    );
+    expect(getNextOccurrence(t)).toBe('2026-08-19');
+  });
+
+  it('is null once the series has ended', () => {
+    expect(getNextOccurrence(template({ type: 'daily', startDate: '2026-01-01', endDate: '2026-08-01' })))
+      .toBeNull();
+    expect(getNextOccurrence(template({ type: 'daily', startDate: '2026-01-01', maxOccurrences: 5 })))
+      .toBeNull();
+  });
+
+  // The project views treat null as "ended" and hide the series, so a start
+  // date beyond the old two-year horizon silently vanished from its project.
+  it('finds a series that starts more than two years out', () => {
+    expect(getNextOccurrence(template({ type: 'weekly', daysOfWeek: [1], startDate: '2029-06-01' })))
+      .toBe('2029-06-04');
+  });
+});


### PR DESCRIPTION
The follow-ups I held back from #1406 so they wouldn't gate an external contributor's PR. All six sit in the same seam: a recurring series meets code that counts, reports or searches project work, and the series isn't there.

## What changed

**MCP reads reported no project.** `expandRecurringForDate` built instances from an explicit field list that omitted `projectId`, so `toBlock` never emitted `project_id`. An MCP read of a day showed recurring work as unaffiliated. `toBlock` already handled the field, so carrying it on the instance was enough.

**Converting a task to recurring left no tombstone.** The original is replaced by a template under a new id. Without a tombstone, cloud sync re-adds it from a device that still has it, leaving a one-off beside the series it became. The mirror-image branch (recurring → regular) already tombstoned; this one didn't.

**Projects kept alive by a series read as stalled.** Completions live as dates on the template, not as completed rows in `allTasks`, so a project where you tick off a daily task every day still tripped the badge. `isProjectStalled` takes an optional `recurringTasks` and treats a completion inside the 7-day window as activity. Deliberately one-directional: recurring data can only *clear* the flag, never raise one, since a series is still never counted as outstanding work. Callers that don't pass it keep today's behaviour, which can only over-report stalling.

**Projects made only of series claimed "0/0 tasks" at 0%.** Series are excluded from totals and progress on purpose, which left the card reporting no progress directly above a list of real work. The card now shows neither when there's nothing measurable. Genuinely empty projects are unchanged — see the open question below.

**`getNextOccurrence` built the whole window to read element 0.** 732 dates for a daily series, and `ProjectCard` called it unmemoised on a card that re-renders every minute via `currentTimeMinutes`. `getOccurrencesInRange` now takes a `maxResults` cap, the weekly walk ends the outer loop instead of only the inner day loop, and the filter is memoised the way `ProjectPlanner`'s already was.

```
daily       0.7070 ms/call  ->  0.0073 ms/call
weekly x3   0.4820 ms/call  ->  0.0085 ms/call
```

**Its two-year horizon hid future series.** A series starting more than 24 months out returned `null`, which the project views read as "ended" and filtered out. With the early exit a ten-year horizon costs nothing. Every real termination already comes from the series itself (`endDate`, `maxOccurrences`) or from finding the occurrence; the horizon is only a backstop.

## Tests

First test files for `recurrenceEngine` and `projectProgress`. 33 new tests, suite goes 1939 → 1972.

Both freeze the clock. `getNextOccurrence` and `isProjectStalled` read today, and a suite that drifts with the calendar ages into failure — which is exactly how the sync-wiring tests went red this morning.

The `maxResults` cases assert the capped result is a **prefix** of the uncapped one across all seven recurrence shapes, so stopping early cannot change *which* occurrence comes first. Checked they have teeth: the 8 new-behaviour tests fail against the pre-change engine, while the 12 behavioural tests pass against both, which is the evidence that existing behaviour is untouched.

## Verification

- `eslint src --max-warnings 0` clean
- 129 files / 1972 tests passing
- `npm run audit` clean, `npm run build` succeeds

## One open question

I scoped the progress-bar fix narrowly: the meter is suppressed only when a project has no countable tasks **and** has recurring series. A project that is simply empty still shows a 0% bar, as today.

The broader rule — hide the meter whenever there's nothing to measure — is arguably cleaner and one condition simpler, but it changes how every empty project looks, which is beyond what this PR set out to fix. Happy to widen it if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGA3jAvMnF9EFbgU3hRA8S

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGA3jAvMnF9EFbgU3hRA8S)_