### PR TITLE
Fix bridge wire format: the server stores envelope bytes, so the wire is base64

### DIFF
--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -28,6 +28,7 @@ import {
   applyBridgeIntent,
   openBridgeEnvelope,
   sealBridgeEnvelope,
+  encodePlainBridgeRow,
   observationEntityId,
   importBridgeSubkey,
   buildDateParser,
@@ -96,7 +97,9 @@ export async function publishPairingMeta(pairing: BridgePairing | null, previous
       accountId: pairing.accountId,
       rows: [{
         entityId: BRIDGE_PAIRING_META_ID,
-        envelope: JSON.stringify({
+        // Wire-encoded (base64), NOT encrypted — the server stores envelope
+        // bytes; see the format package's wire note.
+        envelope: encodePlainBridgeRow({
           v: 1, kind: 'pairing-meta',
           generation: pairing.generation, pairingSalt: pairing.pairingSalt, pairedAt: pairing.pairedAt,
         }),
@@ -116,6 +119,12 @@ export class BridgeTransport {
   private config: BridgeConfigRow | null = null;
   private observeTimers = new Map<string, number>();
   private warnedUnsupported = false;
+  // Once per plugin load (per generation), the drain re-asserts the
+  // meta:pairing row. Normally a no-op overwrite; it is also the self-heal
+  // for a row an older build wrote in the pre-base64 wire format (stored
+  // as garbage) — without it, dayGLANCE devices could never discover the
+  // pairing until the user re-paired.
+  private metaAssertedGeneration: string | null = null;
 
   constructor(host: BridgeHost) {
     this.host = host;
@@ -143,6 +152,10 @@ export class BridgeTransport {
     try {
       const client = this.client(pairing);
       const subkey = await this.subkeyFor(pairing);
+      if (this.metaAssertedGeneration !== pairing.generation) {
+        await publishPairingMeta(pairing);
+        this.metaAssertedGeneration = pairing.generation;
+      }
       const state = this.host.getBridgeState();
       const applied = new Set(state.appliedIds);
       let since = state.hwm;

--- a/packages/obsidian-format/src/bridgePairing.js
+++ b/packages/obsidian-format/src/bridgePairing.js
@@ -38,7 +38,15 @@ const CODE_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
 const CODE_LENGTH = 13;
 
 const enc = new TextEncoder();
-const b64 = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)));
+// Chunked bytes→base64 (String.fromCharCode arg-limit safety, matching
+// bridgeStream.js — offers are small today, but helpers shouldn't have
+// payload-size cliffs).
+const b64 = (bytes) => {
+  const u8 = new Uint8Array(bytes);
+  let s = '';
+  for (let i = 0; i < u8.length; i += 0x8000) s += String.fromCharCode(...u8.subarray(i, i + 0x8000));
+  return btoa(s);
+};
 const unb64 = (s) => Uint8Array.from(atob(s), (c) => c.charCodeAt(0));
 
 /** Mint a pairing code: 13 base32 chars (~65 bits), grouped for typing. */

--- a/packages/obsidian-format/src/bridgeStream.js
+++ b/packages/obsidian-format/src/bridgeStream.js
@@ -65,8 +65,17 @@ export const BRIDGE_INTENT_PREFIX = 'int:';
 export const BRIDGE_OBSERVATION_PREFIX = 'obs:';
 
 const enc = new TextEncoder();
-const b64 = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)));
+// Chunked bytes→base64: String.fromCharCode(...bytes) blows the argument
+// limit (~64k) on large payloads, and an observation carries a whole note.
+const b64 = (bytes) => {
+  const u8 = new Uint8Array(bytes);
+  let s = '';
+  for (let i = 0; i < u8.length; i += 0x8000) s += String.fromCharCode(...u8.subarray(i, i + 0x8000));
+  return btoa(s);
+};
 const unb64 = (s) => Uint8Array.from(atob(s), (c) => c.charCodeAt(0));
+const b64Text = (s) => b64(enc.encode(s));
+const unb64Text = (t) => new TextDecoder().decode(unb64(t));
 
 /** Assigned at write time, persisted with the intent. */
 export function mintIntentId() {
@@ -85,13 +94,23 @@ export async function observationEntityId(path) {
   return `${BRIDGE_OBSERVATION_PREFIX}${hex.slice(0, 32)}`;
 }
 
+// THE WIRE IS BASE64, NON-NEGOTIABLY: GLANCEvault's batch endpoint decodes
+// every row envelope with Buffer.from(envelope, 'base64') and stores the
+// BYTES, and list/get returns those bytes re-encoded as base64. Node's
+// base64 decoder never rejects — a non-base64 envelope (the first shape of
+// this module was raw JSON text) is silently shredded into garbage at
+// write time. So every envelope this module produces is a single valid
+// base64 string, and every reader decodes base64 first; the server round
+// trip is then byte-exact identity (pinned in the tests against the
+// server's exact Buffer semantics).
+
 /** Seal a payload into a row envelope under the bridge subkey. */
 export async function sealBridgeEnvelope(subkey, payload) {
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const ct = await crypto.subtle.encrypt(
     { name: 'AES-GCM', iv }, subkey, enc.encode(JSON.stringify(payload)),
   );
-  return JSON.stringify({ v: 1, iv: b64(iv), ct: b64(ct) });
+  return b64Text(JSON.stringify({ v: 1, iv: b64(iv), ct: b64(ct) }));
 }
 
 /**
@@ -101,12 +120,30 @@ export async function sealBridgeEnvelope(subkey, payload) {
  */
 export async function openBridgeEnvelope(subkey, text) {
   try {
-    const envelope = JSON.parse(text);
+    const envelope = JSON.parse(unb64Text(text));
     if (!envelope || envelope.v !== 1) return null;
     const pt = await crypto.subtle.decrypt(
       { name: 'AES-GCM', iv: unb64(envelope.iv) }, subkey, unb64(envelope.ct),
     );
     return JSON.parse(new TextDecoder().decode(pt));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Wire-encode a PLAINTEXT row (the meta:pairing row — deliberately not
+ * encrypted, see the module header; the salt it carries is not a secret).
+ * Base64 is transport framing here, not protection.
+ */
+export function encodePlainBridgeRow(payload) {
+  return b64Text(JSON.stringify(payload));
+}
+
+/** Decode a plaintext row; null for anything unusable. */
+export function decodePlainBridgeRow(text) {
+  try {
+    return JSON.parse(unb64Text(text));
   } catch {
     return null;
   }

--- a/packages/obsidian-format/src/bridgeStream.test.js
+++ b/packages/obsidian-format/src/bridgeStream.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   sealBridgeEnvelope,
   openBridgeEnvelope,
+  encodePlainBridgeRow,
+  decodePlainBridgeRow,
   applyBridgeIntent,
   mintIntentId,
   observationEntityId,
@@ -21,18 +23,46 @@ const otherKey = () => crypto.subtle.importKey(
   'raw', new Uint8Array(32).fill(4), 'AES-GCM', false, ['encrypt', 'decrypt'],
 );
 
+// THE SERVER'S ENVELOPE SEMANTICS, emulated exactly: GLANCEvault decodes
+// the wire envelope with Buffer.from(s, 'base64'), stores the bytes, and
+// serves them back with .toString('base64'). A non-base64 envelope is not
+// rejected — it is silently shredded. Every wire string this module emits
+// must survive this round trip byte-exactly.
+const serverRoundTrip = (envelope) => Buffer.from(envelope, 'base64').toString('base64');
+
 describe('row envelopes', () => {
   it('round-trip; wrong key, tampered, and malformed are ALL null (rotation makes old rows unreadable)', async () => {
     const key = await subkey();
     const sealed = await sealBridgeEnvelope(key, { kind: 'intent', type: 'daily_note_write' });
-    expect(JSON.parse(sealed).v).toBe(1);
     expect(sealed).not.toContain('daily_note_write');
     expect(await openBridgeEnvelope(key, sealed)).toEqual({ kind: 'intent', type: 'daily_note_write' });
     expect(await openBridgeEnvelope(await otherKey(), sealed)).toBe(null);
-    const parsed = JSON.parse(sealed);
-    parsed.ct = parsed.ct.slice(0, -4) + 'AAAA';
-    expect(await openBridgeEnvelope(key, JSON.stringify(parsed))).toBe(null);
+    expect(await openBridgeEnvelope(key, sealed.slice(0, -8) + 'AAAAAAAA')).toBe(null);
     expect(await openBridgeEnvelope(key, 'junk')).toBe(null);
+  });
+
+  it('every wire string SURVIVES the server (base64 bytes in, base64 bytes out) — the regression that shipped as raw JSON', async () => {
+    const key = await subkey();
+    const sealed = await sealBridgeEnvelope(key, { kind: 'observation', path: 'a.md', content: 'body' });
+    // Byte-exact through the server's Buffer round trip, and still opens.
+    expect(serverRoundTrip(sealed)).toBe(sealed);
+    expect(await openBridgeEnvelope(key, serverRoundTrip(sealed))).toMatchObject({ path: 'a.md' });
+    // The plaintext meta row rides the same wire and must survive it too.
+    const meta = encodePlainBridgeRow({ v: 1, kind: 'pairing-meta', generation: 'g', pairingSalt: 's' });
+    expect(serverRoundTrip(meta)).toBe(meta);
+    expect(decodePlainBridgeRow(serverRoundTrip(meta))).toMatchObject({ kind: 'pairing-meta' });
+    expect(decodePlainBridgeRow('not base64 json {')).toBe(null);
+    // The OLD wire format (raw JSON) does NOT survive — pinned so nobody
+    // reintroduces it: the server mangles it rather than rejecting it.
+    expect(serverRoundTrip('{"v":1,"iv":"aa","ct":"bb"}')).not.toBe('{"v":1,"iv":"aa","ct":"bb"}');
+  });
+
+  it('a whole-note-sized payload seals without blowing the argument limit (chunked base64)', async () => {
+    const key = await subkey();
+    const big = { kind: 'observation', path: 'big.md', content: 'x'.repeat(300_000) };
+    const sealed = await sealBridgeEnvelope(key, big);
+    expect(serverRoundTrip(sealed)).toBe(sealed);
+    expect(await openBridgeEnvelope(key, sealed)).toEqual(big);
   });
 
   it('ids: intent ids are unique; observation ids are stable per path and prefixed', async () => {

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -121,6 +121,8 @@ export function mintIntentId(): string;
 export function observationEntityId(path: string): Promise<string>;
 export function sealBridgeEnvelope(subkey: CryptoKey, payload: unknown): Promise<string>;
 export function openBridgeEnvelope(subkey: CryptoKey, text: string): Promise<unknown | null>;
+export function encodePlainBridgeRow(payload: unknown): string;
+export function decodePlainBridgeRow(text: string): unknown | null;
 export function applyBridgeIntent(
   currentText: string | null, intent: unknown,
 ): { text: string | null; changed: boolean }

--- a/src/utils/obsidianBridgeInbound.test.js
+++ b/src/utils/obsidianBridgeInbound.test.js
@@ -4,6 +4,7 @@ import { getDbRootKey } from '@glance-apps/sync/src/dbCrypto.js';
 import {
   deriveBridgeSubkey,
   sealBridgeEnvelope,
+  encodePlainBridgeRow,
   observationEntityId,
 } from '@glance-apps/obsidian-format';
 import {
@@ -59,7 +60,7 @@ describe('fetchBridgeObservations', () => {
       { entityId: 'obs:deadbeef', seq: 4, envelope: 'not decryptable (rotated generation)' },
     ];
     globalThis.fetch = async (url) => {
-      if (url.includes('/meta')) return { ok: true, status: 200, json: async () => ({ entityId: 'meta:pairing', envelope: JSON.stringify(META) }) };
+      if (url.includes('/meta')) return { ok: true, status: 200, json: async () => ({ entityId: 'meta:pairing', envelope: encodePlainBridgeRow(META) }) };
       if (url.includes('/list')) return { ok: true, status: 200, json: async () => ({ rows, hasMore: false }) };
       return { ok: false, status: 404, json: async () => ({}) };
     };

--- a/src/utils/obsidianBridgeStream.js
+++ b/src/utils/obsidianBridgeStream.js
@@ -35,6 +35,7 @@ import { createVaultClient } from '@glance-apps/sync/src/vaultClient.js';
 import {
   deriveBridgeSubkey,
   sealBridgeEnvelope,
+  decodePlainBridgeRow,
   mintIntentId,
   BRIDGE_VAULT_APP,
   BRIDGE_PAIRING_META_ID,
@@ -91,11 +92,10 @@ export async function getBridgePairingMeta({ force = false } = {}) {
   metaFetchInFlight = (async () => {
     try {
       const row = await ctx.client.getRow(BRIDGE_VAULT_APP, BRIDGE_PAIRING_META_ID, ctx.accountId);
-      let meta = null;
-      try {
-        const parsed = row?.envelope ? JSON.parse(row.envelope) : null;
-        if (parsed?.kind === 'pairing-meta' && parsed.generation && parsed.pairingSalt) meta = parsed;
-      } catch { /* malformed meta row = not paired */ }
+      // The server returns envelope BYTES base64-encoded (see the package's
+      // wire note); a malformed/undecodable row reads as not-paired.
+      const parsed = row?.envelope ? decodePlainBridgeRow(row.envelope) : null;
+      const meta = (parsed?.kind === 'pairing-meta' && parsed.generation && parsed.pairingSalt) ? parsed : null;
       writeJson(META_CACHE_KEY, { meta, fetchedAt: Date.now() });
       return meta;
     } catch {

--- a/src/utils/obsidianBridgeStream.test.js
+++ b/src/utils/obsidianBridgeStream.test.js
@@ -5,6 +5,7 @@ import {
   deriveBridgeSubkey,
   openBridgeEnvelope,
   sealBridgeEnvelope,
+  encodePlainBridgeRow,
 } from '@glance-apps/obsidian-format';
 import {
   emitBridgeIntent,
@@ -42,7 +43,8 @@ const makeFetch = ({ meta = META, failBatch = false } = {}) => {
     }
     if (url.includes('/sync/dayglance-bridge/meta')) {
       if (!meta) return { ok: false, status: 404, json: async () => ({}) };
-      return { ok: true, status: 200, json: async () => ({ entityId: 'meta:pairing', envelope: JSON.stringify(meta) }) };
+      // As the real server serves it: envelope bytes, base64-encoded.
+      return { ok: true, status: 200, json: async () => ({ entityId: 'meta:pairing', envelope: encodePlainBridgeRow(meta) }) };
     }
     return { ok: false, status: 404, json: async () => ({}) };
   };
@@ -87,6 +89,10 @@ describe('emit + flush', () => {
     const batch = globalThis.fetch.batches.at(-1);
     expect(batch.accountId).toBe('acct-1');
     expect(batch.rows[0].entityId).toBe(`int:${queued[0].intentId}`);
+    // The wire envelope must survive the real server's byte round trip
+    // (Buffer.from(base64) in, .toString('base64') out) — the raw-JSON
+    // regression is caught right here.
+    expect(Buffer.from(batch.rows[0].envelope, 'base64').toString('base64')).toBe(batch.rows[0].envelope);
     const subkey = await deriveBridgeSubkey(getDbRootKey(), SALT);
     const opened = await openBridgeEnvelope(subkey, batch.rows[0].envelope);
     expect(opened).toMatchObject({ kind: 'intent', type: 'daily_note_write', content: 'hi', intentId: queued[0].intentId });


### PR DESCRIPTION
Found live: pairing succeeded, but a task added in Obsidian never reached dayGLANCE, and the pairing panel showed the date-less "Bridge plugin active." fallback. Both symptoms had one cause — **the bridge stream was dead on arrival against a real GLANCEvault server, in both directions, silently.**

## The bug

GLANCEvault's batch endpoint decodes every row envelope with `Buffer.from(envelope, "base64")` and stores the **bytes**; list/get return them re-encoded as base64 (`glance-vault/src/routes/sync.ts`). Node's base64 decoder never rejects input — it silently shreds anything that isn't base64. The bridge emitted its envelopes as **raw JSON text** (sealed intent/observation rows *and* the plaintext `meta:pairing` row), so:

- every row was stored as garbage;
- dayGLANCE could never decode the `meta:pairing` row → it never discovered the pairing, never emitted intents, and the panel fell back to the date-less "Bridge plugin active." (the screenshot tell);
- the plugin's drain read the mangled intent rows as sealed-under-a-rotated-generation and **deleted them** (correct behavior, wrong input);
- observations never applied.

Pairing itself worked because the dead-drop is a vault file, never a server row — which is exactly why this only surfaced at first real sync. The tests missed it because the fetch mocks echoed envelope strings verbatim instead of emulating the server's byte round trip. That gap is now closed in the mocks themselves.

## The fix

- `sealBridgeEnvelope` emits `base64(JSON{v,iv,ct})`; `openBridgeEnvelope` decodes base64 first. New `encodePlainBridgeRow`/`decodePlainBridgeRow` wrap the meta:pairing row the same way — wire framing, explicitly not encryption (the salt it carries is not a secret).
- **Self-heal, no re-pair needed:** the plugin re-asserts the `meta:pairing` row once per load per generation at drain time — normally a no-op overwrite; for a vault whose old build wrote the garbage row, it repairs discovery automatically.
- Chunked bytes→base64 helper in both bridge modules: the old `String.fromCharCode(...bytes)` form blows the ~64k argument limit, which a whole-note observation would have hit.

## Pins

- Wire strings survive the server's exact `Buffer.from(...,'base64')` → `.toString('base64')` round trip **byte-for-byte**, and the old raw-JSON shape is pinned as *not* surviving it — so the regression can't come back quietly.
- A 300 KB payload seals and reopens (the chunking).
- The stream/inbound test mocks now serve envelopes exactly as the real server does.

Suite 2511 passing; app and plugin builds verified.

## Recovery for an already-paired vault

Update dayGLANCE and rebuild/reload the plugin — nothing else. The corrupted stored rows need no cleanup: the meta row is overwritten by the re-assert on the plugin's first drain, per-path observation rows are overwritten on the next edit of each note, and the drain already deleted the mangled intent rows. The panel should flip to "paired N days ago" within a sync cycle, and edits flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_