### PR TITLE
Project routing: a task assigned to a linked project lives in its note

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -93,6 +93,14 @@ manually or via BRAT, not submitted to the community directory.
   template asks nothing interactively, otherwise `{{title}}`, `{{date}}`
   and `{{goal}}` are filled and the rest is left visible). Placement happens
   at creation only; linking an existing note never creates or moves.
+  **A project's tasks live in its note** (companion §4.3, project routing):
+  a task assigned to a linked project in dayGLANCE is written into the
+  note's `## Tasks` section (created there, moved there on reassignment,
+  removed on unassignment, its schedule as line metadata), and a task typed
+  in the note imports assigned to the project. A linked note is in the task
+  scope by virtue of the link, folder setting or not. The plugin applies
+  `task_append` (note-task placement: section end, never sorted, never a
+  missing note) and `task_remove` (the line carrying a block id) for this.
 - Six commands: **Sync now** (drains pending intents + refreshes the
   heartbeat), **Enter pairing code**, **Unpair from GLANCEvault**
   (forgets the local credentials and the account key; revoke the token

--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -49,6 +49,7 @@ import {
   BRIDGE_INTENT_PREFIX,
   noteKeyForPath,
   noteInScope,
+  normalizeScope,
   scopeIsActive,
   completedSinceFor,
   PROJECT_NOTE_ID_KEY,
@@ -982,6 +983,27 @@ export class BridgeTransport {
       if (!(await this.emitLink({ targetId: prev, path, unlinked: true }))) this.linked.set(path, prev);
     }
     void this.persistLinked();
+    this.linkScopeChanged(path);
+  }
+
+  /**
+   * The link is the scope (companion §4.3, project routing): a note that
+   * became linked is adopted on the spot; one that stopped being linked is
+   * withdrawn (ruling C) unless the folder/tag scope still holds it.
+   */
+  private linkScopeChanged(path: string): void {
+    if (this.isDailyNote(path)) return;
+    const scoped = this.scopedNote(path);
+    if (scoped && !this.adopted.has(path)) {
+      this.adopted.add(path);
+      this.armObserve(path, false, 0);
+      void this.persistAdopted();
+    } else if (!scoped && this.adopted.has(path)) {
+      this.adopted.delete(path);
+      this.scopedPaths.delete(path);
+      void this.emitWithdrawal(path);
+      void this.persistAdopted();
+    }
   }
 
   /** A note's metadata changed (frontmatter edits arrive here, not on modify). */
@@ -1294,8 +1316,14 @@ export class BridgeTransport {
 
   // ── Vault task scope (companion §6) ──────────────────────────────────────
 
-  /** A non-daily note in the user's scope (folders and/or tags, ruling D). */
+  /**
+   * A non-daily note in the user's scope (folders and/or tags, ruling D) —
+   * or a note LINKED to a dayGLANCE project or goal (companion §4.3, project
+   * routing): the link is the scope. A project's task list lives in its
+   * note, so the note is observed whether or not its folder is scoped.
+   */
   private scopedNote(path: string): boolean {
+    if (this.linked.has(path)) return !this.isDailyNote(path);
     const scope = this.host.getScope?.() ?? null;
     if (!scope || !scopeIsActive(scope)) return false;
     if (!path.endsWith('.md') || path.startsWith('.') || this.isDailyNote(path)) return false;
@@ -1315,7 +1343,9 @@ export class BridgeTransport {
   /** Stamp options: the completion window applies to scoped notes only (ruling E). */
   private stampOptions(path: string): { completedSince: string | null } {
     if (this.dailyNoteDate(path)) return { completedSince: null };
-    const scope = this.host.getScope?.() ?? null;
+    // A linked note with no scope setting takes the default window: the
+    // window governs adoption of untracked completed lines only.
+    const scope = this.host.getScope?.() ?? (this.linked.has(path) ? normalizeScope(null) : null);
     if (!scope) return { completedSince: null };
     const now = new Date();
     const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
@@ -1331,7 +1361,7 @@ export class BridgeTransport {
   adoptTick(): void {
     if (this.disposed || !this.host.getPairing()) return;
     const scope = this.host.getScope?.() ?? null;
-    if (!scope || !scopeIsActive(scope)) return;
+    if (!(scope && scopeIsActive(scope)) && this.linked.size === 0) return;
     if (!this.adoptScanned) {
       this.adoptScanned = true;
       this.adoptQueue = this.host.app.vault.getMarkdownFiles()

--- a/dayglance-obsidian-plugin/test/projectNotes.scenarios.test.ts
+++ b/dayglance-obsidian-plugin/test/projectNotes.scenarios.test.ts
@@ -83,12 +83,26 @@ function mountDevice(name: string, lists: { projects?: Row[]; goals?: Row[] } = 
         if (JSON.parse(store.get('dayglance-bridge-outbox') ?? '[]').length === 0) break;
       }
     }),
-    writeback: () => run(async () => { for (const e of myEffects) if (e.deps?.length === 3) e.fn(); await advanceFake(50); await until(flushBridgeOutbox()); }),
+    /** Run the writeback effect, then push EVERYTHING it queued (a pass can emit several intents; the first emit's own flush may read the outbox before the rest land). */
+    writeback: () => run(async () => {
+      for (const e of myEffects) if (e.deps?.length === 3) e.fn();
+      await advanceFake(50);
+      for (let i = 0; i < 6; i++) {
+        await until(flushBridgeOutbox());
+        if (JSON.parse(store.get('dayglance-bridge-outbox') ?? '[]').length === 0) break;
+      }
+    }),
     patch: (id: string, fields: Row) => {
       const bump = (list: Row[]) => list.map((x) => (x.id === id ? { ...x, ...fields, lastModified: new Date().toISOString() } : x));
       setTasks(bump); setUnscheduledTasks(bump);
     },
     all: () => [...state.tasks, ...state.inbox],
+    /** A task born in dayGLANCE (random id, no vault fields), scheduled or in the inbox. */
+    add: (task: Row) => {
+      const t = { id: `t-${Math.random().toString(36).slice(2, 10)}`, completed: false, lastModified: new Date().toISOString(), ...task };
+      if (t.date) setTasks((prev) => [...prev, t]); else setUnscheduledTasks((prev) => [...prev, t]);
+      return t.id;
+    },
   };
 }
 
@@ -191,8 +205,8 @@ describe('project and goal notes: creation, the maintained map, the project fiel
     expect(s.plugin.app.vault.writes).toBe(writes + 1);
   });
 
-  it('4. a daily-note task reassigned in dayGLANCE gets the project wikilink on its line; an Obsidian edit of the field reassigns it back', async () => {
-    const projects = [{ id: 'p1', title: 'House', status: 'active', obsidianNotePath: 'Projects/House.md' }, { id: 'p2', title: 'Garden', status: 'active' }];
+  it('4. a daily-note task reassigned to an UNLINKED project gets the project field on its line; an Obsidian edit of the field reassigns it back', async () => {
+    const projects = [{ id: 'p2', title: 'Garden', status: 'active' }, { id: 'p3', title: 'Attic', status: 'active' }];
     await boot({ projects });
     await s.write('Daily/2026-09-04.md', '## Tasks\n- [ ] Call the plumber\n');
     for (let i = 0; i < 40; i++) await s.advance(1000);
@@ -201,20 +215,158 @@ describe('project and goal notes: creation, the maintained map, the project fiel
     expect(task.id).toMatch(/^obsidian-dg-/);
     expect(task.projectId).toBeUndefined();
 
-    A.patch(task.id, { projectId: 'p1' });
+    A.patch(task.id, { projectId: 'p2' });
     await A.writeback();
     await s.plugin.transport.drain();
-    // The note's basename equals the title, so the wikilink needs no alias.
-    expect(s.text('Daily/2026-09-04.md')).toMatch(/- \[ \] Call the plumber \[project:: \[\[Projects\/House\]\]\] \^dg-/);
-    for (let i = 0; i < 40; i++) await s.advance(1000);
-    await A.sync();
-    expect(A.all()[0].projectId).toBe('p1');
-    expect(A.all()[0].title).toBe('Call the plumber #obsidian');
-
-    const edited = s.text('Daily/2026-09-04.md')!.replace('[project:: [[Projects/House]]]', '[project:: Garden]');
-    await s.write('Daily/2026-09-04.md', edited);
+    expect(s.text('Daily/2026-09-04.md')).toMatch(/- \[ \] Call the plumber \[project:: Garden\] \^dg-/);
     for (let i = 0; i < 40; i++) await s.advance(1000);
     await A.sync();
     expect(A.all()[0].projectId).toBe('p2');
+    expect(A.all()[0].title).toBe('Call the plumber #obsidian');
+
+    const edited = s.text('Daily/2026-09-04.md')!.replace('[project:: Garden]', '[project:: Attic]');
+    await s.write('Daily/2026-09-04.md', edited);
+    for (let i = 0; i < 40; i++) await s.advance(1000);
+    await A.sync();
+    expect(A.all()[0].projectId).toBe('p3');
+  });
+
+  // ── Project routing (owner, 2026-09-05): a task assigned to a linked
+  // project LIVES in that note. No folder scope is set in any of these:
+  // the link is the scope.
+  const NOTE = 'Projects/House.md';
+  async function bootLinked(extraProjects: Row[] = []): Promise<Row> {
+    const project = { id: 'p1', title: 'House', status: 'active' };
+    await boot({ projects: [project, ...extraProjects] });
+    expect(A.api.createProjectNote('project', 'p1', { title: 'House' })).toBe(true);
+    await A.flush();
+    await s.plugin.transport.drain();
+    await s.advance(3000);
+    await A.sync();
+    expect(project.obsidianNotePath).toBe(NOTE);
+    expect(s.plugin.transport.linkedNotes().has(NOTE)).toBe(true);
+    return project;
+  }
+  const lineFor = (title: string) => new RegExp(`- \\[ \\] ${title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} \\^dg-[a-z0-9]{8}`);
+
+  it('5. a task born in dayGLANCE under a linked project lands in the note under a derived token, the schedule as metadata, and round-trips under that id', async () => {
+    await bootLinked();
+    const before = A.all().length;
+    const scheduledId = A.add({ title: 'Buy hinges', projectId: 'p1', date: '2026-09-06', startTime: '10:00', duration: 30 });
+    const inboxId = A.add({ title: 'Price the gate', projectId: 'p1' });
+    await A.writeback();
+    await s.plugin.transport.drain();
+    const text = s.text(NOTE)!;
+    expect(text).toMatch(/- \[ \] 10:00-10:30 Buy hinges \[scheduled:: 2026-09-06\] \^dg-[a-z0-9]{8}/);
+    expect(text).toMatch(lineFor('Price the gate'));
+    // Under ## Tasks, at the section's end, before ## Done.
+    expect(text.indexOf('## Tasks')).toBeLessThan(text.indexOf('Buy hinges'));
+    expect(text.indexOf('Buy hinges')).toBeLessThan(text.indexOf('## Done'));
+    // Identity moved on enqueue: the app task now carries the derived id and its home.
+    const bound = A.all().filter((t) => t.projectId === 'p1');
+    expect(bound).toHaveLength(2);
+    for (const t of bound) {
+      expect(t.id).toMatch(/^obsidian-dg-/);
+      expect(t.obsidianNotePath).toBe(NOTE);
+      expect(t.importSource).toBe('obsidian');
+      expect(t.title).toMatch(/ #obsidian$/);
+    }
+    expect(A.all().find((t) => t.id === scheduledId)).toBeUndefined();
+    expect(A.all().find((t) => t.id === inboxId)).toBeUndefined();
+    const ids = bound.map((t) => t.id).sort();
+    // The observation round trip keeps ONE task per line, same ids, same assignment and schedule.
+    await s.settle();
+    await A.sync();
+    expect(A.all().length).toBe(before + 2);
+    expect(A.all().filter((t) => t.projectId === 'p1').map((t) => t.id).sort()).toEqual(ids);
+    expect(A.state.tasks.find((t) => t.title.startsWith('Buy hinges'))).toMatchObject({ date: '2026-09-06', startTime: '10:00', projectId: 'p1' });
+    expect(A.state.inbox.find((t) => t.title.startsWith('Price the gate'))).toMatchObject({ projectId: 'p1' });
+    // A second writeback pass writes nothing more.
+    const writes = s.plugin.app.vault.writes;
+    await A.writeback();
+    await s.plugin.transport.drain();
+    expect(s.plugin.app.vault.writes).toBe(writes);
+  });
+
+  it('6. assigning an existing daily-note task moves its line into the note under the SAME id; unassigning removes the line and the task stays in dayGLANCE, app-only', async () => {
+    await bootLinked();
+    await s.write('Daily/2026-09-04.md', '## Tasks\n- [ ] Call the plumber\n');
+    await s.settle();
+    await A.sync();
+    const task = A.all().find((t) => t.title.startsWith('Call the plumber'))!;
+    const id = task.id;
+    expect(task.obsidianFileDate).toBe('2026-09-04');
+
+    A.patch(id, { projectId: 'p1' });
+    await A.writeback();
+    await s.plugin.transport.drain();
+    expect(s.text('Daily/2026-09-04.md')).not.toContain('Call the plumber');
+    expect(s.text(NOTE)).toMatch(new RegExp(`- \\[ \\] Call the plumber \\^dg-${id.slice('obsidian-dg-'.length)}`));
+    expect(A.all().find((t) => t.id === id)).toMatchObject({ obsidianNotePath: NOTE, projectId: 'p1' });
+    // Both notes re-observed, in whatever order: still one task, same id.
+    await s.settle();
+    await A.sync();
+    await s.advance(100_000);
+    await A.sync();
+    expect(A.all().filter((t) => t.title.startsWith('Call the plumber')).map((t) => t.id)).toEqual([id]);
+    expect(A.all().find((t) => t.id === id)).toMatchObject({ obsidianNotePath: NOTE, projectId: 'p1' });
+
+    A.patch(id, { projectId: undefined });
+    await A.writeback();
+    await s.plugin.transport.drain();
+    expect(s.text(NOTE)).not.toContain('Call the plumber');
+    expect(s.text('Daily/2026-09-04.md')).not.toContain('Call the plumber');
+    const gone = A.all().find((t) => t.id === id)!;
+    expect(gone).toBeDefined();
+    expect(gone.importSource).toBeNull();
+    expect(gone.obsidianNotePath).toBeNull();
+    expect(gone.obsidianBlockId).toBe(id.slice('obsidian-dg-'.length)); // the token is for life
+    // The note's next observation (line absent) tombstones nothing: no task claims it.
+    await s.settle();
+    await A.sync();
+    await s.advance(100_000);
+    await A.sync();
+    expect(A.all().filter((t) => t.id === id)).toHaveLength(1);
+  });
+
+  it('7. a line typed in the linked note imports assigned (the link is the scope); reassigning to another linked project moves it between notes', async () => {
+    await bootLinked([{ id: 'p2', title: 'Garden', status: 'active' }]);
+    expect(A.api.createProjectNote('project', 'p2', { title: 'Garden' })).toBe(true);
+    await A.flush();
+    await s.plugin.transport.drain();
+    await s.advance(3000);
+    await A.sync();
+    const GARDEN = 'Projects/Garden.md';
+    expect(s.plugin.transport.linkedNotes().has(GARDEN)).toBe(true);
+
+    await s.write(NOTE, s.text(NOTE)!.replace('## Tasks\n', '## Tasks\n- [ ] Fix the gate\n'));
+    await s.settle();
+    await A.sync();
+    const task = A.all().find((t) => t.title.startsWith('Fix the gate'))!;
+    expect(task).toMatchObject({ projectId: 'p1', obsidianNotePath: NOTE });
+    expect(task.id).toMatch(/^obsidian-dg-/);
+
+    A.patch(task.id, { projectId: 'p2' });
+    await A.writeback();
+    await s.plugin.transport.drain();
+    expect(s.text(NOTE)).not.toContain('Fix the gate');
+    expect(s.text(GARDEN)).toMatch(new RegExp(`- \\[ \\] Fix the gate \\^dg-${task.id.slice('obsidian-dg-'.length)}`));
+    await s.settle();
+    await A.sync();
+    await s.advance(100_000);
+    await A.sync();
+    expect(A.all().filter((t) => t.title.startsWith('Fix the gate')).map((t) => t.id)).toEqual([task.id]);
+    expect(A.all().find((t) => t.id === task.id)).toMatchObject({ projectId: 'p2', obsidianNotePath: GARDEN });
+  });
+
+  it('8. a fresh link fills the note over passes, not in one burst', async () => {
+    await bootLinked();
+    for (let i = 0; i < 30; i++) A.add({ title: `Chore ${String(i).padStart(2, '0')}`, projectId: 'p1' });
+    await A.writeback();
+    await s.plugin.transport.drain();
+    expect((s.text(NOTE)!.match(/- \[ \] Chore /g) ?? []).length).toBe(25);
+    await A.writeback();
+    await s.plugin.transport.drain();
+    expect((s.text(NOTE)!.match(/- \[ \] Chore /g) ?? []).length).toBe(30);
   });
 });

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -808,6 +808,76 @@ the vault (§3.2's recorded dependency, harmless here). The line rules are
 pure and pinned (`editorHidingRules.test.ts`); rendering stays a manual
 check.
 
+#### Project routing (owner, 2026-09-05): a project's tasks live in its note
+
+*The deferral above is closed.* The owner's requirement, verbatim in
+substance: it is critical that the task list in a linked Obsidian project
+note matches the project card in dayGLANCE. Until this round it did not:
+dayGLANCE wrote a task into the vault only when its import source was
+Obsidian (a scanned line, or a task created with the `#obsidian` tag), so
+a project task born in dayGLANCE reached the vault only as a completion-log
+entry. The rule now:
+
+- **A task assigned to a project with a linked note lives in that note.**
+  Born in dayGLANCE, its line is created there (at the end of the `## Tasks`
+  section, or under a new heading at the end of the note; never sorted, the
+  note is the user's document; never created if the note is missing). Typed
+  in the note, it imports assigned (ruling H, unchanged). Reassigned
+  between linked projects, the line moves. Unassigned, or reassigned to a
+  project without a note, **the line is removed** and the task stays in
+  dayGLANCE, app-only: a task is in the vault because something puts it
+  there, and membership in a linked project is the second such reason
+  after the tag; remove the reason and the line goes, exactly as if the
+  task had been created as a plain inbox or scheduled task. A line the user
+  typed in the note and later unassigns in dayGLANCE is removed too; the
+  list matches the card. A scheduled project task keeps its date as line
+  metadata (ruling B) and no longer occupies the daily note; the daily
+  note shows its completion-log entry. Open tasks only: a completed task's
+  record is the completion log and the Done query.
+- **Identity.** A vault task's app id is `obsidian-dg-` plus its token, and
+  the scanner matches lines by that id, so a dayGLANCE-born task's id
+  switches to the derived form when its line is written: the stamping
+  identity move (gate (a), commit on enqueue, the retirement record, the
+  re-mint refusal), applied to a native task. The token is derived in the
+  note's namespace (ruling A) from the line as written. **A token is for
+  life**: unassignment clears the vault fields but keeps the token and the
+  id, so a later reassignment writes the same token and no second move
+  happens.
+- **The link is the scope.** A linked note is observed and stamped whether
+  or not its folder is in the §6 scope: the plugin adopts a note when it
+  becomes linked and withdraws it (ruling C) when the link goes and no
+  folder or tag holds it. Without a scope setting the completion window
+  is the default. This closes the setup trap of a linked note whose folder
+  was never scoped, found in the field on 2026-09-05.
+- **Where it runs.** A placement step at the head of the writeback pass
+  reconciles each task's home (its `obsidianNotePath`) against what its
+  assignment implies, so every assignment site in the app (task editor,
+  project card, planner, archive cascade) is covered without knowing the
+  step exists. The old line's removal is emitted before the new line's
+  append (`task_remove`, a new intent; `task_append` with `noteTask`);
+  the two notes' observations may arrive in either order, the cross-note
+  case the wall-clock confirmation hold exists for. Removal clears the
+  task's vault fields in the same action, so the note's next observation
+  finds no task claiming the missing line and tombstones nothing. Paced at
+  25 placements per pass: a fresh link fills its note over a few passes
+  (the declined-backfill cost, bounded to one note). Plugin-authoritative
+  only: the direct tier reads and writes by date, so it follows in its own
+  PR once the plugin round is field-tested (desktop has path read and
+  write already; each mobile bridge needs two methods).
+- **Creation.** A task created under a linked project, tagged or not, is
+  created as a plain task and placed by the next pass; the tagged
+  daily-note path is used only when the project has no note.
+
+*Considered and rejected:* returning an unassigned task to the daily note
+of its date. Every imported task carries the display tag, so a tag-based
+carve-out could not distinguish a daily-born task from a note-born one,
+and the owner's rule is the simpler one: no reason, no line. The one
+consequence accepted with it: a task typed in a daily note, assigned to a
+linked project and later unassigned, leaves the vault. Pinned by
+`projectNotes.scenarios.test.ts` 5 through 8 (creation, the daily-note
+move and the app-only unassignment across both notes' observations, the
+link as scope with a move between two linked notes, the pacing).
+
 ---
 
 ### 4.4 Templater, via guarded delegation
@@ -1197,6 +1267,7 @@ through retitles, deletes and revivals, and it is what this section pays for.
 
 | 14 | Vault task scope rulings B–F (§6.3): schedule-as-metadata, leaving scope, where scope lives, completion window (30 days, configurable 7–90), direct access stays daily-only | **Decided**, 2026-09-02 |
 | 15 | Project and goal notes rulings A–H (4.3): link identity (id key + locator), frontmatter ownership, block cadence, workspace shape, goals and nested folders, deletion, where links appear, in-note task adoption | **Decided**, 2026-09-03 |
-| 16 | Project notes, templates round (4.3): the project as a Dataview field on daily-note task lines (G amended), the maintained map shrunk to kind/status/goal (C amended), Dataview-presence note bodies chosen at creation; routing project tasks to the project note considered and deferred | **Decided**, 2026-09-04; the backfill of existing lines **declined** (owner, 2026-09-04; cost recorded in 4.3) |
+| 16 | Project notes, templates round (4.3): the project as a Dataview field on daily-note task lines (G amended), the maintained map shrunk to kind/status/goal (C amended), Dataview-presence note bodies chosen at creation; routing project tasks to the project note considered and deferred | **Decided**, 2026-09-04; the backfill of existing lines **declined** (owner, 2026-09-04; cost recorded in 4.3); the routing deferral **closed** by row 17 |
+| 17 | Project routing (4.3): a task assigned to a linked project lives in that note (created there, moved on reassignment, removed on unassignment, the token for life, the link as scope); direct tier to follow | **Decided**, 2026-09-05 (owner); plugin tier built |
 
 Nothing in this table is open. The SSE re-arm sequence (buildout spec status note) runs alongside the project-notes build, not ahead of it (owner, 2026-09-03).

--- a/packages/obsidian-format/src/bridgeStream.js
+++ b/packages/obsidian-format/src/bridgeStream.js
@@ -70,6 +70,7 @@
 // persisting its applied-ID set simply re-applies as no-ops.
 
 import { updateTaskLines, sortTaskLinesInSection, buildObsidianTaskLine } from './taskLines.js';
+import { splitBlockId } from './identity.js';
 import { withCreationFrontmatter } from './frontmatter.js';
 import { validateWikiNoteName } from './filename.js';
 
@@ -269,6 +270,16 @@ export function applyBridgeIntent(currentText, intent) {
       // guard the transport gets for free from being called once: a line
       // already carrying the task's block id (or the exact line, for a
       // tokenless task) means this intent has landed — replay is a no-op.
+      //
+      // NOTE TASK (companion §4.3, project routing): `noteTask: true`
+      // targets a linked project or goal note rather than a daily note.
+      // Three differences, all because the note is the user's document:
+      // a missing note is never created (a deleted project note stays
+      // deleted; dayGLANCE's missing-note state is the surface), the line
+      // goes at the END of the heading's section rather than the top, and
+      // the section is never sorted.
+      const noteTask = intent.noteTask === true;
+      if (noteTask && currentText === null) return { text: null, changed: false };
       const taskLine = buildObsidianTaskLine(intent.task, intent.date);
       if (currentText !== null) {
         const existingLines = currentText.split('\n');
@@ -301,7 +312,15 @@ export function applyBridgeIntent(currentText, intent) {
       if (heading && heading.trim()) {
         const headingStr = heading.trim();
         const headingLineIdx = lines.findIndex((l) => l === headingStr);
-        if (headingLineIdx !== -1) {
+        if (headingLineIdx !== -1 && noteTask) {
+          // Section end: after the last non-blank line before the next
+          // heading (or the end of the note).
+          let end = headingLineIdx + 1;
+          while (end < lines.length && !/^#{1,6}\s/.test(lines[end])) end++;
+          let at = end;
+          while (at > headingLineIdx + 1 && lines[at - 1].trim() === '') at--;
+          lines.splice(at, 0, taskLine);
+        } else if (headingLineIdx !== -1) {
           lines.splice(headingLineIdx + 1, 0, taskLine);
         } else {
           if (lines[lines.length - 1] !== '') lines.push('');
@@ -311,10 +330,34 @@ export function applyBridgeIntent(currentText, intent) {
         if (lines[lines.length - 1] !== '') lines.push('');
         lines.push(taskLine);
       }
-      const sorted = heading && heading.trim()
+      const sorted = heading && heading.trim() && !noteTask
         ? sortTaskLinesInSection(lines, heading.trim(), intent.date)
         : lines;
       return { text: sorted.join('\n'), changed: true };
+    }
+
+    case 'task_remove': {
+      // The line leaves the note (companion §4.3, project routing: a task
+      // unassigned from a linked project, or moved to another project's
+      // note). Matched by block id — the only identity a line has once it
+      // is stamped — or, for a tokenless line, by its exact raw title.
+      // Idempotent: no matching line means the removal has landed. Only
+      // the line goes; the section, its heading and its other lines are the
+      // user's.
+      if (currentText === null) return { text: null, changed: false };
+      const lines = currentText.split('\n');
+      const wantId = intent.blockId ? String(intent.blockId) : null;
+      const wantRaw = typeof intent.obsidianRawTitle === 'string' ? intent.obsidianRawTitle.trim() : null;
+      const idx = lines.findIndex((line) => {
+        const m = line.match(/^\s*- \[[ xX]\]\s+(.+)$/);
+        if (!m) return false;
+        const { text: body, blockId: lineId } = splitBlockId(m[1].trim());
+        if (wantId) return lineId === wantId;
+        return !lineId && wantRaw !== null && body.trim() === wantRaw;
+      });
+      if (idx === -1) return { text: currentText, changed: false };
+      lines.splice(idx, 1);
+      return { text: lines.join('\n'), changed: true };
     }
 
     case 'completion_log_append': {

--- a/packages/obsidian-format/src/bridgeStream.test.js
+++ b/packages/obsidian-format/src/bridgeStream.test.js
@@ -248,3 +248,42 @@ describe('applyBridgeIntent — notes', () => {
     expect(applyBridgeIntent('x', null)).toEqual({ unsupported: true });
   });
 });
+
+describe('applyBridgeIntent — note tasks (companion §4.3, project routing)', () => {
+  const note = '---\ndayglance-id: p1\n---\n# House\n\n## Tasks\n- [ ] Fix the gate ^dg-aaaaaaaa\n- [ ] Paint the fence ^dg-bbbbbbbb\n\n## Done\nquery here\n';
+  const append = {
+    type: 'task_append', path: 'Projects/House.md', date: null, noteTask: true,
+    task: { title: 'Call the plumber [scheduled:: 2026-09-10]', startTime: '10:00', duration: 30, isAllDay: false, blockId: 'cccccccc' },
+    heading: '## Tasks',
+  };
+
+  it('appends at the END of the Tasks section, before the next heading, without sorting', () => {
+    const out = applyBridgeIntent(note, append);
+    expect(out.changed).toBe(true);
+    expect(out.text).toBe('---\ndayglance-id: p1\n---\n# House\n\n## Tasks\n- [ ] Fix the gate ^dg-aaaaaaaa\n- [ ] Paint the fence ^dg-bbbbbbbb\n- [ ] 10:00-10:30 Call the plumber [scheduled:: 2026-09-10] ^dg-cccccccc\n\n## Done\nquery here\n');
+    expect(applyBridgeIntent(out.text, append).changed).toBe(false); // replay
+  });
+
+  it('never creates a missing note (a deleted project note stays deleted)', () => {
+    expect(applyBridgeIntent(null, append)).toEqual({ text: null, changed: false });
+  });
+
+  it('adds the heading at the end when the note has none', () => {
+    const out = applyBridgeIntent('# House\nsome text\n', append);
+    expect(out.text).toBe('# House\nsome text\n\n## Tasks\n- [ ] 10:00-10:30 Call the plumber [scheduled:: 2026-09-10] ^dg-cccccccc\n');
+  });
+
+  it('task_remove drops exactly the line carrying the block id; replay is a no-op; other lines untouched', () => {
+    const out = applyBridgeIntent(note, { type: 'task_remove', path: 'Projects/House.md', blockId: 'aaaaaaaa' });
+    expect(out.changed).toBe(true);
+    expect(out.text).toBe('---\ndayglance-id: p1\n---\n# House\n\n## Tasks\n- [ ] Paint the fence ^dg-bbbbbbbb\n\n## Done\nquery here\n');
+    expect(applyBridgeIntent(out.text, { type: 'task_remove', path: 'Projects/House.md', blockId: 'aaaaaaaa' }).changed).toBe(false);
+    expect(applyBridgeIntent(null, { type: 'task_remove', path: 'x.md', blockId: 'aaaaaaaa' })).toEqual({ text: null, changed: false });
+  });
+
+  it('task_remove without a block id matches a tokenless line by its exact raw title only', () => {
+    const plain = '## Tasks\n- [ ] Alpha\n- [x] Alpha ^dg-dddddddd\n- [ ] Beta\n';
+    const out = applyBridgeIntent(plain, { type: 'task_remove', path: 'n.md', blockId: null, obsidianRawTitle: 'Alpha' });
+    expect(out.text).toBe('## Tasks\n- [x] Alpha ^dg-dddddddd\n- [ ] Beta\n');
+  });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7004,9 +7004,17 @@ const DayPlanner = () => {
       // A task created under a project carries `[project:: …]` on its line
       // from the first write (companion §4.3, ruling G as amended); the
       // identity derives from the line as written.
-      ? (rawTitle, projectId) => buildNewObsidianTaskMeta(
-          withProjectMetadata(rawTitle, projectRefFor(projectId ? projects.find(pr => pr.id === projectId) : null)),
-          new Date().toISOString().split('T')[0])
+      ? (rawTitle, projectId) => {
+          const project = projectId ? projects.find(pr => pr.id === projectId) : null;
+          // A task born under a LINKED project is placed in the project
+          // note by the writeback's placement step (companion §4.3, project
+          // routing); the tagged daily-note line would only be moved a
+          // moment later.
+          if (project?.obsidianNotePath && !project.obsidianNoteMissingAt) return null;
+          return buildNewObsidianTaskMeta(
+            withProjectMetadata(rawTitle, projectRefFor(project)),
+            new Date().toISOString().split('T')[0]);
+        }
       : null,
     onWriteObsidianTask: obsidianConfig?.enabled && obsidianVaultHandleRef.current
       ? (task) => {

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -38,6 +38,12 @@ import { writebackSnapshotEntry } from '../utils/obsidianWritebackSnapshot.js';
 import { emitBridgeIntent, flushBridgeOutbox, publishBridgeConfig, publishBridgeCalendarProjection, getBridgePairingMeta, cachedBridgePairingMeta } from '../utils/obsidianBridgeStream.js';
 import { vaultViewerFor, visibleToViewer, assignVaultViewer, knownTaskIds } from '../utils/obsidianUserScope.js';
 import { writebackTargetFor } from '../utils/obsidianWritebackTarget.js';
+
+// PLACEMENT pacing (companion §4.3, project routing): at most this many
+// tasks bound, moved or removed per writeback pass. A fresh link fills its
+// note over a few passes; a vault-wide burst of line writes is the shape
+// that has started wars (the declined-backfill cost record).
+const PLACEMENT_PER_PASS = 25;
 import { noteTaskId, withScheduledMetadata, withProjectMetadata } from '@glance-apps/obsidian-format';
 import { fetchBridgeObservations, applyBridgeObservations, commitBridgeObservationCursor, pendingBridgeObservations } from '../utils/obsidianBridgeInbound.js';
 import {
@@ -1404,7 +1410,109 @@ export default function useObsidianSync({
     } catch { remintTombstoneBundles = []; }
     const writebackLiveIds = new Set(allObsidian.map(t => String(t.id)));
 
+    // ── PLACEMENT (companion §4.3, project routing; owner 2026-09-05) ────
+    // A task assigned to a project with a linked note LIVES IN THAT NOTE:
+    // its line is created there, moved there on reassignment, removed on
+    // unassignment. The project card and the note's task list are one
+    // list. Reconciled here, every pass, from what the task says about its
+    // home (obsidianNotePath) against what its assignment implies — so
+    // every assignment site in the app is covered without knowing this
+    // step exists. Plugin-authoritative only (ruling F: non-daily notes
+    // are plugin-only until the direct tier's own PR). Open tasks only:
+    // a completed task's record is the completion log. Paced, see
+    // PLACEMENT_PER_PASS. Identity: a token is for life — a task without
+    // one gets it here, in the new note's namespace (ruling A), through
+    // the same re-mint refusal as every minting site, and the id switch
+    // commits on enqueue like every identity move (gate (a)).
+    const placed = new Set();
+    if (authoritative && blockIdWritesEnabled()) {
+      const projectsNow = projectsRef.current || [];
+      const noteOf = (pr) => (pr && pr.obsidianNotePath && !pr.obsidianNoteMissingAt ? normalizeNotePath(pr.obsidianNotePath) : null);
+      const linkedProjectPaths = new Set(projectsNow.map(noteOf).filter(Boolean));
+      const homeFor = (t) => noteOf(t.projectId ? projectsNow.find(pr => pr && String(pr.id) === String(t.projectId)) : null);
+      const schedFmt = tasksPluginRef.current ? 'tasks' : 'dataview';
+      let budget = PLACEMENT_PER_PASS;
+      for (const task of [...tasks, ...unscheduledTasks]) {
+        if (budget <= 0) break;
+        if (!task || task.archived || task.recurrence || task.recurringTemplateId) continue;
+        if (!visibleToViewer(task, writeViewer)) continue;
+        const isVault = task.importSource === 'obsidian' && !!task.obsidianRawTitle;
+        const here = isVault && task.obsidianNotePath ? normalizeNotePath(task.obsidianNotePath) : null;
+        const home = homeFor(task);
+        // Into (or between) linked notes: the task is open and not already home.
+        const wantsMove = !!home && !task.completed && here !== home;
+        // Out of a linked note with nowhere to go: unassigned, reassigned to
+        // an unlinked project, or completed while being reassigned.
+        const leaves = isVault && !!here && linkedProjectPaths.has(here) && here !== home && !wantsMove;
+        if (!wantsMove && !leaves) continue;
+        budget--;
+
+        // The line as it will read in its new home: no project field (the
+        // note is the project, ruling H), the schedule as metadata (B).
+        const baseRaw = isVault ? task.obsidianRawTitle : String(task.title || '').replace(/\s*#obsidian\b/gi, '').trim();
+        const rawTitle = wantsMove ? withScheduledMetadata(withProjectMetadata(baseRaw, null), task.date || null, schedFmt) : null;
+
+        let blockId = task.obsidianBlockId || null;
+        let minted = null;
+        if (wantsMove && !blockId) {
+          minted = deriveBlockId(home, rawTitle);
+          if (isTombstonedRemint(remintRecord, task.id, appIdForBlockId(minted), remintTombstoneBundles, writebackLiveIds)) {
+            console.error(`Obsidian: REFUSING to re-mint ^dg-${minted} for ${task.id} while placing it in ${home} (retire/tombstone oscillation guard).`);
+            continue;
+          }
+          blockId = minted;
+        }
+
+        // The old line goes, then the new one lands. The two notes'
+        // observations may arrive in either order — the cross-note case
+        // the wall-clock confirmation hold exists for.
+        let ok = true;
+        if (isVault) {
+          const from = writebackTargetFor(task, obsidianConfig);
+          if (from) ok = !!emitBridgeIntent('task_remove', { path: from.path, blockId: task.obsidianBlockId || null, obsidianRawTitle: task.obsidianRawTitle });
+        }
+        if (wantsMove && ok) {
+          ok = !!emitBridgeIntent('task_append', {
+            path: home, date: null, noteTask: true, heading: '## Tasks',
+            task: {
+              title: rawTitle,
+              startTime: task.isAllDay ? null : (task.startTime || null),
+              duration: task.isAllDay ? null : (task.duration || null),
+              isAllDay: !!task.isAllDay,
+              blockId,
+            },
+          });
+        }
+        if (!ok) { reportTaskWriteFailure(); continue; }
+        placed.add(String(task.id));
+
+        // Commit on enqueue (gate (a), the general rule): the outbox is
+        // durable, so the enqueue is the write and the bookkeeping rides it.
+        // Deferred via nativeCommits so the snapshot moves operate on the
+        // fresh snapshot, like every confirmed write.
+        const oldId = task.id;
+        const newId = minted ? appIdForBlockId(minted) : task.id;
+        const displayTitle = /#obsidian\b/i.test(String(task.title || '')) ? task.title : `${String(task.title || '').trim()} #obsidian`;
+        const fields = wantsMove
+          ? { id: newId, importSource: 'obsidian', obsidianRawTitle: rawTitle, obsidianNotePath: home, obsidianFileDate: undefined, obsidianBlockId: blockId, title: displayTitle }
+          // Leaving the vault: app-only again, the token kept for life.
+          : { importSource: null, obsidianRawTitle: null, obsidianNotePath: null, obsidianFileDate: undefined };
+        nativeCommits.push(() => {
+          const apply = t => (t.id === oldId ? { ...t, ...fields } : t);
+          setTasks(prevTasks => prevTasks.map(apply));
+          setUnscheduledTasks(prevTasks => prevTasks.map(apply));
+          const snap = obsidianPrevTaskStateRef.current;
+          delete snap[oldId];
+          if (wantsMove) {
+            snap[newId] = { completed: task.completed, startTime: task.startTime || null, duration: task.duration || null, title: displayTitle, date: task.date || null, projectId: task.projectId || null };
+            if (minted) recordRetirements([oldId], newId);
+          }
+        });
+      }
+    }
+
     for (const task of allObsidian) {
+      if (placed.has(String(task.id))) continue;
       const p = prev[task.id];
       if (!p) continue;
 
@@ -1750,7 +1858,7 @@ export default function useObsidianSync({
     // Include date so we can detect future rescheduling to a different day.
     const next = {};
     for (const task of allObsidian) {
-      next[task.id] = { completed: task.completed, startTime: task.startTime || null, duration: task.duration || null, title: task.title, date: task.date || null };
+      next[task.id] = { completed: task.completed, startTime: task.startTime || null, duration: task.duration || null, title: task.title, date: task.date || null, projectId: task.projectId || null };
     }
     obsidianPrevTaskStateRef.current = next;
 


### PR DESCRIPTION
## Summary

Owner ruling, 2026-09-05: the task list in a linked Obsidian project note must match the project card in dayGLANCE. Until now dayGLANCE wrote a task into the vault only when its import source was Obsidian (a scanned line, or a task created with the `#obsidian` tag), so a project task born in dayGLANCE reached the vault only as a completion-log entry. This closes the routing deferral from the templates round.

**The rule.** A task assigned to a project with a linked note lives in that note:

- Born in dayGLANCE, its line is created at the end of the note's `## Tasks` section (never sorted, the note is the user's document; never created if the note is missing).
- Typed in the note, it imports assigned to the project (ruling H, unchanged).
- Reassigned between linked projects, the line moves.
- Unassigned, or reassigned to a project without a note, the line is removed and the task stays in dayGLANCE, app-only. No reason, no line.
- A scheduled project task keeps its date as line metadata (ruling B) and no longer occupies the daily note; the daily note shows its completion-log entry.
- Open tasks only. A completed task's record is the completion log and the Done query.

## How it is built

- **Placement step** at the head of the writeback pass in `useObsidianSync`: reconciles each task's home (`obsidianNotePath`) against what its assignment implies, so every assignment site in the app (task editor, project card, planner, archive cascade) is covered without knowing the step exists. Plugin-authoritative only.
- **Identity.** A vault task's app id is `obsidian-dg-` plus its token and the scanner matches by that id, so a dayGLANCE-born task takes the existing stamping identity move: token derived in the note's namespace, id switch committed on enqueue, retirement recorded, re-mint refusal honored. **A token is for life**: unassignment clears the vault fields but keeps the token and id, so a later reassignment writes the same token with no second move.
- **Removal is safe against the deletion signal.** The vault fields are cleared in the same action that emits the removal, so the note's next observation finds no task claiming the missing line and tombstones nothing. Removal is emitted before the append on a move; the two notes' observations may arrive in either order, which the wall-clock confirmation hold already covers (pinned in scenarios 6 and 7 with a 100 s advance).
- **obsidian-format:** new `task_remove` intent (line by block id, or exact raw title when tokenless); `task_append` gains `noteTask` placement (section end, no sort, no creation of a missing note).
- **Plugin:** a linked note is in the observation scope by virtue of the link. Adopted when it becomes linked, withdrawn (ruling C) when unlinked unless a folder or tag still holds it, adoption runs with links alone, default completion window without a scope setting. This closes the setup trap found in the field this morning, where a linked note's folder was never scoped.
- **Creation:** a task created under a linked project, tagged or not, is created plain and placed by the next pass, instead of being appended to the daily note by the tag path and moved a moment later.
- Paced at 25 placements per pass, so a fresh link fills its note over a few passes rather than in a burst.
- The writeback snapshot's own rebuild now records `projectId` (it was only recorded by the scan path, so a reassignment after a writeback could go undetected until the next scan).

## Judgment calls for review

- **Unassignment removes the line even for a line the user typed in the note.** Follows directly from "the list matches the card". Recorded in the spec with the one accepted consequence: a task typed in a daily note, assigned to a linked project, then unassigned, leaves the vault. The alternative (return it to its daily note) is recorded as considered and rejected, since every imported task carries the display tag and a tag-based carve-out cannot tell the cases apart.
- **Project unlink leaves lines where they are.** Unlinking a note in dayGLANCE is not an unassignment; the note simply stops being observed unless a folder or tag scopes it.
- **Completed tasks are not moved.** A completed task reassigned out of a linked note has its line removed and goes app-only, like an unassignment.
- **Direct tier deferred to its own PR.** It reads and writes by date; desktop has path read and write already, each mobile bridge needs two methods. Sequenced after this round is field-tested.

## Verification

- Full suite green: 222 files, 2865 tests. Lint clean. Plugin type-checks and bundles.
- Harness: scenario 4 reworked around an unlinked project (the field on a daily line); new scenarios 5 to 8 pin creation under a linked project (scheduled and inbox, derived tokens, round trip under the same ids, a second pass writes nothing), the daily-note move under the same id and the app-only unassignment across both notes' observations, a line typed in the note importing assigned with no scope set and moving between two linked notes, and the pacing (30 tasks land as 25 then 5).
- `bridgeStream.test.js` pins the note-task append placement, the no-create rule, and `task_remove` including replay and the tokenless match.
- The harness writeback helper in the project scenarios now drains the whole outbox: a pass can emit several intents and the first emit's own flush could read the outbox before the rest landed.

## Field test after merge

Add the linked folders back to scope only if you want; the link alone now suffices. Then: create a task under a linked project in dayGLANCE and watch it land at the end of the note's Tasks section; assign an existing daily-note task and watch it move; unassign it and confirm the line goes while the task stays in dayGLANCE; reassign between two linked projects. With the completed-line hiding toggle on, completed project tasks stay checked in the note and disappear off the cursor line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_