### PR TITLE
SSE re-arm breakers: batch own-ack coverage (M13), every-kind successor liveness (M8)

### DIFF
--- a/docs/obsidian-buildout-spec.md
+++ b/docs/obsidian-buildout-spec.md
@@ -10,10 +10,16 @@ underway: the completion log (its 4.1) and the sidebar view (its 4.2) are
 built and in daily use, with multi-user scoping across the log, the sidebar
 and the vault writeback. The fleet still runs at poll cadence with SSE nudge
 consumption gated off by default (§3.10, seventh record) while the audit-fix
-backlog soaks; the re-arm sequence — remaining breaker fixes, a supervised
-single-machine re-arm, then the fleet, then default-on — is still owed, and
-every plugin-to-app path (sidebar completions included) runs at the
-five-minute poll until it lands.
+backlog soaks. The last two breaker fixes landed 2026-09-03 (audit M13: the
+own-ack registry now records every write ack at the source, batch and
+delete alike, so a mixed push leaks no self-nudge; M8: the polarity
+reassert and the retirement applier judge a successor's liveness across
+every task kind, recycle bin included, like the partition does). What
+remains of the re-arm sequence is a supervised single-machine flip
+(`dayglance-sse-nudges` = `on`), then the fleet, then default-on; it runs
+ALONGSIDE the Phase 8 project-notes build (owner, 2026-09-03), and every
+plugin-to-app path (sidebar completions included) runs at the five-minute
+poll until it lands.
 
 ---
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5694,13 +5694,16 @@ const DayPlanner = () => {
     // deletion: without this, a retired-id copy re-stamped newer than its
     // tombstone (offline edit crossing a stamp, peer re-stamp) landed here as
     // a resurrected duplicate and fed the scan-evict ↔ guard-heal war. The
-    // live-id set spans BOTH lists so a cross-list successor still counts as
-    // live; a row with no live successor is left alone (deletion tombstones
-    // still govern it).
+    // live-id set spans BOTH lists AND the recycle bin (audit M8: a binned
+    // successor is still the identity the content moved to, exactly as the
+    // snapshot-delete partition judges it), so a cross-list or binned
+    // successor still counts as live; a row with no live successor is left
+    // alone (deletion tombstones still govern it).
     const retiredRecord = data.retiredTaskIds || readRetiredTaskIds();
     const retiredLiveIds = new Set([
       ...(normalizedTasks || tasksLiveRef.current || []),
       ...(normalizedUnsched || unscheduledLiveRef.current || []),
+      ...(data.recycleBin || recycleBin || []),
     ].filter(Boolean).map(t => String(t.id)));
     if (normalizedTasks) normalizedTasks = applyTaskRetirements(normalizedTasks, retiredRecord, retiredLiveIds);
     if (normalizedUnsched) normalizedUnsched = applyTaskRetirements(normalizedUnsched, retiredRecord, retiredLiveIds);

--- a/src/mergeSync.js
+++ b/src/mergeSync.js
@@ -515,7 +515,8 @@ export const mergeSyncData = (local, remote, retentionDays) => {
   // must not resurrect a retired id. This also keeps retired rows out of the
   // uploaded sync file, so the v4.7.x fleet stops re-ingesting them.
   const retApplied = applyRetirementsToTaskLists(
-    { tasks: result.data.tasks, unscheduledTasks: result.data.unscheduledTasks }, retiredMerged,
+    { tasks: result.data.tasks, unscheduledTasks: result.data.unscheduledTasks, recycleBin: result.data.recycleBin },
+    retiredMerged,
   );
   if (retApplied.tasks !== result.data.tasks || retApplied.unscheduledTasks !== result.data.unscheduledTasks) {
     result.data.tasks = retApplied.tasks;

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -52,7 +52,7 @@ import {
   shouldSuppressRetirementHeal, consumeRetirementHealTripped,
   isDeletePropagationLatched, recordDeletePropagation, consumeDeletePropagationTripped,
 } from './retirementHealBreaker.js';
-import { recordOwnWriteSeq } from './ownWrites.js';
+import { recordOwnWriteSeq, withOwnAckRecording } from './ownWrites.js';
 import { isObsidianTombstoned } from '../utils/obsidianDeletions.js';
 import { ghostSuccessorId, persistDerivedGhostRetirements } from '../utils/obsidianGhostRows.js';
 
@@ -315,33 +315,26 @@ export function createDbEngine(callbacks = {}) {
   // at the start of each cycle and committed at the end.
   let mirror = {};
 
-  // OWN-ACK COVERAGE FOR ENGINE DELETES (2026-08-31 war commission): the
-  // server emits ONE nudge per batch — carrying the batch's maxSeq, which the
-  // pushRes.maxSeq record after the push covers — but one nudge PER
-  // deleteRow, each carrying that delete's own seq (glance-vault
-  // routes/sync.ts, verified). pushDirtyRows folds the per-delete seqs into
-  // its returned maxSeq, so a push with two or more deletes left every
-  // non-max delete's echo looking FOREIGN to the exact-identity ownWrites
-  // ring — one guaranteed self-nudge (drain, cycle) per multi-delete push.
-  // The ring is exact-identity by design (no `<=` heuristic — the freshness
+  // OWN-ACK COVERAGE FOR ENGINE WRITES (2026-08-31 war commission; audit M13
+  // closed 2026-09-03): the server emits ONE nudge per batch — carrying the
+  // BATCH's maxSeq — and one nudge PER deleteRow, each carrying that delete's
+  // own seq (glance-vault routes/sync.ts, verified). pushDirtyRows folds all
+  // of them into the single maxSeq it returns, so recording only the fold
+  // left every non-max ack looking FOREIGN to the exact-identity ownWrites
+  // ring: one self-nudge per multi-delete push (the original fix covered
+  // deletes), and — M13 — one per MIXED upsert+delete push, because deletes
+  // follow the batch and push the fold above the batch's own maxSeq. The
+  // ring is exact-identity by design (no `<=` heuristic — the freshness
   // trap), so the fix is to SEE every seq: build the client ourselves (the
-  // same construction the package would run) and record each delete ack at
-  // the source. An INJECTED client (tests) passes through untouched — tests
-  // live-swap methods on the object they hold, and a wrapping copy would
-  // sever that.
+  // same construction the package would run) and record every write ack at
+  // the source (withOwnAckRecording wraps batch AND deleteRow). An INJECTED
+  // client (tests) passes through untouched — tests live-swap methods on the
+  // object they hold, and a wrapping copy would sever that.
   let vaultClient = callbacks.vaultClient;
   if (!vaultClient && cfg.vaultUrl && cfg.vaultToken) {
     try {
-      const inner = createVaultClient({ vaultUrl: cfg.vaultUrl, vaultToken: cfg.vaultToken, fetchImpl: loggingFetch });
-      vaultClient = {
-        ...inner,
-        deleteRow: async (...args) => {
-          const r = await inner.deleteRow(...args);
-          const seq = Number(r?.seq);
-          if (Number.isFinite(seq) && seq > 0) recordOwnWriteSeq(seq);
-          return r;
-        },
-      };
+      vaultClient = withOwnAckRecording(
+        createVaultClient({ vaultUrl: cfg.vaultUrl, vaultToken: cfg.vaultToken, fetchImpl: loggingFetch }));
     } catch { vaultClient = undefined; /* let the package build its own */ }
   }
 

--- a/src/sync/ownEchoDamping.test.js
+++ b/src/sync/ownEchoDamping.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { recordOwnWriteSeq, isOwnWriteSeq, __resetOwnWritesForTests } from './ownWrites.js';
+import { recordOwnWriteSeq, isOwnWriteSeq, withOwnAckRecording, __resetOwnWritesForTests } from './ownWrites.js';
 import { createNudgeCoalescer } from './vaultEventStream.js';
 
 // OWN-ECHO SSE DAMPING (#1455). The server emits each nudge with THE WRITING
@@ -116,5 +116,41 @@ describe('coalescer own-echo suppression', () => {
     expect(c.handleEvent({ seq: 10 })).toBe(true);
     vi.advanceTimersByTime(100);
     expect(onDrain).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('withOwnAckRecording — every write ack recorded at the source (audit M13)', () => {
+  beforeEach(() => __resetOwnWritesForTests());
+
+  it('a MIXED push records the batch maxSeq AND each delete seq, so no nudge of the push looks foreign', async () => {
+    // The server nudges once per batch (batch maxSeq) and once per deleteRow
+    // (that delete's seq). Deletes follow the batch, so the fold pushDirtyRows
+    // returns (12) is above the batch's own ack (10): recording only the fold
+    // left the batch nudge as a self-drain. Wrapped, all three are ours.
+    const inner = {
+      async batch() { return { written: 2, maxSeq: 10 }; },
+      async deleteRow() { return { seq: 11 }; },
+      async list() { return { rows: [] }; },
+    };
+    const client = withOwnAckRecording(inner);
+    expect(await client.batch('dayglance', { accountId: 'a', rows: [] })).toEqual({ written: 2, maxSeq: 10 });
+    await client.deleteRow('dayglance', 'tasks:x', 'a', {});
+    const r2 = await inner.deleteRow(); // an unwrapped call records nothing
+    expect(r2).toEqual({ seq: 11 });
+    expect(isOwnWriteSeq(10)).toBe(true);
+    expect(isOwnWriteSeq(11)).toBe(true);
+    expect(isOwnWriteSeq(12)).toBe(false);
+    // Non-writers pass through untouched; a missing method is not invented.
+    expect(client.list).toBe(inner.list);
+    expect(withOwnAckRecording({ async batch() { return null; } }).deleteRow).toBeUndefined();
+  });
+
+  it('records into an injected registry, ignores malformed acks, and never swallows the response', async () => {
+    const seen = [];
+    const client = withOwnAckRecording({ async batch() { return undefined; }, async deleteRow() { return { seq: 'x' }; } }, (s) => seen.push(s));
+    expect(await client.batch()).toBeUndefined();
+    expect(await client.deleteRow()).toEqual({ seq: 'x' });
+    expect(seen).toEqual([]);
+    expect(withOwnAckRecording(null)).toBe(null);
   });
 });

--- a/src/sync/ownWrites.js
+++ b/src/sync/ownWrites.js
@@ -41,6 +41,39 @@ export function isOwnWriteSeq(seq) {
   return set.has(seq);
 }
 
+/**
+ * Wrap a vault client so every content write's ack lands in the registry AT
+ * THE SOURCE (audit M13, 2026-09-03). The server emits one nudge per `batch`
+ * (carrying the BATCH's maxSeq) and one per `deleteRow` (carrying that
+ * delete's seq). pushDirtyRows folds all of them into the single maxSeq it
+ * returns, so recording only the folded value leaves every non-max ack
+ * looking foreign: a mixed upsert+delete push (deletes follow the batch, so
+ * the batch's maxSeq is below the fold) leaked its batch nudge as one
+ * spurious self-drain per push — dormant while SSE nudge consumption is
+ * gated off, live the moment it returns. Wrapping both writers records each
+ * ack exactly, which is the only thing the exact-identity ring can use.
+ * Other methods pass through untouched; an injected test client is never
+ * wrapped (the caller decides), so live-swapped spies keep working.
+ */
+export function withOwnAckRecording(inner, record = recordOwnWriteSeq) {
+  if (!inner || typeof inner !== 'object') return inner;
+  const recordAck = (r) => {
+    if (!r || typeof r !== 'object') return;
+    if (typeof r.seq === 'number') record(r.seq);
+    if (typeof r.maxSeq === 'number') record(r.maxSeq);
+  };
+  const wrapped = { ...inner };
+  for (const method of ['batch', 'deleteRow']) {
+    if (typeof inner[method] !== 'function') continue;
+    wrapped[method] = async (...args) => {
+      const r = await inner[method](...args);
+      recordAck(r);
+      return r;
+    };
+  }
+  return wrapped;
+}
+
 /** Test seam. */
 export function __resetOwnWritesForTests() {
   ring.length = 0;

--- a/src/sync/snapshotDeleteGuard.js
+++ b/src/sync/snapshotDeleteGuard.js
@@ -56,7 +56,7 @@
 // and still propagate exactly as before.
 
 import { TOMBSTONE_BUNDLE_KEYS } from './tombstoneRetention.js';
-import { getEntityLastModified } from './dbAdapter.js';
+import { getEntityLastModified, TASK_KINDS } from './dbAdapter.js';
 import { resolveRetirement } from '../utils/retiredTaskIds.js';
 
 // Tolerance for the tombstone-vs-lastModified comparison. Delete-path audit
@@ -294,10 +294,17 @@ export function reassertPropagatedDeletes(propagated, mirror, getLiveEntity) {
   if (!Array.isArray(propagated) || propagated.length === 0) return { evict, accepted };
   const tombstoned = collectTombstones(m);
   const retiredRecord = m.retiredTaskIds && typeof m.retiredTaskIds === 'object' ? m.retiredTaskIds : {};
-  const liveTaskIds = new Set(
-    [...(Array.isArray(m.tasks) ? m.tasks : []), ...(Array.isArray(m.unscheduledTasks) ? m.unscheduledTasks : [])]
-      .filter(Boolean).map((t) => String(t.id)),
-  );
+  // The successor's liveness is judged across EVERY task-shaped kind, exactly
+  // as the partition judges it (liveBareIds spans the whole payload, recycle
+  // bin included). Audit M8 (closed 2026-09-03): this set was tasks +
+  // unscheduledTasks only, so a successor sitting in the recycle bin read as
+  // "vanished", the flip was accepted, and the retired copy resurrected — the
+  // upsert-flip alive for binned successors, at its worst at trigger speed.
+  const liveTaskIds = new Set();
+  for (const kind of TASK_KINDS) {
+    const list = Array.isArray(m[kind]) ? m[kind] : [];
+    for (const t of list) if (t) liveTaskIds.add(String(t.id));
+  }
   for (const { entityId, reason } of propagated) {
     let live = null;
     try { live = getLiveEntity(entityId); } catch { live = null; }

--- a/src/sync/snapshotDeleteGuard.test.js
+++ b/src/sync/snapshotDeleteGuard.test.js
@@ -364,6 +364,20 @@ describe('reassertPropagatedDeletes — the polarity reassert (2026-08-31 war, e
     ).accepted).toHaveLength(1);
   });
 
+  it("'retired' judges the successor across EVERY task kind, like the partition: a BINNED successor still evicts (audit M8)", () => {
+    // The partition blessed this delete because the successor was live in
+    // the payload (recycle bin included); the reassert used to look only at
+    // tasks + unscheduledTasks, saw no successor, accepted the flip, and the
+    // retired copy resurrected beside its binned successor.
+    const record = { OLD: { retiredAt: iso(T), successor: 'obsidian-dg-abc' } };
+    for (const kind of ['recycleBin', 'recurringTasks', 'todayRoutines', 'unscheduledTasks']) {
+      const mirror = { retiredTaskIds: record, tasks: [], [kind]: [{ id: 'obsidian-dg-abc', lastModified: iso(T) }] };
+      const out = reassertPropagatedDeletes(
+        [{ entityId: 'tasks:OLD', reason: 'retired' }], mirror, liveOf({ 'tasks:OLD': wrapped('OLD', T + 5000) }));
+      expect(out.evict, kind).toEqual([{ entityId: 'tasks:OLD', reason: 'retired' }]);
+    }
+  });
+
   it('a row still ABSENT from the mirror needs nothing (polarity intact), cross-list reasons pass through, and empty input is a no-op', () => {
     const out = reassertPropagatedDeletes(
       [

--- a/src/utils/retiredTaskIds.js
+++ b/src/utils/retiredTaskIds.js
@@ -287,13 +287,19 @@ export function applyTaskRetirements(list, record, liveIds) {
 
 /**
  * Convenience wrapper for a { tasks, unscheduledTasks } pair: builds the
- * cross-list live-id set and applies the record to both lists.
+ * cross-list live-id set and applies the record to both lists. `recycleBin`
+ * (and any other task-shaped list passed) contributes to the LIVE set only:
+ * a successor sitting in the bin is still the identity the content moved to,
+ * so the retired copy is superseded rather than kept (audit M8 — the same
+ * every-kind rule the snapshot-delete partition applies). The bin itself is
+ * returned untouched.
  */
-export function applyRetirementsToTaskLists({ tasks, unscheduledTasks }, record) {
+export function applyRetirementsToTaskLists({ tasks, unscheduledTasks, recycleBin }, record) {
   const t = Array.isArray(tasks) ? tasks : [];
   const u = Array.isArray(unscheduledTasks) ? unscheduledTasks : [];
+  const b = Array.isArray(recycleBin) ? recycleBin : [];
   if (!record || Object.keys(record).length === 0) return { tasks: t, unscheduledTasks: u };
-  const liveIds = new Set([...t, ...u].filter(Boolean).map((x) => String(x.id)));
+  const liveIds = new Set([...t, ...u, ...b].filter(Boolean).map((x) => String(x.id)));
   return {
     tasks: applyTaskRetirements(t, record, liveIds),
     unscheduledTasks: applyTaskRetirements(u, record, liveIds),

--- a/src/utils/retiredTaskIds.test.js
+++ b/src/utils/retiredTaskIds.test.js
@@ -125,6 +125,16 @@ describe('applyTaskRetirements — the (d) supersede-regardless-of-timestamps ru
     expect(unscheduledTasks).toEqual([]);
   });
 
+  it('a successor in the RECYCLE BIN counts as live: the retired copy is superseded, the bin is untouched (audit M8)', () => {
+    const bin = [task('S', T2)];
+    const { tasks, unscheduledTasks } = applyRetirementsToTaskLists(
+      { tasks: [task('L', T3)], unscheduledTasks: [], recycleBin: bin }, REC,
+    );
+    expect(tasks).toEqual([]);
+    expect(unscheduledTasks).toEqual([]);
+    expect(bin.map((t) => t.id)).toEqual(['S']);
+  });
+
   it('returns the same array when the record touches nothing', () => {
     const list = [task('X', T1)];
     expect(applyTaskRetirements(list, REC, new Set(['X']))).toBe(list);


### PR DESCRIPTION
## Summary

The last two breaker fixes from the audit backlog, closing the build side of the SSE re-arm sequence. Both are dormant while SSE nudge consumption is gated off and matter the moment it returns.

### M13: mixed upsert+delete pushes leaked their batch nudge
The server nudges once per `batch` (carrying the batch's own maxSeq) and once per `deleteRow`. The engine's push folds all of them into one maxSeq, and the previous fix recorded per-delete acks only, so a push with upserts followed by deletes left the batch's ack unrecorded and its nudge looked foreign: one spurious self-drain per mixed push at trigger speed.
- `withOwnAckRecording(inner)` in `ownWrites.js` wraps `batch` and `deleteRow` and records every ack at the source. The engine uses it in place of the inline deleteRow-only wrapper. An injected client is still never wrapped.

### M8: the reassert's live set was narrower than the partition's
`partitionSnapshotDeletes` blesses a retired id's delete when the successor is live anywhere in the payload, recycle bin included. `reassertPropagatedDeletes` checked only tasks + unscheduledTasks, so a binned successor read as vanished, the upsert-flip was accepted, and the retired copy resurrected beside its binned successor. `applyTaskRetirements` had the same narrowness on the apply side.
- The reassert's retired arm now spans every kind in `TASK_KINDS`.
- `applyRetirementsToTaskLists` accepts `recycleBin` as live-set input (the bin itself is untouched); the file-tier merge and the app's apply path pass it.

### Spec
- Buildout status note: what remains of the re-arm is the supervised single-machine flip, then the fleet, then default-on, running alongside the Phase 8 project-notes build.

## Verification
- New tests: wrapper records batch maxSeq and delete seq and passes everything else through; reassert evicts for a successor in each of the other four kinds; a binned successor supersedes at merge time.
- Lint clean; full suite green (2801 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_