### PR TITLE
Completion log: hold on remote applies and missing routes, never consume

### DIFF
--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -215,12 +215,29 @@ heading **configurable, default `## Completed`** (stored in the device-local
 direct-access users** (one shared formatter and applier; the direct routes
 apply the same `completion_log_append` intent shape locally); and **every
 single completion logs** — local, vault-originated (the device whose sync
-first applies the flip logs it; engine echoes on other devices are
-suppressed by the remote-apply guard), and recurring instances
+first applies the flip logs it), and recurring instances
 (`[recurring:: true]`, bucketed to the instance date). Transitions that
 happen while the log is disabled are consumed silently, never retro-logged
 on enable. M2 (the outbox cap and all-or-nothing flush) was fixed first, as
 the precursor the queue story depends on.
+
+**Hold, never consume (field correction, 2026-09-01).** The first build
+copied the notify emitters' echo semantics: a render under the engine's
+remote-apply flag consumed the whole snapshot diff, and the enabled gate
+included the vault handle, consuming edges while the handle was still
+restoring after launch. The first fleet evening falsified both: a
+cross-list delete/resupply war kept the remote-apply flag up in wide
+windows and silently swallowed local completions made inside them (the
+"nothing logs anymore" incident). The corrected detector distinguishes the
+user's intent from transient conditions — only *log disabled* consumes;
+a remote apply in progress and *no write route yet* (handle restoring,
+or a plugin-authoritative device with no local handle, whose emit route
+needs none) HOLD the snapshot, so the edge logs on the next viable render.
+Consequence, accepted deliberately: completions arriving from other devices
+now log on whichever enabled device sees them first, which is what the
+every-single-completion ruling wants (the completing device may have the
+log toggle off); double-writes collapse because entries are deterministic
+and the applier's landed-check scans the whole note, not just the section.
 
 **Offline failure.** v1 recommended failing silently with a status indicator.
 Phase 3 built real failure surfacing (latched sync-error state, named causes,

--- a/src/hooks/useCompletionLog.js
+++ b/src/hooks/useCompletionLog.js
@@ -23,12 +23,13 @@ import { isTrayMode } from '../utils/trayMode.js';
 //   merge): the device whose sync cycle first applies the flip observes it —
 //   those merges do not run under the engine's remote-apply flag, on
 //   purpose: SOME device must log them.
-// - Engine echoes (another device completed it, the change arrives via DB
-//   sync): suppressed by the remote-apply guard — the completing device
-//   already logged, and the entry rides the vault, not the DB.
-//   Residual: two devices independently observing the same vault-originated
-//   flip format the same deterministic entry, and the apply-side exact-line
-//   dedupe collapses them.
+// - Engine applies (a pull/merge is mutating task state): the diff is
+//   DEFERRED to the next quiet render, never consumed — see the hold note
+//   in planCompletionLog. Completions arriving from other devices then log
+//   here too, which is what ruling 4 wants (the completing device may have
+//   the log toggle off); a device that already logged the same completion
+//   is a no-op, because entries are deterministic and the applier's
+//   landed-check scans the whole note.
 // - Recurring instances (completedDates on the template): logged with
 //   [recurring:: true], bucketed to the INSTANCE date (the semantic
 //   completion date), timed by completedDatesTimestamps when present.
@@ -59,7 +60,23 @@ export function snapshotCompletionState(tasks, unscheduledTasks, recurringTasks)
 export function planCompletionLog(prev, next, { tasks, unscheduledTasks, recurringTasks, isRemoteApply = false, enabled = true, inFlight = false } = {}) {
   if (prev === null) return { candidates: [], advanceTo: next };
   if (inFlight) return { candidates: [], advanceTo: null };
-  if (isRemoteApply || !enabled) return { candidates: [], advanceTo: next };
+  // A remote apply HOLDS the snapshot — it must never CONSUME it. The first
+  // shape copied the notify emitter's consume semantics, and the 2026-09-01
+  // field test showed why that's wrong for a permanent record: during a
+  // cross-list delete/resupply war the engine applies fire continuously, the
+  // remote-apply flag is up in wide windows, and LOCAL completions landing
+  // inside those windows were swallowed forever (a global veto eats the
+  // whole diff, not just the remote half). Holding defers the diff to the
+  // next quiet render: local edges log late instead of never, and
+  // remote-arrived completions log too — which ruling 4 (every single
+  // completion) wants, since the completing device may have the log toggle
+  // off. Double-logging collapses in the applier: entries are deterministic
+  // when completedAt is present, and the landed-check scans the WHOLE note,
+  // so a second writer's identical line is a no-op wherever its heading is.
+  if (isRemoteApply) return { candidates: [], advanceTo: null };
+  // Disabled stays CONSUME, deliberately: transitions made while the user
+  // has the log off are never retro-logged on enable.
+  if (!enabled) return { candidates: [], advanceTo: next };
 
   const candidates = [];
   for (const t of [...(tasks || []), ...(unscheduledTasks || [])]) {
@@ -127,13 +144,21 @@ export default function useCompletionLog({
 }) {
   const prevRef = useRef(null);
   const inFlightRef = useRef(false);
+  const holdLoggedRef = useRef(false);
   const [, bump] = useReducer((x) => x + 1, 0);
 
   useEffect(() => {
     if (isTrayMode) return;
-    const enabled = !!(obsidianConfig?.enabled
-      && obsidianConfig?.completionLogEnabled
-      && obsidianVaultHandleRef.current);
+    // The ENABLED gate is the user's intent only (Obsidian on + log on).
+    // The vault handle is NOT part of it — the first shape gated on the
+    // handle too, which silently consumed every completion made while the
+    // handle was still restoring after launch, and would consume forever on
+    // plugin-authoritative devices with no local handle at all (the emit
+    // route needs none). Route availability is a HOLD below, never a
+    // consume.
+    const enabled = !!(obsidianConfig?.enabled && obsidianConfig?.completionLogEnabled);
+    const authoritative = !!bridgeHeartbeatRef?.current?.pluginAuthoritative;
+    const routeAvailable = authoritative || !!obsidianVaultHandleRef.current;
 
     const nextSnap = snapshotCompletionState(tasks, unscheduledTasks, recurringTasks);
     const { candidates, advanceTo } = planCompletionLog(prevRef.current, nextSnap, {
@@ -147,6 +172,20 @@ export default function useCompletionLog({
       if (advanceTo !== null) prevRef.current = advanceTo;
       return;
     }
+
+    if (!routeAvailable) {
+      // No way to write yet (vault handle restoring, pairing not
+      // authoritative): HOLD the snapshot so the edge stays in the diff and
+      // logs as soon as a route exists. Entries are deterministic, so the
+      // late write is byte-identical to what an on-time write would have
+      // been.
+      if (!holdLoggedRef.current) {
+        holdLoggedRef.current = true;
+        console.info(`[Obsidian] Completion log: ${candidates.length} completion(s) waiting for vault access.`);
+      }
+      return;
+    }
+    holdLoggedRef.current = false;
 
     inFlightRef.current = true;
     const fire = async () => {

--- a/src/hooks/useCompletionLog.test.js
+++ b/src/hooks/useCompletionLog.test.js
@@ -79,12 +79,20 @@ describe('planCompletionLog (pure)', () => {
     expect(candidates[0]).toMatchObject({ title: 'A', completedAt: '2026-09-02T10:00:00-05:00', recurring: false });
   });
 
-  it('THE ECHO GUARD: a remote apply consumes the edge silently — the completing device already logged', () => {
+  it('THE APPLY HOLD (2026-09-01 field fix): a remote apply DEFERS the diff — the edge logs on the next quiet render, never silently dies', () => {
+    // The first shape consumed the snapshot on isRemoteApply, and a
+    // cross-list delete/resupply war (applies firing continuously) swallowed
+    // LOCAL completions landing in the apply windows — the field-test
+    // "nothing logs anymore" incident. A hold keeps the edge in the diff.
     const prev = snap([{ id: 'a', completed: false }]);
-    const tasks = [{ id: 'a', completed: true, title: 'A' }];
+    const tasks = [{ id: 'a', completed: true, title: 'A', completedAt: '2026-09-01T19:50:03-06:00' }];
     const next = snap(tasks);
-    const out = planCompletionLog(prev, next, { tasks, isRemoteApply: true });
-    expect(out).toEqual({ candidates: [], advanceTo: next });
+    expect(planCompletionLog(prev, next, { tasks, isRemoteApply: true }))
+      .toEqual({ candidates: [], advanceTo: null });
+    // Quiet render: same prev (held), edge still there → logs.
+    const { candidates } = planCompletionLog(prev, next, { tasks, isRemoteApply: false });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({ title: 'A' });
   });
 
   it('disabled consumption is silent too: transitions while the log is off are never retro-logged on enable', () => {
@@ -197,6 +205,35 @@ describe('the hook glue', () => {
     await flush();
     expect(props.setObsidianSyncError).toHaveBeenCalledWith(expect.stringContaining('was not logged'));
     expect(props.setObsidianSyncStatus).toHaveBeenCalledWith('error');
+    expect(writeDailyNoteFile).not.toHaveBeenCalled();
+  });
+
+  it('NO ROUTE HOLDS (2026-09-01 field fix): a completion made while the vault handle is restoring logs when it arrives, never silently dies', async () => {
+    readDailyNoteFresh.mockResolvedValue({ text: '# Day\n' });
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const noRoute = (tasks) => baseProps(tasks, { obsidianVaultHandleRef: { current: null } });
+    useRenderedHook(noRoute([{ id: 'a', completed: false, title: 'A' }]));
+    // Completion lands while the handle is still null (post-launch restore).
+    useRenderedHook(noRoute([{ id: 'a', completed: true, title: 'A', completedAt: '2026-09-02T10:00:00-05:00' }]));
+    await flush();
+    expect(emitBridgeIntent).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('waiting for vault access'));
+    // The handle restores on a later render: the HELD edge logs now.
+    useRenderedHook(baseProps([{ id: 'a', completed: true, title: 'A', completedAt: '2026-09-02T10:00:00-05:00' }]));
+    await flush();
+    expect(emitBridgeIntent).toHaveBeenCalledTimes(1);
+    expect(emitBridgeIntent.mock.calls[0][1].entry).toContain('10:00 A');
+  });
+
+  it('plugin-authoritative with NO local handle still logs — the emit route needs none (the iOS/plugin-only shape)', async () => {
+    const props = (tasks) => baseProps(tasks, {
+      obsidianVaultHandleRef: { current: null },
+      bridgeHeartbeatRef: { current: { pluginAuthoritative: true } },
+    });
+    useRenderedHook(props([{ id: 'a', completed: false, title: 'A' }]));
+    useRenderedHook(props([{ id: 'a', completed: true, title: 'A', completedAt: '2026-09-02T10:00:00-05:00' }]));
+    await flush();
+    expect(emitBridgeIntent).toHaveBeenCalledTimes(1);
     expect(writeDailyNoteFile).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What

Root cause and fix for the "nothing logs anymore" field incident. The console showed a cross-list delete/resupply war (`obsidian-dg-y0bm31lo`) keeping the engine's remote-apply flag up in wide windows — and the detector, which copied the notify emitters' echo semantics, **consumed the entire snapshot diff on any remote-apply render**. Local completions landing inside those windows were swallowed forever. That one veto explains the missed recurring completion and both missed project completions.

## How

Two consume-where-it-should-hold fixes in `useCompletionLog`:

- **Remote apply → HOLD.** The planner defers the diff (`advanceTo: null`, like in-flight) instead of consuming it, so held edges log on the next quiet render — late, never lost. Deliberate consequence, recorded in the spec: completions arriving *from* other devices now log on whichever enabled device sees them first, which is what the every-single-completion ruling wants (the completing device may have the log toggle off). Double-writes collapse because entries are deterministic and the applier's landed-check scans the whole note, not just the heading's section.
- **Missing route → HOLD.** The enabled gate no longer includes the vault handle (the old gate silently consumed every completion made while the handle was still restoring after launch, and would consume forever on a plugin-authoritative device with no local handle — the emit route needs none). Enabled is now the user's intent only (Obsidian on + log on); no-route holds with a once-per-streak `console.info` ("waiting for vault access") so the state is field-diagnosable.

Only "log disabled" still consumes, deliberately — no retro-logging on enable. Spec §4.1 gains the field-correction record ("Hold, never consume").

Note: the war itself (`obsidian-dg-y0bm31lo` cross-list delete/resupply, war guard engaged and braking) is a separate pre-existing issue this PR does not touch.

## Tests

The echo-guard pin becomes the apply-hold pin (hold, then the held edge logs on the quiet render); two new glue pins: the route hold releases when the handle arrives (identical entry), and authoritative-without-handle emits via the intent route alone. Full suite **2726 passing / 202 files**, ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_