### PR TITLE
Drop the Day Dial wordmark below the macOS traffic lights

### DIFF
--- a/src/components/DayDialModal.jsx
+++ b/src/components/DayDialModal.jsx
@@ -414,8 +414,12 @@ const DayDialModal = () => {
       {/* Maker's mark — a watch face carries its brand, so this stays put
           while the interactive chrome fades; muted so it never competes
           with the now line (which wears the same orange). Top-left, except
-          top-center on narrow viewports where the corners crowd the dial. */}
-      <div className="absolute top-5 left-1/2 -translate-x-1/2 sm:left-6 sm:translate-x-0 z-10 opacity-70 pointer-events-none">
+          top-center on narrow viewports where the corners crowd the dial.
+          The wide-viewport variant sits at top-12: on macOS Electron
+          (titleBarStyle hiddenInset, traffic lights at y:8) the window
+          controls own the top ~20px of this corner, and the mark must
+          clear them. */}
+      <div className="absolute top-5 left-1/2 -translate-x-1/2 sm:top-12 sm:left-6 sm:translate-x-0 z-10 opacity-70 pointer-events-none">
         <Wordmark className="text-2xl" darkMode dayClassName="text-white/60" />
       </div>
       <div className={`absolute top-4 right-4 z-10 flex items-center gap-1 ${chromeClass}`}>


### PR DESCRIPTION
Post-merge polish for the Day Dial (#1423), from testing on Mac: on macOS Electron the window uses `titleBarStyle: 'hiddenInset'` with traffic lights at `y: 8`, so the OS controls own the top ~20px of the overlay's left corner — and the wordmark at `top-5` (20px) sat flush against them.

The wide-viewport (left-anchored) variant now sits at `top-12` (48px), giving ~28px of clearance below the lights. The narrow-viewport top-center position is untouched, since there are no window controls in that band. Verified in headless Chromium: wordmark box at `top: 48px` on a wide viewport.

One-class change plus a comment documenting why the corner's top band is off-limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tk9wjwm9BC52zKF6vofEdy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk9wjwm9BC52zKF6vofEdy)_