### PR TITLE
Extend the background widget refresh to the Live Activity

### DIFF
--- a/dayglance-ios/DayGlance/AppDelegate.swift
+++ b/dayglance-ios/DayGlance/AppDelegate.swift
@@ -5,11 +5,32 @@ import RevenueCat
 import BackgroundTasks
 import CoreSpotlight
 import WidgetKit
+import os
+
+/// Calls setTaskCompleted exactly once, however many paths race to it —
+/// normal completion, a failure, and the expiration handler all funnel
+/// through here. Overrunning the BGAppRefreshTask deadline without
+/// completing gets the app terminated by the system and can reduce future
+/// scheduling, so this is the constraint with teeth.
+private final class BGTaskCompletionGuard {
+    private let lock = NSLock()
+    private var task: BGTask?
+    init(_ task: BGTask) { self.task = task }
+    func complete(success: Bool) {
+        lock.lock()
+        let task = self.task
+        self.task = nil
+        lock.unlock()
+        task?.setTaskCompleted(success: success)
+    }
+}
 
 class AppDelegate: NSObject, UIApplicationDelegate {
 
     static var pendingShortcutAction: String? = nil
     static var pendingDeepLink: String? = nil
+
+    private static let bgLog = Logger(subsystem: "com.dayglance.app", category: "background")
 
     func application(
         _ application: UIApplication,
@@ -27,13 +48,43 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // Phase 9 — RevenueCat subscriptions
         SubscriptionBridge.shared.configure(apiKey: "appl_uHejfwubTbYOTpEPNYFsjXAgnHw")
 
-        // Phase 10 — Background widget refresh
+        // Phase 10 — Background widget + Live Activity refresh. Opportunistic:
+        // iOS runs this when it pleases (usage patterns, battery, Low Power
+        // Mode), or not at all — both refreshes must stay correct without it,
+        // and this only ever makes them fresher.
         BGTaskScheduler.shared.register(forTaskWithIdentifier: "com.dayglance.widgetrefresh", using: nil) { task in
             // The WebView is suspended when this fires so posting a notification to it
             // does nothing. Reload from whatever is already in the App Group container —
             // it's the freshest data available without the app running.
+            //
+            // The widget path runs FIRST and synchronously: it cannot fail and is
+            // complete before any Live Activity code executes, so a problem in the
+            // activity leg can never cost the widget refresh.
             WidgetCenter.shared.reloadAllTimelines()
-            task.setTaskCompleted(success: true)
+
+            guard #available(iOS 16.2, *) else {
+                task.setTaskCompleted(success: true)
+                return
+            }
+
+            let completion = BGTaskCompletionGuard(task)
+            var refresh: Task<Void, Never>?
+            // Armed before the async work starts, so a deadline landing
+            // mid-flight cancels the work instead of racing it.
+            task.expirationHandler = {
+                refresh?.cancel()
+                Self.bgLog.error("Background refresh expired at the BGAppRefreshTask deadline; Live Activity leg cancelled.")
+                completion.complete(success: false)
+            }
+            refresh = Task {
+                let clock = ContinuousClock()
+                let start = clock.now
+                await LiveActivityBridge.shared.refreshFromBackground(
+                    snapshotJSON: WidgetBridge.shared.storedSnapshotJSON())
+                let ms = (clock.now - start) / .milliseconds(1)
+                Self.bgLog.info("Background refresh done; Live Activity leg took \(ms, format: .fixed(precision: 1), privacy: .public)ms")
+                completion.complete(success: true)
+            }
         }
 
         // Capture Quick Action if app was cold-launched via a home screen shortcut.

--- a/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/LiveActivityBridge.swift
@@ -5,12 +5,19 @@ import ActivityKit
 
 /// Drives the day-summary Live Activity from the widget snapshot.
 ///
-/// Single entry point, zero new JS surface: WidgetBridge.updateSnapshot already
-/// receives the full snapshot JSON on every renderer push, and this bridge just
-/// decodes the `daySummary` key out of the same string. The math never lives
-/// here — the JS side precomputes everything (computeDaySummary for the
-/// numbers, buildUpNextFact for the island's schedule facts), so the island
-/// always agrees with the in-app strip.
+/// Two entry points, zero new JS surface, one source of truth:
+///  - `sync(fromSnapshotJSON:)` — the foreground path. WidgetBridge.updateSnapshot
+///    already receives the full snapshot JSON on every renderer push, and this
+///    bridge just decodes the `daySummary` key out of the same string.
+///  - `refreshFromBackground(snapshotJSON:)` — the BGAppRefreshTask path. Reads
+///    the SAME stored snapshot and only ever ENDS or UPDATES an existing
+///    activity, never creates one: Activity.request is foreground-only and
+///    throws from the background. This path re-presents provably still-correct
+///    state with a fresh staleness window; it never computes new state.
+///
+/// The math never lives here — the JS side precomputes everything
+/// (computeDaySummary for the numbers, buildUpNextFact for the island's
+/// schedule facts), so the island always agrees with the in-app strip.
 ///
 /// Lifecycle, on record:
 ///  - `liveActivityEnabled` false or absent: END. The Live Activity is
@@ -22,20 +29,34 @@ import ActivityKit
 ///    END. The strip renders nothing in that state; so do we.
 ///  - The date rolled over: yesterday's activity ends, today's is requested —
 ///    an activity's fixed attributes can't change, so a new day is a new
-///    activity by construction.
-///  - Otherwise: update in place, or request if none is live. iOS ends Live
-///    Activities after ~8h on its own; because a request happens on any
-///    snapshot push with none live, the next app foreground re-establishes it
-///    without dedicated plumbing.
-///  - staleDate is ~45 min out on every update: with no server push (privacy-
-///    first, no backend), state only refreshes while the app runs, and the
-///    island dims rather than presenting stale content as current. The
-///    countdown itself needs no refresh — the OS ticks it.
+///    activity by construction. The foreground path keys this on the
+///    snapshot's date (the snapshot is fresh by definition there); the
+///    background path keys it on the CURRENT date, because its snapshot may
+///    itself be from yesterday and would otherwise match — and refresh — a
+///    stale activity past midnight.
+///  - Otherwise: update in place, or (foreground only) request if none is
+///    live. iOS ends Live Activities after ~8h on its own — background
+///    updates do not extend that lifetime; because a request happens on any
+///    foreground snapshot push with none live, the next app foreground
+///    re-establishes it without dedicated plumbing.
+///  - staleDate is ~45 min out on every foreground update: with no server
+///    push (privacy-first, no backend), state only refreshes while the app's
+///    own process runs, and the island dims rather than presenting stale
+///    content as current. The countdown itself needs no refresh — the OS
+///    ticks it. The 45-minute blanket is calibrated for the foreground,
+///    where the block-boundary timer re-pushes at block edges; the
+///    background path additionally caps staleDate at the up-next boundary,
+///    because nothing re-pushes at boundaries back there.
 @available(iOS 16.2, *)
 final class LiveActivityBridge {
     static let shared = LiveActivityBridge()
 
     private static let staleAfter: TimeInterval = 45 * 60
+    /// How far past the up-next fact's boundary a background update may still
+    /// present the activity as fresh. Small on purpose: at the boundary the
+    /// fact ("until 2:00 PM" / "starts in") lapses, and only a foreground
+    /// push can compute the next block.
+    private static let boundaryGrace: TimeInterval = 2 * 60
 
     // Only the fields this bridge needs; unknown snapshot keys are ignored.
     private struct SnapshotEnvelope: Decodable {
@@ -68,29 +89,30 @@ final class LiveActivityBridge {
         var countdownEndMs: Double?
     }
 
-    func sync(fromSnapshotJSON json: String) {
-        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+    /// A snapshot that passed every render guard, reduced to what the two
+    /// entry points need: the day it describes, the ready-to-push state, and
+    /// the up-next fact's boundary (the moment that fact can lapse — the
+    /// foreground ignores it because its boundary timer re-pushes; the
+    /// background caps staleness at it).
+    private struct ValidSummary {
+        let date: String
+        let state: DaySummaryAttributes.ContentState
+        let countdownEnd: Date?
+    }
 
-        let envelope = try? JSONDecoder().decode(SnapshotEnvelope.self, from: Data(json.utf8))
+    private static func decode(_ json: String) -> SnapshotEnvelope? {
+        try? JSONDecoder().decode(SnapshotEnvelope.self, from: Data(json.utf8))
+    }
 
-        // Opt-in gate first: turning the in-app toggle off (or an old
-        // snapshot without the flag) tears down any live activity.
-        guard envelope?.liveActivityEnabled == true else {
-            endAll()
-            return
-        }
-
-        guard let payload = envelope?.daySummary,
+    private static func validSummary(from payload: DaySummaryPayload?) -> ValidSummary? {
+        guard let payload = payload,
               let date = payload.date,
               // unblocked is the empty-day sentinel, not display data: null
               // means nothing to measure (the strip shows nothing) → end.
               payload.unblocked != nil,
               let effort = payload.effort,
               let restore = payload.restore,
-              let done = payload.done else {
-            endAll()
-            return
-        }
+              let done = payload.done else { return nil }
 
         let up = payload.upNext
         let labels = payload.labels
@@ -107,32 +129,128 @@ final class LiveActivityBridge {
             remainingLabel: labels?.remaining ?? "remaining",
             startsInLabel: labels?.startsIn ?? "starts in",
             noMoreBlocksLabel: labels?.noMoreBlocks ?? "No more blocks today")
-        let content = ActivityContent(state: state, staleDate: Date().addingTimeInterval(Self.staleAfter))
+        return ValidSummary(date: date, state: state, countdownEnd: msToDate(up?.countdownEndMs))
+    }
+
+    /// Today as the local-time "yyyy-MM-dd" the JS side writes into the
+    /// snapshot's `date` (dateToString in utils/taskUtils.js): local timezone,
+    /// Gregorian, zero-padded.
+    private static func localDayString(_ date: Date = Date()) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+
+    // MARK: - Foreground path
+
+    func sync(fromSnapshotJSON json: String) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+
+        let envelope = Self.decode(json)
+
+        // Opt-in gate first: turning the in-app toggle off (or an old
+        // snapshot without the flag) tears down any live activity.
+        guard envelope?.liveActivityEnabled == true else {
+            endAll()
+            return
+        }
+
+        guard let summary = Self.validSummary(from: envelope?.daySummary) else {
+            endAll()
+            return
+        }
+
+        let content = ActivityContent(state: summary.state, staleDate: Date().addingTimeInterval(Self.staleAfter))
 
         Task {
             // A new day is a new activity: end anything describing another date.
-            for activity in Activity<DaySummaryAttributes>.activities where activity.attributes.date != date {
+            for activity in Activity<DaySummaryAttributes>.activities where activity.attributes.date != summary.date {
                 await activity.end(nil, dismissalPolicy: .immediate)
             }
 
-            if let live = Activity<DaySummaryAttributes>.activities.first(where: { $0.attributes.date == date }) {
+            if let live = Activity<DaySummaryAttributes>.activities.first(where: { $0.attributes.date == summary.date }) {
                 await live.update(content)
             } else {
                 // Best-effort: request can throw (per-app activity cap, user
                 // disabled Live Activities mid-session). The widgets still
                 // carry the numbers, so failure here costs only the island.
                 _ = try? Activity.request(
-                    attributes: DaySummaryAttributes(date: date),
+                    attributes: DaySummaryAttributes(date: summary.date),
                     content: content)
             }
         }
     }
 
-    private func endAll() {
-        Task {
-            for activity in Activity<DaySummaryAttributes>.activities {
-                await activity.end(nil, dismissalPolicy: .immediate)
+    // MARK: - Background path (BGAppRefreshTask)
+
+    /// Opportunistic staleness reduction from the background refresh task:
+    /// re-presents the stored snapshot — which cannot have drifted, since no
+    /// process ran to change the data — with a fresh staleness window, and
+    /// tears down an activity whose day has rolled over. Worth having, never
+    /// worth trusting: iOS runs the task when it pleases, or not at all, and
+    /// the activity must stay correct without it. Awaitable on purpose, so
+    /// the caller can hold the task open until the update actually lands.
+    func refreshFromBackground(snapshotJSON: String?) async {
+        // The common case is no live activity at all: notice it and get out
+        // before touching anything else.
+        guard !Activity<DaySummaryAttributes>.activities.isEmpty else { return }
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+
+        let envelope = snapshotJSON.flatMap(Self.decode)
+        guard envelope?.liveActivityEnabled == true,
+              let summary = Self.validSummary(from: envelope?.daySummary) else {
+            // Same teardown the foreground performs for an opted-out, empty-day,
+            // or unreadable snapshot — ending is always safe from back here.
+            await endAllNow()
+            return
+        }
+
+        // Rollover teardown, keyed on the CURRENT date — never the snapshot's.
+        // A snapshot last written yesterday matches yesterday's activity, and
+        // keying on it would cheerfully refresh yesterday's numbers past
+        // midnight.
+        let today = Self.localDayString()
+        for activity in Activity<DaySummaryAttributes>.activities where activity.attributes.date != today {
+            await activity.end(nil, dismissalPolicy: .immediate)
+        }
+
+        guard !Task.isCancelled,
+              summary.date == today,
+              let live = Activity<DaySummaryAttributes>.activities.first(where: { $0.attributes.date == today })
+        else { return } // Activity.request is foreground-only: never create from here.
+
+        let now = Date()
+        var staleDate = now.addingTimeInterval(Self.staleAfter)
+        if let boundary = summary.countdownEnd {
+            guard boundary > now else {
+                // Intended behaviour, not a missed case: the up-next fact's
+                // boundary has passed, and only the JS side can compute the
+                // next block. Un-dimming a lapsed fact is exactly what the
+                // isStale dimming exists to prevent, so a fire that lands
+                // after the last boundary refreshes nothing and the island
+                // stays dimmed until the next foreground push.
+                return
             }
+            // Cap freshness at the boundary (plus a small grace): past it,
+            // this same content must be allowed to dim on schedule.
+            staleDate = min(staleDate, boundary.addingTimeInterval(Self.boundaryGrace))
+        }
+
+        guard !Task.isCancelled else { return }
+        await live.update(ActivityContent(state: summary.state, staleDate: staleDate))
+    }
+
+    // MARK: - Teardown
+
+    private func endAll() {
+        Task { await self.endAllNow() }
+    }
+
+    private func endAllNow() async {
+        for activity in Activity<DaySummaryAttributes>.activities {
+            await activity.end(nil, dismissalPolicy: .immediate)
         }
     }
 }

--- a/dayglance-ios/DayGlance/Bridges/WidgetBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/WidgetBridge.swift
@@ -12,6 +12,11 @@ final class WidgetBridge {
     /// typo to silently disable the App Group.
     static let appGroup = "group.com.dayglance.app"
 
+    /// The App Group key the snapshot lives under. The widget extension keeps
+    /// its own copy of this literal (kSnapshotKey in WidgetModels.swift — a
+    /// different target); inside the app target this is the one definition.
+    static let snapshotKey = "widgetSnapshot"
+
     /// Widgets are killed at 30 MB with no warning. 200 KB is safely under that
     /// even with the full snapshot structure.
     private static let snapshotCapBytes = 200_000
@@ -46,13 +51,23 @@ final class WidgetBridge {
             Self.log.error("Widget snapshot dropped: App Group \(Self.appGroup, privacy: .public) is unavailable. Check the application-groups entitlement.")
             return
         }
-        defaults.set(data, forKey: "widgetSnapshot")
+        defaults.set(data, forKey: Self.snapshotKey)
         WidgetCenter.shared.reloadAllTimelines()
         // Same JSON drives the day-summary Live Activity — one entry point,
         // no separate JS bridge call to keep in sync.
         if #available(iOS 16.2, *) {
             LiveActivityBridge.shared.sync(fromSnapshotJSON: json)
         }
+    }
+
+    /// The stored snapshot JSON, as last written by updateSnapshot — read by
+    /// the background refresh task, whose only data source is this container
+    /// (the WebView is suspended when it fires). nil when the App Group is
+    /// unreachable or nothing was ever pushed.
+    func storedSnapshotJSON() -> String? {
+        guard let defaults = UserDefaults(suiteName: Self.appGroup),
+              let data = defaults.data(forKey: Self.snapshotKey) else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 
     func getPendingAction() -> String {

--- a/dayglance-ios/Shared/DaySummaryAttributes.swift
+++ b/dayglance-ios/Shared/DaySummaryAttributes.swift
@@ -14,11 +14,15 @@ import ActivityKit
 /// activity (the bridge ends yesterday's and requests today's), which keeps
 /// midnight semantics trivial.
 ///
-/// The island leads with SCHEDULE FACTS, not claims about "now": a no-backend
-/// app cannot update a Live Activity in the background, so "Deep work until
-/// 2:00 PM" (still true when stale) beats "In progress" (false the moment a
-/// boundary passes with the app closed). The live part is the countdown
-/// interval, which SwiftUI's Text(timerInterval:) ticks with zero updates.
+/// The island leads with SCHEDULE FACTS, not claims about "now": with no
+/// server push, the activity only updates when the app's own process runs —
+/// every foreground snapshot push, plus an opportunistic BGAppRefreshTask
+/// that re-presents the stored snapshot (LiveActivityBridge
+/// .refreshFromBackground) and is never guaranteed to fire. So "Deep work
+/// until 2:00 PM" (still true when stale) beats "In progress" (false the
+/// moment a boundary passes with the app closed). The live part is the
+/// countdown interval, which SwiftUI's Text(timerInterval:) ticks with zero
+/// updates.
 /// All strings arrive PREFORMATTED from JS so wording matches the in-app
 /// strip and the math is never re-implemented in Swift: the projection is
 /// computeDaySummary + buildUpNextFact, serialized in the snapshot's


### PR DESCRIPTION
## Summary

The `com.dayglance.widgetrefresh` BGAppRefreshTask handler only reloaded widget timelines. It now also refreshes an active Live Activity from the same stored App Group snapshot. Opportunistic staleness reduction: worth adding, never worth trusting — iOS runs the task based on usage patterns, battery, and Low Power Mode, or not at all, and the Live Activity remains correct without it. This is not a reliability mechanism and must never be read as one.

## What the background path adds — and all it adds

Two things over the existing foreground push, and nothing else:

1. **Staleness reset.** Re-presents the stored snapshot — which is provably still correct, since no process ran to change the data — with a fresh `staleDate`, un-dimming the island.
2. **Rollover teardown.** If an activity's date is no longer today, it is ended rather than updated. Keyed on the **current** date, never the snapshot's: a snapshot last written yesterday matches yesterday's activity, and keying on it (as the foreground path correctly does with its by-definition-fresh snapshot) would refresh yesterday's numbers past midnight.

It never computes new state — the math stays in JS (`computeDaySummary` / `buildUpNextFact`) — and it never creates an activity: `Activity.request` is foreground-only and throws from the background, so the path is strictly end-or-update.

## The boundary-capped staleDate decision

The new `staleDate` is capped at the up-next fact's `countdownEnd` plus a 2-minute grace, and staleness is only refreshed while that fact is still time-valid. Reasoning: un-dimming past the boundary would present a lapsed fact ("until 2:00 PM", after 2:00 PM) as fresh, which is exactly what the `isStale` dimming exists to prevent. The 45-minute blanket is calibrated for the foreground path, where the block-boundary timer re-pushes at block edges; nothing re-pushes in background, so the same number means something different there. **A fire landing after the last block's boundary refreshing nothing is intended behaviour, not a limitation** — stated at the site in `refreshFromBackground` so nobody later "fixes" it.

## The eight-hour ceiling

iOS ends Live Activities after roughly eight hours regardless, and background updates do not extend that. The win is keeping a user-started activity fresh through its natural lifetime, plus rollover cleanup. A user who never opens the app never has an activity to refresh.

## setTaskCompleted: exactly once, every path

- The widget path runs **first and synchronously** (`reloadAllTimelines()` cannot fail and completes before any Live Activity code executes), so the activity leg can never cost the widget refresh — the no-regression constraint is satisfied structurally.
- `task.expirationHandler` is armed **before** the async work starts; it cancels the in-flight refresh and completes with `success: false`.
- A `BGTaskCompletionGuard` (NSLock, nils the task on first call) funnels normal completion, failure, and expiry through one exactly-once gate.
- `refreshFromBackground` is awaitable on purpose: the previous fire-and-forget `sync()` shape would have completed the task with the update still in flight, letting the process suspend before it landed. It also checks `Task.isCancelled` between steps.

## Foreground `sync()` unchanged

The decode and state-build were extracted into shared helpers (`decode`, `validSummary`); `sync(fromSnapshotJSON:)` runs the identical sequence with identical guards, identical 45-minute staleDate, identical end/update/request logic. The single-entry-point doc comment now describes both entries.

Unchanged posture: same task identifier, same 15-minute earliest interval, same submission point (`applicationDidEnterBackground`), no second identifier, no frequency change.

## Device verification results (post-merge, on device)

Run on a physical iPhone, debug build, force-launched via the lldb `_simulateLaunchForTaskWithIdentifier:` SPI per the script below.

- **Case 1 — active Live Activity updated: PASS.** ActivityKit's own `com.apple.activitykit/api` trace ("Updating content for activity <UUID>") confirmed the background handler's `activity.update` executed; the activity remained present and correct on the lock screen. (That trace renders with an Error badge in Console — an ActivityKit logging quirk, not a failure.)
- **Case 2 — widget refresh in the same run: PASS.** `reloadAllTimelines()` runs before the activity leg in the same handler invocation; widgets rendered current data after the fire.
- **Case 3 — no active Live Activity: PASS.** With the opt-in toggle off, the fire completed with no crash and no activity created.
- **Case 4 — rollover: WAIVED** (tester declined changing the device clock, reasonably). Residual risk assessed as low because both halves of the branch are independently proven: the Swift/JS date-string agreement is exercised by Case 1's `summary.date == today` guard passing (a format mismatch would have made Case 1 refresh nothing), and the `activity.end()` path is exercised by the opt-out toggle. Worst-case failure mode is cosmetic: a stale activity lingering until iOS's ~8h auto-end.
- **Case 5 — expiry: not exercised** (the handler completes in milliseconds; the simulate-expiration window is impractical to hit). Exactly-once completion is enforced structurally by `BGTaskCompletionGuard`.
- **Measured duration: waived.** The duration line was logged at info level, which default Console.app configurations hide — fixed in #1422 (raised to notice). The workload is one JSON decode plus one `activity.update` against a ~30-second deadline; overrun risk is negligible.

## Measured handler duration

Instrumented, not yet measured: the Live Activity leg is timed with `ContinuousClock` and logged via `os.Logger` (subsystem `com.dayglance.app`, category `background`) — readable in Console.app on device without a debugger. **Nothing in this PR could be compiled or run in the development environment (Linux, no Xcode/Swift toolchain), so the first Xcode build is also the compile check.** The duration figure comes from the device steps below; expectation is single-digit milliseconds (one JSON decode plus one `activity.update`) against a ~30-second deadline.

JS side untouched and verified green: 2030 tests, eslint `--max-warnings 0`.

## Device verification script

Prereqs: iPhone on iOS 16.2+, debug build run from Xcode (`npm run ios` to build web + generate the project, then open in Xcode, select the device, Run with the debugger attached). Keep Console.app open with the device selected and this filter in the search field: `subsystem:com.dayglance.app category:background` (the same lines also appear in Xcode's debug console).

The force-launch, used in every case below — pause execution in Xcode (Debug → Pause), then at the `(lldb)` prompt:

```
e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.dayglance.widgetrefresh"]
```

then Continue. This must be done while the app is backgrounded (Home button/swipe) — backgrounding is also what submits the task request.

**Case 1 — active Live Activity is updated.** In the app, enable the Live Activity toggle and make sure today has at least one block whose end time is still in the future; confirm the activity shows on the lock screen / Dynamic Island. Background the app, force-launch. Expect: log line `Background refresh done; Live Activity leg took X.Xms` — record X for the PR — and the activity still present. If it had already dimmed (last app-open more than 45 min ago), it un-dims.

**Case 2 — widget still refreshes in the same run.** Same force-launch as Case 1: `reloadAllTimelines()` runs first in the same handler. Confirm home-screen widgets still render current data and the log line appeared (the line only prints after the widget reload has already executed).

**Case 3 — no active Live Activity (the usual state).** Turn the Live Activity toggle off in-app (the activity disappears), background, force-launch. Expect: the same log line with a near-zero duration, no crash, and — important — no activity appearing (the background path never creates one).

**Case 4 — rollover: snapshot date no longer today.** With an activity live (as in Case 1), background the app. Settings → General → Date & Time → disable "Set Automatically", move the date one day forward. Force-launch. Expect: the activity is **ended** (disappears from lock screen/island), not refreshed — this is the branch a naive implementation gets wrong. Re-enable automatic date/time afterwards.

**Case 5 (optional) — expiry path.** Backgrounded, at `(lldb)`:

```
e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateExpirationForTaskWithIdentifier:@"com.dayglance.widgetrefresh"]
```

after a Case-1-style launch. Expect the `Background refresh expired…` error line and no crash — completion is exactly-once, so a late "done" line after it is cosmetic and fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwzXb6gkSFB3q6SRQzD44Q