### PR TITLE
Fix cross-device loss of additional calendars; hide iCloud settings on non-Mac Electron

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,7 @@ import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilin
 import { notBucketed, demoteToBucket, normalizeBucketConfig } from './utils/bucketList.js';
 import { parseICS, parseDatetime, filterByDateWindow, expandMultiDayEvent } from './utils/icsParser.js';
 import { fetchIcsFeed, replaceFeedEvents, PRIMARY_FEED_ID, ICS_CALENDARS_KEY, loadIcsCalendars, isActiveIcsCalendar, hasActiveIcsCalendars, stripIcsCalendarCredentials, applyRemoteIcsCalendars, PRIMARY_CAL_META_KEY, defaultPrimaryCalendarMeta, injectPrimaryStub, splitPrimaryStub } from './utils/icsFeedSync.js';
+import { nextPerUserCalendarEntry } from './utils/perUserCalendarEntry.js';
 import { TASK_COLORS, TAILWIND_TO_HEX, taskColorToHex, getProjectColor } from './utils/colorUtils.js';
 import { calculateGoalProgress } from './utils/goalProgress.js';
 import { HABIT_ICONS, HABIT_ICON_NAMES, HABIT_COLORS } from './constants/habits.js';
@@ -2053,8 +2054,15 @@ const DayPlanner = () => {
   // commit it runs first and skips (flag not yet set), then re-runs next render with
   // the cleared URL. Content-compared so updatedAt only advances on a real change
   // (and not during remote apply, when the applied value already matches).
+  // Gated on dataLoaded: syncUrl/taskCalendarUrl state loads asynchronously in
+  // loadData(), so a pre-load run would see '' and rewrite this device's entry
+  // (then rewrite it again post-load) — each write restamps updatedAt, letting
+  // this device's possibly-stale calendar list win whole-entry LWW against a
+  // genuinely newer entry from another device. That was exactly the reported
+  // "second calendar silently dropped": the machine that DIDN'T add the
+  // calendar restamped its old list as newest on every launch.
   useEffect(() => {
-    if (!multiUserEnabled || !meUserSyncId) return;
+    if (!dataLoaded || !multiUserEnabled || !meUserSyncId) return;
     if (localStorage.getItem('day-planner-calendar-per-user-migrated') !== 'true') return;
     const encrypted = !!(cloudSyncConfig?.encryptionEnabled || isVaultEnabled());
     const includeAuth = syncCalendarCreds && encrypted && taskCalendarAuth
@@ -2072,17 +2080,14 @@ const DayPlanner = () => {
     };
     let map = {};
     try { map = JSON.parse(localStorage.getItem('day-planner-calendar-config-by-user') || '{}'); } catch { map = {}; }
-    const cur = map[meUserSyncId];
-    const sameContent = !!cur
-      && (cur.syncUrl ?? '') === (desired.syncUrl ?? '')
-      && (cur.taskCalendarUrl ?? '') === (desired.taskCalendarUrl ?? '')
-      && JSON.stringify(cur.icsCalendars ?? []) === JSON.stringify(desired.icsCalendars ?? [])
-      && JSON.stringify(cur.auth ?? null) === JSON.stringify(desired.auth ?? null);
-    if (sameContent) return;
-    map[meUserSyncId] = { ...desired, updatedAt: new Date().toISOString() };
+    // Unchanged content and fresh-device-with-empty-config both skip the write
+    // (see utils/perUserCalendarEntry.js for why either would clobber the fleet).
+    const next = nextPerUserCalendarEntry(map[meUserSyncId], desired, new Date().toISOString());
+    if (!next) return;
+    map[meUserSyncId] = next;
     localStorage.setItem('day-planner-calendar-config-by-user', JSON.stringify(map));
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [multiUserEnabled, meUserSyncId, syncUrl, taskCalendarUrl, taskCalendarAuth, icsCalendars, primaryCalendarMeta, syncCalendarCreds, cloudSyncConfig?.encryptionEnabled]);
+  }, [dataLoaded, multiUserEnabled, meUserSyncId, syncUrl, taskCalendarUrl, taskCalendarAuth, icsCalendars, primaryCalendarMeta, syncCalendarCreds, cloudSyncConfig?.encryptionEnabled]);
 
   // Signature of the additional-calendar config that affects fetching — sync
   // re-runs when a feed is added/removed/toggled or its URL changes, but not
@@ -5534,7 +5539,18 @@ const DayPlanner = () => {
     const meSidForCal = (() => {
       try { return JSON.parse(localStorage.getItem('dayglance-multi-user-config') || '{}').meUserSyncId || null; } catch { return null; }
     })();
-    const perUserCalendar = !!(data.multiUserEnabled && meSidForCal);
+    // data.multiUserEnabled can be ABSENT: the upstream file-tier merge outputs
+    // an explicit key list that does not carry the per-device toggle, so a
+    // WebDAV/iCloud pull arrives without it. Falling back to this device's own
+    // flag is required — treating absence as false skipped the per-user apply
+    // below, so calendarConfigByUser changes were stored but never applied, and
+    // the per-user maintenance effect then re-stamped this device's stale
+    // calendar list over the fleet's newer entry (calendars added on another
+    // device silently vanished).
+    const localMultiUser = (() => {
+      try { return JSON.parse(localStorage.getItem('dayglance-multi-user-enabled') || 'false') === true; } catch { return false; }
+    })();
+    const perUserCalendar = !!((data.multiUserEnabled ?? localMultiUser) && meSidForCal);
 
     // Normalize task defaults so localStorage and React state are identical.
     // Without this, stampTaskTimestamps detects spurious differences (e.g.

--- a/src/intents/icloudFileTransport.js
+++ b/src/intents/icloudFileTransport.js
@@ -14,9 +14,15 @@
  */
 
 const isIOS = typeof window !== 'undefined' && !!window.DayGlanceIOS;
+// The preload script exposes the iCloud IPC methods on EVERY Electron platform,
+// but the main-process handlers (electron/icloud.ts) are darwin-only no-ops —
+// on Windows/Linux every call returns null/false. Gate on the platform too, or
+// isAvailable() reports true there and callers log spurious failures (e.g.
+// "[shared-users/icloud] writeFile failed") and render dead iCloud settings UI.
 const isMacOS =
   typeof window !== 'undefined' &&
   !!window.electronAPI &&
+  window.electronAPI.platform === 'darwin' &&
   typeof window.electronAPI.listICloudFiles === 'function';
 
 /**

--- a/src/utils/icloudDiagnostics.js
+++ b/src/utils/icloudDiagnostics.js
@@ -63,7 +63,9 @@ export function formatBytes(n) {
  */
 export function detectPlatform({ nativeBridge, electronAPI } = {}) {
   if (nativeBridge?.iCloudAvailable) return 'ios';
-  if (electronAPI?.readICloud) return 'macos';
+  // Electron exposes readICloud on every platform, but the main-process handler
+  // is a darwin-only no-op — Windows/Linux must report 'none', not 'macos'.
+  if (electronAPI?.readICloud && electronAPI.platform === 'darwin') return 'macos';
   return 'none';
 }
 

--- a/src/utils/icloudDiagnostics.test.js
+++ b/src/utils/icloudDiagnostics.test.js
@@ -28,18 +28,25 @@ describe('detectPlatform', () => {
   });
 
   it('detects macOS from the electron API', () => {
-    expect(detectPlatform({ electronAPI: { readICloud: async () => null } })).toBe('macos');
+    expect(detectPlatform({ electronAPI: { platform: 'darwin', readICloud: async () => null } })).toBe('macos');
   });
 
   it('prefers iOS when somehow both are present', () => {
     expect(detectPlatform({
       nativeBridge: { iCloudAvailable: () => '{}' },
-      electronAPI: { readICloud: async () => null },
+      electronAPI: { platform: 'darwin', readICloud: async () => null },
     })).toBe('ios');
   });
 
   it('reports none on Android/web', () => {
     expect(detectPlatform({})).toBe('none');
+  });
+
+  // The preload exposes readICloud on every Electron platform, but the main
+  // process only serves it on darwin — Windows/Linux must not claim macOS.
+  it('reports none on Windows/Linux Electron despite the exposed API', () => {
+    expect(detectPlatform({ electronAPI: { platform: 'win32', readICloud: async () => null } })).toBe('none');
+    expect(detectPlatform({ electronAPI: { platform: 'linux', readICloud: async () => null } })).toBe('none');
   });
 });
 
@@ -302,7 +309,7 @@ describe('collectICloudDiagnostics', () => {
 
   it('gathers a macOS report and awaits the async read', async () => {
     const r = await collectICloudDiagnostics({
-      electronAPI: { readICloud: async () => payload() },
+      electronAPI: { platform: 'darwin', readICloud: async () => payload() },
       localStorage: fakeLocalStorage(),
     });
     expect(r.platform).toBe('macos');

--- a/src/utils/perUserCalendarEntry.js
+++ b/src/utils/perUserCalendarEntry.js
@@ -1,0 +1,35 @@
+/**
+ * Decides what to write for this device's own entry in the per-user calendar
+ * config map (calendarConfigByUser[meUserSyncId]) — or null for "don't write".
+ *
+ * Entries merge whole-entry last-writer-wins by updatedAt across the fleet, so
+ * every write is a claim that THIS device holds the newest config. Two writes
+ * must therefore never happen:
+ *
+ *  - a write whose content equals the stored entry — it would bump updatedAt
+ *    for nothing, letting stale-but-restamped content beat a genuinely newer
+ *    entry from another device;
+ *  - a first write (no stored entry yet) of an EMPTY config — a fresh install
+ *    knows nothing, and seeding {'', '', []} with a brand-new updatedAt wins
+ *    LWW against the fleet's real entry, silently discarding every calendar
+ *    configured on the user's other devices.
+ *
+ * @param {object|null|undefined} cur - the stored entry for this user, if any
+ * @param {{syncUrl: string, taskCalendarUrl: string, icsCalendars: Array<object>, auth?: object}} desired
+ * @param {string} nowIso - timestamp for the write
+ * @returns {object|null} the entry to store, or null when no write should happen
+ */
+export function nextPerUserCalendarEntry(cur, desired, nowIso) {
+  const sameContent = !!cur
+    && (cur.syncUrl ?? '') === (desired.syncUrl ?? '')
+    && (cur.taskCalendarUrl ?? '') === (desired.taskCalendarUrl ?? '')
+    && JSON.stringify(cur.icsCalendars ?? []) === JSON.stringify(desired.icsCalendars ?? [])
+    && JSON.stringify(cur.auth ?? null) === JSON.stringify(desired.auth ?? null);
+  if (sameContent) return null;
+
+  const empty = !desired.syncUrl && !desired.taskCalendarUrl
+    && !(desired.icsCalendars || []).length && !desired.auth;
+  if (!cur && empty) return null;
+
+  return { ...desired, updatedAt: nowIso };
+}

--- a/src/utils/perUserCalendarEntry.test.js
+++ b/src/utils/perUserCalendarEntry.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { nextPerUserCalendarEntry } from './perUserCalendarEntry.js';
+
+const NOW = '2026-08-20T12:00:00.000Z';
+const CAL2 = { id: 'ics-1', name: 'Beta', url: 'https://dav.example.com/beta', color: 'bg-blue-600', enabled: true };
+const STUB = { id: 'primary', name: '', color: 'bg-gray-600', enabled: true };
+
+const entry = (over = {}) => ({
+  syncUrl: 'https://dav.example.com/primary',
+  taskCalendarUrl: '',
+  icsCalendars: [STUB, CAL2],
+  updatedAt: '2026-08-19T00:00:00.000Z',
+  ...over,
+});
+
+describe('nextPerUserCalendarEntry', () => {
+  it('writes a changed config with the new timestamp', () => {
+    const cur = entry({ icsCalendars: [STUB] });
+    const desired = { syncUrl: cur.syncUrl, taskCalendarUrl: '', icsCalendars: [STUB, CAL2] };
+    expect(nextPerUserCalendarEntry(cur, desired, NOW)).toEqual({ ...desired, updatedAt: NOW });
+  });
+
+  it('writes a first entry when the device has real config', () => {
+    const desired = { syncUrl: 'https://dav.example.com/primary', taskCalendarUrl: '', icsCalendars: [] };
+    expect(nextPerUserCalendarEntry(undefined, desired, NOW)).toEqual({ ...desired, updatedAt: NOW });
+  });
+
+  // Restamping equal content would advance updatedAt and let stale content
+  // win LWW against a genuinely newer entry from another device.
+  it('does not restamp when the content is unchanged', () => {
+    const cur = entry();
+    const desired = { syncUrl: cur.syncUrl, taskCalendarUrl: '', icsCalendars: [STUB, CAL2] };
+    expect(nextPerUserCalendarEntry(cur, desired, NOW)).toBeNull();
+    // absent auth on both sides is the same content
+    expect(nextPerUserCalendarEntry({ ...cur, auth: undefined }, desired, NOW)).toBeNull();
+  });
+
+  // The fresh-install clobber: a device with no entry and nothing configured
+  // must stay silent, or its brand-new updatedAt wipes the fleet's calendars.
+  it('never seeds an empty entry on a device with no stored entry', () => {
+    const desired = { syncUrl: '', taskCalendarUrl: '', icsCalendars: [] };
+    expect(nextPerUserCalendarEntry(undefined, desired, NOW)).toBeNull();
+    expect(nextPerUserCalendarEntry(null, desired, NOW)).toBeNull();
+  });
+
+  it('still writes an intentional clear once an entry exists', () => {
+    const cur = entry();
+    const desired = { syncUrl: '', taskCalendarUrl: '', icsCalendars: [] };
+    expect(nextPerUserCalendarEntry(cur, desired, NOW)).toEqual({ ...desired, updatedAt: NOW });
+  });
+
+  it('treats auth changes as content changes', () => {
+    const cur = entry();
+    const desired = {
+      syncUrl: cur.syncUrl, taskCalendarUrl: '', icsCalendars: [STUB, CAL2],
+      auth: { username: 'u', appPassword: 'p' },
+    };
+    expect(nextPerUserCalendarEntry(cur, desired, NOW)).toEqual({ ...desired, updatedAt: NOW });
+  });
+});


### PR DESCRIPTION
Fixes the two Electron-reported bugs: a second CalDAV calendar's URL getting silently dropped, and the dead iCloud sync settings (N/A + `writeFile failed` console error) on Windows/Linux.

## 1. Second calendar silently dropped (multi-user / per-user calendar mode)

Reproduced with two emulated Electron devices syncing through a WebDAV server. Two defects, whose relevance depends on the sync tier:

- **The maintenance effect re-stamped stale entries as newest (all tiers — and the whole bug on GLANCEvault).** The effect that maintains this device's `calendarConfigByUser` entry ran before `loadData()` populated `syncUrl`/`taskCalendarUrl` state (`multiUserEnabled`/`meUserSyncId` initialize synchronously, `syncUrl` does not), so every launch rewrote the entry twice — first with `syncUrl: ''`, then restored — bumping `updatedAt` both times. Whole-entry last-writer-wins therefore resolved to "the machine that launched most recently", not "the machine where the user last edited": add a calendar on machine 1, launch machine 2, and machine 2's freshly-stamped cal2-less entry outranks the real edit and propagates — the primary URL survives inside the stale entry, the added calendar vanishes. On GLANCEvault (whose per-user apply works, see below) the stale entry is then actively applied, deleting the calendar deterministically and silently. The effect is now gated on `dataLoaded`, and it only writes when content genuinely changed; a device with no stored entry never seeds an empty one (a fresh install would otherwise wipe the fleet's calendar config the same way, also reproduced). The write decision is extracted to `src/utils/perUserCalendarEntry.js` with unit tests.
- **Per-user config was pulled but never applied (file tier only).** `applyEngineData` computed `perUserCalendar` from `data.multiUserEnabled`, but the upstream file-tier merge (WebDAV/iCloud) outputs an explicit key list that does not carry the per-device toggle — so on every file-tier pull `perUserCalendar` was false, and `calendarConfigByUser` changes were stored in localStorage but never applied to the device's live calendar config. The GLANCEvault tier is unaffected: its commit data starts from the live payload and `multiUserEnabled` is a device-local bundle kept local (`dbAdapter.js` `ALWAYS_DEVICE_LOCAL`, `commitMerge.js`), so it is always present there. The apply now falls back to the device's own multi-user flag, read fresh from localStorage the same way `meUserSyncId` already is — a no-op on the vault tier, required on the file tier.

After the fix, the same two-device scenarios show the second calendar's URL arriving on the other machine, surviving round trips and restarts, and a fresh install joining the account adopts the fleet's config instead of clobbering it.

## 2. iCloud settings shown (all N/A) + `writeFile failed` on Windows/Linux Electron

The preload exposes the iCloud IPC methods on every Electron platform, but the main-process handlers (`electron/icloud.ts`) are darwin-only no-ops. Both `icloudFileTransport.isAvailable()` and `icloudDiagnostics.detectPlatform()` keyed off the methods' mere presence, so Windows/Linux builds rendered the iCloud sync toggle/diagnostics ("N/A") and the multi-user shared-users roster sync attempted iCloud writes, logging `[shared-users/icloud] writeFile failed`. Both now also require `electronAPI.platform === 'darwin'`: the iCloud sections disappear off macOS, the iCloud transports stay inert, and multi-user gating no longer counts an 'icloud-only' transport that cannot work there. macOS and iOS behavior is unchanged.

## Testing

- `npm test`: 135 files, 2068 tests pass (includes new `perUserCalendarEntry` tests and updated `icloudDiagnostics` platform-detection tests).
- `npm run lint`: clean.
- End-to-end Playwright verification against a live WebDAV mock: single-user and multi-user two-device round trips, fresh-install join, Electron/Linux emulation confirming the iCloud UI is gone and no iCloud console warnings fire. The vault-tier claims (commit data carries `multiUserEnabled`; `calendarConfigByUser` merges per-syncId LWW by `updatedAt`) are verified against `dbAdapter.js`/`commitMerge.js`; the boot-time double-write was observed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkjsFjCdQZ6SLcJSKmA5pv