### PR TITLE
Localization cleanup: untranslated toast and chips, French ordinals, task progress key

### DIFF
--- a/packages/agenda-core/src/recurrence.js
+++ b/packages/agenda-core/src/recurrence.js
@@ -178,7 +178,12 @@ export const getRecurrencePresets = (dateStr, t, language = 'en') => {
   const localizedDate = typeof t === 'function'
     ? new Intl.DateTimeFormat(language || 'en', { month: 'long', day: 'numeric' }).format(taskDate)
     : `${monthName} ${monthDay}`;
-  const localizedMonthDay = translate('recurrence.ordinal', { count: monthDay, ordinal: true }, `${monthDay}${suffix}`);
+  // Two ordinal keys, not one. A month DAY and an ordinal POSITION are the
+  // same word in English ("the 5th", "the 2nd Monday") and diverge in French,
+  // where the day is cardinal after the first ("le 5", but "le 1er") while the
+  // position stays ordinal ("le 2e lundi"). Sharing one key made French wrong
+  // on one side whichever way it was written.
+  const localizedMonthDay = translate('recurrence.monthDayOrdinal', { count: monthDay, ordinal: true }, `${monthDay}${suffix}`);
   const localizedOrdinal = translate('recurrence.ordinal', { count: weekOfMonth, ordinal: true }, ordinals[weekOfMonth]);
 
   return [

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -72,7 +72,16 @@
     "passphrasePlaceholder": "Ihre Synchronisierungs-Passphrase",
     "passphrasePrompt": "Die Cloud-Synchronisierung ist verschlüsselt. Geben Sie Ihre Synchronisierungs-Passphrase ein, um fortzufahren.",
     "unlock": "Entsperren",
-    "unlockTitle": "Synchronisierung entsperren"
+    "unlockTitle": "Synchronisierung entsperren",
+    "obsidianToast": {
+      "syncing": "Obsidian-Vault wird synchronisiert…",
+      "syncingBridge": "Wird über die Plugin-Bridge synchronisiert…",
+      "synced": "Obsidian-Vault synchronisiert",
+      "syncedBridge": "Über die Plugin-Bridge synchronisiert",
+      "failed": "Obsidian-Synchronisierung fehlgeschlagen",
+      "tapToDismiss": "Zum Schließen tippen",
+      "dismissError": "Synchronisierungsfehler schließen"
+    }
   },
   "subscription": {
     "accessCodePlaceholder": "Zugangscode",
@@ -211,7 +220,8 @@
     "example": "Beispiel",
     "apply": "Übernehmen",
     "minutesShort": "{{count}} Min.",
-    "nextWeek": "Nächste Woche"
+    "nextWeek": "Nächste Woche",
+    "taskProgress": "{{done}}/{{total}} Aufgaben"
   },
   "errorBoundary": {
     "title": "Etwas ist schiefgelaufen",
@@ -766,7 +776,11 @@
     "withCount_other": "{{label}} ({{count}} Mal)",
     "onDate": "An einem Datum",
     "after": "Nach",
-    "times": "Mal"
+    "times": "Mal",
+    "monthDayOrdinal_ordinal_one": "{{count}}",
+    "monthDayOrdinal_ordinal_two": "{{count}}",
+    "monthDayOrdinal_ordinal_few": "{{count}}",
+    "monthDayOrdinal_ordinal_other": "{{count}}"
   },
   "dateRange": {
     "sameMonth": "{{startDay}}.–{{endDay}}. {{month}} {{year}}",
@@ -781,7 +795,9 @@
     "afternoon": "Nachmittag",
     "evening": "Abend",
     "night": "Nacht",
-    "timeWithLabel": "{{time}} ({{label}})"
+    "timeWithLabel": "{{time}} ({{label}})",
+    "detectedDetails": "Erkannte Aufgabendetails",
+    "removeChip": "Entfernen: {{label}}"
   },
   "menu": {
     "file": "Datei",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -72,7 +72,16 @@
     "passphrasePlaceholder": "Your sync passphrase",
     "passphrasePrompt": "Cloud sync is encrypted. Enter your sync passphrase to continue.",
     "unlock": "Unlock",
-    "unlockTitle": "Unlock sync"
+    "unlockTitle": "Unlock sync",
+    "obsidianToast": {
+      "syncing": "Syncing Obsidian vault…",
+      "syncingBridge": "Syncing through the Plugin Bridge…",
+      "synced": "Obsidian vault synced",
+      "syncedBridge": "Synced through the Plugin Bridge",
+      "failed": "Obsidian sync failed",
+      "tapToDismiss": "Tap to dismiss",
+      "dismissError": "Dismiss sync error"
+    }
   },
   "subscription": {
     "accessCodePlaceholder": "Access code",
@@ -211,7 +220,8 @@
     "example": "Example",
     "apply": "Apply",
     "minutesShort": "{{count}} min",
-    "nextWeek": "Next week"
+    "nextWeek": "Next week",
+    "taskProgress": "{{done}}/{{total}} tasks"
   },
   "errorBoundary": {
     "title": "Something went wrong",
@@ -766,7 +776,11 @@
     "withCount_other": "{{label}} ({{count}} times)",
     "onDate": "On date",
     "after": "After",
-    "times": "times"
+    "times": "times",
+    "monthDayOrdinal_ordinal_one": "{{count}}st",
+    "monthDayOrdinal_ordinal_two": "{{count}}nd",
+    "monthDayOrdinal_ordinal_few": "{{count}}rd",
+    "monthDayOrdinal_ordinal_other": "{{count}}th"
   },
   "dateRange": {
     "sameMonth": "{{month}} {{startDay}}–{{endDay}}, {{year}}",
@@ -781,7 +795,9 @@
     "afternoon": "Afternoon",
     "evening": "Evening",
     "night": "Night",
-    "timeWithLabel": "{{time}} ({{label}})"
+    "timeWithLabel": "{{time}} ({{label}})",
+    "detectedDetails": "Detected task details",
+    "removeChip": "Remove: {{label}}"
   },
   "menu": {
     "file": "File",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -72,7 +72,16 @@
     "passphrasePlaceholder": "Tu frase de contraseña de sincronización",
     "passphrasePrompt": "La sincronización en la nube está cifrada. Introduce tu frase de contraseña de sincronización para continuar.",
     "unlock": "Desbloquear",
-    "unlockTitle": "Desbloquear la sincronización"
+    "unlockTitle": "Desbloquear la sincronización",
+    "obsidianToast": {
+      "syncing": "Sincronizando la bóveda de Obsidian…",
+      "syncingBridge": "Sincronizando a través del Plugin Bridge…",
+      "synced": "Bóveda de Obsidian sincronizada",
+      "syncedBridge": "Sincronizado a través del Plugin Bridge",
+      "failed": "Error de sincronización con Obsidian",
+      "tapToDismiss": "Toca para descartar",
+      "dismissError": "Descartar el error de sincronización"
+    }
   },
   "subscription": {
     "accessCodePlaceholder": "Código de acceso",
@@ -211,7 +220,8 @@
     "example": "Ejemplo",
     "apply": "Aplicar",
     "minutesShort": "{{count}} min",
-    "nextWeek": "Próxima semana"
+    "nextWeek": "Próxima semana",
+    "taskProgress": "{{done}}/{{total}} tareas"
   },
   "errorBoundary": {
     "title": "Algo salió mal",
@@ -766,7 +776,11 @@
     "withCount_other": "{{label}} ({{count}} veces)",
     "onDate": "En una fecha",
     "after": "Después de",
-    "times": "veces"
+    "times": "veces",
+    "monthDayOrdinal_ordinal_one": "{{count}}",
+    "monthDayOrdinal_ordinal_two": "{{count}}",
+    "monthDayOrdinal_ordinal_few": "{{count}}",
+    "monthDayOrdinal_ordinal_other": "{{count}}"
   },
   "dateRange": {
     "sameMonth": "{{startDay}}–{{endDay}} de {{month}} de {{year}}",
@@ -781,7 +795,9 @@
     "afternoon": "Tarde",
     "evening": "Atardecer",
     "night": "Noche",
-    "timeWithLabel": "{{time}} ({{label}})"
+    "timeWithLabel": "{{time}} ({{label}})",
+    "detectedDetails": "Detalles de tarea detectados",
+    "removeChip": "Quitar: {{label}}"
   },
   "menu": {
     "file": "Archivo",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -72,7 +72,16 @@
     "passphrasePlaceholder": "Votre phrase secrète de synchronisation",
     "passphrasePrompt": "La synchronisation cloud est chiffrée. Saisissez votre phrase secrète de synchronisation pour continuer.",
     "unlock": "Déverrouiller",
-    "unlockTitle": "Déverrouiller la synchronisation"
+    "unlockTitle": "Déverrouiller la synchronisation",
+    "obsidianToast": {
+      "syncing": "Synchronisation du coffre Obsidian…",
+      "syncingBridge": "Synchronisation via le Plugin Bridge…",
+      "synced": "Coffre Obsidian synchronisé",
+      "syncedBridge": "Synchronisé via le Plugin Bridge",
+      "failed": "Échec de la synchronisation Obsidian",
+      "tapToDismiss": "Touchez pour ignorer",
+      "dismissError": "Ignorer l’erreur de synchronisation"
+    }
   },
   "subscription": {
     "accessCodePlaceholder": "Code d'accès",
@@ -211,7 +220,8 @@
     "example": "Exemple",
     "apply": "Appliquer",
     "minutesShort": "{{count}} min",
-    "nextWeek": "Semaine prochaine"
+    "nextWeek": "Semaine prochaine",
+    "taskProgress": "{{done}}/{{total}} tâches"
   },
   "errorBoundary": {
     "title": "Une erreur est survenue",
@@ -742,10 +752,10 @@
     "unscheduledHint": "(ajouter à la carte du projet, sans date ni heure)"
   },
   "recurrence": {
-    "ordinal_ordinal_one": "{{count}}",
-    "ordinal_ordinal_two": "{{count}}",
-    "ordinal_ordinal_few": "{{count}}",
-    "ordinal_ordinal_other": "{{count}}",
+    "ordinal_ordinal_one": "{{count}}er",
+    "ordinal_ordinal_two": "{{count}}e",
+    "ordinal_ordinal_few": "{{count}}e",
+    "ordinal_ordinal_other": "{{count}}e",
     "custom": "Personnalisé",
     "everyDay": "Tous les jours",
     "everyWeek": "Chaque semaine",
@@ -759,14 +769,18 @@
     "everyWeekOn": "Chaque semaine le {{day}}",
     "everyTwoWeeksOn": "Toutes les 2 semaines le {{day}}",
     "monthlyOnDate": "Tous les mois le {{day}}",
-    "monthlyOnOrdinalWeekday": "Tous les mois le {{ordinal}}e {{day}}",
+    "monthlyOnOrdinalWeekday": "Tous les mois le {{ordinal}} {{day}}",
     "yearlyOn": "Tous les ans le {{date}}",
     "withEndDate": "{{label}} jusqu’au {{date}}",
     "withCount_one": "{{label}} ({{count}} fois)",
     "withCount_other": "{{label}} ({{count}} fois)",
     "onDate": "À une date",
     "after": "Après",
-    "times": "fois"
+    "times": "fois",
+    "monthDayOrdinal_ordinal_one": "{{count}}er",
+    "monthDayOrdinal_ordinal_two": "{{count}}",
+    "monthDayOrdinal_ordinal_few": "{{count}}",
+    "monthDayOrdinal_ordinal_other": "{{count}}"
   },
   "dateRange": {
     "sameMonth": "{{startDay}}–{{endDay}} {{month}} {{year}}",
@@ -781,7 +795,9 @@
     "afternoon": "Après-midi",
     "evening": "Soir",
     "night": "Nuit",
-    "timeWithLabel": "{{time}} ({{label}})"
+    "timeWithLabel": "{{time}} ({{label}})",
+    "detectedDetails": "Détails de tâche détectés",
+    "removeChip": "Retirer : {{label}}"
   },
   "menu": {
     "file": "Fichier",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -72,7 +72,16 @@
     "passphrasePlaceholder": "La tua passphrase di sincronizzazione",
     "passphrasePrompt": "La sincronizzazione cloud è cifrata. Inserisci la passphrase di sincronizzazione per continuare.",
     "unlock": "Sblocca",
-    "unlockTitle": "Sblocca la sincronizzazione"
+    "unlockTitle": "Sblocca la sincronizzazione",
+    "obsidianToast": {
+      "syncing": "Sincronizzazione del vault Obsidian…",
+      "syncingBridge": "Sincronizzazione tramite il Plugin Bridge…",
+      "synced": "Vault Obsidian sincronizzato",
+      "syncedBridge": "Sincronizzato tramite il Plugin Bridge",
+      "failed": "Sincronizzazione con Obsidian non riuscita",
+      "tapToDismiss": "Tocca per ignorare",
+      "dismissError": "Ignora l’errore di sincronizzazione"
+    }
   },
   "subscription": {
     "accessCodePlaceholder": "Codice di accesso",
@@ -211,7 +220,8 @@
     "example": "Esempio",
     "apply": "Applica",
     "minutesShort": "{{count}} min",
-    "nextWeek": "Settimana prossima"
+    "nextWeek": "Settimana prossima",
+    "taskProgress": "{{done}}/{{total}} attività"
   },
   "errorBoundary": {
     "title": "Qualcosa è andato storto",
@@ -766,7 +776,11 @@
     "withCount_other": "{{label}} ({{count}} volte)",
     "onDate": "In una data",
     "after": "Dopo",
-    "times": "volte"
+    "times": "volte",
+    "monthDayOrdinal_ordinal_one": "{{count}}",
+    "monthDayOrdinal_ordinal_two": "{{count}}",
+    "monthDayOrdinal_ordinal_few": "{{count}}",
+    "monthDayOrdinal_ordinal_other": "{{count}}"
   },
   "dateRange": {
     "sameMonth": "{{startDay}}–{{endDay}} {{month}} {{year}}",
@@ -781,7 +795,9 @@
     "afternoon": "Pomeriggio",
     "evening": "Sera",
     "night": "Notte",
-    "timeWithLabel": "{{time}} ({{label}})"
+    "timeWithLabel": "{{time}} ({{label}})",
+    "detectedDetails": "Dettagli attività rilevati",
+    "removeChip": "Rimuovi: {{label}}"
   },
   "menu": {
     "file": "File",

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -72,7 +72,16 @@
     "passphrasePlaceholder": "Sua frase de sincronização",
     "passphrasePrompt": "A sincronização na nuvem está criptografada. Digite sua frase de sincronização para continuar.",
     "unlock": "Desbloquear",
-    "unlockTitle": "Desbloquear sincronização"
+    "unlockTitle": "Desbloquear sincronização",
+    "obsidianToast": {
+      "syncing": "Sincronizando o cofre do Obsidian…",
+      "syncingBridge": "Sincronizando pelo Plugin Bridge…",
+      "synced": "Cofre do Obsidian sincronizado",
+      "syncedBridge": "Sincronizado pelo Plugin Bridge",
+      "failed": "Falha na sincronização com o Obsidian",
+      "tapToDismiss": "Toque para dispensar",
+      "dismissError": "Dispensar o erro de sincronização"
+    }
   },
   "subscription": {
     "accessCodePlaceholder": "Código de acesso",
@@ -211,7 +220,8 @@
     "example": "Exemplo",
     "apply": "Aplicar",
     "minutesShort": "{{count}} min",
-    "nextWeek": "Próxima semana"
+    "nextWeek": "Próxima semana",
+    "taskProgress": "{{done}}/{{total}} tarefas"
   },
   "errorBoundary": {
     "title": "Algo correu mal",
@@ -766,7 +776,11 @@
     "withCount_other": "{{label}} ({{count}} vezes)",
     "onDate": "Em uma data",
     "after": "Depois de",
-    "times": "vezes"
+    "times": "vezes",
+    "monthDayOrdinal_ordinal_one": "{{count}}",
+    "monthDayOrdinal_ordinal_two": "{{count}}",
+    "monthDayOrdinal_ordinal_few": "{{count}}",
+    "monthDayOrdinal_ordinal_other": "{{count}}"
   },
   "dateRange": {
     "sameMonth": "{{startDay}}–{{endDay}} de {{month}} de {{year}}",
@@ -781,7 +795,9 @@
     "afternoon": "Tarde",
     "evening": "Fim da tarde",
     "night": "Noite",
-    "timeWithLabel": "{{time}} ({{label}})"
+    "timeWithLabel": "{{time}} ({{label}})",
+    "detectedDetails": "Detalhes da tarefa detectados",
+    "removeChip": "Remover: {{label}}"
   },
   "menu": {
     "file": "Arquivo",

--- a/public/locales/pt-PT/translation.json
+++ b/public/locales/pt-PT/translation.json
@@ -72,7 +72,16 @@
     "passphrasePlaceholder": "A sua frase-passe de sincronização",
     "passphrasePrompt": "A sincronização na nuvem está cifrada. Introduza a sua frase-passe de sincronização para continuar.",
     "unlock": "Desbloquear",
-    "unlockTitle": "Desbloquear sincronização"
+    "unlockTitle": "Desbloquear sincronização",
+    "obsidianToast": {
+      "syncing": "A sincronizar o cofre do Obsidian…",
+      "syncingBridge": "A sincronizar através do Plugin Bridge…",
+      "synced": "Cofre do Obsidian sincronizado",
+      "syncedBridge": "Sincronizado através do Plugin Bridge",
+      "failed": "Falha na sincronização com o Obsidian",
+      "tapToDismiss": "Toque para dispensar",
+      "dismissError": "Dispensar o erro de sincronização"
+    }
   },
   "subscription": {
     "accessCodePlaceholder": "Código de acesso",
@@ -211,7 +220,8 @@
     "example": "Exemplo",
     "apply": "Aplicar",
     "minutesShort": "{{count}} min",
-    "nextWeek": "Próxima semana"
+    "nextWeek": "Próxima semana",
+    "taskProgress": "{{done}}/{{total}} tarefas"
   },
   "errorBoundary": {
     "title": "Algo correu mal",
@@ -766,7 +776,11 @@
     "withCount_other": "{{label}} ({{count}} vezes)",
     "onDate": "Numa data",
     "after": "Após",
-    "times": "vezes"
+    "times": "vezes",
+    "monthDayOrdinal_ordinal_one": "{{count}}",
+    "monthDayOrdinal_ordinal_two": "{{count}}",
+    "monthDayOrdinal_ordinal_few": "{{count}}",
+    "monthDayOrdinal_ordinal_other": "{{count}}"
   },
   "dateRange": {
     "sameMonth": "{{startDay}}–{{endDay}} de {{month}} de {{year}}",
@@ -781,7 +795,9 @@
     "afternoon": "Tarde",
     "evening": "Fim da tarde",
     "night": "Noite",
-    "timeWithLabel": "{{time}} ({{label}})"
+    "timeWithLabel": "{{time}} ({{label}})",
+    "detectedDetails": "Detalhes da tarefa detetados",
+    "removeChip": "Remover: {{label}}"
   },
   "menu": {
     "file": "Ficheiro",

--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -72,7 +72,16 @@
     "passphrasePlaceholder": "输入同步口令",
     "passphrasePrompt": "云同步已加密。请输入同步口令以继续。",
     "unlock": "解锁",
-    "unlockTitle": "解锁同步"
+    "unlockTitle": "解锁同步",
+    "obsidianToast": {
+      "syncing": "正在同步 Obsidian 仓库…",
+      "syncingBridge": "正在通过 Plugin Bridge 同步…",
+      "synced": "Obsidian 仓库已同步",
+      "syncedBridge": "已通过 Plugin Bridge 同步",
+      "failed": "Obsidian 同步失败",
+      "tapToDismiss": "点按可关闭",
+      "dismissError": "关闭同步错误"
+    }
   },
   "subscription": {
     "accessCodePlaceholder": "访问码",
@@ -211,7 +220,8 @@
     "example": "示例",
     "apply": "应用",
     "minutesShort": "{{count}} 分钟",
-    "nextWeek": "下周"
+    "nextWeek": "下周",
+    "taskProgress": "{{done}}/{{total}} 个任务"
   },
   "errorBoundary": {
     "title": "出了点问题",
@@ -766,7 +776,11 @@
     "withCount_other": "{{label}}（共{{count}}次）",
     "onDate": "指定日期",
     "after": "重复",
-    "times": "次后"
+    "times": "次后",
+    "monthDayOrdinal_ordinal_one": "{{count}}",
+    "monthDayOrdinal_ordinal_two": "{{count}}",
+    "monthDayOrdinal_ordinal_few": "{{count}}",
+    "monthDayOrdinal_ordinal_other": "{{count}}"
   },
   "dateRange": {
     "sameMonth": "{{year}}年{{month}}{{startDay}}日至{{endDay}}日",
@@ -781,7 +795,9 @@
     "afternoon": "下午",
     "evening": "晚上",
     "night": "夜间",
-    "timeWithLabel": "{{time}}（{{label}}）"
+    "timeWithLabel": "{{time}}（{{label}}）",
+    "detectedDetails": "识别到的任务详情",
+    "removeChip": "移除：{{label}}"
   },
   "menu": {
     "file": "文件",

--- a/src/components/ObsidianSyncToast.jsx
+++ b/src/components/ObsidianSyncToast.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { CheckCircle, AlertCircle, Loader } from 'lucide-react';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 
 const ObsidianSyncToast = () => {
+  const { t } = useTranslation();
   const { obsidianSyncStatus, obsidianSyncError, obsidianSyncNotice, setObsidianSyncStatus, setObsidianSyncError, bridgeHeartbeatRef } = useSyncCtx();
   // THE HOLDING POSTURE (2026-09-06 ruling, utils/obsidianVaultPosture.js): a
   // paired device with Obsidian closed never touches its vault — the cycle
@@ -42,15 +44,15 @@ const ObsidianSyncToast = () => {
     accentColor = 'bg-blue-500';
   } else if (isSyncing) {
     icon = <Loader size={16} className="text-blue-500 animate-spin flex-shrink-0" />;
-    message = holding ? 'Syncing through the Plugin Bridge…' : 'Syncing Obsidian vault…';
+    message = t(holding ? 'sync.obsidianToast.syncingBridge' : 'sync.obsidianToast.syncing');
     accentColor = 'bg-blue-500';
   } else if (isSuccess) {
     icon = <CheckCircle size={16} className="text-green-500 flex-shrink-0" />;
-    message = holding ? 'Synced through the Plugin Bridge' : 'Obsidian vault synced';
+    message = t(holding ? 'sync.obsidianToast.syncedBridge' : 'sync.obsidianToast.synced');
     accentColor = 'bg-green-500';
   } else {
     icon = <AlertCircle size={16} className="text-red-500 flex-shrink-0" />;
-    message = obsidianSyncError || 'Obsidian sync failed';
+    message = obsidianSyncError || t('sync.obsidianToast.failed');
     accentColor = 'bg-red-500';
   }
 
@@ -65,13 +67,13 @@ const ObsidianSyncToast = () => {
         tabIndex={isError ? 0 : undefined}
         onClick={dismiss}
         onKeyDown={(e) => { if (isError && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); dismiss(); } }}
-        aria-label={isError ? 'Dismiss sync error' : undefined}
+        aria-label={isError ? t('sync.obsidianToast.dismissError') : undefined}
       >
         <div className={`w-1.5 self-stretch rounded-full flex-shrink-0 ${accentColor}`} />
         {icon}
         <div className="min-w-0">
           <p className={`text-sm font-medium ${textPrimary}`}>{message}</p>
-          {isError && <p className={`text-xs ${textSecondary}`}>Tap to dismiss</p>}
+          {isError && <p className={`text-xs ${textSecondary}`}>{t('sync.obsidianToast.tapToDismiss')}</p>}
         </div>
       </div>
     </div>

--- a/src/components/QuickAddChips.jsx
+++ b/src/components/QuickAddChips.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Calendar, Clock, Hash, Repeat, Timer, X } from 'lucide-react';
 
 // Chip row for natural-language quick-add parses ("dentist tomorrow 3pm every
@@ -17,12 +18,13 @@ const ICONS = {
 };
 
 const QuickAddChips = ({ chips, onDismiss, darkMode }) => {
+  const { t } = useTranslation();
   if (!chips || chips.length === 0) return null;
   return (
-    <div className="mt-1.5 flex flex-wrap gap-1.5" aria-label="Detected task details">
+    <div className="mt-1.5 flex flex-wrap gap-1.5" aria-label={t('suggestions.detectedDetails')}>
       {chips.map((chip) => {
         const Icon = ICONS[chip.type] || Calendar;
-        const label = chip.inboxDate ? `Deadline: ${chip.display}` : chip.display;
+        const label = chip.inboxDate ? t('task.deadlineWithDate', { date: chip.display }) : chip.display;
         return (
           <button
             key={`${chip.sig}-${chip.start}`}
@@ -30,7 +32,7 @@ const QuickAddChips = ({ chips, onDismiss, darkMode }) => {
             onClick={() => onDismiss(chip)}
             // Keep focus in the title input while dismissing
             onMouseDown={(e) => e.preventDefault()}
-            title={`Remove: ${label}`}
+            title={t('suggestions.removeChip', { label })}
             className={`inline-flex items-center gap-1 rounded-full pl-2 pr-1.5 py-0.5 text-xs font-medium transition-colors ${
               darkMode
                 ? 'bg-blue-500/15 text-blue-300 hover:bg-blue-500/25'

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -52,7 +52,6 @@ const IS_IOS = typeof navigator !== 'undefined' && (
 const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps, onMoveToClick }, ref) => {
   const { t, i18n } = useTranslation();
   const locale = i18n.resolvedLanguage || i18n.language;
-  const taskUnitLabel = t('reminders.taskCount', { count: 2 }).replace(/^2\s*/, '');
   const {
     tasks, setTasks,
     unscheduledTasks, setUnscheduledTasks, reorderUnscheduledTasks,
@@ -349,7 +348,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
               <CheckCircle2 size={10} /> {t('common.done')}
             </span>
             {totalCount > 0 && (
-              <span className={`text-xs ${textSecondary} opacity-60`}>{completedCount}/{totalCount} {taskUnitLabel}</span>
+              <span className={`text-xs ${textSecondary} opacity-60`}>{t('common.taskProgress', { done: completedCount, total: totalCount })}</span>
             )}
             {totalCount > 0 && (
               <button
@@ -523,7 +522,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
         {/* Task count — hidden by the standalone-card eyeball toggle */}
         {!detailsHidden && !countIsMisleading && (
           <span className={`text-xs ${textSecondary}`}>
-            {completedCount}/{totalCount} {taskUnitLabel}
+            {t('common.taskProgress', { done: completedCount, total: totalCount })}
           </span>
         )}
 

--- a/src/utils/recurrenceEngine.test.js
+++ b/src/utils/recurrenceEngine.test.js
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import i18next from 'i18next';
+import en from '../../public/locales/en/translation.json';
+import fr from '../../public/locales/fr/translation.json';
 import {
   getOccurrencesInRange,
   getNextOccurrence,
@@ -145,6 +148,45 @@ describe('getRecurrencePresets', () => {
     const presets = getRecurrencePresets(WED, t, 'zh-CN');
     expect(presets[3].label).toBe('每周星期三');
     expect(presets.at(-1).label).toBe('每年8月19日');
+  });
+
+  // A month day and an ordinal position are the same word in English and
+  // diverge in French, which is why they read two different keys. Driven
+  // through the real bundles so a regression in either shows up here.
+  describe('ordinals through the shipped bundles', () => {
+    const translator = (language, translation) => {
+      const instance = i18next.createInstance();
+      instance.init({
+        lng: language,
+        fallbackLng: false,
+        resources: { [language]: { translation } },
+        initImmediate: false,
+        interpolation: { escapeValue: false },
+      });
+      return instance.t.bind(instance);
+    };
+    const label = (dateStr, language, bundle, index) =>
+      getRecurrencePresets(dateStr, translator(language, bundle), language)[index].label;
+
+    // 2026-08-01 is a Saturday, the 1st of the month and in its first week.
+    const FIRST = '2026-08-01';
+    // 2026-08-05 is a Wednesday, the 5th and in its first week.
+    const FIFTH = '2026-08-05';
+
+    it('keeps English ordinal suffixes on both the day and the position', () => {
+      expect(label(FIRST, 'en', en, 5)).toBe('Monthly on the 1st');
+      expect(label(FIFTH, 'en', en, 5)).toBe('Monthly on the 5th');
+      expect(label(FIFTH, 'en', en, 6)).toBe('Monthly on the 1st Wednesday');
+    });
+
+    it('gives French an ordinal first and cardinal days after it', () => {
+      expect(label(FIRST, 'fr', fr, 5)).toBe('Tous les mois le 1er');
+      expect(label(FIFTH, 'fr', fr, 5)).toBe('Tous les mois le 5');
+    });
+
+    it('keeps the French ordinal position ordinal', () => {
+      expect(label(FIFTH, 'fr', fr, 6)).toBe('Tous les mois le 1er mercredi');
+    });
   });
 });
 


### PR DESCRIPTION
Follow-up to #1555, closing out the leftovers from that review plus one more the sweep turned up. No behavior changes outside the strings themselves and French recurrence labels.

## The two components the localization pass missed

`ObsidianSyncToast.jsx` and `QuickAddChips.jsx` were the only two components under `src/components` with user-facing literals and no `useTranslation`.

The toast carried five English strings, four after #1556 added the Plugin Bridge wording, now under `sync.obsidianToast.*`. Terminology follows what each bundle already uses for "vault" and "Plugin Bridge" in the `settings.obsidianBridge*` strings, so the toast and the settings panel read the same.

The chip row carried three. One of them, the deadline prefix, reuses the existing `task.deadlineWithDate` rather than introducing a near-duplicate key.

## French ordinals

This could not be fixed with the single `recurrence.ordinal` key. A month **day** and an ordinal **position** are the same word in English ("the 5th", "the 2nd Monday") and diverge in French, where the day is cardinal after the first ("le 5", but "le 1er") while the position stays ordinal ("le 2e lundi").

Writing the marker into the French plural forms fixed the position and broke the day; leaving it in the template did the reverse. So the day now reads its own key, `recurrence.monthDayOrdinal`, which every other locale carries as the bare number it was already using.

Only French output changes:

| | before | after |
| --- | --- | --- |
| 1st of the month | Tous les mois le 1 | Tous les mois le 1er |
| 5th of the month | Tous les mois le 5 | Tous les mois le 5 |
| 1st Wednesday | Tous les mois le 1e mercredi | Tous les mois le 1er mercredi |

The other seven locales render byte-identically before and after, verified across all eight. Worth a second pair of eyes from a native French speaker on the convention, though it is a well-established one; @cedriclocqueneux if you have a moment.

## Task progress key

`ProjectCard` derived the word "tasks" by formatting `reminders.taskCount` with a count of 2 and stripping the leading "2" with a regex. It produced the right word in all eight locales, but it is string surgery on a plural form and would break silently if a locale ever put the number elsewhere. Replaced with `common.taskProgress`, phrased to match the Android widget's `config_task_progress` so the two surfaces read the same. `reminders.taskCount` still has three other callers and is unchanged.

## Tests

Three new cases in `recurrenceEngine.test.js` drive both ordinal keys through the real shipped bundles, so a regression in either shows up rather than passing on a stub translator.

## Validation

Run on Linux against `main` at `06ec76a`:

- 3071 tests passing across 235 files
- `npm run lint` clean
- both Electron TypeScript projects clean
- web build clean
- all eight bundles at full key and placeholder parity, 1759 keys each, no key removed and no existing English value changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWZJjDGC9LHD6hWLYZEz5

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWZJjDGC9LHD6hWLYZEz5)_