### PR TITLE
Localize reminder notification text

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -689,6 +689,20 @@
     "next7Days": "Nächste 7 Tage",
     "goalsDueThisWeek": "Diese Woche fällige Ziele"
   },
+  "reminders": {
+    "before15": "Beginnt in 15 Minuten",
+    "before10": "Beginnt in 10 Minuten",
+    "before5": "Beginnt in 5 Minuten",
+    "start": "Beginnt jetzt",
+    "end": "Endet jetzt",
+    "morning": "Erinnerung an ganztägige Aufgabe",
+    "fallback": "Erinnerung",
+    "weeklyReview": "Zeit für Ihren Wochenrückblick!",
+    "hgUpNext": "{{title}} · Beginnt in {{minutes}} Min.",
+    "hgUpNextWithTasks_one": "{{title}} · {{count}} Aufgabe · Beginnt in {{minutes}} Min.",
+    "hgUpNextWithTasks_other": "{{title}} · {{count}} Aufgaben · Beginnt in {{minutes}} Min.",
+    "hgStartingNow": "{{title}} · Beginnt jetzt"
+  },
   "frames": {
     "title": "GTD-Rahmen",
     "tabMyFrames": "Meine Rahmen",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -689,6 +689,20 @@
     "next7Days": "Next 7 Days",
     "goalsDueThisWeek": "Goals Due This Week"
   },
+  "reminders": {
+    "before15": "Starts in 15 minutes",
+    "before10": "Starts in 10 minutes",
+    "before5": "Starts in 5 minutes",
+    "start": "Starting now",
+    "end": "Ending now",
+    "morning": "All-day task reminder",
+    "fallback": "Reminder",
+    "weeklyReview": "Time for your weekly review!",
+    "hgUpNext": "{{title}} · Starts in {{minutes}}m",
+    "hgUpNextWithTasks_one": "{{title}} · {{count}} task · Starts in {{minutes}}m",
+    "hgUpNextWithTasks_other": "{{title}} · {{count}} tasks · Starts in {{minutes}}m",
+    "hgStartingNow": "{{title}} · Starting now"
+  },
   "frames": {
     "title": "GTD Frames",
     "tabMyFrames": "My Frames",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -689,6 +689,20 @@
     "next7Days": "Próximos 7 días",
     "goalsDueThisWeek": "Objetivos con fecha límite esta semana"
   },
+  "reminders": {
+    "before15": "Empieza en 15 minutos",
+    "before10": "Empieza en 10 minutos",
+    "before5": "Empieza en 5 minutos",
+    "start": "Empieza ahora",
+    "end": "Termina ahora",
+    "morning": "Recordatorio de tarea de todo el día",
+    "fallback": "Recordatorio",
+    "weeklyReview": "¡Hora de tu revisión semanal!",
+    "hgUpNext": "{{title}} · Empieza en {{minutes}} min",
+    "hgUpNextWithTasks_one": "{{title}} · {{count}} tarea · Empieza en {{minutes}} min",
+    "hgUpNextWithTasks_other": "{{title}} · {{count}} tareas · Empieza en {{minutes}} min",
+    "hgStartingNow": "{{title}} · Empieza ahora"
+  },
   "frames": {
     "title": "Bloques GTD",
     "tabMyFrames": "Mis bloques",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -689,6 +689,20 @@
     "next7Days": "7 prochains jours",
     "goalsDueThisWeek": "Objectifs à atteindre cette semaine"
   },
+  "reminders": {
+    "before15": "Commence dans 15 minutes",
+    "before10": "Commence dans 10 minutes",
+    "before5": "Commence dans 5 minutes",
+    "start": "Commence maintenant",
+    "end": "Se termine maintenant",
+    "morning": "Rappel de tâche sur toute la journée",
+    "fallback": "Rappel",
+    "weeklyReview": "C’est l’heure de votre revue hebdomadaire !",
+    "hgUpNext": "{{title}} · Commence dans {{minutes}} min",
+    "hgUpNextWithTasks_one": "{{title}} · {{count}} tâche · Commence dans {{minutes}} min",
+    "hgUpNextWithTasks_other": "{{title}} · {{count}} tâches · Commence dans {{minutes}} min",
+    "hgStartingNow": "{{title}} · Commence maintenant"
+  },
   "frames": {
     "title": "Plages GTD",
     "tabMyFrames": "Mes plages",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -689,6 +689,20 @@
     "next7Days": "Prossimi 7 giorni",
     "goalsDueThisWeek": "Obiettivi in scadenza questa settimana"
   },
+  "reminders": {
+    "before15": "Inizia tra 15 minuti",
+    "before10": "Inizia tra 10 minuti",
+    "before5": "Inizia tra 5 minuti",
+    "start": "Inizia ora",
+    "end": "Termina ora",
+    "morning": "Promemoria attività di tutto il giorno",
+    "fallback": "Promemoria",
+    "weeklyReview": "È ora della tua revisione settimanale!",
+    "hgUpNext": "{{title}} · Inizia tra {{minutes}} min",
+    "hgUpNextWithTasks_one": "{{title}} · {{count}} attività · Inizia tra {{minutes}} min",
+    "hgUpNextWithTasks_other": "{{title}} · {{count}} attività · Inizia tra {{minutes}} min",
+    "hgStartingNow": "{{title}} · Inizia ora"
+  },
   "frames": {
     "title": "Blocchi GTD",
     "tabMyFrames": "I miei blocchi",

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -689,6 +689,20 @@
     "next7Days": "Próximos 7 dias",
     "goalsDueThisWeek": "Objetivos com prazo esta semana"
   },
+  "reminders": {
+    "before15": "Começa em 15 minutos",
+    "before10": "Começa em 10 minutos",
+    "before5": "Começa em 5 minutos",
+    "start": "Começa agora",
+    "end": "Termina agora",
+    "morning": "Lembrete de tarefa de dia inteiro",
+    "fallback": "Lembrete",
+    "weeklyReview": "Está na hora da sua revisão semanal!",
+    "hgUpNext": "{{title}} · Começa em {{minutes}} min",
+    "hgUpNextWithTasks_one": "{{title}} · {{count}} tarefa · Começa em {{minutes}} min",
+    "hgUpNextWithTasks_other": "{{title}} · {{count}} tarefas · Começa em {{minutes}} min",
+    "hgStartingNow": "{{title}} · Começa agora"
+  },
   "frames": {
     "title": "Blocos GTD",
     "tabMyFrames": "Os meus blocos",

--- a/public/locales/pt-PT/translation.json
+++ b/public/locales/pt-PT/translation.json
@@ -689,6 +689,20 @@
     "next7Days": "Próximos 7 dias",
     "goalsDueThisWeek": "Objetivos com prazo esta semana"
   },
+  "reminders": {
+    "before15": "Começa em 15 minutos",
+    "before10": "Começa em 10 minutos",
+    "before5": "Começa em 5 minutos",
+    "start": "Começa agora",
+    "end": "Termina agora",
+    "morning": "Lembrete de tarefa de dia inteiro",
+    "fallback": "Lembrete",
+    "weeklyReview": "Está na hora da sua revisão semanal!",
+    "hgUpNext": "{{title}} · Começa em {{minutes}} min",
+    "hgUpNextWithTasks_one": "{{title}} · {{count}} tarefa · Começa em {{minutes}} min",
+    "hgUpNextWithTasks_other": "{{title}} · {{count}} tarefas · Começa em {{minutes}} min",
+    "hgStartingNow": "{{title}} · Começa agora"
+  },
   "frames": {
     "title": "Blocos GTD",
     "tabMyFrames": "Os meus blocos",

--- a/src/hooks/useReminderEngine.js
+++ b/src/hooks/useReminderEngine.js
@@ -1,4 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
+// The bare singleton, not ../i18n.js: that module boots the language detector
+// as an import side effect, which node-side tests must not inherit. main.jsx
+// imports it before anything fires, so t() is always initialized at runtime.
+import i18n from 'i18next';
 import { dateToString, stripWikilinks } from '../utils/taskUtils.js';
 import { isNativeAndroid, isNativeApp, nativeShowNotification, nativeShowTaskNotification, nativeSyncReminders } from '../native.js';
 
@@ -17,6 +21,18 @@ const minutesToTime = (minutes) => {
   const mins = minutes % 60;
   return `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}`;
 };
+
+// Notification/toast text, localized at fire (or native-schedule) time rather
+// than hardcoded English. Pre-scheduled native bodies re-bake after a language
+// switch, since the scheduling effect below re-runs and nativeSyncReminders
+// replaces the pending set.
+const REMINDER_TYPES = ['before15', 'before10', 'before5', 'start', 'end', 'morning'];
+const reminderMessage = (type) =>
+  i18n.t(REMINDER_TYPES.includes(type) ? `reminders.${type}` : 'reminders.fallback');
+const hgUpNextBody = (session, minutes) =>
+  session.taskCount > 0
+    ? i18n.t('reminders.hgUpNextWithTasks', { title: session.title, count: session.taskCount, minutes })
+    : i18n.t('reminders.hgUpNext', { title: session.title, minutes });
 
 const getTaskCategory = (task) => {
   if (task.isAllDay) return 'allDayTasks';
@@ -61,6 +77,15 @@ export default function useReminderEngine({
   lastWeeklyReviewFiredRef,
 }) {
   const [activeReminders, setActiveReminders] = useState([]);
+  // Bumped on languageChanged so the native-scheduling effect below re-runs
+  // and re-bakes every pending notification body in the new language. The
+  // live-fire effect needs no equivalent: it localizes at fire time.
+  const [langEpoch, setLangEpoch] = useState(0);
+  useEffect(() => {
+    const bump = () => setLangEpoch(e => e + 1);
+    i18n.on('languageChanged', bump);
+    return () => i18n.off('languageChanged', bump);
+  }, []);
   const firedRemindersRef = useRef(new Set());
   const lastReminderDateRef = useRef((() => {
     const d = new Date();
@@ -93,11 +118,11 @@ export default function useReminderEngine({
           playUISound('reminder');
           if (reminderSettings.browserNotifications && typeof Notification !== 'undefined' && Notification.permission === 'granted') {
             if (window.electronAPI?.isElectron) {
-              try { new Notification('dayGLANCE', { body: 'Time for your weekly review!' }); } catch {}
+              try { new Notification('dayGLANCE', { body: i18n.t('reminders.weeklyReview') }); } catch {}
             } else {
               try {
                 navigator.serviceWorker?.ready.then(reg => {
-                  reg.showNotification('dayGLANCE', { body: 'Time for your weekly review!', icon: '/icon-192.png', tag: 'weekly-review' });
+                  reg.showNotification('dayGLANCE', { body: i18n.t('reminders.weeklyReview'), icon: '/icon-192.png', tag: 'weekly-review' });
                 });
               } catch {}
             }
@@ -131,7 +156,7 @@ export default function useReminderEngine({
             firedRemindersRef.current.add(upNextKey);
             hgFires.push({
               title: 'hyperGLANCE',
-              body: `${session.title}${session.taskCount > 0 ? ` · ${session.taskCount} task${session.taskCount !== 1 ? 's' : ''}` : ''} · Starts in ${upNextMinutes}m`,
+              body: hgUpNextBody(session, upNextMinutes),
               tag: `hg-session-${session.id}`,
             });
           }
@@ -144,7 +169,7 @@ export default function useReminderEngine({
           firedRemindersRef.current.add(startKey);
           hgFires.push({
             title: 'hyperGLANCE',
-            body: `${session.title} · Starting now`,
+            body: i18n.t('reminders.hgStartingNow', { title: session.title }),
             tag: `hg-session-${session.id}`,
           });
         }
@@ -197,21 +222,13 @@ export default function useReminderEngine({
         // Fire if current time is within a 2-minute window of the trigger
         if (nowMin >= point.triggerMin && nowMin < point.triggerMin + 2) {
           firedRemindersRef.current.add(point.key);
-          const messageMap = {
-            before15: 'Starts in 15 minutes',
-            before10: 'Starts in 10 minutes',
-            before5: 'Starts in 5 minutes',
-            start: 'Starting now',
-            end: 'Ending now',
-            morning: 'All-day task reminder',
-          };
           newReminders.push({
             id: `${point.key}-${Date.now()}`,
             taskId: task.id,
             taskTitle: stripWikilinks(task.title),
             taskColor: task.color,
             startTime: task.startTime || null,
-            message: messageMap[point.type] || 'Reminder',
+            message: reminderMessage(point.type),
             type: point.type,
             isCalendarEvent: task.imported && !task.isTaskCalendar,
             firedAt: Date.now(),
@@ -289,15 +306,6 @@ export default function useReminderEngine({
       const todayRecurring = expandedRecurringTasks.filter(t => t.date === todayStr && isVisibleForUser(t));
       const allTodayTasks = [...todayRegular, ...todayRecurring];
 
-      const messageMap = {
-        before15: 'Starts in 15 minutes',
-        before10: 'Starts in 10 minutes',
-        before5: 'Starts in 5 minutes',
-        start: 'Starting now',
-        end: 'Ending now',
-        morning: 'All-day task reminder',
-      };
-
       for (const task of allTodayTasks) {
         if (task.completed) continue;
         const category = getTaskCategory(task);
@@ -311,7 +319,7 @@ export default function useReminderEngine({
             id: point.key,
             taskId: String(task.id),
             title: task.title,
-            body: messageMap[point.type] || 'Reminder',
+            body: reminderMessage(point.type),
             type: point.type,
             isCalendarEvent: !!(task.imported && !task.isTaskCalendar),
             triggerAtMillis,
@@ -333,7 +341,7 @@ export default function useReminderEngine({
               id: `hg-upnext-${session.id}-${session.date}`,
               taskId: `hg-${session.id}`,
               title: 'hyperGLANCE',
-              body: `${session.title}${session.taskCount > 0 ? ` · ${session.taskCount} task${session.taskCount !== 1 ? 's' : ''}` : ''} · Starts in ${upNextMinutes}m`,
+              body: hgUpNextBody(session, upNextMinutes),
               type: 'hg-upnext',
               isCalendarEvent: false,
               triggerAtMillis,
@@ -346,7 +354,7 @@ export default function useReminderEngine({
             id: `hg-start-${session.id}-${session.date}`,
             taskId: `hg-${session.id}`,
             title: 'hyperGLANCE',
-            body: `${session.title} · Starting now`,
+            body: i18n.t('reminders.hgStartingNow', { title: session.title }),
             type: 'hg-start',
             isCalendarEvent: false,
             triggerAtMillis: startTrigger,
@@ -356,7 +364,7 @@ export default function useReminderEngine({
     }
 
     nativeSyncReminders(futureReminders);
-  }, [tasks, expandedRecurringTasks, reminderSettings, hgSessions, isVisibleForUser]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [tasks, expandedRecurringTasks, reminderSettings, hgSessions, isVisibleForUser, langEpoch]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Reminder snooze: push task start time forward 15 minutes
   const snoozeReminder = (reminder) => {


### PR DESCRIPTION
Counterpart to lastGLANCE#297, keeping the two apps consistent: the reminder engine was the last hardcoded-English surface in the web layer.

## What was hardcoded (`src/hooks/useReminderEngine.js`)

- The per-point `messageMap` — "Starts in 15/10/5 minutes", "Starting now", "Ending now", "All-day task reminder", fallback "Reminder" — **duplicated** between the live-fire path (in-app toasts, browser/Electron notifications, native rich notifications) and the native pre-scheduling path (`nativeSyncReminders`).
- "Time for your weekly review!" (Electron and service-worker paths).
- The hyperGLANCE session bodies: `Session · N task(s) · Starts in Xm` and `Session · Starting now`, each also duplicated between live and scheduled paths.

## The fix

Everything goes through i18next under a new `reminders` section in **all seven locales**. The two `messageMap` copies collapse into one `reminderMessage()` helper; the hyperGLANCE bodies use count-based `_one`/`_other` plurals. The existing key-parity test enforces coverage per language, and the pt purity guardrail holds on both Portuguese files — the new strings are marker-free and identical across the two standards, as expected for this vocabulary ("Começa em 15 minutos" is both).

Registers and glossary follow each file's convention: de formal *Sie* ("Zeit für Ihren Wochenrückblick!"), es *tú*, fr *vous* (with the French space before `!`), it *tu*, pt European/Brazilian. Timing verbs anchor on the existing `strip.startsIn` entries (*beginnt in / empieza en / commence dans / inizia tra / começa em*), and the all-day term on `task.allDay` per locale.

Wiring details:

- **Pre-scheduled native bodies re-bake on a language switch**: a `langEpoch` state bumps on i18next's `languageChanged` and is a dependency of the scheduling effect, so `nativeSyncReminders` replaces the pending set in the new language. The live-fire path localizes at fire time and needs no equivalent.
- Imports use the bare `i18next` singleton rather than `../i18n.js`, so node-side tests don't inherit the detector boot side effect.

Out of scope, noted for completeness: the native **Snooze / Mark Complete** action-button titles live in the Kotlin/Swift bridge (`showTaskNotification`), not the web layer — localizing those means platform string resources, same as the widgets.

## Verification

- `npm run lint` clean; full suite green (137 files, **2089 tests** — parity + variant purity enforce the new keys); all four Vite configs build (web, Electron, Android, iOS).
- Not verified on a device: seeing a scheduled native notification fire requires a phone build; the string wiring is covered by the tests above and by inspection.

**Translation quality:** no native-speaker review was available; register and glossary consistency is verified against the existing files, naturalness is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX)_