### PR TITLE
Add the Day Dial button to the tablet header strip

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -10,6 +10,7 @@ import { renderTitle } from '../utils/textFormatting.jsx';
 import NotesSubtasksPanel from './NotesSubtasksPanel.jsx';
 import { hasNativeCalendar } from '../utils/nativeCalendar.js';
 import DesktopHeader from './DesktopHeader.jsx';
+import DayDialIcon from './DayDialIcon.jsx';
 import GlanceFabs from './GlanceFabs.jsx';
 import CalendarHeader from './CalendarHeader.jsx';
 import TimeGrid from './TimeGrid.jsx';
@@ -69,6 +70,7 @@ const DesktopLayout = () => {
     mobileWelcomeStep, setMobileWelcomeStep,
     desktopWelcomeStep, setDesktopWelcomeStep,
     showMonthView, setShowMonthView,
+    setShowDayDial,
     viewedMonth, setViewedMonth,
     mobileReviewPage, setMobileReviewPage,
     showMobileDailySummary, setShowMobileDailySummary,
@@ -592,6 +594,14 @@ const DesktopLayout = () => {
               {activeReminders.length > 0 && (
                 <span className={`absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full border-2 ${darkMode ? 'border-gray-800' : 'border-white'} bg-amber-500 animate-pulse`} />
               )}
+            </button>
+            <button
+              onClick={() => setShowDayDial(true)}
+              className={`p-2 ${darkMode ? 'bg-gray-700' : 'bg-stone-200'} rounded-lg hover:bg-black/5 active:bg-black/10 dark:hover:bg-white/5 dark:active:bg-white/10 transition-colors`}
+              title="Day Dial"
+              aria-label="Day Dial"
+            >
+              <DayDialIcon className={textSecondary} />
             </button>
             <button
               onClick={() => setDarkMode(!darkMode)}


### PR DESCRIPTION
## What

On iPad (tablet view) there was no way to open the Day Dial. Tablets never render `DesktopHeader` — `DesktopLayout` swaps in its own 56px header strip (`{!isTablet && <DesktopHeader />}`) — and that strip predates the dial, so it never got the button. The other entry points don't apply either: the `O` shortcut assumes a keyboard, and the GLANCE tab button lives in `MobileLayout`, which tablets don't use.

The fix adds the dial button to the tablet header strip in the same slot it occupies on desktop, between Reminders and the dark-mode toggle, using the strip's own hover/active styling. The tooltip drops the "(O)" hint since tablets have no keyboard.

## Verification

- Under iPad-like emulation (touch-primary pointer, 1024x768 viewport, so `useDeviceType` computes `isTablet`): the desktop header is absent, the tablet strip shows exactly one Day Dial button, and tapping it opens the dial. No console errors.
- Lint, full test suite (2068 passed), and production build all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk9wjwm9BC52zKF6vofEdy)_