### PR TITLE
Native vault gates: fix the stale iOS-lacks-vault-access assumptions (sweep items 1-4)

### DIFF
--- a/src/components/MobileSettingsPanel.jsx
+++ b/src/components/MobileSettingsPanel.jsx
@@ -15,6 +15,7 @@ import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, scanVaultNotes, formatDatePattern } from '../obsidian.js';
 import UnportableVaultNamesPanel from './UnportableVaultNamesPanel.jsx';
+import BridgeStatusPanel from './BridgeStatusPanel.jsx';
 import { validateDailyNotePattern, validateVaultFolderSetting } from '../utils/obsidianFilename.js';
 import { effectiveLaunchOnWrite } from '../utils/obsidianLaunchOnWrite.js';
 import CloudSyncSettingsForm from './CloudSyncSettingsForm.jsx';
@@ -1718,6 +1719,14 @@ const MobileSettingsPanel = () => {
           {obsidianSyncStatus === 'error' && <p className="text-xs text-red-500">{t('settings.obsidianSyncFailed')}</p>}
           {obsidianLastSynced && obsidianConfig?.enabled && (
             <p className={`text-xs ${textSecondary}`}>{t('common.lastSynced')}: {new Date(obsidianLastSynced).toLocaleString()}</p>
+          )}
+          {/* §6 mode indicator, native flavor (three states — see
+              BridgeStatusPanel): this panel is THE settings surface on
+              phones, so without it a phone that silently fell back to
+              direct mode (the 2026-08-31 plugin-settings-sync incident)
+              had no UI saying so anywhere it could see. */}
+          {obsidianConfig?.enabled && (
+            <BridgeStatusPanel darkMode={darkMode} textPrimary={textPrimary} textSecondary={textSecondary} borderClass={borderClass} />
           )}
         </div>
       ) : obsidianConfig?.enabled ? (

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -11,7 +11,7 @@ import CalendarList from './CalendarList.jsx';
 import ICloudSyncToggle from './ICloudSyncToggle.jsx';
 import { cloudSyncProviders } from '../utils/cloudSyncProviders.js';
 import { testConnection, PROVIDER_MODELS, PROVIDER_LABELS } from '../ai.js';
-import { isNativeAndroid, isNativeApp, nativeGetCalendars, nativeGetAutomationIntentsEnabled, nativeSetAutomationIntentsEnabled } from '../native.js';
+import { isNativeAndroid, isNativeApp, nativePickVault, nativeGetCalendars, nativeGetAutomationIntentsEnabled, nativeSetAutomationIntentsEnabled } from '../native.js';
 import { hasNativeCalendar, electronCalendarAvailable, electronGetCalendars } from '../utils/nativeCalendar.js';
 import { isFileSystemAccessSupported, requestVaultAccess, disconnectVault, formatDatePattern } from '../obsidian.js';
 import { validateDailyNotePattern, validateVaultFolderSetting } from '../utils/obsidianFilename.js';
@@ -1517,10 +1517,17 @@ const SettingsModal = () => {
                     </div>
                     </>)}
 
-                    {(!isMobile || isNativeAndroid()) && (<>
+                    {/* Hidden at mobile width ONLY for browsers, where FSA is
+                        unavailable on phones; a NATIVE app (Android or iOS)
+                        has vault access at any width. The old Android-only
+                        exception predated the iOS native bridge. */}
+                    {(!isMobile || isNativeApp()) && (<>
                     <hr className={borderClass} />
 
-                    {/* Obsidian Integration Section — desktop + Android native */}
+                    {/* Obsidian Integration Section — desktop (FSA) + native
+                        apps (Android SAF, iOS bookmark). MobileSettingsPanel
+                        carries the primary mobile surface; this section is the
+                        modal's counterpart wherever the modal is reachable. */}
                     <div className="space-y-3">
                       <button onClick={() => toggleSettingsSection('obsidian')} className={`font-medium ${textPrimary} flex items-center gap-2 w-full text-left`}>
                         <BookOpen size={16} className={textSecondary} />
@@ -1532,7 +1539,11 @@ const SettingsModal = () => {
                       <p className={`${textSecondary} text-xs`}>
                         Import tasks and sync daily notes with your Obsidian vault.
                       </p>
-                      {!isNativeAndroid() && !isFileSystemAccessSupported() && (
+                      {/* The Chromium/FSA requirement is a BROWSER constraint:
+                          a native app reaches the vault through its own bridge
+                          (SAF / iOS bookmark) and must not see this warning —
+                          gating on Android alone showed it, wrongly, on iPad. */}
+                      {!isNativeApp() && !isFileSystemAccessSupported() && (
                         <p className={`text-xs text-amber-500`}>
                           Obsidian integration requires a Chromium-based browser (Chrome, Edge, or Brave). Firefox and Safari do not support the File System Access API.
                         </p>
@@ -1786,6 +1797,18 @@ const SettingsModal = () => {
                       ) : (
                         <button
                           onClick={async () => {
+                            // Native app (iOS lands here; Android took its own
+                            // branch above): the vault is picked through the
+                            // NATIVE folder picker (UIDocumentPickerViewController
+                            // via nativePickVault, which reloads the webview
+                            // once a folder is chosen) — the FSA flow below is
+                            // browser-only and, gated on Android alone, used to
+                            // leave iPad with a dead connect button that could
+                            // only alert about Chromium.
+                            if (isNativeApp()) {
+                              nativePickVault();
+                              return;
+                            }
                             if (!isFileSystemAccessSupported()) {
                               alert('Your browser does not support the File System Access API. Please use a Chromium-based browser (e.g., Chrome, Edge, Brave) to connect an Obsidian vault.');
                               return;


### PR DESCRIPTION
Items 1–4 from the sweep, as approved; item 5 (`UnportableVaultNamesPanel` on mobile) deliberately left for later.

**Stacked on #1495** (`bridge-status-native`) — item 1 renders the `BridgeStatusPanel` that PR introduces, so this PR is based on that branch and retargets to `main` automatically when #1495 merges. Merge order: #1495 first.

## The four fixes

1. **`MobileSettingsPanel` gets the three-state bridge status block** in its native Obsidian view (both platforms, when a vault is configured). This is the fix for the original observation: the mobile panel is the settings surface phones actually see, and #1495 only put the block in `SettingsModal`. The comment at the site names why it matters — a phone that silently fell back to direct mode had no UI saying so anywhere it could look.
2. **The Chromium/FSA warning gate**: `!isNativeAndroid()` → `!isNativeApp()`, matching the gate the mobile panel already had right. Kills the bogus "requires a Chromium-based browser" warning native iPads have been seeing in the modal.
3. **The modal's connect button routes native apps to `nativePickVault()`** (the same call the mobile panel uses — `UIDocumentPickerViewController` on iOS, which reloads the webview after the pick) before falling into the browser FSA flow. Previously an unconfigured iPad-width iOS device had a connect button that could only alert about Chromium — the not-yet-configured sibling of the dead pairing form #1495 fixed.
4. **The section gate**: `!isMobile || isNativeAndroid()` → `!isMobile || isNativeApp()`, with the reasoning at the site: the mobile-width hide is a *browser* constraint (no FSA on phones), and the Android-only exception predated the iOS bridge (confirmed as far as archaeology allows — the gate is older than the repo's visible history, and iOS native vault machinery is present throughout it). The stale "desktop + Android native" section comment is replaced with one that names `MobileSettingsPanel` as the primary mobile surface.

## Confirmed deliberate, untouched

Pairing stays desktop-only (the dead-drop offer is an FSA file write; recorded in the pairing module and spec); launch-on-write stays electron+Android (no iOS launcher exists in the shell — absent capability, not a stale gate); `notifyNativeReady` left Android-only pending the iOS shell source; the genuinely Android-domain guards (SAF `openSettings`, Tasker intents, notify broadcast, viewport hack) are exactly as they were.

## Verification

Full suite 2623 passing (unchanged — pure JSX wiring, no new logic beyond the pinned `deriveBridgeStatus` from #1495, which both surfaces now share). Lint clean; `npm run build` passes. No native code change — `nativePickVault` and the native heartbeat read are existing bridge surfaces on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_