### PR TITLE
Audit fix M2: outbox refuses at cap instead of head-dropping; flush drains in chunks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5394,12 +5394,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -5473,9 +5477,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -5491,12 +5495,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5674,9 +5679,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001766",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
-      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -5691,7 +5696,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -6460,10 +6466,11 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.282",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.282.tgz",
-      "integrity": "sha512-FCPkJtpst28UmFzd903iU7PdeVTfY0KAeJy+Lk0GLZRwgwYHn/irRcaCbQQOmr5Vytc/7rcavsYLvTM8RiHYhQ==",
-      "dev": true
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
@@ -9513,10 +9520,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nopt": {
       "version": "9.0.0",
@@ -10129,10 +10140,11 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -12229,9 +12241,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {
@@ -12247,6 +12259,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"

--- a/src/utils/obsidianBridgeStream.js
+++ b/src/utils/obsidianBridgeStream.js
@@ -50,7 +50,26 @@ const META_CACHE_KEY = 'dayglance-bridge-pairing-meta';
 // kept only so publishBridgeConfig can clean it up (see the guard below).
 const LEGACY_CONFIG_HASH_KEY = 'dayglance-bridge-config-hash';
 const META_TTL_MS = 5 * 60 * 1000;
+// AUDIT FIX M2 — the cap is a REFUSAL threshold, not a drop policy. The
+// original shape shifted the OLDEST entries out when full, which silently
+// unbooked writes whose identity moves were already committed on enqueue
+// (the commit-on-enqueue rule) while telling the newest caller "queued".
+// A full outbox now refuses the NEWEST emit instead: the return value
+// already means "not durably queued", authoritative callers latch a visible
+// error on it, and mirror-intent callers' direct writes have already
+// landed. The unpaired-accretion concern the shift addressed is handled
+// upstream — enqueue is gated on the cached pairing meta, which the sync
+// cycle keeps fresh, so an unpaired vault stops enqueueing within a TTL.
 const OUTBOX_CAP = 500;
+// AUDIT FIX M2, flush half — the backlog drains in bounded chunks, each
+// removed from the persisted outbox as its ack lands. The original shape
+// sent the ENTIRE outbox as one batch: a backlog big enough for the server
+// to reject could never flush at all (fail once, retry the same oversized
+// request forever), and a mid-request failure lost the whole attempt. With
+// chunks, a partial failure keeps every acked chunk's progress and retries
+// only the unsent tail. The value bounds per-request payload (intents can
+// carry whole-note content); it is not otherwise load-bearing.
+const FLUSH_CHUNK = 50;
 
 // Subkey cache, keyed by generation so a re-pair (new salt) re-derives.
 let cachedSubkey = null;
@@ -182,9 +201,10 @@ export function emitBridgeIntent(type, fields) {
     // intents mirrored have already landed, so nothing is lost.
     if (!readJson(META_CACHE_KEY, null)?.meta) return false;
     const outbox = readJson(OUTBOX_KEY, []);
+    // Full → refuse the NEWEST, visibly (see the M2 note at OUTBOX_CAP).
+    // Never shift out the oldest: those entries are booked.
+    if (outbox.length >= OUTBOX_CAP) return false;
     outbox.push({ v: 1, kind: 'intent', type, intentId: mintIntentId(), createdAt: new Date().toISOString(), ...fields });
-    // A vault that unpaired mid-stream must not accrete forever: drop oldest.
-    while (outbox.length > OUTBOX_CAP) outbox.shift();
     // Direct setItem, NOT writeJson: a swallowed storage failure would
     // report "queued" for an intent that was never persisted — exactly the
     // silent loss the return value exists to make visible (gate a).
@@ -216,24 +236,33 @@ async function doFlush() {
     const meta = await getBridgePairingMeta();
     const subkey = await getBridgeSubkey(meta);
     if (!subkey) return false;
-    const rows = [];
-    for (const intent of outbox) {
-      rows.push({
-        entityId: `${BRIDGE_INTENT_PREFIX}${intent.intentId}`,
-        envelope: await sealBridgeEnvelope(subkey, intent),
-        createdAt: Date.parse(intent.createdAt) || Date.now(),
-      });
+    // Chunked drain (M2): each chunk leaves the persisted outbox as soon as
+    // its ack lands, so a failure partway keeps every acked chunk's progress
+    // and retries only the unsent tail. The loop walks a snapshot — an emit
+    // that races in during a network call is not in it and simply stays
+    // queued for the next flush.
+    for (let start = 0; start < outbox.length; start += FLUSH_CHUNK) {
+      // A 429 partway through armed the brake on the real response; sending
+      // the next chunk into it would just deepen the escalation.
+      if (start > 0 && bridgeRateLimited()) return false;
+      const chunk = outbox.slice(start, start + FLUSH_CHUNK);
+      const rows = [];
+      for (const intent of chunk) {
+        rows.push({
+          entityId: `${BRIDGE_INTENT_PREFIX}${intent.intentId}`,
+          envelope: await sealBridgeEnvelope(subkey, intent),
+          createdAt: Date.parse(intent.createdAt) || Date.now(),
+        });
+      }
+      const ack = await ctx.client.batch(BRIDGE_VAULT_APP, { accountId: ctx.accountId, rows });
+      // Own-echo damping (#1455): bridge writes advance the same per-account
+      // seq the engine's do — record each ack so our echo drains nothing.
+      recordOwnWriteSeq(ack?.maxSeq);
+      const sent = new Set(chunk.map((i) => i.intentId));
+      const remaining = readJson(OUTBOX_KEY, []).filter((i) => !sent.has(i.intentId));
+      writeJson(OUTBOX_KEY, remaining);
     }
-    const ack = await ctx.client.batch(BRIDGE_VAULT_APP, { accountId: ctx.accountId, rows });
-    // Own-echo damping (#1455): bridge writes advance the same per-account
-    // seq the engine's do — record the ack so our echo drains nothing.
-    recordOwnWriteSeq(ack?.maxSeq);
-    // Only entries we actually sent leave the queue — an emit that raced in
-    // during the network call stays for the next flush.
-    const sent = new Set(outbox.map((i) => i.intentId));
-    const remaining = readJson(OUTBOX_KEY, []).filter((i) => !sent.has(i.intentId));
-    writeJson(OUTBOX_KEY, remaining);
-    return remaining.length === 0;
+    return readJson(OUTBOX_KEY, []).length === 0;
   } catch {
     // Rate-limited (the client armed on a real 429; a braked retry throws
     // before the wire) or unreachable — queued intents survive either way.

--- a/src/utils/obsidianBridgeStream.test.js
+++ b/src/utils/obsidianBridgeStream.test.js
@@ -336,6 +336,97 @@ describe('the bridge brake (429 backoff)', () => {
   });
 });
 
+describe('AUDIT FIX M2 — the outbox never silently unbooks, and big backlogs drain in chunks', () => {
+  // Entries shaped exactly as emitBridgeIntent persists them.
+  const seedOutbox = (n) => {
+    const entries = Array.from({ length: n }, (_, i) => ({
+      v: 1, kind: 'intent', type: 'daily_note_write', intentId: `int-seed-${i}`,
+      createdAt: '2026-09-01T00:00:00.000Z', path: `${i}.md`, content: `c${i}`,
+    }));
+    localStorage.setItem(OUTBOX_KEY, JSON.stringify(entries));
+    return entries;
+  };
+
+  it('THE CAP PIN: a full outbox refuses the NEWEST emit and keeps the oldest — no shift, no silent unbooking', async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 500, json: async () => ({}) }); // flush can't drain
+    seedOutbox(500);
+    expect(emitBridgeIntent('daily_note_write', { path: 'new.md', content: 'z' })).toBe(false);
+    await new Promise((r) => setTimeout(r, 0));
+    const outbox = JSON.parse(localStorage.getItem(OUTBOX_KEY));
+    expect(outbox).toHaveLength(500);
+    // The oldest booked entry is STILL THERE (the pre-fix shape shifted it
+    // out and reported the new emit as queued).
+    expect(outbox[0].intentId).toBe('int-seed-0');
+    expect(outbox.some((i) => i.path === 'new.md')).toBe(false);
+  });
+
+  it('one below the cap still queues (contrast)', async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 500, json: async () => ({}) });
+    seedOutbox(499);
+    expect(emitBridgeIntent('daily_note_write', { path: 'new.md', content: 'z' })).toBe(true);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(JSON.parse(localStorage.getItem(OUTBOX_KEY))).toHaveLength(500);
+  });
+
+  it('a 120-entry backlog drains as 50/50/20 chunks, oldest first, and the queue empties', async () => {
+    globalThis.fetch = makeFetch();
+    seedOutbox(120);
+    expect(await flushBridgeOutbox()).toBe(true);
+    const sizes = globalThis.fetch.batches.map((b) => b.rows.length);
+    expect(sizes).toEqual([50, 50, 20]);
+    expect(globalThis.fetch.batches[0].rows[0].entityId).toBe('int:int-seed-0');
+    expect(JSON.parse(localStorage.getItem(OUTBOX_KEY))).toHaveLength(0);
+  });
+
+  it('THE PARTIAL-FAILURE PIN: a failure on chunk 2 keeps chunk 1 flushed and retries ONLY the unsent tail', async () => {
+    let calls = 0;
+    const batches = [];
+    globalThis.fetch = async (url, init = {}) => {
+      if (url.includes('/sync/dayglance-bridge/batch')) {
+        calls += 1;
+        if (calls === 2) return { ok: false, status: 500, json: async () => ({}) };
+        batches.push(JSON.parse(init.body));
+        return { ok: true, status: 200, json: async () => ({ written: 1, maxSeq: calls }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    };
+    seedOutbox(120);
+    expect(await flushBridgeOutbox()).toBe(false);
+    // First chunk's 50 are gone for good; the failed chunk and the tail stay.
+    let remaining = JSON.parse(localStorage.getItem(OUTBOX_KEY));
+    expect(remaining).toHaveLength(70);
+    expect(remaining[0].intentId).toBe('int-seed-50');
+    // The pre-fix all-or-nothing shape would now retry all 120 as one
+    // request; the retry sends exactly the 70 left, in two chunks.
+    expect(await flushBridgeOutbox()).toBe(true);
+    expect(batches.map((b) => b.rows.length)).toEqual([50, 50, 20]);
+    expect(JSON.parse(localStorage.getItem(OUTBOX_KEY))).toHaveLength(0);
+  });
+
+  it('an emit racing in during the flush survives it untouched', async () => {
+    let injected = false;
+    globalThis.fetch = async (url, init = {}) => {
+      if (url.includes('/sync/dayglance-bridge/batch')) {
+        if (!injected) {
+          injected = true;
+          // Simulate a concurrent emit landing while the request is in flight.
+          const raced = JSON.parse(localStorage.getItem(OUTBOX_KEY));
+          raced.push({ v: 1, kind: 'intent', type: 'daily_note_write', intentId: 'int-raced', createdAt: '2026-09-01T00:00:01.000Z', path: 'raced.md', content: 'r' });
+          localStorage.setItem(OUTBOX_KEY, JSON.stringify(raced));
+        }
+        JSON.parse(init.body);
+        return { ok: true, status: 200, json: async () => ({ written: 1, maxSeq: 1 }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    };
+    seedOutbox(60);
+    // Not empty after the attempt (the raced entry remains) → false.
+    expect(await flushBridgeOutbox()).toBe(false);
+    const remaining = JSON.parse(localStorage.getItem(OUTBOX_KEY));
+    expect(remaining.map((i) => i.intentId)).toEqual(['int-raced']);
+  });
+});
+
 describe('round trip with the plugin-side seal', () => {
   it('a row the plugin seals under the imported subkey opens on the app side (both directions, one wire format)', async () => {
     const subkey = await deriveBridgeSubkey(getDbRootKey(), SALT);


### PR DESCRIPTION
## What

The M2 audit fix, landed as the precursor to the Phase 8 completion log (whose entries will ride this queue as a permanent record). Two defects in the bridge outbox (`src/utils/obsidianBridgeStream.js`):

**Cap head-drop.** A full outbox shifted the *oldest* entries out silently while reporting "queued" for the newest — unbooking writes whose identity moves were already committed on enqueue (the commit-on-enqueue rule). The cap is now a refusal threshold: a full outbox refuses the *newest* emit through the existing `false` = not-durably-queued contract, which authoritative callers already latch into a visible sync error. The unpaired-accretion concern the shift addressed is handled upstream by the pairing-meta gate on enqueue (an unpaired vault stops enqueueing within a cache TTL).

**All-or-nothing flush.** The entire backlog went out as one `batch` request: a backlog big enough for the server to reject could never flush at all (the same oversized request would fail forever), and a mid-request failure lost the whole attempt. The flush now drains oldest-first in 50-entry chunks, each removed from the persisted outbox as its ack lands, with the own-write seq recorded per chunk. A partial failure keeps every acked chunk's progress and retries only the unsent tail; a mid-drain 429 stops the loop instead of deepening the brake's escalation; emits racing in during a network call stay queued exactly as before (the loop walks a snapshot).

## Tests

Five new pins in `obsidianBridgeStream.test.js`:
- a full outbox refuses the newest emit and **keeps the oldest entry** (the pre-fix shape shifted it out),
- one-below-cap still queues (contrast),
- a 120-entry backlog drains as 50/50/20 chunks, oldest first, queue empty,
- a failure on chunk 2 keeps chunk 1 flushed and the retry sends **only the 70 remaining**,
- an emit racing in mid-flush survives untouched.

Full suite: **2703 passing / 200 files**. ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_