### PR TITLE
Flip OBSIDIAN_BLOCK_ID_WRITES: ship the Phase 2 write release

### DIFF
--- a/docs/obsidian-buildout-spec.md
+++ b/docs/obsidian-buildout-spec.md
@@ -150,15 +150,21 @@ The plugin runs unlisted (BRAT or manual install) through Phases 5 and 6. Submis
 
 ---
 
-### 3.9 Staged vault-format rollout: read-support first, write-support one release later
+### 3.9 Staged vault-format rollout: read-support first, containment as the safety net
 
-**Standing rule, not a one-time decision.** Any change to what dayGLANCE WRITES into the vault ships in two releases: first a release whose parser fully understands the new format but never emits it, then — one release later, once the reader has propagated — a release that enables emission. The gate is a build-time constant (`src/utils/obsidianWritePolicy.js`), never a user-facing setting: a setting pushes correctness onto the user, and someone always has a device they forgot about.
+**Standing rule, not a one-time decision.** Any change to what dayGLANCE WRITES into the vault ships in two releases: first a release whose parser fully understands the new format but never emits it, then a release that enables emission. The gate is a build-time constant (`src/utils/obsidianWritePolicy.js`), never a user-facing setting: a setting pushes correctness onto the user, and someone always has a device they forgot about.
 
-**Rationale.** The fleet spans five platforms on three release channels (dev, Developer ID, MAS, Play, App Store/TestFlight) whose store approvals never align, plus always-on appliances with vault access that lag behind updates. Every write-format change therefore has a mixed-version window measured in days. A client that does not understand a format token reads it as **title text**, hashes it into a brand-new content-derived id, and imports a duplicate that syncs fleet-wide — stable duplicates for the whole mixed window, surviving the update in the heavy-stamp case (analyzed for `^dg-` block ids, then observed live 2026-08-26). Shipping the reader first means that by the time any device emits the new format, every device can read it — the mixed window pairs a token-aware reader with the writer and no mangled identity can ever be minted.
+**Ordering discipline, not a guarantee.** Read-support-first is the right default for every vault-format change because it maximizes the share of the fleet that understands a new format before anything emits it. But release ordering **cannot be enforced** — a Docker user pulls `latest` after six months and skips every intermediate release, so "the reader has propagated" is a state nobody can observe and no release sequencing can produce. Read-first must not be relied on as a gate; it narrows the exposure window, nothing more.
+
+**Rationale for the exposure being worth narrowing.** The fleet spans five platforms on three release channels (dev, Developer ID, MAS, Play, App Store/TestFlight) whose store approvals never align, plus always-on appliances with vault access that lag behind updates. A client that does not understand a format token reads it as **title text**, hashes it into a brand-new content-derived id, and imports a duplicate that syncs fleet-wide — stable duplicates for the whole mixed window, surviving the update in the heavy-stamp case (analyzed for `^dg-` block ids, then observed live 2026-08-26).
+
+**Containment is the actual safety net.** Before any format's emitting release ships, evaluate whether a naive old parser's misread of that format is **self-identifying** — the way a `^dg-` token swallowed into a mangled title still names the very task it duplicates. Where it is, build containment: recognize the misread at every sync ingress AND at boot (PR #1457's fourth wiring point — a device that never syncs never repairs itself), derive the correct identity from the corruption, and retire the duplicate so it stops propagating and the minting device self-repairs on update. Where a misread would NOT be self-identifying, that is a design signal against the format as proposed — prefer a shape whose corruption carries its own antidote.
 
 **Read support means the FULL read semantics, not "strip and ignore."** A device that strips a token but still derives the old identity (e.g. hashing the clean title into a legacy id) keeps re-producing retired identities after a write-release device retires them — a milder seed of the same divergence. The read release carries everything except emission: recognition, identity adoption, bridging, dedup rules.
 
-**Applies next to Phase 4** (Tasks emoji metadata, Dataview inline fields, frontmatter) — a strictly larger write surface than block ids: each of those formats gets a read release before any device emits it.
+**Fleet-readiness gating: investigated and declined.** A per-account readiness gate (capability bundle in the sync payload, a GLANCEvault devices endpoint, cursor cross-referencing to detect stale clients) would make the ordering enforceable — and was deliberately not built: substantial permanent server-and-client surface for a solo maintainer, to close a gap that containment reduces to a bounded, temporary, self-healing inconvenience confined to the un-updated device's own screen. Recorded here so it is not rediscovered as a novel idea later.
+
+**Applies next to Phase 4** (Tasks emoji metadata, Dataview inline fields, frontmatter) — a strictly larger write surface than block ids: each of those formats gets a read release before any device emits it, and each gets the containment question asked, format by format, before its emitting release.
 
 ---
 
@@ -187,7 +193,7 @@ Relevant to Phases 6 and 7.
 
 ## 6. Phases
 
-Phases 0 and 1 are complete. Phases 2 through 4 are independent of the plugin and deliver value on their own.
+Phases 0 through 2 are complete. Phases 2 through 4 are independent of the plugin and deliver value on their own.
 
 ### Phase 0. Platform truth and write safety foundations — COMPLETE
 
@@ -241,11 +247,11 @@ Delivered by PRs #1435, #1444, #1445, and #1446; shipped with 4.7.0. See section
 
 ---
 
-### Phase 2. Block-ID identity
+### Phase 2. Block-ID identity — COMPLETE
 
 **Goal.** Give every dayGLANCE-managed task a stable identity in the vault that survives edits, reordering, and reformatting.
 
-**Status.** Part A delivered by PR #1439. Ships in TWO releases per the staged-rollout rule (3.9): the **read release** carries the full Part A read path — token recognition, `obsidian-dg-` adoption, the legacy bridge, first-occurrence-wins — with emission gated OFF (`OBSIDIAN_BLOCK_ID_WRITES = false` in `src/utils/obsidianWritePolicy.js`; new tasks and writes keep pre-Phase-2 behavior, and tokens already present in lines are preserved, never stripped). The **write release** is the one-line flip of that constant, once the read release has propagated to every channel. The scope below records the split and the semantics decided during implementation.
+**Status.** Complete. Part A delivered by PR #1439; shipped in TWO releases per the staged-rollout rule (3.9): the **read release** (PR #1456) carried the full Part A read path — token recognition, `obsidian-dg-` adoption, the legacy bridge, first-occurrence-wins — with emission gated OFF; the **write release** flipped `OBSIDIAN_BLOCK_ID_WRITES` to `true` in `src/utils/obsidianWritePolicy.js`, backed not by an unenforceable propagation guarantee but by ghost-row containment (PR #1457) as the safety net for straggler clients, per the amended 3.9. Tokens already present in lines are preserved, never stripped. Phase 3 depends on this phase and is now unblocked. The scope below records the split and the semantics decided during implementation.
 
 **Rationale.** Task identity is currently implicit, positional or text-matched. Every bug class fought in GLANCEvault (resurrection, phantom deletes, duplication) has a latent analog here and will surface as write surface grows. This is the highest-value single change in the plan.
 
@@ -304,7 +310,7 @@ Delivered by PRs #1435, #1444, #1445, and #1446; shipped with 4.7.0. See section
 
 **Rationale.** This is the cheapest real user-facing win in the plan and the thing that makes a directory listing compelling to someone already living in their vault.
 
-**Rollout.** Subject to the staged-rollout rule (3.9), format by format: a release that parses Tasks emoji / Dataview fields / frontmatter without emitting them, then the emitting release. This surface is strictly larger than block ids — an emoji date or an inline field misread as title text corrupts identity hashing exactly the way a `^dg-` token did.
+**Rollout.** Subject to the staged-rollout rule as amended (3.9), format by format: a release that parses Tasks emoji / Dataview fields / frontmatter without emitting them, then the emitting release — with read-first understood as an exposure-narrowing discipline, not a gate. This surface is strictly larger than block ids — an emoji date or an inline field misread as title text corrupts identity hashing exactly the way a `^dg-` token did — so **each format gets the 3.9 containment question asked before its emitting release ships**: is an old parser's misread of THIS format self-identifying, and if so, where is the containment built (all sync ingresses plus boot)? A format whose misread is not self-identifying needs a redesign or an explicit accepted-risk record before it emits.
 
 ---
 

--- a/src/utils/obsidianWritePolicy.js
+++ b/src/utils/obsidianWritePolicy.js
@@ -1,9 +1,9 @@
 // The Phase 2 READ/WRITE release split — the vault write-format gate.
 //
 // ═══ THE WRITE-RELEASE SWITCH ══════════════════════════════════════════════
-// Flip this ONE constant to `true` to ship the write release. Nothing else
-// changes. Grep anchor: OBSIDIAN_BLOCK_ID_WRITES.
-export const OBSIDIAN_BLOCK_ID_WRITES = false;
+// This ONE constant is the write release. Nothing else changes on a flip.
+// Grep anchor: OBSIDIAN_BLOCK_ID_WRITES.
+export const OBSIDIAN_BLOCK_ID_WRITES = true;
 // ═══════════════════════════════════════════════════════════════════════════
 //
 // THE STANDING RULE (docs/obsidian-buildout-spec.md, "Staged vault-format
@@ -15,9 +15,25 @@ export const OBSIDIAN_BLOCK_ID_WRITES = false;
 // reads it as TITLE TEXT, hashes it into a brand-new content-derived id, and
 // imports a duplicate that syncs fleet-wide (the staged-rollout analysis, and
 // the live incident of 2026-08-26: stable duplicates for the whole mixed
-// window, surviving the update in the heavy-stamp case). Shipping the READER
-// first means that by the time any device emits the new format, every device
-// understands it.
+// window, surviving the update in the heavy-stamp case).
+//
+// WHAT READ-FIRST ACTUALLY BUYS — an ordering discipline, NOT a guarantee.
+// Release ordering cannot be enforced: a Docker user pulls `latest` after six
+// months and skips every intermediate release, so "once the read release has
+// propagated" is a state no one can observe and no sequencing can produce.
+// Read-first MAXIMIZES the share of the fleet that understands a format
+// before anything emits it; it guarantees nothing about the stragglers.
+// The fleet-readiness gate that WOULD guarantee it (per-account capability
+// bundle, a GLANCEvault devices endpoint, cursor cross-referencing) was
+// investigated and deliberately NOT built: substantial permanent server+client
+// surface for a solo maintainer, to close a gap that ghost-row containment
+// (utils/obsidianGhostRows.js, PR #1457) reduces to a temporary inconvenience.
+// What we accept instead: an old client reading a stamped vault mints local
+// duplicates it shows to its OWN user until it updates. Those duplicates no
+// longer propagate to current clients — every sync ingress and boot-time load
+// contains them, the derived retirement kills the vault ghost row — and the
+// minting device self-repairs the moment it updates. Bounded, temporary,
+// self-healing; that is the basis on which this constant reads `true`.
 //
 // WHY THE READER IS THE FULL PHASE 2 READ PATH, not merely "strip and
 // ignore": a device that strips `^dg-` tokens but still hashes the clean

--- a/src/utils/obsidianWritePolicy.test.js
+++ b/src/utils/obsidianWritePolicy.test.js
@@ -5,13 +5,15 @@ import { buildNewObsidianTaskMeta, simpleHash, blockIdSuffix } from '../obsidian
 afterEach(() => __setBlockIdWritesForTests(null));
 
 describe('the read/write release gate', () => {
-  it('SHIPS READ-ONLY: the constant is false until the write release flips it', () => {
-    // This is the release switch itself. When shipping the write release,
-    // flip OBSIDIAN_BLOCK_ID_WRITES to true in obsidianWritePolicy.js and
-    // update THIS assertion — the failure is the reminder that the flip is a
-    // release decision, not a side effect.
-    expect(OBSIDIAN_BLOCK_ID_WRITES).toBe(false);
-    expect(blockIdWritesEnabled()).toBe(false);
+  it('SHIPS WRITES ON: the write release flipped the constant to true', () => {
+    // This is the release switch itself. The write release shipped the flip
+    // (with ghost-row containment, PR #1457, as the safety net for stragglers
+    // — see the module header). Flipping it BACK is equally a release
+    // decision: update THIS assertion alongside any change to the constant —
+    // the failure is the reminder that the flip leaves a mark in the diff,
+    // never a side effect.
+    expect(OBSIDIAN_BLOCK_ID_WRITES).toBe(true);
+    expect(blockIdWritesEnabled()).toBe(true);
   });
 
   it('the test override forces either mode and restores the constant', () => {


### PR DESCRIPTION
## What

`OBSIDIAN_BLOCK_ID_WRITES = true` — the Phase 2 write release. New vault-bound tasks mint `obsidian-dg-<blockId>` identities and stamp `^dg-` tokens; existing untagged tasks acquire ids opportunistically on write, exactly as PR #1439 built and PR #1456 gated.

The named release-switch test flips with the constant and now asserts the shipped default is **true** — the mechanism keeps working in the other direction, so a future flip back is equally a visible release decision in the diff, never a side effect.

## The recorded reasoning (module header rewritten)

The header previously framed the gate as "off until the read release has propagated." That's not the basis this ships on, and the header now says what is:

- **Release ordering can't be enforced.** A Docker user pulls `latest` after six months and skips every intermediate release. "The reader has propagated" is a state nobody can observe and no sequencing can produce. Read-first maximizes readiness; it guarantees nothing.
- **The fleet-readiness gate was investigated and deliberately not built** — capability bundle, GLANCEvault devices endpoint, cursor cross-referencing, per-account readiness: substantial permanent server-and-client surface for a solo maintainer, to close a gap that ghost-row containment reduces to a temporary inconvenience.
- **What we accept instead:** an old client reading a stamped vault mints local duplicates it shows its own user until it updates. Those duplicates no longer propagate to current clients (PR #1457 — every sync ingress plus boot-time load contains them, and the derived retirement kills the vault ghost row), and the minting device self-repairs the moment it updates. Bounded, temporary, self-healing.

## Spec updates

- **§3.9 rewritten** ("read-support first, containment as the safety net"): read-first stays the standing default for every vault-format change but is named for what it is — an exposure-narrowing ordering discipline, not a gate. The containment requirement is now explicit: before any format's emitting release, evaluate whether a naive old parser's misread is *self-identifying* (the way a swallowed `^dg-` token names the task it duplicates); where it is, build containment at all sync ingresses **and at boot** (#1457's fourth wiring point — a device that never syncs never repairs itself); where it isn't, that's a design signal against the format as proposed. Fleet-readiness gating is recorded as investigated-and-declined with the one-line why, so it isn't rediscovered as a novel idea later.
- **Phase 2 marked COMPLETE**, with the read/write release history and the containment-backed flip recorded, and Phase 3 noted as unblocked.
- **Phase 4's Rollout clause** points at the amended §3.9 and requires the containment question asked format by format — emoji dates and Dataview fields are a strictly larger misread surface than block ids, and each format needs its own answer before it emits.

## Tests

Full suite: 152 files, 2277 tests passing with the flipped default — every gate-sensitive test pins the mode explicitly via `__setBlockIdWritesForTests`, so only the named release-switch test tracks the shipped default, by design. ESLint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_