### PR TITLE
Duration formatter: join hours and minutes with a space in every locale

### DIFF
--- a/src/utils/localeFormatting.js
+++ b/src/utils/localeFormatting.js
@@ -25,7 +25,15 @@ export const formatLocalizedDurationMinutes = (minutes, language = activeLocale(
   const parts = [];
   if (hours) parts.push(formatUnit(hours, 'hour'));
   if (remainingMinutes || !hours) parts.push(formatUnit(remainingMinutes, 'minute'));
-  return new Intl.ListFormat(language, { style: 'narrow', type: 'unit' }).format(parts);
+  // Compact "1h 30m" shape in every locale. The narrow unit list gives each
+  // locale its own separator: a space in most, nothing in Chinese, but a
+  // comma in German and the word "e" in European Portuguese, which read as
+  // a list rather than one duration. Keep whitespace-only separators and
+  // reduce anything carrying punctuation or a word to a single space.
+  return new Intl.ListFormat(language, { style: 'narrow', type: 'unit' })
+    .formatToParts(parts)
+    .map((part) => (part.type === 'literal' && part.value.trim() ? ' ' : part.value))
+    .join('');
 };
 
 export const localizedWeekdays = (width = 'short', language = activeLocale()) => {

--- a/src/utils/localeFormatting.test.js
+++ b/src/utils/localeFormatting.test.js
@@ -35,4 +35,12 @@ describe('Simplified Chinese locale formatting', () => {
     expect(formatLocalizedDurationMinutes(135, 'zh-CN')).toBe('2小时15分钟');
     expect(formatLocalizedDurationMinutes(135, 'en')).toBe('2h 15m');
   });
+
+  it('joins hours and minutes with a space where the locale would list them with a comma or a word', () => {
+    expect(formatLocalizedDurationMinutes(90, 'de')).toBe('1h 30 Min.');      // not "1h, 30 Min."
+    expect(formatLocalizedDurationMinutes(90, 'pt-PT')).toBe('1 h 30 min');   // not "1 h e 30 min"
+    expect(formatLocalizedDurationMinutes(90, 'fr')).toBe('1h 30min');
+    expect(formatLocalizedDurationMinutes(90, 'zh-CN')).toBe('1小时30分钟');   // no separator at all stays that way
+    expect(formatLocalizedDurationMinutes(45, 'de')).toBe('45 Min.');
+  });
 });


### PR DESCRIPTION
## Summary

`formatLocalizedDurationMinutes` (from #1555) builds the compact duration from a narrow unit list, and two locales put something other than whitespace between the units:

| Locale | Before | After |
| --- | --- | --- |
| de | `1h, 30 Min.` | `1h 30 Min.` |
| pt-PT | `1 h e 30 min` | `1 h 30 min` |

A comma or the word "e" makes it read as a list of two things rather than one duration. Every other locale already produced the "1h 30m" shape (a space in en, fr, es, it, pt-BR; nothing in zh-CN), and none of those change.

## Change

`src/utils/localeFormatting.js`: format the list to parts, keep whitespace-only separators as they are, and reduce any separator carrying punctuation or a word to a single space. The units themselves are untouched, so each locale keeps its own abbreviations.

Call sites on main: `App.jsx`, `DayDial.jsx`, `NotesSubtasksPanel.jsx`. #1566 adds the GLANCE surfaces; its tests assert en and zh-CN output, which this does not change, so the two merge independently.

## Tests

`src/utils/localeFormatting.test.js`: de and pt-PT joined with a space, fr unchanged, zh-CN still without a separator, a minutes-only de value. Formatting suite 10/10, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_