### PR TITLE
Bridge brake: decay on success, never amnesty — and make successes visible

### DIFF
--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -149,9 +149,27 @@ export class BridgeTransport {
     console.info(`dayGLANCE bridge: rate-limited (429) — pausing bridge requests for ~${Math.round(this.backoffMs / 1000)}s.`);
   }
 
+  // DECAY, never amnesty — the live lesson of 2026-08-30. The first shape
+  // zeroed the escalation on ANY success, and successes were silent. On a
+  // per-IP budget saturated by OTHER traffic, an occasional cheap request
+  // slips into a fresh limiter window and succeeds; each lucky 200 then
+  // wiped the whole 30→480s escalation, so the observed log read
+  // "escalates, forgets, starts over at 30s" — never settling at the
+  // ceiling while the storm lasted. Now a success clears the GATE (the
+  // window demonstrably has room) but only HALVES the memory, so the next
+  // 429 re-arms at the storm's level; a genuine recovery drains the memory
+  // to zero within a few quiet successes. Both transitions log, so the
+  // interleaving that misled the first diagnosis is visible in the console.
   private noteSuccess(): void {
-    this.backoffMs = 0;
     this.backoffUntil = 0;
+    if (this.backoffMs === 0) return;
+    this.backoffMs = Math.floor(this.backoffMs / 2);
+    if (this.backoffMs < BACKOFF_BASE_MS) {
+      this.backoffMs = 0;
+      console.info('dayGLANCE bridge: request succeeded — brake released.');
+    } else {
+      console.info(`dayGLANCE bridge: request succeeded — brake decaying (a new 429 would pause ~${Math.round(Math.min(this.backoffMs * 2, BACKOFF_MAX_MS) / 1000)}s).`);
+    }
   }
 
   constructor(host: BridgeHost) {

--- a/src/utils/obsidianBridgeStream.js
+++ b/src/utils/obsidianBridgeStream.js
@@ -92,9 +92,26 @@ export function noteBridgeRateLimit() {
   console.info(`[bridge] BRAKE: rate-limited (429) — bridge requests paused for ~${Math.round(backoffMs / 1000)}s.`);
 }
 
+// DECAY, never amnesty — the plugin-side live bug of 2026-08-30, fixed on
+// both sides in the same shape. The first design zeroed the escalation on
+// ANY success, silently; on a per-IP budget saturated by other traffic an
+// occasional request slips into a fresh limiter window and succeeds, and
+// each lucky 200 wiped the whole 30→480s escalation — the client "backs
+// off, escalates, forgets, starts over", never settling at the ceiling
+// while the storm lasts. Now a success clears the GATE (the window
+// demonstrably has room) but only HALVES the memory, so the next 429
+// re-arms at the storm's level; a genuine recovery drains the memory to
+// zero within a few quiet successes. Both transitions log.
 export function noteBridgeRequestSuccess() {
-  backoffMs = 0;
   backoffUntil = 0;
+  if (backoffMs === 0) return;
+  backoffMs = Math.floor(backoffMs / 2);
+  if (backoffMs < BRIDGE_BACKOFF_BASE_MS) {
+    backoffMs = 0;
+    console.info('[bridge] brake released — bridge request succeeded.');
+  } else {
+    console.info(`[bridge] brake decaying — request succeeded (a new 429 would pause ~${Math.round(Math.min(backoffMs * 2, BRIDGE_BACKOFF_MAX_MS) / 1000)}s).`);
+  }
 }
 
 const readJson = (key, fallback) => {

--- a/src/utils/obsidianBridgeStream.test.js
+++ b/src/utils/obsidianBridgeStream.test.js
@@ -189,6 +189,83 @@ describe('the bridge brake (429 backoff)', () => {
       vi.useRealTimers();
     }
   });
+
+  it('DECAY, never amnesty (the 2026-08-30 plugin lesson): one lucky success does NOT reset the escalation — the next 429 re-arms at the storm level', async () => {
+    vi.useFakeTimers();
+    const at = (iso) => vi.setSystemTime(new Date(iso));
+    const limited = async () => ({ ok: false, status: 429, json: async () => ({ error: 'too many requests' }) });
+    try {
+      // Escalate to a 60s arming: 429 (arms 30s), retry past the window 429s again (arms 60s).
+      at('2026-08-30T12:00:00.000Z');
+      // Re-stamp the meta cache under the FAKE clock so flushes serve it from
+      // cache — each network request that succeeds decays the memory once, and
+      // this test counts exactly the batch requests.
+      localStorage.setItem('dayglance-bridge-pairing-meta', JSON.stringify({ meta: META, fetchedAt: Date.now() }));
+      globalThis.fetch = limited;
+      emitBridgeIntent('daily_note_write', { path: 'a.md', content: '1' });
+      await flushBridgeOutbox();               // arms 30s, memory 30s
+      at('2026-08-30T12:00:31.000Z');
+      await flushBridgeOutbox();               // 429 again → arms 60s, memory 60s
+
+      // A lucky success past the window: gate opens, memory HALVES (60→30), not zeroed.
+      at('2026-08-30T12:01:32.000Z');
+      globalThis.fetch = makeFetch();
+      expect(await flushBridgeOutbox()).toBe(true);
+
+      // The storm is still on: the very next 429 re-arms at 60s (2×30s memory),
+      // NOT the fresh 30s base the amnesty design restarted from.
+      globalThis.fetch = limited;
+      emitBridgeIntent('daily_note_write', { path: 'b.md', content: '2' });
+      await flushBridgeOutbox();               // arms min(30*2, cap) = 60s
+
+      // 31s later — the amnesty design would already be retrying; the brake holds.
+      at('2026-08-30T12:02:03.000Z');
+      globalThis.fetch = makeFetch();
+      expect(await flushBridgeOutbox()).toBe(false);
+      expect(globalThis.fetch.batches).toHaveLength(0);
+
+      // Past the full 60s arming it opens again.
+      at('2026-08-30T12:02:33.000Z');
+      expect(await flushBridgeOutbox()).toBe(true);
+      expect(globalThis.fetch.batches).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a genuine recovery drains the memory: consecutive successes decay it to zero, and the next 429 arms at the 30s base again', async () => {
+    vi.useFakeTimers();
+    const at = (iso) => vi.setSystemTime(new Date(iso));
+    const limited = async () => ({ ok: false, status: 429, json: async () => ({ error: 'too many requests' }) });
+    try {
+      // Build 60s of memory as above.
+      at('2026-08-30T12:00:00.000Z');
+      localStorage.setItem('dayglance-bridge-pairing-meta', JSON.stringify({ meta: META, fetchedAt: Date.now() }));
+      globalThis.fetch = limited;
+      emitBridgeIntent('daily_note_write', { path: 'a.md', content: '1' });
+      await flushBridgeOutbox();
+      at('2026-08-30T12:00:31.000Z');
+      await flushBridgeOutbox();               // memory 60s
+
+      // Two quiet successes: 60 → 30 → 0 (released).
+      at('2026-08-30T12:01:32.000Z');
+      globalThis.fetch = makeFetch();
+      expect(await flushBridgeOutbox()).toBe(true);   // memory 30s
+      emitBridgeIntent('daily_note_write', { path: 'b.md', content: '2' });
+      expect(await flushBridgeOutbox()).toBe(true);   // memory 0 — released
+
+      // Fresh incident later: arms at the 30s base, so at +31s the gate is open.
+      globalThis.fetch = limited;
+      emitBridgeIntent('daily_note_write', { path: 'c.md', content: '3' });
+      await flushBridgeOutbox();               // arms 30s
+      at('2026-08-30T12:02:03.000Z');
+      globalThis.fetch = makeFetch();
+      expect(await flushBridgeOutbox()).toBe(true);
+      expect(globalThis.fetch.batches).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('round trip with the plugin-side seal', () => {


### PR DESCRIPTION
Fixes the live brake behavior from the Obsidian console (escalates 30→480s, then re-arms at 30s "with no success in between", repeating). Answers to the three questions, established from the code:

**(a) Why the reset without a success?** There is no hidden reset path, and the state lives where intended: one `BridgeTransport` per plugin load, constructed once in `onload`, module-lifetime fields. The reset is real and it *proves* successes happened: `noteRateLimit` arms `backoffMs ? backoffMs*2 : 30s`, so a 30s arming right after a 480s one is only possible with `backoffMs` zeroed in between — and only `noteSuccess` zeroes it. `noteSuccess` logged **nothing**, so the successes were invisible. On a per-IP budget saturated by other traffic, an occasional cheap request slips into a fresh limiter window and gets a 200; under the old design each lucky 200 granted **full amnesty**, re-licensing the full request cadence. That is the observed "backs off, escalates, forgets, starts over."

**(b) Does the brake gate, or only log?** It gates. `drain()` returns before any network while armed; `emitObservation` re-arms its per-path timer for just past the brake instead of sending. Both request paths are covered.

**(c) New transport/client per cycle?** No. The per-call `VaultClient` is a stateless fetch wrapper; the brake state never lives on it.

## The fix (both brakes — they shared the design)

- A success clears the **gate** (the window demonstrably has room) but only **halves** the escalation memory. The next 429 re-arms at the storm's level (2× remaining memory, capped at 10min) instead of restarting at 30s. A genuine recovery drains the memory to zero within a few quiet successes; a saturated budget with intermittent lucky 200s now settles near the ceiling.
- Both transitions **log** ("brake decaying (a new 429 would pause ~Ns)" / "brake released"), so the interleaving that made this log misleading is visible next time.

Applied identically to the plugin (`dayglance-obsidian-plugin/src/bridge.ts`) and the app-side bridge brake (`src/utils/obsidianBridgeStream.js`). Pinned app-side: one lucky success does not reset the escalation (next 429 re-arms 60s and the gate holds past +31s); consecutive successes drain back to the 30s base.

## Verification

Full suite 2553 passing (2 new pins); lint clean; the plugin typechecks and `main.js` bundles cleanly (`npm run build` in `dayglance-obsidian-plugin/`).

## Important context for the outage itself

An idle plugin cannot be the saturator: its steady state is one `list` per 30s tick plus rare observations, ~2 requests/min against a 600/min budget, even fully unbraked. The 429s it reports are the symptom of the shared per-IP budget being exhausted by the other client on that IP — details and discriminating checks in the session report.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_