### PR TITLE
Sidebar: faded tags, clickable wikilinks, routines strip under the agenda

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -33,7 +33,10 @@ manually or via BRAT, not submitted to the community directory.
   edit; that is dayGLANCE's scan pipeline's job.
 - **Agenda sidebar** (companion spec 4.2): a right-sidebar view — mini
   month calendar over the selected day's agenda (scheduled tasks, recurring
-  instances, imported calendar events; ±35 days around today; no inbox).
+  instances, imported calendar events; ±35 days around today; no inbox),
+  with the day's placed routines as a pill strip underneath (name and start
+  time). Tags in titles render faded; `[[wikilinks]]` render as their display
+  text and click through to the note.
   It reads the account's task rows directly from GLANCEvault: enter your
   dayGLANCE **sync passphrase** once per device in the settings tab's
   "dayGLANCE account" section. The derived root key is kept in the plugin's

--- a/dayglance-obsidian-plugin/src/agenda.ts
+++ b/dayglance-obsidian-plugin/src/agenda.ts
@@ -37,7 +37,7 @@ import {
   BRIDGE_VAULT_APP,
   BRIDGE_ACTION_PREFIX,
 } from '@glance-apps/obsidian-format';
-import { buildAgenda, type AgendaItem } from '@glance-apps/agenda-core';
+import { buildAgenda, routinesForDate, type AgendaItem, type RoutineItem } from '@glance-apps/agenda-core';
 import { createVaultClient, type VaultClient } from '@glance-apps/sync/src/vaultClient.js';
 import {
   setupDbRootKey,
@@ -57,8 +57,12 @@ const DAYGLANCE_APP = 'dayglance';
 const CRYPTO_DB_NAME = 'dayglance-bridge';
 // Row kinds the agenda reads. The inbox (unscheduledTasks) is deliberately
 // absent — the v1 scope ruling. entityIds are `${kind}:${id}` (dbAdapter's
-// scheme), so the kind is readable before decryption.
-const AGENDA_KINDS = new Set(['tasks', 'recurringTasks']);
+// scheme), so the kind is readable before decryption. Routines are the
+// day's placed chips (todayRoutines) plus two singletons: the day they were
+// placed for and the day's completions.
+const AGENDA_KINDS = new Set(['tasks', 'recurringTasks', 'todayRoutines']);
+const SINGLETON_KIND = 'singleton';
+const AGENDA_SINGLETONS = new Set(['routinesDate', 'routineCompletions']);
 // Optimistic completion marks time out: dayGLANCE applies an action within
 // one poll (5 min) once it runs, and a mark older than this with no mirror
 // change behind it means nothing is consuming — show the box unchecked
@@ -121,6 +125,8 @@ export class AgendaStore {
   private host: AgendaHost;
   private tasks = new Map<string, TaskRow>();
   private recurring = new Map<string, TaskRow>();
+  private routines = new Map<string, TaskRow>();
+  private singletons = new Map<string, unknown>();
   private cursor = 0;
   private cursorAccount: string | null = null;
   private status: AgendaStatus = { key: 'unpaired', refreshing: false, lastRefreshedAt: null, lastError: null, undecryptable: 0 };
@@ -166,6 +172,15 @@ export class AgendaStore {
     if (at === undefined) return false;
     if (Date.now() - at > PENDING_TTL_MS) { this.pending.delete(id); return false; }
     return true;
+  }
+
+  /** The routines placed for a day (only the day dayGLANCE stamped; see agenda-core). */
+  routinesFor(dateStr: string): RoutineItem[] {
+    return routinesForDate({
+      todayRoutines: [...this.routines.values()],
+      routinesDate: this.singletons.get('routinesDate') as string | null | undefined,
+      routineCompletions: this.singletons.get('routineCompletions') as Record<string, string> | undefined,
+    }, dateStr);
   }
 
   /** The agenda for an inclusive YYYY-MM-DD window, from the mirror. */
@@ -258,16 +273,20 @@ export class AgendaStore {
           if (!entityId || isReservedEntityId(entityId)) continue;
           const colon = entityId.indexOf(':');
           const kind = colon < 0 ? '' : entityId.slice(0, colon);
-          if (!AGENDA_KINDS.has(kind)) continue;
-          const map = kind === 'tasks' ? this.tasks : this.recurring;
+          const key = entityId.slice(colon + 1);
+          const map = kind === SINGLETON_KIND
+            ? (AGENDA_SINGLETONS.has(key) ? this.singletons : null)
+            : (AGENDA_KINDS.has(kind) ? this.mapFor(kind) : null);
+          if (!map) continue;
+          const mapKey = kind === SINGLETON_KIND ? key : entityId;
           if (row.deleted || !row.envelope) {
-            if (map.delete(entityId)) changed = true;
+            if (map.delete(mapKey)) changed = true;
             continue;
           }
           const value = await this.decryptRow(row.envelope, entityId, kind);
           if (value === undefined) { undecryptable += 1; continue; }
           if (value === null) continue;
-          map.set(entityId, value);
+          map.set(mapKey, value as TaskRow);
           changed = true;
         }
       }
@@ -284,16 +303,23 @@ export class AgendaStore {
     }
   }
 
+  private mapFor(kind: string): Map<string, TaskRow> {
+    return kind === 'tasks' ? this.tasks : kind === 'recurringTasks' ? this.recurring : this.routines;
+  }
+
   // undefined = undecryptable under this key; null = decryptable but not a
-  // row of the expected kind (never routed); otherwise the task value.
-  private async decryptRow(envelope: string, entityId: string, kind: string): Promise<TaskRow | null | undefined> {
+  // row of the expected kind (never routed); otherwise the entity's value
+  // (a task/chip object for collections, the bare value for singletons).
+  private async decryptRow(envelope: string, entityId: string, kind: string): Promise<unknown | null | undefined> {
     let entity: unknown;
     try { entity = await decryptEntity(envelope, entityId); }
     catch { return undefined; }
     if (!entity || typeof entity !== 'object') return null;
     const wrapped = entity as { _kind?: unknown; value?: unknown };
-    if (wrapped._kind !== kind || !wrapped.value || typeof wrapped.value !== 'object') return null;
-    return wrapped.value as TaskRow;
+    if (wrapped._kind !== kind) return null;
+    if (kind === SINGLETON_KIND) return wrapped.value ?? null;
+    if (!wrapped.value || typeof wrapped.value !== 'object') return null;
+    return wrapped.value;
   }
 
   // Drop optimistic marks the mirror has caught up with, and expired ones.
@@ -375,6 +401,8 @@ export class AgendaStore {
   private resetMirror(accountId: string | null = null): void {
     this.tasks.clear();
     this.recurring.clear();
+    this.routines.clear();
+    this.singletons.clear();
     this.pending.clear();
     this.cursor = 0;
     this.cursorAccount = accountId;

--- a/dayglance-obsidian-plugin/src/agendaView.ts
+++ b/dayglance-obsidian-plugin/src/agendaView.ts
@@ -9,8 +9,8 @@
 // here (no styles.css to ship) and lean entirely on Obsidian's theme
 // variables so the view follows the user's theme.
 
-import { ItemView, Notice, WorkspaceLeaf } from 'obsidian';
-import { datesWithItems, localDateStr, shiftDateStr, weekdayOrder, type AgendaItem } from '@glance-apps/agenda-core';
+import { ItemView, Keymap, Notice, WorkspaceLeaf } from 'obsidian';
+import { datesWithItems, localDateStr, shiftDateStr, splitTitle, weekdayOrder, type AgendaItem, type RoutineItem } from '@glance-apps/agenda-core';
 import type { AgendaStore } from './agenda';
 
 export const AGENDA_VIEW_TYPE = 'dayglance-agenda';
@@ -46,6 +46,17 @@ const CSS = `
 .dg-agenda-time { color: var(--text-muted); font-size: var(--font-ui-smaller); font-variant-numeric: tabular-nums; }
 .dg-agenda-title { overflow-wrap: anywhere; }
 .dg-agenda-badge { color: var(--text-faint); font-size: var(--font-ui-smaller); margin-left: 4px; }
+.dg-agenda-tag { color: var(--text-faint); font-style: italic; }
+.dg-agenda-link { color: var(--link-color); text-decoration: none; cursor: pointer; }
+.dg-agenda-link:hover { text-decoration: underline; }
+.dg-agenda-routines-heading { color: var(--text-faint); font-size: var(--font-ui-smaller); text-transform: uppercase; letter-spacing: 0.06em; margin: 12px 2px 4px; }
+.dg-agenda-routines { display: flex; flex-wrap: wrap; gap: 4px 6px; margin: 0; padding: 0; list-style: none; }
+.dg-agenda-routine { display: inline-flex; align-items: center; gap: 6px; padding: 2px 10px 2px 8px; border-radius: 999px; background: var(--background-secondary-alt); border: 1px solid var(--background-modifier-border); color: var(--text-muted); font-size: var(--font-ui-smaller); max-width: 100%; }
+.dg-agenda-routine-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-accent); flex: 0 0 auto; opacity: 0.7; }
+.dg-agenda-routine-time { font-variant-numeric: tabular-nums; color: var(--text-faint); }
+.dg-agenda-routine-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dg-agenda-routine.is-done { opacity: 0.55; }
+.dg-agenda-routine.is-done .dg-agenda-routine-name { text-decoration: line-through; }
 .dg-agenda-swatch { flex: 0 0 4px; width: 4px; align-self: stretch; border-radius: 2px; }
 .dg-agenda-empty { color: var(--text-muted); padding: 8px 2px; }
 .dg-agenda-status { color: var(--text-faint); font-size: var(--font-ui-smaller); margin-top: 10px; padding-top: 6px; border-top: 1px solid var(--background-modifier-border); }
@@ -231,8 +242,12 @@ export class AgendaView extends ItemView {
     }
     if (!items.length) {
       root.createDiv({ cls: 'dg-agenda-empty', text: 'Nothing scheduled.' });
-      return;
     }
+    if (items.length) this.renderItems(root, items);
+    this.renderRoutines(root, this.store.routinesFor(this.selected));
+  }
+
+  private renderItems(root: HTMLElement, items: AgendaItem[]): void {
     const list = root.createEl('ul', { cls: 'dg-agenda-list' });
     for (const item of items) {
       const pending = !item.completed && this.store.isPending(item.id);
@@ -262,9 +277,43 @@ export class AgendaView extends ItemView {
         const end = item.duration ? endOf(item.startTime, item.duration) : null;
         body.createSpan({ cls: 'dg-agenda-time', text: end ? `${formatTime(item.startTime)} to ${end}` : formatTime(item.startTime) });
       }
-      const title = body.createSpan({ cls: 'dg-agenda-title', text: item.title });
+      const title = body.createSpan({ cls: 'dg-agenda-title' });
+      this.renderTitle(title, item.title);
       if (item.recurring) title.createSpan({ cls: 'dg-agenda-badge', text: '↻', attr: { title: 'Recurring' } });
       if (item.imported) title.createSpan({ cls: 'dg-agenda-badge', text: '📅', attr: { title: 'Imported calendar event' } });
+    }
+  }
+
+  // Tags faded and italic; wikilinks shown as their display text and
+  // clickable (mod-click opens in a new leaf, like Obsidian's own links).
+  private renderTitle(el: HTMLElement, title: string): void {
+    for (const seg of splitTitle(title)) {
+      if (seg.type === 'text') { el.appendText(seg.text); continue; }
+      if (seg.type === 'tag') { el.createSpan({ cls: 'dg-agenda-tag', text: seg.text }); continue; }
+      const a = el.createEl('a', { cls: 'dg-agenda-link', text: seg.text, attr: { 'aria-label': `Open ${seg.target}` } });
+      a.addEventListener('click', (evt) => {
+        evt.preventDefault();
+        evt.stopPropagation();
+        void this.app.workspace.openLinkText(seg.target, '', Keymap.isModEvent(evt));
+      });
+    }
+  }
+
+  // The day's placed routines, visually a different species from tasks: a
+  // strip of pills (no checkbox, no swatch), name and start time only.
+  // Routines are day-scoped in dayGLANCE (placed each morning, cleared at
+  // midnight), so only the stamped day ever has any.
+  private renderRoutines(root: HTMLElement, routines: RoutineItem[]): void {
+    if (!routines.length) return;
+    root.createDiv({ cls: 'dg-agenda-routines-heading', text: 'Routines' });
+    const list = root.createEl('ul', { cls: 'dg-agenda-routines' });
+    for (const r of routines) {
+      const li = list.createEl('li', { cls: 'dg-agenda-routine' });
+      if (r.completed) li.addClass('is-done');
+      li.createSpan({ cls: 'dg-agenda-routine-dot' });
+      if (r.startTime) li.createSpan({ cls: 'dg-agenda-routine-time', text: formatTime(r.startTime) });
+      li.createSpan({ cls: 'dg-agenda-routine-name', text: r.name });
+      li.setAttr('title', r.startTime ? `${r.name} at ${formatTime(r.startTime)}` : `${r.name} (any time)`);
     }
   }
 

--- a/packages/agenda-core/src/index.js
+++ b/packages/agenda-core/src/index.js
@@ -7,3 +7,5 @@
 // only — ownership policy stays in dayGLANCE.
 export * from './recurrence.js';
 export * from './agenda.js';
+export * from './routines.js';
+export * from './title.js';

--- a/packages/agenda-core/src/routines.js
+++ b/packages/agenda-core/src/routines.js
@@ -1,0 +1,48 @@
+// Routines for a day (companion spec 4.2, the sidebar's routine strip). Pure.
+//
+// dayGLANCE routines are DAY-SCOPED: each morning the user places chips from
+// the routine definitions onto today (`todayRoutines`, stamped by
+// `routinesDate`), and the midnight rollover clears them. There is no
+// projection for other days — a routine exists only once placed — so this
+// answers for exactly one date: the one `routinesDate` names (or, when that
+// singleton is absent, the local day each chip was last touched).
+// `routineCompletions` (id → YYYY-MM-DD) marks the day's completed ones.
+
+import { localDateStr } from './agenda.js';
+
+const chipDate = (chip) => {
+  const t = Date.parse(chip?.lastModified || '');
+  return Number.isFinite(t) ? localDateStr(new Date(t)) : null;
+};
+
+/**
+ * @param {{ todayRoutines?: object[], routinesDate?: string|null, routineCompletions?: Record<string,string> }} data
+ * @param {string} dateStr  YYYY-MM-DD
+ * @returns {object[]}  { id, name, startTime, duration, isAllDay, completed } sorted all-day first, then by time, then name
+ */
+export function routinesForDate(data, dateStr) {
+  const chips = Array.isArray(data?.todayRoutines) ? data.todayRoutines : [];
+  const stamped = typeof data?.routinesDate === 'string' && data.routinesDate;
+  if (stamped && stamped !== dateStr) return [];
+  const completions = data?.routineCompletions || {};
+  const out = [];
+  for (const r of chips) {
+    if (!r || r.id == null) continue;
+    if (!stamped && chipDate(r) !== dateStr) continue;
+    const startTime = r.isAllDay ? null : (r.startTime || null);
+    out.push({
+      id: String(r.id),
+      name: String(r.name ?? ''),
+      startTime,
+      duration: r.duration ?? null,
+      isAllDay: !startTime,
+      completed: completions[String(r.id)] === dateStr,
+    });
+  }
+  out.sort((a, b) => {
+    const ka = a.startTime || '', kb = b.startTime || '';
+    if (ka !== kb) return ka < kb ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  return out;
+}

--- a/packages/agenda-core/src/routines.test.js
+++ b/packages/agenda-core/src/routines.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { routinesForDate } from './routines.js';
+import { splitTitle } from './title.js';
+
+describe('routinesForDate', () => {
+  const chips = [
+    { id: 'b', name: 'Stretch', startTime: null, isAllDay: true, duration: 15, lastModified: '2026-09-02T13:00:00.000Z' },
+    { id: 'a', name: 'Coffee', startTime: '07:30', isAllDay: false, duration: 15, lastModified: '2026-09-02T13:00:00.000Z' },
+    { id: 'c', name: 'Journal', startTime: '07:00', isAllDay: false, duration: 10, lastModified: '2026-09-02T13:00:00.000Z' },
+  ];
+
+  it('answers only for the stamped routinesDate, all-day first then by time, with completions marked', () => {
+    const out = routinesForDate({ todayRoutines: chips, routinesDate: '2026-09-02', routineCompletions: { a: '2026-09-02', c: '2026-09-01' } }, '2026-09-02');
+    expect(out.map((r) => r.name)).toEqual(['Stretch', 'Journal', 'Coffee']);
+    expect(out.find((r) => r.id === 'a').completed).toBe(true);
+    expect(out.find((r) => r.id === 'c').completed).toBe(false); // yesterday's completion does not carry
+    expect(routinesForDate({ todayRoutines: chips, routinesDate: '2026-09-02' }, '2026-09-03')).toEqual([]);
+  });
+
+  it('without a routinesDate, falls back to the local day each chip was touched', () => {
+    const local = new Date(2026, 8, 2, 9, 0, 0).toISOString();
+    const out = routinesForDate({ todayRoutines: [{ id: 'x', name: 'Walk', startTime: '08:00', lastModified: local }] }, '2026-09-02');
+    expect(out).toHaveLength(1);
+    expect(routinesForDate({ todayRoutines: [{ id: 'x', name: 'Walk', startTime: '08:00', lastModified: local }] }, '2026-09-01')).toEqual([]);
+  });
+
+  it('treats a time-bearing chip flagged isAllDay as all-day (the app clears the time on unplace)', () => {
+    const out = routinesForDate({ todayRoutines: [{ id: 'x', name: 'Walk', startTime: '08:00', isAllDay: true, lastModified: '2026-09-02T13:00:00.000Z' }], routinesDate: '2026-09-02' }, '2026-09-02');
+    expect(out[0]).toMatchObject({ startTime: null, isAllDay: true });
+  });
+});
+
+describe('splitTitle', () => {
+  it('segments tags and wikilinks, keeping text verbatim and aliases as display text', () => {
+    expect(splitTitle('Call [[Alice Smith|Alice]] about #work/deep and #Q3-plan')).toEqual([
+      { type: 'text', text: 'Call ' },
+      { type: 'link', text: 'Alice', target: 'Alice Smith' },
+      { type: 'text', text: ' about ' },
+      { type: 'tag', text: '#work/deep', tag: 'work/deep' },
+      { type: 'text', text: ' and ' },
+      { type: 'tag', text: '#Q3-plan', tag: 'q3-plan' },
+    ]);
+  });
+
+  it('plain titles come back as one text segment; a bare link uses its target as text; #1 is not a tag', () => {
+    expect(splitTitle('Buy milk')).toEqual([{ type: 'text', text: 'Buy milk' }]);
+    expect(splitTitle('[[Weekly review]]')).toEqual([{ type: 'link', text: 'Weekly review', target: 'Weekly review' }]);
+    expect(splitTitle('Issue #1')).toEqual([{ type: 'text', text: 'Issue #1' }]);
+    expect(splitTitle('')).toEqual([]);
+  });
+});

--- a/packages/agenda-core/src/title.js
+++ b/packages/agenda-core/src/title.js
@@ -1,0 +1,35 @@
+// Title segmenting for display (companion spec 4.2). Pure.
+//
+// A task title carries two kinds of markup dayGLANCE's own cards render
+// specially: `#tags` (the app's extractTags alphabet: a letter, then
+// letters/digits/_/-//) and `[[wikilinks]]` (with an optional `|alias`).
+// The sidebar renders tags faded and wikilinks as their display text with
+// a click-through to the note, so it needs the title as segments rather
+// than a string. Nothing here decides what a tag or link MEANS.
+
+const TOKEN = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]|#(\p{L}[\p{L}\p{N}_/-]*)/gu;
+
+/**
+ * @param {string} title
+ * @returns {Array<{ type: 'text', text: string } | { type: 'tag', text: string, tag: string } | { type: 'link', text: string, target: string }>}
+ *   `text` is always what to display; `tag` is the bare tag (lowercased, the
+ *   app's key form); `target` is the note name a wikilink points at.
+ */
+export function splitTitle(title) {
+  const s = String(title ?? '');
+  const out = [];
+  let last = 0;
+  for (const m of s.matchAll(TOKEN)) {
+    const at = m.index ?? 0;
+    if (at > last) out.push({ type: 'text', text: s.slice(last, at) });
+    if (m[1] !== undefined) {
+      const target = m[1].trim();
+      out.push({ type: 'link', text: (m[2] ?? target).trim() || target, target });
+    } else {
+      out.push({ type: 'tag', text: m[0], tag: m[3].toLowerCase() });
+    }
+    last = at + m[0].length;
+  }
+  if (last < s.length) out.push({ type: 'text', text: s.slice(last) });
+  return out;
+}

--- a/packages/agenda-core/types/index.d.ts
+++ b/packages/agenda-core/types/index.d.ts
@@ -32,3 +32,22 @@ export function buildAgenda(
 export function datesWithItems(agenda: Record<string, AgendaItem[]>): Set<string>;
 export function localDateStr(date: Date): string;
 export function shiftDateStr(dateStr: string, days: number): string;
+
+export interface RoutineItem {
+  id: string;
+  name: string;
+  startTime: string | null;
+  duration: number | null;
+  isAllDay: boolean;
+  completed: boolean;
+}
+export function routinesForDate(
+  data: { todayRoutines?: unknown[]; routinesDate?: string | null; routineCompletions?: Record<string, string> },
+  dateStr: string,
+): RoutineItem[];
+
+export type TitleSegment =
+  | { type: 'text'; text: string }
+  | { type: 'tag'; text: string; tag: string }
+  | { type: 'link'; text: string; target: string };
+export function splitTitle(title: string): TitleSegment[];


### PR DESCRIPTION
## Summary

Follow-ups from the first field test of the agenda view (companion spec §4.2).

- **Tags** in task titles render faded and italic.
- **Wikilinks** are stripped to their display text (alias when present) and are clickable: click opens the note, mod-click opens it in a new leaf, via `workspace.openLinkText`.
- **Routines** appear under the task list as a pill strip, name and start time only (all-day chips show just the name), visually distinct from task rows (no checkbox, no swatch, rounded pills on the secondary background). Completed routines are dimmed and struck through.

## How routines are sourced

Routines are day-scoped in dayGLANCE: chips are placed each morning into `todayRoutines` and cleared at the midnight rollover, so there is no projection for other days. The store now mirrors `todayRoutines:` rows plus the `routinesDate` and `routineCompletions` singletons, and `routinesForDate` (new in `@glance-apps/agenda-core`) answers only for the day `routinesDate` stamps (falling back to each chip's local touch day when the singleton is absent). Other days simply show no routine strip.

## Code
- `packages/agenda-core/src/title.js`: `splitTitle` (tags use the app's `extractTags` alphabet; wikilinks with optional alias).
- `packages/agenda-core/src/routines.js`: `routinesForDate`. Tests for both; `.d.ts` updated.
- Plugin `agenda.ts`: `todayRoutines` kind + the two singletons in the mirror, `routinesFor(date)`.
- Plugin `agendaView.ts`: `renderTitle`, `renderRoutines`, CSS on Obsidian theme variables.
- README bullet updated.

## Verification
- Plugin `npm run build` clean.
- App lint clean; full suite 207 files / 2758 tests green (5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_