### PR TITLE
Symmetric enforcement of deletedObsidianKeys at every apply boundary (fixes the echo war, closes #1448)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import { tombstoneCutoff } from './sync/tombstoneRetention.js';
 import { preserveArchived } from './utils/preserveArchived.js';
 import { rescueUnsyncedTasks } from './utils/rescueUnsyncedTasks.js';
 import { readRetiredTaskIds, applyTaskRetirements, RETIRED_TASK_IDS_STORAGE_KEY } from './utils/retiredTaskIds.js';
+import { dropTombstonedObsidianTasks, dropTombstonedObsidianNotes } from './utils/obsidianDeletions.js';
 import { dropResurrectedTasks } from './utils/dropResurrectedTasks.js';
 import { partitionExpiredSingleDayFrames } from './utils/expiredFrames.js';
 import { stripHealthSourcedLogs } from './utils/healthLogFilter.js';
@@ -5611,6 +5612,19 @@ const DayPlanner = () => {
     if (normalizedTasks) normalizedTasks = applyTaskRetirements(normalizedTasks, retiredRecord, retiredLiveIds);
     if (normalizedUnsched) normalizedUnsched = applyTaskRetirements(normalizedUnsched, retiredRecord, retiredLiveIds);
 
+    // Symmetric enforcement of deletedObsidianKeys at the APPLY boundary
+    // (utils/obsidianDeletions.js — the shared gate both tiers use). The
+    // channel used to be honored on the way OUT but ignored on the way IN:
+    // every deleting path consulted it while this apply admitted pulled rows
+    // unfiltered — the asymmetry behind the tombstone echo war
+    // (obsidianTombstoneEchoWar.test.js) and issue #1448. Same LWW as the
+    // scan merge: a genuinely restored/re-created copy (lastModified newer
+    // than its tombstone) passes and propagates.
+    const obsidianTombs = data.deletedObsidianKeys
+      || (() => { try { return JSON.parse(localStorage.getItem('day-planner-deleted-obsidian-keys') || '{}'); } catch { return {}; } })();
+    if (normalizedTasks) normalizedTasks = dropTombstonedObsidianTasks(normalizedTasks, obsidianTombs);
+    if (normalizedUnsched) normalizedUnsched = dropTombstonedObsidianTasks(normalizedUnsched, obsidianTombs);
+
     // Update localStorage
     if (normalizedTasks) localStorage.setItem('day-planner-tasks', JSON.stringify(normalizedTasks));
     if (normalizedUnsched) localStorage.setItem('day-planner-unscheduled', JSON.stringify(normalizedUnsched));
@@ -5678,8 +5692,13 @@ const DayPlanner = () => {
       setRemovedTodayRoutineIds(data.removedTodayRoutineIds);
     }
     if (data.dailyNotes) {
-      localStorage.setItem('day-planner-daily-notes', JSON.stringify(data.dailyNotes));
-      setDailyNotes(data.dailyNotes);
+      // Same apply-boundary gate as the task lists above: a note whose
+      // deletion tombstone is the newest word must not be re-admitted by a
+      // pulled/merged map (this replace used to be the notes' half of the
+      // echo war). A note re-created later (newer lastModified) passes.
+      const gatedNotes = dropTombstonedObsidianNotes(data.dailyNotes, obsidianTombs);
+      localStorage.setItem('day-planner-daily-notes', JSON.stringify(gatedNotes));
+      setDailyNotes(gatedNotes);
     }
     // Day windows MERGE (per-entry LWW) rather than overwrite like the slices
     // above: applyRemoteDayWindows also persists, and is a no-op (no write, no

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -10,6 +10,7 @@ import {
   unionNewerIso as unionTombstones,
 } from './sync/tombstoneRetention.js';
 import { mergeRetiredTaskIds, pruneRetiredTaskIds, applyRetirementsToTaskLists } from './utils/retiredTaskIds.js';
+import { dropTombstonedObsidianTasks, dropTombstonedObsidianNotes } from './utils/obsidianDeletions.js';
 import { mergeDayWindowMaps, dayWindowMapsEqual, migrateDayWindows } from './sync/dayWindowSync.js';
 
 export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =>
@@ -492,6 +493,33 @@ export const mergeSyncData = (local, remote, retentionDays) => {
   if (retApplied.tasks !== result.data.tasks || retApplied.unscheduledTasks !== result.data.unscheduledTasks) {
     result.data.tasks = retApplied.tasks;
     result.data.unscheduledTasks = retApplied.unscheduledTasks;
+    result.localChanged = true;
+    result.remoteChanged = true;
+  }
+
+  // Symmetric enforcement of deletedObsidianKeys in the FILE-TIER merge — the
+  // fix for issue #1448 ("deletedObsidianKeys never reaches the file-tier task
+  // merge"). The channel was honored on the way OUT but ignored on the way IN:
+  // every deleting path consulted it while this merge unioned tombstoned rows
+  // straight back from the remote file — the vaultless-device resurrection
+  // loop, and the file-tier face of the tombstone echo war
+  // (src/sync/obsidianTombstoneEchoWar.test.js; applyEngineData carries the
+  // apply-side of the same gate). Cleansing the MERGE OUTPUT also cleanses the
+  // uploaded file, so a zombie row cannot sit in the remote file waiting to
+  // resurrect the day its tombstone hits the 60-day GC. Same shared LWW
+  // helpers as the apply boundary (utils/obsidianDeletions.js): a row or note
+  // re-created after its deletion (newer lastModified) survives and syncs.
+  const obsTombs = result.data.deletedObsidianKeys || {};
+  const obsCleanTasks = dropTombstonedObsidianTasks(result.data.tasks, obsTombs);
+  const obsCleanUnsched = dropTombstonedObsidianTasks(result.data.unscheduledTasks, obsTombs);
+  const obsCleanNotes = dropTombstonedObsidianNotes(result.data.dailyNotes, obsTombs);
+  if (obsCleanTasks !== result.data.tasks || obsCleanUnsched !== result.data.unscheduledTasks
+      || obsCleanNotes !== result.data.dailyNotes) {
+    result.data.tasks = obsCleanTasks;
+    result.data.unscheduledTasks = obsCleanUnsched;
+    result.data.dailyNotes = obsCleanNotes;
+    // Both sides need the cleansed result: local state applies it, and the
+    // remote file is rewritten without the zombies.
     result.localChanged = true;
     result.remoteChanged = true;
   }

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -44,6 +44,7 @@ import { partitionSnapshotDeletes } from './snapshotDeleteGuard.js';
 import { isPayloadExcludedEntity, agedOutReleaseReason } from './payloadExclusions.js';
 import { shredHashes, hashMapsEqual, mergeMidCycleEdits } from './commitMerge.js';
 import { createSyncCycleBreaker, isRateLimitedError } from './syncBrakes.js';
+import { isObsidianTombstoned } from '../utils/obsidianDeletions.js';
 
 const APP_ID = 'dayglance';
 const CRYPTO_DB_NAME = 'dayglance-db-crypto';
@@ -324,6 +325,26 @@ export function createDbEngine(callbacks = {}) {
       // ping-pong. Logging every applied entityId shows whether the churn arrives
       // FROM the vault (another device re-pushing) vs originates locally.
       if (debugPushEnabled()) console.log('[pull] apply', entityId);
+      // Symmetric enforcement of deletedObsidianKeys at the DB-TIER APPLY —
+      // the third face of the shared gate (utils/obsidianDeletions.js; the
+      // other two are applyEngineData and the file-tier merge). The channel
+      // was honored on the way out but ignored on the way in, and THIS
+      // callback was the deepest ignored ingress: without the gate, a
+      // tombstoned-and-older row echoed back by the pull re-enters the
+      // MIRROR, where the snapshot-diff's blessed delete-marks find it live
+      // again and re-upsert it — an engine-level echo war that continues
+      // even after the app-level applies are gated (the vault seq climbs
+      // every cycle while state stays clean; caught by
+      // obsidianTombstoneEchoWar.test.js). Same revive-preserving LWW as
+      // every other face: a copy newer than its tombstone applies normally.
+      const obsTombs = mirror.deletedObsidianKeys;
+      if (obsTombs && entity && typeof entity === 'object') {
+        const k = entity._kind;
+        const v = entity.value;
+        if ((k === 'tasks' || k === 'unscheduledTasks') && v && v.importSource === 'obsidian'
+            && isObsidianTombstoned(obsTombs, String(v.id), v.lastModified)) return;
+        if (k === 'dailyNotes' && isObsidianTombstoned(obsTombs, String(entity._key), v && v.lastModified)) return;
+      }
       // The vault's content for this row changed under us — whatever we last
       // acked there is stale, so the no-op re-push skip below must not apply.
       ackedUpsertHashes.delete(entityId);

--- a/src/sync/obsidianTombstoneEchoWar.test.js
+++ b/src/sync/obsidianTombstoneEchoWar.test.js
@@ -2,69 +2,47 @@ import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vites
 import { setSyncPassphrase } from '@glance-apps/sync';
 import { createDbEngine } from './dbEngine.js';
 import { setVaultConfig } from './vaultConfig.js';
-import { createSyncCycleBreaker } from './syncBrakes.js';
 import { rescueUnsyncedTasks } from '../utils/rescueUnsyncedTasks.js';
 import { mergeObsidianTasks } from '../utils/mergeObsidianTasks.js';
 import { mergeObsidianDailyNotes } from '../utils/mergeObsidianDailyNotes.js';
+import { dropTombstonedObsidianTasks, dropTombstonedObsidianNotes } from '../utils/obsidianDeletions.js';
+import { mergeSyncData } from '../mergeSync.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// THE TOMBSTONE ECHO WAR — deterministic reproduction of the 2026-08-26 log
-// (three rows — one legacy Obsidian task, two daily notes — cycling pull-DELETE
-// → snapshot-diff-new → push written:3 → "honored deletes: Array(3)" →
-// propagating delete(s) → repeat, ~12 rounds, EVERY cycle successful, counts
-// oscillating 577/576 and 48/46 in lockstep).
+// THE TOMBSTONE ECHO WAR — reproduction of the 2026-08-26 log, now pinning the
+// FIX: symmetric enforcement of deletedObsidianKeys at the apply boundary.
 //
-// THE MECHANISM — one deletion channel, enforced asymmetrically:
+// THE WAR (as captured live): three rows — one legacy Obsidian task, two daily
+// notes — cycled pull-DELETE → snapshot-diff-new → push written:3 → "honored
+// deletes: Array(3)" → propagate, ~12 successful rounds, counts oscillating
+// 577/576 and 48/46. The mechanism: the rows carried deletion tombstones newer
+// than their lastModified, and the channel was HONORED ON THE WAY OUT BUT
+// IGNORED ON THE WAY IN — every deleting path consulted it (the vault-scan
+// merges, rescue, the commit merge's honored-delete blessing, the push guard's
+// 'tombstoned' propagation) while no applying path did (applyEngineData
+// admitted pulled rows unfiltered and replaced dailyNotes wholesale; the
+// file-tier merge unioned tombstoned rows back from the remote file — issue
+// #1448, the same asymmetry's file-tier face). Add the commit-visibility lag
+// (React's flush racing back-to-back SSE drains) and the device fought its own
+// echo: stale state re-pushed the rows the vault just deleted, the flushed
+// state re-propagated blessed deletes, each push seeding the opposite half a
+// cycle later. Every cycle SUCCEEDED, so no failure-armed brake engaged.
 //
-//   The rows carry deletion tombstones newer than their lastModified
-//   (deletedObsidianKeys here; any bundle the guard blesses behaves the same).
-//   The tombstone is honored by EVERY PATH THAT DELETES:
-//     • the vault-scan merges drop the rows from state
-//       (mergeObsidianTasks / mergeObsidianDailyNotes, tombstone ≥ lastModified),
-//     • rescueUnsyncedTasks refuses to rescue them,
-//     • the commit merge blesses their mid-cycle vanish as an honored delete
-//       (commitMerge → partitionSnapshotDeletes unions ALL tombstone bundles),
-//     • the push guard propagates their snapshot vanish as 'tombstoned';
-//   …but by NO PATH THAT APPLIES:
-//     • applyEngineData admits pulled task rows with no deletedObsidianKeys
-//       gate on the merged list and applies dailyNotes as a PLAIN REPLACE,
-//     • the engine's pull applies any vault copy the mirror lacks.
-//
-//   The third ingredient is TIMING: back-to-back cycles (SSE multi-drains, the
-//   3s debounce, the visibility handler firing scan + cycle together) run
-//   against state whose React commit hasn't flushed yet — so a cycle can see
-//   the PREVIOUS state, diff it against the snapshot of the cycle before, and
-//   push the OPPOSITE of what the vault just did. The device fights its own
-//   echo: state-with-rows + snapshot-without → push NEW (resurrect); state-
-//   without + snapshot-with → blessed delete (kill); each push echoes back
-//   through the pull one cycle later and seeds the opposite half. This is the
-//   DB-tier sibling of issue #1448 (the same channel never reaching the
-//   FILE-tier merge): honored on the way out, ignored on the way in.
-//
-//   EVERY CYCLE SUCCEEDS — which is why none of the brakes engage: the circuit
-//   breaker (#1450) arms only on failure, the deferred retry (#1451) only on a
-//   gated cycle, and the acked-hash dedup only suppresses re-pushing content
-//   the vault already acked — these rows are ABSENT from the payload when they
-//   diff as deletes and freshly re-applied when they diff as new, so the dedup
-//   never sees a repeat. Pinned below as the success-loop gap.
-//
-//   SELF-RESOLUTION (the log's "survivors: Array(3)" flip): the war's substrate
-//   is `tombstone ≥ lastModified`. The moment live copies exist whose
-//   lastModified EXCEEDS the tombstones (a scan re-importing a note with a
-//   fresh file mtime; any genuine edit), commitMerge carries them into the
-//   commit as SURVIVORS, the next diff pushes them, and every comparison
-//   thereafter keeps them. LWW revive-beats-tombstone ends the war by design —
-//   it just cannot START until something bumps lastModified. Pinned below.
+// THE FIX (utils/obsidianDeletions.js — dropTombstonedObsidianTasks/Notes, one
+// shared gate for BOTH tiers): applyEngineData filters the merged task lists
+// and gates the dailyNotes apply, and mergeSyncData cleanses its merge output
+// (which is also the uploaded file — closing #1448 and the day-61 resurrection
+// a dirty file would cause when tombstones GC). Same LWW as the scan merge:
+// revive-preserving — a copy whose lastModified beats its tombstone passes and
+// propagates. The echo is refused, the first blessed delete sticks, and the
+// war collapses in one round.
 //
 // HARNESS: real @glance-apps/sync engine + real crypto over the in-memory
-// vault (the #1449 pattern). The device models React's commit-visibility lag
-// explicitly: commitData lands in `pending`, `flush()` promotes it to the
-// state getData sees — the stand-in for the render flush racing back-to-back
-// drains. commitData models applyEngineData's verified behavior (tasks:
-// merged list unfiltered + real tombstone-gated rescue; dailyNotes: plain
-// replace). The scan step is the REAL mergeObsidianTasks /
-// mergeObsidianDailyNotes fed the localStorage tombstones, exactly as
-// useObsidianSync feeds them.
+// vault. The device models React's commit-visibility lag explicitly
+// (pending/flush). commitData models the FIXED applyEngineData: merged tasks
+// through the apply-boundary gate + real tombstone-gated rescue; dailyNotes
+// replace through the same gate. The scan step is the REAL merge functions
+// fed the localStorage tombstones, exactly as useObsidianSync feeds them.
 // ─────────────────────────────────────────────────────────────────────────────
 
 function memLocalStorage() {
@@ -115,11 +93,6 @@ afterAll(() => { delete global.localStorage; });
 
 const clone = (x) => JSON.parse(JSON.stringify(x));
 
-// The cast, mirroring the log: a legacy Obsidian task and two daily notes,
-// each with lastModified OLDER than its deletion tombstone. Which bundle
-// blessed the April task in the field (deletedObsidianKeys, or a
-// deletedTaskIds entry inside the guard's 5s epsilon) doesn't change the
-// shape; deletedObsidianKeys is used for all three here.
 const TASK_ID = 'obsidian-2026-04-27-3a979k';
 const NOTE_A = '2026-08-10';
 const NOTE_B = '2026-08-11';
@@ -146,9 +119,9 @@ const EMPTY = {
 
 // A device with EXPLICIT commit-visibility lag (the React-flush stand-in):
 // getData reads `visible`; commitData computes the applyEngineData model into
-// `pending`; flush() promotes pending → visible. `flushOnPush` promotes the
-// PREVIOUS pending right after a vault write lands — the mid-cycle render
-// flush that produces the log's "honored deletes: Array(3)".
+// `pending`; flush() promotes it. `flushOnPush` promotes the previous pending
+// right after a vault write lands — the mid-cycle render flush that produced
+// the log's "honored deletes: Array(3)".
 function makeLaggedDevice(name, vault, initial, { flushOnPush = false, engineOverrides = {} } = {}) {
   let visible = clone(initial);
   let pending = null;
@@ -172,15 +145,18 @@ function makeLaggedDevice(name, vault, initial, { flushOnPush = false, engineOve
     ...engineOverrides,
     getData: () => clone(visible),
     commitData: (d) => {
+      const tombs = d.deletedObsidianKeys || {};
       const prevTasks = visible.tasks;
       pending = {
         ...d,
-        // applyEngineData: merged list unfiltered + tombstone-gated rescue of
-        // prev-only rows. The gate BLOCKS a rescue of the war rows — but a
-        // pulled copy inside `d.tasks` walks straight in.
-        tasks: rescueUnsyncedTasks(d.tasks, prevTasks, d.deletedTaskIds || {}, undefined, d.deletedObsidianKeys || {}),
-        // applyEngineData: `setDailyNotes(data.dailyNotes)` — plain replace.
-        dailyNotes: d.dailyNotes,
+        // The FIXED applyEngineData: the apply-boundary gate on the merged
+        // list, then the (real, already tombstone-gated) rescue of prev-only
+        // rows, and the same gate on the notes replace.
+        tasks: rescueUnsyncedTasks(
+          dropTombstonedObsidianTasks(d.tasks, tombs),
+          prevTasks, d.deletedTaskIds || {}, undefined, tombs,
+        ),
+        dailyNotes: dropTombstonedObsidianNotes(d.dailyNotes, tombs),
       };
     },
   });
@@ -188,9 +164,6 @@ function makeLaggedDevice(name, vault, initial, { flushOnPush = false, engineOve
 }
 
 // The REAL vault-scan merge step, fed exactly what useObsidianSync feeds it.
-// The local scan does not contain the war rows (the task's note is outside the
-// 90-day import window; the notes scan to nothing here), so the tombstones
-// decide — and they DROP all three from visible state: the remover.
 function runVaultScan(dev, { scannedNotes = {} } = {}) {
   let tombstones = {};
   try { tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-obsidian-keys') || '{}'); } catch { tombstones = {}; }
@@ -205,169 +178,85 @@ const warIds = [`tasks:${TASK_ID}`, `dailyNotes:${NOTE_A}`, `dailyNotes:${NOTE_B
 const hasWarRows = (data) =>
   data.tasks.some((t) => t.id === TASK_ID) && !!data.dailyNotes[NOTE_A] && !!data.dailyNotes[NOTE_B];
 
-// Seed: state holds the rows (lastModified T_OLD) + the tombstones (T_TOMB);
-// two cycles so the engine leaves the HWM=0 full-seed path and has consumed
-// its own seed rows (echo drained); flush so visible is settled.
+// Seed, HISTORICALLY: the rows exist and sync everywhere FIRST (no tombstones
+// yet — two cycles so the engine leaves the HWM=0 full-seed path and consumes
+// its own seed rows), and only THEN are the tombstones written (the detector
+// firing / the bundle syncing in). That is the field pre-state: state and
+// vault holding tombstoned-and-older copies. Seeding the other way around is
+// impossible post-fix — the gated apply strips the rows during seeding, which
+// is the fix itself working.
 async function seedWar(vault, opts = {}) {
-  localStorage.setItem('day-planner-deleted-obsidian-keys', JSON.stringify(TOMBSTONES));
   const dev = makeLaggedDevice('mac', vault, {
     ...EMPTY,
     tasks: [warTask()],
     dailyNotes: { [NOTE_A]: warNote(), [NOTE_B]: warNote(T_OLD, '## Quick Notes\n## Thoughts') },
-    deletedObsidianKeys: TOMBSTONES,
   }, opts);
   await dev.engine.dbSyncCycle();
   await dev.engine.dbSyncCycle();
   dev.flush();
+  localStorage.setItem('day-planner-deleted-obsidian-keys', JSON.stringify(TOMBSTONES));
+  dev.visible = { ...dev.visible, deletedObsidianKeys: TOMBSTONES };
   expect(hasWarRows(dev.visible)).toBe(true);
   return dev;
 }
 
-describe('the echo war — a tombstone honored by every deleting path and no applying path', () => {
-  it("reproduces the log's round anatomy: pull-DELETE supersedes the dirty marks → stale state re-pushes written:3 → honored deletes: 3 → the round re-arms", async () => {
+describe('the echo war — FIXED by symmetric enforcement at the apply boundary', () => {
+  it("the log's round anatomy now collapses: pull-DELETE supersedes → stale re-push resurrects once → the echo is REFUSED → the deletes stick and the vault converges dead", async () => {
     const vault = createMemoryVault();
     const dev = await seedWar(vault, { flushOnPush: true });
 
-    // Pre-state, as mid-war: the vault's latest rows for the three keys are
-    // DELETES (a previous round's blessed propagation), and the snapshot lacks
-    // them (saved from that round's post-delete mirror) — while visible state
-    // still HAS them (the flush lagged).
+    // Mid-war pre-state, as in the log: the vault's latest rows are DELETES
+    // (a previous round's blessed propagation), the snapshot lacks them, but
+    // visible state still HAS them (the flush lagged).
     for (const id of warIds) await vault.deleteRow('dayglance', id, 'acct', { deletedAt: new Date(T_TOMB).getTime() });
     const snapKey = 'dev-mac-db-sync-snapshot';
     const snap = JSON.parse(localStorage.getItem(snapKey));
     for (const id of warIds) delete snap[id];
     localStorage.setItem(snapKey, JSON.stringify(snap));
-    expect(hasWarRows(dev.visible)).toBe(true);
 
-    // ROUND A (log: "[pull] DELETE ×3 … did NOT write … dirty ids: Array(0) …
-    // snapshot-diff new ×3"): the diff marks the rows NEW (state vs snapshot),
-    // the pull's delete rows supersede the dirty marks (deletedAt ≥
-    // lastModified — the engine's LWW), nothing is written, and the commit
-    // carries the deletions — but only into `pending`; visible state still
-    // shows the rows.
-    const seqA0 = vault._seq();
+    // ROUND A (log: "[pull] DELETE ×3 … did NOT write"): the pulled deletes
+    // supersede the dirty marks; no war-row is written (the one legitimate
+    // write this cycle is the freshly-grown deletedObsidianKeys bundle
+    // syncing out); the commit carries the deletions into `pending` while
+    // visible state still shows the rows.
+    const rowSeqsA0 = warIds.map((id) => vault._row(id).seq);
     const resA = await dev.engine.dbSyncCycle();
     expect(resA.error).toBeUndefined();
-    expect(vault._seq()).toBe(seqA0);            // did NOT write this cycle
-    expect(hasWarRows(dev.visible)).toBe(true);  // flush hasn't landed
+    expect(warIds.map((id) => vault._row(id).seq)).toEqual(rowSeqsA0); // war rows untouched
+    expect(hasWarRows(dev.visible)).toBe(true);
 
-    // ROUND B (log: "written:3 … [commit] mid-cycle merge — survivors:
-    // Array(0) honored deletes: Array(3)"): the still-stale state re-diffs the
-    // rows as NEW and pushes them — RESURRECTING the vault rows the previous
-    // round deleted. The flush lands right after the push (flushOnPush), so
-    // the commit merge sees live state WITHOUT the rows, and — because the
-    // tombstones bless the vanish — HONORS the deletes into the commit.
+    // ROUND B (log: "written:3 … honored deletes: Array(3)"): the still-stale
+    // state re-pushes the rows — the ONE resurrection the visibility lag can
+    // still cause — and the mid-cycle flush lets the commit merge honor the
+    // blessed deletes.
     const resB = await dev.engine.dbSyncCycle();
     expect(resB.error).toBeUndefined();
-    for (const id of warIds) expect(vault._row(id).deleted).toBe(false); // resurrected
-    expect(hasWarRows(dev.pending ?? dev.visible)).toBe(false);          // honored deletes carried
+    for (const id of warIds) expect(vault._row(id).deleted).toBe(false); // resurrected once
+    expect(hasWarRows(dev.pending ?? dev.visible)).toBe(false);
 
-    // ROUND C: the flushed state now lacks the rows while the snapshot (saved
-    // pre-merge, WITH the rows) still holds them → the guard blesses the
-    // vanish ('tombstoned') — and the pull echoes round B's upserts straight
-    // back into the mirror, which the commit RE-ADMITS into state. The war has
-    // re-armed itself; nothing converged.
+    // ROUND C — where the war used to re-arm: the pull echoes round B's
+    // upserts into the mirror, but the apply-boundary gate REFUSES them
+    // (tombstone ≥ lastModified). State stays clean.
     dev.flush();
     expect(hasWarRows(dev.visible)).toBe(false);
     const resC = await dev.engine.dbSyncCycle();
     expect(resC.error).toBeUndefined();
     dev.flush();
-    expect(hasWarRows(dev.visible)).toBe(true);  // re-admitted — appear/disappear, forever
-  });
+    expect(hasWarRows(dev.visible)).toBe(false); // the echo did NOT re-enter state
 
-  it('pins the sustained war: scan drops, the echo re-admits, the push re-writes — vault traffic every round, every cycle successful, rows never converge', async () => {
-    const vault = createMemoryVault();
-    const dev = await seedWar(vault);
-
-    let lastSeq = vault._seq();
-    for (let round = 1; round <= 3; round++) {
-      runVaultScan(dev);                          // remover: rows leave visible state
-      expect(hasWarRows(dev.visible)).toBe(false);
-      const res = await dev.engine.dbSyncCycle(); // echo re-applies → push re-writes → commit re-admits
-      expect(res.error).toBeUndefined();
-      dev.flush();
-      expect(hasWarRows(dev.visible)).toBe(true); // …and they are back
-      expect(vault._seq()).toBeGreaterThan(lastSeq); // the vault was written AGAIN
-      lastSeq = vault._seq();
-    }
-    for (const id of warIds) expect(vault._row(id).deleted).toBe(false); // never converged
-  });
-
-  it('confirms the brake gap: every cycle succeeds — the breaker never strikes, nothing is gated, no deferred retry is armed', async () => {
-    const vault = createMemoryVault();
-    const breaker = createSyncCycleBreaker({ random: () => 0 });
-    const onFailure = vi.spyOn(breaker, 'onFailure');
-    const armed = [];
-    const dev = await seedWar(vault, {
-      engineOverrides: {
-        cycleBreaker: breaker,
-        retryTimers: { setTimeoutFn: (fn, ms) => { armed.push(ms); return { fn, ms }; }, clearTimeoutFn: () => {} },
-      },
-    });
-
-    for (let round = 0; round < 4; round++) {
-      runVaultScan(dev);
-      const res = await dev.engine.dbSyncCycle();
-      expect(res.error).toBeUndefined();
-      expect(res.throttled).toBeUndefined();
-      dev.flush();
-    }
-    expect(onFailure).not.toHaveBeenCalled(); // failure-brakes are structurally blind to a success loop
-    expect(armed).toEqual([]);
-  });
-
-  it("pins the self-resolution: copies whose lastModified beats the tombstones end the war (the log's 'survivors' flip) — and it STAYS ended", async () => {
-    const vault = createMemoryVault();
-    const dev = await seedWar(vault);
-
-    for (let round = 0; round < 2; round++) { // a couple of war rounds first
-      runVaultScan(dev);
-      await dev.engine.dbSyncCycle();
-      dev.flush();
-    }
-    expect(hasWarRows(dev.visible)).toBe(true);
-
-    // The resolution event: the scan re-imports the notes with FRESH file
-    // mtimes AND changed text (Obsidian's own sync delivering updated files),
-    // and the task's copy is re-stamped past its tombstone. The changed text
-    // matters: mergeObsidianDailyNotes carries the OLD lastModified forward
-    // for UNCHANGED text (so unedited notes don't re-push every scan), which
-    // means a same-text rescan still loses to the tombstone — only genuinely
-    // newer content (or a fresh import into an absent slot) can end the war.
-    const T_FRESH = '2026-08-26T19:30:00.000Z';
-    const freshNotes = {
-      [NOTE_A]: warNote(T_FRESH, '## Quick Notes\n- Testing on Windows\n- Back on the Mac'),
-      [NOTE_B]: warNote(T_FRESH, '## Quick Notes\n## Thoughts\n- resolved'),
-    };
-    dev.visible = {
-      ...dev.visible,
-      tasks: dev.visible.tasks.map((t) => (t.id === TASK_ID ? { ...t, lastModified: T_FRESH } : t)),
-    };
-    runVaultScan(dev, { scannedNotes: freshNotes });
-    expect(hasWarRows(dev.visible)).toBe(true); // fresh copies now BEAT the tombstones — nothing drops them
-
-    await dev.engine.dbSyncCycle(); // pushes the newer-than-tombstone copies
+    // ROUND D: the snapshot vanish propagates as blessed deletes, the vault
+    // converges dead, and further cycles write nothing.
+    await dev.engine.dbSyncCycle();
     dev.flush();
+    for (const id of warIds) expect(vault._row(id).deleted).toBe(true);
     const settledSeq = vault._seq();
-
-    // Converged: further scan+cycle rounds drop nothing, write nothing.
-    for (let round = 0; round < 2; round++) {
-      runVaultScan(dev, { scannedNotes: freshNotes });
-      expect(hasWarRows(dev.visible)).toBe(true);
-      const res = await dev.engine.dbSyncCycle();
-      expect(res.error).toBeUndefined();
-      dev.flush();
-    }
+    await dev.engine.dbSyncCycle();
+    dev.flush();
     expect(vault._seq()).toBe(settledSeq);
-    expect(hasWarRows(dev.visible)).toBe(true);
+    expect(hasWarRows(dev.visible)).toBe(false);
   });
 
-  // CORRECT behavior — currently false, deliberately pinned as the bug: a
-  // pulled copy of a row whose deletion tombstone is the newest word must not
-  // RE-ENTER state. If the apply path honored deletedObsidianKeys the way
-  // every deleting path does, the scan's drop would stick, the echo would be
-  // refused, and the war would converge instead of re-arming.
-  it.fails('a pulled echo of a tombstoned-and-older obsidian row does not re-enter state — the eviction sticks', async () => {
+  it('the eviction sticks: a pulled echo of a tombstoned-and-older row does not re-enter state (the former it.fails, flipped)', async () => {
     const vault = createMemoryVault();
     const dev = await seedWar(vault);
 
@@ -375,11 +264,193 @@ describe('the echo war — a tombstone honored by every deleting path and no app
     expect(hasWarRows(dev.visible)).toBe(false);
     await dev.engine.dbSyncCycle();
     dev.flush();
-    // CORRECT: the echo is refused and the rows stay gone…
+    // CORRECT (now true): the echo is refused and the rows stay gone…
     expect(hasWarRows(dev.visible)).toBe(false);
     // …so the next cycle propagates clean deletes and the vault converges dead.
     await dev.engine.dbSyncCycle();
     dev.flush();
     for (const id of warIds) expect(vault._row(id).deleted).toBe(true);
+  });
+
+  it('the orphan case in isolation: a tombstoned task with NO scannable file (outside the import window) converges through the gate alone — no self-heal needed', async () => {
+    // The April task's shape, alone: nothing can ever refresh its lastModified
+    // (its daily note is outside the 90-day scan window), so before the fix it
+    // had NO self-heal path and would loop until its tombstone's 60-day GC.
+    // The fix must converge it on its own — not carried by healable rows.
+    const vault = createMemoryVault();
+    const dev = makeLaggedDevice('solo', vault, {
+      ...EMPTY,
+      tasks: [warTask()],
+    });
+    await dev.engine.dbSyncCycle();
+    await dev.engine.dbSyncCycle();
+    dev.flush();
+    // The tombstone arrives AFTER the row is everywhere (historical order).
+    localStorage.setItem('day-planner-deleted-obsidian-keys', JSON.stringify({ [TASK_ID]: T_TOMB }));
+    dev.visible = { ...dev.visible, deletedObsidianKeys: { [TASK_ID]: T_TOMB } };
+
+    runVaultScan(dev); // the scan-merge drops it (tombstone ≥ lastModified)
+    expect(dev.visible.tasks.some((t) => t.id === TASK_ID)).toBe(false);
+
+    await dev.engine.dbSyncCycle(); // echo refused at the apply boundary
+    dev.flush();
+    expect(dev.visible.tasks.some((t) => t.id === TASK_ID)).toBe(false);
+
+    await dev.engine.dbSyncCycle(); // blessed delete propagates
+    dev.flush();
+    expect(vault._row(`tasks:${TASK_ID}`).deleted).toBe(true);
+
+    const settledSeq = vault._seq();
+    for (let round = 0; round < 3; round++) { // stays converged, no loop, no writes
+      runVaultScan(dev);
+      const res = await dev.engine.dbSyncCycle();
+      expect(res.error).toBeUndefined();
+      dev.flush();
+    }
+    expect(vault._seq()).toBe(settledSeq);
+    expect(dev.visible.tasks.some((t) => t.id === TASK_ID)).toBe(false);
+  });
+
+  it('legitimate restore: a copy whose lastModified beats its tombstone by even a small margin passes the gate, survives every merge, and syncs fleet-wide', async () => {
+    const vault = createMemoryVault();
+    const dev = await seedWar(vault);
+
+    // Converge the war first: the old copies die.
+    runVaultScan(dev);
+    await dev.engine.dbSyncCycle();
+    await dev.engine.dbSyncCycle();
+    dev.flush();
+    for (const id of warIds) expect(vault._row(id).deleted).toBe(true);
+
+    // A peer restores the task and re-creates one note — lastModified beats
+    // the tombstone by ONE SECOND. That must be enough: the LWW has no margin
+    // in the restore direction (strictly-newer wins).
+    const T_RESTORE = '2026-08-20T10:00:01.000Z'; // T_TOMB + 1s
+    const peer = makeLaggedDevice('peer', vault, {
+      ...EMPTY,
+      tasks: [warTask(T_RESTORE)],
+      dailyNotes: { [NOTE_A]: warNote(T_RESTORE, '## Quick Notes\n- restored') },
+      deletedObsidianKeys: TOMBSTONES,
+    });
+    await peer.engine.dbSyncCycle();
+    await peer.engine.dbSyncCycle();
+    peer.flush();
+    // The restoring device's own apply keeps the restored copies (revive-preserving).
+    expect(peer.visible.tasks.some((t) => t.id === TASK_ID)).toBe(true);
+    expect(peer.visible.dailyNotes[NOTE_A]).toBeTruthy();
+
+    // The original device pulls the restore: the gate passes it (newer than
+    // tombstone), and the scan-merge keeps it thereafter.
+    await dev.engine.dbSyncCycle();
+    dev.flush();
+    expect(dev.visible.tasks.some((t) => t.id === TASK_ID)).toBe(true);
+    expect(dev.visible.dailyNotes[NOTE_A]).toBeTruthy();
+    runVaultScan(dev);
+    expect(dev.visible.tasks.some((t) => t.id === TASK_ID)).toBe(true);
+    expect(dev.visible.dailyNotes[NOTE_A]).toBeTruthy();
+  });
+
+  it("clock-skew characterization: a restore whose lastModified lands BELOW the tombstone (inside the push guard's 5s epsilon) is dropped — the obsidian LWW has no epsilon, by pre-existing rule", async () => {
+    // The boundary, stated rather than assured: isObsidianTombstoned is
+    // tombstone ≥ lastModified with NO margin — the same rule the scan merge
+    // and rescue gate have always enforced; symmetric enforcement adopts it
+    // unchanged. A restoring device whose clock runs ~3s behind the deleting
+    // device stamps its restore below the tombstone and the restore loses —
+    // everywhere, including on the restoring device's own next apply (that
+    // was already true via the rescue gate before this fix). The push guard's
+    // 5s STALE_TOMBSTONE_EPSILON protects a different comparison (tombstone
+    // vs snapshot copy at the push diff) and does not soften this one. The
+    // recovery path is the same as ever: any later edit or vault write
+    // re-stamps lastModified past the tombstone and the copy revives.
+    const vault = createMemoryVault();
+    const dev = await seedWar(vault);
+    runVaultScan(dev);
+    await dev.engine.dbSyncCycle();
+    await dev.engine.dbSyncCycle();
+    dev.flush();
+
+    const T_SKEWED = '2026-08-20T09:59:57.000Z'; // tombstone − 3s: inside the guard's epsilon
+    const peer = makeLaggedDevice('skewed', vault, {
+      ...EMPTY,
+      tasks: [warTask(T_SKEWED)],
+      deletedObsidianKeys: TOMBSTONES,
+    });
+    await peer.engine.dbSyncCycle();
+    await peer.engine.dbSyncCycle();
+    peer.flush();
+    // The skewed restore is dropped by the restoring device's own apply…
+    expect(peer.visible.tasks.some((t) => t.id === TASK_ID)).toBe(false);
+    // …and never re-enters the original device either.
+    await dev.engine.dbSyncCycle();
+    dev.flush();
+    expect(dev.visible.tasks.some((t) => t.id === TASK_ID)).toBe(false);
+  });
+
+  it('re-creation with fresh content ends up stable everywhere (the self-resolution mechanism, still intact post-fix)', async () => {
+    const vault = createMemoryVault();
+    const dev = await seedWar(vault);
+
+    // The war converges dead first (post-fix behavior).
+    runVaultScan(dev);
+    await dev.engine.dbSyncCycle();
+    await dev.engine.dbSyncCycle();
+    dev.flush();
+
+    // Obsidian's own sync later delivers the notes with fresh mtimes AND
+    // changed text; the scan re-imports them newer than their tombstones.
+    const T_FRESH = '2026-08-26T19:30:00.000Z';
+    const freshNotes = {
+      [NOTE_A]: warNote(T_FRESH, '## Quick Notes\n- Testing on Windows\n- Back on the Mac'),
+      [NOTE_B]: warNote(T_FRESH, '## Quick Notes\n## Thoughts\n- resolved'),
+    };
+    runVaultScan(dev, { scannedNotes: freshNotes });
+    expect(dev.visible.dailyNotes[NOTE_A]).toBeTruthy();
+
+    await dev.engine.dbSyncCycle(); // pushes the newer-than-tombstone notes
+    dev.flush();
+    const settledSeq = vault._seq();
+    for (let round = 0; round < 2; round++) {
+      runVaultScan(dev, { scannedNotes: freshNotes });
+      const res = await dev.engine.dbSyncCycle();
+      expect(res.error).toBeUndefined();
+      dev.flush();
+    }
+    expect(vault._seq()).toBe(settledSeq); // stable — no war, no churn
+    expect(dev.visible.dailyNotes[NOTE_A]).toBeTruthy();
+    expect(dev.visible.dailyNotes[NOTE_B]).toBeTruthy();
+  });
+});
+
+describe('the file-tier half — deletedObsidianKeys reaches the merge (fixes #1448)', () => {
+  const localData = () => ({
+    ...EMPTY,
+    deletedObsidianKeys: TOMBSTONES,
+  });
+  // The remote FILE (WebDAV/iCloud) still carries the zombie rows a vaultless
+  // device kept re-uploading — the #1448 scenario.
+  const remoteData = () => ({
+    ...EMPTY,
+    tasks: [warTask()],
+    dailyNotes: { [NOTE_A]: warNote() },
+    deletedObsidianKeys: {},
+  });
+
+  it('a tombstoned-and-older row in the remote file is dropped from the merge output — and from the rewritten file', () => {
+    const result = mergeSyncData(localData(), remoteData(), 365);
+    expect(result.data.tasks.some((t) => t.id === TASK_ID)).toBe(false);
+    expect(result.data.dailyNotes[NOTE_A]).toBeUndefined();
+    // Both sides need the cleansed result: local applies it, the remote file
+    // is rewritten without the zombies (so nothing is left to resurrect when
+    // the tombstones hit the 60-day GC).
+    expect(result.remoteChanged).toBe(true);
+  });
+
+  it('a revived row in the remote file (newer than its tombstone) survives the merge and syncs', () => {
+    const remote = remoteData();
+    remote.tasks = [warTask('2026-08-21T10:00:00.000Z')]; // newer than T_TOMB
+    remote.dailyNotes = { [NOTE_A]: warNote('2026-08-21T10:00:00.000Z', 'restored') };
+    const result = mergeSyncData(localData(), remote, 365);
+    expect(result.data.tasks.some((t) => t.id === TASK_ID)).toBe(true);
+    expect(result.data.dailyNotes[NOTE_A]).toBeTruthy();
   });
 });

--- a/src/sync/obsidianTombstoneEchoWar.test.js
+++ b/src/sync/obsidianTombstoneEchoWar.test.js
@@ -1,0 +1,385 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import { setSyncPassphrase } from '@glance-apps/sync';
+import { createDbEngine } from './dbEngine.js';
+import { setVaultConfig } from './vaultConfig.js';
+import { createSyncCycleBreaker } from './syncBrakes.js';
+import { rescueUnsyncedTasks } from '../utils/rescueUnsyncedTasks.js';
+import { mergeObsidianTasks } from '../utils/mergeObsidianTasks.js';
+import { mergeObsidianDailyNotes } from '../utils/mergeObsidianDailyNotes.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE TOMBSTONE ECHO WAR — deterministic reproduction of the 2026-08-26 log
+// (three rows — one legacy Obsidian task, two daily notes — cycling pull-DELETE
+// → snapshot-diff-new → push written:3 → "honored deletes: Array(3)" →
+// propagating delete(s) → repeat, ~12 rounds, EVERY cycle successful, counts
+// oscillating 577/576 and 48/46 in lockstep).
+//
+// THE MECHANISM — one deletion channel, enforced asymmetrically:
+//
+//   The rows carry deletion tombstones newer than their lastModified
+//   (deletedObsidianKeys here; any bundle the guard blesses behaves the same).
+//   The tombstone is honored by EVERY PATH THAT DELETES:
+//     • the vault-scan merges drop the rows from state
+//       (mergeObsidianTasks / mergeObsidianDailyNotes, tombstone ≥ lastModified),
+//     • rescueUnsyncedTasks refuses to rescue them,
+//     • the commit merge blesses their mid-cycle vanish as an honored delete
+//       (commitMerge → partitionSnapshotDeletes unions ALL tombstone bundles),
+//     • the push guard propagates their snapshot vanish as 'tombstoned';
+//   …but by NO PATH THAT APPLIES:
+//     • applyEngineData admits pulled task rows with no deletedObsidianKeys
+//       gate on the merged list and applies dailyNotes as a PLAIN REPLACE,
+//     • the engine's pull applies any vault copy the mirror lacks.
+//
+//   The third ingredient is TIMING: back-to-back cycles (SSE multi-drains, the
+//   3s debounce, the visibility handler firing scan + cycle together) run
+//   against state whose React commit hasn't flushed yet — so a cycle can see
+//   the PREVIOUS state, diff it against the snapshot of the cycle before, and
+//   push the OPPOSITE of what the vault just did. The device fights its own
+//   echo: state-with-rows + snapshot-without → push NEW (resurrect); state-
+//   without + snapshot-with → blessed delete (kill); each push echoes back
+//   through the pull one cycle later and seeds the opposite half. This is the
+//   DB-tier sibling of issue #1448 (the same channel never reaching the
+//   FILE-tier merge): honored on the way out, ignored on the way in.
+//
+//   EVERY CYCLE SUCCEEDS — which is why none of the brakes engage: the circuit
+//   breaker (#1450) arms only on failure, the deferred retry (#1451) only on a
+//   gated cycle, and the acked-hash dedup only suppresses re-pushing content
+//   the vault already acked — these rows are ABSENT from the payload when they
+//   diff as deletes and freshly re-applied when they diff as new, so the dedup
+//   never sees a repeat. Pinned below as the success-loop gap.
+//
+//   SELF-RESOLUTION (the log's "survivors: Array(3)" flip): the war's substrate
+//   is `tombstone ≥ lastModified`. The moment live copies exist whose
+//   lastModified EXCEEDS the tombstones (a scan re-importing a note with a
+//   fresh file mtime; any genuine edit), commitMerge carries them into the
+//   commit as SURVIVORS, the next diff pushes them, and every comparison
+//   thereafter keeps them. LWW revive-beats-tombstone ends the war by design —
+//   it just cannot START until something bumps lastModified. Pinned below.
+//
+// HARNESS: real @glance-apps/sync engine + real crypto over the in-memory
+// vault (the #1449 pattern). The device models React's commit-visibility lag
+// explicitly: commitData lands in `pending`, `flush()` promotes it to the
+// state getData sees — the stand-in for the render flush racing back-to-back
+// drains. commitData models applyEngineData's verified behavior (tasks:
+// merged list unfiltered + real tombstone-gated rescue; dailyNotes: plain
+// replace). The scan step is the REAL mergeObsidianTasks /
+// mergeObsidianDailyNotes fed the localStorage tombstones, exactly as
+// useObsidianSync feeds them.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+function createMemoryVault() {
+  const salts = new Map();
+  const log = new Map();
+  let seq = 0;
+  return {
+    async getSalt(accountId) { return salts.get(accountId) || null; },
+    async putSalt(accountId, fresh) { if (!salts.has(accountId)) salts.set(accountId, fresh); return salts.get(accountId); },
+    async batch(app, { rows }) {
+      for (const r of rows) log.set(r.entityId, { entityId: r.entityId, seq: ++seq, envelope: r.envelope, deleted: false });
+      return { maxSeq: seq };
+    },
+    async deleteRow(app, entityId, accountId, opts = {}) {
+      log.set(entityId, { entityId, seq: ++seq, envelope: null, deleted: true, deletedAt: opts.deletedAt });
+      return { seq };
+    },
+    async list(app, { since }) {
+      const rows = [...log.values()].filter((r) => r.seq > since).sort((a, b) => a.seq - b.seq);
+      return { rows, hasMore: false };
+    },
+    async device() { return { updated: true }; },
+    _row(entityId) { return log.get(entityId) || null; },
+    _seq() { return seq; },
+  };
+}
+
+const FIXTURE_NOW = new Date('2026-08-26T19:00:00.000Z');
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(FIXTURE_NOW);
+  global.localStorage = memLocalStorage();
+  setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 't', accountId: 'acct' });
+  setSyncPassphrase('correct horse battery staple');
+});
+afterEach(() => { vi.useRealTimers(); });
+afterAll(() => { delete global.localStorage; });
+
+const clone = (x) => JSON.parse(JSON.stringify(x));
+
+// The cast, mirroring the log: a legacy Obsidian task and two daily notes,
+// each with lastModified OLDER than its deletion tombstone. Which bundle
+// blessed the April task in the field (deletedObsidianKeys, or a
+// deletedTaskIds entry inside the guard's 5s epsilon) doesn't change the
+// shape; deletedObsidianKeys is used for all three here.
+const TASK_ID = 'obsidian-2026-04-27-3a979k';
+const NOTE_A = '2026-08-10';
+const NOTE_B = '2026-08-11';
+const T_OLD = '2026-08-12T10:00:00.000Z';
+const T_TOMB = '2026-08-20T10:00:00.000Z';
+
+const warTask = (lastModified = T_OLD) => ({
+  id: TASK_ID,
+  title: 'Check in with Jake #obsidian',
+  duration: 30, color: 'bg-purple-600', completed: true, notes: '', subtasks: [],
+  importSource: 'obsidian', obsidianRawTitle: 'Check in with Jake', obsidianFileDate: '2026-04-27',
+  lastModified,
+});
+const warNote = (lastModified = T_OLD, text = '## Quick Notes\n- Testing on Windows') =>
+  ({ text, lastModified, fromObsidian: true });
+
+const TOMBSTONES = { [TASK_ID]: T_TOMB, [NOTE_A]: T_TOMB, [NOTE_B]: T_TOMB };
+
+const EMPTY = {
+  tasks: [], unscheduledTasks: [], recurringTasks: [], recycleBin: [], todayRoutines: [],
+  habits: [], goals: [], projects: [], gtdFrames: [], users: [], dailyNotes: {},
+  completedTaskUids: [], deletedTaskIds: {}, deletedObsidianKeys: {},
+};
+
+// A device with EXPLICIT commit-visibility lag (the React-flush stand-in):
+// getData reads `visible`; commitData computes the applyEngineData model into
+// `pending`; flush() promotes pending → visible. `flushOnPush` promotes the
+// PREVIOUS pending right after a vault write lands — the mid-cycle render
+// flush that produces the log's "honored deletes: Array(3)".
+function makeLaggedDevice(name, vault, initial, { flushOnPush = false, engineOverrides = {} } = {}) {
+  let visible = clone(initial);
+  let pending = null;
+  const dev = {
+    flush() { if (pending) { visible = pending; pending = null; } },
+    get visible() { return visible; },
+    set visible(v) { visible = v; },
+    get pending() { return pending; },
+  };
+  const realBatch = vault.batch.bind(vault);
+  const realDelete = vault.deleteRow.bind(vault);
+  const wrappedVault = Object.create(vault);
+  wrappedVault.batch = async (...a) => { const r = await realBatch(...a); if (flushOnPush) dev.flush(); return r; };
+  wrappedVault.deleteRow = async (...a) => { const r = await realDelete(...a); if (flushOnPush) dev.flush(); return r; };
+  dev.engine = createDbEngine({
+    vaultClient: wrappedVault,
+    storageKeyPrefix: `dev-${name}`,
+    deviceId: `device-${name}`,
+    nativeGetSyncKey: () => dev._key ?? null,
+    nativeStoreSyncKey: (v) => { dev._key = v; },
+    ...engineOverrides,
+    getData: () => clone(visible),
+    commitData: (d) => {
+      const prevTasks = visible.tasks;
+      pending = {
+        ...d,
+        // applyEngineData: merged list unfiltered + tombstone-gated rescue of
+        // prev-only rows. The gate BLOCKS a rescue of the war rows — but a
+        // pulled copy inside `d.tasks` walks straight in.
+        tasks: rescueUnsyncedTasks(d.tasks, prevTasks, d.deletedTaskIds || {}, undefined, d.deletedObsidianKeys || {}),
+        // applyEngineData: `setDailyNotes(data.dailyNotes)` — plain replace.
+        dailyNotes: d.dailyNotes,
+      };
+    },
+  });
+  return dev;
+}
+
+// The REAL vault-scan merge step, fed exactly what useObsidianSync feeds it.
+// The local scan does not contain the war rows (the task's note is outside the
+// 90-day import window; the notes scan to nothing here), so the tombstones
+// decide — and they DROP all three from visible state: the remover.
+function runVaultScan(dev, { scannedNotes = {} } = {}) {
+  let tombstones = {};
+  try { tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-obsidian-keys') || '{}'); } catch { tombstones = {}; }
+  dev.visible = {
+    ...dev.visible,
+    tasks: mergeObsidianTasks(dev.visible.tasks, [], new Set(), () => ({}), tombstones),
+    dailyNotes: mergeObsidianDailyNotes(dev.visible.dailyNotes, scannedNotes, tombstones),
+  };
+}
+
+const warIds = [`tasks:${TASK_ID}`, `dailyNotes:${NOTE_A}`, `dailyNotes:${NOTE_B}`];
+const hasWarRows = (data) =>
+  data.tasks.some((t) => t.id === TASK_ID) && !!data.dailyNotes[NOTE_A] && !!data.dailyNotes[NOTE_B];
+
+// Seed: state holds the rows (lastModified T_OLD) + the tombstones (T_TOMB);
+// two cycles so the engine leaves the HWM=0 full-seed path and has consumed
+// its own seed rows (echo drained); flush so visible is settled.
+async function seedWar(vault, opts = {}) {
+  localStorage.setItem('day-planner-deleted-obsidian-keys', JSON.stringify(TOMBSTONES));
+  const dev = makeLaggedDevice('mac', vault, {
+    ...EMPTY,
+    tasks: [warTask()],
+    dailyNotes: { [NOTE_A]: warNote(), [NOTE_B]: warNote(T_OLD, '## Quick Notes\n## Thoughts') },
+    deletedObsidianKeys: TOMBSTONES,
+  }, opts);
+  await dev.engine.dbSyncCycle();
+  await dev.engine.dbSyncCycle();
+  dev.flush();
+  expect(hasWarRows(dev.visible)).toBe(true);
+  return dev;
+}
+
+describe('the echo war — a tombstone honored by every deleting path and no applying path', () => {
+  it("reproduces the log's round anatomy: pull-DELETE supersedes the dirty marks → stale state re-pushes written:3 → honored deletes: 3 → the round re-arms", async () => {
+    const vault = createMemoryVault();
+    const dev = await seedWar(vault, { flushOnPush: true });
+
+    // Pre-state, as mid-war: the vault's latest rows for the three keys are
+    // DELETES (a previous round's blessed propagation), and the snapshot lacks
+    // them (saved from that round's post-delete mirror) — while visible state
+    // still HAS them (the flush lagged).
+    for (const id of warIds) await vault.deleteRow('dayglance', id, 'acct', { deletedAt: new Date(T_TOMB).getTime() });
+    const snapKey = 'dev-mac-db-sync-snapshot';
+    const snap = JSON.parse(localStorage.getItem(snapKey));
+    for (const id of warIds) delete snap[id];
+    localStorage.setItem(snapKey, JSON.stringify(snap));
+    expect(hasWarRows(dev.visible)).toBe(true);
+
+    // ROUND A (log: "[pull] DELETE ×3 … did NOT write … dirty ids: Array(0) …
+    // snapshot-diff new ×3"): the diff marks the rows NEW (state vs snapshot),
+    // the pull's delete rows supersede the dirty marks (deletedAt ≥
+    // lastModified — the engine's LWW), nothing is written, and the commit
+    // carries the deletions — but only into `pending`; visible state still
+    // shows the rows.
+    const seqA0 = vault._seq();
+    const resA = await dev.engine.dbSyncCycle();
+    expect(resA.error).toBeUndefined();
+    expect(vault._seq()).toBe(seqA0);            // did NOT write this cycle
+    expect(hasWarRows(dev.visible)).toBe(true);  // flush hasn't landed
+
+    // ROUND B (log: "written:3 … [commit] mid-cycle merge — survivors:
+    // Array(0) honored deletes: Array(3)"): the still-stale state re-diffs the
+    // rows as NEW and pushes them — RESURRECTING the vault rows the previous
+    // round deleted. The flush lands right after the push (flushOnPush), so
+    // the commit merge sees live state WITHOUT the rows, and — because the
+    // tombstones bless the vanish — HONORS the deletes into the commit.
+    const resB = await dev.engine.dbSyncCycle();
+    expect(resB.error).toBeUndefined();
+    for (const id of warIds) expect(vault._row(id).deleted).toBe(false); // resurrected
+    expect(hasWarRows(dev.pending ?? dev.visible)).toBe(false);          // honored deletes carried
+
+    // ROUND C: the flushed state now lacks the rows while the snapshot (saved
+    // pre-merge, WITH the rows) still holds them → the guard blesses the
+    // vanish ('tombstoned') — and the pull echoes round B's upserts straight
+    // back into the mirror, which the commit RE-ADMITS into state. The war has
+    // re-armed itself; nothing converged.
+    dev.flush();
+    expect(hasWarRows(dev.visible)).toBe(false);
+    const resC = await dev.engine.dbSyncCycle();
+    expect(resC.error).toBeUndefined();
+    dev.flush();
+    expect(hasWarRows(dev.visible)).toBe(true);  // re-admitted — appear/disappear, forever
+  });
+
+  it('pins the sustained war: scan drops, the echo re-admits, the push re-writes — vault traffic every round, every cycle successful, rows never converge', async () => {
+    const vault = createMemoryVault();
+    const dev = await seedWar(vault);
+
+    let lastSeq = vault._seq();
+    for (let round = 1; round <= 3; round++) {
+      runVaultScan(dev);                          // remover: rows leave visible state
+      expect(hasWarRows(dev.visible)).toBe(false);
+      const res = await dev.engine.dbSyncCycle(); // echo re-applies → push re-writes → commit re-admits
+      expect(res.error).toBeUndefined();
+      dev.flush();
+      expect(hasWarRows(dev.visible)).toBe(true); // …and they are back
+      expect(vault._seq()).toBeGreaterThan(lastSeq); // the vault was written AGAIN
+      lastSeq = vault._seq();
+    }
+    for (const id of warIds) expect(vault._row(id).deleted).toBe(false); // never converged
+  });
+
+  it('confirms the brake gap: every cycle succeeds — the breaker never strikes, nothing is gated, no deferred retry is armed', async () => {
+    const vault = createMemoryVault();
+    const breaker = createSyncCycleBreaker({ random: () => 0 });
+    const onFailure = vi.spyOn(breaker, 'onFailure');
+    const armed = [];
+    const dev = await seedWar(vault, {
+      engineOverrides: {
+        cycleBreaker: breaker,
+        retryTimers: { setTimeoutFn: (fn, ms) => { armed.push(ms); return { fn, ms }; }, clearTimeoutFn: () => {} },
+      },
+    });
+
+    for (let round = 0; round < 4; round++) {
+      runVaultScan(dev);
+      const res = await dev.engine.dbSyncCycle();
+      expect(res.error).toBeUndefined();
+      expect(res.throttled).toBeUndefined();
+      dev.flush();
+    }
+    expect(onFailure).not.toHaveBeenCalled(); // failure-brakes are structurally blind to a success loop
+    expect(armed).toEqual([]);
+  });
+
+  it("pins the self-resolution: copies whose lastModified beats the tombstones end the war (the log's 'survivors' flip) — and it STAYS ended", async () => {
+    const vault = createMemoryVault();
+    const dev = await seedWar(vault);
+
+    for (let round = 0; round < 2; round++) { // a couple of war rounds first
+      runVaultScan(dev);
+      await dev.engine.dbSyncCycle();
+      dev.flush();
+    }
+    expect(hasWarRows(dev.visible)).toBe(true);
+
+    // The resolution event: the scan re-imports the notes with FRESH file
+    // mtimes AND changed text (Obsidian's own sync delivering updated files),
+    // and the task's copy is re-stamped past its tombstone. The changed text
+    // matters: mergeObsidianDailyNotes carries the OLD lastModified forward
+    // for UNCHANGED text (so unedited notes don't re-push every scan), which
+    // means a same-text rescan still loses to the tombstone — only genuinely
+    // newer content (or a fresh import into an absent slot) can end the war.
+    const T_FRESH = '2026-08-26T19:30:00.000Z';
+    const freshNotes = {
+      [NOTE_A]: warNote(T_FRESH, '## Quick Notes\n- Testing on Windows\n- Back on the Mac'),
+      [NOTE_B]: warNote(T_FRESH, '## Quick Notes\n## Thoughts\n- resolved'),
+    };
+    dev.visible = {
+      ...dev.visible,
+      tasks: dev.visible.tasks.map((t) => (t.id === TASK_ID ? { ...t, lastModified: T_FRESH } : t)),
+    };
+    runVaultScan(dev, { scannedNotes: freshNotes });
+    expect(hasWarRows(dev.visible)).toBe(true); // fresh copies now BEAT the tombstones — nothing drops them
+
+    await dev.engine.dbSyncCycle(); // pushes the newer-than-tombstone copies
+    dev.flush();
+    const settledSeq = vault._seq();
+
+    // Converged: further scan+cycle rounds drop nothing, write nothing.
+    for (let round = 0; round < 2; round++) {
+      runVaultScan(dev, { scannedNotes: freshNotes });
+      expect(hasWarRows(dev.visible)).toBe(true);
+      const res = await dev.engine.dbSyncCycle();
+      expect(res.error).toBeUndefined();
+      dev.flush();
+    }
+    expect(vault._seq()).toBe(settledSeq);
+    expect(hasWarRows(dev.visible)).toBe(true);
+  });
+
+  // CORRECT behavior — currently false, deliberately pinned as the bug: a
+  // pulled copy of a row whose deletion tombstone is the newest word must not
+  // RE-ENTER state. If the apply path honored deletedObsidianKeys the way
+  // every deleting path does, the scan's drop would stick, the echo would be
+  // refused, and the war would converge instead of re-arming.
+  it.fails('a pulled echo of a tombstoned-and-older obsidian row does not re-enter state — the eviction sticks', async () => {
+    const vault = createMemoryVault();
+    const dev = await seedWar(vault);
+
+    runVaultScan(dev);
+    expect(hasWarRows(dev.visible)).toBe(false);
+    await dev.engine.dbSyncCycle();
+    dev.flush();
+    // CORRECT: the echo is refused and the rows stay gone…
+    expect(hasWarRows(dev.visible)).toBe(false);
+    // …so the next cycle propagates clean deletes and the vault converges dead.
+    await dev.engine.dbSyncCycle();
+    dev.flush();
+    for (const id of warIds) expect(vault._row(id).deleted).toBe(true);
+  });
+});

--- a/src/utils/obsidianDeletions.js
+++ b/src/utils/obsidianDeletions.js
@@ -111,3 +111,67 @@ export function addObsidianTombstones(tombstones, keys, deletedAtIso) {
   }
   return out;
 }
+
+// ─── Symmetric enforcement at the APPLY boundary ─────────────────────────────
+//
+// For a long time deletedObsidianKeys was honored on the way OUT but ignored
+// on the way IN: every path that DELETES consulted it (the vault-scan merges,
+// the rescue gate, the commit merge's honored-delete blessing, the push
+// guard's 'tombstoned' propagation), while no path that APPLIES did —
+// applyEngineData admitted pulled task rows unfiltered and replaced dailyNotes
+// wholesale, and the file-tier merge unioned tombstoned rows straight back in
+// from the remote file (issue #1448). That asymmetry is a war generator: a
+// tombstoned row deleted locally is re-admitted by the next pull/merge, pushed
+// back to the vault as "new", deleted again, forever — the tombstone echo war
+// (src/sync/obsidianTombstoneEchoWar.test.js), and #1448's vaultless-device
+// resurrection, are the DB-tier and file-tier faces of the same missing gate.
+//
+// These two helpers ARE that gate, shared by both tiers so the rule can never
+// fork again: applyEngineData (the single ingress for DB commits AND file-tier
+// applies) and mergeSyncData (the file-tier merge output, which is also what
+// gets uploaded — cleansing it stops the remote file from carrying zombies
+// past their tombstones' 60-day GC, where they would otherwise resurrect).
+//
+// The comparison is the SAME last-writer-wins isObsidianTombstoned every
+// deleting path uses — revive-preserving by construction: a copy whose
+// lastModified is strictly newer than its tombstone (a genuine re-creation or
+// restore) passes untouched and propagates normally. Note the rule has NO
+// epsilon (unlike the push guard's 5s stale-tombstone margin): a restore whose
+// lastModified lands AT or BELOW the tombstone — e.g. a restoring device with
+// a skewed-behind clock — is dropped, exactly as the scan merge and rescue
+// gate have always treated it. Symmetric enforcement adopts the existing rule
+// unchanged; it does not invent a new boundary.
+
+/**
+ * Drop Obsidian-imported task rows whose deletion tombstone is at least as new
+ * as the row (LWW). Non-Obsidian rows pass through untouched — the channel's
+ * keys are Obsidian task ids and note dates by construction. Pure; returns the
+ * SAME array when nothing changed (no spurious re-render/diff churn).
+ *
+ * @param {object[]} tasks
+ * @param {Record<string,string>} tombstones  deletedObsidianKeys {key → ISO}
+ */
+export function dropTombstonedObsidianTasks(tasks, tombstones) {
+  if (!Array.isArray(tasks) || !tombstones || Object.keys(tombstones).length === 0) return tasks || [];
+  const out = tasks.filter((t) =>
+    !(t && t.importSource === 'obsidian' && isObsidianTombstoned(tombstones, String(t.id), t.lastModified)));
+  return out.length === tasks.length ? tasks : out;
+}
+
+/**
+ * Drop daily-note entries whose deletion tombstone is at least as new as the
+ * note (LWW). Pure; returns the SAME map when nothing changed.
+ *
+ * @param {Record<string, {text:string, lastModified?:string}>} notes
+ * @param {Record<string,string>} tombstones  deletedObsidianKeys {key → ISO}
+ */
+export function dropTombstonedObsidianNotes(notes, tombstones) {
+  if (!notes || typeof notes !== 'object' || !tombstones || Object.keys(tombstones).length === 0) return notes || {};
+  let changed = false;
+  const out = {};
+  for (const [date, note] of Object.entries(notes)) {
+    if (isObsidianTombstoned(tombstones, date, note && note.lastModified)) { changed = true; continue; }
+    out[date] = note;
+  }
+  return changed ? out : notes;
+}

--- a/src/utils/obsidianDeletions.test.js
+++ b/src/utils/obsidianDeletions.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { detectObsidianDeletions, isObsidianTombstoned, addObsidianTombstones, obsidianKeyDate } from './obsidianDeletions.js';
+import { detectObsidianDeletions, isObsidianTombstoned, addObsidianTombstones, obsidianKeyDate, dropTombstonedObsidianTasks, dropTombstonedObsidianNotes } from './obsidianDeletions.js';
 
 describe('detectObsidianDeletions (conservative)', () => {
   it('reports a key this device previously scanned and no longer sees', () => {
@@ -124,5 +124,45 @@ describe('detectObsidianDeletions — keyDates sidecar for dateless block-id key
       { keyDates: { 'obsidian-2026-06-22-abc': '2026-01-01' } },
     );
     expect(r.deletions).toEqual(['obsidian-2026-06-22-abc']);
+  });
+});
+
+describe('dropTombstonedObsidianTasks / dropTombstonedObsidianNotes — the shared apply-boundary gate', () => {
+  const T_OLD = '2026-08-12T10:00:00.000Z';
+  const T_TOMB = '2026-08-20T10:00:00.000Z';
+  const T_NEWER = '2026-08-20T10:00:01.000Z';
+  const obsTask = (id, lastModified, extra = {}) => ({ id, importSource: 'obsidian', lastModified, ...extra });
+
+  it('drops an obsidian row whose tombstone is at least as new (LWW), keeps a strictly-newer revive', () => {
+    const tombs = { a: T_TOMB, b: T_TOMB, tie: T_TOMB };
+    const out = dropTombstonedObsidianTasks(
+      [obsTask('a', T_OLD), obsTask('b', T_NEWER), obsTask('tie', T_TOMB)], tombs,
+    );
+    // 'a' (older) and 'tie' (equal — delete wins ties, matching isObsidianTombstoned) drop; 'b' revives.
+    expect(out.map((t) => t.id)).toEqual(['b']);
+  });
+
+  it('never touches non-obsidian rows, even on a key collision', () => {
+    const tombs = { plain: T_TOMB };
+    const rows = [{ id: 'plain', lastModified: T_OLD }];
+    expect(dropTombstonedObsidianTasks(rows, tombs)).toBe(rows); // same array — untouched
+  });
+
+  it('returns the SAME array/map when nothing changes (no spurious diff churn)', () => {
+    const rows = [obsTask('x', T_NEWER)];
+    expect(dropTombstonedObsidianTasks(rows, { x: T_TOMB })).toBe(rows);
+    expect(dropTombstonedObsidianTasks(rows, {})).toBe(rows);
+    const notes = { '2026-08-10': { text: 'n', lastModified: T_NEWER } };
+    expect(dropTombstonedObsidianNotes(notes, { '2026-08-10': T_TOMB })).toBe(notes);
+  });
+
+  it('drops a tombstoned-and-older note, keeps a re-created one', () => {
+    const tombs = { '2026-08-10': T_TOMB, '2026-08-11': T_TOMB };
+    const out = dropTombstonedObsidianNotes({
+      '2026-08-10': { text: 'zombie', lastModified: T_OLD },
+      '2026-08-11': { text: 'recreated', lastModified: T_NEWER },
+      '2026-08-12': { text: 'untombstoned', lastModified: T_OLD },
+    }, tombs);
+    expect(Object.keys(out).sort()).toEqual(['2026-08-11', '2026-08-12']);
   });
 });


### PR DESCRIPTION
## Summary

**Honored on the way out, ignored on the way in** — that asymmetry, now stated in the code where it lives, is what this PR removes. `deletedObsidianKeys` was consulted by every deleting path (scan merges, rescue, the commit merge's honored-delete blessing, the push guard) and by no applying path. The tombstone echo war captured live on 2026-08-26 is its DB-tier face; **#1448** is its file-tier face. Per the decision: **both fixed together, one shared gate**, because the apply-side fix alone leaves the remote file carrying zombies that resurrect the day their tombstones hit the 60-day GC — and because two implementations of one rule is how the asymmetry happened in the first place.

**Stacked on #1453** (the repro); merging this subsumes it. **Closes #1448.**

### The shared gate

`dropTombstonedObsidianTasks` / `dropTombstonedObsidianNotes` in `utils/obsidianDeletions.js` — the exact `isObsidianTombstoned` LWW every deleting path already uses, adopted unchanged (no epsilon; a strictly-newer revive passes). Applied at **three ingresses**:

1. **`applyEngineData`** — filters the merged task lists, gates the `dailyNotes` replace. A pulled echo of a tombstoned-and-older row no longer re-enters state.
2. **`mergeSyncData`** (file tier — the #1448 fix) — cleanses the merge *output*, which is also the uploaded file, so nothing is left in the remote file to resurrect after tombstone GC. Change flags raised so the cleansed file is rewritten; the v4.7.x fleet handles it via its own (already-tombstone-aware) rescue gate and scan merges.
3. **`dbEngine`'s pull `applyRemoteEntity`** — the deepest ingress, and a finding the repro caught rather than let me assume: with only the app-level gates, the engine fights the war *entirely at the mirror level* — the blessed delete-marks find the pull-re-applied rows live in the mirror and re-upsert them, so the vault seq climbs every cycle while state stays clean. The gate here is what makes the first blessed delete actually stick.

## Tests (the two explicitly-requested cases included)

- **The #1453 `it.fails` flipped**: a pulled echo of a tombstoned-and-older row does not re-enter state; the eviction sticks and the vault converges dead.
- **Round anatomy, collapsed**: the log's A/B rounds still occur once (the visibility lag can still cause one stale re-push), then the echo is refused and the war converges dead with no further writes — instead of re-arming.
- **Legitimate restore (requested)**: a restore beating its tombstone by **one second** passes the gate on the restoring device, survives every merge, and syncs fleet-wide.
- **Clock-skew characterization (requested)**: a restore stamped 3s *below* the tombstone (inside the push guard's 5s epsilon) is **dropped** — the obsidian LWW has no epsilon, by pre-existing rule (the scan merge and rescue gate have always enforced exactly this; the guard's epsilon protects a different comparison). Stated in code and test, not assured. Recovery path unchanged: any later edit or vault write re-stamps past the tombstone.
- **The orphan case, in isolation (requested)**: a tombstoned task with no scannable file (outside the 90-day import window — the April task's shape) converges through the gate alone in two cycles, with no self-healing rows to carry it, and stays converged with zero further writes.
- **File tier**: zombies in the remote file are dropped from the merge output (and the rewritten file); revives newer than their tombstones survive and sync.
- Helper unit tests: LWW drop/keep/tie, non-obsidian rows untouched even on key collision, same-reference returns (no diff churn).

Full suite: **2248 passed, 0 expected fail** — the suite carries no pinned-broken behavior. Lint clean.

## Not in scope

The success-loop brake gap (a write-every-cycle war evading all failure-armed brakes) — filed separately with the analysis, per the decision.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_