### PR TITLE
Multi-user: completion log filters to the current user; projection and pairing carry the user

### DIFF
--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -150,6 +150,17 @@ mode, which makes it verifiable. A setting for parenthesis syntax can follow.
 | Query examples | App UI / docs / none | Docs only; Dataview isn't universally installed |
 | Offline failure | Queue and retry / fail with indicator | See below |
 
+**Multi-user (2026-09-02 amendment, built).** The log is THIS user's
+record. The first field test on a two-member account logged the other
+member's completions too: her tasks sync into the same state, and the
+detector logged every edge it saw. The rule is now the app's own visibility
+rule (App.jsx `isVisibleForUser`: unassigned, or assigned to me), applied to
+the three lists before the snapshot, so another member's completions are hers
+to log from her devices. Unassigned tasks log from every member's device: in
+a shared vault the exact-line dedupe collapses the duplicate, in separate
+vaults each gets its own line. Single-user accounts are unaffected (every
+task is visible).
+
 **Uncomplete: the entry stays. Decided.** The log is a historical record, not a
 reflection of current state. If a user uncompletes a task, the completion still
 happened — they marked it done at that moment, and that remains true regardless
@@ -420,6 +431,21 @@ ruling below).
    as of N ago" once the selected day's stamp is over an hour old. Cost
    accepted: a day not viewed recently shows the events from the last time
    any device fetched it, labelled as such.
+9. **User-awareness (2026-09-02, owner ruling).** The sidebar showed another
+   member's scheduled task: the mirror holds every task on the account with
+   no notion of a viewer. Ruling: one rule everywhere, the app's own —
+   tasks and recurring templates by visibility (unassigned, or assigned to
+   the viewer), routines by ownership, calendar projections by the
+   publishing device's user. The plugin learns its viewer from the PAIRING:
+   the dayGLANCE device that mints the offer includes its current user
+   (`userSyncId`, null when single-user), so pairing from your own device
+   needs no setup; a "Show tasks for" setting (populated from the synced
+   users, with "Everyone") overrides it, stored in data.json beside the
+   pairing. Owner's assumption of record: people do not share Obsidian
+   vaults, so a vault-scoped setting is the right scope. App side: the
+   projection carries `userSyncId` (the device's identity when multi-user is
+   on) and the completion log applies the visibility rule (4.1 amendment).
+   The direct-access writeback's user rule is a separate, pending ruling.
 
 **Owner ruling (2026-09-02, pending).** The owner expected the plugin to be
 "a GLANCEvault client like any other, with full access to dayGLANCE"; decision

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -126,6 +126,8 @@ export interface BridgePairingCredentials {
   pairingSalt: string;
   generation: string;
   createdAt: string;
+  /** The pairing device's current multi-user identity; the plugin's default viewer. Absent/null when single-user. */
+  userSyncId?: string | null;
 }
 export function generatePairingCode(): string;
 export function normalizePairingCode(code: string | null | undefined): string;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2790,7 +2790,7 @@ const DayPlanner = () => {
     obsidianTasksRef, obsidianInboxRef,
     recycleBin, setRecycleBin,
     recurringTasks, setRecurringTasks,
-    multiUserEnabled,
+    multiUserEnabled, meUserSyncId,
   });
   // Completion log (companion spec 4.1): every task completion appends one
   // permanent line to the completion date's daily note. Mounted here, after
@@ -2803,6 +2803,7 @@ const DayPlanner = () => {
     obsidianVaultHandleRef, bridgeHeartbeatRef,
     setObsidianSyncError, setObsidianSyncStatus,
     isRemoteApply,
+    isVisibleForUser,
   });
   // Late-bind the SSE → Obsidian nudge (declared beside useVaultEventStream
   // above, which mounts before this hook can exist).

--- a/src/hooks/useCompletionLog.js
+++ b/src/hooks/useCompletionLog.js
@@ -141,6 +141,12 @@ export default function useCompletionLog({
   obsidianVaultHandleRef, bridgeHeartbeatRef,
   setObsidianSyncError, setObsidianSyncStatus,
   isRemoteApply,
+  // Multi-user (companion 4.1 amendment): the log is THIS user's record.
+  // App.jsx's visibility rule — unassigned, or assigned to me — decides
+  // which completions this device logs; another member's completions sync
+  // into the same state but are theirs to log. Optional: absent means
+  // everything is visible (single-user, or an older harness).
+  isVisibleForUser = null,
 }) {
   const prevRef = useRef(null);
   const inFlightRef = useRef(false);
@@ -160,9 +166,13 @@ export default function useCompletionLog({
     const authoritative = !!bridgeHeartbeatRef?.current?.pluginAuthoritative;
     const routeAvailable = authoritative || !!obsidianVaultHandleRef.current;
 
-    const nextSnap = snapshotCompletionState(tasks, unscheduledTasks, recurringTasks);
+    const visible = typeof isVisibleForUser === 'function' ? (list) => (list || []).filter((t) => t && isVisibleForUser(t)) : (list) => list;
+    const myTasks = visible(tasks);
+    const myInbox = visible(unscheduledTasks);
+    const myRecurring = visible(recurringTasks);
+    const nextSnap = snapshotCompletionState(myTasks, myInbox, myRecurring);
     const { candidates, advanceTo } = planCompletionLog(prevRef.current, nextSnap, {
-      tasks, unscheduledTasks, recurringTasks,
+      tasks: myTasks, unscheduledTasks: myInbox, recurringTasks: myRecurring,
       isRemoteApply: !!isRemoteApply?.(),
       enabled,
       inFlight: inFlightRef.current,

--- a/src/hooks/useCompletionLog.test.js
+++ b/src/hooks/useCompletionLog.test.js
@@ -195,6 +195,26 @@ describe('the hook glue', () => {
     expect(emitBridgeIntent).toHaveBeenCalledTimes(1);
   });
 
+  it('multi-user: only completions the current user would see are logged (unassigned, or assigned to me)', async () => {
+    readDailyNoteFresh.mockResolvedValue({ text: '# Day\n' });
+    const me = 'u-me';
+    const isVisibleForUser = (t) => !(t.assignedUserSyncIds?.length) || t.assignedUserSyncIds.includes(me);
+    const before = [
+      { id: 'mine', completed: false, title: 'Mine', assignedUserSyncIds: [me] },
+      { id: 'hers', completed: false, title: 'Hers', assignedUserSyncIds: ['u-wife'] },
+      { id: 'shared', completed: false, title: 'Shared' },
+    ];
+    const done = (t) => ({ ...t, completed: true, completedAt: '2026-09-02T10:00:00-05:00' });
+    useRenderedHook(baseProps(before, { isVisibleForUser }));
+    useRenderedHook(baseProps(before.map(done), { isVisibleForUser }));
+    await flush();
+    const logged = emitBridgeIntent.mock.calls.map(([, f]) => f.entry);
+    expect(logged).toHaveLength(2);
+    expect(logged.join('\n')).toContain('Mine');
+    expect(logged.join('\n')).toContain('Shared');
+    expect(logged.join('\n')).not.toContain('Hers');
+  });
+
   it('plugin authoritative: the intent is the write; a dropped emit latches the visible error', async () => {
     emitBridgeIntent.mockReturnValue(false);
     const props = baseProps([{ id: 'a', completed: false, title: 'A' }], {

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -118,6 +118,9 @@ export default function useObsidianSync({
   // Multi-user changes which imported rows the sync payload excludes, and
   // therefore which ones the calendar projection carries.
   multiUserEnabled = false,
+  // The device's multi-user identity; stamped on the calendar projection so
+  // the plugin can show its viewer's calendars only.
+  meUserSyncId = null,
 }) {
   // Fresh bin contents for the async sync cycle (same staleness fix as the
   // task refs above — interval-triggered syncs must not see the closure's
@@ -595,6 +598,7 @@ export default function useObsidianSync({
         const input = calendarProjectionInput(cache, window);
         const projection = buildCalendarProjection(input.tasks, {
           today, deviceId: getDeviceId(), multiUserEnabled, days: input.days,
+          userSyncId: multiUserEnabled ? meUserSyncId : null,
         });
         void publishBridgeCalendarProjection(projection, calendarProjectionHash(projection));
       } catch (e) {

--- a/src/utils/obsidianBridgePairing.js
+++ b/src/utils/obsidianBridgePairing.js
@@ -86,9 +86,25 @@ export async function startBridgePairing(vaultHandle, deviceToken) {
     // generations tells the plugin an offer supersedes its stored pairing.
     generation: pairingSaltB64,
     createdAt: new Date().toISOString(),
+    // Multi-user (companion 4.2, user-awareness): the plugin's default
+    // "show tasks for" is the user this device is signed in as, so pairing
+    // from your own device needs no further setup. Null when single-user.
+    userSyncId: currentUserSyncId(),
   }, code);
   await writeVaultDotFile(vaultHandle, PAIRING_DIR, PAIRING_FILE, offer);
   return { code };
+}
+
+// The device-local multi-user choice (App.jsx keeps it in this key; it is
+// deliberately never synced, every device answers "who am I" for itself).
+export function currentUserSyncId() {
+  try {
+    if (JSON.parse(localStorage.getItem('dayglance-multi-user-enabled') || 'false') !== true) return null;
+    const cfg = JSON.parse(localStorage.getItem('dayglance-multi-user-config') || 'null');
+    return typeof cfg?.meUserSyncId === 'string' && cfg.meUserSyncId ? cfg.meUserSyncId : null;
+  } catch {
+    return null;
+  }
 }
 
 /** Cancel an outstanding offer by overwriting it with the cancel form. */

--- a/src/utils/obsidianCalendarProjection.js
+++ b/src/utils/obsidianCalendarProjection.js
@@ -30,7 +30,7 @@ export const isProjectedCalendarEvent = (t, { multiUserEnabled = false } = {}) =
  *   reader can say how old a given day's events are and resolve two devices'
  *   copies of a day by freshness.
  */
-export function buildCalendarProjection(tasks, { today, deviceId, now = new Date(), multiUserEnabled = false, days = null }) {
+export function buildCalendarProjection(tasks, { today, deviceId, now = new Date(), multiUserEnabled = false, days = null, userSyncId = null }) {
   const from = shiftDateStr(today, -CALENDAR_PROJECTION_WINDOW_DAYS);
   const to = shiftDateStr(today, CALENDAR_PROJECTION_WINDOW_DAYS);
   const events = [];
@@ -52,6 +52,10 @@ export function buildCalendarProjection(tasks, { today, deviceId, now = new Date
   }
   events.sort((a, b) => (a.date === b.date ? String(a.id).localeCompare(String(b.id)) : (a.date < b.date ? -1 : 1)));
   const payload = { v: 1, kind: 'projection', type: 'calendar', deviceId, from, to, publishedAt: now.toISOString(), events };
+  // Multi-user: a device's calendars belong to the user it is signed in as
+  // (feeds are per-user; a phone's native calendar is its owner's), so the
+  // plugin can keep only its viewer's projections. Absent when single-user.
+  if (userSyncId) payload.userSyncId = userSyncId;
   if (days) {
     payload.days = {};
     for (const [d, at] of Object.entries(days)) if (d >= from && d <= to) payload.days[d] = at;

--- a/src/utils/obsidianCalendarProjection.test.js
+++ b/src/utils/obsidianCalendarProjection.test.js
@@ -37,6 +37,15 @@ describe('buildCalendarProjection', () => {
     expect(payload.events[0]).toMatchObject({ color: '#ff0000', calendarName: 'Work' });
   });
 
+  it('carries the publishing device\'s user when given, and omits the field when single-user', () => {
+    const withUser = buildCalendarProjection([feed()], { today: '2026-09-02', deviceId: 'd', userSyncId: 'u-me' });
+    expect(withUser.userSyncId).toBe('u-me');
+    const single = buildCalendarProjection([feed()], { today: '2026-09-02', deviceId: 'd', userSyncId: null });
+    expect('userSyncId' in single).toBe(false);
+    // A viewer change is a content change: the projection republishes.
+    expect(calendarProjectionHash(withUser)).not.toBe(calendarProjectionHash(single));
+  });
+
   it('hash ignores the publish stamp so an unchanged projection is not republished', () => {
     const a = buildCalendarProjection([feed()], { today: '2026-09-02', deviceId: 'd', now: new Date('2026-09-02T10:00:00Z') });
     const b = buildCalendarProjection([feed()], { today: '2026-09-02', deviceId: 'd', now: new Date('2026-09-02T11:00:00Z') });


### PR DESCRIPTION
## Summary

App side of the user-awareness ruling (companion spec §4.1 amendment, §4.2 decision 9). On a two-member account the completion log wrote the other member's completions and the sidebar showed her tasks, because neither path had a notion of a viewer. The plugin half follows in a second PR stacked on this one.

- **Completion log filters to the current user.** `useCompletionLog` takes the app's own visibility rule (`isVisibleForUser`: unassigned, or assigned to me) and snapshots only visible tasks, inbox items and recurring templates, so another member's completions are hers to log from her devices. Unassigned tasks log from every member's device; the exact-line dedupe collapses the duplicate in a shared vault. Single-user accounts are unaffected.
- **Calendar projection carries the publisher's user.** `buildCalendarProjection` adds `userSyncId` when multi-user is on (part of the content hash, so a viewer change republishes). The plugin will keep only its viewer's projections.
- **Pairing offer carries the pairing device's user.** `startBridgePairing` includes `userSyncId` (null when multi-user is off), read from the device-local multi-user config, so the plugin's default viewer is the person who paired. `BridgePairingCredentials` type gains the optional field.
- Spec: §4.1 multi-user amendment and §4.2 decision 9, recording the owner's assumption that people do not share Obsidian vaults (so a vault-scoped viewer setting is the right scope) and that the direct-access writeback rule is a separate pending ruling.

## Verification
- New tests: completion log logs mine and unassigned, never another member's; projection carries or omits `userSyncId`.
- Lint clean; full suite green (2777 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_