### PR TITLE
Phase 2 read/write release split: full read path ships first, block-id emission gated

### DIFF
--- a/docs/obsidian-buildout-spec.md
+++ b/docs/obsidian-buildout-spec.md
@@ -150,6 +150,18 @@ The plugin runs unlisted (BRAT or manual install) through Phases 5 and 6. Submis
 
 ---
 
+### 3.9 Staged vault-format rollout: read-support first, write-support one release later
+
+**Standing rule, not a one-time decision.** Any change to what dayGLANCE WRITES into the vault ships in two releases: first a release whose parser fully understands the new format but never emits it, then — one release later, once the reader has propagated — a release that enables emission. The gate is a build-time constant (`src/utils/obsidianWritePolicy.js`), never a user-facing setting: a setting pushes correctness onto the user, and someone always has a device they forgot about.
+
+**Rationale.** The fleet spans five platforms on three release channels (dev, Developer ID, MAS, Play, App Store/TestFlight) whose store approvals never align, plus always-on appliances with vault access that lag behind updates. Every write-format change therefore has a mixed-version window measured in days. A client that does not understand a format token reads it as **title text**, hashes it into a brand-new content-derived id, and imports a duplicate that syncs fleet-wide — stable duplicates for the whole mixed window, surviving the update in the heavy-stamp case (analyzed for `^dg-` block ids, then observed live 2026-08-26). Shipping the reader first means that by the time any device emits the new format, every device can read it — the mixed window pairs a token-aware reader with the writer and no mangled identity can ever be minted.
+
+**Read support means the FULL read semantics, not "strip and ignore."** A device that strips a token but still derives the old identity (e.g. hashing the clean title into a legacy id) keeps re-producing retired identities after a write-release device retires them — a milder seed of the same divergence. The read release carries everything except emission: recognition, identity adoption, bridging, dedup rules.
+
+**Applies next to Phase 4** (Tasks emoji metadata, Dataview inline fields, frontmatter) — a strictly larger write surface than block ids: each of those formats gets a read release before any device emits it.
+
+---
+
 ## 4. Obsidian community directory constraints
 
 Relevant from Phase 5 onward. Current as of the May 2026 policy overhaul.
@@ -233,7 +245,7 @@ Delivered by PRs #1435, #1444, #1445, and #1446; shipped with 4.7.0. See section
 
 **Goal.** Give every dayGLANCE-managed task a stable identity in the vault that survives edits, reordering, and reformatting.
 
-**Status.** Part A delivered by PR #1439, riding the first release after 4.7.0. The scope below records the split and the semantics decided during that implementation.
+**Status.** Part A delivered by PR #1439. Ships in TWO releases per the staged-rollout rule (3.9): the **read release** carries the full Part A read path — token recognition, `obsidian-dg-` adoption, the legacy bridge, first-occurrence-wins — with emission gated OFF (`OBSIDIAN_BLOCK_ID_WRITES = false` in `src/utils/obsidianWritePolicy.js`; new tasks and writes keep pre-Phase-2 behavior, and tokens already present in lines are preserved, never stripped). The **write release** is the one-line flip of that constant, once the read release has propagated to every channel. The scope below records the split and the semantics decided during implementation.
 
 **Rationale.** Task identity is currently implicit, positional or text-matched. Every bug class fought in GLANCEvault (resurrection, phantom deletes, duplication) has a latent analog here and will surface as write surface grows. This is the highest-value single change in the plan.
 
@@ -291,6 +303,8 @@ Delivered by PRs #1435, #1444, #1445, and #1446; shipped with 4.7.0. See section
 - Frontmatter on generated notes, so they are queryable from Dataview and Bases.
 
 **Rationale.** This is the cheapest real user-facing win in the plan and the thing that makes a directory listing compelling to someone already living in their vault.
+
+**Rollout.** Subject to the staged-rollout rule (3.9), format by format: a release that parses Tasks emoji / Dataview fields / frontmatter without emitting them, then the emitting release. This surface is strictly larger than block ids — an emoji date or an inline field misread as title text corrupts identity hashing exactly the way a `^dg-` token did.
 
 ---
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { Plus, Clock, X, GripVertical, ChevronUp, ChevronDown, ChevronLeft, Chev
 import { mergeTaskArrays, mergeSyncData } from './mergeSync.js';
 import { hasNativeCalendar, electronGetCalendars, electronGetEventsByDate, electronRequestCalendarAccess, nativeEventToTask } from './utils/nativeCalendar.js';
 import { isNativeAndroid, isNativeApp, isNativeIOS, nativeShareFile, nativeShowTaskNotification, nativeGetPendingAction, nativeSyncReminders, nativeGetEvents, nativeUpdateEvent, nativeGetCalendars, nativeHttpRequest, nativeWriteDailyNote, nativeClearVault, nativeEnterFocusMode, nativeExitFocusMode, nativeIsDndPermissionGranted, nativeRequestDndPermission, nativeGetWidgetPendingAction, triggerHaptic } from './native.js';
-import { writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, simpleHash as obsidianSimpleHash, generateBlockId as obsidianGenerateBlockId, appIdForBlockId as obsidianAppIdForBlockId, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
+import { writeDailyNoteFile, writeDailyNoteNative, readDailyNoteFresh, readDailyNoteNative, simpleHash as obsidianSimpleHash, buildNewObsidianTaskMeta, appendTaskToDailyNote, appendTaskToDailyNoteNative } from './obsidian.js';
 import { loadAIConfig, saveAIConfig, aiComplete, aiJSON, testConnection, DEFAULT_CONFIG, PROVIDER_MODELS, PROVIDER_LABELS } from './ai.js';
 import { taskSuggestSystemPrompt, taskSuggestUserPrompt, frameNudgeSystemPrompt, frameNudgeUserPrompt, rescheduleSystemPrompt, rescheduleUserPrompt, aiSubtasksSystemPrompt, aiSubtasksUserPrompt, weeklySummarySystemPrompt, weeklySummaryUserPrompt, smartScheduleSystemPrompt, smartScheduleUserPrompt } from './ai-prompts.js';
 import { gatherTrmnlData, pushToTrmnl, TRMNL_MARKUP_FULL, TRMNL_MARKUP_HALF_HORIZONTAL, TRMNL_MARKUP_HALF_VERTICAL, TRMNL_MARKUP_QUADRANT } from './trmnl.js';
@@ -6873,22 +6873,11 @@ const DayPlanner = () => {
     exitFocusModeRef,
     playFocusSound,
     getObsidianTaskMeta: obsidianConfig?.enabled && obsidianVaultHandleRef.current
-      ? (rawTitle) => {
-          const todayStr = new Date().toISOString().split('T')[0];
-          // Phase 2: identity is a ^dg- block id generated HERE, at creation/
-          // write time, and persisted on the task — never derived from content
-          // at read time. The appended vault line carries the same id (see
-          // buildObsidianTaskLine), so the next scan parses it back to exactly
-          // this task id and the round trip converges without text matching.
-          const blockId = obsidianGenerateBlockId();
-          return {
-            id: obsidianAppIdForBlockId(blockId),
-            importSource: 'obsidian',
-            obsidianRawTitle: rawTitle,
-            obsidianFileDate: todayStr,
-            obsidianBlockId: blockId,
-          };
-        }
+      // Creation-time identity — gated by the read/write release split: dg
+      // block id on the write release, legacy content-derived id on the read
+      // release. See obsidian.js buildNewObsidianTaskMeta and
+      // utils/obsidianWritePolicy.js.
+      ? (rawTitle) => buildNewObsidianTaskMeta(rawTitle, new Date().toISOString().split('T')[0])
       : null,
     onWriteObsidianTask: obsidianConfig?.enabled && obsidianVaultHandleRef.current
       ? (task) => {

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -25,6 +25,7 @@ import {
   RETIRED_TASK_IDS_STORAGE_KEY,
   RETIRED_ID_DUAL_WRITE,
 } from '../utils/retiredTaskIds.js';
+import { blockIdWritesEnabled } from '../utils/obsidianWritePolicy.js';
 
 /**
  * Obsidian vault sync — extracted from App.jsx (see "App.jsx — Ongoing
@@ -570,7 +571,14 @@ export default function useObsidianSync({
       // matched line, and the assignment is committed to app state only when
       // the write reports success. Existing untagged tasks acquire ids
       // naturally as they get edited; there is no sweep.
-      const assignBlockId = task.obsidianBlockId ? null : generateBlockId();
+      //
+      // GATED by the read/write release split (utils/obsidianWritePolicy.js):
+      // on the READ release no NEW id is ever minted — this is one of the two
+      // emit sites the gate covers. A task that ALREADY carries a block id
+      // (adopted from a vault another release stamped) keeps writing it —
+      // writeBlockId preserves existing tokens unconditionally, because
+      // stripping one would destroy identity other devices rely on.
+      const assignBlockId = (!task.obsidianBlockId && blockIdWritesEnabled()) ? generateBlockId() : null;
       const writeBlockId = task.obsidianBlockId || assignBlockId;
 
       // Title bookkeeping is COMPUTED here but applied only on write success:

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -19,6 +19,7 @@ import {
   validateVaultFolderSetting,
 } from './utils/obsidianFilename.js';
 import { unportableEntryReason } from './utils/vaultPortability.js';
+import { blockIdWritesEnabled } from './utils/obsidianWritePolicy.js';
 
 // How far back the Obsidian daily-note scan reads, in days. DELIBERATELY FIXED and
 // decoupled from the calendar "Keep past events" retention (syncRetentionDays):
@@ -852,6 +853,34 @@ export function generateBlockId() {
  * the legacy `obsidian-<date>-<hash>` id lacks (two devices that first import
  * before/after a retitle derive different ids and cloud merge duplicates).
  */
+// Identity metadata for a NEW vault-bound task created in dayGLANCE — one of
+// the two block-id EMIT sites (the other is the writeback's opportunistic
+// stamp in useObsidianSync), both gated by the read/write release split
+// (utils/obsidianWritePolicy.js).
+//
+// WRITE release: identity is a ^dg- block id generated HERE, at creation
+// time, and persisted on the task — never derived from content at read time.
+// The appended vault line carries the same id (blockIdSuffix via the append
+// path), so the next scan parses it back to exactly this task id and the
+// round trip converges without text matching.
+//
+// READ release: the pre-Phase-2 content-derived identity, so no device emits
+// a token before the whole fleet can read one. The hash input is the same
+// rawTitle a rescan of the (token-less) appended line will hash, so the round
+// trip still converges — exactly as it did before Phase 2.
+export function buildNewObsidianTaskMeta(rawTitle, todayStr) {
+  const base = {
+    importSource: 'obsidian',
+    obsidianRawTitle: rawTitle,
+    obsidianFileDate: todayStr,
+  };
+  if (!blockIdWritesEnabled()) {
+    return { ...base, id: `obsidian-${todayStr}-${simpleHash(rawTitle)}` };
+  }
+  const blockId = generateBlockId();
+  return { ...base, id: appIdForBlockId(blockId), obsidianBlockId: blockId };
+}
+
 export function appIdForBlockId(blockId) {
   return `obsidian-dg-${blockId}`;
 }

--- a/src/obsidian.phase2Transition.test.js
+++ b/src/obsidian.phase2Transition.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { __setBlockIdWritesForTests } from './utils/obsidianWritePolicy.js';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Phase 2 cross-device transition (legacy content-derived id → ^dg- block id).
@@ -200,8 +201,13 @@ const legacyRow = (extra = {}) => ({
   ...extra,
 });
 
-beforeEach(() => { vi.useFakeTimers(); });
-afterEach(() => { vi.useRealTimers(); delete globalThis.localStorage; });
+// This suite tests WRITE-RELEASE behavior (stamping, id migration, retirement
+// recording), so the read/write release gate is forced ON — the shipped
+// default is read-only until the write release flips it
+// (utils/obsidianWritePolicy.js). Read-release behavior has its own suite:
+// obsidian.readRelease.test.js.
+beforeEach(() => { vi.useFakeTimers(); __setBlockIdWritesForTests(true); });
+afterEach(() => { vi.useRealTimers(); __setBlockIdWritesForTests(null); delete globalThis.localStorage; });
 
 // ═══ (a) A stamped; warm B still holds the legacy-keyed row ═════════════════
 describe('transition (a): warm device with the legacy row scans the freshly-tagged vault', () => {
@@ -537,5 +543,86 @@ describe('transition tombstone: the file-tier union no longer resurrects retired
     const obsidianTombs = { [LEGACY_ID]: '2026-08-21T00:00:00.000Z' };
     const { merged } = mergeTaskArrays([dgRow], [legacyRow(), dgRow], obsidianTombs);
     expect(merged.map(t => t.id)).toEqual([DG_ID]);
+  });
+});
+
+// ═══ READ RELEASE — the staged-rollout split ═══════════════════════════════
+// The read/write release split (utils/obsidianWritePolicy.js): the READ
+// release carries the FULL Phase 2 read path — token recognition, dg-id
+// adoption, the legacy bridge hint, first-occurrence-wins — but never EMITS a
+// block id. A pre-Phase-2 client reads a `^dg-` token as title text, hashes
+// it into a brand-new id, and imports a fleet-wide duplicate; shipping the
+// reader first means that by the time any device stamps, every device
+// understands the stamp. The file-level beforeEach forces the gate ON (the
+// suites above test the write release); this describe forces it OFF — the
+// shipped read-release default.
+describe('read release: full read path, zero emission', () => {
+  beforeEach(() => { __setBlockIdWritesForTests(false); });
+
+  const snapshotOf = (id, over = {}) => ({
+    [id]: { completed: false, startTime: null, duration: 45, title: `${TITLE} #obsidian`, date: null, ...over },
+  });
+
+  it('untagged completion writes the line WITHOUT a token: no id mint, no migration, no tombstones — v4.7.0 write parity', async () => {
+    const vault = { [NOTE]: `## Tasks\n- [ ] ${TITLE}` };
+    const device = makeDevice({ inbox: [legacyRow({ completed: true })] });
+    await runWriteback(device, vault, snapshotOf(LEGACY_ID));
+
+    const t = device.inbox[0];
+    expect(vault[NOTE]).toContain(`- [x] ${TITLE}`);
+    expect(vault[NOTE]).not.toContain('^dg-');       // nothing emitted
+    expect(t.id).toBe(LEGACY_ID);                    // no id migration
+    expect(t.obsidianBlockId).toBeUndefined();
+    expect(deletedTaskIdsOf(device)).toEqual({});    // nothing retired
+    expect(readJson(device, 'day-planner-retired-task-ids', {})).toEqual({});
+  });
+
+  it('a task ADOPTED from an already-stamped vault keeps writing its existing token — the gate stops minting, never strips', async () => {
+    const vault = { [NOTE]: `## Tasks\n- [ ] ${TITLE} ^dg-aaaaaaaa` };
+    const device = makeDevice({
+      inbox: [legacyRow({ id: DG_ID, obsidianBlockId: 'aaaaaaaa', completed: true })],
+    });
+    await runWriteback(device, vault, snapshotOf(DG_ID));
+
+    expect(vault[NOTE]).toContain(`- [x] ${TITLE} ^dg-aaaaaaaa`); // token preserved
+    expect(device.inbox[0].id).toBe(DG_ID);
+  });
+
+  it('untagged retitle keeps legacy id semantics (content re-hash) with the retirement recorded — but emits no token', async () => {
+    const vault = { [NOTE]: `## Tasks\n- [ ] ${TITLE}` };
+    const device = makeDevice({ inbox: [legacyRow({ title: 'Renamed thing #obsidian' })] });
+    await runWriteback(device, vault, snapshotOf(LEGACY_ID));
+
+    const t = device.inbox[0];
+    const newHashId = `obsidian-${TODAY}-${simpleHash('Renamed thing')}`;
+    expect(vault[NOTE]).toContain('- [ ] Renamed thing');
+    expect(vault[NOTE]).not.toContain('^dg-');
+    expect(t.id).toBe(newHashId);                    // legacy re-hash, as v4.7.0 did
+    expect(t.obsidianBlockId).toBeUndefined();
+    // The retitle retirement (legacy → legacy) IS still recorded — it is
+    // app-internal channel data, not vault metadata, and it is what stops the
+    // old hash id resurrecting through the sync tiers. Deliberate.
+    const retired = readJson(device, 'day-planner-retired-task-ids', {});
+    expect(retired[LEGACY_ID]?.successor).toBe(newHashId);
+    expect(deletedTaskIdsOf(device)[LEGACY_ID]).toBeTruthy(); // legacy-fleet dual-write shim
+  });
+
+  it('adoption of a stamped vault works in full on the read release: dg id, bridge from the warm legacy row, app fields carried', async () => {
+    // The (c) confirmation: a read-release device pointed at a vault that
+    // already contains ^dg- tokens (stamped by a dev build / a write-release
+    // device) adopts them as first-class identity — it does NOT read them as
+    // title text the way a pre-Phase-2 client does.
+    const vault = { [NOTE]: `## Tasks\n- [ ] ${TITLE} ^dg-aaaaaaaa` };
+    const device = makeDevice({ inbox: [legacyRow()] }); // warm device, legacy row from before the stamp
+    await runVaultSync(device, vault);
+
+    const ids = device.inbox.map((t) => t.id);
+    expect(ids).toContain(DG_ID);                    // adopted, not re-hashed
+    expect(ids).not.toContain(LEGACY_ID);            // bridged away, no duplicate
+    const dg = device.inbox.find((t) => t.id === DG_ID);
+    expect(dg.obsidianBlockId).toBe('aaaaaaaa');
+    expect(dg.projectId).toBe('proj-1');             // app-only fields carried over the bridge
+    expect(dg.title).toContain(TITLE);
+    expect(dg.title).not.toContain('^dg-');          // the token is identity, not title text
   });
 });

--- a/src/utils/obsidianWritePolicy.js
+++ b/src/utils/obsidianWritePolicy.js
@@ -1,0 +1,61 @@
+// The Phase 2 READ/WRITE release split — the vault write-format gate.
+//
+// ═══ THE WRITE-RELEASE SWITCH ══════════════════════════════════════════════
+// Flip this ONE constant to `true` to ship the write release. Nothing else
+// changes. Grep anchor: OBSIDIAN_BLOCK_ID_WRITES.
+export const OBSIDIAN_BLOCK_ID_WRITES = false;
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// THE STANDING RULE (docs/obsidian-buildout-spec.md, "Staged vault-format
+// rollout"): any change to what dayGLANCE WRITES into the vault ships as
+// read-support first, write-support one release later. The fleet spans five
+// platforms on three release channels whose store approvals never align, plus
+// always-on appliances that lag behind — so every write-format change has a
+// mixed-version window. A client that does not understand a format token
+// reads it as TITLE TEXT, hashes it into a brand-new content-derived id, and
+// imports a duplicate that syncs fleet-wide (the staged-rollout analysis, and
+// the live incident of 2026-08-26: stable duplicates for the whole mixed
+// window, surviving the update in the heavy-stamp case). Shipping the READER
+// first means that by the time any device emits the new format, every device
+// understands it.
+//
+// WHY THE READER IS THE FULL PHASE 2 READ PATH, not merely "strip and
+// ignore": a device that strips `^dg-` tokens but still hashes the clean
+// title into a legacy id keeps RE-PRODUCING legacy ids after a write-release
+// device retires them — a milder seed of the same war. The read release
+// therefore carries token recognition, dg-id adoption, the legacy bridge
+// hint, first-occurrence-wins dedup — everything except EMITTING. Tokens
+// already present in a line are always PRESERVED on rewrite (stripping them
+// would destroy identity other devices rely on); the gate only stops the
+// creation of NEW ones.
+//
+// WHAT THE GATE COVERS — the only two emit sites in the codebase:
+//   • the opportunistic stamp on write (useObsidianSync's writeback:
+//     assignBlockId), and
+//   • creation-time identity for new vault-bound tasks
+//     (obsidian.js buildNewObsidianTaskMeta).
+// Everything downstream (blockIdSuffix, updateTaskLines, the append path)
+// emits a token only when handed a block id, so gating id GENERATION gates
+// the entire write surface.
+//
+// Deliberately a BUILD-TIME CONSTANT, not a user-facing setting and not a
+// version handshake: a setting pushes correctness onto the user (someone
+// always has a device they forgot about), and release channels are the
+// natural vehicle — the write release simply is the build where this reads
+// `true`.
+
+let testOverride = null;
+
+/** The live gate the emit sites consult. */
+export function blockIdWritesEnabled() {
+  return testOverride ?? OBSIDIAN_BLOCK_ID_WRITES;
+}
+
+/**
+ * TESTS ONLY: force the gate on/off (pass null to restore the constant).
+ * Write-release behavior (stamping, id migration, retirement recording) is
+ * tested with the override on; read-release behavior with it off/default.
+ */
+export function __setBlockIdWritesForTests(v) {
+  testOverride = v;
+}

--- a/src/utils/obsidianWritePolicy.test.js
+++ b/src/utils/obsidianWritePolicy.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { OBSIDIAN_BLOCK_ID_WRITES, blockIdWritesEnabled, __setBlockIdWritesForTests } from './obsidianWritePolicy.js';
+import { buildNewObsidianTaskMeta, simpleHash, blockIdSuffix } from '../obsidian.js';
+
+afterEach(() => __setBlockIdWritesForTests(null));
+
+describe('the read/write release gate', () => {
+  it('SHIPS READ-ONLY: the constant is false until the write release flips it', () => {
+    // This is the release switch itself. When shipping the write release,
+    // flip OBSIDIAN_BLOCK_ID_WRITES to true in obsidianWritePolicy.js and
+    // update THIS assertion — the failure is the reminder that the flip is a
+    // release decision, not a side effect.
+    expect(OBSIDIAN_BLOCK_ID_WRITES).toBe(false);
+    expect(blockIdWritesEnabled()).toBe(false);
+  });
+
+  it('the test override forces either mode and restores the constant', () => {
+    __setBlockIdWritesForTests(true);
+    expect(blockIdWritesEnabled()).toBe(true);
+    __setBlockIdWritesForTests(false);
+    expect(blockIdWritesEnabled()).toBe(false);
+    __setBlockIdWritesForTests(null);
+    expect(blockIdWritesEnabled()).toBe(OBSIDIAN_BLOCK_ID_WRITES);
+  });
+});
+
+describe('buildNewObsidianTaskMeta — creation-time identity under the gate', () => {
+  it('read release: legacy content-derived id, no block id — the appended line round-trips through the token-less parse', () => {
+    __setBlockIdWritesForTests(false);
+    const meta = buildNewObsidianTaskMeta('Buy milk', '2026-08-27');
+    expect(meta.id).toBe(`obsidian-2026-08-27-${simpleHash('Buy milk')}`);
+    expect(meta.obsidianBlockId).toBeUndefined();
+    expect(meta.obsidianRawTitle).toBe('Buy milk');
+    // No block id → the line builder emits no token.
+    expect(blockIdSuffix(meta.obsidianBlockId, 'Buy milk')).toBe('');
+  });
+
+  it('write release: dg block-id identity, and the line carries the matching token', () => {
+    __setBlockIdWritesForTests(true);
+    const meta = buildNewObsidianTaskMeta('Buy milk', '2026-08-27');
+    expect(meta.obsidianBlockId).toMatch(/^[a-z0-9]{8}$/);
+    expect(meta.id).toBe(`obsidian-dg-${meta.obsidianBlockId}`);
+    expect(blockIdSuffix(meta.obsidianBlockId, 'Buy milk')).toBe(` ^dg-${meta.obsidianBlockId}`);
+  });
+});


### PR DESCRIPTION
## Summary

The staged-rollout restructure — the last blocker before Phase 2 ships. Everything on main stays; this changes *what gets enabled when*. The **read release** carries the full Phase 2 read path (token recognition, `obsidian-dg-` adoption, the legacy bridge hint, first-occurrence-wins — everything except emitting, per the Q2(a) finding that "strip and ignore" re-seeds the war). The **write release** is a one-line constant flip.

### The confirm-before-building answers, in brief

- **(a) Clean.** Every token emission funnels through id *generation* — exactly two call sites: the writeback's opportunistic stamp (`useObsidianSync`) and creation-time identity (extracted from App.jsx into `obsidian.js buildNewObsidianTaskMeta`, now testable). Everything downstream (`blockIdSuffix`, `updateTaskLines`, the append path) emits only when handed an id. Gate the generation, gate the surface.
- **(b)** A build-time constant: `OBSIDIAN_BLOCK_ID_WRITES` in `src/utils/obsidianWritePolicy.js` — not a user setting, not a version handshake. The module header carries the standing rule and the flip instruction.
- **(c)** Yes — adoption of an already-stamped vault is the read path, entirely gate-independent, and now explicitly pinned under the gate: dg id adopted (not re-hashed as title text), legacy row bridged with app fields carried, token preserved on subsequent writes. **The gate stops minting, never strips.**
- **(d)** Inert where it should be: a pure completion on a read-only device retires nothing (`recordRetirements` gets an empty set by construction); the guard/apply/rescue consumers are all data-driven and just honor synced records. One deliberate non-inertness, stated in code and test: an *untagged retitle* still records its legacy→legacy retirement — app-internal channel data (not vault metadata) that stops the old hash resurrecting through the sync tiers.
- **(e)** Flip `OBSIDIAN_BLOCK_ID_WRITES` to `true` — one line, grep-anchored, and a unit test pins the shipped default so the flip fails a named test until the assertion is consciously updated with it.

### Tests

Write-release suites (`obsidian.phase2Transition`) force the gate ON via the test override; a new **read-release describe** runs the same real-pipeline harness with the gate OFF: untagged completion writes the line with **no token, no id mint, no migration, no tombstones** (v4.7.0 write parity); an adopted task keeps writing its existing token; an untagged retitle keeps legacy re-hash semantics with the retirement recorded but nothing emitted; and a read-release device fully adopts a stamped vault. Unit pins for the gate default and the meta builder in both modes.

### Spec

New decision of record **3.9 — Staged vault-format rollout**: any change to what dayGLANCE writes into the vault ships read-support first, write-support one release later; read support means full read semantics; the gate is a build-time constant. Recorded as a **standing rule**, applied to Phase 2's status line and explicitly to **Phase 4's format expansion** (Tasks emoji, Dataview fields, frontmatter — a strictly larger surface where a misread token corrupts identity hashing the same way).

Full suite: **2256 passed**. Lint clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_