### PR TITLE
Log the background refresh duration at notice level

### DIFF
--- a/dayglance-ios/DayGlance/AppDelegate.swift
+++ b/dayglance-ios/DayGlance/AppDelegate.swift
@@ -82,7 +82,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                 await LiveActivityBridge.shared.refreshFromBackground(
                     snapshotJSON: WidgetBridge.shared.storedSnapshotJSON())
                 let ms = (clock.now - start) / .milliseconds(1)
-                Self.bgLog.info("Background refresh done; Live Activity leg took \(ms, format: .fixed(precision: 1), privacy: .public)ms")
+                // notice, not info: info-level is hidden by default in
+                // Console.app (and easy to lose in Xcode's console), which
+                // defeats this line's purpose — the measured duration must be
+                // readable on a device without a debugger attached.
+                Self.bgLog.notice("Background refresh done; Live Activity leg took \(ms, format: .fixed(precision: 1), privacy: .public)ms")
                 completion.complete(success: true)
             }
         }


### PR DESCRIPTION
## Summary

One-line follow-up to #1420: the background-refresh duration line was logged at **info** level, which Console.app hides by default and Xcode's console makes hard to find — defeating its stated purpose (the measured duration must be readable on a device without a debugger attached). It's now **notice**, the default persisted level, which shows everywhere without any console settings.

Found during the device verification of #1420: the functional pass was visible via ActivityKit's own "Updating content for activity" line, but the duration line was invisible in a default Console.app configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwzXb6gkSFB3q6SRQzD44Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwzXb6gkSFB3q6SRQzD44Q)_