### PR TITLE
Bump version to 4.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="screenshots/badges/google-play.png" alt="Get it on Google Play" height="60">](https://play.google.com/store/apps/details?id=com.dayglance.app) [<img src="screenshots/badges/app-store.svg" alt="Download on the App Store" height="60">](https://apps.apple.com/app/id6771540599)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-4.5.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-4.6.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         // fallback for plain gradle/IDE builds and no longer needs a commit
         // per Play upload.
         versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 185
-        versionName = "4.5.0"
+        versionName = "4.6.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "@glance-apps/billing": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dayglance",
   "private": true,
   "license": "MIT",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "homepage": "https://dayglance.app",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
The Day Dial release. #1423 landed the ambient 24-hour instrument view — the dial with task-hued time-tiered wedges, solar and weather layers, the interactive hub (clock, inspection, action sheet, Today chip), day navigation, kiosk boot params, layer toggles, and full screensaver ambient mode (wake lock, planner auto-start, OLED burn-in guard). A substantial backwards-compatible feature set → minor bump per semver: **4.5.0 → 4.6.0**.

Bumped via `npm run bump 4.6.0` per RELEASING.md (never hand-edited): `package.json` + `package-lock.json` version, Android `versionName`, and the README badge. iOS `MARKETING_VERSION` and Electron `CFBundleShortVersionString` derive from `package.json` at build time. Reminder from the bumper for whoever archives iOS: run `npm run ios:generate` before archiving.

Gates on the bumped tree: 2068 tests, lint, and build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tk9wjwm9BC52zKF6vofEdy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk9wjwm9BC52zKF6vofEdy)_