### PR TITLE
Ghost-row containment: recognize and retire the duplicates old clients mint from ^dg- stamped lines

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import { preserveArchived } from './utils/preserveArchived.js';
 import { rescueUnsyncedTasks } from './utils/rescueUnsyncedTasks.js';
 import { readRetiredTaskIds, applyTaskRetirements, RETIRED_TASK_IDS_STORAGE_KEY } from './utils/retiredTaskIds.js';
 import { dropTombstonedObsidianTasks, dropTombstonedObsidianNotes } from './utils/obsidianDeletions.js';
+import { containObsidianGhostRows, persistDerivedGhostRetirements } from './utils/obsidianGhostRows.js';
 import { dropResurrectedTasks } from './utils/dropResurrectedTasks.js';
 import { partitionExpiredSingleDayFrames } from './utils/expiredFrames.js';
 import { stripHealthSourcedLogs } from './utils/healthLogFilter.js';
@@ -5624,6 +5625,25 @@ const DayPlanner = () => {
       || (() => { try { return JSON.parse(localStorage.getItem('day-planner-deleted-obsidian-keys') || '{}'); } catch { return {}; } })();
     if (normalizedTasks) normalizedTasks = dropTombstonedObsidianTasks(normalizedTasks, obsidianTombs);
     if (normalizedUnsched) normalizedUnsched = dropTombstonedObsidianTasks(normalizedUnsched, obsidianTombs);
+
+    // Ghost-row CONTAINMENT (utils/obsidianGhostRows.js): a row an old client
+    // minted by parsing a block-id-stamped line — its title still carries the
+    // swallowed ^dg- token, which names its own successor — is superseded
+    // here (dropped, or its newer edits redirected onto the real task), and
+    // the derived retirement is PERSISTED so the guard propagates the ghost's
+    // delete and the vault row dies instead of echoing. Containment, not
+    // prevention: the minting device keeps its local duplicate until it
+    // updates — at which point this same pass self-repairs its state.
+    {
+      const ghostIn = {
+        tasks: normalizedTasks || tasksLiveRef.current || [],
+        unscheduledTasks: normalizedUnsched || unscheduledLiveRef.current || [],
+      };
+      const contained = containObsidianGhostRows(ghostIn);
+      persistDerivedGhostRetirements(contained.derived);
+      if (normalizedTasks) normalizedTasks = contained.tasks;
+      if (normalizedUnsched) normalizedUnsched = contained.unscheduledTasks;
+    }
 
     // Update localStorage
     if (normalizedTasks) localStorage.setItem('day-planner-tasks', JSON.stringify(normalizedTasks));

--- a/src/hooks/useDataPersistence.js
+++ b/src/hooks/useDataPersistence.js
@@ -18,6 +18,7 @@ const isSubscriptionImport = (t) =>
 // runs on every tray mount and reload, so it needs the guard too: the tray
 // still reads and normalizes for its own render, it just never persists.
 import { isTrayMode } from '../utils/trayMode.js';
+import { repairLoadedGhostRows } from '../utils/obsidianGhostRows.js';
 
 export default function useDataPersistence({
   // setters for loadData
@@ -91,8 +92,16 @@ export default function useDataPersistence({
       // calendar devices, drop any persisted subscription imports so they don't
       // linger as stale duplicates of the live EventKit/bridge events.
       const loadedTasks = hasNativeCalendar() ? parsedTasks.filter(t => !isSubscriptionImport(t)) : parsedTasks;
-      setTasks(prev => [...loadedTasks, ...prev.filter(t => t._native)]);
-      setUnscheduledTasks(parsedUnscheduled.filter(t => !t.imported));
+      // Ghost-row self-repair at boot (utils/obsidianGhostRows.js): if this
+      // device minted mangled duplicates while running a pre-block-id build,
+      // its first launch after updating contains them here — the sync
+      // ingresses only fire when something syncs, and a local-only install
+      // would otherwise never repair. The tray never persists (read snapshot).
+      const ghostRepaired = repairLoadedGhostRows(
+        loadedTasks, parsedUnscheduled.filter(t => !t.imported), { persist: !isTrayMode },
+      );
+      setTasks(prev => [...ghostRepaired.tasks, ...prev.filter(t => t._native)]);
+      setUnscheduledTasks(ghostRepaired.unscheduledTasks);
       if (recycleBinData) {
         setRecycleBin(JSON.parse(recycleBinData));
       }

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -11,6 +11,7 @@ import {
 } from './sync/tombstoneRetention.js';
 import { mergeRetiredTaskIds, pruneRetiredTaskIds, applyRetirementsToTaskLists } from './utils/retiredTaskIds.js';
 import { dropTombstonedObsidianTasks, dropTombstonedObsidianNotes } from './utils/obsidianDeletions.js';
+import { containObsidianGhostRows } from './utils/obsidianGhostRows.js';
 import { mergeDayWindowMaps, dayWindowMapsEqual, migrateDayWindows } from './sync/dayWindowSync.js';
 
 export const mergeTaskArrays = (local, remote, deletedIds, syncHorizon = null) =>
@@ -520,6 +521,24 @@ export const mergeSyncData = (local, remote, retentionDays) => {
     result.data.dailyNotes = obsCleanNotes;
     // Both sides need the cleansed result: local state applies it, and the
     // remote file is rewritten without the zombies.
+    result.localChanged = true;
+    result.remoteChanged = true;
+  }
+
+  // Ghost-row CONTAINMENT at the file-tier merge (utils/obsidianGhostRows.js):
+  // a duplicate an old client minted from a block-id-stamped line carries the
+  // swallowed ^dg- token in its title — the pointer to its own successor. The
+  // merged output (which is also the uploaded file) is cleansed of ghosts
+  // whose successor is live, with a newer ghost's edits redirected onto the
+  // successor. Ephemeral here (a pure merge persists nothing); the derived
+  // retirement is recorded at the apply boundary. Containment, not
+  // prevention: the minting client keeps its local copy until it updates.
+  const ghostContained = containObsidianGhostRows(
+    { tasks: result.data.tasks, unscheduledTasks: result.data.unscheduledTasks },
+  );
+  if (ghostContained.tasks !== result.data.tasks || ghostContained.unscheduledTasks !== result.data.unscheduledTasks) {
+    result.data.tasks = ghostContained.tasks;
+    result.data.unscheduledTasks = ghostContained.unscheduledTasks;
     result.localChanged = true;
     result.remoteChanged = true;
   }

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -45,6 +45,7 @@ import { isPayloadExcludedEntity, agedOutReleaseReason } from './payloadExclusio
 import { shredHashes, hashMapsEqual, mergeMidCycleEdits } from './commitMerge.js';
 import { createSyncCycleBreaker, isRateLimitedError } from './syncBrakes.js';
 import { isObsidianTombstoned } from '../utils/obsidianDeletions.js';
+import { ghostSuccessorId, persistDerivedGhostRetirements } from '../utils/obsidianGhostRows.js';
 
 const APP_ID = 'dayglance';
 const CRYPTO_DB_NAME = 'dayglance-db-crypto';
@@ -344,6 +345,30 @@ export function createDbEngine(callbacks = {}) {
         if ((k === 'tasks' || k === 'unscheduledTasks') && v && v.importSource === 'obsidian'
             && isObsidianTombstoned(obsTombs, String(v.id), v.lastModified)) return;
         if (k === 'dailyNotes' && isObsidianTombstoned(obsTombs, String(entity._key), v && v.lastModified)) return;
+      }
+      // Ghost-row CONTAINMENT at the DB-tier pull — the third ingress (the
+      // #1454 lesson: gate the mirror too, or the guard's blessed delete-marks
+      // find the pull-re-applied ghost live in the mirror and re-upsert it).
+      // A ghost NOT newer than its live successor is refused outright, its
+      // derived retirement persisted, and the entityId marked dirty — the
+      // mirror lacks the row, so THIS cycle's push soft-deletes the vault
+      // ghost row and the echo dies at the source. A NEWER ghost (an edit the
+      // user made on the old client) is deliberately let through: the apply
+      // boundary redirects its content onto the successor and records the
+      // retirement, and the guard propagates its delete next cycle.
+      if (entity && typeof entity === 'object'
+          && (entity._kind === 'tasks' || entity._kind === 'unscheduledTasks')) {
+        const succId = ghostSuccessorId(entity.value);
+        if (succId) {
+          const succ = [...(mirror.tasks || []), ...(mirror.unscheduledTasks || [])]
+            .find((t) => t && String(t.id) === succId);
+          const ts = (x) => { const n = new Date(x ?? 0).getTime(); return Number.isNaN(n) ? 0 : n; };
+          if (succ && ts(entity.value.lastModified) <= ts(succ.lastModified)) {
+            persistDerivedGhostRetirements({ [String(entity.value.id)]: succId });
+            engine.markDirty(entityId); // absent from the mirror → pushed as a soft-delete
+            return;
+          }
+        }
       }
       // The vault's content for this row changed under us — whatever we last
       // acked there is stale, so the no-op re-push skip below must not apply.

--- a/src/sync/obsidianGhostContainment.test.js
+++ b/src/sync/obsidianGhostContainment.test.js
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import { setSyncPassphrase } from '@glance-apps/sync';
+import { createDbEngine } from './dbEngine.js';
+import { setVaultConfig } from './vaultConfig.js';
+import { mergeSyncData } from '../mergeSync.js';
+import { containObsidianGhostRows, persistDerivedGhostRetirements, repairLoadedGhostRows } from '../utils/obsidianGhostRows.js';
+import { legacyObsidianId, appIdForBlockId } from '../obsidian.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GHOST-ROW CONTAINMENT at the three sync ingresses (the #1454 pattern):
+// applyEngineData (modeled in commitData below), the file-tier merge, and the
+// DB-tier pull. A ghost — the duplicate an old client mints by parsing a
+// stamped line with no block-ref awareness — carries its own successor's id
+// inside its mangled title, so current clients derive the retirement from the
+// corruption itself and the duplicate stops propagating. CONTAINMENT, NOT
+// PREVENTION: the minting device keeps its local duplicate until it updates
+// (see utils/obsidianGhostRows.js header).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+function createMemoryVault() {
+  const salts = new Map();
+  const log = new Map();
+  let seq = 0;
+  return {
+    async getSalt(accountId) { return salts.get(accountId) || null; },
+    async putSalt(accountId, fresh) { if (!salts.has(accountId)) salts.set(accountId, fresh); return salts.get(accountId); },
+    async batch(app, { rows }) {
+      for (const r of rows) log.set(r.entityId, { entityId: r.entityId, seq: ++seq, envelope: r.envelope, deleted: false });
+      return { maxSeq: seq };
+    },
+    async deleteRow(app, entityId, accountId, opts = {}) {
+      log.set(entityId, { entityId, seq: ++seq, envelope: null, deleted: true, deletedAt: opts.deletedAt });
+      return { seq };
+    },
+    async list(app, { since }) {
+      const rows = [...log.values()].filter((r) => r.seq > since).sort((a, b) => a.seq - b.seq);
+      return { rows, hasMore: false };
+    },
+    async device() { return { updated: true }; },
+    _row(entityId) { return log.get(entityId) || null; },
+    _seq() { return seq; },
+  };
+}
+
+const FIXTURE_NOW = new Date('2026-08-27T12:00:00.000Z');
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(FIXTURE_NOW);
+  global.localStorage = memLocalStorage();
+  setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 't', accountId: 'acct' });
+  setSyncPassphrase('correct horse battery staple');
+});
+afterEach(() => { vi.useRealTimers(); });
+afterAll(() => { delete global.localStorage; });
+
+const clone = (x) => JSON.parse(JSON.stringify(x));
+
+const DATE = '2026-08-26';
+const BLOCK = 'k3x9q2mf';
+const MANGLED = `Buy milk ^dg-${BLOCK}`;
+const GHOST_ID = legacyObsidianId(DATE, MANGLED);
+const DG_ID = appIdForBlockId(BLOCK);
+const T_SUCC = '2026-08-26T11:00:00.000Z';
+
+const ghost = (extra = {}) => ({
+  id: GHOST_ID, title: `${MANGLED} #obsidian`, obsidianRawTitle: MANGLED,
+  obsidianFileDate: DATE, importSource: 'obsidian',
+  completed: false, notes: '', subtasks: [], duration: 30,
+  lastModified: '2026-08-26T10:00:00.000Z', ...extra,
+});
+const successor = (extra = {}) => ({
+  id: DG_ID, title: 'Buy milk #obsidian', obsidianRawTitle: 'Buy milk',
+  obsidianFileDate: DATE, obsidianBlockId: BLOCK, importSource: 'obsidian',
+  completed: false, notes: '', subtasks: [], duration: 30,
+  lastModified: T_SUCC, ...extra,
+});
+
+const EMPTY = {
+  tasks: [], unscheduledTasks: [], recurringTasks: [], recycleBin: [], todayRoutines: [],
+  habits: [], goals: [], projects: [], gtdFrames: [], users: [], dailyNotes: {},
+  completedTaskUids: [], deletedTaskIds: {}, deletedObsidianKeys: {},
+};
+
+// A device whose commitData models the FIXED applyEngineData: ghost
+// containment + retirement persistence at the apply boundary.
+function makeDevice(name, vault, initial) {
+  let data = clone(initial);
+  let nativeKey = null;
+  const engine = createDbEngine({
+    vaultClient: vault,
+    storageKeyPrefix: `dev-${name}`,
+    deviceId: `device-${name}`,
+    nativeGetSyncKey: () => nativeKey,
+    nativeStoreSyncKey: (v) => { nativeKey = v; },
+    // buildSyncPayload reads the tombstone/retirement bundles from
+    // localStorage every build; the harness mirrors that, or the guard could
+    // never see retirements the ingresses persisted mid-cycle.
+    getData: () => {
+      const d = clone(data);
+      try { d.retiredTaskIds = JSON.parse(localStorage.getItem('day-planner-retired-task-ids') || '{}'); } catch { d.retiredTaskIds = {}; }
+      try { d.deletedTaskIds = { ...d.deletedTaskIds, ...JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}') }; } catch { /* keep seed */ }
+      return d;
+    },
+    commitData: (d) => {
+      const contained = containObsidianGhostRows({ tasks: d.tasks, unscheduledTasks: d.unscheduledTasks });
+      persistDerivedGhostRetirements(contained.derived);
+      data = { ...d, tasks: contained.tasks, unscheduledTasks: contained.unscheduledTasks };
+    },
+  });
+  return { engine, get data() { return data; }, set data(d) { data = d; } };
+}
+
+const stateIds = (dev) => dev.data.tasks.map((t) => t.id);
+
+describe('file-tier merge ingress', () => {
+  it('a ghost in the remote file is contained when its successor is live — and kept out of the rewritten file', () => {
+    const local = { ...EMPTY, tasks: [successor()] };
+    const remote = { ...EMPTY, tasks: [successor(), ghost()] }; // old client uploaded the ghost
+    const result = mergeSyncData(local, remote, 365);
+    expect(result.data.tasks.map((t) => t.id)).toEqual([DG_ID]);
+    expect(result.remoteChanged).toBe(true); // the file gets rewritten without the ghost
+  });
+
+  it("a NEWER ghost's edit is redirected onto the successor in the merge output", () => {
+    const local = { ...EMPTY, tasks: [successor()] };
+    const remote = { ...EMPTY, tasks: [successor(), ghost({ completed: true, lastModified: '2026-08-26T12:00:00.000Z' })] };
+    const result = mergeSyncData(local, remote, 365);
+    expect(result.data.tasks).toHaveLength(1);
+    const s = result.data.tasks[0];
+    expect(s.id).toBe(DG_ID);
+    expect(s.completed).toBe(true);          // the old client's completion survives
+    expect(s.title).not.toMatch(/\^dg-/);    // the corruption does not
+  });
+
+  it('successor absent → the ghost passes through untouched (conservative fall-through)', () => {
+    const local = { ...EMPTY };
+    const remote = { ...EMPTY, tasks: [ghost()] };
+    const result = mergeSyncData(local, remote, 365);
+    expect(result.data.tasks.map((t) => t.id)).toEqual([GHOST_ID]);
+  });
+
+  it('a legitimate token-lookalike title is not eaten by the merge', () => {
+    const raw = 'Test three ^dg-testtest';
+    const lookalike = ghost({ id: legacyObsidianId(DATE, raw), obsidianRawTitle: raw, title: `${raw} #obsidian` });
+    const local = { ...EMPTY, tasks: [successor()] };
+    const remote = { ...EMPTY, tasks: [successor(), lookalike] };
+    const result = mergeSyncData(local, remote, 365);
+    expect(result.data.tasks.map((t) => t.id).sort()).toEqual([lookalike.id, DG_ID].sort());
+  });
+});
+
+describe('DB-tier pull ingress + apply boundary', () => {
+  // Simulate the mixed fleet: an "old client" device pushes the ghost row the
+  // vault-scan of a stamped line minted (its commitData containment is
+  // irrelevant — its DATA already holds the ghost, exactly like a v4.7.0 push).
+  async function seedVaultWithGhost(vault, ghostRow) {
+    const oldClient = makeDevice('old', vault, { ...EMPTY, tasks: [successor(), ghostRow] });
+    // Two cycles: full-seed push, then a pull so its cursor settles.
+    await oldClient.engine.dbSyncCycle();
+    await oldClient.engine.dbSyncCycle();
+    return oldClient;
+  }
+
+  it('an OLDER ghost is refused at the pull, its retirement recorded, and the vault ghost row soft-deleted the same cycle', async () => {
+    const vault = createMemoryVault();
+    await seedVaultWithGhost(vault, ghost());
+
+    const mac = makeDevice('mac', vault, { ...EMPTY, tasks: [successor()] });
+    await mac.engine.dbSyncCycle(); // pulls everything the old client pushed
+    expect(stateIds(mac)).toEqual([DG_ID]);           // ghost never entered state
+    const rec = JSON.parse(localStorage.getItem('day-planner-retired-task-ids'));
+    expect(rec[GHOST_ID].successor).toBe(DG_ID);      // derived retirement persisted
+    expect(vault._row(`tasks:${GHOST_ID}`).deleted).toBe(true); // echo killed at the source
+
+    // Converged: another cycle changes nothing.
+    const seqSettled = vault._seq();
+    await mac.engine.dbSyncCycle();
+    expect(vault._seq()).toBe(seqSettled);
+    expect(stateIds(mac)).toEqual([DG_ID]);
+  });
+
+  it("a NEWER ghost passes the pull deliberately: its edit is redirected onto the successor at the apply boundary, then the guard deletes the vault row", async () => {
+    const vault = createMemoryVault();
+    await seedVaultWithGhost(vault, ghost({ completed: true, lastModified: '2026-08-26T12:00:00.000Z' }));
+
+    const mac = makeDevice('mac', vault, { ...EMPTY, tasks: [successor()] });
+    await mac.engine.dbSyncCycle();
+    expect(stateIds(mac)).toEqual([DG_ID]);
+    const s = mac.data.tasks[0];
+    expect(s.completed).toBe(true);                   // the old client's completion survived the redirect
+    expect(s.title).not.toMatch(/\^dg-/);
+    expect(s.obsidianBlockId).toBe(BLOCK);
+
+    // The mirror carried the ghost this cycle (it passed the pull), so the
+    // snapshot holds it while state doesn't: the next cycle's guard finds the
+    // persisted retirement and propagates the delete.
+    await mac.engine.dbSyncCycle();
+    expect(vault._row(`tasks:${GHOST_ID}`).deleted).toBe(true);
+    expect(stateIds(mac)).toEqual([DG_ID]);
+  });
+
+  it('self-repair at BOOT: the minting device updates and its first LOAD contains its own ghost — no sync required (the local-only case)', () => {
+    // loadData runs repairLoadedGhostRows over the persisted lists before
+    // setting state, so even an install that never syncs repairs on launch.
+    const loaded = repairLoadedGhostRows(
+      [successor(), ghost({ completed: true, lastModified: '2026-08-26T12:00:00.000Z' })], [],
+    );
+    expect(loaded.tasks.map((t) => t.id)).toEqual([DG_ID]);
+    expect(loaded.tasks[0].completed).toBe(true);     // the edit made on the ghost survives
+    expect(loaded.tasks[0].title).not.toMatch(/\^dg-/);
+    const rec = JSON.parse(localStorage.getItem('day-planner-retired-task-ids'));
+    expect(rec[GHOST_ID].successor).toBe(DG_ID);
+  });
+
+  it('self-repair over SYNC: the upgraded device converges its vault copy too — ghost row deleted, retirement synced out', async () => {
+    const vault = createMemoryVault();
+    // While old, this device pushed both rows; its state was then boot-repaired.
+    await (async () => {
+      const asOld = makeDevice('upgraded', vault, {
+        ...EMPTY,
+        tasks: [successor(), ghost({ completed: true, lastModified: '2026-08-26T12:00:00.000Z' })],
+      });
+      await asOld.engine.dbSyncCycle(); // pushed while "old" (full-seed)
+    })();
+    const repaired = repairLoadedGhostRows(
+      [successor(), ghost({ completed: true, lastModified: '2026-08-26T12:00:00.000Z' })], [],
+    );
+    const dev = makeDevice('upgraded', vault, { ...EMPTY, tasks: repaired.tasks });
+    await dev.engine.dbSyncCycle(); // snapshot holds the pushed ghost; the guard propagates 'retired'
+    await dev.engine.dbSyncCycle();
+    expect(vault._row(`tasks:${GHOST_ID}`).deleted).toBe(true);
+    expect(stateIds(dev)).toEqual([DG_ID]);
+  });
+});

--- a/src/utils/obsidianGhostRows.js
+++ b/src/utils/obsidianGhostRows.js
@@ -1,0 +1,184 @@
+// GHOST-ROW CONTAINMENT — recognizing and redirecting the duplicates an OLD
+// client mints from a block-id-stamped vault line.
+//
+// THE CORRUPTION IS SELF-IDENTIFYING. A pre-block-id client parses
+// `- [ ] Buy milk ^dg-k3x9q2mf` with no block-ref awareness: the token becomes
+// TITLE TEXT, the mangled title hashes into a brand-new content-derived id,
+// and the result is a "ghost" task row — `obsidian-<date>-<hash>` with a title
+// that literally ends in `^dg-<id>` — which syncs fleet-wide as a duplicate of
+// the real `obsidian-dg-<id>` task. But that embedded token IS the successor's
+// identity: the ghost carries the pointer to the task it duplicates, so a
+// current client can derive the retirement from the corruption itself — no
+// coordination, no capability negotiation, no server change.
+//
+// ★ THIS IS CONTAINMENT, NOT PREVENTION. The old client that minted the ghost
+// keeps showing its local duplicate until it updates — nothing here reaches
+// into an old build. What containment buys: the ghost stops PROPAGATING (every
+// current client refuses or redirects it at the sync ingresses, and the
+// derived retirement propagates the delete so the vault row dies), and the
+// minting device SELF-REPAIRS the moment it updates (its first apply runs this
+// same containment over its own state). Do not mistake this module for a fix
+// for old clients; the fix for old clients is updating them.
+//
+// RECOGNITION (precision over recall — a false negative leaves a recoverable
+// duplicate; a false positive eats a real task). A row is a ghost only when
+// ALL of these hold:
+//   1. importSource === 'obsidian' — only vault-derived rows qualify;
+//   2. no obsidianBlockId — a properly-adopted row is never a ghost;
+//   3. obsidianRawTitle is a string ending in ` ^dg-<8 chars of [a-z0-9]>` —
+//      the exact emitted token shape, at end of line, exactly where the old
+//      parser would have swallowed it;
+//   4. the row's id EQUALS the legacy content-derived id of that mangled
+//      title (`obsidian-<date>-<simpleHash(rawTitle)>`, date taken from the
+//      id itself) — proving the row was MINTED BY the legacy parser from
+//      exactly this text, not typed by a person into some other identity;
+//   5. the successor the token names (`obsidian-dg-<id>`) is LIVE in the
+//      current task lists — the retirement rule's own conservatism, reused:
+//      with no live successor the record authorizes nothing and the row is
+//      left alone.
+// A legitimate title that merely contains token-LIKE text (someone writing
+// about block ids, a test line "Test three ^dg-testtest") fails 5 unless the
+// 8-char string coincides with a real live block id — and fails 4 as well
+// unless the row is also an untagged vault import of exactly that text. The
+// conjunction is the confidence.
+//
+// ACTION: the ghost's title is sanitized (the swallowed token stripped) and
+// the row is fed through the SAME successor-aware supersede the retirement
+// record uses (utils/retiredTaskIds.js applyTaskRetirements): dropped when
+// older than the successor, its content REDIRECTED onto the successor when
+// newer (an edit the user made on the old client — a completion, a
+// reschedule — survives on the real task). applyEngineData additionally
+// PERSISTS the derived retirement into retiredTaskIds (+ the deletedTaskIds
+// dual-write shim), so the push guard propagates the ghost's delete
+// ('retired'), the vault row dies instead of echoing, and the old client's
+// own payload filter (dropResurrectedTasks) stops re-uploading it.
+
+import { legacyObsidianId, appIdForBlockId } from '../obsidian.js';
+import {
+  applyTaskRetirements,
+  recordRetirements,
+  readRetiredTaskIds,
+  RETIRED_TASK_IDS_STORAGE_KEY,
+  RETIRED_ID_DUAL_WRITE,
+} from './retiredTaskIds.js';
+
+// The exact emitted token, at end of string: space, ^dg-, 8 chars of lowercase
+// base36 (generateBlockId's alphabet), nothing after.
+export const GHOST_TOKEN_RE = /\s\^dg-([a-z0-9]{8})$/;
+
+// Strip ONE SPECIFIC recognized token from a title. The app-level title
+// carries the mangled raw title plus the ' #obsidian' display tag, so the
+// token sits before the tag rather than at end-of-string — target the exact
+// token we recognized (never a general pattern), wherever it appears as a
+// standalone word.
+const stripSpecificToken = (s, blockId) =>
+  (typeof s === 'string' ? s.replace(new RegExp(`\\s\\^dg-${blockId}(?=\\s|$)`), '') : s);
+
+/**
+ * Recognition rules 1–4: is this row a legacy-parser mint of a stamped line?
+ * Returns the successor app id (`obsidian-dg-<id>`) or null. Rule 5 (the
+ * successor must be LIVE) is the caller's — it needs the cross-list id set.
+ */
+export function ghostSuccessorId(task) {
+  if (!task || task.importSource !== 'obsidian') return null;     // 1
+  if (task.obsidianBlockId) return null;                          // 2
+  const raw = task.obsidianRawTitle;
+  if (typeof raw !== 'string') return null;
+  const m = raw.match(GHOST_TOKEN_RE);
+  if (!m) return null;                                            // 3
+  const dateMatch = /^obsidian-(\d{4}-\d{2}-\d{2})-/.exec(String(task.id));
+  if (!dateMatch) return null;
+  if (String(task.id) !== legacyObsidianId(dateMatch[1], raw)) return null; // 4
+  return appIdForBlockId(m[1]);
+}
+
+/**
+ * Contain ghost rows across a { tasks, unscheduledTasks } pair.
+ *
+ * Ghosts whose successor is live (rule 5, checked across BOTH lists) are
+ * sanitized (token stripped from the title fields) and superseded via
+ * applyTaskRetirements — drop, or redirect-if-newer onto the successor. A
+ * ghost with no live successor, and any non-ghost, passes through untouched.
+ * Returns the SAME arrays when nothing changed (no diff churn), plus the
+ * derived retirement entries ({ghostId → successorId}) so applyEngineData can
+ * persist them into the retirement record.
+ */
+export function containObsidianGhostRows({ tasks, unscheduledTasks }) {
+  const t = Array.isArray(tasks) ? tasks : [];
+  const u = Array.isArray(unscheduledTasks) ? unscheduledTasks : [];
+  const liveIds = new Set([...t, ...u].filter(Boolean).map((x) => String(x.id)));
+
+  // Rules 1–5 → the derived retirement record (ephemeral; the caller decides
+  // whether to persist it).
+  const derived = {};
+  for (const row of [...t, ...u]) {
+    const succ = ghostSuccessorId(row);
+    if (succ && liveIds.has(succ)) derived[String(row.id)] = succ;
+  }
+  if (Object.keys(derived).length === 0) return { tasks: t, unscheduledTasks: u, derived };
+
+  // Sanitize the ghosts before the supersede: the swallowed token is
+  // CORRUPTION, not content — a newer ghost's redirect must not carry it onto
+  // the successor's title. (obsidianRawTitle is an identity field the
+  // redirect keeps from the successor, so only `title` needs cleaning.)
+  const sanitize = (list) => list.map((row) => {
+    const succ = row && derived[String(row.id)];
+    if (!succ) return row;
+    const blockId = succ.slice('obsidian-dg-'.length);
+    return { ...row, title: stripSpecificToken(row.title, blockId) };
+  });
+
+  // Reuse the retirement supersede verbatim: same live-successor conservatism,
+  // same redirect-if-newer, same identity-field preservation. retiredAt is
+  // synthetic (the supersede itself never reads it; validity only).
+  const record = {};
+  for (const [ghostId, succ] of Object.entries(derived)) {
+    record[ghostId] = { retiredAt: new Date(0).toISOString(), successor: succ };
+  }
+  return {
+    tasks: applyTaskRetirements(sanitize(t), record, liveIds),
+    unscheduledTasks: applyTaskRetirements(sanitize(u), record, liveIds),
+    derived,
+  };
+}
+
+/**
+ * Boot-time self-repair, for loadData: contain ghosts already sitting in the
+ * PERSISTED task lists — the just-updated minting device's own duplicates.
+ * The sync ingresses only run when something syncs; a local-only install
+ * would otherwise never repair. Pass persist:false for the tray popup, which
+ * must never write localStorage (its state is a read snapshot).
+ */
+export function repairLoadedGhostRows(tasks, unscheduledTasks, { persist = true } = {}) {
+  const contained = containObsidianGhostRows({ tasks, unscheduledTasks });
+  if (persist) persistDerivedGhostRetirements(contained.derived);
+  return { tasks: contained.tasks, unscheduledTasks: contained.unscheduledTasks };
+}
+
+/**
+ * Persist derived ghost retirements ({ghostId → successorId}) into the REAL
+ * retirement record (+ the deletedTaskIds dual-write shim, exactly like the
+ * write-commit's own retirements). This is what makes containment CONVERGE
+ * instead of loop: the push guard propagates the ghost's vanish as 'retired'
+ * so the vault row dies, and the minting old client's payload filter
+ * (dropResurrectedTasks) stops re-uploading its copy once the tombstone
+ * syncs. Provenance holds: this writer KNOWS the successor — it derived it
+ * from the corruption itself.
+ */
+export function persistDerivedGhostRetirements(derived) {
+  const ghostIds = Object.keys(derived || {});
+  if (ghostIds.length === 0) return;
+  const nowIso = new Date().toISOString();
+  try {
+    let rec = readRetiredTaskIds();
+    for (const ghostId of ghostIds) rec = recordRetirements(rec, [ghostId], derived[ghostId], nowIso);
+    localStorage.setItem(RETIRED_TASK_IDS_STORAGE_KEY, JSON.stringify(rec));
+  } catch { /* storage unavailable — the ingress drops still contain locally */ }
+  if (RETIRED_ID_DUAL_WRITE) {
+    try {
+      const tombstones = JSON.parse(localStorage.getItem('day-planner-deleted-task-ids') || '{}');
+      for (const ghostId of ghostIds) tombstones[String(ghostId)] = nowIso;
+      localStorage.setItem('day-planner-deleted-task-ids', JSON.stringify(tombstones));
+    } catch { /* ditto */ }
+  }
+}

--- a/src/utils/obsidianGhostRows.test.js
+++ b/src/utils/obsidianGhostRows.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { ghostSuccessorId, containObsidianGhostRows, persistDerivedGhostRetirements, GHOST_TOKEN_RE } from './obsidianGhostRows.js';
+import { legacyObsidianId, appIdForBlockId } from '../obsidian.js';
+
+const DATE = '2026-08-26';
+const BLOCK = 'k3x9q2mf';
+const MANGLED = `Buy milk ^dg-${BLOCK}`;
+const GHOST_ID = legacyObsidianId(DATE, MANGLED);
+const DG_ID = appIdForBlockId(BLOCK);
+
+// A ghost exactly as v4.7.0 mints one: legacy content-derived id over the
+// MANGLED title (token swallowed as text), no block id, obsidian import.
+const ghost = (extra = {}) => ({
+  id: GHOST_ID,
+  title: `${MANGLED} #obsidian`,
+  obsidianRawTitle: MANGLED,
+  obsidianFileDate: DATE,
+  importSource: 'obsidian',
+  completed: false, notes: '', subtasks: [], duration: 30,
+  lastModified: '2026-08-26T10:00:00.000Z',
+  ...extra,
+});
+const successor = (extra = {}) => ({
+  id: DG_ID,
+  title: 'Buy milk #obsidian',
+  obsidianRawTitle: 'Buy milk',
+  obsidianFileDate: DATE,
+  obsidianBlockId: BLOCK,
+  importSource: 'obsidian',
+  completed: false, notes: '', subtasks: [], duration: 30,
+  lastModified: '2026-08-26T11:00:00.000Z',
+  ...extra,
+});
+
+describe('ghostSuccessorId — recognition rules 1–4 (precision over recall)', () => {
+  it('recognizes the exact v4.7.0 mint: obsidian import, no block id, trailing token, hash-consistent id', () => {
+    expect(ghostSuccessorId(ghost())).toBe(DG_ID);
+  });
+
+  it('rule 1: a non-obsidian row with the same text is never a ghost', () => {
+    expect(ghostSuccessorId(ghost({ importSource: undefined }))).toBeNull();
+    expect(ghostSuccessorId(ghost({ importSource: 'file' }))).toBeNull();
+  });
+
+  it('rule 2: a properly-adopted row (has obsidianBlockId) is never a ghost', () => {
+    expect(ghostSuccessorId(ghost({ obsidianBlockId: BLOCK }))).toBeNull();
+  });
+
+  it('rule 3: the token must be the exact emitted shape, trailing', () => {
+    expect(ghostSuccessorId(ghost({ obsidianRawTitle: `^dg-${BLOCK} Buy milk` }))).toBeNull(); // not trailing
+    expect(ghostSuccessorId(ghost({ obsidianRawTitle: 'Buy milk ^dg-short' }))).toBeNull();    // 5 chars
+    expect(ghostSuccessorId(ghost({ obsidianRawTitle: 'Buy milk ^dg-TOOLOUD1' }))).toBeNull(); // uppercase
+    expect(ghostSuccessorId(ghost({ obsidianRawTitle: 'Buy milk ^quote1' }))).toBeNull();      // user block ref
+    expect(ghostSuccessorId(ghost({ obsidianRawTitle: undefined }))).toBeNull();
+  });
+
+  it("rule 4: the id must be the legacy hash of the MANGLED title — a row that merely mentions a token isn't a mint of it", () => {
+    // Same text, but the id doesn't derive from it (e.g. a task created in-app
+    // whose title happens to contain token-like text, under a different id).
+    expect(ghostSuccessorId(ghost({ id: `obsidian-${DATE}-zzzzzz` }))).toBeNull();
+    expect(ghostSuccessorId(ghost({ id: 'task-uuid-1234' }))).toBeNull(); // no date segment
+  });
+
+  it('the emitted-token regex is anchored and exact', () => {
+    expect(GHOST_TOKEN_RE.test('x ^dg-abcd1234')).toBe(true);
+    expect(GHOST_TOKEN_RE.test('x ^dg-abcd1234 trailing')).toBe(false);
+    expect(GHOST_TOKEN_RE.test('x^dg-abcd1234')).toBe(false); // no separating space
+  });
+});
+
+describe('containObsidianGhostRows — rule 5 and the supersede', () => {
+  it('drops a ghost OLDER than its live successor', () => {
+    const { tasks, derived } = containObsidianGhostRows({ tasks: [successor(), ghost()], unscheduledTasks: [] });
+    expect(tasks.map((t) => t.id)).toEqual([DG_ID]);
+    expect(derived).toEqual({ [GHOST_ID]: DG_ID });
+  });
+
+  it("redirects a NEWER ghost's edits onto the successor — with the swallowed token SANITIZED out of the title", () => {
+    const g = ghost({ completed: true, lastModified: '2026-08-26T12:00:00.000Z', title: `${MANGLED} #obsidian` });
+    const { tasks } = containObsidianGhostRows({ tasks: [successor(), g], unscheduledTasks: [] });
+    expect(tasks).toHaveLength(1);
+    const s = tasks[0];
+    expect(s.id).toBe(DG_ID);
+    expect(s.obsidianBlockId).toBe(BLOCK);           // identity: successor's
+    expect(s.obsidianRawTitle).toBe('Buy milk');     // identity: successor's
+    expect(s.completed).toBe(true);                  // the old client's edit survives
+    expect(s.title).not.toMatch(/\^dg-/);            // the corruption does not
+    expect(s.lastModified).toBe('2026-08-26T12:00:00.000Z');
+  });
+
+  it('cross-list: a ghost in the inbox is contained by a successor living in the scheduled list', () => {
+    const { unscheduledTasks } = containObsidianGhostRows({ tasks: [successor()], unscheduledTasks: [ghost()] });
+    expect(unscheduledTasks).toEqual([]);
+  });
+
+  it('(b) successor NOT live → the record authorizes nothing; the row is left alone', () => {
+    const input = { tasks: [ghost()], unscheduledTasks: [] };
+    const out = containObsidianGhostRows(input);
+    expect(out.tasks).toBe(input.tasks); // same array — untouched
+    expect(out.derived).toEqual({});
+  });
+
+  it('(a) a legitimate title containing token-LIKE text is NOT eaten', () => {
+    // The user's own test line, as a real untagged vault task: rules 1–4 all
+    // pass (it IS an untagged vault import whose id hashes its own text) — so
+    // rule 5 is the shield: no task with block id "testtest" is live, and the
+    // row passes through untouched. Containing it would require the 8-char
+    // string to coincide with a REAL live block id — at which point the row
+    // is, by every observable property, a mint of that task's stamped line.
+    const raw = 'Test three ^dg-testtest';
+    const lookalike = ghost({ id: legacyObsidianId(DATE, raw), obsidianRawTitle: raw, title: `${raw} #obsidian` });
+    const input = { tasks: [successor(), lookalike], unscheduledTasks: [] };
+    const out = containObsidianGhostRows(input);
+    expect(out.tasks).toBe(input.tasks);
+    expect(out.derived).toEqual({});
+  });
+});
+
+describe('persistDerivedGhostRetirements', () => {
+  beforeEach(() => {
+    const m = new Map();
+    global.localStorage = {
+      getItem: (k) => (m.has(k) ? m.get(k) : null),
+      setItem: (k, v) => m.set(k, String(v)),
+      removeItem: (k) => m.delete(k),
+    };
+  });
+  afterAll(() => { delete global.localStorage; });
+
+  it('records the derived retirement and the deletedTaskIds dual-write, like the write-commit does', () => {
+    persistDerivedGhostRetirements({ [GHOST_ID]: DG_ID });
+    const rec = JSON.parse(localStorage.getItem('day-planner-retired-task-ids'));
+    expect(rec[GHOST_ID].successor).toBe(DG_ID);
+    const tombs = JSON.parse(localStorage.getItem('day-planner-deleted-task-ids'));
+    expect(tombs[GHOST_ID]).toBeTruthy();
+  });
+
+  it('is a no-op for an empty derivation', () => {
+    persistDerivedGhostRetirements({});
+    expect(localStorage.getItem('day-planner-retired-task-ids')).toBeNull();
+  });
+});

--- a/src/utils/retiredTaskIds.js
+++ b/src/utils/retiredTaskIds.js
@@ -14,9 +14,14 @@
 //
 // THE PROVENANCE RULE — three channels, three different actors, and no write
 // site ever has two valid choices:
-//   • retiredTaskIds      — written ONLY by the commit that renames an id: it
-//                           KNOWS the successor at write time. (useObsidianSync
-//                           write-success commit; any future id migration.)
+//   • retiredTaskIds      — written ONLY by a writer that KNOWS the successor
+//                           at write time: the commit that renames an id
+//                           (useObsidianSync write-success commit; any future
+//                           id migration), and ghost-row containment, which
+//                           DERIVES the successor from the corruption itself
+//                           (utils/obsidianGhostRows.js — an old client's
+//                           mangled duplicate carries its successor's ^dg- id
+//                           in its own title).
 //   • deletedTaskIds      — written ONLY by user-intent delete paths: the user
 //                           pressed delete, there IS no successor.
 //                           (useTaskActions / useRecycleBin.)
@@ -64,17 +69,22 @@
 // retired ids, because the shipped v4.7.x fleet's file-tier merge consults
 // ONLY deletedTaskIds — dropping the dual-write would let stale legacy rows
 // resurrect on un-upgraded devices (the (b2) resolution would regress).
-// SUNSET CONDITION (checkable, not vibes): delete the dual-write — flip this
-// flag, remove the dead branch in useObsidianSync's recordRetirements — when
-// BOTH hold:
+// SUNSET CONDITION: delete the dual-write — flip this flag, remove the dead
+// branches in useObsidianSync's recordRetirements and obsidianGhostRows'
+// persistDerivedGhostRetirements — when BOTH hold:
 //   1. at least TOMBSTONE_RETENTION_DAYS (60) have passed since the first
 //      release carrying retiredTaskIds shipped, AND
-//   2. no pre-retiredTaskIds client (v4.7.x or older) has synced the account
-//      within the last TOMBSTONE_RETENTION_DAYS (check the device list in
-//      Cloud Sync settings / the vault's device cursors).
-// After (1)+(2), every deletedTaskIds entry an old file-tier merge could still
-// consult has been GC'd by the shared retention anyway, so the dual-write is
-// provably writing entries nothing reads differently.
+//   2. no pre-retiredTaskIds client (v4.7.x or older) still syncs the account.
+// HONESTY ABOUT (2): it is NOT currently checkable from inside the app.
+// GLANCEvault exposes no device-list endpoint — the device-cursor call is
+// write-only ({accountId, deviceId, lastSeenSeq}) and no peer information of
+// any kind reaches a client (verified against @glance-apps/sync vaultClient's
+// full API surface during the staged-rollout review). Until a fleet-visibility
+// mechanism exists (the capability-bundle / devices-endpoint proposal from
+// that review), (2) is an OPERATOR JUDGMENT — "I know every install that
+// syncs this account and none is pre-4.8" — not a queryable fact. Do not
+// remove the shim on (1) alone; if in doubt, the shim's only cost is a few
+// redundant tombstone entries that GC at 60 days.
 export const RETIRED_ID_DUAL_WRITE = true;
 
 export const RETIRED_TASK_IDS_STORAGE_KEY = 'day-planner-retired-task-ids';


### PR DESCRIPTION
## What

A pre-block-id client parsing a stamped vault line (`- [ ] Buy milk ^dg-k3x9q2mf`) swallows the token as title text and mints a duplicate task under a legacy content-derived id — a **ghost row** that syncs fleet-wide. But the corruption is self-identifying: the embedded token names the successor (`obsidian-dg-<id>`). This PR derives the retirement from the ghost itself and contains it at every sync ingress. Always on, no gate, no setting; standalone and independent of the fleet-gate decision.

**★ This is containment, not prevention** — stated plainly in the module header. The old client that minted the ghost keeps showing its local duplicate until it updates; nothing here reaches into an old build. What containment buys: the ghost stops propagating (current clients refuse or redirect it, and the derived retirement propagates the delete so the vault row dies), and the minting device self-repairs the moment it updates.

## Recognition (precision over recall)

A row is a ghost only when **all five** hold (`src/utils/obsidianGhostRows.js`):

1. `importSource === 'obsidian'` — only vault-derived rows qualify;
2. no `obsidianBlockId` — a properly-adopted row is never a ghost;
3. `obsidianRawTitle` ends in the exact emitted token shape (` ^dg-` + 8 chars of `[a-z0-9]`, end of line);
4. the row's id **equals** the legacy content hash of that mangled title — proving the row was minted by the legacy parser from exactly this text, not typed by a person under some other identity;
5. the successor the token names is **live** in the current task lists.

Failing to contain a ghost is recoverable; eating a real task is not. The test line `Test three ^dg-testtest` passes rules 1–4 when written as a real vault task — rule 5 is the shield: no live task has block id `testtest`, so the row passes through untouched (tested). A false positive would require a user-typed 8-char string coinciding with a real live block id on a hash-consistent untagged vault row — at which point the row is, by every observable property, a mint of that task's stamped line.

## Successor absent → nothing happens (confirmed, not assumed)

Containment reuses `applyTaskRetirements` verbatim, and its conservatism with it: with no live successor the derived record authorizes nothing — same array back, no retirement recorded, ordinary tombstone semantics still apply. Covered by a dedicated test asserting reference equality on the input array.

## Action

- The swallowed token is **sanitized** out of the ghost's title (the specific recognized token only, never a general pattern) before the supersede — a newer ghost's redirect must not carry corruption onto the successor's title.
- Then the standard retirement supersede: **dropped** when older than the successor; content **redirected** onto the successor when newer, so a completion or reschedule made on the old client survives.
- Derived retirements are **persisted** into `retiredTaskIds` (+ the `RETIRED_ID_DUAL_WRITE` shim into `deletedTaskIds`), so the push guard propagates the ghost's vanish as `'retired'`, the vault row dies instead of echoing, and the old client's own `dropResurrectedTasks` stops re-uploading its copy. Provenance holds: this writer *knows* the successor — it derived it from the corruption itself (the provenance comment in `retiredTaskIds.js` now names this second writer).

## Wiring — all three ingresses, plus one #1454 taught us to look for

Per the tombstone echo war (#1454): a rule enforced at some ingresses but not all doesn't just under-enforce, it **loops**.

1. **`applyEngineData`** (App.jsx) — contain after the tombstone gate, persist the derived retirements.
2. **File-tier merge** (`mergeSync.js`) — ephemeral containment on the merge result, raising `localChanged`/`remoteChanged` so the *uploaded file itself* is cleansed.
3. **`dbEngine.applyRemoteEntity`** — polarity-aware pull gate: a ghost **older** than the mirror's live successor is refused at pull, the retirement recorded, and the entity marked dirty — the same cycle's push then soft-deletes the vault ghost row. A **newer** ghost deliberately passes through, so the apply-boundary redirect preserves the old client's edit before the guard deletes the vault row on the next push.
4. **Boot-time repair in `loadData`** (`useDataPersistence.js`) — found while testing self-repair: a sync cycle that applies nothing (`commitIsNoop`) never runs the apply path, so a local-only or just-updated minting device would never repair its own persisted duplicates. `repairLoadedGhostRows` runs at load; tray mode loads with `persist: false` (its state is a read snapshot and must not write localStorage).

## Sunset-condition fix (`RETIRED_ID_DUAL_WRITE`)

The shim's sunset comment previously cited a "Cloud Sync device list" — which does not exist. The staged-rollout review verified GLANCEvault's full client API surface: no device-list endpoint; the device-cursor call is write-only (`{accountId, deviceId, lastSeenSeq}`); no peer information of any kind reaches a client. The comment now says so plainly: condition (2) "no pre-retiredTaskIds client still syncs the account" is an **operator judgment**, not a queryable fact, until a fleet-visibility mechanism exists — and the shim must not be removed on the 60-day condition alone.

## Tests

`src/utils/obsidianGhostRows.test.js` (13) — recognition rules 1–4 precision negatives; older-ghost drop; newer-ghost redirect with sanitized title; cross-list containment; successor-absent fall-through; lookalike not eaten; persistence dual-write.

`src/sync/obsidianGhostContainment.test.js` (8, real `@glance-apps/sync` engine + memory vault) — ghost contained at the file tier with the uploaded file cleansed; newer-ghost redirect at file tier; successor-absent and lookalike rows preserved end-to-end; DB-tier older-ghost refused at pull with the vault row soft-deleted the same cycle and the fleet converged; DB-tier newer ghost redirected at apply then deleted by the guard; boot repair (ghost gone, completed edit survives, title token-free, retirement recorded); full sync self-repair (device pushes as-old, updates, boot-repairs, and two cycles later the vault ghost row is deleted and state converged).

Full suite: 152 files, 2277 tests passing. ESLint clean on all touched files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_