### PR TITLE
Phase 7: plugin live sync over SSE, armed by proof

### DIFF
--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -23,7 +23,7 @@
 // plugin NEVER interprets an edit; inferring semantics is dayGLANCE's
 // scan pipeline's job.
 
-import { App, TFile, normalizePath, requestUrl } from 'obsidian';
+import { App, Platform, TFile, normalizePath, requestUrl } from 'obsidian';
 import {
   applyBridgeIntent,
   openBridgeEnvelope,
@@ -35,6 +35,11 @@ import {
   parseDateFromFilename,
   stampUntaggedTaskLines,
   bridgeConfigAllowsStamping,
+  drainSseBuffer,
+  createSseArming,
+  createSseNudgeGate,
+  sseBackoffMs,
+  SSE_READ_TIMEOUT_MS,
   BRIDGE_VAULT_APP,
   BRIDGE_PAIRING_META_ID,
   BRIDGE_CONFIG_META_ID,
@@ -176,6 +181,37 @@ export class BridgeTransport {
   private memHwm = 0;
   private memHwmGeneration: string | null = null;
 
+  // ── LIVE SYNC (Phase 7) — desktop SSE, replacing "wait out the 30s timer"
+  // for the intent-apply leg. THE INVARIANT: **SSE IS ARMED BY PROOF AND
+  // DISARMED BY REFUTATION — the stream opens only after a successful
+  // authenticated drain, closes on auth failure or a vanished pairing, and
+  // makes ZERO reconnect attempts in between. A de-paired plugin burns
+  // nothing.** Between refutation and the next proof, the 30-second drain
+  // timer is the only thing running (today's exact polling posture), and
+  // the first drain that succeeds re-arms the stream — so a dead
+  // credential's total cost is one failed drain per tick, the same benign
+  // failure mode polling always had. Built for an observed failure, not a
+  // hypothetical: Obsidian Sync's plugin-settings toggle flipped off on one
+  // device (2026-08-31) and silently stripped the pairing out of data.json.
+  //
+  // All DECISIONS are pure and pinned in @glance-apps/obsidian-format's
+  // bridgeSse.js (arm/disarm machine, own-ack skip, debounce/cursor gate,
+  // backoff schedule, frame parsers — the same parsers dayGLANCE's stream
+  // uses). This class holds only the wiring: the Node https plumbing and
+  // the connection lifecycle.
+  private sseArming = createSseArming();
+  private sseGate = createSseNudgeGate({ onDrain: () => this.drainFromNudge() });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private sseReq: any = null; // in-flight Node http(s) request, when connected/connecting
+  private sseReconnectTimer: number | null = null;
+  private sseReadTimer: number | null = null;
+  private sseFailures = 0;
+  // A nudge that lands while a drain is in flight must RE-RUN after it —
+  // the `draining` guard silently drops overlapping calls, and a dropped
+  // nudge strands the burst's tail until the 30s timer (the exact hazard
+  // dayGLANCE's #1494 fixed on its side with the same flag).
+  private pendingRedrain = false;
+
   private rateLimited(): boolean {
     return Date.now() < this.backoffUntil;
   }
@@ -228,10 +264,176 @@ export class BridgeTransport {
   // for hours with a quiet console. Rate limits arm the brake like any other
   // bridge request; other failures get one console line.
   private deleteIntentRow(client: VaultClient, entityId: string, accountId: string): void {
-    void client.deleteRow(BRIDGE_VAULT_APP, entityId, accountId).catch((e) => {
+    void client.deleteRow(BRIDGE_VAULT_APP, entityId, accountId).then((res) => {
+      // Own-ack capture (Phase 7): the soft-delete's resulting seq nudges
+      // every SSE client, us included — record it so our own echo never
+      // wakes an idle drain.
+      const seq = Number((res as { seq?: unknown } | null)?.seq);
+      if (Number.isFinite(seq)) this.sseGate.recordOwnSeq(seq);
+    }).catch((e) => {
       if (isRateLimitError(e)) this.noteRateLimit();
       else console.error('dayGLANCE bridge: intent row cleanup failed', e);
     });
+  }
+
+  // ── LIVE SYNC lifecycle (Phase 7) — wiring only; decisions in bridgeSse.js
+
+  private sseDesktop(): boolean {
+    return Platform.isDesktopApp === true;
+  }
+
+  /** The nudge → drain route, with the rerun flag (see the field comment). */
+  private drainFromNudge(): void {
+    if (!this.host.getPairing()) {
+      this.sseArming.noteUnpaired();
+      this.stopSse();
+      return;
+    }
+    if (this.draining) {
+      this.pendingRedrain = true;
+      return;
+    }
+    void this.drain();
+  }
+
+  /** Called after every successful drain — the PROOF site of the invariant. */
+  private maybeStartSse(): void {
+    if (!this.sseArming.shouldConnect({ desktop: this.sseDesktop(), paired: !!this.host.getPairing() })) return;
+    if (this.sseReq || this.sseReconnectTimer !== null) return;
+    if (this.rateLimited()) return; // brake gates connects too; the next drain re-attempts
+    this.connectSse();
+  }
+
+  /** Tear the stream down and cancel every pending SSE timer. Idempotent. */
+  private stopSse(): void {
+    if (this.sseReconnectTimer !== null) { window.clearTimeout(this.sseReconnectTimer); this.sseReconnectTimer = null; }
+    this.clearSseReadTimer();
+    this.sseGate.cancel();
+    if (this.sseReq) {
+      try { this.sseReq.destroy(); } catch { /* already dead */ }
+      this.sseReq = null;
+    }
+    this.sseFailures = 0;
+  }
+
+  /** Plugin unload. */
+  shutdown(): void {
+    this.stopSse();
+  }
+
+  private clearSseReadTimer(): void {
+    if (this.sseReadTimer !== null) { window.clearTimeout(this.sseReadTimer); this.sseReadTimer = null; }
+  }
+
+  // ~60s with the server heartbeating every ~20s: three missed heartbeats
+  // means the socket is dead even when TCP never said so — laptop sleep,
+  // silent network loss on a weeks-open machine.
+  private armSseReadTimeout(): void {
+    this.clearSseReadTimer();
+    this.sseReadTimer = window.setTimeout(() => {
+      this.sseReadTimer = null;
+      console.info('dayGLANCE bridge: live sync went quiet (3 missed heartbeats) — reconnecting.');
+      this.failSse();
+    }, SSE_READ_TIMEOUT_MS);
+  }
+
+  /** Non-auth failure path: reconnect with backoff — but ONLY while armed. */
+  private failSse(): void {
+    this.clearSseReadTimer();
+    if (this.sseReq) {
+      try { this.sseReq.destroy(); } catch { /* already dead */ }
+      this.sseReq = null;
+    }
+    if (!this.sseArming.shouldConnect({ desktop: this.sseDesktop(), paired: !!this.host.getPairing() })) return;
+    if (this.sseReconnectTimer !== null) return;
+    this.sseFailures += 1;
+    // 5s doubling to 60s (reset whenever a frame arrives); the 429 brake
+    // extends it so a rate-limit storm pauses SSE with everything else.
+    // Each reconnect is ONE request against the per-IP budget — a worst-case
+    // flap costs 12/min at the floor, ~1/min at the cap.
+    const brakeMs = Math.max(0, this.backoffUntil - Date.now());
+    const delay = Math.max(sseBackoffMs(this.sseFailures), brakeMs);
+    this.sseReconnectTimer = window.setTimeout(() => {
+      this.sseReconnectTimer = null;
+      this.connectSse();
+    }, delay);
+  }
+
+  private connectSse(): void {
+    const pairing = this.host.getPairing();
+    if (!pairing) { this.sseArming.noteUnpaired(); return; }
+    if (!this.sseDesktop() || this.sseReq) return;
+    // NODE HTTP(S), DELIBERATELY — the one transport here that can stream:
+    // Obsidian's requestUrl buffers whole responses, so it cannot carry SSE
+    // (the same limitation that made the mobile shells grow native
+    // readers), and plain fetch in the renderer enforces CORS, which would
+    // make the stream work or not depending on the server's allowedOrigins
+    // happening to include Obsidian's app:// origin. Node's http(s) module
+    // has neither problem — and its availability (window.require, Electron
+    // renderer only) is itself a structural desktop gate: mobile cannot
+    // take this path even if the platform probe were somehow wrong.
+    const nodeRequire = (window as unknown as { require?: (m: string) => unknown }).require;
+    if (typeof nodeRequire !== 'function') return;
+    let url: URL;
+    try {
+      url = new URL(`${pairing.vaultUrl.replace(/\/+$/, '')}/events?accountId=${encodeURIComponent(pairing.accountId)}`);
+    } catch {
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mod: any;
+    try {
+      mod = nodeRequire(url.protocol === 'http:' ? 'http' : 'https');
+    } catch {
+      return;
+    }
+    let buffer = '';
+    const req = mod.request(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.deviceToken}`, Accept: 'text/event-stream' },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }, (res: any) => {
+      if (res.statusCode === 401 || res.statusCode === 403) {
+        // REFUTATION: the credential is dead — stop outright, no backoff
+        // retries against it. The 30s drain tick keeps running exactly as
+        // in the polling era, and the first drain that SUCCEEDS re-proves
+        // the credential and re-arms the stream. Total cost of a dead
+        // credential: one failed drain per tick — polling's own benign
+        // failure mode, preserved.
+        console.info(`dayGLANCE bridge: live sync refused (${res.statusCode}) — paused until a sync succeeds.`);
+        this.sseArming.noteAuthFailure();
+        this.stopSse();
+        return;
+      }
+      if (res.statusCode !== 200) {
+        console.info(`dayGLANCE bridge: live sync connect failed (${res.statusCode}) — will retry.`);
+        this.failSse();
+        return;
+      }
+      this.armSseReadTimeout();
+      res.setEncoding('utf8');
+      res.on('data', (chunk: string) => {
+        // Any received frame — heartbeat comment included — proves the
+        // stream is alive: reset the failure count and the read timeout.
+        this.sseFailures = 0;
+        this.armSseReadTimeout();
+        buffer = drainSseBuffer(buffer + chunk, (evt) => {
+          // A pairing that vanished mid-connection (the data.json incident)
+          // tears the stream down at the first event that would use it.
+          if (!this.host.getPairing()) {
+            this.sseArming.noteUnpaired();
+            this.stopSse();
+            return;
+          }
+          this.sseGate.handleEvent(evt as { seq?: number });
+        });
+      });
+      res.on('end', () => this.failSse());
+      res.on('error', () => this.failSse());
+    });
+    req.on('error', () => this.failSse());
+    req.end();
+    this.sseReq = req;
   }
 
   private async subkeyFor(pairing: BridgePairing): Promise<CryptoKey> {
@@ -245,7 +447,14 @@ export class BridgeTransport {
   /** Pull and apply pending intents. Safe to call on any cadence. */
   async drain(): Promise<void> {
     const pairing = this.host.getPairing();
-    if (!pairing || this.draining || this.rateLimited()) return;
+    if (!pairing) {
+      // REFUTATION: no pairing (unpaired, or the data.json incident) — the
+      // stream must not outlive its credentials. Idempotent when no stream.
+      this.sseArming.noteUnpaired();
+      this.stopSse();
+      return;
+    }
+    if (this.draining || this.rateLimited()) return;
     this.draining = true;
     try {
       const client = this.client(pairing);
@@ -289,6 +498,12 @@ export class BridgeTransport {
             // the deletes were fire-and-forget. Skipping tombstones lets the
             // cursor advance past the whole backlog once, after which they
             // never re-seq and never return.
+            //
+            // PHASE 7 LEANS ON THIS RULE: the SSE loop-safety argument —
+            // "a nudged drain's idle path performs no writes, so no cycle
+            // can sustain itself" — is only true BECAUSE tombstones are
+            // cursor-movement-only here. If this rule ever changes, that
+            // argument changes with it (see bridgeSse.js).
             continue;
           }
           const entityId = String(row.entityId ?? '');
@@ -354,11 +569,32 @@ export class BridgeTransport {
         }
       }
       this.noteSuccess();
+      // PROOF: a successful authenticated drain is what arms (or re-arms)
+      // live sync — the other half of the armed-by-proof invariant. The 30s
+      // tick runs drains regardless, so proof arrives within one tick of
+      // credentials working.
+      this.sseArming.noteDrainSuccess();
+      this.maybeStartSse();
     } catch (e) {
       if (isRateLimitError(e)) this.noteRateLimit();
-      else console.error('dayGLANCE bridge: drain failed', e);
+      else {
+        const status = (e as { status?: number } | null)?.status;
+        if (status === 401 || status === 403) {
+          // REFUTATION from the drain side: same rule as an SSE 401 — stop
+          // the stream, no reconnects until a drain succeeds again.
+          this.sseArming.noteAuthFailure();
+          this.stopSse();
+        }
+        console.error('dayGLANCE bridge: drain failed', e);
+      }
     } finally {
       this.draining = false;
+      if (this.pendingRedrain) {
+        // A nudge landed mid-drain; without this it would be silently
+        // dropped and the burst's tail would wait for the 30s timer.
+        this.pendingRedrain = false;
+        window.setTimeout(() => { void this.drain(); }, 250);
+      }
     }
   }
 
@@ -573,7 +809,7 @@ export class BridgeTransport {
         content, deleted: deleted || undefined,
         mtime, observedAt: new Date().toISOString(),
       };
-      await this.client(pairing).batch(BRIDGE_VAULT_APP, {
+      const ack = await this.client(pairing).batch(BRIDGE_VAULT_APP, {
         accountId: pairing.accountId,
         rows: [{
           entityId: await observationEntityId(path),
@@ -581,6 +817,11 @@ export class BridgeTransport {
           createdAt: Date.now(),
         }],
       });
+      // Own-ack capture (Phase 7): the server nudges every SSE client with
+      // this write's resulting seq, us included — record it so our own
+      // observation's echo never wakes an idle drain.
+      const ackSeq = Number((ack as { maxSeq?: unknown } | null)?.maxSeq);
+      if (Number.isFinite(ackSeq)) this.sseGate.recordOwnSeq(ackSeq);
       this.noteSuccess();
       this.observeRetryAttempts.delete(path);
     } catch (e) {

--- a/dayglance-obsidian-plugin/src/main.ts
+++ b/dayglance-obsidian-plugin/src/main.ts
@@ -194,6 +194,9 @@ export default class DayGlanceBridgePlugin extends Plugin {
   }
 
   onunload(): void {
+    // Live sync (Phase 7): close the SSE stream and cancel its timers —
+    // a disabled plugin must not hold a socket open.
+    this.transport.shutdown();
     // Best-effort: a graceful quit (or a plugin disable — equally "no
     // bridge here") removes the file so readers see the truth immediately
     // instead of waiting out the staleness window. Crashes skip this, which
@@ -211,6 +214,9 @@ export default class DayGlanceBridgePlugin extends Plugin {
     if (!previous) return;
     delete this.data.pairing;
     delete this.data.bridge;
+    // Live sync must not outlive its credentials (armed-by-proof invariant):
+    // tear the stream down with the pairing, not a tick later.
+    this.transport.shutdown();
     await this.saveData(this.data);
     await publishPairingMeta(null, previous).catch(() => {});
     await this.writeHeartbeat();

--- a/docs/obsidian-buildout-spec.md
+++ b/docs/obsidian-buildout-spec.md
@@ -468,7 +468,7 @@ Tags need no step: dayGLANCE's tag model is "hashtags are title text" — vault 
 
 ---
 
-### Phase 7. Live sync
+### Phase 7. Live sync — COMPLETE
 
 **Goal.** Near-real-time propagation while Obsidian is open.
 
@@ -481,6 +481,15 @@ Tags need no step: dayGLANCE's tag model is "hashtags are title text" — vault 
 - Self-nudge loop prevention: the plugin applying an inbound change must not emit that change back outbound. This is structurally the same failure identified in the lastGLANCE SSE audit; use lifeGLANCE's persisted-flag pattern.
 
 **Exit criteria.** A change made in dayGLANCE on one desktop appears in Obsidian on another within seconds, with no echo.
+
+**Build record.** Two halves, one channel: the dayGLANCE-side inbound nudge landed first (#1494 — bridge-row `/events` nudges wake the observation cycle, paced by probe + min-gap), and this build closes the outbound leg — the plugin consumes the SAME seq-only `/events` stream to drain intents on arrival instead of waiting out the 30-second timer. Decisions of record:
+
+- **THE CREDENTIAL INVARIANT: SSE is armed by proof and disarmed by refutation** — the stream opens only after a successful authenticated drain, closes on auth failure (401/403 at connect or from a drain) or a vanished pairing, and makes zero reconnect attempts in between; a de-paired plugin burns nothing. The 30-second drain tick is both the correctness floor for missed nudges AND the re-arm mechanism (the first drain that succeeds re-proves the credential), so a dead credential's total cost is polling's own benign failure mode: one failed drain per tick. Built for an observed failure, not a hypothetical — the 2026-08-31 plugin-settings-sync incident (§3.2's recorded dependency) silently stripped a device's pairing out of `data.json`.
+- **Transport is Node `http(s)`, deliberately**: Obsidian's `requestUrl` buffers whole responses and cannot stream SSE (the same limitation that made the mobile shells grow native readers), and renderer `fetch` enforces CORS, which would couple the stream to the server's `allowedOrigins` containing Obsidian's `app://` origin. Node's module has neither problem, and its availability (`window.require`, Electron renderer only) is a structural desktop gate alongside `Platform.isDesktopApp` — mobile cannot take this path even if the platform probe were wrong.
+- **The pure/wiring split is the build's shape** (a condition of the commission, same reason as normalize-then-observe): every decision the transport makes is pinned in `@glance-apps/obsidian-format`'s `bridgeSse.js` — the frame parsers (moved verbatim from dayGLANCE's `vaultEventStream.js`, which now re-exports them, so the one wire format has one parser), the arm/disarm state machine, the own-ack skip, the debounce/seq-cursor nudge gate, and the backoff schedule (5s doubling to 60s, reset on any received frame; ~60s read timeout = three missed server heartbeats, the detector for sleep and silent network loss on weeks-open machines). `bridge.ts` keeps only connection lifecycle and Node plumbing.
+- **Self-nudge safety is layered**: the exact-ack own-seq skip (both write paths return their resulting seq; one nudge per write operation — dayGLANCE's `ownWrites` principle, miniaturized) makes own echoes free, and beneath it the by-construction argument: a nudged drain's idle path performs no writes, so no cycle can sustain itself. **That argument leans on #1485's tombstone-is-cursor-movement-only rule and is annotated as such at both sites** — a future change to that rule invalidates this reasoning with it. A nudge landing while a drain is in flight sets a rerun flag instead of being dropped by the `draining` guard (the #1494 hazard, same fix).
+- **Rate budget**: an SSE connection costs one request at connect; heartbeats and nudges are free; reconnects are one each, bounded by the backoff (worst-case flap ~12/min at the floor) and further extended by the shared 429 brake. Server-side caps (64/account, 1024 total) are generous for a household fleet.
+- **Idle-nudge cost** (the shared account seq carries other apps' activity): one empty app-scoped list per debounced foreign nudge — the drain is its own probe, since `/sync/:app/list` returns only bridge-namespace rows. A future glance-vault `app` tag on activity frames would reduce this to zero and let dayGLANCE's #1494 probe be deleted; deliberately not built against (backward-compatible when it comes — both consumers ignore unknown frame fields).
 
 ---
 

--- a/packages/obsidian-format/src/bridgeSse.js
+++ b/packages/obsidian-format/src/bridgeSse.js
@@ -1,0 +1,188 @@
+// BRIDGE SSE — the pure half of the plugin's live-sync transport (Phase 7).
+//
+// THE INVARIANT (the whole credential story rests on this sentence):
+// **SSE IS ARMED BY PROOF AND DISARMED BY REFUTATION — the stream opens only
+// after a successful authenticated drain, closes on auth failure or a
+// vanished pairing, and makes ZERO reconnect attempts in between. A
+// de-paired plugin burns nothing.** Between refutation and the next proof,
+// the 30-second drain timer is the only thing running — exactly today's
+// polling posture — and the first drain that succeeds is what re-arms the
+// stream. The observed failure this is built for: Obsidian Sync's
+// plugin-settings toggle flipping off (2026-08-31), which silently strips
+// the plugin's credentials out of data.json.
+//
+// This module is deliberately PURE — no sockets, no timers of its own
+// (injectable), no Obsidian imports — so every decision the transport makes
+// is pinnable: the SSE wire parsers, the arm/disarm state machine, the
+// own-ack skip, the debounce/cursor gate, and the backoff schedule. The
+// impure remainder (Node https plumbing, connection lifecycle) lives in the
+// plugin's bridge.ts as thin wiring. Same split, same reason, as
+// normalize-then-observe: plugin-side code has no test infra, so anything
+// that must not regress lives here.
+//
+// The frame parsers are the SAME functions dayGLANCE's vault event stream
+// has used since its SSE landed — moved here verbatim so both consumers of
+// the one wire format share one parser (dayGLANCE re-exports them from
+// src/sync/vaultEventStream.js).
+
+// ─── Wire constants ──────────────────────────────────────────────────────────
+
+export const SSE_BACKOFF_BASE_MS = 5_000;
+export const SSE_BACKOFF_MAX_MS = 60_000;
+// The server writes a `: heartbeat` comment every ~20s specifically to
+// survive idle proxies (glance-vault routes/events.ts). Three missed
+// heartbeats = the socket is dead even if TCP never said so (laptop sleep,
+// silent network loss on the weeks-open Pi) — the wiring destroys the
+// request and takes the reconnect path.
+export const SSE_READ_TIMEOUT_MS = 60_000;
+
+/**
+ * Reconnect backoff: 5s doubling to a 60s cap — 5, 10, 20, 40, 60, 60, …
+ * The wiring resets the failure count on any received frame, so an
+ * established stream that later drops starts back at 5s.
+ * @param {number} consecutiveFailures  1-based
+ */
+export function sseBackoffMs(consecutiveFailures) {
+  const n = Math.max(1, Math.floor(consecutiveFailures) || 1);
+  return Math.min(SSE_BACKOFF_BASE_MS * 2 ** (n - 1), SSE_BACKOFF_MAX_MS);
+}
+
+// ─── SSE frame parsing (moved verbatim from dayGLANCE vaultEventStream.js) ──
+
+/**
+ * Parse ONE SSE event block (the text between blank-line boundaries) into the
+ * nudge object {seq}, or null if the block carries no usable data.
+ *
+ * The event NAME (`ready` | `activity`) is deliberately not surfaced: both carry
+ * the same instruction — the account seq advanced past what we knew — so the
+ * data line is the whole contract. Ignores comment lines (leading ':', used for
+ * heartbeats) and non-data fields (event:, id:, retry: — the server sends only
+ * event: and data: today; tolerating the rest is plain SSE-spec hygiene).
+ * Concatenates multiple data: lines per the SSE spec, then JSON-parses. Returns
+ * null on a heartbeat-only block or unparseable data so the caller can skip it.
+ */
+export function parseSseFrame(block) {
+  if (!block) return null;
+  const dataLines = [];
+  for (const rawLine of block.split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    if (!line || line.startsWith(':')) continue; // blank or comment (heartbeat)
+    const colon = line.indexOf(':');
+    const field = colon === -1 ? line : line.slice(0, colon);
+    let value = colon === -1 ? '' : line.slice(colon + 1);
+    if (value.startsWith(' ')) value = value.slice(1); // SSE strips one leading space
+    if (field === 'data') dataLines.push(value);
+  }
+  if (dataLines.length === 0) return null;
+  try {
+    return JSON.parse(dataLines.join('\n'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Feed a growing SSE text buffer, emitting each COMPLETE event (delimited by a
+ * blank line) via onEvent and returning the unconsumed remainder to carry into
+ * the next chunk. Normalizes CRLF/CR to LF first.
+ */
+export function drainSseBuffer(buffer, onEvent) {
+  let buf = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  let idx;
+  while ((idx = buf.indexOf('\n\n')) !== -1) {
+    const block = buf.slice(0, idx);
+    buf = buf.slice(idx + 2);
+    const evt = parseSseFrame(block);
+    if (evt) onEvent(evt);
+  }
+  return buf;
+}
+
+// ─── Arm/disarm state machine ────────────────────────────────────────────────
+
+/**
+ * The armed-by-proof / disarmed-by-refutation decision, as a tiny pinned
+ * state machine. PROOF is a successful authenticated drain (the 30s tick
+ * runs drains regardless, so proof arrives within one tick of credentials
+ * working). REFUTATION is an auth failure (401/403 at connect or from a
+ * drain) or a vanished pairing. Between refutation and the next proof,
+ * shouldConnect is false for every input — the wiring makes no connection
+ * or reconnection attempt at all, so a dead credential's total cost is
+ * today's one failed drain per tick and an unpaired plugin's cost is zero.
+ * Desktop-ness and pairedness are inputs, not state: they are re-read at
+ * every decision so a mid-session unpair gates instantly.
+ */
+export function createSseArming() {
+  let proven = false;
+  return {
+    noteDrainSuccess() { proven = true; },
+    noteAuthFailure() { proven = false; },
+    noteUnpaired() { proven = false; },
+    isProven() { return proven; },
+    shouldConnect({ desktop, paired }) {
+      return desktop === true && paired === true && proven;
+    },
+  };
+}
+
+// ─── Nudge gate (cursor + own-ack skip + debounce) ───────────────────────────
+
+/**
+ * Decide which received nudges become drains. Three layers, each pinned:
+ *  • SEQ-MONOTONIC CURSOR — a nudge at or behind the highest seen seq is
+ *    stale/coalesced and ignored;
+ *  • OWN-ACK SKIP — the plugin's own writes (observation batches, intent-row
+ *    soft-deletes) produce nudges too; the server sends one nudge per write
+ *    operation carrying that operation's own resulting seq, and both write
+ *    paths return it, so exact identity says "this is our echo" with no
+ *    heuristic (the same principle as dayGLANCE's ownWrites registry,
+ *    miniaturized). Without this, every own write costs one idle drain;
+ *    with it, zero.
+ *  • DEBOUNCE — a micro-burst of peer nudges collapses into one onDrain.
+ *
+ * LOOP SAFETY IS BY CONSTRUCTION, NOT ONLY BY THIS SKIP: even a nudge that
+ * slips through to drain() cannot sustain a cycle, because the drain's idle
+ * path performs no writes — tombstoned rows are CURSOR-MOVEMENT-ONLY (the
+ * #1485 rule; if that rule ever changes, THIS ARGUMENT CHANGES WITH IT),
+ * own observation rows fail the int: prefix test, and the one write a drain
+ * can emit (deleting an already-applied live intent row) tombstones its own
+ * cause. The skip is an efficiency layer on top of that argument, not a
+ * substitute for it.
+ */
+export function createSseNudgeGate({
+  onDrain,
+  debounceMs = 400,
+  ackCapacity = 64,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+} = {}) {
+  let lastSeq = -Infinity;
+  let timer = null;
+  const ackRing = [];
+  const ackSet = new Set();
+
+  return {
+    /** Record a write ack's seq as our own. Ignores non-numbers. */
+    recordOwnSeq(seq) {
+      if (typeof seq !== 'number' || !Number.isFinite(seq) || seq <= 0) return;
+      if (ackSet.has(seq)) return;
+      ackRing.push(seq);
+      ackSet.add(seq);
+      while (ackRing.length > ackCapacity) ackSet.delete(ackRing.shift());
+    },
+    /** Feed one nudge. Returns true when a drain was scheduled. */
+    handleEvent(evt) {
+      if (!evt || typeof evt.seq !== 'number' || Number.isNaN(evt.seq)) return false;
+      if (evt.seq <= lastSeq) return false; // stale/coalesced
+      lastSeq = evt.seq;
+      if (ackSet.has(evt.seq)) return false; // our own write's echo
+      if (timer !== null) clearTimeoutFn(timer);
+      timer = setTimeoutFn(() => { timer = null; onDrain?.(); }, debounceMs);
+      return true;
+    },
+    cancel() {
+      if (timer !== null) { clearTimeoutFn(timer); timer = null; }
+    },
+    getCursor() { return lastSeq; },
+  };
+}

--- a/packages/obsidian-format/src/bridgeSse.test.js
+++ b/packages/obsidian-format/src/bridgeSse.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Phase 7's pure half, pinned (the plugin's bridge.ts has no test infra, so
+// every decision the transport makes lives here — the pure/wiring split that
+// kept normalize-then-observe honest). The invariant under test throughout:
+// ARMED BY PROOF, DISARMED BY REFUTATION — a de-paired or auth-refused
+// plugin makes zero connection attempts until a drain succeeds again.
+
+import {
+  parseSseFrame,
+  drainSseBuffer,
+  sseBackoffMs,
+  createSseArming,
+  createSseNudgeGate,
+  SSE_READ_TIMEOUT_MS,
+} from './bridgeSse.js';
+
+describe('the wire parsers (shared with dayGLANCE, one parser per wire format)', () => {
+  it('parses activity frames, ignores heartbeat comments, tolerates unknown fields', () => {
+    expect(parseSseFrame('event: activity\ndata: {"seq":42}')).toEqual({ seq: 42 });
+    expect(parseSseFrame(': heartbeat')).toBe(null);
+    expect(parseSseFrame('event: ready\ndata: {"seq":7,"app":"future-field"}')).toEqual({ seq: 7, app: 'future-field' });
+    expect(parseSseFrame('data: not json')).toBe(null);
+  });
+
+  it('drainSseBuffer emits complete events and returns the partial remainder', () => {
+    const seen = [];
+    const rest = drainSseBuffer(
+      'event: activity\ndata: {"seq":1}\n\n: heartbeat\n\nevent: activity\ndata: {"se',
+      (e) => seen.push(e.seq),
+    );
+    expect(seen).toEqual([1]);
+    expect(rest).toBe('event: activity\ndata: {"se');
+  });
+});
+
+describe('sseBackoffMs (5s doubling to 60s)', () => {
+  it('pins the schedule', () => {
+    expect([1, 2, 3, 4, 5, 6, 99].map(sseBackoffMs)).toEqual([5000, 10000, 20000, 40000, 60000, 60000, 60000]);
+    expect(sseBackoffMs(0)).toBe(5000); // degenerate input clamps to the base
+  });
+
+  it('read timeout is three server heartbeats', () => {
+    expect(SSE_READ_TIMEOUT_MS).toBe(60_000); // server heartbeat is ~20s
+  });
+});
+
+describe('createSseArming — armed by proof, disarmed by refutation', () => {
+  const desktopPaired = { desktop: true, paired: true };
+
+  it('starts UNPROVEN: no connection before the first successful drain, whatever the platform says', () => {
+    const a = createSseArming();
+    expect(a.shouldConnect(desktopPaired)).toBe(false);
+  });
+
+  it('a successful drain is the proof; auth failure and unpairing are refutations, each holding until the NEXT proof', () => {
+    const a = createSseArming();
+    a.noteDrainSuccess();
+    expect(a.shouldConnect(desktopPaired)).toBe(true);
+
+    // The observed incident: plugin-settings sync stripped the credentials.
+    a.noteUnpaired();
+    expect(a.shouldConnect(desktopPaired)).toBe(false);
+    // Zero attempts until proof returns — not "retry with backoff".
+    expect(a.shouldConnect(desktopPaired)).toBe(false);
+    a.noteDrainSuccess();
+    expect(a.shouldConnect(desktopPaired)).toBe(true);
+
+    a.noteAuthFailure(); // 401/403 at connect or from a drain
+    expect(a.shouldConnect(desktopPaired)).toBe(false);
+  });
+
+  it('desktop and paired are gates re-read at every decision — mobile never connects, an unpaired input gates even while proven', () => {
+    const a = createSseArming();
+    a.noteDrainSuccess();
+    expect(a.shouldConnect({ desktop: false, paired: true })).toBe(false); // iPad with a keyboard is still mobile
+    expect(a.shouldConnect({ desktop: true, paired: false })).toBe(false);
+    expect(a.shouldConnect({ desktop: true, paired: true })).toBe(true);
+  });
+});
+
+describe('createSseNudgeGate — cursor, own-ack skip, debounce', () => {
+  const make = (onDrain, opts = {}) => {
+    vi.useFakeTimers();
+    return createSseNudgeGate({ onDrain, debounceMs: 100, ...opts });
+  };
+  const done = () => vi.useRealTimers();
+
+  it('a peer nudge drains after the debounce; a burst collapses into one drain', () => {
+    const onDrain = vi.fn();
+    const g = make(onDrain);
+    g.handleEvent({ seq: 1 });
+    g.handleEvent({ seq: 2 });
+    g.handleEvent({ seq: 3 });
+    vi.advanceTimersByTime(100);
+    expect(onDrain).toHaveBeenCalledTimes(1);
+    expect(g.getCursor()).toBe(3);
+    done();
+  });
+
+  it('stale/coalesced seqs are ignored; malformed events are ignored', () => {
+    const onDrain = vi.fn();
+    const g = make(onDrain);
+    expect(g.handleEvent({ seq: 5 })).toBe(true);
+    expect(g.handleEvent({ seq: 5 })).toBe(false);
+    expect(g.handleEvent({ seq: 4 })).toBe(false);
+    expect(g.handleEvent(null)).toBe(false);
+    expect(g.handleEvent({ seq: 'x' })).toBe(false);
+    done();
+  });
+
+  it('OWN-ACK SKIP: the echo of our own write (exact ack seq) advances the cursor and drains nothing — an observation emit costs zero drains', () => {
+    const onDrain = vi.fn();
+    const g = make(onDrain);
+    g.recordOwnSeq(10); // ack from our observation batch / soft-delete
+    expect(g.handleEvent({ seq: 10 })).toBe(false);
+    expect(g.getCursor()).toBe(10); // cursor still advances past our echo
+    vi.advanceTimersByTime(500);
+    expect(onDrain).not.toHaveBeenCalled();
+
+    // A pending PEER drain keeps its timer when an own echo arrives after it.
+    g.handleEvent({ seq: 11 });
+    g.recordOwnSeq(12);
+    g.handleEvent({ seq: 12 });
+    vi.advanceTimersByTime(100);
+    expect(onDrain).toHaveBeenCalledTimes(1);
+    done();
+  });
+
+  it('the ack ring is bounded and tolerates garbage', () => {
+    const g = make(vi.fn(), { ackCapacity: 2 });
+    g.recordOwnSeq(1); g.recordOwnSeq(2); g.recordOwnSeq(3); // evicts 1
+    g.recordOwnSeq(NaN); g.recordOwnSeq(-5); g.recordOwnSeq('7'); // all ignored
+    expect(g.handleEvent({ seq: 1 })).toBe(true); // evicted → treated as peer
+    expect(g.handleEvent({ seq: 2 })).toBe(false); // still a recorded own ack
+    expect(g.handleEvent({ seq: 4 })).toBe(true); // never ours → peer
+    done();
+  });
+
+  it('cancel clears a pending drain (unload path)', () => {
+    const onDrain = vi.fn();
+    const g = make(onDrain);
+    g.handleEvent({ seq: 1 });
+    g.cancel();
+    vi.advanceTimersByTime(500);
+    expect(onDrain).not.toHaveBeenCalled();
+    done();
+  });
+});

--- a/packages/obsidian-format/src/index.js
+++ b/packages/obsidian-format/src/index.js
@@ -19,3 +19,4 @@ export * from './filename.js';
 export * from './heartbeat.js';
 export * from './bridgePairing.js';
 export * from './bridgeStream.js';
+export * from './bridgeSse.js';

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -121,6 +121,35 @@ export const BRIDGE_CONFIG_META_ID: string;
 export const BRIDGE_INTENT_PREFIX: string;
 export const BRIDGE_OBSERVATION_PREFIX: string;
 export function bridgeConfigAllowsStamping(config: { blockIdWrites?: unknown } | null | undefined): boolean;
+
+// ── bridge SSE (Phase 7 — pure half of the plugin's live-sync transport) ────
+export const SSE_BACKOFF_BASE_MS: number;
+export const SSE_BACKOFF_MAX_MS: number;
+export const SSE_READ_TIMEOUT_MS: number;
+export function sseBackoffMs(consecutiveFailures: number): number;
+export function parseSseFrame(block: string): { seq?: number } | null;
+export function drainSseBuffer(buffer: string, onEvent: (evt: { seq?: number }) => void): string;
+export interface SseArming {
+  noteDrainSuccess(): void;
+  noteAuthFailure(): void;
+  noteUnpaired(): void;
+  isProven(): boolean;
+  shouldConnect(inputs: { desktop: boolean; paired: boolean }): boolean;
+}
+export function createSseArming(): SseArming;
+export interface SseNudgeGate {
+  recordOwnSeq(seq: unknown): void;
+  handleEvent(evt: { seq?: number } | null | undefined): boolean;
+  cancel(): void;
+  getCursor(): number;
+}
+export function createSseNudgeGate(opts?: {
+  onDrain?: () => void;
+  debounceMs?: number;
+  ackCapacity?: number;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+}): SseNudgeGate;
 export function mintIntentId(): string;
 export function observationEntityId(path: string): Promise<string>;
 export function sealBridgeEnvelope(subkey: CryptoKey, payload: unknown): Promise<string>;

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -76,55 +76,14 @@
 //   bridge-fed nudges only ADD instant drains on top.
 
 // ─── SSE frame parsing ────────────────────────────────────────────────────────
-
-/**
- * Parse ONE SSE event block (the text between blank-line boundaries) into the
- * nudge object {seq}, or null if the block carries no usable data.
- *
- * The event NAME (`ready` | `activity`) is deliberately not surfaced: both carry
- * the same instruction — the account seq advanced past what we knew — so the
- * data line is the whole contract. Ignores comment lines (leading ':', used for
- * heartbeats) and non-data fields (event:, id:, retry: — the server sends only
- * event: and data: today; tolerating the rest is plain SSE-spec hygiene).
- * Concatenates multiple data: lines per the SSE spec, then JSON-parses. Returns
- * null on a heartbeat-only block or unparseable data so the caller can skip it.
- */
-export function parseSseFrame(block) {
-  if (!block) return null;
-  const dataLines = [];
-  for (const rawLine of block.split('\n')) {
-    const line = rawLine.replace(/\r$/, '');
-    if (!line || line.startsWith(':')) continue; // blank or comment (heartbeat)
-    const colon = line.indexOf(':');
-    const field = colon === -1 ? line : line.slice(0, colon);
-    let value = colon === -1 ? '' : line.slice(colon + 1);
-    if (value.startsWith(' ')) value = value.slice(1); // SSE strips one leading space
-    if (field === 'data') dataLines.push(value);
-  }
-  if (dataLines.length === 0) return null;
-  try {
-    return JSON.parse(dataLines.join('\n'));
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Feed a growing SSE text buffer, emitting each COMPLETE event (delimited by a
- * blank line) via onEvent and returning the unconsumed remainder to carry into
- * the next chunk. Normalizes CRLF/CR to LF first.
- */
-export function drainSseBuffer(buffer, onEvent) {
-  let buf = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-  let idx;
-  while ((idx = buf.indexOf('\n\n')) !== -1) {
-    const block = buf.slice(0, idx);
-    buf = buf.slice(idx + 2);
-    const evt = parseSseFrame(block);
-    if (evt) onEvent(evt);
-  }
-  return buf;
-}
+//
+// The parsers moved VERBATIM to @glance-apps/obsidian-format (bridgeSse.js)
+// when Phase 7 gave the wire format a second consumer — the bridge plugin's
+// desktop SSE client. One wire format, one parser; re-exported here so this
+// module's API (and its tests, which double as the parser's pins) is
+// unchanged.
+import { parseSseFrame, drainSseBuffer } from '@glance-apps/obsidian-format';
+export { parseSseFrame, drainSseBuffer };
 
 // ─── transport detection ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
Phase 7 to the reported design, with the pure/wiring split as commissioned. Pure transport and pacing — all seven §3.10 rulings untouched; nothing here decides what wins anywhere.

## What it does

The plugin holds a desktop SSE connection to the same seq-only `/events` stream #1494 taught dayGLANCE to consume, and drains intents on arrival — closing the last slow hop (dayGLANCE edit → up-to-30s drain wait). The 30-second timer stays, as both the correctness floor for missed nudges and the re-arm mechanism below.

## The credential invariant (in the module header, as required)

**SSE is armed by proof and disarmed by refutation — the stream opens only after a successful authenticated drain, closes on auth failure or a vanished pairing, and makes zero reconnect attempts in between. A de-paired plugin burns nothing.** Proof sites: the drain's success path (`noteDrainSuccess` + `maybeStartSse`). Refutation sites: 401/403 at connect, 401/403 from a drain, and `getPairing()` returning nothing — checked at the drain gate, per received event, and on explicit unpair (which tears the stream down with the credentials rather than a tick later). Between refutation and the next proof, the only thing running is the 30s tick — so the observed data.json incident's failure mode stays exactly as benign as it was under polling: one failed drain per tick, zero SSE burn.

## The design as reported, item by item

- **Node `http(s)`, not `requestUrl` or `fetch`** — said at the site: `requestUrl` buffers whole responses so it cannot stream (the same limitation that made the mobile shells grow native readers); renderer `fetch` enforces CORS, coupling the stream to `allowedOrigins` containing Obsidian's `app://` origin; and `window.require`'s availability is itself a structural desktop gate beside `Platform.isDesktopApp` — mobile cannot take this path even if the probe were wrong. Both `https:` and LAN `http:` vault URLs are handled.
- **Backoff 5s→60s, reset on any received frame** (heartbeats included); **~60s read timeout = three missed server heartbeats**, the detector for laptop sleep and silent network loss on the weeks-open Pi and Windows box. Reconnects cost one request each against the 600/min budget (worst-case flap ~12/min at the floor) and the shared 429 brake extends the delay so a rate-limit storm pauses SSE with everything else.
- **The rerun flag**: a nudge landing while `draining` is true sets `pendingRedrain` and the drain's `finally` re-runs — previously the guard silently dropped overlaps, the exact hazard #1494 fixed on the dayGLANCE side.
- **Own-ack skip**: both write paths return their resulting seq (observation batch `maxSeq`, soft-delete `seq`); the gate records them and skips exact-match echoes — dayGLANCE's `ownWrites` principle, miniaturized. Beneath it, the by-construction loop argument: a nudged drain's idle path performs no writes, so no cycle can sustain itself — **annotated at both sites as leaning on #1485's tombstone-is-cursor-movement-only rule**, so a future change to that rule can't invalidate this reasoning silently.
- **Idle foreign nudge cost**: one empty app-scoped list (the drain is its own probe — `/sync/:app/list` returns only bridge rows), further thinned by the own-ack skip and the 400ms debounce.

## The pure/wiring split (requirement 1)

Everything decision-shaped is in `@glance-apps/obsidian-format`'s **`bridgeSse.js`**, pinned by 12 tests: the frame parsers (moved **verbatim** from `src/sync/vaultEventStream.js`, which now imports and re-exports them — one wire format, one parser, and dayGLANCE's existing stream tests double as the parsers' pins), `createSseArming` (proof/refutation transitions, gates re-read per decision — the iPad-with-keyboard case pinned as "still mobile"), `createSseNudgeGate` (seq cursor, bounded ack ring with garbage tolerance, debounce coalescing, cancel-on-unload), and `sseBackoffMs` (the exact 5/10/20/40/60 schedule plus the 60s read-timeout constant). `bridge.ts` holds only connection lifecycle and Node plumbing; `main.ts` gains the unload/unpair teardown calls.

## Verification

Full suite **2635 passing, 198 files** (+12, no regressions — including all of dayGLANCE's existing SSE and coalescer tests over the moved parsers). Lint clean; app `npm run build` and plugin `npm run build` (tsc + esbuild) both pass. Deploying needs a plugin rebuild on the desktops; mobile behavior is unchanged by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_