### PR TITLE
Day Dial: fade an hour label while a sun mark sits on its station

### DIFF
--- a/src/components/DayDial.jsx
+++ b/src/components/DayDial.jsx
@@ -12,6 +12,7 @@ import {
   dialPoint,
   dialSectorPath,
   dialTicks,
+  dialLabelYieldsToSun,
   findDialFocusBlock,
   muteDialColor,
   padDialSegment,
@@ -478,7 +479,9 @@ const DayDial = ({ dayTasks, dayWindow, date, nowMin = null, dayIsPast = false, 
           <circle cx={CX} cy={CY} r={R_BEZEL} fill="none" stroke="#ffffff" strokeOpacity={0.07} strokeWidth={2} />
           <TickField />
 
-          {/* Hour labels every 3 hours, cardinals weighted above the rest. */}
+          {/* Hour labels every 3 hours, cardinals weighted above the rest.
+              A label yields (fades out) while a sunrise/sunset mark sits on
+              its station — see dialLabelYieldsToSun. */}
           {HOUR_LABELS.filter((l) => !(compact && l.side)).map((l) => {
             const p = dialPoint(CX, CY, 478, l.min);
             return (
@@ -486,7 +489,8 @@ const DayDial = ({ dayTasks, dayWindow, date, nowMin = null, dayIsPast = false, 
                 key={l.min}
                 x={p.x} y={p.y}
                 textAnchor="middle" dominantBaseline="central"
-                fill="#ffffff" fillOpacity={l.cardinal ? 0.4 : 0.26}
+                fill="#ffffff"
+                fillOpacity={dialLabelYieldsToSun(l.min, sun) ? 0 : (l.cardinal ? 0.4 : 0.26)}
                 style={{ fontSize: l.cardinal ? 26 : 21, letterSpacing: '0.25em', fontWeight: 500 }}
               >
                 {use24HourClock ? l.h24 : l.h12}

--- a/src/utils/dayDial.js
+++ b/src/utils/dayDial.js
@@ -273,3 +273,19 @@ export function findDialFocusBlock(blocks, nowMin) {
   const next = (blocks || []).find((b) => b.startMin > nowMin);
   return next ? { block: next, current: false } : null;
 }
+
+// A sunrise/sunset mark rides its hairline out to the hour-label radius, so
+// a sun time within about half an hour of a label parks the glyph on the
+// text ("6☼AM" for an August sunrise at 6:09). The label yields for those
+// weeks — the hairline and glyph name the station more precisely than the
+// text does. Distance is circular so a white-nights sunset at 23:50 clears
+// the midnight label too.
+export const SUN_LABEL_CLEARANCE_MIN = 30;
+
+export function dialLabelYieldsToSun(labelMin, sun) {
+  return [sun?.sunriseMin, sun?.sunsetMin].some((m) => {
+    if (m == null) return false;
+    const d = Math.abs(m - labelMin) % DIAL_DAY_MINUTES;
+    return Math.min(d, DIAL_DAY_MINUTES - d) < SUN_LABEL_CLEARANCE_MIN;
+  });
+}

--- a/src/utils/dayDial.test.js
+++ b/src/utils/dayDial.test.js
@@ -10,6 +10,7 @@ import {
   padDialSegment,
   classifyPrecip,
   computeDialModel,
+  dialLabelYieldsToSun,
   findDialFocusBlock,
   muteDialColor,
   precipRuns,
@@ -254,5 +255,36 @@ describe('findDialFocusBlock', () => {
   it('returns null when the rest of the day is clear', () => {
     expect(findDialFocusBlock(blocks, 1000)).toBeNull();
     expect(findDialFocusBlock([], 600)).toBeNull();
+  });
+});
+
+describe('dialLabelYieldsToSun', () => {
+  it('yields a label the sunrise mark sits on (August: 6:09 vs 6 AM)', () => {
+    expect(dialLabelYieldsToSun(360, { sunriseMin: 369, sunsetMin: 1183 })).toBe(true);
+  });
+
+  it('yields to a sunset near a label (equinox: 18:12 vs 6 PM)', () => {
+    expect(dialLabelYieldsToSun(1080, { sunriseMin: 420, sunsetMin: 1092 })).toBe(true);
+  });
+
+  it('leaves labels alone once the sun is clear of them', () => {
+    // Late May: sunrise 5:29, sunset 20:14 — both beyond the clearance.
+    expect(dialLabelYieldsToSun(360, { sunriseMin: 329, sunsetMin: 1214 })).toBe(false);
+    expect(dialLabelYieldsToSun(1080, { sunriseMin: 329, sunsetMin: 1214 })).toBe(false);
+  });
+
+  it('measures circularly across midnight', () => {
+    // White nights: a 23:50 sunset is 10 minutes from the 12 AM label.
+    expect(dialLabelYieldsToSun(0, { sunriseMin: 200, sunsetMin: 1430 })).toBe(true);
+  });
+
+  it('treats the clearance as exclusive at the boundary', () => {
+    expect(dialLabelYieldsToSun(360, { sunriseMin: 390, sunsetMin: null })).toBe(false);
+    expect(dialLabelYieldsToSun(360, { sunriseMin: 389, sunsetMin: null })).toBe(true);
+  });
+
+  it('is quiet with no solar data', () => {
+    expect(dialLabelYieldsToSun(360, null)).toBe(false);
+    expect(dialLabelYieldsToSun(360, { sunriseMin: null, sunsetMin: null })).toBe(false);
   });
 });


### PR DESCRIPTION
## What

A sunrise/sunset mark rides its hairline out to the hour-label radius, so whenever a sun time falls near a labeled hour the glyph parks directly on the text. An August sunrise at 6:09 renders as "6☼AM"; equinox sunsets do the same to "6 PM", and high-latitude winter sunrises can hit "9 AM". It's cosmetic, but it reads as a typo for a few weeks twice a year.

Per the agreed approach, the label now **yields**: any hour label renders at `fillOpacity` 0 while a sunrise or sunset is within 30 minutes of its station, and returns as the sun drifts on. The hairline and glyph name that moment more precisely than the text does, and nudging the glyph off its true angle or radius would blur the instrument's precision register.

The predicate is a pure helper, `dialLabelYieldsToSun(labelMin, sun)`, in `utils/dayDial.js` (clearance constant exported alongside), with tests covering the sunrise and sunset hits, the clear case, circular distance across midnight (a white-nights 23:50 sunset clears the 12 AM label), the exclusive boundary, and absent solar data. When the solar layer is off, `sun` is null and nothing changes.

Not for the current release — rides the next one.

## Verification

- 6 new unit tests; full suite 2074 passed, lint and build clean.
- Live repro in headless Chromium (Chicago timezone, August date): the 6 AM label renders at opacity 0 with the sunrise glyph alone on the station; all seven other labels keep their normal weights (6 PM included, since the 7:43 sunset is clear of it).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk9wjwm9BC52zKF6vofEdy)_