### PR TITLE
Skip byte-identical task writes — the no-op echo write reducer

### DIFF
--- a/docs/obsidian-buildout-spec.md
+++ b/docs/obsidian-buildout-spec.md
@@ -288,7 +288,7 @@ Delivered by PRs #1435, #1444, #1445, and #1446; shipped with 4.7.0. See section
 
 **Scope.**
 
-- Content-hash change detection, so a sync cycle with no delta writes nothing.
+- Content-hash change detection, so a sync cycle with no delta writes nothing. *(Delivered: a no-delta scan cycle was measured to already write nothing by construction; the remaining redundancy — the cross-device echo write — is closed by a byte-identity skip in both task write paths: when the would-be output equals what was just read, the disk write is skipped while the confirmed-write semantics are kept. The first echo after an Obsidian-side edit still writes, deliberately — the section sort normalizes the file once and steady-state echoes then skip; avoiding that first write would mean loosening byte-equality into semantic equality, i.e. changing what gets written, which this deliberately is not.)*
 - Modified-since-last-read guard before overwrite, so an edit made in Obsidian between sync cycles is not clobbered.
 - Verify write atomicity per transport. FSA's `createWritable()` provides atomicity by default via a swap file and rename. The Electron main-process path and the Android SAF path need explicit verification. *(Delivered: Electron temp+fsync+rename; Android temp/delete/rename with deterministic recovery; iOS was atomic all along; the write/read failure contracts and their surfacing shipped alongside.)*
 

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -808,9 +808,23 @@ export async function writeTaskStateToFile(vaultHandle, dailyNotesPath, dateStr,
     const finalLines = taskHeading
       ? sortTaskLinesInSection(lines, taskHeading.trim(), dateStr)
       : lines;
-    const writable = await fileHandle.createWritable();
-    await writable.write(finalLines.join('\n'));
-    await writable.close();
+    // NO-OP WRITE SKIP (churn reducer, byte-identity only — never a change to
+    // WHAT gets written). The cross-device echo write rewrites a line already
+    // carrying the state; when the would-be output equals what we just read,
+    // skip the disk write: no mtime churn, no Obsidian Sync churn, no
+    // launch-on-write wake for a vacuous write. The FIRST echo after an
+    // Obsidian-side edit is usually byte-DIFFERENT (the section sort
+    // normalizes, e.g. dropping a trailing blank line) and correctly still
+    // writes — the file converges to canonical form once, then steady-state
+    // echoes skip. `updated` stays true either way: the vault line carries
+    // exactly this state, so callers commit normally (needed when adopting a
+    // deterministically-minted token another device already stamped).
+    const finalText = finalLines.join('\n');
+    if (finalText !== text) {
+      const writable = await fileHandle.createWritable();
+      await writable.write(finalText);
+      await writable.close();
+    }
   }
   return updated;
 }
@@ -1572,7 +1586,12 @@ export function writeTaskStateNative(date, obsidianRawTitle, completed, startTim
       const finalLines = taskHeading
         ? sortTaskLinesInSection(lines, taskHeading.trim(), date)
         : lines;
-      if (!nativeWriteOk(bridge.writeDailyNote(date, finalLines.join('\n')))) {
+      // NO-OP WRITE SKIP — same churn reducer as writeTaskStateToFile: when
+      // the would-be output equals what we just read, the vault already
+      // carries this state; skip the write (and its Obsidian wake), keep the
+      // confirmed-success semantics.
+      const finalText = finalLines.join('\n');
+      if (finalText !== text && !nativeWriteOk(bridge.writeDailyNote(date, finalText))) {
         console.error('Obsidian native writeback: vault write failed, not committing');
         onWriteFailure?.();
         return false;

--- a/src/obsidian.noopWrites.test.js
+++ b/src/obsidian.noopWrites.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writeTaskStateToFile, writeTaskStateNative, deriveBlockId } from './obsidian.js';
+
+// The no-op write skip (Phase 3 content-hash change detection): a write whose
+// byte-identical output equals what was just read is skipped — the vault
+// already carries the state. Churn reducer only: it never changes WHAT gets
+// written, only WHETHER an identical write happens.
+
+function nfe() { const e = new Error('nf'); e.name = 'NotFoundError'; return e; }
+function makeFile(parent, name, counters) {
+  return {
+    kind: 'file', name,
+    async getFile() { counters.reads++; return { text: async () => parent[name], lastModified: 1 }; },
+    async createWritable() {
+      let buf = '';
+      return {
+        write: async (c) => { buf += c; },
+        close: async () => { counters.writes++; parent[name] = buf; },
+      };
+    },
+  };
+}
+function makeDir(node, counters, name = '') {
+  return {
+    kind: 'directory', name,
+    async getFileHandle(n, opts) {
+      if (typeof node[n] === 'string') return makeFile(node, n, counters);
+      if (opts?.create) { node[n] = ''; return makeFile(node, n, counters); }
+      throw nfe();
+    },
+    async getDirectoryHandle(n, opts) {
+      if (node[n] && typeof node[n] === 'object') return makeDir(node[n], counters, n);
+      if (opts?.create) { node[n] = {}; return makeDir(node[n], counters, n); }
+      throw nfe();
+    },
+    async *entries() {
+      for (const [n, v] of Object.entries(node)) yield [n, typeof v === 'string' ? makeFile(node, n, counters) : makeDir(v, counters, n)];
+    },
+    [Symbol.asyncIterator]() { return this.entries(); },
+  };
+}
+
+const DATE = '2026-08-31';
+const BLOCK = 'aaaa1111';
+const echoWrite = (handle) => writeTaskStateToFile(
+  handle, '', DATE, 'Alpha', /* completed */ true, null, undefined, null, undefined, '## Tasks', BLOCK,
+);
+
+describe('desktop no-op write skip', () => {
+  it('pins the echo sequence: the FIRST echo normalizes (writes), the second is byte-identical (skipped), updated true both times', async () => {
+    // The vault copy already carries the state (device A wrote it, Obsidian
+    // Sync delivered) — WITH the trailing newline Obsidian keeps on files.
+    const counters = { reads: 0, writes: 0 };
+    const vault = { [`${DATE}.md`]: `## Tasks\n- [x] Alpha ^dg-${BLOCK}\n` };
+    const handle = makeDir(vault, counters);
+
+    // First echo: sortTaskLinesInSection normalizes (drops the trailing
+    // blank), so the output is byte-DIFFERENT and the write correctly
+    // happens — the file converges to canonical form once.
+    expect(await echoWrite(handle)).toBe(true);
+    expect(counters.writes).toBe(1);
+    expect(vault[`${DATE}.md`]).toBe(`## Tasks\n- [x] Alpha ^dg-${BLOCK}`);
+
+    // Second and later echoes: byte-identical output → skipped.
+    expect(await echoWrite(handle)).toBe(true);
+    expect(await echoWrite(handle)).toBe(true);
+    expect(counters.writes).toBe(1); // still just the one normalizing write
+    expect(counters.reads).toBe(3);  // the pre-write read still happens every time
+  });
+
+  it('a genuinely different state still writes', async () => {
+    const counters = { reads: 0, writes: 0 };
+    const vault = { [`${DATE}.md`]: `## Tasks\n- [ ] Alpha ^dg-${BLOCK}` };
+    const handle = makeDir(vault, counters);
+    expect(await echoWrite(handle)).toBe(true);
+    expect(counters.writes).toBe(1);
+    expect(vault[`${DATE}.md`]).toContain('- [x] Alpha');
+  });
+
+  it('a skipped write still returns true so the caller COMMITS — adopting a token another device already stamped', async () => {
+    // Device A deterministically minted and stamped; device B's echo write
+    // derives the SAME token (#1464) and produces identical bytes. The write
+    // is skipped, but B must still commit the block-id adoption — the vault
+    // line carries exactly the state B asked for.
+    const minted = deriveBlockId(DATE, 'Alpha');
+    const counters = { reads: 0, writes: 0 };
+    const vault = { [`${DATE}.md`]: `## Tasks\n- [x] Alpha ^dg-${minted}` };
+    const handle = makeDir(vault, counters);
+    const updated = await writeTaskStateToFile(
+      handle, '', DATE, 'Alpha', true, null, undefined, null, undefined, '## Tasks', minted,
+    );
+    expect(updated).toBe(true);
+    expect(counters.writes).toBe(0);
+  });
+});
+
+describe('native no-op write skip', () => {
+  beforeEach(() => { vi.spyOn(console, 'error').mockImplementation(() => {}); });
+  afterEach(() => { delete global.window; vi.restoreAllMocks(); });
+
+  it('identical output skips bridge.writeDailyNote, returns true; different output writes', () => {
+    const canonical = `## Tasks\n- [x] Alpha ^dg-${BLOCK}`;
+    const bridge = {
+      getDailyNote: vi.fn(() => canonical),
+      writeDailyNote: vi.fn(() => true),
+    };
+    global.window = { DayGlanceObsidian: bridge };
+    expect(writeTaskStateNative(DATE, 'Alpha', true, null, undefined, null, undefined, '## Tasks', BLOCK)).toBe(true);
+    expect(bridge.writeDailyNote).not.toHaveBeenCalled(); // skipped — no write, no Obsidian wake
+
+    bridge.getDailyNote = vi.fn(() => `## Tasks\n- [ ] Alpha ^dg-${BLOCK}`);
+    expect(writeTaskStateNative(DATE, 'Alpha', true, null, undefined, null, undefined, '## Tasks', BLOCK)).toBe(true);
+    expect(bridge.writeDailyNote).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Phase 3's content-hash change detection, scoped to what measurement showed was actually redundant: a no-delta scan cycle already writes nothing by construction, so the remaining churn was the **cross-device echo write** — device B rewriting a line already carrying the state. Both task write paths (`writeTaskStateToFile`, `writeTaskStateNative`) now compare the would-be output against the text just read — both strings already in hand — and skip the disk write on **strict byte identity**: no mtime churn, no Obsidian Sync churn, no launch-on-write wake for a vacuous write.

**Churn reducer only, by design.** It never changes *what* gets written, only *whether* an identical write happens. Nothing in the build wanted to cross that line.

**The first-echo question, confirmed and answered.** Re-measured and pinned in a test: the first echo after an Obsidian-side edit is byte-*different* — `sortTaskLinesInSection` normalizes the file (it drops the trailing blank line Obsidian keeps) — so it correctly still writes, and the second and later echoes are byte-identical and skip. Letting the file converge to canonical form once is the right call: avoiding that first write would mean loosening byte-equality into semantic equality ("equal modulo normalization"), which is exactly the change-what-gets-written territory this PR is scoped to stay out of. Steady-state skipping holds between Obsidian-side edits; any Obsidian edit that restores the trailing newline makes the next write a (single) normalizing one again — pre-existing behavior, unchanged.

**`updated` stays true on a skip** — the vault line carries exactly the requested state, so callers commit normally. This is load-bearing for #1464: device B's echo derives the same token device A already stamped, produces identical bytes, skips the write, and must still adopt the block id into app state (tested).

## Tests (4; full suite 2351)

- The pinned echo sequence: first echo normalizes and writes; second and third are skipped; `updated` true throughout; the pre-write read still happens every time (the skip never caches).
- A genuine delta still writes.
- Skip-still-commits: deterministic-token adoption through a skipped write.
- Native variant: identical output never calls `bridge.writeDailyNote` (no Obsidian wake), different output does.

Spec: the Phase 3 scope item is marked delivered with the measurement result and the first-write reasoning recorded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_