### PR TITLE
Plugin: agenda viewer (multi-user), defaulted from the pairing, set in settings

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -40,7 +40,12 @@ manually or via BRAT, not submitted to the community directory.
   rows on the bridge stream, built from a per-day cache of the fetches the
   app already makes) and the sidebar merges them with per-day authority (the
   device that fetched a day most recently supplies that day's events); the
-  footer notes when the selected day's events are over an hour old. Tags in
+  footer notes when the selected day's events are over an hour old. On a
+  multi-user account the agenda shows one person's view: tasks unassigned or
+  assigned to them, routines they own, and their devices' calendars. The
+  viewer defaults to the user of the dayGLANCE device that paired the vault
+  and can be changed (or set to Everyone) under "Show tasks for" in the
+  settings tab. Tags in
   titles render faded; `[[wikilinks]]` render as their display text and
   click through to the note.
   It reads the account's task rows directly from GLANCEvault: enter your

--- a/dayglance-obsidian-plugin/src/agenda.ts
+++ b/dayglance-obsidian-plugin/src/agenda.ts
@@ -65,7 +65,7 @@ const CRYPTO_DB_NAME = 'dayglance-bridge';
 // scheme), so the kind is readable before decryption. Routines are the
 // day's placed chips (todayRoutines) plus two singletons: the day they were
 // placed for and the day's completions.
-const AGENDA_KINDS = new Set(['tasks', 'recurringTasks', 'todayRoutines']);
+const AGENDA_KINDS = new Set(['tasks', 'recurringTasks', 'todayRoutines', 'users']);
 const SINGLETON_KIND = 'singleton';
 const AGENDA_SINGLETONS = new Set(['routinesDate', 'routineCompletions']);
 // Optimistic completion marks time out: dayGLANCE applies an action within
@@ -79,7 +79,18 @@ export type AgendaKeyState = 'unpaired' | 'no-key' | 'ready';
 export interface AgendaHost {
   app: App;
   getPairing(): BridgePairing | undefined;
+  /**
+   * The viewer (companion 4.2, decision 9): a user syncId, or null for
+   * everyone. Tasks and recurring templates show when unassigned or assigned
+   * to the viewer, routines when unowned or owned by the viewer, calendar
+   * projections when unstamped or stamped with the viewer — the app's own
+   * rules, applied at read time so a viewer change needs no re-fetch.
+   */
+  getViewer(): string | null;
 }
+
+/** A synced dayGLANCE user, as the settings picker lists them. */
+export interface AgendaUser { syncId: string; name: string }
 
 export interface AgendaStatus {
   key: AgendaKeyState;
@@ -135,6 +146,7 @@ export class AgendaStore {
   private tasks = new Map<string, TaskRow>();
   private recurring = new Map<string, TaskRow>();
   private routines = new Map<string, TaskRow>();
+  private members = new Map<string, TaskRow>();
   private singletons = new Map<string, unknown>();
   // Calendar projections (companion 4.2): read-only calendar events never
   // sync, so each dayGLANCE device publishes its view as a bridge-stream row
@@ -177,6 +189,11 @@ export class AgendaStore {
     return () => { this.listeners.delete(cb); };
   }
 
+  /** The viewer changed: filters are applied at read time, so just redraw. */
+  notifyViewerChanged(): void {
+    this.emit();
+  }
+
   getStatus(): AgendaStatus {
     this.recomputeKeyState();
     return { ...this.status };
@@ -190,10 +207,41 @@ export class AgendaStore {
     return true;
   }
 
+  /** The account's users, for the viewer picker (name-sorted). */
+  users(): AgendaUser[] {
+    const out: AgendaUser[] = [];
+    for (const u of this.members.values()) {
+      const syncId = String((u as { syncId?: unknown }).syncId ?? u.id ?? '');
+      if (!syncId) continue;
+      out.push({ syncId, name: String((u as { name?: unknown }).name ?? syncId) });
+    }
+    return out.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  // The viewer filters (see AgendaHost.getViewer). A null viewer sees all.
+  private visibleTask(t: TaskRow): boolean {
+    const viewer = this.host.getViewer();
+    if (!viewer) return true;
+    const assigned = (t as { assignedUserSyncIds?: unknown }).assignedUserSyncIds;
+    return !Array.isArray(assigned) || assigned.length === 0 || assigned.includes(viewer);
+  }
+  private ownedRoutine(r: TaskRow): boolean {
+    const viewer = this.host.getViewer();
+    if (!viewer) return true;
+    const owner = (r as { ownerSyncId?: unknown }).ownerSyncId;
+    return !owner || owner === viewer;
+  }
+  private viewerProjection(p: CalendarProjection): boolean {
+    const viewer = this.host.getViewer();
+    if (!viewer) return true;
+    const stamped = (p as { userSyncId?: unknown }).userSyncId;
+    return !stamped || stamped === viewer;
+  }
+
   /** The routines placed for a day (only the day dayGLANCE stamped; see agenda-core). */
   routinesFor(dateStr: string): RoutineItem[] {
     return routinesForDate({
-      todayRoutines: [...this.routines.values()],
+      todayRoutines: [...this.routines.values()].filter((r) => this.ownedRoutine(r)),
       routinesDate: this.singletons.get('routinesDate') as string | null | undefined,
       routineCompletions: this.singletons.get('routineCompletions') as Record<string, string> | undefined,
     }, dateStr);
@@ -201,11 +249,15 @@ export class AgendaStore {
 
   /** The agenda for an inclusive YYYY-MM-DD window, from the mirror plus the calendar projections. */
   agenda(from: string, to: string): Record<string, AgendaItem[]> {
-    const calendar = mergeCalendarProjections([...this.projections.values()], { from, to });
+    const calendar = mergeCalendarProjections([...this.projections.values()].filter((p) => this.viewerProjection(p)), { from, to });
     this.status.calendarAsOf = calendar.freshestAt;
     this.status.calendarDayAsOf = calendar.dayAsOf;
     return buildAgenda(
-      { tasks: [...this.tasks.values()], recurringTasks: [...this.recurring.values()], calendarEvents: calendar.events },
+      {
+        tasks: [...this.tasks.values()].filter((t) => this.visibleTask(t)),
+        recurringTasks: [...this.recurring.values()].filter((t) => this.visibleTask(t)),
+        calendarEvents: calendar.events,
+      },
       { from, to },
     );
   }
@@ -324,7 +376,10 @@ export class AgendaStore {
   }
 
   private mapFor(kind: string): Map<string, TaskRow> {
-    return kind === 'tasks' ? this.tasks : kind === 'recurringTasks' ? this.recurring : this.routines;
+    if (kind === 'tasks') return this.tasks;
+    if (kind === 'recurringTasks') return this.recurring;
+    if (kind === 'users') return this.members;
+    return this.routines;
   }
 
   // undefined = undecryptable under this key; null = decryptable but not a
@@ -454,6 +509,7 @@ export class AgendaStore {
     this.tasks.clear();
     this.recurring.clear();
     this.routines.clear();
+    this.members.clear();
     this.singletons.clear();
     this.projections.clear();
     this.pending.clear();

--- a/dayglance-obsidian-plugin/src/main.ts
+++ b/dayglance-obsidian-plugin/src/main.ts
@@ -64,6 +64,11 @@ interface BridgeData {
   deviceId?: string;
   pairing?: BridgePairing;
   bridge?: BridgeState;
+  // The agenda's viewer, when chosen explicitly in settings (companion 4.2,
+  // decision 9). Absent = the pairing's default. Rides data.json like the
+  // pairing itself: the owner's assumption of record is one person per
+  // vault, so vault scope is the right scope.
+  viewer?: { userSyncId: string | null };
 }
 
 const mintDeviceId = (): string => {
@@ -101,6 +106,7 @@ export default class DayGlanceBridgePlugin extends Plugin {
     this.agenda = new AgendaStore({
       app: this.app,
       getPairing: () => this.data.pairing,
+      getViewer: () => this.viewer(),
     });
     void this.agenda.init();
 
@@ -179,6 +185,14 @@ export default class DayGlanceBridgePlugin extends Plugin {
       verifyPassphrase: (passphrase) => this.agenda.verifyPassphrase(passphrase),
       forgetPassphrase: () => this.agenda.forgetKey(),
       openAgenda: () => this.openAgenda(),
+      listUsers: () => this.agenda.users(),
+      getViewer: () => this.viewer(),
+      viewerIsDefault: () => this.data.viewer === undefined,
+      setViewer: async (userSyncId) => {
+        this.data.viewer = { userSyncId };
+        await this.saveData(this.data);
+        this.agenda.notifyViewerChanged();
+      },
     };
     this.addSettingTab(new BridgeSettingTab(host));
 
@@ -243,6 +257,7 @@ export default class DayGlanceBridgePlugin extends Plugin {
     if (!previous) return;
     delete this.data.pairing;
     delete this.data.bridge;
+    delete this.data.viewer;
     // Live sync must not outlive its credentials (armed-by-proof invariant):
     // tear the stream down with the pairing, not a tick later.
     this.transport.shutdown();
@@ -253,6 +268,12 @@ export default class DayGlanceBridgePlugin extends Plugin {
     await publishPairingMeta(null, previous).catch(() => {});
     await this.writeHeartbeat();
     new Notice('dayGLANCE bridge: unpaired. Also revoke the device token on your GLANCEvault server — unpairing only forgets the local credentials.');
+  }
+
+  // Explicit choice wins; else the pairing device's user; else everyone.
+  private viewer(): string | null {
+    if (this.data.viewer) return this.data.viewer.userSyncId;
+    return this.data.pairing?.userSyncId ?? null;
   }
 
   // Reveal (or create, in the right sidebar) the agenda view, landing on

--- a/dayglance-obsidian-plugin/src/pairing.ts
+++ b/dayglance-obsidian-plugin/src/pairing.ts
@@ -33,6 +33,12 @@ export interface BridgePairing {
   pairingSalt: string;
   generation: string;
   pairedAt: string;
+  /**
+   * The multi-user identity of the dayGLANCE device that minted the offer —
+   * the agenda's default viewer (companion 4.2, decision 9). Null/absent
+   * when that account is single-user or the pairing predates the field.
+   */
+  userSyncId?: string | null;
 }
 
 // fetch shim over Obsidian's requestUrl — the sanctioned way to make
@@ -136,6 +142,7 @@ export async function submitPairingCode(host: PairingHost, code: string): Promis
       pairingSalt: creds.pairingSalt,
       generation: creds.generation,
       pairedAt: new Date().toISOString(),
+      userSyncId: typeof creds.userSyncId === 'string' && creds.userSyncId ? creds.userSyncId : null,
     });
     await deletePairingOffer(host.app);
     return {

--- a/dayglance-obsidian-plugin/src/settingsTab.ts
+++ b/dayglance-obsidian-plugin/src/settingsTab.ts
@@ -14,7 +14,7 @@ import {
   type PairingHost,
   type BridgePairing,
 } from './pairing';
-import type { AgendaKeyState } from './agenda';
+import type { AgendaKeyState, AgendaUser } from './agenda';
 
 // Stamped by esbuild at bundle time (see esbuild.config.mjs `define`).
 // Guarded so a build without the define (tests, tooling) still runs.
@@ -43,6 +43,12 @@ export interface BridgeSettingsHost extends PairingHost {
   verifyPassphrase(passphrase: string): Promise<{ ok: boolean; message: string }>;
   forgetPassphrase(): Promise<void>;
   openAgenda(): Promise<void>;
+  /** The viewer picker (companion 4.2, decision 9): who the agenda shows tasks for. */
+  listUsers(): AgendaUser[];
+  getViewer(): string | null;
+  /** True while the viewer is the pairing's default rather than an explicit choice. */
+  viewerIsDefault(): boolean;
+  setViewer(userSyncId: string | null): Promise<void>;
 }
 
 const pairedSince = (pairing: BridgePairing): string => {
@@ -134,6 +140,7 @@ export class BridgeSettingTab extends PluginSettingTab {
     this.containerEl.createEl('h3', { text: 'dayGLANCE account' });
     const state = this.host.agendaKeyState();
     if (state === 'ready') {
+      this.displayViewer();
       new Setting(this.containerEl)
         .setName('Sync passphrase verified on this device')
         .setDesc('The dayGLANCE agenda view can read your tasks. The key is stored only on this device; the passphrase itself was not kept.')
@@ -182,6 +189,29 @@ export class BridgeSettingTab extends PluginSettingTab {
         .setCta()
         .onClick(() => void submit()));
     resultEl = this.containerEl.createEl('p', { text: '', cls: 'setting-item-description' });
+  }
+
+  // Who the agenda is for. Defaults to the user of the dayGLANCE device
+  // that paired this vault; the account's synced users fill the list.
+  private displayViewer(): void {
+    const users = this.host.listUsers();
+    const viewer = this.host.getViewer();
+    const known = users.some((u) => u.syncId === viewer);
+    new Setting(this.containerEl)
+      .setName('Show tasks for')
+      .setDesc(this.host.viewerIsDefault()
+        ? 'Set from the dayGLANCE device that paired this vault. Tasks, routines and calendars are filtered to this user; choose Everyone to see the whole account.'
+        : 'Tasks, routines and calendars are filtered to this user; choose Everyone to see the whole account.')
+      .addDropdown((dd) => {
+        dd.addOption('', 'Everyone');
+        for (const u of users) dd.addOption(u.syncId, u.name);
+        if (viewer && !known) dd.addOption(viewer, `Unknown user (${viewer.slice(0, 8)})`);
+        dd.setValue(viewer ?? '');
+        dd.onChange(async (v) => {
+          await this.host.setViewer(v || null);
+          this.display();
+        });
+      });
   }
 
   private displayUnpaired(): void {

--- a/packages/agenda-core/types/index.d.ts
+++ b/packages/agenda-core/types/index.d.ts
@@ -68,6 +68,8 @@ export interface CalendarProjection {
   events: unknown[];
   /** Per-day fetch stamps (date → ISO) from the publisher's projection cache; absent on older payloads. */
   days?: Record<string, string>;
+  /** The publishing device's multi-user identity; absent when single-user. */
+  userSyncId?: string | null;
 }
 export function mergeCalendarProjections(
   projections: unknown[],


### PR DESCRIPTION
## Summary

Plugin half of the user-awareness ruling (companion spec §4.2 decision 9). Stacked on #1522, which carries the `userSyncId` field on the pairing credentials and the calendar projection; GitHub retargets this to `main` once that merges.

- **Viewer.** `AgendaHost.getViewer()` returns a user syncId or null for everyone. The store applies the app's own rules at read time, so a viewer change needs no re-fetch:
  - tasks and recurring templates: unassigned, or assigned to the viewer;
  - routines: unowned, or owned by the viewer;
  - calendar projections: unstamped (single-user or pre-field publishers), or stamped with the viewer.
- **Default from the pairing.** `BridgePairing` gains `userSyncId`, taken from the offer, so pairing from your own dayGLANCE device sets the viewer with no further setup.
- **"Show tasks for" setting.** In the dayGLANCE account section once the key is verified: a dropdown of the account's synced users (the store now mirrors the `users` kind) plus "Everyone". An explicit choice is stored in `data.json` beside the pairing (`viewer`), wins over the pairing default, and is cleared on unpair. An unknown stored id is listed as such rather than silently dropped.
- README updated.

## Verification
- Plugin `npm run build` clean (tsc strict + esbuild). Filters are pure read-time predicates over the mirror; no new network calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_