### PR TITLE
Deferred retry: a sync trigger gated by a cooldown is delayed, not lost

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2164,6 +2164,9 @@ const DayPlanner = () => {
       document.removeEventListener('visibilitychange', onVisible);
       clearInterval(interval);
       registerDbEngine(null);
+      // Cancels any pending deferred cooldown-retry and makes stray timer
+      // firings no-ops — a timer must never run a cycle against a dead engine.
+      engine.dispose?.();
       dbEngineRef.current = null;
     };
     // Keyed on dataLoaded (sets up the DB engine once). setUndoToast/t are read
@@ -8476,7 +8479,13 @@ const DayPlanner = () => {
         onRowsSkipped: (count) => setVaultSkipped(count),
       });
       if (!eng) return { ok: false, error: 'GLANCEvault is not configured.' };
-      await eng.dbSyncCycle();
+      try {
+        await eng.dbSyncCycle();
+      } finally {
+        // Transient engine: retire it so no deferred cooldown-retry timer can
+        // ever fire a cycle against it after this one-shot bootstrap returns.
+        eng.dispose?.();
+      }
       if (bootErr) return { ok: false, error: bootErr, code: bootCode };
       setVaultError(null);
       setVaultLastSynced(eng.getLastSynced?.() || new Date().toISOString());

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -362,6 +362,46 @@ export function createDbEngine(callbacks = {}) {
   // Log once per imposed cooldown, not once per rejected trigger.
   let throttleAnnounced = false;
 
+  // DEFERRED RETRY — a trigger that arrives during a cooldown must not be
+  // LOST, only delayed. Without this, a gated SSE nudge was consumed and
+  // dropped (the drain wrapper ignores the return value and the nudge
+  // coalescer's seq cursor has already advanced), so a peer edit whose nudge
+  // landed inside even a single isolated cooldown waited for the next
+  // trigger — worst case the 5-minute poll. Instead, the first gated trigger
+  // arms ONE one-shot timer for the cooldown's expiry; further gated triggers
+  // coalesce into it (no queue). When it fires it simply calls dbSyncCycle
+  // again: if the cooldown was extended meanwhile it re-arms through the same
+  // gate, and if the cycle runs and fails, that failure goes through the
+  // normal breaker.onFailure path — so storm damping is unchanged (still at
+  // most one attempted cycle per cooldown window, with escalating windows).
+  // A cycle that COMPLETES cancels any pending retry: its pull already served
+  // whatever the gated trigger was announcing, so firing afterwards would be
+  // a pointless extra cycle. Timer fns are injectable for deterministic tests.
+  const retrySetTimeout = callbacks.retryTimers?.setTimeoutFn || ((fn, ms) => setTimeout(fn, ms));
+  const retryClearTimeout = callbacks.retryTimers?.clearTimeoutFn || ((h) => clearTimeout(h));
+  // Small pad past the nominal expiry so the retry lands after the gate opens
+  // rather than a tick before it (in which case it just re-arms — harmless,
+  // but one wasted hop).
+  const RETRY_PAD_MS = 250;
+  let pendingRetryTimer = null;
+  let disposed = false;
+  const cancelPendingRetry = () => {
+    if (pendingRetryTimer != null) {
+      retryClearTimeout(pendingRetryTimer);
+      pendingRetryTimer = null;
+    }
+  };
+  const armDeferredRetry = (waitMs) => {
+    if (pendingRetryTimer != null) return; // coalesce: one pending retry, never a queue
+    // The callback's returned promise is ignored by a real setTimeout but lets
+    // an injected test timer await the deferred cycle deterministically.
+    pendingRetryTimer = retrySetTimeout(() => {
+      pendingRetryTimer = null;
+      if (disposed) return undefined; // engine torn down while the timer was in flight
+      return dbSyncCycle().catch(() => { /* surfaced via the engine onError */ });
+    }, Math.max(0, waitMs) + RETRY_PAD_MS);
+  };
+
   // PUSH CONTENT DEDUP (the self-nudge fuel cut, same finding): what the vault
   // last acknowledged from us, per entityId — upserts as their pushed content
   // hash, deletes as membership. The snapshot diff consults these so a row
@@ -479,21 +519,24 @@ export function createDbEngine(callbacks = {}) {
   // (the engine's own dbSyncCycle swallows errors, which would let a failed
   // cycle commit a partial mirror).
   const dbSyncCycle = async () => {
+    if (disposed) return;
     if (typeof callbacks.getData !== 'function') return;
     if (syncing) return;
-    // Failure/429 cooldown gate — see the breaker note above. A gated cycle is
-    // a pure no-op (no network traffic, no status churn); the next trigger
-    // after the cooldown expires runs normally.
+    // Failure/429 cooldown gate — see the breaker note above. A gated cycle
+    // performs no network traffic and no status churn, but the TRIGGER is not
+    // lost: it arms (or coalesces into) the deferred retry, which re-runs the
+    // cycle at cooldown expiry. See armDeferredRetry above.
     const gate = breaker.beforeCycle();
     if (!gate.allowed) {
+      armDeferredRetry(gate.waitMs);
       if (!throttleAnnounced) {
         throttleAnnounced = true;
         console.warn(
           `[sync] BRAKE: cycle skipped — backing off after ${gate.reason} ` +
-          `(retry eligible in ~${Math.ceil(gate.waitMs / 1000)}s).`
+          `(deferred retry armed for ~${Math.ceil(gate.waitMs / 1000)}s).`
         );
       }
-      return { applied: 0, skipped: 0, skippedEntityIds: [], throttled: true, retryInMs: gate.waitMs };
+      return { applied: 0, skipped: 0, skippedEntityIds: [], throttled: true, retryInMs: gate.waitMs, retryPending: true };
     }
     syncing = true;
     callbacks.onError?.(null, null);
@@ -816,6 +859,12 @@ export function createDbEngine(callbacks = {}) {
           glitchUnresolved.slice(0, 25), glitchUnresolved.length > 25 ? `(+${glitchUnresolved.length - 25} more)` : ''
         );
       }
+      // This cycle COMPLETED (pull + push both ran), so it served whatever any
+      // gated trigger was announcing — a still-pending deferred retry would
+      // just run a pointless extra cycle. Cancel it. (A THROWN cycle skips
+      // this, deliberately: its pull may not have finished, and the retry
+      // re-arms itself through the gate anyway.)
+      cancelPendingRetry();
       // Breaker bookkeeping: a clean cycle resets the backoff. A cycle that
       // finished but was rate-limited inside the heal still counts as a strike —
       // the vault told us to slow down, and retrying the heal at full trigger
@@ -874,7 +923,20 @@ export function createDbEngine(callbacks = {}) {
     }
   };
 
-  return { ...engine, dbSyncCycle, sync: dbSyncCycle };
+  return {
+    ...engine,
+    dbSyncCycle,
+    sync: dbSyncCycle,
+    // Tear-down for the wrapper's own state: cancels any pending deferred
+    // retry and makes every later dbSyncCycle call (including one from a
+    // timer that already left the queue) a no-op. Call when the engine is
+    // discarded — the App effect cleanup, a transient bootstrap engine — so a
+    // stray timer can never fire a cycle against a dead engine.
+    dispose() {
+      disposed = true;
+      cancelPendingRetry();
+    },
+  };
 }
 
 export { APP_ID, CRYPTO_DB_NAME };

--- a/src/sync/dbSyncDeferredRetry.test.js
+++ b/src/sync/dbSyncDeferredRetry.test.js
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import { setSyncPassphrase } from '@glance-apps/sync';
+import { createDbEngine } from './dbEngine.js';
+import { setVaultConfig } from './vaultConfig.js';
+import { createSyncCycleBreaker } from './syncBrakes.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DEFERRED RETRY AFTER A COOLDOWN — a trigger gated by the cycle breaker must
+// be DELAYED, never LOST.
+//
+// The regression this pins: with the breaker alone, an SSE nudge that fired
+// during a cooldown was consumed and dropped — the gated cycle returned
+// {throttled}, the drain wrapper ignores the return value, and the nudge
+// coalescer's seq cursor had already advanced past that nudge. A single
+// isolated 429 could therefore cost a peer edit up to five minutes (the poll
+// backstop) instead of single-digit seconds.
+//
+// The fix under test (dbEngine.js armDeferredRetry): the first gated trigger
+// arms ONE one-shot timer for the cooldown's expiry; further gated triggers
+// coalesce into it; a completed cycle cancels it (its pull already served the
+// trigger); a torn-down engine cancels it and neuters stray firings; and a
+// deferred retry that fails goes through the normal breaker.onFailure path, so
+// storm damping is unchanged — at most one attempted cycle per cooldown
+// window, with escalating windows.
+//
+// Real @glance-apps/sync engine + real crypto over the in-memory vault (the
+// same harness as the phase2TransitionSyncLoop repro), with two injections for
+// determinism: the REAL breaker built with random()=0 (delays become exactly
+// base/2 · 2^attempt: 7500ms, 15000ms, 30000ms… on the 429 path), and manual
+// retry timers (captured, fired by the test at the moment the mocked clock
+// says they would fire).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+function createMemoryVault() {
+  const salts = new Map();
+  const log = new Map();
+  let seq = 0;
+  return {
+    async getSalt(accountId) { return salts.get(accountId) || null; },
+    async putSalt(accountId, fresh) { if (!salts.has(accountId)) salts.set(accountId, fresh); return salts.get(accountId); },
+    async batch(app, { rows }) {
+      for (const r of rows) log.set(r.entityId, { entityId: r.entityId, seq: ++seq, envelope: r.envelope, deleted: false });
+      return { maxSeq: seq };
+    },
+    async deleteRow(app, entityId) { log.set(entityId, { entityId, seq: ++seq, envelope: null, deleted: true }); return { seq }; },
+    async list(app, { since }) {
+      const rows = [...log.values()].filter((r) => r.seq > since).sort((a, b) => a.seq - b.seq);
+      return { rows, hasMore: false };
+    },
+    async device() { return { updated: true }; },
+  };
+}
+
+// Manual one-shot timers: armDeferredRetry's setTimeout/clearTimeout, captured
+// so the test decides when a timer "fires" (in step with the mocked Date).
+function manualRetryTimers() {
+  const armed = []; // { fn, ms, cleared, fired }
+  return {
+    setTimeoutFn: (fn, ms) => { const h = { fn, ms, cleared: false, fired: false }; armed.push(h); return h; },
+    clearTimeoutFn: (h) => { if (h) h.cleared = true; },
+    armed,
+    pending: () => armed.filter((h) => !h.cleared && !h.fired),
+    // Fire a pending timer as the runtime would: mark it consumed, run its
+    // callback, await the deferred cycle the callback returns.
+    async fire(h) { h.fired = true; await h.fn(); },
+  };
+}
+
+// One-shot failure wrapper: the next list() call throws a 429, then the real
+// implementation is restored (so a shared vault only fails the caller under test).
+function failNextListWith429(vault) {
+  const real = vault.list;
+  vault.list = async (...args) => {
+    vault.list = real;
+    const e = new Error('list failed: 429');
+    e.status = 429;
+    throw e;
+  };
+}
+
+const FIXTURE_NOW = new Date('2026-07-10T12:00:00.000Z');
+const atOffset = (ms) => new Date(FIXTURE_NOW.getTime() + ms);
+
+let warnSpy;
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(FIXTURE_NOW);
+  global.localStorage = memLocalStorage();
+  setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 't', accountId: 'acct' });
+  setSyncPassphrase('correct horse battery staple');
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => { warnSpy.mockRestore(); vi.useRealTimers(); });
+afterAll(() => { delete global.localStorage; });
+
+const clone = (x) => JSON.parse(JSON.stringify(x));
+const EMPTY = {
+  tasks: [], unscheduledTasks: [], recurringTasks: [], recycleBin: [], todayRoutines: [],
+  habits: [], goals: [], projects: [], gtdFrames: [], users: [], dailyNotes: {},
+  completedTaskUids: [], deletedTaskIds: {},
+};
+const task = (id, lastModified, extra = {}) => ({
+  id, title: `task ${id}`, duration: 30, color: 'bg-blue-500', completed: false,
+  notes: '', subtasks: [], lastModified, ...extra,
+});
+
+function makeDevice(name, vault, initial, engineOverrides = {}) {
+  let data = clone(initial);
+  let nativeKey = null;
+  const engine = createDbEngine({
+    vaultClient: vault,
+    storageKeyPrefix: `dev-${name}`,
+    deviceId: `device-${name}`,
+    nativeGetSyncKey: () => nativeKey,
+    nativeStoreSyncKey: (v) => { nativeKey = v; },
+    getData: () => clone(data),
+    commitData: (d) => { data = d; },
+    ...engineOverrides,
+  });
+  return {
+    engine,
+    get data() { return data; },
+    set data(d) { data = d; },
+  };
+}
+
+// A converged mac+peer pair sharing one vault, with the mac carrying the real
+// breaker (deterministic jitter) and manual retry timers.
+async function seedConverged(vault, timers) {
+  const mac = makeDevice('mac', vault, { ...EMPTY, tasks: [task('t1', '2026-07-08T10:00:00.000Z')] }, {
+    cycleBreaker: createSyncCycleBreaker({ random: () => 0 }),
+    retryTimers: timers,
+  });
+  const peer = makeDevice('peer', vault, EMPTY);
+  await mac.engine.dbSyncCycle();
+  await peer.engine.dbSyncCycle();
+  await mac.engine.dbSyncCycle();
+  expect(peer.data.tasks.map((t) => t.id)).toEqual(['t1']);
+  return { mac, peer };
+}
+
+const macTitle = (mac, id) => mac.data.tasks.find((t) => t.id === id)?.title;
+
+describe('deferred retry — a nudge gated by a cooldown lands at cooldown expiry, not at the next poll', () => {
+  it('429 → peer edit + nudge during cooldown → the edit lands when the deferred retry fires; gated triggers coalesce into one timer', async () => {
+    const vault = createMemoryVault();
+    const timers = manualRetryTimers();
+    const { mac, peer } = await seedConverged(vault, timers);
+
+    // One isolated 429 on the mac's pull → attempt-0 rate-limit cooldown of
+    // exactly 7500ms (random()=0 halves the 15s base).
+    failNextListWith429(vault);
+    const failed = await mac.engine.dbSyncCycle();
+    expect(failed.error).toMatch(/429/);
+
+    // A peer edits the task during the mac's cooldown…
+    peer.data = { ...peer.data, tasks: [{ ...peer.data.tasks[0], title: 'edited on peer', lastModified: '2026-07-10T12:00:01.000Z' }] };
+    vi.setSystemTime(atOffset(2000));
+    await peer.engine.dbSyncCycle();
+
+    // …and its SSE nudge drains into the mac's dbSyncCycle mid-cooldown. The
+    // cycle is gated, but the trigger is NOT lost: a deferred retry is armed
+    // for the cooldown's remainder (5500ms left + the 250ms pad).
+    const gated = await mac.engine.dbSyncCycle();
+    expect(gated.throttled).toBe(true);
+    expect(gated.retryPending).toBe(true);
+    expect(timers.pending()).toHaveLength(1);
+    expect(timers.pending()[0].ms).toBe(5750);
+    expect(macTitle(mac, 't1')).toBe('task t1'); // not yet — still cooling down
+
+    // Coalescing (a): more gated triggers during the same cooldown do NOT
+    // queue further retries.
+    await mac.engine.dbSyncCycle();
+    await mac.engine.dbSyncCycle();
+    expect(timers.pending()).toHaveLength(1);
+
+    // The timer fires at cooldown expiry → the deferred cycle runs and pulls
+    // the peer edit. Single-digit seconds after the 429, not the 5-minute poll.
+    vi.setSystemTime(atOffset(2000 + 5750));
+    await timers.fire(timers.pending()[0]);
+    expect(macTitle(mac, 't1')).toBe('edited on peer');
+    expect(timers.pending()).toHaveLength(0); // completed cycle left nothing armed
+  });
+
+  it('(c) a cycle that completes before the timer fires cancels the pending retry — no extra cycle', async () => {
+    const vault = createMemoryVault();
+    const timers = manualRetryTimers();
+    const { mac, peer } = await seedConverged(vault, timers);
+
+    failNextListWith429(vault);
+    await mac.engine.dbSyncCycle();
+    peer.data = { ...peer.data, tasks: [{ ...peer.data.tasks[0], title: 'edited on peer', lastModified: '2026-07-10T12:00:01.000Z' }] };
+    await peer.engine.dbSyncCycle();
+    await mac.engine.dbSyncCycle(); // gated → arms the retry
+    const handle = timers.pending()[0];
+    expect(handle).toBeDefined();
+
+    // The cooldown expires naturally and something else triggers first — a
+    // foreground flip / manual "Sync now". That cycle completes and serves the
+    // trigger, so it must CANCEL the pending retry rather than leave it to run
+    // an extra cycle.
+    vi.setSystemTime(atOffset(8000));
+    const manual = await mac.engine.dbSyncCycle();
+    expect(manual.throttled).toBeUndefined();
+    expect(macTitle(mac, 't1')).toBe('edited on peer');
+    expect(handle.cleared).toBe(true);
+    expect(timers.pending()).toHaveLength(0);
+  });
+
+  it('(d) + storm: sustained 429s with continuous nudges → one attempted cycle per cooldown window, windows escalate', async () => {
+    const vault = createMemoryVault();
+    const timers = manualRetryTimers();
+    const { mac } = await seedConverged(vault, timers);
+
+    // The vault rate-limits every pull from now on.
+    const realList = vault.list;
+    let listCalls = 0;
+    vault.list = async () => { listCalls += 1; const e = new Error('list failed: 429'); e.status = 429; throw e; };
+
+    let now = 0;
+    const windowDelays = [];
+    await mac.engine.dbSyncCycle(); // strike 1 — cooldown 7500ms
+    for (let window = 0; window < 3; window++) {
+      // Continuous nudges throughout the cooldown: every one is gated and
+      // coalesces into the single pending retry.
+      for (let i = 0; i < 4; i++) {
+        const gated = await mac.engine.dbSyncCycle();
+        expect(gated.throttled).toBe(true);
+      }
+      expect(timers.pending()).toHaveLength(1);
+      const handle = timers.pending()[0];
+      windowDelays.push(handle.ms);
+
+      // The retry fires at expiry, attempts ONE cycle, fails again (429) — and
+      // that failure goes through the normal breaker path: the next cooldown
+      // is longer.
+      now += handle.ms;
+      vi.setSystemTime(atOffset(now));
+      await timers.fire(handle);
+    }
+
+    // Exactly one vault attempt per window (plus the initial strike): the
+    // storm stays damped even under continuous nudges.
+    expect(listCalls).toBe(1 + 3);
+    // Escalation through breaker.onFailure: 7500 → 15000 → 30000 (+250ms pad).
+    expect(windowDelays).toEqual([7750, 15250, 30250]);
+
+    vault.list = realList;
+  });
+
+  it('(b) dispose cancels the pending retry, and a stray already-dequeued firing is a no-op against the dead engine', async () => {
+    const vault = createMemoryVault();
+    const timers = manualRetryTimers();
+    const { mac } = await seedConverged(vault, timers);
+
+    failNextListWith429(vault);
+    await mac.engine.dbSyncCycle();
+    await mac.engine.dbSyncCycle(); // gated → arms the retry
+    const handle = timers.pending()[0];
+    expect(handle).toBeDefined();
+
+    mac.engine.dispose();
+    expect(handle.cleared).toBe(true);
+
+    // Simulate the worst case: the timer callback already left the runtime's
+    // queue before clearTimeout landed. The disposed guard makes it inert.
+    const listSpy = vi.spyOn(vault, 'list');
+    vi.setSystemTime(atOffset(60000));
+    await timers.fire(handle);
+    expect(listSpy.mock.calls.length).toBe(0);
+
+    // And any later direct call is equally inert.
+    const dead = await mac.engine.dbSyncCycle();
+    expect(dead).toBeUndefined();
+    expect(listSpy.mock.calls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the live regression the brakes (#1450) introduced: **an SSE nudge that fired during a breaker cooldown was consumed and dropped** — the gated cycle returned `{throttled}`, the drain wrapper ignores the return value, and the nudge coalescer's seq cursor had already advanced past that nudge. One isolated 429 could cost a peer edit up to five minutes (the poll backstop) instead of single-digit seconds.

The fix, scoped exactly as agreed — **deferred retry only, no half-open probe, no scaffolding for one**:

- The first gated trigger arms **one** one-shot timer for the cooldown's expiry (`armDeferredRetry` in `dbEngine.js`); further gated triggers **coalesce** into it — never a queue *(requirement a)*.
- When it fires it simply calls `dbSyncCycle` again: a cooldown that was extended meanwhile re-arms through the same gate, and a deferred retry that fails goes through the normal `breaker.onFailure` path — **storm damping unchanged**: at most one attempted cycle per cooldown window, windows escalating *(requirement d)*.
- A cycle that **completes** cancels the pending retry — its pull already served whatever the gated trigger was announcing, so a foreground flip or manual sync after natural expiry never causes an extra cycle *(requirement c)*. A thrown cycle deliberately does not cancel (its pull may not have finished; the retry re-arms through the gate anyway).
- New `engine.dispose()` cancels the pending timer and makes every later `dbSyncCycle` call — including a stray timer firing that already left the runtime queue — inert. Wired into the App engine-effect cleanup and the transient `vaultBootstrapSync` engine *(requirement b)*.

Gated returns now carry `retryPending: true`, and the brake log line says a retry is armed.

## Tests

`src/sync/dbSyncDeferredRetry.test.js` — real `@glance-apps/sync` engine + real crypto over the in-memory vault (the #1449 harness), with the **real** breaker under deterministic jitter (`random()=0` → exact 7500/15000/30000ms windows) and injected manual retry timers fired in step with the mocked clock:

- **Headline proof:** 429 → peer edit + nudge during the cooldown → the edit lands on the mac **when the deferred retry fires at cooldown expiry** (5750ms after the gated nudge in the fixture), not at the next poll; repeated gated triggers leave exactly one pending timer.
- **Cancel-on-complete:** a manual/foreground cycle after natural expiry serves the trigger and clears the timer — no extra cycle.
- **Storm still damped:** sustained 429s with continuous nudges → exactly one vault attempt per cooldown window (4 list calls across the initial strike + 3 windows), delays escalating 7750 → 15250 → 30250ms (pad included) — proving the retry path escalates through `onFailure` rather than bypassing it.
- **Dispose:** pending timer cleared; a simulated already-dequeued firing and any later direct call are no-ops with zero vault traffic.

Full suite: **2217 passed, 1 expected fail** (the pre-existing war pin). Lint clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_