### PR TITLE
Key the macOS release steps on runner.os, not the runner label

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm ci
 
       - name: Decode provisioning profile
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         run: |
           if [ -n "$MAC_PROVISIONING_PROFILE_BASE64" ]; then
             echo "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/dayglance.provisionprofile"
@@ -52,7 +52,7 @@ jobs:
           MAC_PROVISIONING_PROFILE_BASE64: ${{ secrets.MAC_PROVISIONING_PROFILE_BASE64 }}
 
       - name: Build desktop app (macOS — signed + notarized)
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         run: npm run build:electron -- --publish never
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -63,7 +63,7 @@ jobs:
           MAC_PROVISIONING_PROFILE: ${{ env.MAC_PROVISIONING_PROFILE }}
 
       - name: Build desktop app (Windows / Linux)
-        if: matrix.os != 'macos-latest'
+        if: runner.os != 'macOS'
         run: npm run build:electron -- --publish never
 
       - name: Upload artifacts


### PR DESCRIPTION
Fixes a bug I introduced in #1560.

Three steps were guarded by the literal runner label:

```yaml
- name: Decode provisioning profile
  if: matrix.os == 'macos-latest'
- name: Build desktop app (macOS — signed + notarized)
  if: matrix.os == 'macos-latest'
- name: Build desktop app (Windows / Linux)
  if: matrix.os != 'macos-latest'
```

Pinning the runner to `macos-15` flipped all three at once. In run [34133235340](https://github.com/krelltunez/dayGLANCE/actions/runs/34133235340) the Mac job skipped the provisioning profile and the signed build, ran the Windows/Linux branch instead, then **uploaded a `.dmg` with no Developer ID signature and no notarization**. The job reported success, which is worse than failing: an unsigned artifact that looks releasable.

`runner.os` is the property these steps actually care about, and it does not move when the image label does, so pinning or unpinning can't repeat this.

## Note on the other job in that run

Windows failed for an unrelated reason, a transient CDN error while electron-builder fetched a build tool:

```
• downloaded  label=electron progress=100%
⨯ Response code 504 (Gateway Time-out)
```

No code involved. Re-running that job clears it.

## Still unverified

Whether `macos-15` actually fixes the `set-key-partition-list` signing break is still unknown, because #1560's run never executed the signing step. The first run with this merged is the real test. If Mac is red again, the durable fix remains pre-creating the keychain and passing `CSC_KEYCHAIN` to electron-builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWZJjDGC9LHD6hWLYZEz5

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWZJjDGC9LHD6hWLYZEz5)_