### PR TITLE
Vault user scope: first-import assignment to the viewer, writes scoped to the viewer

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -45,7 +45,9 @@ manually or via BRAT, not submitted to the community directory.
   assigned to them, routines they own, and their devices' calendars. The
   viewer defaults to the user of the dayGLANCE device that paired the vault
   and can be changed (or set to Everyone) under "Show tasks for" in the
-  settings tab. Tags in
+  settings tab. The viewer is also published in the pairing-meta row, and
+  dayGLANCE uses it to scope what it writes into this vault and to assign a
+  task first seen in the vault to that person. Tags in
   titles render faded; `[[wikilinks]]` render as their display text and
   click through to the note.
   It reads the account's task rows directly from GLANCEvault: enter your

--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -148,7 +148,14 @@ const obsidianFetch = async (
  * point: it carries the pairing salt that other dayGLANCE devices need
  * BEFORE they can derive the subkey — an HKDF salt is not a secret.
  */
-export async function publishPairingMeta(pairing: BridgePairing | null, previous?: BridgePairing): Promise<void> {
+export async function publishPairingMeta(
+  pairing: BridgePairing | null, previous?: BridgePairing,
+  // The vault's viewer (companion 4.2 decision 9): dayGLANCE devices read
+  // it to scope what they write into this vault and whom a first-imported
+  // line is assigned to. Defaults to the pairing's own user; main.ts passes
+  // the settings override when one is set.
+  viewer: string | null | undefined = pairing?.userSyncId ?? null,
+): Promise<void> {
   const creds = pairing ?? previous;
   if (!creds) return;
   const client = createVaultClient({
@@ -164,6 +171,7 @@ export async function publishPairingMeta(pairing: BridgePairing | null, previous
         envelope: encodePlainBridgeRow({
           v: 1, kind: 'pairing-meta',
           generation: pairing.generation, pairingSalt: pairing.pairingSalt, pairedAt: pairing.pairedAt,
+          ...(viewer ? { userSyncId: viewer } : {}),
         }),
         createdAt: Date.now(),
       }],

--- a/dayglance-obsidian-plugin/src/main.ts
+++ b/dayglance-obsidian-plugin/src/main.ts
@@ -171,7 +171,7 @@ export default class DayGlanceBridgePlugin extends Plugin {
         await this.saveData(this.data);
         // Publish the plaintext pairing-meta row — how OTHER dayGLANCE
         // devices discover the salt and start emitting (bridge.ts).
-        await publishPairingMeta(pairing).catch((e) => console.error('dayGLANCE bridge: meta publish failed', e));
+        await publishPairingMeta(pairing, undefined, this.viewer()).catch((e) => console.error('dayGLANCE bridge: meta publish failed', e));
         // Beat immediately so dayGLANCE's pairing panel confirms
         // without waiting out the interval.
         await this.writeHeartbeat();
@@ -192,6 +192,12 @@ export default class DayGlanceBridgePlugin extends Plugin {
         this.data.viewer = { userSyncId };
         await this.saveData(this.data);
         this.agenda.notifyViewerChanged();
+        // The viewer scopes what dayGLANCE writes into this vault too:
+        // republish the meta row so its devices pick the change up on their
+        // next cycle (the row is plaintext; a user id is not a secret).
+        if (this.data.pairing) {
+          await publishPairingMeta(this.data.pairing, undefined, userSyncId).catch((e) => console.error('dayGLANCE bridge: meta publish failed', e));
+        }
       },
     };
     this.addSettingTab(new BridgeSettingTab(host));

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -445,7 +445,33 @@ ruling below).
    vaults, so a vault-scoped setting is the right scope. App side: the
    projection carries `userSyncId` (the device's identity when multi-user is
    on) and the completion log applies the visibility rule (4.1 amendment).
-   The direct-access writeback's user rule is a separate, pending ruling.
+10. **Vault scan and writeback user rule (2026-09-02, owner ruling; built).**
+   Two shapes were weighed for a task typed into the vault: assign it to
+   "me" on import (chosen), or require a designation marker in the note
+   with undesignated lines left unassigned. In dayGLANCE "unassigned" means
+   shared with every member, and a personal vault is a personal capture
+   surface, so shared is the wrong default; a marker would also add grammar
+   to the parser and the stamper — where the identity hazards have lived —
+   for a case the app already covers (a task meant to be shared is
+   unassigned in dayGLANCE after import). Rules, in
+   `utils/obsidianUserScope.js`:
+   - **Which "me": the vault's viewer, never the importing device's user.**
+     On the plugin path every dayGLANCE device on the account applies the
+     same observation stream, so the importing device's user is wrong half
+     the time. The plugin publishes the viewer in the plaintext pairing-meta
+     row (`userSyncId`: the pairing's default or the "Show tasks for"
+     override, republished on change) and dayGLANCE reads it from the cached
+     meta. On direct access the vault is on this device, so the viewer is
+     the device's user. No viewer (single-user, Everyone, or a plugin
+     predating the field) means the pre-ruling behavior.
+   - **First import only.** A task not known to the app (either live list or
+     the recycle bin) and carrying no assignment is assigned to the viewer as
+     it enters; known tasks are never touched, so assignment stays app-owned
+     (the preserve-app-fields carry already guaranteed that for the merge).
+   - **The write side mirrors it.** The writeback effect considers only
+     tasks visible to the viewer, on both the direct writer and the intent
+     emitter, so another member's tasks never land in this person's notes.
+     Lines written before the ruling are not removed.
 
 **Owner ruling (2026-09-02, pending).** The owner expected the plugin to be
 "a GLANCEvault client like any other, with full access to dayGLANCE"; decision
@@ -781,4 +807,5 @@ Read-write scan scope is not in this phase. See 6.2.
 | 9 | Sidebar completion write path for tasks with no vault line (4.2) | **Decided: action rows** (`act:` on the bridge stream), applied by dayGLANCE as the single data-plane writer; built |
 | 11 | Plugin reads the data plane with a device-local root key derived from the sync passphrase (4.2, decision 1) | Built under a standing veto; owner ruling pending |
 | 12 | Calendar events in the sidebar (excluded from sync by design) | **Decided: dayGLANCE publishes a per-device projection row** on the bridge stream; the plugin unions them (4.2, decision 8); built |
+| 13 | Multi-user: whose tasks the sidebar, the completion log and the vault writeback handle | **Decided: the vault's viewer**, defaulted from the pairing, overridable in the plugin; first-import assignment to the viewer, writes scoped to the viewer (4.2, decisions 9 and 10); built |
 | 10 | Ownership rule for dayGLANCE-maintained frontmatter (4.3) | Open; what-wins-on-divergence category, ruling before first write |

--- a/src/hooks/useObsidianSync.arbitration.test.js
+++ b/src/hooks/useObsidianSync.arbitration.test.js
@@ -57,6 +57,7 @@ vi.mock('../native.js', () => ({
 const emitBridgeIntent = vi.fn(() => true);
 const getBridgePairingMeta = vi.fn(async () => null);
 vi.mock('../utils/obsidianBridgeStream.js', () => ({
+  cachedBridgePairingMeta: () => null,
   emitBridgeIntent: (...a) => emitBridgeIntent(...a),
   flushBridgeOutbox: vi.fn(async () => true),
   publishBridgeConfig: vi.fn(async () => {}),

--- a/src/hooks/useObsidianSync.binRestore.test.js
+++ b/src/hooks/useObsidianSync.binRestore.test.js
@@ -67,6 +67,7 @@ vi.mock('../native.js', () => ({
   nativeSetLaunchOnWrite: vi.fn(),
 }));
 vi.mock('../utils/obsidianBridgeStream.js', () => ({
+  cachedBridgePairingMeta: () => null,
   emitBridgeIntent: vi.fn(() => true),
   flushBridgeOutbox: vi.fn(async () => true),
   publishBridgeConfig: vi.fn(async () => {}),

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -34,7 +34,8 @@ import { blockIdWritesEnabled, completionMarkerWritesEnabled } from '../utils/ob
 import { titleConflictNoticeText } from '../utils/obsidianTitleConflict.js';
 import { withCreationFrontmatter } from '../utils/obsidianFrontmatter.js';
 import { writebackSnapshotEntry } from '../utils/obsidianWritebackSnapshot.js';
-import { emitBridgeIntent, flushBridgeOutbox, publishBridgeConfig, publishBridgeCalendarProjection, getBridgePairingMeta } from '../utils/obsidianBridgeStream.js';
+import { emitBridgeIntent, flushBridgeOutbox, publishBridgeConfig, publishBridgeCalendarProjection, getBridgePairingMeta, cachedBridgePairingMeta } from '../utils/obsidianBridgeStream.js';
+import { vaultViewerFor, visibleToViewer, assignVaultViewer, knownTaskIds } from '../utils/obsidianUserScope.js';
 import { fetchBridgeObservations, applyBridgeObservations, commitBridgeObservationCursor, pendingBridgeObservations } from '../utils/obsidianBridgeInbound.js';
 import {
   fetchBridgeActions, planBridgeActions, applyActionsToTasks, applyActionsToRecurring,
@@ -745,8 +746,15 @@ export default function useObsidianSync({
             // ruling 6): a scanned line whose tombstone predates its note's
             // mtime is re-admitted with lastModified lifted to that mtime.
             const observedNoteMtimes = noteMtimesFromDailyNotes(applied.dailyNotes);
-            setTasks(prev => mergeObsidianTasks(prev, binRestore.scheduledTasks, applied.scannedIds, preserveObsidianAppFields, tombstones, observedNoteMtimes));
-            setUnscheduledTasks(prev => mergeObsidianTasks(prev, binRestore.inboxTasks, applied.scannedIds, preserveObsidianAppFields, tombstones, observedNoteMtimes));
+            // FIRST-IMPORT ASSIGNMENT (utils/obsidianUserScope.js): a task new
+            // to the app is the vault's viewer's — here the pairing meta's
+            // user, since every device on the account applies this stream.
+            const viewer = vaultViewerFor({ authoritative: true, meta: cachedBridgePairingMeta() });
+            const known = knownTaskIds(currentTasks, currentInbox, recycleBinRef.current);
+            const scheduledIn = assignVaultViewer(binRestore.scheduledTasks, { viewer, knownIds: known });
+            const inboxIn = assignVaultViewer(binRestore.inboxTasks, { viewer, knownIds: known });
+            setTasks(prev => mergeObsidianTasks(prev, scheduledIn, applied.scannedIds, preserveObsidianAppFields, tombstones, observedNoteMtimes));
+            setUnscheduledTasks(prev => mergeObsidianTasks(prev, inboxIn, applied.scannedIds, preserveObsidianAppFields, tombstones, observedNoteMtimes));
             // Refresh the writeback snapshot for the OBSERVED tasks only —
             // observations are per-note, so untouched entries stay put.
             // This is also how this device's own emitted writes settle
@@ -947,8 +955,15 @@ export default function useObsidianSync({
       // so a verbatim re-creation revives on a direct scan exactly as it does
       // on an observation.
       const scannedNoteMtimes = noteMtimesFromDailyNotes(result.dailyNotes);
-      setTasks(prev => mergeObsidianTasks(prev, binRestore.scheduledTasks, scannedObsidianIds, preserveObsidianAppFields, tombstones, scannedNoteMtimes));
-      setUnscheduledTasks(prev => mergeObsidianTasks(prev, binRestore.inboxTasks, scannedObsidianIds, preserveObsidianAppFields, tombstones, scannedNoteMtimes));
+      // FIRST-IMPORT ASSIGNMENT (utils/obsidianUserScope.js): on direct
+      // access the vault is on this device, so the viewer is this device's
+      // user. Known tasks keep the app's own assignment.
+      const directViewer = vaultViewerFor({ authoritative: false, multiUserEnabled, meUserSyncId });
+      const directKnown = knownTaskIds(currentTasks, currentInbox, recycleBinRef.current);
+      const scheduledIn = assignVaultViewer(binRestore.scheduledTasks, { viewer: directViewer, knownIds: directKnown });
+      const inboxIn = assignVaultViewer(binRestore.inboxTasks, { viewer: directViewer, knownIds: directKnown });
+      setTasks(prev => mergeObsidianTasks(prev, scheduledIn, scannedObsidianIds, preserveObsidianAppFields, tombstones, scannedNoteMtimes));
+      setUnscheduledTasks(prev => mergeObsidianTasks(prev, inboxIn, scannedObsidianIds, preserveObsidianAppFields, tombstones, scannedNoteMtimes));
 
       // Snapshot the fresh task state so the writeback effect doesn't re-trigger
       const snapshot = {};
@@ -1175,7 +1190,16 @@ export default function useObsidianSync({
     if (obsidianSyncInProgressRef.current) { writebackPendingRef.current = true; return; }
     writebackPendingRef.current = false;
 
-    const allObsidian = [...tasks, ...unscheduledTasks].filter(t => t.importSource === 'obsidian' && t.obsidianRawTitle);
+    // USER SCOPE (utils/obsidianUserScope.js): only tasks visible to the
+    // vault's viewer are written, so another member's tasks never land in
+    // this person's notes. The viewer is this device's user on direct access
+    // and the pairing meta's user when the plugin is authoritative.
+    const writeViewer = vaultViewerFor({
+      authoritative: bridgeHeartbeatRef.current.pluginAuthoritative,
+      meta: cachedBridgePairingMeta(), multiUserEnabled, meUserSyncId,
+    });
+    const allObsidian = [...tasks, ...unscheduledTasks]
+      .filter(t => t.importSource === 'obsidian' && t.obsidianRawTitle && visibleToViewer(t, writeViewer));
     const prev = obsidianPrevTaskStateRef.current;
     const isNative = obsidianVaultHandleRef.current === 'native';
     // ── ARBITRATION (§3.2, Phase 6 PR 3) — gate (a): emit-in-same-tick ────

--- a/src/hooks/useObsidianSync.renameWar.test.js
+++ b/src/hooks/useObsidianSync.renameWar.test.js
@@ -57,6 +57,7 @@ vi.mock('../native.js', () => ({
 }));
 const emitBridgeIntent = vi.fn(() => true);
 vi.mock('../utils/obsidianBridgeStream.js', () => ({
+  cachedBridgePairingMeta: () => null,
   emitBridgeIntent: (...a) => emitBridgeIntent(...a),
   flushBridgeOutbox: vi.fn(async () => true),
   publishBridgeConfig: vi.fn(async () => {}),

--- a/src/hooks/useObsidianSync.revival.test.js
+++ b/src/hooks/useObsidianSync.revival.test.js
@@ -53,6 +53,7 @@ vi.mock('../native.js', () => ({
 }));
 const emitBridgeIntent = vi.fn(() => true);
 vi.mock('../utils/obsidianBridgeStream.js', () => ({
+  cachedBridgePairingMeta: () => null,
   emitBridgeIntent: (...a) => emitBridgeIntent(...a),
   flushBridgeOutbox: vi.fn(async () => true),
   publishBridgeConfig: vi.fn(async () => {}),

--- a/src/hooks/useObsidianSync.sseNudge.test.js
+++ b/src/hooks/useObsidianSync.sseNudge.test.js
@@ -48,6 +48,7 @@ vi.mock('../native.js', () => ({
   nativeSetLaunchOnWrite: vi.fn(),
 }));
 vi.mock('../utils/obsidianBridgeStream.js', () => ({
+  cachedBridgePairingMeta: () => null,
   emitBridgeIntent: vi.fn(() => true),
   flushBridgeOutbox: vi.fn(async () => true),
   publishBridgeConfig: vi.fn(async () => {}),

--- a/src/hooks/useObsidianSync.stampOnSight.test.js
+++ b/src/hooks/useObsidianSync.stampOnSight.test.js
@@ -54,6 +54,7 @@ vi.mock('../native.js', () => ({
 }));
 const emitBridgeIntent = vi.fn(() => true);
 vi.mock('../utils/obsidianBridgeStream.js', () => ({
+  cachedBridgePairingMeta: () => null,
   emitBridgeIntent: (...a) => emitBridgeIntent(...a),
   flushBridgeOutbox: vi.fn(async () => true),
   publishBridgeConfig: vi.fn(async () => {}),

--- a/src/hooks/useObsidianSync.stampWar.test.js
+++ b/src/hooks/useObsidianSync.stampWar.test.js
@@ -56,6 +56,7 @@ vi.mock('../native.js', () => ({
 }));
 const emitBridgeIntent = vi.fn(() => true);
 vi.mock('../utils/obsidianBridgeStream.js', () => ({
+  cachedBridgePairingMeta: () => null,
   emitBridgeIntent: (...a) => emitBridgeIntent(...a),
   flushBridgeOutbox: vi.fn(async () => true),
   publishBridgeConfig: vi.fn(async () => {}),

--- a/src/hooks/useObsidianSync.wikiNoteCreate.test.js
+++ b/src/hooks/useObsidianSync.wikiNoteCreate.test.js
@@ -67,6 +67,7 @@ vi.mock('../native.js', () => ({
 }));
 const emitBridgeIntent = vi.fn(() => true);
 vi.mock('../utils/obsidianBridgeStream.js', () => ({
+  cachedBridgePairingMeta: () => null,
   emitBridgeIntent: (...a) => emitBridgeIntent(...a),
   flushBridgeOutbox: vi.fn(async () => true),
   publishBridgeConfig: vi.fn(async () => {}),

--- a/src/utils/obsidianBridgeStream.js
+++ b/src/utils/obsidianBridgeStream.js
@@ -143,6 +143,15 @@ const vaultClientOrNull = () => {
  * before pairing completed would otherwise gate emits off for up to a TTL
  * while direct writes have already stopped.
  */
+/**
+ * The cached pairing meta, synchronously (no fetch): what the last
+ * getBridgePairingMeta refresh learned, or null. For callers that run in a
+ * render effect and need the vault's viewer (`userSyncId`) without awaiting.
+ */
+export function cachedBridgePairingMeta() {
+  return readJson(META_CACHE_KEY, null)?.meta ?? null;
+}
+
 export async function getBridgePairingMeta({ force = false } = {}) {
   const cached = readJson(META_CACHE_KEY, null);
   if (!force && cached && Date.now() - (cached.fetchedAt || 0) < META_TTL_MS) {

--- a/src/utils/obsidianUserScope.js
+++ b/src/utils/obsidianUserScope.js
@@ -1,0 +1,70 @@
+// The vault's USER SCOPE (companion spec 4.2 decision 9, the writeback and
+// scan ruling of 2026-09-02). Pure.
+//
+// A vault belongs to one person (the owner's assumption of record). Two
+// rules follow, both keyed on the vault's VIEWER — the user the vault is
+// scoped to — never on the importing device's user:
+//
+//  • IMPORT: a task first seen in the vault is assigned to the viewer. In
+//    dayGLANCE "unassigned" means shared with every member, and a personal
+//    vault is a personal capture surface, so shared is the wrong default. A
+//    task the user wants shared is unassigned in dayGLANCE afterwards.
+//    FIRST IMPORT ONLY: a task already known to the app keeps whatever
+//    assignment the app holds — assignment is app-owned and the scan never
+//    rewrites it (the preserve-app-fields carry already guarantees that for
+//    known tasks; this helper simply never touches them).
+//  • WRITE: only tasks visible to the viewer are written to the vault, so
+//    another member's tasks never land in this person's notes.
+//
+// WHICH VIEWER. On direct access the vault sits on this device, so the
+// viewer is this device's user. On the plugin path every dayGLANCE device
+// on the account applies the same observation stream, so the importing
+// device's user would be wrong half the time; the viewer comes from the
+// plugin's pairing-meta row instead (`userSyncId`: the pairing's default or
+// the plugin's "Show tasks for" setting). No viewer (single-user, or a
+// plugin predating the field) means the pre-ruling behavior: unassigned on
+// import, everything written.
+
+/**
+ * @param {{ authoritative: boolean, meta?: { userSyncId?: string|null } | null, multiUserEnabled?: boolean, meUserSyncId?: string|null }} ctx
+ * @returns {string|null}
+ */
+export function vaultViewerFor({ authoritative, meta = null, multiUserEnabled = false, meUserSyncId = null }) {
+  if (authoritative) {
+    const v = meta && typeof meta.userSyncId === 'string' ? meta.userSyncId : null;
+    return v || null;
+  }
+  return multiUserEnabled && typeof meUserSyncId === 'string' && meUserSyncId ? meUserSyncId : null;
+}
+
+/** The app's visibility rule, for a viewer: unassigned, or assigned to the viewer. */
+export function visibleToViewer(task, viewer) {
+  if (!viewer) return true;
+  const assigned = task?.assignedUserSyncIds;
+  return !Array.isArray(assigned) || assigned.length === 0 || assigned.includes(viewer);
+}
+
+/**
+ * Stamp first-import assignment: every task NOT in `knownIds` and carrying no
+ * assignment becomes the viewer's. Returns the same array when nothing
+ * changes. Known ids (live lists and the recycle bin) are left exactly as
+ * scanned, so the app's own assignment survives the merge's carry.
+ */
+export function assignVaultViewer(tasks, { viewer, knownIds }) {
+  if (!viewer || !Array.isArray(tasks) || !tasks.length) return tasks;
+  let changed = false;
+  const out = tasks.map((t) => {
+    if (!t || knownIds.has(String(t.id))) return t;
+    if (Array.isArray(t.assignedUserSyncIds) && t.assignedUserSyncIds.length) return t;
+    changed = true;
+    return { ...t, assignedUserSyncIds: [viewer] };
+  });
+  return changed ? out : tasks;
+}
+
+/** The ids the app already knows: both live lists plus the recycle bin. */
+export function knownTaskIds(...lists) {
+  const ids = new Set();
+  for (const list of lists) for (const t of list || []) if (t && t.id != null) ids.add(String(t.id));
+  return ids;
+}

--- a/src/utils/obsidianUserScope.test.js
+++ b/src/utils/obsidianUserScope.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { vaultViewerFor, visibleToViewer, assignVaultViewer, knownTaskIds } from './obsidianUserScope.js';
+
+describe('vaultViewerFor', () => {
+  it('direct access: the device user when multi-user is on; plugin path: the pairing meta user; else null', () => {
+    expect(vaultViewerFor({ authoritative: false, multiUserEnabled: true, meUserSyncId: 'u-me' })).toBe('u-me');
+    expect(vaultViewerFor({ authoritative: false, multiUserEnabled: false, meUserSyncId: 'u-me' })).toBe(null);
+    expect(vaultViewerFor({ authoritative: true, meta: { userSyncId: 'u-vault' }, multiUserEnabled: true, meUserSyncId: 'u-me' })).toBe('u-vault');
+    // Plugin predating the field, or Everyone: no viewer, even though this device has one.
+    expect(vaultViewerFor({ authoritative: true, meta: { generation: 'g' }, multiUserEnabled: true, meUserSyncId: 'u-me' })).toBe(null);
+    expect(vaultViewerFor({ authoritative: true, meta: null, multiUserEnabled: true, meUserSyncId: 'u-me' })).toBe(null);
+  });
+});
+
+describe('visibleToViewer', () => {
+  it('no viewer sees all; otherwise unassigned or assigned-to-viewer', () => {
+    expect(visibleToViewer({ assignedUserSyncIds: ['u-wife'] }, null)).toBe(true);
+    expect(visibleToViewer({}, 'u-me')).toBe(true);
+    expect(visibleToViewer({ assignedUserSyncIds: [] }, 'u-me')).toBe(true);
+    expect(visibleToViewer({ assignedUserSyncIds: ['u-me', 'u-wife'] }, 'u-me')).toBe(true);
+    expect(visibleToViewer({ assignedUserSyncIds: ['u-wife'] }, 'u-me')).toBe(false);
+  });
+});
+
+describe('assignVaultViewer', () => {
+  it('assigns first-seen unassigned tasks to the viewer; leaves known and already-assigned ones; same reference when nothing changes', () => {
+    const scanned = [
+      { id: 'new', title: 'New' },
+      { id: 'known', title: 'Known' },
+      { id: 'binned', title: 'Binned' },
+      { id: 'hers', title: 'Hers', assignedUserSyncIds: ['u-wife'] },
+    ];
+    const known = knownTaskIds([{ id: 'known' }], [], [{ id: 'binned' }]);
+    const out = assignVaultViewer(scanned, { viewer: 'u-me', knownIds: known });
+    expect(out.find((t) => t.id === 'new').assignedUserSyncIds).toEqual(['u-me']);
+    expect(out.find((t) => t.id === 'known')).toBe(scanned[1]);
+    expect(out.find((t) => t.id === 'binned')).toBe(scanned[2]);
+    expect(out.find((t) => t.id === 'hers')).toBe(scanned[3]);
+    expect(assignVaultViewer(scanned, { viewer: null, knownIds: known })).toBe(scanned);
+    expect(assignVaultViewer([scanned[1]], { viewer: 'u-me', knownIds: known })).toEqual([scanned[1]]);
+  });
+});


### PR DESCRIPTION
## Summary

The writeback and scan ruling (companion spec §4.2 decision 10). Stacked on #1523 (which is stacked on #1522); GitHub retargets as each merges.

- **First-import assignment.** A task first seen in the vault, meaning not in either live list or the recycle bin and carrying no assignment, is assigned to the vault's viewer as it enters. Known tasks are never touched, so assignment stays app-owned. Applied on both inbound paths: the observation stream and the direct scan.
- **Writes scoped to the viewer.** The writeback effect considers only tasks visible to the viewer (unassigned, or assigned to the viewer), on the direct writer and the intent emitter alike. Another member's tasks never land in this person's notes. Lines written before the ruling are not removed.
- **Which "me".** Never the importing device's user: on the plugin path every dayGLANCE device on the account applies the same observation stream, so the plugin now publishes the viewer in the plaintext pairing-meta row (`userSyncId`: the pairing's default or the "Show tasks for" override, republished when the setting changes) and dayGLANCE reads it from its cached meta via the new `cachedBridgePairingMeta()`. On direct access the vault is on this device, so the viewer is the device's user. No viewer (single-user, Everyone, or a plugin predating the field) means the pre-ruling behavior.

## Code
- `src/utils/obsidianUserScope.js` (+ tests): `vaultViewerFor`, `visibleToViewer`, `assignVaultViewer`, `knownTaskIds`.
- `useObsidianSync`: assignment before both merge sites; viewer filter on the writeback's task set.
- `obsidianBridgeStream.js`: `cachedBridgePairingMeta()`.
- Plugin `bridge.ts` / `main.ts`: `publishPairingMeta` takes the viewer; republished on viewer change.
- Spec decision 10 and §8 row 13; README.

## Verification
- New unit tests for the scope rules; hook test mocks extended for the new export.
- Lint clean; full suite green (2780 tests). Plugin `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_