### PR TITLE
Successor-aware id-retirement record (retiredTaskIds) — ends the scan-evict ↔ guard-heal war

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { tombstoneCutoff } from './sync/tombstoneRetention.js';
 import { preserveArchived } from './utils/preserveArchived.js';
 import { rescueUnsyncedTasks } from './utils/rescueUnsyncedTasks.js';
+import { readRetiredTaskIds, applyTaskRetirements, RETIRED_TASK_IDS_STORAGE_KEY } from './utils/retiredTaskIds.js';
 import { dropResurrectedTasks } from './utils/dropResurrectedTasks.js';
 import { partitionExpiredSingleDayFrames } from './utils/expiredFrames.js';
 import { stripHealthSourcedLogs } from './utils/healthLogFilter.js';
@@ -5461,6 +5462,10 @@ const DayPlanner = () => {
         deletedRoutineChipIds: JSON.parse(localStorage.getItem('day-planner-deleted-routine-chip-ids') || '{}'),
         deletedFrameIds: JSON.parse(localStorage.getItem('day-planner-deleted-frame-ids') || '{}'),
         deletedObsidianKeys: JSON.parse(localStorage.getItem('day-planner-deleted-obsidian-keys') || '{}'),
+        // Id-retirement record ({oldId → {retiredAt, successor}}) — like the
+        // tombstone maps it has no React state and only changes during sync
+        // or the Obsidian write-commit. See utils/retiredTaskIds.js.
+        retiredTaskIds: readRetiredTaskIds(),
         removedTodayRoutineIds,
         dailyNotes,
         // Per-day START/STOP timeline markers (flat date map + 'defaults',
@@ -5585,8 +5590,26 @@ const DayPlanner = () => {
       !(t.imported && !t.isTaskCalendar && t.importSource !== 'file')
       && !(multiUserEnabled && t.imported && t.importSource === 'sync'));
 
-    const normalizedTasks = data.tasks ? preserveArchived(filterTasks(normalizeTasks(data.tasks)), existingArchivedList) : null;
-    const normalizedUnsched = data.unscheduledTasks ? preserveArchived(filterTasks(normalizeTasks(data.unscheduledTasks)), existingArchivedList) : null;
+    let normalizedTasks = data.tasks ? preserveArchived(filterTasks(normalizeTasks(data.tasks)), existingArchivedList) : null;
+    let normalizedUnsched = data.unscheduledTasks ? preserveArchived(filterTasks(normalizeTasks(data.unscheduledTasks)), existingArchivedList) : null;
+
+    // Id-retirement supersede pass (utils/retiredTaskIds.js): a merged/pulled
+    // row whose id the record maps to a LIVE successor is dropped — with its
+    // content redirected onto the successor when it is the newer edit —
+    // REGARDLESS of timestamps. Retirement is an identity move, not a
+    // deletion: without this, a retired-id copy re-stamped newer than its
+    // tombstone (offline edit crossing a stamp, peer re-stamp) landed here as
+    // a resurrected duplicate and fed the scan-evict ↔ guard-heal war. The
+    // live-id set spans BOTH lists so a cross-list successor still counts as
+    // live; a row with no live successor is left alone (deletion tombstones
+    // still govern it).
+    const retiredRecord = data.retiredTaskIds || readRetiredTaskIds();
+    const retiredLiveIds = new Set([
+      ...(normalizedTasks || tasksLiveRef.current || []),
+      ...(normalizedUnsched || unscheduledLiveRef.current || []),
+    ].filter(Boolean).map(t => String(t.id)));
+    if (normalizedTasks) normalizedTasks = applyTaskRetirements(normalizedTasks, retiredRecord, retiredLiveIds);
+    if (normalizedUnsched) normalizedUnsched = applyTaskRetirements(normalizedUnsched, retiredRecord, retiredLiveIds);
 
     // Update localStorage
     if (normalizedTasks) localStorage.setItem('day-planner-tasks', JSON.stringify(normalizedTasks));
@@ -5649,6 +5672,7 @@ const DayPlanner = () => {
     if (data.deletedRoutineChipIds) localStorage.setItem('day-planner-deleted-routine-chip-ids', JSON.stringify(data.deletedRoutineChipIds));
     if (data.deletedFrameIds) localStorage.setItem('day-planner-deleted-frame-ids', JSON.stringify(data.deletedFrameIds));
     if (data.deletedObsidianKeys) localStorage.setItem('day-planner-deleted-obsidian-keys', JSON.stringify(data.deletedObsidianKeys));
+    if (data.retiredTaskIds) localStorage.setItem(RETIRED_TASK_IDS_STORAGE_KEY, JSON.stringify(data.retiredTaskIds));
     if (data.removedTodayRoutineIds) {
       localStorage.setItem('day-planner-removed-today-routine-ids', JSON.stringify(data.removedTodayRoutineIds));
       setRemovedTodayRoutineIds(data.removedTodayRoutineIds);
@@ -5805,8 +5829,18 @@ const DayPlanner = () => {
     // genuinely vault-deleted one must stay gone — honor its deletedObsidianKeys
     // tombstone. See utils/rescueUnsyncedTasks.js (the ala7ur flicker fix).
     const rescueObsidianTombstones = data.deletedObsidianKeys || {};
-    if (normalizedTasks) setTasks(prev => rescueUnsyncedTasks(preserveArchived(normalizedTasks, prev), prev, rescueDeletedIds, undefined, rescueObsidianTombstones));
-    if (normalizedUnsched) setUnscheduledTasks(prev => rescueUnsyncedTasks(preserveArchived(normalizedUnsched, prev), prev, rescueDeletedIds, undefined, rescueObsidianTombstones));
+    // The retirement pass runs AGAIN on the rescue output: rescue can re-add a
+    // prev-only copy of a retired id (this device's own offline edit under the
+    // old id). Same rule as above — dropped when its successor is live, with
+    // the newer content redirected onto the successor first — so the edit
+    // reaches the vault via the successor's normal writeback instead of
+    // resurrecting the retired row.
+    if (normalizedTasks) setTasks(prev => applyTaskRetirements(
+      rescueUnsyncedTasks(preserveArchived(normalizedTasks, prev), prev, rescueDeletedIds, undefined, rescueObsidianTombstones),
+      retiredRecord, retiredLiveIds));
+    if (normalizedUnsched) setUnscheduledTasks(prev => applyTaskRetirements(
+      rescueUnsyncedTasks(preserveArchived(normalizedUnsched, prev), prev, rescueDeletedIds, undefined, rescueObsidianTombstones),
+      retiredRecord, retiredLiveIds));
     if (data.unscheduledOrderTimestamp) {
       setUnscheduledOrderTimestamp(data.unscheduledOrderTimestamp);
       localStorage.setItem('day-planner-unscheduled-order-ts', data.unscheduledOrderTimestamp);

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -19,6 +19,12 @@ import { classifyVaultPaths } from '../utils/vaultPortability.js';
 import { mergeObsidianDailyNotes } from '../utils/mergeObsidianDailyNotes.js';
 import { mergeObsidianTasks } from '../utils/mergeObsidianTasks.js';
 import { detectObsidianDeletions, addObsidianTombstones } from '../utils/obsidianDeletions.js';
+import {
+  readRetiredTaskIds,
+  recordRetirements as recordRetirementEntries,
+  RETIRED_TASK_IDS_STORAGE_KEY,
+  RETIRED_ID_DUAL_WRITE,
+} from '../utils/retiredTaskIds.js';
 
 /**
  * Obsidian vault sync — extracted from App.jsx (see "App.jsx — Ongoing
@@ -264,6 +270,13 @@ export default function useObsidianSync({
       const obsidianCutoff = obsidianWindowCutoffDate(OBSIDIAN_IMPORT_WINDOW_DAYS);
       const { deletions, skipped } = detectObsidianDeletions(lastScanned, scannedKeys, obsidianCutoff, { keyDates: lastScannedDates });
       if (deletions.length) {
+        // PROVENANCE (see utils/retiredTaskIds.js): THIS site is the
+        // detector-observed vanish. It saw a key disappear and knows NEITHER
+        // user intent NOR a successor (an untagged line retitled in the vault
+        // is indistinguishable from delete+create by construction), so it
+        // writes deletedObsidianKeys — the conservative, LWW-revivable
+        // channel — and never retiredTaskIds (commit-that-renames) or
+        // deletedTaskIds (user-pressed delete).
         tombstones = addObsidianTombstones(tombstones, deletions, new Date().toISOString());
         localStorage.setItem('day-planner-deleted-obsidian-keys', JSON.stringify(tombstones));
       }
@@ -481,26 +494,41 @@ export default function useObsidianSync({
       if (snap[fromId]) { snap[newId] = snap[fromId]; delete snap[fromId]; }
     };
 
-    // The transition KNOWS a retired id no longer names anything — it did the
-    // renaming. Record explicit deletedTaskIds tombstones for every id the
-    // confirmed write retires, so the file-tier union merge (which consults
-    // ONLY deletedTaskIds — see the "deletedObsidianKeys never reaches the
-    // file-tier task merge" issue) stops resurrecting retired rows from the
-    // remote file onto every device, vaultless ones included. The deletion
-    // DETECTOR still never infers a deletion from a rename (the scanned-keys
-    // hints see to that): this is the transition asserting a fact it holds,
-    // not the detector guessing from a short scan. LWW protects an offline
-    // device's newer edit under a retired id — its copy outlives the
-    // tombstone and re-bridges on that device's next scan. Entries prune at
-    // the shared 60-day retention (sync/tombstoneRetention.js).
-    const recordRetiredIdTombstones = (ids) => {
+    // PROVENANCE (see utils/retiredTaskIds.js — three channels, three actors,
+    // no write site ever has two valid choices): THIS site is the
+    // commit-that-renames. It KNOWS the successor at write time — it did the
+    // renaming — so retirements are recorded in `retiredTaskIds` as
+    // { oldId → { retiredAt, successor } }, which the guard, the apply path,
+    // and the file-tier merge treat as an identity move: superseded regardless
+    // of timestamps, with a newer edit on the retired id redirected onto the
+    // successor. (User-pressed deletes belong to deletedTaskIds — useTaskActions
+    // / useRecycleBin; detector-observed vanishes to deletedObsidianKeys — the
+    // scan block above. Neither knows a successor; this site never writes
+    // theirs except the shim below.) The deletion DETECTOR still never infers
+    // a deletion from a rename (the scanned-keys hints see to that): this is
+    // the commit asserting a fact it holds. Entries prune at the shared 60-day
+    // retention (sync/tombstoneRetention.js).
+    //
+    // RETIRED_ID_DUAL_WRITE (legacy-fleet shim — sunset condition documented
+    // at the flag in utils/retiredTaskIds.js): the v4.7.x fleet's file-tier
+    // merge consults ONLY deletedTaskIds, so retired ids are ALSO written
+    // there as plain tombstones; without it, stale legacy rows resurrect on
+    // un-upgraded devices. New clients act on the record and merely tolerate
+    // the tombstone.
+    const recordRetirements = (ids, successorId) => {
       if (!ids.length) return;
+      const nowIso = new Date().toISOString();
       try {
-        const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}');
-        const nowIso = new Date().toISOString();
-        for (const id of ids) tombstones[String(id)] = nowIso;
-        localStorage.setItem('day-planner-deleted-task-ids', JSON.stringify(tombstones));
+        const record = recordRetirementEntries(readRetiredTaskIds(), ids, successorId, nowIso);
+        localStorage.setItem(RETIRED_TASK_IDS_STORAGE_KEY, JSON.stringify(record));
       } catch { /* storage unavailable — scanned-keys hints still keep local state coherent */ }
+      if (RETIRED_ID_DUAL_WRITE) {
+        try {
+          const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}');
+          for (const id of ids) tombstones[String(id)] = nowIso;
+          localStorage.setItem('day-planner-deleted-task-ids', JSON.stringify(tombstones));
+        } catch { /* ditto */ }
+      }
     };
 
     for (const task of allObsidian) {
@@ -566,7 +594,10 @@ export default function useObsidianSync({
         if (titleUpdate) applyTitleUpdate(titleUpdate);
         if (assignBlockId) applyBlockIdAssignment(postTitleId, assignBlockId);
         const finalId = assignBlockId ? appIdForBlockId(assignBlockId) : postTitleId;
-        recordRetiredIdTombstones([...new Set([task.id, postTitleId])].filter(id => id !== finalId));
+        // Every retired id in the rename chain maps DIRECTLY to the final id —
+        // chains are collapsed at write time, so the record never needs a
+        // stale L→M hop resolved later (resolveRetirement handles one anyway).
+        recordRetirements([...new Set([task.id, postTitleId])].filter(id => id !== finalId), finalId);
       };
 
       if (isNative) {

--- a/src/hooks/useRecycleBin.js
+++ b/src/hooks/useRecycleBin.js
@@ -39,7 +39,10 @@ export default function useRecycleBin({
 
   const confirmEmptyBin = () => {
     pushUndo();
-    // Record tombstones for permanently deleted tasks (prevents resurrection during merge sync)
+    // Record tombstones for permanently deleted tasks (prevents resurrection during merge sync).
+    // PROVENANCE (see utils/retiredTaskIds.js): user-pressed delete — intent
+    // known, no successor — so deletedTaskIds, never retiredTaskIds (the
+    // commit-that-renames' channel) or deletedObsidianKeys (the detector's).
     const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}');
     const now = new Date().toISOString();
     recycleBin.forEach(t => { tombstones[String(t.id)] = now; });

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -34,6 +34,11 @@ const minutesToTime = (minutes) => {
   return `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}`;
 };
 
+// PROVENANCE (see utils/retiredTaskIds.js): THIS site is the user-pressed
+// delete. It knows INTENT — the user removed the task and there is no
+// successor — so it writes deletedTaskIds, never retiredTaskIds (that channel
+// belongs to the commit-that-renames, which knows a successor) and never
+// deletedObsidianKeys (the vault-scan detector's observed-vanish channel).
 const recordDeletedTaskTombstone = (taskId) => {
   const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}');
   tombstones[String(taskId)] = new Date().toISOString();

--- a/src/mergeSync.canary.test.js
+++ b/src/mergeSync.canary.test.js
@@ -84,6 +84,9 @@ const REPRESENTATIVE = {
   deletedRoutineChipIds: { gonechip: ISO },
   deletedFrameIds: { goneframe: ISO },
   deletedObsidianKeys: { '2026-07-01': ISO },
+  // Id-retirement record (utils/retiredTaskIds.js) — its own wrapper block in
+  // mergeSync.js (union+LWW on retiredAt, pruned at the fixed window).
+  retiredTaskIds: { 'obsidian-2026-08-01-abc': { retiredAt: ISO, successor: 'obsidian-dg-k3x9q2mf' } },
   removedTodayRoutineIds: { removedchip: ISO },
   dailyNotes: { '2026-08-01': 'a note' },
   dayWindows: { defaults: { start: '08:00', stop: '22:00', lastModified: ISO } },

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -9,6 +9,7 @@ import {
   pruneTombstoneMap,
   unionNewerIso as unionTombstones,
 } from './sync/tombstoneRetention.js';
+import { mergeRetiredTaskIds, pruneRetiredTaskIds, applyRetirementsToTaskLists } from './utils/retiredTaskIds.js';
 import { mergeDayWindowMaps, dayWindowMapsEqual, migrateDayWindows } from './sync/dayWindowSync.js';
 
 export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =>
@@ -461,6 +462,38 @@ export const mergeSyncData = (local, remote, retentionDays) => {
     // 60-day set differs from a side, that side needs the corrected bundle written.
     if (!tombstoneMapsEqual(merged, local?.[key] || {})) result.localChanged = true;
     if (!tombstoneMapsEqual(merged, remote?.[key] || {})) result.remoteChanged = true;
+  }
+
+  // Id-retirement record ({oldId → {retiredAt, successor}} — see
+  // utils/retiredTaskIds.js): union with per-key LWW on retiredAt, pruned at
+  // the SAME fixed window as the deletion bundles so the two transports stay
+  // in lockstep. Its object values can't ride unionTombstones/pruneTombstoneMap.
+  const retiredEntryEq = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+  const retiredMapsEqual = (a = {}, b = {}) => {
+    const ka = Object.keys(a); const kb = Object.keys(b);
+    return ka.length === kb.length && ka.every((k) => retiredEntryEq(a[k], b[k]));
+  };
+  const retiredMerged = pruneRetiredTaskIds(
+    mergeRetiredTaskIds(local?.retiredTaskIds || {}, remote?.retiredTaskIds || {}), tsCutoff,
+  );
+  result.data.retiredTaskIds = retiredMerged;
+  if (!retiredMapsEqual(retiredMerged, local?.retiredTaskIds || {})) result.localChanged = true;
+  if (!retiredMapsEqual(retiredMerged, remote?.retiredTaskIds || {})) result.remoteChanged = true;
+
+  // Supersede retired ids in the merged task lists: a row whose id the record
+  // maps to a LIVE successor is dropped (its newer content, if any, redirected
+  // onto the successor) REGARDLESS of timestamps — retirement is an identity
+  // move, not a deletion, so the LWW that lets a genuinely deleted task revive
+  // must not resurrect a retired id. This also keeps retired rows out of the
+  // uploaded sync file, so the v4.7.x fleet stops re-ingesting them.
+  const retApplied = applyRetirementsToTaskLists(
+    { tasks: result.data.tasks, unscheduledTasks: result.data.unscheduledTasks }, retiredMerged,
+  );
+  if (retApplied.tasks !== result.data.tasks || retApplied.unscheduledTasks !== result.data.unscheduledTasks) {
+    result.data.tasks = retApplied.tasks;
+    result.data.unscheduledTasks = retApplied.unscheduledTasks;
+    result.localChanged = true;
+    result.remoteChanged = true;
   }
 
   // Override the upstream resurrection fence (which was max(localFence, remoteFence)

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -28,6 +28,7 @@
 
 import { mergeHabitLogs, mergeRoutineDefinitions, mergeRoutineCompletions, mergeCompletedDates } from '../mergeSync.js';
 import { TOMBSTONE_BUNDLE_KEYS, tombstoneCutoff } from './tombstoneRetention.js';
+import { mergeRetiredTaskIds } from '../utils/retiredTaskIds.js';
 import { mergeDayWindowMaps } from './dayWindowSync.js';
 
 // ── Collection kinds: each array element is one row, keyed by a stable id, with
@@ -421,6 +422,14 @@ function mergeBundle(data, key, value, extra) {
     return;
   }
   switch (key) {
+    case 'retiredTaskIds':
+      // Id-retirement record ({oldId → {retiredAt, successor}}): union with
+      // per-key LWW on retiredAt (deterministic tie-break) — its object values
+      // can't ride the flat unionNewerIso the deletion bundles use. Retention
+      // pruning happens on the mirror alongside the other tombstone bundles
+      // (tombstoneRetention.pruneAllTombstones). See utils/retiredTaskIds.js.
+      data.retiredTaskIds = mergeRetiredTaskIds(data.retiredTaskIds || {}, value || {});
+      return;
     case 'habitLogs': {
       // per-(date,habitId) recency merge; timestamps ride in _extra so the merge
       // is self-contained and order-independent.

--- a/src/sync/phase2TransitionSyncLoop.test.js
+++ b/src/sync/phase2TransitionSyncLoop.test.js
@@ -5,6 +5,7 @@ import { setVaultConfig } from './vaultConfig.js';
 import { partitionSnapshotDeletes, STALE_TOMBSTONE_EPSILON_MS } from './snapshotDeleteGuard.js';
 import { dropResurrectedTasks } from '../utils/dropResurrectedTasks.js';
 import { mergeObsidianTasks } from '../utils/mergeObsidianTasks.js';
+import { applyRetirementsToTaskLists } from '../utils/retiredTaskIds.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PHASE 2 TRANSITION × DB-TIER SYNC LOOP — deterministic reproduction.
@@ -43,6 +44,15 @@ import { mergeObsidianTasks } from '../utils/mergeObsidianTasks.js';
 //         that loop. (Contrast test: a legacy row whose tombstone stayed newest
 //         propagates its delete cleanly and converges. The peer re-stamp is the
 //         whole difference.)
+//     ── FIXED by the id-retirement record (utils/retiredTaskIds.js): the
+//     commit that renames an id records { oldId → {retiredAt, successor} };
+//     the guard classifies a vanish with a LIVE successor 'retired' and
+//     propagates it REGARDLESS of timestamps, and the apply path supersedes
+//     retired rows — redirecting a NEWER copy's content onto the successor —
+//     so nothing is left for the heal to restore. The war section below now
+//     pins the fixed behavior; the seed section keeps the pre-record baseline
+//     ('stale-tombstone' skip) as the deliberate no-record / no-live-successor
+//     fallback.
 //
 //  3. THE STORM — when a heal row-get fails (429), the cycle withholds its
 //     snapshot (dbEngine.js: unresolved glitch-skips poison the baseline). A
@@ -57,9 +67,8 @@ import { mergeObsidianTasks } from '../utils/mergeObsidianTasks.js';
 //     acked-hash push dedup in dbEngine.js); the storm section below now pins
 //     the fixed behavior.
 //
-// Tests asserting correct-but-not-yet-implemented behavior are marked it.fails
-// — they document the remaining bug (the war, parts 1–2) deterministically
-// while keeping CI green; the eventual fix flips them to plain it.
+// Both halves are now fixed; every section pins its fixed behavior, plus the
+// deliberate conservative fallbacks (no record / successor not live).
 // ─────────────────────────────────────────────────────────────────────────────
 
 function memLocalStorage() {
@@ -150,10 +159,12 @@ const obsidianTask = (id, lastModified, extra = {}) => ({
 });
 
 // A device wired like the app: getData mirrors buildSyncPayload (its
-// dropResurrectedTasks pass included), commitData mirrors applyEngineData
-// (replace semantics, NO deletedTaskIds filter on the merged list — the real
-// apply only consults tombstones for prev-only rescue rows, never for rows the
-// mirror itself carries).
+// dropResurrectedTasks pass included), commitData mirrors applyEngineData —
+// replace semantics, NO deletedTaskIds filter on the merged list (the real
+// apply only consults tombstones for prev-only rescue rows), plus the
+// id-retirement supersede pass (applyRetirementsToTaskLists) the real apply
+// now runs: a pulled row whose id maps to a live successor is dropped, with
+// its newer content redirected onto the successor.
 function makeDevice(name, vault, initial, engineOverrides = {}) {
   let data = clone(initial);
   let nativeKey = null;
@@ -170,7 +181,12 @@ function makeDevice(name, vault, initial, engineOverrides = {}) {
       d.unscheduledTasks = dropResurrectedTasks(d.unscheduledTasks, d.deletedTaskIds);
       return d;
     },
-    commitData: (d) => { data = d; },
+    commitData: (d) => {
+      const applied = applyRetirementsToTaskLists(
+        { tasks: d.tasks, unscheduledTasks: d.unscheduledTasks }, d.retiredTaskIds || {},
+      );
+      data = { ...d, tasks: applied.tasks, unscheduledTasks: applied.unscheduledTasks };
+    },
   });
   return {
     engine,
@@ -196,30 +212,86 @@ function runVaultScan(device) {
 const taskIds = (device) => device.data.tasks.map((t) => t.id).sort();
 
 // Shared setup: replay the mixed-version session, then power the peer off.
-//   mac cycle 1  — pushes D + the tombstone bundle (deletedTaskIds[L]=T_TOMB).
-//   peer cycle 1 — pulls, then pushes its re-stamped L (T_PEER) and stale L2 (T_OLD).
-//   mac cycle 2  — pulls both: the duplicates land in Mac state (the phone
-//                  symptom, reproduced on the Mac).
+//   mac cycle 1  — pushes D, the retirement record (L→D, L2→D, both dual-
+//                  written into deletedTaskIds by the commit's legacy-fleet
+//                  shim), and a plain non-obsidian task G (glitch fodder for
+//                  the storm tests).
+//   peer cycle 1 — pulls, then pushes its re-stamped L (T_PEER, retitled
+//                  offline) and stale L2 (T_OLD).
+//   mac cycle 2  — pulls both. Under the retirement record the duplicates NO
+//                  LONGER land: L2 (older than D) is plainly superseded, and
+//                  L — the NEWER offline edit — is REDIRECTED: its content
+//                  moves onto D, its row never enters state.
 async function seedMixedSession(vault, macOverrides = {}) {
   const mac = makeDevice('mac', vault, {
     ...EMPTY,
-    tasks: [obsidianTask(DG_ID, T_EDIT, { obsidianBlockId: 'k3x9q2mf' })],
+    tasks: [
+      obsidianTask(DG_ID, T_EDIT, { obsidianBlockId: 'k3x9q2mf' }),
+      { id: 'g1', title: 'plain task', duration: 30, color: 'bg-blue-500', completed: false, notes: '', subtasks: [], lastModified: T_EDIT },
+    ],
     deletedTaskIds: { [L_ID]: T_TOMB, [L2_ID]: T_TOMB },
+    retiredTaskIds: {
+      [L_ID]: { retiredAt: T_TOMB, successor: DG_ID },
+      [L2_ID]: { retiredAt: T_TOMB, successor: DG_ID },
+    },
   }, macOverrides);
   const peer = makeDevice('peer', vault, {
     ...EMPTY,
-    tasks: [obsidianTask(L_ID, T_PEER), obsidianTask(L2_ID, T_OLD)],
+    tasks: [
+      obsidianTask(L_ID, T_PEER, { title: 'Buy oat milk #obsidian' }),
+      obsidianTask(L2_ID, T_OLD),
+    ],
   });
   await mac.engine.dbSyncCycle();
   await peer.engine.dbSyncCycle();
   await mac.engine.dbSyncCycle();
-  // The mixed-session damage is now in place on the Mac:
-  expect(taskIds(mac)).toContain(L_ID);
+  // The retirement record resolved the mixed-session damage at apply time:
+  // neither retired id entered state, and the peer's newer offline edit was
+  // redirected onto the successor (content + recency, identity kept).
+  expect(taskIds(mac)).not.toContain(L_ID);
+  expect(taskIds(mac)).not.toContain(L2_ID);
+  const dg = mac.data.tasks.find((t) => t.id === DG_ID);
+  expect(dg.title).toBe('Buy oat milk #obsidian');
+  expect(dg.lastModified).toBe(T_PEER);
+  expect(dg.obsidianBlockId).toBe('k3x9q2mf');
   return mac;
 }
 
 describe('the seed — guard classification of a peer-re-stamped retired id', () => {
-  it("a retired id whose vault copy outlived its tombstone is 'stale-tombstone' (skipped + healed), and the aged-out release valve does not cover it", () => {
+  it("with a retirement record and a LIVE successor, the vanish is 'retired' — propagated REGARDLESS of the copy being newer than its tombstone (the war killer)", () => {
+    const snapshotEntity = { _kind: 'tasks', value: obsidianTask(L_ID, T_PEER) };
+    const { propagate, skipped, reasons } = partitionSnapshotDeletes(
+      [`tasks:${L_ID}`],
+      { [`tasks:${DG_ID}`]: 'hash' }, // the successor is live in the current shred
+      {
+        deletedTaskIds: { [L_ID]: T_TOMB },
+        retiredTaskIds: { [L_ID]: { retiredAt: T_TOMB, successor: DG_ID } },
+      },
+      () => snapshotEntity,
+    );
+    expect(propagate).toEqual([`tasks:${L_ID}`]);
+    expect(skipped).toEqual([]);
+    expect(reasons[`tasks:${L_ID}`]).toBe('retired');
+    // The exemption is doing real work: the copy IS newer than its tombstone.
+    expect(new Date(T_PEER).getTime() - new Date(T_TOMB).getTime()).toBeGreaterThan(STALE_TOMBSTONE_EPSILON_MS);
+  });
+
+  it("with a retirement record but NO live successor, the record authorizes nothing — conservative fall-through to 'stale-tombstone'", () => {
+    const snapshotEntity = { _kind: 'tasks', value: obsidianTask(L_ID, T_PEER) };
+    const { skipped, reasons } = partitionSnapshotDeletes(
+      [`tasks:${L_ID}`],
+      {}, // successor not present on this device (record arrived before the row)
+      {
+        deletedTaskIds: { [L_ID]: T_TOMB },
+        retiredTaskIds: { [L_ID]: { retiredAt: T_TOMB, successor: DG_ID } },
+      },
+      () => snapshotEntity,
+    );
+    expect(skipped).toEqual([`tasks:${L_ID}`]);
+    expect(reasons[`tasks:${L_ID}`]).toBe('stale-tombstone');
+  });
+
+  it("without a record, a retired id whose vault copy outlived its tombstone is 'stale-tombstone' (skipped + healed) — the pre-record baseline, and the release valve does not cover it", () => {
     const snapshotEntity = { _kind: 'tasks', value: obsidianTask(L_ID, T_PEER) };
     const { skipped, reasons } = partitionSnapshotDeletes(
       [`tasks:${L_ID}`],
@@ -248,63 +320,56 @@ describe('the seed — guard classification of a peer-re-stamped retired id', ()
   });
 });
 
-describe('the war — scan eviction vs stale-tombstone heal (peers powered off)', () => {
-  it('contrast: the tombstoned-and-older duplicate (L2) converges — delete propagates to the vault and it stays gone', async () => {
+describe('the war — RESOLVED: the retirement record supersedes retired ids instead of healing them back', () => {
+  // Formerly pinned here as it.fails: the scan evicted L every round while the
+  // guard classified its vanish 'stale-tombstone' (the peer's re-stamp was
+  // newer than the tombstone) and heal-fetched it straight back — appear/
+  // disappear forever, one row-get per round, the vault row never deleted.
+  // With the retirement record (utils/retiredTaskIds.js) the guard classifies
+  // the vanish 'retired' (successor live → propagate REGARDLESS of
+  // timestamps), the apply path never lets the retired row re-enter state,
+  // and the newer offline edit is redirected onto the successor.
+
+  it('retired ids converge: deletes propagate (reason: retired) with zero heal traffic, and scan rounds change nothing', async () => {
     const vault = createMemoryVault();
     const mac = await seedMixedSession(vault);
-    // L2 landed in state from the pull, but getData's dropResurrectedTasks hides
-    // it from the payload, so the next cycle diffs it as a delete — and with the
-    // tombstone newest, the guard PROPAGATES it. One more cycle commits the
-    // mirror (which lacks L2) back over state. Converged; no heal traffic.
     const getRowSpy = vi.spyOn(vault, 'getRow');
+    // The seed's pull cycle left L/L2 in the SNAPSHOT (they were applied to
+    // the mirror) but not in state/payload — this cycle diffs them as deletes,
+    // and the record propagates them despite L being newer than its tombstone.
     await mac.engine.dbSyncCycle();
-    await mac.engine.dbSyncCycle();
+    expect(vault._row(`tasks:${L_ID}`).deleted).toBe(true);
     expect(vault._row(`tasks:${L2_ID}`).deleted).toBe(true);
-    expect(taskIds(mac)).not.toContain(L2_ID);
-    expect(getRowSpy.mock.calls.filter((c) => c[1] === `tasks:${L2_ID}`).length).toBe(0);
-  });
+    expect(getRowSpy.mock.calls.filter((c) => c[1] === `tasks:${L_ID}` || c[1] === `tasks:${L2_ID}`).length).toBe(0);
 
-  // What SHOULD happen after the scan evicts the re-stamped duplicate: the
-  // system converges — L stays out of state (or at minimum stops consuming a
-  // vault row-get per scan, forever). What ACTUALLY happens: every scan
-  // eviction is undone by the guard's heal within one cycle, the vault row is
-  // never deleted, and each round costs a fresh row-get. it.fails pins the loop.
-  it.fails('a scan-evicted stale-tombstone duplicate stays evicted (no per-round heal traffic)', async () => {
-    const vault = createMemoryVault();
-    const mac = await seedMixedSession(vault);
-    await mac.engine.dbSyncCycle(); // settle L2's clean delete so only L is in play
-
-    const getRowSpy = vi.spyOn(vault, 'getRow');
+    // Scan rounds are now no-ops: nothing to evict, nothing comes back.
     for (let round = 0; round < 3; round++) {
       runVaultScan(mac);
-      expect(taskIds(mac)).not.toContain(L_ID); // scan evicted it…
       await mac.engine.dbSyncCycle();
-      await mac.engine.dbSyncCycle();
+      expect(taskIds(mac)).not.toContain(L_ID);
     }
-    // CORRECT behavior (currently false): the eviction sticks…
-    expect(taskIds(mac)).not.toContain(L_ID);
-    // …and the war costs no per-round vault row-gets. Currently every round
-    // heal-fetches tasks:L right back (3 rounds → 3 fetches → 3 reappearances).
     expect(getRowSpy.mock.calls.filter((c) => c[1] === `tasks:${L_ID}`).length).toBe(0);
   });
 
-  it('pins the broken shape: every round the heal re-fetches L, re-commits it into state, and the vault row stays live', async () => {
+  it('the (d) cost check: the newer offline edit under the retired id survives — it reaches the whole fleet on the successor', async () => {
     const vault = createMemoryVault();
-    const mac = await seedMixedSession(vault);
-    await mac.engine.dbSyncCycle();
+    const mac = await seedMixedSession(vault); // seed already asserts the redirect landed in mac state
+    await mac.engine.dbSyncCycle();            // pushes the redirected successor + the retired-id deletes
 
-    const getRowSpy = vi.spyOn(vault, 'getRow');
-    for (let round = 1; round <= 3; round++) {
-      runVaultScan(mac);
-      expect(taskIds(mac)).not.toContain(L_ID); // disappears…
-      await mac.engine.dbSyncCycle();
-      expect(taskIds(mac)).toContain(L_ID);     // …reappears, same round
-      expect(getRowSpy.mock.calls.filter((c) => c[1] === `tasks:${L_ID}`).length).toBe(round);
-    }
-    expect(vault._row(`tasks:${L_ID}`).deleted).toBe(false); // never deleted
+    // A fresh device pulling the vault sees exactly one task carrying the
+    // peer's offline retitle with its recency — no duplicate, no lost edit.
+    const checker = makeDevice('checker', vault, EMPTY);
+    await checker.engine.dbSyncCycle();
+    const ids = checker.data.tasks.map((t) => t.id);
+    expect(ids).toContain(DG_ID);
+    expect(ids).not.toContain(L_ID);
+    expect(ids).not.toContain(L2_ID);
+    const d = checker.data.tasks.find((t) => t.id === DG_ID);
+    expect(d.title).toBe('Buy oat milk #obsidian');
+    expect(d.lastModified).toBe(T_PEER);
   });
 
-  it('pins restart survival: a fresh engine over the same persisted state resumes the war immediately', async () => {
+  it('restart: a fresh engine over the same persisted state converges instead of resuming the war', async () => {
     const vault = createMemoryVault();
     const mac = await seedMixedSession(vault);
     await mac.engine.dbSyncCycle();
@@ -315,8 +380,8 @@ describe('the war — scan eviction vs stale-tombstone heal (peers powered off)'
     const reopened = makeDevice('mac', vault, mac.data);
     const getRowSpy = vi.spyOn(vault, 'getRow');
     await reopened.engine.dbSyncCycle();
-    expect(taskIds(reopened)).toContain(L_ID); // healed straight back, no user action
-    expect(getRowSpy.mock.calls.filter((c) => c[1] === `tasks:${L_ID}`).length).toBe(1);
+    expect(taskIds(reopened)).not.toContain(L_ID); // nothing healed back
+    expect(getRowSpy.mock.calls.filter((c) => c[1] === `tasks:${L_ID}`).length).toBe(0);
   });
 });
 
@@ -341,16 +406,19 @@ describe('the storm — FIXED: brakes on the withheld-snapshot re-push loop (syn
     const vault = createMemoryVault();
     const noBreaker = { beforeCycle: () => ({ allowed: true }), onSuccess() {}, onFailure() { return 0; } };
     const mac = await seedMixedSession(vault, { cycleBreaker: noBreaker });
-    await mac.engine.dbSyncCycle();
-    runVaultScan(mac); // L evicted → next cycle wants the delete → skip → heal
+    await mac.engine.dbSyncCycle(); // retirement deletes settle
 
-    // The vault is now rate-limiting row-gets (what the storm looks like server-side).
+    // Manufacture the withheld snapshot: the plain task g1 VANISHES from state
+    // with no tombstone and no retirement (a local-state glitch — the retired
+    // ids no longer skip, so the glitch class is the storm's remaining fuel)
+    // while the vault rate-limits row-gets, so the heal can't resolve it.
+    mac.data = { ...mac.data, tasks: mac.data.tasks.filter((t) => t.id !== 'g1') };
     vault.getRow = async () => { const e = new Error('get row failed: 429'); e.status = 429; throw e; };
 
     // A single ordinary user edit, made once.
     mac.data = {
       ...mac.data,
-      tasks: mac.data.tasks.map((t) => (t.id === DG_ID ? { ...t, title: 'Buy oat milk #obsidian', lastModified: '2026-07-10T11:59:00.000Z' } : t)),
+      tasks: mac.data.tasks.map((t) => (t.id === DG_ID ? { ...t, title: 'Buy soy milk #obsidian', lastModified: '2026-07-10T11:59:00.000Z' } : t)),
     };
 
     const batchSpy = vi.spyOn(vault, 'batch');
@@ -370,7 +438,9 @@ describe('the storm — FIXED: brakes on the withheld-snapshot re-push loop (syn
     const vault = createMemoryVault();
     const mac = await seedMixedSession(vault); // default (real) breaker
     await mac.engine.dbSyncCycle();
-    runVaultScan(mac);
+    // Same glitch fixture as above: an untombstoned, unretired vanish keeps
+    // the heal in play now that retired ids propagate instead of skipping.
+    mac.data = { ...mac.data, tasks: mac.data.tasks.filter((t) => t.id !== 'g1') };
     vault.getRow = async () => { const e = new Error('get row failed: 429'); e.status = 429; throw e; };
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/src/sync/snapshotDeleteGuard.js
+++ b/src/sync/snapshotDeleteGuard.js
@@ -57,6 +57,7 @@
 
 import { TOMBSTONE_BUNDLE_KEYS } from './tombstoneRetention.js';
 import { getEntityLastModified } from './dbAdapter.js';
+import { resolveRetirement } from '../utils/retiredTaskIds.js';
 
 // Tolerance for the tombstone-vs-lastModified comparison. Delete-path audit
 // (2026-07): every tombstone writer stamps `new Date().toISOString()` at delete
@@ -145,7 +146,9 @@ export function partitionSnapshotDeletes(deleteEntityIds, cur, mirror, getDelete
   const propagate = [];
   const skipped = [];
   const excluded = [];
-  // Why each entityId landed where it did — 'tombstoned' (a real deletion), a
+  // Why each entityId landed where it did — 'retired' (an id-migration
+  // retirement whose successor is live: superseded, propagate regardless of
+  // timestamps), 'tombstoned' (a real deletion), a
   // cross-list move ('cross-list', the id survives under another kind), a
   // suspected 'glitch' (skipped, no fingerprint at all), 'stale-tombstone'
   // (skipped: tombstoned, but the deleted copy is clearly newer than the
@@ -165,9 +168,33 @@ export function partitionSnapshotDeletes(deleteEntityIds, cur, mirror, getDelete
     if (r === true) return 'payload-excluded';
     return typeof r === 'string' && r ? r : null;
   };
+  // Id-retirement record (utils/retiredTaskIds.js): { oldId → {retiredAt,
+  // successor} }. Rides the mirror like the tombstone bundles.
+  const retiredRecord = m.retiredTaskIds && typeof m.retiredTaskIds === 'object' ? m.retiredTaskIds : {};
+
   for (const eid of ids) {
     const id = bareId(eid);
     let rr;
+    // RETIREMENT, decided BEFORE the tombstone timestamp rule: a vanished id
+    // whose record names a successor that is LIVE in the current payload is
+    // SUPERSEDED — the same task's identity moved, the content survives under
+    // the successor — so its delete propagates REGARDLESS of timestamps. This
+    // is deliberately exempt from the stale-tombstone LWW: a copy re-stamped
+    // newer than the retirement (an offline edit crossing a stamp, a peer's
+    // normalization re-stamp) is an edit belonging to the successor (the apply
+    // path redirects its content there — applyTaskRetirements), never a
+    // revival of the old id. Without this exemption the guard classified such
+    // rows 'stale-tombstone' and heal-fetched them back forever — the
+    // scan-evict ↔ guard-heal war (phase2TransitionSyncLoop repro). When the
+    // successor is NOT live in `cur`, the record does not authorize anything
+    // and the row falls through to the ordinary classification below —
+    // conservative: never bless a delete whose surviving copy this device
+    // can't see.
+    const successor = resolveRetirement(retiredRecord, id);
+    if (successor && successor !== id && liveBareIds.has(successor)) {
+      propagate.push(eid); reasons[eid] = 'retired';
+      continue;
+    }
     if (tombstoned.has(id)) {
       const tombTs = tombstoned.get(id);
       const lastMod = deletedLastModified(eid);

--- a/src/sync/tombstoneRetention.js
+++ b/src/sync/tombstoneRetention.js
@@ -25,6 +25,7 @@
 // for weeks; keeping them longer only grows the payload with no benefit.
 
 import { floorToUtcDayIso } from '../utils/tombstoneHorizon.js';
+import { pruneRetiredTaskIds } from '../utils/retiredTaskIds.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -115,6 +116,17 @@ export function pruneAllTombstones(data, cutoff = tombstoneCutoff()) {
     const pruned = pruneTombstoneMap(map, cutoff);
     if (Object.keys(pruned).length !== before) {
       data[key] = pruned;
+      changed = true;
+    }
+  }
+  // The retirement record ({oldId → {retiredAt, successor}}) prunes at the SAME
+  // fixed window, keyed on retiredAt — but its values are objects, not bare ISO
+  // strings, so it cannot ride TOMBSTONE_BUNDLE_KEYS / pruneTombstoneMap. Its
+  // own pruner keeps the two transports in the same lockstep.
+  if (data.retiredTaskIds && typeof data.retiredTaskIds === 'object') {
+    const pruned = pruneRetiredTaskIds(data.retiredTaskIds, cutoff);
+    if (pruned !== data.retiredTaskIds) {
+      data.retiredTaskIds = pruned;
       changed = true;
     }
   }

--- a/src/utils/retiredTaskIds.js
+++ b/src/utils/retiredTaskIds.js
@@ -1,0 +1,247 @@
+// The successor-aware ID RETIREMENT record: `retiredTaskIds`, a synced
+// singleton bundle of { oldId → { retiredAt: ISO, successor: newId } }.
+//
+// RETIREMENT ≠ DELETION. A retired id stopped naming anything because the SAME
+// task's identity moved to a successor id (the Phase 2 block-id migration:
+// legacy content-derived id → obsidian-dg-<blockId>; an untagged retitle's
+// intermediate hash → the final id). The content survives under the successor,
+// so "a newer edit on a retired id" must resolve as "an edit belonging to the
+// successor" — never as a resurrection of the old row. Deletion tombstones
+// cannot express that: they are last-writer-wins against the row's
+// lastModified, so a copy re-stamped NEWER than its tombstone (an offline edit
+// crossing a stamp, a peer's normalization re-stamp) revives — which is what
+// fed the scan-evict ↔ guard-heal war (the phase2TransitionSyncLoop repro).
+//
+// THE PROVENANCE RULE — three channels, three different actors, and no write
+// site ever has two valid choices:
+//   • retiredTaskIds      — written ONLY by the commit that renames an id: it
+//                           KNOWS the successor at write time. (useObsidianSync
+//                           write-success commit; any future id migration.)
+//   • deletedTaskIds      — written ONLY by user-intent delete paths: the user
+//                           pressed delete, there IS no successor.
+//                           (useTaskActions / useRecycleBin.)
+//   • deletedObsidianKeys — written ONLY by the vault-scan deletion detector:
+//                           it observed a key vanish and knows NEITHER intent
+//                           nor successor (an untagged line retitled in the
+//                           vault is indistinguishable from delete+create by
+//                           construction — the line carries no identity). It
+//                           keeps its conservative, LWW-revivable semantics.
+//
+// MERGE (mergeRetiredTaskIds): per-key last-writer-wins on retiredAt — two
+// devices retiring the same id to DIFFERENT successors (both stamp the same
+// untagged line while one is offline) keep the newer retirement. The record
+// never arbitrates which successor's ROW survives: the vault line is ground
+// truth, carries exactly one block id once Obsidian's own sync settles, and
+// the deletion detector reaps the losing successor's row on its device's next
+// scan. Ties break deterministically on the successor string so every device
+// converges on the same entry.
+//
+// RESOLUTION (resolveRetirement) is transitive with a cycle guard: entries are
+// written pre-collapsed (the commit records every retired id directly against
+// the FINAL id of its rename chain), so chains do not occur today — but a
+// stale L→M entry alongside M→N resolves to N rather than dangling, so a
+// future producer of chains inherits correct behavior.
+//
+// APPLY (applyTaskRetirements): a row whose id resolves to a live successor is
+// SUPERSEDED REGARDLESS OF TIMESTAMPS — the war killer. If the retired copy is
+// NEWER than the successor, its content is redirected onto the successor
+// (whole-row LWW: the retired copy's fields win, the successor keeps its
+// identity fields) so an offline edit made under the retired id is preserved,
+// not dropped. If the successor is NOT live locally, the record does nothing
+// and the row falls back to ordinary deletion-tombstone semantics — a device
+// that has the record but not yet the successor row must not discard content.
+//
+// PRUNE (pruneRetiredTaskIds): the shared fixed 60-day window
+// (sync/tombstoneRetention.js), keyed on retiredAt, applied by BOTH transports
+// — same lockstep rule as every deletion bundle, so the two tiers never
+// disagree on the set (the disagreement heartbeat the retention module
+// documents). An entry with an unparseable retiredAt is pruned: a retirement
+// we cannot date cannot be honored predictably, and losing an entry only
+// degrades to pre-record semantics.
+//
+// ─── LEGACY-FLEET DUAL-WRITE SHIM — grep anchor: RETIRED_ID_DUAL_WRITE ──────
+// The retirement commit ALSO writes plain deletedTaskIds tombstones for the
+// retired ids, because the shipped v4.7.x fleet's file-tier merge consults
+// ONLY deletedTaskIds — dropping the dual-write would let stale legacy rows
+// resurrect on un-upgraded devices (the (b2) resolution would regress).
+// SUNSET CONDITION (checkable, not vibes): delete the dual-write — flip this
+// flag, remove the dead branch in useObsidianSync's recordRetirements — when
+// BOTH hold:
+//   1. at least TOMBSTONE_RETENTION_DAYS (60) have passed since the first
+//      release carrying retiredTaskIds shipped, AND
+//   2. no pre-retiredTaskIds client (v4.7.x or older) has synced the account
+//      within the last TOMBSTONE_RETENTION_DAYS (check the device list in
+//      Cloud Sync settings / the vault's device cursors).
+// After (1)+(2), every deletedTaskIds entry an old file-tier merge could still
+// consult has been GC'd by the shared retention anyway, so the dual-write is
+// provably writing entries nothing reads differently.
+export const RETIRED_ID_DUAL_WRITE = true;
+
+export const RETIRED_TASK_IDS_STORAGE_KEY = 'day-planner-retired-task-ids';
+
+const ts = (v) => {
+  if (v == null) return 0;
+  const t = new Date(v).getTime();
+  return Number.isNaN(t) ? 0 : t;
+};
+
+// A well-formed entry: { retiredAt: parseable ISO, successor: non-empty string }.
+const validEntry = (e) =>
+  !!(e && typeof e === 'object' && typeof e.successor === 'string' && e.successor
+     && !Number.isNaN(new Date(e.retiredAt).getTime()));
+
+/** Read the record from localStorage (empty map on absence/corruption). */
+export function readRetiredTaskIds() {
+  try { return JSON.parse(localStorage.getItem(RETIRED_TASK_IDS_STORAGE_KEY) || '{}'); } catch { return {}; }
+}
+
+/**
+ * Pure: return a copy of `record` with `{oldId → {retiredAt, successor}}`
+ * entries added for each retired id. An existing entry is overwritten only by
+ * a newer retirement (same LWW the merge applies).
+ */
+export function recordRetirements(record, retiredIds, successor, retiredAtIso) {
+  const out = { ...(record || {}) };
+  for (const oldId of retiredIds || []) {
+    const key = String(oldId);
+    const prev = out[key];
+    if (validEntry(prev) && ts(prev.retiredAt) > ts(retiredAtIso)) continue;
+    out[key] = { retiredAt: retiredAtIso, successor: String(successor) };
+  }
+  return out;
+}
+
+/**
+ * Union merge, per-key last-writer-wins on retiredAt; ties break on the
+ * successor string (larger wins) so both devices converge on one entry.
+ * Malformed entries never beat well-formed ones.
+ */
+export function mergeRetiredTaskIds(local = {}, remote = {}) {
+  const out = {};
+  const keys = new Set([...Object.keys(local || {}), ...Object.keys(remote || {})]);
+  for (const k of keys) {
+    const l = (local || {})[k];
+    const r = (remote || {})[k];
+    const lv = validEntry(l);
+    const rv = validEntry(r);
+    if (lv && !rv) { out[k] = l; continue; }
+    if (rv && !lv) { out[k] = r; continue; }
+    if (!lv && !rv) continue; // both malformed → drop
+    const lt = ts(l.retiredAt);
+    const rt = ts(r.retiredAt);
+    if (lt !== rt) { out[k] = lt > rt ? l : r; continue; }
+    out[k] = String(l.successor) >= String(r.successor) ? l : r;
+  }
+  return out;
+}
+
+/**
+ * Prune entries whose retiredAt is strictly older than `cutoff` (a Date), or
+ * unparseable. Pure — returns a new map (the same map when nothing changed).
+ */
+export function pruneRetiredTaskIds(record, cutoff) {
+  if (!record || typeof record !== 'object' || !cutoff) return record || {};
+  const cutoffMs = cutoff.getTime();
+  let changed = false;
+  const out = {};
+  for (const [k, e] of Object.entries(record)) {
+    if (validEntry(e) && ts(e.retiredAt) >= cutoffMs) out[k] = e;
+    else changed = true;
+  }
+  return changed ? out : record;
+}
+
+/**
+ * Resolve `id` through the record transitively (L→M plus M→N yields N), with
+ * a cycle guard and hop cap. Returns the FINAL successor id, or null when the
+ * id is not retired.
+ */
+export function resolveRetirement(record, id, maxHops = 10) {
+  const rec = record && typeof record === 'object' ? record : {};
+  let cur = String(id);
+  const seen = new Set([cur]);
+  let resolved = null;
+  for (let hop = 0; hop < maxHops; hop++) {
+    const entry = rec[cur];
+    if (!validEntry(entry)) break;
+    const next = String(entry.successor);
+    if (seen.has(next)) break; // cycle — stop at the last sound step
+    resolved = next;
+    seen.add(next);
+    cur = next;
+  }
+  return resolved;
+}
+
+// Fields that belong to the successor's IDENTITY and must survive a content
+// redirect: everything else on the retired copy is user content and moves.
+const IDENTITY_FIELDS = ['id', 'importSource', 'obsidianBlockId', 'obsidianLegacyId', 'obsidianRawTitle', 'obsidianFileDate'];
+
+/**
+ * Apply the retirement record to one task list.
+ *
+ * For each row whose id resolves to a successor:
+ *   • successor live (per `liveIds`, which should span ALL task lists) →
+ *     the retired row is SUPERSEDED regardless of timestamps: dropped — and,
+ *     when the successor sits in THIS list and the retired copy's lastModified
+ *     is strictly newer, the retired copy's content is first redirected onto
+ *     the successor (whole-row LWW; the successor keeps IDENTITY_FIELDS).
+ *   • successor NOT live anywhere → the row is KEPT (conservative: the record
+ *     must never discard content it cannot redirect; ordinary deletion
+ *     tombstones still apply to such a row).
+ *
+ * @param {object[]} list      one task list (tasks or unscheduledTasks)
+ * @param {Record<string,{retiredAt:string,successor:string}>} record
+ * @param {Set<string>} liveIds  ids currently live across BOTH task lists
+ * @returns {object[]} the filtered/redirected list (same array when unchanged)
+ */
+export function applyTaskRetirements(list, record, liveIds) {
+  if (!Array.isArray(list) || !record || Object.keys(record).length === 0) return list || [];
+  let changed = false;
+  const byId = new Map();
+  for (const t of list) { if (t) byId.set(String(t.id), t); }
+  const dropped = new Set();
+  for (const t of list) {
+    if (!t) continue;
+    const successor = resolveRetirement(record, t.id);
+    if (!successor || successor === String(t.id)) continue;
+    if (!liveIds.has(successor)) continue; // no live successor → keep (conservative)
+    dropped.add(String(t.id));
+    changed = true;
+    const succRow = byId.get(successor);
+    if (succRow && ts(t.lastModified) > ts(succRow.lastModified)) {
+      // Redirect: the retired copy is the newer edit — its content belongs to
+      // the successor. Whole-row LWW with the successor's identity preserved.
+      const merged = { ...t };
+      for (const f of IDENTITY_FIELDS) {
+        if (succRow[f] !== undefined) merged[f] = succRow[f];
+        else delete merged[f];
+      }
+      byId.set(successor, merged);
+    }
+  }
+  if (!changed) return list;
+  const out = [];
+  for (const t of list) {
+    if (!t) continue;
+    const id = String(t.id);
+    if (dropped.has(id)) continue;
+    out.push(byId.get(id) || t);
+  }
+  return out;
+}
+
+/**
+ * Convenience wrapper for a { tasks, unscheduledTasks } pair: builds the
+ * cross-list live-id set and applies the record to both lists.
+ */
+export function applyRetirementsToTaskLists({ tasks, unscheduledTasks }, record) {
+  const t = Array.isArray(tasks) ? tasks : [];
+  const u = Array.isArray(unscheduledTasks) ? unscheduledTasks : [];
+  if (!record || Object.keys(record).length === 0) return { tasks: t, unscheduledTasks: u };
+  const liveIds = new Set([...t, ...u].filter(Boolean).map((x) => String(x.id)));
+  return {
+    tasks: applyTaskRetirements(t, record, liveIds),
+    unscheduledTasks: applyTaskRetirements(u, record, liveIds),
+  };
+}

--- a/src/utils/retiredTaskIds.test.js
+++ b/src/utils/retiredTaskIds.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import {
+  recordRetirements,
+  mergeRetiredTaskIds,
+  pruneRetiredTaskIds,
+  resolveRetirement,
+  applyTaskRetirements,
+  applyRetirementsToTaskLists,
+} from './retiredTaskIds.js';
+
+const T1 = '2026-07-08T10:00:00.000Z';
+const T2 = '2026-07-08T11:00:00.000Z';
+const T3 = '2026-07-08T12:00:00.000Z';
+const entry = (retiredAt, successor) => ({ retiredAt, successor });
+const task = (id, lastModified, extra = {}) => ({
+  id, title: `task ${id}`, completed: false, notes: '', subtasks: [], lastModified, ...extra,
+});
+
+describe('recordRetirements', () => {
+  it('adds entries for every retired id against one successor', () => {
+    const rec = recordRetirements({}, ['L', 'M'], 'N', T1);
+    expect(rec).toEqual({ L: entry(T1, 'N'), M: entry(T1, 'N') });
+  });
+  it('a newer retirement overwrites; an older one does not', () => {
+    const rec = recordRetirements({ L: entry(T2, 'B') }, ['L'], 'C', T1);
+    expect(rec.L).toEqual(entry(T2, 'B')); // T1 < T2 → kept
+    const rec2 = recordRetirements({ L: entry(T1, 'B') }, ['L'], 'C', T2);
+    expect(rec2.L).toEqual(entry(T2, 'C'));
+  });
+});
+
+describe('mergeRetiredTaskIds — divergent successors (the (a) case)', () => {
+  it('per-key LWW on retiredAt: the newer retirement wins', () => {
+    const a = { L: entry(T1, 'obsidian-dg-aaa') };
+    const b = { L: entry(T2, 'obsidian-dg-bbb') };
+    expect(mergeRetiredTaskIds(a, b).L).toEqual(entry(T2, 'obsidian-dg-bbb'));
+    expect(mergeRetiredTaskIds(b, a).L).toEqual(entry(T2, 'obsidian-dg-bbb')); // symmetric
+  });
+  it('exact-tie breaks deterministically on the successor string, both merge orders', () => {
+    const a = { L: entry(T1, 'obsidian-dg-aaa') };
+    const b = { L: entry(T1, 'obsidian-dg-bbb') };
+    expect(mergeRetiredTaskIds(a, b).L.successor).toBe('obsidian-dg-bbb');
+    expect(mergeRetiredTaskIds(b, a).L.successor).toBe('obsidian-dg-bbb');
+  });
+  it('a malformed entry never beats a well-formed one; two malformed entries drop', () => {
+    const good = { L: entry(T1, 'S') };
+    expect(mergeRetiredTaskIds(good, { L: { bogus: true } }).L).toEqual(entry(T1, 'S'));
+    expect(mergeRetiredTaskIds({ L: 'junk' }, good).L).toEqual(entry(T1, 'S'));
+    expect(mergeRetiredTaskIds({ L: 'junk' }, { L: null })).toEqual({});
+  });
+  it('union: disjoint keys both survive', () => {
+    const m = mergeRetiredTaskIds({ L: entry(T1, 'S1') }, { M: entry(T2, 'S2') });
+    expect(Object.keys(m).sort()).toEqual(['L', 'M']);
+  });
+});
+
+describe('pruneRetiredTaskIds — the (c) retention rule', () => {
+  const cutoff = new Date(T2);
+  it('drops entries strictly older than the cutoff, keeps the rest', () => {
+    const pruned = pruneRetiredTaskIds({ old: entry(T1, 'S'), fresh: entry(T3, 'S') }, cutoff);
+    expect(pruned).toEqual({ fresh: entry(T3, 'S') });
+  });
+  it('drops unparseable entries (a retirement we cannot date cannot be honored predictably)', () => {
+    const pruned = pruneRetiredTaskIds({ bad: entry('not-a-date', 'S'), junk: 'x', ok: entry(T3, 'S') }, cutoff);
+    expect(pruned).toEqual({ ok: entry(T3, 'S') });
+  });
+  it('returns the SAME map when nothing changed (no spurious diff churn)', () => {
+    const rec = { ok: entry(T3, 'S') };
+    expect(pruneRetiredTaskIds(rec, cutoff)).toBe(rec);
+  });
+});
+
+describe('resolveRetirement — the (b) chain semantics', () => {
+  it('resolves a direct entry', () => {
+    expect(resolveRetirement({ L: entry(T1, 'N') }, 'L')).toBe('N');
+  });
+  it('collapses a stale L→M hop through M→N', () => {
+    const rec = { L: entry(T1, 'M'), M: entry(T2, 'N') };
+    expect(resolveRetirement(rec, 'L')).toBe('N');
+    expect(resolveRetirement(rec, 'M')).toBe('N');
+  });
+  it('null for an unretired id; cycle-guarded (stops at the last sound step)', () => {
+    expect(resolveRetirement({ L: entry(T1, 'N') }, 'X')).toBeNull();
+    const cyclic = { A: entry(T1, 'B'), B: entry(T1, 'A') };
+    expect(resolveRetirement(cyclic, 'A')).toBe('B');
+  });
+});
+
+describe('applyTaskRetirements — the (d) supersede-regardless-of-timestamps rule', () => {
+  const REC = { L: entry(T2, 'S') };
+
+  it('drops a retired row OLDER than its live successor (plain supersede)', () => {
+    const list = [task('S', T2), task('L', T1)];
+    const out = applyTaskRetirements(list, REC, new Set(['S', 'L']));
+    expect(out.map((t) => t.id)).toEqual(['S']);
+    expect(out[0].lastModified).toBe(T2); // successor untouched
+  });
+
+  it('redirects a retired row NEWER than its successor: content moves onto the successor, identity stays', () => {
+    const succ = task('S', T1, { obsidianBlockId: 'k3x9q2mf', obsidianRawTitle: 'Buy milk', importSource: 'obsidian' });
+    const retired = task('L', T3, { title: 'edited offline #obsidian', completed: true, importSource: 'obsidian', obsidianRawTitle: 'stale raw' });
+    const out = applyTaskRetirements([succ, retired], REC, new Set(['S', 'L']));
+    expect(out).toHaveLength(1);
+    const s = out[0];
+    expect(s.id).toBe('S');                        // identity: successor's
+    expect(s.obsidianBlockId).toBe('k3x9q2mf');    // identity: successor's
+    expect(s.obsidianRawTitle).toBe('Buy milk');   // "what the vault line says" stays the successor's
+    expect(s.title).toBe('edited offline #obsidian'); // content: the newer retired copy's
+    expect(s.completed).toBe(true);
+    expect(s.lastModified).toBe(T3);               // the edit keeps its recency for LWW onward
+  });
+
+  it('keeps a retired row whose successor is NOT live anywhere (conservative fallback)', () => {
+    const list = [task('L', T3)];
+    const out = applyTaskRetirements(list, REC, new Set(['L']));
+    expect(out.map((t) => t.id)).toEqual(['L']);
+  });
+
+  it('cross-list: a retired row is dropped when its successor lives in the OTHER list', () => {
+    const { tasks, unscheduledTasks } = applyRetirementsToTaskLists(
+      { tasks: [task('S', T2)], unscheduledTasks: [task('L', T1)] }, REC,
+    );
+    expect(tasks.map((t) => t.id)).toEqual(['S']);
+    expect(unscheduledTasks).toEqual([]);
+  });
+
+  it('returns the same array when the record touches nothing', () => {
+    const list = [task('X', T1)];
+    expect(applyTaskRetirements(list, REC, new Set(['X']))).toBe(list);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the agreed direction: proposal (1) as a **successor-aware retirement record**, alongside — not subsuming — `deletedObsidianKeys`. Retirement is an identity move, not a deletion: `retiredTaskIds` maps `oldId → { retiredAt, successor }`, and every consumer resolves "a newer edit on a retired id" as **an edit belonging to the successor**, never a resurrection. This flips #1449's war `it.fails` tests to passing pins.

### The merge semantics (as reported before building)

- **Divergent successors**: per-key LWW on `retiredAt`, deterministic tie-break on the successor string — the record never arbitrates which successor's *row* wins; the vault line is ground truth and the deletion detector reaps the loser.
- **Chains**: collapsed at write time (every retired id in a rename chain records the *final* id); `resolveRetirement` still resolves a stale hop transitively, cycle-guarded.
- **Prune**: the same fixed 60-day window as every deletion bundle, keyed on `retiredAt`, applied in lockstep by both transports (`pruneAllTombstones` + the `mergeSync` tombstone block); undatable entries are dropped.
- **Ordering**: with a **live** successor, the record wins **regardless of timestamps** — the war killer. The cost is paid by redirect, not loss: a retired copy newer than its successor has its content moved onto the successor (whole-row LWW; the successor keeps its identity fields, including `obsidianRawTitle`). With **no** live successor the record authorizes nothing — conservative fall-through to the pre-record classification, pinned by tests.

### The provenance rule, in code where the writes happen

Three channels, three actors, no write site ever has two valid choices — stated at each site: the **commit-that-renames** knows the successor (`useObsidianSync` → `retiredTaskIds`); **user-pressed delete** knows intent (`useTaskActions`/`useRecycleBin` → `deletedTaskIds`); the **detector-observed vanish** knows neither (`deletedObsidianKeys`, untouched — #1448 stays its own issue, made safer by this split).

### Consumers

`snapshotDeleteGuard` (new `'retired'` classification, decided before the tombstone timestamp rule), `applyEngineData` (supersede pass on the merged lists **and** on the rescue output, so a prev-only offline edit under a retired id redirects instead of resurrecting), the file-tier merge (record merged + pruned + retired rows kept out of the uploaded file), `buildSyncPayload`, `dbAdapter` bundle merge.

### Legacy-fleet shim with a checkable sunset

The commit **dual-writes** `deletedTaskIds` tombstones because v4.7.x's file-tier merge consults only that channel. `RETIRED_ID_DUAL_WRITE` in `utils/retiredTaskIds.js` (grep anchor) carries the sunset condition: delete once **(1)** ≥60 days (`TOMBSTONE_RETENTION_DAYS`) have passed since the first release carrying `retiredTaskIds` shipped, **and (2)** no pre-record client has synced the account within 60 days — after which every entry an old merge could consult has been GC'd anyway.

## Tests

- 17 unit tests for the record module (merge LWW + tie determinism + malformed handling, transitive/cycle-guarded resolution, prune incl. undatable entries and no-change identity, supersede/redirect/conservative-keep/cross-list).
- #1449's war tests **flipped to passing**: retired ids converge with zero heal traffic and scan rounds change nothing; the peer's newer offline retitle reaches a fresh device on the successor (no duplicate, no lost edit); restart converges instead of resuming the war. Guard fallbacks pinned (`'retired'` with live successor; `'stale-tombstone'` without record or without live successor).
- Storm tests keep their coverage by moving the heal fixture to a plain untombstoned glitch (retired ids no longer skip). Payload canary covers the new key.

Full suite: **2236 passed, 0 expected-fail** — the suite no longer carries any pinned-broken behavior. Lint clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_