### PR TITLE
Sync toast: wire the heartbeat ref into the sync context so the holding copy can fire

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8683,6 +8683,12 @@ const DayPlanner = () => {
     suppressClearPendingRef, cloudSyncInProgressRef, cloudSyncInitialDoneRef,
     cloudSyncDownloadRef,
     obsidianVaultHandleRef, obsidianSyncInProgressRef, obsidianPrevTaskStateRef,
+    // The heartbeat ref carries the cycle's vault posture; the sync toast
+    // reads it to name the holding posture. #1556 put it in the deps object
+    // passed INTO useObsidianSync (the hook that returns it) instead of here,
+    // the boot-crash fix removed it from there, and the toast's posture check
+    // was left reading undefined on every platform (2026-09-08 finding).
+    bridgeHeartbeatRef,
     obsidianTasksRef, obsidianInboxRef,
     trmnlSyncTimerRef, trmnlLastPushRef, trmnlBackoffUntilRef, trmnlBackoffCountRef,
     trmnlSyncInProgressRef, performTrmnlSyncRef,

--- a/src/components/ObsidianSyncToast.jsx
+++ b/src/components/ObsidianSyncToast.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { CheckCircle, AlertCircle, Loader } from 'lucide-react';
 import { useSyncCtx } from '../context/SyncContext.jsx';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
+import { obsidianToastKey } from '../utils/obsidianToastCopy.js';
 
 const ObsidianSyncToast = () => {
   const { t } = useTranslation();
@@ -11,7 +12,7 @@ const ObsidianSyncToast = () => {
   // paired device with Obsidian closed never touches its vault — the cycle
   // reads the stream and queues intents. The toast names that, so it never
   // contradicts the settings line saying vault changes wait for Obsidian.
-  const holding = bridgeHeartbeatRef?.current?.vaultPosture === 'holding';
+  const vaultPosture = bridgeHeartbeatRef?.current?.vaultPosture;
   const { cardBg, borderClass, textPrimary, textSecondary, isMobile } = useDayPlannerCtx();
 
   // Fire-and-forget NOTICE (e.g. a two-sided retitle resolution): neutral
@@ -44,11 +45,11 @@ const ObsidianSyncToast = () => {
     accentColor = 'bg-blue-500';
   } else if (isSyncing) {
     icon = <Loader size={16} className="text-blue-500 animate-spin flex-shrink-0" />;
-    message = t(holding ? 'sync.obsidianToast.syncingBridge' : 'sync.obsidianToast.syncing');
+    message = t(obsidianToastKey('syncing', vaultPosture));
     accentColor = 'bg-blue-500';
   } else if (isSuccess) {
     icon = <CheckCircle size={16} className="text-green-500 flex-shrink-0" />;
-    message = t(holding ? 'sync.obsidianToast.syncedBridge' : 'sync.obsidianToast.synced');
+    message = t(obsidianToastKey('success', vaultPosture));
     accentColor = 'bg-green-500';
   } else {
     icon = <AlertCircle size={16} className="text-red-500 flex-shrink-0" />;

--- a/src/utils/obsidianToastCopy.js
+++ b/src/utils/obsidianToastCopy.js
@@ -1,0 +1,14 @@
+// The Obsidian sync toast's copy choice, kept pure so the posture branch is
+// testable without rendering: a paired device whose heartbeat is stale is
+// HOLDING (utils/obsidianVaultPosture.js) — it never touches its vault, the
+// cycle reads the stream and queues intents — and the toast must say so
+// rather than claim a vault sync the settings line says is waiting.
+//
+// @param {'syncing'|'success'} phase
+// @param {string|undefined} vaultPosture  bridgeHeartbeatRef.current.vaultPosture
+// @returns {string} the i18n key under sync.obsidianToast
+export function obsidianToastKey(phase, vaultPosture) {
+  const holding = vaultPosture === 'holding';
+  if (phase === 'syncing') return holding ? 'sync.obsidianToast.syncingBridge' : 'sync.obsidianToast.syncing';
+  return holding ? 'sync.obsidianToast.syncedBridge' : 'sync.obsidianToast.synced';
+}

--- a/src/utils/obsidianToastCopy.test.js
+++ b/src/utils/obsidianToastCopy.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { obsidianToastKey } from './obsidianToastCopy.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+describe('obsidianToastKey — the holding posture names itself', () => {
+  it('holding → the Bridge copy for both phases', () => {
+    expect(obsidianToastKey('syncing', 'holding')).toBe('sync.obsidianToast.syncingBridge');
+    expect(obsidianToastKey('success', 'holding')).toBe('sync.obsidianToast.syncedBridge');
+  });
+  it('plugin, direct, or no posture yet → the vault copy', () => {
+    for (const posture of ['plugin', 'direct', undefined, null]) {
+      expect(obsidianToastKey('syncing', posture)).toBe('sync.obsidianToast.syncing');
+      expect(obsidianToastKey('success', posture)).toBe('sync.obsidianToast.synced');
+    }
+  });
+});
+
+// WIRING CANARY (2026-09-08): the toast reads bridgeHeartbeatRef from the
+// sync context. #1556 added the ref to the deps object passed INTO
+// useObsidianSync (the hook that RETURNS it) instead of the context object;
+// the boot-crash fix removed it from there, and the toast's posture check
+// read undefined on every platform — the relabel never fired. Pin both
+// halves against the source: the context carries the ref, the hook's deps
+// object does not, and the toast reads it from the context.
+describe('App.jsx wiring: bridgeHeartbeatRef reaches the toast through the sync context', () => {
+  const src = readFileSync(path.join(here, '..', 'App.jsx'), 'utf8');
+  const objectAt = (anchor) => {
+    const i = src.indexOf(anchor);
+    expect(i, `anchor present: ${anchor}`).toBeGreaterThan(-1);
+    const open = src.indexOf('{', i);
+    let depth = 0;
+    for (let j = open; j < src.length; j++) {
+      if (src[j] === '{') depth++;
+      else if (src[j] === '}') { depth--; if (depth === 0) return src.slice(open, j + 1); }
+    }
+    throw new Error('unbalanced block');
+  };
+  it('the syncCtx object includes bridgeHeartbeatRef', () => {
+    expect(objectAt('const syncCtx = {')).toMatch(/^\s*bridgeHeartbeatRef,/m);
+  });
+  it('the deps object handed to useObsidianSync does NOT carry the ref it returns (the boot crash)', () => {
+    expect(objectAt('useObsidianSync({')).not.toMatch(/^\s*bridgeHeartbeatRef,/m);
+  });
+  it('the toast reads it from useSyncCtx', () => {
+    const toast = readFileSync(path.join(here, '..', 'components', 'ObsidianSyncToast.jsx'), 'utf8');
+    expect(toast).toMatch(/bridgeHeartbeatRef[^\n]*=\s*useSyncCtx\(\)/);
+  });
+});


### PR DESCRIPTION
## Summary

The holding-posture toast copy added in #1556 never showed anywhere. The toast reads `bridgeHeartbeatRef` from the sync context, but #1556 put the ref into the deps object passed *into* `useObsidianSync`, the hook that returns it. That caused the boot crash fixed this morning, and the fix removed it from there without adding it to the context. So the toast's posture check read undefined on every platform and every cycle.

Found on Android, where a paired phone with Obsidian closed showed the settings block's waiting copy and the toast's vault copy at the same time.

## Changes

- `src/App.jsx`: `bridgeHeartbeatRef` added to the `syncCtx` object. One line plus a comment recording the history.
- `src/components/ObsidianSyncToast.jsx`: the copy choice moves to a pure helper so the posture branch is testable without rendering.
- `src/utils/obsidianToastCopy.js`: the helper. Holding gives the Bridge keys for both phases; plugin, direct, or no posture yet give the vault keys.
- `src/utils/obsidianToastCopy.test.js`: the helper's truth table, plus a wiring canary that pins three facts against the source: the `syncCtx` object carries the ref, the `useObsidianSync` deps object does not, and the toast reads it from `useSyncCtx`.

No copy changes. The wording of the holding copy itself is under review separately.

## Verification

Lint clean on the three changed source files. New tests 5/5, adjacent posture and bridge-status suites pass. Field confirmation is on the next Android build: a paired phone with Obsidian closed should show the Bridge wording in both the syncing and synced toasts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_