### PR TITLE
Vault task scope step 1: note keys, non-daily parse mode, writeback locator

### DIFF
--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -768,15 +768,15 @@ moved note keeps its stamped ids intact.
     bodies of non-daily notes are NOT mirrored (the daily-note editor stays a
     daily-note feature).
 
-### 6.3 Rulings requested (hard-stop category, owner)
+### 6.3 Rulings (hard-stop category; owner, 2026-09-02: "yes to all")
 
-| | Ruling | Proposal |
+| | Ruling | Decided |
 |---|---|---|
 | A | Minting namespace for non-daily notes | The note's vault-relative path; daily notes keep the date. |
 | B | How a schedule is written to a non-daily line | Scheduled-date metadata in the vault's detected format, plus the leading time prefix for a slot; the line never moves. |
 | C | A note leaving scope | Tasks withdrawn from dayGLANCE ("out of scope" tombstone class), stamps untouched; re-entry re-imports under the same ids. |
 | D | Where the scope lives | Plugin settings (folders + tags, union), published in `meta:config`. |
-| E | Completion window for non-daily notes | 14 days. |
+| E | Completion window for non-daily notes | **30 days, user-configurable in the plugin's scope settings, bounded to 7–90** (a year-long window would re-create the adoption burst the throttle exists to prevent); published beside the scope in `meta:config`. A completed line with no completion date counts as older than the window. |
 | F | Direct access | Stays daily-notes-only (§2); non-daily scope is plugin-only. |
 
 ### 6.4 Build order
@@ -788,11 +788,26 @@ moved note keeps its stamped ids intact.
 2. **Plugin discovery.** Scope settings (folders, tags), published in the
    config row; `inScope` and the stamping gate extended from "is a daily
    note" to "is a daily note or in scope"; throttled adoption.
-3. **App import.** The observation classifier admits in-scope non-daily
-   notes; parse under the path key; schedule from metadata, inbox otherwise;
-   the note badge; moves; the out-of-scope withdrawal.
-4. **Scheduling write.** The metadata write on the line.
-5. **Field test** on a real project folder before widening defaults.
+3. **App import, with the scheduling write.** The observation classifier
+   admits in-scope non-daily notes; parse under the path key; schedule from
+   metadata, inbox otherwise; the note badge; moves; the out-of-scope
+   withdrawal; AND the metadata write for a reschedule (ruling B) — folded
+   in here so no non-daily task ever exists in the app without its full
+   write path.
+4. **Field test** on a real project folder before widening defaults.
+
+**Step 1 record (2026-09-02, built).** `deriveBlockId` takes a note key
+(`noteKeyForPath` normalizes a path: NFC, forward slashes, no leading
+slash); `noteTaskId` is the provisional id of an untagged non-daily line.
+`parseTasksFromMarkdown` gains `{ notePath }`: the note's own date is never
+a task date, lines carry `obsidianNotePath` instead of `obsidianFileDate`,
+dateless lines are inbox. The writeback resolves its target through
+`writebackTargetFor` — path and date-as-schedule for a note task, with no
+section sort and the path as the minting key; unchanged for daily notes —
+and admits note tasks only while the plugin is authoritative (ruling F).
+Pinned: same title in two notes mints two ids; the stamp planner mints
+under whatever key it is given; a daily-note derivation is byte-identical
+before and after.
 
 **The TaskForge reference point** stands from the earlier text: discovery
 was never the hard part; identity is what buys cross-device durability
@@ -831,7 +846,7 @@ through retitles, deletes and revivals, and it is what this section pays for.
 | 4 | Project frontmatter update cadence | Open; `data.json` churn lesson applies |
 | 5 | Sidebar refresh mechanism | **Decided: no second stream.** The mirror refreshes on the transport's 30s tick and the drain success tail, so the existing SSE nudge feeds it (4.2, built) |
 | 6 | Vault task scope: which notes | **Decided: opt-in folders and/or tags, union**, chosen in the plugin (§6.2 item 4) |
-| 7 | Note-key design for two-way scope | **Requested** as ruling A (§6.3): the note's path for non-daily notes, the date for daily notes |
+| 7 | Note-key design for two-way scope | **Decided (ruling A, §6.3)**: the note's path for non-daily notes, the date for daily notes |
 | 8 | Completion-log line shape (scan-collision constraint, 4.1) | **Decided: non-task shape** (`- ✅ …`), built |
 | 9 | Sidebar completion write path for tasks with no vault line (4.2) | **Decided: action rows** (`act:` on the bridge stream), applied by dayGLANCE as the single data-plane writer; built |
 | 10 | Ownership rule for dayGLANCE-maintained frontmatter (4.3) | Open; what-wins-on-divergence category, ruling before first write |
@@ -839,7 +854,6 @@ through retitles, deletes and revivals, and it is what this section pays for.
 | 12 | Calendar events in the sidebar (excluded from sync by design) | **Decided: dayGLANCE publishes a per-device projection row** on the bridge stream, merged with per-day authority (4.2, decision 8); built |
 | 13 | Multi-user: whose tasks the sidebar, the completion log and the vault writeback handle | **Decided: the vault's viewer**, defaulted from the pairing, overridable in the plugin; first-import assignment to the viewer, writes scoped to the viewer (4.2, decisions 9 and 10); built |
 
-| 14 | Vault task scope rulings B–F (§6.3): schedule-as-metadata, leaving scope, where scope lives, completion window, direct access stays daily-only | **Requested** with proposals |
+| 14 | Vault task scope rulings B–F (§6.3): schedule-as-metadata, leaving scope, where scope lives, completion window (30 days, configurable 7–90), direct access stays daily-only | **Decided**, 2026-09-02 |
 
-Still open, in sequencing order: 7 and 14 (vault task scope, rulings A–F
-requested), then 3, 4 and 10 (project notes).
+Still open, in sequencing order: 3, 4 and 10 (project notes).

--- a/packages/obsidian-format/src/identity.js
+++ b/packages/obsidian-format/src/identity.js
@@ -66,8 +66,8 @@ export function simpleHash(str) {
  * first-occurrence-wins rule; 36^8 ≈ 2.8e12 makes unrelated collisions
  * vanishingly unlikely at vault scale.
  */
-export function deriveBlockId(dateStr, rawTitle) {
-  const input = `${dateStr}\u0000${String(rawTitle ?? '').normalize('NFC').trim()}`;
+export function deriveBlockId(noteKey, rawTitle) {
+  const input = `${noteKey}\u0000${String(rawTitle ?? '').normalize('NFC').trim()}`;
   let h = 0xcbf29ce484222325n; // FNV-1a 64-bit offset basis
   for (const byte of new TextEncoder().encode(input)) {
     h ^= BigInt(byte);
@@ -78,6 +78,31 @@ export function deriveBlockId(dateStr, rawTitle) {
 
 export function appIdForBlockId(blockId) {
   return `obsidian-dg-${blockId}`;
+}
+
+// ── note keys (companion spec §6, ruling A) ─────────────────────────────────
+// deriveBlockId's first argument is the NOTE KEY: the minting namespace that
+// keeps "Call the plumber" in two notes from hashing to one id. For a daily
+// note it is the note's date (unchanged since Phase 2 — every existing id
+// keeps deriving byte-identically). For any other note it is the note's
+// vault-relative path, normalized here so every device derives the same key
+// from the same file. The key matters only at first minting: once the
+// `^dg-` token is in the file, identity travels with the line, and a
+// renamed or moved note keeps its ids.
+
+/** The note key for a non-daily note: its vault-relative path, NFC, forward slashes, no leading slash. */
+export function noteKeyForPath(path) {
+  return String(path ?? '').normalize('NFC').replace(/\\/g, '/').replace(/^\/+/, '');
+}
+
+/**
+ * The provisional id of an UNTAGGED line in a non-daily note (the
+ * counterpart of legacyObsidianId, whose date the note does not have).
+ * Under ruling 7 the plugin stamps before reporting, so dayGLANCE rarely
+ * sees one; it exists so a line is never id-less between report and stamp.
+ */
+export function noteTaskId(noteKey, rawTitle) {
+  return `obsidian-note-${simpleHash(noteKey)}-${simpleHash(rawTitle)}`;
 }
 
 /** The legacy content-derived id for an untagged line (and pre-Phase-2 tasks). */

--- a/packages/obsidian-format/src/noteScope.test.js
+++ b/packages/obsidian-format/src/noteScope.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveBlockId, noteKeyForPath, noteTaskId, parseTasksFromMarkdown, planStampInsertions, appIdForBlockId,
+} from './index.js';
+
+// Companion spec §6, ruling A: the note key is the minting namespace — the
+// date for a daily note (frozen, unchanged), the vault-relative path for any
+// other note. These pins are the identity half of build step 1.
+
+describe('noteKeyForPath', () => {
+  it('normalizes to NFC, forward slashes, no leading slash', () => {
+    expect(noteKeyForPath('Projects/House.md')).toBe('Projects/House.md');
+    expect(noteKeyForPath('/Projects\\House.md')).toBe('Projects/House.md');
+    // "é" composed vs decomposed → one key.
+    expect(noteKeyForPath('Café.md')).toBe(noteKeyForPath('Café.md'));
+  });
+});
+
+describe('deriveBlockId under a path key', () => {
+  it('the same title in two notes mints two ids; a daily-note id is unaffected by the change', () => {
+    const title = 'Call the plumber';
+    const daily = deriveBlockId('2026-09-02', title);
+    const house = deriveBlockId(noteKeyForPath('Projects/House.md'), title);
+    const office = deriveBlockId(noteKeyForPath('Projects/Office.md'), title);
+    expect(new Set([daily, house, office]).size).toBe(3);
+    // Golden: the daily derivation is byte-identical to what identity.test.js pins.
+    expect(daily).toBe(deriveBlockId('2026-09-02', 'Call the plumber'));
+    expect(daily).toMatch(/^[a-z0-9]{8}$/);
+  });
+  it('the stamp planner mints under whatever key it is given, so the plugin can pass a path', () => {
+    const content = '- [ ] Call the plumber\n';
+    const [dailyPlan] = planStampInsertions(content, '2026-09-02');
+    const [notePlan] = planStampInsertions(content, noteKeyForPath('Projects/House.md'));
+    expect(dailyPlan.blockId).toBe(deriveBlockId('2026-09-02', 'Call the plumber'));
+    expect(notePlan.blockId).toBe(deriveBlockId('Projects/House.md', 'Call the plumber'));
+    expect(dailyPlan.blockId).not.toBe(notePlan.blockId);
+  });
+});
+
+describe('parseTasksFromMarkdown with notePath (non-daily note)', () => {
+  const content = [
+    '# House',
+    '- [ ] Call the plumber ^dg-abcdefgh',
+    '- [ ] 2026-09-10 09:00-09:30 Meet the architect ^dg-11111111',
+    '- [ ] Order tiles ⏳ 2026-09-12 ^dg-22222222',
+    '- [x] Pick paint ✅ 2026-08-30 ^dg-33333333',
+    '- [ ] Untagged line',
+  ].join('\n');
+
+  it('a line without a date of its own is inbox; inline and ⏳ dates schedule; every task carries obsidianNotePath and no obsidianFileDate', () => {
+    const { scheduledTasks, inboxTasks } = parseTasksFromMarkdown(content, '2026-09-02', new Set(), { notePath: '/Projects\\House.md' });
+    const all = [...scheduledTasks, ...inboxTasks];
+    expect(all.every((t) => t.obsidianNotePath === 'Projects/House.md' && t.obsidianFileDate === undefined)).toBe(true);
+    expect(inboxTasks.map((t) => t.id)).toEqual(expect.arrayContaining([appIdForBlockId('abcdefgh'), appIdForBlockId('33333333')]));
+    const meet = scheduledTasks.find((t) => t.id === appIdForBlockId('11111111'));
+    expect(meet).toMatchObject({ date: '2026-09-10', startTime: '09:00', duration: 30, isAllDay: false });
+    const tiles = scheduledTasks.find((t) => t.id === appIdForBlockId('22222222'));
+    expect(tiles).toMatchObject({ date: '2026-09-12', isAllDay: true });
+    // The note's "date" argument never leaks in as a task date.
+    expect(all.some((t) => t.date === '2026-09-02')).toBe(false);
+  });
+
+  it('an untagged line gets the provisional path-keyed id, never a date-keyed legacy id', () => {
+    const { inboxTasks } = parseTasksFromMarkdown(content, '2026-09-02', new Set(), { notePath: 'Projects/House.md' });
+    const untagged = inboxTasks.find((t) => t.title.startsWith('Untagged line'));
+    expect(untagged.id).toBe(noteTaskId('Projects/House.md', 'Untagged line'));
+    expect(untagged.id.startsWith('obsidian-note-')).toBe(true);
+  });
+
+  it('without notePath the daily-note grammar is byte-for-byte unchanged', () => {
+    const daily = parseTasksFromMarkdown('- [ ] Call the plumber\n', '2026-09-02');
+    expect(daily.scheduledTasks).toHaveLength(0);
+    expect(daily.inboxTasks[0]).toMatchObject({ obsidianFileDate: '2026-09-02', id: 'obsidian-2026-09-02-' + daily.inboxTasks[0].id.split('-').pop() });
+    expect(daily.inboxTasks[0].obsidianNotePath).toBeUndefined();
+  });
+});

--- a/packages/obsidian-format/src/taskLines.js
+++ b/packages/obsidian-format/src/taskLines.js
@@ -8,7 +8,16 @@
 // resolving the conflict inside this function, instead of calling back, is
 // the moment format quietly becomes policy and the package boundary erodes.
 
-import { splitBlockId, blockIdSuffix, legacyObsidianId, appIdForBlockId, deriveBlockId, hasForeignBlockId } from './identity.js';
+import {
+  splitBlockId,
+  blockIdSuffix,
+  legacyObsidianId,
+  appIdForBlockId,
+  deriveBlockId,
+  hasForeignBlockId,
+  noteKeyForPath,
+  noteTaskId,
+} from './identity.js';
 import { splitCompletionMarker, completionMarkerSuffix } from './completionMarkers.js';
 import { splitTasksMetadata } from './tasksMetadata.js';
 
@@ -299,10 +308,19 @@ export function updateTaskLines(lines, { obsidianRawTitle, completed, startTime,
  *   tasks. The sync passes ONE set across every file in the scan so the rule
  *   holds vault-wide, not merely per file.
  */
-export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set()) {
+export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(), { notePath = null } = {}) {
   const scheduled = [];
   const inbox = [];
   if (!content) return { scheduledTasks: scheduled, inboxTasks: inbox };
+  // NON-DAILY NOTES (companion spec §6): `notePath` names the note instead
+  // of a date. The note key (ruling A) is the path; a line's date comes only
+  // from its own text (an inline prefix, or ⏳ scheduled metadata) — never
+  // from the note — so a line with neither is an inbox item; and the task
+  // carries obsidianNotePath (the writeback's locator) in place of
+  // obsidianFileDate. Everything else — markers, metadata, block ids — is
+  // exactly the daily-note grammar.
+  const noteKey = notePath ? noteKeyForPath(notePath) : dateStr;
+  const noteFields = notePath ? { obsidianNotePath: noteKeyForPath(notePath) } : { obsidianFileDate: dateStr };
 
   const lines = content.split('\n');
 
@@ -343,7 +361,7 @@ export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(
       // an untagged task (blockId stays null).
     }
 
-    let taskDate = dateStr;
+    let taskDate = notePath ? null : dateStr;
     let startTime = null;
     let isAllDay = false;
     let parsedDuration = null;
@@ -398,7 +416,7 @@ export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(
 
     // ID-first: a ^dg- tagged line gets its durable block-derived id; an
     // untagged line keeps the legacy content-derived id (date + title hash).
-    const legacyId = legacyObsidianId(taskDate, rawTitle);
+    const legacyId = notePath ? noteTaskId(noteKey, rawTitle) : legacyObsidianId(taskDate, rawTitle);
     const id = blockId ? appIdForBlockId(blockId) : legacyId;
     // obsidianLegacyId is a PER-SCAN bridge hint, not an identity: it is what
     // this line's id would have been without the tag, recomputed from current
@@ -422,7 +440,7 @@ export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(
       ...(meta.fields.recurrence ? { obsidianRecurrence: true } : {}),
     };
 
-    if (startTime) {
+    if (startTime && taskDate) {
       // Timed task (with or without inline date)
       scheduled.push({
         id,
@@ -437,12 +455,12 @@ export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(
         subtasks: [],
         importSource: 'obsidian',
         obsidianRawTitle: rawTitle,
-        obsidianFileDate: dateStr,
+        ...noteFields,
         ...blockFields,
         ...completedAtFields,
         ...metadataFields,
       });
-    } else if (isAllDay) {
+    } else if (isAllDay && taskDate) {
       // Date-only task → all-day scheduled task
       scheduled.push({
         id,
@@ -457,7 +475,7 @@ export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(
         subtasks: [],
         importSource: 'obsidian',
         obsidianRawTitle: rawTitle,
-        obsidianFileDate: dateStr,
+        ...noteFields,
         ...blockFields,
         ...completedAtFields,
         ...metadataFields,
@@ -475,7 +493,7 @@ export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(
         color: 'bg-purple-600',
         importSource: 'obsidian',
         obsidianRawTitle: rawTitle,
-        obsidianFileDate: dateStr,
+        ...noteFields,
         ...blockFields,
         ...completedAtFields,
         ...metadataFields,

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -5,7 +5,10 @@
 
 // ── identity ────────────────────────────────────────────────────────────────
 export function simpleHash(str: string): string;
-export function deriveBlockId(dateStr: string, rawTitle: string): string;
+/** noteKey: the note's date for a daily note, noteKeyForPath(path) for any other note (companion §6, ruling A). */
+export function deriveBlockId(noteKey: string, rawTitle: string): string;
+export function noteKeyForPath(path: string): string;
+export function noteTaskId(noteKey: string, rawTitle: string): string;
 export function appIdForBlockId(blockId: string): string;
 export function legacyObsidianId(taskDate: string, rawTitle: string): string;
 export function splitBlockId(text: string): { text: string; blockId: string | null };
@@ -52,6 +55,7 @@ export function updateTaskLines(lines: string[], opts: {
 }): boolean;
 export function parseTasksFromMarkdown(
   content: string, dateStr: string, seenBlockIds?: Set<string>,
+  opts?: { notePath?: string | null },
 ): { scheduledTasks: Record<string, unknown>[]; inboxTasks: Record<string, unknown>[] };
 export function stampUntaggedTaskLines(
   content: string, dateStr: string,

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -4,7 +4,7 @@ import {
   syncObsidianVault, syncObsidianVaultNative,
   writeTaskStateToFile, writeTaskStateNative,
   simpleHash as obsidianSimpleHash,
-  deriveBlockId, appIdForBlockId, dailyNoteFilename,
+  deriveBlockId, appIdForBlockId,
   readWikiNote, writeWikiNote, scanVaultNotes,
   vaultHasTasksPlugin, detectTasksPluginNative,
   readVaultHeartbeat, readVaultHeartbeatNative,
@@ -36,6 +36,8 @@ import { withCreationFrontmatter } from '../utils/obsidianFrontmatter.js';
 import { writebackSnapshotEntry } from '../utils/obsidianWritebackSnapshot.js';
 import { emitBridgeIntent, flushBridgeOutbox, publishBridgeConfig, publishBridgeCalendarProjection, getBridgePairingMeta, cachedBridgePairingMeta } from '../utils/obsidianBridgeStream.js';
 import { vaultViewerFor, visibleToViewer, assignVaultViewer, knownTaskIds } from '../utils/obsidianUserScope.js';
+import { writebackTargetFor } from '../utils/obsidianWritebackTarget.js';
+import { noteTaskId } from '@glance-apps/obsidian-format';
 import { fetchBridgeObservations, applyBridgeObservations, commitBridgeObservationCursor, pendingBridgeObservations } from '../utils/obsidianBridgeInbound.js';
 import {
   fetchBridgeActions, planBridgeActions, applyActionsToTasks, applyActionsToRecurring,
@@ -1198,8 +1200,15 @@ export default function useObsidianSync({
       authoritative: bridgeHeartbeatRef.current.pluginAuthoritative,
       meta: cachedBridgePairingMeta(), multiUserEnabled, meUserSyncId,
     });
+    // NON-DAILY TASKS (companion §6, ruling F) are plugin-only: their writes
+    // are intents, so they enter the writeback only while the plugin is
+    // authoritative. In direct mode they are left out of the pass — and out
+    // of its snapshot — rather than handed to a date-addressed writer that
+    // cannot locate them.
+    const noteTasksWritable = !!bridgeHeartbeatRef.current.pluginAuthoritative;
     const allObsidian = [...tasks, ...unscheduledTasks]
-      .filter(t => t.importSource === 'obsidian' && t.obsidianRawTitle && visibleToViewer(t, writeViewer));
+      .filter(t => t.importSource === 'obsidian' && t.obsidianRawTitle && visibleToViewer(t, writeViewer)
+        && (noteTasksWritable || !t.obsidianNotePath));
     const prev = obsidianPrevTaskStateRef.current;
     const isNative = obsidianVaultHandleRef.current === 'native';
     // ── ARBITRATION (§3.2, Phase 6 PR 3) — gate (a): emit-in-same-tick ────
@@ -1356,10 +1365,14 @@ export default function useObsidianSync({
 
       if (!titleChanged && !stateChanged && !dateChanged && !stampNeeded) continue;
 
-      // Always write back to the original file the task was parsed from.
-      // obsidianFileDate is set at parse time and never changes.
-      const sourceDate = task.obsidianFileDate || task.id.match(/^obsidian-(\d{4}-\d{2}-\d{2})/)?.[1] || task.date;
-      if (!sourceDate) continue;
+      // Always write back to the original file the task was parsed from:
+      // the daily note for obsidianFileDate, or the note at obsidianNotePath
+      // (companion §6: the locator is the path, the note key the minting
+      // namespace — utils/obsidianWritebackTarget.js). Set at parse time,
+      // never changed here.
+      const target = writebackTargetFor(task, obsidianConfig);
+      if (!target) continue;
+      const sourceDate = target.date;
 
       // Derive the new raw title: strip the #obsidian display tag, then
       // RE-ATTACH the line's verbatim Tasks-metadata segment (Step 2's
@@ -1376,13 +1389,17 @@ export default function useObsidianSync({
       // When the task has been rescheduled to a different day, pass the new date
       // so the write adds/updates an inline date prefix in the original file
       // (e.g. "- [ ] 2026-03-20 10:00 Task").  No new file is created.
-      const targetDate = dateChanged ? task.date : undefined;
+      // A non-daily line's schedule is written as metadata, not an inline
+      // date prefix (ruling B) — that write lands with the import step; until
+      // then a reschedule of a note task rewrites the line's state only.
+      const targetDate = dateChanged && !target.isNoteTask ? task.date : undefined;
 
       // All-day tasks have startTime: '00:00' in state but must write back with no
       // time prefix so the line stays as "YYYY-MM-DD Task" (not "YYYY-MM-DD 00:00-00:30 Task").
       const writeStartTime = task.isAllDay ? null : (task.startTime || null);
       const writeDuration = task.isAllDay ? null : (task.duration || null);
-      const taskHeading = obsidianConfig?.taskHeading || '## Tasks';
+      // No section sort inside a non-daily note: it is the user's document.
+      const taskHeading = target.taskHeading;
 
       // Phase 2 opportunistic migration: a changed task with no block id gets
       // one assigned at THIS write — updateTaskLines stamps it onto the
@@ -1405,7 +1422,7 @@ export default function useObsidianSync({
       // matters: the line will CARRY newRawTitle, and a later device deriving
       // from the parsed line must reach the same input.
       let assignBlockId = (!task.obsidianBlockId && blockIdWritesEnabled())
-        ? deriveBlockId(sourceDate, newRawTitle !== undefined ? newRawTitle : task.obsidianRawTitle)
+        ? deriveBlockId(target.noteKey, newRawTitle !== undefined ? newRawTitle : task.obsidianRawTitle)
         : null;
 
       // THE RE-MINT REFUSAL (2026-08-31 db-tier war — see isTombstonedRemint
@@ -1463,7 +1480,9 @@ export default function useObsidianSync({
       let postTitleId = task.id;
       if (titleChanged && newRawTitle) {
         // Mirrors parseTasksFromMarkdown's content-derived id for untagged tasks.
-        const newId = task.obsidianBlockId ? task.id : `obsidian-${sourceDate}-${obsidianSimpleHash(newRawTitle)}`;
+        const newId = task.obsidianBlockId ? task.id
+          : target.isNoteTask ? noteTaskId(target.noteKey, newRawTitle)
+          : `obsidian-${sourceDate}-${obsidianSimpleHash(newRawTitle)}`;
         titleUpdate = { oldId: task.id, newId, newRawTitle };
         postTitleId = newId;
       }
@@ -1493,8 +1512,7 @@ export default function useObsidianSync({
       // a paired vault copy converges byte-for-byte whichever side lands
       // first. Fail-silent; a stream problem never touches the direct write.
       const queued = emitBridgeIntent(titleChanged && newRawTitle ? 'task_retitle' : 'task_state', {
-        path: (obsidianConfig?.dailyNotesPath ? `${obsidianConfig.dailyNotesPath.replace(/\/+$/, '')}/` : '')
-          + dailyNoteFilename(sourceDate, obsidianConfig?.dailyNotePattern || 'yyyy-MM-dd'),
+        path: target.path,
         date: sourceDate,
         obsidianRawTitle: task.obsidianRawTitle,
         completed: task.completed,

--- a/src/utils/obsidianWritebackTarget.js
+++ b/src/utils/obsidianWritebackTarget.js
@@ -1,0 +1,47 @@
+// Where a task's vault line lives, for the writeback (companion spec §6,
+// build step 1: the locator). Pure.
+//
+// A DAILY-NOTE task is located by date: the file is the daily note for
+// `obsidianFileDate` (or the date baked into a legacy id, or the task's own
+// date), named through the configured pattern under the daily-notes folder;
+// its lines are sorted under the configured task heading; and its note key
+// (the minting namespace, ruling A) is the date.
+//
+// A NON-DAILY task is located by path: `obsidianNotePath` (already
+// normalized by the parser), no section sort (a project note is the user's
+// document, not a dayGLANCE-owned section), and the note key is the path.
+// Such tasks exist only on the plugin path (ruling F), so their writes are
+// intents; the direct writers never see them.
+
+import { dailyNoteFilename } from '@glance-apps/obsidian-format';
+
+/**
+ * @returns {{ isNoteTask: boolean, path: string, date: string|null, noteKey: string, taskHeading: string|null } | null}
+ *   null when the task names no note at all (nothing to write to).
+ */
+export function writebackTargetFor(task, obsidianConfig) {
+  if (!task) return null;
+  const notePath = typeof task.obsidianNotePath === 'string' && task.obsidianNotePath ? task.obsidianNotePath : null;
+  if (notePath) {
+    return {
+      isNoteTask: true,
+      path: notePath,
+      date: task.date || null,
+      noteKey: notePath,
+      taskHeading: null,
+    };
+  }
+  const sourceDate = task.obsidianFileDate
+    || String(task.id ?? '').match(/^obsidian-(\d{4}-\d{2}-\d{2})/)?.[1]
+    || task.date
+    || null;
+  if (!sourceDate) return null;
+  const folder = obsidianConfig?.dailyNotesPath ? `${obsidianConfig.dailyNotesPath.replace(/\/+$/, '')}/` : '';
+  return {
+    isNoteTask: false,
+    path: folder + dailyNoteFilename(sourceDate, obsidianConfig?.dailyNotePattern || 'yyyy-MM-dd'),
+    date: sourceDate,
+    noteKey: sourceDate,
+    taskHeading: obsidianConfig?.taskHeading || '## Tasks',
+  };
+}

--- a/src/utils/obsidianWritebackTarget.test.js
+++ b/src/utils/obsidianWritebackTarget.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { writebackTargetFor } from './obsidianWritebackTarget.js';
+
+describe('writebackTargetFor', () => {
+  const cfg = { dailyNotesPath: 'Daily/', dailyNotePattern: 'yyyy-MM-dd', taskHeading: '## Tasks' };
+
+  it('daily-note task: located by date under the daily folder, sorted under the task heading, keyed by the date', () => {
+    expect(writebackTargetFor({ id: 'obsidian-dg-abc', obsidianFileDate: '2026-09-02', date: '2026-09-05' }, cfg)).toEqual({
+      isNoteTask: false, path: 'Daily/2026-09-02.md', date: '2026-09-02', noteKey: '2026-09-02', taskHeading: '## Tasks',
+    });
+    // Legacy id carries the date; the task's own date is the last resort.
+    expect(writebackTargetFor({ id: 'obsidian-2026-08-30-x1', date: '2026-09-01' }, cfg).date).toBe('2026-08-30');
+    expect(writebackTargetFor({ id: 'obsidian-dg-abc', date: '2026-09-01' }, cfg).date).toBe('2026-09-01');
+    expect(writebackTargetFor({ id: 'obsidian-dg-abc' }, cfg)).toBe(null);
+  });
+
+  it('non-daily task: located by its path, no section sort, keyed by the path; the task date is the schedule, not the locator', () => {
+    expect(writebackTargetFor({ id: 'obsidian-dg-def', obsidianNotePath: 'Projects/House.md', date: '2026-09-12' }, cfg)).toEqual({
+      isNoteTask: true, path: 'Projects/House.md', date: '2026-09-12', noteKey: 'Projects/House.md', taskHeading: null,
+    });
+    expect(writebackTargetFor({ id: 'obsidian-dg-def', obsidianNotePath: 'Projects/House.md' }, cfg).date).toBe(null);
+  });
+
+  it('a task carrying both fields is a note task (the path wins)', () => {
+    expect(writebackTargetFor({ id: 'x', obsidianNotePath: 'Notes/A.md', obsidianFileDate: '2026-09-02' }, cfg).isNoteTask).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Build step 1 of companion spec §6 (two-way vault task scope), plus the rulings A through F recorded as decided. Foundations only: nothing imports a non-daily note yet (that is step 3), so behavior for daily notes is unchanged and pinned.

### Identity (ruling A)
- `deriveBlockId(noteKey, rawTitle)`: the first argument is now a **note key**. Daily notes keep the date, so every existing id derives byte-identically (golden test unchanged). `noteKeyForPath(path)` normalizes a vault-relative path (NFC, forward slashes, no leading slash) for any other note.
- `noteTaskId(noteKey, rawTitle)`: the provisional id of an untagged non-daily line, the counterpart of the date-keyed legacy id.
- The stamp planner already takes a key string; a pin confirms it mints under a path when given one.

### Parser
- `parseTasksFromMarkdown(content, dateStr, seen, { notePath })`: in non-daily mode the note's own date is never a task date (only an inline prefix or `⏳` metadata schedules a line; the rest are inbox), tasks carry `obsidianNotePath` instead of `obsidianFileDate`, and untagged lines get the path-keyed provisional id. Without `notePath` the daily grammar is byte-for-byte as before.

### Writeback locator (ruling F)
- `src/utils/obsidianWritebackTarget.js`: `writebackTargetFor(task, config)` returns the file to write, the date to use as schedule, the minting key, and whether to section-sort. Daily-note tasks resolve exactly as before; a note task resolves to its path, no section sort, path as key.
- `useObsidianSync`: the writeback uses the target for the intent path, the block-id derivation, the legacy retitle id, and the heading. Note tasks join the pass only while the plugin is authoritative; a reschedule of a note task does not yet write an inline date (the metadata write is ruling B, folded into step 3).

### Spec
- §6.3 rulings A to F recorded as decided; E is 30 days, user-configurable 7 to 90 in the plugin, published beside the scope. §8 rows 7 and 14 closed. Build order: the scheduling write folded into step 3 so no non-daily task ever exists without its write path. Step 1 record added.

## Verification
- New: `noteScope.test.js` (key normalization, three notes three ids, planner under a path key, non-daily parse mode, daily grammar unchanged) and `obsidianWritebackTarget.test.js`.
- Lint clean; full suite green (2789 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_