### PR TITLE
Project notes step 3: workspace creation with layouts, goal links

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -80,7 +80,14 @@ manually or via BRAT, not submitted to the community directory.
   percent, next scheduled date for a project; progress and its projects as
   wikilinks for a goal), rewritten only when a value changes, at most once
   every five minutes per note, never into unsaved edits. dayGLANCE wins
-  inside that map; nothing outside it is read or written.
+  inside that map; nothing outside it is read or written. A project or goal
+  born in dayGLANCE can create its note here: the **Project and goal notes**
+  settings choose the layout (one note; a folder with an index note; folders
+  nested under the goal), the projects and goals folders, and optional
+  template notes (rendered by Templater when it is installed and the
+  template asks nothing interactively, otherwise `{{title}}`, `{{date}}`
+  and `{{goal}}` are filled and the rest is left visible). Placement happens
+  at creation only; linking an existing note never creates or moves.
 - Six commands: **Sync now** (drains pending intents + refreshes the
   heartbeat), **Enter pairing code**, **Unpair from GLANCEvault**
   (forgets the local credentials and the account key; revoke the token

--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -53,7 +53,15 @@ import {
   completedSinceFor,
   PROJECT_NOTE_ID_KEY,
   linkObservationEntityId,
+  normalizeProjectNoteSettings,
+  projectNotePath,
+  uniqueNotePath,
+  noteNameFromTitle,
+  templateNeedsUser,
+  renderNoteTemplateSubset,
+  withCreationFrontmatter,
   type VaultScope,
+  type ProjectNoteSettings,
 } from '@glance-apps/obsidian-format';
 import { createVaultClient, type VaultClient } from '@glance-apps/sync/src/vaultClient.js';
 import type { BridgePairing } from './pairing';
@@ -151,6 +159,8 @@ export interface BridgeHost {
    * inactive means daily notes only.
    */
   getScope?(): VaultScope | null;
+  /** Project and goal note workspaces (companion §4.3, rulings D and E). */
+  getProjectNotes?(): ProjectNoteSettings;
 }
 
 // Same requestUrl-backed fetch shim as pairing.ts (CORS-free everywhere).
@@ -843,6 +853,9 @@ export class BridgeTransport {
     if (intent.type === 'project_note_link' || intent.type === 'project_note_unlink') {
       return this.applyLinkIntent(intent);
     }
+    if (intent.type === 'project_note_create') {
+      return this.applyCreateIntent(intent);
+    }
     if (intent.type === 'wiki_note_write') {
       // Wikilink resolution is the applier's job (the one intent type
       // without an emitter-resolved path): an existing note anywhere in
@@ -1073,6 +1086,93 @@ export class BridgeTransport {
     if (!views.length) return false;
     const current = await this.host.app.vault.adapter.read(path);
     return views.some((v) => v.getViewData() !== current);
+  }
+
+  // ── Workspace creation (companion §4.3, rulings D and E) ─────────────────
+
+  /** The linked note's path for a dayGLANCE id, or null. */
+  private linkedPathOf(targetId: string): string | null {
+    for (const [path, id] of this.linked) if (id === targetId) return path;
+    return null;
+  }
+
+  /**
+   * Render a template note for a new project or goal note through the §4.4
+   * ladder: Templater when it is installed, its render methods feature-detect,
+   * and the template asks nothing interactively (`tp.system.` would open a
+   * modal nobody is looking at and never settle); otherwise the subset
+   * renderer, leaving unsupported variables visible. Null when the template
+   * note does not exist.
+   */
+  private async renderTemplate(templatePath: string, target: TFile, vars: { title: string; date: string; goal: string }): Promise<string | null> {
+    const tfile = this.host.app.vault.getAbstractFileByPath(normalizePath(templatePath));
+    if (!(tfile instanceof TFile)) return null;
+    const text = await this.host.app.vault.read(tfile);
+    const subset = renderNoteTemplateSubset(text, vars);
+    if (templateNeedsUser(text)) return subset;
+    type Fn = (...args: unknown[]) => unknown;
+    const plugins = (this.host.app as unknown as { plugins?: { plugins?: Record<string, unknown> } }).plugins?.plugins;
+    const templater = (plugins?.['templater-obsidian'] as { templater?: Record<string, unknown> } | undefined)?.templater;
+    const create = templater?.create_running_config;
+    const parse = templater?.read_and_parse_template;
+    if (typeof create !== 'function' || typeof parse !== 'function') return subset;
+    try {
+      // RunMode.CreateNewFromTemplate is 0 in every Templater release since 1.12.
+      const config = (create as Fn).call(templater, tfile, target, 0);
+      const out = await (parse as Fn).call(templater, config);
+      return typeof out === 'string' ? renderNoteTemplateSubset(out, vars) : subset;
+    } catch (e) {
+      console.warn('dayGLANCE bridge: Templater render failed; using the subset renderer', e);
+      return subset;
+    }
+  }
+
+  private async applyCreateIntent(intent: Record<string, unknown>): Promise<'applied'> {
+    const targetId = String(intent.targetId ?? '').trim();
+    const kind = intent.kind === 'goal' ? 'goal' : 'project';
+    const title = String(intent.title ?? '').trim();
+    if (!targetId || !title) return 'applied';
+    if (this.linkedPathOf(targetId)) return 'applied'; // idempotent replay, or linked meanwhile
+    const settings = normalizeProjectNoteSettings(this.host.getProjectNotes?.() ?? null);
+    const goalId = typeof intent.goalId === 'string' ? intent.goalId : '';
+    const goalTitle = typeof intent.goalTitle === 'string' ? intent.goalTitle : '';
+    // Nested layout: a project with a goal goes inside the goal's folder —
+    // wherever the goal's note actually lives when it is linked, else the
+    // folder the goal would get.
+    let goalFolder: string | null = null;
+    if (kind === 'project' && settings.layout === 'nested' && goalId) {
+      const goalPath = this.linkedPathOf(goalId);
+      if (goalPath) goalFolder = goalPath.includes('/') ? goalPath.slice(0, goalPath.lastIndexOf('/')) : '';
+      else if (goalTitle) goalFolder = `${settings.goalsFolder}/${noteNameFromTitle(goalTitle)}`;
+      if (goalFolder === '') goalFolder = null; // a goal note at the vault root nests nothing
+    }
+    let path = normalizePath(projectNotePath({ kind, title, ...settings, goalFolder }));
+    const existing = this.host.app.vault.getAbstractFileByPath(path);
+    if (existing instanceof TFile) {
+      // A note already named for it: adopt when it belongs to nobody, step
+      // aside when it is another entity's.
+      const owner = this.noteLinkId(path);
+      if (!owner) { await this.setNoteLink(existing, targetId); return 'applied'; }
+      if (owner === targetId) return 'applied';
+      path = uniqueNotePath(path, (p) => this.host.app.vault.getAbstractFileByPath(p) !== null);
+    }
+    await this.ensureParentDirs(path);
+    const today = new Date().toISOString().slice(0, 10);
+    const vars = { title, date: today, goal: goalTitle };
+    let created: TFile;
+    try {
+      created = await this.host.app.vault.create(path, withCreationFrontmatter(`# ${title}\n`, today));
+    } catch (e) {
+      console.error(`dayGLANCE bridge: could not create ${path}`, e);
+      return 'applied';
+    }
+    const templatePath = kind === 'goal' ? settings.goalTemplate : settings.projectTemplate;
+    if (templatePath) {
+      const body = await this.renderTemplate(templatePath, created, vars);
+      if (body !== null) await this.host.app.vault.modify(created, withCreationFrontmatter(body, today));
+    }
+    await this.setNoteLink(created, targetId);
+    return 'applied';
   }
 
   /** The palette command: link the given note to a project or goal. */

--- a/dayglance-obsidian-plugin/src/main.ts
+++ b/dayglance-obsidian-plugin/src/main.ts
@@ -46,7 +46,7 @@ import { PairingModal, readPairingOfferText, type BridgePairing } from './pairin
 import { BridgeSettingTab, type BridgeSettingsHost } from './settingsTab';
 import { BridgeTransport, publishPairingMeta, type BridgeState } from './bridge';
 import { AgendaStore } from './agenda';
-import { normalizeScope, scopeIsActive, type VaultScope } from '@glance-apps/obsidian-format';
+import { normalizeScope, scopeIsActive, normalizeProjectNoteSettings, type VaultScope, type ProjectNoteSettings } from '@glance-apps/obsidian-format';
 import { localDateStr } from '@glance-apps/agenda-core';
 import { AgendaView, AGENDA_VIEW_TYPE, removeAgendaStyles } from './agendaView';
 import { LinkTargetModal } from './linkModal';
@@ -76,6 +76,9 @@ interface BridgeData {
   // notes are task sources, and the completion window (ruling E). Absent =
   // daily notes only.
   scope?: VaultScope;
+  // Project and goal note workspaces (companion §4.3, rulings D and E):
+  // where a note born in dayGLANCE goes and which template it uses.
+  projectNotes?: ProjectNoteSettings;
 }
 
 const mintDeviceId = (): string => {
@@ -131,6 +134,7 @@ export default class DayGlanceBridgePlugin extends Plugin {
       // note blocks re-render from the refreshed mirror (companion §4.3).
       onSynced: () => { void this.agenda.refresh().then(() => this.noteBlocks.tick()); },
       getScope: () => this.scope(),
+      getProjectNotes: () => normalizeProjectNoteSettings(this.data.projectNotes),
     });
     this.noteBlocks = new NoteBlockWriter({
       app: this.app,
@@ -253,6 +257,11 @@ export default class DayGlanceBridgePlugin extends Plugin {
         if (this.data.pairing) {
           await publishPairingMeta(this.data.pairing, undefined, userSyncId, this.scope()).catch((e) => console.error('dayGLANCE bridge: meta publish failed', e));
         }
+      },
+      getProjectNotes: () => normalizeProjectNoteSettings(this.data.projectNotes),
+      setProjectNotes: async (s) => {
+        this.data.projectNotes = normalizeProjectNoteSettings(s);
+        await this.saveData(this.data);
       },
       getScope: () => this.scope(),
       setScope: async (scope) => {

--- a/dayglance-obsidian-plugin/src/settingsTab.ts
+++ b/dayglance-obsidian-plugin/src/settingsTab.ts
@@ -15,7 +15,7 @@ import {
   type BridgePairing,
 } from './pairing';
 import type { AgendaKeyState, AgendaUser } from './agenda';
-import { normalizeScope, SCOPE_WINDOW_MIN_DAYS, SCOPE_WINDOW_MAX_DAYS, SCOPE_WINDOW_DEFAULT_DAYS, type VaultScope } from '@glance-apps/obsidian-format';
+import { normalizeScope, SCOPE_WINDOW_MIN_DAYS, SCOPE_WINDOW_MAX_DAYS, SCOPE_WINDOW_DEFAULT_DAYS, type VaultScope, normalizeProjectNoteSettings, PROJECT_NOTE_LAYOUTS, type ProjectNoteSettings } from '@glance-apps/obsidian-format';
 
 // Stamped by esbuild at bundle time (see esbuild.config.mjs `define`).
 // Guarded so a build without the define (tests, tooling) still runs.
@@ -53,6 +53,9 @@ export interface BridgeSettingsHost extends PairingHost {
   /** Vault task scope (companion §6): which non-daily notes are task sources. */
   getScope(): VaultScope | null;
   setScope(scope: VaultScope): Promise<void>;
+  /** Project and goal note workspaces (companion §4.3, rulings D and E). */
+  getProjectNotes(): ProjectNoteSettings;
+  setProjectNotes(s: ProjectNoteSettings): Promise<void>;
 }
 
 const pairedSince = (pairing: BridgePairing): string => {
@@ -78,6 +81,7 @@ export class BridgeSettingTab extends PluginSettingTab {
       this.displayPaired(pairing);
       this.displayAccount();
       this.displayScope();
+      this.displayProjectNotes();
     } else {
       this.displayUnpaired();
     }
@@ -264,6 +268,57 @@ export class BridgeSettingTab extends PluginSettingTab {
         text.inputEl.min = String(SCOPE_WINDOW_MIN_DAYS);
         text.inputEl.max = String(SCOPE_WINDOW_MAX_DAYS);
         text.inputEl.addEventListener('blur', () => void save());
+      });
+  }
+
+  private displayProjectNotes(): void {
+    this.containerEl.createEl('h3', { text: 'Project and goal notes' });
+    const cur = this.host.getProjectNotes();
+    const draft: ProjectNoteSettings = { ...cur };
+    const save = async () => { await this.host.setProjectNotes(normalizeProjectNoteSettings(draft)); };
+    this.containerEl.createEl('p', {
+      cls: 'setting-item-description',
+      text: 'A dayGLANCE project or goal can create its own note here (from dayGLANCE, when the project is created). Linking an existing note never creates or moves anything; placement happens at creation only.',
+    });
+    const layoutLabels: Record<string, string> = {
+      note: 'One note per project or goal',
+      folder: 'A folder per project or goal, with an index note',
+      nested: 'Folders nested under the goal (Goals/<goal>/<project>/)',
+    };
+    new Setting(this.containerEl)
+      .setName('Layout')
+      .setDesc('Where a new note goes. Nested: a goal gets a folder under the goals folder, and a project with a goal gets its folder inside it.')
+      .addDropdown((d) => {
+        for (const l of PROJECT_NOTE_LAYOUTS) d.addOption(l, layoutLabels[l] ?? l);
+        d.setValue(cur.layout).onChange((v) => { draft.layout = v as ProjectNoteSettings['layout']; void save(); });
+      });
+    new Setting(this.containerEl)
+      .setName('Projects folder')
+      .setDesc('Vault-relative folder for new project notes (standalone projects under the nested layout too).')
+      .addText((t) => {
+        t.setPlaceholder('Projects').setValue(cur.projectsFolder).onChange((v) => { draft.projectsFolder = v; });
+        t.inputEl.addEventListener('blur', () => void save());
+      });
+    new Setting(this.containerEl)
+      .setName('Goals folder')
+      .setDesc('Vault-relative folder for new goal notes.')
+      .addText((t) => {
+        t.setPlaceholder('Goals').setValue(cur.goalsFolder).onChange((v) => { draft.goalsFolder = v; });
+        t.inputEl.addEventListener('blur', () => void save());
+      });
+    new Setting(this.containerEl)
+      .setName('Project template')
+      .setDesc('Optional: vault path of a template note. Rendered by Templater when it is installed and the template asks nothing interactively; otherwise {{title}}, {{date}} and {{goal}} are filled and the rest is left as is.')
+      .addText((t) => {
+        t.setPlaceholder('Templates/Project.md').setValue(cur.projectTemplate).onChange((v) => { draft.projectTemplate = v; });
+        t.inputEl.addEventListener('blur', () => void save());
+      });
+    new Setting(this.containerEl)
+      .setName('Goal template')
+      .setDesc('Optional: vault path of a template note for goals, rendered the same way.')
+      .addText((t) => {
+        t.setPlaceholder('Templates/Goal.md').setValue(cur.goalTemplate).onChange((v) => { draft.goalTemplate = v; });
+        t.inputEl.addEventListener('blur', () => void save());
       });
   }
 

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -664,6 +664,34 @@ from the title), the bare title while the note is missing. Ruling H: a task
 line that imports FRESH from a scoped note whose path is a present project
 link starts with that project; a known task keeps whatever the app gave it.
 
+**Step 3 record (2026-09-03, built).** `projectNotes.js` in the shared
+package decides placement (rulings D and E): `note` (default,
+`Projects/House.md`), `folder` (`Projects/House/House.md`), `nested`
+(`Goals/Home/House/House.md` for a project with a goal — under the goal's
+linked note's own folder wherever that is, else the folder the goal would
+get; a standalone project falls back to the folder layout); a portable note
+name from any title; a bounded ` 2`, ` 3` suffix past a taken path; and the
+§4.4 pieces (the `tp.system.` guard, the `{{title}}`/`{{date}}`/`{{goal}}`
+subset). The plugin's settings section holds the layout, both folders and
+the two template paths (plugin-local, like the scope). A `project_note_create`
+intent from dayGLANCE (the "Create a note in Obsidian" checkbox on a NEW
+project or goal; the fields ride the intent because the entity is not in
+any list yet) creates the note with dayGLANCE's creation frontmatter and a
+title heading, renders the template through the ladder (Templater's
+`create_running_config` + `read_and_parse_template` when both feature-detect
+and the template is non-interactive, else the subset), then links it —
+which is the same key write, map update and link observation as step 1, so
+the record learns its locator through the observation stream. Idempotent:
+an already-linked target is a no-op. A note already named for the entity is
+ADOPTED when it carries no id key, stepped past when it is another's.
+Goals: the form row and the goal-card badge land here; the record and
+plugin machinery were already shared. *Judgment calls:* adopting an
+unowned note that already sits at the computed path (it is named for the
+project, in the projects folder; suffixing would leave the obvious note
+unlinked); the subset renderer is three variables rather than v1's fuller
+set (nothing in the repo implements the fuller set, and Templater covers
+the rest when present).
+
 ---
 
 ### 4.4 Templater, via guarded delegation

--- a/packages/obsidian-format/src/bridgeStream.js
+++ b/packages/obsidian-format/src/bridgeStream.js
@@ -43,6 +43,11 @@
 //                     below (which reports it unsupported)
 //   project_note_unlink {path, targetId} — remove that key when it names
 //                     targetId
+//   project_note_create {targetId, kind:'project'|'goal', title, goalId?,
+//                     goalTitle?} — create the entity's note where the
+//                     plugin's layout setting says (projectNotes.js), from
+//                     its template through the §4.4 ladder, and link it;
+//                     idempotent (an already-linked target is a no-op)
 // `path` is always vault-root-relative and resolved BY THE EMITTER (the
 // emitter owns the dailyNotesPath/pattern config; the applier needs no
 // dayGLANCE settings). wiki_note_write is the one type without a resolved

--- a/packages/obsidian-format/src/index.js
+++ b/packages/obsidian-format/src/index.js
@@ -19,6 +19,7 @@ export * from './filename.js';
 export * from './heartbeat.js';
 export * from './bridgePairing.js';
 export * from './bridgeStream.js';
+export * from './projectNotes.js';
 export * from './bridgeSse.js';
 export * from './completionLog.js';
 export * from './noteScope.js';

--- a/packages/obsidian-format/src/projectNotes.js
+++ b/packages/obsidian-format/src/projectNotes.js
@@ -1,0 +1,100 @@
+// Project and goal note WORKSPACES (companion spec §4.3, rulings D and E).
+// Pure: where a note born in dayGLANCE goes, what it is called, and the
+// template subset. The plugin applies these; dayGLANCE only asks.
+//
+// Layouts (a plugin setting, default `note`):
+//   note    — one note per project under the projects folder
+//             (Projects/House.md); goals likewise under the goals folder
+//   folder  — a folder per project with an index note of the same name
+//             (Projects/House/House.md)
+//   nested  — the E amendment: a goal gets a folder under the goals folder
+//             and a project WITH a goal gets its folder inside the goal's
+//             (Goals/Home/House/House.md); a standalone project falls back
+//             to the folder layout under the projects folder
+// Placement happens at creation time only; nothing is ever moved.
+
+import { validateVaultNameSegment } from './filename.js';
+
+export const PROJECT_NOTE_LAYOUTS = ['note', 'folder', 'nested'];
+
+const trimFolder = (s, fallback) => {
+  const t = String(s ?? '').normalize('NFC').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '').trim();
+  return t || fallback;
+};
+
+/** Canonical settings: a known layout, non-empty folders, template paths as typed. */
+export function normalizeProjectNoteSettings(s) {
+  const layout = PROJECT_NOTE_LAYOUTS.includes(s?.layout) ? s.layout : 'note';
+  return {
+    layout,
+    projectsFolder: trimFolder(s?.projectsFolder, 'Projects'),
+    goalsFolder: trimFolder(s?.goalsFolder, 'Goals'),
+    projectTemplate: String(s?.projectTemplate ?? '').trim(),
+    goalTemplate: String(s?.goalTemplate ?? '').trim(),
+  };
+}
+
+/**
+ * A portable note name from a title: characters no platform can carry become
+ * a hyphen, whitespace collapses, leading dots and trailing dots/spaces go,
+ * a Windows-reserved stem gets a suffix, and nothing is ever empty.
+ */
+export function noteNameFromTitle(title) {
+  let name = String(title ?? '').normalize('NFC')
+    .replace(/[[\]#^|*"\\/:?<>]/g, '-')
+    .replace(/[\x00-\x1f]/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/-{2,}/g, '-')
+    .trim()
+    .replace(/^\.+/, '')
+    .replace(/[. ]+$/, '');
+  if (!name) name = 'Untitled';
+  if (validateVaultNameSegment(name)) name = `${name} note`; // the reserved-stem case
+  return name;
+}
+
+/**
+ * The path of a NEW note for a project or goal.
+ * @param {{ kind: 'project'|'goal', title: string, layout?: string, projectsFolder?: string, goalsFolder?: string, goalFolder?: string|null }} a
+ *   goalFolder: for a project with a goal under the nested layout, the goal's
+ *   folder (its linked note's parent, or the folder the goal would get).
+ */
+export function projectNotePath({ kind, title, layout, projectsFolder, goalsFolder, goalFolder = null }) {
+  const s = normalizeProjectNoteSettings({ layout, projectsFolder, goalsFolder });
+  const name = noteNameFromTitle(title);
+  const base = kind === 'goal' ? s.goalsFolder : s.projectsFolder;
+  if (s.layout === 'note') return `${base}/${name}.md`;
+  if (s.layout === 'nested' && kind === 'project' && goalFolder) return `${trimFolder(goalFolder, s.projectsFolder)}/${name}/${name}.md`;
+  return `${base}/${name}/${name}.md`;
+}
+
+/** `path` untouched, or `… 2`, `… 3` while `exists(path)` says it is taken (a bounded search). */
+export function uniqueNotePath(path, exists) {
+  if (!exists(path)) return path;
+  const m = /^(.*?)(\.md)$/.exec(path);
+  const stem = m ? m[1] : path;
+  const ext = m ? m[2] : '';
+  for (let n = 2; n < 100; n++) {
+    const candidate = `${stem} ${n}${ext}`;
+    if (!exists(candidate)) return candidate;
+  }
+  return `${stem} ${Date.now()}${ext}`;
+}
+
+/** True when a template makes an interactive Templater call (the §4.4 guard: never delegate those). */
+export function templateNeedsUser(text) {
+  return /\btp\.system\./.test(String(text ?? ''));
+}
+
+/**
+ * The template subset dayGLANCE renders itself (§4.4 fallback): `{{title}}`,
+ * `{{date}}` (YYYY-MM-DD) and `{{goal}}`. Everything else, Templater's
+ * `<% %>` included, stays visible verbatim, which is Templater's own
+ * on-create behavior and what lets a user notice and fix it.
+ */
+export function renderNoteTemplateSubset(text, { title = '', date = '', goal = '' } = {}) {
+  return String(text ?? '')
+    .replace(/\{\{\s*title\s*\}\}/gi, title)
+    .replace(/\{\{\s*date\s*\}\}/gi, date)
+    .replace(/\{\{\s*goal\s*\}\}/gi, goal);
+}

--- a/packages/obsidian-format/src/projectNotes.test.js
+++ b/packages/obsidian-format/src/projectNotes.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeProjectNoteSettings, noteNameFromTitle, projectNotePath, uniqueNotePath, templateNeedsUser, renderNoteTemplateSubset,
+} from './index.js';
+
+describe('normalizeProjectNoteSettings / noteNameFromTitle', () => {
+  it('defaults the layout and folders; makes any title portable', () => {
+    expect(normalizeProjectNoteSettings(null)).toEqual({ layout: 'note', projectsFolder: 'Projects', goalsFolder: 'Goals', projectTemplate: '', goalTemplate: '' });
+    expect(normalizeProjectNoteSettings({ layout: 'nested', projectsFolder: '/Work/Projects/', goalsFolder: '' }).projectsFolder).toBe('Work/Projects');
+    expect(normalizeProjectNoteSettings({ layout: 'bogus' }).layout).toBe('note');
+    expect(noteNameFromTitle('iOS App: v2 / launch?')).toBe('iOS App- v2 - launch-');
+    expect(noteNameFromTitle('  ..hidden..  ')).toBe('hidden');
+    expect(noteNameFromTitle('')).toBe('Untitled');
+    expect(noteNameFromTitle('CON')).toBe('CON note');
+  });
+});
+
+describe('projectNotePath (rulings D and E)', () => {
+  it('note, folder, and nested layouts; a standalone project never nests', () => {
+    expect(projectNotePath({ kind: 'project', title: 'House', layout: 'note' })).toBe('Projects/House.md');
+    expect(projectNotePath({ kind: 'goal', title: 'Home', layout: 'note' })).toBe('Goals/Home.md');
+    expect(projectNotePath({ kind: 'project', title: 'House', layout: 'folder' })).toBe('Projects/House/House.md');
+    expect(projectNotePath({ kind: 'goal', title: 'dayGLANCE Development', layout: 'nested' })).toBe('Goals/dayGLANCE Development/dayGLANCE Development.md');
+    expect(projectNotePath({ kind: 'project', title: 'iOS App', layout: 'nested', goalFolder: 'Goals/dayGLANCE Development' })).toBe('Goals/dayGLANCE Development/iOS App/iOS App.md');
+    expect(projectNotePath({ kind: 'project', title: 'Loose', layout: 'nested' })).toBe('Projects/Loose/Loose.md');
+    // The goal's folder is honored wherever the goal note actually lives.
+    expect(projectNotePath({ kind: 'project', title: 'iOS App', layout: 'nested', goalFolder: 'Areas/Work/dayGLANCE' })).toBe('Areas/Work/dayGLANCE/iOS App/iOS App.md');
+  });
+  it('uniqueNotePath suffixes past taken paths', () => {
+    const taken = new Set(['Projects/House.md', 'Projects/House 2.md']);
+    expect(uniqueNotePath('Projects/House.md', (p) => taken.has(p))).toBe('Projects/House 3.md');
+    expect(uniqueNotePath('Projects/Garden.md', (p) => taken.has(p))).toBe('Projects/Garden.md');
+  });
+});
+
+describe('templates (the §4.4 ladder pieces)', () => {
+  it('flags interactive templates and renders the subset, leaving everything else visible', () => {
+    expect(templateNeedsUser('<% tp.system.prompt("x") %>')).toBe(true);
+    expect(templateNeedsUser('<% tp.date.now() %>')).toBe(false);
+    expect(renderNoteTemplateSubset('# {{title}}\nGoal: {{ goal }}\n{{date}} <% tp.date.now() %>', { title: 'House', date: '2026-09-03', goal: 'Home' }))
+      .toBe('# House\nGoal: Home\n2026-09-03 <% tp.date.now() %>');
+  });
+});

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -208,3 +208,14 @@ export function applyBridgeIntent(
 ): { text: string | null; changed: boolean }
  | { error: 'unportable_name'; reason: string }
  | { unsupported: true };
+
+// ── project and goal note workspaces (companion §4.3, rulings D and E) ─────
+export type ProjectNoteLayout = 'note' | 'folder' | 'nested';
+export const PROJECT_NOTE_LAYOUTS: ProjectNoteLayout[];
+export interface ProjectNoteSettings { layout: ProjectNoteLayout; projectsFolder: string; goalsFolder: string; projectTemplate: string; goalTemplate: string }
+export function normalizeProjectNoteSettings(s: Partial<ProjectNoteSettings> | null | undefined): ProjectNoteSettings;
+export function noteNameFromTitle(title: string): string;
+export function projectNotePath(a: { kind: 'project' | 'goal'; title: string; layout?: string; projectsFolder?: string; goalsFolder?: string; goalFolder?: string | null }): string;
+export function uniqueNotePath(path: string, exists: (path: string) => boolean): string;
+export function templateNeedsUser(text: string): boolean;
+export function renderNoteTemplateSubset(text: string, vars?: { title?: string; date?: string; goal?: string }): string;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2773,7 +2773,7 @@ const DayPlanner = () => {
   // lives in useObsidianSync; state/refs stay owned by useObsidian above.
   const {
     performObsidianSync, nudgeObsidianObservations, loadWikiNote, saveWikiNote, openInObsidian, bridgeHeartbeatRef,
-    linkProjectNote, unlinkProjectNote,
+    linkProjectNote, unlinkProjectNote, createProjectNote,
   } = useObsidianSync({
     isTrayMode, dataLoaded,
     tasks, setTasks,
@@ -8685,7 +8685,7 @@ const DayPlanner = () => {
     vaultEnabled: isVaultEnabled(),
     syncAll,
     performObsidianSync, loadWikiNote, saveWikiNote, openInObsidian, nativeClearVault,
-    linkProjectNote, unlinkProjectNote,
+    linkProjectNote, unlinkProjectNote, createProjectNote,
     performTrmnlSync,
     performLocalBackup, performRemoteBackup,
     buildAutoBackupPayload, loadAutoBackupHistory,

--- a/src/components/goals/GoalCard.jsx
+++ b/src/components/goals/GoalCard.jsx
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
-import { AlertTriangle, Calendar, CircleCheckBig, Edit2, FolderOpen, Layers, Link2, Plus } from 'lucide-react';
+import { AlertTriangle, Calendar, CircleCheckBig, Edit2, FileText, FolderOpen, Layers, Link2, Plus } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
+import { useSyncCtx } from '../../context/SyncContext.jsx';
+import { noteLinkOf } from '../../utils/obsidianProjectNotes.js';
 import { calculateGoalProgress } from '../../utils/goalProgress.js';
 import { isProjectStalled } from '../../utils/projectProgress.js';
 import GoalProgress from './GoalProgress.jsx';
@@ -31,6 +33,9 @@ const GoalCard = forwardRef(
       borderClass, textPrimary, textSecondary, hoverBg,
     } = useDayPlannerCtx();
     const { updateGoal, isVisibleForUser, areas = [] } = useFeaturesCtx();
+    const { openInObsidian } = useSyncCtx();
+    // Goal note (companion §4.3, ruling E): open the linked note, or warn while it is missing.
+    const noteLink = noteLinkOf(goal);
     const { t } = useTranslation();
 
     // Multi-user: progress and stalled state reflect only the current user's tasks.
@@ -77,6 +82,17 @@ const GoalCard = forwardRef(
           <span className="flex-1 text-white font-semibold text-sm leading-tight truncate">
             {goal.title}
           </span>
+          {noteLink && (
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); if (!noteLink.missing) openInObsidian?.(noteLink.name); }}
+              className={`flex-shrink-0 ${noteLink.missing ? 'text-amber-200' : 'text-white/70 hover:text-white'}`}
+              title={noteLink.missing ? `Obsidian note missing: ${noteLink.name}` : `Open "${noteLink.name}" in Obsidian`}
+              aria-label={noteLink.missing ? 'Obsidian note missing' : 'Open goal note in Obsidian'}
+            >
+              {noteLink.missing ? <AlertTriangle size={12} /> : <FileText size={12} />}
+            </button>
+          )}
           {(goal.source_app === 'app.lifeglance' || goal.synced_to_lifeglance) && (
             <span title="Linked with lifeGLANCE" className="flex-shrink-0 text-white/70">
               <Link2 size={12} />

--- a/src/components/goals/GoalDashboard.jsx
+++ b/src/components/goals/GoalDashboard.jsx
@@ -132,6 +132,7 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
   const [assignedUserSyncIds, setAssignedUserSyncIds] = useState(initial?.assignedUserSyncIds || []);
   const [hideStalled, setHideStalled] = useState(initial?.hideStalled || false);
   const [trackInLifeGlance, setTrackInLifeGlance] = useState(false);
+  const [createNote, setCreateNote] = useState(false);
 
   // "Completed" only available when all child projects are completed (or none exist)
   const activeChildProjects = childProjects.filter(p => p.status !== 'archived');
@@ -148,7 +149,7 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!title.trim()) return;
-    onSave({ title: title.trim(), description: description.trim(), areaId: areaId || undefined, startDate: startDate || undefined, targetDate: targetDate || undefined, color, status, assignedUserSyncIds, hideStalled, trackInLifeGlance: showLifeGlanceCheckbox && !alreadyShared && trackInLifeGlance });
+    onSave({ title: title.trim(), description: description.trim(), areaId: areaId || undefined, startDate: startDate || undefined, targetDate: targetDate || undefined, color, status, assignedUserSyncIds, hideStalled, trackInLifeGlance: showLifeGlanceCheckbox && !alreadyShared && trackInLifeGlance, createNote: !initial && createNote });
   };
 
   return (
@@ -352,6 +353,9 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
         </div>
       )}
 
+      {/* Obsidian note (companion §4.3, ruling E): goals ride the same link machinery */}
+      {initial ? <NoteLinkRow kind="goal" id={initial.id} /> : <CreateNoteCheckbox checked={createNote} onChange={setCreateNote} />}
+
       {/* Actions */}
       <div className="flex gap-2 items-center">
         {initial && onDelete && (
@@ -393,16 +397,16 @@ const GoalForm = ({ initial, childProjects = [], onSave, onCancel, onDelete, mob
 // ─── Project form (create / edit) ─────────────────────────────────────────────
 
 /**
- * ProjectNoteRow — the project's Obsidian note (companion spec §4.3). Links
- * an EXISTING vault note by path (the plugin writes the id key), opens it,
- * unlinks it, and shows the missing state with a relink (ruling F). Reads the
- * live project so the row reflects the link as soon as it lands.
+ * NoteLinkRow — a project's or goal's Obsidian note (companion spec §4.3).
+ * Links an EXISTING vault note by path (the plugin writes the id key), opens
+ * it, unlinks it, and shows the missing state with a relink (ruling F). Reads
+ * the live entity so the row reflects the link as soon as it lands.
  */
-const ProjectNoteRow = ({ projectId }) => {
+const NoteLinkRow = ({ kind = 'project', id }) => {
   const { darkMode, borderClass, textPrimary, textSecondary } = useDayPlannerCtx();
-  const { projects } = useFeaturesCtx();
+  const { projects, goals } = useFeaturesCtx();
   const { obsidianConfig, linkProjectNote, unlinkProjectNote, openInObsidian } = useSyncCtx();
-  const project = (projects || []).find(p => p.id === projectId);
+  const project = ((kind === 'goal' ? goals : projects) || []).find(e => e.id === id);
   const link = noteLinkOf(project);
   const [path, setPath] = useState(link?.name || '');
   const [error, setError] = useState('');
@@ -413,7 +417,7 @@ const ProjectNoteRow = ({ projectId }) => {
   const btnCls = `px-2.5 py-1.5 text-xs rounded-lg border ${borderClass} ${textPrimary} hover:bg-blue-500/10`;
   const submit = () => {
     setError('');
-    if (!linkProjectNote?.('project', project.id, path)) {
+    if (!linkProjectNote?.(kind, project.id, path)) {
       setError('Could not link. Enter a vault path and make sure the dayGLANCE bridge plugin is paired.');
     }
   };
@@ -424,13 +428,13 @@ const ProjectNoteRow = ({ projectId }) => {
         <div className="flex items-center gap-2 text-sm">
           <span className={`${textPrimary} truncate flex-1 min-w-0`} title={link.path}>{link.name}</span>
           <button type="button" className={btnCls} onClick={() => openInObsidian?.(link.name)}>Open</button>
-          <button type="button" className={btnCls} onClick={() => unlinkProjectNote?.('project', project.id)}>Unlink</button>
+          <button type="button" className={btnCls} onClick={() => unlinkProjectNote?.(kind, project.id)}>Unlink</button>
         </div>
       ) : (
         <>
           {link?.missing && (
             <div className="text-xs text-amber-600 dark:text-amber-400">
-              The linked note is missing from the vault ({link.name}). Relink it, or unlink the project.
+              The linked note is missing from the vault ({link.name}). Relink it, or unlink it.
             </div>
           )}
           <div className="flex items-center gap-2">
@@ -443,7 +447,7 @@ const ProjectNoteRow = ({ projectId }) => {
             />
             <button type="button" className={btnCls} onClick={submit}>{link?.missing ? 'Relink' : 'Link'}</button>
             {link?.missing && (
-              <button type="button" className={btnCls} onClick={() => unlinkProjectNote?.('project', project.id)}>Unlink</button>
+              <button type="button" className={btnCls} onClick={() => unlinkProjectNote?.(kind, project.id)}>Unlink</button>
             )}
           </div>
           <div className={`text-[11px] ${textSecondary}`}>
@@ -453,6 +457,19 @@ const ProjectNoteRow = ({ projectId }) => {
         </>
       )}
     </div>
+  );
+};
+
+/** "Create a note in Obsidian" for a NEW project or goal (rulings D and E); shown only with the vault enabled. */
+const CreateNoteCheckbox = ({ checked, onChange }) => {
+  const { textSecondary } = useDayPlannerCtx();
+  const { obsidianConfig, createProjectNote } = useSyncCtx();
+  if (!obsidianConfig?.enabled || !createProjectNote) return null;
+  return (
+    <label className={`flex items-center gap-2 text-xs ${textSecondary} cursor-pointer select-none`}>
+      <input type="checkbox" checked={!!checked} onChange={e => onChange(e.target.checked)} className="rounded" />
+      Create a note in Obsidian (where the bridge plugin's layout puts it)
+    </label>
   );
 };
 
@@ -478,6 +495,7 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
     initial?.assignedUserSyncIds || (initial ? [] : initialGoal?.assignedUserSyncIds || [])
   );
   const [usersTouched, setUsersTouched] = useState(!!initial);
+  const [createNote, setCreateNote] = useState(false);
 
   // "Completed" only available when all project tasks are completed (or none exist)
   const projectTasks = initial
@@ -490,7 +508,7 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
     if (!title.trim()) return;
     // description and hyperglance are managed in the Project Planner now;
     // omitting them here preserves existing values on save (updateProject merges).
-    onSave({ title: title.trim(), goalId: goalId || undefined, status, color, assignedUserSyncIds });
+    onSave({ title: title.trim(), goalId: goalId || undefined, status, color, assignedUserSyncIds, createNote: !initial && createNote });
   };
 
   const activeGoals = goals.filter(g => g.status !== 'archived');
@@ -542,8 +560,8 @@ export const ProjectForm = ({ initial, goals, defaultGoalId, onSave, onCancel, m
         </select>
       </div>
 
-      {/* Obsidian note (companion §4.3) */}
-      {initial && <ProjectNoteRow projectId={initial.id} />}
+      {/* Obsidian note (companion §4.3): link an existing note, or create one with the project */}
+      {initial ? <NoteLinkRow kind="project" id={initial.id} /> : <CreateNoteCheckbox checked={createNote} onChange={setCreateNote} />}
 
       {/* Color — defaults to the goal's color (blue when standalone) until overridden */}
       <div className="flex flex-col gap-1.5">
@@ -2240,6 +2258,8 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
     plannerProjectId, setPlannerProjectId,
     isVisibleForUser,
   } = useFeaturesCtx();
+  // Workspace creation (companion §4.3, rulings D and E): the plugin creates and links the note.
+  const { createProjectNote } = useSyncCtx();
   const { t } = useTranslation();
 
   const [goalForm, setGoalForm] = useState(null);
@@ -2314,7 +2334,7 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
   const archivedCount = archivedGoals.length + archivedProjects.length;
 
   const handleSaveGoal = (fields) => {
-    const { trackInLifeGlance, ...goalFields } = fields;
+    const { trackInLifeGlance, createNote, ...goalFields } = fields;
     if (goalForm.editing) {
       const wasArchived = goalForm.editing.status === 'archived';
       const nowArchived = goalFields.status === 'archived';
@@ -2344,6 +2364,7 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
     } else {
       const newGoal = addGoal({ ...goalFields, ...(trackInLifeGlance ? { synced_to_lifeglance: true } : {}) });
       if (trackInLifeGlance) emitGoalCreate(newGoal);
+      if (createNote && newGoal?.id) createProjectNote?.('goal', newGoal.id, { title: newGoal.title });
     }
     setGoalForm(null);
   };
@@ -2363,7 +2384,8 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
     });
   };
 
-  const handleSaveProject = (fields) => {
+  const handleSaveProject = (allFields) => {
+    const { createNote, ...fields } = allFields;
     if (projectForm.editing) {
       const wasArchived = projectForm.editing.status === 'archived';
       const nowArchived = fields.status === 'archived';
@@ -2382,7 +2404,8 @@ const GoalDashboard = ({ embedded = false, isActive = false, addGoalTrigger = 0,
       }
       updateProject(projectForm.editing.id, fields);
     } else {
-      addProject(fields);
+      const created = addProject(fields);
+      if (createNote && created?.id) createProjectNote?.('project', created.id, { title: created.title, goalId: created.goalId });
     }
     setProjectForm(null);
   };

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -1795,5 +1795,20 @@ export default function useObsidianSync({
     return true;
   }, [updateProject, updateGoal]);
 
-  return { performObsidianSync, nudgeObsidianObservations, loadWikiNote, saveWikiNote, openInObsidian, notifyNativeReady, bridgeHeartbeatRef, linkProjectNote, unlinkProjectNote };
+  // Workspace creation (companion §4.3, rulings D and E): ask the plugin to
+  // create the entity's note where its layout setting says and link it. The
+  // fields travel with the intent because a just-created entity is not in
+  // the lists yet; the link lands through the observation stream. Returns
+  // whether the request was durably queued.
+  const createProjectNote = useCallback((kind, id, { title, goalId = null } = {}) => {
+    const name = String(title ?? '').trim();
+    if (!name) return false;
+    const goal = goalId ? (goalsRef.current || []).find((g) => g && String(g.id) === String(goalId)) : null;
+    return emitBridgeIntent('project_note_create', {
+      targetId: String(id), kind: kind === 'goal' ? 'goal' : 'project', title: name,
+      ...(goal ? { goalId: String(goal.id), goalTitle: String(goal.title ?? '') } : {}),
+    });
+  }, []);
+
+  return { performObsidianSync, nudgeObsidianObservations, loadWikiNote, saveWikiNote, openInObsidian, notifyNativeReady, bridgeHeartbeatRef, linkProjectNote, unlinkProjectNote, createProjectNote };
 }

--- a/src/hooks/useObsidianSync.projectNotes.test.js
+++ b/src/hooks/useObsidianSync.projectNotes.test.js
@@ -162,3 +162,14 @@ describe('project notes: link and unlink from dayGLANCE', () => {
     expect(emitBridgeIntent).toHaveBeenCalledWith('project_note_unlink', { path: 'Projects/House.md', targetId: 'p1' });
   });
 });
+
+describe('project notes: workspace creation from dayGLANCE (rulings D and E)', () => {
+  it('createProjectNote queues the create intent with the title and the goal (id and title); nothing without a title', () => {
+    const h = useMountedHook({ projects: [], goals: [{ id: 'g1', title: 'Home' }] });
+    expect(h.api.createProjectNote('project', 'p9', { title: 'House', goalId: 'g1' })).toBe(true);
+    expect(emitBridgeIntent).toHaveBeenCalledWith('project_note_create', { targetId: 'p9', kind: 'project', title: 'House', goalId: 'g1', goalTitle: 'Home' });
+    expect(h.api.createProjectNote('goal', 'g2', { title: 'Health' })).toBe(true);
+    expect(emitBridgeIntent).toHaveBeenLastCalledWith('project_note_create', { targetId: 'g2', kind: 'goal', title: 'Health' });
+    expect(h.api.createProjectNote('project', 'p9', { title: '  ' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Build step 3 of companion spec §4.3 (rulings D and E, with the nested-folders amendment). Stacked on #1533 (the block). A project or goal born in dayGLANCE can create its own note where the plugin's layout setting puts it; goals get the same form row and badge projects got in step 1.

### Shared (`@glance-apps/obsidian-format`)
- `projectNotes.js`: `normalizeProjectNoteSettings`, `noteNameFromTitle` (portable on every platform a vault syncs to), `projectNotePath` for the three layouts (`note`: `Projects/House.md`; `folder`: `Projects/House/House.md`; `nested`: `Goals/Home/House/House.md` for a project with a goal, placed under the goal's linked note's own folder wherever that is, else the folder the goal would get; a standalone project falls back to the folder layout), `uniqueNotePath`, and the §4.4 ladder pieces: `templateNeedsUser` (the `tp.system.` guard) and `renderNoteTemplateSubset` (`{{title}}`, `{{date}}`, `{{goal}}`; everything else left visible).
- Intent `project_note_create {targetId, kind, title, goalId?, goalTitle?}` documented.

### Plugin
- Settings section **Project and goal notes**: layout dropdown, projects folder, goals folder, optional project and goal template notes. Plugin-local like the scope.
- `project_note_create`: creates the note with dayGLANCE's creation frontmatter and a title heading, renders the template through the ladder (Templater's `create_running_config` and `read_and_parse_template` when both feature-detect and the template is non-interactive, otherwise the subset), then links it through the step 1 path, so the record learns its locator from the link observation. Idempotent: an already-linked target is a no-op. A note already at the computed path is adopted when it carries no id key, stepped past with a numeric suffix when it belongs to another entity.

### App
- "Create a note in Obsidian" checkbox on a new project and a new goal (shown only with the vault enabled). `createProjectNote(kind, id, {title, goalId})` carries the fields on the intent because the new entity is not in any list yet.
- Goal form: the same Obsidian note row as projects (link, open, relink, unlink, missing state). Goal card: note badge or missing warning.

### Judgment calls for review
- Adopting an unowned note that already sits at the computed path: it is named for the project, in the projects folder, so suffixing would leave the obvious note unlinked.
- The subset renderer is three variables. Nothing in the repo implements v1's fuller subset, and Templater covers the rest when present.
- Placement is creation-time only. Moving a project between goals never moves a folder; a hand move is a rename the link follows.

### Verification
- New tests: `projectNotes.test.js` (settings, names, all three layouts, suffixing, template guard and subset) and a `createProjectNote` intent case in the hook suite.
- Plugin builds clean; lint clean; full suite green (2819 tests).

### Stack
#1530 rulings → #1532 link → #1533 block → this PR. Merge top down; each retargets as its base lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_