### PR TITLE
Bump version to 4.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="screenshots/badges/google-play.png" alt="Get it on Google Play" height="60">](https://play.google.com/store/apps/details?id=com.dayglance.app) [<img src="screenshots/badges/app-store.svg" alt="Download on the App Store" height="60">](https://apps.apple.com/app/id6771540599)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-4.4.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-4.5.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         // fallback for plain gradle/IDE builds and no longer needs a commit
         // per Play upload.
         versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 185
-        versionName = "4.4.0"
+        versionName = "4.5.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "@glance-apps/billing": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dayglance",
   "private": true,
   "license": "MIT",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "homepage": "https://dayglance.app",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary

App Store Connect rejected the archive upload with two errors: **ITMS-90062** (`CFBundleShortVersionString` 4.4.0 must be higher than the previously approved 4.4.0) and **ITMS-90186** (the 4.4.0 release train is closed for new build submissions). Both say the same thing: 4.4.0 already shipped, so the next upload needs a higher marketing version.

## Changes

Bumped via `npm run bump 4.5.0` per RELEASING.md — never hand-edited:

- `package.json` version 4.4.0 → 4.5.0 (the single source of truth)
- `dayglance-android/app/build.gradle.kts` `versionName` → 4.5.0
- `README.md` shields.io version badge → 4.5.0
- `package-lock.json` root version fields → 4.5.0

iOS `MARKETING_VERSION` and the Electron `CFBundleShortVersionString` derive from `package.json` at build time, so no direct edits are needed — but per the bumper's own instructions, **run `npm run ios:generate` after pulling this, before archiving**, so the regenerated Xcode project picks up the new version.

## Checks

- `npm run lint` clean
- Full suite: 131 files, 2030 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwzXb6gkSFB3q6SRQzD44Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwzXb6gkSFB3q6SRQzD44Q)_