### PR TITLE
Bridge brake: 429-aware backoff on every bridge request path

### DIFF
--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -48,6 +48,14 @@ export interface BridgeState {
 
 const APPLIED_IDS_CAP = 1000;
 const OBSERVE_DEBOUNCE_MS = 2000;
+// 429 backoff (mirrors the dayGLANCE side's bridge brake): the server
+// rate-limits per IP, a budget shared with every dayGLANCE device in the
+// house — when it trips, retrying at full cadence keeps it tripped.
+const BACKOFF_BASE_MS = 30_000;
+const BACKOFF_MAX_MS = 10 * 60_000;
+
+const isRateLimitError = (e: unknown): boolean =>
+  typeof e === 'object' && e !== null && (e as { status?: number }).status === 429;
 
 interface BridgeConfigRow {
   dailyNotesPath: string;
@@ -125,6 +133,26 @@ export class BridgeTransport {
   // as garbage) — without it, dayGLANCE devices could never discover the
   // pairing until the user re-paired.
   private metaAssertedGeneration: string | null = null;
+  private backoffMs = 0;
+  private backoffUntil = 0;
+
+  private rateLimited(): boolean {
+    return Date.now() < this.backoffUntil;
+  }
+
+  private noteRateLimit(): void {
+    // One arming per burst (matches the dayGLANCE side): concurrent 429s
+    // don't compound; failing again after a brake lifted is what escalates.
+    if (this.rateLimited()) return;
+    this.backoffMs = Math.min(this.backoffMs ? this.backoffMs * 2 : BACKOFF_BASE_MS, BACKOFF_MAX_MS);
+    this.backoffUntil = Date.now() + this.backoffMs;
+    console.info(`dayGLANCE bridge: rate-limited (429) — pausing bridge requests for ~${Math.round(this.backoffMs / 1000)}s.`);
+  }
+
+  private noteSuccess(): void {
+    this.backoffMs = 0;
+    this.backoffUntil = 0;
+  }
 
   constructor(host: BridgeHost) {
     this.host = host;
@@ -147,7 +175,7 @@ export class BridgeTransport {
   /** Pull and apply pending intents. Safe to call on any cadence. */
   async drain(): Promise<void> {
     const pairing = this.host.getPairing();
-    if (!pairing || this.draining) return;
+    if (!pairing || this.draining || this.rateLimited()) return;
     this.draining = true;
     try {
       const client = this.client(pairing);
@@ -212,8 +240,10 @@ export class BridgeTransport {
           hwm: since,
         });
       }
+      this.noteSuccess();
     } catch (e) {
-      console.error('dayGLANCE bridge: drain failed', e);
+      if (isRateLimitError(e)) this.noteRateLimit();
+      else console.error('dayGLANCE bridge: drain failed', e);
     } finally {
       this.draining = false;
     }
@@ -323,6 +353,18 @@ export class BridgeTransport {
     try {
       const pairing = this.host.getPairing();
       if (!pairing) return;
+      if (this.rateLimited()) {
+        // Don't drop the report — this could be the note's LAST edit, and a
+        // dropped observation only re-reports on the next touch. Re-arm for
+        // just after the brake lifts (per-path, so re-edits coalesce).
+        const prior = this.observeTimers.get(path);
+        if (prior !== undefined) window.clearTimeout(prior);
+        this.observeTimers.set(path, window.setTimeout(() => {
+          this.observeTimers.delete(path);
+          void this.emitObservation(path, deleted);
+        }, Math.max(1000, this.backoffUntil - Date.now() + 1000)));
+        return;
+      }
       const adapter = this.host.app.vault.adapter;
       let content: string | null = null;
       let mtime: number | null = null;
@@ -346,9 +388,16 @@ export class BridgeTransport {
           createdAt: Date.now(),
         }],
       });
+      this.noteSuccess();
     } catch (e) {
-      // Observations are best-effort; the next edit re-reports the file.
-      console.error('dayGLANCE bridge: observation failed', e);
+      if (isRateLimitError(e)) {
+        // Arm the brake and requeue this path for after it lifts.
+        this.noteRateLimit();
+        void this.emitObservation(path, deleted);
+      } else {
+        // Observations are best-effort; the next edit re-reports the file.
+        console.error('dayGLANCE bridge: observation failed', e);
+      }
     }
   }
 }

--- a/src/utils/obsidianBridgeInbound.js
+++ b/src/utils/obsidianBridgeInbound.js
@@ -41,7 +41,7 @@ import {
   mergeParsedObsidianTasks,
   parseTasksFromMarkdown,
 } from '../obsidian.js';
-import { getBridgePairingMeta } from './obsidianBridgeStream.js';
+import { getBridgePairingMeta, bridgeRateLimited, isRateLimitError, noteBridgeRateLimit, noteBridgeRequestSuccess } from './obsidianBridgeStream.js';
 
 const OBS_HWM_KEY = 'dayglance-bridge-obs-hwm';
 
@@ -55,6 +55,10 @@ const OBS_HWM_KEY = 'dayglance-bridge-obs-hwm';
  */
 export async function fetchBridgeObservations() {
   try {
+    // Shared bridge brake (obsidianBridgeStream.js): while the server is
+    // rate-limiting, sit the cycle out — the cursor hasn't advanced, so
+    // nothing is lost, and the next cycle retries.
+    if (bridgeRateLimited()) return null;
     const cfg = getVaultConfig();
     if (!cfg?.enabled || !cfg.vaultUrl || !cfg.vaultToken || !cfg.accountId || !hasDbRootKey()) return null;
     const meta = await getBridgePairingMeta();
@@ -84,8 +88,10 @@ export async function fetchBridgeObservations() {
       }
       if (!page.rows?.length) break;
     }
+    noteBridgeRequestSuccess();
     return { observations: [...byPath.values()], maxSeq };
-  } catch {
+  } catch (err) {
+    if (isRateLimitError(err)) noteBridgeRateLimit();
     return null;
   }
 }

--- a/src/utils/obsidianBridgeStream.js
+++ b/src/utils/obsidianBridgeStream.js
@@ -55,6 +55,47 @@ let cachedSubkeyGeneration = null;
 let flushInFlight = null; // the running flush's promise — callers coalesce
 let metaFetchInFlight = null;
 
+// ── THE BRIDGE BRAKE ─────────────────────────────────────────────────────────
+// 429-aware backoff shared by every bridge request path in the app (flush,
+// config publish, meta discovery, and — via the exports — the observation
+// fetch). The GLANCEvault server rate-limits per IP (default 600/min), a
+// budget the whole household's devices share with the main sync engine, the
+// intents poller, and the plugin; when it trips, everything else backs off
+// (the engine's own BRAKE) and the bridge must too — retrying at full
+// cadence just keeps the window saturated for everyone. Exponential:
+// 30s doubling to 10min, reset by the next successful bridge request.
+// While braked, emits still QUEUE (the outbox is the durable buffer) —
+// only network attempts pause.
+const BRIDGE_BACKOFF_BASE_MS = 30_000;
+const BRIDGE_BACKOFF_MAX_MS = 10 * 60_000;
+let backoffMs = 0;
+let backoffUntil = 0;
+
+export function bridgeRateLimited(nowMs = Date.now()) {
+  return nowMs < backoffUntil;
+}
+
+/** True when the error is the server's rate limiter (or a 429 quota). */
+export function isRateLimitError(err) {
+  return err?.status === 429;
+}
+
+export function noteBridgeRateLimit() {
+  // One arming per burst: concurrent 429s from the same incident (a flush's
+  // meta GET and its batch both failing) must not compound. Escalation
+  // comes from failing again AFTER a brake lifted — the retry that proves
+  // the window wasn't long enough.
+  if (bridgeRateLimited()) return;
+  backoffMs = Math.min(backoffMs ? backoffMs * 2 : BRIDGE_BACKOFF_BASE_MS, BRIDGE_BACKOFF_MAX_MS);
+  backoffUntil = Date.now() + backoffMs;
+  console.info(`[bridge] BRAKE: rate-limited (429) — bridge requests paused for ~${Math.round(backoffMs / 1000)}s.`);
+}
+
+export function noteBridgeRequestSuccess() {
+  backoffMs = 0;
+  backoffUntil = 0;
+}
+
 const readJson = (key, fallback) => {
   try { return JSON.parse(localStorage.getItem(key)) ?? fallback; } catch { return fallback; }
 };
@@ -86,6 +127,9 @@ export async function getBridgePairingMeta({ force = false } = {}) {
   if (!force && cached && Date.now() - (cached.fetchedAt || 0) < META_TTL_MS) {
     return cached.meta;
   }
+  // Under the brake, even a forced refresh serves what we have — the brake
+  // exists precisely because more requests won't help right now.
+  if (bridgeRateLimited()) return cached?.meta ?? null;
   if (metaFetchInFlight) return metaFetchInFlight;
   const ctx = vaultClientOrNull();
   if (!ctx) return cached?.meta ?? null;
@@ -96,9 +140,11 @@ export async function getBridgePairingMeta({ force = false } = {}) {
       // wire note); a malformed/undecodable row reads as not-paired.
       const parsed = row?.envelope ? decodePlainBridgeRow(row.envelope) : null;
       const meta = (parsed?.kind === 'pairing-meta' && parsed.generation && parsed.pairingSalt) ? parsed : null;
+      noteBridgeRequestSuccess();
       writeJson(META_CACHE_KEY, { meta, fetchedAt: Date.now() });
       return meta;
-    } catch {
+    } catch (err) {
+      if (isRateLimitError(err)) noteBridgeRateLimit();
       // Unreachable vault: keep whatever we knew; do not thrash.
       return cached?.meta ?? null;
     } finally {
@@ -165,6 +211,7 @@ export async function flushBridgeOutbox() {
 
 async function doFlush() {
   try {
+    if (bridgeRateLimited()) return false; // queued intents wait out the brake
     const outbox = readJson(OUTBOX_KEY, []);
     if (outbox.length === 0) return true;
     const ctx = vaultClientOrNull();
@@ -181,13 +228,15 @@ async function doFlush() {
       });
     }
     await ctx.client.batch(BRIDGE_VAULT_APP, { accountId: ctx.accountId, rows });
+    noteBridgeRequestSuccess();
     // Only entries we actually sent leave the queue — an emit that raced in
     // during the network call stays for the next flush.
     const sent = new Set(outbox.map((i) => i.intentId));
     const remaining = readJson(OUTBOX_KEY, []).filter((i) => !sent.has(i.intentId));
     writeJson(OUTBOX_KEY, remaining);
     return remaining.length === 0;
-  } catch {
+  } catch (err) {
+    if (isRateLimitError(err)) noteBridgeRateLimit();
     return false; // queued intents survive for the next flush
   }
 }
@@ -198,6 +247,7 @@ async function doFlush() {
  */
 export async function publishBridgeConfig({ dailyNotesPath, dailyNotePattern, taskHeading }) {
   try {
+    if (bridgeRateLimited()) return; // the unadvanced hash retries next cycle
     const payload = {
       v: 1, kind: 'config',
       dailyNotesPath: dailyNotesPath || '',
@@ -215,7 +265,11 @@ export async function publishBridgeConfig({ dailyNotesPath, dailyNotePattern, ta
       rows: [{ entityId: BRIDGE_CONFIG_META_ID, envelope: await sealBridgeEnvelope(subkey, payload), createdAt: Date.now() }],
     });
     localStorage.setItem(CONFIG_HASH_KEY, hash);
-  } catch { /* next cycle retries — the hash was not advanced */ }
+    noteBridgeRequestSuccess();
+  } catch (err) {
+    if (isRateLimitError(err)) noteBridgeRateLimit();
+    /* next cycle retries — the hash was not advanced */
+  }
 }
 
 /** Test seam: reset module caches (subkey, in-flight flags). */
@@ -224,4 +278,6 @@ export function __resetBridgeStreamForTests() {
   cachedSubkeyGeneration = null;
   flushInFlight = null;
   metaFetchInFlight = null;
+  backoffMs = 0;
+  backoffUntil = 0;
 }

--- a/src/utils/obsidianBridgeStream.test.js
+++ b/src/utils/obsidianBridgeStream.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setupDbRootKey, clearDbRootKey } from '@glance-apps/sync';
 import { getDbRootKey } from '@glance-apps/sync/src/dbCrypto.js';
 import {
@@ -145,6 +145,49 @@ describe('emit + flush', () => {
     expect(rows).toHaveLength(1);
     const subkey = await deriveBridgeSubkey(getDbRootKey(), SALT);
     expect(await openBridgeEnvelope(subkey, rows[0].rows[0].envelope)).toMatchObject({ kind: 'config', dailyNotesPath: 'Daily' });
+  });
+});
+
+describe('the bridge brake (429 backoff)', () => {
+  it('a 429 arms the brake: no bridge request until it lifts, then flush resumes and success resets it', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-30T12:00:00.000Z'));
+    try {
+      const limited = async () => ({ ok: false, status: 429, json: async () => ({ error: 'too many requests' }) });
+      globalThis.fetch = limited;
+      emitBridgeIntent('daily_note_write', { path: 'x.md', content: 'y' });
+      expect(await flushBridgeOutbox()).toBe(false); // 429 → brake armed
+      expect(JSON.parse(localStorage.getItem(OUTBOX_KEY))).toHaveLength(1); // nothing lost
+
+      // Brake active: the working server is NOT contacted at all.
+      globalThis.fetch = makeFetch();
+      expect(await flushBridgeOutbox()).toBe(false);
+      expect(globalThis.fetch.batches).toHaveLength(0);
+      // …and even a FORCED meta refresh serves the cache instead of fetching.
+      expect(await getBridgePairingMeta({ force: true })).toMatchObject({ generation: SALT_B64 });
+
+      // Past the window: flush goes through, queue drains, brake resets.
+      vi.setSystemTime(new Date('2026-08-30T12:00:31.000Z'));
+      expect(await flushBridgeOutbox()).toBe(true);
+      expect(globalThis.fetch.batches).toHaveLength(1);
+      expect(JSON.parse(localStorage.getItem(OUTBOX_KEY))).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('emits still QUEUE while braked — the brake pauses the network, never the outbox', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-30T12:00:00.000Z'));
+    try {
+      globalThis.fetch = async () => ({ ok: false, status: 429, json: async () => ({}) });
+      emitBridgeIntent('daily_note_write', { path: 'a.md', content: '1' });
+      await flushBridgeOutbox();
+      expect(emitBridgeIntent('daily_note_write', { path: 'b.md', content: '2' })).toBe(true);
+      expect(JSON.parse(localStorage.getItem(OUTBOX_KEY))).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
Found live: a console storm of 429s from GLANCEvault, with the main sync engine visibly braking (`[sync] BRAKE: cycle skipped — backing off`) while `dayglance-bridge/batch` requests kept firing.

## Diagnosis

The GLANCEvault server rate-limits **per IP** — default 600 requests/minute (`glance-vault/src/server.ts` + `config.ts`) — and that budget is shared by every device behind the household NAT: the main sync engine, the intents poller, and now the bridge's several new streams (app: outbox flushes, config publishes, meta discovery, observation lists; plugin: 30-second drains, meta re-asserts, observation batches). When the aggregate trips the limit, every other client backs off — **the bridge had no 429 handling at all**, so it kept its full cadence and retried its failed publishes on every trigger, keeping the window saturated for everyone and spamming the console. (The TRMNL 429s in the same log are trmnl.com's own limit; dayGLANCE already backs off there.)

## Fix — mirror the engine's brake discipline, both sides

- **dayGLANCE** (`obsidianBridgeStream.js`): one shared brake for all bridge request paths. A 429 arms exponential backoff — 30s doubling to 10 minutes, reset by the next successful bridge request. While braked: flush, config publish, meta fetch (forced ones serve the cache), and the observation fetch make **no network attempts**. Emits still **queue** — the outbox is the durable buffer, so the brake pauses the network, never the data, and no false write-error latches fire. One arming per burst: the concurrent 429s of a single incident (a flush's meta GET and its batch both failing) don't compound; escalation comes from failing again *after* a brake lifted.
- **Plugin** (`bridge.ts`): the same brake per transport — the drain (and its meta re-assert) sits the window out; a rate-limited **observation is re-scheduled** for just after the brake lifts rather than dropped, because it could be the note's last edit and a dropped report only re-reports on the next touch.
- Console noise collapses to one `[bridge] BRAKE: … paused for ~Ns` line per burst.

## Pins

A 429 arms the brake and the (now-working) server is **not contacted** until the window passes — then the queue drains and success resets the brake; a forced meta refresh under the brake serves the cache instead of fetching; emits keep queueing while braked. Suite **2513 passing**; app and plugin builds verified.

## Operator note

No server change required. If the household's legitimate aggregate exceeds 600 req/min, the knob is `GLANCEVAULT_RATE_LIMIT_MAX` (window: `GLANCEVAULT_RATE_LIMIT_WINDOW_SECONDS`) on the glance-vault deployment — but with the bridge braking properly, the default may well be enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_