### PR TITLE
Bump version to 4.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="screenshots/badges/google-play.png" alt="Get it on Google Play" height="60">](https://play.google.com/store/apps/details?id=com.dayglance.app) [<img src="screenshots/badges/app-store.svg" alt="Download on the App Store" height="60">](https://apps.apple.com/app/id6771540599)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-4.6.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-4.7.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,6 +55,15 @@ Run these once each on real hardware or a representative simulator:
   action can be drained, and a control whose intent is not compiled into the
   app target silently does neither. `src/iosControls.test.js` guards the
   project layout that makes this work, but only a device proves the launch.
+- iOS: the Up Next widget's Complete and Start Focus buttons still foreground
+  the app and apply the action. These worked at rollout, but the
+  `ForegroundContinuableIntent` conformances in WidgetIntents.swift are marked
+  `@available(iOSApplicationExtension, unavailable)` in a file only the
+  extension target compiles, so they are excluded from that build and the
+  protection the comment describes is not actually in effect. If the buttons
+  have since broken on iOS 18.4+, moving WidgetIntents.swift to `Shared/` (as
+  ControlWidgets.swift already is) puts the conformance in the app target
+  where it compiles. Confirm before deleting the conformances as dead code.
 - Android: vault SSE stream connects and the WebView renders the app.
 - Android: a real purchase completes and is acknowledged, and the app
   recovers when the billing service is not ready at first tap (honest

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,15 +55,16 @@ Run these once each on real hardware or a representative simulator:
   action can be drained, and a control whose intent is not compiled into the
   app target silently does neither. `src/iosControls.test.js` guards the
   project layout that makes this work, but only a device proves the launch.
-- iOS: the Up Next widget's Complete and Start Focus buttons still foreground
-  the app and apply the action. These worked at rollout, but the
-  `ForegroundContinuableIntent` conformances in WidgetIntents.swift are marked
+- iOS: the Up Next widget's Complete and Start Focus buttons foreground the
+  app and apply the action. Confirmed working in the released 4.6.0, so
+  unlike the Control Center controls these do NOT need their intent in the
+  app target: `openAppWhenRun` foregrounds the app from an extension-only
+  widget intent. Keep the check as a regression guard, and do not "fix"
+  WidgetIntents.swift by moving it to `Shared/` without a failure to point
+  at. Its `ForegroundContinuableIntent` conformances are marked
   `@available(iOSApplicationExtension, unavailable)` in a file only the
-  extension target compiles, so they are excluded from that build and the
-  protection the comment describes is not actually in effect. If the buttons
-  have since broken on iOS 18.4+, moving WidgetIntents.swift to `Shared/` (as
-  ControlWidgets.swift already is) puts the conformance in the app target
-  where it compiles. Confirm before deleting the conformances as dead code.
+  extension target builds, so they may well be inert, but the behavior they
+  supposedly guard has never actually broken. Leave them be.
 - Android: vault SSE stream connects and the WebView renders the app.
 - Android: a real purchase completes and is acknowledged, and the app
   recovers when the billing service is not ready at first tap (honest

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,6 +49,12 @@ Run these once each on real hardware or a representative simulator:
 - iOS: external links open in the system browser; the HealthKit permission
   prompt is deferred until first use (not on launch); a vault SSE
   auth-failure surfaces to the user once (no silent retry storm).
+- iOS: each Control Center control (Scheduled Task, Inbox Task, Voice Task)
+  foregrounds the app AND opens its UI, from a cold start and from the
+  background. Tapping a control has to launch the app before the pending
+  action can be drained, and a control whose intent is not compiled into the
+  app target silently does neither. `src/iosControls.test.js` guards the
+  project layout that makes this work, but only a device proves the launch.
 - Android: vault SSE stream connects and the WebView renders the app.
 - Android: a real purchase completes and is acknowledged, and the app
   recovers when the billing service is not ready at first tap (honest

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         // fallback for plain gradle/IDE builds and no longer needs a commit
         // per Play upload.
         versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 185
-        versionName = "4.6.0"
+        versionName = "4.7.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/MainActivity.kt
@@ -2,6 +2,7 @@ package com.dayglance.app
 
 import android.Manifest
 import android.app.AlarmManager
+import android.app.NotificationManager
 import android.content.ActivityNotFoundException
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -181,6 +182,7 @@ class MainActivity : AppCompatActivity() {
             ACTION_VOICE_INPUT    -> store.pendingVoiceInput = true
             ACTION_ADD_TASK       -> store.pendingAddTask = true
             ACTION_ADD_INBOX_TASK -> store.pendingAddInboxTask = true
+            ACTION_COMPLETE_TASK  -> storeCompleteFromNotification(intent, store)
             Intent.ACTION_SEND    -> storeShareIntent(intent, store)
             // Cold start via an app.dayglance.* Activity intent (app was killed):
             // onNewIntent is NOT called for the launching intent, so without this the
@@ -692,6 +694,7 @@ class MainActivity : AppCompatActivity() {
             ACTION_VOICE_INPUT    -> store.pendingVoiceInput = true
             ACTION_ADD_TASK       -> store.pendingAddTask = true
             ACTION_ADD_INBOX_TASK -> store.pendingAddInboxTask = true
+            ACTION_COMPLETE_TASK  -> storeCompleteFromNotification(intent, store)
             Intent.ACTION_SEND    -> storeShareIntent(intent, store)
             "app.dayglance.CREATE",
             "app.dayglance.COMPLETE",
@@ -701,6 +704,30 @@ class MainActivity : AppCompatActivity() {
         }
         // The WebView is already loaded; trigger the JS check immediately.
         forwardPendingIntentToJs()
+    }
+
+    /**
+     * Stores the task from a notification "Mark Complete" tap and dismisses the
+     * notification it came from.
+     *
+     * NotificationActionReceiver used to do both, but it can only bring the app
+     * forward with a background startActivity(), which the platform may drop (see
+     * ACTION_COMPLETE_TASK). Arriving here means the Activity is already being
+     * launched by the system, so the only work left is the same SharedDataStore
+     * write the receiver did; NativeBridge.getPendingAction() hands it to JS.
+     *
+     * Dismissal moves here with it: setAutoCancel applies to the notification body,
+     * not to action buttons, so nothing else would clear it.
+     */
+    private fun storeCompleteFromNotification(intent: Intent, store: SharedDataStore) {
+        val taskId = intent.getStringExtra(EXTRA_COMPLETE_TASK_ID)
+        if (taskId.isNullOrEmpty()) return
+        store.pendingCompleteTaskId = taskId
+
+        val notifId = intent.getIntExtra(EXTRA_COMPLETE_NOTIF_ID, -1)
+        if (notifId >= 0) {
+            (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).cancel(notifId)
+        }
     }
 
     /**
@@ -755,5 +782,21 @@ class MainActivity : AppCompatActivity() {
         const val ACTION_ADD_TASK       = "com.dayglance.app.ACTION_ADD_TASK"
         const val ACTION_ADD_INBOX_TASK = "com.dayglance.app.ACTION_ADD_INBOX_TASK"
         const val ACTION_INTENT_RECEIVED = "com.dayglance.app.INTENT_RECEIVED"
+
+        /**
+         * The notification "Mark Complete" button, delivered straight to this
+         * Activity rather than through NotificationActionReceiver.
+         *
+         * The button used to be a getBroadcast PendingIntent whose receiver then
+         * called startActivity(). Targeting SDK 34+, an app no longer grants its
+         * background-activity-launch privileges when sending a PendingIntent, so
+         * that second hop could be dropped and the tap did nothing at all. A
+         * notification tap that launches an Activity directly is a system-sent
+         * launch and needs no such privilege, which is why this is a getActivity
+         * PendingIntent now. Snooze is unaffected: it only sets an alarm.
+         */
+        const val ACTION_COMPLETE_TASK = "com.dayglance.app.ACTION_COMPLETE_TASK"
+        const val EXTRA_COMPLETE_TASK_ID = "complete_task_id"
+        const val EXTRA_COMPLETE_NOTIF_ID = "complete_notif_id"
     }
 }

--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NotificationBridge.kt
@@ -296,13 +296,21 @@ class NotificationBridge(private val context: Context) {
         )
     }
 
+    /**
+     * Launches MainActivity directly rather than broadcasting to
+     * NotificationActionReceiver. Targeting SDK 34+, the receiver's own
+     * startActivity() is a background activity launch the platform can drop, so
+     * the tap did nothing; a notification that starts an Activity is a
+     * system-sent launch and is exempt. See MainActivity.ACTION_COMPLETE_TASK.
+     */
     private fun completePendingIntent(notifId: Int, taskId: String): PendingIntent {
-        val intent = Intent(context, NotificationActionReceiver::class.java).apply {
-            action = NotificationActionReceiver.ACTION_COMPLETE
-            putExtra(NotificationActionReceiver.EXTRA_NOTIF_ID, notifId)
-            putExtra(NotificationActionReceiver.EXTRA_TASK_ID, taskId)
+        val intent = Intent(context, MainActivity::class.java).apply {
+            action = MainActivity.ACTION_COMPLETE_TASK
+            putExtra(MainActivity.EXTRA_COMPLETE_NOTIF_ID, notifId)
+            putExtra(MainActivity.EXTRA_COMPLETE_TASK_ID, taskId)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
-        return PendingIntent.getBroadcast(
+        return PendingIntent.getActivity(
             context, notifId + 2, intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )

--- a/dayglance-android/app/src/main/java/com/dayglance/app/notifications/NotificationActionReceiver.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/notifications/NotificationActionReceiver.kt
@@ -70,6 +70,15 @@ class NotificationActionReceiver : BroadcastReceiver() {
         }
     }
 
+    /**
+     * Legacy path. Nothing builds an ACTION_COMPLETE broadcast any more: the
+     * notification button is a getActivity PendingIntent straight into
+     * MainActivity, because this method's startActivity() is a background
+     * activity launch the platform can drop on SDK 34+ (see
+     * MainActivity.ACTION_COMPLETE_TASK), which is exactly why the button did
+     * nothing. Kept so a notification still on screen from a pre-upgrade build,
+     * whose PendingIntent still points here, is no worse off than before.
+     */
     private fun handleComplete(context: Context, intent: Intent) {
         val taskId = intent.getStringExtra(EXTRA_TASK_ID) ?: return
         SharedDataStore(context).pendingCompleteTaskId = taskId

--- a/dayglance-android/app/src/main/java/com/dayglance/app/notifications/ReminderReceiver.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/notifications/ReminderReceiver.kt
@@ -91,12 +91,18 @@ class ReminderReceiver : BroadcastReceiver() {
 
         // Mark Complete — available for start/end reminders on non-calendar tasks
         if ((type == "start" || type == "end") && !isCalendar) {
-            val completeIntent = Intent(context, NotificationActionReceiver::class.java).apply {
-                action = NotificationActionReceiver.ACTION_COMPLETE
-                putExtra(NotificationActionReceiver.EXTRA_NOTIF_ID, notifId)
-                putExtra(NotificationActionReceiver.EXTRA_TASK_ID, taskId)
+            // Launches MainActivity directly. A broadcast receiver calling
+            // startActivity() is a background activity launch the platform can drop
+            // on SDK 34+, which is why this button did nothing; a notification that
+            // starts an Activity is system-sent and exempt. See
+            // MainActivity.ACTION_COMPLETE_TASK.
+            val completeIntent = Intent(context, MainActivity::class.java).apply {
+                action = MainActivity.ACTION_COMPLETE_TASK
+                putExtra(MainActivity.EXTRA_COMPLETE_NOTIF_ID, notifId)
+                putExtra(MainActivity.EXTRA_COMPLETE_TASK_ID, taskId)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
             }
-            val completePi = PendingIntent.getBroadcast(
+            val completePi = PendingIntent.getActivity(
                 context, notifId + 2, completeIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )

--- a/dayglance-ios/Shared/ControlWidgets.swift
+++ b/dayglance-ios/Shared/ControlWidgets.swift
@@ -9,11 +9,25 @@ import WidgetKit
 /// which can use a `Link`/`widgetURL`). So each control runs a tiny intent that
 /// stashes a pending action in the shared App Group and opens the app
 /// (`openAppWhenRun`). On foreground the web layer drains it via
-/// `getWidgetPendingAction` → `nativeGetWidgetPendingAction()` — the same App
+/// `getWidgetPendingAction` → `nativeGetWidgetPendingAction()`, the same App
 /// Group slot the widget bridge already reads (see WidgetBridge.getPendingAction).
 ///
 /// Gated to iOS 18 because the Controls (WidgetKit `ControlWidget`) API does not
 /// exist before then; users on iOS 16/17 keep the Home Screen Quick Actions.
+///
+/// ⚠️ THIS FILE MUST LIVE IN `Shared/`, NOT `DayGlanceWidget/`.
+///
+/// `openAppWhenRun` only foregrounds the app if the control's `AppIntent` is a
+/// member of BOTH the app target and the widget extension target. When this file
+/// sat in `DayGlanceWidget/` (extension-only, per project.yml `sources`), tapping
+/// a control did nothing at all: no launch, so nothing ever drained the pending
+/// action the intent had just written. `Shared/` is listed under `sources` for
+/// both the DayGlance app target and the DayGlanceWidget extension target, so
+/// keeping the file here is what satisfies the dual-membership requirement.
+/// src/iosControls.test.js guards this, because CI cannot compile the iOS app.
+///
+/// Everything here is `@available(iOS 18.0, *)`, so compiling into the app
+/// target (deployment target 16.0) is safe.
 
 // MARK: - Shared store
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "4.6.0",
+      "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
         "@glance-apps/billing": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dayglance",
   "private": true,
   "license": "MIT",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "homepage": "https://dayglance.app",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/androidNotificationActions.test.js
+++ b/src/androidNotificationActions.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * CI cannot compile the Android app, so the wiring behind the notification
+ * "Mark Complete" button is guarded here.
+ *
+ * The button used to be a getBroadcast PendingIntent into
+ * NotificationActionReceiver, which then called startActivity() to bring the app
+ * forward. Targeting SDK 34+, an app no longer grants its background-activity-
+ * launch privileges when sending a PendingIntent, so that second hop could be
+ * dropped and tapping the button did nothing at all. Snooze was unaffected
+ * because it only sets an alarm, which is why the two behaved differently.
+ *
+ * It is now a getActivity PendingIntent into MainActivity, a system-sent launch
+ * that needs no such privilege. Two things can silently undo that: someone
+ * reverting to getBroadcast, or the extra keys drifting apart between the two
+ * builders and MainActivity, which the compiler cannot catch because they are
+ * plain strings read back with getStringExtra.
+ */
+const ANDROID = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../dayglance-android/app/src/main/java/com/dayglance/app',
+);
+
+const read = (rel) => readFileSync(join(ANDROID, rel), 'utf8');
+
+const MAIN_ACTIVITY = read('MainActivity.kt');
+// The two places that build the Mark Complete button.
+const BUILDERS = [
+  ['NotificationBridge.kt', read('bridge/NotificationBridge.kt'), 'completePendingIntent'],
+  ['ReminderReceiver.kt', read('notifications/ReminderReceiver.kt'), 'completeIntent'],
+];
+
+/** Value of a `const val NAME = "..."` in MainActivity's companion object. */
+function constant(name) {
+  const m = MAIN_ACTIVITY.match(new RegExp(`const val ${name}\\s*=\\s*"([^"]+)"`));
+  expect(m, `MainActivity is missing const val ${name}`).not.toBeNull();
+  return m[1];
+}
+
+describe('Android notification Mark Complete action', () => {
+  it('declares the action and its two extras on MainActivity', () => {
+    expect(constant('ACTION_COMPLETE_TASK')).toBeTruthy();
+    expect(constant('EXTRA_COMPLETE_TASK_ID')).toBeTruthy();
+    expect(constant('EXTRA_COMPLETE_NOTIF_ID')).toBeTruthy();
+  });
+
+  it('handles the action on both cold start and warm resume', () => {
+    // onCreate covers a tap while the app is dead, onNewIntent while it is
+    // backgrounded. Dropping either loses the completion on that path alone,
+    // which is the kind of half-working that is easy to miss by hand.
+    const branches = [...MAIN_ACTIVITY.matchAll(/ACTION_COMPLETE_TASK\s*->/g)];
+    expect(
+      branches.length,
+      'expected an ACTION_COMPLETE_TASK branch in BOTH onCreate and onNewIntent',
+    ).toBe(2);
+  });
+
+  it('reads back exactly the extras the builders write', () => {
+    const taskIdKey = constant('EXTRA_COMPLETE_TASK_ID');
+    const notifIdKey = constant('EXTRA_COMPLETE_NOTIF_ID');
+
+    // MainActivity must read both by their constants, not by a copied literal.
+    expect(MAIN_ACTIVITY).toMatch(/getStringExtra\(EXTRA_COMPLETE_TASK_ID\)/);
+    expect(MAIN_ACTIVITY).toMatch(/getIntExtra\(EXTRA_COMPLETE_NOTIF_ID/);
+
+    // Guard the values themselves against a rename on one side only.
+    expect(taskIdKey).not.toBe(notifIdKey);
+  });
+
+  it.each(BUILDERS)('%s launches the Activity rather than broadcasting', (_name, src) => {
+    const block = src.slice(src.indexOf('MainActivity.ACTION_COMPLETE_TASK'));
+    expect(
+      block,
+      'the Mark Complete PendingIntent must be getActivity: a getBroadcast whose ' +
+        'receiver calls startActivity() is a background activity launch the platform ' +
+        'drops on SDK 34+, and the button silently does nothing',
+    ).toMatch(/PendingIntent\.getActivity\(/);
+  });
+
+  it.each(BUILDERS)('%s addresses MainActivity with both extras', (_name, src) => {
+    const start = src.indexOf('MainActivity.ACTION_COMPLETE_TASK');
+    const block = src.slice(start, start + 500);
+    expect(block).toMatch(/Intent\(context, MainActivity::class\.java\)|MainActivity::class\.java/);
+    expect(block).toMatch(/MainActivity\.EXTRA_COMPLETE_TASK_ID/);
+    expect(block).toMatch(/MainActivity\.EXTRA_COMPLETE_NOTIF_ID/);
+  });
+
+  it('no longer builds an ACTION_COMPLETE broadcast anywhere', () => {
+    // The receiver branch stays as a fallback for notifications still on screen
+    // from a pre-upgrade build, but nothing may create one afresh.
+    for (const [name, src] of BUILDERS) {
+      expect(
+        src.includes('NotificationActionReceiver.ACTION_COMPLETE'),
+        `${name} still builds a Mark Complete broadcast`,
+      ).toBe(false);
+    }
+  });
+
+  it('still routes Snooze through the broadcast receiver', () => {
+    // Snooze only sets an alarm, so it never needed the Activity launch. If this
+    // ever flips it means a refactor swept it along by accident.
+    const reminder = read('notifications/ReminderReceiver.kt');
+    expect(reminder).toMatch(/NotificationActionReceiver\.ACTION_SNOOZE/);
+  });
+});

--- a/src/iosControls.test.js
+++ b/src/iosControls.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * CI cannot compile the iOS app, so the one project-layout rule that silently
+ * breaks Control Center is guarded here.
+ *
+ * `openAppWhenRun` foregrounds the app only if the control's `AppIntent` is a
+ * member of BOTH the app target and the widget extension target. While
+ * ControlWidgets.swift sat in DayGlanceWidget/ (extension-only per project.yml
+ * `sources`), tapping a control did nothing whatsoever: the app never launched,
+ * so nothing drained the pending action the intent had just written to the App
+ * Group. Nothing catches that at build time, and no unit test on the JS side
+ * can see it either, because the drain code is correct.
+ *
+ * The rule: the file must live in a directory listed under `sources` for both
+ * targets. Shared/ is the only such directory.
+ */
+const IOS = join(dirname(fileURLToPath(import.meta.url)), '../dayglance-ios');
+
+const APP_TARGET = 'DayGlance';
+const WIDGET_TARGET = 'DayGlanceWidget';
+
+/**
+ * Minimal reader for the `targets.<name>.sources[].path` values in project.yml.
+ * Deliberately dependency-free: js-yaml is only present transitively, and this
+ * needs to read two nested keys, not parse arbitrary YAML.
+ */
+function sourcePathsByTarget(yaml) {
+  const out = {};
+  let target = null;
+  let inSources = false;
+  for (const line of yaml.split('\n')) {
+    if (/^\S/.test(line)) { target = null; inSources = false; continue; }
+    const targetMatch = line.match(/^ {2}([A-Za-z0-9_]+):\s*$/);
+    if (targetMatch) {
+      target = targetMatch[1];
+      out[target] = out[target] ?? [];
+      inSources = false;
+      continue;
+    }
+    if (!target) continue;
+    if (/^ {4}sources:\s*$/.test(line)) { inSources = true; continue; }
+    // Any other key at the target's own nesting level closes the sources block.
+    if (/^ {4}[A-Za-z0-9_]+:/.test(line)) { inSources = false; continue; }
+    if (!inSources) continue;
+    const pathMatch = line.match(/^ {6}- path:\s*(\S+)\s*$/);
+    if (pathMatch) out[target].push(pathMatch[1]);
+  }
+  return out;
+}
+
+describe('iOS Control Center controls', () => {
+  const sources = sourcePathsByTarget(readFileSync(join(IOS, 'project.yml'), 'utf8'));
+
+  it('parses both targets out of project.yml', () => {
+    expect(sources[APP_TARGET], 'app target sources').toBeDefined();
+    expect(sources[WIDGET_TARGET], 'widget target sources').toBeDefined();
+    expect(sources[APP_TARGET].length).toBeGreaterThan(0);
+    expect(sources[WIDGET_TARGET].length).toBeGreaterThan(0);
+  });
+
+  it('ships ControlWidgets.swift from a directory both targets compile', () => {
+    const shared = sources[APP_TARGET].filter((p) => sources[WIDGET_TARGET].includes(p));
+    expect(shared, 'no directory is compiled into both targets').not.toEqual([]);
+
+    const home = shared.find((dir) => existsSync(join(IOS, dir, 'ControlWidgets.swift')));
+    expect(
+      home,
+      'ControlWidgets.swift must sit in a directory listed under sources for BOTH ' +
+        `${APP_TARGET} and ${WIDGET_TARGET} (shared: ${shared.join(', ')}). An intent ` +
+        'that is extension-only will not foreground the app, so tapping a Control ' +
+        'Center control does nothing at all.',
+    ).toBeDefined();
+  });
+
+  it('does not leave a second copy in the extension-only directory', () => {
+    expect(existsSync(join(IOS, WIDGET_TARGET, 'ControlWidgets.swift'))).toBe(false);
+  });
+
+  it('keeps every control the widget bundle registers in that shared file', () => {
+    const shared = sources[APP_TARGET].filter((p) => sources[WIDGET_TARGET].includes(p));
+    const home = shared.find((dir) => existsSync(join(IOS, dir, 'ControlWidgets.swift')));
+    const controls = readFileSync(join(IOS, home, 'ControlWidgets.swift'), 'utf8');
+    const bundle = readFileSync(
+      join(IOS, WIDGET_TARGET, 'DayGlanceWidgetBundle.swift'),
+      'utf8',
+    );
+
+    // Whatever the bundle instantiates inside its iOS 18 block are the controls;
+    // each must be defined in the dual-membership file, not somewhere the app
+    // target cannot see.
+    const block = bundle.match(/if #available\(iOS 18\.0, \*\) \{([\s\S]*?)\}/);
+    expect(block, 'widget bundle no longer gates controls on iOS 18').not.toBeNull();
+
+    const registered = [...block[1].matchAll(/^\s*([A-Za-z0-9_]+)\(\)/gm)].map((m) => m[1]);
+    expect(registered.length, 'no controls registered in the bundle').toBeGreaterThan(0);
+
+    const missing = registered.filter((name) => !controls.includes(`struct ${name}:`));
+    expect(missing, 'controls defined outside the shared file').toEqual([]);
+  });
+
+  it('opens the app from each control intent', () => {
+    const shared = sources[APP_TARGET].filter((p) => sources[WIDGET_TARGET].includes(p));
+    const home = shared.find((dir) => existsSync(join(IOS, dir, 'ControlWidgets.swift')));
+    const controls = readFileSync(join(IOS, home, 'ControlWidgets.swift'), 'utf8');
+
+    const intents = [...controls.matchAll(/struct ([A-Za-z0-9_]+ControlIntent): AppIntent \{([\s\S]*?)\n\}/g)];
+    expect(intents.length, 'no control intents found').toBeGreaterThan(0);
+
+    const notOpening = intents
+      .filter(([, , body]) => !/openAppWhenRun: Bool = true/.test(body))
+      .map(([, name]) => name);
+    expect(notOpening, 'these intents would run without foregrounding the app').toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Runs `npm run bump 4.7.0` to prepare the 4.7.0 release. Four files change:

| File | Field | 4.6.0 -> 4.7.0 |
| --- | --- | --- |
| `package.json` | `version` | source of truth |
| `dayglance-android/app/build.gradle.kts` | `versionName` | full x.y.z |
| `README.md` | shields.io version badge | |
| `package-lock.json` | root + `packages[""]` version | |

iOS `MARKETING_VERSION` and the Electron `CFBundleShortVersionString` derive from `package.json` at build time, so they need no edit here. The Android `versionCode` is supplied per build by `build-and-install.sh --release`, not by the bumper.

## Quality gates

Both clean, per RELEASING.md 1.2:

- `npm run lint` passes with `--max-warnings 0`
- `npm test`: 139 files, 2127 tests, all passing

## Release notes

Drafted separately for the GitHub release, Google Play, and App Store Connect (iOS and macOS), covering the 12 substantive commits since `v4.6.0`: the Android and iOS native string localization, localized reminder notifications, the iOS Siri and Shortcuts surface, the Obsidian launch-after-write setting, the iOS Quick Actions cold-launch fix, and the Day Dial sun label fade.

## Reminders before tagging

- `npm run ios:generate` must run after this bump so the regenerated Xcode project picks up the new `MARKETING_VERSION`.
- The Android and iOS localization commits were never compiled in CI (no SDK, no Xcode). A local `build-and-install.sh` and an Xcode build are worth doing before submitting.
- Tag only from a commit carrying this bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYy9cGsKHGqfQbvUVTHA4X)_