### PR TITLE
Fix NativeBridge.getDailyNote signature for the nullable read contract

### DIFF
--- a/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
+++ b/dayglance-android/app/src/main/java/com/dayglance/app/bridge/NativeBridge.kt
@@ -194,8 +194,11 @@ class NativeBridge(
 
     // ── Obsidian ────────────────────────────────────────────────────────────
 
+    // Read contract (#1461, same as ObsidianBridge.getDailyNote): "" means
+    // determinately absent-or-empty, NULL means the read failed — JS must
+    // never treat a failure as an empty note.
     @JavascriptInterface
-    fun getDailyNote(date: String): String = obsidian.getDailyNote(date)
+    fun getDailyNote(date: String): String? = obsidian.getDailyNote(date)
 
     @JavascriptInterface
     fun listNotes(folder: String): String = obsidian.listNotes(folder)


### PR DESCRIPTION
Fixes the Android release-build compile break:

```
NativeBridge.kt:198:46 Type mismatch: inferred type is String? but String was expected
```

#1461 changed `ObsidianRepository`/`ObsidianBridge.getDailyNote` to `String?` (null = failed read) but missed the **legacy delegation copy in `NativeBridge`**, which still declared `String`. The wrapper now propagates the nullable contract, with the contract comment attached.

Why it slipped: my pre-push verification type-checked the `data/` files against Android framework stubs but not the `bridge/` files (they pull app resources and sibling bridges the stub environment can't satisfy). Audited the rest of `NativeBridge`'s obsidian delegations for the same shape: `listNotes`, `appendToNote`, and `getTasksFromNote` delegate to signatures #1461 did not change (the failed-read signal for `getTasksFromNote` is an in-band JSON envelope, still `String`), and a repo-wide grep finds no other Kotlin consumer of the changed methods. JS-side null handling is already in place on every path — and the web app resolves the bridge via `window.DayGlanceObsidian`, so this surface is back-compat only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_