### PR TITLE
Bridge scenario harness: real plugin and real sync hook against a stub vault

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,17 @@ This check is mandatory — even mid-task, even for "small fixes", even when you
 
 Do **not** post comments to GitHub issues directly using `mcp__github__add_issue_comment`. Instead, draft the proposed response and present it to the user so they can review and post it themselves.
 
+# Bridge scenario harness
+
+`dayglance-obsidian-plugin/test/` runs the real Obsidian plugin transport and
+the real `useObsidianSync` hook against a stub Obsidian vault and an in-memory
+GLANCEvault, under fake timers (`vitest.config.js` aliases `obsidian` to the
+stub and the plugin's copy of `@glance-apps/sync` to the root one). When a
+change touches what the plugin stamps, reports, or applies, or how the app
+consumes the observation stream, add or extend a scenario in
+`scope.scenarios.test.ts` rather than relying on a manual vault test. Obsidian
+Sync timing, real editor buffers, and Templater stay manual.
+
 # App.jsx — Ongoing Decomposition
 
 `App.jsx` started at ~30,000 lines and has been reduced to ~9,600 across four refactor passes. All previously listed extraction candidates are done:

--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -97,6 +97,17 @@ Network access happens only while paired (plus pairing verification), only
 to the vault URL carried in the offer, via Obsidian's `requestUrl`. All
 stream rows are AES-256-GCM under the pairing's bridge subkey.
 
+## Tests
+
+The plugin has no unit tests of its own; it is exercised end to end by the
+bridge scenario harness in `test/`, which runs from the repository root
+with the rest of the suite (`npx vitest run`). The harness stubs the
+`obsidian` module (`test/obsidianStub.ts`), serves an in-memory GLANCEvault
+(`test/fakeGlanceVault.ts`), and drives the real transport plus the real
+dayGLANCE sync hook against it (`test/harness.ts`). Add a scenario to
+`test/scope.scenarios.test.ts` for any change to what the plugin stamps,
+reports, or applies.
+
 ## Build
 
 ```

--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -161,6 +161,8 @@ export interface BridgeHost {
   getScope?(): VaultScope | null;
   /** Project and goal note workspaces (companion §4.3, rulings D and E). */
   getProjectNotes?(): ProjectNoteSettings;
+  /** The vault's viewer override (companion 4.2, decision 9); undefined = the pairing's default. */
+  getViewer?(): string | null;
 }
 
 // Same requestUrl-backed fetch shim as pairing.ts (CORS-free everywhere).
@@ -639,7 +641,10 @@ export class BridgeTransport {
       const client = this.client(pairing);
       const subkey = await this.subkeyFor(pairing);
       if (this.metaAssertedGeneration !== pairing.generation) {
-        await publishPairingMeta(pairing);
+        // The row carries the viewer override and the task scope too
+        // (harness finding, 2026-09-04): republishing it bare after every
+        // reload silently dropped both until the settings were touched.
+        await publishPairingMeta(pairing, undefined, this.host.getViewer?.() ?? pairing.userSyncId ?? null, this.host.getScope?.() ?? null);
         this.metaAssertedGeneration = pairing.generation;
       }
       // CONFIG RECOVERY BY DIRECT READ (2026-08-31 config-null incident):
@@ -1472,11 +1477,19 @@ export class BridgeTransport {
       // daily-note classifier runs on its fallback regex, and feeding the
       // note-scoped deletion inference from a guessed classification isn't
       // worth the asymmetry.
-      if (this.config === null && this.isDailyNote(path)) {
+      // A SCOPED note holds too (harness finding, 2026-09-04): its lines
+      // are stamped by the same block, so reporting it config-null would
+      // ship untagged lines and mint provisional ids in dayGLANCE — the
+      // fragment factory, one scope over.
+      if (this.config === null && !deleted && (this.isDailyNote(path) || this.scopedNote(path))) {
         if (!this.warnedConfigHold) {
           this.warnedConfigHold = true;
-          console.warn('dayGLANCE bridge: no config row known yet — daily-note reporting held (fail closed) until it arrives.');
+          console.warn('dayGLANCE bridge: no config row known yet — note reporting held (fail closed) until it arrives.');
         }
+        this.armObserve(path, deleted, CONFIG_HOLD_RETRY_MS);
+        return;
+      }
+      if (this.config === null && deleted && this.isDailyNote(path)) {
         this.armObserve(path, deleted, CONFIG_HOLD_RETRY_MS);
         return;
       }

--- a/dayglance-obsidian-plugin/src/main.ts
+++ b/dayglance-obsidian-plugin/src/main.ts
@@ -135,6 +135,7 @@ export default class DayGlanceBridgePlugin extends Plugin {
       onSynced: () => { void this.agenda.refresh().then(() => this.noteBlocks.tick()); },
       getScope: () => this.scope(),
       getProjectNotes: () => normalizeProjectNoteSettings(this.data.projectNotes),
+      getViewer: () => this.viewer(),
     });
     this.noteBlocks = new NoteBlockWriter({
       app: this.app,

--- a/dayglance-obsidian-plugin/test/fakeGlanceVault.ts
+++ b/dayglance-obsidian-plugin/test/fakeGlanceVault.ts
@@ -1,0 +1,68 @@
+// An in-memory GLANCEvault: the row endpoints the bridge uses (batch, list,
+// getRow, deleteRow), with a monotonic per-server seq and soft deletes,
+// mirroring glance-vault's routes/sync.ts as the client contracts them.
+// Serves both sides of the harness: the plugin through the `obsidian` stub's
+// requestUrl and dayGLANCE through a global fetch shim.
+import type { StubResponse } from './obsidianStub';
+
+export interface VaultRow { entityId: string; envelope: string | null; seq: number; deleted: boolean; createdAt: number }
+
+export class FakeGlanceVault {
+  private seq = 0;
+  private rows = new Map<string, Map<string, VaultRow>>(); // app → entityId → row
+  requests: Array<{ method: string; path: string; who: string; at: number }> = [];
+
+  private table(app: string): Map<string, VaultRow> {
+    if (!this.rows.has(app)) this.rows.set(app, new Map());
+    return this.rows.get(app)!;
+  }
+
+  /** Every live (non-deleted) row of an app, seq order. */
+  live(app: string): VaultRow[] { return [...this.table(app).values()].filter((r) => !r.deleted).sort((a, b) => a.seq - b.seq); }
+  all(app: string): VaultRow[] { return [...this.table(app).values()].sort((a, b) => a.seq - b.seq); }
+  get maxSeq(): number { return this.seq; }
+
+  handle(method: string, rawUrl: string, body?: string, auth = ''): StubResponse {
+    const url = new URL(rawUrl);
+    const path = url.pathname;
+    this.requests.push({ method, path, who: auth.replace(/^Bearer /, ''), at: Date.now() });
+    const json = (status: number, payload: unknown): StubResponse => ({ status, json: payload, text: JSON.stringify(payload), headers: {} });
+    const m = /^\/sync\/([^/]+)(?:\/([^/]+))?$/.exec(path);
+    if (!m) return json(404, { error: 'not found' });
+    const app = decodeURIComponent(m[1]);
+    const tail = m[2] ? decodeURIComponent(m[2]) : null;
+    if (method === 'POST' && tail === 'batch') {
+      const parsed = JSON.parse(body ?? '{}') as { rows?: Array<{ entityId: string; envelope: string; createdAt?: number }> };
+      let maxSeq = this.seq;
+      const t = this.table(app);
+      for (const r of parsed.rows ?? []) {
+        const seq = ++this.seq; maxSeq = seq;
+        t.set(r.entityId, { entityId: r.entityId, envelope: r.envelope, seq, deleted: false, createdAt: r.createdAt ?? Date.now() });
+      }
+      return json(200, { written: (parsed.rows ?? []).length, maxSeq });
+    }
+    if (method === 'GET' && tail === 'list') {
+      const since = Number(url.searchParams.get('since') ?? 0) || 0;
+      const rows = this.all(app).filter((r) => r.seq > since);
+      return json(200, { rows, hasMore: false });
+    }
+    if (method === 'GET' && tail) {
+      const row = this.table(app).get(tail);
+      return row ? json(200, row) : json(404, { error: 'not found' });
+    }
+    if (method === 'DELETE' && tail) {
+      const t = this.table(app);
+      const row = t.get(tail);
+      const seq = ++this.seq;
+      t.set(tail, { entityId: tail, envelope: null, seq, deleted: true, createdAt: row?.createdAt ?? Date.now() });
+      return json(200, { seq });
+    }
+    return json(404, { error: 'not found' });
+  }
+
+  /** A fetch-shaped adaptor for dayGLANCE's vault client. */
+  fetch = async (url: string, init: { method?: string; body?: string; headers?: Record<string, string> } = {}): Promise<{ ok: boolean; status: number; json: () => Promise<unknown>; text: () => Promise<string> }> => {
+    const res = this.handle(init.method ?? 'GET', url, init.body, init.headers?.Authorization ?? '');
+    return { ok: res.status >= 200 && res.status < 300, status: res.status, json: async () => res.json, text: async () => res.text };
+  };
+}

--- a/dayglance-obsidian-plugin/test/harness.ts
+++ b/dayglance-obsidian-plugin/test/harness.ts
@@ -1,0 +1,151 @@
+// The bridge scenario harness: one fake GLANCEvault, one stub Obsidian vault
+// with the real plugin transport wired to it exactly as main.ts wires it,
+// and any number of dayGLANCE "devices" running the real sync hook against
+// the same stream. Time is the test's: install fake timers before calling
+// createScenario and drive it with `advance`.
+//
+// What runs for real: the plugin's BridgeTransport (stamping, observations,
+// scope, links, intent applies), the shared format package, dayGLANCE's
+// bridge stream and inbound modules (sealing, outbox, observation fetch),
+// and the sync hook's merge, deletion inference, withdrawal and writeback.
+// What is faked: Obsidian (the stub), the vault server (in memory), and the
+// app's direct vault access (off: the plugin is authoritative throughout).
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { vi } from 'vitest';
+import { App, TFile, __setRequestHandler } from 'obsidian';
+import { FakeGlanceVault } from './fakeGlanceVault';
+import { BridgeTransport, publishPairingMeta, type BridgeState } from '../src/bridge';
+import type { BridgePairing } from '../src/pairing';
+// The SAME specifier the app uses, so the root key lands in the module instance the app reads.
+import { setupDbRootKey, hasDbRootKey } from '@glance-apps/sync';
+import { getDbRootKey, hasDbRootKey as hasDbRootKeyDirect } from '@glance-apps/sync/src/dbCrypto.js';
+import { deriveBridgeSubkey, exportBridgeSubkey, normalizeScope, normalizeProjectNoteSettings, type VaultScope } from '@glance-apps/obsidian-format';
+
+export const VAULT_URL = 'https://vault.test';
+
+// Captured at import time, BEFORE a test installs fake timers: real async
+// work (Web Crypto runs on Node's threadpool) lands only on a real
+// macrotask, and fake time must not race ahead of it. Every fake-time step
+// first yields one real tick so pending crypto callbacks run.
+const realSetTimeout = globalThis.setTimeout;
+export const realTick = (): Promise<void> => new Promise((r) => realSetTimeout(r, 1));
+
+/** Advance fake time by `ms` in steps, yielding real time between steps. */
+export async function advanceFake(ms: number, step = 200): Promise<void> {
+  let left = ms;
+  while (left > 0) {
+    await realTick();
+    const d = Math.min(step, left);
+    await vi.advanceTimersByTimeAsync(d);
+    left -= d;
+  }
+}
+
+/** Await a promise while fake time flows only when the promise is still pending after real work has had its turn. */
+export async function until<T>(p: Promise<T>, maxMs = 300_000): Promise<T> {
+  let done = false;
+  p.then(() => { done = true; }, () => { done = true; });
+  let elapsed = 0;
+  while (!done && elapsed < maxMs) {
+    await realTick();
+    if (done) break;
+    await vi.advanceTimersByTimeAsync(100);
+    elapsed += 100;
+  }
+  return p;
+}
+export const ACCOUNT_ID = 'acc-1';
+const b64 = (bytes: Uint8Array): string => btoa(String.fromCharCode(...bytes));
+let generationCounter = 0;
+
+export interface PluginSide {
+  app: App;
+  transport: BridgeTransport;
+  data: { pairing?: BridgePairing; bridge?: BridgeState; scope?: VaultScope; saves: number };
+  setScope(scope: Partial<VaultScope>): Promise<void>;
+  /** Simulate a plugin reload: a fresh transport over the same data.json. */
+  reload(): void;
+  shutdown(): void;
+}
+
+export interface Scenario {
+  vault: FakeGlanceVault;
+  pairing: BridgePairing;
+  plugin: PluginSide;
+  /** Advance fake time, running every timer and microtask that falls due. */
+  advance(ms: number): Promise<void>;
+  /** The vault file's text, or null. */
+  text(path: string): string | null;
+  file(path: string): TFile;
+  write(path: string, text: string): Promise<TFile>;
+  /** Let the plugin settle a freshly created or edited note: debounce, stamp settle floor, re-arm, report. */
+  settle(): Promise<void>;
+}
+
+function wireVaultEvents(app: App, transport: BridgeTransport): void {
+  // Mirrors main.ts's onLayoutReady registrations, one for one.
+  app.vault.on('modify', (f: unknown) => { if (f instanceof TFile) transport.scheduleObservation(f); });
+  app.vault.on('create', (f: unknown) => { if (f instanceof TFile) transport.noteCreated(f); });
+  app.vault.on('delete', (f: unknown) => { if (f instanceof TFile) transport.reportDeleted(f.path); });
+  app.vault.on('rename', (f: unknown, oldPath: string) => { if (f instanceof TFile) transport.noteRenamed(oldPath, f); });
+  app.metadataCache.on('changed', (f: unknown) => { if (f instanceof TFile) transport.noteMetaChanged(f.path); });
+}
+
+export async function createScenario(): Promise<Scenario> {
+  const vault = new FakeGlanceVault();
+  __setRequestHandler((req) => vault.handle(req.method, req.url, req.body, req.headers.Authorization ?? ''));
+  vi.stubGlobal('fetch', vault.fetch);
+
+  // One account root key for the whole harness (both sides derive from it).
+  const rootSalt = new Uint8Array(16).fill(7);
+  await setupDbRootKey('harness-passphrase', rootSalt, { nativeGetSyncKey: async () => null, nativeStoreSyncKey: () => {} });
+  if (!hasDbRootKey() || !hasDbRootKeyDirect()) throw new Error(`harness: root key not visible (index ${hasDbRootKey()}, direct ${hasDbRootKeyDirect()})`);
+  const pairingSalt = new Uint8Array(16).fill(3);
+  const subkey = await deriveBridgeSubkey(getDbRootKey(), pairingSalt);
+  const pairing: BridgePairing = {
+    vaultUrl: VAULT_URL, accountId: ACCOUNT_ID, deviceToken: 'device-token',
+    subkeyB64: await exportBridgeSubkey(subkey), pairingSalt: b64(pairingSalt),
+    generation: `gen-${++generationCounter}`, pairedAt: new Date().toISOString(),
+  };
+
+  const app = new App();
+  const data: PluginSide['data'] = { pairing, bridge: { appliedIds: [], hwm: 0 }, saves: 0 };
+  let transport!: BridgeTransport;
+  const host = () => ({
+    app,
+    getPairing: () => data.pairing,
+    getBridgeState: () => data.bridge ?? { appliedIds: [], hwm: 0 },
+    saveBridgeState: async (state: BridgeState) => { data.bridge = state; data.saves++; },
+    getScope: () => (data.scope ? normalizeScope(data.scope) : null),
+    getProjectNotes: () => normalizeProjectNoteSettings(null),
+    getViewer: () => pairing.userSyncId ?? null,
+  });
+  const boot = () => { transport = new BridgeTransport(host()); wireVaultEvents(app, transport); };
+  boot();
+
+  const advance = async (ms: number) => { await advanceFake(ms); };
+  const plugin: PluginSide = {
+    app,
+    get transport() { return transport; },
+    data,
+    setScope: async (scope) => {
+      data.scope = normalizeScope(scope);
+      await publishPairingMeta(pairing, undefined, pairing.userSyncId ?? null, data.scope);
+      transport.scopeChanged();
+      transport.adoptTick();
+    },
+    reload: () => { transport.shutdown(); boot(); },
+    shutdown: () => transport.shutdown(),
+  };
+
+  return {
+    vault, pairing, plugin, advance,
+    text: (path) => app.vault.contents.get(path) ?? null,
+    file: (path) => { const f = app.vault.getAbstractFileByPath(path); if (!(f instanceof TFile)) throw new Error(`no file ${path}`); return f; },
+    write: async (path, text) => { const f = app.vault.getAbstractFileByPath(path); if (f instanceof TFile) { await app.vault.modify(f, text); return f; } return app.vault.create(path, text); },
+    // Debounce (2s), the receiving-posture settle floor (10s) with its 2s
+    // re-arm, the stamp write's own debounce, then the report: ~15s; 40s
+    // leaves room for a retry tick without approaching the 30s backoff.
+    settle: async () => { for (let i = 0; i < 40; i++) await advance(1000); },
+  };
+}

--- a/dayglance-obsidian-plugin/test/obsidianStub.ts
+++ b/dayglance-obsidian-plugin/test/obsidianStub.ts
@@ -1,0 +1,302 @@
+// A stub of the `obsidian` module for the bridge scenario harness: an
+// in-memory vault with the events the plugin listens to, a metadata cache
+// that parses frontmatter and tags, a workspace whose editors the tests
+// open on purpose, and `requestUrl` routed to whatever fake server the test
+// registers. Only what the plugin's transport, agenda store and block writer
+// touch; nothing here models timing (Obsidian Sync, editor autosave), which
+// stays a manual test by design.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export const normalizePath = (p: string): string =>
+  String(p ?? '').replace(/\\/g, '/').replace(/\/{2,}/g, '/').replace(/^\/+|\/+$/g, '');
+
+export class TAbstractFile {
+  path = '';
+  name = '';
+  parent: TFolder | null = null;
+  vault!: Vault;
+}
+export class TFile extends TAbstractFile {
+  basename = '';
+  extension = '';
+  stat = { ctime: 0, mtime: 0, size: 0 };
+  constructor(path: string, vault: Vault, mtime: number) {
+    super();
+    this.vault = vault;
+    this.setPath(path);
+    this.stat = { ctime: mtime, mtime, size: 0 };
+  }
+  setPath(path: string): void {
+    this.path = path;
+    this.name = path.split('/').pop() ?? path;
+    const dot = this.name.lastIndexOf('.');
+    this.basename = dot > 0 ? this.name.slice(0, dot) : this.name;
+    this.extension = dot > 0 ? this.name.slice(dot + 1) : '';
+  }
+}
+export class TFolder extends TAbstractFile {
+  children: TAbstractFile[] = [];
+  constructor(path: string) { super(); this.path = path; this.name = path.split('/').pop() ?? path; }
+  isRoot(): boolean { return this.path === ''; }
+}
+
+type Handler = (...args: any[]) => void;
+class Events {
+  private handlers = new Map<string, Set<Handler>>();
+  on(name: string, cb: Handler): { name: string; cb: Handler } {
+    if (!this.handlers.has(name)) this.handlers.set(name, new Set());
+    this.handlers.get(name)!.add(cb);
+    return { name, cb };
+  }
+  off(name: string, cb: Handler): void { this.handlers.get(name)?.delete(cb); }
+  offref(ref: { name: string; cb: Handler }): void { this.off(ref.name, ref.cb); }
+  trigger(name: string, ...args: any[]): void { for (const cb of [...(this.handlers.get(name) ?? [])]) cb(...args); }
+}
+
+// ── minimal YAML: scalars, inline arrays, block lists, one nested map level ──
+const parseScalar = (raw: string): unknown => {
+  const s = raw.trim();
+  if (s === '' ) return '';
+  if (s === 'null' || s === '~') return null;
+  if (s === 'true') return true;
+  if (s === 'false') return false;
+  if (/^-?\d+(\.\d+)?$/.test(s)) return Number(s);
+  if (/^\[.*\]$/.test(s)) return s.slice(1, -1).split(',').map((x) => parseScalar(x)).filter((x) => x !== '');
+  if (/^".*"$/.test(s) || /^'.*'$/.test(s)) return s.slice(1, -1);
+  return s;
+};
+export function parseYaml(text: string): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const lines = text.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line.trim() || line.trim().startsWith('#')) { i++; continue; }
+    const m = /^([^\s:][^:]*):\s?(.*)$/.exec(line);
+    if (!m) { i++; continue; }
+    const key = m[1].trim();
+    const rest = m[2];
+    if (rest.trim() !== '') { out[key] = parseScalar(rest); i++; continue; }
+    // block list or nested map
+    const items: unknown[] = [];
+    const map: Record<string, unknown> = {};
+    let isList = false; let isMap = false;
+    i++;
+    while (i < lines.length && /^\s+\S/.test(lines[i])) {
+      const inner = lines[i].trim();
+      if (inner.startsWith('- ')) { isList = true; items.push(parseScalar(inner.slice(2))); }
+      else { const mm = /^([^:]+):\s?(.*)$/.exec(inner); if (mm) { isMap = true; map[mm[1].trim()] = parseScalar(mm[2]); } }
+      i++;
+    }
+    out[key] = isList ? items : isMap ? map : null;
+  }
+  return out;
+}
+const quoteIfNeeded = (v: unknown): string => {
+  if (v === null || v === undefined) return 'null';
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  const s = String(v);
+  return /[:#\[\]{}]|^\s|\s$/.test(s) ? JSON.stringify(s) : s;
+};
+export function stringifyYaml(obj: Record<string, unknown>): string {
+  const lines: string[] = [];
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined) continue;
+    if (Array.isArray(v)) {
+      if (!v.length) { lines.push(`${k}: []`); continue; }
+      lines.push(`${k}:`); for (const it of v) lines.push(`  - ${quoteIfNeeded(it)}`);
+    } else if (v && typeof v === 'object') {
+      lines.push(`${k}:`); for (const [kk, vv] of Object.entries(v as Record<string, unknown>)) lines.push(`  ${kk}: ${Array.isArray(vv) ? `[${vv.map(quoteIfNeeded).join(', ')}]` : quoteIfNeeded(vv)}`);
+    } else lines.push(`${k}: ${quoteIfNeeded(v)}`);
+  }
+  return lines.join('\n') + '\n';
+}
+const splitFrontmatter = (text: string): { fm: string | null; body: string } => {
+  if (!text.startsWith('---\n')) return { fm: null, body: text };
+  const end = text.indexOf('\n---', 4);
+  if (end < 0) return { fm: null, body: text };
+  const after = end + 4;
+  return { fm: text.slice(4, end + 1), body: text.slice(after).replace(/^\n/, '') };
+};
+
+export interface CachedMetadata { frontmatter?: Record<string, unknown>; tags?: Array<{ tag: string }> }
+export function getAllTags(cache: CachedMetadata | null): string[] | null {
+  if (!cache) return null;
+  const out = new Set<string>();
+  const fmTags = cache.frontmatter?.tags;
+  for (const t of Array.isArray(fmTags) ? fmTags : typeof fmTags === 'string' ? [fmTags] : []) out.add(String(t).startsWith('#') ? String(t) : `#${t}`);
+  for (const t of cache.tags ?? []) out.add(t.tag);
+  return [...out];
+}
+
+export class Vault extends Events {
+  files = new Map<string, TFile>();
+  contents = new Map<string, string>();
+  folders = new Set<string>(['']);
+  now: () => number = () => Date.now();
+  writes = 0;
+  adapter = {
+    exists: async (p: string) => this.files.has(normalizePath(p)) || this.folders.has(normalizePath(p)),
+    read: async (p: string) => { const c = this.contents.get(normalizePath(p)); if (c === undefined) throw new Error(`ENOENT ${p}`); return c; },
+    stat: async (p: string) => { const f = this.files.get(normalizePath(p)); return f ? { ...f.stat, type: 'file' } : null; },
+    mkdir: async (p: string) => { this.folders.add(normalizePath(p)); },
+    write: async (p: string, data: string) => { await this.writeRaw(normalizePath(p), data); },
+    remove: async (p: string) => { const f = this.files.get(normalizePath(p)); if (f) await this.delete(f); },
+  };
+  private async writeRaw(path: string, data: string): Promise<TFile> {
+    const existing = this.files.get(path);
+    this.contents.set(path, data);
+    this.writes++;
+    if (existing) {
+      existing.stat = { ...existing.stat, mtime: this.now(), size: data.length };
+      this.trigger('modify', existing);
+      (this as any).__cache?.invalidate(existing);
+      return existing;
+    }
+    const file = new TFile(path, this, this.now());
+    this.files.set(path, file);
+    this.ensureFolders(path);
+    this.trigger('create', file);
+    (this as any).__cache?.invalidate(file);
+    return file;
+  }
+  private ensureFolders(path: string): void {
+    const segs = path.split('/').slice(0, -1);
+    let dir = '';
+    for (const s of segs) { dir = dir ? `${dir}/${s}` : s; this.folders.add(dir); }
+  }
+  getAbstractFileByPath(p: string): TFile | TFolder | null {
+    const n = normalizePath(p);
+    return this.files.get(n) ?? (this.folders.has(n) ? new TFolder(n) : null);
+  }
+  getMarkdownFiles(): TFile[] { return [...this.files.values()].filter((f) => f.extension === 'md'); }
+  getFiles(): TFile[] { return [...this.files.values()]; }
+  async read(f: TFile): Promise<string> { return this.adapter.read(f.path); }
+  async cachedRead(f: TFile): Promise<string> { return this.adapter.read(f.path); }
+  async create(path: string, data: string): Promise<TFile> {
+    const n = normalizePath(path);
+    if (this.files.has(n)) throw new Error(`File already exists: ${n}`);
+    return this.writeRaw(n, data);
+  }
+  async modify(f: TFile, data: string): Promise<void> { await this.writeRaw(f.path, data); }
+  async process(f: TFile, fn: (data: string) => string): Promise<string> {
+    const cur = await this.adapter.read(f.path);
+    const next = fn(cur);
+    if (next !== cur) await this.writeRaw(f.path, next);
+    return next;
+  }
+  async delete(f: TFile): Promise<void> {
+    this.files.delete(f.path); this.contents.delete(f.path);
+    (this as any).__cache?.forget(f.path);
+    this.trigger('delete', f);
+  }
+  /** A move or rename: the file keeps its stat (mtime untouched), like a real filesystem move. */
+  async rename(f: TFile, newPath: string): Promise<void> {
+    const oldPath = f.path;
+    const n = normalizePath(newPath);
+    this.files.delete(oldPath);
+    const content = this.contents.get(oldPath) ?? '';
+    this.contents.delete(oldPath);
+    f.setPath(n);
+    this.files.set(n, f);
+    this.contents.set(n, content);
+    this.ensureFolders(n);
+    (this as any).__cache?.forget(oldPath);
+    (this as any).__cache?.invalidate(f);
+    this.trigger('rename', f, oldPath);
+  }
+}
+
+export class MetadataCache extends Events {
+  private cache = new Map<string, CachedMetadata>();
+  constructor(private vault: Vault) { super(); (vault as any).__cache = this; }
+  private compute(f: TFile): CachedMetadata {
+    const text = this.vault.contents.get(f.path) ?? '';
+    const { fm, body } = splitFrontmatter(text);
+    const out: CachedMetadata = {};
+    if (fm !== null) out.frontmatter = parseYaml(fm);
+    const tags: Array<{ tag: string }> = [];
+    for (const m of body.matchAll(/(^|\s)(#[A-Za-z][\w/-]*)/g)) tags.push({ tag: m[2] });
+    if (tags.length) out.tags = tags;
+    return out;
+  }
+  invalidate(f: TFile): void { this.cache.set(f.path, this.compute(f)); this.trigger('changed', f); }
+  forget(path: string): void { this.cache.delete(path); }
+  getFileCache(f: TFile): CachedMetadata | null {
+    if (!this.vault.files.has(f.path)) return null;
+    if (!this.cache.has(f.path)) this.cache.set(f.path, this.compute(f));
+    return this.cache.get(f.path)!;
+  }
+  getFirstLinkpathDest(linkpath: string, _from: string): TFile | null {
+    const n = normalizePath(linkpath);
+    const direct = this.vault.files.get(n.endsWith('.md') ? n : `${n}.md`);
+    if (direct) return direct;
+    for (const f of this.vault.getMarkdownFiles()) if (f.basename === n) return f;
+    return null;
+  }
+}
+
+export class MarkdownView {
+  file: TFile;
+  private data: string;
+  constructor(file: TFile, data: string) { this.file = file; this.data = data; }
+  getViewData(): string { return this.data; }
+  setViewData(d: string): void { this.data = d; }
+  editor = { getCursor: () => ({ line: 0, ch: 0 }), hasFocus: () => false };
+}
+export class WorkspaceLeaf { constructor(public view: unknown) {} }
+export class Workspace extends Events {
+  private leaves: WorkspaceLeaf[] = [];
+  activeFile: TFile | null = null;
+  onLayoutReady(cb: () => void): void { cb(); }
+  getLeavesOfType(_type: string): WorkspaceLeaf[] { return this.leaves; }
+  getActiveFile(): TFile | null { return this.activeFile; }
+  /** Test control: open an editor whose buffer shows `data` (dirty when it differs from disk). */
+  openEditor(file: TFile, data: string): MarkdownView { const v = new MarkdownView(file, data); this.leaves.push(new WorkspaceLeaf(v)); return v; }
+  closeEditors(): void { this.leaves = []; }
+  getLeaf(): { openFile: (f: TFile) => Promise<void> } { return { openFile: async () => {} }; }
+}
+
+export class FileManager {
+  constructor(private vault: Vault) {}
+  async processFrontMatter(file: TFile, fn: (fm: Record<string, unknown>) => void): Promise<void> {
+    const text = await this.vault.read(file);
+    const { fm, body } = splitFrontmatter(text);
+    const obj = fm !== null ? parseYaml(fm) : {};
+    fn(obj);
+    const yaml = stringifyYaml(obj);
+    const next = Object.keys(obj).length ? `---\n${yaml}---\n${body}` : body;
+    if (next !== text) await this.vault.modify(file, next);
+  }
+}
+
+export class App {
+  vault = new Vault();
+  metadataCache = new MetadataCache(this.vault);
+  workspace = new Workspace();
+  fileManager = new FileManager(this.vault);
+  plugins = { plugins: {} as Record<string, unknown> };
+}
+
+export const Platform = { isDesktopApp: false, isMobile: false, isMobileApp: false };
+export class Notice { constructor(public message: string) { notices.push(message); } }
+export const notices: string[] = [];
+export class Modal { constructor(public app: App) {} open(): void {} close(): void {} contentEl = { empty() {}, createEl() { return {} as any; } }; }
+export class FuzzySuggestModal<T> extends Modal { getItems(): T[] { return []; } getItemText(_i: T): string { return ''; } onChooseItem(_i: T): void {} }
+export class Plugin { constructor(public app: App, public manifest: unknown) {} }
+export class PluginSettingTab { containerEl = {} as any; constructor(public app: App, public plugin: Plugin) {} }
+export class Setting { constructor(_el: unknown) {} setName() { return this; } setDesc() { return this; } addText() { return this; } addTextArea() { return this; } addToggle() { return this; } addDropdown() { return this; } addButton() { return this; } }
+export class ItemView { constructor(public leaf: WorkspaceLeaf) {} }
+export const Keymap = { isModEvent: () => false };
+
+// ── requestUrl → the test's fake server ─────────────────────────────────────
+export interface StubResponse { status: number; json: unknown; text: string; headers: Record<string, string> }
+type RequestHandler = (req: { url: string; method: string; headers: Record<string, string>; body?: string }) => Promise<StubResponse> | StubResponse;
+let handler: RequestHandler | null = null;
+export function __setRequestHandler(h: RequestHandler | null): void { handler = h; }
+export async function requestUrl(req: { url: string; method?: string; headers?: Record<string, string>; body?: string; throw?: boolean }): Promise<StubResponse> {
+  if (!handler) throw new Error(`requestUrl: no fake server registered (${req.method ?? 'GET'} ${req.url})`);
+  const res = await handler({ url: req.url, method: req.method ?? 'GET', headers: req.headers ?? {}, body: req.body });
+  if (req.throw !== false && res.status >= 400) throw Object.assign(new Error(`Request failed, status ${res.status}`), { status: res.status });
+  return res;
+}

--- a/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
+++ b/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
@@ -1,0 +1,363 @@
+// Bridge scenario harness: the vault task scope, end to end (companion §6).
+// The real plugin transport stamps and reports a stub vault; the real
+// dayGLANCE sync hook consumes the stream through the real bridge modules
+// against one in-memory GLANCEvault. These are the field-test steps of
+// 2026-09-04, scripted.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const effects: Array<{ fn: () => unknown; deps?: unknown[] }> = [];
+vi.mock('react', () => ({
+  useEffect: (fn: () => unknown, deps?: unknown[]) => { effects.push({ fn, deps }); },
+  useCallback: (fn: unknown) => fn,
+  useRef: (init: unknown) => ({ current: init }),
+}));
+// Direct vault access is OFF on every device: the plugin is authoritative
+// for the whole scenario (a fresh, paired heartbeat every cycle).
+vi.mock('../../src/obsidian.js', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    tryRestoreVaultAccess: vi.fn(async () => null),
+    getVaultAccess: vi.fn(async () => null),
+    syncObsidianVault: vi.fn(async () => ({ dailyNotes: {}, scheduledTasks: [], inboxTasks: [] })),
+    syncObsidianVaultNative: vi.fn(async () => null),
+    writeTaskStateToFile: vi.fn(async () => true),
+    writeTaskStateNative: vi.fn(() => false),
+    readWikiNote: vi.fn(async () => null),
+    writeWikiNote: vi.fn(async () => {}),
+    scanVaultNotes: vi.fn(async () => ({ names: [], unportable: [] })),
+    vaultHasTasksPlugin: vi.fn(async () => false),
+    detectTasksPluginNative: vi.fn(() => null),
+    readVaultHeartbeat: vi.fn(async () => ({ paired: true, tsMs: Date.now(), accountId: 'acc-1', deviceId: 'plugin-dev' })),
+    readVaultHeartbeatNative: vi.fn(() => null),
+  };
+});
+vi.mock('../../src/native.js', () => ({
+  isNativeAndroid: () => false,
+  isNativeApp: () => false,
+  nativeGetVaultConfig: vi.fn(() => null),
+  nativeGetNote: vi.fn(() => null),
+  nativeWriteNote: vi.fn(),
+  nativeOpenNote: vi.fn(),
+  nativeListNotes: vi.fn(() => []),
+  nativeSetVaultSettings: vi.fn(),
+  nativeSetLaunchOnWrite: vi.fn(),
+}));
+vi.mock('../../src/utils/obsidianBridgeMode.js', () => ({
+  recordBridgeMode: vi.fn(),
+  reconcileArchivedBaseline: vi.fn(() => null),
+}));
+
+const { createScenario, VAULT_URL, ACCOUNT_ID, until, advanceFake } = await import('./harness');
+const { default: useObsidianSync } = await import('../../src/hooks/useObsidianSync.js');
+const { flushBridgeOutbox, __resetBridgeStreamForTests } = await import('../../src/utils/obsidianBridgeStream.js');
+const { PROJECT_NOTE_ID_KEY } = await import('@glance-apps/obsidian-format');
+void PROJECT_NOTE_ID_KEY;
+
+type Task = Record<string, any>;
+
+
+/** A dayGLANCE device: its own localStorage and task lists, the real sync hook. */
+function mountDevice(name: string) {
+  const store = new Map<string, string>();
+  const ls = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => store.clear(),
+  };
+  // The device's storage stays installed until another device runs: the
+  // hook fires several fire-and-forget tails (config publish, outbox flush,
+  // projection) that outlive the awaited cycle and read localStorage late.
+  const activate = () => { (globalThis as any).localStorage = ls; };
+  const run = async <T,>(fn: () => Promise<T> | T): Promise<T> => {
+    activate();
+    const out = await fn();
+    await advanceFake(300); // let the cycle's tails land
+    return out;
+  };
+
+  ls.setItem('dayglance-vault-config', JSON.stringify({ enabled: true, vaultUrl: VAULT_URL, vaultToken: `token-${name}`, accountId: ACCOUNT_ID }));
+  const state = { tasks: [] as Task[], inbox: [] as Task[], recycleBin: [] as Task[] };
+  const log: string[] = [];
+  const tasksRef = { current: state.tasks };
+  const inboxRef = { current: state.inbox };
+  // In place: the mocked React never re-renders, so the hook's effects keep
+  // the arrays they were mounted with (the app re-renders with fresh lists).
+  const replace = (arr: Task[], next: Task[]) => { arr.splice(0, arr.length, ...next); };
+  const setTasks = (up: Task[] | ((p: Task[]) => Task[])) => { replace(state.tasks, typeof up === 'function' ? up([...state.tasks]) : up); };
+  const setUnscheduledTasks = (up: Task[] | ((p: Task[]) => Task[])) => { replace(state.inbox, typeof up === 'function' ? up([...state.inbox]) : up); };
+  const setRecycleBin = (up: Task[] | ((p: Task[]) => Task[])) => { state.recycleBin = typeof up === 'function' ? up(state.recycleBin) : up; };
+  const syncRef = { current: false };
+  const prevRef = { current: {} as Record<string, unknown> };
+  effects.length = 0;
+  activate();
+  const api = useObsidianSync({
+    isTrayMode: false, dataLoaded: true,
+    tasks: state.tasks, setTasks,
+    unscheduledTasks: state.inbox, setUnscheduledTasks,
+    setDailyNotes: vi.fn(), setWikilinkCandidates: vi.fn(), setUnportableVaultFiles: vi.fn(),
+    obsidianConfig: { enabled: true, dailyNotesPath: 'Daily', dailyNotePattern: 'yyyy-MM-dd', taskHeading: '## Tasks' },
+    setObsidianConfig: vi.fn(), obsidianLaunchOnWrite: null,
+    obsidianCompletionDates: false,
+    obsidianSyncError: null,
+    setObsidianSyncStatus: (v: unknown) => { log.push(`status:${typeof v === 'function' ? '(fn)' : String(v)}@${Date.now() % 100000}`); },
+    setObsidianSyncError: (v: unknown) => { log.push(`error:${typeof v === 'function' ? '(fn)' : String(v)}@${Date.now() % 100000}`); },
+    setObsidianLastSynced: vi.fn(),
+    setObsidianSyncNotice: (v: unknown) => { log.push(`notice:${JSON.stringify(v)}`); },
+    obsidianVaultHandleRef: { current: {} },
+    obsidianSyncInProgressRef: syncRef,
+    obsidianPrevTaskStateRef: prevRef,
+    obsidianTasksRef: tasksRef, obsidianInboxRef: inboxRef,
+    recycleBin: state.recycleBin, setRecycleBin,
+  });
+  const myEffects = [...effects];
+  api.bridgeHeartbeatRef.current = { obsidianRunning: true, pluginAuthoritative: true };
+  return {
+    name, state, api, store, log,
+    sync: () => run(() => until(api.performObsidianSync())),
+    /** Run the writeback effect against the current lists, then push the outbox to the vault. */
+    writeback: () => run(async () => {
+      for (const e of myEffects) if (e.deps?.length === 3) e.fn();
+      await advanceFake(50);
+      await until(flushBridgeOutbox());
+    }),
+    setTasks, setUnscheduledTasks,
+    /** dayGLANCE-side edits, as the UI would make them (fresh lastModified). */
+    schedule: (id: string, date: string) => {
+      const t = state.inbox.find((x) => x.id === id) ?? state.tasks.find((x) => x.id === id);
+      if (!t) throw new Error(`no task ${id}`);
+      setUnscheduledTasks((p) => p.filter((x) => x.id !== id));
+      setTasks((p) => [...p.filter((x) => x.id !== id), { ...t, date, isAllDay: true, startTime: undefined, lastModified: new Date().toISOString() }]);
+    },
+    unschedule: (id: string) => {
+      const t = state.tasks.find((x) => x.id === id);
+      if (!t) throw new Error(`no task ${id}`);
+      const { date: _d, isAllDay: _a, startTime: _s, ...rest } = t;
+      setTasks((p) => p.filter((x) => x.id !== id));
+      setUnscheduledTasks((p) => [...p, { ...rest, lastModified: new Date().toISOString() }]);
+    },
+    patch: (id: string, fields: Task) => {
+      const bump = (list: Task[]) => list.map((x) => (x.id === id ? { ...x, ...fields, lastModified: new Date().toISOString() } : x));
+      setTasks(bump); setUnscheduledTasks(bump);
+    },
+    all: () => [...state.tasks, ...state.inbox],
+    byPath: (p: string) => [...state.tasks, ...state.inbox].filter((t) => t.obsidianNotePath === p),
+  };
+}
+
+const NOTE = 'Projects/House.md';
+const LINE = 'Call the plumber';
+
+let s: Awaited<ReturnType<typeof createScenario>>;
+let A: ReturnType<typeof mountDevice>;
+
+/** Bring both sides up: meta row, app config row, plugin config adopted (armed), scope set, the note stamped and imported. */
+async function bootWithScopedNote(content = `# House\n\n- [ ] ${LINE}\n`): Promise<void> {
+  await s.plugin.transport.drain();       // publishes meta:pairing
+  A = mountDevice('A');
+  await A.sync();                          // reads the meta, publishes meta:config
+  for (let i = 0; i < 5 && s.plugin.transport.stampingState() !== 'armed'; i++) {
+    await s.advance(1000);
+    await s.plugin.transport.drain();     // adopts the config (stamping armed)
+  }
+  if (s.plugin.transport.stampingState() !== 'armed') {
+    const syncPkg = await import('@glance-apps/sync');
+    throw new Error(`boot: plugin not armed (${s.plugin.transport.stampingState()}); rows ${s.vault.all('dayglance-bridge').map((r) => r.entityId).join(',')}; `
+      + `rateLimited=${syncPkg.isVaultRateLimited()} rootKey=${syncPkg.hasDbRootKey()} metaCache=${A.store.get('dayglance-bridge-pairing-meta')} `
+      + `log=${A.log.join(' ')} heartbeat=${JSON.stringify(A.api.bridgeHeartbeatRef.current)} requests=${s.vault.requests.map((r) => `${r.who}:${r.method} ${r.path.replace('/sync/dayglance-bridge/', '')}@${r.at % 100000}`).join(',')}`);
+  }
+  await s.write(NOTE, content);
+  await s.plugin.setScope({ folders: ['Projects'] });
+  await s.settle();
+  await A.sync();
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers({ now: new Date('2026-09-04T12:00:00.000Z') });
+  vi.stubGlobal('window', globalThis);
+  vi.stubGlobal('document', { addEventListener: () => {}, removeEventListener: () => {}, visibilityState: 'visible' });
+  vi.stubGlobal('requestAnimationFrame', (cb: () => void) => { cb(); return 1; });
+  vi.stubGlobal('setInterval', () => 1);
+  vi.stubGlobal('clearInterval', () => {});
+  __resetBridgeStreamForTests(); // module-level guards (publish-once, subkey cache) must not leak between scenarios
+  s = await createScenario();
+});
+afterEach(() => {
+  s.plugin.shutdown();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('vault task scope, end to end', () => {
+  it('1. a note entering the scope is stamped by the plugin and imported by dayGLANCE under its stamped id', async () => {
+    await bootWithScopedNote();
+    expect(s.text(NOTE)).toMatch(/Call the plumber \^dg-[a-z0-9]{8}/);
+    const mine = A.byPath(NOTE);
+    expect(mine).toHaveLength(1);
+    expect(mine[0].id).toMatch(/^obsidian-dg-/);
+    expect(mine[0].date).toBeUndefined();
+    expect(A.state.inbox).toHaveLength(1);
+  });
+
+  it('2. a rename within the scope keeps the task, under the same id, at the new path', async () => {
+    await bootWithScopedNote();
+    const id = A.byPath(NOTE)[0].id;
+    await s.plugin.app.vault.rename(s.file(NOTE), 'Projects/Home.md');
+    await s.settle();
+    await A.sync();
+    await s.advance(95_000);
+    await A.sync();
+    expect(A.all()).toHaveLength(1);
+    expect(A.all()[0]).toMatchObject({ id, obsidianNotePath: 'Projects/Home.md' });
+  });
+
+  it('3. a note moved OUT of the scope withdraws its tasks; moved BACK, they return under the same ids (the 2026-09-04 field bug)', async () => {
+    await bootWithScopedNote();
+    const id = A.byPath(NOTE)[0].id;
+    await s.plugin.app.vault.rename(s.file(NOTE), 'Archive/House.md');
+    await s.settle();
+    await A.sync();
+    expect(A.all()).toHaveLength(0);
+    // The vault line is untouched (a withdrawal deletes nothing).
+    expect(s.text('Archive/House.md')).toMatch(/\^dg-/);
+
+    await s.plugin.app.vault.rename(s.file('Archive/House.md'), NOTE);
+    await s.settle();
+    await A.sync();
+    expect(A.all()).toHaveLength(1);
+    expect(A.all()[0]).toMatchObject({ id, obsidianNotePath: NOTE });
+  });
+
+  it('4. a deleted note drops its tasks after the wall-clock confirmation hold', async () => {
+    await bootWithScopedNote();
+    await s.plugin.app.vault.delete(s.file(NOTE));
+    await s.settle();
+    await A.sync();
+    expect(A.all()).toHaveLength(1); // the hold: not yet
+    await s.advance(95_000);
+    await A.sync();
+    expect(A.all()).toHaveLength(0);
+  });
+
+  it('5. scheduling from dayGLANCE writes the date as line metadata; clearing it removes the segment and nothing else', async () => {
+    await bootWithScopedNote();
+    const id = A.byPath(NOTE)[0].id;
+    A.schedule(id, '2026-09-10');
+    await A.writeback();
+    await s.plugin.transport.drain();
+    expect(s.text(NOTE)).toMatch(/- \[ \] Call the plumber \[scheduled:: 2026-09-10\] \^dg-/);
+    await s.settle();
+    await A.sync();
+    expect(A.state.tasks.map((t) => t.id)).toEqual([id]);
+    expect(A.state.tasks[0]).toMatchObject({ date: '2026-09-10', title: 'Call the plumber #obsidian' });
+    expect(A.state.inbox).toHaveLength(0);
+
+    A.unschedule(id);
+    await A.writeback();
+    await s.plugin.transport.drain();
+    expect(s.text(NOTE)).toMatch(/- \[ \] Call the plumber \^dg-/);
+    expect(s.text(NOTE)).not.toMatch(/scheduled::/);
+    await s.settle();
+    await A.sync();
+    expect(A.state.tasks).toHaveLength(0);
+    expect(A.state.inbox.map((t) => t.id)).toEqual([id]);
+  });
+
+  it('6. a second device sees the same task, and after a schedule on the first sees ONE scheduled copy and no inbox copy', async () => {
+    await bootWithScopedNote();
+    const id = A.byPath(NOTE)[0].id;
+    const B = mountDevice('B');
+    await B.sync();
+    expect(B.state.inbox.map((t) => t.id)).toEqual([id]);
+    expect(B.state.tasks).toHaveLength(0);
+
+    A.schedule(id, '2026-09-10');
+    await A.writeback();
+    await s.plugin.transport.drain();
+    await s.settle();
+    await B.sync();
+    expect(B.state.tasks.map((t) => t.id)).toEqual([id]);
+    expect(B.state.tasks[0].date).toBe('2026-09-10');
+    expect(B.state.inbox).toHaveLength(0);
+  });
+
+  it('7. the completion window: recent completed lines are stamped and imported, old and undated ones are left alone', async () => {
+    await bootWithScopedNote(['# House', '', '- [ ] Open forever', '- [x] Recent ✅ 2026-08-30', '- [x] Ancient ✅ 2024-01-01', '- [x] Undated done', ''].join('\n'));
+    const text = s.text(NOTE)!;
+    expect(text).toMatch(/Open forever \^dg-/);
+    expect(text).toMatch(/Recent ✅ 2026-08-30 \^dg-/);
+    expect(text).toMatch(/- \[x\] Ancient ✅ 2024-01-01\n/);
+    expect(text).toMatch(/- \[x\] Undated done\n/);
+    const titles = A.all().map((t) => String(t.title).replace(/ #obsidian$/, '')).sort();
+    expect(titles).toEqual(['Open forever', 'Recent']);
+    expect(A.all().find((t) => t.title.startsWith('Recent'))?.completed).toBe(true);
+  });
+
+  it('8. idle: ten minutes of ticks with nothing changing writes no rows, no files, and no data.json', async () => {
+    await bootWithScopedNote();
+    const seq = s.vault.maxSeq;
+    const saves = s.plugin.data.saves;
+    const writes = s.plugin.app.vault.writes;
+    const text = s.text(NOTE);
+    for (let i = 0; i < 20; i++) {
+      await s.plugin.transport.drain();
+      s.plugin.transport.adoptTick();
+      s.plugin.transport.linkTick();
+      await s.advance(30_000);
+      if (i % 10 === 9) await A.sync();
+    }
+    expect(s.vault.maxSeq).toBe(seq);
+    expect(s.plugin.data.saves).toBe(saves);
+    expect(s.plugin.app.vault.writes).toBe(writes);
+    expect(s.text(NOTE)).toBe(text);
+    expect(A.all()).toHaveLength(1);
+  });
+
+  it('10. retitle from dayGLANCE reaches the line; a retitle and a completion in Obsidian reach dayGLANCE under the same id', async () => {
+    await bootWithScopedNote();
+    const id = A.byPath(NOTE)[0].id;
+    A.patch(id, { title: 'Call the electrician #obsidian' });
+    await A.writeback();
+    await s.plugin.transport.drain();
+    expect(s.text(NOTE)).toMatch(/- \[ \] Call the electrician \^dg-/);
+    await s.settle();
+    await A.sync();
+    expect(A.all().map((t) => t.id)).toEqual([id]);
+    expect(A.all()[0].title).toBe('Call the electrician #obsidian');
+
+    // Obsidian side: retitle and check the box by hand. (Completion is OR
+    // across the two sides by ruled design: a box checked in either place
+    // completes the task; unchecking in Obsidian does not reopen it.)
+    const edited = s.text(NOTE)!.replace('- [ ] Call the electrician', '- [x] Call the plumber again');
+    await s.write(NOTE, edited);
+    await s.settle();
+    await A.sync();
+    expect(A.all().map((t) => t.id)).toEqual([id]);
+    expect(A.all()[0]).toMatchObject({ completed: true, title: 'Call the plumber again #obsidian' });
+  });
+
+  it('11. completing from dayGLANCE checks the box in the note', async () => {
+    await bootWithScopedNote();
+    const id = A.byPath(NOTE)[0].id;
+    A.patch(id, { completed: true, completedAt: new Date().toISOString() });
+    await A.writeback();
+    await s.plugin.transport.drain();
+    expect(s.text(NOTE)).toMatch(/- \[x\] Call the plumber \^dg-/);
+    await s.settle();
+    await A.sync();
+    expect(A.all().map((t) => t.id)).toEqual([id]);
+    expect(A.all()[0].completed).toBe(true);
+  });
+
+  it('9. a plugin reload republishes the pairing meta WITH the scope (harness finding)', async () => {
+    await bootWithScopedNote();
+    s.plugin.reload();
+    await s.plugin.transport.drain();
+    const row = s.vault.live('dayglance-bridge').find((r) => r.entityId === 'meta:pairing');
+    const meta = JSON.parse(atob(row!.envelope!));
+    expect(meta.scope).toMatchObject({ folders: ['Projects'] });
+  });
+});

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -1007,6 +1007,33 @@ arrival. Daily notes are untouched. *Remaining gap, recorded:* an arrival is
 memory-only, so a note moved back while the plugin is closed and then left
 unedited reports its old mtime after the reload; an edit revives it.
 
+**The scenario harness (2026-09-04, built).** The field-test checklist is
+now scripted: `dayglance-obsidian-plugin/test/` holds a stub of the
+`obsidian` module (an in-memory vault with the plugin's events, a metadata
+cache that parses frontmatter and tags, editors the test opens on purpose),
+an in-memory GLANCEvault serving the row endpoints, and a scenario runner
+that stands up the REAL plugin transport and any number of dayGLANCE
+"devices" running the REAL sync hook through the real bridge modules, under
+fake time. `scope.scenarios.test.ts` covers adoption and stamping, rename,
+move out and back (the field bug above, pinned), deletion with the hold,
+schedule-as-metadata and its removal, a second device, the completion
+window, ten idle minutes with no churn, retitle and completion in both
+directions, and the reload republish. What stays manual, by design:
+Obsidian Sync replication timing, real editor buffers, the metadata cache's
+own latency, Templater. *Three findings on the first run, all fixed:* the
+drain republished the pairing-meta row BARE after every plugin reload,
+dropping the viewer override and the task scope until the settings were
+touched; a scoped note was reported while the config row was still unknown
+(the fragment factory one scope over — the config-null hold now covers
+scoped notes); and **ruling E is amended in implementation**: the
+completion window governs ADOPTION only — a line already carrying a block
+id is tracked, so a tracked task checked off by hand in Obsidian with no
+completion date is adopted as completed instead of vanishing from the
+parse and being inferred deleted. *Harness caveat, recorded:* both sides
+share one process, so module singletons (the root key, the brake, the
+own-write ring) are one instance; the plugin's own copy of the sync package
+is aliased to the app's for tests.
+
 **The TaskForge reference point** stands from the earlier text: discovery
 was never the hard part; identity is what buys cross-device durability
 through retitles, deletes and revivals, and it is what this section pays for.

--- a/packages/obsidian-format/src/noteScope.test.js
+++ b/packages/obsidian-format/src/noteScope.test.js
@@ -122,4 +122,16 @@ describe('completion window', () => {
     // Daily notes are never windowed: the option is simply not passed.
     expect(stampUntaggedTaskLines(content, '2026-09-02').stamped).toHaveLength(4);
   });
+
+  it('a TRACKED (block-tagged) completed line is imported whatever its date: the window governs adoption, not tracking', () => {
+    const content = [
+      '- [x] Checked by hand, no date ^dg-11111111',
+      '- [x] Ancient but tracked ✅ 2024-01-01 ^dg-22222222',
+      '- [x] Untracked and undated',
+    ].join('\n');
+    const { inboxTasks } = parseTasksFromMarkdown(content, '2026-09-02', new Set(), { notePath: 'Projects/House.md', completedSince: '2026-08-03' });
+    expect(inboxTasks.map((t) => [appIdForBlockId(t.obsidianBlockId), t.completed])).toEqual([
+      [appIdForBlockId('11111111'), true], [appIdForBlockId('22222222'), true],
+    ]);
+  });
 });

--- a/packages/obsidian-format/src/taskLines.js
+++ b/packages/obsidian-format/src/taskLines.js
@@ -342,9 +342,17 @@ export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(
     if (!match) continue;
 
     const completed = match[1] !== ' ';
-    // Completion window (ruling E): in a non-daily note, a completed line
-    // outside the window — or with no completion date — is not a task.
-    if (notePath && completedSince && completed && !completedLineInWindow(splitBlockId(match[2].trim()).text, completedSince)) continue;
+    // Completion window (ruling E): in a non-daily note, an UNTRACKED
+    // completed line outside the window — or with no completion date — is
+    // not a task. A line already carrying a block id is tracked: dayGLANCE
+    // knows it, so its completion is adopted whatever the line's date says
+    // (harness finding, 2026-09-04: a tracked task checked off by hand in
+    // Obsidian, with no ✅ date, vanished from the parse and would have been
+    // inferred deleted). The window governs adoption, not tracking.
+    if (notePath && completedSince && completed) {
+      const { text: body, blockId } = splitBlockId(match[2].trim());
+      if (!blockId && !completedLineInWindow(body, completedSince)) continue;
+    }
     let rawTitle = match[2].trim();
 
     // Strip a trailing ^dg-<id> block reference BEFORE any other parsing, so

--- a/src/utils/obsidianBridgeInbound.test.js
+++ b/src/utils/obsidianBridgeInbound.test.js
@@ -192,10 +192,11 @@ describe('applyBridgeObservations — vault task scope (companion §6)', () => {
     '- [ ] Call the plumber ^dg-aaaaaaaa',
     '- [ ] Order tiles ⏳ 2026-09-12 ^dg-bbbbbbbb',
     '- [x] Pick paint ✅ 2026-08-30 ^dg-cccccccc',
-    '- [x] Ancient ✅ 2024-01-01 ^dg-dddddddd',
+    '- [x] Ancient but tracked ✅ 2024-01-01 ^dg-dddddddd',
+    '- [x] Ancient and untracked ✅ 2024-01-01',
   ].join('\n');
 
-  it('a scoped note parses under its path: dateless lines are inbox, ⏳ schedules, old completions drop, no daily-note entry is made', () => {
+  it('a scoped note parses under its path: dateless lines are inbox, ⏳ schedules, an UNTRACKED old completion drops (a tracked one is kept), no daily-note entry is made', () => {
     const out = applyBridgeObservations(
       [{ path: 'Projects/House.md', content: HOUSE, mtime: 1756400000000, observedAt: '2026-09-02T12:00:00Z', scoped: true }],
       { existingTasks: [], existingInbox: [], dailyNotesPath: 'Daily', scope: { completionWindowDays: 30 }, today: '2026-09-02' },
@@ -204,9 +205,12 @@ describe('applyBridgeObservations — vault task scope (companion §6)', () => {
     expect(out.scopedNotes['Projects/House.md']).toMatchObject({ lastModified: new Date(1756400000000).toISOString() });
     expect(out.scheduledTasks.map((t) => t.id)).toEqual(['obsidian-dg-bbbbbbbb']);
     expect(out.scheduledTasks[0]).toMatchObject({ date: '2026-09-12', obsidianNotePath: 'Projects/House.md' });
-    expect(out.inboxTasks.map((t) => t.id).sort()).toEqual(['obsidian-dg-aaaaaaaa', 'obsidian-dg-cccccccc']);
+    // The window governs ADOPTION: a block-tagged completion is tracked
+    // whatever its date (ruling E as amended by the harness finding).
+    expect(out.inboxTasks.map((t) => t.id).sort()).toEqual(['obsidian-dg-aaaaaaaa', 'obsidian-dg-cccccccc', 'obsidian-dg-dddddddd']);
     expect(out.inboxTasks.every((t) => t.obsidianNotePath === 'Projects/House.md' && t.obsidianFileDate === undefined)).toBe(true);
-    expect(out.scannedIds.has('obsidian-dg-dddddddd')).toBe(false);
+    expect(out.scannedIds.has('obsidian-dg-dddddddd')).toBe(true);
+    expect(out.inboxTasks.some((t) => t.title.startsWith('Ancient and untracked'))).toBe(false);
     expect(out.unapplied).toEqual([]);
   });
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,23 @@
+// Vitest config: the app's Vite config plus the bridge scenario harness
+// (dayglance-obsidian-plugin/test). The `obsidian` module has no runtime of
+// its own (Obsidian provides it in-process), so tests alias it to a stub.
+import { fileURLToPath } from 'node:url';
+import { mergeConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
+import viteConfig from './vite.config.js';
+
+export default mergeConfig(viteConfig, defineConfig({
+  resolve: {
+    alias: [
+      { find: 'obsidian', replacement: fileURLToPath(new URL('./dayglance-obsidian-plugin/test/obsidianStub.ts', import.meta.url)) },
+      // The plugin installs its own copy of @glance-apps/sync; in one test
+      // process both sides must share ONE instance (the root key, the brake,
+      // the own-write ring are module state).
+      { find: /^@glance-apps\/sync(\/.*)?$/, replacement: fileURLToPath(new URL('./node_modules/@glance-apps/sync', import.meta.url)) + '$1' },
+    ],
+  },
+  test: {
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    exclude: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/dist-electron/**'],
+  },
+}));


### PR DESCRIPTION
## Summary

The manual field-test checklist for the Obsidian bridge, scripted. The real plugin transport and the real `useObsidianSync` hook run against a stub Obsidian vault and an in-memory GLANCEvault, under fake time, in the ordinary vitest run. Eleven scenarios, about a second total.

### What runs for real
The plugin's `BridgeTransport` (stamping, the settle floor, observations, scope adoption and withdrawal, link following, intent applies), the shared format package, dayGLANCE's bridge stream and inbound modules (sealing, outbox, observation fetch, pairing-meta cache), and the sync hook's merge, deletion inference, withdrawal, revival and writeback.

### What is faked
- `dayglance-obsidian-plugin/test/obsidianStub.ts`: the `obsidian` module as an in-memory vault with create, modify, delete, rename and metadata-changed events; a metadata cache that parses frontmatter and tags; editors a test opens on purpose (for the dirty-buffer rule); `requestUrl` routed to the test's fake server.
- `test/fakeGlanceVault.ts`: batch, list, getRow, deleteRow with a monotonic seq and soft deletes, serving the plugin (via the stub) and the app (via a global fetch shim).
- `test/harness.ts`: the scenario runner; fake-time stepping that yields a real tick between steps so Web Crypto work lands before the clock moves.
- `vitest.config.js`: aliases `obsidian` to the stub and the plugin's private copy of `@glance-apps/sync` to the root one, so both sides share one module instance (root key, brake, own-write ring).

Still manual, by design: Obsidian Sync replication timing, real editor buffers, the metadata cache's own latency, Templater.

### Scenarios (`test/scope.scenarios.test.ts`)
1. Adoption: a note entering the scope is stamped and imported under its stamped id.
2. Rename within the scope keeps the task at the new path.
3. Move out and back: withdrawal, then return under the same ids (the 2026-09-04 field bug, pinned).
4. Deleted note drops its tasks after the wall-clock hold.
5. Schedule from dayGLANCE as line metadata; clearing removes only the segment.
6. Second device: same task, and one scheduled copy with no inbox copy after a schedule on the first.
7. Completion window: recent completions stamped and imported, old and undated ones left alone.
8. Ten idle minutes: no rows, no file writes, no data.json saves.
9. Plugin reload republishes the pairing meta with the scope.
10. Retitle from dayGLANCE; retitle and completion from Obsidian, same id.
11. Completion from dayGLANCE checks the box.

### Three findings on the first run, fixed here
- **Reload dropped the viewer and scope.** The drain republished the pairing-meta row bare after every plugin reload, so the app lost the completion window (and any viewer override) until the settings were touched. The transport host now supplies the viewer and the drain passes both.
- **Config-null hold missed scoped notes.** A scoped note was reported while the config row was still unknown, shipping untagged lines (the fragment factory one scope over). The hold now covers scoped notes.
- **Ruling E, amended in implementation.** The completion window governs adoption, not tracking: a block-tagged completed line is imported whatever its date. Before this, a tracked task checked off by hand in Obsidian with no completion date vanished from the parse and would have been inferred deleted after the hold. Untracked old or undated completions are still left alone. Recorded in §6.4.

### Verification
- Full suite green six times in a row after the fake-time fix (2835 tests). Lint clean. Plugin builds clean.
- Docs: §6.4 harness record, plugin README "Tests", `CLAUDE.md` note on when to add a scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_