### PR TITLE
Project notes: the project as a line field, a three-key map, default note bodies

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -76,12 +76,17 @@ manually or via BRAT, not submitted to the community directory.
   missing (dayGLANCE keeps the project and offers a relink), re-finds a
   note by its key on a periodic walk, and applies link and unlink requests
   made from dayGLANCE. A linked note also carries a `dayglance:` frontmatter
-  map the plugin maintains from its mirror (status, open, done, total,
-  percent, next scheduled date for a project; progress and its projects as
-  wikilinks for a goal), rewritten only when a value changes, at most once
-  every five minutes per note, never into unsaved edits. dayGLANCE wins
-  inside that map; nothing outside it is read or written. A project or goal
-  born in dayGLANCE can create its note here: the **Project and goal notes**
+  map the plugin maintains from its mirror: `kind`, `status`, and on a
+  project note `goal` (a wikilink to the goal's note when it is linked).
+  Counts and dates are deliberately not in it, so it is rewritten only when
+  a status or a goal assignment changes, at most once every five minutes
+  per note, never into unsaved edits. dayGLANCE wins inside that map;
+  nothing outside it is read or written. A project or goal born in
+  dayGLANCE can create its note here (the default body has a tasks
+  section, a completions section, notes, decisions and a dated log; with
+  Dataview installed the completions and, on a goal note, the projects
+  table and monthly progress are live queries, otherwise a plain sentence
+  stands in each place; chosen once at creation): the **Project and goal notes**
   settings choose the layout (one note; a folder with an index note; folders
   nested under the goal), the projects and goals folders, and optional
   template notes (rendered by Templater when it is installed and the

--- a/dayglance-obsidian-plugin/src/agenda.ts
+++ b/dayglance-obsidian-plugin/src/agenda.ts
@@ -67,9 +67,7 @@ const CRYPTO_DB_NAME = 'dayglance-bridge';
 // placed for and the day's completions.
 // Projects and goals ride the mirror too (companion §4.3): the link picker
 // lists them, and the maintained frontmatter block is rendered from them.
-// The inbox (unscheduledTasks) is mirrored for the BLOCK's counts only; the
-// agenda itself still shows scheduled work (the v1 scope ruling stands).
-const AGENDA_KINDS = new Set(['tasks', 'recurringTasks', 'todayRoutines', 'users', 'projects', 'goals', 'unscheduledTasks']);
+const AGENDA_KINDS = new Set(['tasks', 'recurringTasks', 'todayRoutines', 'users', 'projects', 'goals']);
 const SINGLETON_KIND = 'singleton';
 const AGENDA_SINGLETONS = new Set(['routinesDate', 'routineCompletions']);
 // Optimistic completion marks time out: dayGLANCE applies an action within
@@ -157,7 +155,6 @@ export class AgendaStore {
   private singletons = new Map<string, unknown>();
   private projectRows = new Map<string, TaskRow>();
   private goalRows = new Map<string, TaskRow>();
-  private inboxRows = new Map<string, TaskRow>();
   // Calendar projections (companion 4.2): read-only calendar events never
   // sync, so each dayGLANCE device publishes its view as a bridge-stream row
   // (`proj:calendar:<deviceId>`, sealed under the pairing subkey). Keyed by
@@ -245,17 +242,9 @@ export class AgendaStore {
     return out.sort((a, b) => a.title.localeCompare(b.title));
   }
 
-  /**
-   * Inputs for the maintained note block (companion §4.3, ruling C): every
-   * task of every user (the block counts the project, not the viewer's
-   * share of it), scheduled and inbox, plus projects and goals.
-   */
-  blockInputs(): { tasks: TaskRow[]; projects: TaskRow[]; goals: TaskRow[] } {
-    return {
-      tasks: [...this.tasks.values(), ...this.inboxRows.values()],
-      projects: [...this.projectRows.values()],
-      goals: [...this.goalRows.values()],
-    };
+  /** Inputs for the maintained note map (companion §4.3, ruling C as amended): projects and goals. */
+  blockInputs(): { projects: TaskRow[]; goals: TaskRow[] } {
+    return { projects: [...this.projectRows.values()], goals: [...this.goalRows.values()] };
   }
 
   // The viewer filters (see AgendaHost.getViewer). A null viewer sees all.
@@ -421,7 +410,6 @@ export class AgendaStore {
     if (kind === 'users') return this.members;
     if (kind === 'projects') return this.projectRows;
     if (kind === 'goals') return this.goalRows;
-    if (kind === 'unscheduledTasks') return this.inboxRows;
     return this.routines;
   }
 

--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -60,6 +60,8 @@ import {
   templateNeedsUser,
   renderNoteTemplateSubset,
   withCreationFrontmatter,
+  defaultProjectNote,
+  defaultGoalNote,
   type VaultScope,
   type ProjectNoteSettings,
 } from '@glance-apps/obsidian-format';
@@ -1215,9 +1217,17 @@ export class BridgeTransport {
     await this.ensureParentDirs(path);
     const today = new Date().toISOString().slice(0, 10);
     const vars = { title, date: today, goal: goalTitle };
+    // The default body (companion §4.3, templates ruling): chosen ONCE, at
+    // creation, by whether Dataview is installed; never maintained after.
+    const plugins = (this.host.app as unknown as { plugins?: { plugins?: Record<string, unknown> } }).plugins?.plugins ?? {};
+    const hasDataview = !!plugins['dataview'];
+    const dailyFolder = this.config?.dailyNotesPath ?? '';
+    const defaultBody = kind === 'goal'
+      ? defaultGoalNote({ title, date: today, hasDataview, dailyFolder })
+      : defaultProjectNote({ title, date: today, hasDataview, dailyFolder });
     let created: TFile;
     try {
-      created = await this.host.app.vault.create(path, withCreationFrontmatter(`# ${title}\n`, today));
+      created = await this.host.app.vault.create(path, withCreationFrontmatter(defaultBody, today));
     } catch (e) {
       console.error(`dayGLANCE bridge: could not create ${path}`, e);
       return 'applied';

--- a/dayglance-obsidian-plugin/src/noteBlocks.ts
+++ b/dayglance-obsidian-plugin/src/noteBlocks.ts
@@ -1,14 +1,16 @@
-// The maintained `dayglance:` frontmatter block on linked project and goal
-// notes (companion spec §4.3, rulings B and C).
+// The maintained `dayglance:` frontmatter map on linked project and goal
+// notes (companion spec §4.3, rulings B and C; shrunk 2026-09-04 to `kind`,
+// `status` and a project's `goal` wikilink).
 //
 // Rendered HERE, from the mirror the agenda store already holds, on the
 // plugin's tick and after every successful drain; written only when the
-// rendered block differs from the one in the file, at most once per
-// BLOCK_WRITE_FLOOR_MS per note, never into a dirty editor buffer. Only the
-// `dayglance` key is touched (Obsidian's frontmatter API rewrites the block
-// in place and leaves every other key alone).
+// map differs from the one in the file, at most once per BLOCK_WRITE_FLOOR_MS
+// per note, never into a dirty editor buffer. With no counts and no stamp in
+// the map, a write happens only when a status or a goal assignment changes.
+// Only the `dayglance` key is touched (Obsidian's frontmatter API rewrites
+// the block in place and leaves every other key alone).
 import { App, TFile } from 'obsidian';
-import { NOTE_BLOCK_KEY, projectNoteBlock, goalNoteBlock, noteBlockChanged, withUpdatedStamp, localDateStr } from '@glance-apps/agenda-core';
+import { NOTE_BLOCK_KEY, projectNoteBlock, goalNoteBlock, noteBlockChanged, type ProjectNoteBlock, type GoalNoteBlock } from '@glance-apps/agenda-core';
 
 const BLOCK_WRITE_FLOOR_MS = 5 * 60_000;
 
@@ -19,8 +21,8 @@ export interface NoteBlockHost {
   paired(): boolean;
   /** path → dayGLANCE id of every linked note (bridge.ts). */
   linkedNotes(): ReadonlyMap<string, string>;
-  /** The mirror's rows: every task (scheduled and inbox), every project, every goal. */
-  blockInputs(): { tasks: Row[]; projects: Row[]; goals: Row[] };
+  /** The mirror's project and goal rows. */
+  blockInputs(): { projects: Row[]; goals: Row[] };
   /** True when an editor holds unsaved changes for the note. */
   bufferDirty(path: string): Promise<boolean>;
 }
@@ -41,13 +43,11 @@ export class NoteBlockWriter {
     try {
       const linked = this.host.linkedNotes();
       if (!linked.size) return;
-      const { tasks, projects, goals } = this.host.blockInputs();
+      const { projects, goals } = this.host.blockInputs();
       const projectById = new Map(projects.map((p) => [String(p.id), p]));
       const goalById = new Map(goals.map((g) => [String(g.id), g]));
       const pathOf = new Map<string, string>();
       for (const [path, id] of linked) pathOf.set(id, path);
-      const today = localDateStr(new Date());
-      const nowIso = new Date().toISOString();
       for (const [path, id] of linked) {
         if (this.disposed) return;
         const project = projectById.get(id);
@@ -55,22 +55,26 @@ export class NoteBlockWriter {
         if (!project && !goal) continue; // not (yet) in the mirror
         const file = this.host.app.vault.getAbstractFileByPath(path);
         if (!(file instanceof TFile)) continue;
-        const next = project
-          ? projectNoteBlock(project, { tasks, today })
-          : goalNoteBlock(goal as Row, { projects, tasks, notePathOf: (pid) => pathOf.get(pid) ?? null });
+        let next: ProjectNoteBlock | GoalNoteBlock;
+        if (project) {
+          const goalId = typeof project.goalId === 'string' ? project.goalId : '';
+          const projectGoal = (goalId ? goalById.get(goalId) ?? null : null) as { title?: string } | null;
+          next = projectNoteBlock(project, { goal: projectGoal, goalNotePath: projectGoal ? pathOf.get(goalId) ?? null : null });
+        } else {
+          next = goalNoteBlock(goal as Row);
+        }
         const prev = this.host.app.metadataCache.getFileCache(file)?.frontmatter?.[NOTE_BLOCK_KEY] ?? null;
         if (!noteBlockChanged(prev, next)) continue;
         const last = this.lastWrite.get(path) ?? 0;
         if (Date.now() - last < BLOCK_WRITE_FLOOR_MS) continue; // the floor: the next tick past it writes
         if (await this.host.bufferDirty(path)) continue;        // unsaved keystrokes: never merge into them
-        const stamped = withUpdatedStamp(prev, next, nowIso);
         try {
           await this.host.app.fileManager.processFrontMatter(file, (fm: Record<string, unknown>) => {
-            fm[NOTE_BLOCK_KEY] = stamped;
+            fm[NOTE_BLOCK_KEY] = { ...next };
           });
           this.lastWrite.set(path, Date.now());
         } catch (e) {
-          console.warn(`dayGLANCE bridge: could not update the block in ${path}`, e);
+          console.warn(`dayGLANCE bridge: could not update the map in ${path}`, e);
         }
       }
     } finally {

--- a/dayglance-obsidian-plugin/test/projectNotes.scenarios.test.ts
+++ b/dayglance-obsidian-plugin/test/projectNotes.scenarios.test.ts
@@ -1,0 +1,220 @@
+// Bridge scenario harness: project and goal notes (companion §4.3), the
+// 2026-09-04 rulings. Real plugin transport and map writer, real sync hook.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const effects: Array<{ fn: () => unknown; deps?: unknown[] }> = [];
+vi.mock('react', () => ({
+  useEffect: (fn: () => unknown, deps?: unknown[]) => { effects.push({ fn, deps }); },
+  useCallback: (fn: unknown) => fn,
+  useRef: (init: unknown) => ({ current: init }),
+}));
+vi.mock('../../src/obsidian.js', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    tryRestoreVaultAccess: vi.fn(async () => null),
+    getVaultAccess: vi.fn(async () => null),
+    syncObsidianVault: vi.fn(async () => ({ dailyNotes: {}, scheduledTasks: [], inboxTasks: [] })),
+    syncObsidianVaultNative: vi.fn(async () => null),
+    writeTaskStateToFile: vi.fn(async () => true),
+    writeTaskStateNative: vi.fn(() => false),
+    readWikiNote: vi.fn(async () => null),
+    writeWikiNote: vi.fn(async () => {}),
+    scanVaultNotes: vi.fn(async () => ({ names: [], unportable: [] })),
+    vaultHasTasksPlugin: vi.fn(async () => false),
+    detectTasksPluginNative: vi.fn(() => null),
+    readVaultHeartbeat: vi.fn(async () => ({ paired: true, tsMs: Date.now(), accountId: 'acc-1', deviceId: 'plugin-dev' })),
+    readVaultHeartbeatNative: vi.fn(() => null),
+  };
+});
+vi.mock('../../src/native.js', () => ({
+  isNativeAndroid: () => false, isNativeApp: () => false,
+  nativeGetVaultConfig: vi.fn(() => null), nativeGetNote: vi.fn(() => null), nativeWriteNote: vi.fn(), nativeOpenNote: vi.fn(),
+  nativeListNotes: vi.fn(() => []), nativeSetVaultSettings: vi.fn(), nativeSetLaunchOnWrite: vi.fn(),
+}));
+vi.mock('../../src/utils/obsidianBridgeMode.js', () => ({ recordBridgeMode: vi.fn(), reconcileArchivedBaseline: vi.fn(() => null) }));
+
+const { createScenario, VAULT_URL, ACCOUNT_ID, until, advanceFake } = await import('./harness');
+const { default: useObsidianSync } = await import('../../src/hooks/useObsidianSync.js');
+const { flushBridgeOutbox, __resetBridgeStreamForTests } = await import('../../src/utils/obsidianBridgeStream.js');
+const { NoteBlockWriter } = await import('../src/noteBlocks');
+const { parseYaml } = await import('obsidian');
+
+type Row = Record<string, any>;
+
+function mountDevice(name: string, lists: { projects?: Row[]; goals?: Row[] } = {}) {
+  const store = new Map<string, string>();
+  const ls = { getItem: (k: string) => (store.has(k) ? store.get(k)! : null), setItem: (k: string, v: string) => { store.set(k, String(v)); }, removeItem: (k: string) => { store.delete(k); }, clear: () => store.clear() };
+  const activate = () => { (globalThis as any).localStorage = ls; };
+  const run = async <T,>(fn: () => Promise<T> | T): Promise<T> => { activate(); const out = await fn(); await advanceFake(300); return out; };
+  ls.setItem('dayglance-vault-config', JSON.stringify({ enabled: true, vaultUrl: VAULT_URL, vaultToken: `token-${name}`, accountId: ACCOUNT_ID }));
+  const state = { tasks: [] as Row[], inbox: [] as Row[], recycleBin: [] as Row[], projects: lists.projects ?? [], goals: lists.goals ?? [] };
+  const tasksRef = { current: state.tasks };
+  const inboxRef = { current: state.inbox };
+  const replace = (arr: Row[], next: Row[]) => { arr.splice(0, arr.length, ...next); };
+  const setTasks = (up: Row[] | ((p: Row[]) => Row[])) => { replace(state.tasks, typeof up === 'function' ? up([...state.tasks]) : up); };
+  const setUnscheduledTasks = (up: Row[] | ((p: Row[]) => Row[])) => { replace(state.inbox, typeof up === 'function' ? up([...state.inbox]) : up); };
+  const updateProject = (id: string, updates: Row) => { for (const p of state.projects) if (p.id === id) Object.assign(p, updates); };
+  const updateGoal = (id: string, updates: Row) => { for (const g of state.goals) if (g.id === id) Object.assign(g, updates); };
+  effects.length = 0;
+  activate();
+  const api = useObsidianSync({
+    isTrayMode: false, dataLoaded: true,
+    tasks: state.tasks, setTasks, unscheduledTasks: state.inbox, setUnscheduledTasks,
+    setDailyNotes: vi.fn(), setWikilinkCandidates: vi.fn(), setUnportableVaultFiles: vi.fn(),
+    obsidianConfig: { enabled: true, dailyNotesPath: 'Daily', dailyNotePattern: 'yyyy-MM-dd', taskHeading: '## Tasks' },
+    setObsidianConfig: vi.fn(), obsidianLaunchOnWrite: null, obsidianCompletionDates: false, obsidianSyncError: null,
+    setObsidianSyncStatus: vi.fn(), setObsidianSyncError: vi.fn(), setObsidianLastSynced: vi.fn(), setObsidianSyncNotice: vi.fn(),
+    obsidianVaultHandleRef: { current: {} }, obsidianSyncInProgressRef: { current: false }, obsidianPrevTaskStateRef: { current: {} },
+    obsidianTasksRef: tasksRef, obsidianInboxRef: inboxRef,
+    recycleBin: state.recycleBin, setRecycleBin: vi.fn(),
+    projects: state.projects, goals: state.goals, updateProject, updateGoal,
+  });
+  const myEffects = [...effects];
+  api.bridgeHeartbeatRef.current = { obsidianRunning: true, pluginAuthoritative: true };
+  return {
+    name, state, api, store,
+    sync: () => run(() => until(api.performObsidianSync())),
+    /** Push everything the app has queued: emitBridgeIntent's own flush is fire-and-forget and may have read the outbox before a later emit. */
+    flush: () => run(async () => {
+      for (let i = 0; i < 4; i++) {
+        await until(flushBridgeOutbox());
+        if (JSON.parse(store.get('dayglance-bridge-outbox') ?? '[]').length === 0) break;
+      }
+    }),
+    writeback: () => run(async () => { for (const e of myEffects) if (e.deps?.length === 3) e.fn(); await advanceFake(50); await until(flushBridgeOutbox()); }),
+    patch: (id: string, fields: Row) => {
+      const bump = (list: Row[]) => list.map((x) => (x.id === id ? { ...x, ...fields, lastModified: new Date().toISOString() } : x));
+      setTasks(bump); setUnscheduledTasks(bump);
+    },
+    all: () => [...state.tasks, ...state.inbox],
+  };
+}
+
+let s: Awaited<ReturnType<typeof createScenario>>;
+let A: ReturnType<typeof mountDevice>;
+let blocks: InstanceType<typeof NoteBlockWriter>;
+
+const frontmatterOf = (path: string) => { const t = s.text(path) ?? ''; const end = t.indexOf('\n---', 4); return parseYaml(t.slice(4, end + 1)); };
+
+async function boot(lists: { projects?: Row[]; goals?: Row[] }): Promise<void> {
+  await s.plugin.transport.drain();
+  A = mountDevice('A', lists);
+  await A.sync();
+  for (let i = 0; i < 5 && s.plugin.transport.stampingState() !== 'armed'; i++) { await s.advance(1000); await s.plugin.transport.drain(); }
+  if (s.plugin.transport.stampingState() !== 'armed') throw new Error('boot: plugin not armed');
+  // The map writer, wired as main.ts wires it, fed by the app's lists in place of the mirror.
+  blocks = new NoteBlockWriter({
+    app: s.plugin.app,
+    paired: () => true,
+    linkedNotes: () => s.plugin.transport.linkedNotes(),
+    blockInputs: () => ({ projects: A.state.projects, goals: A.state.goals }),
+    bufferDirty: (p) => s.plugin.transport.bufferDirty(p),
+  });
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers({ now: new Date('2026-09-04T12:00:00.000Z') });
+  vi.stubGlobal('window', globalThis);
+  vi.stubGlobal('document', { addEventListener: () => {}, removeEventListener: () => {}, visibilityState: 'visible' });
+  vi.stubGlobal('requestAnimationFrame', (cb: () => void) => { cb(); return 1; });
+  vi.stubGlobal('setInterval', () => 1);
+  vi.stubGlobal('clearInterval', () => {});
+  __resetBridgeStreamForTests();
+  s = await createScenario();
+});
+afterEach(() => { blocks?.dispose(); s.plugin.shutdown(); vi.unstubAllGlobals(); vi.useRealTimers(); vi.restoreAllMocks(); });
+
+describe('project and goal notes: creation, the maintained map, the project field', () => {
+  it('1. a project born in dayGLANCE gets the default note (no Dataview: sentences, no fences), the id key, and a three-key map that task changes never touch', async () => {
+    const goal = { id: 'g1', title: 'Home', status: 'active' };
+    const project = { id: 'p1', title: 'House', status: 'active', goalId: 'g1' };
+    await boot({ projects: [project], goals: [goal] });
+    expect(A.api.createProjectNote('project', 'p1', { title: 'House', goalId: 'g1' })).toBe(true);
+    await A.flush();
+    await s.plugin.transport.drain();
+    await s.advance(3000);
+    await A.sync();
+    expect(project.obsidianNotePath).toBe('Projects/House.md');
+    const text = s.text('Projects/House.md')!;
+    expect(text).toContain('# House\n');
+    expect(text).toContain('## Tasks\n- [ ] \n');
+    expect(text).toContain('## Done\nWith the Dataview plugin installed');
+    expect(text).not.toContain('```');
+    expect(text).toContain('## Log\n- 2026-09-04 Created\n');
+    expect(frontmatterOf('Projects/House.md')['dayglance-id']).toBe('p1');
+
+    await blocks.tick();
+    const writes = s.plugin.app.vault.writes;
+    expect(frontmatterOf('Projects/House.md').dayglance).toEqual({ kind: 'project', status: 'active', goal: 'Home' });
+    // No counts: neither a tick nor a task change writes again.
+    await blocks.tick();
+    await s.advance(6 * 60_000);
+    await blocks.tick();
+    expect(s.plugin.app.vault.writes).toBe(writes);
+  });
+
+  it('2. with Dataview installed the note carries exactly one query section; the goal note two', async () => {
+    (s.plugin.app as any).plugins.plugins.dataview = {};
+    await boot({ projects: [{ id: 'p1', title: 'House', status: 'active' }], goals: [{ id: 'g1', title: 'Home', status: 'active' }] });
+    const q1 = A.api.createProjectNote('project', 'p1', { title: 'House' });
+    const q2 = A.api.createProjectNote('goal', 'g1', { title: 'Home' });
+    expect(q1 && q2).toBe(true);
+    await A.flush();
+    await s.plugin.transport.drain();
+    const house = s.text('Projects/House.md')!;
+    expect((house.match(/```dataview/g) || []).length).toBe(1);
+    expect(house).toContain('FROM "Daily"\nFLATTEN file.lists AS item\nWHERE item.project = this.file.link');
+    const home = s.text('Goals/Home.md')!;
+    expect((home.match(/```dataview/g) || []).length).toBe(2);
+    expect(home).toContain('WHERE dayglance.goal = this.file.link');
+    expect(home).toContain('item.project.dayglance.goal = this.file.link');
+  });
+
+  it('3. the goal key is a wikilink once the goal note exists, and a goal reassignment is the one thing that rewrites the map', async () => {
+    const goals = [{ id: 'g1', title: 'Home', status: 'active', obsidianNotePath: 'Goals/Home.md' }, { id: 'g2', title: 'Work', status: 'active' }];
+    const projects = [{ id: 'p1', title: 'House', status: 'active', goalId: 'g1' }];
+    await boot({ projects, goals });
+    await s.write('Goals/Home.md', '---\ndayglance-id: g1\n---\n# Home\n');
+    await s.write('Projects/House.md', '---\ndayglance-id: p1\n---\n# House\n');
+    s.plugin.transport.linkTick();
+    await s.advance(3000);
+    await blocks.tick();
+    expect(frontmatterOf('Projects/House.md').dayglance).toEqual({ kind: 'project', status: 'active', goal: '[[Goals/Home]]' });
+    expect(frontmatterOf('Goals/Home.md').dayglance).toEqual({ kind: 'goal', status: 'active' });
+    const writes = s.plugin.app.vault.writes;
+    projects[0].goalId = 'g2';
+    await s.advance(6 * 60_000);
+    await blocks.tick();
+    expect(frontmatterOf('Projects/House.md').dayglance).toEqual({ kind: 'project', status: 'active', goal: 'Work' });
+    expect(s.plugin.app.vault.writes).toBe(writes + 1);
+  });
+
+  it('4. a daily-note task reassigned in dayGLANCE gets the project wikilink on its line; an Obsidian edit of the field reassigns it back', async () => {
+    const projects = [{ id: 'p1', title: 'House', status: 'active', obsidianNotePath: 'Projects/House.md' }, { id: 'p2', title: 'Garden', status: 'active' }];
+    await boot({ projects });
+    await s.write('Daily/2026-09-04.md', '## Tasks\n- [ ] Call the plumber\n');
+    for (let i = 0; i < 40; i++) await s.advance(1000);
+    await A.sync();
+    const task = A.all()[0];
+    expect(task.id).toMatch(/^obsidian-dg-/);
+    expect(task.projectId).toBeUndefined();
+
+    A.patch(task.id, { projectId: 'p1' });
+    await A.writeback();
+    await s.plugin.transport.drain();
+    // The note's basename equals the title, so the wikilink needs no alias.
+    expect(s.text('Daily/2026-09-04.md')).toMatch(/- \[ \] Call the plumber \[project:: \[\[Projects\/House\]\]\] \^dg-/);
+    for (let i = 0; i < 40; i++) await s.advance(1000);
+    await A.sync();
+    expect(A.all()[0].projectId).toBe('p1');
+    expect(A.all()[0].title).toBe('Call the plumber #obsidian');
+
+    const edited = s.text('Daily/2026-09-04.md')!.replace('[project:: [[Projects/House]]]', '[project:: Garden]');
+    await s.write('Daily/2026-09-04.md', edited);
+    for (let i = 0; i < 40; i++) await s.advance(1000);
+    await A.sync();
+    expect(A.all()[0].projectId).toBe('p2');
+  });
+});

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -692,6 +692,79 @@ unlinked); the subset renderer is three variables rather than v1's fuller
 set (nothing in the repo implements the fuller set, and Templater covers
 the rest when present).
 
+**Templates and the maintained map (2026-09-04, owner rulings; built).**
+The design principle: dayGLANCE writes as little into these notes as
+possible, and anything Dataview can produce live beats a maintained copy.
+Three rulings and a verification:
+
+- **Ruling G, amended: the project rides daily-note task lines as a
+  Dataview field**, `[project:: [[Projects/House|House]]]` for a project
+  with a linked note and `[project:: House]` otherwise, written by the same
+  metadata writer as the schedule. It is written at creation (a task born
+  under a project carries it from its first line, and its identity derives
+  from the line as written) and on a task's NEXT write for any other reason
+  (title, state, date, schedule) or on a reassignment in the app, which is
+  its own trigger. Never by a sweep: adoption is piecemeal by ruling, and
+  the backfill of existing lines is a separate decision (below). Only a
+  block-tagged task carries it: on a legacy id the raw title IS the
+  identity and the segment would move it. Never inside the project's own
+  note, where the note is the project (ruling H). On the way in, the field
+  resolves by note path for a link and by unique title for a bare name; a
+  line first seen with it imports under that project, a vault edit of it
+  reassigns or (removed) unassigns through the per-field adoption rule, and
+  an unresolvable name leaves the assignment alone. The field grammar now
+  nests one level of `[[ ]]` inside a Dataview field value, which it did
+  not before (a wikilink value was title text). *Considered and deferred:
+  routing a project-assigned task to the project note instead of the daily
+  note.* It would make the open-tasks query need no link at all, but it
+  moves the working surface: the daily note stops showing that part of the
+  day, and the task's date becomes line metadata. Recorded here so it is not
+  rediscovered; it stays available as a later ruling if the link turns out
+  not to be enough.
+- **Ruling C, amended: the maintained map shrinks to `kind`, `status` and,
+  on a project note, `goal`** (a wikilink to the goal's note when it is
+  linked, the goal's title otherwise; absent for a standalone project).
+  `open`, `done`, `total`, `percent`, `next`, `updated` and the goal's
+  `projects` list are gone. The deciding fact: the map was write-only,
+  nothing in dayGLANCE read it, so the counts were never a cache anyone
+  depended on but output that cost a synced-file write every time a task
+  moved; `updated` was the key that turned any change into a write. The map
+  now changes only when a status or a goal assignment changes. `goal` is the
+  one new key: it is what lets a goal note query its projects live. The
+  first tick after upgrading rewrites each linked note's map once.
+- **The default note bodies, chosen once at creation by whether Dataview is
+  installed, never maintained.** A project note: the title, a one-line
+  prompt, `## Tasks` (the section IS the project's open list, by ruling H;
+  no query), `## Done` (the completions query, or one sentence saying what
+  would be there with Dataview), `## Notes`, `## Decisions`, `## Log` seeded
+  with the creation date. A goal note: the title, a prompt, `## Projects`
+  (the table of its projects with status and live open counts computed from
+  each project note's own tasks), `## Progress` (completions across its
+  projects by month), `## Notes`, `## Log`. Without Dataview a plain
+  sentence stands where each query would be, so the note reads as finished
+  either way. A configured template note still overrides the default and
+  renders through the §4.4 ladder.
+- **Dataview, verified at source (0.5.68 lib, master importer) before the
+  queries shipped:** inline fields on list items parse with bracket nesting
+  (`[project:: [[Projects/House|House]]]` is one field); every link in a
+  list item's fields is canonicalized at index time to the resolved file
+  path, and `=` on links compares paths ignoring the alias, so
+  `item.project = this.file.link` holds for the aliased form; indexing into
+  a link value resolves the linked page's fields, so
+  `item.project.dayglance.goal` traverses; quoted wikilink strings in
+  frontmatter parse as links. Not run in a live vault (none here); the
+  harness pins the note bodies, not Dataview's rendering.
+
+**Backfill of existing lines: pending the owner's decision.** A backfill is
+one retitle intent per block-tagged, project-assigned daily-note task, once,
+idempotent (a line already carrying the right field is skipped). The
+costs: every touched daily note is rewritten and re-observed; the outbox
+refuses past 500 queued intents and flushes 50 per request; the plugin
+applies a drain's intents note by note under the dirty-buffer rule; and
+each device runs the writeback, so two devices could emit the same retitle
+(idempotent on apply, doubled traffic). Legacy-id tasks are excluded on
+purpose: they stamp first, then pick the field up on their next write.
+
 ---
 
 ### 4.4 Templater, via guarded delegation
@@ -1081,5 +1154,6 @@ through retitles, deletes and revivals, and it is what this section pays for.
 
 | 14 | Vault task scope rulings B–F (§6.3): schedule-as-metadata, leaving scope, where scope lives, completion window (30 days, configurable 7–90), direct access stays daily-only | **Decided**, 2026-09-02 |
 | 15 | Project and goal notes rulings A–H (4.3): link identity (id key + locator), frontmatter ownership, block cadence, workspace shape, goals and nested folders, deletion, where links appear, in-note task adoption | **Decided**, 2026-09-03 |
+| 16 | Project notes, templates round (4.3): the project as a Dataview field on daily-note task lines (G amended), the maintained map shrunk to kind/status/goal (C amended), Dataview-presence note bodies chosen at creation; routing project tasks to the project note considered and deferred | **Decided**, 2026-09-04; the backfill of existing lines **open** (owner) |
 
 Nothing in this table is open. The SSE re-arm sequence (buildout spec status note) runs alongside the project-notes build, not ahead of it (owner, 2026-09-03).

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -755,15 +755,23 @@ Three rulings and a verification:
   frontmatter parse as links. Not run in a live vault (none here); the
   harness pins the note bodies, not Dataview's rendering.
 
-**Backfill of existing lines: pending the owner's decision.** A backfill is
-one retitle intent per block-tagged, project-assigned daily-note task, once,
-idempotent (a line already carrying the right field is skipped). The
-costs: every touched daily note is rewritten and re-observed; the outbox
-refuses past 500 queued intents and flushes 50 per request; the plugin
-applies a drain's intents note by note under the dirty-buffer rule; and
-each device runs the writeback, so two devices could emit the same retitle
-(idempotent on apply, doubled traffic). Legacy-id tasks are excluded on
-purpose: they stamp first, then pick the field up on their next write.
+*Considered and declined (owner, 2026-09-04): a backfill of existing
+lines.* Recorded beside the routing deferral so it is read later as a
+deliberate omission, not an obvious missing piece. A backfill would be one
+retitle intent per block-tagged, project-assigned daily-note task, once,
+idempotent (a line already carrying the right field skipped). Its costs:
+every touched daily note rewritten and re-observed; the outbox refusing
+past 500 queued intents and flushing 50 per request; the plugin applying a
+drain's intents note by note under the dirty-buffer rule; every device
+running the writeback, so two devices could emit the same retitle
+(idempotent on apply, doubled traffic); and, given this project's history,
+a burst of retitle intents across the vault is exactly the shape that has
+started wars, so it would have needed pacing (about 25 per sync cycle, one
+device, one-shot) to be safe at all. Legacy-id tasks would have been
+excluded regardless: on those the raw title is the identity. Declined
+because new lines and any line touched for another reason pick the field
+up on their own, and the old lines it would reach are the ones least
+likely to matter in a Done query.
 
 ---
 
@@ -1154,6 +1162,6 @@ through retitles, deletes and revivals, and it is what this section pays for.
 
 | 14 | Vault task scope rulings B–F (§6.3): schedule-as-metadata, leaving scope, where scope lives, completion window (30 days, configurable 7–90), direct access stays daily-only | **Decided**, 2026-09-02 |
 | 15 | Project and goal notes rulings A–H (4.3): link identity (id key + locator), frontmatter ownership, block cadence, workspace shape, goals and nested folders, deletion, where links appear, in-note task adoption | **Decided**, 2026-09-03 |
-| 16 | Project notes, templates round (4.3): the project as a Dataview field on daily-note task lines (G amended), the maintained map shrunk to kind/status/goal (C amended), Dataview-presence note bodies chosen at creation; routing project tasks to the project note considered and deferred | **Decided**, 2026-09-04; the backfill of existing lines **open** (owner) |
+| 16 | Project notes, templates round (4.3): the project as a Dataview field on daily-note task lines (G amended), the maintained map shrunk to kind/status/goal (C amended), Dataview-presence note bodies chosen at creation; routing project tasks to the project note considered and deferred | **Decided**, 2026-09-04; the backfill of existing lines **declined** (owner, 2026-09-04; cost recorded in 4.3) |
 
 Nothing in this table is open. The SSE re-arm sequence (buildout spec status note) runs alongside the project-notes build, not ahead of it (owner, 2026-09-03).

--- a/packages/agenda-core/src/noteBlock.js
+++ b/packages/agenda-core/src/noteBlock.js
@@ -1,15 +1,15 @@
-// The dayGLANCE-maintained frontmatter block on a linked project or goal
-// note (companion spec §4.3, rulings B and C). Pure.
+// The dayGLANCE-maintained frontmatter map on a linked project or goal note
+// (companion spec §4.3, rulings B and C; shrunk 2026-09-04). Pure.
 //
 // Ruling B: every maintained key lives under ONE map key, `dayglance:`.
-// dayGLANCE wins inside it; nothing outside it is ever read or written. The
-// block is a rendered view, not an input.
-// Ruling C: the PLUGIN renders it from its mirror on its tick and writes only
-// when the rendered block differs. `updated` is the time of the last CHANGE,
-// carried forward when nothing else changed, so an unchanged block is
-// byte-identical and costs no write.
-
-import { projectProgressPercent, calculateGoalProgress } from './progress.js';
+// dayGLANCE wins inside it; nothing outside it is ever read or written.
+// Ruling C, as amended: the map carries only what Dataview cannot compute
+// from the vault itself — `kind`, `status`, and on a project note `goal`,
+// the wikilink that lets a goal note query its projects live. Counts and
+// dates were write-only output that cost a synced-file write every time a
+// task moved; they are gone, and so is the `updated` stamp that turned any
+// change into a write. A block now changes only when a status or a goal
+// assignment changes.
 
 export const NOTE_BLOCK_KEY = 'dayglance';
 
@@ -22,71 +22,24 @@ export function noteWikilink(path, title) {
   return base === t || !t ? `[[${p}]]` : `[[${p}|${t}]]`;
 }
 
-const activeTasksOf = (id, tasks) => (tasks || []).filter((t) => t && t.projectId === id && !t.archived);
-
 /**
- * The block for a project note.
+ * The map for a project note.
  * @param {object} project
- * @param {{ tasks: object[], today: string }} ctx  tasks: scheduled AND inbox, every user
+ * @param {{ goal?: object|null, goalNotePath?: string|null }} ctx  the project's goal (when any) and its linked note
  */
-export function projectNoteBlock(project, { tasks, today }) {
-  const mine = activeTasksOf(project.id, tasks);
-  const done = mine.filter((t) => t.completed).length;
-  const upcoming = mine
-    .filter((t) => !t.completed && typeof t.date === 'string' && (!today || t.date >= today))
-    .map((t) => t.date)
-    .sort();
-  return {
-    kind: 'project',
-    status: project.status || 'active',
-    open: mine.length - done,
-    done,
-    total: mine.length,
-    percent: projectProgressPercent(project.id, tasks || []),
-    next: upcoming[0] ?? null,
-  };
+export function projectNoteBlock(project, { goal = null, goalNotePath = null } = {}) {
+  const block = { kind: 'project', status: project.status || 'active' };
+  if (goal) block.goal = goalNotePath ? noteWikilink(goalNotePath, goal.title) : String(goal.title ?? '').trim();
+  return block;
 }
 
-/**
- * The block for a goal note: progress plus its projects as wikilinks (linked
- * ones) or bare titles.
- * @param {object} goal
- * @param {{ projects: object[], tasks: object[], notePathOf?: (id: string) => string|null }} ctx
- */
-export function goalNoteBlock(goal, { projects, tasks, notePathOf = null }) {
-  const children = (projects || []).filter((p) => p && p.goalId === goal.id && p.status !== 'archived');
-  const childIds = new Set(children.map((p) => p.id));
-  const mine = (tasks || []).filter((t) => t && childIds.has(t.projectId) && !t.archived);
-  const done = mine.filter((t) => t.completed).length;
-  const percent = children.length ? Math.round(calculateGoalProgress(goal.id, projects || [], tasks || []) * 100) : null;
-  return {
-    kind: 'goal',
-    status: goal.status || 'active',
-    projects: children
-      .slice()
-      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0) || String(a.title).localeCompare(String(b.title)))
-      .map((p) => noteWikilink(notePathOf?.(p.id) ?? '', p.title)),
-    open: mine.length - done,
-    done,
-    total: mine.length,
-    percent,
-  };
+/** The map for a goal note. */
+export function goalNoteBlock(goal) {
+  return { kind: 'goal', status: goal.status || 'active' };
 }
 
-const stripUpdated = (b) => {
-  if (!b || typeof b !== 'object') return null;
-  const { updated: _u, ...rest } = b;
-  return rest;
-};
-
-/** True when anything but `updated` differs (key order does not matter). */
+/** True when the maps differ (key order does not matter). */
 export function noteBlockChanged(prev, next) {
-  const canon = (o) => JSON.stringify(o, Object.keys(o || {}).sort());
-  return canon(stripUpdated(prev)) !== canon(stripUpdated(next));
-}
-
-/** `next` with `updated` carried forward from `prev` when nothing changed, else set to `nowIso`. */
-export function withUpdatedStamp(prev, next, nowIso) {
-  if (!noteBlockChanged(prev, next) && typeof prev?.updated === 'string') return { ...next, updated: prev.updated };
-  return { ...next, updated: nowIso };
+  const canon = (o) => (o && typeof o === 'object' ? JSON.stringify(o, Object.keys(o).sort()) : 'null');
+  return canon(prev) !== canon(next);
 }

--- a/packages/agenda-core/src/noteBlock.test.js
+++ b/packages/agenda-core/src/noteBlock.test.js
@@ -1,49 +1,30 @@
 import { describe, it, expect } from 'vitest';
-import { projectNoteBlock, goalNoteBlock, noteBlockChanged, withUpdatedStamp, noteWikilink } from './noteBlock.js';
+import { projectNoteBlock, goalNoteBlock, noteBlockChanged, noteWikilink } from './noteBlock.js';
 
-const P = { id: 'p1', title: 'House', status: 'active', goalId: 'g1' };
-const Q = { id: 'p2', title: 'Garden', status: 'active', goalId: 'g1', sortOrder: -1 };
-const G = { id: 'g1', title: 'Home', status: 'active' };
-const tasks = [
-  { id: 't1', projectId: 'p1', completed: true, duration: 60, date: '2026-09-01' },
-  { id: 't2', projectId: 'p1', completed: false, duration: 30, date: '2026-09-10' },
-  { id: 't3', projectId: 'p1', completed: false, duration: 30, date: '2026-09-05' },
-  { id: 't4', projectId: 'p1', completed: false, archived: true, date: '2026-09-02' },
-  { id: 't5', projectId: 'p2', completed: false },
-];
-
-describe('projectNoteBlock', () => {
-  it('counts active tasks, weights percent by duration, and picks the earliest upcoming date', () => {
-    expect(projectNoteBlock(P, { tasks, today: '2026-09-03' })).toEqual({
-      kind: 'project', status: 'active', open: 2, done: 1, total: 3, percent: 50, next: '2026-09-05',
-    });
-    // Nothing to measure → percent null, next null.
-    expect(projectNoteBlock({ id: 'zz' }, { tasks, today: '2026-09-03' })).toMatchObject({ total: 0, percent: null, next: null });
+describe('the maintained map (rulings B and C, shrunk)', () => {
+  it('a project carries kind, status and its goal as a wikilink when the goal note is linked, its title otherwise, nothing when standalone', () => {
+    const goal = { id: 'g1', title: 'Home', status: 'active' };
+    expect(projectNoteBlock({ id: 'p1', status: 'active', goalId: 'g1' }, { goal, goalNotePath: 'Goals/Home.md' }))
+      .toEqual({ kind: 'project', status: 'active', goal: '[[Goals/Home]]' });
+    expect(projectNoteBlock({ id: 'p1', status: 'completed', goalId: 'g1' }, { goal, goalNotePath: 'Areas/Home stuff.md' }))
+      .toEqual({ kind: 'project', status: 'completed', goal: '[[Areas/Home stuff|Home]]' });
+    expect(projectNoteBlock({ id: 'p1' }, { goal })).toEqual({ kind: 'project', status: 'active', goal: 'Home' });
+    expect(projectNoteBlock({ id: 'p1' })).toEqual({ kind: 'project', status: 'active' });
+    expect(goalNoteBlock({ id: 'g1', status: 'archived' })).toEqual({ kind: 'goal', status: 'archived' });
   });
-});
-
-describe('goalNoteBlock', () => {
-  it('lists child projects as wikilinks when linked, titles otherwise, in sort order', () => {
-    const b = goalNoteBlock(G, { projects: [P, Q], tasks, notePathOf: (id) => (id === 'p1' ? 'Projects/House.md' : null) });
-    expect(b.projects).toEqual(['Garden', '[[Projects/House]]']);
-    expect(b).toMatchObject({ kind: 'goal', open: 3, done: 1, total: 4 });
-    expect(typeof b.percent).toBe('number');
+  it('no counts, no dates: a task change never changes the map; a status or goal change does', () => {
+    const a = projectNoteBlock({ id: 'p1', status: 'active' });
+    expect(noteBlockChanged(a, projectNoteBlock({ id: 'p1', status: 'active' }))).toBe(false);
+    expect(noteBlockChanged({ status: 'active', kind: 'project' }, a)).toBe(false);
+    expect(noteBlockChanged(a, projectNoteBlock({ id: 'p1', status: 'completed' }))).toBe(true);
+    expect(noteBlockChanged(a, projectNoteBlock({ id: 'p1' }, { goal: { title: 'Home' } }))).toBe(true);
+    expect(noteBlockChanged(null, a)).toBe(true);
+    // An old block with counts differs from the new shape exactly once (the upgrade write).
+    expect(noteBlockChanged({ kind: 'project', status: 'active', open: 3, updated: 'x' }, a)).toBe(true);
   });
-});
-
-describe('noteWikilink / noteBlockChanged / withUpdatedStamp', () => {
-  it('aliases only when the basename differs from the title', () => {
+  it('noteWikilink aliases only when the basename differs from the title', () => {
     expect(noteWikilink('Projects/House.md', 'House')).toBe('[[Projects/House]]');
     expect(noteWikilink('Projects/House.md', 'The house')).toBe('[[Projects/House|The house]]');
     expect(noteWikilink('', 'Loose')).toBe('Loose');
-  });
-  it('an unchanged block keeps its updated stamp (no write); a change takes the new stamp', () => {
-    const prev = { kind: 'project', open: 1, done: 0, total: 1, percent: 0, next: null, status: 'active', updated: '2026-09-01T00:00:00Z' };
-    const same = { status: 'active', kind: 'project', open: 1, done: 0, total: 1, percent: 0, next: null };
-    expect(noteBlockChanged(prev, same)).toBe(false);
-    expect(withUpdatedStamp(prev, same, '2026-09-03T00:00:00Z').updated).toBe('2026-09-01T00:00:00Z');
-    expect(noteBlockChanged(prev, { ...same, open: 2 })).toBe(true);
-    expect(withUpdatedStamp(prev, { ...same, open: 2 }, '2026-09-03T00:00:00Z').updated).toBe('2026-09-03T00:00:00Z');
-    expect(noteBlockChanged(null, same)).toBe(true);
   });
 });

--- a/packages/agenda-core/types/index.d.ts
+++ b/packages/agenda-core/types/index.d.ts
@@ -88,10 +88,9 @@ export function getProjectTotalDuration(projectId: string, allTasks: unknown[]):
 export function isProjectStalled(projectId: string, allTasks: unknown[], project: unknown, recurringTasks?: unknown[]): boolean;
 export function calculateGoalProgress(goalId: string, projects: unknown[], allTasks: unknown[]): number;
 export const NOTE_BLOCK_KEY: string;
-export interface ProjectNoteBlock { kind: 'project'; status: string; open: number; done: number; total: number; percent: number | null; next: string | null; updated?: string }
-export interface GoalNoteBlock { kind: 'goal'; status: string; projects: string[]; open: number; done: number; total: number; percent: number | null; updated?: string }
+export interface ProjectNoteBlock { kind: 'project'; status: string; goal?: string }
+export interface GoalNoteBlock { kind: 'goal'; status: string }
 export function noteWikilink(path: string, title: string): string;
-export function projectNoteBlock(project: { id: string; status?: string }, ctx: { tasks: unknown[]; today: string }): ProjectNoteBlock;
-export function goalNoteBlock(goal: { id: string; status?: string }, ctx: { projects: unknown[]; tasks: unknown[]; notePathOf?: (id: string) => string | null }): GoalNoteBlock;
+export function projectNoteBlock(project: { id: string; status?: string }, ctx?: { goal?: { title?: string } | null; goalNotePath?: string | null }): ProjectNoteBlock;
+export function goalNoteBlock(goal: { id: string; status?: string }): GoalNoteBlock;
 export function noteBlockChanged(prev: unknown, next: unknown): boolean;
-export function withUpdatedStamp<T extends object>(prev: unknown, next: T, nowIso: string): T & { updated: string };

--- a/packages/obsidian-format/src/projectNotes.js
+++ b/packages/obsidian-format/src/projectNotes.js
@@ -98,3 +98,87 @@ export function renderNoteTemplateSubset(text, { title = '', date = '', goal = '
     .replace(/\{\{\s*date\s*\}\}/gi, date)
     .replace(/\{\{\s*goal\s*\}\}/gi, goal);
 }
+
+// ── Default note bodies (companion §4.3, templates ruling of 2026-09-04) ────
+//
+// Used when no template note is configured. Two variants, chosen ONCE at
+// creation by whether Dataview is installed: with it, the live sections are
+// queries over what dayGLANCE already writes (the completion log's
+// `[project:: [[…]]]` links and the maintained `dayglance.goal` map); without
+// it, one plain sentence stands where each query would be, so the note reads
+// as finished either way. Nothing here is ever maintained afterwards.
+
+const fence = (query) => '```dataview\n' + query.trim() + '\n```';
+const fromDaily = (dailyFolder) => (dailyFolder ? `FROM "${String(dailyFolder).replace(/\/+$/, '')}"\n` : '');
+
+/** Completions logged for this project, newest first (needs the completion-log wikilink). */
+export const projectCompletionsQuery = (dailyFolder = '') =>
+  `TABLE WITHOUT ID dateformat(item.completion, "yyyy-MM-dd HH:mm") AS "When", regexreplace(item.text, "\\\\s*\\\\[\\\\w+::(?:[^\\\\[\\\\]]|\\\\[\\\\[[^\\\\]]*\\\\]\\\\])*\\\\]", "") AS "Done"\n`
+  + fromDaily(dailyFolder)
+  + 'FLATTEN file.lists AS item\nWHERE item.project = this.file.link\nSORT item.completion DESC';
+
+/** A goal's projects with status and live open counts from each project note's own tasks. */
+export const goalProjectsQuery = () =>
+  'TABLE WITHOUT ID file.link AS Project, dayglance.status AS Status, length(filter(file.tasks, (t) => !t.completed)) AS Open\n'
+  + 'WHERE dayglance.goal = this.file.link\nSORT dayglance.status, file.name';
+
+/** Completions across a goal's projects, by month. */
+export const goalProgressQuery = (dailyFolder = '') =>
+  'TABLE WITHOUT ID key AS Month, length(rows) AS Completed\n'
+  + fromDaily(dailyFolder)
+  + 'FLATTEN file.lists AS item\nWHERE item.project AND item.project.dayglance.goal = this.file.link\n'
+  + 'GROUP BY dateformat(item.completion, "yyyy-MM")\nSORT key DESC';
+
+/**
+ * The default body of a new PROJECT note (no frontmatter; the caller adds
+ * dayGLANCE's creation frontmatter and the plugin the id key and the map).
+ */
+export function defaultProjectNote({ title, date, hasDataview = false, dailyFolder = '' }) {
+  const done = hasDataview
+    ? fence(projectCompletionsQuery(dailyFolder))
+    : 'With the Dataview plugin installed, this section lists every completion logged for this project in the daily notes, newest first.';
+  return [
+    `# ${title}`,
+    'One line on what done looks like.',
+    '',
+    '## Tasks',
+    '- [ ] ',
+    '',
+    '## Done',
+    done,
+    '',
+    '## Notes',
+    '',
+    '## Decisions',
+    '',
+    '## Log',
+    `- ${date} Created`,
+    '',
+  ].join('\n');
+}
+
+/** The default body of a new GOAL note. */
+export function defaultGoalNote({ title, date, hasDataview = false, dailyFolder = '' }) {
+  const projects = hasDataview
+    ? fence(goalProjectsQuery())
+    : 'With the Dataview plugin installed, this section lists the projects under this goal with their status and open task counts.';
+  const progress = hasDataview
+    ? fence(goalProgressQuery(dailyFolder))
+    : 'With the Dataview plugin installed, this section shows completions across this goal\'s projects by month.';
+  return [
+    `# ${title}`,
+    'Why this matters, and what finished looks like.',
+    '',
+    '## Projects',
+    projects,
+    '',
+    '## Progress',
+    progress,
+    '',
+    '## Notes',
+    '',
+    '## Log',
+    `- ${date} Created`,
+    '',
+  ].join('\n');
+}

--- a/packages/obsidian-format/src/projectNotes.test.js
+++ b/packages/obsidian-format/src/projectNotes.test.js
@@ -41,3 +41,34 @@ describe('templates (the §4.4 ladder pieces)', () => {
       .toBe('# House\nGoal: Home\n2026-09-03 <% tp.date.now() %>');
   });
 });
+
+import { defaultProjectNote, defaultGoalNote, projectCompletionsQuery, goalProgressQuery } from './index.js';
+
+describe('default note bodies (the templates ruling)', () => {
+  it('a project note with Dataview carries one query section; without it, a sentence stands in its place; both seed the log', () => {
+    const withDv = defaultProjectNote({ title: 'House', date: '2026-09-04', hasDataview: true, dailyFolder: 'Daily' });
+    expect(withDv.startsWith('# House\n')).toBe(true);
+    expect(withDv).toContain('## Tasks\n- [ ] \n');
+    expect(withDv).toContain('## Done\n```dataview\n');
+    expect(withDv).toContain('FROM "Daily"\nFLATTEN file.lists AS item\nWHERE item.project = this.file.link');
+    expect(withDv).toContain('## Log\n- 2026-09-04 Created\n');
+    expect((withDv.match(/```dataview/g) || []).length).toBe(1);
+    const plain = defaultProjectNote({ title: 'House', date: '2026-09-04', hasDataview: false });
+    expect(plain).not.toContain('```');
+    expect(plain).toContain('## Done\nWith the Dataview plugin installed, this section lists every completion');
+    expect(plain).toContain('## Decisions\n');
+    // Daily notes at the vault root: no FROM clause.
+    expect(projectCompletionsQuery('')).not.toContain('FROM');
+  });
+  it('a goal note carries the projects table and the monthly progress, or the two sentences', () => {
+    const withDv = defaultGoalNote({ title: 'Home', date: '2026-09-04', hasDataview: true, dailyFolder: 'Daily/' });
+    expect(withDv).toContain('## Projects\n```dataview\nTABLE WITHOUT ID file.link AS Project, dayglance.status AS Status');
+    expect(withDv).toContain('WHERE dayglance.goal = this.file.link');
+    expect(withDv).toContain('## Progress\n```dataview\n');
+    expect(goalProgressQuery('Daily/')).toContain('FROM "Daily"\n');
+    expect(goalProgressQuery('Daily/')).toContain('item.project.dayglance.goal = this.file.link');
+    const plain = defaultGoalNote({ title: 'Home', date: '2026-09-04' });
+    expect(plain).not.toContain('```');
+    expect(plain).toContain('## Log\n- 2026-09-04 Created\n');
+  });
+});

--- a/packages/obsidian-format/src/scheduledMetadata.test.js
+++ b/packages/obsidian-format/src/scheduledMetadata.test.js
@@ -26,3 +26,31 @@ describe('withScheduledMetadata', () => {
     expect(cleared.inboxTasks).toHaveLength(1);
   });
 });
+
+import { withProjectMetadata } from './index.js';
+
+// Companion §4.3, ruling G as amended: the project rides the line as a
+// Dataview field whose value may be a wikilink.
+describe('the project field and withProjectMetadata', () => {
+  it('a wikilink value nests inside the field: recognized as metadata, stripped from the display text, read back raw', () => {
+    const raw = 'Call the plumber [project:: [[Projects/House|House]]] ⏳ 2026-09-12';
+    const split = splitTasksMetadata(raw);
+    expect(split.text).toBe('Call the plumber');
+    expect(split.metaText).toBe(' [project:: [[Projects/House|House]]] ⏳ 2026-09-12');
+    expect(split.fields.project).toBe('[[Projects/House|House]]');
+    expect(split.fields.scheduled).toBe('2026-09-12');
+    expect(splitTasksMetadata('Call the plumber [project:: House]').fields.project).toBe('House');
+    expect(splitTasksMetadata('Call the plumber').fields.project).toBe(null);
+  });
+  it('appends, replaces, removes, and keeps the other segments verbatim', () => {
+    expect(withProjectMetadata('Call the plumber', '[[Projects/House|House]]')).toBe('Call the plumber [project:: [[Projects/House|House]]]');
+    expect(withProjectMetadata('Call the plumber [project:: House] 📅 2026-09-20', '[[Projects/House|House]]')).toBe('Call the plumber 📅 2026-09-20 [project:: [[Projects/House|House]]]');
+    expect(withProjectMetadata('Call the plumber ⏳ 2026-09-12 [project:: [[Projects/House|House]]]', null)).toBe('Call the plumber ⏳ 2026-09-12');
+    expect(withProjectMetadata('Call the plumber', null)).toBe('Call the plumber');
+    // The parser reads the written line back under the same identity rules as any other line.
+    const line = `- [ ] ${withProjectMetadata('Order tiles', '[[Projects/House|House]]')} ^dg-22222222\n`;
+    const { inboxTasks } = parseTasksFromMarkdown(line, '2026-09-02');
+    expect(inboxTasks[0].title).toBe('Order tiles #obsidian');
+    expect(splitTasksMetadata(inboxTasks[0].obsidianRawTitle).fields.project).toBe('[[Projects/House|House]]');
+  });
+});

--- a/packages/obsidian-format/src/tasksMetadata.js
+++ b/packages/obsidian-format/src/tasksMetadata.js
@@ -37,6 +37,13 @@
 //   scheduled (⏳ / [scheduled::]) → the timeline date
 //   priority (emoji / [priority::]) → 0–3 (see mapping below)
 //   recurrence (🔁 / [repeat::])  → recognized, NOT mapped — badge only
+//   project ([project:: …])       → the app project (companion §4.3, ruling
+//                                   G as amended 2026-09-04): a wikilink
+//                                   resolves by note path, a bare name by
+//                                   title; resolved by the APP on the plugin
+//                                   path, exposed raw here as `fields.project`
+// A Dataview field's value may itself contain a wikilink ([project::
+// [[Projects/House|House]]]): the field grammar nests one level of [[ ]].
 // ✅ done-dates: the TRAILING marker is #1470's (split before this module
 // runs, absorbed into completedAt). A ✅ or [completion:: …] sitting
 // non-trailing inside the run is user/plugin-authored frozen text: it is
@@ -60,7 +67,7 @@ const VS = '\\uFE0F?';
 const SEG = `(?:${DATE_EMOJI}${VS}\\s*\\d{4}-\\d{2}-\\d{2}` +
   `|${PRIORITY_EMOJI}${VS}` +
   `|${RECUR_EMOJI}${VS}[^\\u{1F4C5}\\u{23F3}\\u{1F6EB}\\u{2705}\\u{2795}\\u{274C}\\u{1F53A}\\u{23EB}\\u{1F53C}\\u{1F53D}\\u{23EC}\\u{1F501}\\[\\]]*` +
-  `|\\[[A-Za-z][A-Za-z0-9_-]*::[^\\]]*\\])`;
+  `|\\[[A-Za-z][A-Za-z0-9_-]*::(?:[^\\[\\]]|\\[\\[[^\\]]*\\]\\])*\\])`;
 
 const TRAILING_RUN_RE = new RegExp(`(?:\\s+${SEG})+\\s*$`, 'u');
 
@@ -70,6 +77,9 @@ const SCHEDULED_RE = new RegExp(`(?:\\u{23F3}${VS}\\s*(\\d{4}-\\d{2}-\\d{2}))|\\
 const PRIORITY_EMOJI_RE = new RegExp(`(\\u{1F53A}|\\u{23EB}|\\u{1F53C}|\\u{1F53D}|\\u{23EC})${VS}`, 'u');
 const PRIORITY_DV_RE = /\[priority::\s*(highest|high|medium|low|lowest)\s*\]/iu;
 const RECUR_RE = new RegExp(`${RECUR_EMOJI}${VS}|\\[repeat::[^\\]]*\\]`, 'u');
+// The project field's value, wikilink or bare, trimmed.
+const PROJECT_RE = /\[project::\s*((?:[^\[\]]|\[\[[^\]]*\]\])*?)\s*\]/u;
+const PROJECT_SEG = /\s+\[project::(?:[^\[\]]|\[\[[^\]]*\]\])*\]/gu;
 
 const PRIORITY_BY_EMOJI = {
   '\u{1F53A}': 3, // 🔺 highest
@@ -97,7 +107,7 @@ const PRIORITY_BY_WORD = { highest: 3, high: 3, medium: 2, low: 1, lowest: 1 };
  */
 export function splitTasksMetadata(input) {
   const s = String(input ?? '');
-  const none = { text: s, metaText: '', fields: { due: null, scheduled: null, priority: null, recurrence: false } };
+  const none = { text: s, metaText: '', fields: { due: null, scheduled: null, priority: null, recurrence: false, project: null } };
   const m = TRAILING_RUN_RE.exec(s);
   if (!m) return none;
   const text = s.slice(0, m.index);
@@ -118,6 +128,7 @@ export function splitTasksMetadata(input) {
       scheduled: scheduled ? (scheduled[1] ?? scheduled[2]) : null,
       priority: pe ? PRIORITY_BY_EMOJI[pe[1]] : (pw ? PRIORITY_BY_WORD[pw[1].toLowerCase()] : null),
       recurrence: RECUR_RE.test(metaText),
+      project: (PROJECT_RE.exec(metaText)?.[1] ?? '').trim() || null,
     },
   };
 }
@@ -164,6 +175,22 @@ export function withScheduledMetadata(rawTitle, dateStr, format = 'tasks') {
   if (!dateStr) return base;
   const seg = format === 'dataview' ? `[scheduled:: ${dateStr}]` : `\u{23F3} ${dateStr}`;
   return `${base} ${seg}`;
+}
+
+/**
+ * Write a project reference INTO a line's metadata run (companion §4.3,
+ * ruling G as amended): `[project:: [[Projects/House|House]]]` for a
+ * project with a linked note, `[project:: House]` for one without, removed
+ * when `ref` is null. Replaces an existing segment, keeps every other
+ * segment verbatim. Returns the full raw title.
+ */
+export function withProjectMetadata(rawTitle, ref) {
+  const raw = String(rawTitle ?? '');
+  const { text, metaText } = splitTasksMetadata(raw);
+  const base = (metaText ? text.trimEnd() + metaText.replace(PROJECT_SEG, '') : raw.trimEnd()).trimEnd();
+  const r = String(ref ?? '').trim();
+  if (!r) return base;
+  return `${base} [project:: ${r}]`;
 }
 
 export function reattachTasksMetadata(displayTitle, rawTitle) {

--- a/packages/obsidian-format/src/tasksMetadata.test.js
+++ b/packages/obsidian-format/src/tasksMetadata.test.js
@@ -29,7 +29,7 @@ describe('byte-exact split', () => {
   it('no metadata → whole input is text, metaText empty', () => {
     expect(F('Just a task')).toEqual({
       text: 'Just a task', metaText: '',
-      fields: { due: null, scheduled: null, priority: null, recurrence: false },
+      fields: { due: null, scheduled: null, priority: null, recurrence: false, project: null },
     });
   });
 });
@@ -72,7 +72,7 @@ describe('field mapping', () => {
   it('unknown dataview keys and 🛫/➕/❌ dates: display-stripped, mapped to nothing', () => {
     const r = F('T 🛫 2026-09-01 ➕ 2026-08-01 [x-custom:: v] [id:: abc]');
     expect(r.text).toBe('T');
-    expect(r.fields).toEqual({ due: null, scheduled: null, priority: null, recurrence: false });
+    expect(r.fields).toEqual({ due: null, scheduled: null, priority: null, recurrence: false, project: null });
     expect(r.metaText).toContain('[x-custom:: v]');
   });
 

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -33,6 +33,7 @@ export function splitTasksMetadata(input: string): {
   text: string; metaText: string; fields: TasksMetadataFields;
 };
 export function reattachTasksMetadata(displayTitle: string, rawTitle: string): string;
+export function withProjectMetadata(rawTitle: string, ref: string | null): string;
 export function withScheduledMetadata(rawTitle: string, dateStr: string | null, format?: 'tasks' | 'dataview'): string;
 
 // ── task lines ──────────────────────────────────────────────────────────────
@@ -219,3 +220,8 @@ export function projectNotePath(a: { kind: 'project' | 'goal'; title: string; la
 export function uniqueNotePath(path: string, exists: (path: string) => boolean): string;
 export function templateNeedsUser(text: string): boolean;
 export function renderNoteTemplateSubset(text: string, vars?: { title?: string; date?: string; goal?: string }): string;
+export function projectCompletionsQuery(dailyFolder?: string): string;
+export function goalProjectsQuery(): string;
+export function goalProgressQuery(dailyFolder?: string): string;
+export function defaultProjectNote(a: { title: string; date: string; hasDataview?: boolean; dailyFolder?: string }): string;
+export function defaultGoalNote(a: { title: string; date: string; hasDataview?: boolean; dailyFolder?: string }): string;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,8 @@ import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { tombstoneCutoff } from './sync/tombstoneRetention.js';
 import { preserveArchived } from './utils/preserveArchived.js';
 import { rescueUnsyncedTasks } from './utils/rescueUnsyncedTasks.js';
+import { withProjectMetadata } from '@glance-apps/obsidian-format';
+import { projectRefFor } from './utils/obsidianProjectNotes.js';
 import { readRetiredTaskIds, applyTaskRetirements, RETIRED_TASK_IDS_STORAGE_KEY } from './utils/retiredTaskIds.js';
 import { dropTombstonedObsidianTasks, dropTombstonedObsidianNotes } from './utils/obsidianDeletions.js';
 import { containObsidianGhostRows, persistDerivedGhostRetirements } from './utils/obsidianGhostRows.js';
@@ -6999,7 +7001,12 @@ const DayPlanner = () => {
       // block id on the write release, legacy content-derived id on the read
       // release. See obsidian.js buildNewObsidianTaskMeta and
       // utils/obsidianWritePolicy.js.
-      ? (rawTitle) => buildNewObsidianTaskMeta(rawTitle, new Date().toISOString().split('T')[0])
+      // A task created under a project carries `[project:: …]` on its line
+      // from the first write (companion §4.3, ruling G as amended); the
+      // identity derives from the line as written.
+      ? (rawTitle, projectId) => buildNewObsidianTaskMeta(
+          withProjectMetadata(rawTitle, projectRefFor(projectId ? projects.find(pr => pr.id === projectId) : null)),
+          new Date().toISOString().split('T')[0])
       : null,
     onWriteObsidianTask: obsidianConfig?.enabled && obsidianVaultHandleRef.current
       ? (task) => {

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -23,7 +23,7 @@ import { mergeObsidianTasks, noteMtimesFromDailyNotes, noteMtimesFromScopedNotes
 import { detectObsidianDeletions, addObsidianTombstones } from '../utils/obsidianDeletions.js';
 import { reattachTasksMetadata } from '../utils/obsidianTasksMetadata.js';
 import { obsidianHeartbeatState } from '../utils/obsidianHeartbeat.js';
-import { planNoteLinkUpdates, normalizeNotePath, projectByNotePath } from '../utils/obsidianProjectNotes.js';
+import { planNoteLinkUpdates, normalizeNotePath, projectByNotePath, projectRefFor } from '../utils/obsidianProjectNotes.js';
 import {
   readRetiredTaskIds,
   recordRetirements as recordRetirementEntries,
@@ -38,7 +38,7 @@ import { writebackSnapshotEntry } from '../utils/obsidianWritebackSnapshot.js';
 import { emitBridgeIntent, flushBridgeOutbox, publishBridgeConfig, publishBridgeCalendarProjection, getBridgePairingMeta, cachedBridgePairingMeta } from '../utils/obsidianBridgeStream.js';
 import { vaultViewerFor, visibleToViewer, assignVaultViewer, knownTaskIds } from '../utils/obsidianUserScope.js';
 import { writebackTargetFor } from '../utils/obsidianWritebackTarget.js';
-import { noteTaskId, withScheduledMetadata } from '@glance-apps/obsidian-format';
+import { noteTaskId, withScheduledMetadata, withProjectMetadata } from '@glance-apps/obsidian-format';
 import { fetchBridgeObservations, applyBridgeObservations, commitBridgeObservationCursor, pendingBridgeObservations } from '../utils/obsidianBridgeInbound.js';
 import {
   fetchBridgeActions, planBridgeActions, applyActionsToTasks, applyActionsToRecurring,
@@ -541,7 +541,12 @@ export default function useObsidianSync({
       // deliberately replaced it with the vault's edit, so this layer only
       // fills a deadline the scan produced NOTHING for.
       const preserveObsidianAppFields = (old, scanned = {}) => ({
-        ...(old.projectId ? { projectId: old.projectId } : {}),
+        // The project is app-owned, carried across re-scans — unless the SCAN
+        // adopted a vault edit of the line's [project:: …] field (companion
+        // §4.3, ruling G as amended): a resolved id wins, an explicit null
+        // (the field removed) unassigns.
+        ...(scanned.projectId === null ? { projectId: undefined }
+          : old.projectId && scanned.projectId === undefined ? { projectId: old.projectId } : {}),
         ...(old.deadline && scanned.deadline === undefined ? { deadline: old.deadline } : {}),
         ...(old.archived !== undefined ? { archived: old.archived } : {}),
         ...(old.completedAt !== undefined ? { completedAt: old.completedAt } : {}),
@@ -695,6 +700,7 @@ export default function useObsidianSync({
                 today: dateToString(new Date()),
                 // Project notes (companion §4.3, ruling H).
                 projectByNotePath: projectByNotePath(projectsRef.current),
+                projects: projectsRef.current,
               })
             : null;
 
@@ -1412,6 +1418,13 @@ export default function useObsidianSync({
       // it did not have: its ⏳ metadata must follow (ruling B), a change
       // the daily-note flags above cannot express.
       const scheduleChanged = !!task.obsidianNotePath && (!!p.date !== !!task.date);
+      // PROJECT AS METADATA (companion §4.3, ruling G as amended): a
+      // reassignment in the app writes the line's [project:: …] field. Only
+      // a snapshot that RECORDED the project can say it changed (an older
+      // snapshot has no opinion), so an upgrade never fires a burst; and
+      // only a block-tagged task carries the field, because on a legacy id
+      // the raw title IS the identity and the segment would move it.
+      const projectChanged = !!task.obsidianBlockId && p.projectId !== undefined && (p.projectId ?? null) !== (task.projectId || null);
 
       // STAMP ON SIGHT (spec §3.10, identity-versus-content) — a NAMED new
       // write-trigger class: the IDENTITY-ASSIGNMENT WRITE FIRED BY IMPORT.
@@ -1442,7 +1455,7 @@ export default function useObsidianSync({
         && !titleChanged && !stateChanged && !dateChanged
         && !task.obsidianBlockId && blockIdWritesEnabled();
 
-      if (!titleChanged && !stateChanged && !dateChanged && !scheduleChanged && !stampNeeded) continue;
+      if (!titleChanged && !stateChanged && !dateChanged && !scheduleChanged && !projectChanged && !stampNeeded) continue;
 
       // Always write back to the original file the task was parsed from:
       // the daily note for obsidianFileDate, or the note at obsidianNotePath
@@ -1473,6 +1486,17 @@ export default function useObsidianSync({
         const withSchedule = withScheduledMetadata(
           newRawTitle ?? task.obsidianRawTitle, task.date || null, tasksPluginRef.current ? 'tasks' : 'dataview');
         newRawTitle = withSchedule !== task.obsidianRawTitle ? withSchedule : newRawTitle;
+      }
+      // The project field rides EVERY write of a block-tagged task (adoption
+      // is piecemeal by ruling: a line picks the field up on its next write,
+      // never by a sweep), except inside the project's own note, where the
+      // note is the project (ruling H) and the field would be noise.
+      if (task.obsidianBlockId && (titleChanged || stateChanged || dateChanged || scheduleChanged || projectChanged)) {
+        const project = task.projectId ? (projectsRef.current || []).find(pr => pr && String(pr.id) === String(task.projectId)) : null;
+        const ownNote = !!project?.obsidianNotePath && project.obsidianNotePath === task.obsidianNotePath;
+        const ref = ownNote ? null : projectRefFor(project);
+        const withProject = withProjectMetadata(newRawTitle ?? task.obsidianRawTitle, ref);
+        if (withProject !== (newRawTitle ?? task.obsidianRawTitle)) newRawTitle = withProject;
       }
       const rawTitleChanged = newRawTitle !== undefined && newRawTitle !== task.obsidianRawTitle;
 

--- a/src/hooks/useObsidianSync.projectNotes.test.js
+++ b/src/hooks/useObsidianSync.projectNotes.test.js
@@ -173,3 +173,4 @@ describe('project notes: workspace creation from dayGLANCE (rulings D and E)', (
     expect(h.api.createProjectNote('project', 'p9', { title: '  ' })).toBe(false);
   });
 });
+

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -150,7 +150,7 @@ export default function useTaskActions({
       const rawObsidianTitle = hasObsidianTag ? stripTag(savedTitle, 'obsidian') : null;
       // Skip if stripping the tag leaves an empty title (e.g. task titled only "#obsidian")
       const obsidianMeta = (hasObsidianTag && rawObsidianTitle && !isRecurring && !isSwipeSchedule && getObsidianTaskMeta)
-        ? getObsidianTaskMeta(rawObsidianTitle)
+        ? getObsidianTaskMeta(rawObsidianTitle, newTask.projectId)
         : null;
 
       const taskId = obsidianMeta?.id ?? crypto.randomUUID();
@@ -269,7 +269,9 @@ export default function useTaskActions({
       // app task was just created with (Phase 2 round-trip identity).
       if (obsidianMeta && onWriteObsidianTask) {
         onWriteObsidianTask({
-          title: rawObsidianTitle,
+          // The raw title as the identity was derived from it: with the
+          // project field when the task was created under a project.
+          title: obsidianMeta.obsidianRawTitle ?? rawObsidianTitle,
           startTime: toInbox || newTask.isAllDay ? null : scheduledAdjustedStartTime,
           duration: toInbox ? null : (newTask.duration || null),
           isAllDay: !toInbox && (newTask.isAllDay || false),

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -886,8 +886,12 @@ function vaultMetadataEdits(task, existing) {
     due: base.due !== theirs.due,
     scheduled: base.scheduled !== theirs.scheduled,
     priority: base.priority !== theirs.priority,
+    // The project field (companion §4.3, ruling G as amended): the line's
+    // current value rides along so the adopter can resolve it.
+    project: base.project !== theirs.project,
+    projectRef: theirs.project,
   };
-  return (edits.due || edits.scheduled || edits.priority) ? edits : null;
+  return (edits.due || edits.scheduled || edits.priority || edits.project) ? edits : null;
 }
 
 /**
@@ -897,8 +901,17 @@ function vaultMetadataEdits(task, existing) {
  * remove uniform: the line's whole date semantics (inline-prefix precedence
  * included) reapply for `scheduled`, and a removed 📅 clears the deadline.
  */
-function adoptVaultMetadataEdits(task, edits, lineVals) {
+function adoptVaultMetadataEdits(task, edits, lineVals, resolveProject = null) {
   if (!edits) return;
+  // A vault edit of `[project:: …]` reassigns (or, removed, unassigns) the
+  // task on the plugin path, where the app supplies the resolver; a name
+  // that resolves to nothing leaves the assignment alone.
+  if (edits.project && typeof resolveProject === 'function') {
+    // An explicit null (never undefined) so the downstream merge's app-field
+    // carry can tell "the vault unassigned it" from "the parse has no opinion".
+    if (!edits.projectRef) task.projectId = null;
+    else { const id = resolveProject(edits.projectRef); if (id) task.projectId = id; }
+  }
   if (edits.due) task.deadline = lineVals.deadline ?? null;
   if (edits.priority) task.priority = lineVals.priority ?? 0;
   if (edits.scheduled) {
@@ -1019,7 +1032,7 @@ export function mergeParsedObsidianTasks(parsed, ctx, onTitleConflict, out) {
       if (existing.startTime !== undefined) task.startTime = existing.startTime;
       if (existing.isAllDay !== undefined) task.isAllDay = existing.isAllDay;
       resolveTitleOwnership(task, existing, onTitleConflict);
-      adoptVaultMetadataEdits(task, edits, lineVals);
+      adoptVaultMetadataEdits(task, edits, lineVals, ctx.resolveProject);
       // OWNED-SCHEDULE ENFORCEMENT (§3.10, 2026-09-02 correction): DG owns
       // scheduling once a task is imported, and the copy above enforces
       // that IN MEMORY — but until now nothing pushed DG's time back to a
@@ -1053,6 +1066,7 @@ export function mergeParsedObsidianTasks(parsed, ctx, onTitleConflict, out) {
       // Fresh import with no local match — use epoch so cloud merge
       // correctly prefers real user edits from other devices.
       task.lastModified = new Date(0).toISOString();
+      adoptLineProject(task, ctx.resolveProject);
     }
     allScheduled.push(task);
   }
@@ -1069,7 +1083,7 @@ export function mergeParsedObsidianTasks(parsed, ctx, onTitleConflict, out) {
       if (existing.color !== undefined) task.color = existing.color;
       if (existing.duration !== undefined) task.duration = existing.duration;
       resolveTitleOwnership(task, existing, onTitleConflict);
-      adoptVaultMetadataEdits(task, edits, lineVals);
+      adoptVaultMetadataEdits(task, edits, lineVals, ctx.resolveProject);
       if (existing.lastModified) task.lastModified = existing.lastModified;
 
       // User scheduled this from inbox — respect the cross-array move.
@@ -1082,9 +1096,20 @@ export function mergeParsedObsidianTasks(parsed, ctx, onTitleConflict, out) {
       }
     } else {
       task.lastModified = new Date(0).toISOString();
+      adoptLineProject(task, ctx.resolveProject);
     }
     allInbox.push(task);
   }
+}
+
+// A line first seen carrying `[project:: …]` imports under that project
+// (companion §4.3, ruling G as amended); plugin path only (the resolver).
+function adoptLineProject(task, resolveProject) {
+  if (typeof resolveProject !== 'function' || task.projectId) return;
+  const ref = splitTasksMetadata(String(task.obsidianRawTitle ?? '')).fields.project;
+  if (!ref) return;
+  const id = resolveProject(ref);
+  if (id) task.projectId = id;
 }
 
 export async function syncObsidianVault(

--- a/src/obsidian.ownedScheduleEnforce.test.js
+++ b/src/obsidian.ownedScheduleEnforce.test.js
@@ -72,7 +72,7 @@ describe('the writeback snapshot records the LINE\'s time so the ordinary diff f
   it('with a reported divergence the entry carries the line\'s time; without one, DG\'s', () => {
     const t = dgTask();
     const diverged = writebackSnapshotEntry(t, { [ID]: { startTime: '10:15' } });
-    expect(diverged).toEqual({ completed: true, startTime: '10:15', duration: 30, title: t.title, date: '2026-09-01' });
+    expect(diverged).toEqual({ completed: true, startTime: '10:15', duration: 30, title: t.title, date: '2026-09-01', projectId: null });
     // The writeback's own comparison — p.startTime !== task.startTime — now
     // sees a change, and writes DG's 09:30 through the existing path.
     expect(diverged.startTime).not.toBe(t.startTime);

--- a/src/utils/obsidianBridgeInbound.js
+++ b/src/utils/obsidianBridgeInbound.js
@@ -43,6 +43,7 @@ import {
   parseTasksFromMarkdown,
 } from '../obsidian.js';
 import { getBridgePairingMeta, bridgeRateLimited } from './obsidianBridgeStream.js';
+import { resolveProjectRef } from './obsidianProjectNotes.js';
 
 const OBS_HWM_KEY = 'dayglance-bridge-obs-hwm';
 
@@ -168,6 +169,10 @@ export function applyBridgeObservations(observations, {
   // notes whose note is present; a task line that imports FRESH from such a
   // note (no existing task to match) starts assigned to that project.
   projectByNotePath = null,
+  // The app's projects, so a line's `[project:: …]` field resolves to an id
+  // (companion §4.3, ruling G as amended): on first import and on a vault
+  // edit of the field.
+  projects = null,
 }) {
   const dailyNotes = {};
   const scopedNotes = {}; // path → { lastModified, deleted? } for scoped (non-daily) notes in this batch
@@ -179,6 +184,7 @@ export function applyBridgeObservations(observations, {
   const unapplied = [];
   const completedSince = scope && today ? completedSinceFor(scope, today) : null;
   const ctx = buildExistingObsidianTaskContext(existingTasks, existingInbox);
+  if (Array.isArray(projects)) ctx.resolveProject = (ref) => resolveProjectRef(ref, projects);
   const isDefaultPattern = !dailyNotePattern || dailyNotePattern === 'yyyy-MM-dd';
   const dateParser = isDefaultPattern ? null : buildDateParser(dailyNotePattern);
   const folderPrefix = dailyNotesPath ? `${dailyNotesPath.replace(/\/+$/, '')}/` : '';

--- a/src/utils/obsidianBridgeInbound.test.js
+++ b/src/utils/obsidianBridgeInbound.test.js
@@ -250,3 +250,29 @@ describe('ruling H: scoped lines in a linked project note adopt the project on f
     expect(none.inboxTasks.every((t) => !t.projectId)).toBe(true);
   });
 });
+
+describe('ruling G as amended: the [project:: …] field on daily-note lines', () => {
+  const projects = [{ id: 'p1', title: 'House', obsidianNotePath: 'Projects/House.md' }, { id: 'p2', title: 'Garden' }];
+  const daily = (line) => [{ path: 'Daily/2026-09-04.md', content: `## Tasks\n${line}\n`, mtime: Date.parse('2026-09-04T09:00:00Z') }];
+
+  it('a fresh line carrying the field imports under that project (link by path, bare by title); an unresolvable name imports unassigned', () => {
+    const cfg = { existingTasks: [], existingInbox: [], dailyNotesPath: 'Daily', projects };
+    expect(applyBridgeObservations(daily('- [ ] Call the plumber [project:: [[Projects/House|House]]] ^dg-aaaaaaaa'), cfg).inboxTasks[0].projectId).toBe('p1');
+    expect(applyBridgeObservations(daily('- [ ] Weed the beds [project:: Garden] ^dg-bbbbbbbb'), cfg).inboxTasks[0].projectId).toBe('p2');
+    expect(applyBridgeObservations(daily('- [ ] Loose [project:: Nope] ^dg-cccccccc'), cfg).inboxTasks[0].projectId).toBeUndefined();
+  });
+
+  it('a vault edit of the field reassigns a known task; removing it unassigns; an untouched field keeps the app assignment', () => {
+    const known = {
+      id: 'obsidian-dg-aaaaaaaa', title: 'Call the plumber #obsidian', importSource: 'obsidian', obsidianBlockId: 'aaaaaaaa',
+      obsidianRawTitle: 'Call the plumber [project:: [[Projects/House|House]]]', obsidianFileDate: '2026-09-04', projectId: 'p1', lastModified: '2026-09-04T08:00:00.000Z',
+    };
+    const cfg = { existingTasks: [], existingInbox: [known], dailyNotesPath: 'Daily', projects };
+    expect(applyBridgeObservations(daily('- [ ] Call the plumber [project:: Garden] ^dg-aaaaaaaa'), cfg).inboxTasks[0].projectId).toBe('p2');
+    expect(applyBridgeObservations(daily('- [ ] Call the plumber ^dg-aaaaaaaa'), cfg).inboxTasks[0].projectId).toBeNull(); // explicit: the vault unassigned it
+    // App-side reassignment with the line unchanged: the merge keeps the app's project (preserveAppFields carries it downstream).
+    const moved = { ...known, projectId: 'p2' };
+    const out = applyBridgeObservations(daily('- [ ] Call the plumber [project:: [[Projects/House|House]]] ^dg-aaaaaaaa'), { ...cfg, existingInbox: [moved] });
+    expect(out.inboxTasks[0].projectId).toBeUndefined(); // not adopted here; the hook's merge carries the app value
+  });
+});

--- a/src/utils/obsidianProjectNotes.js
+++ b/src/utils/obsidianProjectNotes.js
@@ -52,10 +52,46 @@ export function noteLinkOf(entity) {
  * bare title otherwise (unlinked, or the note is missing).
  */
 export function projectLogName(project) {
+  return projectRefFor(project);
+}
+
+/**
+ * How a project is written into a line's `[project:: …]` field and the
+ * completion log: a wikilink to its note when linked (and not missing),
+ * its title otherwise, null for no project.
+ */
+export function projectRefFor(project) {
   if (!project) return null;
   const link = noteLinkOf(project);
   const title = project.title ?? null;
   return link && !link.missing ? noteWikilink(link.path, title) : title;
+}
+
+/**
+ * The reverse: a `[project:: …]` value read off a line → the project id it
+ * names, or null. A wikilink resolves by note path (the linked records);
+ * a bare name by title, only when exactly one active project carries it.
+ */
+export function resolveProjectRef(ref, projects) {
+  const raw = String(ref ?? '').trim();
+  if (!raw || !Array.isArray(projects)) return null;
+  const m = /^\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]$/.exec(raw);
+  if (m) {
+    const path = normalizeNotePath(m[1]);
+    const byPath = projects.find((p) => p && p.obsidianNotePath === path);
+    if (byPath) return String(byPath.id);
+    // A link whose note is not linked to any project: fall back to the alias or basename as a title.
+    const alias = /\|([^\]]*)\]\]$/.exec(raw)?.[1]?.trim() || noteDisplayName(path).split('/').pop();
+    return byTitle(alias, projects);
+  }
+  return byTitle(raw, projects);
+}
+
+function byTitle(name, projects) {
+  const key = String(name ?? '').trim().toLowerCase();
+  if (!key) return null;
+  const hits = projects.filter((p) => p && String(p.title ?? '').trim().toLowerCase() === key && p.status !== 'archived');
+  return hits.length === 1 ? String(hits[0].id) : null;
 }
 
 /**

--- a/src/utils/obsidianProjectNotes.test.js
+++ b/src/utils/obsidianProjectNotes.test.js
@@ -79,3 +79,35 @@ describe('projectLogName / projectByNotePath (rulings G and H)', () => {
     expect(projectByNotePath([linked, aliased, missing, bare])).toEqual({ 'Projects/House.md': 'p1', 'Projects/Garden.md': 'p2' });
   });
 });
+
+import { projectRefFor, resolveProjectRef } from './obsidianProjectNotes.js';
+
+describe('the project field (ruling G as amended): projectRefFor / resolveProjectRef', () => {
+  const house = { id: 'p1', title: 'House', obsidianNotePath: 'Projects/House.md' };
+  const garden = { id: 'p2', title: 'Garden' };
+  const missing = { id: 'p3', title: 'Attic', obsidianNotePath: 'Projects/Attic.md', obsidianNoteMissingAt: '2026-09-04T10:00:00Z' };
+  const projects = [house, garden, missing];
+
+  it('writes a wikilink for a linked project, the title for an unlinked or missing one, null for none', () => {
+    expect(projectRefFor(house)).toBe('[[Projects/House]]');
+    expect(projectRefFor({ ...house, title: 'The house' })).toBe('[[Projects/House|The house]]');
+    expect(projectRefFor(garden)).toBe('Garden');
+    expect(projectRefFor(missing)).toBe('Attic');
+    expect(projectRefFor(null)).toBe(null);
+  });
+
+  it('resolves a wikilink by note path (alias ignored), a bare name by a unique title, and refuses ambiguity', () => {
+    expect(resolveProjectRef('[[Projects/House|House]]', projects)).toBe('p1');
+    expect(resolveProjectRef('[[Projects/House]]', projects)).toBe('p1');
+    expect(resolveProjectRef('[[Projects/House#Plan|x]]', projects)).toBe('p1');
+    expect(resolveProjectRef('Garden', projects)).toBe('p2');
+    expect(resolveProjectRef('garden', projects)).toBe('p2');
+    // A link to a note nobody is linked to falls back to its alias, then basename, as a title.
+    expect(resolveProjectRef('[[Notes/Somewhere|Garden]]', projects)).toBe('p2');
+    expect(resolveProjectRef('[[Notes/Garden]]', projects)).toBe('p2');
+    expect(resolveProjectRef('Nope', projects)).toBe(null);
+    expect(resolveProjectRef('House', [house, { id: 'p9', title: 'House' }])).toBe(null);
+    expect(resolveProjectRef('House', [house, { id: 'p9', title: 'House', status: 'archived' }])).toBe('p1');
+    expect(resolveProjectRef('', projects)).toBe(null);
+  });
+});

--- a/src/utils/obsidianWritebackSnapshot.js
+++ b/src/utils/obsidianWritebackSnapshot.js
@@ -26,5 +26,8 @@ export function writebackSnapshotEntry(t, lineSchedule) {
     duration: t.duration || null,
     title: t.title,
     date: t.date || null,
+    // The project rides the line as metadata (companion §4.3, ruling G as
+    // amended); tracked so a reassignment in the app is a write trigger.
+    projectId: t.projectId || null,
   };
 }


### PR DESCRIPTION
## Summary

Companion §4.3, the templates round: the two rulings of 2026-09-04 and the default note bodies. Off `main`.

### Ruling G, amended: the project rides daily-note task lines
- `[project:: [[Projects/House|House]]]` (or the bare title when the project has no linked note) as a Dataview field, written by the same metadata writer as the schedule (`withProjectMetadata`).
- Written at creation (a task born under a project carries it from its first line; the identity derives from the line as written) and on a task's next write for any other reason, or on a reassignment in the app. **Never by a sweep.** Only on block-tagged tasks (on a legacy id the raw title is the identity). Never inside the project's own note (ruling H: the note is the project).
- On the way in: a link resolves by note path, a bare name by unique active title. A line first seen with the field imports under that project; a vault edit of it reassigns or, removed, unassigns through the per-field adoption rule; an unresolvable name leaves the assignment alone.
- Grammar: a Dataview field value may now nest one level of `[[ ]]`. Before this, a wikilink value was title text.
- An upgrade never fires a burst: the snapshot only reports a project change once it has recorded a project, and the field is otherwise added only on writes that were happening anyway.

### Ruling C, amended: the maintained map is `kind`, `status`, `goal`
- `open`, `done`, `total`, `percent`, `next`, `updated`, and the goal's `projects` list are gone. The map changes only when a status or a goal assignment changes.
- `goal` is a wikilink to the goal's note when linked, the title otherwise, absent on a standalone project. It is what lets a goal note query its projects live.
- The first tick after upgrading rewrites each linked note's map once. The plugin's inbox mirror, added for the counts, is removed.

### Default note bodies
- Chosen once at creation by whether Dataview is installed; never maintained. Project: title, prompt, `## Tasks`, `## Done`, `## Notes`, `## Decisions`, `## Log` seeded with the date. Goal: title, prompt, `## Projects`, `## Progress`, `## Notes`, `## Log`.
- With Dataview: one query section on a project note, two on a goal note. Without: one plain sentence where each query would be. A configured template note still overrides the default.

### Considered and deferred: routing
Routing project-assigned tasks to the project note instead of the daily note. Recorded in §4.3 with the reasoning so it is not rediscovered.

### Considered and declined: the backfill of existing lines
Owner ruling, 2026-09-04. Recorded in §4.3 beside the routing deferral, with its cost (one retitle intent per block-tagged project-assigned daily-note task; every touched note rewritten and re-observed; outbox cap 500, flush chunk 50; every device runs the writeback; a vault-wide retitle burst is the shape that has started wars, so it would have needed pacing), so a later reader sees a deliberate omission. New lines and any line touched for another reason pick the field up on their own.

### Dataview verification
At source level (0.5.68 library, master importer), not in a live vault: inline fields on list items parse with bracket nesting; list-item link fields are canonicalized to the resolved path at index time and `=` compares paths ignoring the alias; indexing into a link resolves the linked page's fields, so `item.project.dayglance.goal` traverses; quoted wikilink strings in frontmatter parse as links.

### Verification
- New: `projectNotes.scenarios.test.ts` (creation bodies with and without Dataview, the map's contents and its single rewrite on a goal change, the project field's round trip through the real writeback and a vault-side edit), plus unit pins for the grammar, the writer, the resolver and the inbound adoption.
- Full suite green (2846 tests). Lint clean. Plugin builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ