### PR TITLE
Extract ICS feed sync into tested utility module (multi-calendar groundwork)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOn
 import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate, computeTaskCalendarTombstones, computeRecurringSeriesTombstones } from './utils/taskUtils.js';
 import { notBucketed, demoteToBucket, normalizeBucketConfig } from './utils/bucketList.js';
 import { parseICS, parseDatetime, filterByDateWindow, expandMultiDayEvent } from './utils/icsParser.js';
+import { fetchIcsFeed, replaceFeedEvents, PRIMARY_FEED_ID } from './utils/icsFeedSync.js';
 import { TASK_COLORS, TAILWIND_TO_HEX, taskColorToHex, getProjectColor } from './utils/colorUtils.js';
 import { calculateGoalProgress } from './utils/goalProgress.js';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from './constants/habits.js';
@@ -4790,37 +4791,8 @@ const DayPlanner = () => {
       const calAuthValue = (calendarUrlAuth.username && calendarUrlAuth.password)
         ? 'Basic ' + toBase64(calendarUrlAuth.username + ':' + calendarUrlAuth.password)
         : null;
-      const response = await icsProxyFetch(syncUrl, calAuthValue);
-      if (!response.ok) throw new Error('Failed to fetch calendar');
-
-      let icsContent = await response.text();
-      let effectiveUrl = syncUrl;
-
-      if (!icsContent.includes('BEGIN:VCALENDAR')) {
-        // CalDAV collection URLs (Baikal, Nextcloud, etc.) return HTML or WebDAV XML
-        // unless ?export is appended. Auto-retry once before giving up.
-        if (import.meta.env.DEV) console.log('[calendar-sync] Response is not ICS. Content-Type:', response.headers.get('content-type'), '— First 300 chars:', icsContent.slice(0, 300));
-        if (!syncUrl.includes('export')) {
-          const exportUrl = syncUrl.includes('?') ? `${syncUrl}&export` : `${syncUrl}?export`;
-          if (import.meta.env.DEV) console.log('[calendar-sync] Retrying with ?export:', redactUrl(exportUrl));
-          try {
-            const exportResponse = await icsProxyFetch(exportUrl, calAuthValue);
-            if (exportResponse.ok) {
-              const exportContent = await exportResponse.text();
-              if (exportContent.includes('BEGIN:VCALENDAR')) {
-                icsContent = exportContent;
-                effectiveUrl = exportUrl;
-              } else {
-                if (import.meta.env.DEV) console.log('[calendar-sync] ?export retry also returned non-ICS. Content-Type:', exportResponse.headers.get('content-type'));
-              }
-            }
-          } catch { /* fall through to not-ical error below */ }
-        }
-      }
-
-      if (!icsContent.includes('BEGIN:VCALENDAR')) {
-        throw new Error('not-ical');
-      }
+      const debug = import.meta.env.DEV ? (...args) => console.log('[calendar-sync]', ...args) : undefined;
+      const { icsContent, effectiveUrl } = await fetchIcsFeed(syncUrl, calAuthValue, icsProxyFetch, debug);
 
       // Persist the corrected URL so future syncs use it directly
       if (effectiveUrl !== syncUrl) {
@@ -4831,16 +4803,13 @@ const DayPlanner = () => {
       const events = parseICS(icsContent);
 
       const allImported = events.flatMap(event =>
-        expandMultiDayEvent(event, { asTaskCalendar: false })
+        expandMultiDayEvent(event, { asTaskCalendar: false, feedId: PRIMARY_FEED_ID })
       );
       const importedTasks = filterByDateWindow(allImported, syncRetentionDays);
 
-      // Remove old sync-sourced imported events (not task calendar) and add the fresh ones
+      // Replace old sync-sourced imported events (not task calendar) with the fresh ones.
       // Preserves file-imported events; uses functional form to avoid stale closures
-      setTasks(prevTasks => {
-        const kept = prevTasks.filter(t => !(t.imported && !t.isTaskCalendar && t.importSource !== 'file'));
-        return [...kept, ...importedTasks];
-      });
+      setTasks(prevTasks => replaceFeedEvents(prevTasks, importedTasks));
       return { success: true, count: importedTasks.length, urlUpdated: effectiveUrl !== syncUrl };
     } catch (error) {
       console.error('Sync error:', error);

--- a/src/utils/icsFeedSync.js
+++ b/src/utils/icsFeedSync.js
@@ -1,0 +1,82 @@
+// Helpers for syncing subscribed ICS/CalDAV event feeds ("calendar URL" sync).
+// Pure logic extracted from App.jsx so it can be unit-tested and reused across
+// multiple configured feeds.
+
+// Feed id for the original single "Calendar URL" setting. Events from this feed
+// keep their legacy unprefixed task ids; events that predate feed tagging carry
+// no feedId at all and are treated as belonging to this feed.
+export const PRIMARY_FEED_ID = 'primary';
+
+export const isIcsContent = (text) =>
+  typeof text === 'string' && text.includes('BEGIN:VCALENDAR');
+
+export const withExportParam = (url) =>
+  url.includes('?') ? `${url}&export` : `${url}?export`;
+
+/**
+ * Fetch an ICS feed, auto-retrying once with ?export appended — CalDAV
+ * collection URLs (Baikal, Nextcloud, etc.) return HTML or WebDAV XML unless
+ * ?export is appended.
+ *
+ * @param {string} url
+ * @param {string|null} authValue - value for the Authorization header, or null
+ * @param {(url: string, authValue: string|null) => Promise<Response>} fetchFn
+ * @param {(...args: unknown[]) => void} [debug] - optional dev logger
+ * @returns {Promise<{icsContent: string, effectiveUrl: string}>}
+ * @throws {Error} message 'fetch-failed' (HTTP error) or 'not-ical' (response
+ *   is not an ICS document even after the ?export retry)
+ */
+export const fetchIcsFeed = async (url, authValue, fetchFn, debug) => {
+  const response = await fetchFn(url, authValue);
+  if (!response.ok) throw new Error('fetch-failed');
+
+  let icsContent = await response.text();
+  let effectiveUrl = url;
+
+  if (!isIcsContent(icsContent) && !url.includes('export')) {
+    debug?.('Response is not ICS. Content-Type:', response.headers.get('content-type'), '— First 300 chars:', icsContent.slice(0, 300));
+    const exportUrl = withExportParam(url);
+    debug?.('Retrying with ?export');
+    try {
+      const exportResponse = await fetchFn(exportUrl, authValue);
+      if (exportResponse.ok) {
+        const exportContent = await exportResponse.text();
+        if (isIcsContent(exportContent)) {
+          icsContent = exportContent;
+          effectiveUrl = exportUrl;
+        } else {
+          debug?.('?export retry also returned non-ICS. Content-Type:', exportResponse.headers.get('content-type'));
+        }
+      }
+    } catch { /* fall through to the not-ical check below */ }
+  }
+
+  if (!isIcsContent(icsContent)) throw new Error('not-ical');
+  return { icsContent, effectiveUrl };
+};
+
+// A subscription-derived calendar event: re-fetched on every sync, so it is
+// disposable. Task-calendar items and .ics file imports are first-class user
+// data and are never touched by feed replacement.
+export const isFeedEvent = (t) =>
+  !!(t && t.imported && !t.isTaskCalendar && t.importSource !== 'file');
+
+/**
+ * Replace subscription-derived events in a task list with freshly fetched ones.
+ *
+ * With no keepFeedIds, every feed event is replaced (single-feed behavior).
+ * With keepFeedIds (multi-feed), events belonging to those feeds are preserved
+ * — used to keep the previous events of a feed whose fetch failed this round,
+ * while events of removed feeds (configured no longer) still drop out because
+ * their id is in neither freshEvents nor keepFeedIds.
+ *
+ * @param {Array<object>} prevTasks
+ * @param {Array<object>} freshEvents - already expanded + date-window filtered
+ * @param {{keepFeedIds?: Set<string>|null}} [options]
+ */
+export const replaceFeedEvents = (prevTasks, freshEvents, { keepFeedIds = null } = {}) => {
+  const kept = prevTasks.filter(t =>
+    !isFeedEvent(t) || (keepFeedIds != null && keepFeedIds.has(t.feedId ?? PRIMARY_FEED_ID))
+  );
+  return [...kept, ...freshEvents];
+};

--- a/src/utils/icsFeedSync.test.js
+++ b/src/utils/icsFeedSync.test.js
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  PRIMARY_FEED_ID,
+  isIcsContent,
+  withExportParam,
+  fetchIcsFeed,
+  isFeedEvent,
+  replaceFeedEvents,
+} from './icsFeedSync.js';
+
+const ICS = 'BEGIN:VCALENDAR\nBEGIN:VEVENT\nEND:VEVENT\nEND:VCALENDAR';
+const HTML = '<!doctype html><html><body>login</body></html>';
+
+const mockResponse = (body, { ok = true, contentType = 'text/calendar' } = {}) => ({
+  ok,
+  headers: { get: () => contentType },
+  text: async () => body,
+});
+
+describe('isIcsContent', () => {
+  it('detects ICS documents', () => {
+    expect(isIcsContent(ICS)).toBe(true);
+    expect(isIcsContent(HTML)).toBe(false);
+    expect(isIcsContent(null)).toBe(false);
+  });
+});
+
+describe('withExportParam', () => {
+  it('appends ?export to a bare URL', () => {
+    expect(withExportParam('https://x.test/cal/')).toBe('https://x.test/cal/?export');
+  });
+
+  it('appends &export when the URL already has a query', () => {
+    expect(withExportParam('https://x.test/cal/?a=1')).toBe('https://x.test/cal/?a=1&export');
+  });
+});
+
+describe('fetchIcsFeed', () => {
+  it('returns the content and original URL when the response is ICS', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse(ICS));
+    const result = await fetchIcsFeed('https://x.test/cal.ics', null, fetchFn);
+    expect(result).toEqual({ icsContent: ICS, effectiveUrl: 'https://x.test/cal.ics' });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith('https://x.test/cal.ics', null);
+  });
+
+  it('passes the auth value through to the fetch function', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse(ICS));
+    await fetchIcsFeed('https://x.test/cal.ics', 'Basic abc', fetchFn);
+    expect(fetchFn).toHaveBeenCalledWith('https://x.test/cal.ics', 'Basic abc');
+  });
+
+  it('throws fetch-failed on an HTTP error', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse('', { ok: false }));
+    await expect(fetchIcsFeed('https://x.test/cal.ics', null, fetchFn)).rejects.toThrow('fetch-failed');
+  });
+
+  it('retries with ?export when the response is not ICS and reports the corrected URL', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(mockResponse(HTML, { contentType: 'text/html' }))
+      .mockResolvedValueOnce(mockResponse(ICS));
+    const result = await fetchIcsFeed('https://x.test/cal/', null, fetchFn);
+    expect(result).toEqual({ icsContent: ICS, effectiveUrl: 'https://x.test/cal/?export' });
+    expect(fetchFn).toHaveBeenNthCalledWith(2, 'https://x.test/cal/?export', null);
+  });
+
+  it('does not retry when the URL already contains export', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse(HTML, { contentType: 'text/html' }));
+    await expect(fetchIcsFeed('https://x.test/cal/?export', null, fetchFn)).rejects.toThrow('not-ical');
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws not-ical when the retry also returns non-ICS', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse(HTML, { contentType: 'text/html' }));
+    await expect(fetchIcsFeed('https://x.test/cal/', null, fetchFn)).rejects.toThrow('not-ical');
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws not-ical when the retry request itself fails', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(mockResponse(HTML, { contentType: 'text/html' }))
+      .mockRejectedValueOnce(new Error('network'));
+    await expect(fetchIcsFeed('https://x.test/cal/', null, fetchFn)).rejects.toThrow('not-ical');
+  });
+});
+
+describe('isFeedEvent', () => {
+  it('matches subscription-derived events only', () => {
+    expect(isFeedEvent({ imported: true, isTaskCalendar: false, importSource: 'sync' })).toBe(true);
+    expect(isFeedEvent({ imported: true, isTaskCalendar: true, importSource: 'sync' })).toBe(false);
+    expect(isFeedEvent({ imported: true, isTaskCalendar: false, importSource: 'file' })).toBe(false);
+    expect(isFeedEvent({ imported: false })).toBe(false);
+    expect(isFeedEvent(null)).toBe(false);
+  });
+});
+
+describe('replaceFeedEvents', () => {
+  const userTask = { id: 'u1', title: 'mine' };
+  const fileImport = { id: 'f1', imported: true, isTaskCalendar: false, importSource: 'file' };
+  const taskCalItem = { id: 'tc1', imported: true, isTaskCalendar: true, importSource: 'sync' };
+  const oldPrimary = { id: 'p1', imported: true, isTaskCalendar: false, importSource: 'sync' };
+  const oldFeedA = { id: 'a1', imported: true, isTaskCalendar: false, importSource: 'sync', feedId: 'feed-a' };
+  const oldFeedB = { id: 'b1', imported: true, isTaskCalendar: false, importSource: 'sync', feedId: 'feed-b' };
+
+  it('replaces all feed events by default, preserving user tasks, file imports, and task-calendar items', () => {
+    const fresh = [{ id: 'n1', imported: true, isTaskCalendar: false, importSource: 'sync' }];
+    const result = replaceFeedEvents([userTask, fileImport, taskCalItem, oldPrimary, oldFeedA], fresh);
+    expect(result).toEqual([userTask, fileImport, taskCalItem, ...fresh]);
+  });
+
+  it('keeps events of feeds listed in keepFeedIds (failed fetches) and drops the rest', () => {
+    const fresh = [{ id: 'a2', imported: true, isTaskCalendar: false, importSource: 'sync', feedId: 'feed-a' }];
+    const result = replaceFeedEvents(
+      [userTask, oldFeedA, oldFeedB, oldPrimary],
+      fresh,
+      { keepFeedIds: new Set(['feed-b']) }
+    );
+    expect(result).toEqual([userTask, oldFeedB, ...fresh]);
+  });
+
+  it('treats events without a feedId as belonging to the primary feed', () => {
+    const result = replaceFeedEvents(
+      [oldPrimary, oldFeedA],
+      [],
+      { keepFeedIds: new Set([PRIMARY_FEED_ID]) }
+    );
+    expect(result).toEqual([oldPrimary]);
+  });
+});

--- a/src/utils/icsParser.js
+++ b/src/utils/icsParser.js
@@ -9,6 +9,7 @@
 // task objects.
 
 import { dateToString } from './taskUtils.js';
+import { PRIMARY_FEED_ID } from './icsFeedSync.js';
 
 // ── Time zone handling ────────────────────────────────────────────────────────
 // Outlook (and other Exchange-backed feeds) export event times as local wall
@@ -550,7 +551,7 @@ export const filterByDateWindow = (importedTasks, retentionDays) => {
 
 // Helper to expand multi-day events into separate tasks for each day
 export const expandMultiDayEvent = (event, options = {}) => {
-  const { asTaskCalendar = false, freshCompletedUids = new Set(), color: customColor, importSource = 'sync' } = options;
+  const { asTaskCalendar = false, freshCompletedUids = new Set(), color: customColor, importSource = 'sync', feedId } = options;
   const startDate = parseDatetime(event.dtstart, event.dtstartTzid);
   const endDate = event.dtend ? parseDatetime(event.dtend, event.dtendTzid || event.dtstartTzid) : new Date(startDate.getTime() + 60 * 60 * 1000);
   const duration = Math.round((endDate - startDate) / (1000 * 60));
@@ -573,7 +574,11 @@ export const expandMultiDayEvent = (event, options = {}) => {
 
     const baseId = event.uid || `imported-${Date.now()}-${Math.random()}`;
     const dateStr = dateToString(taskDate);
-    const taskId = dayCount > 1 ? `${baseId}-${dateStr}-day${i + 1}` : `${baseId}-${dateStr}`;
+    // Non-primary feeds prefix the task id with the feed id so the same event
+    // UID appearing in two subscribed calendars can't collide. The primary feed
+    // keeps the legacy unprefixed format.
+    const idPrefix = feedId && feedId !== PRIMARY_FEED_ID ? `${feedId}:` : '';
+    const taskId = dayCount > 1 ? `${idPrefix}${baseId}-${dateStr}-day${i + 1}` : `${idPrefix}${baseId}-${dateStr}`;
 
     // Add day indicator for multi-day events
     const titleSuffix = dayCount > 1 ? ` (Day ${i + 1}/${dayCount})` : '';
@@ -592,6 +597,7 @@ export const expandMultiDayEvent = (event, options = {}) => {
       isAllDay: isAllDay,
       isRecurringSeries: !!event.isRecurringSeries,
       importSource: importSource,
+      ...(feedId ? { feedId } : {}),
       ...(event.description ? { notes: event.description } : {})
     });
   }

--- a/src/utils/icsParser.test.js
+++ b/src/utils/icsParser.test.js
@@ -199,6 +199,29 @@ describe('expandMultiDayEvent', () => {
     );
     expect(tasks[0]).toMatchObject({ completed: true, isTaskCalendar: true, color: 'task-calendar', duration: 15 });
   });
+
+  it('stamps feedId and keeps legacy unprefixed ids for the primary feed', () => {
+    const tasks = expandMultiDayEvent(
+      { uid: 'ev-1', summary: 'Meeting', dtstart: '20260721T090000', dtend: '20260721T100000' },
+      { feedId: 'primary' }
+    );
+    expect(tasks[0].feedId).toBe('primary');
+    expect(tasks[0].id).toBe('ev-1-2026-07-21');
+  });
+
+  it('prefixes ids with the feed id for non-primary feeds so cross-feed UIDs cannot collide', () => {
+    const tasks = expandMultiDayEvent(
+      { uid: 'ev-1', summary: 'Meeting', dtstart: '20260721T090000', dtend: '20260721T100000' },
+      { feedId: 'feed-abc' }
+    );
+    expect(tasks[0].feedId).toBe('feed-abc');
+    expect(tasks[0].id).toBe('feed-abc:ev-1-2026-07-21');
+  });
+
+  it('omits feedId entirely when none is given', () => {
+    const tasks = expandMultiDayEvent({ uid: 'ev-1', summary: 'M', dtstart: '20260721T090000' });
+    expect('feedId' in tasks[0]).toBe(false);
+  });
 });
 
 describe('TZID time zone handling', () => {


### PR DESCRIPTION
## Summary

Groundwork PR for multiple CalDAV/ICS calendar subscriptions — **no user-visible behavior change**. Merge and verify this first; the follow-up PR (multi-calendar support) stacks on top of it.

- Extracts the ICS fetch + `?export` auto-retry logic and the feed-event replacement logic from `App.jsx`'s `syncWithCalendar` into a new pure module `src/utils/icsFeedSync.js`, with 14 unit tests.
- Imported subscription events are now stamped with a `feedId` (`'primary'` for the existing single Calendar URL setting). Events that predate tagging are treated as primary-feed events.
- `expandMultiDayEvent` gains a `feedId` option; non-primary feeds get their feed id prefixed into task ids so the same event UID appearing in two subscribed calendars can't collide. The primary feed keeps the legacy unprefixed id format.
- `replaceFeedEvents` supports scoped replacement via `keepFeedIds` (for preserving a feed's previous events when its fetch fails in the multi-feed world); called without it, it reproduces today's wholesale replace exactly.

## Why

`syncWithCalendar` will become a loop over N feeds in the follow-up PR. This isolates and tests the fragile parts (export retry, replacement scoping, id collisions) before any behavior changes, per the App.jsx decomposition guidance in CLAUDE.md.

## Testing

- `npm test`: 131 files / 2012 tests pass (14 new for `icsFeedSync`, 3 new for `feedId` stamping in `icsParser`).
- `npm run lint` clean; production `vite build` succeeds.
- To smoke-test manually: configure a single Calendar URL as before and sync — events should import identically (same ids, same colors, same replacement of stale events).

---
_Generated by [Claude Code](https://claude.ai/code/session_016kzdx2FXgBpD1aVnV5nBa6)_