### PR TITLE
Surface task-write and restore failures through the latched sync-error state

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/ObsidianBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/ObsidianBridge.kt
@@ -46,6 +46,24 @@ class ObsidianBridge(private val context: Context, private val webView: android.
 
     init {
         repository.onVaultWrite = { noteName -> launchPolicy.onWrite(noteName) }
+        // Crash-recovery outcomes → the web app's surfacing listener
+        // (useObsidianSync registers window.__dgVaultRestoreEvent). 'failed'
+        // means a note is missing and its temp couldn't be restored — the one
+        // recovery state a user may need to act on; 'restored' clears it.
+        // The outcome string is our own constant; the file name is escaped
+        // for the JS single-quoted literal.
+        repository.onRestoreEvent = { outcome, fileName ->
+            val safeName = fileName
+                .replace("\\", "\\\\")
+                .replace("'", "\\'")
+                .replace("\n", " ")
+            webView?.post {
+                webView.evaluateJavascript(
+                    "window.__dgVaultRestoreEvent && window.__dgVaultRestoreEvent('$outcome','$safeName')",
+                    null
+                )
+            }
+        }
     }
 
     /**

--- a/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/data/ObsidianRepository.kt
@@ -39,6 +39,18 @@ class ObsidianRepository(private val context: Context) {
     @Volatile
     var onVaultWrite: ((noteName: String) -> Unit)? = null
 
+    /**
+     * Crash-recovery outcome listener (surfacing, not control flow): invoked
+     * with 'failed' when a note is missing and its temp could not be restored
+     * (SafeReplace RESTORE_FAILED — the one recovery state a user may need to
+     * act on), and with 'restored' when a later retry lands, so the surfaced
+     * error can clear itself. Successful FIRST-TRY restores are deliberately
+     * silent — the note contains exactly what the interrupted write intended.
+     * ObsidianBridge wires this to a window event the web app listens on.
+     */
+    @Volatile
+    var onRestoreEvent: ((outcome: String, fileName: String) -> Unit)? = null
+
     // ── Note URI index ───────────────────────────────────────────────────────
     //
     // SAF recursive search (DocumentFile.listFiles + findFile) is expensive:
@@ -254,9 +266,15 @@ class ObsidianRepository(private val context: Context) {
             SafeReplace.Recovery.RESTORED_FROM_TEMP -> {
                 Log.w(TAG, "Restored $fileName from crashed write's temp")
                 onVaultWrite?.invoke(fileName.removeSuffix(".md"))
+                // Lets a previously SURFACED restore failure clear itself; a
+                // first-try restore stays silent (the JS listener ignores
+                // 'restored' unless a failure is latched).
+                onRestoreEvent?.invoke("restored", fileName)
             }
-            SafeReplace.Recovery.RESTORE_FAILED ->
+            SafeReplace.Recovery.RESTORE_FAILED -> {
                 Log.e(TAG, "Could not restore $fileName from crashed write's temp; leaving temp in place")
+                onRestoreEvent?.invoke("failed", fileName)
+            }
             SafeReplace.Recovery.NONE -> {}
         }
         return outcome

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2763,6 +2763,7 @@ const DayPlanner = () => {
     setUnportableVaultFiles,
     obsidianConfig, setObsidianConfig,
     obsidianLaunchOnWrite,
+    obsidianSyncError,
     setObsidianSyncStatus, setObsidianSyncError, setObsidianLastSynced,
     obsidianVaultHandleRef, obsidianSyncInProgressRef, obsidianPrevTaskStateRef,
     obsidianTasksRef, obsidianInboxRef,

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -42,6 +42,31 @@ import { blockIdWritesEnabled } from '../utils/obsidianWritePolicy.js';
  * handle and dedup refs) and are passed in, so existing persistence and
  * settings wiring is untouched.
  */
+// The one task-write failure message, latched (see the reporters below). It
+// names the CONDITION, never the tasks, and is precise about the actual retry
+// semantics: there is no background retry queue — a failed write re-attempts
+// when the task next changes.
+export const OBSIDIAN_TASK_WRITE_ERROR =
+  "Couldn't write to your Obsidian vault. Your changes are saved in dayGLANCE and will be written on the next edit.";
+
+// A note restore failed (Android crash-safe writes, SafeReplace RESTORE_FAILED):
+// the note is genuinely MISSING from the vault, so the task-write message's
+// reassurance ("your changes are saved in dayGLANCE") would be wrong — the
+// content at risk is the note's, and it is preserved in the hidden temp beside
+// where the note was.
+export const obsidianRestoreFailureMessage = (fileName) =>
+  `Vault note "${fileName}" is missing and couldn't be restored automatically. Its content is preserved in a hidden backup (".${fileName}.dgtmp") in the same folder — check the note in Obsidian.`;
+
+// Vault-ACCESS-LOSS scan errors persist instead of auto-dismissing: they are
+// the user's only signal (native reads used to fail silently — the #1461
+// contract made them throw these) and each names its own fix. Matched against
+// the bridge messages: Android's SecurityException "Vault access has been
+// revoked — re-select the vault folder in Settings" (ObsidianRepository
+// .getAllDailyNotes) and iOS's "vault access failed — the stored folder
+// bookmark could not be opened" (ObsidianBridge.getAllDailyNotes).
+export const isVaultAccessLossError = (message) =>
+  /revoked|bookmark could not be opened/i.test(message || '');
+
 export default function useObsidianSync({
   isTrayMode, dataLoaded,
   tasks, setTasks,
@@ -51,6 +76,7 @@ export default function useObsidianSync({
   setUnportableVaultFiles,
   obsidianConfig, setObsidianConfig,
   obsidianLaunchOnWrite,
+  obsidianSyncError,
   setObsidianSyncStatus, setObsidianSyncError, setObsidianLastSynced,
   obsidianVaultHandleRef, obsidianSyncInProgressRef, obsidianPrevTaskStateRef,
   obsidianTasksRef, obsidianInboxRef,
@@ -115,6 +141,72 @@ export default function useObsidianSync({
       setObsidianSyncStatus('error');
     }
   }, [obsidianConfig?.newNotesFolder, obsidianVaultHandleRef, setObsidianSyncError, setObsidianSyncStatus]);
+
+  // ── Task-write / restore failure surfacing ────────────────────────────────
+  //
+  // Task writes fire on every completion, reschedule and title edit, so the
+  // shape is a LATCH over the existing sync-error state, not per-failure
+  // alerts: the first failure sets the state once; further failures while
+  // latched do nothing (ten failed writes during an outage = one transition);
+  // and the error PERSISTS (no auto-dismiss) — the red sync-dot is the
+  // signal. Clearing: the next CONFIRMED task write (only when the displayed
+  // error is still ours — a concurrent wiki-note error must never be
+  // stomped), or the next successful scan (performObsidianSync's success path
+  // resets the channel wholesale, as it always has).
+
+  // Mirror of the displayed error, so the exact-match clears below can tell
+  // "our message is still showing" from "something else took the channel".
+  const syncErrorValueRef = useRef(obsidianSyncError);
+  useEffect(() => { syncErrorValueRef.current = obsidianSyncError; }, [obsidianSyncError]);
+
+  const taskWriteErrorRef = useRef(null); // the message we latched, or null
+  const restoreErrorRef = useRef(null);   // ditto, for a failed note restore
+
+  const reportTaskWriteFailure = useCallback(() => {
+    if (taskWriteErrorRef.current) return; // latched
+    taskWriteErrorRef.current = OBSIDIAN_TASK_WRITE_ERROR;
+    setObsidianSyncError(OBSIDIAN_TASK_WRITE_ERROR);
+    setObsidianSyncStatus('error');
+  }, [setObsidianSyncError, setObsidianSyncStatus]);
+
+  const reportTaskWriteSuccess = useCallback(() => {
+    const ours = taskWriteErrorRef.current;
+    if (!ours) return;
+    taskWriteErrorRef.current = null;
+    if (syncErrorValueRef.current === ours) {
+      setObsidianSyncError(null);
+      setObsidianSyncStatus('idle');
+    }
+  }, [setObsidianSyncError, setObsidianSyncStatus]);
+
+  // Android's crash-safe writes push restore outcomes up through this window
+  // hook (ObsidianBridge wires ObsidianRepository.onRestoreEvent to it).
+  // 'failed' = a note is missing from the vault and the restore didn't take —
+  // materially different from a failed write, hence its own message; a later
+  // 'restored' (every vault touch retries) clears it. Successful SILENT
+  // restores never reach here as errors — nothing to tell the user about a
+  // note that contains exactly what they last wrote.
+  useEffect(() => {
+    if (isTrayMode || typeof window === 'undefined') return undefined;
+    window.__dgVaultRestoreEvent = (outcome, fileName) => {
+      if (outcome === 'failed') {
+        if (restoreErrorRef.current) return; // latched — one indicator
+        const msg = obsidianRestoreFailureMessage(fileName);
+        restoreErrorRef.current = msg;
+        setObsidianSyncError(msg);
+        setObsidianSyncStatus('error');
+      } else if (outcome === 'restored') {
+        const ours = restoreErrorRef.current;
+        if (!ours) return;
+        restoreErrorRef.current = null;
+        if (syncErrorValueRef.current === ours) {
+          setObsidianSyncError(null);
+          setObsidianSyncStatus('idle');
+        }
+      }
+    };
+    return () => { delete window.__dgVaultRestoreEvent; };
+  }, [isTrayMode, setObsidianSyncError, setObsidianSyncStatus]);
 
   // Opens a vault note in the Obsidian app (Android) or via obsidian:// URI (web/desktop).
   const openInObsidian = useCallback((noteName) => {
@@ -323,14 +415,34 @@ export default function useObsidianSync({
       const now = new Date().toISOString();
       setObsidianLastSynced(now);
       localStorage.setItem('day-planner-obsidian-last-synced', now);
-      setObsidianSyncError(null);
-      setObsidianSyncStatus('success');
-      setTimeout(() => setObsidianSyncStatus(s => s === 'success' ? 'idle' : s), 3000);
+      // A successful scan proves the vault is reachable again — the channel
+      // reset clears any latched task-write error (clearing path 2).
+      taskWriteErrorRef.current = null;
+      if (restoreErrorRef.current) {
+        // …but a MISSING-NOTE condition outlives a successful scan (the scan
+        // legitimately completes without the missing file). Keep it showing;
+        // it clears on the 'restored' event when a retry lands.
+        setObsidianSyncError(restoreErrorRef.current);
+        setObsidianSyncStatus('error');
+      } else {
+        setObsidianSyncError(null);
+        setObsidianSyncStatus('success');
+        setTimeout(() => setObsidianSyncStatus(s => s === 'success' ? 'idle' : s), 3000);
+      }
     } catch (err) {
       console.error('Obsidian sync error:', err);
       setObsidianSyncError(err.message);
       setObsidianSyncStatus('error');
-      setTimeout(() => setObsidianSyncStatus(s => s === 'error' ? 'idle' : s), 5000);
+      // The scan error owns the channel now — release the task-write latch so
+      // a later write failure can re-report rather than being swallowed.
+      taskWriteErrorRef.current = null;
+      // Access-loss errors (revoked SAF grant, dead iOS bookmark — the #1461
+      // read contract throws these with the fix in the message) PERSIST: they
+      // are the user's only signal and don't heal on their own. Everything
+      // else keeps the longstanding transient flash.
+      if (!isVaultAccessLossError(err.message)) {
+        setTimeout(() => setObsidianSyncStatus(s => s === 'error' ? 'idle' : s), 5000);
+      }
     } finally {
       obsidianSyncInProgressRef.current = false;
       notifyNativeReady();
@@ -616,6 +728,10 @@ export default function useObsidianSync({
       };
 
       if (isNative) {
+        // onWriteFailure fires only on a GENUINE failure (unreadable note,
+        // refused write, exception) — never on the benign no-matching-line
+        // case, where the vault simply no longer has the line and the next
+        // scan reconciles. `updated` false alone can't tell the two apart.
         const updated = writeTaskStateNative(
           sourceDate,
           task.obsidianRawTitle,
@@ -626,6 +742,7 @@ export default function useObsidianSync({
           targetDate,
           taskHeading,
           writeBlockId,
+          reportTaskWriteFailure,
         );
         if (updated) nativeCommits.push(commit);
       } else {
@@ -642,8 +759,13 @@ export default function useObsidianSync({
           taskHeading,
           writeBlockId,
         ).then(updated => {
-          if (updated) commit();
-        }).catch(err => console.error('Obsidian: failed to write task state back', err));
+          // `updated` false here is the benign NotFound case (file gone —
+          // the scan reconciles); a real write failure REJECTS instead.
+          if (updated) { commit(); reportTaskWriteSuccess(); }
+        }).catch(err => {
+          console.error('Obsidian: failed to write task state back', err);
+          reportTaskWriteFailure();
+        });
       }
     }
 
@@ -665,6 +787,9 @@ export default function useObsidianSync({
     // on the fresh snapshot. (Desktop commits run in each write's own .then,
     // which also lands after this point.)
     for (const commit of nativeCommits) commit();
+    // Any confirmed native write proves the vault is writable again —
+    // clearing path 1 for a latched task-write error.
+    if (nativeCommits.length) reportTaskWriteSuccess();
     // Keyed on task changes — writeback fires when tasks change and reads the
     // current obsidianConfig paths + dedup refs at that moment. Adding the config
     // paths would re-run a writeback on a mere settings change.

--- a/src/hooks/useObsidianSync.surfacing.test.js
+++ b/src/hooks/useObsidianSync.surfacing.test.js
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Task-write / restore failure surfacing: the latched sync-error state.
+// Uses the retry test's capture pattern (mock React, run effects manually).
+
+const effects = [];
+vi.mock('react', () => ({
+  useEffect: (fn, deps) => { effects.push({ fn, deps }); },
+  useCallback: (fn) => fn,
+  useRef: (init) => ({ current: init }),
+}));
+
+const writeTaskStateToFile = vi.fn();
+const writeTaskStateNative = vi.fn();
+const syncObsidianVault = vi.fn();
+vi.mock('../obsidian.js', () => ({
+  tryRestoreVaultAccess: vi.fn(async () => null),
+  getVaultAccess: vi.fn(async () => null),
+  syncObsidianVault: (...a) => syncObsidianVault(...a),
+  syncObsidianVaultNative: vi.fn(async () => null),
+  writeTaskStateToFile: (...a) => writeTaskStateToFile(...a),
+  writeTaskStateNative: (...a) => writeTaskStateNative(...a),
+  simpleHash: vi.fn(() => 'h'),
+  generateBlockId: vi.fn(() => 'testblock'),
+  appIdForBlockId: vi.fn((b) => `obsidian-dg-${b}`),
+  readWikiNote: vi.fn(async () => null),
+  writeWikiNote: vi.fn(async () => {}),
+  scanVaultNotes: vi.fn(async () => ({ names: [], unportable: [] })),
+  OBSIDIAN_IMPORT_WINDOW_DAYS: 90,
+  obsidianWindowCutoffDate: vi.fn(() => null),
+}));
+vi.mock('../native.js', () => ({
+  isNativeAndroid: () => false,
+  isNativeApp: () => false,
+  nativeGetVaultConfig: vi.fn(() => null),
+  nativeGetNote: vi.fn(() => null),
+  nativeWriteNote: vi.fn(),
+  nativeOpenNote: vi.fn(),
+  nativeListNotes: vi.fn(() => []),
+  nativeSetVaultSettings: vi.fn(),
+  nativeSetLaunchOnWrite: vi.fn(),
+}));
+
+const {
+  default: useObsidianSync,
+  OBSIDIAN_TASK_WRITE_ERROR,
+  obsidianRestoreFailureMessage,
+  isVaultAccessLossError,
+} = await import('./useObsidianSync.js');
+
+const TASK_ID = 'obsidian-2026-08-28-h1';
+const changedTask = () => ({
+  id: TASK_ID, title: 'T #obsidian', obsidianRawTitle: 'T', importSource: 'obsidian',
+  completed: true, date: '2026-08-28', obsidianFileDate: '2026-08-28', startTime: null, duration: null,
+});
+const prevSnapshot = () => ({
+  [TASK_ID]: { completed: false, startTime: null, duration: null, title: 'T #obsidian', date: '2026-08-28' },
+});
+
+// setTimeout stub: sub-3s waits (the scan's 2s minimum-spinner fill) run
+// immediately; the 3s/5s status auto-dismiss timers are RECORDED, not run,
+// so tests can assert whether a dismiss was scheduled.
+let dismissTimers;
+
+function useMountedSurfacing({ handle = {}, tasks = [], prev = {}, displayedError = null, isNative = false } = {}) {
+  effects.length = 0;
+  dismissTimers = [];
+  vi.stubGlobal('setTimeout', (cb, ms) => { if (!ms || ms < 3000) cb(); else dismissTimers.push({ cb, ms }); return 1; });
+  vi.stubGlobal('setInterval', () => 1);
+  vi.stubGlobal('clearInterval', () => {});
+  vi.stubGlobal('document', { addEventListener: () => {}, removeEventListener: () => {}, visibilityState: 'visible' });
+  vi.stubGlobal('window', {});
+  const store = new Map();
+  vi.stubGlobal('localStorage', {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+  });
+
+  const setObsidianSyncError = vi.fn();
+  const setObsidianSyncStatus = vi.fn();
+  const prevRef = { current: prev };
+  const api = useObsidianSync({
+    isTrayMode: false,
+    dataLoaded: true,
+    tasks, setTasks: vi.fn(),
+    unscheduledTasks: [], setUnscheduledTasks: vi.fn(),
+    setDailyNotes: vi.fn(),
+    setWikilinkCandidates: vi.fn(),
+    setUnportableVaultFiles: vi.fn(),
+    obsidianConfig: { enabled: true, dailyNotesPath: '', dailyNotePattern: 'yyyy-MM-dd' },
+    setObsidianConfig: vi.fn(),
+    obsidianLaunchOnWrite: null,
+    obsidianSyncError: displayedError,
+    setObsidianSyncStatus, setObsidianSyncError,
+    setObsidianLastSynced: vi.fn(),
+    obsidianVaultHandleRef: { current: isNative ? 'native' : handle },
+    obsidianSyncInProgressRef: { current: false },
+    obsidianPrevTaskStateRef: prevRef,
+    obsidianTasksRef: { current: tasks },
+    obsidianInboxRef: { current: [] },
+  });
+  for (const e of effects) e.fn();
+  // Re-fires the writeback effect as if the same task changed again: the
+  // effect rebuilds the snapshot after each pass, so a plain re-run would see
+  // no delta — reset the snapshot to the pre-change state first.
+  const rerunWritebackWithChange = () => {
+    prevRef.current = JSON.parse(JSON.stringify(prev));
+    // The writeback effect: deps [tasks, unscheduledTasks, enabled] — the
+    // only THREE-dep effect keyed on the tasks array itself (the tasks-ref
+    // mirror has two deps; the restore-event effect's first dep is isTrayMode).
+    const writeback = effects.find((e) => Array.isArray(e.deps) && e.deps.length === 3 && e.deps[0] === tasks);
+    writeback.fn();
+  };
+  return { api, setObsidianSyncError, setObsidianSyncStatus, rerunWritebackWithChange };
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  writeTaskStateToFile.mockReset();
+  writeTaskStateNative.mockReset();
+  syncObsidianVault.mockReset();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const flush = () => new Promise((r) => process.nextTick(r));
+
+describe('the task-write failure latch', () => {
+  it('a failed desktop write surfaces ONCE, persists (no auto-dismiss), and repeated failures stay latched', async () => {
+    writeTaskStateToFile.mockRejectedValue(new Error('EIO'));
+    const { setObsidianSyncError, setObsidianSyncStatus, rerunWritebackWithChange } = useMountedSurfacing({ tasks: [changedTask()], prev: prevSnapshot() });
+    await flush();
+    expect(setObsidianSyncError).toHaveBeenCalledTimes(1);
+    expect(setObsidianSyncError).toHaveBeenCalledWith(OBSIDIAN_TASK_WRITE_ERROR);
+    expect(setObsidianSyncStatus).toHaveBeenCalledWith('error');
+    expect(dismissTimers).toEqual([]); // persistent: nothing scheduled to dismiss it
+
+    // Second failing pass while latched: no second transition.
+    rerunWritebackWithChange();
+    await flush();
+    expect(writeTaskStateToFile).toHaveBeenCalledTimes(2); // it really failed again
+    expect(setObsidianSyncError).toHaveBeenCalledTimes(1);
+  });
+
+  it('a pass failing on several tasks collapses to one transition', async () => {
+    writeTaskStateToFile.mockRejectedValue(new Error('EIO'));
+    const t2 = { ...changedTask(), id: 'obsidian-2026-08-28-h2', obsidianRawTitle: 'U', title: 'U #obsidian' };
+    const prev = { ...prevSnapshot(), 'obsidian-2026-08-28-h2': { completed: false, startTime: null, duration: null, title: 'U #obsidian', date: '2026-08-28' } };
+    const { setObsidianSyncError } = useMountedSurfacing({ tasks: [changedTask(), t2], prev });
+    await flush();
+    expect(writeTaskStateToFile).toHaveBeenCalledTimes(2);
+    expect(setObsidianSyncError).toHaveBeenCalledTimes(1);
+  });
+
+  it('a later CONFIRMED write clears the error when the displayed error is ours', async () => {
+    writeTaskStateToFile.mockRejectedValueOnce(new Error('EIO')).mockResolvedValue(true);
+    // Mounted with our message displayed (the mirror the exact-match uses).
+    const { setObsidianSyncError, setObsidianSyncStatus, rerunWritebackWithChange } = useMountedSurfacing({
+      tasks: [changedTask()], prev: prevSnapshot(), displayedError: OBSIDIAN_TASK_WRITE_ERROR,
+    });
+    await flush(); // first pass fails and latches
+    rerunWritebackWithChange(); // second pass succeeds
+    await flush();
+    expect(setObsidianSyncError).toHaveBeenLastCalledWith(null);
+    expect(setObsidianSyncStatus).toHaveBeenLastCalledWith('idle');
+  });
+
+  it('a concurrent wiki-note error is NEVER stomped by a task-write success', async () => {
+    writeTaskStateToFile.mockRejectedValueOnce(new Error('EIO')).mockResolvedValue(true);
+    // The displayed error is a wiki message, not ours.
+    const { setObsidianSyncError, rerunWritebackWithChange } = useMountedSurfacing({
+      tasks: [changedTask()], prev: prevSnapshot(), displayedError: 'Note "X" was not written: the vault write failed.',
+    });
+    await flush();
+    rerunWritebackWithChange();
+    await flush();
+    // The latch released, but no clearing calls were made for the wiki error.
+    expect(setObsidianSyncError).not.toHaveBeenCalledWith(null);
+  });
+
+  it('native: the onWriteFailure callback is passed and drives the same latch; benign no-match does not', async () => {
+    // Genuine failure: the mock invokes the callback (arg index 9), like
+    // writeTaskStateNative does on an unreadable note or refused write.
+    writeTaskStateNative.mockImplementation((...args) => { args[9]?.(); return false; });
+    const { setObsidianSyncError } = useMountedSurfacing({ tasks: [changedTask()], prev: prevSnapshot(), isNative: true });
+    await flush();
+    expect(setObsidianSyncError).toHaveBeenCalledWith(OBSIDIAN_TASK_WRITE_ERROR);
+
+    // Benign no-match: false WITHOUT the callback → no error surfaced.
+    writeTaskStateNative.mockImplementation(() => false);
+    const { setObsidianSyncError: quiet } = useMountedSurfacing({ tasks: [changedTask()], prev: prevSnapshot(), isNative: true });
+    await flush();
+    expect(quiet).not.toHaveBeenCalled();
+  });
+});
+
+describe('scan interplay', () => {
+  it('a successful scan clears the task-write latch (clearing path 2)', async () => {
+    writeTaskStateToFile.mockRejectedValue(new Error('EIO'));
+    syncObsidianVault.mockResolvedValue({ dailyNotes: {}, scheduledTasks: [], inboxTasks: [] });
+    const { api, setObsidianSyncError, setObsidianSyncStatus, rerunWritebackWithChange } = useMountedSurfacing({ tasks: [changedTask()], prev: prevSnapshot() });
+    await flush(); // write failure latches
+    await api.performObsidianSync();
+    expect(setObsidianSyncError).toHaveBeenLastCalledWith(null);
+    expect(setObsidianSyncStatus).toHaveBeenLastCalledWith('success');
+    // …and the latch is open again: a fresh failure re-reports.
+    rerunWritebackWithChange();
+    await flush();
+    expect(setObsidianSyncError).toHaveBeenLastCalledWith(OBSIDIAN_TASK_WRITE_ERROR);
+  });
+
+  it('an access-loss scan error persists; a generic scan error keeps the transient dismiss', async () => {
+    syncObsidianVault.mockRejectedValueOnce(new Error('Vault access has been revoked — re-select the vault folder in Settings'));
+    const { api, setObsidianSyncError } = useMountedSurfacing({});
+    await api.performObsidianSync();
+    expect(setObsidianSyncError).toHaveBeenLastCalledWith(expect.stringContaining('revoked'));
+    expect(dismissTimers).toEqual([]); // persistent
+
+    syncObsidianVault.mockRejectedValueOnce(new Error('Failed to parse daily notes from vault: boom'));
+    await api.performObsidianSync();
+    expect(dismissTimers.some((t) => t.ms === 5000)).toBe(true); // transient, as before
+  });
+
+  it('isVaultAccessLossError matches exactly the two bridge messages', () => {
+    expect(isVaultAccessLossError('Vault access has been revoked — re-select the vault folder in Settings')).toBe(true);
+    expect(isVaultAccessLossError('vault access failed — the stored folder bookmark could not be opened')).toBe(true);
+    expect(isVaultAccessLossError('Could not read daily note 2026-08-28.md from the vault')).toBe(false);
+    expect(isVaultAccessLossError(null)).toBe(false);
+  });
+});
+
+describe('RESTORE_FAILED surfacing (Android crash-safe writes)', () => {
+  it("'failed' surfaces the missing-note message — which never claims the changes are safe in dayGLANCE", () => {
+    const { setObsidianSyncError, setObsidianSyncStatus } = useMountedSurfacing({});
+    global.window.__dgVaultRestoreEvent('failed', '2026-08-28.md');
+    const msg = obsidianRestoreFailureMessage('2026-08-28.md');
+    expect(setObsidianSyncError).toHaveBeenCalledWith(msg);
+    expect(setObsidianSyncStatus).toHaveBeenCalledWith('error');
+    expect(msg).toContain('.2026-08-28.md.dgtmp'); // points at the hidden backup
+    expect(msg).not.toMatch(/saved in dayGLANCE/);  // the write message's reassurance would be wrong here
+    // Latched: a second 'failed' does not re-transition.
+    global.window.__dgVaultRestoreEvent('failed', '2026-08-28.md');
+    expect(setObsidianSyncError).toHaveBeenCalledTimes(1);
+  });
+
+  it("'restored' clears it when the displayed error is the restore message; a first-try restore is silent", () => {
+    const msg = obsidianRestoreFailureMessage('2026-08-28.md');
+    const { setObsidianSyncError, setObsidianSyncStatus } = useMountedSurfacing({ displayedError: msg });
+    // First-try restore with nothing latched: silent.
+    global.window.__dgVaultRestoreEvent('restored', '2026-08-28.md');
+    expect(setObsidianSyncError).not.toHaveBeenCalled();
+    // Failed → latched → restored → cleared.
+    global.window.__dgVaultRestoreEvent('failed', '2026-08-28.md');
+    global.window.__dgVaultRestoreEvent('restored', '2026-08-28.md');
+    expect(setObsidianSyncError).toHaveBeenLastCalledWith(null);
+    expect(setObsidianSyncStatus).toHaveBeenLastCalledWith('idle');
+  });
+
+  it('a missing-note error OUTLIVES a successful scan — the scan legitimately completes without the file', async () => {
+    syncObsidianVault.mockResolvedValue({ dailyNotes: {}, scheduledTasks: [], inboxTasks: [] });
+    const { api, setObsidianSyncError, setObsidianSyncStatus } = useMountedSurfacing({});
+    global.window.__dgVaultRestoreEvent('failed', '2026-08-28.md');
+    await api.performObsidianSync();
+    expect(setObsidianSyncError).toHaveBeenLastCalledWith(obsidianRestoreFailureMessage('2026-08-28.md'));
+    expect(setObsidianSyncStatus).toHaveBeenLastCalledWith('error');
+  });
+});

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -1476,15 +1476,20 @@ export function writeDailyNoteNative(date, content) {
  *   half of the desktop contract, where the Electron shim's close() throws on
  *   a failed write and the .then(commit) never runs.
  */
-export function writeTaskStateNative(date, obsidianRawTitle, completed, startTime, newRawTitle, duration, targetDate, taskHeading = null, blockId = null) {
+export function writeTaskStateNative(date, obsidianRawTitle, completed, startTime, newRawTitle, duration, targetDate, taskHeading = null, blockId = null, onWriteFailure = null) {
   const bridge = typeof window !== 'undefined' ? window.DayGlanceObsidian : null;
   if (!bridge?.getDailyNote || !bridge?.writeDailyNote) return false;
 
   try {
     const text = bridge.getDailyNote(date);
     // null = vault not configured OR the read FAILED (the bridges' read
-    // contract) — either way, nothing can be safely rewritten.
-    if (!text && text !== '') return false;
+    // contract) — either way, nothing can be safely rewritten. This IS a
+    // failure worth surfacing: the caller asked to write and the vault
+    // couldn't be reached.
+    if (!text && text !== '') {
+      onWriteFailure?.();
+      return false;
+    }
 
     const lines = text.split('\n');
     const updated = updateTaskLines(lines, { obsidianRawTitle, completed, startTime, newRawTitle, duration, targetDate, blockId });
@@ -1494,15 +1499,18 @@ export function writeTaskStateNative(date, obsidianRawTitle, completed, startTim
         ? sortTaskLinesInSection(lines, taskHeading.trim(), date)
         : lines;
       if (!nativeWriteOk(bridge.writeDailyNote(date, finalLines.join('\n')))) {
-        // Same surfacing as the desktop writeback's failure path: a console
-        // error, nothing user-facing.
         console.error('Obsidian native writeback: vault write failed, not committing');
+        onWriteFailure?.();
         return false;
       }
     }
+    // `updated` false without onWriteFailure is the BENIGN no-matching-line
+    // case: the vault no longer carries the line, which is the vault's truth
+    // and the next scan's job — not a write failure.
     return updated;
   } catch (err) {
     console.error('Obsidian native writeback error:', err);
+    onWriteFailure?.();
     return false;
   }
 }


### PR DESCRIPTION
Builds the approved surfacing proposal, plus the RESTORE_FAILED fold-in. Reporting only — no conflict-resolution, ownership, or divergence semantics touched. No settings.

## The latch

Task writes fire on every completion, reschedule, and title edit, so the surface is the **existing Obsidian sync-error state** (red sync-dot + tooltip, settings status line, toast — the same channel wiki-note failures already use), driven by a **latch**:

- First failure → one transition: `obsidianSyncError` set, status `'error'`, **no auto-dismiss** (the persistent red dot is the signal; task-write errors now persist exactly like wiki-note errors, not like the 5-second scan flash).
- Further failures while latched → nothing. A writeback pass failing on several tasks collapses to one transition (tested).
- The message names the condition, never the tasks: *"Couldn't write to your Obsidian vault. Your changes are saved in dayGLANCE and will be written on the next edit."*

**Precision about what counts as a failure:** `writeTaskStateNative` gains an `onWriteFailure` callback fired only on a *genuine* failure — unreadable note, refused write, exception — never on the benign no-matching-line case (the vault no longer carries the line; the next scan reconciles), which `updated === false` alone cannot distinguish. Desktop reports from the write promise's rejection, matching its existing throw-on-failure contract; its benign `NotFound → false` stays silent.

## Clearing — three paths, no stuck states

1. **Next confirmed task write** — releases the latch and clears the state *only when the displayed error is still ours*: the clear is an exact match against a mirror of the displayed error, so a concurrent wiki-note error (e.g. an unportable name) is never stomped (tested).
2. **Next successful scan** — the existing wholesale channel reset, which now also releases the latch so a later failure re-reports rather than being swallowed (tested).
3. **Vault reconnect** — triggers a scan; that's path 2.

## Android SAF revocation — rides #1461's scan error path

No separate `isVaultAccessible()` probe: #1461 already makes a revoked-grant scan throw a `SecurityException` naming the fix ("re-select the vault folder in Settings"), and iOS the equivalent for a dead bookmark. What was missing: those errors were subject to the scan path's **5-second auto-dismiss** — the last way a read failure still reached the user as near-silence (the "ALSO" answer). Now **vault-access-loss scan errors persist**; every other scan error keeps its longstanding transient flash. The match is against the two exact bridge messages, with grep-anchored comments on both sides.

## RESTORE_FAILED (from #1460)

A note genuinely missing from the vault is materially different from a failed write — the generic message's "your changes are saved in dayGLANCE" would be actively wrong, since the content at risk is the *note's*, preserved in the hidden temp. Its own message:

> *Vault note "X" is missing and couldn't be restored automatically. Its content is preserved in a hidden backup (".X.dgtmp") in the same folder — check the note in Obsidian.*

Wired as `ObsidianRepository.onRestoreEvent` → `ObsidianBridge` (escaped `evaluateJavascript`, same pattern as the async scan dispatch) → a `window.__dgVaultRestoreEvent` listener in `useObsidianSync`. Same channel, same latch discipline. Two deliberate behaviors:

- **`'restored'` clears it** — every vault touch retries the restore (#1460), so recovery self-announces. A first-try silent restore stays silent: the listener ignores `'restored'` unless a failure is latched.
- **The condition outlives a successful scan** — the scan legitimately completes without the missing file, so the success path re-asserts a latched restore error instead of clearing it (tested). It is the one error state that a green scan must not wipe.

## Tests

`useObsidianSync.surfacing.test.js` (11, capture-harness pattern): one transition per outage (single- and multi-task passes, with a second genuinely-failing pass held latched); persistence (no dismiss timer scheduled); clear-on-confirmed-write; wiki-error-not-stomped; native `onWriteFailure` vs. benign no-match; scan-success latch release + re-report; access-loss persistence vs. generic transient dismiss; the exact access-loss matcher; restore failed/restored lifecycle, first-try silence, and scan-survival. Kotlin type-checked against the Android framework surface; full JS suite **2320 passing**; ESLint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_