### PR TITLE
Stream dedupe: a copy-pasted ^dg- token keeps its existing owner, vault-wide

### DIFF
--- a/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
+++ b/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
@@ -80,7 +80,7 @@ function mountDevice(name: string) {
   };
 
   ls.setItem('dayglance-vault-config', JSON.stringify({ enabled: true, vaultUrl: VAULT_URL, vaultToken: `token-${name}`, accountId: ACCOUNT_ID }));
-  const state = { tasks: [] as Task[], inbox: [] as Task[], recycleBin: [] as Task[] };
+  const state = { tasks: [] as Task[], inbox: [] as Task[], recycleBin: [] as Task[], dailyNotes: {} as Record<string, { text?: string; lastModified?: string }> };
   const log: string[] = [];
   const tasksRef = { current: state.tasks };
   const inboxRef = { current: state.inbox };
@@ -90,6 +90,13 @@ function mountDevice(name: string) {
   const setTasks = (up: Task[] | ((p: Task[]) => Task[])) => { replace(state.tasks, typeof up === 'function' ? up([...state.tasks]) : up); };
   const setUnscheduledTasks = (up: Task[] | ((p: Task[]) => Task[])) => { replace(state.inbox, typeof up === 'function' ? up([...state.inbox]) : up); };
   const setRecycleBin = (up: Task[] | ((p: Task[]) => Task[])) => { state.recycleBin = typeof up === 'function' ? up(state.recycleBin) : up; };
+  // Daily notes are kept as a map mutated IN PLACE (like the task arrays) so
+  // the hook's captured reference always reads the current texts.
+  const setDailyNotes = (up: Record<string, unknown> | ((p: Record<string, unknown>) => Record<string, unknown>)) => {
+    const next = typeof up === 'function' ? up({ ...state.dailyNotes }) : up;
+    for (const k of Object.keys(state.dailyNotes)) delete state.dailyNotes[k];
+    Object.assign(state.dailyNotes, next || {});
+  };
   const syncRef = { current: false };
   const prevRef = { current: {} as Record<string, unknown> };
   effects.length = 0;
@@ -98,7 +105,7 @@ function mountDevice(name: string) {
     isTrayMode: false, dataLoaded: true,
     tasks: state.tasks, setTasks,
     unscheduledTasks: state.inbox, setUnscheduledTasks,
-    setDailyNotes: vi.fn(), setWikilinkCandidates: vi.fn(), setUnportableVaultFiles: vi.fn(),
+    dailyNotes: state.dailyNotes, setDailyNotes, setWikilinkCandidates: vi.fn(), setUnportableVaultFiles: vi.fn(),
     obsidianConfig: { enabled: true, dailyNotesPath: 'Daily', dailyNotePattern: 'yyyy-MM-dd', taskHeading: '## Tasks' },
     setObsidianConfig: vi.fn(), obsidianLaunchOnWrite: null,
     obsidianCompletionDates: false,
@@ -489,6 +496,35 @@ describe('vault task scope, end to end', () => {
     expect(mine[0].title).toContain(LINE);            // the import tag follows as usual
     expect(mine[0].title).not.toMatch(/\r/);          // no '\r' rode into the title
     expect(A.state.inbox).toHaveLength(1);
+  });
+
+  it('16. a stamped line copy-pasted into a second daily note keeps its identity on the original; the copy is a separate task, in either observation order (audit low, 2026-08-31)', async () => {
+    await bootWithScopedNote();
+    const D1 = 'Daily/2026-09-04.md';
+    const D2 = 'Daily/2026-09-05.md';
+    await s.write(D1, '## Tasks\n- [ ] Water the plants\n');
+    await s.settle();
+    await A.sync();
+    const original = A.all().find((t) => /Water the plants/.test(t.title))!;
+    expect(original.obsidianFileDate).toBe('2026-09-04');
+    const token = s.text(D1)!.match(/\^dg-([a-z0-9]{8})/)![1];
+    expect(original.id).toBe(`obsidian-dg-${token}`);
+    // Copy the stamped line, token and all, into the next day's note. D1 is
+    // untouched, so only D2 is observed: the batch never contains the owner.
+    await s.write(D2, `## Tasks\n- [ ] Water the plants ^dg-${token}\n`);
+    await s.settle();
+    await A.sync();
+    const keeper = A.all().find((t) => t.id === original.id)!;
+    expect(keeper.obsidianFileDate).toBe('2026-09-04');   // identity stayed home
+    const copies = A.all().filter((t) => /Water the plants/.test(t.title));
+    expect(copies).toHaveLength(2);                        // the copy is its own task
+    expect(copies.find((t) => t.id !== original.id)!.obsidianFileDate).toBe('2026-09-05');
+    // A later edit to D1 alone re-observes the owner: nothing changes hands.
+    await s.write(D1, `## Tasks\n- [ ] Water the plants ^dg-${token}\n- [ ] Buy soil\n`);
+    await s.settle();
+    await A.sync();
+    expect(A.all().find((t) => t.id === original.id)!.obsidianFileDate).toBe('2026-09-04');
+    expect(A.all().filter((t) => /Water the plants/.test(t.title))).toHaveLength(2);
   });
 
   it('9. a plugin reload republishes the pairing meta WITH the scope (harness finding)', async () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2820,7 +2820,7 @@ const DayPlanner = () => {
     isTrayMode, dataLoaded,
     tasks, setTasks,
     unscheduledTasks, setUnscheduledTasks,
-    setDailyNotes,
+    dailyNotes, setDailyNotes,
     setWikilinkCandidates,
     setUnportableVaultFiles,
     obsidianConfig, setObsidianConfig,

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -135,6 +135,11 @@ export default function useObsidianSync({
   tasks, setTasks,
   unscheduledTasks, setUnscheduledTasks,
   setDailyNotes,
+  // The app's daily notes (date → { text, lastModified }): the observation
+  // applier reads the last observed text of a note outside the batch for the
+  // vault-wide duplicate-token dedupe. Optional; the applier falls back to
+  // the app's own store when absent.
+  dailyNotes = null,
   setWikilinkCandidates,
   setUnportableVaultFiles,
   obsidianConfig, setObsidianConfig,
@@ -725,6 +730,7 @@ export default function useObsidianSync({
                 // Project notes (companion §4.3, ruling H).
                 projectByNotePath: projectByNotePath(projectsRef.current),
                 projects: projectsRef.current,
+                knownDailyNotes: dailyNotes ?? null,
               })
             : null;
 

--- a/src/utils/obsidianBridgeInbound.js
+++ b/src/utils/obsidianBridgeInbound.js
@@ -36,6 +36,7 @@ import {
   BRIDGE_OBSERVATION_PREFIX,
   BRIDGE_ACTION_PREFIX,
   completedSinceFor,
+  noteKeyForPath,
 } from '@glance-apps/obsidian-format';
 import {
   buildExistingObsidianTaskContext,
@@ -185,6 +186,35 @@ export async function pendingBridgeObservations() {
  * on demand; deletions — see the module header) is left to the caller via
  * the `unapplied` list.
  */
+/** The note key an observation parses under: a daily note's date, a scoped
+ *  note's path key, or null when the observation carries no note. Mirrors
+ *  the derivation inside applyBridgeObservations exactly. */
+function observationNoteKey(obs, { folderPrefix, isDefaultPattern, dateParser }) {
+  if (!obs || obs.link) return null;
+  if (obs.scoped || obs.withdrawn) return noteKeyForPath(obs.path);
+  const path = String(obs.path || '');
+  if (folderPrefix ? !path.startsWith(folderPrefix) : path.includes('/')) return null;
+  const name = path.slice(folderPrefix.length);
+  if (isDefaultPattern) return /^\d{4}-\d{2}-\d{2}\.md$/.test(name) ? name.slice(0, -3) : null;
+  return name.endsWith('.md') ? (parseDateFromFilename(name, dateParser) || null) : null;
+}
+
+/** token → the note key of the task that currently owns it, from the app's
+ *  Obsidian tasks (a daily note's date or a scoped note's path key). */
+function ownedTokenNotes(existingTasks, existingInbox) {
+  const owner = new Map();
+  for (const t of [...(existingTasks || []), ...(existingInbox || [])]) {
+    if (!t || t.importSource !== 'obsidian' || !t.obsidianBlockId) continue;
+    const key = t.obsidianNotePath || t.obsidianFileDate;
+    if (key) owner.set(String(t.obsidianBlockId), String(key));
+  }
+  return owner;
+}
+
+function readKnownDailyNotes() {
+  try { return JSON.parse(localStorage.getItem('day-planner-daily-notes') || '{}'); } catch { return {}; }
+}
+
 export function applyBridgeObservations(observations, {
   existingTasks, existingInbox, dailyNotesPath = '', dailyNotePattern = 'yyyy-MM-dd', onTitleConflict = null,
   // VAULT TASK SCOPE (companion §6): the plugin flags a non-daily note in
@@ -201,6 +231,11 @@ export function applyBridgeObservations(observations, {
   // (companion §4.3, ruling G as amended): on first import and on a vault
   // edit of the field.
   projects = null,
+  // The app's stored daily notes (date → { text }), the last text observed
+  // for each. The duplicate-token dedupe below reads them to tell whether a
+  // note NOT in this batch still carries a token; defaults to the app's own
+  // store so every caller sees the same vault.
+  knownDailyNotes = null,
 }) {
   const dailyNotes = {};
   const scopedNotes = {}; // path → { lastModified, deleted? } for scoped (non-daily) notes in this batch
@@ -229,9 +264,43 @@ export function applyBridgeObservations(observations, {
   const isDefaultPattern = !dailyNotePattern || dailyNotePattern === 'yyyy-MM-dd';
   const dateParser = isDefaultPattern ? null : buildDateParser(dailyNotePattern);
   const folderPrefix = dailyNotesPath ? `${dailyNotesPath.replace(/\/+$/, '')}/` : '';
-  const seenBlockIds = new Set();
+  const noteKeyOf = (obs) => observationNoteKey(obs, { folderPrefix, isDefaultPattern, dateParser });
 
-  for (const obs of observations) {
+  // DUPLICATE-TOKEN DEDUPE, VAULT-WIDE (audit low, 2026-08-31). A `^dg-`
+  // token names ONE line; when a line is copy-pasted with its token, the
+  // parser lets the first occurrence keep it and the copy falls through as
+  // untagged. A scan reads every note in one pass, so "first" is stable.
+  // The stream reads notes one observation at a time, and `seenBlockIds`
+  // was fresh per batch: whichever note happened to be in the batch won,
+  // so the token's owner flip-flopped between observations and the two
+  // lines traded identity. Two rules restore the scan's answer:
+  //   1. The EXISTING owner keeps its token. Its note goes first within a
+  //      batch, and when its note is not in the batch at all, the token is
+  //      pre-seeded as taken — but only when the app's last observed text
+  //      of that note demonstrably still carries the token, so a line CUT
+  //      from one note and pasted into another, or a note renamed with the
+  //      old path's deletion arriving a batch earlier, still re-homes the
+  //      identity (the stored text no longer has it, or the note is gone).
+  //   2. Only daily notes back the pre-seed: their text is stored; a scoped
+  //      note's is not, so a token owned by a scoped note outside the batch
+  //      is not asserted from memory (the rename-split hazard outweighs it).
+  const ownerByToken = ownedTokenNotes(existingTasks, existingInbox);
+  const knownNotes = knownDailyNotes ?? readKnownDailyNotes();
+  const batchKeys = new Set(observations.map(noteKeyOf).filter(Boolean));
+  const seenBlockIds = new Set();
+  for (const [token, owner] of ownerByToken) {
+    if (batchKeys.has(owner)) continue;
+    const text = knownNotes?.[owner]?.text;
+    if (typeof text === 'string' && text.includes(`^dg-${token}`)) seenBlockIds.add(token);
+  }
+  const ownerNotes = new Set(ownerByToken.values());
+  const ordered = [...observations].sort((a, b) => {
+    const ao = ownerNotes.has(noteKeyOf(a)) ? 0 : 1;
+    const bo = ownerNotes.has(noteKeyOf(b)) ? 0 : 1;
+    return ao - bo; // stable: owners first, batch order otherwise
+  });
+
+  for (const obs of ordered) {
     if (obs.link) {
       if (typeof obs.targetId === 'string' && obs.targetId) {
         links.push({

--- a/src/utils/obsidianBridgeInbound.test.js
+++ b/src/utils/obsidianBridgeInbound.test.js
@@ -194,6 +194,60 @@ describe('applyBridgeObservations', () => {
   });
 });
 
+describe('applyBridgeObservations — duplicate-token dedupe is vault-wide (audit low, 2026-08-31)', () => {
+  // The existing owner of ^dg-abc12345 is the 2026-08-29 daily note.
+  const OWNER_TEXT = '## Tasks\n- [ ] Vault task ^dg-abc12345\n';
+  const COPY_TEXT = '## Tasks\n- [ ] Vault task ^dg-abc12345\n';
+  const owner = () => [{
+    id: 'obsidian-dg-abc12345', importSource: 'obsidian', obsidianBlockId: 'abc12345',
+    obsidianRawTitle: 'Vault task', title: 'Vault task #obsidian', obsidianFileDate: '2026-08-29',
+    completed: false, lastModified: '2026-08-20T00:00:00Z',
+  }];
+  const opts = (extra = {}) => ({
+    existingTasks: [], existingInbox: owner(), dailyNotesPath: 'Daily', dailyNotePattern: 'yyyy-MM-dd',
+    knownDailyNotes: { '2026-08-29': { text: OWNER_TEXT } },
+    ...extra,
+  });
+  const obs = (date, content) => ({ path: `Daily/${date}.md`, content, mtime: 1756400000000, observedAt: '2026-08-30T12:00:00Z' });
+
+  it('a copy-pasted line observed in ANOTHER note, alone in its batch, falls through as untagged: the owner keeps the token', () => {
+    const out = applyBridgeObservations([obs('2026-08-30', COPY_TEXT)], opts());
+    const copies = [...out.scheduledTasks, ...out.inboxTasks];
+    expect(copies).toHaveLength(1);
+    expect(copies[0].obsidianBlockId).toBeUndefined();
+    expect(copies[0].id).not.toBe('obsidian-dg-abc12345');
+    expect(copies[0].obsidianFileDate).toBe('2026-08-30');
+  });
+
+  it('both notes in one batch, the copy FIRST in batch order: the owner still wins (no order dependence)', () => {
+    const out = applyBridgeObservations([obs('2026-08-30', COPY_TEXT), obs('2026-08-29', OWNER_TEXT)], opts());
+    const all = [...out.scheduledTasks, ...out.inboxTasks];
+    const tagged = all.filter((t) => t.obsidianBlockId === 'abc12345');
+    expect(tagged).toHaveLength(1);
+    expect(tagged[0].obsidianFileDate).toBe('2026-08-29');
+    expect(all.find((t) => t.obsidianFileDate === '2026-08-30').obsidianBlockId).toBeUndefined();
+  });
+
+  it('a line CUT from the owner and pasted elsewhere re-homes the identity: the stored owner text no longer carries the token', () => {
+    const out = applyBridgeObservations([obs('2026-08-30', COPY_TEXT)], opts({ knownDailyNotes: { '2026-08-29': { text: '## Tasks\n' } } }));
+    const all = [...out.scheduledTasks, ...out.inboxTasks];
+    expect(all).toHaveLength(1);
+    expect(all[0].obsidianBlockId).toBe('abc12345');
+    expect(all[0].id).toBe('obsidian-dg-abc12345');
+  });
+
+  it('a renamed daily note whose old date was already consumed (no stored text) re-homes the identity too', () => {
+    const out = applyBridgeObservations([obs('2026-08-30', COPY_TEXT)], opts({ knownDailyNotes: {} }));
+    expect([...out.scheduledTasks, ...out.inboxTasks][0].obsidianBlockId).toBe('abc12345');
+  });
+
+  it('a token owned by a SCOPED note outside the batch is not asserted from memory (no stored text to check)', () => {
+    const scopedOwner = [{ ...owner()[0], obsidianFileDate: undefined, obsidianNotePath: 'Projects/House.md' }];
+    const out = applyBridgeObservations([obs('2026-08-30', COPY_TEXT)], opts({ existingInbox: scopedOwner, knownDailyNotes: {} }));
+    expect([...out.scheduledTasks, ...out.inboxTasks][0].obsidianBlockId).toBe('abc12345');
+  });
+});
+
 describe('applyBridgeObservations — vault task scope (companion §6)', () => {
   const HOUSE = [
     '# House',


### PR DESCRIPTION
## Summary

The last of the 2026-08-31 audit lows, the legacy-hint remainder: duplicate-token dedupe was per batch in plugin mode versus vault-wide in scans, so a copy-pasted line's resolution flip-flopped between observations.

A `^dg-` token names one line. When a line is copy-pasted with its token, the parser lets the first occurrence keep it and the copy falls through as untagged. A scan reads every note in one pass, so "first" is stable. The observation stream reads notes one batch at a time and its `seenBlockIds` set was fresh per batch, so whichever note happened to be in the batch won, and the two lines traded identity on every observation.

## The rule

The existing owner keeps its token.

- Within a batch, the owner's note is parsed first, so batch order no longer decides.
- When the owner's note is not in the batch, the token is pre-seeded as taken, but only when the app's last observed text of that note demonstrably still carries it. A line cut from one note and pasted into another, or a note renamed with the old path's deletion arriving a batch earlier, still re-homes the identity: the stored text no longer has the token, or the note is gone.
- Only daily notes back the pre-seed. Their text is stored; a scoped note's is not, and asserting a scoped owner from memory would break the rename split that harness scenario 2 pins. Recorded in the code comment.

The hook hands the applier the app's daily-note state for that check. App.jsx and the harness pass it; the applier falls back to the app's own store when absent.

## Tests

- `src/utils/obsidianBridgeInbound.test.js`: five dedupe cases. A copy alone in a later batch falls through untagged; the copy first within a batch still loses to the owner; a cut line re-homes; a consumed old date re-homes; a scoped owner outside the batch is not asserted.
- Harness scenario 16: a stamped line copied into a second daily note through the real plugin. The identity stays on the original, the copy is its own task, and re-observing the owner changes nothing.
- Suites: applier 19/19, harness 51/51 with plugin typecheck clean, hook and Obsidian suites 312/312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_