### PR TITLE
Daily notes on the template ladder: plugin template path, subset fallback, native gap, on-create trigger guard

### DIFF
--- a/dayglance-obsidian-plugin/README.md
+++ b/dayglance-obsidian-plugin/README.md
@@ -97,6 +97,13 @@ manually or via BRAT, not submitted to the community directory.
   template asks nothing interactively, otherwise `{{title}}`, `{{date}}`
   and `{{goal}}` are filled and the rest is left visible). Placement happens
   at creation only; linking an existing note never creates or moves.
+  **Daily notes** the plugin creates (a task added to today from dayGLANCE,
+  a completion-log entry) render an optional **Daily note template** the
+  same way, here, at creation; without one, the daily note template text
+  from dayGLANCE settings is used with `{{date}}` filled. With Templater's
+  "trigger on new file creation" on, a template that asks for input is not
+  applied at all (the trigger would run that prompt unattended); the
+  settings tab says so.
   **A project's tasks live in its note** (companion §4.3, project routing):
   a task assigned to a linked project in dayGLANCE is written into the
   note's `## Tasks` section (created there, moved there on reassignment,

--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -190,6 +190,12 @@ export interface BridgeHost {
   onLinkedNotesChanged?(): void;
 }
 
+/** The intents that CREATE a daily note when it is missing (the template ladder's daily creation point). */
+function isDailyNoteCreation(intent: Record<string, unknown>): boolean {
+  if (intent.type === 'completion_log_append') return true;
+  return intent.type === 'task_append' && intent.noteTask !== true;
+}
+
 // Same requestUrl-backed fetch shim as pairing.ts (CORS-free everywhere).
 const obsidianFetch = async (
   url: string,
@@ -1003,6 +1009,19 @@ export class BridgeTransport {
 
     const exists = await adapter.exists(path);
     const current = exists ? await adapter.read(path) : null;
+    // DAILY-NOTE CREATION THROUGH THE TEMPLATE LADDER (companion §4.4 build
+    // record, 2026-09-06). A daily note is created because dayGLANCE needed
+    // somewhere to write — a task append or a completion-log entry — and
+    // since the posture ruling that creation ALWAYS happens here, in a
+    // running Obsidian, at apply time: a paired device with Obsidian closed
+    // queues the intent rather than creating anything. So this is the one
+    // creation point a template note can be rendered at, through the same
+    // ladder project and goal notes use. Without a template note the
+    // intent's own text template stands (dailyNoteCreationBody, below).
+    if (current === null && isDailyNoteCreation(intent)) {
+      const dailyTemplate = normalizeProjectNoteSettings(this.host.getProjectNotes?.() ?? null).dailyTemplate;
+      if (dailyTemplate) return this.applyDailyNoteCreation(path, intent, dailyTemplate);
+    }
     const result = applyBridgeIntent(current, intent);
     if ('unsupported' in result) {
       if (!this.warnedUnsupported) {
@@ -1287,19 +1306,108 @@ export class BridgeTransport {
   }
 
   /**
-   * Render a template note for a new project or goal note through the §4.4
-   * ladder: Templater when it is installed, its render methods feature-detect,
-   * and the template asks nothing interactively (`tp.system.` would open a
-   * modal nobody is looking at and never settle); otherwise the subset
-   * renderer, leaving unsupported variables visible. Null when the template
-   * note does not exist.
+   * Create a daily note from the configured template note, then apply the
+   * intent to it. Two steps on purpose: the note is created first with the
+   * intent's own fallback body (a NON-EMPTY file, so a Templater folder
+   * template never races the write, and so the note already stands
+   * correct if the render fails), then rendered against that TFile —
+   * Templater's running config wants the real target — and rewritten with
+   * the intent applied to the rendered body.
+   */
+  private async applyDailyNoteCreation(path: string, intent: Record<string, unknown>, templatePath: string): Promise<'applied' | 'deferred'> {
+    const date = String(intent.date ?? '');
+    // Under Templater's on-create trigger the fallback text is rendered by
+    // Templater too, so it gets the same pre-scan as a template note.
+    const safeIntent = { ...intent, template: this.safeFallbackTemplate(String(intent.template ?? '')) };
+    const first = applyBridgeIntent(null, safeIntent);
+    if ('unsupported' in first || 'error' in first || !first.changed || first.text === null) return 'applied';
+    await this.ensureParentDirs(path);
+    let created: TFile;
+    try {
+      created = await this.host.app.vault.create(path, first.text);
+    } catch (e) {
+      // The path appeared between the existence check and the create (a
+      // race with Obsidian or a sync): the ordinary apply path handles an
+      // existing note on the next drain.
+      console.warn(`dayGLANCE bridge: could not create ${path}; retrying on the next drain`, e);
+      return 'deferred';
+    }
+    const body = await this.renderTemplate(templatePath, created, { title: created.basename, date, goal: '' });
+    if (body === null) return 'applied'; // template missing or refused: the fallback note stands
+    const second = applyBridgeIntent(withCreationFrontmatter(body, date), safeIntent);
+    if ('unsupported' in second || 'error' in second || second.text === null) return 'applied';
+    await this.host.app.vault.modify(created, second.text);
+    return 'applied';
+  }
+
+  /**
+   * Is Templater's "trigger on new file creation" on? THE SECOND DOOR
+   * (companion §4.4, build caution): our pre-scan guards the render WE
+   * perform, but with this trigger on Templater renders every new file
+   * itself, whether we delegated or not — and an interactive call in it
+   * hangs invisibly outside our guard. As of Templater 2.21 the setting is
+   * device-local (`templater-local-settings` in Obsidian's local storage);
+   * older builds kept it in the synced plugin settings. Both are read.
+   */
+  private templaterOnCreateTrigger(): boolean {
+    try {
+      const app = this.host.app as unknown as { loadLocalStorage?: (k: string) => unknown; plugins?: { plugins?: Record<string, unknown> } };
+      const raw = typeof app.loadLocalStorage === 'function' ? app.loadLocalStorage('templater-local-settings') : null;
+      const local = typeof raw === 'string' ? JSON.parse(raw) as unknown : raw;
+      if (local && typeof local === 'object' && (local as Record<string, unknown>).trigger_on_file_creation === true) return true;
+      const tp = app.plugins?.plugins?.['templater-obsidian'] as { settings?: Record<string, unknown> } | undefined;
+      return tp?.settings?.trigger_on_file_creation === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * The app's text template as a fallback BODY: under the on-create
+   * trigger Templater will render whatever we write, so an interactive
+   * call in it is the same hang; strip to the bare note and say so.
+   */
+  private safeFallbackTemplate(text: string): string {
+    if (!text || !templateNeedsUser(text) || !this.templaterOnCreateTrigger()) return text;
+    this.noteTemplateIssue('The daily-note text template from dayGLANCE was not applied: it contains a tp.system.* call and Templater\'s "trigger on new file creation" is on, which would run that prompt unattended. Turn the trigger off, or take the prompt out of the template.');
+    return '';
+  }
+
+  private templateIssue: string | null = null;
+  /** The last template problem worth a settings-tab line (null: none since the plugin loaded). */
+  templateStatus(): string | null { return this.templateIssue; }
+  private noteTemplateIssue(message: string): void {
+    if (this.templateIssue !== message) console.warn(`dayGLANCE bridge: ${message}`);
+    this.templateIssue = message;
+  }
+
+  /**
+   * Render a template note for a new project, goal or daily note through
+   * the §4.4 ladder: Templater when it is installed, its render methods
+   * feature-detect, and the template asks nothing interactively
+   * (`tp.system.` would open a modal nobody is looking at and never settle);
+   * otherwise the subset renderer, leaving unsupported variables visible.
+   * Null when the template note does not exist — or when it is interactive
+   * AND Templater's on-create trigger is on: the subset would leave the
+   * interactive call visible, and the trigger would then run it on the new
+   * file outside our guard. Delegating a non-interactive template under the
+   * trigger is safe: Templater's second pass finds nothing left to render.
    */
   private async renderTemplate(templatePath: string, target: TFile, vars: { title: string; date: string; goal: string }): Promise<string | null> {
     const tfile = this.host.app.vault.getAbstractFileByPath(normalizePath(templatePath));
-    if (!(tfile instanceof TFile)) return null;
+    if (!(tfile instanceof TFile)) {
+      this.noteTemplateIssue(`Template note "${templatePath}" was not found; the default body was used.`);
+      return null;
+    }
     const text = await this.host.app.vault.read(tfile);
     const subset = renderNoteTemplateSubset(text, vars);
-    if (templateNeedsUser(text)) return subset;
+    if (templateNeedsUser(text)) {
+      if (this.templaterOnCreateTrigger()) {
+        this.noteTemplateIssue(`Template "${templatePath}" was not applied: it asks for input (tp.system.*) and Templater's "trigger on new file creation" is on, which would run that prompt unattended. Turn the trigger off, or take the prompt out of the template.`);
+        return null;
+      }
+      return subset;
+    }
     type Fn = (...args: unknown[]) => unknown;
     const plugins = (this.host.app as unknown as { plugins?: { plugins?: Record<string, unknown> } }).plugins?.plugins;
     const templater = (plugins?.['templater-obsidian'] as { templater?: Record<string, unknown> } | undefined)?.templater;
@@ -1310,9 +1418,14 @@ export class BridgeTransport {
       // RunMode.CreateNewFromTemplate is 0 in every Templater release since 1.12.
       const config = (create as Fn).call(templater, tfile, target, 0);
       const out = await (parse as Fn).call(templater, config);
-      return typeof out === 'string' ? renderNoteTemplateSubset(out, vars) : subset;
+      if (typeof out !== 'string') {
+        this.noteTemplateIssue(`Templater returned nothing for "${templatePath}"; the subset renderer was used.`);
+        return subset;
+      }
+      return renderNoteTemplateSubset(out, vars);
     } catch (e) {
       console.warn('dayGLANCE bridge: Templater render failed; using the subset renderer', e);
+      this.noteTemplateIssue(`Templater failed to render "${templatePath}"; the subset renderer was used.`);
       return subset;
     }
   }

--- a/dayglance-obsidian-plugin/src/main.ts
+++ b/dayglance-obsidian-plugin/src/main.ts
@@ -303,6 +303,7 @@ export default class DayGlanceBridgePlugin extends Plugin {
         this.data.projectNotes = normalizeProjectNoteSettings(s);
         await this.saveData(this.data);
       },
+      templateStatus: () => this.transport.templateStatus(),
       getEditorHiding: () => this.editorHiding(),
       setEditorHiding: async (s) => {
         this.data.editorHiding = normalizeEditorHidingSettings(s);

--- a/dayglance-obsidian-plugin/src/settingsTab.ts
+++ b/dayglance-obsidian-plugin/src/settingsTab.ts
@@ -57,6 +57,8 @@ export interface BridgeSettingsHost extends PairingHost {
   /** Project and goal note workspaces (companion §4.3, rulings D and E). */
   getProjectNotes(): ProjectNoteSettings;
   setProjectNotes(s: ProjectNoteSettings): Promise<void>;
+  /** The last template problem (companion §4.4): a missing note, a refused interactive template, a failed render. Null when none. */
+  templateStatus?(): string | null;
   /** Editor hiding (display only, editorHiding.ts). */
   getEditorHiding(): EditorHidingSettings;
   setEditorHiding(s: EditorHidingSettings): Promise<void>;
@@ -325,6 +327,17 @@ export class BridgeSettingTab extends PluginSettingTab {
         t.setPlaceholder('Templates/Goal.md').setValue(cur.goalTemplate).onChange((v) => { draft.goalTemplate = v; });
         t.inputEl.addEventListener('blur', () => void save());
       });
+    new Setting(this.containerEl)
+      .setName('Daily note template')
+      .setDesc('Optional: vault path of a template note for daily notes dayGLANCE creates (a task added to today, a completion-log entry). Rendered the same way, here, when the note is created; {{date}} and {{title}} are the note\'s date. Without it, the daily note template text from dayGLANCE settings is used.')
+      .addText((t) => {
+        t.setPlaceholder('Templates/Daily.md').setValue(cur.dailyTemplate).onChange((v) => { draft.dailyTemplate = v; });
+        t.inputEl.addEventListener('blur', () => void save());
+      });
+    const issue = this.host.templateStatus?.() ?? null;
+    if (issue) {
+      this.containerEl.createEl('p', { cls: 'setting-item-description', text: `Template: ${issue}` });
+    }
   }
 
   private displayEditor(): void {

--- a/dayglance-obsidian-plugin/test/harness.ts
+++ b/dayglance-obsidian-plugin/test/harness.ts
@@ -19,7 +19,7 @@ import type { BridgePairing } from '../src/pairing';
 // The SAME specifier the app uses, so the root key lands in the module instance the app reads.
 import { setupDbRootKey, hasDbRootKey } from '@glance-apps/sync';
 import { getDbRootKey, hasDbRootKey as hasDbRootKeyDirect } from '@glance-apps/sync/src/dbCrypto.js';
-import { deriveBridgeSubkey, exportBridgeSubkey, normalizeScope, normalizeProjectNoteSettings, type VaultScope } from '@glance-apps/obsidian-format';
+import { deriveBridgeSubkey, exportBridgeSubkey, normalizeScope, normalizeProjectNoteSettings, type VaultScope, type ProjectNoteSettings } from '@glance-apps/obsidian-format';
 
 export const VAULT_URL = 'https://vault.test';
 
@@ -61,7 +61,7 @@ let generationCounter = 0;
 export interface PluginSide {
   app: App;
   transport: BridgeTransport;
-  data: { pairing?: BridgePairing; bridge?: BridgeState; scope?: VaultScope; saves: number };
+  data: { pairing?: BridgePairing; bridge?: BridgeState; scope?: VaultScope; projectNotes?: Partial<ProjectNoteSettings>; saves: number };
   setScope(scope: Partial<VaultScope>): Promise<void>;
   /** Simulate a plugin reload: a fresh transport over the same data.json. */
   reload(): void;
@@ -117,7 +117,7 @@ export async function createScenario(): Promise<Scenario> {
     getBridgeState: () => data.bridge ?? { appliedIds: [], hwm: 0 },
     saveBridgeState: async (state: BridgeState) => { data.bridge = state; data.saves++; },
     getScope: () => (data.scope ? normalizeScope(data.scope) : null),
-    getProjectNotes: () => normalizeProjectNoteSettings(null),
+    getProjectNotes: () => normalizeProjectNoteSettings(data.projectNotes ?? null),
     getViewer: () => pairing.userSyncId ?? null,
   });
   const boot = () => { transport = new BridgeTransport(host()); wireVaultEvents(app, transport); };

--- a/dayglance-obsidian-plugin/test/obsidianStub.ts
+++ b/dayglance-obsidian-plugin/test/obsidianStub.ts
@@ -276,6 +276,10 @@ export class App {
   workspace = new Workspace();
   fileManager = new FileManager(this.vault);
   plugins = { plugins: {} as Record<string, unknown> };
+  /** Obsidian's device-local key/value store (App.loadLocalStorage / saveLocalStorage). */
+  localStorageData = new Map<string, unknown>();
+  loadLocalStorage(key: string): unknown { return this.localStorageData.has(key) ? this.localStorageData.get(key) : null; }
+  saveLocalStorage(key: string, value: unknown): void { if (value === null || value === undefined) this.localStorageData.delete(key); else this.localStorageData.set(key, value); }
 }
 
 export const Platform = { isDesktopApp: false, isMobile: false, isMobileApp: false };

--- a/dayglance-obsidian-plugin/test/projectNotes.scenarios.test.ts
+++ b/dayglance-obsidian-plugin/test/projectNotes.scenarios.test.ts
@@ -37,7 +37,7 @@ vi.mock('../../src/utils/obsidianBridgeMode.js', () => ({ recordBridgeMode: vi.f
 
 const { createScenario, VAULT_URL, ACCOUNT_ID, until, advanceFake } = await import('./harness');
 const { default: useObsidianSync } = await import('../../src/hooks/useObsidianSync.js');
-const { flushBridgeOutbox, __resetBridgeStreamForTests } = await import('../../src/utils/obsidianBridgeStream.js');
+const { flushBridgeOutbox, emitBridgeIntent, __resetBridgeStreamForTests } = await import('../../src/utils/obsidianBridgeStream.js');
 const { NoteBlockWriter } = await import('../src/noteBlocks');
 const { parseYaml } = await import('obsidian');
 
@@ -97,6 +97,11 @@ function mountDevice(name: string, lists: { projects?: Row[]; goals?: Row[] } = 
       setTasks(bump); setUnscheduledTasks(bump);
     },
     all: () => [...state.tasks, ...state.inbox],
+    /** Emit one raw intent from this device and push it to the vault. */
+    emit: (type: string, fields: Record<string, unknown>) => run(async () => {
+      if (!emitBridgeIntent(type, fields)) throw new Error(`emit ${type} refused`);
+      await until(flushBridgeOutbox());
+    }),
     /** A task born in dayGLANCE (random id, no vault fields), scheduled or in the inbox. */
     add: (task: Row) => {
       const t = { id: `t-${Math.random().toString(36).slice(2, 10)}`, completed: false, lastModified: new Date().toISOString(), ...task };
@@ -368,5 +373,118 @@ describe('project and goal notes: creation, the maintained map, the project fiel
     await A.writeback();
     await s.plugin.transport.drain();
     expect((s.text(NOTE)!.match(/- \[ \] Chore /g) ?? []).length).toBe(30);
+  });
+});
+
+// ── Daily-note templates (companion §4.4 build record, 2026-09-06) ──────────
+// A daily note is created because dayGLANCE needed somewhere to write, and
+// since the posture ruling that creation always happens HERE, in a running
+// Obsidian, at apply time — so the plugin's creation point is where a
+// template note renders through the ladder. The stub has no Templater, so
+// the ladder's subset rung is what runs unless a scenario installs a fake.
+describe('daily-note templates: the ladder at the plugin\'s creation point', () => {
+  const DAILY = 'Daily/2026-09-10.md';
+  const TEMPLATE = 'Templates/Daily.md';
+  const appendFields = {
+    path: DAILY, date: '2026-09-10', heading: '## Tasks', template: '## Fallback\n',
+    task: { title: 'Water the plants #obsidian', startTime: null, duration: null, isAllDay: true, date: '2026-09-10', blockId: 'abc12345' },
+  };
+  const templaterFake = () => ({
+    templater: {
+      create_running_config: vi.fn((tf: unknown, target: { basename: string }, mode: number) => ({ tf, target, mode })),
+      read_and_parse_template: vi.fn(async (cfg: { target: { basename: string } }) => `# Rendered by Templater for ${cfg.target.basename}\n\n## Tasks\n`),
+    },
+  });
+
+  it('9. a task append that finds no note creates it from the configured template note (subset here), with the line under its heading, not from the text fallback', async () => {
+    await boot({});
+    await s.write(TEMPLATE, '# {{title}}\n\nToday is {{date}}.\n\n## Journal\n\n## Tasks\n');
+    s.plugin.data.projectNotes = { dailyTemplate: TEMPLATE };
+    await A.emit('task_append', appendFields);
+    await s.plugin.transport.drain();
+    const text = s.text(DAILY)!;
+    expect(text.startsWith('---\n')).toBe(true);
+    expect(text).toContain('# 2026-09-10');
+    expect(text).toContain('Today is 2026-09-10.');
+    expect(text).toContain('## Journal');
+    expect(text).toMatch(/## Tasks\n- \[ \] Water the plants #obsidian \^dg-abc12345/);
+    expect(text).not.toContain('## Fallback');
+    expect(s.plugin.transport.templateStatus()).toBeNull();
+    // Replay is a no-op: the note exists now and already carries the line.
+    await A.emit('task_append', appendFields);
+    await s.plugin.transport.drain();
+    expect(s.text(DAILY)).toBe(text);
+  });
+
+  it('9b. a completion-log entry creates the day\'s note from the same template; without a template note the text fallback stands', async () => {
+    await boot({});
+    await s.write(TEMPLATE, '# {{date}}\n\n## Done\n');
+    s.plugin.data.projectNotes = { dailyTemplate: TEMPLATE };
+    await A.emit('completion_log_append', { path: DAILY, date: '2026-09-10', heading: '## Done', entry: '- 10:00 Did the thing', template: '## Fallback\n' });
+    await s.plugin.transport.drain();
+    expect(s.text(DAILY)).toContain('# 2026-09-10');
+    expect(s.text(DAILY)).toContain('## Done\n- 10:00 Did the thing');
+    // No template note configured: the app's text template, subset filled.
+    s.plugin.data.projectNotes = {};
+    const OTHER = 'Daily/2026-09-11.md';
+    await A.emit('completion_log_append', { path: OTHER, date: '2026-09-11', heading: '## Done', entry: '- 11:00 Another', template: '# {{date}} fallback\n' });
+    await s.plugin.transport.drain();
+    expect(s.text(OTHER)).toContain('# 2026-09-11 fallback');
+  });
+
+  it('10. an INTERACTIVE template: without Templater\'s on-create trigger the subset leaves the call visible; with the trigger on it is refused, the fallback stands, and the settings tab says why', async () => {
+    await boot({});
+    await s.write(TEMPLATE, '# {{date}}\n<% tp.system.prompt("Mood?") %>\n\n## Tasks\n');
+    s.plugin.data.projectNotes = { dailyTemplate: TEMPLATE };
+    await A.emit('task_append', appendFields);
+    await s.plugin.transport.drain();
+    expect(s.text(DAILY)).toContain('<% tp.system.prompt("Mood?") %>'); // inert residue, Templater\'s own on-create behavior
+    expect(s.plugin.transport.templateStatus()).toBeNull();
+
+    // THE SECOND DOOR: the trigger renders every new file itself.
+    s.plugin.app.localStorageData.set('templater-local-settings', JSON.stringify({ trigger_on_file_creation: true }));
+    const D2 = 'Daily/2026-09-12.md';
+    await A.emit('task_append', { ...appendFields, path: D2, date: '2026-09-12', task: { ...appendFields.task, date: '2026-09-12' } });
+    await s.plugin.transport.drain();
+    const text = s.text(D2)!;
+    expect(text).not.toContain('tp.system');
+    expect(text).toContain('## Fallback');
+    expect(text).toMatch(/- \[ \] Water the plants #obsidian \^dg-abc12345/);
+    expect(s.plugin.transport.templateStatus()).toMatch(/asks for input/);
+
+    // The fallback text gets the same pre-scan under the trigger.
+    const D3 = 'Daily/2026-09-13.md';
+    await A.emit('task_append', { ...appendFields, path: D3, date: '2026-09-13', task: { ...appendFields.task, date: '2026-09-13' }, template: '<% tp.system.suggester(["a"],["a"]) %>\n' });
+    await s.plugin.transport.drain();
+    expect(s.text(D3)).not.toContain('tp.system');
+    expect(s.text(D3)).toMatch(/- \[ \] Water the plants/);
+  });
+
+  it('11. Templater installed: a non-interactive template is delegated (with the trigger on too: the second pass has nothing left to render); an interactive one never reaches it', async () => {
+    await boot({});
+    const fake = templaterFake();
+    s.plugin.app.plugins.plugins['templater-obsidian'] = fake;
+    await s.write(TEMPLATE, '# <% tp.date.now() %>\n\n## Tasks\n');
+    s.plugin.data.projectNotes = { dailyTemplate: TEMPLATE };
+    await A.emit('task_append', appendFields);
+    await s.plugin.transport.drain();
+    expect(fake.templater.read_and_parse_template).toHaveBeenCalledTimes(1);
+    expect(fake.templater.create_running_config.mock.calls[0][2]).toBe(0); // RunMode.CreateNewFromTemplate
+    expect(s.text(DAILY)).toContain('# Rendered by Templater for 2026-09-10');
+    expect(s.text(DAILY)).toMatch(/## Tasks\n- \[ \] Water the plants #obsidian \^dg-abc12345/);
+
+    (fake as { settings?: Record<string, unknown> }).settings = { trigger_on_file_creation: true }; // the pre-2.21 synced form of the trigger
+    const D2 = 'Daily/2026-09-12.md';
+    await A.emit('task_append', { ...appendFields, path: D2, date: '2026-09-12', task: { ...appendFields.task, date: '2026-09-12' } });
+    await s.plugin.transport.drain();
+    expect(fake.templater.read_and_parse_template).toHaveBeenCalledTimes(2);
+    expect(s.text(D2)).toContain('# Rendered by Templater for 2026-09-12');
+
+    await s.write(TEMPLATE, '<% tp.system.prompt("x") %>\n');
+    const D3 = 'Daily/2026-09-13.md';
+    await A.emit('task_append', { ...appendFields, path: D3, date: '2026-09-13', task: { ...appendFields.task, date: '2026-09-13' } });
+    await s.plugin.transport.drain();
+    expect(fake.templater.read_and_parse_template).toHaveBeenCalledTimes(2); // never delegated
+    expect(s.text(D3)).toContain('## Fallback');
   });
 });

--- a/docs/obsidian-companion-spec.md
+++ b/docs/obsidian-companion-spec.md
@@ -974,6 +974,93 @@ trigger leaves raw `<% %>` in the note. Visible, not corrupt.
 - Register nothing before `onLayoutReady` — Templater's own setup, including its
   WASM parser, is async.
 
+
+#### Build record (2026-09-06): daily notes on the ladder
+
+Project and goal notes shipped with the ladder; daily notes had a separate,
+older mechanism — a plain-text template typed into a textarea in dayGLANCE
+settings, written verbatim at creation, no Templater, no substitution, not
+even the date — and six creation points across three code paths, one of
+which (the native direct-tier append) applied no template at all. This
+record closes that.
+
+**What was built.**
+
+1. **A daily-note template path in the plugin's settings**, beside the
+   project and goal ones (`dailyTemplate`, `normalizeProjectNoteSettings`).
+   The plugin renders it through the existing ladder at its creation point
+   for the two daily-note-creating intents, `task_append` (daily notes only;
+   a note task never creates) and `completion_log_append`. The pre-scan
+   covers it for free. Subset variables: `{{date}}`, and `{{title}}` as the
+   note's name. *Ruling: plugin settings, not a synced app setting.* Only the
+   plugin can render, so a synced setting pointing at a vault path would be
+   one some devices could act on and others could not — the split-brain
+   shape the posture ruling exists to eliminate.
+2. **The app's text template stays as the fallback body** when no path is
+   configured, now with the subset filled on both tiers
+   (`dailyNoteCreationBody`, one function under every creation point: the
+   FSA and native appends, the two intents, the completion log's direct
+   path, and the editor's seed). Nothing changes for anyone who never sets a
+   path except that `{{date}}` now works.
+3. **The native direct-tier gap is closed.** `""` is absent-or-empty under
+   the native read contract; it now reads as absent, and the note is created
+   from the template as the FSA append does. *Ruling, the accepted cost:* a
+   genuinely empty existing note gets the template prepended — small and
+   recoverable, the user deletes it. The alternative was every native
+   direct-tier daily note bare forever, which is not recoverable because
+   nobody knows it happened. Recorded at the site
+   (`appendTaskToDailyNoteNative`; the completion log's native branch).
+4. **Templater's on-create trigger is detected**, for daily, project and
+   goal notes alike, since it is one mechanism and one exposure. THE SECOND
+   DOOR: the pre-scan guards the render *we* perform, but with "trigger
+   Templater on new file creation" on, Templater renders every new file
+   itself whether we delegated or not, and an interactive call in it hangs
+   invisibly outside our guard — the sharp edge arriving through a door the
+   guard did not cover. The rule: a non-interactive template is delegated as
+   before, trigger or no trigger (Templater's second pass over rendered
+   output has nothing left to render); an interactive template under the
+   trigger is refused outright — the subset would leave the interactive call
+   visible for the trigger to run — and the fallback body stands, itself
+   pre-scanned under the trigger (an interactive app text template drops to
+   the bare note). Both homes of the setting are read: the device-local
+   `templater-local-settings` (2.21+) and the synced plugin settings of
+   older builds. Refusals, a missing template note, and a failed render
+   surface in the plugin's settings tab as a template line, the way the
+   stamping tri-state does.
+
+**Two things worth writing down.**
+
+- **The rendering context is whichever Obsidian applies the intent.** If a
+  desktop's plugin drains a phone's intent, the daily note is created by the
+  desktop's Obsidian, and Templater's context — `tp.file`, `tp.date`, the
+  machine's clock and locale, anything reading that machine — is that
+  desktop. Fine for date variables, arbitrary for anything
+  machine-specific. A user with a machine-dependent daily template should
+  expect the note to reflect whichever Obsidian was open, not the device
+  that made the edit.
+- **The posture ruling fixed the unattended case as a side effect.** The
+  worry was a daily note created by dayGLANCE with no plugin present,
+  untemplated, at any hour. Since the posture ruling (build-out spec §3.2,
+  2026-09-06) a paired device with Obsidian closed queues an intent rather
+  than creating anything, so the note is created by a running Obsidian at
+  apply time. Render at apply time, in the plugin, never in the app — the
+  shape the ladder wanted, and it arrived by way of a different ruling.
+  What remains untemplated by the ladder is confined to the direct tier
+  (unpaired vaults), where the text fallback applies on both shells now.
+
+**Creation points after the build**, for the record:
+
+| Creation point | Tier | Body |
+|---|---|---|
+| Plugin `task_append`, `completion_log_append` | stream | template note through the ladder; else the text fallback, subset filled |
+| Task append, FSA desktop | direct | the text fallback, subset filled |
+| Task append and completion log, Android and iOS | direct | the text fallback, subset filled (was: nothing) |
+| Daily note editor in the app | both | the text fallback seeded into the editor, subset filled, for the user to edit |
+
+Harness scenarios 9, 9b, 10 and 11 in `projectNotes.scenarios.test.ts` pin
+the ladder at the creation point, the fallback, the interactive refusal
+under the trigger, and delegation against a fake Templater.
+
 ---
 
 ### 4.5 Dataview conventions, verified rather than assumed

--- a/packages/obsidian-format/src/bridgeStream.js
+++ b/packages/obsidian-format/src/bridgeStream.js
@@ -72,6 +72,23 @@
 import { updateTaskLines, sortTaskLinesInSection, buildObsidianTaskLine } from './taskLines.js';
 import { splitBlockId } from './identity.js';
 import { withCreationFrontmatter } from './frontmatter.js';
+import { renderNoteTemplateSubset } from './projectNotes.js';
+
+/**
+ * The body a daily note is CREATED from when an intent finds no note: the
+ * app's text template with the §4.4 subset filled — `{{date}}`, and
+ * `{{title}}` as the note's name (the date under the default pattern).
+ * Companion §4.4 build record (2026-09-06): the same substitution runs at
+ * every creation point (the FSA and native appends on the direct tier, the
+ * two creating intents here), so a template reads the same wherever the
+ * note is born. A template NOTE configured in the plugin renders through
+ * the full ladder at the plugin's creation point instead; this is the
+ * fallback body everyone gets who never sets one.
+ */
+export function dailyNoteCreationBody(template, date, path = null) {
+  const stem = typeof path === 'string' && path ? path.split('/').pop().replace(/\.md$/i, '') : String(date ?? '');
+  return withCreationFrontmatter(renderNoteTemplateSubset(template || '', { title: stem, date: String(date ?? '') }), date);
+}
 import { validateWikiNoteName } from './filename.js';
 
 // The GLANCEvault app namespace for everything the bridge stores.
@@ -306,7 +323,7 @@ export function applyBridgeIntent(currentText, intent) {
       }
       const base = currentText !== null
         ? currentText
-        : withCreationFrontmatter(intent.template || '', intent.date);
+        : dailyNoteCreationBody(intent.template, intent.date, intent.path);
       const lines = base.split('\n');
       const heading = intent.heading;
       if (heading && heading.trim()) {
@@ -379,7 +396,7 @@ export function applyBridgeIntent(currentText, intent) {
       }
       const logBase = currentText !== null
         ? currentText
-        : withCreationFrontmatter(intent.template || '', intent.date);
+        : dailyNoteCreationBody(intent.template, intent.date, intent.path);
       const logLines = logBase.split('\n');
       const logHeading = (intent.heading || '').trim();
       if (!logHeading) return { text: currentText, changed: false }; // the log always has a home

--- a/packages/obsidian-format/src/bridgeStream.test.js
+++ b/packages/obsidian-format/src/bridgeStream.test.js
@@ -9,6 +9,7 @@ import {
   observationEntityId,
   BRIDGE_INTENT_PREFIX,
   BRIDGE_OBSERVATION_PREFIX,
+  dailyNoteCreationBody,
 } from './bridgeStream.js';
 
 // The stream's load-bearing claims: envelopes round-trip and fail closed;
@@ -285,5 +286,43 @@ describe('applyBridgeIntent — note tasks (companion §4.3, project routing)', 
     const plain = '## Tasks\n- [ ] Alpha\n- [x] Alpha ^dg-dddddddd\n- [ ] Beta\n';
     const out = applyBridgeIntent(plain, { type: 'task_remove', path: 'n.md', blockId: null, obsidianRawTitle: 'Alpha' });
     expect(out.text).toBe('## Tasks\n- [x] Alpha ^dg-dddddddd\n- [ ] Beta\n');
+  });
+});
+
+
+// ── Companion §4.4 build record (2026-09-06): the daily-note creation body ──
+// Every point that CREATES a daily note renders the app's text template
+// through the same subset — `{{date}}`, and `{{title}}` as the note's name
+// — so a template reads the same wherever the note is born.
+describe('dailyNoteCreationBody / creation through the two daily-note intents', () => {
+  it('fills {{date}} and {{title}} (the note name from the path, else the date) and adds the creation frontmatter', () => {
+    const body = dailyNoteCreationBody('# {{title}}\n\nToday is {{date}}.\n', '2026-09-10', 'Daily/2026-09-10.md');
+    expect(body.startsWith('---\n')).toBe(true);
+    expect(body).toContain('# 2026-09-10');
+    expect(body).toContain('Today is 2026-09-10.');
+    expect(dailyNoteCreationBody('{{title}}', '2026-09-10')).toContain('2026-09-10');
+    expect(dailyNoteCreationBody('', '2026-09-10').startsWith('---\n')).toBe(true);
+  });
+
+  it('task_append on an absent note renders the template subset', () => {
+    const out = applyBridgeIntent(null, {
+      type: 'task_append', path: 'Daily/2026-09-10.md', date: '2026-09-10',
+      task: { title: 'Water #obsidian', startTime: null, duration: null, isAllDay: true, date: '2026-09-10', blockId: 'abc12345' },
+      heading: '## Tasks', template: '# {{title}}\n\n## Tasks\n',
+    });
+    expect(out.changed).toBe(true);
+    expect(out.text).toContain('# 2026-09-10');
+    expect(out.text).not.toContain('{{title}}');
+    expect(out.text).toMatch(/## Tasks\n- \[ \] Water #obsidian \^dg-abc12345/);
+  });
+
+  it('completion_log_append on an absent note renders the same subset', () => {
+    const out = applyBridgeIntent(null, {
+      type: 'completion_log_append', path: 'Daily/2026-09-10.md', date: '2026-09-10',
+      heading: '## Done', entry: '- 10:00 Did the thing', template: '# {{date}}\n',
+    });
+    expect(out.changed).toBe(true);
+    expect(out.text).toContain('# 2026-09-10');
+    expect(out.text).toContain('## Done\n- 10:00 Did the thing');
   });
 });

--- a/packages/obsidian-format/src/projectNotes.js
+++ b/packages/obsidian-format/src/projectNotes.js
@@ -22,7 +22,15 @@ const trimFolder = (s, fallback) => {
   return t || fallback;
 };
 
-/** Canonical settings: a known layout, non-empty folders, template paths as typed. */
+/**
+ * Canonical settings: a known layout, non-empty folders, template paths as
+ * typed. `dailyTemplate` (companion §4.4 build record, 2026-09-06) is the
+ * daily-note template note, rendered through the same ladder at the
+ * plugin's creation point; it lives here, plugin-local beside the project
+ * and goal ones, because only the plugin can render it — a synced app
+ * setting pointing at a vault path would be one some devices could act on
+ * and others could not.
+ */
 export function normalizeProjectNoteSettings(s) {
   const layout = PROJECT_NOTE_LAYOUTS.includes(s?.layout) ? s.layout : 'note';
   return {
@@ -31,6 +39,7 @@ export function normalizeProjectNoteSettings(s) {
     goalsFolder: trimFolder(s?.goalsFolder, 'Goals'),
     projectTemplate: String(s?.projectTemplate ?? '').trim(),
     goalTemplate: String(s?.goalTemplate ?? '').trim(),
+    dailyTemplate: String(s?.dailyTemplate ?? '').trim(),
   };
 }
 

--- a/packages/obsidian-format/src/projectNotes.test.js
+++ b/packages/obsidian-format/src/projectNotes.test.js
@@ -5,7 +5,8 @@ import {
 
 describe('normalizeProjectNoteSettings / noteNameFromTitle', () => {
   it('defaults the layout and folders; makes any title portable', () => {
-    expect(normalizeProjectNoteSettings(null)).toEqual({ layout: 'note', projectsFolder: 'Projects', goalsFolder: 'Goals', projectTemplate: '', goalTemplate: '' });
+    expect(normalizeProjectNoteSettings(null)).toEqual({ layout: 'note', projectsFolder: 'Projects', goalsFolder: 'Goals', projectTemplate: '', goalTemplate: '', dailyTemplate: '' });
+    expect(normalizeProjectNoteSettings({ dailyTemplate: ' Templates/Daily.md ' }).dailyTemplate).toBe('Templates/Daily.md');
     expect(normalizeProjectNoteSettings({ layout: 'nested', projectsFolder: '/Work/Projects/', goalsFolder: '' }).projectsFolder).toBe('Work/Projects');
     expect(normalizeProjectNoteSettings({ layout: 'bogus' }).layout).toBe('note');
     expect(noteNameFromTitle('iOS App: v2 / launch?')).toBe('iOS App- v2 - launch-');

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -106,6 +106,7 @@ export function dailyNoteFilename(dateStr: string, pattern?: string): string;
 export function hasFrontmatter(text: string): boolean;
 export function dgFrontmatter(dateIso?: string): string;
 export function withCreationFrontmatter(content: string, dateIso?: string): string;
+export function dailyNoteCreationBody(template: string | null | undefined, date: string, path?: string | null): string;
 
 // ── filename portability ────────────────────────────────────────────────────
 export function validateVaultNameSegment(segment: string): string | null;
@@ -219,7 +220,7 @@ export function applyBridgeIntent(
 // ── project and goal note workspaces (companion §4.3, rulings D and E) ─────
 export type ProjectNoteLayout = 'note' | 'folder' | 'nested';
 export const PROJECT_NOTE_LAYOUTS: ProjectNoteLayout[];
-export interface ProjectNoteSettings { layout: ProjectNoteLayout; projectsFolder: string; goalsFolder: string; projectTemplate: string; goalTemplate: string }
+export interface ProjectNoteSettings { layout: ProjectNoteLayout; projectsFolder: string; goalsFolder: string; projectTemplate: string; goalTemplate: string; dailyTemplate: string }
 export function normalizeProjectNoteSettings(s: Partial<ProjectNoteSettings> | null | undefined): ProjectNoteSettings;
 export function noteNameFromTitle(title: string): string;
 export function projectNotePath(a: { kind: 'project' | 'goal'; title: string; layout?: string; projectsFolder?: string; goalsFolder?: string; goalFolder?: string | null }): string;

--- a/src/components/DailyNotesModal.jsx
+++ b/src/components/DailyNotesModal.jsx
@@ -1,9 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { renderNoteTemplateSubset } from '@glance-apps/obsidian-format';
 import { NotebookPen, X, Loader } from 'lucide-react';
 import { renderFormattedText } from '../utils/textFormatting.jsx';
 
 // Daily Notes Modal — popover for adding/editing notes on a specific date
 const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, template, loadFresh }) => {
+  // The template's `{{date}}` / `{{title}}` are filled for this date, the
+  // same subset every daily-note creation point renders (companion §4.4).
+  const seededTemplate = template ? renderNoteTemplateSubset(template, { title: dateStr, date: dateStr }) : template;
   const defaultText = note?.text || '';
   const [localText, setLocalText] = useState(defaultText);
   const [isEditing, setIsEditing] = useState(!note?.text);
@@ -46,8 +50,8 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
           setIsEditing(false);
         } else {
           // No existing note — apply template if available
-          if (template) {
-            setLocalText(template);
+          if (seededTemplate) {
+            setLocalText(seededTemplate);
           }
           setIsEditing(true);
         }
@@ -68,8 +72,8 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
   // For non-Obsidian: apply template on mount when note is empty
   useEffect(() => {
     if (loadFresh) return; // Obsidian path handles this above
-    if (!defaultText && template) {
-      setLocalText(template);
+    if (!defaultText && seededTemplate) {
+      setLocalText(seededTemplate);
     }
     // Mount-once: seed the template only on open, not on later prop changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1700,7 +1700,7 @@ const SettingsModal = () => {
                               rows={4}
                             />
                             <p className={`text-xs ${textSecondary} mt-1`}>
-                              Pre-filled when creating a new daily note
+                              Pre-filled when creating a new daily note. {'{{date}}'} becomes the note's date. A template note configured in the Bridge plugin takes precedence when the plugin creates the note.
                             </p>
                           </div>
                           {launchOnWritePlatform && (

--- a/src/hooks/useCompletionLog.js
+++ b/src/hooks/useCompletionLog.js
@@ -226,7 +226,12 @@ export default function useCompletionLog({
             // never applied templates — the append precedent).
             const note = readDailyNoteNative(write.date);
             if (note === null) { console.error('[Obsidian] Completion log: daily note read failed, entry skipped:', write.date); continue; }
-            const applied = applyBridgeIntent(note.text, { type: 'completion_log_append', ...write });
+            // "" is absent-or-empty on native; it reads as ABSENT here so the
+            // entry's note is created from the template — the accepted
+            // tradeoff recorded at appendTaskToDailyNoteNative (a genuinely
+            // empty note gets the template prepended; a bare note would
+            // silently never have it).
+            const applied = applyBridgeIntent(note.text === '' ? null : note.text, { type: 'completion_log_append', ...write });
             if (applied.changed && !writeDailyNoteNative(write.date, applied.text)) {
               console.error('[Obsidian] Completion log: daily note write failed:', write.date);
             }

--- a/src/hooks/useCompletionLog.test.js
+++ b/src/hooks/useCompletionLog.test.js
@@ -271,6 +271,36 @@ describe('the hook glue', () => {
   });
 });
 
+describe('native direct tier: "" reads as absent (companion §4.4 build record, the accepted tradeoff)', () => {
+  const baseProps = (tasks, over = {}) => ({
+    tasks, unscheduledTasks: [], recurringTasks: [], projects: [],
+    obsidianConfig: CFG, dailyNoteTemplate: '# T\n',
+    obsidianVaultHandleRef: { current: { kind: 'directory' } },
+    bridgeHeartbeatRef: { current: { pluginAuthoritative: false } },
+    setObsidianSyncError: vi.fn(), setObsidianSyncStatus: vi.fn(),
+    isRemoteApply: () => false,
+    ...over,
+  });
+
+  it('a "" read creates the day\'s note from the template (subset filled) with the entry under the log heading', async () => {
+    readDailyNoteNative.mockReturnValue({ text: '' });
+    writeDailyNoteNative.mockReturnValue(true);
+    const props = baseProps([{ id: 'a', completed: false, title: 'A' }], {
+      obsidianVaultHandleRef: { current: 'native' },
+      obsidianConfig: { ...CFG, completionLogHeading: '## Done' },
+      dailyNoteTemplate: '# {{date}}\n',
+    });
+    useRenderedHook(props);
+    useRenderedHook({ ...props, tasks: [{ id: 'a', completed: true, title: 'A', completedAt: '2026-09-02T10:00:00-05:00' }] });
+    await flush();
+    expect(writeDailyNoteNative).toHaveBeenCalledTimes(1);
+    const written = writeDailyNoteNative.mock.calls[0][1];
+    expect(written.startsWith('---\n')).toBe(true);
+    expect(written).toContain('# 2026-09-02');
+    expect(written).toContain('## Done');
+  });
+});
+
 describe('ruling G: a linked project is named as a wikilink in the log line', () => {
   it('buildCompletionLogWrite writes [[Note|Title]] for a linked project and the title for a missing note', async () => {
     const { buildCompletionLogWrite } = await import('./useCompletionLog.js');

--- a/src/obsidian.js
+++ b/src/obsidian.js
@@ -35,6 +35,7 @@ import {
   splitCompletionMarker, completionMarkerSuffix,
   splitTasksMetadata, reattachTasksMetadata,
   parseObsidianHeartbeat,
+  dailyNoteCreationBody,
 } from '@glance-apps/obsidian-format';
 export {
   formatDatePattern, updateTaskLines, parseTasksFromMarkdown,
@@ -334,10 +335,10 @@ export async function appendTaskToDailyNote(vaultHandle, dailyNotesPath, dateStr
   // genuinely instantiates the note, so it gets the creation frontmatter —
   // unless the user's template opens with its own `---` block, which wins
   // (utils/obsidianFrontmatter.js; the ownership rule). An existing note is
-  // never decorated. (The native append has no template-instantiation path:
-  // its read contract cannot distinguish absent from empty, so it starts
-  // absent notes from the task line alone — pre-existing, unchanged.)
-  let content = existing ? existing.text : withCreationFrontmatter(template || '', dateStr);
+  // never decorated. The body is the app's text template with the §4.4
+  // subset filled (`{{date}}`, `{{title}}`) — dailyNoteCreationBody, the
+  // same function every creation point uses (companion §4.4 build record).
+  let content = existing ? existing.text : dailyNoteCreationBody(template, dateStr, dailyNoteFilename(dateStr, pattern));
 
   const taskLine = buildObsidianTaskLine(task, dateStr);
   const lines = content.split('\n');
@@ -1211,10 +1212,18 @@ export function appendTaskToDailyNoteNative(dateStr, task, heading, template) {
     console.error('[Obsidian native] Daily note read failed; not appending (the note may have content we cannot see)');
     return false;
   }
-  // "" (absent or empty note) keeps its longstanding native behavior: the
-  // task line starts the note. (The template fallback used to trigger only on
-  // a null read — which the failure contract above now correctly aborts.)
-  let content = existing;
+  // "" is ABSENT-OR-EMPTY: the native read contract cannot tell the two
+  // apart. THE RULING (companion §4.4 build record, 2026-09-06): treat it
+  // as absent and create from the template, the way the FSA append does.
+  // The cost, accepted deliberately: a genuinely empty existing note gets
+  // the template prepended — a small, recoverable harm (the user deletes
+  // it). The alternative was every native direct-tier daily note staying
+  // bare forever, silently never carrying the structure the user
+  // configured, which is not recoverable because nobody knows it happened.
+  // (Before this the task line alone started the note here; the template
+  // used to trigger only on a null read, which the failure contract above
+  // now correctly aborts.)
+  let content = existing === '' ? dailyNoteCreationBody(template, dateStr, `${dateStr}.md`) : existing;
 
   const taskLine = buildObsidianTaskLine(task, dateStr);
   const lines = content.split('\n');

--- a/src/obsidian.nativeWriteContract.test.js
+++ b/src/obsidian.nativeWriteContract.test.js
@@ -74,6 +74,29 @@ describe('appendTaskToDailyNoteNative', () => {
     expect(appendTaskToDailyNoteNative('2026-08-28', task, '## Tasks', '')).toBe(true);
   });
 
+  // Companion §4.4 build record (2026-09-06), the accepted tradeoff: "" is
+  // absent-or-empty on native and reads as ABSENT, so the note is created
+  // from the template like the FSA append. A genuinely empty existing note
+  // gets the template prepended — small and recoverable; a bare note that
+  // silently never carried the configured structure was not.
+  it('"" with a template creates the note from the template (subset filled) with the task line under its heading', () => {
+    const bridge = installBridge({ getDailyNote: vi.fn(() => '') });
+    expect(appendTaskToDailyNoteNative('2026-08-28', task, '## Tasks', '# {{date}}\n\n## Tasks\n')).toBe(true);
+    const written = bridge.writeDailyNote.mock.calls[0][1];
+    expect(written.startsWith('---\n')).toBe(true);
+    expect(written).toContain('# 2026-08-28');
+    expect(written).toMatch(/## Tasks\n- \[ \] New task/);
+    expect(written).not.toContain('{{date}}');
+  });
+
+  it('an existing non-empty note is never decorated with the template', () => {
+    const bridge = installBridge({ getDailyNote: vi.fn(() => '## Notes\nhello\n') });
+    expect(appendTaskToDailyNoteNative('2026-08-28', task, '## Tasks', '# {{date}}\n')).toBe(true);
+    const written = bridge.writeDailyNote.mock.calls[0][1];
+    expect(written).not.toContain('# 2026-08-28');
+    expect(written.startsWith('## Notes')).toBe(true);
+  });
+
   it('returns false and logs when the bridge reports failure (boolean or iOS string)', () => {
     installBridge({ writeDailyNote: vi.fn(() => false) });
     expect(appendTaskToDailyNoteNative('2026-08-28', task, '## Tasks', '')).toBe(false);


### PR DESCRIPTION
## Why

Project and goal notes render through the companion spec's §4.4 ladder. Daily notes had a separate, older mechanism: a plain-text template in dayGLANCE settings written verbatim at creation, no Templater, no substitution, not even the date, across six creation points and three code paths, one of which (the native direct-tier append) applied no template at all.

## What was built

1. **A daily-note template path in the plugin's settings**, beside the project and goal ones. The plugin renders it through the existing ladder at its creation point for the two daily-note-creating intents (`task_append` for daily notes; `completion_log_append`). The pre-scan covers it for free. *Ruling: plugin settings, not a synced app setting*, since only the plugin can render and a synced vault path would be a setting some devices could act on and others could not.
2. **The app's text template stays as the fallback body**, now with `{{date}}` and `{{title}}` filled by one function (`dailyNoteCreationBody`) under every creation point: the FSA and native appends, both intents, the completion log's direct path, and the in-app editor's seed.
3. **The native direct-tier gap is closed.** A `""` read (absent-or-empty under the native contract) reads as absent and the note is created from the template like the FSA append. *Ruling, the accepted cost, recorded at the site:* a genuinely empty existing note gets the template prepended, which is small and recoverable; a bare note that silently never carried the configured structure was not.
4. **Templater's on-create trigger is detected**, for daily, project and goal notes alike. The pre-scan guards the render we perform; with the trigger on, Templater renders every new file itself, and an interactive call in it hangs invisibly outside our guard. A non-interactive template is still delegated (Templater's second pass finds nothing to render); an interactive one under the trigger is refused, the fallback stands (itself pre-scanned), and the settings tab shows why. Both homes of the setting are read: device-local `templater-local-settings` (2.21+) and the synced plugin settings of older builds. Missing template notes and failed renders surface on the same settings-tab line.

Creation order for a templated daily note: the note is created first with the fallback body (non-empty, so a Templater folder template never races the write, and the note already stands correct if the render fails), then rendered against the real TFile and rewritten with the intent applied to the rendered body.

## Tests

- Harness scenarios 9, 9b, 10, 11 in `projectNotes.scenarios.test.ts`: the ladder at the creation point and replay idempotence; the completion log through the same template and the text fallback without one; the interactive template left visible without the trigger and refused with it, with the fallback pre-scanned too; delegation against a fake Templater, still delegated under the trigger, never for an interactive template.
- Unit: the creation body's substitution through both intents, the native append on `""` with and without existing content, the completion log's native branch, the settings shape.
- Root suite (227 files), plugin harness (46), plugin typecheck, lint: green.

## Spec

The §4.4 build record in the companion spec, including the two notes asked for: the rendering context is whichever Obsidian applies the intent (a desktop's plugin draining a phone's intent renders with that desktop's Templater context), and the posture ruling fixed the unattended case as a side effect, since a paired device with Obsidian closed now queues an intent rather than creating anything. Plugin README updated.

Identity, merge semantics, and what wins on divergence are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_