### PR TITLE
Brake db-intents: extract the bridge brake into a device-wide vault brake

### DIFF
--- a/src/intents/dbIntentsTransport.js
+++ b/src/intents/dbIntentsTransport.js
@@ -82,6 +82,13 @@ export class KeyUnavailableError extends Error {
 // event would consume it before the main window can act (mirrors useIntentPoller).
 import { isTrayMode } from '../utils/trayMode.js';
 import { recordOwnWriteSeq } from '../sync/ownWrites.js';
+// The device-wide vault brake (sync/vaultRequestBrake.js): db-intents was the
+// LAST unbraked GLANCEvault caller — raw vaultFetch with no pacing, a 429
+// logged-and-abandoned per cycle while the deliverer re-queued at every flush
+// trigger. Now every request here gates on the shared brake (one per-IP
+// budget → one brake), 429s arm it (once-per-incident visibility instead of
+// a silent abandon), and successes decay it.
+import { vaultRateLimited, noteVaultRateLimit, noteVaultRequestSuccess } from '../sync/vaultRequestBrake.js';
 
 // Module-level lock: prevents React StrictMode's double-mount from running two
 // concurrent polls, which would both read the same cursor and double-process.
@@ -194,6 +201,10 @@ function parseBody(res) {
 export async function sendIntentsDb(envelopes, opts = {}) {
   const connection = opts.connection ?? getDbIntentsConnection();
   if (!connection) return undefined;
+  // Braked: no network. Fire-and-forget callers already tolerate an undefined
+  // ack (same surface as a failed POST); the durable path is the outbox, whose
+  // deliverer holds under the same brake.
+  if (vaultRateLimited()) return undefined;
 
   const cfg = opts.config ?? getDbIntentsConfig() ?? {};
   const ttlMs = cfg.ttlMs ?? DEFAULT_DB_INTENTS_TTL_MS;
@@ -214,9 +225,13 @@ export async function sendIntentsDb(envelopes, opts = {}) {
 
   const res = await vaultFetch('POST', url, headers, JSON.stringify(body));
   if (!res || !res.ok) {
-    console.warn('[db-intent] batch POST failed:', res?.status);
+    // 429 arms the shared brake (its arming line is the incident report);
+    // anything else keeps the existing per-failure warn.
+    if (res?.status === 429) noteVaultRateLimit('db-intent');
+    else console.warn('[db-intent] batch POST failed:', res?.status);
     return undefined;
   }
+  noteVaultRequestSuccess();
   const ack = parseBody(res); // { written, maxSeq }
   // Own-echo damping (#1455, sync/ownWrites.js): intent landings advance the
   // same per-account seq and nudge it — record our ack so the SSE coalescer
@@ -389,6 +404,11 @@ async function routeIncoming(raw, context, opts = {}) {
 export async function pollDbIntents(context, opts = {}) {
   const connection = opts.connection ?? getDbIntentsConnection();
   if (!connection) return;
+  // Braked: sit the poll out entirely — the cursor hasn't moved, so nothing
+  // is lost, and the next trigger (interval / focus / SSE drain) retries
+  // after the brake lifts. Silent by design: the brake's one arming line is
+  // the incident report; a line per gated poll would be the old noise.
+  if (vaultRateLimited()) return;
 
   const vaultFetch = opts.vaultFetch ?? defaultVaultFetch();
   // Test seam: lets tests drive the three-way model deterministically. Defaults
@@ -416,9 +436,15 @@ export async function pollDbIntents(context, opts = {}) {
       return;
     }
     if (!res || !res.ok) {
-      console.warn('[db-intent] list returned', res?.status);
+      // The old shape logged and abandoned the cycle — a silent-ish 429 that
+      // left the next trigger to retry at full cadence. Now a 429 arms the
+      // device-wide brake (which also holds the outbox deliverer); other
+      // failures keep the existing warn.
+      if (res?.status === 429) noteVaultRateLimit('db-intent');
+      else console.warn('[db-intent] list returned', res?.status);
       return;
     }
+    noteVaultRequestSuccess();
 
     const payload = parseBody(res);
     if (!payload) {

--- a/src/intents/dbIntentsTransport.test.js
+++ b/src/intents/dbIntentsTransport.test.js
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import { buildEnvelope, buildIntentRow, ACTIONS, TABS } from '@glance-apps/intents';
 import { sendIntentsDb, pollDbIntents, DB_CURSOR_KEY, DB_RETRY_KEY, MAX_INTENT_RETRIES } from './dbIntentsTransport.js';
+import { __resetVaultBrakeForTests } from '../sync/vaultRequestBrake.js';
+import { bridgeRateLimited } from '../utils/obsidianBridgeStream.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // App-owned GLANCEvault DB intents transport. These exercise the REAL codec
@@ -99,6 +101,7 @@ function makeForeignNotify(i) {
 
 beforeEach(() => {
   global.localStorage = memLocalStorage();
+  __resetVaultBrakeForTests();
 });
 
 describe('DB intents — SEND (batch wrapper + idempotency)', () => {
@@ -344,5 +347,62 @@ describe('DB intents — RECEIVE bounded-retry model', () => {
     expect(server.calls.list).toHaveLength(1);
     expect(server.calls.list[0].since).toBe(1);
     expect(calls).toBe(1); // route NOT called again
+  });
+});
+
+describe('DB intents — the device-wide vault brake (the last unbraked caller, braked)', () => {
+  const limited = () => vi.fn(async () => ({ status: 429, ok: false, body: JSON.stringify({ error: 'rate limit exceeded' }) }));
+
+  it('a 429 on list arms the brake; subsequent polls make NO request; past the window it retries', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-30T12:00:00.000Z'));
+    try {
+      const fetch429 = limited();
+      await pollDbIntents({}, { connection: CONN, vaultFetch: fetch429 });
+      expect(fetch429).toHaveBeenCalledTimes(1); // the arming request
+
+      // Gated: interval / focus / SSE-drain triggers no longer hit the wire.
+      await pollDbIntents({}, { connection: CONN, vaultFetch: fetch429 });
+      await pollDbIntents({}, { connection: CONN, vaultFetch: fetch429 });
+      expect(fetch429).toHaveBeenCalledTimes(1);
+
+      // Past the 30s arming: the next trigger goes through again.
+      vi.setSystemTime(new Date('2026-08-30T12:00:31.000Z'));
+      const server = createMemoryIntentsServer();
+      await pollDbIntents({}, { connection: CONN, vaultFetch: server.vaultFetch });
+      expect(server.calls.list).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('sendIntentsDb is gated too: no batch POST while braked (callers already tolerate the undefined ack)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-30T12:00:00.000Z'));
+    try {
+      const fetch429 = limited();
+      await pollDbIntents({}, { connection: CONN, vaultFetch: fetch429 }); // arms
+      const server = createMemoryIntentsServer();
+      const env = buildEnvelope({ action: ACTIONS.OPEN, payload: { tab: TABS.TODAY }, emittedBy: 'app.dayglance' });
+      const ack = await sendIntentsDb(env, { connection: CONN, config: { ttlMs: 3600_000 }, vaultFetch: server.vaultFetch });
+      expect(ack).toBeUndefined();
+      expect(server.calls.batch).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ONE budget, ONE brake: a db-intents 429 pauses the bridge paths as well', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-30T12:00:00.000Z'));
+    try {
+      expect(bridgeRateLimited()).toBe(false);
+      await pollDbIntents({}, { connection: CONN, vaultFetch: limited() });
+      // The per-IP budget is shared by every path on this device, so the
+      // brake is deliberately device-wide (sync/vaultRequestBrake.js).
+      expect(bridgeRateLimited()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/intents/deliverers.js
+++ b/src/intents/deliverers.js
@@ -38,6 +38,7 @@ import {
 } from './dbIntentsConfig.js';
 import * as iCloudTransport from './icloudFileTransport.js';
 import { HELD_NO_KEY_REASON } from './outbox.js';
+import { vaultRateLimited, noteVaultRateLimit, noteVaultRequestSuccess } from '../sync/vaultRequestBrake.js';
 
 export const DELIVERED = 'delivered';
 export const TRANSIENT = 'transient';
@@ -117,6 +118,14 @@ export async function vaultDeliverer(intent, opts = {}) {
   // No vault connection configured yet — hold (may appear); never drop.
   if (!connection) return TRANSIENT;
 
+  // Device-wide vault brake (sync/vaultRequestBrake.js): while the server is
+  // rate-limiting ANY of this device's vault paths, hold WITHOUT a network
+  // attempt. This is what paces the outbox's retries — every flush trigger
+  // (emit, mount, focus, interval) used to re-POST a held intent against the
+  // same saturated window; now those triggers no-op until the brake lifts,
+  // and the intent stays durably queued.
+  if (vaultRateLimited()) return TRANSIENT;
+
   // ── load the ALREADY-CACHED vault intents key (its OWN slot) ──
   const rootKey = await (opts.loadKey ?? loadVaultIntentsRootKey)();
   if (!rootKey) {
@@ -159,6 +168,12 @@ export async function vaultDeliverer(intent, opts = {}) {
     return TRANSIENT;
   }
   if (!res) return TRANSIENT;
+  // Brake bookkeeping, vault tier only (the file tiers have their own
+  // servers and budgets): a 429 arms the shared brake — the once-per-
+  // incident line, instead of the old silent TRANSIENT re-queue — and a
+  // delivery decays it.
+  if (res.status === 429) noteVaultRateLimit('db-intent');
+  else if (res.status >= 200 && res.status < 300) noteVaultRequestSuccess();
   return mapHttpStatus(res.status);
 }
 

--- a/src/intents/deliverers.test.js
+++ b/src/intents/deliverers.test.js
@@ -9,6 +9,7 @@ import {
   PERMANENT,
 } from './deliverers.js';
 import { HELD_NO_KEY_REASON } from './outbox.js';
+import { __resetVaultBrakeForTests } from '../sync/vaultRequestBrake.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Intents deliverers (stage 2a). These exercise the REAL deliverers and the REAL
@@ -28,7 +29,7 @@ function memLocalStorage() {
     clear: () => m.clear(),
   };
 }
-beforeEach(() => { global.localStorage = memLocalStorage(); });
+beforeEach(() => { global.localStorage = memLocalStorage(); __resetVaultBrakeForTests(); });
 afterAll(() => { delete global.localStorage; });
 
 const CONN = { vaultUrl: 'https://vault.example.com', vaultToken: 'tok-123', accountId: 'acct-1' };
@@ -148,8 +149,26 @@ describe('vault deliverer', () => {
 
     expect(await run(async () => ({ status: 503, ok: false, body: '' }))).toBe(TRANSIENT);
     expect(await run(async () => ({ status: 429, ok: false, body: '' }))).toBe(TRANSIENT);
+    __resetVaultBrakeForTests(); // the 429 armed the device-wide brake — clear it so the next run reaches the wire
     expect(await run(async () => ({ status: 400, ok: false, body: '' }))).toBe(PERMANENT);
     expect(await run(async () => { throw new TypeError('Failed to fetch'); })).toBe(TRANSIENT);
+  });
+
+  it('429 arms the DEVICE-WIDE brake: held transient, and further flush attempts make NO network request until it lifts', async () => {
+    const rootKey = await aRootKey(4);
+    const limited = vi.fn(async () => ({ status: 429, ok: false, body: '' }));
+    const run = () => vaultDeliverer(makeIntent(), {
+      connection: CONN, config: { ttlMs: 1000 }, vaultFetch: limited, loadKey: async () => rootKey,
+    });
+
+    expect(await run()).toBe(TRANSIENT);
+    expect(limited).toHaveBeenCalledTimes(1);
+    // Every subsequent flush trigger (emit, mount, focus, interval) used to
+    // re-POST against the same saturated window. Under the brake the intent
+    // stays held WITHOUT touching the network — the pacing the outbox lacked.
+    expect(await run()).toBe(TRANSIENT);
+    expect(await run()).toBe(TRANSIENT);
+    expect(limited).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/sync/vaultRequestBrake.js
+++ b/src/sync/vaultRequestBrake.js
@@ -1,0 +1,73 @@
+// THE DEVICE-WIDE VAULT REQUEST BRAKE — one 429 backoff for every
+// app-owned GLANCEvault request path.
+//
+// The server rate-limits per IP (default 600/min): ONE budget shared by
+// every path on this device (and every device behind the same NAT). A 429
+// on any path is the limiter saying the same thing to all of them, so the
+// brake is deliberately a single module-level instance — a bridge 429
+// pauses db-intents requests and vice versa, because retrying on a sister
+// path against the same exhausted window is the same mistake. Born as the
+// bridge brake (#1481, obsidianBridgeStream.js), extracted here when
+// db-intents — the last unbraked caller — joined (the "each new caller has
+// to remember" pattern this module ends). The DB sync engine keeps its own
+// cycle breaker (cycle-level gating + deferred retry, different semantics);
+// unification lives in @glance-apps/sync's client when the brake moves
+// into it — at that point this module's consumers swap one import.
+//
+// Semantics:
+//  • One arming per burst: concurrent 429s from one incident don't
+//    compound; escalation comes from failing again AFTER a brake lifted.
+//    Exponential 30s → 10min. The arming line is the once-per-incident
+//    visibility — gated paths stay silent by design.
+//  • DECAY, never amnesty (the plugin-side live bug of 2026-08-30): a
+//    success clears the GATE (the window demonstrably has room) but only
+//    HALVES the escalation memory, so the next 429 re-arms at the storm's
+//    level; a genuine recovery drains the memory to zero within a few
+//    quiet successes. Both transitions log.
+//  • While braked, emits still QUEUE (the outboxes are the durable
+//    buffers) — only network attempts pause.
+
+const BACKOFF_BASE_MS = 30_000;
+const BACKOFF_MAX_MS = 10 * 60_000;
+let backoffMs = 0;
+let backoffUntil = 0;
+
+export function vaultRateLimited(nowMs = Date.now()) {
+  return nowMs < backoffUntil;
+}
+
+/** True when the error is the server's rate limiter (or a 429 quota). */
+export function isRateLimitError(err) {
+  return err?.status === 429;
+}
+
+/**
+ * Note a 429 from any vault request path. `source` names the path that saw
+ * it ('bridge', 'db-intent', …) — one arming log per incident, so the
+ * console says which path met the limiter without every gated sibling
+ * repeating it.
+ */
+export function noteVaultRateLimit(source = 'vault') {
+  if (vaultRateLimited()) return;
+  backoffMs = Math.min(backoffMs ? backoffMs * 2 : BACKOFF_BASE_MS, BACKOFF_MAX_MS);
+  backoffUntil = Date.now() + backoffMs;
+  console.info(`[${source}] BRAKE: rate-limited (429) — vault requests paused for ~${Math.round(backoffMs / 1000)}s (all app-owned vault paths).`);
+}
+
+export function noteVaultRequestSuccess() {
+  backoffUntil = 0;
+  if (backoffMs === 0) return;
+  backoffMs = Math.floor(backoffMs / 2);
+  if (backoffMs < BACKOFF_BASE_MS) {
+    backoffMs = 0;
+    console.info('[vault] brake released — request succeeded.');
+  } else {
+    console.info(`[vault] brake decaying — request succeeded (a new 429 would pause ~${Math.round(Math.min(backoffMs * 2, BACKOFF_MAX_MS) / 1000)}s).`);
+  }
+}
+
+/** Test seam. */
+export function __resetVaultBrakeForTests() {
+  backoffMs = 0;
+  backoffUntil = 0;
+}

--- a/src/utils/obsidianBridgeStream.js
+++ b/src/utils/obsidianBridgeStream.js
@@ -56,63 +56,26 @@ let cachedSubkeyGeneration = null;
 let flushInFlight = null; // the running flush's promise — callers coalesce
 let metaFetchInFlight = null;
 
-// ── THE BRIDGE BRAKE ─────────────────────────────────────────────────────────
-// 429-aware backoff shared by every bridge request path in the app (flush,
-// config publish, meta discovery, and — via the exports — the observation
-// fetch). The GLANCEvault server rate-limits per IP (default 600/min), a
-// budget the whole household's devices share with the main sync engine, the
-// intents poller, and the plugin; when it trips, everything else backs off
-// (the engine's own BRAKE) and the bridge must too — retrying at full
-// cadence just keeps the window saturated for everyone. Exponential:
-// 30s doubling to 10min, reset by the next successful bridge request.
-// While braked, emits still QUEUE (the outbox is the durable buffer) —
-// only network attempts pause.
-const BRIDGE_BACKOFF_BASE_MS = 30_000;
-const BRIDGE_BACKOFF_MAX_MS = 10 * 60_000;
-let backoffMs = 0;
-let backoffUntil = 0;
+// ── THE BRAKE (now device-wide) ──────────────────────────────────────────────
+// Born here as the bridge brake (#1481, decay semantics from the 2026-08-30
+// live bug), extracted to sync/vaultRequestBrake.js when db-intents — the
+// last unbraked GLANCEvault caller — joined it: the server's 600/min budget
+// is per IP, one budget for every path on this device, so one brake is the
+// honest model (a 429 on any path pauses them all). The names below stay
+// exported so this module's callers (and the inbound half) are unchanged;
+// noteBridgeRateLimit tags its armings with the bridge's own source label.
+import {
+  vaultRateLimited,
+  isRateLimitError,
+  noteVaultRateLimit,
+  noteVaultRequestSuccess,
+  __resetVaultBrakeForTests,
+} from '../sync/vaultRequestBrake.js';
 
-export function bridgeRateLimited(nowMs = Date.now()) {
-  return nowMs < backoffUntil;
-}
-
-/** True when the error is the server's rate limiter (or a 429 quota). */
-export function isRateLimitError(err) {
-  return err?.status === 429;
-}
-
-export function noteBridgeRateLimit() {
-  // One arming per burst: concurrent 429s from the same incident (a flush's
-  // meta GET and its batch both failing) must not compound. Escalation
-  // comes from failing again AFTER a brake lifted — the retry that proves
-  // the window wasn't long enough.
-  if (bridgeRateLimited()) return;
-  backoffMs = Math.min(backoffMs ? backoffMs * 2 : BRIDGE_BACKOFF_BASE_MS, BRIDGE_BACKOFF_MAX_MS);
-  backoffUntil = Date.now() + backoffMs;
-  console.info(`[bridge] BRAKE: rate-limited (429) — bridge requests paused for ~${Math.round(backoffMs / 1000)}s.`);
-}
-
-// DECAY, never amnesty — the plugin-side live bug of 2026-08-30, fixed on
-// both sides in the same shape. The first design zeroed the escalation on
-// ANY success, silently; on a per-IP budget saturated by other traffic an
-// occasional request slips into a fresh limiter window and succeeds, and
-// each lucky 200 wiped the whole 30→480s escalation — the client "backs
-// off, escalates, forgets, starts over", never settling at the ceiling
-// while the storm lasts. Now a success clears the GATE (the window
-// demonstrably has room) but only HALVES the memory, so the next 429
-// re-arms at the storm's level; a genuine recovery drains the memory to
-// zero within a few quiet successes. Both transitions log.
-export function noteBridgeRequestSuccess() {
-  backoffUntil = 0;
-  if (backoffMs === 0) return;
-  backoffMs = Math.floor(backoffMs / 2);
-  if (backoffMs < BRIDGE_BACKOFF_BASE_MS) {
-    backoffMs = 0;
-    console.info('[bridge] brake released — bridge request succeeded.');
-  } else {
-    console.info(`[bridge] brake decaying — request succeeded (a new 429 would pause ~${Math.round(Math.min(backoffMs * 2, BRIDGE_BACKOFF_MAX_MS) / 1000)}s).`);
-  }
-}
+export { isRateLimitError };
+export const bridgeRateLimited = (nowMs) => (nowMs === undefined ? vaultRateLimited() : vaultRateLimited(nowMs));
+export const noteBridgeRateLimit = () => noteVaultRateLimit('bridge');
+export const noteBridgeRequestSuccess = () => noteVaultRequestSuccess();
 
 const readJson = (key, fallback) => {
   try { return JSON.parse(localStorage.getItem(key)) ?? fallback; } catch { return fallback; }
@@ -294,12 +257,11 @@ export async function publishBridgeConfig({ dailyNotesPath, dailyNotePattern, ta
   }
 }
 
-/** Test seam: reset module caches (subkey, in-flight flags). */
+/** Test seam: reset module caches (subkey, in-flight flags) + the shared brake. */
 export function __resetBridgeStreamForTests() {
   cachedSubkey = null;
   cachedSubkeyGeneration = null;
   flushInFlight = null;
   metaFetchInFlight = null;
-  backoffMs = 0;
-  backoffUntil = 0;
+  __resetVaultBrakeForTests();
 }


### PR DESCRIPTION
Item 3: db-intents — the last unbraked GLANCEvault request path — now gates on, arms, and decays a shared brake.

## The choice, and why

**Neither of the two shapes exactly as named; the honest middle with (a)'s destination.** Migrating onto `createVaultClient` today isn't possible as a transport swap: the client exposes **only `/sync/*` routes — zero `/intents/*` surface** — so a real migration means adding intents methods to `@glance-apps/sync`, a cross-repo package change (version bump, republish, dependents) that can't land from this repo. On the (b) question: that change would touch **no `/intents/*` server semantics** — it's pure client transport; the wire contract is untouched — so the blast radius is package plumbing, not GLANCEintents behavior. It remains the right destination: when item 4 puts the brake inside the client, adding the intents methods in the same version bump makes db-intents inherit everything, and both in-repo consumers swap one import.

To avoid the "join the bridge brake, stay on its own path forever" trap: the brake is **extracted out of the bridge into a neutral, deliberately device-wide module** (`src/sync/vaultRequestBrake.js`) rather than db-intents importing an obsidian-named one. Device-wide is also the semantically honest model, not just a convenience: the server's 600/min budget is **per IP** — one budget for every path on this device — so a 429 on any path is the limiter saying the same thing to all of them, and retrying on a sister path against the same exhausted window is the same mistake. This module is the exact seam item 4 lifts into the client.

## What changed

- **`src/sync/vaultRequestBrake.js` (new)**: the decay-not-amnesty 429 brake moved verbatim from `obsidianBridgeStream.js`. Armings are source-tagged (`[db-intent]` / `[bridge]`) so the console names the path that met the limiter — once per incident, with gated siblings silent by design.
- **`obsidianBridgeStream.js`**: brake removed, names re-exported as thin aliases — zero bridge-caller changes; existing decay pins now exercise the shared module through them.
- **`dbIntentsTransport.js`**: `pollDbIntents` sits a braked poll out entirely (cursor untouched — the next interval/focus/SSE trigger retries after the window); a 429 on list or batch **arms the brake instead of the old log-and-abandon**; successes decay it. `sendIntentsDb` is gated (fire-and-forget callers already tolerate an undefined ack; the durable path is the outbox).
- **`deliverers.js` `vaultDeliverer`**: holds `TRANSIENT` under the brake **without a network attempt** — this is the pacing the outbox retries lacked: every flush trigger (emit, mount, focus, interval) used to re-POST a held intent against the same saturated window; now those triggers no-op until the brake lifts while the intent stays durably queued. A 429 arms; a delivery decays. Vault tier only — WebDAV/iCloud have their own servers and budgets and are untouched.

## Visibility (the regardless-of-shape requirement)

The brake's arming line is the once-per-incident report — `[db-intent] BRAKE: rate-limited (429) — vault requests paused for ~Ns (all app-owned vault paths).` — replacing both the silently-abandoned poll cycle and the invisible TRANSIENT re-queue. Non-429 failures keep their existing warns. Release/decay transitions log too, so the interleaving that hid the last two flooders can't hide the next one.

## Pins (4 new; suite 2557 passing, lint + build clean)

- A 429 on list arms the brake; subsequent polls make **no request**; past the window the next trigger retries.
- `sendIntentsDb` gated while braked (no batch POST).
- The deliverer holds without touching the wire across repeated flush attempts.
- **One budget, one brake**: a db-intents 429 pauses the bridge paths too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_