### PR TITLE
TRMNL: push on content change, persist the backoff, honor Retry-After

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -648,6 +648,7 @@
     "trmnlDescriptionPrefix": "Übertragen Sie Ihren Tagesplan auf ein",
     "trmnlDescriptionSuffix": "E-Ink-Display per Webhook. Installieren Sie zum Einstieg das DayGLANCE-Rezept aus der TRMNL Recipe Library.",
     "trmnlWebhookHint": "Zu finden in den Einstellungen Ihres DayGLANCE-Rezepts auf TRMNL",
+    "trmnlOneDeviceHint": "TRMNL nimmt pro Stunde nur eine begrenzte Zahl von Aktualisierungen für das gesamte Plugin an. Aktiviere dies daher auf einem Gerät, das normalerweise läuft.",
     "usersSyncPathHint": "WebDAV-Pfad, unter dem die gemeinsame Benutzerliste gespeichert wird. Muss in allen GLANCE-Apps übereinstimmen.",
     "weatherLocationPlaceholder": "z. B. 10115 oder Berlin"
   },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -648,6 +648,7 @@
     "trmnlDescriptionPrefix": "Push your daily schedule to a",
     "trmnlDescriptionSuffix": "e-ink display via webhook. Install the DayGLANCE recipe from the TRMNL Recipe Library to get started.",
     "trmnlWebhookHint": "Found in your DayGLANCE recipe settings on TRMNL",
+    "trmnlOneDeviceHint": "TRMNL accepts a limited number of updates per hour for the whole plugin, so enable this on one device that is usually running.",
     "usersSyncPathHint": "WebDAV path where the shared user list is stored. Must match across all GLANCE apps.",
     "weatherLocationPlaceholder": "e.g. 90210 or Seattle"
   },

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -648,6 +648,7 @@
     "trmnlDescriptionPrefix": "Envía tu agenda diaria a una pantalla",
     "trmnlDescriptionSuffix": "de tinta electrónica mediante webhook. Instala la receta DayGLANCE desde TRMNL Recipe Library para empezar.",
     "trmnlWebhookHint": "Se encuentra en los ajustes de tu receta DayGLANCE en TRMNL",
+    "trmnlOneDeviceHint": "TRMNL acepta un número limitado de actualizaciones por hora para todo el plugin, así que activa esto en un solo dispositivo que suela estar en marcha.",
     "usersSyncPathHint": "Ruta WebDAV donde se guarda la lista compartida de usuarios. Debe coincidir en todas las aplicaciones GLANCE.",
     "weatherLocationPlaceholder": "p. ej., 28001 o Madrid"
   },

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -648,6 +648,7 @@
     "trmnlDescriptionPrefix": "Envoyez votre programme quotidien vers un écran",
     "trmnlDescriptionSuffix": "à encre électronique via webhook. Installez la recette DayGLANCE depuis la TRMNL Recipe Library pour commencer.",
     "trmnlWebhookHint": "Disponible dans les réglages de votre recette DayGLANCE sur TRMNL",
+    "trmnlOneDeviceHint": "TRMNL n'accepte qu'un nombre limité de mises à jour par heure pour l'ensemble du plugin. Activez donc ceci sur un seul appareil qui fonctionne habituellement.",
     "usersSyncPathHint": "Chemin WebDAV où la liste partagée des utilisateurs est stockée. Il doit être identique dans toutes les applications GLANCE.",
     "weatherLocationPlaceholder": "par ex. 75001 ou Paris"
   },

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -648,6 +648,7 @@
     "trmnlDescriptionPrefix": "Invia il tuo programma giornaliero a un display",
     "trmnlDescriptionSuffix": "e-ink tramite webhook. Installa la ricetta DayGLANCE dalla TRMNL Recipe Library per iniziare.",
     "trmnlWebhookHint": "Disponibile nelle impostazioni della ricetta DayGLANCE su TRMNL",
+    "trmnlOneDeviceHint": "TRMNL accetta un numero limitato di aggiornamenti all'ora per l'intero plugin, quindi attiva questa opzione su un solo dispositivo che di solito è acceso.",
     "usersSyncPathHint": "Percorso WebDAV in cui viene archiviato l'elenco condiviso degli utenti. Deve coincidere in tutte le app GLANCE.",
     "weatherLocationPlaceholder": "ad es. 00100 o Roma"
   },

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -648,6 +648,7 @@
     "trmnlDescriptionPrefix": "Envie sua agenda diária para uma tela",
     "trmnlDescriptionSuffix": "de tinta eletrônica por webhook. Instale a receita DayGLANCE da TRMNL Recipe Library para começar.",
     "trmnlWebhookHint": "Disponível nas configurações da sua receita DayGLANCE no TRMNL",
+    "trmnlOneDeviceHint": "O TRMNL aceita um número limitado de atualizações por hora para todo o plugin, então ative isto em um único dispositivo que costuma ficar ligado.",
     "usersSyncPathHint": "Caminho WebDAV onde a lista compartilhada de usuários é armazenada. Deve ser igual em todos os aplicativos GLANCE.",
     "weatherLocationPlaceholder": "ex.: 01310-100 ou São Paulo"
   },

--- a/public/locales/pt-PT/translation.json
+++ b/public/locales/pt-PT/translation.json
@@ -648,6 +648,7 @@
     "trmnlDescriptionPrefix": "Envie a sua agenda diária para um ecrã",
     "trmnlDescriptionSuffix": "de tinta eletrónica através de webhook. Instale a receita DayGLANCE da TRMNL Recipe Library para começar.",
     "trmnlWebhookHint": "Disponível nas definições da sua receita DayGLANCE no TRMNL",
+    "trmnlOneDeviceHint": "O TRMNL aceita um número limitado de atualizações por hora para todo o plugin, por isso ative isto num único dispositivo que costuma estar ligado.",
     "usersSyncPathHint": "Caminho WebDAV onde a lista partilhada de utilizadores é guardada. Tem de ser igual em todas as aplicações GLANCE.",
     "weatherLocationPlaceholder": "por ex., 1000-001 ou Lisboa"
   },

--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -648,6 +648,7 @@
     "trmnlDescriptionPrefix": "将每日计划推送到",
     "trmnlDescriptionSuffix": "电子墨水屏。通过 webhook 发送数据；请从 TRMNL Recipe Library 安装 DayGLANCE 配方以开始使用。",
     "trmnlWebhookHint": "可在 TRMNL 的 DayGLANCE 配方设置中找到",
+    "trmnlOneDeviceHint": "TRMNL 对整个插件每小时接受的更新次数有限，因此请只在一台通常保持运行的设备上启用此功能。",
     "usersSyncPathHint": "共享用户列表在 WebDAV 上的存储路径。所有 GLANCE 应用必须使用相同路径。",
     "weatherLocationPlaceholder": "例如 100000 或北京"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import { isStreamPosture } from './utils/obsidianVaultPosture.js';
 import { loadAIConfig, saveAIConfig, aiComplete, aiJSON, testConnection, DEFAULT_CONFIG, PROVIDER_MODELS, PROVIDER_LABELS } from './ai.js';
 import { taskSuggestSystemPrompt, taskSuggestUserPrompt, frameNudgeSystemPrompt, frameNudgeUserPrompt, rescheduleSystemPrompt, rescheduleUserPrompt, aiSubtasksSystemPrompt, aiSubtasksUserPrompt, weeklySummarySystemPrompt, weeklySummaryUserPrompt, smartScheduleSystemPrompt, smartScheduleUserPrompt } from './ai-prompts.js';
 import { gatherTrmnlData, pushToTrmnl, TRMNL_MARKUP_FULL, TRMNL_MARKUP_HALF_HORIZONTAL, TRMNL_MARKUP_HALF_VERTICAL, TRMNL_MARKUP_QUADRANT } from './trmnl.js';
+import { trmnlContentFingerprint, trmnlPushDecision, trmnlBackoffAfterRateLimit, writeTrmnlPushState } from './utils/trmnlPushPolicy.js';
 import { checkForUpdate } from './versionCheck.js';
 import { getStorageUsage, formatBytes } from './utils/storage.js';
 import { tombstoneCutoff, pruneCompletedTaskUids } from './sync/tombstoneRetention.js';
@@ -1110,6 +1111,7 @@ const DayPlanner = () => {
     trmnlLastPushRef,
     trmnlBackoffUntilRef,
     trmnlBackoffCountRef,
+    trmnlLastFingerprintRef,
     trmnlSyncInProgressRef,
     performTrmnlSyncRef,
   } = useTrmnlSync();
@@ -2759,36 +2761,32 @@ const DayPlanner = () => {
     return () => clearInterval(pollTimer);
   }, [cloudSyncConfig?.enabled, cloudSyncDownloadRef]);
 
-  // TRMNL auto-sync: push data when tasks/habits change
-  // Debounce 10s to batch rapid edits, then throttle to at most once per 2 min.
-  // On 429 backoff the cooldown extends to 5 min.
-  const TRMNL_THROTTLE_MS = 2 * 60 * 1000; // 2 minutes between pushes
+  // TRMNL auto-sync (utils/trmnlPushPolicy.js). A data change is debounced
+  // 10 s and then offered to the policy, which pushes only when the CONTENT
+  // changed (clock fields excluded) and the floor has passed; a minute tick
+  // offers again, carrying the time-only refresh and any push the floor or a
+  // 429 backoff deferred. These arrays get a new identity on nearly every
+  // sync cycle, so the old identity-keyed throttle pushed around the clock
+  // whether or not the screen had changed (field incident, 2026-09-08).
   useEffect(() => {
     performTrmnlSyncRef.current = performTrmnlSync;
   });
+  const trmnlAutoEnabled = !isTrayMode && !!trmnlConfig?.enabled && !!trmnlConfig?.webhookUrl && dataLoaded;
   useEffect(() => {
-    if (isTrayMode || !trmnlConfig?.enabled || !trmnlConfig?.webhookUrl || !dataLoaded) return;
+    if (!trmnlAutoEnabled) return;
     if (trmnlSyncTimerRef.current) clearTimeout(trmnlSyncTimerRef.current);
     trmnlSyncTimerRef.current = setTimeout(() => {
-      const now = Date.now();
-      const earliest = Math.max(
-        trmnlLastPushRef.current + TRMNL_THROTTLE_MS,
-        trmnlBackoffUntilRef.current,
-      );
-      if (now >= earliest) {
-        if (performTrmnlSyncRef.current) performTrmnlSyncRef.current();
-      } else {
-        // Schedule for when the cooldown expires
-        trmnlSyncTimerRef.current = setTimeout(() => {
-          if (performTrmnlSyncRef.current) performTrmnlSyncRef.current();
-        }, earliest - now);
-      }
+      performTrmnlSyncRef.current?.({ auto: true });
     }, 10 * 1000); // 10-second debounce after last change
     return () => { if (trmnlSyncTimerRef.current) clearTimeout(trmnlSyncTimerRef.current); };
-    // Keyed on the data that feeds a TRMNL push. The throttle constant, the
-    // trmnl*Ref values, and trmnlConfig.webhookUrl are stable or read at sync time.
+    // Keyed on the data that feeds a TRMNL push; the policy decides at fire time.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tasks, unscheduledTasks, habits, habitLogs, todayRoutines, routinesEnabled, trmnlConfig?.enabled, dataLoaded]);
+  }, [tasks, unscheduledTasks, habits, habitLogs, todayRoutines, routinesEnabled, trmnlAutoEnabled]);
+  useEffect(() => {
+    if (!trmnlAutoEnabled) return;
+    const tick = setInterval(() => { performTrmnlSyncRef.current?.({ auto: true }); }, 60 * 1000);
+    return () => clearInterval(tick);
+  }, [trmnlAutoEnabled, performTrmnlSyncRef]);
 
   // Auto-archive completed inbox tasks older than the configured threshold
   useEffect(() => {
@@ -3337,11 +3335,18 @@ const DayPlanner = () => {
   };
 
   // TRMNL e-ink dashboard sync — push today's data to TRMNL webhook
-  const performTrmnlSync = async () => {
+  const persistTrmnlPushState = () => writeTrmnlPushState({
+    lastPushAt: trmnlLastPushRef.current,
+    backoffUntil: trmnlBackoffUntilRef.current,
+    backoffCount: trmnlBackoffCountRef.current,
+    lastFingerprint: trmnlLastFingerprintRef.current,
+  });
+  // { auto: true } from the auto-sync: the policy may decline (unchanged
+  // content, floor, backoff) and nothing is sent. A manual sync always sends.
+  const performTrmnlSync = async ({ auto = false } = {}) => {
     if (!trmnlConfig?.enabled || !trmnlConfig?.webhookUrl) return;
     if (trmnlSyncInProgressRef.current) return; // prevent concurrent pushes
     trmnlSyncInProgressRef.current = true;
-    setTrmnlSyncStatus('syncing');
     try {
       const today = selectedDate ? dateToString(selectedDate) : new Date().toISOString().slice(0, 10);
       // Multi-user: the TRMNL dashboard belongs to the current user, so scope
@@ -3360,10 +3365,19 @@ const DayPlanner = () => {
         todayRoutines,
         routinesEnabled,
       });
+      const fingerprint = trmnlContentFingerprint(mergeVars);
+      const decision = trmnlPushDecision({
+        now: Date.now(), fingerprint, lastFingerprint: trmnlLastFingerprintRef.current,
+        lastPushAt: trmnlLastPushRef.current, backoffUntil: trmnlBackoffUntilRef.current, manual: !auto,
+      });
+      if (!decision.push) return;
+      setTrmnlSyncStatus('syncing');
       const result = await pushToTrmnl(trmnlConfig, mergeVars);
       trmnlLastPushRef.current = Date.now();
       if (result.success) {
         trmnlBackoffCountRef.current = 0; // reset exponential backoff on success
+        trmnlBackoffUntilRef.current = 0;
+        trmnlLastFingerprintRef.current = fingerprint;
         setTrmnlSyncStatus('success');
         const ts = new Date().toISOString();
         setTrmnlLastSynced(ts);
@@ -3372,12 +3386,15 @@ const DayPlanner = () => {
         setTrmnlSyncStatus('error');
         console.warn('TRMNL sync failed:', result.error);
         if (result.rateLimited) {
-          trmnlBackoffCountRef.current += 1;
-          // Exponential backoff: 5 min, 10 min, 20 min, 40 min … capped at 60 min
-          const backoffMins = Math.min(5 * Math.pow(2, trmnlBackoffCountRef.current - 1), 60);
-          trmnlBackoffUntilRef.current = Date.now() + backoffMins * 60 * 1000;
+          const backoff = trmnlBackoffAfterRateLimit({
+            now: Date.now(), count: trmnlBackoffCountRef.current, retryAfterSeconds: result.retryAfterSeconds ?? null,
+          });
+          trmnlBackoffCountRef.current = backoff.count;
+          trmnlBackoffUntilRef.current = backoff.until;
+          console.info(`TRMNL: backing off until ${new Date(backoff.until).toLocaleTimeString()} (${backoff.count} in a row)`);
         }
       }
+      persistTrmnlPushState();
     } catch (err) {
       setTrmnlSyncStatus('error');
       console.error('TRMNL sync error:', err);

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1905,6 +1905,9 @@ const SettingsModal = () => {
                         <p className={`text-xs ${textSecondary} mt-1`}>
                           {t('settings.trmnlWebhookHint', { defaultValue: 'Found in your DayGLANCE recipe settings on TRMNL' })}
                         </p>
+                        <p className={`text-xs ${textSecondary} mt-1`}>
+                          {t('settings.trmnlOneDeviceHint', { defaultValue: 'TRMNL accepts a limited number of updates per hour for the whole plugin, so enable this on one device that is usually running.' })}
+                        </p>
                       </div>
                       <div>
                         <label className={`block text-sm ${textSecondary} mb-1`}>{t('settings.trmnlApiKey')}</label>

--- a/src/hooks/useTrmnlSync.js
+++ b/src/hooks/useTrmnlSync.js
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { readTrmnlPushState } from '../utils/trmnlPushPolicy.js';
 
 const useTrmnlSync = () => {
   const [trmnlConfig, setTrmnlConfig] = useState(() => {
@@ -11,13 +12,19 @@ const useTrmnlSync = () => {
   const [trmnlLastSynced, setTrmnlLastSynced] = useState(() =>
     localStorage.getItem('day-planner-trmnl-last-synced') || null
   );
-  // Seed from persisted last-synced so the 2-min throttle survives page reloads
+  // The push state (utils/trmnlPushPolicy.js) is persisted so a relaunch
+  // resumes the floor, the backoff and the last content pushed instead of
+  // starting again at full speed (field incident, 2026-09-08).
   const trmnlSyncTimerRef = useRef(null);
   const trmnlLastPushRef = useRef(
-    (() => { const s = localStorage.getItem('day-planner-trmnl-last-synced'); return s ? new Date(s).getTime() : 0; })()
+    (() => {
+      const s = localStorage.getItem('day-planner-trmnl-last-synced');
+      return Math.max(s ? new Date(s).getTime() : 0, readTrmnlPushState().lastPushAt || 0);
+    })()
   ); // timestamp of last push attempt
-  const trmnlBackoffUntilRef = useRef(0); // timestamp: skip auto-sync until this time (429 backoff)
-  const trmnlBackoffCountRef = useRef(0); // consecutive 429s — drives exponential backoff
+  const trmnlBackoffUntilRef = useRef(readTrmnlPushState().backoffUntil || 0); // timestamp: skip auto-sync until this time (429 backoff)
+  const trmnlBackoffCountRef = useRef(readTrmnlPushState().backoffCount || 0); // consecutive 429s — drives exponential backoff
+  const trmnlLastFingerprintRef = useRef(readTrmnlPushState().lastFingerprint ?? null); // content of the last push, clock fields excluded
   const trmnlSyncInProgressRef = useRef(false); // prevents concurrent pushes
   const performTrmnlSyncRef = useRef(null);
 
@@ -38,6 +45,7 @@ const useTrmnlSync = () => {
     trmnlLastPushRef,
     trmnlBackoffUntilRef,
     trmnlBackoffCountRef,
+    trmnlLastFingerprintRef,
     trmnlSyncInProgressRef,
     performTrmnlSyncRef,
   };

--- a/src/trmnl.js
+++ b/src/trmnl.js
@@ -15,6 +15,8 @@ import { notBucketed } from './utils/bucketList.js';
 // ---------------------------------------------------------------------------
 
 /** Format minutes as "Xh Ym" or "Ym" */
+import { parseRetryAfter } from './utils/trmnlPushPolicy.js';
+
 const fmtDuration = (mins) => {
   if (!mins || mins <= 0) return '0m';
   const h = Math.floor(mins / 60);
@@ -243,7 +245,11 @@ export async function pushToTrmnl({ webhookUrl, apiKey }, mergeVars) {
       body: JSON.stringify({ merge_variables: mergeVars }),
     });
 
-    if (res.status === 429) return { success: false, error: 'Rate limited — try again later', rateLimited: true };
+    if (res.status === 429) {
+      // TRMNL may say how long to wait; the caller's backoff never waits less.
+      const retryAfterSeconds = parseRetryAfter(res.headers?.get?.('Retry-After'));
+      return { success: false, error: 'Rate limited — try again later', rateLimited: true, retryAfterSeconds };
+    }
     if (!res.ok) return { success: false, error: `HTTP ${res.status}` };
     return { success: true };
   } catch (err) {

--- a/src/trmnl.test.js
+++ b/src/trmnl.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { pushToTrmnl } from './trmnl.js';
+
+const cfg = { webhookUrl: 'https://usetrmnl.com/api/custom_plugins/abc' };
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe('pushToTrmnl', () => {
+  it('reports a 429 as rate limited and carries Retry-After in seconds', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ status: 429, ok: false, headers: { get: (h) => (h === 'Retry-After' ? '900' : null) } })));
+    const r = await pushToTrmnl(cfg, { a: 1 });
+    expect(r).toMatchObject({ success: false, rateLimited: true, retryAfterSeconds: 900 });
+  });
+
+  it('a 429 without Retry-After still backs off (null hint)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ status: 429, ok: false, headers: { get: () => null } })));
+    const r = await pushToTrmnl(cfg, { a: 1 });
+    expect(r).toMatchObject({ success: false, rateLimited: true, retryAfterSeconds: null });
+  });
+
+  it('posts the merge variables and reports success', async () => {
+    const fetchMock = vi.fn(async () => ({ status: 200, ok: true, headers: { get: () => null } }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await pushToTrmnl({ ...cfg, apiKey: 'k' }, { a: 1 });
+    expect(r).toEqual({ success: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(cfg.webhookUrl);
+    expect(JSON.parse(init.body)).toEqual({ merge_variables: { a: 1 } });
+    expect(init.headers.Authorization).toBe('Bearer k');
+  });
+});

--- a/src/utils/deviceSettings.js
+++ b/src/utils/deviceSettings.js
@@ -90,6 +90,7 @@ const EXCLUDED_KEYS = new Set([
   'day-planner-obsidian-last-scanned',
   'day-planner-obsidian-last-synced',
   'day-planner-trmnl-last-synced',
+  'day-planner-trmnl-push-state',
   'day-planner-steps-cache',
 ]);
 

--- a/src/utils/trmnlPushPolicy.js
+++ b/src/utils/trmnlPushPolicy.js
@@ -1,0 +1,90 @@
+// When the TRMNL auto-sync may push, and how it backs off. Pure, so the
+// rules are tested where they live.
+//
+// Field incident, 2026-09-08: the device had not updated since August 30.
+// Every push was answered 429. The auto-sync was keyed on array identity, and
+// the sync engine hands out new arrays on nearly every cycle, so the push ran
+// at the throttle's cadence around the clock whether or not anything on the
+// screen had changed; the payload carried the clock, so no two pushes were
+// ever equal; and the backoff lived in memory, so every launch started again
+// at full speed. The webhook limit is per plugin, shared by every pusher.
+//
+// Rules:
+//   - push when the CONTENT changed: the payload minus its clock-driven
+//     fields (the time of day, and the overdue/upcoming/next/past marks that
+//     move as the day goes on without anyone touching anything);
+//   - never two pushes closer than TRMNL_MIN_GAP_MS;
+//   - unchanged content is refreshed no more than every TRMNL_TIME_REFRESH_MS,
+//     which is how often the display redraws anyway, so the clock marks stay
+//     roughly right;
+//   - a 429 backs off exponentially from 5 min, capped at 60, and never
+//     shorter than the server's Retry-After; the backoff and the last push
+//     time are persisted so a relaunch resumes the wait instead of resetting it.
+
+export const TRMNL_MIN_GAP_MS = 5 * 60 * 1000;
+export const TRMNL_TIME_REFRESH_MS = 15 * 60 * 1000;
+export const TRMNL_BACKOFF_BASE_MS = 5 * 60 * 1000;
+export const TRMNL_BACKOFF_MAX_MS = 60 * 60 * 1000;
+export const TRMNL_PUSH_STATE_KEY = 'day-planner-trmnl-push-state';
+
+const CLOCK_FIELDS = new Set(['current_time', 'overdue', 'upcoming', 'next_task']);
+
+/** The payload with every clock-driven field removed, as a comparable string. */
+export function trmnlContentFingerprint(mergeVars) {
+  const out = {};
+  for (const [k, v] of Object.entries(mergeVars || {})) {
+    if (CLOCK_FIELDS.has(k)) continue;
+    out[k] = k === 'schedule' && Array.isArray(v)
+      ? v.map((row) => { const { past: _past, ...rest } = row || {}; return rest; })
+      : v;
+  }
+  return JSON.stringify(out);
+}
+
+/**
+ * @returns {{ push: boolean, reason: string, waitMs?: number }}
+ *   push=false carries waitMs: how long until this decision could change on
+ *   its own (the floor or the refresh interval expiring, or the backoff ending).
+ */
+export function trmnlPushDecision({ now, fingerprint, lastFingerprint, lastPushAt = 0, backoffUntil = 0, manual = false }) {
+  if (manual) return { push: true, reason: 'manual' };
+  if (backoffUntil > now) return { push: false, reason: 'backoff', waitMs: backoffUntil - now };
+  const since = now - (lastPushAt || 0);
+  if (fingerprint !== lastFingerprint) {
+    if (since >= TRMNL_MIN_GAP_MS) return { push: true, reason: 'changed' };
+    return { push: false, reason: 'floor', waitMs: TRMNL_MIN_GAP_MS - since };
+  }
+  if (since >= TRMNL_TIME_REFRESH_MS) return { push: true, reason: 'time-refresh' };
+  return { push: false, reason: 'unchanged', waitMs: TRMNL_TIME_REFRESH_MS - since };
+}
+
+/** The backoff after a 429: exponential from the base, capped, never shorter than Retry-After. */
+export function trmnlBackoffAfterRateLimit({ now, count = 0, retryAfterSeconds = null }) {
+  const next = (count || 0) + 1;
+  const exponential = Math.min(TRMNL_BACKOFF_BASE_MS * 2 ** (next - 1), TRMNL_BACKOFF_MAX_MS);
+  const hinted = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0 ? retryAfterSeconds * 1000 : 0;
+  return { count: next, until: now + Math.max(exponential, hinted) };
+}
+
+/** Parse a Retry-After header (delay-seconds or an HTTP date) into seconds, or null. */
+export function parseRetryAfter(value, now = Date.now()) {
+  if (value == null || value === '') return null;
+  const s = String(value).trim();
+  if (/^\d+$/.test(s)) return Number(s);
+  const at = Date.parse(s);
+  return Number.isNaN(at) ? null : Math.max(0, Math.ceil((at - now) / 1000));
+}
+
+const EMPTY = { lastPushAt: 0, backoffUntil: 0, backoffCount: 0, lastFingerprint: null };
+
+export function readTrmnlPushState(storage = globalThis.localStorage) {
+  try {
+    const raw = storage?.getItem(TRMNL_PUSH_STATE_KEY);
+    const v = raw ? JSON.parse(raw) : null;
+    return v && typeof v === 'object' ? { ...EMPTY, ...v } : { ...EMPTY };
+  } catch { return { ...EMPTY }; }
+}
+
+export function writeTrmnlPushState(state, storage = globalThis.localStorage) {
+  try { storage?.setItem(TRMNL_PUSH_STATE_KEY, JSON.stringify({ ...EMPTY, ...state })); } catch { /* storage unavailable */ }
+}

--- a/src/utils/trmnlPushPolicy.test.js
+++ b/src/utils/trmnlPushPolicy.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  trmnlContentFingerprint, trmnlPushDecision, trmnlBackoffAfterRateLimit, parseRetryAfter,
+  readTrmnlPushState, writeTrmnlPushState,
+  TRMNL_MIN_GAP_MS, TRMNL_TIME_REFRESH_MS, TRMNL_BACKOFF_MAX_MS,
+} from './trmnlPushPolicy.js';
+
+const payload = (over = {}) => ({
+  date: '2026-09-08', day_name: 'Tuesday', current_time: '1:51 PM', weather: '',
+  schedule: [{ time: '9:00 AM', dur: '30m', title: 'Standup', done: true, pri: '', allDay: false, past: true }],
+  total: 1, completed: 1, overdue: 0, pct: 100, time_planned: '30m',
+  upcoming: [], next_task: null, inbox_count: 4, habits: [], routines: [], note: '',
+  ...over,
+});
+
+describe('trmnlContentFingerprint', () => {
+  it('ignores the clock: time of day, overdue, upcoming, next task, and the past marks', () => {
+    const a = trmnlContentFingerprint(payload());
+    const b = trmnlContentFingerprint(payload({
+      current_time: '1:52 PM', overdue: 1, upcoming: [{ time: '3:00 PM', title: 'x' }], next_task: { time: '3:00 PM', title: 'x' },
+      schedule: [{ ...payload().schedule[0], past: false }],
+    }));
+    expect(a).toBe(b);
+  });
+
+  it('changes when the content changes', () => {
+    expect(trmnlContentFingerprint(payload({ inbox_count: 5 }))).not.toBe(trmnlContentFingerprint(payload()));
+    expect(trmnlContentFingerprint(payload({ schedule: [{ ...payload().schedule[0], done: false }] }))).not.toBe(trmnlContentFingerprint(payload()));
+  });
+});
+
+describe('trmnlPushDecision', () => {
+  const now = 1_000_000_000_000;
+  it('THE INCIDENT: unchanged content within the refresh window is not pushed', () => {
+    const d = trmnlPushDecision({ now, fingerprint: 'f', lastFingerprint: 'f', lastPushAt: now - 60_000 });
+    expect(d.push).toBe(false);
+    expect(d.reason).toBe('unchanged');
+    expect(d.waitMs).toBe(TRMNL_TIME_REFRESH_MS - 60_000);
+  });
+
+  it('changed content pushes once the floor has passed, and waits for it otherwise', () => {
+    expect(trmnlPushDecision({ now, fingerprint: 'g', lastFingerprint: 'f', lastPushAt: now - TRMNL_MIN_GAP_MS })).toMatchObject({ push: true, reason: 'changed' });
+    const d = trmnlPushDecision({ now, fingerprint: 'g', lastFingerprint: 'f', lastPushAt: now - 1000 });
+    expect(d).toMatchObject({ push: false, reason: 'floor', waitMs: TRMNL_MIN_GAP_MS - 1000 });
+  });
+
+  it('unchanged content is refreshed after the refresh window', () => {
+    expect(trmnlPushDecision({ now, fingerprint: 'f', lastFingerprint: 'f', lastPushAt: now - TRMNL_TIME_REFRESH_MS })).toMatchObject({ push: true, reason: 'time-refresh' });
+  });
+
+  it('a backoff in force blocks everything automatic until it ends', () => {
+    const d = trmnlPushDecision({ now, fingerprint: 'g', lastFingerprint: 'f', lastPushAt: 0, backoffUntil: now + 5000 });
+    expect(d).toMatchObject({ push: false, reason: 'backoff', waitMs: 5000 });
+  });
+
+  it('a manual sync always pushes', () => {
+    expect(trmnlPushDecision({ now, fingerprint: 'f', lastFingerprint: 'f', lastPushAt: now, backoffUntil: now + 5000, manual: true })).toMatchObject({ push: true, reason: 'manual' });
+  });
+
+  it('a first run (no fingerprint yet) pushes', () => {
+    expect(trmnlPushDecision({ now, fingerprint: 'f', lastFingerprint: null, lastPushAt: 0 })).toMatchObject({ push: true, reason: 'changed' });
+  });
+});
+
+describe('trmnlBackoffAfterRateLimit', () => {
+  const now = 1_000_000_000_000;
+  it('doubles from 5 minutes and caps at 60', () => {
+    let s = { count: 0 };
+    const mins = [];
+    for (let i = 0; i < 6; i++) { s = trmnlBackoffAfterRateLimit({ now, count: s.count }); mins.push((s.until - now) / 60000); }
+    expect(mins).toEqual([5, 10, 20, 40, 60, 60]);
+    expect(s.until - now).toBe(TRMNL_BACKOFF_MAX_MS);
+  });
+
+  it('never waits less than Retry-After', () => {
+    const s = trmnlBackoffAfterRateLimit({ now, count: 0, retryAfterSeconds: 900 });
+    expect(s.until - now).toBe(900_000);
+    const t = trmnlBackoffAfterRateLimit({ now, count: 0, retryAfterSeconds: 30 });
+    expect(t.until - now).toBe(5 * 60_000);
+  });
+});
+
+describe('parseRetryAfter', () => {
+  it('reads delay-seconds and HTTP dates, and rejects junk', () => {
+    const now = Date.parse('2026-09-08T20:00:00Z');
+    expect(parseRetryAfter('120')).toBe(120);
+    expect(parseRetryAfter('Tue, 08 Sep 2026 20:10:00 GMT', now)).toBe(600);
+    expect(parseRetryAfter('soon')).toBeNull();
+    expect(parseRetryAfter(null)).toBeNull();
+  });
+});
+
+describe('push state persistence', () => {
+  it('round-trips and defaults on absence or junk', () => {
+    const store = new Map();
+    const storage = { getItem: (k) => store.get(k) ?? null, setItem: (k, v) => store.set(k, v) };
+    expect(readTrmnlPushState(storage)).toEqual({ lastPushAt: 0, backoffUntil: 0, backoffCount: 0, lastFingerprint: null });
+    writeTrmnlPushState({ lastPushAt: 5, backoffUntil: 9, backoffCount: 2, lastFingerprint: 'f' }, storage);
+    expect(readTrmnlPushState(storage)).toEqual({ lastPushAt: 5, backoffUntil: 9, backoffCount: 2, lastFingerprint: 'f' });
+    store.set('day-planner-trmnl-push-state', '{oops');
+    expect(readTrmnlPushState(storage).lastPushAt).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

The TRMNL device had not updated since August 30. Every push from the one configured device was answered 429, because the app was pushing far more often than any webhook allowance:

- **Pushes were keyed on array identity, not content.** The sync engine hands out new task, inbox and habit-log arrays on nearly every cycle, so the 10 s debounce expired almost continuously and the 2 min throttle became the cadence, around the clock, whether or not anything on the screen had changed.
- **The payload carried the clock**, so no two pushes were ever equal even when nothing else moved.
- **The backoff lived in memory.** Every launch reset it and pushed 10 s after data loaded; it also reset on any success, so one lucky push restarted the 2 min cadence.

## Changes

`src/utils/trmnlPushPolicy.js`, pure and tested:

- **Content fingerprint**: the payload with the clock-driven fields removed (time of day, overdue, upcoming, next task, and the per-row past marks). Only a change in that fingerprint counts as new content.
- **Push decision**: changed content pushes once a 5 min floor has passed; unchanged content is refreshed no more than every 15 min, which is how often the display redraws anyway, so the clock marks stay roughly right; nothing automatic pushes during a backoff; a manual sync always pushes.
- **Backoff**: doubles from 5 min, capped at 60, and never shorter than the server's Retry-After.
- **Persisted push state** (last push time, backoff, last fingerprint), so a relaunch resumes the wait. Listed as volatile in the device-settings backup.

Wiring: `pushToTrmnl` surfaces Retry-After on a 429. The auto-sync in `App.jsx` offers the policy a push on a debounced data change and on a minute tick; the policy decides inside `performTrmnlSync`. The hook seeds its refs from the persisted state. Settings gain a line under the webhook field saying the limit is shared by the whole plugin, so TRMNL belongs on one device that is usually running (all eight locales).

Not done, per review: no cap on the schedule. The display shows the whole agenda.

## Expected effect on the Mac

Roughly one push per real change, at most twelve an hour, plus a refresh every 15 min when nothing changed. The first push after this build lands will still meet whatever backoff TRMNL has in force; after that the device should update within its own refresh interval.

## Tests

- `src/utils/trmnlPushPolicy.test.js`: the fingerprint ignores the clock and tracks content; the incident case (unchanged content not pushed); floor, refresh, backoff, manual, first run; the backoff ladder and Retry-After; header parsing; persistence round-trip. 12/12.
- `src/trmnl.test.js`: a 429 carries Retry-After in seconds, or null without one; a successful post sends the merge variables and the bearer token. 3/3.
- Locale parity suites pass with the new key in all eight bundles; lint and whitespace clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_