### PR TITLE
Plugin: hide own block ids and checked lines in linked notes (display only)

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -102,10 +102,24 @@ Network access happens only while paired (plus pairing verification), only
 to the vault URL carried in the offer, via Obsidian's `requestUrl`. All
 stream rows are AES-256-GCM under the pairing's bridge subkey.
 
+- **Editor hiding** (display only, `src/editorHiding.ts`): two settings
+  under Settings → dayGLANCE Bridge → Editor. *Hide dayGLANCE block ids*
+  (default on) hides a well-formed `^dg-` token at the end of a line in
+  Live Preview, except on the cursor line; block ids the user created are
+  untouched, which is why this is a CodeMirror decoration rather than the
+  vault-wide CSS snippet it replaces (CSS cannot match text). *Hide
+  completed tasks in project and goal notes* (default off) hides checked
+  task lines in notes linked to a dayGLANCE project or goal, in Live
+  Preview and Reading view, again except on the cursor line; daily notes
+  are unaffected. Both add CSS classes and let a stylesheet do the hiding;
+  neither writes to a note. The line rules are pure
+  (`src/editorHidingRules.ts`) and pinned by `test/editorHidingRules.test.ts`.
+
 ## Tests
 
-The plugin has no unit tests of its own; it is exercised end to end by the
-bridge scenario harness in `test/`, which runs from the repository root
+Apart from the pure editor-hiding rules, the plugin has no unit tests of its
+own; it is exercised end to end by the bridge scenario harness in `test/`,
+which runs from the repository root
 with the rest of the suite (`npx vitest run`). The harness stubs the
 `obsidian` module (`test/obsidianStub.ts`), serves an in-memory GLANCEvault
 (`test/fakeGlanceVault.ts`), and drives the real transport plus the real

--- a/dayglance-obsidian-plugin/package-lock.json
+++ b/dayglance-obsidian-plugin/package-lock.json
@@ -13,6 +13,8 @@
         "@glance-apps/sync": "2.0.0"
       },
       "devDependencies": {
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.38.6",
         "@types/node": "^20.11.0",
         "esbuild": "^0.21.0",
         "obsidian": "^1.5.7",
@@ -35,7 +37,6 @@
       "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -46,7 +47,6 @@
       "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -464,8 +464,7 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.4.tgz",
       "integrity": "sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/codemirror": {
       "version": "5.60.8",
@@ -509,8 +508,7 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
       "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -581,8 +579,7 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -610,8 +607,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/dayglance-obsidian-plugin/package.json
+++ b/dayglance-obsidian-plugin/package.json
@@ -9,6 +9,8 @@
     "dev": "node esbuild.config.mjs"
   },
   "devDependencies": {
+    "@codemirror/state": "^6.5.0",
+    "@codemirror/view": "^6.38.6",
     "@types/node": "^20.11.0",
     "esbuild": "^0.21.0",
     "obsidian": "^1.5.7",

--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -165,6 +165,8 @@ export interface BridgeHost {
   getProjectNotes?(): ProjectNoteSettings;
   /** The vault's viewer override (companion 4.2, decision 9); undefined = the pairing's default. */
   getViewer?(): string | null;
+  /** The linked-notes map changed (a link made, moved or broken). Display-only consumers. */
+  onLinkedNotesChanged?(): void;
 }
 
 // Same requestUrl-backed fetch shim as pairing.ts (CORS-free everywhere).
@@ -1071,6 +1073,7 @@ export class BridgeTransport {
       const next = Object.fromEntries([...this.linked].sort(([a], [b]) => a.localeCompare(b)));
       if (JSON.stringify(state.linkedNotes ?? {}) === JSON.stringify(next)) return;
       await this.host.saveBridgeState({ ...state, linkedNotes: next });
+      this.host.onLinkedNotesChanged?.();
     } catch (e) {
       console.error('dayGLANCE bridge: could not persist the linked notes', e);
     }

--- a/dayglance-obsidian-plugin/src/editorHiding.ts
+++ b/dayglance-obsidian-plugin/src/editorHiding.ts
@@ -1,0 +1,168 @@
+// Editor hiding: two display-only decorations plus the stylesheet that acts
+// on them. Nothing in this file writes to a note, and nothing here reads or
+// changes identity — the decorations add CSS classes, the CSS hides.
+//
+//   1. dayGLANCE's own block id tokens (`^dg-xxxxxxxx` at the end of a
+//      line) get a mark class in Live Preview. The user's own block ids
+//      are untouched — CSS cannot match on text, which is why this is an
+//      editor extension rather than the vault-wide snippet it replaces.
+//   2. In a note LINKED to a dayGLANCE project or goal (bridge.ts's linked
+//      map, the same map the frontmatter writer keys on), checked task
+//      lines get a line class in Live Preview and a list-item class in
+//      Reading view. Daily notes and unlinked notes are untouched.
+//
+// Both rules exempt the cursor line: the CSS keys on Obsidian's `.cm-active`,
+// so whatever is hidden reappears the moment the cursor lands on its line.
+// That exemption has been the diagnostic window every time a token or a
+// line mattered, and it costs nothing here because the extension never
+// needs to know where the cursor is.
+//
+// The two settings toggle BODY classes rather than the decorations: a
+// flipped toggle takes effect in every open pane at once, with no editor
+// dispatch, and the decoration work stays cheap (visible lines only).
+
+import { RangeSetBuilder, StateEffect, type Extension } from '@codemirror/state';
+import { Decoration, type DecorationSet, EditorView, MatchDecorator, ViewPlugin, type ViewUpdate } from '@codemirror/view';
+import { MarkdownView, editorInfoField, type App } from 'obsidian';
+import { isCompletedTaskLine, isCompletedTaskMarker, ownBlockIdSpan, type EditorHidingSettings } from './editorHidingRules';
+
+export interface EditorHidingHost {
+  app: App;
+  /** True when the path is linked to a dayGLANCE project or goal. */
+  isLinkedNote(path: string): boolean;
+  getSettings(): EditorHidingSettings;
+}
+
+const STYLE_ID = 'dayglance-editor-hiding-styles';
+const BODY_HIDE_BLOCK_IDS = 'dg-hide-block-ids';
+const BODY_HIDE_COMPLETED = 'dg-hide-completed';
+export const BLOCK_ID_CLASS = 'dg-blockid';
+export const DONE_LINE_CLASS = 'dg-done';
+
+// `.cm-active` is Obsidian's cursor-line class (the same hook the common
+// block-id snippet uses). `display: none` on a `.cm-line` is the shape the
+// widely used completed-task snippets take; CodeMirror measures the line
+// at zero height and moves on.
+const CSS = `
+body.${BODY_HIDE_BLOCK_IDS} .markdown-source-view.is-live-preview .cm-line:not(.cm-active) .${BLOCK_ID_CLASS} { display: none; }
+body.${BODY_HIDE_COMPLETED} .markdown-source-view.is-live-preview .cm-line.${DONE_LINE_CLASS}:not(.cm-active) { display: none; }
+body.${BODY_HIDE_COMPLETED} .markdown-reading-view li.task-list-item.${DONE_LINE_CLASS} { display: none; }
+`;
+
+export function injectEditorHidingStyles(doc: Document): void {
+  if (doc.getElementById(STYLE_ID)) return;
+  const el = doc.createElement('style');
+  el.id = STYLE_ID;
+  el.textContent = CSS;
+  doc.head.appendChild(el);
+}
+
+export function removeEditorHidingStyles(doc: Document): void {
+  doc.getElementById(STYLE_ID)?.remove();
+  doc.body.classList.remove(BODY_HIDE_BLOCK_IDS, BODY_HIDE_COMPLETED);
+}
+
+/** Reflect the settings as body classes (idempotent; call on load and on change). */
+export function applyEditorHidingSettings(doc: Document, s: EditorHidingSettings): void {
+  doc.body.classList.toggle(BODY_HIDE_BLOCK_IDS, s.hideBlockIds);
+  doc.body.classList.toggle(BODY_HIDE_COMPLETED, s.hideCompletedInLinkedNotes);
+}
+
+// ── 1. Own block ids (Live Preview) ────────────────────────────────────────
+
+const blockIdMark = Decoration.mark({ class: BLOCK_ID_CLASS });
+
+// MatchDecorator matches within single lines and maintains its set
+// incrementally across viewport and document changes. The regexp finds a
+// candidate at the line end; the decorate callback applies the block-id
+// position rule (whitespace before, or the whole line) from the pure rules
+// module so the two never drift.
+const blockIdDecorator = new MatchDecorator({
+  regexp: /\^dg-[a-z0-9]{8}$/g,
+  decorate: (add, from, to, _match, view) => {
+    const line = view.state.doc.lineAt(from);
+    const span = ownBlockIdSpan(line.text);
+    if (span && line.from + span.from === from && line.from + span.to === to) add(from, to, blockIdMark);
+  },
+});
+
+const blockIdPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    constructor(view: EditorView) { this.decorations = blockIdDecorator.createDeco(view); }
+    update(u: ViewUpdate) { this.decorations = blockIdDecorator.updateDeco(u, this.decorations); }
+  },
+  { decorations: (v) => v.decorations },
+);
+
+// ── 2. Completed lines in linked notes (Live Preview) ──────────────────────
+
+const doneLine = Decoration.line({ class: DONE_LINE_CLASS });
+
+// Dispatched by refreshEditorHiding: "the linked map changed, rebuild".
+const refreshEffect = StateEffect.define<null>();
+
+function buildDoneDecorations(view: EditorView, host: EditorHidingHost): DecorationSet {
+  const path = view.state.field(editorInfoField, false)?.file?.path;
+  if (!path || !host.isLinkedNote(path)) return Decoration.none;
+  const builder = new RangeSetBuilder<Decoration>();
+  let last = -1;
+  for (const { from, to } of view.visibleRanges) {
+    for (let pos = from; pos <= to;) {
+      const line = view.state.doc.lineAt(pos);
+      if (line.from > last && isCompletedTaskLine(line.text)) {
+        builder.add(line.from, line.from, doneLine);
+        last = line.from;
+      }
+      pos = line.to + 1;
+    }
+  }
+  return builder.finish();
+}
+
+function donePlugin(host: EditorHidingHost) {
+  return ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+      constructor(view: EditorView) { this.decorations = buildDoneDecorations(view, host); }
+      update(u: ViewUpdate) {
+        // Doc and viewport changes cover editing and scrolling; a file
+        // switch inside one pane arrives as a doc change. A link change
+        // while the note is open is pushed by refreshEditorHiding below.
+        const refresh = u.transactions.some((tr) => tr.effects.some((e) => e.is(refreshEffect)));
+        if (refresh || u.docChanged || u.viewportChanged) this.decorations = buildDoneDecorations(u.view, host);
+      }
+    },
+    { decorations: (v) => v.decorations },
+  );
+}
+
+export function editorHidingExtension(host: EditorHidingHost): Extension {
+  return [blockIdPlugin, donePlugin(host)];
+}
+
+/**
+ * Re-run the linked-note decoration in every open Markdown pane — for a
+ * link made or broken while the note is open. The editor gets a
+ * no-change transaction carrying the refresh effect; a pane in Reading
+ * view re-renders so the post-processor runs again.
+ */
+export function refreshEditorHiding(app: App): void {
+  app.workspace.iterateAllLeaves((leaf) => {
+    const view = leaf.view;
+    if (!(view instanceof MarkdownView)) return;
+    const cm = (view.editor as unknown as { cm?: EditorView }).cm;
+    if (cm) cm.dispatch({ effects: refreshEffect.of(null) });
+    if (view.getMode() === 'preview') view.previewMode.rerender(true);
+  });
+}
+
+// ── 2b. Completed lines in linked notes (Reading view) ─────────────────────
+
+/** Markdown post-processor: tag checked list items in a linked note. */
+export function markCompletedInReadingView(host: EditorHidingHost, el: HTMLElement, sourcePath: string): void {
+  if (!sourcePath || !host.isLinkedNote(sourcePath)) return;
+  for (const li of Array.from(el.querySelectorAll<HTMLElement>('li.task-list-item'))) {
+    if (isCompletedTaskMarker(li.dataset.task)) li.classList.add(DONE_LINE_CLASS);
+  }
+}

--- a/dayglance-obsidian-plugin/src/editorHidingRules.ts
+++ b/dayglance-obsidian-plugin/src/editorHidingRules.ts
@@ -1,0 +1,58 @@
+// Pure line rules for the editor hiding extension (editorHiding.ts). No
+// Obsidian or CodeMirror imports, so the harness can pin them directly.
+//
+// Both rules are DISPLAY ONLY: they classify text; nothing here writes.
+
+/** A well-formed dayGLANCE block id token: `^dg-` plus eight base-36 chars. */
+export const DG_BLOCK_ID_TOKEN_RE = /\^dg-[a-z0-9]{8}$/g;
+
+/**
+ * The span of a dayGLANCE block id at the END of a line, as [from, to)
+ * offsets into `line`, or null. Only a token in block-id position counts —
+ * preceded by whitespace (or the whole line) and ending the line. A token
+ * anywhere else is a damaged line (the stamper refuses those, §3.10) and
+ * stays visible: hiding the evidence of corruption is the one thing this
+ * rule must never do.
+ */
+export function ownBlockIdSpan(line: string): { from: number; to: number } | null {
+  const m = /(^|\s)(\^dg-[a-z0-9]{8})$/.exec(line);
+  if (!m) return null;
+  const from = m.index + m[1].length;
+  return { from, to: from + m[2].length };
+}
+
+/**
+ * A checked task line in the plugin's own grammar (taskLines.js): a dash
+ * checkbox with `x` or `X`. Other checkbox states are not dayGLANCE
+ * completions and are left alone.
+ */
+export function isCompletedTaskLine(line: string): boolean {
+  return /^\s*- \[[xX]\]\s/.test(line);
+}
+
+/** Reading view exposes the checkbox char as `data-task`; same rule. */
+export function isCompletedTaskMarker(task: string | undefined | null): boolean {
+  return task === 'x' || task === 'X';
+}
+
+export interface EditorHidingSettings {
+  hideBlockIds: boolean;
+  hideCompletedInLinkedNotes: boolean;
+}
+
+export const EDITOR_HIDING_DEFAULTS: EditorHidingSettings = {
+  // Only ever hides dayGLANCE's own tokens, so on by default.
+  hideBlockIds: true,
+  // Off by default: without Dataview a linked note has no Done list, so a
+  // hidden line would be gone from view everywhere except dayGLANCE.
+  hideCompletedInLinkedNotes: false,
+};
+
+export function normalizeEditorHidingSettings(s: Partial<EditorHidingSettings> | undefined | null): EditorHidingSettings {
+  return {
+    hideBlockIds: typeof s?.hideBlockIds === 'boolean' ? s.hideBlockIds : EDITOR_HIDING_DEFAULTS.hideBlockIds,
+    hideCompletedInLinkedNotes: typeof s?.hideCompletedInLinkedNotes === 'boolean'
+      ? s.hideCompletedInLinkedNotes
+      : EDITOR_HIDING_DEFAULTS.hideCompletedInLinkedNotes,
+  };
+}

--- a/dayglance-obsidian-plugin/src/main.ts
+++ b/dayglance-obsidian-plugin/src/main.ts
@@ -51,6 +51,8 @@ import { localDateStr } from '@glance-apps/agenda-core';
 import { AgendaView, AGENDA_VIEW_TYPE, removeAgendaStyles } from './agendaView';
 import { LinkTargetModal } from './linkModal';
 import { NoteBlockWriter } from './noteBlocks';
+import { applyEditorHidingSettings, editorHidingExtension, injectEditorHidingStyles, markCompletedInReadingView, refreshEditorHiding, removeEditorHidingStyles, type EditorHidingHost } from './editorHiding';
+import { normalizeEditorHidingSettings, type EditorHidingSettings } from './editorHidingRules';
 
 const HEARTBEAT_DIR = '.dayglance';
 const HEARTBEAT_PATH = `${HEARTBEAT_DIR}/heartbeat`;
@@ -79,6 +81,9 @@ interface BridgeData {
   // Project and goal note workspaces (companion §4.3, rulings D and E):
   // where a note born in dayGLANCE goes and which template it uses.
   projectNotes?: ProjectNoteSettings;
+  // Editor hiding (display only, editorHiding.ts): dayGLANCE's own block
+  // ids off the cursor line, and checked lines in linked notes.
+  editorHiding?: Partial<EditorHidingSettings>;
 }
 
 const mintDeviceId = (): string => {
@@ -136,6 +141,9 @@ export default class DayGlanceBridgePlugin extends Plugin {
       getScope: () => this.scope(),
       getProjectNotes: () => normalizeProjectNoteSettings(this.data.projectNotes),
       getViewer: () => this.viewer(),
+      // A note linked or unlinked while open: its completed-line hiding
+      // follows the map without waiting for the next edit.
+      onLinkedNotesChanged: () => refreshEditorHiding(this.app),
     });
     this.noteBlocks = new NoteBlockWriter({
       app: this.app,
@@ -144,6 +152,18 @@ export default class DayGlanceBridgePlugin extends Plugin {
       blockInputs: () => this.agenda.blockInputs(),
       bufferDirty: (path) => this.transport.bufferDirty(path),
     });
+
+    // Editor hiding (display only): the decorations always run; the two
+    // settings only toggle body classes the stylesheet keys on.
+    const hidingHost: EditorHidingHost = {
+      app: this.app,
+      isLinkedNote: (path) => this.transport.linkedNotes().has(path),
+      getSettings: () => this.editorHiding(),
+    };
+    this.registerEditorExtension(editorHidingExtension(hidingHost));
+    this.registerMarkdownPostProcessor((el, ctx) => markCompletedInReadingView(hidingHost, el, ctx.sourcePath));
+    injectEditorHidingStyles(document);
+    applyEditorHidingSettings(document, this.editorHiding());
 
     this.registerView(AGENDA_VIEW_TYPE, (leaf) => new AgendaView(leaf, this.agenda));
     this.addRibbonIcon('calendar-check', 'Open dayGLANCE agenda', () => { void this.openAgenda(); });
@@ -261,6 +281,12 @@ export default class DayGlanceBridgePlugin extends Plugin {
         this.data.projectNotes = normalizeProjectNoteSettings(s);
         await this.saveData(this.data);
       },
+      getEditorHiding: () => this.editorHiding(),
+      setEditorHiding: async (s) => {
+        this.data.editorHiding = normalizeEditorHidingSettings(s);
+        await this.saveData(this.data);
+        applyEditorHidingSettings(document, this.editorHiding());
+      },
       getScope: () => this.scope(),
       setScope: async (scope) => {
         this.data.scope = normalizeScope(scope);
@@ -325,6 +351,7 @@ export default class DayGlanceBridgePlugin extends Plugin {
     this.noteBlocks.dispose();
     this.agenda.dispose();
     removeAgendaStyles(document);
+    removeEditorHidingStyles(document);
     // Best-effort: a graceful quit (or a plugin disable — equally "no
     // bridge here") removes the file so readers see the truth immediately
     // instead of waiting out the staleness window. Crashes skip this, which
@@ -356,6 +383,10 @@ export default class DayGlanceBridgePlugin extends Plugin {
   }
 
   // The active vault task scope, or null when none is configured.
+  private editorHiding(): EditorHidingSettings {
+    return normalizeEditorHidingSettings(this.data.editorHiding);
+  }
+
   private scope(): VaultScope | null {
     const s = this.data.scope ? normalizeScope(this.data.scope) : null;
     return s && scopeIsActive(s) ? s : null;

--- a/dayglance-obsidian-plugin/src/settingsTab.ts
+++ b/dayglance-obsidian-plugin/src/settingsTab.ts
@@ -15,6 +15,7 @@ import {
   type BridgePairing,
 } from './pairing';
 import type { AgendaKeyState, AgendaUser } from './agenda';
+import type { EditorHidingSettings } from './editorHidingRules';
 import { normalizeScope, SCOPE_WINDOW_MIN_DAYS, SCOPE_WINDOW_MAX_DAYS, SCOPE_WINDOW_DEFAULT_DAYS, type VaultScope, normalizeProjectNoteSettings, PROJECT_NOTE_LAYOUTS, type ProjectNoteSettings } from '@glance-apps/obsidian-format';
 
 // Stamped by esbuild at bundle time (see esbuild.config.mjs `define`).
@@ -56,6 +57,9 @@ export interface BridgeSettingsHost extends PairingHost {
   /** Project and goal note workspaces (companion §4.3, rulings D and E). */
   getProjectNotes(): ProjectNoteSettings;
   setProjectNotes(s: ProjectNoteSettings): Promise<void>;
+  /** Editor hiding (display only, editorHiding.ts). */
+  getEditorHiding(): EditorHidingSettings;
+  setEditorHiding(s: EditorHidingSettings): Promise<void>;
 }
 
 const pairedSince = (pairing: BridgePairing): string => {
@@ -85,6 +89,7 @@ export class BridgeSettingTab extends PluginSettingTab {
     } else {
       this.displayUnpaired();
     }
+    this.displayEditor();
     this.displayBuildInfo();
   }
 
@@ -320,6 +325,20 @@ export class BridgeSettingTab extends PluginSettingTab {
         t.setPlaceholder('Templates/Goal.md').setValue(cur.goalTemplate).onChange((v) => { draft.goalTemplate = v; });
         t.inputEl.addEventListener('blur', () => void save());
       });
+  }
+
+  private displayEditor(): void {
+    this.containerEl.createEl('h3', { text: 'Editor' });
+    const cur = this.host.getEditorHiding();
+    const save = (patch: Partial<EditorHidingSettings>) => void this.host.setEditorHiding({ ...this.host.getEditorHiding(), ...patch });
+    new Setting(this.containerEl)
+      .setName('Hide dayGLANCE block ids')
+      .setDesc('In Live Preview, hide the ^dg- identity token at the end of a task line, except on the line the cursor is on. Block ids you created yourself are not affected.')
+      .addToggle((t) => t.setValue(cur.hideBlockIds).onChange((v) => save({ hideBlockIds: v })));
+    new Setting(this.containerEl)
+      .setName('Hide completed tasks in project and goal notes')
+      .setDesc('In notes linked to a dayGLANCE project or goal, hide checked task lines in Live Preview and Reading view. The line stays in the note and shows again when the cursor is on it. Daily notes are not affected.')
+      .addToggle((t) => t.setValue(cur.hideCompletedInLinkedNotes).onChange((v) => save({ hideCompletedInLinkedNotes: v })));
   }
 
   private displayUnpaired(): void {

--- a/dayglance-obsidian-plugin/test/editorHidingRules.test.ts
+++ b/dayglance-obsidian-plugin/test/editorHidingRules.test.ts
@@ -1,0 +1,71 @@
+// The editor hiding rules (editorHidingRules.ts) are pure and pinned here;
+// the decorations and CSS that act on them (editorHiding.ts) are display
+// only and stay a manual check in a real editor.
+import { describe, expect, it } from 'vitest';
+import { isCompletedTaskLine, isCompletedTaskMarker, normalizeEditorHidingSettings, ownBlockIdSpan } from '../src/editorHidingRules';
+
+describe('ownBlockIdSpan: only a well-formed dayGLANCE token in block-id position', () => {
+  it('finds the token at the end of a task line, after whitespace', () => {
+    const line = '- [ ] Review proposal ^dg-a1b2c3d4';
+    const span = ownBlockIdSpan(line);
+    expect(span).toEqual({ from: line.length - 12, to: line.length });
+    expect(line.slice(span!.from, span!.to)).toBe('^dg-a1b2c3d4');
+  });
+
+  it('accepts a token that is the whole line', () => {
+    expect(ownBlockIdSpan('^dg-00000000')).toEqual({ from: 0, to: 12 });
+  });
+
+  it("leaves a user's own block ids alone", () => {
+    expect(ownBlockIdSpan('Some paragraph ^my-ref')).toBeNull();
+    expect(ownBlockIdSpan('Some paragraph ^abc123')).toBeNull();
+  });
+
+  it('leaves a damaged line visible: a token mid-line, glued to text, or malformed', () => {
+    // The 2026-08-31 merge corruptions: tokens spliced into the middle of a line.
+    expect(ownBlockIdSpan('Test ^dg-9gbev5xzing again to see')).toBeNull();
+    expect(ownBlockIdSpan('- [ ] 13: ^dg-q6wlym0v more words')).toBeNull();
+    expect(ownBlockIdSpan('- [ ] glued^dg-a1b2c3d4')).toBeNull();
+    expect(ownBlockIdSpan('- [ ] short ^dg-a1b2c3')).toBeNull();
+    expect(ownBlockIdSpan('- [ ] upper ^dg-A1B2C3D4')).toBeNull();
+    expect(ownBlockIdSpan('- [ ] trailing space ^dg-a1b2c3d4 ')).toBeNull();
+  });
+
+  it('with two tokens on one line, only the last (in position) is a candidate', () => {
+    const line = '- [ ] Test ^dg-9gbev5xzing again ^dg-592baea0';
+    expect(ownBlockIdSpan(line)).toEqual({ from: line.length - 12, to: line.length });
+  });
+});
+
+describe('isCompletedTaskLine: the plugin grammar, checked', () => {
+  it('matches x and X, with indentation', () => {
+    expect(isCompletedTaskLine('- [x] done')).toBe(true);
+    expect(isCompletedTaskLine('  - [X] done ^dg-a1b2c3d4')).toBe(true);
+  });
+  it('does not match open, other states, or non-dash lists', () => {
+    expect(isCompletedTaskLine('- [ ] open')).toBe(false);
+    expect(isCompletedTaskLine('- [-] cancelled')).toBe(false);
+    expect(isCompletedTaskLine('- [/] partial')).toBe(false);
+    expect(isCompletedTaskLine('* [x] star')).toBe(false);
+    expect(isCompletedTaskLine('- [x]')).toBe(false);
+    expect(isCompletedTaskLine('text - [x] not a list')).toBe(false);
+  });
+  it('reading view marker follows the same rule', () => {
+    expect(isCompletedTaskMarker('x')).toBe(true);
+    expect(isCompletedTaskMarker('X')).toBe(true);
+    expect(isCompletedTaskMarker(' ')).toBe(false);
+    expect(isCompletedTaskMarker('-')).toBe(false);
+    expect(isCompletedTaskMarker(undefined)).toBe(false);
+  });
+});
+
+describe('settings', () => {
+  it('defaults: block ids hidden, completed lines shown', () => {
+    expect(normalizeEditorHidingSettings(undefined)).toEqual({ hideBlockIds: true, hideCompletedInLinkedNotes: false });
+    expect(normalizeEditorHidingSettings({})).toEqual({ hideBlockIds: true, hideCompletedInLinkedNotes: false });
+  });
+  it('keeps explicit values and ignores junk', () => {
+    expect(normalizeEditorHidingSettings({ hideBlockIds: false, hideCompletedInLinkedNotes: true })).toEqual({ hideBlockIds: false, hideCompletedInLinkedNotes: true });
+    expect(normalizeEditorHidingSettings({ hideBlockIds: 'yes' as unknown as boolean })).toEqual({ hideBlockIds: true, hideCompletedInLinkedNotes: false });
+  });
+});

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -773,6 +773,41 @@ because new lines and any line touched for another reason pick the field
 up on their own, and the old lines it would reach are the ones least
 likely to matter in a Done query.
 
+#### Editor hiding (2026-09-05; display only)
+
+Two cosmetic rules, one plugin extension, no writes and nothing touching
+identity. Both add CSS classes and let a stylesheet hide; both exempt the
+cursor line through Obsidian's `.cm-active`, because seeing the token or
+the line when the cursor is on it has been the diagnostic window every
+time something went wrong.
+
+- **dayGLANCE's own block ids** (`^dg-` plus eight base-36 characters, in
+  block-id position: whitespace before, end of line) are hidden in Live
+  Preview. Default on: it can only ever hide our tokens. A token anywhere
+  else on a line is a damaged line (the stamper refuses those) and stays
+  visible, deliberately. Reading view already strips block ids.
+  *Considered and rejected:* the vault-wide CSS snippet behind a toggle. It
+  hides every block id including the user's own, and CSS cannot match on
+  text; a CodeMirror mark decoration is the same effort and scoped by
+  construction.
+- **Checked task lines in linked notes** (the transport's linked map, not
+  the id key alone: a stale key can outlive its project) are hidden in
+  Live Preview and, through a post-processor on the source path, in
+  Reading view. Daily notes untouched. Default off: without Dataview a
+  linked note has no Done list, so a hidden line would be visible only in
+  dayGLANCE. *Considered and rejected:* scoping to the `## Tasks` section.
+  A Templater override need not carry that heading, and the rule would
+  need a scan from the top of the note on every change; any checked line
+  in a linked note behaves the same.
+
+The costs, accepted: a hidden line cannot be clicked to un-check (arrow
+onto it, un-complete in dayGLANCE, or flip the toggle); its indented
+children stay visible; find-in-note can match invisible text. The settings
+ride data.json, so Obsidian's settings sync carries a flip to every copy of
+the vault (§3.2's recorded dependency, harmless here). The line rules are
+pure and pinned (`editorHidingRules.test.ts`); rendering stays a manual
+check.
+
 ---
 
 ### 4.4 Templater, via guarded delegation


### PR DESCRIPTION
## Summary

Two cosmetic rules as one CodeMirror extension plus an injected stylesheet. No vault writes, nothing touching identity. Both exempt the cursor line through Obsidian's `.cm-active`, so a token or a line reappears the moment the cursor lands on it.

**1. dayGLANCE's own block ids, hidden in Live Preview (default on).** A `MatchDecorator` marks a well-formed `^dg-` token (eight base-36 characters) in block-id position: whitespace before, end of line. The user's own block ids are untouched, which the vault-wide CSS snippet could not do since CSS cannot match on text. A token anywhere else on a line is a damaged line and stays visible, deliberately. Reading view already strips block ids.

**2. Checked task lines in linked notes, hidden in Live Preview and Reading view (default off).** A view plugin adds a line class to `- [x]` / `- [X]` lines when the editor's file is on the transport's linked map (not the id key alone, since a stale key can outlive its project). A markdown post-processor does the same for Reading view by source path. Daily notes and unlinked notes are untouched.

## How it is wired

- The two settings live under Settings → dayGLANCE Bridge → Editor and toggle **body classes** the stylesheet keys on, so a flip takes effect in every open pane at once with no editor dispatch. The decorations always run and cover visible lines only.
- A link made or broken while the note is open refreshes the decoration through a new optional `BridgeHost.onLinkedNotesChanged` callback, fired after the linked map is persisted. Editors get a no-change transaction carrying a refresh effect; a pane in Reading view re-renders.
- Styles are injected like the agenda view's, so the manual install stays two files.
- `@codemirror/state` and `@codemirror/view` become explicit type-only dev dependencies. They were already present transitively and are already external at bundle time. The lockfile diff is the dropped `peer` flags only.

## Judgment calls for review

- **Any checked line in a linked note, not only under `## Tasks`.** A Templater override need not carry that heading, and a section rule would need a scan from the top on every change.
- **Default off for the completed-line rule.** Without Dataview a linked note has no Done list, so a hidden line would be visible only in dayGLANCE.
- **Accepted costs:** a hidden line cannot be clicked to un-check (arrow onto it, un-complete in dayGLANCE, or flip the toggle); its indented children stay visible; find-in-note can match invisible text. Plugin settings ride data.json, so Obsidian settings sync carries a flip vault-wide.

Both rejected shapes and the costs are recorded in companion spec §4.3 ("Editor hiding").

## Verification

- `npm run build` in the plugin: type-check and bundle clean.
- Full suite green (222 files, 2856 tests), including the new `test/editorHidingRules.test.ts` pinning the pure line rules: block-id position, the merge-corrupted line shapes from 2026-08-31 staying visible, the checkbox grammar, and the defaults.
- Rendering is a manual check after merge: in Live Preview, a daily-note token should vanish off the cursor line and return on it; in a linked note with the second toggle on, checked lines should vanish in both modes and return under the cursor. **Remove the vault-wide `.cm-blockid` CSS snippet once this is in**, otherwise it keeps hiding every block id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_