### PR TITLE
Vault task scope step 3: app import, withdrawal, schedule as metadata, note badge

### DIFF
--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -1322,8 +1322,9 @@ export class BridgeTransport {
       // A scoped (non-daily) note is flagged so dayGLANCE parses it under
       // the path key and never as a daily note; remembered so its deletion
       // reports too.
-      const scoped = !deleted && !this.isDailyNote(path) && this.scopedNote(path);
-      if (scoped) this.scopedPaths.add(path);
+      const scoped = !this.isDailyNote(path) && (deleted ? this.scopedPaths.has(path) : this.scopedNote(path));
+      if (scoped && !deleted) this.scopedPaths.add(path);
+      if (deleted) this.scopedPaths.delete(path);
       const subkey = await this.subkeyFor(pairing);
       const payload = {
         v: 1, kind: 'observation', path,

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -824,6 +824,25 @@ the metadata cache once per scope change and reports three notes per 30s
 tick, the adopted set persisted beside the cursor so a reload does not
 re-emit; a note leaving scope emits `withdrawn: true` (ruling C).
 
+**Step 3 record (2026-09-02, built).** App import: `applyBridgeObservations`
+parses a `scoped` observation under its path with the completion window
+from the pairing meta's `scope`, returns `scopedNotes` (path → evidence
+time; a deleted scoped note is complete knowledge that none of its lines
+exist) and `withdrawn` paths. Note-scoped deletion inference judges a task
+by the observation of the note it names — `obsidianNotePath` for a scoped
+task, the date for a daily one — and revival stamping reads the same
+path-keyed evidence. Withdrawal (ruling C) tombstones the note's tasks
+through the vault-origin channel at the withdrawal time, so every device
+drops them while the vault and its stamps are untouched; the path is
+remembered device-locally so the note's next scoped observation counts as
+fresh evidence and revival re-admits the same ids. Schedule (ruling B):
+`withScheduledMetadata` replaces, appends or removes the ⏳ /
+`[scheduled::]` segment on a line, in the vault's detected format; the
+writeback routes a non-daily task's date change (including to and from the
+inbox) through the retitle path, so the raw title changes and the display
+title does not, and the parser reads the date back. Task cards carry a note
+badge naming the note. Direct access is untouched (ruling F).
+
 **The TaskForge reference point** stands from the earlier text: discovery
 was never the hard part; identity is what buys cross-device durability
 through retitles, deletes and revivals, and it is what this section pays for.

--- a/packages/obsidian-format/src/scheduledMetadata.test.js
+++ b/packages/obsidian-format/src/scheduledMetadata.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { withScheduledMetadata, splitTasksMetadata, parseTasksFromMarkdown } from './index.js';
+
+// Companion §6, ruling B: a non-daily task's schedule lives on its line as
+// metadata. The writer replaces, appends or removes the scheduled segment
+// and leaves every other segment verbatim; the parser reads it back.
+
+describe('withScheduledMetadata', () => {
+  it('appends when absent, replaces when present (either format), removes on null, keeps other metadata', () => {
+    expect(withScheduledMetadata('Order tiles', '2026-09-12', 'tasks')).toBe('Order tiles ⏳ 2026-09-12');
+    expect(withScheduledMetadata('Order tiles', '2026-09-12', 'dataview')).toBe('Order tiles [scheduled:: 2026-09-12]');
+    expect(withScheduledMetadata('Order tiles ⏳ 2026-09-12 📅 2026-09-20', '2026-09-15', 'tasks')).toBe('Order tiles 📅 2026-09-20 ⏳ 2026-09-15');
+    expect(withScheduledMetadata('Order tiles [scheduled:: 2026-09-12] [due:: 2026-09-20]', '2026-09-15', 'dataview')).toBe('Order tiles [due:: 2026-09-20] [scheduled:: 2026-09-15]');
+    expect(withScheduledMetadata('Order tiles ⏳ 2026-09-12 🔁 every week', null, 'tasks')).toBe('Order tiles 🔁 every week');
+    expect(withScheduledMetadata('Order tiles ⏳ 2026-09-12', null)).toBe('Order tiles');
+    expect(withScheduledMetadata('Order tiles', null)).toBe('Order tiles');
+  });
+
+  it('round-trips through the parser: the written date schedules the line, removal sends it to the inbox', () => {
+    const raw = withScheduledMetadata('Order tiles', '2026-09-12', 'tasks');
+    const scheduled = parseTasksFromMarkdown(`- [ ] ${raw} ^dg-22222222\n`, '2026-09-02', new Set(), { notePath: 'Projects/House.md' });
+    expect(scheduled.scheduledTasks[0]).toMatchObject({ date: '2026-09-12', isAllDay: true, obsidianRawTitle: raw });
+    expect(splitTasksMetadata(raw).fields.scheduled).toBe('2026-09-12');
+    const cleared = parseTasksFromMarkdown(`- [ ] ${withScheduledMetadata(raw, null)} ^dg-22222222\n`, '2026-09-02', new Set(), { notePath: 'Projects/House.md' });
+    expect(cleared.scheduledTasks).toHaveLength(0);
+    expect(cleared.inboxTasks).toHaveLength(1);
+  });
+});

--- a/packages/obsidian-format/src/tasksMetadata.js
+++ b/packages/obsidian-format/src/tasksMetadata.js
@@ -148,6 +148,24 @@ export function splitTasksMetadata(input) {
  * @param {string} rawTitle      the task's frozen obsidianRawTitle (full
  *   line space) — the metadata source
  */
+/**
+ * Write a scheduled date INTO a line's metadata run (companion §6, ruling
+ * B — the schedule of a non-daily task lives on its line, never in a note
+ * date). Replaces an existing ⏳ / [scheduled::] segment, appends one when
+ * absent, removes it when `dateStr` is null; every other segment is kept
+ * verbatim. `format` is 'tasks' (⏳ emoji) or 'dataview' ([scheduled:: …]).
+ * Returns the full raw title (display text + metadata run).
+ */
+export function withScheduledMetadata(rawTitle, dateStr, format = 'tasks') {
+  const raw = String(rawTitle ?? '');
+  const { text, metaText } = splitTasksMetadata(raw);
+  const SCHED_SEG = new RegExp(`\\s+(?:\\u{23F3}${VS}\\s*\\d{4}-\\d{2}-\\d{2}|\\[scheduled::[^\\]]*\\])`, 'gu');
+  const base = (metaText ? text.trimEnd() + metaText.replace(SCHED_SEG, '') : raw.trimEnd()).trimEnd();
+  if (!dateStr) return base;
+  const seg = format === 'dataview' ? `[scheduled:: ${dateStr}]` : `\u{23F3} ${dateStr}`;
+  return `${base} ${seg}`;
+}
+
 export function reattachTasksMetadata(displayTitle, rawTitle) {
   const { metaText } = splitTasksMetadata(String(rawTitle ?? ''));
   if (!metaText) return displayTitle;

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -33,6 +33,7 @@ export function splitTasksMetadata(input: string): {
   text: string; metaText: string; fields: TasksMetadataFields;
 };
 export function reattachTasksMetadata(displayTitle: string, rawTitle: string): string;
+export function withScheduledMetadata(rawTitle: string, dateStr: string | null, format?: 'tasks' | 'dataview'): string;
 
 // ── task lines ──────────────────────────────────────────────────────────────
 export function taskLineSortKey(line: string, noteDate: string): string;

--- a/src/components/AllDayTaskCard.jsx
+++ b/src/components/AllDayTaskCard.jsx
@@ -198,6 +198,7 @@ const AllDayTaskCard = ({ task, fillWidth = true }) => {
               <Calendar size={14} className="flex-shrink-0" />
               {task.isRecurring && <RefreshCw size={12} className="flex-shrink-0 opacity-75 hover:opacity-100 cursor-pointer" onClick={(e) => { e.stopPropagation(); setEditingRecurrenceTaskId(task.id); }} />}
               {task.obsidianRecurrence && <Repeat size={12} className="flex-shrink-0 opacity-75" title="Recurring in Obsidian — this task's recurrence is managed by the Tasks plugin; completing it here won't create the next instance" />}
+              {task.obsidianNotePath && <FileText size={12} className="flex-shrink-0 opacity-75" title={`In ${task.obsidianNotePath.replace(/\.md$/, '')} (Obsidian)`} />}
               {task.source_app === SOURCE_APPS.LASTGLANCE && <LastGlanceBadge size={12} className="flex-shrink-0" title="From lastGLANCE" />}
               {multiUserEnabled && <UserAssignmentBadge users={users} assignedUserSyncIds={task.assignedUserSyncIds} size={14} />}
               <div

--- a/src/components/GlanceSidebar.jsx
+++ b/src/components/GlanceSidebar.jsx
@@ -1,10 +1,6 @@
 import React, { useRef } from 'react';
 import {
-  AlarmClock, AlertCircle, AlertTriangle, BookOpen, BrainCircuit,
-  Calendar, CalendarClock, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown,
-  ChevronUp, Clock, Filter, Flag, Hash, Inbox, LayoutGrid, Loader,
-  Mic, Minus, Moon, Plus, RefreshCw, Repeat, Search,
-  Settings, Sparkles, Sun, Target, Telescope, Trash2, X, Zap,
+  AlarmClock, AlertCircle, AlertTriangle, BookOpen, BrainCircuit, Calendar, CalendarClock, CalendarDays, Check, CheckCircle, CheckSquare, ChevronDown, ChevronUp, Clock, Filter, Flag, Hash, Inbox, LayoutGrid, Loader, Mic, Minus, Moon, Plus, RefreshCw, Repeat, Search, Settings, Sparkles, Sun, Target, Telescope, Trash2, X, Zap, FileText,
 } from 'lucide-react';
 import { renderTitle } from '../utils/textFormatting.jsx';
 import { nativeGetNextAlarm } from '../native.js';
@@ -1030,6 +1026,7 @@ const GlanceSidebar = ({ variant = 'desktop' }) => {
               {task.isRecurring && <RefreshCw size={13} className="flex-shrink-0 opacity-60" />}
               {task.importSource === 'obsidian' && <BookOpen size={13} className="flex-shrink-0 opacity-60" title="From Obsidian" />}
               {task.obsidianRecurrence && <Repeat size={13} className="flex-shrink-0 opacity-60" title="Recurring in Obsidian — this task's recurrence is managed by the Tasks plugin; completing it here won't create the next instance" />}
+              {task.obsidianNotePath && <FileText size={13} className="flex-shrink-0 opacity-60" title={`In ${task.obsidianNotePath.replace(/\.md$/, '')} (Obsidian)`} />}
               <span className="truncate">{renderTitle(task.title)}</span>
             </div>
             <div className={`text-sm ${textSecondary} flex items-center gap-1`}>

--- a/src/components/MobileGlanceSection.jsx
+++ b/src/components/MobileGlanceSection.jsx
@@ -940,6 +940,7 @@ const MobileGlanceSection = () => {
               {task.isRecurring && <RefreshCw size={13} className="flex-shrink-0 opacity-60" />}
               {task.importSource === 'obsidian' && <BookOpen size={13} className="flex-shrink-0 opacity-60" title="From Obsidian" />}
               {task.obsidianRecurrence && <Repeat size={13} className="flex-shrink-0 opacity-60" title="Recurring in Obsidian — this task's recurrence is managed by the Tasks plugin; completing it here won't create the next instance" />}
+              {task.obsidianNotePath && <FileText size={13} className="flex-shrink-0 opacity-60" title={`In ${task.obsidianNotePath.replace(/\.md$/, '')} (Obsidian)`} />}
               <span className="truncate">{renderTitle(task.title)}</span>
             </div>
             <div className={`text-sm ${textSecondary} flex items-center gap-1`}>

--- a/src/components/TimelineTaskCardContent.jsx
+++ b/src/components/TimelineTaskCardContent.jsx
@@ -228,6 +228,7 @@ const TimelineTaskCardContent = ({ task, height, isNarrowWidth, flipNotesPanel }
                 {task.isRecurring && <RefreshCw size={12} className="flex-shrink-0 opacity-75 hover:opacity-100 cursor-pointer" onClick={(e) => { e.stopPropagation(); setEditingRecurrenceTaskId(task.id); }} />}
                 {task.importSource === 'obsidian' && <BookOpen size={12} className="flex-shrink-0 opacity-75" title="From Obsidian" />}
                 {task.obsidianRecurrence && <Repeat size={12} className="flex-shrink-0 opacity-75" title="Recurring in Obsidian — this task's recurrence is managed by the Tasks plugin; completing it here won't create the next instance" />}
+              {task.obsidianNotePath && <FileText size={12} className="flex-shrink-0 opacity-75" title={`In ${task.obsidianNotePath.replace(/\.md$/, '')} (Obsidian)`} />}
                 {task.source_app === SOURCE_APPS.LASTGLANCE && <LastGlanceBadge size={12} className="flex-shrink-0" title="From lastGLANCE" />}
                 {multiUserEnabled && <UserAssignmentBadge users={users} assignedUserSyncIds={task.assignedUserSyncIds} size={14} />}
                 <div className="flex-1 min-w-0">

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -19,7 +19,7 @@ import { effectiveLaunchOnWrite } from '../utils/obsidianLaunchOnWrite.js';
 import { validateWikiNoteName } from '../utils/obsidianFilename.js';
 import { classifyVaultPaths } from '../utils/vaultPortability.js';
 import { mergeObsidianDailyNotes } from '../utils/mergeObsidianDailyNotes.js';
-import { mergeObsidianTasks, noteMtimesFromDailyNotes } from '../utils/mergeObsidianTasks.js';
+import { mergeObsidianTasks, noteMtimesFromDailyNotes, noteMtimesFromScopedNotes } from '../utils/mergeObsidianTasks.js';
 import { detectObsidianDeletions, addObsidianTombstones } from '../utils/obsidianDeletions.js';
 import { reattachTasksMetadata } from '../utils/obsidianTasksMetadata.js';
 import { obsidianHeartbeatState } from '../utils/obsidianHeartbeat.js';
@@ -37,7 +37,7 @@ import { writebackSnapshotEntry } from '../utils/obsidianWritebackSnapshot.js';
 import { emitBridgeIntent, flushBridgeOutbox, publishBridgeConfig, publishBridgeCalendarProjection, getBridgePairingMeta, cachedBridgePairingMeta } from '../utils/obsidianBridgeStream.js';
 import { vaultViewerFor, visibleToViewer, assignVaultViewer, knownTaskIds } from '../utils/obsidianUserScope.js';
 import { writebackTargetFor } from '../utils/obsidianWritebackTarget.js';
-import { noteTaskId } from '@glance-apps/obsidian-format';
+import { noteTaskId, withScheduledMetadata } from '@glance-apps/obsidian-format';
 import { fetchBridgeObservations, applyBridgeObservations, commitBridgeObservationCursor, pendingBridgeObservations } from '../utils/obsidianBridgeInbound.js';
 import {
   fetchBridgeActions, planBridgeActions, applyActionsToTasks, applyActionsToRecurring,
@@ -78,6 +78,18 @@ import {
 // names the CONDITION, never the tasks, and is precise about the actual retry
 // semantics: there is no background retry queue — a failed write re-attempts
 // when the task next changes.
+// Vault task scope (companion §6, ruling C): notes withdrawn from the scope,
+// path → withdrawal time, so a note re-entering the scope is treated as
+// fresh vault evidence for its tasks' revival. Device-local bookkeeping.
+const WITHDRAWN_NOTES_KEY = 'day-planner-withdrawn-obsidian-notes';
+const readWithdrawnNotes = () => {
+  try { const v = JSON.parse(localStorage.getItem(WITHDRAWN_NOTES_KEY) || '{}'); return v && typeof v === 'object' ? v : {}; }
+  catch { return {}; }
+};
+const writeWithdrawnNotes = (store) => {
+  try { localStorage.setItem(WITHDRAWN_NOTES_KEY, JSON.stringify(store)); } catch { /* best-effort */ }
+};
+
 export const OBSIDIAN_TASK_WRITE_ERROR =
   "Couldn't write to your Obsidian vault. Your changes are saved in dayGLANCE and will be written on the next edit.";
 
@@ -669,8 +681,49 @@ export default function useObsidianSync({
                 dailyNotesPath: obsidianConfig?.dailyNotesPath || '',
                 dailyNotePattern: obsidianConfig?.dailyNotePattern || 'yyyy-MM-dd',
                 onTitleConflict,
+                // Vault task scope (companion §6): the window for scoped notes
+                // comes from the plugin's pairing-meta row.
+                scope: cachedBridgePairingMeta()?.scope ?? null,
+                today: dateToString(new Date()),
               })
             : null;
+
+          // WITHDRAWAL (companion §6, ruling C): a note that left the scope
+          // takes its tasks out of dayGLANCE — tombstoned through the
+          // vault-origin channel at the withdrawal time, so every device
+          // drops them; nothing is deleted in the vault and the stamps stay.
+          // Re-entry re-imports under the same ids: the path is remembered
+          // so its next scoped observation counts as fresh vault evidence
+          // (its mtime alone may predate the withdrawal).
+          if (applied?.withdrawn?.length) {
+            const withdrawnAt = new Date().toISOString();
+            const withdrawnPaths = new Set(applied.withdrawn);
+            const ids = [...currentTasks, ...currentInbox]
+              .filter(t => t?.importSource === 'obsidian' && withdrawnPaths.has(t.obsidianNotePath))
+              .map(t => String(t.id));
+            if (ids.length) {
+              tombstones = addObsidianTombstones(tombstones, ids, withdrawnAt);
+              localStorage.setItem('day-planner-deleted-obsidian-keys', JSON.stringify(tombstones));
+              console.info('[Obsidian] vault task scope: note(s) left the scope; withdrawing', ids.length, 'task(s):', applied.withdrawn.join(', '));
+            }
+            const store = readWithdrawnNotes();
+            for (const p of applied.withdrawn) store[p] = withdrawnAt;
+            writeWithdrawnNotes(store);
+          }
+          if (applied?.scopedNotes) {
+            // A withdrawn note re-entering the scope: lift its evidence time
+            // past the withdrawal so revival stamping re-admits its tasks.
+            const store = readWithdrawnNotes();
+            let touched = false;
+            for (const [p, note] of Object.entries(applied.scopedNotes)) {
+              if (!store[p]) continue;
+              const lifted = new Date(Math.max(Date.parse(note.lastModified || 0) || 0, (Date.parse(store[p]) || 0) + 1000)).toISOString();
+              applied.scopedNotes[p] = { ...note, lastModified: lifted };
+              delete store[p];
+              touched = true;
+            }
+            if (touched) writeWithdrawnNotes(store);
+          }
 
           // NOTE-SCOPED DELETION INFERENCE (see the util's header for the
           // full rules). Runs on EVERY successful fetch — an empty fetch is
@@ -694,6 +747,7 @@ export default function useObsidianSync({
           const candidates = applied
             ? inferNoteScopedDeletionCandidates({
                 observedNotes: applied.dailyNotes,
+                observedPaths: applied.scopedNotes,
                 scannedIds: batchScannedIds,
                 tasks: currentTasks,
                 inbox: currentInbox,
@@ -747,7 +801,7 @@ export default function useObsidianSync({
             // The observed notes' mtimes are the revival evidence (§3.10
             // ruling 6): a scanned line whose tombstone predates its note's
             // mtime is re-admitted with lastModified lifted to that mtime.
-            const observedNoteMtimes = noteMtimesFromDailyNotes(applied.dailyNotes);
+            const observedNoteMtimes = { ...noteMtimesFromDailyNotes(applied.dailyNotes), ...noteMtimesFromScopedNotes(applied.scopedNotes) };
             // FIRST-IMPORT ASSIGNMENT (utils/obsidianUserScope.js): a task new
             // to the app is the vault's viewer's — here the pairing meta's
             // user, since every device on the account applies this stream.
@@ -1333,6 +1387,10 @@ export default function useObsidianSync({
       // Detect rescheduling to a different day by comparing against the prev snapshot
       // (not obsidianFileDate) so this is a one-shot trigger per reschedule.
       const dateChanged = !!(task.date && p.date && task.date !== p.date);
+      // A non-daily task moved to the inbox (date cleared) or given a date
+      // it did not have: its ⏳ metadata must follow (ruling B), a change
+      // the daily-note flags above cannot express.
+      const scheduleChanged = !!task.obsidianNotePath && (!!p.date !== !!task.date);
 
       // STAMP ON SIGHT (spec §3.10, identity-versus-content) — a NAMED new
       // write-trigger class: the IDENTITY-ASSIGNMENT WRITE FIRED BY IMPORT.
@@ -1363,7 +1421,7 @@ export default function useObsidianSync({
         && !titleChanged && !stateChanged && !dateChanged
         && !task.obsidianBlockId && blockIdWritesEnabled();
 
-      if (!titleChanged && !stateChanged && !dateChanged && !stampNeeded) continue;
+      if (!titleChanged && !stateChanged && !dateChanged && !scheduleChanged && !stampNeeded) continue;
 
       // Always write back to the original file the task was parsed from:
       // the daily note for obsidianFileDate, or the note at obsidianNotePath
@@ -1382,9 +1440,20 @@ export default function useObsidianSync({
       // text off the vault line on every dayGLANCE rename. Same helper as
       // the scan-time resolver's `ours` comparison, so what we compare and
       // what we write can never diverge.
-      const newRawTitle = titleChanged
+      let newRawTitle = titleChanged
         ? reattachTasksMetadata(task.title.replace(/\s*#obsidian\b/gi, '').trim(), task.obsidianRawTitle)
         : undefined;
+      // SCHEDULE AS METADATA (companion §6, ruling B): a non-daily task's
+      // date is written onto its line as ⏳ / [scheduled::] — never as an
+      // inline date prefix, never by moving the line — in the vault's
+      // detected format. It rides the retitle path: the raw title (display
+      // text plus metadata run) changes, the display title does not.
+      if (target.isNoteTask && (dateChanged || scheduleChanged || titleChanged)) {
+        const withSchedule = withScheduledMetadata(
+          newRawTitle ?? task.obsidianRawTitle, task.date || null, tasksPluginRef.current ? 'tasks' : 'dataview');
+        newRawTitle = withSchedule !== task.obsidianRawTitle ? withSchedule : newRawTitle;
+      }
+      const rawTitleChanged = newRawTitle !== undefined && newRawTitle !== task.obsidianRawTitle;
 
       // When the task has been rescheduled to a different day, pass the new date
       // so the write adds/updates an inline date prefix in the original file
@@ -1478,7 +1547,7 @@ export default function useObsidianSync({
       const noteTitleConflict = () => { titleConflicted = true; };
       let titleUpdate = null;
       let postTitleId = task.id;
-      if (titleChanged && newRawTitle) {
+      if (rawTitleChanged) {
         // Mirrors parseTasksFromMarkdown's content-derived id for untagged tasks.
         const newId = task.obsidianBlockId ? task.id
           : target.isNoteTask ? noteTaskId(target.noteKey, newRawTitle)
@@ -1511,14 +1580,14 @@ export default function useObsidianSync({
       // identity move), and applyBridgeIntent mirrors its line rewrite, so
       // a paired vault copy converges byte-for-byte whichever side lands
       // first. Fail-silent; a stream problem never touches the direct write.
-      const queued = emitBridgeIntent(titleChanged && newRawTitle ? 'task_retitle' : 'task_state', {
+      const queued = emitBridgeIntent(rawTitleChanged ? 'task_retitle' : 'task_state', {
         path: target.path,
         date: sourceDate,
         obsidianRawTitle: task.obsidianRawTitle,
         completed: task.completed,
         startTime: writeStartTime,
         duration: writeDuration,
-        ...(titleChanged && newRawTitle ? { newRawTitle } : {}),
+        ...(rawTitleChanged ? { newRawTitle } : {}),
         ...(targetDate ? { targetDate } : {}),
         taskHeading,
         blockId: writeBlockId,

--- a/src/utils/mergeObsidianTasks.js
+++ b/src/utils/mergeObsidianTasks.js
@@ -83,7 +83,9 @@ const reviveScannedAgainstTombstone = (t, tombstones, noteMtimes) => {
   // fresh import keeps epoch, and a row with a real content-LWW stamp must
   // not have it regressed toward an (older) note mtime.
   if (!at || ts(at) < ts(t.lastModified)) return t;
-  const noteDate = t.obsidianFileDate || obsidianKeyDate(String(t.id));
+  // A non-daily task's note is named by path (companion §6); dates and
+  // paths share the map without colliding.
+  const noteDate = t.obsidianNotePath || t.obsidianFileDate || obsidianKeyDate(String(t.id));
   const mtime = noteDate ? noteMtimes[noteDate] : undefined;
   // The row is about to be dropped; the note was written AFTER the deletion
   // statement → revive. mtime > at >= lastModified, so the lift is always
@@ -115,6 +117,15 @@ export function mergeObsidianTasks(prevList, scannedList, scannedIdsAllLists, pr
     !scannedIdsAllLists.has(String(t.id)) &&
     !isObsidianTombstoned(tombstones, String(t.id), t.lastModified));
   return [...nonObsidian, ...merged, ...retained];
+}
+
+/** Note path → lastModified ISO, from an observation batch's scopedNotes shape (companion §6). */
+export function noteMtimesFromScopedNotes(scopedNotes) {
+  const out = {};
+  for (const [path, note] of Object.entries(scopedNotes || {})) {
+    if (note && note.lastModified) out[path] = note.lastModified;
+  }
+  return out;
 }
 
 /** Note date → lastModified ISO, from a scan/observation's dailyNotes shape. */

--- a/src/utils/obsidianBridgeInbound.js
+++ b/src/utils/obsidianBridgeInbound.js
@@ -35,6 +35,7 @@ import {
   parseDateFromFilename,
   BRIDGE_VAULT_APP,
   BRIDGE_OBSERVATION_PREFIX,
+  completedSinceFor,
 } from '@glance-apps/obsidian-format';
 import {
   buildExistingObsidianTaskContext,
@@ -152,12 +153,21 @@ export async function pendingBridgeObservations() {
  */
 export function applyBridgeObservations(observations, {
   existingTasks, existingInbox, dailyNotesPath = '', dailyNotePattern = 'yyyy-MM-dd', onTitleConflict = null,
+  // VAULT TASK SCOPE (companion §6): the plugin flags a non-daily note in
+  // the user's scope with `scoped: true`; such a note parses under its PATH
+  // key (ruling A) with the completion window from the pairing meta's
+  // `scope` (ruling E). A `withdrawn: true` observation means the note left
+  // the scope (ruling C): its path is returned for the caller to withdraw.
+  scope = null, today = null,
 }) {
   const dailyNotes = {};
+  const scopedNotes = {}; // path → { lastModified, deleted? } for scoped (non-daily) notes in this batch
+  const withdrawn = [];   // paths that left the scope
   const allScheduled = [];
   const lineSchedule = {}; // id → the line's own time when it differs from DG's (owned-schedule enforcement)
   const allInbox = [];
   const unapplied = [];
+  const completedSince = scope && today ? completedSinceFor(scope, today) : null;
   const ctx = buildExistingObsidianTaskContext(existingTasks, existingInbox);
   const isDefaultPattern = !dailyNotePattern || dailyNotePattern === 'yyyy-MM-dd';
   const dateParser = isDefaultPattern ? null : buildDateParser(dailyNotePattern);
@@ -165,6 +175,23 @@ export function applyBridgeObservations(observations, {
   const seenBlockIds = new Set();
 
   for (const obs of observations) {
+    if (obs.withdrawn) { withdrawn.push(obs.path); continue; }
+    if (obs.scoped) {
+      const at = obs.mtime ? new Date(obs.mtime).toISOString() : (obs.observedAt || new Date().toISOString());
+      if (obs.deleted || obs.content == null) {
+        // A deleted scoped note: complete knowledge that none of its lines
+        // exist — the note-scoped inference tombstones its tasks after the
+        // hold, exactly as for a deleted daily note.
+        scopedNotes[obs.path] = { lastModified: obs.observedAt || at, deleted: true };
+        continue;
+      }
+      scopedNotes[obs.path] = { lastModified: at };
+      mergeParsedObsidianTasks(
+        parseTasksFromMarkdown(obs.content, today || '1970-01-01', seenBlockIds, { notePath: obs.path, completedSince }),
+        ctx, onTitleConflict, { allScheduled, allInbox, lineSchedule },
+      );
+      continue;
+    }
     if (obs.deleted || obs.content == null) { unapplied.push(obs); continue; }
     const path = obs.path;
     if (folderPrefix ? !path.startsWith(folderPrefix) : path.includes('/')) { unapplied.push(obs); continue; }
@@ -192,5 +219,5 @@ export function applyBridgeObservations(observations, {
     ...[...allScheduled, ...allInbox].map((t) => String(t.id)),
     ...[...allScheduled, ...allInbox].filter((t) => t.obsidianLegacyId).map((t) => String(t.obsidianLegacyId)),
   ]);
-  return { dailyNotes, scheduledTasks: allScheduled, inboxTasks: allInbox, scannedIds, unapplied, lineSchedule };
+  return { dailyNotes, scopedNotes, withdrawn, scheduledTasks: allScheduled, inboxTasks: allInbox, scannedIds, unapplied, lineSchedule };
 }

--- a/src/utils/obsidianBridgeInbound.test.js
+++ b/src/utils/obsidianBridgeInbound.test.js
@@ -185,3 +185,42 @@ describe('applyBridgeObservations', () => {
     expect(out.scheduledTasks[0].lastModified).toBe(new Date(0).toISOString());
   });
 });
+
+describe('applyBridgeObservations — vault task scope (companion §6)', () => {
+  const HOUSE = [
+    '# House',
+    '- [ ] Call the plumber ^dg-aaaaaaaa',
+    '- [ ] Order tiles ⏳ 2026-09-12 ^dg-bbbbbbbb',
+    '- [x] Pick paint ✅ 2026-08-30 ^dg-cccccccc',
+    '- [x] Ancient ✅ 2024-01-01 ^dg-dddddddd',
+  ].join('\n');
+
+  it('a scoped note parses under its path: dateless lines are inbox, ⏳ schedules, old completions drop, no daily-note entry is made', () => {
+    const out = applyBridgeObservations(
+      [{ path: 'Projects/House.md', content: HOUSE, mtime: 1756400000000, observedAt: '2026-09-02T12:00:00Z', scoped: true }],
+      { existingTasks: [], existingInbox: [], dailyNotesPath: 'Daily', scope: { completionWindowDays: 30 }, today: '2026-09-02' },
+    );
+    expect(Object.keys(out.dailyNotes)).toEqual([]);
+    expect(out.scopedNotes['Projects/House.md']).toMatchObject({ lastModified: new Date(1756400000000).toISOString() });
+    expect(out.scheduledTasks.map((t) => t.id)).toEqual(['obsidian-dg-bbbbbbbb']);
+    expect(out.scheduledTasks[0]).toMatchObject({ date: '2026-09-12', obsidianNotePath: 'Projects/House.md' });
+    expect(out.inboxTasks.map((t) => t.id).sort()).toEqual(['obsidian-dg-aaaaaaaa', 'obsidian-dg-cccccccc']);
+    expect(out.inboxTasks.every((t) => t.obsidianNotePath === 'Projects/House.md' && t.obsidianFileDate === undefined)).toBe(true);
+    expect(out.scannedIds.has('obsidian-dg-dddddddd')).toBe(false);
+    expect(out.unapplied).toEqual([]);
+  });
+
+  it('a withdrawn note and a deleted scoped note are reported for the caller, not parsed', () => {
+    const out = applyBridgeObservations(
+      [
+        { path: 'Projects/Old.md', withdrawn: true, observedAt: '2026-09-02T12:00:00Z' },
+        { path: 'Projects/Gone.md', deleted: true, content: null, scoped: true, observedAt: '2026-09-02T12:00:00Z' },
+      ],
+      { existingTasks: [], existingInbox: [], dailyNotesPath: 'Daily', today: '2026-09-02' },
+    );
+    expect(out.withdrawn).toEqual(['Projects/Old.md']);
+    expect(out.scopedNotes['Projects/Gone.md']).toMatchObject({ deleted: true, lastModified: '2026-09-02T12:00:00Z' });
+    expect(out.scheduledTasks).toEqual([]);
+    expect(out.inboxTasks).toEqual([]);
+  });
+});

--- a/src/utils/obsidianNoteScopedDeletions.js
+++ b/src/utils/obsidianNoteScopedDeletions.js
@@ -115,9 +115,11 @@
  * @param {object[]} inbox  current inbox tasks (pre-merge)
  * @returns {Array<{id: string, noteDate: string, deletedAt: string}>}
  */
-export function inferNoteScopedDeletionCandidates({ observedNotes, scannedIds, tasks, inbox }) {
+export function inferNoteScopedDeletionCandidates({ observedNotes, observedPaths = null, scannedIds, tasks, inbox }) {
   const out = [];
-  if (!observedNotes || Object.keys(observedNotes).length === 0) return out;
+  const paths = observedPaths || {};
+  const notes = observedNotes || {};
+  if (Object.keys(notes).length === 0 && Object.keys(paths).length === 0) return out;
   for (const t of [...(tasks || []), ...(inbox || [])]) {
     if (!t || t.importSource !== 'obsidian') continue;
     const id = String(t.id);
@@ -135,9 +137,11 @@ export function inferNoteScopedDeletionCandidates({ observedNotes, scannedIds, t
     // honestly name cannot be judged by any note's parse — skip it; the
     // vault-wide detector still covers it on the next direct scan, and any
     // observation re-import re-establishes obsidianFileDate.
-    const noteDate = t.obsidianFileDate;
+    // A non-daily task (companion §6) claims its line by obsidianNotePath
+    // and is judged by that path's observation, the same way.
+    const noteDate = t.obsidianNotePath || t.obsidianFileDate;
     if (!noteDate) continue;
-    const note = observedNotes[noteDate];
+    const note = t.obsidianNotePath ? paths[t.obsidianNotePath] : notes[noteDate];
     if (!note) continue; // note not in this batch — no evidence either way
     if (scannedIds.has(id)) continue; // line present (or a tagged line advertises this id as its hint)
     if (t.obsidianLegacyId && scannedIds.has(String(t.obsidianLegacyId))) continue;

--- a/src/utils/obsidianNoteScopedDeletions.test.js
+++ b/src/utils/obsidianNoteScopedDeletions.test.js
@@ -258,3 +258,21 @@ describe('the continuity guard + pending store (audit fix C1)', () => {
     expect(readPendingNoteDeletions(corrupt)).toEqual({ entries: {}, touchedAt: null });
   });
 });
+
+describe('inferNoteScopedDeletionCandidates — path-keyed notes (companion §6)', () => {
+  it('a task claiming a scoped note by path is judged by that path\'s observation; a daily task never by a path', () => {
+    const tasks = [
+      { id: 'obsidian-dg-a', importSource: 'obsidian', obsidianNotePath: 'Projects/House.md' },
+      { id: 'obsidian-dg-b', importSource: 'obsidian', obsidianNotePath: 'Projects/House.md' },
+      { id: 'obsidian-dg-c', importSource: 'obsidian', obsidianNotePath: 'Projects/Other.md' },
+      { id: 'obsidian-dg-d', importSource: 'obsidian', obsidianFileDate: '2026-09-02' },
+    ];
+    const out = inferNoteScopedDeletionCandidates({
+      observedNotes: {},
+      observedPaths: { 'Projects/House.md': { lastModified: '2026-09-02T10:00:00Z' } },
+      scannedIds: new Set(['obsidian-dg-a']),
+      tasks, inbox: [],
+    });
+    expect(out).toEqual([{ id: 'obsidian-dg-b', noteDate: 'Projects/House.md', deletedAt: '2026-09-02T10:00:00Z' }]);
+  });
+});


### PR DESCRIPTION
## Summary

Build step 3 of companion spec §6. Stacked on step 2 (plugin discovery). With this PR merged, a task in an in-scope project note lives in dayGLANCE with the same two-way treatment as a daily-note task: it imports, it can be scheduled, completed, retitled and deleted from the app, and those changes write back to its note.

### Inbound
- `applyBridgeObservations` takes the scope (read from the plugin's pairing-meta row) and today's date. A scoped observation is parsed under the path key with the completion window; tasks carry `obsidianNotePath` and, unless the line has its own date, land in the inbox (the note's date is never a schedule).
- A withdrawn observation (note left scope, ruling C) is returned as a withdrawal.

### Withdrawal and re-entry
- Tasks of a withdrawn note are tombstoned at withdrawal time and the path is remembered in a small store. A note that re-enters scope with a newer mtime lifts the withdrawal so its lines revive on the next observation.
- Note-scoped deletion inference and revival key on the note path or the daily date, whichever the task carries. Scoped-note mtimes join the observed-note map used for the existence rule.

### Writeback (ruling B)
- A note task's schedule is written as line metadata, `⏳ YYYY-MM-DD` with the Tasks plugin or `[scheduled:: YYYY-MM-DD]` otherwise, never as an inline date prefix. Clearing the date removes the segment; other metadata on the line is left verbatim. `withScheduledMetadata` in the shared package does the edit and round-trips through the parser.
- A schedule change on a note task now counts as a raw-title change for the intent.

### Plugin
- A deleted note that was in scope still reports as scoped, so the app drops its tasks instead of ignoring the deletion.

### UI
- Task cards (timeline, all-day, mobile) and the sidebar show a note badge whose tooltip names the source note.

### Spec
- §6.4 step 3 record.

### Verification
- New tests: `scheduledMetadata.test.js` (writer and round trip), scoped parse and withdrawn/deleted cases in `obsidianBridgeInbound.test.js`, path-keyed candidates in `obsidianNoteScopedDeletions.test.js`.
- Lint clean; full suite green (2797 tests); plugin builds clean.

### Field test tonight
1. Merge #1527, then step 2, then this PR. Rebuild the app and the plugin.
2. In the plugin settings, "Vault task scope": add a folder (e.g. `Projects`) and/or a tag, leave the window at 30.
3. Open lines in those notes should be stamped within a minute (3 notes per 30 s tick), then appear in the dayGLANCE inbox with the note badge. Scheduling one from the app should add `⏳ date` (or the Dataview field) to its line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_