### PR TITLE
Calendar projection: per-day cache so events stop vanishing from the sidebar

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -37,9 +37,12 @@ manually or via BRAT, not submitted to the community directory.
   with the day's placed routines as a pill strip underneath (name and start
   time). Read-only calendar events never sync, so each running dayGLANCE
   publishes a projection of the ones it holds (`proj:calendar:<deviceId>`
-  rows on the bridge stream) and the sidebar unions them, freshest copy per
-  event; the footer notes when that view is over an hour old. Tags in titles render faded; `[[wikilinks]]` render as their display
-  text and click through to the note.
+  rows on the bridge stream, built from a per-day cache of the fetches the
+  app already makes) and the sidebar merges them with per-day authority (the
+  device that fetched a day most recently supplies that day's events); the
+  footer notes when the selected day's events are over an hour old. Tags in
+  titles render faded; `[[wikilinks]]` render as their display text and
+  click through to the note.
   It reads the account's task rows directly from GLANCEvault: enter your
   dayGLANCE **sync passphrase** once per device in the settings tab's
   "dayGLANCE account" section. The derived root key is kept in the plugin's

--- a/dayglance-obsidian-plugin/src/agenda.ts
+++ b/dayglance-obsidian-plugin/src/agenda.ts
@@ -91,6 +91,8 @@ export interface AgendaStatus {
   undecryptable: number;
   /** Publish stamp (epoch ms) of the freshest calendar projection in use, or null when none. */
   calendarAsOf: number | null;
+  /** Per date, when the events shown for it were fetched (epoch ms) — from the publishers' caches. */
+  calendarDayAsOf: Record<string, number>;
 }
 
 interface TaskRow { id: string; [k: string]: unknown }
@@ -143,7 +145,7 @@ export class AgendaStore {
   private bridgeCursor = 0;
   private cursor = 0;
   private cursorAccount: string | null = null;
-  private status: AgendaStatus = { key: 'unpaired', refreshing: false, lastRefreshedAt: null, lastError: null, undecryptable: 0, calendarAsOf: null };
+  private status: AgendaStatus = { key: 'unpaired', refreshing: false, lastRefreshedAt: null, lastError: null, undecryptable: 0, calendarAsOf: null, calendarDayAsOf: {} };
   private pending = new Map<string, number>(); // item id → marked-at ms
   private listeners = new Set<() => void>();
   private refreshChain: Promise<void> = Promise.resolve();
@@ -201,6 +203,7 @@ export class AgendaStore {
   agenda(from: string, to: string): Record<string, AgendaItem[]> {
     const calendar = mergeCalendarProjections([...this.projections.values()], { from, to });
     this.status.calendarAsOf = calendar.freshestAt;
+    this.status.calendarDayAsOf = calendar.dayAsOf;
     return buildAgenda(
       { tasks: [...this.tasks.values()], recurringTasks: [...this.recurring.values()], calendarEvents: calendar.events },
       { from, to },
@@ -461,6 +464,7 @@ export class AgendaStore {
     this.status.lastError = null;
     this.status.undecryptable = 0;
     this.status.calendarAsOf = null;
+    this.status.calendarDayAsOf = {};
   }
 
   private recomputeKeyState(): void {

--- a/dayglance-obsidian-plugin/src/agendaView.ts
+++ b/dayglance-obsidian-plugin/src/agendaView.ts
@@ -126,7 +126,8 @@ const relativeAge = (ms: number): string => {
   const m = Math.round(s / 60);
   if (m < 60) return `${m} min ago`;
   const h = Math.round(m / 60);
-  return `${h} h ago`;
+  if (h < 48) return `${h} h ago`;
+  return `${Math.round(h / 24)} days ago`;
 };
 
 export class AgendaView extends ItemView {
@@ -366,9 +367,11 @@ export class AgendaView extends ItemView {
     else if (status.lastRefreshedAt) parts.push(`Updated ${relativeAge(status.lastRefreshedAt)}`);
     else parts.push('Loading…');
     if (status.undecryptable) parts.push(`${status.undecryptable} rows unreadable with this passphrase`);
-    // Calendar events come from dayGLANCE's projection, not the mirror: say
-    // how old that view is once it is stale enough to matter.
-    if (status.calendarAsOf && Date.now() - status.calendarAsOf > 60 * 60_000) parts.push(`Calendar as of ${relativeAge(status.calendarAsOf)}`);
+    // Calendar events come from dayGLANCE's projection, not the mirror, and
+    // each day's events are as old as the last time a device fetched that
+    // day: say so for the selected day once it is stale enough to matter.
+    const dayAt = status.calendarDayAsOf[this.selected] ?? status.calendarAsOf;
+    if (dayAt && Date.now() - dayAt > 60 * 60_000) parts.push(`Calendar for this day as of ${relativeAge(dayAt)}`);
     if (status.lastError) parts.push(status.lastError);
     const el = root.createDiv({ cls: 'dg-agenda-status', text: parts.join(' · ') });
     if (status.lastError || status.undecryptable) el.addClass('is-error');

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -386,10 +386,40 @@ ruling below).
    projections older than seven days ignored, so a device that stops
    publishing cannot pin stale events). The status footer says "Calendar as
    of N h ago" once the freshest projection is over an hour old. Known
-   limits: a phone's native events are merged into its task list only for
-   the date it is viewing, so its projection carries native events for that
-   day alone; in multi-user mode each device projects its own user's feeds
-   and the plugin shows the union.
+   limit: in multi-user mode each device projects its own user's feeds and
+   the plugin shows the union.
+
+   **Correction (2026-09-02, the disappearing-events field report).** The
+   projection was first built from the live task list. On a native-calendar
+   device (macOS with EventKit, iOS, Android) that list holds calendar events
+   for only the five days around the date being viewed — App.jsx's native
+   effect replaces every calendar event, feed events included, with each
+   fetch — and holds none between launch and the first fetch. So the
+   published projection shrank to the current window on every navigation and
+   to nothing at startup, and the sidebar's events vanished and returned with
+   it ("only the next couple of days"; "they keep disappearing"). Three fixes
+   were weighed: a device-local per-day CACHE fed by the fetches the app
+   already makes (chosen); a dedicated 71-day native fetch per sync cycle
+   (spawns the EventKit helper every five minutes on the Mac, heavier on
+   phones); or widening the app's own view window (changes the app for the
+   sidebar's sake). Built: `utils/calendarProjectionCache.js` — never synced,
+   keyed by day, each day stamped with its fetch time. The native fetch
+   replaces exactly the days it fetched; a feed sync replaces every day of
+   the projection window, keeping the days' events of feeds that failed that
+   round, and is skipped on native-calendar devices (mirroring the app, which
+   drops feed events there). The projection publishes the cache and carries
+   the per-day stamps as `days`; the publish hash ignores them so an
+   unchanged re-fetch costs no request. The cache is seeded once from the
+   live list when empty so the first run after the change never publishes
+   less than before. Reader side (`mergeCalendarProjections`): PER-DAY
+   AUTHORITY — for each date, the freshest projection declaring that date
+   (its `days` stamp, or its whole window at publish time for older payloads)
+   supplies all of the date's events and the others supply none, so a device
+   that re-fetched a day and found an event gone removes it rather than an
+   older copy lingering in a union. The footer reads "Calendar for this day
+   as of N ago" once the selected day's stamp is over an hour old. Cost
+   accepted: a day not viewed recently shows the events from the last time
+   any device fetched it, labelled as such.
 
 **Owner ruling (2026-09-02, pending).** The owner expected the plugin to be
 "a GLANCEvault client like any other, with full access to dayGLANCE"; decision

--- a/packages/agenda-core/src/calendar.js
+++ b/packages/agenda-core/src/calendar.js
@@ -4,37 +4,80 @@
 // events they hold (the sync payload excludes those, so no mirror carries
 // them). A reader may hold several — one per device — and they overlap:
 // the same feed on two devices yields the same event ids. This merges them
-// into one event list: freshest projection wins per event id, projections
-// older than `maxAgeMs` are ignored (a device that stopped publishing must
-// not pin stale events forever), and only events inside [from, to] survive.
+// into one event list with per-day authority (see mergeCalendarProjections),
+// ignores projections older than `maxAgeMs` (a device that stopped
+// publishing must not pin stale events forever), and keeps only events
+// inside [from, to].
 
 const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 const ts = (iso) => { const t = Date.parse(iso || ''); return Number.isFinite(t) ? t : 0; };
 
+const inWindow = (d, from, to) => typeof d === 'string' && d >= from && d <= to;
+
 /**
- * @param {object[]} projections  payloads {deviceId, publishedAt, events:[…]}
+ * @param {object[]} projections  payloads {deviceId, publishedAt, from, to, events:[…], days?:{date: iso}}
  * @param {{ from: string, to: string, nowMs?: number, maxAgeMs?: number }} opts
- * @returns {{ events: object[], freshestAt: number|null }}
+ * @returns {{ events: object[], freshestAt: number|null, dayAsOf: Record<string, number> }}
  *   events carry `imported: true` and `projected: true` so buildAgenda treats
  *   them as read-only calendar items; freshestAt is the newest publish stamp
- *   used (epoch ms) or null when nothing qualified.
+ *   used (epoch ms) or null when nothing qualified; dayAsOf is, per date,
+ *   the fetch stamp of the projection whose events were taken for it.
+ *
+ * PER-DAY AUTHORITY. A projection declares the days it knows: its `days`
+ * map (the cache's per-day fetch stamps) when present, else every day of
+ * its [from, to] at its publish time (payloads from before the cache). For
+ * each date, the freshest declaring projection supplies ALL of that date's
+ * events and the others supply none — so a device that re-fetched a day
+ * and found an event gone removes it, instead of an older device's copy
+ * lingering in a union.
  */
 export function mergeCalendarProjections(projections, { from, to, nowMs = Date.now(), maxAgeMs = DEFAULT_MAX_AGE_MS } = {}) {
-  const byId = new Map();
+  const usable = [];
   let freshestAt = null;
   for (const p of projections || []) {
     if (!p || p.kind !== 'projection' || p.type !== 'calendar' || !Array.isArray(p.events)) continue;
     const at = ts(p.publishedAt);
     if (!at || nowMs - at > maxAgeMs) continue;
     if (freshestAt === null || at > freshestAt) freshestAt = at;
-    for (const e of p.events) {
-      if (!e || e.id == null || typeof e.date !== 'string') continue;
-      if (e.date < from || e.date > to) continue;
-      const prev = byId.get(String(e.id));
-      if (prev && prev.at > at) continue;
-      byId.set(String(e.id), { at, event: { ...e, id: String(e.id), imported: true, projected: true } });
+    usable.push({ p, at });
+  }
+  // date → { at, p } for the freshest declaring projection.
+  const owner = new Map();
+  const declare = (date, at, p) => {
+    if (!inWindow(date, from, to)) return;
+    const prev = owner.get(date);
+    if (!prev || at > prev.at) owner.set(date, { at, p });
+  };
+  for (const { p, at } of usable) {
+    if (p.days && typeof p.days === 'object') {
+      for (const [date, iso] of Object.entries(p.days)) {
+        const dayAt = ts(iso);
+        if (dayAt) declare(date, dayAt, p);
+      }
+    } else {
+      let d = typeof p.from === 'string' ? p.from : from;
+      const end = typeof p.to === 'string' ? p.to : to;
+      for (; d <= end; d = nextDay(d)) declare(d, at, p);
     }
   }
-  return { events: [...byId.values()].map((x) => x.event), freshestAt };
+  const events = [];
+  const dayAsOf = {};
+  for (const [date, { at, p }] of owner) {
+    dayAsOf[date] = at;
+    for (const e of p.events) {
+      if (!e || e.id == null || e.date !== date) continue;
+      events.push({ ...e, id: String(e.id), imported: true, projected: true });
+    }
+  }
+  return { events, freshestAt, dayAsOf };
+}
+
+function nextDay(dateStr) {
+  const d = new Date(`${dateStr}T12:00:00`);
+  d.setDate(d.getDate() + 1);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }

--- a/packages/agenda-core/src/calendar.test.js
+++ b/packages/agenda-core/src/calendar.test.js
@@ -7,20 +7,32 @@ const ev = (id, date, over = {}) => ({ id, title: `Event ${id}`, date, startTime
 
 describe('mergeCalendarProjections', () => {
   const now = Date.parse('2026-09-02T18:00:00Z');
-  it('unions devices, freshest copy wins per id, stale projections and out-of-window events drop', () => {
-    const { events, freshestAt } = mergeCalendarProjections([
+  it('legacy payloads (no days): freshest projection owns every day of its window; stale projections and out-of-window events drop', () => {
+    const { events, freshestAt, dayAsOf } = mergeCalendarProjections([
       proj('desk', '2026-09-02T17:00:00Z', [ev('a', '2026-09-03', { title: 'Old title' }), ev('b', '2026-09-04')]),
       proj('phone', '2026-09-02T17:30:00Z', [ev('a', '2026-09-03', { title: 'New title' }), ev('n', '2026-09-02'), ev('far', '2026-12-01')]),
       proj('dead', '2026-08-20T00:00:00Z', [ev('z', '2026-09-05')]),
       { kind: 'observation' },
     ], { from: '2026-08-01', to: '2026-10-01', nowMs: now });
-    expect(events.map((e) => e.id).sort()).toEqual(['a', 'b', 'n']);
+    // phone is fresher and declares the whole window, so desk's b (09-04) is NOT unioned in.
+    expect(events.map((e) => e.id).sort()).toEqual(['a', 'n']);
     expect(events.find((e) => e.id === 'a').title).toBe('New title');
     expect(events.every((e) => e.imported && e.projected)).toBe(true);
     expect(freshestAt).toBe(Date.parse('2026-09-02T17:30:00Z'));
+    expect(dayAsOf['2026-09-04']).toBe(Date.parse('2026-09-02T17:30:00Z'));
   });
-  it('nothing qualifying → empty, freshestAt null', () => {
-    expect(mergeCalendarProjections([], { from: '2026-08-01', to: '2026-10-01' })).toEqual({ events: [], freshestAt: null });
+  it('per-day stamps: each date goes to the projection that fetched it most recently, so a narrow fresh fetch does not erase other days', () => {
+    const desk = { ...proj('desk', '2026-09-02T17:00:00Z', [ev('a', '2026-09-03'), ev('b', '2026-09-10')]),
+      days: { '2026-09-03': '2026-09-02T17:00:00Z', '2026-09-10': '2026-09-02T17:00:00Z' } };
+    // The phone re-fetched 09-03 later and found `a` gone; it knows nothing about 09-10.
+    const phone = { ...proj('phone', '2026-09-02T17:30:00Z', [ev('c', '2026-09-03')]),
+      days: { '2026-09-03': '2026-09-02T17:30:00Z' } };
+    const { events, dayAsOf } = mergeCalendarProjections([desk, phone], { from: '2026-08-01', to: '2026-10-01', nowMs: now });
+    expect(events.map((e) => e.id).sort()).toEqual(['b', 'c']);
+    expect(dayAsOf).toEqual({ '2026-09-03': Date.parse('2026-09-02T17:30:00Z'), '2026-09-10': Date.parse('2026-09-02T17:00:00Z') });
+  });
+  it('nothing qualifying → empty', () => {
+    expect(mergeCalendarProjections([], { from: '2026-08-01', to: '2026-10-01' })).toEqual({ events: [], freshestAt: null, dayAsOf: {} });
   });
 });
 

--- a/packages/agenda-core/types/index.d.ts
+++ b/packages/agenda-core/types/index.d.ts
@@ -66,11 +66,13 @@ export interface CalendarProjection {
   to: string;
   publishedAt: string;
   events: unknown[];
+  /** Per-day fetch stamps (date → ISO) from the publisher's projection cache; absent on older payloads. */
+  days?: Record<string, string>;
 }
 export function mergeCalendarProjections(
   projections: unknown[],
   opts: { from: string; to: string; nowMs?: number; maxAgeMs?: number },
-): { events: unknown[]; freshestAt: number | null };
+): { events: unknown[]; freshestAt: number | null; dayAsOf: Record<string, number> };
 
 export interface AgendaClock { today: string; nowMinutes: number }
 export function isCalendarEvent(item: AgendaItem | null | undefined): boolean;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,9 @@ import { URL_REGEX, isOnlyUrl, renderFormattedText, hasNotesOrSubtasks, isLinkOn
 import { dateToString, localDateStr, extractTags, extractWikilinks, stripWikilinks, getRecurrenceLabel, formatDate, formatDateRange, formatShortDate, formatDeadlineDate, computeTaskCalendarTombstones, computeRecurringSeriesTombstones } from './utils/taskUtils.js';
 import { notBucketed, demoteToBucket, normalizeBucketConfig } from './utils/bucketList.js';
 import { parseICS, parseDatetime, filterByDateWindow, expandMultiDayEvent } from './utils/icsParser.js';
+import { absorbCalendarDays, absorbCalendarWindow, readCalendarProjectionCache, writeCalendarProjectionCache } from './utils/calendarProjectionCache.js';
+import { CALENDAR_PROJECTION_WINDOW_DAYS } from './utils/obsidianCalendarProjection.js';
+import { shiftDateStr } from '@glance-apps/agenda-core';
 import { fetchIcsFeed, replaceFeedEvents, PRIMARY_FEED_ID, ICS_CALENDARS_KEY, loadIcsCalendars, isActiveIcsCalendar, hasActiveIcsCalendars, stripIcsCalendarCredentials, applyRemoteIcsCalendars, PRIMARY_CAL_META_KEY, defaultPrimaryCalendarMeta, injectPrimaryStub, splitPrimaryStub } from './utils/icsFeedSync.js';
 import { nextPerUserCalendarEntry } from './utils/perUserCalendarEntry.js';
 import { TASK_COLORS, TAILWIND_TO_HEX, taskColorToHex, getProjectColor } from './utils/colorUtils.js';
@@ -3988,6 +3991,12 @@ const DayPlanner = () => {
         ...prev.filter(t => !t._native && !(t.imported && !t.isTaskCalendar && t.importSource !== 'file')),
         ...fetchedWithOverrides,
       ]);
+      // Obsidian sidebar (companion 4.2): the calendar projection is built
+      // from a per-day cache, not this five-day window — record exactly the
+      // days just fetched so days outside the view keep their events.
+      try {
+        writeCalendarProjectionCache(absorbCalendarDays(readCalendarProjectionCache(), dates, fetchedWithOverrides, { multiUserEnabled }));
+      } catch { /* the cache is best-effort */ }
     };
 
     if (isNativeApp()) {
@@ -4939,6 +4948,14 @@ const DayPlanner = () => {
       // No active feeds — drop any leftover feed events (a feed was disabled or
       // its URL cleared and nothing else remains to sync them away).
       setTasks(prevTasks => replaceFeedEvents(prevTasks, []));
+      if (!hasNativeCalendar()) {
+        try {
+          const today = dateToString(new Date());
+          writeCalendarProjectionCache(absorbCalendarWindow(readCalendarProjectionCache(), [], {
+            from: shiftDateStr(today, -CALENDAR_PROJECTION_WINDOW_DAYS), to: shiftDateStr(today, CALENDAR_PROJECTION_WINDOW_DAYS),
+          }));
+        } catch { /* best-effort */ }
+      }
       return { success: false, error: 'no-url' };
     }
 
@@ -4995,6 +5012,19 @@ const DayPlanner = () => {
     // ones, keeping the previous events of feeds that failed this round.
     // Preserves file-imported events; uses functional form to avoid stale closures
     setTasks(prevTasks => replaceFeedEvents(prevTasks, freshEvents, { keepFeedIds: failedFeedIds }));
+    // Obsidian sidebar (companion 4.2): feed events feed the projection cache
+    // over the whole projection window (a feed is fetched whole). Skipped on
+    // native-calendar devices, where the EventKit fetch is the sole source
+    // and the merge above drops feed events again on its next run.
+    if (!hasNativeCalendar()) {
+      try {
+        const today = dateToString(new Date());
+        writeCalendarProjectionCache(absorbCalendarWindow(readCalendarProjectionCache(), freshEvents, {
+          from: shiftDateStr(today, -CALENDAR_PROJECTION_WINDOW_DAYS), to: shiftDateStr(today, CALENDAR_PROJECTION_WINDOW_DAYS),
+          keepFeedIds: failedFeedIds, multiUserEnabled,
+        }));
+      } catch { /* best-effort */ }
+    }
     return { success: true, count: freshEvents.length, urlUpdated, failedFeeds };
   };
 

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -40,7 +40,12 @@ import {
   fetchBridgeActions, planBridgeActions, applyActionsToTasks, applyActionsToRecurring,
   deleteBridgeActions, commitBridgeActionCursor,
 } from '../utils/obsidianBridgeActions.js';
-import { buildCalendarProjection, calendarProjectionHash } from '../utils/obsidianCalendarProjection.js';
+import { buildCalendarProjection, calendarProjectionHash, isProjectedCalendarEvent, CALENDAR_PROJECTION_WINDOW_DAYS } from '../utils/obsidianCalendarProjection.js';
+import {
+  readCalendarProjectionCache, writeCalendarProjectionCache, pruneCalendarProjectionCache,
+  absorbCalendarWindow, calendarProjectionInput,
+} from '../utils/calendarProjectionCache.js';
+import { shiftDateStr } from '@glance-apps/agenda-core';
 import { getDeviceId } from '../sync/deviceId.js';
 import { dateToString } from '../utils/taskUtils.js';
 import { recordBridgeMode, reconcileArchivedBaseline } from '../utils/obsidianBridgeMode.js';
@@ -570,8 +575,26 @@ export default function useObsidianSync({
       // inside skips an unchanged calendar, and the daily window slide
       // republishes at least once a day. Paired-gated and fail-silent inside.
       try {
-        const projection = buildCalendarProjection(currentTasks, {
-          today: dateToString(new Date()), deviceId: getDeviceId(), multiUserEnabled,
+        const today = dateToString(new Date());
+        const window = { from: shiftDateStr(today, -CALENDAR_PROJECTION_WINDOW_DAYS), to: shiftDateStr(today, CALENDAR_PROJECTION_WINDOW_DAYS) };
+        // Built from the per-day CACHE (utils/calendarProjectionCache.js), not
+        // the live task list: on native-calendar devices that list holds only
+        // the five days around the viewed date, and nothing before the first
+        // fetch, which made the published events vanish and return. Seeded
+        // once from the live list when the cache is empty (first run after
+        // the change, or a cleared store) so the sidebar never regresses
+        // below what the old path published.
+        let cache = pruneCalendarProjectionCache(readCalendarProjectionCache(), window);
+        if (!Object.keys(cache.days).length) {
+          const live = currentTasks.filter(t => isProjectedCalendarEvent(t, { multiUserEnabled }));
+          if (live.length) {
+            cache = absorbCalendarWindow(cache, live, { ...window, multiUserEnabled });
+            writeCalendarProjectionCache(cache);
+          }
+        }
+        const input = calendarProjectionInput(cache, window);
+        const projection = buildCalendarProjection(input.tasks, {
+          today, deviceId: getDeviceId(), multiUserEnabled, days: input.days,
         });
         void publishBridgeCalendarProjection(projection, calendarProjectionHash(projection));
       } catch (e) {

--- a/src/utils/calendarProjectionCache.js
+++ b/src/utils/calendarProjectionCache.js
@@ -1,0 +1,117 @@
+// The calendar projection CACHE (companion spec 4.2, calendar events —
+// the 2026-09-02 disappearing-events fix).
+//
+// The projection used to be built from the live task list. On a native-
+// calendar device that list holds calendar events for only the five days
+// around the date being viewed (App.jsx's EventKit effect replaces every
+// calendar event with that window on each navigation), and it holds NONE
+// between launch and the first fetch — so the published projection shrank
+// to the current window on every navigation and to nothing at startup, and
+// the sidebar's events vanished and returned with it.
+//
+// This cache is DEVICE-LOCAL and CUMULATIVE, keyed by day. Every source that
+// produces calendar events feeds it with per-day replacement semantics:
+//  • the native fetch replaces exactly the days it fetched;
+//  • a feed sync replaces every day of the projection window (a feed is
+//    fetched whole), keeping the days' events of feeds that failed.
+// The projection publishes the cache, not the task list, so days outside
+// the current view keep their last-fetched events, startup publishes the
+// last known state, and no extra native or network traffic is needed. Each
+// day carries the time it was last fetched so readers can say how old a
+// given day's events are.
+//
+// Never synced: it is derived from sources that are themselves device-local
+// (payloadExclusions.js is the reason those events are not in the data
+// plane in the first place).
+
+import { PRIMARY_FEED_ID } from './icsFeedSync.js';
+import { isProjectedCalendarEvent } from './obsidianCalendarProjection.js';
+import { shiftDateStr } from '@glance-apps/agenda-core';
+
+export const CALENDAR_PROJECTION_CACHE_KEY = 'dayglance-calendar-projection-cache';
+
+const empty = () => ({ v: 1, days: {} });
+
+export function readCalendarProjectionCache() {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(CALENDAR_PROJECTION_CACHE_KEY) || 'null');
+    if (parsed && parsed.v === 1 && parsed.days && typeof parsed.days === 'object') return parsed;
+  } catch { /* fresh */ }
+  return empty();
+}
+
+export function writeCalendarProjectionCache(cache) {
+  try { localStorage.setItem(CALENDAR_PROJECTION_CACHE_KEY, JSON.stringify(cache)); }
+  catch { /* storage unavailable: the next absorb retries */ }
+}
+
+// Only the fields the projection (and the feed bookkeeping) need. Notes
+// and the like stay out of device storage.
+const slim = (t) => ({
+  id: t.id, title: t.title, date: t.date, startTime: t.startTime ?? null, duration: t.duration ?? null,
+  isAllDay: !!t.isAllDay, completed: !!t.completed,
+  ...(t.color ? { color: t.color } : {}),
+  ...(t.nativeCalendarColor ? { nativeCalendarColor: t.nativeCalendarColor } : {}),
+  ...(t.calendarName ? { calendarName: t.calendarName } : {}),
+  ...(t.location ? { location: t.location } : {}),
+  ...(t.feedId ? { feedId: t.feedId } : {}),
+  imported: !!t.imported, ...(t._native ? { _native: true } : {}),
+  ...(t.isTaskCalendar ? { isTaskCalendar: true } : {}),
+  ...(t.importSource ? { importSource: t.importSource } : {}),
+});
+
+const projected = (events, multiUserEnabled) =>
+  (events || []).filter((t) => isProjectedCalendarEvent(t, { multiUserEnabled })).map(slim);
+
+/**
+ * Per-day replacement for a native fetch: `dates` were fetched in full, so
+ * each of them becomes exactly the events in `events` on that date.
+ */
+export function absorbCalendarDays(cache, dates, events, { now = new Date(), multiUserEnabled = false } = {}) {
+  const at = now.toISOString();
+  const keep = projected(events, multiUserEnabled);
+  const days = { ...(cache?.days || {}) };
+  for (const date of dates || []) {
+    days[date] = { at, events: keep.filter((e) => e.date === date) };
+  }
+  return { v: 1, days };
+}
+
+/**
+ * Whole-window replacement for a feed sync: every day in [from, to] becomes
+ * the fresh events on that day, plus the cached events of feeds that failed
+ * this round (`keepFeedIds`), which the app also keeps in its own list.
+ */
+export function absorbCalendarWindow(cache, events, { from, to, keepFeedIds = null, now = new Date(), multiUserEnabled = false } = {}) {
+  const at = now.toISOString();
+  const fresh = projected(events, multiUserEnabled);
+  const days = { ...(cache?.days || {}) };
+  for (let d = from; d <= to; d = shiftDateStr(d, 1)) {
+    const kept = keepFeedIds
+      ? (days[d]?.events || []).filter((e) => keepFeedIds.has(e.feedId ?? PRIMARY_FEED_ID))
+      : [];
+    days[d] = { at, events: [...kept, ...fresh.filter((e) => e.date === d)] };
+  }
+  return { v: 1, days };
+}
+
+/** Drop days outside [from, to] (the window slides daily). */
+export function pruneCalendarProjectionCache(cache, { from, to }) {
+  const days = {};
+  for (const [d, entry] of Object.entries(cache?.days || {})) {
+    if (d >= from && d <= to) days[d] = entry;
+  }
+  return { v: 1, days };
+}
+
+/** What the projection builder consumes: the cached events plus per-day fetch stamps. */
+export function calendarProjectionInput(cache, { from, to }) {
+  const tasks = [];
+  const days = {};
+  for (const [d, entry] of Object.entries(cache?.days || {})) {
+    if (d < from || d > to) continue;
+    days[d] = entry.at;
+    for (const e of entry.events || []) tasks.push(e);
+  }
+  return { tasks, days };
+}

--- a/src/utils/calendarProjectionCache.test.js
+++ b/src/utils/calendarProjectionCache.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  readCalendarProjectionCache, writeCalendarProjectionCache,
+  absorbCalendarDays, absorbCalendarWindow, pruneCalendarProjectionCache, calendarProjectionInput,
+  CALENDAR_PROJECTION_CACHE_KEY,
+} from './calendarProjectionCache.js';
+import { buildCalendarProjection } from './obsidianCalendarProjection.js';
+
+// The cache exists because the projection used to be built from a task list
+// that, on native-calendar devices, holds only five days of events around
+// the viewed date and none before the first fetch. Per-day replacement is
+// the contract: a fetch replaces exactly the days it covered.
+
+const native = (id, date, over = {}) => ({ id, title: id, date, startTime: '10:00', duration: 30, imported: true, _native: true, notes: 'private', ...over });
+const feed = (id, date, over = {}) => ({ id, title: id, date, startTime: '09:00', duration: 60, imported: true, importSource: 'sync', isTaskCalendar: false, ...over });
+const NOW = new Date('2026-09-02T16:00:00Z');
+
+beforeEach(() => {
+  const store = {};
+  globalThis.localStorage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; },
+  };
+});
+afterEach(() => { delete globalThis.localStorage; });
+
+describe('absorbCalendarDays (native fetch)', () => {
+  it('replaces exactly the fetched days, keeps other days, drops notes and non-projected rows', () => {
+    let cache = absorbCalendarDays(null, ['2026-09-01', '2026-09-02'], [native('a', '2026-09-01'), native('b', '2026-09-02'), { id: 'task', date: '2026-09-02', title: 'Mine' }], { now: NOW });
+    expect(Object.keys(cache.days).sort()).toEqual(['2026-09-01', '2026-09-02']);
+    expect(cache.days['2026-09-02'].events.map((e) => e.id)).toEqual(['b']);
+    expect(cache.days['2026-09-02'].events[0].notes).toBeUndefined();
+    // The user navigates: a new window is fetched, day 01 is untouched, day 02 is replaced (b gone), day 03 added.
+    cache = absorbCalendarDays(cache, ['2026-09-02', '2026-09-03'], [native('c', '2026-09-03')], { now: new Date('2026-09-02T17:00:00Z') });
+    expect(cache.days['2026-09-01'].events.map((e) => e.id)).toEqual(['a']);
+    expect(cache.days['2026-09-02'].events).toEqual([]);
+    expect(cache.days['2026-09-02'].at).toBe('2026-09-02T17:00:00.000Z');
+    expect(cache.days['2026-09-03'].events.map((e) => e.id)).toEqual(['c']);
+  });
+});
+
+describe('absorbCalendarWindow (feed sync)', () => {
+  it('replaces every day in the window, keeping events of feeds that failed this round', () => {
+    let cache = absorbCalendarWindow(null, [feed('p1', '2026-09-01'), feed('x1', '2026-09-02', { feedId: 'ics-x' })], { from: '2026-09-01', to: '2026-09-03', now: NOW });
+    expect(Object.keys(cache.days).sort()).toEqual(['2026-09-01', '2026-09-02', '2026-09-03']);
+    expect(cache.days['2026-09-03'].events).toEqual([]);
+    // Feed ics-x failed: its cached events survive; the primary feed's are replaced.
+    cache = absorbCalendarWindow(cache, [feed('p2', '2026-09-01')], { from: '2026-09-01', to: '2026-09-03', keepFeedIds: new Set(['ics-x']), now: NOW });
+    expect(cache.days['2026-09-01'].events.map((e) => e.id)).toEqual(['p2']);
+    expect(cache.days['2026-09-02'].events.map((e) => e.id)).toEqual(['x1']);
+    // No feeds at all: the window clears.
+    cache = absorbCalendarWindow(cache, [], { from: '2026-09-01', to: '2026-09-03', now: NOW });
+    expect(Object.values(cache.days).every((d) => d.events.length === 0)).toBe(true);
+  });
+});
+
+describe('prune + input + persistence', () => {
+  it('prunes outside the window, exposes per-day stamps, round-trips through localStorage, and feeds the projection builder', () => {
+    let cache = absorbCalendarDays(null, ['2026-07-01', '2026-09-02'], [native('old', '2026-07-01'), native('now', '2026-09-02')], { now: NOW });
+    cache = pruneCalendarProjectionCache(cache, { from: '2026-07-29', to: '2026-10-07' });
+    expect(Object.keys(cache.days)).toEqual(['2026-09-02']);
+    writeCalendarProjectionCache(cache);
+    expect(JSON.parse(localStorage.getItem(CALENDAR_PROJECTION_CACHE_KEY)).days['2026-09-02'].events).toHaveLength(1);
+    const back = readCalendarProjectionCache();
+    const input = calendarProjectionInput(back, { from: '2026-07-29', to: '2026-10-07' });
+    expect(input.days).toEqual({ '2026-09-02': '2026-09-02T16:00:00.000Z' });
+    const payload = buildCalendarProjection(input.tasks, { today: '2026-09-02', deviceId: 'd', now: NOW, days: input.days });
+    expect(payload.events.map((e) => e.id)).toEqual(['now']);
+    expect(payload.days).toEqual(input.days);
+  });
+  it('a corrupt or missing store reads as empty', () => {
+    expect(readCalendarProjectionCache()).toEqual({ v: 1, days: {} });
+    localStorage.setItem(CALENDAR_PROJECTION_CACHE_KEY, '{not json');
+    expect(readCalendarProjectionCache()).toEqual({ v: 1, days: {} });
+  });
+});

--- a/src/utils/obsidianCalendarProjection.js
+++ b/src/utils/obsidianCalendarProjection.js
@@ -25,9 +25,12 @@ export const isProjectedCalendarEvent = (t, { multiUserEnabled = false } = {}) =
 /**
  * Build the projection payload for [today-35, today+35].
  * @param {object[]} tasks  the app's scheduled list (imported + native rows ride in it)
- * @param {{ today: string, deviceId: string, now?: Date, multiUserEnabled?: boolean }} opts
+ * @param {{ today: string, deviceId: string, now?: Date, multiUserEnabled?: boolean, days?: Record<string,string> }} opts
+ *   `days`: per-day fetch stamps (date → ISO) from the projection cache, so a
+ *   reader can say how old a given day's events are and resolve two devices'
+ *   copies of a day by freshness.
  */
-export function buildCalendarProjection(tasks, { today, deviceId, now = new Date(), multiUserEnabled = false }) {
+export function buildCalendarProjection(tasks, { today, deviceId, now = new Date(), multiUserEnabled = false, days = null }) {
   const from = shiftDateStr(today, -CALENDAR_PROJECTION_WINDOW_DAYS);
   const to = shiftDateStr(today, CALENDAR_PROJECTION_WINDOW_DAYS);
   const events = [];
@@ -48,11 +51,18 @@ export function buildCalendarProjection(tasks, { today, deviceId, now = new Date
     });
   }
   events.sort((a, b) => (a.date === b.date ? String(a.id).localeCompare(String(b.id)) : (a.date < b.date ? -1 : 1)));
-  return { v: 1, kind: 'projection', type: 'calendar', deviceId, from, to, publishedAt: now.toISOString(), events };
+  const payload = { v: 1, kind: 'projection', type: 'calendar', deviceId, from, to, publishedAt: now.toISOString(), events };
+  if (days) {
+    payload.days = {};
+    for (const [d, at] of Object.entries(days)) if (d >= from && d <= to) payload.days[d] = at;
+  }
+  return payload;
 }
 
 /** Content identity for the publish guard: everything but the publish stamp. */
 export function calendarProjectionHash(payload) {
-  const { publishedAt: _omit, ...rest } = payload;
+  // The per-day stamps are excluded too: a re-fetch that changed nothing
+  // must not republish, or every navigation would cost a request.
+  const { publishedAt: _omit, days: _days, ...rest } = payload;
   return JSON.stringify(rest);
 }


### PR DESCRIPTION
## Summary

Fixes the disappearing calendar events in the agenda sidebar (companion spec §4.2, decision 8 correction).

**Root cause.** The projection was built from the live task list. On a native-calendar device that list holds calendar events for only the five days around the date being viewed (App.jsx's EventKit effect replaces every calendar event, feed events included, on each fetch) and holds none between launch and the first fetch. So every navigation republished a narrower set and startup published nothing, and the sidebar's events vanished and returned with it.

**Fix: a device-local per-day cache**, `src/utils/calendarProjectionCache.js`, fed by the fetches the app already makes:
- the native fetch replaces exactly the days it fetched;
- a feed sync replaces every day of the projection window, keeping the days' events of feeds that failed that round, and is skipped on native-calendar devices (mirroring the app, which drops feed events there);
- each day carries its fetch stamp, published as `days` in the payload and excluded from the publish hash so an unchanged re-fetch costs no request;
- seeded once from the live list when empty, so the first run after this change never publishes less than before;
- never synced; pruned to the ±35-day window each cycle.

**Reader side.** `mergeCalendarProjections` gains per-day authority: for each date, the freshest projection declaring that date (its `days` stamp, or its whole window at publish time for older payloads) supplies all of that date's events and the others supply none. A device that re-fetched a day and found an event gone therefore removes it, instead of an older device's copy lingering in a union. Returns `dayAsOf` per date.

**Plugin.** The footer now reports the selected day's age ("Calendar for this day as of 3 h ago") once over an hour old; ages over two days read in days.

## Accepted cost
A day not viewed recently shows the events from the last time any device fetched it, labelled as such in the footer.

## Verification
- Cache tests (per-day replacement, failed-feed retention, prune/input/persistence, corrupt store), merge tests (legacy whole-window authority; per-day stamps), existing projection tests updated.
- App lint clean; full suite green (2775 tests). Plugin `npm run build` clean.
- Spec correction record and README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_