### PR TITLE
Launch Obsidian after vault writes (Obsidian build-out Phase 1)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -295,6 +295,24 @@ JS: window.DayGlanceObsidian.getDailyNote("2026-03-15")
   → returns raw markdown string
 ```
 
+### Launch-on-write
+
+After a debounced quiet window (8s) following vault writes, dayGLANCE fires
+`obsidian://open` for the last-written file so Obsidian Sync pushes the change
+even when Obsidian was closed. The debounce sits at each platform's write
+chokepoint, on the native side of the bridge: on Electron the
+`obsidian:write-file` handler feeds `electron/obsidianLaunch.ts` and the main
+process calls `shell.openExternal(uri, { activate: false })` (background launch
+on macOS; option ignored elsewhere); on Android `ObsidianRepository.writeText`
+feeds `LaunchOnWritePolicy` and the bridge fires the intent via its existing
+`openNote` path (`vault` + `file` form — SAF has no absolute path for `path=`).
+The toggle is a device-local tri-state key
+(`day-planner-obsidian-launch-on-write`, unset = platform default: on for
+macOS, off elsewhere), deliberately outside the cloud-synced `obsidianConfig`
+so one platform's setting can't leak to another. A failed launch is always
+silent — the vault write succeeded; only the wake didn't. Browser/PWA has no
+launch mechanism (a `window.open` from a timer is popup-blocked).
+
 ### Markdown parsing
 
 Both paths use the same parser in `obsidian.js`. Supported task formats:

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/ObsidianBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/ObsidianBridge.kt
@@ -4,7 +4,11 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
 import android.webkit.JavascriptInterface
+import com.dayglance.app.data.LaunchOnWritePolicy
 import com.dayglance.app.data.ObsidianRepository
 
 /**
@@ -19,6 +23,36 @@ import com.dayglance.app.data.ObsidianRepository
 class ObsidianBridge(private val context: Context, private val webView: android.webkit.WebView? = null) {
 
     private val repository = ObsidianRepository(context)
+
+    // Launch-on-write (Obsidian build-out Phase 1): after a debounced quiet
+    // window following vault writes, open the last-written note so Obsidian
+    // Sync pushes the change. The policy owns the timing (JVM-tested); this
+    // bridge schedules one delayed check per write — a check made stale by a
+    // later write returns null from fireIfQuiet, so nothing needs cancelling.
+    // Disabled until the web frontend pushes the device-local toggle via
+    // setLaunchOnWrite (Android default: off).
+    private val launchPolicy = LaunchOnWritePolicy()
+    private val launchHandler = Handler(Looper.getMainLooper())
+
+    init {
+        repository.onVaultWrite = { noteName ->
+            launchPolicy.onWrite(noteName, SystemClock.elapsedRealtime())?.let { delayMs ->
+                launchHandler.postDelayed({
+                    launchPolicy.fireIfQuiet(SystemClock.elapsedRealtime())?.let { openNote(it) }
+                }, delayMs)
+            }
+        }
+    }
+
+    /**
+     * Pushed by the web frontend (device-local toggle) at startup and on every
+     * change. The launch itself reuses [openNote], which already degrades the
+     * way the write path requires: no vault name or no Obsidian installed is
+     * silently ignored — the vault write succeeded, only the wake didn't, so
+     * no error surfaces and sync status is untouched.
+     */
+    @JavascriptInterface
+    fun setLaunchOnWrite(enabled: Boolean) = launchPolicy.setEnabled(enabled)
 
     /**
      * Returns the raw markdown content of the daily note for [date] (ISO: yyyy-MM-dd).
@@ -177,7 +211,12 @@ class ObsidianBridge(private val context: Context, private val webView: android.
     /**
      * Clears the stored vault URI so the integration returns to unconfigured state.
      * Does NOT revoke the SAF permission — the user can re-select the same folder.
+     * Also drops any pending launch-on-write (the pending note belongs to the
+     * vault being swapped away from) while keeping the user's toggle intact.
      */
     @JavascriptInterface
-    fun clearVault() = repository.clearVault()
+    fun clearVault() {
+        launchPolicy.cancelPending()
+        repository.clearVault()
+    }
 }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/LaunchOnWritePolicy.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/LaunchOnWritePolicy.kt
@@ -1,0 +1,77 @@
+package com.dayglance.app.data
+
+/**
+ * Launch-on-write debounce (Obsidian build-out Phase 1): after a quiet window
+ * following vault writes, the last-written note is opened via obsidian:// so
+ * Obsidian Sync pushes the change.
+ *
+ * Pure timing policy with all clocks injected, JVM-testable without Android —
+ * the same pattern as [com.dayglance.app.sse.SseBackoff]. The platform layer
+ * (ObsidianBridge) schedules a delayed check per write and calls [fireIfQuiet]
+ * when it lands; a check made stale by a later write simply returns null, so
+ * no platform timer ever needs cancelling.
+ *
+ * Starts DISABLED and stays so until the web frontend pushes the device-local
+ * toggle over setLaunchOnWrite, so nothing can fire ahead of the user's
+ * stored setting (Android default: off).
+ */
+class LaunchOnWritePolicy(private val quietMs: Long = QUIET_MS) {
+
+    companion object {
+        /**
+         * 8 seconds, trailing edge, reset on every write (spec §6 Phase 1) —
+         * matches LAUNCH_ON_WRITE_QUIET_MS in electron/obsidianLaunch.ts.
+         */
+        const val QUIET_MS = 8_000L
+    }
+
+    private var enabled = false
+    private var pendingNote: String? = null
+    private var deadlineMs = 0L
+
+    /** Web-pushed toggle. Turning off drops any pending launch. */
+    @Synchronized
+    fun setEnabled(value: Boolean) {
+        enabled = value
+        if (!value) clearPending()
+    }
+
+    /**
+     * Drop any pending launch without touching the enabled flag — for
+     * clearVault, where the pending note belongs to a vault the user just
+     * swapped away from. The toggle is the user's setting and survives.
+     */
+    @Synchronized
+    fun cancelPending() = clearPending()
+
+    /**
+     * Record a successful vault write of [noteName] (bare name, no .md).
+     * Returns the delay in ms after which the caller should schedule a
+     * [fireIfQuiet] check, or null when launch-on-write is disabled.
+     */
+    @Synchronized
+    fun onWrite(noteName: String, nowMs: Long): Long? {
+        if (!enabled) return null
+        pendingNote = noteName
+        deadlineMs = nowMs + quietMs
+        return quietMs
+    }
+
+    /**
+     * Called when a scheduled check lands. Returns the note to open when the
+     * quiet window has elapsed (clearing the pending state), or null when a
+     * later write extended the window — that write's own check handles it.
+     */
+    @Synchronized
+    fun fireIfQuiet(nowMs: Long): String? {
+        val note = pendingNote ?: return null
+        if (nowMs < deadlineMs) return null
+        clearPending()
+        return note
+    }
+
+    private fun clearPending() {
+        pendingNote = null
+        deadlineMs = 0L
+    }
+}

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
@@ -25,6 +25,16 @@ class ObsidianRepository(private val context: Context) {
 
     private val dataStore = SharedDataStore(context)
 
+    /**
+     * Post-write chokepoint listener (launch-on-write, Obsidian build-out
+     * Phase 1). Every vault write — daily notes, wiki notes, appends — reaches
+     * disk through [writeText], so this is the one place a successful write is
+     * announced. Invoked with the written file's bare name (no .md).
+     * ObsidianBridge wires this to its LaunchOnWritePolicy.
+     */
+    @Volatile
+    var onVaultWrite: ((noteName: String) -> Unit)? = null
+
     // ── Note URI index ───────────────────────────────────────────────────────
     //
     // SAF recursive search (DocumentFile.listFiles + findFile) is expensive:
@@ -128,11 +138,16 @@ class ObsidianRepository(private val context: Context) {
         // buffer is flushed to disk before the stream closes.  Closing only the
         // OutputStream while a BufferedWriter wraps it leaves the buffer unflushed,
         // which silently truncates the file to zero bytes.
-        context.contentResolver.openOutputStream(file.uri, "wt")?.use { outputStream ->
-            outputStream.bufferedWriter().use { writer ->
+        val outputStream = context.contentResolver.openOutputStream(file.uri, "wt") ?: return
+        outputStream.use { stream ->
+            stream.bufferedWriter().use { writer ->
                 writer.write(text)
             }
         }
+        // Announce only a write that actually reached the stream (a null stream
+        // above wrote nothing and must not wake Obsidian).
+        val noteName = file.name?.removeSuffix(".md") ?: return
+        onVaultWrite?.invoke(noteName)
     }
 
     // ── Public API ───────────────────────────────────────────────────────────

--- a/dayglance-android/app/src/test/java/com/dayglance/app/data/LaunchOnWritePolicyTest.kt
+++ b/dayglance-android/app/src/test/java/com/dayglance/app/data/LaunchOnWritePolicyTest.kt
@@ -1,0 +1,80 @@
+package com.dayglance.app.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for the launch-on-write debounce policy. Mirrors the contract the
+ * Electron scheduler is tested for (electron/obsidianLaunch.test.ts), so native
+ * and desktop behaviour match: a burst of writes within the quiet window
+ * produces exactly one launch, writes separated by more than the window produce
+ * one each, and the toggle off produces none.
+ *
+ * All times are explicit millis — the policy owns no clock, so every test is
+ * deterministic. The 8s window comes from LaunchOnWritePolicy.QUIET_MS.
+ */
+class LaunchOnWritePolicyTest {
+
+    private val quiet = LaunchOnWritePolicy.QUIET_MS
+
+    @Test
+    fun `a burst of writes within the quiet window fires exactly once, with the last note`() {
+        val p = LaunchOnWritePolicy()
+        p.setEnabled(true)
+        assertEquals(quiet, p.onWrite("a", 0))
+        assertEquals(quiet, p.onWrite("b", 3_000))
+        assertEquals(quiet, p.onWrite("c", 6_000))
+        // The checks scheduled by "a" and "b" land while a later write holds
+        // the deadline open — both are stale and must not fire.
+        assertNull(p.fireIfQuiet(quiet))
+        assertNull(p.fireIfQuiet(3_000 + quiet - 1))
+        assertEquals("c", p.fireIfQuiet(6_000 + quiet))
+        // And nothing more fires later.
+        assertNull(p.fireIfQuiet(60_000))
+    }
+
+    @Test
+    fun `writes separated by more than the window fire once each`() {
+        val p = LaunchOnWritePolicy()
+        p.setEnabled(true)
+        p.onWrite("a", 0)
+        assertEquals("a", p.fireIfQuiet(quiet))
+        p.onWrite("b", 20_000)
+        assertEquals("b", p.fireIfQuiet(20_000 + quiet))
+    }
+
+    @Test
+    fun `disabled (the initial state) records nothing and fires nothing`() {
+        val p = LaunchOnWritePolicy()
+        assertNull(p.onWrite("a", 0))
+        assertNull(p.fireIfQuiet(60_000))
+        // Enabling later must not resurrect the ignored write.
+        p.setEnabled(true)
+        assertNull(p.fireIfQuiet(120_000))
+    }
+
+    @Test
+    fun `toggling off drops a pending launch`() {
+        val p = LaunchOnWritePolicy()
+        p.setEnabled(true)
+        p.onWrite("a", 0)
+        p.setEnabled(false)
+        assertNull(p.fireIfQuiet(quiet))
+    }
+
+    @Test
+    fun `clearVault then a fresh vault - pending is dropped but the enabled flag is not left stale`() {
+        // ObsidianBridge.clearVault calls cancelPending() — a launch must not
+        // fire against a vault the user just swapped away from, but the user's
+        // toggle survives the swap, so a write into the NEW vault schedules
+        // normally.
+        val p = LaunchOnWritePolicy()
+        p.setEnabled(true)
+        p.onWrite("old-vault-note", 0)
+        p.cancelPending()
+        assertNull(p.fireIfQuiet(quiet))
+        assertEquals(quiet, p.onWrite("new-vault-note", 10_000))
+        assertEquals("new-vault-note", p.fireIfQuiet(10_000 + quiet))
+    }
+}

--- a/electron/obsidian.ts
+++ b/electron/obsidian.ts
@@ -1,7 +1,8 @@
 import { ipcMain, app, dialog, shell, BrowserWindow } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
-import { buildObsidianOpenUri } from './obsidianUri.js';
+import { buildObsidianOpenUri, buildObsidianOpenPathUri } from './obsidianUri.js';
+import { createLaunchScheduler } from './obsidianLaunch.js';
 
 // ── Obsidian vault access (Electron) ─────────────────────────────────────────
 //
@@ -27,6 +28,24 @@ interface VaultConfig { path: string; bookmark?: string; }
 
 let vaultBasePath: string | null = null;
 let stopAccessing: (() => void) | null = null;
+
+// Launch-on-write (Obsidian build-out Phase 1): after a debounced quiet window
+// following vault writes, open the last-written file so Obsidian Sync pushes
+// the change. Fed by the obsidian:write-file handler below — the single funnel
+// every desktop write path runs through. The scheduler starts DISABLED and
+// stays so until the renderer pushes the device-local toggle over
+// obsidian:set-launch-on-write, so no launch can fire ahead of the user's
+// stored setting.
+const launchScheduler = createLaunchScheduler((absPath) => {
+  const uri = buildObsidianOpenPathUri(absPath);
+  if (!uri) return;
+  // activate: false is macOS-only (ignored elsewhere): the launch goes through
+  // LaunchServices without taking focus, App Store sandbox included. Failures
+  // stay silent BY DESIGN — on Linux the obsidian:// handler is frequently
+  // unregistered (AppImage installs), and the vault write already succeeded;
+  // only the wake didn't. No error state, no toast.
+  shell.openExternal(uri, { activate: false }).catch(() => { /* ignore */ });
+});
 
 function configPath(): string {
   return path.join(app.getPath('userData'), 'obsidian-vault.json');
@@ -87,6 +106,8 @@ export function registerObsidianHandlers(): void {
     saveConfig({ path: dir, bookmark });
     vaultBasePath = dir;
     beginAccess(bookmark);
+    // A pending launch would point into the vault just swapped away from.
+    launchScheduler.cancelPending();
     return { path: dir, name: path.basename(dir) };
   });
 
@@ -143,6 +164,18 @@ export function registerObsidianHandlers(): void {
     if (stopAccessing) { try { stopAccessing(); } catch { /* ignore */ } stopAccessing = null; }
     vaultBasePath = null;
     clearConfig();
+    // Pending only, not the enabled flag: the toggle is the user's setting and
+    // survives a vault swap — a write into a newly picked vault schedules again.
+    launchScheduler.cancelPending();
+    return true;
+  });
+
+  // The renderer pushes the device-local launch-on-write setting here at
+  // startup and on every toggle change. Boolean only — the renderer never
+  // supplies a URI or path, so the http/https-only external-URL allowlist
+  // documented at obsidian:open-note keeps its security property.
+  ipcMain.handle('obsidian:set-launch-on-write', async (_e, enabled: unknown) => {
+    launchScheduler.setEnabled(enabled === true);
     return true;
   });
 
@@ -183,13 +216,24 @@ export function registerObsidianHandlers(): void {
   });
 
   // Write a file (creating parent directories). Returns true on success.
+  // Post-write chokepoint: every desktop vault write — daily notes, task
+  // write-back, wiki notes — reaches disk through this handler (via the shim's
+  // createWritable().close()), so launch-on-write hooks here and nowhere else.
   ipcMain.handle('obsidian:write-file', async (_e, relativePath: string, content: string) => {
     const abs = resolveInVault(relativePath);
     if (!abs) return false;
     try {
       fs.mkdirSync(path.dirname(abs), { recursive: true });
       fs.writeFileSync(abs, content, 'utf-8');
+      launchScheduler.noteWrite(abs);
       return true;
     } catch { return false; }
   });
+
+  // A pending launch at quit fires immediately rather than being dropped:
+  // editing a task and closing the app inside the quiet window is a normal
+  // pattern, and dropping the launch would leave that edit unpushed until the
+  // next write. openExternal is fire-and-forget here (no await, no
+  // preventDefault), so quit is not delayed.
+  app.on('will-quit', () => { launchScheduler.flush(); });
 }

--- a/electron/obsidianLaunch.test.ts
+++ b/electron/obsidianLaunch.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { createLaunchScheduler, LAUNCH_ON_WRITE_QUIET_MS } from './obsidianLaunch.js';
+
+// The debounce contract for launch-on-write (spec §6 Phase 1): a burst of
+// writes within the quiet window produces exactly one launch, writes separated
+// by more than the window produce one each, and the toggle off produces none.
+// Timers are injected as a deterministic fake so no test ever sleeps.
+
+function fakeTimers() {
+  let now = 0;
+  let nextId = 1;
+  const tasks = new Map<number, { at: number; fn: () => void }>();
+  return {
+    timers: {
+      setTimeout: (fn: () => void, ms: number) => {
+        const id = nextId++;
+        tasks.set(id, { at: now + ms, fn });
+        return id;
+      },
+      clearTimeout: (handle: unknown) => {
+        tasks.delete(handle as number);
+      },
+    },
+    advance(ms: number) {
+      const target = now + ms;
+      for (;;) {
+        const due = [...tasks.entries()]
+          .filter(([, t]) => t.at <= target)
+          .sort((a, b) => a[1].at - b[1].at)[0];
+        if (!due) break;
+        tasks.delete(due[0]);
+        now = due[1].at;
+        due[1].fn();
+      }
+      now = target;
+    },
+  };
+}
+
+function setup(quietMs = LAUNCH_ON_WRITE_QUIET_MS) {
+  const { timers, advance } = fakeTimers();
+  const launches: string[] = [];
+  const scheduler = createLaunchScheduler((p) => launches.push(p), quietMs, timers);
+  return { scheduler, launches, advance };
+}
+
+describe('createLaunchScheduler', () => {
+  it('coalesces a burst of writes within the quiet window into one launch of the last file', () => {
+    const { scheduler, launches, advance } = setup();
+    scheduler.setEnabled(true);
+    scheduler.noteWrite('/vault/a.md');
+    advance(3_000);
+    scheduler.noteWrite('/vault/b.md');
+    advance(3_000);
+    scheduler.noteWrite('/vault/c.md');
+    // 6s in, nothing yet — every write reset the window.
+    expect(launches).toEqual([]);
+    advance(LAUNCH_ON_WRITE_QUIET_MS);
+    expect(launches).toEqual(['/vault/c.md']);
+    // And nothing more fires later.
+    advance(60_000);
+    expect(launches).toEqual(['/vault/c.md']);
+  });
+
+  it('launches once per write when writes are separated by more than the window', () => {
+    const { scheduler, launches, advance } = setup();
+    scheduler.setEnabled(true);
+    scheduler.noteWrite('/vault/a.md');
+    advance(LAUNCH_ON_WRITE_QUIET_MS);
+    scheduler.noteWrite('/vault/b.md');
+    advance(LAUNCH_ON_WRITE_QUIET_MS);
+    expect(launches).toEqual(['/vault/a.md', '/vault/b.md']);
+  });
+
+  it('produces no launch while disabled (the initial state)', () => {
+    const { scheduler, launches, advance } = setup();
+    scheduler.noteWrite('/vault/a.md');
+    advance(60_000);
+    expect(launches).toEqual([]);
+    // Enabling later must not resurrect the ignored write.
+    scheduler.setEnabled(true);
+    advance(60_000);
+    expect(launches).toEqual([]);
+  });
+
+  it('toggling off clears a pending launch', () => {
+    const { scheduler, launches, advance } = setup();
+    scheduler.setEnabled(true);
+    scheduler.noteWrite('/vault/a.md');
+    scheduler.setEnabled(false);
+    advance(60_000);
+    expect(launches).toEqual([]);
+  });
+
+  it('disconnect then a fresh pick: pending is dropped but the enabled flag is not left stale', () => {
+    // The obsidian:disconnect / obsidian:pick handlers call cancelPending() —
+    // a launch must not fire against a vault the user just swapped away from,
+    // but the user's toggle survives the swap, so a write into the NEW vault
+    // schedules normally.
+    const { scheduler, launches, advance } = setup();
+    scheduler.setEnabled(true);
+    scheduler.noteWrite('/old-vault/a.md');
+    scheduler.cancelPending(); // disconnect + pick of a different vault
+    advance(60_000);
+    expect(launches).toEqual([]);
+    scheduler.noteWrite('/new-vault/b.md');
+    advance(LAUNCH_ON_WRITE_QUIET_MS);
+    expect(launches).toEqual(['/new-vault/b.md']);
+  });
+
+  it('flush fires a pending launch immediately, exactly once', () => {
+    // App quit inside the quiet window: the edit still propagates.
+    const { scheduler, launches, advance } = setup();
+    scheduler.setEnabled(true);
+    scheduler.noteWrite('/vault/a.md');
+    scheduler.flush();
+    expect(launches).toEqual(['/vault/a.md']);
+    // The original timer was cancelled — no double fire.
+    advance(60_000);
+    expect(launches).toEqual(['/vault/a.md']);
+  });
+
+  it('flush with nothing pending is a no-op', () => {
+    const { scheduler, launches } = setup();
+    scheduler.setEnabled(true);
+    scheduler.flush();
+    expect(launches).toEqual([]);
+  });
+});

--- a/electron/obsidianLaunch.ts
+++ b/electron/obsidianLaunch.ts
@@ -1,0 +1,91 @@
+// Launch-on-write debounce (Obsidian build-out Phase 1): after a quiet window
+// following vault writes, the last-written file is opened via obsidian:// so
+// Obsidian Sync pushes the change. Pure module with injected timers so the
+// debounce is unit-testable without Electron (same pattern as fsRetry.ts and
+// obsidianUri.ts).
+//
+// WHY THIS LIVES IN THE MAIN PROCESS: every desktop vault write funnels through
+// the obsidian:write-file IPC handler — the one place that both knows the
+// resolved absolute path and knows whether the write succeeded. The renderer
+// only ever pushes a boolean toggle over IPC; it never supplies a URI or path,
+// preserving the http/https-only external-URL posture documented in
+// obsidianUri.ts.
+
+// 8 seconds, trailing edge, reset on every write (spec §6 Phase 1): a leisurely
+// triage session can have 5-plus second gaps between task edits, which a
+// shorter window would split into multiple launches, while past 8 seconds
+// nothing further coalesces in practice. An extra launch is nearly free (it
+// focuses or no-ops); added delay is invisible.
+export const LAUNCH_ON_WRITE_QUIET_MS = 8_000;
+
+export interface LaunchOnWriteTimers {
+  setTimeout: (fn: () => void, ms: number) => unknown;
+  clearTimeout: (handle: unknown) => void;
+}
+
+export interface LaunchScheduler {
+  /** Renderer-pushed toggle. Turning off clears any pending launch. */
+  setEnabled(enabled: boolean): void;
+  /** Record a successful vault write; (re)starts the quiet window. */
+  noteWrite(absPath: string): void;
+  /**
+   * Drop any pending launch without touching the enabled flag — for
+   * obsidian:disconnect and obsidian:pick, where the pending path belongs to
+   * a vault the user just swapped away from.
+   */
+  cancelPending(): void;
+  /** Fire a pending launch immediately (app quit) instead of dropping it. */
+  flush(): void;
+}
+
+const defaultTimers: LaunchOnWriteTimers = {
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+export function createLaunchScheduler(
+  launch: (absPath: string) => void,
+  quietMs: number = LAUNCH_ON_WRITE_QUIET_MS,
+  timers: LaunchOnWriteTimers = defaultTimers,
+): LaunchScheduler {
+  let enabled = false;
+  let timer: unknown = null;
+  let pendingPath: string | null = null;
+
+  const clearPending = () => {
+    if (timer !== null) {
+      timers.clearTimeout(timer);
+      timer = null;
+    }
+    pendingPath = null;
+  };
+
+  return {
+    setEnabled(next: boolean) {
+      enabled = next;
+      if (!next) clearPending();
+    },
+
+    noteWrite(absPath: string) {
+      if (!enabled) return;
+      // A burst opens the last-written file; any file in the vault wakes Sync.
+      pendingPath = absPath;
+      if (timer !== null) timers.clearTimeout(timer);
+      timer = timers.setTimeout(() => {
+        timer = null;
+        const path = pendingPath;
+        pendingPath = null;
+        if (path) launch(path);
+      }, quietMs);
+    },
+
+    cancelPending: clearPending,
+
+    flush() {
+      if (pendingPath === null) return;
+      const path = pendingPath;
+      clearPending();
+      launch(path);
+    },
+  };
+}

--- a/electron/obsidianUri.test.ts
+++ b/electron/obsidianUri.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildObsidianOpenUri } from './obsidianUri.js';
+import { buildObsidianOpenUri, buildObsidianOpenPathUri } from './obsidianUri.js';
 
 // Regression tests for "Open in Obsidian" doing nothing on macOS. Two defects
 // met here: the renderer's window.open('obsidian://…') was dropped by the
@@ -57,5 +57,36 @@ describe('buildObsidianOpenUri', () => {
     expect(buildObsidianOpenUri(undefined as unknown as string, 'Note')).toBeNull();
     expect(buildObsidianOpenUri('Vault', null as unknown as string)).toBeNull();
     expect(buildObsidianOpenUri('Vault', 42 as unknown as string)).toBeNull();
+  });
+});
+
+// Launch-on-write (Phase 1): the deep link fired by the main process after the
+// debounced quiet window. `path` overrides `vault` and `file`, so the URI
+// carries only the absolute path resolveInVault produced.
+
+describe('buildObsidianOpenPathUri', () => {
+  it('builds a path URI from a POSIX absolute path', () => {
+    expect(buildObsidianOpenPathUri('/Users/me/Vault/Daily Notes/2026-08-22.md'))
+      .toBe('obsidian://open?path=%2FUsers%2Fme%2FVault%2FDaily%20Notes%2F2026-08-22.md');
+  });
+
+  it('builds a path URI from a Windows absolute path (drive colon and backslashes encoded)', () => {
+    expect(buildObsidianOpenPathUri('C:\\Vault\\note.md'))
+      .toBe('obsidian://open?path=C%3A%5CVault%5Cnote.md');
+  });
+
+  it('does not strip or trim — the path is a resolved filesystem path, not a wikilink', () => {
+    // A pre-existing vault file may legally contain '#' (the portability
+    // validator only refuses CREATING such names); the exact path must survive.
+    expect(buildObsidianOpenPathUri('/v/Notes #1.md'))
+      .toBe('obsidian://open?path=%2Fv%2FNotes%20%231.md');
+  });
+
+  it('returns null for empty, blank, or non-string input', () => {
+    expect(buildObsidianOpenPathUri('')).toBeNull();
+    expect(buildObsidianOpenPathUri('   ')).toBeNull();
+    expect(buildObsidianOpenPathUri(undefined as unknown as string)).toBeNull();
+    expect(buildObsidianOpenPathUri(null as unknown as string)).toBeNull();
+    expect(buildObsidianOpenPathUri(42 as unknown as string)).toBeNull();
   });
 });

--- a/electron/obsidianUri.ts
+++ b/electron/obsidianUri.ts
@@ -33,3 +33,22 @@ export function buildObsidianOpenUri(vaultName: string, noteName: string): strin
 
   return `obsidian://open?vault=${encodeURIComponent(vault)}&file=${encodeURIComponent(note)}`;
 }
+
+/**
+ * Builds the launch-on-write deep link for the vault file at an ABSOLUTE path.
+ * Obsidian's `path` parameter overrides both `vault` and `file`, so no vault
+ * name is needed — which is exactly right here, since only the main process
+ * holds the real path (resolveInVault in obsidian.ts) and the renderer is
+ * never involved.
+ *
+ * Unlike buildObsidianOpenUri there is no `#Heading` stripping or trimming:
+ * the input is a filesystem path the main process itself resolved, not a
+ * user-typed wikilink, and it must be passed through exactly.
+ *
+ * @param absPath Absolute path of the file just written.
+ * @returns The obsidian://open URI, or null when the input is unusable.
+ */
+export function buildObsidianOpenPathUri(absPath: string): string | null {
+  if (typeof absPath !== 'string' || absPath.trim() === '') return null;
+  return `obsidian://open?path=${encodeURIComponent(absPath)}`;
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -317,5 +317,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('obsidian:read-file', relativePath),
     writeFile: (relativePath: string, content: string): Promise<boolean> =>
       ipcRenderer.invoke('obsidian:write-file', relativePath, content),
+    // Pushes the device-local launch-on-write toggle to the main process,
+    // which owns the post-write debounce and fires the obsidian:// deep link
+    // itself. Boolean only — no URI ever crosses this boundary.
+    setLaunchOnWrite: (enabled: boolean): Promise<boolean> =>
+      ipcRenderer.invoke('obsidian:set-launch-on-write', enabled),
   },
 });

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -267,6 +267,8 @@
     "obsidianFilenamePattern": "Dateinamenmuster",
     "obsidianTaskHeading": "Aufgaben-Überschrift",
     "obsidianDailyNoteTemplate": "Vorlage für tägliche Notizen",
+    "obsidianLaunchOnWrite": "Obsidian nach Schreibvorgängen starten",
+    "obsidianLaunchOnWriteHint": "Nachdem dayGLANCE in Ihren Tresor geschrieben hat, wird Obsidian gestartet, damit Obsidian Sync die Änderung an Ihre anderen Geräte überträgt. Auf macOS geschieht das im Hintergrund.",
     "obsidianSyncComplete": "Synchronisierung abgeschlossen",
     "obsidianSyncFailed": "Synchronisierung fehlgeschlagen. Konsole prüfen",
     "obsidianSelectVault": "Tresorordner auswählen",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -270,6 +270,8 @@
     "obsidianFilenamePattern": "Filename pattern",
     "obsidianTaskHeading": "Task heading",
     "obsidianDailyNoteTemplate": "Daily note template",
+    "obsidianLaunchOnWrite": "Launch Obsidian after writes",
+    "obsidianLaunchOnWriteHint": "After dayGLANCE writes to your vault, launch Obsidian so Obsidian Sync can push the change to your other devices. On macOS this happens in the background.",
     "obsidianSyncComplete": "Sync complete",
     "obsidianSyncFailed": "Sync failed. Check console for details",
     "obsidianSelectVault": "Select Vault Folder",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -267,6 +267,8 @@
     "obsidianFilenamePattern": "Patrón de nombre de archivo",
     "obsidianTaskHeading": "Encabezado de tareas",
     "obsidianDailyNoteTemplate": "Plantilla de nota diaria",
+    "obsidianLaunchOnWrite": "Abrir Obsidian tras las escrituras",
+    "obsidianLaunchOnWriteHint": "Después de que dayGLANCE escriba en tu vault, se abre Obsidian para que Obsidian Sync envíe el cambio a tus otros dispositivos. En macOS esto ocurre en segundo plano.",
     "obsidianSyncComplete": "Sincronización completada",
     "obsidianSyncFailed": "Sincronización fallida. Ver consola para detalles",
     "obsidianSelectVault": "Seleccionar carpeta del vault",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -267,6 +267,8 @@
     "obsidianFilenamePattern": "Modèle de nom de fichier",
     "obsidianTaskHeading": "En-tête des tâches",
     "obsidianDailyNoteTemplate": "Modèle de note quotidienne",
+    "obsidianLaunchOnWrite": "Lancer Obsidian après les écritures",
+    "obsidianLaunchOnWriteHint": "Après que dayGLANCE a écrit dans votre coffre, Obsidian est lancé pour qu'Obsidian Sync propage la modification vers vos autres appareils. Sur macOS, cela se fait en arrière-plan.",
     "obsidianSyncComplete": "Synchronisation terminée",
     "obsidianSyncFailed": "Échec de la synchronisation. Voir la console pour les détails",
     "obsidianSelectVault": "Sélectionner le dossier du coffre",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -267,6 +267,8 @@
     "obsidianFilenamePattern": "Schema nome file",
     "obsidianTaskHeading": "Intestazione attività",
     "obsidianDailyNoteTemplate": "Modello nota giornaliera",
+    "obsidianLaunchOnWrite": "Avvia Obsidian dopo le scritture",
+    "obsidianLaunchOnWriteHint": "Dopo che dayGLANCE ha scritto nel tuo vault, Obsidian viene avviato così Obsidian Sync invia la modifica agli altri tuoi dispositivi. Su macOS avviene in background.",
     "obsidianSyncComplete": "Sincronizzazione completata",
     "obsidianSyncFailed": "Sincronizzazione fallita. Controlla la console",
     "obsidianSelectVault": "Seleziona cartella vault",

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -267,6 +267,8 @@
     "obsidianFilenamePattern": "Padrão de nome de arquivo",
     "obsidianTaskHeading": "Cabeçalho de tarefas",
     "obsidianDailyNoteTemplate": "Modelo de nota diária",
+    "obsidianLaunchOnWrite": "Abrir o Obsidian após gravações",
+    "obsidianLaunchOnWriteHint": "Depois que o dayGLANCE gravar no seu vault, o Obsidian é aberto para que o Obsidian Sync envie a alteração para os seus outros dispositivos. No macOS isso acontece em segundo plano.",
     "obsidianSyncComplete": "Sincronização concluída",
     "obsidianSyncFailed": "Sincronização falhou. Ver consola para detalhes",
     "obsidianSelectVault": "Selecionar pasta do vault",

--- a/public/locales/pt-PT/translation.json
+++ b/public/locales/pt-PT/translation.json
@@ -267,6 +267,8 @@
     "obsidianFilenamePattern": "Padrão de nome de ficheiro",
     "obsidianTaskHeading": "Cabeçalho de tarefas",
     "obsidianDailyNoteTemplate": "Modelo de nota diária",
+    "obsidianLaunchOnWrite": "Abrir o Obsidian após escritas",
+    "obsidianLaunchOnWriteHint": "Depois de o dayGLANCE escrever no seu vault, o Obsidian é aberto para que o Obsidian Sync envie a alteração para os seus outros dispositivos. No macOS isto acontece em segundo plano.",
     "obsidianSyncComplete": "Sincronização concluída",
     "obsidianSyncFailed": "Sincronização falhou. Ver consola para detalhes",
     "obsidianSelectVault": "Selecionar pasta do vault",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -746,6 +746,7 @@ const DayPlanner = () => {
   // Obsidian Integration state
   const {
     obsidianConfig, setObsidianConfig,
+    obsidianLaunchOnWrite, setObsidianLaunchOnWrite,
     obsidianSyncStatus, setObsidianSyncStatus,
     obsidianSyncError, setObsidianSyncError,
     obsidianLastSynced, setObsidianLastSynced,
@@ -2754,6 +2755,7 @@ const DayPlanner = () => {
     setWikilinkCandidates,
     setUnportableVaultFiles,
     obsidianConfig, setObsidianConfig,
+    obsidianLaunchOnWrite,
     setObsidianSyncStatus, setObsidianSyncError, setObsidianLastSynced,
     obsidianVaultHandleRef, obsidianSyncInProgressRef, obsidianPrevTaskStateRef,
     obsidianTasksRef, obsidianInboxRef,
@@ -8408,6 +8410,7 @@ const DayPlanner = () => {
 
     // ── Obsidian ──────────────────────────────────────────────────────────────
     obsidianConfig, setObsidianConfig,
+    obsidianLaunchOnWrite, setObsidianLaunchOnWrite,
     obsidianSyncStatus, setObsidianSyncStatus,
     obsidianSyncError, setObsidianSyncError,
     obsidianLastSynced, setObsidianLastSynced,

--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -16,6 +16,7 @@ import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, scanVaultNotes, formatDatePattern } from '../obsidian.js';
 import UnportableVaultNamesPanel from './UnportableVaultNamesPanel.jsx';
 import { validateDailyNotePattern, validateVaultFolderSetting } from '../utils/obsidianFilename.js';
+import { effectiveLaunchOnWrite } from '../utils/obsidianLaunchOnWrite.js';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
 import ICloudDiagnostics from './ICloudDiagnostics.jsx';
 import ICloudSyncToggle from './ICloudSyncToggle.jsx';
@@ -95,6 +96,7 @@ const MobileSettingsPanel = () => {
     cloudSyncStatus, cloudSyncLastSynced, cloudSyncError,
     syncKeyReady, setSyncKeyReady,
     obsidianConfig, setObsidianConfig,
+    obsidianLaunchOnWrite, setObsidianLaunchOnWrite,
     obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
     wikilinkCandidates, setWikilinkCandidates,
     unportableVaultFiles, setUnportableVaultFiles,
@@ -107,6 +109,15 @@ const MobileSettingsPanel = () => {
     setShowIntentActivityLog,
     removeFileImportedEvents,
   } = useSyncCtx();
+
+  // Launch-on-write (Obsidian Phase 1) is shown only where a launch mechanism
+  // exists: Electron (main-process shell.openExternal) or the Android bridge
+  // intent. Plain browser has neither — a window.open fired from a debounce
+  // timer is popup-blocked without a user gesture. The platform string feeds
+  // the per-platform default (macOS on, everything else off).
+  const launchOnWritePlatform = window.electronAPI?.obsidian?.setLaunchOnWrite
+    ? window.electronAPI.platform
+    : (isNativeAndroid() && window.DayGlanceObsidian?.setLaunchOnWrite) ? 'android' : null;
   const {
     routinesEnabled, setRoutinesEnabled,
     todayRoutines, setDashboardSelectedChips,
@@ -1664,6 +1675,25 @@ const MobileSettingsPanel = () => {
               />
             </div>
           )}
+          {launchOnWritePlatform && obsidianConfig?.enabled && (
+            <div>
+              <label className="flex items-center gap-3 cursor-pointer">
+                <div className="relative">
+                  <input
+                    type="checkbox"
+                    checked={effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform)}
+                    onChange={(e) => setObsidianLaunchOnWrite(e.target.checked ? 'on' : 'off')}
+                    className="sr-only"
+                  />
+                  <div className={`w-10 h-6 rounded-full transition-colors ${effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform) ? 'bg-purple-600' : darkMode ? 'bg-gray-600' : 'bg-stone-300'}`}>
+                    <div className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform) ? 'translate-x-5' : 'translate-x-1'}`} />
+                  </div>
+                </div>
+                <span className={`text-sm ${textPrimary}`}>{t('settings.obsidianLaunchOnWrite')}</span>
+              </label>
+              <p className={`text-xs ${textSecondary} mt-1`}>{t('settings.obsidianLaunchOnWriteHint')}</p>
+            </div>
+          )}
           {obsidianSyncStatus === 'success' && <p className="text-xs text-green-500">{t('settings.obsidianSyncComplete')}</p>}
           {obsidianSyncStatus === 'error' && <p className="text-xs text-red-500">{t('settings.obsidianSyncFailed')}</p>}
           {obsidianLastSynced && obsidianConfig?.enabled && (
@@ -1737,6 +1767,25 @@ const MobileSettingsPanel = () => {
               rows={4}
             />
           </div>
+          {launchOnWritePlatform && (
+            <div>
+              <label className="flex items-center gap-3 cursor-pointer">
+                <div className="relative">
+                  <input
+                    type="checkbox"
+                    checked={effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform)}
+                    onChange={(e) => setObsidianLaunchOnWrite(e.target.checked ? 'on' : 'off')}
+                    className="sr-only"
+                  />
+                  <div className={`w-10 h-6 rounded-full transition-colors ${effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform) ? 'bg-purple-600' : darkMode ? 'bg-gray-600' : 'bg-stone-300'}`}>
+                    <div className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform) ? 'translate-x-5' : 'translate-x-1'}`} />
+                  </div>
+                </div>
+                <span className={`text-sm ${textPrimary}`}>{t('settings.obsidianLaunchOnWrite')}</span>
+              </label>
+              <p className={`text-xs ${textSecondary} mt-1`}>{t('settings.obsidianLaunchOnWriteHint')}</p>
+            </div>
+          )}
           <div className="flex gap-2">
             <button
               onClick={() => performObsidianSync()}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -15,6 +15,7 @@ import { isNativeAndroid, nativeGetCalendars, nativeGetAutomationIntentsEnabled,
 import { hasNativeCalendar, electronCalendarAvailable, electronGetCalendars } from '../utils/nativeCalendar.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, formatDatePattern } from '../obsidian.js';
 import { validateDailyNotePattern, validateVaultFolderSetting } from '../utils/obsidianFilename.js';
+import { effectiveLaunchOnWrite } from '../utils/obsidianLaunchOnWrite.js';
 import UnportableVaultNamesPanel from './UnportableVaultNamesPanel.jsx';
 import { INTENT_CONFIG_KEY, MULTI_USER_CONFIG_KEY } from '../intents/useIntentPoller.js';
 import { syncSharedUsers, syncSharedUsersViaICloud } from '../intents/sharedUsers.js';
@@ -77,6 +78,7 @@ const SettingsModal = () => {
     syncAll, isSyncing, calSyncLastSynced,
     availableCalendars, setAvailableCalendars, calendarFilter, setCalendarFilter,
     obsidianConfig, setObsidianConfig, obsidianSyncStatus, obsidianSyncError, obsidianLastSynced, setObsidianLastSynced,
+    obsidianLaunchOnWrite, setObsidianLaunchOnWrite,
     obsidianVaultHandleRef, unportableVaultFiles, setUnportableVaultFiles,
     performObsidianSync,
     trmnlConfig, setTrmnlConfig, trmnlSyncStatus, trmnlLastSynced, performTrmnlSync,
@@ -87,6 +89,15 @@ const SettingsModal = () => {
   const fileImportedEventCount = tasks.filter(
     t => t.imported && !t.isTaskCalendar && t.importSource === 'file'
   ).length;
+
+  // Launch-on-write (Obsidian Phase 1) is shown only where a launch mechanism
+  // exists: Electron (main-process shell.openExternal) or the Android bridge
+  // intent. Plain browser has neither — a window.open fired from a debounce
+  // timer is popup-blocked without a user gesture. The platform string feeds
+  // the per-platform default (macOS on, everything else off).
+  const launchOnWritePlatform = window.electronAPI?.obsidian?.setLaunchOnWrite
+    ? window.electronAPI.platform
+    : (isNativeAndroid() && window.DayGlanceObsidian?.setLaunchOnWrite) ? 'android' : null;
   const {
     habitsEnabled, setHabitsEnabled,
     routinesEnabled, setRoutinesEnabled,
@@ -1535,6 +1546,27 @@ const SettingsModal = () => {
                             <FolderOpen size={14} />
                             {t('settings.obsidianOpenVaultSettings')}
                           </button>
+                          {launchOnWritePlatform && obsidianConfig?.enabled && (
+                            <div>
+                              <label className="flex items-center gap-3 cursor-pointer">
+                                <div className="relative">
+                                  <input
+                                    type="checkbox"
+                                    checked={effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform)}
+                                    onChange={(e) => setObsidianLaunchOnWrite(e.target.checked ? 'on' : 'off')}
+                                    className="sr-only"
+                                  />
+                                  <div className={`w-10 h-6 rounded-full transition-colors ${effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform) ? 'bg-purple-600' : darkMode ? 'bg-gray-600' : 'bg-stone-300'}`}>
+                                    <div className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform) ? 'translate-x-5' : 'translate-x-1'}`} />
+                                  </div>
+                                </div>
+                                <span className={`text-sm ${textPrimary}`}>{t('settings.obsidianLaunchOnWrite')}</span>
+                              </label>
+                              <p className={`text-xs ${textSecondary} mt-1`}>
+                                {t('settings.obsidianLaunchOnWriteHint')}
+                              </p>
+                            </div>
+                          )}
                         </div>
                       ) : obsidianConfig?.enabled ? (
                         <div className="space-y-3">
@@ -1628,6 +1660,27 @@ const SettingsModal = () => {
                               Pre-filled when creating a new daily note
                             </p>
                           </div>
+                          {launchOnWritePlatform && (
+                            <div>
+                              <label className="flex items-center gap-3 cursor-pointer">
+                                <div className="relative">
+                                  <input
+                                    type="checkbox"
+                                    checked={effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform)}
+                                    onChange={(e) => setObsidianLaunchOnWrite(e.target.checked ? 'on' : 'off')}
+                                    className="sr-only"
+                                  />
+                                  <div className={`w-10 h-6 rounded-full transition-colors ${effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform) ? 'bg-purple-600' : darkMode ? 'bg-gray-600' : 'bg-stone-300'}`}>
+                                    <div className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${effectiveLaunchOnWrite(obsidianLaunchOnWrite, launchOnWritePlatform) ? 'translate-x-5' : 'translate-x-1'}`} />
+                                  </div>
+                                </div>
+                                <span className={`text-sm ${textPrimary}`}>{t('settings.obsidianLaunchOnWrite')}</span>
+                              </label>
+                              <p className={`text-xs ${textSecondary} mt-1`}>
+                                {t('settings.obsidianLaunchOnWriteHint')}
+                              </p>
+                            </div>
+                          )}
                           <div className="flex gap-2">
                             <button
                               onClick={() => performObsidianSync()}

--- a/src/hooks/useObsidian.js
+++ b/src/hooks/useObsidian.js
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { OBSIDIAN_LAUNCH_ON_WRITE_KEY } from '../utils/obsidianLaunchOnWrite.js';
 
 const useObsidian = () => {
   const [obsidianConfig, setObsidianConfig] = useState(() => {
@@ -20,6 +21,15 @@ const useObsidian = () => {
   const obsidianTasksRef = useRef([]);
   const obsidianInboxRef = useRef([]);
 
+  // Launch-on-write toggle — DEVICE-LOCAL tri-state ('on' | 'off' | null =
+  // platform default), deliberately kept out of obsidianConfig: that object
+  // cloud-syncs and would leak a macOS "on" to a Windows device. See
+  // utils/obsidianLaunchOnWrite.js.
+  const [obsidianLaunchOnWrite, setObsidianLaunchOnWrite] = useState(() => {
+    const saved = localStorage.getItem(OBSIDIAN_LAUNCH_ON_WRITE_KEY);
+    return saved === 'on' || saved === 'off' ? saved : null;
+  });
+
   // Persist Obsidian config
   useEffect(() => {
     if (obsidianConfig) {
@@ -29,8 +39,19 @@ const useObsidian = () => {
     }
   }, [obsidianConfig]);
 
+  // Persist the launch-on-write tri-state (unset clears the key, so a future
+  // platform-default change reaches devices that never made an explicit choice)
+  useEffect(() => {
+    if (obsidianLaunchOnWrite === 'on' || obsidianLaunchOnWrite === 'off') {
+      localStorage.setItem(OBSIDIAN_LAUNCH_ON_WRITE_KEY, obsidianLaunchOnWrite);
+    } else {
+      localStorage.removeItem(OBSIDIAN_LAUNCH_ON_WRITE_KEY);
+    }
+  }, [obsidianLaunchOnWrite]);
+
   return {
     obsidianConfig, setObsidianConfig,
+    obsidianLaunchOnWrite, setObsidianLaunchOnWrite,
     obsidianSyncStatus, setObsidianSyncStatus,
     obsidianSyncError, setObsidianSyncError,
     obsidianLastSynced, setObsidianLastSynced,

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -10,8 +10,9 @@ import {
 import {
   isNativeAndroid, isNativeApp,
   nativeGetVaultConfig, nativeGetNote, nativeWriteNote, nativeOpenNote,
-  nativeListNotes, nativeSetVaultSettings,
+  nativeListNotes, nativeSetVaultSettings, nativeSetLaunchOnWrite,
 } from '../native.js';
+import { effectiveLaunchOnWrite } from '../utils/obsidianLaunchOnWrite.js';
 import { validateWikiNoteName } from '../utils/obsidianFilename.js';
 import { classifyVaultPaths } from '../utils/vaultPortability.js';
 import { mergeObsidianDailyNotes } from '../utils/mergeObsidianDailyNotes.js';
@@ -41,6 +42,7 @@ export default function useObsidianSync({
   setWikilinkCandidates,
   setUnportableVaultFiles,
   obsidianConfig, setObsidianConfig,
+  obsidianLaunchOnWrite,
   setObsidianSyncStatus, setObsidianSyncError, setObsidianLastSynced,
   obsidianVaultHandleRef, obsidianSyncInProgressRef, obsidianPrevTaskStateRef,
   obsidianTasksRef, obsidianInboxRef,
@@ -502,6 +504,22 @@ export default function useObsidianSync({
     // paths would re-run a writeback on a mere settings change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tasks, unscheduledTasks, obsidianConfig?.enabled]);
+
+  // Push the effective launch-on-write value to the platform layer that owns
+  // the post-write debounce: Electron main (obsidian:set-launch-on-write) or
+  // the Android bridge. Runs on mount and on every tri-state change; both
+  // schedulers start disabled, so nothing can fire before the first push.
+  // Plain browser has no launch mechanism (a window.open from a debounce timer
+  // is popup-blocked without a user gesture) — deliberately a no-op there.
+  useEffect(() => {
+    if (isTrayMode) return;
+    const api = typeof window !== 'undefined' ? window.electronAPI : null;
+    if (api?.obsidian?.setLaunchOnWrite) {
+      api.obsidian.setLaunchOnWrite(effectiveLaunchOnWrite(obsidianLaunchOnWrite, api.platform));
+    } else if (isNativeAndroid()) {
+      nativeSetLaunchOnWrite(effectiveLaunchOnWrite(obsidianLaunchOnWrite, 'android'));
+    }
+  }, [obsidianLaunchOnWrite, isTrayMode]);
 
   // On iOS, persist Obsidian folder/pattern/newNotesFolder to UserDefaults so
   // getDailyNote/writeDailyNote use the correct path (iOS has no SettingsActivity).

--- a/src/hooks/useObsidianSync.retry.test.js
+++ b/src/hooks/useObsidianSync.retry.test.js
@@ -40,6 +40,7 @@ vi.mock('../native.js', () => ({
   nativeOpenNote: vi.fn(),
   nativeListNotes: vi.fn(() => []),
   nativeSetVaultSettings: vi.fn(),
+  nativeSetLaunchOnWrite: vi.fn(),
 }));
 
 const { default: useObsidianSync } = await import('./useObsidianSync.js');

--- a/src/native.js
+++ b/src/native.js
@@ -244,6 +244,17 @@ export const nativeOpenNote = (noteName) => {
   bridge.openNote(noteName);
 };
 
+/**
+ * Pushes the device-local launch-on-write toggle to the Android bridge, which
+ * owns the post-write debounce and fires the obsidian:// intent itself.
+ * No-op when the bridge (or an older APK without the method) is absent.
+ */
+export const nativeSetLaunchOnWrite = (enabled) => {
+  const bridge = obsidianBridge();
+  if (!bridge?.setLaunchOnWrite) return;
+  bridge.setLaunchOnWrite(!!enabled);
+};
+
 export const nativeGetDailyNote = (date) => {
   const bridge = obsidianBridge();
   if (!bridge?.getDailyNote) return null;

--- a/src/utils/obsidianLaunchOnWrite.js
+++ b/src/utils/obsidianLaunchOnWrite.js
@@ -1,0 +1,41 @@
+/**
+ * Launch-on-write (Obsidian build-out Phase 1): device-local setting helpers.
+ *
+ * The toggle deliberately lives OUTSIDE obsidianConfig. obsidianConfig
+ * cloud-syncs, and between non-native devices the incoming copy wholesale
+ * replaces the local one (see applySyncedData in App.jsx) — a launchOnWrite
+ * field inside it would leak a Mac's "on" to a Windows machine and defeat the
+ * per-platform defaults. A separate `day-planner-*` key is captured by local
+ * device backups via the prefix rule in utils/deviceSettings.js while staying
+ * out of the cloud payload — the same posture as darkMode and reminderSettings.
+ *
+ * Stored value is a tri-state: 'on' | 'off' | absent. Absent means the
+ * platform default, so changing a default never fights an explicit choice.
+ */
+
+export const OBSIDIAN_LAUNCH_ON_WRITE_KEY = 'day-planner-obsidian-launch-on-write';
+
+/**
+ * Platform default for launch-on-write. On only on macOS, where
+ * `{ activate: false }` launches Obsidian without stealing focus. Windows has
+ * no background launch (Obsidian takes focus), Linux obsidian:// handler
+ * registration is unreliable (AppImage installs), and Android fires a
+ * foreground intent — all default off.
+ *
+ * If `activate: false` turns out to steal focus under the Mac App Store
+ * sandbox, the fallback is flipping the macOS default off — a one-line change
+ * here and nowhere else.
+ *
+ * @param platform `process.platform` on Electron ('darwin' | 'win32' |
+ *   'linux'), or 'android' for the native bridge.
+ */
+export function defaultLaunchOnWrite(platform) {
+  return platform === 'darwin';
+}
+
+/** Resolve the stored tri-state; anything but 'on'/'off' means unset. */
+export function effectiveLaunchOnWrite(stored, platform) {
+  if (stored === 'on') return true;
+  if (stored === 'off') return false;
+  return defaultLaunchOnWrite(platform);
+}

--- a/src/utils/obsidianLaunchOnWrite.test.js
+++ b/src/utils/obsidianLaunchOnWrite.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { defaultLaunchOnWrite, effectiveLaunchOnWrite } from './obsidianLaunchOnWrite.js';
+
+// Per-platform defaults from the Phase 1 table: macOS on (activate:false makes
+// the launch background-only), everything else off. An explicit user choice
+// always beats the default.
+
+describe('defaultLaunchOnWrite', () => {
+  it('defaults on only on macOS', () => {
+    expect(defaultLaunchOnWrite('darwin')).toBe(true);
+    expect(defaultLaunchOnWrite('win32')).toBe(false);
+    expect(defaultLaunchOnWrite('linux')).toBe(false);
+    expect(defaultLaunchOnWrite('android')).toBe(false);
+    expect(defaultLaunchOnWrite(undefined)).toBe(false);
+  });
+});
+
+describe('effectiveLaunchOnWrite', () => {
+  it('an explicit choice wins on every platform', () => {
+    expect(effectiveLaunchOnWrite('off', 'darwin')).toBe(false);
+    expect(effectiveLaunchOnWrite('on', 'win32')).toBe(true);
+    expect(effectiveLaunchOnWrite('on', 'linux')).toBe(true);
+    expect(effectiveLaunchOnWrite('off', 'android')).toBe(false);
+  });
+
+  it('unset falls back to the platform default', () => {
+    expect(effectiveLaunchOnWrite(null, 'darwin')).toBe(true);
+    expect(effectiveLaunchOnWrite(null, 'win32')).toBe(false);
+    expect(effectiveLaunchOnWrite(undefined, 'linux')).toBe(false);
+    expect(effectiveLaunchOnWrite(null, 'android')).toBe(false);
+  });
+
+  it('treats an unrecognized stored value as unset rather than guessing', () => {
+    expect(effectiveLaunchOnWrite('true', 'darwin')).toBe(true); // default, not the string
+    expect(effectiveLaunchOnWrite('yes', 'win32')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Release notes

**This is user-visible new behavior with a per-platform default.** After dayGLANCE writes to a connected Obsidian vault, it now launches Obsidian (once, after an 8-second quiet window) so Obsidian Sync pushes the change to other devices — the push side of spec §1's sync-propagation limit. **Default: ON for macOS Electron** (background launch, no focus steal), **OFF for Windows, Linux, and Android**. A new toggle ("Launch Obsidian after writes") appears in Settings → Obsidian on platforms that have a launch mechanism.

## What changed

Implements Phase 1 of `docs/obsidian-buildout-spec.md` (launch-on-write). Phase 0 landed in #1356/#1357.

### Mechanism, per platform

| Platform | Mechanism | Default |
|---|---|---|
| macOS Electron (all builds) | `shell.openExternal(uri, { activate: false })` from the **main process** | On |
| Windows Electron | same call (`activate` ignored; Obsidian takes focus) | Off |
| Linux Electron | same call; a missing `obsidian://` handler (common for AppImage) **fails silently** — no error state, no toast | Off |
| Android | `ACTION_VIEW` intent from the Kotlin bridge, reusing the existing `openNote` path | Off |
| Browser / PWA | none — `window.open` from a debounce timer is popup-blocked | n/a |

Desktop uses the `obsidian://open?path=<absolute path>` form (overrides `vault`/`file`, so no vault-name configuration). Android uses `vault=<name>&file=<relpath>` since SAF has no absolute filesystem path; the vault name is derived from the tree URI exactly as `openNote` already does.

### Debounce: one chokepoint per platform, on the native side of the bridge

- **Electron** (`electron/obsidianLaunch.ts`, pure, injected timers): fed by the `obsidian:write-file` IPC handler — the single funnel every desktop write path (daily notes, task write-back, wiki notes) already runs through, which holds the resolved absolute path and only reports successful writes.
- **Android** (`LaunchOnWritePolicy.kt`, pure, injected clock): fed by `ObsidianRepository.writeText` — shared by `writeDailyNote`, `writeNote`, *and* `appendToNote`. The bridge schedules one delayed check per write; checks made stale by a later write no-op, so no platform timer needs cancelling.

Quiet window is 8 s, trailing edge, reset on every write (constant in both modules, rationale in the spec).

### IPC surface

One new channel: `obsidian:set-launch-on-write` (renderer → main, boolean), pushed at startup and on toggle change; the Android analog is a `setLaunchOnWrite` bridge method. There is **no** renderer-invocable launch channel — main/the bridge initiates the launch from the write chokepoint, so the renderer never controls a URI and the existing http/https-only `setWindowOpenHandler` posture is unchanged. Both schedulers start disabled until the first push.

### Toggle storage

Device-local tri-state key `day-planner-obsidian-launch-on-write` (`'on'` / `'off'` / unset = platform default). Deliberately **not** in `obsidianConfig`: that object cloud-syncs and is wholesale-replaced between non-native devices, which would leak a macOS "on" to a Windows machine. The key rides local device backups via the `day-planner-` prefix rule and stays out of the cloud payload. The platform default is a single function, `defaultLaunchOnWrite(platform)` — if `activate: false` misbehaves on a real MAS build, flipping the macOS default off is a one-line change there.

### Lifecycle edges

- Toggle-off, `obsidian:disconnect`, and `obsidian:pick` drop a pending launch; the enabled flag survives a vault swap (explicit disconnect→re-pick tests on both platforms).
- **Pending timer at app quit: fires immediately** via a `will-quit` flush. Rationale: edit-then-close within 8 s is a normal pattern and dropping the launch would strand the edit until the next write. The call is fire-and-forget (no `await`, no `preventDefault`), so quit cannot hang — confirmed under xvfb (see below).
- A failed launch is always silent, on every platform: the vault write succeeded; only the wake didn't. On Android this reuses `openNote`'s existing degradation (`ActivityNotFoundException` swallowed, missing vault name → return) and never touches sync status.

### Out of scope (per spec)

No suppression when Obsidian is already running (Phase 5, heartbeat-dependent), no Advanced URI `openmode=silent` detection, no iOS.

## Testing

- `electron/obsidianLaunch.test.ts` (7 tests) and `LaunchOnWritePolicyTest.kt` (5 tests) pin the same contract on both platforms: burst → 1 launch of the last file, spaced writes → 1 each, toggle off → 0, disable mid-window cancels, disconnect→re-pick doesn't leave the flag stale, flush fires exactly once.
- `electron/obsidianUri.test.ts`: new `buildObsidianOpenPathUri` cases (POSIX/Windows paths, no trimming/stripping of resolved paths, null on unusable input).
- Full suite green: **2083 tests / 137 files**, eslint `--max-warnings 0`, and both Electron tsconfig builds clean. The Kotlin policy + test were compiled and run standalone (kotlinc 2.0.21 + JUnit 4: 5/5 pass); the bridge/repository edits need an Android SDK build, which this environment lacks.
- **xvfb smoke test** (real Electron main, real IPC): seeded vault restore → `set-launch-on-write(true)` → `obsidian:write-file` → after 9.5 s the debounce fired `shell.openExternal` with no `obsidian://` handler present and the app stayed alive with no error (the Linux fail-silent path), then a second write followed by immediate quit flushed the pending launch during teardown and exited 0 (flush does not hang quit).

## Manual verification still needed (hardware)

**macOS, incl. MAS** — `activate: false` under the sandbox: connect a vault, leave the toggle at its default (on), quit Obsidian fully, check off or reschedule one Obsidian-imported task, wait ~8 s. Correct: Obsidian appears in the Dock with the written note open, dayGLANCE keeps the menu bar and keyboard focus, and Obsidian Sync pushes within seconds. If Obsidian becomes frontmost, the MAS fallback is flipping the default in `defaultLaunchOnWrite`. **Windows** — same flow with the toggle manually on; Obsidian taking focus is expected there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_