### PR TITLE
Daily-note merge: keep the displaced record's stamp exactly, not 1 ms newer

### DIFF
--- a/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
+++ b/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
@@ -598,7 +598,7 @@ describe('vault task scope, end to end', () => {
     expect(unavailable()).toBe(before + 1);   // a single failure after a success is quiet again
   });
 
-  it('19. THE 2026-09-08 PING-PONG: the observed note replacing a newer-stamped app record outranks it, so a stale copy cannot win the date back', async () => {
+  it('19. THE 2026-09-08 PING-PONG: the observed note replacing a newer-stamped app record keeps that stamp, so the stale copy cannot win the date back here', async () => {
     await bootWithScopedNote();
     const DAILY = 'Daily/2026-09-08.md';
     await s.write(DAILY, '## Tasks\n- [ ] Water the plants\n');
@@ -618,7 +618,7 @@ describe('vault task scope, end to end', () => {
     const rec = A.state.dailyNotes['2026-09-08']!;
     expect(rec.text).toContain('Buy soil');                       // the vault's text won
     expect(rec.text).not.toContain('tp.date.now');
-    expect(Date.parse(rec.lastModified!)).toBe(Date.parse(stale) + 1);   // and outranks the stale copy, strictly
+    expect(rec.lastModified).toBe(stale);                          // and ties the stale copy: every tier keeps local on a tie
     // Steady state: the unchanged file carries that stamp forward, no re-stamp.
     await s.settle();
     await A.sync();

--- a/docs/obsidian-buildout-spec.md
+++ b/docs/obsidian-buildout-spec.md
@@ -253,12 +253,26 @@ than the record it replaced.
    the modal), and every save path writes back only a change to what was
    loaded or last saved. An untouched seed is never persisted.
 2. Ruling, `utils/mergeObsidianDailyNotes.js`: an observed note whose text
-   replaces a record stamped at or after the file's mtime is stamped 1 ms
-   after that record. The vault's content must outrank the record it
-   replaces; a tie would leave the stale copy standing wherever it sits,
-   since the file-tier merge keeps local on a tie. The note's real mtime is
-   unaffected: it travels separately as evidence (noteMtimes) for the
-   tombstone and revival rules, which read the mtime, not the record.
+   replaces a record stamped after the file's mtime keeps that record's
+   stamp, not the mtime. Every tier keeps local on a tie (the DB pull and
+   the file-tier merge both apply a remote copy only when strictly newer),
+   so the equal stamp ends the loop on the observing device: nothing
+   re-applies the stale copy over it. A device still holding the stale copy
+   keeps it until the note next changes in the vault; that divergence is
+   accepted. The alternative, stamping the observed text strictly newer, was
+   built first and withdrawn the same afternoon: the console showed an
+   observation delivered late (the 9/06 note's stamp went back to a value
+   it had held four minutes earlier, through the observation path, since the
+   DB pull cannot apply an older row), and a strictly newer stamp would have
+   pushed that late observation's text to every device as the newest word.
+   The note's real mtime is unaffected: it travels separately as evidence
+   (noteMtimes) for the tombstone and revival rules, which read the mtime,
+   not the record.
+
+**Open, not built.** The late observation itself. An observation whose
+mtime is older than the note's last observed mtime is stale evidence, and
+today the merge still applies its text locally. Skipping it is a what-wins
+change between two observations of the same note and waits for a ruling.
 
 **Manual end to a running loop.** A small edit to the note on the desktop,
 saved from the app, stamps the real text newer than the stale copy and

--- a/src/utils/mergeObsidianDailyNotes.js
+++ b/src/utils/mergeObsidianDailyNotes.js
@@ -15,17 +15,18 @@ import { isObsidianTombstoned } from './obsidianDeletions.js';
 //   - a date in the scan  → take the scanned note (fresher text), carrying the
 //     prior `lastModified` forward when the text is unchanged so an unedited note
 //     doesn't re-push every scan (the native bridge restamps it each scan);
-//   - a scanned note whose text REPLACES a record stamped at or after the
-//     file's mtime is stamped 1 ms after that record, not with the mtime.
-//     The vault's content must outrank the record it replaces: stamped with
-//     an older mtime, the record lost every LWW merge to the stale copy it
-//     had just displaced (DB tier, iCloud file, other devices), which
-//     re-applied the stale copy, the scan replaced it again, and so on every
-//     cycle (field incident, 2026-09-08, buildout spec 2.7). A tie would
-//     leave the stale copy standing wherever it already sits (the file-tier
-//     merge keeps local on a tie), hence strictly newer. The note's REAL
-//     mtime still travels separately as evidence (noteMtimes) and is not
-//     touched by this;
+//   - a scanned note whose text REPLACES a record stamped after the file's
+//     mtime keeps that record's stamp, not the mtime. Stamped with the older
+//     mtime, the record lost every LWW merge to the stale copy it had just
+//     displaced (DB tier, iCloud file), which re-applied the stale copy, the
+//     scan replaced it again, and so on every cycle (field incident,
+//     2026-09-08, buildout spec 2.7). Every tier keeps local on a tie, so the
+//     equal stamp ends the loop on this device without ever outranking a
+//     genuinely newer record elsewhere: an observation delivered late (seen
+//     in the field the same day) must not be re-stamped newest and pushed
+//     fleet-wide. A device still holding the stale copy keeps it until the
+//     note next changes. The note's REAL mtime still travels separately as
+//     evidence (noteMtimes) and is not touched by this;
 //   - a date only in `prev` → KEEP it (belongs to another device's vault);
 //   - EXCEPT: a date whose deletion tombstone is at least as new as the note is
 //     dropped — a genuine vault deletion propagates. A note re-created in Obsidian
@@ -49,8 +50,8 @@ export function mergeObsidianDailyNotes(prev, scanned, tombstones = {}) {
     if (old && old.text === note.text && old.lastModified) {
       merged = { ...note, lastModified: old.lastModified };
     } else if (old && old.lastModified && note.lastModified
-        && Date.parse(old.lastModified) >= Date.parse(note.lastModified)) {
-      merged = { ...note, lastModified: new Date(Date.parse(old.lastModified) + 1).toISOString() };
+        && Date.parse(old.lastModified) > Date.parse(note.lastModified)) {
+      merged = { ...note, lastModified: old.lastModified };
     }
     if (isObsidianTombstoned(tombstones, date, merged.lastModified)) { delete out[date]; continue; }
     out[date] = merged;

--- a/src/utils/mergeObsidianDailyNotes.test.js
+++ b/src/utils/mergeObsidianDailyNotes.test.js
@@ -29,24 +29,28 @@ describe('mergeObsidianDailyNotes', () => {
     expect(out.lastModified).toBe('2026-07-07T00:00:00.000Z');
   });
 
-  it('THE 2026-09-08 PING-PONG: scanned text replacing a record stamped after the file mtime is stamped 1 ms after that record', () => {
+  it('THE 2026-09-08 PING-PONG: scanned text replacing a record stamped after the file mtime keeps that stamp', () => {
     // A device with no copy of the date saved the raw template at 19:22:43.742;
     // the real note's mtime is 18:33:02.841. Stamping the vault's text with
-    // the mtime lost every LWW merge to the template copy, forever.
+    // the mtime lost every LWW merge to the template copy, forever. Every
+    // tier keeps local on a tie, so the equal stamp ends the loop here and
+    // never outranks a genuinely newer record elsewhere.
     const prev = { '2026-09-08': note('<% template %>', '2026-09-08T19:22:43.742Z') };
     const scanned = { '2026-09-08': note('real note', '2026-09-08T18:33:02.841Z') };
     const out = mergeObsidianDailyNotes(prev, scanned)['2026-09-08'];
     expect(out.text).toBe('real note');
-    expect(out.lastModified).toBe('2026-09-08T19:22:43.743Z');
+    expect(out.lastModified).toBe('2026-09-08T19:22:43.742Z');
     // Idempotent: the next scan of the unchanged file carries that stamp forward.
     const again = mergeObsidianDailyNotes({ '2026-09-08': out }, scanned)['2026-09-08'];
     expect(again).toEqual(out);
   });
 
-  it('a record stamped exactly at the file mtime is also outranked (a tie leaves the stale copy standing)', () => {
-    const prev = { '2026-09-08': note('stale', '2026-09-08T18:33:02.841Z') };
-    const scanned = { '2026-09-08': note('real note', '2026-09-08T18:33:02.841Z') };
-    expect(mergeObsidianDailyNotes(prev, scanned)['2026-09-08'].lastModified).toBe('2026-09-08T18:33:02.842Z');
+  it('never stamps the scanned text NEWER than the record it replaces (a late older observation must not win fleet-wide)', () => {
+    const prev = { '2026-09-06': note('three lines re-stamped', '2026-09-08T19:39:15.824Z') };
+    const late = { '2026-09-06': note('first of the three', '2026-09-08T19:39:12.241Z') };
+    const out = mergeObsidianDailyNotes(prev, late)['2026-09-06'];
+    expect(out.text).toBe('first of the three');                  // the observation still wins locally
+    expect(out.lastModified).toBe('2026-09-08T19:39:15.824Z');     // but ties, so every other tier keeps its own
   });
 
   it('a file newer than the record it replaces keeps its own mtime (the ordinary edit)', () => {


### PR DESCRIPTION
## Summary

Follow-up to #1574, which merged with the first version of the stamp rule: an observed note whose text replaces a newer-stamped record was stamped 1 ms after that record so it would outrank the stale copy everywhere. This PR changes it to keep the displaced record's stamp exactly. Same four files, same scenario, one rule.

**Why.** The field console from the same afternoon showed an observation delivered late: the 9/06 note's stamp went back to a value it had held four minutes earlier, with a mid-cycle merge. The DB pull and the file-tier merge both apply a remote copy only when strictly newer, so that regression could only have come through the observation path. Under the 1 ms rule, that late observation's text would have been re-stamped newest and pushed to every device as the newest word. Under the equal stamp it cannot: every tier keeps local on a tie, so the loop from the incident still ends on the observing device (nothing re-applies the stale copy over it), and a late observation never outranks a genuinely newer record elsewhere. A device still holding a stale copy keeps it until the note next changes in the vault; that divergence is accepted and recorded.

**Left open, not built.** The late observation itself. Skipping an observation older than the note's last observed mtime is a what-wins choice between two observations of the same note and waits for a ruling. Spec 2.7 says so.

## Tests

- `src/utils/mergeObsidianDailyNotes.test.js`: the incident case now expects the displaced record's exact stamp; a new case pins that a late older observation still wins locally but never stamps newer than the record it replaces. 12/12.
- Harness scenario 19: the vault's text wins with the stale record's exact stamp, and a further cycle re-stamps nothing. 27/27.
- Lint clean.

`docs/obsidian-buildout-spec.md` 2.7: the ruling reworded, the withdrawn variant and why, and the open question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_