### PR TITLE
Client-side brakes for the GLANCEvault sync cycle (finding (e))

### DIFF
--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -43,6 +43,7 @@ import { pruneAllTombstones, tombstoneCutoff } from './tombstoneRetention.js';
 import { partitionSnapshotDeletes } from './snapshotDeleteGuard.js';
 import { isPayloadExcludedEntity, agedOutReleaseReason } from './payloadExclusions.js';
 import { shredHashes, hashMapsEqual, mergeMidCycleEdits } from './commitMerge.js';
+import { createSyncCycleBreaker, isRateLimitedError } from './syncBrakes.js';
 
 const APP_ID = 'dayglance';
 const CRYPTO_DB_NAME = 'dayglance-db-crypto';
@@ -323,6 +324,10 @@ export function createDbEngine(callbacks = {}) {
       // ping-pong. Logging every applied entityId shows whether the churn arrives
       // FROM the vault (another device re-pushing) vs originates locally.
       if (debugPushEnabled()) console.log('[pull] apply', entityId);
+      // The vault's content for this row changed under us — whatever we last
+      // acked there is stale, so the no-op re-push skip below must not apply.
+      ackedUpsertHashes.delete(entityId);
+      ackedDeletes.delete(entityId);
       // Bundle merges may leave us richer than the clobbered vault row; re-push
       // the superset so it converges at the vault (see dbAdapter / stage-2 doc).
       for (const id of adapterApplyRemoteEntity(mirror, entity)) engine.markDirty(id);
@@ -332,6 +337,10 @@ export function createDbEngine(callbacks = {}) {
       // is the "deleted" half of the ping-pong — it proves the delete came from
       // the vault log (a peer's soft-delete), not from local state loss.
       if (debugPushEnabled()) console.log('[pull] DELETE', entityId);
+      // The vault now holds a delete for this row — remember it so the diff
+      // doesn't re-send an identical soft-delete every cycle.
+      ackedDeletes.add(entityId);
+      ackedUpsertHashes.delete(entityId);
       return adapterApplyRemoteDelete(mirror, entityId);
     },
     isInsertOnly,
@@ -342,6 +351,32 @@ export function createDbEngine(callbacks = {}) {
 
   // In-flight guard so a debounced push never overlaps a cadence-triggered cycle.
   let syncing = false;
+
+  // CYCLE-RATE BRAKE (finding (e), PR #1449 repro): a failed cycle — above all a
+  // rate-limited one — must not be immediately eligible for the next trigger
+  // (interval / debounced push / SSE nudge), or a throttled client retries as
+  // fast as it is triggered and feeds the limiter rejecting it. Gated at the top
+  // of dbSyncCycle; a gated cycle performs NO network traffic. Injectable for
+  // tests via callbacks.cycleBreaker.
+  const breaker = callbacks.cycleBreaker || createSyncCycleBreaker();
+  // Log once per imposed cooldown, not once per rejected trigger.
+  let throttleAnnounced = false;
+
+  // PUSH CONTENT DEDUP (the self-nudge fuel cut, same finding): what the vault
+  // last acknowledged from us, per entityId — upserts as their pushed content
+  // hash, deletes as membership. The snapshot diff consults these so a row
+  // whose current content the vault already holds (or whose delete it already
+  // holds) is never re-marked dirty by a STALE baseline: pushDirtyRows re-sends
+  // dirty rows verbatim, and each re-send advances the account seq → SSE nudge
+  // → next cycle — the write half of the ~1/s loop. A WITHHELD snapshot (the
+  // glitch-heal path deliberately freezes the baseline) is exactly such a stale
+  // baseline, so without this map every cycle re-wrote every since-changed row.
+  // In-memory by design: after a restart the first push is at most one
+  // idempotent re-send, and persisting acks would risk suppressing a push the
+  // vault never actually kept. Entries are invalidated whenever a pull applies
+  // remote content for the row (see applyRemoteEntity/applyRemoteDelete above).
+  const ackedUpsertHashes = new Map();
+  const ackedDeletes = new Set();
 
   // Re-fetch glitch-skipped rows by id and re-inject them into the mirror (see
   // the call site in dbSyncCycle for the full rationale). Uses the vault's
@@ -365,10 +400,10 @@ export function createDbEngine(callbacks = {}) {
   // and automatic), and a hard bail on the first 429 (every further row-get
   // this cycle is doomed and only feeds the limiter).
   const HEAL_MAX_PER_CYCLE = 40;
-  const isRateLimited = (err) => err?.status === 429 || /\b429\b/.test(String(err?.message || ''));
   const healGlitchSkips = async (skippedIds) => {
     const unresolved = [];
     const recovered = [];
+    let rateLimited = false;
     const canGetRow = typeof engine.vault?.getRow === 'function';
     const toHeal = skippedIds.slice(0, HEAL_MAX_PER_CYCLE);
     if (skippedIds.length > HEAL_MAX_PER_CYCLE) {
@@ -396,7 +431,8 @@ export function createDbEngine(callbacks = {}) {
         recovered.push(entityId);
       } catch (err) {
         unresolved.push(entityId); // transient failure — retry next cycle
-        if (isRateLimited(err)) {
+        if (isRateLimitedError(err)) {
+          rateLimited = true;
           const rest = toHeal.slice(i + 1);
           unresolved.push(...rest);
           console.warn(
@@ -414,7 +450,7 @@ export function createDbEngine(callbacks = {}) {
         recovered.slice(0, 25), recovered.length > 25 ? `(+${recovered.length - 25} more)` : ''
       );
     }
-    return unresolved;
+    return { unresolved, rateLimited };
   };
 
   // dayGLANCE wraps the engine's push/pull steps in its own cycle so it can
@@ -445,6 +481,20 @@ export function createDbEngine(callbacks = {}) {
   const dbSyncCycle = async () => {
     if (typeof callbacks.getData !== 'function') return;
     if (syncing) return;
+    // Failure/429 cooldown gate — see the breaker note above. A gated cycle is
+    // a pure no-op (no network traffic, no status churn); the next trigger
+    // after the cooldown expires runs normally.
+    const gate = breaker.beforeCycle();
+    if (!gate.allowed) {
+      if (!throttleAnnounced) {
+        throttleAnnounced = true;
+        console.warn(
+          `[sync] BRAKE: cycle skipped — backing off after ${gate.reason} ` +
+          `(retry eligible in ~${Math.ceil(gate.waitMs / 1000)}s).`
+        );
+      }
+      return { applied: 0, skipped: 0, skippedEntityIds: [], throttled: true, retryInMs: gate.waitMs };
+    }
     syncing = true;
     callbacks.onError?.(null, null);
     // Pull-cursor value as of cycle start, for the rollback in the catch
@@ -494,6 +544,12 @@ export function createDbEngine(callbacks = {}) {
         const cur = baseHashes;
         for (const [id, h] of Object.entries(cur)) {
           if (prev[id] === h) continue;
+          // The vault already holds exactly this content for this row (acked on
+          // a previous push) — the diff only sees it because the baseline is
+          // stale (typically a WITHHELD snapshot). Re-sending it would be a
+          // no-op write that still advances the account seq → SSE nudge → next
+          // cycle: the self-nudge loop's fuel. Skip it.
+          if (ackedUpsertHashes.get(id) === h) continue;
           engine.markDirty(id);
           if (dbgChanges) {
             let a, b;
@@ -572,6 +628,12 @@ export function createDbEngine(callbacks = {}) {
           );
         }
         for (const id of propagate) {
+          // Same no-op-write skip as the upsert diff above: a delete the vault
+          // already acknowledged (or that arrived FROM the vault) re-fires from
+          // a stale baseline every cycle, and each re-send is a seq-advancing
+          // write. If the row ever comes back at the vault, the pull applies it
+          // live (invalidating this entry) before any delete could be wanted.
+          if (ackedDeletes.has(id)) continue;
           engine.markDirty(id); // deletes
           if (dbgChanges) dbgChanges.push({ id, kind: 'deleted', diff: [] });
         }
@@ -614,7 +676,12 @@ export function createDbEngine(callbacks = {}) {
       // (no row-get on this client, network error, undecryptable) poison the
       // snapshot save below.
       let glitchUnresolved = [];
-      if (glitchSkipped.length) glitchUnresolved = await healGlitchSkips(glitchSkipped);
+      let healRateLimited = false;
+      if (glitchSkipped.length) {
+        const heal = await healGlitchSkips(glitchSkipped);
+        glitchUnresolved = heal.unresolved;
+        healRateLimited = heal.rateLimited;
+      }
       reconcileCrossList(
         mirror,
         (id) => engine.markDirty(id),
@@ -643,7 +710,10 @@ export function createDbEngine(callbacks = {}) {
       // re-push + cross-list reconcile) right before the push, then report what
       // vault.batch actually wrote — so we can see if the client writes every
       // cycle and which exact row/field is moving. Gated on dayglance-debug-push.
-      const dirtyBeforePush = pushDbg && typeof engine.getDirtySet === 'function' ? engine.getDirtySet() : null;
+      // Captured unconditionally (not just for the debug log): these are the
+      // rows the push below sends, and on success their pushed content becomes
+      // the acked-hash baseline for the no-op re-push skip in the diff.
+      const dirtyBeforePush = typeof engine.getDirtySet === 'function' ? engine.getDirtySet() : null;
       const pushRes = await engine.pushDirtyRows();        // push merged superset + local changes
       if (pushDbg) {
         const wrote = (pushRes?.written ?? 0) + (pushRes?.deleted ?? 0);
@@ -691,6 +761,21 @@ export function createDbEngine(callbacks = {}) {
       // snapshot → 'new' in cycle N+1's diff → pushed. And for a pulled remote
       // change: in the snapshot AND in the commit → clean, no echo re-push.)
       const vaultSnapshot = shredHashes(mirror);
+      // The push above was fully acked (a throw would have skipped this), so
+      // record what the vault now holds for each pushed id: present in the
+      // mirror → its pushed content hash (vaultSnapshot is hashed from the
+      // exact mirror the push read); absent → an acked soft-delete.
+      if (dirtyBeforePush) {
+        for (const id of dirtyBeforePush) {
+          if (vaultSnapshot[id] !== undefined) {
+            ackedUpsertHashes.set(id, vaultSnapshot[id]);
+            ackedDeletes.delete(id);
+          } else {
+            ackedDeletes.add(id);
+            ackedUpsertHashes.delete(id);
+          }
+        }
+      }
       const liveNow = clone(callbacks.getData()) || {};
       const { survivors, honoredDeletes, liveHashes } = mergeMidCycleEdits(mirror, baseHashes, liveNow);
       if (survivors.length || honoredDeletes.length) {
@@ -731,6 +816,16 @@ export function createDbEngine(callbacks = {}) {
           glitchUnresolved.slice(0, 25), glitchUnresolved.length > 25 ? `(+${glitchUnresolved.length - 25} more)` : ''
         );
       }
+      // Breaker bookkeeping: a clean cycle resets the backoff. A cycle that
+      // finished but was rate-limited inside the heal still counts as a strike —
+      // the vault told us to slow down, and retrying the heal at full trigger
+      // cadence is what sustained the observed 429 storm.
+      if (healRateLimited) {
+        throttleAnnounced = false;
+        breaker.onFailure({ status: 429, message: 'rate-limited during glitch-skip recovery' });
+      } else {
+        breaker.onSuccess();
+      }
       callbacks.onStatusChange?.('success');
       return { applied: pull?.applied ?? 0, skipped: pull?.skipped ?? 0, skippedEntityIds: pull?.skippedEntityIds ?? [] };
     } catch (err) {
@@ -765,6 +860,11 @@ export function createDbEngine(callbacks = {}) {
       // is all-or-nothing. Making the benefit safe here would need durable
       // per-page commits, which is an architecture change, not a bump.
       try { engine.setHighWaterMark(preCycleHwm); } catch { /* storage unavailable */ }
+      // Failed cycle → impose/extend the cooldown so the next trigger (interval,
+      // debounced push, SSE nudge) cannot immediately re-run us against a vault
+      // that just rejected us.
+      throttleAnnounced = false;
+      breaker.onFailure(err);
       const code = err && err.code ? err.code : 'NETWORK_ERROR';
       callbacks.onError?.(err?.message || String(err), code);
       callbacks.onStatusChange?.('error');

--- a/src/sync/dbEngineWiring.test.js
+++ b/src/sync/dbEngineWiring.test.js
@@ -1027,8 +1027,11 @@ describe('Wave B — payload-excluded baseline rows (the fresh-device churn loop
     expect(rateLimitedCalls).toBe(1); // bailed after the FIRST 429 — not 12 doomed attempts
     expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('rate-limited'))).toBe(true);
 
-    // Limiter clears → the withheld snapshot retries and fully recovers.
+    // Limiter clears AND the rate-limit cooldown passes (a heal 429 now counts
+    // as a breaker strike — syncBrakes.js — so an immediate retry would be
+    // gated) → the withheld snapshot retries and fully recovers.
     vault.getRow = realGetRow;
+    vi.setSystemTime(new Date(FIXTURE_NOW.getTime() + 5 * 60 * 1000));
     await A.engine.dbSyncCycle();
     expect(A.data.tasks).toHaveLength(12);
   });

--- a/src/sync/dbPullPagination.test.js
+++ b/src/sync/dbPullPagination.test.js
@@ -82,6 +82,12 @@ function makeDevice(name, vault, initial) {
     nativeStoreSyncKey: (v) => { nativeKey = v; },
     getData: () => clone(data),
     commitData: (d) => { data = d; },
+    // These tests deliberately fail a cycle and retry it IMMEDIATELY to prove
+    // cursor-rollback semantics; the failure backoff (syncBrakes.js) would gate
+    // that retry under the real clock. The brake has its own coverage
+    // (phase2TransitionSyncLoop / syncBrakes tests) — disarm it here so the
+    // pull semantics stay the thing under test.
+    cycleBreaker: { beforeCycle: () => ({ allowed: true }), onSuccess() {}, onFailure() { return 0; } },
   });
   return { engine, get data() { return data; } };
 }

--- a/src/sync/phase2TransitionSyncLoop.test.js
+++ b/src/sync/phase2TransitionSyncLoop.test.js
@@ -47,15 +47,19 @@ import { mergeObsidianTasks } from '../utils/mergeObsidianTasks.js';
 //  3. THE STORM — when a heal row-get fails (429), the cycle withholds its
 //     snapshot (dbEngine.js: unresolved glitch-skips poison the baseline). A
 //     frozen baseline re-marks every since-changed row dirty EVERY cycle, and
-//     pushDirtyRows has no content dedup — each cycle re-writes the same rows,
+//     pushDirtyRows had no content dedup — each cycle re-wrote the same rows,
 //     each write advances the account seq, each seq advance SSE-nudges
-//     drainSync (wired straight to dbSyncCycle, no backoff), which runs the
-//     next cycle: the ~1/s self-nudge loop whose request volume feeds the very
-//     429s that keep the heal failing. Restart changes nothing: snapshot,
-//     tombstones, task lists and the vault row are all persisted.
+//     drainSync (wired straight to dbSyncCycle, originally with no backoff),
+//     running the next cycle: the ~1/s self-nudge loop whose request volume
+//     feeds the very 429s that keep the heal failing. Restart changes nothing:
+//     snapshot, tombstones, task lists and the vault row are all persisted.
+//     ── FIXED by the client-side brakes (src/sync/syncBrakes.js + the
+//     acked-hash push dedup in dbEngine.js); the storm section below now pins
+//     the fixed behavior.
 //
-// Tests asserting the CORRECT behavior are marked it.fails — they document the
-// bug deterministically while keeping CI green; a fix flips them to plain it.
+// Tests asserting correct-but-not-yet-implemented behavior are marked it.fails
+// — they document the remaining bug (the war, parts 1–2) deterministically
+// while keeping CI green; the eventual fix flips them to plain it.
 // ─────────────────────────────────────────────────────────────────────────────
 
 function memLocalStorage() {
@@ -150,7 +154,7 @@ const obsidianTask = (id, lastModified, extra = {}) => ({
 // (replace semantics, NO deletedTaskIds filter on the merged list — the real
 // apply only consults tombstones for prev-only rescue rows, never for rows the
 // mirror itself carries).
-function makeDevice(name, vault, initial) {
+function makeDevice(name, vault, initial, engineOverrides = {}) {
   let data = clone(initial);
   let nativeKey = null;
   const engine = createDbEngine({
@@ -159,6 +163,7 @@ function makeDevice(name, vault, initial) {
     deviceId: `device-${name}`,
     nativeGetSyncKey: () => nativeKey,
     nativeStoreSyncKey: (v) => { nativeKey = v; },
+    ...engineOverrides,
     getData: () => {
       const d = clone(data);
       d.tasks = dropResurrectedTasks(d.tasks, d.deletedTaskIds);
@@ -195,12 +200,12 @@ const taskIds = (device) => device.data.tasks.map((t) => t.id).sort();
 //   peer cycle 1 — pulls, then pushes its re-stamped L (T_PEER) and stale L2 (T_OLD).
 //   mac cycle 2  — pulls both: the duplicates land in Mac state (the phone
 //                  symptom, reproduced on the Mac).
-async function seedMixedSession(vault) {
+async function seedMixedSession(vault, macOverrides = {}) {
   const mac = makeDevice('mac', vault, {
     ...EMPTY,
     tasks: [obsidianTask(DG_ID, T_EDIT, { obsidianBlockId: 'k3x9q2mf' })],
     deletedTaskIds: { [L_ID]: T_TOMB, [L2_ID]: T_TOMB },
-  });
+  }, macOverrides);
   const peer = makeDevice('peer', vault, {
     ...EMPTY,
     tasks: [obsidianTask(L_ID, T_PEER), obsidianTask(L2_ID, T_OLD)],
@@ -315,18 +320,27 @@ describe('the war — scan eviction vs stale-tombstone heal (peers powered off)'
   });
 });
 
-describe('the storm — a failing heal withholds the snapshot and turns one stuck row into full re-pushes', () => {
-  // What SHOULD happen: rows the vault has already acked are not re-written by
-  // cycles in which they did not change. What ACTUALLY happens while any
-  // glitch-skip stays unresolved (429 on the row-get): the snapshot is withheld,
-  // the frozen baseline re-diffs the same rows dirty every cycle, and
-  // pushDirtyRows re-writes them — every write advances the account seq, and the
-  // live app wires each seq advance (SSE 'activity') straight into the next
-  // dbSyncCycle with no backoff: the observed ~1/s self-nudge loop, whose
-  // request volume sustains the 429s that keep the heal failing.
-  it.fails('an unchanged row is not re-pushed on every cycle while a 429 pins the heal', async () => {
+describe('the storm — FIXED: brakes on the withheld-snapshot re-push loop (syncBrakes + acked-hash dedup)', () => {
+  // Originally pinned here as it.fails: while any glitch-skip stayed unresolved
+  // (429 on the row-get), the snapshot was withheld, the frozen baseline
+  // re-diffed the same rows dirty every cycle, and pushDirtyRows re-wrote them —
+  // every write advanced the account seq, each seq advance SSE-nudged the next
+  // dbSyncCycle, and no backoff existed anywhere: the observed ~1/s self-nudge
+  // loop, whose request volume sustained the 429s that kept the heal failing.
+  // Two independent brakes now cover it, each proven in isolation below:
+  //   • acked-hash push dedup (dbEngine.js): a row whose exact content/delete
+  //     the vault already acknowledged is never re-marked dirty by a stale
+  //     baseline — the loop's write fuel is gone even if cycles keep running.
+  //   • cycle breaker (syncBrakes.js): a failed or rate-limited cycle imposes a
+  //     capped-exponential cooldown, so triggers can't hammer a 429ing vault.
+
+  // Cycles keep running here (breaker disarmed) to prove the DEDUP alone stops
+  // the writes: one edit → one write, then the seq stops moving even though the
+  // heal keeps 429ing and the snapshot stays withheld.
+  it('push dedup: an unchanged row is not re-pushed while a 429 pins the heal — the seq stops advancing', async () => {
     const vault = createMemoryVault();
-    const mac = await seedMixedSession(vault);
+    const noBreaker = { beforeCycle: () => ({ allowed: true }), onSuccess() {}, onFailure() { return 0; } };
+    const mac = await seedMixedSession(vault, { cycleBreaker: noBreaker });
     await mac.engine.dbSyncCycle();
     runVaultScan(mac); // L evicted → next cycle wants the delete → skip → heal
 
@@ -342,42 +356,61 @@ describe('the storm — a failing heal withholds the snapshot and turns one stuc
     const batchSpy = vi.spyOn(vault, 'batch');
     await mac.engine.dbSyncCycle(); // pushes the edit; heal 429s → snapshot withheld
     const seqAfterFirst = vault._seq();
-    await mac.engine.dbSyncCycle(); // nothing changed since — should push nothing
+    await mac.engine.dbSyncCycle(); // nothing changed since — must push nothing
     await mac.engine.dbSyncCycle();
 
     const dgWrites = batchSpy.mock.calls
       .flatMap((c) => c[1].rows)
       .filter((r) => r.entityId === `tasks:${DG_ID}`).length;
-    // CORRECT behavior (currently false): one edit → one write, and the account
-    // seq stops moving. Currently dgWrites is 3 (one per cycle) and the seq
-    // advances every cycle — each advance is an SSE nudge scheduling the next
-    // cycle in the live app.
     expect(dgWrites).toBe(1);
     expect(vault._seq()).toBe(seqAfterFirst);
   });
 
-  it('pins the broken shape: while the heal 429s, every cycle re-writes the unchanged row and advances the account seq (the self-nudge fuel)', async () => {
+  it('cycle breaker: a rate-limited heal imposes a cooldown — the next trigger runs no cycle and touches the vault not at all', async () => {
     const vault = createMemoryVault();
-    const mac = await seedMixedSession(vault);
+    const mac = await seedMixedSession(vault); // default (real) breaker
     await mac.engine.dbSyncCycle();
     runVaultScan(mac);
     vault.getRow = async () => { const e = new Error('get row failed: 429'); e.status = 429; throw e; };
-    mac.data = {
-      ...mac.data,
-      tasks: mac.data.tasks.map((t) => (t.id === DG_ID ? { ...t, title: 'Buy oat milk #obsidian', lastModified: '2026-07-10T11:59:00.000Z' } : t)),
-    };
 
-    const batchSpy = vi.spyOn(vault, 'batch');
-    const seqs = [];
-    for (let i = 0; i < 3; i++) {
-      await mac.engine.dbSyncCycle();
-      seqs.push(vault._seq());
-    }
-    const dgWrites = batchSpy.mock.calls
-      .flatMap((c) => c[1].rows)
-      .filter((r) => r.entityId === `tasks:${DG_ID}`).length;
-    expect(dgWrites).toBe(3);                     // same content, re-written every cycle
-    expect(seqs[1]).toBeGreaterThan(seqs[0]);     // every cycle advances the seq —
-    expect(seqs[2]).toBeGreaterThan(seqs[1]);     // each advance = an SSE nudge = the next cycle
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await mac.engine.dbSyncCycle(); // heal 429s → breaker strike → cooldown
+
+    const listSpy = vi.spyOn(vault, 'list');
+    const gated = await mac.engine.dbSyncCycle(); // an SSE nudge / debounce firing now
+    expect(gated.throttled).toBe(true);
+    expect(gated.retryInMs).toBeGreaterThan(0);
+    expect(listSpy.mock.calls.length).toBe(0); // zero vault traffic while gated
+
+    // Cooldown passes (rate-limit backoff caps at 5min) → cycles run again.
+    vi.setSystemTime(new Date(FIXTURE_NOW.getTime() + 5 * 60 * 1000 + 1000));
+    const resumed = await mac.engine.dbSyncCycle();
+    expect(resumed.throttled).toBeUndefined();
+    expect(listSpy.mock.calls.length).toBeGreaterThan(0);
+    warnSpy.mockRestore();
+  });
+
+  it('cycle breaker: a 429-failed pull (list) gates the immediate retry too', async () => {
+    const vault = createMemoryVault();
+    const mac = await seedMixedSession(vault);
+    await mac.engine.dbSyncCycle();
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const realList = vault.list;
+    vault.list = async () => { const e = new Error('list failed: 429'); e.status = 429; throw e; };
+    const failed = await mac.engine.dbSyncCycle();
+    expect(failed.error).toMatch(/429/);
+
+    vault.list = realList;
+    const listSpy = vi.spyOn(vault, 'list');
+    const gated = await mac.engine.dbSyncCycle();
+    expect(gated.throttled).toBe(true);
+    expect(listSpy.mock.calls.length).toBe(0);
+
+    vi.setSystemTime(new Date(FIXTURE_NOW.getTime() + 5 * 60 * 1000 + 1000));
+    const resumed = await mac.engine.dbSyncCycle();
+    expect(resumed.throttled).toBeUndefined();
+    expect(listSpy.mock.calls.length).toBeGreaterThan(0);
+    warnSpy.mockRestore();
   });
 });

--- a/src/sync/phase2TransitionSyncLoop.test.js
+++ b/src/sync/phase2TransitionSyncLoop.test.js
@@ -1,0 +1,383 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import { setSyncPassphrase } from '@glance-apps/sync';
+import { createDbEngine } from './dbEngine.js';
+import { setVaultConfig } from './vaultConfig.js';
+import { partitionSnapshotDeletes, STALE_TOMBSTONE_EPSILON_MS } from './snapshotDeleteGuard.js';
+import { dropResurrectedTasks } from '../utils/dropResurrectedTasks.js';
+import { mergeObsidianTasks } from '../utils/mergeObsidianTasks.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PHASE 2 TRANSITION × DB-TIER SYNC LOOP — deterministic reproduction.
+//
+// Field symptom (macOS dev build, main @ #1439, GLANCEvault backend, all peers
+// powered off): cloud sync fires ~every second, GLANCEvault rate-limits with
+// `list failed: 429`, task rows appear and disappear in a repeating cycle, and
+// the whole thing survives an app restart.
+//
+// THE MECHANISM, in three interlocking parts (each pinned by a test below):
+//
+//  1. THE SEED — a retired legacy row whose VAULT copy outlived its tombstone.
+//     The Phase 2 id migration retires `obsidian-<date>-<hash>` → `obsidian-dg-…`
+//     and tombstones the retired id in deletedTaskIds at commit time T_c. During
+//     the mixed-version window a v4.7.0 peer still holding the legacy row L
+//     re-pushed it to the vault with a lastModified NEWER than T_c (any peer-side
+//     re-stamp does it). The vault now holds L alive, newer than its tombstone.
+//
+//  2. THE WAR — two subsystems permanently disagree about L:
+//       • REMOVER: the Phase 2 vault scan evicts L from app state every scan —
+//         the legacy-hint bridge puts L in scannedIdsAllLists, so
+//         mergeObsidianTasks neither merges nor retains it (utils/
+//         mergeObsidianTasks.js). By design: the dg row replaces it.
+//       • RESTORER: the DB engine's snapshot still holds L, so the push diff
+//         wants to delete it — but snapshotDeleteGuard compares the tombstone
+//         (T_c) against the snapshot copy's lastModified (the peer re-stamp,
+//         > T_c + 5s) and classifies it 'stale-tombstone': the delete is SKIPPED
+//         and healGlitchSkips re-fetches L from the vault (still live there) and
+//         re-commits it into app state. Row reappears; snapshot re-learns it;
+//         the next scan evicts it again. Neither side ever wins: the vault row
+//         is never deleted, the eviction never sticks, and every iteration costs
+//         a list + a row-get. The 'completed'/aged-out release valve
+//         (payloadExclusions) deliberately does NOT apply to the
+//         'stale-tombstone' class, so completed rows — exactly the ones the
+//         user completed, stamping and retiring their legacy ids — are the ones
+//         that loop. (Contrast test: a legacy row whose tombstone stayed newest
+//         propagates its delete cleanly and converges. The peer re-stamp is the
+//         whole difference.)
+//
+//  3. THE STORM — when a heal row-get fails (429), the cycle withholds its
+//     snapshot (dbEngine.js: unresolved glitch-skips poison the baseline). A
+//     frozen baseline re-marks every since-changed row dirty EVERY cycle, and
+//     pushDirtyRows has no content dedup — each cycle re-writes the same rows,
+//     each write advances the account seq, each seq advance SSE-nudges
+//     drainSync (wired straight to dbSyncCycle, no backoff), which runs the
+//     next cycle: the ~1/s self-nudge loop whose request volume feeds the very
+//     429s that keep the heal failing. Restart changes nothing: snapshot,
+//     tombstones, task lists and the vault row are all persisted.
+//
+// Tests asserting the CORRECT behavior are marked it.fails — they document the
+// bug deterministically while keeping CI green; a fix flips them to plain it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+// In-memory GLANCEvault with the single-row GET enabled (the heal path needs it).
+function createMemoryVault() {
+  const salts = new Map();
+  const log = new Map();
+  let seq = 0;
+  const vault = {
+    async getSalt(accountId) { return salts.get(accountId) || null; },
+    async putSalt(accountId, fresh) { if (!salts.has(accountId)) salts.set(accountId, fresh); return salts.get(accountId); },
+    async batch(app, { rows }) {
+      for (const r of rows) log.set(r.entityId, { entityId: r.entityId, seq: ++seq, envelope: r.envelope, deleted: false });
+      return { maxSeq: seq };
+    },
+    async deleteRow(app, entityId) { log.set(entityId, { entityId, seq: ++seq, envelope: null, deleted: true }); return { seq }; },
+    async list(app, { since }) {
+      const rows = [...log.values()].filter((r) => r.seq > since).sort((a, b) => a.seq - b.seq);
+      return { rows, hasMore: false };
+    },
+    async device() { return { updated: true }; },
+    async getRow(app, entityId) {
+      const r = log.get(entityId);
+      return r && !r.deleted ? { entityId: r.entityId, seq: r.seq, envelope: r.envelope, deleted: false } : null;
+    },
+    _row(entityId) { return log.get(entityId) || null; },
+    _seq() { return seq; },
+  };
+  return vault;
+}
+
+// Frozen clock: every fixture date below keeps its meaning against the 60-day
+// tombstone window permanently (same pattern as dbEngineWiring.test.js).
+const FIXTURE_NOW = new Date('2026-07-10T12:00:00.000Z');
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(FIXTURE_NOW);
+  global.localStorage = memLocalStorage();
+  setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 't', accountId: 'acct' });
+  setSyncPassphrase('correct horse battery staple');
+});
+afterEach(() => { vi.useRealTimers(); });
+afterAll(() => { delete global.localStorage; });
+
+const clone = (x) => JSON.parse(JSON.stringify(x));
+
+const EMPTY = {
+  tasks: [], unscheduledTasks: [], recurringTasks: [], recycleBin: [], todayRoutines: [],
+  habits: [], goals: [], projects: [], gtdFrames: [], users: [], dailyNotes: {},
+  completedTaskUids: [], deletedTaskIds: {},
+};
+
+// ── The mixed-session cast ──────────────────────────────────────────────────
+// D: the migrated dg row the Mac keeps. L: the retired legacy id, completed on
+// the Mac at T_EDIT, tombstoned at T_TOMB, re-stamped by a v4.7.0 peer at
+// T_PEER (> T_TOMB + epsilon). L2: a retired id whose tombstone stayed newest
+// (the healthy case — no peer re-stamp).
+const DG_ID = 'obsidian-dg-k3x9q2mf';
+const L_ID = 'obsidian-2026-07-08-1a2b3c';
+const L2_ID = 'obsidian-2026-07-08-9z8y7x';
+const T_EDIT = '2026-07-08T10:00:00.000Z';
+const T_TOMB = '2026-07-08T10:00:05.000Z'; // commit-time tombstone, 5s after the edit
+const T_PEER = '2026-07-08T11:00:00.000Z'; // peer re-stamp, 1h later — well past epsilon
+const T_OLD = '2026-07-08T09:00:00.000Z'; // L2's untouched lastModified — older than its tombstone
+
+const obsidianTask = (id, lastModified, extra = {}) => ({
+  id,
+  title: 'Buy milk #obsidian',
+  duration: 30,
+  color: 'bg-purple-600',
+  completed: true,
+  notes: '',
+  subtasks: [],
+  importSource: 'obsidian',
+  obsidianRawTitle: 'Buy milk',
+  obsidianFileDate: '2026-07-08',
+  lastModified,
+  ...extra,
+});
+
+// A device wired like the app: getData mirrors buildSyncPayload (its
+// dropResurrectedTasks pass included), commitData mirrors applyEngineData
+// (replace semantics, NO deletedTaskIds filter on the merged list — the real
+// apply only consults tombstones for prev-only rescue rows, never for rows the
+// mirror itself carries).
+function makeDevice(name, vault, initial) {
+  let data = clone(initial);
+  let nativeKey = null;
+  const engine = createDbEngine({
+    vaultClient: vault,
+    storageKeyPrefix: `dev-${name}`,
+    deviceId: `device-${name}`,
+    nativeGetSyncKey: () => nativeKey,
+    nativeStoreSyncKey: (v) => { nativeKey = v; },
+    getData: () => {
+      const d = clone(data);
+      d.tasks = dropResurrectedTasks(d.tasks, d.deletedTaskIds);
+      d.unscheduledTasks = dropResurrectedTasks(d.unscheduledTasks, d.deletedTaskIds);
+      return d;
+    },
+    commitData: (d) => { data = d; },
+  });
+  return {
+    engine,
+    get data() { return data; },
+    set data(d) { data = d; },
+  };
+}
+
+// The Phase 2 vault scan, reduced to its task-merge step: the scan parses the
+// stamped line as D and — via the legacy-hint bridge — reports L as "accounted
+// for" in scannedIdsAllLists, so mergeObsidianTasks evicts the L row from state.
+// This is the REAL merge function, fed exactly what useObsidianSync feeds it.
+function runVaultScan(device) {
+  const scannedD = obsidianTask(DG_ID, T_EDIT, { obsidianBlockId: 'k3x9q2mf', obsidianLegacyId: L_ID });
+  const scannedIdsAllLists = new Set([DG_ID, L_ID]);
+  const preserve = () => ({});
+  device.data = {
+    ...device.data,
+    tasks: mergeObsidianTasks(device.data.tasks, [scannedD], scannedIdsAllLists, preserve, {}),
+  };
+}
+
+const taskIds = (device) => device.data.tasks.map((t) => t.id).sort();
+
+// Shared setup: replay the mixed-version session, then power the peer off.
+//   mac cycle 1  — pushes D + the tombstone bundle (deletedTaskIds[L]=T_TOMB).
+//   peer cycle 1 — pulls, then pushes its re-stamped L (T_PEER) and stale L2 (T_OLD).
+//   mac cycle 2  — pulls both: the duplicates land in Mac state (the phone
+//                  symptom, reproduced on the Mac).
+async function seedMixedSession(vault) {
+  const mac = makeDevice('mac', vault, {
+    ...EMPTY,
+    tasks: [obsidianTask(DG_ID, T_EDIT, { obsidianBlockId: 'k3x9q2mf' })],
+    deletedTaskIds: { [L_ID]: T_TOMB, [L2_ID]: T_TOMB },
+  });
+  const peer = makeDevice('peer', vault, {
+    ...EMPTY,
+    tasks: [obsidianTask(L_ID, T_PEER), obsidianTask(L2_ID, T_OLD)],
+  });
+  await mac.engine.dbSyncCycle();
+  await peer.engine.dbSyncCycle();
+  await mac.engine.dbSyncCycle();
+  // The mixed-session damage is now in place on the Mac:
+  expect(taskIds(mac)).toContain(L_ID);
+  return mac;
+}
+
+describe('the seed — guard classification of a peer-re-stamped retired id', () => {
+  it("a retired id whose vault copy outlived its tombstone is 'stale-tombstone' (skipped + healed), and the aged-out release valve does not cover it", () => {
+    const snapshotEntity = { _kind: 'tasks', value: obsidianTask(L_ID, T_PEER) };
+    const { skipped, reasons } = partitionSnapshotDeletes(
+      [`tasks:${L_ID}`],
+      {}, // current shred: the scan evicted L, so it is absent
+      { deletedTaskIds: { [L_ID]: T_TOMB } },
+      () => snapshotEntity,
+      // The release predicate dbEngine passes would say 'completed' for this row —
+      // but partitionSnapshotDeletes only consults it for bare-glitch rows, so the
+      // completed stale-tombstone row is NOT released. Assert that stays true (it
+      // is why the user's COMPLETED tasks are exactly the ones that loop).
+      () => 'completed',
+    );
+    expect(skipped).toEqual([`tasks:${L_ID}`]);
+    expect(reasons[`tasks:${L_ID}`]).toBe('stale-tombstone');
+    // Sanity: the classification really is the timestamp flip, not something else.
+    expect(new Date(T_PEER).getTime() - new Date(T_TOMB).getTime()).toBeGreaterThan(STALE_TOMBSTONE_EPSILON_MS);
+  });
+
+  it("the same id with its tombstone still newest is 'tombstoned' (propagates) — the healthy transition", () => {
+    const snapshotEntity = { _kind: 'tasks', value: obsidianTask(L2_ID, T_OLD) };
+    const { propagate, reasons } = partitionSnapshotDeletes(
+      [`tasks:${L2_ID}`], {}, { deletedTaskIds: { [L2_ID]: T_TOMB } }, () => snapshotEntity,
+    );
+    expect(propagate).toEqual([`tasks:${L2_ID}`]);
+    expect(reasons[`tasks:${L2_ID}`]).toBe('tombstoned');
+  });
+});
+
+describe('the war — scan eviction vs stale-tombstone heal (peers powered off)', () => {
+  it('contrast: the tombstoned-and-older duplicate (L2) converges — delete propagates to the vault and it stays gone', async () => {
+    const vault = createMemoryVault();
+    const mac = await seedMixedSession(vault);
+    // L2 landed in state from the pull, but getData's dropResurrectedTasks hides
+    // it from the payload, so the next cycle diffs it as a delete — and with the
+    // tombstone newest, the guard PROPAGATES it. One more cycle commits the
+    // mirror (which lacks L2) back over state. Converged; no heal traffic.
+    const getRowSpy = vi.spyOn(vault, 'getRow');
+    await mac.engine.dbSyncCycle();
+    await mac.engine.dbSyncCycle();
+    expect(vault._row(`tasks:${L2_ID}`).deleted).toBe(true);
+    expect(taskIds(mac)).not.toContain(L2_ID);
+    expect(getRowSpy.mock.calls.filter((c) => c[1] === `tasks:${L2_ID}`).length).toBe(0);
+  });
+
+  // What SHOULD happen after the scan evicts the re-stamped duplicate: the
+  // system converges — L stays out of state (or at minimum stops consuming a
+  // vault row-get per scan, forever). What ACTUALLY happens: every scan
+  // eviction is undone by the guard's heal within one cycle, the vault row is
+  // never deleted, and each round costs a fresh row-get. it.fails pins the loop.
+  it.fails('a scan-evicted stale-tombstone duplicate stays evicted (no per-round heal traffic)', async () => {
+    const vault = createMemoryVault();
+    const mac = await seedMixedSession(vault);
+    await mac.engine.dbSyncCycle(); // settle L2's clean delete so only L is in play
+
+    const getRowSpy = vi.spyOn(vault, 'getRow');
+    for (let round = 0; round < 3; round++) {
+      runVaultScan(mac);
+      expect(taskIds(mac)).not.toContain(L_ID); // scan evicted it…
+      await mac.engine.dbSyncCycle();
+      await mac.engine.dbSyncCycle();
+    }
+    // CORRECT behavior (currently false): the eviction sticks…
+    expect(taskIds(mac)).not.toContain(L_ID);
+    // …and the war costs no per-round vault row-gets. Currently every round
+    // heal-fetches tasks:L right back (3 rounds → 3 fetches → 3 reappearances).
+    expect(getRowSpy.mock.calls.filter((c) => c[1] === `tasks:${L_ID}`).length).toBe(0);
+  });
+
+  it('pins the broken shape: every round the heal re-fetches L, re-commits it into state, and the vault row stays live', async () => {
+    const vault = createMemoryVault();
+    const mac = await seedMixedSession(vault);
+    await mac.engine.dbSyncCycle();
+
+    const getRowSpy = vi.spyOn(vault, 'getRow');
+    for (let round = 1; round <= 3; round++) {
+      runVaultScan(mac);
+      expect(taskIds(mac)).not.toContain(L_ID); // disappears…
+      await mac.engine.dbSyncCycle();
+      expect(taskIds(mac)).toContain(L_ID);     // …reappears, same round
+      expect(getRowSpy.mock.calls.filter((c) => c[1] === `tasks:${L_ID}`).length).toBe(round);
+    }
+    expect(vault._row(`tasks:${L_ID}`).deleted).toBe(false); // never deleted
+  });
+
+  it('pins restart survival: a fresh engine over the same persisted state resumes the war immediately', async () => {
+    const vault = createMemoryVault();
+    const mac = await seedMixedSession(vault);
+    await mac.engine.dbSyncCycle();
+    runVaultScan(mac);
+
+    // "Quit and reopen": a NEW engine with the same storageKeyPrefix (snapshot,
+    // HWM, dirty set all persisted in localStorage) over the same app data.
+    const reopened = makeDevice('mac', vault, mac.data);
+    const getRowSpy = vi.spyOn(vault, 'getRow');
+    await reopened.engine.dbSyncCycle();
+    expect(taskIds(reopened)).toContain(L_ID); // healed straight back, no user action
+    expect(getRowSpy.mock.calls.filter((c) => c[1] === `tasks:${L_ID}`).length).toBe(1);
+  });
+});
+
+describe('the storm — a failing heal withholds the snapshot and turns one stuck row into full re-pushes', () => {
+  // What SHOULD happen: rows the vault has already acked are not re-written by
+  // cycles in which they did not change. What ACTUALLY happens while any
+  // glitch-skip stays unresolved (429 on the row-get): the snapshot is withheld,
+  // the frozen baseline re-diffs the same rows dirty every cycle, and
+  // pushDirtyRows re-writes them — every write advances the account seq, and the
+  // live app wires each seq advance (SSE 'activity') straight into the next
+  // dbSyncCycle with no backoff: the observed ~1/s self-nudge loop, whose
+  // request volume sustains the 429s that keep the heal failing.
+  it.fails('an unchanged row is not re-pushed on every cycle while a 429 pins the heal', async () => {
+    const vault = createMemoryVault();
+    const mac = await seedMixedSession(vault);
+    await mac.engine.dbSyncCycle();
+    runVaultScan(mac); // L evicted → next cycle wants the delete → skip → heal
+
+    // The vault is now rate-limiting row-gets (what the storm looks like server-side).
+    vault.getRow = async () => { const e = new Error('get row failed: 429'); e.status = 429; throw e; };
+
+    // A single ordinary user edit, made once.
+    mac.data = {
+      ...mac.data,
+      tasks: mac.data.tasks.map((t) => (t.id === DG_ID ? { ...t, title: 'Buy oat milk #obsidian', lastModified: '2026-07-10T11:59:00.000Z' } : t)),
+    };
+
+    const batchSpy = vi.spyOn(vault, 'batch');
+    await mac.engine.dbSyncCycle(); // pushes the edit; heal 429s → snapshot withheld
+    const seqAfterFirst = vault._seq();
+    await mac.engine.dbSyncCycle(); // nothing changed since — should push nothing
+    await mac.engine.dbSyncCycle();
+
+    const dgWrites = batchSpy.mock.calls
+      .flatMap((c) => c[1].rows)
+      .filter((r) => r.entityId === `tasks:${DG_ID}`).length;
+    // CORRECT behavior (currently false): one edit → one write, and the account
+    // seq stops moving. Currently dgWrites is 3 (one per cycle) and the seq
+    // advances every cycle — each advance is an SSE nudge scheduling the next
+    // cycle in the live app.
+    expect(dgWrites).toBe(1);
+    expect(vault._seq()).toBe(seqAfterFirst);
+  });
+
+  it('pins the broken shape: while the heal 429s, every cycle re-writes the unchanged row and advances the account seq (the self-nudge fuel)', async () => {
+    const vault = createMemoryVault();
+    const mac = await seedMixedSession(vault);
+    await mac.engine.dbSyncCycle();
+    runVaultScan(mac);
+    vault.getRow = async () => { const e = new Error('get row failed: 429'); e.status = 429; throw e; };
+    mac.data = {
+      ...mac.data,
+      tasks: mac.data.tasks.map((t) => (t.id === DG_ID ? { ...t, title: 'Buy oat milk #obsidian', lastModified: '2026-07-10T11:59:00.000Z' } : t)),
+    };
+
+    const batchSpy = vi.spyOn(vault, 'batch');
+    const seqs = [];
+    for (let i = 0; i < 3; i++) {
+      await mac.engine.dbSyncCycle();
+      seqs.push(vault._seq());
+    }
+    const dgWrites = batchSpy.mock.calls
+      .flatMap((c) => c[1].rows)
+      .filter((r) => r.entityId === `tasks:${DG_ID}`).length;
+    expect(dgWrites).toBe(3);                     // same content, re-written every cycle
+    expect(seqs[1]).toBeGreaterThan(seqs[0]);     // every cycle advances the seq —
+    expect(seqs[2]).toBeGreaterThan(seqs[1]);     // each advance = an SSE nudge = the next cycle
+  });
+});

--- a/src/sync/syncBrakes.js
+++ b/src/sync/syncBrakes.js
@@ -1,0 +1,108 @@
+// Client-side brakes for the GLANCEvault DB sync cycle.
+//
+// FINDING (the phase2TransitionSyncLoop repro, PR #1449): nothing on the client
+// could stop a sync loop from hammering the vault at network speed. The brakes
+// that existed — the in-flight guard, the 3s push debounce, the 400ms SSE nudge
+// coalescer, the heal's per-cycle cap and first-429 bail — all bound a SINGLE
+// cycle's cost; none bounds the CYCLE RATE. Two gaps did the damage:
+//
+//   1. A cycle that fails (e.g. `list failed: 429`) was immediately eligible
+//      for the next trigger — interval, debounced push, or SSE nudge — so a
+//      rate-limited client retried as fast as it was triggered, feeding the
+//      very limiter that was rejecting it.
+//
+//   2. A cycle that always WRITES self-perpetuates: every vault write advances
+//      the account seq, every seq advance is an SSE 'activity' nudge, and the
+//      nudge drains straight into the next dbSyncCycle. pushDirtyRows has no
+//      content dedup, so a stale diff baseline (a withheld snapshot) re-marked
+//      the same unchanged rows dirty every cycle and re-wrote them — a ~1/s
+//      self-nudge loop made entirely of "successful" cycles, which backoff on
+//      FAILURE can never brake. (The dedup half of the fix lives in
+//      dbEngine.js — the acked-hash skip; this module provides the failure
+//      side.)
+//
+// This module is the failure-side brake: a consecutive-failure circuit breaker
+// with capped exponential backoff, rate-limit-aware (a 429 starts from a much
+// higher floor than a transient network error — the vault TOLD us to slow
+// down). Pure and clock-injectable; the engine wires it around dbSyncCycle.
+//
+// Deliberately NOT included: suppressing a device's own SSE echo nudge (a nudge
+// whose seq equals our own last push). It would also end write-driven loops,
+// but a peer write that lands between our pull and our push carries a lower
+// seq than ours and its nudge would be swallowed with the echo — trading a
+// pathological loop for missed real nudges. The content dedup removes the
+// loop's fuel instead, at no freshness cost.
+
+import { backoffDelayMs } from './vaultEventStream.js';
+
+// A vault rate-limit, however it surfaces: a structured status on the error, or
+// the vaultClient's message text ("list failed: 429", "get row failed: 429").
+// Shared with dbEngine's heal bail so the two detectors cannot drift.
+export const isRateLimitedError = (err) =>
+  err?.status === 429 || /\b429\b/.test(String(err?.message || ''));
+
+/**
+ * Consecutive-failure circuit breaker for the sync cycle.
+ *
+ * beforeCycle() → { allowed:true } | { allowed:false, waitMs, reason } — gate
+ *   every cycle start on this; a disallowed cycle should return without any
+ *   network traffic.
+ * onFailure(err) → delayMs — call on a failed cycle (or a rate-limited heal in
+ *   an otherwise-successful cycle); starts/extends the cooldown. Backoff is
+ *   capped-exponential with equal jitter (the same shape the SSE reconnect
+ *   uses, via backoffDelayMs) so a fleet of throttled clients de-synchronizes
+ *   instead of retrying in waves.
+ * onSuccess() — call on a clean cycle; resets the breaker entirely.
+ *
+ * The cooldown only ever extends (Math.max), so an in-flight cycle finishing
+ * with a failure cannot shorten a longer cooldown already imposed.
+ *
+ * @param {object} [opts]
+ * @param {() => number} [opts.now]      clock (epoch ms), injectable for tests
+ * @param {() => number} [opts.random]   uniform [0,1) jitter source
+ * @param {number} [opts.failureBaseMs]   first-failure backoff base (transient errors)
+ * @param {number} [opts.failureMaxMs]    backoff cap for transient errors
+ * @param {number} [opts.rateLimitBaseMs] first-failure backoff base after a 429
+ * @param {number} [opts.rateLimitMaxMs]  backoff cap after 429s
+ */
+export function createSyncCycleBreaker({
+  now = () => Date.now(),
+  random = Math.random,
+  failureBaseMs = 2000,
+  failureMaxMs = 60000,
+  rateLimitBaseMs = 15000,
+  rateLimitMaxMs = 300000,
+} = {}) {
+  let failures = 0;
+  let cooldownUntil = 0;
+  let reason = null;
+
+  return {
+    beforeCycle() {
+      const waitMs = cooldownUntil - now();
+      if (waitMs > 0) return { allowed: false, waitMs, reason };
+      return { allowed: true };
+    },
+    onSuccess() {
+      failures = 0;
+      cooldownUntil = 0;
+      reason = null;
+    },
+    onFailure(err) {
+      const rateLimited = isRateLimitedError(err);
+      const delayMs = backoffDelayMs({
+        attempt: failures,
+        baseMs: rateLimited ? rateLimitBaseMs : failureBaseMs,
+        maxMs: rateLimited ? rateLimitMaxMs : failureMaxMs,
+        random,
+      });
+      failures += 1;
+      reason = rateLimited ? 'rate-limited' : 'error';
+      cooldownUntil = Math.max(cooldownUntil, now() + delayMs);
+      return delayMs;
+    },
+    getState() {
+      return { failures, cooldownUntil, reason };
+    },
+  };
+}

--- a/src/sync/syncBrakes.test.js
+++ b/src/sync/syncBrakes.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { createSyncCycleBreaker, isRateLimitedError } from './syncBrakes.js';
+
+// Deterministic jitter: random() = 1 - ε makes backoffDelayMs return the full
+// exponential (exp/2 + ~exp/2 ≈ exp); random() = 0 returns exactly exp/2.
+const FULL = () => 0.999999;
+const HALF = () => 0;
+
+describe('isRateLimitedError', () => {
+  it('matches a structured 429 status', () => {
+    expect(isRateLimitedError({ status: 429 })).toBe(true);
+  });
+  it('matches the vaultClient message shapes', () => {
+    expect(isRateLimitedError(new Error('list failed: 429'))).toBe(true);
+    expect(isRateLimitedError(new Error('get row failed: 429'))).toBe(true);
+  });
+  it('does not match other failures', () => {
+    expect(isRateLimitedError(new Error('network blip'))).toBe(false);
+    expect(isRateLimitedError({ status: 503 })).toBe(false);
+    expect(isRateLimitedError(null)).toBe(false);
+    // "429" as part of a larger number is not a rate limit.
+    expect(isRateLimitedError(new Error('entity 14290 rejected'))).toBe(false);
+  });
+});
+
+describe('createSyncCycleBreaker', () => {
+  it('allows cycles until a failure, then gates for the backoff window', () => {
+    let t = 1000000;
+    const b = createSyncCycleBreaker({ now: () => t, random: FULL });
+    expect(b.beforeCycle().allowed).toBe(true);
+
+    const delay = b.onFailure(new Error('network blip'));
+    expect(delay).toBeGreaterThan(0);
+    const gate = b.beforeCycle();
+    expect(gate.allowed).toBe(false);
+    expect(gate.reason).toBe('error');
+    expect(gate.waitMs).toBeGreaterThan(0);
+
+    t += delay + 1; // cooldown passes
+    expect(b.beforeCycle().allowed).toBe(true);
+  });
+
+  it('backs off exponentially on consecutive failures, up to the cap', () => {
+    let t = 0;
+    const b = createSyncCycleBreaker({ now: () => t, random: HALF, failureBaseMs: 2000, failureMaxMs: 60000 });
+    // random=0 → delay is exactly exp/2 = base * 2^attempt / 2.
+    expect(b.onFailure(new Error('x'))).toBe(1000);   // attempt 0: 2000/2
+    expect(b.onFailure(new Error('x'))).toBe(2000);   // attempt 1: 4000/2
+    expect(b.onFailure(new Error('x'))).toBe(4000);   // attempt 2: 8000/2
+    for (let i = 0; i < 10; i++) b.onFailure(new Error('x'));
+    expect(b.onFailure(new Error('x'))).toBe(30000);  // capped: 60000/2
+  });
+
+  it('a 429 starts from the rate-limit floor, far above the generic-failure base', () => {
+    let t = 0;
+    const b = createSyncCycleBreaker({ now: () => t, random: HALF, failureBaseMs: 2000, rateLimitBaseMs: 15000 });
+    const delay = b.onFailure({ status: 429 });
+    expect(delay).toBe(7500); // 15000/2 — vs 1000 for a generic first failure
+    expect(b.beforeCycle().reason).toBe('rate-limited');
+  });
+
+  it('rate-limit backoff caps at rateLimitMaxMs', () => {
+    let t = 0;
+    const b = createSyncCycleBreaker({ now: () => t, random: FULL, rateLimitBaseMs: 15000, rateLimitMaxMs: 300000 });
+    let last = 0;
+    for (let i = 0; i < 12; i++) last = b.onFailure({ status: 429 });
+    expect(last).toBeLessThan(300000);
+    expect(last).toBeGreaterThan(150000); // full jitter of the capped exponential
+  });
+
+  it('success resets the breaker completely', () => {
+    let t = 0;
+    const b = createSyncCycleBreaker({ now: () => t, random: HALF });
+    b.onFailure({ status: 429 });
+    b.onFailure({ status: 429 });
+    expect(b.beforeCycle().allowed).toBe(false);
+    b.onSuccess();
+    expect(b.beforeCycle().allowed).toBe(true);
+    // The attempt counter reset too: the next failure backs off from the base again.
+    expect(b.onFailure(new Error('x'))).toBe(1000);
+  });
+
+  it('a cooldown only ever extends — a shorter late verdict cannot shorten it', () => {
+    let t = 0;
+    const b = createSyncCycleBreaker({ now: () => t, random: HALF, failureBaseMs: 2000, rateLimitBaseMs: 60000 });
+    b.onFailure({ status: 429 });               // cooldown until t+30000
+    const before = b.beforeCycle().waitMs;
+    b.onFailure(new Error('network blip'));     // attempt 1 generic: 2000 — must not shrink the window
+    expect(b.beforeCycle().waitMs).toBeGreaterThanOrEqual(before);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **(3) only** from the sync-loop diagnosis — the finding-(e) fix: nothing on the client bounded the *cycle rate*, so a pathological state could hammer GLANCEvault at ~1/s indefinitely. This PR adds two independent brakes. It does **not** touch the snapshot delete guard's conflict semantics or `applyEngineData` — proposals (1) and (2) remain open and undecided.

**Stacked on #1449** (the deterministic repro): this branch contains those tests and flips the storm section from `it.fails` to passing pins of the fixed behavior. Merging this PR subsumes #1449; merging #1449 first shrinks this diff.

### Brake 1 — cycle breaker (`src/sync/syncBrakes.js`)

A consecutive-failure circuit breaker gates `dbSyncCycle`: a failed cycle imposes a capped-exponential, jittered cooldown (same jitter shape as the SSE reconnect backoff), during which any trigger — interval, debounced push, SSE nudge — is a pure no-op with **zero network traffic**. Rate-limit-aware: a 429 starts at a 15s floor and caps at 5 minutes (the vault *told* us to slow down); generic failures back off 2s → 60s. A cycle that succeeds but gets rate-limited inside the glitch-skip heal counts as a strike too — retrying the heal at full trigger cadence is what sustained the observed 429 storm. A clean cycle resets the breaker. Injectable (`callbacks.cycleBreaker`) for tests.

### Brake 2 — acked-hash push dedup (`dbEngine.js`)

The write half of the loop: with a **withheld snapshot** (the glitch-heal path deliberately freezes the diff baseline), every since-changed row re-diffed dirty every cycle, and `pushDirtyRows` re-sent it verbatim — each write advancing the account seq → SSE nudge → next cycle. The wrapper now remembers what the vault last acknowledged per entityId (pushed content hash for upserts, membership for deletes) and skips re-marking a row whose exact content/delete the vault already holds. One edit → one write, then the seq stops moving — even while a 429 pins the heal. Entries invalidate whenever a pull applies remote content for that row; the map is in-memory by design (a restart costs at most one idempotent re-send, and persisting acks could suppress a push the vault never kept).

**Deliberately not included:** suppressing the device's own SSE echo nudge. It would also end write-driven loops, but a peer write landing between our pull and our push carries a lower seq than ours and its nudge would be swallowed with the echo — trading a pathological loop for missed real nudges. The dedup removes the loop's fuel at no freshness cost instead.

## Tests

- `src/sync/syncBrakes.test.js` — breaker policy units (exponential growth, rate-limit floor/cap, reset on success, cooldown only extends, 429 detection shapes).
- `phase2TransitionSyncLoop.test.js` storm section rewritten to pin the **fixed** behavior, each brake proven in isolation: dedup with the breaker disarmed (writes stop, seq freezes while the heal keeps 429ing), breaker with the dedup active (heal-429 and list-429 both gate the immediate retry with zero vault traffic, then resume after the cooldown). The **war** tests stay `it.fails` — the scan-evict vs stale-tombstone-heal bug is out of scope here.
- `dbPullPagination.test.js` disarms the breaker via the injection point (cursor-rollback semantics require immediate retries); `dbEngineWiring.test.js`'s heal-429 test advances the mocked clock past the cooldown.

Full suite: **2213 passed, 1 expected fail** (the war pin). Lint clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_