### PR TITLE
Audit fixes round 2: pattern-aware writeback, append replay, misattribution

### DIFF
--- a/packages/obsidian-format/src/bridgeStream.js
+++ b/packages/obsidian-format/src/bridgeStream.js
@@ -229,10 +229,24 @@ export function applyBridgeIntent(currentText, intent) {
       if (currentText !== null) {
         const existingLines = currentText.split('\n');
         // Block ids are stored bare; the vault token is ^dg-<id> (identity.js).
-        const blockToken = intent.task?.blockId ? ` ^dg-${intent.task.blockId}` : null;
+        // THE REAL CONDITION is whether the line WE WOULD WRITE carries the
+        // token (audit fix H3): buildObsidianTaskLine routes the token
+        // through blockIdSuffix, which REFUSES it for titles carrying ^dg-
+        // anywhere or ending in a foreign ^ref — so keying the landed-check
+        // on intent.task.blockId alone made replays of such appends
+        // non-idempotent: the appended line never carried the token, the
+        // token check never matched, the exact-line fallback was skipped,
+        // and every crash-replay appended the line AGAIN — breaking the
+        // module contract ("dying between applying a batch and persisting
+        // the applied-ID set replays as no-ops") in exactly the scenario it
+        // exists for. Token comparisons also tolerate trailing whitespace a
+        // human may have left on the landed line.
+        const blockToken = intent.task?.blockId && taskLine.endsWith(` ^dg-${intent.task.blockId}`)
+          ? ` ^dg-${intent.task.blockId}`
+          : null;
         const landed = blockToken
-          ? existingLines.some((l) => l.endsWith(blockToken))
-          : existingLines.includes(taskLine);
+          ? existingLines.some((l) => l.trimEnd().endsWith(blockToken))
+          : existingLines.some((l) => l.trimEnd() === taskLine.trimEnd());
         if (landed) return { text: currentText, changed: false };
       }
       const base = currentText !== null

--- a/packages/obsidian-format/src/bridgeStream.test.js
+++ b/packages/obsidian-format/src/bridgeStream.test.js
@@ -144,6 +144,33 @@ describe('applyBridgeIntent — task_append', () => {
     const replay = applyBridgeIntent(out.text, bare);
     expect(replay.changed).toBe(false);
   });
+
+  it('AUDIT FIX H3: replay stays idempotent when the TITLE refuses the token (foreign ^ref / embedded ^dg-) — the crash-replay contract holds', () => {
+    // buildObsidianTaskLine routes the token through blockIdSuffix, which
+    // refuses it for these titles — so the appended line carries NO token,
+    // and the old landed-check (keyed on intent.task.blockId alone) never
+    // matched: every replay appended the line AGAIN, breaking the module's
+    // "dying between apply and persist replays as no-ops" contract in the
+    // exact scenario it exists for.
+    for (const title of ['See ^quote1', 'Broken ^dg-embedded token #obsidian']) {
+      const refusing = { ...appendIntent, task: { ...appendIntent.task, title, blockId: 'abc12345' } };
+      const out = applyBridgeIntent('# Day\n\n## Tasks\n', refusing);
+      expect(out.changed).toBe(true);
+      expect(out.text).not.toContain('^dg-abc12345'); // token refused, as designed
+      const replay = applyBridgeIntent(out.text, refusing);
+      expect(replay.changed).toBe(false); // landed-check falls back to the exact line
+      expect(replay.text).toBe(out.text);
+    }
+  });
+
+  it('AUDIT FIX H3: a human adding trailing whitespace to the landed line no longer defeats the replay guard', () => {
+    const out = applyBridgeIntent('# Day\n\n## Tasks\n', appendIntent);
+    const withTrailing = out.text.replace(
+      '- [ ] New thing #obsidian ^dg-def67890',
+      '- [ ] New thing #obsidian ^dg-def67890   ');
+    const replay = applyBridgeIntent(withTrailing, appendIntent);
+    expect(replay.changed).toBe(false);
+  });
 });
 
 describe('applyBridgeIntent — notes', () => {

--- a/src/hooks/useObsidianSync.arbitration.test.js
+++ b/src/hooks/useObsidianSync.arbitration.test.js
@@ -35,6 +35,12 @@ vi.mock('../obsidian.js', () => ({
   readVaultHeartbeat: (...a) => readVaultHeartbeat(...a),
   readVaultHeartbeatNative: vi.fn(() => null),
   OBSIDIAN_IMPORT_WINDOW_DAYS: 90,
+  // Real implementation (pure): the hook resolves intent paths through it (audit fix H1).
+  dailyNoteFilename: (dateStr, pattern) => {
+    if (!pattern || pattern === 'yyyy-MM-dd') return `${dateStr}.md`;
+    const [y, m, d] = dateStr.split('-');
+    return `${pattern.replace('yyyy', y).replace('MM', m).replace('dd', d)}.md`;
+  },
   obsidianWindowCutoffDate: vi.fn(() => null),
 }));
 vi.mock('../native.js', () => ({

--- a/src/hooks/useObsidianSync.binRestore.test.js
+++ b/src/hooks/useObsidianSync.binRestore.test.js
@@ -47,6 +47,12 @@ vi.mock('../obsidian.js', () => ({
   readVaultHeartbeat: (...a) => readVaultHeartbeat(...a),
   readVaultHeartbeatNative: vi.fn(() => null),
   OBSIDIAN_IMPORT_WINDOW_DAYS: 90,
+  // Real implementation (pure): the hook resolves intent paths through it (audit fix H1).
+  dailyNoteFilename: (dateStr, pattern) => {
+    if (!pattern || pattern === 'yyyy-MM-dd') return `${dateStr}.md`;
+    const [y, m, d] = dateStr.split('-');
+    return `${pattern.replace('yyyy', y).replace('MM', m).replace('dd', d)}.md`;
+  },
   obsidianWindowCutoffDate: vi.fn(() => null),
 }));
 vi.mock('../native.js', () => ({

--- a/src/hooks/useObsidianSync.completionMeta.test.js
+++ b/src/hooks/useObsidianSync.completionMeta.test.js
@@ -31,6 +31,12 @@ vi.mock('../obsidian.js', () => ({
   vaultHasTasksPlugin: vi.fn(async () => false),
   detectTasksPluginNative: vi.fn(() => null),
   OBSIDIAN_IMPORT_WINDOW_DAYS: 90,
+  // Real implementation (pure): the hook resolves intent paths through it (audit fix H1).
+  dailyNoteFilename: (dateStr, pattern) => {
+    if (!pattern || pattern === 'yyyy-MM-dd') return `${dateStr}.md`;
+    const [y, m, d] = dateStr.split('-');
+    return `${pattern.replace('yyyy', y).replace('MM', m).replace('dd', d)}.md`;
+  },
   obsidianWindowCutoffDate: vi.fn(() => null),
 }));
 vi.mock('../native.js', () => ({

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -4,7 +4,7 @@ import {
   syncObsidianVault, syncObsidianVaultNative,
   writeTaskStateToFile, writeTaskStateNative,
   simpleHash as obsidianSimpleHash,
-  deriveBlockId, appIdForBlockId,
+  deriveBlockId, appIdForBlockId, dailyNoteFilename,
   readWikiNote, writeWikiNote, scanVaultNotes,
   vaultHasTasksPlugin, detectTasksPluginNative,
   readVaultHeartbeat, readVaultHeartbeatNative,
@@ -1328,12 +1328,16 @@ export default function useObsidianSync({
       // retitling write is task_retitle (it carries the state too: one
       // write, one intent), any other state/schedule change is task_state.
       // The path mirrors the direct write's file resolution exactly
-      // (writeTaskStateToFile: `${dateStr}.md` under dailyNotesPath), and
-      // applyBridgeIntent mirrors its line rewrite, so a paired vault
-      // copy converges byte-for-byte whichever side lands first.
-      // Fail-silent; a stream problem never touches the direct write.
+      // (writeTaskStateToFile, PATTERN-AWARE since audit fix H1 — both
+      // sides used to hardcode `${dateStr}.md`, so on a custom-pattern
+      // vault the intent targeted a nonexistent file that applyBridgeIntent
+      // could never change while commit-on-enqueue had already booked the
+      // identity move), and applyBridgeIntent mirrors its line rewrite, so
+      // a paired vault copy converges byte-for-byte whichever side lands
+      // first. Fail-silent; a stream problem never touches the direct write.
       const queued = emitBridgeIntent(titleChanged && newRawTitle ? 'task_retitle' : 'task_state', {
-        path: (obsidianConfig?.dailyNotesPath ? `${obsidianConfig.dailyNotesPath.replace(/\/+$/, '')}/` : '') + `${sourceDate}.md`,
+        path: (obsidianConfig?.dailyNotesPath ? `${obsidianConfig.dailyNotesPath.replace(/\/+$/, '')}/` : '')
+          + dailyNoteFilename(sourceDate, obsidianConfig?.dailyNotePattern || 'yyyy-MM-dd'),
         date: sourceDate,
         obsidianRawTitle: task.obsidianRawTitle,
         completed: task.completed,
@@ -1436,6 +1440,7 @@ export default function useObsidianSync({
           writeBlockId,
           noteTitleConflict,
           completionMeta,
+          obsidianConfig?.dailyNotePattern || 'yyyy-MM-dd', // audit fix H1: pattern-aware
         ).then(updated => {
           // `updated` false here is the benign NotFound case (file gone —
           // the scan reconciles); a real write failure REJECTS instead.

--- a/src/hooks/useObsidianSync.retry.test.js
+++ b/src/hooks/useObsidianSync.retry.test.js
@@ -31,6 +31,12 @@ vi.mock('../obsidian.js', () => ({
   writeWikiNote: vi.fn(async () => {}),
   scanVaultNotes: vi.fn(async () => ({ names: [], unportable: [] })),
   OBSIDIAN_IMPORT_WINDOW_DAYS: 90,
+  // Real implementation (pure): the hook resolves intent paths through it (audit fix H1).
+  dailyNoteFilename: (dateStr, pattern) => {
+    if (!pattern || pattern === 'yyyy-MM-dd') return `${dateStr}.md`;
+    const [y, m, d] = dateStr.split('-');
+    return `${pattern.replace('yyyy', y).replace('MM', m).replace('dd', d)}.md`;
+  },
   obsidianWindowCutoffDate: vi.fn(() => null),
 }));
 vi.mock('../native.js', () => ({

--- a/src/hooks/useObsidianSync.stampOnSight.test.js
+++ b/src/hooks/useObsidianSync.stampOnSight.test.js
@@ -109,7 +109,7 @@ const snapFor = (t) => ({
 
 let store;
 let setTasksCalls;
-function useMountedSightHook({ tasks = [], inbox = [], prevSnap = null, freshStore = true } = {}) {
+function useMountedSightHook({ tasks = [], inbox = [], prevSnap = null, freshStore = true, config = {} } = {}) {
   effects.length = 0;
   vi.stubGlobal('setTimeout', (cb, ms) => { if (!ms || ms < 3000) cb(); return 1; });
   vi.stubGlobal('setInterval', () => 1);
@@ -143,7 +143,7 @@ function useMountedSightHook({ tasks = [], inbox = [], prevSnap = null, freshSto
     tasks: state.tasks, setTasks,
     unscheduledTasks: state.inbox, setUnscheduledTasks,
     setDailyNotes: vi.fn(), setWikilinkCandidates: vi.fn(), setUnportableVaultFiles: vi.fn(),
-    obsidianConfig: { enabled: true, dailyNotesPath: '', dailyNotePattern: 'yyyy-MM-dd' },
+    obsidianConfig: { enabled: true, dailyNotesPath: '', dailyNotePattern: 'yyyy-MM-dd', ...config },
     setObsidianConfig: vi.fn(), obsidianLaunchOnWrite: null,
     obsidianCompletionDates: false,
     obsidianSyncError: null,
@@ -272,6 +272,22 @@ describe('stamp on sight (fix 2): identity-assignment write fired by import', ()
     runWritebackEffect();
     expect(emitBridgeIntent).toHaveBeenCalledTimes(1);
     expect(emitBridgeIntent.mock.calls[0][1].blockId).toBe(BLOCK);
+  });
+
+  it('AUDIT FIX H1: on a custom-pattern vault the emitted intent targets the PATTERNED filename, not `${date}.md`', () => {
+    // Pre-fix both the direct writer and this emit hardcoded `${date}.md`,
+    // so on a custom-pattern vault the intent targeted a nonexistent file
+    // applyBridgeIntent could never change — while commit-on-enqueue had
+    // already booked the identity move.
+    __setBlockIdWritesForTests(true);
+    const task = restingLegacyTask();
+    useMountedSightHook({
+      tasks: [task], prevSnap: { [LEGACY_ID]: snapFor(task) },
+      config: { dailyNotesPath: 'Daily', dailyNotePattern: 'dd.MM.yyyy' },
+    });
+    runWritebackEffect();
+    expect(emitBridgeIntent).toHaveBeenCalledTimes(1);
+    expect(emitBridgeIntent.mock.calls[0][1].path).toBe('Daily/30.08.2026.md'); // DATE = 2026-08-30
   });
 
   it('first import: the cycle merges the new untagged task, nudges ONE writeback pass after the in-progress guard drops, and that pass stamps it', async () => {

--- a/src/hooks/useObsidianSync.surfacing.test.js
+++ b/src/hooks/useObsidianSync.surfacing.test.js
@@ -27,6 +27,12 @@ vi.mock('../obsidian.js', () => ({
   writeWikiNote: vi.fn(async () => {}),
   scanVaultNotes: vi.fn(async () => ({ names: [], unportable: [] })),
   OBSIDIAN_IMPORT_WINDOW_DAYS: 90,
+  // Real implementation (pure): the hook resolves intent paths through it (audit fix H1).
+  dailyNoteFilename: (dateStr, pattern) => {
+    if (!pattern || pattern === 'yyyy-MM-dd') return `${dateStr}.md`;
+    const [y, m, d] = dateStr.split('-');
+    return `${pattern.replace('yyyy', y).replace('MM', m).replace('dd', d)}.md`;
+  },
   obsidianWindowCutoffDate: vi.fn(() => null),
 }));
 vi.mock('../native.js', () => ({

--- a/src/hooks/useObsidianSync.titleConflict.test.js
+++ b/src/hooks/useObsidianSync.titleConflict.test.js
@@ -27,6 +27,12 @@ vi.mock('../obsidian.js', () => ({
   writeWikiNote: vi.fn(async () => {}),
   scanVaultNotes: vi.fn(async () => ({ names: [], unportable: [] })),
   OBSIDIAN_IMPORT_WINDOW_DAYS: 90,
+  // Real implementation (pure): the hook resolves intent paths through it (audit fix H1).
+  dailyNoteFilename: (dateStr, pattern) => {
+    if (!pattern || pattern === 'yyyy-MM-dd') return `${dateStr}.md`;
+    const [y, m, d] = dateStr.split('-');
+    return `${pattern.replace('yyyy', y).replace('MM', m).replace('dd', d)}.md`;
+  },
   obsidianWindowCutoffDate: vi.fn(() => null),
 }));
 vi.mock('../native.js', () => ({

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -679,17 +679,24 @@ export function detectTasksPluginNative() {
  *
  * @param {string|null} [blockId]  the task's ^dg- block id (or a freshly
  *   assigned one to stamp on the matched line)
+ * @param {string} [pattern]  the daily-note FILENAME pattern (audit fix H1:
+ *   this writer used to open `${dateStr}.md` verbatim while every sibling —
+ *   the scan, the daily-note writers, the append, the intent emits —
+ *   resolved through dailyNoteFilename(dateStr, pattern). On a
+ *   custom-pattern vault the miss read as the benign "file gone" case, so
+ *   completions/retitles/reschedules/stamps silently never reached the
+ *   vault and were never retried.)
  * @returns {Promise<boolean>} whether a line was found and the file written —
  *   callers use this to commit a fresh id assignment only when it actually
  *   reached the vault.
  */
-export async function writeTaskStateToFile(vaultHandle, dailyNotesPath, dateStr, obsidianRawTitle, completed, startTime, newRawTitle, duration, targetDate, taskHeading = null, blockId = null, onTitleConflict = null, completionMeta = null) {
+export async function writeTaskStateToFile(vaultHandle, dailyNotesPath, dateStr, obsidianRawTitle, completed, startTime, newRawTitle, duration, targetDate, taskHeading = null, blockId = null, onTitleConflict = null, completionMeta = null, pattern = undefined) {
   assertSafeDateStr(dateStr);
   if (targetDate) assertSafeDateStr(targetDate);
   const dirHandle = await getDailyNotesDir(vaultHandle, dailyNotesPath);
   let fileHandle, text;
   try {
-    fileHandle = await dirHandle.getFileHandle(`${dateStr}.md`);
+    fileHandle = await dirHandle.getFileHandle(dailyNoteFilename(dateStr, pattern));
     const file = await fileHandle.getFile();
     text = await file.text();
   } catch (err) {

--- a/src/obsidian.patternWrite.test.js
+++ b/src/obsidian.patternWrite.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { writeTaskStateToFile, dailyNoteFilename } from './obsidian.js';
+
+// AUDIT FIX H1 — the task-state writer resolves the daily-note FILENAME
+// through the configured pattern, like every sibling path (the scan, the
+// daily-note writers, the append, the intent emits). Before the fix it
+// opened `${dateStr}.md` verbatim: on a custom-pattern vault the miss read
+// as the benign "file gone" case (`updated: false`, no error, no retry), so
+// completions, retitles, reschedules, and opportunistic stamps silently
+// never reached the vault. These pins hold the writer to the pattern AND
+// hold the default-pattern behavior byte-stable.
+
+// In-memory FSA vault (the obsidian.blockIds.test.js shape).
+function nfe() {
+  const e = new Error('A requested file or directory could not be found.');
+  e.name = 'NotFoundError';
+  return e;
+}
+function makeFile(parent, name) {
+  return {
+    kind: 'file',
+    name,
+    async getFile() { return { text: async () => parent[name], lastModified: 1 }; },
+    async createWritable() {
+      let buf = '';
+      return { write: async (c) => { buf += c; }, close: async () => { parent[name] = buf; } };
+    },
+  };
+}
+function makeDir(node, name = '') {
+  return {
+    kind: 'directory',
+    name,
+    async getFileHandle(n, opts) {
+      if (typeof node[n] === 'string') return makeFile(node, n);
+      if (opts?.create) { node[n] = ''; return makeFile(node, n); }
+      throw nfe();
+    },
+    async getDirectoryHandle(n, opts) {
+      if (node[n] && typeof node[n] === 'object') return makeDir(node[n], n);
+      if (opts?.create) { node[n] = {}; return makeDir(node[n], n); }
+      throw nfe();
+    },
+  };
+}
+
+const DATE = '2026-08-31';
+const PATTERN = 'dd.MM.yyyy';
+const NOTE = '# Day\n\n## Tasks\n- [ ] Buy milk ^dg-abc12345\n';
+
+describe('writeTaskStateToFile — pattern-aware filename resolution (audit fix H1)', () => {
+  it('THE H1 PIN: a custom-pattern vault gets its writeback — the patterned file is found and the line updates', async () => {
+    const patternedName = dailyNoteFilename(DATE, PATTERN);
+    expect(patternedName).toBe('31.08.2026.md'); // the fixture is honest
+    const fs = { [patternedName]: NOTE };
+    const updated = await writeTaskStateToFile(
+      makeDir(fs), '', DATE, 'Buy milk', true, null, undefined, null, undefined,
+      '## Tasks', 'abc12345', null, null, PATTERN,
+    );
+    expect(updated).toBe(true);
+    expect(fs[patternedName]).toContain('- [x] Buy milk ^dg-abc12345');
+    // And the ISO-named file it USED to open verbatim was never created.
+    expect(fs[`${DATE}.md`]).toBeUndefined();
+  });
+
+  it('the pre-fix failure shape, pinned as the contrast: without the pattern the patterned file reads as the benign "file gone" no-op', async () => {
+    const fs = { [dailyNoteFilename(DATE, PATTERN)]: NOTE };
+    const updated = await writeTaskStateToFile(
+      makeDir(fs), '', DATE, 'Buy milk', true, null, undefined, null, undefined,
+      '## Tasks', 'abc12345', null, null, /* pattern omitted → default */
+    );
+    expect(updated).toBe(false); // silent no-op — exactly why H1 mattered
+    expect(fs[dailyNoteFilename(DATE, PATTERN)]).toBe(NOTE); // untouched
+  });
+
+  it('default pattern unchanged: omitting the pattern still opens `${date}.md` and writes', async () => {
+    const fs = { [`${DATE}.md`]: NOTE };
+    const updated = await writeTaskStateToFile(
+      makeDir(fs), '', DATE, 'Buy milk', true, null, undefined, null, undefined,
+      '## Tasks', 'abc12345', null, null,
+    );
+    expect(updated).toBe(true);
+    expect(fs[`${DATE}.md`]).toContain('- [x] Buy milk ^dg-abc12345');
+  });
+});

--- a/src/utils/obsidianNoteScopedDeletions.js
+++ b/src/utils/obsidianNoteScopedDeletions.js
@@ -10,8 +10,9 @@
 // file, so for the one note it covers, the parse is the complete truth of
 // which lines exist. This module closes the gap at that grain:
 //
-//   A task that claims to live in an observed note (obsidianFileDate — or,
-//   for legacy content-derived ids, the date baked into the id) and whose
+//   A task that claims to live in an observed note (obsidianFileDate ONLY,
+//   since audit fix H4 — the legacy-id fallback date is the TASK date, not
+//   the file date, and misattributed rescheduled lines) and whose
 //   id AND legacy hint are both absent from that note's parse has had its
 //   line removed from the vault → tombstone it through the EXISTING
 //   deletedObsidianKeys LWW channel, STAMPED AT THE OBSERVATION'S MTIME
@@ -100,7 +101,6 @@
 // A v1 store (bare entries map, no touchedAt) migrates conservatively:
 // unknown continuity is treated as broken, clocks restart.
 
-import { obsidianKeyDate } from './obsidianDeletions.js';
 
 /**
  * Candidates this batch evidences: tasks claiming to live in an observed
@@ -121,11 +121,21 @@ export function inferNoteScopedDeletionCandidates({ observedNotes, scannedIds, t
   for (const t of [...(tasks || []), ...(inbox || [])]) {
     if (!t || t.importSource !== 'obsidian') continue;
     const id = String(t.id);
-    // Where does this task claim its line lives? obsidianFileDate is the
-    // note the line was last parsed from; a legacy content-derived id
-    // carries its note date itself. Neither → conservatively skip (a task
-    // whose home note we can't name can't be judged by any note's parse).
-    const noteDate = t.obsidianFileDate || obsidianKeyDate(id);
+    // Where does this task claim its line lives? obsidianFileDate — the
+    // note the line was last parsed from — and NOTHING ELSE (audit fix H4).
+    // The first shape fell back to the date embedded in a legacy id, but
+    // that date is minted from the TASK date, not the file date
+    // (legacyObsidianId(taskDate, rawTitle)), and the two diverge exactly
+    // when a line carries an inline date prefix (a dayGLANCE reschedule
+    // written into its original note). A task missing obsidianFileDate —
+    // synced from a pre-field build and never rescanned on this device —
+    // was then judged by the parse of a note that NEVER contained its line:
+    // any observation of that note pended it, and the hold committed a
+    // false deletion of a live task. A task whose home note we cannot
+    // honestly name cannot be judged by any note's parse — skip it; the
+    // vault-wide detector still covers it on the next direct scan, and any
+    // observation re-import re-establishes obsidianFileDate.
+    const noteDate = t.obsidianFileDate;
     if (!noteDate) continue;
     const note = observedNotes[noteDate];
     if (!note) continue; // note not in this batch — no evidence either way

--- a/src/utils/obsidianNoteScopedDeletions.test.js
+++ b/src/utils/obsidianNoteScopedDeletions.test.js
@@ -35,12 +35,21 @@ describe('inferNoteScopedDeletionCandidates', () => {
     expect(out).toEqual([{ id: ORPHAN_ID, noteDate: DATE, deletedAt: MTIME }]);
   });
 
-  it('falls back to the date baked into a legacy id when obsidianFileDate is absent', () => {
+  it('AUDIT FIX H4 (flipped pin): a legacy id WITHOUT obsidianFileDate is never judged — the id-embedded date is the TASK date, not the file date', () => {
+    // The old fallback judged such a task by the parse of the note its
+    // legacy id names — but legacyObsidianId mints from the TASK date, and
+    // a line with an inline date prefix (a dayGLANCE reschedule) lives in a
+    // DIFFERENT note. A task synced from a pre-obsidianFileDate build was
+    // then pended against a note that never contained its line, and the
+    // hold committed a false deletion of a live task. A task whose home
+    // note we cannot honestly name is conservatively unjudgeable; the
+    // vault-wide detector covers it on the next direct scan, and any
+    // observation re-import re-establishes obsidianFileDate.
     const out = inferNoteScopedDeletionCandidates({
       observedNotes: NOTE, scannedIds: new Set(),
       tasks: [orphan({ obsidianFileDate: undefined })], inbox: [],
     });
-    expect(out.map(c => c.id)).toEqual([ORPHAN_ID]);
+    expect(out).toEqual([]);
   });
 
   it('never flags: id present, hint advertising the id, own hint present, unobserved note, non-obsidian task, undatable dg id', () => {


### PR DESCRIPTION
The H tranche of the comprehensive audit (H1, H3, H4 — H2 shipped in round 1). None of these intersects the current default-pattern fleet, but each is a landmine for a future configuration or crash timing.

## H1 — Task-state writeback honors `dailyNotePattern`

`writeTaskStateToFile` opened `` `${dateStr}.md` `` verbatim while every sibling path (scan, daily-note writers, append, other intent emits) resolves through `dailyNoteFilename`. On a custom-pattern vault the miss read as the benign "file gone" case — completions, retitles, reschedules, and stamps silently never reached the vault, with no error and no retry. Plugin mode was worse: the `task_state`/`task_retitle` intent hardcoded the same path, so the intent targeted a nonexistent file `applyBridgeIntent` could never change while commit-on-enqueue had already booked the identity move (a block id the app holds that no vault line carries, permanently). Both sites now resolve through `dailyNoteFilename(date, pattern)`; default-pattern behavior is byte-stable, pinned — including a contrast pin of the exact pre-fix silent-no-op shape.

## H3 — `task_append` replay idempotence when the title refuses the token

`buildObsidianTaskLine` routes the token through `blockIdSuffix`, which refuses it for titles carrying `^dg-` anywhere or ending in a foreign `^ref`. The landed-check keyed on `intent.task.blockId` alone, so for such appends it never matched *and* skipped the exact-line fallback — every crash-replay appended the line again, breaking the applier's "dying between apply and persist replays as no-ops" contract in the exact scenario it exists for. The check now keys on whether the line **we would write** carries the token, and tolerates trailing whitespace a human may leave on the landed line.

## H4 — Note-scoped deletion inference judges only by `obsidianFileDate`

The legacy-id fallback date is minted from the **task** date, not the file date (`legacyObsidianId(taskDate, rawTitle)`), and the two diverge exactly for lines with inline date prefixes (dayGLANCE reschedules). A task missing `obsidianFileDate` — synced from a pre-field build and never rescanned locally — was judged by the parse of a note that never contained its line: pended, held 90s, falsely deleted. Such tasks are now conservatively unjudgeable by this channel; the vault-wide detector covers them on the next direct scan, and any observation re-import re-establishes `obsidianFileDate`. The old fallback's test pin is flipped with the rationale inline.

## Verification

- Suite: **2687 passing / 199 files** (was 2681) — new pins: the patterned write + the pre-fix silent-no-op contrast + default-pattern byte-stability; the patterned intent path; token-refusing append replays (executed with `^quote1` and embedded-`^dg-` titles) plus the trailing-whitespace guard; the flipped H4 misattribution pin.
- Lint clean; app build clean; plugin `tsc` + esbuild clean (plugin untouched by these fixes — the shared package change rides both bundles).

## Deploy

dayGLANCE bundle (H1, H4) plus the plugin `main.js` (H3 lives in the shared package the plugin bundles). Same routine: copy once, let Obsidian Sync propagate, restart Obsidian per machine as next used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_