### PR TITLE
Sidebar: calendar events are done once they end, and never count as open

### DIFF
--- a/dayglance-obsidian-plugin/src/agendaView.ts
+++ b/dayglance-obsidian-plugin/src/agendaView.ts
@@ -10,7 +10,10 @@
 // variables so the view follows the user's theme.
 
 import { ItemView, Keymap, Notice, WorkspaceLeaf } from 'obsidian';
-import { datesWithItems, localDateStr, shiftDateStr, splitTitle, weekdayOrder, type AgendaItem, type RoutineItem } from '@glance-apps/agenda-core';
+import {
+  datesWithItems, localDateStr, shiftDateStr, splitTitle, weekdayOrder, isCalendarEvent, eventHasEnded, agendaClock,
+  type AgendaItem, type RoutineItem,
+} from '@glance-apps/agenda-core';
 import type { AgendaStore } from './agenda';
 
 export const AGENDA_VIEW_TYPE = 'dayglance-agenda';
@@ -133,9 +136,11 @@ export class AgendaView extends ItemView {
   private month: { y: number; m: number }; // m is 0-based
   private unsubscribe: (() => void) | null = null;
   private root: HTMLElement | null = null;
-  // The view's own midnight guard: `today` moves without any store change.
+  // The view's own clock guard: `today` moves, and events END, without any
+  // store change. Once a minute, redraw only when either has happened.
   private clock: number | null = null;
   private renderedFor = '';
+  private renderedEnded = '';
 
   constructor(leaf: WorkspaceLeaf, store: AgendaStore, weekStartDay = 0) {
     super(leaf);
@@ -159,7 +164,7 @@ export class AgendaView extends ItemView {
     this.unsubscribe = this.store.onChange(() => this.render());
     this.clock = window.setInterval(() => {
       const today = localDateStr(new Date());
-      if (today !== this.renderedFor) this.render();
+      if (today !== this.renderedFor || this.endedKey() !== this.renderedEnded) this.render();
     }, 60_000);
     this.render();
     void this.store.refresh();
@@ -186,6 +191,7 @@ export class AgendaView extends ItemView {
     root.empty();
     const today = localDateStr(new Date());
     this.renderedFor = today;
+    this.renderedEnded = this.endedKey();
     const status = this.store.getStatus();
 
     if (status.key !== 'ready') {
@@ -252,8 +258,14 @@ export class AgendaView extends ItemView {
     const head = root.createDiv({ cls: 'dg-agenda-heading' });
     const label = this.selected === today ? 'Today' : DAY_FMT.format(noonOf(this.selected));
     head.createSpan({ cls: 'dg-agenda-heading-date', text: label });
-    const open = items.filter((i) => !i.completed).length;
-    head.createSpan({ cls: 'dg-agenda-heading-count', text: items.length ? `${open} open of ${items.length}` : '' });
+    // Events are not completable, so they never count as open: the count
+    // is over tasks, with events tallied separately.
+    const tasks = items.filter((i) => !isCalendarEvent(i));
+    const events = items.length - tasks.length;
+    const parts: string[] = [];
+    if (tasks.length) parts.push(`${tasks.filter((i) => !i.completed).length} open of ${tasks.length}`);
+    if (events) parts.push(`${events} event${events === 1 ? '' : 's'}`);
+    head.createSpan({ cls: 'dg-agenda-heading-count', text: parts.join(', ') });
 
     if (this.selected < from || this.selected > to) {
       root.createDiv({ cls: 'dg-agenda-empty', text: `Only ${AGENDA_WINDOW_DAYS} days either side of today are loaded here. Open dayGLANCE for the rest.` });
@@ -268,18 +280,23 @@ export class AgendaView extends ItemView {
 
   private renderItems(root: HTMLElement, items: AgendaItem[]): void {
     const list = root.createEl('ul', { cls: 'dg-agenda-list' });
+    const clock = agendaClock();
     for (const item of items) {
-      const pending = !item.completed && this.store.isPending(item.id);
+      const event = isCalendarEvent(item);
+      // An event is "done" once it has ended (owner ruling): same
+      // strikethrough and checked box as a completed task.
+      const done = item.completed || (event && eventHasEnded(item, clock));
+      const pending = !done && this.store.isPending(item.id);
       const li = list.createEl('li', { cls: 'dg-agenda-item' });
-      if (item.completed) li.addClass('is-done');
+      if (done) li.addClass('is-done');
       if (pending) li.addClass('is-pending');
       const box = li.createEl('input', { type: 'checkbox' });
-      box.checked = item.completed || pending;
+      box.checked = done || pending;
       // Completion only, and only from here for dayGLANCE-owned items:
-      // imported calendar events are completed in dayGLANCE (their
-      // completion lives in a different store); a done box stays done.
-      box.disabled = item.completed || pending || !!item.imported;
-      if (item.imported) box.setAttr('title', 'Imported calendar event: complete it in dayGLANCE');
+      // calendar events are never completed by hand (they end on their
+      // own); a done box stays done.
+      box.disabled = done || pending || event;
+      if (event) box.setAttr('title', done ? 'This event has ended' : 'Calendar event: it will be marked done once it ends');
       box.addEventListener('change', () => {
         if (!box.checked) return;
         box.disabled = true;
@@ -332,6 +349,15 @@ export class AgendaView extends ItemView {
       li.createSpan({ cls: 'dg-agenda-routine-name', text: r.name });
       li.setAttr('title', r.startTime ? `${r.name} at ${formatTime(r.startTime)}` : `${r.name} (any time)`);
     }
+  }
+
+  // Which of the selected day's events have ended, as a comparable key: the
+  // minute clock redraws when this changes, so an event flips to done on
+  // time without waiting for a store change.
+  private endedKey(): string {
+    const items = this.store.agenda(this.selected, this.selected)[this.selected] ?? [];
+    const clock = agendaClock();
+    return items.filter((i) => isCalendarEvent(i) && eventHasEnded(i, clock)).map((i) => i.id).join('|');
   }
 
   private renderStatus(root: HTMLElement, status: ReturnType<AgendaStore['getStatus']>): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4763,9 +4763,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7185,9 +7185,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/packages/agenda-core/src/agenda.js
+++ b/packages/agenda-core/src/agenda.js
@@ -61,7 +61,7 @@ export function buildAgenda(data, { from, to, includeImported = true } = {}) {
     push(t.date, {
       id: t.id, title: t.title, startTime: t.startTime || null, duration: t.duration ?? null,
       color: t.color || null, isAllDay: !!t.isAllDay, completed: !!t.completed,
-      recurring: false, imported: !!t.imported, date: t.date,
+      recurring: false, imported: !!t.imported, isTaskCalendar: !!t.isTaskCalendar, date: t.date,
       projectId: t.projectId ?? null,
     });
   }

--- a/packages/agenda-core/src/events.js
+++ b/packages/agenda-core/src/events.js
@@ -1,0 +1,43 @@
+// Calendar-event semantics for the agenda (companion spec 4.2). Pure.
+//
+// An imported calendar event is not something you complete; it happens.
+// The sidebar therefore keeps events out of the "open" count and shows an
+// event as done once it has ended (owner ruling 2026-09-02: strikethrough
+// and a checked box, the same treatment as a completed task). Task-calendar
+// to-dos are imported too but ARE completable, so they stay tasks.
+
+/** True for an agenda item that is a calendar event (imported, not a task-calendar to-do). */
+export const isCalendarEvent = (item) => !!item?.imported && !item.isTaskCalendar;
+
+const minutesOf = (hhmm) => {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(String(hhmm || ''));
+  return m ? Number(m[1]) * 60 + Number(m[2]) : null;
+};
+
+/**
+ * Has this event ended as of `now`? A past day has; a future day has not;
+ * on today an all-day event has not (it lasts the whole day), and a timed
+ * event has once start + duration (or start alone, with no duration) is at
+ * or before the current minute.
+ *
+ * @param {{ date: string, startTime?: string|null, duration?: number|null, isAllDay?: boolean }} item
+ * @param {{ today: string, nowMinutes: number }} clock  local date and minutes since local midnight
+ */
+export function eventHasEnded(item, { today, nowMinutes }) {
+  if (!item?.date) return false;
+  if (item.date < today) return true;
+  if (item.date > today) return false;
+  if (item.isAllDay || !item.startTime) return false;
+  const start = minutesOf(item.startTime);
+  if (start === null) return false;
+  const end = start + (item.duration > 0 ? item.duration : 0);
+  return end <= nowMinutes;
+}
+
+/** The clock eventHasEnded wants, from a Date. */
+export function agendaClock(now = new Date()) {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return { today: `${y}-${m}-${d}`, nowMinutes: now.getHours() * 60 + now.getMinutes() };
+}

--- a/packages/agenda-core/src/events.test.js
+++ b/packages/agenda-core/src/events.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { isCalendarEvent, eventHasEnded, agendaClock } from './events.js';
+import { buildAgenda } from './agenda.js';
+
+describe('isCalendarEvent', () => {
+  it('imported items are events unless they are task-calendar to-dos', () => {
+    expect(isCalendarEvent({ imported: true })).toBe(true);
+    expect(isCalendarEvent({ imported: true, projected: true })).toBe(true);
+    expect(isCalendarEvent({ imported: true, isTaskCalendar: true })).toBe(false);
+    expect(isCalendarEvent({ imported: false })).toBe(false);
+    expect(isCalendarEvent(null)).toBe(false);
+  });
+  it('buildAgenda carries isTaskCalendar so the distinction survives', () => {
+    const agenda = buildAgenda({ tasks: [
+      { id: 'todo', title: 'Todo', date: '2026-09-02', imported: true, isTaskCalendar: true },
+      { id: 'ev', title: 'Event', date: '2026-09-02', imported: true },
+    ] }, { from: '2026-09-01', to: '2026-09-30' });
+    const byId = Object.fromEntries(agenda['2026-09-02'].map((i) => [i.id, isCalendarEvent(i)]));
+    expect(byId).toEqual({ todo: false, ev: true });
+  });
+});
+
+describe('eventHasEnded', () => {
+  const clock = { today: '2026-09-02', nowMinutes: 14 * 60 };
+  it('past days have ended, future days have not, all-day today has not', () => {
+    expect(eventHasEnded({ date: '2026-09-01', startTime: '23:00', duration: 30 }, clock)).toBe(true);
+    expect(eventHasEnded({ date: '2026-09-03', startTime: '08:00', duration: 30 }, clock)).toBe(false);
+    expect(eventHasEnded({ date: '2026-09-02', isAllDay: true }, clock)).toBe(false);
+    expect(eventHasEnded({ date: '2026-09-02', startTime: null }, clock)).toBe(false);
+  });
+  it('a timed event today ends at start + duration, inclusive of the end minute', () => {
+    expect(eventHasEnded({ date: '2026-09-02', startTime: '13:00', duration: 60 }, clock)).toBe(true);
+    expect(eventHasEnded({ date: '2026-09-02', startTime: '13:30', duration: 60 }, clock)).toBe(false);
+    expect(eventHasEnded({ date: '2026-09-02', startTime: '13:59', duration: null }, clock)).toBe(true);
+    expect(eventHasEnded({ date: '2026-09-02', startTime: '14:00', duration: 0 }, clock)).toBe(true);
+    expect(eventHasEnded({ date: '2026-09-02', startTime: '14:01' }, clock)).toBe(false);
+  });
+  it('agendaClock reads the local date and minute', () => {
+    expect(agendaClock(new Date(2026, 8, 2, 9, 5))).toEqual({ today: '2026-09-02', nowMinutes: 545 });
+  });
+});

--- a/packages/agenda-core/src/index.js
+++ b/packages/agenda-core/src/index.js
@@ -10,3 +10,4 @@ export * from './agenda.js';
 export * from './routines.js';
 export * from './title.js';
 export * from './calendar.js';
+export * from './events.js';

--- a/packages/agenda-core/types/index.d.ts
+++ b/packages/agenda-core/types/index.d.ts
@@ -18,6 +18,8 @@ export interface AgendaItem {
   completed: boolean;
   recurring: boolean;
   imported?: boolean;
+  /** An imported task-calendar to-do: imported, yet completable like a task. */
+  isTaskCalendar?: boolean;
   /** True for an event that came from a device's calendar projection (read-only). */
   projected?: boolean;
   calendarName?: string;
@@ -69,3 +71,8 @@ export function mergeCalendarProjections(
   projections: unknown[],
   opts: { from: string; to: string; nowMs?: number; maxAgeMs?: number },
 ): { events: unknown[]; freshestAt: number | null };
+
+export interface AgendaClock { today: string; nowMinutes: number }
+export function isCalendarEvent(item: AgendaItem | null | undefined): boolean;
+export function eventHasEnded(item: { date: string; startTime?: string | null; duration?: number | null; isAllDay?: boolean }, clock: AgendaClock): boolean;
+export function agendaClock(now?: Date): AgendaClock;


### PR DESCRIPTION
## Summary

Owner ruling on how the agenda sidebar treats calendar events (companion spec §4.2).

- **Heading count excludes events.** "N open of M" now counts tasks only, with events tallied separately: "2 open of 4, 3 events". A day with only events reads "3 events".
- **Ended events render as done.** An event gets the completed treatment (checked, disabled box plus strikethrough) once it has ended: past days always; today once start + duration has passed (start alone when there is no duration); all-day events not until the day is over. The box tooltip says "This event has ended" or "it will be marked done once it ends".
- **On-time flip.** The view's minute clock now redraws when the set of ended events on the selected day changes, not only at midnight, so an event flips to done at its end time without a store change.
- Task-calendar to-dos remain tasks: `buildAgenda` now carries `isTaskCalendar`, and `isCalendarEvent` is imported-and-not-a-to-do.

## Code
- `packages/agenda-core/src/events.js`: `isCalendarEvent`, `eventHasEnded(item, clock)`, `agendaClock(now)`; tests; `.d.ts` updated.
- Plugin `agendaView.ts`: heading count, done rendering for ended events, `endedKey()` clock guard.

## Verification
- Plugin `npm run build` clean.
- App lint clean; full suite green (2770 tests, 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_