### PR TITLE
Re-arm SSE nudges fleet-wide; sync toast names the holding posture

### DIFF
--- a/docs/obsidian-buildout-spec.md
+++ b/docs/obsidian-buildout-spec.md
@@ -43,11 +43,15 @@ device-local plugin state (Phase 6's build record, the record above the
 Phase 7 section), M4, M12, unsupported-intent preservation, the SSE connect
 timeout and the pairing-meta ack.
 
-What is NOT done, in order: (1) a day's soak with the phones on the stream
-under the polling posture; (2) the SSE re-arm sequence — a supervised
-single-machine flip (`dayglance-sse-nudges` = `on`), then the fleet, then
-default-on — every plugin-to-app path, sidebar completions included, runs at
-the five-minute poll until it lands; (3) the direct-tier half of project
+What is NOT done, in order: (1) DONE 2026-09-05/06 — a day's soak with the
+phones on the stream under the polling posture; (2) DONE 2026-09-07 — the SSE
+re-arm sequence: the supervised single-machine flip on the Mac (2026-09-06)
+surfaced the lost sidebar completion, root-caused to the phantom re-stamp
+on a stale-copy direct scan (#1551) and answered by the posture ruling
+(#1552), not to nudge speed; the default then flipped to ON fleet-wide
+(`SSE_NUDGES_DEFAULT_ON`, `sync/vaultEventStream.js`), with
+`dayglance-sse-nudges` = `off` as the per-device retreat and the constant as
+the one-line fleet retreat; (3) the direct-tier half of project
 routing (companion 4.3, project routing: desktop has path-addressed reads
 and writes, each mobile bridge needs two native methods), wanted only where
 direct mode is relied on. Deferred by design, not planned: companion §5.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2816,6 +2816,9 @@ const DayPlanner = () => {
     setObsidianSyncNotice,
     obsidianVaultHandleRef, obsidianSyncInProgressRef, obsidianPrevTaskStateRef,
     obsidianTasksRef, obsidianInboxRef,
+    // The cycle's vault posture (utils/obsidianVaultPosture.js) rides on the
+    // heartbeat ref; the sync toast reads it to name what a cycle is doing.
+    bridgeHeartbeatRef,
     recycleBin, setRecycleBin,
     recurringTasks, setRecurringTasks,
     multiUserEnabled, meUserSyncId,

--- a/src/components/ObsidianSyncToast.jsx
+++ b/src/components/ObsidianSyncToast.jsx
@@ -4,7 +4,12 @@ import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 
 const ObsidianSyncToast = () => {
-  const { obsidianSyncStatus, obsidianSyncError, obsidianSyncNotice, setObsidianSyncStatus, setObsidianSyncError } = useSyncCtx();
+  const { obsidianSyncStatus, obsidianSyncError, obsidianSyncNotice, setObsidianSyncStatus, setObsidianSyncError, bridgeHeartbeatRef } = useSyncCtx();
+  // THE HOLDING POSTURE (2026-09-06 ruling, utils/obsidianVaultPosture.js): a
+  // paired device with Obsidian closed never touches its vault — the cycle
+  // reads the stream and queues intents. The toast names that, so it never
+  // contradicts the settings line saying vault changes wait for Obsidian.
+  const holding = bridgeHeartbeatRef?.current?.vaultPosture === 'holding';
   const { cardBg, borderClass, textPrimary, textSecondary, isMobile } = useDayPlannerCtx();
 
   // Fire-and-forget NOTICE (e.g. a two-sided retitle resolution): neutral
@@ -37,11 +42,11 @@ const ObsidianSyncToast = () => {
     accentColor = 'bg-blue-500';
   } else if (isSyncing) {
     icon = <Loader size={16} className="text-blue-500 animate-spin flex-shrink-0" />;
-    message = 'Syncing Obsidian vault…';
+    message = holding ? 'Syncing through the Plugin Bridge…' : 'Syncing Obsidian vault…';
     accentColor = 'bg-blue-500';
   } else if (isSuccess) {
     icon = <CheckCircle size={16} className="text-green-500 flex-shrink-0" />;
-    message = 'Obsidian vault synced';
+    message = holding ? 'Synced through the Plugin Bridge' : 'Obsidian vault synced';
     accentColor = 'bg-green-500';
   } else {
     icon = <AlertCircle size={16} className="text-red-500 flex-shrink-0" />;

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -61,14 +61,14 @@ export function useVaultEventStream({ dataLoaded, drainSync, drainIntents, drain
     if (isTrayMode || !dataLoaded || !isVaultEnabled()) return undefined;
 
     // THE SSE NUDGE GATE (2026-08-31 — see sseNudgesEnabled for the full
-    // record): default OFF until this commission's breakers are proven
-    // against live traffic. No stream is opened at all — the polling
-    // backstop (which never stopped running) IS the cadence. One info line
-    // so the posture is visible in any console capture.
+    // record, and the 2026-09-07 fleet re-arm): default ON since the re-arm;
+    // a device pinned 'off' opens no stream at all — the polling backstop
+    // (which never stopped running) IS its cadence. One info line so the
+    // posture is visible in any console capture.
     if (!sseNudgesEnabled()) {
       console.info(
-        `[vault-sse] live nudges are gated OFF (2026-08-31 war posture) — polling cadence only. ` +
-        `To re-arm for a supervised test: localStorage.setItem('${SSE_NUDGES_FLAG_KEY}', 'on') and reload.`);
+        `[vault-sse] live nudges are OFF on this device (${SSE_NUDGES_FLAG_KEY} = 'off') — polling cadence only. ` +
+        `To re-arm: localStorage.removeItem('${SSE_NUDGES_FLAG_KEY}') and reload.`);
       return undefined;
     }
 

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -107,12 +107,22 @@ export { parseSseFrame, drainSseBuffer };
 // and every war cycle has to pass through dayGLANCE's drain, which now runs
 // at poll cadence).
 //
-// The escape hatch is a localStorage flag, not a build: set
-// `dayglance-sse-nudges` to 'on' (and reload) to re-arm live nudges for a
-// supervised test; 'off' pins the gate closed even after the default flips.
-// The flag is read once per stream open (app load / foreground), like the
-// vault-enabled gate beside it.
-export const SSE_NUDGES_DEFAULT_ON = false;
+// The escape hatch is a localStorage flag, not a build: 'on' re-arms a
+// device ahead of the default, 'off' pins the gate closed on one device
+// after it. The flag is read once per stream open (app load / foreground),
+// like the vault-enabled gate beside it.
+//
+// RE-ARMED FLEET-WIDE (2026-09-07). The sequence the assessment asked for
+// ran: a day's soak with the phones on the stream under the polling posture
+// (2026-09-05/06), then a supervised single-machine flip on the Mac
+// (2026-09-06, the flag set by hand) that surfaced one incident — the lost
+// sidebar completion — whose root cause was the phantom re-stamp on a
+// stale-copy direct scan (#1551, #1552), not SSE speed: the breakers held,
+// and nothing on the nudge path was implicated. The default flips here so a
+// phone gets live nudges by installing the build, with no console; 'off'
+// remains the per-device retreat, and flipping this constant back remains
+// the one-line fleet retreat the tripwire promised.
+export const SSE_NUDGES_DEFAULT_ON = true;
 export const SSE_NUDGES_FLAG_KEY = 'dayglance-sse-nudges';
 
 /** Should this app session open the SSE stream and act on nudges? */

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -728,7 +728,7 @@ describe('backoffDelayMs — equal jitter (mirrored by SseBackoff.kt; change bot
   });
 });
 
-describe('sseNudgesEnabled — the nudge gate (2026-08-31 war posture)', () => {
+describe('sseNudgesEnabled — the nudge gate (2026-08-31 war posture; re-armed fleet-wide 2026-09-07)', () => {
   afterEach(() => { delete globalThis.localStorage; });
   const storeWith = (v) => {
     globalThis.localStorage = {
@@ -736,13 +736,13 @@ describe('sseNudgesEnabled — the nudge gate (2026-08-31 war posture)', () => {
     };
   };
 
-  it('DEFAULTS OFF: the tripwire is exercised — no flag means no stream, polling only', () => {
-    expect(SSE_NUDGES_DEFAULT_ON).toBe(false);
+  it('DEFAULTS ON since the fleet re-arm: no flag means live nudges (the tripwire held through the soak and the supervised flip)', () => {
+    expect(SSE_NUDGES_DEFAULT_ON).toBe(true);
     storeWith(null);
-    expect(sseNudgesEnabled()).toBe(false);
+    expect(sseNudgesEnabled()).toBe(true);
   });
 
-  it("the escape hatch: 'on' re-arms for a supervised test; 'off' pins closed; anything else is the default", () => {
+  it("the escape hatch: 'off' pins one device closed; 'on' is explicit; anything else is the default", () => {
     storeWith('on');
     expect(sseNudgesEnabled()).toBe(true);
     storeWith('off');


### PR DESCRIPTION
## SSE re-arm, fleet-wide

The sequence the Phase 7 assessment asked for has run: a day's soak with the phones on the stream under the polling posture (2026-09-05/06), then a supervised single-machine flip on the Mac (2026-09-06). The one incident the flip surfaced, the lost sidebar completion, was the phantom re-stamp on a stale-copy direct scan (#1551) answered by the posture ruling (#1552), not nudge speed. The breakers held and nothing on the nudge path was implicated.

`SSE_NUDGES_DEFAULT_ON` flips to `true`. A device gets live nudges by installing the build, no console. The device-local flag `dayglance-sse-nudges` = `off` remains the per-device retreat, and the constant remains the one-line fleet retreat the tripwire promised. The console line for a pinned-off device now says how to re-arm it.

## Sync toast by posture

A holding device (paired vault, Obsidian closed here) never touches its vault; its cycle reads the stream and queues intents. The toast used to say "Syncing Obsidian vault" regardless, contradicting the settings line that says vault changes wait for Obsidian. It now reads the cycle's posture from the heartbeat ref on the sync context and says "Syncing through the Plugin Bridge…" and "Synced through the Plugin Bridge" while holding. Plugin mode and direct mode are unchanged.

## Tests and spec

Gate tests updated to the new default. Full suite (228 files) and lint green. The spec's status note records the soak and the re-arm as done, with the retreat paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_