### PR TITLE
Format package: bound minutes, strip only what parses, read CRLF notes cleanly

### DIFF
--- a/dayglance-obsidian-plugin/src/bridge.ts
+++ b/dayglance-obsidian-plugin/src/bridge.ts
@@ -37,6 +37,7 @@ import {
   planStampInsertions,
   partitionStampPlan,
   settleStampPlan,
+  splitNoteLines,
   bridgeConfigAllowsStamping,
   drainSseBuffer,
   createSseArming,
@@ -1920,7 +1921,7 @@ export class BridgeTransport {
             const editorView = views[0];
             const buffer = editorView.getViewData();
             const plan = planStampInsertions(buffer, noteDate, stampOpts);
-            const settled = settleStampPlan(plan, buffer.split('\n'), this.stampSettle.get(path), Date.now());
+            const settled = settleStampPlan(plan, splitNoteLines(buffer).lines, this.stampSettle.get(path), Date.now());
             if (settled.nextState.size > 0) this.stampSettle.set(path, settled.nextState);
             else this.stampSettle.delete(path);
             if (settled.apply.length > 0) {
@@ -1947,19 +1948,22 @@ export class BridgeTransport {
             // read and this one simply un-settles the moved lines for this
             // pass (they re-enter on the re-arm).
             const plan = planStampInsertions(content, noteDate, stampOpts);
-            const contentLines = content.split('\n');
+            // Lines are compared and edited '\r'-free and re-joined with the
+            // note's own ending (splitNoteLines): a CRLF note used to get the
+            // one stamped line rewritten LF (audit low, 2026-09-06).
+            const contentLines = splitNoteLines(content).lines;
             const settled = settleStampPlan(plan, contentLines, this.stampSettle.get(path), Date.now());
             if (settled.nextState.size > 0) this.stampSettle.set(path, settled.nextState);
             else this.stampSettle.delete(path);
             if (settled.apply.length > 0) {
               const settledKeys = new Set(settled.apply.map((p) => contentLines[p.line]));
               await this.host.app.vault.process(file, (data) => {
-                const lines = data.split('\n');
+                const { lines, eol } = splitNoteLines(data);
                 for (const p of planStampInsertions(data, noteDate, stampOpts)) {
                   if (!settledKeys.has(lines[p.line])) continue;
                   lines[p.line] = lines[p.line].slice(0, p.fromCh) + p.insert;
                 }
-                return lines.join('\n');
+                return lines.join(eol);
               });
             }
             // Observe the STAMPED state: re-arm the same per-path debounce

--- a/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
+++ b/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
@@ -477,6 +477,20 @@ describe('vault task scope, end to end', () => {
     expect(after).toEqual(before);
   });
 
+  it('15. a CRLF note is stamped in place, stays CRLF throughout, and imports under the same id as its LF twin (audit low, 2026-09-06)', async () => {
+    const lf = `# House\n\n- [ ] ${LINE}\n`;
+    await bootWithScopedNote(lf.replace(/\n/g, '\r\n'));
+    const text = s.text(NOTE)!;
+    expect(text).toMatch(/Call the plumber \^dg-[a-z0-9]{8}\r\n/);
+    expect(text).not.toMatch(/[^\r]\n/);            // no line was rewritten LF inside the CRLF note
+    const mine = A.byPath(NOTE);
+    expect(mine).toHaveLength(1);
+    expect(mine[0].id).toMatch(/^obsidian-dg-/);
+    expect(mine[0].title).toContain(LINE);            // the import tag follows as usual
+    expect(mine[0].title).not.toMatch(/\r/);          // no '\r' rode into the title
+    expect(A.state.inbox).toHaveLength(1);
+  });
+
   it('9. a plugin reload republishes the pairing meta WITH the scope (harness finding)', async () => {
     await bootWithScopedNote();
     s.plugin.reload();

--- a/packages/obsidian-format/src/frontmatter.js
+++ b/packages/obsidian-format/src/frontmatter.js
@@ -37,7 +37,9 @@
 
 /** True when the text already opens with a frontmatter fence. */
 export function hasFrontmatter(text) {
-  return typeof text === 'string' && text.startsWith('---\n');
+  // A CRLF note opens its fence with '---\r\n' (audit low, 2026-09-06): it
+  // is the user's frontmatter all the same, and theirs wins.
+  return typeof text === 'string' && /^---\r?\n/.test(text);
 }
 
 /**

--- a/packages/obsidian-format/src/frontmatter.test.js
+++ b/packages/obsidian-format/src/frontmatter.test.js
@@ -46,6 +46,8 @@ describe('the v4.7.0 parser premise (the pure half)', () => {
 describe('helpers', () => {
   it('hasFrontmatter / withCreationFrontmatter basics', () => {
     expect(hasFrontmatter('---\nx: 1\n---\n')).toBe(true);
+    expect(hasFrontmatter('---\r\nx: 1\r\n---\r\n')).toBe(true); // a CRLF fence is the user's frontmatter too (audit low, 2026-09-06)
+    expect(withCreationFrontmatter('---\r\nx: 1\r\n---\r\nbody')).toBe('---\r\nx: 1\r\n---\r\nbody');
     expect(hasFrontmatter('body')).toBe(false);
     expect(hasFrontmatter('')).toBe(false);
     expect(withCreationFrontmatter('body', '2026-09-01')).toBe('---\ncreated: 2026-09-01\nsource: dayGLANCE\n---\nbody');

--- a/packages/obsidian-format/src/taskLines.js
+++ b/packages/obsidian-format/src/taskLines.js
@@ -118,6 +118,9 @@ function parseLeadingTime(text) {
       if (upper === 'AM' && endH === 12) endH = 0;
     }
     if (startH < 0 || startH > 23 || endH < 0 || endH > 23) return null;
+    // Minutes are bounded like hours (audit low, 2026-09-06): the regex's
+    // \d{2} admits 60–99, which used to parse into a startTime no clock has.
+    if (startM > 59 || endM > 59) return null;
     const startTime = `${startH.toString().padStart(2, '0')}:${rangeMatch[2]}`;
     const rawDuration = (endH * 60 + endM) - (startH * 60 + startM);
     const duration = rawDuration > 0 ? rawDuration : rawDuration + 1440; // handle midnight wrap
@@ -138,6 +141,7 @@ function parseLeadingTime(text) {
     if (upper === 'AM' && hours === 12) hours = 0;
   }
   if (hours < 0 || hours > 23) return null;
+  if (parseInt(minutes, 10) > 59) return null;
   return {
     startTime: `${hours.toString().padStart(2, '0')}:${minutes}`,
     duration: null,
@@ -168,24 +172,46 @@ function buildTimePrefix(startTime, duration) {
  */
 function stripLinePrefixes(text) {
   const trimmed = text.trim();
-  // Regex that matches a single time or a duration range (HH:MM or HH:MM-HH:MM) with optional AM/PM
-  const timeRe = /^(\d{1,2}):(\d{2})\s*(?:[AaPp][Mm])?(?:-\d{1,2}:\d{2}\s*(?:[AaPp][Mm])?)?\s+(.+)$/;
+  // The time prefix is recognized by the SAME function the parser uses, so
+  // the stripper removes exactly what the parser consumed and nothing else.
+  // It used to carry its own regex that matched any two-digit hour and any
+  // two-digit minute, so a "25:00" or "09:60" prefix the parser had refused
+  // (and therefore kept as title text) was still stripped on write — the
+  // line's title changed under a completion toggle (audit low, 2026-09-06).
   // 1) Leading date: "YYYY-MM-DD ..."
   const dateMatch = trimmed.match(/^(\d{4}-\d{2}-\d{2})\s+(.+)$/);
   if (dateMatch) {
     const datePrefix = dateMatch[1] + ' ';
     const afterDate = dateMatch[2];
     // Date + time (or date + range)
-    const tm = afterDate.match(timeRe);
-    if (tm) return { bareTitle: tm[3], datePrefix };
+    const tm = parseLeadingTime(afterDate);
+    if (tm) return { bareTitle: tm.rest, datePrefix };
     // Date only
     return { bareTitle: afterDate, datePrefix };
   }
   // 2) Time only (or range only)
-  const tm = trimmed.match(timeRe);
-  if (tm) return { bareTitle: tm[3], datePrefix: '' };
+  const tm = parseLeadingTime(trimmed);
+  if (tm) return { bareTitle: tm.rest, datePrefix: '' };
   // 3) Plain title
   return { bareTitle: trimmed, datePrefix: '' };
+}
+
+/**
+ * Split note text into lines, accepting CRLF and bare CR as well as LF, and
+ * report the note's own line ending so a rewrite can keep it. Every reader
+ * in this module used to split on '\n' alone, which left a trailing '\r' on
+ * every line of a CRLF note (Windows editors, some sync clients): task lines
+ * still matched, but the '\r' rode into rawTitle, the identity hash, and
+ * the title match on write, and a stamp insertion replaced it with the
+ * token — one line rewritten LF inside a CRLF file (audit low, 2026-09-06).
+ *
+ * @param {string} content
+ * @returns {{ lines: string[], eol: '\n' | '\r\n' }}
+ */
+export function splitNoteLines(content) {
+  const text = typeof content === 'string' ? content : '';
+  const eol = text.includes('\r\n') ? '\r\n' : '\n';
+  return { lines: text.replace(/\r\n?/g, '\n').split('\n'), eol };
 }
 
 /**
@@ -371,7 +397,7 @@ export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(
   const noteKey = notePath ? noteKeyForPath(notePath) : dateStr;
   const noteFields = notePath ? { obsidianNotePath: noteKeyForPath(notePath) } : { obsidianFileDate: dateStr };
 
-  const lines = content.split('\n');
+  const { lines } = splitNoteLines(content);
 
   for (const line of lines) {
     // Match: optional whitespace, -, space, [x or space], space, rest
@@ -613,13 +639,15 @@ export function parseTasksFromMarkdown(content, dateStr, seenBlockIds = new Set(
  */
 export function stampUntaggedTaskLines(content, noteKey, opts = {}) {
   if (!content) return { text: content ?? '', changed: false, stamped: [] };
-  const lines = content.split('\n');
+  const { lines, eol } = splitNoteLines(content);
   const plan = planStampInsertions(content, noteKey, opts);
   for (const p of plan) {
     lines[p.line] = lines[p.line].slice(0, p.fromCh) + p.insert;
   }
   return {
-    text: lines.join('\n'),
+    // Re-joined with the note's own line ending: an untouched CRLF note
+    // round-trips byte-identical, and a stamped one stays CRLF throughout.
+    text: lines.join(eol),
     changed: plan.length > 0,
     stamped: plan.map((p) => ({ blockId: p.blockId, rawTitle: p.rawTitle })),
   };
@@ -648,7 +676,10 @@ export function stampUntaggedTaskLines(content, noteKey, opts = {}) {
  */
 export function planStampInsertions(content, noteKey, { completedSince = null } = {}) {
   if (!content) return [];
-  const lines = content.split('\n');
+  // Line offsets (fromCh/toCh) are within the '\r'-free line, which is what
+  // the editor-transaction path sees too: CodeMirror's line text never
+  // includes the line terminator, CRLF or not.
+  const { lines } = splitNoteLines(content);
   const plan = [];
   for (let i = 0; i < lines.length; i++) {
     const m = lines[i].match(/^\s*- \[([ xX])\]\s+(.+)$/);

--- a/packages/obsidian-format/src/taskLines.test.js
+++ b/packages/obsidian-format/src/taskLines.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseTasksFromMarkdown, legacyObsidianId, updateTaskLines } from './index.js';
+import { parseTasksFromMarkdown, legacyObsidianId, updateTaskLines, stampUntaggedTaskLines, planStampInsertions, splitNoteLines } from './index.js';
 
 // Tasks-metadata PARSE-MAPPING pins, beside the grammar (moved from
 // dayGLANCE's obsidian.tasksMetadataRead.test.js in the format-package
@@ -79,5 +79,92 @@ describe('updateTaskLines — noteDate and the inline date prefix', () => {
     const lines = ['- [ ] Water the plants ^dg-abc12345'];
     updateTaskLines(lines, { ...base, targetDate: '2026-09-06' });
     expect(lines[0]).toBe('- [ ] 2026-09-06 Water the plants ^dg-abc12345');
+  });
+});
+
+describe('time prefix validation — hours AND minutes, and the stripper mirrors the parser (audit low, 2026-09-06)', () => {
+  const DATE = '2026-09-06';
+  it('minutes 60–99 do not parse as a time: the line is an inbox task whose title keeps the prefix text', () => {
+    const { scheduledTasks, inboxTasks } = parseTasksFromMarkdown('- [ ] 09:60 Bad clock', DATE);
+    expect(scheduledTasks).toHaveLength(0);
+    expect(inboxTasks).toHaveLength(1);
+    expect(inboxTasks[0].obsidianRawTitle).toBe('09:60 Bad clock');
+  });
+  it('a bad minute on either end of a range refuses the whole range, like a bad hour does', () => {
+    for (const line of ['- [ ] 09:00-10:75 Long', '- [ ] 09:99-10:00 Long', '- [ ] 25:00-26:00 Long']) {
+      const { scheduledTasks, inboxTasks } = parseTasksFromMarkdown(line, DATE);
+      expect(scheduledTasks, line).toHaveLength(0);
+      expect(inboxTasks, line).toHaveLength(1);
+    }
+    const ok = parseTasksFromMarkdown('- [ ] 09:00-10:59 Long', DATE).scheduledTasks;
+    expect(ok).toHaveLength(1);
+    expect(ok[0].duration).toBe(119);
+  });
+  it('the boundary minutes still parse: :00 and :59', () => {
+    const t = parseTasksFromMarkdown('- [ ] 23:59 Late\n- [ ] 00:00 Early', DATE).scheduledTasks;
+    expect(t.map((x) => x.startTime)).toEqual(['23:59', '00:00']);
+  });
+  it('a completion toggle on a line whose prefix the parser refused leaves that prefix in the title', () => {
+    // The parser kept "25:00 Not a time" as the raw title. The write path
+    // used to strip "25:00 " with its own looser regex, so the completed
+    // line came back as "- [x] Not a time" — a title change nobody asked for.
+    // [line body, the raw title the parser derives from it, the line after a completion toggle]
+    const cases = [
+      ['25:00 Not a time', '25:00 Not a time', '- [x] 25:00 Not a time'],
+      ['09:60 Not a time', '09:60 Not a time', '- [x] 09:60 Not a time'],
+      // A date prefix still parses (all-day); only the refused time stays in the title.
+      ['2026-09-06 09:60 Not a time', '09:60 Not a time', '- [x] 2026-09-06 09:60 Not a time'],
+    ];
+    for (const [body, rawTitle, after] of cases) {
+      const parsed = parseTasksFromMarkdown(`- [ ] ${body}`, DATE);
+      const task = [...parsed.scheduledTasks, ...parsed.inboxTasks][0];
+      expect(task.obsidianRawTitle, body).toBe(rawTitle);
+      const lines = [`- [ ] ${body}`];
+      expect(updateTaskLines(lines, { obsidianRawTitle: rawTitle, completed: true, startTime: null, duration: null, targetDate: null, noteDate: DATE }), body).toBe(true);
+      expect(lines[0], body).toBe(after);
+    }
+  });
+});
+
+describe('CRLF notes (audit low, 2026-09-06)', () => {
+  const DATE = '2026-09-06';
+  const LF = '# Day\n\n- [ ] 09:00 Standup\n- [x] Water plants ✅ 2026-09-06\n';
+  const CRLF = LF.replace(/\n/g, '\r\n');
+  it('splitNoteLines: CRLF and bare CR split to clean lines and report the eol; LF reports LF', () => {
+    expect(splitNoteLines(CRLF)).toEqual({ lines: ['# Day', '', '- [ ] 09:00 Standup', '- [x] Water plants ✅ 2026-09-06', ''], eol: '\r\n' });
+    expect(splitNoteLines('a\rb\n').lines).toEqual(['a', 'b', '']);
+    expect(splitNoteLines(LF).eol).toBe('\n');
+    expect(splitNoteLines('').lines).toEqual(['']);
+  });
+  it('a CRLF note parses to the same tasks, titles, times and identities as its LF twin', () => {
+    const a = parseTasksFromMarkdown(LF, DATE);
+    const b = parseTasksFromMarkdown(CRLF, DATE);
+    expect(b).toEqual(a);
+    const all = [...a.scheduledTasks, ...a.inboxTasks];
+    expect(all).toHaveLength(2);
+    expect(a.scheduledTasks.map((t) => t.obsidianRawTitle)).toEqual(['Standup']);
+    expect(all.some((t) => /\r/.test(t.obsidianRawTitle) || /\r/.test(t.title))).toBe(false);
+  });
+  it('stamping a CRLF note keeps every line ending CRLF and stamps the same ids as the LF twin', () => {
+    const a = stampUntaggedTaskLines(LF, DATE);
+    const b = stampUntaggedTaskLines(CRLF, DATE);
+    expect(b.changed).toBe(true);
+    expect(b.stamped.map((x) => x.blockId)).toEqual(a.stamped.map((x) => x.blockId));
+    expect(b.text).toBe(a.text.replace(/\n/g, '\r\n'));
+    expect(b.text).not.toMatch(/[^\r]\n/);
+  });
+  it('an already-stamped CRLF note round-trips byte-identical through the stamper', () => {
+    const stamped = stampUntaggedTaskLines(CRLF, DATE).text;
+    const again = stampUntaggedTaskLines(stamped, DATE);
+    expect(again.changed).toBe(false);
+    expect(again.text).toBe(stamped);
+  });
+  it('the stamp plan offsets are within the CR-free line, as the editor sees it', () => {
+    const plan = planStampInsertions(CRLF, DATE);
+    expect(plan).toHaveLength(2);
+    for (const p of plan) {
+      expect(p.fromCh).toBe(p.toCh);
+      expect(splitNoteLines(CRLF).lines[p.line]).toHaveLength(p.toCh);
+    }
   });
 });

--- a/packages/obsidian-format/types/index.d.ts
+++ b/packages/obsidian-format/types/index.d.ts
@@ -69,6 +69,8 @@ export function stampUntaggedTaskLines(
 export function planStampInsertions(
   content: string, noteKey: string, opts?: { completedSince?: string | null },
 ): Array<{ line: number; fromCh: number; toCh: number; insert: string; blockId: string; rawTitle: string }>;
+/** Split note text into '\r'-free lines (CRLF and bare CR accepted) and report the note's own line ending for a rewrite. */
+export function splitNoteLines(content: string): { lines: string[]; eol: '\n' | '\r\n' };
 
 // ── vault task scope (companion §6, rulings D and E) ────────────────────────
 export interface VaultScope { folders: string[]; tags: string[]; completionWindowDays: number }


### PR DESCRIPTION
## Summary

The two remaining low audit findings from 2026-09-06, both in the vault-format grammar. One small package change, one plugin follow-through, tests for each.

**Hour/minute asymmetry.** The time-prefix parser bounded hours to 0 to 23 but never checked minutes, so `09:60` parsed as a start time no clock has, on single times and on both ends of a range. Minutes are now bounded 0 to 59; a bad minute refuses the whole prefix, so the line stays an inbox task with its text intact. The write-side prefix stripper had its own looser regex, so a `25:00` or `09:60` prefix the parser had refused and kept as title text was still stripped on a completion toggle, changing the title. The stripper now recognizes the prefix with the parser's own function, so a write strips exactly what the parse consumed.

**CRLF blindness.** Every reader split on `\n` alone, leaving a trailing `\r` on each line of a CRLF note. It rode into the raw title, the identity hash and the title match on write, and a stamp insertion replaced it with the token, rewriting one line LF inside a CRLF file. A new `splitNoteLines` splits on CRLF, CR or LF and reports the note's own line ending. `parseTasksFromMarkdown`, `stampUntaggedTaskLines` and `planStampInsertions` read through it, the stamper re-joins with the note's ending, and the plugin's two stamp paths (editor buffer and `Vault.process`) do the same. `hasFrontmatter` accepts a CRLF fence, so a user's CRLF frontmatter still wins over ours.

**Deliberately not touched.** The plugin's intent applies in `bridgeStream.js` (task appends and the log appends) still split and join on `\n`. That is the apply path and gets its own harness coverage in a separate change.

## Tests

- Package: minute bounds on single and range prefixes, both ends, and the `:00` and `:59` boundaries; a completion toggle on a refused prefix keeps the title, with and without a date prefix; CRLF and LF twins parse identically; stamping a CRLF note stamps the same ids, stays CRLF throughout, and an already-stamped CRLF note round-trips byte-identical; plan offsets are within the CR-free line; a CRLF frontmatter fence is recognized.
- Harness scenario 15: a CRLF note is stamped in place by the real plugin, stays CRLF, and imports with a clean title.
- Suites: format package 180/180, plugin harness 50/50, plugin typecheck clean, app Obsidian suites 511/511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_