### PR TITLE
Completion log field-test fixes: project title lookup, timestamps on ProjectCard and voice completions

### DIFF
--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -17,7 +17,7 @@ import ProjectProgress from './ProjectProgress.jsx';
 import RecurringSeriesRow from './RecurringSeriesRow.jsx';
 import NotesSubtasksPanel from '../NotesSubtasksPanel.jsx';
 import { renderTitle, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, getLinkUrl, isObsidianNoteOnlyTask, openNoteAction, isPhoneOnlyTask } from '../../utils/textFormatting.jsx';
-import { dateToString, extractWikilinks } from '../../utils/taskUtils.js';
+import { dateToString, extractWikilinks, completionTimestamp } from '../../utils/taskUtils.js';
 import { getNextOccurrence } from '../../utils/recurrenceEngine.js';
 import { getActiveHGInstance } from '../../hooks/useHyperGlance.js';
 
@@ -70,13 +70,15 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
   const toggleTaskComplete = (taskId) => {
     const scheduled = tasks.find(t => t.id === taskId);
     if (scheduled) {
-      setTasks(prev => prev.map(t => t.id === taskId ? { ...t, completed: !t.completed } : t));
+      // completedAt matches toggleComplete's stamp (local-offset ISO) so the
+      // completion log carries a wall-clock time; the old shape stamped
+      // nothing here and a bare date below, which logged time-less entries.
+      setTasks(prev => prev.map(t => t.id === taskId ? { ...t, completed: !t.completed, completedAt: !t.completed ? completionTimestamp() : null } : t));
       return;
     }
     // Unscheduled: toggle + reorder within project
-    const todayStr = dateToString(new Date());
     setUnscheduledTasks(prev => {
-      const updated = prev.map(t => t.id === taskId ? { ...t, completed: !t.completed, completedAt: !t.completed ? todayStr : null } : t);
+      const updated = prev.map(t => t.id === taskId ? { ...t, completed: !t.completed, completedAt: !t.completed ? completionTimestamp() : null } : t);
       const nowComplete = updated.find(t => t.id === taskId)?.completed;
       const others = updated.filter(t => !(t.projectId === project.id && t.id === taskId));
       const moved = updated.find(t => t.id === taskId);

--- a/src/hooks/useCompletionLog.js
+++ b/src/hooks/useCompletionLog.js
@@ -97,8 +97,10 @@ export function buildCompletionLogWrite(candidate, { projects, obsidianConfig, d
     title: candidate.title,
     completedAt: candidate.completedAt,
     fallbackDate: bucket,
+    // Projects carry their display name in `title` (every UI surface renders
+    // project.title; `name` is the AREA shape's field).
     projectName: candidate.projectId
-      ? (projects || []).find((p) => p.id === candidate.projectId)?.name ?? null
+      ? (projects || []).find((p) => p.id === candidate.projectId)?.title ?? null
       : null,
     priority: candidate.priority,
     deadline: candidate.deadline,

--- a/src/hooks/useCompletionLog.test.js
+++ b/src/hooks/useCompletionLog.test.js
@@ -128,7 +128,10 @@ describe('buildCompletionLogWrite (pure)', () => {
     const write = buildCompletionLogWrite(
       { title: 'Ship it #dev', completedAt: '2026-09-02T18:05:00-05:00', projectId: 'p1', priority: 2, deadline: null, recurring: false, bucketOverride: null },
       {
-        projects: [{ id: 'p1', name: 'Acme migration' }],
+        // Projects carry their display name in `title` (17 UI sites render
+        // project.title; `name` is the AREA field) — the field-test bug was
+        // this fixture and the lookup agreeing on the WRONG field.
+        projects: [{ id: 'p1', title: 'Acme migration', name: 'wrong-field decoy' }],
         obsidianConfig: { ...CFG, dailyNotePattern: 'dd.MM.yyyy' },
         dailyNoteTemplate: '# Day\n', localToday: '2026-09-03',
       },

--- a/src/hooks/useVoiceInput.js
+++ b/src/hooks/useVoiceInput.js
@@ -5,7 +5,7 @@ import {
   nativeStartRecording, nativeStopRecording, triggerHaptic,
   nativeSupportsSpeech, nativeStartSpeech, nativeStopSpeech, nativeCancelSpeech,
 } from '../native.js';
-import { dateToString } from '../utils/taskUtils.js';
+import { dateToString, completionTimestamp } from '../utils/taskUtils.js';
 import { notBucketed } from '../utils/bucketList.js';
 import { parseTranscriptTasks } from '../utils/voiceQuickAdd.js';
 
@@ -523,13 +523,16 @@ export default function useVoiceInput({
           }
           case 'complete': {
             const setter = isInbox ? setUnscheduledTasks : setTasks;
-            setter(prev => prev.map(t => t.id === id ? { ...t, completed: true, lastModified: new Date().toISOString(), transitionId: crypto.randomUUID() } : t));
+            // completedAt matches toggleComplete's stamp: local-offset ISO,
+            // so the completion log gets a wall-clock time and the Obsidian
+            // completion marker gets its date.
+            setter(prev => prev.map(t => t.id === id ? { ...t, completed: true, completedAt: completionTimestamp(), lastModified: new Date().toISOString(), transitionId: crypto.randomUUID() } : t));
             triggerHaptic('success');
             break;
           }
           case 'uncomplete': {
             const setter = isInbox ? setUnscheduledTasks : setTasks;
-            setter(prev => prev.map(t => t.id === id ? { ...t, completed: false, lastModified: new Date().toISOString(), transitionId: crypto.randomUUID() } : t));
+            setter(prev => prev.map(t => t.id === id ? { ...t, completed: false, completedAt: null, lastModified: new Date().toISOString(), transitionId: crypto.randomUUID() } : t));
             break;
           }
           case 'changePriority': {


### PR DESCRIPTION
## What

Two findings from the completion log's first field-tested day, both surfaced by one entry (a project task completed from its project card, logged with no project and no time).

## How

- **Missing project name**: projects carry their display name in **`title`** (17 UI sites render `project.title`; `name` belongs to the Area shape), but `buildCompletionLogWrite` looked up `.name` — and the test fixture repeated the same wrong field, so the pin passed against a shape that doesn't exist in the app. The lookup now reads `.title`, and the fixture carries a `name: 'wrong-field decoy'` so the pin fails if the lookup ever reverts.
- **Missing time**: not a formatter bug — the ProjectCard completion path stamped `completedAt` as a **bare date** on unscheduled tasks and **nothing** on scheduled ones, so the entry faithfully rendered a timestamp that was never recorded. Both ProjectCard branches now stamp `completionTimestamp()` on complete (null on uncomplete), matching `toggleComplete`. The voice completion path had the same gap and gets the same one-line alignment.
- Intended side effect: ProjectCard and voice completions of Obsidian tasks now carry the timestamp Phase 4's completion markers derive from, same as every other completion surface.

## Tests

The hook test's project fixture is corrected to the real shape (with the decoy field); full suite **2724 passing / 202 files**, ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_