### PR TITLE
Hide the iOS status bar in dial fullscreen and ambient mode

### DIFF
--- a/dayglance-ios/DayGlance/Bridges/StatusBarBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/StatusBarBridge.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Combine
 
 /// Drives the status bar content colour from the web layer's theme.
 ///
@@ -7,10 +8,12 @@ import UIKit
 /// status bar colour from the system trait collection; the web layer has to tell
 /// it (mirroring the Android `setStatusBarAppearance` bridge call).
 ///
-/// With `UIViewControllerBasedStatusBarAppearance` = NO and `UIStatusBarStyle` =
-/// default (adaptive on iOS 13+), the status bar content colour resolves from the
-/// key window's user interface style. Overriding that style therefore flips the
-/// status bar text: dark theme → light (white) text, light theme → dark text.
+/// With `UIViewControllerBasedStatusBarAppearance` = YES (required so SwiftUI's
+/// `.statusBarHidden` works for immersive mode, below) and no explicit style
+/// override, the hosting controller reports `.default`, which resolves from its
+/// trait collection — inherited from the key window. Overriding the window's
+/// style therefore still flips the status bar text: dark theme → light (white)
+/// text, light theme → dark text.
 final class StatusBarBridge {
 
     static let shared = StatusBarBridge()
@@ -25,6 +28,28 @@ final class StatusBarBridge {
             let window = scenes.flatMap { $0.windows }.first { $0.isKeyWindow }
                 ?? scenes.first?.windows.first
             window?.overrideUserInterfaceStyle = isDark ? .dark : .light
+        }
+    }
+}
+
+/// Observable immersive-mode flag — the iOS analogue of Android's immersive
+/// mode, set by the web layer's `setImmersiveMode` bridge call (the Day Dial's
+/// fullscreen toggle and ambient screensaver). ContentView observes it and
+/// hides the status bar and home indicator while it is on. WKWebView offers no
+/// Fullscreen API on iPhone, so the shell has to hide the system chrome itself.
+final class ImmersiveBridge: ObservableObject {
+
+    static let shared = ImmersiveBridge()
+
+    @Published var immersive = false
+
+    private init() {}
+
+    func set(_ on: Bool) {
+        // Bridge callbacks may run off the main thread; the @Published
+        // mutation must happen on the main queue.
+        DispatchQueue.main.async {
+            self.immersive = on
         }
     }
 }

--- a/dayglance-ios/DayGlance/ContentView.swift
+++ b/dayglance-ios/DayGlance/ContentView.swift
@@ -5,10 +5,18 @@ import CoreSpotlight
 struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var lastCalendarStatus = EKEventStore.authorizationStatus(for: .event)
+    // Day Dial fullscreen / ambient screensaver: the web layer can't hide the
+    // status bar itself (WKWebView has no Fullscreen API on iPhone), so it
+    // flips this bridge flag and the chrome is hidden natively. On notched
+    // devices the safe-area inset stays (the cutout is physical), so the web
+    // layer's env(safe-area-inset-top) offsets keep clearing it.
+    @ObservedObject private var immersiveBridge = ImmersiveBridge.shared
 
     var body: some View {
         WebView()
             .ignoresSafeArea()
+            .statusBarHidden(immersiveBridge.immersive)
+            .persistentSystemOverlays(immersiveBridge.immersive ? .hidden : .automatic)
             .task {
                 let calendarWasUndetermined = EKEventStore.authorizationStatus(for: .event) == .notDetermined
 

--- a/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
+++ b/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
@@ -250,6 +250,14 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
             StatusBarBridge.shared.setAppearance(isDark: isDark)
             return "null"
 
+        // Day Dial fullscreen / ambient screensaver: hide or restore the
+        // status bar and home indicator (the iOS analogue of Android's
+        // immersive mode; same bridge method name on both shells).
+        case "setImmersiveMode":
+            guard let on = args.first as? Bool else { return "null" }
+            ImmersiveBridge.shared.set(on)
+            return "null"
+
         // Phase 11 — Spotlight
         case "indexSpotlight":
             guard let json = args.first as? String else { return "null" }

--- a/dayglance-ios/project.yml
+++ b/dayglance-ios/project.yml
@@ -101,7 +101,11 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         UIRequiresFullScreen: false
         UIStatusBarStyle: UIStatusBarStyleDefault
-        UIViewControllerBasedStatusBarAppearance: false
+        # View-controller-based so SwiftUI's .statusBarHidden works (Day Dial
+        # immersive mode). The theme-driven status bar text colour still works:
+        # the hosting controller reports .default, which resolves from the
+        # window's overridden user interface style (see StatusBarBridge).
+        UIViewControllerBasedStatusBarAppearance: true
         # Export compliance: false because the app's encryption uses only standard,
         # internationally-recognized algorithms (AES-256-GCM, PBKDF2-SHA-256,
         # HMAC-SHA-256) for end-to-end cloud sync/backup (@glance-apps/sync) in a

--- a/src/components/DayDialModal.jsx
+++ b/src/components/DayDialModal.jsx
@@ -6,7 +6,7 @@ import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { dateToString } from '../utils/taskUtils.js';
 import { getStoredWeatherCoords, getSunTimes } from '../utils/solar.js';
 import { acquireWakeLock, releaseWakeLock } from '../utils/wakeLock.js';
-import { isNativeAndroid, nativeSetImmersiveMode } from '../native.js';
+import { isNativeApp, nativeSetImmersiveMode } from '../native.js';
 import { AMBIENT_DELAY_OPTIONS, loadAmbientPrefs, saveAmbientPrefs } from '../utils/dialPrefs.js';
 import DayDial from './DayDial.jsx';
 import Wordmark from './Wordmark.jsx';
@@ -265,30 +265,33 @@ const DayDialModal = () => {
   // auto-fullscreen, and true kiosks launch the browser fullscreen instead).
   // Unsupported environments (e.g. iPhone Safari) just don't get the button.
   //
-  // The Android app is different: its WebView rejects the Fullscreen API
-  // (the shell implements no onShowCustomView), but the native bridge can
-  // hide the system bars itself — the same immersive call focus mode uses.
-  // So there "fullscreen" means immersive mode, tracked by hand because no
+  // The native apps are different: neither WebView offers the Fullscreen API
+  // (Android implements no onShowCustomView; iPhone WKWebView has none at
+  // all), but both shells can hide the system chrome themselves through the
+  // same setImmersiveMode bridge call — Android hides the status and nav
+  // bars, iOS the status bar and home indicator (an iOS shell predating the
+  // call no-ops harmlessly: the bar stays, as it always did). So there
+  // "fullscreen" means immersive mode, tracked by hand because no
   // fullscreenchange event ever fires; a bonus is that the native call
   // needs no user gesture, so ambient auto-start truly hides the bars.
   const containerRef = useRef(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const androidApp = isNativeAndroid();
-  const androidImmersiveRef = useRef(false);
-  const fullscreenSupported = androidApp ||
+  const nativeApp = isNativeApp();
+  const nativeImmersiveRef = useRef(false);
+  const fullscreenSupported = nativeApp ||
     (typeof document !== 'undefined' && !!document.fullscreenEnabled);
   // Current fullscreen truth, safe to read inside handlers where the
   // isFullscreen state could be stale.
   const inFullscreen = () =>
-    (androidApp ? androidImmersiveRef.current : !!document.fullscreenElement);
+    (nativeApp ? nativeImmersiveRef.current : !!document.fullscreenElement);
   // Resolves when this call took the screen fullscreen; rejects when it
   // didn't (already fullscreen, unsupported, or no gesture on the web) so
   // callers can track ownership exactly as requestFullscreen() allows.
   const enterFullscreen = () => {
     if (inFullscreen()) return Promise.reject(new Error('already fullscreen'));
-    if (androidApp) {
+    if (nativeApp) {
       nativeSetImmersiveMode(true);
-      androidImmersiveRef.current = true;
+      nativeImmersiveRef.current = true;
       setIsFullscreen(true);
       return Promise.resolve();
     }
@@ -298,10 +301,10 @@ const DayDialModal = () => {
     return Promise.reject(new Error('fullscreen unsupported'));
   };
   const exitFullscreen = () => {
-    if (androidApp) {
-      if (!androidImmersiveRef.current) return;
+    if (nativeApp) {
+      if (!nativeImmersiveRef.current) return;
       nativeSetImmersiveMode(false);
-      androidImmersiveRef.current = false;
+      nativeImmersiveRef.current = false;
       setIsFullscreen(false);
       return;
     }
@@ -315,7 +318,7 @@ const DayDialModal = () => {
       // Leaving the dial leaves fullscreen too — the planner underneath
       // should come back exactly as it was.
       if (document.fullscreenElement) document.exitFullscreen()?.catch(() => {});
-      if (androidImmersiveRef.current) nativeSetImmersiveMode(false);
+      if (nativeImmersiveRef.current) nativeSetImmersiveMode(false);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/native.js
+++ b/src/native.js
@@ -608,9 +608,11 @@ export const nativeExitFocusMode = () => {
 };
 
 /**
- * Hides (enter=true) or restores (enter=false) the system bars without
- * the DND/alarm side effects of full focus mode. Used by hyperGLANCE.
- * No-op when running as a PWA.
+ * Hides (enter=true) or restores (enter=false) the system chrome without
+ * the DND/alarm side effects of full focus mode: status + nav bars on
+ * Android, status bar + home indicator on iOS. Used by the Day Dial's
+ * fullscreen and ambient modes. No-op when running as a PWA (and on iOS
+ * shells predating the bridge case, where the call returns null).
  */
 export const nativeSetImmersiveMode = (enter) => {
   const bridge = nativeBridge();


### PR DESCRIPTION
## What

iPhone counterpart to #1427. Two separate things were going on in the iPhone screenshot situation:

1. **The wordmark / top controls clashing with the cutout and status bar** is already fixed by #1427: the WKWebView runs with `viewport-fit=cover`, so the `env(safe-area-inset-top)` offsets on the dial's top chrome apply on iOS too. The current TestFlight/App Store build just predates that merge — it fixes itself on the next iOS build with the new web bundle.

2. **Fullscreen genuinely couldn't work on iOS** — the iPhone WKWebView has no Fullscreen API at all. But iOS does allow the native shell to hide the system chrome, so this PR mirrors the Android approach:

- `BridgeSchemeHandler` gains a `setImmersiveMode` case (same bridge method name as the Android shell) that flips an observable flag (`ImmersiveBridge`, next to `StatusBarBridge`).
- `ContentView` observes it and applies `.statusBarHidden(...)` and `.persistentSystemOverlays(.hidden)` (dims the home indicator) while immersive.
- `project.yml` flips `UIViewControllerBasedStatusBarAppearance` to YES so SwiftUI's status-bar modifiers work. The theme-driven status-bar text color keeps working: the hosting controller reports `.default`, which resolves from the window's `overrideUserInterfaceStyle` — `StatusBarBridge` is unchanged.
- Web side: the dial's native-immersive path widens from `isNativeAndroid()` to `isNativeApp()`. The iOS bridge shim is a Proxy over any method name, so an older shell without the case no-ops harmlessly (the bar stays, as it always did). This also gives the iPad app the native path for the new tablet-header dial button (#1428).

On notched iPhones the top safe-area inset survives hiding the status bar (the cutout is physical), so the dial's chrome keeps clearing it — which is the correct look: clock and battery disappear, content never slides under the sensor housing.

## Verification

- Simulated both native bridges in headless Chromium (Android object bridge; iOS Proxy-over-any-method shim, answering `getSubscriptionStatus` like the real shell): asserted the exact immersive on/off sequences across the fullscreen button, ambient entry, wake tap, and close-while-immersive, with no HTML5 fullscreen engaged and no page errors.
- Lint, full test suite (2068 passed), and web production build pass.
- The Swift side compiles only on a Mac — needs an Xcode build to confirm (run `npm run ios:generate` first, since `project.yml` changed). Worth a quick device check that the status-bar text color still follows the app theme after the plist flip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk9wjwm9BC52zKF6vofEdy)_