### PR TITLE
Test: freeze the clock in the priority re-stamp test (CI flake on main)

### DIFF
--- a/src/utils/stampTimestamps.test.js
+++ b/src/utils/stampTimestamps.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { stampTimestamps } from './stampTimestamps.js';
 import { mergeTaskArrays } from '../mergeSync.js';
 
@@ -165,8 +165,17 @@ describe('stampTimestamps — priority presence is not an edit', () => {
   });
 
   it('still stamps a real priority edit', () => {
-    const stored = [{ id: 1, title: 'A', lastModified: ISO(100) }];
-    const inMemory = [{ id: 1, title: 'A', priority: 2, lastModified: ISO(100) }];
-    expect(stampTimestamps(inMemory, stored, ISO(0))[0].lastModified).toBe(ISO(0));
+    // Frozen clock: the stamp is "now" as the function reads it, and the
+    // expected value was "now" as the test read it a moment earlier. On CI
+    // those straddled a millisecond boundary (2026-09-08, run 1201) and the
+    // two ISO strings differed by 1 ms.
+    vi.useFakeTimers({ now: new Date('2026-09-08T04:41:17.556Z') });
+    try {
+      const stored = [{ id: 1, title: 'A', lastModified: ISO(100) }];
+      const inMemory = [{ id: 1, title: 'A', priority: 2, lastModified: ISO(100) }];
+      expect(stampTimestamps(inMemory, stored, ISO(0))[0].lastModified).toBe('2026-09-08T04:41:17.556Z');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary

CI run 1201 on main, the #1565 merge, failed in `src/utils/stampTimestamps.test.js` at "still stamps a real priority edit". The test compares the timestamp the function stamps with one the test computed a moment earlier; on that run they straddled a millisecond boundary and differed by 1 ms. Nothing in #1565 touches this path; the test has been racy since #1551 added it.

Fix: fake timers pin both reads to one instant. Test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_