### PR TITLE
Adopt @glance-apps/sync 2.0.0: per-half suppression, retryAt alignment, halt exit

### DIFF
--- a/dayglance-obsidian-plugin/package.json
+++ b/dayglance-obsidian-plugin/package.json
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@glance-apps/obsidian-format": "file:../packages/obsidian-format",
-    "@glance-apps/sync": "1.11.0"
+    "@glance-apps/sync": "2.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@glance-apps/billing": "0.2.2",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/obsidian-format": "file:packages/obsidian-format",
-        "@glance-apps/sync": "1.11.0",
+        "@glance-apps/sync": "2.0.0",
         "@modelcontextprotocol/node": "2.0.0",
         "@modelcontextprotocol/server": "2.0.0",
         "hono": "^4.13.1",
@@ -2626,9 +2626,9 @@
       "link": true
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.11.0.tgz",
-      "integrity": "sha512-hcajfmumIU3PprJAcXTZFgws1MpM/IQzFcX1Cn2v4XczmPdUBhPCVg1/NiiDHXHCnHjPHEj1oyaN/C9gcNb0ag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-2.0.0.tgz",
+      "integrity": "sha512-i6IpNo6DrMd20/aAkjWIEcPEofB3Z1G2sxn+nO1YWRSp9uKJuUCW5d805bgFIVhptmNN9h/ZcKyswdJ4PWXWNg==",
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@glance-apps/billing": "0.2.2",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/obsidian-format": "file:packages/obsidian-format",
-    "@glance-apps/sync": "1.11.0",
+    "@glance-apps/sync": "2.0.0",
     "@modelcontextprotocol/node": "2.0.0",
     "@modelcontextprotocol/server": "2.0.0",
     "hono": "^4.13.1",

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -28,7 +28,7 @@
 //     the PRE-merge (vault-consistent) mirror so those survivors diff dirty and
 //     push next cycle. See the commit block in dbSyncCycle.
 
-import { createDbSyncEngine, clearDbRootKey, initDbRootKey, decryptEntity } from '@glance-apps/sync';
+import { createDbSyncEngine, clearDbRootKey, initDbRootKey, decryptEntity, isSuppressedError } from '@glance-apps/sync';
 import { getVaultConfig, isVaultEnabled } from './vaultConfig.js';
 import { getDeviceId } from './deviceId.js';
 import {
@@ -750,7 +750,32 @@ export function createDbEngine(callbacks = {}) {
       // LOAD-BEARING ORDER: this pull must stay ahead of pushDirtyRows, in the
       // same try, with its failure left to throw — it is what keeps the HWM=0
       // seed gate above from turning into a push/nudge/re-seed loop.
-      const pull = await engine.pullRemoteChanges();   // merge remote into mirror first
+      let pull;
+      try {
+        pull = await engine.pullRemoteChanges();   // merge remote into mirror first
+      } catch (err) {
+        // ── 2.0.0 PER-HALF SUPPRESSION, pull half ─────────────────────────
+        // SYNC_SUPPRESSED is the package's OWN gate declining the call
+        // BEFORE any network (its 4a backoff/quota windows) — a pause, not
+        // a failure. Nothing ran: no rows applied, no cursor moved, so
+        // there is nothing to roll back and no strike to record — feeding
+        // this to breaker.onFailure would stack dayGLANCE's cooldown on
+        // top of the window that produced it, two brakes compounding from
+        // one cause. The TRIGGER is preserved by aligning the deferred
+        // retry to the window's own retryAt (the package changelog's
+        // guidance): a gated SSE nudge lands when the window lifts, not at
+        // the next poll. The early return also aborts the push — the
+        // pull-first-abort ordering the seed gate depends on is untouched.
+        // Real failures fall through to the outer catch (rollback +
+        // strike), unchanged.
+        if (!isSuppressedError(err)) throw err;
+        armDeferredRetry(Math.max(1000, err.retryInMs ?? 1000));
+        callbacks.onStatusChange?.('idle');
+        return {
+          applied: 0, skipped: 0, skippedEntityIds: [],
+          suppressed: true, direction: 'pull', reason: err.reason, retryInMs: err.retryInMs, retryPending: true,
+        };
+      }
       // The engine's onRowsSkipped fires from its own dbSyncCycle, which we
       // bypass — so surface undecryptable-row skips from the pull result here.
       if (pull && pull.skipped > 0) callbacks.onRowsSkipped?.(pull.skipped, pull.skippedEntityIds || []);
@@ -808,7 +833,28 @@ export function createDbEngine(callbacks = {}) {
       // rows the push below sends, and on success their pushed content becomes
       // the acked-hash baseline for the no-op re-push skip in the diff.
       const dirtyBeforePush = typeof engine.getDirtySet === 'function' ? engine.getDirtySet() : null;
-      const pushRes = await engine.pushDirtyRows();        // push merged superset + local changes
+      let pushRes = null;
+      let pushSuppressedRetryInMs = null;
+      try {
+        pushRes = await engine.pushDirtyRows();        // push merged superset + local changes
+      } catch (err) {
+        // ── 2.0.0 PER-HALF SUPPRESSION, push half ─────────────────────────
+        // THE CASE THE BLANKET SHAPE WOULD HAVE BROKEN (ruling 1): the pull
+        // above SUCCEEDED, and under 'end-of-pull' the package persisted the
+        // pull cursor at the end of pullRemoteChanges — so an abort here
+        // that skipped the rollback would discard the mirror with the
+        // cursor already past its rows: the permanent-loss window the
+        // rollback exists for. A suppressed push is therefore a SKIPPED
+        // push, mirroring the package cycle's own pushSkipped: the pulled
+        // mirror is good data, and committing it below is exactly what
+        // makes the pull's cursor advance honest. Nothing was acked, so
+        // the acked-hash recording below is skipped and the persisted
+        // dirty set is untouched — the rows push when the window lifts,
+        // via the deferred retry armed to the window's retryAt at the end
+        // of the cycle. No strike: the package already owns this pause.
+        if (!isSuppressedError(err)) throw err;
+        pushSuppressedRetryInMs = Math.max(1000, err.retryInMs ?? 1000);
+      }
       // Own-echo damping (#1455, sync/ownWrites.js): a push that WROTE gets a
       // nudge back carrying exactly this maxSeq — record it so the SSE
       // coalescer can suppress our own echo by identity. Only on an actual
@@ -863,11 +909,13 @@ export function createDbEngine(callbacks = {}) {
       // snapshot → 'new' in cycle N+1's diff → pushed. And for a pulled remote
       // change: in the snapshot AND in the commit → clean, no echo re-push.)
       const vaultSnapshot = shredHashes(mirror);
-      // The push above was fully acked (a throw would have skipped this), so
-      // record what the vault now holds for each pushed id: present in the
-      // mirror → its pushed content hash (vaultSnapshot is hashed from the
-      // exact mirror the push read); absent → an acked soft-delete.
-      if (dirtyBeforePush) {
+      // The push above was fully acked (a real throw would have skipped
+      // this, and a SUPPRESSED push skips it via the guard — nothing was
+      // sent, so nothing is acked), so record what the vault now holds for
+      // each pushed id: present in the mirror → its pushed content hash
+      // (vaultSnapshot is hashed from the exact mirror the push read);
+      // absent → an acked soft-delete.
+      if (dirtyBeforePush && pushSuppressedRetryInMs === null) {
         for (const id of dirtyBeforePush) {
           if (vaultSnapshot[id] !== undefined) {
             ackedUpsertHashes.set(id, vaultSnapshot[id]);
@@ -918,12 +966,21 @@ export function createDbEngine(callbacks = {}) {
           glitchUnresolved.slice(0, 25), glitchUnresolved.length > 25 ? `(+${glitchUnresolved.length - 25} more)` : ''
         );
       }
-      // This cycle COMPLETED (pull + push both ran), so it served whatever any
-      // gated trigger was announcing — a still-pending deferred retry would
-      // just run a pointless extra cycle. Cancel it. (A THROWN cycle skips
-      // this, deliberately: its pull may not have finished, and the retry
-      // re-arms itself through the gate anyway.)
-      cancelPendingRetry();
+      // This cycle COMPLETED (pull ran; push ran or was window-suppressed),
+      // so it served whatever any gated trigger was announcing — a
+      // still-pending deferred retry would just run a pointless extra
+      // cycle. Cancel it — UNLESS the push half is still owed: then keep
+      // exactly one retry armed for the package window's expiry, so the
+      // untouched dirty set lands when the window lifts rather than at the
+      // next poll. (A THROWN cycle skips this, deliberately: its pull may
+      // not have finished, and the retry re-arms itself through the gate
+      // anyway.)
+      if (pushSuppressedRetryInMs !== null) {
+        cancelPendingRetry();
+        armDeferredRetry(pushSuppressedRetryInMs);
+      } else {
+        cancelPendingRetry();
+      }
       // Breaker bookkeeping: a clean cycle resets the backoff. A cycle that
       // finished but was rate-limited inside the heal still counts as a strike —
       // the vault told us to slow down, and retrying the heal at full trigger
@@ -944,7 +1001,10 @@ export function createDbEngine(callbacks = {}) {
         breaker.onSuccess();
       }
       callbacks.onStatusChange?.('success');
-      return { applied: pull?.applied ?? 0, skipped: pull?.skipped ?? 0, skippedEntityIds: pull?.skippedEntityIds ?? [] };
+      return {
+        applied: pull?.applied ?? 0, skipped: pull?.skipped ?? 0, skippedEntityIds: pull?.skippedEntityIds ?? [],
+        ...(pushSuppressedRetryInMs !== null ? { pushSuppressed: true, retryInMs: pushSuppressedRetryInMs, retryPending: true } : {}),
+      };
     } catch (err) {
       // ROLL THE PULL CURSOR BACK to where this cycle started. This looks like
       // it is fighting the package, and it is — deliberately. As of

--- a/src/sync/dbPullPagination.test.js
+++ b/src/sync/dbPullPagination.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import { setSyncPassphrase } from '@glance-apps/sync';
 import { createDbEngine } from './dbEngine.js';
 import { setVaultConfig } from './vaultConfig.js';
@@ -94,13 +94,28 @@ function makeDevice(name, vault, initial) {
 
 const taskIds = (device) => device.data.tasks.map((t) => t.id).sort();
 
+afterEach(() => { vi.useRealTimers(); });
 afterAll(() => { delete global.localStorage; });
+
+// Advance the faked Date past the package's 30s pull backoff window so the
+// next cycle is a genuine retry rather than a SYNC_SUPPRESSED pause.
+const pastPackageWindow = () => vi.setSystemTime(new Date(Date.now() + 31_000));
 
 describe('multi-page pull: mid-pagination failure must not strand rows below the cursor', () => {
   let vault;
   let seeder;
 
   beforeEach(async () => {
+    // 2.0.0 CLOCK NOTE (ruling 2 — deliberate, not a quiet edit): since 4a,
+    // a real pull failure opens the PACKAGE's own pull backoff window inside
+    // the primitives, so the immediate retry these tests used to make is now
+    // legitimately SUPPRESSED — the package working, not the test failing.
+    // The Date is faked so each post-failure "clean cycle" can first advance
+    // past the window's retryAt. What this suite pins is unchanged and still
+    // fails without the wrapper's rollback: a mid-pagination failure must
+    // not strand rows below the cursor.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-16T12:00:00.000Z'));
     global.localStorage = memLocalStorage();
     setVaultConfig({ enabled: true, vaultUrl: 'https://v', vaultToken: 't', accountId: 'acct' });
     setSyncPassphrase('pagination-test-passphrase');
@@ -140,6 +155,7 @@ describe('multi-page pull: mid-pagination failure must not strand rows below the
     await a.engine.dbSyncCycle();
     vault.disarm();
 
+    pastPackageWindow(); // ruling 2: wait out the 4a pull window, then retry
     await a.engine.dbSyncCycle();
     // Without the rollback this converges to only ['r3', 'r4']: r1/r2 sit
     // below the advanced cursor and no incremental pull ever re-lists them.
@@ -176,6 +192,7 @@ describe('multi-page pull: mid-pagination failure must not strand rows below the
     vault.disarm();
     expect(a.engine.getHighWaterMark()).toBe(settledHwm);
 
+    pastPackageWindow(); // ruling 2: wait out the 4a pull window, then retry
     await a.engine.dbSyncCycle();
     expect(taskIds(a)).toEqual(['r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7']);
   });

--- a/src/sync/dbSyncDeferredRetry.test.js
+++ b/src/sync/dbSyncDeferredRetry.test.js
@@ -184,9 +184,23 @@ describe('deferred retry — a nudge gated by a cooldown lands at cooldown expir
     await mac.engine.dbSyncCycle();
     expect(timers.pending()).toHaveLength(1);
 
-    // The timer fires at cooldown expiry → the deferred cycle runs and pulls
-    // the peer edit. Single-digit seconds after the 429, not the 5-minute poll.
-    vi.setSystemTime(atOffset(2000 + 5750));
+    // 2.0.0 (ruling 3): the same 429 that opened the LOCAL 7.5s cooldown
+    // also opened the PACKAGE's 30s pull window (4a moved enforcement into
+    // the primitives). The locally-aligned retry fires first — and instead
+    // of firing INTO the still-open package window at full cadence, the
+    // cycle is suppressed BEFORE any network and the retry re-arms to the
+    // window's own retryAt: max(local, package) achieved by chaining.
+    vi.setSystemTime(atOffset(2000 + 5750)); // t=7750
+    await timers.fire(timers.pending()[0]);
+    expect(macTitle(mac, 't1')).toBe('task t1'); // package window still open — no pull ran
+    expect(timers.pending()).toHaveLength(1);
+    // Re-armed for the package window's remainder: 30000 − 7750 + 250 pad.
+    expect(timers.pending()[0].ms).toBe(22500);
+
+    // The aligned retry fires when the package window lifts → the deferred
+    // cycle runs and pulls the peer edit — still seconds-scale after the
+    // window, not the 5-minute poll.
+    vi.setSystemTime(atOffset(7750 + 22500));
     await timers.fire(timers.pending()[0]);
     expect(macTitle(mac, 't1')).toBe('edited on peer');
     expect(timers.pending()).toHaveLength(0); // completed cycle left nothing armed
@@ -208,8 +222,10 @@ describe('deferred retry — a nudge gated by a cooldown lands at cooldown expir
     // The cooldown expires naturally and something else triggers first — a
     // foreground flip / manual "Sync now". That cycle completes and serves the
     // trigger, so it must CANCEL the pending retry rather than leave it to run
-    // an extra cycle.
-    vi.setSystemTime(atOffset(8000));
+    // an extra cycle. (2.0.0: "expires naturally" now means BOTH windows —
+    // the local 7.5s cooldown and the package's 30s pull window — so the
+    // manual trigger lands at t=31s, past the longer of the two.)
+    vi.setSystemTime(atOffset(31000));
     const manual = await mac.engine.dbSyncCycle();
     expect(manual.throttled).toBeUndefined();
     expect(macTitle(mac, 't1')).toBe('edited on peer');
@@ -228,8 +244,9 @@ describe('deferred retry — a nudge gated by a cooldown lands at cooldown expir
     vault.list = async () => { listCalls += 1; const e = new Error('list failed: 429'); e.status = 429; throw e; };
 
     let now = 0;
-    const windowDelays = [];
-    await mac.engine.dbSyncCycle(); // strike 1 — cooldown 7500ms
+    const localDelays = [];
+    const alignedDelays = [];
+    await mac.engine.dbSyncCycle(); // strike 1 — local cooldown 7500ms, package pull window 30s
     for (let window = 0; window < 3; window++) {
       // Continuous nudges throughout the cooldown: every one is gated and
       // coalesces into the single pending retry.
@@ -238,22 +255,40 @@ describe('deferred retry — a nudge gated by a cooldown lands at cooldown expir
         expect(gated.throttled).toBe(true);
       }
       expect(timers.pending()).toHaveLength(1);
-      const handle = timers.pending()[0];
-      windowDelays.push(handle.ms);
+      let handle = timers.pending()[0];
+      localDelays.push(handle.ms);
 
-      // The retry fires at expiry, attempts ONE cycle, fails again (429) — and
-      // that failure goes through the normal breaker path: the next cooldown
-      // is longer.
+      // HOP 1 (2.0.0, ruling 3): the locally-aligned retry fires while the
+      // package's LONGER window is still open — the cycle is suppressed
+      // BEFORE any network call (no list attempt burned against the vault)
+      // and the retry re-arms to the package window's own retryAt.
+      now += handle.ms;
+      vi.setSystemTime(atOffset(now));
+      const callsBeforeHop1 = listCalls;
+      await timers.fire(handle);
+      expect(listCalls).toBe(callsBeforeHop1); // suppressed = zero network
+      expect(timers.pending()).toHaveLength(1);
+      handle = timers.pending()[0];
+      alignedDelays.push(handle.ms);
+
+      // HOP 2: the package-aligned retry fires after the window lifts →
+      // exactly ONE real attempt → 429 → BOTH ladders escalate through
+      // their normal failure paths.
       now += handle.ms;
       vi.setSystemTime(atOffset(now));
       await timers.fire(handle);
     }
 
-    // Exactly one vault attempt per window (plus the initial strike): the
-    // storm stays damped even under continuous nudges.
+    // Exactly one REAL vault attempt per window (plus the initial strike):
+    // the storm stays damped even under continuous nudges, and no attempt
+    // is ever wasted against a window known to be closed.
     expect(listCalls).toBe(1 + 3);
-    // Escalation through breaker.onFailure: 7500 → 15000 → 30000 (+250ms pad).
-    expect(windowDelays).toEqual([7750, 15250, 30250]);
+    // The LOCAL ladder is unchanged from before 2.0.0: 7500 → 15000 → 30000
+    // (+250ms pad) — the adoption added alignment, not a different brake.
+    expect(localDelays).toEqual([7750, 15250, 30250]);
+    // And each hop-1 suppression re-armed to the PACKAGE window's remainder
+    // (30s/60s/120s ladder minus the time already waited, +250ms pad).
+    expect(alignedDelays).toEqual([22500, 45000, 90000]);
 
     vault.list = realList;
   });

--- a/src/sync/dbSyncSuppressed.test.js
+++ b/src/sync/dbSyncSuppressed.test.js
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import { setSyncPassphrase } from '@glance-apps/sync';
+import { credentialHaltKey } from '@glance-apps/sync/src/dbEngine.js';
+import { createDbEngine } from './dbEngine.js';
+import { setVaultConfig } from './vaultConfig.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// @glance-apps/sync 2.0.0 ADOPTION — per-half suppression (ruling 1) and the
+// credential-halt exit (ruling 4).
+//
+// Since 4a, the package's primitives refuse to run while their direction's
+// backoff window is open, throwing a typed SYNC_SUPPRESSED BEFORE any
+// network call. That throw is a pause the package already scheduled, not a
+// new failure — so dayGLANCE's composed cycle must not escalate its own
+// brake on it, and must not roll the cursor back for a call that ran
+// nothing. But the two halves are NOT symmetric, and the asymmetry is the
+// bug this suite exists to guard (it was nearly specified):
+//
+//   PULL suppressed → nothing ran. Early return: no rollback, no strike.
+//   PUSH suppressed → the pull SUCCEEDED and, under 'end-of-pull', already
+//     persisted its cursor. The pulled mirror is good data; the cycle must
+//     CONTINUE to commit it — a blanket abort that also skipped the
+//     rollback would discard the mirror with the cursor past its rows:
+//     permanent row loss. No strike; the dirty set is untouched and pushes
+//     when the window lifts.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+function createMemoryVault() {
+  const salts = new Map();
+  const log = new Map();
+  let seq = 0;
+  return {
+    async getSalt(accountId) { return salts.get(accountId) || null; },
+    async putSalt(accountId, fresh) { if (!salts.has(accountId)) salts.set(accountId, fresh); return salts.get(accountId); },
+    async batch(app, { rows }) {
+      for (const r of rows) log.set(r.entityId, { entityId: r.entityId, seq: ++seq, envelope: r.envelope, deleted: false });
+      return { maxSeq: seq };
+    },
+    async deleteRow(app, entityId) { log.set(entityId, { entityId, seq: ++seq, envelope: null, deleted: true }); return { seq }; },
+    async list(app, { since }) {
+      const rows = [...log.values()].filter((r) => r.seq > since).sort((a, b) => a.seq - b.seq);
+      return { rows, hasMore: false };
+    },
+    async device() { return { updated: true }; },
+  };
+}
+
+const throw429 = () => { const e = new Error('429: rate limited'); e.status = 429; throw e; };
+
+const FIXTURE_NOW = new Date('2026-08-16T12:00:00.000Z');
+const atOffset = (ms) => new Date(FIXTURE_NOW.getTime() + ms);
+
+let warnSpy;
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(FIXTURE_NOW);
+  global.localStorage = memLocalStorage();
+  setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 't', accountId: 'acct' });
+  setSyncPassphrase('correct horse battery staple');
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => { warnSpy.mockRestore(); vi.useRealTimers(); });
+afterAll(() => { delete global.localStorage; });
+
+const clone = (x) => JSON.parse(JSON.stringify(x));
+const EMPTY = {
+  tasks: [], unscheduledTasks: [], recurringTasks: [], recycleBin: [], todayRoutines: [],
+  habits: [], goals: [], projects: [], gtdFrames: [], users: [], dailyNotes: {},
+  completedTaskUids: [], deletedTaskIds: {},
+};
+const task = (id, lastModified) => ({
+  id, title: `task ${id}`, duration: 30, color: 'bg-blue-500', completed: false,
+  notes: '', subtasks: [], lastModified, date: '2026-08-16', startTime: '09:00',
+});
+
+// A device with a SPYING local breaker (always-open gate, so what reaches
+// onFailure is exactly what the cycle chose to report as a failure) and
+// captured retry timers.
+function makeDevice(name, vault, initial) {
+  let data = clone(initial);
+  let nativeKey = null;
+  const onFailure = vi.fn(() => 0);
+  const onSuccess = vi.fn();
+  const statuses = [];
+  const armed = [];
+  const engine = createDbEngine({
+    vaultClient: vault,
+    storageKeyPrefix: `dev-${name}`,
+    deviceId: `device-${name}`,
+    nativeGetSyncKey: () => nativeKey,
+    nativeStoreSyncKey: (v) => { nativeKey = v; },
+    getData: () => clone(data),
+    commitData: (d) => { data = d; },
+    onStatusChange: (s) => statuses.push(s),
+    cycleBreaker: { beforeCycle: () => ({ allowed: true }), onSuccess, onFailure },
+    retryTimers: {
+      setTimeoutFn: (fn, ms) => { armed.push({ fn, ms }); return armed[armed.length - 1]; },
+      clearTimeoutFn: () => {},
+    },
+  });
+  return { engine, onFailure, onSuccess, statuses, armed, get data() { return data; }, set data(d) { data = d; } };
+}
+
+describe('ruling 1 — pull suppressed: early return, no rollback, no strike', () => {
+  it('a SYNC_SUPPRESSED pull is a pause, not a failure: no onFailure, no error status, cursor untouched, retry armed to the window', async () => {
+    const vault = createMemoryVault();
+    const seeder = makeDevice('seeder', vault, { ...EMPTY, tasks: [task('r1', '2026-08-10T10:00:00.000Z')] });
+    await seeder.engine.dbSyncCycle();
+
+    const a = makeDevice('A', vault, EMPTY);
+    // Open the package's pull window with one REAL 429.
+    const realList = vault.list;
+    vault.list = throw429;
+    const failed = await a.engine.dbSyncCycle();
+    vault.list = realList;
+    expect(failed.error).toMatch(/429/);
+    expect(a.onFailure).toHaveBeenCalledTimes(1); // the real failure strikes
+    const hwmAfterFailure = a.engine.getHighWaterMark();
+
+    // 5s later — inside the package's 30s pull window — a trigger arrives.
+    vi.setSystemTime(atOffset(5000));
+    const statusCountBefore = a.statuses.length; // the real failure above legitimately logged 'error'
+    const res = await a.engine.dbSyncCycle();
+
+    expect(res.suppressed).toBe(true);
+    expect(res.direction).toBe('pull');
+    expect(res.retryPending).toBe(true);
+    // NOT a failure: no second strike, and the suppressed cycle itself never
+    // paints the 'error' status (the earlier REAL failure rightly did).
+    expect(a.onFailure).toHaveBeenCalledTimes(1);
+    expect(a.statuses.slice(statusCountBefore)).not.toContain('error');
+    // Nothing ran, so nothing moved and nothing was rolled back.
+    expect(a.engine.getHighWaterMark()).toBe(hwmAfterFailure);
+    // The trigger is preserved, aligned to the package window's remainder
+    // (30000 − 5000, + the 250ms pad).
+    const pending = a.armed[a.armed.length - 1];
+    expect(pending.ms).toBe(25250);
+
+    // Past the window, the retry converges — the pause cost nothing.
+    vi.setSystemTime(atOffset(31000));
+    await a.engine.dbSyncCycle();
+    expect(a.data.tasks.map((t) => t.id)).toEqual(['r1']);
+  });
+});
+
+describe('ruling 1 — push suppressed: skip the push, COMMIT the pull (the case the blanket shape would have lost)', () => {
+  it('pull succeeds, push is window-suppressed → pulled rows COMMIT, cursor advance stands, no strike, dirty rows land after the window', async () => {
+    const vault = createMemoryVault();
+    const seeder = makeDevice('seeder', vault, { ...EMPTY, tasks: [task('r1', '2026-08-10T10:00:00.000Z')] });
+    await seeder.engine.dbSyncCycle();
+
+    // Device A has a LOCAL task to push and remote rows to pull.
+    const a = makeDevice('A', vault, { ...EMPTY, tasks: [task('local1', '2026-08-12T10:00:00.000Z')] });
+
+    // Open the package's PUSH window only: one cycle where the pull works
+    // but the batch 429s (a real failure — strike + rollback, unchanged).
+    const realBatch = vault.batch;
+    vault.batch = throw429;
+    const failed = await a.engine.dbSyncCycle();
+    vault.batch = realBatch;
+    expect(failed.error).toMatch(/429/);
+    expect(a.onFailure).toHaveBeenCalledTimes(1);
+    expect(a.engine.getHighWaterMark()).toBe(0); // real failure still rolls back
+
+    // 5s later — pull window closed (the pull never failed), push window
+    // open for another 25s — a trigger arrives.
+    vi.setSystemTime(atOffset(5000));
+    const res = await a.engine.dbSyncCycle();
+
+    // THE PIN: the pulled mirror COMMITTED (r1 is live alongside local1)...
+    expect(a.data.tasks.map((t) => t.id).sort()).toEqual(['local1', 'r1']);
+    // ...and the pull's cursor advance STANDS — no rollback. A blanket
+    // early return (or a blanket failure path) would have left r1 stranded
+    // below an advanced cursor in a discarded mirror.
+    expect(a.engine.getHighWaterMark()).toBeGreaterThan(0);
+    // The suppressed push is a skip, not a failure: no second strike.
+    expect(a.onFailure).toHaveBeenCalledTimes(1);
+    expect(res.pushSuppressed).toBe(true);
+    expect(res.retryPending).toBe(true);
+    // The trigger for the owed push half is armed to the window's remainder.
+    expect(a.armed[a.armed.length - 1].ms).toBe(25250);
+    // And local1 has NOT reached the vault yet — nothing was acked.
+    expect(seeder.data.tasks.map((t) => t.id)).toEqual(['r1']);
+
+    // Past the push window: the dirty set (untouched by the suppression)
+    // pushes, and the fleet converges.
+    vi.setSystemTime(atOffset(31000));
+    await a.engine.dbSyncCycle();
+    await seeder.engine.dbSyncCycle();
+    expect(seeder.data.tasks.map((t) => t.id).sort()).toEqual(['local1', 'r1']);
+  });
+});
+
+describe('ruling 4 — the credential-halt exit (minimal version)', () => {
+  const HALT_KEY = credentialHaltKey('dayglance-vault');
+
+  it('saving CHANGED vault credentials clears a persisted halt (fresh credentials are a fresh chance)', () => {
+    localStorage.setItem(HALT_KEY, JSON.stringify({ message: 'credential rejected', at: FIXTURE_NOW.toISOString() }));
+    setVaultConfig({ enabled: true, vaultUrl: 'https://vault.test', vaultToken: 'BRAND-NEW-TOKEN', accountId: 'acct' });
+    expect(localStorage.getItem(HALT_KEY)).toBe(null);
+  });
+
+  it('re-saving UNCHANGED credentials (e.g. toggling enabled) leaves the halt in place', () => {
+    localStorage.setItem(HALT_KEY, JSON.stringify({ message: 'credential rejected', at: FIXTURE_NOW.toISOString() }));
+    setVaultConfig({ enabled: false, vaultUrl: 'https://vault.test', vaultToken: 't', accountId: 'acct' });
+    expect(localStorage.getItem(HALT_KEY)).not.toBe(null);
+  });
+});

--- a/src/sync/vaultConfig.js
+++ b/src/sync/vaultConfig.js
@@ -3,7 +3,14 @@
 // the file-tier (WebDAV) config — the DB transport runs ALONGSIDE WebDAV and is
 // opt-in. Clearing this config reverts to file-only instantly.
 
+// The package's persisted credential-halt key (2.0.0/4a): set when the server
+// rejects this device's credential, honoured by every primitive. Imported as
+// the exported helper — never a string literal — so the key can't drift.
+import { credentialHaltKey } from '@glance-apps/sync/src/dbEngine.js';
+
 const VAULT_CONFIG_KEY = 'dayglance-vault-config';
+// Must match the wrapper's DEFAULT_STORAGE_KEY_PREFIX (src/sync/dbEngine.js).
+const VAULT_STORAGE_KEY_PREFIX = 'dayglance-vault';
 
 /** @returns {{enabled:boolean, vaultUrl:string, vaultToken:string, accountId:string}|null} */
 export function getVaultConfig() {
@@ -16,6 +23,23 @@ export function getVaultConfig() {
 }
 
 export function setVaultConfig(cfg) {
+  // HALT EXIT (2.0.0 adoption, ruling 4 — the minimal version): the package
+  // persists its credential halt and only its per-account recovery flow
+  // (recoverVaultSyncEngine, which needs the bootstrap secret) clears it —
+  // a flow dayGLANCE doesn't run. Without this, a once-halted device would
+  // refuse to sync forever even after the user pasted a fresh valid token:
+  // strictly worse than pre-2.0.0, where replacing a revoked token
+  // self-recovered. So saving CHANGED credentials clears the halt — fresh
+  // credentials are a fresh chance, and if they are still bad the first
+  // cycle re-halts, which is self-correcting. The complete recovery flow
+  // (per-account era) remains future work.
+  try {
+    const prev = getVaultConfig();
+    const credsChanged = !!cfg && (
+      !prev || prev.vaultUrl !== cfg.vaultUrl || prev.vaultToken !== cfg.vaultToken || prev.accountId !== cfg.accountId
+    );
+    if (credsChanged) localStorage.removeItem(credentialHaltKey(VAULT_STORAGE_KEY_PREFIX));
+  } catch { /* storage unavailable — the halt read would fail the same way */ }
   if (cfg) localStorage.setItem(VAULT_CONFIG_KEY, JSON.stringify(cfg));
   else localStorage.removeItem(VAULT_CONFIG_KEY);
 }


### PR DESCRIPTION
The 2.0.0 adoption, built to the four rulings. **What dayGLANCE gains that it never had:** as the composed caller, it silently opted out of every cycle-level protection — 4a's enforcement-moved-down gives its composed cycle backoff, over-quota suppression, and the credential halt for the first time.

## Ruling 1 — per-half suppression, and why a blanket early return would have lost rows

`SYNC_SUPPRESSED` is the package's own gate declining a call **before any network** — a pause, not a failure — but the two halves are not symmetric:

- **Pull suppressed** → nothing ran. Early return: no cursor rollback, no strike against the local brake, no `'error'` status; the deferred retry is armed to the window's own `retryAt`, so a gated SSE nudge lands at expiry instead of the next poll. Pull-first-abort ordering (the seed-gate protection) is untouched — a suppressed pull aborts the push exactly like a failed one.
- **Push suppressed** → the pull **succeeded**, and under `'end-of-pull'` the package persisted its cursor at the end of `pullRemoteChanges`. The cycle **continues to heal and commit**: the pulled mirror is good data, and committing it is what makes that cursor advance honest. The blanket shape ("a suppressed call applied nothing, so nothing to roll back") is true of the call and false of the cycle — an abort here that skipped the rollback would have discarded the mirror with the cursor past its rows: the permanent-loss window the rollback exists for. Nothing was acked (the acked-hash recording is skipped), the persisted dirty set is untouched, and one deferred retry stays armed for the push window's expiry.

Both branches use the exported `isSuppressedError`, never a code literal. A real failure is byte-for-byte unchanged: rollback + strike + error. The halt's `CREDENTIAL_INVALID` throw deliberately stays on that failure path — a halt is terminal, a suppression is not.

## Ruling 3 — the `retryAt` alignment (the overlap was live, not theoretical)

Three deferred-retry tests failed on the bare bump: the locally-aligned retry (7.5s ladder) fired **into** the package's still-open 30s window. A suppressed cycle now re-arms the retry to the window's own `retryAt` — `max(local, package)` achieved by chaining. The storm pin shows the local ladder **unchanged** (7500→15000→30000 +pad) with the aligned hops on top (22500→45000→90000): still exactly one *real* vault attempt per window, and now **zero attempts wasted** against a window known to be closed.

## Ruling 2 — `dbPullPagination.test.js` clock advance (deliberate, called out)

Since 4a, the mid-pagination failure itself opens the package's pull window, so this suite's immediate retry cycle is legitimately suppressed — the package working, not the test failing. The suite now fakes `Date` and advances past `retryAt` before each post-failure clean cycle. **What it pins is unchanged and it still fails without the wrapper's rollback** (verified: stripping the rollback fails it as before).

## Ruling 4 — the minimal halt exit

The package's credential halt is persisted, and only `recoverVaultSyncEngine` (per-account bootstrap-secret recovery, which dayGLANCE doesn't run) clears it — so a once-halted device would have refused to sync forever even after pasting a fresh valid token, strictly worse than pre-2.0.0. Saving **changed** vault credentials now clears the halt key (fresh credentials are a fresh chance; still-bad ones re-halt on the first cycle, self-correcting). Unchanged-credential saves leave the halt alone. The complete recovery flow remains future work.

## Why no cursor mode is declared

dayGLANCE is safe on the new `'end-of-pull'` default — it closes the mid-pagination loss window the local rollback was written for. The rollback **stays** for the second window ('pull succeeded, later step threw'), which is invisible to the package; `'caller'` mode plus rollback removal is a deliberate follow-up with its own reasoning, not an oversight.

## Negative controls (run and restored)

- Per-half handling stripped from `dbEngine.js` → **4 tests fail**, including the push-suppressed **commit pin** (the row-loss case the original brief would have shipped) and both deferred-retry alignment pins.
- Halt-clear stripped from `vaultConfig.js` → the changed-credentials pin fails.

## Verification

New `dbSyncSuppressed.test.js` (both ruling-1 halves end-to-end against the real 2.0.0 engine, plus both halt behaviors); suite **2561 passing**; lint clean; app build, plugin bundle (also bumped to 2.0.0 — client surface unchanged), and **both electron tsconfigs** clean. Real-failure semantics, commit-only-on-success, and `resetVaultSyncCursor` untouched. Branch note: rebased onto main after #1488 merged, as directed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_