### PR TITLE
Vault task scope step 2: plugin discovery, scope settings, throttled adoption

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -60,6 +60,13 @@ manually or via BRAT, not submitted to the community directory.
   that a running dayGLANCE applies (so its completion log, vault writeback
   and sync all fire), and the box shows as pending until the mirror
   reflects it. Ribbon icon and **Open agenda** command.
+- **Vault task scope** (companion spec §6): beyond daily notes, the settings
+  tab takes folders and/or tags whose notes are task sources. Their open
+  tasks, and tasks completed within a configurable window (30 days by
+  default, 7 to 90), are stamped with an identity under the note's path
+  and reported like daily-note tasks, a few notes per tick when a scope is
+  first added. A note leaving the scope is reported as withdrawn. The
+  scope rides the pairing-meta row so dayGLANCE applies the same window.
 - Four commands: **Sync now** (drains pending intents + refreshes the
   heartbeat), **Enter pairing code**, **Unpair from GLANCEvault**
   (forgets the local credentials and the account key; revoke the token

--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -23,7 +23,7 @@
 // plugin NEVER interprets an edit; inferring semantics is dayGLANCE's
 // scan pipeline's job.
 
-import { App, MarkdownView, Platform, TFile, normalizePath, requestUrl } from 'obsidian';
+import { App, MarkdownView, Platform, TFile, getAllTags, normalizePath, requestUrl } from 'obsidian';
 import {
   applyBridgeIntent,
   openBridgeEnvelope,
@@ -47,6 +47,11 @@ import {
   BRIDGE_PAIRING_META_ID,
   BRIDGE_CONFIG_META_ID,
   BRIDGE_INTENT_PREFIX,
+  noteKeyForPath,
+  noteInScope,
+  scopeIsActive,
+  completedSinceFor,
+  type VaultScope,
 } from '@glance-apps/obsidian-format';
 import { createVaultClient, type VaultClient } from '@glance-apps/sync/src/vaultClient.js';
 import type { BridgePairing } from './pairing';
@@ -69,6 +74,10 @@ export interface BridgeState {
   // now also HOLDS daily-note reporting while config is null (fail closed on
   // the reporting side), making ruling 7's invariant unconditional.
   config?: BridgeConfigRow | null;
+  // Vault task scope (companion §6): the non-daily notes this vault copy has
+  // already reported since they entered scope. Adoption re-reports only what
+  // is not here, so a plugin reload does not re-emit every note in scope.
+  adoptedScope?: string[];
 }
 
 const APPLIED_IDS_CAP = 1000;
@@ -82,6 +91,10 @@ const APPLIED_IDS_CAP = 1000;
 // persisted anyway, capping how many non-intent rows a plugin reload can
 // re-list. Large enough that a normal editing day never trips it.
 const HWM_PERSIST_GAP = 500;
+// Adoption throttle (companion §6.2 item 5): notes newly in scope are
+// reported this many per 30s tick, so bringing a large folder into scope
+// spreads its stamping over minutes instead of one Obsidian Sync burst.
+const ADOPT_PER_TICK = 3;
 const OBSERVE_DEBOUNCE_MS = 2000;
 // Retry cadence for a daily-note report held on config-null (fail closed —
 // see emitObservation). Config arrives within one drain tick of load, so the
@@ -122,6 +135,12 @@ export interface BridgeHost {
    * a second stream of its own.
    */
   onSynced?(): void;
+  /**
+   * The vault task scope (companion §6, rulings D and E): the folders and
+   * tags whose notes are task sources, and the completion window. Null or
+   * inactive means daily notes only.
+   */
+  getScope?(): VaultScope | null;
 }
 
 // Same requestUrl-backed fetch shim as pairing.ts (CORS-free everywhere).
@@ -155,6 +174,9 @@ export async function publishPairingMeta(
   // line is assigned to. Defaults to the pairing's own user; main.ts passes
   // the settings override when one is set.
   viewer: string | null | undefined = pairing?.userSyncId ?? null,
+  // The vault task scope (ruling D): dayGLANCE reads the completion window
+  // from here so both sides drop the same old completed lines.
+  scope: VaultScope | null = null,
 ): Promise<void> {
   const creds = pairing ?? previous;
   if (!creds) return;
@@ -172,6 +194,7 @@ export async function publishPairingMeta(
           v: 1, kind: 'pairing-meta',
           generation: pairing.generation, pairingSalt: pairing.pairingSalt, pairedAt: pairing.pairedAt,
           ...(viewer ? { userSyncId: viewer } : {}),
+          ...(scope ? { scope } : {}),
         }),
         createdAt: Date.now(),
       }],
@@ -232,6 +255,12 @@ export class BridgeTransport {
   // Per-path consecutive observation-failure counts, for the retry backoff
   // below. Reset on the path's first successful report.
   private observeRetryAttempts = new Map<string, number>();
+  // Vault task scope: paths reported as scoped (deletions of these report),
+  // the persisted adopted set, and the throttled adoption queue.
+  private scopedPaths = new Set<string>();
+  private adopted = new Set<string>();
+  private adoptQueue: string[] = [];
+  private adoptScanned = false;
   // In-memory cursor for the persist-on-intent-only rule (see drain): pages
   // that only skipped config/observation/tombstone rows advance the cursor
   // HERE, not in data.json — every data.json save is a vault file write that
@@ -319,6 +348,9 @@ export class BridgeTransport {
     if (persisted && typeof persisted === 'object') {
       this.config = persisted;
       console.info(`dayGLANCE bridge: config restored from settings — stamping ${this.stampingState()}.`);
+    }
+    for (const p of host.getBridgeState().adoptedScope ?? []) {
+      if (typeof p === 'string') { this.adopted.add(p); this.scopedPaths.add(p); }
     }
   }
 
@@ -725,6 +757,7 @@ export class BridgeTransport {
             // and dropping the field here would undo the persistence that
             // closes the 2026-08-31 config-null hole.
             config: this.config,
+            adoptedScope: [...this.adopted],
           });
           persistedHwm = Math.max(persistedHwm, cursor);
           appliedDirty = false;
@@ -879,7 +912,114 @@ export class BridgeTransport {
   private inScope(path: string, content: string | null): boolean {
     if (!path.endsWith('.md') || path.startsWith('.')) return false;
     if (this.isDailyNote(path)) return true;
+    if (this.scopedNote(path)) return true;
     return content !== null && (content.includes('^dg-') || /#obsidian\b/i.test(content));
+  }
+
+  // ── Vault task scope (companion §6) ──────────────────────────────────────
+
+  /** A non-daily note in the user's scope (folders and/or tags, ruling D). */
+  private scopedNote(path: string): boolean {
+    const scope = this.host.getScope?.() ?? null;
+    if (!scope || !scopeIsActive(scope)) return false;
+    if (!path.endsWith('.md') || path.startsWith('.') || this.isDailyNote(path)) return false;
+    const file = this.host.app.vault.getAbstractFileByPath(normalizePath(path));
+    const cache = file instanceof TFile ? this.host.app.metadataCache.getFileCache(file) : null;
+    const tags = cache ? (getAllTags(cache) ?? []) : [];
+    return noteInScope(path, tags, scope);
+  }
+
+  /** The minting key for stamping (ruling A): the note date, or the path for a scoped note; null = never stamp. */
+  private stampKey(path: string): string | null {
+    const date = this.dailyNoteDate(path);
+    if (date) return date;
+    return this.scopedNote(path) ? noteKeyForPath(path) : null;
+  }
+
+  /** Stamp options: the completion window applies to scoped notes only (ruling E). */
+  private stampOptions(path: string): { completedSince: string | null } {
+    if (this.dailyNoteDate(path)) return { completedSince: null };
+    const scope = this.host.getScope?.() ?? null;
+    if (!scope) return { completedSince: null };
+    const now = new Date();
+    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    return { completedSince: completedSinceFor(scope, today) };
+  }
+
+  /**
+   * ADOPTION, throttled: report notes that entered scope and have not been
+   * reported since, ADOPT_PER_TICK per call (main.ts calls this on the 30s
+   * tick). The candidate walk runs once per scope change, over Obsidian's
+   * already-parsed metadata cache — no file reads until a note is reported.
+   */
+  adoptTick(): void {
+    if (this.disposed || !this.host.getPairing()) return;
+    const scope = this.host.getScope?.() ?? null;
+    if (!scope || !scopeIsActive(scope)) return;
+    if (!this.adoptScanned) {
+      this.adoptScanned = true;
+      this.adoptQueue = this.host.app.vault.getMarkdownFiles()
+        .map((f) => f.path)
+        .filter((path) => !this.adopted.has(path) && this.scopedNote(path))
+        .sort();
+      if (this.adoptQueue.length) console.info(`dayGLANCE bridge: ${this.adoptQueue.length} note(s) entering the task scope; reporting ${ADOPT_PER_TICK} per tick.`);
+    }
+    const batch = this.adoptQueue.splice(0, ADOPT_PER_TICK);
+    if (!batch.length) return;
+    for (const path of batch) {
+      this.adopted.add(path);
+      this.armObserve(path, false, 0);
+    }
+    void this.persistAdopted();
+  }
+
+  /**
+   * The scope setting changed: notes that left it are WITHDRAWN (ruling C —
+   * dayGLANCE drops their tasks; stamps stay in the file), and the adoption
+   * walk re-runs so notes that entered it are reported.
+   */
+  scopeChanged(): void {
+    if (this.disposed) return;
+    for (const path of [...this.adopted]) {
+      if (this.scopedNote(path)) continue;
+      this.adopted.delete(path);
+      this.scopedPaths.delete(path);
+      void this.emitWithdrawal(path);
+    }
+    this.adoptScanned = false;
+    this.adoptQueue = [];
+    void this.persistAdopted();
+  }
+
+  private async persistAdopted(): Promise<void> {
+    if (this.disposed) return;
+    try {
+      const state = this.host.getBridgeState();
+      const next = [...this.adopted];
+      const prev = state.adoptedScope ?? [];
+      if (prev.length === next.length && prev.every((p, i) => p === next[i])) return;
+      await this.host.saveBridgeState({ ...state, adoptedScope: next });
+    } catch (e) {
+      console.error('dayGLANCE bridge: could not persist the adopted scope', e);
+    }
+  }
+
+  /** A note left the scope: tell dayGLANCE to withdraw its tasks (no deletion anywhere). */
+  private async emitWithdrawal(path: string): Promise<void> {
+    try {
+      const pairing = this.host.getPairing();
+      if (!pairing || this.rateLimited()) return;
+      const subkey = await this.subkeyFor(pairing);
+      const payload = { v: 1, kind: 'observation', path, withdrawn: true, observedAt: new Date().toISOString() };
+      const ack = await this.client(pairing).batch(BRIDGE_VAULT_APP, {
+        accountId: pairing.accountId,
+        rows: [{ entityId: await observationEntityId(path), envelope: await sealBridgeEnvelope(subkey, payload), createdAt: Date.now() }],
+      });
+      const ackSeq = Number((ack as { maxSeq?: unknown } | null)?.maxSeq);
+      if (Number.isFinite(ackSeq)) this.sseGate.recordOwnSeq(ackSeq);
+    } catch (e) {
+      console.warn('dayGLANCE bridge: withdrawal report failed (the note is simply no longer reported)', e);
+    }
   }
 
   private isDailyNote(path: string): boolean {
@@ -954,7 +1094,7 @@ export class BridgeTransport {
         content = await adapter.read(path);
         try { mtime = (await adapter.stat(path))?.mtime ?? null; } catch { /* stat optional */ }
       }
-      if (deleted ? !this.isDailyNote(path) : !this.inScope(path, content)) return;
+      if (deleted ? !(this.isDailyNote(path) || this.scopedPaths.has(path)) : !this.inScope(path, content)) return;
 
       // ── FAIL CLOSED WHILE CONFIG IS UNKNOWN (2026-08-31 incident) ───────
       // With config null, the normalize block below cannot run — so reporting
@@ -1029,8 +1169,12 @@ export class BridgeTransport {
       // not. The stamp and the observation still defer TOGETHER — unstamped
       // state is never reported (ruling 7's invariant, unchanged).
       if (!deleted && content !== null && bridgeConfigAllowsStamping(this.config)) {
-        const noteDate = this.dailyNoteDate(path);
-        if (noteDate && stampUntaggedTaskLines(content, noteDate).changed) {
+        // The stamp key is the note date, or the path for a scoped note
+        // (ruling A); scoped notes stamp only lines inside the completion
+        // window (ruling E). Wiki notes carrying ^dg- text have no key.
+        const noteDate = this.stampKey(path);
+        const stampOpts = this.stampOptions(path);
+        if (noteDate && stampUntaggedTaskLines(content, noteDate, stampOpts).changed) {
           const rearm = () => this.armObserve(path, false, OBSERVE_DEBOUNCE_MS);
           // Every markdown view showing this path — the shared helper the
           // intent applier's write rule uses too.
@@ -1071,7 +1215,7 @@ export class BridgeTransport {
             // LIVE buffer read in the same tick it is applied.
             const editorView = views[0];
             const buffer = editorView.getViewData();
-            const plan = planStampInsertions(buffer, noteDate);
+            const plan = planStampInsertions(buffer, noteDate, stampOpts);
             // THE CURSOR GATE (premature identity assignment — the
             // 2026-08-31 "W ^dg-...atch tennis" line; rationale pinned on
             // partitionStampPlan in the shared package): never stamp a line
@@ -1121,7 +1265,7 @@ export class BridgeTransport {
             // keystroke instead of racing it).
             const editorView = views[0];
             const buffer = editorView.getViewData();
-            const plan = planStampInsertions(buffer, noteDate);
+            const plan = planStampInsertions(buffer, noteDate, stampOpts);
             const settled = settleStampPlan(plan, buffer.split('\n'), this.stampSettle.get(path), Date.now());
             if (settled.nextState.size > 0) this.stampSettle.set(path, settled.nextState);
             else this.stampSettle.delete(path);
@@ -1148,7 +1292,7 @@ export class BridgeTransport {
             // lines by their exact content, so a write landing between our
             // read and this one simply un-settles the moved lines for this
             // pass (they re-enter on the re-arm).
-            const plan = planStampInsertions(content, noteDate);
+            const plan = planStampInsertions(content, noteDate, stampOpts);
             const contentLines = content.split('\n');
             const settled = settleStampPlan(plan, contentLines, this.stampSettle.get(path), Date.now());
             if (settled.nextState.size > 0) this.stampSettle.set(path, settled.nextState);
@@ -1157,7 +1301,7 @@ export class BridgeTransport {
               const settledKeys = new Set(settled.apply.map((p) => contentLines[p.line]));
               await this.host.app.vault.process(file, (data) => {
                 const lines = data.split('\n');
-                for (const p of planStampInsertions(data, noteDate)) {
+                for (const p of planStampInsertions(data, noteDate, stampOpts)) {
                   if (!settledKeys.has(lines[p.line])) continue;
                   lines[p.line] = lines[p.line].slice(0, p.fromCh) + p.insert;
                 }
@@ -1175,10 +1319,16 @@ export class BridgeTransport {
         }
       }
 
+      // A scoped (non-daily) note is flagged so dayGLANCE parses it under
+      // the path key and never as a daily note; remembered so its deletion
+      // reports too.
+      const scoped = !deleted && !this.isDailyNote(path) && this.scopedNote(path);
+      if (scoped) this.scopedPaths.add(path);
       const subkey = await this.subkeyFor(pairing);
       const payload = {
         v: 1, kind: 'observation', path,
         content, deleted: deleted || undefined,
+        scoped: scoped || undefined,
         mtime, observedAt: new Date().toISOString(),
       };
       const ack = await this.client(pairing).batch(BRIDGE_VAULT_APP, {

--- a/dayglance-obsidian-plugin/src/main.ts
+++ b/dayglance-obsidian-plugin/src/main.ts
@@ -46,6 +46,7 @@ import { PairingModal, readPairingOfferText, type BridgePairing } from './pairin
 import { BridgeSettingTab, type BridgeSettingsHost } from './settingsTab';
 import { BridgeTransport, publishPairingMeta, type BridgeState } from './bridge';
 import { AgendaStore } from './agenda';
+import { normalizeScope, scopeIsActive, type VaultScope } from '@glance-apps/obsidian-format';
 import { localDateStr } from '@glance-apps/agenda-core';
 import { AgendaView, AGENDA_VIEW_TYPE, removeAgendaStyles } from './agendaView';
 
@@ -69,6 +70,10 @@ interface BridgeData {
   // pairing itself: the owner's assumption of record is one person per
   // vault, so vault scope is the right scope.
   viewer?: { userSyncId: string | null };
+  // Vault task scope (companion §6, ruling D): folders and/or tags whose
+  // notes are task sources, and the completion window (ruling E). Absent =
+  // daily notes only.
+  scope?: VaultScope;
 }
 
 const mintDeviceId = (): string => {
@@ -121,6 +126,7 @@ export default class DayGlanceBridgePlugin extends Plugin {
       // A successful drain (tick or SSE nudge) is the agenda's refresh
       // signal too: dayGLANCE's pushes advance the same account seq.
       onSynced: () => { void this.agenda.refresh(); },
+      getScope: () => this.scope(),
     });
 
     this.registerView(AGENDA_VIEW_TYPE, (leaf) => new AgendaView(leaf, this.agenda));
@@ -171,7 +177,7 @@ export default class DayGlanceBridgePlugin extends Plugin {
         await this.saveData(this.data);
         // Publish the plaintext pairing-meta row — how OTHER dayGLANCE
         // devices discover the salt and start emitting (bridge.ts).
-        await publishPairingMeta(pairing, undefined, this.viewer()).catch((e) => console.error('dayGLANCE bridge: meta publish failed', e));
+        await publishPairingMeta(pairing, undefined, this.viewer(), this.scope()).catch((e) => console.error('dayGLANCE bridge: meta publish failed', e));
         // Beat immediately so dayGLANCE's pairing panel confirms
         // without waiting out the interval.
         await this.writeHeartbeat();
@@ -196,8 +202,18 @@ export default class DayGlanceBridgePlugin extends Plugin {
         // republish the meta row so its devices pick the change up on their
         // next cycle (the row is plaintext; a user id is not a secret).
         if (this.data.pairing) {
-          await publishPairingMeta(this.data.pairing, undefined, userSyncId).catch((e) => console.error('dayGLANCE bridge: meta publish failed', e));
+          await publishPairingMeta(this.data.pairing, undefined, userSyncId, this.scope()).catch((e) => console.error('dayGLANCE bridge: meta publish failed', e));
         }
+      },
+      getScope: () => this.scope(),
+      setScope: async (scope) => {
+        this.data.scope = normalizeScope(scope);
+        await this.saveData(this.data);
+        if (this.data.pairing) {
+          await publishPairingMeta(this.data.pairing, undefined, this.viewer(), this.scope()).catch((e) => console.error('dayGLANCE bridge: meta publish failed', e));
+        }
+        this.transport.scopeChanged();
+        this.transport.adoptTick();
       },
     };
     this.addSettingTab(new BridgeSettingTab(host));
@@ -231,11 +247,15 @@ export default class DayGlanceBridgePlugin extends Plugin {
     void this.writeHeartbeat();
     void this.checkForPairingOffer();
     void this.transport.drain();
+    // Scope adoption walks the metadata cache, which is complete only after
+    // layout is ready; the tick then reports a few notes per interval.
+    this.app.workspace.onLayoutReady(() => this.transport.adoptTick());
     this.registerInterval(
       window.setInterval(() => {
         void this.writeHeartbeat();
         void this.checkForPairingOffer();
         void this.transport.drain();
+        this.transport.adoptTick();
       }, HEARTBEAT_INTERVAL_MS),
     );
   }
@@ -274,6 +294,12 @@ export default class DayGlanceBridgePlugin extends Plugin {
     await publishPairingMeta(null, previous).catch(() => {});
     await this.writeHeartbeat();
     new Notice('dayGLANCE bridge: unpaired. Also revoke the device token on your GLANCEvault server — unpairing only forgets the local credentials.');
+  }
+
+  // The active vault task scope, or null when none is configured.
+  private scope(): VaultScope | null {
+    const s = this.data.scope ? normalizeScope(this.data.scope) : null;
+    return s && scopeIsActive(s) ? s : null;
   }
 
   // Explicit choice wins; else the pairing device's user; else everyone.

--- a/dayglance-obsidian-plugin/src/settingsTab.ts
+++ b/dayglance-obsidian-plugin/src/settingsTab.ts
@@ -15,6 +15,7 @@ import {
   type BridgePairing,
 } from './pairing';
 import type { AgendaKeyState, AgendaUser } from './agenda';
+import { normalizeScope, SCOPE_WINDOW_MIN_DAYS, SCOPE_WINDOW_MAX_DAYS, SCOPE_WINDOW_DEFAULT_DAYS, type VaultScope } from '@glance-apps/obsidian-format';
 
 // Stamped by esbuild at bundle time (see esbuild.config.mjs `define`).
 // Guarded so a build without the define (tests, tooling) still runs.
@@ -49,6 +50,9 @@ export interface BridgeSettingsHost extends PairingHost {
   /** True while the viewer is the pairing's default rather than an explicit choice. */
   viewerIsDefault(): boolean;
   setViewer(userSyncId: string | null): Promise<void>;
+  /** Vault task scope (companion §6): which non-daily notes are task sources. */
+  getScope(): VaultScope | null;
+  setScope(scope: VaultScope): Promise<void>;
 }
 
 const pairedSince = (pairing: BridgePairing): string => {
@@ -73,6 +77,7 @@ export class BridgeSettingTab extends PluginSettingTab {
     if (pairing) {
       this.displayPaired(pairing);
       this.displayAccount();
+      this.displayScope();
     } else {
       this.displayUnpaired();
     }
@@ -211,6 +216,54 @@ export class BridgeSettingTab extends PluginSettingTab {
           await this.host.setViewer(v || null);
           this.display();
         });
+      });
+  }
+
+  // Which notes beyond the daily notes are task sources. Folders and tags
+  // are two ways to organize a vault; both are offered, neither privileged.
+  private displayScope(): void {
+    this.containerEl.createEl('h3', { text: 'Vault task scope' });
+    const current = this.host.getScope() ?? { folders: [], tags: [], completionWindowDays: SCOPE_WINDOW_DEFAULT_DAYS };
+    let folders = current.folders.join('\n');
+    let tags = current.tags.join('\n');
+    let windowDays = String(current.completionWindowDays);
+    const save = async () => {
+      const next = normalizeScope({
+        folders: folders.split(/\r?\n/),
+        tags: tags.split(/\r?\n/),
+        completionWindowDays: Number(windowDays),
+      });
+      await this.host.setScope(next);
+    };
+    this.containerEl.createEl('p', {
+      cls: 'setting-item-description',
+      text: 'Daily notes are always task sources. Add folders and/or tags to include other notes: their open tasks (and tasks completed within the window) become dayGLANCE tasks, stamped with an identity like daily-note tasks. Notes are brought in a few at a time.',
+    });
+    new Setting(this.containerEl)
+      .setName('Folders')
+      .setDesc('One vault-relative folder per line, e.g. Projects. Every note under it is included.')
+      .addTextArea((ta) => {
+        ta.setPlaceholder('Projects\nAreas/Home').setValue(folders).onChange((v) => { folders = v; });
+        ta.inputEl.rows = 3;
+        ta.inputEl.addEventListener('blur', () => void save());
+      });
+    new Setting(this.containerEl)
+      .setName('Tags')
+      .setDesc('One tag per line, with or without #. A note carrying the tag (or a nested tag under it) is included.')
+      .addTextArea((ta) => {
+        ta.setPlaceholder('project\nclient/acme').setValue(tags).onChange((v) => { tags = v; });
+        ta.inputEl.rows = 3;
+        ta.inputEl.addEventListener('blur', () => void save());
+      });
+    new Setting(this.containerEl)
+      .setName('Completed-task window (days)')
+      .setDesc(`In included notes, completed tasks are tracked only when completed within this many days (${SCOPE_WINDOW_MIN_DAYS} to ${SCOPE_WINDOW_MAX_DAYS}). Open tasks are always tracked.`)
+      .addText((text) => {
+        text.setPlaceholder(String(SCOPE_WINDOW_DEFAULT_DAYS)).setValue(windowDays).onChange((v) => { windowDays = v; });
+        text.inputEl.type = 'number';
+        text.inputEl.min = String(SCOPE_WINDOW_MIN_DAYS);
+        text.inputEl.max = String(SCOPE_WINDOW_MAX_DAYS);
+        text.inputEl.addEventListener('blur', () => void save());
       });
   }
 

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -809,6 +809,21 @@ Pinned: same title in two notes mints two ids; the stamp planner mints
 under whatever key it is given; a daily-note derivation is byte-identical
 before and after.
 
+**Step 2 record (2026-09-02, built).** The shared package gains the scope
+classifier (`normalizeScope`, `noteInScope`, `scopeIsActive`,
+`completedSinceFor`; window clamped to 7–90, default 30) and the stamper
+and parser take `completedSince` for non-daily notes. Plugin: a "Vault task
+scope" settings section (folders, tags, window) stored in data.json and
+published in the pairing-meta row as `scope` (ruling D, amended: the
+plugin's own row rather than the app-authored config row, since the plugin
+is the author); `inScope` admits scoped notes (tags from `metadataCache`);
+the stamp key is the note date or `noteKeyForPath(path)` (ruling A) with
+the window applied to scoped notes only; observations of scoped notes carry
+`scoped: true`, deletions of reported scoped paths report; adoption walks
+the metadata cache once per scope change and reports three notes per 30s
+tick, the adopted set persisted beside the cursor so a reload does not
+re-emit; a note leaving scope emits `withdrawn: true` (ruling C).
+
 **The TaskForge reference point** stands from the earlier text: discovery
 was never the hard part; identity is what buys cross-device durability
 through retitles, deletes and revivals, and it is what this section pays for.

--- a/packages/obsidian-format/src/index.js
+++ b/packages/obsidian-format/src/index.js
@@ -21,3 +21,4 @@ export * from './bridgePairing.js';
 export * from './bridgeStream.js';
 export * from './bridgeSse.js';
 export * from './completionLog.js';
+export * from './noteScope.js';

--- a/packages/obsidian-format/src/noteScope.js
+++ b/packages/obsidian-format/src/noteScope.js
@@ -1,0 +1,70 @@
+// Vault task scope (companion spec §6, rulings D and E). Pure.
+//
+// Which non-daily notes dayGLANCE treats as task sources is OPT-IN: the
+// user picks folders and/or tags in the plugin, on equal footing ("two
+// separate ways to organize a vault and neither is right or wrong"). A note
+// is in scope when it sits under an included folder OR carries an included
+// tag. Daily notes are always in scope and are classified elsewhere; this
+// module never sees them.
+//
+// The classifier lives in the shared package so the plugin (which decides
+// what to stamp and report) and dayGLANCE (which reads the scope from the
+// pairing-meta row) can never disagree about a path.
+
+export const SCOPE_WINDOW_MIN_DAYS = 7;
+export const SCOPE_WINDOW_MAX_DAYS = 90;
+export const SCOPE_WINDOW_DEFAULT_DAYS = 30;
+
+const trimSlashes = (s) => String(s ?? '').normalize('NFC').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+const normTag = (t) => String(t ?? '').normalize('NFC').trim().replace(/^#+/, '').replace(/^\/+|\/+$/g, '').toLowerCase();
+
+/**
+ * Canonical scope: trimmed folders (no leading/trailing slash), lowercased
+ * tags without `#`, window clamped to [7, 90] (ruling E). Empty entries drop.
+ */
+export function normalizeScope(scope) {
+  const folders = [...new Set((scope?.folders || []).map(trimSlashes).filter(Boolean))];
+  const tags = [...new Set((scope?.tags || []).map(normTag).filter(Boolean))];
+  const raw = Number(scope?.completionWindowDays);
+  const completionWindowDays = Number.isFinite(raw)
+    ? Math.min(SCOPE_WINDOW_MAX_DAYS, Math.max(SCOPE_WINDOW_MIN_DAYS, Math.round(raw)))
+    : SCOPE_WINDOW_DEFAULT_DAYS;
+  return { folders, tags, completionWindowDays };
+}
+
+/** True when the scope names at least one folder or tag. */
+export function scopeIsActive(scope) {
+  const s = normalizeScope(scope);
+  return s.folders.length > 0 || s.tags.length > 0;
+}
+
+/**
+ * Is a non-daily note in scope? `tags` are the note's tags (frontmatter and
+ * inline, with or without `#`); a tag matches when it equals an included tag
+ * or is nested under it (`project/house` is under `project`).
+ */
+export function noteInScope(path, tags, scope) {
+  const s = normalizeScope(scope);
+  const p = trimSlashes(path);
+  if (!p.endsWith('.md') || p.startsWith('.')) return false;
+  if (s.folders.some((f) => p.startsWith(`${f}/`))) return true;
+  if (!s.tags.length) return false;
+  const noteTags = (tags || []).map(normTag).filter(Boolean);
+  return noteTags.some((t) => s.tags.some((inc) => t === inc || t.startsWith(`${inc}/`)));
+}
+
+/**
+ * The earliest completion date (YYYY-MM-DD) a non-daily note's completed
+ * lines must carry to be tracked: `today - window`. Older completed lines,
+ * and completed lines with no completion date at all, are neither stamped
+ * nor imported (ruling E).
+ */
+export function completedSinceFor(scope, today) {
+  const { completionWindowDays } = normalizeScope(scope);
+  const d = new Date(`${today}T12:00:00`);
+  d.setDate(d.getDate() - completionWindowDays);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}

--- a/packages/obsidian-format/src/noteScope.test.js
+++ b/packages/obsidian-format/src/noteScope.test.js
@@ -74,3 +74,52 @@ describe('parseTasksFromMarkdown with notePath (non-daily note)', () => {
     expect(daily.inboxTasks[0].obsidianNotePath).toBeUndefined();
   });
 });
+
+// ── scope classifier and the completion window (rulings D and E) ────────────
+import {
+  normalizeScope, noteInScope, scopeIsActive, completedSinceFor, completedLineInWindow, stampUntaggedTaskLines,
+} from './index.js';
+
+describe('normalizeScope / noteInScope', () => {
+  it('folders and tags are equal citizens, a note is in scope by either; nested tags match their parent; the window clamps to 7..90', () => {
+    const scope = normalizeScope({ folders: ['/Projects/', 'Areas\\Home', ''], tags: ['#Project', 'client/acme', '  '], completionWindowDays: 400 });
+    expect(scope).toEqual({ folders: ['Projects', 'Areas/Home'], tags: ['project', 'client/acme'], completionWindowDays: 90 });
+    expect(normalizeScope({ completionWindowDays: 2 }).completionWindowDays).toBe(7);
+    expect(normalizeScope({}).completionWindowDays).toBe(30);
+    expect(noteInScope('Projects/House.md', [], scope)).toBe(true);
+    expect(noteInScope('Projects.md', [], scope)).toBe(false); // a file named like the folder is not under it
+    expect(noteInScope('Notes/Kitchen.md', ['#project/house'], scope)).toBe(true);
+    expect(noteInScope('Notes/Kitchen.md', ['client/acme/2026'], scope)).toBe(true);
+    expect(noteInScope('Notes/Kitchen.md', ['#projects'], scope)).toBe(false);
+    expect(noteInScope('Notes/Kitchen.png', ['#project'], scope)).toBe(false);
+    expect(noteInScope('.trash/Old.md', ['#project'], scope)).toBe(false);
+    expect(scopeIsActive({ folders: [], tags: [] })).toBe(false);
+    expect(scopeIsActive({ tags: ['x'] })).toBe(true);
+  });
+});
+
+describe('completion window', () => {
+  it('completedSinceFor counts back the window; only dated completions inside it count', () => {
+    expect(completedSinceFor({ completionWindowDays: 30 }, '2026-09-02')).toBe('2026-08-03');
+    expect(completedLineInWindow('Pick paint ✅ 2026-08-30', '2026-08-03')).toBe(true);
+    expect(completedLineInWindow('Pick paint ✅ 2026-07-30', '2026-08-03')).toBe(false);
+    expect(completedLineInWindow('Pick paint [completed:: 2026-08-30T10:00:00-05:00]', '2026-08-03')).toBe(true);
+    expect(completedLineInWindow('Pick paint', '2026-08-03')).toBe(false);
+  });
+
+  it('the stamper and the parser skip completed lines outside the window in a non-daily note, and never window open lines', () => {
+    const content = [
+      '- [ ] Open forever',
+      '- [x] Recent ✅ 2026-08-30',
+      '- [x] Ancient ✅ 2024-01-01',
+      '- [x] Undated done',
+    ].join('\n');
+    const stamped = stampUntaggedTaskLines(content, 'Projects/House.md', { completedSince: '2026-08-03' });
+    expect(stamped.stamped.map((s) => s.rawTitle)).toEqual(['Open forever', 'Recent ✅ 2026-08-30']);
+    const { scheduledTasks, inboxTasks } = parseTasksFromMarkdown(stamped.text, '2026-09-02', new Set(), { notePath: 'Projects/House.md', completedSince: '2026-08-03' });
+    expect(scheduledTasks).toHaveLength(0);
+    expect(inboxTasks.map((t) => t.title.replace(/ #obsidian$/, ''))).toEqual(['Open forever', 'Recent']);
+    // Daily notes are never windowed: the option is simply not passed.
+    expect(stampUntaggedTaskLines(content, '2026-09-02').stamped).toHaveLength(4);
+  });
+});

--- a/packages/obsidian-format/src/taskLines.js
+++ b/packages/obsidian-format/src/taskLines.js
@@ -308,7 +308,19 @@ export function updateTaskLines(lines, { obsidianRawTitle, completed, startTime,
  *   tasks. The sync passes ONE set across every file in the scan so the rule
  *   holds vault-wide, not merely per file.
  */
-export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(), { notePath = null } = {}) {
+/** The completion date a line's marker carries (YYYY-MM-DD), or null. */
+export function completionDateOfLine(body) {
+  const { completedAt } = splitCompletionMarker(String(body ?? ''));
+  return typeof completedAt === 'string' && /^\d{4}-\d{2}-\d{2}/.test(completedAt) ? completedAt.slice(0, 10) : null;
+}
+
+/** True when a completed line's marker date is on or after `completedSince`. Undated → false. */
+export function completedLineInWindow(body, completedSince) {
+  const d = completionDateOfLine(body);
+  return d !== null && d >= completedSince;
+}
+
+export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(), { notePath = null, completedSince = null } = {}) {
   const scheduled = [];
   const inbox = [];
   if (!content) return { scheduledTasks: scheduled, inboxTasks: inbox };
@@ -330,6 +342,9 @@ export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(
     if (!match) continue;
 
     const completed = match[1] !== ' ';
+    // Completion window (ruling E): in a non-daily note, a completed line
+    // outside the window — or with no completion date — is not a task.
+    if (notePath && completedSince && completed && !completedLineInWindow(splitBlockId(match[2].trim()).text, completedSince)) continue;
     let rawTitle = match[2].trim();
 
     // Strip a trailing ^dg-<id> block reference BEFORE any other parsing, so
@@ -551,10 +566,10 @@ export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(
  * @param {string} dateStr  the note's own YYYY-MM-DD date
  * @returns {{ text: string, changed: boolean, stamped: Array<{blockId: string, rawTitle: string}> }}
  */
-export function stampUntaggedTaskLines(content, dateStr) {
+export function stampUntaggedTaskLines(content, noteKey, opts = {}) {
   if (!content) return { text: content ?? '', changed: false, stamped: [] };
   const lines = content.split('\n');
-  const plan = planStampInsertions(content, dateStr);
+  const plan = planStampInsertions(content, noteKey, opts);
   for (const p of plan) {
     lines[p.line] = lines[p.line].slice(0, p.fromCh) + p.insert;
   }
@@ -586,13 +601,18 @@ export function stampUntaggedTaskLines(content, dateStr) {
  * @param {string} dateStr  the note's own YYYY-MM-DD date
  * @returns {Array<{line: number, fromCh: number, toCh: number, insert: string, blockId: string, rawTitle: string}>}
  */
-export function planStampInsertions(content, dateStr) {
+export function planStampInsertions(content, noteKey, { completedSince = null } = {}) {
   if (!content) return [];
   const lines = content.split('\n');
   const plan = [];
   for (let i = 0; i < lines.length; i++) {
     const m = lines[i].match(/^\s*- \[([ xX])\]\s+(.+)$/);
     if (!m) continue;
+    // COMPLETION WINDOW (companion §6, ruling E — non-daily notes only, the
+    // caller passes `completedSince`): a completed line is stamped only when
+    // its completion date is inside the window; an undated completed line
+    // is older than any window. Open lines are never windowed.
+    if (completedSince && m[1] !== ' ' && !completedLineInWindow(m[2], completedSince)) continue;
     // ANY occurrence of '^dg-' anywhere on the line refuses the stamp — not
     // just a valid trailing token. This widens the old two checks (tagged
     // line, duplicate token) to cover the CORRUPTED case surfaced by the
@@ -618,7 +638,7 @@ export function planStampInsertions(content, dateStr) {
       const timePart = parseLeadingTime(rawTitle);
       if (timePart) rawTitle = timePart.rest;
     }
-    const blockId = deriveBlockId(dateStr, rawTitle);
+    const blockId = deriveBlockId(noteKey, rawTitle);
     const trimmed = lines[i].replace(/\s+$/, '');
     plan.push({
       line: i,

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -55,14 +55,27 @@ export function updateTaskLines(lines: string[], opts: {
 }): boolean;
 export function parseTasksFromMarkdown(
   content: string, dateStr: string, seenBlockIds?: Set<string>,
-  opts?: { notePath?: string | null },
+  opts?: { notePath?: string | null; completedSince?: string | null },
 ): { scheduledTasks: Record<string, unknown>[]; inboxTasks: Record<string, unknown>[] };
+export function completionDateOfLine(body: string): string | null;
+export function completedLineInWindow(body: string, completedSince: string): boolean;
+/** noteKey: the note's date for a daily note, noteKeyForPath(path) otherwise; completedSince windows completed lines (non-daily). */
 export function stampUntaggedTaskLines(
-  content: string, dateStr: string,
+  content: string, noteKey: string, opts?: { completedSince?: string | null },
 ): { text: string; changed: boolean; stamped: Array<{ blockId: string; rawTitle: string }> };
 export function planStampInsertions(
-  content: string, dateStr: string,
+  content: string, noteKey: string, opts?: { completedSince?: string | null },
 ): Array<{ line: number; fromCh: number; toCh: number; insert: string; blockId: string; rawTitle: string }>;
+
+// ── vault task scope (companion §6, rulings D and E) ────────────────────────
+export interface VaultScope { folders: string[]; tags: string[]; completionWindowDays: number }
+export const SCOPE_WINDOW_MIN_DAYS: number;
+export const SCOPE_WINDOW_MAX_DAYS: number;
+export const SCOPE_WINDOW_DEFAULT_DAYS: number;
+export function normalizeScope(scope: Partial<VaultScope> | null | undefined): VaultScope;
+export function scopeIsActive(scope: Partial<VaultScope> | null | undefined): boolean;
+export function noteInScope(path: string, tags: string[] | null | undefined, scope: Partial<VaultScope> | null | undefined): boolean;
+export function completedSinceFor(scope: Partial<VaultScope> | null | undefined, today: string): string;
 export function partitionStampPlan<T extends { line: number }>(
   plan: T[], heldLines: Set<number> | null | undefined,
 ): { apply: T[]; deferred: T[] };


### PR DESCRIPTION
## Summary

Build step 2 of companion spec §6 (two-way vault task scope). Stacked on #1527 (step 1). The plugin learns which non-daily notes are task sources, stamps them under the path key, and reports them as scoped observations. Nothing in dayGLANCE consumes those observations yet (that is step 3, #1529), so app behavior is unchanged by this PR alone.

### Scope classifier (rulings D and E), shared package
- `noteScope.js`: `normalizeScope` (folders trimmed, tags lowercased without `#`, window clamped to 7..90, default 30), `scopeIsActive`, `noteInScope(path, tags, scope)` (under an included folder OR carrying an included tag, nested tags match their parent, only `.md`, never dot-folders), `completedSinceFor(scope, today)`.
- Parser and stamper take `completedSince`: in a non-daily note, completed lines older than the window or with no completion date are neither stamped nor imported. Daily notes are never windowed.
- The classifier lives in the shared package so the plugin and dayGLANCE can never disagree about a path.

### Plugin
- **Settings**: new "Vault task scope" section with folders, tags, and completion window (7 to 90 days). Folders and tags are offered equally.
- **Scope publication**: the scope rides the plugin's pairing-meta row beside `userSyncId` (ruling D amended: the row is plaintext and plugin-authored, so no data-plane write is needed). Changing the scope republishes the row.
- **Discovery and adoption**: a scoped note is stamped under `noteKeyForPath(path)` with the completion window; newly in-scope notes are adopted at most 3 per tick (on layout ready and every 30 s) so a large folder does not stampede; the adopted set persists in `data.json`. A note that leaves scope emits a withdrawal observation (ruling C).
- **Observations**: scoped notes report with `scoped: true`; deletions of daily or scoped notes report, other deletions are ignored.

### Verification
- New pins in `noteScope.test.js` (classifier, window, stamper and parser windowing, daily grammar unwindowed).
- Plugin builds clean (tsc strict + esbuild). Lint clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ