### PR TITLE
Honor native vault write results; make Electron vault writes atomic

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
@@ -133,12 +133,19 @@ class ObsidianRepository(private val context: Context) {
             it.bufferedReader().readText()
         } ?: ""
 
-    private fun writeText(file: DocumentFile, text: String) {
+    /**
+     * Returns whether the write reached the stream. A null stream (the provider
+     * refused to open the document) writes NOTHING and must report false — the
+     * JS side gates id/rawTitle bookkeeping on this result, and a false success
+     * here would commit app state for a line that never reached the vault.
+     * An IOException propagates to the caller's runCatching, same outcome.
+     */
+    private fun writeText(file: DocumentFile, text: String): Boolean {
         // Close the BufferedWriter (not just the raw OutputStream) so its internal
         // buffer is flushed to disk before the stream closes.  Closing only the
         // OutputStream while a BufferedWriter wraps it leaves the buffer unflushed,
         // which silently truncates the file to zero bytes.
-        val outputStream = context.contentResolver.openOutputStream(file.uri, "wt") ?: return
+        val outputStream = context.contentResolver.openOutputStream(file.uri, "wt") ?: return false
         outputStream.use { stream ->
             stream.bufferedWriter().use { writer ->
                 writer.write(text)
@@ -146,8 +153,9 @@ class ObsidianRepository(private val context: Context) {
         }
         // Announce only a write that actually reached the stream (a null stream
         // above wrote nothing and must not wake Obsidian).
-        val noteName = file.name?.removeSuffix(".md") ?: return
-        onVaultWrite?.invoke(noteName)
+        val noteName = file.name?.removeSuffix(".md")
+        if (noteName != null) onVaultWrite?.invoke(noteName)
+        return true
     }
 
     // ── Public API ───────────────────────────────────────────────────────────
@@ -226,7 +234,6 @@ class ObsidianRepository(private val context: Context) {
         // Ensure a newline separator before the new content
         val separator = if (existing.isNotEmpty() && !existing.endsWith("\n")) "\n" else ""
         writeText(file, "$existing$separator$content")
-        true
     }.getOrDefault(false)
 
     /**
@@ -292,7 +299,6 @@ class ObsidianRepository(private val context: Context) {
             ?: return false
 
         writeText(file, content)
-        true
     }.getOrDefault(false)
 
     /**
@@ -407,7 +413,6 @@ class ObsidianRepository(private val context: Context) {
         }
 
         writeText(file, content)
-        true
     }.getOrDefault(false)
 
     fun getTasksFromNote(path: String): String {

--- a/electron/atomicWrite.test.ts
+++ b/electron/atomicWrite.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { writeFileAtomicSync } from './atomicWrite.js';
+
+let dir: string;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dg-atomic-')); });
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+const listAll = () => fs.readdirSync(dir);
+
+describe('writeFileAtomicSync', () => {
+  it('creates a new file with the exact content', () => {
+    const target = path.join(dir, '2026-08-28.md');
+    writeFileAtomicSync(target, '## Tasks\n- [ ] Alpha\n');
+    expect(fs.readFileSync(target, 'utf-8')).toBe('## Tasks\n- [ ] Alpha\n');
+  });
+
+  it('replaces an existing file', () => {
+    const target = path.join(dir, 'note.md');
+    fs.writeFileSync(target, 'old');
+    writeFileAtomicSync(target, 'new content');
+    expect(fs.readFileSync(target, 'utf-8')).toBe('new content');
+  });
+
+  it('leaves no temp files behind on success', () => {
+    const target = path.join(dir, 'note.md');
+    writeFileAtomicSync(target, 'a');
+    writeFileAtomicSync(target, 'b');
+    expect(listAll()).toEqual(['note.md']);
+  });
+
+  it('temp files are dot-prefixed while staged, so Obsidian would never index them', () => {
+    // Stage a write into a directory whose rename target is occupied by a
+    // DIRECTORY — the rename fails, and the catch path must clean the temp
+    // file up. Before the failure, everything staged in the dir must be
+    // hidden (dot-prefixed).
+    const target = path.join(dir, 'occupied');
+    fs.mkdirSync(target);
+    expect(() => writeFileAtomicSync(target, 'x')).toThrow();
+    // Original directory untouched, no stray temp files.
+    expect(fs.statSync(target).isDirectory()).toBe(true);
+    expect(listAll()).toEqual(['occupied']);
+  });
+
+  it('a failed write leaves the ORIGINAL file intact (no truncate-then-die window)', () => {
+    const target = path.join(dir, 'daily.md');
+    fs.writeFileSync(target, 'precious original');
+    // Force the failure at the rename step: make the temp-file creation
+    // succeed but the target un-renamable by replacing it with a non-empty
+    // directory (rename onto a dir fails on every platform).
+    fs.rmSync(target);
+    fs.mkdirSync(target);
+    fs.writeFileSync(path.join(target, 'keep.md'), 'precious original');
+    expect(() => writeFileAtomicSync(target, 'new')).toThrow();
+    expect(fs.readFileSync(path.join(target, 'keep.md'), 'utf-8')).toBe('precious original');
+  });
+});

--- a/electron/atomicWrite.ts
+++ b/electron/atomicWrite.ts
@@ -1,0 +1,54 @@
+/**
+ * Atomic file replacement for vault writes.
+ *
+ * The obsidian:write-file handler was a bare fs.writeFileSync — open with
+ * O_TRUNC, then write. A crash (or power loss) between the truncate and the
+ * completed write leaves the file PARTIAL OR EMPTY, and the renderer-side
+ * Electron vault shim presents an FSA-like createWritable() surface, which on
+ * the real File System Access API IS atomic (swap file, commit on close) — so
+ * callers reasonably assume a safety this path never had. A truncated daily
+ * note is user data loss; this module closes that gap.
+ *
+ * Recipe: write the full content to a temp file in the SAME directory
+ * (same-volume, so the rename is a rename and not a copy), fsync it so the
+ * rename cannot be reordered ahead of the data reaching disk, then rename over
+ * the target — atomic on POSIX; on Windows Node uses MoveFileEx with
+ * replace-existing, which is the platform's standard best effort. On any
+ * failure the temp file is unlinked and the original is left untouched.
+ *
+ * The temp name is dot-prefixed: Obsidian ignores hidden files, so neither the
+ * vault indexer nor Obsidian Sync ever sees the intermediate file.
+ *
+ * Syscalls are wrapped in retryTransientFs — vaults live in synced folders
+ * (iCloud Drive included), where EINTR interruptions are the same observed
+ * hazard fsRetry.ts documents for the iCloud container.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import crypto from 'node:crypto';
+import { retryTransientFs } from './fsRetry.js';
+
+/** Write `content` to `abs`, replacing any existing file atomically. Throws on failure. */
+export function writeFileAtomicSync(abs: string, content: string): void {
+  const dir = path.dirname(abs);
+  const tmp = path.join(
+    dir,
+    `.${path.basename(abs)}.dgtmp-${process.pid.toString(36)}-${crypto.randomBytes(4).toString('hex')}`,
+  );
+  let fd: number | null = null;
+  try {
+    fd = retryTransientFs(() => fs.openSync(tmp, 'w'));
+    retryTransientFs(() => fs.writeFileSync(fd as number, content, 'utf-8'));
+    retryTransientFs(() => fs.fsyncSync(fd as number));
+    fs.closeSync(fd);
+    fd = null;
+    retryTransientFs(() => fs.renameSync(tmp, abs));
+  } catch (err) {
+    if (fd !== null) {
+      try { fs.closeSync(fd); } catch { /* already closed or invalid */ }
+    }
+    try { fs.unlinkSync(tmp); } catch { /* nothing staged, or already renamed */ }
+    throw err;
+  }
+}

--- a/electron/obsidian.ts
+++ b/electron/obsidian.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { buildObsidianOpenUri, buildObsidianOpenPathUri } from './obsidianUri.js';
 import { createLaunchScheduler } from './obsidianLaunch.js';
+import { writeFileAtomicSync } from './atomicWrite.js';
 
 // ── Obsidian vault access (Electron) ─────────────────────────────────────────
 //
@@ -219,12 +220,16 @@ export function registerObsidianHandlers(): void {
   // Post-write chokepoint: every desktop vault write — daily notes, task
   // write-back, wiki notes — reaches disk through this handler (via the shim's
   // createWritable().close()), so launch-on-write hooks here and nowhere else.
+  // Atomic (temp file + fsync + rename — see atomicWrite.ts): the shim's
+  // FSA-like createWritable() surface promises what real FSA delivers, and a
+  // bare writeFileSync here could truncate a daily note if the process died
+  // mid-write.
   ipcMain.handle('obsidian:write-file', async (_e, relativePath: string, content: string) => {
     const abs = resolveInVault(relativePath);
     if (!abs) return false;
     try {
       fs.mkdirSync(path.dirname(abs), { recursive: true });
-      fs.writeFileSync(abs, content, 'utf-8');
+      writeFileAtomicSync(abs, content);
       launchScheduler.noteWrite(abs);
       return true;
     } catch { return false; }

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -95,7 +95,14 @@ export default function useObsidianSync({
           return;
         }
       }
-      nativeWriteNote(notePath, content);
+      // Honor the bridge's write result, surfacing failure through the same
+      // visible sync-error state the desktop branch below uses — a silently
+      // ignored false return here was exactly the "silent write loss the user
+      // could never see" this comment block already warns about.
+      if (!nativeWriteNote(notePath, content)) {
+        setObsidianSyncError(`Note "${notePath}" was not written: the vault write failed.`);
+        setObsidianSyncStatus('error');
+      }
       return;
     }
     try {

--- a/src/native.js
+++ b/src/native.js
@@ -281,10 +281,16 @@ export const nativeGetTasksFromNote = (path) => {
   }
 };
 
+// Bridge write results are booleans on Android (@JavascriptInterface) but
+// STRINGS on iOS (the dgbridge:// XHR shim returns responseText, so a failed
+// write is the truthy string "false"). Write wrappers must normalize through
+// this — raw truthiness reads every iOS failure as success.
+const bridgeWriteOk = (v) => v === true || v === 'true';
+
 export const nativeAppendToNote = (path, content) => {
   const bridge = obsidianBridge();
   if (!bridge?.appendToNote) return false;
-  return bridge.appendToNote(path, content);
+  try { return bridgeWriteOk(bridge.appendToNote(path, content)); } catch { return false; }
 };
 
 /** Returns true if the vault root has been configured in the native settings. */
@@ -329,7 +335,7 @@ export const nativeGetNote = (path) => {
 export const nativeWriteNote = (path, content) => {
   const bridge = obsidianBridge();
   if (!bridge?.writeNote) return false;
-  try { return bridge.writeNote(path, content); } catch { return false; }
+  try { return bridgeWriteOk(bridge.writeNote(path, content)); } catch { return false; }
 };
 
 /**
@@ -339,7 +345,7 @@ export const nativeWriteNote = (path, content) => {
 export const nativeWriteDailyNote = (date, content) => {
   const bridge = obsidianBridge();
   if (!bridge?.writeDailyNote) return false;
-  try { return bridge.writeDailyNote(date, content); } catch { return false; }
+  try { return bridgeWriteOk(bridge.writeDailyNote(date, content)); } catch { return false; }
 };
 
 export const nativeScheduleReminder = (id, title, body, triggerAtMillis) => {

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -1367,9 +1367,18 @@ export async function syncObsidianVault(
  *
  * @param task {{ title, startTime, duration, isAllDay, date }}
  */
+// Native bridge write results are booleans on Android (@JavascriptInterface
+// marshals Kotlin's Boolean) but STRINGS on iOS — the dgbridge:// XHR shim
+// returns responseText, so a FAILED write comes back as the truthy string
+// "false". Success is exactly these two values; anything else (false, "false",
+// null, undefined) is a failed or unattempted write. Every native write site
+// must go through this — a raw truthiness check silently converts every iOS
+// failure into a success.
+const nativeWriteOk = (v) => v === true || v === 'true';
+
 export function appendTaskToDailyNoteNative(dateStr, task, heading, template) {
   const bridge = typeof window !== 'undefined' ? window.DayGlanceObsidian : null;
-  if (!bridge?.getDailyNote || !bridge?.writeDailyNote) return;
+  if (!bridge?.getDailyNote || !bridge?.writeDailyNote) return false;
 
   const existing = bridge.getDailyNote(dateStr);
   let content = (existing !== null && existing !== undefined) ? existing : (template || '');
@@ -1396,9 +1405,16 @@ export function appendTaskToDailyNoteNative(dateStr, task, heading, template) {
     ? sortTaskLinesInSection(lines, heading.trim(), dateStr)
     : lines;
   try {
-    bridge.writeDailyNote(dateStr, sorted.join('\n'));
+    // Honor the bridge's write result — mirrors the desktop caller, whose
+    // append promise rejects on a failed write and lands in a console.error.
+    if (!nativeWriteOk(bridge.writeDailyNote(dateStr, sorted.join('\n')))) {
+      console.error('[Obsidian native] Failed to write task to daily note: bridge reported write failure');
+      return false;
+    }
+    return true;
   } catch (err) {
     console.error('[Obsidian native] Failed to write task to daily note:', err);
+    return false;
   }
 }
 
@@ -1426,7 +1442,7 @@ export function writeDailyNoteNative(date, content) {
   const bridge = typeof window !== 'undefined' ? window.DayGlanceObsidian : null;
   if (!bridge?.writeDailyNote) return false;
   try {
-    return bridge.writeDailyNote(date, content);
+    return nativeWriteOk(bridge.writeDailyNote(date, content));
   } catch {
     return false;
   }
@@ -1440,9 +1456,14 @@ export function writeDailyNoteNative(date, content) {
  * as writeTaskStateToFile (shared updateTaskLines), then writes the result
  * back with writeDailyNote.
  *
- * @returns {boolean} whether a line was found and the note written — callers
- *   use this to commit a fresh block-id assignment only when it actually
- *   reached the vault.
+ * @returns {boolean} whether a line was found AND the bridge CONFIRMED the
+ *   write — callers use this to commit id/rawTitle bookkeeping (including a
+ *   fresh block-id assignment) only when it actually reached the vault. The
+ *   bridge's own result is honored via nativeWriteOk: returning `updated`
+ *   alone here once let a failed SAF write commit a block id no vault line
+ *   carried — an id no scan could ever match or tombstone. This is the native
+ *   half of the desktop contract, where the Electron shim's close() throws on
+ *   a failed write and the .then(commit) never runs.
  */
 export function writeTaskStateNative(date, obsidianRawTitle, completed, startTime, newRawTitle, duration, targetDate, taskHeading = null, blockId = null) {
   const bridge = typeof window !== 'undefined' ? window.DayGlanceObsidian : null;
@@ -1459,7 +1480,12 @@ export function writeTaskStateNative(date, obsidianRawTitle, completed, startTim
       const finalLines = taskHeading
         ? sortTaskLinesInSection(lines, taskHeading.trim(), date)
         : lines;
-      bridge.writeDailyNote(date, finalLines.join('\n'));
+      if (!nativeWriteOk(bridge.writeDailyNote(date, finalLines.join('\n')))) {
+        // Same surfacing as the desktop writeback's failure path: a console
+        // error, nothing user-facing.
+        console.error('Obsidian native writeback: vault write failed, not committing');
+        return false;
+      }
     }
     return updated;
   } catch (err) {

--- a/src/obsidian.nativeWriteContract.test.js
+++ b/src/obsidian.nativeWriteContract.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  writeTaskStateNative,
+  appendTaskToDailyNoteNative,
+  writeDailyNoteNative,
+} from './obsidian.js';
+import { nativeWriteNote, nativeAppendToNote, nativeWriteDailyNote } from './native.js';
+
+// The native write-success contract: commit-gating callers must see `false`
+// whenever the bridge did not CONFIRM the write. Two platform shapes feed the
+// same JS: Android's @JavascriptInterface returns real booleans; iOS's
+// dgbridge:// XHR shim returns responseText STRINGS — so a failed iOS write
+// arrives as the truthy string "false", which a raw truthiness check reads as
+// success. These tests pin the normalization at every native write site.
+
+const NOTE = '## Tasks\n- [ ] Buy milk\n';
+
+function installBridge(overrides = {}) {
+  const bridge = {
+    getDailyNote: vi.fn(() => NOTE),
+    writeDailyNote: vi.fn(() => true),
+    writeNote: vi.fn(() => true),
+    appendToNote: vi.fn(() => true),
+    ...overrides,
+  };
+  global.window = { DayGlanceObsidian: bridge };
+  return bridge;
+}
+
+beforeEach(() => { vi.spyOn(console, 'error').mockImplementation(() => {}); });
+afterEach(() => {
+  delete global.window;
+  vi.restoreAllMocks();
+});
+
+describe('writeTaskStateNative — the commit gate', () => {
+  const args = ['2026-08-28', 'Buy milk', true, null, undefined, null, undefined, '## Tasks', 'k3x9q2mf'];
+
+  it('returns true only when a line matched AND the bridge confirmed the write', () => {
+    const bridge = installBridge();
+    expect(writeTaskStateNative(...args)).toBe(true);
+    expect(bridge.writeDailyNote).toHaveBeenCalledTimes(1);
+  });
+
+  it('iOS string results are honored: "true" is success, "false" is FAILURE', () => {
+    installBridge({ writeDailyNote: vi.fn(() => 'true') });
+    expect(writeTaskStateNative(...args)).toBe(true);
+    installBridge({ writeDailyNote: vi.fn(() => 'false') });
+    expect(writeTaskStateNative(...args)).toBe(false);
+  });
+
+  it('an Android false return is a failure — no commit despite a matched line', () => {
+    installBridge({ writeDailyNote: vi.fn(() => false) });
+    expect(writeTaskStateNative(...args)).toBe(false);
+  });
+
+  it('a bridge that throws is a failure', () => {
+    installBridge({ writeDailyNote: vi.fn(() => { throw new Error('SAF says no'); }) });
+    expect(writeTaskStateNative(...args)).toBe(false);
+  });
+
+  it('no matching line still returns false without attempting a write', () => {
+    const bridge = installBridge({ getDailyNote: vi.fn(() => '## Tasks\n- [ ] Something else\n') });
+    expect(writeTaskStateNative(...args)).toBe(false);
+    expect(bridge.writeDailyNote).not.toHaveBeenCalled();
+  });
+});
+
+describe('appendTaskToDailyNoteNative', () => {
+  const task = { title: 'New task', importSource: 'obsidian', obsidianRawTitle: 'New task' };
+
+  it('returns true on a confirmed write', () => {
+    installBridge();
+    expect(appendTaskToDailyNoteNative('2026-08-28', task, '## Tasks', '')).toBe(true);
+  });
+
+  it('returns false and logs when the bridge reports failure (boolean or iOS string)', () => {
+    installBridge({ writeDailyNote: vi.fn(() => false) });
+    expect(appendTaskToDailyNoteNative('2026-08-28', task, '## Tasks', '')).toBe(false);
+    installBridge({ writeDailyNote: vi.fn(() => 'false') });
+    expect(appendTaskToDailyNoteNative('2026-08-28', task, '## Tasks', '')).toBe(false);
+    expect(console.error).toHaveBeenCalled();
+  });
+});
+
+describe('write wrappers normalize both platform shapes', () => {
+  it.each([
+    [true, true], ['true', true],
+    [false, false], ['false', false],
+    [null, false], [undefined, false], ['', false],
+  ])('bridge result %j → %j', (bridgeResult, expected) => {
+    installBridge({
+      writeDailyNote: vi.fn(() => bridgeResult),
+      writeNote: vi.fn(() => bridgeResult),
+      appendToNote: vi.fn(() => bridgeResult),
+    });
+    expect(writeDailyNoteNative('2026-08-28', 'x')).toBe(expected);
+    expect(nativeWriteDailyNote('2026-08-28', 'x')).toBe(expected);
+    expect(nativeWriteNote('Note', 'x')).toBe(expected);
+    expect(nativeAppendToNote('Note', 'x')).toBe(expected);
+  });
+
+  it('a throwing bridge yields false, never a thrown error', () => {
+    const boom = vi.fn(() => { throw new Error('provider refused'); });
+    installBridge({ writeDailyNote: boom, writeNote: boom, appendToNote: boom });
+    expect(writeDailyNoteNative('2026-08-28', 'x')).toBe(false);
+    expect(nativeWriteNote('Note', 'x')).toBe(false);
+    expect(nativeAppendToNote('Note', 'x')).toBe(false);
+  });
+});


### PR DESCRIPTION
Two contract fixes from the Phase 3 investigation, both live on the write-release fleet. No conflict-resolution, ownership, or what-wins-on-divergence semantics are touched — every change either refuses to commit app state for a write that did not happen, or makes the bytes-on-disk transition safer. (Confirmed while implementing; nothing surfaced that required a stop.)

## 1. Native write failures no longer report success

**The commit gate.** `writeTaskStateNative` ignored `bridge.writeDailyNote`'s return and returned `updated` — which only means a line matched — so a failed Android/iOS vault write still fired `commit()`: `obsidianRawTitle` advanced, and since the gate flip a freshly minted block id was committed to app state with no vault line carrying it (an id no scan can ever match or tombstone). The bridge result is now honored before `commit()` can run, matching the desktop contract where the Electron shim's `close()` throws and the `.then(commit)` never runs.

**The iOS trap.** Android's `@JavascriptInterface` returns real booleans, but iOS's `dgbridge://` XHR shim returns `responseText` **strings** — a failed iOS write arrives as the truthy string `"false"`. A raw truthiness check converts every iOS failure into a success. All native write sites now normalize through a shared success check (`v === true || v === 'true'`), with a comment at each helper explaining why.

**The audit asked for.** The same ignored-return shape appeared at every native write site; all are fixed:
- `writeTaskStateNative` — the commit gate above.
- `appendTaskToDailyNoteNative` — now returns a boolean and logs on failure, mirroring the desktop caller's `.catch(console.error)`.
- `writeDailyNoteNative`, `nativeWriteNote`, `nativeWriteDailyNote`, `nativeAppendToNote` — all normalize (and `nativeAppendToNote` gains the try/catch its siblings had).
- `saveWikiNote`'s native branch — a false return now surfaces through the same visible sync-error state the desktop branch already uses.
- Kotlin `ObsidianRepository.writeText` — now returns `Boolean` and reports **false on a null output stream** (previously it wrote nothing and returned normally, so `writeDailyNote` reported `true`); all three Kotlin callers (`writeDailyNote`, `writeNote`, `appendToNote`) propagate it. iOS's `ObsidianBridge` was already correct on the native side (`write(to:atomically:)`, `"true"`/`"false"` results) — its failures were only being lost in JS.

**Desktop surfacing, reported and matched:** task write-back failures and task-append failures surface as `console.error` only — nothing user-facing — so native now does exactly that. Wiki-note save failures *are* user-visible on desktop (sync-error state + `'error'` status), so the native branch now matches that too. If you want task-write failures made user-visible, that's the separate conversation you flagged — both platforms would get it together.

## 2. Electron vault writes are atomic

`obsidian:write-file` was a bare `fs.writeFileSync` — open-with-truncate, so a crash between truncate and completion truncated the note, while the renderer shim's FSA-like `createWritable()` surface implied the atomicity real FSA provides.

New `electron/atomicWrite.ts`: write the full content to a **dot-prefixed temp file in the target's own directory** (same volume, so the rename is a real rename; hidden, so neither Obsidian's indexer nor Obsidian Sync ever sees it), `fsync`, then `rename` over the target — atomic on POSIX, MoveFileEx-replace on Windows. On any failure the temp file is unlinked and the original is untouched.

**`fsRetry.ts` is used** — it fits: every syscall in the sequence is wrapped in `retryTransientFs`, since vaults live in synced folders (iCloud Drive included) where the EINTR hazard that module documents is exactly as applicable as in the iCloud container it was written for.

## Tests

- `src/obsidian.nativeWriteContract.test.js` (15): the commit gate returns false on bridge `false`, iOS `"false"`, and thrown errors; true only on confirmed writes; no write attempted when no line matches; append failure logged; every wrapper normalized across `true`/`"true"`/`false`/`"false"`/`null`/`undefined`/`""`.
- `electron/atomicWrite.test.ts` (5): create, replace, no temp-file residue, cleanup on failed rename, and the headline case — a failed write leaves the original content intact (no truncate-then-die window).
- Full suite: 154 files, 2297 tests passing. `tsc -p tsconfig.electron.json` clean. ESLint clean (electron/*.ts is outside the ESLint config's scope, pre-existing; tsc covers it). The Kotlin change has no runnable test infrastructure in this environment — it compiles by inspection and the JS-side tests pin the contract it feeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_