### PR TITLE
Fix boot crash: useObsidianSync was passed the ref it returns

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2831,9 +2831,6 @@ const DayPlanner = () => {
     setObsidianSyncNotice,
     obsidianVaultHandleRef, obsidianSyncInProgressRef, obsidianPrevTaskStateRef,
     obsidianTasksRef, obsidianInboxRef,
-    // The cycle's vault posture (utils/obsidianVaultPosture.js) rides on the
-    // heartbeat ref; the sync toast reads it to name what a cycle is doing.
-    bridgeHeartbeatRef,
     recycleBin, setRecycleBin,
     recurringTasks, setRecurringTasks,
     multiUserEnabled, meUserSyncId,


### PR DESCRIPTION
`main` has been crashing on load since #1556. The error boundary catches it before anything renders:

```
ReferenceError: Cannot access 'bridgeHeartbeatRef' before initialization
```

## Cause

`App.jsx` destructures `bridgeHeartbeatRef` out of `useObsidianSync`'s return value and, in the same statement, passed it back in as an argument:

```js
const {
  performObsidianSync, …, bridgeHeartbeatRef,   // ← declared here
} = useObsidianSync({
  …
  bridgeHeartbeatRef,                            // ← read here, same statement
  …
});
```

The argument object is evaluated before the destructuring binding is initialised, so every render read the binding while it was still in its temporal dead zone.

The argument was doing nothing regardless. The ref is created inside the hook with `useRef` (`useObsidianSync.js:331`) and returned (`:2019`); it is not one of the hook's parameters, so the value passed in was discarded. Removing it is enough. Consumers that need the ref, the sync toast via `SyncContext` included, read it from the destructured return further down, well after the declaration completes.

## Why nothing caught it

Worth recording, because the fix is three deleted lines but the gap that let it ship is not:

- **ESLint can't see it.** `no-use-before-define` compares source positions, and the reference sits *after* the declarator even though it runs before initialisation. I confirmed this by enabling the rule against the broken tree: zero hits. It is clean on the fixed tree too, so there is no lint rule to add here.
- **No test mounts the app.** The suite is 3071 passing tests and not one of them renders the component that throws, so a render-time crash reaches production with CI fully green.

A scan across `src` and `packages` for the same shape (a destructured binding read inside the initializer that defines it) found no other real instance. The `useMemo` matches it turned up are shorthand keys in returned object literals, not references.

## Validation

Reproduced and verified by loading the production build in headless Chromium:

- before: error boundary, `Cannot access 'Aa' before initialization` at the `useObsidianSync` call site in the minified bundle
- after: app renders, zero TDZ errors

Also 3071 tests passing, lint clean, Electron TypeScript clean, web build clean.

## Follow-up worth considering

A boot smoke test would have caught this in CI, and would catch the whole class. Roughly: build, serve `dist`, load it in headless Chromium, assert the app root renders and no uncaught errors hit the console. It needs Playwright as a dev dependency and a CI step, so it is a real decision rather than something to slip into a hotfix. Happy to open it separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWZJjDGC9LHD6hWLYZEz5

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWZJjDGC9LHD6hWLYZEz5)_