### PR TITLE
Release matrix: don't let one platform cancel the others; pin the macOS runner

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -9,9 +9,17 @@ on:
 jobs:
   build:
     strategy:
+      # One platform's failure must not cancel the others. A macOS signing
+      # break used to take the Windows and Linux builds down with it, leaving
+      # no artifacts at all to test with.
+      fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          # Pinned, not macos-latest: that label moved to a newer image on
+          # 2026-09-07 and electron-builder's `security set-key-partition-list`
+          # started failing on it ("SecKeychainUnlock: the user name or
+          # passphrase you entered is not correct") with no change on our side.
+          - os: macos-15
             artifact_glob: "dist-app/*.dmg dist-app/*-mac.zip"
           - os: windows-latest
             artifact_glob: "dist-app/*.exe"


### PR DESCRIPTION
Two lines, one of them the reason there were no test builds at all today.

## `fail-fast: false`

The macOS signing failure on `42e45c4` **cancelled the Windows and Linux jobs mid-build**. Both show `conclusion: cancelled` with their build step stopped partway, and the run produced zero artifacts. `fail-fast` defaults to `true` and was never turned off, so a Mac-only problem took every platform's test build down with it.

This is the part that matters regardless of anything else: from now on Windows and Linux artifacts survive a Mac failure.

## Pinning `macos-latest` to `macos-15`

The signing break is not ours. GitHub moved the `macos-latest` label to a newer image overnight:

| | last success (`d20a9c9`, 2026-09-06 22:00 UTC) | failure (`42e45c4`, 2026-09-07 14:17 UTC) |
| --- | --- | --- |
| electron-builder `os=` | 25.5.0 | 25.6.0 |
| Runner image | `macos-26-arm64` `20260728.0273.1` | same label, newer image |
| Signing | succeeded, Developer ID identity found | failed before signing |

Same electron-builder 26.15.7, same secrets, same steps. On the new image electron-builder's

```
security set-key-partition-list -S apple-tool:,apple: -s -k *** <temp>.keychain
```

fails with `SecKeychainUnlock: The user name or passphrase you entered is not correct`. That password is electron-builder's own generated keychain password, not `CSC_KEY_PASSWORD`, so this is not a credentials problem, and the certificate is fine: it signed successfully 16 hours earlier.

**This pin is an attempt at the signing break, not a verified fix.** I can't confirm `macos-15` behaves without a run. If it doesn't, `fail-fast: false` still guarantees the other two platforms, and the durable fix is to pre-create the keychain in the workflow and hand it to electron-builder via `CSC_KEYCHAIN` instead of letting it manage its own.

## Getting builds without cutting a tag

The workflow already has `workflow_dispatch`, so once this is in you can trigger it by hand from the Actions tab and get artifacts on all three platforms without pushing a `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWZJjDGC9LHD6hWLYZEz5

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWZJjDGC9LHD6hWLYZEz5)_