### PR TITLE
Make native vault reads report failure — a failed read must never feed the deletion detector

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/ObsidianBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/ObsidianBridge.kt
@@ -161,10 +161,13 @@ class ObsidianBridge(private val context: Context, private val webView: android.
 
     /**
      * Returns the raw markdown content of the daily note for [date] (ISO: yyyy-MM-dd).
-     * Returns "" if vault isn't configured or the note doesn't exist.
+     * "" means determinately absent-or-empty; NULL means the answer could not
+     * be determined (vault unconfigured, folder unnavigable, read failure) —
+     * JS must treat null as a FAILED read, never as an empty note (see
+     * ObsidianRepository.getDailyNote's read contract).
      */
     @JavascriptInterface
-    fun getDailyNote(date: String): String = repository.getDailyNote(date)
+    fun getDailyNote(date: String): String? = repository.getDailyNote(date)
 
     /**
      * Returns a JSON array of note paths (relative to vault root) in [folder].

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
@@ -110,6 +110,24 @@ class ObsidianRepository(private val context: Context) {
     }
 
     /**
+     * True when a vault URI is configured but the persisted SAF grant behind
+     * it is gone — the OS or the user revoked it. DocumentFile hides this
+     * (listFiles just returns empty on a revoked grant), so this is the only
+     * way to tell "the vault is empty" from "we can no longer see the vault
+     * at all". The scan uses it to fail loudly instead of reporting an empty
+     * vault, and the answer names the user's fix: re-pick the folder.
+     */
+    private fun vaultGrantRevoked(): Boolean {
+        val uriString = dataStore.vaultPath ?: return false
+        return try {
+            val uri = Uri.parse(uriString)
+            context.contentResolver.persistedUriPermissions.none { it.uri == uri && it.isReadPermission }
+        } catch (e: Exception) {
+            false // can't tell — never invent an error
+        }
+    }
+
+    /**
      * Traverses from this DocumentFile to a relative path such as "Daily Notes/2026"
      * by walking each path segment. Returns null if any segment is missing.
      */
@@ -136,10 +154,19 @@ class ObsidianRepository(private val context: Context) {
         return current
     }
 
-    private fun readText(file: DocumentFile): String =
+    /**
+     * Returns the file's content, or NULL when the read FAILED — a null input
+     * stream (the provider refused to open the document). The read-side twin
+     * of writeText's contract: "unreadable" must never masquerade as "empty",
+     * because an empty read of a listed daily note erases its task keys from
+     * the scan, and the deletion detector then tombstones them fleet-wide
+     * (within its drop threshold) as if the user had deleted the lines.
+     * An IOException propagates to the caller, same outcome.
+     */
+    private fun readText(file: DocumentFile): String? =
         context.contentResolver.openInputStream(file.uri)?.use {
             it.bufferedReader().readText()
-        } ?: ""
+        }
 
     /**
      * Returns whether the write reached the stream. A null stream (the provider
@@ -277,26 +304,32 @@ class ObsidianRepository(private val context: Context) {
 
     /**
      * Returns the raw markdown content of the daily note for [date] (ISO: yyyy-MM-dd).
-     * Returns "" if vault isn't configured, the folder is missing, or the note doesn't exist.
+     *
+     * READ CONTRACT: "" means the note is DETERMINATELY absent or empty (the
+     * folder was listed, no such file — or the file is genuinely empty);
+     * NULL means the answer could not be determined — vault unconfigured, an
+     * invalid date/pattern, an unnavigable folder, or a read failure. The JS
+     * side must never treat null as an empty note: an "empty" daily note
+     * erases its tasks from the scan and arms the deletion detector.
      */
-    fun getDailyNote(date: String): String {
-        val root = vaultRoot() ?: return ""
+    fun getDailyNote(date: String): String? {
+        val root = vaultRoot() ?: return null
         val folder = dataStore.dailyNoteFolder
         val pattern = dataStore.dailyNotePattern
 
         val localDate = try {
             LocalDate.parse(date)
         } catch (e: DateTimeParseException) {
-            return ""
+            return null
         }
         val formatter = try {
             DateTimeFormatter.ofPattern(pattern)
         } catch (e: IllegalArgumentException) {
-            return ""
+            return null
         }
 
         val fileName = "${localDate.format(formatter)}.md"
-        val dir = if (folder.isBlank()) root else (root.navigateTo(folder) ?: return "")
+        val dir = if (folder.isBlank()) root else (root.navigateTo(folder) ?: return null)
         // Heal a crashed write first: without this, the post-delete crash
         // window reads as "note gone" — which the deletion detector upstream
         // would treat as a real vault deletion.
@@ -350,7 +383,11 @@ class ObsidianRepository(private val context: Context) {
         // could read a freshly-created empty original while the real content
         // sits in a temp, and the append would then wipe the note.
         recoverIn(dir, fileName)
-        val existing = dir.findFile(fileName)?.let { readText(it) } ?: ""
+        // A FAILED read of an existing note must abort the append: treating
+        // it as "" would rewrite the note as just the appended line — erasing
+        // its content. An absent file is genuinely "" (fresh note).
+        val existingFile = dir.findFile(fileName)
+        val existing = if (existingFile != null) (readText(existingFile) ?: return false) else ""
         // Ensure a newline separator before the new content
         val separator = if (existing.isNotEmpty() && !existing.endsWith("\n")) "\n" else ""
         replaceText(dir, fileName, "$existing$separator$content")
@@ -423,27 +460,51 @@ class ObsidianRepository(private val context: Context) {
      * Pass an empty [cutoff] to return all notes.
      * Returns "[]" if the vault isn't configured or the folder doesn't exist.
      *
+     * READ CONTRACT — this is the scan the deletion detector diffs, so a read
+     * that FAILED must never shape the result:
+     *   • a LISTED note that cannot be read THROWS (IOException) — an empty
+     *     "text" would erase the note's task keys from the scan, and within
+     *     the detector's drop threshold those keys would be tombstoned
+     *     fleet-wide as user deletions;
+     *   • an EMPTY LISTING with the vault's SAF grant revoked THROWS
+     *     (SecurityException naming the fix) — DocumentFile hides revocation
+     *     as an empty directory, which the detector would treat as a real
+     *     (fully) empty vault.
+     * The sync bridge propagates the exception; the async wrapper reports it
+     * through the error callback. Either way the JS scan fails loudly and is
+     * treated as never having happened.
+     *
      * Preferred over repeated getDailyNote calls because a single native round trip is
      * far cheaper than N synchronous JS→native calls (each blocking the JS thread).
      */
     fun getAllDailyNotes(folder: String, cutoff: String): String {
         val root = vaultRoot() ?: return "[]"
-        val dir = if (folder.isBlank()) root else (root.navigateTo(folder) ?: return "[]")
+        val dir = if (folder.isBlank()) root else root.navigateTo(folder)
+        if (dir == null) {
+            if (vaultGrantRevoked()) throw SecurityException("Vault access has been revoked — re-select the vault folder in Settings")
+            return "[]"
+        }
         // Sweep crashed-write residue before the listing: a note stuck in the
         // post-delete window would otherwise be missing from this scan, and
         // the deletion detector would read that as a vault deletion.
         recoverStrayTemps(dir)
+        val files = dir.listFiles()
+        if (files.isEmpty() && vaultGrantRevoked()) {
+            throw SecurityException("Vault access has been revoked — re-select the vault folder in Settings")
+        }
         val arr = JSONArray()
-        dir.listFiles()
+        files
             .filter { it.isFile && it.name?.endsWith(".md") == true }
             .forEach { file ->
                 val name = file.name ?: return@forEach
                 val dateStr = name.removeSuffix(".md")
                 if (!dateStr.matches(Regex("""\d{4}-\d{2}-\d{2}"""))) return@forEach
                 if (cutoff.isNotBlank() && dateStr < cutoff) return@forEach
+                val text = readText(file)
+                    ?: throw java.io.IOException("Could not read daily note $name from the vault")
                 arr.put(JSONObject().apply {
                     put("date", dateStr)
-                    put("text", readText(file))
+                    put("text", text)
                     // The file's REAL modification time, so the web frontend's merge
                     // uses a truthful last-writer-wins timestamp instead of stamping
                     // every scanned note as "now". Mirrors getNote() below.
@@ -485,7 +546,12 @@ class ObsidianRepository(private val context: Context) {
             DocumentFile.fromSingleUri(context, uri) ?: return ""
         }
 
+        // A failed read returns an error envelope (an OBJECT, where success is
+        // also an object but with "text") rather than pretending the note is
+        // empty — the JS wrapper logs it and reports "not found" upward, but
+        // the distinction is on the wire for callers that need it.
         val text = readText(file)
+            ?: return JSONObject().apply { put("error", "note read failed") }.toString()
         val lastModified = Instant.ofEpochMilli(file.lastModified()).toString()
         return JSONObject().apply {
             put("text", text)
@@ -551,9 +617,13 @@ class ObsidianRepository(private val context: Context) {
         recoverIn(dir, fileName)
         val file = dir.findFile(fileName) ?: return "[]"
 
+        // Failed read → error envelope (object, not array); the JS wrapper
+        // maps it to null so no caller mistakes "unreadable" for "no tasks".
+        val noteText = readText(file)
+            ?: return JSONObject().apply { put("error", "note read failed") }.toString()
         val taskRegex = Regex("""^- \[([xX ])] (.+)$""")
         val arr = JSONArray()
-        readText(file).lines().forEachIndexed { index, line ->
+        noteText.lines().forEachIndexed { index, line ->
             val match = taskRegex.find(line.trim()) ?: return@forEachIndexed
             arr.put(JSONObject().apply {
                 put("text", match.groupValues[2])

--- a/dayglance-ios/DayGlance/Bridges/ObsidianBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/ObsidianBridge.swift
@@ -107,11 +107,18 @@ final class ObsidianBridge: NSObject {
 
     // MARK: - getDailyNote / writeDailyNote
 
-    func getDailyNote(date: String) -> String {
-        withVault(fallback: "") { vault in
-            guard let fileName = dailyNoteFileName(date: date) else { return "" }
+    /// READ CONTRACT: "" means the note is determinately absent or empty; nil
+    /// means the answer could not be determined — vault unconfigured, bookmark
+    /// or security-scope failure, or the file exists but cannot be read. The
+    /// scheme handler turns nil into a 500 and the JS shim into `null`; JS
+    /// must never treat that as an empty note (an "empty" daily note erases
+    /// its task keys from the scan and arms the deletion detector).
+    func getDailyNote(date: String) -> String? {
+        withVault(fallback: nil) { vault -> String? in
+            guard let fileName = dailyNoteFileName(date: date) else { return nil }
             let file = dailyNoteURL(vault: vault, fileName: fileName)
-            return (try? String(contentsOf: file, encoding: .utf8)) ?? ""
+            guard FileManager.default.fileExists(atPath: file.path) else { return "" }
+            return try? String(contentsOf: file, encoding: .utf8) // read failure → nil
         }
     }
 
@@ -145,8 +152,18 @@ final class ObsidianBridge: NSObject {
 
     // MARK: - getAllDailyNotes
 
+    /// READ CONTRACT — this is the scan the deletion detector diffs, so a
+    /// failed read must never shape the result. Success is a JSON ARRAY;
+    /// failure is a JSON OBJECT `{"error":"…"}` (JS checks Array.isArray and
+    /// fails the scan). Failures: the vault is configured but the bookmark or
+    /// security scope cannot be resolved (an "empty vault" answer there would
+    /// read as everything-deleted), or a listed daily note cannot be read (an
+    /// "empty note" answer would erase its task keys and, within the
+    /// detector's drop threshold, tombstone them fleet-wide). An unconfigured
+    /// vault is legitimately "[]".
     func getAllDailyNotes(folder: String, cutoff: String) -> String {
-        withVault(fallback: "[]") { vault in
+        guard UserDefaults.standard.data(forKey: bookmarkKey) != nil else { return "[]" }
+        return withVault(fallback: #"{"error":"vault access failed — the stored folder bookmark could not be opened"}"#) { vault in
             let dir = folder.isEmpty ? vault : vault.appendingPathComponent(folder)
             guard let entries = try? FileManager.default.contentsOfDirectory(
                 at: dir, includingPropertiesForKeys: nil
@@ -160,7 +177,9 @@ final class ObsidianBridge: NSObject {
                 let range = NSRange(dateStr.startIndex..., in: dateStr)
                 guard dateRe?.firstMatch(in: dateStr, range: range) != nil else { continue }
                 if !cutoff.isEmpty && dateStr < cutoff { continue }
-                let text = (try? String(contentsOf: entry, encoding: .utf8)) ?? ""
+                guard let text = try? String(contentsOf: entry, encoding: .utf8) else {
+                    return #"{"error":"could not read daily note \#(esc(dateStr)).md from the vault"}"#
+                }
                 items.append(#"{"date":"\#(dateStr)","text":"\#(esc(text))"}"#)
             }
 
@@ -180,7 +199,16 @@ final class ObsidianBridge: NSObject {
             let dir = folderPath.isEmpty ? vault : vault.appendingPathComponent(folderPath)
             createDirs(at: dir)
             let file = dir.appendingPathComponent(fileName)
-            let existing = (try? String(contentsOf: file, encoding: .utf8)) ?? ""
+            // A FAILED read of an existing note must abort the append: treating
+            // it as "" would rewrite the note as just the appended line,
+            // erasing its content. An absent file is genuinely "" (fresh note).
+            let existing: String
+            if FileManager.default.fileExists(atPath: file.path) {
+                guard let text = try? String(contentsOf: file, encoding: .utf8) else { return "false" }
+                existing = text
+            } else {
+                existing = ""
+            }
             let sep = (!existing.isEmpty && !existing.hasSuffix("\n")) ? "\n" : ""
             return write("\(existing)\(sep)\(content)", to: file) ? "true" : "false"
         }
@@ -202,7 +230,13 @@ final class ObsidianBridge: NSObject {
                 guard let indexed = noteIndex[noteName.lowercased()] else { return "" }
                 fileURL = indexed
             }
-            guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else { return "" }
+            // Missing file → "" (determinately absent). A file that EXISTS but
+            // cannot be read → error envelope, mirroring the Android contract:
+            // "unreadable" must never masquerade as "not found".
+            guard FileManager.default.fileExists(atPath: fileURL.path) else { return "" }
+            guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else {
+                return #"{"error":"note read failed"}"#
+            }
             let modified = (try? fileURL.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
             let iso = modified.map { ISO8601DateFormatter().string(from: $0) } ?? ""
             return #"{"text":"\#(esc(text))","lastModified":"\#(iso)"}"#
@@ -250,7 +284,12 @@ final class ObsidianBridge: NSObject {
             let fileURL    = folderPath.isEmpty
                 ? vault.appendingPathComponent(fileName)
                 : vault.appendingPathComponent(folderPath).appendingPathComponent(fileName)
-            guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else { return "[]" }
+            // Missing → "[]" (no tasks); exists-but-unreadable → error envelope
+            // so JS never mistakes a failed read for a taskless note.
+            guard FileManager.default.fileExists(atPath: fileURL.path) else { return "[]" }
+            guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else {
+                return #"{"error":"note read failed"}"#
+            }
 
             let taskRe = try? NSRegularExpression(pattern: #"^- \[([xX ])\] (.+)$"#)
             var items: [String] = []

--- a/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
+++ b/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
@@ -19,7 +19,12 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
 
     // MARK: - Routing
 
-    private func route(_ url: URL?) -> String {
+    /// nil means the call FAILED (respond() answers with a 500, which the JS
+    /// shim's `xhr.status === 200` check turns into a JS `null`). This is the
+    /// out-of-band failure channel: it can never collide with content, unlike
+    /// any in-band sentinel string — a daily note's raw markdown could contain
+    /// anything.
+    private func route(_ url: URL?) -> String? {
         guard let url,
               let host = url.host else { return "null" }
 
@@ -34,7 +39,7 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
 
     /// Add cases here as bridge phases are implemented.
     /// Phase 1: all methods return null — the stubs are filled in Phases 2–11.
-    private func dispatch(namespace: String, method: String, args: [Any]) -> String {
+    private func dispatch(namespace: String, method: String, args: [Any]) -> String? {
         switch namespace {
         case "native":
             return dispatchNative(method: method, args: args)
@@ -288,7 +293,7 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
         }
     }
 
-    private func dispatchObsidian(method: String, args: [Any]) -> String {
+    private func dispatchObsidian(method: String, args: [Any]) -> String? {
         switch method {
         case "pickVault":
             ObsidianBridge.shared.pickVault()
@@ -308,7 +313,12 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
             ObsidianBridge.shared.setVaultSettings(folder: folder, pattern: pattern, newNotesFolder: newFolder)
             return "null"
         case "getDailyNote":
-            guard let date = args.first as? String else { return "" }
+            // nil (→ 500 → JS null) means the read FAILED — vault unconfigured,
+            // bookmark/access failure, or an unreadable file. "" means the note
+            // is determinately absent or empty. JS must never treat a failure
+            // as an empty note: an "empty" daily note erases its task keys
+            // from the scan and arms the deletion detector.
+            guard let date = args.first as? String else { return nil }
             return ObsidianBridge.shared.getDailyNote(date: date)
         case "writeDailyNote":
             guard args.count >= 2,
@@ -363,11 +373,12 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
         return array
     }
 
-    private func respond(to task: any WKURLSchemeTask, with json: String) {
-        let data = json.data(using: .utf8) ?? Data()
+    private func respond(to task: any WKURLSchemeTask, with json: String?) {
+        // nil = the bridge call FAILED → 500, which the JS shim maps to null.
+        let data = (json ?? "").data(using: .utf8) ?? Data()
         let response = HTTPURLResponse(
             url: task.request.url ?? URL(string: "about:blank")!,
-            statusCode: 200,
+            statusCode: json == nil ? 500 : 200,
             httpVersion: "HTTP/1.1",
             headerFields: ["Content-Type": "application/json; charset=utf-8"]
         )!

--- a/src/native.js
+++ b/src/native.js
@@ -275,7 +275,14 @@ export const nativeGetTasksFromNote = (path) => {
   const bridge = obsidianBridge();
   if (!bridge?.getTasksFromNote) return null;
   try {
-    return JSON.parse(bridge.getTasksFromNote(path));
+    const parsed = JSON.parse(bridge.getTasksFromNote(path));
+    // Failed-read envelope (read contract): success is always an ARRAY, so a
+    // non-array means the read failed — report null, never an empty task list.
+    if (!Array.isArray(parsed)) {
+      console.warn(`[Obsidian native] Tasks read from "${path}" failed:`, parsed?.error);
+      return null;
+    }
+    return parsed;
   } catch {
     return null;
   }
@@ -321,7 +328,15 @@ export const nativeGetNote = (path) => {
   try {
     const raw = bridge.getNote(path);
     if (!raw) return null;
-    return JSON.parse(raw);
+    const parsed = JSON.parse(raw);
+    // Failed-read envelope (read contract): the note exists but could not be
+    // read. Reported upward as null (same as absent) but logged, so a read
+    // failure is never silently mistaken for "no such note".
+    if (parsed && parsed.error) {
+      console.warn(`[Obsidian native] Note "${path}" read failed:`, parsed.error);
+      return null;
+    }
+    return parsed;
   } catch {
     return null;
   }

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -1380,8 +1380,19 @@ export function appendTaskToDailyNoteNative(dateStr, task, heading, template) {
   const bridge = typeof window !== 'undefined' ? window.DayGlanceObsidian : null;
   if (!bridge?.getDailyNote || !bridge?.writeDailyNote) return false;
 
+  // READ CONTRACT (both bridges): "" = determinately absent-or-empty note;
+  // null = the read FAILED. A failed read must abort the append — falling
+  // back to the template here would OVERWRITE the real note with template
+  // plus one task line.
   const existing = bridge.getDailyNote(dateStr);
-  let content = (existing !== null && existing !== undefined) ? existing : (template || '');
+  if (existing === null || existing === undefined) {
+    console.error('[Obsidian native] Daily note read failed; not appending (the note may have content we cannot see)');
+    return false;
+  }
+  // "" (absent or empty note) keeps its longstanding native behavior: the
+  // task line starts the note. (The template fallback used to trigger only on
+  // a null read — which the failure contract above now correctly aborts.)
+  let content = existing;
 
   const taskLine = buildObsidianTaskLine(task, dateStr);
   const lines = content.split('\n');
@@ -1471,7 +1482,9 @@ export function writeTaskStateNative(date, obsidianRawTitle, completed, startTim
 
   try {
     const text = bridge.getDailyNote(date);
-    if (!text && text !== '') return false; // vault not configured
+    // null = vault not configured OR the read FAILED (the bridges' read
+    // contract) — either way, nothing can be safely rewritten.
+    if (!text && text !== '') return false;
 
     const lines = text.split('\n');
     const updated = updateTaskLines(lines, { obsidianRawTitle, completed, startTime, newRawTitle, duration, targetDate, blockId });
@@ -1607,13 +1620,29 @@ export async function syncObsidianVaultNative(folder, retentionDays, existingTas
       if (!fileName?.endsWith('.md')) continue;
       const dateStr = fileName.replace('.md', '');
       if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr) || dateStr < cutoffStr) continue;
-      try {
-        const text = bridge.getDailyNote(dateStr);
-        if (text !== null && text !== undefined) noteEntries.push({ date: dateStr, text });
-      } catch { /* skip unreadable notes */ }
+      // A LISTED note that cannot be read fails the WHOLE scan. Silently
+      // skipping it (the old behavior) removed the note key AND its task keys
+      // from the scan — feeding the deletion detector "these were deleted".
+      const text = bridge.getDailyNote(dateStr);
+      if (text === null || text === undefined) {
+        throw new Error(`Could not read daily note ${dateStr} from the vault`);
+      }
+      noteEntries.push({ date: dateStr, text });
     }
   } else {
     throw new Error('Obsidian bridge is missing required methods (getAllDailyNotes or listNotes)');
+  }
+
+  // FAILED-READ GATE. The native bridges signal a failed batch read as a JSON
+  // OBJECT `{"error":"…"}` where success is an ARRAY (iOS — its scheme handler
+  // cannot throw across the XHR shim), or by throwing (Android — surfaced
+  // above as a parse/dispatch error). This scan feeds the deletion detector:
+  // an unreadable vault that came back empty-shaped would tombstone task keys
+  // fleet-wide as user deletions. Failing here means the scan never happened —
+  // performObsidianSync's catch keeps the baseline, the tombstones, and the
+  // sync status untouched except for surfacing the error.
+  if (!Array.isArray(noteEntries)) {
+    throw new Error(noteEntries?.error || 'Vault read failed');
   }
 
   // Vault-wide duplicate-^dg-id guard, matching syncObsidianVault.

--- a/src/obsidian.nativeReadContract.test.js
+++ b/src/obsidian.nativeReadContract.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  syncObsidianVaultNative,
+  writeTaskStateNative,
+  appendTaskToDailyNoteNative,
+} from './obsidian.js';
+import { nativeGetNote, nativeGetTasksFromNote } from './native.js';
+import { detectObsidianDeletions } from './utils/obsidianDeletions.js';
+
+// The native READ contract — the read-side twin of the write contract
+// (obsidian.nativeWriteContract.test.js): a read that FAILED must be
+// distinguishable from a read that legitimately found nothing, because the
+// vault scan feeds the deletion detector. Signals: getDailyNote null (Android
+// nullable return / iOS 500→null via the XHR shim) = failed; batch reads
+// return a JSON OBJECT {"error":…} where success is an ARRAY (survives the
+// iOS string transport, which cannot carry booleans or exceptions).
+
+const NOTE = '## Tasks\n- [ ] Buy milk\n- [ ] Walk dog\n';
+
+function installBridge(overrides = {}) {
+  const bridge = {
+    getAllDailyNotes: vi.fn(() => JSON.stringify([{ date: '2026-08-28', text: NOTE, lastModified: '2026-08-28T10:00:00.000Z' }])),
+    getDailyNote: vi.fn(() => NOTE),
+    writeDailyNote: vi.fn(() => true),
+    listNotes: vi.fn(() => JSON.stringify(['2026-08-28.md'])),
+    getNote: vi.fn(() => JSON.stringify({ text: 'hi', lastModified: '2026-08-28T10:00:00.000Z' })),
+    getTasksFromNote: vi.fn(() => JSON.stringify([])),
+    ...overrides,
+  };
+  global.window = { DayGlanceObsidian: bridge };
+  return bridge;
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  delete global.window;
+  vi.restoreAllMocks();
+});
+
+describe('syncObsidianVaultNative — the scan fails loudly on failed reads', () => {
+  it('a healthy scan resolves with notes and tasks', async () => {
+    installBridge();
+    const r = await syncObsidianVaultNative('', 0, [], []);
+    expect(r.dailyNotes['2026-08-28'].text).toBe(NOTE);
+    expect(r.scheduledTasks.length + r.inboxTasks.length).toBe(2);
+  });
+
+  it('an iOS-style error envelope (object, not array) REJECTS the scan', async () => {
+    installBridge({ getAllDailyNotes: vi.fn(() => JSON.stringify({ error: 'vault access failed — the stored folder bookmark could not be opened' })) });
+    await expect(syncObsidianVaultNative('', 0, [], [])).rejects.toThrow(/vault access failed/);
+  });
+
+  it('an Android-style thrown read (revoked grant, unreadable note) REJECTS the scan', async () => {
+    installBridge({ getAllDailyNotes: vi.fn(() => { throw new Error('Vault access has been revoked — re-select the vault folder in Settings'); }) });
+    await expect(syncObsidianVaultNative('', 0, [], [])).rejects.toThrow(/revoked/);
+  });
+
+  it('async path: a dispatched error REJECTS the scan', async () => {
+    installBridge({
+      getAllDailyNotesAsync: vi.fn((folder, cutoff, id) => {
+        setTimeout(() => {
+          const cb = global.window.__obsidianCbs[id];
+          delete global.window.__obsidianCbs[id];
+          cb(null, 'Could not read daily note 2026-08-28.md from the vault');
+        }, 0);
+      }),
+    });
+    await expect(syncObsidianVaultNative('', 0, [], [])).rejects.toThrow(/Could not read daily note/);
+  });
+
+  it('async path: an error-envelope result REJECTS the scan', async () => {
+    installBridge({
+      getAllDailyNotesAsync: vi.fn((folder, cutoff, id) => {
+        setTimeout(() => {
+          const cb = global.window.__obsidianCbs[id];
+          delete global.window.__obsidianCbs[id];
+          cb(JSON.stringify({ error: 'could not read daily note 2026-08-28.md from the vault' }), null);
+        }, 0);
+      }),
+    });
+    await expect(syncObsidianVaultNative('', 0, [], [])).rejects.toThrow(/could not read/);
+  });
+
+  it('legacy fallback: a LISTED note whose read returns null REJECTS the scan instead of silently vanishing', async () => {
+    installBridge({
+      getAllDailyNotes: undefined,
+      getAllDailyNotesAsync: undefined,
+      getDailyNote: vi.fn(() => null),
+    });
+    await expect(syncObsidianVaultNative('', 0, [], [])).rejects.toThrow(/Could not read daily note 2026-08-28/);
+  });
+});
+
+describe('write paths refuse to act on a failed read', () => {
+  it('writeTaskStateNative: null daily note → false, nothing written', () => {
+    const bridge = installBridge({ getDailyNote: vi.fn(() => null) });
+    expect(writeTaskStateNative('2026-08-28', 'Buy milk', true, null)).toBe(false);
+    expect(bridge.writeDailyNote).not.toHaveBeenCalled();
+  });
+
+  it('appendTaskToDailyNoteNative: null daily note → false, nothing written (a template fallback would overwrite the unreadable note)', () => {
+    const bridge = installBridge({ getDailyNote: vi.fn(() => null) });
+    const ok = appendTaskToDailyNoteNative('2026-08-28', { title: 'New' }, '## Tasks', '# My Template');
+    expect(ok).toBe(false);
+    expect(bridge.writeDailyNote).not.toHaveBeenCalled();
+  });
+
+  it('appendTaskToDailyNoteNative: "" (determinately absent/empty) still appends', () => {
+    const bridge = installBridge({ getDailyNote: vi.fn(() => '') });
+    expect(appendTaskToDailyNoteNative('2026-08-28', { title: 'New' }, '## Tasks', '')).toBe(true);
+    expect(bridge.writeDailyNote).toHaveBeenCalledTimes(1);
+    expect(bridge.writeDailyNote.mock.calls[0][1]).toContain('New');
+  });
+});
+
+describe('wiki-note read wrappers surface the failure envelope as null, never as content', () => {
+  it('nativeGetNote: {"error":…} → null (logged), success object passes', () => {
+    installBridge({ getNote: vi.fn(() => JSON.stringify({ error: 'note read failed' })) });
+    expect(nativeGetNote('My Note')).toBeNull();
+    expect(console.warn).toHaveBeenCalled();
+    installBridge({ getNote: vi.fn(() => JSON.stringify({ text: 'content', lastModified: 'x' })) });
+    expect(nativeGetNote('My Note')).toEqual({ text: 'content', lastModified: 'x' });
+  });
+
+  it('nativeGetTasksFromNote: non-array → null, array passes', () => {
+    installBridge({ getTasksFromNote: vi.fn(() => JSON.stringify({ error: 'note read failed' })) });
+    expect(nativeGetTasksFromNote('My Note')).toBeNull();
+    installBridge({ getTasksFromNote: vi.fn(() => JSON.stringify([{ text: 'a', completed: false, line: 1 }])) });
+    expect(nativeGetTasksFromNote('My Note')).toEqual([{ text: 'a', completed: false, line: 1 }]);
+  });
+});
+
+describe('why reads must fail loudly: the detector tombstones a silently-emptied note', () => {
+  it('a note read as "" keeps its note key but loses its task keys — and within the drop threshold those keys WOULD be tombstoned', () => {
+    // The pre-fix hazard, pinned as documentation: this is what a silent ""
+    // read fed the detector. The fully-empty scan is caught ('empty-scan'),
+    // and a huge drop is caught ('drop-too-large') — but a PARTIAL silent
+    // failure walks right through and its deletions would sync fleet-wide.
+    const lastScanned = ['2026-08-28', 'obsidian-2026-08-28-h1', 'obsidian-2026-08-28-h2', '2026-08-27', 'obsidian-2026-08-27-h3'];
+    const currentWithSilentEmptyRead = ['2026-08-28', '2026-08-27', 'obsidian-2026-08-27-h3']; // 28th read as "" — note key present, task keys gone
+    const { deletions, skipped } = detectObsidianDeletions(lastScanned, currentWithSilentEmptyRead, null);
+    expect(skipped).toBe(false);
+    expect(deletions).toEqual(['obsidian-2026-08-28-h1', 'obsidian-2026-08-28-h2']);
+    // Post-fix, this input can no longer be PRODUCED by a failed read: every
+    // native read path above throws or returns null instead of "".
+  });
+});


### PR DESCRIPTION
The read-side twin of #1459's write contract. **Stacked on #1460** (both touch `readText`/`appendToNote`); GitHub retargets the base as the stack merges.

## ⚠ The answer to "can one device tombstone the fleet": yes — via a *partial* silent read failure

Traced before building (full detail in the session report):

- **Fully-empty failed scan: already safe.** `detectObsidianDeletions` skips it (`'empty-scan'`: had rows before, has none now → incomplete scan, no deletions, baseline preserved). A revoked SAF grant that empties the whole listing lands here. Large drops are likewise caught (`'drop-too-large'`, threshold `max(5, 25%)`).
- **The gap: a LISTED daily note whose read silently came back `""`.** The note key stays in the scan (the file was listed) while its **task keys vanish** (nothing parsed from `""`). That's a drop *within* the threshold → real `deletions` → tombstoned in `deletedObsidianKeys` → **syncs fleet-wide**, and the apply-boundary enforcement (#1454) deletes those tasks on every device. Re-import can't revive them — a fresh import carries epoch-0 `lastModified` and loses LWW to the tombstone — so affected tasks stay dead until the 60-day GC (or a vault-side retitle, which only helps untagged lines by minting a new identity). Repeated partial failures on later scans can walk through further ≤threshold batches. On Android the trigger is a per-document `openOutputStream`-style refusal (`openInputStream` null); on iOS, `try?` swallowed *every* per-file read error.
- **A second, immediate data-loss hole found in the audit:** `appendToNote` (both platforms) read the existing note before rewriting it — a silent `""` there rewrites the note as *just the appended line*, and the iOS null path substituted the daily **template**. No crash required.

## The contract (survives the iOS string transport — (e))

| Call | Success | Determinately absent/empty | FAILED |
|---|---|---|---|
| `getDailyNote` | text | `""` | **`null`** — Android `String?`; iOS scheme handler now answers **HTTP 500** on nil, which the XHR shim already maps to `null` (out-of-band: can never collide with note content, unlike any in-band sentinel) |
| `getAllDailyNotes` | JSON **array** | `[]` | Android **throws** (sync bridge propagates; the async wrapper already relays errors); iOS returns a JSON **object** `{"error":…}` — JS gates on `Array.isArray` and throws |
| `getNote` / `getTasksFromNote` | JSON object / array | `""` / `[]` | `{"error":…}` envelope → JS wrappers map to `null` with a warning |

**Android bonus, pre-building (e) for the surfacing PR:** `vaultGrantRevoked()` — a configured vault whose persisted SAF permission is gone. `DocumentFile` hides revocation as an empty directory; the scan now **throws a `SecurityException` naming the fix** ("re-select the vault folder in Settings") instead of reporting an empty vault. iOS throws the equivalent when a stored bookmark fails to resolve.

## (d) The audit — eight sites fixed

Android `readText` → `String?` (null stream = null, mirroring `writeText`'s contract) with every caller made explicit: `getDailyNote`, `getAllDailyNotes` (throw), `getNote` (envelope), `getTasksFromNote` (envelope), `appendToNote` (abort on failed read of an existing note), `SafDir.read` (already null-safe → `RESTORE_FAILED`, correct). iOS: `getDailyNote` (nil + `fileExists` to distinguish absent), `getAllDailyNotes` (envelopes for bookmark failure and per-file failure), `appendToNote` (abort), `getNote`/`getTasksFromNote` (envelopes). JS: the legacy per-note scan fallback **threw away unreadable notes silently** — erasing note *and* task keys — and now throws; `appendTaskToDailyNoteNative` aborts on null instead of falling back to the template.

**Documented, not fixed:** `listNotes` cannot distinguish a failed listing from an empty folder (`DocumentFile.listFiles` swallows provider errors internally); its consumers are cosmetic (wikilink candidates).

## (f) Scan behavior on a failed read

Exactly your instinct, and it's the state machine's existing failure path: the sync function **throws**, landing in `performObsidianSync`'s catch — error status surfaced, **no success**, **no detector run**, **`lastScanned` baseline and tombstones untouched**, no note/task merge. The scan is treated as never having happened, which is precisely what desktop has always done (FSA read errors throw). This also fixes the surfacing-proposal caveat: an Android outage scan now goes **red** instead of "succeeding" empty and clearing a fresh task-write error.

## Compatibility

Web assets and native bridges can skew (the legacy fallback exists for exactly that). New JS + old bridge: old bridges never return null/envelopes, so nothing new triggers. Old JS + new bridge: an envelope makes old JS throw (non-iterable) into the same catch, and Android's throw was always propagated — failures get louder, never quieter.

## Tests

`obsidian.nativeReadContract.test.js` (12): scan rejection on the iOS envelope, the Android throw, the async error dispatch, the async envelope, and the legacy null-note; `writeTaskStateNative` and `appendTaskToDailyNoteNative` refusing failed reads (including the template-overwrite case, with `""` still appending); wrapper envelope handling; and a detector-level test pinning the exact partial-silent-failure input this PR makes unproducible. Kotlin type-checked against the Android framework API surface (standalone kotlinc; Gradle needs the SDK and runs in CI). Full JS suite: **2309 passing**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_