### PR TITLE
Project notes step 1: link by id key, rename following, missing state

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -67,10 +67,19 @@ manually or via BRAT, not submitted to the community directory.
   and reported like daily-note tasks, a few notes per tick when a scope is
   first added. A note leaving the scope is reported as withdrawn. The
   scope rides the pairing-meta row so dayGLANCE applies the same window.
-- Four commands: **Sync now** (drains pending intents + refreshes the
+- **Project and goal notes** (companion spec §4.3): a note can be linked to
+  a dayGLANCE project or goal. The link's identity is a `dayglance-id`
+  frontmatter key the plugin writes; the path is only a cached locator on
+  the dayGLANCE record. **Link current note to a dayGLANCE project or
+  goal** picks from the mirror; **Unlink current note from dayGLANCE**
+  removes the key. The plugin follows renames, reports a deleted note as
+  missing (dayGLANCE keeps the project and offers a relink), re-finds a
+  note by its key on a periodic walk, and applies link and unlink requests
+  made from dayGLANCE. Nothing else in the note is read or written.
+- Six commands: **Sync now** (drains pending intents + refreshes the
   heartbeat), **Enter pairing code**, **Unpair from GLANCEvault**
   (forgets the local credentials and the account key; revoke the token
-  server-side too), and **Open agenda**.
+  server-side too), **Open agenda**, and the two link commands above.
 
 Network access happens only while paired (plus pairing verification), only
 to the vault URL carried in the offer, via Obsidian's `requestUrl`. All

--- a/dayglance-obsidian-plugin/src/agenda.ts
+++ b/dayglance-obsidian-plugin/src/agenda.ts
@@ -65,7 +65,9 @@ const CRYPTO_DB_NAME = 'dayglance-bridge';
 // scheme), so the kind is readable before decryption. Routines are the
 // day's placed chips (todayRoutines) plus two singletons: the day they were
 // placed for and the day's completions.
-const AGENDA_KINDS = new Set(['tasks', 'recurringTasks', 'todayRoutines', 'users']);
+// Projects and goals ride the mirror too (companion §4.3): the link picker
+// lists them, and the maintained frontmatter block is rendered from them.
+const AGENDA_KINDS = new Set(['tasks', 'recurringTasks', 'todayRoutines', 'users', 'projects', 'goals']);
 const SINGLETON_KIND = 'singleton';
 const AGENDA_SINGLETONS = new Set(['routinesDate', 'routineCompletions']);
 // Optimistic completion marks time out: dayGLANCE applies an action within
@@ -91,6 +93,9 @@ export interface AgendaHost {
 
 /** A synced dayGLANCE user, as the settings picker lists them. */
 export interface AgendaUser { syncId: string; name: string }
+
+/** A project or goal the link picker can name (companion §4.3). */
+export interface LinkTarget { kind: 'project' | 'goal'; id: string; title: string; goalTitle?: string }
 
 export interface AgendaStatus {
   key: AgendaKeyState;
@@ -148,6 +153,8 @@ export class AgendaStore {
   private routines = new Map<string, TaskRow>();
   private members = new Map<string, TaskRow>();
   private singletons = new Map<string, unknown>();
+  private projectRows = new Map<string, TaskRow>();
+  private goalRows = new Map<string, TaskRow>();
   // Calendar projections (companion 4.2): read-only calendar events never
   // sync, so each dayGLANCE device publishes its view as a bridge-stream row
   // (`proj:calendar:<deviceId>`, sealed under the pairing subkey). Keyed by
@@ -216,6 +223,23 @@ export class AgendaStore {
       out.push({ syncId, name: String((u as { name?: unknown }).name ?? syncId) });
     }
     return out.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /**
+   * Active projects and goals the viewer can see, for the link picker
+   * (companion §4.3). Title-sorted; a project carries its goal's title.
+   */
+  linkTargets(): LinkTarget[] {
+    const goals = [...this.goalRows.values()].filter((g) => g.status !== 'archived' && this.visibleTask(g));
+    const goalTitle = new Map(goals.map((g) => [String(g.id), String(g.title ?? '')]));
+    const out: LinkTarget[] = [];
+    for (const p of this.projectRows.values()) {
+      if (p.status === 'archived' || !this.visibleTask(p)) continue;
+      const goalId = (p as { goalId?: unknown }).goalId;
+      out.push({ kind: 'project', id: String(p.id), title: String(p.title ?? ''), goalTitle: goalId ? goalTitle.get(String(goalId)) : undefined });
+    }
+    for (const g of goals) out.push({ kind: 'goal', id: String(g.id), title: String(g.title ?? '') });
+    return out.sort((a, b) => a.title.localeCompare(b.title));
   }
 
   // The viewer filters (see AgendaHost.getViewer). A null viewer sees all.
@@ -379,6 +403,8 @@ export class AgendaStore {
     if (kind === 'tasks') return this.tasks;
     if (kind === 'recurringTasks') return this.recurring;
     if (kind === 'users') return this.members;
+    if (kind === 'projects') return this.projectRows;
+    if (kind === 'goals') return this.goalRows;
     return this.routines;
   }
 

--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -51,6 +51,8 @@ import {
   noteInScope,
   scopeIsActive,
   completedSinceFor,
+  PROJECT_NOTE_ID_KEY,
+  linkObservationEntityId,
   type VaultScope,
 } from '@glance-apps/obsidian-format';
 import { createVaultClient, type VaultClient } from '@glance-apps/sync/src/vaultClient.js';
@@ -78,9 +80,17 @@ export interface BridgeState {
   // already reported since they entered scope. Adoption re-reports only what
   // is not here, so a plugin reload does not re-emit every note in scope.
   adoptedScope?: string[];
+  // Project and goal notes (companion §4.3, ruling A): the notes this vault
+  // copy has reported as carrying a `dayglance-id` key, path → id. The
+  // reconciliation walk compares the vault against this map and reports
+  // only the differences, so a reload re-emits nothing.
+  linkedNotes?: Record<string, string>;
 }
 
 const APPLIED_IDS_CAP = 1000;
+// The full link rescan (every markdown file's frontmatter, from the
+// metadata cache) runs at most this often; per-file events cover the rest.
+const LINK_RESCAN_MS = 5 * 60_000;
 // (The stamp-deferral CAP that used to live here is deliberately GONE — it
 // authorized a vault write into a note with a dirty editor buffer, which is
 // how the 2026-08-31 truncation destroyed typed text. Deferral is now
@@ -258,6 +268,10 @@ export class BridgeTransport {
   // Vault task scope: paths reported as scoped (deletions of these report),
   // the persisted adopted set, and the throttled adoption queue.
   private scopedPaths = new Set<string>();
+  // Project and goal notes (companion §4.3): path → dayGLANCE id, as last
+  // reported. Persisted (BridgeState.linkedNotes); see LINK_RESCAN_MS.
+  private linked = new Map<string, string>();
+  private linkScanAt = 0;
   private adopted = new Set<string>();
   private adoptQueue: string[] = [];
   private adoptScanned = false;
@@ -351,6 +365,9 @@ export class BridgeTransport {
     }
     for (const p of host.getBridgeState().adoptedScope ?? []) {
       if (typeof p === 'string') { this.adopted.add(p); this.scopedPaths.add(p); }
+    }
+    for (const [path, id] of Object.entries(host.getBridgeState().linkedNotes ?? {})) {
+      if (typeof path === 'string' && typeof id === 'string' && id) this.linked.set(path, id);
     }
   }
 
@@ -823,6 +840,9 @@ export class BridgeTransport {
   private async applyOne(intent: Record<string, unknown>): Promise<'applied' | 'unsupported' | 'deferred'> {
     const adapter = this.host.app.vault.adapter;
     let path: string;
+    if (intent.type === 'project_note_link' || intent.type === 'project_note_unlink') {
+      return this.applyLinkIntent(intent);
+    }
     if (intent.type === 'wiki_note_write') {
       // Wikilink resolution is the applier's job (the one intent type
       // without an emitter-resolved path): an existing note anywhere in
@@ -885,6 +905,182 @@ export class BridgeTransport {
       }
     }
     return 'applied';
+  }
+
+  // ── Project and goal notes (companion §4.3) ─────────────────────────────
+  //
+  // Ruling A: the durable identity of a link is the `dayglance-id` key in the
+  // note's frontmatter; the path on the dayGLANCE record is a cached locator.
+  // The plugin is the only writer of the key and the only observer of
+  // renames and deletes, so it reports LINK observations — one row per
+  // target id (linkObservationEntityId), upserted: the row is the latest
+  // state — and reconciles the vault against `linked` (what it last
+  // reported) on every relevant event plus a periodic full walk, which is
+  // how a rename that happened while the plugin was off is re-found by key.
+
+  /** The dayGLANCE id a note's frontmatter carries, or null. */
+  private noteLinkId(path: string): string | null | undefined {
+    const file = this.host.app.vault.getAbstractFileByPath(normalizePath(path));
+    if (!(file instanceof TFile)) return undefined; // no such note
+    if (file.extension !== 'md') return null;
+    const raw = this.host.app.metadataCache.getFileCache(file)?.frontmatter?.[PROJECT_NOTE_ID_KEY];
+    const id = typeof raw === 'string' ? raw.trim() : (typeof raw === 'number' ? String(raw) : '');
+    return id && id.length <= 64 ? id : null;
+  }
+
+  /** Reconcile one path against what was last reported; emit on change. A
+   *  failed emission rolls the map back so the next pass re-derives it. */
+  private async syncLink(path: string, deleted: boolean): Promise<void> {
+    if (this.disposed) return;
+    const prev = this.linked.get(path);
+    const id = deleted ? undefined : this.noteLinkId(path);
+    if (id === undefined) {
+      // The note is gone (event, or a walk that no longer finds it).
+      if (prev === undefined) return;
+      this.linked.delete(path);
+      if (!(await this.emitLink({ targetId: prev, path, deleted: true }))) this.linked.set(path, prev);
+      void this.persistLinked();
+      return;
+    }
+    if (id === prev || (id === null && prev === undefined)) return;
+    if (id) {
+      this.linked.set(path, id);
+      if (prev && prev !== id) void this.emitLink({ targetId: prev, path, unlinked: true });
+      if (!(await this.emitLink({ targetId: id, path }))) { if (prev) this.linked.set(path, prev); else this.linked.delete(path); }
+    } else if (prev !== undefined) {
+      this.linked.delete(path);
+      if (!(await this.emitLink({ targetId: prev, path, unlinked: true }))) this.linked.set(path, prev);
+    }
+    void this.persistLinked();
+  }
+
+  /** A note's metadata changed (frontmatter edits arrive here, not on modify). */
+  noteMetaChanged(path: string): void {
+    if (this.disposed || !this.host.getPairing()) return;
+    void this.syncLink(path, false);
+  }
+
+  /** A rename keeps the link: the row for the id simply moves to the new path. */
+  noteRenamed(oldPath: string, newPath: string): void {
+    if (this.disposed) return;
+    const id = this.linked.get(oldPath);
+    if (id === undefined) return;
+    this.linked.delete(oldPath);
+    this.linked.set(newPath, id);
+    void this.persistLinked();
+    void this.emitLink({ targetId: id, path: newPath, previousPath: oldPath }).then((ok) => {
+      if (ok) return;
+      // Roll back to the old path: the next walk reports the delete and the
+      // new note's key as two ordinary observations.
+      this.linked.delete(newPath);
+      this.linked.set(oldPath, id);
+      void this.persistLinked();
+    });
+  }
+
+  /** The periodic full walk (layout ready, then every LINK_RESCAN_MS): every
+   *  markdown file's key against the map, and every mapped path's existence. */
+  linkTick(): void {
+    if (this.disposed || !this.host.getPairing()) return;
+    const now = Date.now();
+    if (now - this.linkScanAt < LINK_RESCAN_MS) return;
+    this.linkScanAt = now;
+    const seen = new Set<string>();
+    for (const f of this.host.app.vault.getMarkdownFiles()) {
+      seen.add(f.path);
+      void this.syncLink(f.path, false);
+    }
+    for (const path of [...this.linked.keys()]) if (!seen.has(path)) void this.syncLink(path, true);
+  }
+
+  private async persistLinked(): Promise<void> {
+    if (this.disposed) return;
+    try {
+      const state = this.host.getBridgeState();
+      const next = Object.fromEntries([...this.linked].sort(([a], [b]) => a.localeCompare(b)));
+      if (JSON.stringify(state.linkedNotes ?? {}) === JSON.stringify(next)) return;
+      await this.host.saveBridgeState({ ...state, linkedNotes: next });
+    } catch (e) {
+      console.error('dayGLANCE bridge: could not persist the linked notes', e);
+    }
+  }
+
+  private async emitLink(fields: { targetId: string; path: string; deleted?: boolean; unlinked?: boolean; previousPath?: string }): Promise<boolean> {
+    try {
+      const pairing = this.host.getPairing();
+      if (!pairing || this.rateLimited()) return false;
+      const subkey = await this.subkeyFor(pairing);
+      const payload: Record<string, unknown> = { v: 1, kind: 'observation', link: true, ...fields, observedAt: new Date().toISOString() };
+      const ack = await this.client(pairing).batch(BRIDGE_VAULT_APP, {
+        accountId: pairing.accountId,
+        rows: [{ entityId: linkObservationEntityId(fields.targetId), envelope: await sealBridgeEnvelope(subkey, payload), createdAt: Date.now() }],
+      });
+      const ackSeq = Number((ack as { maxSeq?: unknown } | null)?.maxSeq);
+      if (Number.isFinite(ackSeq)) this.sseGate.recordOwnSeq(ackSeq);
+      return true;
+    } catch (e) {
+      if (isRateLimitError(e)) this.noteRateLimit();
+      console.warn('dayGLANCE bridge: link report failed (re-derived on the next pass)', e);
+      return false;
+    }
+  }
+
+  /** Write (or remove) the id key through Obsidian's frontmatter API. The
+   *  same dirty-buffer rule as every other write: unsaved keystrokes defer. */
+  private async setNoteLink(file: TFile, targetId: string | null): Promise<'applied' | 'deferred'> {
+    const path = file.path;
+    const current = await this.host.app.vault.adapter.read(path);
+    if (this.markdownViews(path).some((v) => v.getViewData() !== current)) return 'deferred';
+    const prev = this.linked.get(path);
+    await this.host.app.fileManager.processFrontMatter(file, (fm: Record<string, unknown>) => {
+      if (targetId) fm[PROJECT_NOTE_ID_KEY] = targetId;
+      else delete fm[PROJECT_NOTE_ID_KEY];
+    });
+    if (targetId) {
+      this.linked.set(path, targetId);
+      if (prev && prev !== targetId) void this.emitLink({ targetId: prev, path, unlinked: true });
+      if (prev !== targetId && !(await this.emitLink({ targetId, path }))) { if (prev) this.linked.set(path, prev); else this.linked.delete(path); }
+    } else if (prev !== undefined) {
+      this.linked.delete(path);
+      if (!(await this.emitLink({ targetId: prev, path, unlinked: true }))) this.linked.set(path, prev);
+    }
+    void this.persistLinked();
+    return 'applied';
+  }
+
+  private async applyLinkIntent(intent: Record<string, unknown>): Promise<'applied' | 'deferred'> {
+    const path = normalizePath(String(intent.path ?? ''));
+    const targetId = String(intent.targetId ?? '').trim();
+    if (!path || !targetId) return 'applied';
+    const file = this.host.app.vault.getAbstractFileByPath(path);
+    const link = intent.type === 'project_note_link';
+    if (!(file instanceof TFile) || file.extension !== 'md') {
+      // The note dayGLANCE named does not exist here: ruling F, the record
+      // learns its note is missing (a relink or an unlink resolves it).
+      if (link) await this.emitLink({ targetId, path, deleted: true });
+      return 'applied';
+    }
+    if (!link && this.noteLinkId(path) !== targetId) return 'applied'; // not ours to remove
+    return this.setNoteLink(file, link ? targetId : null);
+  }
+
+  /** The palette command: link the given note to a project or goal. */
+  async linkNote(file: TFile, targetId: string): Promise<{ ok: boolean; message: string }> {
+    if (!this.host.getPairing()) return { ok: false, message: 'not paired.' };
+    const r = await this.setNoteLink(file, targetId);
+    return r === 'deferred'
+      ? { ok: false, message: 'the note has unsaved changes; save it and retry.' }
+      : { ok: true, message: `linked "${file.basename}".` };
+  }
+
+  /** The palette command: remove the note's link, whatever it names. */
+  async unlinkNote(file: TFile): Promise<{ ok: boolean; message: string }> {
+    if (!this.host.getPairing()) return { ok: false, message: 'not paired.' };
+    if (!this.noteLinkId(file.path)) return { ok: true, message: `"${file.basename}" is not linked.` };
+    const r = await this.setNoteLink(file, null);
+    return r === 'deferred'
+      ? { ok: false, message: 'the note has unsaved changes; save it and retry.' }
+      : { ok: true, message: `unlinked "${file.basename}".` };
   }
 
   /** Every markdown view whose buffer shows `path` (active or background —
@@ -1086,6 +1282,9 @@ export class BridgeTransport {
         this.armObserve(path, deleted, Math.max(1000, this.backoffUntil - Date.now() + 1000));
         return;
       }
+      // Project and goal notes (companion §4.3): reconcile this note's link
+      // before any scope gate — a linked note need not be a task source.
+      await this.syncLink(path, deleted);
       const adapter = this.host.app.vault.adapter;
       let content: string | null = null;
       let mtime: number | null = null;

--- a/dayglance-obsidian-plugin/src/linkModal.ts
+++ b/dayglance-obsidian-plugin/src/linkModal.ts
@@ -1,0 +1,17 @@
+// The "link this note" picker (companion spec §4.3, ruling A): a fuzzy list
+// of the mirror's active projects and goals. Choosing one writes the
+// entity's id into the current note's frontmatter (bridge.ts linkNote).
+import { App, FuzzySuggestModal } from 'obsidian';
+import type { LinkTarget } from './agenda';
+
+export class LinkTargetModal extends FuzzySuggestModal<LinkTarget> {
+  constructor(app: App, private readonly targets: LinkTarget[], private readonly onChoose: (t: LinkTarget) => void) {
+    super(app);
+    this.setPlaceholder('Link this note to a dayGLANCE project or goal');
+  }
+  getItems(): LinkTarget[] { return this.targets; }
+  getItemText(t: LinkTarget): string {
+    return t.kind === 'goal' ? `${t.title} (goal)` : (t.goalTitle ? `${t.title} (${t.goalTitle})` : t.title);
+  }
+  onChooseItem(t: LinkTarget): void { this.onChoose(t); }
+}

--- a/dayglance-obsidian-plugin/src/main.ts
+++ b/dayglance-obsidian-plugin/src/main.ts
@@ -49,6 +49,7 @@ import { AgendaStore } from './agenda';
 import { normalizeScope, scopeIsActive, type VaultScope } from '@glance-apps/obsidian-format';
 import { localDateStr } from '@glance-apps/agenda-core';
 import { AgendaView, AGENDA_VIEW_TYPE, removeAgendaStyles } from './agendaView';
+import { LinkTargetModal } from './linkModal';
 
 const HEARTBEAT_DIR = '.dayglance';
 const HEARTBEAT_PATH = `${HEARTBEAT_DIR}/heartbeat`;
@@ -145,8 +146,46 @@ export default class DayGlanceBridgePlugin extends Plugin {
       this.registerEvent(this.app.vault.on('create', (f) => { if (f instanceof TFile) this.transport.scheduleObservation(f); }));
       this.registerEvent(this.app.vault.on('delete', (f) => { if (f instanceof TFile) this.transport.reportDeleted(f.path); }));
       this.registerEvent(this.app.vault.on('rename', (f, oldPath) => {
-        if (f instanceof TFile) { this.transport.reportDeleted(oldPath); this.transport.scheduleObservation(f); }
+        if (f instanceof TFile) {
+          // A linked project note keeps its link across the rename (companion §4.3, ruling A).
+          this.transport.noteRenamed(oldPath, f.path);
+          this.transport.reportDeleted(oldPath);
+          this.transport.scheduleObservation(f);
+        }
       }));
+      // Frontmatter edits (the id key) surface as metadata changes, not file modifies.
+      this.registerEvent(this.app.metadataCache.on('changed', (f) => { if (f instanceof TFile) this.transport.noteMetaChanged(f.path); }));
+    });
+
+    // Project and goal notes (companion §4.3): link or unlink the active note.
+    this.addCommand({
+      id: 'link-note-to-project',
+      name: 'Link current note to a dayGLANCE project or goal',
+      checkCallback: (checking) => {
+        const file = this.app.workspace.getActiveFile();
+        if (!file || file.extension !== 'md') return false;
+        if (checking) return true;
+        if (!this.data.pairing) { new Notice('dayGLANCE bridge: not paired.'); return true; }
+        const targets = this.agenda.linkTargets();
+        if (!targets.length) {
+          new Notice('dayGLANCE bridge: no projects or goals in the mirror yet. Open the agenda once, then retry.');
+          return true;
+        }
+        new LinkTargetModal(this.app, targets, (t) => {
+          void this.transport.linkNote(file, t.id).then((r) => new Notice(`dayGLANCE bridge: ${r.message}`));
+        }).open();
+        return true;
+      },
+    });
+    this.addCommand({
+      id: 'unlink-note-from-project',
+      name: 'Unlink current note from dayGLANCE',
+      checkCallback: (checking) => {
+        const file = this.app.workspace.getActiveFile();
+        if (!file || file.extension !== 'md') return false;
+        if (!checking) void this.transport.unlinkNote(file).then((r) => new Notice(`dayGLANCE bridge: ${r.message}`));
+        return true;
+      },
     });
 
     // Full ids in the palette: dayglance-bridge:<id> (Obsidian prefixes the
@@ -249,13 +288,14 @@ export default class DayGlanceBridgePlugin extends Plugin {
     void this.transport.drain();
     // Scope adoption walks the metadata cache, which is complete only after
     // layout is ready; the tick then reports a few notes per interval.
-    this.app.workspace.onLayoutReady(() => this.transport.adoptTick());
+    this.app.workspace.onLayoutReady(() => { this.transport.adoptTick(); this.transport.linkTick(); });
     this.registerInterval(
       window.setInterval(() => {
         void this.writeHeartbeat();
         void this.checkForPairingOffer();
         void this.transport.drain();
         this.transport.adoptTick();
+        this.transport.linkTick();
       }, HEARTBEAT_INTERVAL_MS),
     );
   }

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -620,6 +620,30 @@ action, matching the task badge from §6 step 3.
    project / nested under goal); creation from dayGLANCE through a plugin
    intent, template via the §4.4 ladder (D, E); goal links and blocks.
 
+**Step 1 record (2026-09-03, built).** The record carries `obsidianNotePath`
+(synced locator) and `obsidianNoteMissingAt` (ruling F's mark; the path is
+KEPT while set so a relink can prefill, and every reader treats the link as
+absent). The plugin owns the vault side: it writes and removes the
+`dayglance-id` key through Obsidian's frontmatter API under the same
+dirty-buffer rule as every other write; watches metadata changes, renames
+and deletes; walks the whole vault's frontmatter at layout-ready and every
+five minutes (how a rename made while the plugin was off is re-found by
+key); and reports LINK observations — one row per target id, upserted, so a
+rename replaces the row's path and a deletion replaces it with a deleted
+mark — reconciled against a persisted path→id map so a reload re-emits
+nothing. Two palette commands (link the current note, picking from the
+mirror's active projects and goals; unlink it) and two intents from
+dayGLANCE (`project_note_link`, `project_note_unlink`; a link to a note
+that does not exist reports it missing). dayGLANCE's project form links by
+path (the record updates only once the intent is durably queued), opens,
+relinks and unlinks; the project card carries the note badge, or a warning
+while the note is missing. Goals ride the same machinery in the record and
+the plugin; their form row is step 3. *Judgment calls:* the missing mark
+keeps the path rather than clearing it (the ruling's intent — nothing reads
+a missing link — holds; the relink prefills); linking from dayGLANCE takes
+a typed path rather than a vault picker, since the vault index lives in the
+plugin, whose picker is the primary way to link.
+
 ---
 
 ### 4.4 Templater, via guarded delegation

--- a/packages/obsidian-format/src/bridgeStream.js
+++ b/packages/obsidian-format/src/bridgeStream.js
@@ -36,6 +36,13 @@
 //   completion_log_append {path, date, heading, template, entry} — entry is
 //                     the FINISHED log line, formatted by the emitter
 //                     (completionLog.js), inserted at section end
+//   project_note_link   {path, targetId} — write the `dayglance-id` key
+//                     (PROJECT_NOTE_ID_KEY) into the note's frontmatter
+//                     (companion §4.3, ruling A); applied by the PLUGIN via
+//                     Obsidian's frontmatter API, never by the text applier
+//                     below (which reports it unsupported)
+//   project_note_unlink {path, targetId} — remove that key when it names
+//                     targetId
 // `path` is always vault-root-relative and resolved BY THE EMITTER (the
 // emitter owns the dailyNotesPath/pattern config; the applier needs no
 // dayGLANCE settings). wiki_note_write is the one type without a resolved
@@ -46,6 +53,10 @@
 // OBSERVATION payloads (sealed): { v:1, kind:'observation', path,
 // content|null, deleted?, mtime, observedAt }. One row per path, upserted
 // (entityId from observationEntityId), so the row IS the latest state.
+// LINK observations (companion §4.3): { v:1, kind:'observation', link:true,
+// targetId, path, deleted?, unlinked?, previousPath?, observedAt } — one row
+// per TARGET id (linkObservationEntityId), upserted, so a rename simply
+// replaces the row's path and a deletion replaces it with deleted:true.
 //
 // APPLYING IS A PURE FUNCTION of (current file text, intent) — the spec's
 // convergence requirement. It is also IDEMPOTENT: applying an intent to a
@@ -84,6 +95,12 @@ export const BRIDGE_ACTION_PREFIX = 'act:';
 // deviceId, from, to, publishedAt, events:[…]}`. Readers union the rows and
 // prefer the freshest copy of an event id. Never deleted by the reader.
 export const BRIDGE_PROJECTION_PREFIX = 'proj:';
+// Project and goal notes (companion §4.3, ruling A): the frontmatter key that
+// holds the entity's dayGLANCE id — the durable identity of the link; the
+// path on the entity record is only the cached locator.
+export const PROJECT_NOTE_ID_KEY = 'dayglance-id';
+/** The link observation row for one project or goal id (see the header). */
+export const linkObservationEntityId = (targetId) => `${BRIDGE_OBSERVATION_PREFIX}link:${String(targetId)}`;
 export const bridgeCalendarProjectionId = (deviceId) => `${BRIDGE_PROJECTION_PREFIX}calendar:${deviceId}`;
 
 const enc = new TextEncoder();

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -197,6 +197,8 @@ export function createSseNudgeGate(opts?: {
 }): SseNudgeGate;
 export function mintIntentId(): string;
 export function observationEntityId(path: string): Promise<string>;
+export const PROJECT_NOTE_ID_KEY: string;
+export function linkObservationEntityId(targetId: string): string;
 export function sealBridgeEnvelope(subkey: CryptoKey, payload: unknown): Promise<string>;
 export function openBridgeEnvelope(subkey: CryptoKey, text: string): Promise<unknown | null>;
 export function encodePlainBridgeRow(payload: unknown): string;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2773,6 +2773,7 @@ const DayPlanner = () => {
   // lives in useObsidianSync; state/refs stay owned by useObsidian above.
   const {
     performObsidianSync, nudgeObsidianObservations, loadWikiNote, saveWikiNote, openInObsidian, bridgeHeartbeatRef,
+    linkProjectNote, unlinkProjectNote,
   } = useObsidianSync({
     isTrayMode, dataLoaded,
     tasks, setTasks,
@@ -2791,6 +2792,7 @@ const DayPlanner = () => {
     recycleBin, setRecycleBin,
     recurringTasks, setRecurringTasks,
     multiUserEnabled, meUserSyncId,
+    projects, goals, updateProject, updateGoal,
   });
   // Completion log (companion spec 4.1): every task completion appends one
   // permanent line to the completion date's daily note. Mounted here, after
@@ -8683,6 +8685,7 @@ const DayPlanner = () => {
     vaultEnabled: isVaultEnabled(),
     syncAll,
     performObsidianSync, loadWikiNote, saveWikiNote, openInObsidian, nativeClearVault,
+    linkProjectNote, unlinkProjectNote,
     performTrmnlSync,
     performLocalBackup, performRemoteBackup,
     buildAutoBackupPayload, loadAutoBackupHistory,

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -35,6 +35,8 @@ import {
 } from 'lucide-react';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
+import { useSyncCtx } from '../../context/SyncContext.jsx';
+import { noteLinkOf } from '../../utils/obsidianProjectNotes.js';
 import { TASK_COLORS, TAILWIND_TO_HEX, hexToRgba, PROJECT_FALLBACK_COLOR } from '../../utils/colorUtils.js';
 import { dateToString } from '../../utils/taskUtils.js';
 import { calculateGoalProgress } from '../../utils/goalProgress.js';
@@ -390,6 +392,70 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
 
 // ─── Project form (create / edit) ─────────────────────────────────────────────
 
+/**
+ * ProjectNoteRow — the project's Obsidian note (companion spec §4.3). Links
+ * an EXISTING vault note by path (the plugin writes the id key), opens it,
+ * unlinks it, and shows the missing state with a relink (ruling F). Reads the
+ * live project so the row reflects the link as soon as it lands.
+ */
+const ProjectNoteRow = ({ projectId }) => {
+  const { darkMode, borderClass, textPrimary, textSecondary } = useDayPlannerCtx();
+  const { projects } = useFeaturesCtx();
+  const { obsidianConfig, linkProjectNote, unlinkProjectNote, openInObsidian } = useSyncCtx();
+  const project = (projects || []).find(p => p.id === projectId);
+  const link = noteLinkOf(project);
+  const [path, setPath] = useState(link?.name || '');
+  const [error, setError] = useState('');
+  if (!project || (!obsidianConfig?.enabled && !link)) return null;
+  const inputCls = `px-3 py-2 text-sm rounded-lg border ${borderClass} focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+    darkMode ? 'bg-gray-700 text-gray-100 placeholder-gray-500' : 'bg-white text-stone-900 placeholder-stone-400'
+  }`;
+  const btnCls = `px-2.5 py-1.5 text-xs rounded-lg border ${borderClass} ${textPrimary} hover:bg-blue-500/10`;
+  const submit = () => {
+    setError('');
+    if (!linkProjectNote?.('project', project.id, path)) {
+      setError('Could not link. Enter a vault path and make sure the dayGLANCE bridge plugin is paired.');
+    }
+  };
+  return (
+    <div className="flex flex-col gap-1">
+      <label className={`text-xs font-medium ${textSecondary}`}>Obsidian note</label>
+      {link && !link.missing ? (
+        <div className="flex items-center gap-2 text-sm">
+          <span className={`${textPrimary} truncate flex-1 min-w-0`} title={link.path}>{link.name}</span>
+          <button type="button" className={btnCls} onClick={() => openInObsidian?.(link.name)}>Open</button>
+          <button type="button" className={btnCls} onClick={() => unlinkProjectNote?.('project', project.id)}>Unlink</button>
+        </div>
+      ) : (
+        <>
+          {link?.missing && (
+            <div className="text-xs text-amber-600 dark:text-amber-400">
+              The linked note is missing from the vault ({link.name}). Relink it, or unlink the project.
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <input
+              value={path}
+              onChange={e => setPath(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); submit(); } }}
+              placeholder="Projects/House"
+              className={`${inputCls} flex-1 min-w-0`}
+            />
+            <button type="button" className={btnCls} onClick={submit}>{link?.missing ? 'Relink' : 'Link'}</button>
+            {link?.missing && (
+              <button type="button" className={btnCls} onClick={() => unlinkProjectNote?.('project', project.id)}>Unlink</button>
+            )}
+          </div>
+          <div className={`text-[11px] ${textSecondary}`}>
+            Vault path of an existing note. The dayGLANCE bridge plugin writes the link into the note.
+          </div>
+          {error && <div className="text-xs text-red-500">{error}</div>}
+        </>
+      )}
+    </div>
+  );
+};
+
 export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, mobile }) => {
   const { darkMode, cardBg, borderClass, textPrimary, textSecondary, hoverBg, tasks, unscheduledTasks, use24HourClock, isMobile, isTablet } =
     useDayPlannerCtx();
@@ -475,6 +541,9 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
           ))}
         </select>
       </div>
+
+      {/* Obsidian note (companion §4.3) */}
+      {initial && <ProjectNoteRow projectId={initial.id} />}
 
       {/* Color — defaults to the goal's color (blue when standalone) until overridden */}
       <div className="flex flex-col gap-1.5">

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -20,6 +20,7 @@ import { renderTitle, hasNotesOrSubtasks, isLinkOnlyTask, hasOnlySubtasks, getLi
 import { dateToString, extractWikilinks, completionTimestamp } from '../../utils/taskUtils.js';
 import { getNextOccurrence } from '../../utils/recurrenceEngine.js';
 import { getActiveHGInstance } from '../../hooks/useHyperGlance.js';
+import { noteLinkOf } from '../../utils/obsidianProjectNotes.js';
 
 const toHex = (bgClass) => TAILWIND_TO_HEX[bgClass] || '#3b82f6';
 
@@ -63,6 +64,20 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
     mobileActiveTab,
   } = useDayPlannerCtx();
   const { loadWikiNote, saveWikiNote, openInObsidian } = useSyncCtx();
+  // Project note (companion §4.3): a badge that opens the linked note, or a
+  // warning while the note is missing from the vault (ruling F).
+  const noteLink = noteLinkOf(project);
+  const noteBadge = noteLink && (
+    <button
+      type="button"
+      onClick={(e) => { e.stopPropagation(); if (!noteLink.missing) openInObsidian?.(noteLink.name); }}
+      className={`flex-shrink-0 p-1 rounded ${noteLink.missing ? 'text-amber-500' : `${textSecondary} opacity-60 hover:opacity-100`}`}
+      title={noteLink.missing ? `Obsidian note missing: ${noteLink.name}` : `Open "${noteLink.name}" in Obsidian`}
+      aria-label={noteLink.missing ? 'Obsidian note missing' : 'Open project note in Obsidian'}
+    >
+      {noteLink.missing ? <AlertTriangle size={12} /> : <FileText size={12} />}
+    </button>
+  );
   const { goals, deleteProject, updateProject, setPlannerProjectId, generateAISubtasks, aiSubtasksLoadingForTask, aiConfig, showGoalsDashboard, enterHyperGlanceMode, isVisibleForUser } = useFeaturesCtx();
 
   const isScheduled = (t) => !!tasks.find(s => s.id === t.id);
@@ -310,6 +325,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
             <span className={`text-sm font-medium ${textPrimary} flex-1 min-w-0 truncate`}>
               {project.title}
             </span>
+            {noteBadge}
             {onMoveToClick && (
               <button onClick={() => onMoveToClick(project)} className={`${btnBase} ${editBtn}`} title="Move to…" aria-label="Move to goal">
                 <LogIn size={12} />
@@ -396,6 +412,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
           <span className={`text-sm font-semibold ${textPrimary} leading-tight flex-1 min-w-0`}>
             {project.title}
           </span>
+          {noteBadge}
           {project.hyperglance?.enabled && project.status !== 'completed' && !project.archived && (() => {
               const instance = getActiveHGInstance(project, currentTimeMinutes);
               if (!instance) return null;

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -23,6 +23,7 @@ import { mergeObsidianTasks, noteMtimesFromDailyNotes, noteMtimesFromScopedNotes
 import { detectObsidianDeletions, addObsidianTombstones } from '../utils/obsidianDeletions.js';
 import { reattachTasksMetadata } from '../utils/obsidianTasksMetadata.js';
 import { obsidianHeartbeatState } from '../utils/obsidianHeartbeat.js';
+import { planNoteLinkUpdates, normalizeNotePath } from '../utils/obsidianProjectNotes.js';
 import {
   readRetiredTaskIds,
   recordRetirements as recordRetirementEntries,
@@ -136,7 +137,14 @@ export default function useObsidianSync({
   // The device's multi-user identity; stamped on the calendar projection so
   // the plugin can show its viewer's calendars only.
   meUserSyncId = null,
+  // Project and goal notes (companion §4.3): the plugin's link observations
+  // update these records; optional so existing harnesses need no change.
+  projects = [], goals = [], updateProject = null, updateGoal = null,
 }) {
+  const projectsRef = useRef(projects);
+  projectsRef.current = projects;
+  const goalsRef = useRef(goals);
+  goalsRef.current = goals;
   // Fresh bin contents for the async sync cycle (same staleness fix as the
   // task refs above — interval-triggered syncs must not see the closure's
   // render-time copy).
@@ -687,6 +695,17 @@ export default function useObsidianSync({
                 today: dateToString(new Date()),
               })
             : null;
+
+          // PROJECT AND GOAL NOTES (companion §4.3, rulings A and F): the
+          // plugin reports which note carries each entity's id key — on
+          // link, rename (new path, same id), deletion (the note is missing;
+          // the record keeps its path and is marked) and unlink. The record
+          // is the synced locator; the key in the vault is the identity.
+          if (applied?.links?.length) {
+            const plan = planNoteLinkUpdates(applied.links, { projects: projectsRef.current, goals: goalsRef.current });
+            for (const { id, updates } of plan.projects) updateProject?.(id, updates);
+            for (const { id, updates } of plan.goals) updateGoal?.(id, updates);
+          }
 
           // WITHDRAWAL (companion §6, ruling C): a note that left the scope
           // takes its tasks out of dayGLANCE — tombstoned through the
@@ -1750,5 +1769,29 @@ export default function useObsidianSync({
     );
   }, [obsidianConfig?.dailyNotesPath, obsidianConfig?.dailyNotePattern, obsidianConfig?.newNotesFolder, obsidianConfig?.enabled]);
 
-  return { performObsidianSync, nudgeObsidianObservations, loadWikiNote, saveWikiNote, openInObsidian, notifyNativeReady, bridgeHeartbeatRef };
+  // ── Project and goal notes: link and unlink from dayGLANCE (companion §4.3) ──
+  // The intent is the write (the plugin puts the id key into the note's
+  // frontmatter, or removes it); the record updates only once the intent is
+  // durably queued, so an unpaired vault never shows a link the vault does
+  // not carry. Returns whether the link was queued.
+  const linkProjectNote = useCallback((kind, id, rawPath) => {
+    const path = normalizeNotePath(rawPath);
+    const update = kind === 'goal' ? updateGoal : updateProject;
+    if (!path || !update) return false;
+    if (!emitBridgeIntent('project_note_link', { path, targetId: String(id) })) return false;
+    update(id, { obsidianNotePath: path, obsidianNoteMissingAt: null });
+    return true;
+  }, [updateProject, updateGoal]);
+  const unlinkProjectNote = useCallback((kind, id) => {
+    const list = kind === 'goal' ? goalsRef.current : projectsRef.current;
+    const update = kind === 'goal' ? updateGoal : updateProject;
+    const entity = (list || []).find((e) => e && String(e.id) === String(id));
+    if (!update) return false;
+    const path = entity?.obsidianNotePath; // read before the update (the record may be mutated in place)
+    update(id, { obsidianNotePath: null, obsidianNoteMissingAt: null });
+    if (path) emitBridgeIntent('project_note_unlink', { path, targetId: String(id) });
+    return true;
+  }, [updateProject, updateGoal]);
+
+  return { performObsidianSync, nudgeObsidianObservations, loadWikiNote, saveWikiNote, openInObsidian, notifyNativeReady, bridgeHeartbeatRef, linkProjectNote, unlinkProjectNote };
 }

--- a/src/hooks/useObsidianSync.projectNotes.test.js
+++ b/src/hooks/useObsidianSync.projectNotes.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// PROJECT AND GOAL NOTES, the link (companion spec §4.3, rulings A and F),
+// through the real sync entry point: the plugin's link observations update
+// the project record (locator, rename, missing, unlink), and the app-side
+// link/unlink actions emit the frontmatter intents the plugin applies.
+
+const effects = [];
+vi.mock('react', () => ({
+  useEffect: (fn, deps) => { effects.push({ fn, deps }); },
+  useCallback: (fn) => fn,
+  useRef: (init) => ({ current: init }),
+}));
+
+const heartbeatMock = vi.fn(async () => null);
+vi.mock('../obsidian.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    tryRestoreVaultAccess: vi.fn(async () => null),
+    getVaultAccess: vi.fn(async () => null),
+    syncObsidianVault: vi.fn(async () => ({ dailyNotes: {}, scheduledTasks: [], inboxTasks: [] })),
+    syncObsidianVaultNative: vi.fn(async () => null),
+    writeTaskStateToFile: vi.fn(async () => true),
+    writeTaskStateNative: vi.fn(() => false),
+    readWikiNote: vi.fn(async () => null),
+    writeWikiNote: vi.fn(async () => {}),
+    scanVaultNotes: vi.fn(async () => ({ names: [], unportable: [] })),
+    vaultHasTasksPlugin: vi.fn(async () => false),
+    detectTasksPluginNative: vi.fn(() => null),
+    readVaultHeartbeat: (...a) => heartbeatMock(...a),
+    readVaultHeartbeatNative: vi.fn(() => null),
+  };
+});
+vi.mock('../native.js', () => ({
+  isNativeAndroid: () => false,
+  isNativeApp: () => false,
+  nativeGetVaultConfig: vi.fn(() => null),
+  nativeGetNote: vi.fn(() => null),
+  nativeWriteNote: vi.fn(),
+  nativeOpenNote: vi.fn(),
+  nativeListNotes: vi.fn(() => []),
+  nativeSetVaultSettings: vi.fn(),
+  nativeSetLaunchOnWrite: vi.fn(),
+}));
+const emitBridgeIntent = vi.fn(() => true);
+vi.mock('../utils/obsidianBridgeStream.js', () => ({
+  cachedBridgePairingMeta: () => null,
+  emitBridgeIntent: (...a) => emitBridgeIntent(...a),
+  flushBridgeOutbox: vi.fn(async () => true),
+  publishBridgeConfig: vi.fn(async () => {}),
+  getBridgePairingMeta: vi.fn(async () => null),
+}));
+vi.mock('../utils/obsidianBridgeMode.js', () => ({
+  recordBridgeMode: vi.fn(),
+  reconcileArchivedBaseline: vi.fn(() => null),
+}));
+const fetchMock = vi.fn(async () => null);
+vi.mock('../utils/obsidianBridgeInbound.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, fetchBridgeObservations: (...a) => fetchMock(...a) };
+});
+
+const { default: useObsidianSync } = await import('./useObsidianSync.js');
+
+function useMountedHook({ projects = [], goals = [] } = {}) {
+  effects.length = 0;
+  vi.stubGlobal('setTimeout', (cb, ms) => { if (!ms || ms < 3000) cb(); return 1; });
+  vi.stubGlobal('setInterval', () => 1);
+  vi.stubGlobal('clearInterval', () => {});
+  vi.stubGlobal('requestAnimationFrame', () => 1);
+  vi.stubGlobal('document', { addEventListener: () => {}, removeEventListener: () => {}, visibilityState: 'visible' });
+  vi.stubGlobal('window', {});
+  const store = new Map();
+  vi.stubGlobal('localStorage', {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+  });
+  const state = { projects, goals };
+  // In place: the mocked React never re-renders, so the hook's refs keep
+  // pointing at these arrays (the app re-renders with fresh lists).
+  const updateProject = vi.fn((id, updates) => {
+    for (const p of state.projects) if (p.id === id) Object.assign(p, updates);
+  });
+  const updateGoal = vi.fn((id, updates) => {
+    for (const g of state.goals) if (g.id === id) Object.assign(g, updates);
+  });
+  const api = useObsidianSync({
+    isTrayMode: false, dataLoaded: true,
+    tasks: [], setTasks: vi.fn(),
+    unscheduledTasks: [], setUnscheduledTasks: vi.fn(),
+    setDailyNotes: vi.fn(), setWikilinkCandidates: vi.fn(), setUnportableVaultFiles: vi.fn(),
+    obsidianConfig: { enabled: true, dailyNotesPath: '', dailyNotePattern: 'yyyy-MM-dd' },
+    setObsidianConfig: vi.fn(), obsidianLaunchOnWrite: null,
+    obsidianCompletionDates: false,
+    obsidianSyncError: null,
+    setObsidianSyncStatus: vi.fn(), setObsidianSyncError: vi.fn(), setObsidianLastSynced: vi.fn(),
+    setObsidianSyncNotice: vi.fn(),
+    obsidianVaultHandleRef: { current: {} },
+    obsidianSyncInProgressRef: { current: false },
+    obsidianPrevTaskStateRef: { current: {} },
+    obsidianTasksRef: { current: [] }, obsidianInboxRef: { current: [] },
+    recycleBin: [], setRecycleBin: vi.fn(),
+    projects: state.projects, goals: state.goals, updateProject, updateGoal,
+  });
+  api.bridgeHeartbeatRef.current = { obsidianRunning: true, pluginAuthoritative: true };
+  return { state, api, updateProject, updateGoal };
+}
+const pairedHeartbeat = () => ({ paired: true, tsMs: Date.now(), accountId: 'acc', deviceId: 'dev' });
+const linkObs = (fields) => ({ kind: 'observation', link: true, observedAt: '2026-09-03T10:00:00.000Z', ...fields });
+
+beforeEach(() => {
+  emitBridgeIntent.mockReset(); emitBridgeIntent.mockReturnValue(true);
+  fetchMock.mockReset(); fetchMock.mockResolvedValue(null);
+  heartbeatMock.mockReset(); heartbeatMock.mockResolvedValue(pairedHeartbeat());
+});
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+describe('project notes: link observations → the project record', () => {
+  it('a link sets the locator; a rename moves it; a deletion marks it missing and keeps the path; an unlink clears it', async () => {
+    const h = useMountedHook({ projects: [{ id: 'p1', title: 'House' }], goals: [{ id: 'g1', title: 'Home' }] });
+
+    fetchMock.mockResolvedValue({ observations: [linkObs({ targetId: 'p1', path: 'Projects/House.md' }), linkObs({ targetId: 'g1', path: 'Goals/Home.md' })], maxSeq: 1 });
+    await h.api.performObsidianSync();
+    expect(h.updateProject).toHaveBeenCalledWith('p1', { obsidianNotePath: 'Projects/House.md', obsidianNoteMissingAt: null });
+    expect(h.updateGoal).toHaveBeenCalledWith('g1', { obsidianNotePath: 'Goals/Home.md', obsidianNoteMissingAt: null });
+
+    // The hook reads the LIVE lists (refs), so the next cycle sees the update.
+    fetchMock.mockResolvedValue({ observations: [linkObs({ targetId: 'p1', path: 'Archive/House.md', previousPath: 'Projects/House.md' })], maxSeq: 2 });
+    await h.api.performObsidianSync();
+    expect(h.state.projects[0].obsidianNotePath).toBe('Archive/House.md');
+
+    fetchMock.mockResolvedValue({ observations: [linkObs({ targetId: 'p1', path: 'Archive/House.md', deleted: true })], maxSeq: 3 });
+    await h.api.performObsidianSync();
+    expect(h.state.projects[0]).toMatchObject({ obsidianNotePath: 'Archive/House.md', obsidianNoteMissingAt: '2026-09-03T10:00:00.000Z' });
+
+    fetchMock.mockResolvedValue({ observations: [linkObs({ targetId: 'p1', path: 'Archive/House.md', unlinked: true })], maxSeq: 4 });
+    await h.api.performObsidianSync();
+    expect(h.state.projects[0]).toMatchObject({ obsidianNotePath: null, obsidianNoteMissingAt: null });
+  });
+});
+
+describe('project notes: link and unlink from dayGLANCE', () => {
+  it('linkProjectNote queues the frontmatter intent FIRST and updates the record only when it queued', () => {
+    const h = useMountedHook({ projects: [{ id: 'p1', title: 'House' }] });
+    expect(h.api.linkProjectNote('project', 'p1', '[[Projects/House]]')).toBe(true);
+    expect(emitBridgeIntent).toHaveBeenCalledWith('project_note_link', { path: 'Projects/House.md', targetId: 'p1' });
+    expect(h.updateProject).toHaveBeenCalledWith('p1', { obsidianNotePath: 'Projects/House.md', obsidianNoteMissingAt: null });
+
+    emitBridgeIntent.mockReturnValue(false); // unpaired vault: nothing durable to write the key
+    h.updateProject.mockClear();
+    expect(h.api.linkProjectNote('project', 'p1', 'Elsewhere')).toBe(false);
+    expect(h.updateProject).not.toHaveBeenCalled();
+    expect(h.api.linkProjectNote('project', 'p1', '   ')).toBe(false);
+  });
+
+  it('unlinkProjectNote clears the record and asks the plugin to remove the key from the note it pointed at', () => {
+    const h = useMountedHook({ projects: [{ id: 'p1', title: 'House', obsidianNotePath: 'Projects/House.md' }] });
+    expect(h.api.unlinkProjectNote('project', 'p1')).toBe(true);
+    expect(h.updateProject).toHaveBeenCalledWith('p1', { obsidianNotePath: null, obsidianNoteMissingAt: null });
+    expect(emitBridgeIntent).toHaveBeenCalledWith('project_note_unlink', { path: 'Projects/House.md', targetId: 'p1' });
+  });
+});

--- a/src/utils/obsidianBridgeInbound.js
+++ b/src/utils/obsidianBridgeInbound.js
@@ -87,7 +87,9 @@ export async function fetchBridgeObservations() {
         // Unreadable rows (rotated-away generation, tamper) are skipped, not
         // fatal — the cursor still advances past them.
         if (payload?.kind !== 'observation' || typeof payload.path !== 'string') continue;
-        byPath.set(payload.path, payload);
+        // Keyed by the ROW, not the path: a note's observation row and a
+        // project-note LINK row (companion §4.3) can name the same path.
+        byPath.set(String(row.entityId), payload);
       }
       if (!page.rows?.length) break;
     }
@@ -163,6 +165,7 @@ export function applyBridgeObservations(observations, {
   const dailyNotes = {};
   const scopedNotes = {}; // path → { lastModified, deleted? } for scoped (non-daily) notes in this batch
   const withdrawn = [];   // paths that left the scope
+  const links = [];       // project/goal note link observations (companion §4.3), for the caller
   const allScheduled = [];
   const lineSchedule = {}; // id → the line's own time when it differs from DG's (owned-schedule enforcement)
   const allInbox = [];
@@ -175,6 +178,17 @@ export function applyBridgeObservations(observations, {
   const seenBlockIds = new Set();
 
   for (const obs of observations) {
+    if (obs.link) {
+      if (typeof obs.targetId === 'string' && obs.targetId) {
+        links.push({
+          targetId: obs.targetId, path: obs.path,
+          deleted: !!obs.deleted, unlinked: !!obs.unlinked,
+          previousPath: typeof obs.previousPath === 'string' ? obs.previousPath : undefined,
+          observedAt: obs.observedAt || new Date().toISOString(),
+        });
+      }
+      continue;
+    }
     if (obs.withdrawn) { withdrawn.push(obs.path); continue; }
     if (obs.scoped) {
       const at = obs.mtime ? new Date(obs.mtime).toISOString() : (obs.observedAt || new Date().toISOString());
@@ -219,5 +233,5 @@ export function applyBridgeObservations(observations, {
     ...[...allScheduled, ...allInbox].map((t) => String(t.id)),
     ...[...allScheduled, ...allInbox].filter((t) => t.obsidianLegacyId).map((t) => String(t.obsidianLegacyId)),
   ]);
-  return { dailyNotes, scopedNotes, withdrawn, scheduledTasks: allScheduled, inboxTasks: allInbox, scannedIds, unapplied, lineSchedule };
+  return { dailyNotes, scopedNotes, withdrawn, links, scheduledTasks: allScheduled, inboxTasks: allInbox, scannedIds, unapplied, lineSchedule };
 }

--- a/src/utils/obsidianProjectNotes.js
+++ b/src/utils/obsidianProjectNotes.js
@@ -1,0 +1,105 @@
+// Project and goal notes: the LINK (companion spec §4.3, rulings A and F).
+// Pure.
+//
+// A project (or goal) links to ONE vault note. The durable identity is the
+// `dayglance-id` frontmatter key in the note, holding the entity's UUID; the
+// synced locator is `obsidianNotePath` on the entity record. The plugin owns
+// the vault side (it writes the key, watches renames and deletes, re-finds a
+// note by its key) and reports link OBSERVATIONS; this module turns those
+// observations into record updates, and shapes the link for the UI.
+//
+// Record fields:
+//   obsidianNotePath       vault-relative path of the linked note, or null
+//   obsidianNoteMissingAt  ISO time the note was observed deleted (ruling F:
+//                          the project keeps its path so a relink can prefill,
+//                          but everything that reads the link treats it as
+//                          absent while this is set)
+
+import { noteKeyForPath } from '@glance-apps/obsidian-format';
+
+/** A user-typed note reference → a normalized vault path ending in .md, or ''. */
+export function normalizeNotePath(input) {
+  let s = String(input ?? '').trim();
+  if (!s) return '';
+  s = s.replace(/^\[\[|\]\]$/g, '').trim();
+  const hashIdx = s.indexOf('#');
+  if (hashIdx > 0) s = s.slice(0, hashIdx).trim();
+  if (!s) return '';
+  if (!/\.md$/i.test(s)) s = `${s}.md`;
+  return noteKeyForPath(s);
+}
+
+/** The note as Obsidian names it: the path without the .md extension. */
+export function noteDisplayName(path) {
+  return String(path ?? '').replace(/\.md$/i, '');
+}
+
+/**
+ * The entity's link for display, or null when unlinked.
+ * @returns {{ path: string, name: string, missing: boolean } | null}
+ */
+export function noteLinkOf(entity) {
+  const path = typeof entity?.obsidianNotePath === 'string' ? entity.obsidianNotePath : '';
+  if (!path) return null;
+  return { path, name: noteDisplayName(path), missing: !!entity.obsidianNoteMissingAt };
+}
+
+/**
+ * Turn the plugin's link observations into record updates.
+ *
+ * Each observation names a target id and a path, and is one of:
+ *   • a link      → the note at `path` carries the id: set the locator, clear
+ *                   any missing mark (a trash restore or a relink lands here)
+ *   • deleted     → the linked note is gone (ruling F): keep the path, mark
+ *                   missing at the observation time; ignored when the record
+ *                   already points elsewhere (a newer link won)
+ *   • unlinked    → the key was removed from the note: clear both fields when
+ *                   the record still points at that path
+ *
+ * @param {Array<{targetId: string, path: string, deleted?: boolean, unlinked?: boolean, observedAt?: string}>} links
+ * @param {{ projects?: object[], goals?: object[] }} lists
+ * @returns {{ projects: Array<{id: string, updates: object}>, goals: Array<{id: string, updates: object}> }}
+ */
+export function planNoteLinkUpdates(links, { projects = [], goals = [] } = {}) {
+  const out = { projects: [], goals: [] };
+  if (!Array.isArray(links) || links.length === 0) return out;
+  const working = new Map(); // `${kind}:${id}` → current view of the entity
+  const find = (id) => {
+    const key = String(id);
+    for (const [kind, list] of [['projects', projects], ['goals', goals]]) {
+      const hit = (list || []).find((e) => e && String(e.id) === key);
+      if (hit) {
+        const k = `${kind}:${key}`;
+        if (!working.has(k)) working.set(k, { kind, id: key, entity: { ...hit }, updates: null });
+        return working.get(k);
+      }
+    }
+    return null;
+  };
+  const ordered = [...links].sort((a, b) => String(a.observedAt ?? '').localeCompare(String(b.observedAt ?? '')));
+  for (const link of ordered) {
+    if (!link || typeof link.targetId !== 'string' || typeof link.path !== 'string') continue;
+    const slot = find(link.targetId);
+    if (!slot) continue;
+    const cur = slot.entity;
+    let updates = null;
+    if (link.unlinked) {
+      if (cur.obsidianNotePath && cur.obsidianNotePath === link.path) {
+        updates = { obsidianNotePath: null, obsidianNoteMissingAt: null };
+      }
+    } else if (link.deleted) {
+      if (cur.obsidianNotePath === link.path && !cur.obsidianNoteMissingAt) {
+        updates = { obsidianNoteMissingAt: link.observedAt || new Date().toISOString() };
+      }
+    } else if (cur.obsidianNotePath !== link.path || cur.obsidianNoteMissingAt) {
+      updates = { obsidianNotePath: link.path, obsidianNoteMissingAt: null };
+    }
+    if (!updates) continue;
+    slot.entity = { ...cur, ...updates };
+    slot.updates = { ...(slot.updates || {}), ...updates };
+  }
+  for (const slot of working.values()) {
+    if (slot.updates) out[slot.kind].push({ id: slot.id, updates: slot.updates });
+  }
+  return out;
+}

--- a/src/utils/obsidianProjectNotes.test.js
+++ b/src/utils/obsidianProjectNotes.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeNotePath, noteDisplayName, noteLinkOf, planNoteLinkUpdates } from './obsidianProjectNotes.js';
+
+describe('normalizeNotePath / noteDisplayName / noteLinkOf', () => {
+  it('accepts a bare name, a wikilink, a heading suffix, and a path; adds .md; normalizes slashes', () => {
+    expect(normalizeNotePath('Projects/House')).toBe('Projects/House.md');
+    expect(normalizeNotePath('[[House]]')).toBe('House.md');
+    expect(normalizeNotePath('[[Projects/House#Plan]]')).toBe('Projects/House.md');
+    expect(normalizeNotePath('/Projects\\House.md')).toBe('Projects/House.md');
+    expect(normalizeNotePath('   ')).toBe('');
+    expect(noteDisplayName('Projects/House.md')).toBe('Projects/House');
+  });
+  it('noteLinkOf reads the locator and the missing mark', () => {
+    expect(noteLinkOf({})).toBe(null);
+    expect(noteLinkOf({ obsidianNotePath: 'Projects/House.md' })).toEqual({ path: 'Projects/House.md', name: 'Projects/House', missing: false });
+    expect(noteLinkOf({ obsidianNotePath: 'Projects/House.md', obsidianNoteMissingAt: '2026-09-03T10:00:00.000Z' }).missing).toBe(true);
+  });
+});
+
+describe('planNoteLinkUpdates (rulings A and F)', () => {
+  const P = { id: 'p1', title: 'House' };
+  const G = { id: 'g1', title: 'Home' };
+
+  it('a link sets the locator on the project OR the goal the id names; an unknown id is ignored', () => {
+    const plan = planNoteLinkUpdates(
+      [{ targetId: 'p1', path: 'Projects/House.md' }, { targetId: 'g1', path: 'Goals/Home.md' }, { targetId: 'zzz', path: 'X.md' }],
+      { projects: [P], goals: [G] },
+    );
+    expect(plan.projects).toEqual([{ id: 'p1', updates: { obsidianNotePath: 'Projects/House.md', obsidianNoteMissingAt: null } }]);
+    expect(plan.goals).toEqual([{ id: 'g1', updates: { obsidianNotePath: 'Goals/Home.md', obsidianNoteMissingAt: null } }]);
+  });
+
+  it('an identical link is a no-op; a rename (new path, same id) moves the locator', () => {
+    const linked = { ...P, obsidianNotePath: 'Projects/House.md' };
+    expect(planNoteLinkUpdates([{ targetId: 'p1', path: 'Projects/House.md' }], { projects: [linked] }).projects).toEqual([]);
+    expect(planNoteLinkUpdates([{ targetId: 'p1', path: 'Archive/House.md', previousPath: 'Projects/House.md' }], { projects: [linked] }).projects)
+      .toEqual([{ id: 'p1', updates: { obsidianNotePath: 'Archive/House.md', obsidianNoteMissingAt: null } }]);
+  });
+
+  it('deleted marks the note missing and KEEPS the path (ruling F); a later link clears the mark; a stale delete for another path is ignored', () => {
+    const linked = { ...P, obsidianNotePath: 'Projects/House.md' };
+    const gone = planNoteLinkUpdates([{ targetId: 'p1', path: 'Projects/House.md', deleted: true, observedAt: '2026-09-03T10:00:00.000Z' }], { projects: [linked] });
+    expect(gone.projects).toEqual([{ id: 'p1', updates: { obsidianNoteMissingAt: '2026-09-03T10:00:00.000Z' } }]);
+    const missing = { ...linked, obsidianNoteMissingAt: '2026-09-03T10:00:00.000Z' };
+    expect(planNoteLinkUpdates([{ targetId: 'p1', path: 'Projects/House.md' }], { projects: [missing] }).projects)
+      .toEqual([{ id: 'p1', updates: { obsidianNotePath: 'Projects/House.md', obsidianNoteMissingAt: null } }]);
+    expect(planNoteLinkUpdates([{ targetId: 'p1', path: 'Old/House.md', deleted: true }], { projects: [linked] }).projects).toEqual([]);
+    // Already marked: no churn.
+    expect(planNoteLinkUpdates([{ targetId: 'p1', path: 'Projects/House.md', deleted: true }], { projects: [missing] }).projects).toEqual([]);
+  });
+
+  it('unlinked clears both fields only when the record still points at that path', () => {
+    const linked = { ...P, obsidianNotePath: 'Projects/House.md', obsidianNoteMissingAt: '2026-09-03T10:00:00.000Z' };
+    expect(planNoteLinkUpdates([{ targetId: 'p1', path: 'Projects/House.md', unlinked: true }], { projects: [linked] }).projects)
+      .toEqual([{ id: 'p1', updates: { obsidianNotePath: null, obsidianNoteMissingAt: null } }]);
+    expect(planNoteLinkUpdates([{ targetId: 'p1', path: 'Elsewhere.md', unlinked: true }], { projects: [linked] }).projects).toEqual([]);
+  });
+
+  it('applies in observedAt order and folds updates per entity', () => {
+    const plan = planNoteLinkUpdates([
+      { targetId: 'p1', path: 'B.md', observedAt: '2026-09-03T10:00:02.000Z' },
+      { targetId: 'p1', path: 'A.md', observedAt: '2026-09-03T10:00:01.000Z' },
+    ], { projects: [P] });
+    expect(plan.projects).toEqual([{ id: 'p1', updates: { obsidianNotePath: 'B.md', obsidianNoteMissingAt: null } }]);
+  });
+});


### PR DESCRIPTION
## Summary

Build step 1 of companion spec §4.3 (rulings A and F). Stacked on #1530 (the rulings). A project or goal links to one vault note; the link's identity is a `dayglance-id` frontmatter key in the note, and the path on the record is only a synced locator.

### Shared package
- `PROJECT_NOTE_ID_KEY` (`dayglance-id`), `linkObservationEntityId(targetId)`: link observations are one row per target id, upserted, so a rename replaces the row's path and a deletion replaces it with a deleted mark.
- Intents `project_note_link` and `project_note_unlink` documented; applied by the plugin through Obsidian's frontmatter API, never by the text applier.

### Plugin
- Persisted path → id map of notes carrying the key (`BridgeState.linkedNotes`), reconciled on metadata changes, renames, deletes, and a full walk of every markdown file's frontmatter at layout-ready and every five minutes (how a rename made while the plugin was off is re-found by key). Only differences are reported, so a reload re-emits nothing; a failed emission rolls the map back so the next pass re-derives it.
- Link observations: link, rename (with `previousPath`), deleted, unlinked.
- Writes and removes the key via `processFrontMatter` under the same dirty-buffer rule as every other write.
- Mirror gains `projects` and `goals` rows; `linkTargets()` lists active, viewer-visible ones.
- Two palette commands: **Link current note to a dayGLANCE project or goal** (fuzzy picker) and **Unlink current note from dayGLANCE**.
- Applies the two intents; a link to a note that does not exist reports it missing (ruling F).

### App
- Records carry `obsidianNotePath` and `obsidianNoteMissingAt`. Inbound observations route link rows to a pure planner (`obsidianProjectNotes.js`) that updates projects and goals.
- Hook: `linkProjectNote(kind, id, path)` queues the intent first and updates the record only if it queued; `unlinkProjectNote(kind, id)` clears the record and asks the plugin to remove the key.
- Project form: an "Obsidian note" row to link by path, open, relink and unlink, with the missing state shown. Project card: note badge that opens the note, or a warning while it is missing.
- Observation fetch now keys rows by entity id so a note's row and a link row for the same path never collide.

### Judgment calls for review
- The missing mark keeps the path rather than clearing it. Every reader treats the link as absent while the mark is set, and the relink prefills the old path.
- Linking from dayGLANCE takes a typed vault path. The vault index lives in the plugin, whose picker is the primary way to link; the app path is for relinks and known paths.
- Goals ride the same record and plugin machinery now; their form row lands with step 3.

### Verification
- New tests: `obsidianProjectNotes.test.js` (planner: link, rename, deleted keeps path, unlink, ordering), `useObsidianSync.projectNotes.test.js` (observations through the real sync entry point; link/unlink actions and intents).
- Plugin builds clean; lint clean; full suite green (2807 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_