### PR TITLE
iOS: add a Siri and Shortcuts surface

### DIFF
--- a/dayglance-ios/DayGlance/AppShortcuts.swift
+++ b/dayglance-ios/DayGlance/AppShortcuts.swift
@@ -1,0 +1,90 @@
+import AppIntents
+import Foundation
+
+// Siri and Shortcuts surface for dayGLANCE.
+//
+// The app had App Intents already — CompleteTaskIntent and StartFocusIntent for
+// interactive widget buttons, and three control intents for Control Center — but
+// all of them live in the DayGlanceWidget extension target. The Shortcuts app
+// reads the *app's* Metadata.appintents, and the app target had no App Intents
+// code at all, so dayGLANCE showed nothing in Shortcuts and had no Siri phrases.
+// (The build log said as much on every build: "Metadata extraction skipped. No
+// AppIntents.framework dependency found" for the DayGlance target.)
+//
+// So this is a fourth entry point onto machinery that already exists, not new
+// plumbing. Home Screen Quick Actions, Control Center controls, and interactive
+// widget buttons all write the same pending action to the App Group, which
+// WidgetBridge.getPendingAction() hands to the web layer on resume (App.jsx,
+// `wa === 'newInboxTask'` and friends). These intents do exactly the same thing.
+//
+// Names are suffixed "ShortcutIntent" to stay distinct from the extension's
+// StartFocusIntent. They compile into separate modules so there is no build
+// conflict, but two App Intents with the same type name inside one app bundle is
+// a needless ambiguity for the system to resolve.
+//
+// iOS 16+, matching the app target. The extension's intents are gated to 17/18
+// because interactive widgets and Controls need that — App Intents itself does
+// not, which is why these carry no availability annotation.
+
+struct AddInboxTaskShortcutIntent: AppIntent {
+    static var title: LocalizedStringResource = "Add Inbox Task"
+    static var description = IntentDescription(
+        "Opens dayGLANCE with a new inbox task ready to capture."
+    )
+
+    // Task data lives in the web layer, so there is nothing to do headlessly —
+    // same reasoning as every other intent in this project.
+    static var openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+        WidgetBridge.writePendingAction("newInboxTask")
+        return .result()
+    }
+}
+
+struct StartFocusShortcutIntent: AppIntent {
+    static var title: LocalizedStringResource = "Start Focus"
+    static var description = IntentDescription(
+        "Opens dayGLANCE in Focus mode on your next task."
+    )
+
+    static var openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+        WidgetBridge.writePendingAction("startFocus")
+        return .result()
+    }
+}
+
+// Surfaces both intents to Siri and the Shortcuts app without the user having to
+// assemble a shortcut first. Phrases must interpolate .applicationName — the API
+// requires the app name in every phrase.
+//
+// Deliberately only two. App Shortcuts also feed Spotlight and Siri suggestions,
+// so the list is a discoverability surface rather than a menu: "add a scheduled
+// task" implies details Siri cannot collect without parameterized intents, and a
+// voice-input shortcut would mean asking Siri to open a voice capture UI. Both
+// remain available as Home Screen Quick Actions and Control Center controls.
+struct DayGlanceAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: AddInboxTaskShortcutIntent(),
+            phrases: [
+                "Add a task in \(.applicationName)",
+                "New task in \(.applicationName)",
+                "Add a \(.applicationName) task",
+            ],
+            shortTitle: "Add inbox task",
+            systemImageName: "tray.and.arrow.down"
+        )
+        AppShortcut(
+            intent: StartFocusShortcutIntent(),
+            phrases: [
+                "Start focus in \(.applicationName)",
+                "Start a \(.applicationName) focus session",
+            ],
+            shortTitle: "Start focus",
+            systemImageName: "timer"
+        )
+    }
+}

--- a/dayglance-ios/DayGlance/AppShortcuts.swift
+++ b/dayglance-ios/DayGlance/AppShortcuts.swift
@@ -42,6 +42,20 @@ struct AddInboxTaskShortcutIntent: AppIntent {
     }
 }
 
+struct AddScheduledTaskShortcutIntent: AppIntent {
+    static var title: LocalizedStringResource = "Add Scheduled Task"
+    static var description = IntentDescription(
+        "Opens dayGLANCE with a new task ready to add to your schedule."
+    )
+
+    static var openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+        WidgetBridge.writePendingAction("newScheduledTask")
+        return .result()
+    }
+}
+
 struct StartFocusShortcutIntent: AppIntent {
     static var title: LocalizedStringResource = "Start Focus"
     static var description = IntentDescription(
@@ -60,11 +74,16 @@ struct StartFocusShortcutIntent: AppIntent {
 // assemble a shortcut first. Phrases must interpolate .applicationName — the API
 // requires the app name in every phrase.
 //
-// Deliberately only two. App Shortcuts also feed Spotlight and Siri suggestions,
-// so the list is a discoverability surface rather than a menu: "add a scheduled
-// task" implies details Siri cannot collect without parameterized intents, and a
-// voice-input shortcut would mean asking Siri to open a voice capture UI. Both
-// remain available as Home Screen Quick Actions and Control Center controls.
+// Three of the four available actions. App Shortcuts also feed Spotlight and Siri
+// suggestions, so the list is a discoverability surface rather than a menu — but
+// these three are the ones worth surfacing. Voice input is left out: a shortcut
+// for it would mean asking Siri to open a voice capture UI, which is circular.
+// It remains available as a Home Screen Quick Action and a Control Center control.
+//
+// Note the inbox and scheduled phrasings overlap by design: "add a task" is a
+// prefix of "add a scheduled task". Siri prefers the longest match, so the more
+// specific phrase wins and the bare one falls through to inbox capture, which is
+// the right default for a quick spoken request.
 struct DayGlanceAppShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
         AppShortcut(
@@ -76,6 +95,16 @@ struct DayGlanceAppShortcuts: AppShortcutsProvider {
             ],
             shortTitle: "Add inbox task",
             systemImageName: "tray.and.arrow.down"
+        )
+        AppShortcut(
+            intent: AddScheduledTaskShortcutIntent(),
+            phrases: [
+                "Add a scheduled task in \(.applicationName)",
+                "New scheduled task in \(.applicationName)",
+                "Schedule a task in \(.applicationName)",
+            ],
+            shortTitle: "Add scheduled task",
+            systemImageName: "calendar.badge.plus"
         )
         AppShortcut(
             intent: StartFocusShortcutIntent(),

--- a/dayglance-ios/DayGlance/Bridges/WidgetBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/WidgetBridge.swift
@@ -17,6 +17,11 @@ final class WidgetBridge {
     /// different target); inside the app target this is the one definition.
     static let snapshotKey = "widgetSnapshot"
 
+    /// The App Group key a pending action lives under, drained by
+    /// getPendingAction(). Hoisted for the same reason as appGroup above: it now
+    /// has more than one writer.
+    static let pendingActionKey = "widgetPendingAction"
+
     /// Widgets are killed at 30 MB with no warning. 200 KB is safely under that
     /// even with the full snapshot structure.
     private static let snapshotCapBytes = 200_000
@@ -70,12 +75,21 @@ final class WidgetBridge {
         return String(data: data, encoding: .utf8)
     }
 
+    /// Stashes a pending action for the web layer to pick up on resume. The
+    /// value shape ({ "action": ... }) matches what the widget extension's
+    /// ControlActionStore and widget intents write, so all entry points — Quick
+    /// Actions, Control Center, widget buttons, and the Siri/Shortcuts intents in
+    /// AppShortcuts.swift — land on the single getPendingAction() drain.
+    static func writePendingAction(_ action: String) {
+        UserDefaults(suiteName: appGroup)?.set(["action": action], forKey: pendingActionKey)
+    }
+
     func getPendingAction() -> String {
         guard let defaults = UserDefaults(suiteName: Self.appGroup),
-              let action = defaults.dictionary(forKey: "widgetPendingAction") else {
+              let action = defaults.dictionary(forKey: Self.pendingActionKey) else {
             return "null"
         }
-        defaults.removeObject(forKey: "widgetPendingAction")
+        defaults.removeObject(forKey: Self.pendingActionKey)
         let encoded = (try? JSONSerialization.data(withJSONObject: action))
             .flatMap { String(data: $0, encoding: .utf8) } ?? "null"
         return encoded


### PR DESCRIPTION
## The gap

dayGLANCE shows **nothing** in the Shortcuts app and has no Siri phrases — confirmed on device.

It already has five App Intents: `CompleteTaskIntent` and `StartFocusIntent` for interactive widget buttons, plus three control intents for Control Center. But **all five live in the `DayGlanceWidget` extension target**, and the Shortcuts app reads the *app's* `Metadata.appintents`. The app target had zero App Intents code, so none of them were ever exposed.

The build log has been saying this on every build:

```
appintentsmetadataprocessor: Metadata extraction skipped.
                             No AppIntents.framework dependency found.   [DayGlance target]
```

## What this adds

`DayGlance/AppShortcuts.swift` — three intents plus an `AppShortcutsProvider`.

This is a **fourth entry point onto machinery that already exists**, not new plumbing:

```
Home Screen Quick Actions  ─┐
Control Center controls    ─┼─→ widgetPendingAction (App Group)
Interactive widget buttons ─┤        → WidgetBridge.getPendingAction()
Siri / Shortcuts (new)     ─┘        → App.jsx  (wa === 'newInboxTask' …)
```

All three actions already work end to end on the web side for the other entry points, so there are **no JS changes**.

`WidgetBridge` gains `writePendingAction()` and a `pendingActionKey` constant, hoisting the `"widgetPendingAction"` literal now that it has more than one writer. That is the same reasoning the file already applies to `appGroup`, and its comment there says why: "a single definition is one fewer place for a typo to silently disable the App Group."

## Which actions are exposed

| Action | Exposed | Why |
|---|---|---|
| Add Inbox Task | yes | "capture quickly" is exactly the voice case |
| Add Scheduled Task | yes | opens the scheduled-task form, same as the existing Quick Action and control |
| Start Focus | yes | single unambiguous action |
| Voice Input | no | asking Siri to open a voice capture UI is circular |

Voice input remains available as a Home Screen Quick Action and a Control Center control.

**The inbox and scheduled phrasings overlap by design.** "Add a task" is a prefix of "add a scheduled task"; Siri prefers the longest match, so the specific phrase wins and the bare one falls through to inbox capture — the right default for a quick spoken request. Noted in the file so it does not read as an oversight.

## Details worth a reviewer's eye

**Type names are suffixed `ShortcutIntent`** to stay distinct from the extension's `StartFocusIntent`. They compile into separate modules so there is no build conflict, but two App Intents sharing a type name inside one app bundle is needless ambiguity for the system to resolve.

**No availability gating.** `AppShortcutsProvider` is iOS 16+ and the app target is already 16.0. The extension's intents are gated to 17/18 because interactive widgets and Controls need that — App Intents itself does not.

**No duplicate Shortcuts entries.** I initially expected the extension's intents might already appear as buildable actions and collide with these. The device check disproved that: the app target's metadata is empty, so there is nothing to collide with.

## Verification

Lint clean, 2068 tests pass across 135 files — no test covers this path, so that is a no-regression signal only.

The iOS build gate added in #1355 compiles it, and the build log confirms the toolchain **discovered** the shortcuts rather than merely compiling the file:

```
ExtractAppIntentsMetadata ... in target 'DayGlance'
appintentsmetadataprocessor: Writing Metadata.appintents
appintentsnltrainingprocessor: Starting AppIntents SSU YAML Generation
appintentsnltrainingprocessor: Generated AppIntents SSU YAML files in ...
```

`DayGlance` produces App Intents metadata for the first time. The SSU YAML is the natural-language training data behind the spoken phrases, and it is only generated when a shortcuts provider is actually found — so its presence is the real signal here, not the green tick.

**Not device-tested.** Two things to check:

1. dayGLANCE now appears in the Shortcuts app with "Add inbox task", "Add scheduled task", and "Start focus".
2. The spoken phrases work, including that "Add a task in dayGLANCE" goes to inbox while "Add a scheduled task in dayGLANCE" goes to the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ