### PR TITLE
Use standard region names in the language picker

### DIFF
--- a/src/components/LanguagePicker.jsx
+++ b/src/components/LanguagePicker.jsx
@@ -12,7 +12,11 @@ import { languages, resolveLanguage } from '../locales.js';
  */
 export function nativeLanguageName(tag) {
   try {
-    const name = new Intl.DisplayNames([tag], { type: 'language' }).of(tag);
+    // 'standard' composes regional variants as "language (Region)" —
+    // "Português (Portugal)" — where the default 'dialect' mode picks
+    // ICU-version-dependent dialect names like "Português europeu",
+    // breaking the parenthetical pattern next to "Português (Brasil)".
+    const name = new Intl.DisplayNames([tag], { type: 'language', languageDisplay: 'standard' }).of(tag);
     // Intl echoes the input back when it has no name for the tag.
     if (!name || name === tag) return tag;
     return name.charAt(0).toLocaleUpperCase(tag) + name.slice(1);

--- a/src/components/LanguagePicker.test.js
+++ b/src/components/LanguagePicker.test.js
@@ -13,7 +13,7 @@ describe('nativeLanguageName', () => {
     ['fr', 'Français'],
     ['it', 'Italiano'],
     ['pt-BR', 'Português (Brasil)'],
-    ['pt-PT', 'Português europeu'],
+    ['pt-PT', 'Português (Portugal)'],
   ])('names %s in its own language', (tag, expected) => {
     expect(nativeLanguageName(tag)).toBe(expected);
   });


### PR DESCRIPTION
## Summary

The language picker showed "Português europeu" next to "Português (Brasil)", breaking the parenthetical pattern — and the label varied between environments (some showed "Português (Portugal)", others "Português europeu").

The names come from `Intl.DisplayNames`, whose default `languageDisplay: 'dialect'` mode uses ICU-version-dependent dialect names for regional variants. Passing `languageDisplay: 'standard'` composes them uniformly as "language (Region)" instead, so pt-PT renders as **Português (Portugal)** everywhere.

## Changes

- `src/components/LanguagePicker.jsx`: pass `languageDisplay: 'standard'` to `Intl.DisplayNames`. All other shipped languages (de, en, es, fr, it, pt-BR) are unaffected — verified their names are identical in both modes.
- `src/components/LanguagePicker.test.js`: expect `Português (Portugal)` for pt-PT.

## Testing

- `npx eslint` clean on both files
- LanguagePicker tests: 9 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwzXb6gkSFB3q6SRQzD44Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwzXb6gkSFB3q6SRQzD44Q)_