### PR TITLE
Daily-note modal: never persist an untouched seed; fall back to the app's copy before the template

### DIFF
--- a/src/components/DailyNotesModal.jsx
+++ b/src/components/DailyNotesModal.jsx
@@ -5,6 +5,7 @@ import { renderFormattedText } from '../utils/textFormatting.jsx';
 import { useTranslation } from 'react-i18next';
 import { formatLocalizedDate } from '../utils/localeFormatting.js';
 import { localizeEmptyDailyNote } from '../utils/dailyNoteTemplate.js';
+import { seedDailyNoteText, shouldPersistDailyNote } from '../utils/dailyNoteModalSeed.js';
 
 // Daily Notes Modal — popover for adding/editing notes on a specific date
 const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, template, loadFresh }) => {
@@ -14,6 +15,11 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
   const seededTemplate = template ? renderNoteTemplateSubset(template, { title: dateStr, date: dateStr }) : template;
   const defaultText = localizeEmptyDailyNote(note?.text || '', seededTemplate);
   const [localText, setLocalText] = useState(defaultText);
+  // What the modal last loaded or saved, and whether the date had real
+  // content on open: a close writes back only a change to that baseline
+  // (utils/dailyNoteModalSeed.js). An untouched seed is never persisted.
+  const baselineRef = useRef(defaultText);
+  const hadContentRef = useRef(!!(note?.text && note.text.trim()));
   const [isEditing, setIsEditing] = useState(!note?.text);
   const [loading, setLoading] = useState(!!loadFresh);
 
@@ -49,16 +55,15 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
       try {
         const fresh = await loadFresh(dateStr);
         if (cancelled) return;
-        if (fresh && fresh.text) {
-          setLocalText(localizeEmptyDailyNote(fresh.text, seededTemplate));
-          setIsEditing(false);
-        } else {
-          // No existing note — apply template if available
-          if (seededTemplate) {
-            setLocalText(seededTemplate);
-          }
-          setIsEditing(true);
-        }
+        // Vault text first; an empty or absent read falls back to the app's
+        // own copy of the date; the template seeds only when neither holds
+        // content (utils/dailyNoteModalSeed.js).
+        const seed = seedDailyNoteText({ fresh: fresh?.text ?? null, known: note?.text ?? null, template: seededTemplate });
+        const text = seed.fromTemplate ? seed.text : localizeEmptyDailyNote(seed.text, seededTemplate);
+        baselineRef.current = text;
+        hadContentRef.current = seed.hadContent;
+        setLocalText(text);
+        setIsEditing(!seed.hadContent);
       } catch (err) {
         console.error('Failed to load fresh note from vault:', err);
       } finally {
@@ -77,6 +82,7 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
   useEffect(() => {
     if (loadFresh) return; // Obsidian path handles this above
     if (!defaultText && seededTemplate) {
+      baselineRef.current = seededTemplate;
       setLocalText(seededTemplate);
     }
     // Mount-once: seed the template only on open, not on later prop changes.
@@ -90,6 +96,13 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
   useEffect(() => { localTextRef.current = localText; }, [localText]);
   useEffect(() => { onSaveRef.current = onSave; }, [onSave]);
   useEffect(() => { dateStrRef.current = dateStr; }, [dateStr]);
+  // Every save path funnels through here: nothing is written unless the
+  // text differs from the baseline, and a write moves the baseline.
+  const persist = (text) => {
+    if (!shouldPersistDailyNote(text, baselineRef.current, hadContentRef.current)) return;
+    baselineRef.current = text;
+    onSaveRef.current(dateStrRef.current, text);
+  };
 
   // Focus backdrop when in preview mode (for Escape key) — on mount and after Shift+Enter
   useEffect(() => {
@@ -102,7 +115,7 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
   useEffect(() => {
     return () => {
       if (freshLoadedRef.current && !savedOnCloseRef.current) {
-        onSaveRef.current(dateStrRef.current, localTextRef.current);
+        persist(localTextRef.current);
       }
     };
   }, []);
@@ -110,7 +123,7 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
   const handleKeyDown = (e) => {
     if (e.key === 'Enter' && e.shiftKey) {
       e.preventDefault();
-      onSave(dateStr, localText);
+      persist(localText);
       if (localText.trim()) {
         setIsEditing(false);
       } else {
@@ -122,7 +135,7 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
       e.stopPropagation();
       if (!loading) {
         savedOnCloseRef.current = true;
-        onSave(dateStr, localText);
+        persist(localText);
       }
       onClose();
     }
@@ -131,7 +144,7 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
   const handleBlur = () => {
     // Skip if we're already in the close flow — handleSaveAndClose handles the save.
     if (loading || savedOnCloseRef.current) return;
-    onSave(dateStr, localText);
+    persist(localText);
   };
 
   // Skip save if loadFresh hasn't resolved yet to prevent wiping vault content.
@@ -145,7 +158,7 @@ const DailyNotesModal = ({ dateStr, note, onSave, onClose, darkMode, isMobile, t
       document.activeElement.blur();
     }
     if (!loading) {
-      onSave(dateStr, localText);
+      persist(localText);
     }
     onClose();
   };

--- a/src/utils/dailyNoteModalSeed.js
+++ b/src/utils/dailyNoteModalSeed.js
@@ -1,0 +1,44 @@
+// What the daily-note modal shows on open, and whether closing it should
+// write anything back. Pure so the rules are tested where they live.
+//
+// Field incident, 2026-09-08 (buildout spec 2.7): a tablet with no vault
+// and no copy of today's note yet opened the modal, was seeded with the
+// template, and saved that template on close as the note's record, stamped
+// with the moment of closing. That stamp outranked the real note on every
+// other device, and the app's own copy of a note it never held became the
+// fleet's newest word on it. Two rules follow.
+//
+// 1. Seeding order: the vault's text, then the app's own copy, then the
+//    template. An empty or absent vault read is not evidence of absence
+//    when the app holds content for the date (the completion log has
+//    followed this since the 2026-09-07 empty-note incident; the modal did
+//    not).
+// 2. Closing persists only a change. An untouched seed, template or
+//    otherwise, is not the user's word and is never written back; neither is
+//    an empty note for a date that had no content to begin with.
+
+const hasText = (v) => typeof v === 'string' && v.trim().length > 0;
+
+/**
+ * @param {{ fresh?: string|null, known?: string|null, template?: string|null }} src
+ *   fresh: the vault read ('' or null when absent or unreadable);
+ *   known: the app's own copy for the date; template: the rendered template.
+ * @returns {{ text: string, fromTemplate: boolean, hadContent: boolean }}
+ */
+export function seedDailyNoteText({ fresh = null, known = null, template = null } = {}) {
+  if (hasText(fresh)) return { text: fresh, fromTemplate: false, hadContent: true };
+  if (hasText(known)) return { text: known, fromTemplate: false, hadContent: true };
+  return { text: template || '', fromTemplate: !!template, hadContent: false };
+}
+
+/**
+ * Whether a save path (blur, shortcut, close, unmount) should write `text`.
+ * `baseline` is what the modal last loaded or saved; `hadContent` is whether
+ * the date had real content when the modal opened.
+ */
+export function shouldPersistDailyNote(text, baseline, hadContent) {
+  const next = typeof text === 'string' ? text : '';
+  if (next === (typeof baseline === 'string' ? baseline : '')) return false;
+  if (!hasText(next) && !hadContent) return false;
+  return true;
+}

--- a/src/utils/dailyNoteModalSeed.test.js
+++ b/src/utils/dailyNoteModalSeed.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { seedDailyNoteText, shouldPersistDailyNote } from './dailyNoteModalSeed.js';
+
+const TEMPLATE = '[[<% tp.date.now("YYYY-MM-DD", -1) %>|← Yesterday]]\n\n## Tasks\n';
+const REAL = '[[2026-09-07|← Yesterday]]\n## Tasks\n## Completed\n- ✅ 12:30 Topoff 20Gs\n';
+
+describe('seedDailyNoteText', () => {
+  it('shows the vault text when the read has content', () => {
+    expect(seedDailyNoteText({ fresh: REAL, known: 'older copy', template: TEMPLATE }))
+      .toEqual({ text: REAL, fromTemplate: false, hadContent: true });
+  });
+
+  it('falls back to the app copy when the vault read is empty or absent (the 2026-09-07 rule)', () => {
+    expect(seedDailyNoteText({ fresh: '', known: REAL, template: TEMPLATE }).text).toBe(REAL);
+    expect(seedDailyNoteText({ fresh: null, known: REAL, template: TEMPLATE }).text).toBe(REAL);
+    expect(seedDailyNoteText({ known: REAL, template: TEMPLATE }).hadContent).toBe(true);
+  });
+
+  it('seeds the template only when neither the vault nor the app holds content', () => {
+    expect(seedDailyNoteText({ fresh: '', known: '   ', template: TEMPLATE }))
+      .toEqual({ text: TEMPLATE, fromTemplate: true, hadContent: false });
+    expect(seedDailyNoteText({ template: null })).toEqual({ text: '', fromTemplate: false, hadContent: false });
+  });
+});
+
+describe('shouldPersistDailyNote', () => {
+  it('THE 2026-09-08 INCIDENT: an untouched template seed is never written back', () => {
+    const seed = seedDailyNoteText({ fresh: '', known: null, template: TEMPLATE });
+    expect(shouldPersistDailyNote(seed.text, seed.text, seed.hadContent)).toBe(false);
+  });
+
+  it('an untouched real note is not re-stamped on close', () => {
+    const seed = seedDailyNoteText({ fresh: REAL, template: TEMPLATE });
+    expect(shouldPersistDailyNote(REAL, seed.text, seed.hadContent)).toBe(false);
+  });
+
+  it('a typed change is written, template seed or not', () => {
+    expect(shouldPersistDailyNote(`${TEMPLATE}- [ ] Water the plants\n`, TEMPLATE, false)).toBe(true);
+    expect(shouldPersistDailyNote(`${REAL}- [ ] Water the plants\n`, REAL, true)).toBe(true);
+  });
+
+  it('clearing a note that had content is written (it becomes a deletion tombstone)', () => {
+    expect(shouldPersistDailyNote('', REAL, true)).toBe(true);
+  });
+
+  it('an empty note for a date that never had content is not written', () => {
+    expect(shouldPersistDailyNote('', TEMPLATE, false)).toBe(false);
+    expect(shouldPersistDailyNote('  \n', '', false)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

First of two fixes for the 2026-09-08 daily-note ping-pong (the second, the observation stamp rule, is a separate PR).

**What happened.** A tablet that had not synced since the day before, with no vault and no copy of today's note yet, opened the daily-note modal. The modal found nothing, seeded the template, and on close saved that raw template as the note's record, stamped with the moment of closing. That stamp was newer than the real note's mtime, so the template copy outranked the real note in the vault database and in the iCloud file.

**The rules**, in a new pure module `src/utils/dailyNoteModalSeed.js`, wired through every save path of `DailyNotesModal` (blur, Shift+Enter, Escape, the close button, unmount):

1. **Seeding order:** the vault read, then the app's own copy of the date, then the template. An empty or absent vault read is not evidence of absence when the app holds content. The completion log has followed this since the 2026-09-07 empty-note incident; the modal did not.
2. **Closing persists only a change.** The modal tracks what it loaded or last saved, and a save path writes only when the text differs from that. An untouched seed, template or not, is never written back; an untouched real note is not re-stamped on close; an empty note for a date that never had content is not written. Clearing a note that had content still writes, so it still becomes a deletion tombstone.

Both modal paths are covered: the vault-read path (desktop, Android and any native device with a vault configured) and the no-vault path.

## Tests

`src/utils/dailyNoteModalSeed.test.js`: seeding from vault text, from the app copy on an empty or absent read, from the template only when neither holds content; the incident case (untouched template seed not written); untouched real note not re-stamped; typed change written; cleared note written; empty never-existing note not written. 8/8, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_