### PR TITLE
Let project progress say "not measurable" instead of guessing zero

### DIFF
--- a/src/ai-prompts.js
+++ b/src/ai-prompts.js
@@ -408,7 +408,8 @@ export function weeklySummaryUserPrompt(data) {
     const stalledProjects = projectStats.filter(p => p.stalled);
     if (activeProjects.length > 0) {
       lines.push(`Project activity this week: ${activeProjects.map(p =>
-        `"${p.title}" — ${p.weekCompleted}/${p.weekTotal} tasks completed (${p.overallProgressPct}% overall)`
+        `"${p.title}" — ${p.weekCompleted}/${p.weekTotal} tasks completed${
+          p.overallProgressPct === null ? '' : ` (${p.overallProgressPct}% overall)`}`
       ).join('; ')}.`);
     }
     if (stalledProjects.length > 0) {

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -290,10 +290,13 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
           const childProjects = projects
             .filter(p => p.goalId === g.id && p.status !== 'archived')
             .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
-          const projectBars = childProjects.map(p => ({
-            id: p.id,
-            progress: Math.round(calculateProjectProgress(p.id, allTasksCombined) * 100),
-          }));
+          // One segment per project that has a measurement. A project with
+          // nothing to measure is dropped rather than drawn as an empty
+          // segment, which read as "this project has made no progress".
+          const projectBars = childProjects
+            .map(p => ({ id: p.id, progress: calculateProjectProgress(p.id, allTasksCombined) }))
+            .filter(bar => bar.progress !== null)
+            .map(bar => ({ ...bar, progress: Math.round(bar.progress * 100) }));
           return { ...g, progressPct, daysLeft, projectBars };
         }).sort((a, b) => {
           if (a.daysLeft === null && b.daysLeft === null) return 0;

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -207,10 +207,13 @@ const MobileGlanceSection = () => {
           const childProjects = projects
             .filter(p => p.goalId === g.id && p.status !== 'archived')
             .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
-          const projectBars = childProjects.map(p => ({
-            id: p.id,
-            progress: Math.round(calculateProjectProgress(p.id, allTasksCombined) * 100),
-          }));
+          // One segment per project that has a measurement. A project with
+          // nothing to measure is dropped rather than drawn as an empty
+          // segment, which read as "this project has made no progress".
+          const projectBars = childProjects
+            .map(p => ({ id: p.id, progress: calculateProjectProgress(p.id, allTasksCombined) }))
+            .filter(bar => bar.progress !== null)
+            .map(bar => ({ ...bar, progress: Math.round(bar.progress * 100) }));
           return { ...g, progressPct, daysLeft, projectBars };
         }).sort((a, b) => {
           if (a.daysLeft === null && b.daysLeft === null) return 0;

--- a/src/components/WeeklyReviewModal.jsx
+++ b/src/components/WeeklyReviewModal.jsx
@@ -400,7 +400,7 @@ const WeeklyReviewModal = () => {
                   title: p.title,
                   weekCompleted,
                   weekTotal,
-                  overallProgressPct: Math.round(overallProgress * 100),
+                  overallProgressPct: overallProgress === null ? null : Math.round(overallProgress * 100),
                   stalled,
                 };
               })

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -137,12 +137,15 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
     () => recurringTasks.filter(t => t.projectId === project.id && !t.archived && isVisibleForUser(t) && getNextOccurrence(t) !== null),
     [recurringTasks, project.id, isVisibleForUser],
   );
-  // A project whose only work is a recurring series has nothing countable:
-  // series are excluded from totals and progress on purpose (a series never
-  // completes), so the card claimed "0/0 tasks" at a permanent 0% while the
-  // series list underneath showed real work. Show neither rather than report
-  // no progress. A genuinely empty project is unchanged.
-  const nothingToMeasure = totalCount === 0 && projectRecurring.length > 0;
+  // No bar when there is no measurement to draw (calculateProjectProgress
+  // returns null). That covers both a project whose only work is a recurring
+  // series and one that is simply empty — neither has ever had a meaningful
+  // percentage, they just used to claim 0%.
+  const hasProgress = progress !== null;
+  // The count is a separate statement. "0/0 tasks" is true and useful for an
+  // empty project, but reads as wrong above a list of recurring series, so it
+  // goes only in that case.
+  const countIsMisleading = totalCount === 0 && projectRecurring.length > 0;
   const allProjectDisplayTasks = [
     ...projectScheduled.filter(t => !t.completed),
     ...projectUnscheduled.filter(t => !t.completed),
@@ -496,14 +499,14 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
         </div>
 
         {/* Task count — hidden by the standalone-card eyeball toggle */}
-        {!detailsHidden && !nothingToMeasure && (
+        {!detailsHidden && !countIsMisleading && (
           <span className={`text-xs ${textSecondary}`}>
             {completedCount}/{totalCount} task{totalCount !== 1 ? 's' : ''}
           </span>
         )}
 
         {/* Progress bar — hidden by the standalone-card eyeball toggle */}
-        {!detailsHidden && !nothingToMeasure && <ProjectProgress progress={progress} compact />}
+        {!detailsHidden && hasProgress && <ProjectProgress progress={progress} compact />}
 
         {/* Unscheduled task list */}
         {displayableTasks.length > 0 && (

--- a/src/utils/goalProgress.js
+++ b/src/utils/goalProgress.js
@@ -28,8 +28,12 @@ export function calculateGoalProgress(goalId, projects, allTasks) {
   let weightedSum = 0;
 
   for (const project of childProjects) {
-    const weight = getProjectTotalDuration(project.id, allTasks);
     const progress = calculateProjectProgress(project.id, allTasks);
+    // A project with nothing to measure carries no opinion about the goal.
+    // Its weight was already 0, so this only makes the intent explicit and
+    // keeps null out of the arithmetic.
+    if (progress === null) continue;
+    const weight = getProjectTotalDuration(project.id, allTasks);
     totalWeight += weight;
     weightedSum += progress * weight;
   }

--- a/src/utils/goalProgress.test.js
+++ b/src/utils/goalProgress.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { calculateGoalProgress } from './goalProgress.js';
+
+const project = (id, goalId = 'g1') => ({ id, goalId, status: 'active' });
+const task = (projectId, over = {}) => ({ id: `${projectId}-t`, projectId, duration: 60, completed: false, ...over });
+
+describe('calculateGoalProgress', () => {
+  it('weights each project by its total duration', () => {
+    const projects = [project('p1'), project('p2')];
+    const tasks = [
+      task('p1', { id: 'a', duration: 180, completed: true }),
+      task('p2', { id: 'b', duration: 60 }),
+    ];
+    // 180 of 240 minutes done.
+    expect(calculateGoalProgress('g1', projects, tasks)).toBeCloseTo(0.75);
+  });
+
+  // The reason the null return is safe here: a project with nothing to measure
+  // carries no opinion about its goal, rather than voting 0%.
+  it('skips projects with nothing to measure instead of averaging in a zero', () => {
+    const projects = [project('p1'), project('p2')];
+    const tasks = [task('p1', { completed: true })]; // p2 has no tasks at all
+    expect(calculateGoalProgress('g1', projects, tasks)).toBe(1);
+  });
+
+  it('is 0 when the goal has no projects, or none of them measurable', () => {
+    expect(calculateGoalProgress('g1', [], [])).toBe(0);
+    expect(calculateGoalProgress('g1', [project('p1')], [])).toBe(0);
+  });
+
+  it('ignores archived projects and other goals', () => {
+    const projects = [
+      { id: 'p1', goalId: 'g1', status: 'archived' },
+      project('p2', 'g2'),
+    ];
+    expect(calculateGoalProgress('g1', projects, [task('p1', { completed: true })])).toBe(0);
+  });
+});

--- a/src/utils/mcpReadModel.js
+++ b/src/utils/mcpReadModel.js
@@ -216,13 +216,21 @@ export function buildGoalProgress(state, params) {
     return { notFound: true, invalid: null };
   }
 
+  const projectProgressPercent = (id, tasks) => {
+    const progress = calculateProjectProgress(id, tasks);
+    return progress === null ? null : Math.round(progress * 100);
+  };
+
   const mapProject = (p) => {
     const projectTasks = progressTasks.filter((t) => t.projectId === p.id && !t.archived);
     return {
       id: p.id,
       title: p.title,
       status: p.status,
-      progress_percent: Math.round(calculateProjectProgress(p.id, progressTasks) * 100),
+      // null, not 0, when the project has nothing to measure — a reader that
+      // cannot tell those apart will report "no progress" on a project that is
+      // simply not measurable in tasks.
+      progress_percent: projectProgressPercent(p.id, progressTasks),
       tasks_done: projectTasks.filter((t) => t.completed).length,
       tasks_total: projectTasks.length,
     };

--- a/src/utils/mcpReadModel.test.js
+++ b/src/utils/mcpReadModel.test.js
@@ -241,6 +241,22 @@ describe('buildGoalProgress', () => {
     expect(buildGoalProgress(state, { goal_id: 'nope' }).notFound).toBe(true);
     expect(buildGoalProgress(state, { window: 'weekly' }).invalid).toContain('window');
   });
+
+  // A project whose only work is a recurring series has no countable tasks.
+  // Reporting 0 would tell a reader it has made no progress; null says the
+  // question does not apply.
+  it('reports progress_percent null, not 0, for a project with nothing to measure', () => {
+    const withEmptyProject = {
+      ...state,
+      projects: [...state.projects, { id: 'p3', title: 'Upkeep', status: 'active', goalId: 'g1' }],
+    };
+    const r = buildGoalProgress(withEmptyProject, { goal_id: 'g1' });
+    const p3 = r.goals[0].projects.find((p) => p.id === 'p3');
+    expect(p3.progress_percent).toBeNull();
+    // The measurable sibling is unaffected, and so is the goal rollup.
+    expect(r.goals[0].projects.find((p) => p.id === 'p1').progress_percent).toBe(50);
+    expect(r.goals[0].progress_percent).toBe(50);
+  });
 });
 
 describe('weekDatesFor — the strict calendar week, honoring weekStartDay', () => {

--- a/src/utils/projectProgress.js
+++ b/src/utils/projectProgress.js
@@ -12,22 +12,29 @@ const DEFAULT_DURATION = 30; // minutes — fallback for tasks with no duration 
 /**
  * Calculates duration-weighted completion progress for a single project.
  *
+ * Returns null, not 0, when there is nothing to measure. The two are different
+ * claims — "measured, and no progress yet" versus "there is no measurement to
+ * make" — and collapsing them meant a project whose only work is a recurring
+ * series (series are excluded from progress on purpose, since a series never
+ * completes) reported a confident 0% across every surface. Callers decide how
+ * to render the absence; they must not treat null as a number.
+ *
  * @param {string} projectId
  * @param {Array} allTasks - combined scheduled + unscheduled tasks
- * @returns {number} value between 0 and 1 (0 if no tasks)
+ * @returns {number|null} 0..1, or null when the project has no countable tasks
  */
 export function calculateProjectProgress(projectId, allTasks) {
   const projectTasks = allTasks.filter(
     t => t.projectId === projectId && !t.archived
   );
 
-  if (projectTasks.length === 0) return 0;
+  if (projectTasks.length === 0) return null;
 
   const totalDuration = projectTasks.reduce(
     (sum, t) => sum + (t.duration || DEFAULT_DURATION), 0
   );
 
-  if (totalDuration === 0) return 0;
+  if (totalDuration === 0) return null;
 
   const completedDuration = projectTasks
     .filter(t => t.completed)

--- a/src/utils/projectProgress.test.js
+++ b/src/utils/projectProgress.test.js
@@ -25,10 +25,17 @@ describe('calculateProjectProgress', () => {
     expect(calculateProjectProgress('p1', tasks)).toBeCloseTo(0.5);
   });
 
-  it('ignores archived tasks and other projects, and is 0 with nothing to measure', () => {
-    expect(calculateProjectProgress('p1', [task({ archived: true, completed: true })])).toBe(0);
-    expect(calculateProjectProgress('p1', [task({ projectId: 'p2', completed: true })])).toBe(0);
-    expect(calculateProjectProgress('p1', [])).toBe(0);
+  // null is the whole point: "no measurement to make" is not "measured at 0%".
+  // A project whose only work is a recurring series lands here, because series
+  // are excluded from progress on purpose.
+  it('is null, not 0, when there is nothing to measure', () => {
+    expect(calculateProjectProgress('p1', [])).toBeNull();
+    expect(calculateProjectProgress('p1', [task({ archived: true, completed: true })])).toBeNull();
+    expect(calculateProjectProgress('p1', [task({ projectId: 'p2', completed: true })])).toBeNull();
+  });
+
+  it('is 0 — not null — for real work that is genuinely untouched', () => {
+    expect(calculateProjectProgress('p1', [task()])).toBe(0);
   });
 
   it('reports total duration for goal weighting', () => {

--- a/src/utils/streamDeckPayload.js
+++ b/src/utils/streamDeckPayload.js
@@ -156,7 +156,12 @@ export function buildStreamDeckState({
 
   // ── Projects ──────────────────────────────────────────────────────────
   const mapProject = (p) => {
-    const progress = Math.round(calculateProjectProgress(p.id, allTasksForGoals) * 100);
+    // Deliberately coerced to 0 rather than passed through as null. This
+    // payload is an external contract with the Stream Deck plugin, which sums
+    // and averages `progress` and renders it as a bar width — a key has no way
+    // to draw "unmeasurable", and null would break the arithmetic.
+    const rawProgress = calculateProjectProgress(p.id, allTasksForGoals);
+    const progress = rawProgress === null ? 0 : Math.round(rawProgress * 100);
     const colorHex = TAILWIND_TO_HEX[p.color] || '#3b82f6';
     const parentGoal = p.goalId ? (goals || []).find(g => g.id === p.goalId) : null;
     const goalDaysLeft = parentGoal?.targetDate

--- a/src/utils/streamDeckPayload.test.js
+++ b/src/utils/streamDeckPayload.test.js
@@ -274,3 +274,19 @@ describe('fixture sanity', () => {
     expect(FIXTURE_NOW.getMinutes()).toBe(30);
   });
 });
+
+describe('project progress for an external plugin', () => {
+  // calculateProjectProgress returns null for a project with nothing to
+  // measure, but this payload is a contract with the Stream Deck plugin, which
+  // sums and averages `progress` and renders it as a bar width. A key has no
+  // way to draw an absence, so the coercion here is deliberate.
+  it('sends 0, not null, for an unmeasurable project', () => {
+    const { payload } = build(i => {
+      i.projects = [...i.projects, { id: 'p-empty', title: 'Upkeep', status: 'active', color: 'bg-blue-500' }];
+    });
+    const p = payload.projects.find(x => x.id === 'p-empty');
+    expect(p).toBeDefined();
+    expect(p.progress).toBe(0);
+    expect(p.progress).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Answers the open question on #1411, and subsumes the narrow `ProjectCard` special case it added.

> **Stacked on #1411.** Base is `recurring-followups`; GitHub retargets this to `main` once #1411 merges. Sibling of #1412, which touches different files.

## The problem was one function telling a small lie

`calculateProjectProgress` returned `0` for a project it could not measure. That is a different claim from the one it meant. "Measured, and no progress yet" and "there is no measurement to make here" are not the same thing, and **six** surfaces repeated the wrong one.

It bites hardest on a project whose only work is a recurring series. Series are excluded from progress deliberately — a series never completes, so counting one would peg the meter forever — which left the card reporting a confident 0% directly above a list of real work.

#1411 patched that on the card alone. That was worse than it looked: before, every surface agreed on a wrong answer; after, the card showed nothing while the GLANCE sidebar a few pixels away still showed 0%. This removes the disagreement by fixing the source.

## Each caller now decides what an absence looks like

| surface | with nothing to measure |
|---|---|
| `ProjectCard` | no bar |
| GLANCE goal rings (desktop + mobile) | the project's segment is dropped, not drawn empty |
| Weekly review | `overallProgressPct: null`; the AI prompt omits the clause rather than emitting `null% overall` |
| MCP `progress_percent` | `null`, so a reader can tell the difference the same way a person can |
| Goal rollup | the project abstains. Its weight was already 0 via `getProjectTotalDuration`, so this only makes the intent explicit and keeps `null` out of the arithmetic |
| Stream Deck | `0`, deliberately — see below |

**Stream Deck keeps 0 on purpose.** That payload is a contract with a separate plugin that sums and averages `progress` and renders it as a bar width. A physical key has no way to draw an absence, and `null` would break the arithmetic. Coercing at that boundary is a caller's decision, which is exactly what returning `null` lets each caller make. There's a test pinning it so a future tidy-up doesn't "fix" it into `null`.

## What actually changes on screen

Three project shapes, seeded and screenshotted in a real browser:

| project | count | bar |
|---|---|---|
| empty | `0/0 tasks` | **removed** (was an empty grey bar) |
| recurring only | hidden (as #1411) | hidden (as #1411) |
| regular + series | `1/2 tasks` | unchanged, over the 2 regular tasks |

So the only visible delta versus #1411 is that a **genuinely empty project no longer draws an empty bar**. Its `0/0 tasks` count stays — that's both true and useful, and tells you the project is empty. The count is suppressed only when recurring series exist, where "0/0 tasks" reads as wrong above a list of them.

Two rules rather than one, but they answer different questions: the bar is a *measurement* and shouldn't render without one; the count is a *statement about tasks* and is only misleading in the recurring case.

## Still not fixed, on purpose

A project with regular tasks **and** a series still measures only the regular ones. Making the series count would need it to be complete-for-today rather than complete-ever, so the meter would oscillate daily instead of trending to 100% — not what a progress bar means. That was the contributor's original call in #1406 and this PR keeps it.

## Verification

The only test in the whole suite that broke was #1411's own `toBe(0)` assertion, which is the contract change itself. Nothing else depended on the zero.

First test file for `goalProgress` (it had none), plus null coverage for `projectProgress`, the MCP wire shape, and the Stream Deck coercion. Suite 1972 → 1979.

`eslint src --max-warnings 0` clean, 130 files / 1979 tests passing, `npm run audit` clean, `npm run build` succeeds. Card states verified in Chromium against a seeded store, no console errors.

Not verified: dark mode, and packaged Electron/iOS/Android builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGA3jAvMnF9EFbgU3hRA8S

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGA3jAvMnF9EFbgU3hRA8S)_