### PR TITLE
Route bridge-row SSE nudges to the Obsidian cycle (Phase 7 groundwork)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1368,6 +1368,11 @@ const DayPlanner = () => {
   // frames through the bridge (native-bridge); an older native shell without the
   // reader degrades to polling. Nudges trigger the EXISTING drains: dbSyncCycle for
   // sync, drainDbIntents for intents. See useVaultEventStream / vaultEventStream.
+  // Filled after useObsidianSync mounts below (it needs the task state this
+  // section precedes); the SSE hook reads it per nudge via the callback, so
+  // the ordering costs nothing. All pacing — the observation probe, the min
+  // gap, the plugin-authority gate — lives in the callee.
+  const obsidianSseNudgeRef = useRef(null);
   useVaultEventStream({
     dataLoaded,
     drainSync: useCallback(() => dbEngineRef.current?.dbSyncCycle?.(), []),
@@ -1377,6 +1382,11 @@ const DayPlanner = () => {
       await ensureVaultIntentsKeyReady();
       return drainDbIntents(dbIntentContextRef.current);
     }, []),
+    // Phase 7 groundwork: the same nudge also wakes the Obsidian observation
+    // cycle — bridge rows advance the same account seq, so a plugin-observed
+    // vault edit reaches dayGLANCE in seconds instead of waiting out the
+    // 5-minute poll. See nudgeObsidianObservations in useObsidianSync.
+    drainObsidian: useCallback(() => obsidianSseNudgeRef.current?.(), []),
   });
   // Proactively (re-)derive the GLANCEvault INTENTS root key the moment sync is
   // established with the passphrase in memory — the same trigger that re-derives
@@ -2758,7 +2768,7 @@ const DayPlanner = () => {
   // re-sync, 5-minute poll, task writeback, iOS vault-settings persistence)
   // lives in useObsidianSync; state/refs stay owned by useObsidian above.
   const {
-    performObsidianSync, loadWikiNote, saveWikiNote, openInObsidian, bridgeHeartbeatRef,
+    performObsidianSync, nudgeObsidianObservations, loadWikiNote, saveWikiNote, openInObsidian, bridgeHeartbeatRef,
   } = useObsidianSync({
     isTrayMode, dataLoaded,
     tasks, setTasks,
@@ -2776,6 +2786,9 @@ const DayPlanner = () => {
     obsidianTasksRef, obsidianInboxRef,
     recycleBin, setRecycleBin,
   });
+  // Late-bind the SSE → Obsidian nudge (declared beside useVaultEventStream
+  // above, which mounts before this hook can exist).
+  obsidianSseNudgeRef.current = nudgeObsidianObservations;
 
   // Auto-backup timer
   useEffect(() => {

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -33,7 +33,7 @@ import { blockIdWritesEnabled, completionMarkerWritesEnabled } from '../utils/ob
 import { titleConflictNoticeText } from '../utils/obsidianTitleConflict.js';
 import { withCreationFrontmatter } from '../utils/obsidianFrontmatter.js';
 import { emitBridgeIntent, flushBridgeOutbox, publishBridgeConfig, getBridgePairingMeta } from '../utils/obsidianBridgeStream.js';
-import { fetchBridgeObservations, applyBridgeObservations, commitBridgeObservationCursor } from '../utils/obsidianBridgeInbound.js';
+import { fetchBridgeObservations, applyBridgeObservations, commitBridgeObservationCursor, pendingBridgeObservations } from '../utils/obsidianBridgeInbound.js';
 import { recordBridgeMode, reconcileArchivedBaseline } from '../utils/obsidianBridgeMode.js';
 import { restoreBinnedVaultTasks, binRestoreNoticeText } from '../utils/obsidianBinRestore.js';
 import { inferNoteScopedDeletionCandidates, reconcileNoteScopedDeletions } from '../utils/obsidianNoteScopedDeletions.js';
@@ -815,6 +815,60 @@ export default function useObsidianSync({
     }
   };
 
+  // ── SSE → OBSIDIAN CYCLE (Phase 7 groundwork) ───────────────────────────
+  // Bridge-row writes advance the account seq and already reach this app as
+  // /events nudges (useVaultEventStream); this is the missing route from
+  // those nudges to the observation-consuming cycle, replacing "wait for
+  // the 5-minute poll or a visibility flip" with seconds. PACING, because
+  // trigger-speed loops have burned this project twice (#1455 ×2):
+  //  • the shared coalescer already debounces micro-bursts (400ms) and
+  //    suppresses this device's own write echoes by exact ack identity —
+  //    our stamps/intents/config publishes never wake a cycle; the PLUGIN's
+  //    writes are peer writes whose nudges we want (its observations);
+  //  • a cheap PROBE (pendingBridgeObservations: one list page, prefix
+  //    check, no crypto) gates the wake — foreign DB-tier activity costs
+  //    one GET and runs no cycle, no merges, no status flash;
+  //  • a hard MIN GAP between nudged cycles, trailing-coalesced: nudges
+  //    inside the gap collapse into one run at gap end;
+  //  • a nudge landing while a cycle is in flight retries after the gap
+  //    (performObsidianSync's in-progress guard DROPS overlapping calls, so
+  //    without the retry a burst's tail would wait for the poll);
+  //  • loop safety by construction: a nudged cycle that finds nothing
+  //    performs reads only — no seq advance, no self-nudge; one that emits
+  //    writes records its own acks, which the coalescer suppresses.
+  // Gated on plugin authority (observations are only consumed while
+  // paired-and-fresh; a direct-mode device's inbound is its own scan) and
+  // on the enabled flag. The 5-minute poll and visibility flips stay
+  // untouched as the correctness floor — SSE here is additive, exactly as
+  // it is for the DB drains.
+  const OBSIDIAN_NUDGE_MIN_GAP_MS = 5000;
+  const obsidianNudgeRef = useRef({ timer: null, lastRunAt: 0 });
+  const runNudgedObservationCycle = async () => {
+    const st = obsidianNudgeRef.current;
+    if (obsidianSyncInProgressRef.current) {
+      // A cycle (poll, visibility, manual, or a prior nudge) is mid-flight —
+      // it may not consume rows that land after its fetch. Retry after the
+      // gap; each retry is one cheap probe until it lands.
+      if (!st.timer) {
+        st.timer = setTimeout(() => { st.timer = null; void runNudgedObservationCycle(); }, OBSIDIAN_NUDGE_MIN_GAP_MS);
+      }
+      return;
+    }
+    st.lastRunAt = Date.now();
+    let pending = false;
+    try { pending = await pendingBridgeObservations(); } catch { pending = false; }
+    if (!pending) return;
+    await performObsidianSync();
+  };
+  const nudgeObsidianObservations = () => {
+    if (isTrayMode || !obsidianConfig?.enabled) return;
+    if (!bridgeHeartbeatRef.current.pluginAuthoritative) return;
+    const st = obsidianNudgeRef.current;
+    if (st.timer) return; // a run is already scheduled — coalesce into it
+    const wait = Math.max(0, st.lastRunAt + OBSIDIAN_NUDGE_MIN_GAP_MS - Date.now());
+    st.timer = setTimeout(() => { st.timer = null; void runNudgedObservationCycle(); }, wait);
+  };
+
   // Obsidian sync: restore vault handle on mount and do initial sync
   useEffect(() => {
     if (isTrayMode || !dataLoaded) return;
@@ -1360,5 +1414,5 @@ export default function useObsidianSync({
     );
   }, [obsidianConfig?.dailyNotesPath, obsidianConfig?.dailyNotePattern, obsidianConfig?.newNotesFolder, obsidianConfig?.enabled]);
 
-  return { performObsidianSync, loadWikiNote, saveWikiNote, openInObsidian, notifyNativeReady, bridgeHeartbeatRef };
+  return { performObsidianSync, nudgeObsidianObservations, loadWikiNote, saveWikiNote, openInObsidian, notifyNativeReady, bridgeHeartbeatRef };
 }

--- a/src/hooks/useObsidianSync.sseNudge.test.js
+++ b/src/hooks/useObsidianSync.sseNudge.test.js
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// SSE → OBSIDIAN CYCLE pacing (Phase 7 groundwork). The route from a vault
+// /events nudge to performObsidianSync, with every damping layer pinned:
+// the probe gates the wake (a nudge for DB-tier activity runs no cycle),
+// the min gap coalesces bursts (one cycle, not one per nudge), plugin
+// authority gates the whole thing, and a nudge landing mid-cycle schedules
+// a retry instead of being dropped OR stacking a concurrent cycle. The
+// coalescer's own-echo suppression and the probe's obs:-prefix check are
+// pinned in vaultEventStream.test.js / obsidianBridgeInbound.test.js.
+
+const effects = [];
+vi.mock('react', () => ({
+  useEffect: (fn, deps) => { effects.push({ fn, deps }); },
+  useCallback: (fn) => fn,
+  useRef: (init) => ({ current: init }),
+}));
+
+const heartbeatMock = vi.fn(async () => null);
+vi.mock('../obsidian.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    tryRestoreVaultAccess: vi.fn(async () => null),
+    getVaultAccess: vi.fn(async () => null),
+    syncObsidianVault: vi.fn(async () => ({ dailyNotes: {}, scheduledTasks: [], inboxTasks: [] })),
+    syncObsidianVaultNative: vi.fn(async () => null),
+    writeTaskStateToFile: vi.fn(async () => true),
+    writeTaskStateNative: vi.fn(() => false),
+    readWikiNote: vi.fn(async () => null),
+    writeWikiNote: vi.fn(async () => {}),
+    scanVaultNotes: vi.fn(async () => ({ names: [], unportable: [] })),
+    vaultHasTasksPlugin: vi.fn(async () => false),
+    detectTasksPluginNative: vi.fn(() => null),
+    readVaultHeartbeat: (...a) => heartbeatMock(...a),
+    readVaultHeartbeatNative: vi.fn(() => null),
+  };
+});
+vi.mock('../native.js', () => ({
+  isNativeAndroid: () => false,
+  isNativeApp: () => false,
+  nativeGetVaultConfig: vi.fn(() => null),
+  nativeGetNote: vi.fn(() => null),
+  nativeWriteNote: vi.fn(),
+  nativeOpenNote: vi.fn(),
+  nativeListNotes: vi.fn(() => []),
+  nativeSetVaultSettings: vi.fn(),
+  nativeSetLaunchOnWrite: vi.fn(),
+}));
+vi.mock('../utils/obsidianBridgeStream.js', () => ({
+  emitBridgeIntent: vi.fn(() => true),
+  flushBridgeOutbox: vi.fn(async () => true),
+  publishBridgeConfig: vi.fn(async () => {}),
+  getBridgePairingMeta: vi.fn(async () => null),
+}));
+vi.mock('../utils/obsidianBridgeMode.js', () => ({
+  recordBridgeMode: vi.fn(),
+  reconcileArchivedBaseline: vi.fn(() => null),
+}));
+const probeMock = vi.fn(async () => false);
+const fetchMock = vi.fn(async () => null);
+vi.mock('../utils/obsidianBridgeInbound.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    pendingBridgeObservations: (...a) => probeMock(...a),
+    fetchBridgeObservations: (...a) => fetchMock(...a),
+  };
+});
+
+const { default: useObsidianSync } = await import('./useObsidianSync.js');
+const { legacyObsidianId } = await import('@glance-apps/obsidian-format');
+
+const D = '2026-08-30';
+const NOTE = '## Tasks\n- [ ] Nudged task\n';
+const LEGACY_ID = legacyObsidianId(D, 'Nudged task');
+
+let scheduledTimers;
+function useMountedNudgeHook() {
+  effects.length = 0;
+  scheduledTimers = [];
+  // <3000ms timers fire on the microtask queue (so setTimeout RETURNS before
+  // its callback runs, like a real timer — the nudge stores the returned id
+  // and its callback clears it, an ordering a synchronous stub would
+  // invert); anything longer is only RECORDED — a scheduled-but-not-run 5s
+  // timer is exactly what the coalescing pins assert on.
+  vi.stubGlobal('setTimeout', (cb, ms) => {
+    if (!ms || ms < 3000) { queueMicrotask(cb); return 1; }
+    scheduledTimers.push(ms);
+    return scheduledTimers.length;
+  });
+  vi.stubGlobal('setInterval', () => 1);
+  vi.stubGlobal('clearInterval', () => {});
+  vi.stubGlobal('requestAnimationFrame', () => 1);
+  vi.stubGlobal('document', { addEventListener: () => {}, removeEventListener: () => {}, visibilityState: 'visible' });
+  vi.stubGlobal('window', {});
+  const store = new Map();
+  vi.stubGlobal('localStorage', {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+  });
+  const state = { tasks: [], inbox: [] };
+  const syncRef = { current: false };
+  const tasksRef = { current: state.tasks };
+  const inboxRef = { current: state.inbox };
+  const setTasks = (up) => { state.tasks = typeof up === 'function' ? up(state.tasks) : up; tasksRef.current = state.tasks; };
+  const setUnscheduledTasks = (up) => { state.inbox = typeof up === 'function' ? up(state.inbox) : up; inboxRef.current = state.inbox; };
+  const api = useObsidianSync({
+    isTrayMode: false, dataLoaded: true,
+    tasks: state.tasks, setTasks,
+    unscheduledTasks: state.inbox, setUnscheduledTasks,
+    setDailyNotes: vi.fn(), setWikilinkCandidates: vi.fn(), setUnportableVaultFiles: vi.fn(),
+    obsidianConfig: { enabled: true, dailyNotesPath: '', dailyNotePattern: 'yyyy-MM-dd' },
+    setObsidianConfig: vi.fn(), obsidianLaunchOnWrite: null,
+    obsidianCompletionDates: false,
+    obsidianSyncError: null,
+    setObsidianSyncStatus: vi.fn(), setObsidianSyncError: vi.fn(), setObsidianLastSynced: vi.fn(),
+    setObsidianSyncNotice: vi.fn(),
+    obsidianVaultHandleRef: { current: {} },
+    obsidianSyncInProgressRef: syncRef,
+    obsidianPrevTaskStateRef: { current: {} },
+    obsidianTasksRef: tasksRef, obsidianInboxRef: inboxRef,
+    recycleBin: [], setRecycleBin: vi.fn(),
+  });
+  api.bridgeHeartbeatRef.current = { obsidianRunning: true, pluginAuthoritative: true };
+  return { state, api, syncRef };
+}
+
+// The nudge is deliberately fire-and-forget; settle its async chain.
+const settle = async () => { for (let i = 0; i < 8; i++) await new Promise((r) => setImmediate(r)); };
+
+beforeEach(() => {
+  probeMock.mockReset(); probeMock.mockResolvedValue(false);
+  fetchMock.mockReset(); fetchMock.mockResolvedValue(null);
+  heartbeatMock.mockReset(); heartbeatMock.mockResolvedValue({ paired: true, tsMs: Date.now(), accountId: 'a', deviceId: 'd' });
+});
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+describe('nudgeObsidianObservations (SSE → Obsidian cycle pacing)', () => {
+  it('a nudge with pending observations runs ONE cycle and applies them — the inbound leg at SSE speed', async () => {
+    const h = useMountedNudgeHook();
+    probeMock.mockResolvedValue(true);
+    fetchMock.mockResolvedValue({
+      observations: [{ path: `${D}.md`, content: NOTE, mtime: Date.parse('2026-08-30T10:00:00Z') }],
+      maxSeq: 3,
+    });
+    h.api.nudgeObsidianObservations();
+    await settle();
+    expect(probeMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect([...h.state.tasks, ...h.state.inbox].map(t => String(t.id))).toEqual([LEGACY_ID]);
+  });
+
+  it('a nudge whose probe finds nothing runs NO cycle — foreign DB-tier activity costs one probe, never a sync', async () => {
+    const h = useMountedNudgeHook();
+    probeMock.mockResolvedValue(false);
+    h.api.nudgeObsidianObservations();
+    await settle();
+    expect(probeMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('MIN GAP: nudges after a run coalesce into one trailing timer — never a cycle per nudge', async () => {
+    const h = useMountedNudgeHook();
+    probeMock.mockResolvedValue(false);
+    h.api.nudgeObsidianObservations(); // runs immediately (no prior run)
+    await settle();
+    expect(probeMock).toHaveBeenCalledTimes(1);
+
+    h.api.nudgeObsidianObservations(); // inside the gap → trailing timer
+    h.api.nudgeObsidianObservations(); // coalesces into the SAME timer
+    await settle();
+    expect(probeMock).toHaveBeenCalledTimes(1); // no extra probe ran yet
+    expect(scheduledTimers).toHaveLength(1); // exactly one trailing run scheduled
+  });
+
+  it('no plugin authority → no probe, no cycle (observations are only consumed while paired-and-fresh)', async () => {
+    const h = useMountedNudgeHook();
+    h.api.bridgeHeartbeatRef.current = { obsidianRunning: false, pluginAuthoritative: false };
+    probeMock.mockResolvedValue(true);
+    h.api.nudgeObsidianObservations();
+    await settle();
+    expect(probeMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('a nudge landing while a cycle is in flight schedules a RETRY after the gap — dropped nudges were the old way a burst tail waited for the poll', async () => {
+    const h = useMountedNudgeHook();
+    h.syncRef.current = true; // a cycle is mid-flight
+    probeMock.mockResolvedValue(true);
+    h.api.nudgeObsidianObservations();
+    await settle();
+    expect(probeMock).not.toHaveBeenCalled(); // deferred, not raced
+    expect(scheduledTimers).toEqual([5000]); // one retry armed at the gap
+  });
+});

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -37,14 +37,21 @@ const NATIVE_SSE_RECEIVE = '__glanceVaultSseReceive';
  * @param {boolean}  p.dataLoaded    gate: don't connect before initial load
  * @param {() => (void|Promise<any>)} p.drainSync     triggers the EXISTING vault sync drain (dbSyncCycle)
  * @param {() => (void|Promise<any>)} p.drainIntents  triggers the EXISTING vault intents drain (drainDbIntents)
+ * @param {() => (void|Promise<any>)} [p.drainObsidian]  nudges the Obsidian observation
+ *   cycle (Phase 7 groundwork). The callee owns ALL of its own pacing —
+ *   probe, min gap, authority gate (useObsidianSync.nudgeObsidianObservations)
+ *   — so this hook treats it exactly like the other drains: fire per
+ *   coalesced peer nudge, after sync and intents.
  */
-export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
+export function useVaultEventStream({ dataLoaded, drainSync, drainIntents, drainObsidian }) {
   // Keep the drain callbacks fresh without re-running the effect (which would tear
   // down and re-open the connection on every render).
   const drainSyncRef = useRef(drainSync);
   drainSyncRef.current = drainSync;
   const drainIntentsRef = useRef(drainIntents);
   drainIntentsRef.current = drainIntents;
+  const drainObsidianRef = useRef(drainObsidian);
+  drainObsidianRef.current = drainObsidian;
 
   useEffect(() => {
     if (isTrayMode || !dataLoaded || !isVaultEnabled()) return undefined;
@@ -94,11 +101,13 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents }) {
       // Debounce-only (no throttle). The self-nudge loop is fixed at the root — a
       // no-content sync cycle no longer pushes/nudges (utils/tombstoneHorizon.js) —
       // so drains fire near-instantly on real changes, restoring SSE's low latency.
+      kinds: ['sync', 'intents', 'obsidian'],
       onDrain: (kind) => {
         diag.drains += 1;
         if (sseDebug()) console.info('[vault-sse] drain →', kind);
         if (kind === 'sync') drainSyncRef.current?.();
         else if (kind === 'intents') drainIntentsRef.current?.();
+        else if (kind === 'obsidian') drainObsidianRef.current?.();
       },
       // Own-echo damping (#1455): a nudge whose seq is exactly one our own
       // writers were acked with is our own echo — advance the cursor, drain

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -282,6 +282,11 @@ export async function openWebSseStream({ connection, signal, onOpen, onEvent, fe
 export function createNudgeCoalescer({
   onDrain,
   debounceMs = 400,
+  // Which drains one coalesced nudge fans out to, in order. The default is
+  // the original pair; the app wiring adds 'obsidian' (the observation
+  // cycle — Phase 7 groundwork) after them, so DB state lands before the
+  // Obsidian cycle reads it.
+  kinds = ['sync', 'intents'],
   isOwnSeq,
   onOwnEcho,
   setTimeoutFn = setTimeout,
@@ -301,9 +306,8 @@ export function createNudgeCoalescer({
 
   const flush = () => {
     timer = null;
-    // Deterministic order: sync before intents.
-    runDrain('sync');
-    runDrain('intents');
+    // Deterministic order: sync before intents (before obsidian, when wired).
+    for (const kind of kinds) runDrain(kind);
   };
 
   // Coalesce a micro-burst of nudges into a single drain (debounce ONLY — no

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -198,6 +198,26 @@ describe('createNudgeCoalescer — seq cursor + debounce', () => {
     expect(onDrain.mock.calls.map((a) => a[0])).toEqual(['sync', 'intents']);
   });
 
+  it('the kinds option adds the obsidian drain AFTER sync and intents (Phase 7 groundwork) — one drain each per flush, own echoes suppress ALL of them', () => {
+    const onDrain = vi.fn();
+    const c = createNudgeCoalescer({
+      onDrain, debounceMs: 100,
+      kinds: ['sync', 'intents', 'obsidian'],
+      isOwnSeq: (seq) => seq === 7,
+    });
+    c.handleEvent({ seq: 5 });
+    vi.advanceTimersByTime(100);
+    // Ordering matters: DB state lands before the Obsidian cycle reads it.
+    expect(onDrain.mock.calls.map((a) => a[0])).toEqual(['sync', 'intents', 'obsidian']);
+
+    // An own-write echo (our stamp intent's ack seq) wakes NOTHING — the
+    // obsidian drain included; exactly the same damping the DB drains have.
+    onDrain.mockClear();
+    c.handleEvent({ seq: 7 });
+    vi.advanceTimersByTime(200);
+    expect(onDrain).not.toHaveBeenCalled();
+  });
+
   it('the ready reconcile frame is just a nudge — an advanced seq drains both sides', () => {
     const onDrain = vi.fn();
     const c = createNudgeCoalescer({ onDrain, debounceMs: 100 });

--- a/src/utils/obsidianBridgeInbound.js
+++ b/src/utils/obsidianBridgeInbound.js
@@ -104,6 +104,40 @@ export function commitBridgeObservationCursor(maxSeq) {
 }
 
 /**
+ * SSE-nudge PROBE (Phase 7 groundwork): are there observation rows above the
+ * cursor? The vault's /events stream carries only {seq} — the account seq is
+ * shared across apps, so a nudge cannot say whether a bridge row or a DB row
+ * advanced it. This probe is the cheap discriminator: ONE first-page list of
+ * the bridge namespace since the cursor, checking for `obs:`-prefixed rows —
+ * no decryption, no pairing meta, no pagination. dayGLANCE's own bridge
+ * writes are `int:`/`meta:` rows, so the prefix check structurally excludes
+ * them: only plugin-authored observations (and a `hasMore` page boundary,
+ * conservatively) answer true. The full sync cycle — merges, inference,
+ * writeback, the status UI — runs only on a true answer, so a nudge for
+ * foreign DB-tier activity costs one GET and wakes nothing.
+ *
+ * False on ANY doubt except hasMore: unpaired, disabled, braked
+ * (bridgeRateLimited — the poll floor covers), or unreachable. Never
+ * advances the cursor.
+ */
+export async function pendingBridgeObservations() {
+  try {
+    if (bridgeRateLimited()) return false;
+    const cfg = getVaultConfig();
+    if (!cfg?.enabled || !cfg.vaultUrl || !cfg.vaultToken || !cfg.accountId) return false;
+    let since = 0;
+    try { since = Number(localStorage.getItem(OBS_HWM_KEY)) || 0; } catch { /* fresh cursor */ }
+    const client = createVaultClient({ vaultUrl: cfg.vaultUrl, vaultToken: cfg.vaultToken });
+    const page = await client.list(BRIDGE_VAULT_APP, { accountId: cfg.accountId, since });
+    if (page.hasMore) return true; // rows beyond page 1 — wake conservatively
+    return (page.rows || []).some((row) =>
+      !row.deleted && String(row.entityId || '').startsWith(BRIDGE_OBSERVATION_PREFIX));
+  } catch {
+    return false; // rate-limited/unreachable — the poll floor covers
+  }
+}
+
+/**
  * Turn a batch of observations into the shape a (partial) vault scan
  * produces: { dailyNotes, scheduledTasks, inboxTasks, scannedIds }. Feed the
  * result through mergeObsidianDailyNotes / mergeObsidianTasks exactly like a

--- a/src/utils/obsidianBridgeInbound.test.js
+++ b/src/utils/obsidianBridgeInbound.test.js
@@ -11,6 +11,7 @@ import {
   fetchBridgeObservations,
   commitBridgeObservationCursor,
   applyBridgeObservations,
+  pendingBridgeObservations,
 } from './obsidianBridgeInbound.js';
 
 // The inbound half's load-bearing claims: observations flow through the
@@ -77,6 +78,61 @@ describe('fetchBridgeObservations', () => {
   it('unpaired (no meta row) → null, and nothing touched', async () => {
     globalThis.fetch = async () => ({ ok: false, status: 404, json: async () => ({}) });
     expect(await fetchBridgeObservations()).toBe(null);
+  });
+});
+
+describe('pendingBridgeObservations (the SSE-nudge probe)', () => {
+  // The /events stream carries only {seq} on an account counter shared
+  // across apps, so this probe is the discriminator: one list page, an
+  // obs:-prefix presence check, no decryption. dayGLANCE's own bridge
+  // writes are int:/meta: rows — structurally excluded, a second damping
+  // layer under the coalescer's exact-ack suppression.
+  const listFetch = (payload, calls = []) => async (url) => {
+    calls.push(url);
+    if (url.includes('/list')) return { ok: true, status: 200, json: async () => payload };
+    return { ok: false, status: 404, json: async () => ({}) };
+  };
+
+  it('wakes ONLY on live obs: rows above the cursor — int:/meta rows and tombstones never wake; hasMore wakes conservatively', async () => {
+    globalThis.fetch = listFetch({ rows: [
+      { entityId: 'int:abc', seq: 6 },
+      { entityId: 'meta:config', seq: 7 },
+      { entityId: 'obs:deadbeef', seq: 8, deleted: true },
+    ], hasMore: false });
+    expect(await pendingBridgeObservations()).toBe(false);
+
+    globalThis.fetch = listFetch({ rows: [
+      { entityId: 'int:abc', seq: 6 },
+      { entityId: 'obs:deadbeef', seq: 8 },
+    ], hasMore: false });
+    expect(await pendingBridgeObservations()).toBe(true);
+
+    // Page boundary: the obs row could be on page 2 — wake, don't paginate.
+    globalThis.fetch = listFetch({ rows: [{ entityId: 'int:abc', seq: 6 }], hasMore: true });
+    expect(await pendingBridgeObservations()).toBe(true);
+  });
+
+  it('lists from the persisted cursor, never advances it, and answers false on any doubt (disabled config, unreachable server)', async () => {
+    localStorage.setItem(OBS_HWM_KEY, '41');
+    const calls = [];
+    globalThis.fetch = listFetch({ rows: [], hasMore: false }, calls);
+    expect(await pendingBridgeObservations()).toBe(false);
+    expect(calls.some((u) => u.includes('since=41'))).toBe(true);
+    expect(localStorage.getItem(OBS_HWM_KEY)).toBe('41'); // cursor untouched
+
+    // Disabled vault: no request at all.
+    const calls2 = [];
+    globalThis.fetch = listFetch({ rows: [] }, calls2);
+    localStorage.setItem(VAULT_CONFIG_KEY, JSON.stringify({ enabled: false }));
+    expect(await pendingBridgeObservations()).toBe(false);
+    expect(calls2).toHaveLength(0);
+
+    // Unreachable: false, poll floor covers.
+    localStorage.setItem(VAULT_CONFIG_KEY, JSON.stringify({
+      enabled: true, vaultUrl: 'https://vault.example', vaultToken: 'tok', accountId: 'acct-1',
+    }));
+    globalThis.fetch = async () => { throw new Error('network down'); };
+    expect(await pendingBridgeObservations()).toBe(false);
   });
 });
 


### PR DESCRIPTION
The inbound leg at SSE speed: a plugin-observed vault edit now reaches dayGLANCE seconds after the observation row lands, instead of waiting out the 5-minute poll or a window focus. Built after settling the four questions — the answers, which are the design:

## (a) Discriminator — none on the wire, so the probe is it

Verified against glance-vault `routes/events.ts`: the stream sends `event: ready|activity` with data exactly `{"seq":N}`, and the seq is the **account-global** counter shared across apps — a nudge cannot say whether a bridge row or a DB row advanced it, and the client deliberately ignores the event name (both mean "seq advanced"). The cheap discriminator that does exist is client-side: `pendingBridgeObservations()` — **one first-page list of the bridge namespace since the observation cursor, checking for `obs:`-prefixed rows. No decryption, no pairing meta, no pagination** (a `hasMore` page boundary wakes conservatively). The full cycle — merges, inference, writeback, the status UI flash — runs only on a true answer; a nudge for foreign DB-tier activity costs one GET and wakes nothing. Bonus: dayGLANCE's own bridge writes are `int:`/`meta:` rows, so the prefix check structurally excludes them — a second damping layer independent of (b).

## (b) Own-echo suppression — already covers it, confirmed not assumed

The `ownWrites` registry is fed by every writer in this realm: the DB engine's push, the db-intents batch, **and the bridge outbox flush and config publish** (`obsidianBridgeStream.js` records `ack.maxSeq` at both). The server emits one nudge per write operation carrying that operation's own resulting seq (the registry header verified this against `routes/sync.ts`), so exact-identity suppression catches our stamps and intents precisely. The plugin is a different device: its writes are peer writes, and the registry's own header already says the quiet part — "we WANT their nudges (that's how observations arrive)." This wiring is exactly the consumer that sentence anticipated.

## (c) Pacing — four layers, honoring the twice-burned rule

1. The shared coalescer (400ms debounce, seq-monotonic, own-echo skip) now fans out to a third drain kind, `'obsidian'`, after sync and intents — DB state lands before the Obsidian cycle reads it.
2. The probe gates the wake (above).
3. A hard **5s min gap** between nudged cycles, trailing-coalesced: nudges inside the gap collapse into one run at gap end. A nudge landing while a cycle is mid-flight schedules a **retry after the gap** — `performObsidianSync`'s in-progress guard silently drops overlapping calls, so without the retry a burst's tail rows would wait for the poll.
4. Loop safety by construction: an idle nudged cycle performs reads only (config publish is hash-cached, outbox flush no-ops empty) — no seq advance, no self-nudge; a cycle that does write records its acks, which (b) suppresses. The keystroke-burst worry is also smaller than it looks: the plugin debounces observations 2s per path and emits only after a typing pause, so the natural nudge rate per active note is per-pause, not per-keystroke — and the gap caps it regardless. Gated on plugin authority (direct mode's inbound is its own scan; observations aren't consumed there).

## (d) The 5-minute poll stays, untouched

Same posture as the DB drains — the stream module's core invariant is that SSE is purely additive. Missed nudges (SSE down, `native-unsupported` transport, a probe declined under the brake) land on the poll or a visibility flip. Side benefit: fix 1's confirmation hold now typically confirms in seconds rather than minutes, with correctness never having depended on cadence.

## Shared design with Phase 7 proper — some, worth knowing

Phase 7 (plugin holds the SSE connection, replacing its 30s drain timer) consumes the **same** `/events` channel with the same seq-only payload, so it inherits the same no-discriminator situation — though its answer is cheaper: `drain()` is already a cursor-based list, so it can just drain per nudge without a probe. No code is shared (the plugin is TS on the Obsidian side), but the server-contract knowledge and the nudge→pace→act pattern transfer directly, and if glance-vault ever adds an app tag to `activity` events, both sides drop their workarounds. The two can be taken together or not — nothing here blocks or presupposes Phase 7.

## Pins (+8, suite 2608/193)

- Probe: wakes only on live `obs:` rows above the cursor; `int:`/`meta:` rows and tombstones never wake; `hasMore` wakes conservatively; lists from the persisted cursor and never advances it; false on disabled config (no request) and on network failure.
- Coalescer: the `kinds` option adds `obsidian` after sync and intents; an own-write echo wakes none of the three; existing default-kinds tests unchanged.
- Pacing (hook harness): a nudge with pending observations runs one cycle and applies them; a probe-negative nudge runs no cycle; nudges inside the gap coalesce into exactly one trailing timer; no plugin authority → no probe; a mid-cycle nudge schedules one retry at the gap instead of racing or dropping.

Lint clean; `npm run build` passes; no plugin change in this PR (Phase 7 proper would be the plugin-side half). Independent of #1493 — different concern, minimal file overlap (`useObsidianSync.js` in different regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_