### PR TITLE
Persist PLANNER Completed show/hide on the project record

### DIFF
--- a/src/components/projects/ProjectPlanner.jsx
+++ b/src/components/projects/ProjectPlanner.jsx
@@ -47,7 +47,9 @@ const ProjectPlanner = ({ project, onClose }) => {
   // returns to editing. Starts in preview when notes already exist.
   const [editingNotes, setEditingNotes] = useState(!(project.description || '').trim());
   const [quickAddTitle, setQuickAddTitle] = useState('');
-  const [showCompleted, setShowCompleted] = useState(true);
+  // Persisted on the project record like plannerScheduledHidden below, so
+  // each planner remembers its own choice and it syncs with the project.
+  const showCompleted = !project.plannerCompletedHidden;
   // Mobile shows the two task columns as tabs (they'd otherwise stack, hiding
   // Unscheduled below the fold); desktop keeps them side by side.
   const [activeTab, setActiveTab] = useState('scheduled');
@@ -280,7 +282,7 @@ const ProjectPlanner = ({ project, onClose }) => {
           <div className="flex items-center gap-1 flex-shrink-0">
             {hasAnyCompleted && (
               <button
-                onClick={() => setShowCompleted(v => !v)}
+                onClick={() => updateProject(project.id, { plannerCompletedHidden: showCompleted })}
                 className={`flex items-center gap-1.5 text-xs font-medium px-2 py-1.5 rounded-lg ${hoverBg} ${textSecondary} transition-colors`}
                 title={showCompleted ? t('planner.hideCompleted', 'Hide completed tasks') : t('planner.showCompleted', 'Show completed tasks')}
               >


### PR DESCRIPTION
## Summary

In PLANNER, the Scheduled column's show/hide state already persists per project (as `plannerScheduledHidden` on the project record), but the Completed tasks toggle was plain local `useState` and reset to "shown" every time the planner reopened.

This change stores the Completed toggle the same way: a `plannerCompletedHidden` field on the project record, written via `updateProject`. Each project's planner now remembers its own choice, and it syncs along with the rest of the project data.

## Changes

- `src/components/projects/ProjectPlanner.jsx`: replaced the local `showCompleted` state with `!project.plannerCompletedHidden`, and the toggle button now calls `updateProject(project.id, { plannerCompletedHidden: ... })` — mirroring the existing `plannerScheduledHidden` pattern.

## Testing

- `npx eslint` clean on the edited file
- Full test suite: 131 files, 2030 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwzXb6gkSFB3q6SRQzD44Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwzXb6gkSFB3q6SRQzD44Q)_