### PR TITLE
Plugin drain: never delete a tombstone — kill the silent re-delete loop

### DIFF
--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -182,6 +182,18 @@ export class BridgeTransport {
     });
   }
 
+  // Best-effort intent-row cleanup, fire-and-forget by design (the applied-ID
+  // set and the HWM each independently prevent re-application) — but never
+  // SILENT: a swallowed 429 here is how the tombstone loop burned the budget
+  // for hours with a quiet console. Rate limits arm the brake like any other
+  // bridge request; other failures get one console line.
+  private deleteIntentRow(client: VaultClient, entityId: string, accountId: string): void {
+    void client.deleteRow(BRIDGE_VAULT_APP, entityId, accountId).catch((e) => {
+      if (isRateLimitError(e)) this.noteRateLimit();
+      else console.error('dayGLANCE bridge: intent row cleanup failed', e);
+    });
+  }
+
   private async subkeyFor(pairing: BridgePairing): Promise<CryptoKey> {
     if (!this.subkey || this.subkeyGeneration !== pairing.generation) {
       this.subkey = await importBridgeSubkey(pairing.subkeyB64);
@@ -209,12 +221,28 @@ export class BridgeTransport {
       while (hasMore) {
         const page = await client.list(BRIDGE_VAULT_APP, { accountId: pairing.accountId, since });
         hasMore = !!page.hasMore;
-        const rows = (page.rows ?? []) as Array<{ entityId?: string; envelope?: string; seq?: number }>;
+        const rows = (page.rows ?? []) as Array<{ entityId?: string; envelope?: string; seq?: number; deleted?: boolean }>;
         if (rows.length === 0) break;
         let batchMax = since;
         for (const row of rows) {
           const seq = Number(row.seq) || 0;
           if (seq > batchMax) batchMax = seq;
+          if (row.deleted) {
+            // TOMBSTONE — cursor movement only, NEVER a deleteRow. The server
+            // re-tombstones on every delete: soft-deleting an already-deleted
+            // row still assigns a FRESH seq and emits an SSE nudge, so
+            // deleting a tombstone resurrects it above our own cursor. The
+            // pre-fix drain did exactly that for every applied-intent
+            // tombstone (the applied-ids branch below fired on them), which
+            // built a silent perpetual loop: N tombstones re-deleted every
+            // 30s drain, each bump nudging every SSE client and burning the
+            // shared per-IP budget — the 2026-08-30 storm (~900 foreign seq
+            // events on an idle account), invisible in this console because
+            // the deletes were fire-and-forget. Skipping tombstones lets the
+            // cursor advance past the whole backlog once, after which they
+            // never re-seq and never return.
+            continue;
+          }
           const entityId = String(row.entityId ?? '');
           if (!entityId.startsWith(BRIDGE_INTENT_PREFIX)) {
             // meta rows and our own observations also live here; refresh the
@@ -227,7 +255,7 @@ export class BridgeTransport {
           }
           const intentId = entityId.slice(BRIDGE_INTENT_PREFIX.length);
           if (applied.has(intentId)) {
-            void client.deleteRow(BRIDGE_VAULT_APP, entityId, pairing.accountId).catch(() => {});
+            this.deleteIntentRow(client, entityId, pairing.accountId);
             continue;
           }
           const intent = row.envelope ? await openBridgeEnvelope(subkey, row.envelope) : null;
@@ -235,14 +263,14 @@ export class BridgeTransport {
             // Sealed under a rotated-away generation (or tampered): can never
             // be applied by anyone — treat as consumed.
             applied.add(intentId);
-            void client.deleteRow(BRIDGE_VAULT_APP, entityId, pairing.accountId).catch(() => {});
+            this.deleteIntentRow(client, entityId, pairing.accountId);
             continue;
           }
           try {
             const consumed = await this.applyOne(intent as Record<string, unknown>);
             applied.add(intentId);
             if (consumed) {
-              void client.deleteRow(BRIDGE_VAULT_APP, entityId, pairing.accountId).catch(() => {});
+              this.deleteIntentRow(client, entityId, pairing.accountId);
             }
           } catch (e) {
             // A vault-write failure leaves the row AND the id unapplied — the


### PR DESCRIPTION
Root cause of the persistent 429 storms, proven line by line against the GLANCEvault server code — it was neither the Mac app nor any dayGLANCE device, but a silent self-sustaining loop between the plugin's drain and the server's delete semantics:

1. **`listRows` returns soft-deleted rows** (deliberately — deletions must propagate).
2. **The drain re-deleted them**: any `int:` row whose id was in the applied set got a `deleteRow` call, with no check for `row.deleted`.
3. **`softDeleteRow` re-tombstones on every call**: it checks only that the row *exists* — an already-deleted row exists — so each call assigns a **fresh seq** and the route **emits an SSE nudge**.

The fresh seq put the same tombstone back above the plugin's cursor; the next 30-second drain listed it again, deleted it again, re-seq'd it again — forever, over every intent ever applied or ever undecryptable (a pool that only grew). A few hundred accumulated tombstones ⇒ hundreds of `deleteRow` calls per drain ⇒ the entire 600/min per-IP budget, one nudge per delete (the ~900 foreign SSE events observed on an idle account), a `data.json` save per tick (the every-30-seconds Obsidian Sync uploads), bursts gated only by the drain's own `list` 429s tripping the brake — and all of it **invisible in the plugin console**, because the deletes were fire-and-forget with a swallowed catch. Storms ran exactly while Obsidian was open; every earlier symptom traces back here.

## The fix

- **A deleted row is cursor movement only.** The drain skips tombstones (`batchMax` still advances) and never issues `deleteRow` for one. The existing backlog is listed once more, skipped, and left behind by the cursor permanently — self-healing on the first fixed drain, no migration needed.
- **`deleteRow` failures are no longer silent**: 429s arm the brake like any other bridge request; other failures log one line. Cleanup stays best-effort-safe — the applied-ID set and the HWM each independently prevent re-application.

## Verification

Plugin typechecks and `main.js` bundles cleanly; the app suite (untouched by this change) still passes 2553. Live confirmation after rebuild: with Obsidian open, the Mac's `window.__glanceVaultSse` event counter should go near-flat, `data.json` uploads in the Obsidian Sync log should stop recurring, and 429s should not return.

## Server-side counterpart (glance-vault, separate repo)

The other half of the class is the server re-tombstoning an already-deleted row. An idempotent guard in `softDeleteRow` — if the row is already `deleted`, return its existing seq **without** bumping seq or emitting — closes it for every current and future client. Prompt to run in the glance-vault repo is in the session notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_