### PR TITLE
Completion log: don't believe an empty vault read when we hold content

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2843,7 +2843,7 @@ const DayPlanner = () => {
   // beside the notify emitters) keeps engine echoes from double-logging.
   useCompletionLog({
     tasks, unscheduledTasks, recurringTasks, projects,
-    obsidianConfig, dailyNoteTemplate,
+    obsidianConfig, dailyNoteTemplate, dailyNotes,
     obsidianVaultHandleRef, bridgeHeartbeatRef,
     setObsidianSyncError, setObsidianSyncStatus,
     isRemoteApply,

--- a/src/hooks/useCompletionLog.js
+++ b/src/hooks/useCompletionLog.js
@@ -138,9 +138,37 @@ export function buildCompletionLogWrite(candidate, { projects, obsidianConfig, d
   };
 }
 
+/**
+ * Whether an empty read means the note is ABSENT, and so may be created from
+ * the template.
+ *
+ * readDailyNoteNative collapses "file absent" and "file present but empty"
+ * into the same "" (obsidian.js), and this log has always read that as absent
+ * so a genuinely new note still gets the template. That holds only while
+ * empty means nobody has written the note yet.
+ *
+ * It stopped holding on 2026-09-07. Obsidian, opening to today's daily note
+ * on launch, created an empty note before Obsidian Sync had pulled the real
+ * one down; Sync then carried that empty file to the other devices. Reading
+ * it as absent seeded the template over a note that had content minutes
+ * earlier, and pushing the result to the vault republished the blank state
+ * everywhere. The file was already empty by then, so nothing was rescued by
+ * writing — only the app's own good copy was lost.
+ *
+ * So an empty read is absence only when we hold no content of our own for
+ * that date. When we do, the read is not trustworthy enough to write behind:
+ * refuse, exactly as a null (failed) read already does.
+ */
+export function emptyReadIsAbsent(knownText) {
+  return !(typeof knownText === 'string' && knownText.trim());
+}
+
 export default function useCompletionLog({
   tasks, unscheduledTasks, recurringTasks, projects,
   obsidianConfig, dailyNoteTemplate,
+  // The app's own copy of each date's note, keyed "YYYY-MM-DD" → { text }.
+  // Read only to decide whether an empty vault read is believable.
+  dailyNotes,
   obsidianVaultHandleRef, bridgeHeartbeatRef,
   setObsidianSyncError, setObsidianSyncStatus,
   isRemoteApply,
@@ -229,6 +257,10 @@ export default function useCompletionLog({
             // never applied templates — the append precedent).
             const note = readDailyNoteNative(write.date);
             if (note === null) { console.error('[Obsidian] Completion log: daily note read failed, entry skipped:', write.date); continue; }
+            if (note.text === '' && !emptyReadIsAbsent(dailyNotes?.[write.date]?.text)) {
+              console.error('[Obsidian] Completion log: daily note read empty but this date has known content — entry skipped rather than recreating it from the template:', write.date);
+              continue;
+            }
             // "" is absent-or-empty on native; it reads as ABSENT here so the
             // entry's note is created from the template — the accepted
             // tradeoff recorded at appendTaskToDailyNoteNative (a genuinely
@@ -241,6 +273,13 @@ export default function useCompletionLog({
           } else {
             try {
               const note = await readDailyNoteFresh(handle, obsidianConfig.dailyNotesPath || '', write.date, obsidianConfig?.dailyNotePattern || 'yyyy-MM-dd');
+              // Not the template path native takes, but the same loss: the
+              // heading and entry land on an empty note and that becomes the
+              // record. Refuse on the same evidence.
+              if (note?.text === '' && !emptyReadIsAbsent(dailyNotes?.[write.date]?.text)) {
+                console.error('[Obsidian] Completion log: daily note read empty but this date has known content — entry skipped:', write.date);
+                continue;
+              }
               const applied = applyBridgeIntent(note?.text ?? null, { type: 'completion_log_append', ...write });
               if (applied.changed) {
                 await writeDailyNoteFile(handle, obsidianConfig.dailyNotesPath || '', write.date, applied.text, obsidianConfig?.dailyNotePattern || 'yyyy-MM-dd');

--- a/src/hooks/useCompletionLog.test.js
+++ b/src/hooks/useCompletionLog.test.js
@@ -301,6 +301,82 @@ describe('native direct tier: "" reads as absent (companion §4.4 build record, 
   });
 });
 
+describe('an empty read is not believed when we hold content for that date (2026-09-07)', () => {
+  // Obsidian opening to today's note on launch creates it empty before
+  // Obsidian Sync has pulled the real one down, and Sync carries that empty
+  // file to every device. Seeding the template onto it and pushing the result
+  // republished the blank note through the vault. The file is already empty by
+  // then, so writing rescues nothing and only loses the app's good copy.
+  const baseProps = (tasks, over = {}) => ({
+    tasks, unscheduledTasks: [], recurringTasks: [], projects: [],
+    obsidianConfig: CFG, dailyNoteTemplate: '# T\n',
+    obsidianVaultHandleRef: { current: 'native' },
+    bridgeHeartbeatRef: { current: { pluginAuthoritative: false } },
+    setObsidianSyncError: vi.fn(), setObsidianSyncStatus: vi.fn(),
+    isRemoteApply: () => false,
+    ...over,
+  });
+  const DONE = [{ id: 'a', completed: true, title: 'A', completedAt: '2026-09-02T10:00:00-05:00' }];
+
+  it('refuses the write when the vault reads empty but the app holds content', async () => {
+    readDailyNoteNative.mockReturnValue({ text: '' });
+    writeDailyNoteNative.mockReturnValue(true);
+    const props = baseProps([{ id: 'a', completed: false, title: 'A' }], {
+      dailyNotes: { '2026-09-02': { text: '## Quick Notes\n\nreal content\n' } },
+    });
+    useRenderedHook(props);
+    useRenderedHook({ ...props, tasks: DONE });
+    await flush();
+    expect(writeDailyNoteNative).not.toHaveBeenCalled();
+  });
+
+  it('still creates from the template when we hold nothing for that date', async () => {
+    readDailyNoteNative.mockReturnValue({ text: '' });
+    writeDailyNoteNative.mockReturnValue(true);
+    const props = baseProps([{ id: 'a', completed: false, title: 'A' }], { dailyNotes: {} });
+    useRenderedHook(props);
+    useRenderedHook({ ...props, tasks: DONE });
+    await flush();
+    expect(writeDailyNoteNative).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a whitespace-only record as no content, so the template still lands', async () => {
+    readDailyNoteNative.mockReturnValue({ text: '' });
+    writeDailyNoteNative.mockReturnValue(true);
+    const props = baseProps([{ id: 'a', completed: false, title: 'A' }], {
+      dailyNotes: { '2026-09-02': { text: '   \n' } },
+    });
+    useRenderedHook(props);
+    useRenderedHook({ ...props, tasks: DONE });
+    await flush();
+    expect(writeDailyNoteNative).toHaveBeenCalledTimes(1);
+  });
+
+  it('a non-empty read is written normally even when we hold content', async () => {
+    readDailyNoteNative.mockReturnValue({ text: '# Day\n' });
+    writeDailyNoteNative.mockReturnValue(true);
+    const props = baseProps([{ id: 'a', completed: false, title: 'A' }], {
+      dailyNotes: { '2026-09-02': { text: '# Day\n' } },
+    });
+    useRenderedHook(props);
+    useRenderedHook({ ...props, tasks: DONE });
+    await flush();
+    expect(writeDailyNoteNative).toHaveBeenCalledTimes(1);
+  });
+
+  it('holds the FSA path to the same rule', async () => {
+    readDailyNoteFresh.mockResolvedValue({ text: '' });
+    const props = baseProps([{ id: 'a', completed: false, title: 'A' }], {
+      obsidianVaultHandleRef: { current: { kind: 'directory' } },
+      dailyNotes: { '2026-09-02': { text: '## Quick Notes\n\nreal content\n' } },
+    });
+    useRenderedHook(props);
+    useRenderedHook({ ...props, tasks: DONE });
+    await flush();
+    expect(writeDailyNoteFile).not.toHaveBeenCalled();
+  });
+});
+
 describe('ruling G: a linked project is named as a wikilink in the log line', () => {
   it('buildCompletionLogWrite writes [[Note|Title]] for a linked project and the title for a missing note', async () => {
     const { buildCompletionLogWrite } = await import('./useCompletionLog.js');


### PR DESCRIPTION
## What happened

On 2026-09-07 a daily note holding a wikilink header and a day of completions was replaced in the vault by this:

```
## Quick Notes
## Thoughts
## Accomplished
## Tasks
## Completed
```

That is `ENGLISH_DAILY_NOTE_TEMPLATE` byte for byte plus the completion-log heading. Note the missing blank lines the real note had: the content was not merged into a template, it was replaced by one. The push log shows it reaching the vault, and a later pull restoring the good copy, with the record oscillating in between.

## Why

1. Obsidian, opening to today's daily note on launch, creates that note **empty** before Obsidian Sync has pulled the real one down.
2. Obsidian Sync carries the empty file to the other devices, on top of the good one.
3. `readDailyNoteNative` returns `{ text: "" }`. It collapses "file absent" and "file present but empty" into the same value (`src/obsidian.js:1314`), so the caller cannot tell them apart.
4. `useCompletionLog.js` reads `""` as absent, creates the note from the template, appends the log heading, writes it, and pushes it to the vault as authoritative.

Step 4 is a deliberate, documented tradeoff, so a genuinely new note still receives its template. Its assumption is that empty means nobody has written the note. Obsidian Sync can hand us an empty file over one that had content a minute ago, and then the assumption is false.

The blank note is Obsidian's. The amplification is ours: we turned a blank file into a templated one and published it to the whole fleet.

## The guard

The app already holds the answer. `dailyNotes` carries our own copy of every date. So an empty read counts as absence only when we hold no content for that date; when we do, the read is refused and the entry skipped, exactly as a `null` (failed) read already is.

Refusing rather than restoring is deliberate. The file is empty on disk by that point, so writing rescues nothing, and writing our remembered copy back would resurrect content a user may have deleted on purpose.

The same guard now covers the FSA path, which reached the same loss by a different route: `''` passed straight through, so the heading and entry were appended to nothing and that became the note. Native seeded a template, FSA didn't, and both destroyed the record. The two paths now agree.

## Cost

One completion may go unlogged on the cycle where the note reads empty, matching existing behaviour for a failed read. Losing a log line beats publishing a blank note to every device.

## Tests

Five cases, driving the hook rather than the helper:

- empty read + known content → no write (**fails without the guard**)
- empty read + nothing known → template still created, the existing tradeoff preserved
- empty read + whitespace-only record → treated as no content, template still lands
- non-empty read + known content → normal write, unaffected
- FSA path, empty read + known content → no write (**fails without the guard**)

I confirmed the two marked tests fail against `main` and pass with the change, so they actually pin the behaviour.

Full suite 3076 passing, lint clean, build clean.

## Not covered here

- The task-append path (`appendTaskToDailyNoteNative`) carries the same precedent and probably wants the same treatment. Left out to keep this reviewable.
- A pull applied a daily-note value whose `lastModified` went **backwards** (16:22:28 → 16:19:51). That is what restored the note here, but if it isn't deliberate it will lose a write in the other direction eventually. Worth a separate look.
- Turning off Obsidian's open-daily-note-on-launch removes the race that triggers this. Still worth doing, since this guard limits the damage rather than preventing the blank note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWZJjDGC9LHD6hWLYZEz5

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWZJjDGC9LHD6hWLYZEz5)_