### PR TITLE
Sidebar: calendar events via a per-device projection row

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -35,7 +35,10 @@ manually or via BRAT, not submitted to the community directory.
   month calendar over the selected day's agenda (scheduled tasks, recurring
   instances, imported calendar events; ±35 days around today; no inbox),
   with the day's placed routines as a pill strip underneath (name and start
-  time). Tags in titles render faded; `[[wikilinks]]` render as their display
+  time). Read-only calendar events never sync, so each running dayGLANCE
+  publishes a projection of the ones it holds (`proj:calendar:<deviceId>`
+  rows on the bridge stream) and the sidebar unions them, freshest copy per
+  event; the footer notes when that view is over an hour old. Tags in titles render faded; `[[wikilinks]]` render as their display
   text and click through to the note.
   It reads the account's task rows directly from GLANCEvault: enter your
   dayGLANCE **sync passphrase** once per device in the settings tab's

--- a/dayglance-obsidian-plugin/src/agenda.ts
+++ b/dayglance-obsidian-plugin/src/agenda.ts
@@ -32,12 +32,17 @@ import type { App } from 'obsidian';
 import { requestUrl } from 'obsidian';
 import {
   sealBridgeEnvelope,
+  openBridgeEnvelope,
   importBridgeSubkey,
   mintIntentId,
   BRIDGE_VAULT_APP,
   BRIDGE_ACTION_PREFIX,
+  BRIDGE_PROJECTION_PREFIX,
 } from '@glance-apps/obsidian-format';
-import { buildAgenda, routinesForDate, type AgendaItem, type RoutineItem } from '@glance-apps/agenda-core';
+import {
+  buildAgenda, routinesForDate, mergeCalendarProjections,
+  type AgendaItem, type RoutineItem, type CalendarProjection,
+} from '@glance-apps/agenda-core';
 import { createVaultClient, type VaultClient } from '@glance-apps/sync/src/vaultClient.js';
 import {
   setupDbRootKey,
@@ -84,6 +89,8 @@ export interface AgendaStatus {
   lastError: string | null;
   /** Rows the account key could not decrypt on the last full pass (a passphrase mismatch symptom). */
   undecryptable: number;
+  /** Publish stamp (epoch ms) of the freshest calendar projection in use, or null when none. */
+  calendarAsOf: number | null;
 }
 
 interface TaskRow { id: string; [k: string]: unknown }
@@ -127,9 +134,16 @@ export class AgendaStore {
   private recurring = new Map<string, TaskRow>();
   private routines = new Map<string, TaskRow>();
   private singletons = new Map<string, unknown>();
+  // Calendar projections (companion 4.2): read-only calendar events never
+  // sync, so each dayGLANCE device publishes its view as a bridge-stream row
+  // (`proj:calendar:<deviceId>`, sealed under the pairing subkey). Keyed by
+  // row id; merged freshest-wins per event at read time. Own cursor over the
+  // bridge namespace (the data-plane cursor above is a different app).
+  private projections = new Map<string, CalendarProjection>();
+  private bridgeCursor = 0;
   private cursor = 0;
   private cursorAccount: string | null = null;
-  private status: AgendaStatus = { key: 'unpaired', refreshing: false, lastRefreshedAt: null, lastError: null, undecryptable: 0 };
+  private status: AgendaStatus = { key: 'unpaired', refreshing: false, lastRefreshedAt: null, lastError: null, undecryptable: 0, calendarAsOf: null };
   private pending = new Map<string, number>(); // item id → marked-at ms
   private listeners = new Set<() => void>();
   private refreshChain: Promise<void> = Promise.resolve();
@@ -183,10 +197,12 @@ export class AgendaStore {
     }, dateStr);
   }
 
-  /** The agenda for an inclusive YYYY-MM-DD window, from the mirror. */
+  /** The agenda for an inclusive YYYY-MM-DD window, from the mirror plus the calendar projections. */
   agenda(from: string, to: string): Record<string, AgendaItem[]> {
+    const calendar = mergeCalendarProjections([...this.projections.values()], { from, to });
+    this.status.calendarAsOf = calendar.freshestAt;
     return buildAgenda(
-      { tasks: [...this.tasks.values()], recurringTasks: [...this.recurring.values()] },
+      { tasks: [...this.tasks.values()], recurringTasks: [...this.recurring.values()], calendarEvents: calendar.events },
       { from, to },
     );
   }
@@ -291,6 +307,7 @@ export class AgendaStore {
         }
       }
       this.cursor = since;
+      if (await this.refreshProjections(client, pairing)) changed = true;
       this.status.lastRefreshedAt = Date.now();
       this.status.lastError = null;
       this.status.undecryptable = undecryptable;
@@ -320,6 +337,38 @@ export class AgendaStore {
     if (kind === SINGLETON_KIND) return wrapped.value ?? null;
     if (!wrapped.value || typeof wrapped.value !== 'object') return null;
     return wrapped.value;
+  }
+
+  // Pull projection rows above the bridge cursor. Everything else in the
+  // namespace (intents, observations, meta, actions) is skipped by prefix
+  // without decryption. Returns whether a projection changed.
+  private async refreshProjections(client: VaultClient, pairing: BridgePairing): Promise<boolean> {
+    let since = this.bridgeCursor;
+    let hasMore = true;
+    let changed = false;
+    const subkey = await this.subkeyOf(pairing);
+    while (hasMore && !this.disposed) {
+      const page = await client.list(BRIDGE_VAULT_APP, { accountId: pairing.accountId, since });
+      hasMore = !!page.hasMore;
+      const rows = (page.rows ?? []) as Array<{ entityId?: string; seq?: number; deleted?: boolean; envelope?: string }>;
+      if (!rows.length) break;
+      for (const row of rows) {
+        const seq = Number(row.seq) || 0;
+        if (seq > since) since = seq;
+        const entityId = String(row.entityId ?? '');
+        if (!entityId.startsWith(BRIDGE_PROJECTION_PREFIX)) continue;
+        if (row.deleted || !row.envelope) {
+          if (this.projections.delete(entityId)) changed = true;
+          continue;
+        }
+        const payload = await openBridgeEnvelope(subkey, row.envelope) as Partial<CalendarProjection> | null;
+        if (payload?.kind !== 'projection' || payload.type !== 'calendar' || !Array.isArray(payload.events)) continue;
+        this.projections.set(entityId, payload as CalendarProjection);
+        changed = true;
+      }
+    }
+    this.bridgeCursor = since;
+    return changed;
   }
 
   // Drop optimistic marks the mirror has caught up with, and expired ones.
@@ -403,12 +452,15 @@ export class AgendaStore {
     this.recurring.clear();
     this.routines.clear();
     this.singletons.clear();
+    this.projections.clear();
     this.pending.clear();
     this.cursor = 0;
+    this.bridgeCursor = 0;
     this.cursorAccount = accountId;
     this.status.lastRefreshedAt = null;
     this.status.lastError = null;
     this.status.undecryptable = 0;
+    this.status.calendarAsOf = null;
   }
 
   private recomputeKeyState(): void {

--- a/dayglance-obsidian-plugin/src/agendaView.ts
+++ b/dayglance-obsidian-plugin/src/agendaView.ts
@@ -98,6 +98,24 @@ const endOf = (hhmm: string, duration: number): string | null => {
   return formatTime(`${String(Math.floor(total / 60)).padStart(2, '0')}:${String(total % 60).padStart(2, '0')}`);
 };
 
+// dayGLANCE colors are Tailwind utility classes (colorUtils.js TASK_COLORS,
+// feed defaults like bg-gray-600); imported native events carry a real CSS
+// color. Map the classes to the palette's hex so the swatch renders; pass
+// real colors through; anything else gets no swatch.
+const TAILWIND: Record<string, string> = {
+  blue: '#3b82f6', purple: '#a855f7', green: '#22c55e', orange: '#f97316', pink: '#ec4899',
+  indigo: '#6366f1', red: '#ef4444', teal: '#14b8a6', yellow: '#eab308', gray: '#4b5563',
+  cyan: '#06b6d4', emerald: '#10b981', lime: '#84cc16', amber: '#f59e0b', rose: '#f43f5e',
+  violet: '#8b5cf6', fuchsia: '#d946ef', sky: '#0ea5e9', slate: '#64748b', stone: '#78716c',
+};
+const swatchColor = (color: string | null): string | null => {
+  if (!color) return null;
+  const m = /^bg-([a-z]+)-\d{3}$/.exec(color);
+  if (m) return TAILWIND[m[1]] ?? null;
+  if (color === 'task-calendar') return null;
+  return /^(#|rgb|hsl|[a-z]+$)/i.test(color) ? color : null;
+};
+
 const relativeAge = (ms: number): string => {
   const s = Math.max(0, Math.round((Date.now() - ms) / 1000));
   if (s < 60) return 'just now';
@@ -268,10 +286,8 @@ export class AgendaView extends ItemView {
           if (!r.ok) { new Notice(`dayGLANCE: ${r.message}`); this.render(); }
         });
       });
-      if (item.color) {
-        const swatch = li.createDiv({ cls: 'dg-agenda-swatch' });
-        swatch.style.background = item.color;
-      }
+      const swatch = swatchColor(item.color);
+      if (swatch) li.createDiv({ cls: 'dg-agenda-swatch' }).style.background = swatch;
       const body = li.createDiv({ cls: 'dg-agenda-body' });
       if (!item.isAllDay && item.startTime) {
         const end = item.duration ? endOf(item.startTime, item.duration) : null;
@@ -280,7 +296,7 @@ export class AgendaView extends ItemView {
       const title = body.createSpan({ cls: 'dg-agenda-title' });
       this.renderTitle(title, item.title);
       if (item.recurring) title.createSpan({ cls: 'dg-agenda-badge', text: '↻', attr: { title: 'Recurring' } });
-      if (item.imported) title.createSpan({ cls: 'dg-agenda-badge', text: '📅', attr: { title: 'Imported calendar event' } });
+      if (item.imported) title.createSpan({ cls: 'dg-agenda-badge', text: '📅', attr: { title: item.calendarName ? `Calendar: ${item.calendarName}` : 'Imported calendar event' } });
     }
   }
 
@@ -323,6 +339,9 @@ export class AgendaView extends ItemView {
     else if (status.lastRefreshedAt) parts.push(`Updated ${relativeAge(status.lastRefreshedAt)}`);
     else parts.push('Loading…');
     if (status.undecryptable) parts.push(`${status.undecryptable} rows unreadable with this passphrase`);
+    // Calendar events come from dayGLANCE's projection, not the mirror: say
+    // how old that view is once it is stale enough to matter.
+    if (status.calendarAsOf && Date.now() - status.calendarAsOf > 60 * 60_000) parts.push(`Calendar as of ${relativeAge(status.calendarAsOf)}`);
     if (status.lastError) parts.push(status.lastError);
     const el = root.createDiv({ cls: 'dg-agenda-status', text: parts.join(' · ') });
     if (status.lastError || status.undecryptable) el.addClass('is-error');

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -361,6 +361,35 @@ ruling below).
    unreachable, rows unreadable under this passphrase) once ready.
 7. **Mobile.** The same `ItemView` opens in the right sidebar drawer on mobile;
    no separate layout in v1.
+8. **Calendar events ride a projection, not the data plane (2026-09-02, owner
+   ruling: option 1).** The first field test showed no calendar events: the
+   sync payload structurally excludes read-only calendar events
+   (`payloadExclusions.js` — subscription feeds are re-fetched per device,
+   native device-calendar rows never leave the phone), so no mirror can carry
+   them. Three options were weighed: (1) each running dayGLANCE publishes a
+   PROJECTION of the events it holds; (2) the plugin fetches the feeds itself
+   (feed URLs and credentials leaving the app, a second import pipeline, a
+   wider network footprint for directory review); (3) stop excluding the
+   events from sync (reopens the glitch-loop and multi-user-leak ground the
+   exclusion settled). The owner chose (1), having arrived at it from (2).
+   Built: `utils/obsidianCalendarProjection.js` builds `{v:1,
+   kind:'projection', type:'calendar', deviceId, from, to, publishedAt,
+   events}` for ±35 days from exactly the excluded classes;
+   `publishBridgeCalendarProjection` seals it under the bridge subkey into one
+   upserted `proj:calendar:<deviceId>` row (`BRIDGE_PROJECTION_PREFIX`) per
+   cycle, guarded once-per-(generation, content) so an unchanged calendar
+   costs no request and the daily window slide republishes at least daily.
+   Derived data authored by the app: NOT a data-plane write, so the
+   single-writer boundary is untouched. The plugin keeps a second cursor over
+   the bridge namespace for `proj:` rows and unions them
+   (`mergeCalendarProjections` in agenda-core: freshest copy per event id,
+   projections older than seven days ignored, so a device that stops
+   publishing cannot pin stale events). The status footer says "Calendar as
+   of N h ago" once the freshest projection is over an hour old. Known
+   limits: a phone's native events are merged into its task list only for
+   the date it is viewing, so its projection carries native events for that
+   day alone; in multi-user mode each device projects its own user's feeds
+   and the plugin shows the union.
 
 **Owner ruling (2026-09-02, pending).** The owner expected the plugin to be
 "a GLANCEvault client like any other, with full access to dayGLANCE"; decision
@@ -695,4 +724,5 @@ Read-write scan scope is not in this phase. See 6.2.
 | 8 | Completion-log line shape (scan-collision constraint, 4.1) | **Decided: non-task shape** (`- ✅ …`), built |
 | 9 | Sidebar completion write path for tasks with no vault line (4.2) | **Decided: action rows** (`act:` on the bridge stream), applied by dayGLANCE as the single data-plane writer; built |
 | 11 | Plugin reads the data plane with a device-local root key derived from the sync passphrase (4.2, decision 1) | Built under a standing veto; owner ruling pending |
+| 12 | Calendar events in the sidebar (excluded from sync by design) | **Decided: dayGLANCE publishes a per-device projection row** on the bridge stream; the plugin unions them (4.2, decision 8); built |
 | 10 | Ownership rule for dayGLANCE-maintained frontmatter (4.3) | Open; what-wins-on-divergence category, ruling before first write |

--- a/packages/agenda-core/src/agenda.js
+++ b/packages/agenda-core/src/agenda.js
@@ -41,7 +41,8 @@ const timeKey = (t) => (t.isAllDay || !t.startTime ? '' : t.startTime);
 /**
  * Build the agenda for a date window.
  *
- * @param {{ tasks?: object[], recurringTasks?: object[] }} data  the app's lists
+ * @param {{ tasks?: object[], recurringTasks?: object[], calendarEvents?: object[] }} data  the app's lists
+ *   (calendarEvents: read-only events merged from device projections — see calendar.js)
  * @param {{ from: string, to: string, includeImported?: boolean }} opts  inclusive YYYY-MM-DD bounds
  * @returns {Record<string, object[]>}  date → items sorted all-day first, then by time
  *
@@ -66,6 +67,17 @@ export function buildAgenda(data, { from, to, includeImported = true } = {}) {
   }
   for (const r of data?.recurringTasks || []) {
     for (const inst of expandRecurringTemplate(r, from, to)) push(inst.date, inst);
+  }
+  if (includeImported) {
+    for (const e of data?.calendarEvents || []) {
+      if (!e || !e.date || e.date < from || e.date > to) continue;
+      push(e.date, {
+        id: String(e.id), title: e.title ?? '', startTime: e.isAllDay ? null : (e.startTime || null), duration: e.duration ?? null,
+        color: e.color || null, isAllDay: !!e.isAllDay, completed: !!e.completed,
+        recurring: false, imported: true, projected: true, date: e.date, projectId: null,
+        ...(e.calendarName ? { calendarName: e.calendarName } : {}),
+      });
+    }
   }
   for (const list of Object.values(byDate)) {
     list.sort((a, b) => {

--- a/packages/agenda-core/src/calendar.js
+++ b/packages/agenda-core/src/calendar.js
@@ -1,0 +1,40 @@
+// Calendar projections (companion spec 4.2, calendar events). Pure.
+//
+// dayGLANCE devices each publish a projection of the read-only calendar
+// events they hold (the sync payload excludes those, so no mirror carries
+// them). A reader may hold several — one per device — and they overlap:
+// the same feed on two devices yields the same event ids. This merges them
+// into one event list: freshest projection wins per event id, projections
+// older than `maxAgeMs` are ignored (a device that stopped publishing must
+// not pin stale events forever), and only events inside [from, to] survive.
+
+const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+const ts = (iso) => { const t = Date.parse(iso || ''); return Number.isFinite(t) ? t : 0; };
+
+/**
+ * @param {object[]} projections  payloads {deviceId, publishedAt, events:[…]}
+ * @param {{ from: string, to: string, nowMs?: number, maxAgeMs?: number }} opts
+ * @returns {{ events: object[], freshestAt: number|null }}
+ *   events carry `imported: true` and `projected: true` so buildAgenda treats
+ *   them as read-only calendar items; freshestAt is the newest publish stamp
+ *   used (epoch ms) or null when nothing qualified.
+ */
+export function mergeCalendarProjections(projections, { from, to, nowMs = Date.now(), maxAgeMs = DEFAULT_MAX_AGE_MS } = {}) {
+  const byId = new Map();
+  let freshestAt = null;
+  for (const p of projections || []) {
+    if (!p || p.kind !== 'projection' || p.type !== 'calendar' || !Array.isArray(p.events)) continue;
+    const at = ts(p.publishedAt);
+    if (!at || nowMs - at > maxAgeMs) continue;
+    if (freshestAt === null || at > freshestAt) freshestAt = at;
+    for (const e of p.events) {
+      if (!e || e.id == null || typeof e.date !== 'string') continue;
+      if (e.date < from || e.date > to) continue;
+      const prev = byId.get(String(e.id));
+      if (prev && prev.at > at) continue;
+      byId.set(String(e.id), { at, event: { ...e, id: String(e.id), imported: true, projected: true } });
+    }
+  }
+  return { events: [...byId.values()].map((x) => x.event), freshestAt };
+}

--- a/packages/agenda-core/src/calendar.test.js
+++ b/packages/agenda-core/src/calendar.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { mergeCalendarProjections } from './calendar.js';
+import { buildAgenda } from './agenda.js';
+
+const proj = (deviceId, publishedAt, events) => ({ v: 1, kind: 'projection', type: 'calendar', deviceId, from: '2026-08-01', to: '2026-10-01', publishedAt, events });
+const ev = (id, date, over = {}) => ({ id, title: `Event ${id}`, date, startTime: '10:00', duration: 30, isAllDay: false, completed: false, ...over });
+
+describe('mergeCalendarProjections', () => {
+  const now = Date.parse('2026-09-02T18:00:00Z');
+  it('unions devices, freshest copy wins per id, stale projections and out-of-window events drop', () => {
+    const { events, freshestAt } = mergeCalendarProjections([
+      proj('desk', '2026-09-02T17:00:00Z', [ev('a', '2026-09-03', { title: 'Old title' }), ev('b', '2026-09-04')]),
+      proj('phone', '2026-09-02T17:30:00Z', [ev('a', '2026-09-03', { title: 'New title' }), ev('n', '2026-09-02'), ev('far', '2026-12-01')]),
+      proj('dead', '2026-08-20T00:00:00Z', [ev('z', '2026-09-05')]),
+      { kind: 'observation' },
+    ], { from: '2026-08-01', to: '2026-10-01', nowMs: now });
+    expect(events.map((e) => e.id).sort()).toEqual(['a', 'b', 'n']);
+    expect(events.find((e) => e.id === 'a').title).toBe('New title');
+    expect(events.every((e) => e.imported && e.projected)).toBe(true);
+    expect(freshestAt).toBe(Date.parse('2026-09-02T17:30:00Z'));
+  });
+  it('nothing qualifying → empty, freshestAt null', () => {
+    expect(mergeCalendarProjections([], { from: '2026-08-01', to: '2026-10-01' })).toEqual({ events: [], freshestAt: null });
+  });
+});
+
+describe('buildAgenda with calendarEvents', () => {
+  it('places projected events on their date as read-only imported items, sorted with the rest; includeImported:false drops them', () => {
+    const data = { tasks: [{ id: 't', title: 'Task', date: '2026-09-03', startTime: '09:00' }], calendarEvents: [ev('c', '2026-09-03', { calendarName: 'Work' }), ev('x', '2026-12-01')] };
+    const agenda = buildAgenda(data, { from: '2026-09-01', to: '2026-09-30' });
+    expect(agenda['2026-09-03'].map((i) => i.id)).toEqual(['t', 'c']);
+    expect(agenda['2026-09-03'][1]).toMatchObject({ imported: true, projected: true, calendarName: 'Work', recurring: false });
+    expect(agenda['2026-12-01']).toBeUndefined();
+    expect(buildAgenda(data, { from: '2026-09-01', to: '2026-09-30', includeImported: false })['2026-09-03']).toHaveLength(1);
+  });
+});

--- a/packages/agenda-core/src/index.js
+++ b/packages/agenda-core/src/index.js
@@ -9,3 +9,4 @@ export * from './recurrence.js';
 export * from './agenda.js';
 export * from './routines.js';
 export * from './title.js';
+export * from './calendar.js';

--- a/packages/agenda-core/types/index.d.ts
+++ b/packages/agenda-core/types/index.d.ts
@@ -18,6 +18,9 @@ export interface AgendaItem {
   completed: boolean;
   recurring: boolean;
   imported?: boolean;
+  /** True for an event that came from a device's calendar projection (read-only). */
+  projected?: boolean;
+  calendarName?: string;
   date: string;
   projectId?: string | null;
   templateId?: string;
@@ -26,7 +29,7 @@ export interface AgendaItem {
 export function recurringInstanceId(templateId: string, dateStr: string): string;
 export function expandRecurringTemplate(template: unknown, fromStr: string, toStr: string): AgendaItem[];
 export function buildAgenda(
-  data: { tasks?: unknown[]; recurringTasks?: unknown[] },
+  data: { tasks?: unknown[]; recurringTasks?: unknown[]; calendarEvents?: unknown[] },
   opts: { from: string; to: string; includeImported?: boolean },
 ): Record<string, AgendaItem[]>;
 export function datesWithItems(agenda: Record<string, AgendaItem[]>): Set<string>;
@@ -51,3 +54,18 @@ export type TitleSegment =
   | { type: 'tag'; text: string; tag: string }
   | { type: 'link'; text: string; target: string };
 export function splitTitle(title: string): TitleSegment[];
+
+export interface CalendarProjection {
+  v: number;
+  kind: 'projection';
+  type: 'calendar';
+  deviceId: string;
+  from: string;
+  to: string;
+  publishedAt: string;
+  events: unknown[];
+}
+export function mergeCalendarProjections(
+  projections: unknown[],
+  opts: { from: string; to: string; nowMs?: number; maxAgeMs?: number },
+): { events: unknown[]; freshestAt: number | null };

--- a/packages/obsidian-format/src/bridgeStream.js
+++ b/packages/obsidian-format/src/bridgeStream.js
@@ -75,6 +75,17 @@ export const BRIDGE_OBSERVATION_PREFIX = 'obs:';
 // dayGLANCE deletes an action row after applying it (idempotent by actionId).
 export const BRIDGE_ACTION_PREFIX = 'act:';
 
+// Projection rows (companion 4.2, calendar events): dayGLANCE publishes a
+// derived, device-authored view of data it deliberately does NOT sync — the
+// read-only calendar events the payload builder excludes — so the plugin's
+// agenda can show them without becoming a calendar client. One upserted row
+// per publishing device, `proj:calendar:<deviceId>`, sealed under the
+// pairing subkey. Payload `{v:1, kind:'projection', type:'calendar',
+// deviceId, from, to, publishedAt, events:[…]}`. Readers union the rows and
+// prefer the freshest copy of an event id. Never deleted by the reader.
+export const BRIDGE_PROJECTION_PREFIX = 'proj:';
+export const bridgeCalendarProjectionId = (deviceId) => `${BRIDGE_PROJECTION_PREFIX}calendar:${deviceId}`;
+
 const enc = new TextEncoder();
 // Chunked bytes→base64: String.fromCharCode(...bytes) blows the argument
 // limit (~64k) on large payloads, and an observation carries a whole note.

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -143,6 +143,8 @@ export const BRIDGE_CONFIG_META_ID: string;
 export const BRIDGE_INTENT_PREFIX: string;
 export const BRIDGE_OBSERVATION_PREFIX: string;
 export const BRIDGE_ACTION_PREFIX: string;
+export const BRIDGE_PROJECTION_PREFIX: string;
+export function bridgeCalendarProjectionId(deviceId: string): string;
 export function bridgeConfigAllowsStamping(config: { blockIdWrites?: unknown } | null | undefined): boolean;
 
 // ── bridge SSE (Phase 7 — pure half of the plugin's live-sync transport) ────

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2787,6 +2787,7 @@ const DayPlanner = () => {
     obsidianTasksRef, obsidianInboxRef,
     recycleBin, setRecycleBin,
     recurringTasks, setRecurringTasks,
+    multiUserEnabled,
   });
   // Completion log (companion spec 4.1): every task completion appends one
   // permanent line to the completion date's daily note. Mounted here, after

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -34,12 +34,15 @@ import { blockIdWritesEnabled, completionMarkerWritesEnabled } from '../utils/ob
 import { titleConflictNoticeText } from '../utils/obsidianTitleConflict.js';
 import { withCreationFrontmatter } from '../utils/obsidianFrontmatter.js';
 import { writebackSnapshotEntry } from '../utils/obsidianWritebackSnapshot.js';
-import { emitBridgeIntent, flushBridgeOutbox, publishBridgeConfig, getBridgePairingMeta } from '../utils/obsidianBridgeStream.js';
+import { emitBridgeIntent, flushBridgeOutbox, publishBridgeConfig, publishBridgeCalendarProjection, getBridgePairingMeta } from '../utils/obsidianBridgeStream.js';
 import { fetchBridgeObservations, applyBridgeObservations, commitBridgeObservationCursor, pendingBridgeObservations } from '../utils/obsidianBridgeInbound.js';
 import {
   fetchBridgeActions, planBridgeActions, applyActionsToTasks, applyActionsToRecurring,
   deleteBridgeActions, commitBridgeActionCursor,
 } from '../utils/obsidianBridgeActions.js';
+import { buildCalendarProjection, calendarProjectionHash } from '../utils/obsidianCalendarProjection.js';
+import { getDeviceId } from '../sync/deviceId.js';
+import { dateToString } from '../utils/taskUtils.js';
 import { recordBridgeMode, reconcileArchivedBaseline } from '../utils/obsidianBridgeMode.js';
 import { restoreBinnedVaultTasks, binRestoreNoticeText } from '../utils/obsidianBinRestore.js';
 import {
@@ -107,6 +110,9 @@ export default function useObsidianSync({
   // The sidebar's completion actions (companion spec 4.2) apply to recurring
   // templates too; optional so existing harnesses need no change.
   recurringTasks = [], setRecurringTasks = null,
+  // Multi-user changes which imported rows the sync payload excludes, and
+  // therefore which ones the calendar projection carries.
+  multiUserEnabled = false,
 }) {
   // Fresh bin contents for the async sync cycle (same staleness fix as the
   // task refs above — interval-triggered syncs must not see the closure's
@@ -555,6 +561,21 @@ export default function useObsidianSync({
         }
       } catch (e) {
         console.warn('[Obsidian] sidebar action pass failed (retried next cycle):', e);
+      }
+
+      // ── CALENDAR PROJECTION (companion spec 4.2) ────────────────────────
+      // Read-only calendar events never sync (payloadExclusions.js), so the
+      // plugin's mirror cannot show them. Publish this device's view of them
+      // for the sidebar's window as one upserted row; the publish guard
+      // inside skips an unchanged calendar, and the daily window slide
+      // republishes at least once a day. Paired-gated and fail-silent inside.
+      try {
+        const projection = buildCalendarProjection(currentTasks, {
+          today: dateToString(new Date()), deviceId: getDeviceId(), multiUserEnabled,
+        });
+        void publishBridgeCalendarProjection(projection, calendarProjectionHash(projection));
+      } catch (e) {
+        console.warn('[Obsidian] calendar projection build failed:', e);
       }
 
       // Gate (b), as amended: a direct→plugin transition ARCHIVES the

--- a/src/utils/obsidianBridgeStream.js
+++ b/src/utils/obsidianBridgeStream.js
@@ -42,6 +42,7 @@ import {
   BRIDGE_PAIRING_META_ID,
   BRIDGE_CONFIG_META_ID,
   BRIDGE_INTENT_PREFIX,
+  bridgeCalendarProjectionId,
 } from '@glance-apps/obsidian-format';
 
 const OUTBOX_KEY = 'dayglance-bridge-outbox';
@@ -92,6 +93,9 @@ let metaFetchInFlight = null;
 // row sealed under the old generation is unreadable garbage to the new
 // stream even when the VALUES never changed.
 let publishedConfigHash = null;
+// Same session-scoped guard shape for the calendar projection row (see
+// publishBridgeCalendarProjection): once per (generation, content).
+let publishedProjectionHash = null;
 
 // ── THE BRAKE (now inside the client) ────────────────────────────────────────
 // Born here as the bridge brake (#1481, decay semantics from the 2026-08-30
@@ -317,11 +321,46 @@ export async function publishBridgeConfig({ dailyNotesPath, dailyNotePattern, ta
   }
 }
 
+/**
+ * Publish this device's calendar projection (companion 4.2, calendar
+ * events): the read-only calendar events the sync payload excludes, as one
+ * upserted `proj:calendar:<deviceId>` row sealed under the bridge subkey,
+ * for the plugin's agenda to union with the mirror. Derived data authored
+ * by the app — NOT a data-plane write, so the single-writer boundary is
+ * untouched. Session-scoped once-per-(generation, content) guard like the
+ * config row: the caller's hash (calendarProjectionHash) excludes the
+ * publish stamp, so an unchanged calendar costs no request; the window
+ * slides daily, which republishes at least once a day. Fail-silent.
+ */
+export async function publishBridgeCalendarProjection(payload, contentHash) {
+  try {
+    if (bridgeRateLimited()) return;
+    if (!payload?.deviceId) return;
+    const meta = await getBridgePairingMeta();
+    if (!meta) return; // unpaired: nothing reads projections
+    const hash = `${meta.generation}|${contentHash}`;
+    if (publishedProjectionHash === hash) return;
+    const ctx = vaultClientOrNull();
+    if (!ctx) return;
+    const subkey = await getBridgeSubkey(meta);
+    if (!subkey) return;
+    const ack = await ctx.client.batch(BRIDGE_VAULT_APP, {
+      accountId: ctx.accountId,
+      rows: [{ entityId: bridgeCalendarProjectionId(payload.deviceId), envelope: await sealBridgeEnvelope(subkey, payload), createdAt: Date.now() }],
+    });
+    recordOwnWriteSeq(ack?.maxSeq);
+    publishedProjectionHash = hash;
+  } catch {
+    /* next cycle retries — the hash was not advanced */
+  }
+}
+
 /** Test seam: reset module caches (subkey, in-flight flags) + the client's
  *  module-scope diagnostics (brake/meter/write-history). */
 export function __resetBridgeStreamForTests() {
   cachedSubkey = null;
   cachedSubkeyGeneration = null;
+  publishedProjectionHash = null;
   flushInFlight = null;
   metaFetchInFlight = null;
   publishedConfigHash = null;

--- a/src/utils/obsidianCalendarProjection.js
+++ b/src/utils/obsidianCalendarProjection.js
@@ -1,0 +1,58 @@
+// The calendar projection (companion spec 4.2, calendar events). Pure.
+//
+// The sync payload structurally EXCLUDES read-only calendar events
+// (payloadExclusions.js: subscription feeds are re-fetched per device, native
+// device-calendar rows never leave the phone), so the plugin's agenda mirror
+// cannot see them. Rather than make the plugin a calendar client (feed URLs
+// and credentials leaving the app, a second import pipeline), each running
+// dayGLANCE publishes a PROJECTION: the events it currently holds for the
+// sidebar's window, as one upserted bridge-stream row per device. Derived
+// data, authored by the app, read by the plugin — the single-writer boundary
+// for the data plane is untouched because this is not the data plane.
+//
+// Exactly the excluded classes are projected — nothing the plugin can
+// already read from the mirror is duplicated here.
+
+import { keepImportedTask } from '../sync/payloadExclusions.js';
+import { shiftDateStr } from '@glance-apps/agenda-core';
+
+export const CALENDAR_PROJECTION_WINDOW_DAYS = 35;
+
+/** True for a task the payload excludes and the projection therefore carries. */
+export const isProjectedCalendarEvent = (t, { multiUserEnabled = false } = {}) =>
+  !!t && typeof t === 'object' && !!t.date && (!!t._native || (!!t.imported && !keepImportedTask(t, multiUserEnabled)));
+
+/**
+ * Build the projection payload for [today-35, today+35].
+ * @param {object[]} tasks  the app's scheduled list (imported + native rows ride in it)
+ * @param {{ today: string, deviceId: string, now?: Date, multiUserEnabled?: boolean }} opts
+ */
+export function buildCalendarProjection(tasks, { today, deviceId, now = new Date(), multiUserEnabled = false }) {
+  const from = shiftDateStr(today, -CALENDAR_PROJECTION_WINDOW_DAYS);
+  const to = shiftDateStr(today, CALENDAR_PROJECTION_WINDOW_DAYS);
+  const events = [];
+  for (const t of tasks || []) {
+    if (!isProjectedCalendarEvent(t, { multiUserEnabled })) continue;
+    if (t.date < from || t.date > to) continue;
+    events.push({
+      id: String(t.id),
+      title: String(t.title ?? ''),
+      date: t.date,
+      startTime: t.isAllDay ? null : (t.startTime || null),
+      duration: t.duration ?? null,
+      isAllDay: !!t.isAllDay,
+      color: t.color || t.nativeCalendarColor || null,
+      completed: !!t.completed,
+      ...(t.calendarName ? { calendarName: t.calendarName } : {}),
+      ...(t.location ? { location: t.location } : {}),
+    });
+  }
+  events.sort((a, b) => (a.date === b.date ? String(a.id).localeCompare(String(b.id)) : (a.date < b.date ? -1 : 1)));
+  return { v: 1, kind: 'projection', type: 'calendar', deviceId, from, to, publishedAt: now.toISOString(), events };
+}
+
+/** Content identity for the publish guard: everything but the publish stamp. */
+export function calendarProjectionHash(payload) {
+  const { publishedAt: _omit, ...rest } = payload;
+  return JSON.stringify(rest);
+}

--- a/src/utils/obsidianCalendarProjection.test.js
+++ b/src/utils/obsidianCalendarProjection.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { buildCalendarProjection, calendarProjectionHash, isProjectedCalendarEvent } from './obsidianCalendarProjection.js';
+
+// The projection carries EXACTLY the classes the sync payload excludes
+// (payloadExclusions.keepImportedTask + _native), inside the sidebar window.
+
+const feed = (over = {}) => ({ id: 'uid-1-2026-09-03', title: 'Dentist', date: '2026-09-03', startTime: '10:00', duration: 30, imported: true, importSource: 'sync', isTaskCalendar: false, color: 'bg-gray-600', ...over });
+
+describe('isProjectedCalendarEvent', () => {
+  it('projects subscription events and native rows; not task-calendar to-dos, ICS file imports, or ordinary tasks', () => {
+    expect(isProjectedCalendarEvent(feed())).toBe(true);
+    expect(isProjectedCalendarEvent({ id: 'n', date: '2026-09-03', title: 'Standup', _native: true, imported: true })).toBe(true);
+    expect(isProjectedCalendarEvent(feed({ isTaskCalendar: true }))).toBe(false);
+    expect(isProjectedCalendarEvent(feed({ importSource: 'file' }))).toBe(false);
+    expect(isProjectedCalendarEvent({ id: 't', date: '2026-09-03', title: 'Write report' })).toBe(false);
+    expect(isProjectedCalendarEvent(feed({ date: undefined }))).toBe(false);
+  });
+  it('in multi-user mode, every subscription-derived item is projected (it is excluded from sync there)', () => {
+    expect(isProjectedCalendarEvent(feed({ isTaskCalendar: true }), { multiUserEnabled: true })).toBe(true);
+  });
+});
+
+describe('buildCalendarProjection', () => {
+  it('windows to ±35 days, keeps the display fields only, sorts by date then id, and stamps the device and time', () => {
+    const now = new Date('2026-09-02T16:00:00Z');
+    const payload = buildCalendarProjection([
+      feed({ id: 'b', date: '2026-09-03' }),
+      feed({ id: 'a', date: '2026-09-03', notes: 'private', icalUid: 'x' }),
+      feed({ id: 'far', date: '2026-10-20' }),
+      feed({ id: 'past', date: '2026-07-01' }),
+      { id: 'n', date: '2026-09-02', title: 'Standup', _native: true, imported: true, isAllDay: false, startTime: '09:00', duration: 15, nativeCalendarColor: '#ff0000', calendarName: 'Work' },
+      { id: 'plain', date: '2026-09-02', title: 'Mine' },
+    ], { today: '2026-09-02', deviceId: 'dev-1', now });
+    expect(payload).toMatchObject({ v: 1, kind: 'projection', type: 'calendar', deviceId: 'dev-1', from: '2026-07-29', to: '2026-10-07', publishedAt: '2026-09-02T16:00:00.000Z' });
+    expect(payload.events.map((e) => e.id)).toEqual(['n', 'a', 'b']);
+    expect(payload.events[1]).toEqual({ id: 'a', title: 'Dentist', date: '2026-09-03', startTime: '10:00', duration: 30, isAllDay: false, color: 'bg-gray-600', completed: false });
+    expect(payload.events[0]).toMatchObject({ color: '#ff0000', calendarName: 'Work' });
+  });
+
+  it('hash ignores the publish stamp so an unchanged projection is not republished', () => {
+    const a = buildCalendarProjection([feed()], { today: '2026-09-02', deviceId: 'd', now: new Date('2026-09-02T10:00:00Z') });
+    const b = buildCalendarProjection([feed()], { today: '2026-09-02', deviceId: 'd', now: new Date('2026-09-02T11:00:00Z') });
+    const c = buildCalendarProjection([feed({ title: 'Dentist (moved)' })], { today: '2026-09-02', deviceId: 'd' });
+    expect(calendarProjectionHash(a)).toBe(calendarProjectionHash(b));
+    expect(calendarProjectionHash(a)).not.toBe(calendarProjectionHash(c));
+    // A new day slides the window, so the hash changes and the row republishes.
+    const d = buildCalendarProjection([feed()], { today: '2026-09-03', deviceId: 'd' });
+    expect(calendarProjectionHash(a)).not.toBe(calendarProjectionHash(d));
+  });
+});


### PR DESCRIPTION
## Summary

Option 1 from the calendar-events discussion (companion spec §4.2, decision 8). Stacked on #1517 (base is `sidebar-routines-tags`; GitHub retargets to `main` once that merges).

Read-only calendar events are structurally excluded from the sync payload (`payloadExclusions.js`: subscription feeds re-fetch per device, native device-calendar rows never leave the phone), so the plugin's mirror could not show them. Rather than make the plugin a calendar client, each running dayGLANCE now publishes a **projection** of the events it holds and the sidebar unions them.

### dayGLANCE side
- `src/utils/obsidianCalendarProjection.js` (+ tests): `buildCalendarProjection(tasks, {today, deviceId})` selects exactly the excluded classes (`_native` rows, imported rows failing `keepImportedTask`) inside ±35 days and emits `{v:1, kind:'projection', type:'calendar', deviceId, from, to, publishedAt, events}` with display fields only (no notes/uids). `calendarProjectionHash` excludes the publish stamp.
- `publishBridgeCalendarProjection` in `obsidianBridgeStream.js`: one upserted `proj:calendar:<deviceId>` row (new `BRIDGE_PROJECTION_PREFIX` / `bridgeCalendarProjectionId` in obsidian-format), sealed under the bridge subkey, session-guarded once per (generation, content) like the config row. Unchanged calendar = no request; the daily window slide republishes at least daily. Derived data authored by the app: **not a data-plane write**, so the single-writer boundary is untouched.
- `useObsidianSync` publishes each cycle beside the config row; takes optional `multiUserEnabled` (App passes it) since multi-user changes which imported rows are excluded.

### Plugin
- `agenda.ts`: second cursor over the bridge namespace for `proj:` rows (other prefixes skipped without decryption); projections keyed by row id; `agenda()` merges them via agenda-core's `mergeCalendarProjections` (freshest copy per event id, projections older than 7 days ignored so a device that stops publishing cannot pin stale events). Status gains `calendarAsOf`.
- `agendaView.ts`: footer says "Calendar as of N h ago" once the freshest projection is over an hour old; the 📅 badge tooltip names the calendar when known. Also fixed the color swatch: dayGLANCE colors are Tailwind classes (`bg-blue-500`), which `style.background` silently rejected, so swatches never rendered. Mapped to the palette hex; real CSS colors (native events) pass through.

### agenda-core
- `src/calendar.js` `mergeCalendarProjections` (+ tests); `buildAgenda` accepts `calendarEvents` and marks them `imported: true, projected: true`.

### Known limits (recorded in the spec)
- A phone merges native events into its task list only for the date it is viewing, so its projection carries native events for that day alone.
- In multi-user mode each device projects its own user's feeds; the plugin shows the union.

## Verification
- Plugin `npm run build` clean.
- App lint clean; full suite 209 files / 2765 tests green (7 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_