### PR TITLE
Vault task scope: moves re-classify the scope and carry an arrival time

### DIFF
--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -285,6 +285,14 @@ export class BridgeTransport {
   private adopted = new Set<string>();
   private adoptQueue: string[] = [];
   private adoptScanned = false;
+  // When a note ARRIVED at a path (create or rename), epoch ms. A move does
+  // not touch a file's mtime, so a note moved back into the scope would
+  // report content older than the tombstones its leaving produced and never
+  // revive (field test, 2026-09-04). Its presence at this path is evidence as
+  // of its arrival: scoped observations report max(mtime, arrival). Memory
+  // only; after a reload the plain mtime is reported again, which is right
+  // for a note that has simply been sitting there.
+  private arrivedAt = new Map<string, number>();
   // In-memory cursor for the persist-on-intent-only rule (see drain): pages
   // that only skipped config/observation/tombstone rows advance the cursor
   // HERE, not in data.json — every data.json save is a vault file write that
@@ -974,8 +982,51 @@ export class BridgeTransport {
   }
 
   /** A rename keeps the link: the row for the id simply moves to the new path. */
-  noteRenamed(oldPath: string, newPath: string): void {
+  /** A note appeared at a path (vault create event): remember the arrival, then observe. */
+  noteCreated(file: TFile): void {
     if (this.disposed) return;
+    this.arrivedAt.set(file.path, Date.now());
+    this.scheduleObservation(file);
+  }
+
+  /**
+   * A rename or move (vault rename event). Three things ride it:
+   *   • a linked project note keeps its link (companion §4.3, ruling A);
+   *   • the TASK SCOPE is re-classified (companion §6, ruling C): a scoped
+   *     note leaving the scope is WITHDRAWN, never reported deleted — the
+   *     note still exists, and the withdrawal path is the one that remembers
+   *     it for re-entry; a note entering the scope is adopted on the spot;
+   *     a move within the scope carries its adoption to the new path;
+   *   • the new path records an arrival time (see arrivedAt).
+   * Then the old path reports (a deletion, if it was daily or still counts
+   * as scoped) and the new path is observed.
+   */
+  noteRenamed(oldPath: string, file: TFile): void {
+    if (this.disposed) return;
+    const newPath = file.path;
+    this.arrivedAt.set(newPath, Date.now());
+    this.moveLink(oldPath, newPath);
+    const wasScoped = this.scopedPaths.has(oldPath) || this.adopted.has(oldPath);
+    const nowScoped = this.scopedNote(newPath);
+    if (wasScoped) {
+      this.adopted.delete(oldPath);
+      this.scopedPaths.delete(oldPath);
+      if (nowScoped) {
+        this.adopted.add(newPath);
+      } else {
+        // Left the scope by moving out: withdrawn (ruling C), not deleted.
+        void this.emitWithdrawal(oldPath);
+      }
+      void this.persistAdopted();
+    } else if (nowScoped) {
+      this.adopted.add(newPath);
+      void this.persistAdopted();
+    }
+    this.reportDeleted(oldPath);
+    this.scheduleObservation(file);
+  }
+
+  private moveLink(oldPath: string, newPath: string): void {
     const id = this.linked.get(oldPath);
     if (id === undefined) return;
     this.linked.delete(oldPath);
@@ -1634,7 +1685,13 @@ export class BridgeTransport {
       // reports too.
       const scoped = !this.isDailyNote(path) && (deleted ? this.scopedPaths.has(path) : this.scopedNote(path));
       if (scoped && !deleted) this.scopedPaths.add(path);
-      if (deleted) this.scopedPaths.delete(path);
+      if (deleted) { this.scopedPaths.delete(path); this.arrivedAt.delete(path); }
+      // A scoped note that arrived here by create or move is evidence as of
+      // its arrival (see arrivedAt): revival after a withdrawal or a
+      // deletion needs the note to be NEWER than the tombstone, and a move
+      // leaves the file's own mtime untouched.
+      const arrival = this.arrivedAt.get(path);
+      if (scoped && !deleted && arrival !== undefined && (mtime === null || arrival > mtime)) mtime = arrival;
       const subkey = await this.subkeyFor(pairing);
       const payload = {
         v: 1, kind: 'observation', path,

--- a/dayglance-obsidian-plugin/src/main.ts
+++ b/dayglance-obsidian-plugin/src/main.ts
@@ -157,15 +157,12 @@ export default class DayGlanceBridgePlugin extends Plugin {
     // inert while unpaired. layoutReady gates out the initial index churn.
     this.app.workspace.onLayoutReady(() => {
       this.registerEvent(this.app.vault.on('modify', (f) => { if (f instanceof TFile) this.transport.scheduleObservation(f); }));
-      this.registerEvent(this.app.vault.on('create', (f) => { if (f instanceof TFile) this.transport.scheduleObservation(f); }));
+      this.registerEvent(this.app.vault.on('create', (f) => { if (f instanceof TFile) this.transport.noteCreated(f); }));
       this.registerEvent(this.app.vault.on('delete', (f) => { if (f instanceof TFile) this.transport.reportDeleted(f.path); }));
       this.registerEvent(this.app.vault.on('rename', (f, oldPath) => {
-        if (f instanceof TFile) {
-          // A linked project note keeps its link across the rename (companion §4.3, ruling A).
-          this.transport.noteRenamed(oldPath, f.path);
-          this.transport.reportDeleted(oldPath);
-          this.transport.scheduleObservation(f);
-        }
+        // Link following, scope re-classification (a move out is a
+        // withdrawal, a move in an entry), arrival time, then the reports.
+        if (f instanceof TFile) this.transport.noteRenamed(oldPath, f);
       }));
       // Frontmatter edits (the id key) surface as metadata changes, not file modifies.
       this.registerEvent(this.app.metadataCache.on('changed', (f) => { if (f instanceof TFile) this.transport.noteMetaChanged(f.path); }));

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -990,6 +990,23 @@ inbox) through the retitle path, so the raw title changes and the display
 title does not, and the parser reads the date back. Task cards carry a note
 badge naming the note. Direct access is untouched (ruling F).
 
+**Field-test record (2026-09-04): moves.** A note moved OUT of the scope
+and back did not revive its tasks. Two causes, both in the plugin's rename
+handling: a rename reported the old path as a deleted scoped note (so the
+app's note-scoped inference tombstoned the tasks at observation time, the
+deletion channel rather than ruling C's withdrawal), and a move does not
+touch a file's mtime, so the note's return reported content OLDER than
+those tombstones and ruling 6's existence LWW kept it dead until someone
+edited it. Fixed: the rename handler re-classifies the scope — old path
+scoped and new path out is a WITHDRAWAL (the app's path store then lifts
+the re-entry), new path in is an adoption on the spot, both in carries the
+adoption — and every scoped note carries a memory-only ARRIVAL time (create
+or rename) that its observations report as the later of mtime and arrival,
+so a note that reappears anywhere in the scope is evidence as of its
+arrival. Daily notes are untouched. *Remaining gap, recorded:* an arrival is
+memory-only, so a note moved back while the plugin is closed and then left
+unedited reports its old mtime after the reload; an edit revives it.
+
 **The TaskForge reference point** stands from the earlier text: discovery
 was never the hard part; identity is what buys cross-device durability
 through retitles, deletes and revivals, and it is what this section pays for.


### PR DESCRIPTION
## Summary

Field test finding (companion §6, 2026-09-04): a note moved **out** of the task scope and **back** did not revive its tasks, even after sync, refresh and reload. Plugin-only fix; the app is unchanged.

### Cause
- A rename reported the old path as a *deleted* scoped note, so the app's note-scoped inference tombstoned the tasks through the deletion channel rather than ruling C's withdrawal (which is the path that remembers the note for re-entry).
- A move does not touch a file's mtime, so the note's return reported content older than those tombstones, and the existence rule (ruling 6) kept it dead until someone edited the note.

### Fix
- **Rename re-classifies the scope.** Old path scoped and new path out → a withdrawal (the app's withdrawn-path store then lifts the re-entry). New path in → adopted on the spot. Both in → the adoption moves to the new path. The old path is no longer reported as a deleted scoped note.
- **Arrival time.** Every scoped note carries a memory-only arrival time (create or rename), and its observations report the later of mtime and arrival, so a note that reappears anywhere in the scope is evidence as of its arrival. Covers a note moved back to a *different* folder inside the scope, which the path-keyed store alone would miss.
- Daily notes are untouched. The rename handler in the plugin now owns the whole sequence (link following, scope re-classification, arrival, reports).

### Recorded gap
An arrival is memory-only: a note moved back while the plugin is closed and then left unedited reports its old mtime after the reload. An edit revives it.

### Verification
- Plugin builds clean (tsc strict + esbuild). Spec §6.4 field-test record added.
- To retest: move a scoped note out of the folder (tasks drop after the hold), move it back (tasks return on the next observation). Also rerun the tag test properly: remove the scope *tag* from a note, wait, add it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_