### PR TITLE
Wikilink note creation on all platforms: editor for a missing note instead of a dead end

### DIFF
--- a/src/components/NotesSubtasksPanel.jsx
+++ b/src/components/NotesSubtasksPanel.jsx
@@ -126,7 +126,19 @@ const NotesSubtasksPanel = ({
     setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text: '', lastModified: null, loading: true, error: null } }));
     onLoadWikiNote?.(noteName).then(result => {
       if (result === null) {
+        // Vault unavailable or the read failed — no editor, fail closed.
         setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text: '', lastModified: null, loading: false, error: 'not_found' } }));
+        return;
+      }
+      if (result?.notFound) {
+        // The vault is reachable but the note doesn't exist yet: seed an
+        // EMPTY editor (not a dead-end error) so typing here creates the
+        // note — the ordinary save paths (blur / Shift+Enter / unmount
+        // flush) route through onSaveWikiNote's creation path.
+        setLinkedNoteStates(prev => ({ ...prev, [noteName]: { text: '', lastModified: null, loading: false, error: null } }));
+        setLinkedNoteEditing(prev => ({ ...prev, [noteName]: true }));
+        linkedNoteTextsRef.current[noteName] = '';
+        linkedNoteOriginalRef.current[noteName] = '';
         return;
       }
       const text = result?.text ?? '';

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -112,10 +112,20 @@ export default function useObsidianSync({
     // Strip [[Note#Heading]] fragment — we load the whole note file, not just a section
     const notePath = noteName.split('#')[0].trim();
     if (handle === 'native') {
+      // Stays null on absence: the native read wrapper collapses "no such
+      // note" and "read failed" into one null (read contract), so absence is
+      // never PROVEN here. Reporting notFound on an unreadable existing note
+      // would offer a create editor whose save overwrites it — fail closed.
       return nativeGetNote(notePath);
     }
     try {
-      return await readWikiNote(handle, notePath);
+      const note = await readWikiNote(handle, notePath);
+      // readWikiNote returns null EXACTLY when the note is absent (NotFound
+      // on the path walk / whole-vault search) and throws on real failures,
+      // so null is proven absence: report it as creatable, not as an error.
+      // The linked-note panel turns notFound into an empty editor whose save
+      // creates the note (saveWikiNote's creation path, newNotesFolder).
+      return note === null ? { notFound: true } : note;
     } catch (err) {
       console.error('Failed to read wiki note:', err);
       return null;

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -112,11 +112,15 @@ export default function useObsidianSync({
     // Strip [[Note#Heading]] fragment — we load the whole note file, not just a section
     const notePath = noteName.split('#')[0].trim();
     if (handle === 'native') {
-      // Stays null on absence: the native read wrapper collapses "no such
-      // note" and "read failed" into one null (read contract), so absence is
-      // never PROVEN here. Reporting notFound on an unreadable existing note
-      // would offer a create editor whose save overwrites it — fail closed.
-      return nativeGetNote(notePath);
+      const res = nativeGetNote(notePath);
+      // readFailed = the note exists (or may exist) but could not be read —
+      // fail closed: never offer a create editor whose save overwrites it.
+      if (res?.readFailed) return null;
+      // null = reported absence (both bridges return "" only after looking),
+      // so it is creatable. The residual: "" also covers an unconfigured
+      // vault, where a create attempt fails VISIBLY through nativeWriteNote's
+      // false return — fail-annoying, never data loss.
+      return res === null ? { notFound: true } : res;
     }
     try {
       const note = await readWikiNote(handle, notePath);
@@ -164,7 +168,17 @@ export default function useObsidianSync({
     // silent write loss the user could never see.
     if (handle === 'native') {
       // Android: same ordering — only validate when the note doesn't exist yet.
-      const existing = await Promise.resolve(nativeGetNote(notePath)).catch(() => null);
+      const existing = await Promise.resolve(nativeGetNote(notePath)).catch(() => ({ readFailed: true }));
+      // A FAILED existence read refuses the write outright: before the
+      // readFailed sentinel this fell into the "existing" arm (no frontmatter,
+      // content written as-is) — or worse, with the old collapsed null, into
+      // the CREATION arm, decorating and overwriting a note that exists but
+      // couldn't be read.
+      if (existing?.readFailed) {
+        setObsidianSyncError(`Note "${notePath}" was not written: the note could not be read to verify whether it already exists.`);
+        setObsidianSyncStatus('error');
+        return;
+      }
       if (!existing) {
         const reason = validateWikiNoteName(notePath);
         if (reason) {

--- a/src/hooks/useObsidianSync.wikiNoteCreate.test.js
+++ b/src/hooks/useObsidianSync.wikiNoteCreate.test.js
@@ -5,18 +5,25 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 // creation frontmatter, newNotesFolder) has existed since Phase 6, but the
 // linked-note panel could never reach it: loadWikiNote reported a MISSING note
 // with the same null it uses for "vault unavailable / read failed", so the
-// panel rendered a dead-end error instead of an editor. The contract now:
+// panel rendered a dead-end error instead of an editor. The contract now, on
+// BOTH platforms:
 //
-//   { notFound: true }  — PROVEN absence (desktop FSA only: readWikiNote
-//                         returns null exactly on NotFound, throws otherwise).
-//                         The panel turns this into an empty editor whose
-//                         save creates the note.
-//   null                — vault unavailable, read failure, or NATIVE absence.
-//                         Native stays null on purpose: nativeGetNote
-//                         collapses "no such note" and "read failed" into one
-//                         null (read contract), so absence is never proven
-//                         there, and a create editor over an unreadable
-//                         existing note would invite an overwrite.
+//   { notFound: true }  — absence the vault actually reported: desktop FSA
+//                         (readWikiNote returns null exactly on NotFound,
+//                         throws otherwise) and native ("" on the wire — both
+//                         bridges return it only after looking; a failed read
+//                         is the distinct {"error":…} envelope instead). The
+//                         panel turns this into an empty editor whose save
+//                         creates the note.
+//   null                — unproven absence, fail closed: no vault handle, a
+//                         desktop read failure, or the native readFailed
+//                         sentinel. A create editor over an unreadable
+//                         EXISTING note would invite an overwrite.
+//
+// saveWikiNote's native branch shares the sentinel: a failed existence read
+// REFUSES the write (visible sync error) instead of guessing an arm — the old
+// collapsed null guessed CREATION, decorating and overwriting a note that
+// exists but couldn't be read.
 //
 // Capture-harness pattern (the titleConflict/renameWar shape).
 
@@ -46,22 +53,30 @@ vi.mock('../obsidian.js', () => ({
   obsidianWindowCutoffDate: vi.fn(() => null),
 }));
 const nativeGetNote = vi.fn();
+const nativeWriteNote = vi.fn();
 vi.mock('../native.js', () => ({
   isNativeAndroid: () => false,
   isNativeApp: () => false,
   nativeGetVaultConfig: vi.fn(() => null),
   nativeGetNote: (...a) => nativeGetNote(...a),
-  nativeWriteNote: vi.fn(),
+  nativeWriteNote: (...a) => nativeWriteNote(...a),
   nativeOpenNote: vi.fn(),
   nativeListNotes: vi.fn(() => []),
   nativeSetVaultSettings: vi.fn(),
   nativeSetLaunchOnWrite: vi.fn(),
 }));
+const emitBridgeIntent = vi.fn(() => true);
+vi.mock('../utils/obsidianBridgeStream.js', () => ({
+  emitBridgeIntent: (...a) => emitBridgeIntent(...a),
+  flushBridgeOutbox: vi.fn(async () => true),
+  publishBridgeConfig: vi.fn(async () => {}),
+  getBridgePairingMeta: vi.fn(async () => null),
+}));
 
 const { default: useObsidianSync } = await import('./useObsidianSync.js');
 
-// Calls the hook (effects captured, never run — loadWikiNote is a plain
-// callback) and returns its API.
+// Calls the hook (effects captured, never run — loadWikiNote/saveWikiNote are
+// plain callbacks) and returns its API plus the error-surfacing spies.
 function useMountedSync(vaultHandle) {
   effects.length = 0;
   vi.stubGlobal('setTimeout', () => 1);
@@ -75,7 +90,9 @@ function useMountedSync(vaultHandle) {
     setItem: (k, v) => store.set(k, String(v)),
     removeItem: (k) => store.delete(k),
   });
-  return useObsidianSync({
+  const setObsidianSyncError = vi.fn();
+  const setObsidianSyncStatus = vi.fn();
+  const api = useObsidianSync({
     isTrayMode: false, dataLoaded: true,
     tasks: [], setTasks: vi.fn(),
     unscheduledTasks: [], setUnscheduledTasks: vi.fn(),
@@ -83,13 +100,14 @@ function useMountedSync(vaultHandle) {
     obsidianConfig: { enabled: true, dailyNotesPath: '', dailyNotePattern: 'yyyy-MM-dd' },
     setObsidianConfig: vi.fn(), obsidianLaunchOnWrite: null,
     obsidianSyncError: null,
-    setObsidianSyncStatus: vi.fn(), setObsidianSyncError: vi.fn(), setObsidianLastSynced: vi.fn(),
+    setObsidianSyncStatus, setObsidianSyncError, setObsidianLastSynced: vi.fn(),
     setObsidianSyncNotice: vi.fn(),
     obsidianVaultHandleRef: { current: vaultHandle },
     obsidianSyncInProgressRef: { current: false },
     obsidianPrevTaskStateRef: { current: {} },
     obsidianTasksRef: { current: [] }, obsidianInboxRef: { current: [] },
   });
+  return { ...api, setObsidianSyncError, setObsidianSyncStatus };
 }
 
 afterEach(() => {
@@ -97,21 +115,34 @@ afterEach(() => {
   vi.restoreAllMocks();
   readWikiNote.mockReset();
   nativeGetNote.mockReset();
+  nativeWriteNote.mockReset();
+  emitBridgeIntent.mockReset();
+  emitBridgeIntent.mockReturnValue(true);
 });
 
-describe('loadWikiNote — proven absence is creatable (desktop FSA)', () => {
-  it('THE FIX PIN: a missing note reports { notFound: true }, not the error null', async () => {
+describe('loadWikiNote — reported absence is creatable', () => {
+  it('THE FIX PIN (desktop): a missing note reports { notFound: true }, not the error null', async () => {
     readWikiNote.mockResolvedValue(null); // readWikiNote null = NotFound, by its own contract
     const { loadWikiNote } = useMountedSync({ kind: 'directory' });
     await expect(loadWikiNote('TV Series')).resolves.toEqual({ notFound: true });
     expect(readWikiNote).toHaveBeenCalledWith({ kind: 'directory' }, 'TV Series');
   });
 
-  it('an existing note passes through untouched', async () => {
+  it('THE FIX PIN (native): reported absence (wrapper null, from "" on the wire) is { notFound: true }', async () => {
+    nativeGetNote.mockReturnValue(null);
+    const { loadWikiNote } = useMountedSync('native');
+    await expect(loadWikiNote('TV Series')).resolves.toEqual({ notFound: true });
+    expect(readWikiNote).not.toHaveBeenCalled();
+  });
+
+  it('an existing note passes through untouched (desktop and native)', async () => {
     const note = { text: 'watchlist', lastModified: '2026-08-31T10:00:00.000Z' };
     readWikiNote.mockResolvedValue(note);
-    const { loadWikiNote } = useMountedSync({ kind: 'directory' });
-    await expect(loadWikiNote('TV Series')).resolves.toBe(note);
+    const desktop = useMountedSync({ kind: 'directory' });
+    await expect(desktop.loadWikiNote('TV Series')).resolves.toBe(note);
+    nativeGetNote.mockReturnValue(note);
+    const native = useMountedSync('native');
+    await expect(native.loadWikiNote('TV Series')).resolves.toBe(note);
   });
 
   it('the [[Note#Heading]] fragment is stripped before the read, so absence is judged on the FILE', async () => {
@@ -123,7 +154,7 @@ describe('loadWikiNote — proven absence is creatable (desktop FSA)', () => {
 });
 
 describe('loadWikiNote — unproven absence stays the error null (fail closed)', () => {
-  it('a READ FAILURE (readWikiNote throws) is null, never notFound — an unreadable note must not offer a create editor', async () => {
+  it('a desktop READ FAILURE (readWikiNote throws) is null, never notFound — an unreadable note must not offer a create editor', async () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     readWikiNote.mockRejectedValue(new Error('permission revoked'));
     const { loadWikiNote } = useMountedSync({ kind: 'directory' });
@@ -131,23 +162,47 @@ describe('loadWikiNote — unproven absence stays the error null (fail closed)',
     expect(errSpy).toHaveBeenCalled();
   });
 
+  it('the native readFailed sentinel is null, never notFound — same rule, native wire', async () => {
+    nativeGetNote.mockReturnValue({ readFailed: true });
+    const { loadWikiNote } = useMountedSync('native');
+    await expect(loadWikiNote('TV Series')).resolves.toBe(null);
+  });
+
   it('no vault handle is null — nothing to create into', async () => {
     const { loadWikiNote } = useMountedSync(null);
     await expect(loadWikiNote('TV Series')).resolves.toBe(null);
     expect(readWikiNote).not.toHaveBeenCalled();
   });
+});
 
-  it('NATIVE absence stays null: nativeGetNote cannot distinguish missing from read-failed, so absence is never proven there', async () => {
-    nativeGetNote.mockReturnValue(null);
-    const { loadWikiNote } = useMountedSync('native');
-    await expect(loadWikiNote('TV Series')).resolves.toBe(null);
-    expect(readWikiNote).not.toHaveBeenCalled();
+describe('saveWikiNote (native) — the existence read decides the arm, so a FAILED read refuses the write', () => {
+  it('readFailed → no write, visible sync error (the old collapsed null picked the CREATION arm and overwrote)', async () => {
+    nativeGetNote.mockReturnValue({ readFailed: true });
+    const { saveWikiNote, setObsidianSyncError, setObsidianSyncStatus } = useMountedSync('native');
+    await saveWikiNote('TV Series', 'typed content');
+    expect(nativeWriteNote).not.toHaveBeenCalled();
+    expect(setObsidianSyncError).toHaveBeenCalledWith(expect.stringContaining('could not be read'));
+    expect(setObsidianSyncStatus).toHaveBeenCalledWith('error');
   });
 
-  it('a native EXISTING note still passes through (control)', async () => {
-    const note = { text: 'body', lastModified: '2026-08-31T10:00:00.000Z' };
-    nativeGetNote.mockReturnValue(note);
-    const { loadWikiNote } = useMountedSync('native');
-    await expect(loadWikiNote('TV Series')).resolves.toBe(note);
+  it('reported absence → CREATION arm: validated name, creation frontmatter, write goes through', async () => {
+    nativeGetNote.mockReturnValue(null);
+    nativeWriteNote.mockReturnValue(true);
+    const { saveWikiNote, setObsidianSyncError } = useMountedSync('native');
+    await saveWikiNote('TV Series', 'typed content');
+    expect(nativeWriteNote).toHaveBeenCalledTimes(1);
+    const [path, content] = nativeWriteNote.mock.calls[0];
+    expect(path).toBe('TV Series');
+    expect(content.startsWith('---\n')).toBe(true); // creation frontmatter
+    expect(content).toContain('typed content');
+    expect(setObsidianSyncError).not.toHaveBeenCalled();
+  });
+
+  it('existing note → OVERWRITE arm: content as-is, never re-decorated', async () => {
+    nativeGetNote.mockReturnValue({ text: 'old body', lastModified: 'x' });
+    nativeWriteNote.mockReturnValue(true);
+    const { saveWikiNote } = useMountedSync('native');
+    await saveWikiNote('TV Series', 'edited body');
+    expect(nativeWriteNote).toHaveBeenCalledWith('TV Series', 'edited body');
   });
 });

--- a/src/hooks/useObsidianSync.wikiNoteCreate.test.js
+++ b/src/hooks/useObsidianSync.wikiNoteCreate.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// loadWikiNote's absence contract — the fix for the wikilink-creation dead
+// end. The creation transport (saveWikiNote → wiki_note_write / writeWikiNote,
+// creation frontmatter, newNotesFolder) has existed since Phase 6, but the
+// linked-note panel could never reach it: loadWikiNote reported a MISSING note
+// with the same null it uses for "vault unavailable / read failed", so the
+// panel rendered a dead-end error instead of an editor. The contract now:
+//
+//   { notFound: true }  — PROVEN absence (desktop FSA only: readWikiNote
+//                         returns null exactly on NotFound, throws otherwise).
+//                         The panel turns this into an empty editor whose
+//                         save creates the note.
+//   null                — vault unavailable, read failure, or NATIVE absence.
+//                         Native stays null on purpose: nativeGetNote
+//                         collapses "no such note" and "read failed" into one
+//                         null (read contract), so absence is never proven
+//                         there, and a create editor over an unreadable
+//                         existing note would invite an overwrite.
+//
+// Capture-harness pattern (the titleConflict/renameWar shape).
+
+const effects = [];
+vi.mock('react', () => ({
+  useEffect: (fn, deps) => { effects.push({ fn, deps }); },
+  useCallback: (fn) => fn,
+  useRef: (init) => ({ current: init }),
+}));
+
+const readWikiNote = vi.fn();
+vi.mock('../obsidian.js', () => ({
+  tryRestoreVaultAccess: vi.fn(async () => null),
+  getVaultAccess: vi.fn(async () => null),
+  syncObsidianVault: vi.fn(async () => null),
+  syncObsidianVaultNative: vi.fn(async () => null),
+  writeTaskStateToFile: vi.fn(async () => false),
+  writeTaskStateNative: vi.fn(() => false),
+  simpleHash: vi.fn(() => 'h'),
+  deriveBlockId: vi.fn(() => 'testblok0'),
+  appIdForBlockId: vi.fn((b) => `obsidian-dg-${b}`),
+  readWikiNote: (...a) => readWikiNote(...a),
+  writeWikiNote: vi.fn(async () => {}),
+  scanVaultNotes: vi.fn(async () => ({ names: [], unportable: [] })),
+  OBSIDIAN_IMPORT_WINDOW_DAYS: 90,
+  dailyNoteFilename: (dateStr) => `${dateStr}.md`,
+  obsidianWindowCutoffDate: vi.fn(() => null),
+}));
+const nativeGetNote = vi.fn();
+vi.mock('../native.js', () => ({
+  isNativeAndroid: () => false,
+  isNativeApp: () => false,
+  nativeGetVaultConfig: vi.fn(() => null),
+  nativeGetNote: (...a) => nativeGetNote(...a),
+  nativeWriteNote: vi.fn(),
+  nativeOpenNote: vi.fn(),
+  nativeListNotes: vi.fn(() => []),
+  nativeSetVaultSettings: vi.fn(),
+  nativeSetLaunchOnWrite: vi.fn(),
+}));
+
+const { default: useObsidianSync } = await import('./useObsidianSync.js');
+
+// Calls the hook (effects captured, never run — loadWikiNote is a plain
+// callback) and returns its API.
+function useMountedSync(vaultHandle) {
+  effects.length = 0;
+  vi.stubGlobal('setTimeout', () => 1);
+  vi.stubGlobal('setInterval', () => 1);
+  vi.stubGlobal('clearInterval', () => {});
+  vi.stubGlobal('document', { addEventListener: () => {}, removeEventListener: () => {}, visibilityState: 'visible' });
+  vi.stubGlobal('window', {});
+  const store = new Map();
+  vi.stubGlobal('localStorage', {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+  });
+  return useObsidianSync({
+    isTrayMode: false, dataLoaded: true,
+    tasks: [], setTasks: vi.fn(),
+    unscheduledTasks: [], setUnscheduledTasks: vi.fn(),
+    setDailyNotes: vi.fn(), setWikilinkCandidates: vi.fn(), setUnportableVaultFiles: vi.fn(),
+    obsidianConfig: { enabled: true, dailyNotesPath: '', dailyNotePattern: 'yyyy-MM-dd' },
+    setObsidianConfig: vi.fn(), obsidianLaunchOnWrite: null,
+    obsidianSyncError: null,
+    setObsidianSyncStatus: vi.fn(), setObsidianSyncError: vi.fn(), setObsidianLastSynced: vi.fn(),
+    setObsidianSyncNotice: vi.fn(),
+    obsidianVaultHandleRef: { current: vaultHandle },
+    obsidianSyncInProgressRef: { current: false },
+    obsidianPrevTaskStateRef: { current: {} },
+    obsidianTasksRef: { current: [] }, obsidianInboxRef: { current: [] },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  readWikiNote.mockReset();
+  nativeGetNote.mockReset();
+});
+
+describe('loadWikiNote — proven absence is creatable (desktop FSA)', () => {
+  it('THE FIX PIN: a missing note reports { notFound: true }, not the error null', async () => {
+    readWikiNote.mockResolvedValue(null); // readWikiNote null = NotFound, by its own contract
+    const { loadWikiNote } = useMountedSync({ kind: 'directory' });
+    await expect(loadWikiNote('TV Series')).resolves.toEqual({ notFound: true });
+    expect(readWikiNote).toHaveBeenCalledWith({ kind: 'directory' }, 'TV Series');
+  });
+
+  it('an existing note passes through untouched', async () => {
+    const note = { text: 'watchlist', lastModified: '2026-08-31T10:00:00.000Z' };
+    readWikiNote.mockResolvedValue(note);
+    const { loadWikiNote } = useMountedSync({ kind: 'directory' });
+    await expect(loadWikiNote('TV Series')).resolves.toBe(note);
+  });
+
+  it('the [[Note#Heading]] fragment is stripped before the read, so absence is judged on the FILE', async () => {
+    readWikiNote.mockResolvedValue(null);
+    const { loadWikiNote } = useMountedSync({ kind: 'directory' });
+    await expect(loadWikiNote('TV Series#Watchlist')).resolves.toEqual({ notFound: true });
+    expect(readWikiNote).toHaveBeenCalledWith({ kind: 'directory' }, 'TV Series');
+  });
+});
+
+describe('loadWikiNote — unproven absence stays the error null (fail closed)', () => {
+  it('a READ FAILURE (readWikiNote throws) is null, never notFound — an unreadable note must not offer a create editor', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    readWikiNote.mockRejectedValue(new Error('permission revoked'));
+    const { loadWikiNote } = useMountedSync({ kind: 'directory' });
+    await expect(loadWikiNote('TV Series')).resolves.toBe(null);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it('no vault handle is null — nothing to create into', async () => {
+    const { loadWikiNote } = useMountedSync(null);
+    await expect(loadWikiNote('TV Series')).resolves.toBe(null);
+    expect(readWikiNote).not.toHaveBeenCalled();
+  });
+
+  it('NATIVE absence stays null: nativeGetNote cannot distinguish missing from read-failed, so absence is never proven there', async () => {
+    nativeGetNote.mockReturnValue(null);
+    const { loadWikiNote } = useMountedSync('native');
+    await expect(loadWikiNote('TV Series')).resolves.toBe(null);
+    expect(readWikiNote).not.toHaveBeenCalled();
+  });
+
+  it('a native EXISTING note still passes through (control)', async () => {
+    const note = { text: 'body', lastModified: '2026-08-31T10:00:00.000Z' };
+    nativeGetNote.mockReturnValue(note);
+    const { loadWikiNote } = useMountedSync('native');
+    await expect(loadWikiNote('TV Series')).resolves.toBe(note);
+  });
+});

--- a/src/native.js
+++ b/src/native.js
@@ -320,25 +320,35 @@ export const nativeGetVaultConfig = () => {
 /**
  * Reads an arbitrary vault note by wikilink name (e.g. "My Note" or "Folder/My Note").
  * Bare names are resolved by searching the vault recursively, matching Obsidian's behaviour.
- * Returns { text, lastModified } or null if not found / vault not configured.
+ *
+ * Returns:
+ *   { text, lastModified }  — the note exists and was read.
+ *   null                    — REPORTED absence: both platforms return "" on
+ *                             the wire only after looking (index/dir miss on
+ *                             Android, an explicit existence check on iOS).
+ *                             "" also covers an unconfigured vault, where
+ *                             every write path refuses visibly too.
+ *   { readFailed: true }    — the note exists (or may exist) but could not be
+ *                             read: the {"error":…} envelope, a mangled
+ *                             payload, or no usable bridge. Never collapsed
+ *                             into null (read contract): treating a failed
+ *                             read as absence invites callers to recreate or
+ *                             overwrite a note that is really there.
  */
 export const nativeGetNote = (path) => {
   const bridge = obsidianBridge();
-  if (!bridge?.getNote) return null;
+  if (!bridge?.getNote) return { readFailed: true };
   try {
     const raw = bridge.getNote(path);
     if (!raw) return null;
     const parsed = JSON.parse(raw);
-    // Failed-read envelope (read contract): the note exists but could not be
-    // read. Reported upward as null (same as absent) but logged, so a read
-    // failure is never silently mistaken for "no such note".
     if (parsed && parsed.error) {
       console.warn(`[Obsidian native] Note "${path}" read failed:`, parsed.error);
-      return null;
+      return { readFailed: true };
     }
     return parsed;
   } catch {
-    return null;
+    return { readFailed: true };
   }
 };
 

--- a/src/obsidian.nativeReadContract.test.js
+++ b/src/obsidian.nativeReadContract.test.js
@@ -116,13 +116,27 @@ describe('write paths refuse to act on a failed read', () => {
   });
 });
 
-describe('wiki-note read wrappers surface the failure envelope as null, never as content', () => {
-  it('nativeGetNote: {"error":…} → null (logged), success object passes', () => {
+describe('wiki-note read wrappers keep failure distinct from absence, and neither is ever content', () => {
+  it('nativeGetNote: {"error":…} → { readFailed: true } (logged), "" → null (reported absence), success object passes', () => {
+    // The three-way contract the wikilink-creation flow rides on: a caller
+    // that sees null may offer to CREATE the note; a caller that sees
+    // readFailed must not — the note may exist and be unreadable. Collapsing
+    // the envelope into null (the pre-creation-era behavior) is exactly what
+    // made native creation unshippable.
     installBridge({ getNote: vi.fn(() => JSON.stringify({ error: 'note read failed' })) });
-    expect(nativeGetNote('My Note')).toBeNull();
+    expect(nativeGetNote('My Note')).toEqual({ readFailed: true });
     expect(console.warn).toHaveBeenCalled();
+    installBridge({ getNote: vi.fn(() => '') });
+    expect(nativeGetNote('My Note')).toBeNull();
     installBridge({ getNote: vi.fn(() => JSON.stringify({ text: 'content', lastModified: 'x' })) });
     expect(nativeGetNote('My Note')).toEqual({ text: 'content', lastModified: 'x' });
+  });
+
+  it('nativeGetNote: a mangled payload or a missing bridge is readFailed, not absence', () => {
+    installBridge({ getNote: vi.fn(() => 'not json {') });
+    expect(nativeGetNote('My Note')).toEqual({ readFailed: true });
+    installBridge({ getNote: undefined });
+    expect(nativeGetNote('My Note')).toEqual({ readFailed: true });
   });
 
   it('nativeGetTasksFromNote: non-array → null, array passes', () => {


### PR DESCRIPTION
## What

Typing `[[New Note]]` in a task title was supposed to let you create the note from the task card, and the whole creation transport has existed since Phase 6 (`saveWikiNote` → `wiki_note_write` / `writeWikiNote`, creation frontmatter, the `newNotesFolder` default) — but the UI could never reach it. `loadWikiNote` reported a missing note with the same `null` it uses for "vault unavailable / read failed", so the linked-note panel rendered the dead-end **"Note not found in vault — check that your vault is configured and the note exists."** message with no editor.

Two commits: the first fixes desktop; the second extends the fix to Android/iOS by surfacing a distinction the native bridges already carry on the wire.

## How

**Commit 1 — desktop + panel:**
- **`useObsidianSync.js` — `loadWikiNote`** returns `{ notFound: true }` for reported absence (desktop FSA: `readWikiNote` returns `null` exactly on NotFound and throws on real failures).
- **`NotesSubtasksPanel.jsx`** turns `notFound` into an empty editable editor (state and refs seeded with `''`, editing enabled), so the ordinary save paths — blur, Shift+Enter, unmount flush — route the typed content through `onSaveWikiNote`'s creation path. The existing placeholder ("Empty note — start typing to create it in your vault") already reads correctly for this case.

**Commit 2 — native:**
- Both native bridges already distinguish a missing note (`""` on the wire, returned only after looking — index/dir miss on Android, an explicit existence check on iOS) from an unreadable one (the `{"error":…}` envelope). The collapse was in **`nativeGetNote`**, which mapped both to `null`. It now returns a three-way contract: `{text, lastModified}` on success, `null` for reported absence, and a **`{readFailed: true}` sentinel** for the error envelope, a mangled payload, or a missing bridge. No Kotlin/Swift changes.
- `loadWikiNote`'s native branch maps `null` → `{ notFound: true }` (create editor) and `readFailed` → the fail-closed error `null`.
- **`saveWikiNote`'s native branch gains the matching guard**: a failed existence read now refuses the write with a visible sync error instead of guessing an arm. Under the old collapsed `null` it chose the CREATION arm — decorating with frontmatter and overwriting a note that exists but couldn't be read. That hazard predates the creation feature.

**Fail-closed everywhere absence is unproven:** no vault handle, a desktop read throw, and the native `readFailed` sentinel all keep the error message, never an editor. Accepted residual: native `""` also covers an unconfigured vault, where a create attempt fails *visibly* through `nativeWriteNote`'s false return — fail-annoying, never data loss.

## Tests

`useObsidianSync.wikiNoteCreate.test.js` (capture-harness pattern) pins the whole contract: reported absence → `{ notFound: true }` on both platforms, fragment stripping, existing-note passthrough, the fail-closed nulls (desktop read throw, no handle, native `readFailed`), and the three `saveWikiNote` native arms (refusal on `readFailed`, creation with frontmatter, undecorated overwrite). `obsidian.nativeReadContract.test.js` pins the new three-way `nativeGetNote` wrapper contract.

Full suite: **2698 passing / 200 files**. ESLint clean on all touched files.
